### PR TITLE
Warn on agent tool capability mismatches

### DIFF
--- a/.changeset/steady-tools-warn.md
+++ b/.changeset/steady-tools-warn.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/annotations": patch
+"@shipfox/api-runners": patch
+"@shipfox/api-workflows": patch
+---
+
+Warns on agent tool capability mismatches during dispatch without blocking label-matched runners.

--- a/libs/api/annotations/src/core/write-annotations.test.ts
+++ b/libs/api/annotations/src/core/write-annotations.test.ts
@@ -58,6 +58,38 @@ describe('writeAnnotations', () => {
     expect(updated.accounting).toEqual({annotationCount: 1, totalBodyBytes: 6});
   });
 
+  it('skips unchanged replace writes and preserves original attribution', async () => {
+    const created = await writeAnnotations({
+      ...params,
+      operations: [{context: 'deploy', style: 'warning', op: 'replace', body: 'same'}],
+    });
+    const originalOriginStepId = params.originStepId;
+
+    const unchanged = await writeAnnotations({
+      ...params,
+      originStepId: crypto.randomUUID(),
+      originStepAttempt: 2,
+      operations: [{context: 'deploy', style: 'warning', op: 'replace', body: 'same'}],
+    });
+
+    const rows = await db()
+      .select()
+      .from(annotations)
+      .where(eq(annotations.jobExecutionId, params.jobExecutionId));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: created.annotations[0]?.id,
+      context: 'deploy',
+      style: 'warning',
+      body: 'same',
+      sequence: 1,
+      originStepId: originalOriginStepId,
+      originStepAttempt: 1,
+    });
+    expect(unchanged.annotations[0]?.id).toBe(created.annotations[0]?.id);
+    expect(unchanged.accounting).toEqual({annotationCount: 1, totalBodyBytes: 4});
+  });
+
   it('appends to an existing context', async () => {
     await annotationFactory.create({
       ...params,

--- a/libs/api/annotations/src/core/write-annotations.ts
+++ b/libs/api/annotations/src/core/write-annotations.ts
@@ -49,6 +49,16 @@ export function writeAnnotations(params: WriteAnnotationsParams): Promise<WriteA
       const bodyBytes = Buffer.byteLength(body);
       ensureBodyBudget(bodyBytes);
 
+      const isUnchangedReplace =
+        operation.op === 'replace' &&
+        existing !== undefined &&
+        existing.body === body &&
+        existing.style === operation.style;
+      if (isUnchangedReplace) {
+        results.push({context: operation.context, id: existing.id});
+        continue;
+      }
+
       const draft = new Map(current);
       draft.set(operation.context, {
         id: existing?.id ?? '',

--- a/libs/api/annotations/src/index.ts
+++ b/libs/api/annotations/src/index.ts
@@ -3,6 +3,13 @@ import {db} from '#db/db.js';
 import {migrationsPath} from '#db/index.js';
 import {annotationsRoutes} from '#presentation/routes/index.js';
 
+export {
+  AnnotationBodyTooLargeError,
+  AnnotationCountLimitExceededError,
+  AnnotationTotalBytesLimitExceededError,
+} from '#core/errors.js';
+export {type WriteAnnotationsParams, writeAnnotations} from '#core/write-annotations.js';
+
 export const annotationsModule: ShipfoxModule = {
   name: 'annotations',
   database: {db, migrationsPath},

--- a/libs/api/runners/src/config.test.ts
+++ b/libs/api/runners/src/config.test.ts
@@ -167,6 +167,35 @@ describe('RUNNER_STALE_PROVISIONED_RUNNER_THRESHOLD_SECONDS validation', () => {
   });
 });
 
+describe('RUNNER_TOOL_CAPABILITIES_STALE_AFTER_SECONDS validation', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it.each([
+    '0',
+    '-5',
+    '1.5',
+  ])('fails startup when RUNNER_TOOL_CAPABILITIES_STALE_AFTER_SECONDS is %s', async (value) => {
+    vi.stubEnv('RUNNER_TOOL_CAPABILITIES_STALE_AFTER_SECONDS', value);
+    vi.resetModules();
+
+    await expect(import('#config.js')).rejects.toThrow(
+      'RUNNER_TOOL_CAPABILITIES_STALE_AFTER_SECONDS',
+    );
+  });
+
+  it('accepts the default 60 second stale window', async () => {
+    vi.stubEnv('RUNNER_TOOL_CAPABILITIES_STALE_AFTER_SECONDS', '60');
+    vi.resetModules();
+
+    const {config} = await import('#config.js');
+
+    expect(config.RUNNER_TOOL_CAPABILITIES_STALE_AFTER_SECONDS).toBe(60);
+  });
+});
+
 describe('RUNNER_STALE_PROVISIONED_RUNNER_REAPER_LIMIT validation', () => {
   afterEach(() => {
     vi.unstubAllEnvs();

--- a/libs/api/runners/src/config.ts
+++ b/libs/api/runners/src/config.ts
@@ -57,6 +57,10 @@ export const config = createConfig({
     desc: 'Time window, in seconds, used to list active runners from recent heartbeats and provisioned runner reports.',
     default: 60,
   }),
+  RUNNER_TOOL_CAPABILITIES_STALE_AFTER_SECONDS: num({
+    desc: 'Time window, in seconds, after which a runner tool capability report is treated as stale. Set this higher than the runner heartbeat interval so active runners keep their advertised tools fresh.',
+    default: 60,
+  }),
   RUNNER_NO_FIRST_HEARTBEAT_GRACE_SECONDS: num({
     desc: 'Grace window, in seconds, before maintenance expires a claimed job that has not sent its first heartbeat. Set this lower than the normal stuck-job threshold so startup crashes release work quickly.',
     default: 60,
@@ -186,6 +190,15 @@ if (
 ) {
   throw new Error(
     `RUNNER_ACTIVE_WINDOW_SECONDS (${config.RUNNER_ACTIVE_WINDOW_SECONDS}) must be a whole number of seconds >= 1.`,
+  );
+}
+
+if (
+  !Number.isInteger(config.RUNNER_TOOL_CAPABILITIES_STALE_AFTER_SECONDS) ||
+  config.RUNNER_TOOL_CAPABILITIES_STALE_AFTER_SECONDS < 1
+) {
+  throw new Error(
+    `RUNNER_TOOL_CAPABILITIES_STALE_AFTER_SECONDS (${config.RUNNER_TOOL_CAPABILITIES_STALE_AFTER_SECONDS}) must be a whole number of seconds >= 1.`,
   );
 }
 

--- a/libs/api/runners/src/core/runner-tool-capabilities.test.ts
+++ b/libs/api/runners/src/core/runner-tool-capabilities.test.ts
@@ -1,5 +1,13 @@
 import type {RunnerToolCapabilitiesDto} from '@shipfox/api-runners-dto';
-import {effectiveRunnerToolCapabilities} from './runner-tool-capabilities.js';
+import {eq, sql} from 'drizzle-orm';
+import {db} from '#db/db.js';
+import {runnerSessions} from '#db/schema/runner-sessions.js';
+import {runnerSessionFactory} from '#test/index.js';
+import {
+  effectiveRunnerToolCapabilities,
+  getEffectiveRunnerToolCapabilities,
+  unadvertisedRunnerTools,
+} from './runner-tool-capabilities.js';
 
 const capabilities: RunnerToolCapabilitiesDto = {
   harnesses: {
@@ -50,5 +58,84 @@ describe('effectiveRunnerToolCapabilities', () => {
     });
 
     expect(effective).toBe(capabilities);
+  });
+});
+
+describe('unadvertisedRunnerTools', () => {
+  it('returns no tools when every requested tool is advertised', () => {
+    const missing = unadvertisedRunnerTools({
+      harness: 'pi',
+      requestedTools: ['read', 'bash'],
+      capabilities,
+    });
+
+    expect(missing).toEqual([]);
+  });
+
+  it('returns the missing subset in requested order', () => {
+    const missing = unadvertisedRunnerTools({
+      harness: 'pi',
+      requestedTools: ['read', 'web_search', 'bash', 'get_search_content'],
+      capabilities,
+    });
+
+    expect(missing).toEqual(['web_search', 'get_search_content']);
+  });
+
+  it('returns every requested tool when the harness has no advertised tools', () => {
+    const missing = unadvertisedRunnerTools({
+      harness: 'claude',
+      requestedTools: ['read', 'bash'],
+      capabilities,
+    });
+
+    expect(missing).toEqual(['read', 'bash']);
+  });
+
+  it('matches tool names exactly across harnesses', () => {
+    const missing = unadvertisedRunnerTools({
+      harness: 'claude',
+      requestedTools: ['read', 'Read'],
+      capabilities: {harnesses: {claude: {tools: ['read']}, pi: {tools: ['Read']}}},
+    });
+
+    expect(missing).toEqual(['Read']);
+  });
+});
+
+describe('getEffectiveRunnerToolCapabilities', () => {
+  it('returns fresh capabilities and reports the harness as known', async () => {
+    const runnerSession = await runnerSessionFactory.create({toolCapabilities: capabilities});
+
+    const result = await getEffectiveRunnerToolCapabilities({runnerSessionId: runnerSession.id});
+
+    expect(result.capabilities).toEqual(capabilities);
+    expect(result.reportFresh).toBe(true);
+    expect(result.harnessKnown('pi')).toBe(true);
+    expect(result.harnessKnown('claude')).toBe(false);
+  });
+
+  it('treats missing capabilities as unknown', async () => {
+    const runnerSession = await runnerSessionFactory.create({toolCapabilities: null});
+
+    const result = await getEffectiveRunnerToolCapabilities({runnerSessionId: runnerSession.id});
+
+    expect(result.capabilities).toEqual({harnesses: {}});
+    expect(result.reportFresh).toBe(false);
+    expect(result.harnessKnown('pi')).toBe(false);
+  });
+
+  it('treats stale capabilities as unknown', async () => {
+    const runnerSession = await runnerSessionFactory.create({toolCapabilities: capabilities});
+    await db()
+      .update(runnerSessions)
+      .set({toolCapabilitiesReportedAt: sql`now() - interval '1 hour'`})
+      .where(eq(runnerSessions.id, runnerSession.id));
+
+    const result = await getEffectiveRunnerToolCapabilities({runnerSessionId: runnerSession.id});
+
+    expect(result.capabilities).toEqual({harnesses: {}});
+    expect(result.reportFresh).toBe(false);
+    expect(result.harnessKnown('pi')).toBe(false);
   });
 });

--- a/libs/api/runners/src/core/runner-tool-capabilities.ts
+++ b/libs/api/runners/src/core/runner-tool-capabilities.ts
@@ -1,4 +1,8 @@
 import type {RunnerToolCapabilitiesDto} from '@shipfox/api-runners-dto';
+import {config} from '#config.js';
+import {getRunnerSessionById} from '#db/runner-sessions.js';
+
+type RunnerToolHarness = keyof RunnerToolCapabilitiesDto['harnesses'];
 
 export const EMPTY_RUNNER_TOOL_CAPABILITIES: RunnerToolCapabilitiesDto = {
   harnesses: {},
@@ -17,4 +21,55 @@ export function effectiveRunnerToolCapabilities(params: {
   if (ageMs > params.staleAfterSeconds * 1000) return EMPTY_RUNNER_TOOL_CAPABILITIES;
 
   return params.toolCapabilities;
+}
+
+function runnerToolCapabilityReportIsFresh(params: {
+  toolCapabilities: RunnerToolCapabilitiesDto | null | undefined;
+  reportedAt: Date | null | undefined;
+  staleAfterSeconds: number;
+  now?: Date;
+}): boolean {
+  if (!params.toolCapabilities || !params.reportedAt) return false;
+
+  const now = params.now ?? new Date();
+  const ageMs = now.getTime() - params.reportedAt.getTime();
+  return ageMs <= params.staleAfterSeconds * 1000;
+}
+
+export function unadvertisedRunnerTools(params: {
+  harness: RunnerToolHarness;
+  requestedTools: readonly string[];
+  capabilities: RunnerToolCapabilitiesDto;
+}): string[] {
+  const advertised = new Set(params.capabilities.harnesses[params.harness]?.tools ?? []);
+  return params.requestedTools.filter((tool) => !advertised.has(tool));
+}
+
+export interface EffectiveRunnerToolCapabilitiesResult {
+  capabilities: RunnerToolCapabilitiesDto;
+  reportFresh: boolean;
+  harnessKnown(harness: RunnerToolHarness): boolean;
+}
+
+export async function getEffectiveRunnerToolCapabilities(params: {
+  runnerSessionId: string;
+}): Promise<EffectiveRunnerToolCapabilitiesResult> {
+  const runnerSession = await getRunnerSessionById(params.runnerSessionId);
+  const staleAfterSeconds = config.RUNNER_TOOL_CAPABILITIES_STALE_AFTER_SECONDS;
+  const capabilities = effectiveRunnerToolCapabilities({
+    toolCapabilities: runnerSession?.toolCapabilities ?? null,
+    reportedAt: runnerSession?.toolCapabilitiesReportedAt ?? null,
+    staleAfterSeconds,
+  });
+  const reportFresh = runnerToolCapabilityReportIsFresh({
+    toolCapabilities: runnerSession?.toolCapabilities,
+    reportedAt: runnerSession?.toolCapabilitiesReportedAt,
+    staleAfterSeconds,
+  });
+
+  return {
+    capabilities,
+    reportFresh,
+    harnessKnown: (harness) => capabilities.harnesses[harness] !== undefined,
+  };
 }

--- a/libs/api/runners/src/db/job-executions.test.ts
+++ b/libs/api/runners/src/db/job-executions.test.ts
@@ -557,6 +557,40 @@ describe('claimPendingJobExecution', () => {
     expect(claimed?.jobId).toBe(created.jobId);
   });
 
+  it('claims by labels only when runner tool capabilities differ', async () => {
+    const matchingRunner = await runnerSessionFactory.create({
+      workspaceId,
+      labels: sessionLabels,
+      toolCapabilities: {harnesses: {pi: {tools: ['read']}}},
+    });
+    const underProvisionedRunner = await runnerSessionFactory.create({
+      workspaceId,
+      labels: sessionLabels,
+      toolCapabilities: {harnesses: {pi: {tools: []}}},
+    });
+    const firstJob = await pendingJobFactory.create({
+      workspaceId,
+      requiredLabels: ['linux'],
+    });
+    const secondJob = await pendingJobFactory.create({
+      workspaceId,
+      requiredLabels: ['linux'],
+    });
+
+    const firstClaim = await claimPendingJobExecution({
+      workspaceId,
+      runnerSessionId: underProvisionedRunner.id,
+    });
+    const secondClaim = await claimPendingJobExecution({
+      workspaceId,
+      runnerSessionId: matchingRunner.id,
+    });
+
+    expect([firstClaim?.jobId, secondClaim?.jobId].sort()).toEqual(
+      [firstJob.jobId, secondJob.jobId].sort(),
+    );
+  });
+
   it('skips an older incompatible job and claims the oldest compatible job', async () => {
     await pendingJobFactory.create({workspaceId, requiredLabels: ['macos']});
     const compatible = await pendingJobFactory.create({workspaceId, requiredLabels: ['linux']});

--- a/libs/api/runners/src/db/runner-sessions.ts
+++ b/libs/api/runners/src/db/runner-sessions.ts
@@ -36,6 +36,17 @@ export async function createRunnerSession(
   return toRunnerSession(row);
 }
 
+export async function getRunnerSessionById(runnerSessionId: string): Promise<RunnerSession | null> {
+  const rows = await db()
+    .select()
+    .from(runnerSessions)
+    .where(eq(runnerSessions.id, runnerSessionId))
+    .limit(1);
+
+  const row = rows[0];
+  return row ? toRunnerSession(row) : null;
+}
+
 export interface DeleteExpiredRunnerSessionsParams {
   manualRetentionDays: number;
   ephemeralRetentionDays: number;

--- a/libs/api/runners/src/index.ts
+++ b/libs/api/runners/src/index.ts
@@ -27,6 +27,11 @@ export {
   mintEphemeralRegistrationTokensBatch,
 } from '#core/ephemeral-registration-tokens.js';
 export {
+  type EffectiveRunnerToolCapabilitiesResult,
+  getEffectiveRunnerToolCapabilities,
+  unadvertisedRunnerTools,
+} from '#core/runner-tool-capabilities.js';
+export {
   cancelRunnerJobs,
   type EnqueueJobExecutionParams,
   enqueueJobExecution,

--- a/libs/api/workflows/package.json
+++ b/libs/api/workflows/package.json
@@ -41,6 +41,7 @@
     "@shipfox/api-auth": "workspace:*",
     "@shipfox/api-auth-context": "workspace:*",
     "@shipfox/api-agent-dto": "workspace:*",
+    "@shipfox/annotations": "workspace:*",
     "@shipfox/api-definitions": "workspace:*",
     "@shipfox/api-integration-core": "workspace:*",
     "@shipfox/api-projects": "workspace:*",

--- a/libs/api/workflows/src/core/agent-tool-capability-warning.test.ts
+++ b/libs/api/workflows/src/core/agent-tool-capability-warning.test.ts
@@ -1,0 +1,280 @@
+import type {JobLeaseTokenClaims} from '@shipfox/api-auth';
+import {sql} from 'drizzle-orm';
+import {db} from '#db/db.js';
+import {warnAgentToolCapabilityMismatchOnDispatch} from './agent-tool-capability-warning.js';
+import type {Step} from './entities/step.js';
+
+function lease(params: Partial<JobLeaseTokenClaims> = {}): JobLeaseTokenClaims {
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    aud: 'runner-job-lease',
+    iat: now,
+    exp: now + 60,
+    workspaceId: crypto.randomUUID(),
+    projectId: crypto.randomUUID(),
+    workflowRunId: crypto.randomUUID(),
+    workflowRunAttempt: 1,
+    workflowRunAttemptId: crypto.randomUUID(),
+    jobId: crypto.randomUUID(),
+    jobExecutionId: crypto.randomUUID(),
+    runnerSessionId: crypto.randomUUID(),
+    currentStepId: crypto.randomUUID(),
+    currentStepAttempt: 1,
+    ...params,
+  };
+}
+
+function agentStep(params: Partial<Step> = {}): Step {
+  return {
+    id: crypto.randomUUID(),
+    jobExecutionId: crypto.randomUUID(),
+    key: 'fix',
+    name: 'Fix',
+    sourceLocation: null,
+    status: 'running',
+    statusReason: null,
+    evaluationTrace: null,
+    type: 'agent',
+    config: {
+      harness: 'pi',
+      provider: 'anthropic',
+      model: 'claude-opus-4-8',
+      thinking: 'high',
+      tools: ['read', 'web_search'],
+      prompt: 'Fix it.',
+    },
+    condition: null,
+    configPlan: null,
+    authoredConfig: null,
+    error: null,
+    position: 0,
+    version: 1,
+    currentAttempt: 1,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...params,
+  };
+}
+
+async function insertRunnerSession(params: {
+  runnerSessionId: string;
+  workspaceId: string;
+  toolCapabilities: Record<string, unknown> | null;
+  reportedAt?: 'fresh' | 'stale' | 'missing';
+}): Promise<void> {
+  const reportedAt =
+    params.reportedAt === 'missing'
+      ? sql`NULL`
+      : params.reportedAt === 'stale'
+        ? sql`now() - interval '1 hour'`
+        : sql`now()`;
+  const toolCapabilities =
+    params.toolCapabilities === null
+      ? sql`NULL`
+      : sql`${JSON.stringify(params.toolCapabilities)}::jsonb`;
+
+  await db().execute(sql`
+    INSERT INTO runners_runner_sessions (
+      id,
+      workspace_id,
+      scope,
+      registration_token_id,
+      registration_token_kind,
+      labels,
+      tool_capabilities,
+      tool_capabilities_reported_at
+    )
+    VALUES (
+      ${params.runnerSessionId},
+      ${params.workspaceId},
+      'workspace',
+      ${crypto.randomUUID()},
+      'manual',
+      ARRAY['linux'],
+      ${toolCapabilities},
+      ${reportedAt}
+    )
+  `);
+}
+
+async function annotationsFor(
+  jobExecutionId: string,
+): Promise<Array<{context: string; body: string}>> {
+  const result = await db().execute<{context: string; body: string}>(sql`
+    SELECT context, body
+    FROM annotations_annotations
+    WHERE job_execution_id = ${jobExecutionId}
+    ORDER BY sequence
+  `);
+  return [...result.rows];
+}
+
+describe('warnAgentToolCapabilityMismatchOnDispatch', () => {
+  it('writes a warning when the matched runner advertised a set without requested tools', async () => {
+    const identity = lease();
+    const step = agentStep({jobExecutionId: identity.jobExecutionId});
+    await insertRunnerSession({
+      runnerSessionId: identity.runnerSessionId,
+      workspaceId: identity.workspaceId,
+      toolCapabilities: {harnesses: {pi: {tools: ['read']}}},
+    });
+
+    await warnAgentToolCapabilityMismatchOnDispatch({leaseIdentity: identity, step});
+
+    const rows = await annotationsFor(identity.jobExecutionId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.context).toBe(`agent-tool-capability:${step.id}`);
+    expect(rows[0]?.body).toContain('advertised a `pi` tool set without: `web_search`');
+    expect(rows[0]?.body).toContain('Execution is continuing');
+  });
+
+  it('writes unknown wording when capabilities are missing', async () => {
+    const identity = lease();
+    const step = agentStep({jobExecutionId: identity.jobExecutionId});
+    await insertRunnerSession({
+      runnerSessionId: identity.runnerSessionId,
+      workspaceId: identity.workspaceId,
+      toolCapabilities: null,
+      reportedAt: 'missing',
+    });
+
+    await warnAgentToolCapabilityMismatchOnDispatch({leaseIdentity: identity, step});
+
+    const rows = await annotationsFor(identity.jobExecutionId);
+    expect(rows[0]?.body).toContain('reported no or stale tool capabilities');
+    expect(rows[0]?.body).toContain('`read`, `web_search`');
+  });
+
+  it('writes missing-harness wording when fresh capabilities omit the harness', async () => {
+    const identity = lease();
+    const step = agentStep({jobExecutionId: identity.jobExecutionId});
+    await insertRunnerSession({
+      runnerSessionId: identity.runnerSessionId,
+      workspaceId: identity.workspaceId,
+      toolCapabilities: {harnesses: {claude: {tools: ['read', 'web_search']}}},
+    });
+
+    await warnAgentToolCapabilityMismatchOnDispatch({leaseIdentity: identity, step});
+
+    const rows = await annotationsFor(identity.jobExecutionId);
+    expect(rows[0]?.body).toContain('did not advertise a `pi` tool set');
+    expect(rows[0]?.body).not.toContain('reported no or stale tool capabilities');
+  });
+
+  it('uses Markdown-safe code spans for requested tool names', async () => {
+    const identity = lease();
+    const step = agentStep({
+      jobExecutionId: identity.jobExecutionId,
+      config: {
+        harness: 'pi',
+        provider: 'anthropic',
+        model: 'claude-opus-4-8',
+        thinking: 'high',
+        tools: ['read', 'we`ird'],
+        prompt: 'Fix it.',
+      },
+    });
+    await insertRunnerSession({
+      runnerSessionId: identity.runnerSessionId,
+      workspaceId: identity.workspaceId,
+      toolCapabilities: {harnesses: {pi: {tools: ['read']}}},
+    });
+
+    await warnAgentToolCapabilityMismatchOnDispatch({leaseIdentity: identity, step});
+
+    const rows = await annotationsFor(identity.jobExecutionId);
+    expect(rows[0]?.body).toContain('``we`ird``');
+  });
+
+  it('removes an existing warning when a later dispatch has all requested tools', async () => {
+    const identity = lease();
+    const step = agentStep({jobExecutionId: identity.jobExecutionId});
+    await insertRunnerSession({
+      runnerSessionId: identity.runnerSessionId,
+      workspaceId: identity.workspaceId,
+      toolCapabilities: {harnesses: {pi: {tools: ['read']}}},
+    });
+    await warnAgentToolCapabilityMismatchOnDispatch({leaseIdentity: identity, step});
+    await db().execute(sql`
+      UPDATE runners_runner_sessions
+      SET tool_capabilities = ${JSON.stringify({
+        harnesses: {pi: {tools: ['read', 'web_search']}},
+      })}::jsonb,
+      tool_capabilities_reported_at = now()
+      WHERE id = ${identity.runnerSessionId}
+    `);
+
+    await warnAgentToolCapabilityMismatchOnDispatch({leaseIdentity: identity, step});
+
+    const rows = await annotationsFor(identity.jobExecutionId);
+    expect(rows).toEqual([]);
+  });
+
+  it('does nothing for agent steps without requested tools', async () => {
+    const identity = lease();
+    const step = agentStep({
+      jobExecutionId: identity.jobExecutionId,
+      config: {
+        harness: 'pi',
+        provider: 'anthropic',
+        model: 'claude-opus-4-8',
+        thinking: 'high',
+        prompt: 'Fix it.',
+      },
+    });
+    await insertRunnerSession({
+      runnerSessionId: identity.runnerSessionId,
+      workspaceId: identity.workspaceId,
+      toolCapabilities: null,
+    });
+
+    await warnAgentToolCapabilityMismatchOnDispatch({leaseIdentity: identity, step});
+
+    expect(await annotationsFor(identity.jobExecutionId)).toEqual([]);
+  });
+
+  it('does nothing for non-agent steps', async () => {
+    const identity = lease();
+    const step = agentStep({
+      jobExecutionId: identity.jobExecutionId,
+      type: 'run',
+      config: {run: 'echo ok'},
+    });
+    await insertRunnerSession({
+      runnerSessionId: identity.runnerSessionId,
+      workspaceId: identity.workspaceId,
+      toolCapabilities: null,
+    });
+
+    await warnAgentToolCapabilityMismatchOnDispatch({leaseIdentity: identity, step});
+
+    expect(await annotationsFor(identity.jobExecutionId)).toEqual([]);
+  });
+
+  it('caps long tool lists in the warning body', async () => {
+    const identity = lease();
+    const tools = Array.from({length: 12}, (_, index) => `tool_${index}`);
+    const step = agentStep({
+      jobExecutionId: identity.jobExecutionId,
+      config: {
+        harness: 'pi',
+        provider: 'anthropic',
+        model: 'claude-opus-4-8',
+        thinking: 'high',
+        tools,
+        prompt: 'Fix it.',
+      },
+    });
+    await insertRunnerSession({
+      runnerSessionId: identity.runnerSessionId,
+      workspaceId: identity.workspaceId,
+      toolCapabilities: {harnesses: {pi: {tools: []}}},
+    });
+
+    await warnAgentToolCapabilityMismatchOnDispatch({leaseIdentity: identity, step});
+
+    const rows = await annotationsFor(identity.jobExecutionId);
+    expect(rows[0]?.body).toContain('...and 2 more');
+    expect(rows[0]?.body).not.toContain('tool_10');
+  });
+});

--- a/libs/api/workflows/src/core/agent-tool-capability-warning.ts
+++ b/libs/api/workflows/src/core/agent-tool-capability-warning.ts
@@ -1,0 +1,200 @@
+import {
+  AnnotationBodyTooLargeError,
+  AnnotationCountLimitExceededError,
+  AnnotationTotalBytesLimitExceededError,
+  type WriteAnnotationsParams,
+  writeAnnotations,
+} from '@shipfox/annotations';
+import {
+  harnessSchema,
+  type MaterializedAgentStepConfigDto,
+  materializedAgentStepConfigSchema,
+} from '@shipfox/api-agent-dto';
+import type {LeasedJobContext} from '@shipfox/api-auth-context';
+import {getEffectiveRunnerToolCapabilities, unadvertisedRunnerTools} from '@shipfox/api-runners';
+import {logger} from '@shipfox/node-opentelemetry';
+import {recordWorkflowAgentToolWarningFailed} from '#metrics/instance.js';
+import type {Step} from './entities/step.js';
+
+const TOOL_LIST_LIMIT = 10;
+
+type WarningFailureReason = 'budget' | 'lookup' | 'write';
+type WarningReason = 'known-absence' | 'harness-not-advertised' | 'unknown-or-stale';
+
+export async function warnAgentToolCapabilityMismatchOnDispatch(params: {
+  leaseIdentity: LeasedJobContext;
+  step: Step;
+}): Promise<void> {
+  const config = parseAgentConfig(params.step);
+  if (!config) return;
+
+  const requestedTools = config.tools ?? [];
+  if (requestedTools.length === 0) return;
+
+  const harness = harnessSchema.safeParse(config.harness);
+  if (!harness.success) return;
+
+  let effective: Awaited<ReturnType<typeof getEffectiveRunnerToolCapabilities>>;
+  try {
+    effective = await getEffectiveRunnerToolCapabilities({
+      runnerSessionId: params.leaseIdentity.runnerSessionId,
+    });
+  } catch (error) {
+    recordWarningWriteFailure('lookup');
+    logger().warn(
+      {error, jobExecutionId: params.leaseIdentity.jobExecutionId, stepId: params.step.id},
+      'Failed to read runner tool capabilities for agent tool warning',
+    );
+    return;
+  }
+
+  const missing = unadvertisedRunnerTools({
+    harness: harness.data,
+    requestedTools,
+    capabilities: effective.capabilities,
+  });
+  const context = `agent-tool-capability:${params.step.id}`;
+
+  const operation =
+    missing.length === 0
+      ? {context, style: 'warning' as const, op: 'remove' as const}
+      : {
+          context,
+          style: 'warning' as const,
+          op: 'replace' as const,
+          body: warningBody({
+            harness: harness.data,
+            missing,
+            reason: warningReason({
+              reportFresh: effective.reportFresh,
+              harnessKnown: effective.harnessKnown(harness.data),
+            }),
+          }),
+        };
+
+  try {
+    await writeAnnotations({
+      ...writeParamsFromLease(params.leaseIdentity),
+      originStepId: params.step.id,
+      originStepAttempt: params.step.currentAttempt,
+      operations: [operation],
+    });
+  } catch (error) {
+    const reason = isAnnotationBudgetError(error) ? 'budget' : 'write';
+    recordWarningWriteFailure(reason);
+    logger().warn(
+      {
+        error,
+        reason,
+        jobExecutionId: params.leaseIdentity.jobExecutionId,
+        stepId: params.step.id,
+      },
+      'Failed to write agent tool capability warning annotation',
+    );
+    return;
+  }
+
+  if (missing.length > 0) {
+    logger().warn(
+      {
+        jobExecutionId: params.leaseIdentity.jobExecutionId,
+        stepId: params.step.id,
+        harness: harness.data,
+        missing,
+        reason: warningReason({
+          reportFresh: effective.reportFresh,
+          harnessKnown: effective.harnessKnown(harness.data),
+        }),
+      },
+      'Runner missing requested agent tools; dispatch is continuing',
+    );
+  }
+}
+
+function parseAgentConfig(step: Step): MaterializedAgentStepConfigDto | null {
+  if (step.type !== 'agent') return null;
+
+  const parsed = materializedAgentStepConfigSchema.safeParse(step.config);
+  return parsed.success ? parsed.data : null;
+}
+
+function warningBody(params: {
+  harness: string;
+  missing: readonly string[];
+  reason: WarningReason;
+}): string {
+  const tools = formatToolList(params.missing);
+  const harness = markdownInlineCode(params.harness);
+  if (params.reason === 'known-absence') {
+    return [
+      '**Runner missing requested agent tools**',
+      '',
+      `The matched runner advertised a ${harness} tool set without: ${tools}.`,
+      'Execution is continuing on this runner because labels matched; the step may fail if the harness cannot provide these tools.',
+    ].join('\n');
+  }
+
+  if (params.reason === 'harness-not-advertised') {
+    return [
+      '**Runner missing requested agent harness tools**',
+      '',
+      `The matched runner advertised fresh tool capabilities, but did not advertise a ${harness} tool set. Support for ${tools} could not be confirmed.`,
+      'Execution is continuing on this runner because labels matched; the step may fail if the harness cannot provide these tools.',
+    ].join('\n');
+  }
+
+  return [
+    '**Could not confirm runner agent tools**',
+    '',
+    `The matched runner reported no or stale tool capabilities, so support for ${tools} could not be confirmed.`,
+    'Execution is continuing on this runner because labels matched.',
+  ].join('\n');
+}
+
+function formatToolList(tools: readonly string[]): string {
+  const visible = tools.slice(0, TOOL_LIST_LIMIT).map(markdownInlineCode);
+  const remaining = tools.length - visible.length;
+  return remaining > 0 ? `${visible.join(', ')} ...and ${remaining} more` : visible.join(', ');
+}
+
+function markdownInlineCode(value: string): string {
+  const maxBacktickRun = Math.max(
+    0,
+    ...Array.from(value.matchAll(/`+/g), (match) => match[0].length),
+  );
+  const delimiter = '`'.repeat(maxBacktickRun + 1);
+  const needsPadding = value.startsWith('`') || value.endsWith('`');
+  const content = needsPadding ? ` ${value} ` : value;
+  return `${delimiter}${content}${delimiter}`;
+}
+
+function warningReason(params: {reportFresh: boolean; harnessKnown: boolean}): WarningReason {
+  if (params.harnessKnown) return 'known-absence';
+  return params.reportFresh ? 'harness-not-advertised' : 'unknown-or-stale';
+}
+
+function writeParamsFromLease(
+  lease: LeasedJobContext,
+): Omit<WriteAnnotationsParams, 'originStepId' | 'originStepAttempt' | 'operations'> {
+  return {
+    workspaceId: lease.workspaceId,
+    projectId: lease.projectId,
+    workflowRunId: lease.workflowRunId,
+    workflowRunAttempt: lease.workflowRunAttempt ?? 1,
+    workflowRunAttemptId: lease.workflowRunAttemptId,
+    jobId: lease.jobId,
+    jobExecutionId: lease.jobExecutionId,
+  };
+}
+
+function isAnnotationBudgetError(error: unknown): boolean {
+  return (
+    error instanceof AnnotationBodyTooLargeError ||
+    error instanceof AnnotationCountLimitExceededError ||
+    error instanceof AnnotationTotalBytesLimitExceededError
+  );
+}
+
+function recordWarningWriteFailure(reason: WarningFailureReason): void {
+  recordWorkflowAgentToolWarningFailed(reason);
+}

--- a/libs/api/workflows/src/core/job-execution.test.ts
+++ b/libs/api/workflows/src/core/job-execution.test.ts
@@ -108,7 +108,11 @@ describe('nextStepForJob', () => {
 
     const result = await nextStepForJob(jobId);
 
-    expect(result).toEqual({kind: 'step', step: expect.objectContaining({id: steps[0]?.id})});
+    expect(result).toEqual({
+      kind: 'step',
+      step: expect.objectContaining({id: steps[0]?.id}),
+      dispatched: true,
+    });
     const after = await getStepsByJobId(jobId);
     expect(after[0]?.status).toBe('running');
     expect(after[1]?.status).toBe('pending');
@@ -126,6 +130,8 @@ describe('nextStepForJob', () => {
     const firstId = first.kind === 'step' ? first.step.id : null;
     const secondId = second.kind === 'step' ? second.step.id : null;
     expect(secondId).toBe(firstId);
+    expect(first.kind === 'step' ? first.dispatched : undefined).toBe(true);
+    expect(second.kind === 'step' ? second.dispatched : undefined).toBe(false);
     const running = (await getStepsByJobId(jobId)).filter((s) => s.status === 'running');
     expect(running).toHaveLength(1);
   });
@@ -137,7 +143,11 @@ describe('nextStepForJob', () => {
 
     const next = await nextStepForJob(jobId);
 
-    expect(next).toEqual({kind: 'step', step: expect.objectContaining({id: steps[1]?.id})});
+    expect(next).toEqual({
+      kind: 'step',
+      step: expect.objectContaining({id: steps[1]?.id}),
+      dispatched: true,
+    });
   });
 
   test('fills dispatch config from terminal step attempt output', async () => {
@@ -173,6 +183,7 @@ describe('nextStepForJob', () => {
         config: {run: 'echo ok', env: {SHA: 'abc123'}},
         configPlan: {env: {SHA: shaPlan}},
       }),
+      dispatched: true,
     });
     expect(redelivery).toEqual({
       kind: 'step',
@@ -181,6 +192,7 @@ describe('nextStepForJob', () => {
         config: {run: 'echo ok', env: {SHA: 'abc123'}},
         configPlan: {env: {SHA: shaPlan}},
       }),
+      dispatched: false,
     });
     const attempts = await getStepAttempts(jobId);
     expect(attempts.find((attempt) => attempt.stepId === consumer.id)).toMatchObject({
@@ -247,6 +259,7 @@ describe('nextStepForJob', () => {
         currentAttempt: 1,
         config: expect.objectContaining({env: {SHA: 'abc123'}}),
       }),
+      dispatched: true,
     });
     expect(secondConsumer).toEqual({
       kind: 'step',
@@ -256,6 +269,7 @@ describe('nextStepForJob', () => {
         config: expect.objectContaining({env: {SHA: 'def456'}}),
         configPlan: {env: {SHA: shaPlan}},
       }),
+      dispatched: true,
     });
     const attempts = await getStepAttempts(jobId);
     expect(
@@ -355,7 +369,11 @@ describe('nextStepForJob', () => {
 
     const result = await nextStepForJob(jobId);
 
-    expect(result).toEqual({kind: 'step', step: expect.objectContaining({id: runnableStep.id})});
+    expect(result).toEqual({
+      kind: 'step',
+      step: expect.objectContaining({id: runnableStep.id}),
+      dispatched: true,
+    });
     const after = await getStepsByJobId(jobId);
     expect(after.find((step) => step.id === skippedStep.id)).toMatchObject({
       status: 'skipped',
@@ -378,7 +396,11 @@ describe('nextStepForJob', () => {
 
     const result = await nextStepForJob(jobId);
 
-    expect(result).toEqual({kind: 'step', step: expect.objectContaining({id: runnableStep.id})});
+    expect(result).toEqual({
+      kind: 'step',
+      step: expect.objectContaining({id: runnableStep.id}),
+      dispatched: true,
+    });
     const after = await getStepsByJobId(jobId);
     expect(after.find((step) => step.id === skippedStep.id)).toMatchObject({
       status: 'skipped',
@@ -399,7 +421,11 @@ describe('nextStepForJob', () => {
 
     const result = await nextStepForJob(jobId);
 
-    expect(result).toEqual({kind: 'step', step: expect.objectContaining({id: third.id})});
+    expect(result).toEqual({
+      kind: 'step',
+      step: expect.objectContaining({id: third.id}),
+      dispatched: true,
+    });
     if (result.kind !== 'step') throw new Error('Expected a runnable step');
     expect(result.step.config).not.toHaveProperty('if');
     expect(result.step.condition).toBeNull();
@@ -625,7 +651,11 @@ describe('recordStepResult', () => {
 
     const next = await nextStepForJob(jobId);
 
-    expect(next).toEqual({kind: 'step', step: expect.objectContaining({id: cleanup.id})});
+    expect(next).toEqual({
+      kind: 'step',
+      step: expect.objectContaining({id: cleanup.id}),
+      dispatched: true,
+    });
     await recordStepResult({jobId, stepId: cleanup.id, status: 'succeeded'});
     const done = await nextStepForJob(jobId);
     expect(done).toEqual({kind: 'done', status: 'failed'});
@@ -652,7 +682,11 @@ describe('recordStepResult', () => {
 
     const next = await nextStepForJob(jobId);
 
-    expect(next).toEqual({kind: 'step', step: expect.objectContaining({id: upload.id})});
+    expect(next).toEqual({
+      kind: 'step',
+      step: expect.objectContaining({id: upload.id}),
+      dispatched: true,
+    });
     await recordStepResult({jobId, stepId: upload.id, status: 'succeeded'});
     expect(await nextStepForJob(jobId)).toEqual({kind: 'done', status: 'failed'});
   });
@@ -774,6 +808,7 @@ describe('recordStepResult', () => {
         id: consumer.id,
         config: {run: 'deploy', env: {COUNT: '42'}},
       }),
+      dispatched: true,
     });
   });
 
@@ -1472,6 +1507,7 @@ describe('durable gate restart', () => {
           }),
         },
       }),
+      dispatched: true,
     });
     const attempts = await getStepAttempts(jobId);
     const reviewerAttempt = attempts.find((attempt) => attempt.stepId === reviewer);

--- a/libs/api/workflows/src/core/job-execution.ts
+++ b/libs/api/workflows/src/core/job-execution.ts
@@ -71,7 +71,9 @@ type ReportedStepResult = {
   readonly exitCode: number | null;
 };
 
-export type NextStep = {kind: 'step'; step: Step} | {kind: 'done'; status: CompletionStatus};
+export type NextStep =
+  | {kind: 'step'; step: Step; dispatched: boolean}
+  | {kind: 'done'; status: CompletionStatus};
 
 type DispatchConfigError = InterpolationUnresolvableError | AgentConfigUnresolvableError;
 
@@ -115,7 +117,7 @@ async function nextStepForJobExecutionInTransaction(
   // cannot skip a step.
   const running = steps.find((step) => step.status === 'running');
   const hasRunningStep = running !== undefined;
-  if (hasRunningStep) return {kind: 'step', step: running};
+  if (hasRunningStep) return {kind: 'step', step: running, dispatched: false};
 
   const firstPending = steps.find((step) => step.status === 'pending');
   const hasPendingStep = firstPending !== undefined;
@@ -197,7 +199,7 @@ async function dispatchPendingStep(params: PendingStepDispatchParams): Promise<N
     {jobExecutionId: params.jobExecutionId, stepId: params.pending.id},
     params.tx,
   );
-  return {kind: 'step', step: marked ?? params.pending};
+  return {kind: 'step', step: marked ?? params.pending, dispatched: true};
 }
 
 async function dispatchPendingStepWithConfigPlan({
@@ -223,7 +225,7 @@ async function dispatchPendingStepWithConfigPlan({
       },
       tx,
     );
-    return {kind: 'step', step: marked ?? {...pending, config: completed.config}};
+    return {kind: 'step', step: marked ?? {...pending, config: completed.config}, dispatched: true};
   } catch (error) {
     const configError = toDispatchConfigError(error);
     const isConfigError = configError !== null;

--- a/libs/api/workflows/src/db/job-listeners.test.ts
+++ b/libs/api/workflows/src/db/job-listeners.test.ts
@@ -756,6 +756,7 @@ describe('drainListenerEventsIntoExecution', () => {
         key: 'deploy',
         config: {run: 'echo "$SHA"', env: {SHA: 'abc123'}},
       }),
+      dispatched: true,
     });
   });
 

--- a/libs/api/workflows/src/db/workflow-runs/run-create.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-create.test.ts
@@ -206,6 +206,7 @@ describe('workflow run queries', () => {
           key: 'deploy',
           config: expect.objectContaining({env: {IMAGE_SHA: 'abc123'}}),
         }),
+        dispatched: true,
       });
     });
 

--- a/libs/api/workflows/src/db/workflow-runs/run-rerun.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-rerun.test.ts
@@ -395,6 +395,7 @@ describe('workflow run queries', () => {
           config: {run: 'deploy', env: {SHA: 'new-snapshot'}},
           configPlan: {env: {SHA: shaPlan}},
         }),
+        dispatched: true,
       });
       const attempts = await getStepAttempts(rerunJob.id);
       expect(attempts.find((attempt) => attempt.stepId === sourceConsumer.id)).toBeUndefined();

--- a/libs/api/workflows/src/metrics/instance.ts
+++ b/libs/api/workflows/src/metrics/instance.ts
@@ -78,6 +78,12 @@ const listenerResolvedCount = meter.createCounter<{reason: ResolutionReason}>(
   {description: 'Listener resolutions by bounded reason'},
 );
 
+const agentToolWarningFailedCount = meter.createCounter<{
+  reason: 'budget' | 'lookup' | 'write';
+}>('workflows_agent_tool_warning_failed', {
+  description: 'Agent tool capability warning failures by bounded reason',
+});
+
 const listenerEventsCoalesced = meter.createHistogram<Record<string, never>>(
   'workflows_listener_events_coalesced',
   {
@@ -147,4 +153,8 @@ export function recordWorkflowListenerResolved(reason: ResolutionReason): void {
 
 export function recordListenerEventsCoalesced(batchSize: number): void {
   listenerEventsCoalesced.record(batchSize);
+}
+
+export function recordWorkflowAgentToolWarningFailed(reason: 'budget' | 'lookup' | 'write'): void {
+  agentToolWarningFailedCount.add(1, {reason});
 }

--- a/libs/api/workflows/src/presentation/routes/next-step.test.ts
+++ b/libs/api/workflows/src/presentation/routes/next-step.test.ts
@@ -1,6 +1,6 @@
 import {createLeaseTokenAuthMethod, verifyJobLeaseToken} from '@shipfox/api-auth';
 import {closeApp, createApp, type FastifyInstance} from '@shipfox/node-fastify';
-import {eq} from 'drizzle-orm';
+import {eq, sql} from 'drizzle-orm';
 import {JobNotFoundError} from '#core/errors.js';
 import {recordStepResult as recordJobExecutionStepResult} from '#core/job-execution.js';
 import {db} from '#db/db.js';
@@ -28,6 +28,27 @@ async function recordStepResult(
   if (!step) throw new JobNotFoundError(params.jobId);
   const {jobId: _jobId, ...rest} = params;
   return recordJobExecutionStepResult({...rest, jobExecutionId: step.jobExecutionId});
+}
+
+async function setRunnerToolCapabilities(
+  runnerSessionId: string,
+  capabilities: Record<string, unknown>,
+): Promise<void> {
+  await db().execute(sql`
+    UPDATE runners_runner_sessions
+    SET tool_capabilities = ${JSON.stringify(capabilities)}::jsonb,
+      tool_capabilities_reported_at = now()
+    WHERE id = ${runnerSessionId}
+  `);
+}
+
+async function annotationCount(jobExecutionId: string): Promise<number> {
+  const result = await db().execute<{count: string}>(sql`
+    SELECT count(*)::text AS count
+    FROM annotations_annotations
+    WHERE job_execution_id = ${jobExecutionId}
+  `);
+  return Number(result.rows[0]?.count ?? '0');
 }
 
 describe('POST /runs/jobs/current/steps/next', () => {
@@ -175,6 +196,43 @@ describe('POST /runs/jobs/current/steps/next', () => {
     expect(second.json().step.id).toBe(first.json().step.id);
     const running = (await getStepsByJobId(jobId)).filter((s) => s.status === 'running');
     expect(running).toHaveLength(1);
+  });
+
+  test('writes the tool capability warning only on fresh dispatch', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(1);
+    await db()
+      .update(stepsTable)
+      .set({
+        type: 'agent',
+        config: {
+          harness: 'pi',
+          provider: 'anthropic',
+          model: 'claude-opus-4-8',
+          thinking: 'high',
+          tools: ['read', 'web_search'],
+          prompt: 'Fix it.',
+        },
+      })
+      .where(eq(stepsTable.id, steps[0]?.id as string));
+    const token = await mintActiveLeaseToken({jobId});
+    const lease = await verifyJobLeaseToken(token);
+    if (!lease) throw new Error('Expected minted lease token to verify');
+    await setRunnerToolCapabilities(lease.runnerSessionId, {harnesses: {pi: {tools: ['read']}}});
+
+    const first = await app.inject({
+      method: 'POST',
+      url: URL,
+      headers: {authorization: `Bearer ${token}`},
+    });
+    const second = await app.inject({
+      method: 'POST',
+      url: URL,
+      headers: {authorization: `Bearer ${token}`},
+    });
+
+    expect(first.statusCode).toBe(200);
+    expect(second.statusCode).toBe(200);
+    expect(await annotationCount(lease.jobExecutionId)).toBe(1);
   });
 
   test('returns 404 for a valid token without an active lease', async () => {

--- a/libs/api/workflows/src/presentation/routes/next-step.ts
+++ b/libs/api/workflows/src/presentation/routes/next-step.ts
@@ -2,6 +2,7 @@ import {issueJobLeaseToken, jobLeaseParamsFrom} from '@shipfox/api-auth';
 import {requireLeasedJobContext} from '@shipfox/api-auth-context';
 import {nextStepResponseSchema} from '@shipfox/api-workflows-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
+import {warnAgentToolCapabilityMismatchOnDispatch} from '#core/agent-tool-capability-warning.js';
 import {JobLeaseNotActiveError, JobNotFoundError} from '#core/errors.js';
 import {nextStepForLeasedJobExecution} from '#core/job-execution.js';
 import {toStepDto} from '#presentation/dto/step.js';
@@ -41,6 +42,12 @@ export const nextStepRoute = defineRoute({
           currentStepAttempt: next.step.currentAttempt,
         }),
       );
+      if (next.dispatched) {
+        await warnAgentToolCapabilityMismatchOnDispatch({
+          leaseIdentity: leasedJob,
+          step: next.step,
+        });
+      }
       // The runner echoes this back on report so a stale report from a superseded
       // attempt is ignored.
       return {

--- a/libs/api/workflows/test/globalSetup.ts
+++ b/libs/api/workflows/test/globalSetup.ts
@@ -1,4 +1,5 @@
 import './env.js';
+import {annotationsModule} from '@shipfox/annotations';
 import {agentModule} from '@shipfox/api-agent';
 import {runnersModule} from '@shipfox/api-runners';
 import {secretsModule} from '@shipfox/api-secrets';
@@ -34,10 +35,19 @@ export async function setup() {
     secretsModule.database.migrationsPath,
     '__drizzle_migrations_secrets',
   );
+  if (!annotationsModule.database || Array.isArray(annotationsModule.database)) {
+    throw new Error('Annotations module database is not configured');
+  }
+  await runMigrations(
+    annotationsModule.database.db(),
+    annotationsModule.database.migrationsPath,
+    '__drizzle_migrations_annotations',
+  );
   await runMigrations(db(), migrationsPath, '__drizzle_migrations_workflows');
   await db().execute(sql`TRUNCATE workflows_workflow_runs CASCADE`);
   await db().execute(sql`TRUNCATE workflows_job_listener_events CASCADE`);
   await db().execute(sql`TRUNCATE workflows_outbox CASCADE`);
+  await db().execute(sql`TRUNCATE annotations_annotations CASCADE`);
 
   closeDb();
   await closePostgresClient();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3012,6 +3012,9 @@ importers:
 
   libs/api/workflows:
     dependencies:
+      '@shipfox/annotations':
+        specifier: workspace:*
+        version: link:../annotations
       '@shipfox/api-agent':
         specifier: workspace:*
         version: link:../agent


### PR DESCRIPTION
Warn on agent tool-capability mismatches during workflow dispatch.

Workflow authors can request agent tools, and runners now advertise the tools their harnesses can provide. This compares the dispatched agent step's requested tools with the matched runner session's effective advertised capabilities and writes a run-visible warning annotation when support is missing, unknown, or stale.

Runner selection remains labels-only. The warning is best-effort, records bounded failure metrics when annotation writing fails, and runs only on fresh dispatch so retry polls do not repeatedly take the annotation path.

Closes ENG-838

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add non-blocking warnings when an agent step requests tools not advertised by the matched runner at dispatch time. Selection stays label-only; warnings appear as run annotations and only on fresh dispatch. Closes ENG-838.

- **New Features**
  - Compare requested agent tools with the runner’s effective capabilities (staleness via `RUNNER_TOOL_CAPABILITIES_STALE_AFTER_SECONDS`, validated integer ≥1, default 60s).
  - Write or remove a warning annotation per step (`agent-tool-capability:<stepId>`); cap tool lists; distinct wording for missing/stale reports and for fresh reports that omit the harness; skip unchanged “replace” writes to preserve original attribution.
  - Only writes on fresh dispatch (new `dispatched` flag in `NextStep`); best-effort with bounded failure metrics `workflows_agent_tool_warning_failed`.
  - New APIs: `getEffectiveRunnerToolCapabilities`, `unadvertisedRunnerTools`; export `writeAnnotations` and annotation error types from `@shipfox/annotations`.

- **Dependencies**
  - Added `@shipfox/annotations` to `@shipfox/api-workflows`.

<sup>Written for commit f7ae2231b0d8161425647b3b00ac84d32b18f9bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

