### PR TITLE
Add full-loop E2E coverage for GitHub agent tools

### DIFF
--- a/dev/e2e.mjs
+++ b/dev/e2e.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import {spawn, spawnSync} from 'node:child_process';
+import {generateKeyPairSync} from 'node:crypto';
 import {closeSync, openSync} from 'node:fs';
 import {cp, mkdir, readdir, stat} from 'node:fs/promises';
 import {dirname, join, resolve} from 'node:path';
@@ -12,6 +13,7 @@ const defaultReadinessTimeoutMs = 60_000;
 const defaultShutdownTimeoutMs = 15_000;
 const defaultTurboTask = 'test:e2e';
 const trailingSlashPattern = /\/$/;
+let generatedGithubAppPrivateKey;
 
 if (isCliEntryPoint()) {
   main(process.argv.slice(2)).catch((error) => {
@@ -170,6 +172,7 @@ export function e2eEnv(sourceEnv) {
   const clientUrl = sourceEnv.CLIENT_URL ?? sourceEnv.CLIENT_BASE_URL ?? defaultClientUrl;
   const giteaUrl = sourceEnv.E2E_GITEA_URL ?? sourceEnv.GITEA_BASE_URL ?? 'http://localhost:3000';
   const linearMcpEndpoint = sourceEnv.LINEAR_MCP_ENDPOINT ?? e2eLinearMcpEndpoint(apiUrl);
+  const githubApiBaseUrl = sourceEnv.GITHUB_API_BASE_URL ?? e2eGithubApiBaseUrl(apiUrl);
   return {
     ...sourceEnv,
     API_URL: apiUrl,
@@ -180,6 +183,19 @@ export function e2eEnv(sourceEnv) {
     E2E_GITEA_URL: giteaUrl,
     GITEA_CLONE_BASE_URL: sourceEnv.GITEA_CLONE_BASE_URL ?? giteaUrl,
     HOST: sourceEnv.HOST ?? '0.0.0.0',
+    GITHUB_API_BASE_URL: githubApiBaseUrl,
+    GITHUB_APP_CLIENT_ID: sourceEnv.GITHUB_APP_CLIENT_ID ?? 'e2e-github-client-id',
+    GITHUB_APP_CLIENT_SECRET: sourceEnv.GITHUB_APP_CLIENT_SECRET ?? 'e2e-github-client-secret',
+    GITHUB_APP_ID: sourceEnv.GITHUB_APP_ID ?? '1',
+    GITHUB_APP_PRIVATE_KEY:
+      sourceEnv.GITHUB_APP_PRIVATE_KEY ?? e2eGithubAppPrivateKey(),
+    GITHUB_APP_SLUG: sourceEnv.GITHUB_APP_SLUG ?? 'shipfox-e2e',
+    GITHUB_APP_USERNAME: sourceEnv.GITHUB_APP_USERNAME ?? 'shipfox-e2e',
+    GITHUB_APP_WEBHOOK_SECRET:
+      sourceEnv.GITHUB_APP_WEBHOOK_SECRET ?? 'e2e-github-webhook-secret',
+    GITHUB_INSTALL_STATE_SECRET:
+      sourceEnv.GITHUB_INSTALL_STATE_SECRET ?? 'e2e-github-install-state-secret',
+    INTEGRATIONS_ENABLE_GITHUB_PROVIDER: sourceEnv.INTEGRATIONS_ENABLE_GITHUB_PROVIDER ?? 'true',
     INTEGRATIONS_ENABLE_LINEAR_PROVIDER: sourceEnv.INTEGRATIONS_ENABLE_LINEAR_PROVIDER ?? 'true',
     LINEAR_MCP_ENDPOINT: linearMcpEndpoint,
     LINEAR_OAUTH_CLIENT_ID: sourceEnv.LINEAR_OAUTH_CLIENT_ID ?? 'e2e-linear-client-id',
@@ -193,6 +209,30 @@ export function e2eEnv(sourceEnv) {
     VITE_ENABLE_TEST_VCS_PROVIDER: sourceEnv.VITE_ENABLE_TEST_VCS_PROVIDER ?? 'true',
     WEBHOOK_PUBLIC_URL: sourceEnv.WEBHOOK_PUBLIC_URL ?? apiUrl,
   };
+}
+
+export function e2eGithubApiBaseUrl(apiUrl) {
+  const endpoint = new URL(apiUrl);
+  const apiPort = Number(endpoint.port || (endpoint.protocol === 'https:' ? 443 : 80));
+  const githubApiPort = apiPort + 10;
+  if (githubApiPort > 65_535) {
+    throw new Error(`Cannot derive a GitHub API port from API port ${apiPort}.`);
+  }
+  endpoint.hostname = '127.0.0.1';
+  endpoint.port = String(githubApiPort);
+  endpoint.pathname = '/';
+  endpoint.search = '';
+  endpoint.hash = '';
+  return endpoint.toString();
+}
+
+function e2eGithubAppPrivateKey() {
+  generatedGithubAppPrivateKey ??= generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    privateKeyEncoding: {format: 'pem', type: 'pkcs8'},
+    publicKeyEncoding: {format: 'pem', type: 'spki'},
+  }).privateKey;
+  return generatedGithubAppPrivateKey;
 }
 
 export function e2eLinearMcpEndpoint(apiUrl) {

--- a/dev/e2e.test.mjs
+++ b/dev/e2e.test.mjs
@@ -65,6 +65,9 @@ describe('e2eEnv', () => {
     assert.equal(env.E2E_GITEA_URL, 'http://localhost:55356');
     assert.equal(env.GITEA_CLONE_BASE_URL, 'http://localhost:55356');
     assert.equal(env.INTEGRATIONS_ENABLE_LINEAR_PROVIDER, 'true');
+    assert.equal(env.INTEGRATIONS_ENABLE_GITHUB_PROVIDER, 'true');
+    assert.equal(env.GITHUB_API_BASE_URL, 'http://127.0.0.1:55361/');
+    assert.match(env.GITHUB_APP_PRIVATE_KEY, /BEGIN PRIVATE KEY/u);
     assert.equal(env.LINEAR_MCP_ENDPOINT, 'http://127.0.0.1:55360/mcp');
     assert.equal(env.LINEAR_OAUTH_CLIENT_ID, 'e2e-linear-client-id');
     assert.equal(env.SHIPFOX_TURBO_CONCURRENCY, undefined);
@@ -79,6 +82,7 @@ describe('e2eEnv', () => {
       E2E_GITEA_URL: 'http://localhost:3001',
       GITEA_CLONE_BASE_URL: 'http://localhost:3000',
       LINEAR_MCP_ENDPOINT: 'http://127.0.0.1:16120/mcp',
+      GITHUB_API_BASE_URL: 'http://127.0.0.1:16121',
       SHIPFOX_API_URL: 'http://localhost:55351',
       GITEA_BASE_URL: 'http://localhost:55356',
       WEBHOOK_PUBLIC_URL: 'https://webhooks.example.test',
@@ -89,6 +93,7 @@ describe('e2eEnv', () => {
     assert.equal(env.E2E_GITEA_URL, 'http://localhost:3001');
     assert.equal(env.GITEA_CLONE_BASE_URL, 'http://localhost:3000');
     assert.equal(env.LINEAR_MCP_ENDPOINT, 'http://127.0.0.1:16120/mcp');
+    assert.equal(env.GITHUB_API_BASE_URL, 'http://127.0.0.1:16121');
     assert.equal(env.WEBHOOK_PUBLIC_URL, 'https://webhooks.example.test');
   });
 
@@ -104,6 +109,13 @@ describe('e2eEnv', () => {
     assert.throws(
       () => e2eEnv({API_URL: 'http://localhost:65527'}),
       /Cannot derive a Linear MCP port/u,
+    );
+  });
+
+  test('rejects an API port that cannot reserve the GitHub API offset', () => {
+    assert.throws(
+      () => e2eEnv({API_URL: 'http://localhost:65526'}),
+      /Cannot derive a GitHub API port/u,
     );
   });
 });

--- a/dev/worktree-services.mjs
+++ b/dev/worktree-services.mjs
@@ -137,6 +137,7 @@ export function portsFromBase(base) {
     otelInstance: base + 8,
     otelService: base + 9,
     linearMcp: base + 10,
+    githubApi: base + 11,
   };
 }
 
@@ -155,6 +156,7 @@ function portsFromEnv(env) {
     otelInstance: numberFromEnv(env, 'SHIPFOX_OTEL_INSTANCE_METRICS_PORT'),
     otelService: numberFromEnv(env, 'SHIPFOX_OTEL_SERVICE_METRICS_PORT'),
     linearMcp: optionalNumberFromEnv(env, 'SHIPFOX_LINEAR_MCP_PORT') ?? base + 10,
+    githubApi: optionalNumberFromEnv(env, 'SHIPFOX_GITHUB_API_PORT') ?? base + 11,
   };
   return ports;
 }
@@ -185,6 +187,7 @@ function portEnv(ports) {
     SHIPFOX_OTEL_INSTANCE_METRICS_PORT: String(ports.otelInstance),
     SHIPFOX_OTEL_SERVICE_METRICS_PORT: String(ports.otelService),
     SHIPFOX_LINEAR_MCP_PORT: String(ports.linearMcp),
+    SHIPFOX_GITHUB_API_PORT: String(ports.githubApi),
   };
 }
 
@@ -210,6 +213,7 @@ export function appEnv(ports) {
     POSTGRES_DATABASE: 'api',
     TEMPORAL_ADDRESS: `localhost:${ports.temporal}`,
     GITEA_BASE_URL: `http://localhost:${ports.giteaHttp}`,
+    GITHUB_API_BASE_URL: `http://127.0.0.1:${ports.githubApi}`,
     LOG_STORAGE_S3_ENDPOINT: `http://localhost:${ports.garageS3}`,
     LINEAR_MCP_ENDPOINT: `http://127.0.0.1:${ports.linearMcp}/mcp`,
     OTEL_INSTANCE_METRICS_PORT: String(ports.otelInstance),

--- a/dev/worktree-services.test.mjs
+++ b/dev/worktree-services.test.mjs
@@ -33,6 +33,7 @@ describe('portsFromBase', () => {
       otelInstance: 65_008,
       otelService: 65_009,
       linearMcp: 65_010,
+      githubApi: 65_011,
     });
   });
 });
@@ -75,6 +76,7 @@ describe('appEnv', () => {
     assert.equal(env.SHIPFOX_PROVISIONER_DOCKER_EXTRA_HOSTS, 'host.docker.internal:host-gateway');
     assert.equal(env.SHIPFOX_DOCS_PORT, '55294');
     assert.equal(env.LINEAR_MCP_ENDPOINT, 'http://127.0.0.1:55300/mcp');
+    assert.equal(env.GITHUB_API_BASE_URL, 'http://127.0.0.1:55301');
   });
 });
 

--- a/e2e/drivers/model-provider/src/scripts.ts
+++ b/e2e/drivers/model-provider/src/scripts.ts
@@ -40,6 +40,10 @@ export type FakeOpenAiRequestAssertion = (
       name: string;
     }
   | {
+      kind: 'tool_absent';
+      name: string;
+    }
+  | {
       kind: 'message_content_includes';
       value: string;
     }
@@ -399,7 +403,13 @@ function assertRequest(
     }
 
     if (assertion.kind === 'tool_present' && !summary.tools.includes(assertion.name)) {
-      return [`Expected tool ${assertion.name} to be present`];
+      return [
+        `Expected tool ${assertion.name} to be present; received ${summary.tools.join(', ') || '<none>'}`,
+      ];
+    }
+
+    if (assertion.kind === 'tool_absent' && summary.tools.includes(assertion.name)) {
+      return [`Expected tool ${assertion.name} to be absent`];
     }
 
     if (

--- a/e2e/drivers/model-provider/src/server.test.ts
+++ b/e2e/drivers/model-provider/src/server.test.ts
@@ -486,7 +486,31 @@ describe('fake OpenAI model provider server', () => {
     expect(workflowResult.status).toBe(422);
     await expect(workflowResult.json()).resolves.toEqual({
       error: {
-        message: 'Expected tool set_output to be present',
+        message: 'Expected tool set_output to be present; received <none>',
+        type: 'script_assertion_failed',
+      },
+    });
+  });
+
+  it('rejects requests that advertise an explicitly absent tool', async () => {
+    await postScript(
+      server,
+      fakeScript({
+        id: 'absent-tool',
+        assertions: [{kind: 'tool_absent', name: 'add_issue_comment'}],
+      }),
+    );
+
+    const result = await chatCompletion(server, 'absent-tool', {
+      model: 'deterministic-output-agent',
+      messages: [{role: 'user'}],
+      tools: [{type: 'function', function: {name: 'add_issue_comment', parameters: {}}}],
+    });
+
+    expect(result.status).toBe(422);
+    await expect(result.json()).resolves.toEqual({
+      error: {
+        message: 'Expected tool add_issue_comment to be absent',
         type: 'script_assertion_failed',
       },
     });

--- a/e2e/setup/agent/src/index.ts
+++ b/e2e/setup/agent/src/index.ts
@@ -121,6 +121,10 @@ export type FakeModelProviderRequestAssertion = (
       name: string;
     }
   | {
+      kind: 'tool_absent';
+      name: string;
+    }
+  | {
       kind: 'message_content_includes';
       value: string;
     }

--- a/e2e/setup/integrations/package.json
+++ b/e2e/setup/integrations/package.json
@@ -37,6 +37,7 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
+    "@shipfox/api-integration-github-dto": "workspace:*",
     "@shipfox/api-integration-linear-dto": "workspace:*",
     "@shipfox/e2e-core": "workspace:*"
   },

--- a/e2e/setup/integrations/src/index.test.ts
+++ b/e2e/setup/integrations/src/index.test.ts
@@ -35,4 +35,27 @@ describe('integrations E2E setup helper', () => {
       },
     });
   });
+
+  it('creates GitHub connections through the protected setup route', async () => {
+    requestJson.mockResolvedValueOnce({id: 'connection-id'});
+    const {createGithubConnection} = await import('./index.js');
+
+    await createGithubConnection({
+      workspaceId: '00000000-0000-4000-8000-000000000001',
+      installationId: 1234,
+      accountLogin: 'shipfox-e2e',
+      displayName: 'GitHub Shipfox E2E',
+      installerUserId: '00000000-0000-4000-8000-000000000002',
+    });
+
+    expect(requestJson).toHaveBeenCalledWith('post', '/__e2e/integrations/github-connections', {
+      json: {
+        workspace_id: '00000000-0000-4000-8000-000000000001',
+        installation_id: 1234,
+        account_login: 'shipfox-e2e',
+        display_name: 'GitHub Shipfox E2E',
+        installer_user_id: '00000000-0000-4000-8000-000000000002',
+      },
+    });
+  });
 });

--- a/e2e/setup/integrations/src/index.ts
+++ b/e2e/setup/integrations/src/index.ts
@@ -1,13 +1,51 @@
 import type {
+  CreateE2eGithubConnectionBodyDto,
+  CreateE2eGithubConnectionResponseDto,
+} from '@shipfox/api-integration-github-dto';
+import type {
   CreateE2eLinearConnectionBodyDto,
   CreateE2eLinearConnectionResponseDto,
 } from '@shipfox/api-integration-linear-dto';
 import {requestJson} from '@shipfox/e2e-core';
 
 export type {
+  CreateE2eGithubConnectionBodyDto,
+  CreateE2eGithubConnectionResponseDto,
+} from '@shipfox/api-integration-github-dto';
+export type {
   CreateE2eLinearConnectionBodyDto,
   CreateE2eLinearConnectionResponseDto,
 } from '@shipfox/api-integration-linear-dto';
+
+export interface CreateGithubConnectionParams {
+  workspaceId: string;
+  installationId: number;
+  accountLogin: string;
+  displayName: string;
+  installerUserId: string;
+}
+
+function githubConnectionBody(
+  params: CreateGithubConnectionParams,
+): CreateE2eGithubConnectionBodyDto {
+  return {
+    workspace_id: params.workspaceId,
+    installation_id: params.installationId,
+    account_login: params.accountLogin,
+    display_name: params.displayName,
+    installer_user_id: params.installerUserId,
+  };
+}
+
+export async function createGithubConnection(
+  params: CreateGithubConnectionParams,
+): Promise<CreateE2eGithubConnectionResponseDto> {
+  return await requestJson<CreateE2eGithubConnectionResponseDto>(
+    'post',
+    '/__e2e/integrations/github-connections',
+    {json: githubConnectionBody(params)},
+  );
+}
 
 export interface CreateLinearConnectionParams {
   workspaceId: string;

--- a/e2e/suites/flow/workflows/package.json
+++ b/e2e/suites/flow/workflows/package.json
@@ -13,6 +13,7 @@
     "#attachments.js": "./src/attachments.ts",
     "#create-project.js": "./src/create-project.ts",
     "#expect.js": "./src/expect.ts",
+    "#github-api.js": "./src/github-api.ts",
     "#listener-helpers.js": "./src/listener-helpers.ts",
     "#listener-jobs.js": "./src/listener-jobs.ts",
     "#linear-mcp.js": "./src/linear-mcp.ts",
@@ -37,6 +38,7 @@
   "devDependencies": {
     "@shipfox/api-definitions-dto": "workspace:*",
     "@shipfox/api-integration-webhook-dto": "workspace:*",
+    "@shipfox/api-integration-github-dto": "workspace:*",
     "@shipfox/api-integration-linear-dto": "workspace:*",
     "@shipfox/api-logs-dto": "workspace:*",
     "@shipfox/api-projects-dto": "workspace:*",

--- a/e2e/suites/flow/workflows/src/github-api.test.ts
+++ b/e2e/suites/flow/workflows/src/github-api.test.ts
@@ -1,0 +1,63 @@
+import {
+  GITHUB_INSTALLATION_TOKEN,
+  GITHUB_READ_RESULT_MARKER,
+  GITHUB_WRITE_RESULT_MARKER,
+  startGithubApiMock,
+} from './github-api.js';
+
+describe('GitHub API mock', () => {
+  it('serves installation-token, issue-read, and issue-write requests', async () => {
+    const mock = await startGithubApiMock(new URL('http://127.0.0.1:0'));
+
+    try {
+      const mint = await fetch(new URL('/app/installations/1234/access_tokens', mock.endpoint), {
+        method: 'POST',
+        headers: {authorization: 'Bearer app-jwt', 'content-type': 'application/json'},
+        body: '{}',
+      });
+      const read = await fetch(new URL('/repos/shipfox/e2e/issues/1', mock.endpoint), {
+        headers: {authorization: `token ${GITHUB_INSTALLATION_TOKEN}`},
+      });
+      const write = await fetch(new URL('/repos/shipfox/e2e/issues', mock.endpoint), {
+        method: 'POST',
+        headers: {
+          authorization: `token ${GITHUB_INSTALLATION_TOKEN}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({title: 'Synthetic issue'}),
+      });
+
+      expect(mint.status).toBe(201);
+      await expect(mint.json()).resolves.toMatchObject({
+        token: GITHUB_INSTALLATION_TOKEN,
+        permissions: {issues: 'write'},
+      });
+      await expect(read.json()).resolves.toMatchObject({marker: GITHUB_READ_RESULT_MARKER});
+      await expect(write.json()).resolves.toMatchObject({marker: GITHUB_WRITE_RESULT_MARKER});
+      expect(mock.calls).toEqual([
+        {
+          kind: 'mint-token',
+          authorization: 'Bearer app-jwt',
+          installationId: 1234,
+          body: {},
+        },
+        {
+          kind: 'read-issue',
+          authorization: `token ${GITHUB_INSTALLATION_TOKEN}`,
+          owner: 'shipfox',
+          repo: 'e2e',
+          issueNumber: 1,
+        },
+        {
+          kind: 'create-issue',
+          authorization: `token ${GITHUB_INSTALLATION_TOKEN}`,
+          owner: 'shipfox',
+          repo: 'e2e',
+          body: {title: 'Synthetic issue'},
+        },
+      ]);
+    } finally {
+      await mock.stop();
+    }
+  });
+});

--- a/e2e/suites/flow/workflows/src/github-api.ts
+++ b/e2e/suites/flow/workflows/src/github-api.ts
@@ -1,0 +1,167 @@
+import {once} from 'node:events';
+import {
+  createServer,
+  type Server as HttpServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from 'node:http';
+
+export const GITHUB_INSTALLATION_TOKEN = 'github-e2e-installation-token';
+export const GITHUB_READ_RESULT_MARKER = 'github-read-result-marker';
+export const GITHUB_WRITE_RESULT_MARKER = 'github-write-result-marker';
+
+const INSTALLATION_TOKEN_PATH = /^\/app\/installations\/(\d+)\/access_tokens$/u;
+const ISSUE_PATH = /^\/repos\/([^/]+)\/([^/]+)\/issues\/(\d+)$/u;
+const ISSUES_PATH = /^\/repos\/([^/]+)\/([^/]+)\/issues$/u;
+
+export type GithubApiMockCall =
+  | {
+      kind: 'mint-token';
+      authorization: string | undefined;
+      installationId: number;
+      body: Record<string, unknown>;
+    }
+  | {
+      kind: 'read-issue';
+      authorization: string | undefined;
+      owner: string;
+      repo: string;
+      issueNumber: number;
+    }
+  | {
+      kind: 'create-issue';
+      authorization: string | undefined;
+      owner: string;
+      repo: string;
+      body: Record<string, unknown>;
+    };
+
+export interface GithubApiMock {
+  calls: GithubApiMockCall[];
+  endpoint: URL;
+  stop(): Promise<void>;
+}
+
+export async function startGithubApiMock(
+  endpoint = new URL(requiredGithubApiBaseUrl()),
+): Promise<GithubApiMock> {
+  const calls: GithubApiMockCall[] = [];
+  let boundEndpoint = endpoint;
+  const server = createServer((request, response) => {
+    void handleGithubRequest({calls, endpoint: boundEndpoint, request, response});
+  });
+
+  try {
+    boundEndpoint = await listen(server, endpoint);
+  } catch (error) {
+    throw new Error(`GitHub API mock failed to start at ${endpoint}`, {cause: error});
+  }
+
+  return {
+    calls,
+    endpoint: boundEndpoint,
+    stop: async () => {
+      try {
+        await close(server);
+      } catch (error) {
+        throw new Error(`GitHub API mock failed to stop at ${boundEndpoint}`, {cause: error});
+      }
+    },
+  };
+}
+
+async function handleGithubRequest(params: {
+  calls: GithubApiMockCall[];
+  endpoint: URL;
+  request: IncomingMessage;
+  response: ServerResponse;
+}): Promise<void> {
+  const requestUrl = new URL(params.request.url ?? '/', params.endpoint);
+  const authorization = params.request.headers.authorization;
+  const mintMatch = requestUrl.pathname.match(INSTALLATION_TOKEN_PATH);
+  const issueMatch = requestUrl.pathname.match(ISSUE_PATH);
+  const createIssueMatch = requestUrl.pathname.match(ISSUES_PATH);
+
+  if (params.request.method === 'POST' && mintMatch) {
+    params.calls.push({
+      kind: 'mint-token',
+      authorization,
+      installationId: Number(mintMatch[1]),
+      body: await readJsonBody(params.request),
+    });
+    sendJson(params.response, 201, {
+      token: GITHUB_INSTALLATION_TOKEN,
+      expires_at: '2099-01-01T00:00:00.000Z',
+      permissions: {issues: 'write'},
+      repository_selection: 'all',
+    });
+    return;
+  }
+
+  if (params.request.method === 'GET' && issueMatch) {
+    params.calls.push({
+      kind: 'read-issue',
+      authorization,
+      owner: decodeURIComponent(issueMatch[1] ?? ''),
+      repo: decodeURIComponent(issueMatch[2] ?? ''),
+      issueNumber: Number(issueMatch[3]),
+    });
+    sendJson(params.response, 200, {
+      number: Number(issueMatch[3]),
+      title: 'Synthetic GitHub issue',
+      marker: GITHUB_READ_RESULT_MARKER,
+    });
+    return;
+  }
+
+  if (params.request.method === 'POST' && createIssueMatch) {
+    params.calls.push({
+      kind: 'create-issue',
+      authorization,
+      owner: decodeURIComponent(createIssueMatch[1] ?? ''),
+      repo: decodeURIComponent(createIssueMatch[2] ?? ''),
+      body: await readJsonBody(params.request),
+    });
+    sendJson(params.response, 201, {
+      number: 2,
+      marker: GITHUB_WRITE_RESULT_MARKER,
+    });
+    return;
+  }
+
+  sendJson(params.response, 404, {message: 'Not Found'});
+}
+
+function requiredGithubApiBaseUrl(): string {
+  const endpoint = process.env.GITHUB_API_BASE_URL;
+  if (!endpoint) throw new Error('GITHUB_API_BASE_URL must be configured for the GitHub API mock.');
+  return endpoint;
+}
+
+async function listen(server: HttpServer, endpoint: URL): Promise<URL> {
+  server.listen({host: endpoint.hostname, port: Number(endpoint.port)});
+  await once(server, 'listening');
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('Expected TCP server address.');
+  const boundEndpoint = new URL(endpoint);
+  boundEndpoint.port = String(address.port);
+  return boundEndpoint;
+}
+
+async function close(server: HttpServer): Promise<void> {
+  server.close();
+  await once(server, 'close');
+}
+
+async function readJsonBody(request: NodeJS.ReadableStream): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  const body = Buffer.concat(chunks).toString('utf8');
+  return body === '' ? {} : (JSON.parse(body) as Record<string, unknown>);
+}
+
+function sendJson(response: ServerResponse, statusCode: number, body: unknown): void {
+  response.writeHead(statusCode, {'content-type': 'application/json'}).end(JSON.stringify(body));
+}

--- a/e2e/suites/flow/workflows/tests/github-agent-tools.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/github-agent-tools.e2e.ts
@@ -1,0 +1,263 @@
+import {createApiClient} from '@shipfox/e2e-core';
+import {message, startFakeOpenAiModelProvider, toolCall} from '@shipfox/e2e-driver-model-provider';
+import {stopLocalRunner} from '@shipfox/e2e-driver-runner-process';
+import {createAnthropicFakeModelProviderConfig} from '@shipfox/e2e-setup-agent';
+import {createGithubConnection} from '@shipfox/e2e-setup-integrations';
+import {
+  attachLocalRunnerLog,
+  collectStepLogAttachmentRequests,
+  fetchLogAttachment,
+} from '#attachments.js';
+import {
+  GITHUB_INSTALLATION_TOKEN,
+  GITHUB_READ_RESULT_MARKER,
+  GITHUB_WRITE_RESULT_MARKER,
+  startGithubApiMock,
+} from '#github-api.js';
+import {startSuiteLocalRunner, waitForRunTerminalOrFailedRunner} from '#runner.js';
+import type {SuiteContext} from '#suite-context.js';
+import {fireManualAndAwaitRun} from '#triggers.js';
+import {seedAndWaitForDefinition} from '#workflow-project.js';
+import {expect, test} from './fixtures.js';
+
+const CLAUDE_AGENT_MODEL = 'deterministic-github-tools-agent';
+const TERMINAL_TIMEOUT_MS = 60_000;
+const BEARER_AUTHORIZATION = /^bearer /iu;
+
+test.describe.configure({mode: 'serial'});
+
+test('runs selected GitHub tools and denies unselected authority', async ({suite}, testInfo) => {
+  const uniqueId = crypto.randomUUID().replaceAll('-', '').slice(0, 10);
+  const installationId = Number.parseInt(uniqueId.slice(0, 7), 16) + 1;
+  const githubApi = await startGithubApiMock();
+  let fakeModelProvider: Awaited<ReturnType<typeof startFakeOpenAiModelProvider>> | undefined;
+
+  try {
+    const scriptId = `${suite.runId}-github-agent-tools-${uniqueId}`;
+    fakeModelProvider = await startFakeOpenAiModelProvider({
+      runId: `${suite.runId}-github-agent-tools-${uniqueId}`,
+    });
+    const connection = await createGithubConnection({
+      workspaceId: suite.workspaceId,
+      installationId,
+      accountLogin: `e${uniqueId.slice(0, 5)}`,
+      displayName: `GitHub E2E ${uniqueId}`,
+      installerUserId: crypto.randomUUID(),
+    });
+    const issueReadTool = `mcp__shipfox_integration_tools__${connection.slug}__issue_read`;
+    const issueWriteTool = `mcp__shipfox_integration_tools__${connection.slug}__issue_write`;
+    const addIssueCommentTool = `mcp__shipfox_integration_tools__${connection.slug}__add_issue_comment`;
+    const fakeAnthropic = await createAnthropicFakeModelProviderConfig({
+      workspaceId: suite.workspaceId,
+      fakeModelProvider,
+      scriptId,
+      model: CLAUDE_AGENT_MODEL,
+      responses: [
+        toolCall(issueReadTool, {
+          method: 'get',
+          owner: 'shipfox',
+          repo: 'e2e',
+          issue_number: 1,
+        }),
+        toolCall(issueWriteTool, {
+          method: 'create',
+          owner: 'shipfox',
+          repo: 'e2e',
+          title: 'Synthetic GitHub issue',
+        }),
+        toolCall(issueReadTool, {
+          method: 'get_comments',
+          owner: 'shipfox',
+          repo: 'e2e',
+          issue_number: 1,
+        }),
+        toolCall(addIssueCommentTool, {
+          owner: 'shipfox',
+          repo: 'e2e',
+          issue_number: 1,
+          body: 'This tool was not selected',
+        }),
+        message('done'),
+      ],
+      assertions: [
+        {kind: 'model', equals: CLAUDE_AGENT_MODEL},
+        {kind: 'tool_present', name: issueReadTool},
+        {kind: 'tool_present', name: issueWriteTool},
+        {kind: 'tool_absent', name: addIssueCommentTool},
+        {
+          kind: 'message_content_includes',
+          value: GITHUB_READ_RESULT_MARKER,
+          minRequestIndex: 1,
+        },
+        {
+          kind: 'message_content_includes',
+          value: GITHUB_WRITE_RESULT_MARKER,
+          minRequestIndex: 2,
+        },
+        {
+          kind: 'message_content_includes',
+          value: 'Unauthorized integration tool method: get_comments',
+          minRequestIndex: 3,
+        },
+        {
+          kind: 'message_content_includes',
+          value: 'No such tool available:',
+          minRequestIndex: 4,
+        },
+      ],
+      setAsDefault: true,
+    });
+
+    const terminal = await runGithubToolsWorkflow({
+      suite,
+      testInfo,
+      uniqueId,
+      connectionSlug: connection.slug,
+      runnerEnv: fakeAnthropic.runnerEnv,
+    });
+
+    expect(terminal.status).toBe('succeeded');
+    expect(terminal.jobs.find((job) => job.key === 'tools')?.status).toBe('succeeded');
+    const providerRequests = await fakeModelProvider.getRequests(scriptId);
+    expect(providerRequests).toHaveLength(6);
+    expect(providerRequests[0]).toMatchObject({
+      model: `${CLAUDE_AGENT_MODEL}-small-fast`,
+      served_response: 'message:non_consuming_model',
+    });
+    expect(providerRequests.filter((request) => request.model === CLAUDE_AGENT_MODEL)).toHaveLength(
+      5,
+    );
+    expect(providerRequests.every((request) => request.assertion_failures.length === 0)).toBe(true);
+    expect(githubApi.calls).toEqual([
+      {
+        kind: 'mint-token',
+        authorization: expect.stringMatching(BEARER_AUTHORIZATION),
+        installationId,
+        body: {},
+      },
+      {
+        kind: 'read-issue',
+        authorization: `token ${GITHUB_INSTALLATION_TOKEN}`,
+        owner: 'shipfox',
+        repo: 'e2e',
+        issueNumber: 1,
+      },
+      {
+        kind: 'create-issue',
+        authorization: `token ${GITHUB_INSTALLATION_TOKEN}`,
+        owner: 'shipfox',
+        repo: 'e2e',
+        body: {title: 'Synthetic GitHub issue'},
+      },
+    ]);
+  } finally {
+    await Promise.all([
+      fakeModelProvider?.stop()?.catch((error: unknown) => {
+        process.stderr.write(
+          `github-agent-tools-e2e: stopFakeOpenAiModelProvider failed: ${String(error)}\n`,
+        );
+      }) ?? Promise.resolve(),
+      githubApi.stop().catch((error: unknown) => {
+        process.stderr.write(
+          `github-agent-tools-e2e: stopGithubApiMock failed: ${String(error)}\n`,
+        );
+      }),
+    ]);
+  }
+});
+
+async function runGithubToolsWorkflow(params: {
+  suite: SuiteContext;
+  testInfo: {
+    attach: (name: string, options: {body: Buffer | string; contentType: string}) => Promise<void>;
+  };
+  uniqueId: string;
+  connectionSlug: string;
+  runnerEnv: Record<string, string>;
+}) {
+  const token = params.suite.sessionToken;
+  const client = createApiClient({token});
+  const scenario = 'github-agent-tools';
+  const runnerLabel = `e2e-${scenario}-${params.uniqueId}`;
+  const repo = `${scenario}-${params.uniqueId}`;
+  const localRunner = await startSuiteLocalRunner({
+    workspaceId: params.suite.workspaceId,
+    userToken: token,
+    name: `E2E ${scenario} ${params.uniqueId}`,
+    runnerLabel,
+    extraEnv: {
+      ...params.runnerEnv,
+      SHIPFOX_POLL_MAX_DURATION_MS: String(TERMINAL_TIMEOUT_MS),
+    },
+  });
+
+  try {
+    const {definition} = await seedAndWaitForDefinition({
+      suite: params.suite,
+      token,
+      name: scenario,
+      repo,
+      runnerLabel,
+      workflowYaml: githubToolsWorkflowYaml(params.connectionSlug),
+      configPath: `.shipfox/workflows/${scenario}.yml`,
+    });
+    const runId = await fireManualAndAwaitRun({
+      client,
+      definitionId: definition.id,
+      inputs: {},
+      scenario,
+    });
+
+    const terminal = await waitForRunTerminalOrFailedRunner({
+      runId,
+      token,
+      timeoutMs: TERMINAL_TIMEOUT_MS,
+      runner: localRunner.runner,
+    });
+    if (terminal.status !== 'succeeded') {
+      for (const request of collectStepLogAttachmentRequests(terminal)) {
+        const attachment = await fetchLogAttachment(request, token);
+        await params.testInfo.attach(attachment.name, {
+          body: attachment.body,
+          contentType: attachment.contentType,
+        });
+      }
+    }
+
+    return terminal;
+  } finally {
+    await attachLocalRunnerLog(
+      (attachment) =>
+        params.testInfo.attach(attachment.name, {
+          body: attachment.body,
+          contentType: attachment.contentType,
+        }),
+      localRunner.logFile,
+    );
+    await stopLocalRunner(localRunner.runner).catch((error: unknown) => {
+      process.stderr.write(`${scenario}-e2e: stopLocalRunner failed: ${String(error)}\n`);
+    });
+  }
+}
+
+function githubToolsWorkflowYaml(connectionSlug: string): string {
+  return `
+name: GitHub agent tools
+runner: __RUNNER_LABEL__
+triggers:
+  manual:
+    source: manual
+    event: fire
+jobs:
+  tools:
+    steps:
+      - key: github
+        harness: claude
+        thinking: low
+        prompt: Use the selected GitHub tools.
+        integrations:
+          - connection: ${connectionSlug}
+            include: [issue_read.get, issue_write.create]
+            allow_write: true
+`;
+}

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/resolve-authorized-tools.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/resolve-authorized-tools.test.ts
@@ -16,7 +16,7 @@ import {
 } from './resolve-authorized-tools.js';
 
 describe('resolveAuthorizedIntegrationTools', () => {
-  it('resolves namespaced tools with live descriptions and narrowed method schemas', async () => {
+  it('resolves namespaced tools with live descriptions and Anthropic-compatible method schemas', async () => {
     const request = {};
     const lease = leaseContext();
     const integration = materializedIntegration({connectionId: 'connection-1'});
@@ -43,11 +43,7 @@ describe('resolveAuthorizedIntegrationTools', () => {
     expect(properties.method).toMatchObject({
       enum: ['get', 'get_comments'],
     });
-    expect(authorizedTool?.inputSchema.oneOf).toHaveLength(2);
-    const oneOf = authorizedTool?.inputSchema.oneOf as unknown[];
-    expect(oneOf[0]).toMatchObject({
-      properties: {method: {const: 'get', description: 'Get one issue.'}},
-    });
+    expect(authorizedTool?.inputSchema.oneOf).toBeUndefined();
   });
 
   it('fails closed when the lease has no current step', async () => {

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/resolve-authorized-tools.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/resolve-authorized-tools.ts
@@ -7,7 +7,7 @@ import {requireLeasedJobContext} from '@shipfox/api-auth-context';
 import {ClientError} from '@shipfox/node-fastify';
 import type {IntegrationConnection} from '#core/entities/connection.js';
 import type {IntegrationProviderKind} from '#core/entities/provider.js';
-import type {AgentToolCatalogEntry, AgentToolJsonSchema} from '#core/providers/agent-tools.js';
+import type {AgentToolJsonSchema} from '#core/providers/agent-tools.js';
 import type {IntegrationProviderRegistry} from '#core/providers/registry.js';
 import type {GetIntegrationConnectionByIdFn} from '#db/connections.js';
 
@@ -93,7 +93,7 @@ export async function resolveAuthorizedIntegrationTools(
         connection,
         // The live catalog enriches display metadata only. Frozen step config remains the allowlist.
         description: catalogTool?.description ?? tool.id,
-        inputSchema: tool.methods ? toolInputSchema(tool, catalogTool) : tool.inputSchema,
+        inputSchema: tool.methods ? toolInputSchema(tool) : tool.inputSchema,
         outputSchema: tool.outputSchema ?? catalogTool?.outputSchema,
       });
     }
@@ -113,7 +113,6 @@ export function mcpToolName(connectionSlug: string, toolId: string): string {
 export function narrowMethodEnum(
   inputSchema: AgentToolJsonSchema,
   authorizedMethods: readonly string[],
-  methodDescriptions: ReadonlyMap<string, string> = new Map(),
 ): AgentToolJsonSchema {
   const schema = cloneSchema(inputSchema);
   const methodSchema = getObjectProperty(schema, 'method');
@@ -121,43 +120,16 @@ export function narrowMethodEnum(
     narrowEnumOrConst(methodSchema, authorizedMethods);
   }
 
-  const oneOf = schema.oneOf;
-  if (Array.isArray(oneOf)) {
-    schema.oneOf = oneOf.filter((entry) => {
-      if (!isRecord(entry)) return true;
-      const entryMethod = getObjectProperty(entry, 'method');
-      if (!entryMethod) return true;
-      const methodConst = entryMethod?.const;
-      if (typeof methodConst !== 'string') return true;
-      if (!authorizedMethods.includes(methodConst)) return false;
-
-      const description = methodDescriptions.get(methodConst);
-      if (description) entryMethod.description = description;
-      return true;
-    });
-  } else if (methodDescriptions.size > 0) {
-    schema.oneOf = authorizedMethods.map((method) => ({
-      properties: {
-        method: {
-          const: method,
-          description: methodDescriptions.get(method) ?? method,
-        },
-      },
-    }));
-  }
+  // Claude rejects MCP tools with a top-level oneOf. The narrowed method enum remains the
+  // authority boundary, while provider validation enforces method-specific argument shapes.
+  delete schema.oneOf;
 
   return schema;
 }
 
-function toolInputSchema(
-  tool: MaterializedAgentIntegrationToolConfigDto,
-  catalogTool: AgentToolCatalogEntry | undefined,
-): AgentToolJsonSchema {
+function toolInputSchema(tool: MaterializedAgentIntegrationToolConfigDto): AgentToolJsonSchema {
   const authorizedMethods = tool.methods?.map((method) => method.id) ?? [];
-  const methodDescriptions = new Map(
-    catalogTool?.methods?.map((method) => [method.id, method.description]) ?? [],
-  );
-  return narrowMethodEnum(tool.inputSchema, authorizedMethods, methodDescriptions);
+  return narrowMethodEnum(tool.inputSchema, authorizedMethods);
 }
 
 function parseAgentIntegrations(

--- a/libs/api/integration/core/src/providers/github.ts
+++ b/libs/api/integration/core/src/providers/github.ts
@@ -33,6 +33,7 @@ async function loadGithubModuleParts(
 ): Promise<IntegrationModuleParts> {
   const {
     createGithubInstallationTokenProvider,
+    createGithubE2eRoutes,
     encodeInstallationTokenEnvelope,
     createGithubIntegrationProvider,
     getGithubInstallationByInstallationId,
@@ -127,6 +128,13 @@ async function loadGithubModuleParts(
       deleteSecrets: options.secrets?.deleteSecrets,
       agentTools: {tokenProvider},
     }),
+    e2eRoutes: [
+      createGithubE2eRoutes({
+        getExistingGithubConnection,
+        connectGithubInstallation,
+        connectionCapabilities: ['source_control', 'agent_tools'],
+      }),
+    ],
     database: {
       db: githubDb,
       migrationsPath: githubMigrationsPath,

--- a/libs/api/integration/github-dto/src/schemas/github.ts
+++ b/libs/api/integration/github-dto/src/schemas/github.ts
@@ -21,3 +21,17 @@ export type GithubCallbackQueryDto = z.infer<typeof githubCallbackQuerySchema>;
 
 export const githubCallbackResponseSchema = integrationConnectionDtoSchema;
 export type GithubCallbackResponseDto = z.infer<typeof githubCallbackResponseSchema>;
+
+export const createE2eGithubConnectionBodySchema = z.object({
+  workspace_id: z.string().uuid(),
+  installation_id: z.number().int().positive(),
+  account_login: z.string().min(1),
+  display_name: z.string().min(1),
+  installer_user_id: z.string().uuid(),
+});
+export type CreateE2eGithubConnectionBodyDto = z.infer<typeof createE2eGithubConnectionBodySchema>;
+
+export const createE2eGithubConnectionResponseSchema = integrationConnectionDtoSchema;
+export type CreateE2eGithubConnectionResponseDto = z.infer<
+  typeof createE2eGithubConnectionResponseSchema
+>;

--- a/libs/api/integration/github/src/api/client.test.ts
+++ b/libs/api/integration/github/src/api/client.test.ts
@@ -11,7 +11,11 @@ vi.mock('octokit', () => ({
       rest: {apps: {createInstallationAccessToken: createInstallationAccessTokenMock}},
     };
   },
-  Octokit: class Octokit {},
+  Octokit: {
+    defaults(options: unknown) {
+      return {defaults: options};
+    },
+  },
   RequestError: class RequestError extends Error {},
 }));
 

--- a/libs/api/integration/github/src/api/client.ts
+++ b/libs/api/integration/github/src/api/client.ts
@@ -135,7 +135,10 @@ class OctokitGithubApiClient implements GithubApiClient {
     userAccessToken: string;
     cursor?: string | undefined;
   }): Promise<GithubUserInstallationPage> {
-    const octokit = new Octokit({auth: input.userAccessToken});
+    const octokit = new Octokit({
+      auth: input.userAccessToken,
+      baseUrl: config.GITHUB_API_BASE_URL,
+    });
     const page = cursorToPage(input.cursor);
     const response = await mapGithubError(() =>
       octokit.request('GET /user/installations', {
@@ -380,6 +383,7 @@ class OctokitGithubApiClient implements GithubApiClient {
       this.app = new App({
         appId: config.GITHUB_APP_ID,
         privateKey: normalizedGithubPrivateKey(),
+        Octokit: Octokit.defaults({baseUrl: config.GITHUB_API_BASE_URL}),
       });
     }
     return this.app;

--- a/libs/api/integration/github/src/api/client.ts
+++ b/libs/api/integration/github/src/api/client.ts
@@ -2,7 +2,7 @@ import {Buffer} from 'node:buffer';
 import {MAX_REPOSITORY_FILE_BYTES} from '@shipfox/api-integration-core-dto';
 import ky, {HTTPError, TimeoutError} from 'ky';
 import {App, Octokit, RequestError} from 'octokit';
-import {config, normalizedGithubPrivateKey} from '#config.js';
+import {config, normalizedGithubApiBaseUrl, normalizedGithubPrivateKey} from '#config.js';
 import {GithubIntegrationProviderError} from '#core/errors.js';
 
 const NEXT_PAGE_RE = /[?&]page=(\d+)/;
@@ -137,7 +137,7 @@ class OctokitGithubApiClient implements GithubApiClient {
   }): Promise<GithubUserInstallationPage> {
     const octokit = new Octokit({
       auth: input.userAccessToken,
-      baseUrl: config.GITHUB_API_BASE_URL,
+      baseUrl: normalizedGithubApiBaseUrl(),
     });
     const page = cursorToPage(input.cursor);
     const response = await mapGithubError(() =>
@@ -383,7 +383,7 @@ class OctokitGithubApiClient implements GithubApiClient {
       this.app = new App({
         appId: config.GITHUB_APP_ID,
         privateKey: normalizedGithubPrivateKey(),
-        Octokit: Octokit.defaults({baseUrl: config.GITHUB_API_BASE_URL}),
+        Octokit: Octokit.defaults({baseUrl: normalizedGithubApiBaseUrl()}),
       });
     }
     return this.app;

--- a/libs/api/integration/github/src/api/installation-token-provider.test.ts
+++ b/libs/api/integration/github/src/api/installation-token-provider.test.ts
@@ -190,6 +190,7 @@ describe('GithubInstallationTokenProvider', () => {
       expect.objectContaining({
         Octokit: {
           defaults: {
+            baseUrl: 'https://api.github.com',
             throttle: {
               onRateLimit: expect.any(Function),
               onSecondaryRateLimit: expect.any(Function),

--- a/libs/api/integration/github/src/api/installation-token-provider.ts
+++ b/libs/api/integration/github/src/api/installation-token-provider.ts
@@ -1,6 +1,6 @@
 import type {GetIntegrationConnectionByIdFn} from '@shipfox/api-integration-core-dto';
 import {App, Octokit} from 'octokit';
-import {config, normalizedGithubPrivateKey} from '#config.js';
+import {config, normalizedGithubApiBaseUrl, normalizedGithubPrivateKey} from '#config.js';
 import {GithubIntegrationProviderError} from '#core/errors.js';
 import {withInstallationTokenLock} from '#db/installation-token-lock.js';
 import {getGithubInstallationByInstallationId} from '#db/installations.js';
@@ -87,7 +87,7 @@ class OctokitGithubInstallationTokenProvider implements GithubInstallationTokenP
         appId: config.GITHUB_APP_ID,
         privateKey: normalizedGithubPrivateKey(),
         Octokit: Octokit.defaults({
-          baseUrl: config.GITHUB_API_BASE_URL,
+          baseUrl: normalizedGithubApiBaseUrl(),
           throttle: {
             onRateLimit: (
               _retryAfter: number,

--- a/libs/api/integration/github/src/api/installation-token-provider.ts
+++ b/libs/api/integration/github/src/api/installation-token-provider.ts
@@ -87,6 +87,7 @@ class OctokitGithubInstallationTokenProvider implements GithubInstallationTokenP
         appId: config.GITHUB_APP_ID,
         privateKey: normalizedGithubPrivateKey(),
         Octokit: Octokit.defaults({
+          baseUrl: config.GITHUB_API_BASE_URL,
           throttle: {
             onRateLimit: (
               _retryAfter: number,

--- a/libs/api/integration/github/src/config.test.ts
+++ b/libs/api/integration/github/src/config.test.ts
@@ -1,0 +1,14 @@
+import {describe, expect, it} from '@shipfox/vitest/vi';
+import {normalizeGithubApiBaseUrl} from './config.js';
+
+describe('normalizeGithubApiBaseUrl', () => {
+  it.each([
+    ['https://api.github.com', 'https://api.github.com'],
+    ['https://api.github.com/', 'https://api.github.com'],
+    ['https://github.example.test/api/v3///', 'https://github.example.test/api/v3'],
+  ])('normalizes %s', (baseUrl, expected) => {
+    const result = normalizeGithubApiBaseUrl(baseUrl);
+
+    expect(result).toBe(expected);
+  });
+});

--- a/libs/api/integration/github/src/config.ts
+++ b/libs/api/integration/github/src/config.ts
@@ -1,4 +1,4 @@
-import {createConfig, str} from '@shipfox/config';
+import {createConfig, str, url} from '@shipfox/config';
 
 export const config = createConfig({
   GITHUB_APP_ID: str({
@@ -22,6 +22,10 @@ export const config = createConfig({
   GITHUB_APP_USERNAME: str({
     desc: 'GitHub App username used as the Git commit author when checkout credentials are persisted. Set this to the app username, such as my-app. The [bot] suffix is added automatically. Leave unset to keep Git author identity unset.',
     default: undefined,
+  }),
+  GITHUB_API_BASE_URL: url({
+    desc: 'Base URL used for GitHub REST API requests. Set this only for GitHub Enterprise Server or a compatible test server.',
+    default: 'https://api.github.com',
   }),
   GITHUB_INSTALL_STATE_SECRET: str({
     desc: 'Secret used to sign the state token that protects the GitHub App install flow. Required.',

--- a/libs/api/integration/github/src/config.ts
+++ b/libs/api/integration/github/src/config.ts
@@ -1,5 +1,7 @@
 import {createConfig, str, url} from '@shipfox/config';
 
+const trailingSlashesPattern = /\/+$/u;
+
 export const config = createConfig({
   GITHUB_APP_ID: str({
     desc: "Numeric ID of the GitHub App, found on the app's settings page. Required.",
@@ -34,4 +36,12 @@ export const config = createConfig({
 
 export function normalizedGithubPrivateKey(): string {
   return config.GITHUB_APP_PRIVATE_KEY.replaceAll('\\n', '\n');
+}
+
+export function normalizeGithubApiBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(trailingSlashesPattern, '');
+}
+
+export function normalizedGithubApiBaseUrl(): string {
+  return normalizeGithubApiBaseUrl(config.GITHUB_API_BASE_URL);
 }

--- a/libs/api/integration/github/src/core/agent-tools.test.ts
+++ b/libs/api/integration/github/src/core/agent-tools.test.ts
@@ -1,6 +1,7 @@
 import type {GithubApiClient} from '#api/client.js';
 import {DEFAULT_JOB_LOG_TAIL_LINES} from '#core/actions-logs.js';
 import {
+  type GithubAgentToolId,
   GithubAgentToolsProvider,
   githubAgentToolCatalog,
   githubAgentToolSelectionCatalog,
@@ -355,7 +356,121 @@ describe('github agent tool catalog', () => {
       structuredContent: {number: 1},
     });
   });
+
+  it.each([
+    {
+      toolId: 'list_issue_types',
+      arguments: {owner: 'shipfox'},
+      data: [{id: 1}],
+      expected: {issue_types: [{id: 1}]},
+    },
+    {
+      toolId: 'list_issues',
+      arguments: {owner: 'shipfox', repo: 'platform'},
+      data: [{number: 1}],
+      expected: {issues: [{number: 1}]},
+    },
+    {
+      toolId: 'search_issues',
+      arguments: {query: 'is:open'},
+      data: {items: [{number: 1}], total_count: 1},
+      expected: {issues: [{number: 1}]},
+    },
+    {
+      toolId: 'list_pull_requests',
+      arguments: {owner: 'shipfox', repo: 'platform'},
+      data: [{number: 2}],
+      expected: {pull_requests: [{number: 2}]},
+    },
+    {
+      toolId: 'search_pull_requests',
+      arguments: {query: 'is:open'},
+      data: {items: [{number: 2}], total_count: 1},
+      expected: {pull_requests: [{number: 2}]},
+    },
+    {
+      toolId: 'create_pull_request',
+      arguments: {
+        owner: 'shipfox',
+        repo: 'platform',
+        title: 'Title',
+        head: 'feature',
+        base: 'main',
+      },
+      data: {number: 2},
+      expected: {pull_request: {number: 2}},
+    },
+    {
+      toolId: 'update_pull_request',
+      arguments: {owner: 'shipfox', repo: 'platform', pull_number: 2},
+      data: {number: 2, title: 'Updated'},
+      expected: {pull_request: {number: 2, title: 'Updated'}},
+    },
+    {
+      toolId: 'merge_pull_request',
+      arguments: {owner: 'shipfox', repo: 'platform', pull_number: 2},
+      data: {merged: true},
+      expected: {merge: {merged: true}},
+    },
+    {
+      toolId: 'pull_request_read',
+      arguments: {
+        method: 'get_diff',
+        owner: 'shipfox',
+        repo: 'platform',
+        pull_number: 2,
+      },
+      data: 'diff --git a/file b/file',
+      expected: {result: 'diff --git a/file b/file'},
+    },
+  ] satisfies Array<{
+    toolId: GithubAgentToolId;
+    arguments: Record<string, unknown>;
+    data: unknown;
+    expected: Record<string, unknown>;
+  }>)('projects $toolId responses to their output schema', async (testCase) => {
+    const result = await callGithubTool(testCase.toolId, testCase.arguments, testCase.data);
+
+    expect(result).toEqual({
+      content: [{type: 'text', text: JSON.stringify(testCase.expected)}],
+      structuredContent: testCase.expected,
+    });
+  });
 });
+
+async function callGithubTool(
+  toolId: GithubAgentToolId,
+  arguments_: Record<string, unknown>,
+  data: unknown,
+) {
+  const tool = githubAgentToolCatalog.find((entry) => entry.id === toolId);
+  if (!tool) throw new Error(`Missing GitHub tool: ${toolId}`);
+  const provider = new GithubAgentToolsProvider({
+    getInstallationByConnectionId: vi.fn(() => Promise.resolve(installation())),
+    tokenProvider: {
+      getInstallationAccessToken: vi.fn(() =>
+        Promise.resolve({
+          token: 'installation-token',
+          expiresAt: new Date(),
+          permissions: {
+            actions: 'write' as const,
+            contents: 'write' as const,
+            issues: 'write' as const,
+            pull_requests: 'write' as const,
+          },
+        }),
+      ),
+    },
+    createClient: vi.fn(() => ({request: vi.fn(() => Promise.resolve({data}))})),
+  });
+  const session = await provider.openSession({
+    connection: connection(),
+    tools: [tool],
+    scope: undefined,
+  });
+
+  return await session.call({toolId, arguments: arguments_});
+}
 
 function connection() {
   return {

--- a/libs/api/integration/github/src/core/agent-tools.test.ts
+++ b/libs/api/integration/github/src/core/agent-tools.test.ts
@@ -350,7 +350,10 @@ describe('github agent tool catalog', () => {
       issue_number: 1,
     });
     expect(clientToken).toBe('installation-token');
-    expect(result).toEqual({content: [{type: 'text', text: '{"number":1}'}]});
+    expect(result).toEqual({
+      content: [{type: 'text', text: '{"number":1}'}],
+      structuredContent: {number: 1},
+    });
   });
 });
 

--- a/libs/api/integration/github/src/core/agent-tools.ts
+++ b/libs/api/integration/github/src/core/agent-tools.ts
@@ -14,7 +14,7 @@ import {
   createGithubInstallationTokenProvider,
   type GithubInstallationTokenProvider,
 } from '#api/installation-token-provider.js';
-import {config} from '#config.js';
+import {normalizedGithubApiBaseUrl} from '#config.js';
 import type {GithubInstallation} from '#db/installations.js';
 import {DEFAULT_JOB_LOG_TAIL_LINES} from './actions-logs.js';
 import {buildGithubAgentToolSelectionCatalog} from './agent-tool-selection.js';
@@ -880,7 +880,7 @@ interface GithubToolOperation {
 function createOctokitClient(token: string): GithubToolClient {
   const octokit = new Octokit({
     auth: token,
-    baseUrl: config.GITHUB_API_BASE_URL,
+    baseUrl: normalizedGithubApiBaseUrl(),
     retry: {enabled: false},
   });
   return {

--- a/libs/api/integration/github/src/core/agent-tools.ts
+++ b/libs/api/integration/github/src/core/agent-tools.ts
@@ -14,6 +14,7 @@ import {
   createGithubInstallationTokenProvider,
   type GithubInstallationTokenProvider,
 } from '#api/installation-token-provider.js';
+import {config} from '#config.js';
 import type {GithubInstallation} from '#db/installations.js';
 import {DEFAULT_JOB_LOG_TAIL_LINES} from './actions-logs.js';
 import {buildGithubAgentToolSelectionCatalog} from './agent-tool-selection.js';
@@ -23,6 +24,7 @@ type GithubIntegrationConnection = IntegrationConnection<'github'>;
 type GithubToolCallResult = {
   isError?: boolean | undefined;
   content: readonly {type: 'text'; text: string}[];
+  structuredContent?: Record<string, unknown> | undefined;
 };
 
 export type GithubAgentToolCategory = 'issues' | 'pull_requests' | 'actions';
@@ -876,7 +878,11 @@ interface GithubToolOperation {
 }
 
 function createOctokitClient(token: string): GithubToolClient {
-  const octokit = new Octokit({auth: token, retry: {enabled: false}});
+  const octokit = new Octokit({
+    auth: token,
+    baseUrl: config.GITHUB_API_BASE_URL,
+    retry: {enabled: false},
+  });
   return {
     request: async (route, parameters) => await octokit.request(route, parameters),
   };
@@ -1043,11 +1049,18 @@ function projectGithubOperationParameters(
 }
 
 function githubToolResult(data: unknown): GithubToolCallResult {
-  return {content: [{type: 'text', text: JSON.stringify(data)}]};
+  return {
+    content: [{type: 'text', text: JSON.stringify(data)}],
+    structuredContent: isRecord(data) ? data : {result: data},
+  };
 }
 
 function githubToolError(message: string): GithubToolCallResult {
   return {isError: true, content: [{type: 'text', text: message}]};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function validateGithubToolArguments(

--- a/libs/api/integration/github/src/core/agent-tools.ts
+++ b/libs/api/integration/github/src/core/agent-tools.ts
@@ -847,7 +847,7 @@ export class GithubAgentToolsProvider
 
         try {
           const response = await client.request(operation.route, operation.parameters);
-          return githubToolResult(response.data);
+          return githubToolResult(tool.id as GithubAgentToolId, response.data);
         } catch (error) {
           if (error instanceof GithubIntegrationProviderError)
             return githubToolError(error.message);
@@ -1048,11 +1048,41 @@ function projectGithubOperationParameters(
   return parameters;
 }
 
-function githubToolResult(data: unknown): GithubToolCallResult {
+function githubToolResult(toolId: GithubAgentToolId, data: unknown): GithubToolCallResult {
+  const structuredContent = projectGithubToolOutput(toolId, data);
   return {
-    content: [{type: 'text', text: JSON.stringify(data)}],
-    structuredContent: isRecord(data) ? data : {result: data},
+    content: [{type: 'text', text: JSON.stringify(structuredContent)}],
+    structuredContent,
   };
+}
+
+function projectGithubToolOutput(
+  toolId: GithubAgentToolId,
+  data: unknown,
+): Record<string, unknown> {
+  switch (toolId) {
+    case 'list_issue_types':
+      return {issue_types: data};
+    case 'list_issues':
+      return {issues: data};
+    case 'search_issues':
+      return {issues: githubSearchItems(data)};
+    case 'list_pull_requests':
+      return {pull_requests: data};
+    case 'search_pull_requests':
+      return {pull_requests: githubSearchItems(data)};
+    case 'create_pull_request':
+    case 'update_pull_request':
+      return {pull_request: data};
+    case 'merge_pull_request':
+      return {merge: data};
+    default:
+      return isRecord(data) ? data : {result: data};
+  }
+}
+
+function githubSearchItems(data: unknown): unknown {
+  return isRecord(data) ? data.items : data;
 }
 
 function githubToolError(message: string): GithubToolCallResult {

--- a/libs/api/integration/github/src/index.ts
+++ b/libs/api/integration/github/src/index.ts
@@ -14,6 +14,10 @@ import {closeDb, db} from '#db/db.js';
 import {getGithubInstallationByConnectionId} from '#db/installations.js';
 import {migrationsPath} from '#db/migrations.js';
 import {
+  type CreateGithubE2eRoutesOptions,
+  createGithubE2eRoutes,
+} from '#presentation/e2eRoutes/index.js';
+import {
   type CreateGithubIntegrationRoutesOptions,
   createGithubIntegrationRoutes,
 } from '#presentation/routes/install.js';
@@ -51,7 +55,7 @@ export {
   getGithubInstallationByInstallationId,
   upsertGithubInstallation,
 } from '#db/installations.js';
-export {closeDb, db, migrationsPath};
+export {type CreateGithubE2eRoutesOptions, closeDb, createGithubE2eRoutes, db, migrationsPath};
 
 export interface CreateGithubIntegrationProviderOptions
   extends Omit<CreateGithubIntegrationRoutesOptions, 'github'> {

--- a/libs/api/integration/github/src/presentation/e2eRoutes/create-connection.ts
+++ b/libs/api/integration/github/src/presentation/e2eRoutes/create-connection.ts
@@ -1,0 +1,70 @@
+import type {IntegrationCapability, IntegrationConnection} from '@shipfox/api-integration-core-dto';
+import {toIntegrationConnectionDto} from '@shipfox/api-integration-core-dto';
+import {
+  createE2eGithubConnectionBodySchema,
+  createE2eGithubConnectionResponseSchema,
+} from '@shipfox/api-integration-github-dto';
+import {ClientError, defineRoute} from '@shipfox/node-fastify';
+import type {ConnectGithubInstallationInput} from '#core/install.js';
+
+export interface CreateE2eGithubConnectionRouteOptions {
+  getExistingGithubConnection: (input: {
+    installationId: string;
+  }) => Promise<IntegrationConnection<'github'> | undefined>;
+  connectGithubInstallation: (
+    input: ConnectGithubInstallationInput,
+  ) => Promise<IntegrationConnection<'github'>>;
+  connectionCapabilities: IntegrationCapability[];
+}
+
+export function createE2eGithubConnectionRoute(options: CreateE2eGithubConnectionRouteOptions) {
+  return defineRoute({
+    method: 'POST',
+    path: '/github-connections',
+    description: 'Create a synthetic GitHub connection for E2E tests.',
+    schema: {
+      body: createE2eGithubConnectionBodySchema,
+      response: {201: createE2eGithubConnectionResponseSchema},
+    },
+    handler: async (request, reply) => {
+      const body = request.body;
+      const installationId = String(body.installation_id);
+      const existing = await options.getExistingGithubConnection({installationId});
+      if (existing && existing.workspaceId !== body.workspace_id) {
+        throw new ClientError(
+          'GitHub installation is already connected to another workspace',
+          'github-connection-workspace-mismatch',
+          {status: 409},
+        );
+      }
+
+      const connection =
+        existing ??
+        (await options.connectGithubInstallation({
+          workspaceId: body.workspace_id,
+          installationId,
+          displayName: body.display_name,
+          installerUserId: body.installer_user_id,
+          installation: {
+            installationId,
+            accountLogin: body.account_login,
+            accountType: 'Organization',
+            repositorySelection: 'all',
+            suspendedAt: null,
+            deletedAt: null,
+            latestEvent: {
+              id: body.installation_id,
+              account: {login: body.account_login, type: 'Organization'},
+              repository_selection: 'all',
+            },
+            installerUserId: body.installer_user_id,
+          },
+        }));
+
+      reply.code(201);
+      return toIntegrationConnectionDto(connection, {
+        capabilities: options.connectionCapabilities,
+      });
+    },
+  });
+}

--- a/libs/api/integration/github/src/presentation/e2eRoutes/index.test.ts
+++ b/libs/api/integration/github/src/presentation/e2eRoutes/index.test.ts
@@ -1,0 +1,126 @@
+import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
+import {closeApp, createApp} from '@shipfox/node-fastify';
+import {createGithubE2eRoutes} from './index.js';
+
+function connection(
+  overrides: Partial<IntegrationConnection<'github'>> = {},
+): IntegrationConnection<'github'> {
+  return {
+    id: '00000000-0000-4000-8000-000000000001',
+    workspaceId: '00000000-0000-4000-8000-000000000002',
+    provider: 'github',
+    externalAccountId: '1234',
+    slug: 'github_shipfox_e2e',
+    displayName: 'GitHub Shipfox E2E',
+    lifecycleStatus: 'active',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe('GitHub E2E routes', () => {
+  afterEach(async () => {
+    await closeApp();
+  });
+
+  it('creates a synthetic GitHub connection and installation', async () => {
+    const connectGithubInstallation = vi.fn(() => Promise.resolve(connection()));
+    const app = await createApp({
+      routes: [
+        createGithubE2eRoutes({
+          getExistingGithubConnection: vi.fn(() => Promise.resolve(undefined)),
+          connectGithubInstallation,
+          connectionCapabilities: ['source_control', 'agent_tools'],
+        }),
+      ],
+      swagger: false,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/integrations/github-connections',
+      payload: {
+        workspace_id: '00000000-0000-4000-8000-000000000002',
+        installation_id: 1234,
+        account_login: 'shipfox-e2e',
+        display_name: 'GitHub Shipfox E2E',
+        installer_user_id: '00000000-0000-4000-8000-000000000004',
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.json()).toMatchObject({
+      id: '00000000-0000-4000-8000-000000000001',
+      provider: 'github',
+      capabilities: ['source_control', 'agent_tools'],
+    });
+    expect(connectGithubInstallation).toHaveBeenCalledWith({
+      workspaceId: '00000000-0000-4000-8000-000000000002',
+      installationId: '1234',
+      displayName: 'GitHub Shipfox E2E',
+      installerUserId: '00000000-0000-4000-8000-000000000004',
+      installation: expect.objectContaining({
+        installationId: '1234',
+        accountLogin: 'shipfox-e2e',
+        accountType: 'Organization',
+        repositorySelection: 'all',
+        installerUserId: '00000000-0000-4000-8000-000000000004',
+      }),
+    });
+  });
+
+  it('rejects malformed connection bodies', async () => {
+    const app = await createApp({
+      routes: [
+        createGithubE2eRoutes({
+          getExistingGithubConnection: vi.fn(() => Promise.resolve(undefined)),
+          connectGithubInstallation: vi.fn(() => Promise.resolve(connection())),
+          connectionCapabilities: ['source_control', 'agent_tools'],
+        }),
+      ],
+      swagger: false,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/integrations/github-connections',
+      payload: {workspace_id: 'not-a-uuid'},
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toMatchObject({code: 'validation-error'});
+  });
+
+  it('rejects an installation connected to another workspace', async () => {
+    const connectGithubInstallation = vi.fn(() => Promise.resolve(connection()));
+    const app = await createApp({
+      routes: [
+        createGithubE2eRoutes({
+          getExistingGithubConnection: vi.fn(() =>
+            Promise.resolve(connection({workspaceId: '00000000-0000-4000-8000-000000000003'})),
+          ),
+          connectGithubInstallation,
+          connectionCapabilities: ['source_control', 'agent_tools'],
+        }),
+      ],
+      swagger: false,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/integrations/github-connections',
+      payload: {
+        workspace_id: '00000000-0000-4000-8000-000000000002',
+        installation_id: 1234,
+        account_login: 'shipfox-e2e',
+        display_name: 'GitHub Shipfox E2E',
+        installer_user_id: '00000000-0000-4000-8000-000000000004',
+      },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json()).toMatchObject({code: 'github-connection-workspace-mismatch'});
+    expect(connectGithubInstallation).not.toHaveBeenCalled();
+  });
+});

--- a/libs/api/integration/github/src/presentation/e2eRoutes/index.ts
+++ b/libs/api/integration/github/src/presentation/e2eRoutes/index.ts
@@ -1,0 +1,14 @@
+import type {RouteGroup} from '@shipfox/node-fastify';
+import {
+  type CreateE2eGithubConnectionRouteOptions,
+  createE2eGithubConnectionRoute,
+} from './create-connection.js';
+
+export type CreateGithubE2eRoutesOptions = CreateE2eGithubConnectionRouteOptions;
+
+export function createGithubE2eRoutes(options: CreateGithubE2eRoutesOptions): RouteGroup {
+  return {
+    prefix: '/integrations',
+    routes: [createE2eGithubConnectionRoute(options)],
+  };
+}

--- a/libs/api/integration/github/test/env.ts
+++ b/libs/api/integration/github/test/env.ts
@@ -13,3 +13,4 @@ process.env.GITHUB_APP_WEBHOOK_SECRET = 'test-webhook-secret';
 process.env.GITHUB_APP_SLUG = 'shipfox-test';
 process.env.GITHUB_APP_USERNAME = 'shipfox-test';
 process.env.GITHUB_INSTALL_STATE_SECRET = 'test-install-state-secret';
+process.env.GITHUB_API_BASE_URL = 'https://api.github.com';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -750,6 +750,9 @@ importers:
 
   e2e/setup/integrations:
     dependencies:
+      '@shipfox/api-integration-github-dto':
+        specifier: workspace:*
+        version: link:../../../libs/api/integration/github-dto
       '@shipfox/api-integration-linear-dto':
         specifier: workspace:*
         version: link:../../../libs/api/integration/linear-dto
@@ -1153,6 +1156,9 @@ importers:
       '@shipfox/api-definitions-dto':
         specifier: workspace:*
         version: link:../../../../libs/api/definitions-dto
+      '@shipfox/api-integration-github-dto':
+        specifier: workspace:*
+        version: link:../../../../libs/api/integration/github-dto
       '@shipfox/api-integration-linear-dto':
         specifier: workspace:*
         version: link:../../../../libs/api/integration/linear-dto


### PR DESCRIPTION
Add a deterministic Claude workflow journey that exercises selected GitHub issue read and write tools through a synthetic connection and localhost REST mock.

GitHub agent-tool dispatch previously lacked hermetic full-loop coverage across connection setup, installation-token minting, MCP advertisement, native Octokit calls, and authority denial. The scenario verifies the selected methods succeed while an unselected family method and standalone tool are rejected without reaching GitHub.

This also makes the GitHub API endpoint configurable for E2E, returns structured GitHub tool output required by MCP output schemas, and removes top-level `oneOf` from materialized method-family schemas because the Anthropic API rejects those tools before advertisement. Reviewers should pay particular attention to that schema compatibility boundary; the narrowed method enum remains the authorization allowlist and provider validation still enforces operation-specific arguments.

Closes ENG-854

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full-loop E2E coverage for GitHub agent tools with a hermetic API mock and a synthetic connection. Verifies selected tools run and unselected tools are denied, and makes the GitHub API endpoint configurable and normalized. Fulfills ENG-854.

- **New Features**
  - Deterministic Claude workflow runs GitHub `issue_read.get` and `issue_write.create`, then denies `issue_read.get_comments` and `add_issue_comment` before provider dispatch.
  - Local GitHub API mock serves installation token minting and issues read/write, and records calls for assertions.
  - Protected E2E route to create a synthetic GitHub connection for tests using `@shipfox/api-integration-github-dto`.
  - E2E env derives and exposes `GITHUB_API_BASE_URL`, allocates a dedicated port, enables the GitHub provider, and generates a test RSA key.

- **Refactors**
  - Plumbs `GITHUB_API_BASE_URL` into `Octokit` clients and App, and normalizes base URLs to drop trailing slashes and avoid double-slash paths.
  - Removes top-level `oneOf` from method-family tool schemas for Anthropic compatibility; the narrowed `method` enum remains the allowlist.
  - GitHub tool results now include `structuredContent` and project REST responses into the catalog’s MCP envelopes so text and structured results share the same stable shape.
  - E2E model-provider adds a `tool_absent` assertion and clearer tool error output.

<sup>Written for commit 1084173e896ce98eab595ca5cc5619f232735dad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

