### PR TITLE
[api-workflows] Continue dispatch after step failure

### DIFF
--- a/libs/api/workflows/src/core/job-execution.test.ts
+++ b/libs/api/workflows/src/core/job-execution.test.ts
@@ -399,7 +399,7 @@ describe('nextStepForJob', () => {
     const after = await getStepsByJobId(jobId);
     expect(after).toMatchObject([{status: 'skipped', statusReason: 'condition_rejected'}]);
     expect(await getStepAttempts(jobId)).toHaveLength(0);
-    expect(await jobStepsSettledEvents(jobId)).toHaveLength(0);
+    expect(await jobStepsSettledEvents(jobId)).toMatchObject([{status: 'succeeded'}]);
   });
 
   test('the implicit default gate skips when execution.failed is true', async () => {
@@ -468,7 +468,7 @@ describe('recordStepResult', () => {
     expect(outcome).toEqual({jobFinished: true, status: 'succeeded'});
   });
 
-  test('failed step → step failed, remaining cancelled, {jobFinished:true, failed}', async () => {
+  test('failed step → step failed, remaining pending, {jobFinished:false}', async () => {
     const {jobId, steps} = await arrangeJobWithSteps(3);
     await nextStepForJob(jobId);
 
@@ -479,12 +479,82 @@ describe('recordStepResult', () => {
       error: {message: 'boom'},
     });
 
-    expect(outcome).toEqual({jobFinished: true, status: 'failed'});
+    expect(outcome).toEqual({jobFinished: false});
     const after = await getStepsByJobId(jobId);
     expect(after[0]?.status).toBe('failed');
     expect(after[0]?.error).toEqual({message: 'boom'});
-    expect(after[1]?.status).toBe('cancelled');
-    expect(after[2]?.status).toBe('cancelled');
+    expect(after[1]?.status).toBe('pending');
+    expect(after[2]?.status).toBe('pending');
+  });
+
+  test('after a failure, default-gated pending steps skip and finish the failed job', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(3);
+    await nextStepForJob(jobId);
+    await recordStepResult({
+      jobId,
+      stepId: steps[0]?.id as string,
+      status: 'failed',
+      error: {message: 'boom'},
+    });
+
+    const done = await nextStepForJob(jobId);
+
+    expect(done).toEqual({kind: 'done', status: 'failed'});
+    const after = await getStepsByJobId(jobId);
+    expect(after.map((step) => step.status)).toEqual(['failed', 'skipped', 'skipped']);
+    expect(after[1]?.statusReason).toBe('default_gate_rejected');
+    expect(after[2]?.statusReason).toBe('default_gate_rejected');
+    expect(await jobStepsSettledEvents(jobId)).toMatchObject([{status: 'failed'}]);
+  });
+
+  test('after a failure, if:true cleanup still runs before the job resolves failed', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(3);
+    const cleanup = steps[1];
+    if (!cleanup) throw new Error('Expected cleanup step');
+    await db()
+      .update(stepsTable)
+      .set({condition: conditionExpression('true')})
+      .where(eq(stepsTable.id, cleanup.id));
+    await nextStepForJob(jobId);
+    await recordStepResult({
+      jobId,
+      stepId: steps[0]?.id as string,
+      status: 'failed',
+      error: {message: 'boom'},
+    });
+
+    const next = await nextStepForJob(jobId);
+
+    expect(next).toEqual({kind: 'step', step: expect.objectContaining({id: cleanup.id})});
+    await recordStepResult({jobId, stepId: cleanup.id, status: 'succeeded'});
+    const done = await nextStepForJob(jobId);
+    expect(done).toEqual({kind: 'done', status: 'failed'});
+    const after = await getStepsByJobId(jobId);
+    expect(after.map((step) => step.status)).toEqual(['failed', 'succeeded', 'skipped']);
+    expect(after[2]?.statusReason).toBe('default_gate_rejected');
+  });
+
+  test('if:execution.failed runs only after an earlier step failed', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(2);
+    const upload = steps[1];
+    if (!upload) throw new Error('Expected upload step');
+    await db()
+      .update(stepsTable)
+      .set({condition: conditionExpression('execution.failed')})
+      .where(eq(stepsTable.id, upload.id));
+    await nextStepForJob(jobId);
+    await recordStepResult({
+      jobId,
+      stepId: steps[0]?.id as string,
+      status: 'failed',
+      error: {message: 'boom'},
+    });
+
+    const next = await nextStepForJob(jobId);
+
+    expect(next).toEqual({kind: 'step', step: expect.objectContaining({id: upload.id})});
+    await recordStepResult({jobId, stepId: upload.id, status: 'succeeded'});
+    expect(await nextStepForJob(jobId)).toEqual({kind: 'done', status: 'failed'});
   });
 
   test('never downgrades an already-terminal row', async () => {
@@ -543,7 +613,7 @@ describe('recordStepResult', () => {
     expect(after[1]?.status).toBe('pending');
   });
 
-  test('duplicate failed report is a no-op and job stays fully terminal', async () => {
+  test('duplicate failed report is a no-op and later steps remain dispatchable', async () => {
     const {jobId, steps} = await arrangeJobWithSteps(3);
     await nextStepForJob(jobId);
     await recordStepResult({jobId, stepId: steps[0]?.id as string, status: 'failed'});
@@ -554,12 +624,12 @@ describe('recordStepResult', () => {
       status: 'failed',
     });
 
-    expect(outcome).toEqual({jobFinished: true, status: 'failed'});
+    expect(outcome).toEqual({jobFinished: false});
     const after = await getStepsByJobId(jobId);
     expect(after[0]?.status).toBe('failed');
-    expect(after[1]?.status).toBe('cancelled');
-    expect(after[2]?.status).toBe('cancelled');
-    expect(await jobStepsSettledEvents(jobId)).toHaveLength(1);
+    expect(after[1]?.status).toBe('pending');
+    expect(after[2]?.status).toBe('pending');
+    expect(await jobStepsSettledEvents(jobId)).toHaveLength(0);
   });
 
   test('coerces declared output before persisting and filling later step config', async () => {
@@ -743,6 +813,22 @@ describe('recordStepResult job-completion event', () => {
   });
 
   test('a failed final step enqueues one completion event with status failed', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(1);
+    await nextStepForJob(jobId);
+
+    await recordStepResult({
+      jobId,
+      stepId: steps[0]?.id as string,
+      status: 'failed',
+      error: {message: 'boom'},
+    });
+
+    const events = await jobStepsSettledEvents(jobId);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.status).toBe('failed');
+  });
+
+  test('a failed non-final step enqueues completion only after remaining steps skip', async () => {
     const {jobId, steps} = await arrangeJobWithSteps(2);
     await nextStepForJob(jobId);
 
@@ -752,6 +838,10 @@ describe('recordStepResult job-completion event', () => {
       status: 'failed',
       error: {message: 'boom'},
     });
+
+    expect(await jobStepsSettledEvents(jobId)).toHaveLength(0);
+
+    await nextStepForJob(jobId);
 
     const events = await jobStepsSettledEvents(jobId);
     expect(events).toHaveLength(1);

--- a/libs/api/workflows/src/core/job-execution.ts
+++ b/libs/api/workflows/src/core/job-execution.ts
@@ -20,6 +20,7 @@ import {
   markStepRunning,
   markStepSkipped,
   settleJobFailed,
+  writeJobStepsSettledOutbox,
 } from '#db/workflow-runs.js';
 import {
   recordWorkflowJobExecutionStepsSettled,
@@ -111,9 +112,21 @@ async function nextStepForJobExecutionInTransaction(
   const attempts = await getStepAttemptsByJobExecutionId(jobExecutionId, tx);
   const jobs = await getDirectDependencyJobContexts(jobExecution.jobId, tx);
 
+  let skippedAny = false;
   while (true) {
     const pending = currentSteps.find((step) => step.status === 'pending');
-    if (pending === undefined) return {kind: 'done', status: deriveCompletion(currentSteps)};
+    if (pending === undefined) {
+      const status = deriveCompletion(currentSteps);
+      if (skippedAny) {
+        await writeJobStepsSettledOutbox(tx, {
+          jobId: jobExecution.jobId,
+          jobExecutionId,
+          status,
+        });
+        recordWorkflowJobExecutionStepsSettled(status);
+      }
+      return {kind: 'done', status};
+    }
 
     const context = assembleStepDispatchContext({
       steps: currentSteps,
@@ -142,6 +155,7 @@ async function nextStepForJobExecutionInTransaction(
       error: null,
     };
     currentSteps = currentSteps.map((step) => (step.id === pending.id ? skippedStep : step));
+    skippedAny = true;
   }
 }
 
@@ -211,7 +225,9 @@ async function dispatchPendingStepWithConfigPlan({
       error: failureError,
     });
     if (status) recordWorkflowJobExecutionStepsSettled(status);
-    return {kind: 'done', status: 'failed'};
+    return status === null
+      ? nextStepForJobExecutionInTransaction(jobExecutionId, tx)
+      : {kind: 'done', status};
   }
 }
 

--- a/libs/api/workflows/src/core/step-transition/apply-step-transition.ts
+++ b/libs/api/workflows/src/core/step-transition/apply-step-transition.ts
@@ -144,9 +144,8 @@ export async function applyStepTransition(
     }
   }
 
-  // Re-derive completion from the post-apply projection so the outcome is robust
-  // to the cancel sweep above; emit the steps-settled signal exactly once, here on
-  // the applied path.
+  // Re-derive completion from the post-apply projection and emit the
+  // steps-settled signal exactly once, here on the applied path.
   const after = await getStepsByJobExecutionIdForUpdate(ctx.jobExecutionId, tx);
   if (after.every((step) => isTerminal(step.status))) {
     const status = deriveCompletion(after);

--- a/libs/api/workflows/src/core/step-transition/decide-step-transition.test.ts
+++ b/libs/api/workflows/src/core/step-transition/decide-step-transition.test.ts
@@ -65,7 +65,7 @@ describe('decideStepTransition', () => {
     expect(decision).toEqual({kind: 'complete-job', stepId: 's0', attempt: 1});
   });
 
-  test('a failed step fails the job and cancels from its position', () => {
+  test('a failed step marks the job as failed', () => {
     const target = step({id: 's1', position: 1, status: 'running'});
     const steps = [
       step({id: 's0', position: 0, status: 'succeeded'}),

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -2541,8 +2541,8 @@ export async function bulkUpdateStepStatuses(
   // stranded (it would otherwise read as phantom in-flight work to gate/restart
   // logic). The just-failed step on the normal report path is already terminal,
   // so this only catches the bulk timeout/cancel sweeps.
-  // Only ever called with a terminal sweep status (cancelled on the failed-sibling
-  // path, failed on timeout).
+  // Only ever called with a terminal sweep status: cancelled on run cancellation,
+  // failed on timeout.
   if (params.status === 'failed' || params.status === 'cancelled') {
     const finalizedAttempts = await tx
       .update(stepAttempts)
@@ -2738,7 +2738,6 @@ export async function settleJobFailed(
     },
     tx,
   );
-  await cancelRemainingSteps({jobExecutionId: params.jobExecutionId}, tx);
 
   const after = await getStepsByJobExecutionIdForUpdate(params.jobExecutionId, tx);
   if (!after.every((step) => isTerminal(step.status))) return null;
@@ -3030,8 +3029,6 @@ export interface CancelRemainingStepsParams {
   jobExecutionId: string;
 }
 
-// The just-failed step is already terminal, so the shared guarded sweep leaves
-// it alone and only the still-pending siblings are cancelled.
 export async function cancelRemainingSteps(
   params: CancelRemainingStepsParams,
   tx: Tx,

--- a/libs/api/workflows/src/presentation/routes/get-run.test.ts
+++ b/libs/api/workflows/src/presentation/routes/get-run.test.ts
@@ -267,7 +267,7 @@ jobs:
     ).toEqual([null, {start_line: 5, end_line: 6}, {start_line: 7, end_line: 10}]);
   });
 
-  test('exposes per-step error and cancelled status after a failed per-step report', async () => {
+  test('exposes per-step error and skipped status after a failed per-step report', async () => {
     const projectId = crypto.randomUUID();
     const definitionId = crypto.randomUUID();
 
@@ -291,7 +291,8 @@ jobs:
     const jobId = runJobs[0]?.id ?? '';
     const steps = await getStepsByJobId(jobId);
 
-    // Drive the per-step path: step 1 succeeds, step 2 fails (cancelling step 3).
+    // Drive the per-step path: step 1 succeeds, step 2 fails, step 3 is skipped
+    // by the default gate on the follow-up pull.
     await nextStepForJob(jobId);
     await recordStepResult({
       jobId,
@@ -307,6 +308,7 @@ jobs:
       error: {message: 'Command exited with code 1', exitCode: 1},
       exitCode: 1,
     });
+    await nextStepForJob(jobId);
 
     const res = await app.inject({
       method: 'GET',
@@ -329,7 +331,7 @@ jobs:
       exit_code: 1,
       category: 'user',
     });
-    expect(responseSteps[2]?.status).toBe('cancelled');
+    expect(responseSteps[2]?.status).toBe('skipped');
     expect(responseSteps[2]?.error).toBeNull();
   });
 

--- a/libs/api/workflows/src/presentation/routes/next-step.test.ts
+++ b/libs/api/workflows/src/presentation/routes/next-step.test.ts
@@ -248,7 +248,7 @@ describe('POST /runs/jobs/current/steps/next', () => {
     expect(res.json()).toEqual({kind: 'done', status: 'succeeded'});
   });
 
-  test('reports {done, failed} after a failed step cancelled the rest', async () => {
+  test('reports {done, failed} after a failed step skips the default-gated rest', async () => {
     const {jobId, steps} = await arrangeJobWithSteps(2);
     const token = await mintActiveLeaseToken({jobId});
     await app.inject({method: 'POST', url: URL, headers: {authorization: `Bearer ${token}`}});

--- a/libs/api/workflows/src/presentation/routes/next-step.ts
+++ b/libs/api/workflows/src/presentation/routes/next-step.ts
@@ -10,7 +10,7 @@ export const nextStepRoute = defineRoute({
   method: 'POST',
   path: '/steps/next',
   description:
-    'Returns the next step for the runner to run on its job. The job is identified by the access token, so no job ID is needed. Calling this again before reporting the current step returns that same step, so retries are safe. When no steps remain, the response reports that there are no more steps to run, along with the job status so far; the runner then stops. This endpoint does not finalize the job: finalization is driven server-side from the recorded step results, not by the runner calling a job-completion endpoint.',
+    'Returns the next step for the runner to run on its job. The job is identified by the access token, so no job ID is needed. Calling this again before reporting the current step returns that same step, so retries are safe. When no runnable steps remain, the response reports that there are no more steps to run, along with the job status; the runner then stops. Finalization is driven server-side from recorded step results and dispatch-time skips, not by the runner calling a job-completion endpoint.',
   schema: {
     response: {
       200: nextStepResponseSchema,

--- a/libs/api/workflows/src/presentation/routes/report-step.test.ts
+++ b/libs/api/workflows/src/presentation/routes/report-step.test.ts
@@ -120,8 +120,8 @@ describe('POST /runs/jobs/current/steps/:stepId/report', () => {
     expect(res.json()).toEqual({ok: true, cancel: false});
   });
 
-  test('a failed report cancels the remaining steps → {ok, cancel:true}', async () => {
-    const {jobId, steps} = await arrangeJobWithSteps(3);
+  test('a failed final report finishes the job → {ok, cancel:true}', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(1);
     const token = await mintActiveLeaseToken({jobId});
     await nextStepForJob(jobId);
 
@@ -134,10 +134,26 @@ describe('POST /runs/jobs/current/steps/:stepId/report', () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual({ok: true, cancel: true});
+  });
+
+  test('a failed report leaves remaining steps dispatchable → {ok, cancel:false}', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(3);
+    const token = await mintActiveLeaseToken({jobId});
+    await nextStepForJob(jobId);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: reportUrl(steps[0]?.id as string),
+      headers: {authorization: `Bearer ${token}`},
+      payload: reportPayload({status: 'failed', error: {message: 'boom'}}),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ok: true, cancel: false});
     const after = await getStepsByJobId(jobId);
     expect(after[0]?.status).toBe('failed');
-    expect(after[1]?.status).toBe('cancelled');
-    expect(after[2]?.status).toBe('cancelled');
+    expect(after[1]?.status).toBe('pending');
+    expect(after[2]?.status).toBe('pending');
   });
 
   test('persists the wire error snake_case fields as camelCase on the step row', async () => {
@@ -242,7 +258,7 @@ describe('POST /runs/jobs/current/steps/:stepId/report', () => {
     expect(after[1]?.status).toBe('pending');
   });
 
-  test('a late succeeded report on a dead job never downgrades and says cancel', async () => {
+  test('a late succeeded report after failure completion never downgrades and says cancel', async () => {
     const {jobId, steps} = await arrangeJobWithSteps(2);
     const token = await mintActiveLeaseToken({jobId});
     await nextStepForJob(jobId);
@@ -252,6 +268,7 @@ describe('POST /runs/jobs/current/steps/:stepId/report', () => {
       headers: {authorization: `Bearer ${token}`},
       payload: reportPayload({status: 'failed', error: {message: 'boom'}}),
     });
+    await nextStepForJob(jobId);
 
     const res = await app.inject({
       method: 'POST',
@@ -264,7 +281,7 @@ describe('POST /runs/jobs/current/steps/:stepId/report', () => {
     expect(res.json()).toEqual({ok: true, cancel: true});
     const after = await getStepsByJobId(jobId);
     expect(after[0]?.status).toBe('failed');
-    expect(after[1]?.status).toBe('cancelled');
+    expect(after[1]?.status).toBe('skipped');
   });
 
   test('rejects a result for a pending (never-dispatched) step with 409', async () => {


### PR DESCRIPTION
Continue workflow step dispatch after a step fails.

A failed step previously made the job finish immediately by cancelling the remaining pending steps. Conditional execution needs the server to keep evaluating later steps under `execution.failed == true`, so default-gated steps become `skipped` while explicit cleanup and failure-handling steps can still run.

This removes the eager cancel sweep from failure settlement, emits the steps-settled event when dispatch-time skips complete the job, and updates the report/next-step route expectations so runners stop only once no runnable step remains.

The touched package is private, so no changeset is included.

Closes ENG-831

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Continue dispatch after a step fails so conditional cleanup/failure-handling steps can run. Default-gated steps now skip at dispatch time, and the job finishes failed only when no runnable steps remain (ENG-831).

- **New Features**
  - Removed the eager cancel sweep on failure; remaining steps stay pending for condition checks.
  - Steps-settled event is emitted when dispatch-time skips finish the job; a failed final step still emits immediately.
  - `next-step` now returns done only when no runnable steps remain; `report-step` returns cancel:true only on a failed final step.

- **Migration**
  - Runners should keep calling `next-step` after reporting a failed step until it returns done.
  - Use `if: execution.failed` for failure-handling or cleanup; default-gated steps will auto-skip with `default_gate_rejected`.
  - If you relied on immediate cancel after failure, switch to dispatch-time evaluation.

<sup>Written for commit cfbf5fb7f98dd8255a77fadfd4750e101f06c957. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

