### PR TITLE
[runner] Set GitHub App bot author for Git

### DIFF
--- a/apps/api/.env
+++ b/apps/api/.env
@@ -50,6 +50,7 @@ INTEGRATIONS_ENABLE_GITHUB_PROVIDER=false
 # GITHUB_APP_CLIENT_SECRET=
 # GITHUB_APP_WEBHOOK_SECRET=
 # GITHUB_APP_SLUG=
+# GITHUB_APP_USERNAME=
 # Generate a random secret for the GitHub install state secret. `openssl rand -hex 32`
 # GITHUB_INSTALL_STATE_SECRET=
 

--- a/libs/api/integration/core-dto/src/contracts/integrations.ts
+++ b/libs/api/integration/core-dto/src/contracts/integrations.ts
@@ -87,6 +87,11 @@ export interface CheckoutCredentials {
   expiresAt: Date;
 }
 
+export interface CheckoutGitAuthor {
+  name: string;
+  email: string;
+}
+
 export interface CheckoutPermissions {
   contents: 'read' | 'write';
 }
@@ -101,6 +106,7 @@ export interface CheckoutSpec {
   repositoryUrl: string;
   ref: string;
   credentials?: CheckoutCredentials | undefined;
+  gitAuthor?: CheckoutGitAuthor | undefined;
 }
 
 export interface CreateCheckoutSpecInput<

--- a/libs/api/integration/github/src/config.ts
+++ b/libs/api/integration/github/src/config.ts
@@ -19,6 +19,10 @@ export const config = createConfig({
   GITHUB_APP_SLUG: str({
     desc: 'URL slug of the GitHub App, used to build install and callback links. Required.',
   }),
+  GITHUB_APP_USERNAME: str({
+    desc: 'GitHub App username used as the Git commit author when checkout credentials are persisted. Set this to the app username, such as my-app. The [bot] suffix is added automatically. Leave blank to keep Git author identity unset.',
+    default: '',
+  }),
   GITHUB_INSTALL_STATE_SECRET: str({
     desc: 'Secret used to sign the state token that protects the GitHub App install flow. Required.',
   }),

--- a/libs/api/integration/github/src/config.ts
+++ b/libs/api/integration/github/src/config.ts
@@ -20,8 +20,8 @@ export const config = createConfig({
     desc: 'URL slug of the GitHub App, used to build install and callback links. Required.',
   }),
   GITHUB_APP_USERNAME: str({
-    desc: 'GitHub App username used as the Git commit author when checkout credentials are persisted. Set this to the app username, such as my-app. The [bot] suffix is added automatically. Leave blank to keep Git author identity unset.',
-    default: '',
+    desc: 'GitHub App username used as the Git commit author when checkout credentials are persisted. Set this to the app username, such as my-app. The [bot] suffix is added automatically. Leave unset to keep Git author identity unset.',
+    default: undefined,
   }),
   GITHUB_INSTALL_STATE_SECRET: str({
     desc: 'Secret used to sign the state token that protects the GitHub App install flow. Required.',

--- a/libs/api/integration/github/src/core/source-control.test.ts
+++ b/libs/api/integration/github/src/core/source-control.test.ts
@@ -267,6 +267,10 @@ describe('GithubSourceControlProvider', () => {
         token: 'ghs_installationtoken',
         expiresAt: new Date('2026-06-10T12:00:00.000Z'),
       },
+      gitAuthor: {
+        name: 'shipfox-test[bot]',
+        email: '1+shipfox-test[bot]@users.noreply.github.com',
+      },
     });
     expect(result.repositoryUrl).not.toContain('ghs_installationtoken');
     expect(github.createInstallationAccessToken).toHaveBeenCalledWith({

--- a/libs/api/integration/github/src/core/source-control.ts
+++ b/libs/api/integration/github/src/core/source-control.ts
@@ -18,12 +18,14 @@ import {
   type SourceControlProvider,
 } from '@shipfox/api-integration-core-dto';
 import type {GithubApiClient, GithubRepository} from '#api/client.js';
+import {config} from '#config.js';
 import {getGithubInstallationByConnectionId} from '#db/installations.js';
 import {GithubIntegrationProviderError} from './errors.js';
 
 type GithubIntegrationConnection = IntegrationConnection<'github'>;
 
 const GITHUB_PROVIDER = 'github';
+const GITHUB_APP_BOT_SUFFIX = '[bot]';
 const SEARCH_PAGE_SIZE = 100;
 const SEARCH_MAX_PAGES_PER_REQUEST = 5;
 
@@ -153,11 +155,13 @@ export class GithubSourceControlProvider
       repositoryId,
       permissions: input.permissions,
     });
+    const gitAuthor = githubAppGitAuthor();
 
     return {
       repositoryUrl: repository.cloneUrl,
       ref,
       credentials: {username: 'x-access-token', token, expiresAt},
+      ...(gitAuthor ? {gitAuthor} : {}),
     };
   }
 
@@ -172,6 +176,15 @@ export class GithubSourceControlProvider
 
     return Number.parseInt(installation.installationId, 10);
   }
+}
+
+function githubAppGitAuthor(): CheckoutSpec['gitAuthor'] {
+  const appUsername = config.GITHUB_APP_USERNAME.trim();
+  if (!appUsername) return undefined;
+  const name = appUsername.endsWith(GITHUB_APP_BOT_SUFFIX)
+    ? appUsername
+    : `${appUsername}${GITHUB_APP_BOT_SUFFIX}`;
+  return {name, email: `${config.GITHUB_APP_ID}+${name}@users.noreply.github.com`};
 }
 
 function toRepositorySnapshot(repository: GithubRepository): RepositorySnapshot {

--- a/libs/api/integration/github/src/core/source-control.ts
+++ b/libs/api/integration/github/src/core/source-control.ts
@@ -179,7 +179,7 @@ export class GithubSourceControlProvider
 }
 
 function githubAppGitAuthor(): CheckoutSpec['gitAuthor'] {
-  const appUsername = config.GITHUB_APP_USERNAME.trim();
+  const appUsername = config.GITHUB_APP_USERNAME?.trim();
   if (!appUsername) return undefined;
   const name = appUsername.endsWith(GITHUB_APP_BOT_SUFFIX)
     ? appUsername

--- a/libs/api/integration/github/test/env.ts
+++ b/libs/api/integration/github/test/env.ts
@@ -11,4 +11,5 @@ process.env.GITHUB_APP_CLIENT_ID = 'test-client-id';
 process.env.GITHUB_APP_CLIENT_SECRET = 'test-client-secret';
 process.env.GITHUB_APP_WEBHOOK_SECRET = 'test-webhook-secret';
 process.env.GITHUB_APP_SLUG = 'shipfox-test';
+process.env.GITHUB_APP_USERNAME = 'shipfox-test';
 process.env.GITHUB_INSTALL_STATE_SECRET = 'test-install-state-secret';

--- a/libs/api/workflows-dto/src/schemas/checkout-token.test.ts
+++ b/libs/api/workflows-dto/src/schemas/checkout-token.test.ts
@@ -40,6 +40,20 @@ describe('checkoutTokenResponseSchema', () => {
     expect(result).toEqual(basicResponse);
   });
 
+  it('accepts a Git author identity', () => {
+    const input = {
+      ...basicResponse,
+      git_author: {
+        name: 'shipfox-test[bot]',
+        email: '1+shipfox-test[bot]@users.noreply.github.com',
+      },
+    };
+
+    const result = checkoutTokenResponseSchema.parse(input);
+
+    expect(result.git_author).toEqual(input.git_author);
+  });
+
   it('accepts a credential-free response with no auth (debug provider)', () => {
     const input = {repository_url: 'https://github.com/acme/repo.git', ref: 'main'};
 

--- a/libs/api/workflows-dto/src/schemas/checkout-token.ts
+++ b/libs/api/workflows-dto/src/schemas/checkout-token.ts
@@ -6,6 +6,11 @@ const carryFields = {
   persist: z.boolean(),
 };
 
+const checkoutGitAuthorSchema = z.object({
+  name: z.string().min(1),
+  email: z.string().min(1),
+});
+
 const checkoutTokenBasicAuthSchema = z.object({
   kind: z.literal('basic'),
   username: z.string().min(1),
@@ -31,6 +36,7 @@ export type CheckoutTokenAuthDto = z.infer<typeof checkoutTokenAuthSchema>;
 export const checkoutTokenResponseSchema = z.object({
   repository_url: z.string().min(1),
   ref: z.string().min(1),
+  git_author: checkoutGitAuthorSchema.optional(),
   // Optional: credential-free providers (e.g. the debug source control) return a
   // public clone URL with no auth material, so the runner clones without a token.
   auth: checkoutTokenAuthSchema.optional(),

--- a/libs/api/workflows/src/presentation/dto/checkout-token.test.ts
+++ b/libs/api/workflows/src/presentation/dto/checkout-token.test.ts
@@ -6,6 +6,10 @@ describe('toCheckoutTokenDto', () => {
     const spec: CheckoutSpec = {
       repositoryUrl: 'https://github.com/acme/repo.git',
       ref: 'main',
+      gitAuthor: {
+        name: 'shipfox-test[bot]',
+        email: '1+shipfox-test[bot]@users.noreply.github.com',
+      },
       credentials: {
         username: 'x-access-token',
         token: 'ghs-token',
@@ -18,6 +22,10 @@ describe('toCheckoutTokenDto', () => {
     expect(dto).toEqual({
       repository_url: 'https://github.com/acme/repo.git',
       ref: 'main',
+      git_author: {
+        name: 'shipfox-test[bot]',
+        email: '1+shipfox-test[bot]@users.noreply.github.com',
+      },
       auth: {
         kind: 'basic',
         username: 'x-access-token',

--- a/libs/api/workflows/src/presentation/dto/checkout-token.ts
+++ b/libs/api/workflows/src/presentation/dto/checkout-token.ts
@@ -51,6 +51,9 @@ export function toCheckoutTokenDto(
   return {
     repository_url: spec.repositoryUrl,
     ref: spec.ref,
+    ...(spec.gitAuthor
+      ? {git_author: {name: spec.gitAuthor.name, email: spec.gitAuthor.email}}
+      : {}),
     ...(spec.credentials
       ? {
           auth: {

--- a/libs/runner/execution/src/core/setup-step.test.ts
+++ b/libs/runner/execution/src/core/setup-step.test.ts
@@ -41,11 +41,12 @@ const jobContext = {
   jobExecutionId: '00000000-0000-0000-0000-0000000000ad',
 };
 
-function checkoutResponse(auth?: unknown) {
+function checkoutResponse(auth?: unknown, gitAuthor?: unknown) {
   return {
     repository_url: 'https://github.com/acme/repo.git',
     ref: 'main',
     auth,
+    ...(gitAuthor ? {git_author: gitAuthor} : {}),
   };
 }
 
@@ -112,14 +113,20 @@ afterEach(() => {
 describe('executeSetupStep', () => {
   it('prepares the workspace, checks out the repo, and succeeds', async () => {
     requestCheckoutTokenMock.mockResolvedValue(
-      checkoutResponse({
-        kind: 'bearer',
-        token: 't',
-        expires_at: '2026-01-01T00:00:00Z',
-        carry: 'header',
-        host: 'github.com',
-        persist: true,
-      }),
+      checkoutResponse(
+        {
+          kind: 'bearer',
+          token: 't',
+          expires_at: '2026-01-01T00:00:00Z',
+          carry: 'header',
+          host: 'github.com',
+          persist: true,
+        },
+        {
+          name: 'shipfox-test[bot]',
+          email: '1+shipfox-test[bot]@users.noreply.github.com',
+        },
+      ),
     );
 
     const result = await run();
@@ -155,6 +162,10 @@ describe('executeSetupStep', () => {
         carry: 'header',
         host: 'github.com',
         persist: true,
+      },
+      gitAuthor: {
+        name: 'shipfox-test[bot]',
+        email: '1+shipfox-test[bot]@users.noreply.github.com',
       },
     });
     expect(result).toEqual({

--- a/libs/runner/execution/src/core/setup-step.ts
+++ b/libs/runner/execution/src/core/setup-step.ts
@@ -239,6 +239,7 @@ async function persistAmbientGitCredential(params: {
       configPath: gitConfigPath,
       repositoryUrl: checkout.repository_url,
       auth: checkout.auth,
+      ...(checkout.git_author ? {gitAuthor: checkout.git_author} : {}),
     });
     return gitConfigPath;
   } catch (error) {

--- a/libs/runner/workspace/src/checkout.test.ts
+++ b/libs/runner/workspace/src/checkout.test.ts
@@ -417,6 +417,32 @@ describe('writeAmbientGitCredential', () => {
     expect(content).toContain(`extraHeader = "Authorization: Basic ${expected}"`);
   });
 
+  it('writes the configured Git author identity', async () => {
+    const configPath = join(root, 'git-cred.config');
+
+    await writeAmbientGitCredential({
+      configPath,
+      repositoryUrl: 'https://github.com/acme/repo.git',
+      auth: {
+        kind: 'bearer',
+        token: 'tok-123',
+        expires_at: '2026-01-01T00:00:00Z',
+        carry: 'header',
+        host: 'github.com',
+        persist: true,
+      },
+      gitAuthor: {
+        name: 'shipfox-test[bot]',
+        email: '1+shipfox-test[bot]@users.noreply.github.com',
+      },
+    });
+
+    const content = await readFile(configPath, 'utf8');
+    expect(content).toContain(
+      '[user]\n\tname = "shipfox-test[bot]"\n\temail = "1+shipfox-test[bot]@users.noreply.github.com"',
+    );
+  });
+
   it('does not fall back to home config when GIT_CONFIG_GLOBAL points to a missing file', async () => {
     const configPath = join(root, 'git-cred.config');
     process.env.GIT_CONFIG_GLOBAL = join(root, 'missing.gitconfig');

--- a/libs/runner/workspace/src/checkout.ts
+++ b/libs/runner/workspace/src/checkout.ts
@@ -177,11 +177,19 @@ export async function writeAmbientGitCredential(params: {
   configPath: string;
   repositoryUrl: string;
   auth: CheckoutTokenAuthDto;
+  gitAuthor?: {name: string; email: string} | undefined;
 }): Promise<void> {
-  const {configPath, repositoryUrl, auth} = params;
+  const {configPath, repositoryUrl, auth, gitAuthor} = params;
   const includePath = await ambientIncludePath();
   const lines = [
     ...(includePath ? ['[include]', `\tpath = ${gitConfigQuotedValue(includePath)}`] : []),
+    ...(gitAuthor
+      ? [
+          '[user]',
+          `\tname = ${gitConfigQuotedValue(gitAuthor.name)}`,
+          `\temail = ${gitConfigQuotedValue(gitAuthor.email)}`,
+        ]
+      : []),
     `[http "${gitConfigSubsection(repositoryUrl)}"]`,
     `\textraHeader = ${gitConfigQuotedValue(`Authorization: ${authorizationValue(auth)}`)}`,
     '[http]',


### PR DESCRIPTION
Set Git author identity for runner checkouts backed by GitHub App credentials.

GitHub attributes bot commits using the app username with a [bot] suffix and a noreply email derived from the GitHub App ID. This adds an optional GITHUB_APP_USERNAME config value, carries the derived author identity through the checkout-token response, and writes user.name/user.email into the per-job ambient Git config used by later agent Git commands.

The username config expects the app username without [bot]; the provider appends the suffix once so the resulting identity is <app>[bot] and <app-id>+<app>[bot]@users.noreply.github.com.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets the Git author to the GitHub App bot during runner checkouts so commits are attributed to the app. Adds an optional config to derive the bot name and email and writes them to the runner’s ambient Git config.

- **New Features**
  - Added optional `GITHUB_APP_USERNAME` to derive bot author as `<app>[bot]` with email `<app-id>+<app>[bot]@users.noreply.github.com` (suffix added automatically).
  - Checkout token now includes optional `git_author` (name, email).
  - Runner writes `[user]` name/email to the ambient Git config used by subsequent Git commands.

- **Migration**
  - Optional: set `GITHUB_APP_USERNAME` to your app username (without `[bot]`), e.g. `my-app`. If unset, no author is written and behavior is unchanged.

<sup>Written for commit a334ec091cf3485a067111b04004505581ce71a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

