### PR TITLE
Add server-side step `if:` conditional skipping

### DIFF
--- a/.changeset/quiet-conditions-skip.md
+++ b/.changeset/quiet-conditions-skip.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-workflows": minor
+"@shipfox/api-workflows-dto": minor
+---
+
+Adds server-side step `if:` skipping: a step whose condition evaluates false or errors is marked `skipped` (no attempt) with a reason and dispatch advances, while an execution now fails only when a step failed so an author-skipped step no longer fails the run.

--- a/e2e/suites/flow/workflows/src/expect.test.ts
+++ b/e2e/suites/flow/workflows/src/expect.test.ts
@@ -37,6 +37,7 @@ function makeStep(overrides: Partial<WorkflowRunStepDetailDto> = {}): WorkflowRu
     name: 'Greet',
     source_location: null,
     status: 'succeeded',
+    status_reason: null,
     type: 'run',
     config: {},
     error: null,

--- a/libs/api/workflows-dto/src/schemas/step-source-location.test.ts
+++ b/libs/api/workflows-dto/src/schemas/step-source-location.test.ts
@@ -6,6 +6,7 @@ const baseStep = {
   key: null,
   name: 'echo hello',
   status: 'pending',
+  status_reason: null,
   type: 'run',
   config: {run: 'echo hello'},
   error: null,

--- a/libs/api/workflows-dto/src/schemas/step.ts
+++ b/libs/api/workflows-dto/src/schemas/step.ts
@@ -82,6 +82,9 @@ export const stepDtoSchema = z.object({
   name: z.string(),
   source_location: stepSourceLocationSchema.nullable(),
   status: z.string(),
+  // Why a `skipped` step was skipped (condition_rejected | condition_errored);
+  // null for non-skipped steps.
+  status_reason: z.string().nullable(),
   type: z.string(),
   config: z.record(z.string(), z.unknown()),
   error: stepErrorDtoSchema,

--- a/libs/api/workflows/drizzle/0000_initial.sql
+++ b/libs/api/workflows/drizzle/0000_initial.sql
@@ -7,7 +7,8 @@ CREATE TYPE "public"."workflows_job_status" AS ENUM('pending', 'running', 'succe
 CREATE TYPE "public"."workflows_job_status_reason" AS ENUM('dependency_not_completed', 'condition_false', 'user_cancelled', 'run_cancelled', 'timed_out', 'runner_lost', 'step_failed', 'unknown');--> statement-breakpoint
 CREATE TYPE "public"."workflows_listener_status" AS ENUM('inactive', 'listening', 'resolved');--> statement-breakpoint
 CREATE TYPE "public"."workflows_resolution_reason" AS ENUM('until', 'timeout', 'max_executions', 'cancelled');--> statement-breakpoint
-CREATE TYPE "public"."workflows_step_status" AS ENUM('pending', 'running', 'succeeded', 'failed', 'cancelled');--> statement-breakpoint
+CREATE TYPE "public"."workflows_step_status" AS ENUM('pending', 'running', 'succeeded', 'failed', 'cancelled', 'skipped');--> statement-breakpoint
+CREATE TYPE "public"."workflows_step_status_reason" AS ENUM('condition_rejected', 'condition_errored');--> statement-breakpoint
 CREATE TYPE "public"."workflows_rerun_mode" AS ENUM('all', 'failed');--> statement-breakpoint
 CREATE TYPE "public"."workflows_run_status" AS ENUM('pending', 'running', 'succeeded', 'failed', 'cancelled');--> statement-breakpoint
 CREATE TABLE "workflows_job_executions" (
@@ -124,9 +125,11 @@ CREATE TABLE "workflows_steps" (
 	"name" text NOT NULL,
 	"source_location" jsonb,
 	"status" "workflows_step_status" DEFAULT 'pending' NOT NULL,
+	"status_reason" "workflows_step_status_reason",
 	"type" text NOT NULL,
 	"config" jsonb NOT NULL,
 	"config_plan" jsonb,
+	"condition" jsonb,
 	"authored_config" jsonb,
 	"error" jsonb,
 	"position" integer NOT NULL,

--- a/libs/api/workflows/drizzle/meta/0000_snapshot.json
+++ b/libs/api/workflows/drizzle/meta/0000_snapshot.json
@@ -921,6 +921,13 @@
           "notNull": true,
           "default": "'pending'"
         },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "workflows_step_status_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
         "type": {
           "name": "type",
           "type": "text",
@@ -935,6 +942,12 @@
         },
         "config_plan": {
           "name": "config_plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition": {
+          "name": "condition",
           "type": "jsonb",
           "primaryKey": false,
           "notNull": false
@@ -1554,7 +1567,12 @@
     "public.workflows_step_status": {
       "name": "workflows_step_status",
       "schema": "public",
-      "values": ["pending", "running", "succeeded", "failed", "cancelled"]
+      "values": ["pending", "running", "succeeded", "failed", "cancelled", "skipped"]
+    },
+    "public.workflows_step_status_reason": {
+      "name": "workflows_step_status_reason",
+      "schema": "public",
+      "values": ["condition_rejected", "condition_errored"]
     },
     "public.workflows_rerun_mode": {
       "name": "workflows_rerun_mode",

--- a/libs/api/workflows/src/core/entities/step.ts
+++ b/libs/api/workflows/src/core/entities/step.ts
@@ -3,15 +3,41 @@ import type {
   EvaluationTraceEntry,
   EvaluationTraceLimitEntry,
   ResolvedField,
+  WorkflowExpression,
 } from '@shipfox/expression';
 import type {InterpolationUnresolvableField} from '../errors.js';
 
-export type StepStatus = 'pending' | 'running' | 'succeeded' | 'failed' | 'cancelled';
+export type StepStatus = 'pending' | 'running' | 'succeeded' | 'failed' | 'cancelled' | 'skipped';
 export type StepAttemptLogOutcome = 'drained' | 'abandoned';
 
+// The statuses a step can hold once it is done. `skipped` is a terminal,
+// non-failing status: an execution containing only succeeded/skipped steps
+// resolves succeeded. Single source of truth for the dispatch/cancel guards and
+// the `TERMINAL_STATUSES` set; both `core` and `db` import from this boundary.
+export const TERMINAL_STEP_STATUSES = [
+  'succeeded',
+  'failed',
+  'cancelled',
+  'skipped',
+] as const satisfies readonly StepStatus[];
+
 // A step_attempts row exists only once an attempt is dispatched, so it is never
-// 'pending'.
-export type StepAttemptStatus = Exclude<StepStatus, 'pending'>;
+// 'pending'; a skipped step is attempt-less, so an attempt is never 'skipped'.
+export type StepAttemptStatus = Exclude<StepStatus, 'pending' | 'skipped'>;
+
+// Why a step was skipped by its `if:` predicate. `condition_rejected` = the
+// predicate evaluated to a clean `false`; `condition_errored` = it fell closed
+// on a non-boolean/unresolved/eval error. (The implicit-default-gate reason
+// `default_gate_rejected` arrives with continue-after-failure.)
+export const STEP_STATUS_REASONS = ['condition_rejected', 'condition_errored'] as const;
+export type StepStatusReason = (typeof STEP_STATUS_REASONS)[number];
+
+const STEP_STATUS_REASON_SET = new Set<StepStatusReason>(STEP_STATUS_REASONS);
+
+export function toStepStatusReason(value: string | null): StepStatusReason | null {
+  if (value === null) return null;
+  return STEP_STATUS_REASON_SET.has(value as StepStatusReason) ? (value as StepStatusReason) : null;
+}
 
 export interface StepSourceLocation {
   startLine: number;
@@ -59,9 +85,14 @@ export interface Step {
   name: string;
   sourceLocation: StepSourceLocation | null;
   status: StepStatus;
+  // Why the step was skipped, when `status === 'skipped'`; null otherwise.
+  statusReason: StepStatusReason | null;
   type: string;
   config: Record<string, unknown>;
   configPlan: StepConfigDispatchPlan | null;
+  // The materialized `if:` predicate, evaluated server-side at each dispatch.
+  // A false/errored result skips the step before any attempt is created.
+  condition: WorkflowExpression | null;
   authoredConfig: Record<string, unknown> | null;
   error: Record<string, unknown> | null;
   position: number;

--- a/libs/api/workflows/src/core/job-execution.test.ts
+++ b/libs/api/workflows/src/core/job-execution.test.ts
@@ -15,8 +15,17 @@ import {db} from '#db/db.js';
 import {workflowsOutbox} from '#db/schema/outbox.js';
 import {stepAttempts as stepAttemptsTable} from '#db/schema/step-attempts.js';
 import {steps as stepsTable} from '#db/schema/steps.js';
-import {bulkUpdateStepStatuses, getStepAttempts, getStepsByJobId} from '#db/workflow-runs.js';
+import {
+  bulkUpdateStepStatuses,
+  createWorkflowRun,
+  getJobsByWorkflowRunId,
+  getStepAttempts,
+  getStepsByJobId,
+} from '#db/workflow-runs.js';
 import {arrangeJobWithSteps} from '#test/fixtures/job-with-steps.js';
+import {stripSetupStep} from '#test/fixtures/strip-setup-step.js';
+import {workflowModel} from '#test/index.js';
+import type {Step} from './entities/step.js';
 import {
   JobNotFoundError,
   StepAttemptAheadError,
@@ -312,15 +321,171 @@ describe('nextStepForJob', () => {
     expect(result).toEqual({kind: 'done', status: 'failed'});
   });
 
-  test('all cancelled, none failed → {done, failed}', async () => {
+  test('all cancelled, none failed → {done, succeeded}', async () => {
     const {jobId} = await arrangeJobWithSteps(2);
-    // A cancelled job with no failure must still report 'failed', not a vacuous
-    // success.
+    // Completion is "no step failed": a cancelled-but-unfailed projection derives
+    // 'succeeded'. Real run cancellation never reaches here; it sets the run,
+    // executions, and steps 'cancelled' directly via the run-termination path.
     await bulkUpdateJobStepStatuses({jobId, status: 'cancelled'});
 
     const result = await nextStepForJob(jobId);
 
-    expect(result).toEqual({kind: 'done', status: 'failed'});
+    expect(result).toEqual({kind: 'done', status: 'succeeded'});
+  });
+});
+
+describe('nextStepForJob step if: conditions', () => {
+  const condition = (source: string) => createWorkflowExpression({source, check: {mode: 'syntax'}});
+
+  async function arrangeConditionalJob(
+    steps: ReadonlyArray<{run: string; key: string; if?: ReturnType<typeof condition>}>,
+  ): Promise<{jobId: string; steps: Step[]}> {
+    const model = workflowModel({jobs: {build: {steps}}});
+    const run = await createWorkflowRun({
+      workspaceId: crypto.randomUUID(),
+      projectId: crypto.randomUUID(),
+      definitionId: crypto.randomUUID(),
+      model,
+      triggerPayload: {
+        source: 'manual',
+        event: 'fire',
+        subscriptionId: crypto.randomUUID(),
+        userId: crypto.randomUUID(),
+      },
+    });
+    const jobs = await getJobsByWorkflowRunId(run.id);
+    const jobId = jobs[0]?.id as string;
+    await stripSetupStep(jobId);
+    return {jobId, steps: await getStepsByJobId(jobId)};
+  }
+
+  test('an if:false step is skipped (condition_rejected) and a later step still runs', async () => {
+    const {jobId, steps} = await arrangeConditionalJob([
+      {run: 'echo a', key: 'a', if: condition('false')},
+      {run: 'echo b', key: 'b'},
+    ]);
+
+    const next = await nextStepForJob(jobId);
+
+    expect(next).toEqual({kind: 'step', step: expect.objectContaining({id: steps[1]?.id})});
+    const after = await getStepsByJobId(jobId);
+    expect(after[0]?.status).toBe('skipped');
+    expect(after[0]?.statusReason).toBe('condition_rejected');
+    expect(after[1]?.status).toBe('running');
+    expect(await getStepAttempts(steps[0]?.id as string)).toHaveLength(0);
+  });
+
+  test('an if:true step is dispatched', async () => {
+    const {jobId, steps} = await arrangeConditionalJob([
+      {run: 'echo a', key: 'a', if: condition('true')},
+    ]);
+
+    const next = await nextStepForJob(jobId);
+
+    expect(next).toEqual({kind: 'step', step: expect.objectContaining({id: steps[0]?.id})});
+    expect((await getStepsByJobId(jobId))[0]?.status).toBe('running');
+  });
+
+  test('a job whose only step is author-skipped resolves succeeded and settles once', async () => {
+    const {jobId, steps} = await arrangeConditionalJob([
+      {run: 'echo a', key: 'a', if: condition('false')},
+    ]);
+
+    const result = await nextStepForJob(jobId);
+
+    expect(result).toEqual({kind: 'done', status: 'succeeded'});
+    expect((await getStepsByJobId(jobId))[0]?.status).toBe('skipped');
+    expect(await getStepAttempts(steps[0]?.id as string)).toHaveLength(0);
+    const settled = await jobStepsSettledEvents(jobId);
+    expect(settled).toHaveLength(1);
+    expect(settled[0]?.status).toBe('succeeded');
+  });
+
+  test('a redundant pull after a skip-completed job does not double-emit settlement', async () => {
+    const {jobId} = await arrangeConditionalJob([
+      {run: 'echo a', key: 'a', if: condition('false')},
+    ]);
+    await nextStepForJob(jobId);
+
+    await nextStepForJob(jobId);
+
+    expect(await jobStepsSettledEvents(jobId)).toHaveLength(1);
+  });
+
+  test('if: execution.failed skips in the happy path (nothing has failed)', async () => {
+    const {jobId} = await arrangeConditionalJob([
+      {run: './upload-logs.sh', key: 'upload', if: condition('execution.failed')},
+    ]);
+
+    const result = await nextStepForJob(jobId);
+
+    expect(result).toEqual({kind: 'done', status: 'succeeded'});
+    const after = await getStepsByJobId(jobId);
+    expect(after[0]?.status).toBe('skipped');
+    expect(after[0]?.statusReason).toBe('condition_rejected');
+  });
+
+  test('an if: with an unresolved reference fails closed and skips with condition_errored', async () => {
+    const {jobId} = await arrangeConditionalJob([
+      {run: 'echo a', key: 'a', if: condition('execution.bogus')},
+    ]);
+
+    await nextStepForJob(jobId);
+
+    const after = await getStepsByJobId(jobId);
+    expect(after[0]?.status).toBe('skipped');
+    expect(after[0]?.statusReason).toBe('condition_errored');
+  });
+
+  test('a skip in the middle preserves order and dispatches the next runnable step', async () => {
+    const {jobId, steps} = await arrangeConditionalJob([
+      {run: 'echo a', key: 'a'},
+      {run: 'echo b', key: 'b', if: condition('false')},
+      {run: 'echo c', key: 'c'},
+    ]);
+    const first = await nextStepForJob(jobId);
+    expect(first).toEqual({kind: 'step', step: expect.objectContaining({id: steps[0]?.id})});
+    await recordStepResult({jobId, stepId: steps[0]?.id as string, status: 'succeeded'});
+
+    const next = await nextStepForJob(jobId);
+
+    expect(next).toEqual({kind: 'step', step: expect.objectContaining({id: steps[2]?.id})});
+    const after = await getStepsByJobId(jobId);
+    expect(after[1]?.status).toBe('skipped');
+    expect(after[2]?.status).toBe('running');
+  });
+
+  test('a no-if job runs every step and resolves succeeded (skip loop is transparent)', async () => {
+    const {jobId, steps} = await arrangeConditionalJob([
+      {run: 'echo a', key: 'a'},
+      {run: 'echo b', key: 'b'},
+    ]);
+    await nextStepForJob(jobId);
+    await recordStepResult({jobId, stepId: steps[0]?.id as string, status: 'succeeded'});
+    await nextStepForJob(jobId);
+    await recordStepResult({jobId, stepId: steps[1]?.id as string, status: 'succeeded'});
+
+    const done = await nextStepForJob(jobId);
+
+    expect(done).toEqual({kind: 'done', status: 'succeeded'});
+  });
+
+  test('a later if: on a skipped step outputs falls closed; its status still reads skipped', async () => {
+    const {jobId, steps} = await arrangeConditionalJob([
+      {run: 'echo b', key: 'b', if: condition('false')},
+      {run: 'echo c', key: 'c', if: condition("steps.b.outputs.ready == 'yes'")},
+      {run: 'echo d', key: 'd', if: condition("steps.b.status == 'skipped'")},
+    ]);
+
+    const next = await nextStepForJob(jobId);
+
+    expect(next).toEqual({kind: 'step', step: expect.objectContaining({id: steps[2]?.id})});
+    const after = await getStepsByJobId(jobId);
+    expect(after[0]?.status).toBe('skipped');
+    expect(after[0]?.statusReason).toBe('condition_rejected');
+    expect(after[1]?.status).toBe('skipped');
+    expect(after[1]?.statusReason).toBe('condition_errored');
+    expect(after[2]?.status).toBe('running');
   });
 });
 

--- a/libs/api/workflows/src/core/job-execution.ts
+++ b/libs/api/workflows/src/core/job-execution.ts
@@ -1,6 +1,11 @@
 import {catalogDefaultAgentResolver} from '@shipfox/api-agent/core/resolve-agent-config';
 import type {LogOutcomeDto} from '@shipfox/api-workflows-dto';
-import {coerceStepOutputs, type StepOutputCoercionError} from '@shipfox/expression';
+import {
+  coerceStepOutputs,
+  evaluatePlannedPredicateAtSite,
+  type StepOutputCoercionError,
+  type WorkflowExpression,
+} from '@shipfox/expression';
 import {type Tx, withTransaction} from '#db/db.js';
 import {
   countStepAttempts,
@@ -14,13 +19,15 @@ import {
   insertRunningStepAttempt,
   lockActiveJobExecutionLeaseForUpdate,
   markStepRunning,
+  markStepSkipped,
   settleJobFailed,
+  writeJobStepsSettledOutbox,
 } from '#db/workflow-runs.js';
 import {
   recordWorkflowJobExecutionStepsSettled,
   recordWorkflowStepRestartEnqueued,
 } from '#metrics/instance.js';
-import type {Step} from './entities/step.js';
+import type {Step, StepStatusReason} from './entities/step.js';
 import {
   AgentConfigUnresolvableError,
   InterpolationUnresolvableError,
@@ -65,35 +72,143 @@ export type NextStep = {kind: 'step'; step: Step} | {kind: 'done'; status: Compl
 
 type DispatchConfigError = InterpolationUnresolvableError | AgentConfigUnresolvableError;
 
+type DispatchInputs = {
+  readonly jobExecution: NonNullable<Awaited<ReturnType<typeof getJobExecutionById>>>;
+  readonly attempts: Awaited<ReturnType<typeof getStepAttemptsByJobExecutionId>>;
+  readonly jobs: Awaited<ReturnType<typeof getDirectDependencyJobContexts>>;
+};
+
+type LoadDispatchInputs = () => Promise<DispatchInputs>;
+
 interface PendingStepDispatchParams {
   readonly jobExecutionId: string;
   readonly steps: Step[];
   readonly pending: Step;
+  readonly loadInputs: LoadDispatchInputs;
   readonly tx: Tx;
+}
+
+// Step-dispatch inputs (execution, attempt history, dependency job contexts) are
+// loaded at most once per pull and shared between `if:` evaluation and config
+// completion, so a pull that skips and then dispatches does not re-query.
+async function loadDispatchInputs(jobExecutionId: string, tx: Tx): Promise<DispatchInputs> {
+  const jobExecution = await getJobExecutionById(jobExecutionId, tx);
+  if (!jobExecution) throw new JobNotFoundError(jobExecutionId);
+
+  const attempts = await getStepAttemptsByJobExecutionId(jobExecutionId, tx);
+  const jobs = await getDirectDependencyJobContexts(jobExecution.jobId, tx);
+  return {jobExecution, attempts, jobs};
 }
 
 async function nextStepForJobExecutionInTransaction(
   jobExecutionId: string,
   tx: Tx,
 ): Promise<NextStep> {
-  const steps = await getStepsByJobExecutionIdForUpdate(jobExecutionId, tx);
-  const hasNoSteps = steps.length === 0;
+  const projection = await getStepsByJobExecutionIdForUpdate(jobExecutionId, tx);
 
   // An unknown or step-less execution has nothing to progress; rejecting it stops
   // a bad id from deriving a vacuous 'succeeded' completion below.
-  if (hasNoSteps) throw new JobNotFoundError(jobExecutionId);
+  if (projection.length === 0) throw new JobNotFoundError(jobExecutionId);
 
   // Re-deliver the in-flight step rather than advancing, so a retried pull
   // cannot skip a step.
-  const running = steps.find((step) => step.status === 'running');
-  const hasRunningStep = running !== undefined;
-  if (hasRunningStep) return {kind: 'step', step: running};
+  const running = projection.find((step) => step.status === 'running');
+  if (running !== undefined) return {kind: 'step', step: running};
 
-  const pending = steps.find((step) => step.status === 'pending');
-  const hasPendingStep = pending !== undefined;
-  if (hasPendingStep) return dispatchPendingStep({jobExecutionId, steps, pending, tx});
+  // Server-side skip loop: walk the pending steps in position order, evaluate
+  // each candidate's `if:`, mark false/errored ones `skipped` (no attempt), and
+  // dispatch the first that runs. Inputs load lazily and are cached across
+  // iterations; the local `steps` copy is updated as we skip so a later step's
+  // predicate AND its config interpolation both see the prior skips.
+  const steps = [...projection];
+  let inputs: Promise<DispatchInputs> | undefined;
+  const loadInputs: LoadDispatchInputs = () => (inputs ??= loadDispatchInputs(jobExecutionId, tx));
+  let skippedAny = false;
 
-  return {kind: 'done', status: deriveCompletion(steps)};
+  while (true) {
+    const pendingIndex = steps.findIndex((step) => step.status === 'pending');
+    if (pendingIndex === -1) {
+      return finishJobExecution({jobExecutionId, steps, skippedAny, loadInputs, tx});
+    }
+
+    const pending = steps[pendingIndex] as Step;
+    const condition = readStepCondition(pending);
+    if (condition !== undefined) {
+      const decision = evaluateStepCondition({
+        condition,
+        steps,
+        pending,
+        inputs: await loadInputs(),
+      });
+      if (!decision.run) {
+        await markStepSkipped(
+          {jobExecutionId, stepId: pending.id, statusReason: decision.reason},
+          tx,
+        );
+        steps[pendingIndex] = {...pending, status: 'skipped', statusReason: decision.reason};
+        skippedAny = true;
+        continue;
+      }
+    }
+
+    return dispatchPendingStep({jobExecutionId, steps, pending, loadInputs, tx});
+  }
+}
+
+// Settle the job execution when no runnable step remains. A skip is the only way
+// the job completes without a final step report firing, so when at least one step
+// was skipped this pull we emit the steps-settled outbox here (exactly the signal
+// the report path emits). A redundant post-completion pull has
+// `skippedAny === false` and never re-emits — the last report already settled.
+async function finishJobExecution(params: {
+  jobExecutionId: string;
+  steps: Step[];
+  skippedAny: boolean;
+  loadInputs: LoadDispatchInputs;
+  tx: Tx;
+}): Promise<NextStep> {
+  const status = deriveCompletion(params.steps);
+  if (!params.skippedAny) return {kind: 'done', status};
+
+  const {jobExecution} = await params.loadInputs();
+  await writeJobStepsSettledOutbox(params.tx, {
+    jobId: jobExecution.jobId,
+    jobExecutionId: params.jobExecutionId,
+    status,
+  });
+  recordWorkflowJobExecutionStepsSettled(status);
+  return {kind: 'done', status};
+}
+
+function readStepCondition(step: Step): WorkflowExpression | undefined {
+  return step.condition ?? undefined;
+}
+
+// Evaluates a step's `if:` predicate against the dispatch context. Fail-closed:
+// the step runs only on a strict `true`; a `false`, a non-boolean, or an
+// evaluation error all skip it (the last distinguished as `condition_errored`).
+function evaluateStepCondition(params: {
+  condition: WorkflowExpression;
+  steps: Step[];
+  pending: Step;
+  inputs: DispatchInputs;
+}): {run: true} | {run: false; reason: StepStatusReason} {
+  const context = assembleStepDispatchContext({
+    steps: params.steps,
+    attempts: params.inputs.attempts,
+    targetStepId: params.pending.id,
+    jobExecution: params.inputs.jobExecution,
+    jobs: params.inputs.jobs,
+  });
+  const outcome = evaluatePlannedPredicateAtSite({
+    expression: params.condition,
+    field: 'step.if',
+    site: context.site,
+    context: context.values,
+  });
+  if (outcome.evaluationFailed) return {run: false, reason: 'condition_errored'};
+  if (outcome.value === true) return {run: true};
+  return {run: false, reason: 'condition_rejected'};
 }
 
 async function dispatchPendingStep(params: PendingStepDispatchParams): Promise<NextStep> {
@@ -111,13 +226,10 @@ async function dispatchPendingStepWithConfigPlan({
   jobExecutionId,
   steps,
   pending,
+  loadInputs,
   tx,
 }: PendingStepDispatchParams): Promise<NextStep> {
-  const jobExecution = await getJobExecutionById(jobExecutionId, tx);
-  if (!jobExecution) throw new JobNotFoundError(jobExecutionId);
-
-  const attempts = await getStepAttemptsByJobExecutionId(jobExecutionId, tx);
-  const jobs = await getDirectDependencyJobContexts(jobExecution.jobId, tx);
+  const {jobExecution, attempts, jobs} = await loadInputs();
   const context = assembleStepDispatchContext({
     steps,
     attempts,

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
@@ -249,6 +249,7 @@ describe('assembleStepDispatchContext', () => {
           index: 2,
           name: 'Deploy',
           status: 'running',
+          failed: false,
           started_at: date,
           finished_at: null,
           events: [
@@ -286,6 +287,26 @@ describe('assembleStepDispatchContext', () => {
         },
       },
     });
+  });
+
+  it('sets execution.failed from the latest-terminal step statuses', () => {
+    const targetStep = step({id: 'step-2', key: 'test'});
+
+    const succeededOnly = assembleStepDispatchContext({
+      steps: [step({id: 'step-1', key: 'build', status: 'succeeded'}), targetStep],
+      attempts: [],
+      targetStepId: targetStep.id,
+      jobExecution: jobExecution(),
+    });
+    const withFailure = assembleStepDispatchContext({
+      steps: [step({id: 'step-1', key: 'build', status: 'failed'}), targetStep],
+      attempts: [],
+      targetStepId: targetStep.id,
+      jobExecution: jobExecution(),
+    });
+
+    expect((succeededOnly.values.execution as {failed: boolean}).failed).toBe(false);
+    expect((withFailure.values.execution as {failed: boolean}).failed).toBe(true);
   });
 
   it('uses the latest terminal attempt by execution order and keeps history ordered', () => {
@@ -639,6 +660,8 @@ function step(overrides: Partial<Step> = {}): Step {
     type: 'run',
     config: {},
     configPlan: null,
+    condition: null,
+    statusReason: null,
     authoredConfig: null,
     error: null,
     position: 0,

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.ts
@@ -211,6 +211,11 @@ export function assembleStepDispatchContext(params: {
               index: params.jobExecution.sequence,
               name: params.jobExecution.name,
               status: params.jobExecution.status,
+              // Derived progress boolean: is any settled step already failed in
+              // this execution? Same predicate as `deriveCompletion`, projected
+              // over the latest-terminal step statuses so a step `if:` and the
+              // execution's terminal status can never disagree.
+              failed: params.steps.some((step) => step.status === 'failed'),
               started_at: params.jobExecution.startedAt,
               finished_at: params.jobExecution.finishedAt,
               events: params.jobExecution.triggerEvents,

--- a/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
+++ b/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
@@ -30,6 +30,8 @@ function step(overrides: Partial<Step>): Step {
     type: 'run',
     config: {},
     configPlan: null,
+    condition: null,
+    statusReason: null,
     authoredConfig: null,
     error: null,
     position: 1,

--- a/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.test.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.test.ts
@@ -89,6 +89,7 @@ describe('materializeJobExecutionSteps', () => {
         status: 'pending',
         type: 'setup',
         config: {},
+        condition: null,
         authoredConfig: null,
         position: 0,
       },
@@ -105,6 +106,7 @@ describe('materializeJobExecutionSteps', () => {
             __sf_0: 'Review batch 1',
           },
         },
+        condition: null,
         authoredConfig: {
           run: `echo "${template('executions[0].name')}"`,
           env: {BODY: template('execution.events[0].data.body')},

--- a/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.ts
@@ -3,6 +3,7 @@ import {
   catalogDefaultAgentResolver,
 } from '@shipfox/api-agent/core/resolve-agent-config';
 import type {WorkflowModel} from '@shipfox/api-definitions';
+import type {WorkflowExpression} from '@shipfox/expression';
 import type {StepConfigDispatchPlan} from '#core/entities/step.js';
 import {resolveStepConfig, type WorkflowStepTemplateDiagnostic} from './resolve-step-config.js';
 import type {WorkflowEvaluationContext} from './workflow-evaluation-context.js';
@@ -21,6 +22,9 @@ export interface MaterializedWorkflowStep {
   readonly type: WorkflowModelStep['kind'] | 'setup';
   readonly config: Readonly<Record<string, unknown>>;
   readonly configPlan?: StepConfigDispatchPlan;
+  // The authored `if:` predicate, evaluated server-side at each dispatch. Null
+  // for the synthetic setup step and for steps with no `if:`.
+  readonly condition: WorkflowExpression | null;
   readonly authoredConfig: Readonly<Record<string, unknown>> | null;
   readonly diagnostics?: readonly WorkflowStepTemplateDiagnostic[];
   readonly position: number;
@@ -45,6 +49,9 @@ const SETUP_STEP: MaterializedWorkflowStep = {
   status: 'pending',
   type: 'setup',
   config: {},
+  // The setup step carries no `if:`, so the dispatch skip-loop always takes the
+  // no-condition branch and can never skip it.
+  condition: null,
   authoredConfig: null,
   position: 0,
 };
@@ -83,6 +90,7 @@ export function materializeJobExecutionSteps(
         status: 'pending' as const,
         type: step.kind,
         config: resolved.config,
+        condition: step.if ?? null,
         authoredConfig: resolved.authoredConfig,
         ...materializedConfigPlan(resolved.configPlan, resolved.trace),
         ...(resolved.diagnostics.length === 0 ? {} : {diagnostics: resolved.diagnostics}),

--- a/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
@@ -96,6 +96,7 @@ describe('materializeWorkflowModel', () => {
       status: 'pending',
       type: 'setup',
       config: {},
+      condition: null,
       authoredConfig: null,
       position: 0,
     };
@@ -117,6 +118,7 @@ describe('materializeWorkflowModel', () => {
             status: 'pending',
             type: 'run',
             config: {run: 'npm install'},
+            condition: null,
             authoredConfig: null,
             position: 1,
           },
@@ -133,6 +135,7 @@ describe('materializeWorkflowModel', () => {
                 on_failure: {restart_from: 'install', feedback: 'Build failed'},
               },
             },
+            condition: null,
             authoredConfig: null,
             position: 2,
           },
@@ -154,6 +157,7 @@ describe('materializeWorkflowModel', () => {
             status: 'pending',
             type: 'run',
             config: {run: 'npm test'},
+            condition: null,
             authoredConfig: null,
             position: 1,
           },
@@ -206,6 +210,7 @@ describe('materializeWorkflowModel', () => {
         thinking: 'high',
         prompt: 'Fix the tests.',
       },
+      condition: null,
       authoredConfig: null,
       position: 2,
     });
@@ -226,6 +231,7 @@ describe('materializeWorkflowModel', () => {
           on_failure: {restart_from: 'implement'},
         },
       },
+      condition: null,
       authoredConfig: null,
       position: 3,
     });
@@ -255,6 +261,7 @@ describe('materializeWorkflowModel', () => {
         thinking: 'xhigh',
         prompt: 'Fix the failing tests.',
       },
+      condition: null,
       authoredConfig: null,
       position: 1,
     });
@@ -997,6 +1004,7 @@ describe('materializeWorkflowModel', () => {
         status: 'pending',
         type: 'setup',
         config: {},
+        condition: null,
         authoredConfig: null,
         position: 0,
       },

--- a/libs/api/workflows/src/core/step-transition/decide-step-transition.test.ts
+++ b/libs/api/workflows/src/core/step-transition/decide-step-transition.test.ts
@@ -11,6 +11,8 @@ function step(overrides: Partial<Step> & {id: string; position: number}): Step {
     type: 'run',
     config: {},
     configPlan: null,
+    condition: null,
+    statusReason: null,
     authoredConfig: null,
     error: null,
     version: 1,
@@ -280,16 +282,33 @@ describe('deriveCompletion / isTerminal', () => {
     expect(isTerminal('succeeded')).toBe(true);
     expect(isTerminal('failed')).toBe(true);
     expect(isTerminal('cancelled')).toBe(true);
+    expect(isTerminal('skipped')).toBe(true);
     expect(isTerminal('running')).toBe(false);
     expect(isTerminal('pending')).toBe(false);
   });
 
-  test('deriveCompletion is succeeded only when every step succeeded', () => {
+  test('deriveCompletion fails only when a step failed', () => {
     expect(deriveCompletion([step({id: 'a', position: 0, status: 'succeeded'})])).toBe('succeeded');
     expect(
       deriveCompletion([
         step({id: 'a', position: 0, status: 'succeeded'}),
-        step({id: 'b', position: 1, status: 'cancelled'}),
+        step({id: 'b', position: 1, status: 'failed'}),
+      ]),
+    ).toBe('failed');
+  });
+
+  test('deriveCompletion treats a skipped step as non-failing', () => {
+    expect(deriveCompletion([step({id: 'a', position: 0, status: 'skipped'})])).toBe('succeeded');
+    expect(
+      deriveCompletion([
+        step({id: 'a', position: 0, status: 'succeeded'}),
+        step({id: 'b', position: 1, status: 'skipped'}),
+      ]),
+    ).toBe('succeeded');
+    expect(
+      deriveCompletion([
+        step({id: 'a', position: 0, status: 'skipped'}),
+        step({id: 'b', position: 1, status: 'failed'}),
       ]),
     ).toBe('failed');
   });

--- a/libs/api/workflows/src/core/step-transition/decide-step-transition.ts
+++ b/libs/api/workflows/src/core/step-transition/decide-step-transition.ts
@@ -1,16 +1,22 @@
 import type {PersistedEvaluationTraceEntry, Step, StepStatus} from '../entities/step.js';
+import {TERMINAL_STEP_STATUSES} from '../entities/step.js';
 import type {RuntimeCompletionStatus} from '../workflow-scheduling/runtime-dag.js';
 
-const TERMINAL_STATUSES: ReadonlySet<StepStatus> = new Set(['succeeded', 'failed', 'cancelled']);
+const TERMINAL_STATUSES: ReadonlySet<StepStatus> = new Set(TERMINAL_STEP_STATUSES);
 
 export function isTerminal(status: StepStatus): boolean {
   return TERMINAL_STATUSES.has(status);
 }
 
-// Anything other than an all-succeeded job is a failure, so an externally
-// cancelled job never reads as a vacuous success.
+// Completion is "no step failed", not "every step succeeded": a `skipped` step
+// is terminal but non-failing, so an execution of only succeeded/skipped steps
+// resolves `succeeded`. This is the same predicate as `execution.failed`, so the
+// value a step `if:` reads and the execution's terminal status can never
+// disagree. Callers pass an all-terminal projection (each guards
+// `every(isTerminal)` first). Cancellation is a hard stop applied directly by
+// the run-termination path, never derived here.
 export function deriveCompletion(steps: Step[]): RuntimeCompletionStatus {
-  return steps.every((step) => step.status === 'succeeded') ? 'succeeded' : 'failed';
+  return steps.some((step) => step.status === 'failed') ? 'failed' : 'succeeded';
 }
 
 // The result the runner reported for the step being decided.

--- a/libs/api/workflows/src/db/job-listeners.ts
+++ b/libs/api/workflows/src/db/job-listeners.ts
@@ -287,6 +287,7 @@ export async function drainListenerEventsIntoExecution(
           type: step.type,
           config: step.config,
           configPlan: step.configPlan ?? null,
+          condition: step.condition,
           authoredConfig: step.authoredConfig,
           position: step.position,
         })),

--- a/libs/api/workflows/src/db/schema/steps.ts
+++ b/libs/api/workflows/src/db/schema/steps.ts
@@ -1,3 +1,4 @@
+import type {WorkflowExpression} from '@shipfox/expression';
 import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
 import {sql} from 'drizzle-orm';
 import {
@@ -13,6 +14,7 @@ import {
   uuid,
 } from 'drizzle-orm/pg-core';
 import type {Step, StepConfigDispatchPlan} from '#core/entities/step.js';
+import {toStepStatusReason} from '#core/entities/step.js';
 import {pgTable} from './common.js';
 import {jobExecutions} from './job-executions.js';
 
@@ -22,6 +24,12 @@ export const stepStatusEnum = pgEnum('workflows_step_status', [
   'succeeded',
   'failed',
   'cancelled',
+  'skipped',
+]);
+
+export const stepStatusReasonEnum = pgEnum('workflows_step_status_reason', [
+  'condition_rejected',
+  'condition_errored',
 ]);
 
 export const steps = pgTable(
@@ -33,9 +41,11 @@ export const steps = pgTable(
     name: text('name').notNull(),
     sourceLocation: jsonb('source_location').$type<Step['sourceLocation']>(),
     status: stepStatusEnum('status').notNull().default('pending'),
+    statusReason: stepStatusReasonEnum('status_reason'),
     type: text('type').notNull(),
     config: jsonb('config').notNull().$type<Record<string, unknown>>(),
     configPlan: jsonb('config_plan').$type<StepConfigDispatchPlan>(),
+    condition: jsonb('condition').$type<WorkflowExpression>(),
     authoredConfig: jsonb('authored_config').$type<Record<string, unknown>>(),
     error: jsonb('error').$type<Record<string, unknown>>(),
     position: integer('position').notNull(),
@@ -69,9 +79,11 @@ export function toStep(row: StepDb): Step {
     name: row.name,
     sourceLocation: row.sourceLocation ?? null,
     status: row.status,
+    statusReason: toStepStatusReason(row.statusReason),
     type: row.type,
     config: row.config as Record<string, unknown>,
     configPlan: row.configPlan ?? null,
+    condition: row.condition ?? null,
     authoredConfig: (row.authoredConfig as Record<string, unknown>) ?? null,
     error: (row.error as Record<string, unknown>) ?? null,
     position: row.position,

--- a/libs/api/workflows/src/db/workflow-runs.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs.test.ts
@@ -46,6 +46,7 @@ import {
   getWorkflowRunDetail,
   listRunAttempts,
   listWorkflowRunsByProject,
+  markStepSkipped,
   resolveJobStatusFromJobExecutions,
   updateJobExecutionStatus,
   updateJobStatus,
@@ -3356,5 +3357,59 @@ jobs:
         },
       ]);
     });
+  });
+});
+
+describe('markStepSkipped', () => {
+  async function arrangeFirstStep() {
+    const run = await createTestRun({
+      workspaceId: crypto.randomUUID(),
+      projectId: crypto.randomUUID(),
+      definitionId: crypto.randomUUID(),
+    });
+    const jobs = await getJobsByWorkflowRunId(run.id);
+    const jobId = jobs[0]?.id as string;
+    await stripSetupStep(jobId);
+    const steps = await getStepsByJobId(jobId);
+    return {jobId, step: steps[0]};
+  }
+
+  test('marks a pending step skipped with its reason and creates no attempt', async () => {
+    const {step} = await arrangeFirstStep();
+
+    const updated = await db().transaction((tx) =>
+      markStepSkipped(
+        {
+          jobExecutionId: step?.jobExecutionId as string,
+          stepId: step?.id as string,
+          statusReason: 'condition_rejected',
+        },
+        tx,
+      ),
+    );
+
+    expect(updated?.status).toBe('skipped');
+    expect(updated?.statusReason).toBe('condition_rejected');
+    expect(await getStepAttempts(step?.id as string)).toHaveLength(0);
+  });
+
+  test('is a no-op on a step that is no longer pending', async () => {
+    const {jobId, step} = await arrangeFirstStep();
+    await nextStepForJob(jobId);
+
+    const updated = await db().transaction((tx) =>
+      markStepSkipped(
+        {
+          jobExecutionId: step?.jobExecutionId as string,
+          stepId: step?.id as string,
+          statusReason: 'condition_rejected',
+        },
+        tx,
+      ),
+    );
+
+    expect(updated).toBeNull();
+    const after = await getStepsByJobId(jobId);
+    expect(after[0]?.status).toBe('running');
   });
 });

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -51,7 +51,9 @@ import type {
   StepAttempt,
   StepAttemptStatus,
   StepStatus,
+  StepStatusReason,
 } from '#core/entities/step.js';
+import {TERMINAL_STEP_STATUSES} from '#core/entities/step.js';
 import {
   isWorkflowRunTerminal,
   type JobExecutionDetail,
@@ -323,6 +325,7 @@ export async function createWorkflowRun(params: CreateWorkflowRunParams): Promis
           type: step.type,
           config: step.config,
           configPlan: step.configPlan ?? null,
+          condition: step.condition,
           authoredConfig: step.authoredConfig,
           position: step.position,
         });
@@ -726,9 +729,13 @@ export async function createRerunWorkflowRun(
           name: step.name,
           sourceLocation: step.sourceLocation,
           status: carriedOver ? step.status : ('pending' as const),
+          // A carried-over step keeps its skip reason; a re-materialized step
+          // resets to null so its `if:` is re-evaluated fresh on re-dispatch.
+          statusReason: carriedOver ? step.statusReason : null,
           type: step.type,
           config: step.config,
           configPlan: step.configPlan,
+          condition: step.condition,
           authoredConfig: step.authoredConfig,
           error: null,
           position: step.position,
@@ -2349,7 +2356,7 @@ export async function bulkUpdateStepStatuses(
     .where(
       and(
         eq(steps.jobExecutionId, params.jobExecutionId),
-        sql`${steps.status} NOT IN ('succeeded','failed','cancelled')`,
+        notInArray(steps.status, [...TERMINAL_STEP_STATUSES]),
       ),
     );
 
@@ -2445,7 +2452,7 @@ export async function markStepRunning(params: MarkStepRunningParams, tx: Tx): Pr
       and(
         eq(steps.id, params.stepId),
         eq(steps.jobExecutionId, params.jobExecutionId),
-        sql`${steps.status} NOT IN ('succeeded','failed','cancelled')`,
+        notInArray(steps.status, [...TERMINAL_STEP_STATUSES]),
       ),
     )
     .returning();
@@ -2465,6 +2472,35 @@ export async function markStepRunning(params: MarkStepRunningParams, tx: Tx): Pr
     tx,
   );
   return step;
+}
+
+export interface MarkStepSkippedParams {
+  jobExecutionId: string;
+  stepId: string;
+  statusReason: StepStatusReason;
+}
+
+/**
+ * Marks a `pending` step `skipped` because its `if:` predicate evaluated false
+ * or fell closed. Guarded on `status = 'pending'` (not merely non-terminal) so a
+ * `running` step can never be skipped out from under its in-flight attempt.
+ * Creates no `step_attempt` row: a skipped step is attempt-less. Returns null
+ * when the step was not pending (already dispatched/terminal) — a no-op.
+ */
+export async function markStepSkipped(params: MarkStepSkippedParams, tx: Tx): Promise<Step | null> {
+  const rows = await tx
+    .update(steps)
+    .set({status: 'skipped', statusReason: params.statusReason, updatedAt: new Date()})
+    .where(
+      and(
+        eq(steps.id, params.stepId),
+        eq(steps.jobExecutionId, params.jobExecutionId),
+        eq(steps.status, 'pending'),
+      ),
+    )
+    .returning();
+  const row = rows[0];
+  return row ? toStep(row) : null;
 }
 
 export interface DispatchStepWithCompletedConfigParams {
@@ -2489,7 +2525,7 @@ export async function dispatchStepWithCompletedConfig(
       and(
         eq(steps.id, params.stepId),
         eq(steps.jobExecutionId, params.jobExecutionId),
-        sql`${steps.status} NOT IN ('succeeded','failed','cancelled')`,
+        notInArray(steps.status, [...TERMINAL_STEP_STATUSES]),
       ),
     )
     .returning();
@@ -2802,7 +2838,7 @@ export async function applyStepResult(params: ApplyStepResultParams, tx: Tx): Pr
       and(
         eq(steps.id, params.stepId),
         eq(steps.jobExecutionId, params.jobExecutionId),
-        sql`${steps.status} NOT IN ('succeeded','failed','cancelled')`,
+        notInArray(steps.status, [...TERMINAL_STEP_STATUSES]),
       ),
     );
 }

--- a/libs/api/workflows/src/presentation/dto/step.test.ts
+++ b/libs/api/workflows/src/presentation/dto/step.test.ts
@@ -11,6 +11,8 @@ function step(overrides: Partial<Step> & {type: string}): Step {
     status: 'failed',
     config: {},
     configPlan: null,
+    condition: null,
+    statusReason: null,
     authoredConfig: null,
     error: null,
     position: 0,
@@ -163,6 +165,17 @@ describe('toStepDto error category', () => {
     const dto = toStepDto(step({type: 'setup', sourceLocation: null, error: null}));
 
     expect(dto.source_location).toBeNull();
+  });
+
+  it('surfaces the skip reason for a skipped step and null otherwise', () => {
+    const skipped = toStepDto(
+      step({type: 'run', status: 'skipped', statusReason: 'condition_errored', error: null}),
+    );
+    const running = toStepDto(step({type: 'run', status: 'running', error: null}));
+
+    expect(skipped.status).toBe('skipped');
+    expect(skipped.status_reason).toBe('condition_errored');
+    expect(running.status_reason).toBeNull();
   });
 });
 

--- a/libs/api/workflows/src/presentation/dto/step.ts
+++ b/libs/api/workflows/src/presentation/dto/step.ts
@@ -105,6 +105,7 @@ export function toStepDto(step: Step): StepDto {
     name: step.name,
     source_location: toStepSourceLocationDto(step.sourceLocation),
     status: step.status,
+    status_reason: step.statusReason,
     type: step.type,
     config: step.config,
     error: toStepErrorDto(step.error, step.type === 'setup' ? 'setup' : 'user'),

--- a/libs/api/workflows/test/factories/workflow-model.ts
+++ b/libs/api/workflows/test/factories/workflow-model.ts
@@ -3,6 +3,7 @@ import {
   parseWorkflowTemplate,
   planInterpolationField,
   type ResolvedFieldSegment,
+  type WorkflowExpression,
   type WorkflowInterpolationField,
 } from '@shipfox/expression';
 
@@ -15,6 +16,7 @@ interface TestWorkflowStepBase {
   readonly name?: string | undefined;
   readonly sourceLocation?: WorkflowModel['jobs'][number]['steps'][number]['sourceLocation'];
   readonly gate?: WorkflowModel['jobs'][number]['steps'][number]['gate'] | undefined;
+  readonly if?: WorkflowExpression | undefined;
 }
 
 interface TestRunStep extends TestWorkflowStepBase {
@@ -138,6 +140,7 @@ function stepBase(step: TestWorkflowStep, jobId: string, stepIndex: number) {
     ...(step.name === undefined ? {} : {name: step.name}),
     ...(step.sourceLocation === undefined ? {} : {sourceLocation: step.sourceLocation}),
     ...(step.gate === undefined ? {} : {gate: step.gate}),
+    ...(step.if === undefined ? {} : {if: step.if}),
   };
 }
 

--- a/libs/client/workflows/test/fixtures/workflow-run.ts
+++ b/libs/client/workflows/test/fixtures/workflow-run.ts
@@ -223,6 +223,7 @@ export function workflowStepDto(
     name: 'build',
     source_location: null,
     status: 'pending',
+    status_reason: null,
     type: 'run',
     config: {},
     error: null,

--- a/libs/runner/agent/src/core/step.test.ts
+++ b/libs/runner/agent/src/core/step.test.ts
@@ -29,6 +29,7 @@ function buildAgentStep(overrides: Partial<StepDto> = {}): StepDto {
     name,
     source_location: null,
     status: 'running',
+    status_reason: null,
     type: 'agent',
     config: {model: 'claude-opus-4-8', thinking: 'high', prompt: 'Fix the failing tests.'},
     error: null,

--- a/libs/runner/execution/src/core/run-step.test.ts
+++ b/libs/runner/execution/src/core/run-step.test.ts
@@ -649,6 +649,7 @@ function buildStep(
     name,
     source_location: null,
     status: 'running',
+    status_reason: null,
     type: overrides.type ?? 'run',
     config: overrides.config ?? {run: 'echo test'},
     error: null,

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -1360,6 +1360,7 @@ function buildStep(overrides: Partial<StepDto> = {}): StepDto {
     name,
     source_location: null,
     status: 'running',
+    status_reason: null,
     type: 'run',
     config: {run: 'echo test'},
     error: null,

--- a/libs/runner/protocol/src/api-client.test.ts
+++ b/libs/runner/protocol/src/api-client.test.ts
@@ -160,6 +160,7 @@ describe('api-client auth contexts', () => {
       name: 'Test step',
       source_location: null,
       status: 'running',
+      status_reason: null,
       type: 'run',
       config: {run: 'echo ok'},
       error: null,


### PR DESCRIPTION
Adds server-side `if:` evaluation for workflow steps: at step-dispatch the server evaluates a step's `if:` predicate against the dispatch context and, when it is false or errors, marks the step `skipped` (a new terminal, non-failing status) without creating an attempt or dispatching to a runner, then advances to the next runnable step.

## Why

Part of the Conditional execution epic. Authors need to gate individual steps on run/step state (e.g. `if: ${{ execution.failed }}` for a cleanup step) without the runner ever seeing a skipped step. This is the step half of the epic; the job-level `if:`, continue-dispatch-after-failure, and the predicate trace/UI are separate follow-ups.

## What changed

- **New `skipped` step status** plus `condition_rejected` / `condition_errored` reasons, surfaced on the step DTO as `status_reason`. Skipped steps are attempt-less (`StepAttemptStatus` excludes `skipped`).
- **Fail-closed evaluation**: only a strict `true` runs the step; a `false`, a non-boolean, or an evaluation error all skip it (the last as `condition_errored`).
- **Completion rule flips** from "every step succeeded" to "no step failed", so an author-skipped step no longer fails the run. This is the same predicate as the new `execution.failed` context field, so a step's `if:` reading and the execution's terminal status can never disagree. Cancellation stays a hard stop applied directly by the run-termination path (not derived here).
- **Dispatch loop owns skipping**: the runner protocol is unchanged and never sees a skipped step. A skip that completes a job settles it via the existing steps-settled outbox, guarded by `skippedAny` so a redundant post-completion pull never double-emits. Dispatch inputs load once per pull and are shared across skip iterations and config completion; the local projection is updated as steps skip so a later step's predicate *and* its config interpolation both see the prior skips.
- **`markStepSkipped`** guards on `status = 'pending'` (never downgrades a running step) and scopes by `jobExecutionId`. Rerun preserves `statusReason` for carried-over steps and resets it for re-materialized ones so `if:` re-evaluates fresh.
- Additive schema only: new enum values and nullable `status_reason` / `condition` columns, folded into the baseline migration.

## Review notes

- Migration edits the folded `0000` baseline in place (this pre-deploy workspace's convention); no incremental migration.
- The completion-rule change means a cancelled-but-unfailed projection now derives `succeeded` via `deriveCompletion` — this is intentional and safe because real cancellation is set directly by the run-termination path, never through this function.

Closes ENG-830

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add server-side evaluation of step `if:` so false or errored conditions are skipped without creating attempts, and switch job completion to “no step failed” so skipped steps don’t fail runs. Implements step-level conditional execution from ENG-830.

- **New Features**
  - Evaluate a step’s `if:` at dispatch; on false/non-boolean/error, mark it `skipped` with a reason (`condition_rejected` or `condition_errored`), create no attempt, and move to the next step.
  - Treat `skipped` as terminal and non-failing; completion now fails only if a step failed; `execution.failed` is available in the dispatch context.
  - Server dispatch loop owns skipping; runner protocol is unchanged. Schema/DTO add `steps.condition`, `steps.status_reason`, and the `skipped` status.

- **Migration**
  - Update consumers to handle a `skipped` step status and optional `status_reason` in Step DTOs from `@shipfox/api-workflows-dto`.
  - No runner changes or config changes required.

<sup>Written for commit 106dbc1dd842f2b128dec2654b2c88a04d61eac4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

