### PR TITLE
[api/workflows] Add condition evaluation traces

### DIFF
--- a/libs/api/workflows/drizzle/0000_initial.sql
+++ b/libs/api/workflows/drizzle/0000_initial.sql
@@ -127,6 +127,7 @@ CREATE TABLE "workflows_steps" (
 	"source_location" jsonb,
 	"status" "workflows_step_status" DEFAULT 'pending' NOT NULL,
 	"status_reason" "workflows_step_status_reason",
+	"evaluation_trace" jsonb,
 	"type" text NOT NULL,
 	"config" jsonb NOT NULL,
 	"condition" jsonb,

--- a/libs/api/workflows/drizzle/meta/0000_snapshot.json
+++ b/libs/api/workflows/drizzle/meta/0000_snapshot.json
@@ -934,6 +934,12 @@
           "primaryKey": false,
           "notNull": false
         },
+        "evaluation_trace": {
+          "name": "evaluation_trace",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
         "type": {
           "name": "type",
           "type": "text",

--- a/libs/api/workflows/src/core/condition-trace.ts
+++ b/libs/api/workflows/src/core/condition-trace.ts
@@ -1,0 +1,64 @@
+import {
+  type AvailabilitySite,
+  capTraceEntries,
+  evaluationTraceEntry,
+  predicateTraceEntry,
+  type RoutedExpression,
+  type WorkflowExpression,
+} from '@shipfox/expression';
+import type {PersistedEvaluationTraceEntry} from './entities/step.js';
+
+const DEFAULT_JOB_CONDITION_SOURCE = 'needs.all(n, n.status == "succeeded")';
+const DEFAULT_STEP_CONDITION_SOURCE = '!execution.failed';
+
+export function explicitConditionTrace(params: {
+  readonly expression: WorkflowExpression;
+  readonly field: 'job.if' | 'step.if';
+  readonly route: RoutedExpression;
+  readonly site: AvailabilitySite;
+  readonly value: boolean;
+  readonly degraded: boolean;
+}): readonly PersistedEvaluationTraceEntry[] {
+  return capTraceEntries([
+    {
+      ...predicateTraceEntry({
+        expression: params.expression.source,
+        route: params.route,
+        site: params.site,
+        value: params.value,
+        degraded: params.degraded,
+      }),
+      field: params.field,
+    },
+  ]);
+}
+
+export function defaultJobConditionTrace(): readonly PersistedEvaluationTraceEntry[] {
+  return capTraceEntries([
+    {
+      ...evaluationTraceEntry({
+        expression: DEFAULT_JOB_CONDITION_SOURCE,
+        roots: ['needs'],
+        fillTarget: 'job-activation',
+        evaluatedAt: 'job-activation',
+        value: 'false',
+      }),
+      field: 'job.default_gate',
+    },
+  ]);
+}
+
+export function defaultStepConditionTrace(): readonly PersistedEvaluationTraceEntry[] {
+  return capTraceEntries([
+    {
+      ...evaluationTraceEntry({
+        expression: DEFAULT_STEP_CONDITION_SOURCE,
+        roots: ['execution'],
+        fillTarget: 'step-dispatch',
+        evaluatedAt: 'step-dispatch',
+        value: 'false',
+      }),
+      field: 'step.default_gate',
+    },
+  ]);
+}

--- a/libs/api/workflows/src/core/entities/step.ts
+++ b/libs/api/workflows/src/core/entities/step.ts
@@ -77,6 +77,7 @@ export interface Step {
   sourceLocation: StepSourceLocation | null;
   status: StepStatus;
   statusReason: StepStatusReason | null;
+  evaluationTrace: readonly PersistedEvaluationTraceEntry[] | null;
   type: string;
   config: Record<string, unknown>;
   condition: WorkflowExpression | null;

--- a/libs/api/workflows/src/core/job-execution.test.ts
+++ b/libs/api/workflows/src/core/job-execution.test.ts
@@ -338,6 +338,7 @@ describe('nextStepForJob', () => {
     expect(after.find((step) => step.id === skippedStep.id)).toMatchObject({
       status: 'skipped',
       statusReason: 'condition_rejected',
+      evaluationTrace: [conditionTrace('step.if', 'false', [], false)],
     });
     expect(after.find((step) => step.id === runnableStep.id)?.status).toBe('running');
     expect(await getStepAttempts(jobId)).toMatchObject([{stepId: runnableStep.id}]);
@@ -360,6 +361,7 @@ describe('nextStepForJob', () => {
     expect(after.find((step) => step.id === skippedStep.id)).toMatchObject({
       status: 'skipped',
       statusReason: 'condition_errored',
+      evaluationTrace: [conditionTrace('step.if', '1 / 0 == 0', [], false, true)],
     });
     expect(await getStepAttempts(jobId)).toMatchObject([{stepId: runnableStep.id}]);
   });
@@ -416,12 +418,40 @@ describe('nextStepForJob', () => {
     expect(after.find((step) => step.id === defaultGated.id)).toMatchObject({
       status: 'skipped',
       statusReason: 'default_gate_rejected',
+      evaluationTrace: [
+        {
+          expression: '!execution.failed',
+          roots: ['execution'],
+          fillTarget: 'step-dispatch',
+          evaluatedAt: 'step-dispatch',
+          value: 'false',
+          field: 'step.default_gate',
+        },
+      ],
     });
   });
 });
 
 function conditionExpression(source: string) {
   return createWorkflowExpression({source, check: {mode: 'syntax'}});
+}
+
+function conditionTrace(
+  field: 'step.if',
+  expression: string,
+  roots: string[],
+  value: boolean,
+  degraded = false,
+) {
+  return {
+    expression,
+    roots,
+    fillTarget: 'step-dispatch',
+    evaluatedAt: 'step-dispatch',
+    value: String(value),
+    ...(degraded ? {degraded: true} : {}),
+    field,
+  };
 }
 
 function stepOutputField(stepKey: string, outputKey: string) {

--- a/libs/api/workflows/src/core/job-execution.ts
+++ b/libs/api/workflows/src/core/job-execution.ts
@@ -26,8 +26,9 @@ import {
   recordWorkflowJobExecutionStepsSettled,
   recordWorkflowStepRestartEnqueued,
 } from '#metrics/instance.js';
+import {defaultStepConditionTrace, explicitConditionTrace} from './condition-trace.js';
 import type {JobExecution} from './entities/job-execution.js';
-import type {Step, StepStatusReason} from './entities/step.js';
+import type {PersistedEvaluationTraceEntry, Step, StepStatusReason} from './entities/step.js';
 import {
   AgentConfigUnresolvableError,
   InterpolationUnresolvableError,
@@ -82,7 +83,13 @@ interface PendingStepDispatchParams {
   readonly tx: Tx;
 }
 
-type StepConditionOutcome = {kind: 'run'} | {kind: 'skip'; statusReason: StepStatusReason};
+type StepConditionOutcome =
+  | {kind: 'run'}
+  | {
+      kind: 'skip';
+      statusReason: StepStatusReason;
+      evaluationTrace: readonly PersistedEvaluationTraceEntry[];
+    };
 
 async function nextStepForJobExecutionInTransaction(
   jobExecutionId: string,
@@ -145,6 +152,7 @@ async function nextStepForJobExecutionInTransaction(
         jobExecutionId,
         stepId: pending.id,
         statusReason: condition.statusReason,
+        evaluationTrace: condition.evaluationTrace,
       },
       tx,
     );
@@ -152,6 +160,7 @@ async function nextStepForJobExecutionInTransaction(
       ...pending,
       status: 'skipped' as const,
       statusReason: condition.statusReason,
+      evaluationTrace: condition.evaluationTrace,
       error: null,
     };
     currentSteps = currentSteps.map((step) => (step.id === pending.id ? skippedStep : step));
@@ -239,7 +248,11 @@ function evaluateStepCondition(params: {
   if (condition === null) {
     const execution = params.context.values.execution as {failed?: unknown} | undefined;
     return execution?.failed === true
-      ? {kind: 'skip', statusReason: 'default_gate_rejected'}
+      ? {
+          kind: 'skip',
+          statusReason: 'default_gate_rejected',
+          evaluationTrace: defaultStepConditionTrace(),
+        }
       : {kind: 'run'};
   }
 
@@ -249,8 +262,20 @@ function evaluateStepCondition(params: {
     site: params.context.site,
     context: params.context.values,
   });
-  if (outcome.evaluationFailed) return {kind: 'skip', statusReason: 'condition_errored'};
-  return outcome.value ? {kind: 'run'} : {kind: 'skip', statusReason: 'condition_rejected'};
+  const evaluationTrace = explicitConditionTrace({
+    expression: condition,
+    field: 'step.if',
+    route: outcome.route,
+    site: params.context.site,
+    value: outcome.value,
+    degraded: outcome.evaluationFailed,
+  });
+  if (outcome.evaluationFailed) {
+    return {kind: 'skip', statusReason: 'condition_errored', evaluationTrace};
+  }
+  return outcome.value
+    ? {kind: 'run'}
+    : {kind: 'skip', statusReason: 'condition_rejected', evaluationTrace};
 }
 
 function toDispatchConfigError(error: unknown): DispatchConfigError | null {

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
@@ -775,6 +775,7 @@ function step(overrides: Partial<Step> = {}): Step {
     sourceLocation: null,
     status: 'pending',
     statusReason: null,
+    evaluationTrace: null,
     type: 'run',
     config: {},
     condition: null,

--- a/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
+++ b/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
@@ -28,6 +28,7 @@ function step(overrides: Partial<Step>): Step {
     sourceLocation: null,
     status: 'pending',
     statusReason: null,
+    evaluationTrace: null,
     type: 'run',
     config: {},
     condition: null,

--- a/libs/api/workflows/src/core/step-transition/decide-step-transition.test.ts
+++ b/libs/api/workflows/src/core/step-transition/decide-step-transition.test.ts
@@ -9,6 +9,7 @@ function step(overrides: Partial<Step> & {id: string; position: number}): Step {
     sourceLocation: null,
     status: 'pending',
     statusReason: null,
+    evaluationTrace: null,
     type: 'run',
     config: {},
     condition: null,

--- a/libs/api/workflows/src/db/schema/steps.ts
+++ b/libs/api/workflows/src/db/schema/steps.ts
@@ -14,6 +14,7 @@ import {
   uuid,
 } from 'drizzle-orm/pg-core';
 import {
+  type PersistedEvaluationTraceEntry,
   STEP_STATUS_REASONS,
   type Step,
   type StepConfigDispatchPlan,
@@ -43,6 +44,7 @@ export const steps = pgTable(
     sourceLocation: jsonb('source_location').$type<Step['sourceLocation']>(),
     status: stepStatusEnum('status').notNull().default('pending'),
     statusReason: stepStatusReasonEnum('status_reason'),
+    evaluationTrace: jsonb('evaluation_trace').$type<readonly PersistedEvaluationTraceEntry[]>(),
     type: text('type').notNull(),
     config: jsonb('config').notNull().$type<Record<string, unknown>>(),
     condition: jsonb('condition').$type<WorkflowExpression>(),
@@ -81,6 +83,7 @@ export function toStep(row: StepDb): Step {
     sourceLocation: row.sourceLocation ?? null,
     status: row.status,
     statusReason: toStepStatusReason(row.statusReason),
+    evaluationTrace: row.evaluationTrace ?? null,
     type: row.type,
     config: row.config as Record<string, unknown>,
     condition: (row.condition as WorkflowExpression) ?? null,

--- a/libs/api/workflows/src/db/workflow-runs.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs.test.ts
@@ -68,6 +68,24 @@ function expression(source: string) {
   return createWorkflowExpression({source, check: {mode: 'syntax'}});
 }
 
+function conditionTrace(
+  field: 'job.if',
+  expression: string,
+  roots: string[],
+  value: boolean,
+  degraded = false,
+) {
+  return {
+    expression,
+    roots,
+    fillTarget: 'job-activation',
+    evaluatedAt: 'job-activation',
+    value: String(value),
+    ...(degraded ? {degraded: true} : {}),
+    field,
+  };
+}
+
 function stepOutputField(stepKey: string, outputKey: string) {
   return {
     segments: [
@@ -307,6 +325,9 @@ describe('evaluateJobActivations', () => {
     const skipped = await jobByKey(run.id, 'notify');
     expect(skipped.status).toBe('skipped');
     expect(skipped.statusReason).toBe('condition_rejected');
+    expect(skipped.evaluationTrace).toEqual([
+      conditionTrace('job.if', 'jobs.build.status == "failed"', ['jobs'], false),
+    ]);
   });
 
   it('evaluates fan-in needs aggregation and dependency outputs from persisted state', async () => {
@@ -397,6 +418,9 @@ describe('evaluateJobActivations', () => {
     ]);
     const skipped = await jobByKey(run.id, 'notify');
     expect(skipped.statusReason).toBe('condition_errored');
+    expect(skipped.evaluationTrace).toEqual([
+      conditionTrace('job.if', 'jobs.build.outputs.sha.missing == "abc123"', ['jobs'], false, true),
+    ]);
   });
 });
 

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -43,6 +43,7 @@ import {
   type SQL,
   sql,
 } from 'drizzle-orm';
+import {explicitConditionTrace} from '#core/condition-trace.js';
 import {isJobTerminal, type Job, type JobStatus, type JobStatusReason} from '#core/entities/job.js';
 import type {JobExecution, JobExecutionStatus} from '#core/entities/job-execution.js';
 import type {
@@ -1235,6 +1236,14 @@ export async function evaluateJobActivations(
       }
 
       const statusReason = outcome.evaluationFailed ? 'condition_errored' : 'condition_rejected';
+      const evaluationTrace = explicitConditionTrace({
+        expression: modelJob.if,
+        field: 'job.if',
+        route: outcome.route,
+        site: context.site,
+        value: outcome.value,
+        degraded: outcome.evaluationFailed,
+      });
       const expectedVersion = expectedVersions.get(job.id);
       if (expectedVersion === undefined) {
         throw new Error(`Missing expected version for activation job ${job.id}`);
@@ -1244,6 +1253,7 @@ export async function evaluateJobActivations(
         status: 'skipped',
         expectedVersion,
         statusReason,
+        evaluationTrace,
       });
       if (updated) {
         decisions.push({
@@ -2208,6 +2218,7 @@ export interface UpdateJobStatusParams {
   status: JobStatus;
   expectedVersion: number;
   statusReason?: JobStatusReason | null | undefined;
+  evaluationTrace?: readonly PersistedEvaluationTraceEntry[] | null | undefined;
 }
 
 export async function updateJobStatus(params: UpdateJobStatusParams): Promise<Job> {
@@ -2218,6 +2229,7 @@ export async function updateJobStatus(params: UpdateJobStatusParams): Promise<Jo
       status: params.status,
       expectedVersion: params.expectedVersion,
       statusReason,
+      evaluationTrace: params.evaluationTrace,
     });
     if (updated) return updated;
 
@@ -2623,7 +2635,12 @@ export interface MarkStepRunningParams {
 export async function markStepRunning(params: MarkStepRunningParams, tx: Tx): Promise<Step | null> {
   const rows = await tx
     .update(steps)
-    .set({status: 'running', statusReason: null, updatedAt: new Date()})
+    .set({
+      status: 'running',
+      statusReason: null,
+      evaluationTrace: null,
+      updatedAt: new Date(),
+    })
     .where(
       and(
         eq(steps.id, params.stepId),
@@ -2666,6 +2683,7 @@ export async function dispatchStepWithCompletedConfig(
     .set({
       status: 'running',
       statusReason: null,
+      evaluationTrace: null,
       config: params.config,
       updatedAt: new Date(),
     })
@@ -2697,6 +2715,7 @@ export interface MarkStepSkippedParams {
   jobExecutionId: string;
   stepId: string;
   statusReason: StepStatusReason;
+  evaluationTrace: readonly PersistedEvaluationTraceEntry[];
 }
 
 export async function markStepSkipped(params: MarkStepSkippedParams, tx: Tx): Promise<Step | null> {
@@ -2705,6 +2724,7 @@ export async function markStepSkipped(params: MarkStepSkippedParams, tx: Tx): Pr
     .set({
       status: 'skipped',
       statusReason: params.statusReason,
+      evaluationTrace: params.evaluationTrace,
       error: null,
       updatedAt: new Date(),
     })

--- a/libs/api/workflows/src/presentation/dto/step.test.ts
+++ b/libs/api/workflows/src/presentation/dto/step.test.ts
@@ -10,6 +10,7 @@ function step(overrides: Partial<Step> & {type: string}): Step {
     sourceLocation: null,
     status: 'failed',
     statusReason: null,
+    evaluationTrace: null,
     config: {},
     condition: null,
     configPlan: null,

--- a/libs/api/workflows/src/temporal/activities/orchestration-activities.test.ts
+++ b/libs/api/workflows/src/temporal/activities/orchestration-activities.test.ts
@@ -7,7 +7,7 @@ import {
 } from '#db/index.js';
 import {stripSetupStep} from '#test/fixtures/strip-setup-step.js';
 import {workflowModel} from '#test/index.js';
-import {resolveLeaseExpiredJobExecutionActivity} from './orchestration-activities.js';
+import {resolveLeaseExpiredJobExecutionActivity, setJobStatus} from './orchestration-activities.js';
 
 describe('resolveLeaseExpiredJobExecutionActivity', () => {
   let workspaceId: string;
@@ -69,5 +69,45 @@ describe('resolveLeaseExpiredJobExecutionActivity', () => {
     });
 
     expect(result.status).toBe('failed');
+  });
+
+  test('default-gate skipped jobs record an evaluation trace', async () => {
+    const run = await createWorkflowRun({
+      workspaceId,
+      projectId,
+      definitionId,
+      model: workflowModel({
+        jobs: {
+          build: {steps: [{run: 'npm run build'}]},
+        },
+      }),
+      triggerPayload: {
+        source: 'manual',
+        event: 'fire',
+        subscriptionId: crypto.randomUUID(),
+        userId: crypto.randomUUID(),
+      },
+    });
+    const [job] = await getJobsByWorkflowRunId(run.id);
+    if (!job) throw new Error('Expected job');
+
+    await setJobStatus({
+      jobId: job.id,
+      status: 'skipped',
+      version: job.version,
+      statusReason: 'default_gate_rejected',
+    });
+
+    const [skipped] = await getJobsByWorkflowRunId(run.id);
+    expect(skipped?.evaluationTrace).toEqual([
+      {
+        expression: 'needs.all(n, n.status == "succeeded")',
+        roots: ['needs'],
+        fillTarget: 'job-activation',
+        evaluatedAt: 'job-activation',
+        value: 'false',
+        field: 'job.default_gate',
+      },
+    ]);
   });
 });

--- a/libs/api/workflows/src/temporal/activities/orchestration-activities.test.ts
+++ b/libs/api/workflows/src/temporal/activities/orchestration-activities.test.ts
@@ -9,17 +9,17 @@ import {stripSetupStep} from '#test/fixtures/strip-setup-step.js';
 import {workflowModel} from '#test/index.js';
 import {resolveLeaseExpiredJobExecutionActivity, setJobStatus} from './orchestration-activities.js';
 
+let workspaceId: string;
+let projectId: string;
+let definitionId: string;
+
+beforeEach(() => {
+  workspaceId = crypto.randomUUID();
+  projectId = crypto.randomUUID();
+  definitionId = crypto.randomUUID();
+});
+
 describe('resolveLeaseExpiredJobExecutionActivity', () => {
-  let workspaceId: string;
-  let projectId: string;
-  let definitionId: string;
-
-  beforeEach(() => {
-    workspaceId = crypto.randomUUID();
-    projectId = crypto.randomUUID();
-    definitionId = crypto.randomUUID();
-  });
-
   async function seedRunningJob(stepCount: number) {
     const run = await createWorkflowRun({
       workspaceId,
@@ -70,7 +70,9 @@ describe('resolveLeaseExpiredJobExecutionActivity', () => {
 
     expect(result.status).toBe('failed');
   });
+});
 
+describe('setJobStatus', () => {
   test('default-gate skipped jobs record an evaluation trace', async () => {
     const run = await createWorkflowRun({
       workspaceId,

--- a/libs/api/workflows/src/temporal/activities/orchestration-activities.ts
+++ b/libs/api/workflows/src/temporal/activities/orchestration-activities.ts
@@ -1,7 +1,8 @@
 import {cancelRunnerJobs, enqueueJobExecution, releaseJobExecution} from '@shipfox/api-runners';
 import {ApplicationFailure} from '@temporalio/common';
+import {defaultJobConditionTrace} from '#core/condition-trace.js';
 import type {JobStatus, JobStatusReason, ResolutionReason} from '#core/entities/job.js';
-import type {StepStatus} from '#core/entities/step.js';
+import type {PersistedEvaluationTraceEntry, StepStatus} from '#core/entities/step.js';
 import type {WorkflowRunStatus} from '#core/entities/workflow-run.js';
 import {JobNotFoundError} from '#core/errors.js';
 import type {
@@ -137,14 +138,27 @@ export async function setJobStatus(params: {
   status: JobStatus;
   version: number;
   statusReason?: JobStatusReason | null | undefined;
+  evaluationTrace?: readonly PersistedEvaluationTraceEntry[] | null | undefined;
 }): Promise<{newVersion: number; status: JobStatus}> {
   const updated = await updateJobStatus({
     jobId: params.jobId,
     status: params.status,
     expectedVersion: params.version,
     statusReason: params.statusReason,
+    evaluationTrace: jobStatusEvaluationTrace(params),
   });
   return {newVersion: updated.version, status: updated.status};
+}
+
+function jobStatusEvaluationTrace(params: {
+  status: JobStatus;
+  statusReason?: JobStatusReason | null | undefined;
+  evaluationTrace?: readonly PersistedEvaluationTraceEntry[] | null | undefined;
+}): readonly PersistedEvaluationTraceEntry[] | null | undefined {
+  if (params.evaluationTrace !== undefined) return params.evaluationTrace;
+  return params.status === 'skipped' && params.statusReason === 'default_gate_rejected'
+    ? defaultJobConditionTrace()
+    : undefined;
 }
 
 export async function setJobExecutionStatus(params: {


### PR DESCRIPTION
Add durable evaluation traces for condition-driven skipped workflow nodes.

Skipped jobs and steps previously recorded the skip reason but not the predicate trace that explains the evaluated condition. This persists explicit `if:` predicate traces and server-authored default-gate traces on the owning job or step row, so `condition_rejected`, `condition_errored`, and `default_gate_rejected` skips carry machine-readable debugging context.

The step trace column is folded into the existing workflows initial migration because this branch is still pre-landed, avoiding an extra migration file for the same schema baseline.

Closes ENG-832

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist evaluation traces for condition-driven skips on jobs and steps so condition_rejected, condition_errored, and default_gate_rejected include machine-readable context. Improves debugging and meets ENG-832.

- **New Features**
  - Store explicit if: traces and server default-gate traces on the job or step.
  - Add `evaluation_trace` JSONB to `workflows_steps` (folded into initial migration).
  - Capture trace metadata from `@shipfox/expression` (fields like job.if, step.if, and default-gate labels); set degraded when evaluation fails.
  - Clear traces when a step starts; auto-attach a default-gate trace for skipped jobs in `setJobStatus`.
  - Wire through via `updateJobStatus`, `markStepSkipped`, and DTOs; tests updated to assert traces.

<sup>Written for commit 2952db4a04a6bc6da5ff4e317a23142bc46cf961. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

