### PR TITLE
[api/integration] Add agent tools adapter contract

### DIFF
--- a/libs/api/integration/core-dto/src/contracts/index.ts
+++ b/libs/api/integration/core-dto/src/contracts/index.ts
@@ -1,4 +1,10 @@
 export type {
+  AgentToolCallInput,
+  AgentToolCatalogEntry,
+  AgentToolJsonSchema,
+  AgentToolSensitivity,
+  AgentToolSession,
+  AgentToolsProvider,
   CheckoutCredentials,
   CheckoutPermissions,
   CheckoutSpec,
@@ -16,6 +22,7 @@ export type {
   IntegrationProviderKind,
   ListFilesInput,
   ListRepositoriesInput,
+  OpenAgentToolsSessionInput,
   RegisteredIntegrationProvider,
   RepositoryPage,
   RepositorySnapshot,

--- a/libs/api/integration/core-dto/src/contracts/integrations.ts
+++ b/libs/api/integration/core-dto/src/contracts/integrations.ts
@@ -1,5 +1,5 @@
 export type IntegrationProviderKind = string;
-export type IntegrationCapability = 'source_control';
+export type IntegrationCapability = 'source_control' | 'agent_tools';
 export type IntegrationConnectionLifecycleStatus = 'active' | 'disabled' | 'error';
 
 export interface IntegrationConnection<
@@ -120,10 +120,61 @@ export interface SourceControlProvider<
   createCheckoutSpec?(input: CreateCheckoutSpecInput<Connection>): Promise<CheckoutSpec>;
 }
 
+export type AgentToolSensitivity = 'read' | 'write';
+export type AgentToolJsonSchema = Record<string, unknown>;
+
+export interface AgentToolCatalogEntry<RequiredScope = unknown> {
+  id: string;
+  description: string;
+  sensitivity: AgentToolSensitivity;
+  sensitive: boolean;
+  requiredScope: RequiredScope;
+  inputSchema: AgentToolJsonSchema;
+  outputSchema?: AgentToolJsonSchema | undefined;
+}
+
+export interface AgentToolCallInput {
+  toolId: string;
+  arguments: Record<string, unknown>;
+}
+
+export interface AgentToolSession<CallResult = unknown> {
+  call(input: AgentToolCallInput): Promise<CallResult>;
+  close?(): Promise<void>;
+}
+
+export interface OpenAgentToolsSessionInput<
+  Connection extends IntegrationConnection = IntegrationConnection,
+  RequiredScope = unknown,
+  ProviderScope = unknown,
+  ScopedToken = unknown,
+> {
+  connection: Connection;
+  tools: readonly AgentToolCatalogEntry<RequiredScope>[];
+  scope: ProviderScope;
+  mintToken(requiredScope: RequiredScope): Promise<ScopedToken>;
+}
+
+export interface AgentToolsProvider<
+  Connection extends IntegrationConnection = IntegrationConnection,
+  RequiredScope = unknown,
+  ProviderScope = unknown,
+  ScopedToken = unknown,
+  CallResult = unknown,
+> {
+  catalog():
+    | readonly AgentToolCatalogEntry<RequiredScope>[]
+    | Promise<readonly AgentToolCatalogEntry<RequiredScope>[]>;
+  openSession(
+    input: OpenAgentToolsSessionInput<Connection, RequiredScope, ProviderScope, ScopedToken>,
+  ): Promise<AgentToolSession<CallResult>>;
+}
+
 export interface IntegrationProviderAdapters<
   Connection extends IntegrationConnection = IntegrationConnection,
 > {
   source_control?: SourceControlProvider<Connection> | undefined;
+  agent_tools?: AgentToolsProvider<Connection> | undefined;
 }
 
 export interface IntegrationProvider<

--- a/libs/api/integration/core-dto/src/schemas/integrations.ts
+++ b/libs/api/integration/core-dto/src/schemas/integrations.ts
@@ -6,7 +6,7 @@ export {connectionSlugSchema};
 export const integrationProviderKindSchema = z.string().min(1);
 export type IntegrationProviderKindDto = z.infer<typeof integrationProviderKindSchema>;
 
-export const integrationCapabilitySchema = z.enum(['source_control']);
+export const integrationCapabilitySchema = z.enum(['source_control', 'agent_tools']);
 export type IntegrationCapabilityDto = z.infer<typeof integrationCapabilitySchema>;
 
 export const integrationConnectionLifecycleStatusSchema = z.enum(['active', 'disabled', 'error']);

--- a/libs/api/integration/core/src/core/entities/provider.ts
+++ b/libs/api/integration/core/src/core/entities/provider.ts
@@ -5,9 +5,16 @@ import type {
 import type {RouteExport} from '@shipfox/node-fastify';
 
 export type {
+  AgentToolCallInput,
+  AgentToolCatalogEntry,
+  AgentToolJsonSchema,
+  AgentToolSensitivity,
+  AgentToolSession,
+  AgentToolsProvider,
   IntegrationCapability,
   IntegrationProviderAdapters,
   IntegrationProviderKind,
+  OpenAgentToolsSessionInput,
 } from '@shipfox/api-integration-core-dto';
 
 export type IntegrationProvider = CoreIntegrationProvider<string, RouteExport>;

--- a/libs/api/integration/core/src/core/providers/agent-tools.ts
+++ b/libs/api/integration/core/src/core/providers/agent-tools.ts
@@ -1,0 +1,9 @@
+export type {
+  AgentToolCallInput,
+  AgentToolCatalogEntry,
+  AgentToolJsonSchema,
+  AgentToolSensitivity,
+  AgentToolSession,
+  AgentToolsProvider,
+  OpenAgentToolsSessionInput,
+} from '@shipfox/api-integration-core-dto';

--- a/libs/api/integration/core/src/core/providers/registry.test.ts
+++ b/libs/api/integration/core/src/core/providers/registry.test.ts
@@ -25,6 +25,21 @@ function sourceControlAdapter() {
   };
 }
 
+function agentToolsAdapter() {
+  return {
+    catalog: () => [],
+    openSession: async () => {
+      await Promise.resolve();
+      return {
+        call: async () => {
+          await Promise.resolve();
+          return {};
+        },
+      };
+    },
+  };
+}
+
 describe('integration provider registry', () => {
   it('lists providers by capability', () => {
     const registry = createIntegrationProviderRegistry([
@@ -44,6 +59,23 @@ describe('integration provider registry', () => {
     const result = registry.list('source_control');
 
     expect(result.map((provider) => provider.provider)).toEqual(['gitea']);
+  });
+
+  it('computes the agent tools capability from the adapter', () => {
+    const registry = createIntegrationProviderRegistry([
+      {
+        provider: 'github',
+        displayName: 'GitHub',
+        adapters: {
+          agent_tools: agentToolsAdapter(),
+        },
+      },
+    ]);
+
+    const result = registry.list('agent_tools');
+
+    expect(result.map((provider) => provider.provider)).toEqual(['github']);
+    expect(registry.get('github').capabilities).toEqual(['agent_tools']);
   });
 
   it('keeps provider sets isolated per registry instance', () => {

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -52,6 +52,15 @@ export {
   IntegrationProviderError,
   IntegrationProviderUnavailableError,
 } from '#core/errors.js';
+export type {
+  AgentToolCallInput,
+  AgentToolCatalogEntry,
+  AgentToolJsonSchema,
+  AgentToolSensitivity,
+  AgentToolSession,
+  AgentToolsProvider,
+  OpenAgentToolsSessionInput,
+} from '#core/providers/agent-tools.js';
 export {redactCheckoutSpec} from '#core/providers/redact-checkout-spec.js';
 export type {IntegrationProviderRegistry} from '#core/providers/registry.js';
 export type {

--- a/libs/api/integration/core/src/presentation/routes/list-connections.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/list-connections.test.ts
@@ -65,6 +65,50 @@ describe('GET /integration-connections', () => {
     ).toEqual(['gitea']);
   });
 
+  it('advertises agent tools capability on matching connections', async () => {
+    const app = await createTestApp([
+      {
+        provider: 'github',
+        displayName: 'GitHub',
+        adapters: {
+          agent_tools: {
+            catalog: () => [],
+            openSession: async () => {
+              await Promise.resolve();
+              return {
+                call: async () => {
+                  await Promise.resolve();
+                  return {};
+                },
+              };
+            },
+          },
+        },
+      },
+    ]);
+    await upsertIntegrationConnection({
+      workspaceId: context.workspaceId,
+      provider: 'github',
+      externalAccountId: 'team-1',
+      slug: 'github_team_1',
+      displayName: 'GitHub',
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/integration-connections?workspace_id=${context.workspaceId}&capability=agent_tools`,
+      headers: {authorization: 'Bearer user'},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().connections).toMatchObject([
+      {
+        provider: 'github',
+        capabilities: ['agent_tools'],
+      },
+    ]);
+  });
+
   it('includes external_url when the provider resolves one', async () => {
     const app = await createTestApp([
       sourceProvider({

--- a/libs/api/integration/core/src/presentation/routes/list-providers.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/list-providers.test.ts
@@ -36,6 +36,45 @@ describe('GET /integration-providers', () => {
     ]);
   });
 
+  it('lists providers with agent tools capability', async () => {
+    const app = await createTestApp([
+      sourceProvider(),
+      {
+        provider: 'github',
+        displayName: 'GitHub',
+        adapters: {
+          agent_tools: {
+            catalog: () => [],
+            openSession: async () => {
+              await Promise.resolve();
+              return {
+                call: async () => {
+                  await Promise.resolve();
+                  return {};
+                },
+              };
+            },
+          },
+        },
+      },
+    ]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/integration-providers?capability=agent_tools',
+      headers: {authorization: 'Bearer user'},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().providers).toEqual([
+      {
+        provider: 'github',
+        display_name: 'GitHub',
+        capabilities: ['agent_tools'],
+      },
+    ]);
+  });
+
   it('surfaces the gitea provider once its module is registered', async () => {
     const {provider} = await giteaProviderModule.load();
     const app = await createTestApp([provider]);


### PR DESCRIPTION
Adds the provider-agnostic `agent_tools` integration capability and the `AgentToolsProvider` adapter contract for tool catalogs and sessions.

This lays the foundation for the Integration Agent Tools project without adding a concrete provider implementation yet. The registry already derives provider capabilities from adapter keys, so connections now advertise `agent_tools` whenever a provider registers a non-null adapter.

The touched integration packages are private, so there is no changeset.

Closes ENG-841

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the provider-agnostic `agent_tools` capability and the `AgentToolsProvider` adapter for tool catalogs and sessions so providers and connections can advertise tool support when an adapter is present. Addresses ENG-841.

- **New Features**
  - Added `agent_tools` to `IntegrationCapability` and schema validation.
  - Introduced and exported types: `AgentToolCatalogEntry`, `AgentToolSession`, `AgentToolCallInput`, `OpenAgentToolsSessionInput`, and `AgentToolsProvider` in `@shipfox/api-integration-core-dto` (re-exported in `@shipfox/api-integration-core`).
  - Registry now derives `agent_tools` capability from registered adapters; `GET /integration-providers` and `GET /integration-connections` can filter and return providers/connections with `agent_tools`.
  - Tests cover capability computation and capability-aware listing endpoints.

<sup>Written for commit 8eff1be077b332b1195a5d7cefaebbf096a05dc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

