### PR TITLE
Add client harness configuration UX

### DIFF
--- a/dev/gitea/seed/demo/.shipfox/workflows/agent-claude.yml
+++ b/dev/gitea/seed/demo/.shipfox/workflows/agent-claude.yml
@@ -13,5 +13,5 @@ jobs:
     steps:
       - harness: claude
         provider: anthropic
-        model: claude-opus-4-8
+        model: claude-haiku-4-5
         prompt: Say hello from Claude

--- a/dev/gitea/seed/demo/.shipfox/workflows/agent-claude.yml
+++ b/dev/gitea/seed/demo/.shipfox/workflows/agent-claude.yml
@@ -1,4 +1,4 @@
-name: Agent
+name: Agent Claude
 runner: ubuntu-latest
 triggers:
   on_demand:
@@ -11,6 +11,7 @@ triggers:
 jobs:
   greet:
     steps:
-      - provider: openrouter
-        model: meta-llama/llama-3.1-8b-instruct
-        prompt: Say hello
+      - harness: claude
+        provider: anthropic
+        model: claude-opus-4-8
+        prompt: Say hello from Claude

--- a/dev/gitea/seed/demo/.shipfox/workflows/agent-pi.yml
+++ b/dev/gitea/seed/demo/.shipfox/workflows/agent-pi.yml
@@ -1,0 +1,17 @@
+name: Agent pi
+runner: ubuntu-latest
+triggers:
+  on_demand:
+    source: manual
+    event: fire
+  on_push:
+    source: gitea
+    event: push
+    filter: 'event.ref == "refs/heads/main"'
+jobs:
+  greet:
+    steps:
+      - harness: pi
+        provider: openrouter
+        model: meta-llama/llama-3.1-8b-instruct
+        prompt: Say hello from pi

--- a/dev/gitea/seed/demo/.shipfox/workflows/agent-repair-loop.yaml
+++ b/dev/gitea/seed/demo/.shipfox/workflows/agent-repair-loop.yaml
@@ -39,7 +39,7 @@ jobs:
         name: Run checkout regression gate
         run: node scripts/demo-step.mjs repair test-gate
         gate:
-          success_if: step.exit_code == 0
+          success: step.exit_code == 0
           on_failure:
             restart_from: implement
             feedback: Checkout regression gate failed. Sending failure context back to the agent.

--- a/dev/gitea/seed/demo/.shipfox/workflows/gates.yml
+++ b/dev/gitea/seed/demo/.shipfox/workflows/gates.yml
@@ -25,10 +25,10 @@ jobs:
           fi
           echo "First gate passed"
         gate:
-          success_if: step.exit_code == 0
+          success: step.exit_code == 0
           on_failure:
             restart_from: first-setup
-            output: First gate failed once; retrying from first setup.
+            feedback: First gate failed once; retrying from first setup.
       - key: second-setup
         name: Second setup
         run: mkdir -p .shipfox/demo-gates
@@ -43,10 +43,10 @@ jobs:
           fi
           echo "Second gate passed"
         gate:
-          success_if: step.exit_code == 0
+          success: step.exit_code == 0
           on_failure:
             restart_from: second-setup
-            output: Second gate failed once; retrying from second setup.
+            feedback: Second gate failed once; retrying from second setup.
       - key: third-gate
         name: Third gate
         run: |
@@ -63,10 +63,10 @@ jobs:
           fi
           echo "Third gate passed on attempt $attempts"
         gate:
-          success_if: step.exit_code == 0
+          success: step.exit_code == 0
           on_failure:
             restart_from: second-setup
-            output: Third gate failed; retrying from second setup.
+            feedback: Third gate failed; retrying from second setup.
       - key: finish
         name: Finish
         run: echo "All three gates passed; job succeeded"

--- a/e2e/kit/src/ui/page-objects.test.ts
+++ b/e2e/kit/src/ui/page-objects.test.ts
@@ -9,7 +9,7 @@ type SettingsTab =
   | 'members'
   | 'runners'
   | 'provisioners'
-  | 'model-providers'
+  | 'agents'
   | 'secrets'
   | 'variables'
   | 'integrations'
@@ -19,7 +19,7 @@ const settingsTabLabels: Record<SettingsTab, string> = {
   members: 'Members',
   runners: 'Runners',
   provisioners: 'Runner provisioners',
-  'model-providers': 'Model providers',
+  agents: 'Agents',
   secrets: 'Secrets',
   variables: 'Variables',
   integrations: 'Integrations',

--- a/e2e/kit/src/ui/page-objects.test.ts
+++ b/e2e/kit/src/ui/page-objects.test.ts
@@ -114,7 +114,7 @@ describe('ui page objects', () => {
 
     expect(pageObject.getByRole).toHaveBeenCalledWith('heading', {name: 'Install source control'});
     expect(pageObject.getByRole).toHaveBeenCalledWith('heading', {
-      name: 'Configure model provider',
+      name: 'Choose agent harness',
     });
     expect(pageObject.getByRole).toHaveBeenCalledWith('tab', {name: 'Projects'});
     expect(pageObject.getByRole).toHaveBeenCalledWith('tab', {name: 'Settings'});

--- a/e2e/kit/src/ui/page-objects.test.ts
+++ b/e2e/kit/src/ui/page-objects.test.ts
@@ -106,7 +106,7 @@ describe('ui page objects', () => {
     const setup = new SetupShell(pageObject as never);
 
     setup.sourceControlHeading();
-    setup.modelProviderHeading();
+    setup.agentHarnessHeading();
     setup.projectTab();
     setup.settingsTab();
     setup.projectSwitcher();

--- a/e2e/kit/src/ui/page-objects.ts
+++ b/e2e/kit/src/ui/page-objects.ts
@@ -109,7 +109,7 @@ export class SetupShell {
   }
 
   modelProviderHeading(): AppLocator {
-    return this.page.getByRole('heading', {name: 'Configure model provider'});
+    return this.page.getByRole('heading', {name: 'Choose agent harness'});
   }
 
   projectTab(): AppLocator {

--- a/e2e/kit/src/ui/page-objects.ts
+++ b/e2e/kit/src/ui/page-objects.ts
@@ -108,7 +108,7 @@ export class SetupShell {
     return this.page.getByRole('heading', {name: 'Install source control'});
   }
 
-  modelProviderHeading(): AppLocator {
+  agentHarnessHeading(): AppLocator {
     return this.page.getByRole('heading', {name: 'Choose agent harness'});
   }
 

--- a/e2e/kit/src/ui/page-objects.ts
+++ b/e2e/kit/src/ui/page-objects.ts
@@ -6,7 +6,7 @@ export type SettingsTab =
   | 'members'
   | 'runners'
   | 'provisioners'
-  | 'model-providers'
+  | 'agents'
   | 'secrets'
   | 'variables'
   | 'integrations'
@@ -16,7 +16,7 @@ export const SETTINGS_TAB_LABELS: Record<SettingsTab, string> = {
   members: 'Members',
   runners: 'Runners',
   provisioners: 'Runner provisioners',
-  'model-providers': 'Model providers',
+  agents: 'Agents',
   secrets: 'Secrets',
   variables: 'Variables',
   integrations: 'Integrations',

--- a/e2e/screens/agent/src/index.ts
+++ b/e2e/screens/agent/src/index.ts
@@ -14,7 +14,7 @@ export class CustomModelProviderScreen {
   }
 
   async goto(workspaceId: string): Promise<void> {
-    await this.shell.goto(workspaceId, 'model-providers');
+    await this.shell.goto(workspaceId, 'agents');
   }
 
   configuredProvidersSection(): Locator {

--- a/e2e/screens/integrations/src/index.ts
+++ b/e2e/screens/integrations/src/index.ts
@@ -59,7 +59,7 @@ export class SourceControlSetupScreen {
     return this.page.getByRole('heading', {name: 'Install source control'});
   }
 
-  modelProviderHeading(): Locator {
+  agentHarnessHeading(): Locator {
     return this.page.getByRole('heading', {name: 'Choose agent harness'});
   }
 

--- a/e2e/screens/integrations/src/index.ts
+++ b/e2e/screens/integrations/src/index.ts
@@ -60,7 +60,7 @@ export class SourceControlSetupScreen {
   }
 
   modelProviderHeading(): Locator {
-    return this.page.getByRole('heading', {name: 'Configure model provider'});
+    return this.page.getByRole('heading', {name: 'Choose agent harness'});
   }
 
   providerLink(workspaceId: string, provider: string): Locator {

--- a/e2e/suites/client/integrations/tests/integration-flows.e2e.ts
+++ b/e2e/suites/client/integrations/tests/integration-flows.e2e.ts
@@ -40,7 +40,7 @@ test('connecting Gitea from source-control setup opens model-provider setup', as
   await expect(page).not.toHaveURL(GITEA_INSTALL_URL_RE);
   await expect(page).not.toHaveURL(WORKSPACE_INTEGRATIONS_URL_RE);
   await expect(page).toHaveURL(modelProviderUrlRe(workspace.id));
-  await expect(sourceControlSetup.modelProviderHeading()).toBeVisible();
+  await expect(sourceControlSetup.agentHarnessHeading()).toBeVisible();
   await expect(sourceControlSetup.projectTab()).toHaveCount(0);
   await expect(sourceControlSetup.settingsTab()).toHaveCount(0);
   await expect(sourceControlSetup.projectSwitcher()).toHaveCount(0);

--- a/libs/api/agent-dto/src/schemas/harness.ts
+++ b/libs/api/agent-dto/src/schemas/harness.ts
@@ -4,6 +4,7 @@ import {type ModelProviderRef, SUPPORTED_MODEL_PROVIDER_IDS} from './model-provi
 export interface HarnessDescriptor {
   readonly id: Harness;
   readonly label: string;
+  readonly description: string;
   readonly supportedProviderIds: readonly string[];
   readonly thinkingLevels: readonly AgentThinking[];
   readonly defaultThinking: AgentThinking;
@@ -13,6 +14,7 @@ export interface HarnessDescriptor {
 export const PI_HARNESS: HarnessDescriptor = {
   id: 'pi',
   label: 'pi',
+  description: 'Works with 30+ model providers',
   supportedProviderIds: SUPPORTED_MODEL_PROVIDER_IDS,
   thinkingLevels: agentThinkingByHarness.pi.options,
   defaultThinking: 'xhigh',
@@ -22,6 +24,7 @@ export const PI_HARNESS: HarnessDescriptor = {
 export const CLAUDE_HARNESS: HarnessDescriptor = {
   id: 'claude',
   label: 'Claude',
+  description: 'Runs on your Anthropic API key',
   supportedProviderIds: ['anthropic'],
   thinkingLevels: agentThinkingByHarness.claude.options,
   defaultThinking: 'xhigh',

--- a/libs/api/agent/src/core/harness/registry.test.ts
+++ b/libs/api/agent/src/core/harness/registry.test.ts
@@ -48,6 +48,7 @@ describe('harness registry', () => {
     expect(getHarnessDescriptor('pi')).toEqual({
       id: 'pi',
       label: 'pi',
+      description: 'Works with 30+ model providers',
       supportedProviderIds: expect.arrayContaining(['anthropic', 'openai']),
       thinkingLevels: piAgentThinkingSchema.options,
       defaultThinking: 'xhigh',
@@ -56,6 +57,7 @@ describe('harness registry', () => {
     expect(getHarnessDescriptor('claude')).toEqual({
       id: 'claude',
       label: 'Claude',
+      description: 'Runs on your Anthropic API key',
       supportedProviderIds: ['anthropic'],
       thinkingLevels: claudeAgentThinkingSchema.options,
       defaultThinking: 'xhigh',

--- a/libs/client/agent/src/components/agent-workflow-example.test.ts
+++ b/libs/client/agent/src/components/agent-workflow-example.test.ts
@@ -5,56 +5,70 @@ import {buildAgentWorkflowExample} from './agent-workflow-example.js';
 describe('buildAgentWorkflowExample', () => {
   it.each([
     {
+      harness: 'pi',
       providerId: 'anthropic',
       model: 'claude-opus-4-8',
+      expectedHarness: '        harness: pi',
       expectedProvider: '        provider: anthropic',
       expectedModel: '        model: claude-opus-4-8',
     },
     {
+      harness: 'claude',
       providerId: 'anthropic',
       model: 'anthropic/claude-opus-4.8',
+      expectedHarness: '        harness: claude',
       expectedProvider: '        provider: anthropic',
       expectedModel: '        model: anthropic/claude-opus-4.8',
     },
     {
+      harness: 'pi',
       providerId: 'anthropic',
       model: '@cf/moonshotai/kimi-k2.7-code',
+      expectedHarness: '        harness: pi',
       expectedProvider: '        provider: anthropic',
       expectedModel: "        model: '@cf/moonshotai/kimi-k2.7-code'",
     },
     {
+      harness: 'pi',
       providerId: 'provider#beta',
       model: "model: beta's",
+      expectedHarness: '        harness: pi',
       expectedProvider: "        provider: 'provider#beta'",
       expectedModel: "        model: 'model: beta''s'",
     },
     {
+      harness: 'pi',
       providerId: 'true',
       model: '123',
+      expectedHarness: '        harness: pi',
       expectedProvider: "        provider: 'true'",
       expectedModel: "        model: '123'",
     },
   ])('builds valid workflow YAML for provider $providerId and model $model', ({
+    harness,
     providerId,
     model,
+    expectedHarness,
     expectedProvider,
     expectedModel,
   }) => {
-    const example = buildAgentWorkflowExample({providerId, model});
+    const example = buildAgentWorkflowExample({harness, providerId, model});
 
     const lines = example.code.split('\n');
     const parsed = parse(example.code);
     const parsedStep = parsed as {
-      jobs: {agent: {steps: Array<{provider?: unknown; model?: unknown}>}};
+      jobs: {agent: {steps: Array<{harness?: unknown; provider?: unknown; model?: unknown}>}};
     };
     const result = workflowDocumentSchema.safeParse(parsed);
 
     expect(result.success).toBe(true);
+    expect(parsedStep.jobs.agent.steps[0]?.harness).toBe(harness);
     expect(parsedStep.jobs.agent.steps[0]?.provider).toBe(providerId);
     expect(parsedStep.jobs.agent.steps[0]?.model).toBe(model);
+    expect(lines).toContain(expectedHarness);
     expect(lines).toContain(expectedProvider);
     expect(lines).toContain(expectedModel);
-    expect(example.highlightedLineRange).toEqual({startLine: 11, endLine: 12});
-    expect(lines.slice(10, 12)).toEqual([expectedProvider, expectedModel]);
+    expect(example.highlightedLineRange).toEqual({startLine: 11, endLine: 13});
+    expect(lines.slice(10, 13)).toEqual([expectedHarness, expectedProvider, expectedModel]);
   });
 });

--- a/libs/client/agent/src/components/agent-workflow-example.ts
+++ b/libs/client/agent/src/components/agent-workflow-example.ts
@@ -9,9 +9,11 @@ export interface AgentWorkflowExample {
 }
 
 export function buildAgentWorkflowExample({
+  harness,
   providerId,
   model,
 }: {
+  harness: string;
   providerId: string;
   model: string;
 }): AgentWorkflowExample {
@@ -26,17 +28,18 @@ export function buildAgentWorkflowExample({
     '    runner: ubuntu-latest',
     '    steps:',
     '      - name: implement',
+    `        harness: ${formatYamlPlainOrSingleQuotedScalar(harness)}`,
     `        provider: ${formatYamlPlainOrSingleQuotedScalar(providerId)}`,
     `        model: ${formatYamlPlainOrSingleQuotedScalar(model)}`,
     '        prompt: Describe the change you want the agent to make.',
   ];
-  const providerLineIndex = lines.findIndex((line) => line.trimStart().startsWith('provider:'));
+  const harnessLineIndex = lines.findIndex((line) => line.trimStart().startsWith('harness:'));
   const modelLineIndex = lines.findIndex((line) => line.trimStart().startsWith('model:'));
 
   return {
     code: lines.join('\n'),
     highlightedLineRange: {
-      startLine: providerLineIndex + 1,
+      startLine: harnessLineIndex + 1,
       endLine: modelLineIndex + 1,
     },
   };

--- a/libs/client/agent/src/components/harness-availability.test.ts
+++ b/libs/client/agent/src/components/harness-availability.test.ts
@@ -1,0 +1,45 @@
+import {getHarnessDescriptor} from '@shipfox/api-agent-dto';
+import {customModelProviderConfig, modelProviderConfig} from '#test/fixtures/model-providers.js';
+import {compatibleHarnessIds, isHarnessAvailable} from './harness-availability.js';
+
+describe('harness availability', () => {
+  test('marks pi available with any builtin provider config', () => {
+    const result = isHarnessAvailable(getHarnessDescriptor('pi'), [
+      modelProviderConfig({provider_id: 'openai'}),
+    ]);
+
+    expect(result).toBe(true);
+  });
+
+  test('marks pi available with only a custom provider config', () => {
+    const result = isHarnessAvailable(getHarnessDescriptor('pi'), [customModelProviderConfig()]);
+
+    expect(result).toBe(true);
+  });
+
+  test('marks claude available only when Anthropic is configured', () => {
+    const openai = isHarnessAvailable(getHarnessDescriptor('claude'), [
+      modelProviderConfig({provider_id: 'openai'}),
+    ]);
+    const anthropic = isHarnessAvailable(getHarnessDescriptor('claude'), [
+      modelProviderConfig({provider_id: 'anthropic'}),
+    ]);
+
+    expect(openai).toBe(false);
+    expect(anthropic).toBe(true);
+  });
+
+  test('marks both harnesses unavailable when no providers are configured', () => {
+    expect(isHarnessAvailable(getHarnessDescriptor('pi'), [])).toBe(false);
+    expect(isHarnessAvailable(getHarnessDescriptor('claude'), [])).toBe(false);
+  });
+
+  test('returns compatible harnesses for builtin and custom providers', () => {
+    expect(compatibleHarnessIds({isCustom: false, providerId: 'anthropic'})).toEqual([
+      'pi',
+      'claude',
+    ]);
+    expect(compatibleHarnessIds({isCustom: false, providerId: 'openai'})).toEqual(['pi']);
+    expect(compatibleHarnessIds({isCustom: true, providerId: 'custom-provider'})).toEqual(['pi']);
+  });
+});

--- a/libs/client/agent/src/components/harness-availability.ts
+++ b/libs/client/agent/src/components/harness-availability.ts
@@ -1,0 +1,34 @@
+import {
+  type Harness,
+  type HarnessDescriptor,
+  listHarnessDescriptors,
+  type ModelProviderConfigResponseDto,
+} from '@shipfox/api-agent-dto';
+
+export function configSupportsHarness(
+  config: ModelProviderConfigResponseDto,
+  descriptor: HarnessDescriptor,
+): boolean {
+  if (config.kind === 'custom') return descriptor.id === 'pi';
+  return descriptor.supportedProviderIds.includes(config.provider_id);
+}
+
+export function isHarnessAvailable(
+  descriptor: HarnessDescriptor,
+  configs: ModelProviderConfigResponseDto[],
+): boolean {
+  return configs.some((config) => configSupportsHarness(config, descriptor));
+}
+
+export function compatibleHarnessIds({
+  isCustom,
+  providerId,
+}: {
+  isCustom: boolean;
+  providerId: string;
+}): Harness[] {
+  if (isCustom) return ['pi'];
+  return listHarnessDescriptors()
+    .filter((descriptor) => descriptor.supportedProviderIds.includes(providerId))
+    .map((descriptor) => descriptor.id);
+}

--- a/libs/client/agent/src/components/harness-availability.ts
+++ b/libs/client/agent/src/components/harness-availability.ts
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_HARNESS,
   type Harness,
   type HarnessDescriptor,
   listHarnessDescriptors,
@@ -9,7 +10,7 @@ export function configSupportsHarness(
   config: ModelProviderConfigResponseDto,
   descriptor: HarnessDescriptor,
 ): boolean {
-  if (config.kind === 'custom') return descriptor.id === 'pi';
+  if (config.kind === 'custom') return descriptor.id === DEFAULT_HARNESS;
   return descriptor.supportedProviderIds.includes(config.provider_id);
 }
 
@@ -27,7 +28,7 @@ export function compatibleHarnessIds({
   isCustom: boolean;
   providerId: string;
 }): Harness[] {
-  if (isCustom) return ['pi'];
+  if (isCustom) return [DEFAULT_HARNESS];
   return listHarnessDescriptors()
     .filter((descriptor) => descriptor.supportedProviderIds.includes(providerId))
     .map((descriptor) => descriptor.id);

--- a/libs/client/agent/src/components/harnesses-section.stories.tsx
+++ b/libs/client/agent/src/components/harnesses-section.stories.tsx
@@ -1,0 +1,129 @@
+import type {ModelProviderConfigDto} from '@shipfox/api-agent-dto';
+import {configureApiClient} from '@shipfox/client-api';
+import {Toaster} from '@shipfox/react-ui/toast';
+import type {Meta, StoryObj} from '@storybook/react';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {useMemo} from 'react';
+import {WorkspaceHarnessesSection} from './harnesses-section.js';
+
+const WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
+
+type Scenario =
+  | 'default-pi'
+  | 'default-claude'
+  | 'claude-unavailable'
+  | 'default-claude-unavailable'
+  | 'loading'
+  | 'error';
+
+interface HarnessesStoryProps {
+  scenario: Scenario;
+}
+
+function HarnessesStory({scenario}: HarnessesStoryProps) {
+  configureApiClient({
+    baseUrl: 'https://api.example.test',
+    fetchImpl: fetchForScenario(scenario),
+  });
+
+  const queryClient = useMemo(
+    () => new QueryClient({defaultOptions: {queries: {retry: false}}}),
+    [],
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <div className="mx-auto w-full max-w-[760px] bg-background-neutral-background p-24">
+        <WorkspaceHarnessesSection workspaceId={WORKSPACE_ID} />
+      </div>
+      <Toaster />
+    </QueryClientProvider>
+  );
+}
+
+const meta = {
+  title: 'Agent/HarnessSettings',
+  component: HarnessesStory,
+  parameters: {layout: 'fullscreen'},
+  args: {scenario: 'default-pi'},
+} satisfies Meta<typeof HarnessesStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const DefaultClaude: Story = {
+  args: {scenario: 'default-claude'},
+};
+
+export const ClaudeUnavailable: Story = {
+  args: {scenario: 'claude-unavailable'},
+};
+
+export const DefaultClaudeUnavailable: Story = {
+  args: {scenario: 'default-claude-unavailable'},
+};
+
+export const Loading: Story = {
+  args: {scenario: 'loading'},
+};
+
+export const ErrorState: Story = {
+  args: {scenario: 'error'},
+};
+
+function fetchForScenario(scenario: Scenario): typeof fetch {
+  return () => {
+    if (scenario === 'loading') return new Promise<Response>(() => undefined);
+    if (scenario === 'error') return Promise.resolve(errorResponse());
+    return Promise.resolve(jsonResponse(configsForScenario(scenario)));
+  };
+}
+
+function configsForScenario(scenario: Scenario) {
+  if (scenario === 'claude-unavailable') {
+    return {
+      configs: [providerConfig({provider_id: 'openai'})],
+      default_provider_id: 'openai',
+      default_harness_id: null,
+    };
+  }
+  if (scenario === 'default-claude-unavailable') {
+    return {
+      configs: [providerConfig({provider_id: 'openai'})],
+      default_provider_id: 'openai',
+      default_harness_id: 'claude',
+    };
+  }
+  return {
+    configs: [providerConfig({provider_id: 'anthropic'})],
+    default_provider_id: 'anthropic',
+    default_harness_id: scenario === 'default-claude' ? 'claude' : null,
+  };
+}
+
+function providerConfig(
+  overrides: Partial<Omit<ModelProviderConfigDto, 'kind'>> = {},
+): ModelProviderConfigDto {
+  return {
+    kind: 'builtin',
+    provider_id: 'anthropic',
+    default_model: null,
+    created_at: '2026-05-08T00:00:00.000Z',
+    updated_at: '2026-05-08T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {'content-type': 'application/json'},
+    ...init,
+  });
+}
+
+function errorResponse() {
+  return jsonResponse({code: 'server-error'}, {status: 500, statusText: 'Server error'});
+}

--- a/libs/client/agent/src/components/harnesses-section.test.tsx
+++ b/libs/client/agent/src/components/harnesses-section.test.tsx
@@ -21,13 +21,14 @@ function jsonResponse(body: unknown, init: ResponseInit = {}) {
 
 function renderHarnesses(element: ReactElement) {
   const queryClient = new QueryClient({defaultOptions: {queries: {retry: false}}});
-
-  return render(
+  const result = render(
     <QueryClientProvider client={queryClient}>
       {element}
       <Toaster />
     </QueryClientProvider>,
   );
+
+  return {...result, queryClient};
 }
 
 function deferred<T>() {
@@ -139,5 +140,45 @@ describe('WorkspaceHarnessesSection', () => {
       ),
     );
     expect(await screen.findByText('Could not save default harness. Try again.')).toBeVisible();
+  });
+
+  test('ignores stale default harness failures after changing workspaces', async () => {
+    const user = userEvent.setup();
+    const updateResponse = deferred<Response>();
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (request.method === 'PUT') {
+        return updateResponse.promise;
+      }
+      return Promise.resolve(jsonResponse(modelProviderConfigsResponse()));
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+    const nextWorkspaceId = '22222222-2222-4222-8222-222222222222';
+
+    const result = renderHarnesses(
+      <WorkspaceHarnessesSection workspaceId={AGENT_TEST_WORKSPACE_ID} />,
+    );
+
+    await screen.findByText('Claude');
+    await openHarnessActions(user, 'Claude');
+    await user.click(screen.getByRole('menuitem', {name: 'Set as default'}));
+    await waitFor(() =>
+      expect(screen.getByRole('button', {name: 'Open Claude harness actions'})).toBeDisabled(),
+    );
+
+    result.rerender(
+      <QueryClientProvider client={result.queryClient}>
+        <WorkspaceHarnessesSection workspaceId={nextWorkspaceId} />
+        <Toaster />
+      </QueryClientProvider>,
+    );
+    updateResponse.resolve(jsonResponse({code: 'server-error'}, {status: 500}));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', {name: 'Open Claude harness actions'})).not.toBeDisabled(),
+    );
+    expect(
+      screen.queryByText('Could not save default harness. Try again.'),
+    ).not.toBeInTheDocument();
   });
 });

--- a/libs/client/agent/src/components/harnesses-section.test.tsx
+++ b/libs/client/agent/src/components/harnesses-section.test.tsx
@@ -75,9 +75,9 @@ describe('WorkspaceHarnessesSection', () => {
 
     const claudeRow = (await screen.findByText('Claude')).closest('li');
     if (claudeRow === null) throw new Error('Expected Claude row');
-    expect(within(claudeRow).getByText('Configure Anthropic to enable Claude.')).toHaveClass(
-      'sr-only',
-    );
+    expect(
+      within(claudeRow).getByText('Configure a compatible model provider to use this harness.'),
+    ).toHaveClass('sr-only');
 
     await openHarnessActions(user, 'Claude');
 

--- a/libs/client/agent/src/components/harnesses-section.test.tsx
+++ b/libs/client/agent/src/components/harnesses-section.test.tsx
@@ -30,6 +30,14 @@ function renderHarnesses(element: ReactElement) {
   );
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return {promise, resolve};
+}
+
 async function openHarnessActions(user: ReturnType<typeof userEvent.setup>, label: string) {
   await user.click(screen.getByRole('button', {name: `Open ${label} harness actions`}));
 }
@@ -85,11 +93,12 @@ describe('WorkspaceHarnessesSection', () => {
   test('sets the default harness and shows a success toast', async () => {
     const user = userEvent.setup();
     let requestBody: unknown;
+    const updateResponse = deferred<Response>();
     const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
       const request = input as Request;
       if (request.method === 'PUT') {
         requestBody = await request.clone().json();
-        return jsonResponse({default_harness_id: 'claude'});
+        return await updateResponse.promise;
       }
       return jsonResponse(modelProviderConfigsResponse());
     });
@@ -102,6 +111,8 @@ describe('WorkspaceHarnessesSection', () => {
     await user.click(screen.getByRole('menuitem', {name: 'Set as default'}));
 
     await waitFor(() => expect(requestBody).toEqual({harness_id: 'claude'}));
+    expect(screen.getByRole('button', {name: 'Open Claude harness actions'})).toBeDisabled();
+    updateResponse.resolve(jsonResponse({default_harness_id: 'claude'}));
     expect(await screen.findByText('Claude is now the default harness')).toBeVisible();
   });
 

--- a/libs/client/agent/src/components/harnesses-section.test.tsx
+++ b/libs/client/agent/src/components/harnesses-section.test.tsx
@@ -1,0 +1,134 @@
+import {configureApiClient} from '@shipfox/client-api';
+import {Toaster} from '@shipfox/react-ui/toast';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {render, screen, waitFor, within} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type {ReactElement} from 'react';
+import {
+  AGENT_TEST_WORKSPACE_ID,
+  modelProviderConfig,
+  modelProviderConfigsResponse,
+} from '#test/fixtures/model-providers.js';
+import {WorkspaceHarnessesSection} from './harnesses-section.js';
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {'content-type': 'application/json'},
+    ...init,
+  });
+}
+
+function renderHarnesses(element: ReactElement) {
+  const queryClient = new QueryClient({defaultOptions: {queries: {retry: false}}});
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      {element}
+      <Toaster />
+    </QueryClientProvider>,
+  );
+}
+
+async function openHarnessActions(user: ReturnType<typeof userEvent.setup>, label: string) {
+  await user.click(screen.getByRole('button', {name: `Open ${label} harness actions`}));
+}
+
+describe('WorkspaceHarnessesSection', () => {
+  test('omits set as default on the default row and enables it on an available non-default row', async () => {
+    const user = userEvent.setup();
+    configureApiClient({
+      baseUrl: 'https://api.example.test',
+      fetchImpl: vi.fn().mockResolvedValue(jsonResponse(modelProviderConfigsResponse())),
+    });
+
+    renderHarnesses(<WorkspaceHarnessesSection workspaceId={AGENT_TEST_WORKSPACE_ID} />);
+
+    expect(await screen.findByText('Harnesses')).toBeVisible();
+    expect(await screen.findByText('Default harness')).toHaveClass('sr-only');
+
+    await openHarnessActions(user, 'pi');
+    expect(screen.queryByRole('menuitem', {name: 'Set as default'})).not.toBeInTheDocument();
+
+    await user.keyboard('{Escape}');
+    await openHarnessActions(user, 'Claude');
+    expect(screen.getByRole('menuitem', {name: 'Set as default'})).toBeVisible();
+    expect(screen.getByRole('menuitem', {name: 'Set as default'})).not.toHaveAttribute(
+      'data-disabled',
+    );
+  });
+
+  test('disables set as default and shows a warning for an unavailable harness', async () => {
+    const user = userEvent.setup();
+    configureApiClient({
+      baseUrl: 'https://api.example.test',
+      fetchImpl: vi.fn().mockResolvedValue(
+        jsonResponse(
+          modelProviderConfigsResponse({
+            configs: [modelProviderConfig({provider_id: 'openai'})],
+          }),
+        ),
+      ),
+    });
+
+    renderHarnesses(<WorkspaceHarnessesSection workspaceId={AGENT_TEST_WORKSPACE_ID} />);
+
+    const claudeRow = (await screen.findByText('Claude')).closest('li');
+    if (claudeRow === null) throw new Error('Expected Claude row');
+    expect(within(claudeRow).getByText('Configure Anthropic to enable Claude.')).toHaveClass(
+      'sr-only',
+    );
+
+    await openHarnessActions(user, 'Claude');
+
+    expect(screen.getByRole('menuitem', {name: 'Set as default'})).toHaveAttribute('data-disabled');
+  });
+
+  test('sets the default harness and shows a success toast', async () => {
+    const user = userEvent.setup();
+    let requestBody: unknown;
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (request.method === 'PUT') {
+        requestBody = await request.clone().json();
+        return jsonResponse({default_harness_id: 'claude'});
+      }
+      return jsonResponse(modelProviderConfigsResponse());
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderHarnesses(<WorkspaceHarnessesSection workspaceId={AGENT_TEST_WORKSPACE_ID} />);
+
+    await screen.findByText('Claude');
+    await openHarnessActions(user, 'Claude');
+    await user.click(screen.getByRole('menuitem', {name: 'Set as default'}));
+
+    await waitFor(() => expect(requestBody).toEqual({harness_id: 'claude'}));
+    expect(await screen.findByText('Claude is now the default harness')).toBeVisible();
+  });
+
+  test('shows an inline error when setting the default harness fails', async () => {
+    const user = userEvent.setup();
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (request.method === 'PUT') {
+        return Promise.resolve(jsonResponse({code: 'server-error'}, {status: 500}));
+      }
+      return Promise.resolve(jsonResponse(modelProviderConfigsResponse()));
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderHarnesses(<WorkspaceHarnessesSection workspaceId={AGENT_TEST_WORKSPACE_ID} />);
+
+    await screen.findByText('Claude');
+    await openHarnessActions(user, 'Claude');
+    await user.click(screen.getByRole('menuitem', {name: 'Set as default'}));
+
+    await waitFor(() =>
+      expect(fetchImpl.mock.calls.some(([input]) => (input as Request).method === 'PUT')).toBe(
+        true,
+      ),
+    );
+    expect(await screen.findByText('Could not save default harness. Try again.')).toBeVisible();
+  });
+});

--- a/libs/client/agent/src/components/harnesses-section.test.tsx
+++ b/libs/client/agent/src/components/harnesses-section.test.tsx
@@ -35,7 +35,7 @@ async function openHarnessActions(user: ReturnType<typeof userEvent.setup>, labe
 }
 
 describe('WorkspaceHarnessesSection', () => {
-  test('omits set as default on the default row and enables it on an available non-default row', async () => {
+  test('omits actions on the default row and enables them on an available non-default row', async () => {
     const user = userEvent.setup();
     configureApiClient({
       baseUrl: 'https://api.example.test',
@@ -47,10 +47,8 @@ describe('WorkspaceHarnessesSection', () => {
     expect(await screen.findByText('Harnesses')).toBeVisible();
     expect(await screen.findByText('Default harness')).toHaveClass('sr-only');
 
-    await openHarnessActions(user, 'pi');
-    expect(screen.queryByRole('menuitem', {name: 'Set as default'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Open pi harness actions'})).not.toBeInTheDocument();
 
-    await user.keyboard('{Escape}');
     await openHarnessActions(user, 'Claude');
     expect(screen.getByRole('menuitem', {name: 'Set as default'})).toBeVisible();
     expect(screen.getByRole('menuitem', {name: 'Set as default'})).not.toHaveAttribute(

--- a/libs/client/agent/src/components/harnesses-section.tsx
+++ b/libs/client/agent/src/components/harnesses-section.tsx
@@ -1,5 +1,6 @@
 import {
   DEFAULT_HARNESS,
+  type Harness,
   type HarnessDescriptor,
   listHarnessDescriptors,
 } from '@shipfox/api-agent-dto';
@@ -18,7 +19,7 @@ import {toast} from '@shipfox/react-ui/toast';
 import {Tooltip, TooltipContent, TooltipTrigger} from '@shipfox/react-ui/tooltip';
 import {Header, Text} from '@shipfox/react-ui/typography';
 import {cn} from '@shipfox/react-ui/utils';
-import {useState} from 'react';
+import {useRef, useState} from 'react';
 import {
   useModelProviderConfigsQuery,
   useSetDefaultHarnessMutation,
@@ -31,8 +32,38 @@ const SURFACE_CLASS =
 
 export function WorkspaceHarnessesSection({workspaceId}: {workspaceId: string}) {
   const configsQuery = useModelProviderConfigsQuery(workspaceId);
+  const setDefaultHarness = useSetDefaultHarnessMutation();
+  const defaultRequestInFlightRef = useRef(false);
+  const [pendingDefaultHarnessId, setPendingDefaultHarnessId] = useState<Harness | null>(null);
+  const [defaultError, setDefaultError] = useState<
+    {harnessId: Harness; message: string} | undefined
+  >();
   const configs = configsQuery.data?.configs ?? [];
   const defaultHarnessId = configsQuery.data?.default_harness_id ?? DEFAULT_HARNESS;
+
+  async function handleSetDefault(harness: HarnessDescriptor) {
+    if (defaultRequestInFlightRef.current) return;
+
+    defaultRequestInFlightRef.current = true;
+    setPendingDefaultHarnessId(harness.id);
+    setDefaultError(undefined);
+    try {
+      await setDefaultHarness.mutateAsync({
+        workspaceId,
+        body: {harness_id: harness.id},
+      });
+      toast.success(`${harness.label} is now the default harness`);
+    } catch (error) {
+      const mapped = modelProviderConfigErrorToFormError(error);
+      setDefaultError({
+        harnessId: harness.id,
+        message: mapped.message || 'Could not save default harness. Try again.',
+      });
+    } finally {
+      defaultRequestInFlightRef.current = false;
+      setPendingDefaultHarnessId(null);
+    }
+  }
 
   return (
     <section className="flex flex-col gap-16" aria-label="Harnesses">
@@ -56,10 +87,14 @@ export function WorkspaceHarnessesSection({workspaceId}: {workspaceId: string}) 
           {listHarnessDescriptors().map((harness) => (
             <HarnessRow
               key={harness.id}
-              workspaceId={workspaceId}
               harness={harness}
               isDefault={harness.id === defaultHarnessId}
               isAvailable={isHarnessAvailable(harness, configs)}
+              isSettingDefault={pendingDefaultHarnessId !== null}
+              defaultError={
+                defaultError?.harnessId === harness.id ? defaultError.message : undefined
+              }
+              onSetDefault={handleSetDefault}
             />
           ))}
         </ul>
@@ -69,33 +104,21 @@ export function WorkspaceHarnessesSection({workspaceId}: {workspaceId: string}) 
 }
 
 function HarnessRow({
-  workspaceId,
   harness,
   isDefault,
   isAvailable,
+  isSettingDefault,
+  defaultError,
+  onSetDefault,
 }: {
-  workspaceId: string;
   harness: HarnessDescriptor;
   isDefault: boolean;
   isAvailable: boolean;
+  isSettingDefault: boolean;
+  defaultError: string | undefined;
+  onSetDefault: (harness: HarnessDescriptor) => void;
 }) {
-  const setDefaultHarness = useSetDefaultHarnessMutation();
-  const [defaultError, setDefaultError] = useState<string | undefined>();
   const unavailableCopy = harnessUnavailableCopy(isDefault);
-
-  async function handleSetDefault() {
-    setDefaultError(undefined);
-    try {
-      await setDefaultHarness.mutateAsync({
-        workspaceId,
-        body: {harness_id: harness.id},
-      });
-      toast.success(`${harness.label} is now the default harness`);
-    } catch (error) {
-      const mapped = modelProviderConfigErrorToFormError(error);
-      setDefaultError(mapped.message || 'Could not save default harness. Try again.');
-    }
-  }
 
   return (
     <li className="flex flex-col gap-10 px-16 py-12 transition-colors hover:bg-background-components-hover">
@@ -146,15 +169,16 @@ function HarnessRow({
                 size="sm"
                 variant="transparent"
                 icon="more2Line"
+                disabled={isSettingDefault}
                 aria-label={`Open ${harness.label} harness actions`}
               />
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               <DropdownMenuItem
                 icon="starLine"
-                disabled={setDefaultHarness.isPending || !isAvailable}
+                disabled={isSettingDefault || !isAvailable}
                 onSelect={() => {
-                  void handleSetDefault();
+                  onSetDefault(harness);
                 }}
               >
                 Set as default

--- a/libs/client/agent/src/components/harnesses-section.tsx
+++ b/libs/client/agent/src/components/harnesses-section.tsx
@@ -1,0 +1,200 @@
+import {
+  DEFAULT_HARNESS,
+  type HarnessDescriptor,
+  listHarnessDescriptors,
+} from '@shipfox/api-agent-dto';
+import {QueryLoadError} from '@shipfox/client-ui';
+import {Alert} from '@shipfox/react-ui/alert';
+import {IconButton} from '@shipfox/react-ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@shipfox/react-ui/dropdown-menu';
+import {Icon} from '@shipfox/react-ui/icon';
+import {Skeleton} from '@shipfox/react-ui/skeleton';
+import {toast} from '@shipfox/react-ui/toast';
+import {Tooltip, TooltipContent, TooltipTrigger} from '@shipfox/react-ui/tooltip';
+import {Header, Text} from '@shipfox/react-ui/typography';
+import {cn} from '@shipfox/react-ui/utils';
+import {useState} from 'react';
+import {
+  useModelProviderConfigsQuery,
+  useSetDefaultHarnessMutation,
+} from '#hooks/api/model-providers.js';
+import {modelProviderConfigErrorToFormError} from './form-errors.js';
+import {isHarnessAvailable} from './harness-availability.js';
+
+const SURFACE_CLASS =
+  'overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base';
+
+export function WorkspaceHarnessesSection({workspaceId}: {workspaceId: string}) {
+  const configsQuery = useModelProviderConfigsQuery(workspaceId);
+  const configs = configsQuery.data?.configs ?? [];
+  const defaultHarnessId = configsQuery.data?.default_harness_id ?? DEFAULT_HARNESS;
+
+  return (
+    <section className="flex flex-col gap-16" aria-label="Harnesses">
+      <div className="flex flex-col gap-4">
+        <Header variant="h3">Harnesses</Header>
+        <Text size="sm" className="text-foreground-neutral-muted">
+          Harnesses are the engines that run agent steps; each uses a model provider's credentials.
+        </Text>
+      </div>
+
+      {configsQuery.isPending ? <HarnessRowsSkeleton /> : null}
+
+      {configsQuery.isError && configsQuery.data === undefined ? (
+        <div className={cn(SURFACE_CLASS, 'px-16')}>
+          <QueryLoadError query={configsQuery} subject="harnesses" />
+        </div>
+      ) : null}
+
+      {configsQuery.data !== undefined ? (
+        <ul className={cn('divide-y divide-border-neutral-base', SURFACE_CLASS)}>
+          {listHarnessDescriptors().map((harness) => (
+            <HarnessRow
+              key={harness.id}
+              workspaceId={workspaceId}
+              harness={harness}
+              isDefault={harness.id === defaultHarnessId}
+              isAvailable={isHarnessAvailable(harness, configs)}
+            />
+          ))}
+        </ul>
+      ) : null}
+    </section>
+  );
+}
+
+function HarnessRow({
+  workspaceId,
+  harness,
+  isDefault,
+  isAvailable,
+}: {
+  workspaceId: string;
+  harness: HarnessDescriptor;
+  isDefault: boolean;
+  isAvailable: boolean;
+}) {
+  const setDefaultHarness = useSetDefaultHarnessMutation();
+  const [defaultError, setDefaultError] = useState<string | undefined>();
+  const unavailableCopy = harnessUnavailableCopy(harness, isDefault);
+
+  async function handleSetDefault() {
+    setDefaultError(undefined);
+    try {
+      await setDefaultHarness.mutateAsync({
+        workspaceId,
+        body: {harness_id: harness.id},
+      });
+      toast.success(`${harness.label} is now the default harness`);
+    } catch (error) {
+      const mapped = modelProviderConfigErrorToFormError(error);
+      setDefaultError(mapped.message || 'Could not save default harness. Try again.');
+    }
+  }
+
+  return (
+    <li className="flex flex-col gap-10 px-16 py-12 transition-colors hover:bg-background-components-hover">
+      <div className="flex items-center justify-between gap-12">
+        <div className="flex min-w-0 items-center gap-8">
+          {isDefault ? (
+            <>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="inline-flex size-16 shrink-0 items-center justify-center">
+                    <Icon
+                      name="starLine"
+                      className="size-16 text-foreground-neutral-muted"
+                      aria-hidden
+                    />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>Default harness</TooltipContent>
+              </Tooltip>
+              <span className="sr-only">Default harness</span>
+            </>
+          ) : null}
+          <Text size="md" bold className="truncate">
+            {harness.label}
+          </Text>
+          {!isAvailable ? (
+            <>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="inline-flex size-16 shrink-0 items-center justify-center">
+                    <Icon
+                      name="errorWarningLine"
+                      className="size-16 text-foreground-warning-base"
+                      aria-hidden
+                    />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>{unavailableCopy}</TooltipContent>
+              </Tooltip>
+              <span className="sr-only">{unavailableCopy}</span>
+            </>
+          ) : null}
+        </div>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <IconButton
+              size="sm"
+              variant="transparent"
+              icon="more2Line"
+              aria-label={`Open ${harness.label} harness actions`}
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {!isDefault ? (
+              <DropdownMenuItem
+                icon="starLine"
+                disabled={setDefaultHarness.isPending || !isAvailable}
+                onSelect={() => {
+                  void handleSetDefault();
+                }}
+              >
+                Set as default
+              </DropdownMenuItem>
+            ) : null}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+      {defaultError ? (
+        <Alert variant="error" animated={false}>
+          <Text size="sm">{defaultError}</Text>
+        </Alert>
+      ) : null}
+    </li>
+  );
+}
+
+function harnessUnavailableCopy(harness: HarnessDescriptor, isDefault: boolean): string {
+  const base =
+    harness.id === 'claude'
+      ? 'Configure Anthropic to enable Claude.'
+      : 'No workspace provider configured. Agent steps use the instance default.';
+  if (!isDefault) return base;
+  return `${base} The stored default harness cannot currently run in this workspace.`;
+}
+
+function HarnessRowsSkeleton() {
+  return (
+    <ul
+      role="status"
+      aria-label="Loading harnesses"
+      className={cn('divide-y divide-border-neutral-base', SURFACE_CLASS)}
+    >
+      {[0, 1].map((row) => (
+        <li key={row} className="flex items-center gap-12 px-16 py-12">
+          <Skeleton className="size-16 shrink-0" />
+          <Skeleton className="h-16 w-120" />
+          <Skeleton className="ml-auto size-28 shrink-0" />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/libs/client/agent/src/components/harnesses-section.tsx
+++ b/libs/client/agent/src/components/harnesses-section.tsx
@@ -139,17 +139,17 @@ function HarnessRow({
             </>
           ) : null}
         </div>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <IconButton
-              size="sm"
-              variant="transparent"
-              icon="more2Line"
-              aria-label={`Open ${harness.label} harness actions`}
-            />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" side="top">
-            {!isDefault ? (
+        {!isDefault ? (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <IconButton
+                size="sm"
+                variant="transparent"
+                icon="more2Line"
+                aria-label={`Open ${harness.label} harness actions`}
+              />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
               <DropdownMenuItem
                 icon="starLine"
                 disabled={setDefaultHarness.isPending || !isAvailable}
@@ -159,9 +159,9 @@ function HarnessRow({
               >
                 Set as default
               </DropdownMenuItem>
-            ) : null}
-          </DropdownMenuContent>
-        </DropdownMenu>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : null}
       </div>
       {defaultError ? (
         <Alert variant="error" animated={false}>

--- a/libs/client/agent/src/components/harnesses-section.tsx
+++ b/libs/client/agent/src/components/harnesses-section.tsx
@@ -81,7 +81,7 @@ function HarnessRow({
 }) {
   const setDefaultHarness = useSetDefaultHarnessMutation();
   const [defaultError, setDefaultError] = useState<string | undefined>();
-  const unavailableCopy = harnessUnavailableCopy(harness, isDefault);
+  const unavailableCopy = harnessUnavailableCopy(isDefault);
 
   async function handleSetDefault() {
     setDefaultError(undefined);
@@ -172,11 +172,8 @@ function HarnessRow({
   );
 }
 
-function harnessUnavailableCopy(harness: HarnessDescriptor, isDefault: boolean): string {
-  const base =
-    harness.id === 'claude'
-      ? 'Configure Anthropic to enable Claude.'
-      : 'No workspace provider configured. Agent steps use the instance default.';
+function harnessUnavailableCopy(isDefault: boolean): string {
+  const base = 'Configure a compatible model provider to use this harness.';
   if (!isDefault) return base;
   return `${base} The stored default harness cannot currently run in this workspace.`;
 }

--- a/libs/client/agent/src/components/harnesses-section.tsx
+++ b/libs/client/agent/src/components/harnesses-section.tsx
@@ -35,7 +35,7 @@ export function WorkspaceHarnessesSection({workspaceId}: {workspaceId: string}) 
   const defaultHarnessId = configsQuery.data?.default_harness_id ?? DEFAULT_HARNESS;
 
   return (
-    <section className="relative z-30 flex flex-col gap-16" aria-label="Harnesses">
+    <section className="flex flex-col gap-16" aria-label="Harnesses">
       <div className="flex flex-col gap-4">
         <Header variant="h3">Harnesses</Header>
         <Text size="sm" className="text-foreground-neutral-muted">

--- a/libs/client/agent/src/components/harnesses-section.tsx
+++ b/libs/client/agent/src/components/harnesses-section.tsx
@@ -39,7 +39,7 @@ export function WorkspaceHarnessesSection({workspaceId}: {workspaceId: string}) 
       <div className="flex flex-col gap-4">
         <Header variant="h3">Harnesses</Header>
         <Text size="sm" className="text-foreground-neutral-muted">
-          Harnesses are the engines that run agent steps; each uses a model provider's credentials.
+          Harnesses available to run agent steps in this workspace.
         </Text>
       </div>
 

--- a/libs/client/agent/src/components/harnesses-section.tsx
+++ b/libs/client/agent/src/components/harnesses-section.tsx
@@ -35,7 +35,7 @@ export function WorkspaceHarnessesSection({workspaceId}: {workspaceId: string}) 
   const defaultHarnessId = configsQuery.data?.default_harness_id ?? DEFAULT_HARNESS;
 
   return (
-    <section className="flex flex-col gap-16" aria-label="Harnesses">
+    <section className="relative z-30 flex flex-col gap-16" aria-label="Harnesses">
       <div className="flex flex-col gap-4">
         <Header variant="h3">Harnesses</Header>
         <Text size="sm" className="text-foreground-neutral-muted">

--- a/libs/client/agent/src/components/harnesses-section.tsx
+++ b/libs/client/agent/src/components/harnesses-section.tsx
@@ -148,7 +148,7 @@ function HarnessRow({
               aria-label={`Open ${harness.label} harness actions`}
             />
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
+          <DropdownMenuContent align="end" side="top">
             {!isDefault ? (
               <DropdownMenuItem
                 icon="starLine"

--- a/libs/client/agent/src/components/harnesses-section.tsx
+++ b/libs/client/agent/src/components/harnesses-section.tsx
@@ -33,35 +33,57 @@ const SURFACE_CLASS =
 export function WorkspaceHarnessesSection({workspaceId}: {workspaceId: string}) {
   const configsQuery = useModelProviderConfigsQuery(workspaceId);
   const setDefaultHarness = useSetDefaultHarnessMutation();
-  const defaultRequestInFlightRef = useRef(false);
-  const [pendingDefaultHarnessId, setPendingDefaultHarnessId] = useState<Harness | null>(null);
+  const activeWorkspaceIdRef = useRef(workspaceId);
+  const defaultRequestSeqRef = useRef(0);
+  const activeDefaultRequestRef = useRef<{workspaceId: string; id: number} | null>(null);
+  const [pendingDefaultHarness, setPendingDefaultHarness] = useState<{
+    workspaceId: string;
+    harnessId: Harness;
+  } | null>(null);
   const [defaultError, setDefaultError] = useState<
-    {harnessId: Harness; message: string} | undefined
+    {workspaceId: string; harnessId: Harness; message: string} | undefined
   >();
   const configs = configsQuery.data?.configs ?? [];
   const defaultHarnessId = configsQuery.data?.default_harness_id ?? DEFAULT_HARNESS;
+  activeWorkspaceIdRef.current = workspaceId;
+
+  function isActiveDefaultRequest(request: {workspaceId: string; id: number}) {
+    const activeRequest = activeDefaultRequestRef.current;
+    return (
+      activeWorkspaceIdRef.current === request.workspaceId &&
+      activeRequest?.workspaceId === request.workspaceId &&
+      activeRequest.id === request.id
+    );
+  }
 
   async function handleSetDefault(harness: HarnessDescriptor) {
-    if (defaultRequestInFlightRef.current) return;
+    if (activeDefaultRequestRef.current?.workspaceId === workspaceId) return;
 
-    defaultRequestInFlightRef.current = true;
-    setPendingDefaultHarnessId(harness.id);
+    const request = {workspaceId, id: defaultRequestSeqRef.current + 1};
+    defaultRequestSeqRef.current = request.id;
+    activeDefaultRequestRef.current = request;
+    setPendingDefaultHarness({workspaceId, harnessId: harness.id});
     setDefaultError(undefined);
     try {
       await setDefaultHarness.mutateAsync({
         workspaceId,
         body: {harness_id: harness.id},
       });
+      if (!isActiveDefaultRequest(request)) return;
       toast.success(`${harness.label} is now the default harness`);
     } catch (error) {
+      if (!isActiveDefaultRequest(request)) return;
       const mapped = modelProviderConfigErrorToFormError(error);
       setDefaultError({
+        workspaceId,
         harnessId: harness.id,
         message: mapped.message || 'Could not save default harness. Try again.',
       });
     } finally {
-      defaultRequestInFlightRef.current = false;
-      setPendingDefaultHarnessId(null);
+      if (isActiveDefaultRequest(request)) {
+        activeDefaultRequestRef.current = null;
+        setPendingDefaultHarness(null);
+      }
     }
   }
 
@@ -90,9 +112,11 @@ export function WorkspaceHarnessesSection({workspaceId}: {workspaceId: string}) 
               harness={harness}
               isDefault={harness.id === defaultHarnessId}
               isAvailable={isHarnessAvailable(harness, configs)}
-              isSettingDefault={pendingDefaultHarnessId !== null}
+              isSettingDefault={pendingDefaultHarness?.workspaceId === workspaceId}
               defaultError={
-                defaultError?.harnessId === harness.id ? defaultError.message : undefined
+                defaultError?.workspaceId === workspaceId && defaultError.harnessId === harness.id
+                  ? defaultError.message
+                  : undefined
               }
               onSetDefault={handleSetDefault}
             />

--- a/libs/client/agent/src/components/model-provider-usage-modal.stories.tsx
+++ b/libs/client/agent/src/components/model-provider-usage-modal.stories.tsx
@@ -1,22 +1,33 @@
-import type {ModelProviderCatalogEntryDto} from '@shipfox/api-agent-dto';
+import type {
+  CustomModelProviderConfigDto,
+  ModelProviderCatalogEntryDto,
+} from '@shipfox/api-agent-dto';
 import type {Meta, StoryObj} from '@storybook/react';
 import {useState} from 'react';
 import {ModelProviderUsageModal} from './model-provider-usage-modal.js';
-import {usageTargetFromCatalogEntry} from './model-provider-usage-target.js';
+import {
+  usageTargetFromCatalogEntry,
+  usageTargetFromCustomConfig,
+} from './model-provider-usage-target.js';
 
 interface ModelProviderUsageModalStoryProps {
-  variant: 'anthropic' | 'long-list';
+  variant: 'anthropic' | 'custom' | 'long-list';
 }
 
 function ModelProviderUsageModalStory({variant}: ModelProviderUsageModalStoryProps) {
   const [open, setOpen] = useState(true);
   const entry = variant === 'long-list' ? longListEntry() : anthropicEntry();
+  const target =
+    variant === 'custom'
+      ? usageTargetFromCustomConfig(customProviderConfig())
+      : usageTargetFromCatalogEntry(entry);
 
   return (
     <div className="min-h-screen bg-background-neutral-background p-24">
       <ModelProviderUsageModal
-        target={usageTargetFromCatalogEntry(entry)}
-        initialModel={entry.default_model}
+        target={target}
+        initialModel={target.default_model}
+        workspaceDefaultHarnessId="claude"
         open={open}
         onOpenChange={setOpen}
       />
@@ -38,6 +49,10 @@ export const Playground: Story = {};
 
 export const LongModelList: Story = {
   args: {variant: 'long-list'},
+};
+
+export const CustomProvider: Story = {
+  args: {variant: 'custom'},
 };
 
 function anthropicEntry(): ModelProviderCatalogEntryDto {
@@ -71,5 +86,21 @@ function longListEntry(): ModelProviderCatalogEntryDto {
           : `provider/research-lab/model-family-${String(index).padStart(2, '0')}-large-context`,
       label: index === 0 ? 'Kimi K2.7 Code' : `Research Model ${index}`,
     })),
+  };
+}
+
+function customProviderConfig(): CustomModelProviderConfigDto {
+  return {
+    kind: 'custom',
+    provider_id: 'local-vllm',
+    display_name: 'Local vLLM',
+    api: 'openai-completions',
+    base_url: 'http://localhost:8000/v1',
+    headers: [],
+    secret_header_names: [],
+    models: [{id: 'llama-3.1', label: 'Llama 3.1'}],
+    default_model: 'llama-3.1',
+    created_at: '2026-05-08T00:00:00.000Z',
+    updated_at: '2026-05-08T00:00:00.000Z',
   };
 }

--- a/libs/client/agent/src/components/model-provider-usage-modal.test.tsx
+++ b/libs/client/agent/src/components/model-provider-usage-modal.test.tsx
@@ -1,8 +1,11 @@
 import {fireEvent, render, screen, waitFor, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {modelProviderEntry} from '#test/fixtures/model-providers.js';
+import {customModelProviderConfig, modelProviderEntry} from '#test/fixtures/model-providers.js';
 import {ModelProviderUsageModal} from './model-provider-usage-modal.js';
-import {usageTargetFromCatalogEntry} from './model-provider-usage-target.js';
+import {
+  usageTargetFromCatalogEntry,
+  usageTargetFromCustomConfig,
+} from './model-provider-usage-target.js';
 
 const CLAUDE_MODEL_ROW_NAME = 'Copy Claude Opus 4.8 model id claude-opus-4-8';
 const KIMI_MODEL_ROW_NAME = 'Copy Kimi K2.7 Code model id @cf/moonshotai/kimi-k2.7-code';
@@ -34,6 +37,11 @@ describe('ModelProviderUsageModal', () => {
     renderUsageModal();
     await waitFor(() =>
       expect(screen.getByRole('dialog', {name: 'Use Anthropic in a workflow'})).toHaveTextContent(
+        'harness: pi',
+      ),
+    );
+    await waitFor(() =>
+      expect(screen.getByRole('dialog', {name: 'Use Anthropic in a workflow'})).toHaveTextContent(
         'model: claude-opus-4-8',
       ),
     );
@@ -50,6 +58,109 @@ describe('ModelProviderUsageModal', () => {
       'model: claude-opus-4-8',
     );
   }, 10_000);
+
+  test('changes the selected harness in the workflow example', async () => {
+    renderUsageModal();
+    await waitFor(() =>
+      expect(screen.getByRole('dialog', {name: 'Use Anthropic in a workflow'})).toHaveTextContent(
+        'harness: pi',
+      ),
+    );
+
+    fireEvent.click(screen.getByRole('button', {name: 'Harness'}));
+    fireEvent.click(await screen.findByRole('option', {name: 'Claude'}));
+
+    await waitFor(() =>
+      expect(screen.getByRole('dialog', {name: 'Use Anthropic in a workflow'})).toHaveTextContent(
+        'harness: claude',
+      ),
+    );
+  });
+
+  test('uses the workspace default harness when it is compatible', async () => {
+    const onOpenChange = vi.fn();
+    const entry = modelProviderEntry();
+
+    render(
+      <ModelProviderUsageModal
+        target={usageTargetFromCatalogEntry(entry)}
+        initialModel="claude-opus-4-8"
+        workspaceDefaultHarnessId="claude"
+        open
+        onOpenChange={onOpenChange}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole('dialog', {name: 'Use Anthropic in a workflow'})).toHaveTextContent(
+        'harness: claude',
+      ),
+    );
+  });
+
+  test('clamps the selected harness when the target changes', async () => {
+    const onOpenChange = vi.fn();
+    const anthropic = modelProviderEntry();
+    const openai = modelProviderEntry({
+      id: 'openai',
+      label: 'OpenAI',
+      models: [{id: 'gpt-5.5-pro', label: 'GPT-5.5 Pro'}],
+    });
+    const {rerender} = render(
+      <ModelProviderUsageModal
+        target={usageTargetFromCatalogEntry(anthropic)}
+        initialModel="claude-opus-4-8"
+        workspaceDefaultHarnessId="claude"
+        open
+        onOpenChange={onOpenChange}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByRole('dialog', {name: 'Use Anthropic in a workflow'})).toHaveTextContent(
+        'harness: claude',
+      ),
+    );
+
+    rerender(
+      <ModelProviderUsageModal
+        target={usageTargetFromCatalogEntry(openai)}
+        initialModel="gpt-5.5-pro"
+        workspaceDefaultHarnessId="claude"
+        open
+        onOpenChange={onOpenChange}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole('dialog', {name: 'Use OpenAI in a workflow'})).toHaveTextContent(
+        'harness: pi',
+      ),
+    );
+    expect(screen.queryByRole('button', {name: 'Harness'})).not.toBeInTheDocument();
+  });
+
+  test('renders a static pi harness line for custom providers', async () => {
+    const onOpenChange = vi.fn();
+
+    render(
+      <ModelProviderUsageModal
+        target={usageTargetFromCustomConfig(customModelProviderConfig())}
+        initialModel="custom-model"
+        workspaceDefaultHarnessId="claude"
+        open
+        onOpenChange={onOpenChange}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('dialog', {name: 'Use OpenAI Compatible in a workflow'}),
+      ).toHaveTextContent('harness: pi'),
+    );
+    expect(screen.getByText('Harness')).toBeVisible();
+    expect(screen.getAllByText('pi').length).toBeGreaterThan(0);
+    expect(screen.queryByRole('button', {name: 'Harness'})).not.toBeInTheDocument();
+  });
 
   test('renders reference models as clickable rows with inline ids', async () => {
     renderUsageModal();

--- a/libs/client/agent/src/components/model-provider-usage-modal.tsx
+++ b/libs/client/agent/src/components/model-provider-usage-modal.tsx
@@ -1,3 +1,4 @@
+import {DEFAULT_HARNESS, getHarnessDescriptor, type Harness} from '@shipfox/api-agent-dto';
 import {Button} from '@shipfox/react-ui/button';
 import {
   CodeBlock,
@@ -23,6 +24,7 @@ import {Tooltip, TooltipContent, TooltipTrigger} from '@shipfox/react-ui/tooltip
 import {Code, Text} from '@shipfox/react-ui/typography';
 import {useEffect, useMemo, useRef, useState} from 'react';
 import {buildAgentWorkflowExample} from './agent-workflow-example.js';
+import {compatibleHarnessIds} from './harness-availability.js';
 import type {ModelProviderUsageTarget} from './model-provider-usage-target.js';
 
 type CopyState = 'idle' | 'copied' | 'failed';
@@ -35,26 +37,57 @@ export function ModelProviderUsageModal({
   open,
   onOpenChange,
   closeFocusTarget,
+  workspaceDefaultHarnessId,
 }: {
   target: ModelProviderUsageTarget | null;
   initialModel?: string | null | undefined;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   closeFocusTarget?: HTMLElement | null | undefined;
+  workspaceDefaultHarnessId?: Harness | null | undefined;
 }) {
   const [selectedModel, setSelectedModel] = useState('');
+  const [selectedHarness, setSelectedHarness] = useState<Harness>(DEFAULT_HARNESS);
 
   useEffect(() => {
     if (!target) return;
     setSelectedModel(initialModel ?? target.default_model ?? target.models[0]?.id ?? '');
   }, [target, initialModel]);
 
+  useEffect(() => {
+    if (!target) return;
+    const nextCompatibleHarnessIds = compatibleHarnessIds({
+      isCustom: target.isCustom,
+      providerId: target.id,
+    });
+    setSelectedHarness(selectInitialHarness(nextCompatibleHarnessIds, workspaceDefaultHarnessId));
+  }, [target, workspaceDefaultHarnessId]);
+
+  const compatibleIds = useMemo(
+    () =>
+      target
+        ? compatibleHarnessIds({isCustom: target.isCustom, providerId: target.id})
+        : ([] as Harness[]),
+    [target],
+  );
+  const harnessOptions = useMemo(
+    () =>
+      compatibleIds.map((harnessId) => ({
+        value: harnessId,
+        label: getHarnessDescriptor(harnessId).label,
+      })),
+    [compatibleIds],
+  );
   const modelOptions = useMemo(
     () => target?.models.map((model) => ({value: model.id, label: model.label})) ?? [],
     [target],
   );
   const example = target
-    ? buildAgentWorkflowExample({providerId: target.id, model: selectedModel})
+    ? buildAgentWorkflowExample({
+        harness: selectedHarness,
+        providerId: target.id,
+        model: selectedModel,
+      })
     : null;
   const data =
     example === null
@@ -88,20 +121,57 @@ export function ModelProviderUsageModal({
           <>
             <ModalBody className="min-h-0 flex-1 gap-0 overflow-y-auto overflow-x-clip scrollbar">
               <div className="flex w-full flex-col gap-20">
-                <div>
-                  <Combobox
-                    aria-label="Model"
-                    options={modelOptions}
-                    value={selectedModel}
-                    onValueChange={(value) => {
-                      if (value) setSelectedModel(value);
-                    }}
-                    placeholder="Select model..."
-                    searchPlaceholder="Search models..."
-                    emptyState="No model found."
-                    className="w-full"
-                  />
-                </div>
+                {compatibleIds.length === 1 ? (
+                  <div className="flex flex-col gap-12">
+                    <div className="flex min-h-40 items-center justify-between gap-12 rounded-8 border border-border-neutral-base px-12 py-8">
+                      <Text size="sm" className="text-foreground-neutral-muted">
+                        Harness
+                      </Text>
+                      <Code as="span" variant="label">
+                        {compatibleIds[0]}
+                      </Code>
+                    </div>
+                    <Combobox
+                      aria-label="Model"
+                      options={modelOptions}
+                      value={selectedModel}
+                      onValueChange={(value) => {
+                        if (value) setSelectedModel(value);
+                      }}
+                      placeholder="Select model..."
+                      searchPlaceholder="Search models..."
+                      emptyState="No model found."
+                      className="w-full"
+                    />
+                  </div>
+                ) : (
+                  <div className="flex flex-col gap-12 sm:flex-row sm:gap-12">
+                    <Combobox
+                      aria-label="Harness"
+                      options={harnessOptions}
+                      value={selectedHarness}
+                      onValueChange={(value) => {
+                        if (isHarness(value)) setSelectedHarness(value);
+                      }}
+                      placeholder="Select harness..."
+                      searchPlaceholder="Search harnesses..."
+                      emptyState="No harness found."
+                      className="w-full sm:flex-1"
+                    />
+                    <Combobox
+                      aria-label="Model"
+                      options={modelOptions}
+                      value={selectedModel}
+                      onValueChange={(value) => {
+                        if (value) setSelectedModel(value);
+                      }}
+                      placeholder="Select model..."
+                      searchPlaceholder="Search models..."
+                      emptyState="No model found."
+                      className="w-full sm:flex-1"
+                    />
+                  </div>
+                )}
 
                 <div className="flex flex-col gap-8">
                   <CodeBlock data={data} className="h-auto min-h-0 rounded-8">
@@ -161,6 +231,21 @@ export function ModelProviderUsageModal({
       </ModalContent>
     </Modal>
   );
+}
+
+function selectInitialHarness(
+  compatibleIds: Harness[],
+  workspaceDefaultHarnessId: Harness | null | undefined,
+): Harness {
+  if (workspaceDefaultHarnessId && compatibleIds.includes(workspaceDefaultHarnessId)) {
+    return workspaceDefaultHarnessId;
+  }
+  if (compatibleIds.includes(DEFAULT_HARNESS)) return DEFAULT_HARNESS;
+  return compatibleIds[0] ?? DEFAULT_HARNESS;
+}
+
+function isHarness(value: string): value is Harness {
+  return value === 'pi' || value === 'claude';
 }
 
 function ModelProviderModelRow({label, id}: {label: string; id: string}) {

--- a/libs/client/agent/src/components/model-provider-usage-modal.tsx
+++ b/libs/client/agent/src/components/model-provider-usage-modal.tsx
@@ -1,4 +1,9 @@
-import {DEFAULT_HARNESS, getHarnessDescriptor, type Harness} from '@shipfox/api-agent-dto';
+import {
+  DEFAULT_HARNESS,
+  getHarnessDescriptor,
+  type Harness,
+  listHarnessDescriptors,
+} from '@shipfox/api-agent-dto';
 import {Button} from '@shipfox/react-ui/button';
 import {
   CodeBlock,
@@ -245,7 +250,7 @@ function selectInitialHarness(
 }
 
 function isHarness(value: string): value is Harness {
-  return value === 'pi' || value === 'claude';
+  return listHarnessDescriptors().some((descriptor) => descriptor.id === value);
 }
 
 function ModelProviderModelRow({label, id}: {label: string; id: string}) {

--- a/libs/client/agent/src/components/model-provider-usage-target.ts
+++ b/libs/client/agent/src/components/model-provider-usage-target.ts
@@ -6,6 +6,7 @@ import type {
 export interface ModelProviderUsageTarget {
   id: string;
   label: string;
+  isCustom: boolean;
   models: Array<{id: string; label: string}>;
   default_model: string | null;
 }
@@ -16,6 +17,7 @@ export function usageTargetFromCatalogEntry(
   return {
     id: entry.id,
     label: entry.label,
+    isCustom: false,
     models: entry.models,
     default_model: entry.default_model,
   };
@@ -27,6 +29,7 @@ export function usageTargetFromCustomConfig(
   return {
     id: config.provider_id,
     label: config.display_name,
+    isCustom: true,
     models: config.models,
     default_model: config.default_model,
   };

--- a/libs/client/agent/src/components/model-providers-section.tsx
+++ b/libs/client/agent/src/components/model-providers-section.tsx
@@ -341,6 +341,7 @@ export function WorkspaceModelProvidersSection({workspaceId}: {workspaceId: stri
       <ModelProviderUsageModal
         target={usageTarget?.target ?? null}
         initialModel={usageTarget?.initialModel ?? null}
+        workspaceDefaultHarnessId={configsQuery.data?.default_harness_id ?? null}
         open={usageTarget !== null}
         closeFocusTarget={
           usageTarget?.restoreFocusToConfiguredProviders

--- a/libs/client/agent/src/components/model-providers-section.tsx
+++ b/libs/client/agent/src/components/model-providers-section.tsx
@@ -514,7 +514,7 @@ function ConfiguredProviderRow({
               aria-label={`Open ${label} provider actions`}
             />
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="z-[100]">
+          <DropdownMenuContent align="end">
             {!isDefault ? (
               <DropdownMenuItem
                 icon="starLine"

--- a/libs/client/agent/src/components/model-providers-section.tsx
+++ b/libs/client/agent/src/components/model-providers-section.tsx
@@ -135,7 +135,7 @@ export function WorkspaceModelProvidersSection({workspaceId}: {workspaceId: stri
     <div className="flex min-w-0 flex-col gap-32">
       <section
         ref={configuredProvidersRegionRef}
-        className="flex flex-col gap-16 outline-none"
+        className="relative z-20 flex flex-col gap-16 outline-none"
         aria-label="Configured providers"
         tabIndex={-1}
       >
@@ -213,7 +213,7 @@ export function WorkspaceModelProvidersSection({workspaceId}: {workspaceId: stri
         ) : null}
       </section>
 
-      <section className="flex flex-col gap-16" aria-label="Available providers">
+      <section className="relative z-10 flex flex-col gap-16" aria-label="Available providers">
         <div className="flex flex-col gap-4">
           <Header variant="h3">Available providers</Header>
           <Text size="sm" className="text-foreground-neutral-muted">
@@ -241,7 +241,7 @@ export function WorkspaceModelProvidersSection({workspaceId}: {workspaceId: stri
         ) : null}
       </section>
 
-      <section className="flex flex-col gap-16" aria-label="Unsupported providers">
+      <section className="relative flex flex-col gap-16" aria-label="Unsupported providers">
         <div className="flex flex-col gap-4">
           <Header variant="h3">Unsupported providers</Header>
           <Text size="sm" className="text-foreground-neutral-muted">

--- a/libs/client/agent/src/components/model-providers-section.tsx
+++ b/libs/client/agent/src/components/model-providers-section.tsx
@@ -135,7 +135,7 @@ export function WorkspaceModelProvidersSection({workspaceId}: {workspaceId: stri
     <div className="flex min-w-0 flex-col gap-32">
       <section
         ref={configuredProvidersRegionRef}
-        className="relative z-20 flex flex-col gap-16 outline-none"
+        className="flex flex-col gap-16 outline-none"
         aria-label="Configured providers"
         tabIndex={-1}
       >
@@ -213,7 +213,7 @@ export function WorkspaceModelProvidersSection({workspaceId}: {workspaceId: stri
         ) : null}
       </section>
 
-      <section className="relative z-10 flex flex-col gap-16" aria-label="Available providers">
+      <section className="flex flex-col gap-16" aria-label="Available providers">
         <div className="flex flex-col gap-4">
           <Header variant="h3">Available providers</Header>
           <Text size="sm" className="text-foreground-neutral-muted">
@@ -241,7 +241,7 @@ export function WorkspaceModelProvidersSection({workspaceId}: {workspaceId: stri
         ) : null}
       </section>
 
-      <section className="relative flex flex-col gap-16" aria-label="Unsupported providers">
+      <section className="flex flex-col gap-16" aria-label="Unsupported providers">
         <div className="flex flex-col gap-4">
           <Header variant="h3">Unsupported providers</Header>
           <Text size="sm" className="text-foreground-neutral-muted">
@@ -514,7 +514,7 @@ function ConfiguredProviderRow({
               aria-label={`Open ${label} provider actions`}
             />
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
+          <DropdownMenuContent align="end" className="z-[100]">
             {!isDefault ? (
               <DropdownMenuItem
                 icon="starLine"

--- a/libs/client/agent/src/hooks/api/model-providers.test.ts
+++ b/libs/client/agent/src/hooks/api/model-providers.test.ts
@@ -9,6 +9,7 @@ import {
   deleteModelProviderConfig,
   getModelProviderCatalog,
   listModelProviderConfigs,
+  setDefaultHarness,
   setDefaultModelProvider,
   updateModelProviderDefaultModel,
   upsertModelProviderConfig,
@@ -136,6 +137,29 @@ describe('model provider transport', () => {
     expect(result.default_provider_id).toBe('anthropic');
     expect(request.url).toBe(
       `https://api.example.test/workspaces/${AGENT_TEST_WORKSPACE_ID}/agent/default-model-provider`,
+    );
+    expect(request.method).toBe('PUT');
+    expect(requestBody).toEqual(body);
+  });
+
+  test('sets the default harness', async () => {
+    let requestBody: unknown;
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      requestBody = await (input as Request).clone().json();
+      return jsonResponse({default_harness_id: 'claude'});
+    });
+    configureApiClient({fetchImpl});
+    const body = {harness_id: 'claude'} as const;
+
+    const result = await setDefaultHarness({
+      workspaceId: AGENT_TEST_WORKSPACE_ID,
+      body,
+    });
+
+    const request = fetchImpl.mock.calls[0]?.[0] as Request;
+    expect(result.default_harness_id).toBe('claude');
+    expect(request.url).toBe(
+      `https://api.example.test/workspaces/${AGENT_TEST_WORKSPACE_ID}/agent/default-harness`,
     );
     expect(request.method).toBe('PUT');
     expect(requestBody).toEqual(body);

--- a/libs/client/agent/src/hooks/api/model-providers.ts
+++ b/libs/client/agent/src/hooks/api/model-providers.ts
@@ -8,6 +8,8 @@ import type {
   ModelProviderCatalogResponseDto,
   ModelProviderConfigDto,
   ModelProviderRef,
+  SetDefaultHarnessBodyDto,
+  SetDefaultHarnessResponseDto,
   SetDefaultModelProviderBodyDto,
   SetDefaultModelProviderResponseDto,
   SupportedModelProviderId,
@@ -155,6 +157,19 @@ export async function setDefaultModelProvider({
   );
 }
 
+export async function setDefaultHarness({
+  workspaceId,
+  body,
+}: {
+  workspaceId: string;
+  body: SetDefaultHarnessBodyDto;
+}) {
+  return await apiRequest<SetDefaultHarnessResponseDto>(
+    `/workspaces/${workspaceId}/agent/default-harness`,
+    {method: 'PUT', body},
+  );
+}
+
 export function useModelProviderCatalogQuery() {
   return useQuery({
     queryKey: modelProviderQueryKeys.catalog(),
@@ -245,6 +260,18 @@ export function useSetDefaultModelProviderMutation() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: setDefaultModelProvider,
+    onSuccess: async (_config, variables) => {
+      await queryClient.invalidateQueries({
+        queryKey: modelProviderQueryKeys.configs(variables.workspaceId),
+      });
+    },
+  });
+}
+
+export function useSetDefaultHarnessMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: setDefaultHarness,
     onSuccess: async (_config, variables) => {
       await queryClient.invalidateQueries({
         queryKey: modelProviderQueryKeys.configs(variables.workspaceId),

--- a/libs/client/agent/src/index.ts
+++ b/libs/client/agent/src/index.ts
@@ -1,5 +1,6 @@
 export * from './components/available-provider-card.js';
 export * from './components/form-errors.js';
+export * from './components/harnesses-section.js';
 export * from './components/model-providers-section.js';
 export * from './components/test-and-save-form.js';
 export * from './hooks/api/model-providers.js';

--- a/libs/client/agent/src/pages/model-provider-onboarding-page.stories.tsx
+++ b/libs/client/agent/src/pages/model-provider-onboarding-page.stories.tsx
@@ -131,24 +131,41 @@ export const Playground: Story = {};
 
 export const Loading: Story = {
   args: {scenario: 'loading'},
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', {name: 'Choose pi'}));
+  },
 };
 
 export const CatalogError: Story = {
   args: {scenario: 'catalog-error'},
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', {name: 'Choose pi'}));
+  },
 };
 
 export const NoProvidersAvailable: Story = {
   args: {scenario: 'no-providers'},
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', {name: 'Choose pi'}));
+  },
 };
 
 export const LongNames: Story = {
   args: {scenario: 'long-names'},
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', {name: 'Choose pi'}));
+  },
 };
 
 export const FilteredProviders: Story = {
   args: {scenario: 'available'},
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', {name: 'Choose pi'}));
     await userEvent.type(
       await canvas.findByRole('searchbox', {name: 'Search providers'}),
       'openrouter',
@@ -161,6 +178,7 @@ export const NoMatchingProviders: Story = {
   args: {scenario: 'available'},
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', {name: 'Choose pi'}));
     await userEvent.type(
       await canvas.findByRole('searchbox', {name: 'Search providers'}),
       'not-a-provider',
@@ -173,6 +191,7 @@ export const ConfigureModalOpen: Story = {
   args: {scenario: 'available'},
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', {name: 'Choose pi'}));
     await userEvent.click(await canvas.findByRole('button', {name: 'Configure Anthropic'}));
     await screen.findByLabelText('API key');
   },

--- a/libs/client/agent/src/pages/model-provider-onboarding-page.test.tsx
+++ b/libs/client/agent/src/pages/model-provider-onboarding-page.test.tsx
@@ -1,7 +1,7 @@
 import {configureApiClient} from '@shipfox/client-api';
 import {Toaster} from '@shipfox/react-ui/toast';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
-import {render, screen, waitFor} from '@testing-library/react';
+import {render, screen, waitFor, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type {ReactElement} from 'react';
 import {isModelProviderOnboardingDismissed} from '#state/model-provider-onboarding.js';
@@ -42,7 +42,7 @@ describe('ModelProviderOnboardingPage', () => {
     window.localStorage.clear();
   });
 
-  test('skips setup, records the dismissed flag, and does not save a provider', async () => {
+  test('skips setup, records the dismissed flag, and does not save a provider or harness', async () => {
     const user = userEvent.setup();
     const onSkip = vi.fn();
     const onConfigured = vi.fn();
@@ -65,7 +65,7 @@ describe('ModelProviderOnboardingPage', () => {
     expect(fetchImpl.mock.calls.some(([input]) => (input as Request).method === 'PUT')).toBe(false);
   });
 
-  test('places skip before the provider choices', async () => {
+  test('places skip before the harness choices', () => {
     configureApiClient({
       baseUrl: 'https://api.example.test',
       fetchImpl: vi.fn().mockResolvedValue(jsonResponse(modelProviderCatalogResponse())),
@@ -80,14 +80,55 @@ describe('ModelProviderOnboardingPage', () => {
     );
 
     const skip = screen.getByRole('button', {name: 'Skip for now'});
-    const provider = await screen.findByRole('button', {
-      name: `Configure ${modelProviderEntry().label}`,
-    });
+    const harness = screen.getByRole('button', {name: 'Choose pi'});
 
-    expect(skip.compareDocumentPosition(provider)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(skip.compareDocumentPosition(harness)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   });
 
-  test('filters supported providers and clears a no-match search', async () => {
+  test('shows harnesses first, filters providers by harness, and supports going back', async () => {
+    const user = userEvent.setup();
+    configureApiClient({
+      baseUrl: 'https://api.example.test',
+      fetchImpl: vi.fn().mockResolvedValue(
+        jsonResponse(
+          modelProviderCatalogResponse([
+            modelProviderEntry(),
+            modelProviderEntry({
+              id: 'openai',
+              label: 'OpenAI',
+              default_model: 'gpt-5.5-pro',
+              models: [{id: 'gpt-5.5-pro', label: 'GPT-5.5 Pro'}],
+            }),
+          ]),
+        ),
+      ),
+    });
+
+    renderOnboarding(
+      <ModelProviderOnboardingPage
+        workspaceId={AGENT_TEST_WORKSPACE_ID}
+        onSkip={vi.fn()}
+        onConfigured={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('heading', {name: 'Choose agent harness'})).toBeVisible();
+    expect(screen.getByRole('button', {name: 'Choose pi'})).toBeVisible();
+    expect(screen.getByRole('button', {name: 'Choose Claude'})).toBeVisible();
+
+    await user.click(screen.getByRole('button', {name: 'Choose Claude'}));
+
+    expect(await screen.findByRole('button', {name: 'Configure Anthropic'})).toBeVisible();
+    expect(screen.queryByRole('button', {name: 'Configure OpenAI'})).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', {name: 'Back'}));
+    await user.click(screen.getByRole('button', {name: 'Choose pi'}));
+
+    expect(await screen.findByRole('button', {name: 'Configure Anthropic'})).toBeVisible();
+    expect(screen.getByRole('button', {name: 'Configure OpenAI'})).toBeVisible();
+  });
+
+  test('filters supported providers and clears a no-match search after choosing pi', async () => {
     const user = userEvent.setup();
     configureApiClient({
       baseUrl: 'https://api.example.test',
@@ -103,6 +144,7 @@ describe('ModelProviderOnboardingPage', () => {
         onConfigured={vi.fn()}
       />,
     );
+    await user.click(screen.getByRole('button', {name: 'Choose pi'}));
     const search = await screen.findByRole('searchbox', {name: 'Search providers'});
 
     await user.type(search, 'provider 6');
@@ -146,10 +188,10 @@ describe('ModelProviderOnboardingPage', () => {
     }
   });
 
-  test('saves the selected model provider as default in one upsert request', async () => {
+  test('saves a pi provider as default and skips the default harness request', async () => {
     const user = userEvent.setup();
     const onConfigured = vi.fn();
-    let requestBody: unknown;
+    const requestBodies: unknown[] = [];
     const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
       const request = input as Request;
       if (requestPath(input).endsWith('/agent/model-provider-catalog')) {
@@ -165,13 +207,8 @@ describe('ModelProviderOnboardingPage', () => {
         );
       }
       if (request.method === 'PUT') {
-        requestBody = await request.clone().json();
-        return jsonResponse(
-          modelProviderConfig({
-            provider_id: 'openai',
-            default_model: null,
-          }),
-        );
+        requestBodies.push(await request.clone().json());
+        return jsonResponse(modelProviderConfig({provider_id: 'openai', default_model: null}));
       }
       return jsonResponse({}, {status: 404});
     });
@@ -185,24 +222,126 @@ describe('ModelProviderOnboardingPage', () => {
       />,
     );
 
+    await user.click(screen.getByRole('button', {name: 'Choose pi'}));
     await user.click(await screen.findByRole('button', {name: 'Configure OpenAI'}));
     await user.type(await screen.findByLabelText('API key'), 'sk-proj-secret');
     await user.click(screen.getByRole('button', {name: 'Test & save'}));
 
     await waitFor(() =>
-      expect(requestBody).toEqual({
-        default_model: null,
-        credentials: {api_key: 'sk-proj-secret'},
-        set_as_default: true,
-      }),
+      expect(requestBodies).toEqual([
+        {
+          default_model: null,
+          credentials: {api_key: 'sk-proj-secret'},
+          set_as_default: true,
+        },
+      ]),
     );
     expect(onConfigured).toHaveBeenCalledTimes(1);
     expect(
-      screen.queryByRole('dialog', {name: 'Use OpenAI in a workflow'}),
-    ).not.toBeInTheDocument();
+      fetchImpl.mock.calls.some(([input]) => requestPath(input).endsWith('/agent/default-harness')),
+    ).toBe(false);
   });
 
-  test('keeps skip available when the catalog fails to load', async () => {
+  test('saves the chosen Claude harness after the provider is persisted', async () => {
+    const user = userEvent.setup();
+    const onConfigured = vi.fn();
+    const requests: Array<{path: string; body: unknown}> = [];
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const request = input as Request;
+      const path = requestPath(input);
+      if (path.endsWith('/agent/model-provider-catalog')) {
+        return jsonResponse(modelProviderCatalogResponse());
+      }
+      if (request.method === 'PUT') {
+        const body = await request.clone().json();
+        requests.push({path, body});
+        if (path.endsWith('/agent/default-harness')) {
+          return jsonResponse({default_harness_id: 'claude'});
+        }
+        return jsonResponse(modelProviderConfig());
+      }
+      return jsonResponse({}, {status: 404});
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderOnboarding(
+      <ModelProviderOnboardingPage
+        workspaceId={AGENT_TEST_WORKSPACE_ID}
+        onSkip={vi.fn()}
+        onConfigured={onConfigured}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Choose Claude'}));
+    await user.click(await screen.findByRole('button', {name: 'Configure Anthropic'}));
+    await user.type(await screen.findByLabelText('API key'), 'sk-ant-secret');
+    await user.click(screen.getByRole('button', {name: 'Test & save'}));
+
+    await waitFor(() => expect(onConfigured).toHaveBeenCalledTimes(1));
+    expect(requests).toEqual([
+      {
+        path: `/workspaces/${AGENT_TEST_WORKSPACE_ID}/agent/model-providers/anthropic`,
+        body: {
+          default_model: null,
+          credentials: {api_key: 'sk-ant-secret'},
+          set_as_default: true,
+        },
+      },
+      {
+        path: `/workspaces/${AGENT_TEST_WORKSPACE_ID}/agent/default-harness`,
+        body: {harness_id: 'claude'},
+      },
+    ]);
+  });
+
+  test('keeps the user on the page when saving the default harness fails', async () => {
+    const user = userEvent.setup();
+    const onConfigured = vi.fn();
+    let harnessAttempts = 0;
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const request = input as Request;
+      const path = requestPath(input);
+      if (path.endsWith('/agent/model-provider-catalog')) {
+        return Promise.resolve(jsonResponse(modelProviderCatalogResponse()));
+      }
+      if (request.method === 'PUT' && path.endsWith('/agent/default-harness')) {
+        harnessAttempts += 1;
+        if (harnessAttempts === 1) {
+          return Promise.resolve(jsonResponse({code: 'server-error'}, {status: 500}));
+        }
+        return Promise.resolve(jsonResponse({default_harness_id: 'claude'}));
+      }
+      if (request.method === 'PUT') {
+        return Promise.resolve(jsonResponse(modelProviderConfig()));
+      }
+      return Promise.resolve(jsonResponse({}, {status: 404}));
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderOnboarding(
+      <ModelProviderOnboardingPage
+        workspaceId={AGENT_TEST_WORKSPACE_ID}
+        onSkip={vi.fn()}
+        onConfigured={onConfigured}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Choose Claude'}));
+    await user.click(await screen.findByRole('button', {name: 'Configure Anthropic'}));
+    await user.type(await screen.findByLabelText('API key'), 'sk-ant-secret');
+    await user.click(screen.getByRole('button', {name: 'Test & save'}));
+
+    await waitFor(() => expect(harnessAttempts).toBe(1));
+    expect(await screen.findByText('Could not save default harness')).toBeVisible();
+    expect(screen.getByRole('dialog', {name: 'Configure Anthropic'})).toBeVisible();
+    expect(onConfigured).not.toHaveBeenCalled();
+
+    await user.click(within(screen.getByRole('dialog')).getByRole('button', {name: 'Test & save'}));
+
+    await waitFor(() => expect(onConfigured).toHaveBeenCalledTimes(1));
+  });
+
+  test('keeps skip available when the catalog fails to load after selecting a harness', async () => {
     const user = userEvent.setup();
     const onSkip = vi.fn();
     configureApiClient({
@@ -218,6 +357,7 @@ describe('ModelProviderOnboardingPage', () => {
       />,
     );
 
+    await user.click(screen.getByRole('button', {name: 'Choose pi'}));
     expect(await screen.findByText("Couldn't load model provider catalog")).toBeInTheDocument();
     await user.click(screen.getByRole('button', {name: 'Skip for now'}));
 

--- a/libs/client/agent/src/pages/model-provider-onboarding-page.test.tsx
+++ b/libs/client/agent/src/pages/model-provider-onboarding-page.test.tsx
@@ -114,7 +114,9 @@ describe('ModelProviderOnboardingPage', () => {
 
     expect(screen.getByRole('heading', {name: 'Choose agent harness'})).toBeVisible();
     expect(screen.getByRole('button', {name: 'Choose pi'})).toBeVisible();
+    expect(screen.getByText('Works with 30+ model providers')).toBeVisible();
     expect(screen.getByRole('button', {name: 'Choose Claude'})).toBeVisible();
+    expect(screen.getByText('Runs on your Anthropic API key')).toBeVisible();
 
     await user.click(screen.getByRole('button', {name: 'Choose Claude'}));
 

--- a/libs/client/agent/src/pages/model-provider-onboarding-page.tsx
+++ b/libs/client/agent/src/pages/model-provider-onboarding-page.tsx
@@ -1,16 +1,33 @@
-import type {ModelProviderCatalogEntryDto} from '@shipfox/api-agent-dto';
+import {
+  DEFAULT_HARNESS,
+  type Harness,
+  type HarnessDescriptor,
+  harnessSupportsProvider,
+  listHarnessDescriptors,
+  type ModelProviderCatalogEntryDto,
+} from '@shipfox/api-agent-dto';
 import {QueryLoadError} from '@shipfox/client-ui';
+import {Alert} from '@shipfox/react-ui/alert';
 import {Button} from '@shipfox/react-ui/button';
 import {EmptyState} from '@shipfox/react-ui/empty-state';
+import {Icon} from '@shipfox/react-ui/icon';
 import {Modal, ModalContent, ModalHeader, ModalTitle} from '@shipfox/react-ui/modal';
 import {Skeleton} from '@shipfox/react-ui/skeleton';
 import {toast} from '@shipfox/react-ui/toast';
 import {Header, Text} from '@shipfox/react-ui/typography';
-import {useState} from 'react';
+import {cn} from '@shipfox/react-ui/utils';
+import {useEffect, useMemo, useState} from 'react';
 import {AvailableProvidersGrid, PROVIDER_GRID_CLASS} from '#components/available-providers-grid.js';
+import {modelProviderConfigErrorToFormError} from '#components/form-errors.js';
 import {ModelProviderTestAndSaveForm} from '#components/test-and-save-form.js';
-import {useModelProviderCatalogQuery} from '#hooks/api/model-providers.js';
+import {
+  useModelProviderCatalogQuery,
+  useSetDefaultHarnessMutation,
+} from '#hooks/api/model-providers.js';
 import {dismissModelProviderOnboarding} from '#state/model-provider-onboarding.js';
+
+const SURFACE_CLASS =
+  'overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base';
 
 export function ModelProviderOnboardingPage({
   workspaceId,
@@ -22,10 +39,28 @@ export function ModelProviderOnboardingPage({
   onConfigured: () => void;
 }) {
   const catalogQuery = useModelProviderCatalogQuery();
+  const setDefaultHarness = useSetDefaultHarnessMutation();
+  const [selectedHarness, setSelectedHarness] = useState<Harness | null>(null);
   const [selectedEntry, setSelectedEntry] = useState<ModelProviderCatalogEntryDto | null>(null);
+  const [defaultHarnessError, setDefaultHarnessError] = useState<string | undefined>();
+  const [isSettingDefaultHarness, setIsSettingDefaultHarness] = useState(false);
   const supportedProviders =
     catalogQuery.data?.providers.filter((provider) => provider.support_status === 'supported') ??
     [];
+  const filteredProviders = useMemo(() => {
+    if (selectedHarness === null) return [];
+    return supportedProviders.filter((provider) =>
+      harnessSupportsProvider(selectedHarness, provider.id),
+    );
+  }, [selectedHarness, supportedProviders]);
+
+  useEffect(() => {
+    document
+      .getElementById(
+        selectedHarness === null ? 'model-provider-harness-step' : 'model-provider-provider-step',
+      )
+      ?.focus();
+  }, [selectedHarness]);
 
   function handleSkip() {
     try {
@@ -36,32 +71,89 @@ export function ModelProviderOnboardingPage({
     onSkip();
   }
 
+  async function handleProviderSaved() {
+    if (selectedEntry === null || selectedHarness === null) return;
+
+    setDefaultHarnessError(undefined);
+    if (selectedHarness === DEFAULT_HARNESS) {
+      toast.success(`${selectedEntry.label} saved`);
+      onConfigured();
+      return;
+    }
+
+    setIsSettingDefaultHarness(true);
+    try {
+      await setDefaultHarness.mutateAsync({
+        workspaceId,
+        body: {harness_id: selectedHarness},
+      });
+      toast.success(`${selectedEntry.label} saved`);
+      onConfigured();
+    } catch (error) {
+      const mapped = modelProviderConfigErrorToFormError(error);
+      setDefaultHarnessError(mapped.message || 'Could not save default harness. Try again.');
+    } finally {
+      setIsSettingDefaultHarness(false);
+    }
+  }
+
+  const selectedHarnessDescriptor =
+    selectedHarness === null
+      ? null
+      : listHarnessDescriptors().find((harness) => harness.id === selectedHarness);
+  const headingId =
+    selectedHarness === null ? 'model-provider-harness-step' : 'model-provider-provider-step';
+
   return (
     <div className="mx-auto flex w-full max-w-[640px] flex-col gap-20">
       <header className="flex flex-col gap-12">
         <div className="flex items-start justify-between gap-16 max-[520px]:flex-col max-[520px]:gap-8">
-          <Header variant="h1">Configure model provider</Header>
+          <Header id={headingId} variant="h1" tabIndex={-1} className="outline-none">
+            {selectedHarnessDescriptor
+              ? `Configure ${selectedHarnessDescriptor.label}`
+              : 'Choose agent harness'}
+          </Header>
           <Button type="button" variant="secondary" onClick={handleSkip} className="shrink-0">
             Skip for now
           </Button>
         </div>
         <Text size="md" className="text-foreground-neutral-muted">
-          Agent jobs need a model provider. Add your own API key, or skip - Shipfox runs them with
-          the instance default model provider. You can add this anytime in Settings &gt; Model
-          Providers.
+          {selectedHarnessDescriptor
+            ? `${selectedHarnessDescriptor.label} needs a compatible model provider. Add your own API key, or go back to choose a different harness.`
+            : 'A harness runs agent steps. Choose the engine you want first, then connect a compatible model provider.'}
         </Text>
       </header>
 
-      <ModelProviderPicker
-        catalogQuery={catalogQuery}
-        supportedProviders={supportedProviders}
-        onSelect={setSelectedEntry}
-      />
+      <section aria-labelledby={headingId} className="flex flex-col gap-16">
+        {selectedHarness === null ? (
+          <HarnessPicker onSelect={setSelectedHarness} />
+        ) : (
+          <>
+            <div>
+              <Button type="button" variant="transparent" onClick={() => setSelectedHarness(null)}>
+                Back
+              </Button>
+            </div>
+            <ModelProviderPicker
+              key={selectedHarness}
+              catalogQuery={catalogQuery}
+              supportedProviders={filteredProviders}
+              onSelect={(entry) => {
+                setDefaultHarnessError(undefined);
+                setSelectedEntry(entry);
+              }}
+            />
+          </>
+        )}
+      </section>
 
       <Modal
         open={selectedEntry !== null}
         onOpenChange={(open) => {
-          if (!open) setSelectedEntry(null);
+          if (!open && !isSettingDefaultHarness) {
+            setSelectedEntry(null);
+            setDefaultHarnessError(undefined);
+          }
         }}
       >
         <ModalContent aria-describedby={undefined}>
@@ -77,20 +169,81 @@ export function ModelProviderOnboardingPage({
               {selectedEntry ? `Configure ${selectedEntry.label}` : ''}
             </Text>
           </ModalHeader>
+          {isSettingDefaultHarness ? (
+            <div role="status" className="px-20 pb-8">
+              <Text size="sm" className="text-foreground-neutral-muted">
+                Saving harness default...
+              </Text>
+            </div>
+          ) : null}
+          {defaultHarnessError ? (
+            <div className="px-20 pb-8">
+              <Alert variant="error" animated={false}>
+                <div className="flex flex-col gap-8">
+                  <Text size="sm" bold>
+                    Could not save default harness
+                  </Text>
+                  <Text size="sm">{defaultHarnessError}</Text>
+                </div>
+              </Alert>
+            </div>
+          ) : null}
           {selectedEntry ? (
             <ModelProviderTestAndSaveForm
               workspaceId={workspaceId}
               entry={selectedEntry}
               setAsDefaultOnSave
               onSaved={() => {
-                toast.success(`${selectedEntry.label} saved`);
-                onConfigured();
+                void handleProviderSaved();
               }}
             />
           ) : null}
         </ModalContent>
       </Modal>
     </div>
+  );
+}
+
+function HarnessPicker({onSelect}: {onSelect: (harness: Harness) => void}) {
+  return (
+    <ul className={PROVIDER_GRID_CLASS} aria-label="Agent harnesses">
+      {listHarnessDescriptors().map((harness) => (
+        <HarnessCard key={harness.id} harness={harness} onChoose={() => onSelect(harness.id)} />
+      ))}
+    </ul>
+  );
+}
+
+function HarnessCard({harness, onChoose}: {harness: HarnessDescriptor; onChoose: () => void}) {
+  return (
+    <li>
+      <button
+        type="button"
+        className={cn(
+          'group block w-full cursor-pointer p-16 text-left outline-none transition-colors hover:bg-background-components-hover focus-visible:shadow-button-neutral-focus',
+          SURFACE_CLASS,
+        )}
+        aria-label={`Choose ${harness.label}`}
+        onClick={onChoose}
+      >
+        <div className="flex min-w-0 items-center justify-between gap-12">
+          <div className="flex min-w-0 flex-col gap-4">
+            <Text size="md" bold className="min-w-0 truncate">
+              {harness.label}
+            </Text>
+            <Text size="sm" className="text-foreground-neutral-muted">
+              {harness.id === 'claude'
+                ? 'Runs on your Anthropic API key'
+                : 'Works with 30+ model providers'}
+            </Text>
+          </div>
+          <div className="flex shrink-0 items-center gap-4 text-foreground-neutral-muted transition-colors group-hover:text-foreground-highlight-interactive">
+            <Text size="sm">Choose</Text>
+            <Icon name="chevronRight" className="size-16" />
+          </div>
+        </div>
+      </button>
+    </li>
   );
 }
 

--- a/libs/client/agent/src/pages/model-provider-onboarding-page.tsx
+++ b/libs/client/agent/src/pages/model-provider-onboarding-page.tsx
@@ -232,9 +232,7 @@ function HarnessCard({harness, onChoose}: {harness: HarnessDescriptor; onChoose:
               {harness.label}
             </Text>
             <Text size="sm" className="text-foreground-neutral-muted">
-              {harness.id === 'claude'
-                ? 'Runs on your Anthropic API key'
-                : 'Works with 30+ model providers'}
+              {harness.description}
             </Text>
           </div>
           <div className="flex shrink-0 items-center gap-4 text-foreground-neutral-muted transition-colors group-hover:text-foreground-highlight-interactive">

--- a/libs/client/agent/test/fixtures/model-providers.ts
+++ b/libs/client/agent/test/fixtures/model-providers.ts
@@ -1,4 +1,5 @@
 import type {
+  CustomModelProviderConfigDto,
   ListModelProviderConfigsResponseDto,
   ModelProviderCatalogEntryDto,
   ModelProviderCatalogResponseDto,
@@ -67,6 +68,25 @@ export function modelProviderConfig(
     kind: 'builtin',
     provider_id: 'anthropic',
     default_model: null,
+    created_at: '2026-05-08T00:00:00.000Z',
+    updated_at: '2026-05-08T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+export function customModelProviderConfig(
+  overrides: Partial<Omit<CustomModelProviderConfigDto, 'kind'>> = {},
+): CustomModelProviderConfigDto {
+  return {
+    kind: 'custom',
+    provider_id: 'openai-compatible',
+    display_name: 'OpenAI Compatible',
+    base_url: 'https://models.example.test/v1',
+    api: 'openai-responses',
+    headers: [],
+    secret_header_names: [],
+    default_model: 'custom-model',
+    models: [{id: 'custom-model', label: 'Custom Model'}],
     created_at: '2026-05-08T00:00:00.000Z',
     updated_at: '2026-05-08T00:00:00.000Z',
     ...overrides,

--- a/libs/client/projects/src/components/model-provider-reminder-banner.tsx
+++ b/libs/client/projects/src/components/model-provider-reminder-banner.tsx
@@ -42,8 +42,8 @@ export function ModelProviderReminderBanner({workspaceId}: {workspaceId: string}
         </AlertDescription>
         <AlertActions>
           <Button asChild size="sm" variant="secondary">
-            <Link to="/workspaces/$wid/settings/model-providers" params={{wid: workspaceId}}>
-              Model Providers
+            <Link to="/workspaces/$wid/settings/agents" params={{wid: workspaceId}}>
+              Agents
             </Link>
           </Button>
         </AlertActions>

--- a/libs/client/projects/src/components/workspace-setup-guard.test.tsx
+++ b/libs/client/projects/src/components/workspace-setup-guard.test.tsx
@@ -126,7 +126,7 @@ function renderSetupRoute(
     guardedRoute('/workspaces/$wid/integrations', 'VCS onboarding'),
     guardedRoute('/workspaces/$wid/integrations/gitea', 'Gitea install'),
     guardedRoute('/workspaces/$wid/projects/new', 'Create project'),
-    guardedRoute('/workspaces/$wid/settings/model-providers', 'Settings model providers'),
+    guardedRoute('/workspaces/$wid/settings/agents', 'Settings agents'),
     guardedRoute('/workspaces/$wid/settings/integrations', 'Settings integrations'),
   ]);
   const router = createRouter({
@@ -284,7 +284,7 @@ describe('workspace setup route hook', () => {
 
   test('keeps model provider settings available before first project creation', async () => {
     renderSetupRoute(
-      `/workspaces/${WORKSPACE_ID}/settings/model-providers`,
+      `/workspaces/${WORKSPACE_ID}/settings/agents`,
       setupFetch({
         connections: [sourceConnection()],
         providerConfigs: [],
@@ -292,7 +292,7 @@ describe('workspace setup route hook', () => {
       }),
     );
 
-    expect(await screen.findByText('Settings model providers')).toBeInTheDocument();
+    expect(await screen.findByText('Settings agents')).toBeInTheDocument();
     expect(screen.getByTestId('project-navigation')).toHaveTextContent('hidden');
   });
 

--- a/libs/client/projects/src/components/workspace-setup-guard.tsx
+++ b/libs/client/projects/src/components/workspace-setup-guard.tsx
@@ -72,7 +72,7 @@ export async function loadWorkspaceSetupRoute({
     });
   }
 
-  if (isModelProviderSettingsPath(normalizedPathname, workspaceId)) {
+  if (isAgentSettingsPath(normalizedPathname, workspaceId)) {
     return {hideProjectNavigation: true};
   }
 
@@ -262,6 +262,6 @@ function isModelProviderOnboardingPath(pathname: string, workspaceId: string) {
   return pathname === workspacePath(workspaceId, '/model-provider');
 }
 
-function isModelProviderSettingsPath(pathname: string, workspaceId: string) {
-  return pathname === workspacePath(workspaceId, '/settings/model-providers');
+function isAgentSettingsPath(pathname: string, workspaceId: string) {
+  return pathname === workspacePath(workspaceId, '/settings/agents');
 }

--- a/libs/client/projects/src/pages/create-project-page.stories.tsx
+++ b/libs/client/projects/src/pages/create-project-page.stories.tsx
@@ -125,7 +125,7 @@ function createStoryRouter() {
   });
   const modelProvidersRoute = createRoute({
     getParentRoute: () => workspaceRoute,
-    path: 'settings/model-providers',
+    path: 'settings/agents',
     component: () => <div />,
   });
   const projectRoute = createRoute({

--- a/libs/client/projects/src/pages/create-project-page.test.tsx
+++ b/libs/client/projects/src/pages/create-project-page.test.tsx
@@ -178,9 +178,9 @@ describe('CreateProjectPage', () => {
     renderProjectPage(`/workspaces/${PROJECT_TEST_WID}/projects/new`, <CreateProjectPage />);
 
     expect(await screen.findByText('Finish setting up a model provider')).toBeInTheDocument();
-    expect(screen.getByRole('link', {name: 'Model Providers'})).toHaveAttribute(
+    expect(screen.getByRole('link', {name: 'Agents'})).toHaveAttribute(
       'href',
-      `/workspaces/${PROJECT_TEST_WID}/settings/model-providers`,
+      `/workspaces/${PROJECT_TEST_WID}/settings/agents`,
     );
   });
 

--- a/libs/client/projects/src/pages/projects-hub-page.test.tsx
+++ b/libs/client/projects/src/pages/projects-hub-page.test.tsx
@@ -47,9 +47,9 @@ describe('ProjectsHubPage', () => {
     renderProjectPage(`/workspaces/${PROJECT_TEST_WID}`, <ProjectsHubPage />);
 
     expect(await screen.findByText('Finish setting up a model provider')).toBeInTheDocument();
-    expect(screen.getByRole('link', {name: 'Model Providers'})).toHaveAttribute(
+    expect(screen.getByRole('link', {name: 'Agents'})).toHaveAttribute(
       'href',
-      `/workspaces/${PROJECT_TEST_WID}/settings/model-providers`,
+      `/workspaces/${PROJECT_TEST_WID}/settings/agents`,
     );
     fireEvent.click(screen.getByRole('button', {name: 'Close'}));
 

--- a/libs/client/projects/test/pages.tsx
+++ b/libs/client/projects/test/pages.tsx
@@ -87,8 +87,8 @@ function createTestRouter(path: string, element: ReactElement) {
   });
   const modelProviderSettingsRoute = createRoute({
     getParentRoute: () => rootRoute,
-    path: '/workspaces/$wid/settings/model-providers',
-    component: () => <div>Model provider settings placeholder</div>,
+    path: '/workspaces/$wid/settings/agents',
+    component: () => <div>Agent settings placeholder</div>,
   });
   const projectDetailRoute = createRoute({
     getParentRoute: () => rootRoute,

--- a/libs/client/router/src/routeTree.gen.ts
+++ b/libs/client/router/src/routeTree.gen.ts
@@ -29,10 +29,10 @@ import { Route as WorkspacesWidLayoutSettingsVariablesRouteImport } from './rout
 import { Route as WorkspacesWidLayoutSettingsSecretsRouteImport } from './routes/workspaces/$wid/_layout/settings/secrets'
 import { Route as WorkspacesWidLayoutSettingsRunnersRouteImport } from './routes/workspaces/$wid/_layout/settings/runners'
 import { Route as WorkspacesWidLayoutSettingsProvisionersRouteImport } from './routes/workspaces/$wid/_layout/settings/provisioners'
-import { Route as WorkspacesWidLayoutSettingsModelProvidersRouteImport } from './routes/workspaces/$wid/_layout/settings/model-providers'
 import { Route as WorkspacesWidLayoutSettingsMembersRouteImport } from './routes/workspaces/$wid/_layout/settings/members'
 import { Route as WorkspacesWidLayoutSettingsIntegrationsRouteImport } from './routes/workspaces/$wid/_layout/settings/integrations'
 import { Route as WorkspacesWidLayoutSettingsEventsRouteImport } from './routes/workspaces/$wid/_layout/settings/events'
+import { Route as WorkspacesWidLayoutSettingsAgentsRouteImport } from './routes/workspaces/$wid/_layout/settings/agents'
 import { Route as WorkspacesWidLayoutProjectsNewRouteImport } from './routes/workspaces/$wid/_layout/projects/new'
 import { Route as WorkspacesWidLayoutIntegrationsSentryRouteImport } from './routes/workspaces/$wid/_layout/integrations/sentry'
 import { Route as WorkspacesWidLayoutIntegrationsGithubRouteImport } from './routes/workspaces/$wid/_layout/integrations/github'
@@ -154,12 +154,6 @@ const WorkspacesWidLayoutSettingsProvisionersRoute =
     path: '/settings/provisioners',
     getParentRoute: () => WorkspacesWidLayoutRoute,
   } as any)
-const WorkspacesWidLayoutSettingsModelProvidersRoute =
-  WorkspacesWidLayoutSettingsModelProvidersRouteImport.update({
-    id: '/settings/model-providers',
-    path: '/settings/model-providers',
-    getParentRoute: () => WorkspacesWidLayoutRoute,
-  } as any)
 const WorkspacesWidLayoutSettingsMembersRoute =
   WorkspacesWidLayoutSettingsMembersRouteImport.update({
     id: '/settings/members',
@@ -176,6 +170,12 @@ const WorkspacesWidLayoutSettingsEventsRoute =
   WorkspacesWidLayoutSettingsEventsRouteImport.update({
     id: '/settings/events',
     path: '/settings/events',
+    getParentRoute: () => WorkspacesWidLayoutRoute,
+  } as any)
+const WorkspacesWidLayoutSettingsAgentsRoute =
+  WorkspacesWidLayoutSettingsAgentsRouteImport.update({
+    id: '/settings/agents',
+    path: '/settings/agents',
     getParentRoute: () => WorkspacesWidLayoutRoute,
   } as any)
 const WorkspacesWidLayoutProjectsNewRoute =
@@ -252,10 +252,10 @@ export interface FileRoutesByFullPath {
   '/workspaces/$wid/integrations/github': typeof WorkspacesWidLayoutIntegrationsGithubRoute
   '/workspaces/$wid/integrations/sentry': typeof WorkspacesWidLayoutIntegrationsSentryRoute
   '/workspaces/$wid/projects/new': typeof WorkspacesWidLayoutProjectsNewRoute
+  '/workspaces/$wid/settings/agents': typeof WorkspacesWidLayoutSettingsAgentsRoute
   '/workspaces/$wid/settings/events': typeof WorkspacesWidLayoutSettingsEventsRoute
   '/workspaces/$wid/settings/integrations': typeof WorkspacesWidLayoutSettingsIntegrationsRoute
   '/workspaces/$wid/settings/members': typeof WorkspacesWidLayoutSettingsMembersRoute
-  '/workspaces/$wid/settings/model-providers': typeof WorkspacesWidLayoutSettingsModelProvidersRoute
   '/workspaces/$wid/settings/provisioners': typeof WorkspacesWidLayoutSettingsProvisionersRoute
   '/workspaces/$wid/settings/runners': typeof WorkspacesWidLayoutSettingsRunnersRoute
   '/workspaces/$wid/settings/secrets': typeof WorkspacesWidLayoutSettingsSecretsRoute
@@ -286,10 +286,10 @@ export interface FileRoutesByTo {
   '/workspaces/$wid/integrations/github': typeof WorkspacesWidLayoutIntegrationsGithubRoute
   '/workspaces/$wid/integrations/sentry': typeof WorkspacesWidLayoutIntegrationsSentryRoute
   '/workspaces/$wid/projects/new': typeof WorkspacesWidLayoutProjectsNewRoute
+  '/workspaces/$wid/settings/agents': typeof WorkspacesWidLayoutSettingsAgentsRoute
   '/workspaces/$wid/settings/events': typeof WorkspacesWidLayoutSettingsEventsRoute
   '/workspaces/$wid/settings/integrations': typeof WorkspacesWidLayoutSettingsIntegrationsRoute
   '/workspaces/$wid/settings/members': typeof WorkspacesWidLayoutSettingsMembersRoute
-  '/workspaces/$wid/settings/model-providers': typeof WorkspacesWidLayoutSettingsModelProvidersRoute
   '/workspaces/$wid/settings/provisioners': typeof WorkspacesWidLayoutSettingsProvisionersRoute
   '/workspaces/$wid/settings/runners': typeof WorkspacesWidLayoutSettingsRunnersRoute
   '/workspaces/$wid/settings/secrets': typeof WorkspacesWidLayoutSettingsSecretsRoute
@@ -321,10 +321,10 @@ export interface FileRoutesById {
   '/workspaces/$wid/_layout/integrations/github': typeof WorkspacesWidLayoutIntegrationsGithubRoute
   '/workspaces/$wid/_layout/integrations/sentry': typeof WorkspacesWidLayoutIntegrationsSentryRoute
   '/workspaces/$wid/_layout/projects/new': typeof WorkspacesWidLayoutProjectsNewRoute
+  '/workspaces/$wid/_layout/settings/agents': typeof WorkspacesWidLayoutSettingsAgentsRoute
   '/workspaces/$wid/_layout/settings/events': typeof WorkspacesWidLayoutSettingsEventsRoute
   '/workspaces/$wid/_layout/settings/integrations': typeof WorkspacesWidLayoutSettingsIntegrationsRoute
   '/workspaces/$wid/_layout/settings/members': typeof WorkspacesWidLayoutSettingsMembersRoute
-  '/workspaces/$wid/_layout/settings/model-providers': typeof WorkspacesWidLayoutSettingsModelProvidersRoute
   '/workspaces/$wid/_layout/settings/provisioners': typeof WorkspacesWidLayoutSettingsProvisionersRoute
   '/workspaces/$wid/_layout/settings/runners': typeof WorkspacesWidLayoutSettingsRunnersRoute
   '/workspaces/$wid/_layout/settings/secrets': typeof WorkspacesWidLayoutSettingsSecretsRoute
@@ -358,10 +358,10 @@ export interface FileRouteTypes {
     | '/workspaces/$wid/integrations/github'
     | '/workspaces/$wid/integrations/sentry'
     | '/workspaces/$wid/projects/new'
+    | '/workspaces/$wid/settings/agents'
     | '/workspaces/$wid/settings/events'
     | '/workspaces/$wid/settings/integrations'
     | '/workspaces/$wid/settings/members'
-    | '/workspaces/$wid/settings/model-providers'
     | '/workspaces/$wid/settings/provisioners'
     | '/workspaces/$wid/settings/runners'
     | '/workspaces/$wid/settings/secrets'
@@ -392,10 +392,10 @@ export interface FileRouteTypes {
     | '/workspaces/$wid/integrations/github'
     | '/workspaces/$wid/integrations/sentry'
     | '/workspaces/$wid/projects/new'
+    | '/workspaces/$wid/settings/agents'
     | '/workspaces/$wid/settings/events'
     | '/workspaces/$wid/settings/integrations'
     | '/workspaces/$wid/settings/members'
-    | '/workspaces/$wid/settings/model-providers'
     | '/workspaces/$wid/settings/provisioners'
     | '/workspaces/$wid/settings/runners'
     | '/workspaces/$wid/settings/secrets'
@@ -426,10 +426,10 @@ export interface FileRouteTypes {
     | '/workspaces/$wid/_layout/integrations/github'
     | '/workspaces/$wid/_layout/integrations/sentry'
     | '/workspaces/$wid/_layout/projects/new'
+    | '/workspaces/$wid/_layout/settings/agents'
     | '/workspaces/$wid/_layout/settings/events'
     | '/workspaces/$wid/_layout/settings/integrations'
     | '/workspaces/$wid/_layout/settings/members'
-    | '/workspaces/$wid/_layout/settings/model-providers'
     | '/workspaces/$wid/_layout/settings/provisioners'
     | '/workspaces/$wid/_layout/settings/runners'
     | '/workspaces/$wid/_layout/settings/secrets'
@@ -599,13 +599,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof WorkspacesWidLayoutSettingsProvisionersRouteImport
       parentRoute: typeof WorkspacesWidLayoutRoute
     }
-    '/workspaces/$wid/_layout/settings/model-providers': {
-      id: '/workspaces/$wid/_layout/settings/model-providers'
-      path: '/settings/model-providers'
-      fullPath: '/workspaces/$wid/settings/model-providers'
-      preLoaderRoute: typeof WorkspacesWidLayoutSettingsModelProvidersRouteImport
-      parentRoute: typeof WorkspacesWidLayoutRoute
-    }
     '/workspaces/$wid/_layout/settings/members': {
       id: '/workspaces/$wid/_layout/settings/members'
       path: '/settings/members'
@@ -625,6 +618,13 @@ declare module '@tanstack/react-router' {
       path: '/settings/events'
       fullPath: '/workspaces/$wid/settings/events'
       preLoaderRoute: typeof WorkspacesWidLayoutSettingsEventsRouteImport
+      parentRoute: typeof WorkspacesWidLayoutRoute
+    }
+    '/workspaces/$wid/_layout/settings/agents': {
+      id: '/workspaces/$wid/_layout/settings/agents'
+      path: '/settings/agents'
+      fullPath: '/workspaces/$wid/settings/agents'
+      preLoaderRoute: typeof WorkspacesWidLayoutSettingsAgentsRouteImport
       parentRoute: typeof WorkspacesWidLayoutRoute
     }
     '/workspaces/$wid/_layout/projects/new': {
@@ -736,10 +736,10 @@ interface WorkspacesWidLayoutRouteChildren {
   WorkspacesWidLayoutIntegrationsGithubRoute: typeof WorkspacesWidLayoutIntegrationsGithubRoute
   WorkspacesWidLayoutIntegrationsSentryRoute: typeof WorkspacesWidLayoutIntegrationsSentryRoute
   WorkspacesWidLayoutProjectsNewRoute: typeof WorkspacesWidLayoutProjectsNewRoute
+  WorkspacesWidLayoutSettingsAgentsRoute: typeof WorkspacesWidLayoutSettingsAgentsRoute
   WorkspacesWidLayoutSettingsEventsRoute: typeof WorkspacesWidLayoutSettingsEventsRoute
   WorkspacesWidLayoutSettingsIntegrationsRoute: typeof WorkspacesWidLayoutSettingsIntegrationsRoute
   WorkspacesWidLayoutSettingsMembersRoute: typeof WorkspacesWidLayoutSettingsMembersRoute
-  WorkspacesWidLayoutSettingsModelProvidersRoute: typeof WorkspacesWidLayoutSettingsModelProvidersRoute
   WorkspacesWidLayoutSettingsProvisionersRoute: typeof WorkspacesWidLayoutSettingsProvisionersRoute
   WorkspacesWidLayoutSettingsRunnersRoute: typeof WorkspacesWidLayoutSettingsRunnersRoute
   WorkspacesWidLayoutSettingsSecretsRoute: typeof WorkspacesWidLayoutSettingsSecretsRoute
@@ -759,14 +759,14 @@ const WorkspacesWidLayoutRouteChildren: WorkspacesWidLayoutRouteChildren = {
   WorkspacesWidLayoutIntegrationsSentryRoute:
     WorkspacesWidLayoutIntegrationsSentryRoute,
   WorkspacesWidLayoutProjectsNewRoute: WorkspacesWidLayoutProjectsNewRoute,
+  WorkspacesWidLayoutSettingsAgentsRoute:
+    WorkspacesWidLayoutSettingsAgentsRoute,
   WorkspacesWidLayoutSettingsEventsRoute:
     WorkspacesWidLayoutSettingsEventsRoute,
   WorkspacesWidLayoutSettingsIntegrationsRoute:
     WorkspacesWidLayoutSettingsIntegrationsRoute,
   WorkspacesWidLayoutSettingsMembersRoute:
     WorkspacesWidLayoutSettingsMembersRoute,
-  WorkspacesWidLayoutSettingsModelProvidersRoute:
-    WorkspacesWidLayoutSettingsModelProvidersRoute,
   WorkspacesWidLayoutSettingsProvisionersRoute:
     WorkspacesWidLayoutSettingsProvisionersRoute,
   WorkspacesWidLayoutSettingsRunnersRoute:

--- a/libs/client/router/src/routes/workspaces/$wid/_layout/settings/agents.tsx
+++ b/libs/client/router/src/routes/workspaces/$wid/_layout/settings/agents.tsx
@@ -1,6 +1,6 @@
 import {ModelProvidersSettingsPage} from '@shipfox/client-workspace-settings';
 import {createFileRoute} from '@tanstack/react-router';
 
-export const Route = createFileRoute('/workspaces/$wid/_layout/settings/model-providers')({
+export const Route = createFileRoute('/workspaces/$wid/_layout/settings/agents')({
   component: ModelProvidersSettingsPage,
 });

--- a/libs/client/workflows/src/components/step-list/step-list.stories.tsx
+++ b/libs/client/workflows/src/components/step-list/step-list.stories.tsx
@@ -22,7 +22,7 @@ import {AgentConfigFailureCallout as AgentConfigFailureCalloutView} from '../wor
 import {StepList} from './step-list.js';
 
 const WORKSPACE_ID = '44444444-4444-4444-8444-444444444444';
-const MODEL_PROVIDERS_LINK_NAME = 'Configure Model Providers';
+const AGENTS_LINK_NAME = 'Configure Agents';
 
 const meta = {
   title: 'Workflows/StepList',
@@ -61,21 +61,21 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 type StepListStoryContext = Parameters<NonNullable<Story['play']>>[0];
 
-const withModelProviderSettingsRoute: Decorator = (Story) => {
+const withAgentSettingsRoute: Decorator = (Story) => {
   const rootRoute = createRootRoute({component: Outlet});
   const storyRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/',
     component: () => <Story />,
   });
-  const modelProviderSettingsRoute = createRoute({
+  const agentSettingsRoute = createRoute({
     getParentRoute: () => rootRoute,
-    path: '/workspaces/$wid/settings/model-providers',
+    path: '/workspaces/$wid/settings/agents',
     component: () => null,
   });
   const router = createRouter({
     history: createMemoryHistory({initialEntries: ['/']}),
-    routeTree: rootRoute.addChildren([storyRoute, modelProviderSettingsRoute]),
+    routeTree: rootRoute.addChildren([storyRoute, agentSettingsRoute]),
   });
 
   return <RouterProvider router={router} />;
@@ -85,7 +85,7 @@ async function assertAgentConfigFailureCallout(ctx: StepListStoryContext) {
   const canvas = within(ctx.canvasElement);
 
   await canvas.findByText('Configure credentials for anthropic');
-  await canvas.findByRole('link', {name: MODEL_PROVIDERS_LINK_NAME});
+  await canvas.findByRole('link', {name: AGENTS_LINK_NAME});
 }
 
 export const Playground: Story = {};
@@ -303,7 +303,7 @@ export const ExpandedSlot: Story = {
 };
 
 export const TestAgentConfigFailureCallout: Story = {
-  decorators: [withModelProviderSettingsRoute],
+  decorators: [withAgentSettingsRoute],
   render: renderAgentConfigFailureCallout,
   play: assertAgentConfigFailureCallout,
 };

--- a/libs/client/workflows/src/components/workflow-run-view/agent-config-failure-callout.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/agent-config-failure-callout.stories.tsx
@@ -13,7 +13,7 @@ import type {AgentStepConfig, StepError} from '#core/workflow-run.js';
 import {AgentConfigFailureCallout} from './agent-config-failure-callout.js';
 
 const WORKSPACE_ID = '44444444-4444-4444-8444-444444444444';
-const MODEL_PROVIDERS_LINK_NAME = 'Configure Model Providers';
+const AGENTS_LINK_NAME = 'Configure Agents';
 
 const config: AgentStepConfig = {
   provider: 'anthropic',
@@ -40,14 +40,14 @@ const meta = {
         path: '/',
         component: () => <Story />,
       });
-      const modelProviderSettingsRoute = createRoute({
+      const agentSettingsRoute = createRoute({
         getParentRoute: () => rootRoute,
-        path: '/workspaces/$wid/settings/model-providers',
+        path: '/workspaces/$wid/settings/agents',
         component: () => null,
       });
       const router = createRouter({
         history: createMemoryHistory({initialEntries: ['/']}),
-        routeTree: rootRoute.addChildren([storyRoute, modelProviderSettingsRoute]),
+        routeTree: rootRoute.addChildren([storyRoute, agentSettingsRoute]),
       });
 
       return <RouterProvider router={router} />;
@@ -130,11 +130,11 @@ function assertCallout(title: string, showsCta: boolean): Story['play'] {
     const canvas = within(canvasElement);
 
     await canvas.findByText(title);
-    const cta = canvas.queryByRole('link', {name: MODEL_PROVIDERS_LINK_NAME});
+    const cta = canvas.queryByRole('link', {name: AGENTS_LINK_NAME});
     if (showsCta) {
-      await canvas.findByRole('link', {name: MODEL_PROVIDERS_LINK_NAME});
+      await canvas.findByRole('link', {name: AGENTS_LINK_NAME});
     } else if (cta !== null) {
-      throw new Error(`Unexpected ${MODEL_PROVIDERS_LINK_NAME} CTA`);
+      throw new Error(`Unexpected ${AGENTS_LINK_NAME} CTA`);
     }
   };
 }

--- a/libs/client/workflows/src/components/workflow-run-view/agent-config-failure-callout.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/agent-config-failure-callout.tsx
@@ -28,8 +28,8 @@ export function AgentConfigFailureCallout({
         {copy.showProviderCta ? (
           <AlertActions>
             <Button asChild size="2xs" variant="secondary" iconRight="chevronRight">
-              <Link to="/workspaces/$wid/settings/model-providers" params={{wid: workspaceId}}>
-                Configure Model Providers
+              <Link to="/workspaces/$wid/settings/agents" params={{wid: workspaceId}}>
+                Configure Agents
               </Link>
             </Button>
           </AlertActions>
@@ -50,13 +50,13 @@ function agentConfigFailureCopy(
     case 'provider_not_configured':
       return {
         title: `Configure credentials for ${provider}`,
-        description: `This step uses ${provider}, but no workspace credentials are configured for that model provider. Configure ${provider} in Model Providers, then re-run the workflow.`,
+        description: `This step uses ${provider}, but no workspace credentials are configured for that model provider. Configure ${provider} in Agents, then re-run the workflow.`,
         showProviderCta: true,
       };
     case 'credentials_invalid':
       return {
         title: `Update credentials for ${provider}`,
-        description: `This step uses ${provider}, but the saved credentials could not be used. Reconfigure ${provider} in Model Providers, then re-run the workflow.`,
+        description: `This step uses ${provider}, but the saved credentials could not be used. Reconfigure ${provider} in Agents, then re-run the workflow.`,
         showProviderCta: true,
       };
     case 'provider_unsupported':
@@ -82,7 +82,7 @@ function agentConfigFailureCopy(
       return {
         title: "We couldn't load the agent configuration for this step",
         description:
-          'Make sure the step has a prompt, provider, model, and thinking value. Then configure credentials for the model provider in Model Providers and re-run the workflow.',
+          'Make sure the step has a prompt, provider, model, and thinking value. Then configure credentials for the model provider in Agents and re-run the workflow.',
         showProviderCta: true,
       };
   }

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -296,12 +296,12 @@ describe('WorkflowRunView', () => {
     expect(screen.getByText('Configure credentials for the selected provider')).toBeInTheDocument();
     expect(
       screen.getByText(
-        'This step uses the selected provider, but no workspace credentials are configured for that model provider. Configure the selected provider in Model Providers, then re-run the workflow.',
+        'This step uses the selected provider, but no workspace credentials are configured for that model provider. Configure the selected provider in Agents, then re-run the workflow.',
       ),
     ).toBeInTheDocument();
-    expect(screen.getByRole('link', {name: 'Configure Model Providers'})).toHaveAttribute(
+    expect(screen.getByRole('link', {name: 'Configure Agents'})).toHaveAttribute(
       'href',
-      `/workspaces/${PROJECT_TEST_WID}/settings/model-providers`,
+      `/workspaces/${PROJECT_TEST_WID}/settings/agents`,
     );
   });
 
@@ -376,9 +376,9 @@ describe('WorkflowRunView', () => {
     expect(screen.queryByText('claude-opus-4-8')).not.toBeInTheDocument();
     expect(screen.queryByText('high')).not.toBeInTheDocument();
     expect(screen.getByText('Configure credentials for the selected provider')).toBeInTheDocument();
-    expect(screen.getByRole('link', {name: 'Configure Model Providers'})).toHaveAttribute(
+    expect(screen.getByRole('link', {name: 'Configure Agents'})).toHaveAttribute(
       'href',
-      `/workspaces/${PROJECT_TEST_WID}/settings/model-providers`,
+      `/workspaces/${PROJECT_TEST_WID}/settings/agents`,
     );
   });
 

--- a/libs/client/workflows/test/pages.tsx
+++ b/libs/client/workflows/test/pages.tsx
@@ -47,8 +47,8 @@ function createTestRouter(
   });
   const modelProviderSettingsRoute = createRoute({
     getParentRoute: () => rootRoute,
-    path: '/workspaces/$wid/settings/model-providers',
-    component: () => <div>Model provider settings placeholder</div>,
+    path: '/workspaces/$wid/settings/agents',
+    component: () => <div>Agent settings placeholder</div>,
   });
 
   return createRouter({

--- a/libs/client/workspace-settings/src/components/settings-nav.tsx
+++ b/libs/client/workspace-settings/src/components/settings-nav.tsx
@@ -13,8 +13,8 @@ export function SettingsNav({workspaceId}: {workspaceId: string}) {
   const isProvisionersActive = Boolean(
     matchRoute({to: '/workspaces/$wid/settings/provisioners', params: {wid: workspaceId}}),
   );
-  const isModelProvidersActive = Boolean(
-    matchRoute({to: '/workspaces/$wid/settings/model-providers', params: {wid: workspaceId}}),
+  const isAgentsActive = Boolean(
+    matchRoute({to: '/workspaces/$wid/settings/agents', params: {wid: workspaceId}}),
   );
   const isSecretsActive = Boolean(
     matchRoute({to: '/workspaces/$wid/settings/secrets', params: {wid: workspaceId}}),
@@ -75,16 +75,16 @@ export function SettingsNav({workspaceId}: {workspaceId: string}) {
       </Button>
       <Button
         asChild
-        variant={isModelProvidersActive ? 'secondary' : 'transparent'}
+        variant={isAgentsActive ? 'secondary' : 'transparent'}
         className="w-full justify-start"
       >
         <Link
-          to="/workspaces/$wid/settings/model-providers"
+          to="/workspaces/$wid/settings/agents"
           params={{wid: workspaceId}}
-          aria-current={isModelProvidersActive ? 'page' : undefined}
+          aria-current={isAgentsActive ? 'page' : undefined}
         >
           <Icon name="robot2Line" className="size-16" />
-          Model providers
+          Agents
         </Link>
       </Button>
       <Button

--- a/libs/client/workspace-settings/src/pages/model-providers-settings-page.test.tsx
+++ b/libs/client/workspace-settings/src/pages/model-providers-settings-page.test.tsx
@@ -35,7 +35,7 @@ describe('ModelProvidersSettingsPage', () => {
     configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
 
     renderWorkspaceSettingsPage(
-      `/workspaces/${WORKSPACE_SETTINGS_TEST_WID}/settings/model-providers`,
+      `/workspaces/${WORKSPACE_SETTINGS_TEST_WID}/settings/agents`,
       <ModelProvidersSettingsPage />,
     );
 

--- a/libs/client/workspace-settings/src/pages/model-providers-settings-page.test.tsx
+++ b/libs/client/workspace-settings/src/pages/model-providers-settings-page.test.tsx
@@ -9,24 +9,29 @@ import {ModelProvidersSettingsPage} from './model-providers-settings-page.js';
 
 describe('ModelProvidersSettingsPage', () => {
   test('renders the settings shell and model providers section', async () => {
-    const fetchImpl = vi
-      .fn()
-      .mockResolvedValueOnce(
-        jsonResponse({
-          providers: [
-            {
-              id: 'anthropic',
-              label: 'Anthropic',
-              support_status: 'supported',
-              default_model: 'claude-opus-4-8',
-              credential_fields: [{key: 'api_key', label: 'API key', secret: true}],
-              unsupported_reason: null,
-              models: [{id: 'claude-opus-4-8', label: 'Claude Opus 4.8'}],
-            },
-          ],
-        }),
-      )
-      .mockResolvedValueOnce(jsonResponse({configs: [], default_provider_id: null}));
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const url = new URL((input as Request).url);
+      if (url.pathname.endsWith('/agent/model-provider-catalog')) {
+        return Promise.resolve(
+          jsonResponse({
+            providers: [
+              {
+                id: 'anthropic',
+                label: 'Anthropic',
+                support_status: 'supported',
+                default_model: 'claude-opus-4-8',
+                credential_fields: [{key: 'api_key', label: 'API key', secret: true}],
+                unsupported_reason: null,
+                models: [{id: 'claude-opus-4-8', label: 'Claude Opus 4.8'}],
+              },
+            ],
+          }),
+        );
+      }
+      return Promise.resolve(
+        jsonResponse({configs: [], default_provider_id: null, default_harness_id: null}),
+      );
+    });
     configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
 
     renderWorkspaceSettingsPage(
@@ -35,6 +40,7 @@ describe('ModelProvidersSettingsPage', () => {
     );
 
     expect(await screen.findByRole('heading', {name: 'Workspace settings'})).toBeVisible();
+    expect(await screen.findByText('Harnesses')).toBeVisible();
     expect(await screen.findByText('No providers configured')).toBeVisible();
     expect(screen.getByText('Available providers')).toBeVisible();
     expect(screen.getByRole('button', {name: 'Configure Anthropic'})).toBeVisible();

--- a/libs/client/workspace-settings/src/pages/model-providers-settings-page.tsx
+++ b/libs/client/workspace-settings/src/pages/model-providers-settings-page.tsx
@@ -1,11 +1,12 @@
-import {WorkspaceModelProvidersSection} from '@shipfox/client-agent';
+import {WorkspaceHarnessesSection, WorkspaceModelProvidersSection} from '@shipfox/client-agent';
 import {WorkspaceSettingsShell} from '#components/workspace-settings-shell.js';
 
 export function ModelProvidersSettingsPage() {
   return (
     <WorkspaceSettingsShell>
       {(workspace) => (
-        <div>
+        <div className="flex flex-col gap-32">
+          <WorkspaceHarnessesSection workspaceId={workspace.id} />
           <WorkspaceModelProvidersSection workspaceId={workspace.id} />
         </div>
       )}

--- a/libs/client/workspace-settings/test/pages.tsx
+++ b/libs/client/workspace-settings/test/pages.tsx
@@ -53,7 +53,7 @@ function createTestRouter(path: string, element: ReactElement) {
   });
   const modelProvidersRoute = createRoute({
     getParentRoute: () => rootRoute,
-    path: '/workspaces/$wid/settings/model-providers',
+    path: '/workspaces/$wid/settings/agents',
     component: () => element,
   });
   const integrationsRoute = createRoute({


### PR DESCRIPTION
Add client UX for choosing and using first-party agent harnesses.

Harness selection is now visible in workspace model-provider settings, copied workflow examples include the selected `harness` field, and first-run provider onboarding starts with a harness choice so users only see compatible providers before saving credentials.

Custom providers stay pi-only through a shared compatibility helper, which keeps settings, onboarding, and workflow examples aligned with backend compatibility rules.

No changeset is included because the touched client packages are private.

Closes ENG-809

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds workspace harness selection across settings, onboarding, and usage so users only see and use compatible harnesses. The default harness is now saved per workspace and respected across the app. Implements ENG-809; custom providers remain `pi`-only.

- **New Features**
  - Settings: New Harnesses section lists harnesses, shows the workspace default, hides actions on the default, disables “Set as default” with a generic unavailable message, surfaces toasts/inline errors, and raises menus above rows; setting the default is workspace-scoped.
  - Onboarding: Choose a harness first; provider list shows only compatible providers; saving a non-`pi` provider sets `default_harness_id` via a new API; the modal stays open on errors, adds Back, and the heading is “Choose agent harness”.
  - Usage: Workflow YAML now includes `harness`; a harness combobox appears only when multiple are compatible, prefers the workspace default when compatible, clamps to a compatible harness on target changes, and uses `harness: pi` for custom providers.
  - Compatibility: Shared helper uses `@shipfox/api-agent-dto` metadata to compute availability and `compatibleHarnessIds` consistently across settings, onboarding, and examples.
  - API/UI/Demo: Client adds `setDefaultHarness`, invalidates configs on success, and raises configured-provider menu layering; demo workflows split by harness (`agent-pi.yml`, `agent-claude.yml`) with Anthropic Haiku, and demo gate syntax now uses `success` and `feedback`.

- **Migration**
  - Settings route renamed to `/workspaces/:wid/settings/agents`; links, CTAs, and copy across the app now say “Agents” instead of “Model Providers”.

<sup>Written for commit af81d6e8a14b83c4743832e77f477df9e33b9453. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

