### PR TITLE
[annotations] Add leased write route

### DIFF
--- a/apps/api/src/core/run.test.ts
+++ b/apps/api/src/core/run.test.ts
@@ -44,6 +44,7 @@ const mocks = vi.hoisted(() => {
 });
 
 vi.mock('@shipfox/api-agent', () => ({agentModule: {name: 'agent'}}));
+vi.mock('@shipfox/annotations', () => ({annotationsModule: {name: 'annotations'}}));
 vi.mock('@shipfox/api-auth', () => ({authModule: {name: 'auth'}}));
 vi.mock('@shipfox/api-definitions', () => ({
   createDefinitionsModule: mocks.createDefinitionsModule,

--- a/libs/api/annotations/package.json
+++ b/libs/api/annotations/package.json
@@ -38,13 +38,19 @@
   },
   "dependencies": {
     "@shipfox/annotations-dto": "workspace:*",
+    "@shipfox/api-auth-context": "workspace:*",
+    "@shipfox/config": "workspace:*",
     "@shipfox/node-drizzle": "workspace:*",
+    "@shipfox/node-fastify": "workspace:*",
     "@shipfox/node-module": "workspace:*",
     "@shipfox/node-postgres": "workspace:*",
     "drizzle-orm": "^0.45.2"
   },
   "devDependencies": {
+    "@shipfox/api-auth": "workspace:*",
+    "@shipfox/api-auth-dto": "workspace:*",
     "@shipfox/biome": "workspace:*",
+    "@shipfox/node-jwt": "workspace:*",
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",

--- a/libs/api/annotations/src/config.test.ts
+++ b/libs/api/annotations/src/config.test.ts
@@ -1,0 +1,45 @@
+import {vi} from '@shipfox/vitest/vi';
+
+describe.each([
+  'ANNOTATIONS_MAX_BODY_BYTES',
+  'ANNOTATIONS_MAX_PER_EXECUTION',
+  'ANNOTATIONS_MAX_TOTAL_BYTES',
+] as const)('%s validation', (name) => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it.each(['0', '-5', '1.5'])('fails startup when the value is %s', async (value) => {
+    vi.stubEnv(name, value);
+    vi.resetModules();
+
+    await expect(import('#config.js')).rejects.toThrow(name);
+  });
+
+  it('accepts a whole number greater than 0', async () => {
+    vi.stubEnv(name, '1');
+    vi.resetModules();
+
+    const {config} = await import('#config.js');
+
+    expect(config[name]).toBe(1);
+  });
+});
+
+describe('annotation config defaults', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('uses the documented annotation budget defaults', async () => {
+    vi.resetModules();
+
+    const {config} = await import('#config.js');
+
+    expect(config.ANNOTATIONS_MAX_BODY_BYTES).toBe(1048576);
+    expect(config.ANNOTATIONS_MAX_PER_EXECUTION).toBe(50);
+    expect(config.ANNOTATIONS_MAX_TOTAL_BYTES).toBe(4194304);
+  });
+});

--- a/libs/api/annotations/src/config.ts
+++ b/libs/api/annotations/src/config.ts
@@ -1,0 +1,26 @@
+import {createConfig, num} from '@shipfox/config';
+
+export const config = createConfig({
+  ANNOTATIONS_MAX_BODY_BYTES: num({
+    desc: 'Maximum UTF-8 byte size of one annotation body. Writes that would make an annotation body larger than this are rejected.',
+    default: 1048576,
+  }),
+  ANNOTATIONS_MAX_PER_EXECUTION: num({
+    desc: 'Maximum number of distinct annotation contexts one job execution may store.',
+    default: 50,
+  }),
+  ANNOTATIONS_MAX_TOTAL_BYTES: num({
+    desc: 'Maximum total UTF-8 bytes of annotation bodies one job execution may store.',
+    default: 4194304,
+  }),
+});
+
+for (const name of [
+  'ANNOTATIONS_MAX_BODY_BYTES',
+  'ANNOTATIONS_MAX_PER_EXECUTION',
+  'ANNOTATIONS_MAX_TOTAL_BYTES',
+] as const) {
+  if (!Number.isInteger(config[name]) || config[name] < 1) {
+    throw new Error(`${name} (${config[name]}) must be a whole number greater than 0.`);
+  }
+}

--- a/libs/api/annotations/src/core/errors.ts
+++ b/libs/api/annotations/src/core/errors.ts
@@ -1,0 +1,20 @@
+export class AnnotationBodyTooLargeError extends Error {
+  constructor(public readonly maxBytes: number) {
+    super(`Annotation body exceeds ${maxBytes} bytes`);
+    this.name = 'AnnotationBodyTooLargeError';
+  }
+}
+
+export class AnnotationCountLimitExceededError extends Error {
+  constructor(public readonly maxAnnotations: number) {
+    super(`Annotation count exceeds ${maxAnnotations}`);
+    this.name = 'AnnotationCountLimitExceededError';
+  }
+}
+
+export class AnnotationTotalBytesLimitExceededError extends Error {
+  constructor(public readonly maxBytes: number) {
+    super(`Annotation total body bytes exceed ${maxBytes}`);
+    this.name = 'AnnotationTotalBytesLimitExceededError';
+  }
+}

--- a/libs/api/annotations/src/core/write-annotations.test.ts
+++ b/libs/api/annotations/src/core/write-annotations.test.ts
@@ -1,0 +1,228 @@
+import {eq} from 'drizzle-orm';
+import {withAnnotationLock} from '#db/annotations.js';
+import {db} from '#db/db.js';
+import {annotations} from '#db/schema/annotations.js';
+import {annotationFactory} from '#test/index.js';
+import {
+  AnnotationBodyTooLargeError,
+  AnnotationCountLimitExceededError,
+  AnnotationTotalBytesLimitExceededError,
+} from './errors.js';
+import {type WriteAnnotationsParams, writeAnnotations} from './write-annotations.js';
+
+describe('writeAnnotations', () => {
+  let params: WriteAnnotationsParams;
+
+  beforeEach(() => {
+    params = {
+      workspaceId: crypto.randomUUID(),
+      projectId: crypto.randomUUID(),
+      workflowRunId: crypto.randomUUID(),
+      workflowRunAttemptId: crypto.randomUUID(),
+      jobId: crypto.randomUUID(),
+      jobExecutionId: crypto.randomUUID(),
+      originStepId: crypto.randomUUID(),
+      originStepAttempt: 1,
+      operations: [],
+    };
+  });
+
+  it('replaces by context and preserves sequence across updates', async () => {
+    const created = await writeAnnotations({
+      ...params,
+      operations: [{context: 'deploy', style: 'success', op: 'replace', body: 'first'}],
+    });
+
+    const updated = await writeAnnotations({
+      ...params,
+      originStepId: crypto.randomUUID(),
+      originStepAttempt: 2,
+      operations: [{context: 'deploy', style: 'warning', op: 'replace', body: 'second'}],
+    });
+
+    const rows = await db()
+      .select()
+      .from(annotations)
+      .where(eq(annotations.jobExecutionId, params.jobExecutionId));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: created.annotations[0]?.id,
+      context: 'deploy',
+      style: 'warning',
+      body: 'second',
+      sequence: 1,
+      originStepAttempt: 2,
+    });
+    expect(updated.annotations[0]?.id).toBe(created.annotations[0]?.id);
+    expect(updated.accounting).toEqual({annotationCount: 1, totalBodyBytes: 6});
+  });
+
+  it('appends to an existing context', async () => {
+    await annotationFactory.create({
+      ...params,
+      id: crypto.randomUUID(),
+      context: 'summary',
+      style: 'info',
+      body: 'hello',
+      bodyBytes: Buffer.byteLength('hello'),
+      sequence: 1,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const result = await writeAnnotations({
+      ...params,
+      operations: [{context: 'summary', style: 'info', op: 'append', body: ' world'}],
+    });
+
+    const rows = await db()
+      .select()
+      .from(annotations)
+      .where(eq(annotations.jobExecutionId, params.jobExecutionId));
+    expect(rows[0]).toMatchObject({context: 'summary', body: 'hello world', sequence: 1});
+    expect(result.accounting).toEqual({annotationCount: 1, totalBodyBytes: 11});
+  });
+
+  it('removes a context and returns null for the removed annotation id', async () => {
+    await annotationFactory.create({
+      ...params,
+      id: crypto.randomUUID(),
+      context: 'summary',
+      body: 'remove me',
+      bodyBytes: Buffer.byteLength('remove me'),
+      sequence: 1,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const result = await writeAnnotations({
+      ...params,
+      operations: [{context: 'summary', style: 'default', op: 'remove'}],
+    });
+
+    const rows = await db()
+      .select()
+      .from(annotations)
+      .where(eq(annotations.jobExecutionId, params.jobExecutionId));
+    expect(rows).toHaveLength(0);
+    expect(result).toEqual({
+      annotations: [{context: 'summary', id: null}],
+      accounting: {annotationCount: 0, totalBodyBytes: 0},
+    });
+  });
+
+  it('assigns sequence only on first create of a context', async () => {
+    const result = await writeAnnotations({
+      ...params,
+      operations: [
+        {context: 'first', style: 'default', op: 'replace', body: 'one'},
+        {context: 'second', style: 'default', op: 'replace', body: 'two'},
+        {context: 'first', style: 'default', op: 'append', body: ' more'},
+      ],
+    });
+
+    const rows = await db()
+      .select()
+      .from(annotations)
+      .where(eq(annotations.jobExecutionId, params.jobExecutionId));
+    expect(rows).toHaveLength(2);
+    expect(rows.find((row) => row.context === 'first')).toMatchObject({
+      body: 'one more',
+      sequence: 1,
+    });
+    expect(rows.find((row) => row.context === 'second')).toMatchObject({sequence: 2});
+    expect(result.accounting).toEqual({annotationCount: 2, totalBodyBytes: 11});
+  });
+
+  it('rejects an annotation body over the byte budget', async () => {
+    const body = 'x'.repeat(1048577);
+
+    const write = writeAnnotations({
+      ...params,
+      operations: [{context: 'huge', style: 'default', op: 'replace', body}],
+    });
+
+    await expect(write).rejects.toBeInstanceOf(AnnotationBodyTooLargeError);
+  });
+
+  it('rejects an execution over the annotation count budget', async () => {
+    const operations = Array.from({length: 51}, (_, index) => ({
+      context: `context-${index}`,
+      style: 'default' as const,
+      op: 'replace' as const,
+      body: 'x',
+    }));
+
+    const write = writeAnnotations({...params, operations});
+
+    await expect(write).rejects.toBeInstanceOf(AnnotationCountLimitExceededError);
+  });
+
+  it('rejects an execution over the total byte budget', async () => {
+    const operations = Array.from({length: 5}, (_, index) => ({
+      context: `context-${index}`,
+      style: 'default' as const,
+      op: 'replace' as const,
+      body: 'x'.repeat(900000),
+    }));
+
+    const write = writeAnnotations({...params, operations});
+
+    await expect(write).rejects.toBeInstanceOf(AnnotationTotalBytesLimitExceededError);
+  });
+
+  it('rolls back the whole request when one operation exceeds a budget', async () => {
+    const write = writeAnnotations({
+      ...params,
+      operations: [
+        {context: 'created-first', style: 'default', op: 'replace', body: 'ok'},
+        {
+          context: 'huge',
+          style: 'default',
+          op: 'replace',
+          body: 'x'.repeat(1048577),
+        },
+      ],
+    });
+
+    await expect(write).rejects.toBeInstanceOf(AnnotationBodyTooLargeError);
+
+    const rows = await db()
+      .select()
+      .from(annotations)
+      .where(eq(annotations.jobExecutionId, params.jobExecutionId));
+    expect(rows).toHaveLength(0);
+  });
+
+  it('waits for the per-execution advisory transaction lock before writing', async () => {
+    let releaseLock!: () => void;
+    const lockReleased = new Promise<void>((resolve) => {
+      releaseLock = resolve;
+    });
+    let lockAcquired!: () => void;
+    const lockReady = new Promise<void>((resolve) => {
+      lockAcquired = resolve;
+    });
+    const blocker = withAnnotationLock(params.jobExecutionId, async () => {
+      lockAcquired();
+      await lockReleased;
+    });
+    await lockReady;
+
+    const write = writeAnnotations({
+      ...params,
+      operations: [{context: 'blocked', style: 'default', op: 'replace', body: 'after'}],
+    });
+    const stateBeforeRelease = await Promise.race([
+      write.then(() => 'completed'),
+      new Promise<'blocked'>((resolve) => setTimeout(() => resolve('blocked'), 50)),
+    ]);
+    releaseLock();
+    await blocker;
+
+    const result = await write;
+
+    expect(stateBeforeRelease).toBe('blocked');
+    expect(result.accounting).toEqual({annotationCount: 1, totalBodyBytes: 5});
+  });
+});

--- a/libs/api/annotations/src/core/write-annotations.ts
+++ b/libs/api/annotations/src/core/write-annotations.ts
@@ -1,0 +1,130 @@
+import type {LeasedWriteAnnotationOperationDto} from '@shipfox/annotations-dto';
+import {config} from '#config.js';
+import {type StoredAnnotation, withAnnotationLock} from '#db/annotations.js';
+import {
+  AnnotationBodyTooLargeError,
+  AnnotationCountLimitExceededError,
+  AnnotationTotalBytesLimitExceededError,
+} from './errors.js';
+
+export interface WriteAnnotationsParams {
+  workspaceId: string;
+  projectId: string;
+  workflowRunId: string;
+  workflowRunAttemptId: string;
+  jobId: string;
+  jobExecutionId: string;
+  originStepId: string;
+  originStepAttempt: number;
+  operations: readonly LeasedWriteAnnotationOperationDto[];
+}
+
+export interface WriteAnnotationsResult {
+  annotations: Array<{context: string; id: string | null}>;
+  accounting: {
+    annotationCount: number;
+    totalBodyBytes: number;
+  };
+}
+
+export function writeAnnotations(params: WriteAnnotationsParams): Promise<WriteAnnotationsResult> {
+  return withAnnotationLock(params.jobExecutionId, async (repo) => {
+    const current = await repo.loadCurrentAnnotations(params.jobExecutionId);
+    let nextSequence =
+      Math.max(0, ...Array.from(current.values()).map((annotation) => annotation.sequence)) + 1;
+    const results: WriteAnnotationsResult['annotations'] = [];
+
+    for (const operation of params.operations) {
+      if (operation.op === 'remove') {
+        await repo.removeAnnotation(params.jobExecutionId, operation.context);
+        current.delete(operation.context);
+        results.push({context: operation.context, id: null});
+        continue;
+      }
+
+      const existing = current.get(operation.context);
+      const body =
+        operation.op === 'append' ? `${existing?.body ?? ''}${operation.body}` : operation.body;
+      const bodyBytes = Buffer.byteLength(body);
+      ensureBodyBudget(bodyBytes);
+
+      const draft = new Map(current);
+      draft.set(operation.context, {
+        id: existing?.id ?? '',
+        context: operation.context,
+        style: operation.style,
+        body,
+        bodyBytes,
+        sequence: existing?.sequence ?? nextSequence,
+      });
+      ensureExecutionBudgets(draft);
+
+      const row = existing
+        ? await repo.updateAnnotation({
+            id: existing.id,
+            originStepId: params.originStepId,
+            originStepAttempt: params.originStepAttempt,
+            style: operation.style,
+            body,
+            bodyBytes,
+          })
+        : await repo.createAnnotation({
+            workspaceId: params.workspaceId,
+            projectId: params.projectId,
+            workflowRunId: params.workflowRunId,
+            workflowRunAttemptId: params.workflowRunAttemptId,
+            jobId: params.jobId,
+            jobExecutionId: params.jobExecutionId,
+            originStepId: params.originStepId,
+            originStepAttempt: params.originStepAttempt,
+            context: operation.context,
+            style: operation.style,
+            body,
+            bodyBytes,
+            sequence: nextSequence,
+          });
+
+      current.set(operation.context, {
+        id: row.id,
+        context: row.context,
+        style: row.style,
+        body: row.body,
+        bodyBytes: row.bodyBytes,
+        sequence: row.sequence,
+      });
+      if (!existing) nextSequence += 1;
+      results.push({context: operation.context, id: row.id});
+    }
+
+    return {
+      annotations: results,
+      accounting: currentAccounting(current),
+    };
+  });
+}
+
+function ensureBodyBudget(bodyBytes: number): void {
+  if (bodyBytes > config.ANNOTATIONS_MAX_BODY_BYTES) {
+    throw new AnnotationBodyTooLargeError(config.ANNOTATIONS_MAX_BODY_BYTES);
+  }
+}
+
+function ensureExecutionBudgets(annotationsByContext: ReadonlyMap<string, StoredAnnotation>): void {
+  const accounting = currentAccounting(annotationsByContext);
+  if (accounting.annotationCount > config.ANNOTATIONS_MAX_PER_EXECUTION) {
+    throw new AnnotationCountLimitExceededError(config.ANNOTATIONS_MAX_PER_EXECUTION);
+  }
+  if (accounting.totalBodyBytes > config.ANNOTATIONS_MAX_TOTAL_BYTES) {
+    throw new AnnotationTotalBytesLimitExceededError(config.ANNOTATIONS_MAX_TOTAL_BYTES);
+  }
+}
+
+function currentAccounting(annotationsByContext: ReadonlyMap<string, StoredAnnotation>) {
+  return {
+    annotationCount: annotationsByContext.size,
+    totalBodyBytes: Array.from(annotationsByContext.values()).reduce(
+      (total, annotation) => total + annotation.bodyBytes,
+      0,
+    ),
+  };
+}

--- a/libs/api/annotations/src/db/annotations.ts
+++ b/libs/api/annotations/src/db/annotations.ts
@@ -1,0 +1,121 @@
+import type {AnnotationStyleDto} from '@shipfox/annotations-dto';
+import {and, eq, sql} from 'drizzle-orm';
+import {db} from './db.js';
+import {annotations} from './schema/annotations.js';
+
+export interface StoredAnnotation {
+  id: string;
+  context: string;
+  style: AnnotationStyleDto;
+  body: string;
+  bodyBytes: number;
+  sequence: number;
+}
+
+export interface CreateAnnotationParams {
+  workspaceId: string;
+  projectId: string;
+  workflowRunId: string;
+  workflowRunAttemptId: string;
+  jobId: string;
+  jobExecutionId: string;
+  originStepId: string;
+  originStepAttempt: number;
+  context: string;
+  style: AnnotationStyleDto;
+  body: string;
+  bodyBytes: number;
+  sequence: number;
+}
+
+export interface UpdateAnnotationParams {
+  id: string;
+  originStepId: string;
+  originStepAttempt: number;
+  style: AnnotationStyleDto;
+  body: string;
+  bodyBytes: number;
+}
+
+export interface AnnotationWriteRepository {
+  loadCurrentAnnotations(jobExecutionId: string): Promise<Map<string, StoredAnnotation>>;
+  removeAnnotation(jobExecutionId: string, context: string): Promise<void>;
+  createAnnotation(params: CreateAnnotationParams): Promise<StoredAnnotation>;
+  updateAnnotation(params: UpdateAnnotationParams): Promise<StoredAnnotation>;
+}
+
+export function withAnnotationLock<T>(
+  jobExecutionId: string,
+  work: (repo: AnnotationWriteRepository) => Promise<T>,
+): Promise<T> {
+  return db().transaction(async (tx) => {
+    await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${jobExecutionId}))`);
+
+    const repo: AnnotationWriteRepository = {
+      loadCurrentAnnotations: async (lockedJobExecutionId) => {
+        const rows = await tx
+          .select({
+            id: annotations.id,
+            context: annotations.context,
+            style: annotations.style,
+            body: annotations.body,
+            bodyBytes: annotations.bodyBytes,
+            sequence: annotations.sequence,
+          })
+          .from(annotations)
+          .where(eq(annotations.jobExecutionId, lockedJobExecutionId));
+
+        return new Map(rows.map((row) => [row.context, row]));
+      },
+      removeAnnotation: async (lockedJobExecutionId, context) => {
+        await tx
+          .delete(annotations)
+          .where(
+            and(
+              eq(annotations.jobExecutionId, lockedJobExecutionId),
+              eq(annotations.context, context),
+            ),
+          );
+      },
+      createAnnotation: async (params) => {
+        const [row] = await tx.insert(annotations).values(params).returning({
+          id: annotations.id,
+          context: annotations.context,
+          style: annotations.style,
+          body: annotations.body,
+          bodyBytes: annotations.bodyBytes,
+          sequence: annotations.sequence,
+        });
+
+        if (!row) throw new Error('createAnnotation: insert returned no row');
+        return row;
+      },
+      updateAnnotation: async (params) => {
+        const [row] = await tx
+          .update(annotations)
+          .set({
+            originStepId: params.originStepId,
+            originStepAttempt: params.originStepAttempt,
+            style: params.style,
+            body: params.body,
+            bodyBytes: params.bodyBytes,
+            updatedAt: new Date(),
+          })
+          .where(eq(annotations.id, params.id))
+          .returning({
+            id: annotations.id,
+            context: annotations.context,
+            style: annotations.style,
+            body: annotations.body,
+            bodyBytes: annotations.bodyBytes,
+            sequence: annotations.sequence,
+          });
+
+        if (!row) throw new Error('updateAnnotation: update returned no row');
+        return row;
+      },
+    };
+
+    return await work(repo);
+  });
+}

--- a/libs/api/annotations/src/index.ts
+++ b/libs/api/annotations/src/index.ts
@@ -1,8 +1,10 @@
 import type {ShipfoxModule} from '@shipfox/node-module';
 import {db} from '#db/db.js';
 import {migrationsPath} from '#db/index.js';
+import {annotationsRoutes} from '#presentation/routes/index.js';
 
 export const annotationsModule: ShipfoxModule = {
   name: 'annotations',
   database: {db, migrationsPath},
+  routes: annotationsRoutes,
 };

--- a/libs/api/annotations/src/presentation/routes/index.ts
+++ b/libs/api/annotations/src/presentation/routes/index.ts
@@ -1,1 +1,11 @@
-export const annotationsRoutes: [] = [];
+import {AUTH_LEASED_JOB} from '@shipfox/api-auth-context';
+import type {RouteGroup} from '@shipfox/node-fastify';
+import {writeAnnotationsRoute} from './write-annotations.js';
+
+export const annotationsRoutes: RouteGroup[] = [
+  {
+    prefix: '/runs/jobs/current',
+    auth: AUTH_LEASED_JOB,
+    routes: [writeAnnotationsRoute],
+  },
+];

--- a/libs/api/annotations/src/presentation/routes/write-annotations.test.ts
+++ b/libs/api/annotations/src/presentation/routes/write-annotations.test.ts
@@ -1,0 +1,185 @@
+import {createLeaseTokenAuthMethod} from '@shipfox/api-auth';
+import {closeApp, createApp, type FastifyInstance} from '@shipfox/node-fastify';
+import {eq} from 'drizzle-orm';
+import {db} from '#db/db.js';
+import {annotations} from '#db/schema/annotations.js';
+import {mintLeaseToken} from '#test/index.js';
+import {annotationsRoutes} from './index.js';
+
+function annotationsUrl(): string {
+  return '/runs/jobs/current/annotations';
+}
+
+function mintTestLeaseToken(params: {
+  jobId?: string;
+  jobExecutionId?: string;
+  stepId?: string;
+  attempt?: number;
+}): Promise<string> {
+  return mintLeaseToken({
+    jobId: params.jobId ?? crypto.randomUUID(),
+    jobExecutionId: params.jobExecutionId ?? crypto.randomUUID(),
+    ...(params.stepId
+      ? {currentStepId: params.stepId, currentStepAttempt: params.attempt ?? 1}
+      : {}),
+  });
+}
+
+describe('POST /runs/jobs/current/annotations', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = await createApp({
+      auth: [createLeaseTokenAuthMethod()],
+      routes: annotationsRoutes,
+      swagger: false,
+    });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await closeApp();
+  });
+
+  it('rejects a request without a lease token', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: annotationsUrl(),
+      payload: {step_id: crypto.randomUUID(), attempt: 1, annotations: []},
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json().code).toBe('unauthorized');
+  });
+
+  it('accepts a scoped lease and writes annotations from lease identity', async () => {
+    const stepId = crypto.randomUUID();
+    const jobId = crypto.randomUUID();
+    const jobExecutionId = crypto.randomUUID();
+    const token = await mintTestLeaseToken({jobId, jobExecutionId, stepId});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: annotationsUrl(),
+      headers: {authorization: `Bearer ${token}`},
+      payload: {
+        step_id: stepId,
+        attempt: 1,
+        annotations: [{context: 'deploy', style: 'success', op: 'replace', body: 'done'}],
+      },
+    });
+
+    const rows = await db()
+      .select()
+      .from(annotations)
+      .where(eq(annotations.jobExecutionId, jobExecutionId));
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      annotations: [{context: 'deploy', id: rows[0]?.id}],
+      accounting: {annotation_count: 1, total_body_bytes: 4},
+    });
+    expect(rows[0]).toMatchObject({
+      jobId,
+      originStepId: stepId,
+      originStepAttempt: 1,
+      context: 'deploy',
+      body: 'done',
+    });
+  });
+
+  it('rejects writes for a step outside the leased execution', async () => {
+    const token = await mintTestLeaseToken({stepId: crypto.randomUUID()});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: annotationsUrl(),
+      headers: {authorization: `Bearer ${token}`},
+      payload: {
+        step_id: crypto.randomUUID(),
+        attempt: 1,
+        annotations: [{context: 'deploy', body: 'wrong step'}],
+      },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().code).toBe('step-not-found');
+  });
+
+  it('rejects writes for a different attempt than the leased step scope', async () => {
+    const stepId = crypto.randomUUID();
+    const token = await mintTestLeaseToken({stepId, attempt: 1});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: annotationsUrl(),
+      headers: {authorization: `Bearer ${token}`},
+      payload: {
+        step_id: stepId,
+        attempt: 2,
+        annotations: [{context: 'deploy', body: 'wrong attempt'}],
+      },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().code).toBe('step-not-found');
+  });
+
+  it('rejects writes with a job-scoped lease token', async () => {
+    const token = await mintLeaseToken({
+      jobId: crypto.randomUUID(),
+      jobExecutionId: crypto.randomUUID(),
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: annotationsUrl(),
+      headers: {authorization: `Bearer ${token}`},
+      payload: {
+        step_id: crypto.randomUUID(),
+        attempt: 1,
+        annotations: [{context: 'deploy', body: 'job scoped'}],
+      },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().code).toBe('step-not-found');
+  });
+
+  it('accepts an empty operation list and returns current accounting', async () => {
+    const stepId = crypto.randomUUID();
+    const token = await mintTestLeaseToken({stepId});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: annotationsUrl(),
+      headers: {authorization: `Bearer ${token}`},
+      payload: {step_id: stepId, attempt: 1, annotations: []},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      annotations: [],
+      accounting: {annotation_count: 0, total_body_bytes: 0},
+    });
+  });
+
+  it('maps annotation count budget failures to a specific client code', async () => {
+    const stepId = crypto.randomUUID();
+    const token = await mintTestLeaseToken({stepId});
+    const operations = Array.from({length: 51}, (_, index) => ({
+      context: `context-${index}`,
+      op: 'replace',
+      body: 'x',
+    }));
+
+    const res = await app.inject({
+      method: 'POST',
+      url: annotationsUrl(),
+      headers: {authorization: `Bearer ${token}`},
+      payload: {step_id: stepId, attempt: 1, annotations: operations},
+    });
+
+    expect(res.statusCode).toBe(413);
+    expect(res.json().code).toBe('annotation-count-limit-exceeded');
+  });
+});

--- a/libs/api/annotations/src/presentation/routes/write-annotations.ts
+++ b/libs/api/annotations/src/presentation/routes/write-annotations.ts
@@ -1,0 +1,75 @@
+import {
+  leasedWriteAnnotationsBodySchema,
+  leasedWriteAnnotationsResponseSchema,
+} from '@shipfox/annotations-dto';
+import {requireLeasedJobContext} from '@shipfox/api-auth-context';
+import {ClientError, defineRoute} from '@shipfox/node-fastify';
+import {
+  AnnotationBodyTooLargeError,
+  AnnotationCountLimitExceededError,
+  AnnotationTotalBytesLimitExceededError,
+} from '#core/errors.js';
+import {writeAnnotations} from '#core/write-annotations.js';
+
+export const writeAnnotationsRoute = defineRoute({
+  method: 'POST',
+  path: '/annotations',
+  description: 'Creates, updates, or removes annotations for the current leased job execution.',
+  schema: {
+    body: leasedWriteAnnotationsBodySchema,
+    response: {
+      200: leasedWriteAnnotationsResponseSchema,
+    },
+  },
+  errorHandler: (error) => {
+    if (error instanceof AnnotationBodyTooLargeError) {
+      throw new ClientError(error.message, 'annotation-body-too-large', {
+        status: 413,
+        details: {max_body_bytes: error.maxBytes},
+      });
+    }
+    if (error instanceof AnnotationCountLimitExceededError) {
+      throw new ClientError(error.message, 'annotation-count-limit-exceeded', {
+        status: 413,
+        details: {max_annotations: error.maxAnnotations},
+      });
+    }
+    if (error instanceof AnnotationTotalBytesLimitExceededError) {
+      throw new ClientError(error.message, 'annotation-total-bytes-limit-exceeded', {
+        status: 413,
+        details: {max_total_body_bytes: error.maxBytes},
+      });
+    }
+    throw error;
+  },
+  handler: async (request) => {
+    const leasedJob = requireLeasedJobContext(request);
+    const {step_id: stepId, attempt, annotations} = request.body;
+
+    if (leasedJob.currentStepId !== stepId || leasedJob.currentStepAttempt !== attempt) {
+      throw new ClientError('Step not found for leased job execution', 'step-not-found', {
+        status: 404,
+      });
+    }
+
+    const result = await writeAnnotations({
+      workspaceId: leasedJob.workspaceId,
+      projectId: leasedJob.projectId,
+      workflowRunId: leasedJob.workflowRunId,
+      workflowRunAttemptId: leasedJob.workflowRunAttemptId,
+      jobId: leasedJob.jobId,
+      jobExecutionId: leasedJob.jobExecutionId,
+      originStepId: stepId,
+      originStepAttempt: attempt,
+      operations: annotations,
+    });
+
+    return {
+      annotations: result.annotations,
+      accounting: {
+        annotation_count: result.accounting.annotationCount,
+        total_body_bytes: result.accounting.totalBodyBytes,
+      },
+    };
+  },
+});

--- a/libs/api/annotations/test/env.ts
+++ b/libs/api/annotations/test/env.ts
@@ -1,2 +1,5 @@
 process.env.DATABASE_URL ??= 'postgres://shipfox:shipfox@127.0.0.1:5432/api_test';
+process.env.AUTH_JWT_SECRET = 'test-jwt-secret';
+process.env.AUTH_JOB_LEASE_TOKEN_SECRET = 'test-lease-secret';
+process.env.AUTH_RUNNER_SESSION_TOKEN_SECRET = 'test-runner-session-secret';
 process.env.TZ = 'UTC';

--- a/libs/api/annotations/test/fixtures/lease-token.ts
+++ b/libs/api/annotations/test/fixtures/lease-token.ts
@@ -1,0 +1,41 @@
+import {JOB_LEASE_TOKEN_AUDIENCE} from '@shipfox/api-auth-dto';
+import {signHs256} from '@shipfox/node-jwt';
+
+const SECRET = process.env.AUTH_JOB_LEASE_TOKEN_SECRET ?? 'test-lease-secret';
+
+export interface MintLeaseTokenParams {
+  jobId: string;
+  jobExecutionId: string;
+  workspaceId?: string;
+  projectId?: string;
+  workflowRunId?: string;
+  workflowRunAttemptId?: string;
+  currentStepId?: string;
+  currentStepAttempt?: number;
+  secret?: string;
+  expiresIn?: string;
+  audience?: string;
+}
+
+export function mintLeaseToken(params: MintLeaseTokenParams): Promise<string> {
+  return signHs256({
+    payload: {
+      jobId: params.jobId,
+      jobExecutionId: params.jobExecutionId,
+      workflowRunId: params.workflowRunId ?? crypto.randomUUID(),
+      workflowRunAttemptId: params.workflowRunAttemptId ?? crypto.randomUUID(),
+      projectId: params.projectId ?? crypto.randomUUID(),
+      workspaceId: params.workspaceId ?? crypto.randomUUID(),
+      runnerSessionId: crypto.randomUUID(),
+      ...(params.currentStepId && params.currentStepAttempt !== undefined
+        ? {
+            currentStepId: params.currentStepId,
+            currentStepAttempt: params.currentStepAttempt,
+          }
+        : {}),
+    },
+    secret: params.secret ?? SECRET,
+    expiresIn: params.expiresIn ?? '90m',
+    audience: params.audience ?? JOB_LEASE_TOKEN_AUDIENCE,
+  });
+}

--- a/libs/api/annotations/test/index.ts
+++ b/libs/api/annotations/test/index.ts
@@ -1,1 +1,2 @@
 export {annotationFactory} from './factories/annotation.js';
+export {mintLeaseToken} from './fixtures/lease-token.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1231,9 +1231,18 @@ importers:
       '@shipfox/annotations-dto':
         specifier: workspace:*
         version: link:../annotations-dto
+      '@shipfox/api-auth-context':
+        specifier: workspace:*
+        version: link:../auth-context
+      '@shipfox/config':
+        specifier: workspace:*
+        version: link:../../shared/common/config
       '@shipfox/node-drizzle':
         specifier: workspace:*
         version: link:../../shared/node/drizzle
+      '@shipfox/node-fastify':
+        specifier: workspace:*
+        version: link:../../shared/node/fastify
       '@shipfox/node-module':
         specifier: workspace:*
         version: link:../../shared/node/module
@@ -1244,9 +1253,18 @@ importers:
         specifier: ^0.45.2
         version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
     devDependencies:
+      '@shipfox/api-auth':
+        specifier: workspace:*
+        version: link:../auth
+      '@shipfox/api-auth-dto':
+        specifier: workspace:*
+        version: link:../auth-dto
       '@shipfox/biome':
         specifier: workspace:*
         version: link:../../../tools/biome
+      '@shipfox/node-jwt':
+        specifier: workspace:*
+        version: link:../../shared/node/jwt
       '@shipfox/swc':
         specifier: workspace:*
         version: link:../../../tools/swc


### PR DESCRIPTION
Adds the lease-authenticated annotations write route used by runners to create, update, append, and remove annotations for the current job execution.

The route treats the job lease as authoritative and does not read workflows job-execution state. To keep writes deterministic without cross-module coupling, the annotations module serializes writes per job execution with a transaction-scoped advisory lock, applies request operations all-or-nothing, and enforces per-body, per-execution count, and total-byte budgets with specific client errors.

I also updated the Linear issue and added a spec amendment comment to the canonical annotations design doc to reflect the no-terminal-gate requirement.

Validation run locally: changed-package build, test, and check; annotations package test, type, type:emit, build, and check.

Closes ENG-865

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a lease-authenticated annotations write route for runners. Supports replace, append, and remove with atomic, deterministic writes for the current job execution, meeting ENG-865 with a leased write path and no terminal gate.

- **New Features**
  - Route: POST `/runs/jobs/current/annotations` with `AUTH_LEASED_JOB`; scope enforced by `step_id` and `attempt` from the lease; mismatches return 404 `step-not-found`.
  - Writes: replace/append/remove per context; all-or-nothing transaction; per-execution advisory lock; `sequence` set on first create and preserved.
  - Budgets: per-body, per-execution count, and total bytes; defaults `1048576`, `50`, `4194304`; validated at startup; 413 errors with codes `annotation-body-too-large`, `annotation-count-limit-exceeded`, `annotation-total-bytes-limit-exceeded`.
  - Lease is the source of truth (no workflow state reads). Response returns annotation ids and accounting.

- **Dependencies**
  - Runtime: `@shipfox/api-auth-context`, `@shipfox/node-fastify`, `@shipfox/config`.
  - Dev: `@shipfox/api-auth`, `@shipfox/api-auth-dto`, `@shipfox/node-jwt`.

<sup>Written for commit 51bb63a03d08378bc14f13088d6230b3a9428194. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

