### PR TITLE
[node-postgres] Add managed TLS and pool configuration

### DIFF
--- a/.changeset/quiet-pools-connect.md
+++ b/.changeset/quiet-pools-connect.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/node-postgres": minor
+---
+
+Adds verified TLS modes and serverless pool timeout configuration with safe duplicate initialization.

--- a/libs/shared/node/postgres/README.md
+++ b/libs/shared/node/postgres/README.md
@@ -1,85 +1,102 @@
 # Shipfox Postgres
 
-Thin wrapper around `pg` for Shipfox Node services. It creates one shared pool from environment config and exposes health and shutdown helpers.
+PostgreSQL pool setup for Shipfox services and Node.js 24 apps.
 
 ## What it does
 
-- **`createPostgresClient(options?)`** creates and stores one `pg.Pool`.
-- **`pgClient()`** returns the current pool.
-- **`closePostgresClient()`** closes and clears the pool.
-- **`isPostgresHealthy()`** runs `SELECT 1`.
-- **`DatabaseError` and `pg` types** are re-exported.
-
-Environment variables (with defaults):
-
-- `POSTGRES_HOST` (default: `localhost`)
-- `POSTGRES_PORT` (default: `5432`)
-- `POSTGRES_USERNAME` (default: `shipfox`)
-- `POSTGRES_PASSWORD` (default: `password`)
-- `POSTGRES_DATABASE` (default: `api`)
-- `POSTGRES_MAX_CONNECTIONS` (default: `10`)
+- **`createPostgresClient(options?)`**: Creates one shared `pg.Pool` from the environment and optional overrides.
+- **`pgClient()`**: Returns the shared pool after initialization.
+- **`closePostgresClient()`**: Closes and clears the shared pool.
+- **`isPostgresHealthy()`**: Runs `SELECT 1` through the shared pool.
+- **PostgreSQL exports**: Re-exports `DatabaseError` and the public `pg` types.
 
 ## Installation
 
-```bash
+```sh
 pnpm add @shipfox/node-postgres
-# or
-yarn add @shipfox/node-postgres
-# or
-npm install @shipfox/node-postgres
 ```
 
 ## Usage
 
 ```ts
 import {
-  createPostgresClient,
-  pgClient,
   closePostgresClient,
+  createPostgresClient,
   isPostgresHealthy,
-  type Pool,
-} from "@shipfox/node-postgres";
+  pgClient,
+} from '@shipfox/node-postgres';
 
-const pool: Pool = createPostgresClient({
-  // connectionTimeoutMillis: 5000,
-  // max: 10,
-});
+createPostgresClient();
 
-async function getServerTime() {
-  const client = await pgClient().connect();
-  try {
-    const res = await client.query("SELECT NOW() AS now");
-    return res.rows[0]?.now;
-  } finally {
-    client.release();
-  }
-}
+const result = await pgClient().query('SELECT NOW() AS now');
+console.log(result.rows[0]?.now);
 
-async function ready() {
-  return await isPostgresHealthy();
-}
-
-async function shutdown() {
-  await closePostgresClient();
-}
+const ready = await isPostgresHealthy();
+await closePostgresClient();
 ```
 
-Configure via environment variables before starting your app:
+## Environment
 
-```bash
-export POSTGRES_HOST="127.0.0.1"
-export POSTGRES_PORT="5432"
-export POSTGRES_USERNAME="service_user"
-export POSTGRES_PASSWORD="supersecret"
-export POSTGRES_DATABASE="appdb"
-export POSTGRES_MAX_CONNECTIONS="10"
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `POSTGRES_HOST` | `localhost` | PostgreSQL hostname. |
+| `POSTGRES_PORT` | `5432` | PostgreSQL port. |
+| `POSTGRES_USERNAME` | `shipfox` | PostgreSQL user. |
+| `POSTGRES_PASSWORD` | `password` | PostgreSQL password. Set a strong value in production. |
+| `POSTGRES_DATABASE` | `api` | PostgreSQL database. |
+| `POSTGRES_MAX_CONNECTIONS` | `10` | Largest number of connections in the local pool. |
+| `POSTGRES_CONNECTION_TIMEOUT_MS` | `5000` | Time allowed to connect. Set it to `0` to wait without a timeout. |
+| `POSTGRES_IDLE_TIMEOUT_MS` | `10000` | Time an unused connection stays open. Set it to `0` to keep idle connections open. |
+| `POSTGRES_TLS_MODE` | `disable` | TLS policy. Use `disable` or `verify-full`. |
+
+`verify-full` checks the server certificate and hostname. Use it for a managed production database. Use `disable` for local development.
+
+### Serverless application
+
+Use the provider's pooled hostname for application traffic. A pool size of one limits each serverless instance to one connection. A short idle timeout releases unused connections. This allows the database to scale to zero.
+
+```sh
+POSTGRES_HOST=pool.example.com
+POSTGRES_PORT=5432
+POSTGRES_USERNAME=application
+POSTGRES_PASSWORD=replace-me
+POSTGRES_DATABASE=application
+POSTGRES_MAX_CONNECTIONS=1
+POSTGRES_CONNECTION_TIMEOUT_MS=5000
+POSTGRES_IDLE_TIMEOUT_MS=10000
+POSTGRES_TLS_MODE=verify-full
 ```
+
+### Migrations
+
+Use the provider's direct hostname for migrations. Keep the same verified TLS mode.
+
+```sh
+POSTGRES_HOST=direct.example.com
+POSTGRES_PORT=5432
+POSTGRES_USERNAME=migrations
+POSTGRES_PASSWORD=replace-me
+POSTGRES_DATABASE=application
+POSTGRES_MAX_CONNECTIONS=1
+POSTGRES_CONNECTION_TIMEOUT_MS=5000
+POSTGRES_IDLE_TIMEOUT_MS=10000
+POSTGRES_TLS_MODE=verify-full
+```
+
+## Behavior Notes
+
+- The environment uses split connection fields. Application and migration processes can select different hosts without parsing a connection URL.
+- Caller options still override environment settings for existing consumers.
+- A second call to `createPostgresClient()` throws until `closePostgresClient()` completes.
+- `isPostgresHealthy()` executes a real query. A health check wakes a suspended database and can delay scale to zero.
 
 ## Development
 
 ```sh
 turbo check --filter=@shipfox/node-postgres
 turbo type --filter=@shipfox/node-postgres
+turbo test --filter=@shipfox/node-postgres
+turbo build --filter=@shipfox/node-postgres
 ```
 
 ## License

--- a/libs/shared/node/postgres/package.json
+++ b/libs/shared/node/postgres/package.json
@@ -31,6 +31,8 @@
     "build": "shipfox-swc",
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
+    "test": "shipfox-vitest-run",
+    "test:watch": "shipfox-vitest-watch",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"
   },
@@ -43,6 +45,7 @@
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*",
     "@types/pg": "^8.15.5"
   }
 }

--- a/libs/shared/node/postgres/src/config.test.ts
+++ b/libs/shared/node/postgres/src/config.test.ts
@@ -1,0 +1,19 @@
+import {loadPostgresConfig} from './config.js';
+
+describe('loadPostgresConfig', () => {
+  it('rejects an unsupported TLS mode', () => {
+    const act = () => loadPostgresConfig({POSTGRES_TLS_MODE: 'require'});
+
+    expect(act).toThrow('process.exit unexpectedly called with "1"');
+  });
+
+  it.each([
+    'POSTGRES_MAX_CONNECTIONS',
+    'POSTGRES_CONNECTION_TIMEOUT_MS',
+    'POSTGRES_IDLE_TIMEOUT_MS',
+  ] as const)('rejects a non-numeric %s value', (name) => {
+    const act = () => loadPostgresConfig({[name]: 'invalid'});
+
+    expect(act).toThrow('process.exit unexpectedly called with "1"');
+  });
+});

--- a/libs/shared/node/postgres/src/config.test.ts
+++ b/libs/shared/node/postgres/src/config.test.ts
@@ -1,6 +1,40 @@
-import {loadPostgresConfig} from './config.js';
+import {loadPostgresConfig, postgresConfigSchema} from './config.js';
+
+const ENVIRONMENT_VARIABLE_NAMES = Object.keys(postgresConfigSchema);
+
+let originalEnvironment: Map<string, string | undefined>;
 
 describe('loadPostgresConfig', () => {
+  beforeEach(() => {
+    originalEnvironment = new Map(
+      ENVIRONMENT_VARIABLE_NAMES.map((name) => [name, process.env[name]]),
+    );
+    for (const name of ENVIRONMENT_VARIABLE_NAMES) delete process.env[name];
+  });
+
+  afterEach(() => {
+    for (const [name, value] of originalEnvironment) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  });
+
+  it('loads the documented defaults', () => {
+    const config = loadPostgresConfig();
+
+    expect(config).toMatchObject({
+      POSTGRES_HOST: 'localhost',
+      POSTGRES_PORT: 5432,
+      POSTGRES_USERNAME: 'shipfox',
+      POSTGRES_PASSWORD: 'password',
+      POSTGRES_DATABASE: 'api',
+      POSTGRES_MAX_CONNECTIONS: 10,
+      POSTGRES_CONNECTION_TIMEOUT_MS: 5_000,
+      POSTGRES_IDLE_TIMEOUT_MS: 10_000,
+      POSTGRES_TLS_MODE: 'disable',
+    });
+  });
+
   it('rejects an unsupported TLS mode', () => {
     const act = () => loadPostgresConfig({POSTGRES_TLS_MODE: 'require'});
 
@@ -15,5 +49,24 @@ describe('loadPostgresConfig', () => {
     const act = () => loadPostgresConfig({[name]: 'invalid'});
 
     expect(act).toThrow('process.exit unexpectedly called with "1"');
+  });
+
+  it.each([
+    'POSTGRES_CONNECTION_TIMEOUT_MS',
+    'POSTGRES_IDLE_TIMEOUT_MS',
+  ] as const)('rejects a negative %s value', (name) => {
+    const act = () => loadPostgresConfig({[name]: '-1'});
+
+    expect(act).toThrow(`${name} must be 0 or greater`);
+  });
+
+  it('accepts zero timeout values', () => {
+    const config = loadPostgresConfig({
+      POSTGRES_CONNECTION_TIMEOUT_MS: '0',
+      POSTGRES_IDLE_TIMEOUT_MS: '0',
+    });
+
+    expect(config.POSTGRES_CONNECTION_TIMEOUT_MS).toBe(0);
+    expect(config.POSTGRES_IDLE_TIMEOUT_MS).toBe(0);
   });
 });

--- a/libs/shared/node/postgres/src/config.ts
+++ b/libs/shared/node/postgres/src/config.ts
@@ -41,9 +41,20 @@ export const postgresConfigSchema = {
 };
 
 export function loadPostgresConfig(update?: Partial<NodeJS.ProcessEnv>) {
-  return createConfig(postgresConfigSchema, update);
+  const loadedConfig = createConfig(postgresConfigSchema, update);
+
+  validateTimeout('POSTGRES_CONNECTION_TIMEOUT_MS', loadedConfig.POSTGRES_CONNECTION_TIMEOUT_MS);
+  validateTimeout('POSTGRES_IDLE_TIMEOUT_MS', loadedConfig.POSTGRES_IDLE_TIMEOUT_MS);
+
+  return loadedConfig;
 }
 
 export type PostgresConfig = ReturnType<typeof loadPostgresConfig>;
 
 export const config = loadPostgresConfig();
+
+function validateTimeout(name: string, value: number) {
+  if (value < 0) {
+    throw new Error(`${name} must be 0 or greater`);
+  }
+}

--- a/libs/shared/node/postgres/src/config.ts
+++ b/libs/shared/node/postgres/src/config.ts
@@ -1,8 +1,8 @@
 import {createConfig, host, num, str} from '@shipfox/config';
 
-export const config = createConfig({
+export const postgresConfigSchema = {
   POSTGRES_HOST: host({
-    desc: 'Hostname of the PostgreSQL server.',
+    desc: 'Hostname of the PostgreSQL server. Use the pooled hostname for application traffic and the direct hostname for migrations.',
     default: 'localhost',
   }),
   POSTGRES_PORT: num({
@@ -25,4 +25,25 @@ export const config = createConfig({
     desc: 'Largest number of connections the pool keeps open. Higher values allow more queries at once but use more resources.',
     default: 10,
   }),
-});
+  POSTGRES_CONNECTION_TIMEOUT_MS: num({
+    desc: 'How long the pool waits to connect before it reports an error, in milliseconds. Use 0 to wait without a timeout.',
+    default: 5_000,
+  }),
+  POSTGRES_IDLE_TIMEOUT_MS: num({
+    desc: 'How long an unused connection stays open, in milliseconds. Use 0 to keep idle connections open.',
+    default: 10_000,
+  }),
+  POSTGRES_TLS_MODE: str({
+    desc: 'How the client secures the PostgreSQL connection. Use disable for local development or verify-full to verify the certificate and hostname.',
+    choices: ['disable', 'verify-full'] as const,
+    default: 'disable' as const,
+  }),
+};
+
+export function loadPostgresConfig(update?: Partial<NodeJS.ProcessEnv>) {
+  return createConfig(postgresConfigSchema, update);
+}
+
+export type PostgresConfig = ReturnType<typeof loadPostgresConfig>;
+
+export const config = loadPostgresConfig();

--- a/libs/shared/node/postgres/src/index.test.ts
+++ b/libs/shared/node/postgres/src/index.test.ts
@@ -1,0 +1,35 @@
+import {closePostgresClient, createPostgresClient, isPostgresHealthy, pgClient} from './index.js';
+
+describe('Postgres client', () => {
+  afterEach(async () => {
+    await closePostgresClient();
+  });
+
+  it('rejects duplicate initialization without replacing the pool', () => {
+    const pool = createPostgresClient();
+
+    const act = () => createPostgresClient();
+
+    expect(act).toThrow('Postgres client has already been created');
+    expect(pgClient()).toBe(pool);
+  });
+
+  it('clears the pool after shutdown', async () => {
+    createPostgresClient();
+
+    await closePostgresClient();
+    const act = () => pgClient();
+
+    expect(act).toThrow('Postgres client has not been created');
+  });
+
+  it('reports a successful health query', async () => {
+    const pool = createPostgresClient();
+    vi.spyOn(pool, 'query').mockResolvedValue({rowCount: 1} as never);
+
+    const healthy = await isPostgresHealthy();
+
+    expect(healthy).toBe(true);
+    expect(pool.query).toHaveBeenCalledWith('SELECT 1');
+  });
+});

--- a/libs/shared/node/postgres/src/index.ts
+++ b/libs/shared/node/postgres/src/index.ts
@@ -1,5 +1,6 @@
 import pg from 'pg';
 import {config} from './config.js';
+import {createPoolConfig} from './pool-config.js';
 
 export type * from 'pg';
 
@@ -8,18 +9,11 @@ export {DatabaseError} from 'pg';
 let _pool: pg.Pool | undefined;
 
 export function createPostgresClient(options?: pg.PoolConfig): pg.Pool {
-  _pool = new pg.Pool({
-    host: config.POSTGRES_HOST,
-    port: config.POSTGRES_PORT,
-    database: config.POSTGRES_DATABASE,
-    user: config.POSTGRES_USERNAME,
-    password: config.POSTGRES_PASSWORD,
-    max: config.POSTGRES_MAX_CONNECTIONS,
-    keepAlive: true,
-    idleTimeoutMillis: 10_000,
-    connectionTimeoutMillis: 5_000,
-    ...options,
-  });
+  if (_pool) {
+    throw new Error('Postgres client has already been created');
+  }
+
+  _pool = new pg.Pool(createPoolConfig(config, options));
   return _pool;
 }
 

--- a/libs/shared/node/postgres/src/pool-config.test.ts
+++ b/libs/shared/node/postgres/src/pool-config.test.ts
@@ -1,0 +1,50 @@
+import {loadPostgresConfig} from './config.js';
+import {createPoolConfig} from './pool-config.js';
+
+describe('createPoolConfig', () => {
+  it.each([
+    ['disable', false],
+    ['verify-full', {rejectUnauthorized: true}],
+  ] as const)('maps the %s TLS mode', (tlsMode, expected) => {
+    const config = loadPostgresConfig({POSTGRES_TLS_MODE: tlsMode});
+
+    const poolConfig = createPoolConfig(config);
+
+    expect(poolConfig.ssl).toEqual(expected);
+  });
+
+  it('maps the maximum connection count', () => {
+    const config = loadPostgresConfig({POSTGRES_MAX_CONNECTIONS: '1'});
+
+    const poolConfig = createPoolConfig(config);
+
+    expect(poolConfig.max).toBe(1);
+  });
+
+  it('maps connection and idle timeouts', () => {
+    const config = loadPostgresConfig({
+      POSTGRES_CONNECTION_TIMEOUT_MS: '2000',
+      POSTGRES_IDLE_TIMEOUT_MS: '3000',
+    });
+
+    const poolConfig = createPoolConfig(config);
+
+    expect(poolConfig.connectionTimeoutMillis).toBe(2_000);
+    expect(poolConfig.idleTimeoutMillis).toBe(3_000);
+  });
+
+  it('keeps caller overrides backward compatible', () => {
+    const config = loadPostgresConfig({
+      POSTGRES_MAX_CONNECTIONS: '10',
+      POSTGRES_TLS_MODE: 'disable',
+    });
+
+    const poolConfig = createPoolConfig(config, {
+      max: 2,
+      ssl: {rejectUnauthorized: true},
+    });
+
+    expect(poolConfig.max).toBe(2);
+    expect(poolConfig.ssl).toEqual({rejectUnauthorized: true});
+  });
+});

--- a/libs/shared/node/postgres/src/pool-config.ts
+++ b/libs/shared/node/postgres/src/pool-config.ts
@@ -1,0 +1,18 @@
+import type {PoolConfig} from 'pg';
+import type {PostgresConfig} from './config.js';
+
+export function createPoolConfig(config: PostgresConfig, options?: PoolConfig): PoolConfig {
+  return {
+    host: config.POSTGRES_HOST,
+    port: config.POSTGRES_PORT,
+    database: config.POSTGRES_DATABASE,
+    user: config.POSTGRES_USERNAME,
+    password: config.POSTGRES_PASSWORD,
+    max: config.POSTGRES_MAX_CONNECTIONS,
+    keepAlive: true,
+    idleTimeoutMillis: config.POSTGRES_IDLE_TIMEOUT_MS,
+    connectionTimeoutMillis: config.POSTGRES_CONNECTION_TIMEOUT_MS,
+    ssl: config.POSTGRES_TLS_MODE === 'verify-full' ? {rejectUnauthorized: true} : false,
+    ...options,
+  };
+}

--- a/libs/shared/node/postgres/vitest.config.ts
+++ b/libs/shared/node/postgres/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({}, import.meta.url) as UserConfigExport;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5738,6 +5738,9 @@ importers:
       '@shipfox/typescript':
         specifier: workspace:*
         version: link:../../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../../tools/vitest
       '@types/pg':
         specifier: ^8.15.5
         version: 8.20.0


### PR DESCRIPTION
Add supported environment settings for verified PostgreSQL TLS, connection timeouts, idle timeouts, and serverless pool sizing.

External Node.js consumers previously needed application-specific `pg.PoolConfig` parsing for secure managed databases. The package now maps `verify-full` to certificate and hostname verification while preserving the existing local defaults and caller override behavior. Duplicate initialization also fails clearly instead of replacing and leaking the active pool.

The configuration remains split into individual fields instead of adding a connection URL. This keeps pooled application and direct migration hosts explicit without requiring consumers to parse or rewrite URLs.

The TLS mapping, caller override precedence, and duplicate initialization boundary deserve careful review. The README includes pooled application and direct migration examples, plus the scale-to-zero effect of idle connections and health queries.

Closes ENG-908

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add verified TLS, strict timeout config, and serverless-friendly pool settings to `@shipfox/node-postgres`, enabling secure managed PostgreSQL connections without custom `pg.PoolConfig` parsing. Addresses ENG-908.

- **New Features**
  - TLS modes via `POSTGRES_TLS_MODE` with `disable` (local) and `verify-full` (certificate + hostname verification).
  - Connection controls: `POSTGRES_CONNECTION_TIMEOUT_MS` and `POSTGRES_IDLE_TIMEOUT_MS` (both defaulted; `0` disables; negative values are rejected).
  - Serverless sizing: use `POSTGRES_MAX_CONNECTIONS` to cap concurrency; docs include pooled app vs direct migration host examples and scale-to-zero notes.
  - Safer lifecycle: calling `createPostgresClient()` twice now throws until `closePostgresClient()` completes.
  - Backward compatible: split env fields retained (no URL), and caller `pg.PoolConfig` overrides still take precedence; README and tests cover mapping and behavior.

<sup>Written for commit 2b1f8bb25d7dcaecdb5ababb803dd4ddd3b77b96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

