### PR TITLE
[redact] Publish package for external consumers

### DIFF
--- a/.changeset/calm-foxes-publish.md
+++ b/.changeset/calm-foxes-publish.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/redact": minor
+---
+
+Publishes the supported redaction helpers for external ESM consumers with public package metadata and packed-install coverage.

--- a/libs/shared/common/redact/README.md
+++ b/libs/shared/common/redact/README.md
@@ -1,97 +1,68 @@
 # Shipfox Redact
 
-Shared credential-redaction helpers. One home for the redaction techniques used
-across Shipfox so they cannot drift.
+Redaction helpers for secrets, credentials, URLs, free text, and structured values.
 
 ## What it does
 
-- **`redactUrlCredentials(text)`** scrubs `user:pass@` (and bare `user@`)
-  credentials from free text, for every `scheme://` URL it finds (http, https,
-  git, ssh, ...). Use it on log lines and command stderr.
-- **`stripUrlCredentials(url)`** removes the userinfo from a single known URL via
-  `new URL()`, returning a clean URL with no `***@` residue. Use it on one URL
-  field you control. When the value does not parse as a URL it falls back to
-  `redactUrlCredentials`, so a credential with a malformed authority is still
-  masked; a credential-free non-URL (scp-style `git@host:path`) is returned
-  unchanged.
-- **`redactSecrets(text, secrets)`** removes every occurrence of each literal
-  secret, then applies `redactUrlCredentials`. The helper only removes the
-  literals it is given, so pass every wire form a secret takes; use
-  `secretWireForms` to derive them.
-- **`redactSensitiveUrl(url)`** redacts userinfo plus sensitive query and
-  fragment fields in one parseable URL. It covers signed S3-compatible URLs,
-  OAuth callbacks, and non-HTTP schemes such as `postgres`, `redis`, and `ftp`.
-- **`redactSensitiveText(text, options)`** redacts URLs, Authorization schemes,
-  cookies, webhook signatures, sensitive key-value pairs, and configured
-  secrets from free text.
-- **`createRedactor(options)`** returns a provider-independent recursive
-  redactor for strings, arrays, JSON-like objects, `Error`, `URL`, and `Date`
-  values. It returns copies instead of mutating input and safely replaces
-  circular references with `[Circular]`. String, `URL`, and `Date` inputs return
-  strings; other structured inputs return `unknown` because their keys and
-  values can change representation during redaction.
-- **`secretWireForms(secret)`** derives every wire form one secret can appear as
-  in captured output: the literal, its base64 and base64url forms (all three
-  phase alignments, so a secret embedded in a larger encoded blob is masked too),
-  its URL-encoded form, and its lower- and upper-case hex. The result is
-  deduplicated and sorted longest-first, ready to hand straight to `redactSecrets`.
-  The literal is always included so a registered secret is never left unmasked;
-  its derived forms are dropped below 8 characters, because a short derivation
-  matches common encoded text and would scrub unrelated output.
-- **`REDACTION_PLACEHOLDER`** is the `'***'` string every redaction writes.
-
-scp-style remotes (`git@host:path`) are left untouched on purpose: an scp URL
-carrying a password is not a real git form, and redacting it would corrupt
-structurally identical strings (Docker digests, `host:port`). Literal secrets are
-the backstop for those.
+- **`redactUrlCredentials(text)`**: Masks credentials in every `scheme://` URL
+  found in free text.
+- **`stripUrlCredentials(url)`**: Removes user information from one URL without
+  leaving a masked user marker.
+- **`redactSecrets(text, secrets)`**: Masks literal secrets and URL credentials.
+- **`safeRedactionPrefixLength(buffer, secrets)`**: Finds the part of a stream
+  buffer that is safe to mask and emit without splitting a secret.
+- **`secretWireForms(secret)`**: Returns the literal, base64, base64url,
+  URL-encoded, and hex forms of a secret.
+- **`redactSensitiveUrl(url)`**: Masks URL credentials plus sensitive query and
+  fragment fields used by signed URLs and OAuth callbacks.
+- **`redactSensitiveText(text, options)`**: Masks authorization values, cookies,
+  signatures, URLs, key-value pairs, and configured secrets in free text.
+- **`createRedactor(options)`**: Creates a recursive redactor for strings,
+  arrays, objects, errors, URLs, and dates. It copies input values and replaces
+  circular references with `[Circular]`.
+- **`REDACTION_PLACEHOLDER`**: Exposes the `***` value written in place of
+  sensitive data.
 
 ## Installation
 
-```bash
+```sh
 pnpm add @shipfox/redact
 ```
 
 ## Usage
 
 ```ts
-import {
-  createRedactor,
-  redactSecrets,
-  redactSensitiveText,
-  redactSensitiveUrl,
-  redactUrlCredentials,
-  secretWireForms,
-  stripUrlCredentials,
-} from "@shipfox/redact";
+import {createRedactor, redactSensitiveUrl} from '@shipfox/redact';
 
-redactUrlCredentials("fatal: clone of https://x:tok@github.com/o/r.git failed");
-// -> "fatal: clone of https://***@github.com/o/r.git failed"
+const redact = createRedactor({secrets: [process.env.API_TOKEN ?? '']});
 
-stripUrlCredentials("https://x-access-token:tok@github.com/o/r.git");
-// -> "https://github.com/o/r.git"
-
-redactSecrets("Authorization: Basic dXNlcjp0b2tlbg==", ["dXNlcjp0b2tlbg=="]);
-// -> "Authorization: Basic ***"
-
-// Mask a token in every form it might appear as (base64, hex, URL-encoded, ...).
-redactSecrets("digest=" + tokenAsHex, secretWireForms(token));
-// -> "digest=***"
-
-redactSensitiveUrl(
-  "https://objects.example/file?X-Amz-Credential=credential&X-Amz-Signature=signature",
-);
-// -> "https://objects.example/file?X-Amz-Credential=***&X-Amz-Signature=***"
-
-redactSensitiveText("Authorization: AWS4-HMAC-SHA256 signed-credentials");
-// -> "Authorization: ***"
-
-const redactor = createRedactor({secrets: [runtimeSecret]});
-redactor.redact({
-  databaseUrl: `postgres://user:${runtimeSecret}@db/glint`,
-  token: "project-token",
+const attributes = redact.redact({
+  authorization: 'Bearer project-token',
+  databaseUrl: 'postgres://user:password@db.example/glint',
 });
-// -> {databaseUrl: "postgres://***@db/glint", token: "***"}
+
+const safeUrl = redactSensitiveUrl(
+  'https://objects.example/file?X-Amz-Credential=id&X-Amz-Signature=signature',
+);
 ```
+
+## Behavior notes
+
+The package ships ECMAScript modules compiled to ES2022. It uses the standard
+`URL` and `TextEncoder` APIs and has no runtime dependencies. It works in
+Node.js and browser-like runtimes that provide those APIs.
+
+The package does not know which application values are secret. Pass configured
+secrets through `StructuredRedactionOptions` or derive their forms with
+`secretWireForms`.
+
+`redactUrlCredentials` leaves scp-style remotes such as `git@host:path`
+unchanged. Such values do not have a password field. Passing the real secret to
+`redactSecrets` or `createRedactor` remains the safety net for unusual forms.
+
+The package follows semantic versioning. Additive helpers ship in minor
+versions. Breaking changes to exports or masking behavior require a major
+version.
 
 ## Development
 
@@ -99,7 +70,11 @@ redactor.redact({
 turbo check --filter=@shipfox/redact
 turbo type --filter=@shipfox/redact
 turbo test --filter=@shipfox/redact
+pnpm --filter=@shipfox/redact test:external
 ```
+
+The external test packs the package and installs it in a clean temporary
+project. It checks runtime imports, type imports, and the published file list.
 
 ## License
 

--- a/libs/shared/common/redact/README.md
+++ b/libs/shared/common/redact/README.md
@@ -34,7 +34,7 @@ pnpm add @shipfox/redact
 ```ts
 import {createRedactor, redactSensitiveUrl} from '@shipfox/redact';
 
-const redact = createRedactor({secrets: [process.env.API_TOKEN ?? '']});
+const redact = createRedactor({secrets: ['your-api-token']});
 
 const attributes = redact.redact({
   authorization: 'Bearer project-token',

--- a/libs/shared/common/redact/package.json
+++ b/libs/shared/common/redact/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shipfox/redact",
   "license": "MIT",
-  "private": true,
+  "private": false,
   "version": "0.1.0",
   "repository": {
     "type": "git",
@@ -9,6 +9,15 @@
     "directory": "libs/shared/common/redact"
   },
   "type": "module",
+  "files": [
+    "CHANGELOG.md",
+    "LICENSE",
+    "README.md",
+    "dist/**/*.d.ts",
+    "dist/**/*.d.ts.map",
+    "dist/**/*.js",
+    "dist/**/*.js.map"
+  ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "imports": {
@@ -31,6 +40,7 @@
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
     "test": "shipfox-vitest-run",
+    "test:external": "node test/external/verify.mjs",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"
   },

--- a/libs/shared/common/redact/test/external/package.template.json
+++ b/libs/shared/common/redact/test/external/package.template.json
@@ -1,0 +1,16 @@
+{
+  "name": "redact-external-fixture",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "check": "tsc --project tsconfig.json --noEmit",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@shipfox/redact": "file:./redact.tgz"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  }
+}

--- a/libs/shared/common/redact/test/external/src/index.ts
+++ b/libs/shared/common/redact/test/external/src/index.ts
@@ -1,0 +1,40 @@
+import {
+  createRedactor,
+  REDACTION_PLACEHOLDER,
+  type Redactor,
+  redactSecrets,
+  redactSensitiveText,
+  redactSensitiveUrl,
+  redactUrlCredentials,
+  type StructuredRedactionOptions,
+  safeRedactionPrefixLength,
+  secretWireForms,
+  stripUrlCredentials,
+} from '@shipfox/redact';
+
+const options: StructuredRedactionOptions = {secrets: ['runtime-secret']};
+const redactor: Redactor = createRedactor(options);
+const redacted = redactor.redact({
+  authorization: 'Bearer project-token',
+  databaseUrl: 'postgres://user:runtime-secret@db.example/glint',
+});
+
+const results = {
+  placeholder: REDACTION_PLACEHOLDER,
+  prefixLength: safeRedactionPrefixLength('safe runtime-sec', ['runtime-secret']),
+  secret: redactSecrets('token=runtime-secret', ['runtime-secret']),
+  sensitiveText: redactSensitiveText('Cookie: session=secret'),
+  sensitiveUrl: redactSensitiveUrl('https://objects.example/file?X-Amz-Signature=secret'),
+  urlCredentials: redactUrlCredentials('clone https://user:password@example.com/repo'),
+  strippedUrl: stripUrlCredentials('https://user:password@example.com/repo'),
+  wireForms: secretWireForms('runtime-secret'),
+};
+
+if (
+  JSON.stringify(redacted).includes('runtime-secret') ||
+  !results.secret.includes(REDACTION_PLACEHOLDER) ||
+  !results.sensitiveUrl.includes(REDACTION_PLACEHOLDER) ||
+  !results.wireForms.includes('runtime-secret')
+) {
+  throw new Error('Public redaction helpers returned an unexpected result');
+}

--- a/libs/shared/common/redact/test/external/tsconfig.json
+++ b/libs/shared/common/redact/test/external/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": ["src"]
+}

--- a/libs/shared/common/redact/test/external/verify.mjs
+++ b/libs/shared/common/redact/test/external/verify.mjs
@@ -1,0 +1,69 @@
+import {spawn} from 'node:child_process';
+import {cp, mkdtemp, readdir, readFile, rename, rm} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {dirname, join, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const fixtureSource = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(fixtureSource, '../..');
+const fixtureRoot = await mkdtemp(join(tmpdir(), 'redact-external-'));
+const tarball = join(fixtureRoot, 'redact.tgz');
+
+function run(command, args, cwd) {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(command, args, {cwd, stdio: 'inherit'});
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code === 0) resolvePromise();
+      else reject(new Error(`${command} ${args.join(' ')} exited with code ${code}`));
+    });
+  });
+}
+
+try {
+  await run('pnpm', ['run', 'build'], packageRoot);
+  await run('pnpm', ['run', 'type:emit'], packageRoot);
+  await cp(fixtureSource, fixtureRoot, {
+    recursive: true,
+    filter: (source) => source !== import.meta.filename,
+  });
+  await rename(join(fixtureRoot, 'package.template.json'), join(fixtureRoot, 'package.json'));
+  await run('pnpm', ['pack', '--out', tarball], packageRoot);
+  await run('pnpm', ['install', '--ignore-workspace'], fixtureRoot);
+
+  const installedRoot = join(fixtureRoot, 'node_modules/@shipfox/redact');
+  const manifest = JSON.parse(await readFile(join(installedRoot, 'package.json'), 'utf8'));
+  if (manifest.private || manifest.license !== 'MIT' || manifest.dependencies) {
+    throw new Error('Packed package metadata is not safe for public consumers');
+  }
+  if (
+    manifest.repository?.url !== 'git+https://github.com/ShipfoxHQ/shipfox.git' ||
+    manifest.repository?.directory !== 'libs/shared/common/redact'
+  ) {
+    throw new Error('Packed package repository metadata is incomplete');
+  }
+
+  const packedFiles = (await readdir(installedRoot, {recursive: true, withFileTypes: true}))
+    .filter((entry) => entry.isFile())
+    .map((entry) => join(entry.parentPath, entry.name).slice(installedRoot.length + 1))
+    .sort();
+  const expectedFiles = [
+    'CHANGELOG.md',
+    'LICENSE',
+    'README.md',
+    'dist/index.d.ts',
+    'dist/index.d.ts.map',
+    'dist/index.js',
+    'dist/index.js.map',
+    'package.json',
+  ];
+  if (JSON.stringify(packedFiles) !== JSON.stringify(expectedFiles)) {
+    throw new Error(`Unexpected packed files: ${packedFiles.join(', ')}`);
+  }
+
+  await run('pnpm', ['run', 'check'], fixtureRoot);
+  await run('pnpm', ['run', 'build'], fixtureRoot);
+  await run('pnpm', ['run', 'start'], fixtureRoot);
+} finally {
+  await rm(fixtureRoot, {recursive: true, force: true});
+}

--- a/libs/shared/common/redact/tsconfig.test.json
+++ b/libs/shared/common/redact/tsconfig.test.json
@@ -4,5 +4,5 @@
     "rootDir": "."
   },
   "include": ["src", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
-  "exclude": []
+  "exclude": ["test/external"]
 }


### PR DESCRIPTION
Publish `@shipfox/redact` as a supported public npm package through the existing changesets release flow.

Open-source consumers such as Glint need the shared redaction primitives without a Shipfox workspace or private registry. This change makes the package publishable, limits the tarball to its runtime, declarations, README, license, changelog, and metadata, and documents the supported ESM API and compatibility contract.

A clean temporary project packs and installs the package, type-checks every public type import, and exercises every runtime export. The tarball allowlist and external fixture are the main review boundaries because they define what external consumers receive.

Closes ENG-910

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish `@shipfox/redact` as a public npm package and verify its ESM and type contract from a clean external project. This fulfills ENG-910 by letting consumers like Glint use our redaction helpers without a Shipfox workspace or private registry.

- **New Features**
  - Public package via the changesets-to-npm flow (new minor) with a strict packed file allowlist.
  - Expanded README with API docs, behavior notes for Node and browser-like runtimes, and a runtime-neutral usage example.
  - External fixture (`pnpm test:external`) that packs/installs the tarball, checks types and runtime imports, and validates repository metadata and the exact file list; excluded from internal TS tests.

<sup>Written for commit 12ddbf332bb8cc20e92955e58408123c2a958e89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

