### PR TITLE
[redact] Add structured and signed URL redaction primitives

### DIFF
--- a/libs/shared/common/redact/README.md
+++ b/libs/shared/common/redact/README.md
@@ -18,6 +18,16 @@ across Shipfox so they cannot drift.
   secret, then applies `redactUrlCredentials`. The helper only removes the
   literals it is given, so pass every wire form a secret takes; use
   `secretWireForms` to derive them.
+- **`redactSensitiveUrl(url)`** redacts userinfo plus sensitive query and
+  fragment fields in one parseable URL. It covers signed S3-compatible URLs,
+  OAuth callbacks, and non-HTTP schemes such as `postgres`, `redis`, and `ftp`.
+- **`redactSensitiveText(text, options)`** redacts URLs, Authorization schemes,
+  cookies, webhook signatures, sensitive key-value pairs, and configured
+  secrets from free text.
+- **`createRedactor(options)`** returns a provider-independent recursive
+  redactor for strings, arrays, JSON-like objects, `Error`, `URL`, and `Date`
+  values. It returns copies instead of mutating input and safely replaces
+  circular references with `[Circular]`.
 - **`secretWireForms(secret)`** derives every wire form one secret can appear as
   in captured output: the literal, its base64 and base64url forms (all three
   phase alignments, so a secret embedded in a larger encoded blob is masked too),
@@ -43,7 +53,10 @@ pnpm add @shipfox/redact
 
 ```ts
 import {
+  createRedactor,
   redactSecrets,
+  redactSensitiveText,
+  redactSensitiveUrl,
   redactUrlCredentials,
   secretWireForms,
   stripUrlCredentials,
@@ -61,6 +74,21 @@ redactSecrets("Authorization: Basic dXNlcjp0b2tlbg==", ["dXNlcjp0b2tlbg=="]);
 // Mask a token in every form it might appear as (base64, hex, URL-encoded, ...).
 redactSecrets("digest=" + tokenAsHex, secretWireForms(token));
 // -> "digest=***"
+
+redactSensitiveUrl(
+  "https://objects.example/file?X-Amz-Credential=credential&X-Amz-Signature=signature",
+);
+// -> "https://objects.example/file?X-Amz-Credential=***&X-Amz-Signature=***"
+
+redactSensitiveText("Authorization: AWS4-HMAC-SHA256 signed-credentials");
+// -> "Authorization: ***"
+
+const redactor = createRedactor({secrets: [runtimeSecret]});
+redactor.redact({
+  databaseUrl: `postgres://user:${runtimeSecret}@db/glint`,
+  token: "project-token",
+});
+// -> {databaseUrl: "postgres://***@db/glint", token: "***"}
 ```
 
 ## Development

--- a/libs/shared/common/redact/README.md
+++ b/libs/shared/common/redact/README.md
@@ -27,7 +27,9 @@ across Shipfox so they cannot drift.
 - **`createRedactor(options)`** returns a provider-independent recursive
   redactor for strings, arrays, JSON-like objects, `Error`, `URL`, and `Date`
   values. It returns copies instead of mutating input and safely replaces
-  circular references with `[Circular]`.
+  circular references with `[Circular]`. String, `URL`, and `Date` inputs return
+  strings; other structured inputs return `unknown` because their keys and
+  values can change representation during redaction.
 - **`secretWireForms(secret)`** derives every wire form one secret can appear as
   in captured output: the literal, its base64 and base64url forms (all three
   phase alignments, so a secret embedded in a larger encoded blob is masked too),

--- a/libs/shared/common/redact/src/index.test.ts
+++ b/libs/shared/common/redact/src/index.test.ts
@@ -36,6 +36,17 @@ describe('redactSensitiveUrl', () => {
     expect(result).toContain('state=public');
   });
 
+  it('redacts OpenStack Swift temporary URL signatures', () => {
+    const input =
+      'https://objects.example/v1/account/container/object?temp_url_sig=secret-signature&temp_url_expires=1783886400';
+
+    const result = redactSensitiveUrl(input);
+
+    expect(result).not.toContain('secret-signature');
+    expect(result).toContain('temp_url_sig=***');
+    expect(result).toContain('temp_url_expires=1783886400');
+  });
+
   it.each(['postgres', 'redis', 'ftp'])('redacts %s URL credentials', (scheme) => {
     const result = redactSensitiveUrl(`${scheme}://user:password@example.com/resource`);
 
@@ -80,9 +91,10 @@ describe('createRedactor', () => {
     };
 
     const result = createRedactor().redact(input);
+    const resultRecord = result as {nested: unknown};
 
     expect(result).not.toBe(input);
-    expect(result.nested).not.toBe(input.nested);
+    expect(resultRecord.nested).not.toBe(input.nested);
     expect(JSON.stringify(result)).not.toContain('project-token');
     expect(JSON.stringify(result)).not.toContain('password');
     expect(JSON.stringify(result)).not.toContain('plain-token');
@@ -94,6 +106,7 @@ describe('createRedactor', () => {
     const error = new Error(`Request failed with ${secret}`, {
       cause: new Error('Authorization: Basic encoded-credentials'),
     });
+    error.name = `Custom${secret}`;
     const input = {
       date: new Date('2026-07-12T12:00:00.000Z'),
       error,
@@ -110,6 +123,38 @@ describe('createRedactor', () => {
     expect(serialized).toContain('Error');
   });
 
+  it('redacts configured secrets used as object keys', () => {
+    const secret = 'dynamic-property-secret-with-entropy';
+    const input = {[secret]: 'public value'};
+
+    const result = createRedactor({secrets: [secret]}).redact(input);
+    const serialized = JSON.stringify(result);
+
+    expect(serialized).not.toContain(secret);
+    expect(serialized).toContain(REDACTION_PLACEHOLDER);
+    expect(input).toHaveProperty(secret);
+  });
+
+  it('serializes invalid Date values without throwing', () => {
+    const input = new Date(Number.NaN);
+
+    const result = createRedactor().redact(input);
+
+    expect(result).toBe('Invalid Date');
+  });
+
+  it('types transformed structured values as unknown', () => {
+    const redactor = createRedactor();
+
+    const text = redactor.redact('public');
+    const date = redactor.redact(new Date());
+    const structured = redactor.redact({value: 'public'});
+
+    expectTypeOf(text).toEqualTypeOf<string>();
+    expectTypeOf(date).toEqualTypeOf<string>();
+    expectTypeOf(structured).toEqualTypeOf<unknown>();
+  });
+
   it('replaces circular references while preserving repeated non-circular values', () => {
     const shared = {value: 'public'};
     const input: {self?: unknown; first: typeof shared; second: typeof shared} = {
@@ -119,11 +164,12 @@ describe('createRedactor', () => {
     input.self = input;
 
     const result = createRedactor().redact(input);
+    const resultRecord = result as Record<string, unknown>;
 
-    expect(result.self).toBe('[Circular]');
-    expect(result.first).toEqual(shared);
-    expect(result.second).toEqual(shared);
-    expect(result.first).not.toBe(result.second);
+    expect(resultRecord.self).toBe('[Circular]');
+    expect(resultRecord.first).toEqual(shared);
+    expect(resultRecord.second).toEqual(shared);
+    expect(resultRecord.first).not.toBe(resultRecord.second);
   });
 });
 

--- a/libs/shared/common/redact/src/index.test.ts
+++ b/libs/shared/common/redact/src/index.test.ts
@@ -1,11 +1,131 @@
 import {
+  createRedactor,
   REDACTION_PLACEHOLDER,
   redactSecrets,
+  redactSensitiveText,
+  redactSensitiveUrl,
   redactUrlCredentials,
   safeRedactionPrefixLength,
   secretWireForms,
   stripUrlCredentials,
 } from './index.js';
+
+describe('redactSensitiveUrl', () => {
+  it('redacts signed S3-compatible query fields while preserving public fields', () => {
+    const input =
+      'https://objects.example/assets/hash?X-Amz-Credential=credential&X-Amz-Signature=signature&X-Amz-Expires=300&download=1';
+
+    const result = redactSensitiveUrl(input);
+
+    expect(result).not.toContain('credential');
+    expect(result).not.toContain('signature');
+    expect(result).toContain('X-Amz-Credential=***');
+    expect(result).toContain('X-Amz-Signature=***');
+    expect(result).toContain('X-Amz-Expires=***');
+    expect(result).toContain('download=1');
+  });
+
+  it('redacts OAuth token fragments while preserving public fragment fields', () => {
+    const input =
+      'https://example.com/callback#access_token=fragment-token&token_type=bearer&state=public';
+
+    const result = redactSensitiveUrl(input);
+
+    expect(result).not.toContain('fragment-token');
+    expect(result).toContain('access_token=***');
+    expect(result).toContain('state=public');
+  });
+
+  it.each(['postgres', 'redis', 'ftp'])('redacts %s URL credentials', (scheme) => {
+    const result = redactSensitiveUrl(`${scheme}://user:password@example.com/resource`);
+
+    expect(result).not.toContain('user');
+    expect(result).not.toContain('password');
+    expect(result).toContain(`${scheme}://***@example.com/resource`);
+  });
+});
+
+describe('redactSensitiveText', () => {
+  it.each([
+    ['Authorization: Basic encoded-credentials', 'encoded-credentials'],
+    ['Authorization: AWS4-HMAC-SHA256 signed-credentials', 'signed-credentials'],
+    ['Cookie: session=secret-session', 'secret-session'],
+    ['Set-Cookie: session=secret-session; HttpOnly', 'secret-session'],
+    ['X-Hub-Signature-256: sha256=secret-signature', 'secret-signature'],
+    ['credential=plain-credential token=plain-token signature=plain-signature', 'plain-token'],
+  ])('redacts common credential text %s', (input, secret) => {
+    const result = redactSensitiveText(input);
+
+    expect(result).not.toContain(secret);
+    expect(result).toContain(REDACTION_PLACEHOLDER);
+  });
+
+  it('redacts configured secrets in supported wire forms', () => {
+    const secret = 'configured secret with entropy';
+    const encoded = encodeURIComponent(secret);
+
+    const result = redactSensitiveText(`callback?opaque=${encoded}`, {secrets: [secret]});
+
+    expect(result).not.toContain(encoded);
+    expect(result).toContain(REDACTION_PLACEHOLDER);
+  });
+});
+
+describe('createRedactor', () => {
+  it('redacts nested values without mutating caller-owned input', () => {
+    const input = {
+      authorization: 'Bearer project-token',
+      nested: {endpoint: 'redis://user:password@example.com/0'},
+      values: ['token=plain-token'],
+    };
+
+    const result = createRedactor().redact(input);
+
+    expect(result).not.toBe(input);
+    expect(result.nested).not.toBe(input.nested);
+    expect(JSON.stringify(result)).not.toContain('project-token');
+    expect(JSON.stringify(result)).not.toContain('password');
+    expect(JSON.stringify(result)).not.toContain('plain-token');
+    expect(input.nested.endpoint).toContain('password');
+  });
+
+  it('redacts URL and Error values and serializes Date values', () => {
+    const secret = 'configured-secret-with-entropy';
+    const error = new Error(`Request failed with ${secret}`, {
+      cause: new Error('Authorization: Basic encoded-credentials'),
+    });
+    const input = {
+      date: new Date('2026-07-12T12:00:00.000Z'),
+      error,
+      url: new URL(`postgres://user:password@example.com/${secret}`),
+    };
+
+    const result = createRedactor({secrets: [secret]}).redact(input);
+    const serialized = JSON.stringify(result);
+
+    expect(serialized).not.toContain(secret);
+    expect(serialized).not.toContain('password');
+    expect(serialized).not.toContain('encoded-credentials');
+    expect(serialized).toContain('2026-07-12T12:00:00.000Z');
+    expect(serialized).toContain('Error');
+  });
+
+  it('replaces circular references while preserving repeated non-circular values', () => {
+    const shared = {value: 'public'};
+    const input: {self?: unknown; first: typeof shared; second: typeof shared} = {
+      first: shared,
+      second: shared,
+    };
+    input.self = input;
+
+    const result = createRedactor().redact(input);
+
+    expect(result.self).toBe('[Circular]');
+    expect(result.first).toEqual(shared);
+    expect(result.second).toEqual(shared);
+    expect(result.first).not.toBe(result.second);
+  });
+});
 
 describe('redactUrlCredentials', () => {
   it.each([

--- a/libs/shared/common/redact/src/index.ts
+++ b/libs/shared/common/redact/src/index.ts
@@ -5,7 +5,7 @@ const CIRCULAR_PLACEHOLDER = '[Circular]';
 const SENSITIVE_KEY =
   /(?:authorization|cookie|credential|password|private[_-]?key|secret|signature|token|api[_-]?key)/i;
 const SENSITIVE_URL_FIELD =
-  /^(?:access[_-]?token|authorization|awsaccesskeyid|client[_-]?secret|code|credential|googleaccessid|id[_-]?token|password|policy|refresh[_-]?token|secret|signature|sig|token|x-amz-(?:algorithm|credential|date|expires|security-token|signature|signedheaders)|x-goog-(?:algorithm|credential|date|expires|signature|signedheaders)|x-oss-(?:credential|signature))$/i;
+  /^(?:access[_-]?token|authorization|awsaccesskeyid|client[_-]?secret|code|credential|googleaccessid|id[_-]?token|password|policy|refresh[_-]?token|secret|signature|sig|temp_url_sig|token|x-amz-(?:algorithm|credential|date|expires|security-token|signature|signedheaders)|x-goog-(?:algorithm|credential|date|expires|signature|signedheaders)|x-oss-(?:credential|signature))$/i;
 const SENSITIVE_TEXT_PAIR =
   /(\b(?:access[_-]?token|api[_-]?key|authorization|client[_-]?secret|code|credential|id[_-]?token|password|refresh[_-]?token|secret|signature|sig|token|x-amz-signature)\b)\s*[:=]\s*[^\s,;&#]+/gi;
 const SCHEME_URL = /[a-z][a-z0-9+.-]{0,31}:\/\/[^\s"'<>]+/gi;
@@ -16,8 +16,14 @@ export interface StructuredRedactionOptions {
 }
 
 export interface Redactor {
-  /** Returns a redacted copy of `value`. Caller-owned objects are never mutated. */
-  redact<T>(value: T): T;
+  /**
+   * Returns a redacted copy of `value`. String, URL, and Date inputs become
+   * strings. Other inputs return `unknown` because keys, values, errors, and
+   * circular references can change representation. Caller-owned values are
+   * never mutated.
+   */
+  redact(value: string | Date | URL): string;
+  redact(value: unknown): unknown;
 }
 
 // Bounded scheme length keeps the match linear: an unbounded `*` before the
@@ -295,7 +301,9 @@ export function createRedactor(options: StructuredRedactionOptions = {}): Redact
     if (typeof value === 'string') return redactText(value);
     if (value === null || typeof value !== 'object') return value;
     if (value instanceof URL) return redactSensitiveUrl(redactText(value.toString()));
-    if (value instanceof Date) return value.toISOString();
+    if (value instanceof Date) {
+      return Number.isNaN(value.getTime()) ? value.toString() : value.toISOString();
+    }
     if (ancestors.has(value)) return CIRCULAR_PLACEHOLDER;
 
     ancestors.add(value);
@@ -304,7 +312,7 @@ export function createRedactor(options: StructuredRedactionOptions = {}): Redact
         return {
           cause: value.cause === undefined ? undefined : visit(value.cause, ancestors),
           message: redactText(value.message),
-          name: value.name,
+          name: redactText(value.name),
           stack: value.stack ? redactText(value.stack) : undefined,
         };
       }
@@ -312,7 +320,7 @@ export function createRedactor(options: StructuredRedactionOptions = {}): Redact
 
       return Object.fromEntries(
         Object.entries(value).map(([key, item]) => [
-          key,
+          redactText(key),
           SENSITIVE_KEY.test(key) ? REDACTION_PLACEHOLDER : visit(item, ancestors),
         ]),
       );
@@ -321,7 +329,11 @@ export function createRedactor(options: StructuredRedactionOptions = {}): Redact
     }
   }
 
-  return {
-    redact: <T>(value: T): T => visit(value, new WeakSet()) as T,
-  };
+  function redact(value: string | Date | URL): string;
+  function redact(value: unknown): unknown;
+  function redact(value: unknown): unknown {
+    return visit(value, new WeakSet());
+  }
+
+  return {redact};
 }

--- a/libs/shared/common/redact/src/index.ts
+++ b/libs/shared/common/redact/src/index.ts
@@ -1,6 +1,25 @@
 /** Replacement written in place of any redacted secret or URL credential. */
 export const REDACTION_PLACEHOLDER = '***';
 
+const CIRCULAR_PLACEHOLDER = '[Circular]';
+const SENSITIVE_KEY =
+  /(?:authorization|cookie|credential|password|private[_-]?key|secret|signature|token|api[_-]?key)/i;
+const SENSITIVE_URL_FIELD =
+  /^(?:access[_-]?token|authorization|awsaccesskeyid|client[_-]?secret|code|credential|googleaccessid|id[_-]?token|password|policy|refresh[_-]?token|secret|signature|sig|token|x-amz-(?:algorithm|credential|date|expires|security-token|signature|signedheaders)|x-goog-(?:algorithm|credential|date|expires|signature|signedheaders)|x-oss-(?:credential|signature))$/i;
+const SENSITIVE_TEXT_PAIR =
+  /(\b(?:access[_-]?token|api[_-]?key|authorization|client[_-]?secret|code|credential|id[_-]?token|password|refresh[_-]?token|secret|signature|sig|token|x-amz-signature)\b)\s*[:=]\s*[^\s,;&#]+/gi;
+const SCHEME_URL = /[a-z][a-z0-9+.-]{0,31}:\/\/[^\s"'<>]+/gi;
+
+export interface StructuredRedactionOptions {
+  /** Secrets to redact in their literal, encoded, base64, base64url, and hex forms. */
+  readonly secrets?: readonly string[];
+}
+
+export interface Redactor {
+  /** Returns a redacted copy of `value`. Caller-owned objects are never mutated. */
+  redact<T>(value: T): T;
+}
+
 // Bounded scheme length keeps the match linear: an unbounded `*` before the
 // `://` literal backtracks O(n) per start position (O(n^2) overall) on long
 // adversarial input, while a capped repetition stays O(n). No real URL scheme
@@ -69,7 +88,7 @@ export function stripUrlCredentials(url: string): string {
  * real, high-entropy secrets only; a trivially short literal (e.g. a single
  * character) would scrub unrelated text.
  */
-export function redactSecrets(text: string, secrets: string[]): string {
+export function redactSecrets(text: string, secrets: readonly string[]): string {
   let redacted = text;
   // Remove longer secrets first: scrubbing a shorter secret that is a substring
   // of a longer one would otherwise leave the longer secret's tail visible.
@@ -193,4 +212,116 @@ export function secretWireForms(secret: string): string[] {
   ].filter((form) => form.length >= MIN_DERIVED_FORM_LENGTH);
   // The literal always masks; only its derived forms are length-gated.
   return [...new Set([secret, ...derived])].sort((a, b) => b.length - a.length);
+}
+
+/**
+ * Redacts credentials and sensitive query or fragment fields from one URL.
+ * Parseable URLs keep their non-sensitive fields. Malformed values fall back to
+ * the free-text URL-credential scrubber.
+ */
+export function redactSensitiveUrl(url: string | URL): string {
+  const input = url.toString();
+  let parsed: URL;
+  try {
+    parsed = new URL(input);
+  } catch {
+    return redactUrlCredentials(input);
+  }
+
+  if (parsed.username || parsed.password) {
+    parsed.username = REDACTION_PLACEHOLDER;
+    parsed.password = '';
+  }
+
+  for (const key of [...parsed.searchParams.keys()]) {
+    if (SENSITIVE_URL_FIELD.test(key)) {
+      parsed.searchParams.set(key, REDACTION_PLACEHOLDER);
+    }
+  }
+
+  if (parsed.hash) {
+    parsed.hash = parsed.hash.slice(1).replace(SENSITIVE_TEXT_PAIR, `$1=${REDACTION_PLACEHOLDER}`);
+  }
+
+  return parsed.toString();
+}
+
+function configuredSecretWireForms(secrets: readonly string[]): string[] {
+  return [...new Set(secrets.flatMap((secret) => secretWireForms(secret)))];
+}
+
+function redactSensitiveTextWithWireForms(text: string, wireForms: readonly string[]): string {
+  let redacted = text.replace(
+    /\b(Bearer|Basic|Digest|AWS4-HMAC-SHA256)\s+[^\s,;]+/gi,
+    `$1 ${REDACTION_PLACEHOLDER}`,
+  );
+  redacted = redacted.replace(
+    /Authorization\s*[:=]\s*[^\r\n]+/gi,
+    `Authorization: ${REDACTION_PLACEHOLDER}`,
+  );
+  redacted = redacted.replace(
+    /((?:set-)?cookie|x-hub-signature(?:-256)?|x-webhook-signature)\s*[:=]\s*[^\r\n]+/gi,
+    `$1: ${REDACTION_PLACEHOLDER}`,
+  );
+  redacted = redacted.replace(SCHEME_URL, (url) => redactSensitiveUrl(url));
+  redacted = redacted.replace(SENSITIVE_TEXT_PAIR, `$1=${REDACTION_PLACEHOLDER}`);
+  return redactSecrets(redacted, wireForms);
+}
+
+/**
+ * Redacts common credential forms from free text, including authorization and
+ * cookie headers, webhook signatures, sensitive key-value pairs, URLs, and any
+ * configured secrets in the wire forms returned by {@link secretWireForms}.
+ */
+export function redactSensitiveText(
+  text: string,
+  options: StructuredRedactionOptions = {},
+): string {
+  const wireForms = configuredSecretWireForms(options.secrets ?? []);
+  return redactSensitiveTextWithWireForms(text, wireForms);
+}
+
+/**
+ * Creates a provider-independent redactor for log messages and structured
+ * values. Arrays and objects are copied recursively; `URL` and `Date` become
+ * strings; `Error` becomes a plain object; circular references become
+ * `[Circular]`.
+ */
+export function createRedactor(options: StructuredRedactionOptions = {}): Redactor {
+  const wireForms = configuredSecretWireForms(options.secrets ?? []);
+  const redactText = (text: string): string => redactSensitiveTextWithWireForms(text, wireForms);
+
+  function visit(value: unknown, ancestors: WeakSet<object>): unknown {
+    if (typeof value === 'string') return redactText(value);
+    if (value === null || typeof value !== 'object') return value;
+    if (value instanceof URL) return redactSensitiveUrl(redactText(value.toString()));
+    if (value instanceof Date) return value.toISOString();
+    if (ancestors.has(value)) return CIRCULAR_PLACEHOLDER;
+
+    ancestors.add(value);
+    try {
+      if (value instanceof Error) {
+        return {
+          cause: value.cause === undefined ? undefined : visit(value.cause, ancestors),
+          message: redactText(value.message),
+          name: value.name,
+          stack: value.stack ? redactText(value.stack) : undefined,
+        };
+      }
+      if (Array.isArray(value)) return value.map((item) => visit(item, ancestors));
+
+      return Object.fromEntries(
+        Object.entries(value).map(([key, item]) => [
+          key,
+          SENSITIVE_KEY.test(key) ? REDACTION_PLACEHOLDER : visit(item, ancestors),
+        ]),
+      );
+    } finally {
+      ancestors.delete(value);
+    }
+  }
+
+  return {
+    redact: <T>(value: T): T => visit(value, new WeakSet()) as T,
+  };
 }


### PR DESCRIPTION
Extend `@shipfox/redact` with provider-independent URL, free-text, and structured-value redaction primitives required by Glint.

Glint currently carries parallel security-critical handling for signed object-store URLs, OAuth fragments, authorization and cookie forms, and recursive log attributes. Centralizing that behavior keeps literal secrets and their derived wire forms on the existing Shipfox masking implementation while preserving all current package exports.

The structured redactor copies caller-owned values, handles `Error`, `URL`, `Date`, arrays, nested objects, and circular references, and stays independent of logger and observability providers. The package remains private in this change; ENG-910 owns its public package metadata and initial release changeset.

The sensitive field allowlists, free-text patterns, and structured transformation semantics deserve careful review because downstream loggers will rely on them as a security boundary.

Closes ENG-909

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds provider‑independent structured, signed‑URL, and free‑text redaction to `@shipfox/redact` to centralize Glint’s masking logic and keep current APIs stable. Updates address ENG‑909 edge cases including Swift signatures, invalid dates, secret‑bearing keys, and error names.

- **New Features**
  - `createRedactor(options)` recursively redacts JSON-like values; supports `Error`, `URL`, `Date`; copies input; safely marks circular refs as `[Circular]`; structured inputs return `unknown`, while `string`/`URL`/`Date` return `string`.
  - `redactSensitiveUrl(url)` scrubs userinfo and sensitive query/fragment fields (S3-style, OAuth, Swift temp URLs); supports non-HTTP schemes like `postgres`, `redis`, `ftp`.
  - `redactSensitiveText(text, options)` scrubs Authorization schemes, cookies, webhook signatures, sensitive key–value pairs, URLs, and configured secrets via `secretWireForms`.

- **Bug Fixes**
  - Redacts secret-bearing object keys and `Error.name`.
  - Serializes invalid `Date` values safely.
  - Keeps existing helpers (`redactUrlCredentials`, `stripUrlCredentials`, `redactSecrets`, `secretWireForms`) compatible.

<sup>Written for commit e3010e759af31f2feb39f76656351b77c3b309d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

