### PR TITLE
[node-module] Add stoppable worker lifecycle

### DIFF
--- a/.changeset/brave-orcas-coordinate.md
+++ b/.changeset/brave-orcas-coordinate.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/node-module": minor
+"@shipfox/api-integration-core": minor
+---
+
+Adds stoppable module workers and declarative module startup tasks for server composition.

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -161,8 +161,20 @@ export async function createIntegrationsContext(
     getIntegrationConnectionById,
   });
 
+  async function runStartupTasks(): Promise<void> {
+    for (const task of parts.flatMap((part) => part.startupTasks ?? [])) {
+      // A provider convenience must never gate API boot.
+      try {
+        await task();
+      } catch (error) {
+        logger().error({err: error}, 'Integration startup task failed, continuing boot');
+      }
+    }
+  }
+
   const module: ShipfoxModule = {
     name: 'integrations',
+    startupTasks: runStartupTasks,
     database: [
       {db, migrationsPath},
       ...parts.flatMap((part) => (part.database ? [part.database] : [])),
@@ -195,17 +207,6 @@ export async function createIntegrationsContext(
       ...parts.flatMap((part) => part.workers ?? []),
     ],
   };
-
-  async function runStartupTasks(): Promise<void> {
-    for (const task of parts.flatMap((part) => part.startupTasks ?? [])) {
-      // A provider convenience must never gate API boot.
-      try {
-        await task();
-      } catch (error) {
-        logger().error({err: error}, 'Integration startup task failed, continuing boot');
-      }
-    }
-  }
 
   return {module, registry, capabilities: {sourceControl}, sourceControl, runStartupTasks};
 }

--- a/libs/shared/node/module/README.md
+++ b/libs/shared/node/module/README.md
@@ -6,7 +6,8 @@ Module setup helpers for Shipfox API services. A module can list its database, a
 
 - **`initializeModules({modules})`**: Sets up modules in array order.
 - **`registerModuleMetrics({modules})`**: Registers service-level metrics for modules that declare a metrics hook.
-- **`startModuleWorkers({workers})`**: Creates Temporal workers and starts declared workflows before the app is marked ready.
+- **`runModuleStartupTasks({modules})`**: Runs module startup tasks in declaration order after initialization.
+- **`startModuleWorkers({workers})`**: Creates Temporal workers and returns a handle that drains workers and closes their Temporal resources.
 - **`ShipfoxModule`**: Module contract used by API packages.
 - **Publisher registry**: Adds outbox tables, drains pending events, and marks events as sent.
 - **Subscriber registry**: Adds and reads in-process event handlers by event type.
@@ -15,7 +16,12 @@ Module setup helpers for Shipfox API services. A module can list its database, a
 
 ```ts
 import {createApp, listen} from '@shipfox/node-fastify';
-import {initializeModules, registerModuleMetrics, startModuleWorkers} from '@shipfox/node-module';
+import {
+  initializeModules,
+  registerModuleMetrics,
+  runModuleStartupTasks,
+  startModuleWorkers,
+} from '@shipfox/node-module';
 import {authModule} from '@shipfox/api-auth';
 
 const modules = [authModule];
@@ -23,14 +29,15 @@ const {auth, routes, workers} = await initializeModules({
   modules,
 });
 registerModuleMetrics({modules});
+await runModuleStartupTasks({modules});
 
 await createApp({auth, routes});
-await startModuleWorkers({workers});
+const moduleWorkers = await startModuleWorkers({workers});
 await listen();
 ```
 
 `initializeModules` runs module migrations first. It exposes auth methods and routes after that. Put modules with shared database needs earlier in the array. Call `registerModuleMetrics` once after instrumentation has started and migrations have run, so observable gauges can query shared storage safely.
-Worker startup failures reject `startModuleWorkers`, so call it before serving traffic when workers are required for app health.
+Worker startup failures reject `startModuleWorkers`, so call it before serving traffic when workers are required for app health. Call `runModuleStartupTasks` after initialization so migrations complete first. The returned worker handle is idempotent and stops workers before releasing the shared Temporal connection and client.
 
 ## Module Shape
 
@@ -53,6 +60,7 @@ export const exampleModule: ShipfoxModule = {
   auth: [authMethod],
   routes: [routes],
   metrics: registerExampleServiceMetrics,
+  startupTasks: warmExampleCache,
   publishers: [{name: 'example', table: outbox, db}],
   subscribers: [subscriber('example.created', handleExampleCreated)],
   workers: [{taskQueue: 'example', workflowsPath, activities, workflows: []}],

--- a/libs/shared/node/module/src/index.ts
+++ b/libs/shared/node/module/src/index.ts
@@ -3,9 +3,15 @@ export {boundedMap} from './bounded-map.js';
 export type {
   InitializedModules,
   InitializeModulesOptions,
+  ModuleWorkersHandle,
   StartModuleWorkersOptions,
 } from './initialize.js';
-export {initializeModules, registerModuleMetrics, startModuleWorkers} from './initialize.js';
+export {
+  initializeModules,
+  registerModuleMetrics,
+  runModuleStartupTasks,
+  startModuleWorkers,
+} from './initialize.js';
 export type {
   DrainAllOptions,
   DrainAllResult,
@@ -35,6 +41,7 @@ export type {
   ModuleDatabase,
   ModuleMetricsRegistration,
   ModulePublisher,
+  ModuleStartupTasks,
   ModuleWorker,
   ShipfoxModule,
   WorkflowStart,

--- a/libs/shared/node/module/src/initialize.test.ts
+++ b/libs/shared/node/module/src/initialize.test.ts
@@ -1,9 +1,11 @@
-import {registerModuleMetrics, startModuleWorkers} from './initialize.js';
+import {registerModuleMetrics, runModuleStartupTasks, startModuleWorkers} from './initialize.js';
 import type {ModuleWorker, ShipfoxModule} from './types.js';
 
 const mocks = vi.hoisted(() => ({
+  closeTemporalClient: vi.fn(),
   createTemporalClient: vi.fn(),
   createTemporalWorker: vi.fn(),
+  createTemporalWorkerConnection: vi.fn(),
   workflowStart: vi.fn(),
   logger: {
     error: vi.fn(),
@@ -13,8 +15,10 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@shipfox/node-temporal', () => ({
+  closeTemporalClient: mocks.closeTemporalClient,
   createTemporalClient: mocks.createTemporalClient,
   createTemporalWorker: mocks.createTemporalWorker,
+  createTemporalWorkerConnection: mocks.createTemporalWorkerConnection,
   temporalClient: () => ({workflow: {start: mocks.workflowStart}}),
 }));
 
@@ -64,6 +68,49 @@ describe('registerModuleMetrics', () => {
   });
 });
 
+describe('runModuleStartupTasks', () => {
+  it('runs startup tasks sequentially in module order', async () => {
+    const calls: string[] = [];
+    const modules: ShipfoxModule[] = [
+      {
+        name: 'first',
+        startupTasks: async () => {
+          calls.push('first:start');
+          await Promise.resolve();
+          calls.push('first:end');
+        },
+      },
+      {name: 'none'},
+      {
+        name: 'second',
+        startupTasks: () => {
+          calls.push('second');
+          return Promise.resolve();
+        },
+      },
+    ];
+
+    await runModuleStartupTasks({modules});
+
+    expect(calls).toEqual(['first:start', 'first:end', 'second']);
+  });
+
+  it('propagates a startup task failure without running later tasks', async () => {
+    const failure = new Error('task failed');
+    const later = vi.fn();
+
+    const result = runModuleStartupTasks({
+      modules: [
+        {name: 'failing', startupTasks: async () => Promise.reject(failure)},
+        {name: 'later', startupTasks: later},
+      ],
+    });
+
+    await expect(result).rejects.toBe(failure);
+    expect(later).not.toHaveBeenCalled();
+  });
+});
+
 function moduleWorker(overrides: Partial<ModuleWorker> = {}): ModuleWorker {
   return {
     taskQueue: 'test-queue',
@@ -77,6 +124,7 @@ function moduleWorker(overrides: Partial<ModuleWorker> = {}): ModuleWorker {
 function temporalWorker(runResult: Promise<void> = new Promise(() => undefined)) {
   return {
     run: vi.fn(() => runResult),
+    shutdown: vi.fn(),
   };
 }
 
@@ -93,20 +141,48 @@ async function flushMicrotasks(): Promise<void> {
 
 describe('startModuleWorkers', () => {
   beforeEach(() => {
+    mocks.closeTemporalClient.mockReset();
     mocks.createTemporalClient.mockReset();
     mocks.createTemporalWorker.mockReset();
+    mocks.createTemporalWorkerConnection.mockReset();
     mocks.workflowStart.mockReset();
     mocks.logger.error.mockReset();
     mocks.logger.info.mockReset();
+    mocks.logger.warn.mockReset();
+    mocks.closeTemporalClient.mockResolvedValue(undefined);
     mocks.createTemporalClient.mockResolvedValue({});
+    mocks.createTemporalWorkerConnection.mockResolvedValue({close: vi.fn()});
     mocks.createTemporalWorker.mockResolvedValue(temporalWorker());
     mocks.workflowStart.mockResolvedValue({});
   });
 
-  it('does not create a Temporal client when no workers are declared', async () => {
-    await startModuleWorkers({workers: []});
+  it('returns a no-op handle without Temporal resources when no workers are declared', async () => {
+    const handle = await startModuleWorkers({workers: []});
+
+    await handle.stop();
 
     expect(mocks.createTemporalClient).not.toHaveBeenCalled();
+    expect(mocks.createTemporalWorkerConnection).not.toHaveBeenCalled();
+    expect(mocks.closeTemporalClient).not.toHaveBeenCalled();
+  });
+
+  it('shares one Temporal worker connection across workers', async () => {
+    const connection = {close: vi.fn()};
+    mocks.createTemporalWorkerConnection.mockResolvedValue(connection);
+
+    await startModuleWorkers({
+      workers: [moduleWorker({taskQueue: 'first'}), moduleWorker({taskQueue: 'second'})],
+    });
+
+    expect(mocks.createTemporalWorkerConnection).toHaveBeenCalledOnce();
+    expect(mocks.createTemporalWorker).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({connection}),
+    );
+    expect(mocks.createTemporalWorker).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({connection}),
+    );
   });
 
   it('rejects when Temporal client creation fails', async () => {
@@ -116,6 +192,16 @@ describe('startModuleWorkers', () => {
     const result = startModuleWorkers({workers: [moduleWorker()]});
 
     await expect(result).rejects.toBe(failure);
+  });
+
+  it('closes the Temporal client when worker connection creation fails', async () => {
+    const failure = new Error('worker connection unavailable');
+    mocks.createTemporalWorkerConnection.mockRejectedValueOnce(failure);
+
+    const result = startModuleWorkers({workers: [moduleWorker()]});
+
+    await expect(result).rejects.toBe(failure);
+    expect(mocks.closeTemporalClient).toHaveBeenCalledOnce();
   });
 
   it('wraps worker creation failures with the task queue and original cause', async () => {
@@ -201,7 +287,9 @@ describe('startModuleWorkers', () => {
 
   it('wraps unexpected workflow start failures with the task queue and original cause', async () => {
     const failure = new Error('workflow service unavailable');
+    const worker = temporalWorker();
     mocks.workflowStart.mockRejectedValueOnce(failure);
+    mocks.createTemporalWorker.mockResolvedValueOnce(worker);
 
     const result = startModuleWorkers({
       workers: [
@@ -216,6 +304,8 @@ describe('startModuleWorkers', () => {
       expect(error).toBeInstanceOf(Error);
       expect((error as Error).cause).toBe(failure);
     });
+    expect(worker.shutdown).toHaveBeenCalledOnce();
+    expect(mocks.closeTemporalClient).toHaveBeenCalledOnce();
   });
 
   it('calls the runtime failure callback when a started worker stops unexpectedly', async () => {
@@ -264,11 +354,65 @@ describe('startModuleWorkers', () => {
     );
   });
 
+  it('stops every worker, logs deliberate-stop failures, and closes Temporal resources in order', async () => {
+    const failure = new Error('forced shutdown timeout');
+    const shutdownFailure = new Error('worker not running');
+    const connection = {close: vi.fn().mockResolvedValue(undefined)};
+    let rejectRun: (error: Error) => void = () => undefined;
+    const runPromise = new Promise<void>((_resolve, reject) => {
+      rejectRun = reject;
+    });
+    const firstWorker = temporalWorker(runPromise);
+    firstWorker.shutdown.mockImplementation(() => {
+      throw shutdownFailure;
+    });
+    const secondWorker = temporalWorker(Promise.resolve());
+    const onWorkerFailure = vi.fn();
+    mocks.createTemporalWorkerConnection.mockResolvedValue(connection);
+    mocks.createTemporalWorker
+      .mockResolvedValueOnce(firstWorker)
+      .mockResolvedValueOnce(secondWorker);
+
+    const handle = await startModuleWorkers({
+      workers: [moduleWorker({taskQueue: 'first'}), moduleWorker({taskQueue: 'second'})],
+      onWorkerFailure,
+    });
+    const firstStop = handle.stop();
+    const secondStop = handle.stop();
+
+    await flushMicrotasks();
+
+    expect(connection.close).not.toHaveBeenCalled();
+    rejectRun(failure);
+
+    await firstStop;
+
+    expect(secondStop).toBe(firstStop);
+    expect(firstWorker.shutdown).toHaveBeenCalledOnce();
+    expect(secondWorker.shutdown).toHaveBeenCalledOnce();
+    expect(onWorkerFailure).not.toHaveBeenCalled();
+    expect(mocks.logger.warn).toHaveBeenCalledWith(
+      {err: shutdownFailure},
+      'Failed to shut down module worker',
+    );
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      {err: failure},
+      'Module worker stopped with an error',
+    );
+    expect(connection.close.mock.invocationCallOrder[0]).toBeGreaterThan(
+      secondWorker.shutdown.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(mocks.closeTemporalClient.mock.invocationCallOrder[0]).toBeGreaterThan(
+      connection.close.mock.invocationCallOrder[0] ?? 0,
+    );
+  });
+
   it('identifies the failing task queue when a later worker fails to start', async () => {
     const failure = new Error('second worker missing');
-    mocks.createTemporalWorker
-      .mockResolvedValueOnce(temporalWorker())
-      .mockRejectedValueOnce(failure);
+    const connection = {close: vi.fn().mockResolvedValue(undefined)};
+    const firstWorker = temporalWorker(Promise.resolve());
+    mocks.createTemporalWorkerConnection.mockResolvedValue(connection);
+    mocks.createTemporalWorker.mockResolvedValueOnce(firstWorker).mockRejectedValueOnce(failure);
 
     const result = startModuleWorkers({
       workers: [moduleWorker({taskQueue: 'first'}), moduleWorker({taskQueue: 'second'})],
@@ -279,5 +423,8 @@ describe('startModuleWorkers', () => {
       expect(error).toBeInstanceOf(Error);
       expect((error as Error).cause).toBe(failure);
     });
+    expect(firstWorker.shutdown).toHaveBeenCalledOnce();
+    expect(connection.close).toHaveBeenCalledOnce();
+    expect(mocks.closeTemporalClient).toHaveBeenCalledOnce();
   });
 });

--- a/libs/shared/node/module/src/initialize.ts
+++ b/libs/shared/node/module/src/initialize.ts
@@ -1,7 +1,15 @@
 import {runMigrations} from '@shipfox/node-drizzle';
 import type {AuthMethod, RouteExport} from '@shipfox/node-fastify';
 import {logger} from '@shipfox/node-opentelemetry';
-import {createTemporalClient, createTemporalWorker, temporalClient} from '@shipfox/node-temporal';
+import {
+  closeTemporalClient,
+  createTemporalClient,
+  createTemporalWorker,
+  createTemporalWorkerConnection,
+  type NativeConnection,
+  temporalClient,
+  type Worker,
+} from '@shipfox/node-temporal';
 import {registerPublisher} from './publisher-registry.js';
 import {subscribe} from './registry.js';
 import type {ModuleDatabase, ModuleWorker, ShipfoxModule} from './types.js';
@@ -20,6 +28,15 @@ export interface InitializedModules {
 export interface StartModuleWorkersOptions {
   workers: ModuleWorker[];
   onWorkerFailure?: (error: unknown, worker: ModuleWorker) => void | Promise<void>;
+}
+
+export interface ModuleWorkersHandle {
+  stop(): Promise<void>;
+}
+
+interface StartedModuleWorker {
+  worker: Worker;
+  runPromise?: Promise<void>;
 }
 
 /**
@@ -114,58 +131,144 @@ export function registerModuleMetrics(options: {modules: ShipfoxModule[]}): void
   }
 }
 
+export async function runModuleStartupTasks(options: {modules: ShipfoxModule[]}): Promise<void> {
+  for (const mod of options.modules) {
+    await mod.startupTasks?.();
+  }
+}
+
 /**
  * Creates Temporal workers for all module-declared workers and starts their workflows.
  * Call this after `initializeModules` so that all publishers/subscribers are registered.
  */
-export async function startModuleWorkers(options: StartModuleWorkersOptions): Promise<void> {
-  if (options.workers.length === 0) return;
+export async function startModuleWorkers(
+  options: StartModuleWorkersOptions,
+): Promise<ModuleWorkersHandle> {
+  if (options.workers.length === 0) return {stop: async () => undefined};
 
   await createTemporalClient();
+  let connection: NativeConnection | undefined;
+  const workers: StartedModuleWorker[] = [];
+  let stopping = false;
+  let stopPromise: Promise<void> | undefined;
 
-  for (const workerDef of options.workers) {
-    try {
-      const worker = await createTemporalWorker({
-        taskQueue: workerDef.taskQueue,
-        workflowsPath: workerDef.workflowsPath,
-        activities: workerDef.activities(),
-      });
+  try {
+    connection = await createTemporalWorkerConnection();
 
-      for (const workflow of workerDef.workflows) {
-        try {
-          await temporalClient().workflow.start(workflow.name, {
-            taskQueue: workerDef.taskQueue,
-            workflowId: workflow.id,
-            ...(workflow.args ? {args: workflow.args} : {}),
-            ...(workflow.cronSchedule ? {cronSchedule: workflow.cronSchedule} : {}),
-          });
-        } catch (error) {
-          if (error instanceof Error && error.name === 'WorkflowExecutionAlreadyStartedError') {
-            logger().info({workflowId: workflow.id}, 'Workflow already running, skipping start');
-          } else {
-            throw error;
+    for (const workerDef of options.workers) {
+      try {
+        const worker = await createTemporalWorker({
+          connection,
+          taskQueue: workerDef.taskQueue,
+          workflowsPath: workerDef.workflowsPath,
+          activities: workerDef.activities(),
+        });
+        const startedWorker: StartedModuleWorker = {worker};
+        workers.push(startedWorker);
+
+        for (const workflow of workerDef.workflows) {
+          try {
+            await temporalClient().workflow.start(workflow.name, {
+              taskQueue: workerDef.taskQueue,
+              workflowId: workflow.id,
+              ...(workflow.args ? {args: workflow.args} : {}),
+              ...(workflow.cronSchedule ? {cronSchedule: workflow.cronSchedule} : {}),
+            });
+          } catch (error) {
+            if (error instanceof Error && error.name === 'WorkflowExecutionAlreadyStartedError') {
+              logger().info({workflowId: workflow.id}, 'Workflow already running, skipping start');
+            } else {
+              throw error;
+            }
           }
         }
-      }
 
-      worker.run().catch((error) => {
-        if (options.onWorkerFailure) {
-          void Promise.resolve(options.onWorkerFailure(error, workerDef)).catch((handlerError) => {
-            logger().error(
-              {err: handlerError, workerErr: error, taskQueue: workerDef.taskQueue},
-              'Module worker failure handler failed',
+        const runPromise = worker.run();
+        startedWorker.runPromise = runPromise;
+        runPromise.catch((error) => {
+          if (stopping) return;
+          if (options.onWorkerFailure) {
+            void Promise.resolve(options.onWorkerFailure(error, workerDef)).catch(
+              (handlerError) => {
+                logger().error(
+                  {err: handlerError, workerErr: error, taskQueue: workerDef.taskQueue},
+                  'Module worker failure handler failed',
+                );
+              },
             );
-          });
-          return;
-        }
-        logger().error({err: error, taskQueue: workerDef.taskQueue}, 'Worker stopped unexpectedly');
-      });
+            return;
+          }
+          logger().error(
+            {err: error, taskQueue: workerDef.taskQueue},
+            'Worker stopped unexpectedly',
+          );
+        });
 
-      logger().info({taskQueue: workerDef.taskQueue}, 'Module worker started');
-    } catch (error) {
-      throw new Error(`Failed to start module worker for task queue ${workerDef.taskQueue}`, {
-        cause: error,
-      });
+        logger().info({taskQueue: workerDef.taskQueue}, 'Module worker started');
+      } catch (error) {
+        throw new Error(`Failed to start module worker for task queue ${workerDef.taskQueue}`, {
+          cause: error,
+        });
+      }
     }
+  } catch (error) {
+    stopping = true;
+    await cleanUpFailedModuleWorkerStartup({error, workers, connection});
+    throw error;
+  }
+
+  return {
+    stop: () => {
+      stopping = true;
+      stopPromise ??= stopModuleWorkers({workers, connection});
+      return stopPromise;
+    },
+  };
+}
+
+async function stopModuleWorkers(options: {
+  workers: StartedModuleWorker[];
+  connection: NativeConnection;
+}): Promise<void> {
+  for (const {worker} of options.workers) {
+    try {
+      worker.shutdown();
+    } catch (error) {
+      logger().warn({err: error}, 'Failed to shut down module worker');
+    }
+  }
+
+  const results = await Promise.allSettled(
+    options.workers.flatMap(({runPromise}) => (runPromise ? [runPromise] : [])),
+  );
+  for (const result of results) {
+    if (result.status === 'rejected') {
+      logger().error({err: result.reason}, 'Module worker stopped with an error');
+    }
+  }
+
+  try {
+    await options.connection.close();
+  } finally {
+    await closeTemporalClient();
+  }
+}
+
+async function cleanUpFailedModuleWorkerStartup(options: {
+  error: unknown;
+  workers: StartedModuleWorker[];
+  connection: NativeConnection | undefined;
+}): Promise<void> {
+  try {
+    if (options.connection) {
+      await stopModuleWorkers({workers: options.workers, connection: options.connection});
+    } else {
+      await closeTemporalClient();
+    }
+  } catch (cleanupError) {
+    logger().error(
+      {err: cleanupError, workerErr: options.error},
+      'Failed to clean up module worker startup resources',
+    );
   }
 }

--- a/libs/shared/node/module/src/types.ts
+++ b/libs/shared/node/module/src/types.ts
@@ -57,6 +57,8 @@ export interface ModuleWorker {
  */
 export type ModuleMetricsRegistration = () => void;
 
+export type ModuleStartupTasks = () => Promise<void>;
+
 export interface ShipfoxModule {
   name: string;
   database?: ModuleDatabase | ModuleDatabase[];
@@ -67,4 +69,5 @@ export interface ShipfoxModule {
   subscribers?: ModuleSubscriber[];
   workers?: ModuleWorker[];
   metrics?: ModuleMetricsRegistration;
+  startupTasks?: ModuleStartupTasks;
 }


### PR DESCRIPTION
Add stoppable module workers and declarative startup tasks.

The server composition API needs module arrays to own both boot and shutdown behavior. This lets the forthcoming API-server lifecycle drain workers, release Temporal resources deterministically, and run provider initialization without an integrations-specific side channel.

`startModuleWorkers` now shares one caller-owned worker connection, returns an idempotent stop handle, and releases workers, the connection, and client on either normal shutdown or startup failure. Modules can declare ordered startup tasks; integration-core attaches its existing provider task runner while preserving per-provider failure isolation.

`apps/api` remains on its legacy lifecycle path until the dedicated API-server extraction slice. Migrating it here would duplicate that work; this PR supplies the tested module-level contract it will consume.

Closes ENG-953

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a stoppable worker lifecycle and module startup tasks so server composition can own boot and shutdown. Implements ENG-953 by returning a worker stop handle and adding `startupTasks` to modules.

- **New Features**
  - `@shipfox/node-module`
    - `startModuleWorkers` returns `ModuleWorkersHandle.stop()` that drains workers, then closes a shared Temporal worker connection and client. Deliberate stops don’t trigger the failure handler.
    - New `runModuleStartupTasks({modules})` runs tasks sequentially in module order.
    - `ShipfoxModule` gains `startupTasks`.
  - `@shipfox/api-integration-core`
    - Hooks existing provider startup tasks into `startupTasks`, keeping per-provider failure isolation.

- **Migration**
  - After `initializeModules`, call `runModuleStartupTasks({modules})` if you have startup tasks.
  - Keep the handle from `startModuleWorkers({workers})` and call `stop()` on shutdown. Existing call sites still typecheck if the handle is ignored.

<sup>Written for commit 611ee59981185fb8ec3fa10b2ecdb27067d597a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

