### PR TITLE
[api/integration] Add Linear webhook receiver

### DIFF
--- a/libs/api/integration/core/src/providers/linear.ts
+++ b/libs/api/integration/core/src/providers/linear.ts
@@ -14,6 +14,7 @@ import {
   upsertIntegrationConnection,
 } from '#db/connections.js';
 import {db} from '#db/db.js';
+import {publishIntegrationEventReceived, recordDeliveryOnly} from '#db/webhook-deliveries.js';
 import {retryConnectionSlugCollision} from '#providers/connection-slug.js';
 import type {IntegrationModuleParts, IntegrationProviderModule} from '#providers/types.js';
 
@@ -138,6 +139,10 @@ async function loadLinearModuleParts(
         getExistingLinearConnection,
         connectLinearInstallation,
         disconnectLinearInstallation,
+        publishIntegrationEventReceived,
+        recordDeliveryOnly,
+        getIntegrationConnectionById,
+        coreDb: db,
       },
     }),
     database: {

--- a/libs/api/integration/linear-dto/src/schemas/index.test.ts
+++ b/libs/api/integration/linear-dto/src/schemas/index.test.ts
@@ -46,6 +46,22 @@ describe('linear webhook schemas', () => {
     ).toBe(false);
   });
 
+  it.each([
+    null,
+    'issue-1',
+    1,
+  ])('rejects non-object data payloads from supported events', (data) => {
+    const result = linearWebhookEnvelopeSchema.safeParse({
+      action: 'create',
+      type: 'Issue',
+      organizationId: 'org-1',
+      webhookTimestamp: 1_786_257_600_000,
+      data,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
   it('accepts unsupported but routable base envelopes for record-and-drop handling', () => {
     const result = linearWebhookBaseEnvelopeSchema.parse({
       action: 'create',

--- a/libs/api/integration/linear-dto/src/schemas/index.test.ts
+++ b/libs/api/integration/linear-dto/src/schemas/index.test.ts
@@ -1,7 +1,66 @@
-import {LINEAR_PROVIDER} from './index.js';
+import {
+  LINEAR_PROVIDER,
+  linearWebhookBaseEnvelopeSchema,
+  linearWebhookEnvelopeSchema,
+  linearWebhookEventNames,
+} from './index.js';
 
 describe('LINEAR_PROVIDER', () => {
   it('names the Linear provider id', () => {
     expect(LINEAR_PROVIDER).toBe('linear');
+  });
+});
+
+describe('linear webhook schemas', () => {
+  it('accepts supported data webhook envelopes', () => {
+    const result = linearWebhookEnvelopeSchema.parse({
+      action: 'create',
+      type: 'Issue',
+      organizationId: 'org-1',
+      webhookTimestamp: 1_786_257_600_000,
+      data: {id: 'issue-1'},
+    });
+
+    expect(result.type).toBe('Issue');
+    expect(result.action).toBe('create');
+  });
+
+  it('rejects unsupported resources and actions from the supported event schema', () => {
+    expect(
+      linearWebhookEnvelopeSchema.safeParse({
+        action: 'create',
+        type: 'Reaction',
+        organizationId: 'org-1',
+        webhookTimestamp: 1_786_257_600_000,
+        data: {id: 'reaction-1'},
+      }).success,
+    ).toBe(false);
+    expect(
+      linearWebhookEnvelopeSchema.safeParse({
+        action: 'archive',
+        type: 'Issue',
+        organizationId: 'org-1',
+        webhookTimestamp: 1_786_257_600_000,
+        data: {id: 'issue-1'},
+      }).success,
+    ).toBe(false);
+  });
+
+  it('accepts unsupported but routable base envelopes for record-and-drop handling', () => {
+    const result = linearWebhookBaseEnvelopeSchema.parse({
+      action: 'create',
+      type: 'Reaction',
+      organizationId: 'org-1',
+      webhookTimestamp: 1_786_257_600_000,
+      data: {id: 'reaction-1'},
+    });
+
+    expect(result.type).toBe('Reaction');
+  });
+
+  it('exports Linear-facing event names without remapping resource casing', () => {
+    expect(linearWebhookEventNames).toContain('Issue.create');
+    expect(linearWebhookEventNames).toContain('IssueLabel.update');
+    expect(linearWebhookEventNames).toContain('Cycle.remove');
   });
 });

--- a/libs/api/integration/linear-dto/src/schemas/index.ts
+++ b/libs/api/integration/linear-dto/src/schemas/index.ts
@@ -5,6 +5,43 @@ export const LINEAR_PROVIDER = 'linear';
 
 export type LinearProvider = typeof LINEAR_PROVIDER;
 
+export const linearWebhookResourceTypes = [
+  'Issue',
+  'Comment',
+  'IssueLabel',
+  'Project',
+  'Cycle',
+] as const;
+export const linearWebhookActions = ['create', 'update', 'remove'] as const;
+
+export const linearWebhookEventNames = linearWebhookResourceTypes.flatMap((type) =>
+  linearWebhookActions.map((action) => `${type}.${action}` as const),
+);
+
+export type LinearWebhookResourceType = (typeof linearWebhookResourceTypes)[number];
+export type LinearWebhookAction = (typeof linearWebhookActions)[number];
+export type LinearWebhookEventName = (typeof linearWebhookEventNames)[number];
+
+const requiredUnknownSchema = z.custom<unknown>((value) => value !== undefined);
+
+export const linearWebhookEnvelopeSchema = z.object({
+  action: z.enum(linearWebhookActions),
+  type: z.enum(linearWebhookResourceTypes),
+  organizationId: z.string().min(1),
+  webhookTimestamp: z.number().int(),
+  data: requiredUnknownSchema,
+});
+export type LinearWebhookEnvelopeDto = z.infer<typeof linearWebhookEnvelopeSchema>;
+
+export const linearWebhookBaseEnvelopeSchema = z.object({
+  action: z.string().min(1),
+  type: z.string().min(1),
+  organizationId: z.string().min(1),
+  webhookTimestamp: z.number().int(),
+  data: requiredUnknownSchema,
+});
+export type LinearWebhookBaseEnvelopeDto = z.infer<typeof linearWebhookBaseEnvelopeSchema>;
+
 export const createLinearInstallBodySchema = z.object({
   workspace_id: z.string().uuid(),
 });

--- a/libs/api/integration/linear-dto/src/schemas/index.ts
+++ b/libs/api/integration/linear-dto/src/schemas/index.ts
@@ -22,14 +22,14 @@ export type LinearWebhookResourceType = (typeof linearWebhookResourceTypes)[numb
 export type LinearWebhookAction = (typeof linearWebhookActions)[number];
 export type LinearWebhookEventName = (typeof linearWebhookEventNames)[number];
 
-const requiredUnknownSchema = z.custom<unknown>((value) => value !== undefined);
+const linearWebhookDataSchema = z.record(z.string(), z.unknown());
 
 export const linearWebhookEnvelopeSchema = z.object({
   action: z.enum(linearWebhookActions),
   type: z.enum(linearWebhookResourceTypes),
   organizationId: z.string().min(1),
   webhookTimestamp: z.number().int(),
-  data: requiredUnknownSchema,
+  data: linearWebhookDataSchema,
 });
 export type LinearWebhookEnvelopeDto = z.infer<typeof linearWebhookEnvelopeSchema>;
 
@@ -38,7 +38,7 @@ export const linearWebhookBaseEnvelopeSchema = z.object({
   type: z.string().min(1),
   organizationId: z.string().min(1),
   webhookTimestamp: z.number().int(),
-  data: requiredUnknownSchema,
+  data: linearWebhookDataSchema,
 });
 export type LinearWebhookBaseEnvelopeDto = z.infer<typeof linearWebhookBaseEnvelopeSchema>;
 

--- a/libs/api/integration/linear/README.md
+++ b/libs/api/integration/linear/README.md
@@ -1,8 +1,30 @@
 # Shipfox API Integration Linear
 
 Shipfox API Integration Linear provides the Linear provider foundation. It is
-currently enabled behind `INTEGRATIONS_ENABLE_LINEAR_PROVIDER`; follow-up work
-adds OAuth connect routes, webhook ingestion, and hosted MCP execution.
+currently enabled behind `INTEGRATIONS_ENABLE_LINEAR_PROVIDER`; it includes OAuth
+connect routes and signed webhook ingestion. Hosted MCP execution is follow-up
+work.
+
+## Webhooks
+
+Linear sends OAuth application webhooks to:
+
+```text
+POST /webhooks/integrations/linear
+```
+
+The receiver requires `LINEAR_WEBHOOK_SIGNING_SECRET` to match the signing secret
+configured on the Linear app. It verifies `Linear-Signature` against the raw
+request body before parsing JSON, rejects signed payloads whose
+`webhookTimestamp` is more than 60 seconds from the API server clock, and uses
+the `Linear-Delivery` header as the integration delivery id.
+
+Supported data webhook events are `Issue`, `Comment`, `IssueLabel`, `Project`,
+and `Cycle` with `create`, `update`, or `remove` actions. Supported deliveries
+publish `integrations.event.received` with `provider: "linear"`,
+`source: connection.slug`, and event names such as `Issue.create`. Signed but
+unsupported webhook shapes are recorded and dropped with a 200 response so
+Linear does not retry or disable the webhook endpoint.
 
 ## Agent Tool Catalog
 

--- a/libs/api/integration/linear/src/core/webhook.test.ts
+++ b/libs/api/integration/linear/src/core/webhook.test.ts
@@ -1,0 +1,255 @@
+import {randomUUID} from 'node:crypto';
+import type {
+  GetIntegrationConnectionByIdFn,
+  IntegrationConnection,
+  PublishIntegrationEventReceivedFn,
+  RecordDeliveryOnlyFn,
+} from '@shipfox/api-integration-core-dto';
+import {db} from '#db/db.js';
+import {upsertLinearInstallation} from '#db/installations.js';
+import {linearInstallations} from '#db/schema/installations.js';
+import {handleLinearWebhook} from './webhook.js';
+
+function fakeConnection(overrides: Partial<IntegrationConnection> = {}): IntegrationConnection {
+  return {
+    id: randomUUID(),
+    workspaceId: randomUUID(),
+    provider: 'linear',
+    externalAccountId: 'org-1',
+    slug: 'Linear_Acme',
+    displayName: 'Linear Acme',
+    lifecycleStatus: 'active',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function payload(overrides: Record<string, unknown> = {}) {
+  return {
+    action: 'create',
+    type: 'Issue',
+    organizationId: `org-${randomUUID()}`,
+    webhookTimestamp: Date.now(),
+    data: {id: 'issue-1'},
+    ...overrides,
+  };
+}
+
+function deps(
+  options: {
+    connection?: IntegrationConnection | undefined;
+    publishIntegrationEventReceivedResult?: {published: boolean};
+  } = {},
+) {
+  return {
+    publishIntegrationEventReceived: vi.fn<PublishIntegrationEventReceivedFn>(() =>
+      Promise.resolve(options.publishIntegrationEventReceivedResult ?? {published: true}),
+    ),
+    recordDeliveryOnly: vi.fn<RecordDeliveryOnlyFn>(() => Promise.resolve()),
+    getIntegrationConnectionById: vi.fn<GetIntegrationConnectionByIdFn>(() =>
+      Promise.resolve(options.connection ?? fakeConnection()),
+    ),
+  };
+}
+
+function firstPublishIntegrationEventReceivedCall(publishIntegrationEventReceived: {
+  mock: {calls: Array<Parameters<PublishIntegrationEventReceivedFn>>};
+}): Parameters<PublishIntegrationEventReceivedFn>[0] {
+  const [call] = publishIntegrationEventReceived.mock.calls;
+  if (!call) throw new Error('Expected publishIntegrationEventReceived to be called');
+  return call[0];
+}
+
+function firstRecordDeliveryOnlyCall(recordDeliveryOnly: {
+  mock: {calls: Array<Parameters<RecordDeliveryOnlyFn>>};
+}): Parameters<RecordDeliveryOnlyFn>[0] {
+  const [call] = recordDeliveryOnly.mock.calls;
+  if (!call) throw new Error('Expected recordDeliveryOnly to be called');
+  return call[0];
+}
+
+async function seedInstallation(input: {
+  connectionId: string;
+  organizationId: string;
+  status?: 'installed' | 'revoked' | undefined;
+}): Promise<void> {
+  await upsertLinearInstallation({
+    connectionId: input.connectionId,
+    organizationId: input.organizationId,
+    organizationUrlKey: 'acme',
+    appUserId: 'app-user-1',
+    scopes: ['read', 'write'],
+    status: input.status ?? 'installed',
+  });
+}
+
+describe('handleLinearWebhook', () => {
+  beforeEach(async () => {
+    await db().delete(linearInstallations);
+  });
+
+  it('publishes a supported Linear data event for an active connection', async () => {
+    const connection = fakeConnection();
+    const deliveryId = randomUUID();
+    const rawPayload = payload({organizationId: 'org-active'});
+    await seedInstallation({connectionId: connection.id, organizationId: 'org-active'});
+    const handlers = deps({connection});
+
+    const result = await handleLinearWebhook({
+      tx: db(),
+      deliveryId,
+      payload: rawPayload,
+      rawPayload,
+      ...handlers,
+    });
+
+    expect(result.outcome).toBe('published');
+    expect(handlers.recordDeliveryOnly).not.toHaveBeenCalled();
+    expect(
+      firstPublishIntegrationEventReceivedCall(handlers.publishIntegrationEventReceived),
+    ).toMatchObject({
+      event: {
+        provider: 'linear',
+        source: connection.slug,
+        event: 'Issue.create',
+        workspaceId: connection.workspaceId,
+        connectionId: connection.id,
+        connectionName: connection.displayName,
+        deliveryId,
+        payload: rawPayload,
+      },
+    });
+  });
+
+  it('returns duplicate when the delivery was already published', async () => {
+    const connection = fakeConnection();
+    const rawPayload = payload({organizationId: 'org-duplicate'});
+    await seedInstallation({connectionId: connection.id, organizationId: 'org-duplicate'});
+    const handlers = deps({
+      connection,
+      publishIntegrationEventReceivedResult: {published: false},
+    });
+
+    const result = await handleLinearWebhook({
+      tx: db(),
+      deliveryId: randomUUID(),
+      payload: rawPayload,
+      rawPayload,
+      ...handlers,
+    });
+
+    expect(result.outcome).toBe('duplicate');
+    expect(handlers.publishIntegrationEventReceived).toHaveBeenCalledTimes(1);
+    expect(handlers.recordDeliveryOnly).not.toHaveBeenCalled();
+  });
+
+  it('records the delivery only for an unknown organization', async () => {
+    const handlers = deps();
+    const deliveryId = randomUUID();
+
+    const result = await handleLinearWebhook({
+      tx: db(),
+      deliveryId,
+      payload: payload({organizationId: 'org-missing'}),
+      rawPayload: payload({organizationId: 'org-missing'}),
+      ...handlers,
+    });
+
+    expect(result.outcome).toBe('unknown-organization');
+    expect(handlers.getIntegrationConnectionById).not.toHaveBeenCalled();
+    expect(handlers.publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(firstRecordDeliveryOnlyCall(handlers.recordDeliveryOnly)).toMatchObject({
+      provider: 'linear',
+      deliveryId,
+    });
+  });
+
+  it('records the delivery only for a revoked installation', async () => {
+    const connection = fakeConnection();
+    const rawPayload = payload({organizationId: 'org-revoked'});
+    await seedInstallation({
+      connectionId: connection.id,
+      organizationId: 'org-revoked',
+      status: 'revoked',
+    });
+    const handlers = deps({connection});
+
+    const result = await handleLinearWebhook({
+      tx: db(),
+      deliveryId: randomUUID(),
+      payload: rawPayload,
+      rawPayload,
+      ...handlers,
+    });
+
+    expect(result.outcome).toBe('revoked-installation');
+    expect(handlers.getIntegrationConnectionById).not.toHaveBeenCalled();
+    expect(handlers.publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(handlers.recordDeliveryOnly).toHaveBeenCalledTimes(1);
+  });
+
+  it('records the delivery only when the installation has no connection', async () => {
+    const connection = fakeConnection();
+    const rawPayload = payload({organizationId: 'org-dangling'});
+    await seedInstallation({connectionId: connection.id, organizationId: 'org-dangling'});
+    const handlers = deps({connection});
+    handlers.getIntegrationConnectionById.mockResolvedValue(undefined);
+
+    const result = await handleLinearWebhook({
+      tx: db(),
+      deliveryId: randomUUID(),
+      payload: rawPayload,
+      rawPayload,
+      ...handlers,
+    });
+
+    expect(result.outcome).toBe('missing-connection');
+    expect(handlers.publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(handlers.recordDeliveryOnly).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    'disabled',
+    'error',
+  ] as const)('records the delivery only when the connection is %s', async (lifecycleStatus) => {
+    const connection = fakeConnection({lifecycleStatus});
+    const rawPayload = payload({organizationId: `org-${lifecycleStatus}`});
+    await seedInstallation({
+      connectionId: connection.id,
+      organizationId: `org-${lifecycleStatus}`,
+    });
+    const handlers = deps({connection});
+
+    const result = await handleLinearWebhook({
+      tx: db(),
+      deliveryId: randomUUID(),
+      payload: rawPayload,
+      rawPayload,
+      ...handlers,
+    });
+
+    expect(result.outcome).toBe('inactive-connection');
+    expect(handlers.publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(handlers.recordDeliveryOnly).toHaveBeenCalledTimes(1);
+  });
+
+  it('records the delivery only for unsupported resources', async () => {
+    const connection = fakeConnection();
+    const rawPayload = payload({organizationId: 'org-reaction', type: 'Reaction'});
+    await seedInstallation({connectionId: connection.id, organizationId: 'org-reaction'});
+    const handlers = deps({connection});
+
+    const result = await handleLinearWebhook({
+      tx: db(),
+      deliveryId: randomUUID(),
+      payload: rawPayload,
+      rawPayload,
+      ...handlers,
+    });
+
+    expect(result.outcome).toBe('unsupported-event');
+    expect(handlers.publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(handlers.recordDeliveryOnly).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/api/integration/linear/src/core/webhook.ts
+++ b/libs/api/integration/linear/src/core/webhook.ts
@@ -1,0 +1,139 @@
+import type {
+  GetIntegrationConnectionByIdFn,
+  IntegrationTx,
+  PublishIntegrationEventReceivedFn,
+  RecordDeliveryOnlyFn,
+} from '@shipfox/api-integration-core-dto';
+import {
+  LINEAR_PROVIDER,
+  type LinearWebhookBaseEnvelopeDto,
+  linearWebhookEnvelopeSchema,
+} from '@shipfox/api-integration-linear-dto';
+import {logger} from '@shipfox/node-opentelemetry';
+import {getLinearInstallationByOrganizationId} from '#db/installations.js';
+
+export interface HandleLinearWebhookParams {
+  tx: IntegrationTx;
+  deliveryId: string;
+  payload: LinearWebhookBaseEnvelopeDto;
+  rawPayload: unknown;
+  publishIntegrationEventReceived: PublishIntegrationEventReceivedFn;
+  recordDeliveryOnly: RecordDeliveryOnlyFn;
+  getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
+}
+
+export type HandleLinearWebhookOutcome =
+  | 'published'
+  | 'duplicate'
+  | 'unknown-organization'
+  | 'revoked-installation'
+  | 'missing-connection'
+  | 'inactive-connection'
+  | 'unsupported-event';
+
+export async function handleLinearWebhook(
+  params: HandleLinearWebhookParams,
+): Promise<{outcome: HandleLinearWebhookOutcome}> {
+  const installation = await getLinearInstallationByOrganizationId(params.payload.organizationId, {
+    tx: params.tx,
+  });
+  if (!installation) {
+    logger().warn(
+      {deliveryId: params.deliveryId, organizationId: params.payload.organizationId},
+      'linear webhook: unknown organization, dropping',
+    );
+    await recordDeliveryOnly(params);
+    return {outcome: 'unknown-organization'};
+  }
+
+  if (installation.status !== 'installed') {
+    logger().info(
+      {
+        deliveryId: params.deliveryId,
+        organizationId: params.payload.organizationId,
+        connectionId: installation.connectionId,
+        status: installation.status,
+      },
+      'linear webhook: installation is not installed, dropping',
+    );
+    await recordDeliveryOnly(params);
+    return {outcome: 'revoked-installation'};
+  }
+
+  const connection = await params.getIntegrationConnectionById(installation.connectionId, {
+    tx: params.tx,
+  });
+  if (!connection) {
+    logger().warn(
+      {
+        deliveryId: params.deliveryId,
+        organizationId: params.payload.organizationId,
+        connectionId: installation.connectionId,
+      },
+      'linear webhook: installation has no connection, dropping',
+    );
+    await recordDeliveryOnly(params);
+    return {outcome: 'missing-connection'};
+  }
+
+  if (connection.lifecycleStatus !== 'active') {
+    const logContext = {
+      deliveryId: params.deliveryId,
+      organizationId: params.payload.organizationId,
+      connectionId: connection.id,
+      workspaceId: connection.workspaceId,
+      lifecycleStatus: connection.lifecycleStatus,
+    };
+    if (connection.lifecycleStatus === 'error') {
+      logger().warn(logContext, 'linear webhook: connection in error state, dropping');
+    } else {
+      logger().info(logContext, 'linear webhook: connection disabled, dropping');
+    }
+    await recordDeliveryOnly(params);
+    return {outcome: 'inactive-connection'};
+  }
+
+  const supported = linearWebhookEnvelopeSchema.safeParse(params.payload);
+  if (!supported.success) {
+    logger().info(
+      {
+        deliveryId: params.deliveryId,
+        organizationId: params.payload.organizationId,
+        type: params.payload.type,
+        action: params.payload.action,
+      },
+      'linear webhook: unsupported event, dropping',
+    );
+    await recordDeliveryOnly(params);
+    return {outcome: 'unsupported-event'};
+  }
+
+  const result = await params.publishIntegrationEventReceived({
+    tx: params.tx,
+    event: {
+      provider: LINEAR_PROVIDER,
+      source: connection.slug,
+      event: `${supported.data.type}.${supported.data.action}`,
+      workspaceId: connection.workspaceId,
+      connectionId: connection.id,
+      connectionName: connection.displayName,
+      deliveryId: params.deliveryId,
+      receivedAt: new Date().toISOString(),
+      payload: params.rawPayload,
+    },
+  });
+
+  return {outcome: result.published ? 'published' : 'duplicate'};
+}
+
+async function recordDeliveryOnly(params: {
+  tx: IntegrationTx;
+  deliveryId: string;
+  recordDeliveryOnly: RecordDeliveryOnlyFn;
+}): Promise<void> {
+  await params.recordDeliveryOnly({
+    tx: params.tx,
+    provider: LINEAR_PROVIDER,
+    deliveryId: params.deliveryId,
+  });
+}

--- a/libs/api/integration/linear/src/index.ts
+++ b/libs/api/integration/linear/src/index.ts
@@ -8,6 +8,10 @@ import {
   type CreateLinearIntegrationRoutesOptions,
   createLinearIntegrationRoutes,
 } from '#presentation/routes/install.js';
+import {
+  type CreateLinearWebhookRoutesOptions,
+  createLinearWebhookRoutes,
+} from '#presentation/routes/webhooks.js';
 
 export type {LinearProvider} from '@shipfox/api-integration-linear-dto';
 export type {LinearApiClient, LinearAuthorization, LinearIdentity} from '#api/client.js';
@@ -59,6 +63,8 @@ export {
   createLinearTokenStore,
   linearSecretsNamespace,
 } from '#core/tokens.js';
+export type {HandleLinearWebhookOutcome, HandleLinearWebhookParams} from '#core/webhook.js';
+export {handleLinearWebhook} from '#core/webhook.js';
 export type {
   LinearInstallation,
   LinearInstallationStatus,
@@ -78,7 +84,10 @@ export {closeDb, config, db, migrationsPath};
 export interface CreateLinearIntegrationProviderOptions {
   linear?: LinearApiClient | undefined;
   getLinearInstallationByConnectionId?: typeof getLinearInstallationByConnectionId | undefined;
-  routes?: Omit<CreateLinearIntegrationRoutesOptions, 'linear'> | undefined;
+  routes?:
+    | (Omit<CreateLinearIntegrationRoutesOptions, 'linear'> &
+        Partial<CreateLinearWebhookRoutesOptions>)
+    | undefined;
 }
 
 export function createLinearIntegrationProvider(
@@ -87,6 +96,18 @@ export function createLinearIntegrationProvider(
   const linear = options.linear ?? createLinearApiClient();
   const getInstallationByConnectionId =
     options.getLinearInstallationByConnectionId ?? getLinearInstallationByConnectionId;
+
+  const routes = options.routes
+    ? [
+        createLinearIntegrationRoutes({
+          linear,
+          ...options.routes,
+        }),
+      ]
+    : [];
+  if (options.routes && hasLinearWebhookRoutesOptions(options.routes)) {
+    routes.push(createLinearWebhookRoutes(options.routes));
+  }
 
   return {
     provider: LINEAR_PROVIDER,
@@ -97,13 +118,17 @@ export function createLinearIntegrationProvider(
       if (!installation?.organizationUrlKey) return undefined;
       return `https://linear.app/${encodeURIComponent(installation.organizationUrlKey)}/settings`;
     },
-    routes: options.routes
-      ? [
-          createLinearIntegrationRoutes({
-            linear,
-            ...options.routes,
-          }),
-        ]
-      : [],
+    routes,
   };
+}
+
+function hasLinearWebhookRoutesOptions(
+  routes: Partial<CreateLinearWebhookRoutesOptions>,
+): routes is CreateLinearWebhookRoutesOptions {
+  return (
+    routes.coreDb !== undefined &&
+    routes.publishIntegrationEventReceived !== undefined &&
+    routes.recordDeliveryOnly !== undefined &&
+    routes.getIntegrationConnectionById !== undefined
+  );
 }

--- a/libs/api/integration/linear/src/presentation/routes/webhooks.test.ts
+++ b/libs/api/integration/linear/src/presentation/routes/webhooks.test.ts
@@ -1,4 +1,4 @@
-import {createHmac, randomUUID} from 'node:crypto';
+import {createHash, createHmac, randomUUID} from 'node:crypto';
 import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
 import {closeApp, createApp} from '@shipfox/node-fastify';
 import type {FastifyInstance} from 'fastify';
@@ -43,6 +43,10 @@ function signedHeaders(rawBody: string, event: string, deliveryId: string) {
     'linear-event': event,
     'linear-signature': signature,
   };
+}
+
+function signedBodyDeliveryId(rawBody: string) {
+  return createHash('sha256').update(rawBody).digest('hex');
 }
 
 interface TestApp {
@@ -123,10 +127,37 @@ describe('Linear webhook route', () => {
         workspaceId: connection.workspaceId,
         connectionId: connection.id,
         connectionName: connection.displayName,
-        deliveryId,
+        deliveryId: signedBodyDeliveryId(body),
         payload: rawPayload,
       },
     });
+  });
+
+  it('uses the signed body digest as the delivery dedup key', async () => {
+    const connection = fakeConnection();
+    const {app, publishIntegrationEventReceived} = await createTestApp({connection});
+    const rawPayload = linearPayload({organizationId: 'org-dedup'});
+    await seedInstallation({connectionId: connection.id, organizationId: 'org-dedup'});
+    const body = JSON.stringify(rawPayload);
+
+    const first = await app.inject({
+      method: 'POST',
+      url: '/webhooks/integrations/linear',
+      headers: signedHeaders(body, 'Issue', 'unsigned-delivery-a'),
+      payload: body,
+    });
+    const second = await app.inject({
+      method: 'POST',
+      url: '/webhooks/integrations/linear',
+      headers: signedHeaders(body, 'Issue', 'unsigned-delivery-b'),
+      payload: body,
+    });
+
+    expect(first.statusCode).toBe(200);
+    expect(second.statusCode).toBe(200);
+    expect(
+      publishIntegrationEventReceived.mock.calls.map(([call]) => call.event.deliveryId),
+    ).toEqual([signedBodyDeliveryId(body), signedBodyDeliveryId(body)]);
   });
 
   it.each([
@@ -235,7 +266,7 @@ describe('Linear webhook route', () => {
     expect(getIntegrationConnectionById).not.toHaveBeenCalled();
     expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
     expect(recordDeliveryOnly).toHaveBeenCalledWith(
-      expect.objectContaining({provider: 'linear', deliveryId}),
+      expect.objectContaining({provider: 'linear', deliveryId: signedBodyDeliveryId(body)}),
     );
   });
 
@@ -258,7 +289,7 @@ describe('Linear webhook route', () => {
     expect(res.statusCode).toBe(200);
     expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
     expect(recordDeliveryOnly).toHaveBeenCalledWith(
-      expect.objectContaining({provider: 'linear', deliveryId}),
+      expect.objectContaining({provider: 'linear', deliveryId: signedBodyDeliveryId(body)}),
     );
   });
 });

--- a/libs/api/integration/linear/src/presentation/routes/webhooks.test.ts
+++ b/libs/api/integration/linear/src/presentation/routes/webhooks.test.ts
@@ -1,0 +1,264 @@
+import {createHmac, randomUUID} from 'node:crypto';
+import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
+import {closeApp, createApp} from '@shipfox/node-fastify';
+import type {FastifyInstance} from 'fastify';
+import {db} from '#db/db.js';
+import {upsertLinearInstallation} from '#db/installations.js';
+import {linearInstallations} from '#db/schema/installations.js';
+import {createLinearWebhookRoutes} from './webhooks.js';
+
+const WEBHOOK_SECRET = 'test-webhook-secret';
+
+function fakeConnection(overrides: Partial<IntegrationConnection> = {}): IntegrationConnection {
+  return {
+    id: randomUUID(),
+    workspaceId: randomUUID(),
+    provider: 'linear',
+    externalAccountId: 'org-1',
+    slug: 'Linear_Acme',
+    displayName: 'Linear Acme',
+    lifecycleStatus: 'active',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function linearPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    action: 'create',
+    type: 'Issue',
+    organizationId: `org-${randomUUID()}`,
+    webhookTimestamp: Date.now(),
+    data: {id: 'issue-1'},
+    ...overrides,
+  };
+}
+
+function signedHeaders(rawBody: string, event: string, deliveryId: string) {
+  const signature = createHmac('sha256', WEBHOOK_SECRET).update(rawBody).digest('hex');
+  return {
+    'content-type': 'application/json',
+    'linear-delivery': deliveryId,
+    'linear-event': event,
+    'linear-signature': signature,
+  };
+}
+
+interface TestApp {
+  app: FastifyInstance;
+  publishIntegrationEventReceived: ReturnType<typeof vi.fn>;
+  recordDeliveryOnly: ReturnType<typeof vi.fn>;
+  getIntegrationConnectionById: ReturnType<typeof vi.fn>;
+}
+
+async function createTestApp(
+  options: {connection?: IntegrationConnection | undefined} = {},
+): Promise<TestApp> {
+  const publishIntegrationEventReceived = vi.fn(() => Promise.resolve({published: true}));
+  const recordDeliveryOnly = vi.fn(() => Promise.resolve());
+  const getIntegrationConnectionById = vi.fn(() =>
+    Promise.resolve(options.connection ?? fakeConnection()),
+  );
+  const routes = createLinearWebhookRoutes({
+    coreDb: db,
+    publishIntegrationEventReceived,
+    recordDeliveryOnly,
+    getIntegrationConnectionById,
+  });
+  const app = await createApp({routes: [routes], swagger: false});
+  await app.ready();
+  return {app, publishIntegrationEventReceived, recordDeliveryOnly, getIntegrationConnectionById};
+}
+
+async function seedInstallation(input: {
+  connectionId: string;
+  organizationId: string;
+}): Promise<void> {
+  await upsertLinearInstallation({
+    connectionId: input.connectionId,
+    organizationId: input.organizationId,
+    organizationUrlKey: 'acme',
+    appUserId: 'app-user-1',
+    scopes: ['read', 'write'],
+    status: 'installed',
+  });
+}
+
+describe('Linear webhook route', () => {
+  beforeEach(async () => {
+    await closeApp();
+    await db().delete(linearInstallations);
+  });
+
+  afterEach(async () => {
+    await closeApp();
+  });
+
+  it('publishes a supported signed data webhook', async () => {
+    const connection = fakeConnection();
+    const {app, publishIntegrationEventReceived, recordDeliveryOnly} = await createTestApp({
+      connection,
+    });
+    const deliveryId = randomUUID();
+    const rawPayload = linearPayload({organizationId: 'org-active'});
+    await seedInstallation({connectionId: connection.id, organizationId: 'org-active'});
+    const body = JSON.stringify(rawPayload);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/integrations/linear',
+      headers: signedHeaders(body, 'Issue', deliveryId),
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(recordDeliveryOnly).not.toHaveBeenCalled();
+    expect(publishIntegrationEventReceived).toHaveBeenCalledTimes(1);
+    expect(publishIntegrationEventReceived.mock.calls[0]?.[0]).toMatchObject({
+      event: {
+        provider: 'linear',
+        source: connection.slug,
+        event: 'Issue.create',
+        workspaceId: connection.workspaceId,
+        connectionId: connection.id,
+        connectionName: connection.displayName,
+        deliveryId,
+        payload: rawPayload,
+      },
+    });
+  });
+
+  it.each([
+    ['linear-delivery', 'missing Linear-Delivery header'],
+    ['linear-event', 'missing Linear-Event header'],
+    ['linear-signature', 'missing Linear-Signature header'],
+  ])('rejects requests missing the %s header', async (headerName, error) => {
+    const {app, publishIntegrationEventReceived, recordDeliveryOnly} = await createTestApp();
+    const body = JSON.stringify(linearPayload());
+    const headers = signedHeaders(body, 'Issue', randomUUID());
+    delete headers[headerName as keyof typeof headers];
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/integrations/linear',
+      headers,
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(headerName === 'linear-signature' ? 401 : 400);
+    expect(res.json()).toEqual({error});
+    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(recordDeliveryOnly).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid signature before publishing or recording', async () => {
+    const {app, publishIntegrationEventReceived, recordDeliveryOnly} = await createTestApp();
+    const body = JSON.stringify(linearPayload());
+    const headers = signedHeaders(body, 'Issue', randomUUID());
+    headers['linear-signature'] = 'bad-signature';
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/integrations/linear',
+      headers,
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(recordDeliveryOnly).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed JSON after signature verification', async () => {
+    const {app, publishIntegrationEventReceived, recordDeliveryOnly} = await createTestApp();
+    const body = '{"type":';
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/integrations/linear',
+      headers: signedHeaders(body, 'Issue', randomUUID()),
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(recordDeliveryOnly).not.toHaveBeenCalled();
+  });
+
+  it('rejects stale webhook timestamps before publishing or recording', async () => {
+    const {app, publishIntegrationEventReceived, recordDeliveryOnly} = await createTestApp();
+    const body = JSON.stringify(linearPayload({webhookTimestamp: Date.now() - 61_000}));
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/integrations/linear',
+      headers: signedHeaders(body, 'Issue', randomUUID()),
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(recordDeliveryOnly).not.toHaveBeenCalled();
+  });
+
+  it('rejects a Linear-Event header that disagrees with the signed payload type', async () => {
+    const {app, publishIntegrationEventReceived, recordDeliveryOnly} = await createTestApp();
+    const body = JSON.stringify(linearPayload({type: 'Issue'}));
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/integrations/linear',
+      headers: signedHeaders(body, 'Comment', randomUUID()),
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(recordDeliveryOnly).not.toHaveBeenCalled();
+  });
+
+  it('records and drops a signed webhook for an unknown organization', async () => {
+    const {app, publishIntegrationEventReceived, recordDeliveryOnly, getIntegrationConnectionById} =
+      await createTestApp();
+    const deliveryId = randomUUID();
+    const body = JSON.stringify(linearPayload({organizationId: 'org-missing'}));
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/integrations/linear',
+      headers: signedHeaders(body, 'Issue', deliveryId),
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(getIntegrationConnectionById).not.toHaveBeenCalled();
+    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(recordDeliveryOnly).toHaveBeenCalledWith(
+      expect.objectContaining({provider: 'linear', deliveryId}),
+    );
+  });
+
+  it('records and drops signed unsupported resource events', async () => {
+    const connection = fakeConnection();
+    const {app, publishIntegrationEventReceived, recordDeliveryOnly} = await createTestApp({
+      connection,
+    });
+    const deliveryId = randomUUID();
+    await seedInstallation({connectionId: connection.id, organizationId: 'org-reaction'});
+    const body = JSON.stringify(linearPayload({organizationId: 'org-reaction', type: 'Reaction'}));
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/integrations/linear',
+      headers: signedHeaders(body, 'Reaction', deliveryId),
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(recordDeliveryOnly).toHaveBeenCalledWith(
+      expect.objectContaining({provider: 'linear', deliveryId}),
+    );
+  });
+});

--- a/libs/api/integration/linear/src/presentation/routes/webhooks.test.ts
+++ b/libs/api/integration/linear/src/presentation/routes/webhooks.test.ts
@@ -1,4 +1,4 @@
-import {createHash, createHmac, randomUUID} from 'node:crypto';
+import {createHmac, randomUUID} from 'node:crypto';
 import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
 import {closeApp, createApp} from '@shipfox/node-fastify';
 import type {FastifyInstance} from 'fastify';
@@ -43,10 +43,6 @@ function signedHeaders(rawBody: string, event: string, deliveryId: string) {
     'linear-event': event,
     'linear-signature': signature,
   };
-}
-
-function signedBodyDeliveryId(rawBody: string) {
-  return createHash('sha256').update(rawBody).digest('hex');
 }
 
 interface TestApp {
@@ -127,13 +123,13 @@ describe('Linear webhook route', () => {
         workspaceId: connection.workspaceId,
         connectionId: connection.id,
         connectionName: connection.displayName,
-        deliveryId: signedBodyDeliveryId(body),
+        deliveryId,
         payload: rawPayload,
       },
     });
   });
 
-  it('uses the signed body digest as the delivery dedup key', async () => {
+  it('uses the Linear-Delivery header as the delivery dedup key', async () => {
     const connection = fakeConnection();
     const {app, publishIntegrationEventReceived} = await createTestApp({connection});
     const rawPayload = linearPayload({organizationId: 'org-dedup'});
@@ -143,13 +139,13 @@ describe('Linear webhook route', () => {
     const first = await app.inject({
       method: 'POST',
       url: '/webhooks/integrations/linear',
-      headers: signedHeaders(body, 'Issue', 'unsigned-delivery-a'),
+      headers: signedHeaders(body, 'Issue', 'linear-delivery-a'),
       payload: body,
     });
     const second = await app.inject({
       method: 'POST',
       url: '/webhooks/integrations/linear',
-      headers: signedHeaders(body, 'Issue', 'unsigned-delivery-b'),
+      headers: signedHeaders(body, 'Issue', 'linear-delivery-b'),
       payload: body,
     });
 
@@ -157,7 +153,7 @@ describe('Linear webhook route', () => {
     expect(second.statusCode).toBe(200);
     expect(
       publishIntegrationEventReceived.mock.calls.map(([call]) => call.event.deliveryId),
-    ).toEqual([signedBodyDeliveryId(body), signedBodyDeliveryId(body)]);
+    ).toEqual(['linear-delivery-a', 'linear-delivery-b']);
   });
 
   it.each([
@@ -217,6 +213,33 @@ describe('Linear webhook route', () => {
     expect(recordDeliveryOnly).not.toHaveBeenCalled();
   });
 
+  it('records and drops signed JSON that does not match the base webhook envelope', async () => {
+    const {app, publishIntegrationEventReceived, recordDeliveryOnly, getIntegrationConnectionById} =
+      await createTestApp();
+    const deliveryId = randomUUID();
+    const body = JSON.stringify({
+      action: 'create',
+      type: 'AppUserNotification',
+      organizationId: 'org-notification',
+      webhookTimestamp: Date.now(),
+      notification: {id: 'notification-1'},
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/integrations/linear',
+      headers: signedHeaders(body, 'AppUserNotification', deliveryId),
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(getIntegrationConnectionById).not.toHaveBeenCalled();
+    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(recordDeliveryOnly).toHaveBeenCalledWith(
+      expect.objectContaining({provider: 'linear', deliveryId}),
+    );
+  });
+
   it('rejects stale webhook timestamps before publishing or recording', async () => {
     const {app, publishIntegrationEventReceived, recordDeliveryOnly} = await createTestApp();
     const body = JSON.stringify(linearPayload({webhookTimestamp: Date.now() - 61_000}));
@@ -233,20 +256,39 @@ describe('Linear webhook route', () => {
     expect(recordDeliveryOnly).not.toHaveBeenCalled();
   });
 
-  it('rejects a Linear-Event header that disagrees with the signed payload type', async () => {
+  it('rejects future webhook timestamps before publishing or recording', async () => {
     const {app, publishIntegrationEventReceived, recordDeliveryOnly} = await createTestApp();
+    const body = JSON.stringify(linearPayload({webhookTimestamp: Date.now() + 61_000}));
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/integrations/linear',
+      headers: signedHeaders(body, 'Issue', randomUUID()),
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(recordDeliveryOnly).not.toHaveBeenCalled();
+  });
+
+  it('records and drops when the Linear-Event header disagrees with the signed payload type', async () => {
+    const {app, publishIntegrationEventReceived, recordDeliveryOnly} = await createTestApp();
+    const deliveryId = randomUUID();
     const body = JSON.stringify(linearPayload({type: 'Issue'}));
 
     const res = await app.inject({
       method: 'POST',
       url: '/webhooks/integrations/linear',
-      headers: signedHeaders(body, 'Comment', randomUUID()),
+      headers: signedHeaders(body, 'Comment', deliveryId),
       payload: body,
     });
 
-    expect(res.statusCode).toBe(400);
+    expect(res.statusCode).toBe(200);
     expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
-    expect(recordDeliveryOnly).not.toHaveBeenCalled();
+    expect(recordDeliveryOnly).toHaveBeenCalledWith(
+      expect.objectContaining({provider: 'linear', deliveryId}),
+    );
   });
 
   it('records and drops a signed webhook for an unknown organization', async () => {
@@ -266,7 +308,7 @@ describe('Linear webhook route', () => {
     expect(getIntegrationConnectionById).not.toHaveBeenCalled();
     expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
     expect(recordDeliveryOnly).toHaveBeenCalledWith(
-      expect.objectContaining({provider: 'linear', deliveryId: signedBodyDeliveryId(body)}),
+      expect.objectContaining({provider: 'linear', deliveryId}),
     );
   });
 
@@ -289,7 +331,7 @@ describe('Linear webhook route', () => {
     expect(res.statusCode).toBe(200);
     expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
     expect(recordDeliveryOnly).toHaveBeenCalledWith(
-      expect.objectContaining({provider: 'linear', deliveryId: signedBodyDeliveryId(body)}),
+      expect.objectContaining({provider: 'linear', deliveryId}),
     );
   });
 });

--- a/libs/api/integration/linear/src/presentation/routes/webhooks.ts
+++ b/libs/api/integration/linear/src/presentation/routes/webhooks.ts
@@ -1,4 +1,5 @@
 import {Buffer} from 'node:buffer';
+import {createHash} from 'node:crypto';
 import type {
   GetIntegrationConnectionByIdFn,
   PublishIntegrationEventReceivedFn,
@@ -101,10 +102,11 @@ export function createLinearWebhookRoutes(options: CreateLinearWebhookRoutesOpti
         return {error: 'stale webhook timestamp'};
       }
 
+      const signedBodyDeliveryId = createHash('sha256').update(rawBody).digest('hex');
       await options.coreDb().transaction(async (tx) => {
         await handleLinearWebhook({
           tx,
-          deliveryId,
+          deliveryId: signedBodyDeliveryId,
           payload: payload.data,
           rawPayload: parsedJson,
           publishIntegrationEventReceived: options.publishIntegrationEventReceived,

--- a/libs/api/integration/linear/src/presentation/routes/webhooks.ts
+++ b/libs/api/integration/linear/src/presentation/routes/webhooks.ts
@@ -1,0 +1,127 @@
+import {Buffer} from 'node:buffer';
+import type {
+  GetIntegrationConnectionByIdFn,
+  PublishIntegrationEventReceivedFn,
+  RecordDeliveryOnlyFn,
+} from '@shipfox/api-integration-core-dto';
+import {linearWebhookBaseEnvelopeSchema} from '@shipfox/api-integration-linear-dto';
+import {
+  defineRoute,
+  type RouteGroup,
+  rawBodyPlugin,
+  verifyHexHmacSignature,
+  WEBHOOK_BODY_LIMIT,
+} from '@shipfox/node-fastify';
+import {logger} from '@shipfox/node-opentelemetry';
+import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
+import {config} from '#config.js';
+import {handleLinearWebhook} from '#core/webhook.js';
+
+const DELIVERY_HEADER = 'linear-delivery';
+const EVENT_HEADER = 'linear-event';
+const SIGNATURE_HEADER = 'linear-signature';
+const WEBHOOK_REPLAY_WINDOW_MS = 60_000;
+
+export interface CreateLinearWebhookRoutesOptions {
+  coreDb: () => NodePgDatabase<Record<string, unknown>>;
+  publishIntegrationEventReceived: PublishIntegrationEventReceivedFn;
+  recordDeliveryOnly: RecordDeliveryOnlyFn;
+  getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
+}
+
+export function createLinearWebhookRoutes(options: CreateLinearWebhookRoutesOptions): RouteGroup {
+  const webhookRoute = defineRoute({
+    method: 'POST',
+    path: '/',
+    auth: [],
+    description: 'Linear webhook receiver.',
+    options: {bodyLimit: WEBHOOK_BODY_LIMIT},
+    handler: async (request, reply) => {
+      const deliveryId = request.headers[DELIVERY_HEADER];
+      const event = request.headers[EVENT_HEADER];
+      const signature = request.headers[SIGNATURE_HEADER];
+
+      if (typeof deliveryId !== 'string' || !deliveryId) {
+        reply.code(400);
+        return {error: 'missing Linear-Delivery header'};
+      }
+      if (typeof event !== 'string' || !event) {
+        reply.code(400);
+        return {error: 'missing Linear-Event header'};
+      }
+      if (typeof signature !== 'string' || !signature) {
+        reply.code(401);
+        return {error: 'missing Linear-Signature header'};
+      }
+
+      const body = request.body;
+      if (!Buffer.isBuffer(body)) {
+        reply.code(400);
+        return {error: 'expected raw JSON body'};
+      }
+      const rawBody = body.toString('utf8');
+
+      if (
+        !verifyHexHmacSignature({
+          rawBody,
+          signature,
+          secret: config.LINEAR_WEBHOOK_SIGNING_SECRET,
+        })
+      ) {
+        reply.code(401);
+        return {error: 'invalid signature'};
+      }
+
+      let parsedJson: unknown;
+      try {
+        parsedJson = JSON.parse(rawBody);
+      } catch (error) {
+        logger().warn({deliveryId, err: error}, 'linear webhook payload JSON parse failed');
+        reply.code(400);
+        return {error: 'malformed JSON'};
+      }
+
+      const payload = linearWebhookBaseEnvelopeSchema.safeParse(parsedJson);
+      if (!payload.success) {
+        logger().warn(
+          {deliveryId, issues: payload.error.issues},
+          'linear webhook envelope failed schema validation',
+        );
+        reply.code(400);
+        return {error: 'malformed webhook payload'};
+      }
+
+      if (event !== payload.data.type) {
+        reply.code(400);
+        return {error: 'Linear-Event header does not match payload type'};
+      }
+
+      if (Math.abs(Date.now() - payload.data.webhookTimestamp) > WEBHOOK_REPLAY_WINDOW_MS) {
+        reply.code(401);
+        return {error: 'stale webhook timestamp'};
+      }
+
+      await options.coreDb().transaction(async (tx) => {
+        await handleLinearWebhook({
+          tx,
+          deliveryId,
+          payload: payload.data,
+          rawPayload: parsedJson,
+          publishIntegrationEventReceived: options.publishIntegrationEventReceived,
+          recordDeliveryOnly: options.recordDeliveryOnly,
+          getIntegrationConnectionById: options.getIntegrationConnectionById,
+        });
+      });
+
+      reply.code(200);
+      return null;
+    },
+  });
+
+  return {
+    prefix: '/webhooks/integrations/linear',
+    auth: [],
+    plugins: [rawBodyPlugin],
+    routes: [webhookRoute],
+  };
+}

--- a/libs/api/integration/linear/src/presentation/routes/webhooks.ts
+++ b/libs/api/integration/linear/src/presentation/routes/webhooks.ts
@@ -1,11 +1,14 @@
 import {Buffer} from 'node:buffer';
-import {createHash} from 'node:crypto';
 import type {
   GetIntegrationConnectionByIdFn,
+  IntegrationTx,
   PublishIntegrationEventReceivedFn,
   RecordDeliveryOnlyFn,
 } from '@shipfox/api-integration-core-dto';
-import {linearWebhookBaseEnvelopeSchema} from '@shipfox/api-integration-linear-dto';
+import {
+  LINEAR_PROVIDER,
+  linearWebhookBaseEnvelopeSchema,
+} from '@shipfox/api-integration-linear-dto';
 import {
   defineRoute,
   type RouteGroup,
@@ -38,11 +41,11 @@ export function createLinearWebhookRoutes(options: CreateLinearWebhookRoutesOpti
     description: 'Linear webhook receiver.',
     options: {bodyLimit: WEBHOOK_BODY_LIMIT},
     handler: async (request, reply) => {
-      const deliveryId = request.headers[DELIVERY_HEADER];
+      const deliveryHeader = request.headers[DELIVERY_HEADER];
       const event = request.headers[EVENT_HEADER];
       const signature = request.headers[SIGNATURE_HEADER];
 
-      if (typeof deliveryId !== 'string' || !deliveryId) {
+      if (typeof deliveryHeader !== 'string' || !deliveryHeader) {
         reply.code(400);
         return {error: 'missing Linear-Delivery header'};
       }
@@ -77,7 +80,10 @@ export function createLinearWebhookRoutes(options: CreateLinearWebhookRoutesOpti
       try {
         parsedJson = JSON.parse(rawBody);
       } catch (error) {
-        logger().warn({deliveryId, err: error}, 'linear webhook payload JSON parse failed');
+        logger().warn(
+          {deliveryId: deliveryHeader, err: error},
+          'linear webhook payload JSON parse failed',
+        );
         reply.code(400);
         return {error: 'malformed JSON'};
       }
@@ -85,16 +91,12 @@ export function createLinearWebhookRoutes(options: CreateLinearWebhookRoutesOpti
       const payload = linearWebhookBaseEnvelopeSchema.safeParse(parsedJson);
       if (!payload.success) {
         logger().warn(
-          {deliveryId, issues: payload.error.issues},
+          {deliveryId: deliveryHeader, issues: payload.error.issues},
           'linear webhook envelope failed schema validation',
         );
-        reply.code(400);
-        return {error: 'malformed webhook payload'};
-      }
-
-      if (event !== payload.data.type) {
-        reply.code(400);
-        return {error: 'Linear-Event header does not match payload type'};
+        await recordSignedDeliveryOnly(options, deliveryHeader);
+        reply.code(200);
+        return null;
       }
 
       if (Math.abs(Date.now() - payload.data.webhookTimestamp) > WEBHOOK_REPLAY_WINDOW_MS) {
@@ -102,11 +104,21 @@ export function createLinearWebhookRoutes(options: CreateLinearWebhookRoutesOpti
         return {error: 'stale webhook timestamp'};
       }
 
-      const signedBodyDeliveryId = createHash('sha256').update(rawBody).digest('hex');
+      if (event !== payload.data.type) {
+        logger().warn(
+          {deliveryId: deliveryHeader, event, type: payload.data.type},
+          'linear webhook event header did not match payload type',
+        );
+        await recordSignedDeliveryOnly(options, deliveryHeader);
+        reply.code(200);
+        return null;
+      }
+
       await options.coreDb().transaction(async (tx) => {
         await handleLinearWebhook({
           tx,
-          deliveryId: signedBodyDeliveryId,
+          // Linear documents this header as the delivery UUID; the signed timestamp is per-send.
+          deliveryId: deliveryHeader,
           payload: payload.data,
           rawPayload: parsedJson,
           publishIntegrationEventReceived: options.publishIntegrationEventReceived,
@@ -126,4 +138,17 @@ export function createLinearWebhookRoutes(options: CreateLinearWebhookRoutesOpti
     plugins: [rawBodyPlugin],
     routes: [webhookRoute],
   };
+}
+
+async function recordSignedDeliveryOnly(
+  options: Pick<CreateLinearWebhookRoutesOptions, 'coreDb' | 'recordDeliveryOnly'>,
+  deliveryId: string,
+): Promise<void> {
+  await options.coreDb().transaction(async (tx: IntegrationTx) => {
+    await options.recordDeliveryOnly({
+      tx,
+      provider: LINEAR_PROVIDER,
+      deliveryId,
+    });
+  });
 }

--- a/libs/api/triggers/src/core/dispatch-integration-event.test.ts
+++ b/libs/api/triggers/src/core/dispatch-integration-event.test.ts
@@ -158,6 +158,52 @@ describe('dispatchIntegrationEvent', () => {
     );
   });
 
+  test('dispatches a Linear data webhook event to a matching trigger subscription', async () => {
+    const workspaceId = crypto.randomUUID();
+    const deliveryId = crypto.randomUUID();
+    const payload = {
+      action: 'create',
+      type: 'Issue',
+      organizationId: 'linear-org-id',
+      webhookTimestamp: Date.now(),
+      data: {
+        id: 'issue-id',
+        identifier: 'ENG-876',
+        title: 'Receive and verify Linear webhooks',
+      },
+    };
+    const subscription = await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'Linear_Acme',
+      event: 'Issue.create',
+      config: {},
+    });
+
+    await dispatch({
+      provider: 'linear',
+      workspaceId,
+      source: 'Linear_Acme',
+      event: 'Issue.create',
+      deliveryId,
+      payload,
+    });
+
+    expect(runWorkflow).toHaveBeenCalledTimes(1);
+    expect(runWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: subscription.projectId,
+        definitionId: subscription.workflowDefinitionId,
+        triggerPayload: {
+          provider: 'linear',
+          source: 'Linear_Acme',
+          event: 'Issue.create',
+          deliveryId,
+          data: payload,
+        },
+      }),
+    );
+  });
+
   test('routes webhook events only when workspace, source, and received event match', async () => {
     const workspaceId = crypto.randomUUID();
     const matching = await triggerSubscriptionFactory.create({


### PR DESCRIPTION
Adds a signed Linear webhook receiver that verifies incoming deliveries, maps supported Linear data webhooks into the existing `integrations.event.received` pipeline, and records unsupported or inactive delivery cases without dispatching workflows.

Linear trigger support needs to reuse the source-agnostic integration event dispatcher rather than add provider-specific trigger code. This keeps the new receiver layered in the Linear provider while integration core continues to own delivery dedup, outbox publishing, and connection lookup injection.

The trigger acceptance coverage lives in `@shipfox/api-triggers` instead of importing triggers or workflows from the Linear package, avoiding a package dependency cycle while proving a Linear `Issue.create` event reaches `runWorkflow` with the expected payload.

Closes ENG-876

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a signed Linear webhook receiver that verifies HMAC, validates envelopes, uses Linear’s delivery UUID for idempotency, and publishes supported data events through the existing integration event pipeline. Unknown orgs, inactive/missing connections, header/type mismatches, and unsupported resources are recorded as delivery-only with a 200 response, meeting ENG-876.

- **New Features**
  - Adds POST `/webhooks/integrations/linear` using `@shipfox/node-fastify` raw body + HMAC (SHA‑256) with `LINEAR_WEBHOOK_SIGNING_SECRET`; requires `Linear-Delivery`, `Linear-Event`, `Linear-Signature`; rejects invalid signatures, malformed JSON, header/type mismatches, and webhook timestamps with >60s drift (past or future).
  - Uses `Linear-Delivery` as the delivery id for idempotency/deduplication.
  - Supports `Issue`, `Comment`, `IssueLabel`, `Project`, `Cycle` with `create|update|remove`; emits `Issue.create`-style events via `publishIntegrationEventReceived`.
  - Tightens DTO validation: rejects non-object `data` for supported events; accepts base envelopes for record‑and‑drop handling.
  - Reuses the core integration dispatcher for dedup/outbox and connection lookup; records-and-drops for unknown organization, revoked/missing/inactive connection, unsupported events, or invalid base envelopes (200 so Linear doesn’t retry).
  - Exposes `handleLinearWebhook`, `createLinearWebhookRoutes`, and schemas (`linearWebhookEnvelopeSchema`, `linearWebhookBaseEnvelopeSchema`, `linearWebhookEventNames`) in `@shipfox/api-integration-linear-dto`; `createLinearIntegrationProvider` wires routes when provided `coreDb`, `publishIntegrationEventReceived`, `recordDeliveryOnly`, and `getIntegrationConnectionById`.

<sup>Written for commit a970cc106def55510d0c593872dbe8f590bdc821. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

