### PR TITLE
[runner] Add Claude Ollama override

### DIFF
--- a/e2e/drivers/runner-process/src/local-runner-process.ts
+++ b/e2e/drivers/runner-process/src/local-runner-process.ts
@@ -21,6 +21,8 @@ export interface StartLocalRunnerParams {
   pollIntervalMs?: number | undefined;
   pollMaxIntervalMs?: number | undefined;
   pollMaxDurationMs?: number | undefined;
+  /** Extra environment variables for one runner process. */
+  extraEnv?: Record<string, string> | undefined;
   /** Overrides the resolved `@shipfox/runner` source entry (run via tsx). */
   entryPath?: string | undefined;
 }
@@ -77,6 +79,7 @@ function buildRunnerEnv(params: StartLocalRunnerParams): Record<string, string> 
     ...(params.workspaceRoot !== undefined
       ? {SHIPFOX_RUNNER_WORKSPACE_ROOT: params.workspaceRoot}
       : {}),
+    ...(params.extraEnv ?? {}),
   };
 }
 

--- a/e2e/setup/agent/src/index.test.ts
+++ b/e2e/setup/agent/src/index.test.ts
@@ -11,7 +11,7 @@ describe('agent e2e helper', () => {
     createApiClient.mockReset();
     requestJson.mockReset();
     createApiClient.mockReturnValue({requestJson});
-    vi.doMock('@shipfox/e2e-core', () => ({createApiClient}));
+    vi.doMock('@shipfox/e2e-core', () => ({createApiClient, requestJson}));
   });
 
   afterEach(() => {
@@ -179,5 +179,25 @@ describe('agent e2e helper', () => {
       'get',
       `/workspaces/${workspaceId}/agent/model-providers`,
     );
+  });
+
+  it('creates an Anthropic model provider config through the E2E route', async () => {
+    const {createAnthropicModelProviderConfig} = await import('./index.js');
+
+    await createAnthropicModelProviderConfig({
+      workspaceId,
+      defaultModel: 'claude-opus-4-8',
+      setAsDefault: true,
+    });
+
+    expect(requestJson).toHaveBeenCalledWith('post', '/__e2e/agent/model-provider', {
+      json: {
+        workspace_id: workspaceId,
+        provider_id: 'anthropic',
+        api_key: 'sk-e2e-anthropic-placeholder',
+        default_model: 'claude-opus-4-8',
+        set_as_default: true,
+      },
+    });
   });
 });

--- a/e2e/setup/agent/src/index.ts
+++ b/e2e/setup/agent/src/index.ts
@@ -6,7 +6,7 @@ import type {
   ModelProviderApi,
   ModelProviderRef,
 } from '@shipfox/api-agent-dto';
-import {createApiClient} from '@shipfox/e2e-core';
+import {createApiClient, requestJson} from '@shipfox/e2e-core';
 
 const DEFAULT_OLLAMA_BASE_URL = 'http://127.0.0.1:11434';
 const DEFAULT_OLLAMA_MODEL = 'smollm2:135m-instruct-q2_K';
@@ -50,6 +50,13 @@ export type OpenAiCompatibleCustomProviderModelMetadata = Omit<CustomAgentModelD
 export interface ListModelProviderConfigsParams {
   workspaceId: string;
   sessionToken: string;
+}
+
+export interface CreateAnthropicModelProviderConfigParams {
+  workspaceId: string;
+  apiKey?: string | undefined;
+  defaultModel?: string | undefined;
+  setAsDefault?: boolean | undefined;
 }
 
 export function ollamaConfig(env: NodeJS.ProcessEnv = process.env): OllamaConfig {
@@ -140,8 +147,23 @@ export async function listModelProviderConfigs(
   );
 }
 
+export async function createAnthropicModelProviderConfig(
+  params: CreateAnthropicModelProviderConfigParams,
+): Promise<void> {
+  await requestJson('post', '/__e2e/agent/model-provider', {
+    json: {
+      workspace_id: params.workspaceId,
+      provider_id: 'anthropic',
+      api_key: params.apiKey ?? 'sk-e2e-anthropic-placeholder',
+      ...(params.defaultModel !== undefined ? {default_model: params.defaultModel} : {}),
+      ...(params.setAsDefault !== undefined ? {set_as_default: params.setAsDefault} : {}),
+    },
+  });
+}
+
 export function createAgentHelper() {
   return {
+    createAnthropicModelProviderConfig,
     createOpenAiCompatibleCustomProvider,
     createOllamaCustomProvider,
     listModelProviderConfigs,

--- a/e2e/suites/flow/workflows/package.json
+++ b/e2e/suites/flow/workflows/package.json
@@ -48,6 +48,7 @@
     "@shipfox/e2e-observe-definitions": "workspace:*",
     "@shipfox/e2e-observe-logs": "workspace:*",
     "@shipfox/e2e-observe-workflows": "workspace:*",
+    "@shipfox/e2e-setup-agent": "workspace:*",
     "@shipfox/e2e-setup-auth": "workspace:*",
     "@shipfox/e2e-setup-secrets": "workspace:*",
     "@shipfox/e2e-setup-workspaces": "workspace:*",

--- a/e2e/suites/flow/workflows/src/runner.ts
+++ b/e2e/suites/flow/workflows/src/runner.ts
@@ -20,6 +20,7 @@ export async function startSuiteLocalRunner(params: {
   userToken: string;
   name: string;
   runnerLabel: string;
+  extraEnv?: Record<string, string> | undefined;
 }): Promise<{runner: LocalRunnerHandle; logFile: string}> {
   const registrationToken = await mintManualRegistrationToken({
     workspaceId: params.workspaceId,
@@ -38,6 +39,7 @@ export async function startSuiteLocalRunner(params: {
       labels: [params.runnerLabel],
       logFile,
       workspaceRoot: join(runDir, 'runner-workspaces', params.runnerLabel),
+      extraEnv: params.extraEnv,
     }),
     logFile,
   };

--- a/e2e/suites/flow/workflows/tests/claude-ollama-agent.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/claude-ollama-agent.e2e.ts
@@ -78,7 +78,7 @@ test('runs a Claude harness step against local Ollama', async ({suite}, testInfo
     const terminal = await waitForRunTerminalOrFailedRunner({
       runId,
       token,
-      timeoutMs: 180_000,
+      timeoutMs: 300_000,
       runner: localRunner.runner,
     });
 

--- a/e2e/suites/flow/workflows/tests/claude-ollama-agent.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/claude-ollama-agent.e2e.ts
@@ -1,0 +1,100 @@
+import {createApiClient} from '@shipfox/e2e-core';
+import {stopLocalRunner} from '@shipfox/e2e-driver-runner-process';
+import {
+  createAnthropicModelProviderConfig,
+  type ollamaConfig,
+  requireOllamaModel,
+} from '@shipfox/e2e-setup-agent';
+import {attachLocalRunnerLog} from '#attachments.js';
+import {startSuiteLocalRunner, waitForRunTerminalOrFailedRunner} from '#runner.js';
+import {fireManualAndAwaitRun} from '#triggers.js';
+import {seedAndWaitForDefinition} from '#workflow-project.js';
+import {expect, test} from './fixtures.js';
+
+const WORKFLOW_YAML = `
+name: Claude Ollama agent
+runner: __RUNNER_LABEL__
+triggers:
+  manual:
+    source: manual
+    event: fire
+jobs:
+  fix:
+    steps:
+      - key: reply
+        harness: claude
+        thinking: low
+        prompt: 'Reply with exactly: ok'
+`;
+
+test('runs a Claude harness step against local Ollama', async ({suite}, testInfo) => {
+  let ollama: ReturnType<typeof ollamaConfig>;
+  try {
+    ollama = await requireOllamaModel();
+  } catch (error) {
+    test.skip(true, error instanceof Error ? error.message : String(error));
+    return;
+  }
+
+  const token = suite.sessionToken;
+  const client = createApiClient({token});
+  const uniqueId = crypto.randomUUID().replaceAll('-', '').slice(0, 10);
+  const runnerLabel = `e2e-claude-ollama-${uniqueId}`;
+  const repo = `claude-ollama-${uniqueId}`;
+  await createAnthropicModelProviderConfig({
+    workspaceId: suite.workspaceId,
+    defaultModel: 'claude-opus-4-8',
+    setAsDefault: true,
+  });
+  const localRunner = await startSuiteLocalRunner({
+    workspaceId: suite.workspaceId,
+    userToken: token,
+    name: `E2E Claude Ollama ${uniqueId}`,
+    runnerLabel,
+    extraEnv: {
+      AGENT_CLAUDE_ANTHROPIC_BASE_URL: ollama.baseUrl,
+      AGENT_CLAUDE_ANTHROPIC_MODEL: ollama.model,
+      AGENT_CLAUDE_ANTHROPIC_SMALL_FAST_MODEL: ollama.model,
+    },
+  });
+
+  try {
+    const {definition} = await seedAndWaitForDefinition({
+      suite,
+      token,
+      name: 'claude-ollama-agent',
+      repo,
+      runnerLabel,
+      workflowYaml: WORKFLOW_YAML,
+      configPath: '.shipfox/workflows/claude-ollama-agent.yml',
+    });
+
+    const runId = await fireManualAndAwaitRun({
+      client,
+      definitionId: definition.id,
+      inputs: {},
+      scenario: 'claude-ollama-agent',
+    });
+    const terminal = await waitForRunTerminalOrFailedRunner({
+      runId,
+      token,
+      timeoutMs: 180_000,
+      runner: localRunner.runner,
+    });
+
+    expect(terminal.status).toBe('succeeded');
+    expect(terminal.jobs.find((job) => job.key === 'fix')?.status).toBe('succeeded');
+  } finally {
+    await attachLocalRunnerLog(
+      (attachment) =>
+        testInfo.attach(attachment.name, {
+          body: attachment.body,
+          contentType: attachment.contentType,
+        }),
+      localRunner.logFile,
+    );
+    await stopLocalRunner(localRunner.runner).catch((error: unknown) => {
+      process.stderr.write(`claude-ollama-agent-e2e: stopLocalRunner failed: ${String(error)}\n`);
+    });
+  }
+});

--- a/libs/api/agent/src/index.ts
+++ b/libs/api/agent/src/index.ts
@@ -1,5 +1,6 @@
 import type {ShipfoxModule} from '@shipfox/node-module';
 import {db, migrationsPath} from '#db/index.js';
+import {agentE2eRoutes} from '#presentation/e2eRoutes/index.js';
 import {routes} from '#presentation/index.js';
 
 export {
@@ -38,4 +39,5 @@ export const agentModule: ShipfoxModule = {
   name: 'agent',
   database: {db, migrationsPath},
   routes,
+  e2eRoutes: [agentE2eRoutes],
 };

--- a/libs/api/agent/src/presentation/e2eRoutes/create-model-provider.test.ts
+++ b/libs/api/agent/src/presentation/e2eRoutes/create-model-provider.test.ts
@@ -1,0 +1,47 @@
+import {closeApp, createApp} from '@shipfox/node-fastify';
+import {agentE2eRoutes} from './index.js';
+
+describe('agent e2e routes', () => {
+  afterEach(async () => {
+    await closeApp();
+  });
+
+  it('rejects malformed workspace ids through route validation', async () => {
+    const app = await createApp({routes: [agentE2eRoutes], swagger: false});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/agent/model-provider',
+      payload: {
+        workspace_id: 'not-a-uuid',
+        provider_id: 'anthropic',
+        api_key: 'sk-e2e-placeholder',
+        default_model: 'claude-opus-4-8',
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toMatchObject({code: 'validation-error'});
+  });
+
+  it('rejects default models outside the Anthropic catalog', async () => {
+    const app = await createApp({routes: [agentE2eRoutes], swagger: false});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/agent/model-provider',
+      payload: {
+        workspace_id: crypto.randomUUID(),
+        provider_id: 'anthropic',
+        api_key: 'sk-e2e-placeholder',
+        default_model: 'missing-model',
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toMatchObject({
+      code: 'unsupported-model',
+      details: {default_model: 'missing-model'},
+    });
+  });
+});

--- a/libs/api/agent/src/presentation/e2eRoutes/create-model-provider.ts
+++ b/libs/api/agent/src/presentation/e2eRoutes/create-model-provider.ts
@@ -1,0 +1,52 @@
+import {DEFAULT_AGENT_THINKING, getModelProviderEntry} from '@shipfox/api-agent-dto';
+import {setSecrets} from '@shipfox/api-secrets';
+import {ClientError, defineRoute} from '@shipfox/node-fastify';
+import {z} from 'zod';
+import {agentSystemNamespace} from '#core/credential-fingerprints.js';
+import {upsertModelProviderConfig} from '#db/index.js';
+
+const createE2eModelProviderBodySchema = z.object({
+  workspace_id: z.string().min(1),
+  provider_id: z.literal('anthropic'),
+  api_key: z.string().min(1),
+  default_model: z.string().min(1).optional(),
+  set_as_default: z.boolean().optional(),
+});
+
+const createE2eModelProviderResponseSchema = z.object({
+  provider_id: z.literal('anthropic'),
+});
+
+export const createE2eModelProviderRoute = defineRoute({
+  method: 'POST',
+  path: '/model-provider',
+  description: 'Create an Anthropic model provider config for E2E tests.',
+  schema: {
+    body: createE2eModelProviderBodySchema,
+    response: {201: createE2eModelProviderResponseSchema},
+  },
+  handler: async (request, reply) => {
+    const entry = getModelProviderEntry(request.body.provider_id);
+    if (entry === undefined || entry.default_model === null) {
+      throw new ClientError('Unsupported E2E model provider', 'unsupported-model-provider', {
+        status: 400,
+      });
+    }
+
+    await setSecrets({
+      workspaceId: request.body.workspace_id,
+      namespace: agentSystemNamespace(request.body.provider_id),
+      values: {API_KEY: request.body.api_key},
+    });
+    await upsertModelProviderConfig({
+      workspaceId: request.body.workspace_id,
+      providerId: request.body.provider_id,
+      defaultModel: request.body.default_model ?? entry.default_model,
+      defaultThinking: DEFAULT_AGENT_THINKING,
+      setAsDefault: request.body.set_as_default,
+    });
+
+    reply.code(201);
+    return {provider_id: request.body.provider_id};
+  },
+});

--- a/libs/api/agent/src/presentation/e2eRoutes/create-model-provider.ts
+++ b/libs/api/agent/src/presentation/e2eRoutes/create-model-provider.ts
@@ -3,10 +3,11 @@ import {setSecrets} from '@shipfox/api-secrets';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
 import {agentSystemNamespace} from '#core/credential-fingerprints.js';
+import {listHarnessProviderModels} from '#core/harness/registry.js';
 import {upsertModelProviderConfig} from '#db/index.js';
 
 const createE2eModelProviderBodySchema = z.object({
-  workspace_id: z.string().min(1),
+  workspace_id: z.string().uuid(),
   provider_id: z.literal('anthropic'),
   api_key: z.string().min(1),
   default_model: z.string().min(1).optional(),
@@ -32,6 +33,14 @@ export const createE2eModelProviderRoute = defineRoute({
         status: 400,
       });
     }
+    const defaultModel = request.body.default_model ?? entry.default_model;
+    const supportedModels = listHarnessProviderModels('claude', request.body.provider_id);
+    if (!supportedModels.some((model) => model.id === defaultModel)) {
+      throw new ClientError('Unsupported Anthropic default model', 'unsupported-model', {
+        status: 400,
+        details: {default_model: defaultModel},
+      });
+    }
 
     await setSecrets({
       workspaceId: request.body.workspace_id,
@@ -41,7 +50,7 @@ export const createE2eModelProviderRoute = defineRoute({
     await upsertModelProviderConfig({
       workspaceId: request.body.workspace_id,
       providerId: request.body.provider_id,
-      defaultModel: request.body.default_model ?? entry.default_model,
+      defaultModel,
       defaultThinking: DEFAULT_AGENT_THINKING,
       setAsDefault: request.body.set_as_default,
     });

--- a/libs/api/agent/src/presentation/e2eRoutes/index.ts
+++ b/libs/api/agent/src/presentation/e2eRoutes/index.ts
@@ -1,0 +1,7 @@
+import type {RouteGroup} from '@shipfox/node-fastify';
+import {createE2eModelProviderRoute} from './create-model-provider.js';
+
+export const agentE2eRoutes: RouteGroup = {
+  prefix: '/agent',
+  routes: [createE2eModelProviderRoute],
+};

--- a/libs/runner/agent/src/config.ts
+++ b/libs/runner/agent/src/config.ts
@@ -2,6 +2,18 @@ import {bool, createConfig, str} from '@shipfox/config';
 import {type EgressPolicy, parseEgressHostDenylist} from '@shipfox/node-egress-guard';
 
 export const config = createConfig({
+  AGENT_CLAUDE_ANTHROPIC_BASE_URL: str({
+    desc: 'Optional Anthropic-compatible base URL for the claude harness. Leave empty to use the Anthropic API. Set this for automated tests or private runner operations, such as a local Ollama server at http://127.0.0.1:11434.',
+    default: '',
+  }),
+  AGENT_CLAUDE_ANTHROPIC_MODEL: str({
+    desc: 'Model ID the claude harness sends when AGENT_CLAUDE_ANTHROPIC_BASE_URL is set. Leave empty to use the model resolved by the API.',
+    default: '',
+  }),
+  AGENT_CLAUDE_ANTHROPIC_SMALL_FAST_MODEL: str({
+    desc: 'Small fast model ID the claude harness sends when AGENT_CLAUDE_ANTHROPIC_BASE_URL is set. Leave empty to use the Claude SDK default.',
+    default: '',
+  }),
   AGENT_CUSTOM_PROVIDER_ALLOW_PRIVATE_NETWORKS: bool({
     desc: 'Allows custom model providers to use private, loopback, link-local, metadata, and .internal network targets. Keep this true for local development and self-hosted private networks. Set it to false on cloud instances.',
     default: true,

--- a/libs/runner/agent/src/config.ts
+++ b/libs/runner/agent/src/config.ts
@@ -3,16 +3,16 @@ import {type EgressPolicy, parseEgressHostDenylist} from '@shipfox/node-egress-g
 
 export const config = createConfig({
   AGENT_CLAUDE_ANTHROPIC_BASE_URL: str({
-    desc: 'Optional Anthropic-compatible base URL for the claude harness. Leave empty to use the Anthropic API. Set this for automated tests or private runner operations, such as a local Ollama server at http://127.0.0.1:11434.',
-    default: '',
+    desc: 'Optional Anthropic-compatible base URL for the claude harness. Unset to use the Anthropic API. Set this for automated tests or private runner operations, such as a local Ollama server at http://127.0.0.1:11434.',
+    default: undefined,
   }),
   AGENT_CLAUDE_ANTHROPIC_MODEL: str({
-    desc: 'Model ID the claude harness sends when AGENT_CLAUDE_ANTHROPIC_BASE_URL is set. Leave empty to use the model resolved by the API.',
-    default: '',
+    desc: 'Model ID the claude harness sends when AGENT_CLAUDE_ANTHROPIC_BASE_URL is set. Unset to use the model resolved by the API.',
+    default: undefined,
   }),
   AGENT_CLAUDE_ANTHROPIC_SMALL_FAST_MODEL: str({
-    desc: 'Small fast model ID the claude harness sends when AGENT_CLAUDE_ANTHROPIC_BASE_URL is set. Leave empty to use the Claude SDK default.',
-    default: '',
+    desc: 'Small fast model ID the claude harness sends when AGENT_CLAUDE_ANTHROPIC_BASE_URL is set. Unset to use the Claude SDK default.',
+    default: undefined,
   }),
   AGENT_CUSTOM_PROVIDER_ALLOW_PRIVATE_NETWORKS: bool({
     desc: 'Allows custom model providers to use private, loopback, link-local, metadata, and .internal network targets. Keep this true for local development and self-hosted private networks. Set it to false on cloud instances.',

--- a/libs/runner/agent/src/core/claude-adapter.test.ts
+++ b/libs/runner/agent/src/core/claude-adapter.test.ts
@@ -24,9 +24,9 @@ const {assertEgressAllowedMock, EgressDeniedErrorMock} = vi.hoisted(() => {
 });
 const {configMock} = vi.hoisted(() => ({
   configMock: {
-    AGENT_CLAUDE_ANTHROPIC_BASE_URL: '',
-    AGENT_CLAUDE_ANTHROPIC_MODEL: '',
-    AGENT_CLAUDE_ANTHROPIC_SMALL_FAST_MODEL: '',
+    AGENT_CLAUDE_ANTHROPIC_BASE_URL: undefined as string | undefined,
+    AGENT_CLAUDE_ANTHROPIC_MODEL: undefined as string | undefined,
+    AGENT_CLAUDE_ANTHROPIC_SMALL_FAST_MODEL: undefined as string | undefined,
   },
 }));
 
@@ -151,9 +151,9 @@ describe('claudeHarnessAdapter', () => {
     createSdkMcpServerMock.mockClear();
     assertEgressAllowedMock.mockReset();
     assertEgressAllowedMock.mockResolvedValue(undefined);
-    configMock.AGENT_CLAUDE_ANTHROPIC_BASE_URL = '';
-    configMock.AGENT_CLAUDE_ANTHROPIC_MODEL = '';
-    configMock.AGENT_CLAUDE_ANTHROPIC_SMALL_FAST_MODEL = '';
+    configMock.AGENT_CLAUDE_ANTHROPIC_BASE_URL = undefined;
+    configMock.AGENT_CLAUDE_ANTHROPIC_MODEL = undefined;
+    configMock.AGENT_CLAUDE_ANTHROPIC_SMALL_FAST_MODEL = undefined;
   });
 
   afterEach(() => {
@@ -291,6 +291,23 @@ describe('claudeHarnessAdapter', () => {
       }),
     });
     expect(lastQueryOptions().mcpServers).toBeUndefined();
+  });
+
+  it('rejects declared outputs when the Anthropic base URL override is active', async () => {
+    configMock.AGENT_CLAUDE_ANTHROPIC_BASE_URL = 'http://127.0.0.1:11434';
+
+    const result = claudeHarnessAdapter.run(
+      invocation({credentials: {}, outputs: {summary: {type: 'string'}}}),
+    );
+
+    await expect(result).rejects.toThrow(
+      new AgentConfigError(
+        'Claude Anthropic base URL override does not support declared step outputs.',
+        'provider_unsupported',
+      ),
+    );
+    expect(assertEgressAllowedMock).not.toHaveBeenCalled();
+    expect(queryMock).not.toHaveBeenCalled();
   });
 
   it('maps Anthropic override egress denial to AgentConfigError', async () => {

--- a/libs/runner/agent/src/core/claude-adapter.test.ts
+++ b/libs/runner/agent/src/core/claude-adapter.test.ts
@@ -22,11 +22,22 @@ const {assertEgressAllowedMock, EgressDeniedErrorMock} = vi.hoisted(() => {
 
   return {assertEgressAllowedMock: vi.fn(), EgressDeniedErrorMock: EgressDeniedError};
 });
+const {configMock} = vi.hoisted(() => ({
+  configMock: {
+    AGENT_CLAUDE_ANTHROPIC_BASE_URL: '',
+    AGENT_CLAUDE_ANTHROPIC_MODEL: '',
+    AGENT_CLAUDE_ANTHROPIC_SMALL_FAST_MODEL: '',
+  },
+}));
 
 vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
   createSdkMcpServer: createSdkMcpServerMock,
   query: queryMock,
   tool: toolMock,
+}));
+vi.mock('#config.js', () => ({
+  config: configMock,
+  runnerEgressPolicy: () => ({allowPrivateNetworks: true, hostDenylist: []}),
 }));
 vi.mock('@shipfox/node-egress-guard', () => ({
   assertEgressAllowed: assertEgressAllowedMock,
@@ -97,9 +108,22 @@ function makeThrowingQuery(error: Error) {
 function lastQueryOptions(): {
   env: NodeJS.ProcessEnv;
   abortController: AbortController;
+  mcpServers?: unknown;
+  model?: string;
+  tools?: string[];
 } {
   const call = queryMock.mock.calls[0] as
-    | [{options: {env: NodeJS.ProcessEnv; abortController: AbortController}}]
+    | [
+        {
+          options: {
+            env: NodeJS.ProcessEnv;
+            abortController: AbortController;
+            mcpServers?: unknown;
+            model?: string;
+            tools?: string[];
+          };
+        },
+      ]
     | undefined;
   if (call === undefined) throw new Error('Expected Claude SDK query to be called.');
   return call[0].options;
@@ -127,6 +151,9 @@ describe('claudeHarnessAdapter', () => {
     createSdkMcpServerMock.mockClear();
     assertEgressAllowedMock.mockReset();
     assertEgressAllowedMock.mockResolvedValue(undefined);
+    configMock.AGENT_CLAUDE_ANTHROPIC_BASE_URL = '';
+    configMock.AGENT_CLAUDE_ANTHROPIC_MODEL = '';
+    configMock.AGENT_CLAUDE_ANTHROPIC_SMALL_FAST_MODEL = '';
   });
 
   afterEach(() => {
@@ -231,6 +258,52 @@ describe('claudeHarnessAdapter', () => {
     await expect(result).rejects.toThrow(
       new AgentConfigError(
         'Claude Anthropic API endpoint blocked by egress policy: host-denied (api.anthropic.com).',
+      ),
+    );
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it('uses the Anthropic base URL override without requiring an API key', async () => {
+    configMock.AGENT_CLAUDE_ANTHROPIC_BASE_URL = 'http://127.0.0.1:11434';
+    configMock.AGENT_CLAUDE_ANTHROPIC_MODEL = 'smollm2:135m-instruct-q2_K';
+    configMock.AGENT_CLAUDE_ANTHROPIC_SMALL_FAST_MODEL = 'smollm2:135m-instruct-q2_K';
+    queryMock.mockReturnValue(makeQuery([successMessage]));
+
+    await claudeHarnessAdapter.run(invocation({credentials: {}}));
+
+    expect(assertEgressAllowedMock).toHaveBeenCalledWith(
+      'http://127.0.0.1:11434',
+      expect.objectContaining({allowPrivateNetworks: true}),
+    );
+    expect(createSdkMcpServerMock).not.toHaveBeenCalled();
+    expect(queryMock).toHaveBeenCalledWith({
+      prompt: expect.any(Object),
+      options: expect.objectContaining({
+        model: 'smollm2:135m-instruct-q2_K',
+        tools: [],
+        env: expect.objectContaining({
+          ANTHROPIC_API_KEY: '',
+          ANTHROPIC_AUTH_TOKEN: 'ollama',
+          ANTHROPIC_BASE_URL: 'http://127.0.0.1:11434',
+          ANTHROPIC_MODEL: 'smollm2:135m-instruct-q2_K',
+          ANTHROPIC_SMALL_FAST_MODEL: 'smollm2:135m-instruct-q2_K',
+        }),
+      }),
+    });
+    expect(lastQueryOptions().mcpServers).toBeUndefined();
+  });
+
+  it('maps Anthropic override egress denial to AgentConfigError', async () => {
+    configMock.AGENT_CLAUDE_ANTHROPIC_BASE_URL = 'http://blocked.example.test';
+    assertEgressAllowedMock.mockRejectedValue(
+      new EgressDeniedErrorMock('host-denied', 'blocked.example.test'),
+    );
+
+    const result = claudeHarnessAdapter.run(invocation({credentials: {}}));
+
+    await expect(result).rejects.toThrow(
+      new AgentConfigError(
+        'Claude Anthropic base URL override blocked by egress policy: host-denied (blocked.example.test).',
       ),
     );
     expect(queryMock).not.toHaveBeenCalled();

--- a/libs/runner/agent/src/core/claude-adapter.ts
+++ b/libs/runner/agent/src/core/claude-adapter.ts
@@ -71,9 +71,15 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
   const targetUrl = override?.baseUrl ?? ANTHROPIC_API_URL;
   const targetLabel =
     override === undefined ? 'Claude Anthropic API endpoint' : 'Claude Anthropic base URL override';
-  const useOutputTools =
-    override === undefined ||
-    (invocation.outputs !== undefined && Object.keys(invocation.outputs).length > 0);
+  const hasDeclaredOutputs =
+    invocation.outputs !== undefined && Object.keys(invocation.outputs).length > 0;
+  if (override !== undefined && hasDeclaredOutputs) {
+    throw new AgentConfigError(
+      'Claude Anthropic base URL override does not support declared step outputs.',
+      'provider_unsupported',
+    );
+  }
+  const useOutputTools = override === undefined;
 
   await assertRunnerEgressAllowed(targetUrl, targetLabel);
 
@@ -292,16 +298,12 @@ function claudeEnvironment(
 }
 
 function claudeAnthropicOverride(): ClaudeAnthropicOverride | undefined {
-  if (config.AGENT_CLAUDE_ANTHROPIC_BASE_URL === '') return undefined;
+  if (config.AGENT_CLAUDE_ANTHROPIC_BASE_URL === undefined) return undefined;
 
   return {
     baseUrl: config.AGENT_CLAUDE_ANTHROPIC_BASE_URL,
-    model:
-      config.AGENT_CLAUDE_ANTHROPIC_MODEL === '' ? undefined : config.AGENT_CLAUDE_ANTHROPIC_MODEL,
-    smallFastModel:
-      config.AGENT_CLAUDE_ANTHROPIC_SMALL_FAST_MODEL === ''
-        ? undefined
-        : config.AGENT_CLAUDE_ANTHROPIC_SMALL_FAST_MODEL,
+    model: config.AGENT_CLAUDE_ANTHROPIC_MODEL,
+    smallFastModel: config.AGENT_CLAUDE_ANTHROPIC_SMALL_FAST_MODEL,
   };
 }
 

--- a/libs/runner/agent/src/core/claude-adapter.ts
+++ b/libs/runner/agent/src/core/claude-adapter.ts
@@ -10,6 +10,7 @@ import {
   tool,
 } from '@anthropic-ai/claude-agent-sdk';
 import {z} from 'zod';
+import {config} from '#config.js';
 import {assertRunnerEgressAllowed} from '#core/egress.js';
 import {AgentConfigError, AgentInvocationError} from '#core/errors.js';
 import type {HarnessAdapter, HarnessInvocation, HarnessResult} from '#core/harness.js';
@@ -21,8 +22,20 @@ import {
 } from '#core/output-collector.js';
 
 const ANTHROPIC_API_URL = 'https://api.anthropic.com';
+const OLLAMA_ANTHROPIC_AUTH_TOKEN = 'ollama';
 
 export const claudeHarnessAdapter: HarnessAdapter = {run: runClaudeAgent};
+
+interface ClaudeAnthropicOverride {
+  readonly baseUrl: string;
+  readonly model: string | undefined;
+  readonly smallFastModel: string | undefined;
+}
+
+interface ClaudeAuth {
+  readonly apiKey: string;
+  readonly authToken: string | undefined;
+}
 
 async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessResult> {
   const {
@@ -53,16 +66,16 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
     );
   }
 
-  const apiKey = credentials.api_key;
-  if (apiKey === undefined || apiKey === '') {
-    throw new AgentConfigError(
-      'No credentials configured for provider "anthropic". ' +
-        'Verify the provider is configured for this workspace.',
-      'provider_not_configured',
-    );
-  }
+  const override = claudeAnthropicOverride();
+  const auth = claudeAuth(credentials, override);
+  const targetUrl = override?.baseUrl ?? ANTHROPIC_API_URL;
+  const targetLabel =
+    override === undefined ? 'Claude Anthropic API endpoint' : 'Claude Anthropic base URL override';
+  const useOutputTools =
+    override === undefined ||
+    (invocation.outputs !== undefined && Object.keys(invocation.outputs).length > 0);
 
-  await assertRunnerEgressAllowed(ANTHROPIC_API_URL, 'Claude Anthropic API endpoint');
+  await assertRunnerEgressAllowed(targetUrl, targetLabel);
 
   let configDir: string | undefined;
   let claudeQuery: Query | undefined;
@@ -81,7 +94,7 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
     claudeQuery = query({
       prompt: messages,
       options: {
-        model,
+        model: override?.model ?? model,
         cwd,
         permissionMode: 'bypassPermissions',
         allowDangerouslySkipPermissions: true,
@@ -89,16 +102,21 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
         thinking: {type: 'adaptive'},
         effort: thinking as EffortLevel,
         abortController: controller,
-        env: claudeEnvironment(apiKey, configDir, gitConfigGlobal),
-        mcpServers: {
-          shipfox_outputs: createSdkMcpServer({
-            name: 'shipfox_outputs',
-            version: '1.0.0',
-            instructions: collector.guidanceText(),
-            tools: [setOutputTool(collector)],
-            alwaysLoad: true,
-          }),
-        },
+        ...(override !== undefined ? {tools: []} : {}),
+        env: claudeEnvironment(auth, configDir, gitConfigGlobal, override),
+        ...(useOutputTools
+          ? {
+              mcpServers: {
+                shipfox_outputs: createSdkMcpServer({
+                  name: 'shipfox_outputs',
+                  version: '1.0.0',
+                  instructions: collector.guidanceText(),
+                  tools: [setOutputTool(collector)],
+                  alwaysLoad: true,
+                }),
+              },
+            }
+          : {}),
         persistSession: false,
         includePartialMessages: false,
       },
@@ -114,7 +132,7 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
     try {
       await runOutputTurnLoop({
         signal,
-        prompt: withOutputGuidance(prompt, collector.guidanceText()),
+        prompt: useOutputTools ? withOutputGuidance(prompt, collector.guidanceText()) : prompt,
         missingRequired: () => collector.missingRequired(),
         runTurn: async (message) => {
           messages?.push(userMessage(message));
@@ -249,17 +267,62 @@ function forwardSessionEntry(
 }
 
 function claudeEnvironment(
-  apiKey: string,
+  auth: ClaudeAuth,
   configDir: string,
   gitConfigGlobal: string | undefined,
+  override: ClaudeAnthropicOverride | undefined,
 ): NodeJS.ProcessEnv {
   return {
     ...process.env,
-    ANTHROPIC_API_KEY: apiKey,
+    ANTHROPIC_API_KEY: auth.apiKey,
+    ...(auth.authToken !== undefined ? {ANTHROPIC_AUTH_TOKEN: auth.authToken} : {}),
+    ...(override !== undefined
+      ? {
+          ANTHROPIC_BASE_URL: override.baseUrl,
+          ...(override.model !== undefined ? {ANTHROPIC_MODEL: override.model} : {}),
+          ...(override.smallFastModel !== undefined
+            ? {ANTHROPIC_SMALL_FAST_MODEL: override.smallFastModel}
+            : {}),
+        }
+      : {}),
     CLAUDE_CONFIG_DIR: configDir,
     CLAUDE_AGENT_SDK_CLIENT_APP: '@shipfox/runner-agent',
     ...(gitConfigGlobal ? {GIT_CONFIG_GLOBAL: gitConfigGlobal} : {}),
   };
+}
+
+function claudeAnthropicOverride(): ClaudeAnthropicOverride | undefined {
+  if (config.AGENT_CLAUDE_ANTHROPIC_BASE_URL === '') return undefined;
+
+  return {
+    baseUrl: config.AGENT_CLAUDE_ANTHROPIC_BASE_URL,
+    model:
+      config.AGENT_CLAUDE_ANTHROPIC_MODEL === '' ? undefined : config.AGENT_CLAUDE_ANTHROPIC_MODEL,
+    smallFastModel:
+      config.AGENT_CLAUDE_ANTHROPIC_SMALL_FAST_MODEL === ''
+        ? undefined
+        : config.AGENT_CLAUDE_ANTHROPIC_SMALL_FAST_MODEL,
+  };
+}
+
+function claudeAuth(
+  credentials: Record<string, string>,
+  override: ClaudeAnthropicOverride | undefined,
+): ClaudeAuth {
+  if (override !== undefined) {
+    return {apiKey: '', authToken: OLLAMA_ANTHROPIC_AUTH_TOKEN};
+  }
+
+  const apiKey = credentials.api_key;
+  if (apiKey === undefined || apiKey === '') {
+    throw new AgentConfigError(
+      'No credentials configured for provider "anthropic". ' +
+        'Verify the provider is configured for this workspace.',
+      'provider_not_configured',
+    );
+  }
+
+  return {apiKey, authToken: undefined};
 }
 
 function claudeResult(message: SDKResultMessage): HarnessResult {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1082,6 +1082,9 @@ importers:
       '@shipfox/e2e-observe-workflows':
         specifier: workspace:*
         version: link:../../../observe/workflows
+      '@shipfox/e2e-setup-agent':
+        specifier: workspace:*
+        version: link:../../../setup/agent
       '@shipfox/e2e-setup-auth':
         specifier: workspace:*
         version: link:../../../setup/auth


### PR DESCRIPTION
Adds an opt-in runner-side Anthropic base URL override for the Claude harness so the real Claude Agent SDK path can run against local Ollama in E2E.

The Claude harness previously required a real Anthropic API key and always targeted Anthropic. This keeps normal Anthropic behavior unchanged, but when the runner has `AGENT_CLAUDE_ANTHROPIC_BASE_URL` set it redirects the SDK subprocess, pins the model env, checks egress against the override URL, and skips the API-key requirement inside the runner.

The full-loop coverage uses an E2E-only agent setup route to seed dummy Anthropic provider credentials, because server-side runtime config still needs a configured provider before dispatch. The runner ignores that dummy key under the override.

The SDK spike showed the default Ollama model rejects tool calls, so the override path disables Claude Code built-in tools. Declared step outputs are rejected explicitly while the override is active instead of attempting MCP/tool use against Anthropic-compatible backends that may not support it.

Considered wiring this through the custom-provider system, but this is intentionally a runner-local CI/testing knob rather than a client- or workspace-facing provider feature.

Validated with `turbo build --filter '...[origin/main]'`, `turbo test --filter '...[origin/main]'`, `turbo check --filter '...[origin/main]'`, and `mise run e2e -- --filter=@shipfox/e2e-flow-workflows`.