### PR TITLE
Build MCP tool gateway

### DIFF
--- a/apps/api/src/core/run.test.ts
+++ b/apps/api/src/core/run.test.ts
@@ -42,6 +42,7 @@ const mocks = vi.hoisted(() => {
     registerModuleMetrics: vi.fn(),
     setAgentToolMaterializationServices: vi.fn(),
     setSourceControl: vi.fn(),
+    loadRunningLeasedStep: vi.fn(),
     startModuleWorkers: vi.fn(),
     startServiceMetrics: vi.fn(),
   };
@@ -72,6 +73,7 @@ vi.mock('@shipfox/api-secrets', () => ({
 }));
 vi.mock('@shipfox/api-triggers', () => ({triggersModule: {name: 'triggers'}}));
 vi.mock('@shipfox/api-workflows', () => ({
+  loadRunningLeasedStep: mocks.loadRunningLeasedStep,
   setAgentToolMaterializationServices: mocks.setAgentToolMaterializationServices,
   setSourceControl: mocks.setSourceControl,
   workflowsModule: {name: 'workflows'},
@@ -155,6 +157,7 @@ describe('run', () => {
     mocks.registerModuleMetrics.mockReset();
     mocks.setAgentToolMaterializationServices.mockReset();
     mocks.setSourceControl.mockReset();
+    mocks.loadRunningLeasedStep.mockReset();
     mocks.startModuleWorkers.mockReset();
     mocks.startServiceMetrics.mockReset();
 
@@ -221,6 +224,22 @@ describe('run', () => {
     await run();
 
     expect(mocks.listen).toHaveBeenCalledWith({port: 55_291});
+  });
+
+  it('injects the leased-step loader into integration routes', async () => {
+    await run();
+
+    expect(mocks.createIntegrationsContext).toHaveBeenCalledWith({
+      secrets: {
+        deleteSecrets: mocks.deleteSecrets,
+        linear: expect.objectContaining({
+          deleteSecrets: expect.any(Function),
+          getSecret: expect.any(Function),
+          setSecrets: expect.any(Function),
+        }),
+      },
+      agentTools: {loadLeasedAgentStep: mocks.loadRunningLeasedStep},
+    });
   });
 
   it('does not listen when module worker startup fails', async () => {

--- a/apps/api/src/core/run.ts
+++ b/apps/api/src/core/run.ts
@@ -16,6 +16,7 @@ import {runnersModule} from '@shipfox/api-runners';
 import {deleteSecrets, getSecret, secretsModule, setSecrets} from '@shipfox/api-secrets';
 import {triggersModule} from '@shipfox/api-triggers';
 import {
+  loadRunningLeasedStep,
   setAgentToolMaterializationServices,
   setSourceControl,
   workflowsModule,
@@ -59,6 +60,7 @@ export async function run(): Promise<void> {
           }),
       },
     },
+    agentTools: {loadLeasedAgentStep: loadRunningLeasedStep},
   });
   const [agentToolSelectionCatalogs, agentToolCatalogs] = await Promise.all([
     buildAgentToolSelectionCatalogs(integrations.registry),

--- a/libs/api/integration/core/package.json
+++ b/libs/api/integration/core/package.json
@@ -37,6 +37,8 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "1.29.0",
+    "@shipfox/api-agent-dto": "workspace:*",
     "@shipfox/api-auth-context": "workspace:*",
     "@shipfox/api-integration-core-dto": "workspace:*",
     "@shipfox/api-integration-gitea": "workspace:*",
@@ -55,6 +57,7 @@
     "@shipfox/regex": "workspace:*",
     "@shipfox/redact": "workspace:*",
     "@temporalio/workflow": "^1.16.1",
+    "ajv": "^8.20.0",
     "drizzle-orm": "^0.45.2",
     "zod": "^4.4.3"
   },

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -16,7 +16,7 @@ import {getIntegrationConnectionById} from '#db/connections.js';
 import {db} from '#db/db.js';
 import {migrationsPath} from '#db/migrations.js';
 import {integrationsOutbox} from '#db/schema/outbox.js';
-import {createIntegrationRoutes} from '#presentation/routes/index.js';
+import {createIntegrationRoutes, type LeasedAgentStepLoader} from '#presentation/routes/index.js';
 import {loadEnabledProviderModules} from '#providers/modules.js';
 import type {IntegrationModuleParts, IntegrationProviderSecrets} from '#providers/types.js';
 import {createIntegrationsMaintenanceActivities} from '#temporal/activities/index.js';
@@ -118,6 +118,11 @@ export interface CreateIntegrationsModuleOptions {
    */
   parts?: IntegrationModuleParts[] | undefined;
   secrets?: IntegrationProviderSecrets | undefined;
+  agentTools?:
+    | {
+        loadLeasedAgentStep: LeasedAgentStepLoader;
+      }
+    | undefined;
 }
 
 export interface IntegrationsContext {
@@ -162,7 +167,14 @@ export async function createIntegrationsContext(
       {db, migrationsPath},
       ...parts.flatMap((part) => (part.database ? [part.database] : [])),
     ],
-    routes: createIntegrationRoutes(registry, sourceControl),
+    routes: createIntegrationRoutes(registry, sourceControl, {
+      agentTools: options.agentTools
+        ? {
+            loadLeasedAgentStep: options.agentTools.loadLeasedAgentStep,
+            getIntegrationConnectionById,
+          }
+        : undefined,
+    }),
     publishers: [
       {name: 'integrations', table: integrationsOutbox, db, eventSchemas: integrationsEventSchemas},
     ],

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/agent-tools-gateway.route.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/agent-tools-gateway.route.test.ts
@@ -1,0 +1,150 @@
+import {Client} from '@modelcontextprotocol/sdk/client/index.js';
+import {StreamableHTTPClientTransport} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import type {Transport} from '@modelcontextprotocol/sdk/shared/transport.js';
+import {CallToolResultSchema} from '@modelcontextprotocol/sdk/types.js';
+import {
+  AUTH_LEASED_JOB,
+  type LeasedJobContext,
+  setLeasedJobContext,
+} from '@shipfox/api-auth-context';
+import {type AuthMethod, ClientError, closeApp, createApp} from '@shipfox/node-fastify';
+import type {FastifyInstance, FastifyRequest} from 'fastify';
+import {
+  agentStepConfig,
+  connection,
+  leaseContext,
+  materializedIntegration,
+  registryWithAgentTools,
+} from '#test/agent-tools-gateway-helpers.js';
+import {createAgentToolsGatewayRoutes} from './index.js';
+
+let leases = new Map<string, LeasedJobContext>();
+
+const fakeLeaseAuth: AuthMethod = {
+  name: AUTH_LEASED_JOB,
+  authenticate: (request: FastifyRequest) => {
+    const authorization = request.headers.authorization;
+    const token =
+      typeof authorization === 'string' && authorization.startsWith('Bearer ')
+        ? authorization.slice('Bearer '.length)
+        : null;
+    const lease = token ? leases.get(token) : undefined;
+    if (!lease) {
+      throw new ClientError('Invalid job lease token', 'unauthorized', {status: 401});
+    }
+
+    setLeasedJobContext(request, lease);
+    return Promise.resolve();
+  },
+};
+
+describe('agent tools gateway route', () => {
+  beforeEach(async () => {
+    await closeApp();
+    leases = new Map();
+  });
+
+  afterEach(async () => {
+    await closeApp();
+  });
+
+  it('requires lease auth before resolving tools', async () => {
+    const app = await createGatewayApp();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/runs/jobs/current/integration-tools/mcp',
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns a normal HTTP error for pre-hijack resolution failures', async () => {
+    const lease = leaseContext({currentStepId: undefined, currentStepAttempt: undefined});
+    leases.set('lease-without-step', lease);
+    const app = await createGatewayApp();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/runs/jobs/current/integration-tools/mcp',
+      headers: {authorization: 'Bearer lease-without-step'},
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('lease-missing-step');
+  });
+
+  it('serves MCP over stateless Streamable HTTP after resolving server-side state', async () => {
+    const lease = leaseContext({workspaceId: 'workspace-1'});
+    const integration = materializedIntegration({connectionId: 'connection-1'});
+    leases.set('valid-lease', lease);
+    const app = await createGatewayApp({
+      loadLeasedAgentStep: async () => ({
+        workspaceId: lease.workspaceId,
+        step: {type: 'agent', config: agentStepConfig([integration])},
+      }),
+      getIntegrationConnectionById: async () =>
+        connection({
+          id: integration.connectionId,
+          workspaceId: lease.workspaceId,
+          slug: integration.connectionSlug,
+        }),
+    });
+    const address = await app.listen({port: 0, host: '127.0.0.1'});
+    const client = new Client({name: 'test-http-client', version: '0.0.0'});
+    const transport = new StreamableHTTPClientTransport(
+      new URL('/runs/jobs/current/integration-tools/mcp', address),
+      {
+        requestInit: {
+          headers: {authorization: 'Bearer valid-lease'},
+        },
+      },
+    );
+
+    await client.connect(transport as unknown as Transport);
+    const tools = await client.listTools();
+    const result = await client.callTool(
+      {
+        name: 'github_main__issue_read',
+        arguments: {method: 'get', owner: 'shipfox', repo: 'platform', issue_number: 1},
+      },
+      CallToolResultSchema,
+    );
+    await client.close();
+
+    expect(tools.tools.map((tool) => tool.name)).toEqual(['github_main__issue_read']);
+    expect(result.isError).not.toBe(true);
+    expect(result.structuredContent).toMatchObject({
+      status: 'stubbed',
+      provider: 'github',
+      connection_id: 'connection-1',
+      tool_id: 'issue_read',
+      method: 'get',
+    });
+  });
+});
+
+async function createGatewayApp(
+  overrides: Partial<Parameters<typeof createAgentToolsGatewayRoutes>[0]> = {},
+): Promise<FastifyInstance> {
+  const app = await createApp({
+    auth: [fakeLeaseAuth],
+    routes: [
+      createAgentToolsGatewayRoutes({
+        registry: registryWithAgentTools(),
+        getIntegrationConnectionById: async () =>
+          connection({workspaceId: 'workspace-1', id: 'connection-1'}),
+        loadLeasedAgentStep: async () => ({
+          workspaceId: 'workspace-1',
+          step: {type: 'agent', config: agentStepConfig()},
+        }),
+        ...overrides,
+      }),
+    ],
+    swagger: false,
+  });
+  await app.ready();
+  return app;
+}

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/dispatch-stub.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/dispatch-stub.ts
@@ -1,0 +1,21 @@
+import type {CallToolResult} from '@modelcontextprotocol/sdk/types.js';
+import type {IntegrationToolDispatchInput} from './mcp-server.js';
+
+export async function dispatchIntegrationToolCall(
+  input: IntegrationToolDispatchInput,
+): Promise<CallToolResult> {
+  await Promise.resolve();
+
+  const structuredContent = {
+    status: 'stubbed',
+    provider: input.authorizedTool.integration.provider,
+    connection_id: input.authorizedTool.integration.connectionId,
+    tool_id: input.authorizedTool.tool.id,
+    ...(input.method ? {method: input.method} : {}),
+  };
+
+  return {
+    content: [{type: 'text', text: JSON.stringify(structuredContent)}],
+    structuredContent,
+  };
+}

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/index.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/index.ts
@@ -1,0 +1,58 @@
+import {StreamableHTTPServerTransport} from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import type {Transport} from '@modelcontextprotocol/sdk/shared/transport.js';
+import {AUTH_LEASED_JOB} from '@shipfox/api-auth-context';
+import {defineRoute, type RouteGroup} from '@shipfox/node-fastify';
+import type {IntegrationProviderRegistry} from '#core/providers/registry.js';
+import type {GetIntegrationConnectionByIdFn} from '#db/connections.js';
+import {dispatchIntegrationToolCall} from './dispatch-stub.js';
+import {buildAgentToolsMcpServer} from './mcp-server.js';
+import {
+  type LeasedAgentStepLoader,
+  resolveAuthorizedIntegrationTools,
+} from './resolve-authorized-tools.js';
+
+export type {LeasedAgentStepLoader} from './resolve-authorized-tools.js';
+
+export interface CreateAgentToolsGatewayRoutesParams {
+  loadLeasedAgentStep: LeasedAgentStepLoader;
+  registry: IntegrationProviderRegistry;
+  getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
+}
+
+export function createAgentToolsGatewayRoutes(
+  params: CreateAgentToolsGatewayRoutesParams,
+): RouteGroup {
+  return {
+    prefix: '/runs/jobs/current/integration-tools',
+    auth: AUTH_LEASED_JOB,
+    routes: [
+      defineRoute({
+        method: 'POST',
+        path: '/mcp',
+        description: 'Gateway MCP endpoint for integration-backed agent tools',
+        handler: async (request, reply) => {
+          const authorizedTools = await resolveAuthorizedIntegrationTools({
+            request,
+            loadLeasedAgentStep: params.loadLeasedAgentStep,
+            registry: params.registry,
+            getIntegrationConnectionById: params.getIntegrationConnectionById,
+          });
+          const server = buildAgentToolsMcpServer({
+            authorizedTools,
+            dispatch: dispatchIntegrationToolCall,
+          });
+          const transport = new StreamableHTTPServerTransport();
+
+          await server.connect(transport as unknown as Transport);
+          reply.raw.on('close', () => {
+            void transport.close();
+            void server.close();
+          });
+
+          reply.hijack();
+          await transport.handleRequest(request.raw, reply.raw, request.body);
+        },
+      }),
+    ],
+  };
+}

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/mcp-server.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/mcp-server.test.ts
@@ -1,0 +1,195 @@
+import {Client} from '@modelcontextprotocol/sdk/client/index.js';
+import {InMemoryTransport} from '@modelcontextprotocol/sdk/inMemory.js';
+import {CallToolResultSchema} from '@modelcontextprotocol/sdk/types.js';
+import {
+  catalogTool,
+  connection,
+  materializedIntegration,
+  materializedTool,
+} from '#test/agent-tools-gateway-helpers.js';
+import {buildAgentToolsMcpServer, type IntegrationToolDispatchInput} from './mcp-server.js';
+import type {AuthorizedIntegrationToolMap} from './resolve-authorized-tools.js';
+
+describe('buildAgentToolsMcpServer', () => {
+  it('lists namespaced tools and dispatches authorized method-family calls', async () => {
+    const dispatch = vi.fn(async (input: IntegrationToolDispatchInput) => ({
+      content: [{type: 'text' as const, text: `called:${input.method}`}],
+    }));
+    const {client, close} = await connectClient(dispatch);
+
+    const tools = await client.listTools();
+    const result = await client.callTool(
+      {
+        name: 'github_main__issue_read',
+        arguments: {method: 'get', owner: 'shipfox', repo: 'platform', issue_number: 1},
+      },
+      CallToolResultSchema,
+    );
+    await close();
+
+    expect(tools.tools).toMatchObject([
+      {
+        name: 'github_main__issue_read',
+        description: 'Read issue metadata from GitHub.',
+      },
+    ]);
+    expect(result.isError).not.toBe(true);
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'get',
+        arguments: expect.objectContaining({issue_number: 1}),
+      }),
+    );
+  });
+
+  it.each([
+    ['unknown tool', 'missing__tool', {method: 'get'}],
+    ['missing method', 'github_main__issue_read', {}],
+    ['non-string method', 'github_main__issue_read', {method: 1}],
+    ['unauthorized method', 'github_main__issue_read', {method: 'get_labels'}],
+  ])('returns an isError tool result for %s', async (_label, name, args) => {
+    const dispatch = vi.fn();
+    const {client, close} = await connectClient(dispatch);
+
+    const result = await client.callTool({name, arguments: args}, CallToolResultSchema);
+    await close();
+
+    expect(result.isError).toBe(true);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('ignores a stray method argument for standalone tools', async () => {
+    const dispatch = vi.fn(async () => ({
+      content: [{type: 'text' as const, text: 'called'}],
+    }));
+    const {client, close} = await connectClient(dispatch, standaloneTools());
+
+    const result = await client.callTool(
+      {name: 'github_main__list_issues', arguments: {method: 'ignored'}},
+      CallToolResultSchema,
+    );
+    await close();
+
+    expect(result.isError).not.toBe(true);
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: undefined,
+        arguments: {method: 'ignored'},
+      }),
+    );
+  });
+
+  it('defaults omitted arguments to an empty object for optional-argument tools', async () => {
+    const dispatch = vi.fn(async () => ({
+      content: [{type: 'text' as const, text: 'called'}],
+    }));
+    const {client, close} = await connectClient(dispatch, standaloneTools());
+
+    const result = await client.callTool({name: 'github_main__list_issues'}, CallToolResultSchema);
+    await close();
+
+    expect(result.isError).not.toBe(true);
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        arguments: {},
+      }),
+    );
+  });
+
+  it('rejects arguments that do not match the exposed input schema', async () => {
+    const dispatch = vi.fn();
+    const {client, close} = await connectClient(dispatch);
+
+    const result = await client.callTool(
+      {
+        name: 'github_main__issue_read',
+        arguments: {
+          method: 'get',
+          owner: 'shipfox',
+          repo: 'platform',
+          issue_number: 'not-an-integer',
+        },
+      },
+      CallToolResultSchema,
+    );
+    await close();
+
+    expect(result.isError).toBe(true);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});
+
+async function connectClient(
+  dispatch: Parameters<typeof buildAgentToolsMcpServer>[0]['dispatch'],
+  authorizedTools = defaultAuthorizedTools(),
+) {
+  const server = buildAgentToolsMcpServer({authorizedTools, dispatch});
+  const client = new Client({name: 'test-client', version: '0.0.0'});
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  return {
+    client,
+    close: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+function defaultAuthorizedTools(): AuthorizedIntegrationToolMap {
+  const integration = materializedIntegration({connectionId: 'connection-1'});
+  const tool = materializedTool();
+  return new Map([
+    [
+      'github_main__issue_read',
+      {
+        mcpName: 'github_main__issue_read',
+        integration,
+        tool,
+        connection: connection({
+          id: 'connection-1',
+          workspaceId: 'workspace-1',
+          slug: integration.connectionSlug,
+        }),
+        description: catalogTool().description,
+        inputSchema: tool.inputSchema,
+      },
+    ],
+  ]);
+}
+
+function standaloneTools(): AuthorizedIntegrationToolMap {
+  const integration = materializedIntegration({
+    connectionId: 'connection-1',
+    tools: [
+      materializedTool({
+        id: 'list_issues',
+        methods: undefined,
+        inputSchema: {type: 'object', properties: {}, additionalProperties: true},
+      }),
+    ],
+  });
+  const [tool] = integration.tools;
+  if (!tool) throw new Error('Expected standalone integration tool');
+
+  return new Map([
+    [
+      'github_main__list_issues',
+      {
+        mcpName: 'github_main__list_issues',
+        integration,
+        tool,
+        connection: connection({
+          id: 'connection-1',
+          workspaceId: 'workspace-1',
+          slug: integration.connectionSlug,
+        }),
+        description: 'List issues',
+        inputSchema: tool.inputSchema,
+      },
+    ],
+  ]);
+}

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/mcp-server.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/mcp-server.ts
@@ -1,0 +1,132 @@
+import {Server} from '@modelcontextprotocol/sdk/server/index.js';
+import {
+  CallToolRequestSchema,
+  type CallToolResult,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import {Ajv, type ValidateFunction} from 'ajv';
+import type {
+  AuthorizedIntegrationTool,
+  AuthorizedIntegrationToolMap,
+} from './resolve-authorized-tools.js';
+
+export interface IntegrationToolDispatchInput {
+  authorizedTool: AuthorizedIntegrationTool;
+  arguments: Record<string, unknown>;
+  method?: string | undefined;
+}
+
+export type IntegrationToolDispatcher = (
+  input: IntegrationToolDispatchInput,
+) => Promise<CallToolResult>;
+
+export interface BuildAgentToolsMcpServerParams {
+  authorizedTools: AuthorizedIntegrationToolMap;
+  dispatch: IntegrationToolDispatcher;
+}
+
+const ajv = new Ajv({strict: false, allErrors: true});
+
+export function buildAgentToolsMcpServer(params: BuildAgentToolsMcpServerParams): Server {
+  const server = new Server(
+    {name: 'shipfox-integration-tools', version: '0.0.0'},
+    {capabilities: {tools: {}}},
+  );
+  const validators = new Map<string, ValidateFunction>();
+
+  server.setRequestHandler(ListToolsRequestSchema, () => ({
+    tools: [...params.authorizedTools.values()].map((authorizedTool) => ({
+      name: authorizedTool.mcpName,
+      description: authorizedTool.description,
+      inputSchema: authorizedTool.inputSchema as {
+        type: 'object';
+        properties?: Record<string, object> | undefined;
+        required?: string[] | undefined;
+      },
+      ...(authorizedTool.outputSchema
+        ? {
+            outputSchema: authorizedTool.outputSchema as {
+              type: 'object';
+              properties?: Record<string, object> | undefined;
+              required?: string[] | undefined;
+            },
+          }
+        : {}),
+    })),
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const authorizedTool = params.authorizedTools.get(request.params.name);
+    if (!authorizedTool) return toolError(`Unknown integration tool: ${request.params.name}`);
+
+    const args = request.params.arguments ?? {};
+    if (!isRecord(args)) return toolError('Tool arguments must be an object');
+
+    const methodValidation = validateMethod(authorizedTool, args);
+    if (methodValidation.kind === 'error') return toolError(methodValidation.message);
+
+    const schemaError = validateToolInput(authorizedTool, args, validators);
+    if (schemaError) return toolError(schemaError);
+
+    const result = await params.dispatch({
+      authorizedTool,
+      arguments: args,
+      method: methodValidation.method,
+    });
+    return result;
+  });
+
+  return server;
+}
+
+function validateMethod(
+  authorizedTool: AuthorizedIntegrationTool,
+  args: Record<string, unknown>,
+): {kind: 'ok'; method?: string | undefined} | {kind: 'error'; message: string} {
+  if (!authorizedTool.tool.methods) return {kind: 'ok'};
+
+  const method = args.method;
+  if (typeof method !== 'string') {
+    return {kind: 'error', message: 'Method-family tools require a string method argument'};
+  }
+
+  const allowedMethods = new Set(authorizedTool.tool.methods.map((candidate) => candidate.id));
+  if (!allowedMethods.has(method)) {
+    return {kind: 'error', message: `Unauthorized integration tool method: ${method}`};
+  }
+
+  return {kind: 'ok', method};
+}
+
+function validateToolInput(
+  authorizedTool: AuthorizedIntegrationTool,
+  args: Record<string, unknown>,
+  validators: Map<string, ValidateFunction>,
+): string | null {
+  let validate = validators.get(authorizedTool.mcpName);
+  if (!validate) {
+    try {
+      validate = ajv.compile(authorizedTool.inputSchema);
+    } catch {
+      return 'Tool input schema is invalid';
+    }
+    validators.set(authorizedTool.mcpName, validate);
+  }
+
+  if (validate(args)) return null;
+
+  return `Tool arguments do not match input schema: ${ajv.errorsText(validate.errors, {
+    separator: '; ',
+  })}`;
+}
+
+function toolError(message: string): CallToolResult {
+  return {
+    isError: true,
+    content: [{type: 'text', text: message}],
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/resolve-authorized-tools.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/resolve-authorized-tools.test.ts
@@ -1,0 +1,185 @@
+import {setLeasedJobContext} from '@shipfox/api-auth-context';
+import {createIntegrationProviderRegistry} from '#core/providers/registry.js';
+import {
+  agentStepConfig,
+  catalogTool,
+  connection,
+  leaseContext,
+  materializedIntegration,
+  registryWithAgentTools,
+} from '#test/agent-tools-gateway-helpers.js';
+import {
+  mcpToolName,
+  narrowMethodEnum,
+  resolveAuthorizedIntegrationTools,
+  sanitizeSlug,
+} from './resolve-authorized-tools.js';
+
+describe('resolveAuthorizedIntegrationTools', () => {
+  it('resolves namespaced tools with live descriptions and narrowed method schemas', async () => {
+    const request = {};
+    const lease = leaseContext();
+    const integration = materializedIntegration({connectionId: 'connection-1'});
+    setLeasedJobContext(request, lease);
+
+    const result = await resolveAuthorizedIntegrationTools({
+      request,
+      registry: registryWithAgentTools([catalogTool({description: 'Live issue reader'})]),
+      getIntegrationConnectionById: async () =>
+        connection({
+          id: 'connection-1',
+          workspaceId: lease.workspaceId,
+          slug: integration.connectionSlug,
+        }),
+      loadLeasedAgentStep: async () => ({
+        workspaceId: lease.workspaceId,
+        step: {type: 'agent', config: agentStepConfig([integration])},
+      }),
+    });
+
+    const authorizedTool = result.get('github_main__issue_read');
+    expect(authorizedTool?.description).toBe('Live issue reader');
+    const properties = authorizedTool?.inputSchema.properties as Record<string, unknown>;
+    expect(properties.method).toMatchObject({
+      enum: ['get', 'get_comments'],
+    });
+    expect(authorizedTool?.inputSchema.oneOf).toHaveLength(2);
+    const oneOf = authorizedTool?.inputSchema.oneOf as unknown[];
+    expect(oneOf[0]).toMatchObject({
+      properties: {method: {const: 'get', description: 'Get one issue.'}},
+    });
+  });
+
+  it('fails closed when the lease has no current step', async () => {
+    const request = {};
+    setLeasedJobContext(
+      request,
+      leaseContext({currentStepId: undefined, currentStepAttempt: undefined}),
+    );
+
+    const act = resolveAuthorizedIntegrationTools({
+      request,
+      registry: registryWithAgentTools(),
+      getIntegrationConnectionById: async () => undefined,
+      loadLeasedAgentStep: () => Promise.reject(new Error('should not load')),
+    });
+
+    await expect(act).rejects.toMatchObject({code: 'lease-missing-step', status: 409});
+  });
+
+  it('fails closed when the current step is not an agent step', async () => {
+    const request = {};
+    const lease = leaseContext();
+    setLeasedJobContext(request, lease);
+
+    const act = resolveAuthorizedIntegrationTools({
+      request,
+      registry: registryWithAgentTools(),
+      getIntegrationConnectionById: async () => undefined,
+      loadLeasedAgentStep: async () => ({
+        workspaceId: lease.workspaceId,
+        step: {type: 'run', config: {}},
+      }),
+    });
+
+    await expect(act).rejects.toMatchObject({code: 'leased-step-not-agent', status: 409});
+  });
+
+  it.each([
+    ['deleted', undefined],
+    ['inactive', connection({id: 'connection-1', lifecycleStatus: 'disabled'})],
+    ['workspace mismatch', connection({id: 'connection-1', workspaceId: 'other-workspace'})],
+  ])('denies when the connection is %s', async (_label, resolvedConnection) => {
+    const request = {};
+    const lease = leaseContext({workspaceId: 'workspace-1'});
+    const integration = materializedIntegration({connectionId: 'connection-1'});
+    setLeasedJobContext(request, lease);
+
+    const act = resolveAuthorizedIntegrationTools({
+      request,
+      registry: registryWithAgentTools(),
+      getIntegrationConnectionById: async () => resolvedConnection,
+      loadLeasedAgentStep: async () => ({
+        workspaceId: lease.workspaceId,
+        step: {type: 'agent', config: agentStepConfig([integration])},
+      }),
+    });
+
+    await expect(act).rejects.toMatchObject({
+      code: 'integration-tool-connection-unavailable',
+      status: 409,
+    });
+  });
+
+  it('denies when the provider no longer exposes agent tools', async () => {
+    const request = {};
+    const lease = leaseContext({workspaceId: 'workspace-1'});
+    const integration = materializedIntegration({connectionId: 'connection-1'});
+    setLeasedJobContext(request, lease);
+
+    const act = resolveAuthorizedIntegrationTools({
+      request,
+      registry: createIntegrationProviderRegistry([{provider: 'github', displayName: 'GitHub'}]),
+      getIntegrationConnectionById: async () =>
+        connection({id: 'connection-1', workspaceId: lease.workspaceId}),
+      loadLeasedAgentStep: async () => ({
+        workspaceId: lease.workspaceId,
+        step: {type: 'agent', config: agentStepConfig([integration])},
+      }),
+    });
+
+    await expect(act).rejects.toMatchObject({
+      code: 'integration-tool-connection-unavailable',
+      status: 409,
+    });
+  });
+
+  it('detects MCP name collisions after slug sanitization', async () => {
+    const request = {};
+    const lease = leaseContext({workspaceId: 'workspace-1'});
+    const first = materializedIntegration({
+      connectionId: 'connection-1',
+      connectionSlug: 'github-main',
+    });
+    const second = materializedIntegration({
+      connectionId: 'connection-2',
+      connectionSlug: 'github_main',
+    });
+    setLeasedJobContext(request, lease);
+
+    const act = resolveAuthorizedIntegrationTools({
+      request,
+      registry: registryWithAgentTools(),
+      getIntegrationConnectionById: async (id) =>
+        connection({
+          id,
+          workspaceId: lease.workspaceId,
+          slug: id === 'connection-1' ? 'github-main' : 'github_main',
+        }),
+      loadLeasedAgentStep: async () => ({
+        workspaceId: lease.workspaceId,
+        step: {type: 'agent', config: agentStepConfig([first, second])},
+      }),
+    });
+
+    await expect(act).rejects.toMatchObject({
+      code: 'integration-tool-name-collision',
+      status: 409,
+    });
+  });
+
+  it('leaves unknown method schema shapes intact while runtime enforcement remains separate', () => {
+    const schema = {type: 'object', properties: {method: {type: 'string'}}};
+
+    const narrowed = narrowMethodEnum(schema, ['allowed']);
+
+    expect(narrowed).toEqual(schema);
+  });
+});
+
+describe('MCP tool names', () => {
+  it('sanitizes connection slugs without parsing names back apart', () => {
+    expect(sanitizeSlug('github-main')).toBe('github_main');
+    expect(mcpToolName('github-main', 'issue_read')).toBe('github_main__issue_read');
+  });
+});

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/resolve-authorized-tools.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/resolve-authorized-tools.ts
@@ -1,0 +1,273 @@
+import {
+  type MaterializedAgentIntegrationConfigDto,
+  type MaterializedAgentIntegrationToolConfigDto,
+  materializedAgentStepConfigSchema,
+} from '@shipfox/api-agent-dto';
+import {requireLeasedJobContext} from '@shipfox/api-auth-context';
+import {ClientError} from '@shipfox/node-fastify';
+import type {IntegrationConnection} from '#core/entities/connection.js';
+import type {IntegrationProviderKind} from '#core/entities/provider.js';
+import type {AgentToolCatalogEntry, AgentToolJsonSchema} from '#core/providers/agent-tools.js';
+import type {IntegrationProviderRegistry} from '#core/providers/registry.js';
+import type {GetIntegrationConnectionByIdFn} from '#db/connections.js';
+
+export type LeasedAgentStepLoader = (params: {
+  request: object;
+  stepId: string;
+  attempt: number;
+}) => Promise<{
+  step: {type: string; config: Record<string, unknown>};
+  workspaceId: string;
+}>;
+
+export interface AuthorizedIntegrationTool {
+  mcpName: string;
+  integration: MaterializedAgentIntegrationConfigDto;
+  tool: MaterializedAgentIntegrationToolConfigDto;
+  connection: IntegrationConnection;
+  description: string;
+  inputSchema: AgentToolJsonSchema;
+  outputSchema?: AgentToolJsonSchema | undefined;
+}
+
+export type AuthorizedIntegrationToolMap = Map<string, AuthorizedIntegrationTool>;
+
+export interface ResolveAuthorizedToolsParams {
+  request: object;
+  loadLeasedAgentStep: LeasedAgentStepLoader;
+  registry: IntegrationProviderRegistry;
+  getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
+}
+
+export async function resolveAuthorizedIntegrationTools(
+  params: ResolveAuthorizedToolsParams,
+): Promise<AuthorizedIntegrationToolMap> {
+  const leasedJob = requireLeasedJobContext(params.request);
+  if (!leasedJob.currentStepId || leasedJob.currentStepAttempt === undefined) {
+    throw new ClientError('Lease does not identify a current step', 'lease-missing-step', {
+      status: 409,
+    });
+  }
+
+  const {step, workspaceId} = await params.loadLeasedAgentStep({
+    request: params.request,
+    stepId: leasedJob.currentStepId,
+    attempt: leasedJob.currentStepAttempt,
+  });
+  if (step.type !== 'agent') {
+    throw new ClientError('Current leased step is not an agent step', 'leased-step-not-agent', {
+      status: 409,
+    });
+  }
+
+  const integrations = parseAgentIntegrations(step.config);
+  const authorizedTools: AuthorizedIntegrationToolMap = new Map();
+
+  for (const integration of integrations) {
+    const connection = await loadAuthorizedConnection({
+      integration,
+      workspaceId,
+      registry: params.registry,
+      getIntegrationConnectionById: params.getIntegrationConnectionById,
+    });
+    const catalog = await params.registry.getAdapter(integration.provider, 'agent_tools').catalog();
+    const catalogByToolId = new Map(catalog.map((entry) => [entry.id, entry]));
+
+    for (const tool of integration.tools) {
+      const catalogTool = catalogByToolId.get(tool.id);
+      const mcpName = mcpToolName(integration.connectionSlug, tool.id);
+      if (authorizedTools.has(mcpName)) {
+        throw new ClientError(
+          'Integration tool names collide after MCP namespacing',
+          'integration-tool-name-collision',
+          {
+            status: 409,
+          },
+        );
+      }
+
+      authorizedTools.set(mcpName, {
+        mcpName,
+        integration,
+        tool,
+        connection,
+        // The live catalog enriches display metadata only. Frozen step config remains the allowlist.
+        description: catalogTool?.description ?? tool.id,
+        inputSchema: tool.methods ? toolInputSchema(tool, catalogTool) : tool.inputSchema,
+        outputSchema: tool.outputSchema ?? catalogTool?.outputSchema,
+      });
+    }
+  }
+
+  return authorizedTools;
+}
+
+export function sanitizeSlug(slug: string): string {
+  return slug.replaceAll('-', '_');
+}
+
+export function mcpToolName(connectionSlug: string, toolId: string): string {
+  return `${sanitizeSlug(connectionSlug)}__${toolId}`;
+}
+
+export function narrowMethodEnum(
+  inputSchema: AgentToolJsonSchema,
+  authorizedMethods: readonly string[],
+  methodDescriptions: ReadonlyMap<string, string> = new Map(),
+): AgentToolJsonSchema {
+  const schema = cloneSchema(inputSchema);
+  const methodSchema = getObjectProperty(schema, 'method');
+  if (methodSchema) {
+    narrowEnumOrConst(methodSchema, authorizedMethods);
+  }
+
+  const oneOf = schema.oneOf;
+  if (Array.isArray(oneOf)) {
+    schema.oneOf = oneOf.filter((entry) => {
+      if (!isRecord(entry)) return true;
+      const entryMethod = getObjectProperty(entry, 'method');
+      if (!entryMethod) return true;
+      const methodConst = entryMethod?.const;
+      if (typeof methodConst !== 'string') return true;
+      if (!authorizedMethods.includes(methodConst)) return false;
+
+      const description = methodDescriptions.get(methodConst);
+      if (description) entryMethod.description = description;
+      return true;
+    });
+  } else if (methodDescriptions.size > 0) {
+    schema.oneOf = authorizedMethods.map((method) => ({
+      properties: {
+        method: {
+          const: method,
+          description: methodDescriptions.get(method) ?? method,
+        },
+      },
+    }));
+  }
+
+  return schema;
+}
+
+function toolInputSchema(
+  tool: MaterializedAgentIntegrationToolConfigDto,
+  catalogTool: AgentToolCatalogEntry | undefined,
+): AgentToolJsonSchema {
+  const authorizedMethods = tool.methods?.map((method) => method.id) ?? [];
+  const methodDescriptions = new Map(
+    catalogTool?.methods?.map((method) => [method.id, method.description]) ?? [],
+  );
+  return narrowMethodEnum(tool.inputSchema, authorizedMethods, methodDescriptions);
+}
+
+function parseAgentIntegrations(
+  config: Record<string, unknown>,
+): MaterializedAgentIntegrationConfigDto[] {
+  try {
+    return materializedAgentStepConfigSchema.parse(config).integrations ?? [];
+  } catch (error) {
+    throw new ClientError('Agent step config is invalid', 'agent-step-config-invalid', {
+      status: 409,
+      cause: error,
+    });
+  }
+}
+
+async function loadAuthorizedConnection(params: {
+  integration: MaterializedAgentIntegrationConfigDto;
+  workspaceId: string;
+  registry: IntegrationProviderRegistry;
+  getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
+}): Promise<IntegrationConnection> {
+  const connection = await params.getIntegrationConnectionById(params.integration.connectionId);
+  if (!connection) {
+    throw new ClientError(
+      'Integration connection is no longer available',
+      'integration-tool-connection-unavailable',
+      {
+        status: 409,
+      },
+    );
+  }
+  if (connection.workspaceId !== params.workspaceId) {
+    throw new ClientError(
+      'Integration connection does not belong to the leased workspace',
+      'integration-tool-connection-unavailable',
+      {
+        status: 409,
+      },
+    );
+  }
+  if (connection.lifecycleStatus !== 'active') {
+    throw new ClientError(
+      'Integration connection is not active',
+      'integration-tool-connection-unavailable',
+      {
+        status: 409,
+      },
+    );
+  }
+  if (connection.provider !== params.integration.provider) {
+    throw new ClientError(
+      'Integration connection provider changed',
+      'integration-tool-connection-unavailable',
+      {
+        status: 409,
+      },
+    );
+  }
+  if (!providerSupportsAgentTools(params.registry, params.integration.provider)) {
+    throw new ClientError(
+      'Integration provider no longer exposes agent tools',
+      'integration-tool-connection-unavailable',
+      {
+        status: 409,
+      },
+    );
+  }
+
+  return connection;
+}
+
+function providerSupportsAgentTools(
+  registry: IntegrationProviderRegistry,
+  provider: IntegrationProviderKind,
+): boolean {
+  try {
+    return registry.get(provider).capabilities.includes('agent_tools');
+  } catch {
+    return false;
+  }
+}
+
+function cloneSchema(schema: AgentToolJsonSchema): AgentToolJsonSchema {
+  return structuredClone(schema);
+}
+
+function getObjectProperty(
+  schema: AgentToolJsonSchema,
+  property: string,
+): AgentToolJsonSchema | null {
+  const properties = schema.properties;
+  if (!isRecord(properties)) return null;
+  const value = properties[property];
+  return isRecord(value) ? value : null;
+}
+
+function narrowEnumOrConst(
+  schema: AgentToolJsonSchema,
+  authorizedMethods: readonly string[],
+): void {
+  if (Array.isArray(schema.enum)) {
+    schema.enum = schema.enum.filter(
+      (value): value is string => typeof value === 'string' && authorizedMethods.includes(value),
+    );
+  }
+  if (typeof schema.const === 'string' && !authorizedMethods.includes(schema.const)) {
+    delete schema.const;
+  }
+}
+
+function isRecord(value: unknown): value is AgentToolJsonSchema {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/libs/api/integration/core/src/presentation/routes/index.ts
+++ b/libs/api/integration/core/src/presentation/routes/index.ts
@@ -1,6 +1,11 @@
 import type {RouteExport} from '@shipfox/node-fastify';
 import type {IntegrationProviderRegistry} from '#core/providers/registry.js';
 import type {IntegrationSourceControlService} from '#core/source-control-service.js';
+import type {GetIntegrationConnectionByIdFn} from '#db/connections.js';
+import {
+  createAgentToolsGatewayRoutes,
+  type LeasedAgentStepLoader,
+} from './agent-tools-gateway/index.js';
 import {createListIntegrationConnectionsRoute} from './list-connections.js';
 import {createListIntegrationProvidersRoute} from './list-providers.js';
 import {createListRepositoriesRoute} from './list-repositories.js';
@@ -9,11 +14,32 @@ import {
   createUpdateIntegrationConnectionRoute,
 } from './manage-connections.js';
 
+export type {LeasedAgentStepLoader} from './agent-tools-gateway/index.js';
+
+export interface CreateIntegrationRoutesOptions {
+  agentTools?:
+    | {
+        loadLeasedAgentStep: LeasedAgentStepLoader;
+        getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
+      }
+    | undefined;
+}
+
 export function createIntegrationRoutes(
   registry: IntegrationProviderRegistry,
   sourceControl: IntegrationSourceControlService,
+  options: CreateIntegrationRoutesOptions = {},
 ): RouteExport[] {
   const providerRoutes = registry.list().flatMap((provider) => provider.routes ?? []);
+  const agentToolsRoutes = options.agentTools
+    ? [
+        createAgentToolsGatewayRoutes({
+          registry,
+          loadLeasedAgentStep: options.agentTools.loadLeasedAgentStep,
+          getIntegrationConnectionById: options.agentTools.getIntegrationConnectionById,
+        }),
+      ]
+    : [];
 
   return [
     createListIntegrationProvidersRoute(registry),
@@ -21,6 +47,7 @@ export function createIntegrationRoutes(
     createUpdateIntegrationConnectionRoute(registry),
     createDeleteIntegrationConnectionRoute(),
     createListRepositoriesRoute(sourceControl),
+    ...agentToolsRoutes,
     ...providerRoutes,
   ];
 }

--- a/libs/api/integration/core/test/agent-tools-gateway-helpers.ts
+++ b/libs/api/integration/core/test/agent-tools-gateway-helpers.ts
@@ -1,0 +1,171 @@
+import type {
+  MaterializedAgentIntegrationConfigDto,
+  MaterializedAgentIntegrationToolConfigDto,
+} from '@shipfox/api-agent-dto';
+import type {LeasedJobContext} from '@shipfox/api-auth-context';
+import type {IntegrationConnection} from '#core/entities/connection.js';
+import type {AgentToolCatalogEntry, AgentToolsProvider} from '#core/providers/agent-tools.js';
+import {createIntegrationProviderRegistry} from '#core/providers/registry.js';
+
+export function leaseContext(overrides: Partial<LeasedJobContext> = {}): LeasedJobContext {
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    workflowRunId: crypto.randomUUID(),
+    workflowRunAttemptId: crypto.randomUUID(),
+    jobId: crypto.randomUUID(),
+    jobExecutionId: crypto.randomUUID(),
+    projectId: crypto.randomUUID(),
+    workspaceId: crypto.randomUUID(),
+    runnerSessionId: crypto.randomUUID(),
+    currentStepId: crypto.randomUUID(),
+    currentStepAttempt: 1,
+    aud: 'runner-job-lease',
+    iat: now,
+    exp: now + 3600,
+    ...overrides,
+  };
+}
+
+export function connection(overrides: Partial<IntegrationConnection> = {}): IntegrationConnection {
+  const now = new Date();
+  return {
+    id: crypto.randomUUID(),
+    workspaceId: crypto.randomUUID(),
+    provider: 'github',
+    externalAccountId: 'installation-1',
+    slug: 'github-main',
+    displayName: 'GitHub',
+    lifecycleStatus: 'active',
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+export function materializedTool(
+  overrides: Partial<MaterializedAgentIntegrationToolConfigDto> = {},
+): MaterializedAgentIntegrationToolConfigDto {
+  return {
+    id: 'issue_read',
+    sensitivity: 'read',
+    sensitive: false,
+    requiredScope: [],
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        method: {
+          type: 'string',
+          enum: ['get', 'get_comments', 'get_labels'],
+        },
+        owner: {type: 'string'},
+        repo: {type: 'string'},
+        issue_number: {type: 'integer'},
+      },
+      required: ['method', 'owner', 'repo', 'issue_number'],
+      oneOf: [
+        {properties: {method: {const: 'get'}}, required: ['issue_number']},
+        {properties: {method: {const: 'get_comments'}}, required: ['issue_number']},
+        {properties: {method: {const: 'get_labels'}}, required: ['issue_number']},
+      ],
+    },
+    methods: [
+      {
+        id: 'get',
+        token: 'issue_read.get',
+        sensitivity: 'read',
+        sensitive: false,
+        requiredScope: [],
+      },
+      {
+        id: 'get_comments',
+        token: 'issue_read.get_comments',
+        sensitivity: 'read',
+        sensitive: false,
+        requiredScope: [],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+export function materializedIntegration(
+  overrides: Partial<MaterializedAgentIntegrationConfigDto> = {},
+): MaterializedAgentIntegrationConfigDto {
+  return {
+    connectionId: crypto.randomUUID(),
+    connectionSlug: 'github-main',
+    provider: 'github',
+    repos: ['github:owner/repo'],
+    requiredScope: [],
+    tools: [materializedTool()],
+    ...overrides,
+  };
+}
+
+export function agentStepConfig(
+  integrations: MaterializedAgentIntegrationConfigDto[] = [materializedIntegration()],
+): Record<string, unknown> {
+  return {
+    provider: 'openai',
+    model: 'gpt-5',
+    thinking: 'off',
+    prompt: 'Use tools',
+    integrations,
+  };
+}
+
+export function catalogTool(overrides: Partial<AgentToolCatalogEntry> = {}): AgentToolCatalogEntry {
+  return {
+    id: 'issue_read',
+    description: 'Read issue metadata from GitHub.',
+    sensitivity: 'read',
+    sensitive: false,
+    requiredScope: [],
+    inputSchema: {type: 'object', properties: {}, additionalProperties: false},
+    outputSchema: {type: 'object', additionalProperties: true},
+    methods: [
+      {
+        id: 'get',
+        description: 'Get one issue.',
+        sensitivity: 'read',
+        sensitive: false,
+        requiredScope: [],
+      },
+      {
+        id: 'get_comments',
+        description: 'Get issue comments.',
+        sensitivity: 'read',
+        sensitive: false,
+        requiredScope: [],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+export function agentToolsProvider(
+  catalog: readonly AgentToolCatalogEntry[] = [catalogTool()],
+): AgentToolsProvider {
+  return {
+    catalog: () => catalog,
+    selectionCatalog: () => ({selectors: []}),
+    openSession: async () => ({
+      call: async () => ({}),
+    }),
+  };
+}
+
+export function registryWithAgentTools(
+  catalog: readonly AgentToolCatalogEntry[] = [catalogTool()],
+) {
+  return createIntegrationProviderRegistry([
+    {
+      provider: 'github',
+      displayName: 'GitHub',
+      adapters: {
+        agent_tools: agentToolsProvider(catalog),
+      },
+    },
+  ]);
+}

--- a/libs/api/workflows/src/index.ts
+++ b/libs/api/workflows/src/index.ts
@@ -64,6 +64,7 @@ export {
   workflowsOutbox,
 } from '#db/index.js';
 export {routes} from '#presentation/index.js';
+export {loadRunningLeasedStep} from '#presentation/routes/leased-step.js';
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const workflowsPath = resolve(packageRoot, 'dist/temporal/workflows/index.js');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1711,6 +1711,12 @@ importers:
 
   libs/api/integration/core:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: 1.29.0
+        version: 1.29.0(zod@4.4.3)
+      '@shipfox/api-agent-dto':
+        specifier: workspace:*
+        version: link:../../agent-dto
       '@shipfox/api-auth-context':
         specifier: workspace:*
         version: link:../../auth-context
@@ -1765,6 +1771,9 @@ importers:
       '@temporalio/workflow':
         specifier: ^1.16.1
         version: 1.18.1
+      ajv:
+        specifier: ^8.20.0
+        version: 8.20.0
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)


### PR DESCRIPTION
Build the lease-authenticated integration MCP gateway for agent workflow steps.

Agent runners should never receive provider credentials or decide which integration tools are authorized. This adds the integration-core gateway that derives the current agent step from the job lease, reloads the frozen integration tool selection from server state, revalidates the live connection, and exposes only the authorized namespaced MCP tools.

Provider execution remains intentionally stubbed here so ENG-848 can add GitHub dispatch behind the same authorization boundary. The PR also wires the workflows leased-step loader into API composition without making integration-core depend on workflows directly.

Closes ENG-847

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a lease‑authenticated MCP gateway for agent workflow steps so runners only see server‑authorized, namespaced integration tools. Satisfies ENG-847 by resolving the leased agent step and validating live connections before exposing tools over MCP.

- **New Features**
  - POST `/runs/jobs/current/integration-tools/mcp` guarded by `AUTH_LEASED_JOB`.
  - Resolves frozen step tools, revalidates live connection (exists, active, same workspace, provider match, provider supports `agent_tools`); returns 409s pre‑hijack on failures.
  - Streams MCP via stateless `StreamableHTTPServerTransport`; tools are namespaced as `<sanitized-connection-slug>__<tool-id>` with collision checks.
  - Narrows method‑family input schemas and enforces allowed methods at runtime; validates args with Ajv and returns MCP `isError` results for invalid tool/method/args; uses live catalog descriptions while the frozen allowlist remains the source of truth.
  - Dispatch remains stubbed and returns structured content; real provider execution will land in ENG-848.
  - API wiring: injects `loadRunningLeasedStep` into `createIntegrationsContext` and passes `getIntegrationConnectionById` into route composition.

- **Dependencies**
  - Added `@modelcontextprotocol/sdk@1.29.0`.
  - Added `@shipfox/api-agent-dto`.
  - Added `ajv@^8.20.0`.

<sup>Written for commit 7388b988f5d09abed7d99082ed43e2e46ecaa9b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

