### PR TITLE
Fix agent repair loop feedback field

### DIFF
--- a/dev/gitea/seed/demo/.shipfox/workflows/agent-repair-loop.yaml
+++ b/dev/gitea/seed/demo/.shipfox/workflows/agent-repair-loop.yaml
@@ -42,7 +42,7 @@ jobs:
           success_if: step.exit_code == 0
           on_failure:
             restart_from: implement
-            output: Checkout regression gate failed. Sending failure context back to the agent.
+            feedback: Checkout regression gate failed. Sending failure context back to the agent.
       - key: package
         name: Package verified change
         run: node scripts/demo-step.mjs repair package


### PR DESCRIPTION
Fix the bundled demo agent repair workflow so its gate retry message uses `gate.on_failure.feedback`.

The workflow definition schema no longer accepts `gate.on_failure.output`, which caused definition sync to fail for the seeded demo repository with an unrecognized-key error. Updating the seed keeps the demo workflow compatible with the current gate failure contract.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the demo agent repair workflow by switching `gate.on_failure.output` to `gate.on_failure.feedback`, restoring compatibility with the current gate failure contract and preventing definition sync errors.

- **Bug Fixes**
  - Updated `dev/gitea/seed/demo/.shipfox/workflows/agent-repair-loop.yaml` to set `on_failure.feedback` on the "Checkout regression" gate, removing the unrecognized-key error during sync.

<sup>Written for commit 5bf007188ac42d63416193f29d3cd9023de482dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

