### PR TITLE
Fix worktree service archive cleanup

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -17,7 +17,7 @@ mise exec -- pnpm -r install --frozen-lockfile
 """
 archive = """
 if [ "${CONDUCTOR_IS_LOCAL:-1}" = "1" ]; then
-  mise exec -- node dev/worktree-services.mjs destroy
+  mise exec -- node "${CONDUCTOR_ROOT_PATH:-$PWD}/dev/worktree-services.mjs" destroy
 fi
 """
 

--- a/dev/worktree-services.mjs
+++ b/dev/worktree-services.mjs
@@ -2,11 +2,12 @@
 import {spawnSync} from 'node:child_process';
 import {createHash} from 'node:crypto';
 import {existsSync, mkdirSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
-import {resolve} from 'node:path';
+import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 
 const composeProjectNameMaxLength = 63;
 const composeProjectNamePrefix = 'shipfox-';
+const composeFileName = 'compose.yml';
 const stateDir = resolve('.context/local-services');
 const portsFile = resolve(stateDir, 'ports.env');
 const composeEnvFile = resolve(stateDir, 'compose.env');
@@ -61,9 +62,13 @@ function up(workspaceName, projectName) {
   writeEnvFile(composeEnvFile, composeEnv(ports));
   writeAppEnvFile(appEnvFile, appEnv(ports));
 
-  runDockerCompose(projectName, ['up', '-d', '--wait', 'postgres', 'temporal', 'garage', 'gitea']);
-  runDockerCompose(projectName, ['run', '--rm', 'garage-init']);
-  runDockerCompose(projectName, ['run', '--rm', 'gitea-init']);
+  const composeFile = resolveComposeFile();
+
+  runDockerCompose(projectName, ['up', '-d', '--wait', 'postgres', 'temporal', 'garage', 'gitea'], {
+    composeFile,
+  });
+  runDockerCompose(projectName, ['run', '--rm', 'garage-init'], {composeFile});
+  runDockerCompose(projectName, ['run', '--rm', 'gitea-init'], {composeFile});
 
   printLine(`Worktree services are ready for ${workspaceName}.`);
   printLine(`Docker Compose project: ${projectName}`);
@@ -72,7 +77,9 @@ function up(workspaceName, projectName) {
 
 function stop(projectName) {
   requireComposeState();
-  runDockerCompose(projectName, ['down', '--remove-orphans']);
+  runDockerCompose(projectName, ['down', '--remove-orphans'], {
+    composeFile: resolveComposeFile({allowRootFallback: true}),
+  });
 }
 
 function destroy(projectName) {
@@ -80,13 +87,17 @@ function destroy(projectName) {
     rmSync(stateDir, {recursive: true, force: true});
     return;
   }
-  runDockerCompose(projectName, ['down', '-v', '--remove-orphans']);
+  runDockerCompose(projectName, ['down', '-v', '--remove-orphans'], {
+    composeFile: resolveComposeFile({allowRootFallback: true}),
+  });
   rmSync(stateDir, {recursive: true, force: true});
 }
 
 function status(projectName) {
   requireComposeState();
-  runDockerCompose(projectName, ['ps']);
+  runDockerCompose(projectName, ['ps'], {
+    composeFile: resolveComposeFile({allowRootFallback: true}),
+  });
 }
 
 function requireConductorWorkspace() {
@@ -201,14 +212,41 @@ export function appEnv(ports) {
   };
 }
 
-function runDockerCompose(projectName, args) {
+function runDockerCompose(projectName, args, {composeFile = resolveComposeFile()} = {}) {
   const result = spawnSync(
     'docker',
-    ['compose', '--env-file', composeEnvFile, '-p', projectName, ...args],
+    [
+      'compose',
+      '--env-file',
+      composeEnvFile,
+      '-f',
+      composeFile,
+      '--project-directory',
+      dirname(composeFile),
+      '-p',
+      projectName,
+      ...args,
+    ],
     {stdio: 'inherit'},
   );
   if (result.error) fail(result.error.message);
   if (result.status !== 0) process.exit(result.status ?? 1);
+}
+
+export function resolveComposeFile({
+  workspacePath = process.cwd(),
+  rootPath = process.env.CONDUCTOR_ROOT_PATH,
+  allowRootFallback = false,
+} = {}) {
+  const workspaceComposeFile = resolve(workspacePath, composeFileName);
+  if (existsSync(workspaceComposeFile)) return workspaceComposeFile;
+
+  if (allowRootFallback && rootPath) {
+    const rootComposeFile = resolve(rootPath, composeFileName);
+    if (existsSync(rootComposeFile)) return rootComposeFile;
+  }
+
+  fail(`Missing ${relativePath(workspaceComposeFile)}.`);
 }
 
 function resolveProjectName(workspaceName) {

--- a/dev/worktree-services.test.mjs
+++ b/dev/worktree-services.test.mjs
@@ -1,4 +1,7 @@
 import assert from 'node:assert/strict';
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
 import {describe, test} from 'node:test';
 
 import {
@@ -8,6 +11,7 @@ import {
   parseEnvFile,
   parsePort,
   portsFromBase,
+  resolveComposeFile,
 } from './worktree-services.mjs';
 
 const longShipfoxProjectName = /^shipfox-a+-[a-f0-9]{8}$/;
@@ -68,6 +72,51 @@ describe('appEnv', () => {
 
     assert.equal(env.SHIPFOX_RUNNER_API_URL, 'http://host.docker.internal:55291');
     assert.equal(env.SHIPFOX_PROVISIONER_DOCKER_EXTRA_HOSTS, 'host.docker.internal:host-gateway');
+  });
+});
+
+describe('resolveComposeFile', () => {
+  test('prefers the workspace compose file', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'shipfox-worktree-services-'));
+    const workspaceDir = join(tempDir, 'workspace');
+    const rootDir = join(tempDir, 'root');
+    const workspaceComposeFile = join(workspaceDir, 'compose.yml');
+
+    mkdirSync(workspaceDir);
+    mkdirSync(rootDir);
+    writeFileSync(workspaceComposeFile, '');
+    writeFileSync(join(rootDir, 'compose.yml'), '');
+
+    const composeFile = resolveComposeFile({
+      workspacePath: workspaceDir,
+      rootPath: rootDir,
+      allowRootFallback: true,
+    });
+
+    assert.equal(composeFile, workspaceComposeFile);
+
+    rmSync(tempDir, {recursive: true, force: true});
+  });
+
+  test('falls back to the root compose file for archive cleanup', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'shipfox-worktree-services-'));
+    const workspaceDir = join(tempDir, 'workspace');
+    const rootDir = join(tempDir, 'root');
+    const rootComposeFile = join(rootDir, 'compose.yml');
+
+    mkdirSync(workspaceDir);
+    mkdirSync(rootDir);
+    writeFileSync(rootComposeFile, '');
+
+    const composeFile = resolveComposeFile({
+      workspacePath: workspaceDir,
+      rootPath: rootDir,
+      allowRootFallback: true,
+    });
+
+    assert.equal(composeFile, rootComposeFile);
+
+    rmSync(tempDir, {recursive: true, force: true});
   });
 });
 

--- a/dev/worktree-services.test.mjs
+++ b/dev/worktree-services.test.mjs
@@ -78,45 +78,49 @@ describe('appEnv', () => {
 describe('resolveComposeFile', () => {
   test('prefers the workspace compose file', () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'shipfox-worktree-services-'));
-    const workspaceDir = join(tempDir, 'workspace');
-    const rootDir = join(tempDir, 'root');
-    const workspaceComposeFile = join(workspaceDir, 'compose.yml');
+    try {
+      const workspaceDir = join(tempDir, 'workspace');
+      const rootDir = join(tempDir, 'root');
+      const workspaceComposeFile = join(workspaceDir, 'compose.yml');
 
-    mkdirSync(workspaceDir);
-    mkdirSync(rootDir);
-    writeFileSync(workspaceComposeFile, '');
-    writeFileSync(join(rootDir, 'compose.yml'), '');
+      mkdirSync(workspaceDir);
+      mkdirSync(rootDir);
+      writeFileSync(workspaceComposeFile, '');
+      writeFileSync(join(rootDir, 'compose.yml'), '');
 
-    const composeFile = resolveComposeFile({
-      workspacePath: workspaceDir,
-      rootPath: rootDir,
-      allowRootFallback: true,
-    });
+      const composeFile = resolveComposeFile({
+        workspacePath: workspaceDir,
+        rootPath: rootDir,
+        allowRootFallback: true,
+      });
 
-    assert.equal(composeFile, workspaceComposeFile);
-
-    rmSync(tempDir, {recursive: true, force: true});
+      assert.equal(composeFile, workspaceComposeFile);
+    } finally {
+      rmSync(tempDir, {recursive: true, force: true});
+    }
   });
 
   test('falls back to the root compose file for archive cleanup', () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'shipfox-worktree-services-'));
-    const workspaceDir = join(tempDir, 'workspace');
-    const rootDir = join(tempDir, 'root');
-    const rootComposeFile = join(rootDir, 'compose.yml');
+    try {
+      const workspaceDir = join(tempDir, 'workspace');
+      const rootDir = join(tempDir, 'root');
+      const rootComposeFile = join(rootDir, 'compose.yml');
 
-    mkdirSync(workspaceDir);
-    mkdirSync(rootDir);
-    writeFileSync(rootComposeFile, '');
+      mkdirSync(workspaceDir);
+      mkdirSync(rootDir);
+      writeFileSync(rootComposeFile, '');
 
-    const composeFile = resolveComposeFile({
-      workspacePath: workspaceDir,
-      rootPath: rootDir,
-      allowRootFallback: true,
-    });
+      const composeFile = resolveComposeFile({
+        workspacePath: workspaceDir,
+        rootPath: rootDir,
+        allowRootFallback: true,
+      });
 
-    assert.equal(composeFile, rootComposeFile);
-
-    rmSync(tempDir, {recursive: true, force: true});
+      assert.equal(composeFile, rootComposeFile);
+    } finally {
+      rmSync(tempDir, {recursive: true, force: true});
+    }
   });
 });
 


### PR DESCRIPTION
Fix Conductor workspace archive cleanup when the worktree-local `compose.yml` is unavailable during teardown.

The archive script now invokes the worktree service helper from the root checkout when Conductor provides `CONDUCTOR_ROOT_PATH`. The helper also passes an explicit Compose file to Docker Compose and allows stop/destroy/status to fall back to the root checkout's `compose.yml`, so resource cleanup can still remove the workspace Docker project and volumes even if the archived worktree path no longer has the compose file.

This avoids leaving per-worktree Docker resources behind after archive failures like `open .../compose.yml: no such file or directory`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Conductor archive cleanup so Docker resources are removed even when the worktree’s `compose.yml` is gone. The helper now runs from the repo root (when `CONDUCTOR_ROOT_PATH` is set) and always passes an explicit Compose file.

- **Bug Fixes**
  - Archive calls `dev/worktree-services.mjs` from `${CONDUCTOR_ROOT_PATH}/dev` to avoid missing scripts in archived worktrees.
  - Added `resolveComposeFile` to prefer the workspace `compose.yml` and fall back to the root `compose.yml` for stop/destroy/status.
  - All compose commands now pass `-f <compose.yml>` and `--project-directory`, ensuring the correct project context.
  - Tests cover workspace-preferred and root-fallback behavior and remove temp dirs.

<sup>Written for commit df18efc0e9c5a1b29956926481c4886b5277a35c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

