### PR TITLE
[api/workflows] Extract workflow run graph persistence

### DIFF
--- a/libs/api/workflows/src/db/workflow-runs/run-create.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-create.ts
@@ -4,7 +4,6 @@ import {
 } from '@shipfox/api-agent/core/resolve-agent-config';
 import type {WorkflowModel} from '@shipfox/api-definitions';
 import {getVariablesByNamespace} from '@shipfox/api-secrets';
-import {WORKFLOWS_WORKFLOW_RUN_ATTEMPT_CREATED} from '@shipfox/api-workflows-dto';
 import {analyzeContextKeyAccess, type ResolvedFieldSegment} from '@shipfox/expression';
 import {logger} from '@shipfox/node-opentelemetry';
 import {eq} from 'drizzle-orm';
@@ -27,12 +26,9 @@ import {resolveJobExecutionName} from '#core/step-config/resolve-job-execution-n
 import type {WorkflowStepTemplateDiagnostic} from '#core/step-config/resolve-step-config.js';
 import {recordWorkflowRunCreated} from '#metrics/instance.js';
 import {db} from '../db.js';
-import {writeWorkflowsOutboxEvent} from '../outbox-writes.js';
-import {jobExecutions} from '../schema/job-executions.js';
-import {jobs} from '../schema/jobs.js';
-import {steps} from '../schema/steps.js';
 import {workflowRunAttempts} from '../schema/workflow-run-attempts.js';
 import {toWorkflowRun, workflowRuns} from '../schema/workflow-runs.js';
+import {type MaterializedRunGraphJob, persistMaterializedRunGraph} from './run-graph.js';
 
 export type WorkflowModelJob = WorkflowModel['jobs'][number];
 
@@ -134,139 +130,16 @@ export async function createWorkflowRun(params: CreateWorkflowRunParams): Promis
       definitionId: params.definitionId,
     });
 
-    let jobRows: (typeof jobs.$inferSelect)[] = [];
-
-    if (materializedJobs.length > 0) {
-      jobRows = await tx
-        .insert(jobs)
-        .values(
-          materializedJobs.map((job) => ({
-            workflowRunAttemptId: attemptRow.id,
-            key: job.key,
-            mode: job.mode,
-            name: workflowTemplateSource(job.name),
-            status: 'pending' as const,
-            checkoutPersistCredentials: job.checkout.persistCredentials,
-            checkoutPermissionsContents: job.checkout.permissions.contents,
-            success: job.success ?? null,
-            executionTimeoutMs: job.executionTimeoutMs ?? null,
-            listeningTimeoutMs: job.listening?.timeoutMs ?? null,
-            maxExecutions: job.listening?.maxExecutions ?? null,
-            onResolve: job.listening?.onResolve ?? null,
-            batchDebounceMs: job.listening?.batch?.debounceMs ?? null,
-            batchMaxSize: job.listening?.batch?.maxSize ?? null,
-            batchMaxWaitMs: job.listening?.batch?.maxWaitMs ?? null,
-            listeningOn: job.listening?.on ? [...job.listening.on] : null,
-            listeningUntil: job.listening?.until ? [...job.listening.until] : null,
-            dependencies: [...job.dependencies],
-            runner: job.runner.length === 0 ? null : [...job.runner],
-            position: job.position,
-          })),
-        )
-        .returning();
-    }
-
-    const jobExecutionValues = jobRows.flatMap((jobRow, jobIndex) => {
-      if (jobRow.mode === 'listening') return [];
-      const job = materializedJobs[jobIndex];
-      if (!job) return [];
-
-      const fallbackName = `${jobRow.key} #1`;
-      const context = assembleExecutionCreationContext({
-        run,
-        triggerPayload: params.triggerPayload,
-        inputs: params.inputs ?? null,
-        vars,
-        jobId: jobRow.id,
-        sequence: 1,
-        executionName: fallbackName,
-        status: 'pending',
-        triggerEvents: [],
-        priorExecutions: [],
-      });
-      const resolvedName = resolveJobExecutionName({
-        definitionId: params.definitionId,
-        job,
-        fallbackName,
-        context: context.values,
-      });
-      const modelJob = params.model.jobs[jobIndex];
-      if (!modelJob) return [];
-      const runnerContext = assembleExecutionCreationContext({
-        run,
-        triggerPayload: params.triggerPayload,
-        inputs: params.inputs ?? null,
-        vars,
-        jobId: jobRow.id,
-        sequence: 1,
-        executionName: resolvedName.value,
-        status: 'pending',
-        triggerEvents: [],
-        priorExecutions: [],
-      });
-      const runner = materializeJobRunner({
-        job: modelJob,
-        context: runnerContext,
-        definitionId: params.definitionId,
-      });
-
-      return [
-        {
-          jobId: jobRow.id,
-          sequence: 1,
-          name: resolvedName.value,
-          runner: [...runner],
-          status: 'pending' as const,
-          evaluationTrace: resolvedName.trace.length === 0 ? null : resolvedName.trace,
-        },
-      ];
+    const graphJobs = materializeRunGraphJobs({
+      params,
+      run,
+      vars,
+      materializedJobs,
     });
-    const jobExecutionRows =
-      jobExecutionValues.length === 0
-        ? []
-        : await tx.insert(jobExecutions).values(jobExecutionValues).returning();
-
-    const jobExecutionByJobId = new Map(
-      jobExecutionRows.map((jobExecution) => [jobExecution.jobId, jobExecution]),
-    );
-
-    const stepValues: (typeof steps.$inferInsert)[] = [];
-    for (const [jobIndex, jobRow] of jobRows.entries()) {
-      const job = materializedJobs[jobIndex];
-      const jobExecution = jobExecutionByJobId.get(jobRow.id);
-      if (!jobExecution) continue;
-      if (!job) continue;
-      for (const step of job.steps) {
-        stepValues.push({
-          jobExecutionId: jobExecution.id,
-          key: step.key,
-          name: step.name,
-          sourceLocation: step.sourceLocation,
-          status: step.status,
-          type: step.type,
-          config: step.config,
-          condition: step.condition ?? null,
-          configPlan: step.configPlan ?? null,
-          authoredConfig: step.authoredConfig,
-          position: step.position,
-        });
-      }
-    }
-
-    if (stepValues.length > 0) {
-      await tx.insert(steps).values(stepValues);
-    }
-
-    await writeWorkflowsOutboxEvent(tx, {
-      type: WORKFLOWS_WORKFLOW_RUN_ATTEMPT_CREATED,
-      payload: {
-        workflowRunId: runRow.id,
-        workflowRunAttemptId: attemptRow.id,
-        attempt: attemptRow.attempt,
-        workspaceId: runRow.workspaceId,
-        projectId: runRow.projectId,
-        definitionId: runRow.definitionId,
-      },
+    await persistMaterializedRunGraph(tx, {
+      run,
+      workflowRunAttempt: attemptRow,
+      materializedJobs: graphJobs,
     });
 
     logTemplateDiagnostics({
@@ -318,6 +191,101 @@ export async function loadReferencedVariables(params: {
   }
 
   return vars;
+}
+
+function materializeRunGraphJobs(params: {
+  readonly params: CreateWorkflowRunParams;
+  readonly run: WorkflowRun;
+  readonly vars: Record<string, string> | undefined;
+  readonly materializedJobs: readonly MaterializedWorkflowJob[];
+}): readonly MaterializedRunGraphJob[] {
+  return params.materializedJobs.map((job, jobIndex) => ({
+    job: {
+      key: job.key,
+      mode: job.mode,
+      name: workflowTemplateSource(job.name),
+      status: 'pending' as const,
+      checkoutPersistCredentials: job.checkout.persistCredentials,
+      checkoutPermissionsContents: job.checkout.permissions.contents,
+      success: job.success ?? null,
+      executionTimeoutMs: job.executionTimeoutMs ?? null,
+      listeningTimeoutMs: job.listening?.timeoutMs ?? null,
+      maxExecutions: job.listening?.maxExecutions ?? null,
+      onResolve: job.listening?.onResolve ?? null,
+      batchDebounceMs: job.listening?.batch?.debounceMs ?? null,
+      batchMaxSize: job.listening?.batch?.maxSize ?? null,
+      batchMaxWaitMs: job.listening?.batch?.maxWaitMs ?? null,
+      listeningOn: job.listening?.on ? [...job.listening.on] : null,
+      listeningUntil: job.listening?.until ? [...job.listening.until] : null,
+      dependencies: [...job.dependencies],
+      runner: job.runner.length === 0 ? null : [...job.runner],
+      position: job.position,
+    },
+    createExecution: (jobRow) => {
+      if (jobRow.mode === 'listening') return undefined;
+
+      const fallbackName = `${jobRow.key} #1`;
+      const context = assembleExecutionCreationContext({
+        run: params.run,
+        triggerPayload: params.params.triggerPayload,
+        inputs: params.params.inputs ?? null,
+        vars: params.vars,
+        jobId: jobRow.id,
+        sequence: 1,
+        executionName: fallbackName,
+        status: 'pending',
+        triggerEvents: [],
+        priorExecutions: [],
+      });
+      const resolvedName = resolveJobExecutionName({
+        definitionId: params.params.definitionId,
+        job,
+        fallbackName,
+        context: context.values,
+      });
+      const modelJob = params.params.model.jobs[jobIndex];
+      if (!modelJob) return undefined;
+
+      const runnerContext = assembleExecutionCreationContext({
+        run: params.run,
+        triggerPayload: params.params.triggerPayload,
+        inputs: params.params.inputs ?? null,
+        vars: params.vars,
+        jobId: jobRow.id,
+        sequence: 1,
+        executionName: resolvedName.value,
+        status: 'pending',
+        triggerEvents: [],
+        priorExecutions: [],
+      });
+      const runner = materializeJobRunner({
+        job: modelJob,
+        context: runnerContext,
+        definitionId: params.params.definitionId,
+      });
+
+      return {
+        sequence: 1,
+        name: resolvedName.value,
+        runner: [...runner],
+        status: 'pending' as const,
+        evaluationTrace: resolvedName.trace.length === 0 ? null : resolvedName.trace,
+      };
+    },
+    createSteps: () =>
+      job.steps.map((step) => ({
+        key: step.key,
+        name: step.name,
+        sourceLocation: step.sourceLocation,
+        status: step.status,
+        type: step.type,
+        config: step.config,
+        condition: step.condition ?? null,
+        configPlan: step.configPlan ?? null,
+        authoredConfig: step.authoredConfig,
+        position: step.position,
+      })),
+  }));
 }
 
 function referencedVariables(

--- a/libs/api/workflows/src/db/workflow-runs/run-graph.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-graph.ts
@@ -1,0 +1,95 @@
+import {WORKFLOWS_WORKFLOW_RUN_ATTEMPT_CREATED} from '@shipfox/api-workflows-dto';
+import type {SQL} from 'drizzle-orm';
+import type {WorkflowRun} from '#core/entities/workflow-run.js';
+import type {Tx} from '../db.js';
+import {writeWorkflowsOutboxEvent} from '../outbox-writes.js';
+import {
+  type JobExecutionCreateDb,
+  type JobExecutionDb,
+  jobExecutions,
+} from '../schema/job-executions.js';
+import {type JobCreateDb, type JobDb, jobs} from '../schema/jobs.js';
+import {type StepCreateDb, steps} from '../schema/steps.js';
+
+type MaterializedRunGraphJobExecution = Omit<JobExecutionCreateDb, 'finishedAt' | 'jobId'> & {
+  readonly finishedAt?: JobExecutionCreateDb['finishedAt'] | SQL | undefined;
+};
+
+export interface MaterializedRunGraphJob {
+  readonly job: Omit<JobCreateDb, 'workflowRunAttemptId'>;
+  readonly createExecution?:
+    | ((job: JobDb) => MaterializedRunGraphJobExecution | undefined)
+    | undefined;
+  readonly createSteps?:
+    | ((params: {
+        readonly job: JobDb;
+        readonly jobExecution: JobExecutionDb;
+      }) => readonly Omit<StepCreateDb, 'jobExecutionId'>[])
+    | undefined;
+}
+
+export async function persistMaterializedRunGraph(
+  tx: Tx,
+  params: {
+    readonly run: Pick<WorkflowRun, 'id' | 'workspaceId' | 'projectId' | 'definitionId'>;
+    readonly workflowRunAttempt: {readonly id: string; readonly attempt: number};
+    readonly materializedJobs: readonly MaterializedRunGraphJob[];
+  },
+): Promise<void> {
+  const jobRows =
+    params.materializedJobs.length === 0
+      ? []
+      : await tx
+          .insert(jobs)
+          .values(
+            params.materializedJobs.map((materializedJob) => ({
+              ...materializedJob.job,
+              workflowRunAttemptId: params.workflowRunAttempt.id,
+            })),
+          )
+          .returning();
+
+  const jobExecutionValues = jobRows.flatMap((jobRow, jobIndex) => {
+    const materializedJob = params.materializedJobs[jobIndex];
+    const jobExecution = materializedJob?.createExecution?.(jobRow);
+    return jobExecution === undefined ? [] : [{...jobExecution, jobId: jobRow.id}];
+  });
+  const jobExecutionRows =
+    jobExecutionValues.length === 0
+      ? []
+      : await tx.insert(jobExecutions).values(jobExecutionValues).returning();
+
+  const jobById = new Map(jobRows.map((job) => [job.id, job]));
+  const materializedJobByJobId = new Map(
+    jobRows.flatMap((jobRow, index) => {
+      const materializedJob = params.materializedJobs[index];
+      return materializedJob === undefined ? [] : [[jobRow.id, materializedJob] as const];
+    }),
+  );
+  const stepValues = jobExecutionRows.flatMap((jobExecution) => {
+    const job = jobById.get(jobExecution.jobId);
+    const materializedJob = materializedJobByJobId.get(jobExecution.jobId);
+    if (!job || !materializedJob) return [];
+
+    return (materializedJob.createSteps?.({job, jobExecution}) ?? []).map((step) => ({
+      ...step,
+      jobExecutionId: jobExecution.id,
+    }));
+  });
+
+  if (stepValues.length > 0) {
+    await tx.insert(steps).values(stepValues);
+  }
+
+  await writeWorkflowsOutboxEvent(tx, {
+    type: WORKFLOWS_WORKFLOW_RUN_ATTEMPT_CREATED,
+    payload: {
+      workflowRunId: params.run.id,
+      workflowRunAttemptId: params.workflowRunAttempt.id,
+      attempt: params.workflowRunAttempt.attempt,
+      workspaceId: params.run.workspaceId,
+      projectId: params.run.projectId,
+      definitionId: params.run.definitionId,
+    },
+  });
+}

--- a/libs/api/workflows/src/db/workflow-runs/run-rerun.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-rerun.ts
@@ -1,17 +1,16 @@
-import {WORKFLOWS_WORKFLOW_RUN_ATTEMPT_CREATED} from '@shipfox/api-workflows-dto';
 import {and, asc, eq, inArray, sql} from 'drizzle-orm';
 import {isWorkflowRunTerminal, type WorkflowRun} from '#core/entities/workflow-run.js';
 import {NoFailedJobsError, RunNotTerminalError, SourceRunNotFoundError} from '#core/errors.js';
 import {assembleExecutionCreationContext} from '#core/step-config/assemble-run-context.js';
 import {materializeJobRunner} from '#core/step-config/materialize-workflow-model.js';
 import {recordWorkflowRunCreated} from '#metrics/instance.js';
-import {db} from '../db.js';
-import {writeWorkflowsOutboxEvent} from '../outbox-writes.js';
-import {jobExecutions} from '../schema/job-executions.js';
-import {jobs} from '../schema/jobs.js';
-import {steps} from '../schema/steps.js';
-import {workflowRunAttempts} from '../schema/workflow-run-attempts.js';
+import {db, type Tx} from '../db.js';
+import {type JobExecutionDb, jobExecutions} from '../schema/job-executions.js';
+import {type JobDb, jobs} from '../schema/jobs.js';
+import {type StepDb, steps} from '../schema/steps.js';
+import {type WorkflowRunAttemptDb, workflowRunAttempts} from '../schema/workflow-run-attempts.js';
 import {toWorkflowRun, workflowRuns} from '../schema/workflow-runs.js';
+import {type MaterializedRunGraphJob, persistMaterializedRunGraph} from './run-graph.js';
 import {lockWorkflowRun} from './shared.js';
 
 export interface CreateRerunWorkflowRunParams {
@@ -82,163 +81,21 @@ export async function createRerunWorkflowRun(
       .returning();
     if (!newAttemptRow) throw new Error('Insert returned no rows');
 
-    const sourceJobIds = sourceJobs.map((job) => job.id);
-    const sourceJobExecutionRows =
-      sourceJobIds.length === 0
-        ? []
-        : await tx
-            .select()
-            .from(jobExecutions)
-            .where(inArray(jobExecutions.jobId, sourceJobIds))
-            .orderBy(asc(jobExecutions.jobId), asc(jobExecutions.sequence), asc(jobExecutions.id));
-    const sourceJobExecutionByJobId = new Map<string, (typeof sourceJobExecutionRows)[number]>();
-    for (const jobExecution of sourceJobExecutionRows) {
-      if (!sourceJobExecutionByJobId.has(jobExecution.jobId)) {
-        sourceJobExecutionByJobId.set(jobExecution.jobId, jobExecution);
-      }
-    }
-    const sourceJobExecutionIds = [...sourceJobExecutionByJobId.values()].map(
-      (jobExecution) => jobExecution.id,
-    );
-    const sourceSteps =
-      sourceJobExecutionIds.length === 0
-        ? []
-        : await tx
-            .select()
-            .from(steps)
-            .where(inArray(steps.jobExecutionId, sourceJobExecutionIds))
-            .orderBy(asc(steps.jobExecutionId), asc(steps.position), asc(steps.id));
+    const sourceGraph = await loadRerunSourceGraph(tx, sourceJobs);
 
-    const clonedJobRows =
-      sourceJobs.length === 0
-        ? []
-        : await tx
-            .insert(jobs)
-            .values(
-              sourceJobs.map((job) => {
-                const carriedOver = params.mode === 'failed' && job.status === 'succeeded';
-                return {
-                  workflowRunAttemptId: newAttemptRow.id,
-                  key: job.key,
-                  name: job.name,
-                  mode: job.mode,
-                  status: carriedOver ? ('succeeded' as const) : ('pending' as const),
-                  statusReason: null,
-                  carriedOver,
-                  checkoutPersistCredentials: job.checkoutPersistCredentials,
-                  checkoutPermissionsContents: job.checkoutPermissionsContents,
-                  success: job.success,
-                  executionTimeoutMs: job.executionTimeoutMs,
-                  listeningTimeoutMs: job.listeningTimeoutMs,
-                  maxExecutions: job.maxExecutions,
-                  onResolve: job.onResolve,
-                  batchDebounceMs: job.batchDebounceMs,
-                  batchMaxSize: job.batchMaxSize,
-                  batchMaxWaitMs: job.batchMaxWaitMs,
-                  listenerStatus: 'inactive' as const,
-                  resolutionReason: null,
-                  listeningOn: job.listeningOn ? [...job.listeningOn] : null,
-                  listeningUntil: job.listeningUntil ? [...job.listeningUntil] : null,
-                  outputs: carriedOver && job.outputs ? {...job.outputs} : null,
-                  dependencies: [...job.dependencies],
-                  runner: job.runner ? [...job.runner] : null,
-                  position: job.position,
-                };
-              }),
-            )
-            .returning();
-
-    const sourceJobByPosition = new Map(sourceJobs.map((job) => [job.position, job]));
-    const sourceModelJobByKey = new Map(
-      (sourceAttemptRow.model?.jobs ?? []).map((job) => [job.key, job]),
-    );
-    const clonedJobExecutionValues = clonedJobRows.flatMap((job) => {
-      const carriedOver = params.mode === 'failed' && job.status === 'succeeded';
-      const sourceJob = sourceJobByPosition.get(job.position);
-      const sourceExecution = sourceJob ? sourceJobExecutionByJobId.get(sourceJob.id) : undefined;
-      const modelJob = sourceModelJobByKey.get(job.key);
-      const executionName = sourceExecution?.name ?? `${job.key} #1`;
-      const runner =
-        carriedOver || modelJob === undefined
-          ? (sourceExecution?.runner ?? job.runner ?? null)
-          : materializeJobRunner({
-              job: modelJob,
-              context: assembleExecutionCreationContext({
-                run: toWorkflowRun(sourceRow),
-                triggerPayload: sourceRow.triggerPayload,
-                inputs: sourceRow.inputs,
-                jobId: job.id,
-                sequence: 1,
-                executionName,
-                status: 'pending',
-                triggerEvents: [],
-                priorExecutions: [],
-              }),
-              definitionId: sourceRow.definitionId,
-            });
-      return job.mode === 'listening'
-        ? []
-        : [
-            {
-              jobId: job.id,
-              sequence: 1,
-              name: executionName,
-              runner: runner ? [...runner] : null,
-              status: carriedOver ? ('succeeded' as const) : ('pending' as const),
-              statusReason: null,
-              outputs:
-                carriedOver && sourceExecution?.outputs ? {...sourceExecution.outputs} : null,
-              ...(carriedOver ? {finishedAt: sql`now()`} : {}),
-            },
-          ];
+    const sourceRun = toWorkflowRun(sourceRow);
+    const graphJobs = materializeRerunGraphJobs({
+      mode: params.mode,
+      sourceRun,
+      sourceAttempt: sourceAttemptRow,
+      sourceJobs,
+      ...sourceGraph,
     });
-    const clonedJobExecutionRows =
-      clonedJobExecutionValues.length === 0
-        ? []
-        : await tx.insert(jobExecutions).values(clonedJobExecutionValues).returning();
-
-    const sourceJobById = new Map(sourceJobs.map((job) => [job.id, job]));
-    const sourceJobByJobExecutionId = new Map(
-      [...sourceJobExecutionByJobId.entries()].flatMap(([jobId, jobExecution]) => {
-        const job = sourceJobById.get(jobId);
-        return job ? [[jobExecution.id, job] as const] : [];
-      }),
-    );
-    const clonedJobByPosition = new Map(clonedJobRows.map((job) => [job.position, job]));
-    const clonedJobExecutionByJobId = new Map(
-      clonedJobExecutionRows.map((jobExecution) => [jobExecution.jobId, jobExecution]),
-    );
-    const stepValues = sourceSteps.flatMap((step) => {
-      const sourceJob = sourceJobByJobExecutionId.get(step.jobExecutionId);
-      if (!sourceJob) return [];
-      const clonedJob = clonedJobByPosition.get(sourceJob.position);
-      if (!clonedJob) return [];
-      const clonedJobExecution = clonedJobExecutionByJobId.get(clonedJob.id);
-      if (!clonedJobExecution) return [];
-      const carriedOver = params.mode === 'failed' && sourceJob.status === 'succeeded';
-      return [
-        {
-          jobExecutionId: clonedJobExecution.id,
-          key: step.key,
-          name: step.name,
-          sourceLocation: step.sourceLocation,
-          status: carriedOver ? step.status : ('pending' as const),
-          statusReason: carriedOver ? step.statusReason : null,
-          type: step.type,
-          config: step.config,
-          condition: step.condition ?? null,
-          configPlan: step.configPlan,
-          authoredConfig: step.authoredConfig,
-          error: null,
-          position: step.position,
-          currentAttempt: 1,
-        },
-      ];
+    await persistMaterializedRunGraph(tx, {
+      run: sourceRun,
+      workflowRunAttempt: newAttemptRow,
+      materializedJobs: graphJobs,
     });
-
-    if (stepValues.length > 0) {
-      await tx.insert(steps).values(stepValues);
-    }
 
     const [newRunRow] = await tx
       .update(workflowRuns)
@@ -254,22 +111,163 @@ export async function createRerunWorkflowRun(
       .returning();
     if (!newRunRow) throw new Error(`Workflow run missing after rerun: ${sourceRow.id}`);
 
-    await writeWorkflowsOutboxEvent(tx, {
-      type: WORKFLOWS_WORKFLOW_RUN_ATTEMPT_CREATED,
-      payload: {
-        workflowRunId: newRunRow.id,
-        workflowRunAttemptId: newAttemptRow.id,
-        attempt: newAttemptRow.attempt,
-        workspaceId: newRunRow.workspaceId,
-        projectId: newRunRow.projectId,
-        definitionId: newRunRow.definitionId,
-      },
-    });
-
     return toWorkflowRun(newRunRow);
   });
 
   recordWorkflowRunCreated(result.triggerPayload.provider ?? result.triggerSource);
 
   return result;
+}
+
+async function loadRerunSourceGraph(
+  tx: Tx,
+  sourceJobs: readonly JobDb[],
+): Promise<{
+  readonly sourceJobExecutionByJobId: ReadonlyMap<string, JobExecutionDb>;
+  readonly sourceJobByJobExecutionId: ReadonlyMap<string, JobDb>;
+  readonly sourceSteps: readonly StepDb[];
+}> {
+  const sourceJobIds = sourceJobs.map((job) => job.id);
+  const sourceJobExecutionRows =
+    sourceJobIds.length === 0
+      ? []
+      : await tx
+          .select()
+          .from(jobExecutions)
+          .where(inArray(jobExecutions.jobId, sourceJobIds))
+          .orderBy(asc(jobExecutions.jobId), asc(jobExecutions.sequence), asc(jobExecutions.id));
+  const sourceJobExecutionByJobId = new Map<string, JobExecutionDb>();
+  for (const jobExecution of sourceJobExecutionRows) {
+    if (!sourceJobExecutionByJobId.has(jobExecution.jobId)) {
+      sourceJobExecutionByJobId.set(jobExecution.jobId, jobExecution);
+    }
+  }
+
+  const sourceJobExecutionIds = [...sourceJobExecutionByJobId.values()].map(
+    (jobExecution) => jobExecution.id,
+  );
+  const sourceSteps =
+    sourceJobExecutionIds.length === 0
+      ? []
+      : await tx
+          .select()
+          .from(steps)
+          .where(inArray(steps.jobExecutionId, sourceJobExecutionIds))
+          .orderBy(asc(steps.jobExecutionId), asc(steps.position), asc(steps.id));
+
+  const sourceJobById = new Map(sourceJobs.map((job) => [job.id, job]));
+  const sourceJobByJobExecutionId = new Map(
+    [...sourceJobExecutionByJobId.entries()].flatMap(([jobId, jobExecution]) => {
+      const job = sourceJobById.get(jobId);
+      return job ? [[jobExecution.id, job] as const] : [];
+    }),
+  );
+
+  return {sourceJobExecutionByJobId, sourceJobByJobExecutionId, sourceSteps};
+}
+
+function materializeRerunGraphJobs(params: {
+  readonly mode: CreateRerunWorkflowRunParams['mode'];
+  readonly sourceRun: WorkflowRun;
+  readonly sourceAttempt: WorkflowRunAttemptDb;
+  readonly sourceJobs: readonly JobDb[];
+  readonly sourceJobExecutionByJobId: ReadonlyMap<string, JobExecutionDb>;
+  readonly sourceJobByJobExecutionId: ReadonlyMap<string, JobDb>;
+  readonly sourceSteps: readonly StepDb[];
+}): readonly MaterializedRunGraphJob[] {
+  const sourceModelJobByKey = new Map(
+    (params.sourceAttempt.model?.jobs ?? []).map((job) => [job.key, job]),
+  );
+  const sourceStepsByJobId = new Map<string, StepDb[]>();
+  for (const step of params.sourceSteps) {
+    const sourceJob = params.sourceJobByJobExecutionId.get(step.jobExecutionId);
+    if (!sourceJob) continue;
+    const sourceJobSteps = sourceStepsByJobId.get(sourceJob.id) ?? [];
+    sourceJobSteps.push(step);
+    sourceStepsByJobId.set(sourceJob.id, sourceJobSteps);
+  }
+
+  return params.sourceJobs.map((sourceJob) => {
+    const carriedOver = params.mode === 'failed' && sourceJob.status === 'succeeded';
+
+    return {
+      job: {
+        key: sourceJob.key,
+        name: sourceJob.name,
+        mode: sourceJob.mode,
+        status: carriedOver ? ('succeeded' as const) : ('pending' as const),
+        statusReason: null,
+        carriedOver,
+        checkoutPersistCredentials: sourceJob.checkoutPersistCredentials,
+        checkoutPermissionsContents: sourceJob.checkoutPermissionsContents,
+        success: sourceJob.success,
+        executionTimeoutMs: sourceJob.executionTimeoutMs,
+        listeningTimeoutMs: sourceJob.listeningTimeoutMs,
+        maxExecutions: sourceJob.maxExecutions,
+        onResolve: sourceJob.onResolve,
+        batchDebounceMs: sourceJob.batchDebounceMs,
+        batchMaxSize: sourceJob.batchMaxSize,
+        batchMaxWaitMs: sourceJob.batchMaxWaitMs,
+        listenerStatus: 'inactive' as const,
+        resolutionReason: null,
+        listeningOn: sourceJob.listeningOn ? [...sourceJob.listeningOn] : null,
+        listeningUntil: sourceJob.listeningUntil ? [...sourceJob.listeningUntil] : null,
+        outputs: carriedOver && sourceJob.outputs ? {...sourceJob.outputs} : null,
+        dependencies: [...sourceJob.dependencies],
+        runner: sourceJob.runner ? [...sourceJob.runner] : null,
+        position: sourceJob.position,
+      },
+      createExecution: (job) => {
+        if (job.mode === 'listening') return undefined;
+
+        const sourceExecution = params.sourceJobExecutionByJobId.get(sourceJob.id);
+        const modelJob = sourceModelJobByKey.get(job.key);
+        const executionName = sourceExecution?.name ?? `${job.key} #1`;
+        const runner =
+          carriedOver || modelJob === undefined
+            ? (sourceExecution?.runner ?? job.runner ?? null)
+            : materializeJobRunner({
+                job: modelJob,
+                context: assembleExecutionCreationContext({
+                  run: params.sourceRun,
+                  triggerPayload: params.sourceRun.triggerPayload,
+                  inputs: params.sourceRun.inputs,
+                  jobId: job.id,
+                  sequence: 1,
+                  executionName,
+                  status: 'pending',
+                  triggerEvents: [],
+                  priorExecutions: [],
+                }),
+                definitionId: params.sourceRun.definitionId,
+              });
+
+        return {
+          sequence: 1,
+          name: executionName,
+          runner: runner ? [...runner] : null,
+          status: carriedOver ? ('succeeded' as const) : ('pending' as const),
+          statusReason: null,
+          outputs: carriedOver && sourceExecution?.outputs ? {...sourceExecution.outputs} : null,
+          ...(carriedOver ? {finishedAt: sql`now()`} : {}),
+        };
+      },
+      createSteps: () =>
+        (sourceStepsByJobId.get(sourceJob.id) ?? []).map((step) => ({
+          key: step.key,
+          name: step.name,
+          sourceLocation: step.sourceLocation,
+          status: carriedOver ? step.status : ('pending' as const),
+          statusReason: carriedOver ? step.statusReason : null,
+          type: step.type,
+          config: step.config,
+          condition: step.condition ?? null,
+          configPlan: step.configPlan,
+          authoredConfig: step.authoredConfig,
+          error: null,
+          position: step.position,
+          currentAttempt: 1,
+        })),
+    };
+  });
 }

--- a/libs/api/workflows/src/temporal/workflows/job-execution-orchestration.ts
+++ b/libs/api/workflows/src/temporal/workflows/job-execution-orchestration.ts
@@ -1,4 +1,4 @@
-import {ApplicationFailure} from '@temporalio/common';
+import {ApplicationFailure, type Duration} from '@temporalio/common';
 import {condition, defineSignal, log, proxyActivities, setHandler} from '@temporalio/workflow';
 import {
   hasNoRequiredRunnerLabels,
@@ -155,7 +155,7 @@ async function markJobExecutionRunningAndEnqueue(
 // ordering), so callers must evaluate `finished` before `leaseExpired`.
 async function awaitJobOutcome(
   jobExecutionId: string,
-  timeout: string | number,
+  timeout: Duration,
 ): Promise<JobExecutionOutcomeSignals> {
   let finished: {status: RuntimeCompletionStatus; jobExecutionId?: string | undefined} | undefined;
   let leaseExpired = false;


### PR DESCRIPTION
Extract the shared workflow run graph writer used by initial run creation and reruns.

`createWorkflowRun` and `createRerunWorkflowRun` both persisted the same job, execution, step, and attempt-created outbox graph inline. This moves that shared write path into `persistMaterializedRunGraph`, leaving the create path responsible for trigger idempotency and materialization and the rerun path responsible for advisory locking plus carried-over succeeded jobs.

The main create/rerun functions are now small enough to review directly: `createWorkflowRun` is 111 lines and `createRerunWorkflowRun` is 99 lines. No changeset is included because `@shipfox/api-workflows` is private.

Closes ENG-883

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a shared workflow run graph persistence layer used by both run creation and reruns to remove duplicate write logic and keep behavior consistent. This makes both paths smaller and easier to reason about. Closes ENG-883.

- **Refactors**
  - Added `persistMaterializedRunGraph` to persist jobs, executions, steps, and emit `WORKFLOWS_WORKFLOW_RUN_ATTEMPT_CREATED`.
  - `createWorkflowRun` now materializes jobs via `materializeRunGraphJobs` and delegates persistence.
  - `createRerunWorkflowRun` now loads the source graph with `loadRerunSourceGraph`, materializes via `materializeRerunGraphJobs`, and delegates persistence; preserves idempotency, advisory locking, and carried-over succeeded jobs.
  - No behavior or API changes expected.

<sup>Written for commit 9a6bd25f940bc4fdf6f7635d10f4ee5ac88a9f83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

