### PR TITLE
[e2e-driver-agent-provider] Add sidecar lifecycle handle

### DIFF
--- a/e2e/drivers/agent-provider/README.md
+++ b/e2e/drivers/agent-provider/README.md
@@ -5,9 +5,26 @@ provider for E2E tests. It is strict test infrastructure: suites register it as 
 normal custom model provider through product HTTP routes, while the fake provider
 itself stays outside the API app.
 
-This package currently owns the in-process HTTP server and script engine. The
-child-process sidecar wrapper is added separately so flow suites can keep the
-provider alive across Playwright `globalSetup` and worker processes.
+Use `startFakeOpenAiProvider()` for suites that need the provider to outlive
+Playwright `globalSetup` and serve worker-process jobs:
+
+```ts
+const provider = await startFakeOpenAiProvider({runId});
+const script = await provider.createScript({
+  id: `${runId}-agent-output-tool`,
+  model: 'deterministic-output-agent',
+  responses: [
+    toolCall('set_output', {key: 'message', value: 'qwen-tool-output-ok'}),
+    message('done'),
+  ],
+});
+
+await provider.stop();
+```
+
+The provider writes `.context/e2e-agent-provider/<runId>.json` with the child
+pid, base URL, and admin token. Global teardown can call
+`stopFakeOpenAiProvider({runId})` when the original handle is not available.
 
 ## HTTP Surface
 

--- a/e2e/drivers/agent-provider/README.md
+++ b/e2e/drivers/agent-provider/README.md
@@ -9,6 +9,8 @@ Use `startFakeOpenAiProvider()` for suites that need the provider to outlive
 Playwright `globalSetup` and serve worker-process jobs:
 
 ```ts
+import {message, startFakeOpenAiProvider, toolCall} from '@shipfox/e2e-driver-agent-provider';
+
 const provider = await startFakeOpenAiProvider({runId});
 const script = await provider.createScript({
   id: `${runId}-agent-output-tool`,

--- a/e2e/drivers/agent-provider/package.json
+++ b/e2e/drivers/agent-provider/package.json
@@ -42,6 +42,7 @@
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",
-    "@shipfox/vitest": "workspace:*"
+    "@shipfox/vitest": "workspace:*",
+    "tsx": "^4.22.4"
   }
 }

--- a/e2e/drivers/agent-provider/src/index.ts
+++ b/e2e/drivers/agent-provider/src/index.ts
@@ -6,6 +6,19 @@ export {
   type OpenAiErrorBody,
 } from './openai.js';
 export {
+  type FakeOpenAiProviderHandle,
+  type FakeOpenAiProviderState,
+  type FakeOpenAiScriptHandle,
+  message,
+  providerStateFile,
+  readFakeOpenAiProviderState,
+  type StartFakeOpenAiProviderParams,
+  type StopFakeOpenAiProviderParams,
+  startFakeOpenAiProvider,
+  stopFakeOpenAiProvider,
+  toolCall,
+} from './process.js';
+export {
   type FakeOpenAiRecordedRequest,
   type FakeOpenAiRequestAssertion,
   type FakeOpenAiResponse,

--- a/e2e/drivers/agent-provider/src/openai.ts
+++ b/e2e/drivers/agent-provider/src/openai.ts
@@ -50,6 +50,18 @@ export interface OpenAiErrorBody {
   };
 }
 
+export interface OpenAiModelList {
+  object: 'list';
+  data: OpenAiModel[];
+}
+
+export interface OpenAiModel {
+  id: string;
+  object: 'model';
+  created: number;
+  owned_by: string;
+}
+
 export function buildChatCompletion(params: {
   model: string;
   response: Exclude<FakeOpenAiResponse, {kind: 'error'}>;
@@ -99,4 +111,18 @@ export function buildChatCompletion(params: {
 
 export function buildOpenAiError(type: string, message: string): OpenAiErrorBody {
   return {error: {message, type}};
+}
+
+export function buildOpenAiModelList(model: string): OpenAiModelList {
+  return {
+    object: 'list',
+    data: [
+      {
+        id: model,
+        object: 'model',
+        created: fakeCreatedAt,
+        owned_by: 'shipfox-e2e',
+      },
+    ],
+  };
 }

--- a/e2e/drivers/agent-provider/src/process.test.ts
+++ b/e2e/drivers/agent-provider/src/process.test.ts
@@ -1,0 +1,147 @@
+import {mkdtemp, readFile, rm} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {afterEach, beforeEach, describe, expect, it} from '@shipfox/vitest/vi';
+import {
+  type FakeOpenAiProviderHandle,
+  message,
+  providerStateFile,
+  readFakeOpenAiProviderState,
+  startFakeOpenAiProvider,
+  stopFakeOpenAiProvider,
+  toolCall,
+} from './index.js';
+
+describe('fake OpenAI provider process', () => {
+  let stateDirectory: string;
+  let provider: FakeOpenAiProviderHandle | undefined;
+
+  beforeEach(async () => {
+    stateDirectory = await mkdtemp(join(tmpdir(), 'shipfox-fake-provider-'));
+  });
+
+  afterEach(async () => {
+    await provider?.stop().catch(() => undefined);
+    provider = undefined;
+    await rm(stateDirectory, {recursive: true, force: true});
+  });
+
+  it('starts a sidecar, serves a scripted OpenAI request, and cleans up state on stop', async () => {
+    provider = await startFakeOpenAiProvider({runId: 'lifecycle', stateDirectory});
+    const {baseUrl} = provider;
+    const script = await provider.createScript({
+      id: 'scripted-request',
+      model: 'deterministic-output-agent',
+      responses: [
+        toolCall('set_output', {key: 'message', value: 'qwen-tool-output-ok'}),
+        message('done'),
+      ],
+    });
+
+    const result = await fetch(`${script.providerBaseUrl}/chat/completions`, {
+      method: 'POST',
+      body: JSON.stringify(openAiRequest()),
+    });
+    const requests = await provider.getRequests(script.id);
+    const state = await readFakeOpenAiProviderState({runId: 'lifecycle', stateDirectory});
+    await provider.stop();
+    provider = undefined;
+    const stateAfterStop = await readStateFile('lifecycle');
+    const processAliveAfterStop = isProcessAlive(state.pid);
+
+    expect(result.status).toBe(200);
+    await expect(result.json()).resolves.toMatchObject({
+      id: 'chatcmpl-fake-scripted-request-0',
+      choices: [
+        {
+          message: {
+            tool_calls: [
+              {
+                function: {
+                  name: 'set_output',
+                  arguments: '{"key":"message","value":"qwen-tool-output-ok"}',
+                },
+              },
+            ],
+          },
+          finish_reason: 'tool_calls',
+        },
+      ],
+    });
+    expect(requests).toMatchObject([
+      {
+        index: 0,
+        model: 'deterministic-output-agent',
+        tools: ['set_output'],
+        message_roles: ['system', 'user'],
+        served_response: 'tool_call:set_output',
+      },
+    ]);
+    expect(state).toMatchObject({
+      runId: 'lifecycle',
+      baseUrl,
+    });
+    expect(state.pid).toBeGreaterThan(0);
+    expect(state.adminToken).toEqual(expect.any(String));
+    expect(stateAfterStop).toBeNull();
+    expect(processAliveAfterStop).toBe(false);
+  });
+
+  it('stops a sidecar from the persisted run state', async () => {
+    provider = await startFakeOpenAiProvider({runId: 'teardown', stateDirectory});
+    const {baseUrl} = provider;
+    const state = await readFakeOpenAiProviderState({runId: 'teardown', stateDirectory});
+
+    await stopFakeOpenAiProvider({runId: 'teardown', stateDirectory});
+    provider = undefined;
+    const stateAfterStop = await readStateFile('teardown');
+    const processAliveAfterStop = isProcessAlive(state.pid);
+    const reachable = await isReachable(baseUrl);
+
+    expect(stateAfterStop).toBeNull();
+    expect(processAliveAfterStop).toBe(false);
+    expect(reachable).toBe(false);
+  });
+
+  async function readStateFile(runId: string): Promise<string | null> {
+    try {
+      const path = providerStateFile({runId, stateDirectory});
+      return await readFile(path, 'utf8');
+    } catch {
+      return null;
+    }
+  }
+});
+
+function openAiRequest() {
+  return {
+    model: 'deterministic-output-agent',
+    messages: [{role: 'system'}, {role: 'user'}],
+    tools: [
+      {
+        type: 'function',
+        function: {
+          name: 'set_output',
+        },
+      },
+    ],
+  };
+}
+
+async function isReachable(baseUrl: string): Promise<boolean> {
+  try {
+    await fetch(`${baseUrl}/healthz`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/e2e/drivers/agent-provider/src/process.ts
+++ b/e2e/drivers/agent-provider/src/process.ts
@@ -1,0 +1,391 @@
+import {type ChildProcess, spawn} from 'node:child_process';
+import {existsSync} from 'node:fs';
+import {mkdir, readFile, rm, writeFile} from 'node:fs/promises';
+import {dirname, join, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import type {FakeOpenAiRecordedRequest, FakeOpenAiResponse, FakeOpenAiScript} from './scripts.js';
+
+const DEFAULT_READINESS_TIMEOUT_MS = 10_000;
+const DEFAULT_SIGTERM_TIMEOUT_MS = 5_000;
+const READY_EVENT = 'ready';
+
+export interface StartFakeOpenAiProviderParams {
+  runId?: string | undefined;
+  readinessTimeoutMs?: number | undefined;
+  stateDirectory?: string | undefined;
+  entryPath?: string | undefined;
+}
+
+export interface StopFakeOpenAiProviderParams {
+  runId: string;
+  sigtermTimeoutMs?: number | undefined;
+  stateDirectory?: string | undefined;
+}
+
+export interface FakeOpenAiProviderState {
+  runId: string;
+  pid: number;
+  baseUrl: string;
+  adminToken: string;
+}
+
+export interface FakeOpenAiScriptHandle {
+  id: string;
+  model: string;
+  providerBaseUrl: string;
+}
+
+export interface FakeOpenAiProviderHandle {
+  baseUrl: string;
+  createScript(params: FakeOpenAiScript): Promise<FakeOpenAiScriptHandle>;
+  resetScript(id: string): Promise<void>;
+  getRequests(id: string): Promise<FakeOpenAiRecordedRequest[]>;
+  stop(): Promise<void>;
+}
+
+interface ReadyMessage {
+  event: typeof READY_EVENT;
+  baseUrl: string;
+}
+
+export function toolCall(
+  name: string,
+  args: Record<string, unknown>,
+): Extract<FakeOpenAiResponse, {kind: 'tool_call'}> {
+  return {kind: 'tool_call', toolName: name, arguments: args, content: ''};
+}
+
+export function message(content: string): Extract<FakeOpenAiResponse, {kind: 'message'}> {
+  return {kind: 'message', content};
+}
+
+export async function startFakeOpenAiProvider(
+  params: StartFakeOpenAiProviderParams = {},
+): Promise<FakeOpenAiProviderHandle> {
+  const runId = params.runId ?? crypto.randomUUID();
+  const adminToken = crypto.randomUUID();
+  const {cwd, entry} = providerSidecarModule(params.entryPath);
+  const child = spawn(process.execPath, ['--import', 'tsx', '--conditions=development', entry], {
+    cwd,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: {
+      ...inheritedProcessEnv(),
+      SHIPFOX_FAKE_OPENAI_ADMIN_TOKEN: adminToken,
+    },
+  });
+
+  const {pid} = child;
+  if (pid === undefined) {
+    child.kill('SIGKILL');
+    throw new Error('Fake OpenAI provider child process failed to start (no pid)');
+  }
+
+  let baseUrl: string;
+  try {
+    baseUrl = await waitForReadyMessage(
+      child,
+      params.readinessTimeoutMs ?? DEFAULT_READINESS_TIMEOUT_MS,
+    );
+    await waitForHealthz({
+      adminToken,
+      baseUrl,
+      child,
+      timeoutMs: params.readinessTimeoutMs ?? DEFAULT_READINESS_TIMEOUT_MS,
+    });
+  } catch (error) {
+    child.kill('SIGKILL');
+    throw error;
+  }
+
+  const stateFile = providerStateFile({runId, stateDirectory: params.stateDirectory});
+  await writeProviderState(stateFile, {runId, pid, baseUrl, adminToken});
+
+  return {
+    baseUrl,
+    createScript: async (script) => {
+      const body = await requestJson<{
+        model: string;
+        provider_base_url: string;
+        script_id: string;
+      }>({
+        adminToken,
+        body: script,
+        method: 'POST',
+        url: `${baseUrl}/scripts`,
+      });
+      return {
+        id: body.script_id,
+        model: body.model,
+        providerBaseUrl: body.provider_base_url,
+      };
+    },
+    resetScript: async (id) => {
+      await requestNoContent({
+        adminToken,
+        method: 'POST',
+        url: `${baseUrl}/scripts/${encodeURIComponent(id)}/reset`,
+      });
+    },
+    getRequests: async (id) => {
+      const body = await requestJson<{requests: FakeOpenAiRecordedRequest[]}>({
+        adminToken,
+        method: 'GET',
+        url: `${baseUrl}/scripts/${encodeURIComponent(id)}/requests`,
+      });
+      return body.requests;
+    },
+    stop: async () => {
+      await terminate(child, DEFAULT_SIGTERM_TIMEOUT_MS);
+      await rm(stateFile, {force: true}).catch(() => undefined);
+    },
+  };
+}
+
+export function providerStateFile(params: {
+  runId: string;
+  stateDirectory?: string | undefined;
+}): string {
+  return join(params.stateDirectory ?? defaultStateDirectory(), `${params.runId}.json`);
+}
+
+export async function readFakeOpenAiProviderState(params: {
+  runId: string;
+  stateDirectory?: string | undefined;
+}): Promise<FakeOpenAiProviderState> {
+  return JSON.parse(await readFile(providerStateFile(params), 'utf8')) as FakeOpenAiProviderState;
+}
+
+export async function stopFakeOpenAiProvider(params: StopFakeOpenAiProviderParams): Promise<void> {
+  const stateFile = providerStateFile(params);
+  let state: FakeOpenAiProviderState;
+  try {
+    state = JSON.parse(await readFile(stateFile, 'utf8')) as FakeOpenAiProviderState;
+  } catch {
+    return;
+  }
+
+  await terminatePid(state.pid, params.sigtermTimeoutMs ?? DEFAULT_SIGTERM_TIMEOUT_MS);
+  await rm(stateFile, {force: true}).catch(() => undefined);
+}
+
+async function writeProviderState(path: string, state: FakeOpenAiProviderState): Promise<void> {
+  await mkdir(dirname(path), {recursive: true});
+  await writeFile(path, JSON.stringify(state, null, 2));
+}
+
+function providerSidecarModule(entryPath: string | undefined): {cwd: string; entry: string} {
+  if (entryPath) return {cwd: dirname(entryPath), entry: entryPath};
+
+  const sourceDir = dirname(fileURLToPath(import.meta.url));
+  const packageDir = dirname(sourceDir);
+  return {cwd: packageDir, entry: join(sourceDir, 'sidecar.ts')};
+}
+
+function inheritedProcessEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const key of ['PATH', 'HOME', 'TMPDIR', 'TEMP', 'TMP', 'SystemRoot', 'WINDIR', 'COMSPEC']) {
+    const value = process.env[key];
+    if (value !== undefined) env[key] = value;
+  }
+  return env;
+}
+
+function waitForReadyMessage(child: ChildProcess, timeoutMs: number): Promise<string> {
+  let stdout = '';
+  let stderr = '';
+
+  return new Promise((resolveReady, rejectReady) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      rejectReady(new Error(`Fake OpenAI provider did not report ready within ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      child.stdout?.removeListener('data', onStdout);
+      child.stderr?.removeListener('data', onStderr);
+      child.removeListener('exit', onExit);
+      child.removeListener('error', onError);
+    };
+
+    const onStdout = (chunk: Buffer) => {
+      stdout += chunk.toString('utf8');
+      for (const line of stdout.split('\n')) {
+        const message = parseReadyMessage(line);
+        if (!message) continue;
+        cleanup();
+        resolveReady(message.baseUrl);
+        return;
+      }
+    };
+
+    const onStderr = (chunk: Buffer) => {
+      stderr += chunk.toString('utf8');
+    };
+
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      rejectReady(
+        new Error(
+          `Fake OpenAI provider exited before readiness (code ${code}, signal ${signal})${stderrTail(stderr)}`,
+        ),
+      );
+    };
+
+    const onError = (error: Error) => {
+      cleanup();
+      rejectReady(new Error(`Fake OpenAI provider process error: ${error.message}`));
+    };
+
+    child.stdout?.on('data', onStdout);
+    child.stderr?.on('data', onStderr);
+    child.once('exit', onExit);
+    child.once('error', onError);
+  });
+}
+
+function parseReadyMessage(line: string): ReadyMessage | null {
+  try {
+    const parsed = JSON.parse(line) as Partial<ReadyMessage>;
+    if (parsed.event === READY_EVENT && typeof parsed.baseUrl === 'string') {
+      return {event: READY_EVENT, baseUrl: parsed.baseUrl};
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+async function waitForHealthz(params: {
+  adminToken: string;
+  baseUrl: string;
+  child: ChildProcess;
+  timeoutMs: number;
+}): Promise<void> {
+  const deadline = Date.now() + params.timeoutMs;
+  while (Date.now() < deadline) {
+    if (params.child.exitCode !== null || params.child.signalCode !== null) {
+      throw new Error(
+        `Fake OpenAI provider exited before health check passed (code ${params.child.exitCode}, signal ${params.child.signalCode})`,
+      );
+    }
+
+    try {
+      const response = await fetch(`${params.baseUrl}/healthz`, {
+        headers: adminHeaders(params.adminToken),
+      });
+      if (response.ok) return;
+    } catch {
+      await sleep(50);
+      continue;
+    }
+
+    await sleep(50);
+  }
+
+  throw new Error(`Fake OpenAI provider health check did not pass within ${params.timeoutMs}ms`);
+}
+
+async function requestJson<T>(params: {
+  adminToken: string;
+  body?: unknown;
+  method: string;
+  url: string;
+}): Promise<T> {
+  const response = await fetch(params.url, {
+    method: params.method,
+    headers: {
+      ...adminHeaders(params.adminToken),
+      ...(params.body === undefined ? {} : {'content-type': 'application/json'}),
+    },
+    ...(params.body === undefined ? {} : {body: JSON.stringify(params.body)}),
+  });
+
+  if (!response.ok) throw new Error(await responseErrorMessage(response));
+  return (await response.json()) as T;
+}
+
+async function requestNoContent(params: {
+  adminToken: string;
+  method: string;
+  url: string;
+}): Promise<void> {
+  const response = await fetch(params.url, {
+    method: params.method,
+    headers: adminHeaders(params.adminToken),
+  });
+
+  if (!response.ok) throw new Error(await responseErrorMessage(response));
+}
+
+function adminHeaders(adminToken: string): Record<string, string> {
+  return {authorization: `Bearer ${adminToken}`};
+}
+
+async function responseErrorMessage(response: Response): Promise<string> {
+  const body = await response.text().catch(() => '');
+  return `Fake OpenAI provider request failed: ${response.status} ${response.statusText}${body ? ` ${body}` : ''}`;
+}
+
+function terminate(child: ChildProcess, sigtermTimeoutMs: number): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve();
+
+  const exited = new Promise<void>((resolveExit) => child.once('exit', () => resolveExit()));
+  child.kill('SIGTERM');
+
+  return new Promise((resolveTerminate) => {
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      exited.then(resolveTerminate);
+    }, sigtermTimeoutMs);
+    exited.then(() => {
+      clearTimeout(timer);
+      resolveTerminate();
+    });
+  });
+}
+
+async function terminatePid(pid: number, sigtermTimeoutMs: number): Promise<void> {
+  if (!isProcessAlive(pid)) return;
+  process.kill(pid, 'SIGTERM');
+
+  const deadline = Date.now() + sigtermTimeoutMs;
+  while (Date.now() < deadline) {
+    if (!isProcessAlive(pid)) return;
+    await sleep(50);
+  }
+
+  if (isProcessAlive(pid)) process.kill(pid, 'SIGKILL');
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function defaultStateDirectory(): string {
+  return join(workspaceRoot(), '.context', 'e2e-agent-provider');
+}
+
+function workspaceRoot(): string {
+  let current = resolve(process.cwd());
+  while (true) {
+    if (existsSync(join(current, 'pnpm-workspace.yaml'))) return current;
+    const parent = dirname(current);
+    if (parent === current) return resolve(process.cwd());
+    current = parent;
+  }
+}
+
+function stderrTail(stderr: string): string {
+  const tail = stderr.trimEnd().split('\n').slice(-20).join('\n');
+  return tail ? `\n\nSidecar stderr tail:\n${tail}` : '';
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
+}

--- a/e2e/drivers/agent-provider/src/process.ts
+++ b/e2e/drivers/agent-provider/src/process.ts
@@ -6,7 +6,9 @@ import {fileURLToPath} from 'node:url';
 import type {FakeOpenAiRecordedRequest, FakeOpenAiResponse, FakeOpenAiScript} from './scripts.js';
 
 const DEFAULT_READINESS_TIMEOUT_MS = 10_000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 5_000;
 const DEFAULT_SIGTERM_TIMEOUT_MS = 5_000;
+const HEALTHZ_REQUEST_TIMEOUT_MS = 500;
 const READY_EVENT = 'ready';
 
 export interface StartFakeOpenAiProviderParams {
@@ -98,7 +100,12 @@ export async function startFakeOpenAiProvider(
   }
 
   const stateFile = providerStateFile({runId, stateDirectory: params.stateDirectory});
-  await writeProviderState(stateFile, {runId, pid, baseUrl, adminToken});
+  try {
+    await writeProviderState(stateFile, {runId, pid, baseUrl, adminToken});
+  } catch (error) {
+    await terminate(child, DEFAULT_SIGTERM_TIMEOUT_MS);
+    throw error;
+  }
 
   return {
     baseUrl,
@@ -176,9 +183,11 @@ async function writeProviderState(path: string, state: FakeOpenAiProviderState):
 function providerSidecarModule(entryPath: string | undefined): {cwd: string; entry: string} {
   if (entryPath) return {cwd: dirname(entryPath), entry: entryPath};
 
-  const sourceDir = dirname(fileURLToPath(import.meta.url));
-  const packageDir = dirname(sourceDir);
-  return {cwd: packageDir, entry: join(sourceDir, 'sidecar.ts')};
+  const moduleDir = dirname(fileURLToPath(import.meta.url));
+  const packageDir = dirname(moduleDir);
+  const sourceEntry = join(packageDir, 'src', 'sidecar.ts');
+  const builtEntry = join(packageDir, 'dist', 'sidecar.js');
+  return {cwd: packageDir, entry: existsSync(sourceEntry) ? sourceEntry : builtEntry};
 }
 
 function inheritedProcessEnv(): Record<string, string> {
@@ -271,8 +280,10 @@ async function waitForHealthz(params: {
     }
 
     try {
-      const response = await fetch(`${params.baseUrl}/healthz`, {
+      const remainingMs = deadline - Date.now();
+      const response = await fetchWithTimeout(`${params.baseUrl}/healthz`, {
         headers: adminHeaders(params.adminToken),
+        timeoutMs: Math.min(HEALTHZ_REQUEST_TIMEOUT_MS, remainingMs),
       });
       if (response.ok) return;
     } catch {
@@ -292,13 +303,14 @@ async function requestJson<T>(params: {
   method: string;
   url: string;
 }): Promise<T> {
-  const response = await fetch(params.url, {
+  const response = await fetchWithTimeout(params.url, {
     method: params.method,
     headers: {
       ...adminHeaders(params.adminToken),
       ...(params.body === undefined ? {} : {'content-type': 'application/json'}),
     },
     ...(params.body === undefined ? {} : {body: JSON.stringify(params.body)}),
+    timeoutMs: DEFAULT_REQUEST_TIMEOUT_MS,
   });
 
   if (!response.ok) throw new Error(await responseErrorMessage(response));
@@ -310,9 +322,10 @@ async function requestNoContent(params: {
   method: string;
   url: string;
 }): Promise<void> {
-  const response = await fetch(params.url, {
+  const response = await fetchWithTimeout(params.url, {
     method: params.method,
     headers: adminHeaders(params.adminToken),
+    timeoutMs: DEFAULT_REQUEST_TIMEOUT_MS,
   });
 
   if (!response.ok) throw new Error(await responseErrorMessage(response));
@@ -320,6 +333,25 @@ async function requestNoContent(params: {
 
 function adminHeaders(adminToken: string): Record<string, string> {
   return {authorization: `Bearer ${adminToken}`};
+}
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit & {timeoutMs: number},
+): Promise<Response> {
+  const {timeoutMs, ...requestInit} = init;
+  const abortController = new AbortController();
+  const timer = setTimeout(() => abortController.abort(), timeoutMs);
+  try {
+    return await fetch(url, {...requestInit, signal: abortController.signal});
+  } catch (error) {
+    if (abortController.signal.aborted) {
+      throw new Error(`Fake OpenAI provider request timed out after ${timeoutMs}ms: ${url}`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 async function responseErrorMessage(response: Response): Promise<string> {
@@ -347,7 +379,7 @@ function terminate(child: ChildProcess, sigtermTimeoutMs: number): Promise<void>
 
 async function terminatePid(pid: number, sigtermTimeoutMs: number): Promise<void> {
   if (!isProcessAlive(pid)) return;
-  process.kill(pid, 'SIGTERM');
+  if (!sendSignal(pid, 'SIGTERM')) return;
 
   const deadline = Date.now() + sigtermTimeoutMs;
   while (Date.now() < deadline) {
@@ -355,16 +387,31 @@ async function terminatePid(pid: number, sigtermTimeoutMs: number): Promise<void
     await sleep(50);
   }
 
-  if (isProcessAlive(pid)) process.kill(pid, 'SIGKILL');
+  if (isProcessAlive(pid)) sendSignal(pid, 'SIGKILL');
 }
 
 function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;
-  } catch {
+  } catch (error) {
+    if (isErrnoException(error) && error.code === 'EPERM') return true;
     return false;
   }
+}
+
+function sendSignal(pid: number, signal: NodeJS.Signals): boolean {
+  try {
+    process.kill(pid, signal);
+    return true;
+  } catch (error) {
+    if (isErrnoException(error) && error.code === 'ESRCH') return false;
+    throw error;
+  }
+}
+
+function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error;
 }
 
 function defaultStateDirectory(): string {

--- a/e2e/drivers/agent-provider/src/scripts.ts
+++ b/e2e/drivers/agent-provider/src/scripts.ts
@@ -97,6 +97,10 @@ export class FakeOpenAiScriptRegistry {
     return [...this.#scriptState(scriptId).requests];
   }
 
+  script(scriptId: string): FakeOpenAiScript {
+    return this.#scriptState(scriptId).script;
+  }
+
   advance(
     scriptId: string,
     request: {body: unknown; method: string; path: string},

--- a/e2e/drivers/agent-provider/src/server.test.ts
+++ b/e2e/drivers/agent-provider/src/server.test.ts
@@ -138,6 +138,25 @@ describe('fake OpenAI provider server', () => {
     });
   });
 
+  it('lists the registered model through the OpenAI-compatible models endpoint', async () => {
+    await postScript(server, fakeScript({id: 'models', model: 'deterministic-settings-agent'}));
+
+    const result = await fetch(`${server.baseUrl}/scripts/models/v1/models`);
+
+    expect(result.status).toBe(200);
+    await expect(result.json()).resolves.toEqual({
+      object: 'list',
+      data: [
+        {
+          id: 'deterministic-settings-agent',
+          object: 'model',
+          created: 1783344000,
+          owned_by: 'shipfox-e2e',
+        },
+      ],
+    });
+  });
+
   it('returns a deterministic 409 when a script is exhausted', async () => {
     await postScript(
       server,

--- a/e2e/drivers/agent-provider/src/server.ts
+++ b/e2e/drivers/agent-provider/src/server.ts
@@ -1,6 +1,6 @@
 import {createServer, type IncomingMessage, type Server, type ServerResponse} from 'node:http';
 import type {AddressInfo} from 'node:net';
-import {buildOpenAiError} from './openai.js';
+import {buildOpenAiError, buildOpenAiModelList} from './openai.js';
 import {type FakeOpenAiScript, FakeOpenAiScriptRegistry} from './scripts.js';
 
 export interface FakeOpenAiProviderServer {
@@ -20,6 +20,7 @@ const maxBodyBytes = 1024 * 1024;
 const resetPathRe = /^\/scripts\/([^/]+)\/reset$/u;
 const requestsPathRe = /^\/scripts\/([^/]+)\/requests$/u;
 const completionsPathRe = /^\/scripts\/([^/]+)\/v1\/chat\/completions$/u;
+const modelsPathRe = /^\/scripts\/([^/]+)\/v1\/models$/u;
 
 export async function createFakeOpenAiProviderServer(
   params: CreateFakeOpenAiProviderServerParams = {},
@@ -117,6 +118,13 @@ async function routeRequest(params: {
       const body = await readJson(params.request);
       const result = params.registry.advance(scriptId, {body, method, path: pathname});
       writeJson(params.response, result.status, result.body);
+      return;
+    }
+
+    const modelsMatch = modelsPathRe.exec(pathname);
+    if (modelsMatch && method === 'GET') {
+      const script = params.registry.script(decodeURIComponent(modelsMatch[1] ?? ''));
+      writeJson(params.response, 200, buildOpenAiModelList(script.model));
       return;
     }
 

--- a/e2e/drivers/agent-provider/src/sidecar.ts
+++ b/e2e/drivers/agent-provider/src/sidecar.ts
@@ -1,0 +1,32 @@
+import {createFakeOpenAiProviderServer, type FakeOpenAiProviderServer} from './server.js';
+
+const adminToken = process.env.SHIPFOX_FAKE_OPENAI_ADMIN_TOKEN;
+
+if (!adminToken) {
+  process.stderr.write('Fake OpenAI provider sidecar requires SHIPFOX_FAKE_OPENAI_ADMIN_TOKEN\n');
+  process.exit(1);
+}
+
+let server: FakeOpenAiProviderServer | undefined;
+
+try {
+  server = await createFakeOpenAiProviderServer({adminToken});
+  process.stdout.write(`${JSON.stringify({event: 'ready', baseUrl: server.baseUrl})}\n`);
+} catch (error) {
+  process.stderr.write(`Fake OpenAI provider sidecar failed to start: ${String(error)}\n`);
+  process.exit(1);
+}
+
+async function shutdown(): Promise<void> {
+  const activeServer = server;
+  server = undefined;
+  if (activeServer) await activeServer.stop().catch(() => undefined);
+}
+
+process.once('SIGTERM', () => {
+  void shutdown().finally(() => process.exit(0));
+});
+
+process.once('SIGINT', () => {
+  void shutdown().finally(() => process.exit(0));
+});

--- a/e2e/setup/agent/src/index.test.ts
+++ b/e2e/setup/agent/src/index.test.ts
@@ -168,6 +168,23 @@ describe('agent e2e helper', () => {
     expect(helper.createOpenAiCompatibleCustomProvider).toBe(createOpenAiCompatibleCustomProvider);
   });
 
+  it('deletes a model provider config through the product route', async () => {
+    requestJson.mockResolvedValueOnce(undefined);
+    const {deleteModelProviderConfig} = await import('./index.js');
+
+    await deleteModelProviderConfig({
+      workspaceId,
+      sessionToken,
+      providerId: 'local-ollama-e2e',
+    });
+
+    expect(createApiClient).toHaveBeenCalledWith({token: sessionToken});
+    expect(requestJson).toHaveBeenCalledWith(
+      'delete',
+      `/workspaces/${workspaceId}/agent/model-providers/local-ollama-e2e`,
+    );
+  });
+
   it('lists model provider configs through the product route', async () => {
     requestJson.mockResolvedValueOnce({configs: [], default_provider_id: null});
     const {listModelProviderConfigs} = await import('./index.js');

--- a/e2e/setup/agent/src/index.ts
+++ b/e2e/setup/agent/src/index.ts
@@ -59,6 +59,12 @@ export interface CreateAnthropicModelProviderConfigParams {
   setAsDefault?: boolean | undefined;
 }
 
+export interface DeleteModelProviderConfigParams {
+  workspaceId: string;
+  sessionToken: string;
+  providerId: ModelProviderRef;
+}
+
 export function ollamaConfig(env: NodeJS.ProcessEnv = process.env): OllamaConfig {
   const baseUrl = normalizeBaseUrl(
     env.OLLAMA_BASE_URL || env.SHIPFOX_OLLAMA_BASE_URL || DEFAULT_OLLAMA_BASE_URL,
@@ -161,11 +167,23 @@ export async function createAnthropicModelProviderConfig(
   });
 }
 
+export async function deleteModelProviderConfig(
+  params: DeleteModelProviderConfigParams,
+): Promise<void> {
+  const client = createApiClient({token: params.sessionToken});
+
+  await client.requestJson(
+    'delete',
+    `/workspaces/${params.workspaceId}/agent/model-providers/${params.providerId}`,
+  );
+}
+
 export function createAgentHelper() {
   return {
     createAnthropicModelProviderConfig,
     createOpenAiCompatibleCustomProvider,
     createOllamaCustomProvider,
+    deleteModelProviderConfig,
     listModelProviderConfigs,
     requireOllamaModel,
   };

--- a/e2e/suites/client/agent/package.json
+++ b/e2e/suites/client/agent/package.json
@@ -25,6 +25,7 @@
     "@shipfox/client-workspace-settings": "workspace:*",
     "@shipfox/depcruise": "workspace:*",
     "@shipfox/e2e-core": "workspace:*",
+    "@shipfox/e2e-driver-agent-provider": "workspace:*",
     "@shipfox/e2e-kit": "workspace:*",
     "@shipfox/e2e-screens-agent": "workspace:*",
     "@shipfox/e2e-setup-agent": "workspace:*",

--- a/e2e/suites/client/agent/tests/custom-model-provider-settings.e2e.ts
+++ b/e2e/suites/client/agent/tests/custom-model-provider-settings.e2e.ts
@@ -1,16 +1,33 @@
-import {type AgentHelper, ollamaConfig} from '@shipfox/e2e-setup-agent';
+import {
+  type FakeOpenAiProviderHandle,
+  type FakeOpenAiScriptHandle,
+  message,
+  startFakeOpenAiProvider,
+} from '@shipfox/e2e-driver-agent-provider';
+import type {AgentHelper} from '@shipfox/e2e-setup-agent';
 import {expect, test} from './test.js';
 
-const OLLAMA = ollamaConfig();
-const OLLAMA_MODEL_ID = OLLAMA.model;
-const CREATE_PROVIDER_ID = 'local-ollama-create';
-const CREATE_PROVIDER_NAME = 'Local Ollama Create';
-const EDIT_PROVIDER_ID = 'local-ollama-edit';
-const EDIT_PROVIDER_NAME = 'Local Ollama Edit';
-const EDITED_PROVIDER_NAME = 'Local Ollama Edited';
-const DELETE_PROVIDER_ID = 'local-ollama-delete';
-const DELETE_PROVIDER_NAME = 'Local Ollama Delete';
+const FAKE_MODEL_ID = 'deterministic-settings-agent';
+const CREATE_PROVIDER_ID = 'fake-openai-create';
+const CREATE_PROVIDER_NAME = 'Fake OpenAI Create';
+const EDIT_PROVIDER_ID = 'fake-openai-edit';
+const EDIT_PROVIDER_NAME = 'Fake OpenAI Edit';
+const EDITED_PROVIDER_NAME = 'Fake OpenAI Edited';
+const DELETE_PROVIDER_ID = 'fake-openai-delete';
+const DELETE_PROVIDER_NAME = 'Fake OpenAI Delete';
 const PROVIDER_SAVE_TIMEOUT_MS = 75_000;
+
+let fakeProvider: FakeOpenAiProviderHandle | undefined;
+
+test.beforeAll(async () => {
+  fakeProvider = await startFakeOpenAiProvider({
+    runId: `client-agent-custom-model-provider-settings-${process.pid}-${crypto.randomUUID()}`,
+  });
+});
+
+test.afterAll(async () => {
+  await fakeProvider?.stop();
+});
 
 async function expectProviderInApi(params: {
   agent: AgentHelper;
@@ -33,7 +50,7 @@ async function expectProviderInApi(params: {
   );
 }
 
-test('creates a custom model provider backed by local Ollama', async ({
+test('creates a custom model provider backed by a fake OpenAI-compatible provider', async ({
   page,
   agent,
   customModelProviders,
@@ -42,6 +59,7 @@ test('creates a custom model provider backed by local Ollama', async ({
   const {workspaceId, sessionToken} = await createReadyWorkspace({
     name: 'Agent Provider Create Workspace',
   });
+  const script = await createFakeProviderScript('create', 1);
 
   await customModelProviders.goto(workspaceId);
   const dialog = await customModelProviders.openCreateDialog();
@@ -49,7 +67,7 @@ test('creates a custom model provider backed by local Ollama', async ({
   await customModelProviders.fillProviderIdentity(dialog, {
     displayName: CREATE_PROVIDER_NAME,
     providerId: CREATE_PROVIDER_ID,
-    baseUrl: OLLAMA.openAiBaseUrl,
+    baseUrl: script.providerBaseUrl,
   });
   const discoveryResponse = page.waitForResponse(
     (response) =>
@@ -60,14 +78,14 @@ test('creates a custom model provider backed by local Ollama', async ({
   expect((await discoveryResponse).ok()).toBe(true);
 
   const defaultModelField = customModelProviders.defaultModelField(dialog);
-  const discoveredModelOption = customModelProviders.discoveredModelOption(dialog, OLLAMA_MODEL_ID);
+  const discoveredModelOption = customModelProviders.discoveredModelOption(dialog, FAKE_MODEL_ID);
   if ((await discoveredModelOption.count()) === 0) {
-    await customModelProviders.firstModelIdField(dialog).fill(OLLAMA_MODEL_ID);
-    await customModelProviders.firstModelLabelField(dialog).fill(OLLAMA_MODEL_ID);
+    await customModelProviders.firstModelIdField(dialog).fill(FAKE_MODEL_ID);
+    await customModelProviders.firstModelLabelField(dialog).fill(FAKE_MODEL_ID);
   }
-  await expect(defaultModelField).toContainText(OLLAMA_MODEL_ID);
+  await expect(defaultModelField).toContainText(FAKE_MODEL_ID);
 
-  await defaultModelField.selectOption(OLLAMA_MODEL_ID);
+  await defaultModelField.selectOption(FAKE_MODEL_ID);
   const saveResponse = page.waitForResponse(
     (response) =>
       response.url().includes('/agent/custom-model-providers') &&
@@ -89,7 +107,7 @@ test('creates a custom model provider backed by local Ollama', async ({
   });
 });
 
-test('edits an existing custom model provider and validates with local Ollama', async ({
+test('edits an existing custom model provider and validates the provider endpoint', async ({
   page,
   agent,
   customModelProviders,
@@ -98,7 +116,10 @@ test('edits an existing custom model provider and validates with local Ollama', 
   const {workspaceId, sessionToken} = await createReadyWorkspace({
     name: 'Agent Provider Edit Workspace',
   });
-  await agent.createOllamaCustomProvider({
+  const script = await createFakeProviderScript('edit', 2);
+  await agent.createOpenAiCompatibleCustomProvider({
+    baseUrl: script.providerBaseUrl,
+    model: FAKE_MODEL_ID,
     workspaceId,
     sessionToken,
     providerId: EDIT_PROVIDER_ID,
@@ -141,7 +162,10 @@ test('deletes an existing custom model provider', async ({
   const {workspaceId, sessionToken} = await createReadyWorkspace({
     name: 'Agent Provider Delete Workspace',
   });
-  await agent.createOllamaCustomProvider({
+  const script = await createFakeProviderScript('delete', 1);
+  await agent.createOpenAiCompatibleCustomProvider({
+    baseUrl: script.providerBaseUrl,
+    model: FAKE_MODEL_ID,
     workspaceId,
     sessionToken,
     providerId: DELETE_PROVIDER_ID,
@@ -159,3 +183,16 @@ test('deletes an existing custom model provider', async ({
   const configs = await agent.listModelProviderConfigs({workspaceId, sessionToken});
   expect(configs.configs.map((config) => config.provider_id)).not.toContain(DELETE_PROVIDER_ID);
 });
+
+async function createFakeProviderScript(
+  suffix: string,
+  validationResponses: number,
+): Promise<FakeOpenAiScriptHandle> {
+  if (!fakeProvider) throw new Error('Fake OpenAI provider did not start.');
+
+  return await fakeProvider.createScript({
+    id: `${suffix}-${crypto.randomUUID()}`,
+    model: FAKE_MODEL_ID,
+    responses: Array.from({length: validationResponses}, () => message('OK')),
+  });
+}

--- a/e2e/suites/flow/workflows/README.md
+++ b/e2e/suites/flow/workflows/README.md
@@ -104,7 +104,10 @@ localhost API and gitea URLs are correct for the standard dev stack.
 # 1. Infrastructure (postgres, temporal, garage, gitea)
 docker compose up -d            # Conductor worktrees: node dev/worktree-services.mjs up
 
-# 2. Start the API/client dev servers and run the suite.
+# 2. Local Ollama for the runner agent-step scenario.
+mise run ollama:up
+
+# 3. Start the API/client dev servers and run the suite.
 mise run e2e -- --filter=@shipfox/e2e-flow-workflows
 ```
 

--- a/e2e/suites/flow/workflows/scenarios/ollama-agent-step/expect.yaml
+++ b/e2e/suites/flow/workflows/scenarios/ollama-agent-step/expect.yaml
@@ -1,0 +1,11 @@
+trigger: push
+timeout_seconds: 180
+run:
+  status: succeeded
+jobs:
+  fix:
+    status: succeeded
+    steps:
+      ask-ollama:
+        status: succeeded
+        exit_code: 0

--- a/e2e/suites/flow/workflows/scenarios/ollama-agent-step/workflow.yml
+++ b/e2e/suites/flow/workflows/scenarios/ollama-agent-step/workflow.yml
@@ -1,0 +1,15 @@
+name: Ollama agent step
+runner: __RUNNER_LABEL__
+triggers:
+  on_push:
+    source: __GITEA_SOURCE__
+    event: push
+    filter: 'event.ref == "refs/heads/main" && event.repository.full_name == "__GITEA_REPOSITORY__"'
+jobs:
+  fix:
+    steps:
+      - key: ask-ollama
+        harness: pi
+        thinking: off
+        prompt: |
+          Reply with exactly: ollama-runner-step-ok

--- a/e2e/suites/flow/workflows/tests/global-setup.ts
+++ b/e2e/suites/flow/workflows/tests/global-setup.ts
@@ -1,5 +1,6 @@
-import {preflightCheck} from '@shipfox/e2e-core';
+import {createApiClient, preflightCheck} from '@shipfox/e2e-core';
 import {createConnectedOrg, deleteOrg} from '@shipfox/e2e-driver-gitea';
+import {createOllamaCustomProvider} from '@shipfox/e2e-setup-agent';
 import {createSession, createUser} from '@shipfox/e2e-setup-auth';
 import {createWorkspace} from '@shipfox/e2e-setup-workspaces';
 import {resetSuiteRunDir, writeSuiteContext} from '#suite-context.js';
@@ -27,6 +28,18 @@ export default async function globalSetup(): Promise<void> {
     });
     cleanups.push(() => deleteOrg({org: org.org}).catch(() => undefined));
 
+    const ollamaProvider = await createOllamaCustomProvider({
+      workspaceId: workspace.id,
+      sessionToken: session.token,
+      providerId: 'local-ollama-e2e',
+      displayName: 'Local Ollama E2E',
+    });
+    await setDefaultModelProvider({
+      workspaceId: workspace.id,
+      sessionToken: session.token,
+      providerId: ollamaProvider.provider_id,
+    });
+
     writeSuiteContext({
       runId,
       workspaceId: workspace.id,
@@ -41,4 +54,17 @@ export default async function globalSetup(): Promise<void> {
     }
     throw error;
   }
+}
+
+async function setDefaultModelProvider(params: {
+  workspaceId: string;
+  sessionToken: string;
+  providerId: string;
+}): Promise<void> {
+  const client = createApiClient({token: params.sessionToken});
+  await client.requestJson(
+    'put',
+    `/workspaces/${params.workspaceId}/agent/default-model-provider`,
+    {json: {provider_id: params.providerId}},
+  );
 }

--- a/e2e/suites/flow/workflows/tests/global-setup.ts
+++ b/e2e/suites/flow/workflows/tests/global-setup.ts
@@ -1,6 +1,6 @@
 import {createApiClient, preflightCheck} from '@shipfox/e2e-core';
 import {createConnectedOrg, deleteOrg} from '@shipfox/e2e-driver-gitea';
-import {createOllamaCustomProvider} from '@shipfox/e2e-setup-agent';
+import {createOllamaCustomProvider, deleteModelProviderConfig} from '@shipfox/e2e-setup-agent';
 import {createSession, createUser} from '@shipfox/e2e-setup-auth';
 import {createWorkspace} from '@shipfox/e2e-setup-workspaces';
 import {resetSuiteRunDir, writeSuiteContext} from '#suite-context.js';
@@ -34,6 +34,13 @@ export default async function globalSetup(): Promise<void> {
       providerId: 'local-ollama-e2e',
       displayName: 'Local Ollama E2E',
     });
+    cleanups.push(() =>
+      deleteModelProviderConfig({
+        workspaceId: workspace.id,
+        sessionToken: session.token,
+        providerId: ollamaProvider.provider_id,
+      }).catch(() => undefined),
+    );
     await setDefaultModelProvider({
       workspaceId: workspace.id,
       sessionToken: session.token,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,6 +280,9 @@ importers:
       '@shipfox/vitest':
         specifier: workspace:*
         version: link:../../../tools/vitest
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
 
   e2e/drivers/gitea:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -812,6 +812,9 @@ importers:
       '@shipfox/e2e-core':
         specifier: workspace:*
         version: link:../../../core
+      '@shipfox/e2e-driver-agent-provider':
+        specifier: workspace:*
+        version: link:../../../drivers/agent-provider
       '@shipfox/e2e-kit':
         specifier: workspace:*
         version: link:../../../kit


### PR DESCRIPTION
Add a child-process lifecycle wrapper for the deterministic fake OpenAI provider driver.

Flow E2E suites need the fake provider to outlive Playwright global setup so runner jobs can call it later from worker processes. This adds a public `startFakeOpenAiProvider()` handle, a sidecar entrypoint, persisted run state for teardown, and lifecycle coverage for both handle-based and state-file-based shutdown.

The provider still stays outside product API modules; suites register its script URL as a normal OpenAI-compatible custom provider.

Closes ENG-855

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a child-process sidecar and lifecycle handle for the deterministic fake OpenAI provider so E2E suites can keep it alive across Playwright global setup and worker jobs. Also adds a models endpoint, switches the client custom-provider E2E to this fake provider, and adds a runner scenario that validates an Ollama agent step. Addresses ENG-855.

- **New Features**
  - Public `startFakeOpenAiProvider()`/`stopFakeOpenAiProvider()` to spawn/kill the sidecar and persist run state at `.context/e2e-agent-provider/<runId>.json`.
  - Hardened lifecycle: JSON readiness on stdout and `/healthz`, request/health timeouts, resolves built `dist/sidecar.js`, idempotent PID signaling, cleanup on state-write failure.
  - OpenAI-compatible `GET /scripts/:id/v1/models`; the client agent custom-provider E2E now uses the fake provider from `@shipfox/e2e-driver-agent-provider`.
  - Flow runner coverage: adds an Ollama agent-step scenario; global setup creates a local Ollama custom provider, sets it as default, and cleans it up on failure.
  - Exports `message()`/`toolCall()`, provider/script/handle types; adds lifecycle tests, README usage; adds `tsx`. Also exposes `deleteModelProviderConfig()` in setup helpers.

- **Migration**
  - In E2E: call `startFakeOpenAiProvider({runId})` in `globalSetup`, create a script via `createScript()`, and use its `providerBaseUrl` as your OpenAI-compatible provider.
  - Teardown with `provider.stop()` or `stopFakeOpenAiProvider({runId})` if you only have persisted state; ensure `.context/e2e-agent-provider/` is writable in CI.
  - For the runner Ollama step, start a local Ollama instance before tests and ensure a default provider is set.

<sup>Written for commit f12078f5d02983e3f843e653a539906d1f15dbd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

