### PR TITLE
[api/integration] Add Linear agent-session triggers

### DIFF
--- a/libs/api/integration/linear-dto/src/schemas/index.test.ts
+++ b/libs/api/integration/linear-dto/src/schemas/index.test.ts
@@ -1,5 +1,7 @@
 import {
   LINEAR_PROVIDER,
+  linearAgentSessionWebhookBaseEnvelopeSchema,
+  linearAgentSessionWebhookEnvelopeSchema,
   linearWebhookBaseEnvelopeSchema,
   linearWebhookEnvelopeSchema,
   linearWebhookEventNames,
@@ -74,9 +76,64 @@ describe('linear webhook schemas', () => {
     expect(result.type).toBe('Reaction');
   });
 
+  it.each([
+    'created',
+    'prompted',
+  ] as const)('accepts the supported AgentSessionEvent %s action', (action) => {
+    const result = linearAgentSessionWebhookEnvelopeSchema.parse({
+      action,
+      type: 'AgentSessionEvent',
+      organizationId: 'org-1',
+      appUserId: 'app-user-1',
+      webhookTimestamp: 1_786_257_600_000,
+      agentSession: {id: 'session-1'},
+    });
+
+    expect(result.action).toBe(action);
+  });
+
+  it.each([
+    ['organizationId', undefined],
+    ['organizationId', ''],
+    ['appUserId', undefined],
+    ['appUserId', ''],
+    ['webhookTimestamp', undefined],
+    ['webhookTimestamp', 1.5],
+    ['agentSession', undefined],
+    ['agentSession', 'session-1'],
+  ])('rejects AgentSessionEvent payloads missing or invalid %s', (field, value) => {
+    const payload = {
+      action: 'created',
+      type: 'AgentSessionEvent',
+      organizationId: 'org-1',
+      appUserId: 'app-user-1',
+      webhookTimestamp: 1_786_257_600_000,
+      agentSession: {id: 'session-1'},
+      [field]: value,
+    };
+
+    expect(linearAgentSessionWebhookEnvelopeSchema.safeParse(payload).success).toBe(false);
+  });
+
+  it('accepts an unknown AgentSessionEvent action in the base schema but not the supported schema', () => {
+    const payload = {
+      action: 'resolved',
+      type: 'AgentSessionEvent',
+      organizationId: 'org-1',
+      appUserId: 'app-user-1',
+      webhookTimestamp: 1_786_257_600_000,
+      agentSession: {id: 'session-1'},
+    };
+
+    expect(linearAgentSessionWebhookBaseEnvelopeSchema.safeParse(payload).success).toBe(true);
+    expect(linearAgentSessionWebhookEnvelopeSchema.safeParse(payload).success).toBe(false);
+  });
+
   it('exports Linear-facing event names without remapping resource casing', () => {
     expect(linearWebhookEventNames).toContain('Issue.create');
     expect(linearWebhookEventNames).toContain('IssueLabel.update');
     expect(linearWebhookEventNames).toContain('Cycle.remove');
+    expect(linearWebhookEventNames).toContain('agentSession.created');
+    expect(linearWebhookEventNames).toContain('agentSession.prompted');
   });
 });

--- a/libs/api/integration/linear-dto/src/schemas/index.ts
+++ b/libs/api/integration/linear-dto/src/schemas/index.ts
@@ -13,33 +13,74 @@ export const linearWebhookResourceTypes = [
   'Cycle',
 ] as const;
 export const linearWebhookActions = ['create', 'update', 'remove'] as const;
+export const linearAgentSessionWebhookActions = ['created', 'prompted'] as const;
 
-export const linearWebhookEventNames = linearWebhookResourceTypes.flatMap((type) =>
+const linearDataWebhookEventNames = linearWebhookResourceTypes.flatMap((type) =>
   linearWebhookActions.map((action) => `${type}.${action}` as const),
 );
+export const linearAgentSessionWebhookEventNames = linearAgentSessionWebhookActions.map(
+  (action) => `agentSession.${action}` as const,
+);
+export const linearWebhookEventNames = [
+  ...linearDataWebhookEventNames,
+  ...linearAgentSessionWebhookEventNames,
+] as const;
 
 export type LinearWebhookResourceType = (typeof linearWebhookResourceTypes)[number];
 export type LinearWebhookAction = (typeof linearWebhookActions)[number];
+export type LinearAgentSessionWebhookAction = (typeof linearAgentSessionWebhookActions)[number];
+export type LinearAgentSessionWebhookEventName =
+  (typeof linearAgentSessionWebhookEventNames)[number];
 export type LinearWebhookEventName = (typeof linearWebhookEventNames)[number];
 
 const linearWebhookDataSchema = z.record(z.string(), z.unknown());
+const linearWebhookAgentSessionSchema = z.record(z.string(), z.unknown());
 
-export const linearWebhookEnvelopeSchema = z.object({
+const linearWebhookDataEnvelopeSchema = z.object({
   action: z.enum(linearWebhookActions),
   type: z.enum(linearWebhookResourceTypes),
   organizationId: z.string().min(1),
   webhookTimestamp: z.number().int(),
   data: linearWebhookDataSchema,
 });
-export type LinearWebhookEnvelopeDto = z.infer<typeof linearWebhookEnvelopeSchema>;
 
-export const linearWebhookBaseEnvelopeSchema = z.object({
+const linearWebhookDataBaseEnvelopeSchema = z.object({
   action: z.string().min(1),
   type: z.string().min(1),
   organizationId: z.string().min(1),
   webhookTimestamp: z.number().int(),
   data: linearWebhookDataSchema,
 });
+export const linearAgentSessionWebhookBaseEnvelopeSchema = z.object({
+  action: z.string().min(1),
+  type: z.literal('AgentSessionEvent'),
+  organizationId: z.string().min(1),
+  appUserId: z.string().min(1),
+  webhookTimestamp: z.number().int(),
+  agentSession: linearWebhookAgentSessionSchema,
+});
+export type LinearAgentSessionWebhookBaseEnvelopeDto = z.infer<
+  typeof linearAgentSessionWebhookBaseEnvelopeSchema
+>;
+
+export const linearAgentSessionWebhookEnvelopeSchema =
+  linearAgentSessionWebhookBaseEnvelopeSchema.extend({
+    action: z.enum(linearAgentSessionWebhookActions),
+  });
+export type LinearAgentSessionWebhookEnvelopeDto = z.infer<
+  typeof linearAgentSessionWebhookEnvelopeSchema
+>;
+
+export const linearWebhookEnvelopeSchema = z.union([
+  linearWebhookDataEnvelopeSchema,
+  linearAgentSessionWebhookEnvelopeSchema,
+]);
+export type LinearWebhookEnvelopeDto = z.infer<typeof linearWebhookEnvelopeSchema>;
+
+export const linearWebhookBaseEnvelopeSchema = z.union([
+  linearWebhookDataBaseEnvelopeSchema,
+  linearAgentSessionWebhookBaseEnvelopeSchema,
+]);
 export type LinearWebhookBaseEnvelopeDto = z.infer<typeof linearWebhookBaseEnvelopeSchema>;
 
 export const createLinearInstallBodySchema = z.object({

--- a/libs/api/integration/linear/README.md
+++ b/libs/api/integration/linear/README.md
@@ -18,12 +18,31 @@ request body before parsing JSON, rejects signed payloads whose
 `webhookTimestamp` is more than 60 seconds from the API server clock, and uses
 the `Linear-Delivery` header as the integration delivery id.
 
+The OAuth app manifest is the canonical webhook configuration. Configure its
+initial webhook resource types as `Issue`, `Comment`, `IssueLabel`, `Project`,
+`Cycle`, and `AgentSessionEvent`; Linear applies that app-level configuration
+when an organization authorizes the app. Shipfox does not issue a runtime
+`webhookCreate` mutation, and there are no earlier installed organizations to
+migrate. See [Linear's OAuth app manifests](https://linear.app/developers/oauth-app-manifests).
+
 Supported data webhook events are `Issue`, `Comment`, `IssueLabel`, `Project`,
-and `Cycle` with `create`, `update`, or `remove` actions. Supported deliveries
-publish `integrations.event.received` with `provider: "linear"`,
-`source: connection.slug`, and event names such as `Issue.create`. Signed but
-unsupported webhook shapes are recorded and dropped with a 200 response so
-Linear does not retry or disable the webhook endpoint.
+and `Cycle` with `create`, `update`, or `remove` actions. They publish
+`integrations.event.received` with `provider: "linear"`, `source:
+connection.slug`, and event names such as `Issue.create`.
+
+`AgentSessionEvent.created` publishes `agentSession.created` for both an
+assignment and a comment mention. The raw payload is preserved, including
+`agentSession.commentId` and `agentSession.sourceCommentId`, so workflow filters
+can distinguish the context. Authors can get the Linear app user id from an
+observed event or the Linear app identity, then compare it with `appUserId` in a
+filter literal. `AgentSessionEvent.prompted` publishes `agentSession.prompted`;
+it can start a subscribed workflow or reach an explicitly configured job listener,
+but never automatically resumes a run from its AgentSession. The module does not
+acknowledge sessions or emit Linear agent activities. See [Linear's agent-session
+behavior](https://linear.app/developers/agent-interaction).
+
+Signed but unsupported webhook shapes are recorded and dropped with a 200
+response so Linear does not retry or disable the webhook endpoint.
 ## Agent Tool Catalog
 
 The v1 Linear agent tool catalog is a broad workspace catalog over Linear's

--- a/libs/api/integration/linear/src/core/webhook.test.ts
+++ b/libs/api/integration/linear/src/core/webhook.test.ts
@@ -5,6 +5,7 @@ import type {
   PublishIntegrationEventReceivedFn,
   RecordDeliveryOnlyFn,
 } from '@shipfox/api-integration-core-dto';
+import type {LinearWebhookBaseEnvelopeDto} from '@shipfox/api-integration-linear-dto';
 import {db} from '#db/db.js';
 import {upsertLinearInstallation} from '#db/installations.js';
 import {linearInstallations} from '#db/schema/installations.js';
@@ -32,6 +33,20 @@ function payload(overrides: Record<string, unknown> = {}) {
     organizationId: `org-${randomUUID()}`,
     webhookTimestamp: Date.now(),
     data: {id: 'issue-1'},
+    ...overrides,
+  };
+}
+
+function agentSessionPayload(
+  overrides: Record<string, unknown> = {},
+): LinearWebhookBaseEnvelopeDto {
+  return {
+    action: 'created',
+    type: 'AgentSessionEvent',
+    organizationId: `org-${randomUUID()}`,
+    appUserId: 'app-user-1',
+    webhookTimestamp: Date.now(),
+    agentSession: {id: 'session-1'},
     ...overrides,
   };
 }
@@ -144,6 +159,35 @@ describe('handleLinearWebhook', () => {
     expect(handlers.recordDeliveryOnly).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ['created', 'agentSession.created'],
+    ['prompted', 'agentSession.prompted'],
+  ] as const)('publishes AgentSessionEvent %s as %s', async (action, event) => {
+    const connection = fakeConnection();
+    const rawPayload = agentSessionPayload({
+      action,
+      organizationId: `org-${action}`,
+      promptContext: '<issue identifier="ENG-879">Route the complete payload</issue>',
+    });
+    await seedInstallation({connectionId: connection.id, organizationId: `org-${action}`});
+    const handlers = deps({connection});
+
+    const result = await handleLinearWebhook({
+      tx: db(),
+      deliveryId: randomUUID(),
+      payload: rawPayload,
+      rawPayload,
+      ...handlers,
+    });
+
+    expect(result.outcome).toBe('published');
+    const published = firstPublishIntegrationEventReceivedCall(
+      handlers.publishIntegrationEventReceived,
+    );
+    expect(published.event.event).toBe(event);
+    expect(published.event.payload).toEqual(rawPayload);
+  });
+
   it('records the delivery only for an unknown organization', async () => {
     const handlers = deps();
     const deliveryId = randomUUID();
@@ -238,6 +282,25 @@ describe('handleLinearWebhook', () => {
     const connection = fakeConnection();
     const rawPayload = payload({organizationId: 'org-reaction', type: 'Reaction'});
     await seedInstallation({connectionId: connection.id, organizationId: 'org-reaction'});
+    const handlers = deps({connection});
+
+    const result = await handleLinearWebhook({
+      tx: db(),
+      deliveryId: randomUUID(),
+      payload: rawPayload,
+      rawPayload,
+      ...handlers,
+    });
+
+    expect(result.outcome).toBe('unsupported-event');
+    expect(handlers.publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(handlers.recordDeliveryOnly).toHaveBeenCalledTimes(1);
+  });
+
+  it('records and drops an unsupported AgentSessionEvent action', async () => {
+    const connection = fakeConnection();
+    const rawPayload = agentSessionPayload({action: 'resolved', organizationId: 'org-resolved'});
+    await seedInstallation({connectionId: connection.id, organizationId: 'org-resolved'});
     const handlers = deps({connection});
 
     const result = await handleLinearWebhook({

--- a/libs/api/integration/linear/src/core/webhook.ts
+++ b/libs/api/integration/linear/src/core/webhook.ts
@@ -7,6 +7,8 @@ import type {
 import {
   LINEAR_PROVIDER,
   type LinearWebhookBaseEnvelopeDto,
+  type LinearWebhookEnvelopeDto,
+  type LinearWebhookEventName,
   linearWebhookEnvelopeSchema,
 } from '@shipfox/api-integration-linear-dto';
 import {logger} from '@shipfox/node-opentelemetry';
@@ -113,7 +115,7 @@ export async function handleLinearWebhook(
     event: {
       provider: LINEAR_PROVIDER,
       source: connection.slug,
-      event: `${supported.data.type}.${supported.data.action}`,
+      event: linearWebhookEventName(supported.data),
       workspaceId: connection.workspaceId,
       connectionId: connection.id,
       connectionName: connection.displayName,
@@ -124,6 +126,11 @@ export async function handleLinearWebhook(
   });
 
   return {outcome: result.published ? 'published' : 'duplicate'};
+}
+
+function linearWebhookEventName(payload: LinearWebhookEnvelopeDto): LinearWebhookEventName {
+  if (payload.type === 'AgentSessionEvent') return `agentSession.${payload.action}`;
+  return `${payload.type}.${payload.action}`;
 }
 
 async function recordDeliveryOnly(params: {

--- a/libs/api/integration/linear/src/presentation/routes/webhooks.test.ts
+++ b/libs/api/integration/linear/src/presentation/routes/webhooks.test.ts
@@ -35,6 +35,18 @@ function linearPayload(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function agentSessionPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    action: 'created',
+    type: 'AgentSessionEvent',
+    organizationId: `org-${randomUUID()}`,
+    appUserId: 'app-user-1',
+    webhookTimestamp: Date.now(),
+    agentSession: {id: 'session-1'},
+    ...overrides,
+  };
+}
+
 function signedHeaders(rawBody: string, event: string, deliveryId: string) {
   const signature = createHmac('sha256', WEBHOOK_SECRET).update(rawBody).digest('hex');
   return {
@@ -154,6 +166,64 @@ describe('Linear webhook route', () => {
     expect(
       publishIntegrationEventReceived.mock.calls.map(([call]) => call.event.deliveryId),
     ).toEqual(['linear-delivery-a', 'linear-delivery-b']);
+  });
+
+  it.each([
+    ['an assignment', {agentSession: {id: 'session-1', issueId: 'issue-1'}}],
+    [
+      'a comment mention',
+      {agentSession: {id: 'session-1', commentId: 'comment-1', sourceCommentId: 'comment-1'}},
+    ],
+  ])('publishes %s as agentSession.created', async (_context, details) => {
+    const connection = fakeConnection();
+    const {app, publishIntegrationEventReceived} = await createTestApp({connection});
+    const deliveryId = randomUUID();
+    const rawPayload = agentSessionPayload({
+      organizationId: `org-${deliveryId}`,
+      promptContext: '<issue identifier="ENG-879">Route the complete payload</issue>',
+      ...details,
+    });
+    await seedInstallation({connectionId: connection.id, organizationId: `org-${deliveryId}`});
+    const body = JSON.stringify(rawPayload);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/integrations/linear',
+      headers: signedHeaders(body, 'AgentSessionEvent', deliveryId),
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(publishIntegrationEventReceived).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({event: 'agentSession.created', payload: rawPayload}),
+      }),
+    );
+  });
+
+  it('publishes prompted AgentSessionEvent deliveries without an agent response', async () => {
+    const connection = fakeConnection();
+    const {app, publishIntegrationEventReceived} = await createTestApp({connection});
+    const deliveryId = randomUUID();
+    const rawPayload = agentSessionPayload({
+      action: 'prompted',
+      organizationId: `org-${deliveryId}`,
+      agentSession: {id: 'session-1', issueId: 'issue-1'},
+    });
+    await seedInstallation({connectionId: connection.id, organizationId: `org-${deliveryId}`});
+    const body = JSON.stringify(rawPayload);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/integrations/linear',
+      headers: signedHeaders(body, 'AgentSessionEvent', deliveryId),
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(publishIntegrationEventReceived).toHaveBeenCalledWith(
+      expect.objectContaining({event: expect.objectContaining({event: 'agentSession.prompted'})}),
+    );
   });
 
   it.each([

--- a/libs/api/triggers/src/core/dispatch-integration-event.test.ts
+++ b/libs/api/triggers/src/core/dispatch-integration-event.test.ts
@@ -204,6 +204,46 @@ describe('dispatchIntegrationEvent', () => {
     );
   });
 
+  test('dispatches AgentSessionEvent deliveries only to the matching app-user filter', async () => {
+    const workspaceId = crypto.randomUUID();
+    const payload = {
+      action: 'created',
+      type: 'AgentSessionEvent',
+      organizationId: 'linear-org-id',
+      appUserId: 'app-user-1',
+      webhookTimestamp: Date.now(),
+      agentSession: {id: 'session-id', commentId: 'comment-id'},
+    };
+    const matching = await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'Linear_Acme',
+      event: 'agentSession.created',
+      config: {filter: 'event.appUserId == "app-user-1"'},
+    });
+    await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'Linear_Acme',
+      event: 'agentSession.created',
+      config: {filter: 'event.appUserId == "other-app-user"'},
+    });
+
+    await dispatch({
+      provider: 'linear',
+      workspaceId,
+      source: 'Linear_Acme',
+      event: 'agentSession.created',
+      payload,
+    });
+
+    expect(runWorkflow).toHaveBeenCalledTimes(1);
+    expect(runWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: matching.projectId,
+        triggerPayload: expect.objectContaining({data: payload}),
+      }),
+    );
+  });
+
   test('routes webhook events only when workspace, source, and received event match', async () => {
     const workspaceId = crypto.randomUUID();
     const matching = await triggerSubscriptionFactory.create({


### PR DESCRIPTION
Add Linear `AgentSessionEvent` deliveries to the existing integration trigger pipeline.

Assignments, mentions, and follow-up prompts from a Linear app user previously reached the signed receiver but were outside the supported data-webhook contract. This lets workflow authors react to `agentSession.created` and `agentSession.prompted` while preserving the complete raw payload for filtering by `appUserId` and comment context.

The implementation keeps dispatch source-agnostic rather than adding a Linear-specific trigger path. It deliberately does not bind Agent Sessions to Shipfox runs: prompted events can reach configured workflow subscriptions or job listeners, but never automatically resume an existing run. Unknown actions continue through record-and-drop handling.

The Linear README now treats `AgentSessionEvent` as an initial OAuth app-manifest webhook resource rather than a runtime webhook mutation. Reviewers should especially check the shallow public payload boundary and the explicit no-session-resumption behavior.

Closes ENG-879

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Linear agent-session triggers to the existing webhook pipeline so workflows can react to `agentSession.created` and `agentSession.prompted`. Addresses ENG-879.

- New Features
  - Support `AgentSessionEvent` (`created`, `prompted`) and publish as `agentSession.created`/`agentSession.prompted`.
  - Pass through the full payload for filtering by `appUserId` and comment context (e.g., `agentSession.commentId`, `sourceCommentId`).
  - No automatic session-bound run resumption; events only trigger subscribed workflows or reach configured job listeners.
  - Record-and-drop unsupported agent-session actions; README updates the OAuth app manifest to include `AgentSessionEvent` in initial resources.

<sup>Written for commit a310e0bbbcbfa0e04e5f7404052c3840847b7c7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

