### PR TITLE
[node-temporal] Support caller-owned worker connections

### DIFF
--- a/.changeset/brisk-otters-connect.md
+++ b/.changeset/brisk-otters-connect.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/node-temporal": minor
+---
+
+Adds caller-owned Temporal worker connections for shared worker lifecycle management.

--- a/libs/shared/node/temporal/README.md
+++ b/libs/shared/node/temporal/README.md
@@ -8,6 +8,7 @@ Temporal client and worker helpers for Shipfox Node services.
 - **`temporalClient()`**: Returns the current client or throws if it has not been created.
 - **`closeTemporalClient()`**: Closes the Temporal connection.
 - **`isTemporalHealthy()`**: Checks the Temporal connection health service.
+- **`createTemporalWorkerConnection()`**: Creates a Temporal worker connection for a caller that owns its lifecycle.
 - **`createTemporalWorker(options)`**: Creates a worker with Shipfox defaults.
 - **Interceptor helpers**: Return client, worker, and workflow settings.
 
@@ -23,6 +24,7 @@ pnpm add @shipfox/node-temporal
 import {
   createTemporalClient,
   createTemporalWorker,
+  createTemporalWorkerConnection,
   temporalClient,
 } from '@shipfox/node-temporal';
 
@@ -40,6 +42,20 @@ const worker = await createTemporalWorker({
 });
 
 await worker.run();
+```
+
+To share and close a connection outside the worker, create it explicitly and pass it to each worker:
+
+```ts
+const connection = await createTemporalWorkerConnection();
+const worker = await createTemporalWorker({
+  connection,
+  workflowsPath: new URL('./workflows.js', import.meta.url).pathname,
+  activities: {syncActivity},
+});
+
+await worker.shutdown();
+await connection.close();
 ```
 
 ## Environment

--- a/libs/shared/node/temporal/src/index.ts
+++ b/libs/shared/node/temporal/src/index.ts
@@ -1,5 +1,5 @@
 export type * from '@temporalio/client';
-export type {Worker, WorkerOptions} from '@temporalio/worker';
+export type {NativeConnection, Worker, WorkerOptions} from '@temporalio/worker';
 export {
   closeTemporalClient,
   createTemporalClient,
@@ -12,4 +12,8 @@ export {
   getWorkerInterceptors,
   getWorkflowInterceptorModules,
 } from './interceptors.js';
-export {type CreateWorkerOptions, createTemporalWorker} from './worker.js';
+export {
+  type CreateWorkerOptions,
+  createTemporalWorker,
+  createTemporalWorkerConnection,
+} from './worker.js';

--- a/libs/shared/node/temporal/src/worker.test.ts
+++ b/libs/shared/node/temporal/src/worker.test.ts
@@ -1,0 +1,107 @@
+import type {NativeConnection} from '@temporalio/worker';
+import type {CreateWorkerOptions} from './worker.js';
+import {createTemporalWorker, createTemporalWorkerConnection} from './worker.js';
+
+const mocks = vi.hoisted(() => ({
+  nativeConnectionConnect: vi.fn(),
+  workerCreate: vi.fn(),
+  logger: {info: vi.fn()},
+  getTemporalConnectionOptions: vi.fn(),
+  temporalConnectionError: vi.fn(),
+}));
+
+vi.mock('@temporalio/worker', () => ({
+  NativeConnection: {connect: mocks.nativeConnectionConnect},
+  Worker: {create: mocks.workerCreate},
+}));
+
+vi.mock('@shipfox/node-opentelemetry', () => ({
+  logger: () => mocks.logger,
+}));
+
+vi.mock('./connection-options.js', () => ({
+  getTemporalConnectionOptions: mocks.getTemporalConnectionOptions,
+  temporalConnectionError: mocks.temporalConnectionError,
+}));
+
+function workerOptions(overrides: Partial<CreateWorkerOptions> = {}): CreateWorkerOptions {
+  return {
+    workflowsPath: '/tmp/workflows.js',
+    activities: {},
+    ...overrides,
+  };
+}
+
+describe('createTemporalWorkerConnection', () => {
+  beforeEach(() => {
+    mocks.nativeConnectionConnect.mockReset();
+    mocks.getTemporalConnectionOptions.mockReset();
+    mocks.temporalConnectionError.mockReset();
+    mocks.getTemporalConnectionOptions.mockReturnValue({address: 'temporal.example.test:7233'});
+    mocks.temporalConnectionError.mockImplementation(
+      (error) => new Error('Failed to connect to Temporal.', {cause: error}),
+    );
+  });
+
+  it('connects with the configured Temporal connection options', async () => {
+    const connection = {};
+    mocks.nativeConnectionConnect.mockResolvedValue(connection);
+
+    const result = await createTemporalWorkerConnection();
+
+    expect(result).toBe(connection);
+    expect(mocks.nativeConnectionConnect).toHaveBeenCalledWith({
+      address: 'temporal.example.test:7233',
+    });
+  });
+
+  it('translates connection failures', async () => {
+    const failure = new Error('connection refused');
+    mocks.nativeConnectionConnect.mockRejectedValue(failure);
+
+    const result = createTemporalWorkerConnection();
+
+    await expect(result).rejects.toThrow('Failed to connect to Temporal.');
+    await result.catch((error: unknown) => {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).cause).toBe(failure);
+    });
+  });
+});
+
+describe('createTemporalWorker', () => {
+  beforeEach(() => {
+    mocks.nativeConnectionConnect.mockReset();
+    mocks.workerCreate.mockReset();
+    mocks.logger.info.mockReset();
+    mocks.getTemporalConnectionOptions.mockReset();
+    mocks.temporalConnectionError.mockReset();
+    mocks.nativeConnectionConnect.mockResolvedValue({});
+    mocks.workerCreate.mockResolvedValue({});
+    mocks.getTemporalConnectionOptions.mockReturnValue({address: 'temporal.example.test:7233'});
+  });
+
+  it('creates a connection when one is not provided', async () => {
+    const connection = {};
+    mocks.nativeConnectionConnect.mockResolvedValue(connection);
+
+    await createTemporalWorker(workerOptions());
+
+    expect(mocks.workerCreate).toHaveBeenCalledWith(
+      expect.objectContaining({connection, taskQueue: 'shipfox'}),
+    );
+  });
+
+  it('uses a caller-owned connection without creating or closing one', async () => {
+    const connection = {close: vi.fn()} as unknown as NativeConnection;
+    const worker = {shutdown: vi.fn()};
+    mocks.workerCreate.mockResolvedValue(worker);
+
+    const result = await createTemporalWorker(workerOptions({connection}));
+    await result.shutdown();
+
+    expect(mocks.nativeConnectionConnect).not.toHaveBeenCalled();
+    expect(mocks.workerCreate).toHaveBeenCalledWith(expect.objectContaining({connection}));
+    expect(connection.close).not.toHaveBeenCalled();
+  });
+});

--- a/libs/shared/node/temporal/src/worker.test.ts
+++ b/libs/shared/node/temporal/src/worker.test.ts
@@ -8,6 +8,10 @@ const mocks = vi.hoisted(() => ({
   logger: {info: vi.fn()},
   getTemporalConnectionOptions: vi.fn(),
   temporalConnectionError: vi.fn(),
+  temporalConfig: {
+    TEMPORAL_NAMESPACE: 'test-namespace',
+    TEMPORAL_TASK_QUEUE: 'test-queue',
+  },
 }));
 
 vi.mock('@temporalio/worker', () => ({
@@ -23,6 +27,8 @@ vi.mock('./connection-options.js', () => ({
   getTemporalConnectionOptions: mocks.getTemporalConnectionOptions,
   temporalConnectionError: mocks.temporalConnectionError,
 }));
+
+vi.mock('./config.js', () => ({config: mocks.temporalConfig}));
 
 function workerOptions(overrides: Partial<CreateWorkerOptions> = {}): CreateWorkerOptions {
   return {
@@ -88,7 +94,11 @@ describe('createTemporalWorker', () => {
     await createTemporalWorker(workerOptions());
 
     expect(mocks.workerCreate).toHaveBeenCalledWith(
-      expect.objectContaining({connection, taskQueue: 'shipfox'}),
+      expect.objectContaining({
+        connection,
+        namespace: 'test-namespace',
+        taskQueue: 'test-queue',
+      }),
     );
   });
 

--- a/libs/shared/node/temporal/src/worker.ts
+++ b/libs/shared/node/temporal/src/worker.ts
@@ -5,6 +5,7 @@ import {getTemporalConnectionOptions, temporalConnectionError} from './connectio
 import {getWorkerInterceptors, getWorkflowInterceptorModules} from './interceptors.js';
 
 export interface CreateWorkerOptions {
+  connection?: NativeConnection;
   taskQueue?: string;
   workflowsPath: string;
   activities: object;
@@ -12,14 +13,16 @@ export interface CreateWorkerOptions {
   maxConcurrentWorkflowTaskExecutions?: number;
 }
 
-export async function createTemporalWorker(options: CreateWorkerOptions): Promise<Worker> {
-  let connection: NativeConnection;
+export async function createTemporalWorkerConnection(): Promise<NativeConnection> {
   try {
-    connection = await NativeConnection.connect(getTemporalConnectionOptions());
+    return await NativeConnection.connect(getTemporalConnectionOptions());
   } catch (error) {
     throw temporalConnectionError(error);
   }
+}
 
+export async function createTemporalWorker(options: CreateWorkerOptions): Promise<Worker> {
+  const connection = options.connection ?? (await createTemporalWorkerConnection());
   const taskQueue = options.taskQueue ?? config.TEMPORAL_TASK_QUEUE;
 
   const worker = await Worker.create({


### PR DESCRIPTION
Add a public worker-connection creation seam and allow `createTemporalWorker` to receive a caller-owned connection.

Module workers currently create a private native connection that cannot be closed by the server lifecycle. Sharing one explicit connection lets the API server stop workers and release the connection deterministically.

The optional connection preserves existing worker construction. A shared global connection was not used because the lifecycle owner must control when it is closed.

Review the ownership boundary: supplied connections are forwarded to the worker and are never closed by this package.

Refs ENG-952

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `createTemporalWorkerConnection()` and support a caller-owned `NativeConnection` in `createTemporalWorker` so servers can share and close a single Temporal worker connection. Addresses ENG-952 by aligning the worker connection lifecycle with API server shutdown.

- **New Features**
  - Added `createTemporalWorkerConnection()` to build a worker connection from existing config.
  - `createTemporalWorker({connection})` accepts a caller-owned connection; this package never closes it.
  - Re-exported `NativeConnection`; updated README and added deterministic tests (isolated from env config).

- **Migration**
  - No required changes. To manage lifecycle, create one connection with `createTemporalWorkerConnection()`, pass it to each `createTemporalWorker`, then close it on shutdown.

<sup>Written for commit fe2c4b42a80a3ac9ea6f58d32830e156c7bae4ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

