### PR TITLE
Add Conductor docs startup script

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -25,3 +25,7 @@ fi
 command = "SHIPFOX_CLIENT_OPEN=1 mise exec -- turbo dev --filter=@shipfox/api --filter=@shipfox/client"
 default = true
 icon = "play"
+
+[scripts.run.docs]
+command = "mise exec -- pnpm --filter=@shipfox/docs dev"
+icon = "book-open"


### PR DESCRIPTION
Add a dedicated Conductor run script for the docs app.

The docs app already owns its local dev command through the `@shipfox/docs` package script, including the fixed port used by the app. Exposing that command in Conductor lets workspaces start docs directly without changing the existing API/client startup script.

Validated the TOML parses, the diff has no whitespace errors, the `@shipfox/docs` filter resolves to `apps/docs`, and the branch-scoped build, test, and check gates complete with no package tasks to run for this config-only change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Conductor run script to start the docs app via the `@shipfox/docs` dev command, so teams can launch docs directly without touching the API/client runner.

- **New Features**
  - Adds `[scripts.run.docs]` to `.conductor/settings.toml` with `mise exec -- pnpm --filter=@shipfox/docs dev` and icon `book-open`.
  - Keeps the default `dev` runner for `@shipfox/api` and `@shipfox/client` unchanged.

<sup>Written for commit ef299e3d165212636945495706719c9b609f563f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

