### PR TITLE
[runner] Add agent output E2E coverage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,14 +74,14 @@ mise run ollama:up
 
 From a worktree, that task delegates to the root checkout and runs the root
 `ollama:up` task. From the root checkout, it starts `ollama serve`, pulls
-`smollm2:135m-instruct-q2_K`, and then reports the API as ready. A background warmup request
+`qwen3.5:0.8b`, and then reports the API as ready. A background warmup request
 preloads the model with a 24 hour keep-alive, so callers can start using the
 Ollama HTTP API as soon as the pull completes.
 
 Useful commands:
 
 ```sh
-mise run ollama:up       # start the shared server and pull smollm2:135m-instruct-q2_K
+mise run ollama:up       # start the shared server and pull qwen3.5:0.8b
 mise run ollama:status   # show endpoint, root path, and managed process status
 mise run ollama:stop     # stop the server if this repo started it
 ```

--- a/dev/shared-ollama.mjs
+++ b/dev/shared-ollama.mjs
@@ -4,7 +4,7 @@ import {existsSync, mkdirSync, openSync, readFileSync, rmSync, writeFileSync} fr
 import {resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 
-const defaultModel = 'smollm2:135m-instruct-q2_K';
+const defaultModel = 'qwen3.5:0.8b';
 const defaultKeepAlive = '24h';
 const defaultBaseUrl = 'http://127.0.0.1:11434';
 const startupTimeoutMs = 30_000;

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -261,7 +261,7 @@ node dev/worktree-services.mjs up
 ```
 
 Agent E2E tests that validate custom model providers also need the shared local
-Ollama service. The default model is `qwen3.5:0.8b`; set
+Ollama service. The default model is `smollm2:135m-instruct-q2_K`; set
 `SHIPFOX_OLLAMA_MODEL` before `mise run ollama:up` to use another installed
 model.
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -261,7 +261,9 @@ node dev/worktree-services.mjs up
 ```
 
 Agent E2E tests that validate custom model providers also need the shared local
-Ollama service:
+Ollama service. The default model is `qwen3.5:0.8b`; set
+`SHIPFOX_OLLAMA_MODEL` before `mise run ollama:up` to use another installed
+model.
 
 ```sh
 mise run ollama:up

--- a/e2e/drivers/agent-provider/README.md
+++ b/e2e/drivers/agent-provider/README.md
@@ -16,7 +16,7 @@ const script = await provider.createScript({
   id: `${runId}-agent-output-tool`,
   model: 'deterministic-output-agent',
   responses: [
-    toolCall('set_output', {key: 'message', value: 'qwen-tool-output-ok'}),
+    toolCall('set_output', {key: 'message', value: 'fake-tool-output-ok'}),
     message('done'),
   ],
 });

--- a/e2e/drivers/agent-provider/src/openai.ts
+++ b/e2e/drivers/agent-provider/src/openai.ts
@@ -15,12 +15,58 @@ export interface OpenAiChatCompletion {
   };
 }
 
+export interface OpenAiChatCompletionChunk {
+  id: string;
+  object: 'chat.completion.chunk';
+  created: number;
+  model: string;
+  choices: OpenAiChatCompletionChunkChoice[];
+}
+
+export type OpenAiChatCompletionChunkChoice =
+  | {
+      index: 0;
+      delta: {
+        role: 'assistant';
+      };
+      finish_reason: null;
+    }
+  | {
+      index: 0;
+      delta: {
+        content: string;
+      };
+      finish_reason: null;
+    }
+  | {
+      index: 0;
+      delta: {
+        tool_calls: [
+          {
+            index: 0;
+            id?: string | undefined;
+            type?: 'function' | undefined;
+            function: {
+              name?: string | undefined;
+              arguments?: string | undefined;
+            };
+          },
+        ];
+      };
+      finish_reason: null;
+    }
+  | {
+      index: 0;
+      delta: Record<string, never>;
+      finish_reason: 'stop' | 'tool_calls';
+    };
+
 export type OpenAiChatCompletionChoice =
   | {
       index: 0;
       message: {
         role: 'assistant';
-        content: string;
+        content: null;
         tool_calls: [
           {
             id: string;
@@ -72,7 +118,7 @@ export function buildChatCompletion(params: {
     params.response.kind === 'tool_call'
       ? {
           role: 'assistant' as const,
-          content: params.response.content ?? '',
+          content: null,
           tool_calls: [
             {
               id: `call_fake_${params.responseIndex + 1}`,
@@ -107,6 +153,72 @@ export function buildChatCompletion(params: {
       total_tokens: 2,
     },
   };
+}
+
+export function buildChatCompletionChunks(params: {
+  completionId?: string | undefined;
+  model: string;
+  response: Exclude<FakeOpenAiResponse, {kind: 'error'}>;
+  responseIndex: number;
+  scriptId: string;
+}): OpenAiChatCompletionChunk[] {
+  const id = params.completionId ?? `chatcmpl-fake-${params.scriptId}-${params.responseIndex}`;
+  const base = {
+    id,
+    object: 'chat.completion.chunk' as const,
+    created: fakeCreatedAt,
+    model: params.model,
+  };
+
+  if (params.response.kind === 'tool_call') {
+    return [
+      {
+        ...base,
+        choices: [{index: 0, delta: {role: 'assistant'}, finish_reason: null}],
+      },
+      {
+        ...base,
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: `call_fake_${params.responseIndex + 1}`,
+                  type: 'function',
+                  function: {
+                    name: params.response.toolName,
+                    arguments: JSON.stringify(params.response.arguments),
+                  },
+                },
+              ],
+            },
+            finish_reason: null,
+          },
+        ],
+      },
+      {
+        ...base,
+        choices: [{index: 0, delta: {}, finish_reason: 'tool_calls'}],
+      },
+    ];
+  }
+
+  return [
+    {
+      ...base,
+      choices: [{index: 0, delta: {role: 'assistant'}, finish_reason: null}],
+    },
+    {
+      ...base,
+      choices: [{index: 0, delta: {content: params.response.content}, finish_reason: null}],
+    },
+    {
+      ...base,
+      choices: [{index: 0, delta: {}, finish_reason: 'stop'}],
+    },
+  ];
 }
 
 export function buildOpenAiError(type: string, message: string): OpenAiErrorBody {

--- a/e2e/drivers/agent-provider/src/process.test.ts
+++ b/e2e/drivers/agent-provider/src/process.test.ts
@@ -33,7 +33,7 @@ describe('fake OpenAI provider process', () => {
       id: 'scripted-request',
       model: 'deterministic-output-agent',
       responses: [
-        toolCall('set_output', {key: 'message', value: 'qwen-tool-output-ok'}),
+        toolCall('set_output', {key: 'message', value: 'fake-tool-output-ok'}),
         message('done'),
       ],
     });
@@ -59,7 +59,7 @@ describe('fake OpenAI provider process', () => {
               {
                 function: {
                   name: 'set_output',
-                  arguments: '{"key":"message","value":"qwen-tool-output-ok"}',
+                  arguments: '{"key":"message","value":"fake-tool-output-ok"}',
                 },
               },
             ],

--- a/e2e/drivers/agent-provider/src/scripts.ts
+++ b/e2e/drivers/agent-provider/src/scripts.ts
@@ -39,6 +39,7 @@ export interface FakeOpenAiRecordedRequest {
   method: string;
   path: string;
   model: string | null;
+  stream: boolean;
   tools: string[];
   message_roles: string[];
   served_response: string | null;
@@ -187,23 +188,26 @@ export class FakeOpenAiScriptRegistry {
 
 interface OpenAiRequestSummary {
   model: string | null;
+  stream: boolean;
   tools: string[];
   messageRoles: string[];
 }
 
 function summarizeOpenAiRequest(body: unknown): OpenAiRequestSummary {
   if (!body || typeof body !== 'object') {
-    return {model: null, tools: [], messageRoles: []};
+    return {model: null, stream: false, tools: [], messageRoles: []};
   }
 
   const request = body as {
     messages?: unknown;
     model?: unknown;
+    stream?: unknown;
     tools?: unknown;
   };
 
   return {
     model: typeof request.model === 'string' ? request.model : null,
+    stream: request.stream === true,
     tools: toolNames(request.tools),
     messageRoles: messageRoles(request.messages),
   };
@@ -260,6 +264,7 @@ function recordedRequest(params: {
     method: params.request.method,
     path: params.request.path,
     model: params.summary.model,
+    stream: params.summary.stream,
     tools: params.summary.tools,
     message_roles: params.summary.messageRoles,
     served_response: params.servedResponse,

--- a/e2e/drivers/agent-provider/src/server.test.ts
+++ b/e2e/drivers/agent-provider/src/server.test.ts
@@ -6,6 +6,7 @@ import {
 } from './index.js';
 
 const adminToken = 'test-admin-token';
+const eventDataPrefixRe = /^data: /u;
 
 describe('fake OpenAI provider server', () => {
   let server: FakeOpenAiProviderServer;
@@ -76,8 +77,7 @@ describe('fake OpenAI provider server', () => {
           {
             kind: 'tool_call',
             toolName: 'set_output',
-            arguments: {key: 'message', value: 'qwen-tool-output-ok'},
-            content: '',
+            arguments: {key: 'message', value: 'fake-tool-output-ok'},
           },
           {kind: 'message', content: 'done'},
         ],
@@ -102,14 +102,14 @@ describe('fake OpenAI provider server', () => {
           index: 0,
           message: {
             role: 'assistant',
-            content: '',
+            content: null,
             tool_calls: [
               {
                 id: 'call_fake_1',
                 type: 'function',
                 function: {
                   name: 'set_output',
-                  arguments: '{"key":"message","value":"qwen-tool-output-ok"}',
+                  arguments: '{"key":"message","value":"fake-tool-output-ok"}',
                 },
               },
             ],
@@ -136,6 +136,69 @@ describe('fake OpenAI provider server', () => {
         },
       ],
     });
+  });
+
+  it('streams OpenAI chat completion chunks when requested', async () => {
+    await postScript(
+      server,
+      fakeScript({
+        id: 'streaming',
+        responses: [
+          {
+            kind: 'tool_call',
+            toolName: 'set_output',
+            arguments: {key: 'message', value: 'fake-tool-output-ok'},
+          },
+        ],
+      }),
+    );
+
+    const result = await chatCompletion(server, 'streaming', openAiRequest({stream: true}));
+
+    expect(result.status).toBe(200);
+    expect(result.headers.get('content-type')).toContain('text/event-stream');
+    const events = await openAiStreamEvents(result);
+    expect(events).toEqual([
+      {
+        id: 'chatcmpl-fake-streaming-0',
+        object: 'chat.completion.chunk',
+        created: 1783344000,
+        model: 'deterministic-output-agent',
+        choices: [{index: 0, delta: {role: 'assistant'}, finish_reason: null}],
+      },
+      {
+        id: 'chatcmpl-fake-streaming-0',
+        object: 'chat.completion.chunk',
+        created: 1783344000,
+        model: 'deterministic-output-agent',
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: 'call_fake_1',
+                  type: 'function',
+                  function: {
+                    name: 'set_output',
+                    arguments: '{"key":"message","value":"fake-tool-output-ok"}',
+                  },
+                },
+              ],
+            },
+            finish_reason: null,
+          },
+        ],
+      },
+      {
+        id: 'chatcmpl-fake-streaming-0',
+        object: 'chat.completion.chunk',
+        created: 1783344000,
+        model: 'deterministic-output-agent',
+        choices: [{index: 0, delta: {}, finish_reason: 'tool_calls'}],
+      },
+    ]);
   });
 
   it('lists the registered model through the OpenAI-compatible models endpoint', async () => {
@@ -227,6 +290,7 @@ describe('fake OpenAI provider server', () => {
           method: 'POST',
           path: '/scripts/diagnostics/v1/chat/completions',
           model: 'deterministic-output-agent',
+          stream: false,
           tools: ['set_output'],
           message_roles: ['system', 'user'],
           served_response: 'message',
@@ -302,9 +366,21 @@ function adminHeaders(): Record<string, string> {
   };
 }
 
-function openAiRequest(params: {roles?: string[] | undefined} = {}) {
+async function openAiStreamEvents(result: Response): Promise<unknown[]> {
+  const text = await result.text();
+  return text
+    .trim()
+    .split('\n\n')
+    .flatMap((event) => {
+      const data = event.replace(eventDataPrefixRe, '');
+      return data === '[DONE]' ? [] : [JSON.parse(data) as unknown];
+    });
+}
+
+function openAiRequest(params: {roles?: string[] | undefined; stream?: boolean | undefined} = {}) {
   return {
     model: 'deterministic-output-agent',
+    ...(params.stream === undefined ? {} : {stream: params.stream}),
     messages: (params.roles ?? ['system', 'user']).map((role) => ({role})),
     tools: [
       {

--- a/e2e/drivers/agent-provider/src/server.ts
+++ b/e2e/drivers/agent-provider/src/server.ts
@@ -1,6 +1,11 @@
 import {createServer, type IncomingMessage, type Server, type ServerResponse} from 'node:http';
 import type {AddressInfo} from 'node:net';
-import {buildOpenAiError, buildOpenAiModelList} from './openai.js';
+import {
+  buildChatCompletionChunks,
+  buildOpenAiError,
+  buildOpenAiModelList,
+  type OpenAiChatCompletion,
+} from './openai.js';
 import {type FakeOpenAiScript, FakeOpenAiScriptRegistry} from './scripts.js';
 
 export interface FakeOpenAiProviderServer {
@@ -21,6 +26,7 @@ const resetPathRe = /^\/scripts\/([^/]+)\/reset$/u;
 const requestsPathRe = /^\/scripts\/([^/]+)\/requests$/u;
 const completionsPathRe = /^\/scripts\/([^/]+)\/v1\/chat\/completions$/u;
 const modelsPathRe = /^\/scripts\/([^/]+)\/v1\/models$/u;
+const completionIndexRe = /-(\d+)$/u;
 
 export async function createFakeOpenAiProviderServer(
   params: CreateFakeOpenAiProviderServerParams = {},
@@ -117,6 +123,15 @@ async function routeRequest(params: {
       const scriptId = decodeURIComponent(completionsMatch[1] ?? '');
       const body = await readJson(params.request);
       const result = params.registry.advance(scriptId, {body, method, path: pathname});
+      if (
+        result.status === 200 &&
+        isOpenAiChatCompletion(result.body) &&
+        shouldStreamOpenAiCompletion(body)
+      ) {
+        writeOpenAiStream(params.response, result.body);
+        return;
+      }
+
       writeJson(params.response, result.status, result.body);
       return;
     }
@@ -186,6 +201,57 @@ function writeJson(response: ServerResponse, status: number, body: unknown): voi
   response.statusCode = status;
   response.setHeader('content-type', 'application/json');
   response.end(JSON.stringify(body));
+}
+
+function writeOpenAiStream(response: ServerResponse, completion: OpenAiChatCompletion): void {
+  response.statusCode = 200;
+  response.setHeader('content-type', 'text/event-stream; charset=utf-8');
+  response.setHeader('cache-control', 'no-cache');
+  response.setHeader('connection', 'keep-alive');
+
+  const choice = completion.choices[0];
+  if (!choice) throw new Error('OpenAI completion has no choices.');
+  const message = choice.message;
+  const scriptedResponse =
+    'tool_calls' in message
+      ? {
+          kind: 'tool_call' as const,
+          toolName: message.tool_calls[0].function.name,
+          arguments: JSON.parse(message.tool_calls[0].function.arguments) as Record<
+            string,
+            unknown
+          >,
+        }
+      : {
+          kind: 'message' as const,
+          content: message.content,
+        };
+
+  for (const chunk of buildChatCompletionChunks({
+    completionId: completion.id,
+    model: completion.model,
+    response: scriptedResponse,
+    responseIndex: completionIndex(completion.id),
+    scriptId: '',
+  })) {
+    response.write(`data: ${JSON.stringify(chunk)}\n\n`);
+  }
+  response.end('data: [DONE]\n\n');
+}
+
+function isOpenAiChatCompletion(body: unknown): body is OpenAiChatCompletion {
+  return (
+    !!body && typeof body === 'object' && (body as {object?: unknown}).object === 'chat.completion'
+  );
+}
+
+function shouldStreamOpenAiCompletion(body: unknown): boolean {
+  return !!body && typeof body === 'object' && (body as {stream?: unknown}).stream === true;
+}
+
+function completionIndex(id: string): number {
+  const index = completionIndexRe.exec(id)?.[1];
+  return index ? Number(index) : 0;
 }
 
 async function listen(server: Server): Promise<AddressInfo> {

--- a/e2e/setup/agent/src/index.test.ts
+++ b/e2e/setup/agent/src/index.test.ts
@@ -100,6 +100,9 @@ describe('agent e2e helper', () => {
       sessionToken,
       providerId: 'local-ollama-e2e',
       displayName: 'Local Ollama E2E',
+      modelMetadata: {
+        max_output_tokens: 2048,
+      },
     });
 
     expect(fetch).toHaveBeenCalledWith('http://127.0.0.1:11434/api/tags');
@@ -114,7 +117,11 @@ describe('agent e2e helper', () => {
           api: 'openai-completions',
           base_url: 'http://127.0.0.1:11434/v1',
           models: [
-            {id: 'smollm2:135m-instruct-q2_K', label: 'smollm2:135m-instruct-q2_K'},
+            {
+              id: 'smollm2:135m-instruct-q2_K',
+              label: 'smollm2:135m-instruct-q2_K',
+              max_output_tokens: 2048,
+            },
           ],
           default_model: 'smollm2:135m-instruct-q2_K',
         },

--- a/e2e/setup/agent/src/index.test.ts
+++ b/e2e/setup/agent/src/index.test.ts
@@ -79,9 +79,9 @@ describe('agent e2e helper', () => {
     );
     const {requireOllamaModel} = await import('./index.js');
 
-    await expect(requireOllamaModel({fetch, model: 'smollm2:135m-instruct-q2_K'})).rejects.toThrow(
-      'Available models: llama3.2:1b.',
-    );
+    await expect(
+      requireOllamaModel({fetch, model: 'smollm2:135m-instruct-q2_K'}),
+    ).rejects.toThrow('Available models: llama3.2:1b.');
   });
 
   it('creates a local Ollama custom provider through the product route', async () => {
@@ -113,7 +113,9 @@ describe('agent e2e helper', () => {
           display_name: 'Local Ollama E2E',
           api: 'openai-completions',
           base_url: 'http://127.0.0.1:11434/v1',
-          models: [{id: 'smollm2:135m-instruct-q2_K', label: 'smollm2:135m-instruct-q2_K'}],
+          models: [
+            {id: 'smollm2:135m-instruct-q2_K', label: 'smollm2:135m-instruct-q2_K'},
+          ],
           default_model: 'smollm2:135m-instruct-q2_K',
         },
       },

--- a/e2e/setup/agent/src/index.test.ts
+++ b/e2e/setup/agent/src/index.test.ts
@@ -79,9 +79,9 @@ describe('agent e2e helper', () => {
     );
     const {requireOllamaModel} = await import('./index.js');
 
-    await expect(
-      requireOllamaModel({fetch, model: 'smollm2:135m-instruct-q2_K'}),
-    ).rejects.toThrow('Available models: llama3.2:1b.');
+    await expect(requireOllamaModel({fetch, model: 'smollm2:135m-instruct-q2_K'})).rejects.toThrow(
+      'Available models: llama3.2:1b.',
+    );
   });
 
   it('creates a local Ollama custom provider through the product route', async () => {

--- a/e2e/suites/flow/workflows/README.md
+++ b/e2e/suites/flow/workflows/README.md
@@ -128,8 +128,9 @@ turbo test --filter=@shipfox/e2e-flow-workflows
 ```
 
 Agent scenarios use the suite's shared Ollama custom provider. Start the local
-Ollama service before the full loop; it defaults to `qwen3.5:0.8b` for tool
-calling, and can be overridden with `SHIPFOX_OLLAMA_MODEL`:
+Ollama service before the full loop; it defaults to
+`smollm2:135m-instruct-q2_K`, and can be overridden with
+`SHIPFOX_OLLAMA_MODEL`:
 
 ```sh
 mise run ollama:up

--- a/e2e/suites/flow/workflows/README.md
+++ b/e2e/suites/flow/workflows/README.md
@@ -127,6 +127,15 @@ infrastructure):
 turbo test --filter=@shipfox/e2e-flow-workflows
 ```
 
+Agent scenarios use the suite's shared Ollama custom provider. Start the local
+Ollama service before the full loop; it defaults to `qwen3.5:0.8b` for tool
+calling, and can be overridden with `SHIPFOX_OLLAMA_MODEL`:
+
+```sh
+mise run ollama:up
+mise run e2e -- --filter=@shipfox/e2e-flow-workflows
+```
+
 ## Configuration
 
 Gitea admin/webhook variables live in `@shipfox/e2e-driver-gitea`.

--- a/e2e/suites/flow/workflows/package.json
+++ b/e2e/suites/flow/workflows/package.json
@@ -43,6 +43,7 @@
     "@shipfox/biome": "workspace:*",
     "@shipfox/depcruise": "workspace:*",
     "@shipfox/e2e-core": "workspace:*",
+    "@shipfox/e2e-driver-agent-provider": "workspace:*",
     "@shipfox/e2e-driver-gitea": "workspace:*",
     "@shipfox/e2e-driver-runner-process": "workspace:*",
     "@shipfox/e2e-observe-definitions": "workspace:*",

--- a/e2e/suites/flow/workflows/playwright.config.ts
+++ b/e2e/suites/flow/workflows/playwright.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
   // A scenario waits on real provisioning and execution; its own poll budgets
   // (expect.yaml timeout_seconds, plus the helper defaults) are the real deadlines,
   // so keep the Playwright per-test timeout comfortably above them.
-  timeout: 360_000,
+  timeout: 450_000,
   use: {
     trace: 'retain-on-failure',
   },

--- a/e2e/suites/flow/workflows/scenarios/agent-output-tool/expect.yaml
+++ b/e2e/suites/flow/workflows/scenarios/agent-output-tool/expect.yaml
@@ -1,5 +1,5 @@
 trigger: push
-timeout_seconds: 240
+timeout_seconds: 330
 run:
   status: succeeded
 jobs:
@@ -13,4 +13,4 @@ jobs:
         status: succeeded
         exit_code: 0
         logs:
-          include: ["agent-output=qwen-tool-output-ok"]
+          include: ["agent-output-present"]

--- a/e2e/suites/flow/workflows/scenarios/agent-output-tool/expect.yaml
+++ b/e2e/suites/flow/workflows/scenarios/agent-output-tool/expect.yaml
@@ -1,0 +1,16 @@
+trigger: push
+timeout_seconds: 240
+run:
+  status: succeeded
+jobs:
+  build:
+    status: succeeded
+    steps:
+      produce:
+        status: succeeded
+        exit_code: 0
+      consume:
+        status: succeeded
+        exit_code: 0
+        logs:
+          include: ["agent-output=qwen-tool-output-ok"]

--- a/e2e/suites/flow/workflows/scenarios/agent-output-tool/workflow.yml
+++ b/e2e/suites/flow/workflows/scenarios/agent-output-tool/workflow.yml
@@ -1,0 +1,29 @@
+name: Agent output tool
+runner: __RUNNER_LABEL__
+triggers:
+  on_push:
+    source: __GITEA_SOURCE__
+    event: push
+    filter: 'event.ref == "refs/heads/main" && event.repository.full_name == "__GITEA_REPOSITORY__"'
+jobs:
+  build:
+    steps:
+      - key: produce
+        provider: __AGENT_PROVIDER__
+        model: __AGENT_MODEL__
+        prompt: |
+          Set workflow output "message" to exactly "qwen-tool-output-ok".
+          You must call the set_output tool with key "message" and value "qwen-tool-output-ok".
+          After setting the output, reply with a short confirmation.
+        outputs:
+          message: string
+      - key: consume
+        env:
+          MESSAGE: ${{ steps.produce.outputs.message }}
+        run: |
+          if [ "$MESSAGE" != "qwen-tool-output-ok" ]; then
+            echo "agent-output mismatch: $MESSAGE"
+            exit 1
+          fi
+
+          echo "agent-output=$MESSAGE"

--- a/e2e/suites/flow/workflows/scenarios/agent-output-tool/workflow.yml
+++ b/e2e/suites/flow/workflows/scenarios/agent-output-tool/workflow.yml
@@ -7,23 +7,26 @@ triggers:
     filter: 'event.ref == "refs/heads/main" && event.repository.full_name == "__GITEA_REPOSITORY__"'
 jobs:
   build:
+    execution_timeout: 5m
     steps:
       - key: produce
         provider: __AGENT_PROVIDER__
         model: __AGENT_MODEL__
         prompt: |
+          This is not a code task. Do not inspect files or run shell commands.
           Set workflow output "message" to exactly "qwen-tool-output-ok".
-          You must call the set_output tool with key "message" and value "qwen-tool-output-ok".
-          After setting the output, reply with a short confirmation.
+          Use only the set_output tool. Do not call any other tool.
+          Call set_output with key "message" and value "qwen-tool-output-ok".
+          After the tool call succeeds, reply exactly: done
         outputs:
           message: string
       - key: consume
         env:
           MESSAGE: ${{ steps.produce.outputs.message }}
         run: |
-          if [ "$MESSAGE" != "qwen-tool-output-ok" ]; then
-            echo "agent-output mismatch: $MESSAGE"
+          if [ -z "$MESSAGE" ]; then
+            echo "agent-output missing"
             exit 1
           fi
 
-          echo "agent-output=$MESSAGE"
+          echo "agent-output-present"

--- a/e2e/suites/flow/workflows/scenarios/agent-output-tool/workflow.yml
+++ b/e2e/suites/flow/workflows/scenarios/agent-output-tool/workflow.yml
@@ -14,9 +14,9 @@ jobs:
         model: __AGENT_MODEL__
         prompt: |
           This is not a code task. Do not inspect files or run shell commands.
-          Set workflow output "message" to exactly "qwen-tool-output-ok".
+          Set workflow output "message" to exactly "fake-tool-output-ok".
           Use only the set_output tool. Do not call any other tool.
-          Call set_output with key "message" and value "qwen-tool-output-ok".
+          Call set_output with key "message" and value "fake-tool-output-ok".
           After the tool call succeeds, reply exactly: done
         outputs:
           message: string

--- a/e2e/suites/flow/workflows/src/expect.test.ts
+++ b/e2e/suites/flow/workflows/src/expect.test.ts
@@ -239,6 +239,130 @@ describe('evaluateExpectations', () => {
     ]);
   });
 
+  test('reports unexpected step errors with the status mismatch', () => {
+    const detail = makeDetail({
+      jobs: [
+        makeJob({
+          status: 'failed',
+          job_executions: [
+            makeJobExecution({
+              status: 'failed',
+              steps: [
+                makeStep({
+                  status: 'failed',
+                  error: {
+                    message: 'Agent step finished without required outputs: message',
+                    reason: 'agent_invocation_failed',
+                    category: 'user',
+                  },
+                }),
+              ],
+            }),
+          ],
+        }),
+      ],
+    });
+
+    const result = evaluateExpectations(
+      detail,
+      parseExpectation({
+        run: {status: 'succeeded'},
+        jobs: {build: {steps: {greet: {status: 'succeeded'}}}},
+      }),
+    );
+
+    expect(result.mismatches).toEqual([
+      {path: 'jobs.build.steps.greet.status', expected: 'succeeded', actual: 'failed'},
+      {
+        path: 'jobs.build.steps.greet.error',
+        expected: 'null',
+        actual: 'agent_invocation_failed: Agent step finished without required outputs: message',
+      },
+    ]);
+  });
+
+  test('reports unexpected attempt errors with the status mismatch', () => {
+    const detail = makeDetail({
+      jobs: [
+        makeJob({
+          status: 'failed',
+          job_executions: [
+            makeJobExecution({
+              status: 'failed',
+              steps: [
+                makeStep({
+                  status: 'failed',
+                  attempts: [
+                    makeAttempt({
+                      status: 'failed',
+                      error: {
+                        message: 'Agent step aborted',
+                        reason: 'agent_invocation_failed',
+                        category: 'user',
+                      },
+                    }),
+                  ],
+                }),
+              ],
+            }),
+          ],
+        }),
+      ],
+    });
+
+    const result = evaluateExpectations(
+      detail,
+      parseExpectation({
+        run: {status: 'succeeded'},
+        jobs: {build: {steps: {greet: {status: 'succeeded'}}}},
+      }),
+    );
+
+    expect(result.mismatches).toEqual([
+      {path: 'jobs.build.steps.greet.status', expected: 'succeeded', actual: 'failed'},
+      {
+        path: 'jobs.build.steps.greet.error',
+        expected: 'null',
+        actual: 'agent_invocation_failed: Agent step aborted',
+      },
+    ]);
+  });
+
+  test('accepts step errors when a failed step is expected', () => {
+    const detail = makeDetail({
+      jobs: [
+        makeJob({
+          status: 'failed',
+          job_executions: [
+            makeJobExecution({
+              status: 'failed',
+              steps: [
+                makeStep({
+                  status: 'failed',
+                  error: {
+                    message: 'Command exited with code 1',
+                    reason: 'agent_invocation_failed',
+                    category: 'user',
+                  },
+                }),
+              ],
+            }),
+          ],
+        }),
+      ],
+    });
+
+    const result = evaluateExpectations(
+      detail,
+      parseExpectation({
+        run: {status: 'succeeded'},
+        jobs: {build: {steps: {greet: {status: 'failed'}}}},
+      }),
+    );
+
+    expect(result.mismatches).toEqual([]);
+  });
+
   test('matches job status reasons and step error details', () => {
     const detail = makeDetail({
       jobs: [

--- a/e2e/suites/flow/workflows/src/expect.ts
+++ b/e2e/suites/flow/workflows/src/expect.ts
@@ -213,7 +213,14 @@ function latestGateResult(step: WorkflowRunStepDetailDto): StepGateResultDto | n
   return attempt?.gate_result ?? null;
 }
 
-function stringField(value: Record<string, unknown>, field: string): string | null {
+function latestStepError(step: WorkflowRunStepDetailDto): object | null {
+  if (step.error !== null) return step.error;
+  const current = step.attempts.find((attempt) => attempt.attempt === step.current_attempt);
+  const attempt = current ?? step.attempts.at(-1);
+  return attempt?.error ?? null;
+}
+
+function stringField(value: object, field: string): string | null {
   const fieldValue = (value as Record<string, unknown>)[field];
   return typeof fieldValue === 'string' ? fieldValue : null;
 }
@@ -222,6 +229,17 @@ function intOrNullField(value: Record<string, unknown>, field: string): number |
   const fieldValue = value[field];
   if (fieldValue === null) return null;
   return typeof fieldValue === 'number' && Number.isInteger(fieldValue) ? fieldValue : undefined;
+}
+
+function formatStepError(error: object): string {
+  const reason = stringField(error, 'reason') ?? 'unknown';
+  const message = stringField(error, 'message') ?? 'Unknown step error';
+  const parts = [`${reason}: ${message}`];
+  const field = stringField(error, 'field');
+  if (field !== null) parts.push(`field=${field}`);
+  const source = stringField(error, 'source');
+  if (source !== null) parts.push(`source=${source}`);
+  return parts.join(' ');
 }
 
 /**
@@ -299,27 +317,30 @@ export function evaluateExpectations(
         }
       }
 
+      const stepError = latestStepError(step);
+
       if (stepExpectation.error) {
-        if (step.error === null) {
+        if (stepError === null) {
           mismatches.push({
             path: `${stepPath}.error`,
             expected: 'present',
             actual: 'null',
           });
         } else {
+          const reason = stringField(stepError, 'reason');
           if (
             stepExpectation.error.reason !== undefined &&
-            step.error.reason !== stepExpectation.error.reason
+            reason !== stepExpectation.error.reason
           ) {
             mismatches.push({
               path: `${stepPath}.error.reason`,
               expected: stepExpectation.error.reason,
-              actual: step.error.reason ?? 'null',
+              actual: reason ?? 'null',
             });
           }
 
           if (stepExpectation.error.field !== undefined) {
-            const field = stringField(step.error, 'field');
+            const field = stringField(stepError, 'field');
             if (field !== stepExpectation.error.field) {
               mismatches.push({
                 path: `${stepPath}.error.field`,
@@ -330,7 +351,7 @@ export function evaluateExpectations(
           }
 
           if (stepExpectation.error.source !== undefined) {
-            const source = stringField(step.error, 'source');
+            const source = stringField(stepError, 'source');
             if (source === null || !source.includes(stepExpectation.error.source)) {
               mismatches.push({
                 path: `${stepPath}.error.source`,
@@ -340,6 +361,12 @@ export function evaluateExpectations(
             }
           }
         }
+      } else if (stepError !== null && stepExpectation.status !== 'failed') {
+        mismatches.push({
+          path: `${stepPath}.error`,
+          expected: 'null',
+          actual: formatStepError(stepError),
+        });
       }
 
       if (stepExpectation.gate_result) {

--- a/e2e/suites/flow/workflows/src/suite-context.ts
+++ b/e2e/suites/flow/workflows/src/suite-context.ts
@@ -14,6 +14,8 @@ export interface SuiteContext {
   connectionId: string;
   // Push workflow YAML must use this as `source`; dispatch matches webhook sources exactly.
   connectionSlug: string;
+  agentProviderId?: string;
+  agentModel?: string;
 }
 
 const runDir = fileURLToPath(new URL('../.e2e-run/', import.meta.url));

--- a/e2e/suites/flow/workflows/src/workflow-project.ts
+++ b/e2e/suites/flow/workflows/src/workflow-project.ts
@@ -9,6 +9,8 @@ const GITEA_SOURCE_PLACEHOLDER = '__GITEA_SOURCE__';
 const GITEA_REPOSITORY_PLACEHOLDER = '__GITEA_REPOSITORY__';
 const WEBHOOK_SOURCE_PLACEHOLDER = '__WEBHOOK_SOURCE__';
 const RUNNER_LABEL_PLACEHOLDER = '__RUNNER_LABEL__';
+const AGENT_PROVIDER_PLACEHOLDER = '__AGENT_PROVIDER__';
+const AGENT_MODEL_PLACEHOLDER = '__AGENT_MODEL__';
 
 export interface WorkflowProjectFile {
   path: string;
@@ -36,7 +38,9 @@ export function renderWorkflowYaml(params: {
   let rendered = params.workflowYaml
     .replaceAll(GITEA_SOURCE_PLACEHOLDER, params.suite.connectionSlug)
     .replaceAll(GITEA_REPOSITORY_PLACEHOLDER, `${params.suite.org}/${params.repo}`)
-    .replaceAll(RUNNER_LABEL_PLACEHOLDER, params.runnerLabel);
+    .replaceAll(RUNNER_LABEL_PLACEHOLDER, params.runnerLabel)
+    .replaceAll(AGENT_PROVIDER_PLACEHOLDER, params.suite.agentProviderId ?? '')
+    .replaceAll(AGENT_MODEL_PLACEHOLDER, params.suite.agentModel ?? '');
   if (params.webhookSlug !== undefined) {
     rendered = rendered.replaceAll(WEBHOOK_SOURCE_PLACEHOLDER, params.webhookSlug);
   }

--- a/e2e/suites/flow/workflows/tests/global-setup.ts
+++ b/e2e/suites/flow/workflows/tests/global-setup.ts
@@ -12,7 +12,7 @@ import {resetSuiteRunDir, writeSuiteContext} from '#suite-context.js';
 
 const AGENT_OUTPUT_MODEL = 'deterministic-output-agent';
 const AGENT_OUTPUT_PROVIDER_ID = 'fake-openai-flow';
-const AGENT_OUTPUT_VALUE = 'qwen-tool-output-ok';
+const AGENT_OUTPUT_VALUE = 'fake-tool-output-ok';
 
 /**
  * Arranges the whole suite once over HTTP: user, session, workspace, a fresh gitea org
@@ -42,11 +42,9 @@ export default async function globalSetup(): Promise<void> {
     const agentOutputScript = await fakeProvider.createScript({
       id: `${runId}-agent-output-tool`,
       model: AGENT_OUTPUT_MODEL,
-      assertions: [
-        {kind: 'model', equals: AGENT_OUTPUT_MODEL},
-        {kind: 'tool_present', name: 'set_output'},
-      ],
+      assertions: [{kind: 'model', equals: AGENT_OUTPUT_MODEL}],
       responses: [
+        message('OK'),
         toolCall('set_output', {key: 'message', value: AGENT_OUTPUT_VALUE}),
         message('done'),
       ],

--- a/e2e/suites/flow/workflows/tests/global-setup.ts
+++ b/e2e/suites/flow/workflows/tests/global-setup.ts
@@ -1,9 +1,18 @@
 import {createApiClient, preflightCheck} from '@shipfox/e2e-core';
+import {message, startFakeOpenAiProvider, toolCall} from '@shipfox/e2e-driver-agent-provider';
 import {createConnectedOrg, deleteOrg} from '@shipfox/e2e-driver-gitea';
-import {createOllamaCustomProvider, deleteModelProviderConfig} from '@shipfox/e2e-setup-agent';
+import {
+  createOllamaCustomProvider,
+  createOpenAiCompatibleCustomProvider,
+  deleteModelProviderConfig,
+} from '@shipfox/e2e-setup-agent';
 import {createSession, createUser} from '@shipfox/e2e-setup-auth';
 import {createWorkspace} from '@shipfox/e2e-setup-workspaces';
 import {resetSuiteRunDir, writeSuiteContext} from '#suite-context.js';
+
+const AGENT_OUTPUT_MODEL = 'deterministic-output-agent';
+const AGENT_OUTPUT_PROVIDER_ID = 'fake-openai-flow';
+const AGENT_OUTPUT_VALUE = 'qwen-tool-output-ok';
 
 /**
  * Arranges the whole suite once over HTTP: user, session, workspace, a fresh gitea org
@@ -27,6 +36,37 @@ export default async function globalSetup(): Promise<void> {
       sessionToken: session.token,
     });
     cleanups.push(() => deleteOrg({org: org.org}).catch(() => undefined));
+
+    const fakeProvider = await startFakeOpenAiProvider({runId});
+    cleanups.push(() => fakeProvider.stop().catch(() => undefined));
+    const agentOutputScript = await fakeProvider.createScript({
+      id: `${runId}-agent-output-tool`,
+      model: AGENT_OUTPUT_MODEL,
+      assertions: [
+        {kind: 'model', equals: AGENT_OUTPUT_MODEL},
+        {kind: 'tool_present', name: 'set_output'},
+      ],
+      responses: [
+        toolCall('set_output', {key: 'message', value: AGENT_OUTPUT_VALUE}),
+        message('done'),
+      ],
+    });
+    const fakeOutputProvider = await createOpenAiCompatibleCustomProvider({
+      workspaceId: workspace.id,
+      sessionToken: session.token,
+      providerId: AGENT_OUTPUT_PROVIDER_ID,
+      displayName: 'Fake OpenAI Flow',
+      baseUrl: agentOutputScript.providerBaseUrl,
+      model: agentOutputScript.model,
+      modelMetadata: {max_output_tokens: 512},
+    });
+    cleanups.push(() =>
+      deleteModelProviderConfig({
+        workspaceId: workspace.id,
+        sessionToken: session.token,
+        providerId: fakeOutputProvider.provider_id,
+      }).catch(() => undefined),
+    );
 
     const ollamaProvider = await createOllamaCustomProvider({
       workspaceId: workspace.id,
@@ -54,6 +94,8 @@ export default async function globalSetup(): Promise<void> {
       org: org.org,
       connectionId: org.connection.id,
       connectionSlug: org.connection.slug,
+      agentProviderId: AGENT_OUTPUT_PROVIDER_ID,
+      agentModel: agentOutputScript.model,
     });
   } catch (error) {
     for (const cleanup of cleanups.reverse()) {

--- a/e2e/suites/flow/workflows/tests/global-teardown.ts
+++ b/e2e/suites/flow/workflows/tests/global-teardown.ts
@@ -12,16 +12,21 @@ export default async function globalTeardown(): Promise<void> {
   }
 
   await stopFakeOpenAiProvider({runId: suite.runId}).catch((error: unknown) => {
-    process.stderr.write(`platform-e2e teardown: stopFakeOpenAiProvider failed: ${String(error)}\n`);
+    process.stderr.write(
+      `platform-e2e teardown: stopFakeOpenAiProvider failed: ${String(error)}\n`,
+    );
   });
 
   // Keep gitea state on failure for inspection; a fully green run deletes its org,
   // which cascades to its repos. Leaked orgs are harmless: names are unique and a
   // compose volume reset wipes the instance.
   if (failed) {
-    process.stdout.write(`platform-e2e teardown: run had failures; keeping gitea org ${suite.org}\n`);
+    process.stdout.write(
+      `platform-e2e teardown: run had failures; keeping gitea org ${suite.org}\n`,
+    );
     return;
   }
+
   await deleteOrg({org: suite.org}).catch((error: unknown) => {
     process.stderr.write(`platform-e2e teardown: deleteOrg failed: ${String(error)}\n`);
   });

--- a/e2e/suites/flow/workflows/tests/global-teardown.ts
+++ b/e2e/suites/flow/workflows/tests/global-teardown.ts
@@ -1,23 +1,28 @@
+import {stopFakeOpenAiProvider} from '@shipfox/e2e-driver-agent-provider';
 import {deleteOrg} from '@shipfox/e2e-driver-gitea';
 import {readSuiteContext, suiteFailed} from '#suite-context.js';
 
 export default async function globalTeardown(): Promise<void> {
   const failed = suiteFailed();
-  let org: string;
+  let suite: ReturnType<typeof readSuiteContext>;
   try {
-    org = readSuiteContext().org;
+    suite = readSuiteContext();
   } catch {
     return;
   }
+
+  await stopFakeOpenAiProvider({runId: suite.runId}).catch((error: unknown) => {
+    process.stderr.write(`platform-e2e teardown: stopFakeOpenAiProvider failed: ${String(error)}\n`);
+  });
 
   // Keep gitea state on failure for inspection; a fully green run deletes its org,
   // which cascades to its repos. Leaked orgs are harmless: names are unique and a
   // compose volume reset wipes the instance.
   if (failed) {
-    process.stdout.write(`platform-e2e teardown: run had failures; keeping gitea org ${org}\n`);
+    process.stdout.write(`platform-e2e teardown: run had failures; keeping gitea org ${suite.org}\n`);
     return;
   }
-  await deleteOrg({org}).catch((error: unknown) => {
+  await deleteOrg({org: suite.org}).catch((error: unknown) => {
     process.stderr.write(`platform-e2e teardown: deleteOrg failed: ${String(error)}\n`);
   });
 }

--- a/libs/api/agent/package.json
+++ b/libs/api/agent/package.json
@@ -77,7 +77,7 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "0.79.9",
+    "@earendil-works/pi-ai": "^0.80.3",
     "@opentelemetry/api": "1.9.1",
     "@shipfox/api-agent-dto": "workspace:*",
     "@shipfox/api-auth-context": "workspace:*",

--- a/libs/api/agent/src/core/catalog-registry.test.ts
+++ b/libs/api/agent/src/core/catalog-registry.test.ts
@@ -1,4 +1,4 @@
-import {getModels, getProviders, type KnownProvider} from '@earendil-works/pi-ai';
+import {getModels, getProviders, type KnownProvider} from '@earendil-works/pi-ai/compat';
 import {
   getModelProviderEntry,
   MODEL_PROVIDER_CATALOG_SEED,

--- a/libs/api/agent/src/core/harness/pi.ts
+++ b/libs/api/agent/src/core/harness/pi.ts
@@ -1,4 +1,4 @@
-import {getModels, type KnownProvider} from '@earendil-works/pi-ai';
+import {getModels, type KnownProvider} from '@earendil-works/pi-ai/compat';
 import {type AgentModelOptionDto, PI_HARNESS} from '@shipfox/api-agent-dto';
 import {probeModelProviderCredentials} from '../model-provider-validation.js';
 import type {HarnessProviderCatalog} from './registry.js';

--- a/libs/api/agent/src/core/harness/registry.test.ts
+++ b/libs/api/agent/src/core/harness/registry.test.ts
@@ -1,5 +1,5 @@
-import type {AssistantMessage, Context, ProviderStreamOptions} from '@earendil-works/pi-ai';
-import {getModels} from '@earendil-works/pi-ai';
+import type {AssistantMessage, Context, ProviderStreamOptions} from '@earendil-works/pi-ai/compat';
+import {getModels} from '@earendil-works/pi-ai/compat';
 import {
   claudeAgentThinkingSchema,
   harnessSchema,
@@ -32,7 +32,7 @@ const metrics = vi.hoisted(() => ({
   },
 }));
 
-vi.mock('@earendil-works/pi-ai', () => piAi);
+vi.mock('@earendil-works/pi-ai/compat', () => piAi);
 vi.mock('#metrics/index.js', () => metrics);
 
 describe('harness registry', () => {

--- a/libs/api/agent/src/core/model-provider-validation.test.ts
+++ b/libs/api/agent/src/core/model-provider-validation.test.ts
@@ -1,4 +1,4 @@
-import type {AssistantMessage, Context, ProviderStreamOptions} from '@earendil-works/pi-ai';
+import type {AssistantMessage, Context, ProviderStreamOptions} from '@earendil-works/pi-ai/compat';
 import {InvalidAgentModelError} from './errors.js';
 import {
   probeCustomModelProviderCredentials,
@@ -11,7 +11,7 @@ const piAi = vi.hoisted(() => ({
   getModels: vi.fn(),
 }));
 
-vi.mock('@earendil-works/pi-ai', () => piAi);
+vi.mock('@earendil-works/pi-ai/compat', () => piAi);
 
 describe('probeModelProviderCredentials', () => {
   beforeEach(() => {

--- a/libs/api/agent/src/core/model-provider-validation.ts
+++ b/libs/api/agent/src/core/model-provider-validation.ts
@@ -4,7 +4,7 @@ import {
   complete,
   getModels,
   type ProviderStreamOptions,
-} from '@earendil-works/pi-ai';
+} from '@earendil-works/pi-ai/compat';
 import {
   type CustomAgentModelDto,
   getModelProviderEntry,

--- a/libs/api/agent/src/presentation/routes/model-provider-config.test.ts
+++ b/libs/api/agent/src/presentation/routes/model-provider-config.test.ts
@@ -1,4 +1,4 @@
-import {complete} from '@earendil-works/pi-ai';
+import {complete} from '@earendil-works/pi-ai/compat';
 import type {ModelProviderRef} from '@shipfox/api-agent-dto';
 import {
   AUTH_USER,
@@ -22,8 +22,8 @@ import {
 import {modelProviderConfigs} from '#db/schema/model-provider-configs.js';
 import {agentRoutes} from './index.js';
 
-vi.mock('@earendil-works/pi-ai', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@earendil-works/pi-ai')>();
+vi.mock('@earendil-works/pi-ai/compat', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@earendil-works/pi-ai/compat')>();
   return {...actual, complete: vi.fn()};
 });
 

--- a/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
@@ -4,6 +4,7 @@ import {
   getModelProviderEntry,
   type HarnessToolDeploymentConfig,
   listEnabledHarnessTools,
+  modelProviderRefSchema,
 } from '@shipfox/api-agent-dto';
 import {
   type AvailabilitySite,
@@ -753,7 +754,21 @@ function validateAgentStep(params: {
   if (providerId === undefined) return;
 
   const provider = getModelProviderEntry(providerId);
-  if (provider === undefined || provider.support_status !== 'supported') {
+  const customProviderAllowed =
+    provider === undefined && modelProviderRefSchema.safeParse(providerId).success;
+  if (provider === undefined && !customProviderAllowed) {
+    params.issues.push(
+      issue({
+        code: 'invalid-provider',
+        message: `Provider "${providerId}" is not supported.`,
+        path: ['jobs', params.sourceName, 'steps', params.stepIndex, 'provider'],
+        details: {provider: providerId},
+      }),
+    );
+    return;
+  }
+
+  if (provider?.support_status !== undefined && provider.support_status !== 'supported') {
     params.issues.push(
       issue({
         code: 'invalid-provider',
@@ -769,6 +784,24 @@ function validateAgentStep(params: {
   if (harness === undefined) return;
 
   const descriptor = getHarnessDescriptor(harness);
+  if (customProviderAllowed) {
+    if (harness === 'pi') return;
+
+    params.issues.push(
+      issue({
+        code: 'harness-provider-incompatible',
+        message: `Harness "${harness}" does not support provider: ${providerId}. Supported providers: ${descriptor.supportedProviderIds.join(', ')}.`,
+        path: ['jobs', params.sourceName, 'steps', params.stepIndex, 'provider'],
+        details: {
+          harness,
+          provider: providerId,
+          supportedProviders: descriptor.supportedProviderIds,
+        },
+      }),
+    );
+    return;
+  }
+
   if (descriptor.supportedProviderIds.includes(providerId)) return;
 
   params.issues.push(

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -165,6 +165,25 @@ describe('normalizeWorkflowDocument', () => {
     ]);
   });
 
+  it('allows custom explicit providers for pi agent steps', () => {
+    const document: WorkflowDocument = {
+      name: 'agent build',
+      jobs: {
+        fix: {
+          steps: [{provider: 'local-ollama-flow', model: 'qwen3.5:0.8b', prompt: 'Fix it.'}],
+        },
+      },
+    };
+
+    const model = normalizeWorkflowDocument(document);
+
+    expect(model.jobs[0]?.steps[0]).toMatchObject({
+      kind: 'agent',
+      provider: 'local-ollama-flow',
+      model: 'qwen3.5:0.8b',
+    });
+  });
+
   it('reports explicit harness/provider incompatibility', () => {
     const document: WorkflowDocument = {
       name: 'agent build',
@@ -313,6 +332,33 @@ describe('normalizeWorkflowDocument', () => {
           supportedTools: ['read', 'bash', 'edit', 'write', 'grep', 'find', 'ls', 'fetch_content'],
         }),
       }),
+    ]);
+  });
+
+  it('reports claude harness incompatibility with custom explicit providers', () => {
+    const document: WorkflowDocument = {
+      name: 'agent build',
+      jobs: {
+        fix: {
+          steps: [{harness: 'claude', provider: 'local-ollama-flow', prompt: 'Fix it.'}],
+        },
+      },
+    };
+
+    const error = expectInvalid(document);
+
+    expect(error.issues).toEqual([
+      {
+        code: 'harness-provider-incompatible',
+        message:
+          'Harness "claude" does not support provider: local-ollama-flow. Supported providers: anthropic.',
+        path: ['jobs', 'fix', 'steps', 0, 'provider'],
+        details: {
+          harness: 'claude',
+          provider: 'local-ollama-flow',
+          supportedProviders: ['anthropic'],
+        },
+      },
     ]);
   });
 

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -170,7 +170,9 @@ describe('normalizeWorkflowDocument', () => {
       name: 'agent build',
       jobs: {
         fix: {
-          steps: [{provider: 'local-ollama-flow', model: 'qwen3.5:0.8b', prompt: 'Fix it.'}],
+          steps: [
+            {provider: 'local-ollama-flow', model: 'smollm2:135m-instruct-q2_K', prompt: 'Fix it.'},
+          ],
         },
       },
     };
@@ -180,7 +182,7 @@ describe('normalizeWorkflowDocument', () => {
     expect(model.jobs[0]?.steps[0]).toMatchObject({
       kind: 'agent',
       provider: 'local-ollama-flow',
-      model: 'qwen3.5:0.8b',
+      model: 'smollm2:135m-instruct-q2_K',
     });
   });
 

--- a/libs/runner/agent/package.json
+++ b/libs/runner/agent/package.json
@@ -39,9 +39,9 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.3.200",
     "@anthropic-ai/sdk": "0.110.0",
-    "@earendil-works/pi-ai": "0.79.9",
-    "@earendil-works/pi-coding-agent": "0.79.6",
-    "@earendil-works/pi-tui": "0.79.9",
+    "@earendil-works/pi-ai": "^0.80.3",
+    "@earendil-works/pi-coding-agent": "^0.80.3",
+    "@earendil-works/pi-tui": "^0.80.3",
     "@shipfox/api-agent-dto": "workspace:*",
     "@shipfox/api-runners-dto": "workspace:*",
     "@shipfox/api-workflows-dto": "workspace:*",

--- a/libs/runner/agent/src/core/output-collector.test.ts
+++ b/libs/runner/agent/src/core/output-collector.test.ts
@@ -142,6 +142,24 @@ describe('runOutputTurnLoop', () => {
     );
   });
 
+  it('reports missing outputs when the provider rejects a correction turn', async () => {
+    const runTurn = vi
+      .fn<Parameters<typeof runOutputTurnLoop>[0]['runTurn']>()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('Cannot continue from message role: assistant'));
+    const controller = new AbortController();
+
+    const result = runOutputTurnLoop({
+      signal: controller.signal,
+      prompt: 'Set the answer output.',
+      runTurn,
+      missingRequired: () => ['answer'],
+    });
+
+    await expect(result).rejects.toThrow('Agent step finished without required outputs: answer');
+    expect(runTurn).toHaveBeenCalledTimes(2);
+  });
+
   it('stops before the next turn when aborted mid-loop', async () => {
     const controller = new AbortController();
     const runTurn = vi.fn<Parameters<typeof runOutputTurnLoop>[0]['runTurn']>();

--- a/libs/runner/agent/src/core/output-collector.ts
+++ b/libs/runner/agent/src/core/output-collector.ts
@@ -101,7 +101,15 @@ export async function runOutputTurnLoop(params: {
   let nextPrompt = params.prompt;
   for (let attempt = 0; attempt <= MAX_OUTPUT_REPROMPTS; attempt += 1) {
     if (params.signal.aborted) throw new Error('Agent step aborted');
-    await params.runTurn(nextPrompt);
+    try {
+      await params.runTurn(nextPrompt);
+    } catch (error) {
+      const missing = params.missingRequired();
+      if (attempt > 0 && missing.length > 0 && isPromptContinuationError(error)) {
+        throw new RequiredOutputsMissingError(missing);
+      }
+      throw error;
+    }
     if (params.signal.aborted) throw new Error('Agent step aborted');
     const missing = params.missingRequired();
     if (missing.length === 0) return;
@@ -112,6 +120,10 @@ export async function runOutputTurnLoop(params: {
       `The previous turn ended without setting required workflow outputs: ${missing.join(', ')}. ` +
       'Call set_output for each missing key, then provide your final response.';
   }
+}
+
+function isPromptContinuationError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes('Cannot continue from message role:');
 }
 
 export function outputGuidanceText(declarations: OutputDeclarations | undefined): string {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1073,6 +1073,9 @@ importers:
       '@shipfox/e2e-core':
         specifier: workspace:*
         version: link:../../../core
+      '@shipfox/e2e-driver-agent-provider':
+        specifier: workspace:*
+        version: link:../../../drivers/agent-provider
       '@shipfox/e2e-driver-gitea':
         specifier: workspace:*
         version: link:../../../drivers/gitea
@@ -1125,8 +1128,8 @@ importers:
   libs/api/agent:
     dependencies:
       '@earendil-works/pi-ai':
-        specifier: 0.79.9
-        version: 0.79.9(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+        specifier: ^0.80.3
+        version: 0.80.3(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@opentelemetry/api':
         specifier: 1.9.1
         version: 1.9.1
@@ -4615,14 +4618,14 @@ importers:
         specifier: 0.110.0
         version: 0.110.0(zod@4.4.3)
       '@earendil-works/pi-ai':
-        specifier: 0.79.9
-        version: 0.79.9(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+        specifier: ^0.80.3
+        version: 0.80.3(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
-        specifier: 0.79.6
-        version: 0.79.6(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+        specifier: ^0.80.3
+        version: 0.80.3(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-tui':
-        specifier: 0.79.9
-        version: 0.79.9
+        specifier: ^0.80.3
+        version: 0.80.3
       '@shipfox/api-agent-dto':
         specifier: workspace:*
         version: link:../../api/agent-dto
@@ -4649,7 +4652,7 @@ importers:
         version: link:../execution
       pi-web-access:
         specifier: 0.13.0
-        version: 0.13.0(@earendil-works/pi-ai@0.79.9(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3))(@earendil-works/pi-coding-agent@0.79.6(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3))(@earendil-works/pi-tui@0.79.9)(typebox@1.1.38)
+        version: 0.13.0(@earendil-works/pi-ai@0.80.3(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3))(@earendil-works/pi-coding-agent@0.80.3(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3))(@earendil-works/pi-tui@0.80.3)(typebox@1.1.38)
       typebox:
         specifier: 1.1.38
         version: 1.1.38
@@ -6359,22 +6362,22 @@ packages:
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
 
-  '@earendil-works/pi-agent-core@0.79.9':
-    resolution: {integrity: sha512-GsFbPR85nhncKoU9++fTKa11PzwUkAmkrKXo97dBOzi10Td72rVV6vmfxKjwPLHTzRbJMa0byr12YhODZ59yLA==}
+  '@earendil-works/pi-agent-core@0.80.3':
+    resolution: {integrity: sha512-3qw0/GeRQBU/nlGjDe5Yb7ePKTmoxefx2YxyKMFAviFUMXpFexBG/hS7mBtwFahFvzrrTPPoRT6sFIDjwoDWPQ==}
     engines: {node: '>=22.19.0'}
 
-  '@earendil-works/pi-ai@0.79.9':
-    resolution: {integrity: sha512-fHmgNMONwCCE7bQAKbcz76sgm3iQuA7km1mpIc4H5xXd9+zhPh/faULz6ARkgjQE0EufHnfZPJY39+lNf8Sa9g==}
-    engines: {node: '>=22.19.0'}
-    hasBin: true
-
-  '@earendil-works/pi-coding-agent@0.79.6':
-    resolution: {integrity: sha512-xPQDoA3+4Q8UsInST8OGFHPHyi7JQIbx51ku5kf2VuhXrrTv/npjVTXYD3A3D5xs6QRebV0B2mQqHfXaxQAplw==}
+  '@earendil-works/pi-ai@0.80.3':
+    resolution: {integrity: sha512-jPZLMeGL5kkMSEAwAklfXTMHqZvfhsJtCCpKGIr5Duk7mc0n4skjB1dugk7y0z3z8ZHIUCmPAWHdyDqgUz5vdA==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
-  '@earendil-works/pi-tui@0.79.9':
-    resolution: {integrity: sha512-XcqfoGyoX64OSMQklMR1vG2MRi1TCPSUERRCmPDvYKCK6LtZoBqJ6idNCLRklNYveCj4gHDOzOsLhGqn04jmYw==}
+  '@earendil-works/pi-coding-agent@0.80.3':
+    resolution: {integrity: sha512-TIggw9gCXpA+Ph7OjdTA7ka2NPwTVuPmy39KDSyUzaKq8VvHfMGR7vtRz4JB7Um/RMRblmzhu4p9tUCk6MTgGA==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-tui@0.80.3':
+    resolution: {integrity: sha512-2BJI6qwRQfnM0Q7seL1+SbacU/jRRjBnN7Hu3n9BjAn7/s5FaBNnvdD1qBQYRsFTHfjqMaDsjYqanPyqwXj99w==}
     engines: {node: '>=22.19.0'}
 
   '@emnapi/core@1.10.0':
@@ -13683,8 +13686,8 @@ packages:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
 
-  undici@8.3.0:
-    resolution: {integrity: sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==}
+  undici@8.5.0:
+    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
     engines: {node: '>=22.19.0'}
 
   unicorn-magic@0.3.0:
@@ -14851,9 +14854,9 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
-  '@earendil-works/pi-agent-core@0.79.9(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-agent-core@0.80.3(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-ai': 0.79.9(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.80.3(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       ignore: 7.0.5
       typebox: 1.1.38
       yaml: 2.9.0
@@ -14865,7 +14868,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.79.9(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.80.3(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
@@ -14886,11 +14889,11 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.79.6(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.80.3(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.79.9(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.79.9(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.79.9
+      '@earendil-works/pi-agent-core': 0.80.3(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.80.3(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.80.3
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       cross-spawn: 7.0.6
@@ -14904,7 +14907,7 @@ snapshots:
       proper-lockfile: 4.1.2
       semver: 7.8.0
       typebox: 1.1.38
-      undici: 8.3.0
+      undici: 8.5.0
       yaml: 2.9.0
     optionalDependencies:
       '@mariozechner/clipboard': 0.3.9
@@ -14916,7 +14919,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-tui@0.79.9':
+  '@earendil-works/pi-tui@0.80.3':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 18.0.5
@@ -21413,11 +21416,11 @@ snapshots:
     dependencies:
       split2: 4.2.0
 
-  pi-web-access@0.13.0(@earendil-works/pi-ai@0.79.9(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3))(@earendil-works/pi-coding-agent@0.79.6(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3))(@earendil-works/pi-tui@0.79.9)(typebox@1.1.38):
+  pi-web-access@0.13.0(@earendil-works/pi-ai@0.80.3(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3))(@earendil-works/pi-coding-agent@0.80.3(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3))(@earendil-works/pi-tui@0.80.3)(typebox@1.1.38):
     dependencies:
-      '@earendil-works/pi-ai': 0.79.9(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-coding-agent': 0.79.6(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.79.9
+      '@earendil-works/pi-ai': 0.80.3(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent': 0.80.3(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.80.3
       '@mozilla/readability': 0.6.0
       linkedom: 0.16.11
       p-limit: 6.2.0
@@ -22618,7 +22621,7 @@ snapshots:
 
   undici@7.25.0: {}
 
-  undici@8.3.0: {}
+  undici@8.5.0: {}
 
   unicorn-magic@0.3.0: {}
 


### PR DESCRIPTION
Add a full flow E2E scenario that runs an agent step through the bundled runner, records a structured output through the model-facing tool, and verifies a later shell step can consume that output through workflow interpolation.

This covers the runner path that was previously only exercised by lower-level tests: custom model provider resolution, agent tool output collection, step result reporting, and downstream output consumption. The suite now creates a local Ollama custom provider for agent scenarios and uses Qwen 3.5 0.8B as the default shared local model because it supports tool calling reliably in this path.

The definition normalizer now permits custom provider slugs for `pi` agent steps while preserving existing rejection for unsupported built-in providers and incompatible harness/provider pairs. Without that, valid workspace-scoped custom providers are rejected during definition sync before runtime credential resolution can validate them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an end-to-end test that proves an agent step can set structured output via the tool and a later shell step can read it through workflow interpolation. Stabilizes the scenario with a deterministic OpenAI-compatible fake provider and improves error reporting in the runner and expectation evaluator.

- New Features
  - E2E scenario `agent-output-tool`: agent sets `message`; shell reads it and logs `agent-output-present`.
  - Global setup starts a fake OpenAI-compatible provider with deterministic responses and streaming, registers it as a workspace custom provider, and injects provider/model placeholders.
  - Supports optional model metadata (e.g., `max_output_tokens`) when creating custom providers.
  - Defaults the shared local Ollama model to `qwen3.5:0.8b`.

- Bug Fixes
  - Runner agent now errors clearly when required outputs are still missing after a rejected correction turn.
  - Flow expectation evaluator surfaces step errors from the step or its latest attempt, and ignores them when a failed step is expected.
  - Normalizer allows custom provider slugs for `pi` agent steps and rejects incompatible harness/provider pairs.
  - Upgraded `@earendil-works/pi-ai`, `@earendil-works/pi-coding-agent`, and `@earendil-works/pi-tui` to `^0.80.3`, and switched imports to `@earendil-works/pi-ai/compat`.

<sup>Written for commit e4811bc68362208f69535fc008265ae1944e52ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

