### PR TITLE
[runner] Wire integration MCP tools into Pi and Claude

### DIFF
--- a/libs/runner/agent/package.json
+++ b/libs/runner/agent/package.json
@@ -52,6 +52,7 @@
     "@shipfox/node-opentelemetry": "workspace:*",
     "@shipfox/runner-execution": "workspace:*",
     "@shipfox/runner-protocol": "workspace:*",
+    "pi-mcp-adapter": "2.11.0",
     "pi-web-access": "0.13.0",
     "typebox": "1.1.38",
     "zod": "4.4.3"

--- a/libs/runner/agent/src/core/claude-adapter.test.ts
+++ b/libs/runner/agent/src/core/claude-adapter.test.ts
@@ -55,6 +55,7 @@ import {join} from 'node:path';
 import {claudeHarnessAdapter} from '#core/claude-adapter.js';
 import {AgentConfigError} from '#core/errors.js';
 import type {HarnessInvocation} from '#core/harness.js';
+import type {IntegrationToolsBridge} from '#core/integration-tools-bridge.js';
 
 function invocation(overrides: Partial<HarnessInvocation> = {}): HarnessInvocation {
   return {
@@ -102,6 +103,17 @@ function makeThrowingQuery(error: Error) {
     [Symbol.asyncIterator]: () => ({
       next: () => Promise.reject(error),
     }),
+  };
+}
+
+function mcpBridge(): IntegrationToolsBridge {
+  return {
+    name: 'shipfox_integration_tools',
+    server: {} as IntegrationToolsBridge['server'],
+    listTools: vi.fn(),
+    callTool: vi.fn(),
+    activateHttp: vi.fn(),
+    close: vi.fn(),
   };
 }
 
@@ -293,6 +305,25 @@ describe('claudeHarnessAdapter', () => {
     expect(lastQueryOptions().mcpServers).toBeUndefined();
   });
 
+  it('keeps integration bridges available with the Anthropic base URL override', async () => {
+    configMock.AGENT_CLAUDE_ANTHROPIC_BASE_URL = 'http://127.0.0.1:11434';
+    const bridge = mcpBridge();
+    queryMock.mockReturnValue(makeQuery([successMessage]));
+
+    await claudeHarnessAdapter.run(invocation({credentials: {}, mcpServers: [bridge]}));
+
+    expect(lastQueryOptions()).toMatchObject({
+      tools: [],
+      mcpServers: {
+        shipfox_integration_tools: {
+          type: 'sdk',
+          name: 'shipfox_integration_tools',
+          instance: bridge.server,
+        },
+      },
+    });
+  });
+
   it('registers declared output tools when the Anthropic base URL override is active', async () => {
     configMock.AGENT_CLAUDE_ANTHROPIC_BASE_URL = 'http://127.0.0.1:11434';
     queryMock.mockReturnValue(makeQuery([successMessage, successMessage, successMessage]));
@@ -388,6 +419,42 @@ describe('claudeHarnessAdapter', () => {
         tools: ['Read', 'Grep', 'WebSearch'],
       }),
     });
+  });
+
+  it('registers integration bridges with the Claude SDK transport', async () => {
+    const bridge = mcpBridge();
+    queryMock.mockReturnValue(makeQuery([successMessage]));
+
+    await claudeHarnessAdapter.run(invocation({mcpServers: [bridge]}));
+
+    expect(lastQueryOptions().mcpServers).toEqual({
+      shipfox_integration_tools: {
+        type: 'sdk',
+        name: 'shipfox_integration_tools',
+        instance: bridge.server,
+      },
+    });
+  });
+
+  it('merges integration bridges with output tools', async () => {
+    const bridge = mcpBridge();
+    queryMock.mockReturnValue(makeQuery([successMessage, successMessage, successMessage]));
+
+    const result = claudeHarnessAdapter.run(
+      invocation({mcpServers: [bridge], outputs: {summary: {type: 'string'}}}),
+    );
+
+    await expect(result).rejects.toThrow('Agent step finished without required outputs: summary');
+    expect(lastQueryOptions().mcpServers).toEqual(
+      expect.objectContaining({
+        shipfox_integration_tools: {
+          type: 'sdk',
+          name: 'shipfox_integration_tools',
+          instance: bridge.server,
+        },
+        shipfox_outputs: expect.objectContaining({name: 'shipfox_outputs'}),
+      }),
+    );
   });
 
   it('does not spawn Claude when already aborted', async () => {

--- a/libs/runner/agent/src/core/claude-adapter.ts
+++ b/libs/runner/agent/src/core/claude-adapter.ts
@@ -75,6 +75,7 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
   const hasDeclaredOutputs =
     invocation.outputs !== undefined && Object.keys(invocation.outputs).length > 0;
   const useOutputTools = hasDeclaredOutputs;
+  const mcpServers = claudeMcpServers(invocation.mcpServers, collector, useOutputTools);
 
   await assertRunnerEgressAllowed(targetUrl, targetLabel);
 
@@ -105,19 +106,7 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
         abortController: controller,
         ...claudeToolsOption(tools, override),
         env: claudeEnvironment(auth, configDir, gitConfigGlobal, override),
-        ...(useOutputTools
-          ? {
-              mcpServers: {
-                shipfox_outputs: createSdkMcpServer({
-                  name: 'shipfox_outputs',
-                  version: '1.0.0',
-                  instructions: collector.guidanceText(),
-                  tools: [setOutputTool(collector)],
-                  alwaysLoad: true,
-                }),
-              },
-            }
-          : {}),
+        ...(mcpServers === undefined ? {} : {mcpServers}),
         persistSession: false,
         includePartialMessages: false,
       },
@@ -159,6 +148,29 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
   }
 
   throw new Error('Claude agent did not emit a result message.');
+}
+
+function claudeMcpServers(
+  integrationMcpServers: HarnessInvocation['mcpServers'],
+  collector: OutputCollector,
+  useOutputTools: boolean,
+) {
+  const servers = Object.fromEntries(
+    (integrationMcpServers ?? []).map((server) => [
+      server.name,
+      {type: 'sdk' as const, name: server.name, instance: server.server},
+    ]),
+  );
+  if (useOutputTools) {
+    servers.shipfox_outputs = createSdkMcpServer({
+      name: 'shipfox_outputs',
+      version: '1.0.0',
+      instructions: collector.guidanceText(),
+      tools: [setOutputTool(collector)],
+      alwaysLoad: true,
+    });
+  }
+  return Object.keys(servers).length === 0 ? undefined : servers;
 }
 
 function claudeToolsOption(

--- a/libs/runner/agent/src/core/integration-tools-bridge.test.ts
+++ b/libs/runner/agent/src/core/integration-tools-bridge.test.ts
@@ -1,6 +1,7 @@
 import {once} from 'node:events';
 import {createServer, type Server as HttpServer} from 'node:http';
 import {Client} from '@modelcontextprotocol/sdk/client/index.js';
+import {StreamableHTTPClientTransport} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import {InMemoryTransport} from '@modelcontextprotocol/sdk/inMemory.js';
 import {Server} from '@modelcontextprotocol/sdk/server/index.js';
 import {StreamableHTTPServerTransport} from '@modelcontextprotocol/sdk/server/streamableHttp.js';
@@ -94,6 +95,66 @@ describe('createIntegrationToolsBridge', () => {
     });
     expect(gateway.authorizations).toContain('Bearer lease-initial');
     expect(gateway.authorizations.at(-1)).toBe('Bearer lease-next');
+  });
+
+  it('serves the MCP bridge over one loopback endpoint', async () => {
+    let leaseToken = 'lease-initial';
+    gateway = await startFakeGateway(() => leaseToken);
+    const bridge = createIntegrationToolsBridge({
+      name: 'shipfox_integration_tools',
+      url: gateway.url,
+      fetch: leaseFetch(() => leaseToken),
+    });
+
+    const [endpoint, concurrentEndpoint] = await Promise.all([
+      bridge.activateHttp(),
+      bridge.activateHttp(),
+    ]);
+    const probe = new Client({name: 'pi-mcp-probe', version: '2.1.2'});
+    await probe.connect(new StreamableHTTPClientTransport(endpoint) as unknown as Transport);
+    await probe.close();
+    const client = new Client({name: 'test-client', version: '0.0.0'});
+    const transport = new StreamableHTTPClientTransport(endpoint);
+    await client.connect(transport as unknown as Transport);
+    const tools = await client.listTools();
+    leaseToken = 'lease-next';
+    const result = await client.callTool(
+      {
+        name: 'github_main__issue_read',
+        arguments: {method: 'get', owner: 'shipfox', repo: 'platform', issue_number: 3},
+      },
+      CallToolResultSchema,
+    );
+    const invalidPath = await fetch(new URL('/other', endpoint));
+    const invalidOrigin = await fetch(endpoint, {headers: {Origin: 'http://outside.example.test'}});
+    await client.close();
+    await bridge.close();
+
+    expect(endpoint).toEqual(concurrentEndpoint);
+    expect(endpoint.hostname).toBe('127.0.0.1');
+    expect(endpoint.pathname).toBe('/mcp');
+    expect(tools.tools.map((tool) => tool.name)).toEqual(['github_main__issue_read']);
+    expect(result.structuredContent).toEqual({
+      name: 'github_main__issue_read',
+      method: 'get',
+      issue_number: 3,
+    });
+    expect(gateway.authorizations.at(-1)).toBe('Bearer lease-next');
+    expect(invalidPath.status).toBe(404);
+    expect(invalidOrigin.status).toBe(403);
+  });
+
+  it('allows repeated close before activation', async () => {
+    gateway = await startFakeGateway(() => 'lease');
+    const bridge = createIntegrationToolsBridge({
+      name: 'shipfox_integration_tools',
+      url: gateway.url,
+      fetch: leaseFetch(() => 'lease'),
+    });
+
+    await Promise.all([bridge.close(), bridge.close()]);
+
+    await expect(bridge.activateHttp()).rejects.toThrow('closed');
   });
 });
 

--- a/libs/runner/agent/src/core/integration-tools-bridge.ts
+++ b/libs/runner/agent/src/core/integration-tools-bridge.ts
@@ -186,7 +186,11 @@ async function handleHttpRequest(
     if (isInitializeRequest(body)) sessions.set(session.id, session);
     await session.transport.handleRequest(request, response, body);
     if (request.method === 'DELETE') {
-      response.once('finish', () => void closeHttpSession(session, sessions));
+      response.once('finish', () => {
+        void closeHttpSession(session, sessions).catch((error) => {
+          logger().warn({err: error}, 'Failed to close MCP HTTP session');
+        });
+      });
     }
   } catch (error) {
     logger().warn({err: error}, 'MCP bridge request failed');
@@ -302,9 +306,9 @@ async function closeHttpSession(
 }
 
 function closeHttpServer(server: HttpServer): Promise<void> {
-  server.closeAllConnections();
   if (!server.listening) return Promise.resolve();
   return new Promise((resolve, reject) => {
     server.close((error) => (error === undefined ? resolve() : reject(error)));
+    server.closeAllConnections();
   });
 }

--- a/libs/runner/agent/src/core/integration-tools-bridge.ts
+++ b/libs/runner/agent/src/core/integration-tools-bridge.ts
@@ -1,6 +1,15 @@
+import {once} from 'node:events';
+import {
+  createServer,
+  type Server as HttpServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from 'node:http';
 import {Client} from '@modelcontextprotocol/sdk/client/index.js';
 import {StreamableHTTPClientTransport} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import {Server} from '@modelcontextprotocol/sdk/server/index.js';
+import {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
+import {StreamableHTTPServerTransport} from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import type {Transport} from '@modelcontextprotocol/sdk/shared/transport.js';
 import {
   CallToolRequestSchema,
@@ -9,12 +18,17 @@ import {
   ListToolsRequestSchema,
   type ListToolsResult,
 } from '@modelcontextprotocol/sdk/types.js';
+import {logger} from '@shipfox/node-opentelemetry';
+
+const MAX_MCP_REQUEST_BYTES = 1_048_576;
+const MCP_REQUEST_TIMEOUT_MS = 30_000;
 
 export interface IntegrationToolsBridge {
   readonly name: string;
-  readonly server: Server;
+  readonly server: McpServer;
   listTools(): Promise<ListToolsResult>;
   callTool(name: string, args?: Record<string, unknown>): Promise<CallToolResult>;
+  activateHttp(): Promise<URL>;
   close(): Promise<void>;
 }
 
@@ -25,8 +39,12 @@ export function createIntegrationToolsBridge(params: {
 }): IntegrationToolsBridge {
   const client = new Client({name: params.name, version: '0.0.0'});
   const transport = new StreamableHTTPClientTransport(params.url, {fetch: params.fetch});
-  const server = new Server({name: params.name, version: '0.0.0'}, {capabilities: {tools: {}}});
+  const server = new McpServer({name: params.name, version: '0.0.0'}, {capabilities: {tools: {}}});
   let connectPromise: Promise<void> | undefined;
+  let activationPromise: Promise<URL> | undefined;
+  let closePromise: Promise<void> | undefined;
+  let httpServer: HttpServer | undefined;
+  const httpSessions = new Map<string, HttpSession>();
 
   const ensureConnected = () => {
     connectPromise ??= client.connect(transport as unknown as Transport);
@@ -47,21 +65,246 @@ export function createIntegrationToolsBridge(params: {
         CallToolResultSchema,
       ) as Promise<CallToolResult>;
     },
-    async close() {
-      await client.close();
-      await server.close();
+    activateHttp() {
+      if (closePromise !== undefined) {
+        return Promise.reject(new Error('Integration tools bridge is closed.'));
+      }
+      activationPromise ??= activateBridgeHttp({
+        server,
+        setHttpServer: (value) => (httpServer = value),
+        createHttpSession: async () => {
+          const id = crypto.randomUUID();
+          const sessionServer = new Server(
+            {name: params.name, version: '0.0.0'},
+            {capabilities: {tools: {}}},
+          );
+          installForwardingHandlers(sessionServer, ensureConnected, client);
+          const sessionTransport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: () => id,
+          });
+          await sessionServer.connect(sessionTransport as unknown as Transport);
+          return {id, server: sessionServer, transport: sessionTransport};
+        },
+        httpSessions,
+      });
+      return activationPromise;
+    },
+    close() {
+      closePromise ??= closeBridge({
+        activationPromise,
+        client,
+        server,
+        getHttpServer: () => httpServer,
+        httpSessions,
+      });
+      return closePromise;
     },
   };
 
+  installForwardingHandlers(server.server, ensureConnected, client);
+
+  return bridge;
+}
+
+async function activateBridgeHttp(params: {
+  server: McpServer;
+  setHttpServer: (server: HttpServer) => void;
+  createHttpSession: () => Promise<HttpSession>;
+  httpSessions: Map<string, HttpSession>;
+}): Promise<URL> {
+  const httpServer = createServer((request, response) => {
+    void handleHttpRequest(request, response, params.httpSessions, params.createHttpSession);
+  });
+  httpServer.headersTimeout = MCP_REQUEST_TIMEOUT_MS;
+  httpServer.requestTimeout = MCP_REQUEST_TIMEOUT_MS;
+  params.setHttpServer(httpServer);
+
+  try {
+    httpServer.listen(0, '127.0.0.1');
+    await once(httpServer, 'listening');
+    const address = httpServer.address();
+    if (typeof address !== 'object' || address === null) {
+      throw new Error('Integration tools bridge did not bind a TCP address.');
+    }
+    return new URL(`http://127.0.0.1:${address.port}/mcp`);
+  } catch (error) {
+    try {
+      await releaseResources({
+        server: params.server,
+        httpServer,
+        httpSessions: params.httpSessions,
+      });
+    } catch (cleanupError) {
+      logger().warn({err: cleanupError}, 'Failed to clean up an inactive MCP bridge');
+    }
+    throw error;
+  }
+}
+
+interface HttpSession {
+  readonly id: string;
+  readonly server: Server;
+  readonly transport: StreamableHTTPServerTransport;
+}
+
+async function handleHttpRequest(
+  request: IncomingMessage,
+  response: ServerResponse,
+  sessions: Map<string, HttpSession>,
+  createHttpSession: () => Promise<HttpSession>,
+): Promise<void> {
+  const requestUrl = new URL(request.url ?? '/', 'http://127.0.0.1');
+  if (requestUrl.pathname !== '/mcp') {
+    sendMcpError(response, 404, -32600, 'Invalid MCP endpoint.');
+    return;
+  }
+
+  if (!isLoopbackRequest(request)) {
+    sendMcpError(response, 403, -32600, 'MCP endpoint accepts loopback requests only.');
+    return;
+  }
+  if (
+    request.headers['content-length'] !== undefined &&
+    Number(request.headers['content-length']) > MAX_MCP_REQUEST_BYTES
+  ) {
+    sendMcpError(response, 413, -32600, 'MCP request is too large.');
+    return;
+  }
+
+  try {
+    const body = request.method === 'POST' ? await readJsonBody(request) : undefined;
+    const sessionId = request.headers['mcp-session-id'];
+    const session = isInitializeRequest(body)
+      ? await createHttpSession()
+      : typeof sessionId === 'string'
+        ? sessions.get(sessionId)
+        : undefined;
+    if (session === undefined) {
+      sendMcpError(response, 404, -32600, 'Unknown MCP session.');
+      return;
+    }
+    if (isInitializeRequest(body)) sessions.set(session.id, session);
+    await session.transport.handleRequest(request, response, body);
+    if (request.method === 'DELETE') {
+      response.once('finish', () => void closeHttpSession(session, sessions));
+    }
+  } catch (error) {
+    logger().warn({err: error}, 'MCP bridge request failed');
+    if (!response.headersSent) sendMcpError(response, 500, -32603, 'MCP request failed.');
+    else response.end();
+  }
+}
+
+function installForwardingHandlers(
+  server: Server,
+  ensureConnected: () => Promise<void>,
+  client: Client,
+): void {
   server.setRequestHandler(ListToolsRequestSchema, async (request) => {
     await ensureConnected();
     return client.listTools(request.params);
   });
-
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     await ensureConnected();
     return client.callTool(request.params, CallToolResultSchema);
   });
+}
 
-  return bridge;
+function isInitializeRequest(body: unknown): boolean {
+  return (
+    typeof body === 'object' && body !== null && 'method' in body && body.method === 'initialize'
+  );
+}
+
+function isLoopbackRequest(request: IncomingMessage): boolean {
+  const host = request.headers.host;
+  if (host === undefined || !host.startsWith('127.0.0.1:')) return false;
+  const origin = request.headers.origin;
+  return origin === undefined || origin === `http://${host}`;
+}
+
+async function readJsonBody(request: NodeJS.ReadableStream): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  let byteLength = 0;
+  for await (const chunk of request) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    byteLength += buffer.length;
+    if (byteLength > MAX_MCP_REQUEST_BYTES) throw new Error('MCP request is too large.');
+    chunks.push(buffer);
+  }
+  return JSON.parse(Buffer.concat(chunks).toString('utf8')) as unknown;
+}
+
+function sendMcpError(
+  response: ServerResponse,
+  statusCode: number,
+  code: number,
+  message: string,
+): void {
+  response
+    .writeHead(statusCode, {'Content-Type': 'application/json'})
+    .end(JSON.stringify({jsonrpc: '2.0', error: {code, message}, id: null}));
+}
+
+async function closeBridge(params: {
+  activationPromise: Promise<URL> | undefined;
+  client: Client;
+  server: McpServer;
+  getHttpServer: () => HttpServer | undefined;
+  httpSessions: Map<string, HttpSession>;
+}): Promise<void> {
+  try {
+    await params.activationPromise;
+  } catch {
+    // Activation has already released its partially created resources.
+  }
+
+  const httpServer = params.getHttpServer();
+  await releaseResources({
+    client: params.client,
+    server: params.server,
+    httpSessions: params.httpSessions,
+    ...(httpServer === undefined ? {} : {httpServer}),
+  });
+}
+
+async function releaseResources(params: {
+  client?: Client;
+  server: McpServer;
+  httpServer?: HttpServer;
+  httpSessions?: Map<string, HttpSession>;
+}): Promise<void> {
+  const httpSessions = params.httpSessions;
+  const results = await Promise.allSettled([
+    ...(params.client === undefined ? [] : [params.client.close()]),
+    params.server.close(),
+    ...(httpSessions === undefined
+      ? []
+      : [...httpSessions.values()].map((session) => closeHttpSession(session, httpSessions))),
+    ...(params.httpServer === undefined ? [] : [closeHttpServer(params.httpServer)]),
+  ]);
+  const errors = results.flatMap((result) => (result.status === 'rejected' ? [result.reason] : []));
+  if (errors.length > 0) {
+    throw new AggregateError(errors, 'Failed to close integration tools bridge resources.');
+  }
+}
+
+async function closeHttpSession(
+  session: HttpSession,
+  sessions: Map<string, HttpSession>,
+): Promise<void> {
+  sessions.delete(session.id);
+  const results = await Promise.allSettled([session.server.close(), session.transport.close()]);
+  const errors = results.flatMap((result) => (result.status === 'rejected' ? [result.reason] : []));
+  if (errors.length > 0) {
+    throw new AggregateError(errors, 'Failed to close MCP HTTP session.');
+  }
+}
+
+function closeHttpServer(server: HttpServer): Promise<void> {
+  server.closeAllConnections();
+  if (!server.listening) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error === undefined ? resolve() : reject(error)));
+  });
 }

--- a/libs/runner/agent/src/core/pi-adapter.test.ts
+++ b/libs/runner/agent/src/core/pi-adapter.test.ts
@@ -253,6 +253,33 @@ describe('piHarnessAdapter', () => {
     expect(existsSync(configPath)).toBe(false);
   });
 
+  it('aborts Pi while MCP extensions are binding', async () => {
+    sessionDir = mkdtempSync(join(tmpdir(), 'shipfox-pi-mcp-'));
+    const abortController = new AbortController();
+    let resolveBinding: (() => void) | undefined;
+    bindExtensionsMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveBinding = resolve;
+        }),
+    );
+
+    const result = piHarnessAdapter.run(
+      invocation({
+        cwd: sessionDir,
+        signal: abortController.signal,
+        mcpServers: [mcpBridge()],
+      }),
+    );
+    await vi.waitFor(() => expect(bindExtensionsMock).toHaveBeenCalledTimes(1));
+
+    abortController.abort();
+
+    expect(abortMock).toHaveBeenCalledTimes(1);
+    resolveBinding?.();
+    await expect(result).rejects.toThrow('Agent step aborted during pi session creation');
+  });
+
   it('fails before creating a Pi session when extension setup reports an error', async () => {
     createAgentSessionServicesMock.mockResolvedValue({
       cwd: '/work',

--- a/libs/runner/agent/src/core/pi-adapter.test.ts
+++ b/libs/runner/agent/src/core/pi-adapter.test.ts
@@ -8,7 +8,10 @@ const {
   defineToolMock,
   promptMock,
   abortMock,
+  bindExtensionsMock,
   getLastAssistantTextMock,
+  disposeMock,
+  extensionShutdownMock,
 } = vi.hoisted(() => ({
   createAgentSessionMock: vi.fn(),
   createAgentSessionServicesMock: vi.fn(),
@@ -19,7 +22,10 @@ const {
   defineToolMock: vi.fn((tool) => tool),
   promptMock: vi.fn(),
   abortMock: vi.fn(),
+  bindExtensionsMock: vi.fn(),
   getLastAssistantTextMock: vi.fn(),
+  disposeMock: vi.fn(),
+  extensionShutdownMock: vi.fn(),
 }));
 const {authStorageCreateMock, authStorageInMemoryMock} = vi.hoisted(() => ({
   authStorageCreateMock: vi.fn(),
@@ -65,7 +71,7 @@ vi.mock('@shipfox/node-egress-guard', () => ({
       .filter(Boolean),
 }));
 
-import {appendFileSync, mkdtempSync, rmSync} from 'node:fs';
+import {appendFileSync, existsSync, mkdtempSync, readFileSync, rmSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {
@@ -77,6 +83,7 @@ import {
 } from '@shipfox/api-agent-dto';
 import {AgentConfigError} from '#core/errors.js';
 import type {HarnessInvocation} from '#core/harness.js';
+import type {IntegrationToolsBridge} from '#core/integration-tools-bridge.js';
 import {piHarnessAdapter} from '#core/pi-adapter.js';
 
 function invocation(overrides: Partial<HarnessInvocation> = {}): HarnessInvocation {
@@ -106,6 +113,18 @@ function customProvider(
   };
 }
 
+function mcpBridge(overrides: Partial<IntegrationToolsBridge> = {}): IntegrationToolsBridge {
+  return {
+    name: 'shipfox_integration_tools',
+    server: {} as IntegrationToolsBridge['server'],
+    listTools: vi.fn(),
+    callTool: vi.fn(),
+    activateHttp: vi.fn().mockResolvedValue(new URL('http://127.0.0.1:43123/mcp')),
+    close: vi.fn(),
+    ...overrides,
+  };
+}
+
 describe('piHarnessAdapter', () => {
   // Tracked so the temp dir is removed in afterEach even if an assertion throws first.
   let sessionDir: string | undefined;
@@ -123,7 +142,10 @@ describe('piHarnessAdapter', () => {
     defineToolMock.mockClear();
     promptMock.mockReset();
     abortMock.mockReset();
+    bindExtensionsMock.mockReset();
     getLastAssistantTextMock.mockReset();
+    disposeMock.mockReset();
+    extensionShutdownMock.mockReset();
     assertEgressAllowedMock.mockReset();
     authStorageCreateMock.mockReset();
     authStorageInMemoryMock.mockReset();
@@ -135,11 +157,14 @@ describe('piHarnessAdapter', () => {
     hasConfiguredAuthMock.mockReturnValue(true);
     promptMock.mockResolvedValue(undefined);
     getLastAssistantTextMock.mockReturnValue(undefined);
-    createAgentSessionServicesMock.mockResolvedValue({cwd: '/work'});
+    createAgentSessionServicesMock.mockResolvedValue({cwd: '/work', diagnostics: []});
     createAgentSessionMock.mockResolvedValue({
       session: {
         prompt: promptMock,
         abort: abortMock,
+        bindExtensions: bindExtensionsMock,
+        dispose: disposeMock,
+        extensionRunner: {emit: extensionShutdownMock},
         getLastAssistantText: getLastAssistantTextMock,
         messages: [],
       },
@@ -168,7 +193,11 @@ describe('piHarnessAdapter', () => {
       }),
     );
     expect(createAgentSessionMock).toHaveBeenCalledWith(
-      expect.objectContaining({services: {cwd: '/work'}, thinkingLevel: 'high', model}),
+      expect.objectContaining({
+        services: expect.objectContaining({cwd: '/work'}),
+        thinkingLevel: 'high',
+        model,
+      }),
     );
     expect(promptMock).toHaveBeenCalledWith(expect.stringContaining('Fix it.'));
     expect(result).toEqual({response: ''});
@@ -183,6 +212,57 @@ describe('piHarnessAdapter', () => {
       }),
     );
     expect(createAgentSessionMock.mock.calls[0]?.[0]).not.toHaveProperty('customTools');
+  });
+
+  it('configures eager loopback MCP proxy access in the job workspace', async () => {
+    sessionDir = mkdtempSync(join(tmpdir(), 'shipfox-pi-mcp-'));
+    const bridge = mcpBridge();
+    let configPath = '';
+    let config: unknown;
+    createAgentSessionServicesMock.mockImplementation((options) => {
+      configPath = options.extensionFlagValues.get('mcp-config');
+      config = JSON.parse(readFileSync(configPath, 'utf8'));
+      return {cwd: sessionDir, diagnostics: []};
+    });
+
+    await piHarnessAdapter.run(invocation({cwd: sessionDir, mcpServers: [bridge]}));
+
+    expect(bridge.activateHttp).toHaveBeenCalledTimes(1);
+    expect(bindExtensionsMock).toHaveBeenCalledWith(expect.objectContaining({mode: 'print'}));
+    expect(configPath).toMatch(`${sessionDir}/logs/pi-mcp-`);
+    expect(config).toEqual({
+      settings: {toolPrefix: 'none'},
+      mcpServers: {
+        shipfox_integration_tools: {
+          url: 'http://127.0.0.1:43123/mcp',
+          auth: false,
+          lifecycle: 'eager',
+          exposeResources: false,
+        },
+      },
+    });
+    expect(createAgentSessionServicesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceLoaderOptions: {
+          additionalExtensionPaths: ['pi-web-access', 'pi-mcp-adapter'],
+        },
+      }),
+    );
+    expect(extensionShutdownMock).toHaveBeenCalledWith({type: 'session_shutdown', reason: 'quit'});
+    expect(disposeMock).toHaveBeenCalledAfter(extensionShutdownMock);
+    expect(existsSync(configPath)).toBe(false);
+  });
+
+  it('fails before creating a Pi session when extension setup reports an error', async () => {
+    createAgentSessionServicesMock.mockResolvedValue({
+      cwd: '/work',
+      diagnostics: [{type: 'error', message: 'Unknown option: --mcp-config'}],
+    });
+
+    await expect(piHarnessAdapter.run(invocation())).rejects.toThrow(
+      'Pi extension setup failed: Unknown option: --mcp-config',
+    );
+    expect(createAgentSessionMock).not.toHaveBeenCalled();
   });
 
   it('registers the output tool for steps with declared outputs', async () => {
@@ -205,6 +285,36 @@ describe('piHarnessAdapter', () => {
     );
   });
 
+  it('adds the MCP proxy once when native tools are explicitly selected', async () => {
+    sessionDir = mkdtempSync(join(tmpdir(), 'shipfox-pi-mcp-'));
+    await piHarnessAdapter.run(
+      invocation({
+        cwd: sessionDir,
+        mcpServers: [mcpBridge()],
+        tools: ['read', 'mcp', 'web_search'],
+      }),
+    );
+
+    expect(createAgentSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({tools: ['read', 'mcp', 'web_search']}),
+    );
+  });
+
+  it('appends the MCP proxy tool to an explicit tools list that omits it', async () => {
+    sessionDir = mkdtempSync(join(tmpdir(), 'shipfox-pi-mcp-'));
+    await piHarnessAdapter.run(
+      invocation({
+        cwd: sessionDir,
+        mcpServers: [mcpBridge()],
+        tools: ['read', 'web_search'],
+      }),
+    );
+
+    expect(createAgentSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({tools: ['read', 'web_search', 'mcp']}),
+    );
+  });
+
   it('omits the Pi tools option when no tools are selected', async () => {
     await piHarnessAdapter.run(invocation());
 
@@ -220,6 +330,26 @@ describe('piHarnessAdapter', () => {
       invocation({
         provider: 'local-ollama',
         model: 'llama',
+        customProvider: customProvider({models: [{id: 'llama', label: 'Llama'}]}),
+      }),
+    );
+
+    expect(createAgentSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({model, noTools: 'builtin'}),
+    );
+  });
+
+  it('preserves custom-provider builtin suppression when MCP is configured', async () => {
+    const model = {provider: 'local-ollama', id: 'llama'};
+    findMock.mockReturnValue(model);
+    sessionDir = mkdtempSync(join(tmpdir(), 'shipfox-pi-mcp-'));
+
+    await piHarnessAdapter.run(
+      invocation({
+        cwd: sessionDir,
+        provider: 'local-ollama',
+        model: 'llama',
+        mcpServers: [mcpBridge()],
         customProvider: customProvider({models: [{id: 'llama', label: 'Llama'}]}),
       }),
     );

--- a/libs/runner/agent/src/core/pi-adapter.ts
+++ b/libs/runner/agent/src/core/pi-adapter.ts
@@ -127,17 +127,6 @@ async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult>
     });
     const piSession = createdSession.session;
     session = piSession;
-    if (mcpConfig !== undefined) {
-      await piSession.bindExtensions({
-        mode: 'print',
-        onError: (error) => {
-          logger().warn({err: error}, 'Pi extension failed');
-        },
-      });
-    }
-
-    // session.abort() returns a promise; a rejected abort must not become an unhandled
-    // rejection that crashes the long-lived runner, so swallow it.
     const abortSession = () => {
       Promise.resolve(piSession.abort()).catch(() => undefined);
     };
@@ -148,53 +137,74 @@ async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult>
     }
 
     signal.addEventListener('abort', abortSession, {once: true});
-    const forwarder = startForwarding(piSession.sessionFile, onSessionEntry);
-    // pi may not settle session.prompt() promptly on abort (step.ts races the call), so the
-    // finally below can be delayed indefinitely. Stop the forwarder on abort too, or its poll
-    // timer leaks past workspace teardown. stop() is idempotent, so the finally re-calling it is
-    // safe, and the early stop still does its final drain.
-    const stopForwarder = () => forwarder?.stop();
-    signal.addEventListener('abort', stopForwarder, {once: true});
-    const restoreGitConfigGlobal = createGitConfigGlobalRestorer(gitConfigGlobal);
-    if (gitConfigGlobal) {
-      // The runner executes one agent step at a time in this process; restore promptly so the
-      // process-global Git config cannot leak into the next step.
-      process.env.GIT_CONFIG_GLOBAL = gitConfigGlobal;
-      signal.addEventListener('abort', restoreGitConfigGlobal, {once: true});
-    }
     try {
-      let response = '';
-      await runOutputTurnLoop({
-        signal,
-        prompt: hasDeclaredOutputs ? withOutputGuidance(prompt, collector.guidanceText()) : prompt,
-        runTurn: async (message) => {
-          await piSession.prompt(message);
-          const assistantError = lastAssistantError(piSession.messages);
-          if (assistantError !== undefined) {
-            throw new AgentInvocationError(assistantError, piSession.getLastAssistantText() ?? '');
-          }
-          response = piSession.getLastAssistantText() ?? '';
-        },
-        missingRequired: () => collector.missingRequired(),
-      });
-      const outputs = collector.snapshot();
-      return {
-        response,
-        ...(Object.keys(outputs).length === 0 ? {} : {outputs}),
-      };
-    } catch (error) {
-      if (error instanceof RequiredOutputsMissingError) {
-        throw new AgentInvocationError(error.message, piSession.getLastAssistantText() ?? '');
+      if (mcpConfig !== undefined) {
+        await piSession.bindExtensions({
+          mode: 'print',
+          onError: (error) => {
+            logger().warn({err: error}, 'Pi extension failed');
+          },
+        });
       }
-      throw error;
+
+      if (signal.aborted) {
+        throw new Error('Agent step aborted during pi session creation');
+      }
+
+      const forwarder = startForwarding(piSession.sessionFile, onSessionEntry);
+      // pi may not settle session.prompt() promptly on abort (step.ts races the call), so the
+      // finally below can be delayed indefinitely. Stop the forwarder on abort too, or its poll
+      // timer leaks past workspace teardown. stop() is idempotent, so the finally re-calling it is
+      // safe, and the early stop still does its final drain.
+      const stopForwarder = () => forwarder?.stop();
+      signal.addEventListener('abort', stopForwarder, {once: true});
+      const restoreGitConfigGlobal = createGitConfigGlobalRestorer(gitConfigGlobal);
+      if (gitConfigGlobal) {
+        // The runner executes one agent step at a time in this process; restore promptly so the
+        // process-global Git config cannot leak into the next step.
+        process.env.GIT_CONFIG_GLOBAL = gitConfigGlobal;
+        signal.addEventListener('abort', restoreGitConfigGlobal, {once: true});
+      }
+      try {
+        let response = '';
+        await runOutputTurnLoop({
+          signal,
+          prompt: hasDeclaredOutputs
+            ? withOutputGuidance(prompt, collector.guidanceText())
+            : prompt,
+          runTurn: async (message) => {
+            await piSession.prompt(message);
+            const assistantError = lastAssistantError(piSession.messages);
+            if (assistantError !== undefined) {
+              throw new AgentInvocationError(
+                assistantError,
+                piSession.getLastAssistantText() ?? '',
+              );
+            }
+            response = piSession.getLastAssistantText() ?? '';
+          },
+          missingRequired: () => collector.missingRequired(),
+        });
+        const outputs = collector.snapshot();
+        return {
+          response,
+          ...(Object.keys(outputs).length === 0 ? {} : {outputs}),
+        };
+      } catch (error) {
+        if (error instanceof RequiredOutputsMissingError) {
+          throw new AgentInvocationError(error.message, piSession.getLastAssistantText() ?? '');
+        }
+        throw error;
+      } finally {
+        // A final synchronous read forwards every entry written before the caller closes the log
+        // stream, so all session records precede its end marker.
+        forwarder?.stop();
+        restoreGitConfigGlobal();
+        signal.removeEventListener('abort', stopForwarder);
+        signal.removeEventListener('abort', restoreGitConfigGlobal);
+      }
     } finally {
-      // A final synchronous read forwards every entry written before the caller closes the log
-      // stream, so all session records precede its end marker.
-      forwarder?.stop();
-      restoreGitConfigGlobal();
       signal.removeEventListener('abort', abortSession);
-      signal.removeEventListener('abort', stopForwarder);
-      signal.removeEventListener('abort', restoreGitConfigGlobal);
     }
   } finally {
     await closePiSession({session, mcpConfig});

--- a/libs/runner/agent/src/core/pi-adapter.ts
+++ b/libs/runner/agent/src/core/pi-adapter.ts
@@ -1,3 +1,4 @@
+import {mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises';
 import {join} from 'node:path';
 import {
   type ApiKeyCredential,
@@ -17,6 +18,7 @@ import {
   DEFAULT_CUSTOM_MODEL_MAX_OUTPUT_TOKENS,
   DEFAULT_CUSTOM_MODEL_REASONING,
 } from '@shipfox/api-agent-dto';
+import {logger} from '@shipfox/node-opentelemetry';
 import {Type} from 'typebox';
 import {assertRunnerEgressAllowed} from '#core/egress.js';
 import {AgentConfigError, AgentInvocationError} from '#core/errors.js';
@@ -55,6 +57,7 @@ async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult>
     thinking,
     prompt,
     tools,
+    mcpServers,
     credentials,
     customProvider,
     gitConfigGlobal,
@@ -93,94 +96,202 @@ async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult>
     );
   }
 
-  const services = await createAgentSessionServices({
-    cwd,
-    authStorage,
-    modelRegistry,
-    resourceLoaderOptions: {
-      additionalExtensionPaths: ['pi-web-access'],
-    },
-  });
+  let session: Awaited<ReturnType<typeof createAgentSessionFromServices>>['session'] | undefined;
+  let mcpConfig: PiMcpConfig | undefined;
 
-  const {session} = await createAgentSessionFromServices({
-    services,
-    model,
-    thinkingLevel: thinking as PiThinkingLevel,
-    ...piToolsOption(tools, customProvider),
-    ...(hasDeclaredOutputs ? {customTools: [setOutputTool(collector)]} : {}),
-    // Keep the session JSONL inside the job workspace so it forwards from a deterministic path
-    // and is cleaned up with the workspace; pi's default lives under ~/.pi, outside it.
-    sessionManager: SessionManager.create(cwd, join(cwd, 'logs', 'agent-sessions')),
-  });
-
-  // session.abort() returns a promise; a rejected abort must not become an unhandled
-  // rejection that crashes the long-lived runner, so swallow it.
-  const abortSession = () => {
-    Promise.resolve(session.abort()).catch(() => undefined);
-  };
-
-  if (signal.aborted) {
-    abortSession();
-    throw new Error('Agent step aborted during pi session creation');
-  }
-
-  signal.addEventListener('abort', abortSession, {once: true});
-  const forwarder = startForwarding(session.sessionFile, onSessionEntry);
-  // pi may not settle session.prompt() promptly on abort (step.ts races the call), so the
-  // finally below can be delayed indefinitely. Stop the forwarder on abort too, or its poll
-  // timer leaks past workspace teardown. stop() is idempotent, so the finally re-calling it is
-  // safe, and the early stop still does its final drain.
-  const stopForwarder = () => forwarder?.stop();
-  signal.addEventListener('abort', stopForwarder, {once: true});
-  const restoreGitConfigGlobal = createGitConfigGlobalRestorer(gitConfigGlobal);
-  if (gitConfigGlobal) {
-    // The runner executes one agent step at a time in this process; restore promptly so the
-    // process-global Git config cannot leak into the next step.
-    process.env.GIT_CONFIG_GLOBAL = gitConfigGlobal;
-    signal.addEventListener('abort', restoreGitConfigGlobal, {once: true});
-  }
   try {
-    let response = '';
-    await runOutputTurnLoop({
-      signal,
-      prompt: hasDeclaredOutputs ? withOutputGuidance(prompt, collector.guidanceText()) : prompt,
-      runTurn: async (message) => {
-        await session.prompt(message);
-        const assistantError = lastAssistantError(session.messages);
-        if (assistantError !== undefined) {
-          throw new AgentInvocationError(assistantError, session.getLastAssistantText() ?? '');
-        }
-        response = session.getLastAssistantText() ?? '';
+    mcpConfig = await createPiMcpConfig(cwd, mcpServers);
+    const services = await createAgentSessionServices({
+      cwd,
+      authStorage,
+      modelRegistry,
+      ...(mcpConfig === undefined
+        ? {}
+        : {extensionFlagValues: new Map([['mcp-config', mcpConfig.path]])}),
+      resourceLoaderOptions: {
+        additionalExtensionPaths:
+          mcpConfig === undefined ? ['pi-web-access'] : ['pi-web-access', 'pi-mcp-adapter'],
       },
-      missingRequired: () => collector.missingRequired(),
     });
-    const outputs = collector.snapshot();
-    return {
-      response,
-      ...(Object.keys(outputs).length === 0 ? {} : {outputs}),
-    };
-  } catch (error) {
-    if (error instanceof RequiredOutputsMissingError) {
-      throw new AgentInvocationError(error.message, session.getLastAssistantText() ?? '');
+    assertPiServiceDiagnostics(services.diagnostics);
+
+    const createdSession = await createAgentSessionFromServices({
+      services,
+      model,
+      thinkingLevel: thinking as PiThinkingLevel,
+      ...piToolsOption(tools, customProvider, mcpConfig !== undefined),
+      ...(hasDeclaredOutputs ? {customTools: [setOutputTool(collector)]} : {}),
+      // Keep the session JSONL inside the job workspace so it forwards from a deterministic path
+      // and is cleaned up with the workspace; pi's default lives under ~/.pi, outside it.
+      sessionManager: SessionManager.create(cwd, join(cwd, 'logs', 'agent-sessions')),
+    });
+    const piSession = createdSession.session;
+    session = piSession;
+    if (mcpConfig !== undefined) {
+      await piSession.bindExtensions({
+        mode: 'print',
+        onError: (error) => {
+          logger().warn({err: error}, 'Pi extension failed');
+        },
+      });
     }
-    throw error;
+
+    // session.abort() returns a promise; a rejected abort must not become an unhandled
+    // rejection that crashes the long-lived runner, so swallow it.
+    const abortSession = () => {
+      Promise.resolve(piSession.abort()).catch(() => undefined);
+    };
+
+    if (signal.aborted) {
+      abortSession();
+      throw new Error('Agent step aborted during pi session creation');
+    }
+
+    signal.addEventListener('abort', abortSession, {once: true});
+    const forwarder = startForwarding(piSession.sessionFile, onSessionEntry);
+    // pi may not settle session.prompt() promptly on abort (step.ts races the call), so the
+    // finally below can be delayed indefinitely. Stop the forwarder on abort too, or its poll
+    // timer leaks past workspace teardown. stop() is idempotent, so the finally re-calling it is
+    // safe, and the early stop still does its final drain.
+    const stopForwarder = () => forwarder?.stop();
+    signal.addEventListener('abort', stopForwarder, {once: true});
+    const restoreGitConfigGlobal = createGitConfigGlobalRestorer(gitConfigGlobal);
+    if (gitConfigGlobal) {
+      // The runner executes one agent step at a time in this process; restore promptly so the
+      // process-global Git config cannot leak into the next step.
+      process.env.GIT_CONFIG_GLOBAL = gitConfigGlobal;
+      signal.addEventListener('abort', restoreGitConfigGlobal, {once: true});
+    }
+    try {
+      let response = '';
+      await runOutputTurnLoop({
+        signal,
+        prompt: hasDeclaredOutputs ? withOutputGuidance(prompt, collector.guidanceText()) : prompt,
+        runTurn: async (message) => {
+          await piSession.prompt(message);
+          const assistantError = lastAssistantError(piSession.messages);
+          if (assistantError !== undefined) {
+            throw new AgentInvocationError(assistantError, piSession.getLastAssistantText() ?? '');
+          }
+          response = piSession.getLastAssistantText() ?? '';
+        },
+        missingRequired: () => collector.missingRequired(),
+      });
+      const outputs = collector.snapshot();
+      return {
+        response,
+        ...(Object.keys(outputs).length === 0 ? {} : {outputs}),
+      };
+    } catch (error) {
+      if (error instanceof RequiredOutputsMissingError) {
+        throw new AgentInvocationError(error.message, piSession.getLastAssistantText() ?? '');
+      }
+      throw error;
+    } finally {
+      // A final synchronous read forwards every entry written before the caller closes the log
+      // stream, so all session records precede its end marker.
+      forwarder?.stop();
+      restoreGitConfigGlobal();
+      signal.removeEventListener('abort', abortSession);
+      signal.removeEventListener('abort', stopForwarder);
+      signal.removeEventListener('abort', restoreGitConfigGlobal);
+    }
   } finally {
-    // A final synchronous read forwards every entry written before the caller closes the log
-    // stream, so all session records precede its end marker.
-    forwarder?.stop();
-    restoreGitConfigGlobal();
-    signal.removeEventListener('abort', abortSession);
-    signal.removeEventListener('abort', stopForwarder);
-    signal.removeEventListener('abort', restoreGitConfigGlobal);
+    await closePiSession({session, mcpConfig});
   }
 }
 
 function piToolsOption(
   tools: readonly string[] | undefined,
   customProvider: CustomModelProviderRuntimeConfigDto | undefined,
+  hasMcpServers: boolean,
 ): {tools: string[]} | {noTools: 'builtin'} | Record<string, never> {
-  if (tools !== undefined) return {tools: [...tools]};
+  if (tools !== undefined) {
+    const needsMcpTool = hasMcpServers && !tools.includes('mcp');
+    return {tools: needsMcpTool ? [...tools, 'mcp'] : [...tools]};
+  }
   return customProvider === undefined ? {} : {noTools: 'builtin'};
+}
+
+interface PiMcpConfig {
+  readonly directory: string;
+  readonly path: string;
+}
+
+function assertPiServiceDiagnostics(
+  diagnostics: Awaited<ReturnType<typeof createAgentSessionServices>>['diagnostics'],
+): void {
+  const errors = diagnostics.filter((diagnostic) => diagnostic.type === 'error');
+  if (errors.length === 0) return;
+  throw new AgentConfigError(
+    `Pi extension setup failed: ${errors.map((diagnostic) => diagnostic.message).join('; ')}`,
+  );
+}
+
+async function createPiMcpConfig(
+  cwd: string,
+  mcpServers: HarnessInvocation['mcpServers'],
+): Promise<PiMcpConfig | undefined> {
+  if (mcpServers === undefined || mcpServers.length === 0) return undefined;
+
+  const logsDirectory = join(cwd, 'logs');
+  await mkdir(logsDirectory, {recursive: true});
+  const directory = await mkdtemp(join(logsDirectory, 'pi-mcp-'));
+  const path = join(directory, 'mcp.json');
+  try {
+    const serverEntries = await Promise.all(
+      mcpServers.map(async (server) => [
+        server.name,
+        {
+          url: (await server.activateHttp()).toString(),
+          auth: false,
+          lifecycle: 'eager',
+          exposeResources: false,
+        },
+      ]),
+    );
+    await writeFile(
+      path,
+      JSON.stringify({
+        settings: {toolPrefix: 'none'},
+        mcpServers: Object.fromEntries(serverEntries),
+      }),
+    );
+    return {directory, path};
+  } catch (error) {
+    try {
+      await rm(directory, {recursive: true, force: true});
+    } catch (cleanupError) {
+      logger().warn({err: cleanupError}, 'Failed to remove incomplete Pi MCP configuration');
+    }
+    throw error;
+  }
+}
+
+async function closePiSession(params: {
+  session: Awaited<ReturnType<typeof createAgentSessionFromServices>>['session'] | undefined;
+  mcpConfig: PiMcpConfig | undefined;
+}): Promise<void> {
+  const {session, mcpConfig} = params;
+  if (session !== undefined) {
+    try {
+      await session.extensionRunner.emit({type: 'session_shutdown', reason: 'quit'});
+    } catch (error) {
+      logger().warn({err: error}, 'Failed to shut down Pi extensions');
+    }
+    try {
+      session.dispose();
+    } catch (error) {
+      logger().warn({err: error}, 'Failed to dispose Pi session');
+    }
+  }
+  if (mcpConfig !== undefined) {
+    try {
+      await rm(mcpConfig.directory, {recursive: true, force: true});
+    } catch (error) {
+      logger().warn({err: error}, 'Failed to remove Pi MCP configuration');
+    }
+  }
 }
 
 function lastAssistantError(messages: readonly unknown[]): string | undefined {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4946,6 +4946,9 @@ importers:
       '@shipfox/runner-protocol':
         specifier: workspace:*
         version: link:../protocol
+      pi-mcp-adapter:
+        specifier: 2.11.0
+        version: 2.11.0(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.21.0)(zod@4.4.3)
       pi-web-access:
         specifier: 0.13.0
         version: 0.13.0(@earendil-works/pi-ai@0.79.9(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3))(@earendil-works/pi-coding-agent@0.79.6(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3))(@earendil-works/pi-tui@0.79.9)(typebox@1.1.38)
@@ -6684,6 +6687,11 @@ packages:
     resolution: {integrity: sha512-GsFbPR85nhncKoU9++fTKa11PzwUkAmkrKXo97dBOzi10Td72rVV6vmfxKjwPLHTzRbJMa0byr12YhODZ59yLA==}
     engines: {node: '>=22.19.0'}
 
+  '@earendil-works/pi-ai@0.74.2':
+    resolution: {integrity: sha512-ukQBHGDm20k9ZUS2cGjNN9vDJp/48r35xmvgSx3paCaC06r2N/PLuRZoJmwQ1ZM7f8T3072odv9YPWn+77w0LA==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+
   '@earendil-works/pi-ai@0.79.9':
     resolution: {integrity: sha512-fHmgNMONwCCE7bQAKbcz76sgm3iQuA7km1mpIc4H5xXd9+zhPh/faULz6ARkgjQE0EufHnfZPJY39+lNf8Sa9g==}
     engines: {node: '>=22.19.0'}
@@ -6693,6 +6701,10 @@ packages:
     resolution: {integrity: sha512-xPQDoA3+4Q8UsInST8OGFHPHyi7JQIbx51ku5kf2VuhXrrTv/npjVTXYD3A3D5xs6QRebV0B2mQqHfXaxQAplw==}
     engines: {node: '>=22.19.0'}
     hasBin: true
+
+  '@earendil-works/pi-tui@0.74.2':
+    resolution: {integrity: sha512-valQPz74qbdydRqII6t9rJ46YANMOOJeDhKm25a1ZrWvWwdjAaAEu6s3ur/LWz84Wkkwcbub2ZkVjzCZi8gFGA==}
+    engines: {node: '>=20.0.0'}
 
   '@earendil-works/pi-tui@0.79.9':
     resolution: {integrity: sha512-XcqfoGyoX64OSMQklMR1vG2MRi1TCPSUERRCmPDvYKCK6LtZoBqJ6idNCLRklNYveCj4gHDOzOsLhGqn04jmYw==}
@@ -7855,6 +7867,20 @@ packages:
 
   '@mixmark-io/domino@2.2.0':
     resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
+
+  '@modelcontextprotocol/ext-apps@1.7.4':
+    resolution: {integrity: sha512-QQqysE549cf/Y0VabBmAACXhj92EhB3t8yVct2BHbkWiPTFA1S91EqTVjYXXcZEefXU0pmHcdObhsNMcomJIOQ==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.29.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -9022,6 +9048,10 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@pkgr/core@0.1.2':
+    resolution: {integrity: sha512-fdDH1LSGfZdTH2sxdpVMw31BanV28K/Gry0cVFxaNP77neJSkd82mM8ErPNYs9e+0O7SdHBLTDzDgwUuy18RnQ==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
   '@playwright/test@1.61.0':
     resolution: {integrity: sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==}
@@ -12817,6 +12847,9 @@ packages:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
 
+  koffi@2.16.2:
+    resolution: {integrity: sha512-owU0MRwv6xkrVqCd+33uw6BaYppkTRXbO/rVdJNI2dvZG0gzyRhYwW25eWtc5pauwK8TGh3AbkFONSezdykfSA==}
+
   ky@1.14.3:
     resolution: {integrity: sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==}
     engines: {node: '>=18'}
@@ -12998,6 +13031,11 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  marked@15.0.12:
+    resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
+    engines: {node: '>= 18'}
+    hasBin: true
 
   marked@18.0.5:
     resolution: {integrity: sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==}
@@ -13714,6 +13752,12 @@ packages:
   pgpass@1.0.5:
     resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
 
+  pi-mcp-adapter@2.11.0:
+    resolution: {integrity: sha512-4Y/eLbhbxnRih519dJUxMyQ5QASvPcdWyBlS8+dDXteAzaMuLnd4nMTWgoZw3JRIW+0r93KAQcz1Rbli4xCwEQ==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+
   pi-web-access@0.13.0:
     resolution: {integrity: sha512-ny0bHisMWdobmu1hcMp/jqjaRh6pYrH7dctBK2CVyRF4ia7bP47RnOPYdG1yiks9ohtcanWir5Hl9EFap8h0zQ==}
     peerDependencies:
@@ -14179,6 +14223,33 @@ packages:
   recast@0.23.11:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
+
+  recheck-jar@4.5.0:
+    resolution: {integrity: sha512-Ad7oCQmY8cQLzd3QVNXjzZ+S6MbImGhR4AaW2yiGzteOfMV45522rt6nSzFyt8p3mCEaMcm/4MoZrMSxUcCbrA==}
+
+  recheck-linux-x64@4.5.0:
+    resolution: {integrity: sha512-52kXsR/v+IbGIKYYFZfSZcgse/Ci9IA2HnuzrtvRRcfODkcUGe4n72ESQ8nOPwrdHFg9i4j9/YyPh1HWWgpJ6A==}
+    cpu: [x64]
+    os: [linux]
+
+  recheck-macos-arm64@4.5.0:
+    resolution: {integrity: sha512-qIyK3dRuLkORQvv0b59fZZRXweSmjjWaoA4K8Kgifz0anMBH4pqsDV6plBlgjcRmW9yC12wErIRzifREaKnk2w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  recheck-macos-x64@4.5.0:
+    resolution: {integrity: sha512-1wp/eiLxcjC/Ex4wurlrS/LGzt8IiF4TiK5sEjldu4HVAKdNCnnmsS9a5vFpfcikDz4ZuZlLlTi1VbQTxHlwZg==}
+    cpu: [x64]
+    os: [darwin]
+
+  recheck-windows-x64@4.5.0:
+    resolution: {integrity: sha512-ekBKwAp0oKkMULn5zgmHEYLwSJfkfb95AbTtbDkQazNkqYw9PRD/mVyFUR6Ff2IeRyZI0gxy+N2AKBISWydhug==}
+    cpu: [x64]
+    os: [win32]
+
+  recheck@4.5.0:
+    resolution: {integrity: sha512-kPnbOV6Zfx9a25AZ++28fI1q78L/UVRQmmuazwVRPfiiqpMs+WbOU69Shx820XgfKWfak0JH75PUvZMFtRGSsw==}
+    engines: {node: '>=20'}
 
   rechoir@0.8.0:
     resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
@@ -14722,6 +14793,10 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  synckit@0.9.2:
+    resolution: {integrity: sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==}
+    engines: {node: ^14.18.0 || >=16.0.0}
 
   systeminformation@5.31.8:
     resolution: {integrity: sha512-/HGurKdgjYGbfwCPSokoX4WAlasVxuj1SnTukLiIYHPkjbDbN1PMATj8mkHpqkVzUF34y5ZyCY1TMKP32AI9rA==}
@@ -16195,6 +16270,26 @@ snapshots:
       - ws
       - zod
 
+  '@earendil-works/pi-ai@0.74.2(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@opentelemetry/api@1.9.1)(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
+      '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.1)
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      openai: 6.26.0(ws@8.21.0)(zod@4.4.3)
+      partial-json: 0.1.7
+      typebox: 1.1.38
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - '@opentelemetry/api'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
   '@earendil-works/pi-ai@0.79.9(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
@@ -16245,6 +16340,13 @@ snapshots:
       - utf-8-validate
       - ws
       - zod
+
+  '@earendil-works/pi-tui@0.74.2':
+    dependencies:
+      get-east-asian-width: 1.6.0
+      marked: 15.0.12
+    optionalDependencies:
+      koffi: 2.16.2
 
   '@earendil-works/pi-tui@0.79.9':
     dependencies:
@@ -17117,7 +17219,28 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  '@mistralai/mistralai@2.2.6(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/semantic-conventions': 1.41.1
+      ws: 8.21.0
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@mixmark-io/domino@2.2.0': {}
+
+  '@modelcontextprotocol/ext-apps@1.7.4(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      '@standard-schema/spec': 1.1.0
+      zod: 4.4.3
+    optionalDependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
@@ -18368,6 +18491,8 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@pkgr/core@0.1.2': {}
 
   '@playwright/test@1.61.0':
     dependencies:
@@ -22414,6 +22539,9 @@ snapshots:
 
   kleur@3.0.3: {}
 
+  koffi@2.16.2:
+    optional: true
+
   ky@1.14.3: {}
 
   ky@2.0.2: {}
@@ -22551,6 +22679,8 @@ snapshots:
   markdown-extensions@2.0.0: {}
 
   markdown-table@3.0.4: {}
+
+  marked@15.0.12: {}
 
   marked@18.0.5: {}
 
@@ -23905,6 +24035,26 @@ snapshots:
     dependencies:
       split2: 4.2.0
 
+  pi-mcp-adapter@2.11.0(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(ws@8.21.0)(zod@4.4.3):
+    dependencies:
+      '@earendil-works/pi-ai': 0.74.2(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@opentelemetry/api@1.9.1)(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.74.2
+      '@modelcontextprotocol/ext-apps': 1.7.4(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      open: 10.2.0
+      recheck: 4.5.0
+      typebox: 1.1.38
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - '@opentelemetry/api'
+      - bufferutil
+      - react
+      - react-dom
+      - supports-color
+      - utf-8-validate
+      - ws
+
   pi-web-access@0.13.0(@earendil-works/pi-ai@0.79.9(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3))(@earendil-works/pi-coding-agent@0.79.6(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3))(@earendil-works/pi-tui@0.79.9)(typebox@1.1.38):
     dependencies:
       '@earendil-works/pi-ai': 0.79.9(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
@@ -24412,6 +24562,31 @@ snapshots:
       source-map: 0.6.1
       tiny-invariant: 1.3.3
       tslib: 2.8.1
+
+  recheck-jar@4.5.0:
+    optional: true
+
+  recheck-linux-x64@4.5.0:
+    optional: true
+
+  recheck-macos-arm64@4.5.0:
+    optional: true
+
+  recheck-macos-x64@4.5.0:
+    optional: true
+
+  recheck-windows-x64@4.5.0:
+    optional: true
+
+  recheck@4.5.0:
+    dependencies:
+      synckit: 0.9.2
+    optionalDependencies:
+      recheck-jar: 4.5.0
+      recheck-linux-x64: 4.5.0
+      recheck-macos-arm64: 4.5.0
+      recheck-macos-x64: 4.5.0
+      recheck-windows-x64: 4.5.0
 
   rechoir@0.8.0:
     dependencies:
@@ -25066,6 +25241,11 @@ snapshots:
       webpack: 5.107.2(@swc/core@1.15.41(@swc/helpers@0.5.23))
 
   symbol-tree@3.2.4: {}
+
+  synckit@0.9.2:
+    dependencies:
+      '@pkgr/core': 0.1.2
+      tslib: 2.8.1
 
   systeminformation@5.31.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,7 @@ allowBuilds:
   core-js: false
   cpu-features: true
   esbuild: true
+  koffi: true
   protobufjs: true
   sharp: true
   ssh2: true


### PR DESCRIPTION
Agent steps can already receive integration MCP descriptors, but neither Pi nor Claude attached the runner-local bridge. This wires each harness to the bridge so selected integration tools are available during agent execution.

Pi uses its MCP extension and a job-local configuration; Claude receives SDK MCP server instances. The loopback bridge now isolates per-client sessions so Pi's connection probe cannot consume the invocation client session, validates the loopback boundary, and force-closes active connections during teardown.

Pi's native MCP proxy was chosen over direct tool registration to avoid adding tool definitions to the default context window. Provider credentials remain outside the agent-visible configuration.

Closes ENG-851

Review focus: HTTP session lifecycle and Pi extension teardown ordering.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wire the runner-local MCP bridge into the Pi and Claude harnesses so integration tools are available during runs, and harden session teardown and cancellation. Addresses ENG-851.

- New Features
  - Harness invocation accepts `mcpServers`; Pi and Claude register these.
  - Pi: uses `pi-mcp-adapter`, writes a job-local MCP config (eager lifecycle, toolPrefix none), binds extensions in print mode, appends `mcp` when missing, preserves custom-provider builtin suppression, surfaces extension setup errors, cancels safely while extensions bind, and shuts down extensions then deletes the config on teardown; output tools still work.
  - Claude: maps integration servers to SDK `mcpServers`, merges with output tools, and works with the Anthropic base URL override.
  - MCP bridge: serves one loopback HTTP endpoint (http://127.0.0.1/mcp), isolates per-client sessions, enforces loopback-only and 1MB request limits with 30s timeouts, stops accepting new requests before draining, supports idempotent and pre-activation close, and closes sessions/HTTP server safely.
  - Tool names remain connection-namespaced (e.g., `<connection>__issue_read`); no translation to old flat names.

- Dependencies
  - Added `pi-mcp-adapter@2.11.0`.
  - Allowed `koffi` native build in `pnpm-workspace.yaml` for the adapter’s transitive dependency.

<sup>Written for commit 7b20e0760b7b745fc17b1780331b2094f8413a31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

