### PR TITLE
[node-drizzle] Publish package for external consumers

### DIFF
--- a/.changeset/bright-otters-migrate.md
+++ b/.changeset/bright-otters-migrate.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/node-drizzle": minor
+---
+
+Publishes the supported Drizzle helpers with migration safety, keyset cursor coverage, and external consumer documentation.

--- a/libs/shared/node/drizzle/README.md
+++ b/libs/shared/node/drizzle/README.md
@@ -1,18 +1,28 @@
 # Shipfox Drizzle
 
-Small Drizzle helpers for Shipfox Node packages. It wraps Drizzle's PostgreSQL driver and adds a migration runner that is safe to use when tests or services start in parallel.
+Helpers for using Drizzle with PostgreSQL in Node.js services.
 
 ## What it does
 
-- **`drizzle`**: Re-exports `drizzle-orm/node-postgres`.
-- **`runMigrations(database, migrationsFolder, migrationsTable?)`**: Runs Drizzle migrations inside a transaction and takes a PostgreSQL advisory lock before migrating.
-- **`uuidv7PrimaryKey()`**: Creates a UUID primary key column that defaults to `uuidv7()`.
-- **`NodePgDatabase`**: Re-exported type from Drizzle.
+- **`drizzle`**: Exports the Drizzle driver for `node-postgres`.
+- **`NodePgDatabase`**: Exports the matching database type.
+- **`runMigrations()`**: Runs migrations in a transaction. It uses a PostgreSQL advisory lock.
+- **`uuidv7PrimaryKey()`**: Makes a UUID primary key with a `uuidv7()` default.
+- **Cursor helpers**: Encode, decode, filter, and page through keyset cursors.
+
+## Installation
+
+Use Node.js 24 or newer. Use PostgreSQL 18.
+
+```sh
+pnpm add @shipfox/node-drizzle @shipfox/node-postgres drizzle-orm
+```
 
 ## Usage
 
 ```ts
 import {drizzle, runMigrations, uuidv7PrimaryKey} from '@shipfox/node-drizzle';
+import {createPostgresClient} from '@shipfox/node-postgres';
 import {pgTable, text} from 'drizzle-orm/pg-core';
 
 export const users = pgTable('users', {
@@ -20,17 +30,27 @@ export const users = pgTable('users', {
   email: text('email').notNull(),
 });
 
+const pool = createPostgresClient();
 const db = drizzle(pool);
 await runMigrations(db, './drizzle', '__drizzle_migrations_users');
 ```
 
-Use a custom migration table name when several modules share one database. This keeps each module's migration history separate.
+## Behavior Notes
+
+- `uuidv7PrimaryKey()` uses the built-in `uuidv7()` function. That function needs PostgreSQL 18.
+- Give each module its own migration table when modules share a database. Their histories stay separate.
+- Connect straight to the database for migrations. Do not use a transaction pool or serverless pool.
+- The advisory lock lets only one process set up migration tables at a time.
 
 ## Development
 
 ```sh
 turbo check --filter=@shipfox/node-drizzle
 turbo type --filter=@shipfox/node-drizzle
+turbo type:emit --filter=@shipfox/node-drizzle
+turbo build --filter=@shipfox/node-drizzle
+turbo test --filter=@shipfox/node-drizzle
+pnpm --filter=@shipfox/node-drizzle test:external
 ```
 
 ## License

--- a/libs/shared/node/drizzle/package.json
+++ b/libs/shared/node/drizzle/package.json
@@ -7,8 +7,19 @@
     "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/shared/node/drizzle"
   },
-  "private": true,
+  "private": false,
   "type": "module",
+  "engines": {
+    "node": ">=24"
+  },
+  "files": [
+    "CHANGELOG.md",
+    "README.md",
+    "dist/**/*.d.ts",
+    "dist/**/*.d.ts.map",
+    "dist/**/*.js",
+    "dist/**/*.js.map"
+  ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "imports": {
@@ -31,17 +42,21 @@
     "build": "shipfox-swc",
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
+    "test": "shipfox-vitest-run",
+    "test:external": "node test/external/verify.mjs",
+    "test:watch": "shipfox-vitest-watch",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
-    "@shipfox/node-postgres": "workspace:*",
+    "@shipfox/node-postgres": "workspace:^",
     "drizzle-orm": "^0.45.2"
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
-    "@shipfox/typescript": "workspace:*"
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*"
   }
 }

--- a/libs/shared/node/drizzle/src/client.test.ts
+++ b/libs/shared/node/drizzle/src/client.test.ts
@@ -1,0 +1,76 @@
+import {randomUUID} from 'node:crypto';
+import {fileURLToPath} from 'node:url';
+import {closePostgresClient, createPostgresClient, type Pool} from '@shipfox/node-postgres';
+import {drizzle} from 'drizzle-orm/node-postgres';
+import {runMigrations} from './client.js';
+
+const moduleAMigrations = fileURLToPath(new URL('../test/fixtures/module-a', import.meta.url));
+const moduleBMigrations = fileURLToPath(new URL('../test/fixtures/module-b', import.meta.url));
+
+let adminPool: Pool;
+
+beforeAll(() => {
+  adminPool = createPostgresClient({database: 'postgres'});
+});
+
+afterAll(async () => {
+  await closePostgresClient();
+});
+
+async function withFreshDatabase(run: (pool: Pool) => Promise<void>): Promise<void> {
+  const databaseName = `node_drizzle_test_${randomUUID().replaceAll('-', '')}`;
+  await adminPool.query(`CREATE DATABASE ${databaseName}`);
+  await closePostgresClient();
+  const testPool = createPostgresClient({database: databaseName});
+
+  try {
+    await run(testPool);
+  } finally {
+    await closePostgresClient();
+    adminPool = createPostgresClient({database: 'postgres'});
+    await adminPool.query(`DROP DATABASE ${databaseName} WITH (FORCE)`);
+  }
+}
+
+describe('runMigrations', () => {
+  it('keeps migration history isolated by table name', async () => {
+    await withFreshDatabase(async (pool) => {
+      const database = drizzle(pool);
+
+      await runMigrations(database, moduleAMigrations, 'node_drizzle_module_a_migrations');
+      await runMigrations(database, moduleBMigrations, 'node_drizzle_module_b_migrations');
+
+      const histories = await pool.query<{table_name: string}>(
+        "SELECT table_name FROM information_schema.tables WHERE table_schema = 'drizzle' ORDER BY table_name",
+      );
+      expect(histories.rows).toEqual([
+        {table_name: 'node_drizzle_module_a_migrations'},
+        {table_name: 'node_drizzle_module_b_migrations'},
+      ]);
+
+      const migrationCounts = await pool.query<{module_a: number; module_b: number}>(
+        'SELECT (SELECT count(*)::int FROM drizzle.node_drizzle_module_a_migrations) AS module_a, (SELECT count(*)::int FROM drizzle.node_drizzle_module_b_migrations) AS module_b',
+      );
+      expect(migrationCounts.rows).toEqual([{module_a: 1, module_b: 1}]);
+    });
+  });
+
+  it('serializes concurrent migration setup on a fresh database', async () => {
+    await withFreshDatabase(async (pool) => {
+      const database = drizzle(pool);
+
+      await Promise.all([
+        runMigrations(database, moduleAMigrations, 'node_drizzle_module_a_migrations'),
+        runMigrations(database, moduleBMigrations, 'node_drizzle_module_b_migrations'),
+      ]);
+
+      const tables = await pool.query<{table_name: string}>(
+        "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_name LIKE 'node_drizzle_test_%' ORDER BY table_name",
+      );
+      expect(tables.rows).toEqual([
+        {table_name: 'node_drizzle_test_module_a'},
+        {table_name: 'node_drizzle_test_module_b'},
+      ]);
+    });
+  });
+});

--- a/libs/shared/node/drizzle/src/cursor.test.ts
+++ b/libs/shared/node/drizzle/src/cursor.test.ts
@@ -1,0 +1,123 @@
+import {sql} from 'drizzle-orm';
+import {
+  decodeNumberIdCursor,
+  decodeStringIdCursor,
+  decodeTimestampIdCursor,
+  encodeNumberIdCursor,
+  encodeStringIdCursor,
+  encodeTimestampIdCursor,
+  paginateTimestampIdRows,
+  timestampIdCursorWhere,
+} from './cursor.js';
+
+function encodeRaw(value: unknown): string {
+  return Buffer.from(JSON.stringify(value), 'utf8').toString('base64url');
+}
+
+describe('timestamp cursors', () => {
+  it('round-trips a timestamp and ID', () => {
+    const cursor = {createdAt: new Date('2026-07-12T12:00:00.000Z'), id: 'run-1'};
+
+    const decoded = decodeTimestampIdCursor(encodeTimestampIdCursor(cursor));
+
+    expect(decoded).toEqual(cursor);
+  });
+
+  it.each([
+    undefined,
+    '',
+    'not-json',
+    encodeRaw([]),
+    encodeRaw({createdAt: 'bad', id: 'run-1'}),
+  ])('rejects an invalid cursor', (cursor) => {
+    const decoded = decodeTimestampIdCursor(cursor);
+
+    expect(decoded).toBeUndefined();
+  });
+
+  it('builds a keyset condition only when a cursor is present', () => {
+    const timestampColumn = sql.raw('created_at');
+    const idColumn = sql.raw('id');
+
+    const absent = timestampIdCursorWhere({timestampColumn, idColumn, cursor: undefined});
+    const present = timestampIdCursorWhere({
+      timestampColumn,
+      idColumn,
+      cursor: {createdAt: new Date('2026-07-12T12:00:00.000Z'), id: 'run-1'},
+    });
+
+    expect(absent).toBeUndefined();
+    expect(present).toBeDefined();
+  });
+});
+
+describe('string cursors', () => {
+  it('round-trips a string value and ID', () => {
+    const cursor = {value: 'alpha', id: 'project-1'};
+
+    const decoded = decodeStringIdCursor(encodeStringIdCursor(cursor));
+
+    expect(decoded).toEqual(cursor);
+  });
+
+  it.each([
+    undefined,
+    '',
+    'not-json',
+    encodeRaw(null),
+    encodeRaw({value: 1, id: 'project-1'}),
+  ])('rejects an invalid cursor', (cursor) => {
+    const decoded = decodeStringIdCursor(cursor);
+
+    expect(decoded).toBeUndefined();
+  });
+});
+
+describe('number cursors', () => {
+  it('round-trips a positive integer and ID', () => {
+    const cursor = {value: 42, id: 'annotation-1'};
+
+    const decoded = decodeNumberIdCursor(encodeNumberIdCursor(cursor));
+
+    expect(decoded).toEqual(cursor);
+  });
+
+  it.each([
+    undefined,
+    '',
+    'not-json',
+    encodeRaw({value: '0', id: 'annotation-1'}),
+    encodeRaw({value: '1.5', id: 'annotation-1'}),
+  ])('rejects an invalid cursor', (cursor) => {
+    const decoded = decodeNumberIdCursor(cursor);
+
+    expect(decoded).toBeUndefined();
+  });
+});
+
+describe('paginateTimestampIdRows', () => {
+  const rows = [
+    {id: 'run-3', createdAt: new Date('2026-07-12T12:03:00.000Z')},
+    {id: 'run-2', createdAt: new Date('2026-07-12T12:02:00.000Z')},
+    {id: 'run-1', createdAt: new Date('2026-07-12T12:01:00.000Z')},
+  ];
+
+  it('returns the requested page and a cursor when another row exists', () => {
+    const page = paginateTimestampIdRows({rows, limit: 2, timestampKey: 'createdAt'});
+
+    expect(page).toEqual({
+      pageRows: rows.slice(0, 2),
+      nextCursor: {createdAt: rows[1]?.createdAt, id: 'run-2'},
+    });
+  });
+
+  it('returns no cursor when all rows fit on the page', () => {
+    const page = paginateTimestampIdRows({
+      rows: rows.slice(0, 2),
+      limit: 2,
+      timestampKey: 'createdAt',
+    });
+
+    expect(page).toEqual({pageRows: rows.slice(0, 2), nextCursor: null});
+  });
+});

--- a/libs/shared/node/drizzle/src/index.test.ts
+++ b/libs/shared/node/drizzle/src/index.test.ts
@@ -1,0 +1,19 @@
+import * as publicApi from './index.js';
+
+describe('@shipfox/node-drizzle public exports', () => {
+  it('exposes only the supported runtime API', () => {
+    expect(Object.keys(publicApi).sort()).toEqual([
+      'decodeNumberIdCursor',
+      'decodeStringIdCursor',
+      'decodeTimestampIdCursor',
+      'drizzle',
+      'encodeNumberIdCursor',
+      'encodeStringIdCursor',
+      'encodeTimestampIdCursor',
+      'paginateTimestampIdRows',
+      'runMigrations',
+      'timestampIdCursorWhere',
+      'uuidv7PrimaryKey',
+    ]);
+  });
+});

--- a/libs/shared/node/drizzle/test/external/package.template.json
+++ b/libs/shared/node/drizzle/test/external/package.template.json
@@ -1,0 +1,17 @@
+{
+  "name": "node-drizzle-external-fixture",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "check": "tsc --project tsconfig.json --noEmit",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@shipfox/node-drizzle": "file:./node-drizzle.tgz"
+  },
+  "devDependencies": {
+    "@types/node": "^24.1.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/libs/shared/node/drizzle/test/external/src/index.ts
+++ b/libs/shared/node/drizzle/test/external/src/index.ts
@@ -1,0 +1,38 @@
+import {
+  decodeNumberIdCursor,
+  decodeStringIdCursor,
+  decodeTimestampIdCursor,
+  drizzle,
+  encodeNumberIdCursor,
+  encodeStringIdCursor,
+  encodeTimestampIdCursor,
+  type NodePgDatabase,
+  paginateTimestampIdRows,
+  runMigrations,
+  timestampIdCursorWhere,
+  uuidv7PrimaryKey,
+} from '@shipfox/node-drizzle';
+
+const timestampCursor = {createdAt: new Date('2026-07-12T12:00:00.000Z'), id: 'row-1'};
+const timestampRows = [{...timestampCursor}];
+
+const results = {
+  number: decodeNumberIdCursor(encodeNumberIdCursor({value: 1, id: 'row-1'})),
+  string: decodeStringIdCursor(encodeStringIdCursor({value: 'alpha', id: 'row-1'})),
+  timestamp: decodeTimestampIdCursor(encodeTimestampIdCursor(timestampCursor)),
+  page: paginateTimestampIdRows({rows: timestampRows, limit: 1, timestampKey: 'createdAt'}),
+  primaryKey: uuidv7PrimaryKey(),
+};
+
+function acceptsDatabase(database: NodePgDatabase): NodePgDatabase {
+  return database;
+}
+
+void acceptsDatabase;
+void drizzle;
+void runMigrations;
+void timestampIdCursorWhere;
+
+if (!results.primaryKey || results.number?.value !== 1) {
+  throw new Error('Public helpers returned an unexpected result');
+}

--- a/libs/shared/node/drizzle/test/external/tsconfig.json
+++ b/libs/shared/node/drizzle/test/external/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2024"
+  },
+  "include": ["src"]
+}

--- a/libs/shared/node/drizzle/test/external/verify.mjs
+++ b/libs/shared/node/drizzle/test/external/verify.mjs
@@ -1,0 +1,63 @@
+import {spawn} from 'node:child_process';
+import {cp, mkdtemp, readFile, realpath, rename, rm} from 'node:fs/promises';
+import {createRequire} from 'node:module';
+import {tmpdir} from 'node:os';
+import {dirname, join, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const fixtureSource = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(fixtureSource, '../..');
+const fixtureRoot = await mkdtemp(join(tmpdir(), 'node-drizzle-external-'));
+const tarball = join(fixtureRoot, 'node-drizzle.tgz');
+
+function run(command, args, cwd) {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(command, args, {cwd, stdio: 'inherit'});
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code === 0) resolvePromise();
+      else reject(new Error(`${command} ${args.join(' ')} exited with code ${code}`));
+    });
+  });
+}
+
+try {
+  await cp(fixtureSource, fixtureRoot, {
+    recursive: true,
+    filter: (source) => source !== import.meta.filename,
+  });
+  await rename(join(fixtureRoot, 'package.template.json'), join(fixtureRoot, 'package.json'));
+  await run('pnpm', ['pack', '--out', tarball], packageRoot);
+  await run('pnpm', ['install', '--ignore-workspace'], fixtureRoot);
+
+  const manifest = JSON.parse(
+    await readFile(join(fixtureRoot, 'node_modules/@shipfox/node-drizzle/package.json'), 'utf8'),
+  );
+  const workspacePostgresManifest = JSON.parse(
+    await readFile(resolve(packageRoot, '../postgres/package.json'), 'utf8'),
+  );
+  const expectedPostgresRange = `^${workspacePostgresManifest.version}`;
+  const postgresRange = manifest.dependencies?.['@shipfox/node-postgres'];
+  if (postgresRange !== expectedPostgresRange) {
+    throw new Error(
+      `Expected @shipfox/node-postgres ${expectedPostgresRange}, received ${postgresRange}`,
+    );
+  }
+  const installedManifestPath = await realpath(
+    join(fixtureRoot, 'node_modules/@shipfox/node-drizzle/package.json'),
+  );
+  const fixtureRequire = createRequire(installedManifestPath);
+  const postgresEntry = fixtureRequire.resolve('@shipfox/node-postgres');
+  const postgresManifest = JSON.parse(
+    await readFile(resolve(dirname(postgresEntry), '../package.json'), 'utf8'),
+  );
+  if (postgresManifest.name !== '@shipfox/node-postgres' || postgresManifest.version === '0.0.0') {
+    throw new Error('The packed package did not install a released @shipfox/node-postgres version');
+  }
+
+  await run('pnpm', ['run', 'check'], fixtureRoot);
+  await run('pnpm', ['run', 'build'], fixtureRoot);
+  await run('pnpm', ['run', 'start'], fixtureRoot);
+} finally {
+  await rm(fixtureRoot, {recursive: true, force: true});
+}

--- a/libs/shared/node/drizzle/test/fixtures/module-a/0000_module_a.sql
+++ b/libs/shared/node/drizzle/test/fixtures/module-a/0000_module_a.sql
@@ -1,0 +1,3 @@
+CREATE TABLE "node_drizzle_test_module_a" (
+	"id" integer PRIMARY KEY
+);

--- a/libs/shared/node/drizzle/test/fixtures/module-a/meta/_journal.json
+++ b/libs/shared/node/drizzle/test/fixtures/module-a/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1783867200000,
+      "tag": "0000_module_a",
+      "breakpoints": true
+    }
+  ]
+}

--- a/libs/shared/node/drizzle/test/fixtures/module-b/0000_module_b.sql
+++ b/libs/shared/node/drizzle/test/fixtures/module-b/0000_module_b.sql
@@ -1,0 +1,3 @@
+CREATE TABLE "node_drizzle_test_module_b" (
+	"id" integer PRIMARY KEY
+);

--- a/libs/shared/node/drizzle/test/fixtures/module-b/meta/_journal.json
+++ b/libs/shared/node/drizzle/test/fixtures/module-b/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1783867200000,
+      "tag": "0000_module_b",
+      "breakpoints": true
+    }
+  ]
+}

--- a/libs/shared/node/drizzle/tsconfig.test.json
+++ b/libs/shared/node/drizzle/tsconfig.test.json
@@ -4,5 +4,5 @@
     "rootDir": "."
   },
   "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
-  "exclude": []
+  "exclude": ["test/external"]
 }

--- a/libs/shared/node/drizzle/vitest.config.ts
+++ b/libs/shared/node/drizzle/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({}, import.meta.url) as UserConfigExport;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5343,7 +5343,7 @@ importers:
   libs/shared/node/drizzle:
     dependencies:
       '@shipfox/node-postgres':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../postgres
       drizzle-orm:
         specifier: ^0.45.2
@@ -5361,6 +5361,9 @@ importers:
       '@shipfox/typescript':
         specifier: workspace:*
         version: link:../../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../../tools/vitest
 
   libs/shared/node/egress-guard:
     dependencies:


### PR DESCRIPTION
Publish `@shipfox/node-drizzle` through the normal Changesets pipeline and define its initial supported package-root API.

Glint and other repositories need the existing migration, UUIDv7, and keyset cursor helpers without depending on the Shipfox workspace. This makes the package public, documents the Node.js 24 and PostgreSQL 18 contract, and requires direct database connections for migrations.

The source dependency stays workspace-linked for local development, while the packed manifest is verified to contain a released semver range for `@shipfox/node-postgres`. A clean external fixture installs the tarball, type-checks, builds, and runs the public helpers. PostgreSQL tests also cover isolated migration histories and concurrent setup.

Closes ENG-907

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes `@shipfox/node-drizzle` for external use and defines its initial public API. Adds safe migrations, UUIDv7 primary keys, and keyset cursor helpers; satisfies ENG-907.

- **New Features**
  - Public API: `drizzle`, `NodePgDatabase`, `runMigrations()`, `uuidv7PrimaryKey()`, and cursor helpers (encode/decode, where, pagination).
  - Migration safety: advisory lock + transaction; isolated histories by table name; concurrent setup covered in tests.
  - External packaging check packs and installs the tarball; verifies a released semver range for `@shipfox/node-postgres` and the public exports.

- **Migration**
  - Requires Node.js 24 and PostgreSQL 18.
  - Install: pnpm add `@shipfox/node-drizzle` `@shipfox/node-postgres` `drizzle-orm`.
  - Use a direct database connection for `runMigrations()` and give each module a unique migration table if sharing a database.

<sup>Written for commit cc031d8836b1fe8d5250396afe05bd4345a4ab4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

