### PR TITLE
[api/integration] Add GitHub installation token provider

### DIFF
--- a/.changeset/steady-clouds-refresh.md
+++ b/.changeset/steady-clouds-refresh.md
@@ -1,5 +1,6 @@
 ---
+"@shipfox/api-integration-core-dto": patch
 "@shipfox/api-integration-github": patch
 ---
 
-Adds a shared GitHub installation token provider with broad REST minting, in-memory reuse, refresh-margin reminting, and single-flight dedupe.
+Adds a shared GitHub installation token provider with broad REST minting, in-memory reuse, refresh-margin reminting, single-flight dedupe, and a missing-installation provider error reason.

--- a/.changeset/steady-clouds-refresh.md
+++ b/.changeset/steady-clouds-refresh.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-integration-github": patch
+---
+
+Adds a shared GitHub installation token provider with broad REST minting, in-memory reuse, refresh-margin reminting, and single-flight dedupe.

--- a/libs/api/integration/core-dto/src/contracts/integrations.ts
+++ b/libs/api/integration/core-dto/src/contracts/integrations.ts
@@ -205,6 +205,7 @@ export interface RegisteredIntegrationProvider<
 
 export type IntegrationProviderErrorReason =
   | 'repository-not-found'
+  | 'installation-not-found'
   | 'file-not-found'
   | 'access-denied'
   | 'rate-limited'

--- a/libs/api/integration/github/src/api/client.ts
+++ b/libs/api/integration/github/src/api/client.ts
@@ -416,7 +416,10 @@ async function mapGithubOAuthError<T>(operation: () => Promise<T>): Promise<T> {
 
 export async function mapGithubError<T>(
   operation: () => Promise<T>,
-  notFoundReason: 'repository-not-found' | 'file-not-found' = 'repository-not-found',
+  notFoundReason:
+    | 'repository-not-found'
+    | 'installation-not-found'
+    | 'file-not-found' = 'repository-not-found',
 ): Promise<T> {
   try {
     return await operation();

--- a/libs/api/integration/github/src/api/client.ts
+++ b/libs/api/integration/github/src/api/client.ts
@@ -414,7 +414,7 @@ async function mapGithubOAuthError<T>(operation: () => Promise<T>): Promise<T> {
   }
 }
 
-async function mapGithubError<T>(
+export async function mapGithubError<T>(
   operation: () => Promise<T>,
   notFoundReason: 'repository-not-found' | 'file-not-found' = 'repository-not-found',
 ): Promise<T> {

--- a/libs/api/integration/github/src/api/installation-token-provider.test.ts
+++ b/libs/api/integration/github/src/api/installation-token-provider.test.ts
@@ -1,9 +1,17 @@
 import {GithubIntegrationProviderError} from '#core/errors.js';
 import {createGithubInstallationTokenProvider} from './installation-token-provider.js';
 
-const {appOptions, createInstallationAccessTokenMock} = vi.hoisted(() => ({
+const {appOptions, createInstallationAccessTokenMock, RequestErrorMock} = vi.hoisted(() => ({
   appOptions: [] as unknown[],
   createInstallationAccessTokenMock: vi.fn(),
+  RequestErrorMock: class RequestError extends Error {
+    constructor(
+      message: string,
+      public readonly status: number,
+    ) {
+      super(message);
+    }
+  },
 }));
 
 vi.mock('octokit', () => ({
@@ -21,7 +29,7 @@ vi.mock('octokit', () => ({
       return {defaults: options};
     },
   },
-  RequestError: class RequestError extends Error {},
+  RequestError: RequestErrorMock,
 }));
 
 describe('GithubInstallationTokenProvider', () => {
@@ -134,6 +142,17 @@ describe('GithubInstallationTokenProvider', () => {
         },
       }),
     ]);
+  });
+
+  it('maps missing installations to an installation-not-found provider error', async () => {
+    createInstallationAccessTokenMock.mockRejectedValue(new RequestErrorMock('Not Found', 404));
+    const provider = createGithubInstallationTokenProvider();
+
+    const result = provider.getInstallationAccessToken(1);
+
+    await expect(result).rejects.toMatchObject({
+      reason: 'installation-not-found',
+    });
   });
 
   it('rejects a response without a token', async () => {

--- a/libs/api/integration/github/src/api/installation-token-provider.test.ts
+++ b/libs/api/integration/github/src/api/installation-token-provider.test.ts
@@ -1,0 +1,165 @@
+import {GithubIntegrationProviderError} from '#core/errors.js';
+import {createGithubInstallationTokenProvider} from './installation-token-provider.js';
+
+const {appOptions, createInstallationAccessTokenMock} = vi.hoisted(() => ({
+  appOptions: [] as unknown[],
+  createInstallationAccessTokenMock: vi.fn(),
+}));
+
+vi.mock('octokit', () => ({
+  App: class App {
+    octokit = {
+      rest: {apps: {createInstallationAccessToken: createInstallationAccessTokenMock}},
+    };
+
+    constructor(options: unknown) {
+      appOptions.push(options);
+    }
+  },
+  Octokit: {
+    defaults(options: unknown) {
+      return {defaults: options};
+    },
+  },
+  RequestError: class RequestError extends Error {},
+}));
+
+describe('GithubInstallationTokenProvider', () => {
+  beforeEach(() => {
+    appOptions.length = 0;
+    createInstallationAccessTokenMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('mints a broad installation token on a cache miss', async () => {
+    createInstallationAccessTokenMock.mockResolvedValue({
+      data: {token: 'ghs_installationtoken', expires_at: '2026-06-10T12:00:00.000Z'},
+    });
+    const provider = createGithubInstallationTokenProvider();
+
+    const result = await provider.getInstallationAccessToken(1);
+
+    expect(result).toEqual({
+      token: 'ghs_installationtoken',
+      expiresAt: new Date('2026-06-10T12:00:00.000Z'),
+    });
+    expect(createInstallationAccessTokenMock).toHaveBeenCalledWith({
+      installation_id: 1,
+    });
+  });
+
+  it('returns a cached token without a second mint', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-10T11:00:00.000Z'));
+    createInstallationAccessTokenMock.mockResolvedValue({
+      data: {token: 'ghs_installationtoken', expires_at: '2026-06-10T12:00:00.000Z'},
+    });
+    const provider = createGithubInstallationTokenProvider();
+
+    const first = await provider.getInstallationAccessToken(1);
+    const second = await provider.getInstallationAccessToken(1);
+
+    expect(first).toEqual(second);
+    expect(createInstallationAccessTokenMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('mints a fresh token inside the expiry refresh margin', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-10T12:00:00.000Z'));
+    createInstallationAccessTokenMock
+      .mockResolvedValueOnce({
+        data: {token: 'ghs_first', expires_at: '2026-06-10T12:10:00.000Z'},
+      })
+      .mockResolvedValueOnce({
+        data: {token: 'ghs_second', expires_at: '2026-06-10T13:00:00.000Z'},
+      });
+    const provider = createGithubInstallationTokenProvider();
+
+    const first = await provider.getInstallationAccessToken(1);
+    vi.setSystemTime(new Date('2026-06-10T12:06:00.000Z'));
+    const second = await provider.getInstallationAccessToken(1);
+
+    expect(first.token).toBe('ghs_first');
+    expect(second.token).toBe('ghs_second');
+    expect(createInstallationAccessTokenMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('dedupes concurrent cold-cache mints for one installation', async () => {
+    let resolveMint: (
+      value: Awaited<ReturnType<typeof createInstallationAccessTokenMock>>,
+    ) => void = (_value) => {
+      throw new Error('Mint promise was not initialized');
+    };
+    createInstallationAccessTokenMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveMint = resolve;
+      }),
+    );
+    const provider = createGithubInstallationTokenProvider();
+
+    const first = provider.getInstallationAccessToken(1);
+    const second = provider.getInstallationAccessToken(1);
+    resolveMint({
+      data: {token: 'ghs_installationtoken', expires_at: '2026-06-10T12:00:00.000Z'},
+    });
+    const results = await Promise.all([first, second]);
+
+    expect(results).toEqual([
+      {token: 'ghs_installationtoken', expiresAt: new Date('2026-06-10T12:00:00.000Z')},
+      {token: 'ghs_installationtoken', expiresAt: new Date('2026-06-10T12:00:00.000Z')},
+    ]);
+    expect(createInstallationAccessTokenMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('configures throttle retry handlers on the mint octokit', async () => {
+    createInstallationAccessTokenMock.mockResolvedValue({
+      data: {token: 'ghs_installationtoken', expires_at: '2026-06-10T12:00:00.000Z'},
+    });
+    const provider = createGithubInstallationTokenProvider();
+
+    await provider.getInstallationAccessToken(1);
+
+    expect(appOptions).toEqual([
+      expect.objectContaining({
+        Octokit: {
+          defaults: {
+            throttle: {
+              onRateLimit: expect.any(Function),
+              onSecondaryRateLimit: expect.any(Function),
+            },
+          },
+        },
+      }),
+    ]);
+  });
+
+  it('rejects a response without a token', async () => {
+    createInstallationAccessTokenMock.mockResolvedValue({
+      data: {expires_at: '2026-06-10T12:00:00.000Z'},
+    });
+    const provider = createGithubInstallationTokenProvider();
+
+    const result = provider.getInstallationAccessToken(1);
+
+    await expect(result).rejects.toMatchObject({
+      reason: 'malformed-provider-response',
+    });
+    await expect(result).rejects.toBeInstanceOf(GithubIntegrationProviderError);
+  });
+
+  it('rejects a response with a missing or unparseable expiry', async () => {
+    createInstallationAccessTokenMock.mockResolvedValue({
+      data: {token: 'ghs_installationtoken'},
+    });
+    const provider = createGithubInstallationTokenProvider();
+
+    const result = provider.getInstallationAccessToken(1);
+
+    await expect(result).rejects.toMatchObject({
+      reason: 'malformed-provider-response',
+    });
+  });
+});

--- a/libs/api/integration/github/src/api/installation-token-provider.ts
+++ b/libs/api/integration/github/src/api/installation-token-provider.ts
@@ -36,10 +36,12 @@ class OctokitGithubInstallationTokenProvider implements GithubInstallationTokenP
   private async mintInstallationAccessToken(
     installationId: number,
   ): Promise<GithubInstallationAccessToken> {
-    const response = await mapGithubError(() =>
-      this.getApp().octokit.rest.apps.createInstallationAccessToken({
-        installation_id: installationId,
-      }),
+    const response = await mapGithubError(
+      () =>
+        this.getApp().octokit.rest.apps.createInstallationAccessToken({
+          installation_id: installationId,
+        }),
+      'installation-not-found',
     );
 
     if (typeof response.data.token !== 'string') {

--- a/libs/api/integration/github/src/api/installation-token-provider.ts
+++ b/libs/api/integration/github/src/api/installation-token-provider.ts
@@ -1,0 +1,134 @@
+import {App, Octokit} from 'octokit';
+import {config, normalizedGithubPrivateKey} from '#config.js';
+import {GithubIntegrationProviderError} from '#core/errors.js';
+import {type GithubInstallationAccessToken, mapGithubError} from './client.js';
+
+const TOKEN_REFRESH_MARGIN_MS = 5 * 60 * 1000;
+
+export interface GithubInstallationTokenProvider {
+  getInstallationAccessToken(installationId: number): Promise<GithubInstallationAccessToken>;
+}
+
+interface InstallationTokenCache {
+  getOrMint(
+    installationId: number,
+    mint: () => Promise<GithubInstallationAccessToken>,
+  ): Promise<GithubInstallationAccessToken>;
+}
+
+export function createGithubInstallationTokenProvider(): GithubInstallationTokenProvider {
+  return new OctokitGithubInstallationTokenProvider();
+}
+
+class OctokitGithubInstallationTokenProvider implements GithubInstallationTokenProvider {
+  private app: App | undefined;
+
+  constructor(
+    private readonly cache: InstallationTokenCache = new InMemoryInstallationTokenCache(),
+  ) {}
+
+  getInstallationAccessToken(installationId: number): Promise<GithubInstallationAccessToken> {
+    return this.cache.getOrMint(installationId, () =>
+      this.mintInstallationAccessToken(installationId),
+    );
+  }
+
+  private async mintInstallationAccessToken(
+    installationId: number,
+  ): Promise<GithubInstallationAccessToken> {
+    const response = await mapGithubError(() =>
+      this.getApp().octokit.rest.apps.createInstallationAccessToken({
+        installation_id: installationId,
+      }),
+    );
+
+    if (typeof response.data.token !== 'string') {
+      throw new GithubIntegrationProviderError(
+        'malformed-provider-response',
+        'GitHub installation access token response did not include a token',
+      );
+    }
+
+    const expiresAt = new Date(response.data.expires_at);
+    if (Number.isNaN(expiresAt.getTime())) {
+      throw new GithubIntegrationProviderError(
+        'malformed-provider-response',
+        'GitHub installation access token response did not include a valid expiry',
+      );
+    }
+
+    return {
+      token: response.data.token,
+      expiresAt,
+    };
+  }
+
+  private getApp(): App {
+    if (!this.app) {
+      this.app = new App({
+        appId: config.GITHUB_APP_ID,
+        privateKey: normalizedGithubPrivateKey(),
+        Octokit: Octokit.defaults({
+          throttle: {
+            onRateLimit: (
+              _retryAfter: number,
+              _options: unknown,
+              _octokit: unknown,
+              retryCount: number,
+            ) => retryCount === 0,
+            onSecondaryRateLimit: (
+              _retryAfter: number,
+              _options: unknown,
+              _octokit: unknown,
+              retryCount: number,
+            ) => retryCount === 0,
+          },
+        }),
+      });
+    }
+    return this.app;
+  }
+}
+
+class InMemoryInstallationTokenCache implements InstallationTokenCache {
+  private readonly tokens = new Map<number, GithubInstallationAccessToken>();
+  private readonly inFlightMints = new Map<number, Promise<GithubInstallationAccessToken>>();
+
+  constructor(
+    private readonly options: {
+      refreshMarginMs: number;
+      now: () => Date;
+    } = {
+      refreshMarginMs: TOKEN_REFRESH_MARGIN_MS,
+      now: () => new Date(),
+    },
+  ) {}
+
+  getOrMint(
+    installationId: number,
+    mint: () => Promise<GithubInstallationAccessToken>,
+  ): Promise<GithubInstallationAccessToken> {
+    const cached = this.tokens.get(installationId);
+    if (cached && !this.isInsideRefreshMargin(cached.expiresAt)) {
+      return Promise.resolve(cached);
+    }
+
+    const inFlightMint = this.inFlightMints.get(installationId);
+    if (inFlightMint) return inFlightMint;
+
+    const freshToken = mint()
+      .then((token) => {
+        this.tokens.set(installationId, token);
+        return token;
+      })
+      .finally(() => {
+        this.inFlightMints.delete(installationId);
+      });
+    this.inFlightMints.set(installationId, freshToken);
+    return freshToken;
+  }
+
+  private isInsideRefreshMargin(expiresAt: Date): boolean {
+    return expiresAt.getTime() <= this.options.now().getTime() + this.options.refreshMarginMs;
+  }
+}

--- a/libs/api/integration/github/src/index.ts
+++ b/libs/api/integration/github/src/index.ts
@@ -19,6 +19,10 @@ import {createGithubWebhookRoutes} from '#presentation/routes/webhooks.js';
 
 export type {GithubApiClient} from '#api/client.js';
 export {
+  createGithubInstallationTokenProvider,
+  type GithubInstallationTokenProvider,
+} from '#api/installation-token-provider.js';
+export {
   type GithubAgentToolCatalogEntry,
   type GithubAgentToolCategory,
   type GithubAgentToolId,


### PR DESCRIPTION
Add a server-side GitHub installation token provider for agent tools.

ENG-843 originally described per-tool-set scoped token minting, but the design review moved containment to gateway authorization. This PR implements the resilient token foundation instead: the provider mints broad installation tokens through the app-JWT REST endpoint, reuses them in process, refreshes before expiry, and deduplicates concurrent cold mints for the same installation.

The provider is exported but not wired into session dispatch yet. That keeps the broad token out of execution paths until ENG-848 enforces selected tool/method and per-call repository authorization. ENG-859 tracks the DB-backed cross-pod cache behind the same cache boundary.

Verified locally with branch-scoped build, test, and check runs before commit.

Closes ENG-843
Refs ENG-848
Refs ENG-859

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a server-side GitHub installation token provider that mints broad installation tokens, caches them in memory, refreshes before expiry, and deduplicates concurrent mints. Also maps missing installations to `installation-not-found` with a shared, exported `mapGithubError`, fulfilling ENG-843 and setting up ENG-848.

- **New Features**
  - Mints via GitHub App JWT using Octokit REST with rate-limit retry; maps 404 to `installation-not-found`.
  - In-process cache with a 5-minute refresh margin and single-flight dedupe per installation.
  - Exposes `createGithubInstallationTokenProvider` from `@shipfox/api-integration-github` and adds `installation-not-found` to `@shipfox/api-integration-core-dto`; not wired into session dispatch until ENG-848 (ENG-859 will add a cross-pod cache).

<sup>Written for commit 883f318bf2c38bf67839acb65e9768c784d9170b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

