### PR TITLE
[annotations] Add module foundation

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -23,6 +23,7 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
+    "@shipfox/annotations": "workspace:*",
     "@shipfox/api-agent": "workspace:*",
     "@shipfox/api-auth": "workspace:*",
     "@shipfox/api-definitions": "workspace:*",

--- a/apps/api/src/core/run.ts
+++ b/apps/api/src/core/run.ts
@@ -1,3 +1,4 @@
+import {annotationsModule} from '@shipfox/annotations';
 import {agentModule} from '@shipfox/api-agent';
 import {authModule} from '@shipfox/api-auth';
 import {createDefinitionsModule} from '@shipfox/api-definitions';
@@ -43,6 +44,7 @@ export async function run(): Promise<void> {
     projectsModule,
     definitionsModule,
     workflowsModule,
+    annotationsModule,
     runnersModule,
     logsModule,
     triggersModule,

--- a/libs/api/annotations-dto/package.json
+++ b/libs/api/annotations-dto/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@shipfox/annotations-dto",
+  "license": "MIT",
+  "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
+    "directory": "libs/api/annotations-dto"
+  },
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "imports": {
+    "#test/*": "./test/*",
+    "#*": "./src/*"
+  },
+  "exports": {
+    ".": {
+      "development": {
+        "types": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "depcruise": "shipfox-depcruise",
+    "test": "shipfox-vitest-run",
+    "test:watch": "shipfox-vitest-watch",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/depcruise": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*"
+  }
+}

--- a/libs/api/annotations-dto/src/index.ts
+++ b/libs/api/annotations-dto/src/index.ts
@@ -1,5 +1,6 @@
 export {
   ANNOTATION_CONTEXT_MAX_LENGTH,
+  ANNOTATION_CONTEXT_TRIM_CODE_POINTS,
   ANNOTATION_STYLES,
   type AnnotationDto,
   type AnnotationStyleDto,

--- a/libs/api/annotations-dto/src/index.ts
+++ b/libs/api/annotations-dto/src/index.ts
@@ -1,4 +1,6 @@
 export {
+  ANNOTATION_CONTEXT_MAX_LENGTH,
+  ANNOTATION_STYLES,
   type AnnotationDto,
   type AnnotationStyleDto,
   annotationDtoSchema,

--- a/libs/api/annotations-dto/src/index.ts
+++ b/libs/api/annotations-dto/src/index.ts
@@ -1,0 +1,14 @@
+export {
+  type AnnotationDto,
+  type AnnotationStyleDto,
+  annotationDtoSchema,
+  annotationStyleSchema,
+  type LeasedWriteAnnotationOperationDto,
+  type LeasedWriteAnnotationsBodyDto,
+  type LeasedWriteAnnotationsResponseDto,
+  leasedWriteAnnotationOperationSchema,
+  leasedWriteAnnotationsBodySchema,
+  leasedWriteAnnotationsResponseSchema,
+  type ReadAnnotationsResponseDto,
+  readAnnotationsResponseSchema,
+} from '#schemas/index.js';

--- a/libs/api/annotations-dto/src/schemas/annotation.test.ts
+++ b/libs/api/annotations-dto/src/schemas/annotation.test.ts
@@ -5,7 +5,7 @@ describe('annotation schemas', () => {
     const body = leasedWriteAnnotationsBodySchema.parse({
       step_id: crypto.randomUUID(),
       attempt: 1,
-      annotations: [{context: 'default', body: '### Summary'}],
+      annotations: [{context: ' default ', body: '### Summary'}],
     });
 
     expect(body.annotations[0]).toMatchObject({
@@ -14,6 +14,27 @@ describe('annotation schemas', () => {
       op: 'replace',
       body: '### Summary',
     });
+  });
+
+  it('rejects write operations with invalid body pairing', () => {
+    const baseBody = {
+      step_id: crypto.randomUUID(),
+      attempt: 1,
+    };
+
+    const missingReplaceBody = () =>
+      leasedWriteAnnotationsBodySchema.parse({
+        ...baseBody,
+        annotations: [{context: 'deploy', op: 'replace'}],
+      });
+    const removeWithBody = () =>
+      leasedWriteAnnotationsBodySchema.parse({
+        ...baseBody,
+        annotations: [{context: 'deploy', op: 'remove', body: 'ignored'}],
+      });
+
+    expect(missingReplaceBody).toThrow();
+    expect(removeWithBody).toThrow();
   });
 
   it('accepts the read response annotation DTO shape', () => {

--- a/libs/api/annotations-dto/src/schemas/annotation.test.ts
+++ b/libs/api/annotations-dto/src/schemas/annotation.test.ts
@@ -1,0 +1,38 @@
+import {leasedWriteAnnotationsBodySchema, readAnnotationsResponseSchema} from './annotation.js';
+
+describe('annotation schemas', () => {
+  it('defaults leased write operation style and op', () => {
+    const body = leasedWriteAnnotationsBodySchema.parse({
+      step_id: crypto.randomUUID(),
+      attempt: 1,
+      annotations: [{context: 'default', body: '### Summary'}],
+    });
+
+    expect(body.annotations[0]).toMatchObject({
+      context: 'default',
+      style: 'default',
+      op: 'replace',
+      body: '### Summary',
+    });
+  });
+
+  it('accepts the read response annotation DTO shape', () => {
+    const response = readAnnotationsResponseSchema.parse({
+      annotations: [
+        {
+          id: crypto.randomUUID(),
+          job_id: crypto.randomUUID(),
+          job_execution_id: crypto.randomUUID(),
+          origin_step_id: crypto.randomUUID(),
+          origin_step_attempt: 1,
+          context: 'deploy',
+          style: 'success',
+          sequence: 1,
+          body: 'Deployed **v42**',
+        },
+      ],
+    });
+
+    expect(response.annotations).toHaveLength(1);
+  });
+});

--- a/libs/api/annotations-dto/src/schemas/annotation.test.ts
+++ b/libs/api/annotations-dto/src/schemas/annotation.test.ts
@@ -1,4 +1,8 @@
-import {leasedWriteAnnotationsBodySchema, readAnnotationsResponseSchema} from './annotation.js';
+import {
+  ANNOTATION_CONTEXT_MAX_LENGTH,
+  leasedWriteAnnotationsBodySchema,
+  readAnnotationsResponseSchema,
+} from './annotation.js';
 
 describe('annotation schemas', () => {
   it('defaults leased write operation style and op', () => {
@@ -35,6 +39,28 @@ describe('annotation schemas', () => {
 
     expect(missingReplaceBody).toThrow();
     expect(removeWithBody).toThrow();
+  });
+
+  it('counts context length by Unicode code point', () => {
+    const baseBody = {
+      step_id: crypto.randomUUID(),
+      attempt: 1,
+    };
+    const maxLengthContext = '😀'.repeat(ANNOTATION_CONTEXT_MAX_LENGTH);
+    const tooLongContext = '😀'.repeat(ANNOTATION_CONTEXT_MAX_LENGTH + 1);
+
+    const body = leasedWriteAnnotationsBodySchema.parse({
+      ...baseBody,
+      annotations: [{context: maxLengthContext, body: 'ok'}],
+    });
+    const parseTooLong = () =>
+      leasedWriteAnnotationsBodySchema.parse({
+        ...baseBody,
+        annotations: [{context: tooLongContext, body: 'no'}],
+      });
+
+    expect(body.annotations[0]?.context).toBe(maxLengthContext);
+    expect(parseTooLong).toThrow();
   });
 
   it('accepts the read response annotation DTO shape', () => {

--- a/libs/api/annotations-dto/src/schemas/annotation.test.ts
+++ b/libs/api/annotations-dto/src/schemas/annotation.test.ts
@@ -1,5 +1,6 @@
 import {
   ANNOTATION_CONTEXT_MAX_LENGTH,
+  ANNOTATION_CONTEXT_TRIM_CODE_POINTS,
   leasedWriteAnnotationsBodySchema,
   readAnnotationsResponseSchema,
 } from './annotation.js';
@@ -61,6 +62,18 @@ describe('annotation schemas', () => {
 
     expect(body.annotations[0]?.context).toBe(maxLengthContext);
     expect(parseTooLong).toThrow();
+  });
+
+  it('keeps exported trim code points aligned with JavaScript trim', () => {
+    const javascriptTrimCodePoints: number[] = [];
+    for (let codePoint = 0; codePoint <= 0xffff; codePoint += 1) {
+      const character = String.fromCodePoint(codePoint);
+      if (`${character}deploy${character}`.trim() === 'deploy') {
+        javascriptTrimCodePoints.push(codePoint);
+      }
+    }
+
+    expect(ANNOTATION_CONTEXT_TRIM_CODE_POINTS).toEqual(javascriptTrimCodePoints);
   });
 
   it('accepts the read response annotation DTO shape', () => {

--- a/libs/api/annotations-dto/src/schemas/annotation.ts
+++ b/libs/api/annotations-dto/src/schemas/annotation.ts
@@ -7,7 +7,9 @@ const annotationContextSchema = z
   .string()
   .trim()
   .min(1)
-  .max(ANNOTATION_CONTEXT_MAX_LENGTH)
+  .refine((value) => [...value].length <= ANNOTATION_CONTEXT_MAX_LENGTH, {
+    message: `String must contain at most ${ANNOTATION_CONTEXT_MAX_LENGTH} character(s)`,
+  })
   .describe('Caller-chosen annotation key. Trimmed and unique within a job execution.');
 
 export const annotationStyleSchema = z.enum(ANNOTATION_STYLES);

--- a/libs/api/annotations-dto/src/schemas/annotation.ts
+++ b/libs/api/annotations-dto/src/schemas/annotation.ts
@@ -3,11 +3,21 @@ import {z} from 'zod';
 export const ANNOTATION_STYLES = ['default', 'info', 'success', 'warning', 'error'] as const;
 export const ANNOTATION_CONTEXT_MAX_LENGTH = 255;
 
+function hasMaxCodePoints(value: string, maxCodePoints: number): boolean {
+  let count = 0;
+  for (const _codePoint of value) {
+    count += 1;
+    if (count > maxCodePoints) return false;
+  }
+
+  return true;
+}
+
 const annotationContextSchema = z
   .string()
   .trim()
   .min(1)
-  .refine((value) => [...value].length <= ANNOTATION_CONTEXT_MAX_LENGTH, {
+  .refine((value) => hasMaxCodePoints(value, ANNOTATION_CONTEXT_MAX_LENGTH), {
     message: `String must contain at most ${ANNOTATION_CONTEXT_MAX_LENGTH} character(s)`,
   })
   .describe('Caller-chosen annotation key. Trimmed and unique within a job execution.');

--- a/libs/api/annotations-dto/src/schemas/annotation.ts
+++ b/libs/api/annotations-dto/src/schemas/annotation.ts
@@ -2,6 +2,10 @@ import {z} from 'zod';
 
 export const ANNOTATION_STYLES = ['default', 'info', 'success', 'warning', 'error'] as const;
 export const ANNOTATION_CONTEXT_MAX_LENGTH = 255;
+export const ANNOTATION_CONTEXT_TRIM_CODE_POINTS = [
+  9, 10, 11, 12, 13, 32, 160, 5760, 8192, 8193, 8194, 8195, 8196, 8197, 8198, 8199, 8200, 8201,
+  8202, 8232, 8233, 8239, 8287, 12288, 65279,
+] as const;
 
 function hasMaxCodePoints(value: string, maxCodePoints: number): boolean {
   let count = 0;

--- a/libs/api/annotations-dto/src/schemas/annotation.ts
+++ b/libs/api/annotations-dto/src/schemas/annotation.ts
@@ -1,6 +1,16 @@
 import {z} from 'zod';
 
-export const annotationStyleSchema = z.enum(['default', 'info', 'success', 'warning', 'error']);
+export const ANNOTATION_STYLES = ['default', 'info', 'success', 'warning', 'error'] as const;
+export const ANNOTATION_CONTEXT_MAX_LENGTH = 255;
+
+const annotationContextSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(ANNOTATION_CONTEXT_MAX_LENGTH)
+  .describe('Caller-chosen annotation key. Trimmed and unique within a job execution.');
+
+export const annotationStyleSchema = z.enum(ANNOTATION_STYLES);
 
 export type AnnotationStyleDto = z.infer<typeof annotationStyleSchema>;
 
@@ -10,7 +20,7 @@ export const annotationDtoSchema = z.object({
   job_execution_id: z.string().uuid(),
   origin_step_id: z.string().uuid(),
   origin_step_attempt: z.number().int().min(1),
-  context: z.string().min(1),
+  context: annotationContextSchema,
   style: annotationStyleSchema,
   sequence: z.number().int().min(1),
   body: z.string(),
@@ -18,12 +28,25 @@ export const annotationDtoSchema = z.object({
 
 export type AnnotationDto = z.infer<typeof annotationDtoSchema>;
 
-export const leasedWriteAnnotationOperationSchema = z.object({
-  context: z.string().min(1),
+const leasedWriteAnnotationOperationBaseSchema = z.object({
+  context: annotationContextSchema,
   style: annotationStyleSchema.default('default'),
-  op: z.enum(['replace', 'append', 'remove']).default('replace'),
-  body: z.string().optional(),
 });
+
+export const leasedWriteAnnotationOperationSchema = z.union([
+  leasedWriteAnnotationOperationBaseSchema.extend({
+    op: z.literal('replace').default('replace'),
+    body: z.string(),
+  }),
+  leasedWriteAnnotationOperationBaseSchema.extend({
+    op: z.literal('append'),
+    body: z.string(),
+  }),
+  leasedWriteAnnotationOperationBaseSchema.extend({
+    op: z.literal('remove'),
+    body: z.never().optional(),
+  }),
+]);
 
 export type LeasedWriteAnnotationOperationDto = z.infer<
   typeof leasedWriteAnnotationOperationSchema
@@ -40,7 +63,7 @@ export type LeasedWriteAnnotationsBodyDto = z.infer<typeof leasedWriteAnnotation
 export const leasedWriteAnnotationsResponseSchema = z.object({
   annotations: z.array(
     z.object({
-      context: z.string().min(1),
+      context: annotationContextSchema,
       id: z.string().uuid().nullable(),
     }),
   ),

--- a/libs/api/annotations-dto/src/schemas/annotation.ts
+++ b/libs/api/annotations-dto/src/schemas/annotation.ts
@@ -1,0 +1,61 @@
+import {z} from 'zod';
+
+export const annotationStyleSchema = z.enum(['default', 'info', 'success', 'warning', 'error']);
+
+export type AnnotationStyleDto = z.infer<typeof annotationStyleSchema>;
+
+export const annotationDtoSchema = z.object({
+  id: z.string().uuid(),
+  job_id: z.string().uuid(),
+  job_execution_id: z.string().uuid(),
+  origin_step_id: z.string().uuid(),
+  origin_step_attempt: z.number().int().min(1),
+  context: z.string().min(1),
+  style: annotationStyleSchema,
+  sequence: z.number().int().min(1),
+  body: z.string(),
+});
+
+export type AnnotationDto = z.infer<typeof annotationDtoSchema>;
+
+export const leasedWriteAnnotationOperationSchema = z.object({
+  context: z.string().min(1),
+  style: annotationStyleSchema.default('default'),
+  op: z.enum(['replace', 'append', 'remove']).default('replace'),
+  body: z.string().optional(),
+});
+
+export type LeasedWriteAnnotationOperationDto = z.infer<
+  typeof leasedWriteAnnotationOperationSchema
+>;
+
+export const leasedWriteAnnotationsBodySchema = z.object({
+  step_id: z.string().uuid(),
+  attempt: z.number().int().min(1),
+  annotations: z.array(leasedWriteAnnotationOperationSchema),
+});
+
+export type LeasedWriteAnnotationsBodyDto = z.infer<typeof leasedWriteAnnotationsBodySchema>;
+
+export const leasedWriteAnnotationsResponseSchema = z.object({
+  annotations: z.array(
+    z.object({
+      context: z.string().min(1),
+      id: z.string().uuid().nullable(),
+    }),
+  ),
+  accounting: z.object({
+    annotation_count: z.number().int().min(0),
+    total_body_bytes: z.number().int().min(0),
+  }),
+});
+
+export type LeasedWriteAnnotationsResponseDto = z.infer<
+  typeof leasedWriteAnnotationsResponseSchema
+>;
+
+export const readAnnotationsResponseSchema = z.object({
+  annotations: z.array(annotationDtoSchema),
+});
+
+export type ReadAnnotationsResponseDto = z.infer<typeof readAnnotationsResponseSchema>;

--- a/libs/api/annotations-dto/src/schemas/index.ts
+++ b/libs/api/annotations-dto/src/schemas/index.ts
@@ -1,5 +1,6 @@
 export {
   ANNOTATION_CONTEXT_MAX_LENGTH,
+  ANNOTATION_CONTEXT_TRIM_CODE_POINTS,
   ANNOTATION_STYLES,
   type AnnotationDto,
   type AnnotationStyleDto,

--- a/libs/api/annotations-dto/src/schemas/index.ts
+++ b/libs/api/annotations-dto/src/schemas/index.ts
@@ -1,4 +1,6 @@
 export {
+  ANNOTATION_CONTEXT_MAX_LENGTH,
+  ANNOTATION_STYLES,
   type AnnotationDto,
   type AnnotationStyleDto,
   annotationDtoSchema,

--- a/libs/api/annotations-dto/src/schemas/index.ts
+++ b/libs/api/annotations-dto/src/schemas/index.ts
@@ -1,0 +1,14 @@
+export {
+  type AnnotationDto,
+  type AnnotationStyleDto,
+  annotationDtoSchema,
+  annotationStyleSchema,
+  type LeasedWriteAnnotationOperationDto,
+  type LeasedWriteAnnotationsBodyDto,
+  type LeasedWriteAnnotationsResponseDto,
+  leasedWriteAnnotationOperationSchema,
+  leasedWriteAnnotationsBodySchema,
+  leasedWriteAnnotationsResponseSchema,
+  type ReadAnnotationsResponseDto,
+  readAnnotationsResponseSchema,
+} from './annotation.js';

--- a/libs/api/annotations-dto/tsconfig.build.json
+++ b/libs/api/annotations-dto/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.tsx", "**/*.test.ts"]
+}

--- a/libs/api/annotations-dto/tsconfig.json
+++ b/libs/api/annotations-dto/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.test.json" }]
+}

--- a/libs/api/annotations-dto/tsconfig.test.json
+++ b/libs/api/annotations-dto/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "exclude": []
+}

--- a/libs/api/annotations-dto/vitest.config.ts
+++ b/libs/api/annotations-dto/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({}, import.meta.url) as UserConfigExport;

--- a/libs/api/annotations/drizzle.config.ts
+++ b/libs/api/annotations/drizzle.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from 'drizzle-kit';
+
+export default defineConfig({
+  schema: './src/db/schema/*.ts',
+  out: './drizzle',
+  dialect: 'postgresql',
+});

--- a/libs/api/annotations/drizzle/0000_initial.sql
+++ b/libs/api/annotations/drizzle/0000_initial.sql
@@ -1,5 +1,5 @@
 CREATE TYPE "public"."annotations_style" AS ENUM('default', 'info', 'success', 'warning', 'error');--> statement-breakpoint
-CREATE TABLE "annotations_annotations" (
+CREATE TABLE "annotations" (
 	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
 	"workspace_id" uuid NOT NULL,
 	"project_id" uuid NOT NULL,
@@ -16,12 +16,13 @@ CREATE TABLE "annotations_annotations" (
 	"sequence" integer NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
-	CONSTRAINT "annotations_origin_step_attempt_positive_ck" CHECK ("annotations_annotations"."origin_step_attempt" > 0),
-	CONSTRAINT "annotations_body_bytes_nonnegative_ck" CHECK ("annotations_annotations"."body_bytes" >= 0),
-	CONSTRAINT "annotations_sequence_positive_ck" CHECK ("annotations_annotations"."sequence" > 0),
-	CONSTRAINT "annotations_context_not_empty_ck" CHECK (length("annotations_annotations"."context") > 0)
+	CONSTRAINT "annotations_origin_step_attempt_positive_ck" CHECK ("annotations"."origin_step_attempt" > 0),
+	CONSTRAINT "annotations_body_bytes_matches_body_ck" CHECK ("annotations"."body_bytes" = octet_length("annotations"."body")),
+	CONSTRAINT "annotations_sequence_positive_ck" CHECK ("annotations"."sequence" > 0),
+	CONSTRAINT "annotations_context_not_empty_ck" CHECK (length("annotations"."context") > 0),
+	CONSTRAINT "annotations_context_max_length_ck" CHECK (length("annotations"."context") <= 255)
 );
 --> statement-breakpoint
-CREATE UNIQUE INDEX "annotations_job_execution_context_unique" ON "annotations_annotations" USING btree ("job_execution_id","context");--> statement-breakpoint
-CREATE INDEX "annotations_workflow_run_attempt_id_idx" ON "annotations_annotations" USING btree ("workflow_run_attempt_id");--> statement-breakpoint
-CREATE INDEX "annotations_job_execution_id_idx" ON "annotations_annotations" USING btree ("job_execution_id");
+CREATE UNIQUE INDEX "annotations_job_execution_context_unique" ON "annotations" USING btree ("job_execution_id","context");--> statement-breakpoint
+CREATE INDEX "annotations_workflow_run_attempt_id_idx" ON "annotations" USING btree ("workflow_run_attempt_id");--> statement-breakpoint
+CREATE INDEX "annotations_job_execution_id_idx" ON "annotations" USING btree ("job_execution_id");

--- a/libs/api/annotations/drizzle/0000_initial.sql
+++ b/libs/api/annotations/drizzle/0000_initial.sql
@@ -20,6 +20,7 @@ CREATE TABLE "annotations_annotations" (
 	CONSTRAINT "annotations_body_bytes_matches_body_ck" CHECK ("annotations_annotations"."body_bytes" = octet_length("annotations_annotations"."body")),
 	CONSTRAINT "annotations_sequence_positive_ck" CHECK ("annotations_annotations"."sequence" > 0),
 	CONSTRAINT "annotations_context_not_empty_ck" CHECK (length("annotations_annotations"."context") > 0),
+	CONSTRAINT "annotations_context_trimmed_ck" CHECK ("annotations_annotations"."context" = btrim("annotations_annotations"."context")),
 	CONSTRAINT "annotations_context_max_length_ck" CHECK (length("annotations_annotations"."context") <= 255)
 );
 --> statement-breakpoint

--- a/libs/api/annotations/drizzle/0000_initial.sql
+++ b/libs/api/annotations/drizzle/0000_initial.sql
@@ -1,5 +1,5 @@
 CREATE TYPE "public"."annotations_style" AS ENUM('default', 'info', 'success', 'warning', 'error');--> statement-breakpoint
-CREATE TABLE "annotations" (
+CREATE TABLE "annotations_annotations" (
 	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
 	"workspace_id" uuid NOT NULL,
 	"project_id" uuid NOT NULL,
@@ -16,13 +16,13 @@ CREATE TABLE "annotations" (
 	"sequence" integer NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
-	CONSTRAINT "annotations_origin_step_attempt_positive_ck" CHECK ("annotations"."origin_step_attempt" > 0),
-	CONSTRAINT "annotations_body_bytes_matches_body_ck" CHECK ("annotations"."body_bytes" = octet_length("annotations"."body")),
-	CONSTRAINT "annotations_sequence_positive_ck" CHECK ("annotations"."sequence" > 0),
-	CONSTRAINT "annotations_context_not_empty_ck" CHECK (length("annotations"."context") > 0),
-	CONSTRAINT "annotations_context_max_length_ck" CHECK (length("annotations"."context") <= 255)
+	CONSTRAINT "annotations_origin_step_attempt_positive_ck" CHECK ("annotations_annotations"."origin_step_attempt" > 0),
+	CONSTRAINT "annotations_body_bytes_matches_body_ck" CHECK ("annotations_annotations"."body_bytes" = octet_length("annotations_annotations"."body")),
+	CONSTRAINT "annotations_sequence_positive_ck" CHECK ("annotations_annotations"."sequence" > 0),
+	CONSTRAINT "annotations_context_not_empty_ck" CHECK (length("annotations_annotations"."context") > 0),
+	CONSTRAINT "annotations_context_max_length_ck" CHECK (length("annotations_annotations"."context") <= 255)
 );
 --> statement-breakpoint
-CREATE UNIQUE INDEX "annotations_job_execution_context_unique" ON "annotations" USING btree ("job_execution_id","context");--> statement-breakpoint
-CREATE INDEX "annotations_workflow_run_attempt_id_idx" ON "annotations" USING btree ("workflow_run_attempt_id");--> statement-breakpoint
-CREATE INDEX "annotations_job_execution_id_idx" ON "annotations" USING btree ("job_execution_id");
+CREATE UNIQUE INDEX "annotations_job_execution_context_unique" ON "annotations_annotations" USING btree ("job_execution_id","context");--> statement-breakpoint
+CREATE INDEX "annotations_workflow_run_attempt_id_idx" ON "annotations_annotations" USING btree ("workflow_run_attempt_id");--> statement-breakpoint
+CREATE INDEX "annotations_job_execution_id_idx" ON "annotations_annotations" USING btree ("job_execution_id");

--- a/libs/api/annotations/drizzle/0000_initial.sql
+++ b/libs/api/annotations/drizzle/0000_initial.sql
@@ -20,7 +20,7 @@ CREATE TABLE "annotations_annotations" (
 	CONSTRAINT "annotations_body_bytes_matches_body_ck" CHECK ("annotations_annotations"."body_bytes" = octet_length("annotations_annotations"."body")),
 	CONSTRAINT "annotations_sequence_positive_ck" CHECK ("annotations_annotations"."sequence" > 0),
 	CONSTRAINT "annotations_context_not_empty_ck" CHECK (length("annotations_annotations"."context") > 0),
-	CONSTRAINT "annotations_context_trimmed_ck" CHECK ("annotations_annotations"."context" = btrim("annotations_annotations"."context")),
+	CONSTRAINT "annotations_context_trimmed_ck" CHECK ("annotations_annotations"."context" = btrim("annotations_annotations"."context", concat(chr(9), chr(10), chr(11), chr(12), chr(13), chr(32), chr(160), chr(5760), chr(8192), chr(8193), chr(8194), chr(8195), chr(8196), chr(8197), chr(8198), chr(8199), chr(8200), chr(8201), chr(8202), chr(8232), chr(8233), chr(8239), chr(8287), chr(12288), chr(65279)))),
 	CONSTRAINT "annotations_context_max_length_ck" CHECK (length("annotations_annotations"."context") <= 255)
 );
 --> statement-breakpoint

--- a/libs/api/annotations/drizzle/0000_initial.sql
+++ b/libs/api/annotations/drizzle/0000_initial.sql
@@ -1,0 +1,27 @@
+CREATE TYPE "public"."annotations_style" AS ENUM('default', 'info', 'success', 'warning', 'error');--> statement-breakpoint
+CREATE TABLE "annotations_annotations" (
+	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
+	"workspace_id" uuid NOT NULL,
+	"project_id" uuid NOT NULL,
+	"workflow_run_id" uuid NOT NULL,
+	"workflow_run_attempt_id" uuid NOT NULL,
+	"job_id" uuid NOT NULL,
+	"job_execution_id" uuid NOT NULL,
+	"origin_step_id" uuid NOT NULL,
+	"origin_step_attempt" integer NOT NULL,
+	"context" text NOT NULL,
+	"style" "annotations_style" DEFAULT 'default' NOT NULL,
+	"body" text NOT NULL,
+	"body_bytes" integer NOT NULL,
+	"sequence" integer NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "annotations_origin_step_attempt_positive_ck" CHECK ("annotations_annotations"."origin_step_attempt" > 0),
+	CONSTRAINT "annotations_body_bytes_nonnegative_ck" CHECK ("annotations_annotations"."body_bytes" >= 0),
+	CONSTRAINT "annotations_sequence_positive_ck" CHECK ("annotations_annotations"."sequence" > 0),
+	CONSTRAINT "annotations_context_not_empty_ck" CHECK (length("annotations_annotations"."context") > 0)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "annotations_job_execution_context_unique" ON "annotations_annotations" USING btree ("job_execution_id","context");--> statement-breakpoint
+CREATE INDEX "annotations_workflow_run_attempt_id_idx" ON "annotations_annotations" USING btree ("workflow_run_attempt_id");--> statement-breakpoint
+CREATE INDEX "annotations_job_execution_id_idx" ON "annotations_annotations" USING btree ("job_execution_id");

--- a/libs/api/annotations/drizzle/meta/0000_snapshot.json
+++ b/libs/api/annotations/drizzle/meta/0000_snapshot.json
@@ -186,7 +186,7 @@
         },
         "annotations_context_trimmed_ck": {
           "name": "annotations_context_trimmed_ck",
-          "value": "\"annotations_annotations\".\"context\" = btrim(\"annotations_annotations\".\"context\")"
+          "value": "\"annotations_annotations\".\"context\" = btrim(\"annotations_annotations\".\"context\", concat(chr(9), chr(10), chr(11), chr(12), chr(13), chr(32), chr(160), chr(5760), chr(8192), chr(8193), chr(8194), chr(8195), chr(8196), chr(8197), chr(8198), chr(8199), chr(8200), chr(8201), chr(8202), chr(8232), chr(8233), chr(8239), chr(8287), chr(12288), chr(65279)))"
         },
         "annotations_context_max_length_ck": {
           "name": "annotations_context_max_length_ck",

--- a/libs/api/annotations/drizzle/meta/0000_snapshot.json
+++ b/libs/api/annotations/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,208 @@
+{
+  "id": "b920fb4a-f313-42df-88bf-a2f929f35884",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.annotations_annotations": {
+      "name": "annotations_annotations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_run_attempt_id": {
+          "name": "workflow_run_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_execution_id": {
+          "name": "job_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_step_id": {
+          "name": "origin_step_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_step_attempt": {
+          "name": "origin_step_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "style": {
+          "name": "style",
+          "type": "annotations_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_bytes": {
+          "name": "body_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "annotations_job_execution_context_unique": {
+          "name": "annotations_job_execution_context_unique",
+          "columns": [
+            {
+              "expression": "job_execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "annotations_workflow_run_attempt_id_idx": {
+          "name": "annotations_workflow_run_attempt_id_idx",
+          "columns": [
+            {
+              "expression": "workflow_run_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "annotations_job_execution_id_idx": {
+          "name": "annotations_job_execution_id_idx",
+          "columns": [
+            {
+              "expression": "job_execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "annotations_origin_step_attempt_positive_ck": {
+          "name": "annotations_origin_step_attempt_positive_ck",
+          "value": "\"annotations_annotations\".\"origin_step_attempt\" > 0"
+        },
+        "annotations_body_bytes_nonnegative_ck": {
+          "name": "annotations_body_bytes_nonnegative_ck",
+          "value": "\"annotations_annotations\".\"body_bytes\" >= 0"
+        },
+        "annotations_sequence_positive_ck": {
+          "name": "annotations_sequence_positive_ck",
+          "value": "\"annotations_annotations\".\"sequence\" > 0"
+        },
+        "annotations_context_not_empty_ck": {
+          "name": "annotations_context_not_empty_ck",
+          "value": "length(\"annotations_annotations\".\"context\") > 0"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.annotations_style": {
+      "name": "annotations_style",
+      "schema": "public",
+      "values": ["default", "info", "success", "warning", "error"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/api/annotations/drizzle/meta/0000_snapshot.json
+++ b/libs/api/annotations/drizzle/meta/0000_snapshot.json
@@ -184,6 +184,10 @@
           "name": "annotations_context_not_empty_ck",
           "value": "length(\"annotations_annotations\".\"context\") > 0"
         },
+        "annotations_context_trimmed_ck": {
+          "name": "annotations_context_trimmed_ck",
+          "value": "\"annotations_annotations\".\"context\" = btrim(\"annotations_annotations\".\"context\")"
+        },
         "annotations_context_max_length_ck": {
           "name": "annotations_context_max_length_ck",
           "value": "length(\"annotations_annotations\".\"context\") <= 255"

--- a/libs/api/annotations/drizzle/meta/0000_snapshot.json
+++ b/libs/api/annotations/drizzle/meta/0000_snapshot.json
@@ -4,8 +4,8 @@
   "version": "7",
   "dialect": "postgresql",
   "tables": {
-    "public.annotations_annotations": {
-      "name": "annotations_annotations",
+    "public.annotations": {
+      "name": "annotations",
       "schema": "",
       "columns": {
         "id": {
@@ -170,19 +170,23 @@
       "checkConstraints": {
         "annotations_origin_step_attempt_positive_ck": {
           "name": "annotations_origin_step_attempt_positive_ck",
-          "value": "\"annotations_annotations\".\"origin_step_attempt\" > 0"
+          "value": "\"annotations\".\"origin_step_attempt\" > 0"
         },
-        "annotations_body_bytes_nonnegative_ck": {
-          "name": "annotations_body_bytes_nonnegative_ck",
-          "value": "\"annotations_annotations\".\"body_bytes\" >= 0"
+        "annotations_body_bytes_matches_body_ck": {
+          "name": "annotations_body_bytes_matches_body_ck",
+          "value": "\"annotations\".\"body_bytes\" = octet_length(\"annotations\".\"body\")"
         },
         "annotations_sequence_positive_ck": {
           "name": "annotations_sequence_positive_ck",
-          "value": "\"annotations_annotations\".\"sequence\" > 0"
+          "value": "\"annotations\".\"sequence\" > 0"
         },
         "annotations_context_not_empty_ck": {
           "name": "annotations_context_not_empty_ck",
-          "value": "length(\"annotations_annotations\".\"context\") > 0"
+          "value": "length(\"annotations\".\"context\") > 0"
+        },
+        "annotations_context_max_length_ck": {
+          "name": "annotations_context_max_length_ck",
+          "value": "length(\"annotations\".\"context\") <= 255"
         }
       },
       "isRLSEnabled": false

--- a/libs/api/annotations/drizzle/meta/0000_snapshot.json
+++ b/libs/api/annotations/drizzle/meta/0000_snapshot.json
@@ -4,8 +4,8 @@
   "version": "7",
   "dialect": "postgresql",
   "tables": {
-    "public.annotations": {
-      "name": "annotations",
+    "public.annotations_annotations": {
+      "name": "annotations_annotations",
       "schema": "",
       "columns": {
         "id": {
@@ -170,23 +170,23 @@
       "checkConstraints": {
         "annotations_origin_step_attempt_positive_ck": {
           "name": "annotations_origin_step_attempt_positive_ck",
-          "value": "\"annotations\".\"origin_step_attempt\" > 0"
+          "value": "\"annotations_annotations\".\"origin_step_attempt\" > 0"
         },
         "annotations_body_bytes_matches_body_ck": {
           "name": "annotations_body_bytes_matches_body_ck",
-          "value": "\"annotations\".\"body_bytes\" = octet_length(\"annotations\".\"body\")"
+          "value": "\"annotations_annotations\".\"body_bytes\" = octet_length(\"annotations_annotations\".\"body\")"
         },
         "annotations_sequence_positive_ck": {
           "name": "annotations_sequence_positive_ck",
-          "value": "\"annotations\".\"sequence\" > 0"
+          "value": "\"annotations_annotations\".\"sequence\" > 0"
         },
         "annotations_context_not_empty_ck": {
           "name": "annotations_context_not_empty_ck",
-          "value": "length(\"annotations\".\"context\") > 0"
+          "value": "length(\"annotations_annotations\".\"context\") > 0"
         },
         "annotations_context_max_length_ck": {
           "name": "annotations_context_max_length_ck",
-          "value": "length(\"annotations\".\"context\") <= 255"
+          "value": "length(\"annotations_annotations\".\"context\") <= 255"
         }
       },
       "isRLSEnabled": false

--- a/libs/api/annotations/drizzle/meta/_journal.json
+++ b/libs/api/annotations/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1782017246000,
+      "tag": "0000_initial",
+      "breakpoints": true
+    }
+  ]
+}

--- a/libs/api/annotations/package.json
+++ b/libs/api/annotations/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@shipfox/annotations",
+  "license": "MIT",
+  "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
+    "directory": "libs/api/annotations"
+  },
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "imports": {
+    "#test/*": "./test/*",
+    "#*": "./src/*"
+  },
+  "exports": {
+    ".": {
+      "development": {
+        "types": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "test": "shipfox-vitest-run",
+    "test:watch": "shipfox-vitest-watch",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "@shipfox/annotations-dto": "workspace:*",
+    "@shipfox/node-drizzle": "workspace:*",
+    "@shipfox/node-module": "workspace:*",
+    "@shipfox/node-postgres": "workspace:*",
+    "drizzle-orm": "^0.45.2"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*",
+    "@types/pg": "^8.15.5",
+    "drizzle-kit": "^0.31.10",
+    "fishery": "^2.2.2"
+  }
+}

--- a/libs/api/annotations/src/core/entities/annotation.ts
+++ b/libs/api/annotations/src/core/entities/annotation.ts
@@ -1,0 +1,20 @@
+import type {AnnotationStyleDto} from '@shipfox/annotations-dto';
+
+export interface Annotation {
+  id: string;
+  workspaceId: string;
+  projectId: string;
+  workflowRunId: string;
+  workflowRunAttemptId: string;
+  jobId: string;
+  jobExecutionId: string;
+  originStepId: string;
+  originStepAttempt: number;
+  context: string;
+  style: AnnotationStyleDto;
+  body: string;
+  bodyBytes: number;
+  sequence: number;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/libs/api/annotations/src/core/entities/index.ts
+++ b/libs/api/annotations/src/core/entities/index.ts
@@ -1,0 +1,1 @@
+export type {Annotation} from './annotation.js';

--- a/libs/api/annotations/src/db/db.ts
+++ b/libs/api/annotations/src/db/db.ts
@@ -1,0 +1,19 @@
+import {drizzle, type NodePgDatabase} from '@shipfox/node-drizzle';
+import {pgClient} from '@shipfox/node-postgres';
+import {annotations} from './schema/annotations.js';
+
+export const schema = {annotations};
+
+export type Database = NodePgDatabase<typeof schema>;
+export type Transaction = Parameters<Parameters<Database['transaction']>[0]>[0];
+
+let _db: Database | undefined;
+
+export function db() {
+  if (!_db) _db = drizzle(pgClient(), {schema});
+  return _db;
+}
+
+export function closeDb(): void {
+  _db = undefined;
+}

--- a/libs/api/annotations/src/db/index.ts
+++ b/libs/api/annotations/src/db/index.ts
@@ -1,0 +1,4 @@
+import {dirname, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+export const migrationsPath = resolve(dirname(fileURLToPath(import.meta.url)), '../../drizzle');

--- a/libs/api/annotations/src/db/schema/annotations.test.ts
+++ b/libs/api/annotations/src/db/schema/annotations.test.ts
@@ -32,8 +32,11 @@ describe('annotations schema', () => {
     expect(row ? toAnnotation(row) : undefined).toEqual(annotation);
   });
 
-  it('rejects untrimmed context values at the database boundary', async () => {
-    const createAnnotation = annotationFactory.create({context: ' deploy '});
+  it.each([
+    ' deploy ',
+    '\tdeploy\n',
+  ])('rejects untrimmed context values at the database boundary: %s', async (context) => {
+    const createAnnotation = annotationFactory.create({context});
 
     await expect(createAnnotation).rejects.toThrow();
   });

--- a/libs/api/annotations/src/db/schema/annotations.test.ts
+++ b/libs/api/annotations/src/db/schema/annotations.test.ts
@@ -5,12 +5,25 @@ import {annotations, toAnnotation} from './annotations.js';
 
 describe('annotations schema', () => {
   it('maps a persisted annotation row to the domain entity', async () => {
+    const createdAt = new Date('2026-07-07T10:00:00.000Z');
+    const updatedAt = new Date('2026-07-07T10:01:00.000Z');
     const annotation = await annotationFactory.create({
+      id: '11111111-1111-4111-8111-111111111111',
+      workspaceId: '22222222-2222-4222-8222-222222222222',
+      projectId: '33333333-3333-4333-8333-333333333333',
+      workflowRunId: '44444444-4444-4444-8444-444444444444',
+      workflowRunAttemptId: '55555555-5555-4555-8555-555555555555',
+      jobId: '66666666-6666-4666-8666-666666666666',
+      jobExecutionId: '77777777-7777-4777-8777-777777777777',
+      originStepId: '88888888-8888-4888-8888-888888888888',
+      originStepAttempt: 3,
       context: 'deploy',
       style: 'success',
       body: 'Deployed **v42** to staging',
       bodyBytes: Buffer.byteLength('Deployed **v42** to staging'),
       sequence: 2,
+      createdAt,
+      updatedAt,
     });
 
     const [row] = await db().select().from(annotations).where(eq(annotations.id, annotation.id));

--- a/libs/api/annotations/src/db/schema/annotations.test.ts
+++ b/libs/api/annotations/src/db/schema/annotations.test.ts
@@ -31,4 +31,10 @@ describe('annotations schema', () => {
     expect(row).toBeDefined();
     expect(row ? toAnnotation(row) : undefined).toEqual(annotation);
   });
+
+  it('rejects untrimmed context values at the database boundary', async () => {
+    const createAnnotation = annotationFactory.create({context: ' deploy '});
+
+    await expect(createAnnotation).rejects.toThrow();
+  });
 });

--- a/libs/api/annotations/src/db/schema/annotations.test.ts
+++ b/libs/api/annotations/src/db/schema/annotations.test.ts
@@ -1,0 +1,21 @@
+import {eq} from 'drizzle-orm';
+import {db} from '#db/db.js';
+import {annotationFactory} from '#test/index.js';
+import {annotations, toAnnotation} from './annotations.js';
+
+describe('annotations schema', () => {
+  it('maps a persisted annotation row to the domain entity', async () => {
+    const annotation = await annotationFactory.create({
+      context: 'deploy',
+      style: 'success',
+      body: 'Deployed **v42** to staging',
+      bodyBytes: Buffer.byteLength('Deployed **v42** to staging'),
+      sequence: 2,
+    });
+
+    const [row] = await db().select().from(annotations).where(eq(annotations.id, annotation.id));
+
+    expect(row).toBeDefined();
+    expect(row ? toAnnotation(row) : undefined).toEqual(annotation);
+  });
+});

--- a/libs/api/annotations/src/db/schema/annotations.ts
+++ b/libs/api/annotations/src/db/schema/annotations.ts
@@ -47,6 +47,7 @@ export const annotations = pgTable(
     ),
     check('annotations_sequence_positive_ck', sql`${table.sequence} > 0`),
     check('annotations_context_not_empty_ck', sql`length(${table.context}) > 0`),
+    check('annotations_context_trimmed_ck', sql`${table.context} = btrim(${table.context})`),
     check(
       'annotations_context_max_length_ck',
       sql`length(${table.context}) <= ${ANNOTATION_CONTEXT_MAX_LENGTH}`,

--- a/libs/api/annotations/src/db/schema/annotations.ts
+++ b/libs/api/annotations/src/db/schema/annotations.ts
@@ -1,0 +1,77 @@
+import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
+import {sql} from 'drizzle-orm';
+import {
+  check,
+  index,
+  integer,
+  pgEnum,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from 'drizzle-orm/pg-core';
+import type {Annotation} from '#core/entities/annotation.js';
+import {pgTable} from './common.js';
+
+export const annotationStyleEnum = pgEnum('annotations_style', [
+  'default',
+  'info',
+  'success',
+  'warning',
+  'error',
+]);
+
+export const annotations = pgTable(
+  'annotations',
+  {
+    id: uuidv7PrimaryKey(),
+    workspaceId: uuid('workspace_id').notNull(),
+    projectId: uuid('project_id').notNull(),
+    workflowRunId: uuid('workflow_run_id').notNull(),
+    workflowRunAttemptId: uuid('workflow_run_attempt_id').notNull(),
+    jobId: uuid('job_id').notNull(),
+    jobExecutionId: uuid('job_execution_id').notNull(),
+    originStepId: uuid('origin_step_id').notNull(),
+    originStepAttempt: integer('origin_step_attempt').notNull(),
+    context: text('context').notNull(),
+    style: annotationStyleEnum('style').notNull().default('default'),
+    body: text('body').notNull(),
+    bodyBytes: integer('body_bytes').notNull(),
+    sequence: integer('sequence').notNull(),
+    createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', {withTimezone: true}).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex('annotations_job_execution_context_unique').on(table.jobExecutionId, table.context),
+    index('annotations_workflow_run_attempt_id_idx').on(table.workflowRunAttemptId),
+    index('annotations_job_execution_id_idx').on(table.jobExecutionId),
+    check('annotations_origin_step_attempt_positive_ck', sql`${table.originStepAttempt} > 0`),
+    check('annotations_body_bytes_nonnegative_ck', sql`${table.bodyBytes} >= 0`),
+    check('annotations_sequence_positive_ck', sql`${table.sequence} > 0`),
+    check('annotations_context_not_empty_ck', sql`length(${table.context}) > 0`),
+  ],
+);
+
+export type AnnotationDb = typeof annotations.$inferSelect;
+export type AnnotationCreateDb = typeof annotations.$inferInsert;
+
+export function toAnnotation(row: AnnotationDb): Annotation {
+  return {
+    id: row.id,
+    workspaceId: row.workspaceId,
+    projectId: row.projectId,
+    workflowRunId: row.workflowRunId,
+    workflowRunAttemptId: row.workflowRunAttemptId,
+    jobId: row.jobId,
+    jobExecutionId: row.jobExecutionId,
+    originStepId: row.originStepId,
+    originStepAttempt: row.originStepAttempt,
+    context: row.context,
+    style: row.style,
+    body: row.body,
+    bodyBytes: row.bodyBytes,
+    sequence: row.sequence,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}

--- a/libs/api/annotations/src/db/schema/annotations.ts
+++ b/libs/api/annotations/src/db/schema/annotations.ts
@@ -1,4 +1,8 @@
-import {ANNOTATION_CONTEXT_MAX_LENGTH, ANNOTATION_STYLES} from '@shipfox/annotations-dto';
+import {
+  ANNOTATION_CONTEXT_MAX_LENGTH,
+  ANNOTATION_CONTEXT_TRIM_CODE_POINTS,
+  ANNOTATION_STYLES,
+} from '@shipfox/annotations-dto';
 import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
 import {sql} from 'drizzle-orm';
 import {
@@ -16,33 +20,10 @@ import {pgTable} from './common.js';
 
 export const annotationStyleEnum = pgEnum('annotations_style', [...ANNOTATION_STYLES]);
 
-const annotationContextTrimCharactersSql = sql`concat(
-  chr(9),
-  chr(10),
-  chr(11),
-  chr(12),
-  chr(13),
-  chr(32),
-  chr(160),
-  chr(5760),
-  chr(8192),
-  chr(8193),
-  chr(8194),
-  chr(8195),
-  chr(8196),
-  chr(8197),
-  chr(8198),
-  chr(8199),
-  chr(8200),
-  chr(8201),
-  chr(8202),
-  chr(8232),
-  chr(8233),
-  chr(8239),
-  chr(8287),
-  chr(12288),
-  chr(65279)
-)`;
+const annotationContextTrimCharactersSql = sql`concat(${sql.join(
+  ANNOTATION_CONTEXT_TRIM_CODE_POINTS.map((codePoint) => sql.raw(`chr(${codePoint})`)),
+  sql`, `,
+)})`;
 
 export const annotations = pgTable(
   'annotations',

--- a/libs/api/annotations/src/db/schema/annotations.ts
+++ b/libs/api/annotations/src/db/schema/annotations.ts
@@ -16,6 +16,34 @@ import {pgTable} from './common.js';
 
 export const annotationStyleEnum = pgEnum('annotations_style', [...ANNOTATION_STYLES]);
 
+const annotationContextTrimCharactersSql = sql`concat(
+  chr(9),
+  chr(10),
+  chr(11),
+  chr(12),
+  chr(13),
+  chr(32),
+  chr(160),
+  chr(5760),
+  chr(8192),
+  chr(8193),
+  chr(8194),
+  chr(8195),
+  chr(8196),
+  chr(8197),
+  chr(8198),
+  chr(8199),
+  chr(8200),
+  chr(8201),
+  chr(8202),
+  chr(8232),
+  chr(8233),
+  chr(8239),
+  chr(8287),
+  chr(12288),
+  chr(65279)
+)`;
+
 export const annotations = pgTable(
   'annotations',
   {
@@ -47,7 +75,10 @@ export const annotations = pgTable(
     ),
     check('annotations_sequence_positive_ck', sql`${table.sequence} > 0`),
     check('annotations_context_not_empty_ck', sql`length(${table.context}) > 0`),
-    check('annotations_context_trimmed_ck', sql`${table.context} = btrim(${table.context})`),
+    check(
+      'annotations_context_trimmed_ck',
+      sql`${table.context} = btrim(${table.context}, ${annotationContextTrimCharactersSql})`,
+    ),
     check(
       'annotations_context_max_length_ck',
       sql`length(${table.context}) <= ${ANNOTATION_CONTEXT_MAX_LENGTH}`,

--- a/libs/api/annotations/src/db/schema/annotations.ts
+++ b/libs/api/annotations/src/db/schema/annotations.ts
@@ -1,3 +1,4 @@
+import {ANNOTATION_CONTEXT_MAX_LENGTH, ANNOTATION_STYLES} from '@shipfox/annotations-dto';
 import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
 import {sql} from 'drizzle-orm';
 import {
@@ -13,13 +14,7 @@ import {
 import type {Annotation} from '#core/entities/annotation.js';
 import {pgTable} from './common.js';
 
-export const annotationStyleEnum = pgEnum('annotations_style', [
-  'default',
-  'info',
-  'success',
-  'warning',
-  'error',
-]);
+export const annotationStyleEnum = pgEnum('annotations_style', [...ANNOTATION_STYLES]);
 
 export const annotations = pgTable(
   'annotations',
@@ -46,9 +41,16 @@ export const annotations = pgTable(
     index('annotations_workflow_run_attempt_id_idx').on(table.workflowRunAttemptId),
     index('annotations_job_execution_id_idx').on(table.jobExecutionId),
     check('annotations_origin_step_attempt_positive_ck', sql`${table.originStepAttempt} > 0`),
-    check('annotations_body_bytes_nonnegative_ck', sql`${table.bodyBytes} >= 0`),
+    check(
+      'annotations_body_bytes_matches_body_ck',
+      sql`${table.bodyBytes} = octet_length(${table.body})`,
+    ),
     check('annotations_sequence_positive_ck', sql`${table.sequence} > 0`),
     check('annotations_context_not_empty_ck', sql`length(${table.context}) > 0`),
+    check(
+      'annotations_context_max_length_ck',
+      sql`length(${table.context}) <= ${ANNOTATION_CONTEXT_MAX_LENGTH}`,
+    ),
   ],
 );
 

--- a/libs/api/annotations/src/db/schema/common.ts
+++ b/libs/api/annotations/src/db/schema/common.ts
@@ -1,5 +1,3 @@
 import {pgTableCreator} from 'drizzle-orm/pg-core';
 
-export const pgTable = pgTableCreator((name) =>
-  name === 'annotations' ? name : `annotations_${name}`,
-);
+export const pgTable = pgTableCreator((name) => `annotations_${name}`);

--- a/libs/api/annotations/src/db/schema/common.ts
+++ b/libs/api/annotations/src/db/schema/common.ts
@@ -1,3 +1,5 @@
 import {pgTableCreator} from 'drizzle-orm/pg-core';
 
-export const pgTable = pgTableCreator((name) => `annotations_${name}`);
+export const pgTable = pgTableCreator((name) =>
+  name === 'annotations' ? name : `annotations_${name}`,
+);

--- a/libs/api/annotations/src/db/schema/common.ts
+++ b/libs/api/annotations/src/db/schema/common.ts
@@ -1,0 +1,3 @@
+import {pgTableCreator} from 'drizzle-orm/pg-core';
+
+export const pgTable = pgTableCreator((name) => `annotations_${name}`);

--- a/libs/api/annotations/src/index.ts
+++ b/libs/api/annotations/src/index.ts
@@ -1,0 +1,8 @@
+import type {ShipfoxModule} from '@shipfox/node-module';
+import {db} from '#db/db.js';
+import {migrationsPath} from '#db/index.js';
+
+export const annotationsModule: ShipfoxModule = {
+  name: 'annotations',
+  database: {db, migrationsPath},
+};

--- a/libs/api/annotations/src/presentation/routes/index.ts
+++ b/libs/api/annotations/src/presentation/routes/index.ts
@@ -1,0 +1,1 @@
+export const annotationsRoutes: [] = [];

--- a/libs/api/annotations/test/env.ts
+++ b/libs/api/annotations/test/env.ts
@@ -1,0 +1,2 @@
+process.env.DATABASE_URL ??= 'postgres://shipfox:shipfox@127.0.0.1:5432/api_test';
+process.env.TZ = 'UTC';

--- a/libs/api/annotations/test/factories/annotation.ts
+++ b/libs/api/annotations/test/factories/annotation.ts
@@ -1,0 +1,55 @@
+import {Factory} from 'fishery';
+import type {Annotation} from '#core/entities/annotation.js';
+import {db} from '#db/db.js';
+import {annotations, toAnnotation} from '#db/schema/annotations.js';
+
+export const annotationFactory = Factory.define<Annotation>(({onCreate}) => {
+  onCreate(async (annotation) => {
+    const [row] = await db()
+      .insert(annotations)
+      .values({
+        id: annotation.id,
+        workspaceId: annotation.workspaceId,
+        projectId: annotation.projectId,
+        workflowRunId: annotation.workflowRunId,
+        workflowRunAttemptId: annotation.workflowRunAttemptId,
+        jobId: annotation.jobId,
+        jobExecutionId: annotation.jobExecutionId,
+        originStepId: annotation.originStepId,
+        originStepAttempt: annotation.originStepAttempt,
+        context: annotation.context,
+        style: annotation.style,
+        body: annotation.body,
+        bodyBytes: annotation.bodyBytes,
+        sequence: annotation.sequence,
+        createdAt: annotation.createdAt,
+        updatedAt: annotation.updatedAt,
+      })
+      .returning();
+
+    if (!row) throw new Error('annotationFactory: insert returned no row');
+    return toAnnotation(row);
+  });
+
+  const body = '### Summary\nAnnotation body';
+  const now = new Date();
+
+  return {
+    id: crypto.randomUUID(),
+    workspaceId: crypto.randomUUID(),
+    projectId: crypto.randomUUID(),
+    workflowRunId: crypto.randomUUID(),
+    workflowRunAttemptId: crypto.randomUUID(),
+    jobId: crypto.randomUUID(),
+    jobExecutionId: crypto.randomUUID(),
+    originStepId: crypto.randomUUID(),
+    originStepAttempt: 1,
+    context: 'default',
+    style: 'default',
+    body,
+    bodyBytes: Buffer.byteLength(body),
+    sequence: 1,
+    createdAt: now,
+    updatedAt: now,
+  };
+});

--- a/libs/api/annotations/test/factories/annotation.ts
+++ b/libs/api/annotations/test/factories/annotation.ts
@@ -1,7 +1,7 @@
 import {Factory} from 'fishery';
 import type {Annotation} from '#core/entities/annotation.js';
 import {db} from '#db/db.js';
-import {annotations, toAnnotation} from '#db/schema/annotations.js';
+import {annotations} from '#db/schema/annotations.js';
 
 export const annotationFactory = Factory.define<Annotation>(({onCreate}) => {
   onCreate(async (annotation) => {
@@ -28,7 +28,7 @@ export const annotationFactory = Factory.define<Annotation>(({onCreate}) => {
       .returning();
 
     if (!row) throw new Error('annotationFactory: insert returned no row');
-    return toAnnotation(row);
+    return annotation;
   });
 
   const body = '### Summary\nAnnotation body';

--- a/libs/api/annotations/test/globalSetup.ts
+++ b/libs/api/annotations/test/globalSetup.ts
@@ -1,0 +1,16 @@
+import './env.js';
+import {runMigrations} from '@shipfox/node-drizzle';
+import {closePostgresClient, createPostgresClient} from '@shipfox/node-postgres';
+import {sql} from 'drizzle-orm';
+import {closeDb, db} from '#db/db.js';
+import {migrationsPath} from '#db/index.js';
+
+export async function setup() {
+  createPostgresClient();
+
+  await runMigrations(db(), migrationsPath, '__drizzle_migrations_annotations');
+  await db().execute(sql`TRUNCATE annotations_annotations CASCADE`);
+
+  closeDb();
+  await closePostgresClient();
+}

--- a/libs/api/annotations/test/globalSetup.ts
+++ b/libs/api/annotations/test/globalSetup.ts
@@ -8,8 +8,12 @@ import {migrationsPath} from '#db/index.js';
 export async function setup() {
   createPostgresClient();
 
+  await db().execute(sql`DROP TABLE IF EXISTS annotations_annotations CASCADE`);
+  await db().execute(sql`DROP TABLE IF EXISTS annotations CASCADE`);
+  await db().execute(sql`DROP TABLE IF EXISTS drizzle.__drizzle_migrations_annotations CASCADE`);
+  await db().execute(sql`DROP TYPE IF EXISTS annotations_style CASCADE`);
   await runMigrations(db(), migrationsPath, '__drizzle_migrations_annotations');
-  await db().execute(sql`TRUNCATE annotations_annotations CASCADE`);
+  await db().execute(sql`TRUNCATE annotations CASCADE`);
 
   closeDb();
   await closePostgresClient();

--- a/libs/api/annotations/test/globalSetup.ts
+++ b/libs/api/annotations/test/globalSetup.ts
@@ -13,7 +13,7 @@ export async function setup() {
   await db().execute(sql`DROP TABLE IF EXISTS drizzle.__drizzle_migrations_annotations CASCADE`);
   await db().execute(sql`DROP TYPE IF EXISTS annotations_style CASCADE`);
   await runMigrations(db(), migrationsPath, '__drizzle_migrations_annotations');
-  await db().execute(sql`TRUNCATE annotations CASCADE`);
+  await db().execute(sql`TRUNCATE annotations_annotations CASCADE`);
 
   closeDb();
   await closePostgresClient();

--- a/libs/api/annotations/test/index.ts
+++ b/libs/api/annotations/test/index.ts
@@ -1,0 +1,1 @@
+export {annotationFactory} from './factories/annotation.js';

--- a/libs/api/annotations/test/setup.ts
+++ b/libs/api/annotations/test/setup.ts
@@ -1,0 +1,17 @@
+import './env.js';
+import {closePostgresClient, createPostgresClient} from '@shipfox/node-postgres';
+import {afterAll, afterEach, beforeAll, vi} from '@shipfox/vitest/vi';
+import {closeDb} from '#db/db.js';
+
+beforeAll(() => {
+  createPostgresClient();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterAll(async () => {
+  closeDb();
+  await closePostgresClient();
+});

--- a/libs/api/annotations/tsconfig.build.json
+++ b/libs/api/annotations/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.tsx", "**/*.test.ts"]
+}

--- a/libs/api/annotations/tsconfig.json
+++ b/libs/api/annotations/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.test.json" }]
+}

--- a/libs/api/annotations/tsconfig.test.json
+++ b/libs/api/annotations/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "exclude": []
+}

--- a/libs/api/annotations/vitest.config.ts
+++ b/libs/api/annotations/vitest.config.ts
@@ -1,0 +1,13 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig(
+  {
+    test: {
+      fileParallelism: false,
+      globalSetup: ['test/globalSetup.ts'],
+      isolate: false,
+      setupFiles: ['test/setup.ts'],
+    },
+  },
+  import.meta.url,
+) as UserConfigExport;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
 
   apps/api:
     dependencies:
+      '@shipfox/annotations':
+        specifier: workspace:*
+        version: link:../../libs/api/annotations
       '@shipfox/api-agent':
         specifier: workspace:*
         version: link:../../libs/api/agent
@@ -1200,6 +1203,74 @@ importers:
       '@shipfox/workflow-document':
         specifier: workspace:*
         version: link:../../shared/workflow/document
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/depcruise':
+        specifier: workspace:*
+        version: link:../../../tools/depcruise
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../tools/vitest
+
+  libs/api/annotations:
+    dependencies:
+      '@shipfox/annotations-dto':
+        specifier: workspace:*
+        version: link:../annotations-dto
+      '@shipfox/node-drizzle':
+        specifier: workspace:*
+        version: link:../../shared/node/drizzle
+      '@shipfox/node-module':
+        specifier: workspace:*
+        version: link:../../shared/node/module
+      '@shipfox/node-postgres':
+        specifier: workspace:*
+        version: link:../../shared/node/postgres
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../tools/vitest
+      '@types/pg':
+        specifier: ^8.15.5
+        version: 8.20.0
+      drizzle-kit:
+        specifier: ^0.31.10
+        version: 0.31.10
+      fishery:
+        specifier: ^2.2.2
+        version: 2.4.0
+
+  libs/api/annotations-dto:
+    dependencies:
       zod:
         specifier: ^4.4.3
         version: 4.4.3


### PR DESCRIPTION
Add the annotations foundation package and DTO contract.

Annotations need a stable storage and contract layer before the leased write and user read routes can land. This adds the `@shipfox/annotations-dto` schemas, the `@shipfox/annotations` module skeleton, the initial Drizzle table and migration, and a Fishery factory test for persisted rows.

Routes are intentionally out of scope for this PR; the module is registered in the API after workflows so follow-up route work can attach to it. No changeset is included because the touched library packages are private.

Fixes ENG-860

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@shipfox/annotations` and `@shipfox/annotations-dto` to establish the annotations storage layer and DTO contract, registers the module in the API, and ensures annotation context normalization (trim + code point length) matches between DTOs and the DB with stricter op/body rules. This unblocks leased write and read routes (Fixes ENG-860).

- New Features
  - Introduced `@shipfox/annotations-dto` with zod schemas (annotation DTO, style enum, leased write body/response, read response); defaults style to `default`; validates op/body pairing; counts context length by Unicode code points; trims context; exports `ANNOTATION_CONTEXT_TRIM_CODE_POINTS` with a parity test to match JavaScript trim.
  - Added `@shipfox/annotations` with Drizzle schema/table, shared style enum, DB wiring, and tests; enforces checks (trim/length aligned with DTO via the shared trim code-point list, positive ints, `body_bytes` matches `body`) and a unique index on job_execution_id+context; preserves module-prefixed table name; module registered in the API; routes are out of scope.

- Migration
  - Creates `annotations_annotations` table and `annotations_style` enum with indexes and checks (including context trim/bounds using the shared trim characters and body-bytes integrity).
  - Run database migrations before deploying.

<sup>Written for commit 2323b1004f52fdfc47e4ea209cef3e0f6b129e8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

