### PR TITLE
[api] Add native env-file startup support

### DIFF
--- a/apps/api/.dockerignore
+++ b/apps/api/.dockerignore
@@ -4,5 +4,6 @@
 # layer cache, then re-include out/. The /** line is required because
 # re-including a directory does not re-include its contents (moby/moby#30018).
 *
+!docker-entrypoint.sh
 !out
 !out/**

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -36,6 +36,7 @@ ENV NODE_ENV=production
 RUN groupadd --system shipfox && useradd --system --gid shipfox --no-create-home shipfox
 
 COPY --from=build /prod ./
+COPY --chmod=755 docker-entrypoint.sh /usr/local/bin/shipfox-entrypoint
 
 USER shipfox
 
@@ -48,7 +49,8 @@ LABEL org.opencontainers.image.title="@shipfox/api" \
       org.opencontainers.image.licenses="MIT" \
       org.opencontainers.image.source=$IMAGE_SOURCE \
       org.opencontainers.image.revision=$IMAGE_REVISION \
-      org.opencontainers.image.created=$IMAGE_CREATED
+      org.opencontainers.image.created=$IMAGE_CREATED \
+      io.shipfox.compatibility.env-file="SHIPFOX_ENV_FILE"
 
 # --enable-source-maps maps stack traces back to TypeScript. The two --import
 # flags preload OpenTelemetry then Sentry before the app graph loads.
@@ -57,4 +59,5 @@ LABEL org.opencontainers.image.title="@shipfox/api" \
 # already registered the global meter provider. The flags stay on the entrypoint
 # command (not NODE_OPTIONS) so they apply to the app only, not to any other node
 # process run inside the container.
+ENTRYPOINT ["shipfox-entrypoint"]
 CMD ["node", "--enable-source-maps", "--import", "./dist/instrumentation.js", "--import", "@shipfox/node-error-monitoring/init", "./dist/index.js"]

--- a/apps/api/docker-entrypoint.sh
+++ b/apps/api/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+if [ "${1:-}" = "node" ] && [ -n "${SHIPFOX_ENV_FILE:-}" ]; then
+  shift
+  set -- node "--env-file=$SHIPFOX_ENV_FILE" "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
Adds provider-neutral `SHIPFOX_ENV_FILE` support to the combined API and control-plane image.

Hosted deployments can now mount a rendered environment file without introducing a custom parser or provider-specific dependency. The entrypoint passes the configured path to Node native `--env-file` handling and uses `exec` so shutdown signals still reach Node directly.

Non-Node command overrides remain unchanged, and the image exposes the supported environment variable through the `io.shipfox.compatibility.env-file` label for immutable-release compatibility checks.

Closes ENG-932

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds provider-neutral env-file startup to the combined API/control-plane container, meeting ENG-932. If `SHIPFOX_ENV_FILE` is set, the entrypoint passes it to Node via `--env-file` and execs the app; otherwise behavior is unchanged.

- **New Features**
  - Optional `SHIPFOX_ENV_FILE` is forwarded as `--env-file=<path>` when running `node`. Missing or unreadable files fail startup before app init.
  - Uses `exec` so Node receives termination signals and shuts down gracefully.
  - Non-Node command overrides remain unchanged.
  - Image advertises support via `io.shipfox.compatibility.env-file="SHIPFOX_ENV_FILE"` and stays provider-neutral (no cloud-specific deps).

<sup>Written for commit cf5c677058cce1719bc3c212a5e703e3eeed2264. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

