### PR TITLE
[e2e-setup-agent] Add OpenAI-compatible provider setup helper

### DIFF
--- a/e2e/setup/agent/src/index.test.ts
+++ b/e2e/setup/agent/src/index.test.ts
@@ -86,15 +86,13 @@ describe('agent e2e helper', () => {
 
   it('creates a local Ollama custom provider through the product route', async () => {
     requestJson.mockResolvedValueOnce({provider_id: 'local-ollama-e2e'});
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue(
-        new Response(JSON.stringify({models: [{name: 'smollm2:135m-instruct-q2_K'}]}), {
-          status: 200,
-          headers: {'content-type': 'application/json'},
-        }),
-      ),
+    const fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({models: [{name: 'smollm2:135m-instruct-q2_K'}]}), {
+        status: 200,
+        headers: {'content-type': 'application/json'},
+      }),
     );
+    vi.stubGlobal('fetch', fetch);
     const {createOllamaCustomProvider} = await import('./index.js');
 
     await createOllamaCustomProvider({
@@ -104,6 +102,7 @@ describe('agent e2e helper', () => {
       displayName: 'Local Ollama E2E',
     });
 
+    expect(fetch).toHaveBeenCalledWith('http://127.0.0.1:11434/api/tags');
     expect(createApiClient).toHaveBeenCalledWith({token: sessionToken});
     expect(requestJson).toHaveBeenCalledWith(
       'post',
@@ -119,6 +118,54 @@ describe('agent e2e helper', () => {
         },
       },
     );
+  });
+
+  it('creates an OpenAI-compatible custom provider without probing Ollama', async () => {
+    requestJson.mockResolvedValueOnce({provider_id: 'fake-openai-provider'});
+    const fetch = vi.fn();
+    vi.stubGlobal('fetch', fetch);
+    const {createOpenAiCompatibleCustomProvider} = await import('./index.js');
+
+    await createOpenAiCompatibleCustomProvider({
+      workspaceId,
+      sessionToken,
+      providerId: 'fake-openai-provider',
+      displayName: 'Deterministic Agent Provider',
+      baseUrl: 'http://127.0.0.1:9000/scripts/run-1/v1',
+      model: 'deterministic-output-agent',
+      modelMetadata: {max_output_tokens: 512},
+    });
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(createApiClient).toHaveBeenCalledWith({token: sessionToken});
+    expect(requestJson).toHaveBeenCalledWith(
+      'post',
+      `/workspaces/${workspaceId}/agent/custom-model-providers`,
+      {
+        json: {
+          slug: 'fake-openai-provider',
+          display_name: 'Deterministic Agent Provider',
+          api: 'openai-completions',
+          base_url: 'http://127.0.0.1:9000/scripts/run-1/v1',
+          models: [
+            {
+              id: 'deterministic-output-agent',
+              label: 'deterministic-output-agent',
+              max_output_tokens: 512,
+            },
+          ],
+          default_model: 'deterministic-output-agent',
+        },
+      },
+    );
+  });
+
+  it('exposes the OpenAI-compatible custom provider helper through the fixture helper', async () => {
+    const {createAgentHelper, createOpenAiCompatibleCustomProvider} = await import('./index.js');
+
+    const helper = createAgentHelper();
+
+    expect(helper.createOpenAiCompatibleCustomProvider).toBe(createOpenAiCompatibleCustomProvider);
   });
 
   it('lists model provider configs through the product route', async () => {

--- a/e2e/setup/agent/src/index.ts
+++ b/e2e/setup/agent/src/index.ts
@@ -1,5 +1,6 @@
 import type {
   CreateCustomModelProviderBodyDto,
+  CustomAgentModelDto,
   CustomModelProviderConfigDto,
   ListModelProviderConfigsResponseDto,
   ModelProviderApi,
@@ -9,7 +10,7 @@ import {createApiClient} from '@shipfox/e2e-core';
 
 const DEFAULT_OLLAMA_BASE_URL = 'http://127.0.0.1:11434';
 const DEFAULT_OLLAMA_MODEL = 'smollm2:135m-instruct-q2_K';
-const DEFAULT_OLLAMA_PROVIDER_API: ModelProviderApi = 'openai-completions';
+const OPENAI_COMPATIBLE_PROVIDER_API: ModelProviderApi = 'openai-completions';
 const TRAILING_SLASHES_RE = /\/+$/u;
 
 export interface OllamaConfig {
@@ -27,12 +28,24 @@ export interface RequireOllamaModelParams {
 export interface CreateOllamaCustomProviderParams {
   workspaceId: string;
   sessionToken: string;
-  api?: ModelProviderApi | undefined;
   baseUrl?: string | undefined;
   displayName?: string | undefined;
   model?: string | undefined;
+  modelMetadata?: OpenAiCompatibleCustomProviderModelMetadata | undefined;
   providerId?: ModelProviderRef | undefined;
 }
+
+export interface CreateOpenAiCompatibleCustomProviderParams {
+  workspaceId: string;
+  sessionToken: string;
+  baseUrl: string;
+  displayName: string;
+  model: string;
+  providerId: ModelProviderRef;
+  modelMetadata?: OpenAiCompatibleCustomProviderModelMetadata | undefined;
+}
+
+export type OpenAiCompatibleCustomProviderModelMetadata = Omit<CustomAgentModelDto, 'id' | 'label'>;
 
 export interface ListModelProviderConfigsParams {
   workspaceId: string;
@@ -84,6 +97,19 @@ export async function requireOllamaModel(
   return {baseUrl, model, openAiBaseUrl: `${baseUrl}/v1`};
 }
 
+export async function createOpenAiCompatibleCustomProvider(
+  params: CreateOpenAiCompatibleCustomProviderParams,
+): Promise<CustomModelProviderConfigDto> {
+  const body = createOpenAiCompatibleCustomProviderBody(params);
+  const client = createApiClient({token: params.sessionToken});
+
+  return await client.requestJson<CustomModelProviderConfigDto>(
+    'post',
+    `/workspaces/${params.workspaceId}/agent/custom-model-providers`,
+    {json: body},
+  );
+}
+
 export async function createOllamaCustomProvider(
   params: CreateOllamaCustomProviderParams,
 ): Promise<CustomModelProviderConfigDto> {
@@ -92,20 +118,15 @@ export async function createOllamaCustomProvider(
     model: params.model,
   });
   const providerId = params.providerId ?? createOllamaProviderId();
-  const body = createOllamaCustomProviderBody({
-    api: params.api ?? DEFAULT_OLLAMA_PROVIDER_API,
+  return await createOpenAiCompatibleCustomProvider({
     baseUrl: ollama.openAiBaseUrl,
     displayName: params.displayName ?? 'Local Ollama',
     model: ollama.model,
+    modelMetadata: params.modelMetadata,
     providerId,
+    sessionToken: params.sessionToken,
+    workspaceId: params.workspaceId,
   });
-  const client = createApiClient({token: params.sessionToken});
-
-  return await client.requestJson<CustomModelProviderConfigDto>(
-    'post',
-    `/workspaces/${params.workspaceId}/agent/custom-model-providers`,
-    {json: body},
-  );
 }
 
 export async function listModelProviderConfigs(
@@ -121,6 +142,7 @@ export async function listModelProviderConfigs(
 
 export function createAgentHelper() {
   return {
+    createOpenAiCompatibleCustomProvider,
     createOllamaCustomProvider,
     listModelProviderConfigs,
     requireOllamaModel,
@@ -142,19 +164,25 @@ export const agentHelper = {
   },
 };
 
-function createOllamaCustomProviderBody(params: {
-  api: ModelProviderApi;
+function createOpenAiCompatibleCustomProviderBody(params: {
   baseUrl: string;
   displayName: string;
   model: string;
+  modelMetadata?: OpenAiCompatibleCustomProviderModelMetadata | undefined;
   providerId: ModelProviderRef;
 }): CreateCustomModelProviderBodyDto {
+  const model = {
+    id: params.model,
+    label: params.model,
+    ...params.modelMetadata,
+  };
+
   return {
     slug: params.providerId,
     display_name: params.displayName,
-    api: params.api,
+    api: OPENAI_COMPATIBLE_PROVIDER_API,
     base_url: params.baseUrl,
-    models: [{id: params.model, label: params.model}],
+    models: [model],
     default_model: params.model,
   };
 }


### PR DESCRIPTION
Add a generic OpenAI-compatible custom-provider setup helper for E2E suites.

The deterministic provider work needs to register non-Ollama `openai-completions` endpoints through the same product HTTP route used by real custom providers. This extracts the reusable registration path from the Ollama helper, supports per-model metadata, and keeps `createOllamaCustomProvider` as a convenience wrapper that still verifies the configured Ollama model first.

This is limited to E2E setup helpers and does not change product custom-provider behavior.

Closes ENG-856

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a generic helper to register OpenAI-compatible custom providers in E2E suites via the product route. Enables deterministic providers for `openai-completions` (ENG-856) while keeping the Ollama helper as a probed wrapper; product behavior is unchanged.

- **New Features**
  - Added `createOpenAiCompatibleCustomProvider(...)` to register providers through `/workspaces/{id}/agent/custom-model-providers` with `api: 'openai-completions'`.
  - Supports per-model metadata (e.g., `max_output_tokens`) in the `models` list.
  - `createOllamaCustomProvider(...)` now delegates to the generic helper after verifying the Ollama model and using its `/v1` base URL.
  - Exposed via `createAgentHelper()`; tests cover no-probe behavior for the generic helper and Ollama’s model probe.

<sup>Written for commit 88bee44a8e4a57c3ba2e89e5e53f1a274b690154. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

