### PR TITLE
[api-secrets] Add module metrics

### DIFF
--- a/libs/api/secrets/package.json
+++ b/libs/api/secrets/package.json
@@ -54,6 +54,7 @@
     "@shipfox/node-drizzle": "workspace:*",
     "@shipfox/node-fastify": "workspace:*",
     "@shipfox/node-module": "workspace:*",
+    "@shipfox/node-opentelemetry": "workspace:*",
     "@shipfox/node-outbox": "workspace:*",
     "@shipfox/node-postgres": "workspace:*",
     "drizzle-orm": "^0.45.2",

--- a/libs/api/secrets/src/core/dek-manager.test.ts
+++ b/libs/api/secrets/src/core/dek-manager.test.ts
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto';
 import {describe, expect, it} from '@shipfox/vitest/vi';
 import {eq} from 'drizzle-orm';
-import {db, secretDataKeys} from '#db/index.js';
+import {db, insertDataKeyIfAbsent, secretDataKeys} from '#db/index.js';
 import {DekManager} from './dek-manager.js';
 import {createLocalKeyProvider} from './key-provider.js';
 
@@ -24,6 +24,27 @@ describe('DekManager', () => {
 
     expect(rows).toHaveLength(1);
     expect(first.equals(second)).toBe(true);
+  });
+
+  it('reports whether a first-use data key insert won the race', async () => {
+    const workspaceId = crypto.randomUUID();
+    const keyProvider = createLocalKeyProvider({currentKek: crypto.randomBytes(32)});
+    const first = keyProvider.wrapDek(workspaceId, crypto.randomBytes(32));
+    const second = keyProvider.wrapDek(workspaceId, crypto.randomBytes(32));
+
+    const inserted = await insertDataKeyIfAbsent({
+      workspaceId,
+      wrappedDek: first.wrappedDek,
+      kekVersion: first.kekVersion,
+    });
+    const skipped = await insertDataKeyIfAbsent({
+      workspaceId,
+      wrappedDek: second.wrappedDek,
+      kekVersion: second.kekVersion,
+    });
+
+    expect(inserted).toBe(true);
+    expect(skipped).toBe(false);
   });
 
   it('re-reads persisted data keys on cold start', async () => {

--- a/libs/api/secrets/src/core/dek-manager.ts
+++ b/libs/api/secrets/src/core/dek-manager.ts
@@ -1,5 +1,6 @@
 import crypto from 'node:crypto';
 import {getDataKey, insertDataKeyIfAbsent} from '#db/index.js';
+import {classifyDekAccessError, recordSecretsDekAccess} from '#metrics/instance.js';
 import type {KeyProvider} from './key-provider.js';
 
 const DEK_BYTES = 32;
@@ -20,44 +21,60 @@ export class DekManager {
   }
 
   async getPlaintextDek(workspaceId: string): Promise<Buffer> {
-    const cached = this.#cache.get(workspaceId);
-    if (cached && cached.expiresAt > Date.now()) {
-      this.#cache.delete(workspaceId);
-      this.#cache.set(workspaceId, cached);
-      return Buffer.from(cached.dek);
-    }
-    if (cached) this.#cache.delete(workspaceId);
+    const startedAt = Date.now();
+    try {
+      const cached = this.#cache.get(workspaceId);
+      if (cached && cached.expiresAt > Date.now()) {
+        this.#cache.delete(workspaceId);
+        this.#cache.set(workspaceId, cached);
+        recordSecretsDekAccess({outcome: 'cache_hit', durationMs: Date.now() - startedAt});
+        return Buffer.from(cached.dek);
+      }
+      const hadExpiredCache = Boolean(cached);
+      if (cached) this.#cache.delete(workspaceId);
 
-    const existing = await getDataKey(workspaceId);
-    if (existing) {
+      const existing = await getDataKey(workspaceId);
+      if (existing) {
+        const dek = this.#keyProvider.unwrapDek(
+          workspaceId,
+          existing.wrappedDek,
+          existing.kekVersion,
+        );
+        this.#set(workspaceId, dek);
+        recordSecretsDekAccess({
+          outcome: hadExpiredCache ? 'cache_expired' : 'db_unwrapped',
+          durationMs: Date.now() - startedAt,
+        });
+        return Buffer.from(dek);
+      }
+
+      const generatedDek = crypto.randomBytes(DEK_BYTES);
+      const wrapped = this.#keyProvider.wrapDek(workspaceId, generatedDek);
+      await insertDataKeyIfAbsent({
+        workspaceId,
+        wrappedDek: wrapped.wrappedDek,
+        kekVersion: wrapped.kekVersion,
+      });
+
+      // The DEK row commits before value writes. If concurrent first-use inserts race,
+      // the primary key decides the winner and every caller re-reads the persisted row.
+      const persisted = await getDataKey(workspaceId);
+      if (!persisted) throw new Error(`Data key was not persisted for workspace ${workspaceId}`);
       const dek = this.#keyProvider.unwrapDek(
         workspaceId,
-        existing.wrappedDek,
-        existing.kekVersion,
+        persisted.wrappedDek,
+        persisted.kekVersion,
       );
       this.#set(workspaceId, dek);
+      recordSecretsDekAccess({outcome: 'generated', durationMs: Date.now() - startedAt});
       return Buffer.from(dek);
+    } catch (error) {
+      recordSecretsDekAccess({
+        outcome: classifyDekAccessError(error),
+        durationMs: Date.now() - startedAt,
+      });
+      throw error;
     }
-
-    const generatedDek = crypto.randomBytes(DEK_BYTES);
-    const wrapped = this.#keyProvider.wrapDek(workspaceId, generatedDek);
-    await insertDataKeyIfAbsent({
-      workspaceId,
-      wrappedDek: wrapped.wrappedDek,
-      kekVersion: wrapped.kekVersion,
-    });
-
-    // The DEK row commits before value writes. If concurrent first-use inserts race,
-    // the primary key decides the winner and every caller re-reads the persisted row.
-    const persisted = await getDataKey(workspaceId);
-    if (!persisted) throw new Error(`Data key was not persisted for workspace ${workspaceId}`);
-    const dek = this.#keyProvider.unwrapDek(
-      workspaceId,
-      persisted.wrappedDek,
-      persisted.kekVersion,
-    );
-    this.#set(workspaceId, dek);
-    return Buffer.from(dek);
   }
 
   invalidate(workspaceId: string): void {

--- a/libs/api/secrets/src/core/dek-manager.ts
+++ b/libs/api/secrets/src/core/dek-manager.ts
@@ -50,7 +50,7 @@ export class DekManager {
 
       const generatedDek = crypto.randomBytes(DEK_BYTES);
       const wrapped = this.#keyProvider.wrapDek(workspaceId, generatedDek);
-      await insertDataKeyIfAbsent({
+      const inserted = await insertDataKeyIfAbsent({
         workspaceId,
         wrappedDek: wrapped.wrappedDek,
         kekVersion: wrapped.kekVersion,
@@ -66,7 +66,10 @@ export class DekManager {
         persisted.kekVersion,
       );
       this.#set(workspaceId, dek);
-      recordSecretsDekAccess({outcome: 'generated', durationMs: Date.now() - startedAt});
+      recordSecretsDekAccess({
+        outcome: inserted ? 'generated' : 'db_unwrapped',
+        durationMs: Date.now() - startedAt,
+      });
       return Buffer.from(dek);
     } catch (error) {
       recordSecretsDekAccess({

--- a/libs/api/secrets/src/core/management.ts
+++ b/libs/api/secrets/src/core/management.ts
@@ -28,6 +28,13 @@ import {
 } from '#db/index.js';
 import type {SecretVariable} from '#db/schema/variables.js';
 import {normalizedProjectId} from '#db/scope.js';
+import {
+  classifySecretsOperationError,
+  operationScope,
+  recordSecretsEntriesMutated,
+  recordSecretsOperation,
+  type SecretsMetricResource,
+} from '#metrics/instance.js';
 import type {DekManager} from './dek-manager.js';
 import {
   SecretBatchDuplicateKeyError,
@@ -63,124 +70,311 @@ export interface ManagementListParams extends StoreScope {
 
 export function createSecretsManagementApi(params: {dekManager: DekManager}) {
   return {
-    listSecrets: listSecretManagementRows,
-    listVariables: listVariableManagementRows,
+    async listSecrets(input: ManagementListParams) {
+      const startedAt = Date.now();
+      const scope = operationScope(input);
+      try {
+        const result = await listSecretManagementRows(input);
+        recordSecretsOperation({
+          resource: 'secret',
+          operation: 'list',
+          surface: 'management',
+          scope,
+          outcome: 'success',
+          durationMs: Date.now() - startedAt,
+        });
+        return result;
+      } catch (error) {
+        recordSecretsOperation({
+          resource: 'secret',
+          operation: 'list',
+          surface: 'management',
+          scope,
+          outcome: classifySecretsOperationError(error),
+          durationMs: Date.now() - startedAt,
+        });
+        throw error;
+      }
+    },
+    async listVariables(input: ManagementListParams) {
+      const startedAt = Date.now();
+      const scope = operationScope(input);
+      try {
+        const result = await listVariableManagementRows(input);
+        recordSecretsOperation({
+          resource: 'variable',
+          operation: 'list',
+          surface: 'management',
+          scope,
+          outcome: 'success',
+          durationMs: Date.now() - startedAt,
+        });
+        return result;
+      } catch (error) {
+        recordSecretsOperation({
+          resource: 'variable',
+          operation: 'list',
+          surface: 'management',
+          scope,
+          outcome: classifySecretsOperationError(error),
+          durationMs: Date.now() - startedAt,
+        });
+        throw error;
+      }
+    },
     async getVariable(
       input: StoreScope & {workspaceId: string; key: string},
     ): Promise<SecretVariable> {
-      validateSecretKeys([input.key]);
+      const startedAt = Date.now();
+      const scope = operationScope(input);
+      try {
+        validateSecretKeys([input.key]);
 
-      const variable = await getVariableManagementRow(input);
-      if (!variable) throw new VariableNotFoundError(input.key);
-      return variable;
+        const variable = await getVariableManagementRow(input);
+        if (!variable) throw new VariableNotFoundError(input.key);
+        recordSecretsOperation({
+          resource: 'variable',
+          operation: 'get',
+          surface: 'management',
+          scope,
+          outcome: 'success',
+          durationMs: Date.now() - startedAt,
+        });
+        return variable;
+      } catch (error) {
+        recordSecretsOperation({
+          resource: 'variable',
+          operation: 'get',
+          surface: 'management',
+          scope,
+          outcome: classifySecretsOperationError(error),
+          durationMs: Date.now() - startedAt,
+        });
+        throw error;
+      }
     },
     async setSecrets(input: ManagementWriteParams): Promise<SecretManagementRow[]> {
-      const entries = normalizeEntries(input.entries);
-      validateSecretKeys(entries.map((entry) => entry.key));
-      validateValueBytes(entries.map((entry) => entry.value));
-      if (entries.length === 0) return [];
+      const startedAt = Date.now();
+      const scope = operationScope(input);
+      try {
+        const entries = normalizeEntries(input.entries);
+        validateSecretKeys(entries.map((entry) => entry.key));
+        validateValueBytes(entries.map((entry) => entry.value));
+        if (entries.length === 0) {
+          recordSecretsOperation({
+            resource: 'secret',
+            operation: 'set',
+            surface: 'management',
+            scope,
+            outcome: 'success',
+            durationMs: Date.now() - startedAt,
+          });
+          return [];
+        }
 
-      const projectId = normalizedProjectId(input);
-      const dek = await params.dekManager.getPlaintextDek(input.workspaceId);
-      return writeManagementEntries({
-        input,
-        keys: entries.map((entry) => entry.key),
-        listExistingKeys: listExistingSecretManagementKeys,
-        writeRows: async (tx) => {
-          await upsertSecretValueRows(
-            entries.map((entry) => ({
-              workspaceId: input.workspaceId,
-              projectId,
-              namespace: '',
-              key: entry.key,
-              ciphertext: encryptSecretValue({
-                dek,
+        const projectId = normalizedProjectId(input);
+        const dek = await params.dekManager.getPlaintextDek(input.workspaceId);
+        const rows = await writeManagementEntries({
+          resource: 'secret',
+          input,
+          keys: entries.map((entry) => entry.key),
+          listExistingKeys: listExistingSecretManagementKeys,
+          writeRows: async (tx) => {
+            await upsertSecretValueRows(
+              entries.map((entry) => ({
                 workspaceId: input.workspaceId,
-                scope: {projectId},
+                projectId,
+                namespace: '',
+                key: entry.key,
+                ciphertext: encryptSecretValue({
+                  dek,
+                  workspaceId: input.workspaceId,
+                  scope: {projectId},
+                  namespace: '',
+                  key: entry.key,
+                  value: entry.value,
+                }),
+                fingerprint: fingerprintSecretValue(entry.value, dek),
+                lastEditedBy: input.actorId,
+              })),
+              tx,
+            );
+            const rows = await Promise.all(
+              entries.map((entry) =>
+                getSecretManagementRow(
+                  {workspaceId: input.workspaceId, projectId, key: entry.key},
+                  tx,
+                ),
+              ),
+            );
+            return rows.map(assertFound);
+          },
+          eventTypes: {created: SECRET_CREATED, updated: SECRET_UPDATED},
+        });
+        recordSecretsOperation({
+          resource: 'secret',
+          operation: 'set',
+          surface: 'management',
+          scope,
+          outcome: 'success',
+          durationMs: Date.now() - startedAt,
+        });
+        return rows;
+      } catch (error) {
+        recordSecretsOperation({
+          resource: 'secret',
+          operation: 'set',
+          surface: 'management',
+          scope,
+          outcome: classifySecretsOperationError(error),
+          durationMs: Date.now() - startedAt,
+        });
+        throw error;
+      }
+    },
+    async setVariables(input: ManagementWriteParams): Promise<SecretVariable[]> {
+      const startedAt = Date.now();
+      const scope = operationScope(input);
+      try {
+        const entries = normalizeEntries(input.entries);
+        validateSecretKeys(entries.map((entry) => entry.key));
+        validateValueBytes(entries.map((entry) => entry.value));
+        if (entries.length === 0) {
+          recordSecretsOperation({
+            resource: 'variable',
+            operation: 'set',
+            surface: 'management',
+            scope,
+            outcome: 'success',
+            durationMs: Date.now() - startedAt,
+          });
+          return [];
+        }
+
+        const projectId = normalizedProjectId(input);
+        const rows = await writeManagementEntries({
+          resource: 'variable',
+          input,
+          keys: entries.map((entry) => entry.key),
+          listExistingKeys: listExistingVariableManagementKeys,
+          writeRows: async (tx) => {
+            await upsertSecretVariableRows(
+              entries.map((entry) => ({
+                workspaceId: input.workspaceId,
+                projectId,
                 namespace: '',
                 key: entry.key,
                 value: entry.value,
-              }),
-              fingerprint: fingerprintSecretValue(entry.value, dek),
-              lastEditedBy: input.actorId,
-            })),
-            tx,
-          );
-          const rows = await Promise.all(
-            entries.map((entry) =>
-              getSecretManagementRow(
-                {workspaceId: input.workspaceId, projectId, key: entry.key},
-                tx,
+                lastEditedBy: input.actorId,
+              })),
+              tx,
+            );
+            const rows = await Promise.all(
+              entries.map((entry) =>
+                getVariableManagementRow(
+                  {workspaceId: input.workspaceId, projectId, key: entry.key},
+                  tx,
+                ),
               ),
-            ),
-          );
-          return rows.map(assertFound);
-        },
-        eventTypes: {created: SECRET_CREATED, updated: SECRET_UPDATED},
-      });
-    },
-    setVariables(input: ManagementWriteParams): Promise<SecretVariable[]> {
-      const entries = normalizeEntries(input.entries);
-      validateSecretKeys(entries.map((entry) => entry.key));
-      validateValueBytes(entries.map((entry) => entry.value));
-      if (entries.length === 0) return Promise.resolve([]);
-
-      const projectId = normalizedProjectId(input);
-      return writeManagementEntries({
-        input,
-        keys: entries.map((entry) => entry.key),
-        listExistingKeys: listExistingVariableManagementKeys,
-        writeRows: async (tx) => {
-          await upsertSecretVariableRows(
-            entries.map((entry) => ({
-              workspaceId: input.workspaceId,
-              projectId,
-              namespace: '',
-              key: entry.key,
-              value: entry.value,
-              lastEditedBy: input.actorId,
-            })),
-            tx,
-          );
-          const rows = await Promise.all(
-            entries.map((entry) =>
-              getVariableManagementRow(
-                {workspaceId: input.workspaceId, projectId, key: entry.key},
-                tx,
-              ),
-            ),
-          );
-          return rows.map(assertFound);
-        },
-        eventTypes: {created: VARIABLE_CREATED, updated: VARIABLE_UPDATED},
-      });
+            );
+            return rows.map(assertFound);
+          },
+          eventTypes: {created: VARIABLE_CREATED, updated: VARIABLE_UPDATED},
+        });
+        recordSecretsOperation({
+          resource: 'variable',
+          operation: 'set',
+          surface: 'management',
+          scope,
+          outcome: 'success',
+          durationMs: Date.now() - startedAt,
+        });
+        return rows;
+      } catch (error) {
+        recordSecretsOperation({
+          resource: 'variable',
+          operation: 'set',
+          surface: 'management',
+          scope,
+          outcome: classifySecretsOperationError(error),
+          durationMs: Date.now() - startedAt,
+        });
+        throw error;
+      }
     },
     async deleteSecret(input: ManagementKeyParams): Promise<void> {
-      validateSecretKeys([input.key]);
+      const startedAt = Date.now();
+      const scope = operationScope(input);
+      try {
+        validateSecretKeys([input.key]);
 
-      const deleted = await deleteManagementEntries({
-        input,
-        keys: [input.key],
-        deleteRows: deleteSecretManagementRows,
-        eventType: SECRET_DELETED,
-      });
-      if (deleted === 0) throw new SecretNotFoundError(input.key);
+        const deleted = await deleteManagementEntries({
+          resource: 'secret',
+          input,
+          keys: [input.key],
+          deleteRows: deleteSecretManagementRows,
+          eventType: SECRET_DELETED,
+        });
+        if (deleted === 0) throw new SecretNotFoundError(input.key);
+        recordSecretsOperation({
+          resource: 'secret',
+          operation: 'delete',
+          surface: 'management',
+          scope,
+          outcome: 'success',
+          durationMs: Date.now() - startedAt,
+        });
+      } catch (error) {
+        recordSecretsOperation({
+          resource: 'secret',
+          operation: 'delete',
+          surface: 'management',
+          scope,
+          outcome: classifySecretsOperationError(error),
+          durationMs: Date.now() - startedAt,
+        });
+        throw error;
+      }
     },
     async deleteVariable(input: ManagementKeyParams): Promise<void> {
-      validateSecretKeys([input.key]);
+      const startedAt = Date.now();
+      const scope = operationScope(input);
+      try {
+        validateSecretKeys([input.key]);
 
-      const deleted = await deleteManagementEntries({
-        input,
-        keys: [input.key],
-        deleteRows: deleteVariableManagementRows,
-        eventType: VARIABLE_DELETED,
-      });
-      if (deleted === 0) throw new VariableNotFoundError(input.key);
+        const deleted = await deleteManagementEntries({
+          resource: 'variable',
+          input,
+          keys: [input.key],
+          deleteRows: deleteVariableManagementRows,
+          eventType: VARIABLE_DELETED,
+        });
+        if (deleted === 0) throw new VariableNotFoundError(input.key);
+        recordSecretsOperation({
+          resource: 'variable',
+          operation: 'delete',
+          surface: 'management',
+          scope,
+          outcome: 'success',
+          durationMs: Date.now() - startedAt,
+        });
+      } catch (error) {
+        recordSecretsOperation({
+          resource: 'variable',
+          operation: 'delete',
+          surface: 'management',
+          scope,
+          outcome: classifySecretsOperationError(error),
+          durationMs: Date.now() - startedAt,
+        });
+        throw error;
+      }
     },
   };
 }
 
-function writeManagementEntries<Row extends {key: string}>(params: {
+async function writeManagementEntries<Row extends {key: string}>(params: {
+  resource: SecretsMetricResource;
   input: ManagementWriteParams;
   keys: string[];
   listExistingKeys: (
@@ -193,7 +387,9 @@ function writeManagementEntries<Row extends {key: string}>(params: {
     updated: typeof SECRET_UPDATED | typeof VARIABLE_UPDATED;
   };
 }): Promise<Row[]> {
-  return db().transaction(async (tx) => {
+  let createdCount = 0;
+  let updatedCount = 0;
+  const rows = await db().transaction(async (tx) => {
     await lockWorkspaceEntries(params.input.workspaceId, tx);
     const existingKeys = await params.listExistingKeys(
       {
@@ -203,10 +399,12 @@ function writeManagementEntries<Row extends {key: string}>(params: {
       },
       tx,
     );
+    createdCount = params.keys.length - existingKeys.size;
+    updatedCount = existingKeys.size;
     await assertWorkspaceCap({
       workspaceId: params.input.workspaceId,
       namespace: '',
-      incomingEntries: params.keys.length - existingKeys.size,
+      incomingEntries: createdCount,
       tx,
     });
 
@@ -221,9 +419,25 @@ function writeManagementEntries<Row extends {key: string}>(params: {
     );
     return rows;
   });
+  recordSecretsEntriesMutated({
+    resource: params.resource,
+    operation: 'set',
+    effect: 'created',
+    surface: 'management',
+    count: createdCount,
+  });
+  recordSecretsEntriesMutated({
+    resource: params.resource,
+    operation: 'set',
+    effect: 'updated',
+    surface: 'management',
+    count: updatedCount,
+  });
+  return rows;
 }
 
-function deleteManagementEntries<Row extends {key: string}>(params: {
+async function deleteManagementEntries<Row extends {key: string}>(params: {
+  resource: SecretsMetricResource;
   input: ManagementKeyParams;
   keys: string[];
   deleteRows: (
@@ -232,7 +446,7 @@ function deleteManagementEntries<Row extends {key: string}>(params: {
   ) => Promise<Row[]>;
   eventType: typeof SECRET_DELETED | typeof VARIABLE_DELETED;
 }): Promise<number> {
-  return db().transaction(async (tx) => {
+  const deleted = await db().transaction(async (tx) => {
     await lockWorkspaceEntries(params.input.workspaceId, tx);
     const rows = await params.deleteRows(
       {
@@ -252,6 +466,14 @@ function deleteManagementEntries<Row extends {key: string}>(params: {
     );
     return rows.length;
   });
+  recordSecretsEntriesMutated({
+    resource: params.resource,
+    operation: 'delete',
+    effect: 'deleted',
+    surface: 'management',
+    count: deleted,
+  });
+  return deleted;
 }
 
 function normalizeEntries(entries: ManagementEntry[]): ManagementEntry[] {

--- a/libs/api/secrets/src/core/rotate-kek.ts
+++ b/libs/api/secrets/src/core/rotate-kek.ts
@@ -95,5 +95,6 @@ function rotationDurationOutcome(params: {
 }) {
   if (params.rotated > 0) return 'rotated';
   if (params.skippedRace > 0) return 'skipped_race';
+  if (params.skippedCurrent === 0) return 'none';
   return 'skipped_current';
 }

--- a/libs/api/secrets/src/core/rotate-kek.ts
+++ b/libs/api/secrets/src/core/rotate-kek.ts
@@ -1,4 +1,5 @@
 import {listDataKeysPage, listDataKeyVersions, updateDataKeyWrapCas} from '#db/index.js';
+import {classifyKekRotationError, recordSecretsKekRotation} from '#metrics/instance.js';
 import {KekVersionStrandedError} from './errors.js';
 import type {KeyProvider} from './key-provider.js';
 
@@ -17,49 +18,82 @@ export async function rotateWorkspaceDataKeysWithProvider(
   keyProvider: KeyProvider,
   options: RotateWorkspaceDataKeysOptions = {},
 ): Promise<RotateWorkspaceDataKeysResult> {
-  const knownVersions = [keyProvider.currentKeyVersion, keyProvider.previousKeyVersion].filter(
-    (version): version is string => Boolean(version),
-  );
-  const unknownVersions = await listDataKeyVersions(knownVersions, {
-    workspaceIds: options.workspaceIds,
-  });
-  if (unknownVersions.length > 0) throw new KekVersionStrandedError(unknownVersions[0] as string);
-
-  let rotated = 0;
-  let skipped = 0;
-  let afterWorkspaceId: string | undefined;
-
-  while (true) {
-    const page = await listDataKeysPage({
-      afterWorkspaceId,
-      limit: PAGE_SIZE,
+  const startedAt = Date.now();
+  try {
+    const knownVersions = [keyProvider.currentKeyVersion, keyProvider.previousKeyVersion].filter(
+      (version): version is string => Boolean(version),
+    );
+    const unknownVersions = await listDataKeyVersions(knownVersions, {
       workspaceIds: options.workspaceIds,
     });
-    if (page.length === 0) break;
+    if (unknownVersions.length > 0) throw new KekVersionStrandedError(unknownVersions[0] as string);
 
-    for (const row of page) {
-      afterWorkspaceId = row.workspaceId;
-      if (row.kekVersion === keyProvider.currentKeyVersion) {
-        skipped += 1;
-        continue;
-      }
+    let rotated = 0;
+    let skipped = 0;
+    let skippedCurrent = 0;
+    let skippedRace = 0;
+    let afterWorkspaceId: string | undefined;
 
-      const plaintextDek = keyProvider.unwrapDek(row.workspaceId, row.wrappedDek, row.kekVersion);
-      try {
-        const wrapped = keyProvider.wrapDek(row.workspaceId, plaintextDek);
-        const updated = await updateDataKeyWrapCas({
-          workspaceId: row.workspaceId,
-          oldKekVersion: row.kekVersion,
-          wrappedDek: wrapped.wrappedDek,
-          kekVersion: wrapped.kekVersion,
-        });
-        if (updated) rotated += 1;
-        else skipped += 1;
-      } finally {
-        plaintextDek.fill(0);
+    while (true) {
+      const page = await listDataKeysPage({
+        afterWorkspaceId,
+        limit: PAGE_SIZE,
+        workspaceIds: options.workspaceIds,
+      });
+      if (page.length === 0) break;
+
+      for (const row of page) {
+        afterWorkspaceId = row.workspaceId;
+        if (row.kekVersion === keyProvider.currentKeyVersion) {
+          skipped += 1;
+          skippedCurrent += 1;
+          continue;
+        }
+
+        const plaintextDek = keyProvider.unwrapDek(row.workspaceId, row.wrappedDek, row.kekVersion);
+        try {
+          const wrapped = keyProvider.wrapDek(row.workspaceId, plaintextDek);
+          const updated = await updateDataKeyWrapCas({
+            workspaceId: row.workspaceId,
+            oldKekVersion: row.kekVersion,
+            wrappedDek: wrapped.wrappedDek,
+            kekVersion: wrapped.kekVersion,
+          });
+          if (updated) rotated += 1;
+          else {
+            skipped += 1;
+            skippedRace += 1;
+          }
+        } finally {
+          plaintextDek.fill(0);
+        }
       }
     }
-  }
 
-  return {rotated, skipped};
+    recordSecretsKekRotation({outcome: 'rotated', count: rotated});
+    recordSecretsKekRotation({outcome: 'skipped_current', count: skippedCurrent});
+    recordSecretsKekRotation({outcome: 'skipped_race', count: skippedRace});
+    recordSecretsKekRotation({
+      outcome: rotationDurationOutcome({rotated, skippedCurrent, skippedRace}),
+      count: 0,
+      durationMs: Date.now() - startedAt,
+    });
+    return {rotated, skipped};
+  } catch (error) {
+    recordSecretsKekRotation({
+      outcome: classifyKekRotationError(error),
+      durationMs: Date.now() - startedAt,
+    });
+    throw error;
+  }
+}
+
+function rotationDurationOutcome(params: {
+  rotated: number;
+  skippedCurrent: number;
+  skippedRace: number;
+}) {
+  if (params.rotated > 0) return 'rotated';
+  if (params.skippedRace > 0) return 'skipped_race';
+  return 'skipped_current';
 }

--- a/libs/api/secrets/src/core/secret-store.ts
+++ b/libs/api/secrets/src/core/secret-store.ts
@@ -7,6 +7,12 @@ import {
   upsertSecretValueRows,
 } from '#db/index.js';
 import {normalizedProjectId} from '#db/scope.js';
+import {
+  classifySecretsOperationError,
+  operationScope,
+  recordSecretsEntriesMutated,
+  recordSecretsOperation,
+} from '#metrics/instance.js';
 import type {DekManager} from './dek-manager.js';
 import {fingerprintSecretValue} from './fingerprint.js';
 import type {SecretStoreProvider} from './store-resolver.js';
@@ -36,7 +42,7 @@ export function createSecretStoreApi(params: {
   resolveSecretStore: (name?: string | undefined) => SecretStoreProvider;
 }) {
   return {
-    getSecret(
+    async getSecret(
       input: StoreScope & {
         workspaceId: string;
         namespace?: string | undefined;
@@ -44,76 +50,202 @@ export function createSecretStoreApi(params: {
         store?: string;
       },
     ) {
-      const namespace = input.namespace ?? '';
-      validateNamespace(namespace);
-      validateSecretKeys([input.key]);
-      return params.resolveSecretStore(input.store).getSecret({...input, namespace});
+      const startedAt = Date.now();
+      const scope = operationScope(input);
+      try {
+        const namespace = input.namespace ?? '';
+        validateNamespace(namespace);
+        validateSecretKeys([input.key]);
+        const value = await params.resolveSecretStore(input.store).getSecret({...input, namespace});
+        recordSecretsOperation({
+          resource: 'secret',
+          operation: 'get',
+          surface: 'internal',
+          scope,
+          outcome: value === null ? 'not_found' : 'success',
+          durationMs: Date.now() - startedAt,
+        });
+        return value;
+      } catch (error) {
+        recordSecretsOperation({
+          resource: 'secret',
+          operation: 'get',
+          surface: 'internal',
+          scope,
+          outcome: classifySecretsOperationError(error),
+          durationMs: Date.now() - startedAt,
+        });
+        throw error;
+      }
     },
-    getSecretsByNamespace(
+    async getSecretsByNamespace(
       input: StoreScope & {workspaceId: string; namespace?: string | undefined; store?: string},
     ) {
-      const namespace = input.namespace ?? '';
-      validateNamespace(namespace);
-      return params.resolveSecretStore(input.store).getSecretsByNamespace({...input, namespace});
+      const startedAt = Date.now();
+      const scope = operationScope(input);
+      try {
+        const namespace = input.namespace ?? '';
+        validateNamespace(namespace);
+        const values = await params
+          .resolveSecretStore(input.store)
+          .getSecretsByNamespace({...input, namespace});
+        recordSecretsOperation({
+          resource: 'secret',
+          operation: 'get_namespace',
+          surface: 'internal',
+          scope,
+          outcome: 'success',
+          durationMs: Date.now() - startedAt,
+        });
+        return values;
+      } catch (error) {
+        recordSecretsOperation({
+          resource: 'secret',
+          operation: 'get_namespace',
+          surface: 'internal',
+          scope,
+          outcome: classifySecretsOperationError(error),
+          durationMs: Date.now() - startedAt,
+        });
+        throw error;
+      }
     },
     async setSecrets(input: SetSecretsParams): Promise<void> {
-      const namespace = input.namespace ?? '';
-      const entries = Object.entries(input.values);
-      validateNamespace(namespace);
-      validateSecretKeys(entries.map(([key]) => key));
-      validateValueBytes(entries.map(([, value]) => value));
-      if (entries.length === 0) return;
+      const startedAt = Date.now();
+      const scope = operationScope(input);
+      try {
+        const namespace = input.namespace ?? '';
+        const entries = Object.entries(input.values);
+        validateNamespace(namespace);
+        validateSecretKeys(entries.map(([key]) => key));
+        validateValueBytes(entries.map(([, value]) => value));
+        if (entries.length === 0) {
+          recordSecretsOperation({
+            resource: 'secret',
+            operation: 'set',
+            surface: 'internal',
+            scope,
+            outcome: 'success',
+            durationMs: Date.now() - startedAt,
+          });
+          return;
+        }
 
-      const dek = await params.dekManager.getPlaintextDek(input.workspaceId);
-      const projectId = normalizedProjectId(input);
-      const rows = entries.map(([key, value]) => ({
-        workspaceId: input.workspaceId,
-        projectId,
-        namespace,
-        key,
-        ciphertext: encryptSecretValue({
-          dek,
+        const dek = await params.dekManager.getPlaintextDek(input.workspaceId);
+        const projectId = normalizedProjectId(input);
+        const rows = entries.map(([key, value]) => ({
           workspaceId: input.workspaceId,
-          scope: {projectId},
+          projectId,
           namespace,
           key,
-          value,
-        }),
-        fingerprint: fingerprintSecretValue(value, dek),
-        lastEditedBy: input.editedBy ?? null,
-      }));
-
-      await db().transaction(async (tx) => {
-        await lockWorkspaceEntries(input.workspaceId, tx);
-        const existingEntries = await countSecretValueRows(
-          {
+          ciphertext: encryptSecretValue({
+            dek,
             workspaceId: input.workspaceId,
-            projectId,
+            scope: {projectId},
             namespace,
-            keys: entries.map(([key]) => key),
-          },
-          tx,
-        );
-        await assertWorkspaceCap({
-          workspaceId: input.workspaceId,
-          namespace,
-          incomingEntries: entries.length - existingEntries,
-          tx,
-        });
-        await upsertSecretValueRows(rows, tx);
-      });
-    },
-    deleteSecrets(input: DeleteSecretsParams): Promise<number> {
-      const namespace = input.namespace ?? '';
-      validateNamespace(namespace);
-      if (input.keys) validateSecretKeys(input.keys);
+            key,
+            value,
+          }),
+          fingerprint: fingerprintSecretValue(value, dek),
+          lastEditedBy: input.editedBy ?? null,
+        }));
 
-      return deleteSecretValueRows({
-        workspaceId: input.workspaceId,
-        projectId: normalizedProjectId(input),
-        namespace,
-        keys: input.keys,
-      });
+        let existingEntries = 0;
+        await db().transaction(async (tx) => {
+          await lockWorkspaceEntries(input.workspaceId, tx);
+          existingEntries = await countSecretValueRows(
+            {
+              workspaceId: input.workspaceId,
+              projectId,
+              namespace,
+              keys: entries.map(([key]) => key),
+            },
+            tx,
+          );
+          await assertWorkspaceCap({
+            workspaceId: input.workspaceId,
+            namespace,
+            incomingEntries: entries.length - existingEntries,
+            tx,
+          });
+          await upsertSecretValueRows(rows, tx);
+        });
+
+        recordSecretsEntriesMutated({
+          resource: 'secret',
+          operation: 'set',
+          effect: 'created',
+          surface: 'internal',
+          count: entries.length - existingEntries,
+        });
+        recordSecretsEntriesMutated({
+          resource: 'secret',
+          operation: 'set',
+          effect: 'updated',
+          surface: 'internal',
+          count: existingEntries,
+        });
+        recordSecretsOperation({
+          resource: 'secret',
+          operation: 'set',
+          surface: 'internal',
+          scope,
+          outcome: 'success',
+          durationMs: Date.now() - startedAt,
+        });
+      } catch (error) {
+        recordSecretsOperation({
+          resource: 'secret',
+          operation: 'set',
+          surface: 'internal',
+          scope,
+          outcome: classifySecretsOperationError(error),
+          durationMs: Date.now() - startedAt,
+        });
+        throw error;
+      }
+    },
+    async deleteSecrets(input: DeleteSecretsParams): Promise<number> {
+      const startedAt = Date.now();
+      const scope = operationScope(input);
+      try {
+        const namespace = input.namespace ?? '';
+        validateNamespace(namespace);
+        if (input.keys) validateSecretKeys(input.keys);
+
+        const deleted = await deleteSecretValueRows({
+          workspaceId: input.workspaceId,
+          projectId: normalizedProjectId(input),
+          namespace,
+          keys: input.keys,
+        });
+        recordSecretsEntriesMutated({
+          resource: 'secret',
+          operation: 'delete',
+          effect: 'deleted',
+          surface: 'internal',
+          count: deleted,
+        });
+        recordSecretsOperation({
+          resource: 'secret',
+          operation: 'delete',
+          surface: 'internal',
+          scope,
+          outcome: 'success',
+          durationMs: Date.now() - startedAt,
+        });
+        return deleted;
+      } catch (error) {
+        recordSecretsOperation({
+          resource: 'secret',
+          operation: 'delete',
+          surface: 'internal',
+          scope,
+          outcome: classifySecretsOperationError(error),
+          durationMs: Date.now() - startedAt,
+        });
+        throw error;
+      }
     },
   };
 }

--- a/libs/api/secrets/src/core/variable-store.ts
+++ b/libs/api/secrets/src/core/variable-store.ts
@@ -10,6 +10,12 @@ import {
 } from '#db/index.js';
 import {normalizedProjectId} from '#db/scope.js';
 import {
+  classifySecretsOperationError,
+  operationScope,
+  recordSecretsEntriesMutated,
+  recordSecretsOperation,
+} from '#metrics/instance.js';
+import {
   assertWorkspaceCap,
   validateNamespace,
   validateSecretKeys,
@@ -32,73 +38,195 @@ export interface DeleteVariablesParams extends StoreScope {
 export async function getVariable(
   input: StoreScope & {workspaceId: string; namespace?: string | undefined; key: string},
 ): Promise<string | null> {
-  const namespace = input.namespace ?? '';
-  validateNamespace(namespace);
-  validateSecretKeys([input.key]);
+  const startedAt = Date.now();
+  const scope = operationScope(input);
+  try {
+    const namespace = input.namespace ?? '';
+    validateNamespace(namespace);
+    validateSecretKeys([input.key]);
 
-  const row = await getSecretVariableRowWithPrecedence({...input, namespace});
-  return row?.value ?? null;
+    const row = await getSecretVariableRowWithPrecedence({...input, namespace});
+    recordSecretsOperation({
+      resource: 'variable',
+      operation: 'get',
+      surface: 'internal',
+      scope,
+      outcome: row ? 'success' : 'not_found',
+      durationMs: Date.now() - startedAt,
+    });
+    return row?.value ?? null;
+  } catch (error) {
+    recordSecretsOperation({
+      resource: 'variable',
+      operation: 'get',
+      surface: 'internal',
+      scope,
+      outcome: classifySecretsOperationError(error),
+      durationMs: Date.now() - startedAt,
+    });
+    throw error;
+  }
 }
 
 export async function getVariablesByNamespace(
   input: StoreScope & {workspaceId: string; namespace?: string | undefined},
 ): Promise<Record<string, string>> {
-  const namespace = input.namespace ?? '';
-  validateNamespace(namespace);
+  const startedAt = Date.now();
+  const scope = operationScope(input);
+  try {
+    const namespace = input.namespace ?? '';
+    validateNamespace(namespace);
 
-  const rows = await listSecretVariableRowsByNamespace({...input, namespace});
-  return Object.fromEntries(rows.map((row) => [row.key, row.value]));
+    const rows = await listSecretVariableRowsByNamespace({...input, namespace});
+    recordSecretsOperation({
+      resource: 'variable',
+      operation: 'get_namespace',
+      surface: 'internal',
+      scope,
+      outcome: 'success',
+      durationMs: Date.now() - startedAt,
+    });
+    return Object.fromEntries(rows.map((row) => [row.key, row.value]));
+  } catch (error) {
+    recordSecretsOperation({
+      resource: 'variable',
+      operation: 'get_namespace',
+      surface: 'internal',
+      scope,
+      outcome: classifySecretsOperationError(error),
+      durationMs: Date.now() - startedAt,
+    });
+    throw error;
+  }
 }
 
 export async function setVariables(input: SetVariablesParams): Promise<void> {
-  const namespace = input.namespace ?? '';
-  const entries = Object.entries(input.values);
-  validateNamespace(namespace);
-  validateSecretKeys(entries.map(([key]) => key));
-  validateValueBytes(entries.map(([, value]) => value));
-  if (entries.length === 0) return;
+  const startedAt = Date.now();
+  const scope = operationScope(input);
+  try {
+    const namespace = input.namespace ?? '';
+    const entries = Object.entries(input.values);
+    validateNamespace(namespace);
+    validateSecretKeys(entries.map(([key]) => key));
+    validateValueBytes(entries.map(([, value]) => value));
+    if (entries.length === 0) {
+      recordSecretsOperation({
+        resource: 'variable',
+        operation: 'set',
+        surface: 'internal',
+        scope,
+        outcome: 'success',
+        durationMs: Date.now() - startedAt,
+      });
+      return;
+    }
 
-  const projectId = normalizedProjectId(input);
-  await db().transaction(async (tx) => {
-    await lockWorkspaceEntries(input.workspaceId, tx);
-    const existingEntries = await countSecretVariableRows(
-      {
+    const projectId = normalizedProjectId(input);
+    let existingEntries = 0;
+    await db().transaction(async (tx) => {
+      await lockWorkspaceEntries(input.workspaceId, tx);
+      existingEntries = await countSecretVariableRows(
+        {
+          workspaceId: input.workspaceId,
+          projectId,
+          namespace,
+          keys: entries.map(([key]) => key),
+        },
+        tx,
+      );
+      await assertWorkspaceCap({
         workspaceId: input.workspaceId,
-        projectId,
         namespace,
-        keys: entries.map(([key]) => key),
-      },
-      tx,
-    );
-    await assertWorkspaceCap({
-      workspaceId: input.workspaceId,
-      namespace,
-      incomingEntries: entries.length - existingEntries,
-      tx,
+        incomingEntries: entries.length - existingEntries,
+        tx,
+      });
+      await upsertSecretVariableRows(
+        entries.map(([key, value]) => ({
+          workspaceId: input.workspaceId,
+          projectId,
+          namespace,
+          key,
+          value,
+          lastEditedBy: input.editedBy ?? null,
+        })),
+        tx,
+      );
     });
-    await upsertSecretVariableRows(
-      entries.map(([key, value]) => ({
-        workspaceId: input.workspaceId,
-        projectId,
-        namespace,
-        key,
-        value,
-        lastEditedBy: input.editedBy ?? null,
-      })),
-      tx,
-    );
-  });
+
+    recordSecretsEntriesMutated({
+      resource: 'variable',
+      operation: 'set',
+      effect: 'created',
+      surface: 'internal',
+      count: entries.length - existingEntries,
+    });
+    recordSecretsEntriesMutated({
+      resource: 'variable',
+      operation: 'set',
+      effect: 'updated',
+      surface: 'internal',
+      count: existingEntries,
+    });
+    recordSecretsOperation({
+      resource: 'variable',
+      operation: 'set',
+      surface: 'internal',
+      scope,
+      outcome: 'success',
+      durationMs: Date.now() - startedAt,
+    });
+  } catch (error) {
+    recordSecretsOperation({
+      resource: 'variable',
+      operation: 'set',
+      surface: 'internal',
+      scope,
+      outcome: classifySecretsOperationError(error),
+      durationMs: Date.now() - startedAt,
+    });
+    throw error;
+  }
 }
 
-export function deleteVariables(input: DeleteVariablesParams): Promise<number> {
-  const namespace = input.namespace ?? '';
-  validateNamespace(namespace);
-  if (input.keys) validateSecretKeys(input.keys);
+export async function deleteVariables(input: DeleteVariablesParams): Promise<number> {
+  const startedAt = Date.now();
+  const scope = operationScope(input);
+  try {
+    const namespace = input.namespace ?? '';
+    validateNamespace(namespace);
+    if (input.keys) validateSecretKeys(input.keys);
 
-  return deleteSecretVariableRows({
-    workspaceId: input.workspaceId,
-    projectId: normalizedProjectId(input),
-    namespace,
-    keys: input.keys,
-  });
+    const deleted = await deleteSecretVariableRows({
+      workspaceId: input.workspaceId,
+      projectId: normalizedProjectId(input),
+      namespace,
+      keys: input.keys,
+    });
+    recordSecretsEntriesMutated({
+      resource: 'variable',
+      operation: 'delete',
+      effect: 'deleted',
+      surface: 'internal',
+      count: deleted,
+    });
+    recordSecretsOperation({
+      resource: 'variable',
+      operation: 'delete',
+      surface: 'internal',
+      scope,
+      outcome: 'success',
+      durationMs: Date.now() - startedAt,
+    });
+    return deleted;
+  } catch (error) {
+    recordSecretsOperation({
+      resource: 'variable',
+      operation: 'delete',
+      surface: 'internal',
+      scope,
+      outcome: classifySecretsOperationError(error),
+      durationMs: Date.now() - startedAt,
+    });
+    throw error;
+  }
 }

--- a/libs/api/secrets/src/db/cap.ts
+++ b/libs/api/secrets/src/db/cap.ts
@@ -30,6 +30,27 @@ export async function countWorkspaceEntries(workspaceId: string, tx?: Tx): Promi
   return Number(row?.value ?? 0);
 }
 
+export async function countPublicEntriesByResource(
+  tx?: Tx,
+): Promise<{secrets: number; variables: number}> {
+  const executor = tx ?? db();
+  const [secretCount, variableCount] = await Promise.all([
+    executor
+      .select({count: count().as('secret_count')})
+      .from(secretValues)
+      .where(notLike(secretValues.namespace, 'system/%')),
+    executor
+      .select({count: count().as('variable_count')})
+      .from(secretVariables)
+      .where(notLike(secretVariables.namespace, 'system/%')),
+  ]);
+
+  return {
+    secrets: Number(secretCount[0]?.count ?? 0),
+    variables: Number(variableCount[0]?.count ?? 0),
+  };
+}
+
 export async function lockWorkspaceEntries(workspaceId: string, tx: Tx): Promise<void> {
   await tx.execute(sql`
     SELECT pg_advisory_xact_lock(hashtext('shipfox_secrets_workspace_cap'), hashtext(${workspaceId}))

--- a/libs/api/secrets/src/db/data-keys.ts
+++ b/libs/api/secrets/src/db/data-keys.ts
@@ -16,11 +16,16 @@ export async function getDataKey(workspaceId: string, tx?: Tx): Promise<DataKey 
 export async function insertDataKeyIfAbsent(
   dataKey: {workspaceId: string; wrappedDek: string; kekVersion: string},
   tx?: Tx,
-): Promise<void> {
+): Promise<boolean> {
   const executor = tx ?? db();
-  await executor.insert(secretDataKeys).values(dataKey).onConflictDoNothing({
-    target: secretDataKeys.workspaceId,
-  });
+  const rows = await executor
+    .insert(secretDataKeys)
+    .values(dataKey)
+    .onConflictDoNothing({
+      target: secretDataKeys.workspaceId,
+    })
+    .returning({workspaceId: secretDataKeys.workspaceId});
+  return rows.length > 0;
 }
 
 export async function updateDataKeyWrapCas(

--- a/libs/api/secrets/src/db/index.ts
+++ b/libs/api/secrets/src/db/index.ts
@@ -1,7 +1,7 @@
 import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 
-export {countWorkspaceEntries, lockWorkspaceEntries} from './cap.js';
+export {countPublicEntriesByResource, countWorkspaceEntries, lockWorkspaceEntries} from './cap.js';
 export {
   getDataKey,
   insertDataKeyIfAbsent,

--- a/libs/api/secrets/src/index.ts
+++ b/libs/api/secrets/src/index.ts
@@ -1,6 +1,7 @@
 import {secretsEventSchemas} from '@shipfox/api-secrets-dto';
 import type {ShipfoxModule} from '@shipfox/node-module';
 import {db, migrationsPath, secretsOutbox} from '#db/index.js';
+import {registerSecretsServiceMetrics} from '#metrics/index.js';
 import {secretsE2eRoutes} from '#presentation/e2eRoutes/index.js';
 import {secretsRoutes} from '#presentation/routes/index.js';
 
@@ -44,5 +45,6 @@ export const secretsModule: ShipfoxModule = {
   database: {db, migrationsPath},
   routes: secretsRoutes,
   e2eRoutes: [secretsE2eRoutes],
+  metrics: registerSecretsServiceMetrics,
   publishers: [{name: 'secrets', table: secretsOutbox, db, eventSchemas: secretsEventSchemas}],
 };

--- a/libs/api/secrets/src/metrics/index.ts
+++ b/libs/api/secrets/src/metrics/index.ts
@@ -1,0 +1,19 @@
+export {
+  classifyDekAccessError,
+  classifyKekRotationError,
+  classifySecretsOperationError,
+  operationScope,
+  recordSecretsDekAccess,
+  recordSecretsEntriesMutated,
+  recordSecretsKekRotation,
+  recordSecretsOperation,
+  type SecretsDekAccessOutcome,
+  type SecretsKekRotationOutcome,
+  type SecretsMetricOperation,
+  type SecretsMetricResource,
+  type SecretsMetricScope,
+  type SecretsMetricSurface,
+  type SecretsMutationEffect,
+  type SecretsOperationOutcome,
+} from './instance.js';
+export {registerSecretsServiceMetrics} from './service.js';

--- a/libs/api/secrets/src/metrics/instance.ts
+++ b/libs/api/secrets/src/metrics/instance.ts
@@ -1,0 +1,218 @@
+import {instanceMetrics} from '@shipfox/node-opentelemetry';
+import {
+  DekUnwrapError,
+  DekWrapError,
+  KekVersionStrandedError,
+  NamespaceValidationError,
+  SecretBatchDuplicateKeyError,
+  SecretBatchScopeMismatchError,
+  SecretDecryptionError,
+  SecretKeyValidationError,
+  SecretNotFoundError,
+  SecretValueTooLargeError,
+  UnknownSecretStoreError,
+  VariableNotFoundError,
+  WorkspaceSecretCapExceededError,
+} from '#core/errors.js';
+
+const meter = instanceMetrics.getMeter('secrets');
+
+export type SecretsMetricResource = 'secret' | 'variable';
+export type SecretsMetricOperation = 'get' | 'get_namespace' | 'set' | 'delete' | 'list';
+export type SecretsMetricSurface = 'internal' | 'management';
+export type SecretsMetricScope = 'workspace' | 'project';
+export type SecretsOperationOutcome =
+  | 'success'
+  | 'not_found'
+  | 'validation_failed'
+  | 'cap_exceeded'
+  | 'value_too_large'
+  | 'decryption_failed'
+  | 'crypto_failed'
+  | 'failure';
+export type SecretsMutationEffect = 'created' | 'updated' | 'deleted';
+export type SecretsDekAccessOutcome =
+  | 'cache_hit'
+  | 'cache_expired'
+  | 'db_unwrapped'
+  | 'generated'
+  | 'unwrap_failed'
+  | 'wrap_failed'
+  | 'persist_failed';
+export type SecretsKekRotationOutcome =
+  | 'rotated'
+  | 'skipped_current'
+  | 'skipped_race'
+  | 'stranded'
+  | 'failure';
+
+const operationCount = meter.createCounter<{
+  resource: SecretsMetricResource;
+  operation: SecretsMetricOperation;
+  surface: SecretsMetricSurface;
+  scope: SecretsMetricScope;
+  outcome: SecretsOperationOutcome;
+}>('secrets_operation', {
+  description: 'Secrets module operation attempts by resource, surface, scope, and outcome',
+});
+
+const operationDuration = meter.createHistogram<{
+  resource: SecretsMetricResource;
+  operation: SecretsMetricOperation;
+  surface: SecretsMetricSurface;
+  scope: SecretsMetricScope;
+  outcome: SecretsOperationOutcome;
+}>('secrets_operation_duration', {
+  description: 'Secrets module operation duration',
+  unit: 'ms',
+  advice: {explicitBucketBoundaries: [1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000]},
+});
+
+const entriesMutatedCount = meter.createCounter<{
+  resource: SecretsMetricResource;
+  operation: 'set' | 'delete';
+  effect: SecretsMutationEffect;
+  surface: SecretsMetricSurface;
+}>('secrets_entries_mutated', {
+  description: 'Secret and variable entries mutated by operation, effect, and surface',
+});
+
+const dekAccessCount = meter.createCounter<{outcome: SecretsDekAccessOutcome}>(
+  'secrets_dek_access',
+  {description: 'Plaintext data-encryption key access attempts by outcome'},
+);
+
+const dekAccessDuration = meter.createHistogram<{outcome: SecretsDekAccessOutcome}>(
+  'secrets_dek_access_duration',
+  {
+    description: 'Plaintext data-encryption key access duration',
+    unit: 'ms',
+    advice: {explicitBucketBoundaries: [0, 1, 5, 10, 25, 50, 100, 250, 500, 1000]},
+  },
+);
+
+const kekRotationCount = meter.createCounter<{outcome: SecretsKekRotationOutcome}>(
+  'secrets_kek_rotation',
+  {description: 'Workspace data-key KEK rotation outcomes'},
+);
+
+const kekRotationDuration = meter.createHistogram<{outcome: SecretsKekRotationOutcome}>(
+  'secrets_kek_rotation_duration',
+  {
+    description: 'Workspace data-key KEK rotation duration',
+    unit: 'ms',
+    advice: {explicitBucketBoundaries: [10, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000]},
+  },
+);
+
+function recordMetric(record: () => void): void {
+  try {
+    record();
+  } catch {
+    // Metrics must not affect secret storage outcomes.
+  }
+}
+
+export function operationScope(params: {
+  projectId?: string | null | undefined;
+}): SecretsMetricScope {
+  return params.projectId ? 'project' : 'workspace';
+}
+
+export function classifySecretsOperationError(error: unknown): SecretsOperationOutcome {
+  if (error instanceof SecretNotFoundError || error instanceof VariableNotFoundError) {
+    return 'not_found';
+  }
+  if (error instanceof WorkspaceSecretCapExceededError) return 'cap_exceeded';
+  if (error instanceof SecretValueTooLargeError) return 'value_too_large';
+  if (error instanceof SecretDecryptionError) return 'decryption_failed';
+  if (error instanceof DekUnwrapError || error instanceof DekWrapError) return 'crypto_failed';
+  if (
+    error instanceof NamespaceValidationError ||
+    error instanceof SecretKeyValidationError ||
+    error instanceof SecretBatchDuplicateKeyError ||
+    error instanceof SecretBatchScopeMismatchError ||
+    error instanceof UnknownSecretStoreError
+  ) {
+    return 'validation_failed';
+  }
+  return 'failure';
+}
+
+export function recordSecretsOperation(params: {
+  resource: SecretsMetricResource;
+  operation: SecretsMetricOperation;
+  surface: SecretsMetricSurface;
+  scope: SecretsMetricScope;
+  outcome: SecretsOperationOutcome;
+  durationMs: number;
+}): void {
+  recordMetric(() => {
+    const labels = {
+      resource: params.resource,
+      operation: params.operation,
+      surface: params.surface,
+      scope: params.scope,
+      outcome: params.outcome,
+    };
+    operationCount.add(1, labels);
+    operationDuration.record(params.durationMs, labels);
+  });
+}
+
+export function recordSecretsEntriesMutated(params: {
+  resource: SecretsMetricResource;
+  operation: 'set' | 'delete';
+  effect: SecretsMutationEffect;
+  surface: SecretsMetricSurface;
+  count: number;
+}): void {
+  if (params.count <= 0) return;
+
+  recordMetric(() =>
+    entriesMutatedCount.add(params.count, {
+      resource: params.resource,
+      operation: params.operation,
+      effect: params.effect,
+      surface: params.surface,
+    }),
+  );
+}
+
+export function recordSecretsDekAccess(params: {
+  outcome: SecretsDekAccessOutcome;
+  durationMs: number;
+}): void {
+  recordMetric(() => {
+    dekAccessCount.add(1, {outcome: params.outcome});
+    dekAccessDuration.record(params.durationMs, {outcome: params.outcome});
+  });
+}
+
+export function classifyDekAccessError(error: unknown): SecretsDekAccessOutcome {
+  if (error instanceof DekUnwrapError) return 'unwrap_failed';
+  if (error instanceof DekWrapError) return 'wrap_failed';
+  return 'persist_failed';
+}
+
+export function recordSecretsKekRotation(params: {
+  outcome: SecretsKekRotationOutcome;
+  count?: number | undefined;
+  durationMs?: number | undefined;
+}): void {
+  const count = params.count ?? 1;
+  if (count <= 0 && params.durationMs === undefined) return;
+
+  recordMetric(() => {
+    if (count > 0) kekRotationCount.add(count, {outcome: params.outcome});
+    if (params.durationMs !== undefined) {
+      kekRotationDuration.record(params.durationMs, {outcome: params.outcome});
+    }
+  });
+}
+
+export function classifyKekRotationError(error: unknown): SecretsKekRotationOutcome {
+  if (error instanceof KekVersionStrandedError) return 'stranded';
+  if (error instanceof DekUnwrapError || error instanceof DekWrapError) return 'failure';
+  return 'failure';
+}

--- a/libs/api/secrets/src/metrics/instance.ts
+++ b/libs/api/secrets/src/metrics/instance.ts
@@ -38,7 +38,6 @@ export type SecretsDekAccessOutcome =
   | 'generated'
   | 'unwrap_failed'
   | 'wrap_failed'
-  | 'persist_failed'
   | 'failure';
 export type SecretsKekRotationOutcome =
   | 'rotated'

--- a/libs/api/secrets/src/metrics/instance.ts
+++ b/libs/api/secrets/src/metrics/instance.ts
@@ -38,11 +38,13 @@ export type SecretsDekAccessOutcome =
   | 'generated'
   | 'unwrap_failed'
   | 'wrap_failed'
-  | 'persist_failed';
+  | 'persist_failed'
+  | 'failure';
 export type SecretsKekRotationOutcome =
   | 'rotated'
   | 'skipped_current'
   | 'skipped_race'
+  | 'none'
   | 'stranded'
   | 'failure';
 
@@ -192,7 +194,7 @@ export function recordSecretsDekAccess(params: {
 export function classifyDekAccessError(error: unknown): SecretsDekAccessOutcome {
   if (error instanceof DekUnwrapError) return 'unwrap_failed';
   if (error instanceof DekWrapError) return 'wrap_failed';
-  return 'persist_failed';
+  return 'failure';
 }
 
 export function recordSecretsKekRotation(params: {

--- a/libs/api/secrets/src/metrics/service.ts
+++ b/libs/api/secrets/src/metrics/service.ts
@@ -1,0 +1,19 @@
+import {getServiceMetricsProvider} from '@shipfox/node-opentelemetry';
+import {countPublicEntriesByResource} from '#db/index.js';
+
+export function registerSecretsServiceMetrics(): void {
+  const meter = getServiceMetricsProvider().getMeter('secrets');
+
+  const publicEntries = meter.createObservableGauge('secrets_public_entries', {
+    description: 'Public secret and variable entries currently stored, excluding system namespaces',
+  });
+
+  meter.addBatchObservableCallback(
+    async (observer) => {
+      const counts = await countPublicEntriesByResource();
+      observer.observe(publicEntries, counts.secrets, {resource: 'secret'});
+      observer.observe(publicEntries, counts.variables, {resource: 'variable'});
+    },
+    [publicEntries],
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2740,6 +2740,9 @@ importers:
       '@shipfox/node-module':
         specifier: workspace:*
         version: link:../../shared/node/module
+      '@shipfox/node-opentelemetry':
+        specifier: workspace:*
+        version: link:../../shared/node/opentelemetry
       '@shipfox/node-outbox':
         specifier: workspace:*
         version: link:../../shared/node/outbox


### PR DESCRIPTION
Adds OpenTelemetry metrics to the API secrets module for operation attempts and durations, entry mutation counts, DEK access outcomes, KEK rotation outcomes, and aggregate public entry counts.

The secrets module previously had no module-owned metrics, which left secret-store health, storage pressure, crypto failures, and rotation progress invisible outside logs and downstream callers. This instruments the domain paths directly so read/write, management, DEK, and rotation behavior is observable at the point the outcome is known.

Labels intentionally stay bounded and avoid workspace, project, namespace, key, store, ciphertext, and error-message values to prevent cardinality growth and secret metadata leakage. The aggregate gauge uses `secrets_public_entries` rather than a workspace-named metric because it is not grouped by workspace.

No changeset is included because `@shipfox/api-secrets` is private.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenTelemetry metrics to the secrets module to expose operation health, DEK access, KEK rotation, and public entry counts. Outcome labels are bounded, and a stale DEK outcome label was removed.

- **New Features**
  - Instrument secret and variable get/list/set/delete on internal and management surfaces with count and duration metrics and bounded outcomes.
  - Count entries created/updated/deleted per operation and surface.
  - Track DEK access outcomes and latency (cache_hit, cache_expired, db_unwrapped, generated, unwrap_failed/wrap_failed, failure).
  - Track KEK rotation outcomes and latency (rotated, skipped_current, skipped_race, none, stranded).
  - Add service gauge `secrets_public_entries` for current public secret/variable totals.

- **Dependencies**
  - Added `@shipfox/node-opentelemetry` and registered metrics via the module’s `metrics` hook.

<sup>Written for commit be2327f98864416b49e7a572be4456a5e0be943b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

