### PR TITLE
[integration/linear] Add token custody primitives

### DIFF
--- a/.changeset/clear-linear-tokens.md
+++ b/.changeset/clear-linear-tokens.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-integration-linear": patch
+---
+
+Adds Linear OAuth client and token custody primitives for storing and refreshing workspace connection tokens.

--- a/libs/api/integration/linear/package.json
+++ b/libs/api/integration/linear/package.json
@@ -41,9 +41,14 @@
     "@shipfox/api-integration-linear-dto": "workspace:*",
     "@shipfox/config": "workspace:*",
     "@shipfox/node-drizzle": "workspace:*",
+    "@shipfox/node-opentelemetry": "workspace:*",
     "@shipfox/node-postgres": "workspace:*",
     "drizzle-orm": "^0.45.2",
+    "ky": "^2.0.0",
     "zod": "^4.4.3"
+  },
+  "peerDependencies": {
+    "@shipfox/api-secrets": "workspace:*"
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",

--- a/libs/api/integration/linear/src/api/client.test.ts
+++ b/libs/api/integration/linear/src/api/client.test.ts
@@ -283,6 +283,24 @@ describe('createLinearApiClient.getIdentity', () => {
     expect(serialized).not.toContain('invalid token');
   });
 
+  it('maps GraphQL transport auth failures to access-denied', async () => {
+    mocks.post.mockReturnValue(rejects(httpError(401)));
+    const client = createLinearApiClient();
+
+    const result = client.getIdentity({accessToken: 'linear-token'});
+
+    await expect(result).rejects.toMatchObject({reason: 'access-denied'});
+  });
+
+  it('maps GraphQL non-auth transport 4xx failures to malformed-provider-response', async () => {
+    mocks.post.mockReturnValue(rejects(httpError(400)));
+    const client = createLinearApiClient();
+
+    const result = client.getIdentity({accessToken: 'linear-token'});
+
+    await expect(result).rejects.toMatchObject({reason: 'malformed-provider-response'});
+  });
+
   it('maps non-auth GraphQL errors to malformed-provider-response', async () => {
     mocks.post.mockReturnValue(
       resolves({

--- a/libs/api/integration/linear/src/api/client.test.ts
+++ b/libs/api/integration/linear/src/api/client.test.ts
@@ -1,0 +1,307 @@
+import {HTTPError, TimeoutError} from 'ky';
+import {LinearIntegrationProviderError} from '#core/errors.js';
+import {createLinearApiClient} from './client.js';
+
+const mocks = vi.hoisted(() => ({
+  post: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock('@shipfox/node-opentelemetry', () => ({
+  logger: () => ({
+    warn: mocks.warn,
+  }),
+}));
+
+vi.mock('ky', () => {
+  class HTTPError extends Error {
+    constructor(public response: {status: number; statusText?: string; headers: Headers}) {
+      super('http');
+      this.name = 'HTTPError';
+    }
+  }
+  class TimeoutError extends Error {
+    constructor() {
+      super('timeout');
+      this.name = 'TimeoutError';
+    }
+  }
+  return {default: {post: mocks.post}, HTTPError, TimeoutError};
+});
+
+function resolves(data: unknown) {
+  return {json: () => Promise.resolve(data)};
+}
+
+function rejects(error: unknown) {
+  return {json: () => Promise.reject(error)};
+}
+
+function httpError(
+  status: number,
+  headers: Record<string, string> = {},
+  statusText = 'Rejected',
+): HTTPError {
+  return new HTTPError(
+    {status, statusText, headers: new Headers(headers)} as never,
+    {} as never,
+    {} as never,
+  );
+}
+
+describe('createLinearApiClient.exchangeAuthorizationCode', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    mocks.post.mockReset();
+    mocks.warn.mockReset();
+  });
+
+  it('posts a form-encoded OAuth exchange and parses tokens, expiry, and scopes', async () => {
+    vi.useFakeTimers({now: new Date('2026-07-07T12:00:00.000Z')});
+    mocks.post.mockReturnValue(
+      resolves({
+        access_token: 'access-token',
+        refresh_token: 'refresh-token',
+        expires_in: 3600,
+        scope: 'read write app:assignable',
+      }),
+    );
+    const client = createLinearApiClient();
+
+    const result = await client.exchangeAuthorizationCode({code: 'oauth-code'});
+
+    const firstCall = mocks.post.mock.calls[0];
+    expect(firstCall).toBeDefined();
+    const [, options] = firstCall as [string, {body: URLSearchParams}];
+    const body = options.body as URLSearchParams;
+    expect(body.get('grant_type')).toBe('authorization_code');
+    expect(body.get('client_id')).toBe('test-client-id');
+    expect(body.get('client_secret')).toBe('test-client-secret');
+    expect(body.get('code')).toBe('oauth-code');
+    expect(body.get('redirect_uri')).toBe(
+      'https://api.example.com/integrations/linear/callback/api',
+    );
+    expect(result).toEqual({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      expiresAt: new Date('2026-07-07T13:00:00.000Z'),
+      scopes: ['read', 'write', 'app:assignable'],
+    });
+  });
+
+  it('parses a long-lived token response without refresh or expiry', async () => {
+    mocks.post.mockReturnValue(resolves({access_token: 'access-token', scope: ['read']}));
+    const client = createLinearApiClient();
+
+    const result = await client.exchangeAuthorizationCode({code: 'oauth-code'});
+
+    expect(result).toEqual({
+      accessToken: 'access-token',
+      refreshToken: undefined,
+      expiresAt: undefined,
+      scopes: ['read'],
+    });
+  });
+
+  it('maps a 429 to rate-limited with retry-after seconds', async () => {
+    mocks.post.mockReturnValue(rejects(httpError(429, {'retry-after': '30'})));
+    const client = createLinearApiClient();
+
+    const result = client.exchangeAuthorizationCode({code: 'oauth-code'});
+
+    await expect(result).rejects.toMatchObject({reason: 'rate-limited', retryAfterSeconds: 30});
+    await expect(result).rejects.toBeInstanceOf(LinearIntegrationProviderError);
+  });
+
+  it('maps a 5xx to provider-unavailable', async () => {
+    mocks.post.mockReturnValue(rejects(httpError(503)));
+    const client = createLinearApiClient();
+
+    const result = client.exchangeAuthorizationCode({code: 'oauth-code'});
+
+    await expect(result).rejects.toMatchObject({reason: 'provider-unavailable'});
+  });
+
+  it('maps a 4xx to access-denied', async () => {
+    mocks.post.mockReturnValue(rejects(httpError(403)));
+    const client = createLinearApiClient();
+
+    const result = client.exchangeAuthorizationCode({code: 'oauth-code'});
+
+    await expect(result).rejects.toMatchObject({reason: 'access-denied'});
+  });
+
+  it('maps a timeout to timeout', async () => {
+    mocks.post.mockReturnValue(rejects(new TimeoutError({} as never)));
+    const client = createLinearApiClient();
+
+    const result = client.exchangeAuthorizationCode({code: 'oauth-code'});
+
+    await expect(result).rejects.toMatchObject({reason: 'timeout'});
+  });
+
+  it('maps a response without an access token to malformed-provider-response', async () => {
+    mocks.post.mockReturnValue(resolves({refresh_token: 'refresh-token', scope: 'read'}));
+    const client = createLinearApiClient();
+
+    const result = client.exchangeAuthorizationCode({code: 'oauth-code'});
+
+    await expect(result).rejects.toMatchObject({reason: 'malformed-provider-response'});
+  });
+
+  it('never logs or throws OAuth secrets from rejected requests', async () => {
+    mocks.post.mockReturnValue(rejects(httpError(403)));
+    const client = createLinearApiClient();
+
+    const error = await client
+      .exchangeAuthorizationCode({code: 'super-secret-code'})
+      .catch((thrown: unknown) => thrown);
+
+    const serialized = [
+      (error as Error).message,
+      JSON.stringify(error),
+      String((error as {cause?: unknown}).cause),
+      JSON.stringify(mocks.warn.mock.calls),
+    ].join(' ');
+    expect(serialized).not.toContain('super-secret-code');
+    expect(serialized).not.toContain('test-client-secret');
+    expect(mocks.warn.mock.calls[0]).toEqual([
+      {operation: 'exchange-authorization-code', status: 403, statusText: 'Rejected'},
+      'Linear API request rejected',
+    ]);
+  });
+});
+
+describe('createLinearApiClient.refreshAccessToken', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    mocks.post.mockReset();
+    mocks.warn.mockReset();
+  });
+
+  it('posts a refresh-token grant and parses the new tokens', async () => {
+    vi.useFakeTimers({now: new Date('2026-07-07T12:00:00.000Z')});
+    mocks.post.mockReturnValue(
+      resolves({
+        access_token: 'new-access-token',
+        refresh_token: 'new-refresh-token',
+        expires_in: 1800,
+        scope: 'read,write',
+      }),
+    );
+    const client = createLinearApiClient();
+
+    const result = await client.refreshAccessToken({refreshToken: 'old-refresh-token'});
+
+    const firstCall = mocks.post.mock.calls[0];
+    expect(firstCall).toBeDefined();
+    const [, options] = firstCall as [string, {body: URLSearchParams}];
+    const body = options.body as URLSearchParams;
+    expect(body.get('grant_type')).toBe('refresh_token');
+    expect(body.get('refresh_token')).toBe('old-refresh-token');
+    expect(result).toEqual({
+      accessToken: 'new-access-token',
+      refreshToken: 'new-refresh-token',
+      expiresAt: new Date('2026-07-07T12:30:00.000Z'),
+      scopes: ['read', 'write'],
+    });
+  });
+
+  it('maps an invalid refresh token to access-denied', async () => {
+    mocks.post.mockReturnValue(rejects(httpError(400)));
+    const client = createLinearApiClient();
+
+    const result = client.refreshAccessToken({refreshToken: 'invalid-refresh-token'});
+
+    await expect(result).rejects.toMatchObject({reason: 'access-denied'});
+  });
+});
+
+describe('createLinearApiClient.getIdentity', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    mocks.post.mockReset();
+    mocks.warn.mockReset();
+  });
+
+  it('derives the app user and organization identity', async () => {
+    mocks.post.mockReturnValue(
+      resolves({
+        data: {
+          viewer: {id: 'app-user-id'},
+          organization: {id: 'org-id', name: 'Acme', urlKey: 'acme'},
+        },
+      }),
+    );
+    const client = createLinearApiClient();
+
+    const result = await client.getIdentity({accessToken: 'linear-token'});
+
+    const firstCall = mocks.post.mock.calls[0];
+    expect(firstCall).toBeDefined();
+    const [, options] = firstCall as [string, {headers: Record<string, string>}];
+    expect(options.headers).toEqual({authorization: 'Bearer linear-token'});
+    expect(result).toEqual({
+      appUserId: 'app-user-id',
+      organizationId: 'org-id',
+      organizationName: 'Acme',
+      organizationUrlKey: 'acme',
+    });
+  });
+
+  it('maps missing viewer or organization data to malformed-provider-response', async () => {
+    mocks.post.mockReturnValue(resolves({data: {viewer: {id: 'app-user-id'}}}));
+    const client = createLinearApiClient();
+
+    const result = client.getIdentity({accessToken: 'linear-token'});
+
+    await expect(result).rejects.toMatchObject({reason: 'malformed-provider-response'});
+  });
+
+  it('maps GraphQL auth errors to access-denied without leaking the provider message', async () => {
+    mocks.post.mockReturnValue(
+      resolves({
+        errors: [
+          {
+            message: 'invalid token linear-token',
+            extensions: {type: 'authentication'},
+          },
+        ],
+      }),
+    );
+    const client = createLinearApiClient();
+
+    const error = await client.getIdentity({accessToken: 'linear-token'}).catch((thrown) => thrown);
+
+    expect(error).toMatchObject({reason: 'access-denied'});
+    const serialized = [
+      (error as Error).message,
+      JSON.stringify(error),
+      JSON.stringify(mocks.warn.mock.calls),
+    ].join(' ');
+    expect(serialized).not.toContain('linear-token');
+    expect(serialized).not.toContain('invalid token');
+  });
+
+  it('maps non-auth GraphQL errors to malformed-provider-response', async () => {
+    mocks.post.mockReturnValue(
+      resolves({
+        errors: [{message: 'validation detail', extensions: {type: 'invalid'}}],
+      }),
+    );
+    const client = createLinearApiClient();
+
+    const result = client.getIdentity({accessToken: 'linear-token'});
+
+    await expect(result).rejects.toMatchObject({reason: 'malformed-provider-response'});
+  });
+
+  it('maps GraphQL responses without data to malformed-provider-response', async () => {
+    mocks.post.mockReturnValue(resolves({}));
+    const client = createLinearApiClient();
+
+    const result = client.getIdentity({accessToken: 'linear-token'});
+
+    await expect(result).rejects.toMatchObject({reason: 'malformed-provider-response'});
+  });
+});

--- a/libs/api/integration/linear/src/api/client.ts
+++ b/libs/api/integration/linear/src/api/client.ts
@@ -1,0 +1,246 @@
+import {logger} from '@shipfox/node-opentelemetry';
+import ky, {HTTPError, TimeoutError} from 'ky';
+import {config} from '#config.js';
+import {LinearIntegrationProviderError} from '#core/errors.js';
+
+const LINEAR_OAUTH_TOKEN_URL = 'https://api.linear.app/oauth/token';
+const LINEAR_GRAPHQL_URL = 'https://api.linear.app/graphql';
+const LINEAR_API_TIMEOUT_MS = 10_000;
+const SCOPE_SEPARATOR_RE = /[,\s]+/;
+
+const IDENTITY_QUERY = `
+  query ShipfoxLinearIdentity {
+    viewer {
+      id
+    }
+    organization {
+      id
+      name
+      urlKey
+    }
+  }
+`;
+
+export interface LinearAuthorization {
+  accessToken: string;
+  refreshToken?: string | undefined;
+  expiresAt?: Date | undefined;
+  scopes: string[];
+}
+
+export interface LinearIdentity {
+  appUserId: string;
+  organizationId: string;
+  organizationName: string;
+  organizationUrlKey: string;
+}
+
+export interface LinearApiClient {
+  exchangeAuthorizationCode(input: {code: string}): Promise<LinearAuthorization>;
+  refreshAccessToken(input: {refreshToken: string}): Promise<LinearAuthorization>;
+  getIdentity(input: {accessToken: string}): Promise<LinearIdentity>;
+}
+
+interface LinearTokenResponse {
+  access_token?: unknown;
+  refresh_token?: unknown;
+  expires_in?: unknown;
+  scope?: unknown;
+}
+
+interface LinearGraphqlResponse<Data> {
+  data?: Data | null;
+  errors?: LinearGraphqlError[] | undefined;
+}
+
+interface LinearGraphqlError {
+  extensions?: {type?: unknown} | undefined;
+}
+
+interface LinearIdentityData {
+  viewer?: {id?: unknown} | null;
+  organization?: {id?: unknown; name?: unknown; urlKey?: unknown} | null;
+}
+
+export function createLinearApiClient(): LinearApiClient {
+  return {
+    async exchangeAuthorizationCode(input) {
+      const body = await mapLinearError('exchange-authorization-code', () =>
+        ky
+          .post(LINEAR_OAUTH_TOKEN_URL, {
+            body: new URLSearchParams({
+              grant_type: 'authorization_code',
+              client_id: config.LINEAR_OAUTH_CLIENT_ID,
+              client_secret: config.LINEAR_OAUTH_CLIENT_SECRET,
+              code: input.code,
+              redirect_uri: config.LINEAR_OAUTH_REDIRECT_URL,
+            }),
+            timeout: LINEAR_API_TIMEOUT_MS,
+          })
+          .json<LinearTokenResponse>(),
+      );
+
+      return parseTokenResponse(body);
+    },
+
+    async refreshAccessToken(input) {
+      const body = await mapLinearError('refresh-access-token', () =>
+        ky
+          .post(LINEAR_OAUTH_TOKEN_URL, {
+            body: new URLSearchParams({
+              grant_type: 'refresh_token',
+              client_id: config.LINEAR_OAUTH_CLIENT_ID,
+              client_secret: config.LINEAR_OAUTH_CLIENT_SECRET,
+              refresh_token: input.refreshToken,
+            }),
+            timeout: LINEAR_API_TIMEOUT_MS,
+          })
+          .json<LinearTokenResponse>(),
+      );
+
+      return parseTokenResponse(body);
+    },
+
+    async getIdentity(input) {
+      const body = await mapLinearError('get-identity', () =>
+        ky
+          .post(LINEAR_GRAPHQL_URL, {
+            headers: {authorization: `Bearer ${input.accessToken}`},
+            json: {query: IDENTITY_QUERY},
+            timeout: LINEAR_API_TIMEOUT_MS,
+          })
+          .json<LinearGraphqlResponse<LinearIdentityData>>(),
+      );
+      const data = graphqlData('get-identity', body);
+      const appUserId = data.viewer?.id;
+      const organizationId = data.organization?.id;
+      const organizationName = data.organization?.name;
+      const organizationUrlKey = data.organization?.urlKey;
+
+      if (
+        typeof appUserId !== 'string' ||
+        typeof organizationId !== 'string' ||
+        typeof organizationName !== 'string' ||
+        typeof organizationUrlKey !== 'string'
+      ) {
+        throw new LinearIntegrationProviderError(
+          'malformed-provider-response',
+          'Linear identity response did not include the app user and organization',
+        );
+      }
+
+      return {appUserId, organizationId, organizationName, organizationUrlKey};
+    },
+  };
+}
+
+function parseTokenResponse(body: LinearTokenResponse): LinearAuthorization {
+  if (typeof body.access_token !== 'string' || body.access_token.length === 0) {
+    throw new LinearIntegrationProviderError(
+      'malformed-provider-response',
+      'Linear authorization response did not include an access token',
+    );
+  }
+
+  const scopes = parseScopes(body.scope);
+  const expiresAt = parseExpiresAt(body.expires_in);
+  const refreshToken = typeof body.refresh_token === 'string' ? body.refresh_token : undefined;
+  return {accessToken: body.access_token, refreshToken, expiresAt, scopes};
+}
+
+function parseScopes(scope: unknown): string[] {
+  if (typeof scope === 'string') {
+    return scope
+      .split(SCOPE_SEPARATOR_RE)
+      .map((value) => value.trim())
+      .filter(Boolean);
+  }
+  if (Array.isArray(scope) && scope.every((value) => typeof value === 'string')) return scope;
+  if (scope === undefined) return [];
+  throw new LinearIntegrationProviderError(
+    'malformed-provider-response',
+    'Linear authorization response included malformed scopes',
+  );
+}
+
+function parseExpiresAt(expiresIn: unknown): Date | undefined {
+  if (expiresIn === undefined) return undefined;
+  if (typeof expiresIn !== 'number' || !Number.isFinite(expiresIn) || expiresIn <= 0) {
+    throw new LinearIntegrationProviderError(
+      'malformed-provider-response',
+      'Linear authorization response included a malformed expiry',
+    );
+  }
+  return new Date(Date.now() + expiresIn * 1000);
+}
+
+function graphqlData<Data>(operation: string, body: LinearGraphqlResponse<Data>): Data {
+  if (hasGraphqlErrors(body)) {
+    const reason = hasAuthGraphqlError(body.errors)
+      ? 'access-denied'
+      : 'malformed-provider-response';
+    logger().warn({operation}, 'Linear GraphQL request returned errors');
+    throw new LinearIntegrationProviderError(reason, 'Linear GraphQL request failed');
+  }
+  if (!body.data) {
+    throw new LinearIntegrationProviderError(
+      'malformed-provider-response',
+      'Linear GraphQL response did not include data',
+    );
+  }
+  return body.data;
+}
+
+function hasGraphqlErrors(body: LinearGraphqlResponse<unknown>): boolean {
+  return Array.isArray(body.errors) && body.errors.length > 0;
+}
+
+function hasAuthGraphqlError(errors: LinearGraphqlError[] | undefined): boolean {
+  return (
+    errors?.some((error) => {
+      const type = error.extensions?.type;
+      return (
+        typeof type === 'string' && ['authentication', 'authorization'].includes(type.toLowerCase())
+      );
+    }) ?? false
+  );
+}
+
+async function mapLinearError<T>(operation: string, request: () => Promise<T>): Promise<T> {
+  try {
+    return await request();
+  } catch (error) {
+    if (error instanceof LinearIntegrationProviderError) throw error;
+    if (error instanceof HTTPError) {
+      const {status, statusText, headers} = error.response;
+      logger().warn({operation, status, statusText}, 'Linear API request rejected');
+      if (status === 429) {
+        throw new LinearIntegrationProviderError(
+          'rate-limited',
+          'Linear request was rate limited',
+          retryAfterSeconds(headers),
+        );
+      }
+      if (status >= 500) {
+        throw new LinearIntegrationProviderError('provider-unavailable', 'Linear request failed');
+      }
+      throw new LinearIntegrationProviderError('access-denied', 'Linear request was rejected');
+    }
+    if (error instanceof TimeoutError) {
+      logger().warn({operation}, 'Linear API request timed out');
+      throw new LinearIntegrationProviderError('timeout', 'Linear request timed out');
+    }
+    logger().warn(
+      {operation, errName: error instanceof Error ? error.name : typeof error},
+      'Linear API request failed',
+    );
+    throw new LinearIntegrationProviderError('provider-unavailable', 'Linear request failed');
+  }
+}
+
+function retryAfterSeconds(headers: Headers): number | undefined {
+  const retryAfter = headers.get('retry-after');
+  if (!retryAfter) return undefined;
+  const parsed = Number.parseInt(retryAfter, 10);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}

--- a/libs/api/integration/linear/src/api/client.ts
+++ b/libs/api/integration/linear/src/api/client.ts
@@ -62,6 +62,10 @@ interface LinearIdentityData {
   organization?: {id?: unknown; name?: unknown; urlKey?: unknown} | null;
 }
 
+interface MapLinearErrorOptions {
+  classifyHttp4xx?(status: number): 'access-denied' | 'malformed-provider-response';
+}
+
 export function createLinearApiClient(): LinearApiClient {
   return {
     async exchangeAuthorizationCode(input) {
@@ -102,14 +106,17 @@ export function createLinearApiClient(): LinearApiClient {
     },
 
     async getIdentity(input) {
-      const body = await mapLinearError('get-identity', () =>
-        ky
-          .post(LINEAR_GRAPHQL_URL, {
-            headers: {authorization: `Bearer ${input.accessToken}`},
-            json: {query: IDENTITY_QUERY},
-            timeout: LINEAR_API_TIMEOUT_MS,
-          })
-          .json<LinearGraphqlResponse<LinearIdentityData>>(),
+      const body = await mapLinearError(
+        'get-identity',
+        () =>
+          ky
+            .post(LINEAR_GRAPHQL_URL, {
+              headers: {authorization: `Bearer ${input.accessToken}`},
+              json: {query: IDENTITY_QUERY},
+              timeout: LINEAR_API_TIMEOUT_MS,
+            })
+            .json<LinearGraphqlResponse<LinearIdentityData>>(),
+        {classifyHttp4xx: classifyGraphqlHttp4xx},
       );
       const data = graphqlData('get-identity', body);
       const appUserId = data.viewer?.id;
@@ -206,7 +213,11 @@ function hasAuthGraphqlError(errors: LinearGraphqlError[] | undefined): boolean 
   );
 }
 
-async function mapLinearError<T>(operation: string, request: () => Promise<T>): Promise<T> {
+async function mapLinearError<T>(
+  operation: string,
+  request: () => Promise<T>,
+  options: MapLinearErrorOptions = {},
+): Promise<T> {
   try {
     return await request();
   } catch (error) {
@@ -224,7 +235,8 @@ async function mapLinearError<T>(operation: string, request: () => Promise<T>): 
       if (status >= 500) {
         throw new LinearIntegrationProviderError('provider-unavailable', 'Linear request failed');
       }
-      throw new LinearIntegrationProviderError('access-denied', 'Linear request was rejected');
+      const reason = options.classifyHttp4xx?.(status) ?? 'access-denied';
+      throw new LinearIntegrationProviderError(reason, 'Linear request was rejected');
     }
     if (error instanceof TimeoutError) {
       logger().warn({operation}, 'Linear API request timed out');
@@ -236,6 +248,10 @@ async function mapLinearError<T>(operation: string, request: () => Promise<T>): 
     );
     throw new LinearIntegrationProviderError('provider-unavailable', 'Linear request failed');
   }
+}
+
+function classifyGraphqlHttp4xx(status: number): 'access-denied' | 'malformed-provider-response' {
+  return status === 401 || status === 403 ? 'access-denied' : 'malformed-provider-response';
 }
 
 function retryAfterSeconds(headers: Headers): number | undefined {

--- a/libs/api/integration/linear/src/core/errors.ts
+++ b/libs/api/integration/linear/src/core/errors.ts
@@ -1,3 +1,7 @@
+import {IntegrationProviderError} from '@shipfox/api-integration-core-dto';
+
+export class LinearIntegrationProviderError extends IntegrationProviderError {}
+
 export class LinearInstallationAlreadyLinkedError extends Error {
   constructor(organizationId: string) {
     super(`Linear organization is already linked to another Shipfox workspace: ${organizationId}`);
@@ -11,5 +15,26 @@ export class LinearConnectionAlreadyLinkedError extends Error {
       `Integration connection is already linked to another Linear organization: ${connectionId}`,
     );
     this.name = 'LinearConnectionAlreadyLinkedError';
+  }
+}
+
+export class LinearConnectionNotFoundError extends Error {
+  constructor(connectionId: string) {
+    super(`Linear integration connection was not found: ${connectionId}`);
+    this.name = 'LinearConnectionNotFoundError';
+  }
+}
+
+export class LinearAccessTokenMissingError extends Error {
+  constructor(connectionId: string) {
+    super(`Linear access token is missing for connection: ${connectionId}`);
+    this.name = 'LinearAccessTokenMissingError';
+  }
+}
+
+export class LinearTokenUnrefreshableError extends Error {
+  constructor(public readonly connectionId: string) {
+    super(`Linear token cannot be refreshed; reconnect is required: ${connectionId}`);
+    this.name = 'LinearTokenUnrefreshableError';
   }
 }

--- a/libs/api/integration/linear/src/core/tokens.test.ts
+++ b/libs/api/integration/linear/src/core/tokens.test.ts
@@ -1,0 +1,281 @@
+import {getLinearInstallationByConnectionId, upsertLinearInstallation} from '#db/installations.js';
+import {
+  LinearAccessTokenMissingError,
+  LinearConnectionNotFoundError,
+  LinearTokenUnrefreshableError,
+} from './errors.js';
+import {
+  createLinearTokenStore,
+  type LinearConnectionResolverResult,
+  type LinearSecretsStore,
+  linearSecretsNamespace,
+} from './tokens.js';
+
+let secrets: LinearSecretsStore;
+
+beforeAll(async () => {
+  // @ts-expect-error @shipfox/api-secrets is a peer supplied by the composing API app.
+  secrets = await import('@shipfox/api-secrets');
+});
+
+function createConnectionContext() {
+  const workspaceId = crypto.randomUUID();
+  const connectionId = crypto.randomUUID();
+  const resolveConnection = vi
+    .fn<(connectionId: string) => Promise<LinearConnectionResolverResult | undefined>>()
+    .mockResolvedValue({workspaceId});
+  const refreshAccessToken = vi.fn();
+  const store = createLinearTokenStore({
+    resolveConnection,
+    secrets,
+    client: {
+      exchangeAuthorizationCode: vi.fn(),
+      getIdentity: vi.fn(),
+      refreshAccessToken,
+    },
+  });
+
+  return {workspaceId, connectionId, resolveConnection, refreshAccessToken, store};
+}
+
+function createInstallation(input: {
+  connectionId: string;
+  tokenExpiresAt?: Date | null | undefined;
+  scopes?: string[] | undefined;
+}) {
+  return upsertLinearInstallation({
+    connectionId: input.connectionId,
+    organizationId: `org-${crypto.randomUUID()}`,
+    organizationUrlKey: 'acme',
+    appUserId: 'app-user-id',
+    scopes: input.scopes ?? ['read'],
+    tokenExpiresAt: input.tokenExpiresAt,
+    status: 'installed',
+  });
+}
+
+function storedToken(input: {
+  workspaceId: string;
+  connectionId: string;
+  key: 'ACCESS_TOKEN' | 'REFRESH_TOKEN';
+}) {
+  return secrets.getSecret({
+    workspaceId: input.workspaceId,
+    namespace: linearSecretsNamespace(input.connectionId),
+    key: input.key,
+  });
+}
+
+describe('createLinearTokenStore.storeTokens', () => {
+  it('stores access and refresh tokens in the Linear system namespace', async () => {
+    const {workspaceId, connectionId, store} = createConnectionContext();
+
+    await store.storeTokens({
+      connectionId,
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      editedBy: crypto.randomUUID(),
+    });
+
+    await expect(storedToken({workspaceId, connectionId, key: 'ACCESS_TOKEN'})).resolves.toBe(
+      'access-token',
+    );
+    await expect(storedToken({workspaceId, connectionId, key: 'REFRESH_TOKEN'})).resolves.toBe(
+      'refresh-token',
+    );
+  });
+
+  it('stores only the access token when no refresh token was issued', async () => {
+    const {workspaceId, connectionId, store} = createConnectionContext();
+
+    await store.storeTokens({connectionId, accessToken: 'access-token'});
+
+    await expect(storedToken({workspaceId, connectionId, key: 'ACCESS_TOKEN'})).resolves.toBe(
+      'access-token',
+    );
+    await expect(
+      storedToken({workspaceId, connectionId, key: 'REFRESH_TOKEN'}),
+    ).resolves.toBeNull();
+  });
+
+  it('throws a typed error when the connection cannot be resolved', async () => {
+    const {store, resolveConnection, connectionId} = createConnectionContext();
+    resolveConnection.mockResolvedValue(undefined);
+
+    const result = store.storeTokens({connectionId, accessToken: 'access-token'});
+
+    await expect(result).rejects.toBeInstanceOf(LinearConnectionNotFoundError);
+  });
+});
+
+describe('createLinearTokenStore.getAccessToken', () => {
+  it('returns the stored token when no refresh is needed', async () => {
+    const {connectionId, refreshAccessToken, store} = createConnectionContext();
+    await store.storeTokens({connectionId, accessToken: 'access-token'});
+    await createInstallation({
+      connectionId,
+      tokenExpiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    });
+
+    const result = await store.getAccessToken({connectionId});
+
+    expect(result).toBe('access-token');
+    expect(refreshAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('refreshes an expired token and writes the new secret and metadata', async () => {
+    const {workspaceId, connectionId, refreshAccessToken, store} = createConnectionContext();
+    const expiresAt = new Date('2026-07-07T13:00:00.000Z');
+    await store.storeTokens({
+      connectionId,
+      accessToken: 'old-access-token',
+      refreshToken: 'old-refresh-token',
+    });
+    await createInstallation({
+      connectionId,
+      tokenExpiresAt: new Date('2026-07-07T11:00:00.000Z'),
+      scopes: ['read'],
+    });
+    refreshAccessToken.mockResolvedValue({
+      accessToken: 'new-access-token',
+      refreshToken: 'new-refresh-token',
+      expiresAt,
+      scopes: ['read', 'write'],
+    });
+
+    const result = await store.getAccessToken({connectionId});
+
+    const installation = await getLinearInstallationByConnectionId(connectionId);
+    expect(result).toBe('new-access-token');
+    await expect(storedToken({workspaceId, connectionId, key: 'ACCESS_TOKEN'})).resolves.toBe(
+      'new-access-token',
+    );
+    await expect(storedToken({workspaceId, connectionId, key: 'REFRESH_TOKEN'})).resolves.toBe(
+      'new-refresh-token',
+    );
+    expect(installation?.tokenExpiresAt?.toISOString()).toBe(expiresAt.toISOString());
+    expect(installation?.scopes).toEqual(['read', 'write']);
+  });
+
+  it('force refreshes even when the token expiry is unknown', async () => {
+    const {connectionId, refreshAccessToken, store} = createConnectionContext();
+    await store.storeTokens({
+      connectionId,
+      accessToken: 'old-access-token',
+      refreshToken: 'refresh-token',
+    });
+    await createInstallation({connectionId, tokenExpiresAt: null});
+    refreshAccessToken.mockResolvedValue({
+      accessToken: 'new-access-token',
+      expiresAt: new Date('2026-07-07T13:00:00.000Z'),
+      scopes: [],
+    });
+
+    const result = await store.getAccessToken({connectionId, forceRefresh: true});
+
+    expect(result).toBe('new-access-token');
+  });
+
+  it('returns the stored token for proactive refresh when no refresh token exists', async () => {
+    const {connectionId, refreshAccessToken, store} = createConnectionContext();
+    await store.storeTokens({connectionId, accessToken: 'access-token'});
+    await createInstallation({
+      connectionId,
+      tokenExpiresAt: new Date('2026-07-07T11:00:00.000Z'),
+    });
+
+    const result = await store.getAccessToken({connectionId});
+
+    expect(result).toBe('access-token');
+    expect(refreshAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('preserves the stored refresh token when Linear omits a rotated replacement', async () => {
+    const {workspaceId, connectionId, refreshAccessToken, store} = createConnectionContext();
+    await store.storeTokens({
+      connectionId,
+      accessToken: 'old-access-token',
+      refreshToken: 'old-refresh-token',
+    });
+    await createInstallation({
+      connectionId,
+      tokenExpiresAt: new Date('2026-07-07T11:00:00.000Z'),
+    });
+    refreshAccessToken.mockResolvedValue({
+      accessToken: 'new-access-token',
+      expiresAt: new Date('2026-07-07T13:00:00.000Z'),
+      scopes: ['read'],
+    });
+
+    await store.getAccessToken({connectionId});
+
+    await expect(storedToken({workspaceId, connectionId, key: 'REFRESH_TOKEN'})).resolves.toBe(
+      'old-refresh-token',
+    );
+  });
+
+  it('shares one in-process refresh across concurrent callers', async () => {
+    const {connectionId, refreshAccessToken, store} = createConnectionContext();
+    await store.storeTokens({
+      connectionId,
+      accessToken: 'old-access-token',
+      refreshToken: 'refresh-token',
+    });
+    await createInstallation({
+      connectionId,
+      tokenExpiresAt: new Date('2026-07-07T11:00:00.000Z'),
+    });
+    refreshAccessToken.mockResolvedValue({
+      accessToken: 'new-access-token',
+      refreshToken: 'new-refresh-token',
+      expiresAt: new Date('2026-07-07T13:00:00.000Z'),
+      scopes: ['read'],
+    });
+
+    const results = await Promise.all([
+      store.getAccessToken({connectionId}),
+      store.getAccessToken({connectionId}),
+    ]);
+
+    expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(results).toEqual(['new-access-token', 'new-access-token']);
+  });
+
+  it('throws reconnect-needed when a forced refresh has no refresh token', async () => {
+    const {connectionId, store} = createConnectionContext();
+    await store.storeTokens({connectionId, accessToken: 'dead-access-token'});
+    await createInstallation({connectionId, tokenExpiresAt: null});
+
+    const result = store.getAccessToken({connectionId, forceRefresh: true});
+
+    await expect(result).rejects.toBeInstanceOf(LinearTokenUnrefreshableError);
+  });
+
+  it('throws a typed error when the connection cannot be resolved', async () => {
+    const {store, resolveConnection, connectionId} = createConnectionContext();
+    resolveConnection.mockResolvedValue(undefined);
+
+    const result = store.getAccessToken({connectionId});
+
+    await expect(result).rejects.toBeInstanceOf(LinearConnectionNotFoundError);
+  });
+
+  it('throws a typed error when no access token is stored', async () => {
+    const {connectionId, store} = createConnectionContext();
+    await createInstallation({connectionId, tokenExpiresAt: null});
+
+    const result = store.getAccessToken({connectionId});
+
+    await expect(result).rejects.toBeInstanceOf(LinearAccessTokenMissingError);
+  });
+
+  it('skips proactive refresh when the installation row is missing', async () => {
+    const {connectionId, refreshAccessToken, store} = createConnectionContext();
+    await store.storeTokens({connectionId, accessToken: 'access-token'});
+
+    const result = await store.getAccessToken({connectionId});
+
+    expect(result).toBe('access-token');
+    expect(refreshAccessToken).not.toHaveBeenCalled();
+  });
+});

--- a/libs/api/integration/linear/src/core/tokens.ts
+++ b/libs/api/integration/linear/src/core/tokens.ts
@@ -1,0 +1,201 @@
+import {createLinearApiClient, type LinearApiClient} from '#api/client.js';
+import {
+  LinearAccessTokenMissingError,
+  LinearConnectionNotFoundError,
+  LinearIntegrationProviderError,
+  LinearTokenUnrefreshableError,
+} from '#core/errors.js';
+import {
+  getLinearInstallationByConnectionId,
+  updateLinearInstallationTokenExpiry,
+  withLinearRefreshLock,
+} from '#db/installations.js';
+
+const ACCESS_TOKEN_KEY = 'ACCESS_TOKEN';
+const REFRESH_TOKEN_KEY = 'REFRESH_TOKEN';
+const TOKEN_REFRESH_MARGIN_MS = 5 * 60 * 1000;
+const tokenRefreshes = new Map<string, Promise<string>>();
+
+export interface LinearConnectionResolverResult {
+  workspaceId: string;
+}
+
+export interface CreateLinearTokenStoreParams {
+  resolveConnection(connectionId: string): Promise<LinearConnectionResolverResult | undefined>;
+  secrets: LinearSecretsStore;
+  client?: LinearApiClient | undefined;
+}
+
+export interface LinearSecretsStore {
+  getSecret(params: {workspaceId: string; namespace: string; key: string}): Promise<string | null>;
+  setSecrets(params: {
+    workspaceId: string;
+    namespace: string;
+    values: Record<string, string>;
+    editedBy?: string | null | undefined;
+  }): Promise<void>;
+}
+
+export interface StoreLinearTokensParams {
+  connectionId: string;
+  accessToken: string;
+  refreshToken?: string | undefined;
+  editedBy?: string | null | undefined;
+}
+
+export interface GetLinearAccessTokenParams {
+  connectionId: string;
+  forceRefresh?: boolean | undefined;
+}
+
+export interface LinearTokenStore {
+  storeTokens(params: StoreLinearTokensParams): Promise<void>;
+  getAccessToken(params: GetLinearAccessTokenParams): Promise<string>;
+}
+
+export function linearSecretsNamespace(connectionId: string): string {
+  return `system/integrations/linear/${connectionId}`;
+}
+
+export function createLinearTokenStore(params: CreateLinearTokenStoreParams): LinearTokenStore {
+  const client = params.client ?? createLinearApiClient();
+
+  async function resolveWorkspaceId(connectionId: string): Promise<string> {
+    const connection = await params.resolveConnection(connectionId);
+    if (!connection) throw new LinearConnectionNotFoundError(connectionId);
+    return connection.workspaceId;
+  }
+
+  function readSecretToken(
+    workspaceId: string,
+    connectionId: string,
+    key: typeof ACCESS_TOKEN_KEY | typeof REFRESH_TOKEN_KEY,
+  ): Promise<string | null> {
+    return params.secrets.getSecret({
+      workspaceId,
+      namespace: linearSecretsNamespace(connectionId),
+      key,
+    });
+  }
+
+  async function readAccessToken(workspaceId: string, connectionId: string): Promise<string> {
+    const token = await readSecretToken(workspaceId, connectionId, ACCESS_TOKEN_KEY);
+    if (!token) throw new LinearAccessTokenMissingError(connectionId);
+    return token;
+  }
+
+  return {
+    async storeTokens(input) {
+      const workspaceId = await resolveWorkspaceId(input.connectionId);
+      const values: Record<string, string> = {[ACCESS_TOKEN_KEY]: input.accessToken};
+      if (input.refreshToken) values[REFRESH_TOKEN_KEY] = input.refreshToken;
+
+      await params.secrets.setSecrets({
+        workspaceId,
+        namespace: linearSecretsNamespace(input.connectionId),
+        values,
+        editedBy: input.editedBy,
+      });
+    },
+
+    async getAccessToken(input) {
+      const forceRefresh = input.forceRefresh === true;
+      const workspaceId = await resolveWorkspaceId(input.connectionId);
+      const installation = await getLinearInstallationByConnectionId(input.connectionId);
+      const accessToken = await readAccessToken(workspaceId, input.connectionId);
+
+      if (!forceRefresh && !shouldRefresh(installation?.tokenExpiresAt ?? null)) {
+        return accessToken;
+      }
+
+      const inFlightRefresh = tokenRefreshes.get(input.connectionId);
+      if (inFlightRefresh) return inFlightRefresh;
+
+      const lock = await withLinearRefreshLock(input.connectionId, async () => {
+        const refresh = refreshAccessTokenForConnection({
+          connectionId: input.connectionId,
+          workspaceId,
+          originalAccessToken: accessToken,
+          forceRefresh,
+          client,
+          secrets: params.secrets,
+          readAccessToken,
+          readSecretToken,
+        });
+        tokenRefreshes.set(input.connectionId, refresh);
+        try {
+          return await refresh;
+        } finally {
+          tokenRefreshes.delete(input.connectionId);
+        }
+      });
+
+      if (lock.acquired) return lock.value;
+
+      const missedRefresh = tokenRefreshes.get(input.connectionId);
+      if (missedRefresh) return missedRefresh;
+
+      const rereadToken = await readAccessToken(workspaceId, input.connectionId);
+      if (rereadToken !== accessToken) return rereadToken;
+      if (forceRefresh) {
+        throw new LinearIntegrationProviderError(
+          'provider-unavailable',
+          'Linear token refresh is already in progress',
+        );
+      }
+      return accessToken;
+    },
+  };
+}
+
+function shouldRefresh(expiresAt: Date | null): boolean {
+  return expiresAt !== null && expiresAt.getTime() <= Date.now() + TOKEN_REFRESH_MARGIN_MS;
+}
+
+async function refreshAccessTokenForConnection(params: {
+  connectionId: string;
+  workspaceId: string;
+  originalAccessToken: string;
+  forceRefresh: boolean;
+  client: LinearApiClient;
+  secrets: LinearSecretsStore;
+  readAccessToken(workspaceId: string, connectionId: string): Promise<string>;
+  readSecretToken(
+    workspaceId: string,
+    connectionId: string,
+    key: typeof ACCESS_TOKEN_KEY | typeof REFRESH_TOKEN_KEY,
+  ): Promise<string | null>;
+}): Promise<string> {
+  const currentAccessToken = await params.readAccessToken(params.workspaceId, params.connectionId);
+  const currentInstallation = await getLinearInstallationByConnectionId(params.connectionId);
+  const tokenChanged = currentAccessToken !== params.originalAccessToken;
+  const isFresh =
+    !params.forceRefresh && !shouldRefresh(currentInstallation?.tokenExpiresAt ?? null);
+  if (tokenChanged || isFresh) return currentAccessToken;
+
+  const refreshToken = await params.readSecretToken(
+    params.workspaceId,
+    params.connectionId,
+    REFRESH_TOKEN_KEY,
+  );
+  if (!refreshToken) {
+    if (params.forceRefresh) throw new LinearTokenUnrefreshableError(params.connectionId);
+    return currentAccessToken;
+  }
+
+  const refreshed = await params.client.refreshAccessToken({refreshToken});
+  const values: Record<string, string> = {[ACCESS_TOKEN_KEY]: refreshed.accessToken};
+  if (refreshed.refreshToken) values[REFRESH_TOKEN_KEY] = refreshed.refreshToken;
+  await params.secrets.setSecrets({
+    workspaceId: params.workspaceId,
+    namespace: linearSecretsNamespace(params.connectionId),
+    values,
+  });
+  await updateLinearInstallationTokenExpiry({
+    connectionId: params.connectionId,
+    tokenExpiresAt: refreshed.expiresAt ?? null,
+    scopes: refreshed.scopes.length > 0 ? refreshed.scopes : undefined,
+  });
+
+  return refreshed.accessToken;
+}

--- a/libs/api/integration/linear/src/db/installations.test.ts
+++ b/libs/api/integration/linear/src/db/installations.test.ts
@@ -7,6 +7,7 @@ import {
   getLinearInstallationByOrganizationId,
   markLinearInstallationRevoked,
   upsertLinearInstallation,
+  withLinearRefreshLock,
 } from './installations.js';
 
 describe('linear installations', () => {
@@ -153,5 +154,29 @@ describe('linear installations', () => {
     const result = await markLinearInstallationRevoked(connectionId);
 
     expect(result?.status).toBe('revoked');
+  });
+
+  it('allows one refresh lock holder per connection and fails contenders fast', async () => {
+    const connectionId = crypto.randomUUID();
+    let releaseLock: () => void = () => {
+      throw new Error('releaseLock was not initialized');
+    };
+    const holder = withLinearRefreshLock(
+      connectionId,
+      () =>
+        new Promise<string>((resolve) => {
+          releaseLock = () => resolve('holder');
+        }),
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    const contender = await withLinearRefreshLock(connectionId, async () => 'contender');
+    const different = await withLinearRefreshLock(crypto.randomUUID(), async () => 'different');
+    releaseLock();
+    const held = await holder;
+
+    expect(contender).toEqual({acquired: false});
+    expect(different).toEqual({acquired: true, value: 'different'});
+    expect(held).toEqual({acquired: true, value: 'holder'});
   });
 });

--- a/libs/api/integration/linear/src/db/installations.ts
+++ b/libs/api/integration/linear/src/db/installations.ts
@@ -1,4 +1,5 @@
-import {eq, sql} from 'drizzle-orm';
+import {pgClient} from '@shipfox/node-postgres';
+import {eq} from 'drizzle-orm';
 import {
   LinearConnectionAlreadyLinkedError,
   LinearInstallationAlreadyLinkedError,
@@ -172,14 +173,32 @@ export function withLinearRefreshLock<T>(
   connectionId: string,
   fn: () => Promise<T>,
 ): Promise<LinearRefreshLockResult<T>> {
-  return db().transaction(async (tx) => {
-    const lock = await tx.execute<{acquired: boolean}>(sql`
-      SELECT pg_try_advisory_xact_lock(hashtext(${connectionId})) AS acquired
-    `);
-    const acquired = lock.rows[0]?.acquired === true;
+  return withLinearRefreshLockClient(connectionId, fn);
+}
+
+async function withLinearRefreshLockClient<T>(
+  connectionId: string,
+  fn: () => Promise<T>,
+): Promise<LinearRefreshLockResult<T>> {
+  const client = await pgClient().connect();
+  let acquired = false;
+  try {
+    const lock = await client.query<{acquired: boolean}>(
+      'SELECT pg_try_advisory_lock(hashtext($1)) AS acquired',
+      [connectionId],
+    );
+    acquired = lock.rows[0]?.acquired === true;
     if (!acquired) return {acquired: false};
 
     const value = await fn();
     return {acquired: true, value};
-  });
+  } finally {
+    try {
+      if (acquired) {
+        await client.query('SELECT pg_advisory_unlock(hashtext($1))', [connectionId]);
+      }
+    } finally {
+      client.release();
+    }
+  }
 }

--- a/libs/api/integration/linear/src/db/installations.ts
+++ b/libs/api/integration/linear/src/db/installations.ts
@@ -1,4 +1,4 @@
-import {eq} from 'drizzle-orm';
+import {eq, sql} from 'drizzle-orm';
 import {
   LinearConnectionAlreadyLinkedError,
   LinearInstallationAlreadyLinkedError,
@@ -29,6 +29,12 @@ export interface UpsertLinearInstallationParams {
   scopes: string[];
   tokenExpiresAt?: Date | null | undefined;
   status: LinearInstallationStatus;
+}
+
+export interface UpdateLinearInstallationTokenExpiryParams {
+  connectionId: string;
+  tokenExpiresAt: Date | null;
+  scopes?: string[] | undefined;
 }
 
 type LinearDb = ReturnType<typeof db>;
@@ -128,6 +134,24 @@ export async function getLinearInstallationByOrganizationId(
   return toLinearInstallation(row);
 }
 
+export async function updateLinearInstallationTokenExpiry(
+  params: UpdateLinearInstallationTokenExpiryParams,
+  options: {tx?: unknown} = {},
+): Promise<LinearInstallation | undefined> {
+  const executor = (options.tx ?? db()) as LinearDb | LinearTx;
+  const [row] = await executor
+    .update(linearInstallations)
+    .set({
+      tokenExpiresAt: params.tokenExpiresAt,
+      ...(params.scopes === undefined ? {} : {scopes: params.scopes}),
+      updatedAt: new Date(),
+    })
+    .where(eq(linearInstallations.connectionId, params.connectionId))
+    .returning();
+  if (!row) return undefined;
+  return toLinearInstallation(row);
+}
+
 export async function markLinearInstallationRevoked(
   connectionId: string,
   options: {tx?: unknown} = {},
@@ -140,4 +164,22 @@ export async function markLinearInstallationRevoked(
     .returning();
   if (!row) return undefined;
   return toLinearInstallation(row);
+}
+
+export type LinearRefreshLockResult<T> = {acquired: true; value: T} | {acquired: false};
+
+export function withLinearRefreshLock<T>(
+  connectionId: string,
+  fn: () => Promise<T>,
+): Promise<LinearRefreshLockResult<T>> {
+  return db().transaction(async (tx) => {
+    const lock = await tx.execute<{acquired: boolean}>(sql`
+      SELECT pg_try_advisory_xact_lock(hashtext(${connectionId})) AS acquired
+    `);
+    const acquired = lock.rows[0]?.acquired === true;
+    if (!acquired) return {acquired: false};
+
+    const value = await fn();
+    return {acquired: true, value};
+  });
 }

--- a/libs/api/integration/linear/src/index.ts
+++ b/libs/api/integration/linear/src/index.ts
@@ -5,6 +5,8 @@ import {getLinearInstallationByConnectionId} from '#db/installations.js';
 import {migrationsPath} from '#db/migrations.js';
 
 export type {LinearProvider} from '@shipfox/api-integration-linear-dto';
+export type {LinearApiClient, LinearAuthorization, LinearIdentity} from '#api/client.js';
+export {createLinearApiClient} from '#api/client.js';
 export type {
   LinearAgentToolCatalogEntry,
   LinearAgentToolCategory,
@@ -16,19 +18,38 @@ export {
   linearAgentToolSelectionCatalog,
 } from '#core/agent-tools.js';
 export {
+  LinearAccessTokenMissingError,
   LinearConnectionAlreadyLinkedError,
+  LinearConnectionNotFoundError,
   LinearInstallationAlreadyLinkedError,
+  LinearIntegrationProviderError,
+  LinearTokenUnrefreshableError,
 } from '#core/errors.js';
+export type {
+  CreateLinearTokenStoreParams,
+  GetLinearAccessTokenParams,
+  LinearConnectionResolverResult,
+  LinearSecretsStore,
+  LinearTokenStore,
+  StoreLinearTokensParams,
+} from '#core/tokens.js';
+export {
+  createLinearTokenStore,
+  linearSecretsNamespace,
+} from '#core/tokens.js';
 export type {
   LinearInstallation,
   LinearInstallationStatus,
+  UpdateLinearInstallationTokenExpiryParams,
   UpsertLinearInstallationParams,
 } from '#db/installations.js';
 export {
   getLinearInstallationByConnectionId,
   getLinearInstallationByOrganizationId,
   markLinearInstallationRevoked,
+  updateLinearInstallationTokenExpiry,
   upsertLinearInstallation,
+  withLinearRefreshLock,
 } from '#db/installations.js';
 export {closeDb, config, db, migrationsPath};
 

--- a/libs/api/integration/linear/test/env.ts
+++ b/libs/api/integration/linear/test/env.ts
@@ -9,3 +9,4 @@ process.env.LINEAR_OAUTH_CLIENT_ID = 'test-client-id';
 process.env.LINEAR_OAUTH_CLIENT_SECRET = 'test-client-secret';
 process.env.LINEAR_WEBHOOK_SIGNING_SECRET = 'test-webhook-secret';
 process.env.LINEAR_OAUTH_REDIRECT_URL = 'https://api.example.com/integrations/linear/callback/api';
+process.env.SECRETS_ENCRYPTION_KEK = 'ZmVkY2JhOTg3NjU0MzIxMGZlZGNiYTk4NzY1NDMyMTA=';

--- a/libs/api/integration/linear/test/globalSetup.ts
+++ b/libs/api/integration/linear/test/globalSetup.ts
@@ -8,6 +8,16 @@ export async function setup() {
   createPostgresClient();
 
   await runMigrations(db(), migrationsPath, '__drizzle_migrations_integrations_linear');
+  // @ts-expect-error @shipfox/api-secrets is a peer supplied by the composing API app.
+  const {secretsModule} = await import('@shipfox/api-secrets');
+  if (!secretsModule.database || Array.isArray(secretsModule.database)) {
+    throw new Error('Secrets module database is not configured');
+  }
+  await runMigrations(
+    secretsModule.database.db(),
+    secretsModule.database.migrationsPath,
+    '__drizzle_migrations_secrets',
+  );
 
   closeDb();
   await closePostgresClient();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2017,18 +2017,27 @@ importers:
       '@shipfox/api-integration-linear-dto':
         specifier: workspace:*
         version: link:../linear-dto
+      '@shipfox/api-secrets':
+        specifier: workspace:*
+        version: link:../../secrets
       '@shipfox/config':
         specifier: workspace:*
         version: link:../../../shared/common/config
       '@shipfox/node-drizzle':
         specifier: workspace:*
         version: link:../../../shared/node/drizzle
+      '@shipfox/node-opentelemetry':
+        specifier: workspace:*
+        version: link:../../../shared/node/opentelemetry
       '@shipfox/node-postgres':
         specifier: workspace:*
         version: link:../../../shared/node/postgres
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
+      ky:
+        specifier: ^2.0.0
+        version: 2.0.2
       zod:
         specifier: ^4.4.3
         version: 4.4.3


### PR DESCRIPTION
Add the Linear OAuth API client and workspace-scoped token custody primitives.

Linear follow-up work needs reusable building blocks before the connect flow and hosted MCP adapter can be wired: a redaction-safe `ky` client for code exchange, refresh, and identity derivation, plus a token store that writes access and refresh tokens through the secrets module and refreshes them without blocking pooled DB connections.

The token store takes a structural secrets dependency instead of importing `@shipfox/api-secrets` directly. A hard dependency creates a package cycle through `api-secrets -> api-projects -> api-integration-core -> api-integration-linear`, while the composition point can still pass the real `getSecret` and `setSecrets` functions.

Reviewers should look closely at the refresh single-flight path and GraphQL error classification because ENG-874 and ENG-875 will build on those seams.

Closes ENG-872

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Linear OAuth client and workspace-scoped token store to handle code exchange, token refresh, and identity lookup, unblocking the connect flow and hosted MCP adapter. Implements ENG-872’s token custody requirements with refined GraphQL error handling and safer refresh locking.

- **New Features**
  - OAuth client (`createLinearApiClient`): exchanges codes, refreshes tokens, and fetches identity with 10s timeout; maps 401/403 to access-denied, other 4xx to malformed-provider-response, 5xx to provider-unavailable, 429 to rate-limited (with retry-after), and timeouts; redacts secrets in logs/errors.
  - Token store (`createLinearTokenStore`): saves `ACCESS_TOKEN`/`REFRESH_TOKEN` in secrets under `system/integrations/linear/{connectionId}`; proactive 5‑min margin refresh with single‑flight (in‑process dedupe + `pg_try_advisory_lock`); updates token expiry/scopes; typed errors for missing tokens or unrefreshable sessions.
  - DB helpers: `updateLinearInstallationTokenExpiry` and `withLinearRefreshLock`.

- **Dependencies**
  - Add `ky` and `@shipfox/node-opentelemetry`; declare `@shipfox/api-secrets` as a peer. Composing apps must provide secrets (`getSecret`/`setSecrets`) to the token store.

<sup>Written for commit 6c1dc5f7beea044e7b6d5c733fdef233a517cb1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

