### PR TITLE
Stabilize flow workflow E2E flakes

### DIFF
--- a/e2e/suites/flow/workflows/src/triggers.ts
+++ b/e2e/suites/flow/workflows/src/triggers.ts
@@ -1,8 +1,9 @@
-import {setTimeout as delay} from 'node:timers/promises';
 import type {FireManualTriggerResponseDto} from '@shipfox/api-triggers-dto';
-import {type createApiClient, E2eApiError} from '@shipfox/e2e-core';
+import {type createApiClient, E2eApiError, pollUntil} from '@shipfox/e2e-core';
 import {commitFiles} from '@shipfox/e2e-driver-gitea';
 import {waitForRunByCommit} from '@shipfox/e2e-observe-workflows';
+
+const MANUAL_TRIGGER_TIMEOUT_MS = 60_000;
 
 export async function triggerPushAndAwaitRun(params: {
   org: string;
@@ -49,26 +50,39 @@ export async function fireManualAndAwaitRun(params: {
   definitionId: string;
   inputs: Record<string, unknown>;
   scenario: string;
+  timeoutMs?: number | undefined;
 }): Promise<string> {
-  const maxAttempts = 8;
-  let lastError: unknown;
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    try {
-      const response = await params.client.requestJson<FireManualTriggerResponseDto>(
-        'post',
-        `/workflow-definitions/${params.definitionId}/fire-manual`,
-        {json: {inputs: params.inputs}},
-      );
-      return response.workflow_run_id;
-    } catch (error) {
-      if (!(error instanceof E2eApiError) || error.status !== 404) throw error;
-      lastError = error;
-      await delay(500);
-    }
-  }
-  throw lastError instanceof Error
-    ? lastError
-    : new Error(
-        `Manual trigger for ${params.scenario} was not ready after ${maxAttempts} attempts`,
-      );
+  let lastNotFound: E2eApiError | undefined;
+  const response = await pollUntil<FireManualTriggerResponseDto>(
+    {
+      timeoutMs: params.timeoutMs ?? MANUAL_TRIGGER_TIMEOUT_MS,
+      intervalMs: 250,
+      maxIntervalMs: 4_000,
+      backoffFactor: 1.5,
+      describe: () =>
+        `manual trigger for ${params.scenario}: definitionId=${params.definitionId}${formatLastNotFound(
+          lastNotFound,
+        )}`,
+    },
+    async () => {
+      try {
+        return await params.client.requestJson<FireManualTriggerResponseDto>(
+          'post',
+          `/workflow-definitions/${params.definitionId}/fire-manual`,
+          {json: {inputs: params.inputs}},
+        );
+      } catch (error) {
+        if (!(error instanceof E2eApiError) || error.status !== 404) throw error;
+        lastNotFound = error;
+        return null;
+      }
+    },
+  );
+
+  return response.workflow_run_id;
+}
+
+function formatLastNotFound(error: E2eApiError | undefined): string {
+  if (error === undefined) return '';
+  return ` last404=${JSON.stringify(error.details)}`;
 }

--- a/e2e/suites/flow/workflows/tests/ollama-agent.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/ollama-agent.e2e.ts
@@ -16,6 +16,9 @@ import {seedAndWaitForDefinition} from '#workflow-project.js';
 import {expect, test} from './fixtures.js';
 
 const CLAUDE_CONFIG_MODEL = 'claude-opus-4-8';
+const OLLAMA_SMOKE_MAX_OUTPUT_TOKENS = 64;
+
+test.describe.configure({mode: 'serial'});
 
 test('runs a Claude harness smoke workflow against local Ollama', async ({suite}, testInfo) => {
   const ollama = await requireOllamaOrSkip();
@@ -63,6 +66,7 @@ test('runs a Pi harness smoke workflow against local Ollama', async ({suite}, te
     displayName: `Local Ollama Smoke ${uniqueId}`,
     baseUrl: ollama.baseUrl,
     model: ollama.model,
+    modelMetadata: {max_output_tokens: OLLAMA_SMOKE_MAX_OUTPUT_TOKENS},
   });
 
   try {
@@ -125,7 +129,8 @@ jobs:
         model: ${params.model}
         thinking: ${params.thinking}
         prompt: |
-          Return a final assistant response with one short sentence.
+          Reply with exactly the word: ok
+          Do not include any other text.
 `;
 }
 


### PR DESCRIPTION
Stabilize the flow workflow E2E suite by making manual trigger firing wait for the trigger subscription projection and by constraining the live Ollama smoke tests.

Definition sync can expose a workflow definition before the triggers subscriber has projected the manual subscription, so the manual fire helper now treats 404 as a readiness signal for the same timeout budget used elsewhere in the suite.

The Ollama diagnostics showed both live Ollama tests reaching the agent step and then generating until the five-minute test timeout. The Ollama smoke tests now run serially, use a tighter prompt, and cap the Pi custom provider output length while keeping Claude/Anthropic on normal `thinking: low` workflow configuration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the flow workflow E2E suite by waiting for manual-trigger readiness and tightening live Ollama smoke tests to avoid timeouts and shared-model contention. This reduces flakes from 404s and over-generation.

- **Bug Fixes**
  - Manual trigger firing now uses `pollUntil` with backoff and treats 404 as "not ready" until the subscription is projected; default 60s timeout (overridable).
  - Ollama smoke tests run serially, force a one-word "ok" response, and cap Pi run `max_output_tokens` to 64; Claude stays on normal "thinking: low".

<sup>Written for commit 2c9ed4310f313fb146f30d058a7f35bb7340cf42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

