### PR TITLE
[api/integration] Add tool call audit metrics

### DIFF
--- a/libs/api/integration/core/src/metrics/index.ts
+++ b/libs/api/integration/core/src/metrics/index.ts
@@ -1,0 +1,1 @@
+export * from './instance.js';

--- a/libs/api/integration/core/src/metrics/instance.ts
+++ b/libs/api/integration/core/src/metrics/instance.ts
@@ -1,0 +1,35 @@
+import {instanceMetrics} from '@shipfox/node-opentelemetry';
+
+const meter = instanceMetrics.getMeter('integrations');
+
+export type IntegrationAgentToolCallOutcome =
+  | 'success'
+  | 'tool-error'
+  | 'invalid-request'
+  | 'exception';
+
+const agentToolCallCount = meter.createCounter<{
+  provider: string;
+  tool: string;
+  method: string;
+  outcome: IntegrationAgentToolCallOutcome;
+}>('integrations_agent_tool_call', {
+  description: 'Integration agent tool calls by provider, tool, method, and outcome',
+});
+
+function recordMetric(record: () => void): void {
+  try {
+    record();
+  } catch {
+    // Metrics must not affect integration tool call outcomes.
+  }
+}
+
+export function recordIntegrationAgentToolCall(params: {
+  provider: string;
+  tool: string;
+  method: string;
+  outcome: IntegrationAgentToolCallOutcome;
+}): void {
+  recordMetric(() => agentToolCallCount.add(1, params));
+}

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/audit.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/audit.test.ts
@@ -1,0 +1,86 @@
+import {
+  connection,
+  leaseContext,
+  materializedIntegration,
+  materializedTool,
+} from '#test/agent-tools-gateway-helpers.js';
+import {createIntegrationToolCallRecorder, summarizeIntegrationToolArguments} from './audit.js';
+
+describe('integration tool call audit', () => {
+  it('records bounded metric labels and structured audit context', () => {
+    const recordMetric = vi.fn();
+    const logInfo = vi.fn();
+    const lease = leaseContext({
+      jobId: 'job-1',
+      jobExecutionId: 'execution-1',
+      workflowRunId: 'run-1',
+      workflowRunAttemptId: 'attempt-1',
+      workspaceId: 'workspace-1',
+      currentStepId: 'step-1',
+      currentStepAttempt: 2,
+    });
+    const integration = materializedIntegration({connectionId: 'connection-1'});
+    const tool = materializedTool();
+    const recorder = createIntegrationToolCallRecorder(lease, {recordMetric, logInfo});
+
+    recorder({
+      authorizedTool: {
+        mcpName: 'github_main__issue_read',
+        integration,
+        tool,
+        connection: connection({
+          id: 'connection-1',
+          workspaceId: 'workspace-1',
+          slug: integration.connectionSlug,
+        }),
+        description: 'Read issues',
+        inputSchema: tool.inputSchema,
+      },
+      arguments: {
+        repo: 'platform',
+        owner: 'shipfox',
+        token: 'must-not-appear',
+      },
+      method: 'get',
+      outcome: 'success',
+    });
+
+    expect(recordMetric).toHaveBeenCalledWith({
+      provider: 'github',
+      tool: 'issue_read',
+      method: 'get',
+      outcome: 'success',
+    });
+    expect(logInfo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobId: 'job-1',
+        jobExecutionId: 'execution-1',
+        workflowRunId: 'run-1',
+        workflowRunAttemptId: 'attempt-1',
+        workspaceId: 'workspace-1',
+        currentStepId: 'step-1',
+        currentStepAttempt: 2,
+        connectionId: 'connection-1',
+        provider: 'github',
+        toolId: 'issue_read',
+        method: 'get',
+        outcome: 'success',
+        argumentSummary: {
+          keys: ['owner', 'repo', 'token'],
+          serializedSizeBytes: expect.any(Number),
+        },
+      }),
+      'integration tool call audited',
+    );
+    expect(JSON.stringify(logInfo.mock.calls)).not.toContain('must-not-appear');
+  });
+
+  it('summarizes arguments without values', () => {
+    const summary = summarizeIntegrationToolArguments({z: 'secret', a: 1});
+
+    expect(summary).toEqual({
+      keys: ['a', 'z'],
+      serializedSizeBytes: 20,
+    });
+  });
+});

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/audit.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/audit.ts
@@ -1,0 +1,90 @@
+import type {LeasedJobContext} from '@shipfox/api-auth-context';
+import {logger} from '@shipfox/node-opentelemetry';
+import {
+  type IntegrationAgentToolCallOutcome,
+  recordIntegrationAgentToolCall,
+} from '#metrics/index.js';
+import type {AuthorizedIntegrationTool} from './resolve-authorized-tools.js';
+
+export const UNKNOWN_TOOL_LABEL = 'unknown';
+export const NO_METHOD_LABEL = 'none';
+export const INVALID_METHOD_LABEL = 'invalid';
+
+export interface IntegrationToolArgumentSummary {
+  keys: string[];
+  serializedSizeBytes: number;
+}
+
+export interface IntegrationToolCallAuditRecord {
+  authorizedTool?: AuthorizedIntegrationTool | undefined;
+  arguments: unknown;
+  method: string;
+  outcome: IntegrationAgentToolCallOutcome;
+}
+
+export type IntegrationToolCallRecorder = (record: IntegrationToolCallAuditRecord) => void;
+
+export interface CreateIntegrationToolCallRecorderOptions {
+  recordMetric?: typeof recordIntegrationAgentToolCall | undefined;
+  logInfo?:
+    | ((context: Record<string, unknown>, message: 'integration tool call audited') => void)
+    | undefined;
+}
+
+export function createIntegrationToolCallRecorder(
+  lease: LeasedJobContext,
+  options: CreateIntegrationToolCallRecorderOptions = {},
+): IntegrationToolCallRecorder {
+  const recordMetric = options.recordMetric ?? recordIntegrationAgentToolCall;
+  const logInfo = options.logInfo ?? ((context, message) => logger().info(context, message));
+
+  return (record) => {
+    const provider = record.authorizedTool?.integration.provider ?? UNKNOWN_TOOL_LABEL;
+    const toolId = record.authorizedTool?.tool.id ?? UNKNOWN_TOOL_LABEL;
+
+    recordMetric({
+      provider,
+      tool: toolId,
+      method: record.method,
+      outcome: record.outcome,
+    });
+
+    logInfo(
+      {
+        jobId: lease.jobId,
+        jobExecutionId: lease.jobExecutionId,
+        workflowRunId: lease.workflowRunId,
+        workflowRunAttemptId: lease.workflowRunAttemptId,
+        workspaceId: lease.workspaceId,
+        currentStepId: lease.currentStepId,
+        currentStepAttempt: lease.currentStepAttempt,
+        connectionId: record.authorizedTool?.connection.id,
+        provider,
+        toolId,
+        method: record.method,
+        outcome: record.outcome,
+        argumentSummary: summarizeIntegrationToolArguments(record.arguments),
+      },
+      'integration tool call audited',
+    );
+  };
+}
+
+export function summarizeIntegrationToolArguments(value: unknown): IntegrationToolArgumentSummary {
+  return {
+    keys: isRecord(value) ? Object.keys(value).sort() : [],
+    serializedSizeBytes: serializedSize(value),
+  };
+}
+
+function serializedSize(value: unknown): number {
+  try {
+    return Buffer.byteLength(JSON.stringify(value) ?? '', 'utf8');
+  } catch {
+    return 0;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/index.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/index.ts
@@ -1,9 +1,10 @@
 import {StreamableHTTPServerTransport} from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import type {Transport} from '@modelcontextprotocol/sdk/shared/transport.js';
-import {AUTH_LEASED_JOB} from '@shipfox/api-auth-context';
+import {AUTH_LEASED_JOB, requireLeasedJobContext} from '@shipfox/api-auth-context';
 import {defineRoute, type RouteGroup} from '@shipfox/node-fastify';
 import type {IntegrationProviderRegistry} from '#core/providers/registry.js';
 import type {GetIntegrationConnectionByIdFn} from '#db/connections.js';
+import {createIntegrationToolCallRecorder} from './audit.js';
 import {dispatchIntegrationToolCall} from './dispatch-stub.js';
 import {buildAgentToolsMcpServer} from './mcp-server.js';
 import {
@@ -40,6 +41,7 @@ export function createAgentToolsGatewayRoutes(
           const server = buildAgentToolsMcpServer({
             authorizedTools,
             dispatch: dispatchIntegrationToolCall,
+            recordCall: createIntegrationToolCallRecorder(requireLeasedJobContext(request)),
           });
           const transport = new StreamableHTTPServerTransport();
 

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/mcp-server.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/mcp-server.test.ts
@@ -7,6 +7,7 @@ import {
   materializedIntegration,
   materializedTool,
 } from '#test/agent-tools-gateway-helpers.js';
+import {INVALID_METHOD_LABEL, NO_METHOD_LABEL} from './audit.js';
 import {buildAgentToolsMcpServer, type IntegrationToolDispatchInput} from './mcp-server.js';
 import type {AuthorizedIntegrationToolMap} from './resolve-authorized-tools.js';
 
@@ -15,7 +16,12 @@ describe('buildAgentToolsMcpServer', () => {
     const dispatch = vi.fn(async (input: IntegrationToolDispatchInput) => ({
       content: [{type: 'text' as const, text: `called:${input.method}`}],
     }));
-    const {client, close} = await connectClient(dispatch);
+    const records: Parameters<
+      NonNullable<Parameters<typeof buildAgentToolsMcpServer>[0]['recordCall']>
+    >[0][] = [];
+    const {client, close} = await connectClient(dispatch, defaultAuthorizedTools(), (record) =>
+      records.push(record),
+    );
 
     const tools = await client.listTools();
     const result = await client.callTool(
@@ -40,29 +46,74 @@ describe('buildAgentToolsMcpServer', () => {
         arguments: expect.objectContaining({issue_number: 1}),
       }),
     );
+    expect(records).toMatchObject([
+      {
+        authorizedTool: expect.objectContaining({
+          integration: expect.objectContaining({provider: 'github'}),
+          tool: expect.objectContaining({id: 'issue_read'}),
+        }),
+        method: 'get',
+        outcome: 'success',
+      },
+    ]);
   });
 
   it.each([
-    ['unknown tool', 'missing__tool', {method: 'get'}],
-    ['missing method', 'github_main__issue_read', {}],
-    ['non-string method', 'github_main__issue_read', {method: 1}],
-    ['unauthorized method', 'github_main__issue_read', {method: 'get_labels'}],
-  ])('returns an isError tool result for %s', async (_label, name, args) => {
+    ['unknown tool', 'missing__tool', {method: 'get'}, NO_METHOD_LABEL, undefined],
+    ['missing method', 'github_main__issue_read', {}, INVALID_METHOD_LABEL, 'issue_read'],
+    [
+      'non-string method',
+      'github_main__issue_read',
+      {method: 1},
+      INVALID_METHOD_LABEL,
+      'issue_read',
+    ],
+    [
+      'unauthorized method',
+      'github_main__issue_read',
+      {method: 'get_labels'},
+      INVALID_METHOD_LABEL,
+      'issue_read',
+    ],
+  ])('returns an isError tool result and records invalid-request for %s', async (_label, name, args, expectedMethod, expectedToolId) => {
     const dispatch = vi.fn();
-    const {client, close} = await connectClient(dispatch);
+    const records: Parameters<
+      NonNullable<Parameters<typeof buildAgentToolsMcpServer>[0]['recordCall']>
+    >[0][] = [];
+    const {client, close} = await connectClient(dispatch, defaultAuthorizedTools(), (record) =>
+      records.push(record),
+    );
 
     const result = await client.callTool({name, arguments: args}, CallToolResultSchema);
     await close();
 
     expect(result.isError).toBe(true);
     expect(dispatch).not.toHaveBeenCalled();
+    expect(records).toMatchObject([
+      {
+        method: expectedMethod,
+        outcome: 'invalid-request',
+      },
+    ]);
+    if (expectedToolId) {
+      expect(records[0]?.authorizedTool).toEqual(
+        expect.objectContaining({tool: expect.objectContaining({id: expectedToolId})}),
+      );
+    } else {
+      expect(records[0]?.authorizedTool).toBeUndefined();
+    }
   });
 
   it('ignores a stray method argument for standalone tools', async () => {
     const dispatch = vi.fn(async () => ({
       content: [{type: 'text' as const, text: 'called'}],
     }));
-    const {client, close} = await connectClient(dispatch, standaloneTools());
+    const records: Parameters<
+      NonNullable<Parameters<typeof buildAgentToolsMcpServer>[0]['recordCall']>
+    >[0][] = [];
+    const {client, close} = await connectClient(dispatch, standaloneTools(), (record) =>
+      records.push(record),
+    );
 
     const result = await client.callTool(
       {name: 'github_main__list_issues', arguments: {method: 'ignored'}},
@@ -77,6 +128,7 @@ describe('buildAgentToolsMcpServer', () => {
         arguments: {method: 'ignored'},
       }),
     );
+    expect(records).toMatchObject([{method: NO_METHOD_LABEL, outcome: 'success'}]);
   });
 
   it('defaults omitted arguments to an empty object for optional-argument tools', async () => {
@@ -98,7 +150,12 @@ describe('buildAgentToolsMcpServer', () => {
 
   it('rejects arguments that do not match the exposed input schema', async () => {
     const dispatch = vi.fn();
-    const {client, close} = await connectClient(dispatch);
+    const records: Parameters<
+      NonNullable<Parameters<typeof buildAgentToolsMcpServer>[0]['recordCall']>
+    >[0][] = [];
+    const {client, close} = await connectClient(dispatch, defaultAuthorizedTools(), (record) =>
+      records.push(record),
+    );
 
     const result = await client.callTool(
       {
@@ -116,14 +173,64 @@ describe('buildAgentToolsMcpServer', () => {
 
     expect(result.isError).toBe(true);
     expect(dispatch).not.toHaveBeenCalled();
+    expect(records).toMatchObject([{method: 'get', outcome: 'invalid-request'}]);
+  });
+
+  it('records tool-error when dispatch returns an error result', async () => {
+    const dispatch = vi.fn(async () => ({
+      isError: true,
+      content: [{type: 'text' as const, text: 'provider rejected call'}],
+    }));
+    const records: Parameters<
+      NonNullable<Parameters<typeof buildAgentToolsMcpServer>[0]['recordCall']>
+    >[0][] = [];
+    const {client, close} = await connectClient(dispatch, defaultAuthorizedTools(), (record) =>
+      records.push(record),
+    );
+
+    const result = await client.callTool(
+      {
+        name: 'github_main__issue_read',
+        arguments: {method: 'get', owner: 'shipfox', repo: 'platform', issue_number: 1},
+      },
+      CallToolResultSchema,
+    );
+    await close();
+
+    expect(result.isError).toBe(true);
+    expect(records).toMatchObject([{method: 'get', outcome: 'tool-error'}]);
+  });
+
+  it('records exception before rethrowing dispatcher failures', async () => {
+    const dispatch = vi.fn(() => Promise.reject(new Error('provider unavailable')));
+    const records: Parameters<
+      NonNullable<Parameters<typeof buildAgentToolsMcpServer>[0]['recordCall']>
+    >[0][] = [];
+    const {client, close} = await connectClient(dispatch, defaultAuthorizedTools(), (record) =>
+      records.push(record),
+    );
+
+    await expect(
+      client.callTool(
+        {
+          name: 'github_main__issue_read',
+          arguments: {method: 'get', owner: 'shipfox', repo: 'platform', issue_number: 1},
+        },
+        CallToolResultSchema,
+      ),
+    ).rejects.toThrow('MCP error -32603');
+    await close();
+
+    expect(records).toMatchObject([{method: 'get', outcome: 'exception'}]);
   });
 });
 
 async function connectClient(
   dispatch: Parameters<typeof buildAgentToolsMcpServer>[0]['dispatch'],
   authorizedTools = defaultAuthorizedTools(),
+  recordCall?: Parameters<typeof buildAgentToolsMcpServer>[0]['recordCall'],
 ) {
-  const server = buildAgentToolsMcpServer({authorizedTools, dispatch});
+  const server = buildAgentToolsMcpServer({authorizedTools, dispatch, recordCall});
   const client = new Client({name: 'test-client', version: '0.0.0'});
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
 

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/mcp-server.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/mcp-server.ts
@@ -5,6 +5,7 @@ import {
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import {Ajv, type ValidateFunction} from 'ajv';
+import {INVALID_METHOD_LABEL, type IntegrationToolCallRecorder, NO_METHOD_LABEL} from './audit.js';
 import type {
   AuthorizedIntegrationTool,
   AuthorizedIntegrationToolMap,
@@ -23,6 +24,7 @@ export type IntegrationToolDispatcher = (
 export interface BuildAgentToolsMcpServerParams {
   authorizedTools: AuthorizedIntegrationToolMap;
   dispatch: IntegrationToolDispatcher;
+  recordCall?: IntegrationToolCallRecorder | undefined;
 }
 
 const ajv = new Ajv({strict: false, allErrors: true});
@@ -57,26 +59,85 @@ export function buildAgentToolsMcpServer(params: BuildAgentToolsMcpServerParams)
 
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const authorizedTool = params.authorizedTools.get(request.params.name);
-    if (!authorizedTool) return toolError(`Unknown integration tool: ${request.params.name}`);
+    if (!authorizedTool) {
+      recordToolCall(params.recordCall, {
+        arguments: request.params.arguments ?? {},
+        method: NO_METHOD_LABEL,
+        outcome: 'invalid-request',
+      });
+      return toolError(`Unknown integration tool: ${request.params.name}`);
+    }
 
     const args = request.params.arguments ?? {};
-    if (!isRecord(args)) return toolError('Tool arguments must be an object');
+    if (!isRecord(args)) {
+      recordToolCall(params.recordCall, {
+        authorizedTool,
+        arguments: args,
+        method: NO_METHOD_LABEL,
+        outcome: 'invalid-request',
+      });
+      return toolError('Tool arguments must be an object');
+    }
 
     const methodValidation = validateMethod(authorizedTool, args);
-    if (methodValidation.kind === 'error') return toolError(methodValidation.message);
+    if (methodValidation.kind === 'error') {
+      recordToolCall(params.recordCall, {
+        authorizedTool,
+        arguments: args,
+        method: INVALID_METHOD_LABEL,
+        outcome: 'invalid-request',
+      });
+      return toolError(methodValidation.message);
+    }
+    const method = methodValidation.method ?? NO_METHOD_LABEL;
 
     const schemaError = validateToolInput(authorizedTool, args, validators);
-    if (schemaError) return toolError(schemaError);
+    if (schemaError) {
+      recordToolCall(params.recordCall, {
+        authorizedTool,
+        arguments: args,
+        method,
+        outcome: 'invalid-request',
+      });
+      return toolError(schemaError);
+    }
 
-    const result = await params.dispatch({
-      authorizedTool,
-      arguments: args,
-      method: methodValidation.method,
-    });
-    return result;
+    try {
+      const result = await params.dispatch({
+        authorizedTool,
+        arguments: args,
+        method: methodValidation.method,
+      });
+      recordToolCall(params.recordCall, {
+        authorizedTool,
+        arguments: args,
+        method,
+        outcome: result.isError === true ? 'tool-error' : 'success',
+      });
+      return result;
+    } catch (error) {
+      recordToolCall(params.recordCall, {
+        authorizedTool,
+        arguments: args,
+        method,
+        outcome: 'exception',
+      });
+      throw error;
+    }
   });
 
   return server;
+}
+
+function recordToolCall(
+  recordCall: IntegrationToolCallRecorder | undefined,
+  record: Parameters<IntegrationToolCallRecorder>[0],
+): void {
+  try {
+    recordCall?.(record);
+  } catch {
+    // Audit and metrics must not affect MCP responses.
+  }
 }
 
 function validateMethod(


### PR DESCRIPTION
Add provider-agnostic audit logging and instance metrics for integration MCP gateway tool calls.

Integration tool calls cross the server-side credential custody boundary, so the gateway needs an authoritative audit trail and bounded Prometheus labels before native provider dispatch lands. This records successes, validation failures, tool-error results, and dispatcher exceptions without putting high-cardinality identifiers in metrics or raw argument values in logs.

Argument audit data is intentionally limited to sorted top-level keys and serialized byte size. This keeps the logs useful for investigation while avoiding raw tool input leakage.

Closes ENG-853

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds provider-agnostic audit logging and bounded-label metrics for MCP gateway integration tool calls, meeting ENG-853. Provides an authoritative audit trail and outcome metrics without leaking tool inputs.

- **New Features**
  - Counter metric `integrations_agent_tool_call` with labels: provider, tool, method, outcome; recorded via `@shipfox/node-opentelemetry` and never throws.
  - Structured audit logs include job/workflow/workspace/step and connection IDs, provider, toolId, method, outcome, plus argument summary (sorted top-level keys and serialized size only).
  - MCP server records outcomes: success, invalid-request (unknown tool, non-object args, missing/non-string/unauthorized method), tool-error (provider returns error), exception (dispatcher throws). Uses bounded method labels `none`/`invalid` and fallback provider/tool label `unknown`.
  - Recorder is wired into the gateway route with `requireLeasedJobContext`; tests cover argument summarization and audit/metric recording across outcomes.

<sup>Written for commit a5afd6bae872aa7277d618a20bcfd5dcc3f5e1f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

