### PR TITLE
[api-workflows] Cover listener config plan dispatch

### DIFF
--- a/libs/api/workflows/src/db/job-listeners.test.ts
+++ b/libs/api/workflows/src/db/job-listeners.test.ts
@@ -563,6 +563,74 @@ describe('drainListenerEventsIntoExecution', () => {
     expect(materialized[1]?.config).toEqual({run: 'echo review'});
   });
 
+  it('persists listener step config plans for dispatch-time templates', async () => {
+    const job = await createListeningJobFromModel({
+      jobs: {
+        deploy: {
+          steps: [
+            {key: 'build', run: 'echo build'},
+            {
+              key: 'deploy',
+              run: 'echo "$SHA"',
+              env: {SHA: template('steps.build.outputs.sha')},
+            },
+          ],
+        },
+      },
+    });
+    await bufferEvent(job.id);
+
+    const drained = await drainListenerEventsIntoExecution({jobId: job.id, expectedSequence: 1});
+
+    if (drained.kind !== 'execution') throw new Error('Expected listener execution');
+    const materialized = await db()
+      .select()
+      .from(steps)
+      .where(eq(steps.jobExecutionId, drained.jobExecutionId))
+      .orderBy(asc(steps.position));
+    expect(materialized[0]?.configPlan).toBeNull();
+    expect(materialized[2]?.configPlan).toMatchObject({
+      env: {
+        SHA: {
+          segments: [
+            {
+              kind: 'deferred',
+              roots: ['steps'],
+              fillTarget: 'step-dispatch',
+              expression: {source: 'steps.build.outputs.sha'},
+            },
+          ],
+        },
+      },
+    });
+
+    const setupStep = await nextStepForJob(job.id);
+    if (setupStep.kind !== 'step') throw new Error('Expected setup step');
+    await recordStepResult({
+      jobExecutionId: drained.jobExecutionId,
+      stepId: setupStep.step.id,
+      status: 'succeeded',
+    });
+    const buildStep = await nextStepForJob(job.id);
+    if (buildStep.kind !== 'step') throw new Error('Expected build step');
+    await recordStepResult({
+      jobExecutionId: drained.jobExecutionId,
+      stepId: buildStep.step.id,
+      status: 'succeeded',
+      output: {sha: 'abc123'},
+    });
+
+    const deployStep = await nextStepForJob(job.id);
+
+    expect(deployStep).toEqual({
+      kind: 'step',
+      step: expect.objectContaining({
+        key: 'deploy',
+        config: {run: 'echo "$SHA"', env: {SHA: 'abc123'}},
+      }),
+    });
+  });
+
   it('peeks the unconsumed listener buffer from DB state', async () => {
     const job = await createListeningJob({status: 'running', listenerStatus: 'listening'});
     await bufferEvent(job.id, 'fire', crypto.randomUUID(), new Date(Date.now() - 10_000));


### PR DESCRIPTION
Add regression coverage for listener execution materialization preserving deferred step config plans.

Listener firings materialize steps at execution creation, then dispatch later fills any `step-dispatch` templates from upstream step outputs. This test proves a listener-created consumer step keeps its `configPlan` after drain and then resolves `${{ steps.build.outputs.sha }}` when dispatched.

No changeset is included because this is test-only coverage for existing behavior.

Closes ENG-792

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add regression test to ensure listener-created steps keep their deferred config plans through event drain and that dispatch resolves step-dispatch templates (e.g., steps.build.outputs.sha) into env from upstream outputs. Addresses ENG-792 by validating listener execution materialization and dispatch behavior without changing runtime code.

<sup>Written for commit bc4f7c1d5b70a2ce997bf2b4ea3b1a2abe71928b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

