### PR TITLE
Fix listener delivery retry assertions

### DIFF
--- a/e2e/suites/flow/workflows/src/listener-helpers.test.ts
+++ b/e2e/suites/flow/workflows/src/listener-helpers.test.ts
@@ -8,6 +8,7 @@ import type {
 import {
   batchedListenerExecutionMatches,
   findListenerExecutionByDeliveryId,
+  findListenerExecutionByDeliveryIds,
   listenerDeliveryObserved,
   listenerExecutionCountMatches,
   listenerResolutionMatches,
@@ -134,6 +135,28 @@ describe('listener helper predicates', () => {
     });
 
     expect(result?.sequence).toBe(2);
+  });
+
+  test('finds the listener execution containing any delivery id', () => {
+    const detail = runDetail({
+      jobs: [
+        listenerJob({
+          job_executions: [
+            execution({sequence: 1, trigger_events: [event({delivery_id: 'delivery-1'})]}),
+            execution({sequence: 2, trigger_events: [event({delivery_id: 'delivery-2'})]}),
+          ],
+        }),
+      ],
+    });
+
+    const result = findListenerExecutionByDeliveryIds({
+      runDetail: detail,
+      jobKey: 'listen',
+      deliveryIds: ['delivery-3', 'delivery-2'],
+    });
+
+    expect(result?.deliveryId).toBe('delivery-2');
+    expect(result?.execution.sequence).toBe(2);
   });
 
   test('reports a missing delivery with observed delivery ids', () => {

--- a/e2e/suites/flow/workflows/src/listener-helpers.ts
+++ b/e2e/suites/flow/workflows/src/listener-helpers.ts
@@ -148,6 +148,20 @@ export function findListenerExecutionByDeliveryId(params: {
   );
 }
 
+export function findListenerExecutionByDeliveryIds(params: {
+  runDetail: WorkflowRunDetailResponseDto;
+  jobKey: string;
+  deliveryIds: string[];
+}): {deliveryId: string; execution: WorkflowRunJobExecutionDetailDto} | undefined {
+  const expected = new Set(params.deliveryIds);
+  const job = findListenerJob(params.runDetail, params.jobKey);
+  for (const execution of job?.job_executions ?? []) {
+    const event = execution.trigger_events.find((candidate) => expected.has(candidate.delivery_id));
+    if (event) return {deliveryId: event.delivery_id, execution};
+  }
+  return undefined;
+}
+
 export function findListenerExecutionBySequence(params: {
   runDetail: WorkflowRunDetailResponseDto;
   jobKey: string;
@@ -242,14 +256,34 @@ export async function sendWebhookDeliveryUntilObserved(params: {
         runId: params.runId,
         timeoutMs: attemptTimeoutMs,
         description: `listener delivery ${deliveryId}`,
-        matches: (candidate) =>
-          listenerDeliveryObserved({
+        matches: (candidate) => {
+          const match = findListenerExecutionByDeliveryIds({
             runDetail: candidate,
             jobKey: params.jobKey,
-            deliveryId,
-          }),
+            deliveryIds,
+          });
+          if (match) {
+            return {
+              matched: true,
+              diagnostic: `listener job ${params.jobKey} observed delivery ${match.deliveryId} in execution ${match.execution.sequence}`,
+            };
+          }
+          const observed = findListenerJob(candidate, params.jobKey)?.job_executions.flatMap(
+            (execution) => execution.trigger_events.map((event) => event.delivery_id),
+          );
+          return {
+            matched: false,
+            diagnostic: `listener job ${params.jobKey} did not observe deliveries [${deliveryIds.join(', ')}]; observed=[${observed?.join(', ') ?? ''}]`,
+          };
+        },
       });
-      return {deliveryId, deliveryIds, runDetail};
+      const match = findListenerExecutionByDeliveryIds({
+        runDetail,
+        jobKey: params.jobKey,
+        deliveryIds,
+      });
+      if (!match) throw new Error(`Observed listener delivery match disappeared for ${deliveryId}`);
+      return {deliveryId: match.deliveryId, deliveryIds, runDetail};
     } catch (error) {
       lastError = error;
     }

--- a/e2e/suites/flow/workflows/src/listener-jobs.ts
+++ b/e2e/suites/flow/workflows/src/listener-jobs.ts
@@ -389,7 +389,7 @@ jobs:
       - key: slow
         run: |
           echo "listener_started"
-          sleep 30
+          sleep 120
           echo "listener_done"
 `,
 };

--- a/e2e/suites/flow/workflows/tests/listener-jobs.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/listener-jobs.e2e.ts
@@ -1,5 +1,5 @@
 import {
-  findListenerExecutionByDeliveryId,
+  findListenerExecutionByDeliveryIds,
   waitForListenerExecution,
   waitForListenerResolution,
 } from '#listener-helpers.js';
@@ -73,18 +73,23 @@ test.describe('listener jobs', () => {
 
         const listen = terminal.jobs.find((job) => job.key === LISTENER_JOB);
         const deploy = terminal.jobs.find((job) => job.key === 'deploy');
-        const firstExecution = findListenerExecutionByDeliveryId({
+        const firstExecution = findListenerExecutionByDeliveryIds({
           runDetail: terminal,
           jobKey: LISTENER_JOB,
-          deliveryId: firstFire.deliveryId,
-        });
-        const secondExecution = findListenerExecutionByDeliveryId({
+          deliveryIds: firstFire.deliveryIds,
+        })?.execution;
+        const secondExecution = findListenerExecutionByDeliveryIds({
           runDetail: terminal,
           jobKey: LISTENER_JOB,
-          deliveryId: secondFire.deliveryId,
-        });
+          deliveryIds: secondFire.deliveryIds,
+        })?.execution;
         if (!firstExecution || !secondExecution) {
           throw new Error('Expected both listener fire deliveries to create executions');
+        }
+        const firstDeliveryId = firstExecution.trigger_events[0]?.delivery_id;
+        const secondDeliveryId = secondExecution.trigger_events[0]?.delivery_id;
+        if (!firstDeliveryId || !secondDeliveryId) {
+          throw new Error('Expected listener executions to include trigger deliveries');
         }
         const firstLogs = await stepLogText({
           runDetail: terminal,
@@ -118,10 +123,12 @@ test.describe('listener jobs', () => {
         expect(listen?.job_executions.length).toBeGreaterThanOrEqual(2);
         expect(firstExecution.sequence).not.toBe(secondExecution.sequence);
         expect(deploy?.status).toBe('succeeded');
+        expect(firstFire.deliveryIds).toContain(firstDeliveryId);
+        expect(secondFire.deliveryIds).toContain(secondDeliveryId);
         expect(firstLogs).toContain('listener_message=hello-listener');
-        expect(firstLogs).toContain(`listener_delivery=${firstFire.deliveryId}`);
+        expect(firstLogs).toContain(`listener_delivery=${firstDeliveryId}`);
         expect(secondLogs).toContain('listener_message=hello-again');
-        expect(secondLogs).toContain(`listener_delivery=${secondFire.deliveryId}`);
+        expect(secondLogs).toContain(`listener_delivery=${secondDeliveryId}`);
         expect(deployLogs).toContain('listener_last=hello-again');
         expect(deployLogs).toContain('listener_count=2');
         expect(resolveDeliveryId).toContain('resolve');
@@ -173,8 +180,12 @@ test.describe('listener jobs', () => {
         'max_executions',
       );
       expect(listen?.job_executions.map((execution) => execution.sequence)).toEqual([1, 2]);
-      expect(listen?.job_executions[0]?.trigger_events[0]?.delivery_id).toBe(first.deliveryId);
-      expect(listen?.job_executions[1]?.trigger_events[0]?.delivery_id).toBe(second.deliveryId);
+      const firstExecutionDeliveryId = listen?.job_executions[0]?.trigger_events[0]?.delivery_id;
+      const secondExecutionDeliveryId = listen?.job_executions[1]?.trigger_events[0]?.delivery_id;
+      expect(firstExecutionDeliveryId).toBeDefined();
+      expect(secondExecutionDeliveryId).toBeDefined();
+      expect(first.deliveryIds).toContain(firstExecutionDeliveryId);
+      expect(second.deliveryIds).toContain(secondExecutionDeliveryId);
     } catch (error) {
       await cleanupListenerCase(testCase, runId);
       throw error;


### PR DESCRIPTION
Fix listener workflow E2E assertions that assumed the helper's latest posted webhook retry was the delivery consumed by the listener execution.

Webhook delivery retries can race with workflow observation: an earlier retry may create the execution after the helper has already posted a later retry. This changes the listener helper to match against the full retry set and return the delivery ID actually observed on the execution, then updates assertions to compare logs and execution details against that observed trigger event.

The cancel-on-resolve scenario also now keeps its listener step running longer, giving CI a stable window to observe the active execution before sending the resolve event.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flaky listener workflow E2E tests by matching against all webhook retry deliveries and asserting with the delivery ID actually observed by the execution. Also stabilizes the cancel-on-resolve case by keeping the listener running longer in CI.

- **Bug Fixes**
  - Added a helper to find executions by any of the posted retry delivery IDs.
  - Updated webhook wait logic to return the observed delivery ID and improve diagnostics.
  - Adjusted assertions to use the execution’s trigger event ID instead of the latest posted retry.
  - Increased the “slow” listener step sleep from 30s to 120s for a stable observation window.

<sup>Written for commit e258b71d7f900e9154bd4fc9a499a0392a5d8d79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

