### PR TITLE
[api/workflows] Decompose workflow execution helpers

### DIFF
--- a/libs/api/workflows/src/core/job-execution.test.ts
+++ b/libs/api/workflows/src/core/job-execution.test.ts
@@ -17,13 +17,18 @@ import {stepAttempts as stepAttemptsTable} from '#db/schema/step-attempts.js';
 import {steps as stepsTable} from '#db/schema/steps.js';
 import {bulkUpdateStepStatuses, getStepAttempts, getStepsByJobId} from '#db/workflow-runs.js';
 import {arrangeJobWithSteps} from '#test/fixtures/job-with-steps.js';
+import type {Step} from './entities/step.js';
 import {
   JobNotFoundError,
   StepAttemptAheadError,
   StepNotFoundError,
   StepNotRunningError,
 } from './errors.js';
-import {nextStepForJob, recordStepResult as recordJobExecutionStepResult} from './job-execution.js';
+import {
+  classifyReportedStep,
+  nextStepForJob,
+  recordStepResult as recordJobExecutionStepResult,
+} from './job-execution.js';
 
 async function recordStepResult(
   params: Omit<Parameters<typeof recordJobExecutionStepResult>[0], 'jobExecutionId'> & {
@@ -78,6 +83,31 @@ async function stepAttemptTerminatedEvents(
       ),
     );
   return rows.map((row) => row.payload as WorkflowsStepAttemptTerminatedEventDto);
+}
+
+function stepForClassification(params: Partial<Step> = {}): Step {
+  return {
+    id: 'step-1',
+    jobExecutionId: 'job-execution-1',
+    key: 'build',
+    name: 'Build',
+    sourceLocation: null,
+    status: 'running',
+    statusReason: null,
+    evaluationTrace: null,
+    type: 'run',
+    config: {run: 'echo ok'},
+    condition: null,
+    configPlan: null,
+    authoredConfig: null,
+    error: null,
+    position: 0,
+    version: 1,
+    currentAttempt: 1,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    ...params,
+  };
 }
 
 describe('nextStepForJob', () => {
@@ -469,6 +499,54 @@ function stepOutputField(stepKey: string, outputKey: string) {
     ],
   };
 }
+
+describe('classifyReportedStep', () => {
+  it('allows a report for the current running attempt', () => {
+    const step = stepForClassification({status: 'running', currentAttempt: 2});
+
+    const result = classifyReportedStep(step, 2, 'job-1');
+
+    expect(result).toBe('proceed');
+  });
+
+  it('rejects a report ahead of the current attempt', () => {
+    const step = stepForClassification({currentAttempt: 2});
+
+    const result = classifyReportedStep(step, 3, 'job-1');
+
+    expect(result).toBeInstanceOf(StepAttemptAheadError);
+    expect(result).toMatchObject({stepId: step.id, jobId: 'job-1'});
+  });
+
+  it('ignores a stale report from an older attempt', () => {
+    const step = stepForClassification({currentAttempt: 2});
+
+    const result = classifyReportedStep(step, 1, 'job-1');
+
+    expect(result).toBe('noop');
+  });
+
+  it.each([
+    'succeeded',
+    'failed',
+    'cancelled',
+    'skipped',
+  ] as const)('ignores duplicate reports for a %s step', (status) => {
+    const step = stepForClassification({status});
+
+    const result = classifyReportedStep(step, 1, 'job-1');
+
+    expect(result).toBe('noop');
+  });
+
+  it('rejects a report for a pending step', () => {
+    const step = stepForClassification({status: 'pending'});
+
+    const result = classifyReportedStep(step, 1, 'job-1');
+
+    expect(result).toBeInstanceOf(StepNotRunningError);
+  });
+});
 
 describe('recordStepResult', () => {
   test('succeeded on a non-final step → {jobFinished:false}', async () => {

--- a/libs/api/workflows/src/core/job-execution.ts
+++ b/libs/api/workflows/src/core/job-execution.ts
@@ -83,6 +83,15 @@ interface PendingStepDispatchParams {
   readonly tx: Tx;
 }
 
+interface ResolvePendingStepParams {
+  readonly jobExecutionId: string;
+  readonly steps: Step[];
+  readonly jobExecution: JobExecution;
+  readonly attempts: Awaited<ReturnType<typeof getStepAttemptsByJobExecutionId>>;
+  readonly jobs: Awaited<ReturnType<typeof getDirectDependencyJobContexts>>;
+  readonly tx: Tx;
+}
+
 type StepConditionOutcome =
   | {kind: 'run'}
   | {
@@ -108,10 +117,9 @@ async function nextStepForJobExecutionInTransaction(
   const hasRunningStep = running !== undefined;
   if (hasRunningStep) return {kind: 'step', step: running};
 
-  let currentSteps = steps;
-  const firstPending = currentSteps.find((step) => step.status === 'pending');
+  const firstPending = steps.find((step) => step.status === 'pending');
   const hasPendingStep = firstPending !== undefined;
-  if (!hasPendingStep) return {kind: 'done', status: deriveCompletion(currentSteps)};
+  if (!hasPendingStep) return {kind: 'done', status: deriveCompletion(steps)};
 
   const jobExecution = await getJobExecutionById(jobExecutionId, tx);
   if (!jobExecution) throw new JobNotFoundError(jobExecutionId);
@@ -119,7 +127,20 @@ async function nextStepForJobExecutionInTransaction(
   const attempts = await getStepAttemptsByJobExecutionId(jobExecutionId, tx);
   const jobs = await getDirectDependencyJobContexts(jobExecution.jobId, tx);
 
+  return resolveNextPendingStep({jobExecutionId, steps, jobExecution, attempts, jobs, tx});
+}
+
+async function resolveNextPendingStep({
+  jobExecutionId,
+  steps,
+  jobExecution,
+  attempts,
+  jobs,
+  tx,
+}: ResolvePendingStepParams): Promise<NextStep> {
   let skippedAny = false;
+  let currentSteps = steps;
+
   while (true) {
     const pending = currentSteps.find((step) => step.status === 'pending');
     if (pending === undefined) {
@@ -388,34 +409,11 @@ async function recordStepResultInTransaction(
 
   if (!hasTargetStep) throw new StepNotFoundError(params.stepId, jobExecutionId);
 
-  // Attempt-aware idempotency, evaluated before the running/terminal checks and
-  // anchored on the step's current attempt (the step_attempts unique constraint
-  // is the race backstop). These DB-state-dependent guards stay in the service;
-  // only the semantic decision below is pure.
   const current = target.currentAttempt;
   const reported = params.attempt ?? current;
-  const reportIsAhead = reported > current;
-  if (reportIsAhead) {
-    // The host allocates attempts; a runner cannot report one ahead of dispatch.
-    throw new StepAttemptAheadError(params.stepId, jobExecution.jobId, reported, current);
-  }
-
-  const reportIsStale = reported < current;
-  if (reportIsStale) {
-    // A stale report from a superseded attempt (e.g. after a rewind bumped the
-    // current attempt). No-op: leave the projection untouched.
-    return {outcome: outcomeFromSteps(steps), metrics: {}};
-  }
-
-  const targetIsTerminal = isTerminal(target.status);
-  // A terminal target is a duplicate report, left untouched.
-  if (targetIsTerminal) return {outcome: outcomeFromSteps(steps), metrics: {}};
-
-  const targetIsPending = target.status === 'pending';
-  // A result may only land on a step that was actually handed out.
-  if (targetIsPending) {
-    throw new StepNotRunningError(params.stepId, jobExecution.jobId);
-  }
+  const reportClassification = classifyReportedStep(target, reported, jobExecution.jobId);
+  if (reportClassification instanceof Error) throw reportClassification;
+  if (reportClassification === 'noop') return {outcome: outcomeFromSteps(steps), metrics: {}};
 
   // Migration/back-compat boundary: a running step may predate the
   // step_attempts table or have been marked running by legacy code. Create
@@ -495,6 +493,24 @@ type OutputCoercionResult =
   | {kind: 'not-applicable'}
   | {kind: 'coerced'; output: Record<string, unknown>}
   | {kind: 'failed'; error: StepOutputCoercionError};
+
+export type ReportedStepClassification = 'proceed' | 'noop' | Error;
+
+export function classifyReportedStep(
+  target: Step,
+  reportedAttempt: number,
+  jobId: string,
+): ReportedStepClassification {
+  const currentAttempt = target.currentAttempt;
+  if (reportedAttempt > currentAttempt) {
+    return new StepAttemptAheadError(target.id, jobId, reportedAttempt, currentAttempt);
+  }
+
+  if (reportedAttempt < currentAttempt) return 'noop';
+  if (isTerminal(target.status)) return 'noop';
+  if (target.status === 'pending') return new StepNotRunningError(target.id, jobId);
+  return 'proceed';
+}
 
 function coerceReportedStepOutput(
   config: Record<string, unknown>,

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -1589,21 +1589,14 @@ interface RunTerminationSpec {
   emitCancelledEvent: boolean;
 }
 
-/**
- * Shared terminal transition for a run attempt. The caller locks the run and the
- * attempt (and decides how an already-terminal run is handled: timeout returns
- * idempotently, cancellation rejects), then this drives every non-terminal job,
- * execution, and step to `spec.terminalStatus`, resolves still-listening jobs,
- * flips the attempt and run, and writes the outbox. Callers record metrics after
- * the transaction commits.
- */
-async function terminateRunAttempt(
+interface TerminateRunAttemptParams {
+  lockedRun: typeof workflowRuns.$inferSelect;
+  lockedAttempt: typeof workflowRunAttempts.$inferSelect;
+}
+
+async function cascadeRunAttemptTermination(
   tx: Tx,
-  params: {
-    lockedRun: typeof workflowRuns.$inferSelect;
-    lockedAttempt: typeof workflowRunAttempts.$inferSelect;
-    spec: RunTerminationSpec;
-  },
+  params: TerminateRunAttemptParams & {spec: RunTerminationSpec},
 ): Promise<{run: WorkflowRun; changedJobs: Job[]}> {
   const {lockedRun, lockedAttempt, spec} = params;
 
@@ -1726,6 +1719,36 @@ async function terminateRunAttempt(
   return {run, changedJobs};
 }
 
+function timeoutRunAttempt(
+  tx: Tx,
+  params: TerminateRunAttemptParams,
+): Promise<{run: WorkflowRun; changedJobs: Job[]}> {
+  return cascadeRunAttemptTermination(tx, {
+    ...params,
+    spec: {
+      terminalStatus: 'failed',
+      statusReason: 'timed_out',
+      markExecutionTimedOut: true,
+      emitCancelledEvent: false,
+    },
+  });
+}
+
+function cancelRunAttempt(
+  tx: Tx,
+  params: TerminateRunAttemptParams,
+): Promise<{run: WorkflowRun; changedJobs: Job[]}> {
+  return cascadeRunAttemptTermination(tx, {
+    ...params,
+    spec: {
+      terminalStatus: 'cancelled',
+      statusReason: 'run_cancelled',
+      markExecutionTimedOut: false,
+      emitCancelledEvent: true,
+    },
+  });
+}
+
 export async function failWorkflowRunAsTimedOut(
   params: FailWorkflowRunAsTimedOutParams,
 ): Promise<WorkflowRun> {
@@ -1749,15 +1772,9 @@ export async function failWorkflowRunAsTimedOut(
       return {run: toWorkflowRun(lockedRun), changedJobs: []};
     }
 
-    return terminateRunAttempt(tx, {
+    return timeoutRunAttempt(tx, {
       lockedRun,
       lockedAttempt,
-      spec: {
-        terminalStatus: 'failed',
-        statusReason: 'timed_out',
-        markExecutionTimedOut: true,
-        emitCancelledEvent: false,
-      },
     });
   });
 
@@ -1799,15 +1816,9 @@ export async function cancelWorkflowRun(params: CancelWorkflowRunParams): Promis
       );
     }
 
-    return terminateRunAttempt(tx, {
+    return cancelRunAttempt(tx, {
       lockedRun,
       lockedAttempt,
-      spec: {
-        terminalStatus: 'cancelled',
-        statusReason: 'run_cancelled',
-        markExecutionTimedOut: false,
-        emitCancelledEvent: true,
-      },
     });
   });
 


### PR DESCRIPTION
Decompose overloaded workflow execution helpers without behavior changes.

`recordStepResultInTransaction` mixed attempt idempotency classification with output coercion, gate evaluation, and transition application, while next-step dispatch and run termination also carried inline mode-specific branches. This extracts pure step-report classification, isolates pending-step skip resolution, and gives timeout/cancel run termination intention-named wrappers over the shared cascade.

This keeps the existing persistence and orchestration behavior intact while making the idempotency guard directly testable and reducing the long helper surfaces called out in the workflows refactor.

The only package touched is private `@shipfox/api-workflows`, so no changeset is included.

Closes ENG-884

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decomposed overloaded workflow execution helpers to simplify responsibilities and improve testability, with no behavior changes. Aligns with ENG-884 by isolating idempotency checks and reducing long helper surfaces in `@shipfox/api-workflows`.

- **Refactors**
  - Extracted `classifyReportedStep` for attempt-aware idempotency and state checks; added unit tests.
  - Isolated pending-step resolution into `resolveNextPendingStep`, used by `nextStepForJobExecutionInTransaction`.
  - Split run termination into `timeoutRunAttempt` and `cancelRunAttempt` wrappers over `cascadeRunAttemptTermination` (shared cascade).

<sup>Written for commit b81130cc41f75913981ffee67a26bcb31998b267. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

