### PR TITLE
Use minor bumps for pre-1.0 breaking changes

### DIFF
--- a/.changeset/executions-workflows-expand.md
+++ b/.changeset/executions-workflows-expand.md
@@ -1,8 +1,8 @@
 ---
 "@shipfox/api-definitions": minor
-"@shipfox/api-auth-dto": major
-"@shipfox/api-runners-dto": major
-"@shipfox/api-workflows-dto": major
+"@shipfox/api-auth-dto": minor
+"@shipfox/api-runners-dto": minor
+"@shipfox/api-workflows-dto": minor
 "@shipfox/workflow-document": minor
 ---
 

--- a/.changeset/react-ui-subpath-exports.md
+++ b/.changeset/react-ui-subpath-exports.md
@@ -1,5 +1,5 @@
 ---
-"@shipfox/react-ui": major
+"@shipfox/react-ui": minor
 ---
 
 Replace the root barrel with per-component subpath exports. Import from a subpath

--- a/.changeset/sharp-clocks-configure.md
+++ b/.changeset/sharp-clocks-configure.md
@@ -1,5 +1,5 @@
 ---
-"@shipfox/workflow-document": major
+"@shipfox/workflow-document": minor
 ---
 
 Moves trigger source-specific authoring fields into per-source config blocks so cron triggers use `config.schedule` and `config.timezone`.

--- a/.changeset/sharp-gates-align.md
+++ b/.changeset/sharp-gates-align.md
@@ -1,6 +1,6 @@
 ---
-"@shipfox/workflow-document": major
-"@shipfox/expression": major
+"@shipfox/workflow-document": minor
+"@shipfox/expression": minor
 ---
 
 Renames the step gate predicate from `success_if` to `success` and the restart payload from `on_failure.output` to `on_failure.feedback` across workflow authoring and predicate planning.

--- a/.changeset/sharp-planners-route.md
+++ b/.changeset/sharp-planners-route.md
@@ -1,5 +1,5 @@
 ---
-"@shipfox/expression": major
+"@shipfox/expression": minor
 "@shipfox/api-definitions": minor
 "@shipfox/api-workflows": patch
 ---


### PR DESCRIPTION
Use minor rather than major release bumps for the active breaking changesets.

The project is still pre-1.0, so breaking contract changes should advance minor versions instead of requesting major releases. This updates all eight major entries across five changesets while leaving existing patch and minor entries and their release notes unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches breaking changeset bumps from major to minor for pre-1.0 packages so releases follow SemVer and avoid unnecessary majors. Updates five changesets; release notes unchanged.

- **Refactors**
  - Use minor bumps for breaking changes in `@shipfox/api-auth-dto`, `@shipfox/api-runners-dto`, `@shipfox/api-workflows-dto`, `@shipfox/react-ui`, `@shipfox/workflow-document`, `@shipfox/expression`.
  - No code changes; only changeset metadata.

<sup>Written for commit 635b5f607277075fe908a46fd1dbfba50281a462. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

