### PR TITLE
Add Linear agent tools full-loop test

### DIFF
--- a/dev/e2e.mjs
+++ b/dev/e2e.mjs
@@ -169,6 +169,7 @@ export function e2eEnv(sourceEnv) {
   const apiUrl = sourceEnv.API_URL ?? sourceEnv.SHIPFOX_API_URL ?? defaultApiUrl;
   const clientUrl = sourceEnv.CLIENT_URL ?? sourceEnv.CLIENT_BASE_URL ?? defaultClientUrl;
   const giteaUrl = sourceEnv.E2E_GITEA_URL ?? sourceEnv.GITEA_BASE_URL ?? 'http://localhost:3000';
+  const linearMcpEndpoint = sourceEnv.LINEAR_MCP_ENDPOINT ?? e2eLinearMcpEndpoint(apiUrl);
   return {
     ...sourceEnv,
     API_URL: apiUrl,
@@ -179,10 +180,34 @@ export function e2eEnv(sourceEnv) {
     E2E_GITEA_URL: giteaUrl,
     GITEA_CLONE_BASE_URL: sourceEnv.GITEA_CLONE_BASE_URL ?? giteaUrl,
     HOST: sourceEnv.HOST ?? '0.0.0.0',
+    INTEGRATIONS_ENABLE_LINEAR_PROVIDER: sourceEnv.INTEGRATIONS_ENABLE_LINEAR_PROVIDER ?? 'true',
+    LINEAR_MCP_ENDPOINT: linearMcpEndpoint,
+    LINEAR_OAUTH_CLIENT_ID: sourceEnv.LINEAR_OAUTH_CLIENT_ID ?? 'e2e-linear-client-id',
+    LINEAR_OAUTH_CLIENT_SECRET:
+      sourceEnv.LINEAR_OAUTH_CLIENT_SECRET ?? 'e2e-linear-client-secret',
+    LINEAR_OAUTH_REDIRECT_URL:
+      sourceEnv.LINEAR_OAUTH_REDIRECT_URL ?? `${clientUrl}/integrations/linear/callback`,
+    LINEAR_WEBHOOK_SIGNING_SECRET:
+      sourceEnv.LINEAR_WEBHOOK_SIGNING_SECRET ?? 'e2e-linear-webhook-secret',
     VITE_API_URL: sourceEnv.VITE_API_URL ?? apiUrl,
     VITE_ENABLE_TEST_VCS_PROVIDER: sourceEnv.VITE_ENABLE_TEST_VCS_PROVIDER ?? 'true',
     WEBHOOK_PUBLIC_URL: sourceEnv.WEBHOOK_PUBLIC_URL ?? apiUrl,
   };
+}
+
+export function e2eLinearMcpEndpoint(apiUrl) {
+  const endpoint = new URL(apiUrl);
+  const apiPort = Number(endpoint.port || (endpoint.protocol === 'https:' ? 443 : 80));
+  const linearMcpPort = apiPort + 9;
+  if (linearMcpPort > 65_535) {
+    throw new Error(`Cannot derive a Linear MCP port from API port ${apiPort}.`);
+  }
+  endpoint.hostname = '127.0.0.1';
+  endpoint.port = String(linearMcpPort);
+  endpoint.pathname = '/mcp';
+  endpoint.search = '';
+  endpoint.hash = '';
+  return endpoint.toString();
 }
 
 export function turboCommandArgs(options, env) {

--- a/dev/e2e.test.mjs
+++ b/dev/e2e.test.mjs
@@ -64,6 +64,9 @@ describe('e2eEnv', () => {
     assert.equal(env.CLIENT_URL, 'http://localhost:55350');
     assert.equal(env.E2E_GITEA_URL, 'http://localhost:55356');
     assert.equal(env.GITEA_CLONE_BASE_URL, 'http://localhost:55356');
+    assert.equal(env.INTEGRATIONS_ENABLE_LINEAR_PROVIDER, 'true');
+    assert.equal(env.LINEAR_MCP_ENDPOINT, 'http://127.0.0.1:55360/mcp');
+    assert.equal(env.LINEAR_OAUTH_CLIENT_ID, 'e2e-linear-client-id');
     assert.equal(env.SHIPFOX_TURBO_CONCURRENCY, undefined);
     assert.equal(env.VITE_API_URL, 'http://localhost:55351');
     assert.equal(env.WEBHOOK_PUBLIC_URL, 'http://localhost:55351');
@@ -75,6 +78,7 @@ describe('e2eEnv', () => {
       CLIENT_URL: 'http://localhost:5173',
       E2E_GITEA_URL: 'http://localhost:3001',
       GITEA_CLONE_BASE_URL: 'http://localhost:3000',
+      LINEAR_MCP_ENDPOINT: 'http://127.0.0.1:16120/mcp',
       SHIPFOX_API_URL: 'http://localhost:55351',
       GITEA_BASE_URL: 'http://localhost:55356',
       WEBHOOK_PUBLIC_URL: 'https://webhooks.example.test',
@@ -84,6 +88,7 @@ describe('e2eEnv', () => {
     assert.equal(env.CLIENT_URL, 'http://localhost:5173');
     assert.equal(env.E2E_GITEA_URL, 'http://localhost:3001');
     assert.equal(env.GITEA_CLONE_BASE_URL, 'http://localhost:3000');
+    assert.equal(env.LINEAR_MCP_ENDPOINT, 'http://127.0.0.1:16120/mcp');
     assert.equal(env.WEBHOOK_PUBLIC_URL, 'https://webhooks.example.test');
   });
 
@@ -93,6 +98,13 @@ describe('e2eEnv', () => {
     });
 
     assert.equal(env.SHIPFOX_TURBO_CONCURRENCY, '3');
+  });
+
+  test('rejects an API port that cannot reserve the Linear MCP offset', () => {
+    assert.throws(
+      () => e2eEnv({API_URL: 'http://localhost:65527'}),
+      /Cannot derive a Linear MCP port/u,
+    );
   });
 });
 

--- a/dev/worktree-services.mjs
+++ b/dev/worktree-services.mjs
@@ -136,6 +136,7 @@ export function portsFromBase(base) {
     giteaSsh: base + 7,
     otelInstance: base + 8,
     otelService: base + 9,
+    linearMcp: base + 10,
   };
 }
 
@@ -153,6 +154,7 @@ function portsFromEnv(env) {
     giteaSsh: numberFromEnv(env, 'SHIPFOX_GITEA_SSH_PORT'),
     otelInstance: numberFromEnv(env, 'SHIPFOX_OTEL_INSTANCE_METRICS_PORT'),
     otelService: numberFromEnv(env, 'SHIPFOX_OTEL_SERVICE_METRICS_PORT'),
+    linearMcp: optionalNumberFromEnv(env, 'SHIPFOX_LINEAR_MCP_PORT') ?? base + 10,
   };
   return ports;
 }
@@ -182,6 +184,7 @@ function portEnv(ports) {
     SHIPFOX_GITEA_SSH_PORT: String(ports.giteaSsh),
     SHIPFOX_OTEL_INSTANCE_METRICS_PORT: String(ports.otelInstance),
     SHIPFOX_OTEL_SERVICE_METRICS_PORT: String(ports.otelService),
+    SHIPFOX_LINEAR_MCP_PORT: String(ports.linearMcp),
   };
 }
 
@@ -208,6 +211,7 @@ export function appEnv(ports) {
     TEMPORAL_ADDRESS: `localhost:${ports.temporal}`,
     GITEA_BASE_URL: `http://localhost:${ports.giteaHttp}`,
     LOG_STORAGE_S3_ENDPOINT: `http://localhost:${ports.garageS3}`,
+    LINEAR_MCP_ENDPOINT: `http://127.0.0.1:${ports.linearMcp}/mcp`,
     OTEL_INSTANCE_METRICS_PORT: String(ports.otelInstance),
     OTEL_SERVICE_METRICS_PORT: String(ports.otelService),
     VITE_API_URL: apiUrl,
@@ -303,7 +307,7 @@ export function parsePort(raw) {
 
 export function parseBasePort(raw) {
   const port = parsePort(raw);
-  return port !== undefined && port <= 65_526 ? port : undefined;
+  return port !== undefined && port <= 65_525 ? port : undefined;
 }
 
 function writeEnvFile(file, values) {

--- a/dev/worktree-services.test.mjs
+++ b/dev/worktree-services.test.mjs
@@ -32,6 +32,7 @@ describe('portsFromBase', () => {
       giteaSsh: 65_007,
       otelInstance: 65_008,
       otelService: 65_009,
+      linearMcp: 65_010,
     });
   });
 });
@@ -73,6 +74,7 @@ describe('appEnv', () => {
     assert.equal(env.SHIPFOX_RUNNER_API_URL, 'http://host.docker.internal:55291');
     assert.equal(env.SHIPFOX_PROVISIONER_DOCKER_EXTRA_HOSTS, 'host.docker.internal:host-gateway');
     assert.equal(env.SHIPFOX_DOCS_PORT, '55294');
+    assert.equal(env.LINEAR_MCP_ENDPOINT, 'http://127.0.0.1:55300/mcp');
   });
 });
 
@@ -161,7 +163,7 @@ describe('parsePort', () => {
 
 describe('parseBasePort', () => {
   test('keeps the base port low enough for every service offset', () => {
-    assert.equal(parseBasePort('65526'), 65_526);
-    assert.equal(parseBasePort('65527'), undefined);
+    assert.equal(parseBasePort('65525'), 65_525);
+    assert.equal(parseBasePort('65526'), undefined);
   });
 });

--- a/e2e/drivers/model-provider/src/scripts.ts
+++ b/e2e/drivers/model-provider/src/scripts.ts
@@ -39,6 +39,10 @@ export type FakeOpenAiRequestAssertion = (
       kind: 'tool_present';
       name: string;
     }
+  | {
+      kind: 'message_content_includes';
+      value: string;
+    }
 ) & {minRequestIndex?: number | undefined};
 
 export interface FakeOpenAiRecordedRequest {
@@ -310,13 +314,14 @@ export class FakeOpenAiScriptRegistry {
 
 interface ModelProviderRequestSummary {
   model: string | null;
+  messageContent: string[];
   tools: string[];
   messageRoles: string[];
 }
 
 function summarizeModelProviderRequest(body: unknown): ModelProviderRequestSummary {
   if (!body || typeof body !== 'object') {
-    return {model: null, tools: [], messageRoles: []};
+    return {model: null, messageContent: [], tools: [], messageRoles: []};
   }
 
   const request = body as {
@@ -327,9 +332,31 @@ function summarizeModelProviderRequest(body: unknown): ModelProviderRequestSumma
 
   return {
     model: typeof request.model === 'string' ? request.model : null,
+    messageContent: messageContent(request.messages),
     tools: toolNames(request.tools),
     messageRoles: messageRoles(request.messages),
   };
+}
+
+function messageContent(messages: unknown): string[] {
+  if (!Array.isArray(messages)) return [];
+
+  return messages.flatMap((message) => {
+    if (!message || typeof message !== 'object') return [];
+    return contentStrings((message as {content?: unknown}).content);
+  });
+}
+
+function contentStrings(content: unknown): string[] {
+  if (typeof content === 'string') return [content];
+  if (Array.isArray(content)) return content.flatMap(contentStrings);
+  if (!content || typeof content !== 'object') return [];
+
+  const {text, content: nestedContent} = content as {text?: unknown; content?: unknown};
+  return [
+    ...(typeof text === 'string' ? [text] : []),
+    ...(nestedContent === undefined ? [] : contentStrings(nestedContent)),
+  ];
 }
 
 function toolNames(tools: unknown): string[] {
@@ -373,6 +400,13 @@ function assertRequest(
 
     if (assertion.kind === 'tool_present' && !summary.tools.includes(assertion.name)) {
       return [`Expected tool ${assertion.name} to be present`];
+    }
+
+    if (
+      assertion.kind === 'message_content_includes' &&
+      !summary.messageContent.some((content) => content.includes(assertion.value))
+    ) {
+      return [`Expected message content to include ${assertion.value}`];
     }
 
     return [];

--- a/e2e/drivers/model-provider/src/server.test.ts
+++ b/e2e/drivers/model-provider/src/server.test.ts
@@ -492,6 +492,77 @@ describe('fake OpenAI model provider server', () => {
     });
   });
 
+  it.each([
+    [
+      'Anthropic tool-result blocks',
+      anthropicMessage,
+      anthropicRequest({
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: 'toolu_1',
+                content: [{type: 'text', text: 'linear-read-result-marker'}],
+              },
+            ],
+          },
+        ],
+      }),
+    ],
+    [
+      'OpenAI tool-result messages',
+      chatCompletion,
+      openAiRequest({
+        messages: [{role: 'tool', content: 'linear-read-result-marker', tool_call_id: 'call_1'}],
+      }),
+    ],
+  ])('matches content returned through %s', async (_shape, requestModel, request) => {
+    await postScript(
+      server,
+      fakeScript({
+        id: `message-content-${_shape}`,
+        assertions: [{kind: 'message_content_includes', value: 'linear-read-result-marker'}],
+        responses: [{kind: 'message', content: 'done'}],
+      }),
+    );
+
+    const result = await requestModel(server, `message-content-${_shape}`, request);
+
+    expect(result.status).toBe(200);
+  });
+
+  it('does not consume a scripted response when returned tool content is missing', async () => {
+    await postScript(
+      server,
+      fakeScript({
+        id: 'missing-message-content',
+        assertions: [{kind: 'message_content_includes', value: 'linear-read-result-marker'}],
+        responses: [{kind: 'message', content: 'done'}],
+      }),
+    );
+
+    const rejected = await chatCompletion(
+      server,
+      'missing-message-content',
+      openAiRequest({messages: [{role: 'tool', content: 'wrong marker', tool_call_id: 'call_1'}]}),
+    );
+    const accepted = await chatCompletion(
+      server,
+      'missing-message-content',
+      openAiRequest({
+        messages: [{role: 'tool', content: 'linear-read-result-marker', tool_call_id: 'call_1'}],
+      }),
+    );
+
+    expect(rejected.status).toBe(422);
+    expect(accepted.status).toBe(200);
+    await expect(accepted.json()).resolves.toMatchObject({
+      id: 'chatcmpl-fake-missing-message-content-0',
+    });
+  });
+
   it('records request diagnostics and clears them on reset', async () => {
     await postScript(
       server,
@@ -603,10 +674,12 @@ function adminHeaders(): Record<string, string> {
   };
 }
 
-function openAiRequest(params: {roles?: string[] | undefined} = {}) {
+function openAiRequest(
+  params: {roles?: string[] | undefined; messages?: unknown[] | undefined} = {},
+) {
   return {
     model: 'deterministic-output-agent',
-    messages: (params.roles ?? ['system', 'user']).map((role) => ({role})),
+    messages: params.messages ?? (params.roles ?? ['system', 'user']).map((role) => ({role})),
     tools: [
       {
         type: 'function',
@@ -618,11 +691,13 @@ function openAiRequest(params: {roles?: string[] | undefined} = {}) {
   };
 }
 
-function anthropicRequest(params: {model?: string | undefined} = {}) {
+function anthropicRequest(
+  params: {model?: string | undefined; messages?: unknown[] | undefined} = {},
+) {
   return {
     model: params.model ?? 'deterministic-output-agent',
     max_tokens: 128,
-    messages: [{role: 'user', content: 'Set the output'}],
+    messages: params.messages ?? [{role: 'user', content: 'Set the output'}],
     tools: [
       {
         name: 'mcp__shipfox_outputs__set_output',

--- a/e2e/setup/agent/src/index.ts
+++ b/e2e/setup/agent/src/index.ts
@@ -120,6 +120,10 @@ export type FakeModelProviderRequestAssertion = (
       kind: 'tool_present';
       name: string;
     }
+  | {
+      kind: 'message_content_includes';
+      value: string;
+    }
 ) & {minRequestIndex?: number | undefined};
 
 export interface FakeModelProviderScriptHandle {

--- a/e2e/setup/integrations/package.json
+++ b/e2e/setup/integrations/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@shipfox/e2e-setup-integrations",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
+    "directory": "e2e/setup/integrations"
+  },
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "imports": {
+    "#test/*": "./test/*",
+    "#*": "./src/*"
+  },
+  "exports": {
+    ".": {
+      "development": {
+        "types": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "depcruise": "shipfox-depcruise",
+    "test": "shipfox-vitest-run",
+    "test:watch": "shipfox-vitest-watch",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "@shipfox/api-integration-linear-dto": "workspace:*",
+    "@shipfox/e2e-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/depcruise": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*"
+  }
+}

--- a/e2e/setup/integrations/src/index.test.ts
+++ b/e2e/setup/integrations/src/index.test.ts
@@ -1,0 +1,38 @@
+import {beforeEach, describe, expect, it, vi} from '@shipfox/vitest/vi';
+
+const requestJson = vi.fn();
+
+describe('integrations E2E setup helper', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    requestJson.mockReset();
+    vi.doMock('@shipfox/e2e-core', () => ({requestJson}));
+  });
+
+  it('creates Linear connections through the protected setup route', async () => {
+    requestJson.mockResolvedValueOnce({id: 'connection-id'});
+    const {createLinearConnection} = await import('./index.js');
+
+    await createLinearConnection({
+      workspaceId: 'workspace-id',
+      organizationId: 'linear-org',
+      organizationUrlKey: 'acme',
+      appUserId: 'linear-app-user',
+      displayName: 'Linear Acme',
+      accessToken: 'linear-e2e-token',
+      scopes: ['read', 'write'],
+    });
+
+    expect(requestJson).toHaveBeenCalledWith('post', '/__e2e/integrations/linear-connections', {
+      json: {
+        workspace_id: 'workspace-id',
+        organization_id: 'linear-org',
+        organization_url_key: 'acme',
+        app_user_id: 'linear-app-user',
+        display_name: 'Linear Acme',
+        access_token: 'linear-e2e-token',
+        scopes: ['read', 'write'],
+      },
+    });
+  });
+});

--- a/e2e/setup/integrations/src/index.ts
+++ b/e2e/setup/integrations/src/index.ts
@@ -1,0 +1,44 @@
+import type {
+  CreateE2eLinearConnectionBodyDto,
+  CreateE2eLinearConnectionResponseDto,
+} from '@shipfox/api-integration-linear-dto';
+import {requestJson} from '@shipfox/e2e-core';
+
+export type {
+  CreateE2eLinearConnectionBodyDto,
+  CreateE2eLinearConnectionResponseDto,
+} from '@shipfox/api-integration-linear-dto';
+
+export interface CreateLinearConnectionParams {
+  workspaceId: string;
+  organizationId: string;
+  organizationUrlKey: string;
+  appUserId: string;
+  displayName: string;
+  accessToken: string;
+  scopes?: string[] | undefined;
+}
+
+function linearConnectionBody(
+  params: CreateLinearConnectionParams,
+): CreateE2eLinearConnectionBodyDto {
+  return {
+    workspace_id: params.workspaceId,
+    organization_id: params.organizationId,
+    organization_url_key: params.organizationUrlKey,
+    app_user_id: params.appUserId,
+    display_name: params.displayName,
+    access_token: params.accessToken,
+    scopes: params.scopes ?? ['read', 'write'],
+  };
+}
+
+export async function createLinearConnection(
+  params: CreateLinearConnectionParams,
+): Promise<CreateE2eLinearConnectionResponseDto> {
+  return await requestJson<CreateE2eLinearConnectionResponseDto>(
+    'post',
+    '/__e2e/integrations/linear-connections',
+    {json: linearConnectionBody(params)},
+  );
+}

--- a/e2e/setup/integrations/tsconfig.build.json
+++ b/e2e/setup/integrations/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/e2e/setup/integrations/tsconfig.json
+++ b/e2e/setup/integrations/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.test.json" }]
+}

--- a/e2e/setup/integrations/tsconfig.test.json
+++ b/e2e/setup/integrations/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "vitest.config.ts"]
+}

--- a/e2e/setup/integrations/vitest.config.ts
+++ b/e2e/setup/integrations/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({}, import.meta.url) as UserConfigExport;

--- a/e2e/suites/flow/workflows/package.json
+++ b/e2e/suites/flow/workflows/package.json
@@ -15,6 +15,7 @@
     "#expect.js": "./src/expect.ts",
     "#listener-helpers.js": "./src/listener-helpers.ts",
     "#listener-jobs.js": "./src/listener-jobs.ts",
+    "#linear-mcp.js": "./src/linear-mcp.ts",
     "#polling.js": "./src/polling.ts",
     "#run-scenario.js": "./src/run-scenario.ts",
     "#runner.js": "./src/runner.ts",
@@ -36,6 +37,7 @@
   "devDependencies": {
     "@shipfox/api-definitions-dto": "workspace:*",
     "@shipfox/api-integration-webhook-dto": "workspace:*",
+    "@shipfox/api-integration-linear-dto": "workspace:*",
     "@shipfox/api-logs-dto": "workspace:*",
     "@shipfox/api-projects-dto": "workspace:*",
     "@shipfox/api-triggers-dto": "workspace:*",
@@ -50,6 +52,7 @@
     "@shipfox/e2e-observe-logs": "workspace:*",
     "@shipfox/e2e-observe-workflows": "workspace:*",
     "@shipfox/e2e-setup-agent": "workspace:*",
+    "@shipfox/e2e-setup-integrations": "workspace:*",
     "@shipfox/e2e-setup-auth": "workspace:*",
     "@shipfox/e2e-setup-secrets": "workspace:*",
     "@shipfox/e2e-setup-workspaces": "workspace:*",
@@ -58,6 +61,7 @@
     "@shipfox/typescript": "workspace:*",
     "@shipfox/vitest": "workspace:*",
     "@types/js-yaml": "^4.0.9",
+    "@modelcontextprotocol/sdk": "1.29.0",
     "js-yaml": "^4.1.0",
     "zod": "^4.4.3"
   }

--- a/e2e/suites/flow/workflows/src/linear-mcp.test.ts
+++ b/e2e/suites/flow/workflows/src/linear-mcp.test.ts
@@ -1,0 +1,71 @@
+import {once} from 'node:events';
+import {createServer} from 'node:http';
+import {Client} from '@modelcontextprotocol/sdk/client/index.js';
+import {StreamableHTTPClientTransport} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import type {Transport} from '@modelcontextprotocol/sdk/shared/transport.js';
+import {CallToolResultSchema} from '@modelcontextprotocol/sdk/types.js';
+import {
+  LINEAR_READ_RESULT_MARKER,
+  LINEAR_WRITE_RESULT_MARKER,
+  startLinearMcpMock,
+} from './linear-mcp.js';
+
+describe('Linear MCP mock', () => {
+  it('serves deterministic authenticated read and write tool calls', async () => {
+    const mock = await startLinearMcpMock(new URL('http://127.0.0.1:0/mcp'));
+    const client = new Client({name: 'linear-mcp-test', version: '0.0.0'});
+    const transport = new StreamableHTTPClientTransport(mock.endpoint, {
+      requestInit: {headers: {authorization: 'Bearer synthetic-linear-token'}},
+    });
+
+    try {
+      await client.connect(transport as unknown as Transport);
+      const read = await client.callTool(
+        {name: 'get_issue', arguments: {id: 'ENG-878'}},
+        CallToolResultSchema,
+      );
+      const write = await client.callTool(
+        {
+          name: 'save_comment',
+          arguments: {issueId: 'ENG-878', body: 'Synthetic Linear comment'},
+        },
+        CallToolResultSchema,
+      );
+
+      expect(read.content).toContainEqual({type: 'text', text: LINEAR_READ_RESULT_MARKER});
+      expect(write.content).toContainEqual({type: 'text', text: LINEAR_WRITE_RESULT_MARKER});
+      expect(mock.calls).toEqual([
+        {
+          authorization: 'Bearer synthetic-linear-token',
+          arguments: {id: 'ENG-878'},
+          toolName: 'get_issue',
+        },
+        {
+          authorization: 'Bearer synthetic-linear-token',
+          arguments: {issueId: 'ENG-878', body: 'Synthetic Linear comment'},
+          toolName: 'save_comment',
+        },
+      ]);
+    } finally {
+      await client.close();
+      await mock.stop();
+    }
+  });
+
+  it('fails clearly when its endpoint port is occupied', async () => {
+    const occupied = createServer();
+    occupied.listen({host: '127.0.0.1', port: 0});
+    await once(occupied, 'listening');
+    const address = occupied.address();
+    if (!address || typeof address === 'string') throw new Error('Expected TCP server address.');
+
+    try {
+      await expect(
+        startLinearMcpMock(new URL(`http://127.0.0.1:${address.port}/mcp`)),
+      ).rejects.toThrow('Linear MCP mock failed to start');
+    } finally {
+      occupied.close();
+      await once(occupied, 'close');
+    }
+  });
+});

--- a/e2e/suites/flow/workflows/src/linear-mcp.ts
+++ b/e2e/suites/flow/workflows/src/linear-mcp.ts
@@ -1,0 +1,156 @@
+import {once} from 'node:events';
+import {
+  createServer,
+  type Server as HttpServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from 'node:http';
+import {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
+import {StreamableHTTPServerTransport} from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import type {Transport} from '@modelcontextprotocol/sdk/shared/transport.js';
+import {z} from 'zod';
+
+export const LINEAR_READ_RESULT_MARKER = 'linear-read-result-marker';
+export const LINEAR_WRITE_RESULT_MARKER = 'linear-write-result-marker';
+
+export interface LinearMcpCall {
+  authorization: string | undefined;
+  arguments: Record<string, unknown>;
+  toolName: 'get_issue' | 'save_comment';
+}
+
+export interface LinearMcpMock {
+  calls: LinearMcpCall[];
+  endpoint: URL;
+  stop(): Promise<void>;
+}
+
+export async function startLinearMcpMock(
+  endpoint = new URL(requiredLinearMcpEndpoint()),
+): Promise<LinearMcpMock> {
+  const calls: LinearMcpCall[] = [];
+  let boundEndpoint = endpoint;
+  const server = createServer((request, response) => {
+    void handleMcpRequest({calls, endpoint: boundEndpoint, request, response});
+  });
+
+  try {
+    boundEndpoint = await listen(server, endpoint);
+  } catch (error) {
+    throw new Error(`Linear MCP mock failed to start at ${endpoint}`, {cause: error});
+  }
+
+  return {
+    calls,
+    endpoint: boundEndpoint,
+    stop: async () => {
+      try {
+        await close(server);
+      } catch (error) {
+        throw new Error(`Linear MCP mock failed to stop at ${boundEndpoint}`, {cause: error});
+      }
+    },
+  };
+}
+
+async function handleMcpRequest(params: {
+  calls: LinearMcpCall[];
+  endpoint: URL;
+  request: IncomingMessage;
+  response: ServerResponse;
+}): Promise<void> {
+  const requestUrl = new URL(params.request.url ?? '/', params.endpoint);
+  if (requestUrl.pathname !== params.endpoint.pathname) {
+    sendMcpError(params.response, 404, -32600, 'Invalid MCP endpoint.');
+    return;
+  }
+  if (params.request.method !== 'POST') {
+    sendMcpError(params.response, 405, -32600, 'Method not allowed.');
+    return;
+  }
+
+  try {
+    const body = await readJsonBody(params.request);
+    const mcp = new McpServer({name: 'linear-e2e-mock', version: '0.0.0'});
+    mcp.registerTool(
+      'get_issue',
+      {
+        description: 'Get a deterministic Linear issue.',
+        inputSchema: {id: z.string()},
+      },
+      (arguments_) => {
+        params.calls.push({
+          authorization: params.request.headers.authorization,
+          arguments: arguments_,
+          toolName: 'get_issue',
+        });
+        return {content: [{type: 'text', text: LINEAR_READ_RESULT_MARKER}]};
+      },
+    );
+    mcp.registerTool(
+      'save_comment',
+      {
+        description: 'Save a deterministic Linear comment.',
+        inputSchema: {issueId: z.string(), body: z.string()},
+      },
+      (arguments_) => {
+        params.calls.push({
+          authorization: params.request.headers.authorization,
+          arguments: arguments_,
+          toolName: 'save_comment',
+        });
+        return {content: [{type: 'text', text: LINEAR_WRITE_RESULT_MARKER}]};
+      },
+    );
+    const transport = new StreamableHTTPServerTransport();
+    await mcp.connect(transport as unknown as Transport);
+    params.response.once('close', () => {
+      void Promise.all([transport.close(), mcp.close()]).catch(() => undefined);
+    });
+    await transport.handleRequest(params.request, params.response, body);
+  } catch (_error) {
+    if (!params.response.headersSent)
+      sendMcpError(params.response, 500, -32603, 'MCP request failed.');
+    else params.response.end();
+  }
+}
+
+function requiredLinearMcpEndpoint(): string {
+  const endpoint = process.env.LINEAR_MCP_ENDPOINT;
+  if (!endpoint) throw new Error('LINEAR_MCP_ENDPOINT must be configured for the Linear MCP mock.');
+  return endpoint;
+}
+
+async function listen(server: HttpServer, endpoint: URL): Promise<URL> {
+  server.listen({host: endpoint.hostname, port: Number(endpoint.port)});
+  await once(server, 'listening');
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('Expected TCP server address.');
+  const boundEndpoint = new URL(endpoint);
+  boundEndpoint.port = String(address.port);
+  return boundEndpoint;
+}
+
+async function close(server: HttpServer): Promise<void> {
+  server.close();
+  await once(server, 'close');
+}
+
+async function readJsonBody(request: NodeJS.ReadableStream): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return JSON.parse(Buffer.concat(chunks).toString('utf8')) as unknown;
+}
+
+function sendMcpError(
+  response: ServerResponse,
+  statusCode: number,
+  code: number,
+  message: string,
+): void {
+  response
+    .writeHead(statusCode, {'content-type': 'application/json'})
+    .end(JSON.stringify({jsonrpc: '2.0', error: {code, message}, id: null}));
+}

--- a/e2e/suites/flow/workflows/tests/linear-agent-tools.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/linear-agent-tools.e2e.ts
@@ -1,0 +1,197 @@
+import {createApiClient} from '@shipfox/e2e-core';
+import {message, startFakeOpenAiModelProvider, toolCall} from '@shipfox/e2e-driver-model-provider';
+import {stopLocalRunner} from '@shipfox/e2e-driver-runner-process';
+import {createAnthropicFakeModelProviderConfig} from '@shipfox/e2e-setup-agent';
+import {createLinearConnection} from '@shipfox/e2e-setup-integrations';
+import {attachLocalRunnerLog} from '#attachments.js';
+import {
+  LINEAR_READ_RESULT_MARKER,
+  LINEAR_WRITE_RESULT_MARKER,
+  startLinearMcpMock,
+} from '#linear-mcp.js';
+import {startSuiteLocalRunner, waitForRunTerminalOrFailedRunner} from '#runner.js';
+import type {SuiteContext} from '#suite-context.js';
+import {fireManualAndAwaitRun} from '#triggers.js';
+import {seedAndWaitForDefinition} from '#workflow-project.js';
+import {expect, test} from './fixtures.js';
+
+const CLAUDE_AGENT_MODEL = 'deterministic-linear-tools-agent';
+const TERMINAL_TIMEOUT_MS = 60_000;
+
+test.describe.configure({mode: 'serial'});
+
+test('runs Linear read and write tools through the agent-step MCP path', async ({
+  suite,
+}, testInfo) => {
+  const uniqueId = crypto.randomUUID().replaceAll('-', '').slice(0, 10);
+  const accessToken = `linear-e2e-token-${uniqueId}`;
+  const mcpMock = await startLinearMcpMock();
+  let fakeModelProvider: Awaited<ReturnType<typeof startFakeOpenAiModelProvider>> | undefined;
+
+  try {
+    fakeModelProvider = await startFakeOpenAiModelProvider({
+      runId: `${suite.runId}-linear-agent-tools-${uniqueId}`,
+    });
+    const connection = await createLinearConnection({
+      workspaceId: suite.workspaceId,
+      organizationId: `linear-org-${uniqueId}`,
+      organizationUrlKey: `e2e-${uniqueId}`,
+      appUserId: `linear-app-user-${uniqueId}`,
+      displayName: `Linear E2E ${uniqueId}`,
+      accessToken,
+    });
+    const getIssueTool = `mcp__shipfox_integration_tools__${connection.slug}__get_issue`;
+    const saveCommentTool = `mcp__shipfox_integration_tools__${connection.slug}__save_comment`;
+    const fakeAnthropic = await createAnthropicFakeModelProviderConfig({
+      workspaceId: suite.workspaceId,
+      fakeModelProvider,
+      scriptId: `${suite.runId}-linear-agent-tools-${uniqueId}`,
+      model: CLAUDE_AGENT_MODEL,
+      responses: [
+        toolCall(getIssueTool, {id: 'ENG-878'}),
+        toolCall(saveCommentTool, {issueId: 'ENG-878', body: 'Synthetic Linear comment'}),
+        message('done'),
+      ],
+      assertions: [
+        {kind: 'model', equals: CLAUDE_AGENT_MODEL},
+        {kind: 'tool_present', name: getIssueTool},
+        {kind: 'tool_present', name: saveCommentTool},
+        {
+          kind: 'message_content_includes',
+          value: LINEAR_READ_RESULT_MARKER,
+          minRequestIndex: 1,
+        },
+        {
+          kind: 'message_content_includes',
+          value: LINEAR_WRITE_RESULT_MARKER,
+          minRequestIndex: 2,
+        },
+      ],
+      setAsDefault: true,
+    });
+
+    const terminal = await runLinearToolsWorkflow({
+      suite,
+      testInfo,
+      uniqueId,
+      connectionSlug: connection.slug,
+      runnerEnv: fakeAnthropic.runnerEnv,
+    });
+
+    expect(terminal.status).toBe('succeeded');
+    expect(terminal.jobs.find((job) => job.key === 'tools')?.status).toBe('succeeded');
+    expect(mcpMock.endpoint.toString()).toBe(process.env.LINEAR_MCP_ENDPOINT);
+    expect(mcpMock.endpoint.hostname).toBe('127.0.0.1');
+    expect(mcpMock.endpoint.hostname).not.toBe('mcp.linear.app');
+    expect(mcpMock.calls).toEqual([
+      {
+        authorization: `Bearer ${accessToken}`,
+        arguments: {id: 'ENG-878'},
+        toolName: 'get_issue',
+      },
+      {
+        authorization: `Bearer ${accessToken}`,
+        arguments: {issueId: 'ENG-878', body: 'Synthetic Linear comment'},
+        toolName: 'save_comment',
+      },
+    ]);
+  } finally {
+    await Promise.all([
+      fakeModelProvider?.stop().catch((error: unknown) => {
+        process.stderr.write(
+          `linear-agent-tools-e2e: stopFakeOpenAiModelProvider failed: ${String(error)}\n`,
+        );
+      }) ?? Promise.resolve(),
+      mcpMock.stop().catch((error: unknown) => {
+        process.stderr.write(
+          `linear-agent-tools-e2e: stopLinearMcpMock failed: ${String(error)}\n`,
+        );
+      }),
+    ]);
+  }
+});
+
+async function runLinearToolsWorkflow(params: {
+  suite: SuiteContext;
+  testInfo: {
+    attach: (name: string, options: {body: Buffer | string; contentType: string}) => Promise<void>;
+  };
+  uniqueId: string;
+  connectionSlug: string;
+  runnerEnv: Record<string, string>;
+}) {
+  const token = params.suite.sessionToken;
+  const client = createApiClient({token});
+  const scenario = 'linear-agent-tools';
+  const runnerLabel = `e2e-${scenario}-${params.uniqueId}`;
+  const repo = `${scenario}-${params.uniqueId}`;
+  const localRunner = await startSuiteLocalRunner({
+    workspaceId: params.suite.workspaceId,
+    userToken: token,
+    name: `E2E ${scenario} ${params.uniqueId}`,
+    runnerLabel,
+    extraEnv: {
+      ...params.runnerEnv,
+      SHIPFOX_POLL_MAX_DURATION_MS: String(TERMINAL_TIMEOUT_MS),
+    },
+  });
+
+  try {
+    const {definition} = await seedAndWaitForDefinition({
+      suite: params.suite,
+      token,
+      name: scenario,
+      repo,
+      runnerLabel,
+      workflowYaml: linearToolsWorkflowYaml(params.connectionSlug),
+      configPath: `.shipfox/workflows/${scenario}.yml`,
+    });
+    const runId = await fireManualAndAwaitRun({
+      client,
+      definitionId: definition.id,
+      inputs: {},
+      scenario,
+    });
+
+    return await waitForRunTerminalOrFailedRunner({
+      runId,
+      token,
+      timeoutMs: TERMINAL_TIMEOUT_MS,
+      runner: localRunner.runner,
+    });
+  } finally {
+    await attachLocalRunnerLog(
+      (attachment) =>
+        params.testInfo.attach(attachment.name, {
+          body: attachment.body,
+          contentType: attachment.contentType,
+        }),
+      localRunner.logFile,
+    );
+    await stopLocalRunner(localRunner.runner).catch((error: unknown) => {
+      process.stderr.write(`${scenario}-e2e: stopLocalRunner failed: ${String(error)}\n`);
+    });
+  }
+}
+
+function linearToolsWorkflowYaml(connectionSlug: string): string {
+  return `
+name: Linear agent tools
+runner: __RUNNER_LABEL__
+triggers:
+  manual:
+    source: manual
+    event: fire
+jobs:
+  tools:
+    steps:
+      - key: linear
+        harness: claude
+        thinking: low
+        prompt: Use the selected Linear tools.
+        integrations:
+          - connection: ${connectionSlug}
+            include: [get_issue, save_comment]
+            allow_write: true
+`;
+}

--- a/e2e/suites/flow/workflows/tests/linear-agent-tools.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/linear-agent-tools.e2e.ts
@@ -97,7 +97,7 @@ test('runs Linear read and write tools through the agent-step MCP path', async (
     ]);
   } finally {
     await Promise.all([
-      fakeModelProvider?.stop().catch((error: unknown) => {
+      fakeModelProvider?.stop()?.catch((error: unknown) => {
         process.stderr.write(
           `linear-agent-tools-e2e: stopFakeOpenAiModelProvider failed: ${String(error)}\n`,
         );

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -175,6 +175,7 @@ export async function createIntegrationsContext(
           }
         : undefined,
     }),
+    e2eRoutes: parts.flatMap((part) => part.e2eRoutes ?? []),
     publishers: [
       {name: 'integrations', table: integrationsOutbox, db, eventSchemas: integrationsEventSchemas},
     ],

--- a/libs/api/integration/core/src/providers/linear.ts
+++ b/libs/api/integration/core/src/providers/linear.ts
@@ -29,7 +29,9 @@ async function loadLinearModuleParts(
 ): Promise<IntegrationModuleParts> {
   const {
     createLinearTokenStore,
+    createLinearE2eRoutes,
     createLinearIntegrationProvider,
+    config: linearConfig,
     disconnectLinearInstallation: disconnectLinearInstallationRecords,
     getLinearInstallationByOrganizationId,
     db: linearDb,
@@ -134,7 +136,7 @@ async function loadLinearModuleParts(
 
   return {
     provider: createLinearIntegrationProvider({
-      agentTools: {tokenStore},
+      agentTools: {tokenStore, endpoint: linearConfig.LINEAR_MCP_ENDPOINT},
       routes: {
         tokenStore,
         getExistingLinearConnection,
@@ -146,6 +148,15 @@ async function loadLinearModuleParts(
         coreDb: db,
       },
     }),
+    e2eRoutes: [
+      createLinearE2eRoutes({
+        tokenStore,
+        getExistingLinearConnection,
+        connectLinearInstallation,
+        disconnectLinearInstallation,
+        connectionCapabilities: ['agent_tools'],
+      }),
+    ],
     database: {
       db: linearDb,
       migrationsPath: linearMigrationsPath,

--- a/libs/api/integration/core/src/providers/types.ts
+++ b/libs/api/integration/core/src/providers/types.ts
@@ -1,3 +1,4 @@
+import type {RouteExport} from '@shipfox/node-fastify';
 import type {ModuleDatabase, ModuleWorker} from '@shipfox/node-module';
 import type {IntegrationProvider} from '#core/entities/provider.js';
 
@@ -13,6 +14,7 @@ import type {IntegrationProvider} from '#core/entities/provider.js';
 export interface IntegrationModuleParts {
   provider: IntegrationProvider;
   database?: ModuleDatabase | undefined;
+  e2eRoutes?: RouteExport[] | undefined;
   workers?: ModuleWorker[] | undefined;
   startupTasks?: Array<() => Promise<void>> | undefined;
 }

--- a/libs/api/integration/core/test/env.ts
+++ b/libs/api/integration/core/test/env.ts
@@ -16,6 +16,7 @@ process.env.LINEAR_OAUTH_CLIENT_ID = 'test-client-id';
 process.env.LINEAR_OAUTH_CLIENT_SECRET = 'test-client-secret';
 process.env.LINEAR_WEBHOOK_SIGNING_SECRET = 'test-webhook-secret';
 process.env.LINEAR_OAUTH_REDIRECT_URL = 'https://shipfox.example.com/integrations/linear/callback';
+process.env.LINEAR_MCP_ENDPOINT = 'https://mcp.linear.app/mcp';
 process.env.GITEA_BASE_URL = 'https://gitea.example.com';
 process.env.GITEA_SERVICE_USERNAME = 'shipfox-bot';
 process.env.GITEA_SERVICE_TOKEN = 'test-service-token';

--- a/libs/api/integration/linear-dto/src/schemas/index.ts
+++ b/libs/api/integration/linear-dto/src/schemas/index.ts
@@ -108,3 +108,19 @@ export type LinearCallbackQueryDto = z.infer<typeof linearCallbackQuerySchema>;
 
 export const linearCallbackResponseSchema = integrationConnectionDtoSchema;
 export type LinearCallbackResponseDto = z.infer<typeof linearCallbackResponseSchema>;
+
+export const createE2eLinearConnectionBodySchema = z.object({
+  workspace_id: z.string().uuid(),
+  organization_id: z.string().min(1),
+  organization_url_key: z.string().min(1),
+  app_user_id: z.string().min(1),
+  display_name: z.string().min(1),
+  access_token: z.string().min(1),
+  scopes: z.array(z.string().min(1)).min(1).default(['read', 'write']),
+});
+export type CreateE2eLinearConnectionBodyDto = z.infer<typeof createE2eLinearConnectionBodySchema>;
+
+export const createE2eLinearConnectionResponseSchema = integrationConnectionDtoSchema;
+export type CreateE2eLinearConnectionResponseDto = z.infer<
+  typeof createE2eLinearConnectionResponseSchema
+>;

--- a/libs/api/integration/linear/src/config.test.ts
+++ b/libs/api/integration/linear/src/config.test.ts
@@ -12,6 +12,7 @@ describe('linear config', () => {
   });
 
   it('exports validated Linear config from the package root', async () => {
+    vi.stubEnv('LINEAR_MCP_ENDPOINT', undefined);
     vi.resetModules();
 
     const {config} = await import('#index.js');

--- a/libs/api/integration/linear/src/config.test.ts
+++ b/libs/api/integration/linear/src/config.test.ts
@@ -7,6 +7,7 @@ const linearEnvNames = [
 
 describe('linear config', () => {
   afterEach(() => {
+    vi.unstubAllEnvs();
     vi.resetModules();
   });
 
@@ -18,5 +19,15 @@ describe('linear config', () => {
     for (const name of linearEnvNames) {
       expect(config[name]).toBe(process.env[name]);
     }
+    expect(config.LINEAR_MCP_ENDPOINT).toBe('https://mcp.linear.app/mcp');
+  });
+
+  it('accepts a compatible Linear MCP endpoint override', async () => {
+    vi.stubEnv('LINEAR_MCP_ENDPOINT', 'https://linear-mcp.example.test/mcp');
+    vi.resetModules();
+
+    const {config} = await import('#index.js');
+
+    expect(config.LINEAR_MCP_ENDPOINT).toBe('https://linear-mcp.example.test/mcp');
   });
 });

--- a/libs/api/integration/linear/src/config.ts
+++ b/libs/api/integration/linear/src/config.ts
@@ -13,6 +13,10 @@ const linearConfigSchema = {
   LINEAR_OAUTH_REDIRECT_URL: url({
     desc: 'Public client callback URL Linear redirects to after OAuth authorization, such as https://shipfox.example.com/integrations/linear/callback. Required.',
   }),
+  LINEAR_MCP_ENDPOINT: url({
+    desc: 'Streamable HTTP endpoint used for Linear MCP tool calls. Set this only when routing Linear tools through a compatible proxy or test server.',
+    default: 'https://mcp.linear.app/mcp',
+  }),
 };
 
 export const config = createConfig(linearConfigSchema);

--- a/libs/api/integration/linear/src/index.ts
+++ b/libs/api/integration/linear/src/index.ts
@@ -81,6 +81,10 @@ export {
   upsertLinearInstallation,
   withLinearRefreshLock,
 } from '#db/installations.js';
+export {
+  type CreateLinearE2eRoutesOptions,
+  createLinearE2eRoutes,
+} from '#presentation/e2eRoutes/index.js';
 export {closeDb, config, db, migrationsPath};
 
 export interface CreateLinearIntegrationProviderOptions {

--- a/libs/api/integration/linear/src/presentation/e2eRoutes/create-connection.ts
+++ b/libs/api/integration/linear/src/presentation/e2eRoutes/create-connection.ts
@@ -4,6 +4,7 @@ import {
   createE2eLinearConnectionResponseSchema,
 } from '@shipfox/api-integration-linear-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
+import {logger} from '@shipfox/node-opentelemetry';
 import type {ConnectLinearInstallationInput} from '#core/install.js';
 import type {LinearTokenStore} from '#core/tokens.js';
 import {toIntegrationConnectionDto} from '#presentation/dto/integrations.js';
@@ -59,7 +60,7 @@ export function createE2eLinearConnectionRoute(options: CreateE2eLinearConnectio
           accessToken: body.access_token,
         });
       } catch (error) {
-        if (!existing) await options.disconnectLinearInstallation({connectionId: connection.id});
+        if (!existing) await bestEffortDisconnectLinearInstallation(options, connection.id);
         throw error;
       }
 
@@ -67,4 +68,18 @@ export function createE2eLinearConnectionRoute(options: CreateE2eLinearConnectio
       return toIntegrationConnectionDto(connection, {capabilities: options.connectionCapabilities});
     },
   });
+}
+
+async function bestEffortDisconnectLinearInstallation(
+  options: CreateE2eLinearConnectionRouteOptions,
+  connectionId: string,
+): Promise<void> {
+  try {
+    await options.disconnectLinearInstallation({connectionId});
+  } catch (error) {
+    logger().warn(
+      {err: error, connectionId},
+      'Linear E2E connection compensation failed after token storage rejection',
+    );
+  }
 }

--- a/libs/api/integration/linear/src/presentation/e2eRoutes/create-connection.ts
+++ b/libs/api/integration/linear/src/presentation/e2eRoutes/create-connection.ts
@@ -1,0 +1,70 @@
+import type {IntegrationCapability, IntegrationConnection} from '@shipfox/api-integration-core-dto';
+import {
+  createE2eLinearConnectionBodySchema,
+  createE2eLinearConnectionResponseSchema,
+} from '@shipfox/api-integration-linear-dto';
+import {ClientError, defineRoute} from '@shipfox/node-fastify';
+import type {ConnectLinearInstallationInput} from '#core/install.js';
+import type {LinearTokenStore} from '#core/tokens.js';
+import {toIntegrationConnectionDto} from '#presentation/dto/integrations.js';
+
+export interface CreateE2eLinearConnectionRouteOptions {
+  tokenStore: Pick<LinearTokenStore, 'storeTokens'>;
+  getExistingLinearConnection: (input: {
+    organizationId: string;
+  }) => Promise<IntegrationConnection<'linear'> | undefined>;
+  connectLinearInstallation: (
+    input: ConnectLinearInstallationInput,
+  ) => Promise<IntegrationConnection<'linear'>>;
+  disconnectLinearInstallation: (input: {connectionId: string}) => Promise<void>;
+  connectionCapabilities: IntegrationCapability[];
+}
+
+export function createE2eLinearConnectionRoute(options: CreateE2eLinearConnectionRouteOptions) {
+  return defineRoute({
+    method: 'POST',
+    path: '/linear-connections',
+    description: 'Create a synthetic Linear connection for E2E tests.',
+    schema: {
+      body: createE2eLinearConnectionBodySchema,
+      response: {201: createE2eLinearConnectionResponseSchema},
+    },
+    handler: async (request, reply) => {
+      const body = request.body;
+      const existing = await options.getExistingLinearConnection({
+        organizationId: body.organization_id,
+      });
+      if (existing && existing.workspaceId !== body.workspace_id) {
+        throw new ClientError(
+          'Linear organization is already connected to another workspace',
+          'linear-connection-workspace-mismatch',
+          {status: 409},
+        );
+      }
+      const connection =
+        existing ??
+        (await options.connectLinearInstallation({
+          workspaceId: body.workspace_id,
+          organizationId: body.organization_id,
+          organizationUrlKey: body.organization_url_key,
+          appUserId: body.app_user_id,
+          scopes: body.scopes,
+          tokenExpiresAt: null,
+          displayName: body.display_name,
+        }));
+
+      try {
+        await options.tokenStore.storeTokens({
+          connectionId: connection.id,
+          accessToken: body.access_token,
+        });
+      } catch (error) {
+        if (!existing) await options.disconnectLinearInstallation({connectionId: connection.id});
+        throw error;
+      }
+
+      reply.code(201);
+      return toIntegrationConnectionDto(connection, {capabilities: options.connectionCapabilities});
+    },
+  });
+}

--- a/libs/api/integration/linear/src/presentation/e2eRoutes/index.test.ts
+++ b/libs/api/integration/linear/src/presentation/e2eRoutes/index.test.ts
@@ -89,8 +89,8 @@ describe('Linear E2E routes', () => {
     expect(res.json()).toMatchObject({code: 'validation-error'});
   });
 
-  it('removes a newly-created connection when token storage fails', async () => {
-    const disconnectLinearInstallation = vi.fn(() => Promise.resolve());
+  it('preserves the token storage error when cleanup of a new connection fails', async () => {
+    const disconnectLinearInstallation = vi.fn(() => Promise.reject(new Error('cleanup failed')));
     const app = await createApp({
       routes: [
         createLinearE2eRoutes({

--- a/libs/api/integration/linear/src/presentation/e2eRoutes/index.test.ts
+++ b/libs/api/integration/linear/src/presentation/e2eRoutes/index.test.ts
@@ -1,0 +1,193 @@
+import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
+import {closeApp, createApp} from '@shipfox/node-fastify';
+import {createLinearE2eRoutes} from './index.js';
+
+function connection(
+  overrides: Partial<IntegrationConnection<'linear'>> = {},
+): IntegrationConnection<'linear'> {
+  return {
+    id: '00000000-0000-4000-8000-000000000001',
+    workspaceId: '00000000-0000-4000-8000-000000000002',
+    provider: 'linear',
+    externalAccountId: 'linear-org',
+    slug: 'linear_acme',
+    displayName: 'Linear Acme',
+    lifecycleStatus: 'active',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe('Linear E2E routes', () => {
+  afterEach(async () => {
+    await closeApp();
+  });
+
+  it('creates a connection and stores its token without returning it', async () => {
+    const tokenStore = {storeTokens: vi.fn(() => Promise.resolve())};
+    const app = await createApp({
+      routes: [
+        createLinearE2eRoutes({
+          tokenStore,
+          getExistingLinearConnection: vi.fn(() => Promise.resolve(undefined)),
+          connectLinearInstallation: vi.fn(() => Promise.resolve(connection())),
+          disconnectLinearInstallation: vi.fn(() => Promise.resolve()),
+          connectionCapabilities: ['agent_tools'],
+        }),
+      ],
+      swagger: false,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/integrations/linear-connections',
+      payload: {
+        workspace_id: '00000000-0000-4000-8000-000000000002',
+        organization_id: 'linear-org',
+        organization_url_key: 'acme',
+        app_user_id: 'linear-app-user',
+        display_name: 'Linear Acme',
+        access_token: 'linear-e2e-token',
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.json()).toMatchObject({
+      id: '00000000-0000-4000-8000-000000000001',
+      provider: 'linear',
+      capabilities: ['agent_tools'],
+    });
+    expect(res.body).not.toContain('linear-e2e-token');
+    expect(tokenStore.storeTokens).toHaveBeenCalledWith({
+      connectionId: '00000000-0000-4000-8000-000000000001',
+      accessToken: 'linear-e2e-token',
+    });
+  });
+
+  it('rejects malformed connection bodies', async () => {
+    const app = await createApp({
+      routes: [
+        createLinearE2eRoutes({
+          tokenStore: {storeTokens: vi.fn(() => Promise.resolve())},
+          getExistingLinearConnection: vi.fn(() => Promise.resolve(undefined)),
+          connectLinearInstallation: vi.fn(() => Promise.resolve(connection())),
+          disconnectLinearInstallation: vi.fn(() => Promise.resolve()),
+          connectionCapabilities: ['agent_tools'],
+        }),
+      ],
+      swagger: false,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/integrations/linear-connections',
+      payload: {workspace_id: 'not-a-uuid'},
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toMatchObject({code: 'validation-error'});
+  });
+
+  it('removes a newly-created connection when token storage fails', async () => {
+    const disconnectLinearInstallation = vi.fn(() => Promise.resolve());
+    const app = await createApp({
+      routes: [
+        createLinearE2eRoutes({
+          tokenStore: {storeTokens: vi.fn(() => Promise.reject(new Error('token storage failed')))},
+          getExistingLinearConnection: vi.fn(() => Promise.resolve(undefined)),
+          connectLinearInstallation: vi.fn(() => Promise.resolve(connection())),
+          disconnectLinearInstallation,
+          connectionCapabilities: ['agent_tools'],
+        }),
+      ],
+      swagger: false,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/integrations/linear-connections',
+      payload: {
+        workspace_id: '00000000-0000-4000-8000-000000000002',
+        organization_id: 'linear-org',
+        organization_url_key: 'acme',
+        app_user_id: 'linear-app-user',
+        display_name: 'Linear Acme',
+        access_token: 'linear-e2e-token',
+      },
+    });
+
+    expect(res.statusCode).toBe(500);
+    expect(disconnectLinearInstallation).toHaveBeenCalledWith({
+      connectionId: '00000000-0000-4000-8000-000000000001',
+    });
+  });
+
+  it('leaves an existing connection unchanged when token storage fails', async () => {
+    const connectLinearInstallation = vi.fn(() => Promise.resolve(connection()));
+    const disconnectLinearInstallation = vi.fn(() => Promise.resolve());
+    const app = await createApp({
+      routes: [
+        createLinearE2eRoutes({
+          tokenStore: {storeTokens: vi.fn(() => Promise.reject(new Error('token storage failed')))},
+          getExistingLinearConnection: vi.fn(() => Promise.resolve(connection())),
+          connectLinearInstallation,
+          disconnectLinearInstallation,
+          connectionCapabilities: ['agent_tools'],
+        }),
+      ],
+      swagger: false,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/integrations/linear-connections',
+      payload: {
+        workspace_id: '00000000-0000-4000-8000-000000000002',
+        organization_id: 'linear-org',
+        organization_url_key: 'changed-acme',
+        app_user_id: 'changed-linear-app-user',
+        display_name: 'Changed Linear Acme',
+        access_token: 'linear-e2e-token',
+      },
+    });
+
+    expect(res.statusCode).toBe(500);
+    expect(connectLinearInstallation).not.toHaveBeenCalled();
+    expect(disconnectLinearInstallation).not.toHaveBeenCalled();
+  });
+
+  it('rejects a Linear organization already connected to another workspace', async () => {
+    const existing = connection({workspaceId: '00000000-0000-4000-8000-000000000003'});
+    const connectLinearInstallation = vi.fn(() => Promise.resolve(connection()));
+    const app = await createApp({
+      routes: [
+        createLinearE2eRoutes({
+          tokenStore: {storeTokens: vi.fn(() => Promise.resolve())},
+          getExistingLinearConnection: vi.fn(() => Promise.resolve(existing)),
+          connectLinearInstallation,
+          disconnectLinearInstallation: vi.fn(() => Promise.resolve()),
+          connectionCapabilities: ['agent_tools'],
+        }),
+      ],
+      swagger: false,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/integrations/linear-connections',
+      payload: {
+        workspace_id: '00000000-0000-4000-8000-000000000002',
+        organization_id: 'linear-org',
+        organization_url_key: 'acme',
+        app_user_id: 'linear-app-user',
+        display_name: 'Linear Acme',
+        access_token: 'linear-e2e-token',
+      },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json()).toMatchObject({code: 'linear-connection-workspace-mismatch'});
+    expect(connectLinearInstallation).not.toHaveBeenCalled();
+  });
+});

--- a/libs/api/integration/linear/src/presentation/e2eRoutes/index.ts
+++ b/libs/api/integration/linear/src/presentation/e2eRoutes/index.ts
@@ -1,0 +1,14 @@
+import type {RouteGroup} from '@shipfox/node-fastify';
+import {
+  type CreateE2eLinearConnectionRouteOptions,
+  createE2eLinearConnectionRoute,
+} from './create-connection.js';
+
+export type CreateLinearE2eRoutesOptions = CreateE2eLinearConnectionRouteOptions;
+
+export function createLinearE2eRoutes(options: CreateLinearE2eRoutesOptions): RouteGroup {
+  return {
+    prefix: '/integrations',
+    routes: [createE2eLinearConnectionRoute(options)],
+  };
+}

--- a/libs/api/integration/linear/test/env.ts
+++ b/libs/api/integration/linear/test/env.ts
@@ -9,5 +9,5 @@ process.env.LINEAR_OAUTH_CLIENT_ID = 'test-client-id';
 process.env.LINEAR_OAUTH_CLIENT_SECRET = 'test-client-secret';
 process.env.LINEAR_WEBHOOK_SIGNING_SECRET = 'test-webhook-secret';
 process.env.LINEAR_OAUTH_REDIRECT_URL = 'https://shipfox.example.com/integrations/linear/callback';
-process.env.LINEAR_MCP_ENDPOINT = 'https://mcp.linear.app/mcp';
+process.env.LINEAR_MCP_ENDPOINT = 'http://127.0.0.1:0/mcp';
 process.env.SECRETS_ENCRYPTION_KEK = 'ZmVkY2JhOTg3NjU0MzIxMGZlZGNiYTk4NzY1NDMyMTA=';

--- a/libs/api/integration/linear/test/env.ts
+++ b/libs/api/integration/linear/test/env.ts
@@ -9,4 +9,5 @@ process.env.LINEAR_OAUTH_CLIENT_ID = 'test-client-id';
 process.env.LINEAR_OAUTH_CLIENT_SECRET = 'test-client-secret';
 process.env.LINEAR_WEBHOOK_SIGNING_SECRET = 'test-webhook-secret';
 process.env.LINEAR_OAUTH_REDIRECT_URL = 'https://shipfox.example.com/integrations/linear/callback';
+process.env.LINEAR_MCP_ENDPOINT = 'https://mcp.linear.app/mcp';
 process.env.SECRETS_ENCRYPTION_KEK = 'ZmVkY2JhOTg3NjU0MzIxMGZlZGNiYTk4NzY1NDMyMTA=';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -748,6 +748,34 @@ importers:
         specifier: workspace:*
         version: link:../../../tools/vitest
 
+  e2e/setup/integrations:
+    dependencies:
+      '@shipfox/api-integration-linear-dto':
+        specifier: workspace:*
+        version: link:../../../libs/api/integration/linear-dto
+      '@shipfox/e2e-core':
+        specifier: workspace:*
+        version: link:../../core
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/depcruise':
+        specifier: workspace:*
+        version: link:../../../tools/depcruise
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../tools/vitest
+
   e2e/setup/projects:
     dependencies:
       '@shipfox/api-projects-dto':
@@ -1119,9 +1147,15 @@ importers:
 
   e2e/suites/flow/workflows:
     devDependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: 1.29.0
+        version: 1.29.0(zod@4.4.3)
       '@shipfox/api-definitions-dto':
         specifier: workspace:*
         version: link:../../../../libs/api/definitions-dto
+      '@shipfox/api-integration-linear-dto':
+        specifier: workspace:*
+        version: link:../../../../libs/api/integration/linear-dto
       '@shipfox/api-integration-webhook-dto':
         specifier: workspace:*
         version: link:../../../../libs/api/integration/webhook-dto
@@ -1170,6 +1204,9 @@ importers:
       '@shipfox/e2e-setup-auth':
         specifier: workspace:*
         version: link:../../../setup/auth
+      '@shipfox/e2e-setup-integrations':
+        specifier: workspace:*
+        version: link:../../../setup/integrations
       '@shipfox/e2e-setup-secrets':
         specifier: workspace:*
         version: link:../../../setup/secrets


### PR DESCRIPTION
Add deterministic full-loop coverage for Linear agent tools, including a local Streamable HTTP MCP mock, synthetic E2E connection setup, and a configurable Linear MCP endpoint.

Linear's hosted MCP proxy was previously covered below the harness boundary, but no test proved a selected Linear read and write tool could travel through workflow materialization, the leased gateway, runner bridge, Claude, and return their results to the model. This closes that evidence gap without contacting mcp.linear.app.

The mock stays suite-local rather than becoming a shared driver because it has a single consumer. The E2E connection route remains protected by the existing E2E admin gate and compensates newly-created connections when token storage fails.

Closes ENG-878

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a deterministic, end-to-end test for Linear agent tools using a local Streamable HTTP MCP mock and a protected E2E connection route. Hardens feedback and MCP endpoint handling so the test runs locally without calling `mcp.linear.app` (ENG-878).

- **New Features**
  - Local MCP mock with `get_issue` and `save_comment` tools that return fixed markers; Bearer token auth; clear errors if the port is occupied.
  - Full-loop E2E test that selects Linear tools with `allow_write: true` and asserts tool result text using a new `message_content_includes` assertion that works for Anthropic and OpenAI tool-result shapes and only consumes a script when matched.
  - Protected E2E API `POST /__e2e/integrations/linear-connections` to create synthetic Linear connections; rejects workspace mismatches and compensates connection creation on token storage failure. Exposed via `createLinearE2eRoutes`.
  - Configurable `LINEAR_MCP_ENDPOINT` (defaults to `https://mcp.linear.app/mcp`); E2E/dev derive a local endpoint on `127.0.0.1` from the API port with a safe offset and pass it to the Linear provider’s agent tools. Linear provider is enabled in E2E by default.

- **Dependencies**
  - Added `@modelcontextprotocol/sdk`.
  - Added internal `@shipfox/e2e-setup-integrations` package for E2E connection setup.

<sup>Written for commit acf60d82a761569fc74d7a625ecf45cfe196e9f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

