### PR TITLE
[api/workflows] Move job transition decisions into core

### DIFF
--- a/libs/api/workflows/src/core/index.ts
+++ b/libs/api/workflows/src/core/index.ts
@@ -27,6 +27,14 @@ export {
 } from './errors.js';
 export type {NextStep, RecordStepResultOutcome, RecordStepResultParams} from './job-execution.js';
 export {nextStepForJob, recordStepResult} from './job-execution.js';
+export {
+  type DecideJobActivationInput,
+  type DeriveJobSuccessResult,
+  decideJobActivation,
+  deriveJobExecutionOutputs,
+  deriveJobSuccess,
+  type JobActivationDecision,
+} from './job-transition/index.js';
 export type {RunWorkflowParams} from './run-workflow.js';
 export {runWorkflow} from './run-workflow.js';
 export {
@@ -35,6 +43,11 @@ export {
   materializeWorkflowModel,
   modelHasAgentStep,
 } from './step-config/index.js';
+export {
+  deriveInitialJobExecutionPlan,
+  deriveJobExecutionRunner,
+  materializeWorkflowRunJobs,
+} from './workflow-run-creation.js';
 export {
   type ScheduleRuntimeDagInput,
   scheduleRuntimeDag,

--- a/libs/api/workflows/src/core/job-transition/decide-job-activation.test.ts
+++ b/libs/api/workflows/src/core/job-transition/decide-job-activation.test.ts
@@ -1,0 +1,196 @@
+import {createWorkflowExpression} from '@shipfox/expression';
+import type {Job} from '../entities/job.js';
+import type {JobExecution} from '../entities/job-execution.js';
+import type {WorkflowRun} from '../entities/workflow-run.js';
+import {decideJobActivation} from './decide-job-activation.js';
+
+describe('decideJobActivation', () => {
+  test('starts a pending job without an activation condition', () => {
+    const run = workflowRun();
+    const job = workflowJob({key: 'build'});
+
+    const decision = decideJobActivation({run, job, dependencies: []});
+
+    expect(decision).toEqual({kind: 'start-job', jobId: job.id});
+  });
+
+  test('starts a failure-handling job when its dependency failed', () => {
+    const run = workflowRun();
+    const build = workflowJob({key: 'build', status: 'failed'});
+    const notify = workflowJob({key: 'notify', dependencies: ['build']});
+
+    const decision = decideJobActivation({
+      run,
+      job: notify,
+      condition: expression('jobs.build.status == "failed"'),
+      dependencies: [{job: build, executions: []}],
+    });
+
+    expect(decision).toEqual({kind: 'start-job', jobId: notify.id});
+  });
+
+  test('skips a conditional job when the predicate is false', () => {
+    const run = workflowRun();
+    const build = workflowJob({key: 'build', status: 'succeeded'});
+    const notify = workflowJob({key: 'notify', dependencies: ['build']});
+
+    const decision = decideJobActivation({
+      run,
+      job: notify,
+      condition: expression('jobs.build.status == "failed"'),
+      dependencies: [{job: build, executions: []}],
+    });
+
+    expect(decision).toEqual({
+      kind: 'skip-job',
+      jobId: notify.id,
+      status: 'skipped',
+      statusReason: 'condition_rejected',
+      evaluationTrace: [
+        expect.objectContaining({
+          expression: 'jobs.build.status == "failed"',
+          roots: ['jobs'],
+          value: 'false',
+          field: 'job.if',
+        }),
+      ],
+    });
+  });
+
+  test('marks skipped jobs as condition_errored when the predicate cannot evaluate', () => {
+    const run = workflowRun();
+    const build = workflowJob({key: 'build', status: 'succeeded'});
+    const notify = workflowJob({key: 'notify', dependencies: ['build']});
+
+    const decision = decideJobActivation({
+      run,
+      job: notify,
+      condition: expression('jobs.build.outputs.sha.missing == "abc123"'),
+      dependencies: [{job: build, executions: []}],
+    });
+
+    expect(decision).toEqual({
+      kind: 'skip-job',
+      jobId: notify.id,
+      status: 'skipped',
+      statusReason: 'condition_errored',
+      evaluationTrace: [
+        expect.objectContaining({
+          expression: 'jobs.build.outputs.sha.missing == "abc123"',
+          roots: ['jobs'],
+          value: 'false',
+          degraded: true,
+          field: 'job.if',
+        }),
+      ],
+    });
+  });
+
+  test('returns terminal jobs unchanged', () => {
+    const run = workflowRun();
+    const job = workflowJob({key: 'build', status: 'skipped', version: 4});
+
+    const decision = decideJobActivation({
+      run,
+      job,
+      condition: expression('false'),
+      dependencies: [],
+    });
+
+    expect(decision).toEqual({
+      kind: 'terminal-job',
+      jobId: job.id,
+      status: 'skipped',
+      jobVersion: 4,
+    });
+  });
+});
+
+function expression(source: string) {
+  return createWorkflowExpression({source, check: {mode: 'syntax'}});
+}
+
+function workflowRun(): WorkflowRun {
+  return {
+    id: crypto.randomUUID(),
+    workspaceId: crypto.randomUUID(),
+    projectId: crypto.randomUUID(),
+    definitionId: crypto.randomUUID(),
+    name: 'Run',
+    status: 'pending',
+    currentAttempt: 1,
+    triggerProvider: null,
+    triggerSource: 'manual',
+    triggerEvent: 'fire',
+    triggerPayload: {
+      source: 'manual',
+      event: 'fire',
+      subscriptionId: crypto.randomUUID(),
+      userId: crypto.randomUUID(),
+    },
+    inputs: null,
+    sourceSnapshot: null,
+    triggerIdempotencyKey: null,
+    timeoutMs: 3_600_000,
+    version: 1,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    startedAt: null,
+    finishedAt: null,
+  };
+}
+
+function workflowJob(params: Partial<Job> & Pick<Job, 'key'>): Job {
+  return {
+    id: crypto.randomUUID(),
+    workflowRunAttemptId: crypto.randomUUID(),
+    key: params.key,
+    mode: 'one_shot',
+    name: null,
+    status: params.status ?? 'pending',
+    statusReason: null,
+    carriedOver: false,
+    checkout: {permissions: {contents: 'read'}, persistCredentials: true},
+    success: null,
+    evaluationTrace: null,
+    executionTimeoutMs: null,
+    listeningTimeoutMs: null,
+    maxExecutions: null,
+    onResolve: null,
+    batchDebounceMs: null,
+    batchMaxSize: null,
+    batchMaxWaitMs: null,
+    listenerStatus: 'inactive',
+    resolutionReason: null,
+    listeningOn: null,
+    listeningUntil: null,
+    outputs: params.outputs ?? null,
+    dependencies: params.dependencies ?? [],
+    runner: ['ubuntu-latest'],
+    position: params.position ?? 0,
+    version: params.version ?? 1,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+  };
+}
+
+export function jobExecution(params: Partial<JobExecution> = {}): JobExecution {
+  return {
+    id: crypto.randomUUID(),
+    jobId: params.jobId ?? crypto.randomUUID(),
+    sequence: params.sequence ?? 1,
+    name: params.name ?? 'build',
+    runner: null,
+    status: params.status ?? 'succeeded',
+    statusReason: params.statusReason ?? null,
+    outputs: params.outputs ?? null,
+    triggerEvents: [],
+    version: 1,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    queuedAt: null,
+    startedAt: null,
+    finishedAt: null,
+    timedOutAt: null,
+  };
+}

--- a/libs/api/workflows/src/core/job-transition/decide-job-activation.ts
+++ b/libs/api/workflows/src/core/job-transition/decide-job-activation.ts
@@ -1,0 +1,79 @@
+import type {WorkflowExpression} from '@shipfox/expression';
+import {evaluatePlannedPredicateAtSite} from '@shipfox/expression';
+import {explicitConditionTrace} from '../condition-trace.js';
+import {isJobTerminal, type Job, type JobStatusReason} from '../entities/job.js';
+import type {WorkflowRun} from '../entities/workflow-run.js';
+import {
+  assembleJobActivationContext,
+  type JobContextInput,
+} from '../step-config/assemble-run-context.js';
+import type {RuntimeCompletionStatus} from '../workflow-scheduling/runtime-dag.js';
+import {runtimeCompletionStatusForJob} from './runtime-completion-status-for-job.js';
+
+export type JobActivationDecision =
+  | {
+      kind: 'start-job';
+      jobId: string;
+    }
+  | {
+      kind: 'skip-job';
+      jobId: string;
+      status: 'skipped';
+      statusReason: JobStatusReason;
+      evaluationTrace: ReturnType<typeof explicitConditionTrace>;
+    }
+  | {
+      kind: 'terminal-job';
+      jobId: string;
+      status: RuntimeCompletionStatus;
+      jobVersion: number;
+    };
+
+export interface DecideJobActivationInput {
+  run: WorkflowRun;
+  job: Job;
+  condition?: WorkflowExpression | undefined;
+  dependencies: readonly JobContextInput[];
+}
+
+export function decideJobActivation(input: DecideJobActivationInput): JobActivationDecision {
+  if (isJobTerminal(input.job.status)) {
+    return {
+      kind: 'terminal-job',
+      jobId: input.job.id,
+      status: runtimeCompletionStatusForJob(input.job.status),
+      jobVersion: input.job.version,
+    };
+  }
+
+  if (input.condition === undefined) return {kind: 'start-job', jobId: input.job.id};
+
+  const context = assembleJobActivationContext({
+    run: input.run,
+    triggerPayload: input.run.triggerPayload,
+    inputs: input.run.inputs,
+    jobs: input.dependencies,
+  });
+  const outcome = evaluatePlannedPredicateAtSite({
+    expression: input.condition,
+    field: 'job.if',
+    site: context.site,
+    context: context.values,
+  });
+  if (outcome.value) return {kind: 'start-job', jobId: input.job.id};
+
+  return {
+    kind: 'skip-job',
+    jobId: input.job.id,
+    status: 'skipped',
+    statusReason: outcome.evaluationFailed ? 'condition_errored' : 'condition_rejected',
+    evaluationTrace: explicitConditionTrace({
+      expression: input.condition,
+      field: 'job.if',
+      route: outcome.route,
+      site: context.site,
+      value: outcome.value,
+      degraded: outcome.evaluationFailed,
+    }),
+  };
+}

--- a/libs/api/workflows/src/core/job-transition/derive-job-execution-outputs.ts
+++ b/libs/api/workflows/src/core/job-transition/derive-job-execution-outputs.ts
@@ -1,0 +1,41 @@
+import type {WorkflowModel} from '@shipfox/api-definitions';
+import type {Job} from '../entities/job.js';
+import type {JobExecution} from '../entities/job-execution.js';
+import type {Step, StepAttempt} from '../entities/step.js';
+import type {WorkflowRun} from '../entities/workflow-run.js';
+import {
+  assembleExecutionResolutionContext,
+  type JobContextInput,
+} from '../step-config/assemble-run-context.js';
+import {materializeJobOutputs} from '../step-config/materialize-workflow-model.js';
+
+export function deriveJobExecutionOutputs(params: {
+  run: WorkflowRun;
+  modelJob: WorkflowModel['jobs'][number];
+  job: Job;
+  jobExecution: JobExecution;
+  executions: readonly JobExecution[];
+  steps: readonly Step[];
+  attempts: readonly StepAttempt[];
+  jobs: readonly JobContextInput[];
+  vars?: Record<string, string> | undefined;
+}): Record<string, unknown> | null {
+  const context = assembleExecutionResolutionContext({
+    run: params.run,
+    triggerPayload: params.run.triggerPayload,
+    inputs: params.run.inputs,
+    vars: params.vars,
+    job: params.job,
+    jobExecution: params.jobExecution,
+    executions: params.executions,
+    steps: params.steps,
+    attempts: params.attempts,
+    jobs: params.jobs,
+  });
+
+  return materializeJobOutputs({
+    job: params.modelJob,
+    context,
+    definitionId: params.run.definitionId,
+  });
+}

--- a/libs/api/workflows/src/core/job-transition/derive-job-success.test.ts
+++ b/libs/api/workflows/src/core/job-transition/derive-job-success.test.ts
@@ -4,10 +4,11 @@ import {deriveJobSuccess} from './derive-job-success.js';
 
 describe('deriveJobSuccess', () => {
   test('treats zero or cancelled listener executions as successful by default', () => {
-    const empty = deriveJobSuccess({success: null, executions: []});
+    const empty = deriveJobSuccess({success: null, executions: [], jobs: []});
     const cancelled = deriveJobSuccess({
       success: null,
       executions: [jobExecution({status: 'cancelled'})],
+      jobs: [],
     });
 
     expect(empty).toMatchObject({status: 'succeeded', statusReason: null});
@@ -29,6 +30,7 @@ describe('deriveJobSuccess', () => {
     const result = deriveJobSuccess({
       success: null,
       executions: [jobExecution({status: 'failed', statusReason: 'timed_out'})],
+      jobs: [],
     });
 
     expect(result).toMatchObject({status: 'failed', statusReason: 'timed_out'});
@@ -54,6 +56,7 @@ describe('deriveJobSuccess', () => {
     const result = deriveJobSuccess({
       success: 'executions.all(e, 1 / 0 == 0)',
       executions: [jobExecution({status: 'succeeded'})],
+      jobs: [],
     });
 
     expect(result).toMatchObject({

--- a/libs/api/workflows/src/core/job-transition/derive-job-success.test.ts
+++ b/libs/api/workflows/src/core/job-transition/derive-job-success.test.ts
@@ -1,0 +1,130 @@
+import type {Job} from '../entities/job.js';
+import type {JobExecution} from '../entities/job-execution.js';
+import {deriveJobSuccess} from './derive-job-success.js';
+
+describe('deriveJobSuccess', () => {
+  test('treats zero or cancelled listener executions as successful by default', () => {
+    const empty = deriveJobSuccess({success: null, executions: []});
+    const cancelled = deriveJobSuccess({
+      success: null,
+      executions: [jobExecution({status: 'cancelled'})],
+    });
+
+    expect(empty).toMatchObject({status: 'succeeded', statusReason: null});
+    expect(cancelled).toMatchObject({status: 'succeeded', statusReason: null});
+    expect(empty.trace).toEqual([
+      expect.objectContaining({
+        expression: "!executions.exists(e, e.status == 'failed')",
+        roots: ['executions'],
+        fillTarget: 'job-resolution',
+        evaluatedAt: 'job-resolution',
+        value: 'true',
+        field: 'job.success',
+      }),
+    ]);
+    expect(cancelled.trace).toEqual(empty.trace);
+  });
+
+  test('fails with the first execution status reason when the success expression is false', () => {
+    const result = deriveJobSuccess({
+      success: null,
+      executions: [jobExecution({status: 'failed', statusReason: 'timed_out'})],
+    });
+
+    expect(result).toMatchObject({status: 'failed', statusReason: 'timed_out'});
+  });
+
+  test('resolves custom success expressions over direct dependency outputs', () => {
+    const build = workflowJob({
+      key: 'build',
+      status: 'succeeded',
+      outputs: {release: 'yes'},
+    });
+
+    const result = deriveJobSuccess({
+      success: 'jobs.build.status == "succeeded" && jobs.build.outputs.release == "yes"',
+      executions: [jobExecution({status: 'succeeded'})],
+      jobs: [{job: build, executions: []}],
+    });
+
+    expect(result).toMatchObject({status: 'succeeded', statusReason: null});
+  });
+
+  test('fails closed when the success expression throws at runtime', () => {
+    const result = deriveJobSuccess({
+      success: 'executions.all(e, 1 / 0 == 0)',
+      executions: [jobExecution({status: 'succeeded'})],
+    });
+
+    expect(result).toMatchObject({
+      status: 'failed',
+      statusReason: 'unknown',
+      trace: [
+        expect.objectContaining({
+          expression: 'executions.all(e, 1 / 0 == 0)',
+          roots: ['executions'],
+          fillTarget: 'job-resolution',
+          evaluatedAt: 'job-resolution',
+          value: 'false',
+          degraded: true,
+          field: 'job.success',
+        }),
+      ],
+    });
+  });
+});
+
+function workflowJob(params: Partial<Job> & Pick<Job, 'key'>): Job {
+  return {
+    id: crypto.randomUUID(),
+    workflowRunAttemptId: crypto.randomUUID(),
+    key: params.key,
+    mode: 'one_shot',
+    name: null,
+    status: params.status ?? 'pending',
+    statusReason: null,
+    carriedOver: false,
+    checkout: {permissions: {contents: 'read'}, persistCredentials: true},
+    success: null,
+    evaluationTrace: null,
+    executionTimeoutMs: null,
+    listeningTimeoutMs: null,
+    maxExecutions: null,
+    onResolve: null,
+    batchDebounceMs: null,
+    batchMaxSize: null,
+    batchMaxWaitMs: null,
+    listenerStatus: 'inactive',
+    resolutionReason: null,
+    listeningOn: null,
+    listeningUntil: null,
+    outputs: params.outputs ?? null,
+    dependencies: params.dependencies ?? [],
+    runner: ['ubuntu-latest'],
+    position: params.position ?? 0,
+    version: params.version ?? 1,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+  };
+}
+
+function jobExecution(params: Partial<JobExecution> = {}): JobExecution {
+  return {
+    id: crypto.randomUUID(),
+    jobId: params.jobId ?? crypto.randomUUID(),
+    sequence: params.sequence ?? 1,
+    name: params.name ?? 'build',
+    runner: null,
+    status: params.status ?? 'succeeded',
+    statusReason: params.statusReason ?? null,
+    outputs: params.outputs ?? null,
+    triggerEvents: [],
+    version: 1,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    queuedAt: null,
+    startedAt: null,
+    finishedAt: null,
+    timedOutAt: null,
+  };
+}

--- a/libs/api/workflows/src/core/job-transition/derive-job-success.ts
+++ b/libs/api/workflows/src/core/job-transition/derive-job-success.ts
@@ -1,0 +1,67 @@
+import {DEFAULT_JOB_SUCCESS} from '@shipfox/api-definitions';
+import {
+  capTraceEntries,
+  createWorkflowExpression,
+  evaluatePlannedPredicateAtSite,
+  predicateTraceEntry,
+} from '@shipfox/expression';
+import type {JobStatusReason} from '../entities/job.js';
+import type {JobExecution} from '../entities/job-execution.js';
+import type {PersistedEvaluationTraceEntry} from '../entities/step.js';
+import {
+  assembleExecutionsContext,
+  assembleJobsContext,
+  type JobContextInput,
+} from '../step-config/assemble-run-context.js';
+import type {RuntimeCompletionStatus} from '../workflow-scheduling/runtime-dag.js';
+
+export interface DeriveJobSuccessResult {
+  status: RuntimeCompletionStatus;
+  statusReason: JobStatusReason | null;
+  trace: readonly PersistedEvaluationTraceEntry[];
+}
+
+export function deriveJobSuccess(params: {
+  success: string | null;
+  executions: readonly JobExecution[];
+  jobs?: readonly JobContextInput[];
+}): DeriveJobSuccessResult {
+  const expression = createWorkflowExpression({
+    source: params.success ?? DEFAULT_JOB_SUCCESS,
+    check: {mode: 'syntax'},
+  });
+  const context = {
+    ...assembleExecutionsContext(params.executions),
+    ...(params.jobs === undefined ? {} : assembleJobsContext(params.jobs)),
+  };
+  const outcome = evaluatePlannedPredicateAtSite({
+    expression,
+    field: 'job.success',
+    site: 'job-resolution',
+    context,
+  });
+  const trace = capTraceEntries([
+    {
+      ...predicateTraceEntry({
+        expression: expression.source,
+        route: outcome.route,
+        site: 'job-resolution',
+        value: outcome.value,
+        degraded: outcome.evaluationFailed,
+      }),
+      field: 'job.success',
+    },
+  ]);
+  const passed = outcome.value;
+  const status: RuntimeCompletionStatus = passed ? 'succeeded' : 'failed';
+  if (status === 'succeeded') return {status, statusReason: null, trace};
+
+  return {
+    status,
+    statusReason: outcome.evaluationFailed
+      ? 'unknown'
+      : (params.executions.find((execution) => execution.statusReason)?.statusReason ??
+        'step_failed'),
+    trace,
+  };
+}

--- a/libs/api/workflows/src/core/job-transition/derive-job-success.ts
+++ b/libs/api/workflows/src/core/job-transition/derive-job-success.ts
@@ -24,7 +24,7 @@ export interface DeriveJobSuccessResult {
 export function deriveJobSuccess(params: {
   success: string | null;
   executions: readonly JobExecution[];
-  jobs?: readonly JobContextInput[];
+  jobs: readonly JobContextInput[];
 }): DeriveJobSuccessResult {
   const expression = createWorkflowExpression({
     source: params.success ?? DEFAULT_JOB_SUCCESS,
@@ -32,7 +32,7 @@ export function deriveJobSuccess(params: {
   });
   const context = {
     ...assembleExecutionsContext(params.executions),
-    ...(params.jobs === undefined ? {} : assembleJobsContext(params.jobs)),
+    ...assembleJobsContext(params.jobs),
   };
   const outcome = evaluatePlannedPredicateAtSite({
     expression,

--- a/libs/api/workflows/src/core/job-transition/index.ts
+++ b/libs/api/workflows/src/core/job-transition/index.ts
@@ -1,0 +1,11 @@
+export {
+  type DecideJobActivationInput,
+  decideJobActivation,
+  type JobActivationDecision,
+} from './decide-job-activation.js';
+export {deriveJobExecutionOutputs} from './derive-job-execution-outputs.js';
+export {
+  type DeriveJobSuccessResult,
+  deriveJobSuccess,
+} from './derive-job-success.js';
+export {runtimeCompletionStatusForJob} from './runtime-completion-status-for-job.js';

--- a/libs/api/workflows/src/core/job-transition/runtime-completion-status-for-job.ts
+++ b/libs/api/workflows/src/core/job-transition/runtime-completion-status-for-job.ts
@@ -1,0 +1,14 @@
+import type {JobStatus} from '../entities/job.js';
+import type {RuntimeCompletionStatus} from '../workflow-scheduling/runtime-dag.js';
+
+export function runtimeCompletionStatusForJob(status: JobStatus): RuntimeCompletionStatus {
+  if (
+    status === 'succeeded' ||
+    status === 'failed' ||
+    status === 'cancelled' ||
+    status === 'skipped'
+  ) {
+    return status;
+  }
+  throw new Error(`Job status is not terminal: ${status}`);
+}

--- a/libs/api/workflows/src/core/workflow-run-creation.ts
+++ b/libs/api/workflows/src/core/workflow-run-creation.ts
@@ -3,6 +3,10 @@ import {
   catalogDefaultAgentResolver,
 } from '@shipfox/api-agent/core/resolve-agent-config';
 import type {WorkflowModel} from '@shipfox/api-definitions';
+import type {
+  AgentToolMaterializationContext,
+  AgentToolMaterializationSnapshot,
+} from './agent-tools.js';
 import type {JobExecution} from './entities/job-execution.js';
 import type {TriggerPayload, WorkflowRun} from './entities/workflow-run.js';
 import {
@@ -24,6 +28,8 @@ export function materializeWorkflowRunJobs(params: {
   vars?: Record<string, string> | undefined;
   resolveAgentDefaults?: AgentDefaultsResolver | undefined;
   definitionId: string;
+  agentToolContext?: AgentToolMaterializationContext | undefined;
+  agentToolSnapshot?: AgentToolMaterializationSnapshot | null | undefined;
 }): readonly MaterializedWorkflowJob[] {
   const context = assembleCreationContext({
     run: params.run,
@@ -36,6 +42,8 @@ export function materializeWorkflowRunJobs(params: {
     context,
     resolveAgentDefaults: params.resolveAgentDefaults ?? catalogDefaultAgentResolver,
     definitionId: params.definitionId,
+    agentToolContext: params.agentToolContext,
+    agentToolSnapshot: params.agentToolSnapshot,
   });
 }
 

--- a/libs/api/workflows/src/core/workflow-run-creation.ts
+++ b/libs/api/workflows/src/core/workflow-run-creation.ts
@@ -1,0 +1,123 @@
+import {
+  type AgentDefaultsResolver,
+  catalogDefaultAgentResolver,
+} from '@shipfox/api-agent/core/resolve-agent-config';
+import type {WorkflowModel} from '@shipfox/api-definitions';
+import type {JobExecution} from './entities/job-execution.js';
+import type {TriggerPayload, WorkflowRun} from './entities/workflow-run.js';
+import {
+  assembleCreationContext,
+  assembleExecutionCreationContext,
+} from './step-config/assemble-run-context.js';
+import {
+  type MaterializedWorkflowJob,
+  materializeJobRunner,
+  materializeWorkflowModel,
+} from './step-config/materialize-workflow-model.js';
+import {resolveJobExecutionName} from './step-config/resolve-job-execution-name.js';
+
+export function materializeWorkflowRunJobs(params: {
+  run: WorkflowRun;
+  model: WorkflowModel;
+  triggerPayload: TriggerPayload;
+  inputs?: Record<string, unknown> | null | undefined;
+  vars?: Record<string, string> | undefined;
+  resolveAgentDefaults?: AgentDefaultsResolver | undefined;
+  definitionId: string;
+}): readonly MaterializedWorkflowJob[] {
+  const context = assembleCreationContext({
+    run: params.run,
+    triggerPayload: params.triggerPayload,
+    inputs: params.inputs ?? null,
+    vars: params.vars,
+  });
+  return materializeWorkflowModel({
+    model: params.model,
+    context,
+    resolveAgentDefaults: params.resolveAgentDefaults ?? catalogDefaultAgentResolver,
+    definitionId: params.definitionId,
+  });
+}
+
+export function deriveInitialJobExecutionPlan(params: {
+  run: WorkflowRun;
+  modelJob: WorkflowModel['jobs'][number];
+  job: MaterializedWorkflowJob;
+  jobId: string;
+  sequence: number;
+  fallbackName: string;
+  triggerPayload: TriggerPayload;
+  inputs?: Record<string, unknown> | null | undefined;
+  vars?: Record<string, string> | undefined;
+}): {
+  name: string;
+  runner: readonly string[];
+  evaluationTrace: JobExecution['evaluationTrace'];
+} {
+  const nameContext = assembleExecutionCreationContext({
+    run: params.run,
+    triggerPayload: params.triggerPayload,
+    inputs: params.inputs ?? null,
+    vars: params.vars,
+    jobId: params.jobId,
+    sequence: params.sequence,
+    executionName: params.fallbackName,
+    status: 'pending',
+    triggerEvents: [],
+    priorExecutions: [],
+  });
+  const resolvedName = resolveJobExecutionName({
+    definitionId: params.run.definitionId,
+    job: params.job,
+    fallbackName: params.fallbackName,
+    context: nameContext.values,
+  });
+  const runnerContext = assembleExecutionCreationContext({
+    run: params.run,
+    triggerPayload: params.triggerPayload,
+    inputs: params.inputs ?? null,
+    vars: params.vars,
+    jobId: params.jobId,
+    sequence: params.sequence,
+    executionName: resolvedName.value,
+    status: 'pending',
+    triggerEvents: [],
+    priorExecutions: [],
+  });
+  return {
+    name: resolvedName.value,
+    runner: materializeJobRunner({
+      job: params.modelJob,
+      context: runnerContext,
+      definitionId: params.run.definitionId,
+    }),
+    evaluationTrace: resolvedName.trace,
+  };
+}
+
+export function deriveJobExecutionRunner(params: {
+  run: WorkflowRun;
+  modelJob: WorkflowModel['jobs'][number];
+  jobId: string;
+  sequence: number;
+  executionName: string;
+  status: JobExecution['status'];
+  triggerEvents?: readonly JobExecution['triggerEvents'][number][] | undefined;
+  priorExecutions?: readonly JobExecution[] | undefined;
+}): readonly string[] {
+  return materializeJobRunner({
+    job: params.modelJob,
+    context: assembleExecutionCreationContext({
+      run: params.run,
+      triggerPayload: params.run.triggerPayload,
+      inputs: params.run.inputs,
+      jobId: params.jobId,
+      sequence: params.sequence,
+      executionName: params.executionName,
+      status: params.status,
+      triggerEvents: params.triggerEvents ?? [],
+      priorExecutions: params.priorExecutions ?? [],
+    }),
+    definitionId: params.run.definitionId,
+  });
+}

--- a/libs/api/workflows/src/db/job-listeners.test.ts
+++ b/libs/api/workflows/src/db/job-listeners.test.ts
@@ -403,6 +403,41 @@ describe('resolveJobListener', () => {
     expect(stored?.resolutionReason).toBe('max_executions');
   });
 
+  it('resolves custom success expressions with direct dependency context', async () => {
+    const model = workflowModel({
+      jobs: {
+        build: {
+          steps: [{run: 'echo build'}],
+        },
+        listen: {
+          needs: 'build',
+          success: 'jobs.build.status == "succeeded" && jobs.build.outputs.release == "yes"',
+          steps: [{run: 'echo listen'}],
+        },
+      },
+    });
+    const run = await workflowRunFactory.create({}, {transient: {model}});
+    const [build, listener] = await getJobsByWorkflowRunId(run.id);
+    if (!build || !listener) throw new Error('Expected build and listener jobs');
+    await db()
+      .update(jobs)
+      .set({status: 'succeeded', outputs: {release: 'yes'}})
+      .where(eq(jobs.id, build.id));
+    await db()
+      .update(jobs)
+      .set({mode: 'listening', status: 'running', listenerStatus: 'listening'})
+      .where(eq(jobs.id, listener.id));
+    await db().delete(jobExecutions).where(eq(jobExecutions.jobId, listener.id));
+    await insertExecution(listener.id, 1, 'succeeded');
+
+    const result = await resolveJobListener({jobId: listener.id, reason: 'until'});
+
+    const stored = await readJob(listener.id);
+    expect(result.status).toBe('succeeded');
+    expect(stored?.status).toBe('succeeded');
+    expect(stored?.listenerStatus).toBe('resolved');
+  });
+
   it('resolves a listener with zero firings under the default success rule', async () => {
     const job = await createListeningJob({status: 'running', listenerStatus: 'listening'});
 

--- a/libs/api/workflows/src/db/job-listeners.test.ts
+++ b/libs/api/workflows/src/db/job-listeners.test.ts
@@ -436,6 +436,7 @@ describe('resolveJobListener', () => {
     expect(result.status).toBe('succeeded');
     expect(stored?.status).toBe('succeeded');
     expect(stored?.listenerStatus).toBe('resolved');
+    expect(stored?.resolutionReason).toBe('until');
   });
 
   it('resolves a listener with zero firings under the default success rule', async () => {

--- a/libs/api/workflows/src/db/job-listeners.ts
+++ b/libs/api/workflows/src/db/job-listeners.ts
@@ -7,6 +7,7 @@ import {and, asc, count, eq, inArray, isNull, notInArray, sql} from 'drizzle-orm
 import {loadAgentToolMaterializationContext} from '#core/agent-tools.js';
 import type {JobStatus, ResolutionReason} from '#core/entities/job.js';
 import type {JobExecutionStatus, WorkflowExecutionEvent} from '#core/entities/job-execution.js';
+import {deriveJobSuccess} from '#core/job-transition/index.js';
 import {
   type MaterializedListenerExecution,
   materializeListenerExecution,
@@ -32,7 +33,6 @@ import {workflowRunAttempts} from './schema/workflow-run-attempts.js';
 import {toWorkflowRun, workflowRuns} from './schema/workflow-runs.js';
 import {
   bulkUpdateStepStatuses,
-  evaluateJobSuccess,
   getDirectDependencyJobContexts,
   updateJobStatusAtVersion,
 } from './workflow-runs.js';
@@ -292,7 +292,7 @@ export async function resolveJobListener(params: {
       .from(jobExecutions)
       .where(eq(jobExecutions.jobId, params.jobId))
       .orderBy(asc(jobExecutions.sequence), asc(jobExecutions.id));
-    const {status, statusReason, trace} = evaluateJobSuccess({
+    const {status, statusReason, trace} = deriveJobSuccess({
       success: jobRow.success,
       executions: executionRows.map(toJobExecution),
     });

--- a/libs/api/workflows/src/db/job-listeners.ts
+++ b/libs/api/workflows/src/db/job-listeners.ts
@@ -5,9 +5,9 @@ import {
 } from '@shipfox/api-workflows-dto';
 import {and, asc, count, eq, inArray, isNull, notInArray, sql} from 'drizzle-orm';
 import {loadAgentToolMaterializationContext} from '#core/agent-tools.js';
-import type {JobStatus, ResolutionReason} from '#core/entities/job.js';
+import {isJobTerminal, type JobStatus, type ResolutionReason} from '#core/entities/job.js';
 import type {JobExecutionStatus, WorkflowExecutionEvent} from '#core/entities/job-execution.js';
-import {deriveJobSuccess} from '#core/job-transition/index.js';
+import {type DeriveJobSuccessResult, deriveJobSuccess} from '#core/job-transition/index.js';
 import {
   type MaterializedListenerExecution,
   materializeListenerExecution,
@@ -38,6 +38,7 @@ import {
 } from './workflow-runs.js';
 
 const TERMINAL_EXECUTION_STATUSES: JobExecutionStatus[] = ['succeeded', 'failed', 'cancelled'];
+const MAX_LISTENER_RESOLUTION_ATTEMPTS = 3;
 
 export interface ActivateJobListenerParams {
   jobId: string;
@@ -268,7 +269,66 @@ export async function resolveJobListener(params: {
   jobId: string;
   reason: ResolutionReason;
 }): Promise<{status: 'succeeded' | 'failed'; jobVersion: number}> {
-  const result = await db().transaction(async (tx) => {
+  let result: ApplyJobListenerResolutionResult | undefined;
+  for (let attempt = 0; attempt < MAX_LISTENER_RESOLUTION_ATTEMPTS; attempt += 1) {
+    const decision = await deriveJobListenerResolutionDecision(params.jobId);
+    result = await applyJobListenerResolution(params, decision);
+    if (result.kind === 'applied') break;
+  }
+
+  if (result?.kind !== 'applied') {
+    throw new Error(`Optimistic lock failure resolving listener job ${params.jobId}`);
+  }
+
+  if (result.changed) recordWorkflowListenerResolved(params.reason);
+  return {status: result.status, jobVersion: result.jobVersion};
+}
+
+type JobListenerResolutionDecision = DeriveJobSuccessResult & {
+  expectedVersion: number;
+};
+
+type ApplyJobListenerResolutionResult =
+  | {
+      kind: 'applied';
+      status: 'succeeded' | 'failed';
+      jobVersion: number;
+      changed: boolean;
+    }
+  | {kind: 'stale'};
+
+async function deriveJobListenerResolutionDecision(
+  jobId: string,
+): Promise<JobListenerResolutionDecision> {
+  const [jobRow] = await db().select().from(jobs).where(eq(jobs.id, jobId)).limit(1);
+  if (!jobRow) throw new Error(`Job not found: ${jobId}`);
+
+  const [executionRows, dependencyJobs] = await Promise.all([
+    db()
+      .select()
+      .from(jobExecutions)
+      .where(eq(jobExecutions.jobId, jobId))
+      .orderBy(asc(jobExecutions.sequence), asc(jobExecutions.id)),
+    getDirectDependencyJobContexts(jobId),
+  ]);
+  return {
+    expectedVersion: jobRow.version,
+    ...deriveJobSuccess({
+      success: jobRow.success,
+      executions: executionRows.map(toJobExecution),
+      jobs: dependencyJobs,
+    }),
+  };
+}
+
+async function applyJobListenerResolution(
+  params: {
+    jobId: string;
+    reason: ResolutionReason;
+  },
+  decision: JobListenerResolutionDecision,
+): Promise<ApplyJobListenerResolutionResult> {
+  return await db().transaction(async (tx) => {
     const [jobRow] = await tx
       .select()
       .from(jobs)
@@ -276,6 +336,10 @@ export async function resolveJobListener(params: {
       .limit(1)
       .for('update');
     if (!jobRow) throw new Error(`Job not found: ${params.jobId}`);
+
+    if (jobRow.version !== decision.expectedVersion && !isJobTerminal(jobRow.status)) {
+      return {kind: 'stale' as const};
+    }
 
     const listenerRows = await tx
       .update(jobs)
@@ -287,34 +351,23 @@ export async function resolveJobListener(params: {
       .where(and(eq(jobs.id, params.jobId), notInArray(jobs.listenerStatus, ['resolved'])))
       .returning({id: jobs.id});
 
-    const executionRows = await tx
-      .select()
-      .from(jobExecutions)
-      .where(eq(jobExecutions.jobId, params.jobId))
-      .orderBy(asc(jobExecutions.sequence), asc(jobExecutions.id));
-    const {status, statusReason, trace} = deriveJobSuccess({
-      success: jobRow.success,
-      executions: executionRows.map(toJobExecution),
-    });
     const updated = await updateJobStatusAtVersion(tx, {
       jobId: params.jobId,
-      status,
-      expectedVersion: jobRow.version,
-      statusReason,
-      evaluationTrace: trace,
+      status: decision.status,
+      expectedVersion: decision.expectedVersion,
+      statusReason: decision.statusReason,
+      evaluationTrace: decision.trace,
     });
     const job = updated?.job ?? toJob(jobRow);
     const resolvedStatus: 'succeeded' | 'failed' =
       job.status === 'succeeded' ? 'succeeded' : 'failed';
     return {
+      kind: 'applied' as const,
       status: resolvedStatus,
       jobVersion: job.version,
       changed: listenerRows.length > 0 || updated?.changed === true,
     };
   });
-
-  if (result.changed) recordWorkflowListenerResolved(params.reason);
-  return {status: result.status, jobVersion: result.jobVersion};
 }
 
 export async function settleListenerJobExecution(params: {

--- a/libs/api/workflows/src/db/workflow-runs/job-executions.ts
+++ b/libs/api/workflows/src/db/workflow-runs/job-executions.ts
@@ -3,8 +3,7 @@ import {and, asc, desc, eq, isNull, notInArray, sql} from 'drizzle-orm';
 import type {JobStatusReason} from '#core/entities/job.js';
 import type {JobExecution, JobExecutionStatus} from '#core/entities/job-execution.js';
 import {InterpolationUnresolvableError, JobNotFoundError} from '#core/errors.js';
-import {assembleExecutionResolutionContext} from '#core/step-config/assemble-run-context.js';
-import {materializeJobOutputs} from '#core/step-config/materialize-workflow-model.js';
+import {deriveJobExecutionOutputs} from '#core/job-transition/index.js';
 import {deriveCompletion, isTerminal} from '#core/step-transition/decide-step-transition.js';
 import type {RuntimeCompletionStatus} from '#core/workflow-scheduling/runtime-dag.js';
 import {
@@ -166,10 +165,15 @@ async function resolveJobExecutionOutputs(
     .orderBy(asc(stepAttempts.executionOrder), asc(stepAttempts.id));
   const dependencyJobs = await getDirectDependencyJobContexts(target.job.id, tx);
 
-  const context = assembleExecutionResolutionContext({
+  return deriveJobExecutionOutputs({
     run: toWorkflowRun(target.run),
-    triggerPayload: target.run.triggerPayload,
-    inputs: target.run.inputs,
+    modelJob,
+    job: toJob(target.job),
+    jobExecution,
+    executions,
+    steps: stepRows.map(toStep),
+    attempts: attemptRows.map(toStepAttempt),
+    jobs: dependencyJobs,
     vars: await loadReferencedVariables({
       model,
       jobs: [modelJob],
@@ -177,18 +181,6 @@ async function resolveJobExecutionOutputs(
       projectId: target.run.projectId,
       definitionId: target.run.definitionId,
     }),
-    job: toJob(target.job),
-    jobExecution,
-    executions,
-    steps: stepRows.map(toStep),
-    attempts: attemptRows.map(toStepAttempt),
-    jobs: dependencyJobs,
-  });
-
-  return materializeJobOutputs({
-    job: modelJob,
-    context,
-    definitionId: target.run.definitionId,
   });
 }
 

--- a/libs/api/workflows/src/db/workflow-runs/job-status.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/job-status.test.ts
@@ -1,11 +1,9 @@
 import {eq, sql} from 'drizzle-orm';
-import type {JobExecution} from '#core/entities/job-execution.js';
 import {buildModel, createTestRun, jobTerminatedEvents} from '#test/helpers/workflow-runs.js';
 import {db} from '../db.js';
 import {jobs} from '../schema/jobs.js';
 import {
   createWorkflowRun,
-  evaluateJobSuccess,
   getFirstJobExecutionByJobId,
   getJobsByWorkflowRunId,
   resolveJobStatusFromJobExecutions,
@@ -25,46 +23,6 @@ describe('workflow run queries', () => {
   });
 
   describe('resolveJobStatusFromJobExecutions', () => {
-    function execution(status: 'succeeded' | 'failed' | 'cancelled'): JobExecution {
-      return {
-        id: crypto.randomUUID(),
-        jobId: crypto.randomUUID(),
-        sequence: 1,
-        name: 'build',
-        runner: null,
-        status,
-        statusReason: status === 'failed' ? 'step_failed' : null,
-        outputs: null,
-        triggerEvents: [],
-        version: 1,
-        createdAt: new Date('2026-01-01T00:00:00.000Z'),
-        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
-        queuedAt: null,
-        startedAt: null,
-        finishedAt: null,
-        timedOutAt: null,
-      };
-    }
-
-    test('treats zero or cancelled listener executions as successful by default', () => {
-      const empty = evaluateJobSuccess({success: null, executions: []});
-      const cancelled = evaluateJobSuccess({success: null, executions: [execution('cancelled')]});
-
-      expect(empty).toMatchObject({status: 'succeeded', statusReason: null});
-      expect(cancelled).toMatchObject({status: 'succeeded', statusReason: null});
-      expect(empty.trace).toEqual([
-        {
-          expression: "!executions.exists(e, e.status == 'failed')",
-          roots: ['executions'],
-          fillTarget: 'job-resolution',
-          evaluatedAt: 'job-resolution',
-          value: 'true',
-          field: 'job.success',
-        },
-      ]);
-      expect(cancelled.trace).toEqual(empty.trace);
-    });
-
     test('fails closed when a job has no executions', async () => {
       const run = await createWorkflowRun({
         workspaceId,

--- a/libs/api/workflows/src/db/workflow-runs/jobs.ts
+++ b/libs/api/workflows/src/db/workflow-runs/jobs.ts
@@ -1,23 +1,16 @@
-import {DEFAULT_JOB_SUCCESS} from '@shipfox/api-definitions';
 import {WORKFLOWS_JOB_TERMINATED} from '@shipfox/api-workflows-dto';
-import {
-  capTraceEntries,
-  createWorkflowExpression,
-  evaluatePlannedPredicateAtSite,
-  predicateTraceEntry,
-} from '@shipfox/expression';
 import {and, asc, desc, eq, inArray, notInArray, sql} from 'drizzle-orm';
-import {explicitConditionTrace} from '#core/condition-trace.js';
 import {isJobTerminal, type Job, type JobStatus, type JobStatusReason} from '#core/entities/job.js';
 import type {JobExecution} from '#core/entities/job-execution.js';
 import type {PersistedEvaluationTraceEntry} from '#core/entities/step.js';
 import {JobNotFoundError} from '#core/errors.js';
 import {
-  assembleExecutionsContext,
-  assembleJobActivationContext,
-  assembleJobsContext,
-  type JobContextInput,
-} from '#core/step-config/assemble-run-context.js';
+  type DeriveJobSuccessResult,
+  decideJobActivation,
+  deriveJobSuccess,
+  runtimeCompletionStatusForJob,
+} from '#core/job-transition/index.js';
+import type {JobContextInput} from '#core/step-config/assemble-run-context.js';
 import type {RuntimeCompletionStatus} from '#core/workflow-scheduling/runtime-dag.js';
 import {recordWorkflowJobStatusChanged} from '#metrics/instance.js';
 import {db, type Tx} from '../db.js';
@@ -168,61 +161,32 @@ export async function evaluateJobActivations(
       const target = targetsByJobId.get(input.jobId);
       if (!target) throw new Error(`Cannot evaluate missing activation job: ${input.jobId}`);
       const job = toJob(target.job);
-      if (isJobTerminal(job.status)) {
-        decisions.push({
-          kind: 'terminal-job',
-          jobId: job.id,
-          status: runtimeCompletionStatusForJob(job.status),
-          jobVersion: job.version,
-        });
-        continue;
-      }
-
       const modelJob = target.attempt.model?.jobs.find((item) => item.key === target.job.key);
-      if (modelJob?.if === undefined) {
-        decisions.push({kind: 'start-job', jobId: job.id});
-        continue;
-      }
-
-      const context = assembleJobActivationContext({
+      const decision = decideJobActivation({
         run: toWorkflowRun(target.run),
-        triggerPayload: target.run.triggerPayload,
-        inputs: target.run.inputs,
-        jobs: job.dependencies.flatMap((key) => {
+        job,
+        condition: modelJob?.if,
+        dependencies: job.dependencies.flatMap((key) => {
           const dependency = contextsByJobKey.get(key);
           return dependency === undefined ? [] : [dependency];
         }),
       });
-      const outcome = evaluatePlannedPredicateAtSite({
-        expression: modelJob.if,
-        field: 'job.if',
-        site: context.site,
-        context: context.values,
-      });
-      if (outcome.value) {
-        decisions.push({kind: 'start-job', jobId: job.id});
+
+      if (decision.kind === 'terminal-job' || decision.kind === 'start-job') {
+        decisions.push(decision);
         continue;
       }
 
-      const statusReason = outcome.evaluationFailed ? 'condition_errored' : 'condition_rejected';
-      const evaluationTrace = explicitConditionTrace({
-        expression: modelJob.if,
-        field: 'job.if',
-        route: outcome.route,
-        site: context.site,
-        value: outcome.value,
-        degraded: outcome.evaluationFailed,
-      });
       const expectedVersion = expectedVersions.get(job.id);
       if (expectedVersion === undefined) {
         throw new Error(`Missing expected version for activation job ${job.id}`);
       }
       const updated = await updateJobStatusAtVersion(tx, {
         jobId: job.id,
-        status: 'skipped',
+        status: decision.status,
         expectedVersion,
-        statusReason,
-        evaluationTrace,
+        statusReason: decision.statusReason,
+        evaluationTrace: decision.evaluationTrace,
       });
       if (updated) {
         decisions.push({
@@ -286,18 +250,6 @@ async function directDependencyContextsByJobKey(
   }
 
   return contextsByJobKey;
-}
-
-function runtimeCompletionStatusForJob(status: JobStatus): RuntimeCompletionStatus {
-  if (
-    status === 'succeeded' ||
-    status === 'failed' ||
-    status === 'cancelled' ||
-    status === 'skipped'
-  ) {
-    return status;
-  }
-  throw new Error(`Job status is not terminal: ${status}`);
 }
 
 export interface UpdateJobStatusAtVersionParams {
@@ -413,57 +365,8 @@ export async function updateJobStatus(params: UpdateJobStatusParams): Promise<Jo
   return result.job;
 }
 
-export interface EvaluateJobSuccessResult {
-  status: RuntimeCompletionStatus;
-  statusReason: JobStatusReason | null;
-  trace: readonly PersistedEvaluationTraceEntry[];
-}
-
-export function evaluateJobSuccess(params: {
-  success: string | null;
-  executions: readonly JobExecution[];
-  jobs?: readonly JobContextInput[];
-}): EvaluateJobSuccessResult {
-  const expression = createWorkflowExpression({
-    source: params.success ?? DEFAULT_JOB_SUCCESS,
-    check: {mode: 'syntax'},
-  });
-  const context = {
-    ...assembleExecutionsContext(params.executions),
-    ...(params.jobs === undefined ? {} : assembleJobsContext(params.jobs)),
-  };
-  const outcome = evaluatePlannedPredicateAtSite({
-    expression,
-    field: 'job.success',
-    site: 'job-resolution',
-    context,
-  });
-  const trace = capTraceEntries([
-    {
-      ...predicateTraceEntry({
-        expression: expression.source,
-        route: outcome.route,
-        site: 'job-resolution',
-        value: outcome.value,
-        degraded: outcome.evaluationFailed,
-      }),
-      field: 'job.success',
-    },
-  ]);
-  const passed = outcome.value;
-  const status: RuntimeCompletionStatus = passed ? 'succeeded' : 'failed';
-  if (status === 'succeeded') return {status, statusReason: null, trace};
-
-  // A thrown predicate is a job-level failure, not evidence that any execution failed.
-  return {
-    status,
-    statusReason: outcome.evaluationFailed
-      ? 'unknown'
-      : (params.executions.find((execution) => execution.statusReason)?.statusReason ??
-        'step_failed'),
-    trace,
-  };
-}
+export type EvaluateJobSuccessResult = DeriveJobSuccessResult;
+export const evaluateJobSuccess = deriveJobSuccess;
 
 export async function resolveJobStatusFromJobExecutions(params: {
   jobId: string;

--- a/libs/api/workflows/src/db/workflow-runs/run-create.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-create.ts
@@ -17,17 +17,12 @@ import type {
   WorkflowSourceSnapshot,
 } from '#core/entities/workflow-run.js';
 import {InterpolationUnresolvableError} from '#core/errors.js';
-import {
-  assembleCreationContext,
-  assembleExecutionCreationContext,
-} from '#core/step-config/assemble-run-context.js';
 import type {MaterializedWorkflowJob} from '#core/step-config/materialize-workflow-model.js';
-import {
-  materializeJobRunner,
-  materializeWorkflowModel,
-} from '#core/step-config/materialize-workflow-model.js';
-import {resolveJobExecutionName} from '#core/step-config/resolve-job-execution-name.js';
 import type {WorkflowStepTemplateDiagnostic} from '#core/step-config/resolve-step-config.js';
+import {
+  deriveInitialJobExecutionPlan,
+  materializeWorkflowRunJobs,
+} from '#core/workflow-run-creation.js';
 import {recordWorkflowRunCreated} from '#metrics/instance.js';
 import {db} from '../db.js';
 import {workflowRunAttempts} from '../schema/workflow-run-attempts.js';
@@ -131,15 +126,12 @@ export async function createWorkflowRun(params: CreateWorkflowRunParams): Promis
       projectId: params.projectId,
       definitionId: params.definitionId,
     });
-    const context = assembleCreationContext({
+    const materializedJobs = materializeWorkflowRunJobs({
       run,
+      model: params.model,
       triggerPayload: params.triggerPayload,
       inputs: params.inputs ?? null,
       vars,
-    });
-    const materializedJobs = materializeWorkflowModel({
-      model: params.model,
-      context,
       resolveAgentDefaults: params.resolveAgentDefaults ?? catalogDefaultAgentResolver,
       definitionId: params.definitionId,
       agentToolContext,
@@ -241,51 +233,27 @@ function materializeRunGraphJobs(params: {
       if (jobRow.mode === 'listening') return undefined;
 
       const fallbackName = `${jobRow.key} #1`;
-      const context = assembleExecutionCreationContext({
-        run: params.run,
-        triggerPayload: params.params.triggerPayload,
-        inputs: params.params.inputs ?? null,
-        vars: params.vars,
-        jobId: jobRow.id,
-        sequence: 1,
-        executionName: fallbackName,
-        status: 'pending',
-        triggerEvents: [],
-        priorExecutions: [],
-      });
-      const resolvedName = resolveJobExecutionName({
-        definitionId: params.params.definitionId,
-        job,
-        fallbackName,
-        context: context.values,
-      });
       const modelJob = params.params.model.jobs[jobIndex];
       if (!modelJob) return undefined;
-
-      const runnerContext = assembleExecutionCreationContext({
+      const executionPlan = deriveInitialJobExecutionPlan({
         run: params.run,
+        modelJob,
+        job,
+        jobId: jobRow.id,
+        sequence: 1,
+        fallbackName,
         triggerPayload: params.params.triggerPayload,
         inputs: params.params.inputs ?? null,
         vars: params.vars,
-        jobId: jobRow.id,
-        sequence: 1,
-        executionName: resolvedName.value,
-        status: 'pending',
-        triggerEvents: [],
-        priorExecutions: [],
-      });
-      const runner = materializeJobRunner({
-        job: modelJob,
-        context: runnerContext,
-        definitionId: params.params.definitionId,
       });
 
       return {
         sequence: 1,
-        name: resolvedName.value,
-        runner: [...runner],
+        name: executionPlan.name,
+        runner: [...executionPlan.runner],
         status: 'pending' as const,
-        evaluationTrace: resolvedName.trace.length === 0 ? null : resolvedName.trace,
+        evaluationTrace:
+          executionPlan.evaluationTrace?.length === 0 ? null : executionPlan.evaluationTrace,
       };
     },
     createSteps: () =>

--- a/libs/api/workflows/src/db/workflow-runs/run-rerun.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-rerun.ts
@@ -1,8 +1,7 @@
 import {and, asc, eq, inArray, sql} from 'drizzle-orm';
 import {isWorkflowRunTerminal, type WorkflowRun} from '#core/entities/workflow-run.js';
 import {NoFailedJobsError, RunNotTerminalError, SourceRunNotFoundError} from '#core/errors.js';
-import {assembleExecutionCreationContext} from '#core/step-config/assemble-run-context.js';
-import {materializeJobRunner} from '#core/step-config/materialize-workflow-model.js';
+import {deriveJobExecutionRunner} from '#core/workflow-run-creation.js';
 import {recordWorkflowRunCreated} from '#metrics/instance.js';
 import {db, type Tx} from '../db.js';
 import {type JobExecutionDb, jobExecutions} from '../schema/job-executions.js';
@@ -227,20 +226,13 @@ function materializeRerunGraphJobs(params: {
         const runner =
           carriedOver || modelJob === undefined
             ? (sourceExecution?.runner ?? job.runner ?? null)
-            : materializeJobRunner({
-                job: modelJob,
-                context: assembleExecutionCreationContext({
-                  run: params.sourceRun,
-                  triggerPayload: params.sourceRun.triggerPayload,
-                  inputs: params.sourceRun.inputs,
-                  jobId: job.id,
-                  sequence: 1,
-                  executionName,
-                  status: 'pending',
-                  triggerEvents: [],
-                  priorExecutions: [],
-                }),
-                definitionId: params.sourceRun.definitionId,
+            : deriveJobExecutionRunner({
+                run: params.sourceRun,
+                modelJob,
+                jobId: job.id,
+                sequence: 1,
+                executionName,
+                status: 'pending',
               });
 
         return {


### PR DESCRIPTION
Move job activation, success, output, and run-creation materialization decisions into workflows core helpers.

The workflows db layer was still evaluating job predicates and materializing job outputs/runners while holding persistence transactions. This brings job decisions closer to the existing step transition pattern: core owns pure decisions and materialization, while db modules load rows, apply guarded writes, and emit outbox events.

The run creation path still preserves the existing idempotent insert and transaction boundary because the inserted run id is part of template context. The extraction therefore moves the materialization calls behind core helpers without introducing the shared graph writer planned separately for ENG-883.

Reviewers should pay closest attention to behavior parity for skipped job activation traces, custom job success expressions, output materialization failures, and rerun runner resolution.

No changeset is included because `@shipfox/api-workflows` is private.

Closes ENG-882

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved job activation, job success and listener resolution (with direct dependency context), job execution output derivation, and run-creation planning into core so the DB layer only applies decisions with optimistic locking. Agent tool materialization is forwarded through core wrappers, reducing in-transaction work and aligning job transitions with steps (ENG-882).

- **New Features**
  - Core decisions: `decideJobActivation`, `deriveJobSuccess`, `deriveJobExecutionOutputs`.
  - Run creation: `materializeWorkflowRunJobs`, `deriveInitialJobExecutionPlan`, `deriveJobExecutionRunner` (passes agent tool context/snapshot).

- **Refactors**
  - DB now delegates activation, listener resolution, outputs, and runner resolution to core; applies results with optimistic locking (listener resolution retries up to 3 times).
  - `resolveJobListener` derives success in core with direct dependency context and then persists; metrics parity preserved.
  - `createWorkflowRun` and reruns use core wrappers; pure evaluations and tests live in core.
  - Behavior parity maintained for skips, custom success expressions, output errors, and rerun runner selection.

<sup>Written for commit 526c43a6e1c07f464ad005f9972f65cfac137dff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

