### PR TITLE
[api/workflows] Move listener firing materialization into core

### DIFF
--- a/libs/api/triggers/src/core/route-event-to-job-listeners.test.ts
+++ b/libs/api/triggers/src/core/route-event-to-job-listeners.test.ts
@@ -235,7 +235,12 @@ describe('routeEventToJobListeners', () => {
     expect(result).toMatchObject({engagedCount: 0, matchedJobCount: 0, acceptedJobCount: 0});
   });
 
-  it('records filter-error when listener filter evaluation fails', async () => {
+  it.each([
+    {name: 'missing jobs snapshot', filterSnapshot: {}},
+    {name: 'empty jobs snapshot', filterSnapshot: {jobs: {}}},
+  ])('records filter-error when listener filter evaluation fails with $name', async ({
+    filterSnapshot,
+  }) => {
     const workspaceId = crypto.randomUUID();
     await jobListenerSubscriptionFactory.create({
       workspaceId,
@@ -243,7 +248,7 @@ describe('routeEventToJobListeners', () => {
       event: 'pull_request_review',
       config: {
         filter: 'event.issue.number == jobs.build.outputs.pr_number',
-        filter_snapshot: {},
+        filter_snapshot: filterSnapshot,
       },
     });
 

--- a/libs/api/workflows/src/core/listener-execution-materialization.ts
+++ b/libs/api/workflows/src/core/listener-execution-materialization.ts
@@ -107,7 +107,7 @@ export function materializeListenerExecution(
     runner,
     status,
     statusReason: status === 'failed' ? 'unknown' : null,
-    triggerEvents: [...params.triggerEvents],
+    triggerEvents: params.triggerEvents,
     evaluationTrace: evaluationTrace.length === 0 ? null : evaluationTrace,
     steps,
   };

--- a/libs/api/workflows/src/core/listener-execution-materialization.ts
+++ b/libs/api/workflows/src/core/listener-execution-materialization.ts
@@ -1,0 +1,152 @@
+import {
+  type AgentDefaultsResolver,
+  catalogDefaultAgentResolver,
+} from '@shipfox/api-agent/core/resolve-agent-config';
+import type {WorkflowModel} from '@shipfox/api-definitions';
+import type {Job} from './entities/job.js';
+import type {
+  JobExecution,
+  JobExecutionStatus,
+  WorkflowExecutionEvent,
+} from './entities/job-execution.js';
+import type {PersistedEvaluationTraceEntry} from './entities/step.js';
+import type {WorkflowRun} from './entities/workflow-run.js';
+import {
+  AgentConfigUnresolvableError,
+  InterpolationUnresolvableError,
+  InvalidJobRunnerLabelsError,
+} from './errors.js';
+import {
+  assembleExecutionCreationContext,
+  type MaterializedWorkflowStep,
+  materializeJobExecutionSteps,
+  materializeJobRunner,
+  resolveJobExecutionName,
+} from './step-config/index.js';
+
+export interface MaterializeListenerExecutionParams {
+  readonly model: WorkflowModel | null;
+  readonly run: Pick<
+    WorkflowRun,
+    | 'id'
+    | 'name'
+    | 'definitionId'
+    | 'projectId'
+    | 'workspaceId'
+    | 'createdAt'
+    | 'triggerPayload'
+    | 'inputs'
+  >;
+  readonly job: Pick<Job, 'id' | 'key'>;
+  readonly sequence: number;
+  readonly triggerEvents: readonly WorkflowExecutionEvent[];
+  readonly priorExecutions: readonly JobExecution[];
+  readonly resolveAgentDefaults?: AgentDefaultsResolver | undefined;
+}
+
+export interface MaterializedListenerExecution {
+  readonly name: string;
+  readonly runner: readonly string[];
+  readonly status: JobExecutionStatus;
+  readonly statusReason: 'unknown' | null;
+  readonly triggerEvents: readonly WorkflowExecutionEvent[];
+  readonly evaluationTrace: readonly PersistedEvaluationTraceEntry[] | null;
+  readonly steps: readonly MaterializedWorkflowStep[];
+}
+
+export function materializeListenerExecution(
+  params: MaterializeListenerExecutionParams,
+): MaterializedListenerExecution {
+  const fallbackName = `${params.job.key} #${params.sequence}`;
+  let executionName = fallbackName;
+  let evaluationTrace: readonly PersistedEvaluationTraceEntry[] = [];
+  let runner: readonly string[] = [];
+  let steps: readonly MaterializedWorkflowStep[] = [];
+  let status: JobExecutionStatus = 'pending';
+
+  try {
+    if (!params.model) throw new PermanentListenerMaterializationError('Run attempt has no model');
+    const modelJob = params.model.jobs.find((job) => job.key === params.job.key);
+    if (!modelJob) {
+      throw new PermanentListenerMaterializationError(
+        `Workflow model has no job key: ${params.job.key}`,
+      );
+    }
+
+    const resolvedName = resolveJobExecutionName({
+      definitionId: params.run.definitionId,
+      job: modelJob,
+      fallbackName,
+      context: listenerExecutionContext({...params, executionName, status}).values,
+    });
+    executionName = resolvedName.value;
+    evaluationTrace = resolvedName.trace;
+
+    const context = listenerExecutionContext({...params, executionName, status});
+    runner = materializeJobRunner({
+      job: modelJob,
+      context,
+      definitionId: params.run.definitionId,
+    });
+    steps = materializeJobExecutionSteps({
+      model: params.model,
+      job: modelJob,
+      context,
+      resolveAgentDefaults: params.resolveAgentDefaults ?? catalogDefaultAgentResolver,
+      definitionId: params.run.definitionId,
+    });
+  } catch (error) {
+    if (!isPermanentListenerMaterializationError(error)) throw error;
+    status = 'failed';
+    steps = [];
+    runner = [];
+  }
+
+  return {
+    name: executionName,
+    runner,
+    status,
+    statusReason: status === 'failed' ? 'unknown' : null,
+    triggerEvents: [...params.triggerEvents],
+    evaluationTrace: evaluationTrace.length === 0 ? null : evaluationTrace,
+    steps,
+  };
+}
+
+function listenerExecutionContext(
+  params: Pick<
+    MaterializeListenerExecutionParams,
+    'run' | 'job' | 'sequence' | 'triggerEvents' | 'priorExecutions'
+  > & {
+    readonly executionName: string;
+    readonly status: JobExecutionStatus;
+  },
+) {
+  return assembleExecutionCreationContext({
+    run: params.run,
+    triggerPayload: params.run.triggerPayload,
+    inputs: params.run.inputs,
+    jobId: params.job.id,
+    sequence: params.sequence,
+    executionName: params.executionName,
+    status: params.status,
+    triggerEvents: params.triggerEvents,
+    priorExecutions: params.priorExecutions,
+  });
+}
+
+class PermanentListenerMaterializationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PermanentListenerMaterializationError';
+  }
+}
+
+function isPermanentListenerMaterializationError(error: unknown): boolean {
+  return (
+    error instanceof PermanentListenerMaterializationError ||
+    error instanceof InterpolationUnresolvableError ||
+    error instanceof InvalidJobRunnerLabelsError ||
+    error instanceof AgentConfigUnresolvableError
+  );
+}

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
@@ -415,7 +415,7 @@ describe('listener filter snapshots', () => {
     ]);
   });
 
-  it('omits the jobs root when no referenced dependency is available', () => {
+  it('snapshots an empty jobs root when no referenced dependency is available', () => {
     const plan = planListenerFilterSnapshots({
       on: [
         {
@@ -445,6 +445,55 @@ describe('listener filter snapshots', () => {
       source: 'github',
       event: 'pull_request',
       filter: 'jobs.missing.outputs.pr_number == event.pull_request.number',
+      filter_snapshot: {jobs: {}},
+    });
+  });
+
+  it('snapshots all dependency jobs for dynamic jobs access', () => {
+    const plan = planListenerFilterSnapshots({
+      on: [
+        {
+          source: 'github',
+          event: 'pull_request',
+          filter: 'jobs[inputs.target].outputs.pr_number == event.pull_request.number',
+        },
+      ],
+      until: null,
+    });
+    const context = assembleListenerSnapshotContext({
+      job: {key: 'await'},
+      run,
+      triggerPayload,
+      inputs: {target: 'build'},
+      plan,
+      dependencyJobs: [
+        {
+          job: {key: 'build', status: 'succeeded', outputs: {pr_number: 42}},
+          executions: [jobExecution({id: 'exec-build', jobId: 'job-build'})],
+        },
+        {
+          job: {key: 'review', status: 'skipped', outputs: null},
+          executions: [],
+        },
+      ],
+    });
+
+    const [matcher] = applyListenerFilterSnapshots(plan.on, context);
+
+    expect(matcher?.filter_snapshot).toEqual({
+      inputs: {target: 'build'},
+      jobs: {
+        build: expect.objectContaining({
+          key: 'build',
+          status: 'succeeded',
+          outputs: {pr_number: 42},
+        }),
+        review: expect.objectContaining({
+          key: 'review',
+          status: 'skipped',
+          outputs: {},
+        }),
+      },
     });
   });
 });

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
@@ -1,14 +1,17 @@
 import type {JobExecution} from '#core/entities/job-execution.js';
 import type {Step, StepAttempt} from '#core/entities/step.js';
 import {
+  applyListenerFilterSnapshots,
   assembleCreationContext,
   assembleExecutionCreationContext,
   assembleExecutionResolutionContext,
   assembleGateContext,
   assembleJobActivationContext,
   assembleJobResolutionContext,
+  assembleListenerSnapshotContext,
   assembleStepDispatchContext,
   assembleWorkflowRunContext,
+  planListenerFilterSnapshots,
 } from './assemble-run-context.js';
 
 const date = new Date('2026-06-30T12:00:00.000Z');
@@ -318,6 +321,130 @@ describe('assembleJobActivationContext', () => {
           },
         ],
       },
+    });
+  });
+});
+
+describe('listener filter snapshots', () => {
+  const run = {
+    id: 'run-1',
+    name: 'Build',
+    definitionId: 'def-1',
+    projectId: 'proj-1',
+    workspaceId: 'workspace-1',
+    createdAt: new Date('2026-06-30T12:00:00.000Z'),
+  };
+  const triggerPayload = {
+    source: 'github',
+    event: 'pull_request',
+    deliveryId: 'delivery-1',
+    data: {action: 'opened'},
+  } as const;
+
+  it('snapshots supported roots and exact referenced job keys', () => {
+    const plan = planListenerFilterSnapshots({
+      on: [
+        {
+          source: 'github',
+          event: 'pull_request',
+          filter:
+            'jobs.build.outputs.pr_number == event.pull_request.number && inputs.environment == "prod" && trigger.event == "pull_request" && run.id != "" && job.key == "await"',
+        },
+      ],
+      until: null,
+    });
+    const context = assembleListenerSnapshotContext({
+      job: {key: 'await'},
+      run,
+      triggerPayload,
+      inputs: {environment: 'prod'},
+      plan,
+      dependencyJobs: [
+        {
+          job: {key: 'build', status: 'succeeded', outputs: {pr_number: 42}},
+          executions: [jobExecution({id: 'exec-build', jobId: 'job-build'})],
+        },
+        {
+          job: {key: 'review', status: 'succeeded', outputs: {pr_number: 99}},
+          executions: [jobExecution({id: 'exec-review', jobId: 'job-review'})],
+        },
+      ],
+    });
+
+    const [matcher] = applyListenerFilterSnapshots(plan.on, context);
+
+    expect(matcher?.filter_snapshot).toEqual({
+      run: expect.objectContaining({id: 'run-1', name: 'Build'}),
+      trigger: {source: 'github', event: 'pull_request'},
+      inputs: {environment: 'prod'},
+      job: {key: 'await'},
+      jobs: {
+        build: expect.objectContaining({
+          key: 'build',
+          status: 'succeeded',
+          outputs: {pr_number: 42},
+          executions: expect.any(Array),
+        }),
+      },
+    });
+    expect(matcher?.filter_snapshot).not.toHaveProperty('event');
+    expect(matcher?.filter_snapshot?.jobs).not.toHaveProperty('review');
+  });
+
+  it('omits snapshots for event-only filters and malformed filters', () => {
+    const plan = planListenerFilterSnapshots({
+      on: [
+        {source: 'github', event: 'pull_request', filter: 'event.action == "closed"'},
+        {source: 'github', event: 'pull_request', filter: 'event.'},
+      ],
+      until: null,
+    });
+    const context = assembleListenerSnapshotContext({
+      job: {key: 'await'},
+      run,
+      triggerPayload,
+      plan,
+      dependencyJobs: [],
+    });
+
+    const matchers = applyListenerFilterSnapshots(plan.on, context);
+
+    expect(matchers).toEqual([
+      {source: 'github', event: 'pull_request', filter: 'event.action == "closed"'},
+      {source: 'github', event: 'pull_request', filter: 'event.'},
+    ]);
+  });
+
+  it('omits the jobs root when no referenced dependency is available', () => {
+    const plan = planListenerFilterSnapshots({
+      on: [
+        {
+          source: 'github',
+          event: 'pull_request',
+          filter: 'jobs.missing.outputs.pr_number == event.pull_request.number',
+        },
+      ],
+      until: null,
+    });
+    const context = assembleListenerSnapshotContext({
+      job: {key: 'await'},
+      run,
+      triggerPayload,
+      plan,
+      dependencyJobs: [
+        {
+          job: {key: 'build', status: 'succeeded', outputs: {pr_number: 42}},
+          executions: [jobExecution({id: 'exec-build', jobId: 'job-build'})],
+        },
+      ],
+    });
+
+    const [matcher] = applyListenerFilterSnapshots(plan.on, context);
+
+    expect(matcher).toEqual({
+      source: 'github',
+      event: 'pull_request',
+      filter: 'jobs.missing.outputs.pr_number == event.pull_request.number',
     });
   });
 });

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.ts
@@ -1,5 +1,9 @@
-import type {WorkflowExpressionEvaluationContext} from '@shipfox/expression';
-import type {Job} from '#core/entities/job.js';
+import {
+  analyzeContextRootKeyAccess,
+  extractExactContextRoots,
+  type WorkflowExpressionEvaluationContext,
+} from '@shipfox/expression';
+import type {Job, JobListeningTrigger} from '#core/entities/job.js';
 import type {JobExecution} from '#core/entities/job-execution.js';
 import type {Step, StepAttempt, StepStatus} from '#core/entities/step.js';
 import type {TriggerPayload, WorkflowRun} from '#core/entities/workflow-run.js';
@@ -140,6 +144,163 @@ export function assembleJobActivationContext(
       needs: params.jobs.map(assembleJobContext),
     },
   };
+}
+
+type ListenerSnapshotRoot = 'run' | 'trigger' | 'inputs' | 'job' | 'jobs';
+
+export interface MatcherSnapshotPlan {
+  readonly matcher: JobListeningTrigger;
+  readonly roots: ReadonlySet<ListenerSnapshotRoot>;
+  readonly jobKeys: ReadonlySet<string>;
+}
+
+export interface ListenerSnapshotPlan {
+  readonly on: readonly MatcherSnapshotPlan[];
+  readonly until: readonly MatcherSnapshotPlan[];
+  readonly roots: ReadonlySet<ListenerSnapshotRoot>;
+  readonly jobKeys: ReadonlySet<string>;
+}
+
+export function planListenerFilterSnapshots(params: {
+  readonly on: readonly JobListeningTrigger[];
+  readonly until: readonly JobListeningTrigger[] | null;
+}): ListenerSnapshotPlan {
+  const roots = new Set<ListenerSnapshotRoot>();
+  const jobKeys = new Set<string>();
+  const on = params.on.map((matcher) => planMatcherFilterSnapshot(matcher, roots, jobKeys));
+  const until = (params.until ?? []).map((matcher) =>
+    planMatcherFilterSnapshot(matcher, roots, jobKeys),
+  );
+  return {on, until, roots, jobKeys};
+}
+
+function planMatcherFilterSnapshot(
+  matcher: JobListeningTrigger,
+  allRoots: Set<ListenerSnapshotRoot>,
+  allJobKeys: Set<string>,
+): MatcherSnapshotPlan {
+  if (matcher.filter === undefined) return {matcher, roots: new Set(), jobKeys: new Set()};
+
+  let roots: ListenerSnapshotRoot[];
+  try {
+    roots = extractExactContextRoots(matcher.filter)
+      .filter((root) => root !== 'event')
+      .filter(isListenerSnapshotRoot);
+  } catch {
+    return {matcher, roots: new Set(), jobKeys: new Set()};
+  }
+
+  if (roots.length === 0) return {matcher, roots: new Set(), jobKeys: new Set()};
+
+  const jobKeys =
+    roots.includes('jobs') && matcher.filter !== undefined
+      ? new Set(
+          analyzeContextRootKeyAccess(matcher.filter, ['jobs']).references.map(
+            (reference) => reference.key,
+          ),
+        )
+      : new Set<string>();
+  for (const root of roots) allRoots.add(root);
+  for (const key of jobKeys) allJobKeys.add(key);
+  return {matcher, roots: new Set(roots), jobKeys};
+}
+
+function isListenerSnapshotRoot(root: string): root is ListenerSnapshotRoot {
+  return (
+    root === 'run' || root === 'trigger' || root === 'inputs' || root === 'job' || root === 'jobs'
+  );
+}
+
+export function assembleListenerSnapshotContext(params: {
+  readonly job: Pick<Job, 'key'>;
+  readonly run: AssembleWorkflowRunContextParams['run'];
+  readonly triggerPayload: TriggerPayload;
+  readonly inputs?: Record<string, unknown> | null | undefined;
+  readonly plan: ListenerSnapshotPlan;
+  readonly dependencyJobs: readonly JobContextInput[];
+}): WorkflowExpressionEvaluationContext {
+  const context: Record<string, unknown> = {};
+  if (params.plan.roots.has('run') || params.plan.roots.has('trigger')) {
+    const runContext = assembleWorkflowRunContext({
+      run: params.run,
+      triggerPayload: params.triggerPayload,
+      inputs: params.inputs,
+    });
+    if (params.plan.roots.has('run')) context.run = runContext.run;
+    if (params.plan.roots.has('trigger')) context.trigger = runContext.trigger;
+  }
+
+  if (params.plan.roots.has('inputs')) {
+    context.inputs = params.inputs ?? null;
+  }
+  if (params.plan.roots.has('job')) {
+    context.job = {key: params.job.key};
+  }
+  if (params.plan.roots.has('jobs') && params.plan.jobKeys.size > 0) {
+    const jobsContext = requestedJobsContext(params.dependencyJobs, params.plan.jobKeys);
+    if (jobsContext !== undefined) context.jobs = jobsContext;
+  }
+
+  return context;
+}
+
+function requestedJobsContext(
+  dependencyJobs: readonly JobContextInput[],
+  jobKeys: ReadonlySet<string>,
+): unknown {
+  const filtered = dependencyJobs.filter(({job}) => jobKeys.has(job.key));
+  if (filtered.length === 0) return undefined;
+
+  return assembleJobsContext(filtered).jobs;
+}
+
+export type ListenerTriggerWithSnapshot = JobListeningTrigger & {
+  readonly filter_snapshot?: Record<string, unknown>;
+};
+
+export function applyListenerFilterSnapshots(
+  plans: readonly MatcherSnapshotPlan[],
+  context: WorkflowExpressionEvaluationContext,
+): ListenerTriggerWithSnapshot[] {
+  return plans.map((plan) => {
+    const filterSnapshot = filterSnapshotForPlan(plan, context);
+    if (filterSnapshot === undefined) return plan.matcher;
+
+    return {...plan.matcher, filter_snapshot: filterSnapshot};
+  });
+}
+
+function filterSnapshotForPlan(
+  plan: MatcherSnapshotPlan,
+  context: WorkflowExpressionEvaluationContext,
+): Record<string, unknown> | undefined {
+  const snapshot: Record<string, unknown> = {};
+  for (const root of plan.roots) {
+    if (root === 'jobs') {
+      const jobsSnapshot = jobsSnapshotForPlan(plan, context);
+      if (jobsSnapshot !== undefined) snapshot.jobs = jobsSnapshot;
+      continue;
+    }
+
+    if (root in context) snapshot[root] = context[root];
+  }
+
+  return Object.keys(snapshot).length === 0 ? undefined : snapshot;
+}
+
+function jobsSnapshotForPlan(
+  plan: MatcherSnapshotPlan,
+  context: WorkflowExpressionEvaluationContext,
+): Record<string, unknown> | undefined {
+  if (plan.jobKeys.size === 0 || typeof context.jobs !== 'object' || context.jobs === null) {
+    return undefined;
+  }
+
+  const jobsContext = context.jobs as Record<string, unknown>;
+  const snapshot = Object.fromEntries(
+    [...plan.jobKeys].flatMap((key) => (key in jobsContext ? [[key, jobsContext[key]]] : [])),
+  );
+  return Object.keys(snapshot).length === 0 ? undefined : snapshot;
 }
 
 function assembleJobContext({job, executions}: JobContextInput): Record<string, unknown> {

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.ts
@@ -123,7 +123,7 @@ function assembleExecutionContext(execution: JobExecution, index: number): Recor
 
 export function assembleJobsContext(
   jobs: readonly JobContextInput[],
-): WorkflowExpressionEvaluationContext {
+): WorkflowExpressionEvaluationContext & {readonly jobs: Record<string, unknown>} {
   return {
     jobs: Object.fromEntries(jobs.map((input) => [input.job.key, assembleJobContext(input)])),
   };
@@ -247,7 +247,7 @@ export function assembleListenerSnapshotContext(params: {
 function requestedJobsContext(
   dependencyJobs: readonly JobContextInput[],
   jobKeys: ReadonlySet<string>,
-): unknown {
+): Record<string, unknown> | undefined {
   const filtered = dependencyJobs.filter(({job}) => jobKeys.has(job.key));
   if (filtered.length === 0) return undefined;
 

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.ts
@@ -236,9 +236,8 @@ export function assembleListenerSnapshotContext(params: {
   if (params.plan.roots.has('job')) {
     context.job = {key: params.job.key};
   }
-  if (params.plan.roots.has('jobs') && params.plan.jobKeys.size > 0) {
-    const jobsContext = requestedJobsContext(params.dependencyJobs, params.plan.jobKeys);
-    if (jobsContext !== undefined) context.jobs = jobsContext;
+  if (params.plan.roots.has('jobs')) {
+    context.jobs = requestedJobsContext(params.dependencyJobs, params.plan.jobKeys);
   }
 
   return context;
@@ -247,9 +246,10 @@ export function assembleListenerSnapshotContext(params: {
 function requestedJobsContext(
   dependencyJobs: readonly JobContextInput[],
   jobKeys: ReadonlySet<string>,
-): Record<string, unknown> | undefined {
+): Record<string, unknown> {
+  if (jobKeys.size === 0) return assembleJobsContext(dependencyJobs).jobs;
+
   const filtered = dependencyJobs.filter(({job}) => jobKeys.has(job.key));
-  if (filtered.length === 0) return undefined;
 
   return assembleJobsContext(filtered).jobs;
 }
@@ -292,15 +292,19 @@ function jobsSnapshotForPlan(
   plan: MatcherSnapshotPlan,
   context: WorkflowExpressionEvaluationContext,
 ): Record<string, unknown> | undefined {
-  if (plan.jobKeys.size === 0 || typeof context.jobs !== 'object' || context.jobs === null) {
+  if (typeof context.jobs !== 'object' || context.jobs === null) {
     return undefined;
   }
 
   const jobsContext = context.jobs as Record<string, unknown>;
+  if (plan.jobKeys.size === 0) return {...jobsContext};
+
   const snapshot = Object.fromEntries(
-    [...plan.jobKeys].flatMap((key) => (key in jobsContext ? [[key, jobsContext[key]]] : [])),
+    [...plan.jobKeys].flatMap((key) =>
+      Object.hasOwn(jobsContext, key) ? [[key, jobsContext[key]]] : [],
+    ),
   );
-  return Object.keys(snapshot).length === 0 ? undefined : snapshot;
+  return snapshot;
 }
 
 function assembleJobContext({job, executions}: JobContextInput): Record<string, unknown> {

--- a/libs/api/workflows/src/core/step-config/index.ts
+++ b/libs/api/workflows/src/core/step-config/index.ts
@@ -2,6 +2,7 @@ export {
   type AssembleExecutionCreationContextParams,
   type AssembleJobActivationContextParams,
   type AssembleWorkflowRunContextParams,
+  applyListenerFilterSnapshots,
   assembleCreationContext,
   assembleExecutionCreationContext,
   assembleExecutionResolutionContext,
@@ -9,9 +10,14 @@ export {
   assembleGateContext,
   assembleJobActivationContext,
   assembleJobResolutionContext,
+  assembleListenerSnapshotContext,
   assembleStepDispatchContext,
   assembleWorkflowRunContext,
   type JobContextInput,
+  type ListenerSnapshotPlan,
+  type ListenerTriggerWithSnapshot,
+  type MatcherSnapshotPlan,
+  planListenerFilterSnapshots,
 } from './assemble-run-context.js';
 export {completeStepDispatchConfig} from './complete-step-dispatch-config.js';
 export {

--- a/libs/api/workflows/src/db/job-listeners.test.ts
+++ b/libs/api/workflows/src/db/job-listeners.test.ts
@@ -339,7 +339,7 @@ describe('activateJobListener', () => {
     expect(snapshot?.jobs).not.toHaveProperty('review');
   });
 
-  it('omits snapshots when referenced job keys are absent', async () => {
+  it('snapshots an empty jobs root when referenced job keys are absent', async () => {
     const job = await createListenerWithDependencies({
       on: [
         {
@@ -358,6 +358,7 @@ describe('activateJobListener', () => {
       source: 'github',
       event: 'pull_request',
       filter: 'jobs.missing.outputs.pr_number == event.pull_request.number',
+      filter_snapshot: {jobs: {}},
     });
   });
 

--- a/libs/api/workflows/src/db/job-listeners.ts
+++ b/libs/api/workflows/src/db/job-listeners.ts
@@ -1,35 +1,20 @@
-import {
-  type AgentDefaultsResolver,
-  catalogDefaultAgentResolver,
-} from '@shipfox/api-agent/core/resolve-agent-config';
+import type {AgentDefaultsResolver} from '@shipfox/api-agent/core/resolve-agent-config';
 import {
   WORKFLOWS_JOB_ACTIVATED,
   type WorkflowsJobActivatedEventDto,
 } from '@shipfox/api-workflows-dto';
-import {
-  analyzeContextRootKeyAccess,
-  extractExactContextRoots,
-  type WorkflowExpressionEvaluationContext,
-} from '@shipfox/expression';
 import {and, asc, count, eq, inArray, isNull, notInArray, sql} from 'drizzle-orm';
-import type {JobListeningTrigger, JobStatus, ResolutionReason} from '#core/entities/job.js';
+import type {JobStatus, ResolutionReason} from '#core/entities/job.js';
 import type {JobExecutionStatus, WorkflowExecutionEvent} from '#core/entities/job-execution.js';
 import {
-  AgentConfigUnresolvableError,
-  InterpolationUnresolvableError,
-  InvalidJobRunnerLabelsError,
-} from '#core/errors.js';
+  type MaterializedListenerExecution,
+  materializeListenerExecution,
+} from '#core/listener-execution-materialization.js';
 import {
-  assembleJobsContext,
-  assembleWorkflowRunContext,
-  type JobContextInput,
+  applyListenerFilterSnapshots,
+  assembleListenerSnapshotContext,
+  planListenerFilterSnapshots,
 } from '#core/step-config/assemble-run-context.js';
-import {
-  assembleExecutionCreationContext,
-  materializeJobExecutionSteps,
-  materializeJobRunner,
-  resolveJobExecutionName,
-} from '#core/step-config/index.js';
 import {
   recordListenerEventsCoalesced,
   recordWorkflowJobExecutionStatusChanged,
@@ -37,8 +22,8 @@ import {
 } from '#metrics/instance.js';
 import {db, type Tx} from './db.js';
 import {writeWorkflowsOutboxEvent} from './outbox-writes.js';
-import {jobExecutions, toJobExecution} from './schema/job-executions.js';
-import {jobListenerEvents} from './schema/job-listener-events.js';
+import {type JobExecutionDb, jobExecutions, toJobExecution} from './schema/job-executions.js';
+import {type JobListenerEventDb, jobListenerEvents} from './schema/job-listener-events.js';
 import {jobs, toJob} from './schema/jobs.js';
 import {steps} from './schema/steps.js';
 import {workflowRunAttempts} from './schema/workflow-run-attempts.js';
@@ -68,21 +53,6 @@ type JobActivatedListenerMatcher = Extract<
   WorkflowsJobActivatedEventDto,
   {mode: 'listening'}
 >['on'][number];
-
-type SnapshotRoot = 'run' | 'trigger' | 'inputs' | 'job' | 'jobs';
-
-interface MatcherSnapshotPlan {
-  readonly matcher: JobListeningTrigger;
-  readonly roots: ReadonlySet<SnapshotRoot>;
-  readonly jobKeys: ReadonlySet<string>;
-}
-
-interface ListenerSnapshotPlan {
-  readonly on: readonly MatcherSnapshotPlan[];
-  readonly until: readonly MatcherSnapshotPlan[];
-  readonly roots: ReadonlySet<SnapshotRoot>;
-  readonly jobKeys: ReadonlySet<string>;
-}
 
 export async function activateJobListener(
   params: ActivateJobListenerParams,
@@ -144,10 +114,17 @@ export async function activateJobListener(
         until: target.job.listeningUntil ?? null,
       };
       const snapshotPlan = planListenerFilterSnapshots(matchers);
-      const snapshotContext = await assembleListenerSnapshotContext(tx, {
+      const dependencyJobs =
+        snapshotPlan.jobKeys.size === 0
+          ? []
+          : await getDirectDependencyJobContexts(params.jobId, tx);
+      const snapshotContext = assembleListenerSnapshotContext({
         job: toJob(target.job),
         run: toWorkflowRun(target.run),
+        triggerPayload: target.run.triggerPayload,
+        inputs: target.run.inputs,
         plan: snapshotPlan,
+        dependencyJobs,
       });
 
       await writeWorkflowsOutboxEvent(tx, {
@@ -157,156 +134,23 @@ export async function activateJobListener(
           workflowRunId: target.run.id,
           workspaceId: target.run.workspaceId,
           mode: 'listening',
-          on: applyFilterSnapshots(snapshotPlan.on, snapshotContext),
+          on: applyListenerFilterSnapshots(
+            snapshotPlan.on,
+            snapshotContext,
+          ) as JobActivatedListenerMatcher[],
           until:
             matchers.until === null
               ? null
-              : applyFilterSnapshots(snapshotPlan.until, snapshotContext),
+              : (applyListenerFilterSnapshots(
+                  snapshotPlan.until,
+                  snapshotContext,
+                ) as JobActivatedListenerMatcher[]),
         },
       });
     }
 
     return {status: 'running', jobStatus: job.status, jobVersion: job.version, executionCount};
   });
-}
-
-function planListenerFilterSnapshots(params: {
-  readonly on: readonly JobListeningTrigger[];
-  readonly until: readonly JobListeningTrigger[] | null;
-}): ListenerSnapshotPlan {
-  const roots = new Set<SnapshotRoot>();
-  const jobKeys = new Set<string>();
-  const on = params.on.map((matcher) => planMatcherFilterSnapshot(matcher, roots, jobKeys));
-  const until = (params.until ?? []).map((matcher) =>
-    planMatcherFilterSnapshot(matcher, roots, jobKeys),
-  );
-  return {on, until, roots, jobKeys};
-}
-
-function planMatcherFilterSnapshot(
-  matcher: JobListeningTrigger,
-  allRoots: Set<SnapshotRoot>,
-  allJobKeys: Set<string>,
-): MatcherSnapshotPlan {
-  if (matcher.filter === undefined) return {matcher, roots: new Set(), jobKeys: new Set()};
-
-  let roots: SnapshotRoot[];
-  try {
-    roots = extractExactContextRoots(matcher.filter)
-      .filter((root) => root !== 'event')
-      .filter(isSnapshotRoot);
-  } catch {
-    return {matcher, roots: new Set(), jobKeys: new Set()};
-  }
-
-  if (roots.length === 0) return {matcher, roots: new Set(), jobKeys: new Set()};
-
-  const jobKeys =
-    roots.includes('jobs') && matcher.filter !== undefined
-      ? new Set(
-          analyzeContextRootKeyAccess(matcher.filter, ['jobs']).references.map(
-            (reference) => reference.key,
-          ),
-        )
-      : new Set<string>();
-  for (const root of roots) allRoots.add(root);
-  for (const key of jobKeys) allJobKeys.add(key);
-  return {matcher, roots: new Set(roots), jobKeys};
-}
-
-function isSnapshotRoot(root: string): root is SnapshotRoot {
-  return (
-    root === 'run' || root === 'trigger' || root === 'inputs' || root === 'job' || root === 'jobs'
-  );
-}
-
-async function assembleListenerSnapshotContext(
-  tx: Tx,
-  params: {
-    readonly job: ReturnType<typeof toJob>;
-    readonly run: ReturnType<typeof toWorkflowRun>;
-    readonly plan: ListenerSnapshotPlan;
-  },
-): Promise<WorkflowExpressionEvaluationContext> {
-  const context: Record<string, unknown> = {};
-  if (params.plan.roots.has('run') || params.plan.roots.has('trigger')) {
-    const runContext = assembleWorkflowRunContext({
-      run: params.run,
-      triggerPayload: params.run.triggerPayload,
-      inputs: params.run.inputs,
-    });
-    if (params.plan.roots.has('run')) context.run = runContext.run;
-    if (params.plan.roots.has('trigger')) context.trigger = runContext.trigger;
-  }
-
-  if (params.plan.roots.has('inputs')) {
-    context.inputs = params.run.inputs;
-  }
-  if (params.plan.roots.has('job')) {
-    context.job = {key: params.job.key};
-  }
-  if (params.plan.roots.has('jobs') && params.plan.jobKeys.size > 0) {
-    const dependencyJobs = await getDirectDependencyJobContexts(params.job.id, tx);
-    const jobsContext = requestedJobsContext(dependencyJobs, params.plan.jobKeys);
-    if (jobsContext !== undefined) context.jobs = jobsContext;
-  }
-
-  return context;
-}
-
-function requestedJobsContext(
-  dependencyJobs: readonly JobContextInput[],
-  jobKeys: ReadonlySet<string>,
-): unknown {
-  const filtered = dependencyJobs.filter(({job}) => jobKeys.has(job.key));
-  if (filtered.length === 0) return undefined;
-
-  return assembleJobsContext(filtered).jobs;
-}
-
-function applyFilterSnapshots(
-  plans: readonly MatcherSnapshotPlan[],
-  context: WorkflowExpressionEvaluationContext,
-): JobActivatedListenerMatcher[] {
-  return plans.map((plan) => {
-    const filterSnapshot = filterSnapshotForPlan(plan, context);
-    if (filterSnapshot === undefined) return plan.matcher;
-
-    return {...plan.matcher, filter_snapshot: filterSnapshot};
-  });
-}
-
-function filterSnapshotForPlan(
-  plan: MatcherSnapshotPlan,
-  context: WorkflowExpressionEvaluationContext,
-): Record<string, unknown> | undefined {
-  const snapshot: Record<string, unknown> = {};
-  for (const root of plan.roots) {
-    if (root === 'jobs') {
-      const jobsSnapshot = jobsSnapshotForPlan(plan, context);
-      if (jobsSnapshot !== undefined) snapshot.jobs = jobsSnapshot;
-      continue;
-    }
-
-    if (root in context) snapshot[root] = context[root];
-  }
-
-  return Object.keys(snapshot).length === 0 ? undefined : snapshot;
-}
-
-function jobsSnapshotForPlan(
-  plan: MatcherSnapshotPlan,
-  context: WorkflowExpressionEvaluationContext,
-): Record<string, unknown> | undefined {
-  if (plan.jobKeys.size === 0 || typeof context.jobs !== 'object' || context.jobs === null) {
-    return undefined;
-  }
-
-  const jobsContext = context.jobs as Record<string, unknown>;
-  const snapshot = Object.fromEntries(
-    [...plan.jobKeys].flatMap((key) => (key in jobsContext ? [[key, jobsContext[key]]] : [])),
-  );
-  return Object.keys(snapshot).length === 0 ? undefined : snapshot;
 }
 
 export type DrainListenerEventsResult =
@@ -335,165 +179,35 @@ export async function drainListenerEventsIntoExecution(
     const existing = await findExistingExecution(params, tx);
     if (existing) return {result: existing};
 
-    const [resolveEvent] = await tx
-      .select({id: jobListenerEvents.id})
-      .from(jobListenerEvents)
-      .where(
-        and(
-          eq(jobListenerEvents.jobId, params.jobId),
-          eq(jobListenerEvents.disposition, 'resolve'),
-          isNull(jobListenerEvents.consumedByExecutionId),
-        ),
-      )
-      .orderBy(asc(jobListenerEvents.receivedAt), asc(jobListenerEvents.id))
-      .limit(1)
-      .for('update');
-    if (resolveEvent) return {result: {kind: 'resolve-requested' as const}};
+    const resolveRequested = await hasPendingResolveEvent(params.jobId, tx);
+    if (resolveRequested) return {result: {kind: 'resolve-requested' as const}};
 
-    const bufferedQuery = tx
-      .select()
-      .from(jobListenerEvents)
-      .where(
-        and(
-          eq(jobListenerEvents.jobId, params.jobId),
-          eq(jobListenerEvents.disposition, 'fire'),
-          isNull(jobListenerEvents.consumedByExecutionId),
-        ),
-      )
-      .orderBy(asc(jobListenerEvents.receivedAt), asc(jobListenerEvents.id));
-    const bufferedEvents = await (params.maxSize === undefined
-      ? bufferedQuery
-      : bufferedQuery.limit(params.maxSize)
-    ).for('update');
+    const bufferedEvents = await lockBufferedFireEvents(params, tx);
     if (bufferedEvents.length === 0) return {result: {kind: 'empty' as const}};
 
     const target = await loadListenerMaterializationTarget(params.jobId, tx);
-    const triggerEvents = bufferedEvents.map(
-      (event): WorkflowExecutionEvent => ({
-        source: event.source,
-        event: event.event,
-        delivery_id: event.deliveryId,
-        received_at: event.receivedAt.toISOString(),
-        data: event.payload,
-      }),
-    );
+    const materialized = materializeListenerExecution({
+      model: target.attempt.model,
+      run: toWorkflowRun(target.run),
+      job: toJob(target.job),
+      sequence: params.expectedSequence,
+      triggerEvents: listenerTriggerEvents(bufferedEvents),
+      priorExecutions: target.priorExecutions,
+      resolveAgentDefaults: params.resolveAgentDefaults,
+    });
+    const execution = await persistMaterializedListenerExecution(tx, {
+      jobId: params.jobId,
+      sequence: params.expectedSequence,
+      bufferedEventIds: bufferedEvents.map((event) => event.id),
+      materialized,
+    });
 
-    const fallbackName = `${target.job.key} #${params.expectedSequence}`;
-    let executionName = fallbackName;
-    let executionNameTrace: ReturnType<typeof resolveJobExecutionName>['trace'] = [];
-    let status: JobExecutionStatus = 'pending';
-    let materializedSteps: ReturnType<typeof materializeJobExecutionSteps> = [];
-    let runner: readonly string[] = [];
-    try {
-      const model = target.attempt.model;
-      if (!model) throw new PermanentListenerMaterializationError('Run attempt has no model');
-      const modelJob = model.jobs.find((job) => job.key === target.job.key);
-      if (!modelJob) {
-        throw new PermanentListenerMaterializationError(
-          `Workflow model has no job key: ${target.job.key}`,
-        );
-      }
-
-      const nameContext = listenerExecutionContext({
-        run: toWorkflowRun(target.run),
-        jobId: params.jobId,
-        sequence: params.expectedSequence,
-        executionName,
-        status,
-        triggerEvents,
-        priorExecutions: target.priorExecutions,
-      });
-      const resolvedExecutionName = resolveJobExecutionName({
-        definitionId: target.run.definitionId,
-        job: modelJob,
-        fallbackName,
-        context: nameContext.values,
-      });
-      executionName = resolvedExecutionName.value;
-      executionNameTrace = resolvedExecutionName.trace;
-      const stepContext = listenerExecutionContext({
-        run: toWorkflowRun(target.run),
-        jobId: params.jobId,
-        sequence: params.expectedSequence,
-        executionName,
-        status,
-        triggerEvents,
-        priorExecutions: target.priorExecutions,
-      });
-      runner = materializeJobRunner({
-        job: modelJob,
-        context: stepContext,
-        definitionId: target.run.definitionId,
-      });
-      materializedSteps = materializeJobExecutionSteps({
-        model,
-        job: modelJob,
-        context: stepContext,
-        resolveAgentDefaults: params.resolveAgentDefaults ?? catalogDefaultAgentResolver,
-        definitionId: target.run.definitionId,
-      });
-    } catch (error) {
-      if (!isPermanentListenerMaterializationError(error)) throw error;
-      status = 'failed';
-    }
-
-    const [execution] = await tx
-      .insert(jobExecutions)
-      .values({
-        jobId: params.jobId,
-        sequence: params.expectedSequence,
-        name: executionName,
-        runner: runner.length === 0 ? null : [...runner],
-        status,
-        statusReason: status === 'failed' ? 'unknown' : null,
-        triggerEvents,
-        evaluationTrace: executionNameTrace.length === 0 ? null : executionNameTrace,
-        ...(status === 'failed' ? {finishedAt: sql`now()`} : {}),
-      })
-      .returning();
-    if (!execution) throw new Error('Insert returned no rows');
-
-    await tx
-      .update(jobListenerEvents)
-      .set({consumedByExecutionId: execution.id})
-      .where(
-        inArray(
-          jobListenerEvents.id,
-          bufferedEvents.map((event) => event.id),
-        ),
-      );
-
-    if (status === 'pending' && materializedSteps.length > 0) {
-      await tx.insert(steps).values(
-        materializedSteps.map((step) => ({
-          jobExecutionId: execution.id,
-          key: step.key,
-          name: step.name,
-          sourceLocation: step.sourceLocation,
-          status: step.status,
-          type: step.type,
-          config: step.config,
-          configPlan: step.configPlan ?? null,
-          authoredConfig: step.authoredConfig,
-          condition: step.condition ?? null,
-          position: step.position,
-        })),
-      );
-    }
-
-    if (status === 'failed') {
-      recordWorkflowJobExecutionStatusChanged(status);
+    if (materialized.status === 'failed') {
+      recordWorkflowJobExecutionStatusChanged(materialized.status);
     }
 
     return {
-      result: {
-        kind: 'execution' as const,
-        jobExecutionId: execution.id,
-        executionVersion: execution.version,
-        sequence: execution.sequence,
-        requiredLabels: execution.runner ?? [],
-        status: execution.status,
-      },
+      result: drainExecutionResult(execution),
       batchSize: bufferedEvents.length,
     };
   });
@@ -656,6 +370,120 @@ async function findExistingExecution(
   };
 }
 
+async function hasPendingResolveEvent(jobId: string, tx: Tx): Promise<boolean> {
+  const [resolveEvent] = await tx
+    .select({id: jobListenerEvents.id})
+    .from(jobListenerEvents)
+    .where(
+      and(
+        eq(jobListenerEvents.jobId, jobId),
+        eq(jobListenerEvents.disposition, 'resolve'),
+        isNull(jobListenerEvents.consumedByExecutionId),
+      ),
+    )
+    .orderBy(asc(jobListenerEvents.receivedAt), asc(jobListenerEvents.id))
+    .limit(1)
+    .for('update');
+  return resolveEvent !== undefined;
+}
+
+async function lockBufferedFireEvents(
+  params: DrainListenerEventsParams,
+  tx: Tx,
+): Promise<JobListenerEventDb[]> {
+  const bufferedQuery = tx
+    .select()
+    .from(jobListenerEvents)
+    .where(
+      and(
+        eq(jobListenerEvents.jobId, params.jobId),
+        eq(jobListenerEvents.disposition, 'fire'),
+        isNull(jobListenerEvents.consumedByExecutionId),
+      ),
+    )
+    .orderBy(asc(jobListenerEvents.receivedAt), asc(jobListenerEvents.id));
+  return await (params.maxSize === undefined
+    ? bufferedQuery
+    : bufferedQuery.limit(params.maxSize)
+  ).for('update');
+}
+
+function listenerTriggerEvents(
+  bufferedEvents: readonly JobListenerEventDb[],
+): WorkflowExecutionEvent[] {
+  return bufferedEvents.map((event) => ({
+    source: event.source,
+    event: event.event,
+    delivery_id: event.deliveryId,
+    received_at: event.receivedAt.toISOString(),
+    data: event.payload,
+  }));
+}
+
+async function persistMaterializedListenerExecution(
+  tx: Tx,
+  params: {
+    readonly jobId: string;
+    readonly sequence: number;
+    readonly bufferedEventIds: readonly string[];
+    readonly materialized: MaterializedListenerExecution;
+  },
+): Promise<JobExecutionDb> {
+  const [execution] = await tx
+    .insert(jobExecutions)
+    .values({
+      jobId: params.jobId,
+      sequence: params.sequence,
+      name: params.materialized.name,
+      runner: params.materialized.runner.length === 0 ? null : [...params.materialized.runner],
+      status: params.materialized.status,
+      statusReason: params.materialized.statusReason,
+      triggerEvents: [...params.materialized.triggerEvents],
+      evaluationTrace: params.materialized.evaluationTrace,
+      ...(params.materialized.status === 'failed' ? {finishedAt: sql`now()`} : {}),
+    })
+    .returning();
+  if (!execution) throw new Error('Insert returned no rows');
+
+  await tx
+    .update(jobListenerEvents)
+    .set({consumedByExecutionId: execution.id})
+    .where(inArray(jobListenerEvents.id, [...params.bufferedEventIds]));
+
+  if (params.materialized.status === 'pending' && params.materialized.steps.length > 0) {
+    await tx.insert(steps).values(
+      params.materialized.steps.map((step) => ({
+        jobExecutionId: execution.id,
+        key: step.key,
+        name: step.name,
+        sourceLocation: step.sourceLocation,
+        status: step.status,
+        type: step.type,
+        config: step.config,
+        configPlan: step.configPlan ?? null,
+        authoredConfig: step.authoredConfig,
+        condition: step.condition ?? null,
+        position: step.position,
+      })),
+    );
+  }
+
+  return execution;
+}
+
+function drainExecutionResult(
+  execution: JobExecutionDb,
+): Extract<DrainListenerEventsResult, {kind: 'execution'}> {
+  return {
+    kind: 'execution',
+    jobExecutionId: execution.id,
+    executionVersion: execution.version,
+    sequence: execution.sequence,
+    requiredLabels: execution.runner ?? [],
+    status: execution.status,
+  };
+}
+
 async function loadListenerMaterializationTarget(jobId: string, tx: Tx) {
   const [target] = await tx
     .select({job: jobs, attempt: workflowRunAttempts, run: workflowRuns})
@@ -673,42 +501,4 @@ async function loadListenerMaterializationTarget(jobId: string, tx: Tx) {
     .where(eq(jobExecutions.jobId, jobId))
     .orderBy(asc(jobExecutions.sequence), asc(jobExecutions.id));
   return {...target, priorExecutions: priorExecutions.map(toJobExecution)};
-}
-
-function listenerExecutionContext(params: {
-  run: ReturnType<typeof toWorkflowRun>;
-  jobId: string;
-  sequence: number;
-  executionName: string;
-  status: JobExecutionStatus;
-  triggerEvents: readonly WorkflowExecutionEvent[];
-  priorExecutions: ReturnType<typeof toJobExecution>[];
-}) {
-  return assembleExecutionCreationContext({
-    run: params.run,
-    triggerPayload: params.run.triggerPayload,
-    inputs: params.run.inputs,
-    jobId: params.jobId,
-    sequence: params.sequence,
-    executionName: params.executionName,
-    status: params.status,
-    triggerEvents: params.triggerEvents,
-    priorExecutions: params.priorExecutions,
-  });
-}
-
-class PermanentListenerMaterializationError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'PermanentListenerMaterializationError';
-  }
-}
-
-function isPermanentListenerMaterializationError(error: unknown): boolean {
-  return (
-    error instanceof PermanentListenerMaterializationError ||
-    error instanceof InterpolationUnresolvableError ||
-    error instanceof InvalidJobRunnerLabelsError ||
-    error instanceof AgentConfigUnresolvableError
-  );
 }

--- a/libs/api/workflows/src/db/job-listeners.ts
+++ b/libs/api/workflows/src/db/job-listeners.ts
@@ -363,14 +363,7 @@ async function findExistingExecution(
     )
     .limit(1);
   if (!existing) return undefined;
-  return {
-    kind: 'execution',
-    jobExecutionId: existing.id,
-    executionVersion: existing.version,
-    sequence: existing.sequence,
-    requiredLabels: existing.runner ?? [],
-    status: existing.status,
-  };
+  return drainExecutionResult(existing);
 }
 
 async function hasPendingResolveEvent(jobId: string, tx: Tx): Promise<boolean> {

--- a/libs/api/workflows/src/db/job-listeners.ts
+++ b/libs/api/workflows/src/db/job-listeners.ts
@@ -13,6 +13,7 @@ import {
 import {
   applyListenerFilterSnapshots,
   assembleListenerSnapshotContext,
+  type ListenerTriggerWithSnapshot,
   planListenerFilterSnapshots,
 } from '#core/step-config/assemble-run-context.js';
 import {
@@ -52,7 +53,15 @@ export interface ActivateJobListenerResult {
 type JobActivatedListenerMatcher = Extract<
   WorkflowsJobActivatedEventDto,
   {mode: 'listening'}
->['on'][number];
+>['on'][number] &
+  ListenerTriggerWithSnapshot;
+
+function applyActivatedListenerFilterSnapshots(
+  plans: Parameters<typeof applyListenerFilterSnapshots>[0],
+  context: Parameters<typeof applyListenerFilterSnapshots>[1],
+): JobActivatedListenerMatcher[] {
+  return applyListenerFilterSnapshots(plans, context);
+}
 
 export async function activateJobListener(
   params: ActivateJobListenerParams,
@@ -134,17 +143,11 @@ export async function activateJobListener(
           workflowRunId: target.run.id,
           workspaceId: target.run.workspaceId,
           mode: 'listening',
-          on: applyListenerFilterSnapshots(
-            snapshotPlan.on,
-            snapshotContext,
-          ) as JobActivatedListenerMatcher[],
+          on: applyActivatedListenerFilterSnapshots(snapshotPlan.on, snapshotContext),
           until:
             matchers.until === null
               ? null
-              : (applyListenerFilterSnapshots(
-                  snapshotPlan.until,
-                  snapshotContext,
-                ) as JobActivatedListenerMatcher[]),
+              : applyActivatedListenerFilterSnapshots(snapshotPlan.until, snapshotContext),
         },
       });
     }


### PR DESCRIPTION
Moves listener firing materialization and listener filter snapshot planning out of `db/job-listeners.ts` into core helpers.

The listener drain path had grown into a transaction that mixed event locking, batch coalescing, expression snapshot analysis, job execution materialization, step materialization, and persistence. This keeps the SQL concerns in the database layer while core owns the pure decisions for listener snapshots and listener execution materialization.

Reviewers should pay closest attention to behavior parity in listener activation snapshots and permanent materialization failure handling.

Closes ENG-885

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves listener firing execution materialization and listener filter snapshot planning from the DB layer into core so the drain path focuses on locking/persistence while core owns pure decision logic. Closes ENG-885.

- **Refactors**
  - Added core `materializeListenerExecution` to resolve execution name, runner, steps, and status; treats permanent materialization errors as failed and returns trigger events by reference.
  - Centralized and typed listener snapshot helpers in core: `planListenerFilterSnapshots`, `assembleListenerSnapshotContext`, `applyListenerFilterSnapshots`, and `ListenerTriggerWithSnapshot` (exported via `step-config`); removed inline casts and adopted a concrete jobs snapshot shape.
  - Preserved activation jobs snapshots by freezing the `jobs` root for dynamic access and missing-key filters and using own-property checks to avoid prototype bleed-through.
  - Simplified the DB drain path to lock buffered events, delegate materialization to core, persist execution and steps, mark events consumed, and reuse the execution result mapper; added tests for roots, exact job keys, dynamic jobs, event-only/malformed filters, and missing dependencies (now snapshot `{jobs: {}}`).
  - Documented empty `jobs` snapshot semantics: an explicit empty snapshot behaves the same as a missing snapshot; added trigger-side tests.

<sup>Written for commit e9ba141e7a851d265e32f93ecdc744d18c9d16cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

