### PR TITLE
[workflow] Carry agent step tools through persistence

### DIFF
--- a/libs/api/agent-dto/src/schemas/materialized-agent-step-config.test.ts
+++ b/libs/api/agent-dto/src/schemas/materialized-agent-step-config.test.ts
@@ -7,6 +7,7 @@ describe('materializedAgentStepConfigSchema', () => {
       provider: 'anthropic',
       model: 'claude-opus-4-8',
       thinking: 'high',
+      tools: ['read', 'web_search'],
       prompt: 'Fix the failing tests.',
     });
 
@@ -15,6 +16,7 @@ describe('materializedAgentStepConfigSchema', () => {
       provider: 'anthropic',
       model: 'claude-opus-4-8',
       thinking: 'high',
+      tools: ['read', 'web_search'],
       prompt: 'Fix the failing tests.',
     });
   });
@@ -67,5 +69,19 @@ describe('materializedAgentStepConfigSchema', () => {
       thinking: 'high',
       prompt: 'Fix the failing tests.',
     });
+  });
+
+  it('rejects malformed tools', () => {
+    const emptyTools = () =>
+      materializedAgentStepConfigSchema.parse({
+        harness: 'pi',
+        provider: 'anthropic',
+        model: 'claude-opus-4-8',
+        thinking: 'high',
+        tools: [],
+        prompt: 'Fix the failing tests.',
+      });
+
+    expect(emptyTools).toThrow();
   });
 });

--- a/libs/api/agent-dto/src/schemas/materialized-agent-step-config.ts
+++ b/libs/api/agent-dto/src/schemas/materialized-agent-step-config.ts
@@ -8,6 +8,7 @@ export const materializedAgentStepConfigSchema = z
     provider: modelProviderRefSchema,
     model: z.string().min(1),
     thinking: agentThinkingSchema,
+    tools: z.array(z.string().min(1)).min(1).optional(),
     prompt: z.string(),
   })
   .strip();

--- a/libs/api/workflows/src/core/entities/step.ts
+++ b/libs/api/workflows/src/core/entities/step.ts
@@ -65,6 +65,7 @@ export interface StepConfigDispatchPlan {
     provider?: ResolvedField;
     harness?: Harness;
     thinking?: AgentThinking;
+    tools?: readonly string[];
   };
   trace?: readonly (StepConfigEvaluationTraceEntry | EvaluationTraceLimitEntry)[];
 }

--- a/libs/api/workflows/src/core/step-config/agent.ts
+++ b/libs/api/workflows/src/core/step-config/agent.ts
@@ -114,6 +114,7 @@ export function completeAgentConfig(params: {
   params.config.model = defaults.model;
   params.config.thinking = defaults.thinking;
   params.config.prompt = prompt;
+  if (agent.tools !== undefined) params.config.tools = [...agent.tools];
 }
 
 function completeAgentField(args: {
@@ -215,6 +216,7 @@ function authoredAgentStepConfig(
       ...(step.model === undefined ? {} : {model: step.model}),
       ...(step.harness === undefined ? {} : {harness: step.harness}),
       ...(step.thinking === undefined ? {} : {thinking: step.thinking}),
+      ...agentToolsConfig(step),
       prompt: step.prompt,
     },
     configPlan: null,
@@ -237,6 +239,7 @@ function deferredAgentStepConfig(
         ...(fields.provider === undefined ? {} : {provider: dispatchPlanField(fields.provider)}),
         ...(step.harness === undefined ? {} : {harness: step.harness}),
         ...(step.thinking === undefined ? {} : {thinking: step.thinking}),
+        ...agentToolsConfig(step),
       },
     },
     diagnostics: fields.diagnostics,
@@ -273,6 +276,7 @@ function agentStepConfigWithDefaults(
       configPlan: {
         agent: {
           prompt: dispatchPlanField(fields.prompt),
+          ...agentToolsConfig(step),
         },
       },
       diagnostics: fields.diagnostics,
@@ -288,6 +292,7 @@ function agentStepConfigWithDefaults(
       model: resolved.model,
       harness: resolved.harness,
       thinking: resolved.thinking,
+      ...agentToolsConfig(step),
       prompt: promptValue,
     },
     configPlan: null,
@@ -295,6 +300,12 @@ function agentStepConfigWithDefaults(
     trace: fields.trace,
     hasTemplates: fields.hasTemplates,
   };
+}
+
+function agentToolsConfig(
+  step: WorkflowModelAgentStep,
+): {readonly tools: readonly string[]} | Record<string, never> {
+  return step.tools === undefined ? {} : {tools: [...step.tools]};
 }
 
 function dispatchPlanField(field: FieldResolution): ResolvedField {

--- a/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
+++ b/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
@@ -179,6 +179,7 @@ describe('completeStepDispatchConfig', () => {
       configPlan: {
         agent: {
           harness: 'claude',
+          tools: ['Read', 'WebSearch'],
           prompt: plannedField(`Review ${template('steps.build.outputs.sha')}`),
         },
       },
@@ -197,6 +198,7 @@ describe('completeStepDispatchConfig', () => {
         provider: 'openai',
         model: 'gpt-5.5',
         thinking: 'off',
+        tools: ['Read', 'WebSearch'],
         prompt: 'Review abc123',
       },
       trace: [

--- a/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
@@ -260,6 +260,36 @@ describe('materializeWorkflowModel', () => {
     });
   });
 
+  it('materializes agent step tools into resolved config', () => {
+    const model = workflowModel({
+      jobs: {
+        fix: {
+          steps: [
+            {
+              harness: 'pi',
+              model: 'claude-opus-4-8',
+              provider: 'anthropic',
+              thinking: 'high',
+              tools: ['read', 'web_search'],
+              prompt: 'Fix the failing tests.',
+            },
+          ],
+        },
+      },
+    });
+
+    const rows = materializeWorkflowModel({model});
+
+    expect(rows[0]?.steps[1]?.config).toEqual({
+      harness: 'pi',
+      model: 'claude-opus-4-8',
+      provider: 'anthropic',
+      thinking: 'high',
+      tools: ['read', 'web_search'],
+      prompt: 'Fix the failing tests.',
+    });
+  });
+
   it('materializes provider-only agent steps with that provider catalog default model', () => {
     const model = workflowModel({
       jobs: {
@@ -687,8 +717,10 @@ describe('materializeWorkflowModel', () => {
         fix: {
           steps: [
             {
+              harness: 'claude',
               provider: template('trigger.source'),
               model: template('run.name'),
+              tools: ['Read', 'WebSearch'],
               prompt: `Fix ${template('run.id')}`,
             },
           ],
@@ -696,7 +728,7 @@ describe('materializeWorkflowModel', () => {
       },
     });
     const resolveAgentDefaults = vi.fn<AgentDefaultsResolver>().mockReturnValue({
-      harness: 'pi',
+      harness: 'claude',
       provider: 'openai',
       model: 'gpt-5.5-pro',
       thinking: 'medium',
@@ -713,23 +745,69 @@ describe('materializeWorkflowModel', () => {
     });
 
     expect(resolveAgentDefaults).toHaveBeenCalledWith({
-      harness: undefined,
+      harness: 'claude',
       provider: 'openai',
       model: 'gpt-5.5-pro',
       thinking: undefined,
     });
     expect(rows[0]?.steps[1]?.config).toEqual({
-      harness: 'pi',
+      harness: 'claude',
       provider: 'openai',
       model: 'gpt-5.5-pro',
       thinking: 'medium',
+      tools: ['Read', 'WebSearch'],
       prompt: 'Fix run-1',
     });
     expect(rows[0]?.steps[1]?.authoredConfig).toEqual({
+      harness: 'claude',
       provider: template('trigger.source'),
       model: template('run.name'),
+      tools: ['Read', 'WebSearch'],
       prompt: `Fix ${template('run.id')}`,
     });
+  });
+
+  it('keeps agent tools in the dispatch plan while config is deferred', () => {
+    const model = workflowModel({
+      jobs: {
+        fix: {
+          steps: [
+            {
+              harness: 'claude',
+              model: template('execution.events[0].data.model'),
+              provider: 'anthropic',
+              tools: ['Read', 'Grep'],
+              prompt: 'Review it.',
+            },
+          ],
+        },
+      },
+    });
+
+    const rows = materializeWorkflowModel({
+      model,
+      context: creationContext(),
+      definitionId: 'def-1',
+    });
+
+    expect(rows[0]?.steps[1]?.config).toEqual({});
+    expect(rows[0]?.steps[1]?.configPlan?.agent).toMatchObject({
+      harness: 'claude',
+      provider: {
+        segments: [{kind: 'literal', value: 'anthropic'}],
+      },
+      tools: ['Read', 'Grep'],
+      prompt: {
+        segments: [{kind: 'literal', value: 'Review it.'}],
+      },
+    });
+    expect(rows[0]?.steps[1]?.configPlan?.agent?.model?.segments).toEqual([
+      expect.objectContaining({
+        kind: 'deferred',
+        roots: ['execution'],
+        fillTarget: 'execution-creation',
+      }),
+    ]);
   });
 
   it('throws a permanent interpolation error for unsafe run interpolation', () => {

--- a/libs/api/workflows/src/db/workflow-runs.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs.test.ts
@@ -1323,14 +1323,22 @@ describe('workflow run queries', () => {
       expect(runJobs[0]?.dependencies).toEqual([]);
     });
 
-    test('stores prompt-only agent steps with runtime agent defaults resolved', async () => {
+    test('stores authored agent tools with runtime agent defaults resolved', async () => {
       const run = await createWorkflowRun({
         workspaceId,
         projectId,
         definitionId,
         model: buildModel({
           jobs: {
-            fix: {steps: [{prompt: 'Fix the failing tests.'}]},
+            fix: {
+              steps: [
+                {
+                  harness: 'pi',
+                  tools: ['read', 'web_search'],
+                  prompt: 'Fix the failing tests.',
+                },
+              ],
+            },
           },
         }),
         triggerPayload: {
@@ -1352,6 +1360,7 @@ describe('workflow run queries', () => {
           model: 'claude-opus-4-8',
           provider: 'anthropic',
           thinking: 'xhigh',
+          tools: ['read', 'web_search'],
           prompt: 'Fix the failing tests.',
         },
       });
@@ -1938,7 +1947,15 @@ jobs:
         definitionId,
         model: buildModel({
           jobs: {
-            fix: {steps: [{prompt: 'Fix the failing tests.'}]},
+            fix: {
+              steps: [
+                {
+                  harness: 'pi',
+                  tools: ['read', 'web_search'],
+                  prompt: 'Fix the failing tests.',
+                },
+              ],
+            },
           },
         }),
         triggerPayload: {
@@ -1972,6 +1989,7 @@ jobs:
         model: 'gpt-5.5-pro',
         provider: 'openai',
         thinking: 'medium',
+        tools: ['read', 'web_search'],
         prompt: 'Fix the failing tests.',
       });
     });

--- a/libs/api/workflows/test/factories/workflow-model.ts
+++ b/libs/api/workflows/test/factories/workflow-model.ts
@@ -9,6 +9,7 @@ import {
 
 type ModelStep = WorkflowModel['jobs'][number]['steps'][number];
 type AgentThinking = Extract<ModelStep, {kind: 'agent'}>['thinking'];
+type Harness = Extract<ModelStep, {kind: 'agent'}>['harness'];
 type WorkflowEnvTemplates = NonNullable<NonNullable<WorkflowModel['templates']>['env']>;
 
 interface TestWorkflowStepBase {
@@ -25,10 +26,12 @@ interface TestRunStep extends TestWorkflowStepBase {
 }
 
 interface TestAgentStep extends TestWorkflowStepBase {
+  readonly harness?: Harness | undefined;
   readonly model?: string | undefined;
   readonly provider?: string | undefined;
   readonly prompt: string;
   readonly thinking?: AgentThinking | undefined;
+  readonly tools?: readonly string[] | undefined;
 }
 
 type TestWorkflowStep = TestRunStep | TestAgentStep;
@@ -133,9 +136,11 @@ function normalizeStep(step: TestWorkflowStep, jobId: string, stepIndex: number)
     : {
         ...base,
         kind: 'agent',
+        ...(step.harness === undefined ? {} : {harness: step.harness}),
         ...(step.model === undefined ? {} : {model: step.model}),
         ...(step.provider === undefined ? {} : {provider: step.provider}),
         ...(step.thinking === undefined ? {} : {thinking: step.thinking}),
+        ...(step.tools === undefined ? {} : {tools: step.tools}),
         prompt: step.prompt,
         ...optionalAgentTemplates(step),
       };


### PR DESCRIPTION
Preserve step-level agent `tools` after workflow definition normalization by carrying them through workflow materialization, deferred dispatch completion, runtime config parsing, and rerun cloning.

Authors can now rely on selected tools being part of the persisted agent step audit contract instead of being stripped before runner dispatch. Existing steps that omit `tools` continue to use the current harness default behavior, and the scheduler path remains label-based only.

This intentionally stops at persistence/materialization; runner capability mismatch warnings and adapter pass-through are covered by follow-up Agent Step Tool Selection issues.

Closes ENG-837

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves selected agent step `tools` through persistence and execution planning so tool choices are stored and replayed. This meets ENG-837.

- **New Features**
  - Keep `tools` on agent steps across materialization, deferred dispatch plans, runtime config parsing, and reruns.
  - Schema now accepts an optional, non-empty `tools` array; empty arrays are rejected.
  - No change for steps without `tools` and no scheduler changes; defaults still apply.

<sup>Written for commit 831e47d01de76b48ffc65de0585c3f9de9befd86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

