### PR TITLE
[node-outbox] Publish package for external consumers

### DIFF
--- a/.changeset/calm-foxes-publish.md
+++ b/.changeset/calm-foxes-publish.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/node-outbox": minor
+---
+
+Publishes the supported PostgreSQL outbox API with external-consumer verification and operational documentation.

--- a/libs/shared/node/outbox/README.md
+++ b/libs/shared/node/outbox/README.md
@@ -11,16 +11,18 @@ Typed transactional outbox helpers for Drizzle and PostgreSQL.
 - **`DomainEvent`**: Runtime event shape used by dispatchers.
 - **`EventMapLike`, `EventType`, `EventPayload`**: Type helpers for module event maps.
 
+## Public API
+
+Import the supported API from `@shipfox/node-outbox`. The package has no public subpath exports.
+
+The runtime exports are `PostgresOutbox`, `createPostgresOutbox`, `createPostgresOutboxTable`, `writeIdempotentOutboxEvent`, and the behavior-preserving legacy exports `createOutboxTable`, `writeOutboxEvent`, and `writeOutboxEvents`. The root also exports the matching option, event, result, health, table, and event-map types used by those functions. Query construction and internal serialization helpers are not public.
+
 ## Installation
 
-This package is private to the workspace. Add it to another workspace package:
+Use Node.js 24 or newer. Use PostgreSQL 18.
 
-```json
-{
-  "dependencies": {
-    "@shipfox/node-outbox": "workspace:*"
-  }
-}
+```sh
+pnpm add @shipfox/node-outbox @shipfox/node-drizzle @shipfox/node-postgres drizzle-orm
 ```
 
 ## Usage
@@ -66,6 +68,8 @@ It needs PostgreSQL 18 because that release added the built-in `uuidv7()` functi
 
 ## Behavior Notes
 
+- Insert an outbox event through the same Drizzle transaction as the domain write. A rollback then removes both writes.
+- The caller owns each stable idempotency key. Reusing a key keeps the first event and returns `duplicate`.
 - Claims use `FOR UPDATE SKIP LOCKED`. Concurrent workers receive different rows.
 - A non-empty ordering key blocks newer events in the same group until the oldest event finishes.
 - Each claim increments `dispatch_attempts` and gets a new lease token.
@@ -74,12 +78,28 @@ It needs PostgreSQL 18 because that release added the built-in `uuidv7()` functi
 - `maxRetryDelayMs` defaults to 30 minutes. Longer retry delays use that limit.
 - `createOutboxTable` stays separate, so current Shipfox modules need no schema or source change.
 
+## Connections and Migrations
+
+- Create and migrate the table before application startup. The package defines the Drizzle table but does not run migrations.
+- Use a direct PostgreSQL connection for migrations. Do not run migrations through a transaction pooler or serverless pool.
+- Runtime writes and dispatch may use a direct connection or a pool. The connection layer must keep each Drizzle transaction on one PostgreSQL connection and support `FOR UPDATE SKIP LOCKED`.
+- `createPostgresOutboxTable` uses PostgreSQL 18's built-in `uuidv7()` function. Older PostgreSQL versions are not supported.
+
+## Health and Shutdown
+
+`outbox.health()` checks database access and returns the pending count and oldest pending event age. It rejects database failures. It does not prove that a dispatcher is running, so monitor worker liveness separately.
+
+For a graceful shutdown, stop starting claims, let active deliveries finish, and then close the database pool. If a worker exits with an active delivery, do not acknowledge it during shutdown. Its lease expires and another worker can claim it with a new token. Choose a lease duration longer than normal delivery time and shorter than the maximum acceptable recovery delay.
+
 ## Development
 
 ```sh
 turbo check --filter=@shipfox/node-outbox
 turbo type --filter=@shipfox/node-outbox
+turbo type:emit --filter=@shipfox/node-outbox
+turbo build --filter=@shipfox/node-outbox
 turbo test --filter=@shipfox/node-outbox
+pnpm --filter=@shipfox/node-outbox test:external
 ```
 
 The PostgreSQL contract tests need the local PostgreSQL 18 service. Start it with `docker compose up -d`.

--- a/libs/shared/node/outbox/README.md
+++ b/libs/shared/node/outbox/README.md
@@ -22,7 +22,7 @@ The runtime exports are `PostgresOutbox`, `createPostgresOutbox`, `createPostgre
 Use Node.js 24 or newer. Use PostgreSQL 18.
 
 ```sh
-pnpm add @shipfox/node-outbox @shipfox/node-drizzle @shipfox/node-postgres drizzle-orm
+pnpm add @shipfox/node-outbox @shipfox/node-drizzle drizzle-orm
 ```
 
 ## Usage

--- a/libs/shared/node/outbox/package.json
+++ b/libs/shared/node/outbox/package.json
@@ -7,8 +7,19 @@
     "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/shared/node/outbox"
   },
-  "private": true,
+  "private": false,
   "type": "module",
+  "engines": {
+    "node": ">=24"
+  },
+  "files": [
+    "CHANGELOG.md",
+    "README.md",
+    "dist/**/*.d.ts",
+    "dist/**/*.d.ts.map",
+    "dist/**/*.js",
+    "dist/**/*.js.map"
+  ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "imports": {
@@ -32,12 +43,13 @@
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
     "test": "shipfox-vitest-run",
+    "test:external": "pnpm run build && pnpm run type:emit && node test/external/verify.mjs",
     "test:watch": "shipfox-vitest-watch",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
-    "@shipfox/node-drizzle": "workspace:*",
+    "@shipfox/node-drizzle": "workspace:^",
     "drizzle-orm": "^0.45.2"
   },
   "devDependencies": {

--- a/libs/shared/node/outbox/src/index.test.ts
+++ b/libs/shared/node/outbox/src/index.test.ts
@@ -1,0 +1,15 @@
+import * as publicApi from './index.js';
+
+describe('@shipfox/node-outbox public exports', () => {
+  it('exposes only the supported runtime API', () => {
+    expect(Object.keys(publicApi).sort()).toEqual([
+      'PostgresOutbox',
+      'createOutboxTable',
+      'createPostgresOutbox',
+      'createPostgresOutboxTable',
+      'writeIdempotentOutboxEvent',
+      'writeOutboxEvent',
+      'writeOutboxEvents',
+    ]);
+  });
+});

--- a/libs/shared/node/outbox/test/external/package.template.json
+++ b/libs/shared/node/outbox/test/external/package.template.json
@@ -1,0 +1,20 @@
+{
+  "name": "node-outbox-external-fixture",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "check": "tsc --project tsconfig.json --noEmit",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@shipfox/node-drizzle": "^0.2.0",
+    "@shipfox/node-outbox": "file:./node-outbox.tgz",
+    "@shipfox/node-postgres": "^0.4.0",
+    "drizzle-orm": "^0.45.2"
+  },
+  "devDependencies": {
+    "@types/node": "^24.1.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/libs/shared/node/outbox/test/external/src/index.ts
+++ b/libs/shared/node/outbox/test/external/src/index.ts
@@ -1,0 +1,132 @@
+import {randomUUID} from 'node:crypto';
+import {drizzle, type NodePgDatabase} from '@shipfox/node-drizzle';
+import {
+  createPostgresOutbox,
+  createPostgresOutboxTable,
+  writeIdempotentOutboxEvent,
+} from '@shipfox/node-outbox';
+import {closePostgresClient, createPostgresClient} from '@shipfox/node-postgres';
+import {pgTableCreator} from 'drizzle-orm/pg-core';
+
+interface GlintDelivery {
+  eventId: string;
+  type: string;
+  payload: unknown;
+  attempt: number;
+  lease: {token: string; expiresAt: Date};
+}
+
+interface GlintOutboxHealth {
+  pending: number;
+  oldestPendingAgeMs?: number;
+}
+
+interface GlintOutboxPort {
+  claim(batchSize: number): Promise<Array<GlintDelivery>>;
+  acknowledge(delivery: GlintDelivery): Promise<void>;
+  retry(
+    delivery: GlintDelivery,
+    failure: unknown,
+  ): Promise<'scheduled' | 'dead-lettered' | 'stale'>;
+  health(): Promise<GlintOutboxHealth>;
+}
+
+class ShipfoxOutboxAdapter implements GlintOutboxPort {
+  readonly #outbox: ReturnType<typeof createPostgresOutbox>;
+
+  constructor(database: NodePgDatabase, table: ReturnType<typeof createPostgresOutboxTable>) {
+    this.#outbox = createPostgresOutbox({database, table});
+  }
+
+  async claim(batchSize: number) {
+    const deliveries = await this.#outbox.claim({batchSize, leaseDurationMs: 30_000});
+    return deliveries.map((delivery) => ({
+      eventId: delivery.id,
+      type: delivery.type,
+      payload: delivery.payload,
+      attempt: delivery.attempts,
+      lease: {token: delivery.leaseToken, expiresAt: delivery.leaseExpiresAt},
+    }));
+  }
+
+  async acknowledge(delivery: GlintDelivery) {
+    const result = await this.#outbox.acknowledge({
+      id: delivery.eventId,
+      leaseToken: delivery.lease.token,
+    });
+    if (result.status !== 'acknowledged') throw new Error('Expected a current delivery lease');
+  }
+
+  async retry(delivery: GlintDelivery, failure: unknown) {
+    const result = await this.#outbox.retry({
+      id: delivery.eventId,
+      leaseToken: delivery.lease.token,
+      delayMs: 1_000,
+      failure,
+    });
+    if (result.status === 'retry-scheduled') return 'scheduled';
+    return result.status;
+  }
+
+  async health() {
+    const health = await this.#outbox.health();
+    return {
+      pending: health.pendingCount,
+      ...(health.oldestPendingAgeMs === undefined
+        ? {}
+        : {oldestPendingAgeMs: health.oldestPendingAgeMs}),
+    };
+  }
+}
+
+const suffix = randomUUID().replaceAll('-', '');
+const tableName = `node_outbox_external_${suffix}`;
+const pool = createPostgresClient();
+const database = drizzle(pool);
+const table = createPostgresOutboxTable(pgTableCreator(() => tableName));
+const availableAt = new Date(Date.now() - 60_000);
+
+try {
+  await pool.query(`
+    CREATE TABLE "${tableName}" (
+      id uuid PRIMARY KEY DEFAULT uuidv7(),
+      idempotency_key text NOT NULL,
+      event_type text NOT NULL,
+      ordering_key text,
+      payload jsonb NOT NULL,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      dispatched_at timestamptz,
+      dispatch_attempts integer NOT NULL DEFAULT 0,
+      next_dispatch_at timestamptz NOT NULL DEFAULT now(),
+      lease_token uuid,
+      lease_expires_at timestamptz,
+      last_dispatch_error jsonb,
+      last_dispatch_failed_at timestamptz,
+      dead_lettered_at timestamptz
+    );
+    CREATE UNIQUE INDEX "${tableName}_idempotency_key_idx" ON "${tableName}" (idempotency_key);
+    CREATE UNIQUE INDEX "${tableName}_lease_token_idx" ON "${tableName}" (lease_token);
+    CREATE INDEX "${tableName}_pending_idx" ON "${tableName}" (next_dispatch_at, created_at, id)
+      WHERE dispatched_at IS NULL AND dead_lettered_at IS NULL;
+  `);
+
+  await database.transaction(async (tx) => {
+    const result = await writeIdempotentOutboxEvent(tx, table, {
+      idempotencyKey: 'build-created:build-1',
+      type: 'build.created',
+      payload: {buildId: 'build-1'},
+      availableAt,
+    });
+    if (result.status !== 'created') throw new Error('Expected a new durable event');
+  });
+
+  const outbox: GlintOutboxPort = new ShipfoxOutboxAdapter(database, table);
+  const [delivery] = await outbox.claim(1);
+  if (!delivery) throw new Error('Expected the external consumer to claim its event');
+  await outbox.acknowledge(delivery);
+  const health = await outbox.health();
+  if (health.pending !== 0) throw new Error('Expected no pending events after delivery');
+} finally {
+  await pool.query(`DROP TABLE IF EXISTS "${tableName}"`);
+  await closePostgresClient();
+}

--- a/libs/shared/node/outbox/test/external/tsconfig.json
+++ b/libs/shared/node/outbox/test/external/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2024"
+  },
+  "include": ["src"]
+}

--- a/libs/shared/node/outbox/test/external/tsconfig.json
+++ b/libs/shared/node/outbox/test/external/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "outDir": "dist",

--- a/libs/shared/node/outbox/test/external/verify.mjs
+++ b/libs/shared/node/outbox/test/external/verify.mjs
@@ -56,11 +56,21 @@ try {
     );
   }
 
+  const publishedExport = manifest.exports?.['.']?.default;
+  if (
+    !publishedExport ||
+    typeof publishedExport !== 'object' ||
+    typeof publishedExport.default !== 'string' ||
+    typeof publishedExport.types !== 'string'
+  ) {
+    throw new Error('Expected root runtime and declaration export targets');
+  }
+
   for (const relativePath of [
     'CHANGELOG.md',
     'README.md',
-    manifest.exports['.'].default.default,
-    manifest.exports['.'].default.types,
+    publishedExport.default,
+    publishedExport.types,
   ]) {
     await access(resolve(installedRoot, relativePath));
   }

--- a/libs/shared/node/outbox/test/external/verify.mjs
+++ b/libs/shared/node/outbox/test/external/verify.mjs
@@ -1,0 +1,73 @@
+import {spawn} from 'node:child_process';
+import {access, cp, mkdtemp, readFile, rename, rm} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {dirname, join, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const fixtureSource = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(fixtureSource, '../..');
+const fixtureRoot = await mkdtemp(join(tmpdir(), 'node-outbox-external-'));
+const tarball = join(fixtureRoot, 'node-outbox.tgz');
+
+function run(command, args, cwd) {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(command, args, {cwd, stdio: 'inherit'});
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code === 0) resolvePromise();
+      else reject(new Error(`${command} ${args.join(' ')} exited with code ${code}`));
+    });
+  });
+}
+
+function findWorkspaceRange(value, path = 'package.json') {
+  if (typeof value === 'string') return value.startsWith('workspace:') ? path : undefined;
+  if (!value || typeof value !== 'object') return undefined;
+  for (const [key, child] of Object.entries(value)) {
+    const found = findWorkspaceRange(child, `${path}.${key}`);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+try {
+  await cp(fixtureSource, fixtureRoot, {
+    recursive: true,
+    filter: (source) => source !== import.meta.filename,
+  });
+  await rename(join(fixtureRoot, 'package.template.json'), join(fixtureRoot, 'package.json'));
+  await run('pnpm', ['pack', '--out', tarball], packageRoot);
+  await run('pnpm', ['install', '--ignore-workspace'], fixtureRoot);
+
+  const installedRoot = join(fixtureRoot, 'node_modules/@shipfox/node-outbox');
+  const manifest = JSON.parse(await readFile(join(installedRoot, 'package.json'), 'utf8'));
+  const workspaceRange = findWorkspaceRange(manifest);
+  if (workspaceRange)
+    throw new Error(`Packed manifest contains a workspace range at ${workspaceRange}`);
+
+  const workspaceDrizzleManifest = JSON.parse(
+    await readFile(resolve(packageRoot, '../drizzle/package.json'), 'utf8'),
+  );
+  const expectedDrizzleRange = `^${workspaceDrizzleManifest.version}`;
+  const drizzleRange = manifest.dependencies?.['@shipfox/node-drizzle'];
+  if (drizzleRange !== expectedDrizzleRange) {
+    throw new Error(
+      `Expected @shipfox/node-drizzle ${expectedDrizzleRange}, received ${drizzleRange}`,
+    );
+  }
+
+  for (const relativePath of [
+    'CHANGELOG.md',
+    'README.md',
+    manifest.exports['.'].default.default,
+    manifest.exports['.'].default.types,
+  ]) {
+    await access(resolve(installedRoot, relativePath));
+  }
+
+  await run('pnpm', ['run', 'check'], fixtureRoot);
+  await run('pnpm', ['run', 'build'], fixtureRoot);
+  await run('pnpm', ['run', 'start'], fixtureRoot);
+} finally {
+  await rm(fixtureRoot, {recursive: true, force: true});
+}

--- a/libs/shared/node/outbox/tsconfig.test.json
+++ b/libs/shared/node/outbox/tsconfig.test.json
@@ -4,5 +4,5 @@
     "rootDir": "."
   },
   "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
-  "exclude": []
+  "exclude": ["test/external"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5704,7 +5704,7 @@ importers:
   libs/shared/node/outbox:
     dependencies:
       '@shipfox/node-drizzle':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../drizzle
       drizzle-orm:
         specifier: ^0.45.2


### PR DESCRIPTION
Publish `@shipfox/node-outbox` through the supported Changesets release pipeline and freeze its initial external contract.

The reusable PostgreSQL dispatch primitives are now stable, but the package is still private and its `@shipfox/node-drizzle` dependency uses a workspace-only range. This adds publish metadata and a minor Changeset, documents the Node 24 and PostgreSQL 18 operational contract, and verifies the packed artifact from a clean Glint-shaped consumer against real PostgreSQL.

The public root keeps the existing Shipfox helpers to avoid source migrations while an export contract test prevents internal query and serialization helpers from becoming accidental API. The external fixture also rejects packed manifests containing `workspace:` ranges and verifies the published runtime and declaration targets.

Closes ENG-912

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes `@shipfox/node-outbox` to npm with a stable public API and an external install verifier. Documents Node 24/PostgreSQL 18 support and no subpath exports; satisfies ENG-912 and unblocks GLI-11.

- **New Features**
  - Locks public runtime exports (`PostgresOutbox`, `createPostgresOutbox`, `createPostgresOutboxTable`, `writeIdempotentOutboxEvent`; legacy `createOutboxTable`, `writeOutboxEvent`, `writeOutboxEvents`) and adds a test to assert the surface.
  - Adds a minimal external fixture that packs, installs, type-checks, builds, runs against PostgreSQL, and validates the packed export-map shape and published files.
  - Expands README with a Public API section (no subpath exports), installation steps, connection/migration constraints, behavior notes, and health/shutdown guidance.

- **Dependencies**
  - Makes the package public, sets `engines.node: >=24`, whitelists published files, and adds a minor Changeset; adds `test:external`.
  - Switches `@shipfox/node-drizzle` to `workspace:^`; the pack verifier rejects `workspace:` ranges, checks the resolved semver, and ensures root runtime/types export targets exist.

<sup>Written for commit 98a1684349e73c55d05dec389d54836f13ddd490. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

