### PR TITLE
[docs] Fix Vercel preview base path

### DIFF
--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -3,12 +3,10 @@ import {createMDX} from 'fumadocs-mdx/next';
 
 const withMDX = createMDX();
 
-// In production the docs are served behind the cloud landing app at
-// www.shipfox.io/docs, so they build under the /docs basePath. Local `next dev`
-// has no proxy in front, so skip the basePath there and serve at localhost:3500/
-// directly. The value is exposed as NEXT_PUBLIC_BASE_PATH so app code (src/url.ts)
-// builds URLs with the same prefix.
-const basePath = process.env.NODE_ENV === 'development' ? '' : '/docs';
+// The production docs deployment is mounted behind the cloud landing app at
+// www.shipfox.io/docs. Vercel previews stay rooted at / so preview URLs work
+// directly from the generated deployment URL.
+const basePath = process.env.VERCEL_ENV === 'production' ? '/docs' : '';
 
 /** @type {import('next').NextConfig} */
 const config = {


### PR DESCRIPTION
Fix the docs app base path so only Vercel production deployments build under `/docs`.

The docs production deployment is mounted behind the landing app at `www.shipfox.io/docs`, but Vercel preview deployments should serve directly from the generated deployment root. `NODE_ENV` is `production` for both production and preview builds, so this switches the base path decision to Vercel's deployment context via `VERCEL_ENV`.

The existing root redirect remains tied to the configured base path, so direct production hits to `/` still redirect to `/docs` while previews stay rooted at `/`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix basePath in `apps/docs/next.config.mjs` to use `/docs` only when `VERCEL_ENV` is `production`. Vercel previews now serve from `/`, and the production root redirect to `/docs` still works.

<sup>Written for commit 1cbdad1cdf665c6eb4435dc749ff96df9fbd5046. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

