### PR TITLE
ENG-850 add runner integration tools bridge

### DIFF
--- a/libs/runner/agent/package.json
+++ b/libs/runner/agent/package.json
@@ -42,6 +42,7 @@
     "@earendil-works/pi-ai": "0.79.9",
     "@earendil-works/pi-coding-agent": "0.79.6",
     "@earendil-works/pi-tui": "0.79.9",
+    "@modelcontextprotocol/sdk": "1.29.0",
     "@shipfox/api-agent-dto": "workspace:*",
     "@shipfox/api-runners-dto": "workspace:*",
     "@shipfox/api-workflows-dto": "workspace:*",
@@ -50,6 +51,7 @@
     "@shipfox/node-egress-guard": "workspace:*",
     "@shipfox/node-opentelemetry": "workspace:*",
     "@shipfox/runner-execution": "workspace:*",
+    "@shipfox/runner-protocol": "workspace:*",
     "pi-web-access": "0.13.0",
     "typebox": "1.1.38",
     "zod": "4.4.3"

--- a/libs/runner/agent/src/core/harness.ts
+++ b/libs/runner/agent/src/core/harness.ts
@@ -1,5 +1,6 @@
 import type {CustomModelProviderRuntimeConfigDto} from '@shipfox/api-agent-dto';
 import type {OutputDeclarations} from '@shipfox/expression';
+import type {IntegrationToolsBridge} from '#core/integration-tools-bridge.js';
 
 // The invocation shape is still pi-oriented because v1 only has two harnesses.
 // Revisit this shared contract if a third harness needs materially different inputs.
@@ -10,6 +11,7 @@ export interface HarnessInvocation {
   readonly thinking: string;
   readonly prompt: string;
   readonly tools?: readonly string[] | undefined;
+  readonly mcpServers?: readonly IntegrationToolsBridge[] | undefined;
   readonly outputs?: OutputDeclarations | undefined;
   readonly credentials: Record<string, string>;
   readonly customProvider?: CustomModelProviderRuntimeConfigDto | undefined;

--- a/libs/runner/agent/src/core/integration-tools-bridge.test.ts
+++ b/libs/runner/agent/src/core/integration-tools-bridge.test.ts
@@ -1,0 +1,196 @@
+import {once} from 'node:events';
+import {createServer, type Server as HttpServer} from 'node:http';
+import {Client} from '@modelcontextprotocol/sdk/client/index.js';
+import {InMemoryTransport} from '@modelcontextprotocol/sdk/inMemory.js';
+import {Server} from '@modelcontextprotocol/sdk/server/index.js';
+import {StreamableHTTPServerTransport} from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import type {Transport} from '@modelcontextprotocol/sdk/shared/transport.js';
+import {
+  CallToolRequestSchema,
+  CallToolResultSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import {createIntegrationToolsBridge} from '#core/integration-tools-bridge.js';
+
+describe('createIntegrationToolsBridge', () => {
+  let gateway: FakeGateway | undefined;
+
+  afterEach(async () => {
+    await gateway?.close();
+    gateway = undefined;
+  });
+
+  it('lists tools and forwards calls to the gateway with the current lease token', async () => {
+    let leaseToken = 'lease-initial';
+    gateway = await startFakeGateway(() => leaseToken);
+    const bridge = createIntegrationToolsBridge({
+      name: 'shipfox_integration_tools',
+      url: gateway.url,
+      fetch: leaseFetch(() => leaseToken),
+    });
+
+    const tools = await bridge.listTools();
+    leaseToken = 'lease-next';
+    const result = await bridge.callTool('github_main__issue_read', {
+      method: 'get',
+      owner: 'shipfox',
+      repo: 'platform',
+      issue_number: 1,
+    });
+    await bridge.close();
+
+    expect(tools.tools.map((tool) => tool.name)).toEqual(['github_main__issue_read']);
+    expect(result.isError).not.toBe(true);
+    expect(result.structuredContent).toEqual({
+      name: 'github_main__issue_read',
+      method: 'get',
+      issue_number: 1,
+    });
+    expect(gateway.authorizations).toContain('Bearer lease-initial');
+    expect(gateway.authorizations.at(-1)).toBe('Bearer lease-next');
+    expect(gateway.calls).toEqual([
+      {
+        name: 'github_main__issue_read',
+        arguments: {
+          method: 'get',
+          owner: 'shipfox',
+          repo: 'platform',
+          issue_number: 1,
+        },
+      },
+    ]);
+  });
+
+  it('relays list and call through the in-process MCP server', async () => {
+    let leaseToken = 'lease-initial';
+    gateway = await startFakeGateway(() => leaseToken);
+    const bridge = createIntegrationToolsBridge({
+      name: 'shipfox_integration_tools',
+      url: gateway.url,
+      fetch: leaseFetch(() => leaseToken),
+    });
+    const client = new Client({name: 'test-client', version: '0.0.0'});
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    await bridge.server.connect(serverTransport);
+    await client.connect(clientTransport);
+    const tools = await client.listTools();
+    leaseToken = 'lease-next';
+    const result = await client.callTool(
+      {
+        name: 'github_main__issue_read',
+        arguments: {method: 'get', owner: 'shipfox', repo: 'platform', issue_number: 2},
+      },
+      CallToolResultSchema,
+    );
+    await client.close();
+    await bridge.close();
+
+    expect(tools.tools.map((tool) => tool.name)).toEqual(['github_main__issue_read']);
+    expect(result.structuredContent).toEqual({
+      name: 'github_main__issue_read',
+      method: 'get',
+      issue_number: 2,
+    });
+    expect(gateway.authorizations).toContain('Bearer lease-initial');
+    expect(gateway.authorizations.at(-1)).toBe('Bearer lease-next');
+  });
+});
+
+interface FakeGateway {
+  url: URL;
+  authorizations: string[];
+  calls: Array<{name: string; arguments: Record<string, unknown> | undefined}>;
+  close(): Promise<void>;
+}
+
+async function startFakeGateway(expectedLeaseToken: () => string): Promise<FakeGateway> {
+  const authorizations: string[] = [];
+  const calls: Array<{name: string; arguments: Record<string, unknown> | undefined}> = [];
+  const httpServer = createServer(async (request, response) => {
+    const authorization = request.headers.authorization ?? '';
+    authorizations.push(authorization);
+    if (authorization !== `Bearer ${expectedLeaseToken()}`) {
+      response.writeHead(401).end();
+      return;
+    }
+
+    const body = await readJsonBody(request);
+    const server = new Server(
+      {name: 'fake-integration-tools', version: '0.0.0'},
+      {capabilities: {tools: {}}},
+    );
+    const transport = new StreamableHTTPServerTransport();
+
+    server.setRequestHandler(ListToolsRequestSchema, () => ({
+      tools: [
+        {
+          name: 'github_main__issue_read',
+          description: 'Read issue metadata from GitHub.',
+          inputSchema: {type: 'object'},
+        },
+      ],
+    }));
+    server.setRequestHandler(CallToolRequestSchema, (toolRequest) => {
+      calls.push({
+        name: toolRequest.params.name,
+        arguments: toolRequest.params.arguments,
+      });
+      return {
+        content: [{type: 'text', text: 'called'}],
+        structuredContent: {
+          name: toolRequest.params.name,
+          method: toolRequest.params.arguments?.method,
+          issue_number: toolRequest.params.arguments?.issue_number,
+        },
+      };
+    });
+
+    await server.connect(transport as unknown as Transport);
+    response.on('close', () => {
+      void transport.close();
+      void server.close();
+    });
+    await transport.handleRequest(request, response, body);
+  });
+  httpServer.listen(0, '127.0.0.1');
+  await once(httpServer, 'listening');
+
+  return {
+    url: new URL('/runs/jobs/current/integration-tools/mcp', address(httpServer)),
+    authorizations,
+    calls,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        httpServer.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      }),
+  };
+}
+
+function leaseFetch(leaseToken: () => string): typeof fetch {
+  return (input, init) => {
+    const headers = new Headers(init?.headers);
+    headers.set('Authorization', `Bearer ${leaseToken()}`);
+    return fetch(input, {...init, headers});
+  };
+}
+
+function address(server: HttpServer): string {
+  const addressInfo = server.address();
+  if (typeof addressInfo !== 'object' || addressInfo === null) {
+    throw new Error('Fake gateway did not bind a TCP address.');
+  }
+  return `http://127.0.0.1:${addressInfo.port}`;
+}
+
+async function readJsonBody(request: NodeJS.ReadableStream): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  const text = Buffer.concat(chunks).toString('utf8');
+  return text === '' ? undefined : (JSON.parse(text) as unknown);
+}

--- a/libs/runner/agent/src/core/integration-tools-bridge.ts
+++ b/libs/runner/agent/src/core/integration-tools-bridge.ts
@@ -1,0 +1,67 @@
+import {Client} from '@modelcontextprotocol/sdk/client/index.js';
+import {StreamableHTTPClientTransport} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import {Server} from '@modelcontextprotocol/sdk/server/index.js';
+import type {Transport} from '@modelcontextprotocol/sdk/shared/transport.js';
+import {
+  CallToolRequestSchema,
+  type CallToolResult,
+  CallToolResultSchema,
+  ListToolsRequestSchema,
+  type ListToolsResult,
+} from '@modelcontextprotocol/sdk/types.js';
+
+export interface IntegrationToolsBridge {
+  readonly name: string;
+  readonly server: Server;
+  listTools(): Promise<ListToolsResult>;
+  callTool(name: string, args?: Record<string, unknown>): Promise<CallToolResult>;
+  close(): Promise<void>;
+}
+
+export function createIntegrationToolsBridge(params: {
+  url: URL;
+  fetch: typeof fetch;
+  name: string;
+}): IntegrationToolsBridge {
+  const client = new Client({name: params.name, version: '0.0.0'});
+  const transport = new StreamableHTTPClientTransport(params.url, {fetch: params.fetch});
+  const server = new Server({name: params.name, version: '0.0.0'}, {capabilities: {tools: {}}});
+  let connectPromise: Promise<void> | undefined;
+
+  const ensureConnected = () => {
+    connectPromise ??= client.connect(transport as unknown as Transport);
+    return connectPromise;
+  };
+
+  const bridge: IntegrationToolsBridge = {
+    name: params.name,
+    server,
+    async listTools() {
+      await ensureConnected();
+      return client.listTools();
+    },
+    async callTool(name, args) {
+      await ensureConnected();
+      return client.callTool(
+        {name, ...(args === undefined ? {} : {arguments: args})},
+        CallToolResultSchema,
+      ) as Promise<CallToolResult>;
+    },
+    async close() {
+      await client.close();
+      await server.close();
+    },
+  };
+
+  server.setRequestHandler(ListToolsRequestSchema, async (request) => {
+    await ensureConnected();
+    return client.listTools(request.params);
+  });
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    await ensureConnected();
+    return client.callTool(request.params, CallToolResultSchema);
+  });
+
+  return bridge;
+}

--- a/libs/runner/agent/src/core/step.test.ts
+++ b/libs/runner/agent/src/core/step.test.ts
@@ -1,11 +1,45 @@
-const {runAgentMock, runClaudeMock} = vi.hoisted(() => ({
-  runAgentMock: vi.fn(),
-  runClaudeMock: vi.fn(),
-}));
+const {
+  bridgeCloseMock,
+  createIntegrationToolsBridgeMock,
+  createIntegrationToolsGatewayFetchMock,
+  gatewayFetch,
+  runAgentMock,
+  runClaudeMock,
+} = vi.hoisted(() => {
+  const bridgeCloseMock = vi.fn();
+  const gatewayFetch = vi.fn();
+
+  return {
+    bridgeCloseMock,
+    createIntegrationToolsBridgeMock: vi.fn((params: {name: string}) => ({
+      name: params.name,
+      server: {},
+      listTools: vi.fn(),
+      callTool: vi.fn(),
+      close: bridgeCloseMock,
+    })),
+    createIntegrationToolsGatewayFetchMock: vi.fn(() => gatewayFetch),
+    gatewayFetch,
+    runAgentMock: vi.fn(),
+    runClaudeMock: vi.fn(),
+  };
+});
 
 vi.mock('#core/pi-adapter.js', () => ({piHarnessAdapter: {run: runAgentMock}}));
 vi.mock('#core/claude-adapter.js', () => ({claudeHarnessAdapter: {run: runClaudeMock}}));
+vi.mock('#core/integration-tools-bridge.js', () => ({
+  createIntegrationToolsBridge: createIntegrationToolsBridgeMock,
+}));
+vi.mock('@shipfox/runner-protocol', () => ({
+  createIntegrationToolsGatewayFetch: createIntegrationToolsGatewayFetchMock,
+}));
 
+import {
+  AGENT_INTEGRATION_MCP_AUTH,
+  AGENT_INTEGRATION_MCP_ENDPOINT,
+  AGENT_INTEGRATION_MCP_SERVER_NAME,
+  AGENT_INTEGRATION_MCP_TRANSPORT,
+} from '@shipfox/api-agent-dto';
 import type {StepDto} from '@shipfox/api-workflows-dto';
 import {AgentConfigError, AgentInvocationError} from '#core/errors.js';
 import type {HarnessInvocation} from '#core/harness.js';
@@ -42,6 +76,10 @@ function buildAgentStep(overrides: Partial<StepDto> = {}): StepDto {
 
 describe('executeAgentStep', () => {
   beforeEach(() => {
+    bridgeCloseMock.mockReset();
+    createIntegrationToolsBridgeMock.mockClear();
+    createIntegrationToolsGatewayFetchMock.mockClear();
+    gatewayFetch.mockReset();
     runAgentMock.mockReset();
     runClaudeMock.mockReset();
   });
@@ -118,6 +156,123 @@ describe('executeAgentStep', () => {
     expect(runAgentMock).toHaveBeenCalledWith(
       expect.objectContaining({tools: ['read', 'web_search']}),
     );
+  });
+
+  it('runs normally when integration tools are absent', async () => {
+    runAgentMock.mockResolvedValue({});
+
+    await executeAgentStep(buildAgentStep({config: {prompt: 'p'}}), {
+      runtime: RUNTIME,
+    });
+
+    expect(runAgentMock).toHaveBeenCalledWith(
+      expect.not.objectContaining({mcpServers: expect.anything()}),
+    );
+    expect(createIntegrationToolsBridgeMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['non-array MCP servers', {prompt: 'p', mcpServers: 'bad'}],
+    ['empty MCP servers', {prompt: 'p', mcpServers: []}],
+    ['wrong transport', {prompt: 'p', mcpServers: [integrationToolsConfig({transport: 'stdio'})]}],
+    ['wrong auth', {prompt: 'p', mcpServers: [integrationToolsConfig({auth: 'provider_token'})]}],
+  ])('fails with agent_config_invalid for %s', async (_name, config) => {
+    const result = await executeAgentStep(buildAgentStep({config}), {runtime: RUNTIME});
+
+    expect(result).toEqual({
+      success: false,
+      error: {
+        message: 'Agent step config has invalid integration tools.',
+        reason: 'agent_config_invalid',
+        agent_config_issue: 'step_config_invalid',
+      },
+      exit_code: null,
+    });
+    expect(runAgentMock).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when integration tools are configured without bridge prerequisites', async () => {
+    const result = await executeAgentStep(
+      buildAgentStep({config: {prompt: 'p', mcpServers: [integrationToolsConfig()]}}),
+      {runtime: RUNTIME},
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: {
+        message: 'Agent step config has invalid integration tools.',
+        reason: 'agent_config_invalid',
+        agent_config_issue: 'step_config_invalid',
+      },
+      exit_code: null,
+    });
+    expect(runAgentMock).not.toHaveBeenCalled();
+    expect(createIntegrationToolsBridgeMock).not.toHaveBeenCalled();
+  });
+
+  it('constructs, forwards, and closes integration tool bridges around the harness run', async () => {
+    runAgentMock.mockResolvedValue({});
+    const leaseToken = () => 'lease-current';
+    const gatewayUrl = new URL('https://api.example.test/runs/jobs/current/integration-tools/mcp');
+
+    await executeAgentStep(
+      buildAgentStep({config: {prompt: 'p', mcpServers: [integrationToolsConfig()]}}),
+      {
+        runtime: RUNTIME,
+        leaseToken,
+        integrationToolsGatewayUrl: gatewayUrl,
+      },
+    );
+
+    expect(createIntegrationToolsGatewayFetchMock).toHaveBeenCalledWith(leaseToken, gatewayUrl);
+    expect(createIntegrationToolsBridgeMock).toHaveBeenCalledWith({
+      name: AGENT_INTEGRATION_MCP_SERVER_NAME,
+      url: gatewayUrl,
+      fetch: gatewayFetch,
+    });
+    expect(runAgentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mcpServers: [expect.objectContaining({name: AGENT_INTEGRATION_MCP_SERVER_NAME})],
+      }),
+    );
+    expect(bridgeCloseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes integration tool bridges when the harness run fails', async () => {
+    runAgentMock.mockRejectedValue(new Error('provider failed'));
+
+    const result = await executeAgentStep(
+      buildAgentStep({config: {prompt: 'p', mcpServers: [integrationToolsConfig()]}}),
+      {
+        runtime: RUNTIME,
+        leaseToken: 'lease-current',
+        integrationToolsGatewayUrl: new URL(
+          'https://api.example.test/runs/jobs/current/integration-tools/mcp',
+        ),
+      },
+    );
+
+    expect(result.success).toBe(false);
+    expect(bridgeCloseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves the harness result when closing an integration tool bridge fails', async () => {
+    runAgentMock.mockResolvedValue({response: 'done'});
+    bridgeCloseMock.mockRejectedValueOnce(new Error('close failed'));
+
+    const result = await executeAgentStep(
+      buildAgentStep({config: {prompt: 'p', mcpServers: [integrationToolsConfig()]}}),
+      {
+        runtime: RUNTIME,
+        leaseToken: 'lease-current',
+        integrationToolsGatewayUrl: new URL(
+          'https://api.example.test/runs/jobs/current/integration-tools/mcp',
+        ),
+      },
+    );
+
+    expect(result).toEqual({success: true, response: 'done', error: null, exit_code: 0});
+    expect(bridgeCloseMock).toHaveBeenCalledTimes(1);
   });
 
   it('forwards custom provider runtime config to the agent invocation', async () => {
@@ -318,3 +473,31 @@ describe('executeAgentStep', () => {
     expect(result.success).toBe(false);
   });
 });
+
+function integrationToolsConfig(overrides: Record<string, unknown> = {}) {
+  return {
+    name: AGENT_INTEGRATION_MCP_SERVER_NAME,
+    transport: AGENT_INTEGRATION_MCP_TRANSPORT,
+    endpoint: AGENT_INTEGRATION_MCP_ENDPOINT,
+    auth: AGENT_INTEGRATION_MCP_AUTH,
+    integrations: [
+      {
+        connectionId: 'connection-1',
+        connectionSlug: 'github_main',
+        provider: 'github',
+        repos: ['shipfox/platform'],
+        requiredScope: [],
+        tools: [
+          {
+            id: 'issue_read',
+            sensitivity: 'read',
+            sensitive: false,
+            requiredScope: [],
+            inputSchema: {type: 'object'},
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}

--- a/libs/runner/agent/src/core/step.ts
+++ b/libs/runner/agent/src/core/step.ts
@@ -1,4 +1,9 @@
-import type {CustomModelProviderRuntimeConfigDto, Harness} from '@shipfox/api-agent-dto';
+import {
+  type AgentIntegrationMcpServerConfigDto,
+  agentIntegrationMcpServerSchema,
+  type CustomModelProviderRuntimeConfigDto,
+  type Harness,
+} from '@shipfox/api-agent-dto';
 import type {
   AgentConfigIssueDto,
   StepDto,
@@ -6,12 +11,19 @@ import type {
   StepErrorReasonDto,
 } from '@shipfox/api-workflows-dto';
 import type {OutputDeclarations} from '@shipfox/expression';
+import {logger} from '@shipfox/node-opentelemetry';
 import type {StepResult} from '@shipfox/runner-execution';
+import {createIntegrationToolsGatewayFetch, type LeaseTokenSource} from '@shipfox/runner-protocol';
+import {z} from 'zod';
 import {AgentConfigError, AgentInvocationError} from '#core/errors.js';
 import type {HarnessAdapter} from '#core/harness.js';
+import {
+  createIntegrationToolsBridge,
+  type IntegrationToolsBridge,
+} from '#core/integration-tools-bridge.js';
 import {piHarnessAdapter} from '#core/pi-adapter.js';
 
-export function executeAgentStep(
+export async function executeAgentStep(
   step: StepDto,
   options: {
     signal?: AbortSignal;
@@ -26,48 +38,71 @@ export function executeAgentStep(
     };
     gitConfigGlobal?: string | undefined;
     onSessionEntry?: (line: string) => void;
+    leaseToken?: LeaseTokenSource | undefined;
+    integrationToolsGatewayUrl?: URL | undefined;
   },
 ): Promise<StepResult> {
   if (step.type !== 'agent') {
-    return Promise.resolve(agentFailure(`Unsupported step type: ${step.type}`));
+    return agentFailure(`Unsupported step type: ${step.type}`);
   }
 
   const {prompt} = step.config;
   if (typeof prompt !== 'string' || prompt === '') {
-    return Promise.resolve(
-      agentFailure(
-        'Agent step config is missing prompt',
-        'agent_config_invalid',
-        'step_config_invalid',
-      ),
+    return agentFailure(
+      'Agent step config is missing prompt',
+      'agent_config_invalid',
+      'step_config_invalid',
     );
   }
   const tools = toolsFromConfig(step.config.tools);
   if (tools === 'invalid') {
-    return Promise.resolve(
-      agentFailure(
-        'Agent step config has invalid tools.',
-        'agent_config_invalid',
-        'step_config_invalid',
-      ),
+    return agentFailure(
+      'Agent step config has invalid tools.',
+      'agent_config_invalid',
+      'step_config_invalid',
+    );
+  }
+  const mcpServers = mcpServersFromConfig(step.config.mcpServers);
+  if (mcpServers === 'invalid') {
+    return agentFailure(
+      'Agent step config has invalid integration tools.',
+      'agent_config_invalid',
+      'step_config_invalid',
     );
   }
 
-  return runSelectedHarness({
-    cwd: options.cwd ?? process.cwd(),
-    harness: options.runtime.harness,
-    model: options.runtime.model,
-    outputs: outputDeclarationsFromConfig(step.config.outputs),
-    prompt,
-    tools,
-    thinking: options.runtime.thinking,
-    provider: options.runtime.provider,
-    credentials: options.runtime.credentials,
-    customProvider: options.runtime.custom_provider,
-    signal: options.signal,
-    gitConfigGlobal: options.gitConfigGlobal,
-    onSessionEntry: options.onSessionEntry,
+  const integrationToolsBridges = integrationToolsBridgesFromConfig(mcpServers, {
+    leaseToken: options.leaseToken,
+    integrationToolsGatewayUrl: options.integrationToolsGatewayUrl,
   });
+  if (integrationToolsBridges === 'invalid') {
+    return agentFailure(
+      'Agent step config has invalid integration tools.',
+      'agent_config_invalid',
+      'step_config_invalid',
+    );
+  }
+
+  try {
+    return await runSelectedHarness({
+      cwd: options.cwd ?? process.cwd(),
+      harness: options.runtime.harness,
+      model: options.runtime.model,
+      outputs: outputDeclarationsFromConfig(step.config.outputs),
+      prompt,
+      tools,
+      mcpServers: integrationToolsBridges,
+      thinking: options.runtime.thinking,
+      provider: options.runtime.provider,
+      credentials: options.runtime.credentials,
+      customProvider: options.runtime.custom_provider,
+      signal: options.signal,
+      gitConfigGlobal: options.gitConfigGlobal,
+      onSessionEntry: options.onSessionEntry,
+    });
+  } finally {
+    await closeIntegrationToolsBridges(integrationToolsBridges);
+  }
 }
 
 async function runSelectedHarness(params: {
@@ -77,6 +112,7 @@ async function runSelectedHarness(params: {
   outputs: OutputDeclarations | undefined;
   prompt: string;
   tools: readonly string[] | undefined;
+  mcpServers: readonly IntegrationToolsBridge[] | undefined;
   thinking: string;
   provider: string;
   credentials: Record<string, string>;
@@ -92,6 +128,7 @@ async function runSelectedHarness(params: {
     outputs,
     prompt,
     tools,
+    mcpServers,
     thinking,
     provider,
     credentials,
@@ -111,6 +148,7 @@ async function runSelectedHarness(params: {
         thinking,
         prompt,
         ...(tools === undefined ? {} : {tools}),
+        ...(mcpServers === undefined ? {} : {mcpServers}),
         outputs,
         credentials,
         customProvider,
@@ -216,4 +254,45 @@ function toolsFromConfig(value: unknown): readonly string[] | undefined | 'inval
   if (!Array.isArray(value) || value.length === 0) return 'invalid';
   if (value.some((tool) => typeof tool !== 'string' || tool === '')) return 'invalid';
   return [...value];
+}
+
+function mcpServersFromConfig(
+  value: unknown,
+): readonly AgentIntegrationMcpServerConfigDto[] | undefined | 'invalid' {
+  if (value === undefined) return undefined;
+  const parsed = z.array(agentIntegrationMcpServerSchema).length(1).safeParse(value);
+  return parsed.success ? parsed.data : 'invalid';
+}
+
+function integrationToolsBridgesFromConfig(
+  mcpServers: readonly AgentIntegrationMcpServerConfigDto[] | undefined,
+  options: {
+    leaseToken?: LeaseTokenSource | undefined;
+    integrationToolsGatewayUrl?: URL | undefined;
+  },
+): readonly IntegrationToolsBridge[] | undefined | 'invalid' {
+  const {leaseToken, integrationToolsGatewayUrl} = options;
+  if (mcpServers === undefined) {
+    return undefined;
+  }
+  if (leaseToken === undefined || integrationToolsGatewayUrl === undefined) return 'invalid';
+
+  return mcpServers.map((mcpServer) =>
+    createIntegrationToolsBridge({
+      name: mcpServer.name,
+      url: integrationToolsGatewayUrl,
+      fetch: createIntegrationToolsGatewayFetch(leaseToken, integrationToolsGatewayUrl),
+    }),
+  );
+}
+
+async function closeIntegrationToolsBridges(
+  bridges: readonly IntegrationToolsBridge[] | undefined,
+): Promise<void> {
+  const results = await Promise.allSettled(bridges?.map((bridge) => bridge.close()) ?? []);
+  for (const result of results) {
+    if (result.status === 'rejected') {
+      logger().warn({err: result.reason}, 'Failed to close integration tools bridge');
+    }
+  }
 }

--- a/libs/runner/orchestration/src/core/runner.test.ts
+++ b/libs/runner/orchestration/src/core/runner.test.ts
@@ -153,6 +153,7 @@ describe('runJob', () => {
     );
     const leaseTokenSource = mockCreateLeaseClient.mock.calls[0]?.[0];
     expect(leaseTokenSource).toEqual(expect.any(Function));
+    expect(mockRunJobSteps.mock.calls[0]?.[0].leaseToken).toEqual(expect.any(Function));
     expect(mockRunJobSteps).toHaveBeenCalledWith(
       expect.objectContaining({
         jobId: JOB.job_id,
@@ -187,12 +188,16 @@ describe('runJob', () => {
 
     const leaseTokenSource = mockCreateLeaseClient.mock.calls[0]?.[0];
     const stepParams = mockRunJobSteps.mock.calls[0]?.[0];
+    const stepLeaseTokenSource = stepParams?.leaseToken as (() => string) | undefined;
     expect(typeof leaseTokenSource).toBe('function');
+    expect(typeof stepLeaseTokenSource).toBe('function');
     expect((leaseTokenSource as () => string)()).toBe(JOB.lease_token);
+    expect(stepLeaseTokenSource?.()).toBe(JOB.lease_token);
     expect(stepParams?.secrets).toEqual(['sf_mrt_runner-registration-token', JOB.lease_token]);
     const heartbeatOptions = mockStartHeartbeatLoop.mock.calls[0]?.[3];
     heartbeatOptions?.onLeaseTokenRenewed?.('lease-next');
     expect((leaseTokenSource as () => string)()).toBe('lease-next');
+    expect(stepLeaseTokenSource?.()).toBe('lease-next');
     heartbeatOptions?.onLeaseTokenRenewed?.('lease-third');
     heartbeatOptions?.onLeaseTokenRenewed?.('lease-fourth');
 
@@ -220,11 +225,14 @@ describe('runJob', () => {
 
     const leaseTokenSource = mockCreateLeaseClient.mock.calls[0]?.[0];
     const stepParams = mockRunJobSteps.mock.calls[0]?.[0];
+    const stepLeaseTokenSource = stepParams?.leaseToken as (() => string) | undefined;
     expect(typeof leaseTokenSource).toBe('function');
+    expect(typeof stepLeaseTokenSource).toBe('function');
 
     stepParams?.onLeaseTokenAdopted?.('lease-step-scoped');
 
     expect((leaseTokenSource as () => string)()).toBe('lease-step-scoped');
+    expect(stepLeaseTokenSource?.()).toBe('lease-step-scoped');
     expect(stepParams?.secrets).toEqual([
       'sf_mrt_runner-registration-token',
       JOB.lease_token,

--- a/libs/runner/orchestration/src/core/runner.ts
+++ b/libs/runner/orchestration/src/core/runner.ts
@@ -203,6 +203,7 @@ export async function runJob(
     await runJobSteps({
       jobId: job.job_id,
       leaseClient,
+      leaseToken: () => currentLeaseToken,
       secrets,
       subscribeSecrets: (subscriber) => {
         leaseTokenSecretSubscribers.add(subscriber);

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -38,6 +38,7 @@ const requestStepSecretsMock = vi.fn();
 const reportStepMock = vi.fn();
 const appendStepLogsMock = vi.fn();
 const writeStepAnnotationsMock = vi.fn();
+const integrationToolsGatewayUrlMock = vi.fn();
 const executeRunStepMock = vi.fn();
 const executeSetupStepMock = vi.fn();
 const createStepLogStreamMock = vi.fn();
@@ -51,6 +52,7 @@ vi.mock('@shipfox/runner-protocol', () => ({
   reportStep: (...args: unknown[]) => reportStepMock(...args),
   appendStepLogs: (...args: unknown[]) => appendStepLogsMock(...args),
   writeStepAnnotations: (...args: unknown[]) => writeStepAnnotationsMock(...args),
+  integrationToolsGatewayUrl: (...args: unknown[]) => integrationToolsGatewayUrlMock(...args),
   AgentRuntimeConfigRequestError,
   StepSecretsRequestError,
   HTTPError,
@@ -89,6 +91,10 @@ const JOB_CONTEXT = {
   jobExecutionId: '00000000-0000-0000-0000-0000000000ad',
 };
 const leaseClient = {} as never;
+const leaseTokenSource = () => 'lease-current';
+const integrationGatewayUrl = new URL(
+  'https://api.example.test/runs/jobs/current/integration-tools/mcp',
+);
 const STREAM_LENGTH = 128;
 
 // Ordered log of stream lifecycle events across all created streams, so tests can
@@ -163,6 +169,7 @@ function streamFor(stepId: string): FakeStream {
 
 function runLoop(params: {
   signal: AbortSignal;
+  leaseToken?: () => string;
   secrets?: string[];
   cwd?: string;
   subscribeSecrets?: (subscriber: (secrets: string[]) => void) => () => void;
@@ -171,6 +178,7 @@ function runLoop(params: {
   return runJobSteps({
     jobId: JOB_ID,
     leaseClient,
+    leaseToken: params.leaseToken ?? leaseTokenSource,
     secrets: params.secrets ?? [],
     ...(params.subscribeSecrets ? {subscribeSecrets: params.subscribeSecrets} : {}),
     signal: params.signal,
@@ -190,6 +198,7 @@ describe('runJobSteps', () => {
     reportStepMock.mockReset();
     appendStepLogsMock.mockReset();
     writeStepAnnotationsMock.mockReset();
+    integrationToolsGatewayUrlMock.mockReset();
     executeRunStepMock.mockReset();
     executeSetupStepMock.mockReset();
     createStepLogStreamMock.mockReset();
@@ -203,6 +212,7 @@ describe('runJobSteps', () => {
       credentials: {api_key: 'sk-runtime-secret'},
     });
     requestStepSecretsMock.mockResolvedValue({secrets: []});
+    integrationToolsGatewayUrlMock.mockReturnValue(integrationGatewayUrl);
     events = [];
     createdStreams = new Map();
     reportStepMock.mockResolvedValue({ok: true, cancel: false});
@@ -1195,6 +1205,8 @@ describe('runJobSteps', () => {
         thinking: 'high',
         credentials: {api_key: 'sk-runtime-secret'},
       },
+      leaseToken: leaseTokenSource,
+      integrationToolsGatewayUrl: integrationGatewayUrl,
       onSessionEntry: expect.any(Function),
     });
     expect(requestAgentRuntimeConfigMock).toHaveBeenCalledWith(leaseClient, {
@@ -1389,6 +1401,8 @@ describe('runJobSteps', () => {
         thinking: 'high',
         credentials: {api_key: 'sk-runtime-secret'},
       },
+      leaseToken: leaseTokenSource,
+      integrationToolsGatewayUrl: integrationGatewayUrl,
     });
     expect(reportStepMock).toHaveBeenCalledWith(
       leaseClient,
@@ -1444,6 +1458,7 @@ describe('runJobSteps', () => {
       logsDir: LOGS_DIR,
       jobContext: JOB_CONTEXT,
       leaseClient,
+      leaseToken: leaseTokenSource,
       secrets: [],
       signal: ac.signal,
       workspacePrepared: true,
@@ -1481,6 +1496,7 @@ describe('runJobSteps', () => {
       logsDir: LOGS_DIR,
       jobContext: JOB_CONTEXT,
       leaseClient,
+      leaseToken: leaseTokenSource,
       secrets: [],
       signal: ac.signal,
       workspacePrepared: true,

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -28,6 +28,8 @@ import {
   type AnnotationWriteOutcome,
   appendStepLogs,
   HTTPError,
+  integrationToolsGatewayUrl,
+  type LeaseTokenSource,
   type LogAppendFn,
   reportStep,
   requestAgentRuntimeConfig,
@@ -51,6 +53,7 @@ const WHITESPACE_REGEX = /\s+/;
 export async function runJobSteps(params: {
   jobId: string;
   leaseClient: KyInstance;
+  leaseToken: LeaseTokenSource;
   /** Secrets masked out of captured output before it reaches the spool. */
   secrets: string[];
   subscribeSecrets?: (subscriber: (secrets: string[]) => void) => () => void;
@@ -98,6 +101,7 @@ export async function runJobSteps(params: {
         attempt,
         cwd,
         leaseClient,
+        leaseToken: params.leaseToken,
         secrets,
         ...(params.subscribeSecrets ? {subscribeSecrets: params.subscribeSecrets} : {}),
         signal,
@@ -208,6 +212,7 @@ export async function executeStep(params: {
   logsDir: string;
   jobContext: SetupJobContext;
   leaseClient: KyInstance;
+  leaseToken: LeaseTokenSource;
   secrets: string[];
   subscribeSecrets?: (subscriber: (secrets: string[]) => void) => () => void;
   signal: AbortSignal;
@@ -224,6 +229,7 @@ export async function executeStep(params: {
     logsDir,
     jobContext,
     leaseClient,
+    leaseToken,
     secrets,
     subscribeSecrets,
     signal,
@@ -371,6 +377,8 @@ export async function executeStep(params: {
             ? {custom_provider: runtimeConfig.custom_provider}
             : {}),
         },
+        leaseToken,
+        integrationToolsGatewayUrl: integrationToolsGatewayUrl(),
         ...(sessionStream
           ? {onSessionEntry: (line: string) => sessionStream?.writeEntry(line)}
           : {}),

--- a/libs/runner/protocol/src/api-client.ts
+++ b/libs/runner/protocol/src/api-client.ts
@@ -219,7 +219,7 @@ function hasRunnerSessionExhaustedCode(body: unknown): boolean {
 // retried — it surfaces so the loop can stop.
 export type LeaseTokenSource = string | (() => string);
 
-function readLeaseToken(leaseToken: LeaseTokenSource): string {
+export function readLeaseToken(leaseToken: LeaseTokenSource): string {
   return typeof leaseToken === 'function' ? leaseToken() : leaseToken;
 }
 

--- a/libs/runner/protocol/src/index.ts
+++ b/libs/runner/protocol/src/index.ts
@@ -7,6 +7,7 @@ export {
   createLeaseClient,
   HTTPError,
   heartbeat,
+  type LeaseTokenSource,
   type LogAppendFn,
   type LogAppendOutcome,
   RunnerLabelsRequiredError,
@@ -23,3 +24,7 @@ export {
   StepSecretsRequestError,
   writeStepAnnotations,
 } from '#api-client.js';
+export {
+  createIntegrationToolsGatewayFetch,
+  integrationToolsGatewayUrl,
+} from '#integration-tools-gateway.js';

--- a/libs/runner/protocol/src/integration-tools-gateway.test.ts
+++ b/libs/runner/protocol/src/integration-tools-gateway.test.ts
@@ -1,0 +1,86 @@
+import {AGENT_INTEGRATION_MCP_ENDPOINT} from '@shipfox/api-agent-dto';
+import {
+  createIntegrationToolsGatewayFetch,
+  integrationToolsGatewayUrl,
+} from '#integration-tools-gateway.js';
+
+let calls: Array<{
+  url: string;
+  authorization: string | null;
+  accept: string | null;
+  redirect: RequestInit['redirect'];
+}>;
+let originalFetch: typeof globalThis.fetch;
+
+beforeAll(() => {
+  originalFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+beforeEach(() => {
+  calls = [];
+});
+
+describe('integration tools gateway protocol helpers', () => {
+  it('composes the configured API base URL with the integration MCP endpoint', () => {
+    const url = integrationToolsGatewayUrl();
+
+    expect(url.pathname).toBe(AGENT_INTEGRATION_MCP_ENDPOINT);
+  });
+
+  it('injects the current lease token on every gateway fetch', async () => {
+    stubFetch();
+    let leaseToken = 'lease-initial';
+    const gatewayUrl = new URL('https://api.example.test/runs/jobs/current/integration-tools/mcp');
+    const gatewayFetch = createIntegrationToolsGatewayFetch(() => leaseToken, gatewayUrl);
+
+    await gatewayFetch('https://api.example.test/runs/jobs/current/integration-tools/mcp', {
+      headers: {accept: 'application/json, text/event-stream'},
+    });
+    leaseToken = 'lease-next';
+    await gatewayFetch(new URL('https://api.example.test/runs/jobs/current/integration-tools/mcp'));
+
+    expect(calls).toEqual([
+      {
+        url: 'https://api.example.test/runs/jobs/current/integration-tools/mcp',
+        authorization: 'Bearer lease-initial',
+        accept: 'application/json, text/event-stream',
+        redirect: 'error',
+      },
+      {
+        url: 'https://api.example.test/runs/jobs/current/integration-tools/mcp',
+        authorization: 'Bearer lease-next',
+        accept: null,
+        redirect: 'error',
+      },
+    ]);
+  });
+
+  it('refuses to attach the lease token to non-gateway requests', async () => {
+    stubFetch();
+    const gatewayUrl = new URL('https://api.example.test/runs/jobs/current/integration-tools/mcp');
+    const gatewayFetch = createIntegrationToolsGatewayFetch('lease-current', gatewayUrl);
+
+    await expect(gatewayFetch('https://api.example.test/runs/jobs/current')).rejects.toThrow(
+      'Integration tools gateway fetch refused request to https://api.example.test/runs/jobs/current',
+    );
+
+    expect(calls).toEqual([]);
+  });
+});
+
+function stubFetch(): void {
+  globalThis.fetch = vi.fn((input: Request | string | URL, init?: RequestInit) => {
+    const request = input instanceof Request ? input : new Request(input, init);
+    calls.push({
+      url: request.url,
+      authorization: request.headers.get('authorization'),
+      accept: request.headers.get('accept'),
+      redirect: request.redirect,
+    });
+    return Promise.resolve(new Response(null, {status: 202}));
+  }) as unknown as typeof globalThis.fetch;
+}

--- a/libs/runner/protocol/src/integration-tools-gateway.ts
+++ b/libs/runner/protocol/src/integration-tools-gateway.ts
@@ -1,0 +1,42 @@
+import {AGENT_INTEGRATION_MCP_ENDPOINT} from '@shipfox/api-agent-dto';
+import {type LeaseTokenSource, readLeaseToken} from '#api-client.js';
+import {config} from '#config.js';
+
+const baseUrl = config.SHIPFOX_API_URL.endsWith('/')
+  ? config.SHIPFOX_API_URL
+  : `${config.SHIPFOX_API_URL}/`;
+const LEADING_SLASH_REGEX = /^\//;
+
+export function integrationToolsGatewayUrl(): URL {
+  return new URL(AGENT_INTEGRATION_MCP_ENDPOINT.replace(LEADING_SLASH_REGEX, ''), baseUrl);
+}
+
+export function createIntegrationToolsGatewayFetch(
+  leaseToken: LeaseTokenSource,
+  gatewayUrl: URL,
+): typeof fetch {
+  return (input, init) => {
+    const requestUrl = input instanceof Request ? new URL(input.url) : new URL(input);
+    if (!isIntegrationToolsGatewayRequest(requestUrl, gatewayUrl)) {
+      return Promise.reject(
+        new Error(
+          `Integration tools gateway fetch refused request to ${requestUrl.origin}${requestUrl.pathname}`,
+        ),
+      );
+    }
+
+    const headers = new Headers(input instanceof Request ? input.headers : undefined);
+    if (init?.headers) {
+      new Headers(init.headers).forEach((value, key) => {
+        headers.set(key, value);
+      });
+    }
+    headers.set('Authorization', `Bearer ${readLeaseToken(leaseToken)}`);
+
+    return fetch(input, {...init, headers, redirect: 'error'});
+  };
+}
+
+function isIntegrationToolsGatewayRequest(requestUrl: URL, gatewayUrl: URL): boolean {
+  return requestUrl.origin === gatewayUrl.origin && requestUrl.pathname === gatewayUrl.pathname;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4916,6 +4916,9 @@ importers:
       '@earendil-works/pi-tui':
         specifier: 0.79.9
         version: 0.79.9
+      '@modelcontextprotocol/sdk':
+        specifier: 1.29.0
+        version: 1.29.0(zod@4.4.3)
       '@shipfox/api-agent-dto':
         specifier: workspace:*
         version: link:../../api/agent-dto
@@ -4940,6 +4943,9 @@ importers:
       '@shipfox/runner-execution':
         specifier: workspace:*
         version: link:../execution
+      '@shipfox/runner-protocol':
+        specifier: workspace:*
+        version: link:../protocol
       pi-web-access:
         specifier: 0.13.0
         version: 0.13.0(@earendil-works/pi-ai@0.79.9(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3))(@earendil-works/pi-coding-agent@0.79.6(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3))(@earendil-works/pi-tui@0.79.9)(typebox@1.1.38)


### PR DESCRIPTION
## Summary
- add runner-protocol helpers for the integration-tools MCP gateway URL and per-request lease-token fetch
- add the runner-agent integration tools bridge with programmatic list/call plus in-process MCP proxy server
- validate mcpServers fail-closed in agent steps and thread the rotating lease token through orchestration

## Notes
- Adapter consumption of invocation.mcpServers is intentionally left for the follow-up wiring PR.
- No changeset: touched runner packages are private.

## Verification
- rtk mise exec -- turbo test --filter=@shipfox/runner-agent --filter=@shipfox/runner-protocol --filter=@shipfox/runner-orchestration
- rtk mise exec -- turbo type type:emit --filter=@shipfox/runner-agent --filter=@shipfox/runner-protocol --filter=@shipfox/runner-orchestration
- rtk mise exec -- turbo check --filter=@shipfox/runner-agent --filter=@shipfox/runner-protocol --filter=@shipfox/runner-orchestration

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a runner-side MCP bridge for integration tools that forwards tool list/call to the gateway with the current lease token. Implements ENG-850 by threading the rotating lease token through orchestration and validating `mcpServers` fail-closed.

- **New Features**
  - `@shipfox/runner-protocol`: `integrationToolsGatewayUrl()` and `createIntegrationToolsGatewayFetch(leaseToken, gatewayUrl)` for per-request auth; refuses non-gateway requests.
  - `@shipfox/runner-agent`: `createIntegrationToolsBridge(...)` with in-process MCP server and programmatic `listTools`/`callTool`; bridges are passed to harness via `mcpServers` and closed after runs; agent step validates integration tools via `agentIntegrationMcpServerSchema` and rejects invalid/empty servers, wrong transport, or wrong auth.
  - Orchestration passes `leaseToken` and the gateway URL to steps; heartbeat/adoption rotations are honored in tool calls.

- **Dependencies**
  - Added `@modelcontextprotocol/sdk@1.29.0`.
  - Linked `@shipfox/runner-protocol` in `@shipfox/runner-agent`.

<sup>Written for commit 1adf001f53983b2f98f26478c8d73afe571571d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

