### PR TITLE
[node-outbox] Add PostgreSQL dispatch primitives

### DIFF
--- a/libs/shared/node/outbox/README.md
+++ b/libs/shared/node/outbox/README.md
@@ -1,50 +1,88 @@
 # Shipfox Outbox
 
-Typed outbox helpers for Shipfox modules. Use this package when a database write needs to record a domain event in the same transaction.
+Typed transactional outbox helpers for Drizzle and PostgreSQL.
 
 ## What it does
 
-- **`createOutboxTable(pgTable)`**: Creates a Drizzle table named `outbox` for a module table namespace.
-- **`writeOutboxEvent(tx, outboxTable, event)`**: Inserts a typed event into an outbox table.
+- **Legacy module helpers**: `createOutboxTable`, `writeOutboxEvent`, and `writeOutboxEvents` keep the current Shipfox module contract.
+- **`createPostgresOutboxTable(pgTable)`**: Creates an outbox table with idempotency keys and delivery leases.
+- **`writeIdempotentOutboxEvent(tx, table, event)`**: Adds one event inside a Drizzle transaction and reports if the key was new.
+- **`createPostgresOutbox(options)`**: Claims events, records retries, rejects stale deliveries, and reports pending age.
 - **`DomainEvent`**: Runtime event shape used by dispatchers.
 - **`EventMapLike`, `EventType`, `EventPayload`**: Type helpers for module event maps.
+
+## Installation
+
+This package is private to the workspace. Add it to another workspace package:
+
+```json
+{
+  "dependencies": {
+    "@shipfox/node-outbox": "workspace:*"
+  }
+}
+```
 
 ## Usage
 
 ```ts
-import {createOutboxTable, writeOutboxEvent} from '@shipfox/node-outbox';
+import {
+  createPostgresOutbox,
+  createPostgresOutboxTable,
+  writeIdempotentOutboxEvent,
+} from '@shipfox/node-outbox';
 import {pgTableCreator} from 'drizzle-orm/pg-core';
 
 const pgTable = pgTableCreator((name) => `projects_${name}`);
-export const outbox = createOutboxTable(pgTable);
-
-interface ProjectEventMap {
-  'project.created': {projectId: string};
-}
+const outboxTable = createPostgresOutboxTable(pgTable);
+const outbox = createPostgresOutbox({database: db, table: outboxTable});
 
 await db.transaction(async (tx) => {
   await tx.insert(projects).values({id: projectId});
-  await writeOutboxEvent<ProjectEventMap>(tx, outbox, {
+  await writeIdempotentOutboxEvent(tx, outboxTable, {
+    idempotencyKey: `project-created:${projectId}`,
     type: 'project.created',
     payload: {projectId},
   });
 });
+
+const [delivery] = await outbox.claim({batchSize: 100, leaseDurationMs: 30_000});
+if (delivery) await outbox.acknowledge(delivery);
 ```
 
-Each row also carries bounded-retry and dead-letter columns: `dispatch_attempts`,
-`next_dispatch_at`, `last_dispatch_error`, `last_dispatch_failed_at`, and
-`dead_lettered_at`. A dispatcher records failures, backs off `next_dispatch_at`,
-and dead-letters a row once it exhausts its attempts.
+## Data Model
 
-The table includes a pending-event index on `(next_dispatch_at, created_at)` for
-rows where `dispatched_at` and `dead_lettered_at` are both null.
+`createPostgresOutboxTable` creates an `outbox` table in the given table namespace.
+It needs PostgreSQL 18 because its primary key uses `uuidv7()`.
+
+| Columns | Purpose |
+| --- | --- |
+| `id`, `idempotency_key` | Keep the row key separate from the caller's unique event key. |
+| `event_type`, `ordering_key`, `payload`, `created_at` | Store the event and its order group. |
+| `lease_token`, `lease_expires_at` | Give one delivery attempt time-bound authority. |
+| `dispatch_attempts`, `next_dispatch_at` | Count claims and schedule retries. |
+| `last_dispatch_error`, `last_dispatch_failed_at` | Store the last failure. |
+| `dispatched_at`, `dead_lettered_at` | Store terminal delivery state. |
+
+## Behavior Notes
+
+- Claims use `FOR UPDATE SKIP LOCKED`. Concurrent workers receive different rows.
+- A non-empty ordering key blocks newer events in the same group until the oldest event finishes.
+- Each claim increments `dispatch_attempts` and gets a new lease token.
+- Acknowledgement and retry require the current unexpired token. A stale call returns `stale` and changes nothing.
+- `maxAttempts` defaults to 5. The last failed attempt moves the event to the dead letter state.
+- `maxRetryDelayMs` defaults to 30 minutes. Longer retry delays use that limit.
+- `createOutboxTable` stays separate, so current Shipfox modules need no schema or source change.
 
 ## Development
 
 ```sh
 turbo check --filter=@shipfox/node-outbox
 turbo type --filter=@shipfox/node-outbox
+turbo test --filter=@shipfox/node-outbox
 ```
+
+The PostgreSQL contract tests need the local PostgreSQL 18 service. Start it with `docker compose up -d`.
 
 ## License
 

--- a/libs/shared/node/outbox/README.md
+++ b/libs/shared/node/outbox/README.md
@@ -53,7 +53,7 @@ if (delivery) await outbox.acknowledge(delivery);
 ## Data Model
 
 `createPostgresOutboxTable` creates an `outbox` table in the given table namespace.
-It needs PostgreSQL 18 because its primary key uses `uuidv7()`.
+It needs PostgreSQL 18 because that release added the built-in `uuidv7()` function used by its primary key.
 
 | Columns | Purpose |
 | --- | --- |

--- a/libs/shared/node/outbox/package.json
+++ b/libs/shared/node/outbox/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",
+    "@shipfox/node-postgres": "workspace:*",
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",

--- a/libs/shared/node/outbox/src/index.ts
+++ b/libs/shared/node/outbox/src/index.ts
@@ -1,4 +1,25 @@
-export type {OutboxTable} from './schema.js';
-export {createOutboxTable} from './schema.js';
-export type {DomainEvent, EventMapLike, EventPayload, EventType} from './types.js';
-export {writeOutboxEvent, writeOutboxEvents} from './write.js';
+export {
+  type AcknowledgeOutboxEventOptions,
+  type ClaimOutboxEventsOptions,
+  createPostgresOutbox,
+  type GetOutboxHealthOptions,
+  PostgresOutbox,
+  type PostgresOutboxOptions,
+  type RetryOutboxEventOptions,
+} from './postgres.js';
+export type {OutboxTable, PostgresOutboxTable} from './schema.js';
+export {createOutboxTable, createPostgresOutboxTable} from './schema.js';
+export type {
+  ClaimedOutboxEvent,
+  DomainEvent,
+  EventMapLike,
+  EventPayload,
+  EventType,
+  IdempotentOutboxEvent,
+  OutboxAcknowledgeResult,
+  OutboxClaimReference,
+  OutboxHealth,
+  OutboxRetryResult,
+  OutboxWriteResult,
+} from './types.js';
+export {writeIdempotentOutboxEvent, writeOutboxEvent, writeOutboxEvents} from './write.js';

--- a/libs/shared/node/outbox/src/postgres.test.ts
+++ b/libs/shared/node/outbox/src/postgres.test.ts
@@ -395,6 +395,44 @@ describe('PostgreSQL outbox contract', () => {
     expect(stored?.lastFailure).toEqual({attempts: '3', self: '[Circular]'});
   });
 
+  it('schedules a retry when failure string conversion throws', async () => {
+    await append({idempotencyKey: 'event-1'});
+    const outbox = createOutbox();
+    const [delivery] = await outbox.claim({batchSize: 1, leaseDurationMs: 1_000, now: start});
+    if (!delivery) throw new Error('Expected an outbox delivery');
+    const failure = Object.assign(() => undefined, {
+      toString: () => {
+        throw new Error('cannot stringify');
+      },
+    });
+
+    const retry = await outbox.retry({...delivery, delayMs: 0, failure, now: start});
+    const [stored] = await database
+      .select({lastFailure: outboxTable.lastDispatchError})
+      .from(outboxTable);
+
+    expect(retry).toEqual({status: 'retry-scheduled', nextAttemptAt: start});
+    expect(stored?.lastFailure).toBe('[Unserializable]');
+  });
+
+  it('preserves a failure property named __proto__', async () => {
+    await append({idempotencyKey: 'event-1'});
+    const outbox = createOutbox();
+    const [delivery] = await outbox.claim({batchSize: 1, leaseDurationMs: 1_000, now: start});
+    if (!delivery) throw new Error('Expected an outbox delivery');
+    const failure = Object.fromEntries([['__proto__', {message: 'prototype failure'}]]);
+
+    await outbox.retry({...delivery, delayMs: 0, failure, now: start});
+    const [stored] = await database
+      .select({lastFailure: outboxTable.lastDispatchError})
+      .from(outboxTable);
+
+    expect(Object.hasOwn(stored?.lastFailure as object, '__proto__')).toBe(true);
+    expect((stored?.lastFailure as Record<string, unknown>).__proto__).toEqual({
+      message: 'prototype failure',
+    });
+  });
+
   it('reports the oldest pending event age and excludes acknowledged events', async () => {
     const createdAt = new Date(start.getTime() - 5_000);
     await append({idempotencyKey: 'event-1', createdAt, availableAt: createdAt});

--- a/libs/shared/node/outbox/src/postgres.test.ts
+++ b/libs/shared/node/outbox/src/postgres.test.ts
@@ -26,9 +26,12 @@ const event = {
 
 class TestDeliveryError extends Error {
   readonly reason = 'rate-limited';
+  readonly retryAfterMs = 5_000n;
 
   constructor() {
-    super('delivery timed out', {cause: new Error('socket closed')});
+    const cause = new Error('socket closed');
+    cause.cause = cause;
+    super('delivery timed out', {cause});
     this.name = 'TestDeliveryError';
   }
 }
@@ -233,6 +236,25 @@ describe('PostgreSQL outbox contract', () => {
     expect(health.pendingCount).toBe(0);
   });
 
+  it('dead-letters an unleased row when maxAttempts is lowered below its attempt count', async () => {
+    await append({idempotencyKey: 'event-1', orderingKey: 'aggregate-1'});
+    const originalOutbox = createOutbox({maxAttempts: 5});
+    const [delivery] = await originalOutbox.claim({
+      batchSize: 1,
+      leaseDurationMs: 1_000,
+      now: start,
+    });
+    if (!delivery) throw new Error('Expected an outbox delivery');
+    await originalOutbox.retry({...delivery, delayMs: 0, failure: 'retry', now: start});
+    const loweredOutbox = createOutbox({maxAttempts: 1});
+
+    const claimed = await loweredOutbox.claim({batchSize: 1, leaseDurationMs: 1_000, now: start});
+    const health = await loweredOutbox.health({now: start});
+
+    expect(claimed).toEqual([]);
+    expect(health.pendingCount).toBe(0);
+  });
+
   it('does not let an older lease acknowledge or retry a newer claim', async () => {
     await append({idempotencyKey: 'event-1'});
     const outbox = createOutbox();
@@ -344,14 +366,33 @@ describe('PostgreSQL outbox contract', () => {
         name: 'TestDeliveryError',
         message: 'delivery timed out',
         reason: 'rate-limited',
+        retryAfterMs: '5000',
         stack: expect.stringContaining('TestDeliveryError: delivery timed out'),
         cause: expect.objectContaining({
           name: 'Error',
           message: 'socket closed',
           stack: expect.stringContaining('Error: socket closed'),
+          cause: '[Circular]',
         }),
       }),
     );
+  });
+
+  it('stores cyclic non-Error failures with bigint fields as JSON-safe data', async () => {
+    await append({idempotencyKey: 'event-1'});
+    const outbox = createOutbox();
+    const [delivery] = await outbox.claim({batchSize: 1, leaseDurationMs: 1_000, now: start});
+    if (!delivery) throw new Error('Expected an outbox delivery');
+    const failure: {attempts: bigint; self?: unknown} = {attempts: 3n};
+    failure.self = failure;
+
+    const retry = await outbox.retry({...delivery, delayMs: 0, failure, now: start});
+    const [stored] = await database
+      .select({lastFailure: outboxTable.lastDispatchError})
+      .from(outboxTable);
+
+    expect(retry).toEqual({status: 'retry-scheduled', nextAttemptAt: start});
+    expect(stored?.lastFailure).toEqual({attempts: '3', self: '[Circular]'});
   });
 
   it('reports the oldest pending event age and excludes acknowledged events', async () => {

--- a/libs/shared/node/outbox/src/postgres.test.ts
+++ b/libs/shared/node/outbox/src/postgres.test.ts
@@ -1,0 +1,377 @@
+import {randomUUID} from 'node:crypto';
+import {closePostgresClient, createPostgresClient, type Pool} from '@shipfox/node-postgres';
+import {count} from 'drizzle-orm';
+import {drizzle} from 'drizzle-orm/node-postgres';
+import {integer, pgTable, pgTableCreator, text} from 'drizzle-orm/pg-core';
+import {createPostgresOutbox} from './postgres.js';
+import {createPostgresOutboxTable} from './schema.js';
+import type {IdempotentOutboxEvent} from './types.js';
+import {writeIdempotentOutboxEvent} from './write.js';
+
+const pgTableForOutbox = pgTableCreator((name) => `node_outbox_test_${name}`);
+const outboxTable = createPostgresOutboxTable(pgTableForOutbox);
+const domainTable = pgTable('node_outbox_test_domain', {
+  id: integer('id').primaryKey(),
+  value: text('value').notNull(),
+});
+
+const start = new Date('2030-01-01T00:00:00.000Z');
+const event = {
+  idempotencyKey: 'event-1',
+  type: 'thing.created',
+  payload: {id: 'thing-1'},
+  createdAt: start,
+  availableAt: start,
+};
+
+class TestDeliveryError extends Error {
+  readonly reason = 'rate-limited';
+
+  constructor() {
+    super('delivery timed out', {cause: new Error('socket closed')});
+    this.name = 'TestDeliveryError';
+  }
+}
+
+let databaseName: string;
+let pool: Pool;
+let database: ReturnType<typeof drizzle>;
+let serverVersionNum: number;
+
+beforeAll(async () => {
+  databaseName = `node_outbox_test_${randomUUID().replaceAll('-', '')}`;
+  const adminPool = createPostgresClient({database: 'postgres'});
+  const version = await adminPool.query<{server_version_num: string}>(
+    "SELECT current_setting('server_version_num') AS server_version_num",
+  );
+  serverVersionNum = Number(version.rows[0]?.server_version_num);
+  await adminPool.query(`CREATE DATABASE ${databaseName}`);
+  await closePostgresClient();
+
+  pool = createPostgresClient({database: databaseName});
+  database = drizzle(pool);
+  await pool.query(`
+    CREATE TABLE node_outbox_test_domain (
+      id integer PRIMARY KEY,
+      value text NOT NULL
+    );
+    CREATE TABLE node_outbox_test_outbox (
+      id uuid PRIMARY KEY DEFAULT uuidv7(),
+      idempotency_key text NOT NULL,
+      event_type text NOT NULL,
+      ordering_key text,
+      payload jsonb NOT NULL,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      dispatched_at timestamptz,
+      dispatch_attempts integer NOT NULL DEFAULT 0,
+      next_dispatch_at timestamptz NOT NULL DEFAULT now(),
+      lease_token uuid,
+      lease_expires_at timestamptz,
+      last_dispatch_error jsonb,
+      last_dispatch_failed_at timestamptz,
+      dead_lettered_at timestamptz
+    );
+    CREATE UNIQUE INDEX node_outbox_test_outbox_idempotency_key_idx
+      ON node_outbox_test_outbox (idempotency_key);
+    CREATE UNIQUE INDEX node_outbox_test_outbox_lease_token_idx
+      ON node_outbox_test_outbox (lease_token);
+    CREATE INDEX node_outbox_test_outbox_pending_idx
+      ON node_outbox_test_outbox (next_dispatch_at, created_at, id)
+      WHERE dispatched_at IS NULL AND dead_lettered_at IS NULL;
+  `);
+});
+
+afterAll(async () => {
+  await closePostgresClient();
+  const adminPool = createPostgresClient({database: 'postgres'});
+  await adminPool.query(`DROP DATABASE ${databaseName} WITH (FORCE)`);
+  await closePostgresClient();
+});
+
+beforeEach(async () => {
+  await pool.query('TRUNCATE node_outbox_test_domain, node_outbox_test_outbox');
+});
+
+function createOutbox(options: {maxAttempts?: number; maxRetryDelayMs?: number} = {}) {
+  return createPostgresOutbox({database, table: outboxTable, ...options});
+}
+
+async function append(
+  input: Partial<IdempotentOutboxEvent<(typeof event)['payload']>> & {idempotencyKey: string},
+): Promise<void> {
+  await writeIdempotentOutboxEvent(database, outboxTable, {...event, ...input});
+}
+
+describe('PostgreSQL outbox contract', () => {
+  it('runs against PostgreSQL 18', () => {
+    expect(serverVersionNum).toBeGreaterThanOrEqual(180_000);
+    expect(serverVersionNum).toBeLessThan(190_000);
+  });
+
+  it('commits a domain write and outbox event in one transaction', async () => {
+    const result = await database.transaction(async (tx) => {
+      await tx.insert(domainTable).values({id: 1, value: 'committed'});
+      return await writeIdempotentOutboxEvent(tx, outboxTable, event);
+    });
+
+    const domainRows = await database.select().from(domainTable);
+    const claimed = await createOutbox().claim({batchSize: 1, leaseDurationMs: 1_000, now: start});
+    expect(result).toEqual({status: 'created'});
+    expect(domainRows).toEqual([{id: 1, value: 'committed'}]);
+    expect(claimed).toHaveLength(1);
+  });
+
+  it('rolls back both the domain write and outbox event', async () => {
+    const transaction = database.transaction(async (tx) => {
+      await tx.insert(domainTable).values({id: 1, value: 'rolled-back'});
+      await writeIdempotentOutboxEvent(tx, outboxTable, event);
+      throw new Error('rollback');
+    });
+
+    await expect(transaction).rejects.toThrow('rollback');
+    const domainRows = await database.select().from(domainTable);
+    const claimed = await createOutbox().claim({batchSize: 1, leaseDurationMs: 1_000, now: start});
+    expect(domainRows).toEqual([]);
+    expect(claimed).toEqual([]);
+  });
+
+  it('stores one durable event for a reused idempotency key', async () => {
+    const first = await writeIdempotentOutboxEvent(database, outboxTable, event);
+    const duplicate = await writeIdempotentOutboxEvent(database, outboxTable, {
+      ...event,
+      payload: {id: 'different-payload'},
+    });
+
+    const rows = await database.select({count: count()}).from(outboxTable);
+    expect(first).toEqual({status: 'created'});
+    expect(duplicate).toEqual({status: 'duplicate'});
+    expect(rows).toEqual([{count: 1}]);
+  });
+
+  it('claims rows in deterministic availability and creation order', async () => {
+    await Promise.all([
+      append({idempotencyKey: 'event-3', createdAt: new Date(start.getTime() + 3_000)}),
+      append({idempotencyKey: 'event-1', createdAt: new Date(start.getTime() + 1_000)}),
+      append({idempotencyKey: 'event-2', createdAt: new Date(start.getTime() + 2_000)}),
+    ]);
+
+    const claimed = await createOutbox().claim({batchSize: 3, leaseDurationMs: 1_000, now: start});
+
+    expect(claimed.map((delivery) => delivery.idempotencyKey)).toEqual([
+      'event-1',
+      'event-2',
+      'event-3',
+    ]);
+  });
+
+  it('keeps a newer ordering-key event pending until the older event is acknowledged', async () => {
+    await append({idempotencyKey: 'event-1', orderingKey: 'aggregate-1'});
+    await append({
+      idempotencyKey: 'event-2',
+      orderingKey: 'aggregate-1',
+      createdAt: new Date(start.getTime() + 1),
+    });
+    const outbox = createOutbox();
+
+    const firstClaim = await outbox.claim({batchSize: 2, leaseDurationMs: 1_000, now: start});
+    const [first] = firstClaim;
+    if (!first) throw new Error('Expected the first ordered delivery');
+    await outbox.acknowledge({...first, now: start});
+    const second = await outbox.claim({batchSize: 2, leaseDurationMs: 1_000, now: start});
+
+    expect(firstClaim.map((delivery) => delivery.idempotencyKey)).toEqual(['event-1']);
+    expect(second.map((delivery) => delivery.idempotencyKey)).toEqual(['event-2']);
+  });
+
+  it('gives concurrent workers disjoint bounded claims', async () => {
+    await Promise.all(
+      Array.from({length: 8}, (_, index) => append({idempotencyKey: `event-${index}`})),
+    );
+    const outbox = createOutbox();
+
+    const [left, right] = await Promise.all([
+      outbox.claim({batchSize: 4, leaseDurationMs: 1_000, now: start}),
+      outbox.claim({batchSize: 4, leaseDurationMs: 1_000, now: start}),
+    ]);
+
+    const leftIds = new Set(left.map((delivery) => delivery.id));
+    const rightIds = new Set(right.map((delivery) => delivery.id));
+    expect(left).toHaveLength(4);
+    expect(right).toHaveLength(4);
+    expect([...leftIds].filter((id) => rightIds.has(id))).toEqual([]);
+  });
+
+  it('redelivers an expired lease with a new token and incremented attempt count', async () => {
+    await append({idempotencyKey: 'event-1'});
+    const outbox = createOutbox();
+    const [first] = await outbox.claim({batchSize: 1, leaseDurationMs: 1_000, now: start});
+
+    const [second] = await outbox.claim({
+      batchSize: 1,
+      leaseDurationMs: 1_000,
+      now: new Date(start.getTime() + 1_001),
+    });
+
+    expect(second?.id).toBe(first?.id);
+    expect(second?.attempts).toBe(2);
+    expect(second?.leaseToken).not.toBe(first?.leaseToken);
+  });
+
+  it('dead-letters an expired final attempt instead of claiming it again', async () => {
+    await append({idempotencyKey: 'event-1'});
+    const outbox = createOutbox({maxAttempts: 1});
+    await outbox.claim({batchSize: 1, leaseDurationMs: 1_000, now: start});
+
+    const claimed = await outbox.claim({
+      batchSize: 1,
+      leaseDurationMs: 1_000,
+      now: new Date(start.getTime() + 1_001),
+    });
+    const health = await outbox.health({now: new Date(start.getTime() + 1_001)});
+
+    expect(claimed).toEqual([]);
+    expect(health.pendingCount).toBe(0);
+  });
+
+  it('does not let an older lease acknowledge or retry a newer claim', async () => {
+    await append({idempotencyKey: 'event-1'});
+    const outbox = createOutbox();
+    const [first] = await outbox.claim({batchSize: 1, leaseDurationMs: 1_000, now: start});
+    const redeliveryTime = new Date(start.getTime() + 1_001);
+    const [second] = await outbox.claim({
+      batchSize: 1,
+      leaseDurationMs: 1_000,
+      now: redeliveryTime,
+    });
+    if (!first || !second) throw new Error('Expected both delivery attempts');
+
+    const acknowledgement = await outbox.acknowledge({...first, now: redeliveryTime});
+    const retry = await outbox.retry({
+      ...first,
+      delayMs: 0,
+      failure: {message: 'old'},
+      now: redeliveryTime,
+    });
+    const currentAcknowledgement = await outbox.acknowledge({
+      ...second,
+      now: new Date(redeliveryTime.getTime() + 1),
+    });
+
+    expect(acknowledgement).toEqual({status: 'stale'});
+    expect(retry).toEqual({status: 'stale'});
+    expect(currentAcknowledgement).toEqual({status: 'acknowledged'});
+  });
+
+  it('bounds retry delay and dead-letters the final failed attempt', async () => {
+    await append({idempotencyKey: 'event-1'});
+    const outbox = createOutbox({maxAttempts: 3, maxRetryDelayMs: 1_000});
+    const [first] = await outbox.claim({batchSize: 1, leaseDurationMs: 10_000, now: start});
+    if (!first) throw new Error('Expected the first delivery');
+
+    const firstRetry = await outbox.retry({
+      ...first,
+      delayMs: 5_000,
+      failure: {message: 'first'},
+      now: start,
+    });
+    const beforeBackoff = await outbox.claim({
+      batchSize: 1,
+      leaseDurationMs: 10_000,
+      now: new Date(start.getTime() + 999),
+    });
+    const [second] = await outbox.claim({
+      batchSize: 1,
+      leaseDurationMs: 10_000,
+      now: new Date(start.getTime() + 1_000),
+    });
+    if (!second) throw new Error('Expected the second delivery');
+    await outbox.retry({
+      ...second,
+      delayMs: 0,
+      failure: {message: 'second'},
+      now: new Date(start.getTime() + 1_001),
+    });
+    const [third] = await outbox.claim({
+      batchSize: 1,
+      leaseDurationMs: 10_000,
+      now: new Date(start.getTime() + 1_001),
+    });
+    if (!third) throw new Error('Expected the third delivery');
+
+    const finalRetry = await outbox.retry({
+      ...third,
+      delayMs: 0,
+      failure: {message: 'final'},
+      now: new Date(start.getTime() + 1_002),
+    });
+    const stored = await database
+      .select({
+        attempts: outboxTable.dispatchAttempts,
+        deadLetteredAt: outboxTable.deadLetteredAt,
+        lastFailure: outboxTable.lastDispatchError,
+      })
+      .from(outboxTable);
+
+    expect(firstRetry).toEqual({
+      status: 'retry-scheduled',
+      nextAttemptAt: new Date(start.getTime() + 1_000),
+    });
+    expect(beforeBackoff).toEqual([]);
+    expect(finalRetry).toEqual({status: 'dead-lettered'});
+    expect(stored).toEqual([
+      {
+        attempts: 3,
+        deadLetteredAt: new Date(start.getTime() + 1_002),
+        lastFailure: {message: 'final'},
+      },
+    ]);
+  });
+
+  it('stores Error details and typed fields as JSON failure data', async () => {
+    await append({idempotencyKey: 'event-1'});
+    const outbox = createOutbox();
+    const [delivery] = await outbox.claim({batchSize: 1, leaseDurationMs: 1_000, now: start});
+    if (!delivery) throw new Error('Expected an outbox delivery');
+    const failure = new TestDeliveryError();
+
+    await outbox.retry({...delivery, delayMs: 0, failure, now: start});
+    const [stored] = await database
+      .select({lastFailure: outboxTable.lastDispatchError})
+      .from(outboxTable);
+
+    expect(stored?.lastFailure).toEqual(
+      expect.objectContaining({
+        name: 'TestDeliveryError',
+        message: 'delivery timed out',
+        reason: 'rate-limited',
+        stack: expect.stringContaining('TestDeliveryError: delivery timed out'),
+        cause: expect.objectContaining({
+          name: 'Error',
+          message: 'socket closed',
+          stack: expect.stringContaining('Error: socket closed'),
+        }),
+      }),
+    );
+  });
+
+  it('reports the oldest pending event age and excludes acknowledged events', async () => {
+    const createdAt = new Date(start.getTime() - 5_000);
+    await append({idempotencyKey: 'event-1', createdAt, availableAt: createdAt});
+    const outbox = createOutbox();
+
+    const pending = await outbox.health({now: start});
+    const [delivery] = await outbox.claim({batchSize: 1, leaseDurationMs: 1_000, now: start});
+    if (!delivery) throw new Error('Expected an outbox delivery');
+    await outbox.acknowledge({...delivery, now: start});
+    const empty = await outbox.health({now: start});
+
+    expect(pending).toEqual({
+      status: 'ready',
+      checkedAt: start,
+      pendingCount: 1,
+      oldestPendingAt: createdAt,
+      oldestPendingAgeMs: 5_000,
+    });
+    expect(empty).toEqual({status: 'ready', checkedAt: start, pendingCount: 0});
+  });
+});

--- a/libs/shared/node/outbox/src/postgres.ts
+++ b/libs/shared/node/outbox/src/postgres.ts
@@ -306,7 +306,13 @@ function toJsonSafe(value: unknown, ancestors: WeakSet<object>): unknown {
   if (typeof value === 'number') return Number.isFinite(value) ? value : String(value);
   if (typeof value === 'bigint') return value.toString();
   if (typeof value === 'undefined') return null;
-  if (typeof value === 'symbol' || typeof value === 'function') return String(value);
+  if (typeof value === 'symbol' || typeof value === 'function') {
+    try {
+      return String(value);
+    } catch (_error) {
+      return '[Unserializable]';
+    }
+  }
 
   try {
     if (value instanceof Date) {
@@ -344,12 +350,25 @@ function serializeObject(value: object, ancestors: WeakSet<object>): Record<stri
   const serialized: Record<string, unknown> = {};
   for (const key of Object.keys(value)) {
     try {
-      serialized[key] = toJsonSafe((value as Record<string, unknown>)[key], ancestors);
+      defineOwnProperty(
+        serialized,
+        key,
+        toJsonSafe((value as Record<string, unknown>)[key], ancestors),
+      );
     } catch (_error) {
-      serialized[key] = '[Unserializable]';
+      defineOwnProperty(serialized, key, '[Unserializable]');
     }
   }
   return serialized;
+}
+
+function defineOwnProperty(target: Record<string, unknown>, key: string, value: unknown): void {
+  Object.defineProperty(target, key, {
+    value,
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  });
 }
 
 function assertPositiveInteger(value: number, name: string): void {

--- a/libs/shared/node/outbox/src/postgres.ts
+++ b/libs/shared/node/outbox/src/postgres.ts
@@ -91,7 +91,7 @@ export class PostgresOutbox<TSchema extends Record<string, unknown> = Record<str
             isNull(this.#table.dispatchedAt),
             isNull(this.#table.deadLetteredAt),
             gte(this.#table.dispatchAttempts, this.#maxAttempts),
-            lte(this.#table.leaseExpiresAt, now),
+            or(isNull(this.#table.leaseExpiresAt), lte(this.#table.leaseExpiresAt, now)),
           ),
         )
         .orderBy(asc(this.#table.leaseExpiresAt), asc(this.#table.createdAt), asc(this.#table.id))
@@ -297,18 +297,59 @@ function requireClaimValue<T>(value: T | null, name: string): T {
   return value;
 }
 
-function serializeFailure(failure: unknown, seen = new WeakSet<Error>()): unknown {
-  if (!(failure instanceof Error)) return failure ?? null;
-  if (seen.has(failure)) return {name: failure.name, message: failure.message};
-  seen.add(failure);
+function serializeFailure(failure: unknown): unknown {
+  return toJsonSafe(failure, new WeakSet<object>());
+}
 
+function toJsonSafe(value: unknown, ancestors: WeakSet<object>): unknown {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return value;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : String(value);
+  if (typeof value === 'bigint') return value.toString();
+  if (typeof value === 'undefined') return null;
+  if (typeof value === 'symbol' || typeof value === 'function') return String(value);
+
+  try {
+    if (value instanceof Date) {
+      return Number.isNaN(value.getTime()) ? String(value) : value.toISOString();
+    }
+    if (ancestors.has(value)) return '[Circular]';
+    ancestors.add(value);
+
+    const serialized =
+      value instanceof Error
+        ? serializeError(value, ancestors)
+        : Array.isArray(value)
+          ? value.map((item) => toJsonSafe(item, ancestors))
+          : serializeObject(value, ancestors);
+    ancestors.delete(value);
+    return serialized;
+  } catch (_error) {
+    ancestors.delete(value);
+    return '[Unserializable]';
+  }
+}
+
+function serializeError(error: Error, ancestors: WeakSet<object>): Record<string, unknown> {
+  const properties = serializeObject(error, ancestors);
   return {
-    ...Object.fromEntries(Object.entries(failure)),
-    name: failure.name,
-    message: failure.message,
-    ...(failure.stack ? {stack: failure.stack} : {}),
-    ...(failure.cause !== undefined ? {cause: serializeFailure(failure.cause, seen)} : {}),
+    ...properties,
+    name: error.name,
+    message: error.message,
+    ...(error.stack ? {stack: error.stack} : {}),
+    ...(error.cause !== undefined ? {cause: toJsonSafe(error.cause, ancestors)} : {}),
   };
+}
+
+function serializeObject(value: object, ancestors: WeakSet<object>): Record<string, unknown> {
+  const serialized: Record<string, unknown> = {};
+  for (const key of Object.keys(value)) {
+    try {
+      serialized[key] = toJsonSafe((value as Record<string, unknown>)[key], ancestors);
+    } catch (_error) {
+      serialized[key] = '[Unserializable]';
+    }
+  }
+  return serialized;
 }
 
 function assertPositiveInteger(value: number, name: string): void {

--- a/libs/shared/node/outbox/src/postgres.ts
+++ b/libs/shared/node/outbox/src/postgres.ts
@@ -1,0 +1,324 @@
+import {
+  and,
+  asc,
+  count,
+  eq,
+  gt,
+  gte,
+  inArray,
+  isNull,
+  lte,
+  min,
+  notExists,
+  or,
+  sql,
+} from 'drizzle-orm';
+import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
+import {alias} from 'drizzle-orm/pg-core';
+import type {PostgresOutboxTable} from './schema.js';
+import type {
+  ClaimedOutboxEvent,
+  OutboxAcknowledgeResult,
+  OutboxClaimReference,
+  OutboxHealth,
+  OutboxRetryResult,
+} from './types.js';
+
+export interface PostgresOutboxOptions<
+  TSchema extends Record<string, unknown> = Record<string, never>,
+> {
+  database: NodePgDatabase<TSchema>;
+  table: PostgresOutboxTable;
+  /** Number of claims allowed before a failed or expired delivery is dead-lettered. Defaults to 5. */
+  maxAttempts?: number;
+  /** Largest retry delay accepted from a caller. Defaults to 30 minutes. */
+  maxRetryDelayMs?: number;
+}
+
+export interface ClaimOutboxEventsOptions {
+  batchSize: number;
+  leaseDurationMs: number;
+  now?: Date;
+}
+
+export interface AcknowledgeOutboxEventOptions extends OutboxClaimReference {
+  now?: Date;
+}
+
+export interface RetryOutboxEventOptions extends OutboxClaimReference {
+  delayMs: number;
+  failure: unknown;
+  now?: Date;
+}
+
+export interface GetOutboxHealthOptions {
+  now?: Date;
+}
+
+const DEFAULT_MAX_ATTEMPTS = 5;
+const DEFAULT_MAX_RETRY_DELAY_MS = 30 * 60 * 1_000;
+
+/** PostgreSQL-backed leased delivery operations for a `createPostgresOutboxTable` table. */
+export class PostgresOutbox<TSchema extends Record<string, unknown> = Record<string, never>> {
+  readonly #database: NodePgDatabase<TSchema>;
+  readonly #table: PostgresOutboxTable;
+  readonly #maxAttempts: number;
+  readonly #maxRetryDelayMs: number;
+
+  constructor(options: PostgresOutboxOptions<TSchema>) {
+    this.#database = options.database;
+    this.#table = options.table;
+    this.#maxAttempts = options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+    this.#maxRetryDelayMs = options.maxRetryDelayMs ?? DEFAULT_MAX_RETRY_DELAY_MS;
+    assertPositiveInteger(this.#maxAttempts, 'maxAttempts');
+    assertNonNegativeInteger(this.#maxRetryDelayMs, 'maxRetryDelayMs');
+  }
+
+  /** Claims a deterministic bounded batch and increments each event's attempt count. */
+  async claim<TPayload = unknown>(
+    options: ClaimOutboxEventsOptions,
+  ): Promise<Array<ClaimedOutboxEvent<TPayload>>> {
+    assertPositiveInteger(options.batchSize, 'batchSize');
+    assertPositiveInteger(options.leaseDurationMs, 'leaseDurationMs');
+    const now = normalizeDate(options.now);
+
+    const rows = await this.#database.transaction(async (tx) => {
+      const exhausted = await tx
+        .select({id: this.#table.id})
+        .from(this.#table)
+        .where(
+          and(
+            isNull(this.#table.dispatchedAt),
+            isNull(this.#table.deadLetteredAt),
+            gte(this.#table.dispatchAttempts, this.#maxAttempts),
+            lte(this.#table.leaseExpiresAt, now),
+          ),
+        )
+        .orderBy(asc(this.#table.leaseExpiresAt), asc(this.#table.createdAt), asc(this.#table.id))
+        .limit(options.batchSize)
+        .for('update', {skipLocked: true});
+      if (exhausted.length > 0) {
+        await tx
+          .update(this.#table)
+          .set({deadLetteredAt: now, leaseToken: null, leaseExpiresAt: null})
+          .where(
+            inArray(
+              this.#table.id,
+              exhausted.map((event) => event.id),
+            ),
+          );
+      }
+
+      const earlier = alias(this.#table, 'earlier_outbox');
+      const candidates = await tx
+        .select({id: this.#table.id})
+        .from(this.#table)
+        .where(
+          and(
+            isNull(this.#table.dispatchedAt),
+            isNull(this.#table.deadLetteredAt),
+            lte(this.#table.dispatchAttempts, this.#maxAttempts - 1),
+            lte(this.#table.nextDispatchAt, now),
+            or(isNull(this.#table.leaseExpiresAt), lte(this.#table.leaseExpiresAt, now)),
+            or(
+              isNull(this.#table.orderingKey),
+              notExists(
+                tx
+                  .select({id: earlier.id})
+                  .from(earlier)
+                  .where(
+                    and(
+                      isNull(earlier.dispatchedAt),
+                      isNull(earlier.deadLetteredAt),
+                      eq(earlier.orderingKey, this.#table.orderingKey),
+                      sql`(${earlier.createdAt}, ${earlier.id}) < (${this.#table.createdAt}, ${this.#table.id})`,
+                    ),
+                  ),
+              ),
+            ),
+          ),
+        )
+        .orderBy(asc(this.#table.nextDispatchAt), asc(this.#table.createdAt), asc(this.#table.id))
+        .limit(options.batchSize)
+        .for('update', {skipLocked: true});
+      if (candidates.length === 0) return [];
+
+      return await tx
+        .update(this.#table)
+        .set({
+          dispatchAttempts: sql`${this.#table.dispatchAttempts} + 1`,
+          leaseToken: sql`gen_random_uuid()`,
+          leaseExpiresAt: sql`${now}::timestamptz + (${options.leaseDurationMs} * interval '1 millisecond')`,
+        })
+        .where(
+          inArray(
+            this.#table.id,
+            candidates.map((candidate) => candidate.id),
+          ),
+        )
+        .returning({
+          id: this.#table.id,
+          idempotencyKey: this.#table.idempotencyKey,
+          eventType: this.#table.eventType,
+          orderingKey: this.#table.orderingKey,
+          payload: this.#table.payload,
+          createdAt: this.#table.createdAt,
+          nextDispatchAt: this.#table.nextDispatchAt,
+          dispatchAttempts: this.#table.dispatchAttempts,
+          leaseToken: this.#table.leaseToken,
+          leaseExpiresAt: this.#table.leaseExpiresAt,
+        });
+    });
+
+    return rows.sort(compareClaimedRows).map((row) => ({
+      id: row.id,
+      idempotencyKey: row.idempotencyKey,
+      type: row.eventType,
+      orderingKey: row.orderingKey,
+      payload: row.payload as TPayload,
+      createdAt: row.createdAt,
+      attempts: row.dispatchAttempts,
+      leaseToken: requireClaimValue(row.leaseToken, 'leaseToken'),
+      leaseExpiresAt: requireClaimValue(row.leaseExpiresAt, 'leaseExpiresAt'),
+    }));
+  }
+
+  /** Marks a delivery complete only while its lease token is current and unexpired. */
+  async acknowledge(options: AcknowledgeOutboxEventOptions): Promise<OutboxAcknowledgeResult> {
+    const now = normalizeDate(options.now);
+    const result = await this.#database
+      .update(this.#table)
+      .set({dispatchedAt: now, leaseToken: null, leaseExpiresAt: null})
+      .where(
+        and(
+          eq(this.#table.id, options.id),
+          eq(this.#table.leaseToken, options.leaseToken),
+          gt(this.#table.leaseExpiresAt, now),
+          isNull(this.#table.dispatchedAt),
+          isNull(this.#table.deadLetteredAt),
+        ),
+      )
+      .returning({id: this.#table.id});
+
+    return {status: result.length === 0 ? 'stale' : 'acknowledged'};
+  }
+
+  /** Records a failure and schedules a bounded retry or moves the event to dead letter. */
+  async retry(options: RetryOutboxEventOptions): Promise<OutboxRetryResult> {
+    assertNonNegativeInteger(options.delayMs, 'delayMs');
+    const now = normalizeDate(options.now);
+    const boundedDelayMs = Math.min(options.delayMs, this.#maxRetryDelayMs);
+    const failure = serializeFailure(options.failure);
+    const result = await this.#database
+      .update(this.#table)
+      .set({
+        nextDispatchAt: sql`CASE
+          WHEN ${this.#table.dispatchAttempts} >= ${this.#maxAttempts}
+            THEN ${this.#table.nextDispatchAt}
+          ELSE ${now}::timestamptz + (${boundedDelayMs} * interval '1 millisecond')
+        END`,
+        lastDispatchError: failure,
+        lastDispatchFailedAt: now,
+        deadLetteredAt: sql`CASE
+          WHEN ${this.#table.dispatchAttempts} >= ${this.#maxAttempts} THEN ${now}
+          ELSE ${this.#table.deadLetteredAt}
+        END`,
+        leaseToken: null,
+        leaseExpiresAt: null,
+      })
+      .where(
+        and(
+          eq(this.#table.id, options.id),
+          eq(this.#table.leaseToken, options.leaseToken),
+          gt(this.#table.leaseExpiresAt, now),
+          isNull(this.#table.dispatchedAt),
+          isNull(this.#table.deadLetteredAt),
+        ),
+      )
+      .returning({
+        deadLetteredAt: this.#table.deadLetteredAt,
+        nextDispatchAt: this.#table.nextDispatchAt,
+      });
+    const row = result[0];
+    if (!row) return {status: 'stale'};
+    if (row.deadLetteredAt) return {status: 'dead-lettered'};
+    return {status: 'retry-scheduled', nextAttemptAt: new Date(row.nextDispatchAt)};
+  }
+
+  /** Reads the pending count and oldest pending event age. Database failures reject the call. */
+  async health(options: GetOutboxHealthOptions = {}): Promise<OutboxHealth> {
+    const now = normalizeDate(options.now);
+    const result = await this.#database
+      .select({pendingCount: count(), oldestPendingAt: min(this.#table.createdAt)})
+      .from(this.#table)
+      .where(and(isNull(this.#table.dispatchedAt), isNull(this.#table.deadLetteredAt)));
+    const row = result[0] ?? {pendingCount: 0, oldestPendingAt: null};
+    const oldestPendingAt = row.oldestPendingAt ? new Date(row.oldestPendingAt) : undefined;
+
+    return {
+      status: 'ready',
+      checkedAt: now,
+      pendingCount: row.pendingCount,
+      ...(oldestPendingAt
+        ? {
+            oldestPendingAt,
+            oldestPendingAgeMs: Math.max(0, now.getTime() - oldestPendingAt.getTime()),
+          }
+        : {}),
+    };
+  }
+}
+
+export function createPostgresOutbox<TSchema extends Record<string, unknown>>(
+  options: PostgresOutboxOptions<TSchema>,
+): PostgresOutbox<TSchema> {
+  return new PostgresOutbox(options);
+}
+
+function compareClaimedRows(
+  left: {id: string; nextDispatchAt: Date; createdAt: Date},
+  right: {id: string; nextDispatchAt: Date; createdAt: Date},
+): number {
+  const availableDelta =
+    new Date(left.nextDispatchAt).getTime() - new Date(right.nextDispatchAt).getTime();
+  if (availableDelta !== 0) return availableDelta;
+  const createdDelta = new Date(left.createdAt).getTime() - new Date(right.createdAt).getTime();
+  return createdDelta === 0 ? left.id.localeCompare(right.id) : createdDelta;
+}
+
+function normalizeDate(value: Date | undefined): Date {
+  const date = value ? new Date(value) : new Date();
+  if (Number.isNaN(date.getTime())) throw new Error('now must be a valid date');
+  return date;
+}
+
+function requireClaimValue<T>(value: T | null, name: string): T {
+  if (value === null) throw new Error(`Claimed outbox event is missing ${name}`);
+  return value;
+}
+
+function serializeFailure(failure: unknown, seen = new WeakSet<Error>()): unknown {
+  if (!(failure instanceof Error)) return failure ?? null;
+  if (seen.has(failure)) return {name: failure.name, message: failure.message};
+  seen.add(failure);
+
+  return {
+    ...Object.fromEntries(Object.entries(failure)),
+    name: failure.name,
+    message: failure.message,
+    ...(failure.stack ? {stack: failure.stack} : {}),
+    ...(failure.cause !== undefined ? {cause: serializeFailure(failure.cause, seen)} : {}),
+  };
+}
+
+function assertPositiveInteger(value: number, name: string): void {
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+}
+
+function assertNonNegativeInteger(value: number, name: string): void {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+}

--- a/libs/shared/node/outbox/src/schema.ts
+++ b/libs/shared/node/outbox/src/schema.ts
@@ -1,6 +1,15 @@
 import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
 import {getTableName, sql} from 'drizzle-orm';
-import {index, integer, jsonb, type pgTableCreator, text, timestamp} from 'drizzle-orm/pg-core';
+import {
+  index,
+  integer,
+  jsonb,
+  type pgTableCreator,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from 'drizzle-orm/pg-core';
 
 export function createOutboxTable(pgTable: ReturnType<typeof pgTableCreator>) {
   // The pgTableCreator prefixes table names but not index names, and inside the
@@ -35,3 +44,39 @@ export function createOutboxTable(pgTable: ReturnType<typeof pgTableCreator>) {
 }
 
 export type OutboxTable = ReturnType<typeof createOutboxTable>;
+
+/** Creates the PostgreSQL 18 table shape required by the leased dispatch helpers. */
+export function createPostgresOutboxTable(pgTable: ReturnType<typeof pgTableCreator>) {
+  const tableName = getTableName(pgTable('outbox', {id: uuidv7PrimaryKey()}));
+  return pgTable(
+    'outbox',
+    {
+      id: uuidv7PrimaryKey(),
+      idempotencyKey: text('idempotency_key').notNull(),
+      eventType: text('event_type').notNull(),
+      orderingKey: text('ordering_key'),
+      payload: jsonb('payload').notNull(),
+      createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
+      dispatchedAt: timestamp('dispatched_at', {withTimezone: true}),
+      dispatchAttempts: integer('dispatch_attempts').notNull().default(0),
+      nextDispatchAt: timestamp('next_dispatch_at', {withTimezone: true}).notNull().defaultNow(),
+      leaseToken: uuid('lease_token'),
+      leaseExpiresAt: timestamp('lease_expires_at', {withTimezone: true}),
+      lastDispatchError: jsonb('last_dispatch_error'),
+      lastDispatchFailedAt: timestamp('last_dispatch_failed_at', {withTimezone: true}),
+      deadLetteredAt: timestamp('dead_lettered_at', {withTimezone: true}),
+    },
+    (table) => [
+      uniqueIndex(`${tableName}_idempotency_key_idx`).on(table.idempotencyKey),
+      uniqueIndex(`${tableName}_lease_token_idx`).on(table.leaseToken),
+      index(`${tableName}_pending_idx`)
+        .on(table.nextDispatchAt, table.createdAt, table.id)
+        .where(sql`"dispatched_at" IS NULL AND "dead_lettered_at" IS NULL`),
+      index(`${tableName}_dispatched_retention_idx`)
+        .on(table.dispatchedAt, table.id)
+        .where(sql`"dispatched_at" IS NOT NULL`),
+    ],
+  );
+}
+
+export type PostgresOutboxTable = ReturnType<typeof createPostgresOutboxTable>;

--- a/libs/shared/node/outbox/src/types.ts
+++ b/libs/shared/node/outbox/src/types.ts
@@ -19,5 +19,48 @@ export interface DomainEvent<TPayload = unknown> {
   createdAt: Date;
 }
 
+export interface IdempotentOutboxEvent<TPayload = unknown> {
+  idempotencyKey: string;
+  type: string;
+  orderingKey?: string;
+  payload: TPayload;
+  createdAt?: Date;
+  availableAt?: Date;
+}
+
+export interface ClaimedOutboxEvent<TPayload = unknown> {
+  id: string;
+  idempotencyKey: string;
+  type: string;
+  orderingKey: string | null;
+  payload: TPayload;
+  createdAt: Date;
+  attempts: number;
+  leaseToken: string;
+  leaseExpiresAt: Date;
+}
+
+export interface OutboxClaimReference {
+  id: string;
+  leaseToken: string;
+}
+
+export interface OutboxHealth {
+  status: 'ready';
+  checkedAt: Date;
+  pendingCount: number;
+  oldestPendingAt?: Date;
+  oldestPendingAgeMs?: number;
+}
+
+export type OutboxAcknowledgeResult = {status: 'acknowledged'} | {status: 'stale'};
+
+export type OutboxRetryResult =
+  | {status: 'retry-scheduled'; nextAttemptAt: Date}
+  | {status: 'dead-lettered'}
+  | {status: 'stale'};
+
+export type OutboxWriteResult = {status: 'created' | 'duplicate'};
+
 // biome-ignore lint/suspicious/noExplicitAny: generic constraint for event maps
 export type EventMapLike = Record<string, any>;

--- a/libs/shared/node/outbox/src/write.test.ts
+++ b/libs/shared/node/outbox/src/write.test.ts
@@ -1,8 +1,9 @@
 import {getTableConfig, pgTableCreator} from 'drizzle-orm/pg-core';
-import {createOutboxTable} from './schema.js';
-import {writeOutboxEvent, writeOutboxEvents} from './write.js';
+import {createOutboxTable, createPostgresOutboxTable} from './schema.js';
+import {writeIdempotentOutboxEvent, writeOutboxEvent, writeOutboxEvents} from './write.js';
 
 const outboxTable = createOutboxTable(pgTableCreator((name) => name));
+const postgresOutboxTable = createPostgresOutboxTable(pgTableCreator((name) => name));
 
 interface TestEventMap {
   'thing.created': {id: string};
@@ -29,6 +30,29 @@ describe('createOutboxTable', () => {
       retentionIndex?.config.columns.map((column) => ('name' in column ? column.name : null)),
     ).toEqual(['dispatched_at', 'id']);
     expect(retentionIndex?.config.where).toBeDefined();
+  });
+});
+
+describe('createPostgresOutboxTable', () => {
+  it('adds idempotency and lease columns without changing the legacy table factory', () => {
+    expect(postgresOutboxTable.idempotencyKey.name).toBe('idempotency_key');
+    expect(postgresOutboxTable.leaseToken.name).toBe('lease_token');
+    expect(postgresOutboxTable.leaseExpiresAt.name).toBe('lease_expires_at');
+    expect('idempotencyKey' in outboxTable).toBe(false);
+  });
+
+  it('enforces unique idempotency keys and lease tokens', () => {
+    const indexes = getTableConfig(postgresOutboxTable).indexes.map((index) => ({
+      name: index.config.name,
+      unique: index.config.unique,
+    }));
+
+    expect(indexes).toEqual(
+      expect.arrayContaining([
+        {name: 'outbox_idempotency_key_idx', unique: true},
+        {name: 'outbox_lease_token_idx', unique: true},
+      ]),
+    );
   });
 });
 
@@ -93,5 +117,50 @@ describe('writeOutboxEvent', () => {
     expect(values).toHaveBeenCalledWith([
       {eventType: 'thing.created', orderingKey: null, payload: {id: 'a'}},
     ]);
+  });
+});
+
+describe('writeIdempotentOutboxEvent', () => {
+  function fakeIdempotentTx(inserted: Array<{id: string}>) {
+    const returning = vi.fn().mockResolvedValue(inserted);
+    const onConflictDoNothing = vi.fn(() => ({returning}));
+    const values = vi.fn(() => ({onConflictDoNothing}));
+    const insert = vi.fn(() => ({values}));
+    return {tx: {insert}, values, onConflictDoNothing, returning};
+  }
+
+  it.each([
+    ['created', [{id: '018f0000-0000-7000-8000-000000000000'}]],
+    ['duplicate', []],
+  ] as const)('returns %s from the conflict-safe insert', async (status, inserted) => {
+    const {tx, onConflictDoNothing, returning} = fakeIdempotentTx([...inserted]);
+
+    const result = await writeIdempotentOutboxEvent(tx, postgresOutboxTable, {
+      idempotencyKey: ' event-1 ',
+      type: ' thing.created ',
+      orderingKey: ' aggregate-1 ',
+      payload: {id: 'a'},
+    });
+
+    expect(result).toEqual({status});
+    expect(onConflictDoNothing).toHaveBeenCalledWith({
+      target: postgresOutboxTable.idempotencyKey,
+    });
+    expect(returning).toHaveBeenCalledWith({id: postgresOutboxTable.id});
+  });
+
+  it.each([
+    ['idempotencyKey', {idempotencyKey: ' ', type: 'thing.created'}],
+    ['type', {idempotencyKey: 'event-1', type: ' '}],
+  ] as const)('rejects an empty %s before inserting', async (name, event) => {
+    const {tx, values} = fakeIdempotentTx([]);
+
+    const write = writeIdempotentOutboxEvent(tx, postgresOutboxTable, {
+      ...event,
+      payload: {id: 'a'},
+    });
+
+    await expect(write).rejects.toThrow(`${name} must not be empty`);
+    expect(values).not.toHaveBeenCalled();
   });
 });

--- a/libs/shared/node/outbox/src/write.ts
+++ b/libs/shared/node/outbox/src/write.ts
@@ -1,5 +1,5 @@
-import type {OutboxTable} from './schema.js';
-import type {EventMapLike, EventType} from './types.js';
+import type {OutboxTable, PostgresOutboxTable} from './schema.js';
+import type {EventMapLike, EventType, IdempotentOutboxEvent, OutboxWriteResult} from './types.js';
 
 type OutboxRow = {eventType: string; orderingKey: string | null; payload: unknown};
 
@@ -8,6 +8,23 @@ interface DrizzleInsertable {
     values: {
       (value: OutboxRow): Promise<unknown>;
       (values: OutboxRow[]): Promise<unknown>;
+    };
+  };
+}
+
+interface IdempotentDrizzleInsertable {
+  insert: (table: PostgresOutboxTable) => {
+    values: (value: {
+      idempotencyKey: string;
+      eventType: string;
+      orderingKey: string | null;
+      payload: unknown;
+      createdAt?: Date | undefined;
+      nextDispatchAt?: Date | undefined;
+    }) => {
+      onConflictDoNothing: (options: {target: PostgresOutboxTable['idempotencyKey']}) => {
+        returning: (fields: {id: PostgresOutboxTable['id']}) => Promise<Array<{id: string}>>;
+      };
     };
   };
 }
@@ -41,7 +58,40 @@ export async function writeOutboxEvents<TMap extends EventMapLike>(
   );
 }
 
+/**
+ * Inserts an event through the caller's Drizzle transaction.
+ * A repeated idempotency key leaves the first durable event unchanged.
+ */
+export async function writeIdempotentOutboxEvent<TPayload>(
+  tx: IdempotentDrizzleInsertable,
+  outboxTable: PostgresOutboxTable,
+  event: IdempotentOutboxEvent<TPayload>,
+): Promise<OutboxWriteResult> {
+  const idempotencyKey = normalizeRequiredKey(event.idempotencyKey, 'idempotencyKey');
+  const eventType = normalizeRequiredKey(event.type, 'type');
+  const inserted = await tx
+    .insert(outboxTable)
+    .values({
+      idempotencyKey,
+      eventType,
+      orderingKey: normalizeKey(event.orderingKey),
+      payload: event.payload,
+      ...(event.createdAt ? {createdAt: event.createdAt} : {}),
+      ...(event.availableAt ? {nextDispatchAt: event.availableAt} : {}),
+    })
+    .onConflictDoNothing({target: outboxTable.idempotencyKey})
+    .returning({id: outboxTable.id});
+
+  return {status: inserted.length === 0 ? 'duplicate' : 'created'};
+}
+
 function normalizeKey(key: string | undefined): string | null {
   const trimmed = key?.trim();
   return trimmed ? trimmed : null;
+}
+
+function normalizeRequiredKey(value: string, name: string): string {
+  const normalized = value.trim();
+  if (!normalized) throw new Error(`${name} must not be empty`);
+  return normalized;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5713,6 +5713,9 @@ importers:
       '@shipfox/biome':
         specifier: workspace:*
         version: link:../../../../tools/biome
+      '@shipfox/node-postgres':
+        specifier: workspace:*
+        version: link:../postgres
       '@shipfox/swc':
         specifier: workspace:*
         version: link:../../../../tools/swc


### PR DESCRIPTION
Add a reusable PostgreSQL 18 implementation to @shipfox/node-outbox with idempotent transactional writes, deterministic skip-locked claims, unique expiring leases, stale-safe acknowledge and retry transitions, bounded backoff, dead-lettering, and pending-age health.

Glint needs these operations behind its provider-neutral outbox contract, while the existing Shipfox dispatcher should keep its current schema and source API. This introduces an opt-in table and factory instead of changing createOutboxTable, so current module consumers require no migration.

Claims and transitions use the Drizzle query builder, including FOR UPDATE SKIP LOCKED. Real PostgreSQL 18 contract tests cover atomic commit and rollback, concurrent claims, ordering, expiry, stale leases, retries, dead letters, and Error failure serialization.

Careful review areas are attempt and dead-letter accounting plus ordering-key head-of-line behavior.

Closes ENG-911

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds reusable PostgreSQL 18 dispatch primitives to `@shipfox/node-outbox` with idempotent writes, leased claim/ack/retry/dead-letter, pending-age health, and hardened JSON-safe failure diagnostics. Uses PG 18 `uuidv7()` and stays opt-in so existing modules are unchanged; meets ENG-911 for a provider-neutral outbox for Glint.

- **New Features**
  - `createPostgresOutboxTable` with idempotency keys, leases, a pending index, and a dispatched retention index; requires PG 18 for `uuidv7()`.
  - `writeIdempotentOutboxEvent` for conflict-safe inserts inside a transaction.
  - `createPostgresOutbox` with deterministic claims (`FOR UPDATE SKIP LOCKED` + ordering key), lease-checked acknowledge, bounded retries (defaults: 5 attempts, 30m max delay), dead-lettering (including unleased exhausted rows after config changes), and health.
  - Hardened failure serialization: stores Errors and arbitrary failures as JSON, handles bigints and cycles, tolerates throwing string conversions, and preserves special keys like `__proto__`; adds real PostgreSQL 18 contract tests for these cases plus concurrency, ordering, expiry, retries, and dead letters.

- **Migration**
  - No changes required for current consumers; the new table and APIs are opt-in.

<sup>Written for commit 8dc5516fcf12755a50ae11f9de46e6667db8668e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

