### PR TITLE
[runner] Advertise tool capabilities

### DIFF
--- a/.changeset/steady-runners-advertise.md
+++ b/.changeset/steady-runners-advertise.md
@@ -1,0 +1,9 @@
+---
+"@shipfox/api-runners": minor
+"@shipfox/api-runners-dto": minor
+"@shipfox/runner-agent": minor
+"@shipfox/runner-orchestration": minor
+"@shipfox/runner-protocol": minor
+---
+
+Adds runner-advertised tool capabilities to registration, heartbeat, persistence, and runner protocol reporting.

--- a/libs/api/runners-dto/src/index.ts
+++ b/libs/api/runners-dto/src/index.ts
@@ -19,7 +19,9 @@ export {
   createProvisionerTokenResponseSchema,
   type DemandStatDto,
   demandStatSchema,
+  type HeartbeatBodyDto,
   type HeartbeatResponseDto,
+  heartbeatBodySchema,
   heartbeatResponseSchema,
   type ListActiveProvisionersResponseDto,
   type ListManualRegistrationTokensResponseDto,
@@ -73,6 +75,8 @@ export {
   type RevokeManualRegistrationTokenResponseDto,
   type RevokeProvisionerTokenResponseDto,
   RUNNER_SESSION_EXHAUSTED_CODE,
+  type RunnerHarnessToolCapabilitiesDto,
+  type RunnerToolCapabilitiesDto,
   reconcileDesiredIntentSchema,
   reconciledBoundJobSchema,
   reconciledProvisionedRunnerSchema,
@@ -85,6 +89,8 @@ export {
   reservationGrantSchema,
   revokeManualRegistrationTokenResponseSchema,
   revokeProvisionerTokenResponseSchema,
+  runnerHarnessToolCapabilitiesSchema,
+  runnerToolCapabilitiesSchema,
 } from '#schemas/index.js';
 export {
   RUNNER_JOB_CLAIMED,

--- a/libs/api/runners-dto/src/schemas/heartbeat.ts
+++ b/libs/api/runners-dto/src/schemas/heartbeat.ts
@@ -1,8 +1,16 @@
 import {z} from 'zod';
+import {runnerToolCapabilitiesSchema} from './tool-capabilities.js';
+
+export const heartbeatBodySchema = z
+  .object({
+    capabilities: runnerToolCapabilitiesSchema.optional(),
+  })
+  .strict();
 
 export const heartbeatResponseSchema = z.object({
   cancel: z.boolean(),
   lease_token: z.string().min(1),
 });
 
+export type HeartbeatBodyDto = z.infer<typeof heartbeatBodySchema>;
 export type HeartbeatResponseDto = z.infer<typeof heartbeatResponseSchema>;

--- a/libs/api/runners-dto/src/schemas/index.ts
+++ b/libs/api/runners-dto/src/schemas/index.ts
@@ -3,7 +3,12 @@ export {
   claimedJobResponseSchema,
   RUNNER_SESSION_EXHAUSTED_CODE,
 } from './claim-job.js';
-export {type HeartbeatResponseDto, heartbeatResponseSchema} from './heartbeat.js';
+export {
+  type HeartbeatBodyDto,
+  type HeartbeatResponseDto,
+  heartbeatBodySchema,
+  heartbeatResponseSchema,
+} from './heartbeat.js';
 export {
   type ActiveProvisionerDto,
   activeProvisionerDtoSchema,
@@ -102,3 +107,9 @@ export {
   reportProvisionedRunnersBodySchema,
   reportProvisionedRunnersResponseSchema,
 } from './report-provisioned-runners.js';
+export {
+  type RunnerHarnessToolCapabilitiesDto,
+  type RunnerToolCapabilitiesDto,
+  runnerHarnessToolCapabilitiesSchema,
+  runnerToolCapabilitiesSchema,
+} from './tool-capabilities.js';

--- a/libs/api/runners-dto/src/schemas/register.ts
+++ b/libs/api/runners-dto/src/schemas/register.ts
@@ -4,6 +4,7 @@ import {
   RUNNER_LABEL_PATTERN,
 } from '@shipfox/runner-labels';
 import {z} from 'zod';
+import {runnerToolCapabilitiesSchema} from './tool-capabilities.js';
 
 export const runnerLabelSchema = z
   .string()
@@ -13,6 +14,7 @@ export const runnerLabelSchema = z
 
 export const registerRunnerBodySchema = z.object({
   labels: z.array(runnerLabelSchema).min(1).max(MAX_RUNNER_LABELS),
+  capabilities: runnerToolCapabilitiesSchema.optional(),
 });
 
 export const registerRunnerResponseSchema = z.object({

--- a/libs/api/runners-dto/src/schemas/tool-capabilities.test.ts
+++ b/libs/api/runners-dto/src/schemas/tool-capabilities.test.ts
@@ -51,8 +51,10 @@ describe('runnerToolCapabilitiesSchema', () => {
   it.each([
     null,
     {},
+    {harnesses: {}, extra: true},
     {harnesses: {pi: {tools: ['read']}, unknown: {tools: ['x']}}},
     {harnesses: {pi: {tools: ['read'], extra: true}}},
+    {harnesses: {pi: {tools: ['']}}},
     {harnesses: {pi: {tools: [42]}}},
   ])('rejects malformed capability report %#', (value) => {
     const result = runnerToolCapabilitiesSchema.safeParse(value);

--- a/libs/api/runners-dto/src/schemas/tool-capabilities.test.ts
+++ b/libs/api/runners-dto/src/schemas/tool-capabilities.test.ts
@@ -1,0 +1,62 @@
+import {runnerToolCapabilitiesSchema} from './tool-capabilities.js';
+
+describe('runnerToolCapabilitiesSchema', () => {
+  it('accepts a full capability report', () => {
+    const result = runnerToolCapabilitiesSchema.safeParse({
+      harnesses: {
+        pi: {tools: ['read', 'bash', 'web_search']},
+        claude: {tools: ['Read', 'Bash', 'WebSearch']},
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a partial capability report', () => {
+    const result = runnerToolCapabilitiesSchema.safeParse({
+      harnesses: {
+        pi: {tools: ['read']},
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts no harness support', () => {
+    const result = runnerToolCapabilitiesSchema.safeParse({harnesses: {}});
+
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts an empty tool array', () => {
+    const result = runnerToolCapabilitiesSchema.safeParse({
+      harnesses: {
+        claude: {tools: []},
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects duplicate tool names per harness', () => {
+    const result = runnerToolCapabilitiesSchema.safeParse({
+      harnesses: {
+        pi: {tools: ['read', 'read']},
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it.each([
+    null,
+    {},
+    {harnesses: {pi: {tools: ['read']}, unknown: {tools: ['x']}}},
+    {harnesses: {pi: {tools: ['read'], extra: true}}},
+    {harnesses: {pi: {tools: [42]}}},
+  ])('rejects malformed capability report %#', (value) => {
+    const result = runnerToolCapabilitiesSchema.safeParse(value);
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/libs/api/runners-dto/src/schemas/tool-capabilities.ts
+++ b/libs/api/runners-dto/src/schemas/tool-capabilities.ts
@@ -1,0 +1,35 @@
+import {z} from 'zod';
+
+export const runnerHarnessToolCapabilitiesSchema = z
+  .object({
+    tools: z.array(z.string().min(1)).superRefine((tools, ctx) => {
+      const seen = new Set<string>();
+      for (const [index, tool] of tools.entries()) {
+        if (!seen.has(tool)) {
+          seen.add(tool);
+          continue;
+        }
+
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Duplicate tool name',
+          path: [index],
+        });
+      }
+    }),
+  })
+  .strict();
+
+export const runnerToolCapabilitiesSchema = z
+  .object({
+    harnesses: z
+      .object({
+        pi: runnerHarnessToolCapabilitiesSchema.optional(),
+        claude: runnerHarnessToolCapabilitiesSchema.optional(),
+      })
+      .strict(),
+  })
+  .strict();
+
+export type RunnerHarnessToolCapabilitiesDto = z.infer<typeof runnerHarnessToolCapabilitiesSchema>;
+export type RunnerToolCapabilitiesDto = z.infer<typeof runnerToolCapabilitiesSchema>;

--- a/libs/api/runners/drizzle/0000_initial.sql
+++ b/libs/api/runners/drizzle/0000_initial.sql
@@ -123,6 +123,8 @@ CREATE TABLE "runners_runner_sessions" (
 	"provisioner_id" uuid,
 	"provisioned_runner_id" text,
 	"labels" text[] NOT NULL,
+	"tool_capabilities" jsonb,
+	"tool_capabilities_reported_at" timestamp with time zone,
 	"max_claims" integer,
 	"claims_used" integer DEFAULT 0 NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,

--- a/libs/api/runners/drizzle/meta/0000_snapshot.json
+++ b/libs/api/runners/drizzle/meta/0000_snapshot.json
@@ -1175,6 +1175,18 @@
           "primaryKey": false,
           "notNull": true
         },
+        "tool_capabilities": {
+          "name": "tool_capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_capabilities_reported_at": {
+          "name": "tool_capabilities_reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
         "max_claims": {
           "name": "max_claims",
           "type": "integer",

--- a/libs/api/runners/src/core/entities/runner-session.ts
+++ b/libs/api/runners/src/core/entities/runner-session.ts
@@ -1,3 +1,5 @@
+import type {RunnerToolCapabilitiesDto} from '@shipfox/api-runners-dto';
+
 export interface RunnerSession {
   id: string;
   workspaceId: string;
@@ -7,6 +9,8 @@ export interface RunnerSession {
   provisionerId: string | null;
   provisionedRunnerId: string | null;
   labels: string[];
+  toolCapabilities: RunnerToolCapabilitiesDto | null;
+  toolCapabilitiesReportedAt: Date | null;
   maxClaims: number | null;
   claimsUsed: number;
   createdAt: Date;

--- a/libs/api/runners/src/core/index.ts
+++ b/libs/api/runners/src/core/index.ts
@@ -50,3 +50,7 @@ export {
   type RunnerRegistrationCredential,
   registerRunnerSession,
 } from './runner-sessions.js';
+export {
+  EMPTY_RUNNER_TOOL_CAPABILITIES,
+  effectiveRunnerToolCapabilities,
+} from './runner-tool-capabilities.js';

--- a/libs/api/runners/src/core/runner-sessions.ts
+++ b/libs/api/runners/src/core/runner-sessions.ts
@@ -1,4 +1,5 @@
 import {issueRunnerSessionToken} from '@shipfox/api-auth';
+import type {RunnerToolCapabilitiesDto} from '@shipfox/api-runners-dto';
 import {canonicalizeLabels} from '@shipfox/runner-labels';
 import {createRunnerSessionConsumingEphemeralToken} from '#db/ephemeral-registration-tokens.js';
 import {createRunnerSession} from '#db/runner-sessions.js';
@@ -30,6 +31,7 @@ export type RunnerRegistrationCredential =
 export async function registerRunnerSession(params: {
   credential: RunnerRegistrationCredential;
   labels: string[];
+  toolCapabilities?: RunnerToolCapabilitiesDto | null;
 }): Promise<RegisterRunnerSessionResult> {
   const labels = [...canonicalizeLabels(params.labels)];
   if (labels.length === 0) throw new EmptyRunnerLabelsError();
@@ -43,11 +45,13 @@ export async function registerRunnerSession(params: {
           scope: 'workspace',
           registrationTokenId: params.credential.registrationTokenId,
           labels,
+          toolCapabilities: params.toolCapabilities ?? null,
         })
       : await createRunnerSessionConsumingEphemeralToken({
           ephemeralTokenId: params.credential.ephemeralTokenId,
           workspaceId: params.credential.workspaceId,
           labels,
+          toolCapabilities: params.toolCapabilities ?? null,
           maxClaims: 1,
         });
   const sessionToken = await issueRunnerSessionToken({

--- a/libs/api/runners/src/core/runner-tool-capabilities.test.ts
+++ b/libs/api/runners/src/core/runner-tool-capabilities.test.ts
@@ -1,0 +1,54 @@
+import type {RunnerToolCapabilitiesDto} from '@shipfox/api-runners-dto';
+import {effectiveRunnerToolCapabilities} from './runner-tool-capabilities.js';
+
+const capabilities: RunnerToolCapabilitiesDto = {
+  harnesses: {
+    pi: {tools: ['read', 'bash']},
+  },
+};
+
+describe('effectiveRunnerToolCapabilities', () => {
+  it('returns an empty set when the report is missing', () => {
+    const effective = effectiveRunnerToolCapabilities({
+      toolCapabilities: null,
+      reportedAt: new Date('2026-01-01T00:00:00.000Z'),
+      staleAfterSeconds: 10,
+      now: new Date('2026-01-01T00:00:01.000Z'),
+    });
+
+    expect(effective).toEqual({harnesses: {}});
+  });
+
+  it('returns an empty set when the report timestamp is missing', () => {
+    const effective = effectiveRunnerToolCapabilities({
+      toolCapabilities: capabilities,
+      reportedAt: null,
+      staleAfterSeconds: 10,
+      now: new Date('2026-01-01T00:00:01.000Z'),
+    });
+
+    expect(effective).toEqual({harnesses: {}});
+  });
+
+  it('returns an empty set when the report is stale', () => {
+    const effective = effectiveRunnerToolCapabilities({
+      toolCapabilities: capabilities,
+      reportedAt: new Date('2026-01-01T00:00:00.000Z'),
+      staleAfterSeconds: 10,
+      now: new Date('2026-01-01T00:00:11.000Z'),
+    });
+
+    expect(effective).toEqual({harnesses: {}});
+  });
+
+  it('returns exact persisted tools when the report is fresh', () => {
+    const effective = effectiveRunnerToolCapabilities({
+      toolCapabilities: capabilities,
+      reportedAt: new Date('2026-01-01T00:00:00.000Z'),
+      staleAfterSeconds: 10,
+      now: new Date('2026-01-01T00:00:10.000Z'),
+    });
+
+    expect(effective).toBe(capabilities);
+  });
+});

--- a/libs/api/runners/src/core/runner-tool-capabilities.ts
+++ b/libs/api/runners/src/core/runner-tool-capabilities.ts
@@ -1,0 +1,20 @@
+import type {RunnerToolCapabilitiesDto} from '@shipfox/api-runners-dto';
+
+export const EMPTY_RUNNER_TOOL_CAPABILITIES: RunnerToolCapabilitiesDto = {
+  harnesses: {},
+};
+
+export function effectiveRunnerToolCapabilities(params: {
+  toolCapabilities: RunnerToolCapabilitiesDto | null;
+  reportedAt: Date | null;
+  staleAfterSeconds: number;
+  now?: Date;
+}): RunnerToolCapabilitiesDto {
+  if (!params.toolCapabilities || !params.reportedAt) return EMPTY_RUNNER_TOOL_CAPABILITIES;
+
+  const now = params.now ?? new Date();
+  const ageMs = now.getTime() - params.reportedAt.getTime();
+  if (ageMs > params.staleAfterSeconds * 1000) return EMPTY_RUNNER_TOOL_CAPABILITIES;
+
+  return params.toolCapabilities;
+}

--- a/libs/api/runners/src/db/ephemeral-registration-tokens.ts
+++ b/libs/api/runners/src/db/ephemeral-registration-tokens.ts
@@ -1,3 +1,4 @@
+import type {RunnerToolCapabilitiesDto} from '@shipfox/api-runners-dto';
 import {and, asc, eq, gt, inArray, isNull, lt, sql} from 'drizzle-orm';
 import type {EphemeralRegistrationToken} from '#core/entities/ephemeral-registration-token.js';
 import {
@@ -256,6 +257,7 @@ export async function createRunnerSessionConsumingEphemeralToken(params: {
   ephemeralTokenId: string;
   workspaceId: string;
   labels: string[];
+  toolCapabilities?: RunnerToolCapabilitiesDto | null;
   maxClaims: number;
 }) {
   return await db().transaction(async (tx) => {
@@ -315,6 +317,8 @@ export async function createRunnerSessionConsumingEphemeralToken(params: {
         provisionerId: consumed[0].provisionerId,
         provisionedRunnerId: consumed[0].provisionedRunnerId,
         labels: params.labels,
+        toolCapabilities: params.toolCapabilities ?? null,
+        toolCapabilitiesReportedAt: params.toolCapabilities ? sql`now()` : null,
         maxClaims: params.maxClaims,
         claimsUsed: 0,
       })

--- a/libs/api/runners/src/db/job-executions.ts
+++ b/libs/api/runners/src/db/job-executions.ts
@@ -3,6 +3,7 @@ import {
   RUNNER_JOB_LEASE_EXPIRED,
   RUNNER_JOB_QUEUED,
   type RunnersEventMap,
+  type RunnerToolCapabilitiesDto,
 } from '@shipfox/api-runners-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import {writeOutboxEvent, writeOutboxEvents} from '@shipfox/node-outbox';
@@ -536,8 +537,11 @@ export async function isJobLeaseActive(params: {
 export async function recordHeartbeat(params: {
   jobExecutionId: string;
   runnerSessionId: string;
+  toolCapabilities?: RunnerToolCapabilitiesDto | null;
 }): Promise<{
   cancellationRequested: boolean;
+  previousToolCapabilities: RunnerToolCapabilitiesDto | null;
+  currentToolCapabilities: RunnerToolCapabilitiesDto | null;
   runningJobExecution: {
     workflowRunId: string;
     workflowRunAttemptId: string;
@@ -548,33 +552,63 @@ export async function recordHeartbeat(params: {
     runnerSessionId: string;
   };
 }> {
-  const updated = await db()
-    .update(runningJobExecutions)
-    .set({
-      firstHeartbeatAt: sql`COALESCE(${runningJobExecutions.firstHeartbeatAt}, now())`,
-      lastHeartbeatAt: sql`now()`,
-    })
-    .where(
-      and(
-        eq(runningJobExecutions.jobExecutionId, params.jobExecutionId),
-        eq(runningJobExecutions.runnerSessionId, params.runnerSessionId),
-      ),
-    )
-    .returning({
-      cancellationRequestedAt: runningJobExecutions.cancellationRequestedAt,
-      workflowRunId: runningJobExecutions.workflowRunId,
-      workflowRunAttemptId: runningJobExecutions.workflowRunAttemptId,
-      jobId: runningJobExecutions.jobId,
-      jobExecutionId: runningJobExecutions.jobExecutionId,
-      projectId: runningJobExecutions.projectId,
-      workspaceId: runningJobExecutions.workspaceId,
-      runnerSessionId: runningJobExecutions.runnerSessionId,
-    });
+  const result = await db().transaction(async (tx) => {
+    const updated = await tx
+      .update(runningJobExecutions)
+      .set({
+        firstHeartbeatAt: sql`COALESCE(${runningJobExecutions.firstHeartbeatAt}, now())`,
+        lastHeartbeatAt: sql`now()`,
+      })
+      .where(
+        and(
+          eq(runningJobExecutions.jobExecutionId, params.jobExecutionId),
+          eq(runningJobExecutions.runnerSessionId, params.runnerSessionId),
+        ),
+      )
+      .returning({
+        cancellationRequestedAt: runningJobExecutions.cancellationRequestedAt,
+        workflowRunId: runningJobExecutions.workflowRunId,
+        workflowRunAttemptId: runningJobExecutions.workflowRunAttemptId,
+        jobId: runningJobExecutions.jobId,
+        jobExecutionId: runningJobExecutions.jobExecutionId,
+        projectId: runningJobExecutions.projectId,
+        workspaceId: runningJobExecutions.workspaceId,
+        runnerSessionId: runningJobExecutions.runnerSessionId,
+      });
 
-  const row = updated[0];
+    const row = updated[0];
+    if (!row) throw new RunningJobExecutionNotFoundError(params.jobExecutionId);
+
+    const [previous] = await tx
+      .select({toolCapabilities: runnerSessions.toolCapabilities})
+      .from(runnerSessions)
+      .where(eq(runnerSessions.id, params.runnerSessionId))
+      .limit(1)
+      .for('update');
+
+    const [session] = await tx
+      .update(runnerSessions)
+      .set({
+        toolCapabilities: params.toolCapabilities ?? null,
+        toolCapabilitiesReportedAt: params.toolCapabilities ? sql`now()` : null,
+        updatedAt: sql`now()`,
+      })
+      .where(eq(runnerSessions.id, params.runnerSessionId))
+      .returning({toolCapabilities: runnerSessions.toolCapabilities});
+
+    return {
+      row,
+      previousToolCapabilities: previous?.toolCapabilities ?? null,
+      currentToolCapabilities: session?.toolCapabilities ?? null,
+    };
+  });
+
+  const row = result.row;
   if (!row) throw new RunningJobExecutionNotFoundError(params.jobExecutionId);
   return {
     cancellationRequested: row.cancellationRequestedAt !== null,
+    previousToolCapabilities: result.previousToolCapabilities,
+    currentToolCapabilities: result.currentToolCapabilities,
     runningJobExecution: {
       workflowRunId: row.workflowRunId,
       workflowRunAttemptId: row.workflowRunAttemptId,

--- a/libs/api/runners/src/db/runner-sessions.ts
+++ b/libs/api/runners/src/db/runner-sessions.ts
@@ -1,3 +1,4 @@
+import type {RunnerToolCapabilitiesDto} from '@shipfox/api-runners-dto';
 import {and, asc, eq, inArray, lt, notExists, or, sql} from 'drizzle-orm';
 import type {RunnerSession} from '#core/entities/runner-session.js';
 import {db} from './db.js';
@@ -9,6 +10,7 @@ export interface CreateRunnerSessionParams {
   scope: 'workspace';
   registrationTokenId: string;
   labels: string[];
+  toolCapabilities?: RunnerToolCapabilitiesDto | null;
 }
 
 export async function createRunnerSession(
@@ -22,6 +24,8 @@ export async function createRunnerSession(
       registrationTokenId: params.registrationTokenId,
       registrationTokenKind: 'manual',
       labels: params.labels,
+      toolCapabilities: params.toolCapabilities ?? null,
+      toolCapabilitiesReportedAt: params.toolCapabilities ? sql`now()` : null,
       maxClaims: null,
       claimsUsed: 0,
     })

--- a/libs/api/runners/src/db/schema/runner-sessions.ts
+++ b/libs/api/runners/src/db/schema/runner-sessions.ts
@@ -1,6 +1,7 @@
+import type {RunnerToolCapabilitiesDto} from '@shipfox/api-runners-dto';
 import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
 import {sql} from 'drizzle-orm';
-import {check, index, integer, pgEnum, text, timestamp, uuid} from 'drizzle-orm/pg-core';
+import {check, index, integer, jsonb, pgEnum, text, timestamp, uuid} from 'drizzle-orm/pg-core';
 import type {RunnerSession} from '#core/entities/runner-session.js';
 import {pgTable} from './common.js';
 
@@ -22,6 +23,8 @@ export const runnerSessions = pgTable(
     provisionerId: uuid('provisioner_id'),
     provisionedRunnerId: text('provisioned_runner_id'),
     labels: text('labels').array().notNull(),
+    toolCapabilities: jsonb('tool_capabilities').$type<RunnerToolCapabilitiesDto | null>(),
+    toolCapabilitiesReportedAt: timestamp('tool_capabilities_reported_at', {withTimezone: true}),
     maxClaims: integer('max_claims'),
     claimsUsed: integer('claims_used').notNull().default(0),
     createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
@@ -64,6 +67,8 @@ export function toRunnerSession(row: RunnerSessionDb): RunnerSession {
     provisionerId: row.provisionerId,
     provisionedRunnerId: row.provisionedRunnerId,
     labels: row.labels,
+    toolCapabilities: row.toolCapabilities,
+    toolCapabilitiesReportedAt: row.toolCapabilitiesReportedAt,
     maxClaims: row.maxClaims,
     claimsUsed: row.claimsUsed,
     createdAt: row.createdAt,

--- a/libs/api/runners/src/presentation/routes/heartbeat.test.ts
+++ b/libs/api/runners/src/presentation/routes/heartbeat.test.ts
@@ -6,6 +6,7 @@ import {
   verifyJobLeaseToken,
 } from '@shipfox/api-auth';
 import {AUTH_PROVISIONER_TOKEN, AUTH_USER} from '@shipfox/api-auth-context';
+import type {RunnerToolCapabilitiesDto} from '@shipfox/api-runners-dto';
 import type {AuthMethod} from '@shipfox/node-fastify';
 import {closeApp, createApp} from '@shipfox/node-fastify';
 import {eq} from 'drizzle-orm';
@@ -13,6 +14,7 @@ import type {FastifyInstance} from 'fastify';
 import {claimJobExecution} from '#core/job-executions.js';
 import {db} from '#db/db.js';
 import {requestJobExecutionCancellation} from '#db/job-executions.js';
+import {runnerSessions} from '#db/schema/runner-sessions.js';
 import {runningJobExecutions} from '#db/schema/running-job-executions.js';
 import {createRunnerRegistrationTokenAuthMethod} from '#presentation/auth/index.js';
 import {pendingJobFactory, runnerSessionFactory} from '#test/index.js';
@@ -26,6 +28,19 @@ const fakeUserAuth: AuthMethod = {
 const fakeProvisionerAuth: AuthMethod = {
   name: AUTH_PROVISIONER_TOKEN,
   authenticate: () => Promise.resolve(),
+};
+
+const fullCapabilities: RunnerToolCapabilitiesDto = {
+  harnesses: {
+    pi: {tools: ['read', 'bash', 'web_search']},
+    claude: {tools: ['Read', 'Bash', 'WebSearch']},
+  },
+};
+
+const partialCapabilities: RunnerToolCapabilitiesDto = {
+  harnesses: {
+    pi: {tools: ['read']},
+  },
 };
 
 describe('POST /runners/jobs/:jobId/heartbeat', () => {
@@ -119,6 +134,91 @@ describe('POST /runners/jobs/:jobId/heartbeat', () => {
       .from(runningJobExecutions)
       .where(eq(runningJobExecutions.jobExecutionId, jobExecutionId));
     expect(running?.firstHeartbeatAt).toBeInstanceOf(Date);
+  });
+
+  it('refreshes job heartbeat and runner capability report', async () => {
+    const {jobId, jobExecutionId, leaseToken} = await claimAvailableJob();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/runners/jobs/${jobId}/heartbeat`,
+      headers: {authorization: `Bearer ${leaseToken}`},
+      payload: {capabilities: fullCapabilities},
+    });
+
+    expect(res.statusCode).toBe(200);
+    const [running] = await db()
+      .select()
+      .from(runningJobExecutions)
+      .where(eq(runningJobExecutions.jobExecutionId, jobExecutionId));
+    const [session] = await db()
+      .select()
+      .from(runnerSessions)
+      .where(eq(runnerSessions.id, runnerSessionId));
+    expect(running?.firstHeartbeatAt).toBeInstanceOf(Date);
+    expect(session?.toolCapabilities).toEqual(fullCapabilities);
+    expect(session?.toolCapabilitiesReportedAt).toBeInstanceOf(Date);
+  });
+
+  it('clears the stored capability report when heartbeat omits capabilities', async () => {
+    const {jobId, leaseToken} = await claimAvailableJob();
+    await db()
+      .update(runnerSessions)
+      .set({
+        toolCapabilities: partialCapabilities,
+        toolCapabilitiesReportedAt: new Date('2026-01-01T00:00:00.000Z'),
+      })
+      .where(eq(runnerSessions.id, runnerSessionId));
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/runners/jobs/${jobId}/heartbeat`,
+      headers: {authorization: `Bearer ${leaseToken}`},
+    });
+
+    expect(res.statusCode).toBe(200);
+    const [session] = await db()
+      .select()
+      .from(runnerSessions)
+      .where(eq(runnerSessions.id, runnerSessionId));
+    expect(session?.toolCapabilities).toBeNull();
+    expect(session?.toolCapabilitiesReportedAt).toBeNull();
+  });
+
+  it('rejects malformed capability reports without liveness or capability side effects', async () => {
+    const {jobId, jobExecutionId, leaseToken} = await claimAvailableJob();
+    await db()
+      .update(runnerSessions)
+      .set({
+        toolCapabilities: partialCapabilities,
+        toolCapabilitiesReportedAt: new Date('2026-01-01T00:00:00.000Z'),
+      })
+      .where(eq(runnerSessions.id, runnerSessionId));
+    const [beforeRunning] = await db()
+      .select()
+      .from(runningJobExecutions)
+      .where(eq(runningJobExecutions.jobExecutionId, jobExecutionId));
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/runners/jobs/${jobId}/heartbeat`,
+      headers: {authorization: `Bearer ${leaseToken}`},
+      payload: {capabilities: {harnesses: {pi: {tools: ['read', 'read']}}}},
+    });
+
+    expect(res.statusCode).toBe(400);
+    const [afterRunning] = await db()
+      .select()
+      .from(runningJobExecutions)
+      .where(eq(runningJobExecutions.jobExecutionId, jobExecutionId));
+    const [session] = await db()
+      .select()
+      .from(runnerSessions)
+      .where(eq(runnerSessions.id, runnerSessionId));
+    expect(afterRunning?.firstHeartbeatAt).toEqual(beforeRunning?.firstHeartbeatAt);
+    expect(afterRunning?.lastHeartbeatAt).toEqual(beforeRunning?.lastHeartbeatAt);
+    expect(session?.toolCapabilities).toEqual(partialCapabilities);
+    expect(session?.toolCapabilitiesReportedAt).toEqual(new Date('2026-01-01T00:00:00.000Z'));
   });
 
   it('returns 200 + cancel:true after requestJobExecutionCancellation', async () => {

--- a/libs/api/runners/src/presentation/routes/heartbeat.ts
+++ b/libs/api/runners/src/presentation/routes/heartbeat.ts
@@ -1,6 +1,6 @@
 import {issueJobLeaseToken, jobLeaseParamsFrom} from '@shipfox/api-auth';
 import {requireLeasedJobContext} from '@shipfox/api-auth-context';
-import {heartbeatResponseSchema} from '@shipfox/api-runners-dto';
+import {heartbeatBodySchema, heartbeatResponseSchema} from '@shipfox/api-runners-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
 import {RunningJobExecutionNotFoundError} from '#core/errors.js';
@@ -13,6 +13,7 @@ export const heartbeatRoute = defineRoute({
     'Keeps a running job execution alive while the runner is still working on it. Returns whether the server has asked the runner to cancel.',
   schema: {
     params: z.object({jobId: z.string().uuid()}),
+    body: heartbeatBodySchema.nullish(),
     response: {
       200: heartbeatResponseSchema,
     },
@@ -32,14 +33,35 @@ export const heartbeatRoute = defineRoute({
       });
     }
 
-    const {cancellationRequested, runningJobExecution} = await recordHeartbeat({
+    const heartbeatResult = await recordHeartbeat({
       jobExecutionId: lease.jobExecutionId,
       runnerSessionId: lease.runnerSessionId,
+      toolCapabilities: request.body?.capabilities ?? null,
     });
+
+    if (
+      heartbeatResult.previousToolCapabilities &&
+      !sameToolCapabilities(
+        heartbeatResult.previousToolCapabilities,
+        heartbeatResult.currentToolCapabilities,
+      )
+    ) {
+      request.log.info(
+        {
+          runnerSessionId: lease.runnerSessionId,
+          jobExecutionId: lease.jobExecutionId,
+          previousHarnesses: Object.keys(heartbeatResult.previousToolCapabilities.harnesses),
+          currentHarnesses: heartbeatResult.currentToolCapabilities
+            ? Object.keys(heartbeatResult.currentToolCapabilities.harnesses)
+            : [],
+        },
+        'Runner heartbeat changed advertised tool capabilities',
+      );
+    }
 
     const leaseToken = await issueJobLeaseToken(
       jobLeaseParamsFrom(
-        runningJobExecution,
+        heartbeatResult.runningJobExecution,
         lease.currentStepId && lease.currentStepAttempt !== undefined
           ? {
               currentStepId: lease.currentStepId,
@@ -49,6 +71,10 @@ export const heartbeatRoute = defineRoute({
       ),
     );
 
-    return {cancel: cancellationRequested, lease_token: leaseToken};
+    return {cancel: heartbeatResult.cancellationRequested, lease_token: leaseToken};
   },
 });
+
+function sameToolCapabilities(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}

--- a/libs/api/runners/src/presentation/routes/register.test.ts
+++ b/libs/api/runners/src/presentation/routes/register.test.ts
@@ -4,6 +4,7 @@ import {
   verifyRunnerSessionToken,
 } from '@shipfox/api-auth';
 import {AUTH_PROVISIONER_TOKEN, AUTH_USER} from '@shipfox/api-auth-context';
+import type {RunnerToolCapabilitiesDto} from '@shipfox/api-runners-dto';
 import type {AuthMethod} from '@shipfox/node-fastify';
 import {closeApp, createApp} from '@shipfox/node-fastify';
 import {generateOpaqueToken} from '@shipfox/node-tokens';
@@ -28,6 +29,13 @@ const fakeUserAuth: AuthMethod = {
 const fakeProvisionerAuth: AuthMethod = {
   name: AUTH_PROVISIONER_TOKEN,
   authenticate: () => Promise.resolve(),
+};
+
+const fullCapabilities: RunnerToolCapabilitiesDto = {
+  harnesses: {
+    pi: {tools: ['read', 'bash', 'web_search']},
+    claude: {tools: ['Read', 'Bash', 'WebSearch']},
+  },
 };
 
 describe('POST /runners/register', () => {
@@ -92,6 +100,25 @@ describe('POST /runners/register', () => {
     expect(rows[0]?.registrationTokenKind).toBe('manual');
     expect(rows[0]?.provisionerId).toBeNull();
     expect(rows[0]?.provisionedRunnerId).toBeNull();
+    expect(rows[0]?.toolCapabilities).toBeNull();
+    expect(rows[0]?.toolCapabilitiesReportedAt).toBeNull();
+  });
+
+  it('persists a full capability report for a manual runner session', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/runners/register',
+      headers: {authorization: `Bearer ${rawToken}`},
+      payload: {labels: ['linux'], capabilities: fullCapabilities},
+    });
+
+    expect(res.statusCode).toBe(200);
+    const [session] = await db()
+      .select()
+      .from(runnerSessions)
+      .where(eq(runnerSessions.id, res.json().session_id));
+    expect(session?.toolCapabilities).toEqual(fullCapabilities);
+    expect(session?.toolCapabilitiesReportedAt).toBeInstanceOf(Date);
   });
 
   it('exchanges an ephemeral registration token for a one-claim runner session', async () => {
@@ -105,7 +132,7 @@ describe('POST /runners/register', () => {
       method: 'POST',
       url: '/runners/register',
       headers: {authorization: `Bearer ${ephemeralRawToken}`},
-      payload: {labels: ['Linux', 'x64']},
+      payload: {labels: ['Linux', 'x64'], capabilities: {harnesses: {pi: {tools: ['read']}}}},
     });
 
     expect(res.statusCode).toBe(200);
@@ -125,6 +152,8 @@ describe('POST /runners/register', () => {
     expect(session?.provisionedRunnerId).toBe(token.provisionedRunnerId);
     expect(session?.maxClaims).toBe(1);
     expect(session?.claimsUsed).toBe(0);
+    expect(session?.toolCapabilities).toEqual({harnesses: {pi: {tools: ['read']}}});
+    expect(session?.toolCapabilitiesReportedAt).toBeInstanceOf(Date);
 
     const [consumed] = await db()
       .select()
@@ -132,6 +161,22 @@ describe('POST /runners/register', () => {
       .where(eq(ephemeralRegistrationTokens.id, token.id));
     expect(consumed?.consumedAt).toBeInstanceOf(Date);
     expect(consumed?.consumedSessionId).toBe(body.session_id);
+  });
+
+  it('rejects malformed capability reports without creating a runner session', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/runners/register',
+      headers: {authorization: `Bearer ${rawToken}`},
+      payload: {labels: ['linux'], capabilities: {harnesses: {pi: {tools: ['read', 'read']}}}},
+    });
+
+    expect(res.statusCode).toBe(400);
+    const rows = await db()
+      .select()
+      .from(runnerSessions)
+      .where(eq(runnerSessions.workspaceId, workspaceId));
+    expect(rows).toHaveLength(0);
   });
 
   it('creates independent sessions from the same registration token', async () => {

--- a/libs/api/runners/src/presentation/routes/register.ts
+++ b/libs/api/runners/src/presentation/routes/register.ts
@@ -62,6 +62,7 @@ export const registerRoute = defineRoute({
             }
           : runner,
       labels: request.body.labels,
+      toolCapabilities: request.body.capabilities ?? null,
     });
 
     return {

--- a/libs/api/runners/test/factories/runner-session.ts
+++ b/libs/api/runners/test/factories/runner-session.ts
@@ -9,6 +9,7 @@ export const runnerSessionFactory = Factory.define<RunnerSession>(({onCreate}) =
       scope: session.scope,
       registrationTokenId: session.registrationTokenId,
       labels: session.labels,
+      toolCapabilities: session.toolCapabilities,
     });
   });
 
@@ -21,6 +22,8 @@ export const runnerSessionFactory = Factory.define<RunnerSession>(({onCreate}) =
     provisionerId: null,
     provisionedRunnerId: null,
     labels: ['linux', 'x64'],
+    toolCapabilities: null,
+    toolCapabilitiesReportedAt: null,
     maxClaims: null,
     claimsUsed: 0,
     createdAt: new Date(),

--- a/libs/runner/agent/package.json
+++ b/libs/runner/agent/package.json
@@ -39,14 +39,18 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.3.200",
     "@anthropic-ai/sdk": "0.110.0",
+    "@earendil-works/pi-ai": "0.79.9",
     "@earendil-works/pi-coding-agent": "0.79.6",
+    "@earendil-works/pi-tui": "0.79.9",
     "@shipfox/api-agent-dto": "workspace:*",
+    "@shipfox/api-runners-dto": "workspace:*",
     "@shipfox/api-workflows-dto": "workspace:*",
     "@shipfox/config": "workspace:*",
     "@shipfox/expression": "workspace:*",
     "@shipfox/node-egress-guard": "workspace:*",
     "@shipfox/node-opentelemetry": "workspace:*",
     "@shipfox/runner-execution": "workspace:*",
+    "pi-web-access": "0.13.0",
     "typebox": "1.1.38",
     "zod": "4.4.3"
   },

--- a/libs/runner/agent/src/core/pi-adapter.test.ts
+++ b/libs/runner/agent/src/core/pi-adapter.test.ts
@@ -1,5 +1,6 @@
 const {
   createAgentSessionMock,
+  createAgentSessionServicesMock,
   findMock,
   getAllMock,
   hasConfiguredAuthMock,
@@ -10,6 +11,7 @@ const {
   getLastAssistantTextMock,
 } = vi.hoisted(() => ({
   createAgentSessionMock: vi.fn(),
+  createAgentSessionServicesMock: vi.fn(),
   findMock: vi.fn(),
   getAllMock: vi.fn(),
   hasConfiguredAuthMock: vi.fn(),
@@ -38,7 +40,8 @@ const {assertEgressAllowedMock, EgressDeniedErrorMock} = vi.hoisted(() => {
 });
 
 vi.mock('@earendil-works/pi-coding-agent', () => ({
-  createAgentSession: createAgentSessionMock,
+  createAgentSessionFromServices: createAgentSessionMock,
+  createAgentSessionServices: createAgentSessionServicesMock,
   defineTool: defineToolMock,
   AuthStorage: {create: authStorageCreateMock, inMemory: authStorageInMemoryMock},
   ModelRegistry: {
@@ -112,6 +115,7 @@ describe('piHarnessAdapter', () => {
     priorGitConfigGlobal = process.env.GIT_CONFIG_GLOBAL;
     delete process.env.GIT_CONFIG_GLOBAL;
     createAgentSessionMock.mockReset();
+    createAgentSessionServicesMock.mockReset();
     findMock.mockReset();
     getAllMock.mockReset();
     hasConfiguredAuthMock.mockReset();
@@ -131,6 +135,7 @@ describe('piHarnessAdapter', () => {
     hasConfiguredAuthMock.mockReturnValue(true);
     promptMock.mockResolvedValue(undefined);
     getLastAssistantTextMock.mockReturnValue(undefined);
+    createAgentSessionServicesMock.mockResolvedValue({cwd: '/work'});
     createAgentSessionMock.mockResolvedValue({
       session: {
         prompt: promptMock,
@@ -156,11 +161,32 @@ describe('piHarnessAdapter', () => {
     const result = await piHarnessAdapter.run(invocation({provider: 'openai', model: 'gpt-5.1'}));
 
     expect(findMock).toHaveBeenCalledWith('openai', 'gpt-5.1');
+    expect(createAgentSessionServicesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cwd: '/work',
+        resourceLoaderOptions: {additionalExtensionPaths: ['pi-web-access']},
+      }),
+    );
     expect(createAgentSessionMock).toHaveBeenCalledWith(
-      expect.objectContaining({cwd: '/work', thinkingLevel: 'high', model}),
+      expect.objectContaining({services: {cwd: '/work'}, thinkingLevel: 'high', model}),
     );
     expect(promptMock).toHaveBeenCalledWith(expect.stringContaining('Fix it.'));
     expect(result).toEqual({response: ''});
+  });
+
+  it('loads pi-web-access through the Pi resource loader and keeps the output tool', async () => {
+    await piHarnessAdapter.run(invocation());
+
+    expect(createAgentSessionServicesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceLoaderOptions: {additionalExtensionPaths: ['pi-web-access']},
+      }),
+    );
+    expect(createAgentSessionMock.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        customTools: [expect.objectContaining({name: 'set_output'})],
+      }),
+    );
   });
 
   it('preserves the final assistant response when required outputs stay missing', async () => {

--- a/libs/runner/agent/src/core/pi-adapter.ts
+++ b/libs/runner/agent/src/core/pi-adapter.ts
@@ -3,7 +3,8 @@ import {
   type ApiKeyCredential,
   AuthStorage,
   type CreateAgentSessionOptions,
-  createAgentSession,
+  createAgentSessionFromServices,
+  createAgentSessionServices,
   defineTool,
   ModelRegistry,
   SessionManager,
@@ -89,12 +90,19 @@ async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult>
     );
   }
 
-  const {session} = await createAgentSession({
+  const services = await createAgentSessionServices({
     cwd,
-    model,
-    thinkingLevel: thinking as PiThinkingLevel,
     authStorage,
     modelRegistry,
+    resourceLoaderOptions: {
+      additionalExtensionPaths: ['pi-web-access'],
+    },
+  });
+
+  const {session} = await createAgentSessionFromServices({
+    services,
+    model,
+    thinkingLevel: thinking as PiThinkingLevel,
     customTools: [setOutputTool(collector)],
     // Keep the session JSONL inside the job workspace so it forwards from a deterministic path
     // and is cleaned up with the workspace; pi's default lives under ~/.pi, outside it.

--- a/libs/runner/agent/src/core/tool-capabilities.ts
+++ b/libs/runner/agent/src/core/tool-capabilities.ts
@@ -1,0 +1,34 @@
+import type {RunnerToolCapabilitiesDto} from '@shipfox/api-runners-dto';
+
+const PI_TOOLS = [
+  'read',
+  'bash',
+  'edit',
+  'write',
+  'grep',
+  'find',
+  'ls',
+  'web_search',
+  'fetch_content',
+  'get_search_content',
+] as const;
+
+const CLAUDE_TOOLS = [
+  'Read',
+  'Bash',
+  'Edit',
+  'Write',
+  'Glob',
+  'Grep',
+  'WebFetch',
+  'WebSearch',
+] as const;
+
+export function runnerToolCapabilities(): RunnerToolCapabilitiesDto {
+  return {
+    harnesses: {
+      pi: {tools: [...PI_TOOLS]},
+      claude: {tools: [...CLAUDE_TOOLS]},
+    },
+  };
+}

--- a/libs/runner/agent/src/index.ts
+++ b/libs/runner/agent/src/index.ts
@@ -1,1 +1,2 @@
 export {executeAgentStep} from '#core/step.js';
+export {runnerToolCapabilities} from '#core/tool-capabilities.js';

--- a/libs/runner/orchestration/src/core/heartbeat-loop.test.ts
+++ b/libs/runner/orchestration/src/core/heartbeat-loop.test.ts
@@ -3,8 +3,11 @@ import {HTTPError} from 'ky';
 const heartbeatMock = vi.fn();
 
 vi.mock('@shipfox/runner-protocol', () => ({
-  heartbeat: (jobId: string, leaseToken: string, opts?: {signal?: AbortSignal}) =>
-    heartbeatMock(jobId, leaseToken, opts),
+  heartbeat: (
+    jobId: string,
+    leaseToken: string,
+    opts?: {signal?: AbortSignal; capabilities?: unknown},
+  ) => heartbeatMock(jobId, leaseToken, opts),
   HTTPError,
 }));
 
@@ -44,6 +47,26 @@ describe('startHeartbeatLoop', () => {
     expect(heartbeatMock.mock.calls[0]?.[1]).toBe('lease-1');
     expect(ac.signal.aborted).toBe(false);
     expect(handle.bumpGeneration).toEqual(expect.any(Function));
+
+    handle.stop();
+  });
+
+  test('passes advertised tool capabilities to heartbeat', async () => {
+    const capabilities = {harnesses: {pi: {tools: ['read']}}};
+    heartbeatMock.mockResolvedValue({cancel: false, lease_token: 'lease-1'});
+    const ac = new AbortController();
+
+    const handle = startHeartbeatLoop('job-1', () => 'lease-1', ac, {
+      intervalMs: 100,
+      maxStaleMs: 1000,
+      getToolCapabilities: () => capabilities,
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(heartbeatMock.mock.calls[0]?.[2]).toEqual(
+      expect.objectContaining({capabilities, signal: expect.any(AbortSignal)}),
+    );
 
     handle.stop();
   });
@@ -126,7 +149,11 @@ describe('startHeartbeatLoop', () => {
   test('max-stale guard aborts the in-flight call and schedules the next tick', async () => {
     let receivedSignal: AbortSignal | undefined;
     heartbeatMock.mockImplementation(
-      (_jobId: string, _leaseToken: string, opts?: {signal?: AbortSignal}) =>
+      (
+        _jobId: string,
+        _leaseToken: string,
+        opts?: {signal?: AbortSignal; capabilities?: unknown},
+      ) =>
         new Promise<{cancel: boolean; lease_token: string}>((_resolve, reject) => {
           receivedSignal = opts?.signal;
           opts?.signal?.addEventListener('abort', () => {
@@ -221,7 +248,11 @@ describe('startHeartbeatLoop', () => {
   test('stop() prevents future ticks and aborts any in-flight call', async () => {
     let aborted = false;
     heartbeatMock.mockImplementation(
-      (_jobId: string, _leaseToken: string, opts?: {signal?: AbortSignal}) =>
+      (
+        _jobId: string,
+        _leaseToken: string,
+        opts?: {signal?: AbortSignal; capabilities?: unknown},
+      ) =>
         new Promise<{cancel: boolean; lease_token: string}>((_resolve, reject) => {
           opts?.signal?.addEventListener('abort', () => {
             aborted = true;

--- a/libs/runner/orchestration/src/core/heartbeat-loop.ts
+++ b/libs/runner/orchestration/src/core/heartbeat-loop.ts
@@ -1,6 +1,8 @@
 import {logger} from '@shipfox/node-opentelemetry';
 import {HTTPError, heartbeat} from '@shipfox/runner-protocol';
 
+type HeartbeatCapabilities = NonNullable<Parameters<typeof heartbeat>[2]>['capabilities'];
+
 export interface HeartbeatLoopOptions {
   intervalMs: number;
   /**
@@ -9,6 +11,7 @@ export interface HeartbeatLoopOptions {
    * call in flight" under any API latency.
    */
   maxStaleMs: number;
+  getToolCapabilities?: () => HeartbeatCapabilities;
   onLeaseTokenRenewed?: (leaseToken: string) => void;
 }
 
@@ -63,8 +66,10 @@ export function startHeartbeatLoop(
     }, options.maxStaleMs);
 
     try {
+      const capabilities = options.getToolCapabilities?.();
       const {cancel, lease_token: renewedLeaseToken} = await heartbeat(jobId, sentLeaseToken, {
         signal: httpAc.signal,
+        ...(capabilities ? {capabilities} : {}),
       });
       if (stopped) return;
       if (generation === sentGeneration && renewedLeaseToken !== getLeaseToken()) {

--- a/libs/runner/orchestration/src/core/runner.test.ts
+++ b/libs/runner/orchestration/src/core/runner.test.ts
@@ -27,6 +27,14 @@ vi.mock('#core/step-loop.js', () => ({
   runJobSteps: vi.fn(),
 }));
 
+vi.mock('@shipfox/runner-agent', () => ({
+  runnerToolCapabilities: vi.fn(() => ({
+    harnesses: {
+      pi: {tools: ['read']},
+    },
+  })),
+}));
+
 vi.mock('@shipfox/runner-protocol', () => ({
   registerRunnerSession: vi.fn(),
   requireRunnerLabels: vi.fn(),
@@ -45,6 +53,7 @@ vi.mock('@shipfox/runner-protocol', () => ({
   },
 }));
 
+import {runnerToolCapabilities} from '@shipfox/runner-agent';
 import {
   createLeaseClient,
   HTTPError,
@@ -83,6 +92,7 @@ const mockRegisterRunnerSession = vi.mocked(registerRunnerSession);
 const mockRequireRunnerLabels = vi.mocked(requireRunnerLabels);
 const mockRequestJob = vi.mocked(requestJob);
 const mockStartHeartbeatLoop = vi.mocked(startHeartbeatLoop);
+const mockRunnerToolCapabilities = vi.mocked(runnerToolCapabilities);
 
 const JOB = {
   workflow_run_id: '00000000-0000-0000-0000-000000000004',
@@ -138,6 +148,7 @@ describe('runJob', () => {
       expect.objectContaining({
         intervalMs: 10_000,
         maxStaleMs: 10_000,
+        getToolCapabilities: runnerToolCapabilities,
       }),
     );
     const leaseTokenSource = mockCreateLeaseClient.mock.calls[0]?.[0];
@@ -280,6 +291,10 @@ describe('startRunner', () => {
     await startRunner();
 
     expect(mockRegisterRunnerSession).toHaveBeenCalledTimes(1);
+    expect(mockRegisterRunnerSession).toHaveBeenCalledWith({
+      capabilities: {harnesses: {pi: {tools: ['read']}}},
+    });
+    expect(mockRunnerToolCapabilities).toHaveBeenCalled();
     expect(mockRequestJob).toHaveBeenCalledTimes(1);
     expect(mockRunJobSteps).not.toHaveBeenCalled();
   });

--- a/libs/runner/orchestration/src/core/runner.ts
+++ b/libs/runner/orchestration/src/core/runner.ts
@@ -6,6 +6,7 @@ import {
   createGracefulShutdownController,
   interruptibleSleep,
 } from '@shipfox/node-resilient-loop';
+import {runnerToolCapabilities} from '@shipfox/runner-agent';
 import {
   createLeaseClient,
   HTTPError,
@@ -73,7 +74,7 @@ export async function startRunner(): Promise<void> {
   while (running) {
     try {
       if (!runnerSession) {
-        runnerSession = await registerRunnerSession();
+        runnerSession = await registerRunnerSession({capabilities: runnerToolCapabilities()});
         logger().info({runnerSessionId: runnerSession.session_id}, 'Runner session registered');
       }
 
@@ -191,6 +192,7 @@ export async function runJob(
   const heartbeatLoop = startHeartbeatLoop(job.job_id, () => currentLeaseToken, ac, {
     intervalMs: config.SHIPFOX_HEARTBEAT_INTERVAL_MS,
     maxStaleMs: config.SHIPFOX_HEARTBEAT_MAX_STALE_MS,
+    getToolCapabilities: runnerToolCapabilities,
     onLeaseTokenRenewed: rememberLeaseToken,
   });
 

--- a/libs/runner/protocol/src/api-client.test.ts
+++ b/libs/runner/protocol/src/api-client.test.ts
@@ -2,7 +2,10 @@
 // claim, heartbeat, and step calls use the right bearer token class. SHIPFOX_API_URL comes
 // from test/env.ts (setupFiles), loaded before config is imported.
 
-import {RUNNER_SESSION_EXHAUSTED_CODE} from '@shipfox/api-runners-dto';
+import {
+  RUNNER_SESSION_EXHAUSTED_CODE,
+  type RunnerToolCapabilitiesDto,
+} from '@shipfox/api-runners-dto';
 import {STEP_ERROR_MESSAGE_MAX_LENGTH, STEP_RESPONSE_MAX_LENGTH} from '@shipfox/api-workflows-dto';
 import {
   AgentRuntimeConfigRequestError,
@@ -30,6 +33,12 @@ const WORKFLOW_RUN_ATTEMPT_ID = crypto.randomUUID();
 const STEP_ID = crypto.randomUUID();
 const SESSION_ID = crypto.randomUUID();
 const ZOD_ERROR_TEXT_REGEX = /Zod|Invalid|Required/;
+const TOOL_CAPABILITIES: RunnerToolCapabilitiesDto = {
+  harnesses: {
+    pi: {tools: ['read', 'bash']},
+    claude: {tools: ['Read', 'Bash']},
+  },
+};
 
 let calls: Array<{url: string; method: string; authorization: string | null; body: string}>;
 let originalFetch: typeof globalThis.fetch;
@@ -80,6 +89,17 @@ describe('api-client auth contexts', () => {
     expect(calls[0]?.url).toContain('runners/register');
     expect(calls[0]?.authorization).toBe(`Bearer ${config.SHIPFOX_RUNNER_REGISTRATION_TOKEN}`);
     expect(JSON.parse(calls[0]?.body ?? '{}')).toEqual({labels: ['linux', 'x64']});
+  });
+
+  it('registerRunnerSession sends runner tool capabilities when provided', async () => {
+    stubFetch(() => jsonResponse(registerResponse()));
+
+    await registerRunnerSession({capabilities: TOOL_CAPABILITIES});
+
+    expect(JSON.parse(calls[0]?.body ?? '{}')).toEqual({
+      labels: ['linux', 'x64'],
+      capabilities: TOOL_CAPABILITIES,
+    });
   });
 
   it('requestJob sends the runner session token and parses the step-less claim + lease token', async () => {
@@ -139,6 +159,16 @@ describe('api-client auth contexts', () => {
     expect(response.lease_token).toBe('lease-next');
     expect(calls[0]?.url).toContain(`runners/jobs/${JOB_ID}/heartbeat`);
     expect(calls[0]?.authorization).toBe('Bearer lease-heartbeat');
+  });
+
+  it('heartbeat sends runner tool capabilities when provided', async () => {
+    stubFetch(() => jsonResponse({cancel: false, lease_token: 'lease-next'}));
+
+    await heartbeat(JOB_ID, 'lease-heartbeat', {capabilities: TOOL_CAPABILITIES});
+
+    expect(calls[0]?.url).toContain(`runners/jobs/${JOB_ID}/heartbeat`);
+    expect(calls[0]?.authorization).toBe('Bearer lease-heartbeat');
+    expect(JSON.parse(calls[0]?.body ?? '{}')).toEqual({capabilities: TOOL_CAPABILITIES});
   });
 
   it('requestNextStep sends the lease token, not the runner registration token', async () => {

--- a/libs/runner/protocol/src/api-client.ts
+++ b/libs/runner/protocol/src/api-client.ts
@@ -7,9 +7,11 @@ import {
   type ClaimedJobResponseDto,
   claimedJobResponseSchema,
   type HeartbeatResponseDto,
+  heartbeatBodySchema,
   heartbeatResponseSchema,
   type RegisterRunnerResponseDto,
   RUNNER_SESSION_EXHAUSTED_CODE,
+  type RunnerToolCapabilitiesDto,
   registerRunnerBodySchema,
   registerRunnerResponseSchema,
 } from '@shipfox/api-runners-dto';
@@ -133,12 +135,17 @@ export function requireRunnerLabels(): string[] {
   return labels;
 }
 
-export async function registerRunnerSession(): Promise<RegisterRunnerResponseDto> {
+export async function registerRunnerSession(
+  options: {capabilities?: RunnerToolCapabilitiesDto} = {},
+): Promise<RegisterRunnerResponseDto> {
   const labels = configuredRunnerLabels();
 
   logger().debug({labels}, 'Registering runner session');
 
-  const body = registerRunnerBodySchema.parse({labels});
+  const body = registerRunnerBodySchema.parse({
+    labels,
+    ...(options.capabilities ? {capabilities: options.capabilities} : {}),
+  });
   const response = await registrationApi.post('runners/register', {json: body});
 
   return registerRunnerResponseSchema.parse(await response.json());
@@ -420,11 +427,19 @@ export async function appendStepLogs(
 export async function heartbeat(
   jobId: string,
   leaseToken: string,
-  options: {signal?: AbortSignal} = {},
+  options: {signal?: AbortSignal; capabilities?: RunnerToolCapabilitiesDto} = {},
 ): Promise<HeartbeatResponseDto> {
+  const body =
+    options.capabilities === undefined
+      ? undefined
+      : heartbeatBodySchema.parse({capabilities: options.capabilities});
+  const requestOptions = {
+    ...(body ? {json: body} : {}),
+    ...(options.signal ? {signal: options.signal} : {}),
+  };
   const response = await createLeaseClient(leaseToken).post(
     `runners/jobs/${jobId}/heartbeat`,
-    options.signal ? {signal: options.signal} : undefined,
+    Object.keys(requestOptions).length > 0 ? requestOptions : undefined,
   );
   return heartbeatResponseSchema.parse(await response.json());
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4584,12 +4584,21 @@ importers:
       '@anthropic-ai/sdk':
         specifier: 0.110.0
         version: 0.110.0(zod@4.4.3)
+      '@earendil-works/pi-ai':
+        specifier: 0.79.9
+        version: 0.79.9(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: 0.79.6
-        version: 0.79.6(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
+        version: 0.79.6(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui':
+        specifier: 0.79.9
+        version: 0.79.9
       '@shipfox/api-agent-dto':
         specifier: workspace:*
         version: link:../../api/agent-dto
+      '@shipfox/api-runners-dto':
+        specifier: workspace:*
+        version: link:../../api/runners-dto
       '@shipfox/api-workflows-dto':
         specifier: workspace:*
         version: link:../../api/workflows-dto
@@ -4608,6 +4617,9 @@ importers:
       '@shipfox/runner-execution':
         specifier: workspace:*
         version: link:../execution
+      pi-web-access:
+        specifier: 0.13.0
+        version: 0.13.0(@earendil-works/pi-ai@0.79.9(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3))(@earendil-works/pi-coding-agent@0.79.6(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3))(@earendil-works/pi-tui@0.79.9)(typebox@1.1.38)
       typebox:
         specifier: 1.1.38
         version: 1.1.38
@@ -7317,6 +7329,9 @@ packages:
       '@opentelemetry/api':
         optional: true
 
+  '@mixmark-io/domino@2.2.0':
+    resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
+
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
@@ -7326,6 +7341,10 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@mozilla/readability@0.6.0':
+    resolution: {integrity: sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==}
+    engines: {node: '>=14.0.0'}
 
   '@napi-rs/nice-android-arm-eabi@1.1.1':
     resolution: {integrity: sha512-kjirL3N6TnRPv5iuHw36wnucNqXAO46dzK9oPb0wj076R5Xm8PfUVA9nAFB5ZNMmfJQJVKACAPd/Z2KYMppthw==}
@@ -10572,6 +10591,9 @@ packages:
     resolution: {integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
 
+  cssom@0.5.0:
+    resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -11364,6 +11386,9 @@ packages:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  html-escaper@3.0.3:
+    resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
+
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
@@ -11841,6 +11866,9 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  linkedom@0.16.11:
+    resolution: {integrity: sha512-WgaTVbj7itjyXTsCvgerpneERXShcnNJF5VIV+/4SLtyRLN+HppPre/WDHRofAr2IpEuujSNgJbCBd5lMl6lRw==}
+
   loader-runner@4.3.2:
     resolution: {integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==}
     engines: {node: '>=6.11.5'}
@@ -12296,6 +12324,10 @@ packages:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
 
+  p-limit@6.2.0:
+    resolution: {integrity: sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==}
+    engines: {node: '>=18'}
+
   p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
@@ -12438,6 +12470,14 @@ packages:
 
   pgpass@1.0.5:
     resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
+  pi-web-access@0.13.0:
+    resolution: {integrity: sha512-ny0bHisMWdobmu1hcMp/jqjaRh6pYrH7dctBK2CVyRF4ia7bP47RnOPYdG1yiks9ohtcanWir5Hl9EFap8h0zQ==}
+    peerDependencies:
+      '@earendil-works/pi-ai': '*'
+      '@earendil-works/pi-coding-agent': '*'
+      '@earendil-works/pi-tui': '*'
+      typebox: '*'
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -13552,6 +13592,10 @@ packages:
     resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
     engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
 
+  turndown@7.2.4:
+    resolution: {integrity: sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==}
+    engines: {node: '>=18', npm: '>=9'}
+
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
@@ -13578,6 +13622,9 @@ packages:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
     hasBin: true
+
+  uhyphen@0.2.0:
+    resolution: {integrity: sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==}
 
   uint8array-extras@1.5.0:
     resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
@@ -13641,6 +13688,14 @@ packages:
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
+
+  unpdf@1.6.2:
+    resolution: {integrity: sha512-zQ80ySoPuPHOsvIoRp/nJyQt8TOUoTh1+WBCGcBvlddQNgKDLRwm0AY3x8Q35I7+kIiRSgqMx+Ma2pl9McIp7A==}
+    peerDependencies:
+      '@napi-rs/canvas': ^0.1.69
+    peerDependenciesMeta:
+      '@napi-rs/canvas':
+        optional: true
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -13972,6 +14027,10 @@ packages:
   yauzl@3.3.0:
     resolution: {integrity: sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==}
     engines: {node: '>=12'}
+
+  yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
+    engines: {node: '>=12.20'}
 
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
@@ -14762,7 +14821,7 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
-  '@earendil-works/pi-agent-core@0.79.9(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
+  '@earendil-works/pi-agent-core@0.79.9(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@earendil-works/pi-ai': 0.79.9(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       ignore: 7.0.5
@@ -14797,9 +14856,9 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.79.6(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.79.6(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.79.9(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
+      '@earendil-works/pi-agent-core': 0.79.9(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-ai': 0.79.9(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-tui': 0.79.9
       '@silvia-odwyer/photon-node': 0.3.4
@@ -15578,6 +15637,8 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  '@mixmark-io/domino@2.2.0': {}
+
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.27)
@@ -15599,6 +15660,8 @@ snapshots:
       zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
+
+  '@mozilla/readability@0.6.0': {}
 
   '@napi-rs/nice-android-arm-eabi@1.1.1':
     optional: true
@@ -19086,6 +19149,8 @@ snapshots:
     dependencies:
       css-tree: 2.2.1
 
+  cssom@0.5.0: {}
+
   csstype@3.2.3: {}
 
   data-uri-to-buffer@4.0.1: {}
@@ -19951,6 +20016,8 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  html-escaper@3.0.3: {}
+
   html-void-elements@3.0.0: {}
 
   htmlnano@3.3.2(cssnano@7.1.9(postcss@8.5.15))(postcss@8.5.15)(relateurl@0.2.7)(svgo@4.0.1)(terser@5.48.0)(typescript@6.0.3):
@@ -20350,6 +20417,14 @@ snapshots:
   lilconfig@3.1.3: {}
 
   lines-and-columns@1.2.4: {}
+
+  linkedom@0.16.11:
+    dependencies:
+      css-select: 5.2.2
+      cssom: 0.5.0
+      html-escaper: 3.0.3
+      htmlparser2: 9.1.0
+      uhyphen: 0.2.0
 
   loader-runner@4.3.2: {}
 
@@ -21173,6 +21248,10 @@ snapshots:
     dependencies:
       p-try: 2.2.0
 
+  p-limit@6.2.0:
+    dependencies:
+      yocto-queue: 1.2.2
+
   p-locate@4.1.0:
     dependencies:
       p-limit: 2.3.0
@@ -21303,6 +21382,20 @@ snapshots:
   pgpass@1.0.5:
     dependencies:
       split2: 4.2.0
+
+  pi-web-access@0.13.0(@earendil-works/pi-ai@0.79.9(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3))(@earendil-works/pi-coding-agent@0.79.6(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3))(@earendil-works/pi-tui@0.79.9)(typebox@1.1.38):
+    dependencies:
+      '@earendil-works/pi-ai': 0.79.9(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent': 0.79.6(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.79.9
+      '@mozilla/readability': 0.6.0
+      linkedom: 0.16.11
+      p-limit: 6.2.0
+      turndown: 7.2.4
+      typebox: 1.1.38
+      unpdf: 1.6.2
+    transitivePeerDependencies:
+      - '@napi-rs/canvas'
 
   picocolors@1.1.1: {}
 
@@ -22451,6 +22544,10 @@ snapshots:
 
   tunnel@0.0.6: {}
 
+  turndown@7.2.4:
+    dependencies:
+      '@mixmark-io/domino': 2.2.0
+
   tw-animate-css@1.4.0: {}
 
   tweetnacl@0.14.5: {}
@@ -22469,6 +22566,8 @@ snapshots:
 
   uglify-js@3.19.3:
     optional: true
+
+  uhyphen@0.2.0: {}
 
   uint8array-extras@1.5.0: {}
 
@@ -22525,6 +22624,8 @@ snapshots:
   universal-user-agent@7.0.3: {}
 
   universalify@0.1.2: {}
+
+  unpdf@1.6.2: {}
 
   unpipe@1.0.0: {}
 
@@ -22862,6 +22963,8 @@ snapshots:
     dependencies:
       buffer-crc32: 0.2.13
       pend: 1.2.0
+
+  yocto-queue@1.2.2: {}
 
   yoctocolors@2.1.2: {}
 


### PR DESCRIPTION
Add runner-advertised tool capabilities to the runner protocol.

Runners now report exact Pi and Claude harness tool names during registration and heartbeat, and the runners API persists the latest report on the runner session. This gives dispatch enforcement a fail-closed source of truth for missing, stale, or malformed capability reports.

Heartbeat updates job liveness and capability state in one transaction, and omitted heartbeat capabilities intentionally clear the stored report. The runner agent loads `pi-web-access` through Pi's resource loader and advertises the web tools it enables.

The runner-session columns are folded into the existing initial runners migration per this branch's migration convention.

Closes ENG-835

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runners now advertise Pi and Claude tool capabilities during registration and heartbeat, and the API persists the latest report per session. This creates a fail-closed, server-side source of truth for dispatch (ENG-835).

- **New Features**
  - Protocol: `register` and `heartbeat` accept optional `capabilities`; orchestration sends them at registration and on each beat.
  - API: stores `tool_capabilities` and `tool_capabilities_reported_at`; heartbeat updates liveness and capabilities in one transaction; omitted capabilities clear the report; logs capability changes on heartbeat.
  - DTOs: added `runnerToolCapabilitiesSchema`, `runnerHarnessToolCapabilitiesSchema`, and `heartbeatBodySchema`.
  - Agent: exposes `runnerToolCapabilities()`, loads `pi-web-access` via Pi’s resource loader, and advertises web tools; retains Pi’s `set_output` tool.
  - Core: `effectiveRunnerToolCapabilities` returns an empty set when missing or stale.

- **Dependencies**
  - Added `@earendil-works/pi-ai`, `@earendil-works/pi-tui`, and `pi-web-access` to `@shipfox/runner-agent`.

<sup>Written for commit 1de1cb8d7376122704042c6bf4dadbf28b479bae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

