### PR TITLE
Expose integration tool MCP descriptors

### DIFF
--- a/.changeset/steady-tools-describe.md
+++ b/.changeset/steady-tools-describe.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-agent-dto": patch
+"@shipfox/api-workflows": patch
+---
+
+Exposes frozen agent integration tool selections as non-secret MCP server descriptors in materialized step config.

--- a/libs/api/agent-dto/src/index.ts
+++ b/libs/api/agent-dto/src/index.ts
@@ -1,7 +1,13 @@
 export {
+  AGENT_INTEGRATION_MCP_AUTH,
+  AGENT_INTEGRATION_MCP_ENDPOINT,
+  AGENT_INTEGRATION_MCP_SERVER_NAME,
+  AGENT_INTEGRATION_MCP_TRANSPORT,
+  type AgentIntegrationMcpServerConfigDto,
   type AgentModelOptionDto,
   type AgentRuntimeCredentialsResponseDto,
   type AgentThinking,
+  agentIntegrationMcpServerSchema,
   agentModelOptionSchema,
   agentRuntimeCredentialsResponseSchema,
   agentThinkingByHarness,

--- a/libs/api/agent-dto/src/schemas/index.ts
+++ b/libs/api/agent-dto/src/schemas/index.ts
@@ -80,6 +80,12 @@ export {
   parsePiEnabledToolPackages,
 } from './harness.js';
 export {
+  AGENT_INTEGRATION_MCP_AUTH,
+  AGENT_INTEGRATION_MCP_ENDPOINT,
+  AGENT_INTEGRATION_MCP_SERVER_NAME,
+  AGENT_INTEGRATION_MCP_TRANSPORT,
+  type AgentIntegrationMcpServerConfigDto,
+  agentIntegrationMcpServerSchema,
   type MaterializedAgentIntegrationConfigDto,
   type MaterializedAgentIntegrationToolConfigDto,
   type MaterializedAgentStepConfigDto,

--- a/libs/api/agent-dto/src/schemas/materialized-agent-step-config.test.ts
+++ b/libs/api/agent-dto/src/schemas/materialized-agent-step-config.test.ts
@@ -1,4 +1,61 @@
-import {materializedAgentStepConfigSchema} from './materialized-agent-step-config.js';
+import {
+  AGENT_INTEGRATION_MCP_AUTH,
+  AGENT_INTEGRATION_MCP_ENDPOINT,
+  AGENT_INTEGRATION_MCP_SERVER_NAME,
+  AGENT_INTEGRATION_MCP_TRANSPORT,
+  materializedAgentStepConfigSchema,
+} from './materialized-agent-step-config.js';
+
+const materializedIntegration = {
+  connectionId: 'connection-1',
+  connectionSlug: 'github-main',
+  provider: 'github',
+  repos: ['github:owner/repo'],
+  requiredScope: [{permission: 'issues', access: 'write'}],
+  tools: [
+    {
+      id: 'issue_read',
+      sensitivity: 'read',
+      sensitive: false,
+      requiredScope: [{permission: 'issues', access: 'read'}],
+      inputSchema: {type: 'object'},
+      methods: [
+        {
+          id: 'get',
+          token: 'issue_read.get',
+          sensitivity: 'read',
+          sensitive: false,
+          requiredScope: [{permission: 'issues', access: 'read'}],
+        },
+      ],
+    },
+    {
+      id: 'issue_write',
+      sensitivity: 'write',
+      sensitive: false,
+      requiredScope: [{permission: 'issues', access: 'write'}],
+      inputSchema: {type: 'object'},
+      outputSchema: {type: 'object'},
+      methods: [
+        {
+          id: 'create',
+          token: 'issue_write.create',
+          sensitivity: 'write',
+          sensitive: false,
+          requiredScope: [{permission: 'issues', access: 'write'}],
+        },
+      ],
+    },
+  ],
+} as const;
+
+const integrationMcpServer = {
+  name: AGENT_INTEGRATION_MCP_SERVER_NAME,
+  transport: AGENT_INTEGRATION_MCP_TRANSPORT,
+  endpoint: AGENT_INTEGRATION_MCP_ENDPOINT,
+  auth: AGENT_INTEGRATION_MCP_AUTH,
+  integrations: [materializedIntegration],
+} as const;
 
 describe('materializedAgentStepConfigSchema', () => {
   it('accepts a materialized agent step config', () => {
@@ -8,50 +65,8 @@ describe('materializedAgentStepConfigSchema', () => {
       model: 'claude-opus-4-8',
       thinking: 'high',
       tools: ['read', 'web_search'],
-      integrations: [
-        {
-          connectionId: 'connection-1',
-          connectionSlug: 'github-main',
-          provider: 'github',
-          repos: ['github:owner/repo'],
-          requiredScope: [{permission: 'issues', access: 'write'}],
-          tools: [
-            {
-              id: 'issue_read',
-              sensitivity: 'read',
-              sensitive: false,
-              requiredScope: [{permission: 'issues', access: 'read'}],
-              inputSchema: {type: 'object'},
-              methods: [
-                {
-                  id: 'get',
-                  token: 'issue_read.get',
-                  sensitivity: 'read',
-                  sensitive: false,
-                  requiredScope: [{permission: 'issues', access: 'read'}],
-                },
-              ],
-            },
-            {
-              id: 'issue_write',
-              sensitivity: 'write',
-              sensitive: false,
-              requiredScope: [{permission: 'issues', access: 'write'}],
-              inputSchema: {type: 'object'},
-              outputSchema: {type: 'object'},
-              methods: [
-                {
-                  id: 'create',
-                  token: 'issue_write.create',
-                  sensitivity: 'write',
-                  sensitive: false,
-                  requiredScope: [{permission: 'issues', access: 'write'}],
-                },
-              ],
-            },
-          ],
-        },
-      ],
+      integrations: [materializedIntegration],
+      mcpServers: [integrationMcpServer],
       prompt: 'Fix the failing tests.',
     });
 
@@ -61,50 +76,8 @@ describe('materializedAgentStepConfigSchema', () => {
       model: 'claude-opus-4-8',
       thinking: 'high',
       tools: ['read', 'web_search'],
-      integrations: [
-        {
-          connectionId: 'connection-1',
-          connectionSlug: 'github-main',
-          provider: 'github',
-          repos: ['github:owner/repo'],
-          requiredScope: [{permission: 'issues', access: 'write'}],
-          tools: [
-            {
-              id: 'issue_read',
-              sensitivity: 'read',
-              sensitive: false,
-              requiredScope: [{permission: 'issues', access: 'read'}],
-              inputSchema: {type: 'object'},
-              methods: [
-                {
-                  id: 'get',
-                  token: 'issue_read.get',
-                  sensitivity: 'read',
-                  sensitive: false,
-                  requiredScope: [{permission: 'issues', access: 'read'}],
-                },
-              ],
-            },
-            {
-              id: 'issue_write',
-              sensitivity: 'write',
-              sensitive: false,
-              requiredScope: [{permission: 'issues', access: 'write'}],
-              inputSchema: {type: 'object'},
-              outputSchema: {type: 'object'},
-              methods: [
-                {
-                  id: 'create',
-                  token: 'issue_write.create',
-                  sensitivity: 'write',
-                  sensitive: false,
-                  requiredScope: [{permission: 'issues', access: 'write'}],
-                },
-              ],
-            },
-          ],
-        },
-      ],
+      integrations: [materializedIntegration],
+      mcpServers: [integrationMcpServer],
       prompt: 'Fix the failing tests.',
     });
   });
@@ -195,4 +168,31 @@ describe('materializedAgentStepConfigSchema', () => {
 
     expect(emptyTools).toThrow();
   });
+
+  it.each([
+    ['empty integrations', {...integrationMcpServer, integrations: []}],
+    ['wrong auth', {...integrationMcpServer, auth: 'provider_token'}],
+    ['wrong transport', {...integrationMcpServer, transport: 'stdio'}],
+    ['missing endpoint', omit(integrationMcpServer, 'endpoint')],
+    ['missing name', omit(integrationMcpServer, 'name')],
+  ])('rejects malformed integration MCP server config for %s', (_caseName, mcpServer) => {
+    const parse = () =>
+      materializedAgentStepConfigSchema.parse({
+        harness: 'pi',
+        provider: 'anthropic',
+        model: 'claude-opus-4-8',
+        thinking: 'high',
+        integrations: [materializedIntegration],
+        mcpServers: [mcpServer],
+        prompt: 'Fix the failing tests.',
+      });
+
+    expect(parse).toThrow();
+  });
 });
+
+function omit<T extends object, K extends keyof T>(object: T, key: K): Omit<T, K> {
+  const copy = {...object};
+  delete copy[key];
+  return copy;
+}

--- a/libs/api/agent-dto/src/schemas/materialized-agent-step-config.ts
+++ b/libs/api/agent-dto/src/schemas/materialized-agent-step-config.ts
@@ -33,6 +33,19 @@ export const materializedAgentIntegrationSchema = z.strictObject({
   tools: z.array(materializedAgentIntegrationToolSchema).min(1),
 });
 
+export const AGENT_INTEGRATION_MCP_SERVER_NAME = 'shipfox_integration_tools';
+export const AGENT_INTEGRATION_MCP_ENDPOINT = '/runs/jobs/current/integration-tools/mcp';
+export const AGENT_INTEGRATION_MCP_TRANSPORT = 'http';
+export const AGENT_INTEGRATION_MCP_AUTH = 'lease_token';
+
+export const agentIntegrationMcpServerSchema = z.strictObject({
+  name: z.literal(AGENT_INTEGRATION_MCP_SERVER_NAME),
+  transport: z.literal(AGENT_INTEGRATION_MCP_TRANSPORT),
+  endpoint: z.literal(AGENT_INTEGRATION_MCP_ENDPOINT),
+  auth: z.literal(AGENT_INTEGRATION_MCP_AUTH),
+  integrations: z.array(materializedAgentIntegrationSchema).min(1),
+});
+
 export const materializedAgentStepConfigSchema = z
   .object({
     harness: harnessSchema.default(DEFAULT_HARNESS),
@@ -41,6 +54,7 @@ export const materializedAgentStepConfigSchema = z
     thinking: agentThinkingSchema,
     tools: z.array(z.string().min(1)).min(1).optional(),
     integrations: z.array(materializedAgentIntegrationSchema).min(1).optional(),
+    mcpServers: z.array(agentIntegrationMcpServerSchema).length(1).optional(),
     prompt: z.string(),
   })
   .strip();
@@ -52,3 +66,4 @@ export type MaterializedAgentIntegrationConfigDto = z.infer<
 export type MaterializedAgentIntegrationToolConfigDto = z.infer<
   typeof materializedAgentIntegrationToolSchema
 >;
+export type AgentIntegrationMcpServerConfigDto = z.infer<typeof agentIntegrationMcpServerSchema>;

--- a/libs/api/workflows/src/core/entities/step.ts
+++ b/libs/api/workflows/src/core/entities/step.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentIntegrationMcpServerConfigDto,
   AgentThinking,
   Harness,
   MaterializedAgentIntegrationConfigDto,
@@ -71,6 +72,7 @@ export interface StepConfigDispatchPlan {
     thinking?: AgentThinking;
     tools?: readonly string[];
     integrations?: readonly MaterializedAgentIntegrationConfigDto[];
+    mcpServers?: readonly AgentIntegrationMcpServerConfigDto[];
   };
   trace?: readonly (StepConfigEvaluationTraceEntry | EvaluationTraceLimitEntry)[];
 }

--- a/libs/api/workflows/src/core/step-config/agent.ts
+++ b/libs/api/workflows/src/core/step-config/agent.ts
@@ -131,8 +131,12 @@ export function completeAgentConfig(params: {
   params.config.thinking = defaults.thinking;
   params.config.prompt = prompt;
   if (agent.tools !== undefined) params.config.tools = [...agent.tools];
-  if (agent.integrations !== undefined) params.config.integrations = [...agent.integrations];
-  if (agent.mcpServers !== undefined) params.config.mcpServers = [...agent.mcpServers];
+  const integrations = agent.integrations === undefined ? undefined : [...agent.integrations];
+  if (integrations !== undefined) params.config.integrations = integrations;
+  const mcpServers =
+    agent.mcpServers ??
+    (integrations === undefined ? undefined : agentIntegrationMcpServers(integrations));
+  if (mcpServers !== undefined) params.config.mcpServers = [...mcpServers];
 }
 
 function completeAgentField(args: {

--- a/libs/api/workflows/src/core/step-config/agent.ts
+++ b/libs/api/workflows/src/core/step-config/agent.ts
@@ -5,7 +5,15 @@ import {
   UnsupportedModelProviderError,
 } from '@shipfox/api-agent/core/errors';
 import type {AgentDefaultsResolver} from '@shipfox/api-agent/core/resolve-agent-config';
-import type {AgentThinking, MaterializedAgentIntegrationConfigDto} from '@shipfox/api-agent-dto';
+import {
+  AGENT_INTEGRATION_MCP_AUTH,
+  AGENT_INTEGRATION_MCP_ENDPOINT,
+  AGENT_INTEGRATION_MCP_SERVER_NAME,
+  AGENT_INTEGRATION_MCP_TRANSPORT,
+  type AgentIntegrationMcpServerConfigDto,
+  type AgentThinking,
+  type MaterializedAgentIntegrationConfigDto,
+} from '@shipfox/api-agent-dto';
 import type {WorkflowModel} from '@shipfox/api-definitions';
 import type {ResolvedField, SiteResolvedField} from '@shipfox/expression';
 import {
@@ -124,6 +132,7 @@ export function completeAgentConfig(params: {
   params.config.prompt = prompt;
   if (agent.tools !== undefined) params.config.tools = [...agent.tools];
   if (agent.integrations !== undefined) params.config.integrations = [...agent.integrations];
+  if (agent.mcpServers !== undefined) params.config.mcpServers = [...agent.mcpServers];
 }
 
 function completeAgentField(args: {
@@ -330,10 +339,11 @@ function authoredAgentIntegrationsConfig(
   return step.integrations === undefined ? {} : {integrations: step.integrations};
 }
 
-function materializedAgentIntegrationsConfig(
-  params: ResolveAgentStepConfigParams,
-):
-  | {readonly integrations: readonly MaterializedAgentIntegrationConfigDto[]}
+function materializedAgentIntegrationsConfig(params: ResolveAgentStepConfigParams):
+  | {
+      readonly integrations: readonly MaterializedAgentIntegrationConfigDto[];
+      readonly mcpServers: readonly AgentIntegrationMcpServerConfigDto[];
+    }
   | Record<string, never> {
   const integrations = materializeAgentIntegrations({
     jobKey: params.jobKey,
@@ -342,7 +352,23 @@ function materializedAgentIntegrationsConfig(
     context: params.agentToolContext,
     snapshot: params.agentToolSnapshot,
   });
-  return integrations === undefined ? {} : {integrations};
+  return integrations === undefined
+    ? {}
+    : {integrations, mcpServers: agentIntegrationMcpServers(integrations)};
+}
+
+function agentIntegrationMcpServers(
+  integrations: readonly MaterializedAgentIntegrationConfigDto[],
+): readonly AgentIntegrationMcpServerConfigDto[] {
+  return [
+    {
+      name: AGENT_INTEGRATION_MCP_SERVER_NAME,
+      transport: AGENT_INTEGRATION_MCP_TRANSPORT,
+      endpoint: AGENT_INTEGRATION_MCP_ENDPOINT,
+      auth: AGENT_INTEGRATION_MCP_AUTH,
+      integrations: [...integrations],
+    },
+  ];
 }
 
 function dispatchPlanField(field: FieldResolution): ResolvedField {

--- a/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
+++ b/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
@@ -70,35 +70,51 @@ const resolveAgentDefaults: AgentDefaultsResolver = (params) => ({
   thinking: params.thinking ?? 'off',
 });
 
-describe('completeStepDispatchConfig', () => {
-  it('copies frozen agent integrations from the dispatch plan', () => {
-    const integrations = [
+function materializedIntegration(): MaterializedAgentIntegrationConfigDto {
+  return {
+    connectionId: 'connection-1',
+    connectionSlug: 'github-main',
+    provider: 'github',
+    repos: ['github:owner/repo'],
+    requiredScope: [{permission: 'issues', access: 'read'}],
+    tools: [
       {
-        connectionId: 'connection-1',
-        connectionSlug: 'github-main',
-        provider: 'github',
-        repos: ['github:owner/repo'],
+        id: 'issue_read',
+        sensitivity: 'read',
+        sensitive: false,
         requiredScope: [{permission: 'issues', access: 'read'}],
-        tools: [
+        inputSchema: {type: 'object'},
+        methods: [
           {
-            id: 'issue_read',
-            sensitivity: 'read' as const,
+            id: 'get',
+            token: 'issue_read.get',
+            sensitivity: 'read',
             sensitive: false,
             requiredScope: [{permission: 'issues', access: 'read'}],
-            inputSchema: {type: 'object'},
-            methods: [
-              {
-                id: 'get',
-                token: 'issue_read.get',
-                sensitivity: 'read' as const,
-                sensitive: false,
-                requiredScope: [{permission: 'issues', access: 'read'}],
-              },
-            ],
           },
         ],
       },
-    ];
+    ],
+  };
+}
+
+function integrationMcpServers(
+  integrations: readonly MaterializedAgentIntegrationConfigDto[],
+): readonly AgentIntegrationMcpServerConfigDto[] {
+  return [
+    {
+      name: AGENT_INTEGRATION_MCP_SERVER_NAME,
+      transport: AGENT_INTEGRATION_MCP_TRANSPORT,
+      endpoint: AGENT_INTEGRATION_MCP_ENDPOINT,
+      auth: AGENT_INTEGRATION_MCP_AUTH,
+      integrations: [...integrations],
+    },
+  ];
+}
+
+describe('completeStepDispatchConfig', () => {
+  it('copies frozen agent integrations from the dispatch plan', () => {
+    const integrations = [materializedIntegration()];
     const pending = step({
       type: 'agent',
       config: {
@@ -123,6 +139,7 @@ describe('completeStepDispatchConfig', () => {
     });
 
     expect(result.config.integrations).toEqual(integrations);
+    expect(result.config.mcpServers).toEqual(integrationMcpServers(integrations));
   });
 
   it('serializes residual secret env values as secret bindings without writing env values', () => {
@@ -235,40 +252,8 @@ describe('completeStepDispatchConfig', () => {
   });
 
   it('completes deferred agent config with the resolved harness', () => {
-    const integration: MaterializedAgentIntegrationConfigDto = {
-      connectionId: 'connection-1',
-      connectionSlug: 'github-main',
-      provider: 'github',
-      repos: ['github:owner/repo'],
-      requiredScope: [{permission: 'issues', access: 'read'}],
-      tools: [
-        {
-          id: 'issue_read',
-          sensitivity: 'read',
-          sensitive: false,
-          requiredScope: [{permission: 'issues', access: 'read'}],
-          inputSchema: {type: 'object'},
-          methods: [
-            {
-              id: 'get',
-              token: 'issue_read.get',
-              sensitivity: 'read',
-              sensitive: false,
-              requiredScope: [{permission: 'issues', access: 'read'}],
-            },
-          ],
-        },
-      ],
-    };
-    const mcpServers: readonly AgentIntegrationMcpServerConfigDto[] = [
-      {
-        name: AGENT_INTEGRATION_MCP_SERVER_NAME,
-        transport: AGENT_INTEGRATION_MCP_TRANSPORT,
-        endpoint: AGENT_INTEGRATION_MCP_ENDPOINT,
-        auth: AGENT_INTEGRATION_MCP_AUTH,
-        integrations: [integration],
-      },
-    ];
+    const integration = materializedIntegration();
+    const mcpServers = integrationMcpServers([integration]);
     const pending = step({
       type: 'agent',
       config: {},

--- a/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
+++ b/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
@@ -1,5 +1,13 @@
 import {UnsupportedHarnessThinkingError} from '@shipfox/api-agent/core/errors';
 import type {AgentDefaultsResolver} from '@shipfox/api-agent/core/resolve-agent-config';
+import {
+  AGENT_INTEGRATION_MCP_AUTH,
+  AGENT_INTEGRATION_MCP_ENDPOINT,
+  AGENT_INTEGRATION_MCP_SERVER_NAME,
+  AGENT_INTEGRATION_MCP_TRANSPORT,
+  type AgentIntegrationMcpServerConfigDto,
+  type MaterializedAgentIntegrationConfigDto,
+} from '@shipfox/api-agent-dto';
 import {parseWorkflowTemplate, planInterpolationField} from '@shipfox/expression';
 import type {Step} from '#core/entities/step.js';
 import {AgentConfigUnresolvableError, InterpolationUnresolvableError} from '#core/errors.js';
@@ -227,6 +235,40 @@ describe('completeStepDispatchConfig', () => {
   });
 
   it('completes deferred agent config with the resolved harness', () => {
+    const integration: MaterializedAgentIntegrationConfigDto = {
+      connectionId: 'connection-1',
+      connectionSlug: 'github-main',
+      provider: 'github',
+      repos: ['github:owner/repo'],
+      requiredScope: [{permission: 'issues', access: 'read'}],
+      tools: [
+        {
+          id: 'issue_read',
+          sensitivity: 'read',
+          sensitive: false,
+          requiredScope: [{permission: 'issues', access: 'read'}],
+          inputSchema: {type: 'object'},
+          methods: [
+            {
+              id: 'get',
+              token: 'issue_read.get',
+              sensitivity: 'read',
+              sensitive: false,
+              requiredScope: [{permission: 'issues', access: 'read'}],
+            },
+          ],
+        },
+      ],
+    };
+    const mcpServers: readonly AgentIntegrationMcpServerConfigDto[] = [
+      {
+        name: AGENT_INTEGRATION_MCP_SERVER_NAME,
+        transport: AGENT_INTEGRATION_MCP_TRANSPORT,
+        endpoint: AGENT_INTEGRATION_MCP_ENDPOINT,
+        auth: AGENT_INTEGRATION_MCP_AUTH,
+        integrations: [integration],
+      },
+    ];
     const pending = step({
       type: 'agent',
       config: {},
@@ -234,6 +276,8 @@ describe('completeStepDispatchConfig', () => {
         agent: {
           harness: 'claude',
           tools: ['Read', 'WebSearch'],
+          integrations: [integration],
+          mcpServers,
           prompt: plannedField(`Review ${template('steps.build.outputs.sha')}`),
         },
       },
@@ -253,6 +297,8 @@ describe('completeStepDispatchConfig', () => {
         model: 'gpt-5.5',
         thinking: 'off',
         tools: ['Read', 'WebSearch'],
+        integrations: [integration],
+        mcpServers,
         prompt: 'Review abc123',
       },
       trace: [

--- a/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.test.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.test.ts
@@ -3,6 +3,12 @@ import {
   UnsupportedModelProviderError,
 } from '@shipfox/api-agent/core/errors';
 import type {AgentDefaultsResolver} from '@shipfox/api-agent/core/resolve-agent-config';
+import {
+  AGENT_INTEGRATION_MCP_AUTH,
+  AGENT_INTEGRATION_MCP_ENDPOINT,
+  AGENT_INTEGRATION_MCP_SERVER_NAME,
+  AGENT_INTEGRATION_MCP_TRANSPORT,
+} from '@shipfox/api-agent-dto';
 import type {AgentToolCatalogEntry} from '@shipfox/api-integration-core';
 import type {AgentToolMaterializationContext} from '#core/agent-tools.js';
 import {AgentConfigUnresolvableError, InterpolationUnresolvableError} from '#core/errors.js';
@@ -257,8 +263,9 @@ describe('materializeJobExecutionSteps', () => {
       context: jobExecutionContext(),
       agentToolContext: githubAgentToolContext(),
     });
+    const integrations = steps[1]?.config.integrations;
 
-    expect(steps[1]?.config.integrations).toEqual([
+    expect(integrations).toEqual([
       {
         connectionId: 'connection-1',
         connectionSlug: 'github-main',
@@ -315,6 +322,15 @@ describe('materializeJobExecutionSteps', () => {
         ],
       },
     ]);
+    expect(steps[1]?.config.mcpServers).toEqual([
+      {
+        name: AGENT_INTEGRATION_MCP_SERVER_NAME,
+        transport: AGENT_INTEGRATION_MCP_TRANSPORT,
+        endpoint: AGENT_INTEGRATION_MCP_ENDPOINT,
+        auth: AGENT_INTEGRATION_MCP_AUTH,
+        integrations,
+      },
+    ]);
   });
 
   it('carries frozen integrations through the agent dispatch plan when prompt is deferred', () => {
@@ -358,7 +374,8 @@ describe('materializeJobExecutionSteps', () => {
       model: 'claude-opus-4-8',
       thinking: 'high',
     });
-    expect(steps[1]?.configPlan?.agent?.integrations).toEqual([
+    const integrations = steps[1]?.configPlan?.agent?.integrations;
+    expect(integrations).toEqual([
       {
         connectionId: 'connection-1',
         connectionSlug: 'github-main',
@@ -383,6 +400,15 @@ describe('materializeJobExecutionSteps', () => {
             ],
           },
         ],
+      },
+    ]);
+    expect(steps[1]?.configPlan?.agent?.mcpServers).toEqual([
+      {
+        name: AGENT_INTEGRATION_MCP_SERVER_NAME,
+        transport: AGENT_INTEGRATION_MCP_TRANSPORT,
+        endpoint: AGENT_INTEGRATION_MCP_ENDPOINT,
+        auth: AGENT_INTEGRATION_MCP_AUTH,
+        integrations,
       },
     ]);
   });


### PR DESCRIPTION
Expose integration tool selections to runners as non-secret MCP server descriptors in materialized agent step config.

Integration tool selection is already frozen during materialization, but runners did not yet have a runner-facing descriptor that says a step has integration tools or where the gateway MCP endpoint will live. This adds a typed `mcpServers` descriptor generated from the frozen `integrations` snapshot, keeping provider credentials and runtime model credentials off this path.

The descriptor reserves the future gateway endpoint for ENG-847/ENG-850/ENG-851 while leaving `/agent-runtime-config` unchanged as the model credential route. Review the DTO shape carefully because downstream runner bridge and harness wiring will consume it.

Closes ENG-849

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose non-secret MCP server descriptors for selected integration tools so runners can discover and connect. Satisfies ENG-849; keeps credentials off this path; backfills during deferred completion for older plans; `/agent-runtime-config` remains the model credential route.

- **New Features**
  - Add optional `mcpServers` (length 1) to `MaterializedAgentStepConfigDto`, generated from frozen `integrations` during materialization and backfilled on dispatch if missing (supports deferred plans).
  - Export `agentIntegrationMcpServerSchema`, `AgentIntegrationMcpServerConfigDto`, and constants `AGENT_INTEGRATION_MCP_SERVER_NAME`, `AGENT_INTEGRATION_MCP_TRANSPORT`, `AGENT_INTEGRATION_MCP_ENDPOINT`, `AGENT_INTEGRATION_MCP_AUTH` in `@shipfox/api-agent-dto`; include `mcpServers` in the dispatch plan shape in `@shipfox/api-workflows`.

<sup>Written for commit 185ea28f16bc8b2657bb84c813ae8fd6d1e282b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

