### PR TITLE
[node-temporal] Add Temporal Cloud API key authentication

### DIFF
--- a/.changeset/calm-clouds-connect.md
+++ b/.changeset/calm-clouds-connect.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/node-temporal": minor
+---
+
+Adds Temporal Cloud API key authentication with TLS for workflow clients and workers.

--- a/libs/shared/node/temporal/README.md
+++ b/libs/shared/node/temporal/README.md
@@ -1,6 +1,6 @@
 # Shipfox Temporal
 
-Temporal client and worker helpers for Shipfox Node services. It keeps connection settings, worker defaults, health checks, and interceptor hooks in one place.
+Temporal client and worker helpers for Shipfox Node services.
 
 ## What it does
 
@@ -11,13 +11,11 @@ Temporal client and worker helpers for Shipfox Node services. It keeps connectio
 - **`createTemporalWorker(options)`**: Creates a worker with Shipfox defaults.
 - **Interceptor helpers**: Return client, worker, and workflow settings.
 
-Environment variables:
+## Installation
 
-| Variable | Default | Purpose |
-| --- | --- | --- |
-| `TEMPORAL_ADDRESS` | `localhost:7233` | Temporal frontend address. |
-| `TEMPORAL_NAMESPACE` | `default` | Temporal namespace. |
-| `TEMPORAL_TASK_QUEUE` | `shipfox` | Default task queue for workers. |
+```sh
+pnpm add @shipfox/node-temporal
+```
 
 ## Usage
 
@@ -44,11 +42,28 @@ const worker = await createTemporalWorker({
 await worker.run();
 ```
 
+## Environment
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `TEMPORAL_ADDRESS` | `localhost:7233` | Temporal frontend address. |
+| `TEMPORAL_NAMESPACE` | `default` | Temporal namespace. |
+| `TEMPORAL_TASK_QUEUE` | `shipfox` | Default task queue for workers. |
+| `TEMPORAL_API_KEY` | none | API key used to connect to Temporal Cloud. Store it as a secret. |
+
+## Behavior notes
+
+- Local connections use no authentication or Transport Layer Security (TLS).
+- Setting `TEMPORAL_API_KEY` enables TLS for clients and workers.
+- A `tmprl.cloud` address without `TEMPORAL_API_KEY` stops startup with a configuration error.
+- This package does not configure mutual TLS (mTLS) client certificates.
+
 ## Development
 
 ```sh
 turbo check --filter=@shipfox/node-temporal
 turbo type --filter=@shipfox/node-temporal
+turbo test --filter=@shipfox/node-temporal
 ```
 
 ## License

--- a/libs/shared/node/temporal/README.md
+++ b/libs/shared/node/temporal/README.md
@@ -54,8 +54,9 @@ await worker.run();
 ## Behavior notes
 
 - Local connections use no authentication or Transport Layer Security (TLS).
-- Setting `TEMPORAL_API_KEY` enables TLS for clients and workers.
+- Setting `TEMPORAL_API_KEY` for a `tmprl.cloud` address enables TLS for clients and workers.
 - A `tmprl.cloud` address without `TEMPORAL_API_KEY` stops startup with a configuration error.
+- A non-Cloud address with `TEMPORAL_API_KEY` also stops startup so the key cannot be sent to it.
 - This package does not configure mutual TLS (mTLS) client certificates.
 
 ## Development

--- a/libs/shared/node/temporal/package.json
+++ b/libs/shared/node/temporal/package.json
@@ -31,6 +31,8 @@
     "build": "shipfox-swc",
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
+    "test": "shipfox-vitest-run",
+    "test:watch": "shipfox-vitest-watch",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"
   },
@@ -46,6 +48,7 @@
     "@shipfox/biome": "workspace:*",
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
-    "@shipfox/typescript": "workspace:*"
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*"
   }
 }

--- a/libs/shared/node/temporal/src/client.ts
+++ b/libs/shared/node/temporal/src/client.ts
@@ -1,15 +1,18 @@
 import {logger} from '@shipfox/node-opentelemetry';
 import {Client, Connection} from '@temporalio/client';
 import {config} from './config.js';
+import {getTemporalConnectionOptions, temporalConnectionError} from './connection-options.js';
 import {getClientInterceptors} from './interceptors.js';
 
 let _connection: Connection | undefined;
 let _client: Client | undefined;
 
 export async function createTemporalClient(): Promise<Client> {
-  _connection = await Connection.connect({
-    address: config.TEMPORAL_ADDRESS,
-  });
+  try {
+    _connection = await Connection.connect(getTemporalConnectionOptions());
+  } catch (error) {
+    throw temporalConnectionError(error);
+  }
 
   _client = new Client({
     connection: _connection,

--- a/libs/shared/node/temporal/src/config.ts
+++ b/libs/shared/node/temporal/src/config.ts
@@ -1,16 +1,40 @@
 import {createConfig, str} from '@shipfox/config';
 
-export const config = createConfig({
+const TEMPORAL_CLOUD_ADDRESS_PATTERN = /\.tmprl\.cloud(?::\d+)?$/i;
+
+export const temporalConfigSchema = {
   TEMPORAL_ADDRESS: str({
-    desc: 'Address of the Temporal server in host:port form.',
+    desc: 'Address of the Temporal server in host:port form. Temporal Cloud uses <namespace>.<account>.tmprl.cloud:7233.',
     default: 'localhost:7233',
   }),
   TEMPORAL_NAMESPACE: str({
-    desc: 'Temporal namespace that workflows and activities run in.',
+    desc: 'Temporal namespace that workflows and activities run in. Temporal Cloud uses <namespace>.<account>.',
     default: 'default',
   }),
   TEMPORAL_TASK_QUEUE: str({
     desc: 'Task queue that workers and clients share. Workers and clients must use the same value.',
     default: 'shipfox',
   }),
-});
+  TEMPORAL_API_KEY: str({
+    desc: 'API key used to authenticate with Temporal Cloud. Store it as a secret. It is required when TEMPORAL_ADDRESS uses a tmprl.cloud endpoint.',
+    default: undefined,
+  }),
+};
+
+export function loadTemporalConfig(update?: Partial<NodeJS.ProcessEnv>) {
+  const loadedConfig = createConfig(temporalConfigSchema, update);
+
+  if (isTemporalCloudAddress(loadedConfig.TEMPORAL_ADDRESS) && !loadedConfig.TEMPORAL_API_KEY) {
+    throw new Error('TEMPORAL_API_KEY is required when TEMPORAL_ADDRESS points to Temporal Cloud');
+  }
+
+  return loadedConfig;
+}
+
+export type TemporalConfig = ReturnType<typeof loadTemporalConfig>;
+
+export const config = loadTemporalConfig();
+
+function isTemporalCloudAddress(address: string): boolean {
+  return TEMPORAL_CLOUD_ADDRESS_PATTERN.test(address);
+}

--- a/libs/shared/node/temporal/src/config.ts
+++ b/libs/shared/node/temporal/src/config.ts
@@ -16,16 +16,22 @@ export const temporalConfigSchema = {
     default: 'shipfox',
   }),
   TEMPORAL_API_KEY: str({
-    desc: 'API key used to authenticate with Temporal Cloud. Store it as a secret. It is required when TEMPORAL_ADDRESS uses a tmprl.cloud endpoint.',
+    desc: 'API key used to authenticate with Temporal Cloud. Store it as a secret. It is required for tmprl.cloud endpoints and must be unset for other endpoints.',
     default: undefined,
   }),
 };
 
 export function loadTemporalConfig(update?: Partial<NodeJS.ProcessEnv>) {
   const loadedConfig = createConfig(temporalConfigSchema, update);
+  const usesTemporalCloud = isTemporalCloudAddress(loadedConfig.TEMPORAL_ADDRESS);
 
-  if (isTemporalCloudAddress(loadedConfig.TEMPORAL_ADDRESS) && !loadedConfig.TEMPORAL_API_KEY) {
+  if (usesTemporalCloud && !loadedConfig.TEMPORAL_API_KEY) {
     throw new Error('TEMPORAL_API_KEY is required when TEMPORAL_ADDRESS points to Temporal Cloud');
+  }
+  if (!usesTemporalCloud && loadedConfig.TEMPORAL_API_KEY) {
+    throw new Error(
+      'TEMPORAL_API_KEY must be unset when TEMPORAL_ADDRESS does not point to Temporal Cloud',
+    );
   }
 
   return loadedConfig;

--- a/libs/shared/node/temporal/src/connection-options.test.ts
+++ b/libs/shared/node/temporal/src/connection-options.test.ts
@@ -1,0 +1,67 @@
+import {loadTemporalConfig} from './config.js';
+import {getTemporalConnectionOptions, temporalConnectionError} from './connection-options.js';
+
+function loadConfig(update: Partial<NodeJS.ProcessEnv> = {}) {
+  return loadTemporalConfig({
+    TEMPORAL_ADDRESS: 'localhost:7233',
+    TEMPORAL_NAMESPACE: 'default',
+    TEMPORAL_TASK_QUEUE: 'shipfox',
+    TEMPORAL_API_KEY: undefined,
+    ...update,
+  });
+}
+
+describe('getTemporalConnectionOptions', () => {
+  it('keeps local Temporal connections unauthenticated', () => {
+    const config = loadConfig();
+
+    const result = getTemporalConnectionOptions(config);
+
+    expect(result).toEqual({address: 'localhost:7233'});
+  });
+
+  it('enables TLS and API key authentication when a key is configured', () => {
+    const config = loadConfig({
+      TEMPORAL_ADDRESS: 'shipfox.account.tmprl.cloud:7233',
+      TEMPORAL_NAMESPACE: 'shipfox.account',
+      TEMPORAL_API_KEY: 'cloud-secret',
+    });
+
+    const result = getTemporalConnectionOptions(config);
+
+    expect(result).toEqual({
+      address: 'shipfox.account.tmprl.cloud:7233',
+      apiKey: 'cloud-secret',
+      tls: true,
+    });
+  });
+});
+
+describe('loadTemporalConfig', () => {
+  it('rejects a Temporal Cloud address without an API key', () => {
+    const load = () =>
+      loadConfig({
+        TEMPORAL_ADDRESS: 'shipfox.account.tmprl.cloud:7233',
+        TEMPORAL_NAMESPACE: 'shipfox.account',
+      });
+
+    expect(load).toThrow(
+      'TEMPORAL_API_KEY is required when TEMPORAL_ADDRESS points to Temporal Cloud',
+    );
+  });
+});
+
+describe('temporalConnectionError', () => {
+  it('keeps API key material out of the actionable error message', () => {
+    const cause = new Error('unauthenticated');
+    const config = loadConfig({TEMPORAL_API_KEY: 'cloud-secret'});
+
+    const result = temporalConnectionError(cause, config);
+
+    expect(result.message).toBe(
+      'Failed to connect to Temporal. Verify TEMPORAL_ADDRESS and TEMPORAL_API_KEY.',
+    );
+    expect(result.message).not.toContain('cloud-secret');
+    expect(result.cause).toBe(cause);
+  });
+});

--- a/libs/shared/node/temporal/src/connection-options.test.ts
+++ b/libs/shared/node/temporal/src/connection-options.test.ts
@@ -49,12 +49,24 @@ describe('loadTemporalConfig', () => {
       'TEMPORAL_API_KEY is required when TEMPORAL_ADDRESS points to Temporal Cloud',
     );
   });
+
+  it('rejects an API key for a non-Cloud address', () => {
+    const load = () => loadConfig({TEMPORAL_API_KEY: 'cloud-secret'});
+
+    expect(load).toThrow(
+      'TEMPORAL_API_KEY must be unset when TEMPORAL_ADDRESS does not point to Temporal Cloud',
+    );
+  });
 });
 
 describe('temporalConnectionError', () => {
   it('keeps API key material out of the actionable error message', () => {
     const cause = new Error('unauthenticated');
-    const config = loadConfig({TEMPORAL_API_KEY: 'cloud-secret'});
+    const config = loadConfig({
+      TEMPORAL_ADDRESS: 'shipfox.account.tmprl.cloud:7233',
+      TEMPORAL_NAMESPACE: 'shipfox.account',
+      TEMPORAL_API_KEY: 'cloud-secret',
+    });
 
     const result = temporalConnectionError(cause, config);
 

--- a/libs/shared/node/temporal/src/connection-options.ts
+++ b/libs/shared/node/temporal/src/connection-options.ts
@@ -1,0 +1,28 @@
+import {config, type TemporalConfig} from './config.js';
+
+export interface TemporalConnectionOptions {
+  address: string;
+  apiKey?: string;
+  tls?: true;
+}
+
+export function getTemporalConnectionOptions(
+  temporalConfig: TemporalConfig = config,
+): TemporalConnectionOptions {
+  const {TEMPORAL_ADDRESS: address, TEMPORAL_API_KEY: apiKey} = temporalConfig;
+
+  if (!apiKey) return {address};
+
+  return {address, apiKey, tls: true};
+}
+
+export function temporalConnectionError(
+  error: unknown,
+  temporalConfig: TemporalConfig = config,
+): Error {
+  const credentialHint = temporalConfig.TEMPORAL_API_KEY
+    ? 'Verify TEMPORAL_ADDRESS and TEMPORAL_API_KEY.'
+    : 'Verify TEMPORAL_ADDRESS and that the Temporal service is reachable.';
+
+  return new Error(`Failed to connect to Temporal. ${credentialHint}`, {cause: error});
+}

--- a/libs/shared/node/temporal/src/worker.ts
+++ b/libs/shared/node/temporal/src/worker.ts
@@ -1,6 +1,7 @@
 import {logger} from '@shipfox/node-opentelemetry';
 import {NativeConnection, Worker} from '@temporalio/worker';
 import {config} from './config.js';
+import {getTemporalConnectionOptions, temporalConnectionError} from './connection-options.js';
 import {getWorkerInterceptors, getWorkflowInterceptorModules} from './interceptors.js';
 
 export interface CreateWorkerOptions {
@@ -12,9 +13,12 @@ export interface CreateWorkerOptions {
 }
 
 export async function createTemporalWorker(options: CreateWorkerOptions): Promise<Worker> {
-  const connection = await NativeConnection.connect({
-    address: config.TEMPORAL_ADDRESS,
-  });
+  let connection: NativeConnection;
+  try {
+    connection = await NativeConnection.connect(getTemporalConnectionOptions());
+  } catch (error) {
+    throw temporalConnectionError(error);
+  }
 
   const taskQueue = options.taskQueue ?? config.TEMPORAL_TASK_QUEUE;
 

--- a/libs/shared/node/temporal/vitest.config.ts
+++ b/libs/shared/node/temporal/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({}, import.meta.url) as UserConfigExport;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5826,6 +5826,9 @@ importers:
       '@shipfox/typescript':
         specifier: workspace:*
         version: link:../../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../../tools/vitest
 
   libs/shared/node/tokens:
     dependencies:

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -35,7 +35,7 @@
         "OTEL_SERVICE_METRICS_PORT",
         "POSTGRES_*",
         "SHIPFOX_*",
-        "TEMPORAL_ADDRESS",
+        "TEMPORAL_*",
         "VITE_*"
       ]
     },
@@ -72,7 +72,7 @@
         "OTEL_SERVICE_METRICS_PORT",
         "POSTGRES_*",
         "SHIPFOX_*",
-        "TEMPORAL_ADDRESS",
+        "TEMPORAL_*",
         "VITE_API_URL"
       ],
       "dependsOn": ["^build", "build"]


### PR DESCRIPTION
Add API key authentication to the shared Temporal connection configuration used by workflow clients and workers. Temporal Cloud endpoints now require a key, enable TLS, and return actionable errors without exposing credential material. Local Temporal remains unauthenticated.

The production namespace is configured for API key authentication. mTLS support was considered but left out because certificate authentication is disabled for this namespace and would add a separate certificate and private-key lifecycle.

The package now includes local and authenticated configuration coverage, environment documentation, and a release changeset.

Closes ENG-915

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add API key auth and TLS for Temporal Cloud in `@shipfox/node-temporal` (closes ENG-915). Clients and workers now share one connection config; local Temporal stays unauthenticated and rejects keys on non-Cloud endpoints.

- **Migration**
  - Set `TEMPORAL_API_KEY` when `TEMPORAL_ADDRESS` is `*.tmprl.cloud[:7233]`; TLS is enabled automatically.
  - Startup fails with a clear error if the key is missing for Cloud or set for non-Cloud; secrets are not logged.
  - No mTLS support; local `localhost:7233` needs no changes.

<sup>Written for commit 8090651e1721142290321fe6d9eaf90e19fd1fde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

