### PR TITLE
[application-release] Publish atomic release manifests

### DIFF
--- a/.changeset/bright-foxes-publish.md
+++ b/.changeset/bright-foxes-publish.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/application-release": minor
+---
+
+Adds a versioned application release manifest tool that verifies the complete OCI image set before publication.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,13 +284,43 @@ jobs:
 
       - name: Log in to GHCR
         run: |
+          set -euo pipefail
           printf '%s' "${{ secrets.GITHUB_TOKEN }}" \
             | oras login ghcr.io --username "${{ github.actor }}" --password-stdin
 
+      - name: Resolve existing application release
+        id: application-release
+        env:
+          APPLICATION_RELEASE_REPOSITORY: ghcr.io/shipfoxhq/application-releases
+        run: |
+          set -euo pipefail
+          resolve_error="$(mktemp)"
+          trap 'rm -f "$resolve_error"' EXIT
+
+          set +e
+          existing_digest="$(oras resolve "$APPLICATION_RELEASE_REPOSITORY:$GITHUB_SHA" 2>"$resolve_error")"
+          resolve_status=$?
+          set -e
+
+          if (( resolve_status == 0 )); then
+            if [[ ! "$existing_digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+              echo "Existing application release returned an invalid digest: $existing_digest" >&2
+              exit 1
+            fi
+            echo "digest=$existing_digest" >> "$GITHUB_OUTPUT"
+          elif grep -Eiq 'not found|404' "$resolve_error"; then
+            echo 'digest=' >> "$GITHUB_OUTPUT"
+          else
+            cat "$resolve_error" >&2
+            exit "$resolve_status"
+          fi
+
       - name: Build application release tool
+        if: steps.application-release.outputs.digest == ''
         run: turbo build --filter=@shipfox/application-release
 
       - name: Create application release
+        if: steps.application-release.outputs.digest == ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -311,12 +341,24 @@ jobs:
           published_at="$(jq -r '.publishedAt' application-release.json)"
           echo "APPLICATION_RELEASE_PUBLISHED_AT=$published_at" >> "$GITHUB_ENV"
 
-      # ORAS pushes one complete artifact and applies both tags to that object.
-      # No discoverable release tag exists until image resolution and label checks pass.
+      # The first successful push owns the revision tag. Reruns reuse its digest
+      # and only move latest, so the revision-addressed manifest stays immutable.
       - name: Publish application release
         env:
+          APPLICATION_RELEASE_EXISTING_DIGEST: ${{ steps.application-release.outputs.digest }}
           APPLICATION_RELEASE_REPOSITORY: ghcr.io/shipfoxhq/application-releases
         run: |
+          set -euo pipefail
+
+          if [[ -n "$APPLICATION_RELEASE_EXISTING_DIGEST" ]]; then
+            oras tag \
+              "$APPLICATION_RELEASE_REPOSITORY@$APPLICATION_RELEASE_EXISTING_DIGEST" \
+              latest
+            echo "Reused $APPLICATION_RELEASE_REPOSITORY@$APPLICATION_RELEASE_EXISTING_DIGEST" \
+              >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
           oras push \
             --artifact-type application/vnd.shipfox.application-release.v1+json \
             --annotation "org.opencontainers.image.created=$APPLICATION_RELEASE_PUBLISHED_AT" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,3 +255,79 @@ jobs:
           # appending its base to IMAGE_REGISTRIES and adding a matching login step.
           export IMAGE_REGISTRIES="ghcr.io/$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
           turbo image --filter "${{ matrix.package }}"
+
+  publish-application-release:
+    name: Publish application release
+    needs: [publish-images]
+    if: github.ref == 'refs/heads/main' && needs.publish-images.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+      packages: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Set up mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
+
+      - name: Set up pnpm
+        uses: ./.github/actions/setup-pnpm
+
+      - name: Set up ORAS
+        uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1
+        with:
+          version: 1.3.3
+
+      - name: Log in to GHCR
+        run: |
+          printf '%s' "${{ secrets.GITHUB_TOKEN }}" \
+            | oras login ghcr.io --username "${{ github.actor }}" --password-stdin
+
+      - name: Build application release tool
+        run: turbo build --filter=@shipfox/application-release
+
+      - name: Create application release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          build_started_at="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" --jq '.run_started_at')"
+
+          node tools/application-release/bin/application-release.js create \
+            --source-repository "https://github.com/$GITHUB_REPOSITORY" \
+            --revision "$GITHUB_SHA" \
+            --build-system github-actions \
+            --build-id "$GITHUB_RUN_ID" \
+            --build-number "$GITHUB_RUN_NUMBER" \
+            --build-attempt "$GITHUB_RUN_ATTEMPT" \
+            --build-started-at "$build_started_at" \
+            --build-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            --image-tag "build-$GITHUB_RUN_NUMBER" \
+            --output application-release.json
+
+          published_at="$(jq -r '.publishedAt' application-release.json)"
+          echo "APPLICATION_RELEASE_PUBLISHED_AT=$published_at" >> "$GITHUB_ENV"
+
+      # ORAS pushes one complete artifact and applies both tags to that object.
+      # No discoverable release tag exists until image resolution and label checks pass.
+      - name: Publish application release
+        env:
+          APPLICATION_RELEASE_REPOSITORY: ghcr.io/shipfoxhq/application-releases
+        run: |
+          oras push \
+            --artifact-type application/vnd.shipfox.application-release.v1+json \
+            --annotation "org.opencontainers.image.created=$APPLICATION_RELEASE_PUBLISHED_AT" \
+            --annotation "org.opencontainers.image.revision=$GITHUB_SHA" \
+            --annotation "org.opencontainers.image.source=https://github.com/$GITHUB_REPOSITORY" \
+            --format json \
+            "$APPLICATION_RELEASE_REPOSITORY:$GITHUB_SHA,latest" \
+            application-release.json:application/vnd.shipfox.application-release.v1+json \
+            | tee application-release-publication.json
+
+          published_reference="$(jq -r '.reference' application-release-publication.json)"
+          test -n "$published_reference"
+          test "$published_reference" != "null"
+          echo "Published $published_reference" >> "$GITHUB_STEP_SUMMARY"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6052,6 +6052,31 @@ importers:
         specifier: workspace:*
         version: link:../../../../tools/vitest
 
+  tools/application-release:
+    dependencies:
+      ajv:
+        specifier: ^8.20.0
+        version: 8.20.0
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.20.0)
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../typescript
+      '@types/node':
+        specifier: 25.9.3
+        version: 25.9.3
+
   tools/biome:
     dependencies:
       '@biomejs/biome':

--- a/tools/application-release/README.md
+++ b/tools/application-release/README.md
@@ -65,6 +65,9 @@ the same file.
 The current workflow stores releases in
 `ghcr.io/shipfoxhq/application-releases`. The artifact and JSON file use
 `application/vnd.shipfox.application-release.v1+json` as their media type.
+The first successful publish owns the full source revision tag. A workflow
+rerun reuses that artifact and only moves `latest`, so the revision tag does
+not change.
 
 `build.startedAt` records when CI starts. `publishedAt` records when all image
 checks finish.

--- a/tools/application-release/README.md
+++ b/tools/application-release/README.md
@@ -1,0 +1,83 @@
+# @shipfox/application-release
+
+Creates a manifest for one complete Shipfox app release.
+
+## What it does
+
+- **Release contract**: Records the source, build, publish time, and image
+  digests.
+- **OCI image checks**: Finds each digest and checks the source label on every
+  platform.
+- **Version 1 schema**: Rejects missing images, extra fields, and deployment
+  data.
+
+## Installation
+
+```sh
+pnpm add -D @shipfox/application-release
+```
+
+The command needs [ORAS](https://oras.land/) on `PATH`. ORAS reads images from
+an Open Container Initiative (OCI) registry. Log in before reading a private
+registry.
+
+## Usage
+
+```sh
+shipfox-application-release create \
+  --source-repository https://github.com/ShipfoxHQ/shipfox \
+  --revision 0123456789abcdef0123456789abcdef01234567 \
+  --build-system github-actions \
+  --build-id 123456789 \
+  --build-number 42 \
+  --build-attempt 1 \
+  --build-started-at 2026-07-13T15:30:00Z \
+  --build-url https://github.com/ShipfoxHQ/shipfox/actions/runs/123456789 \
+  --image-tag build-42 \
+  --output application-release.json
+```
+
+## Manifest contract
+
+[`schema/v1.schema.json`](schema/v1.schema.json) defines version 1. The manifest
+uses `kind: shipfox.application-release` and `apiVersion: v1` as its type.
+
+The contract contains these required image repositories:
+
+- `ghcr.io/shipfoxhq/api`
+- `ghcr.io/shipfoxhq/client`
+- `ghcr.io/shipfoxhq/provisioner-docker`
+- `ghcr.io/shipfoxhq/runner`
+
+Changing this required set creates a new contract version. Publishing another
+image in CI does not add it to this contract.
+
+Each image has a repository, digest, platform list, and attestation state. The
+image build does not publish provenance or a software bill of materials (SBOM)
+today. Both fields use `status: not-published` until those OCI artifacts exist.
+
+## Behavior Notes
+
+The command only writes JSON. CI decides where to store the file. It uses the
+full source revision as the OCI artifact tag. Another OCI registry can store
+the same file.
+
+The current workflow stores releases in
+`ghcr.io/shipfoxhq/application-releases`. The artifact and JSON file use
+`application/vnd.shipfox.application-release.v1+json` as their media type.
+
+`build.startedAt` records when CI starts. `publishedAt` records when all image
+checks finish.
+
+## Development
+
+```sh
+turbo check --filter=@shipfox/application-release
+turbo type --filter=@shipfox/application-release
+turbo test --filter=@shipfox/application-release
+turbo build --filter=@shipfox/application-release
+```
+
+## License
+
+MIT

--- a/tools/application-release/bin/application-release.js
+++ b/tools/application-release/bin/application-release.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import {runApplicationReleaseCli} from '../dist/cli.js';
+
+runApplicationReleaseCli(process.argv.slice(2));

--- a/tools/application-release/package.json
+++ b/tools/application-release/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@shipfox/application-release",
+  "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
+    "directory": "tools/application-release"
+  },
+  "license": "MIT",
+  "private": false,
+  "type": "module",
+  "files": [
+    "bin",
+    "dist",
+    "schema"
+  ],
+  "bin": {
+    "shipfox-application-release": "./bin/application-release.js"
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "test": "pnpm run build && node --test test/*.test.mjs",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*",
+    "@types/node": "25.9.3"
+  }
+}

--- a/tools/application-release/schema/v1.schema.json
+++ b/tools/application-release/schema/v1.schema.json
@@ -26,11 +26,11 @@
         "id": { "type": "string", "minLength": 1 },
         "number": { "type": "integer", "minimum": 1 },
         "attempt": { "type": "integer", "minimum": 1 },
-        "startedAt": { "type": "string", "format": "date-time" },
-        "url": { "type": "string", "format": "uri" }
+        "startedAt": { "$ref": "#/$defs/timestamp" },
+        "url": { "$ref": "#/$defs/uri" }
       }
     },
-    "publishedAt": { "type": "string", "format": "date-time" },
+    "publishedAt": { "$ref": "#/$defs/timestamp" },
     "images": {
       "type": "object",
       "additionalProperties": false,
@@ -44,6 +44,16 @@
     }
   },
   "$defs": {
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^(?:(?:\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|02-(?:0[1-9]|1\\d|2[0-8])))|(?:(?:\\d{2}(?:0[48]|[2468][048]|[13579][26])|(?:[02468][048]|[13579][26])00)-02-29))T(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d(?:\\.[0-9]{3})?Z$"
+    },
+    "uri": {
+      "type": "string",
+      "format": "uri",
+      "pattern": "^https://[^\\s/?#]+(?:[/?#][^\\s]*)?$"
+    },
     "revision": { "type": "string", "pattern": "^[a-f0-9]{40}$" },
     "digest": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
     "attestation": {

--- a/tools/application-release/schema/v1.schema.json
+++ b/tools/application-release/schema/v1.schema.json
@@ -1,0 +1,130 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:shipfox:schema:application-release:v1",
+  "title": "Shipfox application release v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["kind", "apiVersion", "source", "build", "publishedAt", "images"],
+  "properties": {
+    "kind": { "const": "shipfox.application-release" },
+    "apiVersion": { "const": "v1" },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "revision"],
+      "properties": {
+        "repository": { "const": "https://github.com/ShipfoxHQ/shipfox" },
+        "revision": { "$ref": "#/$defs/revision" }
+      }
+    },
+    "build": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["system", "id", "number", "attempt", "startedAt", "url"],
+      "properties": {
+        "system": { "type": "string", "minLength": 1 },
+        "id": { "type": "string", "minLength": 1 },
+        "number": { "type": "integer", "minimum": 1 },
+        "attempt": { "type": "integer", "minimum": 1 },
+        "startedAt": { "type": "string", "format": "date-time" },
+        "url": { "type": "string", "format": "uri" }
+      }
+    },
+    "publishedAt": { "type": "string", "format": "date-time" },
+    "images": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["api", "client", "provisioner", "runner"],
+      "properties": {
+        "api": { "$ref": "#/$defs/apiImage" },
+        "client": { "$ref": "#/$defs/clientImage" },
+        "provisioner": { "$ref": "#/$defs/provisionerImage" },
+        "runner": { "$ref": "#/$defs/runnerImage" }
+      }
+    }
+  },
+  "$defs": {
+    "revision": { "type": "string", "pattern": "^[a-f0-9]{40}$" },
+    "digest": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+    "attestation": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status"],
+          "properties": { "status": { "const": "not-published" } }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "reference"],
+          "properties": {
+            "status": { "const": "available" },
+            "reference": {
+              "type": "string",
+              "pattern": "^ghcr\\.io/shipfoxhq/[a-z0-9._-]+@sha256:[a-f0-9]{64}$"
+            }
+          }
+        }
+      ]
+    },
+    "attestations": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provenance", "sbom"],
+      "properties": {
+        "provenance": { "$ref": "#/$defs/attestation" },
+        "sbom": { "$ref": "#/$defs/attestation" }
+      }
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "digest", "platforms", "attestations"],
+      "properties": {
+        "repository": { "type": "string" },
+        "digest": { "$ref": "#/$defs/digest" },
+        "platforms": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "pattern": "^[a-z0-9]+/[a-z0-9]+(?:/[A-Za-z0-9._-]+)?$" }
+        },
+        "attestations": { "$ref": "#/$defs/attestations" }
+      }
+    },
+    "apiImage": {
+      "allOf": [
+        { "$ref": "#/$defs/image" },
+        { "type": "object", "properties": { "repository": { "const": "ghcr.io/shipfoxhq/api" } } }
+      ]
+    },
+    "clientImage": {
+      "allOf": [
+        { "$ref": "#/$defs/image" },
+        {
+          "type": "object",
+          "properties": { "repository": { "const": "ghcr.io/shipfoxhq/client" } }
+        }
+      ]
+    },
+    "provisionerImage": {
+      "allOf": [
+        { "$ref": "#/$defs/image" },
+        {
+          "type": "object",
+          "properties": { "repository": { "const": "ghcr.io/shipfoxhq/provisioner-docker" } }
+        }
+      ]
+    },
+    "runnerImage": {
+      "allOf": [
+        { "$ref": "#/$defs/image" },
+        {
+          "type": "object",
+          "properties": { "repository": { "const": "ghcr.io/shipfoxhq/runner" } }
+        }
+      ]
+    }
+  }
+}

--- a/tools/application-release/src/cli.ts
+++ b/tools/application-release/src/cli.ts
@@ -1,0 +1,97 @@
+import {writeFileSync} from 'node:fs';
+import {parseArgs} from 'node:util';
+import {createApplicationReleaseManifest} from './manifest.js';
+import {resolveApplicationImages} from './oci.js';
+
+const POSITIVE_DECIMAL_PATTERN = /^[1-9]\d*$/;
+
+export interface CreateOptions {
+  sourceRepository: string;
+  revision: string;
+  buildSystem: string;
+  buildId: string;
+  buildNumber: number;
+  buildAttempt: number;
+  buildStartedAt: string;
+  buildUrl: string;
+  imageTag: string;
+  output: string;
+}
+
+export function parseCreateOptions(args: string[]): CreateOptions {
+  const {positionals, values} = parseArgs({
+    args,
+    allowPositionals: true,
+    strict: true,
+    options: {
+      'source-repository': {type: 'string'},
+      revision: {type: 'string'},
+      'build-system': {type: 'string'},
+      'build-id': {type: 'string'},
+      'build-number': {type: 'string'},
+      'build-attempt': {type: 'string'},
+      'build-started-at': {type: 'string'},
+      'build-url': {type: 'string'},
+      'image-tag': {type: 'string'},
+      output: {type: 'string'},
+    },
+  });
+
+  if (positionals.length !== 1 || positionals[0] !== 'create') {
+    throw new Error('Usage: shipfox-application-release create [options]');
+  }
+
+  return {
+    sourceRepository: required(values['source-repository'], '--source-repository'),
+    revision: required(values.revision, '--revision'),
+    buildSystem: required(values['build-system'], '--build-system'),
+    buildId: required(values['build-id'], '--build-id'),
+    buildNumber: positiveInteger(required(values['build-number'], '--build-number')),
+    buildAttempt: positiveInteger(required(values['build-attempt'], '--build-attempt')),
+    buildStartedAt: required(values['build-started-at'], '--build-started-at'),
+    buildUrl: required(values['build-url'], '--build-url'),
+    imageTag: required(values['image-tag'], '--image-tag'),
+    output: required(values.output, '--output'),
+  };
+}
+
+export function createApplicationRelease(options: CreateOptions): void {
+  const images = resolveApplicationImages(options.imageTag, options.revision);
+  const manifest = createApplicationReleaseManifest({
+    sourceRepository: options.sourceRepository,
+    revision: options.revision,
+    build: {
+      system: options.buildSystem,
+      id: options.buildId,
+      number: options.buildNumber,
+      attempt: options.buildAttempt,
+      startedAt: options.buildStartedAt,
+      url: options.buildUrl,
+    },
+    publishedAt: new Date().toISOString(),
+    images,
+  });
+
+  writeFileSync(options.output, `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
+export function runApplicationReleaseCli(args: string[]): void {
+  createApplicationRelease(parseCreateOptions(args));
+}
+
+function required(value: string | undefined, option: string): string {
+  if (!value) throw new Error(`${option} is required`);
+  return value;
+}
+
+function positiveInteger(value: string): number {
+  if (!POSITIVE_DECIMAL_PATTERN.test(value)) {
+    throw new Error(`${JSON.stringify(value)} must be a positive decimal integer`);
+  }
+
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new Error(`${JSON.stringify(value)} must be a safe positive decimal integer`);
+  }
+  return parsed;
+}

--- a/tools/application-release/src/manifest.ts
+++ b/tools/application-release/src/manifest.ts
@@ -4,6 +4,7 @@ import addFormats from 'ajv-formats';
 
 export const APPLICATION_RELEASE_KIND = 'shipfox.application-release';
 export const APPLICATION_RELEASE_API_VERSION = 'v1';
+const UTC_TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:\.\d{3})?Z$/;
 
 /**
  * Required v1 components. Keeping this list explicit prevents a newly published
@@ -104,9 +105,16 @@ function createManifestValidator(): ValidateFunction<ApplicationReleaseManifest>
 }
 
 function timestamp(value: string, label: string): string {
+  if (!UTC_TIMESTAMP_PATTERN.test(value)) {
+    throw new Error(`${label} must be a valid UTC timestamp`);
+  }
+
+  const canonicalValue = value.includes('.') ? value : `${value.slice(0, -1)}.000Z`;
   const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) throw new Error(`${label} must be an ISO 8601 timestamp`);
-  return parsed.toISOString();
+  const isValid = !Number.isNaN(parsed.getTime()) && parsed.toISOString() === canonicalValue;
+
+  if (!isValid) throw new Error(`${label} must be a valid UTC timestamp`);
+  return canonicalValue;
 }
 
 function formatErrors(validator: ValidateFunction): string {

--- a/tools/application-release/src/manifest.ts
+++ b/tools/application-release/src/manifest.ts
@@ -1,0 +1,118 @@
+import {readFileSync} from 'node:fs';
+import Ajv2020, {type ValidateFunction} from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+export const APPLICATION_RELEASE_KIND = 'shipfox.application-release';
+export const APPLICATION_RELEASE_API_VERSION = 'v1';
+
+/**
+ * Required v1 components. Keeping this list explicit prevents a newly published
+ * image from entering a release without an application-release schema change.
+ */
+export const APPLICATION_RELEASE_IMAGES = {
+  api: 'ghcr.io/shipfoxhq/api',
+  client: 'ghcr.io/shipfoxhq/client',
+  provisioner: 'ghcr.io/shipfoxhq/provisioner-docker',
+  runner: 'ghcr.io/shipfoxhq/runner',
+} as const;
+
+export type ApplicationImageName = keyof typeof APPLICATION_RELEASE_IMAGES;
+
+export interface UnpublishedAttestation {
+  status: 'not-published';
+}
+
+export interface PublishedAttestation {
+  status: 'available';
+  reference: string;
+}
+
+export type Attestation = UnpublishedAttestation | PublishedAttestation;
+
+export interface ApplicationImage {
+  repository: string;
+  digest: string;
+  platforms: string[];
+  attestations: {
+    provenance: Attestation;
+    sbom: Attestation;
+  };
+}
+
+export type ApplicationImageSet = Record<ApplicationImageName, ApplicationImage>;
+
+export interface ApplicationReleaseInput {
+  sourceRepository: string;
+  revision: string;
+  build: {
+    system: string;
+    id: string;
+    number: number;
+    attempt: number;
+    startedAt: string;
+    url: string;
+  };
+  publishedAt: string;
+  images: ApplicationImageSet;
+}
+
+export interface ApplicationReleaseManifest {
+  kind: typeof APPLICATION_RELEASE_KIND;
+  apiVersion: typeof APPLICATION_RELEASE_API_VERSION;
+  source: {
+    repository: string;
+    revision: string;
+  };
+  build: ApplicationReleaseInput['build'];
+  publishedAt: string;
+  images: ApplicationImageSet;
+}
+
+const validateManifest = createManifestValidator();
+
+export function createApplicationReleaseManifest(
+  input: ApplicationReleaseInput,
+): ApplicationReleaseManifest {
+  const manifest: ApplicationReleaseManifest = {
+    kind: APPLICATION_RELEASE_KIND,
+    apiVersion: APPLICATION_RELEASE_API_VERSION,
+    source: {
+      repository: input.sourceRepository,
+      revision: input.revision,
+    },
+    build: {
+      ...input.build,
+      startedAt: timestamp(input.build.startedAt, 'Build start time'),
+    },
+    publishedAt: timestamp(input.publishedAt, 'Publication time'),
+    images: input.images,
+  };
+
+  if (!validateManifest(manifest)) {
+    throw new Error(`Invalid application release manifest: ${formatErrors(validateManifest)}`);
+  }
+
+  return manifest;
+}
+
+function createManifestValidator(): ValidateFunction<ApplicationReleaseManifest> {
+  const schemaPath = new URL('../schema/v1.schema.json', import.meta.url);
+  const schema = JSON.parse(readFileSync(schemaPath, 'utf8'));
+  const validator = new Ajv2020({allErrors: true, strict: true});
+  addFormats(validator);
+  return validator.compile<ApplicationReleaseManifest>(schema);
+}
+
+function timestamp(value: string, label: string): string {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) throw new Error(`${label} must be an ISO 8601 timestamp`);
+  return parsed.toISOString();
+}
+
+function formatErrors(validator: ValidateFunction): string {
+  return (
+    validator.errors
+      ?.map((error) => `${error.instancePath || '/'} ${error.message ?? 'is invalid'}`)
+      .join('; ') ?? 'unknown schema error'
+  );
+}

--- a/tools/application-release/src/oci.ts
+++ b/tools/application-release/src/oci.ts
@@ -1,0 +1,157 @@
+import {execFileSync} from 'node:child_process';
+import {
+  APPLICATION_RELEASE_IMAGES,
+  type ApplicationImage,
+  type ApplicationImageSet,
+} from './manifest.js';
+
+const DIGEST_PATTERN = /^sha256:[a-f0-9]{64}$/;
+
+interface OciDescriptor {
+  digest?: string;
+}
+
+interface OciManifest {
+  config?: OciDescriptor;
+  manifests?: Array<
+    OciDescriptor & {
+      platform?: {
+        os?: string;
+        architecture?: string;
+        variant?: string;
+      };
+    }
+  >;
+}
+
+interface OciImageConfig {
+  config?: {
+    Labels?: Record<string, string>;
+  };
+}
+
+export interface OciRegistry {
+  fetchDescriptor(reference: string): OciDescriptor;
+  fetchManifest(reference: string): OciManifest;
+  fetchBlob(reference: string): OciImageConfig;
+}
+
+export function resolveApplicationImages(
+  tag: string,
+  revision: string,
+  registry: OciRegistry = orasRegistry(),
+): ApplicationImageSet {
+  return {
+    api: resolveImage(APPLICATION_RELEASE_IMAGES.api, tag, revision, registry),
+    client: resolveImage(APPLICATION_RELEASE_IMAGES.client, tag, revision, registry),
+    provisioner: resolveImage(APPLICATION_RELEASE_IMAGES.provisioner, tag, revision, registry),
+    runner: resolveImage(APPLICATION_RELEASE_IMAGES.runner, tag, revision, registry),
+  };
+}
+
+export function resolveImage(
+  repository: string,
+  tag: string,
+  revision: string,
+  registry: OciRegistry,
+): ApplicationImage {
+  const taggedReference = `${repository}:${tag}`;
+  const descriptor = registry.fetchDescriptor(taggedReference);
+  const digest = assertDigest(descriptor.digest, `Digest for ${taggedReference}`);
+  const manifest = registry.fetchManifest(taggedReference);
+  const platformDescriptors = manifest.manifests?.filter(hasRunnablePlatform);
+
+  if (!platformDescriptors?.length) {
+    throw new Error(`${taggedReference} must be a multi-platform OCI image index`);
+  }
+
+  const platforms = platformDescriptors.map((platformDescriptor) => {
+    const platformDigest = assertDigest(
+      platformDescriptor.digest,
+      `Platform manifest digest for ${taggedReference}`,
+    );
+    const platformManifest = registry.fetchManifest(`${repository}@${platformDigest}`);
+    const configDigest = assertDigest(
+      platformManifest.config?.digest,
+      `Config digest for ${taggedReference}`,
+    );
+    const config = registry.fetchBlob(`${repository}@${configDigest}`);
+    const actualRevision = config.config?.Labels?.['org.opencontainers.image.revision'];
+    const platform = platformName(platformDescriptor.platform);
+
+    if (actualRevision !== revision) {
+      throw new Error(
+        `${taggedReference} (${platform}) has OCI revision ${JSON.stringify(actualRevision)}; expected ${revision}`,
+      );
+    }
+
+    return platform;
+  });
+
+  if (new Set(platforms).size !== platforms.length) {
+    throw new Error(`${taggedReference} contains a duplicate OCI platform`);
+  }
+
+  return {
+    repository,
+    digest,
+    platforms,
+    attestations: {
+      provenance: {status: 'not-published'},
+      sbom: {status: 'not-published'},
+    },
+  };
+}
+
+function orasRegistry(): OciRegistry {
+  return {
+    fetchDescriptor(reference) {
+      return orasJson(['manifest', 'fetch', '--descriptor', reference]);
+    },
+    fetchManifest(reference) {
+      return orasJson(['manifest', 'fetch', reference]);
+    },
+    fetchBlob(reference) {
+      return orasJson(['blob', 'fetch', '--output', '-', reference]);
+    },
+  };
+}
+
+function orasJson<T>(args: string[]): T {
+  let output: string;
+  try {
+    output = execFileSync('oras', args, {encoding: 'utf8', maxBuffer: 16 * 1024 * 1024});
+  } catch (error) {
+    const detail = error instanceof Error && 'stderr' in error ? String(error.stderr).trim() : '';
+    throw new Error(`oras ${args.slice(0, 2).join(' ')} failed${detail ? `: ${detail}` : ''}`, {
+      cause: error,
+    });
+  }
+
+  try {
+    return JSON.parse(output) as T;
+  } catch (error) {
+    throw new Error(`oras ${args.slice(0, 2).join(' ')} returned invalid JSON`, {cause: error});
+  }
+}
+
+function hasRunnablePlatform(descriptor: NonNullable<OciManifest['manifests']>[number]): boolean {
+  return Boolean(
+    descriptor.platform?.os &&
+      descriptor.platform.architecture &&
+      descriptor.platform.os !== 'unknown' &&
+      descriptor.platform.architecture !== 'unknown',
+  );
+}
+
+function platformName(platform: NonNullable<OciManifest['manifests']>[number]['platform']): string {
+  const parts = [platform?.os, platform?.architecture, platform?.variant].filter(Boolean);
+  if (parts.length < 2)
+    throw new Error('OCI platform must include an operating system and architecture');
+  return parts.join('/');
+}
+
+function assertDigest(value: string | undefined, label: string): string {
+  if (!DIGEST_PATTERN.test(value ?? '')) throw new Error(`${label} must be a sha256 digest`);
+  return value as string;
+}

--- a/tools/application-release/src/oci.ts
+++ b/tools/application-release/src/oci.ts
@@ -58,7 +58,7 @@ export function resolveImage(
   const taggedReference = `${repository}:${tag}`;
   const descriptor = registry.fetchDescriptor(taggedReference);
   const digest = assertDigest(descriptor.digest, `Digest for ${taggedReference}`);
-  const manifest = registry.fetchManifest(taggedReference);
+  const manifest = registry.fetchManifest(`${repository}@${digest}`);
   const platformDescriptors = manifest.manifests?.filter(hasRunnablePlatform);
 
   if (!platformDescriptors?.length) {

--- a/tools/application-release/test/cli.test.mjs
+++ b/tools/application-release/test/cli.test.mjs
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import {describe, test} from 'node:test';
+
+import {parseCreateOptions} from '../dist/cli.js';
+
+const missingRevisionError = /--revision is required/;
+const invalidIntegerError = /must be a positive decimal integer/;
+const nonDecimalIntegers = ['0x10', '1e3', ' 42 '];
+
+function args() {
+  return [
+    'create',
+    '--source-repository',
+    'https://github.com/ShipfoxHQ/shipfox',
+    '--revision',
+    '0123456789abcdef0123456789abcdef01234567',
+    '--build-system',
+    'github-actions',
+    '--build-id',
+    '123456789',
+    '--build-number',
+    '42',
+    '--build-attempt',
+    '1',
+    '--build-started-at',
+    '2026-07-13T15:30:00Z',
+    '--build-url',
+    'https://github.com/ShipfoxHQ/shipfox/actions/runs/123456789',
+    '--image-tag',
+    'build-42',
+    '--output',
+    'application-release.json',
+  ];
+}
+
+describe('parseCreateOptions', () => {
+  test('maps explicit adapter arguments into release options', () => {
+    const options = parseCreateOptions(args());
+
+    assert.equal(options.buildNumber, 42);
+    assert.equal(options.buildAttempt, 1);
+    assert.equal(options.imageTag, 'build-42');
+    assert.equal(options.output, 'application-release.json');
+  });
+
+  test('rejects a missing required argument', () => {
+    const input = args();
+    input.splice(input.indexOf('--revision'), 2);
+
+    const parse = () => parseCreateOptions(input);
+
+    assert.throws(parse, missingRevisionError);
+  });
+
+  for (const nonDecimalInteger of nonDecimalIntegers) {
+    test(`rejects non-decimal integer syntax: ${JSON.stringify(nonDecimalInteger)}`, () => {
+      const input = args();
+      input[input.indexOf('--build-number') + 1] = nonDecimalInteger;
+
+      const parse = () => parseCreateOptions(input);
+
+      assert.throws(parse, invalidIntegerError);
+    });
+  }
+});

--- a/tools/application-release/test/manifest.test.mjs
+++ b/tools/application-release/test/manifest.test.mjs
@@ -18,6 +18,9 @@ const schema = JSON.parse(
 const schemaValidator = new Ajv2020({strict: true});
 addFormats(schemaValidator);
 const validateManifest = schemaValidator.compile(schema);
+const portableSchemaValidator = new Ajv2020({strict: true, validateFormats: false});
+const validatePortableManifest = portableSchemaValidator.compile(schema);
+const invalidBuildTimestampError = /Build start time must be a valid UTC timestamp/;
 
 function image(repository, character) {
   return {
@@ -87,6 +90,42 @@ describe('createApplicationReleaseManifest', () => {
     manifest.deployment = {provider: 'example-cloud'};
 
     const valid = validateManifest(manifest);
+
+    assert.equal(valid, false);
+  });
+
+  test('rejects a calendar date that JavaScript would normalize', () => {
+    const releaseInput = input();
+    releaseInput.build.startedAt = '2024-02-30T15:30:00Z';
+
+    const create = () => createApplicationReleaseManifest(releaseInput);
+
+    assert.throws(create, invalidBuildTimestampError);
+  });
+
+  test('accepts a valid leap-day timestamp', () => {
+    const releaseInput = input();
+    releaseInput.publishedAt = '2024-02-29T16:00:00Z';
+
+    const manifest = createApplicationReleaseManifest(releaseInput);
+
+    assert.equal(manifest.publishedAt, '2024-02-29T16:00:00.000Z');
+  });
+
+  test('schema rejects malformed timestamps without format assertions', () => {
+    const manifest = createApplicationReleaseManifest(input());
+    manifest.publishedAt = '2023-02-29T16:00:00.000Z';
+
+    const valid = validatePortableManifest(manifest);
+
+    assert.equal(valid, false);
+  });
+
+  test('schema rejects malformed URIs without format assertions', () => {
+    const manifest = createApplicationReleaseManifest(input());
+    manifest.build.url = 'https:not-a-hierarchical-url';
+
+    const valid = validatePortableManifest(manifest);
 
     assert.equal(valid, false);
   });

--- a/tools/application-release/test/manifest.test.mjs
+++ b/tools/application-release/test/manifest.test.mjs
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import {readFileSync} from 'node:fs';
+import {describe, test} from 'node:test';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+import {
+  APPLICATION_RELEASE_API_VERSION,
+  APPLICATION_RELEASE_KIND,
+  createApplicationReleaseManifest,
+} from '../dist/manifest.js';
+
+const revision = '0123456789abcdef0123456789abcdef01234567';
+const digest = (character) => `sha256:${character.repeat(64)}`;
+const schema = JSON.parse(
+  readFileSync(new URL('../schema/v1.schema.json', import.meta.url), 'utf8'),
+);
+const schemaValidator = new Ajv2020({strict: true});
+addFormats(schemaValidator);
+const validateManifest = schemaValidator.compile(schema);
+
+function image(repository, character) {
+  return {
+    repository,
+    digest: digest(character),
+    platforms: ['linux/amd64', 'linux/arm64'],
+    attestations: {
+      provenance: {status: 'not-published'},
+      sbom: {status: 'not-published'},
+    },
+  };
+}
+
+function input() {
+  return {
+    sourceRepository: 'https://github.com/ShipfoxHQ/shipfox',
+    revision,
+    build: {
+      system: 'github-actions',
+      id: '123456789',
+      number: 42,
+      attempt: 2,
+      startedAt: '2026-07-13T15:30:00Z',
+      url: 'https://github.com/ShipfoxHQ/shipfox/actions/runs/123456789',
+    },
+    publishedAt: '2026-07-13T16:00:00Z',
+    images: {
+      api: image('ghcr.io/shipfoxhq/api', 'a'),
+      client: image('ghcr.io/shipfoxhq/client', 'b'),
+      provisioner: image('ghcr.io/shipfoxhq/provisioner-docker', 'c'),
+      runner: image('ghcr.io/shipfoxhq/runner', 'd'),
+    },
+  };
+}
+
+describe('createApplicationReleaseManifest', () => {
+  test('creates a provider-neutral application release contract', () => {
+    const manifest = createApplicationReleaseManifest(input());
+
+    assert.equal(manifest.kind, APPLICATION_RELEASE_KIND);
+    assert.equal(manifest.apiVersion, APPLICATION_RELEASE_API_VERSION);
+    assert.equal(manifest.source.revision, revision);
+    assert.equal(manifest.build.startedAt, '2026-07-13T15:30:00.000Z');
+    assert.equal(manifest.publishedAt, '2026-07-13T16:00:00.000Z');
+    assert.equal('publication' in manifest, false);
+  });
+
+  test('matches the strict version 1 schema', () => {
+    const manifest = createApplicationReleaseManifest(input());
+
+    const valid = validateManifest(manifest);
+
+    assert.equal(valid, true, JSON.stringify(validateManifest.errors));
+  });
+
+  test('schema rejects an incomplete image set', () => {
+    const manifest = createApplicationReleaseManifest(input());
+    delete manifest.images.runner;
+
+    const valid = validateManifest(manifest);
+
+    assert.equal(valid, false);
+  });
+
+  test('schema rejects deployment-provider data', () => {
+    const manifest = createApplicationReleaseManifest(input());
+    manifest.deployment = {provider: 'example-cloud'};
+
+    const valid = validateManifest(manifest);
+
+    assert.equal(valid, false);
+  });
+});

--- a/tools/application-release/test/oci.test.mjs
+++ b/tools/application-release/test/oci.test.mjs
@@ -18,6 +18,7 @@ function registry(options = {}) {
     descriptorDigest = digest('a'),
     indexManifest,
     labelRevision = revision,
+    manifestReferences,
     omitConfigDigest = false,
   } = options;
   const platformDigests = [digest('b'), digest('c')];
@@ -40,7 +41,8 @@ function registry(options = {}) {
       return {digest: descriptorDigest};
     },
     fetchManifest(reference) {
-      if (reference.includes(':build-')) {
+      manifestReferences?.push(reference);
+      if (reference.endsWith(`@${descriptorDigest}`)) {
         return indexManifest ?? defaultIndexManifest;
       }
 
@@ -56,7 +58,9 @@ function registry(options = {}) {
 
 describe('resolveApplicationImages', () => {
   test('resolves the complete image set by immutable digest', () => {
-    const images = resolveApplicationImages('build-42', revision, registry());
+    const manifestReferences = [];
+
+    const images = resolveApplicationImages('build-42', revision, registry({manifestReferences}));
 
     assert.deepEqual(Object.keys(images), ['api', 'client', 'provisioner', 'runner']);
     assert.deepEqual(images.api, {
@@ -68,6 +72,8 @@ describe('resolveApplicationImages', () => {
         sbom: {status: 'not-published'},
       },
     });
+    assert.equal(manifestReferences[0], `ghcr.io/shipfoxhq/api@${digest('a')}`);
+    assert.equal(manifestReferences.includes('ghcr.io/shipfoxhq/api:build-42'), false);
   });
 
   test('rejects an image whose OCI revision does not match the release', () => {

--- a/tools/application-release/test/oci.test.mjs
+++ b/tools/application-release/test/oci.test.mjs
@@ -1,0 +1,122 @@
+import assert from 'node:assert/strict';
+import {describe, test} from 'node:test';
+
+import {resolveApplicationImages} from '../dist/oci.js';
+
+const revision = '0123456789abcdef0123456789abcdef01234567';
+const digest = (character) => `sha256:${character.repeat(64)}`;
+const mismatchedRevisionError = /has OCI revision "other-revision"; expected 0123456789abcdef/;
+const multiPlatformError = /must be a multi-platform OCI image index/;
+const duplicatePlatformError = /contains a duplicate OCI platform/;
+const invalidIndexDigestError =
+  /Digest for ghcr\.io\/shipfoxhq\/api:build-42 must be a sha256 digest/;
+const missingConfigDigestError =
+  /Config digest for ghcr\.io\/shipfoxhq\/api:build-42 must be a sha256 digest/;
+
+function registry(options = {}) {
+  const {
+    descriptorDigest = digest('a'),
+    indexManifest,
+    labelRevision = revision,
+    omitConfigDigest = false,
+  } = options;
+  const platformDigests = [digest('b'), digest('c')];
+  const configDigests = [digest('d'), digest('e')];
+  const defaultIndexManifest = {
+    manifests: [
+      {
+        digest: platformDigests[0],
+        platform: {os: 'linux', architecture: 'amd64'},
+      },
+      {
+        digest: platformDigests[1],
+        platform: {os: 'linux', architecture: 'arm64', variant: 'v8'},
+      },
+    ],
+  };
+
+  return {
+    fetchDescriptor() {
+      return {digest: descriptorDigest};
+    },
+    fetchManifest(reference) {
+      if (reference.includes(':build-')) {
+        return indexManifest ?? defaultIndexManifest;
+      }
+
+      const platformIndex = platformDigests.findIndex((value) => reference.endsWith(value));
+      if (omitConfigDigest) return {config: {}};
+      return {config: {digest: configDigests[platformIndex]}};
+    },
+    fetchBlob() {
+      return {config: {Labels: {'org.opencontainers.image.revision': labelRevision}}};
+    },
+  };
+}
+
+describe('resolveApplicationImages', () => {
+  test('resolves the complete image set by immutable digest', () => {
+    const images = resolveApplicationImages('build-42', revision, registry());
+
+    assert.deepEqual(Object.keys(images), ['api', 'client', 'provisioner', 'runner']);
+    assert.deepEqual(images.api, {
+      repository: 'ghcr.io/shipfoxhq/api',
+      digest: digest('a'),
+      platforms: ['linux/amd64', 'linux/arm64/v8'],
+      attestations: {
+        provenance: {status: 'not-published'},
+        sbom: {status: 'not-published'},
+      },
+    });
+  });
+
+  test('rejects an image whose OCI revision does not match the release', () => {
+    const resolve = () =>
+      resolveApplicationImages('build-42', revision, registry({labelRevision: 'other-revision'}));
+
+    assert.throws(resolve, mismatchedRevisionError);
+  });
+
+  test('rejects a single-platform image manifest', () => {
+    const resolve = () =>
+      resolveApplicationImages(
+        'build-42',
+        revision,
+        registry({indexManifest: {config: {digest: digest('d')}}}),
+      );
+
+    assert.throws(resolve, multiPlatformError);
+  });
+
+  test('rejects duplicate OCI platforms', () => {
+    const resolve = () =>
+      resolveApplicationImages(
+        'build-42',
+        revision,
+        registry({
+          indexManifest: {
+            manifests: [
+              {digest: digest('b'), platform: {os: 'linux', architecture: 'amd64'}},
+              {digest: digest('c'), platform: {os: 'linux', architecture: 'amd64'}},
+            ],
+          },
+        }),
+      );
+
+    assert.throws(resolve, duplicatePlatformError);
+  });
+
+  test('rejects an invalid image index digest', () => {
+    const resolve = () =>
+      resolveApplicationImages('build-42', revision, registry({descriptorDigest: 'latest'}));
+
+    assert.throws(resolve, invalidIndexDigestError);
+  });
+
+  test('rejects a missing platform config digest', () => {
+    const resolve = () =>
+      resolveApplicationImages('build-42', revision, registry({omitConfigDigest: true}));
+
+    assert.throws(resolve, missingConfigDigestError);
+  });
+});

--- a/tools/application-release/tsconfig.build.json
+++ b/tools/application-release/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.tsx", "**/*.test.ts"]
+}

--- a/tools/application-release/tsconfig.json
+++ b/tools/application-release/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "tsconfig.build.json" }]
+}


### PR DESCRIPTION
Publish a versioned application release manifest only after the complete Shipfox OCI image set has been verified.

A successful image build previously left no single, immutable contract tying the API, client, provisioner, and runner images to one source revision. This adds `@shipfox/application-release`, which resolves every platform to immutable digests, verifies OCI revision labels, validates the strict v1 schema, and fails closed before publication. The main CI workflow then publishes the JSON as one ORAS artifact under the full source revision and moves `latest` in the same push.

The release contract lives in `tools/application-release` rather than `dev/` or workflow-local files because it is a reusable, versioned application artifact with its own schema, tests, and package lifecycle. Deployment-provider details remain outside the manifest.

The main review points are the fixed v1 four-image boundary, the OCI platform and revision guards, and the atomic two-tag ORAS publication step.

Closes ENG-923

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes a single, versioned application release manifest only after all Shipfox images are verified. Adds a CI job that publishes one ORAS JSON artifact per revision and keeps the revision tag immutable while moving `latest`.

- **New Features**
  - Adds `@shipfox/application-release` with a strict v1 schema and tests. The v1 contract fixes a four‑image boundary.
  - CLI `shipfox-application-release create` writes `application-release.json` with repo, full Git SHA, build info, published time, and immutable digests. Validates and normalizes canonical UTC timestamps.
  - Resolves and checks each required image: `ghcr.io/shipfoxhq/api`, `ghcr.io/shipfoxhq/client`, `ghcr.io/shipfoxhq/provisioner-docker`, `ghcr.io/shipfoxhq/runner`. Pins OCI reads to resolved digests, verifies multi‑platform manifests, de‑dupes platforms, and enforces per‑platform `org.opencontainers.image.revision` to match the release SHA.
  - CI adds a `publish-application-release` job on `main` after `publish-images`. It builds the tool, generates the manifest, and pushes one ORAS artifact to `ghcr.io/shipfoxhq/application-releases` with media type `application/vnd.shipfox.application-release.v1+json`, annotations, and tags `<full SHA>` and `latest` atomically. If the `<full SHA>` tag already exists, it reuses that digest and only moves `latest` to keep the revision tag immutable.
  - Meets ENG-923: main‑only aggregation after all images succeed; records immutable digests and build metadata; enforces per‑platform revision guards; pins OCI reads; publishes at a stable, SHA‑addressable location; fails closed on partial builds and keeps revision tags immutable across reruns.

<sup>Written for commit 2f00eca8a91b88a5f002ed4c9099daa65976cc12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

