### PR TITLE
[docs] Redirect local docs base path

### DIFF
--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -35,9 +35,16 @@ const config = {
   // With a basePath, the deployment domain root (the URL Vercel puts in the PR
   // preview comment) would 404, so redirect it to /docs. basePath:false matches
   // the literal domain root, before the prefix is applied. Not needed in dev,
-  // where there is no basePath and the root already serves the docs.
+  // where there is no basePath and the root already serves the docs. In dev,
+  // redirect /docs-prefixed URLs back to the unprefixed route so production URLs
+  // copied into a local browser still work.
   redirects() {
-    if (!basePath) return [];
+    if (!basePath) {
+      return [
+        {source: '/docs', destination: '/', permanent: false},
+        {source: '/docs/:path*', destination: '/:path*', permanent: false},
+      ];
+    }
     return [{source: '/', destination: basePath, basePath: false, permanent: false}];
   },
 };


### PR DESCRIPTION
Redirect production-style /docs URLs back to the unprefixed local docs routes during development.

Production serves the docs under /docs, while local development intentionally omits the base path and serves the same content from /. Copying a production or preview docs URL into localhost therefore produced a local 404 even when the docs app itself was running correctly.

This keeps production behavior unchanged and only maps /docs-prefixed paths to their local equivalents when the development base path is disabled.