### PR TITLE
[api/integration] Add shared GitHub installation token cache

### DIFF
--- a/apps/api/src/core/run.test.ts
+++ b/apps/api/src/core/run.test.ts
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => {
     getIntegrationConnectionById: vi.fn(),
     createPostgresClient: vi.fn(),
     createProjectsModule: vi.fn(),
+    deleteSecrets: vi.fn(),
     apiConfig: {
       API_PORT: undefined as number | undefined,
       API_TRUST_PROXY: 'false',
@@ -57,7 +58,10 @@ vi.mock('@shipfox/api-integration-core', () => ({
 vi.mock('@shipfox/api-logs', () => ({logsModule: {name: 'logs'}}));
 vi.mock('@shipfox/api-projects', () => ({createProjectsModule: mocks.createProjectsModule}));
 vi.mock('@shipfox/api-runners', () => ({runnersModule: {name: 'runners'}}));
-vi.mock('@shipfox/api-secrets', () => ({secretsModule: {name: 'secrets'}}));
+vi.mock('@shipfox/api-secrets', () => ({
+  deleteSecrets: mocks.deleteSecrets,
+  secretsModule: {name: 'secrets'},
+}));
 vi.mock('@shipfox/api-triggers', () => ({triggersModule: {name: 'triggers'}}));
 vi.mock('@shipfox/api-workflows', () => ({
   setSourceControl: mocks.setSourceControl,
@@ -124,6 +128,7 @@ describe('run', () => {
     mocks.getIntegrationConnectionById.mockReset();
     mocks.createPostgresClient.mockReset();
     mocks.createProjectsModule.mockReset();
+    mocks.deleteSecrets.mockReset();
     mocks.apiConfig.API_PORT = undefined;
     mocks.apiConfig.API_TRUST_PROXY = 'false';
     mocks.apiConfig.E2E_ENABLED = false;

--- a/apps/api/src/core/run.ts
+++ b/apps/api/src/core/run.ts
@@ -11,7 +11,7 @@ import {
 import {logsModule} from '@shipfox/api-logs';
 import {createProjectsModule} from '@shipfox/api-projects';
 import {runnersModule} from '@shipfox/api-runners';
-import {secretsModule} from '@shipfox/api-secrets';
+import {deleteSecrets, secretsModule} from '@shipfox/api-secrets';
 import {triggersModule} from '@shipfox/api-triggers';
 import {setSourceControl, workflowsModule} from '@shipfox/api-workflows';
 import {workspacesModule} from '@shipfox/api-workspaces';
@@ -32,7 +32,7 @@ export async function run(): Promise<void> {
 
   createPostgresClient();
 
-  const integrations = await createIntegrationsContext();
+  const integrations = await createIntegrationsContext({secrets: {deleteSecrets}});
   const agentToolSelectionCatalogs = await buildAgentToolSelectionCatalogs(integrations.registry);
   const loadWorkspaceConnectionSnapshot = createWorkspaceConnectionSnapshotLoader(
     integrations.registry,

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -18,7 +18,7 @@ import {migrationsPath} from '#db/migrations.js';
 import {integrationsOutbox} from '#db/schema/outbox.js';
 import {createIntegrationRoutes} from '#presentation/routes/index.js';
 import {loadEnabledProviderModules} from '#providers/modules.js';
-import type {IntegrationModuleParts} from '#providers/types.js';
+import type {IntegrationModuleParts, IntegrationProviderSecrets} from '#providers/types.js';
 import {createIntegrationsMaintenanceActivities} from '#temporal/activities/index.js';
 import {INTEGRATIONS_MAINTENANCE_TASK_QUEUE} from '#temporal/constants.js';
 
@@ -114,6 +114,7 @@ export interface CreateIntegrationsModuleOptions {
    * precedence over `providers`.
    */
   parts?: IntegrationModuleParts[] | undefined;
+  secrets?: IntegrationProviderSecrets | undefined;
 }
 
 export interface IntegrationsContext {
@@ -144,7 +145,7 @@ export async function createIntegrationsContext(
     options.parts ??
     (options.providers
       ? options.providers.map((provider) => ({provider}))
-      : await loadEnabledProviderModules());
+      : await loadEnabledProviderModules({secrets: options.secrets}));
 
   const registry = createIntegrationProviderRegistry(parts.map((part) => part.provider));
   const sourceControl = createSourceControlIntegrationService({

--- a/libs/api/integration/core/src/providers/github.ts
+++ b/libs/api/integration/core/src/providers/github.ts
@@ -16,7 +16,11 @@ import {
   recordDeliveryOnly,
 } from '#db/webhook-deliveries.js';
 import {retryConnectionSlugCollision} from '#providers/connection-slug.js';
-import type {IntegrationModuleParts, IntegrationProviderModule} from '#providers/types.js';
+import type {
+  IntegrationModuleParts,
+  IntegrationProviderModule,
+  IntegrationProviderModuleLoadOptions,
+} from '#providers/types.js';
 
 // Stable migration-tracking table name for the GitHub provider database. This
 // must NOT depend on the provider's position in the module `database` array. A
@@ -24,7 +28,9 @@ import type {IntegrationModuleParts, IntegrationProviderModule} from '#providers
 // re-run migrations against existing tables.
 const GITHUB_MIGRATIONS_TABLE = '__drizzle_migrations_integrations_github';
 
-async function loadGithubModuleParts(): Promise<IntegrationModuleParts> {
+async function loadGithubModuleParts(
+  options: IntegrationProviderModuleLoadOptions = {},
+): Promise<IntegrationModuleParts> {
   const {
     createGithubIntegrationProvider,
     getGithubInstallationByInstallationId,
@@ -94,6 +100,7 @@ async function loadGithubModuleParts(): Promise<IntegrationModuleParts> {
       recordDeliveryOnly,
       getIntegrationConnectionById,
       coreDb: db,
+      deleteSecrets: options.secrets?.deleteSecrets,
     }),
     database: {
       db: githubDb,

--- a/libs/api/integration/core/src/providers/modules.ts
+++ b/libs/api/integration/core/src/providers/modules.ts
@@ -2,7 +2,10 @@ import {cronProviderModule} from '#providers/cron.js';
 import {giteaProviderModule} from '#providers/gitea.js';
 import {githubProviderModule} from '#providers/github.js';
 import {sentryProviderModule} from '#providers/sentry.js';
-import type {IntegrationModuleParts} from '#providers/types.js';
+import type {
+  IntegrationModuleParts,
+  IntegrationProviderModuleLoadOptions,
+} from '#providers/types.js';
 import {webhookProviderModule} from '#providers/webhook.js';
 
 // Order is significant: databases are migrated in this order, so list a provider
@@ -15,11 +18,13 @@ const providerModules = [
   webhookProviderModule,
 ];
 
-export async function loadEnabledProviderModules(): Promise<IntegrationModuleParts[]> {
+export async function loadEnabledProviderModules(
+  options: IntegrationProviderModuleLoadOptions = {},
+): Promise<IntegrationModuleParts[]> {
   const parts: IntegrationModuleParts[] = [];
   for (const module of providerModules) {
     if (!module.enabled) continue;
-    parts.push(await module.load());
+    parts.push(await module.load(options));
   }
   return parts;
 }

--- a/libs/api/integration/core/src/providers/types.ts
+++ b/libs/api/integration/core/src/providers/types.ts
@@ -25,5 +25,13 @@ export interface IntegrationModuleParts {
 export interface IntegrationProviderModule {
   id: string;
   enabled: boolean;
-  load(): Promise<IntegrationModuleParts>;
+  load(options?: IntegrationProviderModuleLoadOptions): Promise<IntegrationModuleParts>;
+}
+
+export interface IntegrationProviderModuleLoadOptions {
+  secrets?: IntegrationProviderSecrets | undefined;
+}
+
+export interface IntegrationProviderSecrets {
+  deleteSecrets(params: {workspaceId: string; namespace: string}): Promise<number>;
 }

--- a/libs/api/integration/github/src/api/installation-token-envelope.ts
+++ b/libs/api/integration/github/src/api/installation-token-envelope.ts
@@ -1,0 +1,163 @@
+import {
+  IntegrationProviderError,
+  type IntegrationProviderErrorReason,
+} from '@shipfox/api-integration-core-dto';
+import {z} from 'zod';
+import {GithubIntegrationProviderError} from '#core/errors.js';
+
+export const TOKEN_REFRESH_MARGIN_MS = 5 * 60 * 1000;
+export const TOKEN_VALIDITY_BUFFER_MS = 60 * 1000;
+export const TRANSIENT_BACKOFF_MIN_MS = 30 * 1000;
+export const TRANSIENT_BACKOFF_MAX_MS = 5 * 60 * 1000;
+export const TERMINAL_BACKOFF_MS = 15 * 60 * 1000;
+
+const providerErrorReasons = [
+  'repository-not-found',
+  'installation-not-found',
+  'file-not-found',
+  'access-denied',
+  'rate-limited',
+  'timeout',
+  'provider-unavailable',
+  'malformed-provider-response',
+  'content-too-large',
+  'too-many-files',
+] as const satisfies readonly IntegrationProviderErrorReason[];
+
+const providerErrorReasonSchema = z.enum(providerErrorReasons);
+
+type MissingProviderErrorReason = Exclude<
+  IntegrationProviderErrorReason,
+  (typeof providerErrorReasons)[number]
+>;
+const providerErrorReasonSchemaCoversUnion: Record<MissingProviderErrorReason, never> = {};
+void providerErrorReasonSchemaCoversUnion;
+
+const installationTokenEnvelopeSchema = z.object({
+  token: z.string().min(1).optional(),
+  expiresAt: z.string().datetime().optional(),
+  backoffUntil: z.string().datetime().optional(),
+  backoffReason: providerErrorReasonSchema.optional(),
+});
+
+export interface InstallationTokenEnvelope {
+  token?: string | undefined;
+  expiresAt?: Date | undefined;
+  backoffUntil?: Date | undefined;
+  backoffReason?: IntegrationProviderErrorReason | undefined;
+}
+
+export type MintErrorClass = 'transient' | 'terminal';
+
+export interface ClassifiedMintError {
+  class: MintErrorClass;
+  reason: IntegrationProviderErrorReason;
+  retryAfterSeconds?: number | undefined;
+}
+
+export function githubInstallationTokenNamespace(installationId: number): string {
+  return `system/github/installation-token/${installationId}`;
+}
+
+export function encodeInstallationTokenEnvelope(envelope: InstallationTokenEnvelope): string {
+  return JSON.stringify({
+    ...(envelope.token !== undefined && {token: envelope.token}),
+    ...(envelope.expiresAt !== undefined && {expiresAt: envelope.expiresAt.toISOString()}),
+    ...(envelope.backoffUntil !== undefined && {
+      backoffUntil: envelope.backoffUntil.toISOString(),
+    }),
+    ...(envelope.backoffReason !== undefined && {backoffReason: envelope.backoffReason}),
+  });
+}
+
+export function parseInstallationTokenEnvelope(raw: string): InstallationTokenEnvelope | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+
+  const result = installationTokenEnvelopeSchema.safeParse(parsed);
+  if (!result.success) return undefined;
+
+  return {
+    token: result.data.token,
+    expiresAt: result.data.expiresAt ? new Date(result.data.expiresAt) : undefined,
+    backoffUntil: result.data.backoffUntil ? new Date(result.data.backoffUntil) : undefined,
+    backoffReason: result.data.backoffReason,
+  };
+}
+
+export function usable(
+  envelope: InstallationTokenEnvelope | undefined,
+  now: Date,
+): envelope is InstallationTokenEnvelope & {token: string; expiresAt: Date} {
+  return (
+    envelope?.token !== undefined &&
+    envelope.expiresAt !== undefined &&
+    !needsRefresh(envelope.expiresAt, now)
+  );
+}
+
+export function needsRefresh(expiresAt: Date, now: Date): boolean {
+  return expiresAt.getTime() <= now.getTime() + TOKEN_REFRESH_MARGIN_MS;
+}
+
+export function stillValid(expiresAt: Date | undefined, now: Date): boolean {
+  return expiresAt !== undefined && expiresAt.getTime() > now.getTime() + TOKEN_VALIDITY_BUFFER_MS;
+}
+
+export function backoffActive(envelope: InstallationTokenEnvelope | undefined, now: Date): boolean {
+  return (
+    envelope?.backoffUntil !== undefined &&
+    envelope.backoffReason !== undefined &&
+    envelope.backoffUntil.getTime() > now.getTime()
+  );
+}
+
+export function classifyMintError(error: unknown): ClassifiedMintError {
+  if (error instanceof IntegrationProviderError) {
+    return {
+      reason: error.reason,
+      retryAfterSeconds: error.retryAfterSeconds,
+      class:
+        error.reason === 'access-denied' ||
+        error.reason === 'installation-not-found' ||
+        error.reason === 'malformed-provider-response'
+          ? 'terminal'
+          : 'transient',
+    };
+  }
+
+  return {reason: 'provider-unavailable', class: 'transient'};
+}
+
+export function backoffMs(classified: ClassifiedMintError): number {
+  if (classified.class === 'terminal') return TERMINAL_BACKOFF_MS;
+
+  const retryAfterMs = (classified.retryAfterSeconds ?? 0) * 1000;
+  return Math.min(TRANSIENT_BACKOFF_MAX_MS, Math.max(TRANSIENT_BACKOFF_MIN_MS, retryAfterMs));
+}
+
+export function providerErrorFromBackoff(
+  reason: IntegrationProviderErrorReason,
+  retryAfterMs: number,
+): GithubIntegrationProviderError {
+  return new GithubIntegrationProviderError(
+    reason,
+    `GitHub installation token mint is backed off after ${reason}`,
+    Math.max(1, Math.ceil(retryAfterMs / 1000)),
+  );
+}
+
+export function toProviderError(error: unknown): GithubIntegrationProviderError {
+  if (error instanceof GithubIntegrationProviderError) return error;
+  if (error instanceof IntegrationProviderError) {
+    return new GithubIntegrationProviderError(error.reason, error.message, error.retryAfterSeconds);
+  }
+  return new GithubIntegrationProviderError(
+    'provider-unavailable',
+    error instanceof Error ? error.message : 'GitHub installation token mint failed',
+  );
+}

--- a/libs/api/integration/github/src/api/installation-token-envelope.ts
+++ b/libs/api/integration/github/src/api/installation-token-envelope.ts
@@ -25,6 +25,11 @@ const providerErrorReasons = [
 ] as const satisfies readonly IntegrationProviderErrorReason[];
 
 const providerErrorReasonSchema = z.enum(providerErrorReasons);
+const terminalMintErrorReasons = new Set<IntegrationProviderErrorReason>([
+  'access-denied',
+  'installation-not-found',
+  'malformed-provider-response',
+]);
 
 type MissingProviderErrorReason = Exclude<
   IntegrationProviderErrorReason,
@@ -121,16 +126,15 @@ export function classifyMintError(error: unknown): ClassifiedMintError {
     return {
       reason: error.reason,
       retryAfterSeconds: error.retryAfterSeconds,
-      class:
-        error.reason === 'access-denied' ||
-        error.reason === 'installation-not-found' ||
-        error.reason === 'malformed-provider-response'
-          ? 'terminal'
-          : 'transient',
+      class: mintErrorClassForReason(error.reason),
     };
   }
 
   return {reason: 'provider-unavailable', class: 'transient'};
+}
+
+export function mintErrorClassForReason(reason: IntegrationProviderErrorReason): MintErrorClass {
+  return terminalMintErrorReasons.has(reason) ? 'terminal' : 'transient';
 }
 
 export function backoffMs(classified: ClassifiedMintError): number {

--- a/libs/api/integration/github/src/api/installation-token-provider.test.ts
+++ b/libs/api/integration/github/src/api/installation-token-provider.test.ts
@@ -1,4 +1,7 @@
+import type {GetIntegrationConnectionByIdFn} from '@shipfox/api-integration-core-dto';
 import {GithubIntegrationProviderError} from '#core/errors.js';
+import {githubInstallationFactory} from '#test/index.js';
+import {encodeInstallationTokenEnvelope} from './installation-token-envelope.js';
 import {createGithubInstallationTokenProvider} from './installation-token-provider.js';
 
 const {appOptions, createInstallationAccessTokenMock, RequestErrorMock} = vi.hoisted(() => ({
@@ -119,6 +122,59 @@ describe('GithubInstallationTokenProvider', () => {
       {token: 'ghs_installationtoken', expiresAt: new Date('2026-06-10T12:00:00.000Z')},
       {token: 'ghs_installationtoken', expiresAt: new Date('2026-06-10T12:00:00.000Z')},
     ]);
+    expect(createInstallationAccessTokenMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('composes the RAM tier over the shared token cache', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-10T11:00:00.000Z'));
+    const installationId = Math.floor(Math.random() * 1_000_000_000);
+    const connectionId = crypto.randomUUID();
+    const workspaceId = crypto.randomUUID();
+    await githubInstallationFactory.create({installationId: String(installationId), connectionId});
+    const values = new Map<string, string>();
+    let lockCalls = 0;
+    function withLock<T>(_installationId: number, fn: () => Promise<T>) {
+      lockCalls += 1;
+      return fn().then((value) => ({acquired: true as const, value}));
+    }
+    const getIntegrationConnectionById: GetIntegrationConnectionByIdFn = () =>
+      Promise.resolve({
+        id: connectionId,
+        workspaceId,
+        provider: 'github',
+        externalAccountId: String(installationId),
+        slug: 'github_shipfox',
+        displayName: 'GitHub shipfox',
+        lifecycleStatus: 'active',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+    createInstallationAccessTokenMock.mockResolvedValue({
+      data: {token: 'ghs_installationtoken', expires_at: '2026-06-10T12:00:00.000Z'},
+    });
+    const provider = createGithubInstallationTokenProvider({
+      getIntegrationConnectionById,
+      secretStore: {
+        read: (readWorkspaceId, readInstallationId) =>
+          Promise.resolve(values.get(`${readWorkspaceId}:${readInstallationId}`) ?? null),
+        write: (writeWorkspaceId, writeInstallationId, envelope) => {
+          values.set(
+            `${writeWorkspaceId}:${writeInstallationId}`,
+            encodeInstallationTokenEnvelope(envelope),
+          );
+          return Promise.resolve();
+        },
+      },
+      withLock,
+      now: () => new Date(),
+    });
+
+    const first = await provider.getInstallationAccessToken(installationId);
+    const second = await provider.getInstallationAccessToken(installationId);
+
+    expect(first).toEqual(second);
+    expect(lockCalls).toBe(1);
     expect(createInstallationAccessTokenMock).toHaveBeenCalledTimes(1);
   });
 

--- a/libs/api/integration/github/src/api/installation-token-provider.ts
+++ b/libs/api/integration/github/src/api/installation-token-provider.ts
@@ -1,23 +1,38 @@
+import type {GetIntegrationConnectionByIdFn} from '@shipfox/api-integration-core-dto';
 import {App, Octokit} from 'octokit';
 import {config, normalizedGithubPrivateKey} from '#config.js';
 import {GithubIntegrationProviderError} from '#core/errors.js';
+import {withInstallationTokenLock} from '#db/installation-token-lock.js';
+import {getGithubInstallationByInstallationId} from '#db/installations.js';
+import {recordInstallationTokenLookup} from '#metrics/index.js';
 import {type GithubInstallationAccessToken, mapGithubError} from './client.js';
-
-const TOKEN_REFRESH_MARGIN_MS = 5 * 60 * 1000;
+import {
+  githubInstallationTokenNamespace,
+  TOKEN_REFRESH_MARGIN_MS,
+} from './installation-token-envelope.js';
+import {
+  type InstallationTokenCache,
+  type InstallationTokenSecretStore,
+  SharedInstallationTokenCache,
+  type SharedInstallationTokenCacheOptions,
+} from './shared-installation-token-cache.js';
 
 export interface GithubInstallationTokenProvider {
   getInstallationAccessToken(installationId: number): Promise<GithubInstallationAccessToken>;
 }
 
-interface InstallationTokenCache {
-  getOrMint(
-    installationId: number,
-    mint: () => Promise<GithubInstallationAccessToken>,
-  ): Promise<GithubInstallationAccessToken>;
+export interface GithubInstallationTokenProviderOptions {
+  cache?: InstallationTokenCache | undefined;
+  getIntegrationConnectionById?: GetIntegrationConnectionByIdFn | undefined;
+  secretStore?: InstallationTokenSecretStore | undefined;
+  withLock?: SharedInstallationTokenCacheOptions['withLock'] | undefined;
+  now?: (() => Date) | undefined;
 }
 
-export function createGithubInstallationTokenProvider(): GithubInstallationTokenProvider {
-  return new OctokitGithubInstallationTokenProvider();
+export function createGithubInstallationTokenProvider(
+  options: GithubInstallationTokenProviderOptions = {},
+): GithubInstallationTokenProvider {
+  return new OctokitGithubInstallationTokenProvider(createInstallationTokenCache(options));
 }
 
 class OctokitGithubInstallationTokenProvider implements GithubInstallationTokenProvider {
@@ -112,6 +127,7 @@ class InMemoryInstallationTokenCache implements InstallationTokenCache {
   ): Promise<GithubInstallationAccessToken> {
     const cached = this.tokens.get(installationId);
     if (cached && !this.isInsideRefreshMargin(cached.expiresAt)) {
+      recordInstallationTokenLookup('ram-hit');
       return Promise.resolve(cached);
     }
 
@@ -133,4 +149,74 @@ class InMemoryInstallationTokenCache implements InstallationTokenCache {
   private isInsideRefreshMargin(expiresAt: Date): boolean {
     return expiresAt.getTime() <= this.options.now().getTime() + this.options.refreshMarginMs;
   }
+}
+
+class TieredInstallationTokenCache implements InstallationTokenCache {
+  constructor(
+    private readonly ram: InstallationTokenCache,
+    private readonly shared: InstallationTokenCache,
+  ) {}
+
+  getOrMint(
+    installationId: number,
+    mint: () => Promise<GithubInstallationAccessToken>,
+  ): Promise<GithubInstallationAccessToken> {
+    return this.ram.getOrMint(installationId, () => this.shared.getOrMint(installationId, mint));
+  }
+}
+
+function createInstallationTokenCache(
+  options: GithubInstallationTokenProviderOptions,
+): InstallationTokenCache {
+  if (options.cache) return options.cache;
+
+  const ram = new InMemoryInstallationTokenCache({
+    refreshMarginMs: TOKEN_REFRESH_MARGIN_MS,
+    now: options.now ?? (() => new Date()),
+  });
+  if (!options.getIntegrationConnectionById || !options.secretStore) return ram;
+
+  const shared = new SharedInstallationTokenCache({
+    secretStore: options.secretStore,
+    withLock: options.withLock ?? withInstallationTokenLock,
+    resolveWorkspaceId: createGithubInstallationWorkspaceResolver(
+      options.getIntegrationConnectionById,
+    ),
+    now: options.now,
+  });
+  return new TieredInstallationTokenCache(ram, shared);
+}
+
+function createGithubInstallationWorkspaceResolver(
+  getIntegrationConnectionById: GetIntegrationConnectionByIdFn,
+) {
+  return async (installationId: number): Promise<string> => {
+    const installation = await getGithubInstallationByInstallationId(String(installationId));
+    if (!installation) {
+      throw new GithubIntegrationProviderError(
+        'installation-not-found',
+        `GitHub installation not found: ${installationId}`,
+      );
+    }
+
+    const connection = await getIntegrationConnectionById(installation.connectionId);
+    if (!connection) {
+      throw new GithubIntegrationProviderError(
+        'installation-not-found',
+        `GitHub installation connection not found: ${installation.connectionId}`,
+      );
+    }
+    return connection.workspaceId;
+  };
+}
+
+export function deleteGithubInstallationTokenSecret(params: {
+  workspaceId: string;
+  installationId: number;
+  deleteSecrets: (params: {workspaceId: string; namespace: string}) => Promise<number>;
+}): Promise<number> {
+  return params.deleteSecrets({
+    workspaceId: params.workspaceId,
+    namespace: githubInstallationTokenNamespace(params.installationId),
+  });
 }

--- a/libs/api/integration/github/src/api/shared-installation-token-cache.test.ts
+++ b/libs/api/integration/github/src/api/shared-installation-token-cache.test.ts
@@ -1,0 +1,265 @@
+import {GithubIntegrationProviderError} from '#core/errors.js';
+import {
+  backoffActive,
+  encodeInstallationTokenEnvelope,
+  needsRefresh,
+  stillValid,
+  TOKEN_REFRESH_MARGIN_MS,
+  TOKEN_VALIDITY_BUFFER_MS,
+} from './installation-token-envelope.js';
+import {
+  type InstallationTokenLockResult,
+  type InstallationTokenSecretStore,
+  SharedInstallationTokenCache,
+} from './shared-installation-token-cache.js';
+
+const workspaceId = '00000000-0000-4000-8000-000000000001';
+const installationId = 123;
+
+function token(tokenValue: string, expiresAt = '2026-06-10T12:00:00.000Z') {
+  return {token: tokenValue, expiresAt: new Date(expiresAt)};
+}
+
+function createStore(): InstallationTokenSecretStore & {
+  values: Map<string, string>;
+  failWrites: boolean;
+} {
+  const values = new Map<string, string>();
+  const store = {
+    values,
+    failWrites: false,
+    read(readWorkspaceId: string, readInstallationId: number) {
+      return Promise.resolve(values.get(`${readWorkspaceId}:${readInstallationId}`) ?? null);
+    },
+    write(
+      writeWorkspaceId: string,
+      writeInstallationId: number,
+      envelope: Parameters<InstallationTokenSecretStore['write']>[2],
+    ) {
+      if (store.failWrites) return Promise.reject(new Error('write failed'));
+      values.set(
+        `${writeWorkspaceId}:${writeInstallationId}`,
+        encodeInstallationTokenEnvelope(envelope),
+      );
+      return Promise.resolve();
+    },
+  };
+  return store;
+}
+
+function cache(
+  options: {
+    store?: InstallationTokenSecretStore | undefined;
+    now?: Date | undefined;
+    withLock?:
+      | (<T>(
+          installationId: number,
+          fn: () => Promise<T>,
+        ) => Promise<InstallationTokenLockResult<T>>)
+      | undefined;
+    resolveWorkspaceId?: ((installationId: number) => Promise<string>) | undefined;
+    sleep?: ((ms: number) => Promise<void>) | undefined;
+    pollDelaysMs?: number[] | undefined;
+  } = {},
+) {
+  return new SharedInstallationTokenCache({
+    secretStore: options.store ?? createStore(),
+    withLock: options.withLock ?? (async (_id, fn) => ({acquired: true, value: await fn()})),
+    resolveWorkspaceId: options.resolveWorkspaceId ?? (() => Promise.resolve(workspaceId)),
+    now: () => options.now ?? new Date('2026-06-10T11:00:00.000Z'),
+    sleep: options.sleep ?? (() => Promise.resolve()),
+    pollDelaysMs: options.pollDelaysMs ?? [],
+  });
+}
+
+function setEnvelope(
+  store: {values: Map<string, string>},
+  envelope: Parameters<typeof encodeInstallationTokenEnvelope>[0],
+) {
+  store.values.set(`${workspaceId}:${installationId}`, encodeInstallationTokenEnvelope(envelope));
+}
+
+describe('SharedInstallationTokenCache', () => {
+  it('mints once on a cold winner miss and writes the secret envelope', async () => {
+    const store = createStore();
+    const mint = vi.fn(() => Promise.resolve(token('ghs_new')));
+    const shared = cache({store});
+
+    const result = await shared.getOrMint(installationId, mint);
+
+    expect(result).toEqual(token('ghs_new'));
+    expect(mint).toHaveBeenCalledTimes(1);
+    expect(store.values.get(`${workspaceId}:${installationId}`)).toContain('ghs_new');
+  });
+
+  it('returns a warm store hit without minting', async () => {
+    const store = createStore();
+    setEnvelope(store, token('ghs_cached'));
+    const mint = vi.fn(() => Promise.resolve(token('ghs_new')));
+    const shared = cache({store});
+
+    const result = await shared.getOrMint(installationId, mint);
+
+    expect(result).toEqual(token('ghs_cached'));
+    expect(mint).not.toHaveBeenCalled();
+  });
+
+  it('serves a still-valid token on a contended refresh path', async () => {
+    const store = createStore();
+    setEnvelope(store, token('ghs_stale_but_valid', '2026-06-10T11:04:30.000Z'));
+    const mint = vi.fn(() => Promise.resolve(token('ghs_new')));
+    const shared = cache({
+      store,
+      withLock: () => Promise.resolve({acquired: false}),
+    });
+
+    const result = await shared.getOrMint(installationId, mint);
+
+    expect(result).toEqual(token('ghs_stale_but_valid', '2026-06-10T11:04:30.000Z'));
+    expect(mint).not.toHaveBeenCalled();
+  });
+
+  it('polls for the winner commit on a contended cold miss', async () => {
+    const store = createStore();
+    const mint = vi.fn(() => Promise.resolve(token('ghs_new')));
+    let polls = 0;
+    const shared = cache({
+      store,
+      withLock: () => Promise.resolve({acquired: false}),
+      pollDelaysMs: [1, 1],
+      sleep: () => {
+        polls += 1;
+        if (polls === 1) setEnvelope(store, token('ghs_committed'));
+        return Promise.resolve();
+      },
+    });
+
+    const result = await shared.getOrMint(installationId, mint);
+
+    expect(result).toEqual(token('ghs_committed'));
+    expect(mint).not.toHaveBeenCalled();
+  });
+
+  it('refreshes a near-expiry token and clears backoff', async () => {
+    const store = createStore();
+    setEnvelope(store, {
+      ...token('ghs_old', '2026-06-10T11:04:00.000Z'),
+      backoffUntil: new Date('2026-06-10T10:00:00.000Z'),
+      backoffReason: 'rate-limited',
+    });
+    const shared = cache({store});
+
+    const result = await shared.getOrMint(installationId, () => Promise.resolve(token('ghs_new')));
+
+    expect(result).toEqual(token('ghs_new'));
+    expect(store.values.get(`${workspaceId}:${installationId}`)).not.toContain('backoff');
+  });
+
+  it('records transient backoff and short-circuits the next call with the stored reason', async () => {
+    const store = createStore();
+    const mint = vi
+      .fn()
+      .mockRejectedValue(new GithubIntegrationProviderError('rate-limited', 'rate limited', 42));
+    const shared = cache({store});
+
+    await expect(shared.getOrMint(installationId, mint)).rejects.toMatchObject({
+      reason: 'rate-limited',
+    });
+    await expect(shared.getOrMint(installationId, mint)).rejects.toMatchObject({
+      reason: 'rate-limited',
+      retryAfterSeconds: 42,
+    });
+
+    expect(mint).toHaveBeenCalledTimes(1);
+  });
+
+  it('records terminal backoff without hiding access denied as provider unavailable', async () => {
+    const store = createStore();
+    const mint = vi
+      .fn()
+      .mockRejectedValue(new GithubIntegrationProviderError('access-denied', 'denied'));
+    const shared = cache({store});
+
+    await expect(shared.getOrMint(installationId, mint)).rejects.toMatchObject({
+      reason: 'access-denied',
+    });
+    await expect(shared.getOrMint(installationId, mint)).rejects.toMatchObject({
+      reason: 'access-denied',
+    });
+
+    expect(mint).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves stale when refresh minting fails while the token is still valid', async () => {
+    const store = createStore();
+    setEnvelope(store, token('ghs_existing', '2026-06-10T11:04:30.000Z'));
+    const shared = cache({store});
+
+    const result = await shared.getOrMint(installationId, () =>
+      Promise.reject(new GithubIntegrationProviderError('provider-unavailable', 'down')),
+    );
+
+    expect(result).toEqual(token('ghs_existing', '2026-06-10T11:04:30.000Z'));
+  });
+
+  it('returns a minted token when the cache write fails', async () => {
+    const store = createStore();
+    store.failWrites = true;
+    const shared = cache({store});
+
+    const result = await shared.getOrMint(installationId, () => Promise.resolve(token('ghs_new')));
+
+    expect(result).toEqual(token('ghs_new'));
+  });
+
+  it('treats an invalid envelope as a miss and overwrites it', async () => {
+    const store = createStore();
+    store.values.set(`${workspaceId}:${installationId}`, '{bad json');
+    const shared = cache({store});
+
+    const result = await shared.getOrMint(installationId, () => Promise.resolve(token('ghs_new')));
+
+    expect(result).toEqual(token('ghs_new'));
+    expect(store.values.get(`${workspaceId}:${installationId}`)).toContain('ghs_new');
+  });
+
+  it('surfaces an unresolvable installation as installation-not-found', async () => {
+    const shared = cache({
+      resolveWorkspaceId: () =>
+        Promise.reject(new GithubIntegrationProviderError('installation-not-found', 'missing')),
+    });
+
+    await expect(
+      shared.getOrMint(installationId, () => Promise.resolve(token('ghs_new'))),
+    ).rejects.toMatchObject({reason: 'installation-not-found'});
+  });
+});
+
+describe('installation token envelope predicates', () => {
+  it('uses exact refresh, validity, and backoff boundaries', () => {
+    const now = new Date('2026-06-10T11:00:00.000Z');
+
+    expect(needsRefresh(new Date(now.getTime() + TOKEN_REFRESH_MARGIN_MS), now)).toBe(true);
+    expect(needsRefresh(new Date(now.getTime() + TOKEN_REFRESH_MARGIN_MS + 1), now)).toBe(false);
+    expect(stillValid(new Date(now.getTime() + TOKEN_VALIDITY_BUFFER_MS), now)).toBe(false);
+    expect(stillValid(new Date(now.getTime() + TOKEN_VALIDITY_BUFFER_MS + 1), now)).toBe(true);
+    expect(
+      backoffActive(
+        {
+          backoffUntil: now,
+          backoffReason: 'provider-unavailable',
+        },
+        now,
+      ),
+    ).toBe(false);
+    expect(
+      backoffActive(
+        {
+          backoffUntil: new Date(now.getTime() + 1),
+          backoffReason: 'provider-unavailable',
+        },
+        now,
+      ),
+    ).toBe(true);
+  });
+});

--- a/libs/api/integration/github/src/api/shared-installation-token-cache.test.ts
+++ b/libs/api/integration/github/src/api/shared-installation-token-cache.test.ts
@@ -202,6 +202,35 @@ describe('SharedInstallationTokenCache', () => {
     expect(result).toEqual(token('ghs_existing', '2026-06-10T11:04:30.000Z'));
   });
 
+  it('does not serve stale when refresh minting fails with a terminal reason', async () => {
+    const store = createStore();
+    setEnvelope(store, token('ghs_existing', '2026-06-10T11:04:30.000Z'));
+    const shared = cache({store});
+
+    await expect(
+      shared.getOrMint(installationId, () =>
+        Promise.reject(new GithubIntegrationProviderError('access-denied', 'denied')),
+      ),
+    ).rejects.toMatchObject({reason: 'access-denied'});
+  });
+
+  it('does not serve stale from active terminal backoff on a contended refresh', async () => {
+    const store = createStore();
+    setEnvelope(store, {
+      ...token('ghs_existing', '2026-06-10T11:04:30.000Z'),
+      backoffUntil: new Date('2026-06-10T11:15:00.000Z'),
+      backoffReason: 'installation-not-found',
+    });
+    const shared = cache({
+      store,
+      withLock: () => Promise.resolve({acquired: false}),
+    });
+
+    await expect(
+      shared.getOrMint(installationId, () => Promise.resolve(token('ghs_new'))),
+    ).rejects.toMatchObject({reason: 'installation-not-found'});
+  });
+
   it('returns a minted token when the cache write fails', async () => {
     const store = createStore();
     store.failWrites = true;

--- a/libs/api/integration/github/src/api/shared-installation-token-cache.ts
+++ b/libs/api/integration/github/src/api/shared-installation-token-cache.ts
@@ -12,6 +12,7 @@ import {
   backoffMs,
   classifyMintError,
   type InstallationTokenEnvelope,
+  mintErrorClassForReason,
   parseInstallationTokenEnvelope,
   providerErrorFromBackoff,
   stillValid,
@@ -102,8 +103,8 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
       return tokenFromEnvelope(envelope);
     }
 
-    if (backoffActive(envelope, now)) {
-      if (envelope?.token && stillValid(envelope.expiresAt, now)) {
+    if (activeBackoff(envelope, now)) {
+      if (canServeStale(envelope, now)) {
         recordInstallationTokenLookup('served-stale');
         return tokenFromEnvelope(envelope);
       }
@@ -135,7 +136,11 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
         );
       });
 
-      if (envelope?.token && stillValid(envelope.expiresAt, this.now())) {
+      if (
+        classified.class === 'transient' &&
+        envelope?.token &&
+        stillValid(envelope.expiresAt, this.now())
+      ) {
         logger().warn(
           {
             installationId: params.installationId,
@@ -187,9 +192,17 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
     installationId: number;
     envelope: InstallationTokenEnvelope | undefined;
   }): Promise<GithubInstallationAccessToken> {
-    if (params.envelope?.token && stillValid(params.envelope.expiresAt, this.now())) {
+    const initialNow = this.now();
+    if (canServeStale(params.envelope, initialNow)) {
       recordInstallationTokenLookup('served-stale');
       return tokenFromEnvelope(params.envelope);
+    }
+    if (activeBackoff(params.envelope, initialNow)) {
+      recordInstallationTokenLookup('backoff');
+      throw providerErrorFromBackoff(
+        params.envelope.backoffReason,
+        params.envelope.backoffUntil.getTime() - initialNow.getTime(),
+      );
     }
 
     for (const delayMs of this.pollDelaysMs) {
@@ -264,6 +277,38 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
     });
     return workspaceId;
   }
+}
+
+type ActiveBackoffEnvelope = InstallationTokenEnvelope & {
+  backoffUntil: Date;
+  backoffReason: NonNullable<InstallationTokenEnvelope['backoffReason']>;
+};
+
+type TokenEnvelope = InstallationTokenEnvelope & {token: string; expiresAt: Date};
+
+function activeBackoff(
+  envelope: InstallationTokenEnvelope | undefined,
+  now: Date,
+): envelope is ActiveBackoffEnvelope {
+  return (
+    backoffActive(envelope, now) &&
+    envelope?.backoffUntil !== undefined &&
+    envelope.backoffReason !== undefined
+  );
+}
+
+function canServeStale(
+  envelope: InstallationTokenEnvelope | undefined,
+  now: Date,
+): envelope is TokenEnvelope {
+  const terminalBackoff =
+    activeBackoff(envelope, now) && mintErrorClassForReason(envelope.backoffReason) === 'terminal';
+  return (
+    envelope?.token !== undefined &&
+    envelope.expiresAt !== undefined &&
+    stillValid(envelope.expiresAt, now) &&
+    !terminalBackoff
+  );
 }
 
 function tokenFromEnvelope(envelope: InstallationTokenEnvelope): GithubInstallationAccessToken {

--- a/libs/api/integration/github/src/api/shared-installation-token-cache.ts
+++ b/libs/api/integration/github/src/api/shared-installation-token-cache.ts
@@ -1,0 +1,295 @@
+import {setTimeout as sleepTimeout} from 'node:timers/promises';
+import {logger} from '@shipfox/node-opentelemetry';
+import {GithubIntegrationProviderError} from '#core/errors.js';
+import {
+  recordInstallationTokenBackoff,
+  recordInstallationTokenLookup,
+  recordInstallationTokenMint,
+} from '#metrics/index.js';
+import type {GithubInstallationAccessToken} from './client.js';
+import {
+  backoffActive,
+  backoffMs,
+  classifyMintError,
+  type InstallationTokenEnvelope,
+  parseInstallationTokenEnvelope,
+  providerErrorFromBackoff,
+  stillValid,
+  toProviderError,
+  usable,
+} from './installation-token-envelope.js';
+
+export interface InstallationTokenCache {
+  getOrMint(
+    installationId: number,
+    mint: () => Promise<GithubInstallationAccessToken>,
+  ): Promise<GithubInstallationAccessToken>;
+}
+
+export type InstallationTokenLockResult<T> = {acquired: true; value: T} | {acquired: false};
+
+export interface InstallationTokenSecretStore {
+  read(workspaceId: string, installationId: number): Promise<string | null>;
+  write(
+    workspaceId: string,
+    installationId: number,
+    envelope: InstallationTokenEnvelope,
+  ): Promise<void>;
+}
+
+export interface SharedInstallationTokenCacheOptions {
+  secretStore: InstallationTokenSecretStore;
+  withLock: <T>(
+    installationId: number,
+    fn: () => Promise<T>,
+  ) => Promise<InstallationTokenLockResult<T>>;
+  resolveWorkspaceId: (installationId: number) => Promise<string>;
+  now?: (() => Date) | undefined;
+  sleep?: ((ms: number) => Promise<void>) | undefined;
+  pollDelaysMs?: number[] | undefined;
+  workspaceCacheTtlMs?: number | undefined;
+  mintTimeoutMs?: number | undefined;
+}
+
+const DEFAULT_POLL_DELAYS_MS = [100, 200, 400, 500, 800];
+const DEFAULT_WORKSPACE_CACHE_TTL_MS = 10 * 60 * 1000;
+const DEFAULT_MINT_TIMEOUT_MS = 30 * 1000;
+
+export class SharedInstallationTokenCache implements InstallationTokenCache {
+  private readonly workspaceIds = new Map<number, {workspaceId: string; expiresAtMs: number}>();
+  private readonly now: () => Date;
+  private readonly sleep: (ms: number) => Promise<void>;
+  private readonly pollDelaysMs: number[];
+  private readonly workspaceCacheTtlMs: number;
+  private readonly mintTimeoutMs: number;
+
+  constructor(private readonly options: SharedInstallationTokenCacheOptions) {
+    this.now = options.now ?? (() => new Date());
+    this.sleep = options.sleep ?? ((ms) => sleepTimeout(ms).then(() => undefined));
+    this.pollDelaysMs = options.pollDelaysMs ?? DEFAULT_POLL_DELAYS_MS;
+    this.workspaceCacheTtlMs = options.workspaceCacheTtlMs ?? DEFAULT_WORKSPACE_CACHE_TTL_MS;
+    this.mintTimeoutMs = options.mintTimeoutMs ?? DEFAULT_MINT_TIMEOUT_MS;
+  }
+
+  async getOrMint(
+    installationId: number,
+    mint: () => Promise<GithubInstallationAccessToken>,
+  ): Promise<GithubInstallationAccessToken> {
+    const workspaceId = await this.resolveWorkspaceId(installationId);
+    const envelope = await this.readEnvelope(workspaceId, installationId);
+    if (usable(envelope, this.now())) {
+      recordInstallationTokenLookup('db-hit');
+      return tokenFromEnvelope(envelope);
+    }
+
+    const result = await this.options.withLock(installationId, () =>
+      this.mintUnderLock({workspaceId, installationId, mint}),
+    );
+    if (result.acquired) return result.value;
+
+    return await this.serveStaleOrPoll({workspaceId, installationId, envelope});
+  }
+
+  private async mintUnderLock(params: {
+    workspaceId: string;
+    installationId: number;
+    mint: () => Promise<GithubInstallationAccessToken>;
+  }): Promise<GithubInstallationAccessToken> {
+    const envelope = await this.readEnvelope(params.workspaceId, params.installationId);
+    const now = this.now();
+    if (usable(envelope, now)) {
+      recordInstallationTokenLookup('db-hit');
+      return tokenFromEnvelope(envelope);
+    }
+
+    if (backoffActive(envelope, now)) {
+      if (envelope?.token && stillValid(envelope.expiresAt, now)) {
+        recordInstallationTokenLookup('served-stale');
+        return tokenFromEnvelope(envelope);
+      }
+      recordInstallationTokenLookup('backoff');
+      throw providerErrorFromBackoff(
+        envelope?.backoffReason ?? 'provider-unavailable',
+        (envelope?.backoffUntil?.getTime() ?? now.getTime()) - now.getTime(),
+      );
+    }
+
+    let token: GithubInstallationAccessToken;
+    try {
+      token = await this.recordMint(params.mint);
+    } catch (error) {
+      const providerError = toProviderError(error);
+      const classified = classifyMintError(providerError);
+      const until = new Date(this.now().getTime() + backoffMs(classified));
+      recordInstallationTokenBackoff({reason: classified.reason, class: classified.class});
+
+      await this.writeEnvelope(params.workspaceId, params.installationId, {
+        token: envelope?.token,
+        expiresAt: envelope?.expiresAt,
+        backoffUntil: until,
+        backoffReason: classified.reason,
+      }).catch((writeError) => {
+        logger().warn(
+          {installationId: params.installationId, reason: classified.reason, error: writeError},
+          'github installation token backoff write failed',
+        );
+      });
+
+      if (envelope?.token && stillValid(envelope.expiresAt, this.now())) {
+        logger().warn(
+          {
+            installationId: params.installationId,
+            expiresAt: envelope.expiresAt?.toISOString(),
+            reason: classified.reason,
+            backoffUntil: until.toISOString(),
+          },
+          'github installation token mint failed; serving stale token',
+        );
+        recordInstallationTokenLookup('served-stale');
+        return tokenFromEnvelope(envelope);
+      }
+
+      logger().warn(
+        {
+          installationId: params.installationId,
+          reason: classified.reason,
+          backoffUntil: until.toISOString(),
+          error: providerError,
+        },
+        'github installation token mint failed; backoff recorded',
+      );
+      recordInstallationTokenLookup('backoff');
+      throw providerError;
+    }
+
+    try {
+      await this.writeEnvelope(params.workspaceId, params.installationId, {
+        token: token.token,
+        expiresAt: token.expiresAt,
+      });
+    } catch (error) {
+      logger().warn(
+        {installationId: params.installationId, expiresAt: token.expiresAt.toISOString(), error},
+        'github installation token cache write failed after mint',
+      );
+    }
+
+    logger().info(
+      {installationId: params.installationId, expiresAt: token.expiresAt.toISOString()},
+      'github installation token minted',
+    );
+    recordInstallationTokenLookup('minted');
+    return token;
+  }
+
+  private async serveStaleOrPoll(params: {
+    workspaceId: string;
+    installationId: number;
+    envelope: InstallationTokenEnvelope | undefined;
+  }): Promise<GithubInstallationAccessToken> {
+    if (params.envelope?.token && stillValid(params.envelope.expiresAt, this.now())) {
+      recordInstallationTokenLookup('served-stale');
+      return tokenFromEnvelope(params.envelope);
+    }
+
+    for (const delayMs of this.pollDelaysMs) {
+      await this.sleep(delayMs);
+      const envelope = await this.readEnvelope(params.workspaceId, params.installationId);
+      const now = this.now();
+      if (usable(envelope, now)) {
+        recordInstallationTokenLookup('contended-poll');
+        return tokenFromEnvelope(envelope);
+      }
+      if (backoffActive(envelope, now)) {
+        recordInstallationTokenLookup('backoff');
+        throw providerErrorFromBackoff(
+          envelope?.backoffReason ?? 'provider-unavailable',
+          (envelope?.backoffUntil?.getTime() ?? now.getTime()) - now.getTime(),
+        );
+      }
+    }
+
+    throw new GithubIntegrationProviderError(
+      'provider-unavailable',
+      'GitHub installation token mint is still in progress',
+      1,
+    );
+  }
+
+  private async recordMint(
+    mint: () => Promise<GithubInstallationAccessToken>,
+  ): Promise<GithubInstallationAccessToken> {
+    const startedAt = Date.now();
+    try {
+      const token = await withTimeout(mint(), this.mintTimeoutMs);
+      recordInstallationTokenMint({outcome: 'success', durationMs: Date.now() - startedAt});
+      return token;
+    } catch (error) {
+      recordInstallationTokenMint({outcome: 'failure', durationMs: Date.now() - startedAt});
+      throw error;
+    }
+  }
+
+  private async readEnvelope(
+    workspaceId: string,
+    installationId: number,
+  ): Promise<InstallationTokenEnvelope | undefined> {
+    const raw = await this.options.secretStore.read(workspaceId, installationId);
+    if (raw === null) return undefined;
+
+    const envelope = parseInstallationTokenEnvelope(raw);
+    if (envelope === undefined) {
+      logger().warn({installationId}, 'github installation token cache envelope failed to decode');
+    }
+    return envelope;
+  }
+
+  private async writeEnvelope(
+    workspaceId: string,
+    installationId: number,
+    envelope: InstallationTokenEnvelope,
+  ): Promise<void> {
+    await this.options.secretStore.write(workspaceId, installationId, envelope);
+  }
+
+  private async resolveWorkspaceId(installationId: number): Promise<string> {
+    const nowMs = this.now().getTime();
+    const cached = this.workspaceIds.get(installationId);
+    if (cached && cached.expiresAtMs > nowMs) return cached.workspaceId;
+
+    const workspaceId = await this.options.resolveWorkspaceId(installationId);
+    this.workspaceIds.set(installationId, {
+      workspaceId,
+      expiresAtMs: nowMs + this.workspaceCacheTtlMs,
+    });
+    return workspaceId;
+  }
+}
+
+function tokenFromEnvelope(envelope: InstallationTokenEnvelope): GithubInstallationAccessToken {
+  if (!envelope.token || !envelope.expiresAt) {
+    throw new GithubIntegrationProviderError(
+      'malformed-provider-response',
+      'GitHub installation token cache envelope is missing a token or expiry',
+    );
+  }
+  return {token: envelope.token, expiresAt: envelope.expiresAt};
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<T>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(
+        new GithubIntegrationProviderError(
+          'timeout',
+          'Timed out minting GitHub installation access token',
+        ),
+      );
+    }, timeoutMs);
+  });
+
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}

--- a/libs/api/integration/github/src/core/webhook.test.ts
+++ b/libs/api/integration/github/src/core/webhook.test.ts
@@ -322,6 +322,49 @@ describe('handleGithubEvent', () => {
     });
   });
 
+  it('does not clean up cached installation tokens for duplicate lifecycle deliveries', async () => {
+    const installationId = 7792;
+    const connection = fakeConnection();
+    await seedInstallation(installationId, connection.id);
+    const handlers = deps({connection, publishIntegrationEventReceivedResult: {published: false}});
+    const deleteInstallationTokenSecret = vi.fn(() => Promise.resolve());
+
+    const result = await handleGithubEvent({
+      tx: db(),
+      deliveryId: randomUUID(),
+      event: 'installation',
+      payload: {action: 'suspend', installation: {id: installationId}},
+      deleteInstallationTokenSecret,
+      ...handlers,
+    });
+
+    expect(result.outcome).toBe('duplicate-envelope');
+    expect(deleteInstallationTokenSecret).not.toHaveBeenCalled();
+  });
+
+  it('does not fail lifecycle webhook handling when cached token cleanup fails', async () => {
+    const installationId = 7793;
+    const connection = fakeConnection();
+    await seedInstallation(installationId, connection.id);
+    const handlers = deps({connection});
+    const deleteInstallationTokenSecret = vi.fn(() => Promise.reject(new Error('store down')));
+
+    const result = await handleGithubEvent({
+      tx: db(),
+      deliveryId: randomUUID(),
+      event: 'installation',
+      payload: {action: 'deleted', installation: {id: installationId}},
+      deleteInstallationTokenSecret,
+      ...handlers,
+    });
+
+    expect(result.outcome).toBe('published-envelope');
+    expect(deleteInstallationTokenSecret).toHaveBeenCalledWith({
+      workspaceId: connection.workspaceId,
+      installationId,
+    });
+  });
+
   it('publishes a bare resource envelope when action is malformed', async () => {
     const installationId = 7782;
     const connection = fakeConnection();

--- a/libs/api/integration/github/src/core/webhook.test.ts
+++ b/libs/api/integration/github/src/core/webhook.test.ts
@@ -299,6 +299,29 @@ describe('handleGithubEvent', () => {
     });
   });
 
+  it('requests cached installation token cleanup when the installation is deleted', async () => {
+    const installationId = 7791;
+    const connection = fakeConnection();
+    await seedInstallation(installationId, connection.id);
+    const handlers = deps({connection});
+    const deleteInstallationTokenSecret = vi.fn(() => Promise.resolve());
+
+    const result = await handleGithubEvent({
+      tx: db(),
+      deliveryId: randomUUID(),
+      event: 'installation',
+      payload: {action: 'deleted', installation: {id: installationId}},
+      deleteInstallationTokenSecret,
+      ...handlers,
+    });
+
+    expect(result.outcome).toBe('published-envelope');
+    expect(deleteInstallationTokenSecret).toHaveBeenCalledWith({
+      workspaceId: connection.workspaceId,
+      installationId,
+    });
+  });
+
   it('publishes a bare resource envelope when action is malformed', async () => {
     const installationId = 7782;
     const connection = fakeConnection();

--- a/libs/api/integration/github/src/core/webhook.ts
+++ b/libs/api/integration/github/src/core/webhook.ts
@@ -30,6 +30,9 @@ export interface HandleGithubEventParams {
   publishSourcePush: PublishSourcePushFn;
   recordDeliveryOnly: RecordDeliveryOnlyFn;
   getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
+  deleteInstallationTokenSecret?:
+    | ((params: {workspaceId: string; installationId: number}) => Promise<unknown>)
+    | undefined;
 }
 
 export type HandleGithubEventOutcome =
@@ -98,6 +101,13 @@ export async function handleGithubEvent(
     return {outcome: 'missing-connection'};
   }
 
+  if (shouldDeleteInstallationTokenSecret(params.event, action)) {
+    await params.deleteInstallationTokenSecret?.({
+      workspaceId: connection.workspaceId,
+      installationId,
+    });
+  }
+
   if (connection.lifecycleStatus !== 'active') {
     const logContext = {
       deliveryId: params.deliveryId,
@@ -154,6 +164,10 @@ export async function handleGithubEvent(
     connection,
     event: eventName,
   });
+}
+
+function shouldDeleteInstallationTokenSecret(event: string, action: string | undefined): boolean {
+  return event === 'installation' && (action === 'deleted' || action === 'suspend');
 }
 
 async function publishGithubPush(params: {

--- a/libs/api/integration/github/src/core/webhook.ts
+++ b/libs/api/integration/github/src/core/webhook.ts
@@ -101,13 +101,6 @@ export async function handleGithubEvent(
     return {outcome: 'missing-connection'};
   }
 
-  if (shouldDeleteInstallationTokenSecret(params.event, action)) {
-    await params.deleteInstallationTokenSecret?.({
-      workspaceId: connection.workspaceId,
-      installationId,
-    });
-  }
-
   if (connection.lifecycleStatus !== 'active') {
     const logContext = {
       deliveryId: params.deliveryId,
@@ -156,7 +149,7 @@ export async function handleGithubEvent(
   }
 
   const eventName = action ? `${params.event}.${action}` : params.event;
-  return publishGithubEnvelopeOnly({
+  const result = await publishGithubEnvelopeOnly({
     tx: params.tx,
     deliveryId: params.deliveryId,
     payload: params.payload,
@@ -164,10 +157,51 @@ export async function handleGithubEvent(
     connection,
     event: eventName,
   });
+  if (result.outcome === 'published-envelope') {
+    await deleteInstallationTokenSecretBestEffort({
+      deleteInstallationTokenSecret: params.deleteInstallationTokenSecret,
+      event: params.event,
+      action,
+      deliveryId: params.deliveryId,
+      workspaceId: connection.workspaceId,
+      installationId,
+    });
+  }
+  return result;
 }
 
 function shouldDeleteInstallationTokenSecret(event: string, action: string | undefined): boolean {
   return event === 'installation' && (action === 'deleted' || action === 'suspend');
+}
+
+async function deleteInstallationTokenSecretBestEffort(params: {
+  deleteInstallationTokenSecret:
+    | ((params: {workspaceId: string; installationId: number}) => Promise<unknown>)
+    | undefined;
+  event: string;
+  action: string | undefined;
+  deliveryId: string;
+  workspaceId: string;
+  installationId: number;
+}): Promise<void> {
+  if (!shouldDeleteInstallationTokenSecret(params.event, params.action)) return;
+
+  try {
+    await params.deleteInstallationTokenSecret?.({
+      workspaceId: params.workspaceId,
+      installationId: params.installationId,
+    });
+  } catch (error) {
+    logger().warn(
+      {
+        deliveryId: params.deliveryId,
+        installationId: params.installationId,
+        workspaceId: params.workspaceId,
+        error,
+      },
+      'github webhook installation token cleanup failed',
+    );
+  }
 }
 
 async function publishGithubPush(params: {

--- a/libs/api/integration/github/src/db/installation-token-lock.test.ts
+++ b/libs/api/integration/github/src/db/installation-token-lock.test.ts
@@ -24,6 +24,27 @@ describe('withInstallationTokenLock', () => {
     expect(winner).toEqual({acquired: true, value: 'winner'});
   });
 
+  it('does not collide installations that differ outside the 32-bit range', async () => {
+    let releaseLock: () => void = () => {
+      throw new Error('releaseLock was not initialized');
+    };
+    const holder = withInstallationTokenLock(
+      1,
+      () =>
+        new Promise<string>((resolve) => {
+          releaseLock = () => resolve('holder');
+        }),
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    const different = await withInstallationTokenLock(1 + 2 ** 32, async () => 'different');
+    releaseLock();
+    const held = await holder;
+
+    expect(different).toEqual({acquired: true, value: 'different'});
+    expect(held).toEqual({acquired: true, value: 'holder'});
+  });
+
   it('does not exhaust a small pool when many contenders miss the try-lock', async () => {
     let releaseLock: () => void = () => {
       throw new Error('releaseLock was not initialized');

--- a/libs/api/integration/github/src/db/installation-token-lock.test.ts
+++ b/libs/api/integration/github/src/db/installation-token-lock.test.ts
@@ -1,0 +1,49 @@
+import {withInstallationTokenLock} from './installation-token-lock.js';
+
+describe('withInstallationTokenLock', () => {
+  it('allows one holder per installation and fails contenders fast', async () => {
+    let releaseLock: () => void = () => {
+      throw new Error('releaseLock was not initialized');
+    };
+    const first = withInstallationTokenLock(
+      9001,
+      () =>
+        new Promise<string>((resolve) => {
+          releaseLock = () => resolve('winner');
+        }),
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    const contender = await withInstallationTokenLock(9001, async () => 'contender');
+    const different = await withInstallationTokenLock(9002, async () => 'different');
+    releaseLock();
+    const winner = await first;
+
+    expect(contender).toEqual({acquired: false});
+    expect(different).toEqual({acquired: true, value: 'different'});
+    expect(winner).toEqual({acquired: true, value: 'winner'});
+  });
+
+  it('does not exhaust a small pool when many contenders miss the try-lock', async () => {
+    let releaseLock: () => void = () => {
+      throw new Error('releaseLock was not initialized');
+    };
+    const holder = withInstallationTokenLock(
+      9010,
+      () =>
+        new Promise<string>((resolve) => {
+          releaseLock = () => resolve('holder');
+        }),
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    const contenders = await Promise.all(
+      Array.from({length: 20}, () => withInstallationTokenLock(9010, async () => 'contender')),
+    );
+    releaseLock();
+    const held = await holder;
+
+    expect(contenders).toEqual(Array.from({length: 20}, () => ({acquired: false})));
+    expect(held).toEqual({acquired: true, value: 'holder'});
+  });
+});

--- a/libs/api/integration/github/src/db/installation-token-lock.ts
+++ b/libs/api/integration/github/src/db/installation-token-lock.ts
@@ -8,13 +8,11 @@ export function withInstallationTokenLock<T>(
   installationId: number,
   fn: () => Promise<T>,
 ): Promise<InstallationTokenLockResult<T>> {
+  const lockKey = installationTokenLockKey(installationId);
   return db().transaction(async (tx) => {
     const startedAt = Date.now();
     const lock = await tx.execute<{acquired: boolean}>(sql`
-      SELECT pg_try_advisory_xact_lock(
-        hashtext('shipfox_github_installation_token'),
-        hashtext(${String(installationId)})
-      ) AS acquired
+      SELECT pg_try_advisory_xact_lock(${lockKey}::bigint) AS acquired
     `);
     const acquired = lock.rows[0]?.acquired === true;
     if (!acquired) {
@@ -29,4 +27,13 @@ export function withInstallationTokenLock<T>(
       recordInstallationTokenLockWait(Date.now() - startedAt);
     }
   });
+}
+
+function installationTokenLockKey(installationId: number): string {
+  if (!Number.isSafeInteger(installationId) || installationId < 0) {
+    throw new Error(`Invalid GitHub installation id for advisory lock: ${installationId}`);
+  }
+
+  // Keep these exact per-installation keys away from positive advisory-lock ids.
+  return String(-BigInt(installationId) - 1n);
 }

--- a/libs/api/integration/github/src/db/installation-token-lock.ts
+++ b/libs/api/integration/github/src/db/installation-token-lock.ts
@@ -1,0 +1,32 @@
+import {sql} from 'drizzle-orm';
+import {recordInstallationTokenLockWait} from '#metrics/index.js';
+import {db} from './db.js';
+
+export type InstallationTokenLockResult<T> = {acquired: true; value: T} | {acquired: false};
+
+export function withInstallationTokenLock<T>(
+  installationId: number,
+  fn: () => Promise<T>,
+): Promise<InstallationTokenLockResult<T>> {
+  return db().transaction(async (tx) => {
+    const startedAt = Date.now();
+    const lock = await tx.execute<{acquired: boolean}>(sql`
+      SELECT pg_try_advisory_xact_lock(
+        hashtext('shipfox_github_installation_token'),
+        hashtext(${String(installationId)})
+      ) AS acquired
+    `);
+    const acquired = lock.rows[0]?.acquired === true;
+    if (!acquired) {
+      recordInstallationTokenLockWait(Date.now() - startedAt);
+      return {acquired: false};
+    }
+
+    try {
+      const value = await fn();
+      return {acquired: true, value};
+    } finally {
+      recordInstallationTokenLockWait(Date.now() - startedAt);
+    }
+  });
+}

--- a/libs/api/integration/github/src/index.ts
+++ b/libs/api/integration/github/src/index.ts
@@ -6,6 +6,7 @@ import type {
 } from '@shipfox/api-integration-core-dto';
 import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
 import {createGithubApiClient, type GithubApiClient} from '#api/client.js';
+import {deleteGithubInstallationTokenSecret} from '#api/installation-token-provider.js';
 import {GithubAgentToolsProvider} from '#core/agent-tools.js';
 import {GithubSourceControlProvider} from '#core/source-control.js';
 import {closeDb, db} from '#db/db.js';
@@ -56,12 +57,16 @@ export interface CreateGithubIntegrationProviderOptions
   recordDeliveryOnly: RecordDeliveryOnlyFn;
   getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
   getGithubInstallationByConnectionId?: typeof getGithubInstallationByConnectionId | undefined;
+  deleteSecrets?:
+    | ((params: {workspaceId: string; namespace: string}) => Promise<number>)
+    | undefined;
 }
 
 export function createGithubIntegrationProvider(options: CreateGithubIntegrationProviderOptions) {
   const github = options.github ?? createGithubApiClient();
   const getInstallationByConnectionId =
     options.getGithubInstallationByConnectionId ?? getGithubInstallationByConnectionId;
+  const deleteSecrets = options.deleteSecrets;
 
   return {
     provider: 'github' as const,
@@ -92,6 +97,14 @@ export function createGithubIntegrationProvider(options: CreateGithubIntegration
         publishSourcePush: options.publishSourcePush,
         recordDeliveryOnly: options.recordDeliveryOnly,
         getIntegrationConnectionById: options.getIntegrationConnectionById,
+        deleteInstallationTokenSecret: deleteSecrets
+          ? (params) =>
+              deleteGithubInstallationTokenSecret({
+                workspaceId: params.workspaceId,
+                installationId: params.installationId,
+                deleteSecrets,
+              })
+          : undefined,
       }),
     ],
   };

--- a/libs/api/integration/github/src/metrics/index.ts
+++ b/libs/api/integration/github/src/metrics/index.ts
@@ -1,0 +1,1 @@
+export * from './instance.js';

--- a/libs/api/integration/github/src/metrics/instance.ts
+++ b/libs/api/integration/github/src/metrics/instance.ts
@@ -1,0 +1,82 @@
+import type {IntegrationProviderErrorReason} from '@shipfox/api-integration-core-dto';
+import {instanceMetrics} from '@shipfox/node-opentelemetry';
+import type {MintErrorClass} from '#api/installation-token-envelope.js';
+
+const meter = instanceMetrics.getMeter('github');
+
+export type GithubInstallationTokenLookupOutcome =
+  | 'ram-hit'
+  | 'db-hit'
+  | 'minted'
+  | 'served-stale'
+  | 'backoff'
+  | 'contended-poll';
+
+const installationTokenLookupCount = meter.createCounter<{
+  outcome: GithubInstallationTokenLookupOutcome;
+}>('github_installation_token_lookup', {
+  description: 'GitHub installation token cache lookups by serving outcome',
+});
+
+const installationTokenMintCount = meter.createCounter<{outcome: 'success' | 'failure'}>(
+  'github_installation_token_mint',
+  {description: 'GitHub installation token mint attempts by outcome'},
+);
+
+const installationTokenMintDuration = meter.createHistogram<Record<string, never>>(
+  'github_installation_token_mint_duration',
+  {
+    description: 'GitHub installation token mint duration',
+    unit: 'ms',
+    advice: {explicitBucketBoundaries: [10, 50, 100, 250, 500, 1000, 2500, 5000, 10000]},
+  },
+);
+
+const installationTokenLockWaitDuration = meter.createHistogram<Record<string, never>>(
+  'github_installation_token_lock_wait_duration',
+  {
+    description: 'GitHub installation token advisory lock acquire and hold duration',
+    unit: 'ms',
+    advice: {explicitBucketBoundaries: [0, 1, 5, 10, 25, 50, 100, 250, 500, 1000, 5000]},
+  },
+);
+
+const installationTokenBackoffCount = meter.createCounter<{
+  reason: IntegrationProviderErrorReason;
+  class: MintErrorClass;
+}>('github_installation_token_backoff', {
+  description: 'GitHub installation token mint backoff activations by reason and class',
+});
+
+function recordMetric(record: () => void): void {
+  try {
+    record();
+  } catch {
+    // Metrics must not affect GitHub provider outcomes.
+  }
+}
+
+export function recordInstallationTokenLookup(outcome: GithubInstallationTokenLookupOutcome): void {
+  recordMetric(() => installationTokenLookupCount.add(1, {outcome}));
+}
+
+export function recordInstallationTokenMint(params: {
+  outcome: 'success' | 'failure';
+  durationMs: number;
+}): void {
+  recordMetric(() => {
+    installationTokenMintCount.add(1, {outcome: params.outcome});
+    installationTokenMintDuration.record(params.durationMs);
+  });
+}
+
+export function recordInstallationTokenLockWait(durationMs: number): void {
+  recordMetric(() => installationTokenLockWaitDuration.record(durationMs));
+}
+
+export function recordInstallationTokenBackoff(params: {
+  reason: IntegrationProviderErrorReason;
+  class: MintErrorClass;
+}): void {
+  recordMetric(() => installationTokenBackoffCount.add(1, params));
+}

--- a/libs/api/integration/github/src/presentation/routes/webhooks.ts
+++ b/libs/api/integration/github/src/presentation/routes/webhooks.ts
@@ -27,6 +27,9 @@ export interface CreateGithubWebhookRoutesOptions {
   publishSourcePush: PublishSourcePushFn;
   recordDeliveryOnly: RecordDeliveryOnlyFn;
   getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
+  deleteInstallationTokenSecret?:
+    | ((params: {workspaceId: string; installationId: number}) => Promise<unknown>)
+    | undefined;
 }
 
 export function createGithubWebhookRoutes(options: CreateGithubWebhookRoutesOptions): RouteGroup {
@@ -94,6 +97,7 @@ export function createGithubWebhookRoutes(options: CreateGithubWebhookRoutesOpti
           publishSourcePush: options.publishSourcePush,
           recordDeliveryOnly: options.recordDeliveryOnly,
           getIntegrationConnectionById: options.getIntegrationConnectionById,
+          deleteInstallationTokenSecret: options.deleteInstallationTokenSecret,
         });
       });
 

--- a/libs/api/secrets/src/core/management.ts
+++ b/libs/api/secrets/src/core/management.ts
@@ -205,6 +205,7 @@ function writeManagementEntries<Row extends {key: string}>(params: {
     );
     await assertWorkspaceCap({
       workspaceId: params.input.workspaceId,
+      namespace: '',
       incomingEntries: params.keys.length - existingKeys.size,
       tx,
     });

--- a/libs/api/secrets/src/core/secret-store.test.ts
+++ b/libs/api/secrets/src/core/secret-store.test.ts
@@ -118,6 +118,56 @@ describe('secret store', () => {
     );
   });
 
+  it('does not count system namespace entries against the workspace cap', async () => {
+    const workspaceId = crypto.randomUUID();
+    await db()
+      .insert(secretValues)
+      .values(
+        Array.from({length: 10_000}, (_, index) => ({
+          workspaceId,
+          projectId: null,
+          namespace: 'system/github/installation-token/1',
+          key: `KEY_${index}`,
+          ciphertext: 'v1:test',
+          fingerprint: null,
+        })),
+      );
+
+    await setSecrets({workspaceId, values: {TOKEN: 'user-value'}});
+    const value = await getSecret({workspaceId, key: 'TOKEN'});
+
+    expect(value).toBe('user-value');
+  });
+
+  it('allows system namespace writes when user entries are at the workspace cap', async () => {
+    const workspaceId = crypto.randomUUID();
+    await db()
+      .insert(secretValues)
+      .values(
+        Array.from({length: 10_000}, (_, index) => ({
+          workspaceId,
+          projectId: null,
+          namespace: '',
+          key: `KEY_${index}`,
+          ciphertext: 'v1:test',
+          fingerprint: null,
+        })),
+      );
+
+    await setSecrets({
+      workspaceId,
+      namespace: 'system/github/installation-token/1',
+      values: {TOKEN: 'system-value'},
+    });
+    const value = await getSecret({
+      workspaceId,
+      namespace: 'system/github/installation-token/1',
+      key: 'TOKEN',
+    });
+
+    expect(value).toBe('system-value');
+  });
+
   it('allows updating an existing secret at the workspace cap', async () => {
     const workspaceId = crypto.randomUUID();
     await setSecrets({workspaceId, values: {TOKEN: 'old-value'}});

--- a/libs/api/secrets/src/core/secret-store.ts
+++ b/libs/api/secrets/src/core/secret-store.ts
@@ -96,6 +96,7 @@ export function createSecretStoreApi(params: {
         );
         await assertWorkspaceCap({
           workspaceId: input.workspaceId,
+          namespace,
           incomingEntries: entries.length - existingEntries,
           tx,
         });

--- a/libs/api/secrets/src/core/store-validation.ts
+++ b/libs/api/secrets/src/core/store-validation.ts
@@ -1,4 +1,4 @@
-import {namespaceSchema, secretKeySchema} from '@shipfox/api-secrets-dto';
+import {isSystemNamespace, namespaceSchema, secretKeySchema} from '@shipfox/api-secrets-dto';
 import {config, MAX_VALUE_BYTES} from '#config.js';
 import {countWorkspaceEntries, type Tx} from '#db/index.js';
 import {
@@ -29,9 +29,13 @@ export function validateValueBytes(values: Iterable<string>): void {
 
 export async function assertWorkspaceCap(params: {
   workspaceId: string;
+  namespace: string;
   incomingEntries: number;
   tx: Tx;
 }): Promise<void> {
+  // System namespaces are internal-only; public management routes do not accept a namespace.
+  if (isSystemNamespace(params.namespace)) return;
+
   const count = await countWorkspaceEntries(params.workspaceId, params.tx);
   if (count + params.incomingEntries > config.SECRETS_MAX_PER_WORKSPACE) {
     throw new WorkspaceSecretCapExceededError(params.workspaceId, config.SECRETS_MAX_PER_WORKSPACE);

--- a/libs/api/secrets/src/core/variable-store.ts
+++ b/libs/api/secrets/src/core/variable-store.ts
@@ -72,6 +72,7 @@ export async function setVariables(input: SetVariablesParams): Promise<void> {
     );
     await assertWorkspaceCap({
       workspaceId: input.workspaceId,
+      namespace,
       incomingEntries: entries.length - existingEntries,
       tx,
     });

--- a/libs/api/secrets/src/db/cap.ts
+++ b/libs/api/secrets/src/db/cap.ts
@@ -5,23 +5,29 @@ import {secretVariables} from './schema/variables.js';
 
 export async function countWorkspaceEntries(workspaceId: string, tx?: Tx): Promise<number> {
   const executor = tx ?? db();
-  const valueRows = await executor
-    .select({value: count()})
+  const valueCount = executor
+    .select({count: count().as('value_count')})
     .from(secretValues)
     .where(
       and(eq(secretValues.workspaceId, workspaceId), notLike(secretValues.namespace, 'system/%')),
-    );
-  const variableRows = await executor
-    .select({value: count()})
+    )
+    .as('value_count');
+  const variableCount = executor
+    .select({count: count().as('variable_count')})
     .from(secretVariables)
     .where(
       and(
         eq(secretVariables.workspaceId, workspaceId),
         notLike(secretVariables.namespace, 'system/%'),
       ),
-    );
+    )
+    .as('variable_count');
+  const [row] = await executor
+    .select({value: sql<number>`${valueCount.count} + ${variableCount.count}`})
+    .from(valueCount)
+    .crossJoin(variableCount);
 
-  return Number(valueRows[0]?.value ?? 0) + Number(variableRows[0]?.value ?? 0);
+  return Number(row?.value ?? 0);
 }
 
 export async function lockWorkspaceEntries(workspaceId: string, tx: Tx): Promise<void> {

--- a/libs/api/secrets/src/db/cap.ts
+++ b/libs/api/secrets/src/db/cap.ts
@@ -1,25 +1,27 @@
-import {sql} from 'drizzle-orm';
+import {and, count, eq, notLike, sql} from 'drizzle-orm';
 import {db, type Tx} from './db.js';
+import {secretValues} from './schema/values.js';
+import {secretVariables} from './schema/variables.js';
 
 export async function countWorkspaceEntries(workspaceId: string, tx?: Tx): Promise<number> {
   const executor = tx ?? db();
-  const result = await executor.execute<{count: string | number}>(sql`
-    SELECT
-      (
-        SELECT COUNT(*)
-        FROM secrets_values
-        WHERE workspace_id = ${workspaceId}
-          AND namespace NOT LIKE 'system/%'
-      ) +
-      (
-        SELECT COUNT(*)
-        FROM secrets_variables
-        WHERE workspace_id = ${workspaceId}
-          AND namespace NOT LIKE 'system/%'
-      ) AS count
-  `);
-  const count = result.rows[0]?.count ?? 0;
-  return Number(count);
+  const valueRows = await executor
+    .select({value: count()})
+    .from(secretValues)
+    .where(
+      and(eq(secretValues.workspaceId, workspaceId), notLike(secretValues.namespace, 'system/%')),
+    );
+  const variableRows = await executor
+    .select({value: count()})
+    .from(secretVariables)
+    .where(
+      and(
+        eq(secretVariables.workspaceId, workspaceId),
+        notLike(secretVariables.namespace, 'system/%'),
+      ),
+    );
+
+  return Number(valueRows[0]?.value ?? 0) + Number(variableRows[0]?.value ?? 0);
 }
 
 export async function lockWorkspaceEntries(workspaceId: string, tx: Tx): Promise<void> {

--- a/libs/api/secrets/src/db/cap.ts
+++ b/libs/api/secrets/src/db/cap.ts
@@ -5,8 +5,18 @@ export async function countWorkspaceEntries(workspaceId: string, tx?: Tx): Promi
   const executor = tx ?? db();
   const result = await executor.execute<{count: string | number}>(sql`
     SELECT
-      (SELECT COUNT(*) FROM secrets_values WHERE workspace_id = ${workspaceId}) +
-      (SELECT COUNT(*) FROM secrets_variables WHERE workspace_id = ${workspaceId}) AS count
+      (
+        SELECT COUNT(*)
+        FROM secrets_values
+        WHERE workspace_id = ${workspaceId}
+          AND namespace NOT LIKE 'system/%'
+      ) +
+      (
+        SELECT COUNT(*)
+        FROM secrets_variables
+        WHERE workspace_id = ${workspaceId}
+          AND namespace NOT LIKE 'system/%'
+      ) AS count
   `);
   const count = result.rows[0]?.count ?? 0;
   return Number(count);


### PR DESCRIPTION
Add a shared GitHub installation-token cache backed by the internal secrets store abstraction.

Broad installation tokens were previously cached only in each pod's memory, so cold starts and refresh margins could fan out into duplicate GitHub token mints across replicas. This introduces a RAM-over-shared cache with a persisted envelope, refresh/backoff state, non-blocking advisory-lock coordination, bounded contender polling, and metrics for lookup, mint, lock, and backoff outcomes.

The GitHub package keeps the secrets store injected rather than depending on `@shipfox/api-secrets`, avoiding a package cycle. The API composition layer passes the cleanup dependency through, and installation deleted/suspended webhooks clear cached token namespaces. `system/%` secrets are excluded from user workspace cap accounting because these entries are internal service state, not user-managed secrets.

Changesets were not added because the touched library packages are private. The production `secretStore` adapter and encrypted ciphertext round-trip integration test remain coupled to the follow-up gateway wiring.

Refs ENG-859

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared, tiered cache for GitHub installation tokens to prevent duplicate mints across replicas and survive cold starts. Also cleans up cached tokens on installation delete/suspend and exempts `system/%` namespaces from workspace caps. Refs ENG-859.

- **New Features**
  - RAM-over-shared token cache with persisted envelope/backoff, non-blocking PG advisory locks, bounded polling, and cached workspace-id resolution.
  - Metrics for lookup outcomes (ram-hit/db-hit/minted/served-stale/backoff/contended-poll), mint success/failure with duration, and lock-wait; mint attempts are time-limited; serves stale tokens on transient mint failures.
  - Webhooks trigger best-effort token-secret cleanup on installation `deleted`/`suspend` after envelope publish; skipped for duplicate deliveries and failures are non-blocking.

- **Refactors**
  - `createIntegrationsContext` accepts `secrets` and passes to provider loaders; GitHub module calls injected `deleteSecrets` without depending on `@shipfox/api-secrets`; API boot wires `deleteSecrets` through.
  - GitHub token provider composes in-memory cache over a shared secrets-backed cache with PG advisory locks.
  - Secrets cap counting now uses a single Drizzle query, excludes `system/%`, and passes `namespace` into cap checks.

<sup>Written for commit 2dc61264075d4178dc052c6b6399ccd139878888. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

