### PR TITLE
Add fake provider diagnostics to flow suite

### DIFF
--- a/e2e/drivers/model-provider/README.md
+++ b/e2e/drivers/model-provider/README.md
@@ -48,3 +48,5 @@ POST /scripts/:scriptId/v1/chat/completions
 
 Scripts advance one response per provider request. Exhausted scripts return
 `409 script_exhausted`; assertion failures return `422 script_assertion_failed`.
+Assertions can set `minRequestIndex` when setup probes should use the script before
+scenario-only request assertions apply.

--- a/e2e/drivers/model-provider/src/scripts.ts
+++ b/e2e/drivers/model-provider/src/scripts.ts
@@ -24,7 +24,7 @@ export type FakeOpenAiResponse =
       message: string;
     };
 
-export type FakeOpenAiRequestAssertion =
+export type FakeOpenAiRequestAssertion = (
   | {
       kind: 'model';
       equals: string;
@@ -32,7 +32,8 @@ export type FakeOpenAiRequestAssertion =
   | {
       kind: 'tool_present';
       name: string;
-    };
+    }
+) & {minRequestIndex?: number | undefined};
 
 export interface FakeOpenAiRecordedRequest {
   index: number;
@@ -108,7 +109,7 @@ export class FakeOpenAiScriptRegistry {
     const state = this.#scriptState(scriptId);
     const requestIndex = state.cursor;
     const summary = summarizeOpenAiRequest(request.body);
-    const assertionFailures = assertRequest(state.script.assertions ?? [], summary);
+    const assertionFailures = assertRequest(state.script.assertions ?? [], summary, requestIndex);
 
     if (assertionFailures.length > 0) {
       state.requests.push(
@@ -237,8 +238,13 @@ function messageRoles(messages: unknown): string[] {
 function assertRequest(
   assertions: FakeOpenAiRequestAssertion[],
   summary: OpenAiRequestSummary,
+  requestIndex: number,
 ): string[] {
   return assertions.flatMap((assertion) => {
+    if (assertion.minRequestIndex !== undefined && requestIndex < assertion.minRequestIndex) {
+      return [];
+    }
+
     if (assertion.kind === 'model' && summary.model !== assertion.equals) {
       return [`Expected model ${assertion.equals} but received ${summary.model ?? '<missing>'}`];
     }

--- a/e2e/drivers/model-provider/src/server.test.ts
+++ b/e2e/drivers/model-provider/src/server.test.ts
@@ -280,6 +280,40 @@ describe('fake OpenAI model provider server', () => {
     });
   });
 
+  it('can apply request assertions after a setup probe', async () => {
+    await postScript(
+      server,
+      fakeScript({
+        id: 'deferred-assertions',
+        assertions: [{kind: 'tool_present', name: 'set_output', minRequestIndex: 1}],
+        responses: [
+          {kind: 'message', content: 'probe-ok'},
+          {kind: 'message', content: 'workflow-ok'},
+        ],
+      }),
+    );
+
+    const probeResult = await chatCompletion(server, 'deferred-assertions', {
+      model: 'deterministic-output-agent',
+      messages: [{role: 'user'}],
+      tools: [],
+    });
+    const workflowResult = await chatCompletion(server, 'deferred-assertions', {
+      model: 'deterministic-output-agent',
+      messages: [{role: 'user'}],
+      tools: [],
+    });
+
+    expect(probeResult.status).toBe(200);
+    expect(workflowResult.status).toBe(422);
+    await expect(workflowResult.json()).resolves.toEqual({
+      error: {
+        message: 'Expected tool set_output to be present',
+        type: 'script_assertion_failed',
+      },
+    });
+  });
+
   it('records request diagnostics and clears them on reset', async () => {
     await postScript(
       server,

--- a/e2e/suites/flow/workflows/README.md
+++ b/e2e/suites/flow/workflows/README.md
@@ -19,6 +19,7 @@ scenarios/hello-world/
   workflow.yml    pushed verbatim to .shipfox/workflows/hello-world.yml
   expect.yaml     declarative expectations (run/job/step status, job status reason, step error, exit code, logs)
   reject.yaml     alternative to expect.yaml for authoring-time rejection scenarios
+  model-provider.yaml optional fake model-provider script metadata
   secrets.yaml    optional E2E setup secrets to seed before the run
   files/          optional extra repo files, committed alongside the workflow
 ```
@@ -78,6 +79,26 @@ Assertions that are only observable inside the runner (checkout contents, env
 propagation) are written as self-asserting `run` steps in the workflow itself; the
 manifest then only asserts the run succeeded.
 
+### model-provider.yaml
+
+Use `model-provider.yaml` only for scenarios backed by the deterministic
+`@shipfox/e2e-driver-model-provider` sidecar:
+
+```yaml
+script_key: agent-output-tool
+```
+
+`globalSetup` starts the sidecar, creates known scenario scripts, and writes a
+`script_key` to script id map into the suite context. `runScenario` uses that map to
+attach `GET /scripts/:scriptId/requests` to failing Playwright results. The attachment
+contains each provider request's index, model, advertised tools, message roles, served
+response, and assertion failures.
+
+The flow suite uses the fake provider for `agent-output-tool` output-plumbing coverage.
+The script is registered as a normal `openai-completions` custom provider through the
+product HTTP route; the API has no `/__e2e` fake-provider control surface. Required
+script assertions are the deterministic model name and `set_output` tool presence.
+
 ### reject.yaml
 
 Use `reject.yaml` instead of `expect.yaml` when the workflow must be rejected during
@@ -104,7 +125,7 @@ localhost API and gitea URLs are correct for the standard dev stack.
 # 1. Infrastructure (postgres, temporal, garage, gitea)
 docker compose up -d            # Conductor worktrees: node dev/worktree-services.mjs up
 
-# 2. Local Ollama for the runner agent-step scenario.
+# 2. Local Ollama for the single Ollama-backed runner agent-step scenario.
 mise run ollama:up
 
 # 3. Start the API/client dev servers and run the suite.

--- a/e2e/suites/flow/workflows/scenarios/agent-output-tool/expect.yaml
+++ b/e2e/suites/flow/workflows/scenarios/agent-output-tool/expect.yaml
@@ -1,4 +1,4 @@
-trigger: push
+trigger: manual
 timeout_seconds: 180
 run:
   status: succeeded

--- a/e2e/suites/flow/workflows/scenarios/agent-output-tool/model-provider.yaml
+++ b/e2e/suites/flow/workflows/scenarios/agent-output-tool/model-provider.yaml
@@ -1,0 +1,1 @@
+script_key: agent-output-tool

--- a/e2e/suites/flow/workflows/scenarios/agent-output-tool/workflow.yml
+++ b/e2e/suites/flow/workflows/scenarios/agent-output-tool/workflow.yml
@@ -1,10 +1,9 @@
 name: __MODEL_PROVIDER__
 runner: __RUNNER_LABEL__
 triggers:
-  on_push:
-    source: __GITEA_SOURCE__
-    event: push
-    filter: 'event.ref == "refs/heads/main" && event.repository.full_name == "__GITEA_REPOSITORY__"'
+  manual:
+    source: manual
+    event: fire
 jobs:
   fix:
     steps:

--- a/e2e/suites/flow/workflows/src/run-scenario.ts
+++ b/e2e/suites/flow/workflows/src/run-scenario.ts
@@ -260,7 +260,7 @@ export async function runScenario(params: RunScenarioParams): Promise<Mismatch[]
       });
       for (const log of fetchedLogs) await params.attach(log);
       if (runnerLogFile !== undefined) await attachLocalRunnerLog(params.attach, runnerLogFile);
-      await attachFakeModelProviderRequests({attach: params.attach, scenario, suite});
+      await attachFakeModelProviderRequestsBestEffort({attach: params.attach, scenario, suite});
       if (webhookDiagnostics !== undefined) {
         await attachWebhookTriggerDiagnostics({
           attach: params.attach,
@@ -293,7 +293,7 @@ export async function runScenario(params: RunScenarioParams): Promise<Mismatch[]
       });
     }
     if (runnerLogFile !== undefined) await attachLocalRunnerLog(params.attach, runnerLogFile);
-    await attachFakeModelProviderRequests({attach: params.attach, scenario, suite});
+    await attachFakeModelProviderRequestsBestEffort({attach: params.attach, scenario, suite});
     throw error;
   } finally {
     if (runner !== undefined) {
@@ -302,6 +302,18 @@ export async function runScenario(params: RunScenarioParams): Promise<Mismatch[]
       });
     }
   }
+}
+
+async function attachFakeModelProviderRequestsBestEffort(params: {
+  attach: (attachment: Attachment) => Promise<void>;
+  scenario: Scenario;
+  suite: SuiteContext;
+}): Promise<void> {
+  await attachFakeModelProviderRequests(params).catch((error: unknown) => {
+    process.stderr.write(
+      `platform-e2e: attachFakeModelProviderRequests failed: ${String(error)}\n`,
+    );
+  });
 }
 
 async function attachFakeModelProviderRequests(params: {

--- a/e2e/suites/flow/workflows/src/run-scenario.ts
+++ b/e2e/suites/flow/workflows/src/run-scenario.ts
@@ -1,5 +1,6 @@
 import {readFile} from 'node:fs/promises';
 import {createApiClient} from '@shipfox/e2e-core';
+import {readFakeOpenAiModelProviderState} from '@shipfox/e2e-driver-model-provider';
 import {type LocalRunnerHandle, stopLocalRunner} from '@shipfox/e2e-driver-runner-process';
 import {fetchStepLogs} from '@shipfox/e2e-observe-logs';
 import {createSecret} from '@shipfox/e2e-setup-secrets';
@@ -26,6 +27,7 @@ import {seedAndWaitForDefinition, seedWorkflowProject} from './workflow-project.
 
 const REJECTION_NO_RUN_TIMEOUT_MS = 15_000;
 const E2E_SECRET_ACTOR_ID = '11111111-1111-4111-8111-111111111111';
+const FAKE_MODEL_PROVIDER_REQUEST_TIMEOUT_MS = 5_000;
 
 export interface RunScenarioParams {
   scenario: Scenario;
@@ -258,6 +260,7 @@ export async function runScenario(params: RunScenarioParams): Promise<Mismatch[]
       });
       for (const log of fetchedLogs) await params.attach(log);
       if (runnerLogFile !== undefined) await attachLocalRunnerLog(params.attach, runnerLogFile);
+      await attachFakeModelProviderRequests({attach: params.attach, scenario, suite});
       if (webhookDiagnostics !== undefined) {
         await attachWebhookTriggerDiagnostics({
           attach: params.attach,
@@ -290,6 +293,7 @@ export async function runScenario(params: RunScenarioParams): Promise<Mismatch[]
       });
     }
     if (runnerLogFile !== undefined) await attachLocalRunnerLog(params.attach, runnerLogFile);
+    await attachFakeModelProviderRequests({attach: params.attach, scenario, suite});
     throw error;
   } finally {
     if (runner !== undefined) {
@@ -297,5 +301,91 @@ export async function runScenario(params: RunScenarioParams): Promise<Mismatch[]
         process.stderr.write(`platform-e2e: stopLocalRunner failed: ${String(error)}\n`);
       });
     }
+  }
+}
+
+async function attachFakeModelProviderRequests(params: {
+  attach: (attachment: Attachment) => Promise<void>;
+  scenario: Scenario;
+  suite: SuiteContext;
+}): Promise<void> {
+  const scriptKey = params.scenario.fakeModelProviderScriptKey;
+  if (scriptKey === undefined) return;
+
+  const scriptId = params.suite.fakeModelProviderScripts[scriptKey];
+  if (scriptId === undefined) {
+    await attachFakeModelProviderError({
+      attach: params.attach,
+      scenario: params.scenario.name,
+      message: `No fake model provider script is registered for key "${scriptKey}".`,
+    });
+    return;
+  }
+
+  try {
+    const state = await readFakeOpenAiModelProviderState({
+      runId: params.suite.fakeModelProviderRunId,
+    });
+    const response = await fetchWithTimeout(
+      `${state.baseUrl}/scripts/${encodeURIComponent(scriptId)}/requests`,
+      {
+        headers: {authorization: `Bearer ${state.adminToken}`},
+        timeoutMs: FAKE_MODEL_PROVIDER_REQUEST_TIMEOUT_MS,
+      },
+    );
+    const body = await response.text();
+    if (!response.ok)
+      throw new Error(`GET /scripts/${scriptId}/requests returned ${response.status}: ${body}`);
+
+    await params.attach({
+      name: `fake-model-provider-${params.scenario.name}.json`,
+      contentType: 'application/json',
+      body: formatJsonBody(body),
+    });
+  } catch (error) {
+    await attachFakeModelProviderError({
+      attach: params.attach,
+      scenario: params.scenario.name,
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+async function attachFakeModelProviderError(params: {
+  attach: (attachment: Attachment) => Promise<void>;
+  message: string;
+  scenario: string;
+}): Promise<void> {
+  await params.attach({
+    name: `fake-model-provider-${params.scenario}-error.txt`,
+    contentType: 'text/plain',
+    body: params.message,
+  });
+}
+
+function formatJsonBody(body: string): string {
+  try {
+    return JSON.stringify(JSON.parse(body), null, 2);
+  } catch {
+    return body;
+  }
+}
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit & {timeoutMs: number},
+): Promise<Response> {
+  const {timeoutMs, ...requestInit} = init;
+  const abortController = new AbortController();
+  const timer = setTimeout(() => abortController.abort(), timeoutMs);
+  try {
+    return await fetch(url, {...requestInit, signal: abortController.signal});
+  } catch (error) {
+    if (abortController.signal.aborted) {
+      throw new Error(`Fake model provider request timed out after ${timeoutMs}ms: ${url}`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
   }
 }

--- a/e2e/suites/flow/workflows/src/scenarios.test.ts
+++ b/e2e/suites/flow/workflows/src/scenarios.test.ts
@@ -56,6 +56,33 @@ describe('discoverScenarios', () => {
     }
   });
 
+  test('loads optional fake model provider script metadata', () => {
+    const root = createTempScenariosRoot();
+    try {
+      writeScenarioFile(root, 'with-model-provider', 'expect.yaml', 'run:\n  status: succeeded\n');
+      writeScenarioFile(
+        root,
+        'with-model-provider',
+        'workflow.yml',
+        'jobs:\n  build:\n    steps: []\n',
+      );
+      writeScenarioFile(
+        root,
+        'with-model-provider',
+        'model-provider.yaml',
+        'script_key: agent-output-tool\n',
+      );
+
+      const scenarios = discoverScenarios(root);
+
+      expect(scenarios[0]).toMatchObject({
+        fakeModelProviderScriptKey: 'agent-output-tool',
+      });
+    } finally {
+      rmSync(root, {recursive: true, force: true});
+    }
+  });
+
   test('loads directories that contain reject.yaml and workflow.yml', () => {
     const root = createTempScenariosRoot();
     try {

--- a/e2e/suites/flow/workflows/src/scenarios.ts
+++ b/e2e/suites/flow/workflows/src/scenarios.ts
@@ -20,6 +20,12 @@ const seededSecretsSchema = z
   })
   .strict();
 
+const modelProviderSchema = z
+  .object({
+    script_key: z.string().min(1),
+  })
+  .strict();
+
 export type SeededSecret = z.infer<typeof seededSecretSchema>;
 
 export interface ScenarioFile {
@@ -34,6 +40,7 @@ interface BaseScenario {
   workflowYaml: string;
   extraFiles: ScenarioFile[];
   seededSecrets: SeededSecret[];
+  fakeModelProviderScriptKey?: string | undefined;
 }
 
 export interface ExpectScenario extends BaseScenario {
@@ -82,6 +89,12 @@ function loadSeededSecrets(dir: string): SeededSecret[] {
   return seededSecretsSchema.parse(yaml.load(readFileSync(path, 'utf8'))).secrets;
 }
 
+function loadModelProviderScriptKey(dir: string): string | undefined {
+  const path = join(dir, 'model-provider.yaml');
+  if (!existsSync(path)) return undefined;
+  return modelProviderSchema.parse(yaml.load(readFileSync(path, 'utf8'))).script_key;
+}
+
 function loadScenario(root: string, name: string): Scenario {
   const dir = join(root, name);
   const workflowPath = requireScenarioFile(dir, name, 'workflow.yml');
@@ -101,6 +114,7 @@ function loadScenario(root: string, name: string): Scenario {
     workflowYaml: readFileSync(workflowPath, 'utf8'),
     extraFiles: readScenarioFiles(join(dir, 'files')),
     seededSecrets: loadSeededSecrets(dir),
+    fakeModelProviderScriptKey: loadModelProviderScriptKey(dir),
   };
 
   if (hasExpect) {

--- a/e2e/suites/flow/workflows/src/suite-context.ts
+++ b/e2e/suites/flow/workflows/src/suite-context.ts
@@ -17,6 +17,7 @@ export interface SuiteContext {
   modelProviderId: string;
   agentModel: string;
   fakeModelProviderRunId: string;
+  fakeModelProviderScripts: Record<string, string>;
 }
 
 const runDir = fileURLToPath(new URL('../.e2e-run/', import.meta.url));

--- a/e2e/suites/flow/workflows/tests/global-setup.ts
+++ b/e2e/suites/flow/workflows/tests/global-setup.ts
@@ -45,7 +45,10 @@ export default async function globalSetup(): Promise<void> {
         toolCall('set_output', {key: 'message', value: 'qwen-tool-output-ok'}),
         message('done'),
       ],
-      assertions: [{kind: 'model', equals: DETERMINISTIC_AGENT_MODEL}],
+      assertions: [
+        {kind: 'model', equals: DETERMINISTIC_AGENT_MODEL},
+        {kind: 'tool_present', name: 'set_output', minRequestIndex: 1},
+      ],
     });
     const modelProvider = await createOpenAiCompatibleCustomProvider({
       workspaceId: workspace.id,
@@ -93,6 +96,7 @@ export default async function globalSetup(): Promise<void> {
       modelProviderId: modelProvider.provider_id,
       agentModel: modelProviderScript.model,
       fakeModelProviderRunId: runId,
+      fakeModelProviderScripts: {'agent-output-tool': modelProviderScript.id},
     });
   } catch (error) {
     for (const cleanup of cleanups.reverse()) {


### PR DESCRIPTION
Add opt-in fake model-provider request diagnostics to the flow workflow suite.

The deterministic agent-output-tool scenario can now declare its fake-provider script metadata, and failing runs attach the provider's recorded requests to the Playwright result. This makes runner/provider request-shape failures diagnosable from CI artifacts without adding an API-owned fake-provider control surface.

The model-provider driver also supports deferring request assertions until after setup probes, so the scenario can require the deterministic model and set_output tool while still passing custom-provider registration validation.

The existing single Ollama-backed flow scenario remains in place for harness coverage; this PR only removes Ollama from the deterministic output-tool diagnostic path.

Closes ENG-858

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in fake model-provider diagnostics to the flow E2E suite so CI artifacts include provider request logs on failures. Defers assertions until after setup probes, makes diagnostics attachment best-effort with a timeout, and switches the deterministic agent-output-tool scenario to a manual trigger to avoid seed push consuming scripted responses; addresses ENG-858.

- New Features
  - Scenarios can add `model-provider.yaml` with a `script_key` to opt into `@shipfox/e2e-driver-model-provider`.
  - Fake provider supports `minRequestIndex` to defer request assertions until after setup probes.
  - Global setup seeds the deterministic script and exposes a `script_key -> script_id` map in suite context.
  - On failure, `runScenario` attaches `GET /scripts/:id/requests` JSON to Playwright results.

- Bug Fixes
  - Diagnostics attachment is best-effort with a 5s timeout; on error, attach a text error and log to stderr.
  - The `agent-output-tool` scenario is now manual-triggered to keep seed pushes from consuming scripted responses.

<sup>Written for commit 8e1de28d1b22eff9c146101c5071e0729d6b830f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

