### PR TITLE
Add public README and security policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@
 </p>
 
 <p align="center">
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT" /></a>
-  <a href="https://github.com/ShipfoxHQ/shipfox/actions/workflows/ci.yml"><img src="https://github.com/ShipfoxHQ/shipfox/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs welcome" />
 </p>
 

--- a/README.md
+++ b/README.md
@@ -22,54 +22,23 @@ to finish, on compute you own. A software factory that assembles itself in your
 repo.
 
 ```yaml
-name: Fix Sentry issues & answer PR reviews
+name: Test and review
 runner: ubuntu-latest
-
-triggers:
-  on_issue:
-    source: sentry_acme         # a new Sentry issue starts the run
-    event: issue.created
-
 jobs:
-  fix:                            # opens the PR
+  ci:
     steps:
-      - model: claude-opus-4-8
-        prompt: >
-          Sentry reported "${{ event.title }}" (${{ event.webUrl }}).
-          Find the cause, fix it, and push a fix branch.
-      - key: create-pr             # stdout is just the PR URL
-        run: basename "$(gh pr create --fill)"   # → the PR number
-
-  review:
-    needs: fix
-    name: Review batch ${{ execution.index }}
-    listening:                     # event-driven job
-      on:
-        - source: github_acme
-          event: issue_comment.created
-          filter: event.issue.number == fix.output.pr_number
-      until:                       # resolves the listener
-        - source: github_acme
-          event: pull_request       # fires on merge / close
-      timeout: 30d
-      max_executions: 10
-      batch:
-        debounce: 5s              # collapse rapid comments
-        max_size: 10
-        max_wait: 1h
-    steps:
-      - model: claude-opus-4-8
-        prompt: |
-          Address every comment in this review batch:
-          ${{ execution.events.map(e, e.data.body) }}  # an array of issue comments
-          Push fixes and reply on the thread.
+      - run: npm test              # a shell step
+      - model: claude-opus-4-8     # an agent step, same job
+        prompt: Review the latest diff and flag any regressions.
 ```
 
 If you've written GitHub Actions, you already know how to read this file, and
-that's deliberate. What's different is what a step can do and the control flow
-around it: a Sentry issue starts the run, an agent finds the cause and opens a PR,
-then a **listening job** wakes on each batch of review comments and runs an agent
-to answer them, until the PR merges.
+that's deliberate. What's different is what a step can be: `run` executes a shell
+command, and an agent step hands the same job to a model that reads your code and
+acts. Events can go further and drive a workflow while it is still running, so a
+job can react to what arrives instead of running once. See
+[listening jobs](docs/concepts/listening-jobs.mdx) for event-driven, asynchronous
+workflows.
 
 ## Highlights
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,220 @@
-# platform
+<div align="center">
+  <img src="https://www.shipfox.io/og-image.png" alt="Shipfox" width="640" />
+</div>
+
+<p align="center">
+  <a href="https://www.shipfox.io/docs"><b>Docs</b></a> ·
+  <a href="#getting-started"><b>Getting started</b></a> ·
+  <a href="#core-concepts"><b>Concepts</b></a> ·
+  <a href="https://join.slack.com/t/shipfoxcommunity/shared_invite/zt-42wdu4lvl-KiYxEKCzzHUCafiC0EjbVA"><b>Slack community</b></a> ·
+  <a href="CONTRIBUTING.md"><b>Contributing</b></a>
+</p>
+
+<p align="center">
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT" /></a>
+  <a href="https://github.com/ShipfoxHQ/shipfox/actions/workflows/ci.yml"><img src="https://github.com/ShipfoxHQ/shipfox/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
+  <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs welcome" />
+</p>
+
+**Shipfox is a continuous shipping platform for workflows that reason and react.**
+
+Most automation is trigger-based: an event fires a fixed job graph, and the run
+plays out on rails. Shipfox is built on two shifts that go further.
+
+**Workflows reason.** A step isn't limited to a shell command. Any step can be an
+agent (a model with your repository checked out) that reads code, runs tools, and
+makes changes. Agents are first-class: they share one lifecycle with shell steps,
+so an agent can be **gated and retried until a real check passes**. It edits, your
+tests run, and the workflow loops back until they're green.
+
+**Workflows react.** An event is not only an entry point; it is a first-class
+control-flow signal. Beyond starting a run, events can advance a workflow while it
+is still running, so a run becomes a stateful process that reacts to what arrives
+rather than a one-shot graph. A [listening job](docs/concepts/listening-jobs.mdx)
+wakes on each batch of events and runs again inside the same run, until a
+resolution condition is met.
+
+Everything runs on **runners you own**, and every step, including the agent's full
+reasoning, streams live to the dashboard.
+
+```yaml
+name: Fix Sentry issues & answer PR reviews
+runner: ubuntu-latest
+
+triggers:
+  on_issue:
+    source: sentry_acme         # a new Sentry issue starts the run
+    event: issue.created
+
+jobs:
+  fix:                            # opens the PR
+    steps:
+      - model: claude-opus-4-8
+        prompt: >
+          Sentry reported "${{ event.title }}" (${{ event.webUrl }}).
+          Find the cause, fix it, and push a fix branch.
+      - key: create-pr             # stdout is just the PR URL
+        run: basename "$(gh pr create --fill)"   # → the PR number
+
+  review:
+    needs: fix
+    name: Review batch ${{ execution.index }}
+    listening:                     # event-driven job
+      on:
+        - source: github_acme
+          event: issue_comment.created
+          filter: event.issue.number == fix.output.pr_number
+      until:                       # resolves the listener
+        - source: github_acme
+          event: pull_request       # fires on merge / close
+      timeout: 30d
+      max_executions: 10
+      batch:
+        debounce: 5s              # collapse rapid comments
+        max_size: 10
+        max_wait: 1h
+    steps:
+      - model: claude-opus-4-8
+        prompt: |
+          Address every comment in this review batch:
+          ${{ execution.events.map(e, e.data.body) }}  # an array of issue comments
+          Push fixes and reply on the thread.
+```
+
+If you've written GitHub Actions, you already know how to read this file, and
+that's deliberate. What's different is what a step can do and the control flow
+around it: a Sentry issue starts the run, an agent finds the cause and opens a PR,
+then a **listening job** wakes on each batch of review comments and runs an agent
+to answer them, until the PR merges.
+
+## Highlights
+
+- **Workflows as code.** YAML under `.shipfox/workflows/`, versioned and reviewed
+  like the rest of your repo. No plugin, no action, no glue.
+- **Bounded retry loops.** A gate's `success_if` plus `restart_from` loops back to
+  an earlier step until a real check passes, automatically bounded, no scripting.
+- **See the agent think.** Agent steps stream structured events (messages,
+  thinking, tool calls, token usage, and cost), not just raw text.
+- **Your own runners, your own keys.** Runners poll outbound, so nothing connects
+  into your network. Model traffic leaves from your runners across 30+ providers.
+
+## How a run executes
+
+```
+event source → trigger match → run created (event data resolved into prompts)
+             → jobs scheduled as a needs DAG
+             → a runner on your compute polls outbound and claims a job
+             → it re-clones the repo and runs each step (shell or agent)
+             → a gate can loop back on failure
+             → logs and agent sessions stream live to the dashboard
+```
+
+## Core concepts
+
+| Concept | Summary |
+|---|---|
+| **Workflow** | A YAML file under `.shipfox/workflows/`, versioned and reviewed like code. One file, one workflow. |
+| **Trigger** | What starts a run: an event from a connected source, or an on-demand fire. |
+| **Job** | A group of steps on one runner. Jobs form a DAG via `needs` and are isolated, so each re-clones the repo. |
+| **Step** | A `run` shell command or an agent (`model` + `prompt`). Runs in order within a job. |
+| **Gate** | A CEL `success_if` on a step plus `on_failure.restart_from` to build bounded retry loops. |
+| **Runner** | A process you register on your own compute; matched to jobs by label. |
+
+## Repository layout
+
+Shipfox is a pnpm + Turborepo monorepo.
+
+| Path | Role |
+|---|---|
+| [`apps/api`](apps/api) | Control plane: definitions, triggers, dispatch, runs, logs, auth |
+| [`apps/client`](apps/client) | Operator dashboard: run detail, job graph, live log and agent-session tails |
+| [`apps/runner`](apps/runner) | Polls the API for jobs and executes their steps on the runner host |
+| [`apps/provisioner-docker`](apps/provisioner-docker) | Starts ephemeral, single-job runners on demand |
+| [`libs/`](libs) | Feature logic by tier: `api`, `client`, `runner`, `provisioner`, `shared` |
+| [`e2e/`](e2e) | End-to-end suites, including the full workflow run loop |
+| [`docs/`](docs) | Product documentation (Mintlify) |
+
+Public HTTP contracts are shared through sibling `*-dto` packages so the backend,
+client, and E2E helpers speak the same schema.
+
+## Getting started
+
+To run the full stack on your machine (API, dashboard, PostgreSQL, Temporal,
+object storage, and a local Git host), then connect a project, register a runner,
+and fire your first run, follow the
+[**Local Evaluation guide**](docs/installation/local.mdx)
+([shipfox.io/docs/installation/local](https://www.shipfox.io/docs/installation/local)).
+It walks through the whole loop end to end.
+
+Prerequisites: [mise](https://mise.jdx.dev/) (manages Node, pnpm, Turbo, Ollama)
+and [Docker](https://docs.docker.com/get-docker/).
+
+```sh
+# Install the pinned toolchain
+mise install
+
+# Start local service dependencies (PostgreSQL, Temporal, object storage, test VCS)
+docker compose up -d
+
+# Install workspace dependencies and build everything
+pnpm install
+turbo build
+
+# Run a dev app with hot reload
+pnpm --filter=@shipfox/api dev
+```
+
+Common tasks:
+
+```sh
+turbo check      # lint + format + import sorting
+turbo type       # type-check
+turbo test       # unit + integration tests (real Postgres, minimal mocks)
+```
+
+Scope any Turbo task to one package with `--filter`, e.g.
+`turbo test --filter=@shipfox/api...`. See [CONTRIBUTING.md](CONTRIBUTING.md) for
+the full setup, tooling, and workflow.
+
+## Deploying Shipfox
+
+Standing up Shipfox has two parts: a **control plane** (the stateless API and
+dashboard, backed by PostgreSQL, Temporal, and S3-compatible object storage) and
+one or more **runners** on compute you own. The runner ships as a Docker image and
+is configured through environment variables. See the installation docs for the
+local evaluation and self-hosting paths.
+
+## Documentation
+
+Full documentation lives in [`docs/`](docs) and is published at
+[shipfox.io/docs](https://www.shipfox.io/docs):
+
+- **Getting started:** connect a project, add a workflow, register a runner, fire a run
+- **Concepts:** workflows, jobs & steps, gates, triggers, runners, logging
+- **Guides:** agent steps, gate & retry loops, multi-job pipelines, triaging Sentry issues
+- **Reference:** workflow schema, step types, expressions (CEL), model providers, REST API
+- **Installation:** local evaluation and self-hosting
+
+## Community
+
+- **Slack:** join the [Shipfox community Slack](https://join.slack.com/t/shipfoxcommunity/shared_invite/zt-42wdu4lvl-KiYxEKCzzHUCafiC0EjbVA)
+  for help, ideas, and release news.
+- **Issues:** report bugs and request features on
+  [GitHub Issues](https://github.com/ShipfoxHQ/shipfox/issues).
+
+## Security
+
+Please report vulnerabilities privately by emailing **security@shipfox.io** rather
+than opening a public issue. See [SECURITY.md](SECURITY.md) for details. Shipfox's
+token and trust model is documented in the
+[auth security model](libs/api/auth/README.md).
+
+## Contributing
+
+Read [CONTRIBUTING.md](CONTRIBUTING.md) and the codebase conventions in
+[CLAUDE.md](CLAUDE.md) / [AGENTS.md](AGENTS.md) before opening a pull request. UI
+work should follow [DESIGN.md](DESIGN.md); E2E work follows [e2e/README.md](e2e/README.md).
+
+## License
+
+[MIT](LICENSE) © Shipfox

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ then a `gate` reruns the tests and sends the agent back until they pass.
 
 - **Workflows as code.** YAML under `.shipfox/workflows/`, versioned and reviewed
   like the rest of your repo. No plugin, no action, no glue.
+- **Trigger from your whole stack.** Start runs from GitHub, Sentry, Slack, Linear,
+  and more through integrations. Missing one? Point it at the generic webhook
+  integration and trigger on its events too. Connect several of the same provider
+  and target each independently.
 - **Bounded retry loops.** A gate's `success_if` plus `restart_from` loops back to
   an earlier step until a real check passes, automatically bounded, no scripting.
 - **See the agent think.** Agent steps stream structured events (messages,
@@ -65,7 +69,8 @@ then a `gate` reruns the tests and sends the agent back until they pass.
 | Concept | Summary |
 |---|---|
 | **Workflow** | A YAML file under `.shipfox/workflows/`, versioned and reviewed like code. One file, one workflow. |
-| **Trigger** | What starts a run: an event from a connected source, or an on-demand fire. |
+| **Trigger** | What starts a run: an event from a connected integration, or an on-demand fire. |
+| **Integration** | A connection to an external tool (GitHub, Sentry, Slack, Linear, ...) whose events start runs. Use the [generic webhook](docs/integrations/webhooks.mdx) to connect anything not built in. |
 | **Job** | A group of steps on one runner. Jobs form a DAG via `needs` and are isolated, so each re-clones the repo. |
 | **Step** | A `run` shell command or an agent (`model` + `prompt`). Runs in order within a job. |
 | **Gate** | A [`success_if` expression](docs/reference/expressions.mdx) on a step, such as `exit_code == 0`, plus `on_failure.restart_from` to build bounded retry loops. |
@@ -143,6 +148,7 @@ Full documentation lives in [`docs/`](docs) and is published at
 
 - **Getting started:** connect a project, add a workflow, register a runner, fire a run
 - **Concepts:** workflows, jobs & steps, gates, triggers, runners, logging
+- **Integrations:** GitHub, Sentry, Slack, Linear, and custom webhooks
 - **Guides:** agent steps, gate & retry loops, multi-job pipelines, triaging Sentry issues
 - **Reference:** workflow schema, step types, expressions, model providers, REST API
 - **Installation:** local evaluation and self-hosting

--- a/README.md
+++ b/README.md
@@ -47,10 +47,7 @@ jobs:
 If you've written GitHub Actions, you already know how to read this file, and
 that's deliberate. What's different is what a step can be and the control flow
 around it: a Sentry issue starts the run, an agent reproduces and fixes the cause,
-then a `gate` reruns the tests and sends the agent back until they pass. Events can
-also drive a workflow while it is still running; see
-[listening jobs](docs/concepts/listening-jobs.mdx) for event-driven, asynchronous
-workflows.
+then a `gate` reruns the tests and sends the agent back until they pass.
 
 ## Highlights
 
@@ -63,17 +60,6 @@ workflows.
 - **Your own runners, your own keys.** Runners poll outbound, so nothing connects
   into your network. Model traffic leaves from your runners across 30+ providers.
 
-## How a run executes
-
-```
-event source → trigger match → run created (event data resolved into prompts)
-             → jobs scheduled as a needs DAG
-             → a runner on your compute polls outbound and claims a job
-             → it re-clones the repo and runs each step (shell or agent)
-             → a gate can loop back on failure
-             → logs and agent sessions stream live to the dashboard
-```
-
 ## Core concepts
 
 | Concept | Summary |
@@ -83,6 +69,7 @@ event source → trigger match → run created (event data resolved into prompts
 | **Job** | A group of steps on one runner. Jobs form a DAG via `needs` and are isolated, so each re-clones the repo. |
 | **Step** | A `run` shell command or an agent (`model` + `prompt`). Runs in order within a job. |
 | **Gate** | A CEL `success_if` on a step plus `on_failure.restart_from` to build bounded retry loops. |
+| **Listening job** | A [job that waits on events](docs/concepts/listening-jobs.mdx) and runs again per batch inside the same run, until a resolution condition. Drives event-driven, asynchronous workflows. |
 | **Runner** | A process you register on your own compute; matched to jobs by label. |
 
 ## Repository layout

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Shipfox is a pnpm + Turborepo monorepo.
 | [`apps/provisioner-docker`](apps/provisioner-docker) | Starts ephemeral, single-job runners on demand |
 | [`libs/`](libs) | Feature logic by tier: `api`, `client`, `runner`, `provisioner`, `shared` |
 | [`e2e/`](e2e) | End-to-end suites, including the full workflow run loop |
-| [`docs/`](docs) | Product documentation (Mintlify) |
+| [`docs/`](docs) | Product documentation |
 
 Public HTTP contracts are shared through sibling `*-dto` packages so the backend,
 client, and E2E helpers speak the same schema.

--- a/README.md
+++ b/README.md
@@ -14,26 +14,12 @@
   <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs welcome" />
 </p>
 
-**Shipfox is a continuous shipping platform for workflows that reason and react.**
+**Build your software factory.**
 
-Most automation is trigger-based: an event fires a fixed job graph, and the run
-plays out on rails. Shipfox is built on two shifts that go further.
-
-**Workflows reason.** A step isn't limited to a shell command. Any step can be an
-agent (a model with your repository checked out) that reads code, runs tools, and
-makes changes. Agents are first-class: they share one lifecycle with shell steps,
-so an agent can be **gated and retried until a real check passes**. It edits, your
-tests run, and the workflow loops back until they're green.
-
-**Workflows react.** An event is not only an entry point; it is a first-class
-control-flow signal. Beyond starting a run, events can advance a workflow while it
-is still running, so a run becomes a stateful process that reacts to what arrives
-rather than a one-shot graph. A [listening job](docs/concepts/listening-jobs.mdx)
-wakes on each batch of events and runs again inside the same run, until a
-resolution condition is met.
-
-Everything runs on **runners you own**, and every step, including the agent's full
-reasoning, streams live to the dashboard.
+Shipfox is a continuous shipping platform for workflows that reason and react:
+every step is a shell command or an AI agent, and events drive the run from start
+to finish, on compute you own. A software factory that assembles itself in your
+repo.
 
 ```yaml
 name: Fix Sentry issues & answer PR reviews

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ then a `gate` reruns the tests and sends the agent back until they pass.
 | **Integration** | A connection to an external tool (GitHub, Sentry, Slack, Linear, ...) whose events start runs. Use the [generic webhook](docs/integrations/webhooks.mdx) to connect anything not built in. |
 | **Job** | A group of steps on one runner. Jobs form a DAG via `needs` and are isolated, so each re-clones the repo. |
 | **Step** | A `run` shell command or an agent (`model` + `prompt`, on the `pi` or `claude` harness). Runs in order within a job. |
-| **Gate** | A check on a step ([`success`](docs/reference/expressions.mdx), default `exit_code == 0`) plus an `on_failure` action (`restart_from` an earlier step, with optional `feedback` to the agent) to build bounded retry loops. |
+| **Gate** | A pass/fail [check on a step](docs/concepts/gates.mdx) that retries from an earlier step when it fails. Bounded retry loops, no scripting. |
 | **Listening job** | A [job that waits on events](docs/concepts/listening-jobs.mdx) and runs again per batch inside the same run, until a resolution condition. Drives event-driven, asynchronous workflows. |
 | **Runner** | A process you register on your own compute; matched to jobs by label. |
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ then a `gate` reruns the tests and sends the agent back until they pass.
   and more through integrations. Missing one? Point it at the generic webhook
   integration and trigger on its events too. Connect several of the same provider
   and target each independently.
-- **Bounded retry loops.** A gate's `success_if` plus `restart_from` loops back to
-  an earlier step until a real check passes, automatically bounded, no scripting.
+- **Automatic retry loops.** Guard a step with a check (a *gate*): when it fails,
+  the workflow loops back to an earlier step and tries again, up to a safe limit.
+  That is how an agent keeps going until the tests pass, with no scripting.
 - **Long-running, event-driven agents.** A listening job stays alive across a run
   and runs an agent on each new batch of events (PR review comments, new issues)
   until a resolution condition is met. Asynchronous agent loops, not one-shot runs.

--- a/README.md
+++ b/README.md
@@ -77,69 +77,15 @@ then a `gate` reruns the tests and sends the agent back until they pass.
 | **Listening job** | A [job that waits on events](docs/concepts/listening-jobs.mdx) and runs again per batch inside the same run, until a resolution condition. Drives event-driven, asynchronous workflows. |
 | **Runner** | A process you register on your own compute; matched to jobs by label. |
 
-## Repository layout
-
-Shipfox is a pnpm + Turborepo monorepo.
-
-| Path | Role |
-|---|---|
-| [`apps/api`](apps/api) | Control plane: definitions, triggers, dispatch, runs, logs, auth |
-| [`apps/client`](apps/client) | Operator dashboard: run detail, job graph, live log and agent-session tails |
-| [`apps/runner`](apps/runner) | Polls the API for jobs and executes their steps on the runner host |
-| [`apps/provisioner-docker`](apps/provisioner-docker) | Starts ephemeral, single-job runners on demand |
-| [`libs/`](libs) | Feature logic by tier: `api`, `client`, `runner`, `provisioner`, `shared` |
-| [`e2e/`](e2e) | End-to-end suites, including the full workflow run loop |
-| [`docs/`](docs) | Product documentation |
-
-Public HTTP contracts are shared through sibling `*-dto` packages so the backend,
-client, and E2E helpers speak the same schema.
-
 ## Getting started
 
-To run the full stack on your machine (API, dashboard, PostgreSQL, Temporal,
-object storage, and a local Git host), then connect a project, register a runner,
-and fire your first run, follow the
-[**Local Evaluation guide**](docs/installation/local.mdx)
-([shipfox.io/docs/installation/local](https://www.shipfox.io/docs/installation/local)).
-It walks through the whole loop end to end.
+Try Shipfox on your machine with the
+[Local Evaluation guide](https://www.shipfox.io/docs/installation/local): it runs
+the full stack locally, then walks you through connecting a project, registering a
+runner, and firing your first run. To run Shipfox for your team, see the
+[installation docs](https://www.shipfox.io/docs/installation).
 
-Prerequisites: [mise](https://mise.jdx.dev/) (manages Node, pnpm, Turbo, Ollama)
-and [Docker](https://docs.docker.com/get-docker/).
-
-```sh
-# Install the pinned toolchain
-mise install
-
-# Start local service dependencies (PostgreSQL, Temporal, object storage, test VCS)
-docker compose up -d
-
-# Install workspace dependencies and build everything
-pnpm install
-turbo build
-
-# Run a dev app with hot reload
-pnpm --filter=@shipfox/api dev
-```
-
-Common tasks:
-
-```sh
-turbo check      # lint + format + import sorting
-turbo type       # type-check
-turbo test       # unit + integration tests (real Postgres, minimal mocks)
-```
-
-Scope any Turbo task to one package with `--filter`, e.g.
-`turbo test --filter=@shipfox/api...`. See [CONTRIBUTING.md](CONTRIBUTING.md) for
-the full setup, tooling, and workflow.
-
-## Deploying Shipfox
-
-Standing up Shipfox has two parts: a **control plane** (the stateless API and
-dashboard, backed by PostgreSQL, Temporal, and S3-compatible object storage) and
-one or more **runners** on compute you own. The runner ships as a Docker image and
-is configured through environment variables. See the installation docs for the
-local evaluation and self-hosting paths.
+Working on Shipfox itself? See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -22,21 +22,33 @@ to finish, on compute you own. A software factory that assembles itself in your
 repo.
 
 ```yaml
-name: Test and review
+name: Fix new Sentry issues
 runner: ubuntu-latest
+triggers:
+  on_issue:
+    source: sentry_acme            # a new Sentry issue starts the run
+    event: issue.created
 jobs:
-  ci:
+  fix:
     steps:
-      - run: npm test              # a shell step
-      - model: claude-opus-4-8     # an agent step, same job
-        prompt: Review the latest diff and flag any regressions.
+      - run: npm install
+      - key: fix                    # an agent step
+        model: claude-opus-4-8
+        prompt: >
+          Sentry reported "${{ event.title }}" (${{ event.webUrl }}).
+          Reproduce it in this repository, find the root cause, and fix it.
+      - run: npm test               # verify the fix
+        gate:
+          success_if: exit_code == 0
+          on_failure:
+            restart_from: fix        # send the agent back until the tests pass
 ```
 
 If you've written GitHub Actions, you already know how to read this file, and
-that's deliberate. What's different is what a step can be: `run` executes a shell
-command, and an agent step hands the same job to a model that reads your code and
-acts. Events can go further and drive a workflow while it is still running, so a
-job can react to what arrives instead of running once. See
+that's deliberate. What's different is what a step can be and the control flow
+around it: a Sentry issue starts the run, an agent reproduces and fixes the cause,
+then a `gate` reruns the tests and sends the agent back until they pass. Events can
+also drive a workflow while it is still running; see
 [listening jobs](docs/concepts/listening-jobs.mdx) for event-driven, asynchronous
 workflows.
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,14 @@ then a `gate` reruns the tests and sends the agent back until they pass.
   and target each independently.
 - **Bounded retry loops.** A gate's `success_if` plus `restart_from` loops back to
   an earlier step until a real check passes, automatically bounded, no scripting.
+- **Long-running, event-driven agents.** A listening job stays alive across a run
+  and runs an agent on each new batch of events (PR review comments, new issues)
+  until a resolution condition is met. Asynchronous agent loops, not one-shot runs.
 - **See the agent think.** Agent steps stream structured events (messages,
   thinking, tool calls, token usage, and cost), not just raw text.
+- **Pick the agent, not just the model.** Run an agent step on the `pi` harness
+  (any of 30+ providers) or the `claude` harness (the Claude Agent SDK on your
+  Anthropic key), chosen per step.
 - **Your own runners, your own keys.** Runners poll outbound, so nothing connects
   into your network. Model traffic leaves from your runners across 30+ providers.
 
@@ -72,7 +78,7 @@ then a `gate` reruns the tests and sends the agent back until they pass.
 | **Trigger** | What starts a run: an event from a connected integration, or an on-demand fire. |
 | **Integration** | A connection to an external tool (GitHub, Sentry, Slack, Linear, ...) whose events start runs. Use the [generic webhook](docs/integrations/webhooks.mdx) to connect anything not built in. |
 | **Job** | A group of steps on one runner. Jobs form a DAG via `needs` and are isolated, so each re-clones the repo. |
-| **Step** | A `run` shell command or an agent (`model` + `prompt`). Runs in order within a job. |
+| **Step** | A `run` shell command or an agent (`model` + `prompt`, on the `pi` or `claude` harness). Runs in order within a job. |
 | **Gate** | A [`success_if` expression](docs/reference/expressions.mdx) on a step, such as `exit_code == 0`, plus `on_failure.restart_from` to build bounded retry loops. |
 | **Listening job** | A [job that waits on events](docs/concepts/listening-jobs.mdx) and runs again per batch inside the same run, until a resolution condition. Drives event-driven, asynchronous workflows. |
 | **Runner** | A process you register on your own compute; matched to jobs by label. |

--- a/README.md
+++ b/README.md
@@ -143,15 +143,7 @@ local evaluation and self-hosting paths.
 
 ## Documentation
 
-Full documentation lives in [`docs/`](docs) and is published at
-[shipfox.io/docs](https://www.shipfox.io/docs):
-
-- **Getting started:** connect a project, add a workflow, register a runner, fire a run
-- **Concepts:** workflows, jobs & steps, gates, triggers, runners, logging
-- **Integrations:** GitHub, Sentry, Slack, Linear, and custom webhooks
-- **Guides:** agent steps, gate & retry loops, multi-job pipelines, triaging Sentry issues
-- **Reference:** workflow schema, step types, expressions, model providers, REST API
-- **Installation:** local evaluation and self-hosting
+Full documentation is published at [shipfox.io/docs](https://www.shipfox.io/docs).
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ jobs:
           Reproduce it in this repository, find the root cause, and fix it.
       - run: npm test               # verify the fix
         gate:
-          success_if: exit_code == 0
           on_failure:
             restart_from: fix        # send the agent back until the tests pass
+            feedback: Unit tests are failing
 ```
 
 If you've written GitHub Actions, you already know how to read this file, and
@@ -80,7 +80,7 @@ then a `gate` reruns the tests and sends the agent back until they pass.
 | **Integration** | A connection to an external tool (GitHub, Sentry, Slack, Linear, ...) whose events start runs. Use the [generic webhook](docs/integrations/webhooks.mdx) to connect anything not built in. |
 | **Job** | A group of steps on one runner. Jobs form a DAG via `needs` and are isolated, so each re-clones the repo. |
 | **Step** | A `run` shell command or an agent (`model` + `prompt`, on the `pi` or `claude` harness). Runs in order within a job. |
-| **Gate** | A [`success_if` expression](docs/reference/expressions.mdx) on a step, such as `exit_code == 0`, plus `on_failure.restart_from` to build bounded retry loops. |
+| **Gate** | A check on a step ([`success`](docs/reference/expressions.mdx), default `exit_code == 0`) plus an `on_failure` action (`restart_from` an earlier step, with optional `feedback` to the agent) to build bounded retry loops. |
 | **Listening job** | A [job that waits on events](docs/concepts/listening-jobs.mdx) and runs again per batch inside the same run, until a resolution condition. Drives event-driven, asynchronous workflows. |
 | **Runner** | A process you register on your own compute; matched to jobs by label. |
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ then a `gate` reruns the tests and sends the agent back until they pass.
 | **Trigger** | What starts a run: an event from a connected source, or an on-demand fire. |
 | **Job** | A group of steps on one runner. Jobs form a DAG via `needs` and are isolated, so each re-clones the repo. |
 | **Step** | A `run` shell command or an agent (`model` + `prompt`). Runs in order within a job. |
-| **Gate** | A CEL `success_if` on a step plus `on_failure.restart_from` to build bounded retry loops. |
+| **Gate** | A [`success_if` expression](docs/reference/expressions.mdx) on a step, such as `exit_code == 0`, plus `on_failure.restart_from` to build bounded retry loops. |
 | **Listening job** | A [job that waits on events](docs/concepts/listening-jobs.mdx) and runs again per batch inside the same run, until a resolution condition. Drives event-driven, asynchronous workflows. |
 | **Runner** | A process you register on your own compute; matched to jobs by label. |
 
@@ -144,7 +144,7 @@ Full documentation lives in [`docs/`](docs) and is published at
 - **Getting started:** connect a project, add a workflow, register a runner, fire a run
 - **Concepts:** workflows, jobs & steps, gates, triggers, runners, logging
 - **Guides:** agent steps, gate & retry loops, multi-job pipelines, triaging Sentry issues
-- **Reference:** workflow schema, step types, expressions (CEL), model providers, REST API
+- **Reference:** workflow schema, step types, expressions, model providers, REST API
 - **Installation:** local evaluation and self-hosting
 
 ## Community

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+We take the security of Shipfox seriously and appreciate the efforts of security
+researchers and users who report vulnerabilities to us responsibly.
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Instead, email us at **security@shipfox.io**. If you would like to encrypt your
+report, ask us for a public key in your first message.
+
+Please include as much of the following as you can, to help us triage the issue
+quickly:
+
+- The type of issue (for example: authentication bypass, token leakage, injection,
+  privilege escalation).
+- The affected component, package, or endpoint, and the version, branch, or commit.
+- Step-by-step instructions to reproduce the issue.
+- Proof-of-concept or exploit code, if available.
+- The impact of the issue, including how an attacker might exploit it.
+
+## What to expect
+
+- We will acknowledge your report within **3 business days**.
+- We will keep you informed as we investigate and work on a fix.
+- We will let you know when the issue is resolved, and we are happy to credit you
+  in the disclosure unless you prefer to remain anonymous.
+
+Please give us a reasonable amount of time to address the issue before any public
+disclosure.
+
+## Scope
+
+Reports about the code in this repository and the Shipfox service are in scope.
+When in doubt, email us and we will help you determine whether an issue is in
+scope.
+
+Thank you for helping keep Shipfox and its users safe.


### PR DESCRIPTION
Introduce a public README for the repository, which was previously effectively
empty (`# platform`), plus a `SECURITY.md` responsible-disclosure policy.

The README presents Shipfox on its own terms: a continuous shipping platform for
workflows that reason (agent steps) and react (event-driven listening jobs). It
leads with the why, shows a worked workflow example, then covers core concepts,
the monorepo layout, local setup (pointing at the Local Evaluation guide), and
links to docs and the community Slack. Content and positioning follow the docs
tree on `docs/full`.

`SECURITY.md` adds a standard policy directing vulnerability reports to
security@shipfox.io, referenced from the README's Security section.

Note: several links point into `docs/` (and the logo uses the absolute og-image
URL, which already resolves). The relative `docs/` links resolve once `docs/full`
merges to `main`.

Closes ENG-470

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a public README that explains Shipfox and shows a Sentry‑fix workflow with a `gate` retry loop using `on_failure.restart_from` and agent `feedback`. Adds `SECURITY.md` for responsible disclosure and updates the Gate concept to the current schema, trimmed to a short summary with a docs link. Fixes ENG‑470.

- **New Features**
  - New README with why Shipfox, a single‑job run+agent example, a Core concepts table, Getting started, and community links.
  - Gate example and concept: drop explicit success; use `on_failure.restart_from` with optional `feedback`; Core concepts reflect default `success`/`on_failure`; Gate row trimmed to a short summary with a docs link.
  - Emphasized integrations (GitHub/Sentry/Slack/Linear) and the generic webhook; introduced the Integration concept with docs links.
  - Highlighted listening jobs and per‑step harness choice (`pi` across 30+ providers or `claude` via the Claude Agent SDK); tightened intro and removed CI/license badges, the run‑flow diagram, and CEL jargon.

<sup>Written for commit 950ae9722935debbbab2730f0a419cf8f2a8785f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

