### PR TITLE
[runner] Pass selected tools through harness adapters

### DIFF
--- a/libs/runner/agent/src/core/claude-adapter.test.ts
+++ b/libs/runner/agent/src/core/claude-adapter.test.ts
@@ -363,6 +363,20 @@ describe('claudeHarnessAdapter', () => {
     });
     const env = lastQueryOptions().env;
     expect(env.CLAUDE_CONFIG_DIR).toMatch(`${testCwd}/logs/claude-config-`);
+    expect(lastQueryOptions()).not.toHaveProperty('tools');
+  });
+
+  it('passes selected Claude tool names through unchanged', async () => {
+    queryMock.mockReturnValue(makeQuery([successMessage]));
+
+    await claudeHarnessAdapter.run(invocation({tools: ['Read', 'Grep', 'WebSearch']}));
+
+    expect(queryMock).toHaveBeenCalledWith({
+      prompt: expect.any(Object),
+      options: expect.objectContaining({
+        tools: ['Read', 'Grep', 'WebSearch'],
+      }),
+    });
   });
 
   it('does not spawn Claude when already aborted', async () => {

--- a/libs/runner/agent/src/core/claude-adapter.ts
+++ b/libs/runner/agent/src/core/claude-adapter.ts
@@ -44,6 +44,7 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
     provider,
     thinking,
     prompt,
+    tools,
     credentials,
     customProvider,
     gitConfigGlobal,
@@ -108,7 +109,7 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
         thinking: {type: 'adaptive'},
         effort: thinking as EffortLevel,
         abortController: controller,
-        ...(override !== undefined ? {tools: []} : {}),
+        ...claudeToolsOption(tools, override),
         env: claudeEnvironment(auth, configDir, gitConfigGlobal, override),
         ...(useOutputTools
           ? {
@@ -164,6 +165,14 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
   }
 
   throw new Error('Claude agent did not emit a result message.');
+}
+
+function claudeToolsOption(
+  tools: readonly string[] | undefined,
+  override: ClaudeAnthropicOverride | undefined,
+): {readonly tools?: string[]} {
+  if (tools !== undefined) return {tools: [...tools]};
+  return override === undefined ? {} : {tools: []};
 }
 
 function setOutputTool(collector: OutputCollector) {

--- a/libs/runner/agent/src/core/harness.ts
+++ b/libs/runner/agent/src/core/harness.ts
@@ -9,6 +9,7 @@ export interface HarnessInvocation {
   readonly provider: string;
   readonly thinking: string;
   readonly prompt: string;
+  readonly tools?: readonly string[] | undefined;
   readonly outputs?: OutputDeclarations | undefined;
   readonly credentials: Record<string, string>;
   readonly customProvider?: CustomModelProviderRuntimeConfigDto | undefined;

--- a/libs/runner/agent/src/core/pi-adapter.test.ts
+++ b/libs/runner/agent/src/core/pi-adapter.test.ts
@@ -189,6 +189,21 @@ describe('piHarnessAdapter', () => {
     );
   });
 
+  it('passes selected Pi tool names through unchanged', async () => {
+    await piHarnessAdapter.run(invocation({tools: ['read', 'web_search', 'fetch_content']}));
+
+    expect(createAgentSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({tools: ['read', 'web_search', 'fetch_content']}),
+    );
+  });
+
+  it('omits the Pi tools option when no tools are selected', async () => {
+    await piHarnessAdapter.run(invocation());
+
+    const options = createAgentSessionMock.mock.calls[0]?.[0];
+    expect(options).not.toHaveProperty('tools');
+  });
+
   it('preserves the final assistant response when required outputs stay missing', async () => {
     const model = {provider: 'anthropic', id: 'claude-opus-4-8'};
     findMock.mockReturnValue(model);

--- a/libs/runner/agent/src/core/pi-adapter.ts
+++ b/libs/runner/agent/src/core/pi-adapter.ts
@@ -54,6 +54,7 @@ async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult>
     provider,
     thinking,
     prompt,
+    tools,
     credentials,
     customProvider,
     gitConfigGlobal,
@@ -103,6 +104,7 @@ async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult>
     services,
     model,
     thinkingLevel: thinking as PiThinkingLevel,
+    ...(tools === undefined ? {} : {tools: [...tools]}),
     customTools: [setOutputTool(collector)],
     // Keep the session JSONL inside the job workspace so it forwards from a deterministic path
     // and is cleaned up with the workspace; pi's default lives under ~/.pi, outside it.

--- a/libs/runner/agent/src/core/step.test.ts
+++ b/libs/runner/agent/src/core/step.test.ts
@@ -108,6 +108,18 @@ describe('executeAgentStep', () => {
     );
   });
 
+  it('forwards selected tools to the agent invocation unchanged', async () => {
+    runAgentMock.mockResolvedValue({});
+
+    await executeAgentStep(buildAgentStep({config: {prompt: 'p', tools: ['read', 'web_search']}}), {
+      runtime: RUNTIME,
+    });
+
+    expect(runAgentMock).toHaveBeenCalledWith(
+      expect.objectContaining({tools: ['read', 'web_search']}),
+    );
+  });
+
   it('forwards custom provider runtime config to the agent invocation', async () => {
     runAgentMock.mockResolvedValue({});
     const customProvider = {
@@ -251,6 +263,26 @@ describe('executeAgentStep', () => {
     expect(result.success).toBe(false);
     expect(result.error?.reason).toBe('agent_config_invalid');
     expect(result.error?.agent_config_issue).toBe('step_config_invalid');
+    expect(runAgentMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['non-array tools', {prompt: 'p', tools: 'read'}],
+    ['empty tools', {prompt: 'p', tools: []}],
+    ['non-string tool', {prompt: 'p', tools: ['read', 1]}],
+    ['empty tool name', {prompt: 'p', tools: ['read', '']}],
+  ])('fails with agent_config_invalid for %s', async (_name, config) => {
+    const result = await executeAgentStep(buildAgentStep({config}), {runtime: RUNTIME});
+
+    expect(result).toEqual({
+      success: false,
+      error: {
+        message: 'Agent step config has invalid tools.',
+        reason: 'agent_config_invalid',
+        agent_config_issue: 'step_config_invalid',
+      },
+      exit_code: null,
+    });
     expect(runAgentMock).not.toHaveBeenCalled();
   });
 

--- a/libs/runner/agent/src/core/step.ts
+++ b/libs/runner/agent/src/core/step.ts
@@ -42,6 +42,16 @@ export function executeAgentStep(
       ),
     );
   }
+  const tools = toolsFromConfig(step.config.tools);
+  if (tools === 'invalid') {
+    return Promise.resolve(
+      agentFailure(
+        'Agent step config has invalid tools.',
+        'agent_config_invalid',
+        'step_config_invalid',
+      ),
+    );
+  }
 
   return runSelectedHarness({
     cwd: options.cwd ?? process.cwd(),
@@ -49,6 +59,7 @@ export function executeAgentStep(
     model: options.runtime.model,
     outputs: outputDeclarationsFromConfig(step.config.outputs),
     prompt,
+    tools,
     thinking: options.runtime.thinking,
     provider: options.runtime.provider,
     credentials: options.runtime.credentials,
@@ -65,6 +76,7 @@ async function runSelectedHarness(params: {
   model: string;
   outputs: OutputDeclarations | undefined;
   prompt: string;
+  tools: readonly string[] | undefined;
   thinking: string;
   provider: string;
   credentials: Record<string, string>;
@@ -79,6 +91,7 @@ async function runSelectedHarness(params: {
     model,
     outputs,
     prompt,
+    tools,
     thinking,
     provider,
     credentials,
@@ -97,6 +110,7 @@ async function runSelectedHarness(params: {
         provider,
         thinking,
         prompt,
+        ...(tools === undefined ? {} : {tools}),
         outputs,
         credentials,
         customProvider,
@@ -195,4 +209,11 @@ function outputDeclarationsFromConfig(value: unknown): OutputDeclarations | unde
     return undefined;
   }
   return value as OutputDeclarations;
+}
+
+function toolsFromConfig(value: unknown): readonly string[] | undefined | 'invalid' {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || value.length === 0) return 'invalid';
+  if (value.some((tool) => typeof tool !== 'string' || tool === '')) return 'invalid';
+  return [...value];
 }


### PR DESCRIPTION
Pass selected agent step tools through the runner harness invocation.

Persisted `step.config.tools` now has a final runner-side shape check before adapter selection. Valid tool lists are forwarded unchanged to Pi and Claude SDK options, while malformed persisted config fails as a user-fixable `agent_config_invalid` step config error.

This keeps runner labels as the scheduling boundary: the runner only validates and invokes the already-selected harness, and omitted tools continue to use existing harness defaults.

No changeset is included because `@shipfox/runner-agent` is private.

Closes ENG-839

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass selected agent tool names from `step.config.tools` through the runner harness to Pi and Claude unchanged. Invalid tool lists now fail with `agent_config_invalid` at the runner boundary, closing ENG-839.

- **New Features**
  - Validate `step.config.tools`: must be a non-empty array of non-empty strings; otherwise `agent_config_invalid` with `step_config_invalid`.
  - Forward tools unchanged to Pi and Claude SDK options; omit when not set.
  - Keep runner labels as the scheduling boundary; the runner only validates and invokes the selected harness.

<sup>Written for commit 53e19997feb5d6b7f395085c92b1e5640c83b0a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

