### PR TITLE
[e2e] Use fake model providers for agent smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,11 +106,6 @@ jobs:
       - name: Set up mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
 
-      - name: Start Ollama
-        id: ollama
-        run: mise run ollama:up
-        background: true
-
       - name: Set up pnpm
         uses: ./.github/actions/setup-pnpm
 
@@ -122,8 +117,8 @@ jobs:
       - name: Build dev server dependencies
         run: turbo build --filter @shipfox/api --filter @shipfox/vite
 
-      - name: Wait for test services and Ollama
-        wait: [test-services, ollama]
+      - name: Wait for test services
+        wait: test-services
 
       - name: Run E2E tests
         id: e2e

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,14 +204,6 @@ docker compose up -d
 mise run e2e -- --filter=@shipfox/e2e-client-auth
 ```
 
-Agent E2E tests that validate custom model providers against local Ollama also
-require the shared Ollama service and default model:
-
-```sh
-mise run ollama:up
-mise run e2e -- --filter=@shipfox/e2e-client-agent
-```
-
 The harness writes API/client logs and failure diagnostics to
 `.context/shipfox-e2e-logs/` locally. It also reads Conductor worktree ports from
 `.context/local-services/env` through mise, so the same command works in worktrees.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -260,14 +260,6 @@ The equivalent service command is:
 node dev/worktree-services.mjs up
 ```
 
-Agent E2E tests that validate custom model providers also need the shared local
-Ollama service:
-
-```sh
-mise run ollama:up
-mise run e2e -- --filter=@shipfox/e2e-client-agent
-```
-
 If the API and client are already running, run the package directly:
 
 ```sh

--- a/e2e/suites/client/agent/tests/global-setup.ts
+++ b/e2e/suites/client/agent/tests/global-setup.ts
@@ -1,7 +1,5 @@
 import globalSetup from '@shipfox/e2e-kit/global-setup';
-import {requireOllamaModel} from '@shipfox/e2e-setup-agent';
 
 export default async function agentGlobalSetup(): Promise<void> {
   await globalSetup();
-  await requireOllamaModel();
 }

--- a/e2e/suites/flow/workflows/README.md
+++ b/e2e/suites/flow/workflows/README.md
@@ -125,10 +125,7 @@ localhost API and gitea URLs are correct for the standard dev stack.
 # 1. Infrastructure (postgres, temporal, garage, gitea)
 docker compose up -d            # Conductor worktrees: node dev/worktree-services.mjs up
 
-# 2. Local Ollama for the skip-gated Claude and Pi live smoke workflows.
-mise run ollama:up
-
-# 3. Start the API/client dev servers and run the suite.
+# 2. Start the API/client dev servers and run the suite.
 mise run e2e -- --filter=@shipfox/e2e-flow-workflows
 ```
 

--- a/e2e/suites/flow/workflows/tests/claude-agent.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/claude-agent.e2e.ts
@@ -12,6 +12,7 @@ import {seedAndWaitForDefinition} from '#workflow-project.js';
 import {expect, test} from './fixtures.js';
 
 const CLAUDE_AGENT_MODEL = 'deterministic-claude-agent';
+const TERMINAL_TIMEOUT_MS = 60_000;
 
 const SMOKE_WORKFLOW_YAML = `
 name: Claude deterministic agent
@@ -168,7 +169,10 @@ async function runClaudeWorkflow(params: {
     userToken: token,
     name: `E2E ${params.scenario} ${params.uniqueId}`,
     runnerLabel,
-    extraEnv: params.runnerEnv,
+    extraEnv: {
+      ...params.runnerEnv,
+      SHIPFOX_POLL_MAX_DURATION_MS: String(TERMINAL_TIMEOUT_MS),
+    },
   });
 
   try {
@@ -192,7 +196,7 @@ async function runClaudeWorkflow(params: {
     return await waitForRunTerminalOrFailedRunner({
       runId,
       token,
-      timeoutMs: 300_000,
+      timeoutMs: TERMINAL_TIMEOUT_MS,
       runner: localRunner.runner,
     });
   } finally {

--- a/e2e/suites/flow/workflows/tests/model-provider-agent.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/model-provider-agent.e2e.ts
@@ -1,12 +1,11 @@
 import type {WorkflowRunDetailResponseDto} from '@shipfox/api-workflows-dto';
 import {createApiClient} from '@shipfox/e2e-core';
+import {message, startFakeOpenAiModelProvider} from '@shipfox/e2e-driver-model-provider';
 import {stopLocalRunner} from '@shipfox/e2e-driver-runner-process';
 import {
-  createAnthropicModelProviderConfig,
-  createOllamaCustomProvider,
+  createAnthropicFakeModelProviderConfig,
+  createOpenAiCompatibleCustomProvider,
   deleteModelProviderConfig,
-  type OllamaConfig,
-  requireOllamaModel,
 } from '@shipfox/e2e-setup-agent';
 import {attachLocalRunnerLog} from '#attachments.js';
 import {startSuiteLocalRunner, waitForRunTerminalOrFailedRunner} from '#runner.js';
@@ -16,95 +15,120 @@ import {seedAndWaitForDefinition} from '#workflow-project.js';
 import {expect, test} from './fixtures.js';
 
 const CLAUDE_CONFIG_MODEL = 'claude-opus-4-8';
-const OLLAMA_SMOKE_MAX_OUTPUT_TOKENS = 64;
+const CLAUDE_FAKE_MODEL = 'deterministic-claude-smoke-agent';
+const OPENAI_FAKE_MODEL = 'deterministic-openai-smoke-agent';
+const OPENAI_SMOKE_MAX_OUTPUT_TOKENS = 64;
+const OPENAI_SMOKE_RESPONSE_COUNT = 4;
+const TERMINAL_TIMEOUT_MS = 60_000;
 
 test.describe.configure({mode: 'serial'});
 
-test('runs a Claude harness smoke workflow against local Ollama', async ({suite}, testInfo) => {
-  const ollama = await requireOllamaOrSkip();
-  if (ollama === undefined) return;
-
+test('runs a Claude harness smoke workflow against the fake Anthropic endpoint', async ({
+  suite,
+}, testInfo) => {
   const uniqueId = crypto.randomUUID().replaceAll('-', '').slice(0, 10);
-  await createAnthropicModelProviderConfig({
-    workspaceId: suite.workspaceId,
-    defaultModel: CLAUDE_CONFIG_MODEL,
-  });
-
-  const terminal = await runLiveOllamaWorkflow({
-    suite,
-    testInfo,
-    uniqueId,
-    scenario: 'claude-ollama-agent',
-    workflowYaml: workflowYaml({
-      name: 'Claude Ollama agent',
-      harness: 'claude',
-      thinking: 'low',
-      provider: 'anthropic',
-      model: CLAUDE_CONFIG_MODEL,
-    }),
-    runnerEnv: {
-      AGENT_CLAUDE_ANTHROPIC_BASE_URL: ollama.baseUrl,
-      AGENT_CLAUDE_ANTHROPIC_MODEL: ollama.model,
-      AGENT_CLAUDE_ANTHROPIC_SMALL_FAST_MODEL: ollama.model,
-    },
-  });
-
-  expect(terminal.status).toBe('succeeded');
-  expect(terminal.jobs.find((job) => job.key === 'fix')?.status).toBe('succeeded');
-  expect(stepResponse(terminal, 'fix', 'reply').trim().length).toBeGreaterThan(0);
-});
-
-test('runs a Pi harness smoke workflow against local Ollama', async ({suite}, testInfo) => {
-  const ollama = await requireOllamaOrSkip();
-  if (ollama === undefined) return;
-
-  const uniqueId = crypto.randomUUID().replaceAll('-', '').slice(0, 10);
-  const provider = await createOllamaCustomProvider({
-    workspaceId: suite.workspaceId,
-    sessionToken: suite.sessionToken,
-    providerId: `local-ollama-smoke-${uniqueId}`,
-    displayName: `Local Ollama Smoke ${uniqueId}`,
-    baseUrl: ollama.baseUrl,
-    model: ollama.model,
-    modelMetadata: {max_output_tokens: OLLAMA_SMOKE_MAX_OUTPUT_TOKENS},
+  const fakeModelProvider = await startFakeOpenAiModelProvider({
+    runId: `${suite.runId}-claude-provider-smoke-${uniqueId}`,
   });
 
   try {
-    const terminal = await runLiveOllamaWorkflow({
+    const fakeAnthropic = await createAnthropicFakeModelProviderConfig({
+      workspaceId: suite.workspaceId,
+      fakeModelProvider,
+      scriptId: `${suite.runId}-claude-provider-smoke-${uniqueId}`,
+      model: CLAUDE_FAKE_MODEL,
+      configDefaultModel: CLAUDE_CONFIG_MODEL,
+      responses: [message('ok')],
+      assertions: [{kind: 'model', equals: CLAUDE_FAKE_MODEL}],
+    });
+
+    const terminal = await runFakeModelProviderWorkflow({
       suite,
       testInfo,
       uniqueId,
-      scenario: 'pi-ollama-agent',
+      scenario: 'claude-fake-model-agent',
       workflowYaml: workflowYaml({
-        name: 'Pi Ollama agent',
+        name: 'Claude fake model agent',
+        harness: 'claude',
+        thinking: 'low',
+        provider: 'anthropic',
+        model: CLAUDE_CONFIG_MODEL,
+      }),
+      runnerEnv: fakeAnthropic.runnerEnv,
+    });
+
+    expect(terminal.status).toBe('succeeded');
+    expect(terminal.jobs.find((job) => job.key === 'fix')?.status).toBe('succeeded');
+    expect(stepResponse(terminal, 'fix', 'reply').trim()).toBe('ok');
+  } finally {
+    await fakeModelProvider.stop().catch((error: unknown) => {
+      process.stderr.write(
+        `claude-fake-model-agent-e2e: stopFakeOpenAiModelProvider failed: ${String(error)}\n`,
+      );
+    });
+  }
+});
+
+test('runs a Pi harness smoke workflow against the fake OpenAI-compatible endpoint', async ({
+  suite,
+}, testInfo) => {
+  const uniqueId = crypto.randomUUID().replaceAll('-', '').slice(0, 10);
+  const fakeModelProvider = await startFakeOpenAiModelProvider({
+    runId: `${suite.runId}-pi-provider-smoke-${uniqueId}`,
+  });
+
+  let providerId: string | undefined;
+  try {
+    const script = await fakeModelProvider.createScript({
+      id: `${suite.runId}-pi-provider-smoke-${uniqueId}`,
+      model: OPENAI_FAKE_MODEL,
+      responses: openAiSmokeResponses(),
+      assertions: [{kind: 'model', equals: OPENAI_FAKE_MODEL}],
+    });
+    const provider = await createOpenAiCompatibleCustomProvider({
+      workspaceId: suite.workspaceId,
+      sessionToken: suite.sessionToken,
+      providerId: `fake-openai-smoke-${uniqueId}`,
+      displayName: `Fake OpenAI Smoke ${uniqueId}`,
+      baseUrl: script.modelProviderBaseUrl,
+      model: script.model,
+      modelMetadata: {max_output_tokens: OPENAI_SMOKE_MAX_OUTPUT_TOKENS},
+    });
+    providerId = provider.provider_id;
+
+    const terminal = await runFakeModelProviderWorkflow({
+      suite,
+      testInfo,
+      uniqueId,
+      scenario: 'pi-fake-model-agent',
+      workflowYaml: workflowYaml({
+        name: 'Pi fake model agent',
         harness: 'pi',
         thinking: 'off',
         provider: provider.provider_id,
-        model: ollama.model,
+        model: script.model,
       }),
       runnerEnv: {},
     });
 
     expect(terminal.status).toBe('succeeded');
     expect(terminal.jobs.find((job) => job.key === 'fix')?.status).toBe('succeeded');
-    expect(stepResponse(terminal, 'fix', 'reply').trim().length).toBeGreaterThan(0);
+    expect(stepResponse(terminal, 'fix', 'reply').trim()).toBe('ok');
   } finally {
-    await deleteModelProviderConfig({
-      workspaceId: suite.workspaceId,
-      sessionToken: suite.sessionToken,
-      providerId: provider.provider_id,
-    }).catch(() => undefined);
+    if (providerId !== undefined) {
+      await deleteModelProviderConfig({
+        workspaceId: suite.workspaceId,
+        sessionToken: suite.sessionToken,
+        providerId,
+      }).catch(() => undefined);
+    }
+    await fakeModelProvider.stop().catch((error: unknown) => {
+      process.stderr.write(
+        `pi-fake-model-agent-e2e: stopFakeOpenAiModelProvider failed: ${String(error)}\n`,
+      );
+    });
   }
 });
-
-async function requireOllamaOrSkip(): Promise<OllamaConfig | undefined> {
-  try {
-    return await requireOllamaModel();
-  } catch (error) {
-    test.skip(true, error instanceof Error ? error.message : String(error));
-    return undefined;
-  }
-}
 
 function workflowYaml(params: {
   name: string;
@@ -134,7 +158,7 @@ jobs:
 `;
 }
 
-async function runLiveOllamaWorkflow(params: {
+async function runFakeModelProviderWorkflow(params: {
   suite: SuiteContext;
   testInfo: {
     attach: (name: string, options: {body: Buffer | string; contentType: string}) => Promise<void>;
@@ -153,7 +177,10 @@ async function runLiveOllamaWorkflow(params: {
     userToken: token,
     name: `E2E ${params.scenario} ${params.uniqueId}`,
     runnerLabel,
-    extraEnv: params.runnerEnv,
+    extraEnv: {
+      ...params.runnerEnv,
+      SHIPFOX_POLL_MAX_DURATION_MS: String(TERMINAL_TIMEOUT_MS),
+    },
   });
 
   try {
@@ -177,7 +204,7 @@ async function runLiveOllamaWorkflow(params: {
     return await waitForRunTerminalOrFailedRunner({
       runId,
       token,
-      timeoutMs: 300_000,
+      timeoutMs: TERMINAL_TIMEOUT_MS,
       runner: localRunner.runner,
     });
   } finally {
@@ -204,4 +231,8 @@ function stepResponse(run: WorkflowRunDetailResponseDto, jobKey: string, stepKey
   if (step.response === null)
     throw new Error(`Step ${jobKey}.${stepKey} did not record a response`);
   return step.response;
+}
+
+function openAiSmokeResponses() {
+  return Array.from({length: OPENAI_SMOKE_RESPONSE_COUNT}, () => message('ok'));
 }


### PR DESCRIPTION
Use the deterministic fake model-provider sidecar for agent E2E coverage instead of local Ollama.

The previous Claude and Pi flow smoke tests depended on live local Ollama behavior and waited up to 300 seconds for terminal run status. That made CI failures slow and sensitive to model startup or generation stalls. This replaces those live calls with fake Anthropic and OpenAI-compatible endpoints, keeps the assertions deterministic, and lowers the smoke-test runner and terminal poll budgets to 60 seconds.

CI no longer starts or waits for Ollama in the E2E job. The client-agent E2E suite already uses fake OpenAI-compatible provider scripts, so this also removes its stale global Ollama preflight and the related local runbook notes.

The OpenAI-compatible script includes a small deterministic response budget because the Pi harness can issue an internal setup request before the user-facing turn.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace live local Ollama in agent smoke tests with deterministic fake Anthropic and OpenAI-compatible endpoints to make CI faster and stable. CI no longer starts Ollama; terminal polling drops from 300s to 60s with fixed “ok” assertions.

- **Refactors**
  - Switched Claude and Pi smoke tests to fake providers via `@shipfox/e2e-driver-model-provider`.
  - Added fake provider helpers and scripted responses: `startFakeOpenAiModelProvider`, `createAnthropicFakeModelProviderConfig`, `createOpenAiCompatibleCustomProvider`.
  - Set `SHIPFOX_POLL_MAX_DURATION_MS` and terminal timeouts to 60_000 ms (incl. `claude-agent.e2e.ts`).
  - Deterministic models: `deterministic-claude-smoke-agent`, `deterministic-openai-smoke-agent`; Pi script sends 4 “ok” replies.
  - CI/docs cleanup: removed Ollama startup/waits from `.github/workflows/ci.yml` and Ollama instructions from `CONTRIBUTING.md`, `e2e/README.md`, and flow workflows README; renamed test to `model-provider-agent.e2e.ts`.

<sup>Written for commit 36550287ed1a33fb5591cb2013304e9b58f2142a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

