### PR TITLE
Add GitHub native tool dispatch

### DIFF
--- a/.changeset/tidy-falcons-fly.md
+++ b/.changeset/tidy-falcons-fly.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/workflow-document": major
+---
+
+Removes per-integration repository allowlists from agent workflow documents.

--- a/libs/api/agent-dto/src/schemas/materialized-agent-step-config.test.ts
+++ b/libs/api/agent-dto/src/schemas/materialized-agent-step-config.test.ts
@@ -10,7 +10,6 @@ const materializedIntegration = {
   connectionId: 'connection-1',
   connectionSlug: 'github-main',
   provider: 'github',
-  repos: ['github:owner/repo'],
   requiredScope: [{permission: 'issues', access: 'write'}],
   tools: [
     {
@@ -160,7 +159,6 @@ describe('materializedAgentStepConfigSchema', () => {
             connectionId: 'connection-1',
             connectionSlug: 'github-main',
             provider: 'github',
-            repos: ['github:owner/repo'],
             requiredScope: [],
             tools: [],
           },

--- a/libs/api/agent-dto/src/schemas/materialized-agent-step-config.ts
+++ b/libs/api/agent-dto/src/schemas/materialized-agent-step-config.ts
@@ -29,7 +29,6 @@ export const materializedAgentIntegrationSchema = z.strictObject({
   connectionId: z.string().min(1),
   connectionSlug: z.string().min(1),
   provider: z.string().min(1),
-  repos: z.array(z.string().min(1)).min(1),
   requiredScope: agentToolRequiredScopeSchema,
   tools: z.array(materializedAgentIntegrationToolSchema).min(1),
 });

--- a/libs/api/definitions/src/core/entities/workflow-model.ts
+++ b/libs/api/definitions/src/core/entities/workflow-model.ts
@@ -128,7 +128,6 @@ export interface WorkflowModelStepIntegration {
   readonly include: readonly string[];
   readonly exclude?: readonly string[];
   readonly allowWrite: boolean;
-  readonly repos?: readonly string[];
 }
 
 export interface WorkflowSourceLocation {

--- a/libs/api/definitions/src/core/workflow-model/normalize-agent-integrations.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-agent-integrations.ts
@@ -29,7 +29,6 @@ function normalizeIntegration(
     include: dedupe(integration.include),
     ...(integration.exclude === undefined ? {} : {exclude: dedupe(integration.exclude)}),
     allowWrite: integration.allow_write ?? false,
-    ...(integration.repos === undefined ? {} : {repos: dedupe(integration.repos)}),
   };
 }
 

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -201,7 +201,6 @@ describe('normalizeWorkflowDocument', () => {
                     'list_issues',
                   ],
                   exclude: ['issue_read.get', 'issue_read.get'],
-                  repos: ['ShipfoxHQ/shipfox', 'ShipfoxHQ/shipfox'],
                 },
               ],
             },
@@ -219,7 +218,6 @@ describe('normalizeWorkflowDocument', () => {
           include: ['issue_read', 'issue_read.*', 'issue_read.get', 'list_issues'],
           exclude: ['issue_read.get'],
           allowWrite: false,
-          repos: ['ShipfoxHQ/shipfox'],
         },
       ],
     });

--- a/libs/api/integration/core-dto/src/contracts/integrations.ts
+++ b/libs/api/integration/core-dto/src/contracts/integrations.ts
@@ -175,19 +175,16 @@ export interface OpenAgentToolsSessionInput<
   Connection extends IntegrationConnection = IntegrationConnection,
   RequiredScope = unknown,
   ProviderScope = unknown,
-  ScopedToken = unknown,
 > {
   connection: Connection;
   tools: readonly AgentToolCatalogEntry<RequiredScope>[];
   scope: ProviderScope;
-  mintToken(requiredScope: RequiredScope): Promise<ScopedToken>;
 }
 
 export interface AgentToolsProvider<
   Connection extends IntegrationConnection = IntegrationConnection,
   RequiredScope = unknown,
   ProviderScope = unknown,
-  ScopedToken = unknown,
   CallResult = unknown,
 > {
   catalog():
@@ -195,7 +192,7 @@ export interface AgentToolsProvider<
     | Promise<readonly AgentToolCatalogEntry<RequiredScope>[]>;
   selectionCatalog(): AgentToolSelectionCatalog | Promise<AgentToolSelectionCatalog>;
   openSession(
-    input: OpenAgentToolsSessionInput<Connection, RequiredScope, ProviderScope, ScopedToken>,
+    input: OpenAgentToolsSessionInput<Connection, RequiredScope, ProviderScope>,
   ): Promise<AgentToolSession<CallResult>>;
 }
 

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/dispatch.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/dispatch.ts
@@ -35,14 +35,12 @@ async function dispatchIntegrationToolCall(
       typeof input.authorizedTool.connection,
       unknown,
       typeof input.authorizedTool.integration,
-      unknown,
       CallToolResult
     >;
     session = await adapter.openSession({
       connection: input.authorizedTool.connection,
       tools: [agentToolCatalogEntry(input)],
       scope: input.authorizedTool.integration,
-      mintToken: async (requiredScope) => requiredScope,
     });
 
     return await session.call({

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/mcp-server.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/mcp-server.test.ts
@@ -148,8 +148,10 @@ describe('buildAgentToolsMcpServer', () => {
     );
   });
 
-  it('rejects arguments that do not match the exposed input schema', async () => {
-    const dispatch = vi.fn();
+  it('leaves provider argument validation to the selected provider', async () => {
+    const dispatch = vi.fn(async () => ({
+      content: [{type: 'text' as const, text: 'called'}],
+    }));
     const records: Parameters<
       NonNullable<Parameters<typeof buildAgentToolsMcpServer>[0]['recordCall']>
     >[0][] = [];
@@ -171,9 +173,13 @@ describe('buildAgentToolsMcpServer', () => {
     );
     await close();
 
-    expect(result.isError).toBe(true);
-    expect(dispatch).not.toHaveBeenCalled();
-    expect(records).toMatchObject([{method: 'get', outcome: 'invalid-request'}]);
+    expect(result.isError).not.toBe(true);
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        arguments: expect.objectContaining({issue_number: 'not-an-integer'}),
+      }),
+    );
+    expect(records).toMatchObject([{method: 'get', outcome: 'success'}]);
   });
 
   it('records tool-error when dispatch returns an error result', async () => {

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/mcp-server.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/mcp-server.ts
@@ -4,7 +4,6 @@ import {
   type CallToolResult,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import {Ajv, type ValidateFunction} from 'ajv';
 import {INVALID_METHOD_LABEL, type IntegrationToolCallRecorder, NO_METHOD_LABEL} from './audit.js';
 import type {
   AuthorizedIntegrationTool,
@@ -27,15 +26,11 @@ export interface BuildAgentToolsMcpServerParams {
   recordCall?: IntegrationToolCallRecorder | undefined;
 }
 
-const ajv = new Ajv({strict: false, allErrors: true});
-
 export function buildAgentToolsMcpServer(params: BuildAgentToolsMcpServerParams): Server {
   const server = new Server(
     {name: 'shipfox-integration-tools', version: '0.0.0'},
     {capabilities: {tools: {}}},
   );
-  const validators = new Map<string, ValidateFunction>();
-
   server.setRequestHandler(ListToolsRequestSchema, () => ({
     tools: [...params.authorizedTools.values()].map((authorizedTool) => ({
       name: authorizedTool.mcpName,
@@ -90,17 +85,6 @@ export function buildAgentToolsMcpServer(params: BuildAgentToolsMcpServerParams)
       return toolError(methodValidation.message);
     }
     const method = methodValidation.method ?? NO_METHOD_LABEL;
-
-    const schemaError = validateToolInput(authorizedTool, args, validators);
-    if (schemaError) {
-      recordToolCall(params.recordCall, {
-        authorizedTool,
-        arguments: args,
-        method,
-        outcome: 'invalid-request',
-      });
-      return toolError(schemaError);
-    }
 
     try {
       const result = await params.dispatch({
@@ -157,28 +141,6 @@ function validateMethod(
   }
 
   return {kind: 'ok', method};
-}
-
-function validateToolInput(
-  authorizedTool: AuthorizedIntegrationTool,
-  args: Record<string, unknown>,
-  validators: Map<string, ValidateFunction>,
-): string | null {
-  let validate = validators.get(authorizedTool.mcpName);
-  if (!validate) {
-    try {
-      validate = ajv.compile(authorizedTool.inputSchema);
-    } catch {
-      return 'Tool input schema is invalid';
-    }
-    validators.set(authorizedTool.mcpName, validate);
-  }
-
-  if (validate(args)) return null;
-
-  return `Tool arguments do not match input schema: ${ajv.errorsText(validate.errors, {
-    separator: '; ',
-  })}`;
 }
 
 function toolError(message: string): CallToolResult {

--- a/libs/api/integration/core/src/providers/github.ts
+++ b/libs/api/integration/core/src/providers/github.ts
@@ -44,21 +44,23 @@ async function loadGithubModuleParts(
 
   const tokenProvider = createGithubInstallationTokenProvider({
     getIntegrationConnectionById,
-    secretStore: {
-      read: async (workspaceId, installationId) =>
-        (await options.secrets?.github?.getSecret({
-          workspaceId,
-          namespace: githubInstallationTokenNamespace(installationId),
-          key: 'envelope',
-        })) ?? null,
-      write: async (workspaceId, installationId, envelope) => {
-        await options.secrets?.github?.setSecrets({
-          workspaceId,
-          namespace: githubInstallationTokenNamespace(installationId),
-          values: {envelope: encodeInstallationTokenEnvelope(envelope)},
-        });
-      },
-    },
+    secretStore: options.secrets?.github
+      ? {
+          read: async (workspaceId, installationId) =>
+            (await options.secrets?.github?.getSecret({
+              workspaceId,
+              namespace: githubInstallationTokenNamespace(installationId),
+              key: 'envelope',
+            })) ?? null,
+          write: async (workspaceId, installationId, envelope) => {
+            await options.secrets?.github?.setSecrets({
+              workspaceId,
+              namespace: githubInstallationTokenNamespace(installationId),
+              values: {envelope: encodeInstallationTokenEnvelope(envelope)},
+            });
+          },
+        }
+      : undefined,
   });
 
   async function getExistingGithubConnection(input: {

--- a/libs/api/integration/core/src/providers/github.ts
+++ b/libs/api/integration/core/src/providers/github.ts
@@ -32,12 +32,34 @@ async function loadGithubModuleParts(
   options: IntegrationProviderModuleLoadOptions = {},
 ): Promise<IntegrationModuleParts> {
   const {
+    createGithubInstallationTokenProvider,
+    encodeInstallationTokenEnvelope,
     createGithubIntegrationProvider,
     getGithubInstallationByInstallationId,
+    githubInstallationTokenNamespace,
     db: githubDb,
     migrationsPath: githubMigrationsPath,
     upsertGithubInstallation,
   } = await import('@shipfox/api-integration-github');
+
+  const tokenProvider = createGithubInstallationTokenProvider({
+    getIntegrationConnectionById,
+    secretStore: {
+      read: async (workspaceId, installationId) =>
+        (await options.secrets?.github?.getSecret({
+          workspaceId,
+          namespace: githubInstallationTokenNamespace(installationId),
+          key: 'envelope',
+        })) ?? null,
+      write: async (workspaceId, installationId, envelope) => {
+        await options.secrets?.github?.setSecrets({
+          workspaceId,
+          namespace: githubInstallationTokenNamespace(installationId),
+          values: {envelope: encodeInstallationTokenEnvelope(envelope)},
+        });
+      },
+    },
+  });
 
   async function getExistingGithubConnection(input: {
     installationId: string;
@@ -101,6 +123,7 @@ async function loadGithubModuleParts(
       getIntegrationConnectionById,
       coreDb: db,
       deleteSecrets: options.secrets?.deleteSecrets,
+      agentTools: {tokenProvider},
     }),
     database: {
       db: githubDb,

--- a/libs/api/integration/core/src/providers/types.ts
+++ b/libs/api/integration/core/src/providers/types.ts
@@ -33,6 +33,7 @@ export interface IntegrationProviderModuleLoadOptions {
 }
 
 export interface IntegrationProviderSecrets {
+  github?: IntegrationProviderScopedSecrets | undefined;
   linear?: IntegrationProviderScopedSecrets | undefined;
   deleteSecrets(params: {workspaceId: string; namespace: string}): Promise<number>;
 }

--- a/libs/api/integration/core/test/agent-tools-gateway-helpers.ts
+++ b/libs/api/integration/core/test/agent-tools-gateway-helpers.ts
@@ -99,7 +99,6 @@ export function materializedIntegration(
     connectionId: crypto.randomUUID(),
     connectionSlug: 'github-main',
     provider: 'github',
-    repos: ['github:owner/repo'],
     requiredScope: [],
     tools: [materializedTool()],
     ...overrides,

--- a/libs/api/integration/github/src/api/client.ts
+++ b/libs/api/integration/github/src/api/client.ts
@@ -98,6 +98,7 @@ export interface GithubApiClient {
 export interface GithubInstallationAccessToken {
   token: string;
   expiresAt: Date;
+  permissions?: Record<string, 'read' | 'write' | 'admin'> | undefined;
 }
 
 export function createGithubApiClient(): GithubApiClient {
@@ -370,6 +371,7 @@ class OctokitGithubApiClient implements GithubApiClient {
     return {
       token: response.data.token,
       expiresAt,
+      ...(response.data.permissions === undefined ? {} : {permissions: response.data.permissions}),
     };
   }
 

--- a/libs/api/integration/github/src/api/installation-token-envelope.ts
+++ b/libs/api/integration/github/src/api/installation-token-envelope.ts
@@ -41,6 +41,7 @@ void providerErrorReasonSchemaCoversUnion;
 const installationTokenEnvelopeSchema = z.object({
   token: z.string().min(1).optional(),
   expiresAt: z.string().datetime().optional(),
+  permissions: z.record(z.string(), z.enum(['read', 'write', 'admin'])).optional(),
   backoffUntil: z.string().datetime().optional(),
   backoffReason: providerErrorReasonSchema.optional(),
 });
@@ -48,6 +49,7 @@ const installationTokenEnvelopeSchema = z.object({
 export interface InstallationTokenEnvelope {
   token?: string | undefined;
   expiresAt?: Date | undefined;
+  permissions?: Record<string, 'read' | 'write' | 'admin'> | undefined;
   backoffUntil?: Date | undefined;
   backoffReason?: IntegrationProviderErrorReason | undefined;
 }
@@ -68,6 +70,7 @@ export function encodeInstallationTokenEnvelope(envelope: InstallationTokenEnvel
   return JSON.stringify({
     ...(envelope.token !== undefined && {token: envelope.token}),
     ...(envelope.expiresAt !== undefined && {expiresAt: envelope.expiresAt.toISOString()}),
+    ...(envelope.permissions !== undefined && {permissions: envelope.permissions}),
     ...(envelope.backoffUntil !== undefined && {
       backoffUntil: envelope.backoffUntil.toISOString(),
     }),
@@ -89,6 +92,7 @@ export function parseInstallationTokenEnvelope(raw: string): InstallationTokenEn
   return {
     token: result.data.token,
     expiresAt: result.data.expiresAt ? new Date(result.data.expiresAt) : undefined,
+    permissions: result.data.permissions,
     backoffUntil: result.data.backoffUntil ? new Date(result.data.backoffUntil) : undefined,
     backoffReason: result.data.backoffReason,
   };

--- a/libs/api/integration/github/src/api/installation-token-provider.ts
+++ b/libs/api/integration/github/src/api/installation-token-provider.ts
@@ -77,6 +77,7 @@ class OctokitGithubInstallationTokenProvider implements GithubInstallationTokenP
     return {
       token: response.data.token,
       expiresAt,
+      ...(response.data.permissions === undefined ? {} : {permissions: response.data.permissions}),
     };
   }
 

--- a/libs/api/integration/github/src/api/shared-installation-token-cache.ts
+++ b/libs/api/integration/github/src/api/shared-installation-token-cache.ts
@@ -127,6 +127,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
       await this.writeEnvelope(params.workspaceId, params.installationId, {
         token: envelope?.token,
         expiresAt: envelope?.expiresAt,
+        permissions: envelope?.permissions,
         backoffUntil: until,
         backoffReason: classified.reason,
       }).catch((writeError) => {
@@ -171,6 +172,7 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
       await this.writeEnvelope(params.workspaceId, params.installationId, {
         token: token.token,
         expiresAt: token.expiresAt,
+        permissions: token.permissions,
       });
     } catch (error) {
       logger().warn(
@@ -318,7 +320,11 @@ function tokenFromEnvelope(envelope: InstallationTokenEnvelope): GithubInstallat
       'GitHub installation token cache envelope is missing a token or expiry',
     );
   }
-  return {token: envelope.token, expiresAt: envelope.expiresAt};
+  return {
+    token: envelope.token,
+    expiresAt: envelope.expiresAt,
+    ...(envelope.permissions === undefined ? {} : {permissions: envelope.permissions}),
+  };
 }
 
 function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {

--- a/libs/api/integration/github/src/core/agent-tools.test.ts
+++ b/libs/api/integration/github/src/core/agent-tools.test.ts
@@ -316,6 +316,7 @@ describe('github agent tool catalog', () => {
 
   it('opens a provider-owned installation session and dispatches the selected operation', async () => {
     const request = vi.fn(() => Promise.resolve({data: {number: 1}}));
+    let clientToken: string | undefined;
     const provider = new GithubAgentToolsProvider({
       getInstallationByConnectionId: vi.fn(() => Promise.resolve(installation())),
       tokenProvider: {
@@ -328,7 +329,7 @@ describe('github agent tool catalog', () => {
         ),
       },
       createClient: vi.fn((token) => {
-        expect(token).toBe('installation-token');
+        clientToken = token;
         return {request};
       }),
     });
@@ -348,6 +349,7 @@ describe('github agent tool catalog', () => {
       repo: 'platform',
       issue_number: 1,
     });
+    expect(clientToken).toBe('installation-token');
     expect(result).toEqual({content: [{type: 'text', text: '{"number":1}'}]});
   });
 });

--- a/libs/api/integration/github/src/core/agent-tools.test.ts
+++ b/libs/api/integration/github/src/core/agent-tools.test.ts
@@ -300,16 +300,88 @@ describe('github agent tool catalog', () => {
     expect(selectionCatalog).toBe(githubAgentToolSelectionCatalog);
   });
 
-  it('fails closed for execution until dispatch is implemented', async () => {
-    const provider = new GithubAgentToolsProvider();
-
-    const result = provider.openSession();
-
-    await expect(result).rejects.toMatchObject({
-      reason: 'provider-unavailable',
+  it('fails closed when the connection has no GitHub installation', async () => {
+    const provider = new GithubAgentToolsProvider({
+      getInstallationByConnectionId: vi.fn(() => Promise.resolve(undefined)),
     });
+
+    const result = provider.openSession({
+      connection: connection(),
+      tools: [githubAgentToolCatalog[0]],
+      scope: undefined,
+    });
+
+    await expect(result).rejects.toMatchObject({reason: 'installation-not-found'});
+  });
+
+  it('opens a provider-owned installation session and dispatches the selected operation', async () => {
+    const request = vi.fn(() => Promise.resolve({data: {number: 1}}));
+    const provider = new GithubAgentToolsProvider({
+      getInstallationByConnectionId: vi.fn(() => Promise.resolve(installation())),
+      tokenProvider: {
+        getInstallationAccessToken: vi.fn(() =>
+          Promise.resolve({
+            token: 'installation-token',
+            expiresAt: new Date(),
+            permissions: {issues: 'read' as const},
+          }),
+        ),
+      },
+      createClient: vi.fn((token) => {
+        expect(token).toBe('installation-token');
+        return {request};
+      }),
+    });
+
+    const session = await provider.openSession({
+      connection: connection(),
+      tools: [githubAgentToolCatalog[0]],
+      scope: undefined,
+    });
+    const result = await session.call({
+      toolId: 'issue_read',
+      arguments: {method: 'get', owner: 'shipfox', repo: 'platform', issue_number: 1},
+    });
+
+    expect(request).toHaveBeenCalledWith('GET /repos/{owner}/{repo}/issues/{issue_number}', {
+      owner: 'shipfox',
+      repo: 'platform',
+      issue_number: 1,
+    });
+    expect(result).toEqual({content: [{type: 'text', text: '{"number":1}'}]});
   });
 });
+
+function connection() {
+  return {
+    id: 'connection-1',
+    workspaceId: 'workspace-1',
+    provider: 'github' as const,
+    externalAccountId: 'github:1',
+    slug: 'github-main',
+    displayName: 'GitHub',
+    lifecycleStatus: 'active' as const,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+function installation() {
+  return {
+    id: 'installation-row-1',
+    connectionId: 'connection-1',
+    installationId: '1',
+    accountLogin: 'shipfox',
+    accountType: 'Organization',
+    repositorySelection: 'all',
+    suspendedAt: null,
+    deletedAt: null,
+    latestEvent: {},
+    installerUserId: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
 
 function createProvider() {
   return createGithubIntegrationProvider({

--- a/libs/api/integration/github/src/core/agent-tools.ts
+++ b/libs/api/integration/github/src/core/agent-tools.ts
@@ -893,8 +893,11 @@ function resolveGithubOperation(
 
   if (tool.methods && !tool.methods.some((candidate) => candidate.id === method)) return undefined;
 
-  const route = githubOperationRoute(tool.id as GithubAgentToolId, method, params);
-  return route === undefined ? undefined : {route, parameters: params};
+  const toolId = tool.id as GithubAgentToolId;
+  const route = githubOperationRoute(toolId, method, params);
+  return route === undefined
+    ? undefined
+    : {route, parameters: projectGithubOperationParameters(toolId, method, params)};
 }
 
 function githubOperationRoute(
@@ -930,9 +933,11 @@ function githubOperationRoute(
     case 'search_issues.':
       return 'GET /search/issues';
     case 'add_issue_comment.':
-      return args.comment_id === undefined
-        ? `POST ${repoPath}/issues/${issue}/comments`
-        : `POST ${repoPath}/issues/comments/{comment_id}/reactions`;
+      if (args.comment_id !== undefined)
+        return `POST ${repoPath}/issues/comments/{comment_id}/reactions`;
+      return args.reaction !== undefined && args.body === undefined
+        ? `POST ${repoPath}/issues/${issue}/reactions`
+        : `POST ${repoPath}/issues/${issue}/comments`;
     case 'issue_write.create':
       return `POST ${repoPath}/issues`;
     case 'issue_write.update':
@@ -1018,6 +1023,23 @@ function githubOperationRoute(
     default:
       return undefined;
   }
+}
+
+function projectGithubOperationParameters(
+  toolId: GithubAgentToolId,
+  method: string | undefined,
+  args: Record<string, unknown>,
+): Record<string, unknown> {
+  const parameters = {...args};
+  if (toolId === 'add_issue_comment' && parameters.reaction !== undefined) {
+    parameters.content = parameters.reaction;
+    delete parameters.reaction;
+    if (parameters.body === undefined) delete parameters.body;
+  }
+  if (toolId === 'pull_request_read' && method === 'get_diff') {
+    parameters.headers = {accept: 'application/vnd.github.diff'};
+  }
+  return parameters;
 }
 
 function githubToolResult(data: unknown): GithubToolCallResult {

--- a/libs/api/integration/github/src/core/agent-tools.ts
+++ b/libs/api/integration/github/src/core/agent-tools.ts
@@ -1,16 +1,29 @@
 import type {
+  AgentToolCallInput,
   AgentToolCatalogEntry,
   AgentToolCatalogMethod,
   AgentToolJsonSchema,
   AgentToolSelectionCatalog,
+  AgentToolSession,
   AgentToolsProvider,
   IntegrationConnection,
+  OpenAgentToolsSessionInput,
 } from '@shipfox/api-integration-core-dto';
+import {Octokit} from 'octokit';
+import {
+  createGithubInstallationTokenProvider,
+  type GithubInstallationTokenProvider,
+} from '#api/installation-token-provider.js';
+import type {GithubInstallation} from '#db/installations.js';
 import {DEFAULT_JOB_LOG_TAIL_LINES} from './actions-logs.js';
 import {buildGithubAgentToolSelectionCatalog} from './agent-tool-selection.js';
 import {GithubIntegrationProviderError} from './errors.js';
 
 type GithubIntegrationConnection = IntegrationConnection<'github'>;
+type GithubToolCallResult = {
+  isError?: boolean | undefined;
+  content: readonly {type: 'text'; text: string}[];
+};
 
 export type GithubAgentToolCategory = 'issues' | 'pull_requests' | 'actions';
 export type GithubAgentToolPermission = 'actions' | 'contents' | 'issues' | 'pull_requests';
@@ -770,8 +783,20 @@ export const githubAgentToolSelectionCatalog =
   buildGithubAgentToolSelectionCatalog(githubAgentToolCatalog);
 
 export class GithubAgentToolsProvider
-  implements AgentToolsProvider<GithubIntegrationConnection, GithubAgentToolRequiredScope>
+  implements
+    AgentToolsProvider<
+      GithubIntegrationConnection,
+      GithubAgentToolRequiredScope,
+      unknown,
+      GithubToolCallResult
+    >
 {
+  private readonly tokenProvider: GithubInstallationTokenProvider;
+
+  constructor(private readonly options: GithubAgentToolsProviderOptions = {}) {
+    this.tokenProvider = options.tokenProvider ?? createGithubInstallationTokenProvider();
+  }
+
   catalog(): readonly GithubAgentToolCatalogEntry[] {
     return githubAgentToolCatalog;
   }
@@ -780,14 +805,269 @@ export class GithubAgentToolsProvider
     return githubAgentToolSelectionCatalog;
   }
 
-  openSession(): Promise<never> {
-    return Promise.reject(
-      new GithubIntegrationProviderError(
-        'provider-unavailable',
-        'GitHub agent tool execution is not implemented yet',
-      ),
-    );
+  async openSession(
+    input: OpenAgentToolsSessionInput<GithubIntegrationConnection, GithubAgentToolRequiredScope>,
+  ): Promise<AgentToolSession<GithubToolCallResult>> {
+    const installation = await this.options.getInstallationByConnectionId?.(input.connection.id);
+    if (!installation) {
+      throw new GithubIntegrationProviderError(
+        'installation-not-found',
+        'GitHub installation is not connected to this integration',
+      );
+    }
+    const installationId = Number(installation.installationId);
+    if (!Number.isSafeInteger(installationId) || installationId < 1) {
+      throw new GithubIntegrationProviderError(
+        'malformed-provider-response',
+        'GitHub installation has an invalid installation ID',
+      );
+    }
+    let tokenPromise:
+      | ReturnType<GithubInstallationTokenProvider['getInstallationAccessToken']>
+      | undefined;
+
+    return {
+      call: async (call) => {
+        const tool = input.tools.find((candidate) => candidate.id === call.toolId);
+        if (!tool) return githubToolError(`Unknown GitHub tool: ${call.toolId}`);
+        const operation = resolveGithubOperation(tool, call);
+        if (operation === undefined) return githubToolError('Unknown GitHub tool operation');
+        const validationError = validateGithubToolArguments(tool, call.arguments);
+        if (validationError) return githubToolError(validationError);
+        tokenPromise ??= this.tokenProvider.getInstallationAccessToken(installationId);
+        const token = await tokenPromise;
+        if (!hasGrantedPermissions(token.permissions ?? {}, tool, call)) {
+          return githubToolError(
+            'GitHub installation token is missing permission for this operation',
+          );
+        }
+        const client = (this.options.createClient ?? createOctokitClient)(token.token);
+
+        try {
+          const response = await client.request(operation.route, operation.parameters);
+          return githubToolResult(response.data);
+        } catch (error) {
+          if (error instanceof GithubIntegrationProviderError)
+            return githubToolError(error.message);
+          throw error;
+        }
+      },
+    };
   }
+}
+
+export interface GithubAgentToolsProviderOptions {
+  getInstallationByConnectionId?:
+    | ((connectionId: string) => Promise<GithubInstallation | undefined>)
+    | undefined;
+  tokenProvider?: GithubInstallationTokenProvider | undefined;
+  createClient?: GithubToolClientFactory | undefined;
+}
+
+export interface GithubToolClient {
+  request(route: string, parameters: Record<string, unknown>): Promise<{data: unknown}>;
+}
+
+export type GithubToolClientFactory = (token: string) => GithubToolClient;
+
+interface GithubToolOperation {
+  route: string;
+  parameters: Record<string, unknown>;
+}
+
+function createOctokitClient(token: string): GithubToolClient {
+  const octokit = new Octokit({auth: token, retry: {enabled: false}});
+  return {
+    request: async (route, parameters) => await octokit.request(route, parameters),
+  };
+}
+
+function resolveGithubOperation(
+  tool: AgentToolCatalogEntry<GithubAgentToolRequiredScope>,
+  call: AgentToolCallInput,
+): GithubToolOperation | undefined {
+  const args = call.arguments;
+  const method = typeof args.method === 'string' ? args.method : undefined;
+  const params = {...args};
+  delete params.method;
+
+  if (tool.methods && !tool.methods.some((candidate) => candidate.id === method)) return undefined;
+
+  const route = githubOperationRoute(tool.id as GithubAgentToolId, method, params);
+  return route === undefined ? undefined : {route, parameters: params};
+}
+
+function githubOperationRoute(
+  toolId: GithubAgentToolId,
+  method: string | undefined,
+  args: Record<string, unknown>,
+): string | undefined {
+  const owner = '{owner}';
+  const repo = '{repo}';
+  const issue = '{issue_number}';
+  const pull = '{pull_number}';
+  const run = '{run_id}';
+  const resource = '{resource_id}';
+  const repoPath = `/repos/${owner}/${repo}`;
+
+  switch (`${toolId}.${method ?? ''}`) {
+    case 'issue_read.get':
+      return `GET ${repoPath}/issues/${issue}`;
+    case 'issue_read.get_comments':
+      return `GET ${repoPath}/issues/${issue}/comments`;
+    case 'issue_read.get_sub_issues':
+      return `GET ${repoPath}/issues/${issue}/sub_issues`;
+    case 'issue_read.get_parent':
+      return `GET ${repoPath}/issues/${issue}/parent`;
+    case 'issue_read.get_labels':
+      return `GET ${repoPath}/issues/${issue}/labels`;
+    case 'list_issue_types.':
+      return args.repo === undefined
+        ? 'GET /orgs/{owner}/issue-types'
+        : `GET ${repoPath}/issue-types`;
+    case 'list_issues.':
+      return `GET ${repoPath}/issues`;
+    case 'search_issues.':
+      return 'GET /search/issues';
+    case 'add_issue_comment.':
+      return args.comment_id === undefined
+        ? `POST ${repoPath}/issues/${issue}/comments`
+        : `POST ${repoPath}/issues/comments/{comment_id}/reactions`;
+    case 'issue_write.create':
+      return `POST ${repoPath}/issues`;
+    case 'issue_write.update':
+      return `PATCH ${repoPath}/issues/${issue}`;
+    case 'sub_issue_write.add':
+      return `POST ${repoPath}/issues/${issue}/sub_issues`;
+    case 'sub_issue_write.remove':
+      return `DELETE ${repoPath}/issues/${issue}/sub_issues/{sub_issue_id}`;
+    case 'sub_issue_write.reprioritize':
+      return `PATCH ${repoPath}/issues/${issue}/sub_issues/{sub_issue_id}`;
+    case 'pull_request_read.get':
+      return `GET ${repoPath}/pulls/${pull}`;
+    case 'pull_request_read.get_diff':
+      return `GET ${repoPath}/pulls/${pull}`;
+    case 'pull_request_read.get_status':
+      return `GET ${repoPath}/commits/{ref}/status`;
+    case 'pull_request_read.get_files':
+      return `GET ${repoPath}/pulls/${pull}/files`;
+    case 'pull_request_read.get_commits':
+      return `GET ${repoPath}/pulls/${pull}/commits`;
+    case 'pull_request_read.get_review_comments':
+      return `GET ${repoPath}/pulls/${pull}/comments`;
+    case 'pull_request_read.get_reviews':
+      return `GET ${repoPath}/pulls/${pull}/reviews`;
+    case 'pull_request_read.get_comments':
+      return `GET ${repoPath}/issues/${pull}/comments`;
+    case 'pull_request_read.get_check_runs':
+      return `GET ${repoPath}/commits/{ref}/check-runs`;
+    case 'list_pull_requests.':
+      return `GET ${repoPath}/pulls`;
+    case 'search_pull_requests.':
+      return 'GET /search/issues';
+    case 'create_pull_request.':
+      return `POST ${repoPath}/pulls`;
+    case 'update_pull_request.':
+      return `PATCH ${repoPath}/pulls/${pull}`;
+    case 'add_reply_to_pull_request_comment.':
+      return `POST ${repoPath}/pulls/{comment_id}/replies`;
+    case 'merge_pull_request.':
+      return `PUT ${repoPath}/pulls/${pull}/merge`;
+    case 'update_pull_request_branch.':
+      return `PUT ${repoPath}/pulls/${pull}/update-branch`;
+    case 'pull_request_review_write.create':
+      return `POST ${repoPath}/pulls/${pull}/reviews`;
+    case 'pull_request_review_write.submit_pending':
+      return `POST ${repoPath}/pulls/${pull}/reviews/{review_id}/events`;
+    case 'pull_request_review_write.delete_pending':
+      return `DELETE ${repoPath}/pulls/${pull}/reviews/{review_id}`;
+    case 'add_comment_to_pending_review.':
+      return `POST ${repoPath}/pulls/${pull}/comments`;
+    case 'actions_list.list_workflows':
+      return `GET ${repoPath}/actions/workflows`;
+    case 'actions_list.list_workflow_runs':
+      return `GET ${repoPath}/actions/workflows/${resource}/runs`;
+    case 'actions_list.list_workflow_jobs':
+      return `GET ${repoPath}/actions/runs/${resource}/jobs`;
+    case 'actions_list.list_workflow_run_artifacts':
+      return `GET ${repoPath}/actions/runs/${resource}/artifacts`;
+    case 'actions_get.get_workflow':
+      return `GET ${repoPath}/actions/workflows/${resource}`;
+    case 'actions_get.get_workflow_run':
+      return `GET ${repoPath}/actions/runs/${resource}`;
+    case 'actions_get.get_workflow_job':
+      return `GET ${repoPath}/actions/jobs/${resource}`;
+    case 'actions_get.download_workflow_run_artifact':
+      return `GET ${repoPath}/actions/artifacts/${resource}/{archive_format}`;
+    case 'actions_get.get_workflow_run_usage':
+      return `GET ${repoPath}/actions/runs/${resource}/timing`;
+    case 'actions_get.get_workflow_run_logs_url':
+      return `GET ${repoPath}/actions/runs/${resource}/logs`;
+    case 'actions_run_trigger.run_workflow':
+      return `POST ${repoPath}/actions/workflows/{workflow_id}/dispatches`;
+    case 'actions_run_trigger.rerun_workflow_run':
+      return `POST ${repoPath}/actions/runs/${run}/rerun`;
+    case 'actions_run_trigger.rerun_failed_jobs':
+      return `POST ${repoPath}/actions/runs/${run}/rerun-failed-jobs`;
+    case 'actions_run_trigger.cancel_workflow_run':
+      return `POST ${repoPath}/actions/runs/${run}/cancel`;
+    case 'actions_run_trigger.delete_workflow_run_logs':
+      return `DELETE ${repoPath}/actions/runs/${run}/logs`;
+    case 'get_job_logs.':
+      return `GET ${repoPath}/actions/jobs/{job_id}/logs`;
+    default:
+      return undefined;
+  }
+}
+
+function githubToolResult(data: unknown): GithubToolCallResult {
+  return {content: [{type: 'text', text: JSON.stringify(data)}]};
+}
+
+function githubToolError(message: string): GithubToolCallResult {
+  return {isError: true, content: [{type: 'text', text: message}]};
+}
+
+function validateGithubToolArguments(
+  tool: AgentToolCatalogEntry<GithubAgentToolRequiredScope>,
+  arguments_: Record<string, unknown>,
+): string | undefined {
+  const required = Array.isArray(tool.inputSchema.required) ? tool.inputSchema.required : [];
+  for (const name of required) {
+    if (typeof name === 'string' && arguments_[name] === undefined) {
+      return `Missing required parameter: ${name}`;
+    }
+  }
+
+  const properties = tool.inputSchema.properties;
+  if (typeof properties !== 'object' || properties === null || Array.isArray(properties)) {
+    return undefined;
+  }
+  const propertySchemas = properties as Record<string, unknown>;
+  for (const [name, value] of Object.entries(arguments_)) {
+    const schema = propertySchemas[name];
+    if (typeof schema !== 'object' || schema === null || Array.isArray(schema)) continue;
+    const type = (schema as {type?: unknown}).type;
+    if (type === 'integer' && (!Number.isInteger(value) || typeof value !== 'number')) {
+      return `Parameter ${name} must be an integer`;
+    }
+    if (type === 'array' && !Array.isArray(value)) return `Parameter ${name} must be an array`;
+  }
+  return undefined;
+}
+
+function hasGrantedPermissions(
+  granted: Record<string, 'read' | 'write' | 'admin'>,
+  tool: AgentToolCatalogEntry<GithubAgentToolRequiredScope>,
+  call: AgentToolCallInput,
+): boolean {
+  const method = typeof call.arguments.method === 'string' ? call.arguments.method : undefined;
+  const required =
+    tool.methods?.find((candidate) => candidate.id === method)?.requiredScope ?? tool.requiredScope;
+  return required.every(({permission, access}) => {
+    const actual = granted[permission];
+    return actual === 'write' || actual === 'admin' || actual === access;
+  });
 }
 
 function tool(input: GithubAgentToolCatalogInput): GithubAgentToolCatalogEntry {

--- a/libs/api/integration/github/src/index.ts
+++ b/libs/api/integration/github/src/index.ts
@@ -6,6 +6,7 @@ import type {
 } from '@shipfox/api-integration-core-dto';
 import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
 import {createGithubApiClient, type GithubApiClient} from '#api/client.js';
+import type {GithubInstallationTokenProvider} from '#api/installation-token-provider.js';
 import {deleteGithubInstallationTokenSecret} from '#api/installation-token-provider.js';
 import {GithubAgentToolsProvider} from '#core/agent-tools.js';
 import {GithubSourceControlProvider} from '#core/source-control.js';
@@ -19,6 +20,10 @@ import {
 import {createGithubWebhookRoutes} from '#presentation/routes/webhooks.js';
 
 export type {GithubApiClient} from '#api/client.js';
+export {
+  encodeInstallationTokenEnvelope,
+  githubInstallationTokenNamespace,
+} from '#api/installation-token-envelope.js';
 export {
   createGithubInstallationTokenProvider,
   type GithubInstallationTokenProvider,
@@ -60,6 +65,7 @@ export interface CreateGithubIntegrationProviderOptions
   deleteSecrets?:
     | ((params: {workspaceId: string; namespace: string}) => Promise<number>)
     | undefined;
+  agentTools?: {tokenProvider: GithubInstallationTokenProvider} | undefined;
 }
 
 export function createGithubIntegrationProvider(options: CreateGithubIntegrationProviderOptions) {
@@ -73,7 +79,10 @@ export function createGithubIntegrationProvider(options: CreateGithubIntegration
     displayName: 'GitHub',
     adapters: {
       source_control: new GithubSourceControlProvider(github),
-      agent_tools: new GithubAgentToolsProvider(),
+      agent_tools: new GithubAgentToolsProvider({
+        getInstallationByConnectionId: getInstallationByConnectionId,
+        tokenProvider: options.agentTools?.tokenProvider,
+      }),
     },
     async connectionExternalUrl(connection: {id: string}): Promise<string | undefined> {
       const installation = await getInstallationByConnectionId(connection.id);

--- a/libs/api/integration/linear/src/core/agent-tools-provider.test.ts
+++ b/libs/api/integration/linear/src/core/agent-tools-provider.test.ts
@@ -48,7 +48,6 @@ describe('LinearAgentToolsProvider', () => {
       connection: linearConnection({id: 'linear-connection-7'}),
       tools: [],
       scope: {provider: 'linear'},
-      mintToken: async (scope) => scope,
     });
 
     expect(getAccessToken).toHaveBeenCalledWith({connectionId: 'linear-connection-7'});
@@ -77,7 +76,6 @@ describe('LinearAgentToolsProvider', () => {
         connection: linearConnection(),
         tools: [],
         scope: {provider: 'linear'},
-        mintToken: async (scope) => scope,
       });
       const result = await session.call({toolId: 'get_issue', arguments: {id: 'ENG-875'}});
       await session.close?.();
@@ -114,7 +112,6 @@ describe('LinearAgentToolsProvider', () => {
       connection: linearConnection(),
       tools: [],
       scope: {provider: 'linear'},
-      mintToken: async (scope) => scope,
     });
 
     const readResult = await session.call({
@@ -156,7 +153,6 @@ describe('LinearAgentToolsProvider', () => {
       connection: linearConnection(),
       tools: [],
       scope: {provider: 'linear'},
-      mintToken: async (scope) => scope,
     });
 
     await expect(result).rejects.toBeInstanceOf(LinearAccessTokenMissingError);
@@ -177,7 +173,6 @@ describe('LinearAgentToolsProvider', () => {
       connection: linearConnection(),
       tools: [],
       scope: {provider: 'linear'},
-      mintToken: async (scope) => scope,
     });
 
     const result = session.call({toolId: 'get_issue', arguments: {id: 'ENG-875'}});

--- a/libs/api/workflows/src/core/agent-tools.ts
+++ b/libs/api/workflows/src/core/agent-tools.ts
@@ -33,7 +33,6 @@ export interface AgentToolMaterializationContext {
     readonly slug: string;
     readonly provider: IntegrationProviderKind;
   };
-  readonly defaultRepositoryId: string;
 }
 
 export interface AgentToolMaterializationSnapshot {
@@ -100,7 +99,6 @@ export async function loadAgentToolMaterializationContext(params: {
       slug: defaultConnection.slug,
       provider: defaultConnection.provider,
     },
-    defaultRepositoryId: project.sourceExternalRepositoryId,
   };
 }
 
@@ -188,7 +186,6 @@ function materializeAgentIntegration(params: {
     connectionId: connection.id,
     connectionSlug: connection.slug,
     provider: connection.provider,
-    repos: [...(params.integration.repos ?? [params.context.defaultRepositoryId])],
     requiredScope,
     tools,
   };
@@ -199,7 +196,6 @@ function copyMaterializedIntegration(
 ): MaterializedAgentIntegrationConfigDto {
   return {
     ...integration,
-    repos: [...integration.repos],
     requiredScope: [...integration.requiredScope],
     tools: integration.tools.map((tool) => ({
       ...tool,

--- a/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
+++ b/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
@@ -75,7 +75,6 @@ function materializedIntegration(): MaterializedAgentIntegrationConfigDto {
     connectionId: 'connection-1',
     connectionSlug: 'github-main',
     provider: 'github',
-    repos: ['github:owner/repo'],
     requiredScope: [{permission: 'issues', access: 'read'}],
     tools: [
       {

--- a/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.test.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.test.ts
@@ -89,7 +89,6 @@ function githubAgentToolContext(
       slug: 'github-main',
       provider: 'github',
     },
-    defaultRepositoryId: 'github:owner/repo',
   };
 }
 
@@ -270,7 +269,6 @@ describe('materializeJobExecutionSteps', () => {
         connectionId: 'connection-1',
         connectionSlug: 'github-main',
         provider: 'github',
-        repos: ['github:owner/repo'],
         requiredScope: [
           {permission: 'issues', access: 'write'},
           {permission: 'pull_requests', access: 'write'},
@@ -352,7 +350,6 @@ describe('materializeJobExecutionSteps', () => {
                   include: ['issue_read'],
                   exclude: ['issue_read.get_comments'],
                   allowWrite: false,
-                  repos: ['github:owner/explicit'],
                 },
               ],
             },
@@ -382,7 +379,6 @@ describe('materializeJobExecutionSteps', () => {
         connectionId: 'connection-1',
         connectionSlug: 'github-main',
         provider: 'github',
-        repos: ['github:owner/explicit'],
         requiredScope: [{permission: 'issues', access: 'read'}],
         tools: [
           {

--- a/libs/api/workflows/src/db/job-listeners.test.ts
+++ b/libs/api/workflows/src/db/job-listeners.test.ts
@@ -526,7 +526,6 @@ describe('drainListenerEventsIntoExecution', () => {
         connectionId: crypto.randomUUID(),
         connectionSlug: 'github',
         provider: 'github',
-        repos: ['github:shipfox/platform'],
         requiredScope: [{permission: 'issues', access: 'read'}],
         tools: [
           {

--- a/libs/api/workflows/src/db/workflow-runs/run-rerun.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-rerun.test.ts
@@ -158,7 +158,6 @@ describe('workflow run queries', () => {
                 connectionId: crypto.randomUUID(),
                 connectionSlug: 'github',
                 provider: 'github',
-                repos: ['github:shipfox/platform'],
                 requiredScope: [{permission: 'issues', access: 'read'}],
                 tools: [
                   {

--- a/libs/runner/agent/src/core/step.test.ts
+++ b/libs/runner/agent/src/core/step.test.ts
@@ -485,7 +485,6 @@ function integrationToolsConfig(overrides: Record<string, unknown> = {}) {
         connectionId: 'connection-1',
         connectionSlug: 'github_main',
         provider: 'github',
-        repos: ['shipfox/platform'],
         requiredScope: [],
         tools: [
           {

--- a/libs/shared/workflow/document/README.md
+++ b/libs/shared/workflow/document/README.md
@@ -91,8 +91,8 @@ parseWorkflowDocument({
 
 Integration tools are selected with an `integrations` block on an agent step.
 This package validates the shape only: non-empty selections, optional connection
-and repository strings, and boolean write opt-in. Catalog checks, wildcard
-expansion, connection lookup, and write-safety rules belong to later layers.
+and boolean write opt-in. Catalog checks, wildcard expansion, connection lookup,
+and write-safety rules belong to later layers.
 
 ```ts
 parseWorkflowDocument({
@@ -110,7 +110,6 @@ parseWorkflowDocument({
               include: ['issue_read.get', 'pull_request_read.get_files'],
               exclude: ['actions_run_trigger.run_workflow'],
               allow_write: false,
-              repos: ['shipfox'],
             },
           ],
         },

--- a/libs/shared/workflow/document/src/document/workflow-document.test.ts
+++ b/libs/shared/workflow/document/src/document/workflow-document.test.ts
@@ -874,7 +874,6 @@ describe('workflowDocumentSchema', () => {
             include: ['issue_read.get', 'pull_request_read.get_files'],
             exclude: ['actions_run_trigger.run_workflow'],
             allow_write: false,
-            repos: ['shipfox'],
           },
         ],
       },
@@ -926,10 +925,6 @@ describe('workflowDocumentSchema', () => {
     [
       'empty integration connection',
       {prompt: 'Fix.', integrations: [{connection: '', include: ['issue_read']}]},
-    ],
-    [
-      'empty integration repo',
-      {prompt: 'Fix.', integrations: [{include: ['issue_read'], repos: ['shipfox', '']}]},
     ],
     [
       'non-boolean integration allow_write',

--- a/libs/shared/workflow/document/src/document/workflow-document.ts
+++ b/libs/shared/workflow/document/src/document/workflow-document.ts
@@ -228,7 +228,6 @@ export const workflowDocumentStepIntegrationSchema = z.strictObject({
   include: workflowDocumentStepIntegrationSelectionSchema,
   exclude: workflowDocumentStepIntegrationSelectionSchema.optional(),
   allow_write: z.boolean().optional(),
-  repos: z.array(z.string().min(1)).min(1).optional(),
 });
 
 // A step is a run step (`run`) or an inline agent step (`prompt`), never


### PR DESCRIPTION
Adds provider-owned GitHub agent-tool sessions, native Octokit dispatch, and installation-permission cache persistence. It also removes the obsolete per-integration repository allowlist from workflow documents.

GitHub-native calls need the installation token and its granted permissions to stay owned by the provider, rather than by the generic MCP gateway. The workflow contract now reflects connection-wide repository authority for this pre-deploy cutover.

The shared token-cache path uses the configured encrypted secret store so grants and mint backoff survive process boundaries.

The pinned GitHub MCP parity work still needs explicit operation projectors and full golden coverage; this PR intentionally references, rather than closes, the ticket.

Refs ENG-848

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements native GitHub tool dispatch using provider-owned Octokit installation sessions, enforcing installation-level permissions and removing per-step repo allowlists, in line with ENG-848.

- **New Features**
  - Provider-owned installation sessions for GitHub; routes catalog tool/methods to REST and blocks unselected tools/methods.
  - Preflight checks against installation token permissions before dispatch; argument validation is handled by the GitHub provider (gateway no longer validates schemas).
  - Shared token cache persists token, expiry, and permissions; uses `github`-scoped encrypted secrets when provided, otherwise runs without shared persistence.
  - Projects requests to GitHub’s expected format (e.g., reactions as `content`, PR diffs via Accept header).

- **Migration**
  - Remove `repos` from agent integration blocks; `@shipfox/workflow-document` is a major bump.
  - Materialized integration DTOs drop `repos`.
  - `OpenAgentToolsSessionInput` removes `mintToken`; providers mint/cache tokens internally.
  - If supplying secrets to the provider loader, add a `github` scoped store for token envelopes.

<sup>Written for commit 891ab214b19b0b3f1f584f8b8497b07416287180. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

