### PR TITLE
[integration/linear] Add OAuth connect flow

### DIFF
--- a/apps/api/src/core/run.test.ts
+++ b/apps/api/src/core/run.test.ts
@@ -21,6 +21,8 @@ const mocks = vi.hoisted(() => {
     createPostgresClient: vi.fn(),
     createProjectsModule: vi.fn(),
     deleteSecrets: vi.fn(),
+    getSecret: vi.fn(),
+    setSecrets: vi.fn(),
     apiConfig: {
       API_PORT: undefined as number | undefined,
       API_TRUST_PROXY: 'false',
@@ -64,7 +66,9 @@ vi.mock('@shipfox/api-projects', () => ({createProjectsModule: mocks.createProje
 vi.mock('@shipfox/api-runners', () => ({runnersModule: {name: 'runners'}}));
 vi.mock('@shipfox/api-secrets', () => ({
   deleteSecrets: mocks.deleteSecrets,
+  getSecret: mocks.getSecret,
   secretsModule: {name: 'secrets'},
+  setSecrets: mocks.setSecrets,
 }));
 vi.mock('@shipfox/api-triggers', () => ({triggersModule: {name: 'triggers'}}));
 vi.mock('@shipfox/api-workflows', () => ({
@@ -135,6 +139,8 @@ describe('run', () => {
     mocks.createPostgresClient.mockReset();
     mocks.createProjectsModule.mockReset();
     mocks.deleteSecrets.mockReset();
+    mocks.getSecret.mockReset();
+    mocks.setSecrets.mockReset();
     mocks.apiConfig.API_PORT = undefined;
     mocks.apiConfig.API_TRUST_PROXY = 'false';
     mocks.apiConfig.E2E_ENABLED = false;

--- a/apps/api/src/core/run.ts
+++ b/apps/api/src/core/run.ts
@@ -13,7 +13,7 @@ import {
 import {logsModule} from '@shipfox/api-logs';
 import {createProjectsModule} from '@shipfox/api-projects';
 import {runnersModule} from '@shipfox/api-runners';
-import {deleteSecrets, secretsModule} from '@shipfox/api-secrets';
+import {deleteSecrets, getSecret, secretsModule, setSecrets} from '@shipfox/api-secrets';
 import {triggersModule} from '@shipfox/api-triggers';
 import {
   setAgentToolMaterializationServices,
@@ -38,7 +38,9 @@ export async function run(): Promise<void> {
 
   createPostgresClient();
 
-  const integrations = await createIntegrationsContext({secrets: {deleteSecrets}});
+  const integrations = await createIntegrationsContext({
+    secrets: {deleteSecrets, getSecret, setSecrets},
+  });
   const [agentToolSelectionCatalogs, agentToolCatalogs] = await Promise.all([
     buildAgentToolSelectionCatalogs(integrations.registry),
     buildAgentToolCatalogs(integrations.registry),

--- a/apps/api/src/core/run.ts
+++ b/apps/api/src/core/run.ts
@@ -39,7 +39,21 @@ export async function run(): Promise<void> {
   createPostgresClient();
 
   const integrations = await createIntegrationsContext({
-    secrets: {deleteSecrets, getSecret, setSecrets},
+    secrets: {
+      deleteSecrets,
+      linear: {
+        getSecret: (params) =>
+          getSecret({
+            ...params,
+            namespace: `system/integrations/linear/${params.namespace}`,
+          }),
+        setSecrets: (params) =>
+          setSecrets({
+            ...params,
+            namespace: `system/integrations/linear/${params.namespace}`,
+          }),
+      },
+    },
   });
   const [agentToolSelectionCatalogs, agentToolCatalogs] = await Promise.all([
     buildAgentToolSelectionCatalogs(integrations.registry),

--- a/apps/api/src/core/run.ts
+++ b/apps/api/src/core/run.ts
@@ -52,6 +52,11 @@ export async function run(): Promise<void> {
             ...params,
             namespace: `system/integrations/linear/${params.namespace}`,
           }),
+        deleteSecrets: (params) =>
+          deleteSecrets({
+            ...params,
+            namespace: `system/integrations/linear/${params.namespace}`,
+          }),
       },
     },
   });

--- a/libs/api/integration/core/src/providers/linear.ts
+++ b/libs/api/integration/core/src/providers/linear.ts
@@ -20,13 +20,16 @@ import type {IntegrationModuleParts, IntegrationProviderModule} from '#providers
 const LINEAR_MIGRATIONS_TABLE = '__drizzle_migrations_integrations_linear';
 const LINEAR_SECRETS_NAMESPACE_PREFIX = 'system/integrations/linear/';
 
+type IntegrationDb = ReturnType<typeof db>;
+type IntegrationTx = Parameters<Parameters<IntegrationDb['transaction']>[0]>[0];
+
 async function loadLinearModuleParts(
   options: Parameters<IntegrationProviderModule['load']>[0] = {},
 ): Promise<IntegrationModuleParts> {
   const {
     createLinearTokenStore,
     createLinearIntegrationProvider,
-    deleteLinearInstallationByConnectionId,
+    disconnectLinearInstallation: disconnectLinearInstallationRecords,
     getLinearInstallationByOrganizationId,
     db: linearDb,
     migrationsPath: linearMigrationsPath,
@@ -91,9 +94,17 @@ async function loadLinearModuleParts(
   }
 
   async function disconnectLinearInstallation(input: {connectionId: string}): Promise<void> {
-    await db().transaction(async (tx) => {
-      await deleteLinearInstallationByConnectionId(input.connectionId, {tx});
-      await deleteIntegrationConnection({id: input.connectionId}, {tx});
+    await disconnectLinearInstallationRecords<IntegrationTx>({
+      connectionId: input.connectionId,
+      getConnection: getIntegrationConnectionById,
+      deleteSecrets: (params) =>
+        options.secrets?.linear?.deleteSecrets({
+          ...params,
+          namespace: linearNamespaceSuffix(params.namespace),
+        }) ?? Promise.resolve(0),
+      transaction: (fn) => db().transaction((tx) => fn(tx)),
+      deleteConnection: (params, options) =>
+        deleteIntegrationConnection({id: params.connectionId}, options),
     });
   }
 

--- a/libs/api/integration/core/src/providers/linear.ts
+++ b/libs/api/integration/core/src/providers/linear.ts
@@ -1,17 +1,110 @@
+import {
+  type IntegrationConnection as CoreIntegrationConnection,
+  slugifyConnectionSlug,
+} from '@shipfox/api-integration-core-dto';
+import type {
+  ConnectLinearInstallationInput,
+  LinearSecretsStore,
+} from '@shipfox/api-integration-linear';
 import {config} from '#config.js';
+import {
+  getIntegrationConnectionById,
+  resolveUniqueConnectionSlug,
+  upsertIntegrationConnection,
+} from '#db/connections.js';
+import {db} from '#db/db.js';
+import {retryConnectionSlugCollision} from '#providers/connection-slug.js';
 import type {IntegrationModuleParts, IntegrationProviderModule} from '#providers/types.js';
 
 const LINEAR_MIGRATIONS_TABLE = '__drizzle_migrations_integrations_linear';
 
-async function loadLinearModuleParts(): Promise<IntegrationModuleParts> {
+async function loadLinearModuleParts(
+  options: Parameters<IntegrationProviderModule['load']>[0] = {},
+): Promise<IntegrationModuleParts> {
   const {
+    createLinearTokenStore,
     createLinearIntegrationProvider,
+    getLinearInstallationByOrganizationId,
     db: linearDb,
     migrationsPath: linearMigrationsPath,
+    upsertLinearInstallation,
   } = await import('@shipfox/api-integration-linear');
 
+  async function getExistingLinearConnection(input: {
+    organizationId: string;
+  }): Promise<CoreIntegrationConnection<'linear'> | undefined> {
+    const installation = await getLinearInstallationByOrganizationId(input.organizationId);
+    if (!installation) return undefined;
+    const connection = await getIntegrationConnectionById(installation.connectionId);
+    if (!connection) return undefined;
+    return connection as CoreIntegrationConnection<'linear'>;
+  }
+
+  async function connectLinearInstallation(
+    input: ConnectLinearInstallationInput,
+  ): Promise<CoreIntegrationConnection<'linear'>> {
+    return await retryConnectionSlugCollision(() =>
+      db().transaction(async (tx) => {
+        const baseSlug = slugifyConnectionSlug(`linear_${input.organizationUrlKey}`, {
+          fallback: 'linear',
+        });
+        const slug = await resolveUniqueConnectionSlug(
+          {
+            workspaceId: input.workspaceId,
+            provider: 'linear',
+            externalAccountId: input.organizationId,
+            baseSlug,
+          },
+          {tx},
+        );
+        const connection = await upsertIntegrationConnection(
+          {
+            workspaceId: input.workspaceId,
+            provider: 'linear',
+            externalAccountId: input.organizationId,
+            slug,
+            displayName: input.displayName,
+            lifecycleStatus: 'active',
+          },
+          {tx},
+        );
+
+        await upsertLinearInstallation(
+          {
+            connectionId: connection.id,
+            organizationId: input.organizationId,
+            organizationUrlKey: input.organizationUrlKey,
+            appUserId: input.appUserId,
+            scopes: input.scopes,
+            tokenExpiresAt: input.tokenExpiresAt,
+            status: 'installed',
+          },
+          {tx},
+        );
+
+        return connection as CoreIntegrationConnection<'linear'>;
+      }),
+    );
+  }
+
+  const fallbackSecrets: LinearSecretsStore = {
+    getSecret: () => Promise.resolve(null),
+    setSecrets: () => Promise.reject(new Error('Linear token storage is not configured')),
+  };
+  const secrets = options.secrets ?? fallbackSecrets;
+  const tokenStore = createLinearTokenStore({
+    resolveConnection: async (connectionId) => getIntegrationConnectionById(connectionId),
+    secrets,
+  });
+
   return {
-    provider: createLinearIntegrationProvider(),
+    provider: createLinearIntegrationProvider({
+      routes: {
+        tokenStore,
+        getExistingLinearConnection,
+        connectLinearInstallation,
+      },
+    }),
     database: {
       db: linearDb,
       migrationsPath: linearMigrationsPath,

--- a/libs/api/integration/core/src/providers/linear.ts
+++ b/libs/api/integration/core/src/providers/linear.ts
@@ -8,6 +8,7 @@ import type {
 } from '@shipfox/api-integration-linear';
 import {config} from '#config.js';
 import {
+  deleteIntegrationConnection,
   getIntegrationConnectionById,
   resolveUniqueConnectionSlug,
   upsertIntegrationConnection,
@@ -17,6 +18,7 @@ import {retryConnectionSlugCollision} from '#providers/connection-slug.js';
 import type {IntegrationModuleParts, IntegrationProviderModule} from '#providers/types.js';
 
 const LINEAR_MIGRATIONS_TABLE = '__drizzle_migrations_integrations_linear';
+const LINEAR_SECRETS_NAMESPACE_PREFIX = 'system/integrations/linear/';
 
 async function loadLinearModuleParts(
   options: Parameters<IntegrationProviderModule['load']>[0] = {},
@@ -24,6 +26,7 @@ async function loadLinearModuleParts(
   const {
     createLinearTokenStore,
     createLinearIntegrationProvider,
+    deleteLinearInstallationByConnectionId,
     getLinearInstallationByOrganizationId,
     db: linearDb,
     migrationsPath: linearMigrationsPath,
@@ -87,11 +90,31 @@ async function loadLinearModuleParts(
     );
   }
 
+  async function disconnectLinearInstallation(input: {connectionId: string}): Promise<void> {
+    await db().transaction(async (tx) => {
+      await deleteLinearInstallationByConnectionId(input.connectionId, {tx});
+      await deleteIntegrationConnection({id: input.connectionId}, {tx});
+    });
+  }
+
   const fallbackSecrets: LinearSecretsStore = {
     getSecret: () => Promise.resolve(null),
     setSecrets: () => Promise.reject(new Error('Linear token storage is not configured')),
   };
-  const secrets = options.secrets ?? fallbackSecrets;
+  const secrets: LinearSecretsStore = options.secrets?.linear
+    ? {
+        getSecret: (params: Parameters<LinearSecretsStore['getSecret']>[0]) =>
+          options.secrets?.linear?.getSecret({
+            ...params,
+            namespace: linearNamespaceSuffix(params.namespace),
+          }) ?? Promise.resolve(null),
+        setSecrets: (params: Parameters<LinearSecretsStore['setSecrets']>[0]) =>
+          options.secrets?.linear?.setSecrets({
+            ...params,
+            namespace: linearNamespaceSuffix(params.namespace),
+          }) ?? Promise.resolve(),
+      }
+    : fallbackSecrets;
   const tokenStore = createLinearTokenStore({
     resolveConnection: async (connectionId) => getIntegrationConnectionById(connectionId),
     secrets,
@@ -103,6 +126,7 @@ async function loadLinearModuleParts(
         tokenStore,
         getExistingLinearConnection,
         connectLinearInstallation,
+        disconnectLinearInstallation,
       },
     }),
     database: {
@@ -118,3 +142,10 @@ export const linearProviderModule: IntegrationProviderModule = {
   enabled: config.INTEGRATIONS_ENABLE_LINEAR_PROVIDER,
   load: loadLinearModuleParts,
 };
+
+function linearNamespaceSuffix(namespace: string): string {
+  if (!namespace.startsWith(LINEAR_SECRETS_NAMESPACE_PREFIX)) {
+    throw new Error('Linear provider attempted to access an unscoped secret namespace');
+  }
+  return namespace.slice(LINEAR_SECRETS_NAMESPACE_PREFIX.length);
+}

--- a/libs/api/integration/core/src/providers/types.ts
+++ b/libs/api/integration/core/src/providers/types.ts
@@ -45,4 +45,5 @@ export interface IntegrationProviderScopedSecrets {
     values: Record<string, string>;
     editedBy?: string | null | undefined;
   }): Promise<void>;
+  deleteSecrets(params: {workspaceId: string; namespace: string}): Promise<number>;
 }

--- a/libs/api/integration/core/src/providers/types.ts
+++ b/libs/api/integration/core/src/providers/types.ts
@@ -33,5 +33,12 @@ export interface IntegrationProviderModuleLoadOptions {
 }
 
 export interface IntegrationProviderSecrets {
+  getSecret(params: {workspaceId: string; namespace: string; key: string}): Promise<string | null>;
+  setSecrets(params: {
+    workspaceId: string;
+    namespace: string;
+    values: Record<string, string>;
+    editedBy?: string | null | undefined;
+  }): Promise<void>;
   deleteSecrets(params: {workspaceId: string; namespace: string}): Promise<number>;
 }

--- a/libs/api/integration/core/src/providers/types.ts
+++ b/libs/api/integration/core/src/providers/types.ts
@@ -33,6 +33,11 @@ export interface IntegrationProviderModuleLoadOptions {
 }
 
 export interface IntegrationProviderSecrets {
+  linear?: IntegrationProviderScopedSecrets | undefined;
+  deleteSecrets(params: {workspaceId: string; namespace: string}): Promise<number>;
+}
+
+export interface IntegrationProviderScopedSecrets {
   getSecret(params: {workspaceId: string; namespace: string; key: string}): Promise<string | null>;
   setSecrets(params: {
     workspaceId: string;
@@ -40,5 +45,4 @@ export interface IntegrationProviderSecrets {
     values: Record<string, string>;
     editedBy?: string | null | undefined;
   }): Promise<void>;
-  deleteSecrets(params: {workspaceId: string; namespace: string}): Promise<number>;
 }

--- a/libs/api/integration/linear-dto/package.json
+++ b/libs/api/integration/linear-dto/package.json
@@ -38,6 +38,7 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
+    "@shipfox/api-integration-core-dto": "workspace:*",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/libs/api/integration/linear-dto/src/schemas/index.ts
+++ b/libs/api/integration/linear-dto/src/schemas/index.ts
@@ -1,3 +1,25 @@
+import {integrationConnectionDtoSchema} from '@shipfox/api-integration-core-dto';
+import {z} from 'zod';
+
 export const LINEAR_PROVIDER = 'linear';
 
 export type LinearProvider = typeof LINEAR_PROVIDER;
+
+export const createLinearInstallBodySchema = z.object({
+  workspace_id: z.string().uuid(),
+});
+export type CreateLinearInstallBodyDto = z.infer<typeof createLinearInstallBodySchema>;
+
+export const createLinearInstallResponseSchema = z.object({
+  install_url: z.string().url(),
+});
+export type CreateLinearInstallResponseDto = z.infer<typeof createLinearInstallResponseSchema>;
+
+export const linearCallbackQuerySchema = z.object({
+  code: z.string().min(1),
+  state: z.string().min(1),
+});
+export type LinearCallbackQueryDto = z.infer<typeof linearCallbackQuerySchema>;
+
+export const linearCallbackResponseSchema = integrationConnectionDtoSchema;
+export type LinearCallbackResponseDto = z.infer<typeof linearCallbackResponseSchema>;

--- a/libs/api/integration/linear-dto/src/schemas/index.ts
+++ b/libs/api/integration/linear-dto/src/schemas/index.ts
@@ -15,10 +15,17 @@ export const createLinearInstallResponseSchema = z.object({
 });
 export type CreateLinearInstallResponseDto = z.infer<typeof createLinearInstallResponseSchema>;
 
-export const linearCallbackQuerySchema = z.object({
-  code: z.string().min(1),
-  state: z.string().min(1),
-});
+export const linearCallbackQuerySchema = z.union([
+  z.object({
+    code: z.string().min(1),
+    state: z.string().min(1),
+  }),
+  z.object({
+    error: z.string().min(1),
+    error_description: z.string().min(1).optional(),
+    state: z.string().min(1),
+  }),
+]);
 export type LinearCallbackQueryDto = z.infer<typeof linearCallbackQuerySchema>;
 
 export const linearCallbackResponseSchema = integrationConnectionDtoSchema;

--- a/libs/api/integration/linear/package.json
+++ b/libs/api/integration/linear/package.json
@@ -37,10 +37,13 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
+    "@shipfox/api-auth-context": "workspace:*",
     "@shipfox/api-integration-core-dto": "workspace:*",
     "@shipfox/api-integration-linear-dto": "workspace:*",
+    "@shipfox/api-workspaces": "workspace:*",
     "@shipfox/config": "workspace:*",
     "@shipfox/node-drizzle": "workspace:*",
+    "@shipfox/node-fastify": "workspace:*",
     "@shipfox/node-opentelemetry": "workspace:*",
     "@shipfox/node-postgres": "workspace:*",
     "drizzle-orm": "^0.45.2",
@@ -58,6 +61,7 @@
     "@shipfox/vitest": "workspace:*",
     "@types/pg": "^8.15.5",
     "drizzle-kit": "^0.31.10",
+    "fastify": "^5.3.3",
     "fishery": "^2.2.2"
   }
 }

--- a/libs/api/integration/linear/src/api/client.test.ts
+++ b/libs/api/integration/linear/src/api/client.test.ts
@@ -217,6 +217,47 @@ describe('createLinearApiClient.refreshAccessToken', () => {
   });
 });
 
+describe('createLinearApiClient.revokeToken', () => {
+  beforeEach(() => {
+    mocks.post.mockReset();
+    mocks.warn.mockReset();
+  });
+
+  it('posts an OAuth token revocation request', async () => {
+    mocks.post.mockResolvedValue(undefined);
+    const client = createLinearApiClient();
+
+    await client.revokeToken({token: 'access-token', tokenTypeHint: 'access_token'});
+
+    const firstCall = mocks.post.mock.calls[0];
+    expect(firstCall).toBeDefined();
+    const [url, options] = firstCall as [string, {body: URLSearchParams}];
+    const body = options.body as URLSearchParams;
+    expect(url).toBe('https://api.linear.app/oauth/revoke');
+    expect(body.get('client_id')).toBe('test-client-id');
+    expect(body.get('client_secret')).toBe('test-client-secret');
+    expect(body.get('token')).toBe('access-token');
+    expect(body.get('token_type_hint')).toBe('access_token');
+  });
+
+  it('maps a rejected revocation without logging the token', async () => {
+    mocks.post.mockRejectedValue(httpError(400));
+    const client = createLinearApiClient();
+
+    const error = await client
+      .revokeToken({token: 'secret-token', tokenTypeHint: 'refresh_token'})
+      .catch((thrown: unknown) => thrown);
+
+    expect(error).toMatchObject({reason: 'access-denied'});
+    const serialized = [
+      (error as Error).message,
+      JSON.stringify(error),
+      JSON.stringify(mocks.warn.mock.calls),
+    ].join(' ');
+    expect(serialized).not.toContain('secret-token');
+  });
+});
+
 describe('createLinearApiClient.getIdentity', () => {
   beforeEach(() => {
     vi.useRealTimers();

--- a/libs/api/integration/linear/src/api/client.ts
+++ b/libs/api/integration/linear/src/api/client.ts
@@ -4,6 +4,7 @@ import {config} from '#config.js';
 import {LinearIntegrationProviderError} from '#core/errors.js';
 
 const LINEAR_OAUTH_TOKEN_URL = 'https://api.linear.app/oauth/token';
+const LINEAR_OAUTH_REVOKE_URL = 'https://api.linear.app/oauth/revoke';
 const LINEAR_GRAPHQL_URL = 'https://api.linear.app/graphql';
 const LINEAR_API_TIMEOUT_MS = 10_000;
 const SCOPE_SEPARATOR_RE = /[,\s]+/;
@@ -38,6 +39,10 @@ export interface LinearIdentity {
 export interface LinearApiClient {
   exchangeAuthorizationCode(input: {code: string}): Promise<LinearAuthorization>;
   refreshAccessToken(input: {refreshToken: string}): Promise<LinearAuthorization>;
+  revokeToken(input: {
+    token: string;
+    tokenTypeHint: 'access_token' | 'refresh_token';
+  }): Promise<void>;
   getIdentity(input: {accessToken: string}): Promise<LinearIdentity>;
 }
 
@@ -103,6 +108,20 @@ export function createLinearApiClient(): LinearApiClient {
       );
 
       return parseTokenResponse(body);
+    },
+
+    async revokeToken(input) {
+      await mapLinearError('revoke-token', async () => {
+        await ky.post(LINEAR_OAUTH_REVOKE_URL, {
+          body: new URLSearchParams({
+            client_id: config.LINEAR_OAUTH_CLIENT_ID,
+            client_secret: config.LINEAR_OAUTH_CLIENT_SECRET,
+            token: input.token,
+            token_type_hint: input.tokenTypeHint,
+          }),
+          timeout: LINEAR_API_TIMEOUT_MS,
+        });
+      });
     },
 
     async getIdentity(input) {

--- a/libs/api/integration/linear/src/core/disconnect.test.ts
+++ b/libs/api/integration/linear/src/core/disconnect.test.ts
@@ -1,0 +1,45 @@
+import {disconnectLinearInstallation} from './disconnect.js';
+
+vi.mock('#db/installations.js', () => ({
+  deleteLinearInstallationByConnectionId: vi.fn(() => Promise.resolve(true)),
+}));
+
+const {deleteLinearInstallationByConnectionId} = await import('#db/installations.js');
+const deleteLinearInstallationByConnectionIdMock = vi.mocked(
+  deleteLinearInstallationByConnectionId,
+);
+
+describe('disconnectLinearInstallation', () => {
+  beforeEach(() => {
+    deleteLinearInstallationByConnectionIdMock.mockClear();
+  });
+
+  it('deletes stored tokens before deleting connection records', async () => {
+    const tx = Symbol('tx');
+    const calls: string[] = [];
+    const deleteSecrets = vi.fn(() => {
+      calls.push('secrets');
+      return Promise.resolve(2);
+    });
+    const deleteConnection = vi.fn(() => {
+      calls.push('connection');
+      return Promise.resolve(true);
+    });
+
+    await disconnectLinearInstallation({
+      connectionId: 'connection-1',
+      getConnection: vi.fn(() => Promise.resolve({workspaceId: 'workspace-1'})),
+      deleteSecrets,
+      transaction: async (fn) => await fn(tx),
+      deleteConnection,
+    });
+
+    expect(deleteSecrets).toHaveBeenCalledWith({
+      workspaceId: 'workspace-1',
+      namespace: 'system/integrations/linear/connection-1',
+    });
+    expect(deleteLinearInstallationByConnectionIdMock).toHaveBeenCalledWith('connection-1', {tx});
+    expect(deleteConnection).toHaveBeenCalledWith({connectionId: 'connection-1'}, {tx});
+    expect(calls).toEqual(['secrets', 'connection']);
+  });
+});

--- a/libs/api/integration/linear/src/core/disconnect.ts
+++ b/libs/api/integration/linear/src/core/disconnect.ts
@@ -1,0 +1,27 @@
+import {deleteLinearInstallationByConnectionId} from '#db/installations.js';
+import {linearSecretsNamespace} from './tokens.js';
+
+export interface DisconnectLinearInstallationParams<Tx = unknown> {
+  connectionId: string;
+  getConnection(connectionId: string): Promise<{workspaceId: string} | undefined>;
+  deleteSecrets(params: {workspaceId: string; namespace: string}): Promise<number>;
+  transaction<T>(fn: (tx: Tx) => Promise<T>): Promise<T>;
+  deleteConnection(params: {connectionId: string}, options: {tx: Tx}): Promise<boolean>;
+}
+
+export async function disconnectLinearInstallation<Tx = unknown>(
+  params: DisconnectLinearInstallationParams<Tx>,
+): Promise<void> {
+  const connection = await params.getConnection(params.connectionId);
+  if (connection) {
+    await params.deleteSecrets({
+      workspaceId: connection.workspaceId,
+      namespace: linearSecretsNamespace(params.connectionId),
+    });
+  }
+
+  await params.transaction(async (tx) => {
+    await deleteLinearInstallationByConnectionId(params.connectionId, {tx});
+    await params.deleteConnection({connectionId: params.connectionId}, {tx});
+  });
+}

--- a/libs/api/integration/linear/src/core/errors.ts
+++ b/libs/api/integration/linear/src/core/errors.ts
@@ -16,6 +16,23 @@ export class LinearInstallStateActorMismatchError extends Error {
   }
 }
 
+export class LinearOAuthCallbackError extends Error {
+  constructor(
+    public readonly providerError: string,
+    public readonly providerDescription: string | undefined,
+  ) {
+    super(providerDescription ?? `Linear OAuth callback failed: ${providerError}`);
+    this.name = 'LinearOAuthCallbackError';
+  }
+}
+
+export class LinearAuthorizationScopeMismatchError extends Error {
+  constructor(public readonly missingScopes: string[]) {
+    super(`Linear authorization is missing required scopes: ${missingScopes.join(', ')}`);
+    this.name = 'LinearAuthorizationScopeMismatchError';
+  }
+}
+
 export class LinearInstallationAlreadyLinkedError extends Error {
   constructor(organizationId: string) {
     super(`Linear organization is already linked to another Shipfox workspace: ${organizationId}`);

--- a/libs/api/integration/linear/src/core/errors.ts
+++ b/libs/api/integration/linear/src/core/errors.ts
@@ -2,6 +2,20 @@ import {IntegrationProviderError} from '@shipfox/api-integration-core-dto';
 
 export class LinearIntegrationProviderError extends IntegrationProviderError {}
 
+export class LinearInstallStateError extends Error {
+  constructor(message = 'Invalid Linear install state') {
+    super(message);
+    this.name = 'LinearInstallStateError';
+  }
+}
+
+export class LinearInstallStateActorMismatchError extends Error {
+  constructor() {
+    super('Linear install state was created by a different user');
+    this.name = 'LinearInstallStateActorMismatchError';
+  }
+}
+
 export class LinearInstallationAlreadyLinkedError extends Error {
   constructor(organizationId: string) {
     super(`Linear organization is already linked to another Shipfox workspace: ${organizationId}`);

--- a/libs/api/integration/linear/src/core/install.ts
+++ b/libs/api/integration/linear/src/core/install.ts
@@ -1,0 +1,81 @@
+import type {UserContextMembership} from '@shipfox/api-auth-context';
+import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
+import type {LinearApiClient} from '#api/client.js';
+import type {LinearTokenStore} from '#core/tokens.js';
+import {
+  LinearInstallationAlreadyLinkedError,
+  LinearInstallStateActorMismatchError,
+} from './errors.js';
+import {verifyLinearInstallState} from './state.js';
+
+export interface ConnectLinearInstallationInput {
+  workspaceId: string;
+  organizationId: string;
+  organizationUrlKey: string;
+  appUserId: string;
+  scopes: string[];
+  tokenExpiresAt: Date | null;
+  displayName: string;
+}
+
+export interface HandleLinearCallbackParams {
+  linear: LinearApiClient;
+  tokenStore: Pick<LinearTokenStore, 'storeTokens'>;
+  code: string;
+  state: string;
+  sessionUserId: string;
+  sessionMemberships: ReadonlyArray<UserContextMembership>;
+  requireWorkspaceMembership: (params: {
+    workspaceId: string;
+    userId: string;
+    memberships: ReadonlyArray<UserContextMembership>;
+  }) => Promise<unknown>;
+  getExistingLinearConnection: (input: {
+    organizationId: string;
+  }) => Promise<IntegrationConnection<'linear'> | undefined>;
+  connectLinearInstallation: (
+    input: ConnectLinearInstallationInput,
+  ) => Promise<IntegrationConnection<'linear'>>;
+}
+
+export async function handleLinearCallback(
+  params: HandleLinearCallbackParams,
+): Promise<IntegrationConnection<'linear'>> {
+  const claims = verifyLinearInstallState(params.state);
+  if (claims.userId !== params.sessionUserId) {
+    throw new LinearInstallStateActorMismatchError();
+  }
+  await params.requireWorkspaceMembership({
+    workspaceId: claims.workspaceId,
+    userId: claims.userId,
+    memberships: params.sessionMemberships,
+  });
+
+  const authorization = await params.linear.exchangeAuthorizationCode({code: params.code});
+  const identity = await params.linear.getIdentity({accessToken: authorization.accessToken});
+  const existing = await params.getExistingLinearConnection({
+    organizationId: identity.organizationId,
+  });
+  if (existing && existing.workspaceId !== claims.workspaceId) {
+    throw new LinearInstallationAlreadyLinkedError(identity.organizationId);
+  }
+
+  const connection = await params.connectLinearInstallation({
+    workspaceId: claims.workspaceId,
+    organizationId: identity.organizationId,
+    organizationUrlKey: identity.organizationUrlKey,
+    appUserId: identity.appUserId,
+    scopes: authorization.scopes,
+    tokenExpiresAt: authorization.expiresAt ?? null,
+    displayName: `Linear ${identity.organizationName}`,
+  });
+
+  await params.tokenStore.storeTokens({
+    connectionId: connection.id,
+    accessToken: authorization.accessToken,
+    refreshToken: authorization.refreshToken,
+    editedBy: claims.userId,
+  });
+
+  return connection;
+}

--- a/libs/api/integration/linear/src/core/install.ts
+++ b/libs/api/integration/linear/src/core/install.ts
@@ -39,12 +39,16 @@ export interface HandleLinearCallbackParams {
   connectLinearInstallation: (
     input: ConnectLinearInstallationInput,
   ) => Promise<IntegrationConnection<'linear'>>;
-  disconnectLinearInstallation?: ((input: {connectionId: string}) => Promise<void>) | undefined;
+  disconnectLinearInstallation: (input: {connectionId: string}) => Promise<void>;
 }
 
 export async function handleLinearCallback(
   params: HandleLinearCallbackParams,
 ): Promise<IntegrationConnection<'linear'>> {
+  if (typeof params.disconnectLinearInstallation !== 'function') {
+    throw new Error('Linear installation cleanup is not configured');
+  }
+
   const claims = verifyLinearInstallState(params.state);
   if (claims.userId !== params.sessionUserId) {
     throw new LinearInstallStateActorMismatchError();
@@ -56,44 +60,45 @@ export async function handleLinearCallback(
   });
 
   const authorization = await params.linear.exchangeAuthorizationCode({code: params.code});
-  const identity = await params.linear.getIdentity({accessToken: authorization.accessToken});
-  const existing = await params.getExistingLinearConnection({
-    organizationId: identity.organizationId,
-  });
-  if (existing && existing.workspaceId !== claims.workspaceId) {
-    await bestEffortRevokeAuthorization(params.linear, authorization);
-    throw new LinearInstallationAlreadyLinkedError(identity.organizationId);
-  }
+  let connectedConnectionId: string | undefined;
+  let shouldDisconnectConnection = false;
   try {
+    const identity = await params.linear.getIdentity({accessToken: authorization.accessToken});
+    const existing = await params.getExistingLinearConnection({
+      organizationId: identity.organizationId,
+    });
+    if (existing && existing.workspaceId !== claims.workspaceId) {
+      throw new LinearInstallationAlreadyLinkedError(identity.organizationId);
+    }
+
     assertLinearAuthorizationScopes(authorization.scopes);
-  } catch (error) {
-    await bestEffortRevokeAuthorization(params.linear, authorization);
-    throw error;
-  }
 
-  const connection = await params.connectLinearInstallation({
-    workspaceId: claims.workspaceId,
-    organizationId: identity.organizationId,
-    organizationUrlKey: identity.organizationUrlKey,
-    appUserId: identity.appUserId,
-    scopes: authorization.scopes,
-    tokenExpiresAt: authorization.expiresAt ?? null,
-    displayName: `Linear ${identity.organizationName}`,
-  });
-
-  try {
+    const connection = await params.connectLinearInstallation({
+      workspaceId: claims.workspaceId,
+      organizationId: identity.organizationId,
+      organizationUrlKey: identity.organizationUrlKey,
+      appUserId: identity.appUserId,
+      scopes: authorization.scopes,
+      tokenExpiresAt: authorization.expiresAt ?? null,
+      displayName: `Linear ${identity.organizationName}`,
+    });
+    connectedConnectionId = connection.id;
+    shouldDisconnectConnection = !existing;
     await params.tokenStore.storeTokens({
       connectionId: connection.id,
       accessToken: authorization.accessToken,
       refreshToken: authorization.refreshToken,
       editedBy: claims.userId,
     });
+
+    return connection;
   } catch (error) {
-    if (!existing) await bestEffortDisconnectLinearInstallation(params, connection.id);
+    await bestEffortRevokeAuthorization(params.linear, authorization);
+    if (connectedConnectionId && shouldDisconnectConnection) {
+      await bestEffortDisconnectLinearInstallation(params, connectedConnectionId);
+    }
     throw error;
   }
-
-  return connection;
 }
 
 export async function handleLinearOAuthCallbackError(params: {
@@ -146,7 +151,6 @@ async function bestEffortDisconnectLinearInstallation(
   params: HandleLinearCallbackParams,
   connectionId: string,
 ): Promise<void> {
-  if (!params.disconnectLinearInstallation) return;
   try {
     await params.disconnectLinearInstallation({connectionId});
   } catch (error) {

--- a/libs/api/integration/linear/src/core/install.ts
+++ b/libs/api/integration/linear/src/core/install.ts
@@ -1,11 +1,14 @@
 import type {UserContextMembership} from '@shipfox/api-auth-context';
 import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
+import {logger} from '@shipfox/node-opentelemetry';
 import type {LinearApiClient} from '#api/client.js';
 import type {LinearTokenStore} from '#core/tokens.js';
 import {
   LinearInstallationAlreadyLinkedError,
   LinearInstallStateActorMismatchError,
+  LinearOAuthCallbackError,
 } from './errors.js';
+import {assertLinearAuthorizationScopes} from './scopes.js';
 import {verifyLinearInstallState} from './state.js';
 
 export interface ConnectLinearInstallationInput {
@@ -36,6 +39,7 @@ export interface HandleLinearCallbackParams {
   connectLinearInstallation: (
     input: ConnectLinearInstallationInput,
   ) => Promise<IntegrationConnection<'linear'>>;
+  disconnectLinearInstallation?: ((input: {connectionId: string}) => Promise<void>) | undefined;
 }
 
 export async function handleLinearCallback(
@@ -57,7 +61,14 @@ export async function handleLinearCallback(
     organizationId: identity.organizationId,
   });
   if (existing && existing.workspaceId !== claims.workspaceId) {
+    await bestEffortRevokeAuthorization(params.linear, authorization);
     throw new LinearInstallationAlreadyLinkedError(identity.organizationId);
+  }
+  try {
+    assertLinearAuthorizationScopes(authorization.scopes);
+  } catch (error) {
+    await bestEffortRevokeAuthorization(params.linear, authorization);
+    throw error;
   }
 
   const connection = await params.connectLinearInstallation({
@@ -70,12 +81,78 @@ export async function handleLinearCallback(
     displayName: `Linear ${identity.organizationName}`,
   });
 
-  await params.tokenStore.storeTokens({
-    connectionId: connection.id,
-    accessToken: authorization.accessToken,
-    refreshToken: authorization.refreshToken,
-    editedBy: claims.userId,
-  });
+  try {
+    await params.tokenStore.storeTokens({
+      connectionId: connection.id,
+      accessToken: authorization.accessToken,
+      refreshToken: authorization.refreshToken,
+      editedBy: claims.userId,
+    });
+  } catch (error) {
+    if (!existing) await bestEffortDisconnectLinearInstallation(params, connection.id);
+    throw error;
+  }
 
   return connection;
+}
+
+export async function handleLinearOAuthCallbackError(params: {
+  state: string;
+  error: string;
+  errorDescription?: string | undefined;
+  sessionUserId: string;
+  sessionMemberships: ReadonlyArray<UserContextMembership>;
+  requireWorkspaceMembership: (input: {
+    workspaceId: string;
+    userId: string;
+    memberships: ReadonlyArray<UserContextMembership>;
+  }) => Promise<unknown>;
+}): Promise<never> {
+  const claims = verifyLinearInstallState(params.state);
+  if (claims.userId !== params.sessionUserId) throw new LinearInstallStateActorMismatchError();
+  await params.requireWorkspaceMembership({
+    workspaceId: claims.workspaceId,
+    userId: claims.userId,
+    memberships: params.sessionMemberships,
+  });
+  throw new LinearOAuthCallbackError(params.error, params.errorDescription);
+}
+
+async function bestEffortRevokeAuthorization(
+  linear: LinearApiClient,
+  authorization: {accessToken: string; refreshToken?: string | undefined},
+): Promise<void> {
+  await Promise.all([
+    authorization.refreshToken
+      ? revokeToken(linear, authorization.refreshToken, 'refresh_token')
+      : Promise.resolve(),
+    revokeToken(linear, authorization.accessToken, 'access_token'),
+  ]);
+}
+
+async function revokeToken(
+  linear: LinearApiClient,
+  token: string,
+  tokenTypeHint: 'access_token' | 'refresh_token',
+): Promise<void> {
+  try {
+    await linear.revokeToken({token, tokenTypeHint});
+  } catch (error) {
+    logger().warn({err: error, tokenTypeHint}, 'Linear OAuth token revocation failed');
+  }
+}
+
+async function bestEffortDisconnectLinearInstallation(
+  params: HandleLinearCallbackParams,
+  connectionId: string,
+): Promise<void> {
+  if (!params.disconnectLinearInstallation) return;
+  try {
+    await params.disconnectLinearInstallation({connectionId});
+  } catch (error) {
+    logger().warn(
+      {err: error, connectionId},
+      'Linear connect compensation failed after token storage rejection',
+    );
+  }
 }

--- a/libs/api/integration/linear/src/core/scopes.ts
+++ b/libs/api/integration/linear/src/core/scopes.ts
@@ -1,6 +1,11 @@
 import {LinearAuthorizationScopeMismatchError} from './errors.js';
 
-export const LINEAR_OAUTH_SCOPES = ['read', 'write', 'app:assignable', 'app:mentionable'];
+export const LINEAR_OAUTH_SCOPES = Object.freeze([
+  'read',
+  'write',
+  'app:assignable',
+  'app:mentionable',
+]);
 
 export function formatLinearOAuthScopes(scopes = LINEAR_OAUTH_SCOPES): string {
   return scopes.join(',');

--- a/libs/api/integration/linear/src/core/scopes.ts
+++ b/libs/api/integration/linear/src/core/scopes.ts
@@ -1,0 +1,13 @@
+import {LinearAuthorizationScopeMismatchError} from './errors.js';
+
+export const LINEAR_OAUTH_SCOPES = ['read', 'write', 'app:assignable', 'app:mentionable'];
+
+export function formatLinearOAuthScopes(scopes = LINEAR_OAUTH_SCOPES): string {
+  return scopes.join(',');
+}
+
+export function assertLinearAuthorizationScopes(scopes: string[]): void {
+  const grantedScopes = new Set(scopes);
+  const missingScopes = LINEAR_OAUTH_SCOPES.filter((scope) => !grantedScopes.has(scope));
+  if (missingScopes.length > 0) throw new LinearAuthorizationScopeMismatchError(missingScopes);
+}

--- a/libs/api/integration/linear/src/core/state.test.ts
+++ b/libs/api/integration/linear/src/core/state.test.ts
@@ -1,0 +1,51 @@
+import {LinearInstallStateError} from './errors.js';
+import {signLinearInstallState, verifyLinearInstallState} from './state.js';
+
+describe('Linear install state', () => {
+  it('round-trips signed workspace and user claims', () => {
+    const state = signLinearInstallState({
+      workspaceId: 'workspace-1',
+      userId: 'user-1',
+      nonce: 'nonce-1',
+      now: new Date('2026-07-07T12:00:00.000Z'),
+    });
+
+    const result = verifyLinearInstallState(state, new Date('2026-07-07T12:05:00.000Z'));
+
+    expect(result).toEqual({workspaceId: 'workspace-1', userId: 'user-1'});
+  });
+
+  it('rejects tampered payloads', () => {
+    const state = signLinearInstallState({
+      workspaceId: 'workspace-1',
+      userId: 'user-1',
+      nonce: 'nonce-1',
+      now: new Date('2026-07-07T12:00:00.000Z'),
+    });
+    const [encodedPayload, signature] = state.split('.');
+    const payload = JSON.parse(Buffer.from(encodedPayload ?? '', 'base64url').toString('utf8'));
+    payload.workspaceId = 'workspace-2';
+    const tamperedPayload = Buffer.from(JSON.stringify(payload)).toString('base64url');
+
+    const result = () =>
+      verifyLinearInstallState(
+        `${tamperedPayload}.${signature}`,
+        new Date('2026-07-07T12:05:00.000Z'),
+      );
+
+    expect(result).toThrow(LinearInstallStateError);
+  });
+
+  it('rejects expired states', () => {
+    const state = signLinearInstallState({
+      workspaceId: 'workspace-1',
+      userId: 'user-1',
+      nonce: 'nonce-1',
+      now: new Date('2026-07-07T12:00:00.000Z'),
+    });
+
+    const result = () => verifyLinearInstallState(state, new Date('2026-07-07T12:31:00.000Z'));
+
+    expect(result).toThrow(LinearInstallStateError);
+  });
+});

--- a/libs/api/integration/linear/src/core/state.ts
+++ b/libs/api/integration/linear/src/core/state.ts
@@ -1,0 +1,85 @@
+import {createHmac, randomUUID, timingSafeEqual} from 'node:crypto';
+import {config} from '#config.js';
+import {LinearInstallStateError} from './errors.js';
+
+const STATE_TTL_SECONDS = 30 * 60;
+
+interface LinearInstallStatePayload {
+  workspaceId: string;
+  userId: string;
+  nonce: string;
+  expiresAt: number;
+}
+
+export interface LinearInstallStateClaims {
+  workspaceId: string;
+  userId: string;
+}
+
+export function signLinearInstallState(params: {
+  workspaceId: string;
+  userId: string;
+  nonce?: string | undefined;
+  now?: Date | undefined;
+}): string {
+  const now = params.now ?? new Date();
+  const payload: LinearInstallStatePayload = {
+    workspaceId: params.workspaceId,
+    userId: params.userId,
+    nonce: params.nonce ?? randomUUID(),
+    expiresAt: Math.floor(now.getTime() / 1000) + STATE_TTL_SECONDS,
+  };
+  const encodedPayload = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${encodedPayload}.${sign(encodedPayload)}`;
+}
+
+export function verifyLinearInstallState(
+  state: string,
+  now: Date = new Date(),
+): LinearInstallStateClaims {
+  const [encodedPayload, signature, extra] = state.split('.');
+  if (!encodedPayload || !signature || extra !== undefined) {
+    throw new LinearInstallStateError('Invalid Linear install state');
+  }
+
+  if (!constantTimeEqual(signature, sign(encodedPayload))) {
+    throw new LinearInstallStateError('Invalid Linear install state signature');
+  }
+
+  const payload = parsePayload(encodedPayload);
+  if (payload.expiresAt < Math.floor(now.getTime() / 1000)) {
+    throw new LinearInstallStateError('Expired Linear install state');
+  }
+
+  return {workspaceId: payload.workspaceId, userId: payload.userId};
+}
+
+function sign(encodedPayload: string): string {
+  return createHmac('sha256', config.LINEAR_OAUTH_CLIENT_SECRET)
+    .update(encodedPayload)
+    .digest('base64url');
+}
+
+function constantTimeEqual(a: string, b: string): boolean {
+  const left = Buffer.from(a);
+  const right = Buffer.from(b);
+  if (left.length !== right.length) return false;
+  return timingSafeEqual(left, right);
+}
+
+function parsePayload(encodedPayload: string): LinearInstallStatePayload {
+  try {
+    const parsed = JSON.parse(Buffer.from(encodedPayload, 'base64url').toString('utf8'));
+    if (
+      typeof parsed.workspaceId !== 'string' ||
+      typeof parsed.userId !== 'string' ||
+      typeof parsed.nonce !== 'string' ||
+      typeof parsed.expiresAt !== 'number'
+    ) {
+      throw new Error('Invalid payload shape');
+    }
+    return parsed;
+  } catch (_error) {
+    throw new LinearInstallStateError('Invalid Linear install state payload');
+  }
+}

--- a/libs/api/integration/linear/src/core/tokens.test.ts
+++ b/libs/api/integration/linear/src/core/tokens.test.ts
@@ -14,7 +14,6 @@ import {
 let secrets: LinearSecretsStore;
 
 beforeAll(async () => {
-  // @ts-expect-error @shipfox/api-secrets is a peer supplied by the composing API app.
   secrets = await import('@shipfox/api-secrets');
 });
 

--- a/libs/api/integration/linear/src/core/tokens.test.ts
+++ b/libs/api/integration/linear/src/core/tokens.test.ts
@@ -31,6 +31,7 @@ function createConnectionContext() {
       exchangeAuthorizationCode: vi.fn(),
       getIdentity: vi.fn(),
       refreshAccessToken,
+      revokeToken: vi.fn(),
     },
   });
 

--- a/libs/api/integration/linear/src/db/installations.ts
+++ b/libs/api/integration/linear/src/db/installations.ts
@@ -167,6 +167,17 @@ export async function markLinearInstallationRevoked(
   return toLinearInstallation(row);
 }
 
+export async function deleteLinearInstallationByConnectionId(
+  connectionId: string,
+  options: {tx?: unknown} = {},
+): Promise<boolean> {
+  const executor = (options.tx ?? db()) as LinearDb | LinearTx;
+  const result = await executor
+    .delete(linearInstallations)
+    .where(eq(linearInstallations.connectionId, connectionId));
+  return (result.rowCount ?? 0) > 0;
+}
+
 export type LinearRefreshLockResult<T> = {acquired: true; value: T} | {acquired: false};
 
 export function withLinearRefreshLock<T>(

--- a/libs/api/integration/linear/src/index.ts
+++ b/libs/api/integration/linear/src/index.ts
@@ -1,8 +1,13 @@
 import {LINEAR_PROVIDER} from '@shipfox/api-integration-linear-dto';
+import {createLinearApiClient, type LinearApiClient} from '#api/client.js';
 import {config} from '#config.js';
 import {closeDb, db} from '#db/db.js';
 import {getLinearInstallationByConnectionId} from '#db/installations.js';
 import {migrationsPath} from '#db/migrations.js';
+import {
+  type CreateLinearIntegrationRoutesOptions,
+  createLinearIntegrationRoutes,
+} from '#presentation/routes/install.js';
 
 export type {LinearProvider} from '@shipfox/api-integration-linear-dto';
 export type {LinearApiClient, LinearAuthorization, LinearIdentity} from '#api/client.js';
@@ -22,9 +27,15 @@ export {
   LinearConnectionAlreadyLinkedError,
   LinearConnectionNotFoundError,
   LinearInstallationAlreadyLinkedError,
+  LinearInstallStateActorMismatchError,
+  LinearInstallStateError,
   LinearIntegrationProviderError,
   LinearTokenUnrefreshableError,
 } from '#core/errors.js';
+export type {ConnectLinearInstallationInput, HandleLinearCallbackParams} from '#core/install.js';
+export {handleLinearCallback} from '#core/install.js';
+export type {LinearInstallStateClaims} from '#core/state.js';
+export {signLinearInstallState, verifyLinearInstallState} from '#core/state.js';
 export type {
   CreateLinearTokenStoreParams,
   GetLinearAccessTokenParams,
@@ -54,12 +65,15 @@ export {
 export {closeDb, config, db, migrationsPath};
 
 export interface CreateLinearIntegrationProviderOptions {
+  linear?: LinearApiClient | undefined;
   getLinearInstallationByConnectionId?: typeof getLinearInstallationByConnectionId | undefined;
+  routes?: Omit<CreateLinearIntegrationRoutesOptions, 'linear'> | undefined;
 }
 
 export function createLinearIntegrationProvider(
   options: CreateLinearIntegrationProviderOptions = {},
 ) {
+  const linear = options.linear ?? createLinearApiClient();
   const getInstallationByConnectionId =
     options.getLinearInstallationByConnectionId ?? getLinearInstallationByConnectionId;
 
@@ -72,5 +86,13 @@ export function createLinearIntegrationProvider(
       if (!installation?.organizationUrlKey) return undefined;
       return `https://linear.app/${encodeURIComponent(installation.organizationUrlKey)}/settings`;
     },
+    routes: options.routes
+      ? [
+          createLinearIntegrationRoutes({
+            linear,
+            ...options.routes,
+          }),
+        ]
+      : [],
   };
 }

--- a/libs/api/integration/linear/src/index.ts
+++ b/libs/api/integration/linear/src/index.ts
@@ -24,16 +24,23 @@ export {
 } from '#core/agent-tools.js';
 export {
   LinearAccessTokenMissingError,
+  LinearAuthorizationScopeMismatchError,
   LinearConnectionAlreadyLinkedError,
   LinearConnectionNotFoundError,
   LinearInstallationAlreadyLinkedError,
   LinearInstallStateActorMismatchError,
   LinearInstallStateError,
   LinearIntegrationProviderError,
+  LinearOAuthCallbackError,
   LinearTokenUnrefreshableError,
 } from '#core/errors.js';
 export type {ConnectLinearInstallationInput, HandleLinearCallbackParams} from '#core/install.js';
-export {handleLinearCallback} from '#core/install.js';
+export {handleLinearCallback, handleLinearOAuthCallbackError} from '#core/install.js';
+export {
+  assertLinearAuthorizationScopes,
+  formatLinearOAuthScopes,
+  LINEAR_OAUTH_SCOPES,
+} from '#core/scopes.js';
 export type {LinearInstallStateClaims} from '#core/state.js';
 export {signLinearInstallState, verifyLinearInstallState} from '#core/state.js';
 export type {
@@ -55,6 +62,7 @@ export type {
   UpsertLinearInstallationParams,
 } from '#db/installations.js';
 export {
+  deleteLinearInstallationByConnectionId,
   getLinearInstallationByConnectionId,
   getLinearInstallationByOrganizationId,
   markLinearInstallationRevoked,

--- a/libs/api/integration/linear/src/index.ts
+++ b/libs/api/integration/linear/src/index.ts
@@ -23,6 +23,10 @@ export {
   linearAgentToolSelectionCatalog,
 } from '#core/agent-tools.js';
 export {
+  type DisconnectLinearInstallationParams,
+  disconnectLinearInstallation,
+} from '#core/disconnect.js';
+export {
   LinearAccessTokenMissingError,
   LinearAuthorizationScopeMismatchError,
   LinearConnectionAlreadyLinkedError,
@@ -62,7 +66,6 @@ export type {
   UpsertLinearInstallationParams,
 } from '#db/installations.js';
 export {
-  deleteLinearInstallationByConnectionId,
   getLinearInstallationByConnectionId,
   getLinearInstallationByOrganizationId,
   markLinearInstallationRevoked,

--- a/libs/api/integration/linear/src/presentation/dto/integrations.ts
+++ b/libs/api/integration/linear/src/presentation/dto/integrations.ts
@@ -1,0 +1,6 @@
+import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
+import {toIntegrationConnectionDto as toCoreIntegrationConnectionDto} from '@shipfox/api-integration-core-dto';
+
+export function toIntegrationConnectionDto(connection: IntegrationConnection) {
+  return toCoreIntegrationConnectionDto(connection, {capabilities: []});
+}

--- a/libs/api/integration/linear/src/presentation/routes/errors.ts
+++ b/libs/api/integration/linear/src/presentation/routes/errors.ts
@@ -4,11 +4,13 @@ import {
 } from '@shipfox/api-integration-core-dto';
 import {ClientError} from '@shipfox/node-fastify';
 import {
+  LinearAuthorizationScopeMismatchError,
   LinearConnectionAlreadyLinkedError,
   LinearInstallationAlreadyLinkedError,
   LinearInstallStateActorMismatchError,
   LinearInstallStateError,
   LinearIntegrationProviderError,
+  LinearOAuthCallbackError,
 } from '#core/errors.js';
 
 function providerStatus(reason: IntegrationProviderErrorReason): number {
@@ -29,6 +31,21 @@ export function linearRouteErrorHandler(error: unknown): never {
   }
   if (error instanceof LinearConnectionAlreadyLinkedError) {
     throw new ClientError(error.message, 'linear-connection-already-linked', {status: 409});
+  }
+  if (error instanceof LinearAuthorizationScopeMismatchError) {
+    throw new ClientError(error.message, 'linear-authorization-scope-mismatch', {
+      status: 422,
+      details: {missing_scopes: error.missingScopes},
+    });
+  }
+  if (error instanceof LinearOAuthCallbackError) {
+    throw new ClientError(error.message, 'linear-oauth-callback-error', {
+      status: 422,
+      details: {
+        error: error.providerError,
+        ...(error.providerDescription ? {error_description: error.providerDescription} : {}),
+      },
+    });
   }
   if (error instanceof ConnectionSlugConflictError) {
     throw new ClientError(error.message, 'slug-conflict', {status: 409});

--- a/libs/api/integration/linear/src/presentation/routes/errors.ts
+++ b/libs/api/integration/linear/src/presentation/routes/errors.ts
@@ -1,0 +1,43 @@
+import {
+  ConnectionSlugConflictError,
+  type IntegrationProviderErrorReason,
+} from '@shipfox/api-integration-core-dto';
+import {ClientError} from '@shipfox/node-fastify';
+import {
+  LinearConnectionAlreadyLinkedError,
+  LinearInstallationAlreadyLinkedError,
+  LinearInstallStateActorMismatchError,
+  LinearInstallStateError,
+  LinearIntegrationProviderError,
+} from '#core/errors.js';
+
+function providerStatus(reason: IntegrationProviderErrorReason): number {
+  if (reason === 'rate-limited') return 429;
+  if (reason === 'timeout' || reason === 'provider-unavailable') return 503;
+  return 422;
+}
+
+export function linearRouteErrorHandler(error: unknown): never {
+  if (error instanceof LinearInstallStateError) {
+    throw new ClientError(error.message, 'invalid-linear-install-state', {status: 400});
+  }
+  if (error instanceof LinearInstallStateActorMismatchError) {
+    throw new ClientError(error.message, 'linear-install-state-actor-mismatch', {status: 403});
+  }
+  if (error instanceof LinearInstallationAlreadyLinkedError) {
+    throw new ClientError(error.message, 'linear-installation-already-linked', {status: 409});
+  }
+  if (error instanceof LinearConnectionAlreadyLinkedError) {
+    throw new ClientError(error.message, 'linear-connection-already-linked', {status: 409});
+  }
+  if (error instanceof ConnectionSlugConflictError) {
+    throw new ClientError(error.message, 'slug-conflict', {status: 409});
+  }
+  if (error instanceof LinearIntegrationProviderError) {
+    throw new ClientError(error.message, error.reason, {
+      details: {retry_after_seconds: error.retryAfterSeconds},
+      status: providerStatus(error.reason),
+    });
+  }
+  throw error;
+}

--- a/libs/api/integration/linear/src/presentation/routes/install.test.ts
+++ b/libs/api/integration/linear/src/presentation/routes/install.test.ts
@@ -1,0 +1,309 @@
+import {
+  AUTH_USER,
+  buildUserContext,
+  setUserContext,
+  type UserContextMembership,
+} from '@shipfox/api-auth-context';
+import {
+  ConnectionSlugConflictError,
+  type IntegrationConnection,
+} from '@shipfox/api-integration-core-dto';
+import {type AuthMethod, ClientError, closeApp, createApp} from '@shipfox/node-fastify';
+import type {FastifyInstance, FastifyRequest} from 'fastify';
+import type {LinearApiClient} from '#api/client.js';
+import type {ConnectLinearInstallationInput} from '#core/install.js';
+import {verifyLinearInstallState} from '#core/state.js';
+import type {LinearTokenStore} from '#core/tokens.js';
+import {createLinearIntegrationProvider} from '#index.js';
+
+vi.mock('@shipfox/api-workspaces', () => ({
+  requireWorkspaceMembership: vi.fn(() => Promise.resolve()),
+}));
+
+const {requireWorkspaceMembership} = await import('@shipfox/api-workspaces');
+const requireWorkspaceMembershipMock = vi.mocked(requireWorkspaceMembership);
+let authenticatedMemberships: UserContextMembership[] = [];
+
+const fakeUserAuth: AuthMethod = {
+  name: AUTH_USER,
+  authenticate: (request: FastifyRequest) => {
+    if (request.headers.authorization !== 'Bearer user') {
+      throw new ClientError('Invalid user token', 'unauthorized', {status: 401});
+    }
+
+    setUserContext(
+      request,
+      buildUserContext({
+        userId: 'user-1',
+        email: 'user@example.com',
+        memberships: authenticatedMemberships,
+      }),
+    );
+    return Promise.resolve();
+  },
+};
+
+function linearClient(overrides: Partial<LinearApiClient> = {}): LinearApiClient {
+  return {
+    exchangeAuthorizationCode: vi.fn(() =>
+      Promise.resolve({
+        accessToken: 'linear-access-token',
+        refreshToken: 'linear-refresh-token',
+        expiresAt: new Date('2026-07-07T13:00:00.000Z'),
+        scopes: ['read', 'write', 'app:assignable', 'app:mentionable'],
+      }),
+    ),
+    refreshAccessToken: vi.fn(() => {
+      throw new Error('not used');
+    }),
+    getIdentity: vi.fn(() =>
+      Promise.resolve({
+        appUserId: 'app-user-id',
+        organizationId: 'org-id',
+        organizationName: 'Acme',
+        organizationUrlKey: 'acme',
+      }),
+    ),
+    ...overrides,
+  };
+}
+
+function connection(input: Partial<IntegrationConnection<'linear'>> = {}) {
+  return {
+    id: crypto.randomUUID(),
+    workspaceId: crypto.randomUUID(),
+    provider: 'linear',
+    externalAccountId: 'org-id',
+    slug: 'linear_acme',
+    displayName: 'Linear Acme',
+    lifecycleStatus: 'active',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...input,
+  } satisfies IntegrationConnection<'linear'>;
+}
+
+interface CreateTestAppOptions {
+  linear?: LinearApiClient;
+  tokenStore?: Pick<LinearTokenStore, 'storeTokens'> | undefined;
+  existingConnection?: IntegrationConnection<'linear'> | undefined;
+  connectLinearInstallation?:
+    | ((input: ConnectLinearInstallationInput) => Promise<IntegrationConnection<'linear'>>)
+    | undefined;
+}
+
+async function createTestApp(options: CreateTestAppOptions = {}): Promise<FastifyInstance> {
+  const provider = createLinearIntegrationProvider({
+    linear: options.linear ?? linearClient(),
+    routes: {
+      tokenStore: options.tokenStore ?? {
+        storeTokens: vi.fn(() => Promise.resolve()),
+      },
+      getExistingLinearConnection: vi.fn(() => Promise.resolve(options.existingConnection)),
+      connectLinearInstallation:
+        options.connectLinearInstallation ??
+        vi.fn((input: ConnectLinearInstallationInput) =>
+          Promise.resolve(
+            connection({
+              workspaceId: input.workspaceId,
+              externalAccountId: input.organizationId,
+              displayName: input.displayName,
+            }),
+          ),
+        ),
+    },
+  });
+  const app = await createApp({
+    auth: [fakeUserAuth],
+    routes: provider.routes,
+    swagger: false,
+  });
+  await app.ready();
+  return app;
+}
+
+describe('Linear integration routes', () => {
+  beforeEach(async () => {
+    authenticatedMemberships = [];
+    requireWorkspaceMembershipMock.mockClear();
+    await closeApp();
+  });
+
+  afterEach(async () => {
+    await closeApp();
+  });
+
+  it('returns an actor=app OAuth URL with signed workspace state', async () => {
+    const app = await createTestApp();
+    const workspaceId = crypto.randomUUID();
+    authenticatedMemberships = [{workspaceId, role: 'admin'}];
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/integrations/linear/install',
+      headers: {authorization: 'Bearer user'},
+      payload: {workspace_id: workspaceId},
+    });
+
+    const installUrl = new URL(res.json().install_url);
+    const state = installUrl.searchParams.get('state');
+    const claims = verifyLinearInstallState(state ?? '');
+    expect(res.statusCode).toBe(200);
+    expect(installUrl.origin + installUrl.pathname).toBe('https://linear.app/oauth/authorize');
+    expect(installUrl.searchParams.get('client_id')).toBe('test-client-id');
+    expect(installUrl.searchParams.get('redirect_uri')).toBe(
+      'https://api.example.com/integrations/linear/callback/api',
+    );
+    expect(installUrl.searchParams.get('response_type')).toBe('code');
+    expect(installUrl.searchParams.get('actor')).toBe('app');
+    expect(installUrl.searchParams.get('scope')).toBe('read write app:assignable app:mentionable');
+    expect(claims.workspaceId).toBe(workspaceId);
+    expect(claims.userId).toBe('user-1');
+  });
+
+  it('handles a verified Linear callback and stores tokens for the connection', async () => {
+    const tokenStore = {storeTokens: vi.fn(() => Promise.resolve())};
+    const connectLinearInstallation = vi.fn((input: ConnectLinearInstallationInput) =>
+      Promise.resolve(
+        connection({
+          id: '00000000-0000-4000-8000-000000000001',
+          workspaceId: input.workspaceId,
+          externalAccountId: input.organizationId,
+          displayName: input.displayName,
+        }),
+      ),
+    );
+    const app = await createTestApp({tokenStore, connectLinearInstallation});
+    const workspaceId = crypto.randomUUID();
+    const state = await createInstallState(app, workspaceId);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/integrations/linear/callback/api?code=code&state=${state}`,
+      headers: {authorization: 'Bearer user'},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      id: '00000000-0000-4000-8000-000000000001',
+      workspace_id: workspaceId,
+      provider: 'linear',
+      external_account_id: 'org-id',
+      display_name: 'Linear Acme',
+      lifecycle_status: 'active',
+    });
+    expect(connectLinearInstallation).toHaveBeenCalledWith({
+      workspaceId,
+      organizationId: 'org-id',
+      organizationUrlKey: 'acme',
+      appUserId: 'app-user-id',
+      scopes: ['read', 'write', 'app:assignable', 'app:mentionable'],
+      tokenExpiresAt: new Date('2026-07-07T13:00:00.000Z'),
+      displayName: 'Linear Acme',
+    });
+    expect(tokenStore.storeTokens).toHaveBeenCalledWith({
+      connectionId: '00000000-0000-4000-8000-000000000001',
+      accessToken: 'linear-access-token',
+      refreshToken: 'linear-refresh-token',
+      editedBy: 'user-1',
+    });
+    expect(requireWorkspaceMembershipMock).toHaveBeenCalledWith({
+      workspaceId,
+      userId: 'user-1',
+      memberships: [{workspaceId, role: 'admin'}],
+    });
+  });
+
+  it('rejects tampered callback state', async () => {
+    const app = await createTestApp();
+    const workspaceId = crypto.randomUUID();
+    const state = await createInstallState(app, workspaceId);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/integrations/linear/callback/api?code=code&state=${state}x`,
+      headers: {authorization: 'Bearer user'},
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().code).toBe('invalid-linear-install-state');
+  });
+
+  it('rejects callbacks for a Linear organization linked to another workspace', async () => {
+    const app = await createTestApp({
+      existingConnection: connection({workspaceId: crypto.randomUUID()}),
+    });
+    const workspaceId = crypto.randomUUID();
+    const state = await createInstallState(app, workspaceId);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/integrations/linear/callback/api?code=code&state=${state}`,
+      headers: {authorization: 'Bearer user'},
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('linear-installation-already-linked');
+  });
+
+  it('reconnects an existing workspace connection and refreshes stored tokens', async () => {
+    const workspaceId = crypto.randomUUID();
+    const existingConnection = connection({
+      id: '00000000-0000-4000-8000-000000000002',
+      workspaceId,
+    });
+    const tokenStore = {storeTokens: vi.fn(() => Promise.resolve())};
+    const connectLinearInstallation = vi.fn(() => Promise.resolve(existingConnection));
+    const app = await createTestApp({
+      tokenStore,
+      existingConnection,
+      connectLinearInstallation,
+    });
+    const state = await createInstallState(app, workspaceId);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/integrations/linear/callback/api?code=code&state=${state}`,
+      headers: {authorization: 'Bearer user'},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().id).toBe(existingConnection.id);
+    expect(connectLinearInstallation).toHaveBeenCalledTimes(1);
+    expect(tokenStore.storeTokens).toHaveBeenCalledWith(
+      expect.objectContaining({connectionId: existingConnection.id}),
+    );
+  });
+
+  it('returns 409 when connection slug allocation conflicts repeatedly', async () => {
+    const app = await createTestApp({
+      connectLinearInstallation: vi.fn(() =>
+        Promise.reject(new ConnectionSlugConflictError(new Error('duplicate slug'))),
+      ),
+    });
+    const state = await createInstallState(app, crypto.randomUUID());
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/integrations/linear/callback/api?code=code&state=${state}`,
+      headers: {authorization: 'Bearer user'},
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('slug-conflict');
+  });
+});
+
+async function createInstallState(app: FastifyInstance, workspaceId: string): Promise<string> {
+  authenticatedMemberships = [{workspaceId, role: 'admin'}];
+  const res = await app.inject({
+    method: 'POST',
+    url: '/integrations/linear/install',
+    headers: {authorization: 'Bearer user'},
+    payload: {workspace_id: workspaceId},
+  });
+  const installUrl = new URL(res.json().install_url);
+  const state = installUrl.searchParams.get('state');
+  if (!state) throw new Error('Install URL did not include state');
+  return encodeURIComponent(state);
+}

--- a/libs/api/integration/linear/src/presentation/routes/install.test.ts
+++ b/libs/api/integration/linear/src/presentation/routes/install.test.ts
@@ -56,6 +56,7 @@ function linearClient(overrides: Partial<LinearApiClient> = {}): LinearApiClient
     refreshAccessToken: vi.fn(() => {
       throw new Error('not used');
     }),
+    revokeToken: vi.fn(() => Promise.resolve()),
     getIdentity: vi.fn(() =>
       Promise.resolve({
         appUserId: 'app-user-id',
@@ -90,6 +91,7 @@ interface CreateTestAppOptions {
   connectLinearInstallation?:
     | ((input: ConnectLinearInstallationInput) => Promise<IntegrationConnection<'linear'>>)
     | undefined;
+  disconnectLinearInstallation?: ((input: {connectionId: string}) => Promise<void>) | undefined;
 }
 
 async function createTestApp(options: CreateTestAppOptions = {}): Promise<FastifyInstance> {
@@ -111,6 +113,7 @@ async function createTestApp(options: CreateTestAppOptions = {}): Promise<Fastif
             }),
           ),
         ),
+      disconnectLinearInstallation: options.disconnectLinearInstallation,
     },
   });
   const app = await createApp({
@@ -156,7 +159,7 @@ describe('Linear integration routes', () => {
     );
     expect(installUrl.searchParams.get('response_type')).toBe('code');
     expect(installUrl.searchParams.get('actor')).toBe('app');
-    expect(installUrl.searchParams.get('scope')).toBe('read write app:assignable app:mentionable');
+    expect(installUrl.searchParams.get('scope')).toBe('read,write,app:assignable,app:mentionable');
     expect(claims.workspaceId).toBe(workspaceId);
     expect(claims.userId).toBe('user-1');
   });
@@ -229,8 +232,33 @@ describe('Linear integration routes', () => {
     expect(res.json().code).toBe('invalid-linear-install-state');
   });
 
-  it('rejects callbacks for a Linear organization linked to another workspace', async () => {
+  it('handles Linear OAuth error callbacks after validating state', async () => {
+    const app = await createTestApp();
+    const workspaceId = crypto.randomUUID();
+    const state = await createInstallState(app, workspaceId);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/integrations/linear/callback/api?error=access_denied&error_description=Denied&state=${state}`,
+      headers: {authorization: 'Bearer user'},
+    });
+
+    expect(res.statusCode).toBe(422);
+    expect(res.json()).toMatchObject({
+      code: 'linear-oauth-callback-error',
+      details: {error: 'access_denied', error_description: 'Denied'},
+    });
+    expect(requireWorkspaceMembershipMock).toHaveBeenCalledWith({
+      workspaceId,
+      userId: 'user-1',
+      memberships: [{workspaceId, role: 'admin'}],
+    });
+  });
+
+  it('rejects callbacks for a Linear organization linked to another workspace and revokes tokens', async () => {
+    const revokeToken = vi.fn(() => Promise.resolve());
     const app = await createTestApp({
+      linear: linearClient({revokeToken}),
       existingConnection: connection({workspaceId: crypto.randomUUID()}),
     });
     const workspaceId = crypto.randomUUID();
@@ -244,6 +272,74 @@ describe('Linear integration routes', () => {
 
     expect(res.statusCode).toBe(409);
     expect(res.json().code).toBe('linear-installation-already-linked');
+    expect(revokeToken).toHaveBeenCalledWith({
+      token: 'linear-refresh-token',
+      tokenTypeHint: 'refresh_token',
+    });
+    expect(revokeToken).toHaveBeenCalledWith({
+      token: 'linear-access-token',
+      tokenTypeHint: 'access_token',
+    });
+  });
+
+  it('rejects callbacks when Linear omits required scopes and revokes tokens', async () => {
+    const revokeToken = vi.fn(() => Promise.resolve());
+    const app = await createTestApp({
+      linear: linearClient({
+        revokeToken,
+        exchangeAuthorizationCode: vi.fn(() =>
+          Promise.resolve({
+            accessToken: 'linear-access-token',
+            refreshToken: 'linear-refresh-token',
+            expiresAt: new Date('2026-07-07T13:00:00.000Z'),
+            scopes: ['read'],
+          }),
+        ),
+      }),
+    });
+    const state = await createInstallState(app, crypto.randomUUID());
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/integrations/linear/callback/api?code=code&state=${state}`,
+      headers: {authorization: 'Bearer user'},
+    });
+
+    expect(res.statusCode).toBe(422);
+    expect(res.json()).toMatchObject({
+      code: 'linear-authorization-scope-mismatch',
+      details: {missing_scopes: ['write', 'app:assignable', 'app:mentionable']},
+    });
+    expect(revokeToken).toHaveBeenCalledTimes(2);
+  });
+
+  it('compensates a new connection when token storage fails', async () => {
+    const connectionId = '00000000-0000-4000-8000-000000000003';
+    const disconnectLinearInstallation = vi.fn(() => Promise.resolve());
+    const app = await createTestApp({
+      tokenStore: {storeTokens: vi.fn(() => Promise.reject(new Error('secret store down')))},
+      connectLinearInstallation: vi.fn((input: ConnectLinearInstallationInput) =>
+        Promise.resolve(
+          connection({
+            id: connectionId,
+            workspaceId: input.workspaceId,
+            externalAccountId: input.organizationId,
+            displayName: input.displayName,
+          }),
+        ),
+      ),
+      disconnectLinearInstallation,
+    });
+    const state = await createInstallState(app, crypto.randomUUID());
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/integrations/linear/callback/api?code=code&state=${state}`,
+      headers: {authorization: 'Bearer user'},
+    });
+
+    expect(res.statusCode).toBe(500);
+    expect(disconnectLinearInstallation).toHaveBeenCalledWith({connectionId});
   });
 
   it('reconnects an existing workspace connection and refreshes stored tokens', async () => {

--- a/libs/api/integration/linear/src/presentation/routes/install.test.ts
+++ b/libs/api/integration/linear/src/presentation/routes/install.test.ts
@@ -113,7 +113,8 @@ async function createTestApp(options: CreateTestAppOptions = {}): Promise<Fastif
             }),
           ),
         ),
-      disconnectLinearInstallation: options.disconnectLinearInstallation,
+      disconnectLinearInstallation:
+        options.disconnectLinearInstallation ?? vi.fn(() => Promise.resolve()),
     },
   });
   const app = await createApp({
@@ -282,6 +283,33 @@ describe('Linear integration routes', () => {
     });
   });
 
+  it('revokes tokens when Linear identity lookup fails after authorization', async () => {
+    const revokeToken = vi.fn(() => Promise.resolve());
+    const app = await createTestApp({
+      linear: linearClient({
+        revokeToken,
+        getIdentity: vi.fn(() => Promise.reject(new Error('Linear unavailable'))),
+      }),
+    });
+    const state = await createInstallState(app, crypto.randomUUID());
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/integrations/linear/callback/api?code=code&state=${state}`,
+      headers: {authorization: 'Bearer user'},
+    });
+
+    expect(res.statusCode).toBe(500);
+    expect(revokeToken).toHaveBeenCalledWith({
+      token: 'linear-refresh-token',
+      tokenTypeHint: 'refresh_token',
+    });
+    expect(revokeToken).toHaveBeenCalledWith({
+      token: 'linear-access-token',
+      tokenTypeHint: 'access_token',
+    });
+  });
+
   it('rejects callbacks when Linear omits required scopes and revokes tokens', async () => {
     const revokeToken = vi.fn(() => Promise.resolve());
     const app = await createTestApp({
@@ -316,7 +344,9 @@ describe('Linear integration routes', () => {
   it('compensates a new connection when token storage fails', async () => {
     const connectionId = '00000000-0000-4000-8000-000000000003';
     const disconnectLinearInstallation = vi.fn(() => Promise.resolve());
+    const revokeToken = vi.fn(() => Promise.resolve());
     const app = await createTestApp({
+      linear: linearClient({revokeToken}),
       tokenStore: {storeTokens: vi.fn(() => Promise.reject(new Error('secret store down')))},
       connectLinearInstallation: vi.fn((input: ConnectLinearInstallationInput) =>
         Promise.resolve(
@@ -339,6 +369,7 @@ describe('Linear integration routes', () => {
     });
 
     expect(res.statusCode).toBe(500);
+    expect(revokeToken).toHaveBeenCalledTimes(2);
     expect(disconnectLinearInstallation).toHaveBeenCalledWith({connectionId});
   });
 

--- a/libs/api/integration/linear/src/presentation/routes/install.ts
+++ b/libs/api/integration/linear/src/presentation/routes/install.ts
@@ -31,7 +31,7 @@ export interface CreateLinearIntegrationRoutesOptions {
   connectLinearInstallation: (
     input: ConnectLinearInstallationInput,
   ) => Promise<IntegrationConnection<'linear'>>;
-  disconnectLinearInstallation?: ((input: {connectionId: string}) => Promise<void>) | undefined;
+  disconnectLinearInstallation: (input: {connectionId: string}) => Promise<void>;
 }
 
 export function createLinearIntegrationRoutes({

--- a/libs/api/integration/linear/src/presentation/routes/install.ts
+++ b/libs/api/integration/linear/src/presentation/routes/install.ts
@@ -1,0 +1,102 @@
+import {AUTH_USER, requireUserContext, requireWorkspaceAccess} from '@shipfox/api-auth-context';
+import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
+import {
+  createLinearInstallBodySchema,
+  createLinearInstallResponseSchema,
+  linearCallbackQuerySchema,
+  linearCallbackResponseSchema,
+} from '@shipfox/api-integration-linear-dto';
+import {requireWorkspaceMembership} from '@shipfox/api-workspaces';
+import {defineRoute, type RouteGroup} from '@shipfox/node-fastify';
+import type {LinearApiClient} from '#api/client.js';
+import {config} from '#config.js';
+import {type ConnectLinearInstallationInput, handleLinearCallback} from '#core/install.js';
+import {signLinearInstallState} from '#core/state.js';
+import type {LinearTokenStore} from '#core/tokens.js';
+import {toIntegrationConnectionDto} from '#presentation/dto/integrations.js';
+import {linearRouteErrorHandler} from './errors.js';
+
+const LINEAR_OAUTH_SCOPES = ['read', 'write', 'app:assignable', 'app:mentionable'];
+
+export interface CreateLinearIntegrationRoutesOptions {
+  linear: LinearApiClient;
+  tokenStore: Pick<LinearTokenStore, 'storeTokens'>;
+  getExistingLinearConnection: (input: {
+    organizationId: string;
+  }) => Promise<IntegrationConnection<'linear'> | undefined>;
+  connectLinearInstallation: (
+    input: ConnectLinearInstallationInput,
+  ) => Promise<IntegrationConnection<'linear'>>;
+}
+
+export function createLinearIntegrationRoutes({
+  linear,
+  tokenStore,
+  getExistingLinearConnection,
+  connectLinearInstallation,
+}: CreateLinearIntegrationRoutesOptions): RouteGroup {
+  const createInstallRoute = defineRoute({
+    method: 'POST',
+    path: '/install',
+    auth: AUTH_USER,
+    description: 'Create a Linear OAuth authorization URL for a workspace.',
+    schema: {
+      body: createLinearInstallBodySchema,
+      response: {
+        200: createLinearInstallResponseSchema,
+      },
+    },
+    handler: (request) => {
+      const {workspace_id: workspaceId} = request.body;
+      const actor = requireUserContext(request);
+
+      requireWorkspaceAccess({request, workspaceId});
+
+      const state = signLinearInstallState({workspaceId, userId: actor.userId});
+      const installUrl = new URL('https://linear.app/oauth/authorize');
+      installUrl.searchParams.set('client_id', config.LINEAR_OAUTH_CLIENT_ID);
+      installUrl.searchParams.set('redirect_uri', config.LINEAR_OAUTH_REDIRECT_URL);
+      installUrl.searchParams.set('response_type', 'code');
+      installUrl.searchParams.set('state', state);
+      installUrl.searchParams.set('actor', 'app');
+      installUrl.searchParams.set('scope', LINEAR_OAUTH_SCOPES.join(' '));
+
+      return {install_url: installUrl.toString()};
+    },
+  });
+
+  const callbackApiRoute = defineRoute({
+    method: 'GET',
+    path: '/callback/api',
+    auth: AUTH_USER,
+    description: 'Handle the Linear OAuth callback.',
+    schema: {
+      querystring: linearCallbackQuerySchema,
+      response: {
+        200: linearCallbackResponseSchema,
+      },
+    },
+    errorHandler: linearRouteErrorHandler,
+    handler: async (request) => {
+      const actor = requireUserContext(request);
+      const connection = await handleLinearCallback({
+        linear,
+        tokenStore,
+        code: request.query.code,
+        state: request.query.state,
+        sessionUserId: actor.userId,
+        sessionMemberships: actor.memberships,
+        requireWorkspaceMembership,
+        getExistingLinearConnection,
+        connectLinearInstallation,
+      });
+
+      return toIntegrationConnectionDto(connection);
+    },
+  });
+
+  return {
+    prefix: '/integrations/linear',
+    routes: [createInstallRoute, callbackApiRoute],
+  };
+}

--- a/libs/api/integration/linear/src/presentation/routes/install.ts
+++ b/libs/api/integration/linear/src/presentation/routes/install.ts
@@ -3,6 +3,7 @@ import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
 import {
   createLinearInstallBodySchema,
   createLinearInstallResponseSchema,
+  type LinearCallbackQueryDto,
   linearCallbackQuerySchema,
   linearCallbackResponseSchema,
 } from '@shipfox/api-integration-linear-dto';
@@ -10,13 +11,16 @@ import {requireWorkspaceMembership} from '@shipfox/api-workspaces';
 import {defineRoute, type RouteGroup} from '@shipfox/node-fastify';
 import type {LinearApiClient} from '#api/client.js';
 import {config} from '#config.js';
-import {type ConnectLinearInstallationInput, handleLinearCallback} from '#core/install.js';
+import {
+  type ConnectLinearInstallationInput,
+  handleLinearCallback,
+  handleLinearOAuthCallbackError,
+} from '#core/install.js';
+import {formatLinearOAuthScopes} from '#core/scopes.js';
 import {signLinearInstallState} from '#core/state.js';
 import type {LinearTokenStore} from '#core/tokens.js';
 import {toIntegrationConnectionDto} from '#presentation/dto/integrations.js';
 import {linearRouteErrorHandler} from './errors.js';
-
-const LINEAR_OAUTH_SCOPES = ['read', 'write', 'app:assignable', 'app:mentionable'];
 
 export interface CreateLinearIntegrationRoutesOptions {
   linear: LinearApiClient;
@@ -27,6 +31,7 @@ export interface CreateLinearIntegrationRoutesOptions {
   connectLinearInstallation: (
     input: ConnectLinearInstallationInput,
   ) => Promise<IntegrationConnection<'linear'>>;
+  disconnectLinearInstallation?: ((input: {connectionId: string}) => Promise<void>) | undefined;
 }
 
 export function createLinearIntegrationRoutes({
@@ -34,6 +39,7 @@ export function createLinearIntegrationRoutes({
   tokenStore,
   getExistingLinearConnection,
   connectLinearInstallation,
+  disconnectLinearInstallation,
 }: CreateLinearIntegrationRoutesOptions): RouteGroup {
   const createInstallRoute = defineRoute({
     method: 'POST',
@@ -59,7 +65,7 @@ export function createLinearIntegrationRoutes({
       installUrl.searchParams.set('response_type', 'code');
       installUrl.searchParams.set('state', state);
       installUrl.searchParams.set('actor', 'app');
-      installUrl.searchParams.set('scope', LINEAR_OAUTH_SCOPES.join(' '));
+      installUrl.searchParams.set('scope', formatLinearOAuthScopes());
 
       return {install_url: installUrl.toString()};
     },
@@ -79,16 +85,28 @@ export function createLinearIntegrationRoutes({
     errorHandler: linearRouteErrorHandler,
     handler: async (request) => {
       const actor = requireUserContext(request);
+      const query = request.query;
+      if (isLinearOAuthErrorCallback(query)) {
+        return await handleLinearOAuthCallbackError({
+          state: query.state,
+          error: query.error,
+          errorDescription: query.error_description,
+          sessionUserId: actor.userId,
+          sessionMemberships: actor.memberships,
+          requireWorkspaceMembership,
+        });
+      }
       const connection = await handleLinearCallback({
         linear,
         tokenStore,
-        code: request.query.code,
-        state: request.query.state,
+        code: query.code,
+        state: query.state,
         sessionUserId: actor.userId,
         sessionMemberships: actor.memberships,
         requireWorkspaceMembership,
         getExistingLinearConnection,
         connectLinearInstallation,
+        disconnectLinearInstallation,
       });
 
       return toIntegrationConnectionDto(connection);
@@ -99,4 +117,14 @@ export function createLinearIntegrationRoutes({
     prefix: '/integrations/linear',
     routes: [createInstallRoute, callbackApiRoute],
   };
+}
+
+function isLinearOAuthErrorCallback(
+  query: LinearCallbackQueryDto,
+): query is LinearCallbackQueryDto & {
+  error: string;
+  error_description?: string | undefined;
+  state: string;
+} {
+  return 'error' in query && typeof query.error === 'string';
 }

--- a/libs/api/integration/linear/test/api-secrets.d.ts
+++ b/libs/api/integration/linear/test/api-secrets.d.ts
@@ -1,0 +1,28 @@
+declare module '@shipfox/api-secrets' {
+  import type {NodePgDatabase} from '@shipfox/node-drizzle';
+
+  export function getSecret(params: {
+    workspaceId: string;
+    namespace: string;
+    key: string;
+  }): Promise<string | null>;
+
+  export function setSecrets(params: {
+    workspaceId: string;
+    namespace: string;
+    values: Record<string, string>;
+    editedBy?: string | null | undefined;
+  }): Promise<void>;
+
+  export function deleteSecrets(params: {workspaceId: string; namespace: string}): Promise<number>;
+
+  export const secretsModule: {
+    database?:
+      | {
+          db(): NodePgDatabase<Record<string, unknown>>;
+          migrationsPath: string;
+        }
+      | unknown[]
+      | undefined;
+  };
+}

--- a/libs/api/integration/linear/test/globalSetup.ts
+++ b/libs/api/integration/linear/test/globalSetup.ts
@@ -8,7 +8,6 @@ export async function setup() {
   createPostgresClient();
 
   await runMigrations(db(), migrationsPath, '__drizzle_migrations_integrations_linear');
-  // @ts-expect-error @shipfox/api-secrets is a peer supplied by the composing API app.
   const {secretsModule} = await import('@shipfox/api-secrets');
   if (!secretsModule.database || Array.isArray(secretsModule.database)) {
     throw new Error('Secrets module database is not configured');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2029,6 +2029,9 @@ importers:
 
   libs/api/integration/linear:
     dependencies:
+      '@shipfox/api-auth-context':
+        specifier: workspace:*
+        version: link:../../auth-context
       '@shipfox/api-integration-core-dto':
         specifier: workspace:*
         version: link:../core-dto
@@ -2038,12 +2041,18 @@ importers:
       '@shipfox/api-secrets':
         specifier: workspace:*
         version: link:../../secrets
+      '@shipfox/api-workspaces':
+        specifier: workspace:*
+        version: link:../../workspaces
       '@shipfox/config':
         specifier: workspace:*
         version: link:../../../shared/common/config
       '@shipfox/node-drizzle':
         specifier: workspace:*
         version: link:../../../shared/node/drizzle
+      '@shipfox/node-fastify':
+        specifier: workspace:*
+        version: link:../../../shared/node/fastify
       '@shipfox/node-opentelemetry':
         specifier: workspace:*
         version: link:../../../shared/node/opentelemetry
@@ -2081,12 +2090,18 @@ importers:
       drizzle-kit:
         specifier: ^0.31.10
         version: 0.31.10
+      fastify:
+        specifier: ^5.3.3
+        version: 5.8.5
       fishery:
         specifier: ^2.2.2
         version: 2.4.0
 
   libs/api/integration/linear-dto:
     dependencies:
+      '@shipfox/api-integration-core-dto':
+        specifier: workspace:*
+        version: link:../core-dto
       zod:
         specifier: ^4.4.3
         version: 4.4.3


### PR DESCRIPTION
Add the Linear OAuth connect flow for app-actor installs.

Linear connections need a server-owned OAuth round trip before the client UI and webhook work can rely on workspace-scoped installation state. This adds signed state binding for the initiating workspace and user, exchanges the callback code through the Linear API client, derives organization and app-user identity from Linear, upserts the shared connection and Linear installation row, and stores issued tokens through the secrets module.

The connect flow uses `actor=app` with `read write app:assignable app:mentionable`. It does not create webhooks through the API because Linear documents that `actor=app` grants cannot request `admin`, while webhook API creation requires admin; OAuth app webhook settings are the intended auto-registration path for authorized organizations.

Closes ENG-874

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Linear OAuth connect flow for app-actor installs with secure state validation, scoped secret storage, and robust cleanup on failure. Fulfills ENG-874.

- **New Features**
  - POST `/integrations/linear/install`: returns a Linear OAuth URL with `actor=app` and scopes `read write app:assignable app:mentionable`, including an HMAC-signed state binding the workspace and user.
  - GET `/integrations/linear/callback/api`: verifies state and membership; handles success and provider error callbacks. Exchanges the code, checks scopes, derives org/app-user identity, prevents cross-workspace linking, connects or reconnects the installation, and stores tokens. On any post-exchange failure (identity, scope, storage), issued tokens are revoked and new connections are compensated by disconnecting; secrets are purged before connection records are removed. Maps state/scope/slug/provider errors to clear 4xx/409/422/429/503 responses.
  - Provider wiring: `@shipfox/api-integration-linear` exports Fastify routes with a token store backed by secrets scoped under `system/integrations/linear/<connectionId>`. The API wires `getSecret`/`setSecrets`/`deleteSecrets` with a Linear namespace prefix, and the provider enforces scoping and purges secrets on disconnect. Adds helpers to connect/reconnect and disconnect installations and retries slug collisions. Linear client adds `revokeToken` for OAuth cleanup.

- **Dependencies**
  - Added `@shipfox/api-auth-context`, `@shipfox/api-workspaces`, and `@shipfox/node-fastify` to `@shipfox/api-integration-linear`.
  - Added `@shipfox/api-integration-core-dto` to `@shipfox/api-integration-linear-dto`.
  - Test-only: added a declaration for `@shipfox/api-secrets` to fix Linear test type-checking without creating a dependency cycle.

<sup>Written for commit 4100e4f6367110b7eafba5b854153cdd4e8e6598. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

