### PR TITLE
[api-workflows] Trim workflow run detail step payloads

### DIFF
--- a/e2e/suites/flow/workflows/src/expect.test.ts
+++ b/e2e/suites/flow/workflows/src/expect.test.ts
@@ -40,7 +40,6 @@ function makeStep(overrides: Partial<WorkflowRunStepDetailDto> = {}): WorkflowRu
     source_location: null,
     status: 'succeeded',
     type: 'run',
-    config: {},
     error: null,
     position: 0,
     current_attempt: 1,

--- a/libs/api/workflows-dto/src/index.ts
+++ b/libs/api/workflows-dto/src/index.ts
@@ -9,6 +9,8 @@ export {
   checkoutIntentSchema,
   checkoutTokenAuthSchema,
   checkoutTokenResponseSchema,
+  type ExecutableStepDto,
+  executableStepDtoSchema,
   type JobDto,
   type JobExecutionDto,
   type JobListeningDto,

--- a/libs/api/workflows-dto/src/schemas/index.ts
+++ b/libs/api/workflows-dto/src/schemas/index.ts
@@ -49,6 +49,8 @@ export {type LogOutcomeDto, logOutcomeSchema} from './log-outcome.js';
 export {
   type AgentConfigIssueDto,
   agentConfigIssueSchema,
+  type ExecutableStepDto,
+  executableStepDtoSchema,
   STEP_ERROR_MESSAGE_MAX_LENGTH,
   type StepAttemptDto,
   type StepDto,

--- a/libs/api/workflows-dto/src/schemas/job-execution.ts
+++ b/libs/api/workflows-dto/src/schemas/job-execution.ts
@@ -1,6 +1,6 @@
 import {z} from 'zod';
 import {logOutcomeSchema} from './log-outcome.js';
-import {stepDtoSchema, stepErrorDtoSchema} from './step.js';
+import {executableStepDtoSchema, stepErrorDtoSchema} from './step.js';
 
 export const STEP_RESPONSE_MAX_LENGTH = 8 * 1024;
 
@@ -11,7 +11,7 @@ export const STEP_RESPONSE_MAX_LENGTH = 8 * 1024;
 export const nextStepResponseSchema = z.discriminatedUnion('kind', [
   z.object({
     kind: z.literal('step'),
-    step: stepDtoSchema,
+    step: executableStepDtoSchema,
     attempt: z
       .number()
       .int()

--- a/libs/api/workflows-dto/src/schemas/step-source-location.test.ts
+++ b/libs/api/workflows-dto/src/schemas/step-source-location.test.ts
@@ -1,4 +1,5 @@
-import {stepDtoSchema, stepSourceLocationSchema} from './step.js';
+import {executableStepDtoSchema, stepDtoSchema, stepSourceLocationSchema} from './step.js';
+import {workflowRunStepDetailDtoSchema} from './workflow-run-detail.js';
 
 const baseStep = {
   id: '11111111-1111-4111-8111-111111111111',
@@ -7,7 +8,6 @@ const baseStep = {
   name: 'echo hello',
   status: 'pending',
   type: 'run',
-  config: {run: 'echo hello'},
   error: null,
   position: 1,
   current_attempt: 1,
@@ -41,5 +41,40 @@ describe('step source location schemas', () => {
     const result = stepDtoSchema.parse({...baseStep, source_location: null});
 
     expect(result.source_location).toBeNull();
+  });
+
+  test('rejects config on read step DTOs', () => {
+    const result = stepDtoSchema.safeParse({
+      ...baseStep,
+      source_location: null,
+      config: {run: 'echo hello'},
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  test('accepts config on executable step DTOs', () => {
+    const result = executableStepDtoSchema.parse({
+      ...baseStep,
+      source_location: null,
+      config: {run: 'echo hello'},
+    });
+
+    expect(result.config).toEqual({run: 'echo hello'});
+  });
+
+  test('rejects config on workflow run detail step DTOs', () => {
+    const result = workflowRunStepDetailDtoSchema.safeParse({
+      ...baseStep,
+      source_location: null,
+      exit_code: null,
+      outputs: null,
+      response: null,
+      gate_result: null,
+      attempts: [],
+      config: {run: 'echo hello'},
+    });
+
+    expect(result.success).toBe(false);
   });
 });

--- a/libs/api/workflows-dto/src/schemas/step.ts
+++ b/libs/api/workflows-dto/src/schemas/step.ts
@@ -75,24 +75,31 @@ export const stepSourceLocationSchema = z
 
 export type StepSourceLocationDto = z.infer<typeof stepSourceLocationSchema>;
 
-export const stepDtoSchema = z.object({
-  id: z.string().uuid(),
-  job_execution_id: z.string().uuid(),
-  key: z.string().nullable(),
-  name: z.string(),
-  source_location: stepSourceLocationSchema.nullable(),
-  status: z.string(),
-  type: z.string(),
-  config: z.record(z.string(), z.unknown()),
-  error: stepErrorDtoSchema,
-  position: z.number(),
-  // Execution-attempt identity of the current projection (>1 after a restart).
-  current_attempt: z.number().int(),
-  created_at: z.string(),
-  updated_at: z.string(),
-});
+export const stepDtoSchema = z
+  .object({
+    id: z.string().uuid(),
+    job_execution_id: z.string().uuid(),
+    key: z.string().nullable(),
+    name: z.string(),
+    source_location: stepSourceLocationSchema.nullable(),
+    status: z.string(),
+    type: z.string(),
+    error: stepErrorDtoSchema,
+    position: z.number(),
+    // Execution-attempt identity of the current projection (>1 after a restart).
+    current_attempt: z.number().int(),
+    created_at: z.string(),
+    updated_at: z.string(),
+  })
+  .strict();
 
 export type StepDto = z.infer<typeof stepDtoSchema>;
+
+export const executableStepDtoSchema = stepDtoSchema.extend({
+  config: z.record(z.string(), z.unknown()),
+});
+
+export type ExecutableStepDto = z.infer<typeof executableStepDtoSchema>;
 
 export const stepGateResultDtoSchema = z
   .discriminatedUnion('kind', [

--- a/libs/api/workflows/src/core/entities/workflow-run.ts
+++ b/libs/api/workflows/src/core/entities/workflow-run.ts
@@ -83,8 +83,49 @@ export interface JobExecutionDetail extends JobExecution {
   steps: StepDetail[];
 }
 
+export interface WorkflowRunStepAttemptDetail
+  extends Pick<
+    StepAttempt,
+    | 'id'
+    | 'stepId'
+    | 'attempt'
+    | 'executionOrder'
+    | 'status'
+    | 'output'
+    | 'response'
+    | 'error'
+    | 'exitCode'
+    | 'gateResult'
+    | 'restartFeedback'
+    | 'startedAt'
+    | 'finishedAt'
+  > {}
+
+export interface WorkflowRunStepDetail
+  extends Pick<
+    Step,
+    | 'id'
+    | 'jobExecutionId'
+    | 'key'
+    | 'name'
+    | 'sourceLocation'
+    | 'status'
+    | 'type'
+    | 'error'
+    | 'position'
+    | 'currentAttempt'
+    | 'createdAt'
+    | 'updatedAt'
+  > {
+  attempts: WorkflowRunStepAttemptDetail[];
+}
+
+export interface WorkflowRunJobExecutionDetail extends JobExecution {
+  steps: WorkflowRunStepDetail[];
+}
+
 export interface WorkflowJobDetail extends Job {
-  jobExecutions: JobExecutionDetail[];
+  jobExecutions: WorkflowRunJobExecutionDetail[];
 }
 
 export interface WorkflowRunDetail extends WorkflowRun {

--- a/libs/api/workflows/src/db/workflow-runs/queries.ts
+++ b/libs/api/workflows/src/db/workflow-runs/queries.ts
@@ -4,18 +4,18 @@ import {
   timestampIdCursorWhere,
 } from '@shipfox/node-drizzle';
 import {and, asc, count, desc, eq, gte, lte, type SQL, sql} from 'drizzle-orm';
+import type {StepAttemptStatus} from '#core/entities/step.js';
 import type {
   JobExecutionDetail,
   StepDetail,
-  WorkflowRunJobExecutionDetail,
   WorkflowJobDetail,
   WorkflowRun,
   WorkflowRunDetail,
+  WorkflowRunJobExecutionDetail,
+  WorkflowRunStatus,
   WorkflowRunStepAttemptDetail,
   WorkflowRunStepDetail,
-  WorkflowRunStatus,
 } from '#core/entities/workflow-run.js';
-import type {StepAttemptStatus} from '#core/entities/step.js';
 import {db} from '../db.js';
 import {jobExecutions, toJobExecution} from '../schema/job-executions.js';
 import {jobs, toJob} from '../schema/jobs.js';

--- a/libs/api/workflows/src/db/workflow-runs/queries.ts
+++ b/libs/api/workflows/src/db/workflow-runs/queries.ts
@@ -7,11 +7,15 @@ import {and, asc, count, desc, eq, gte, lte, type SQL, sql} from 'drizzle-orm';
 import type {
   JobExecutionDetail,
   StepDetail,
+  WorkflowRunJobExecutionDetail,
   WorkflowJobDetail,
   WorkflowRun,
   WorkflowRunDetail,
+  WorkflowRunStepAttemptDetail,
+  WorkflowRunStepDetail,
   WorkflowRunStatus,
 } from '#core/entities/workflow-run.js';
+import type {StepAttemptStatus} from '#core/entities/step.js';
 import {db} from '../db.js';
 import {jobExecutions, toJobExecution} from '../schema/job-executions.js';
 import {jobs, toJob} from '../schema/jobs.js';
@@ -307,8 +311,35 @@ export async function getWorkflowRunDetail(
       run: workflowRuns,
       job: jobs,
       jobExecution: jobExecutions,
-      step: steps,
-      stepAttempt: stepAttempts,
+      step: {
+        id: steps.id,
+        jobExecutionId: steps.jobExecutionId,
+        key: steps.key,
+        name: steps.name,
+        sourceLocation: steps.sourceLocation,
+        status: steps.status,
+        type: steps.type,
+        error: steps.error,
+        position: steps.position,
+        currentAttempt: steps.currentAttempt,
+        createdAt: steps.createdAt,
+        updatedAt: steps.updatedAt,
+      },
+      stepAttempt: {
+        id: stepAttempts.id,
+        stepId: stepAttempts.stepId,
+        attempt: stepAttempts.attempt,
+        executionOrder: stepAttempts.executionOrder,
+        status: stepAttempts.status,
+        output: stepAttempts.output,
+        response: stepAttempts.response,
+        error: stepAttempts.error,
+        exitCode: stepAttempts.exitCode,
+        gateResult: stepAttempts.gateResult,
+        restartFeedback: stepAttempts.restartFeedback,
+        startedAt: stepAttempts.startedAt,
+        finishedAt: stepAttempts.finishedAt,
+      },
     })
     .from(workflowRuns)
     .innerJoin(workflowRunAttempts, eq(workflowRunAttempts.id, target.attempt.id))
@@ -376,8 +407,8 @@ function hydrateWorkflowRunDetail(
     run: typeof workflowRuns.$inferSelect;
     job: typeof jobs.$inferSelect | null;
     jobExecution: typeof jobExecutions.$inferSelect | null;
-    step: typeof steps.$inferSelect | null;
-    stepAttempt: typeof stepAttempts.$inferSelect | null;
+    step: WorkflowRunStepDetailRow | null;
+    stepAttempt: WorkflowRunStepAttemptDetailRow | null;
   }[],
   attempt: typeof workflowRunAttempts.$inferSelect,
   latestAttempt: number,
@@ -392,8 +423,8 @@ function hydrateWorkflowRunDetail(
     jobs: [],
   };
   const jobById = new Map<string, WorkflowJobDetail>();
-  const jobExecutionById = new Map<string, JobExecutionDetail>();
-  const stepById = new Map<string, StepDetail>();
+  const jobExecutionById = new Map<string, WorkflowRunJobExecutionDetail>();
+  const stepById = new Map<string, WorkflowRunStepDetail>();
 
   for (const row of rows) {
     if (!row.job) continue;
@@ -413,13 +444,94 @@ function hydrateWorkflowRunDetail(
     }
 
     if (!row.step) continue;
-    const step = getOrCreateStepDetail(stepById, jobExecution.steps, row.step);
+    const step = getOrCreateWorkflowRunStepDetail(stepById, jobExecution.steps, row.step);
     if (row.stepAttempt) {
-      step.attempts.push(toStepAttempt(row.stepAttempt));
+      step.attempts.push(toWorkflowRunStepAttemptDetail(row.stepAttempt));
     }
   }
 
   return detail;
+}
+
+type WorkflowRunStepDetailRow = Pick<
+  typeof steps.$inferSelect,
+  | 'id'
+  | 'jobExecutionId'
+  | 'key'
+  | 'name'
+  | 'sourceLocation'
+  | 'status'
+  | 'type'
+  | 'error'
+  | 'position'
+  | 'currentAttempt'
+  | 'createdAt'
+  | 'updatedAt'
+>;
+
+type WorkflowRunStepAttemptDetailRow = Pick<
+  typeof stepAttempts.$inferSelect,
+  | 'id'
+  | 'stepId'
+  | 'attempt'
+  | 'executionOrder'
+  | 'status'
+  | 'output'
+  | 'response'
+  | 'error'
+  | 'exitCode'
+  | 'gateResult'
+  | 'restartFeedback'
+  | 'startedAt'
+  | 'finishedAt'
+>;
+
+function toWorkflowRunStepAttemptDetail(
+  row: WorkflowRunStepAttemptDetailRow,
+): WorkflowRunStepAttemptDetail {
+  return {
+    id: row.id,
+    stepId: row.stepId,
+    attempt: row.attempt,
+    executionOrder: row.executionOrder,
+    status: row.status as StepAttemptStatus,
+    output: (row.output as Record<string, unknown>) ?? null,
+    response: row.response ?? null,
+    error: (row.error as Record<string, unknown>) ?? null,
+    exitCode: row.exitCode ?? null,
+    gateResult: (row.gateResult as Record<string, unknown>) ?? null,
+    restartFeedback: row.restartFeedback ?? null,
+    startedAt: row.startedAt,
+    finishedAt: row.finishedAt ?? null,
+  };
+}
+
+function getOrCreateWorkflowRunStepDetail(
+  stepById: Map<string, WorkflowRunStepDetail>,
+  target: WorkflowRunStepDetail[],
+  row: WorkflowRunStepDetailRow,
+): WorkflowRunStepDetail {
+  let step = stepById.get(row.id);
+  if (!step) {
+    step = {
+      id: row.id,
+      jobExecutionId: row.jobExecutionId,
+      key: row.key,
+      name: row.name,
+      sourceLocation: row.sourceLocation ?? null,
+      status: row.status,
+      type: row.type,
+      error: (row.error as Record<string, unknown>) ?? null,
+      position: row.position,
+      currentAttempt: row.currentAttempt,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+      attempts: [],
+    };
+    stepById.set(row.id, step);
+    target.push(step);
+  }
+  return step;
 }
 
 function getOrCreateStepDetail(

--- a/libs/api/workflows/src/db/workflow-runs/run-create.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-create.test.ts
@@ -11,8 +11,8 @@ import {workflowsOutbox} from '../schema/outbox.js';
 import {workflowRuns} from '../schema/workflow-runs.js';
 import {
   createWorkflowRun,
-  getJobExecutionsByJobId,
   getJobExecutionDetail,
+  getJobExecutionsByJobId,
   getJobsByWorkflowRunId,
   getStepsByJobId,
   getWorkflowRunAttemptById,

--- a/libs/api/workflows/src/db/workflow-runs/run-create.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-create.test.ts
@@ -12,6 +12,7 @@ import {workflowRuns} from '../schema/workflow-runs.js';
 import {
   createWorkflowRun,
   getJobExecutionsByJobId,
+  getJobExecutionDetail,
   getJobsByWorkflowRunId,
   getStepsByJobId,
   getWorkflowRunAttemptById,
@@ -430,11 +431,33 @@ describe('workflow run queries', () => {
         },
       });
 
+      const runJobs = await getJobsByWorkflowRunId(run.id);
+      const job = runJobs[0];
+      if (!job) throw new Error('Expected job');
+      const dispatched = await nextStepForJob(job.id);
+      if (dispatched.kind !== 'step') throw new Error('Expected dispatched step');
+
       const detail = await getWorkflowRunDetail(run.id);
 
       expect(detail?.runAttempt.model).toEqual(model);
       expect(detail?.jobs).toHaveLength(1);
       expect(detail?.jobs[0]?.jobExecutions[0]?.steps).toHaveLength(3);
+      const setupStep = detail?.jobs[0]?.jobExecutions[0]?.steps[0];
+      const setupAttempt = setupStep?.attempts[0];
+      expect(setupAttempt).not.toHaveProperty('config');
+      expect(setupAttempt).not.toHaveProperty('evaluationTrace');
+      expect(setupAttempt).not.toHaveProperty('logOutcome');
+      const userStep = detail?.jobs[0]?.jobExecutions[0]?.steps[1];
+      expect(userStep).not.toHaveProperty('config');
+      expect(userStep).not.toHaveProperty('authoredConfig');
+      expect(userStep).not.toHaveProperty('configPlan');
+
+      const jobExecutionId = detail?.jobs[0]?.jobExecutions[0]?.id;
+      if (!jobExecutionId) throw new Error('Expected job execution');
+      const jobExecutionDetail = await getJobExecutionDetail(jobExecutionId);
+      expect(jobExecutionDetail?.steps[0]?.attempts[0]).toHaveProperty('config');
+      expect(jobExecutionDetail?.steps[0]?.attempts[0]).toHaveProperty('evaluationTrace');
+      expect(jobExecutionDetail?.steps[1]?.config).toMatchObject({run: 'echo first'});
     });
 
     test('persists explicit checkout policy on jobs', async () => {

--- a/libs/api/workflows/src/presentation/dto/index.ts
+++ b/libs/api/workflows/src/presentation/dto/index.ts
@@ -1,3 +1,3 @@
 export {toJobDto, toJobExecutionDto} from './job.js';
-export {toStepAttemptDto, toStepDto} from './step.js';
+export {toExecutableStepDto, toStepAttemptDto, toStepDto} from './step.js';
 export {toRunAttemptDto, toRunDto} from './workflow-run.js';

--- a/libs/api/workflows/src/presentation/dto/step.test.ts
+++ b/libs/api/workflows/src/presentation/dto/step.test.ts
@@ -1,5 +1,5 @@
 import type {Step, StepAttempt} from '#core/entities/step.js';
-import {fromStepErrorDto, toStepAttemptDto, toStepDto} from './step.js';
+import {fromStepErrorDto, toExecutableStepDto, toStepAttemptDto, toStepDto} from './step.js';
 
 function step(overrides: Partial<Step> & {type: string}): Step {
   return {
@@ -166,6 +166,18 @@ describe('toStepDto error category', () => {
     const dto = toStepDto(step({type: 'setup', sourceLocation: null, error: null}));
 
     expect(dto.source_location).toBeNull();
+  });
+
+  it('omits executable config from read step DTOs', () => {
+    const dto = toStepDto(step({type: 'run', config: {run: 'echo hello'}, error: null}));
+
+    expect(dto).not.toHaveProperty('config');
+  });
+
+  it('keeps executable config on runner step DTOs', () => {
+    const dto = toExecutableStepDto(step({type: 'run', config: {run: 'echo hello'}, error: null}));
+
+    expect(dto.config).toEqual({run: 'echo hello'});
   });
 });
 

--- a/libs/api/workflows/src/presentation/dto/step.ts
+++ b/libs/api/workflows/src/presentation/dto/step.ts
@@ -27,6 +27,23 @@ type StepDtoInput = Pick<
   | 'updatedAt'
 >;
 
+type StepAttemptDtoInput = Pick<
+  StepAttempt,
+  | 'id'
+  | 'stepId'
+  | 'attempt'
+  | 'executionOrder'
+  | 'status'
+  | 'output'
+  | 'response'
+  | 'error'
+  | 'exitCode'
+  | 'gateResult'
+  | 'restartFeedback'
+  | 'startedAt'
+  | 'finishedAt'
+>;
+
 // Domain `error` is loosely typed (jsonb), so narrow it to the fixed runner
 // contract rather than trusting whatever shape the row happens to hold. `category`
 // is not stored on the row; the caller derives it from the step type and passes it
@@ -148,7 +165,7 @@ function toStepSourceLocationDto(
   };
 }
 
-export function toStepAttemptDto(attempt: StepAttempt): StepAttemptDto {
+export function toStepAttemptDto(attempt: StepAttemptDtoInput): StepAttemptDto {
   return {
     id: attempt.id,
     step_id: attempt.stepId,

--- a/libs/api/workflows/src/presentation/dto/step.ts
+++ b/libs/api/workflows/src/presentation/dto/step.ts
@@ -1,5 +1,6 @@
 import {
   agentConfigIssueSchema,
+  type ExecutableStepDto,
   type StepAttemptDto,
   type StepDto,
   type StepErrorCategoryDto,
@@ -9,6 +10,22 @@ import {
 } from '@shipfox/api-workflows-dto';
 import type {Step, StepAttempt} from '#core/entities/step.js';
 import {GATE_EVALUATION_ERROR_REASON} from '#core/step-transition/evaluate-gate.js';
+
+type StepDtoInput = Pick<
+  Step,
+  | 'id'
+  | 'jobExecutionId'
+  | 'key'
+  | 'name'
+  | 'sourceLocation'
+  | 'status'
+  | 'type'
+  | 'error'
+  | 'position'
+  | 'currentAttempt'
+  | 'createdAt'
+  | 'updatedAt'
+>;
 
 // Domain `error` is loosely typed (jsonb), so narrow it to the fixed runner
 // contract rather than trusting whatever shape the row happens to hold. `category`
@@ -97,7 +114,7 @@ function toStepGateResultDto(
   return {kind: 'unknown', data: gateResult};
 }
 
-export function toStepDto(step: Step): StepDto {
+export function toStepDto(step: StepDtoInput): StepDto {
   return {
     id: step.id,
     job_execution_id: step.jobExecutionId,
@@ -106,12 +123,18 @@ export function toStepDto(step: Step): StepDto {
     source_location: toStepSourceLocationDto(step.sourceLocation),
     status: step.status,
     type: step.type,
-    config: step.config,
     error: toStepErrorDto(step.error, step.type === 'setup' ? 'setup' : 'user'),
     position: step.position,
     current_attempt: step.currentAttempt,
     created_at: step.createdAt.toISOString(),
     updated_at: step.updatedAt.toISOString(),
+  };
+}
+
+export function toExecutableStepDto(step: Step): ExecutableStepDto {
+  return {
+    ...toStepDto(step),
+    config: step.config,
   };
 }
 

--- a/libs/api/workflows/src/presentation/routes/get-run.test.ts
+++ b/libs/api/workflows/src/presentation/routes/get-run.test.ts
@@ -134,6 +134,11 @@ describe('GET /api/workflows/runs/:id', () => {
     expect(steps[0].name).toBe('Set up job');
     expect(steps[1].name).toBe('Install');
     expect(steps[2].name).toBe('npm build');
+    for (const step of steps) {
+      expect(step).not.toHaveProperty('config');
+      expect(step).not.toHaveProperty('authored_config');
+      expect(step).not.toHaveProperty('config_plan');
+    }
     // Run timing fields flow through the read model (null on a fresh, unstamped run).
     expect(body).toMatchObject({latest_attempt: 1, started_at: null, finished_at: null});
     expect(body.jobs[0]).not.toHaveProperty('queued_at');

--- a/libs/api/workflows/src/presentation/routes/next-step.test.ts
+++ b/libs/api/workflows/src/presentation/routes/next-step.test.ts
@@ -143,6 +143,7 @@ describe('POST /runs/jobs/current/steps/next', () => {
     expect(body.kind).toBe('step');
     expect(body.step.id).toBe(steps[0]?.id);
     expect(body.step.status).toBe('running');
+    expect(body.step.config).toEqual(steps[0]?.config);
     expect(body.lease_token).toEqual(expect.any(String));
     const scopedLease = await verifyJobLeaseToken(body.lease_token);
     expect(scopedLease).toMatchObject({

--- a/libs/api/workflows/src/presentation/routes/next-step.ts
+++ b/libs/api/workflows/src/presentation/routes/next-step.ts
@@ -4,7 +4,7 @@ import {nextStepResponseSchema} from '@shipfox/api-workflows-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {JobLeaseNotActiveError, JobNotFoundError} from '#core/errors.js';
 import {nextStepForLeasedJobExecution} from '#core/job-execution.js';
-import {toStepDto} from '#presentation/dto/step.js';
+import {toExecutableStepDto} from '#presentation/dto/step.js';
 
 export const nextStepRoute = defineRoute({
   method: 'POST',
@@ -45,7 +45,7 @@ export const nextStepRoute = defineRoute({
       // attempt is ignored.
       return {
         kind: 'step' as const,
-        step: toStepDto(next.step),
+        step: toExecutableStepDto(next.step),
         attempt: next.step.currentAttempt,
         lease_token: leaseToken,
       };

--- a/libs/client/workflows/src/components/step-list/step-list-model.test.ts
+++ b/libs/client/workflows/src/components/step-list/step-list-model.test.ts
@@ -26,7 +26,6 @@ describe('buildStepListModel', () => {
       key: null,
       name: 'npm test',
       position: 1,
-      config: {run: 'npm test'},
       attempts: [makeAttempt({execution_order: 1})],
     });
     const unnamed = makeStep({
@@ -57,7 +56,6 @@ describe('buildStepListModel', () => {
       name: 'pnpm test',
       position: 1,
       type: 'run',
-      config: {run: 'pnpm test\npnpm build'},
       attempts: [makeAttempt()],
     });
     const agent = makeStep({
@@ -65,7 +63,6 @@ describe('buildStepListModel', () => {
       name: 'claude-opus-4-8 · Fix the failing tests.',
       position: 2,
       type: 'agent',
-      config: {model: 'claude-opus-4-8', prompt: 'Fix the failing tests.\nKeep it small.'},
       attempts: [makeAttempt()],
     });
 

--- a/libs/client/workflows/src/components/step-list/step-list.stories.tsx
+++ b/libs/client/workflows/src/components/step-list/step-list.stories.tsx
@@ -236,7 +236,6 @@ export const ContentVariants: Story = {
           name: 'pnpm test --filter=@shipfox/client-workflows',
           position: 1,
           type: 'run',
-          config: {run: 'pnpm test --filter=@shipfox/client-workflows'},
           status: 'succeeded',
           attempts: [makeAttempt({status: 'succeeded'})],
         }),
@@ -245,10 +244,6 @@ export const ContentVariants: Story = {
           name: 'claude-opus-4-8 · Review the failing workflow step tests and propose the smallest fix.',
           position: 2,
           type: 'agent',
-          config: {
-            model: 'claude-opus-4-8',
-            prompt: 'Review the failing workflow step tests and propose the smallest fix.',
-          },
           status: 'failed',
           error: {
             message: 'Agent invocation failed',
@@ -369,12 +364,6 @@ function renderAgentConfigFailureCallout() {
     name: 'Fix the failing tests.',
     type: 'agent',
     status: 'failed',
-    config: {
-      provider: 'anthropic',
-      model: 'claude-opus-4-8',
-      thinking: 'high',
-      prompt: 'Fix the failing tests.',
-    },
     error: {
       message: 'Model provider credentials are not configured',
       category: 'user',

--- a/libs/client/workflows/src/components/step-list/step-list.stories.tsx
+++ b/libs/client/workflows/src/components/step-list/step-list.stories.tsx
@@ -84,7 +84,7 @@ const withAgentSettingsRoute: Decorator = (Story) => {
 async function assertAgentConfigFailureCallout(ctx: StepListStoryContext) {
   const canvas = within(ctx.canvasElement);
 
-  await canvas.findByText('Configure credentials for anthropic');
+  await canvas.findByText('Configure credentials for the selected provider');
   await canvas.findByRole('link', {name: AGENTS_LINK_NAME});
 }
 
@@ -380,7 +380,6 @@ function renderAgentConfigFailureCallout() {
       renderExpandedStep={() => (
         <AgentConfigFailureCalloutView
           workspaceId={WORKSPACE_ID}
-          config={{provider: 'anthropic', model: 'claude-opus-4-8', thinking: 'high'}}
           error={{
             message: 'Model provider credentials are not configured',
             reason: 'agent_config_invalid',

--- a/libs/client/workflows/src/components/workflow-run-view/agent-config-failure-callout.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/agent-config-failure-callout.stories.tsx
@@ -9,17 +9,11 @@ import {
   RouterProvider,
 } from '@tanstack/react-router';
 import {within} from 'storybook/test';
-import type {AgentStepConfig, StepError} from '#core/workflow-run.js';
+import type {StepError} from '#core/workflow-run.js';
 import {AgentConfigFailureCallout} from './agent-config-failure-callout.js';
 
 const WORKSPACE_ID = '44444444-4444-4444-8444-444444444444';
 const AGENTS_LINK_NAME = 'Configure Agents';
-
-const config: AgentStepConfig = {
-  provider: 'anthropic',
-  model: 'claude-opus-4-8',
-  thinking: 'high',
-};
 
 const meta = {
   title: 'Workflows/RunView/AgentConfigFailureCallout',
@@ -55,7 +49,6 @@ const meta = {
   ],
   args: {
     workspaceId: WORKSPACE_ID,
-    config,
     error: makeError('provider_not_configured'),
   },
 } satisfies Meta<typeof AgentConfigFailureCallout>;
@@ -104,7 +97,7 @@ export const ErrorVariants: Story = {
 };
 
 export const TestProviderNotConfigured: Story = {
-  play: assertCallout('Configure credentials for anthropic', true),
+  play: assertCallout('Configure credentials for the selected provider', true),
 };
 
 export const TestProviderUnsupported: Story = {

--- a/libs/client/workflows/src/components/workflow-run-view/agent-config-failure-callout.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/agent-config-failure-callout.tsx
@@ -7,18 +7,16 @@ import {
 } from '@shipfox/react-ui/alert';
 import {Button} from '@shipfox/react-ui/button';
 import {Link} from '@tanstack/react-router';
-import type {AgentStepConfig, StepError} from '#core/workflow-run.js';
+import type {StepError} from '#core/workflow-run.js';
 
 export function AgentConfigFailureCallout({
   workspaceId,
-  config,
   error,
 }: {
   workspaceId: string;
-  config: AgentStepConfig | null;
   error: StepError | null;
 }) {
-  const copy = agentConfigFailureCopy(config, error);
+  const copy = agentConfigFailureCopy(error);
 
   return (
     <Alert variant="warning" animated={false} className="px-10 py-8">
@@ -39,12 +37,13 @@ export function AgentConfigFailureCallout({
   );
 }
 
-function agentConfigFailureCopy(
-  config: AgentStepConfig | null,
-  error: StepError | null,
-): {title: string; description: string; showProviderCta: boolean} {
-  const provider = configValue(config?.provider, 'the selected provider');
-  const model = configValue(config?.model, 'the selected model');
+function agentConfigFailureCopy(error: StepError | null): {
+  title: string;
+  description: string;
+  showProviderCta: boolean;
+} {
+  const provider = 'the selected provider';
+  const model = 'the selected model';
 
   switch (error?.agentConfigIssue) {
     case 'provider_not_configured':
@@ -86,8 +85,4 @@ function agentConfigFailureCopy(
         showProviderCta: true,
       };
   }
-}
-
-function configValue(value: string | null | undefined, fallback: string): string {
-  return value ?? fallback;
 }

--- a/libs/client/workflows/src/components/workflow-run-view/job-card.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/job-card.tsx
@@ -387,11 +387,7 @@ function StepAttemptDetailPanel({
   return (
     <div className="flex min-w-0 flex-col gap-10">
       {isAgentConfigFailure(step, selectedAttemptError) ? (
-        <AgentConfigFailureCallout
-          workspaceId={workspaceId}
-          config={null}
-          error={selectedAttemptError}
-        />
+        <AgentConfigFailureCallout workspaceId={workspaceId} error={selectedAttemptError} />
       ) : null}
       <StepAttemptLogPanel stepId={stepId} attempt={attempt} attemptStatus={attemptStatus} />
     </div>

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -245,12 +245,6 @@ describe('WorkflowRunView', () => {
                     name: 'Fix the failing tests.',
                     type: 'agent',
                     status: 'failed',
-                    config: {
-                      provider: 'anthropic',
-                      model: 'claude-opus-4-8',
-                      thinking: 'high',
-                      prompt: 'Fix the failing tests.',
-                    },
                     error: {
                       message: 'Model provider request failed',
                       reason: 'agent_invocation_failed',
@@ -333,12 +327,6 @@ describe('WorkflowRunView', () => {
                       name: 'Fix the failing tests.',
                       type: 'agent',
                       status: 'failed',
-                      config: {
-                        provider: 'anthropic',
-                        model: 'claude-opus-4-8',
-                        thinking: 'high',
-                        prompt: 'Fix the failing tests.',
-                      },
                       error: {
                         message: 'Model provider credentials are not configured',
                         reason: 'agent_config_invalid',

--- a/libs/client/workflows/src/core/entities/step.ts
+++ b/libs/client/workflows/src/core/entities/step.ts
@@ -25,12 +25,6 @@ export interface StepError {
   category: StepErrorCategory | undefined;
 }
 
-export interface AgentStepConfig {
-  provider: string | null;
-  model: string | null;
-  thinking: string | null;
-}
-
 export interface Step {
   id: string;
   jobExecutionId: string;

--- a/libs/client/workflows/src/core/entities/step.ts
+++ b/libs/client/workflows/src/core/entities/step.ts
@@ -39,8 +39,6 @@ export interface Step {
   sourceLocation: StepSourceLocation | null;
   status: string;
   type: string;
-  config: Record<string, unknown>;
-  agentConfig: AgentStepConfig | null;
   error: StepError | null;
   position: number;
   currentAttempt: number;
@@ -58,8 +56,6 @@ export function toStep(dto: WorkflowRunStepDetailDto): Step {
     sourceLocation: dto.source_location ? toStepSourceLocation(dto.source_location) : null,
     status: dto.status,
     type: dto.type,
-    config: dto.config,
-    agentConfig: toAgentStepConfig(dto),
     error: dto.error ? toStepError(dto.error) : null,
     position: dto.position,
     currentAttempt: dto.current_attempt,
@@ -85,21 +81,4 @@ function toStepError(dto: NonNullable<WorkflowRunStepDetailDto['error']>): StepE
     agentConfigIssue: dto.agent_config_issue,
     category: dto.category,
   };
-}
-
-function toAgentStepConfig(dto: WorkflowRunStepDetailDto): AgentStepConfig | null {
-  if (dto.type !== 'agent') return null;
-
-  return {
-    provider: stringConfigValue(dto.config.provider),
-    model: stringConfigValue(dto.config.model),
-    thinking: stringConfigValue(dto.config.thinking),
-  };
-}
-
-function stringConfigValue(value: unknown): string | null {
-  if (typeof value !== 'string') return null;
-
-  const trimmedValue = value.trim();
-  return trimmedValue ? trimmedValue : null;
 }

--- a/libs/client/workflows/src/core/workflow-run.test.ts
+++ b/libs/client/workflows/src/core/workflow-run.test.ts
@@ -526,54 +526,6 @@ describe('workflow run model mapping', () => {
     expect(detail.jobs[0]?.displayDuration).toBeNull();
   });
 
-  test('maps resolved agent step configuration from the opaque step config', () => {
-    const step = workflowStepDto({
-      type: 'agent',
-      config: {
-        provider: 'anthropic',
-        model: 'claude-opus-4-8',
-        thinking: 'high',
-        prompt: 'Fix the failing tests.',
-      },
-    });
-    const missingConfigStep = workflowStepDto({
-      type: 'agent',
-      config: {provider: '', model: 42},
-    });
-
-    const detail = toWorkflowRunDetail(
-      workflowRunDetailDto({
-        jobs: [workflowJobDto({steps: [step, missingConfigStep]})],
-      }),
-    );
-
-    expect(detail.jobs[0]?.jobExecutions[0]?.steps[0]?.agentConfig).toEqual({
-      provider: 'anthropic',
-      model: 'claude-opus-4-8',
-      thinking: 'high',
-    });
-    expect(detail.jobs[0]?.jobExecutions[0]?.steps[1]?.agentConfig).toEqual({
-      provider: null,
-      model: null,
-      thinking: null,
-    });
-  });
-
-  test('leaves non-agent steps without agent configuration', () => {
-    const step = workflowStepDto({
-      type: 'run',
-      config: {provider: 'anthropic', model: 'claude-opus-4-8', thinking: 'high'},
-    });
-
-    const detail = toWorkflowRunDetail(
-      workflowRunDetailDto({
-        jobs: [workflowJobDto({steps: [step]})],
-      }),
-    );
-
-    expect(detail.jobs[0]?.jobExecutions[0]?.steps[0]?.agentConfig).toBeNull();
-  });
-
   test('maps run attempt summaries', () => {
     const dto = workflowRunAttemptDto({
       id: '77777777-7777-4777-8777-777777777777',

--- a/libs/client/workflows/src/core/workflow-run.ts
+++ b/libs/client/workflows/src/core/workflow-run.ts
@@ -23,7 +23,6 @@ export type {
 export {JobExecution, toJobExecution} from './entities/job-execution.js';
 export type {
   AgentConfigIssue,
-  AgentStepConfig,
   Step,
   StepError,
   StepErrorCategory,

--- a/libs/client/workflows/test/fixtures/workflow-run.ts
+++ b/libs/client/workflows/test/fixtures/workflow-run.ts
@@ -226,7 +226,6 @@ export function workflowStepDto(
     source_location: null,
     status: 'pending',
     type: 'run',
-    config: {},
     error: null,
     position: 0,
     current_attempt: 1,

--- a/libs/runner/agent/src/core/step.test.ts
+++ b/libs/runner/agent/src/core/step.test.ts
@@ -6,7 +6,7 @@ const {runAgentMock, runClaudeMock} = vi.hoisted(() => ({
 vi.mock('#core/pi-adapter.js', () => ({piHarnessAdapter: {run: runAgentMock}}));
 vi.mock('#core/claude-adapter.js', () => ({claudeHarnessAdapter: {run: runClaudeMock}}));
 
-import type {StepDto} from '@shipfox/api-workflows-dto';
+import type {ExecutableStepDto} from '@shipfox/api-workflows-dto';
 import {AgentConfigError, AgentInvocationError} from '#core/errors.js';
 import type {HarnessInvocation} from '#core/harness.js';
 import {executeAgentStep} from '#core/step.js';
@@ -19,7 +19,7 @@ const RUNTIME = {
   credentials: {api_key: 'sk-runtime-secret'},
 };
 
-function buildAgentStep(overrides: Partial<StepDto> = {}): StepDto {
+function buildAgentStep(overrides: Partial<ExecutableStepDto> = {}): ExecutableStepDto {
   const name =
     typeof overrides.name === 'string' && overrides.name.trim() ? overrides.name : 'implement';
   return {

--- a/libs/runner/agent/src/core/step.ts
+++ b/libs/runner/agent/src/core/step.ts
@@ -1,7 +1,7 @@
 import type {CustomModelProviderRuntimeConfigDto, Harness} from '@shipfox/api-agent-dto';
 import type {
   AgentConfigIssueDto,
-  StepDto,
+  ExecutableStepDto,
   StepErrorDto,
   StepErrorReasonDto,
 } from '@shipfox/api-workflows-dto';
@@ -12,7 +12,7 @@ import type {HarnessAdapter} from '#core/harness.js';
 import {piHarnessAdapter} from '#core/pi-adapter.js';
 
 export function executeAgentStep(
-  step: StepDto,
+  step: ExecutableStepDto,
   options: {
     signal?: AbortSignal;
     cwd?: string;

--- a/libs/runner/execution/src/core/run-step.test.ts
+++ b/libs/runner/execution/src/core/run-step.test.ts
@@ -1,7 +1,7 @@
 import {mkdtemp, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {basename, isAbsolute, join} from 'node:path';
-import type {StepDto} from '@shipfox/api-workflows-dto';
+import type {ExecutableStepDto} from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import {type CommandStartMetadata, executeRunStep, type OutputSink} from '#core/run-step.js';
 import {MAX_OUTPUT_TOTAL_BYTES} from '#core/step-output.js';
@@ -639,8 +639,12 @@ describe('executeRunStep', () => {
 });
 
 function buildStep(
-  overrides: Partial<{type: string; name: string | null; config: Record<string, unknown>}> = {},
-): StepDto {
+  overrides: Partial<{
+    type: string;
+    name: string | null;
+    config: ExecutableStepDto['config'];
+  }> = {},
+): ExecutableStepDto {
   const name = overrides.name ?? 'test-step';
   return {
     id: '00000000-0000-0000-0000-000000000001',

--- a/libs/runner/execution/src/core/run-step.ts
+++ b/libs/runner/execution/src/core/run-step.ts
@@ -5,7 +5,7 @@ import {open, unlink, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {basename, delimiter, isAbsolute, join, resolve} from 'node:path';
 import {TextDecoder} from 'node:util';
-import type {StepDto, StepErrorDto} from '@shipfox/api-workflows-dto';
+import type {ExecutableStepDto, StepErrorDto} from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import {redactSecrets, safeRedactionPrefixLength, secretWireForms} from '@shipfox/redact';
 import {MAX_OUTPUT_TOTAL_BYTES, parseStepOutput, StepOutputError} from '#core/step-output.js';
@@ -43,7 +43,10 @@ interface RunStepOptions {
   onCommandStart?: CommandStartSink;
 }
 
-export function executeRunStep(step: StepDto, options: RunStepOptions = {}): Promise<StepResult> {
+export function executeRunStep(
+  step: ExecutableStepDto,
+  options: RunStepOptions = {},
+): Promise<StepResult> {
   if (step.type !== 'run') {
     return Promise.resolve({
       success: false,
@@ -358,7 +361,7 @@ function signalExitCode(signal: NodeJS.Signals): number | undefined {
   return undefined;
 }
 
-function readStepEnv(step: StepDto): Readonly<Record<string, string>> {
+function readStepEnv(step: ExecutableStepDto): Readonly<Record<string, string>> {
   const rawEnv = step.config.env;
   if (
     rawEnv === undefined ||

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -1,4 +1,8 @@
-import type {AgentConfigIssueDto, NextStepResponseDto, StepDto} from '@shipfox/api-workflows-dto';
+import type {
+  AgentConfigIssueDto,
+  ExecutableStepDto,
+  NextStepResponseDto,
+} from '@shipfox/api-workflows-dto';
 import {HTTPError} from 'ky';
 
 const {AgentRuntimeConfigRequestError, StepSecretsRequestError} = vi.hoisted(() => ({
@@ -1196,7 +1200,7 @@ describe('runJobSteps', () => {
     const sessionStream = makeFakeStream(agent.id);
     createSessionLogStreamMock.mockReturnValue(sessionStream);
     executeAgentStepMock.mockImplementation(
-      (_step: StepDto, opts: {onSessionEntry?: (line: string) => void}) => {
+      (_step: ExecutableStepDto, opts: {onSessionEntry?: (line: string) => void}) => {
         opts.onSessionEntry?.('{"type":"message","id":"a"}');
         return Promise.resolve({success: true, error: null, exit_code: 0});
       },
@@ -1387,7 +1391,7 @@ describe('runJobSteps', () => {
   });
 });
 
-function buildSetupStep(overrides: Partial<StepDto> = {}): StepDto {
+function buildSetupStep(overrides: Partial<ExecutableStepDto> = {}): ExecutableStepDto {
   return buildStep({
     id: '00000000-0000-0000-0000-0000000000b0',
     name: 'Set up job',
@@ -1398,11 +1402,11 @@ function buildSetupStep(overrides: Partial<StepDto> = {}): StepDto {
   });
 }
 
-function buildRunStep(overrides: Partial<StepDto> = {}): StepDto {
+function buildRunStep(overrides: Partial<ExecutableStepDto> = {}): ExecutableStepDto {
   return buildStep({position: 1, ...overrides});
 }
 
-function buildAgentStep(overrides: Partial<StepDto> = {}): StepDto {
+function buildAgentStep(overrides: Partial<ExecutableStepDto> = {}): ExecutableStepDto {
   return buildStep({
     id: '00000000-0000-0000-0000-0000000000c0',
     name: 'implement',
@@ -1413,7 +1417,7 @@ function buildAgentStep(overrides: Partial<StepDto> = {}): StepDto {
   });
 }
 
-function buildStep(overrides: Partial<StepDto> = {}): StepDto {
+function buildStep(overrides: Partial<ExecutableStepDto> = {}): ExecutableStepDto {
   const name =
     typeof overrides.name === 'string' && overrides.name.trim() ? overrides.name : 'test-step';
   return {
@@ -1435,7 +1439,7 @@ function buildStep(overrides: Partial<StepDto> = {}): StepDto {
 }
 
 function stepResponse(
-  step: StepDto,
+  step: ExecutableStepDto,
   attempt: number,
   leaseToken = `lease-${step.id}-${attempt}`,
 ): NextStepResponseDto {

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -3,7 +3,11 @@ import {
   materializedSecretBindingSchema,
   type StepSecretDto,
 } from '@shipfox/api-secrets-dto';
-import type {LogOutcomeDto, NextStepResponseDto, StepDto} from '@shipfox/api-workflows-dto';
+import type {
+  ExecutableStepDto,
+  LogOutcomeDto,
+  NextStepResponseDto,
+} from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import {redactSecrets} from '@shipfox/redact';
 import {executeAgentStep} from '@shipfox/runner-agent';
@@ -143,7 +147,7 @@ export async function runJobSteps(params: {
 }
 
 export interface PulledStep {
-  step: StepDto;
+  step: ExecutableStepDto;
   attempt: number;
   leaseToken: string;
 }
@@ -191,7 +195,7 @@ export interface StepExecution {
 // hang `running`. The log stream is returned even on a
 // throw, so the caller can still settle it.
 export async function executeStep(params: {
-  step: StepDto;
+  step: ExecutableStepDto;
   attempt: number;
   cwd: string;
   logsDir: string;
@@ -459,7 +463,7 @@ interface RunSecretMaterial {
 const runSecretBindingsSchema = materializedSecretBindingSchema.array();
 
 async function loadRunSecretMaterial(params: {
-  step: StepDto;
+  step: ExecutableStepDto;
   leaseClient: KyInstance;
   attempt: number;
   signal: AbortSignal;
@@ -642,7 +646,7 @@ function summarizeCommand(command: string): string {
 // Returns whether the server asked the loop to stop (job finished without full success).
 export async function reportStepResult(params: {
   leaseClient: KyInstance;
-  step: StepDto;
+  step: ExecutableStepDto;
   attempt: number;
   result: StepResult;
   logOutcome: LogOutcomeDto;


### PR DESCRIPTION
Trim workflow run detail step payloads so `GET /workflows/runs/:id` no longer ships per-step `config`, `authored_config`, or `config_plan` in the whole-run response.

Large runs were paying for heavy per-step JSON that the run view does not render. This splits the step DTOs by purpose: run-detail steps are config-free, while runner dispatch uses an executable step DTO that still carries `config` for `next-step`.

The DB read model now selects an explicit light step projection for run detail instead of selecting the full `steps` row. Client run-detail types and fixtures now assume the breaking config-free contract.

A follow-up Linear ticket, ENG-888, tracks adding a future user-auth drill-down endpoint for full step config if the UI needs it later.

Reviewers should focus on the DTO split and the DB projection boundary: run detail should stay light, but runner dispatch must keep executable config.

Closes ENG-795

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed workflow run detail payloads by removing step config and heavy attempt fields so the run view only gets what it needs. Runner dispatch still returns `ExecutableStepDto` with `config` via `next-step`. Closes ENG-795.

- **Refactors**
  - Split step DTOs: read-only `StepDto` vs `ExecutableStepDto` (with `config`); exported in `@shipfox/api-workflows-dto`.
  - Endpoints: `GET /workflows/runs/:id` returns config‑free steps and light attempt fields; `POST /runs/jobs/current/steps/next` returns `ExecutableStepDto`.
  - Schemas: `stepDtoSchema` is strict (rejects `config`); `nextStepResponse` uses `executableStepDtoSchema`.
  - DB: run‑detail selects only needed step/attempt fields; drops step `config`/authored plan and attempt `config`/evaluation trace/log outcome. Full `getJobExecutionDetail` remains unchanged for internal drill‑downs.
  - Runner: execution/orchestration now type against `ExecutableStepDto`; updated mappers, route, and tests.
  - Client: removed `AgentStepConfig`; agent‑config failure callout uses provider‑agnostic copy.

- **Migration**
  - Stop reading step config from run detail; use `next-step` for executable `config`.
  - ENG-888 tracks a future drill‑down endpoint if the UI needs full step/attempt config.

<sup>Written for commit 80af87f39454a7b54aa342d4d2a8c5b293bafa0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

