### PR TITLE
[api-integration-github] Match GitHub Actions log tool behavior

### DIFF
--- a/libs/api/integration/github/src/core/actions-logs.test.ts
+++ b/libs/api/integration/github/src/core/actions-logs.test.ts
@@ -1,0 +1,156 @@
+import {
+  buildGithubFailedJobLogsResult,
+  buildGithubSingleJobLogResult,
+  DEFAULT_JOB_LOG_TAIL_LINES,
+  MAX_JOB_LOG_LINE_BYTES,
+  MAX_TRUNCATED_JOB_LOG_LINE_CHARS,
+  processGithubJobLogContent,
+} from './actions-logs.js';
+
+describe('buildGithubSingleJobLogResult', () => {
+  it('returns a logs URL without fetching content by default', async () => {
+    const fetchContent = vi.fn(() => Promise.resolve('full log'));
+
+    const result = await buildGithubSingleJobLogResult({
+      job: job({fetchContent}),
+    });
+
+    expect(fetchContent).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      job_id: 1,
+      job_name: 'Unit tests',
+      logs_url: 'https://github.example/logs/1',
+      message: 'Job logs are available for download',
+      note: 'The logs_url provides a download link for the individual job logs in plain text format.\nUse return_content=true to get the actual log content.',
+    });
+  });
+
+  it('returns default tail content when content is requested', async () => {
+    const lines = Array.from(
+      {length: DEFAULT_JOB_LOG_TAIL_LINES + 50},
+      (_value, index) => `line ${index + 1}`,
+    );
+
+    const result = await buildGithubSingleJobLogResult({
+      job: job({fetchContent: async () => lines.join('\n')}),
+      returnContent: true,
+    });
+
+    expect(result).toEqual({
+      job_id: 1,
+      job_name: 'Unit tests',
+      logs_content: lines.slice(-DEFAULT_JOB_LOG_TAIL_LINES).join('\n'),
+      message: 'Job logs content retrieved successfully',
+      original_length: DEFAULT_JOB_LOG_TAIL_LINES + 50,
+    });
+  });
+});
+
+describe('buildGithubFailedJobLogsResult', () => {
+  it('reports when a workflow run has no failed jobs', async () => {
+    const result = await buildGithubFailedJobLogsResult({
+      runId: 123,
+      jobs: [job({conclusion: 'success'})],
+    });
+
+    expect(result).toEqual({
+      message: 'No failed jobs found in this workflow run',
+      run_id: 123,
+      total_jobs: 1,
+      failed_jobs: 0,
+    });
+  });
+
+  it('returns logs for every failed job without a failed-job cap', async () => {
+    const jobs = Array.from({length: 25}, (_value, index) =>
+      job({jobId: index + 1, conclusion: index % 2 === 0 ? 'failure' : 'success'}),
+    );
+
+    const result = await buildGithubFailedJobLogsResult({runId: 123, jobs});
+
+    expect(result).toMatchObject({
+      message: 'Retrieved logs for 13 failed jobs',
+      run_id: 123,
+      total_jobs: 25,
+      failed_jobs: 13,
+      return_format: {content: false, urls: true},
+    });
+    expect(result.logs).toHaveLength(13);
+    expect(result.logs?.[0]).toMatchObject({
+      job_id: 1,
+      job_name: 'Unit tests',
+      logs_url: 'https://github.example/logs/1',
+    });
+  });
+
+  it('keeps failed-job fetch errors local to the affected job', async () => {
+    const result = await buildGithubFailedJobLogsResult({
+      runId: 123,
+      returnContent: true,
+      jobs: [
+        job({
+          conclusion: 'failure',
+          fetchContent: () => Promise.reject(new Error('download failed')),
+        }),
+      ],
+    });
+
+    expect(result.logs).toEqual([
+      {
+        job_id: 1,
+        job_name: 'Unit tests',
+        error: 'download failed',
+      },
+    ]);
+  });
+});
+
+describe('processGithubJobLogContent', () => {
+  it('uses the smaller of tail_lines and content window size', () => {
+    const lines = Array.from({length: 10}, (_value, index) => `line ${index + 1}`);
+
+    const result = processGithubJobLogContent(lines.join('\n'), {
+      tailLines: 8,
+      contentWindowSize: 3,
+    });
+
+    expect(result).toEqual({
+      content: ['line 8', 'line 9', 'line 10'].join('\n'),
+      totalLines: 10,
+    });
+  });
+
+  it('defaults invalid tail_lines to 500', () => {
+    const lines = Array.from(
+      {length: DEFAULT_JOB_LOG_TAIL_LINES + 1},
+      (_value, index) => `line ${index + 1}`,
+    );
+
+    const result = processGithubJobLogContent(lines.join('\n'), {tailLines: 0});
+
+    expect(result.content).toBe(lines.slice(-DEFAULT_JOB_LOG_TAIL_LINES).join('\n'));
+    expect(result.totalLines).toBe(DEFAULT_JOB_LOG_TAIL_LINES + 1);
+  });
+
+  it('truncates extremely long single lines', () => {
+    const line = 'a'.repeat(MAX_JOB_LOG_LINE_BYTES + 1);
+
+    const result = processGithubJobLogContent(line);
+
+    expect(result.content).toBe(`${'a'.repeat(MAX_TRUNCATED_JOB_LOG_LINE_CHARS)}...\n[TRUNCATED]`);
+    expect(result.totalLines).toBe(1);
+  });
+});
+
+function job(
+  overrides: Partial<Parameters<typeof buildGithubSingleJobLogResult>[0]['job']> = {},
+): Parameters<typeof buildGithubSingleJobLogResult>[0]['job'] {
+  const jobId = overrides.jobId ?? 1;
+  return {
+    jobId,
+    name: 'Unit tests',
+    conclusion: 'failure',
+    logsUrl: `https://github.example/logs/${jobId}`,
+    ...overrides,
+  };
+}

--- a/libs/api/integration/github/src/core/actions-logs.ts
+++ b/libs/api/integration/github/src/core/actions-logs.ts
@@ -1,0 +1,186 @@
+import {Buffer} from 'node:buffer';
+
+export const DEFAULT_JOB_LOG_TAIL_LINES = 500;
+export const DEFAULT_JOB_LOG_CONTENT_WINDOW_LINES = 5000;
+export const MAX_JOB_LOG_RING_BUFFER_LINES = 100000;
+export const MAX_JOB_LOG_LINE_BYTES = 10 * 1024 * 1024;
+export const MAX_TRUNCATED_JOB_LOG_LINE_CHARS = 1000;
+
+export interface GithubJobLogSource {
+  jobId: number;
+  name?: string | undefined;
+  conclusion?: string | undefined;
+  logsUrl: string;
+  fetchContent?: (() => Promise<string>) | undefined;
+}
+
+export interface BuildGithubSingleJobLogResultInput {
+  job: GithubJobLogSource;
+  returnContent?: boolean | undefined;
+  tailLines?: number | undefined;
+  contentWindowSize?: number | undefined;
+}
+
+export interface BuildGithubFailedJobLogsResultInput {
+  jobs: readonly GithubJobLogSource[];
+  runId: number;
+  returnContent?: boolean | undefined;
+  tailLines?: number | undefined;
+  contentWindowSize?: number | undefined;
+}
+
+export type GithubJobLogResult = Record<string, unknown>;
+
+export interface GithubFailedJobLogsResult {
+  message: string;
+  run_id: number;
+  total_jobs: number;
+  failed_jobs: number;
+  logs?: GithubJobLogResult[] | undefined;
+  return_format?: {content: boolean; urls: boolean} | undefined;
+}
+
+export function buildGithubSingleJobLogResult(
+  input: BuildGithubSingleJobLogResultInput,
+): Promise<GithubJobLogResult> {
+  return buildGithubJobLogData(input);
+}
+
+export async function buildGithubFailedJobLogsResult(
+  input: BuildGithubFailedJobLogsResultInput,
+): Promise<GithubFailedJobLogsResult> {
+  const failedJobs = input.jobs.filter((job) => job.conclusion === 'failure');
+
+  if (failedJobs.length === 0) {
+    return {
+      message: 'No failed jobs found in this workflow run',
+      run_id: input.runId,
+      total_jobs: input.jobs.length,
+      failed_jobs: 0,
+    };
+  }
+
+  const logs: GithubJobLogResult[] = [];
+  for (const job of failedJobs) {
+    try {
+      logs.push(await buildGithubJobLogData({job, ...input}));
+    } catch (error) {
+      logs.push({
+        job_id: job.jobId,
+        ...(job.name ? {job_name: job.name} : {}),
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return {
+    message: `Retrieved logs for ${failedJobs.length} failed jobs`,
+    run_id: input.runId,
+    total_jobs: input.jobs.length,
+    failed_jobs: failedJobs.length,
+    logs,
+    return_format: {content: input.returnContent === true, urls: input.returnContent !== true},
+  };
+}
+
+function buildGithubJobLogData(
+  input: BuildGithubSingleJobLogResultInput,
+): Promise<GithubJobLogResult> {
+  const result: GithubJobLogResult = {
+    job_id: input.job.jobId,
+    ...(input.job.name ? {job_name: input.job.name} : {}),
+  };
+
+  if (input.returnContent === true) {
+    const content = input.job.fetchContent ? input.job.fetchContent() : Promise.resolve('');
+    return content.then((logsContent) => {
+      const processed = processGithubJobLogContent(logsContent, {
+        tailLines: input.tailLines,
+        contentWindowSize: input.contentWindowSize,
+      });
+      return {
+        ...result,
+        logs_content: processed.content,
+        message: 'Job logs content retrieved successfully',
+        original_length: processed.totalLines,
+      };
+    });
+  }
+
+  return Promise.resolve({
+    ...result,
+    logs_url: input.job.logsUrl,
+    message: 'Job logs are available for download',
+    note: 'The logs_url provides a download link for the individual job logs in plain text format.\nUse return_content=true to get the actual log content.',
+  });
+}
+
+export function processGithubJobLogContent(
+  content: string,
+  options: {tailLines?: number | undefined; contentWindowSize?: number | undefined} = {},
+): {content: string; totalLines: number} {
+  const tailLines = normalizeTailLines(options.tailLines);
+  const maxLines = Math.min(
+    tailLines,
+    options.contentWindowSize ?? DEFAULT_JOB_LOG_CONTENT_WINDOW_LINES,
+  );
+  const processed = processResponseAsRingBufferToEnd(content, maxLines);
+  const lines = processed.content.split('\n');
+  const finalLines = lines.length > tailLines ? lines.slice(-tailLines) : lines;
+
+  return {content: finalLines.join('\n'), totalLines: processed.totalLines};
+}
+
+function normalizeTailLines(tailLines: number | undefined): number {
+  if (tailLines === undefined) return DEFAULT_JOB_LOG_TAIL_LINES;
+  if (!Number.isFinite(tailLines) || tailLines <= 0) return DEFAULT_JOB_LOG_TAIL_LINES;
+  return Math.trunc(tailLines);
+}
+
+function processResponseAsRingBufferToEnd(
+  content: string,
+  maxJobLogLines: number,
+): {content: string; totalLines: number} {
+  let maxLines = Math.trunc(maxJobLogLines);
+  if (maxLines <= 0) maxLines = DEFAULT_JOB_LOG_TAIL_LINES;
+  if (maxLines > MAX_JOB_LOG_RING_BUFFER_LINES) maxLines = MAX_JOB_LOG_RING_BUFFER_LINES;
+
+  const lines = new Array<string>(maxLines);
+  const validLines = new Array<boolean>(maxLines).fill(false);
+  let totalLines = 0;
+  let writeIndex = 0;
+
+  const storeLine = (line: string) => {
+    lines[writeIndex] = truncateLongLine(line);
+    validLines[writeIndex] = true;
+    totalLines += 1;
+    writeIndex = (writeIndex + 1) % maxLines;
+  };
+
+  for (const line of splitLogLines(content)) {
+    storeLine(line);
+  }
+
+  const result: string[] = [];
+  const linesInBuffer = Math.min(totalLines, maxLines);
+  const startIndex = totalLines > maxLines ? writeIndex : 0;
+
+  for (let offset = 0; offset < linesInBuffer; offset += 1) {
+    const index = (startIndex + offset) % maxLines;
+    if (validLines[index]) result.push(lines[index] ?? '');
+  }
+
+  return {content: result.join('\n'), totalLines};
+}
+
+function splitLogLines(content: string): string[] {
+  if (content.length === 0) return [];
+  const lines = content.split('\n');
+  if (content.endsWith('\n')) lines.pop();
+  return lines;
+}
+
+function truncateLongLine(line: string): string {
+  if (Buffer.byteLength(line, 'utf8') < MAX_JOB_LOG_LINE_BYTES) return line;
+  return `${Array.from(line).slice(0, MAX_TRUNCATED_JOB_LOG_LINE_CHARS).join('')}...\n[TRUNCATED]`;
+}

--- a/libs/api/integration/github/src/core/agent-tools.test.ts
+++ b/libs/api/integration/github/src/core/agent-tools.test.ts
@@ -1,4 +1,5 @@
 import type {GithubApiClient} from '#api/client.js';
+import {DEFAULT_JOB_LOG_TAIL_LINES} from '#core/actions-logs.js';
 import {
   GithubAgentToolsProvider,
   githubAgentToolCatalog,
@@ -258,6 +259,7 @@ describe('github agent tool catalog', () => {
     const updatePullRequestSchema = inputSchemaFor('update_pull_request');
     const addReplySchema = inputSchemaFor('add_reply_to_pull_request_comment');
     const actionsRunTriggerSchema = inputSchemaFor('actions_run_trigger');
+    const getJobLogsSchema = inputSchemaFor('get_job_logs');
 
     expect(listIssueTypesSchema.required).toEqual(['owner']);
     expect(updatePullRequestSchema.properties).not.toHaveProperty('draft');
@@ -277,6 +279,15 @@ describe('github agent tool catalog', () => {
       {properties: {method: {const: 'cancel_workflow_run'}}, required: ['run_id']},
       {properties: {method: {const: 'delete_workflow_run_logs'}}, required: ['run_id']},
     ]);
+    expect(getJobLogsSchema.properties?.return_content).toMatchObject({
+      type: 'boolean',
+    });
+    expect(getJobLogsSchema.properties?.job_id).toMatchObject({type: 'number'});
+    expect(getJobLogsSchema.properties?.run_id).toMatchObject({type: 'number'});
+    expect(getJobLogsSchema.properties?.tail_lines).toMatchObject({
+      type: 'number',
+      default: DEFAULT_JOB_LOG_TAIL_LINES,
+    });
   });
 
   it('exposes the catalog through the provider adapter', () => {

--- a/libs/api/integration/github/src/core/agent-tools.ts
+++ b/libs/api/integration/github/src/core/agent-tools.ts
@@ -6,6 +6,7 @@ import type {
   AgentToolsProvider,
   IntegrationConnection,
 } from '@shipfox/api-integration-core-dto';
+import {DEFAULT_JOB_LOG_TAIL_LINES} from './actions-logs.js';
 import {buildGithubAgentToolSelectionCatalog} from './agent-tool-selection.js';
 import {GithubIntegrationProviderError} from './errors.js';
 
@@ -739,20 +740,27 @@ export const githubAgentToolCatalog = [
     id: 'get_job_logs',
     category: 'actions',
     description:
-      'Get logs for GitHub Actions workflow jobs. Use this tool to retrieve logs for a specific job or all failed jobs in a workflow run.',
+      'Get logs for GitHub Actions workflow jobs. Use this tool to retrieve logs for a specific job or all failed jobs in a workflow run. For single job logs, provide job_id. For all failed jobs in a run, provide run_id with failed_only=true.',
     sensitivity: 'read',
     sensitive: false,
     requiredScope: scopes.actionsRead,
     inputSchema: repositoryInputSchema({
-      job_id: integerSchema('The unique identifier of the workflow job'),
-      run_id: integerSchema('The unique identifier of the workflow run'),
+      job_id: numberSchema(
+        'The unique identifier of the workflow job. Required when getting logs for a single job.',
+      ),
+      run_id: numberSchema(
+        'The unique identifier of the workflow run. Required when failed_only is true to get logs for all failed jobs in the run.',
+      ),
       failed_only: booleanSchema(
-        'When true, gets logs for all failed jobs in the workflow run specified by run_id',
+        'When true, gets logs for all failed jobs in the workflow run specified by run_id. Requires run_id to be provided.',
       ),
       return_content: booleanSchema('Returns actual log content instead of URLs'),
-      tail_lines: integerSchema('Number of lines to return from the end of the log'),
+      tail_lines: {
+        ...numberSchema('Number of lines to return from the end of the log'),
+        default: DEFAULT_JOB_LOG_TAIL_LINES,
+      },
     }),
-    outputSchema: objectSchema({logs: openObjectSchema('GitHub Actions job logs')}, ['logs']),
+    outputSchema: openObjectSchema('GitHub Actions workflow job logs'),
   }),
 ] as const satisfies readonly GithubAgentToolCatalogEntry[];
 
@@ -887,6 +895,10 @@ function integerSchema(
   options: {minimum?: number | undefined; maximum?: number | undefined} = {},
 ): AgentToolJsonSchema {
   return {type: 'integer', ...(description ? {description} : {}), ...options};
+}
+
+function numberSchema(description?: string): AgentToolJsonSchema {
+  return {type: 'number', ...(description ? {description} : {})};
 }
 
 function booleanSchema(description: string): AgentToolJsonSchema {


### PR DESCRIPTION
Align the GitHub Actions `get_job_logs` catalog and result helper with GitHub MCP's native behavior.

GitHub MCP exposes `get_job_logs` as URL-first by default: callers get `logs_url` unless they explicitly pass `return_content=true`. When content is requested, GitHub downloads the temporary log URL server-side and returns `logs_content` after retaining only the tail of the log through a line-window/ring-buffer path. This PR mirrors that shape with `tail_lines` defaulting to 500, GitHub's `logs_url` / `logs_content` field names, failed-job aggregation semantics, and long-line truncation behavior.

The gateway dispatcher is still stubbed, so this prepares the GitHub tool schema and core result-shaping helper for the runtime wiring that will call it.

Refs ENG-848