### PR TITLE
[runner] Add run step annotation emission

### DIFF
--- a/.changeset/brisk-annotations-spool.md
+++ b/.changeset/brisk-annotations-spool.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/runner-execution": patch
+"@shipfox/runner-protocol": minor
+"@shipfox/runner-orchestration": patch
+---
+
+Adds run-step annotation summary and spool collection with leased annotation publishing.

--- a/libs/runner/execution/package.json
+++ b/libs/runner/execution/package.json
@@ -47,12 +47,14 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
+    "@shipfox/annotations-dto": "workspace:*",
     "@shipfox/api-workflows-dto": "workspace:*",
     "@shipfox/node-opentelemetry": "workspace:*",
     "@shipfox/redact": "workspace:*",
     "@shipfox/runner-protocol": "workspace:*",
     "@shipfox/runner-workspace": "workspace:*",
-    "ky": "^2.0.0"
+    "ky": "^2.0.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",

--- a/libs/runner/execution/src/core/annotation-spool.test.ts
+++ b/libs/runner/execution/src/core/annotation-spool.test.ts
@@ -102,10 +102,16 @@ describe('annotation spool', () => {
 
   it('skips symlinked annotation files', async () => {
     const spool = await makeSpool();
-    const target = join(spool.annotationsDir, 'target');
+    const summaryTarget = `${spool.summaryPath}-target`;
+    const operationTarget = `${spool.summaryPath}-operation-target`;
     await rm(spool.summaryPath);
-    await writeFile(target, 'secret');
-    await symlink(target, spool.summaryPath);
+    await writeFile(summaryTarget, 'summary-secret');
+    await writeFile(
+      operationTarget,
+      JSON.stringify({context: 'deploy', op: 'append', body: 'operation-secret'}),
+    );
+    await symlink(summaryTarget, spool.summaryPath);
+    await symlink(operationTarget, join(spool.annotationsDir, '001-symlink.json'));
 
     const operations = await collectAnnotationOperations(spool);
 

--- a/libs/runner/execution/src/core/annotation-spool.test.ts
+++ b/libs/runner/execution/src/core/annotation-spool.test.ts
@@ -1,9 +1,10 @@
-import {access, mkdir, mkdtemp, rm, stat, writeFile} from 'node:fs/promises';
+import {access, chmod, mkdir, mkdtemp, rm, stat, symlink, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {logger} from '@shipfox/node-opentelemetry';
 import {
   ANNOTATION_BODY_MAX_BYTES,
+  ANNOTATION_MAX_SPOOL_BYTES,
   type AnnotationSpool,
   collectAnnotationOperations,
   createAnnotationSpool,
@@ -96,6 +97,59 @@ describe('annotation spool', () => {
     expect(warn).toHaveBeenCalledWith(
       expect.objectContaining({limit: ANNOTATION_BODY_MAX_BYTES}),
       expect.stringContaining('exceeds the local read limit'),
+    );
+  });
+
+  it('skips symlinked annotation files', async () => {
+    const spool = await makeSpool();
+    const target = join(spool.annotationsDir, 'target');
+    await rm(spool.summaryPath);
+    await writeFile(target, 'secret');
+    await symlink(target, spool.summaryPath);
+
+    const operations = await collectAnnotationOperations(spool);
+
+    expect(operations).toEqual([]);
+  });
+
+  it('keeps valid operations when a single operation file cannot be read', async () => {
+    const warn = vi.spyOn(logger(), 'warn').mockImplementation(() => undefined);
+    const spool = await makeSpool();
+    const unreadablePath = join(spool.annotationsDir, '002-unreadable.json');
+    await writeFile(
+      join(spool.annotationsDir, '001-valid.json'),
+      JSON.stringify({context: 'deploy', op: 'append', body: 'body'}),
+    );
+    await writeFile(unreadablePath, JSON.stringify({context: 'deploy', op: 'append', body: 'bad'}));
+    await chmod(unreadablePath, 0o000);
+
+    const operations = await collectAnnotationOperations(spool);
+
+    expect(operations).toEqual([{context: 'deploy', style: 'default', op: 'append', body: 'body'}]);
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({path: unreadablePath}),
+      'Skipping unreadable annotation operation file',
+    );
+  });
+
+  it('counts skipped oversized operation files against the spool byte limit', async () => {
+    const warn = vi.spyOn(logger(), 'warn').mockImplementation(() => undefined);
+    const spool = await makeSpool();
+    await writeFile(
+      join(spool.annotationsDir, '001-oversized.json'),
+      Buffer.alloc(ANNOTATION_MAX_SPOOL_BYTES + 1, 'x'),
+    );
+    await writeFile(
+      join(spool.annotationsDir, '002-valid.json'),
+      JSON.stringify({context: 'deploy', op: 'append', body: 'body'}),
+    );
+
+    const operations = await collectAnnotationOperations(spool);
+
+    expect(operations).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({limit: ANNOTATION_MAX_SPOOL_BYTES}),
+      'Annotation operation spool byte limit exceeded; skipping remaining files',
     );
   });
 });

--- a/libs/runner/execution/src/core/annotation-spool.test.ts
+++ b/libs/runner/execution/src/core/annotation-spool.test.ts
@@ -1,0 +1,118 @@
+import {access, mkdir, mkdtemp, rm, stat, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {logger} from '@shipfox/node-opentelemetry';
+import {
+  ANNOTATION_BODY_MAX_BYTES,
+  type AnnotationSpool,
+  collectAnnotationOperations,
+  createAnnotationSpool,
+  disposeAnnotationSpool,
+} from '#core/annotation-spool.js';
+
+let tempDirs: string[] = [];
+
+describe('annotation spool', () => {
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await Promise.all(tempDirs.map((dir) => rm(dir, {recursive: true, force: true})));
+    tempDirs = [];
+  });
+
+  it('creates summary and operation spool env paths and disposes them', async () => {
+    const spool = await createAnnotationSpool();
+
+    expect(spool.env).toEqual({
+      SHIPFOX_STEP_SUMMARY: spool.summaryPath,
+      SHIPFOX_ANNOTATIONS_DIR: spool.annotationsDir,
+    });
+    expect((await stat(spool.summaryPath)).isFile()).toBe(true);
+    expect((await stat(spool.annotationsDir)).isDirectory()).toBe(true);
+
+    await disposeAnnotationSpool(spool);
+
+    await expect(access(spool.summaryPath)).rejects.toThrow();
+    await expect(access(spool.annotationsDir)).rejects.toThrow();
+  });
+
+  it('collects summary and sorted operation files into resolved wire operations', async () => {
+    const spool = await makeSpool();
+    await writeFile(spool.summaryPath, 'summary');
+    await writeFile(
+      join(spool.annotationsDir, '002-b.json'),
+      JSON.stringify({context: 'deploy', op: 'append', body: ' done'}),
+    );
+    await writeFile(
+      join(spool.annotationsDir, '001-a.json'),
+      JSON.stringify({context: 'deploy', style: 'info', body: 'started'}),
+    );
+
+    const operations = await collectAnnotationOperations(spool);
+
+    expect(operations).toEqual([
+      {context: 'default', style: 'default', op: 'replace', body: 'summary'},
+      {context: 'deploy', style: 'info', op: 'replace', body: 'started done'},
+    ]);
+  });
+
+  it('skips malformed JSON, schema-invalid files, and non-files without throwing', async () => {
+    const warn = vi.spyOn(logger(), 'warn').mockImplementation(() => undefined);
+    const spool = await makeSpool();
+    await writeFile(join(spool.annotationsDir, '001-invalid-json.json'), '{');
+    await writeFile(join(spool.annotationsDir, '002-invalid-schema.json'), '{"context":"deploy"}');
+    await mkdir(join(spool.annotationsDir, '003-dir.json'));
+    await writeFile(
+      join(spool.annotationsDir, '004-valid.json'),
+      JSON.stringify({context: 'deploy', op: 'append', body: 'body'}),
+    );
+
+    const operations = await collectAnnotationOperations(spool);
+
+    expect(operations).toEqual([{context: 'deploy', style: 'default', op: 'append', body: 'body'}]);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('returns an empty list for missing spool paths', async () => {
+    const operations = await collectAnnotationOperations({
+      summaryPath: join(tmpdir(), 'shipfox-missing-summary'),
+      annotationsDir: join(tmpdir(), 'shipfox-missing-annotations'),
+      env: {
+        SHIPFOX_STEP_SUMMARY: 'unused',
+        SHIPFOX_ANNOTATIONS_DIR: 'unused',
+      },
+    });
+
+    expect(operations).toEqual([]);
+  });
+
+  it('bounds an over-cap summary file and keeps the step fail-open', async () => {
+    const warn = vi.spyOn(logger(), 'warn').mockImplementation(() => undefined);
+    const spool = await makeSpool();
+    await writeFile(spool.summaryPath, Buffer.alloc(ANNOTATION_BODY_MAX_BYTES + 1, 'x'));
+
+    const operations = await collectAnnotationOperations(spool);
+
+    expect(operations).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({limit: ANNOTATION_BODY_MAX_BYTES}),
+      expect.stringContaining('exceeds the local read limit'),
+    );
+  });
+});
+
+async function makeSpool(): Promise<AnnotationSpool> {
+  const root = await mkdtemp(join(tmpdir(), 'shipfox-annotations-test-'));
+  tempDirs.push(root);
+  const summaryPath = join(root, 'summary');
+  const annotationsDir = join(root, 'annotations');
+  await writeFile(summaryPath, '');
+  await mkdir(annotationsDir);
+  return {
+    summaryPath,
+    annotationsDir,
+    env: {
+      SHIPFOX_STEP_SUMMARY: summaryPath,
+      SHIPFOX_ANNOTATIONS_DIR: annotationsDir,
+    },
+  };
+}

--- a/libs/runner/execution/src/core/annotation-spool.ts
+++ b/libs/runner/execution/src/core/annotation-spool.ts
@@ -1,6 +1,6 @@
 import {randomUUID} from 'node:crypto';
 import {constants} from 'node:fs';
-import {mkdir, open, readdir, rm, unlink, writeFile} from 'node:fs/promises';
+import {mkdir, open, opendir, rm, unlink, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import type {LeasedWriteAnnotationOperationDto} from '@shipfox/annotations-dto';
@@ -24,6 +24,11 @@ export interface AnnotationSpool {
   };
 }
 
+interface BoundedFileRead {
+  raw: string | undefined;
+  accountedBytes: number;
+}
+
 export async function createAnnotationSpool(): Promise<AnnotationSpool> {
   const summaryPath = join(tmpdir(), `shipfox-step-summary-${randomUUID()}`);
   const annotationsDir = join(tmpdir(), `shipfox-annotations-${randomUUID()}`);
@@ -45,7 +50,7 @@ export async function collectAnnotationOperations(
   spool: AnnotationSpool,
 ): Promise<LeasedWriteAnnotationOperationDto[]> {
   try {
-    const summary = await readOptionalBoundedFile(spool.summaryPath, 'summary');
+    const {raw: summary} = await readOptionalBoundedFile(spool.summaryPath, 'summary');
     const operations = await readOperationFiles(spool);
     return resolveAnnotationOperations({summary, operations});
   } catch (error) {
@@ -60,41 +65,21 @@ export async function disposeAnnotationSpool(spool: AnnotationSpool): Promise<vo
 }
 
 async function readOperationFiles(spool: AnnotationSpool): Promise<AnnotationOperationFile[]> {
-  let entries: Array<{name: string; isFile(): boolean}>;
-  try {
-    entries = await readdir(spool.annotationsDir, {withFileTypes: true});
-  } catch (error) {
-    if (errorCode(error) === 'ENOENT') return [];
-    throw error;
-  }
-
-  const files = entries
-    .filter((entry) => {
-      if (entry.isFile()) return true;
-      logger().warn(
-        {path: join(spool.annotationsDir, entry.name)},
-        'Skipping non-file annotation operation spool entry',
-      );
-      return false;
-    })
-    .map((entry) => entry.name)
-    .sort();
-
-  if (files.length > ANNOTATION_MAX_OP_FILES) {
-    logger().warn(
-      {count: files.length, limit: ANNOTATION_MAX_OP_FILES},
-      'Annotation operation spool file limit exceeded; skipping remaining files',
-    );
-  }
+  const files = await readOperationFileNames(spool.annotationsDir);
 
   const operations: AnnotationOperationFile[] = [];
   let totalBytes = 0;
-  for (const name of files.slice(0, ANNOTATION_MAX_OP_FILES)) {
+  for (const name of files) {
     const path = join(spool.annotationsDir, name);
-    const raw = await readOptionalBoundedFile(path, 'operation');
-    if (raw === undefined) continue;
+    let read: BoundedFileRead;
+    try {
+      read = await readOptionalBoundedFile(path, 'operation');
+    } catch (error) {
+      logger().warn({err: error, path}, 'Skipping unreadable annotation operation file');
+      continue;
+    }
 
-    totalBytes += Buffer.byteLength(raw, 'utf8');
+    totalBytes += read.accountedBytes;
     if (totalBytes > ANNOTATION_MAX_SPOOL_BYTES) {
       logger().warn(
         {limit: ANNOTATION_MAX_SPOOL_BYTES},
@@ -102,6 +87,9 @@ async function readOperationFiles(spool: AnnotationSpool): Promise<AnnotationOpe
       );
       break;
     }
+
+    const {raw} = read;
+    if (raw === undefined) continue;
 
     const parsedJson = parseJson(raw, path);
     if (parsedJson === undefined) continue;
@@ -118,34 +106,81 @@ async function readOperationFiles(spool: AnnotationSpool): Promise<AnnotationOpe
   return operations;
 }
 
-async function readOptionalBoundedFile(
-  path: string,
-  kind: 'summary' | 'operation',
-): Promise<string | undefined> {
-  const handle = await open(path, constants.O_RDONLY | constants.O_NONBLOCK).catch((error) => {
+async function readOperationFileNames(annotationsDir: string): Promise<string[]> {
+  const dir = await opendir(annotationsDir).catch((error) => {
     if (errorCode(error) === 'ENOENT') return undefined;
     throw error;
   });
-  if (!handle) return undefined;
+  if (!dir) return [];
+
+  const files: string[] = [];
+  try {
+    while (true) {
+      const entry = await dir.read();
+      if (!entry) break;
+
+      if (!entry.isFile()) {
+        logger().warn(
+          {path: join(annotationsDir, entry.name)},
+          'Skipping non-file annotation operation spool entry',
+        );
+        continue;
+      }
+
+      files.push(entry.name);
+      if (files.length >= ANNOTATION_MAX_OP_FILES) {
+        logger().warn(
+          {limit: ANNOTATION_MAX_OP_FILES},
+          'Annotation operation spool file limit reached; skipping remaining files',
+        );
+        break;
+      }
+    }
+  } finally {
+    await dir.close().catch(() => undefined);
+  }
+
+  return files.sort();
+}
+
+async function readOptionalBoundedFile(
+  path: string,
+  kind: 'summary' | 'operation',
+): Promise<BoundedFileRead> {
+  const handle = await open(
+    path,
+    constants.O_RDONLY | constants.O_NONBLOCK | constants.O_NOFOLLOW,
+  ).catch((error) => {
+    const code = errorCode(error);
+    if (code === 'ENOENT' || code === 'ELOOP') return undefined;
+    throw error;
+  });
+  if (!handle) return {raw: undefined, accountedBytes: 0};
 
   try {
     const stat = await handle.stat();
     if (!stat.isFile()) {
       logger().warn({path}, `Skipping non-regular annotation ${kind} file`);
-      return undefined;
+      return {raw: undefined, accountedBytes: 0};
     }
 
-    const buffer = Buffer.alloc(ANNOTATION_BODY_MAX_BYTES + 1);
-    const {bytesRead} = await handle.read(buffer, 0, buffer.length, 0);
-    if (bytesRead === 0) return undefined;
-    if (bytesRead > ANNOTATION_BODY_MAX_BYTES) {
+    if (stat.size === 0) return {raw: undefined, accountedBytes: 0};
+    if (stat.size > ANNOTATION_BODY_MAX_BYTES) {
       logger().warn(
         {path, limit: ANNOTATION_BODY_MAX_BYTES},
         `Annotation ${kind} file exceeds the local read limit; skipping file`,
       );
-      return undefined;
+      return {raw: undefined, accountedBytes: stat.size};
     }
-    return buffer.subarray(0, bytesRead).toString('utf8');
+
+    const buffer = Buffer.alloc(stat.size);
+    const {bytesRead} = await handle.read(buffer, 0, buffer.length, 0);
+    if (bytesRead === 0) return {raw: undefined, accountedBytes: 0};
+
+    return {
+      raw: buffer.subarray(0, bytesRead).toString('utf8'),
+      accountedBytes: bytesRead,
+    };
   } finally {
     await handle.close();
   }

--- a/libs/runner/execution/src/core/annotation-spool.ts
+++ b/libs/runner/execution/src/core/annotation-spool.ts
@@ -1,0 +1,167 @@
+import {randomUUID} from 'node:crypto';
+import {constants} from 'node:fs';
+import {mkdir, open, readdir, rm, unlink, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import type {LeasedWriteAnnotationOperationDto} from '@shipfox/annotations-dto';
+import {logger} from '@shipfox/node-opentelemetry';
+import {
+  type AnnotationOperationFile,
+  annotationOperationFileSchema,
+  resolveAnnotationOperations,
+} from '#core/annotations.js';
+
+export const ANNOTATION_BODY_MAX_BYTES = 1024 * 1024;
+export const ANNOTATION_MAX_OP_FILES = 256;
+export const ANNOTATION_MAX_SPOOL_BYTES = 5 * 1024 * 1024;
+
+export interface AnnotationSpool {
+  summaryPath: string;
+  annotationsDir: string;
+  env: {
+    SHIPFOX_STEP_SUMMARY: string;
+    SHIPFOX_ANNOTATIONS_DIR: string;
+  };
+}
+
+export async function createAnnotationSpool(): Promise<AnnotationSpool> {
+  const summaryPath = join(tmpdir(), `shipfox-step-summary-${randomUUID()}`);
+  const annotationsDir = join(tmpdir(), `shipfox-annotations-${randomUUID()}`);
+
+  await writeFile(summaryPath, '', {mode: 0o600});
+  await mkdir(annotationsDir, {mode: 0o700});
+
+  return {
+    summaryPath,
+    annotationsDir,
+    env: {
+      SHIPFOX_STEP_SUMMARY: summaryPath,
+      SHIPFOX_ANNOTATIONS_DIR: annotationsDir,
+    },
+  };
+}
+
+export async function collectAnnotationOperations(
+  spool: AnnotationSpool,
+): Promise<LeasedWriteAnnotationOperationDto[]> {
+  try {
+    const summary = await readOptionalBoundedFile(spool.summaryPath, 'summary');
+    const operations = await readOperationFiles(spool);
+    return resolveAnnotationOperations({summary, operations});
+  } catch (error) {
+    logger().warn({err: error}, 'Failed to collect step annotations; skipping annotations');
+    return [];
+  }
+}
+
+export async function disposeAnnotationSpool(spool: AnnotationSpool): Promise<void> {
+  await unlink(spool.summaryPath).catch(() => undefined);
+  await rm(spool.annotationsDir, {recursive: true, force: true}).catch(() => undefined);
+}
+
+async function readOperationFiles(spool: AnnotationSpool): Promise<AnnotationOperationFile[]> {
+  let entries: Array<{name: string; isFile(): boolean}>;
+  try {
+    entries = await readdir(spool.annotationsDir, {withFileTypes: true});
+  } catch (error) {
+    if (errorCode(error) === 'ENOENT') return [];
+    throw error;
+  }
+
+  const files = entries
+    .filter((entry) => {
+      if (entry.isFile()) return true;
+      logger().warn(
+        {path: join(spool.annotationsDir, entry.name)},
+        'Skipping non-file annotation operation spool entry',
+      );
+      return false;
+    })
+    .map((entry) => entry.name)
+    .sort();
+
+  if (files.length > ANNOTATION_MAX_OP_FILES) {
+    logger().warn(
+      {count: files.length, limit: ANNOTATION_MAX_OP_FILES},
+      'Annotation operation spool file limit exceeded; skipping remaining files',
+    );
+  }
+
+  const operations: AnnotationOperationFile[] = [];
+  let totalBytes = 0;
+  for (const name of files.slice(0, ANNOTATION_MAX_OP_FILES)) {
+    const path = join(spool.annotationsDir, name);
+    const raw = await readOptionalBoundedFile(path, 'operation');
+    if (raw === undefined) continue;
+
+    totalBytes += Buffer.byteLength(raw, 'utf8');
+    if (totalBytes > ANNOTATION_MAX_SPOOL_BYTES) {
+      logger().warn(
+        {limit: ANNOTATION_MAX_SPOOL_BYTES},
+        'Annotation operation spool byte limit exceeded; skipping remaining files',
+      );
+      break;
+    }
+
+    const parsedJson = parseJson(raw, path);
+    if (parsedJson === undefined) continue;
+
+    const parsedOperation = annotationOperationFileSchema.safeParse(parsedJson);
+    if (!parsedOperation.success) {
+      logger().warn({path}, 'Skipping malformed annotation operation file');
+      continue;
+    }
+
+    operations.push(parsedOperation.data);
+  }
+
+  return operations;
+}
+
+async function readOptionalBoundedFile(
+  path: string,
+  kind: 'summary' | 'operation',
+): Promise<string | undefined> {
+  const handle = await open(path, constants.O_RDONLY | constants.O_NONBLOCK).catch((error) => {
+    if (errorCode(error) === 'ENOENT') return undefined;
+    throw error;
+  });
+  if (!handle) return undefined;
+
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile()) {
+      logger().warn({path}, `Skipping non-regular annotation ${kind} file`);
+      return undefined;
+    }
+
+    const buffer = Buffer.alloc(ANNOTATION_BODY_MAX_BYTES + 1);
+    const {bytesRead} = await handle.read(buffer, 0, buffer.length, 0);
+    if (bytesRead === 0) return undefined;
+    if (bytesRead > ANNOTATION_BODY_MAX_BYTES) {
+      logger().warn(
+        {path, limit: ANNOTATION_BODY_MAX_BYTES},
+        `Annotation ${kind} file exceeds the local read limit; skipping file`,
+      );
+      return undefined;
+    }
+    return buffer.subarray(0, bytesRead).toString('utf8');
+  } finally {
+    await handle.close();
+  }
+}
+
+function parseJson(raw: string, path: string): unknown | undefined {
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    logger().warn({err: error, path}, 'Skipping annotation operation file with invalid JSON');
+    return undefined;
+  }
+}
+
+function errorCode(error: unknown): string | undefined {
+  return typeof error === 'object' && error !== null && 'code' in error
+    ? String(error.code)
+    : undefined;
+}

--- a/libs/runner/execution/src/core/annotations.test.ts
+++ b/libs/runner/execution/src/core/annotations.test.ts
@@ -1,0 +1,112 @@
+import {ANNOTATION_CONTEXT_MAX_LENGTH} from '@shipfox/annotations-dto';
+import {annotationOperationFileSchema, resolveAnnotationOperations} from '#core/annotations.js';
+
+describe('annotationOperationFileSchema', () => {
+  it('parses a default replace operation without defaulting style', () => {
+    const operation = annotationOperationFileSchema.parse({
+      context: ' default ',
+      body: 'summary',
+    });
+
+    expect(operation).toEqual({context: 'default', op: 'replace', body: 'summary'});
+  });
+
+  it('rejects replace and append operations without a body', () => {
+    expect(() => annotationOperationFileSchema.parse({context: 'deploy'})).toThrow();
+    expect(() => annotationOperationFileSchema.parse({context: 'deploy', op: 'append'})).toThrow();
+  });
+
+  it('rejects remove operations with a body', () => {
+    expect(() =>
+      annotationOperationFileSchema.parse({context: 'deploy', op: 'remove', body: 'x'}),
+    ).toThrow();
+  });
+
+  it('rejects contexts over the DTO code point limit', () => {
+    expect(() =>
+      annotationOperationFileSchema.parse({
+        context: '😀'.repeat(ANNOTATION_CONTEXT_MAX_LENGTH + 1),
+        body: 'x',
+      }),
+    ).toThrow();
+  });
+});
+
+describe('resolveAnnotationOperations', () => {
+  it('turns summary content into a default replace operation', () => {
+    const operations = resolveAnnotationOperations({summary: '### Build\nok', operations: []});
+
+    expect(operations).toEqual([
+      {context: 'default', style: 'default', op: 'replace', body: '### Build\nok'},
+    ]);
+  });
+
+  it('resolves replace, append, and remove operations in order', () => {
+    const operations = resolveAnnotationOperations({
+      operations: [
+        {context: 'deploy', op: 'replace', style: 'info', body: 'started\n'},
+        {context: 'deploy', op: 'append', body: 'done'},
+        {context: 'flaky', op: 'append', style: 'warning', body: 'retry'},
+        {context: 'old', op: 'replace', body: 'stale'},
+        {context: 'old', op: 'remove'},
+      ],
+    });
+
+    expect(operations).toEqual([
+      {context: 'deploy', style: 'info', op: 'replace', body: 'started\ndone'},
+      {context: 'flaky', style: 'warning', op: 'append', body: 'retry'},
+      {context: 'old', style: 'default', op: 'remove'},
+    ]);
+  });
+
+  it('lets append style inherit until explicitly changed', () => {
+    const operations = resolveAnnotationOperations({
+      operations: [
+        {context: 'tests', op: 'replace', style: 'info', body: 'one'},
+        {context: 'tests', op: 'append', body: ' two'},
+        {context: 'tests', op: 'append', style: 'success', body: ' three'},
+      ],
+    });
+
+    expect(operations).toEqual([
+      {context: 'tests', style: 'success', op: 'replace', body: 'one two three'},
+    ]);
+  });
+
+  it('treats append after remove as a fresh in-step replace', () => {
+    const operations = resolveAnnotationOperations({
+      operations: [
+        {context: 'deploy', op: 'replace', body: 'old'},
+        {context: 'deploy', op: 'remove'},
+        {context: 'deploy', op: 'append', body: 'new'},
+      ],
+    });
+
+    expect(operations).toEqual([{context: 'deploy', style: 'default', op: 'replace', body: 'new'}]);
+  });
+
+  it('preserves first-seen context order', () => {
+    const operations = resolveAnnotationOperations({
+      summary: 'summary',
+      operations: [
+        {context: 'zeta', op: 'replace', body: 'z'},
+        {context: 'default', op: 'append', body: ' plus'},
+        {context: 'alpha', op: 'replace', body: 'a'},
+      ],
+    });
+
+    expect(operations.map((operation) => operation.context)).toEqual(['default', 'zeta', 'alpha']);
+    expect(operations[0]).toEqual({
+      context: 'default',
+      style: 'default',
+      op: 'replace',
+      body: 'summary plus',
+    });
+  });
+
+  it('returns an empty list for an empty spool', () => {
+    const operations = resolveAnnotationOperations({operations: []});
+
+    expect(operations).toEqual([]);
+  });
+});

--- a/libs/runner/execution/src/core/annotations.ts
+++ b/libs/runner/execution/src/core/annotations.ts
@@ -1,0 +1,113 @@
+import {
+  ANNOTATION_CONTEXT_MAX_LENGTH,
+  type AnnotationStyleDto,
+  annotationStyleSchema,
+  type LeasedWriteAnnotationOperationDto,
+} from '@shipfox/annotations-dto';
+import {z} from 'zod';
+
+function hasMaxCodePoints(value: string, maxCodePoints: number): boolean {
+  let count = 0;
+  for (const _codePoint of value) {
+    count += 1;
+    if (count > maxCodePoints) return false;
+  }
+  return true;
+}
+
+const annotationOperationFileBaseSchema = z.object({
+  context: z
+    .string()
+    .trim()
+    .min(1)
+    .refine((value) => hasMaxCodePoints(value, ANNOTATION_CONTEXT_MAX_LENGTH), {
+      message: `String must contain at most ${ANNOTATION_CONTEXT_MAX_LENGTH} character(s)`,
+    }),
+  style: annotationStyleSchema.optional(),
+});
+
+export const annotationOperationFileSchema = z.union([
+  annotationOperationFileBaseSchema.extend({
+    op: z.literal('replace').default('replace'),
+    body: z.string(),
+  }),
+  annotationOperationFileBaseSchema.extend({
+    op: z.literal('append'),
+    body: z.string(),
+  }),
+  annotationOperationFileBaseSchema.extend({
+    op: z.literal('remove'),
+    body: z.never().optional(),
+  }),
+]);
+
+export type AnnotationOperationFile = z.infer<typeof annotationOperationFileSchema>;
+
+type AnnotationState =
+  | {kind: 'replace'; style: AnnotationStyleDto; body: string}
+  | {kind: 'append'; style: AnnotationStyleDto; body: string}
+  | {kind: 'remove'};
+
+export function resolveAnnotationOperations(args: {
+  summary?: string | undefined;
+  operations: readonly AnnotationOperationFile[];
+}): LeasedWriteAnnotationOperationDto[] {
+  const states = new Map<string, AnnotationState>();
+
+  if (args.summary !== undefined && args.summary !== '') {
+    states.set('default', {kind: 'replace', style: 'default', body: args.summary});
+  }
+
+  for (const operation of args.operations) {
+    applyOperation(states, operation);
+  }
+
+  return [...states.entries()].map(([context, state]) => {
+    if (state.kind === 'remove') return {context, op: 'remove', style: 'default'};
+    return {context, op: state.kind, style: state.style, body: state.body};
+  });
+}
+
+function applyOperation(
+  states: Map<string, AnnotationState>,
+  operation: AnnotationOperationFile,
+): void {
+  if (operation.op === 'replace') {
+    states.set(operation.context, {
+      kind: 'replace',
+      style: operation.style ?? 'default',
+      body: operation.body,
+    });
+    return;
+  }
+
+  if (operation.op === 'remove') {
+    states.set(operation.context, {kind: 'remove'});
+    return;
+  }
+
+  const prior = states.get(operation.context);
+  if (!prior) {
+    states.set(operation.context, {
+      kind: 'append',
+      style: operation.style ?? 'default',
+      body: operation.body,
+    });
+    return;
+  }
+
+  if (prior.kind === 'remove') {
+    states.set(operation.context, {
+      kind: 'replace',
+      style: operation.style ?? 'default',
+      body: operation.body,
+    });
+    return;
+  }
+
+  states.set(operation.context, {
+    kind: prior.kind,
+    style: operation.style ?? prior.style,
+    body: prior.body + operation.body,
+  });
+}

--- a/libs/runner/execution/src/core/run-step.test.ts
+++ b/libs/runner/execution/src/core/run-step.test.ts
@@ -1,4 +1,4 @@
-import {mkdtemp, rm, writeFile} from 'node:fs/promises';
+import {access, mkdtemp, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {basename, isAbsolute, join} from 'node:path';
 import type {StepDto} from '@shipfox/api-workflows-dto';
@@ -12,6 +12,8 @@ const ESRCH_REGEX = /ESRCH/;
 const SHELL_EXECUTABLE_REGEX = /(?:^|\/)(bash|sh)$/;
 const SCRIPT_PATH_REGEX = /shipfox-runner-.*\.sh$/;
 const OUTPUT_PATH_REGEX = /shipfox-output-/;
+const SUMMARY_PATH_REGEX = /shipfox-step-summary-/;
+const ANNOTATIONS_DIR_REGEX = /shipfox-annotations-/;
 const PROCESS_TEST_WAIT_TIMEOUT_MS = 4_000;
 
 function collectOutput(): {sink: OutputSink; text: () => string; sources: () => string[]} {
@@ -179,6 +181,92 @@ describe('executeRunStep', () => {
     expect(result.success).toBe(true);
     expect(result.outputs?.path).toMatch(OUTPUT_PATH_REGEX);
     expect(result.outputs?.path).not.toBe('/tmp/user-output');
+  });
+
+  it('collects SHIPFOX_STEP_SUMMARY as a default annotation', async () => {
+    const step = buildStep({
+      config: {run: 'echo "### Summary" >> "$SHIPFOX_STEP_SUMMARY"'},
+    });
+
+    const result = await executeRunStep(step);
+
+    expect(result.success).toBe(true);
+    expect(result.annotations).toEqual([
+      {context: 'default', style: 'default', op: 'replace', body: '### Summary\n'},
+    ]);
+  });
+
+  it('collects JSON operation files from SHIPFOX_ANNOTATIONS_DIR', async () => {
+    const operation = JSON.stringify({
+      context: 'deploy',
+      style: 'success',
+      op: 'replace',
+      body: 'deployed',
+    });
+    const step = buildStep({
+      config: {
+        run: `printf '%s' ${JSON.stringify(operation)} > "$SHIPFOX_ANNOTATIONS_DIR/001-op.json"`,
+      },
+    });
+
+    const result = await executeRunStep(step);
+
+    expect(result.success).toBe(true);
+    expect(result.annotations).toEqual([
+      {context: 'deploy', style: 'success', op: 'replace', body: 'deployed'},
+    ]);
+  });
+
+  it('exposes annotation env to the child and overrides user env', async () => {
+    const step = buildStep({
+      config: {
+        run: [
+          'echo "summary=$SHIPFOX_STEP_SUMMARY" >> "$SHIPFOX_OUTPUT"',
+          'echo "dir=$SHIPFOX_ANNOTATIONS_DIR" >> "$SHIPFOX_OUTPUT"',
+        ].join('\n'),
+        env: {
+          SHIPFOX_STEP_SUMMARY: '/tmp/user-summary',
+          SHIPFOX_ANNOTATIONS_DIR: '/tmp/user-annotations',
+        },
+      },
+    });
+
+    const result = await executeRunStep(step);
+
+    expect(result.success).toBe(true);
+    expect(result.outputs?.summary).toMatch(SUMMARY_PATH_REGEX);
+    expect(result.outputs?.dir).toMatch(ANNOTATIONS_DIR_REGEX);
+    expect(result.outputs?.summary).not.toBe('/tmp/user-summary');
+    expect(result.outputs?.dir).not.toBe('/tmp/user-annotations');
+  });
+
+  it('does not fail a passing step when the annotation spool is malformed', async () => {
+    const step = buildStep({
+      config: {run: 'echo "{" > "$SHIPFOX_ANNOTATIONS_DIR/001-bad.json"'},
+    });
+
+    const result = await executeRunStep(step);
+
+    expect(result.success).toBe(true);
+    expect(result.annotations).toBeUndefined();
+  });
+
+  it('removes annotation spool files after collection', async () => {
+    const step = buildStep({
+      config: {
+        run: [
+          'echo "summary=$SHIPFOX_STEP_SUMMARY" >> "$SHIPFOX_OUTPUT"',
+          'echo "dir=$SHIPFOX_ANNOTATIONS_DIR" >> "$SHIPFOX_OUTPUT"',
+          'echo "body" >> "$SHIPFOX_STEP_SUMMARY"',
+        ].join('\n'),
+      },
+    });
+
+    const result = await executeRunStep(step);
+
+    expect(result.success).toBe(true);
+    await expect(access(result.outputs?.summary ?? '')).rejects.toThrow();
+    await expect(access(result.outputs?.dir ?? '')).rejects.toThrow();
   });
 
   it('fails a succeeded step when emitted output exceeds the total byte cap', async () => {

--- a/libs/runner/execution/src/core/run-step.test.ts
+++ b/libs/runner/execution/src/core/run-step.test.ts
@@ -265,8 +265,14 @@ describe('executeRunStep', () => {
     const result = await executeRunStep(step);
 
     expect(result.success).toBe(true);
-    await expect(access(result.outputs?.summary ?? '')).rejects.toThrow();
-    await expect(access(result.outputs?.dir ?? '')).rejects.toThrow();
+    expect(result.outputs?.summary).toMatch(SUMMARY_PATH_REGEX);
+    expect(result.outputs?.dir).toMatch(ANNOTATIONS_DIR_REGEX);
+    expect(result.outputs).toBeDefined();
+    if (!result.outputs) throw new Error('Expected annotation spool output paths');
+    const {summary, dir} = result.outputs;
+    if (!summary || !dir) throw new Error('Expected annotation spool output paths');
+    await expect(access(summary)).rejects.toThrow();
+    await expect(access(dir)).rejects.toThrow();
   });
 
   it('fails a succeeded step when emitted output exceeds the total byte cap', async () => {

--- a/libs/runner/execution/src/core/run-step.ts
+++ b/libs/runner/execution/src/core/run-step.ts
@@ -8,6 +8,12 @@ import {TextDecoder} from 'node:util';
 import type {StepDto, StepErrorDto} from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import {redactSecrets, safeRedactionPrefixLength, secretWireForms} from '@shipfox/redact';
+import {
+  type AnnotationSpool,
+  collectAnnotationOperations,
+  createAnnotationSpool,
+  disposeAnnotationSpool,
+} from '#core/annotation-spool.js';
 import {MAX_OUTPUT_TOTAL_BYTES, parseStepOutput, StepOutputError} from '#core/step-output.js';
 import type {StepResult} from '#core/step-result.js';
 
@@ -73,13 +79,29 @@ async function runShellCommand(
   const outputPath = join(tmpdir(), `shipfox-output-${randomUUID()}`);
   const metadata = commandStartMetadata({command, scriptPath, cwd: options.cwd});
   notifyCommandStart(options.onCommandStart, cloneCommandStartMetadata(metadata));
+  let annotationSpool: AnnotationSpool | undefined;
 
   try {
     await writeFile(scriptPath, command, {mode: 0o700});
     await writeFile(outputPath, '', {mode: 0o600});
-    const result = await spawnAndCapture(metadata, stepEnv, outputPath, options);
-    return await finalizeStepOutput(result, outputPath);
+    try {
+      annotationSpool = await createAnnotationSpool();
+    } catch (error) {
+      logger().warn(
+        {err: error},
+        'Failed to create annotation spool; running step without annotation collection',
+      );
+    }
+
+    const result = await spawnAndCapture(metadata, stepEnv, outputPath, annotationSpool, options);
+    const outputResult = await finalizeStepOutput(result, outputPath);
+    if (!annotationSpool) return outputResult;
+
+    const annotations = await collectAnnotationOperations(annotationSpool);
+    if (annotations.length === 0) return outputResult;
+    return {...outputResult, annotations};
   } finally {
+    if (annotationSpool) await disposeAnnotationSpool(annotationSpool);
     await unlink(scriptPath).catch(() => undefined);
     await unlink(outputPath).catch(() => undefined);
   }
@@ -89,6 +111,7 @@ function spawnAndCapture(
   metadata: CommandStartMetadata,
   stepEnv: Readonly<Record<string, string>>,
   outputPath: string,
+  annotationSpool: AnnotationSpool | undefined,
   options: RunStepOptions,
 ): Promise<StepResult> {
   return new Promise((resolve) => {
@@ -104,7 +127,12 @@ function spawnAndCapture(
       stdio: ['ignore', 'pipe', 'pipe'],
       detached: true,
       cwd: options.cwd,
-      env: {...process.env, ...stepEnv, SHIPFOX_OUTPUT: outputPath},
+      env: {
+        ...process.env,
+        ...stepEnv,
+        SHIPFOX_OUTPUT: outputPath,
+        ...(annotationSpool?.env ?? {}),
+      },
     });
 
     // stdout and stderr are two separate pipes, so the sink sees them merged by

--- a/libs/runner/execution/src/core/step-result.ts
+++ b/libs/runner/execution/src/core/step-result.ts
@@ -1,3 +1,4 @@
+import type {LeasedWriteAnnotationOperationDto} from '@shipfox/annotations-dto';
 import type {StepErrorDto} from '@shipfox/api-workflows-dto';
 
 export interface StepResult {
@@ -6,6 +7,8 @@ export interface StepResult {
   response?: string;
   // Step key/value outputs reported in the API report `output` field.
   outputs?: Record<string, string>;
+  // Run-step annotations posted before reporting the step result.
+  annotations?: LeasedWriteAnnotationOperationDto[];
   // Populated when success is false. Null on success.
   error: StepErrorDto;
   // 0 on success, the exit code on failure, null when signal-killed or never spawned.

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -225,6 +225,10 @@ describe('runJobSteps', () => {
     });
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('runs the setup step then a run step against the prepared cwd, reporting both', async () => {
     const setup = buildSetupStep();
     const run = buildRunStep();

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -1,4 +1,5 @@
 import type {AgentConfigIssueDto, NextStepResponseDto, StepDto} from '@shipfox/api-workflows-dto';
+import {logger} from '@shipfox/node-opentelemetry';
 import {HTTPError} from 'ky';
 
 const {AgentRuntimeConfigRequestError, StepSecretsRequestError} = vi.hoisted(() => ({
@@ -36,6 +37,7 @@ const requestAgentRuntimeConfigMock = vi.fn();
 const requestStepSecretsMock = vi.fn();
 const reportStepMock = vi.fn();
 const appendStepLogsMock = vi.fn();
+const writeStepAnnotationsMock = vi.fn();
 const executeRunStepMock = vi.fn();
 const executeSetupStepMock = vi.fn();
 const createStepLogStreamMock = vi.fn();
@@ -48,6 +50,7 @@ vi.mock('@shipfox/runner-protocol', () => ({
   requestStepSecrets: (...args: unknown[]) => requestStepSecretsMock(...args),
   reportStep: (...args: unknown[]) => reportStepMock(...args),
   appendStepLogs: (...args: unknown[]) => appendStepLogsMock(...args),
+  writeStepAnnotations: (...args: unknown[]) => writeStepAnnotationsMock(...args),
   AgentRuntimeConfigRequestError,
   StepSecretsRequestError,
   HTTPError,
@@ -72,9 +75,8 @@ vi.mock('@shipfox/runner-agent', () => ({
   executeAgentStep: (...args: unknown[]) => executeAgentStepMock(...args),
 }));
 
-const {executeStep, pullNextStep, reportStepResult, runJobSteps} = await import(
-  '#core/step-loop.js'
-);
+const {executeStep, pullNextStep, publishStepAnnotations, reportStepResult, runJobSteps} =
+  await import('#core/step-loop.js');
 
 const JOB_ID = '00000000-0000-0000-0000-0000000000aa';
 const RUN_ID = '00000000-0000-0000-0000-0000000000ab';
@@ -187,6 +189,7 @@ describe('runJobSteps', () => {
     requestStepSecretsMock.mockReset();
     reportStepMock.mockReset();
     appendStepLogsMock.mockReset();
+    writeStepAnnotationsMock.mockReset();
     executeRunStepMock.mockReset();
     executeSetupStepMock.mockReset();
     createStepLogStreamMock.mockReset();
@@ -203,6 +206,11 @@ describe('runJobSteps', () => {
     events = [];
     createdStreams = new Map();
     reportStepMock.mockResolvedValue({ok: true, cancel: false});
+    writeStepAnnotationsMock.mockResolvedValue({
+      status: 'written',
+      annotationCount: 1,
+      totalBodyBytes: 7,
+    });
     // Setup succeeds by default; tests that exercise setup failure override it.
     executeSetupStepMock.mockResolvedValue({
       result: {success: true, error: null, exit_code: 0},
@@ -671,6 +679,104 @@ describe('runJobSteps', () => {
     );
   });
 
+  it('publishes run step annotations after log drain and before reporting the step', async () => {
+    const setup = buildSetupStep();
+    const run = buildRunStep();
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(run, 1))
+      .mockResolvedValueOnce({kind: 'done', status: 'succeeded'});
+    executeRunStepMock.mockResolvedValue({
+      success: true,
+      error: null,
+      exit_code: 0,
+      annotations: [{context: 'default', style: 'default', op: 'replace', body: 'summary'}],
+    });
+    writeStepAnnotationsMock.mockImplementation(() => {
+      events.push(`annotations:${run.id}`);
+      return Promise.resolve({status: 'written', annotationCount: 1, totalBodyBytes: 7});
+    });
+    reportStepMock.mockImplementation((_client, params: {stepId: string}) => {
+      events.push(`report:${params.stepId}`);
+      return Promise.resolve({ok: true, cancel: false});
+    });
+    const ac = new AbortController();
+
+    await runLoop({signal: ac.signal});
+
+    expect(writeStepAnnotationsMock).toHaveBeenCalledWith(leaseClient, {
+      stepId: run.id,
+      attempt: 1,
+      annotations: [{context: 'default', style: 'default', op: 'replace', body: 'summary'}],
+      signal: ac.signal,
+    });
+    expect(events.indexOf(`drain:${run.id}`)).toBeLessThan(events.indexOf(`annotations:${run.id}`));
+    expect(events.indexOf(`annotations:${run.id}`)).toBeLessThan(
+      events.indexOf(`report:${run.id}`),
+    );
+  });
+
+  it('does not publish when a result has no annotations', async () => {
+    const run = buildRunStep();
+    const ac = new AbortController();
+
+    await publishStepAnnotations({
+      leaseClient,
+      step: run,
+      attempt: 1,
+      annotations: undefined,
+      jobId: JOB_ID,
+      signal: ac.signal,
+    });
+
+    expect(writeStepAnnotationsMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [{status: 'capped', code: 'annotation-body-too-large'}],
+    [{status: 'rejected', statusCode: 503, code: 'server-error'}],
+  ])('warns and continues when annotation publishing returns %j', async (outcome) => {
+    const warn = vi.spyOn(logger(), 'warn').mockImplementation(() => undefined);
+    const run = buildRunStep();
+    const ac = new AbortController();
+    writeStepAnnotationsMock.mockResolvedValueOnce(outcome);
+
+    await publishStepAnnotations({
+      leaseClient,
+      step: run,
+      attempt: 1,
+      annotations: [{context: 'default', style: 'default', op: 'replace', body: 'summary'}],
+      jobId: JOB_ID,
+      signal: ac.signal,
+    });
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({outcome}),
+      'Step annotations were not written; continuing step report',
+    );
+  });
+
+  it('warns and continues when annotation publishing throws', async () => {
+    const warn = vi.spyOn(logger(), 'warn').mockImplementation(() => undefined);
+    const run = buildRunStep();
+    const ac = new AbortController();
+    writeStepAnnotationsMock.mockRejectedValueOnce(new Error('timeout'));
+
+    await publishStepAnnotations({
+      leaseClient,
+      step: run,
+      attempt: 1,
+      annotations: [{context: 'default', style: 'default', op: 'replace', body: 'summary'}],
+      jobId: JOB_ID,
+      signal: ac.signal,
+    });
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({jobId: JOB_ID, stepId: run.id, attempt: 1}),
+      'Failed to publish step annotations; continuing step report',
+    );
+  });
+
   it('drains and disposes the prior attempt stream before opening the next', async () => {
     const setup = buildSetupStep();
     const run1 = buildRunStep({id: '00000000-0000-0000-0000-0000000000c1', position: 1});
@@ -878,6 +984,40 @@ describe('runJobSteps', () => {
       expect.objectContaining({
         stepId: run.id,
         outputs: {token: '***'},
+      }),
+    );
+  });
+
+  it('masks run step annotation bodies with the full secret set before publishing', async () => {
+    const setup = buildSetupStep();
+    const run = buildRunStep();
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(run, 1));
+    executeRunStepMock.mockResolvedValueOnce({
+      success: true,
+      error: null,
+      exit_code: 0,
+      annotations: [
+        {context: 'default', style: 'default', op: 'replace', body: 'checkout-secret'},
+        {context: 'old', style: 'default', op: 'remove'},
+      ],
+    });
+    reportStepMock
+      .mockResolvedValueOnce({ok: true, cancel: false})
+      .mockResolvedValueOnce({ok: true, cancel: true});
+    const ac = new AbortController();
+
+    await runLoop({signal: ac.signal, secrets: ['checkout-secret']});
+
+    expect(writeStepAnnotationsMock).toHaveBeenCalledWith(
+      leaseClient,
+      expect.objectContaining({
+        stepId: run.id,
+        annotations: [
+          {context: 'default', style: 'default', op: 'replace', body: '***'},
+          {context: 'old', style: 'default', op: 'remove'},
+        ],
       }),
     );
   });

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -25,6 +25,7 @@ import {
 } from '@shipfox/runner-logs';
 import {
   AgentRuntimeConfigRequestError,
+  type AnnotationWriteOutcome,
   appendStepLogs,
   HTTPError,
   type LogAppendFn,
@@ -33,6 +34,7 @@ import {
   requestNextStep,
   requestStepSecrets,
   StepSecretsRequestError,
+  writeStepAnnotations,
 } from '@shipfox/runner-protocol';
 import type {KyInstance} from 'ky';
 
@@ -116,6 +118,15 @@ export async function runJobSteps(params: {
       const logOutcome =
         (await settleStream({stream: activeStream, signal})) ?? execution.logOutcome ?? 'drained';
       activeStream = undefined;
+
+      await publishStepAnnotations({
+        leaseClient,
+        step,
+        attempt,
+        annotations: execution.result.annotations,
+        jobId,
+        signal,
+      });
 
       const {cancel} = await reportStepResult({
         leaseClient,
@@ -562,6 +573,7 @@ function maskRunStepOutputs(result: StepResult, secretVariants: string[]): StepR
     result.outputs === undefined
       ? result.outputs
       : redactOutputValues(result.outputs, secretVariants);
+  const annotations = redactAnnotationBodies(result.annotations, secretVariants);
   const error =
     result.success || result.error === null || result.error === undefined
       ? result.error
@@ -569,8 +581,20 @@ function maskRunStepOutputs(result: StepResult, secretVariants: string[]): StepR
   return {
     ...result,
     ...(outputs === undefined ? {} : {outputs}),
+    ...(annotations === undefined ? {} : {annotations}),
     error,
   };
+}
+
+function redactAnnotationBodies(
+  annotations: StepResult['annotations'],
+  secretVariants: string[],
+): StepResult['annotations'] {
+  if (annotations === undefined) return undefined;
+  return annotations.map((annotation) => {
+    if (annotation.op === 'remove') return annotation;
+    return {...annotation, body: redactSecrets(annotation.body, secretVariants)};
+  });
 }
 
 function redactOutputValues(
@@ -603,6 +627,46 @@ function agentRuntimeConfigFailure(error: unknown): StepResult {
     error: {message: error instanceof Error ? error.message : String(error)},
     exit_code: null,
   };
+}
+
+export async function publishStepAnnotations(params: {
+  leaseClient: KyInstance;
+  step: StepDto;
+  attempt: number;
+  annotations: StepResult['annotations'];
+  jobId: string;
+  signal: AbortSignal;
+}): Promise<void> {
+  const annotations = params.annotations ?? [];
+  if (annotations.length === 0) return;
+
+  let outcome: AnnotationWriteOutcome;
+  try {
+    outcome = await writeStepAnnotations(params.leaseClient, {
+      stepId: params.step.id,
+      attempt: params.attempt,
+      annotations,
+      signal: params.signal,
+    });
+  } catch (error) {
+    logger().warn(
+      {err: error, jobId: params.jobId, stepId: params.step.id, attempt: params.attempt},
+      'Failed to publish step annotations; continuing step report',
+    );
+    return;
+  }
+
+  if (outcome.status === 'written') return;
+
+  logger().warn(
+    {
+      jobId: params.jobId,
+      stepId: params.step.id,
+      attempt: params.attempt,
+      outcome,
+    },
+    'Step annotations were not written; continuing step report',
+  );
 }
 
 function writeCommandMetadata(

--- a/libs/runner/protocol/package.json
+++ b/libs/runner/protocol/package.json
@@ -37,6 +37,7 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
+    "@shipfox/annotations-dto": "workspace:*",
     "@shipfox/api-logs-dto": "workspace:*",
     "@shipfox/api-agent-dto": "workspace:*",
     "@shipfox/api-runners-dto": "workspace:*",

--- a/libs/runner/protocol/src/api-client.test.ts
+++ b/libs/runner/protocol/src/api-client.test.ts
@@ -23,6 +23,7 @@ import {
   requestStepSecrets,
   requireRunnerLabels,
   StepSecretsRequestError,
+  writeStepAnnotations,
 } from '#api-client.js';
 import {config} from '#config.js';
 
@@ -651,6 +652,77 @@ describe('appendStepLogs', () => {
 
     await expect(append).rejects.toThrow();
     expect(calls).toHaveLength(0);
+  });
+});
+
+describe('writeStepAnnotations', () => {
+  it('posts annotations to the lease-authed endpoint and parses accounting', async () => {
+    stubFetch(() =>
+      jsonResponse({
+        annotations: [{context: 'default', id: crypto.randomUUID()}],
+        accounting: {annotation_count: 1, total_body_bytes: 7},
+      }),
+    );
+    const leaseClient = createLeaseClient('lease-annotations');
+
+    const outcome = await writeStepAnnotations(leaseClient, {
+      stepId: STEP_ID,
+      attempt: 2,
+      annotations: [{context: 'default', style: 'default', op: 'replace', body: 'summary'}],
+    });
+
+    expect(outcome).toEqual({status: 'written', annotationCount: 1, totalBodyBytes: 7});
+    expect(calls[0]?.url).toContain('runs/jobs/current/annotations');
+    expect(calls[0]?.authorization).toBe('Bearer lease-annotations');
+    expect(JSON.parse(calls[0]?.body ?? '{}')).toEqual({
+      step_id: STEP_ID,
+      attempt: 2,
+      annotations: [{context: 'default', style: 'default', op: 'replace', body: 'summary'}],
+    });
+  });
+
+  it.each([
+    'annotation-body-too-large',
+    'annotation-count-limit-exceeded',
+    'annotation-total-bytes-limit-exceeded',
+  ])('maps capped 413 code %s', async (code) => {
+    stubFetch(() => jsonResponse({code}, 413));
+    const leaseClient = createLeaseClient('lease-annotations');
+
+    const outcome = await writeStepAnnotations(leaseClient, {
+      stepId: STEP_ID,
+      attempt: 1,
+      annotations: [{context: 'default', style: 'default', op: 'replace', body: 'summary'}],
+    });
+
+    expect(outcome).toEqual({status: 'capped', code});
+  });
+
+  it('maps non-cap errors to rejected and does not retry the POST', async () => {
+    stubFetch(() => jsonResponse({code: 'server-error'}, 500));
+    const leaseClient = createLeaseClient('lease-annotations');
+
+    const outcome = await writeStepAnnotations(leaseClient, {
+      stepId: STEP_ID,
+      attempt: 1,
+      annotations: [{context: 'default', style: 'default', op: 'replace', body: 'summary'}],
+    });
+
+    expect(outcome).toEqual({status: 'rejected', statusCode: 500, code: 'server-error'});
+    expect(calls).toHaveLength(1);
+  });
+
+  it('maps unknown 413 codes to rejected', async () => {
+    stubFetch(() => jsonResponse({code: 'other-limit'}, 413));
+    const leaseClient = createLeaseClient('lease-annotations');
+
+    const outcome = await writeStepAnnotations(leaseClient, {
+      stepId: STEP_ID,
+      attempt: 1,
+      annotations: [{context: 'default', style: 'default', op: 'replace', body: 'summary'}],
+    });
+
+    expect(outcome).toEqual({status: 'rejected', statusCode: 413, code: 'other-limit'});
   });
 });
 

--- a/libs/runner/protocol/src/api-client.ts
+++ b/libs/runner/protocol/src/api-client.ts
@@ -1,4 +1,9 @@
 import {
+  type LeasedWriteAnnotationOperationDto,
+  leasedWriteAnnotationsBodySchema,
+  leasedWriteAnnotationsResponseSchema,
+} from '@shipfox/annotations-dto';
+import {
   type AgentRuntimeCredentialsResponseDto,
   agentRuntimeCredentialsResponseSchema,
 } from '@shipfox/api-agent-dto';
@@ -38,6 +43,13 @@ import {config} from '#config.js';
 
 /** Media type the append endpoint expects for the raw NDJSON request body. */
 const LOG_NDJSON_CONTENT_TYPE = 'application/x-ndjson';
+export const ANNOTATION_POST_TIMEOUT_MS = 2_500;
+
+const ANNOTATION_CAPPED_CODES = new Set([
+  'annotation-body-too-large',
+  'annotation-count-limit-exceeded',
+  'annotation-total-bytes-limit-exceeded',
+]);
 
 /**
  * The runner-facing result of one append, after the transport has interpreted the
@@ -50,6 +62,11 @@ export type LogAppendOutcome =
   | {status: 'committed'; committedLength: number; capped: boolean}
   | {status: 'conflict'; committedLength: number}
   | {status: 'stopped'};
+
+export type AnnotationWriteOutcome =
+  | {status: 'written'; annotationCount: number; totalBodyBytes: number}
+  | {status: 'capped'; code: string}
+  | {status: 'rejected'; statusCode: number; code?: string | undefined};
 
 /**
  * The append port the runner's uploader depends on. The caller binds the lease
@@ -422,6 +439,46 @@ export async function appendStepLogs(
   // 5xx, 408, 429, or any other unexpected status: throw so the uploader logs it and retries
   // on the next tick (throwHttpErrors disables ky's in-transport status-code retry).
   throw new Error(`Log append failed with status ${response.status}`);
+}
+
+export async function writeStepAnnotations(
+  leaseClient: KyInstance,
+  params: {
+    stepId: string;
+    attempt: number;
+    annotations: readonly LeasedWriteAnnotationOperationDto[];
+    signal?: AbortSignal;
+  },
+): Promise<AnnotationWriteOutcome> {
+  const body = leasedWriteAnnotationsBodySchema.parse({
+    step_id: params.stepId,
+    attempt: params.attempt,
+    annotations: params.annotations,
+  });
+
+  const response = await leaseClient.post('runs/jobs/current/annotations', {
+    json: body,
+    throwHttpErrors: false,
+    retry: 0,
+    timeout: ANNOTATION_POST_TIMEOUT_MS,
+    ...(params.signal ? {signal: params.signal} : {}),
+  });
+
+  if (response.ok) {
+    const parsed = leasedWriteAnnotationsResponseSchema.parse(await response.json());
+    return {
+      status: 'written',
+      annotationCount: parsed.accounting.annotation_count,
+      totalBodyBytes: parsed.accounting.total_body_bytes,
+    };
+  }
+
+  const code = await errorCode(response);
+  if (response.status === 413 && code !== undefined && ANNOTATION_CAPPED_CODES.has(code)) {
+    return {status: 'capped', code};
+  }
+
+  return {status: 'rejected', statusCode: response.status, ...(code ? {code} : {})};
 }
 
 export async function heartbeat(

--- a/libs/runner/protocol/src/index.ts
+++ b/libs/runner/protocol/src/index.ts
@@ -1,5 +1,7 @@
 export {
   AgentRuntimeConfigRequestError,
+  ANNOTATION_POST_TIMEOUT_MS,
+  type AnnotationWriteOutcome,
   appendStepLogs,
   configuredRunnerLabels,
   createLeaseClient,
@@ -19,4 +21,5 @@ export {
   requireRunnerLabels,
   runnerRegistrationToken,
   StepSecretsRequestError,
+  writeStepAnnotations,
 } from '#api-client.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4859,6 +4859,9 @@ importers:
 
   libs/runner/execution:
     dependencies:
+      '@shipfox/annotations-dto':
+        specifier: workspace:*
+        version: link:../../api/annotations-dto
       '@shipfox/api-workflows-dto':
         specifier: workspace:*
         version: link:../../api/workflows-dto
@@ -4877,6 +4880,9 @@ importers:
       ky:
         specifier: ^2.0.0
         version: 2.0.2
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@shipfox/biome':
         specifier: workspace:*
@@ -4988,6 +4994,9 @@ importers:
 
   libs/runner/protocol:
     dependencies:
+      '@shipfox/annotations-dto':
+        specifier: workspace:*
+        version: link:../../api/annotations-dto
       '@shipfox/api-agent-dto':
         specifier: workspace:*
         version: link:../../api/agent-dto


### PR DESCRIPTION
Add runner-side annotation emission for run steps.

Run steps now receive `SHIPFOX_STEP_SUMMARY` and `SHIPFOX_ANNOTATIONS_DIR`, collect summary/spool files after the shell exits, collapse them into leased annotation operations, redact run secrets from annotation bodies, and publish them over the active job lease before reporting the step result. Annotation setup, collection, and publishing are all best-effort so presentational annotation failures never change the step outcome.

The resolver/spool code stays internal to `@shipfox/runner-execution`; agent-step annotations are deferred to ENG-891 so that tool-vs-env harness behavior can be designed separately.

Changed-scope build, check, and test passed locally. A broader `check type type:emit` run still hits an existing unrelated `@shipfox/api-workflows#type` error in `libs/api/workflows/src/temporal/workflows/job-execution-orchestration.ts:171`.

Closes ENG-867

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable run-step annotations via a local summary/spool and leased publishing. Exposes SHIPFOX_STEP_SUMMARY/SHIPFOX_ANNOTATIONS_DIR, resolves operations, redacts secrets, and posts after log drain and before the step report; publishing is best‑effort and never affects step results (ENG-867).

- **New Features**
  - Inject `SHIPFOX_STEP_SUMMARY` and `SHIPFOX_ANNOTATIONS_DIR` into run steps; collect the summary and JSON op files, then resolve to `replace`/`append`/`remove` operations with context/style.
  - Hardened collection: no‑follow the summary file and skip symlinked op files; bound work (1MB/file, 256 files, 5MB total), stop after limits, skip malformed/non-file/unreadable entries, count oversized files against the cap, and clean up the spool.
  - Publish annotations over the job lease after log drain; redact bodies with all step secrets, use a 2.5s POST timeout with no retries, map 413 “capped” vs. rejected outcomes, warn, and continue.

<sup>Written for commit 69f5f8da180ab071a98f5a368c9ed49caab2768e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

