### PR TITLE
[e2e-driver-agent-provider] Add deterministic provider script engine

### DIFF
--- a/e2e/drivers/agent-provider/README.md
+++ b/e2e/drivers/agent-provider/README.md
@@ -1,0 +1,31 @@
+# Agent Provider E2E Driver
+
+`@shipfox/e2e-driver-agent-provider` provides a deterministic OpenAI-compatible
+provider for E2E tests. It is strict test infrastructure: suites register it as a
+normal custom model provider through product HTTP routes, while the fake provider
+itself stays outside the API app.
+
+This package currently owns the in-process HTTP server and script engine. The
+child-process sidecar wrapper is added separately so flow suites can keep the
+provider alive across Playwright `globalSetup` and worker processes.
+
+## HTTP Surface
+
+Control endpoints require the server admin token:
+
+```text
+GET  /healthz
+POST /scripts
+POST /scripts/:scriptId/reset
+GET  /scripts/:scriptId/requests
+```
+
+Provider-compatible endpoints bind to `127.0.0.1` and intentionally do not
+require auth:
+
+```text
+POST /scripts/:scriptId/v1/chat/completions
+```
+
+Scripts advance one response per provider request. Exhausted scripts return
+`409 script_exhausted`; assertion failures return `422 script_assertion_failed`.

--- a/e2e/drivers/agent-provider/package.json
+++ b/e2e/drivers/agent-provider/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@shipfox/e2e-driver-agent-provider",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
+    "directory": "e2e/drivers/agent-provider"
+  },
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "imports": {
+    "#test/*": "./test/*",
+    "#*": "./src/*"
+  },
+  "exports": {
+    ".": {
+      "development": {
+        "types": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "depcruise": "shipfox-depcruise",
+    "test": "shipfox-vitest-run",
+    "test:watch": "shipfox-vitest-watch",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/depcruise": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*"
+  }
+}

--- a/e2e/drivers/agent-provider/src/index.ts
+++ b/e2e/drivers/agent-provider/src/index.ts
@@ -1,0 +1,21 @@
+export {
+  buildChatCompletion,
+  buildOpenAiError,
+  type OpenAiChatCompletion,
+  type OpenAiChatCompletionChoice,
+  type OpenAiErrorBody,
+} from './openai.js';
+export {
+  type FakeOpenAiRecordedRequest,
+  type FakeOpenAiRequestAssertion,
+  type FakeOpenAiResponse,
+  type FakeOpenAiScript,
+  FakeOpenAiScriptRegistry,
+  type ScriptAdvanceResult,
+  type ScriptRegistrationResult,
+} from './scripts.js';
+export {
+  type CreateFakeOpenAiProviderServerParams,
+  createFakeOpenAiProviderServer,
+  type FakeOpenAiProviderServer,
+} from './server.js';

--- a/e2e/drivers/agent-provider/src/openai.ts
+++ b/e2e/drivers/agent-provider/src/openai.ts
@@ -1,0 +1,102 @@
+import type {FakeOpenAiResponse} from './scripts.js';
+
+const fakeCreatedAt = 1783344000;
+
+export interface OpenAiChatCompletion {
+  id: string;
+  object: 'chat.completion';
+  created: number;
+  model: string;
+  choices: OpenAiChatCompletionChoice[];
+  usage: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
+}
+
+export type OpenAiChatCompletionChoice =
+  | {
+      index: 0;
+      message: {
+        role: 'assistant';
+        content: string;
+        tool_calls: [
+          {
+            id: string;
+            type: 'function';
+            function: {
+              name: string;
+              arguments: string;
+            };
+          },
+        ];
+      };
+      finish_reason: 'tool_calls';
+    }
+  | {
+      index: 0;
+      message: {
+        role: 'assistant';
+        content: string;
+      };
+      finish_reason: 'stop';
+    };
+
+export interface OpenAiErrorBody {
+  error: {
+    message: string;
+    type: string;
+  };
+}
+
+export function buildChatCompletion(params: {
+  model: string;
+  response: Exclude<FakeOpenAiResponse, {kind: 'error'}>;
+  responseIndex: number;
+  scriptId: string;
+}): OpenAiChatCompletion {
+  const message =
+    params.response.kind === 'tool_call'
+      ? {
+          role: 'assistant' as const,
+          content: params.response.content ?? '',
+          tool_calls: [
+            {
+              id: `call_fake_${params.responseIndex + 1}`,
+              type: 'function' as const,
+              function: {
+                name: params.response.toolName,
+                arguments: JSON.stringify(params.response.arguments),
+              },
+            },
+          ],
+        }
+      : {
+          role: 'assistant' as const,
+          content: params.response.content,
+        };
+
+  return {
+    id: `chatcmpl-fake-${params.scriptId}-${params.responseIndex}`,
+    object: 'chat.completion',
+    created: fakeCreatedAt,
+    model: params.model,
+    choices: [
+      {
+        index: 0,
+        message,
+        finish_reason: params.response.kind === 'tool_call' ? 'tool_calls' : 'stop',
+      } as OpenAiChatCompletionChoice,
+    ],
+    usage: {
+      prompt_tokens: 1,
+      completion_tokens: 1,
+      total_tokens: 2,
+    },
+  };
+}
+
+export function buildOpenAiError(type: string, message: string): OpenAiErrorBody {
+  return {error: {message, type}};
+}

--- a/e2e/drivers/agent-provider/src/scripts.ts
+++ b/e2e/drivers/agent-provider/src/scripts.ts
@@ -1,0 +1,271 @@
+import {buildChatCompletion, buildOpenAiError, type OpenAiChatCompletion} from './openai.js';
+
+export interface FakeOpenAiScript {
+  id: string;
+  model: string;
+  responses: FakeOpenAiResponse[];
+  assertions?: FakeOpenAiRequestAssertion[] | undefined;
+}
+
+export type FakeOpenAiResponse =
+  | {
+      kind: 'tool_call';
+      toolName: string;
+      arguments: Record<string, unknown>;
+      content?: string | undefined;
+    }
+  | {
+      kind: 'message';
+      content: string;
+    }
+  | {
+      kind: 'error';
+      status: number;
+      message: string;
+    };
+
+export type FakeOpenAiRequestAssertion =
+  | {
+      kind: 'model';
+      equals: string;
+    }
+  | {
+      kind: 'tool_present';
+      name: string;
+    };
+
+export interface FakeOpenAiRecordedRequest {
+  index: number;
+  method: string;
+  path: string;
+  model: string | null;
+  tools: string[];
+  message_roles: string[];
+  served_response: string | null;
+  assertion_failures: string[];
+  created_at: string;
+}
+
+export interface ScriptRegistrationResult {
+  scriptId: string;
+  model: string;
+}
+
+export type ScriptAdvanceResult =
+  | {
+      status: 200;
+      body: OpenAiChatCompletion;
+    }
+  | {
+      status: number;
+      body: ReturnType<typeof buildOpenAiError>;
+    };
+
+interface ScriptState {
+  cursor: number;
+  requests: FakeOpenAiRecordedRequest[];
+  script: FakeOpenAiScript;
+}
+
+export class FakeOpenAiScriptRegistry {
+  readonly #scripts = new Map<string, ScriptState>();
+
+  register(script: FakeOpenAiScript): ScriptRegistrationResult {
+    if (script.responses.length === 0) {
+      throw new Error(`Fake provider script ${script.id} must define at least one response.`);
+    }
+
+    this.#scripts.set(script.id, {
+      cursor: 0,
+      requests: [],
+      script,
+    });
+
+    return {
+      scriptId: script.id,
+      model: script.model,
+    };
+  }
+
+  reset(scriptId: string): void {
+    const state = this.#scriptState(scriptId);
+    state.cursor = 0;
+    state.requests = [];
+  }
+
+  requests(scriptId: string): FakeOpenAiRecordedRequest[] {
+    return [...this.#scriptState(scriptId).requests];
+  }
+
+  advance(
+    scriptId: string,
+    request: {body: unknown; method: string; path: string},
+  ): ScriptAdvanceResult {
+    const state = this.#scriptState(scriptId);
+    const requestIndex = state.cursor;
+    const summary = summarizeOpenAiRequest(request.body);
+    const assertionFailures = assertRequest(state.script.assertions ?? [], summary);
+
+    if (assertionFailures.length > 0) {
+      state.requests.push(
+        recordedRequest({
+          assertionFailures,
+          request,
+          requestIndex,
+          servedResponse: null,
+          summary,
+        }),
+      );
+
+      return {
+        status: 422,
+        body: buildOpenAiError(
+          'script_assertion_failed',
+          assertionFailures[0] ?? 'Script assertion failed',
+        ),
+      };
+    }
+
+    const response = state.script.responses[requestIndex];
+    if (!response) {
+      state.requests.push(
+        recordedRequest({
+          assertionFailures,
+          request,
+          requestIndex,
+          servedResponse: 'error:script_exhausted',
+          summary,
+        }),
+      );
+
+      return {
+        status: 409,
+        body: buildOpenAiError('script_exhausted', `Fake provider script exhausted: ${scriptId}`),
+      };
+    }
+
+    state.cursor += 1;
+    const servedResponse = describeResponse(response);
+    state.requests.push(
+      recordedRequest({
+        assertionFailures,
+        request,
+        requestIndex,
+        servedResponse,
+        summary,
+      }),
+    );
+
+    if (response.kind === 'error') {
+      return {
+        status: response.status,
+        body: buildOpenAiError('fake_provider_error', response.message),
+      };
+    }
+
+    return {
+      status: 200,
+      body: buildChatCompletion({
+        model: state.script.model,
+        response,
+        responseIndex: requestIndex,
+        scriptId,
+      }),
+    };
+  }
+
+  #scriptState(scriptId: string): ScriptState {
+    const state = this.#scripts.get(scriptId);
+    if (!state) throw new Error(`Fake provider script not found: ${scriptId}`);
+    return state;
+  }
+}
+
+interface OpenAiRequestSummary {
+  model: string | null;
+  tools: string[];
+  messageRoles: string[];
+}
+
+function summarizeOpenAiRequest(body: unknown): OpenAiRequestSummary {
+  if (!body || typeof body !== 'object') {
+    return {model: null, tools: [], messageRoles: []};
+  }
+
+  const request = body as {
+    messages?: unknown;
+    model?: unknown;
+    tools?: unknown;
+  };
+
+  return {
+    model: typeof request.model === 'string' ? request.model : null,
+    tools: toolNames(request.tools),
+    messageRoles: messageRoles(request.messages),
+  };
+}
+
+function toolNames(tools: unknown): string[] {
+  if (!Array.isArray(tools)) return [];
+
+  return tools.flatMap((tool) => {
+    if (!tool || typeof tool !== 'object') return [];
+    const functionTool = (tool as {function?: unknown}).function;
+    if (!functionTool || typeof functionTool !== 'object') return [];
+    const name = (functionTool as {name?: unknown}).name;
+    return typeof name === 'string' ? [name] : [];
+  });
+}
+
+function messageRoles(messages: unknown): string[] {
+  if (!Array.isArray(messages)) return [];
+
+  return messages.flatMap((message) => {
+    if (!message || typeof message !== 'object') return [];
+    const role = (message as {role?: unknown}).role;
+    return typeof role === 'string' ? [role] : [];
+  });
+}
+
+function assertRequest(
+  assertions: FakeOpenAiRequestAssertion[],
+  summary: OpenAiRequestSummary,
+): string[] {
+  return assertions.flatMap((assertion) => {
+    if (assertion.kind === 'model' && summary.model !== assertion.equals) {
+      return [`Expected model ${assertion.equals} but received ${summary.model ?? '<missing>'}`];
+    }
+
+    if (assertion.kind === 'tool_present' && !summary.tools.includes(assertion.name)) {
+      return [`Expected tool ${assertion.name} to be present`];
+    }
+
+    return [];
+  });
+}
+
+function recordedRequest(params: {
+  assertionFailures: string[];
+  request: {method: string; path: string};
+  requestIndex: number;
+  servedResponse: string | null;
+  summary: OpenAiRequestSummary;
+}): FakeOpenAiRecordedRequest {
+  return {
+    index: params.requestIndex,
+    method: params.request.method,
+    path: params.request.path,
+    model: params.summary.model,
+    tools: params.summary.tools,
+    message_roles: params.summary.messageRoles,
+    served_response: params.servedResponse,
+    assertion_failures: params.assertionFailures,
+    created_at: new Date().toISOString(),
+  };
+}
+
+function describeResponse(response: FakeOpenAiResponse): string {
+  if (response.kind === 'tool_call') return `tool_call:${response.toolName}`;
+  if (response.kind === 'message') return 'message';
+  return `error:${response.status}`;
+}

--- a/e2e/drivers/agent-provider/src/server.test.ts
+++ b/e2e/drivers/agent-provider/src/server.test.ts
@@ -1,0 +1,266 @@
+import {afterEach, beforeEach, describe, expect, it} from '@shipfox/vitest/vi';
+import {
+  createFakeOpenAiProviderServer,
+  type FakeOpenAiProviderServer,
+  type FakeOpenAiScript,
+} from './index.js';
+
+const adminToken = 'test-admin-token';
+
+describe('fake OpenAI provider server', () => {
+  let server: FakeOpenAiProviderServer;
+
+  beforeEach(async () => {
+    server = await createFakeOpenAiProviderServer({adminToken});
+  });
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  it('registers scripts behind the admin token', async () => {
+    const script = fakeScript({id: 'registration'});
+
+    const result = await postScript(server, script);
+
+    expect(result.status).toBe(201);
+    await expect(result.json()).resolves.toEqual({
+      script_id: 'registration',
+      model: 'deterministic-output-agent',
+      provider_base_url: `${server.baseUrl}/scripts/registration/v1`,
+    });
+  });
+
+  it('rejects control requests without the admin token', async () => {
+    const result = await fetch(`${server.baseUrl}/healthz`);
+
+    expect(result.status).toBe(401);
+    await expect(result.json()).resolves.toEqual({
+      error: {
+        message: 'Missing or invalid admin token',
+        type: 'unauthorized',
+      },
+    });
+  });
+
+  it('advances the script cursor and returns OpenAI chat completion payloads', async () => {
+    await postScript(
+      server,
+      fakeScript({
+        id: 'advance',
+        responses: [
+          {
+            kind: 'tool_call',
+            toolName: 'set_output',
+            arguments: {key: 'message', value: 'qwen-tool-output-ok'},
+            content: '',
+          },
+          {kind: 'message', content: 'done'},
+        ],
+      }),
+    );
+
+    const toolCallResult = await chatCompletion(server, 'advance', openAiRequest());
+    const messageResult = await chatCompletion(
+      server,
+      'advance',
+      openAiRequest({roles: ['system', 'user', 'assistant', 'tool']}),
+    );
+
+    expect(toolCallResult.status).toBe(200);
+    await expect(toolCallResult.json()).resolves.toMatchObject({
+      id: 'chatcmpl-fake-advance-0',
+      object: 'chat.completion',
+      created: 1783344000,
+      model: 'deterministic-output-agent',
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: '',
+            tool_calls: [
+              {
+                id: 'call_fake_1',
+                type: 'function',
+                function: {
+                  name: 'set_output',
+                  arguments: '{"key":"message","value":"qwen-tool-output-ok"}',
+                },
+              },
+            ],
+          },
+          finish_reason: 'tool_calls',
+        },
+      ],
+      usage: {
+        prompt_tokens: 1,
+        completion_tokens: 1,
+        total_tokens: 2,
+      },
+    });
+    expect(messageResult.status).toBe(200);
+    await expect(messageResult.json()).resolves.toMatchObject({
+      id: 'chatcmpl-fake-advance-1',
+      choices: [
+        {
+          message: {
+            role: 'assistant',
+            content: 'done',
+          },
+          finish_reason: 'stop',
+        },
+      ],
+    });
+  });
+
+  it('returns a deterministic 409 when a script is exhausted', async () => {
+    await postScript(
+      server,
+      fakeScript({id: 'exhausted', responses: [{kind: 'message', content: 'done'}]}),
+    );
+    await chatCompletion(server, 'exhausted', openAiRequest());
+
+    const result = await chatCompletion(server, 'exhausted', openAiRequest());
+
+    expect(result.status).toBe(409);
+    await expect(result.json()).resolves.toEqual({
+      error: {
+        message: 'Fake provider script exhausted: exhausted',
+        type: 'script_exhausted',
+      },
+    });
+  });
+
+  it('returns a deterministic 422 when request assertions fail', async () => {
+    await postScript(
+      server,
+      fakeScript({
+        id: 'assertions',
+        assertions: [
+          {kind: 'model', equals: 'deterministic-output-agent'},
+          {kind: 'tool_present', name: 'set_output'},
+        ],
+      }),
+    );
+
+    const result = await chatCompletion(server, 'assertions', {
+      model: 'wrong-model',
+      messages: [{role: 'user'}],
+      tools: [],
+    });
+
+    expect(result.status).toBe(422);
+    await expect(result.json()).resolves.toEqual({
+      error: {
+        message: 'Expected model deterministic-output-agent but received wrong-model',
+        type: 'script_assertion_failed',
+      },
+    });
+  });
+
+  it('records request diagnostics and clears them on reset', async () => {
+    await postScript(
+      server,
+      fakeScript({id: 'diagnostics', responses: [{kind: 'message', content: 'done'}]}),
+    );
+    await chatCompletion(server, 'diagnostics', openAiRequest({roles: ['system', 'user']}));
+    await chatCompletion(
+      server,
+      'diagnostics',
+      openAiRequest({roles: ['system', 'user', 'assistant', 'tool']}),
+    );
+
+    const requestsResult = await fetch(`${server.baseUrl}/scripts/diagnostics/requests`, {
+      headers: adminHeaders(),
+    });
+
+    expect(requestsResult.status).toBe(200);
+    await expect(requestsResult.json()).resolves.toMatchObject({
+      script_id: 'diagnostics',
+      requests: [
+        {
+          index: 0,
+          method: 'POST',
+          path: '/scripts/diagnostics/v1/chat/completions',
+          model: 'deterministic-output-agent',
+          tools: ['set_output'],
+          message_roles: ['system', 'user'],
+          served_response: 'message',
+          assertion_failures: [],
+        },
+        {
+          index: 1,
+          served_response: 'error:script_exhausted',
+        },
+      ],
+    });
+
+    const resetResult = await fetch(`${server.baseUrl}/scripts/diagnostics/reset`, {
+      method: 'POST',
+      headers: adminHeaders(),
+    });
+    const clearedResult = await fetch(`${server.baseUrl}/scripts/diagnostics/requests`, {
+      headers: adminHeaders(),
+    });
+
+    expect(resetResult.status).toBe(204);
+    await expect(clearedResult.json()).resolves.toEqual({
+      script_id: 'diagnostics',
+      requests: [],
+    });
+  });
+});
+
+function fakeScript(params: Partial<FakeOpenAiScript>): FakeOpenAiScript {
+  return {
+    id: params.id ?? 'script',
+    model: params.model ?? 'deterministic-output-agent',
+    responses: params.responses ?? [{kind: 'message', content: 'done'}],
+    assertions: params.assertions,
+  };
+}
+
+async function postScript(
+  server: FakeOpenAiProviderServer,
+  script: FakeOpenAiScript,
+): Promise<Response> {
+  return await fetch(`${server.baseUrl}/scripts`, {
+    method: 'POST',
+    headers: adminHeaders(),
+    body: JSON.stringify(script),
+  });
+}
+
+async function chatCompletion(
+  server: FakeOpenAiProviderServer,
+  scriptId: string,
+  body: unknown,
+): Promise<Response> {
+  return await fetch(`${server.baseUrl}/scripts/${scriptId}/v1/chat/completions`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+function adminHeaders(): Record<string, string> {
+  return {
+    authorization: `Bearer ${adminToken}`,
+    'content-type': 'application/json',
+  };
+}
+
+function openAiRequest(params: {roles?: string[] | undefined} = {}) {
+  return {
+    model: 'deterministic-output-agent',
+    messages: (params.roles ?? ['system', 'user']).map((role) => ({role})),
+    tools: [
+      {
+        type: 'function',
+        function: {
+          name: 'set_output',
+        },
+      },
+    ],
+  };
+}

--- a/e2e/drivers/agent-provider/src/server.test.ts
+++ b/e2e/drivers/agent-provider/src/server.test.ts
@@ -43,6 +43,30 @@ describe('fake OpenAI provider server', () => {
     });
   });
 
+  it.each([
+    [
+      'missing id',
+      {model: 'deterministic-output-agent', responses: [{kind: 'message', content: 'done'}]},
+      'Script id must be a non-empty string.',
+    ],
+    [
+      'missing model',
+      {id: 'invalid-script', responses: [{kind: 'message', content: 'done'}]},
+      'Script model must be a non-empty string.',
+    ],
+    ['empty body', undefined, 'Request body is required.'],
+  ])('rejects script registration with %s', async (_caseName, body, message) => {
+    const result = await postRawScript(server, body);
+
+    expect(result.status).toBe(400);
+    await expect(result.json()).resolves.toEqual({
+      error: {
+        message,
+        type: 'bad_request',
+      },
+    });
+  });
+
   it('advances the script cursor and returns OpenAI chat completion payloads', async () => {
     await postScript(
       server,
@@ -225,11 +249,20 @@ async function postScript(
   server: FakeOpenAiProviderServer,
   script: FakeOpenAiScript,
 ): Promise<Response> {
-  return await fetch(`${server.baseUrl}/scripts`, {
+  return await postRawScript(server, script);
+}
+
+async function postRawScript(
+  server: FakeOpenAiProviderServer,
+  body: unknown | undefined,
+): Promise<Response> {
+  const request = {
     method: 'POST',
     headers: adminHeaders(),
-    body: JSON.stringify(script),
-  });
+    ...(body === undefined ? {} : {body: JSON.stringify(body)}),
+  };
+
+  return await fetch(`${server.baseUrl}/scripts`, request);
 }
 
 async function chatCompletion(

--- a/e2e/drivers/agent-provider/src/server.ts
+++ b/e2e/drivers/agent-provider/src/server.ts
@@ -73,6 +73,7 @@ async function routeRequest(params: {
       }
 
       const script = await readJson<FakeOpenAiScript>(params.request);
+      validateScriptRegistration(script);
       const result = params.registry.register(script);
       writeJson(params.response, 201, {
         script_id: result.scriptId,
@@ -147,6 +148,17 @@ function writeUnauthorized(response: ServerResponse): void {
   writeJson(response, 401, buildOpenAiError('unauthorized', 'Missing or invalid admin token'));
 }
 
+function validateScriptRegistration(script: FakeOpenAiScript): void {
+  if (!script || typeof script !== 'object') throw new Error('Script body must be an object.');
+  if (!isNonEmptyString(script.id)) throw new Error('Script id must be a non-empty string.');
+  if (!isNonEmptyString(script.model)) throw new Error('Script model must be a non-empty string.');
+  if (!Array.isArray(script.responses)) throw new Error('Script responses must be an array.');
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
 async function readJson<T = unknown>(request: IncomingMessage): Promise<T> {
   const chunks: Buffer[] = [];
   let totalBytes = 0;
@@ -158,7 +170,7 @@ async function readJson<T = unknown>(request: IncomingMessage): Promise<T> {
     chunks.push(buffer);
   }
 
-  if (chunks.length === 0) return undefined as T;
+  if (chunks.length === 0) throw new Error('Request body is required.');
   return JSON.parse(Buffer.concat(chunks).toString('utf8')) as T;
 }
 

--- a/e2e/drivers/agent-provider/src/server.ts
+++ b/e2e/drivers/agent-provider/src/server.ts
@@ -1,0 +1,193 @@
+import {createServer, type IncomingMessage, type Server, type ServerResponse} from 'node:http';
+import type {AddressInfo} from 'node:net';
+import {buildOpenAiError} from './openai.js';
+import {type FakeOpenAiScript, FakeOpenAiScriptRegistry} from './scripts.js';
+
+export interface FakeOpenAiProviderServer {
+  adminToken: string;
+  baseUrl: string;
+  registry: FakeOpenAiScriptRegistry;
+  stop(): Promise<void>;
+}
+
+export interface CreateFakeOpenAiProviderServerParams {
+  adminToken?: string | undefined;
+  registry?: FakeOpenAiScriptRegistry | undefined;
+}
+
+const host = '127.0.0.1';
+const maxBodyBytes = 1024 * 1024;
+const resetPathRe = /^\/scripts\/([^/]+)\/reset$/u;
+const requestsPathRe = /^\/scripts\/([^/]+)\/requests$/u;
+const completionsPathRe = /^\/scripts\/([^/]+)\/v1\/chat\/completions$/u;
+
+export async function createFakeOpenAiProviderServer(
+  params: CreateFakeOpenAiProviderServerParams = {},
+): Promise<FakeOpenAiProviderServer> {
+  const adminToken = params.adminToken ?? crypto.randomUUID();
+  const registry = params.registry ?? new FakeOpenAiScriptRegistry();
+  const server = createServer((request, response) => {
+    void routeRequest({adminToken, registry, request, response});
+  });
+
+  await listen(server);
+  const address = server.address();
+  if (!address || typeof address === 'string')
+    throw new Error('Fake provider did not bind a TCP port.');
+
+  return {
+    adminToken,
+    baseUrl: `http://${host}:${address.port}`,
+    registry,
+    stop: async () => {
+      await close(server);
+    },
+  };
+}
+
+async function routeRequest(params: {
+  adminToken: string;
+  registry: FakeOpenAiScriptRegistry;
+  request: IncomingMessage;
+  response: ServerResponse;
+}): Promise<void> {
+  try {
+    const url = requestUrl(params.request);
+    const pathname = url.pathname;
+    const method = params.request.method ?? 'GET';
+
+    if (pathname === '/healthz' && method === 'GET') {
+      if (!isAuthorized(params.request, params.adminToken)) {
+        writeUnauthorized(params.response);
+        return;
+      }
+
+      writeJson(params.response, 200, {ok: true});
+      return;
+    }
+
+    if (pathname === '/scripts' && method === 'POST') {
+      if (!isAuthorized(params.request, params.adminToken)) {
+        writeUnauthorized(params.response);
+        return;
+      }
+
+      const script = await readJson<FakeOpenAiScript>(params.request);
+      const result = params.registry.register(script);
+      writeJson(params.response, 201, {
+        script_id: result.scriptId,
+        model: result.model,
+        provider_base_url: `${origin(url)}/scripts/${result.scriptId}/v1`,
+      });
+      return;
+    }
+
+    const resetMatch = resetPathRe.exec(pathname);
+    if (resetMatch && method === 'POST') {
+      if (!isAuthorized(params.request, params.adminToken)) {
+        writeUnauthorized(params.response);
+        return;
+      }
+
+      params.registry.reset(decodeURIComponent(resetMatch[1] ?? ''));
+      params.response.statusCode = 204;
+      params.response.end();
+      return;
+    }
+
+    const requestsMatch = requestsPathRe.exec(pathname);
+    if (requestsMatch && method === 'GET') {
+      if (!isAuthorized(params.request, params.adminToken)) {
+        writeUnauthorized(params.response);
+        return;
+      }
+
+      const scriptId = decodeURIComponent(requestsMatch[1] ?? '');
+      writeJson(params.response, 200, {
+        script_id: scriptId,
+        requests: params.registry.requests(scriptId),
+      });
+      return;
+    }
+
+    const completionsMatch = completionsPathRe.exec(pathname);
+    if (completionsMatch && method === 'POST') {
+      const scriptId = decodeURIComponent(completionsMatch[1] ?? '');
+      const body = await readJson(params.request);
+      const result = params.registry.advance(scriptId, {body, method, path: pathname});
+      writeJson(params.response, result.status, result.body);
+      return;
+    }
+
+    writeJson(
+      params.response,
+      404,
+      buildOpenAiError('not_found', `Route not found: ${method} ${pathname}`),
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Fake provider request failed.';
+    writeJson(params.response, 400, buildOpenAiError('bad_request', message));
+  }
+}
+
+function requestUrl(request: IncomingMessage): URL {
+  const hostHeader = request.headers.host ?? `${host}:0`;
+  return new URL(request.url ?? '/', `http://${hostHeader}`);
+}
+
+function origin(url: URL): string {
+  return `${url.protocol}//${url.host}`;
+}
+
+function isAuthorized(request: IncomingMessage, adminToken: string): boolean {
+  return request.headers.authorization === `Bearer ${adminToken}`;
+}
+
+function writeUnauthorized(response: ServerResponse): void {
+  writeJson(response, 401, buildOpenAiError('unauthorized', 'Missing or invalid admin token'));
+}
+
+async function readJson<T = unknown>(request: IncomingMessage): Promise<T> {
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+
+  for await (const chunk of request) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    totalBytes += buffer.byteLength;
+    if (totalBytes > maxBodyBytes) throw new Error('Request body is too large.');
+    chunks.push(buffer);
+  }
+
+  if (chunks.length === 0) return undefined as T;
+  return JSON.parse(Buffer.concat(chunks).toString('utf8')) as T;
+}
+
+function writeJson(response: ServerResponse, status: number, body: unknown): void {
+  response.statusCode = status;
+  response.setHeader('content-type', 'application/json');
+  response.end(JSON.stringify(body));
+}
+
+async function listen(server: Server): Promise<AddressInfo> {
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, host, () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  if (!address || typeof address === 'string')
+    throw new Error('Fake provider did not bind a TCP port.');
+  return address;
+}
+
+async function close(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}

--- a/e2e/drivers/agent-provider/tsconfig.build.json
+++ b/e2e/drivers/agent-provider/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/e2e/drivers/agent-provider/tsconfig.json
+++ b/e2e/drivers/agent-provider/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "tsconfig.build.json" }]
+}

--- a/e2e/drivers/agent-provider/tsconfig.test.json
+++ b/e2e/drivers/agent-provider/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "exclude": []
+}

--- a/e2e/drivers/agent-provider/vitest.config.ts
+++ b/e2e/drivers/agent-provider/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({}, import.meta.url) as UserConfigExport;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,6 +260,27 @@ importers:
         specifier: workspace:*
         version: link:../../tools/vitest
 
+  e2e/drivers/agent-provider:
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/depcruise':
+        specifier: workspace:*
+        version: link:../../../tools/depcruise
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../tools/vitest
+
   e2e/drivers/gitea:
     dependencies:
       '@shipfox/api-integration-gitea-dto':


### PR DESCRIPTION
Adds the new private `@shipfox/e2e-driver-agent-provider` package with an in-process localhost fake OpenAI-compatible chat completions server, script registry, deterministic response builders, request assertions, and diagnostics.

Flow E2E tests need to prove agent output plumbing without depending on a small local model choosing the right tool call in CI. This driver lets suites script tool-call and final-message responses while still registering the provider through normal product custom-provider routes in follow-up work.

The sidecar process lifecycle and public `startFakeOpenAiProvider()` handle are intentionally left to ENG-855; this PR only lands the server and script engine needed by that wrapper.

Closes ENG-852

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds private `@shipfox/e2e-driver-agent-provider`: an in-process, deterministic OpenAI-compatible chat completions server for E2E tests. Lets suites script tool-calls and final messages to verify agent plumbing in CI, and now validates script registration inputs (ENG-852).

- **New Features**
  - Deterministic script engine with ordered responses and request assertions.
  - OpenAI-compatible endpoint: `POST /scripts/:scriptId/v1/chat/completions`.
  - Control endpoints (admin token required): `GET /healthz`, `POST /scripts`, `POST /scripts/:id/reset`, `GET /scripts/:id/requests`.
  - Clear failure modes: `400 bad_request` for invalid registrations, `409 script_exhausted`, `422 script_assertion_failed`; records request diagnostics.
  - Simple server factory: `createFakeOpenAiProviderServer()` with exported builders and types.

<sup>Written for commit 63ef6187bfa307b7ef434f2b1f52976b8c016fc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

