### PR TITLE
[react-ui] Standardize static notices on Callout

### DIFF
--- a/.changeset/brisk-callouts-align.md
+++ b/.changeset/brisk-callouts-align.md
@@ -1,5 +1,0 @@
----
-"@shipfox/react-ui": patch
----
-
-Aligns static alert rendering with the canonical Callout notice treatment.

--- a/.changeset/brisk-callouts-align.md
+++ b/.changeset/brisk-callouts-align.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/react-ui": patch
+---
+
+Aligns static alert rendering with the canonical Callout notice treatment.

--- a/libs/client/agent/src/components/change-default-model-form.tsx
+++ b/libs/client/agent/src/components/change-default-model-form.tsx
@@ -1,6 +1,6 @@
 import type {ModelProviderConfigDto} from '@shipfox/api-agent-dto';
-import {Alert} from '@shipfox/react-ui/alert';
 import {Button} from '@shipfox/react-ui/button';
+import {Callout} from '@shipfox/react-ui/callout';
 import {fieldError} from '@shipfox/react-ui/form-field';
 import {ModalBody, ModalFooter} from '@shipfox/react-ui/modal';
 import {Text} from '@shipfox/react-ui/typography';
@@ -80,14 +80,14 @@ export function ChangeDefaultModelForm({
           </form.Field>
         </form>
         {formError ? (
-          <Alert variant="error" animated={false}>
+          <Callout role="alert" type="error">
             <div className="flex flex-col gap-8">
               <Text size="sm" bold>
                 Could not save default model
               </Text>
               <Text size="sm">{formError}</Text>
             </div>
-          </Alert>
+          </Callout>
         ) : null}
       </ModalBody>
       <ModalFooter>

--- a/libs/client/agent/src/components/custom-model-provider-form.tsx
+++ b/libs/client/agent/src/components/custom-model-provider-form.tsx
@@ -1,7 +1,7 @@
 import type {CustomModelProviderConfigDto, ModelProviderApi} from '@shipfox/api-agent-dto';
-import {Alert} from '@shipfox/react-ui/alert';
 import {Badge} from '@shipfox/react-ui/badge';
 import {Button, IconButton} from '@shipfox/react-ui/button';
+import {Callout} from '@shipfox/react-ui/callout';
 import {Collapsible, CollapsibleContent, CollapsibleTrigger} from '@shipfox/react-ui/collapsible';
 import {FormField, FormFieldInput, fieldError} from '@shipfox/react-ui/form-field';
 import {ModalBody, ModalFooter} from '@shipfox/react-ui/modal';
@@ -365,11 +365,11 @@ export function CustomModelProviderForm({
                   </form.Field>
 
                   {removedDefaultNotice ? (
-                    <Alert variant="warning" animated={false}>
+                    <Callout role="alert" type="warning">
                       <Text size="sm">
                         Default model removed - choose a new default or keep none.
                       </Text>
-                    </Alert>
+                    </Callout>
                   ) : null}
                   <form.Field
                     name="default_model"
@@ -410,14 +410,14 @@ export function CustomModelProviderForm({
           </form.Subscribe>
         </form>
         {formError ? (
-          <Alert variant="error" animated={false} className="mt-16">
+          <Callout role="alert" type="error" className="mt-16">
             <div className="flex flex-col gap-8">
               <Text size="sm" bold>
                 Could not save provider
               </Text>
               <Text size="sm">{formError}</Text>
             </div>
-          </Alert>
+          </Callout>
         ) : null}
       </ModalBody>
       <ModalFooter>

--- a/libs/client/agent/src/components/harnesses-section.tsx
+++ b/libs/client/agent/src/components/harnesses-section.tsx
@@ -5,8 +5,8 @@ import {
   listHarnessDescriptors,
 } from '@shipfox/api-agent-dto';
 import {QueryLoadError} from '@shipfox/client-ui';
-import {Alert} from '@shipfox/react-ui/alert';
 import {IconButton} from '@shipfox/react-ui/button';
+import {Callout} from '@shipfox/react-ui/callout';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -212,9 +212,9 @@ function HarnessRow({
         ) : null}
       </div>
       {defaultError ? (
-        <Alert variant="error" animated={false}>
+        <Callout role="alert" type="error">
           <Text size="sm">{defaultError}</Text>
-        </Alert>
+        </Callout>
       ) : null}
     </li>
   );

--- a/libs/client/agent/src/components/model-providers-section.tsx
+++ b/libs/client/agent/src/components/model-providers-section.tsx
@@ -5,8 +5,8 @@ import type {
   ModelProviderConfigResponseDto,
 } from '@shipfox/api-agent-dto';
 import {QueryLoadError} from '@shipfox/client-ui';
-import {Alert} from '@shipfox/react-ui/alert';
 import {Button, IconButton} from '@shipfox/react-ui/button';
+import {Callout} from '@shipfox/react-ui/callout';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -553,9 +553,9 @@ function ConfiguredProviderRow({
         </DropdownMenu>
       </div>
       {defaultError ? (
-        <Alert variant="error" animated={false}>
+        <Callout role="alert" type="error">
           <Text size="sm">{defaultError}</Text>
-        </Alert>
+        </Callout>
       ) : null}
       <DeleteModelProviderDialog
         open={deleteOpen}
@@ -595,9 +595,9 @@ function DeleteModelProviderDialog({
             until it is configured again.
           </Text>
           {errorMessage ? (
-            <Alert variant="error" animated={false}>
+            <Callout role="alert" type="error">
               <Text size="sm">{errorMessage}</Text>
-            </Alert>
+            </Callout>
           ) : null}
         </ModalBody>
         <ModalFooter>

--- a/libs/client/agent/src/components/test-and-save-form.tsx
+++ b/libs/client/agent/src/components/test-and-save-form.tsx
@@ -3,8 +3,8 @@ import type {
   ModelProviderConfigDto,
   SupportedModelProviderId,
 } from '@shipfox/api-agent-dto';
-import {Alert} from '@shipfox/react-ui/alert';
 import {Button} from '@shipfox/react-ui/button';
+import {Callout} from '@shipfox/react-ui/callout';
 import {FormField, FormFieldInput, fieldError} from '@shipfox/react-ui/form-field';
 import {ModalBody, ModalFooter} from '@shipfox/react-ui/modal';
 import {Text} from '@shipfox/react-ui/typography';
@@ -132,14 +132,14 @@ export function ModelProviderTestAndSaveForm({
           ))}
         </form>
         {formError ? (
-          <Alert variant="error" animated={false}>
+          <Callout role="alert" type="error">
             <div className="flex flex-col gap-8">
               <Text size="sm" bold>
                 Could not save provider
               </Text>
               <Text size="sm">{formError}</Text>
             </div>
-          </Alert>
+          </Callout>
         ) : null}
       </ModalBody>
       <ModalFooter>

--- a/libs/client/agent/src/pages/model-provider-onboarding-page.tsx
+++ b/libs/client/agent/src/pages/model-provider-onboarding-page.tsx
@@ -7,8 +7,8 @@ import {
   type ModelProviderCatalogEntryDto,
 } from '@shipfox/api-agent-dto';
 import {QueryLoadError} from '@shipfox/client-ui';
-import {Alert} from '@shipfox/react-ui/alert';
 import {Button} from '@shipfox/react-ui/button';
+import {Callout} from '@shipfox/react-ui/callout';
 import {EmptyState} from '@shipfox/react-ui/empty-state';
 import {Icon} from '@shipfox/react-ui/icon';
 import {Modal, ModalContent, ModalHeader, ModalTitle} from '@shipfox/react-ui/modal';
@@ -178,14 +178,14 @@ export function ModelProviderOnboardingPage({
           ) : null}
           {defaultHarnessError ? (
             <div className="px-20 pb-8">
-              <Alert variant="error" animated={false}>
+              <Callout role="alert" type="error">
                 <div className="flex flex-col gap-8">
                   <Text size="sm" bold>
                     Could not save default harness
                   </Text>
                   <Text size="sm">{defaultHarnessError}</Text>
                 </div>
-              </Alert>
+              </Callout>
             </div>
           ) : null}
           {selectedEntry ? (

--- a/libs/client/auth/src/pages/login-page.tsx
+++ b/libs/client/auth/src/pages/login-page.tsx
@@ -1,6 +1,6 @@
 import {loginBodySchema} from '@shipfox/api-auth-dto';
-import {Alert} from '@shipfox/react-ui/alert';
 import {Button, ButtonLink} from '@shipfox/react-ui/button';
+import {Callout} from '@shipfox/react-ui/callout';
 import {FormField, FormFieldInput, fieldError} from '@shipfox/react-ui/form-field';
 import {Icon} from '@shipfox/react-ui/icon';
 import {Text} from '@shipfox/react-ui/typography';
@@ -103,7 +103,11 @@ export function LoginPage() {
           void form.handleSubmit();
         }}
       >
-        {formError ? <Alert variant="error">{formError}</Alert> : null}
+        {formError ? (
+          <Callout role="alert" type="error">
+            {formError}
+          </Callout>
+        ) : null}
         <form.Field
           name="email"
           validators={{onBlur: loginBodySchema.shape.email, onSubmit: loginBodySchema.shape.email}}

--- a/libs/client/auth/src/pages/password-reset-page.tsx
+++ b/libs/client/auth/src/pages/password-reset-page.tsx
@@ -2,8 +2,8 @@ import {
   passwordResetConfirmBodySchema,
   passwordResetRequestBodySchema,
 } from '@shipfox/api-auth-dto';
-import {Alert} from '@shipfox/react-ui/alert';
 import {Button, ButtonLink} from '@shipfox/react-ui/button';
+import {Callout} from '@shipfox/react-ui/callout';
 import {FormField, FormFieldInput, fieldError} from '@shipfox/react-ui/form-field';
 import {toast} from '@shipfox/react-ui/toast';
 import {Text} from '@shipfox/react-ui/typography';
@@ -72,9 +72,9 @@ function PasswordResetRequest() {
         title="Check your email"
         description={`We sent reset instructions to ${submittedEmail}.`}
       >
-        <Alert variant="success">
+        <Callout role="alert" type="success">
           If a Shipfox account exists for that email, the reset link will arrive shortly.
-        </Alert>
+        </Callout>
         <Button
           className="w-full"
           variant="secondary"
@@ -104,7 +104,11 @@ function PasswordResetRequest() {
           void form.handleSubmit();
         }}
       >
-        {formError ? <Alert variant="error">{formError}</Alert> : null}
+        {formError ? (
+          <Callout role="alert" type="error">
+            {formError}
+          </Callout>
+        ) : null}
         <form.Field
           name="email"
           validators={{
@@ -181,7 +185,11 @@ function PasswordResetConfirm({token}: {token: string}) {
           void form.handleSubmit();
         }}
       >
-        {formError ? <Alert variant="error">{formError}</Alert> : null}
+        {formError ? (
+          <Callout role="alert" type="error">
+            {formError}
+          </Callout>
+        ) : null}
         <form.Field
           name="new_password"
           validators={{

--- a/libs/client/auth/src/pages/signup-page.tsx
+++ b/libs/client/auth/src/pages/signup-page.tsx
@@ -1,7 +1,7 @@
 import {signupBodySchema} from '@shipfox/api-auth-dto';
 import {displayNameFieldError} from '@shipfox/client-ui';
-import {Alert} from '@shipfox/react-ui/alert';
 import {Button, ButtonLink} from '@shipfox/react-ui/button';
+import {Callout} from '@shipfox/react-ui/callout';
 import {FormField, FormFieldInput, fieldError} from '@shipfox/react-ui/form-field';
 import {Icon} from '@shipfox/react-ui/icon';
 import {toast} from '@shipfox/react-ui/toast';
@@ -180,10 +180,14 @@ export function SignupPage() {
         title="Check your email"
         description={`We sent a verification link to ${submittedEmail}.`}
       >
-        {resendError ? <Alert variant="error">{resendError}</Alert> : null}
-        <Alert variant="success">
+        {resendError ? (
+          <Callout role="alert" type="error">
+            {resendError}
+          </Callout>
+        ) : null}
+        <Callout role="alert" type="success">
           Click the verification link to activate your account, then come back to log in.
-        </Alert>
+        </Callout>
         <div className="flex flex-col gap-8">
           <Button
             aria-disabled={isResendCoolingDown ? true : undefined}
@@ -248,7 +252,11 @@ export function SignupPage() {
           void form.handleSubmit();
         }}
       >
-        {formError ? <Alert variant="error">{formError}</Alert> : null}
+        {formError ? (
+          <Callout role="alert" type="error">
+            {formError}
+          </Callout>
+        ) : null}
         <form.Field
           name="name"
           validators={{

--- a/libs/client/auth/src/pages/workspace-onboarding-page.tsx
+++ b/libs/client/auth/src/pages/workspace-onboarding-page.tsx
@@ -1,7 +1,7 @@
 import {createWorkspaceBodySchema} from '@shipfox/api-workspaces-dto';
 import {displayNameFieldError} from '@shipfox/client-ui';
-import {Alert} from '@shipfox/react-ui/alert';
 import {Button} from '@shipfox/react-ui/button';
+import {Callout} from '@shipfox/react-ui/callout';
 import {Card, CardContent, CardDescription, CardHeader, CardTitle} from '@shipfox/react-ui/card';
 import {FormField, FormFieldInput, fieldError} from '@shipfox/react-ui/form-field';
 import {Icon} from '@shipfox/react-ui/icon';
@@ -94,7 +94,11 @@ export function WorkspaceOnboardingPage() {
                 <CardDescription>Give your team a place to collaborate.</CardDescription>
               </CardHeader>
 
-              {formError ? <Alert variant="error">{formError}</Alert> : null}
+              {formError ? (
+                <Callout role="alert" type="error">
+                  {formError}
+                </Callout>
+              ) : null}
 
               <CardContent className="flex flex-col gap-8">
                 <form.Field

--- a/libs/client/integrations/src/components/integration-delete-confirm-modal.tsx
+++ b/libs/client/integrations/src/components/integration-delete-confirm-modal.tsx
@@ -1,5 +1,5 @@
-import {Alert} from '@shipfox/react-ui/alert';
 import {Button} from '@shipfox/react-ui/button';
+import {Callout} from '@shipfox/react-ui/callout';
 import {
   Modal,
   ModalBody,
@@ -37,10 +37,10 @@ export function IntegrationDeleteConfirmModal({
         <ModalTitle className="sr-only">Delete integration</ModalTitle>
         <ModalHeader title="Delete integration" showClose={!isPending} />
         <ModalBody className="gap-16">
-          <Alert variant="error" animated={false}>
+          <Callout role="alert" type="error">
             Are you sure you want to delete <strong>{name}</strong>? Once deleted, Shipfox will
             immediately stop processing events from this integration. This cannot be undone.
-          </Alert>
+          </Callout>
         </ModalBody>
         <ModalFooter>
           <Button

--- a/libs/client/integrations/src/components/integration-delete-confirm-modal.tsx
+++ b/libs/client/integrations/src/components/integration-delete-confirm-modal.tsx
@@ -1,5 +1,4 @@
 import {Button} from '@shipfox/react-ui/button';
-import {Callout} from '@shipfox/react-ui/callout';
 import {
   Modal,
   ModalBody,
@@ -8,6 +7,7 @@ import {
   ModalHeader,
   ModalTitle,
 } from '@shipfox/react-ui/modal';
+import {Text} from '@shipfox/react-ui/typography';
 
 interface IntegrationDeleteConfirmModalProps {
   connectionName: string | undefined;
@@ -37,10 +37,11 @@ export function IntegrationDeleteConfirmModal({
         <ModalTitle className="sr-only">Delete integration</ModalTitle>
         <ModalHeader title="Delete integration" showClose={!isPending} />
         <ModalBody className="gap-16">
-          <Callout role="alert" type="error">
-            Are you sure you want to delete <strong>{name}</strong>? Once deleted, Shipfox will
-            immediately stop processing events from this integration. This cannot be undone.
-          </Callout>
+          <Text size="sm">
+            Are you sure you want to delete <strong className="font-medium">{name}</strong>? Once
+            deleted, Shipfox will immediately stop processing events from this integration. This
+            cannot be undone.
+          </Text>
         </ModalBody>
         <ModalFooter>
           <Button

--- a/libs/client/integrations/src/components/integration-gallery.test.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.test.tsx
@@ -441,12 +441,13 @@ describe('IntegrationGallery — installed section', () => {
     fireEvent.click(screen.getByRole('menuitem', {name: 'Delete integration'}));
 
     const dialog = await screen.findByRole('dialog', {name: 'Delete integration'});
-    const alert = within(dialog).getByRole('alert');
+    const integrationName = within(dialog).getByText('acme-corp');
 
-    expect(alert).toHaveTextContent(
+    expect(dialog).toHaveTextContent(
       'Are you sure you want to delete acme-corp? Once deleted, Shipfox will immediately stop processing events from this integration. This cannot be undone.',
     );
-    expect(within(alert).getByText('acme-corp')).toBeVisible();
+    expect(integrationName.tagName).toBe('STRONG');
+    expect(integrationName).toHaveClass('font-medium');
     expect(within(dialog).getByRole('button', {name: 'Delete integration'})).toBeVisible();
   });
 

--- a/libs/client/integrations/src/components/redirect-install-page.tsx
+++ b/libs/client/integrations/src/components/redirect-install-page.tsx
@@ -1,7 +1,7 @@
 import {ApiError} from '@shipfox/client-api';
 import {useActiveWorkspace} from '@shipfox/client-auth';
-import {Alert} from '@shipfox/react-ui/alert';
 import {ButtonLink} from '@shipfox/react-ui/button';
+import {Callout} from '@shipfox/react-ui/callout';
 import {FullPageLoader} from '@shipfox/react-ui/loader';
 import {Text} from '@shipfox/react-ui/typography';
 import {useMutation} from '@tanstack/react-query';
@@ -55,9 +55,9 @@ export function RedirectInstallPage({
   if (errorMessage) {
     return (
       <div className="mx-auto flex w-full max-w-[480px] flex-col gap-16">
-        <Alert variant="error">
+        <Callout role="alert" type="error">
           <Text size="sm">{errorMessage}</Text>
-        </Alert>
+        </Callout>
         <ButtonLink asChild variant="muted" className="w-fit">
           <Link to="/workspaces/$wid/integrations" params={{wid: workspace.id}}>
             Back to integrations

--- a/libs/client/integrations/src/components/webhook/webhook-create-modal.tsx
+++ b/libs/client/integrations/src/components/webhook/webhook-create-modal.tsx
@@ -6,8 +6,8 @@ import {
   webhookSlugSchema,
 } from '@shipfox/api-integration-webhook-dto';
 import {displayNameFieldError} from '@shipfox/client-ui';
-import {Alert} from '@shipfox/react-ui/alert';
 import {Button} from '@shipfox/react-ui/button';
+import {Callout} from '@shipfox/react-ui/callout';
 import {FormField, FormFieldInput, fieldError} from '@shipfox/react-ui/form-field';
 import {
   Modal,
@@ -102,7 +102,11 @@ export function WebhookCreateModal({
             <Text size="sm" className="text-foreground-neutral-muted">
               Create a named inbound webhook URL for this workspace.
             </Text>
-            {formError ? <Alert variant="error">{formError}</Alert> : null}
+            {formError ? (
+              <Callout role="alert" type="error">
+                {formError}
+              </Callout>
+            ) : null}
             <form.Field
               name="name"
               validators={{

--- a/libs/client/integrations/src/components/webhook/webhook-public-endpoint-alert.tsx
+++ b/libs/client/integrations/src/components/webhook/webhook-public-endpoint-alert.tsx
@@ -1,15 +1,15 @@
-import {Alert, AlertContent, AlertDescription, AlertTitle} from '@shipfox/react-ui/alert';
+import {Callout, CalloutContent, CalloutDescription, CalloutTitle} from '@shipfox/react-ui/callout';
 
 export function WebhookPublicEndpointAlert() {
   return (
-    <Alert variant="default" animated={false}>
-      <AlertContent>
-        <AlertTitle>Public webhook endpoint</AlertTitle>
-        <AlertDescription>
+    <Callout role="alert" type="default">
+      <CalloutContent>
+        <CalloutTitle>Public webhook endpoint</CalloutTitle>
+        <CalloutDescription>
           Anyone with this URL can send webhook events to this source. You are responsible for
           verifying the received webhook in your workflow before trusting its payload.
-        </AlertDescription>
-      </AlertContent>
-    </Alert>
+        </CalloutDescription>
+      </CalloutContent>
+    </Callout>
   );
 }

--- a/libs/client/integrations/src/pages/gitea-install-page.tsx
+++ b/libs/client/integrations/src/pages/gitea-install-page.tsx
@@ -1,6 +1,6 @@
 import {useActiveWorkspace} from '@shipfox/client-auth';
-import {Alert} from '@shipfox/react-ui/alert';
 import {Button, ButtonLink} from '@shipfox/react-ui/button';
+import {Callout} from '@shipfox/react-ui/callout';
 import {FormField, FormFieldInput, fieldError} from '@shipfox/react-ui/form-field';
 import {toast} from '@shipfox/react-ui/toast';
 import {Header, Text} from '@shipfox/react-ui/typography';
@@ -66,7 +66,11 @@ export function GiteaInstallPage() {
           void form.handleSubmit();
         }}
       >
-        {formError ? <Alert variant="error">{formError}</Alert> : null}
+        {formError ? (
+          <Callout role="alert" type="error">
+            {formError}
+          </Callout>
+        ) : null}
         <form.Field
           name="org"
           validators={{

--- a/libs/client/integrations/src/pages/sentry-callback-page.tsx
+++ b/libs/client/integrations/src/pages/sentry-callback-page.tsx
@@ -229,8 +229,10 @@ export function SentryCallbackPage() {
 
 function CallbackColumn({children}: {children: React.ReactNode}) {
   return (
-    <div className="mx-auto flex min-h-screen w-full max-w-[480px] flex-col justify-center gap-20 px-16 py-32">
-      {children}
-    </div>
+    <main className="flex min-h-screen bg-background-subtle-base px-16 py-32">
+      <div className="mx-auto flex w-full max-w-[480px] flex-col justify-center gap-20">
+        {children}
+      </div>
+    </main>
   );
 }

--- a/libs/client/integrations/src/pages/sentry-callback-page.tsx
+++ b/libs/client/integrations/src/pages/sentry-callback-page.tsx
@@ -1,7 +1,7 @@
 import type {SentryConnectResponseDto} from '@shipfox/api-integration-sentry-dto';
 import {useAuthState, useRefreshAuth} from '@shipfox/client-auth';
-import {Alert} from '@shipfox/react-ui/alert';
 import {Button, ButtonLink} from '@shipfox/react-ui/button';
+import {Callout} from '@shipfox/react-ui/callout';
 import {Card} from '@shipfox/react-ui/card';
 import {FullPageLoader} from '@shipfox/react-ui/loader';
 import {toast} from '@shipfox/react-ui/toast';
@@ -79,12 +79,12 @@ export function SentryCallbackPage() {
   if (!params) {
     return (
       <CallbackColumn>
-        <Alert variant="error">
+        <Callout role="alert" type="error">
           <Text size="sm">
             This Sentry link is missing required parameters. Start the install again from your
             workspace settings.
           </Text>
-        </Alert>
+        </Callout>
         <ButtonLink asChild variant="muted" className="w-fit">
           <Link to="/">Back to Shipfox</Link>
         </ButtonLink>
@@ -171,7 +171,7 @@ export function SentryCallbackPage() {
       </header>
 
       {failure ? (
-        <Alert variant="error">
+        <Callout role="alert" type="error">
           <div className="flex flex-col gap-8">
             <Text size="sm">{failure.failure.message}</Text>
             {failure.failure.kind === 'retryable' ? (
@@ -193,7 +193,7 @@ export function SentryCallbackPage() {
               </Button>
             ) : null}
           </div>
-        </Alert>
+        </Callout>
       ) : null}
 
       <section className="flex flex-col gap-8" aria-label="Choose a workspace">

--- a/libs/client/invitations/src/pages/invitation-accept-page.tsx
+++ b/libs/client/invitations/src/pages/invitation-accept-page.tsx
@@ -1,6 +1,6 @@
 import {AuthShell, useAuthState, useRefreshAuth} from '@shipfox/client-auth';
-import {Alert} from '@shipfox/react-ui/alert';
 import {Button} from '@shipfox/react-ui/button';
+import {Callout} from '@shipfox/react-ui/callout';
 import {ShipfoxLoader} from '@shipfox/react-ui/loader';
 import {toast} from '@shipfox/react-ui/toast';
 import {Text} from '@shipfox/react-ui/typography';
@@ -90,9 +90,9 @@ export function InvitationAcceptPage() {
   if (!token) {
     return (
       <AuthShell title="Invalid link" description="This invitation link is incomplete.">
-        <Alert variant="error">
+        <Callout role="alert" type="error">
           This invitation link is missing a token. Ask your administrator to resend it.
-        </Alert>
+        </Callout>
         <Text size="sm" className="text-center text-foreground-neutral-muted" aria-live="polite">
           Redirecting to the dashboard…
         </Text>
@@ -111,9 +111,9 @@ export function InvitationAcceptPage() {
   if (preview.isError) {
     return (
       <AuthShell title="Couldn't load invitation" description="Try again in a moment.">
-        <Alert variant="error">
+        <Callout role="alert" type="error">
           We couldn't reach the server. Check your connection and retry.
-        </Alert>
+        </Callout>
         <Button className="w-full" onClick={() => preview.refetch()}>
           Try again
         </Button>
@@ -130,9 +130,9 @@ export function InvitationAcceptPage() {
     notifyOnce(`invalid:${token}`, () => toast.error('This invitation link is no longer valid.'));
     return (
       <AuthShell title="Invalid invitation" description="The link you used didn't work.">
-        <Alert variant="error">
+        <Callout role="alert" type="error">
           This invitation link is not valid. Ask your administrator to send a new one.
-        </Alert>
+        </Callout>
         <GoHomeButton navigate={navigate} />
       </AuthShell>
     );
@@ -142,10 +142,10 @@ export function InvitationAcceptPage() {
     notifyOnce(`expired:${token}`, () => toast.error('This invitation has expired.'));
     return (
       <AuthShell title="Invitation expired" description="The link is no longer accepting joins.">
-        <Alert variant="error">
+        <Callout role="alert" type="error">
           This invitation expired on {formatDate(data.expires_at)}. Ask your administrator to send a
           new one.
-        </Alert>
+        </Callout>
         <GoHomeButton navigate={navigate} />
       </AuthShell>
     );
@@ -157,12 +157,12 @@ export function InvitationAcceptPage() {
     );
     return (
       <AuthShell title="Invitation already used" description={data.workspace_name}>
-        <Alert variant="info">
+        <Callout role="alert" type="info">
           This invitation has already been accepted.{' '}
           {auth.isAuthenticated
             ? `Open your dashboard to access ${data.workspace_name} if your account is a member.`
             : `Log in to access ${data.workspace_name}.`}
-        </Alert>
+        </Callout>
         {auth.isAuthenticated ? null : (
           <Button asChild className="w-full">
             <Link to="/auth/login">Log in</Link>
@@ -206,9 +206,9 @@ export function InvitationAcceptPage() {
     const logoutHref = `/auth/logout?redirect=${encodeURIComponent(redirect)}`;
     return (
       <AuthShell title={data.workspace_name} description={inviterLine}>
-        <Alert variant="warning">
+        <Callout role="alert" type="warning">
           You're signed in as {auth.user?.email}, but this invitation is for {data.email}.
-        </Alert>
+        </Callout>
         <div className="flex flex-col gap-16">
           <Button asChild className="w-full">
             <Link to={logoutHref}>Log out and continue</Link>
@@ -230,9 +230,9 @@ export function InvitationAcceptPage() {
   if (accept.isError) {
     return (
       <AuthShell title={data.workspace_name} description={inviterLine}>
-        <Alert variant="error">
+        <Callout role="alert" type="error">
           We couldn't add you to {data.workspace_name}. Try again in a moment.
-        </Alert>
+        </Callout>
         <Button
           className="w-full"
           isLoading={accept.isPending}

--- a/libs/client/projects/src/components/workspace-setup-guard.tsx
+++ b/libs/client/projects/src/components/workspace-setup-guard.tsx
@@ -7,8 +7,8 @@ import {
 } from '@shipfox/client-agent';
 import {ApiError} from '@shipfox/client-api';
 import {integrationsQueryKeys, listSourceConnections} from '@shipfox/client-integrations';
-import {Alert} from '@shipfox/react-ui/alert';
 import {Button} from '@shipfox/react-ui/button';
+import {Callout} from '@shipfox/react-ui/callout';
 import {FullPageLoader} from '@shipfox/react-ui/loader';
 import {Header, Text} from '@shipfox/react-ui/typography';
 import type {QueryClient} from '@tanstack/react-query';
@@ -123,7 +123,7 @@ function WorkspaceSetupError({message, onRetry}: {message: string; onRetry: () =
     <main className="min-h-screen bg-background-subtle-base px-24 py-32 max-[520px]:px-16">
       <div className="mx-auto flex w-full max-w-[640px] flex-col gap-24">
         <Header variant="h1">Workspace setup</Header>
-        <Alert variant="error">
+        <Callout role="alert" type="error">
           <div className="flex flex-col gap-8">
             <Text size="sm" bold>
               Could not load workspace setup
@@ -133,7 +133,7 @@ function WorkspaceSetupError({message, onRetry}: {message: string; onRetry: () =
               Retry
             </Button>
           </div>
-        </Alert>
+        </Callout>
       </div>
     </main>
   );
@@ -150,7 +150,7 @@ function WorkspaceRouteError({message, onRetry}: {message: string; onRetry: () =
     <main className="min-h-screen bg-background-subtle-base px-24 py-32 max-[520px]:px-16">
       <div className="mx-auto flex w-full max-w-[640px] flex-col gap-24">
         <Header variant="h1">Workspace</Header>
-        <Alert variant="error">
+        <Callout role="alert" type="error">
           <div className="flex flex-col gap-8">
             <Text size="sm" bold>
               Could not load workspace
@@ -160,7 +160,7 @@ function WorkspaceRouteError({message, onRetry}: {message: string; onRetry: () =
               Retry
             </Button>
           </div>
-        </Alert>
+        </Callout>
       </div>
     </main>
   );

--- a/libs/client/projects/src/pages/create-project-page.tsx
+++ b/libs/client/projects/src/pages/create-project-page.tsx
@@ -13,8 +13,8 @@ import {
   useSourceConnectionsQuery,
 } from '@shipfox/client-integrations';
 import {displayNameFieldError} from '@shipfox/client-ui';
-import {Alert} from '@shipfox/react-ui/alert';
 import {Button} from '@shipfox/react-ui/button';
+import {Callout} from '@shipfox/react-ui/callout';
 import {FormField, FormFieldInput, fieldError} from '@shipfox/react-ui/form-field';
 import {FullPageLoader} from '@shipfox/react-ui/loader';
 import {toast} from '@shipfox/react-ui/toast';
@@ -185,7 +185,7 @@ export function CreateProjectPage() {
       <ModelProviderReminderBanner workspaceId={workspace.id} />
 
       {connectionsQuery.isError ? (
-        <Alert variant="error">
+        <Callout role="alert" type="error">
           <div className="flex w-full flex-wrap items-center justify-between gap-12">
             <Text size="sm" className="min-w-[240px] flex-1">
               Could not load source integrations. Refresh the integrations list to continue.
@@ -199,7 +199,7 @@ export function CreateProjectPage() {
               Refresh integrations
             </Button>
           </div>
-        </Alert>
+        </Callout>
       ) : null}
 
       <form
@@ -275,11 +275,11 @@ export function CreateProjectPage() {
             </div>
 
             {formError ? (
-              <Alert variant="error" animated={false}>
+              <Callout role="alert" type="error">
                 <div ref={errorRef} tabIndex={-1}>
                   {formError}
                 </div>
-              </Alert>
+              </Callout>
             ) : null}
 
             <ProjectSummary

--- a/libs/client/projects/src/pages/project-workflows-page.tsx
+++ b/libs/client/projects/src/pages/project-workflows-page.tsx
@@ -2,8 +2,8 @@ import type {DefinitionDto, DefinitionSyncSummaryDto} from '@shipfox/api-definit
 import {ApiError} from '@shipfox/client-api';
 import {QueryLoadError} from '@shipfox/client-ui';
 import {useFireManualWorkflowMutation} from '@shipfox/client-workflows';
-import {Alert} from '@shipfox/react-ui/alert';
 import {Button} from '@shipfox/react-ui/button';
+import {Callout} from '@shipfox/react-ui/callout';
 import {EmptyState} from '@shipfox/react-ui/empty-state';
 import {Icon, type IconName} from '@shipfox/react-ui/icon';
 import {LoadErrorState} from '@shipfox/react-ui/load-error-state';
@@ -314,14 +314,14 @@ function WorkflowDefinitionsList({
       </div>
 
       {isFetchNextPageError ? (
-        <Alert variant="error" animated={false}>
+        <Callout role="alert" type="error">
           <div className="flex items-center justify-between gap-12">
             <Text size="sm">Could not load more workflows.</Text>
             <Button size="sm" variant="secondary" onClick={onLoadMore}>
               Retry
             </Button>
           </div>
-        </Alert>
+        </Callout>
       ) : null}
 
       {hasNextPage ? (
@@ -358,7 +358,7 @@ function WorkflowSyncAlert({sync}: {sync: DefinitionSyncSummaryDto | null | unde
   if (sync?.status !== 'failed') return null;
 
   return (
-    <Alert variant="error" animated={false}>
+    <Callout role="alert" type="error">
       <div className="flex flex-col gap-4">
         <Text size="sm" bold>
           Workflow sync failed
@@ -367,7 +367,7 @@ function WorkflowSyncAlert({sync}: {sync: DefinitionSyncSummaryDto | null | unde
           {sync.last_error_message ?? 'The latest workflow sync failed before definitions updated.'}
         </Text>
       </div>
-    </Alert>
+    </Callout>
   );
 }
 

--- a/libs/client/projects/src/pages/projects-hub-page.tsx
+++ b/libs/client/projects/src/pages/projects-hub-page.tsx
@@ -7,8 +7,8 @@ import {
   useIntegrationConnectionsQuery,
 } from '@shipfox/client-integrations';
 import {QueryLoadError} from '@shipfox/client-ui';
-import {Alert} from '@shipfox/react-ui/alert';
 import {Button} from '@shipfox/react-ui/button';
+import {Callout} from '@shipfox/react-ui/callout';
 import {Card} from '@shipfox/react-ui/card';
 import {EmptyState} from '@shipfox/react-ui/empty-state';
 import {Icon} from '@shipfox/react-ui/icon';
@@ -109,11 +109,11 @@ export function ProjectsHubPage() {
             ))}
           </ul>
           {query.error && query.data ? (
-            <Alert variant="error" className="mt-16">
+            <Callout role="alert" type="error" className="mt-16">
               <Text size="sm">
                 Could not load the next page. Existing projects are still shown.
               </Text>
-            </Alert>
+            </Callout>
           ) : null}
           {query.hasNextPage ? (
             <div className="mt-16 flex justify-center">

--- a/libs/client/runners/src/components/create-manual-registration-token-form.tsx
+++ b/libs/client/runners/src/components/create-manual-registration-token-form.tsx
@@ -1,5 +1,4 @@
 import type {CreateManualRegistrationTokenResponseDto} from '@shipfox/api-runners-dto';
-import {Alert} from '@shipfox/react-ui/alert';
 import {Button} from '@shipfox/react-ui/button';
 import {Callout, CalloutContent, CalloutDescription, CalloutTitle} from '@shipfox/react-ui/callout';
 import {FormField, FormFieldInput, fieldError} from '@shipfox/react-ui/form-field';
@@ -119,14 +118,14 @@ export function CreateManualRegistrationTokenForm({
           </form.Subscribe>
         </form>
         {formError ? (
-          <Alert variant="error" animated={false}>
+          <Callout role="alert" type="error">
             <div className="flex flex-col gap-8">
               <Text size="sm" bold>
                 Could not create token
               </Text>
               <Text size="sm">{formError}</Text>
             </div>
-          </Alert>
+          </Callout>
         ) : null}
       </ModalBody>
       <ModalFooter>

--- a/libs/client/runners/src/components/create-provisioner-token-form.tsx
+++ b/libs/client/runners/src/components/create-provisioner-token-form.tsx
@@ -1,5 +1,4 @@
 import type {CreateProvisionerTokenResponseDto} from '@shipfox/api-runners-dto';
-import {Alert} from '@shipfox/react-ui/alert';
 import {Button} from '@shipfox/react-ui/button';
 import {Callout, CalloutContent, CalloutDescription, CalloutTitle} from '@shipfox/react-ui/callout';
 import {FormField, FormFieldInput, fieldError} from '@shipfox/react-ui/form-field';
@@ -119,14 +118,14 @@ export function CreateProvisionerTokenForm({
           </form.Subscribe>
         </form>
         {formError ? (
-          <Alert variant="error" animated={false}>
+          <Callout role="alert" type="error">
             <div className="flex flex-col gap-8">
               <Text size="sm" bold>
                 Could not create token
               </Text>
               <Text size="sm">{formError}</Text>
             </div>
-          </Alert>
+          </Callout>
         ) : null}
       </ModalBody>
       <ModalFooter>

--- a/libs/client/runners/src/components/manual-registration-token-list.tsx
+++ b/libs/client/runners/src/components/manual-registration-token-list.tsx
@@ -1,6 +1,6 @@
 import type {ManualRegistrationTokenDto} from '@shipfox/api-runners-dto';
-import {Alert} from '@shipfox/react-ui/alert';
 import {Button, IconButton} from '@shipfox/react-ui/button';
+import {Callout} from '@shipfox/react-ui/callout';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -197,9 +197,9 @@ function RevokeManualRegistrationTokenButton({
               expire on their own.
             </Text>
             {revokeToken.isError ? (
-              <Alert variant="error" animated={false}>
+              <Callout role="alert" type="error">
                 <Text size="sm">{manualRegistrationTokenErrorMessage(revokeToken.error)}</Text>
-              </Alert>
+              </Callout>
             ) : null}
           </ModalBody>
           <ModalFooter>

--- a/libs/client/runners/src/components/provisioner-token-list.tsx
+++ b/libs/client/runners/src/components/provisioner-token-list.tsx
@@ -1,6 +1,6 @@
 import type {ProvisionerTokenDto} from '@shipfox/api-runners-dto';
-import {Alert} from '@shipfox/react-ui/alert';
 import {Button, IconButton} from '@shipfox/react-ui/button';
+import {Callout} from '@shipfox/react-ui/callout';
 import {Dot} from '@shipfox/react-ui/dot';
 import {
   DropdownMenu,
@@ -235,9 +235,9 @@ function RevokeProvisionerTokenButton({
               keep running until their leases expire.
             </Text>
             {revokeToken.isError ? (
-              <Alert variant="error" animated={false}>
+              <Callout role="alert" type="error">
                 <Text size="sm">{provisionerTokenErrorMessage(revokeToken.error)}</Text>
-              </Alert>
+              </Callout>
             ) : null}
           </ModalBody>
           <ModalFooter>

--- a/libs/client/secrets/src/components/delete-entry-dialog.tsx
+++ b/libs/client/secrets/src/components/delete-entry-dialog.tsx
@@ -1,5 +1,5 @@
-import {Alert} from '@shipfox/react-ui/alert';
 import {Button} from '@shipfox/react-ui/button';
+import {Callout} from '@shipfox/react-ui/callout';
 import {
   Modal,
   ModalBody,
@@ -38,9 +38,9 @@ export function DeleteEntryDialog({
             Workflows that reference <strong>{entryKey}</strong> will fail at their next run.
           </Text>
           {errorMessage ? (
-            <Alert variant="error" animated={false}>
+            <Callout role="alert" type="error">
               <Text size="sm">{errorMessage}</Text>
-            </Alert>
+            </Callout>
           ) : null}
         </ModalBody>
         <ModalFooter>

--- a/libs/client/secrets/src/components/form-errors.ts
+++ b/libs/client/secrets/src/components/form-errors.ts
@@ -5,7 +5,7 @@ export type SecretsFormField = 'key';
 /**
  * Classifies a management error into either a field-level message (routed to
  * the `key` field via `errorMap.onServer`) or a form-level message (rendered
- * in an `<Alert>`). Shared by the secret and variable forms because both hit
+ * in an `<Callout role="alert"`). Shared by the secret and variable forms because both hit
  * the same management routes / `ClientError` codes.
  */
 export type SecretsFormErrorMapping =

--- a/libs/client/secrets/src/components/secret-form.tsx
+++ b/libs/client/secrets/src/components/secret-form.tsx
@@ -1,6 +1,6 @@
 import {isShortSecretValue} from '@shipfox/api-secrets-dto';
-import {Alert} from '@shipfox/react-ui/alert';
 import {Button, IconButton} from '@shipfox/react-ui/button';
+import {Callout} from '@shipfox/react-ui/callout';
 import {
   FormField,
   FormFieldInput,
@@ -140,21 +140,21 @@ export function SecretForm({
                   />
                 </div>
                 {isShortSecretValue(field.state.value, SHORT_VALUE_THRESHOLD) ? (
-                  <Alert variant="warning" animated={false}>
+                  <Callout role="alert" type="warning">
                     <Text size="sm">
                       Very short secrets can match ordinary log text and redact unrelated output. If
                       this value is not sensitive, store it as a Variable instead.
                     </Text>
-                  </Alert>
+                  </Callout>
                 ) : null}
               </FormField>
             )}
           </form.Field>
         </form>
         {formError ? (
-          <Alert variant="error" animated={false}>
+          <Callout role="alert" type="error">
             <Text size="sm">{formError}</Text>
-          </Alert>
+          </Callout>
         ) : null}
       </FormBody>
       <FormFooter>

--- a/libs/client/secrets/src/components/variable-form.tsx
+++ b/libs/client/secrets/src/components/variable-form.tsx
@@ -1,6 +1,6 @@
 import {isSensitiveSecretName} from '@shipfox/api-secrets-dto';
-import {Alert} from '@shipfox/react-ui/alert';
 import {Button} from '@shipfox/react-ui/button';
+import {Callout} from '@shipfox/react-ui/callout';
 import {
   FormField,
   FormFieldInput,
@@ -119,12 +119,12 @@ export function VariableForm({
                   onBlur={field.handleBlur}
                 />
                 {isSensitiveSecretName(field.state.value) ? (
-                  <Alert variant="warning" animated={false}>
+                  <Callout role="alert" type="warning">
                     <Text size="sm" aria-live="polite">
                       This looks like it may be sensitive. Variables are stored in plaintext and are
                       not redacted from logs. Use a Secret if this value contains private data.
                     </Text>
-                  </Alert>
+                  </Callout>
                 ) : null}
               </FormField>
             )}
@@ -154,14 +154,14 @@ export function VariableForm({
           </form.Field>
         </form>
         {awaitingFullValue && fullValueQuery.isError ? (
-          <Alert variant="error" animated={false}>
+          <Callout role="alert" type="error">
             <Text size="sm">Could not load the current value. Close and try again.</Text>
-          </Alert>
+          </Callout>
         ) : null}
         {formError ? (
-          <Alert variant="error" animated={false}>
+          <Callout role="alert" type="error">
             <Text size="sm">{formError}</Text>
-          </Alert>
+          </Callout>
         ) : null}
       </FormBody>
       <FormFooter>

--- a/libs/client/triggers/src/components/events-list-states.tsx
+++ b/libs/client/triggers/src/components/events-list-states.tsx
@@ -1,6 +1,6 @@
 import type {QueryLoadErrorQuery} from '@shipfox/client-ui';
-import {Alert} from '@shipfox/react-ui/alert';
 import {Button} from '@shipfox/react-ui/button';
+import {Callout} from '@shipfox/react-ui/callout';
 import {EmptyState} from '@shipfox/react-ui/empty-state';
 import {Skeleton} from '@shipfox/react-ui/skeleton';
 import {Text} from '@shipfox/react-ui/typography';
@@ -68,7 +68,7 @@ export function EventsListNoMatches({onClear}: {onClear: () => void}) {
 export function EventsListStaleError({query}: {query: QueryLoadErrorQuery}) {
   return (
     <div className="p-8">
-      <Alert variant="error" animated={false}>
+      <Callout role="alert" type="error">
         <div className="flex items-center justify-between gap-8">
           <Text size="xs">Could not refresh events.</Text>
           <Button
@@ -83,7 +83,7 @@ export function EventsListStaleError({query}: {query: QueryLoadErrorQuery}) {
             Retry
           </Button>
         </div>
-      </Alert>
+      </Callout>
     </div>
   );
 }

--- a/libs/client/triggers/src/components/trigger-event-detail.tsx
+++ b/libs/client/triggers/src/components/trigger-event-detail.tsx
@@ -1,7 +1,7 @@
 import type {TriggerDecisionDto, TriggerEventDetailResponseDto} from '@shipfox/api-triggers-dto';
-import {Alert} from '@shipfox/react-ui/alert';
 import {Badge} from '@shipfox/react-ui/badge';
 import {Button} from '@shipfox/react-ui/button';
+import {Callout} from '@shipfox/react-ui/callout';
 import {
   CodeBlock,
   CodeBlockBody,
@@ -184,14 +184,14 @@ function TriggerEventDetailError({onBack, onRetry}: {onBack: () => void; onRetry
       >
         Back to events
       </Button>
-      <Alert variant="error" animated={false}>
+      <Callout role="alert" type="error">
         <div className="flex items-center justify-between gap-12">
           <Text size="sm">Event detail could not be loaded.</Text>
           <Button type="button" variant="secondary" size="xs" onClick={onRetry}>
             Retry
           </Button>
         </div>
-      </Alert>
+      </Callout>
     </aside>
   );
 }

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-states.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-states.tsx
@@ -1,6 +1,6 @@
 import type {QueryLoadErrorQuery} from '@shipfox/client-ui';
-import {Alert} from '@shipfox/react-ui/alert';
 import {Button} from '@shipfox/react-ui/button';
+import {Callout} from '@shipfox/react-ui/callout';
 import {EmptyState} from '@shipfox/react-ui/empty-state';
 import {Skeleton} from '@shipfox/react-ui/skeleton';
 import {Text} from '@shipfox/react-ui/typography';
@@ -36,7 +36,7 @@ export function WorkflowRunListSkeleton() {
 export function WorkflowRunListStaleError({query}: {query: QueryLoadErrorQuery}) {
   return (
     <div className="border-b border-border-neutral-base p-8">
-      <Alert variant="error" animated={false}>
+      <Callout role="alert" type="error">
         <div className="flex items-center justify-between gap-8">
           <Text size="xs">Could not refresh workflow runs.</Text>
           <Button
@@ -51,7 +51,7 @@ export function WorkflowRunListStaleError({query}: {query: QueryLoadErrorQuery})
             Retry
           </Button>
         </div>
-      </Alert>
+      </Callout>
     </div>
   );
 }

--- a/libs/client/workflows/src/components/workflow-run-view/step-attempt-log-panel.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/step-attempt-log-panel.tsx
@@ -4,8 +4,8 @@ import {
   LogViewSkeleton,
   useStepAttemptLogsQuery,
 } from '@shipfox/client-logs';
-import {Alert} from '@shipfox/react-ui/alert';
 import {Button} from '@shipfox/react-ui/button';
+import {Callout} from '@shipfox/react-ui/callout';
 import {Text} from '@shipfox/react-ui/typography';
 import {type UIEvent, useEffect, useRef} from 'react';
 
@@ -85,7 +85,7 @@ export function StepAttemptLogPanel({
   return (
     <div ref={panelRef} className="flex min-w-0 flex-col gap-8">
       {staleError ? (
-        <Alert variant="warning" animated={false} className="px-10 py-8">
+        <Callout role="alert" type="warning" className="px-10 py-8">
           <div className="flex min-w-0 flex-1 items-center justify-between gap-8">
             <Text size="xs">Could not refresh logs.</Text>
             <Button
@@ -98,7 +98,7 @@ export function StepAttemptLogPanel({
               Retry
             </Button>
           </div>
-        </Alert>
+        </Callout>
       ) : null}
       <LogView
         records={records}
@@ -140,13 +140,13 @@ function isTerminalAttemptStatus(status: string): boolean {
 
 function StepLogsError({retrying, onRetry}: {retrying: boolean; onRetry: () => void}) {
   return (
-    <Alert variant="error" animated={false} className="px-10 py-8">
+    <Callout role="alert" type="error" className="px-10 py-8">
       <div className="flex min-w-0 flex-1 items-center justify-between gap-8">
         <Text size="xs">Could not load logs.</Text>
         <Button type="button" size="2xs" variant="secondary" isLoading={retrying} onClick={onRetry}>
           Retry
         </Button>
       </div>
-    </Alert>
+    </Callout>
   );
 }

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-states.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-states.tsx
@@ -1,6 +1,6 @@
 import type {QueryLoadErrorQuery} from '@shipfox/client-ui';
-import {Alert} from '@shipfox/react-ui/alert';
 import {Button} from '@shipfox/react-ui/button';
+import {Callout} from '@shipfox/react-ui/callout';
 import {EmptyState} from '@shipfox/react-ui/empty-state';
 import {Skeleton} from '@shipfox/react-ui/skeleton';
 import {Text} from '@shipfox/react-ui/typography';
@@ -49,7 +49,7 @@ export function WorkflowRunNotFound() {
 export function WorkflowRunStaleError({query}: {query: QueryLoadErrorQuery}) {
   return (
     <div className="border-b border-border-neutral-base p-8">
-      <Alert variant="error" animated={false}>
+      <Callout role="alert" type="error">
         <div className="flex items-center justify-between gap-8">
           <Text size="xs">Could not refresh this run.</Text>
           <Button
@@ -64,7 +64,7 @@ export function WorkflowRunStaleError({query}: {query: QueryLoadErrorQuery}) {
             Retry
           </Button>
         </div>
-      </Alert>
+      </Callout>
     </div>
   );
 }

--- a/libs/client/workspace-settings/src/components/members/workspace-members-section.tsx
+++ b/libs/client/workspace-settings/src/components/members/workspace-members-section.tsx
@@ -2,9 +2,9 @@ import {createInvitationBodySchema, type MembershipWithUserDto} from '@shipfox/a
 import {ApiError} from '@shipfox/client-api';
 import {useAuthState} from '@shipfox/client-auth';
 import {QueryLoadError} from '@shipfox/client-ui';
-import {Alert} from '@shipfox/react-ui/alert';
 import {Badge} from '@shipfox/react-ui/badge';
 import {Button} from '@shipfox/react-ui/button';
+import {Callout} from '@shipfox/react-ui/callout';
 import {EmptyState} from '@shipfox/react-ui/empty-state';
 import {FormField, FormFieldInput, fieldError} from '@shipfox/react-ui/form-field';
 import {Icon} from '@shipfox/react-ui/icon';
@@ -383,7 +383,11 @@ function InviteMemberModal({
           <Text size="lg">Invite a member</Text>
         </ModalHeader>
         <ModalBody className="gap-16">
-          {formError ? <Alert variant="error">{formError}</Alert> : null}
+          {formError ? (
+            <Callout role="alert" type="error">
+              {formError}
+            </Callout>
+          ) : null}
           <form
             id="invite-member-form"
             className="flex flex-col gap-16"

--- a/libs/shared/react/ui/src/components/alert/alert.stories.tsx
+++ b/libs/shared/react/ui/src/components/alert/alert.stories.tsx
@@ -25,7 +25,7 @@ const meta = {
   },
   args: {
     variant: 'default',
-    animated: false,
+    animated: true,
   },
 } satisfies Meta<typeof Alert>;
 
@@ -53,7 +53,7 @@ export const Variants: Story = {
   render: () => (
     <div className="flex min-w-500 flex-col gap-16">
       {variants.map((variant) => (
-        <Alert key={variant} variant={variant} animated={false}>
+        <Alert key={variant} variant={variant}>
           <AlertContent>
             <AlertTitle>{variant}</AlertTitle>
             <AlertDescription>Short message explaining the current status.</AlertDescription>
@@ -73,7 +73,7 @@ export const DesignMock: Story = {
       </Header>
       <div className="flex min-w-500 flex-col gap-16">
         {variants.map((variant) => (
-          <Alert key={variant} variant={variant} animated={false}>
+          <Alert key={variant} variant={variant}>
             <AlertContent>
               <AlertTitle>Title</AlertTitle>
               <AlertDescription>Description</AlertDescription>

--- a/libs/shared/react/ui/src/components/alert/alert.stories.tsx
+++ b/libs/shared/react/ui/src/components/alert/alert.stories.tsx
@@ -25,7 +25,7 @@ const meta = {
   },
   args: {
     variant: 'default',
-    animated: true,
+    animated: false,
   },
 } satisfies Meta<typeof Alert>;
 
@@ -53,7 +53,7 @@ export const Variants: Story = {
   render: () => (
     <div className="flex min-w-500 flex-col gap-16">
       {variants.map((variant) => (
-        <Alert key={variant} variant={variant}>
+        <Alert key={variant} variant={variant} animated={false}>
           <AlertContent>
             <AlertTitle>{variant}</AlertTitle>
             <AlertDescription>Short message explaining the current status.</AlertDescription>
@@ -73,7 +73,7 @@ export const DesignMock: Story = {
       </Header>
       <div className="flex min-w-500 flex-col gap-16">
         {variants.map((variant) => (
-          <Alert key={variant} variant={variant}>
+          <Alert key={variant} variant={variant} animated={false}>
             <AlertContent>
               <AlertTitle>Title</AlertTitle>
               <AlertDescription>Description</AlertDescription>

--- a/libs/shared/react/ui/src/components/alert/alert.tsx
+++ b/libs/shared/react/ui/src/components/alert/alert.tsx
@@ -13,40 +13,8 @@ import {
   useState,
 } from 'react';
 import {cn} from '#utils/cn.js';
+import {Callout, type CalloutType} from '../callout/index.js';
 import {Icon} from '../icon/index.js';
-
-const alertVariants = cva(
-  'relative w-full rounded-l-4 rounded-r-8 px-16 py-12 text-sm flex gap-12 items-start border',
-  {
-    variants: {
-      variant: {
-        default: 'bg-tag-neutral-bg text-foreground-neutral-base border-tag-neutral-border',
-        info: 'bg-tag-blue-bg text-foreground-neutral-base border-tag-blue-border',
-        success: 'bg-tag-success-bg text-foreground-neutral-base border-tag-success-border',
-        warning: 'bg-tag-warning-bg text-foreground-neutral-base border-tag-warning-border',
-        error: 'bg-tag-error-bg text-foreground-neutral-base border-tag-error-border',
-      },
-    },
-    defaultVariants: {
-      variant: 'default',
-    },
-  },
-);
-
-const alertLineVariants = cva('w-4 self-stretch rounded-full', {
-  variants: {
-    variant: {
-      default: 'bg-tag-neutral-icon',
-      info: 'bg-tag-blue-icon',
-      success: 'bg-tag-success-icon',
-      warning: 'bg-tag-warning-icon',
-      error: 'bg-tag-error-icon',
-    },
-  },
-  defaultVariants: {
-    variant: 'default',
-  },
-});
 
 const closeIconVariants = cva('w-16 h-16', {
   variants: {
@@ -71,7 +39,7 @@ const alertDefaultTransition: Transition = {
 type AlertContextValue = {
   isOpen: boolean;
   onClose: () => void;
-  variant: VariantProps<typeof alertVariants>['variant'];
+  variant: CalloutType;
 };
 
 const AlertContext = createContext<AlertContextValue | null>(null);
@@ -84,15 +52,15 @@ function useAlertContext() {
   return context;
 }
 
-type AlertProps = ComponentProps<'div'> &
-  VariantProps<typeof alertVariants> & {
-    open?: boolean;
-    defaultOpen?: boolean;
-    onOpenChange?: (open: boolean) => void;
-    animated?: boolean;
-    transition?: Transition;
-    autoClose?: number;
-  };
+type AlertProps = ComponentProps<'div'> & {
+  variant?: CalloutType;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  animated?: boolean;
+  transition?: Transition;
+  autoClose?: number;
+};
 
 function Alert({
   className,
@@ -140,30 +108,26 @@ function Alert({
     variant,
   };
 
+  const alert = (
+    <AlertContext.Provider value={contextValue}>
+      <Callout
+        data-slot="alert"
+        role="alert"
+        type={variant}
+        className={cn('relative', className)}
+        {...props}
+      >
+        {children}
+      </Callout>
+    </AlertContext.Provider>
+  );
+
   if (!animated) {
     if (!isOpen) {
       return null;
     }
 
-    return (
-      <AlertContext.Provider value={contextValue}>
-        <div className="w-full flex items-start gap-4">
-          <div
-            data-slot="alert-line"
-            className={cn(alertLineVariants({variant}))}
-            aria-hidden="true"
-          />
-          <div
-            data-slot="alert"
-            role="alert"
-            className={cn(alertVariants({variant}), className)}
-            {...props}
-          >
-            {children}
-          </div>
-        </div>
-      </AlertContext.Provider>
-    );
+    return alert;
   }
 
   return (
@@ -177,21 +141,7 @@ function Alert({
           exit={{opacity: 0}}
           transition={transition}
         >
-          <AlertContext.Provider value={contextValue}>
-            <div
-              data-slot="alert-line"
-              className={cn(alertLineVariants({variant}))}
-              aria-hidden="true"
-            />
-            <div
-              data-slot="alert"
-              role="alert"
-              className={cn(alertVariants({variant}), className)}
-              {...props}
-            >
-              {children}
-            </div>
-          </AlertContext.Provider>
+          {alert}
         </motion.div>
       )}
     </AnimatePresence>

--- a/libs/shared/react/ui/src/components/alert/alert.tsx
+++ b/libs/shared/react/ui/src/components/alert/alert.tsx
@@ -13,8 +13,40 @@ import {
   useState,
 } from 'react';
 import {cn} from '#utils/cn.js';
-import {Callout, type CalloutType} from '../callout/index.js';
 import {Icon} from '../icon/index.js';
+
+const alertVariants = cva(
+  'relative w-full rounded-l-4 rounded-r-8 px-16 py-12 text-sm flex gap-12 items-start border',
+  {
+    variants: {
+      variant: {
+        default: 'bg-tag-neutral-bg text-foreground-neutral-base border-tag-neutral-border',
+        info: 'bg-tag-blue-bg text-foreground-neutral-base border-tag-blue-border',
+        success: 'bg-tag-success-bg text-foreground-neutral-base border-tag-success-border',
+        warning: 'bg-tag-warning-bg text-foreground-neutral-base border-tag-warning-border',
+        error: 'bg-tag-error-bg text-foreground-neutral-base border-tag-error-border',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+const alertLineVariants = cva('w-4 self-stretch rounded-full', {
+  variants: {
+    variant: {
+      default: 'bg-tag-neutral-icon',
+      info: 'bg-tag-blue-icon',
+      success: 'bg-tag-success-icon',
+      warning: 'bg-tag-warning-icon',
+      error: 'bg-tag-error-icon',
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+  },
+});
 
 const closeIconVariants = cva('w-16 h-16', {
   variants: {
@@ -39,7 +71,7 @@ const alertDefaultTransition: Transition = {
 type AlertContextValue = {
   isOpen: boolean;
   onClose: () => void;
-  variant: CalloutType;
+  variant: VariantProps<typeof alertVariants>['variant'];
 };
 
 const AlertContext = createContext<AlertContextValue | null>(null);
@@ -52,15 +84,15 @@ function useAlertContext() {
   return context;
 }
 
-type AlertProps = ComponentProps<'div'> & {
-  variant?: CalloutType;
-  open?: boolean;
-  defaultOpen?: boolean;
-  onOpenChange?: (open: boolean) => void;
-  animated?: boolean;
-  transition?: Transition;
-  autoClose?: number;
-};
+type AlertProps = ComponentProps<'div'> &
+  VariantProps<typeof alertVariants> & {
+    open?: boolean;
+    defaultOpen?: boolean;
+    onOpenChange?: (open: boolean) => void;
+    animated?: boolean;
+    transition?: Transition;
+    autoClose?: number;
+  };
 
 function Alert({
   className,
@@ -108,26 +140,30 @@ function Alert({
     variant,
   };
 
-  const alert = (
-    <AlertContext.Provider value={contextValue}>
-      <Callout
-        data-slot="alert"
-        role="alert"
-        type={variant}
-        className={cn('relative', className)}
-        {...props}
-      >
-        {children}
-      </Callout>
-    </AlertContext.Provider>
-  );
-
   if (!animated) {
     if (!isOpen) {
       return null;
     }
 
-    return alert;
+    return (
+      <AlertContext.Provider value={contextValue}>
+        <div className="w-full flex items-start gap-4">
+          <div
+            data-slot="alert-line"
+            className={cn(alertLineVariants({variant}))}
+            aria-hidden="true"
+          />
+          <div
+            data-slot="alert"
+            role="alert"
+            className={cn(alertVariants({variant}), className)}
+            {...props}
+          >
+            {children}
+          </div>
+        </div>
+      </AlertContext.Provider>
+    );
   }
 
   return (
@@ -141,7 +177,21 @@ function Alert({
           exit={{opacity: 0}}
           transition={transition}
         >
-          {alert}
+          <AlertContext.Provider value={contextValue}>
+            <div
+              data-slot="alert-line"
+              className={cn(alertLineVariants({variant}))}
+              aria-hidden="true"
+            />
+            <div
+              data-slot="alert"
+              role="alert"
+              className={cn(alertVariants({variant}), className)}
+              {...props}
+            >
+              {children}
+            </div>
+          </AlertContext.Provider>
         </motion.div>
       )}
     </AnimatePresence>


### PR DESCRIPTION
Standardize static app notice usages on `Callout`.

`Callout` is now the preferred primitive for non-dismissible static notices, so this migrates static client `Alert` call sites to `Callout` while preserving `role=\"alert\"` announcements where those notices previously used Alert. The two dismissible or animated exceptions remain on `Alert`.

This intentionally leaves the `Alert` component implementation and stories unchanged; the PR only updates app call sites.

Review carefully around the broad static usage sweep.

Closes ENG-889