### PR TITLE
Fix docs search 404 under the /docs basePath

### DIFF
--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -3,6 +3,7 @@ import {RootProvider} from 'fumadocs-ui/provider/next';
 import {Inter} from 'next/font/google';
 import localFont from 'next/font/local';
 import type {ReactNode} from 'react';
+import {basePath} from '@/url';
 
 const inter = Inter({
   subsets: ['latin'],
@@ -30,7 +31,11 @@ export default function Layout({children}: {children: ReactNode}) {
         <link rel="alternate" type="text/markdown" href="/llms.txt" />
       </head>
       <body className="flex flex-col min-h-screen">
-        <RootProvider theme={{enabled: false}}>{children}</RootProvider>
+        {/* The search client fetches this URL as-is; Next does not apply basePath to
+            it, so it must carry the /docs prefix in production (empty in dev). */}
+        <RootProvider theme={{enabled: false}} search={{options: {api: `${basePath}/api/search`}}}>
+          {children}
+        </RootProvider>
       </body>
     </html>
   );


### PR DESCRIPTION
Follow-up to #691 / #717.

Fumadocs' default search client fetches `/api/search` as a literal URL — Next does **not** apply `basePath` to it. On the production docs deployment (`basePath: '/docs'`, per #717) the route lives at `/docs/api/search`, so the client hit `/api/search` and 404'd: **search returned no results in production**.

Point the `RootProvider` search at `${basePath}/api/search` (basePath from `NEXT_PUBLIC_BASE_PATH`), so the fetch URL matches the route everywhere:
- dev / Vercel preview (no basePath) → `/api/search`
- Vercel production (`/docs`) → `/docs/api/search`

Verified: the dev search dialog returns results; the production build serves `/docs/api/search` (200) and the client bundle targets it. One-line change in `app/layout.tsx`.

Refs ENG-475

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a 404 in docs search by making the search API path basePath-aware (ENG-475). The client now requests `${basePath}/api/search`, hitting `/api/search` in dev and `/docs/api/search` in production.

<sup>Written for commit fb9b51846e63a8d710edf0f7a2eecb1c515ce693. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

