### PR TITLE
[api/workflows] Fix workflow execution timeout typing

### DIFF
--- a/libs/api/workflows/src/temporal/workflows/job-execution-orchestration.ts
+++ b/libs/api/workflows/src/temporal/workflows/job-execution-orchestration.ts
@@ -1,4 +1,4 @@
-import {ApplicationFailure} from '@temporalio/common';
+import {ApplicationFailure, type Duration} from '@temporalio/common';
 import {condition, defineSignal, log, proxyActivities, setHandler} from '@temporalio/workflow';
 import {
   hasNoRequiredRunnerLabels,
@@ -56,7 +56,7 @@ const {releaseLeaseActivity} = proxyActivities<ReturnType<typeof createOrchestra
   retry: {maximumAttempts: 5},
 });
 
-const DEFAULT_EXECUTION_MAX_DURATION = '6 hours';
+const DEFAULT_EXECUTION_MAX_DURATION: Duration = '6 hours';
 
 export const jobFinishedSignal =
   defineSignal<[{status: RuntimeCompletionStatus; jobExecutionId?: string | undefined}]>(
@@ -155,7 +155,7 @@ async function markJobExecutionRunningAndEnqueue(
 // ordering), so callers must evaluate `finished` before `leaseExpired`.
 async function awaitJobOutcome(
   jobExecutionId: string,
-  timeout: string | number,
+  timeout: Duration,
 ): Promise<JobExecutionOutcomeSignals> {
   let finished: {status: RuntimeCompletionStatus; jobExecutionId?: string | undefined} | undefined;
   let leaseExpired = false;


### PR DESCRIPTION
[api/workflows] Fix workflow execution timeout typing

The workflows CI type check failed because `awaitJobOutcome` widened Temporal's accepted timeout type to `string | number`. The default timeout string is valid for Temporal, but the widened `string` type is not assignable to Temporal's `Duration` alias.

This imports and uses `Duration` for the timeout boundary and default value, preserving runtime behavior while matching the `condition` API contract.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes workflow timeout typing by using Temporal’s `Duration` type, aligning `awaitJobOutcome` with the `condition` API and resolving CI type errors. Runtime behavior stays the same.

- **Bug Fixes**
  - Typed `DEFAULT_EXECUTION_MAX_DURATION` and the `timeout` param as `Duration` from `@temporalio/common`.
  - Removes widened `string | number` usage so timeouts match `@temporalio/workflow` expectations.

<sup>Written for commit 5e0262edb1e89dc6dec23f82db2e686262ee2719. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

