### PR TITLE
[api-server] Add reusable server lifecycle

### DIFF
--- a/.changeset/tidy-toads-build.md
+++ b/.changeset/tidy-toads-build.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/api-server": minor
+"@shipfox/node-opentelemetry": minor
+---
+
+Adds the @shipfox/api-server package with server lifecycle, default module composition, and an
+instrumentation preload entry, and exposes shutdownServiceMetrics from @shipfox/node-opentelemetry.

--- a/libs/api/server/README.md
+++ b/libs/api/server/README.md
@@ -1,0 +1,59 @@
+# Shipfox API Server
+
+Runs a Shipfox API server.
+
+## What it does
+
+- **`defaultModules()`**: Returns the standard module list.
+- **`createServer()`**: Builds an API server. The caller owns process signals.
+- **`runServer()`**: Starts the server. It listens for SIGTERM and SIGINT.
+- **Instrumentation preload**: Starts metrics early. Load it before feature modules.
+
+## Installation
+
+```sh
+pnpm add @shipfox/api-server
+```
+
+## Usage
+
+```ts
+import {defaultModules, runServer} from '@shipfox/api-server';
+
+await runServer({modules: await defaultModules()});
+```
+
+Load the instrumentation entry before feature modules:
+
+```sh
+node --import @shipfox/api-server/instrumentation ./dist/index.js
+```
+
+## Environment
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `E2E_ENABLED` | `false` | Turns on routes under `/__e2e`. |
+| `E2E_ADMIN_API_KEY` | none | Protects E2E routes. |
+| `API_PORT` | shared `PORT` | Sets the listener port. |
+| `API_TRUST_PROXY` | `false` | Sets proxy IP checks. |
+
+## Behavior Notes
+
+- **Custom composition**: Pass a module list to make a custom server.
+- **Signal handling**: `createServer` does not install signal handlers.
+- **Lifecycle**: `start` starts workers before the HTTP listener. `stop` is safe to call again.
+- **Process scope**: Run one server at a time.
+
+## Development
+
+```sh
+turbo build --filter=@shipfox/api-server
+turbo check --filter=@shipfox/api-server
+turbo type --filter=@shipfox/api-server
+turbo test --filter=@shipfox/api-server
+```
+
+## License
+
+MIT

--- a/libs/api/server/README.md
+++ b/libs/api/server/README.md
@@ -33,8 +33,8 @@ node --import @shipfox/api-server/instrumentation ./dist/index.js
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `E2E_ENABLED` | `false` | Turns on routes under `/__e2e`. |
-| `E2E_ADMIN_API_KEY` | none | Protects E2E routes. |
+| `E2E_ENABLED` | `false` | Enables routes under `/__e2e` when `E2E_ADMIN_API_KEY` is set. |
+| `E2E_ADMIN_API_KEY` | none | Required to enable and protect E2E routes. |
 | `API_PORT` | shared `PORT` | Sets the listener port. |
 | `API_TRUST_PROXY` | `false` | Sets proxy IP checks. |
 

--- a/libs/api/server/package.json
+++ b/libs/api/server/package.json
@@ -1,0 +1,80 @@
+{
+  "name": "@shipfox/api-server",
+  "license": "MIT",
+  "private": false,
+  "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
+    "directory": "libs/api/server"
+  },
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "imports": {
+    "#*": {
+      "workspace-source": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
+  },
+  "exports": {
+    ".": {
+      "development": {
+        "types": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    },
+    "./instrumentation": {
+      "development": {
+        "types": "./src/instrumentation.ts",
+        "default": "./src/instrumentation.ts"
+      },
+      "default": {
+        "types": "./dist/instrumentation.d.ts",
+        "default": "./dist/instrumentation.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "test": "shipfox-vitest-run",
+    "test:watch": "shipfox-vitest-watch",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "@shipfox/annotations": "workspace:*",
+    "@shipfox/api-agent": "workspace:*",
+    "@shipfox/api-auth": "workspace:*",
+    "@shipfox/api-definitions": "workspace:*",
+    "@shipfox/api-dispatcher": "workspace:*",
+    "@shipfox/api-integration-core": "workspace:*",
+    "@shipfox/api-logs": "workspace:*",
+    "@shipfox/api-projects": "workspace:*",
+    "@shipfox/api-runners": "workspace:*",
+    "@shipfox/api-secrets": "workspace:*",
+    "@shipfox/api-triggers": "workspace:*",
+    "@shipfox/api-workflows": "workspace:*",
+    "@shipfox/api-workspaces": "workspace:*",
+    "@shipfox/config": "workspace:*",
+    "@shipfox/node-error-monitoring": "workspace:*",
+    "@shipfox/node-fastify": "workspace:*",
+    "@shipfox/node-module": "workspace:*",
+    "@shipfox/node-opentelemetry": "workspace:*",
+    "@shipfox/node-postgres": "workspace:*"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*"
+  }
+}

--- a/libs/api/server/src/config.test.ts
+++ b/libs/api/server/src/config.test.ts
@@ -1,0 +1,33 @@
+import {parseApiTrustProxy} from './config.js';
+
+describe('parseApiTrustProxy', () => {
+  it.each([
+    ['false', false],
+    [' true ', true],
+    ['1', 1],
+    ['3', 3],
+    ['127.0.0.1', '127.0.0.1'],
+    ['10.0.0.0/8', '10.0.0.0/8'],
+    ['2001:db8::/32', '2001:db8::/32'],
+  ])('parses %s', (value, expected) => {
+    const result = parseApiTrustProxy(value);
+
+    expect(result).toBe(expected);
+  });
+
+  it.each([
+    '',
+    '0',
+    '-1',
+    '1.5',
+    'maybe',
+    '9007199254740992',
+    '1'.repeat(400),
+    '10.0.0.0/99',
+    '2001:db8::/129',
+  ])('rejects %s', (value) => {
+    const act = () => parseApiTrustProxy(value);
+
+    expect(act).toThrow('API_TRUST_PROXY');
+  });
+});

--- a/libs/api/server/src/config.ts
+++ b/libs/api/server/src/config.ts
@@ -1,0 +1,54 @@
+import {isIP} from 'node:net';
+import {bool, createConfig, port, str} from '@shipfox/config';
+
+export type ApiTrustProxy = false | true | number | string;
+
+const INTEGER_PATTERN = /^\d+$/;
+
+export const config = createConfig({
+  E2E_ENABLED: bool({
+    desc: 'Enables the end-to-end test routes under /__e2e. Keep it false in production.',
+    default: false,
+  }),
+  E2E_ADMIN_API_KEY: str({
+    desc: 'Bearer token that protects the E2E admin routes. Set it when E2E_ENABLED is true.',
+    default: undefined,
+  }),
+  API_PORT: port({
+    desc: 'Port the API HTTP server listens on. When unset, the shared PORT setting controls the server port.',
+    default: undefined,
+  }),
+  API_TRUST_PROXY: str({
+    desc: 'Controls how the API trusts proxy headers for client IP detection. Use false when clients connect directly, true only when every caller is a trusted proxy, a positive hop count such as 1, or a trusted proxy IP/CIDR such as 10.0.0.0/8.',
+    default: 'false',
+  }),
+});
+
+function parseCidr(value: string): boolean {
+  const [address, prefix, extra] = value.split('/');
+  if (!address || !prefix || extra !== undefined || isIP(address) === 0) return false;
+
+  const maxPrefix = isIP(address) === 4 ? 32 : 128;
+  if (!INTEGER_PATTERN.test(prefix)) return false;
+
+  const prefixNumber = Number(prefix);
+  return prefixNumber >= 0 && prefixNumber <= maxPrefix;
+}
+
+export function parseApiTrustProxy(value: string): ApiTrustProxy {
+  const trimmed = value.trim();
+  if (trimmed === 'false') return false;
+  if (trimmed === 'true') return true;
+
+  if (INTEGER_PATTERN.test(trimmed)) {
+    const hops = Number(trimmed);
+    if (Number.isSafeInteger(hops) && hops > 0) return hops;
+    throw new Error('API_TRUST_PROXY hop count must be a positive safe integer');
+  }
+
+  if (isIP(trimmed) !== 0 || parseCidr(trimmed)) return trimmed;
+
+  throw new Error(
+    'API_TRUST_PROXY must be false, true, a positive hop count, or a trusted proxy IP/CIDR',
+  );
+}

--- a/libs/api/server/src/e2e.test.ts
+++ b/libs/api/server/src/e2e.test.ts
@@ -1,0 +1,85 @@
+import {closeApp, createApp, defineRoute} from '@shipfox/node-fastify';
+import {afterEach, describe, expect, it} from '@shipfox/vitest/vi';
+import {createE2eAdminAuthMethod, createE2eRouteGroup} from './e2e.js';
+
+const pingRoute = defineRoute({
+  method: 'POST',
+  path: '/ping',
+  description: 'E2E test route.',
+  handler: () => ({ok: true}),
+});
+
+describe('E2E route gating', () => {
+  afterEach(async () => {
+    await closeApp();
+  });
+
+  it('does not mount E2E routes when E2E is disabled', async () => {
+    const app = await createApp({
+      auth: [createE2eAdminAuthMethod({E2E_ENABLED: false, E2E_ADMIN_API_KEY: 'secret'})],
+      routes: createE2eRouteGroup([pingRoute], {E2E_ENABLED: false, E2E_ADMIN_API_KEY: 'secret'}),
+      swagger: false,
+    });
+
+    const res = await app.inject({method: 'POST', url: '/__e2e/ping'});
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('does not mount E2E routes when the admin key is missing', async () => {
+    const app = await createApp({
+      auth: [createE2eAdminAuthMethod({E2E_ENABLED: true})],
+      routes: createE2eRouteGroup([pingRoute], {E2E_ENABLED: true}),
+      swagger: false,
+    });
+
+    const res = await app.inject({method: 'POST', url: '/__e2e/ping'});
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('rejects missing E2E admin bearer tokens', async () => {
+    const app = await createApp({
+      auth: [createE2eAdminAuthMethod({E2E_ENABLED: true, E2E_ADMIN_API_KEY: 'secret'})],
+      routes: createE2eRouteGroup([pingRoute], {E2E_ENABLED: true, E2E_ADMIN_API_KEY: 'secret'}),
+      swagger: false,
+    });
+
+    const res = await app.inject({method: 'POST', url: '/__e2e/ping'});
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects invalid E2E admin bearer tokens', async () => {
+    const app = await createApp({
+      auth: [createE2eAdminAuthMethod({E2E_ENABLED: true, E2E_ADMIN_API_KEY: 'secret'})],
+      routes: createE2eRouteGroup([pingRoute], {E2E_ENABLED: true, E2E_ADMIN_API_KEY: 'secret'}),
+      swagger: false,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/__e2e/ping',
+      headers: {authorization: 'Bearer wrong'},
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('allows valid E2E admin bearer tokens', async () => {
+    const app = await createApp({
+      auth: [createE2eAdminAuthMethod({E2E_ENABLED: true, E2E_ADMIN_API_KEY: 'secret'})],
+      routes: createE2eRouteGroup([pingRoute], {E2E_ENABLED: true, E2E_ADMIN_API_KEY: 'secret'}),
+      swagger: false,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/__e2e/ping',
+      headers: {authorization: 'Bearer secret'},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ok: true});
+  });
+});

--- a/libs/api/server/src/e2e.test.ts
+++ b/libs/api/server/src/e2e.test.ts
@@ -82,4 +82,20 @@ describe('E2E route gating', () => {
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual({ok: true});
   });
+
+  it('allows a mixed-case E2E admin bearer scheme', async () => {
+    const app = await createApp({
+      auth: [createE2eAdminAuthMethod({E2E_ENABLED: true, E2E_ADMIN_API_KEY: 'secret'})],
+      routes: createE2eRouteGroup([pingRoute], {E2E_ENABLED: true, E2E_ADMIN_API_KEY: 'secret'}),
+      swagger: false,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/__e2e/ping',
+      headers: {authorization: 'bEaReR secret'},
+    });
+
+    expect(res.statusCode).toBe(200);
+  });
 });

--- a/libs/api/server/src/e2e.ts
+++ b/libs/api/server/src/e2e.ts
@@ -1,0 +1,61 @@
+import {timingSafeEqual} from 'node:crypto';
+import {
+  type AuthMethod,
+  ClientError,
+  type RouteExport,
+  type RouteGroup,
+} from '@shipfox/node-fastify';
+
+export const AUTH_E2E_ADMIN = 'e2e-admin';
+
+export interface E2eConfig {
+  E2E_ENABLED: boolean;
+  E2E_ADMIN_API_KEY?: string | undefined;
+}
+
+const BEARER_RE = /^Bearer /u;
+
+export function shouldMountE2eRoutes(config: E2eConfig): boolean {
+  return config.E2E_ENABLED && Boolean(config.E2E_ADMIN_API_KEY);
+}
+
+function extractBearerToken(header: string | undefined): string | undefined {
+  return header?.replace(BEARER_RE, '');
+}
+
+function tokensMatch(actual: string, expected: string): boolean {
+  const actualBuffer = Buffer.from(actual);
+  const expectedBuffer = Buffer.from(expected);
+  return (
+    actualBuffer.length === expectedBuffer.length && timingSafeEqual(actualBuffer, expectedBuffer)
+  );
+}
+
+export function createE2eAdminAuthMethod(config: E2eConfig): AuthMethod {
+  return {
+    name: AUTH_E2E_ADMIN,
+    authenticate: async (request) => {
+      await Promise.resolve();
+      const expected = config.E2E_ADMIN_API_KEY;
+      const actual = extractBearerToken(request.headers.authorization);
+
+      if (!expected || !actual || !tokensMatch(actual, expected)) {
+        throw new ClientError('Missing or invalid E2E admin API key', 'unauthorized', {
+          status: 401,
+        });
+      }
+    },
+  };
+}
+
+export function createE2eRouteGroup(routes: RouteExport[], config: E2eConfig): RouteGroup[] {
+  if (!shouldMountE2eRoutes(config) || routes.length === 0) return [];
+
+  return [
+    {
+      prefix: '/__e2e',
+      auth: AUTH_E2E_ADMIN,
+      routes,
+    },
+  ];
+}

--- a/libs/api/server/src/e2e.ts
+++ b/libs/api/server/src/e2e.ts
@@ -13,7 +13,7 @@ export interface E2eConfig {
   E2E_ADMIN_API_KEY?: string | undefined;
 }
 
-const BEARER_RE = /^Bearer /u;
+const BEARER_RE = /^Bearer /iu;
 
 export function shouldMountE2eRoutes(config: E2eConfig): boolean {
   return config.E2E_ENABLED && Boolean(config.E2E_ADMIN_API_KEY);

--- a/libs/api/server/src/index.ts
+++ b/libs/api/server/src/index.ts
@@ -1,0 +1,3 @@
+export {defaultModules} from './modules.js';
+export type {CreateServerOptions, ServerHandle} from './server.js';
+export {createServer, runServer} from './server.js';

--- a/libs/api/server/src/instrumentation.ts
+++ b/libs/api/server/src/instrumentation.ts
@@ -1,0 +1,8 @@
+import {startInstanceInstrumentation} from '@shipfox/node-opentelemetry';
+
+// The metrics API has no proxy meter: instruments created before this preload
+// completes bind to a no-op provider for the process lifetime.
+await startInstanceInstrumentation({
+  serviceName: 'api',
+  instrumentations: {fastify: true, http: true, pg: true},
+});

--- a/libs/api/server/src/modules.test.ts
+++ b/libs/api/server/src/modules.test.ts
@@ -1,0 +1,137 @@
+import {defaultModules} from './modules.js';
+
+const mocks = vi.hoisted(() => ({
+  buildAgentToolCatalogs: vi.fn(),
+  buildAgentToolSelectionCatalogs: vi.fn(),
+  createDefinitionsModule: vi.fn(),
+  createIntegrationsContext: vi.fn(),
+  createProjectsModule: vi.fn(),
+  createWorkspaceConnectionSnapshotLoader: vi.fn(),
+  deleteSecrets: vi.fn(),
+  getIntegrationConnectionById: vi.fn(),
+  getSecret: vi.fn(),
+  loadRunningLeasedStep: vi.fn(),
+  setAgentToolMaterializationServices: vi.fn(),
+  setSecrets: vi.fn(),
+  setSourceControl: vi.fn(),
+}));
+
+vi.mock('@shipfox/api-agent', () => ({agentModule: {name: 'agent'}}));
+vi.mock('@shipfox/annotations', () => ({annotationsModule: {name: 'annotations'}}));
+vi.mock('@shipfox/api-auth', () => ({authModule: {name: 'auth'}}));
+vi.mock('@shipfox/api-definitions', () => ({
+  createDefinitionsModule: mocks.createDefinitionsModule,
+}));
+vi.mock('@shipfox/api-dispatcher', () => ({dispatcherModule: {name: 'dispatcher'}}));
+vi.mock('@shipfox/api-integration-core', () => ({
+  buildAgentToolCatalogs: mocks.buildAgentToolCatalogs,
+  buildAgentToolSelectionCatalogs: mocks.buildAgentToolSelectionCatalogs,
+  createIntegrationsContext: mocks.createIntegrationsContext,
+  createWorkspaceConnectionSnapshotLoader: mocks.createWorkspaceConnectionSnapshotLoader,
+  getIntegrationConnectionById: mocks.getIntegrationConnectionById,
+}));
+vi.mock('@shipfox/api-logs', () => ({logsModule: {name: 'logs'}}));
+vi.mock('@shipfox/api-projects', () => ({createProjectsModule: mocks.createProjectsModule}));
+vi.mock('@shipfox/api-runners', () => ({runnersModule: {name: 'runners'}}));
+vi.mock('@shipfox/api-secrets', () => ({
+  deleteSecrets: mocks.deleteSecrets,
+  getSecret: mocks.getSecret,
+  secretsModule: {name: 'secrets'},
+  setSecrets: mocks.setSecrets,
+}));
+vi.mock('@shipfox/api-triggers', () => ({triggersModule: {name: 'triggers'}}));
+vi.mock('@shipfox/api-workflows', () => ({
+  loadRunningLeasedStep: mocks.loadRunningLeasedStep,
+  setAgentToolMaterializationServices: mocks.setAgentToolMaterializationServices,
+  setSourceControl: mocks.setSourceControl,
+  workflowsModule: {name: 'workflows'},
+}));
+vi.mock('@shipfox/api-workspaces', () => ({workspacesModule: {name: 'workspaces'}}));
+
+describe('defaultModules', () => {
+  beforeEach(() => {
+    mocks.buildAgentToolCatalogs.mockReset();
+    mocks.buildAgentToolSelectionCatalogs.mockReset();
+    mocks.createDefinitionsModule.mockReset();
+    mocks.createIntegrationsContext.mockReset();
+    mocks.createProjectsModule.mockReset();
+    mocks.createWorkspaceConnectionSnapshotLoader.mockReset();
+    mocks.deleteSecrets.mockReset();
+    mocks.getIntegrationConnectionById.mockReset();
+    mocks.getSecret.mockReset();
+    mocks.loadRunningLeasedStep.mockReset();
+    mocks.setAgentToolMaterializationServices.mockReset();
+    mocks.setSecrets.mockReset();
+    mocks.setSourceControl.mockReset();
+
+    mocks.createIntegrationsContext.mockResolvedValue({
+      module: {name: 'integrations'},
+      registry: {},
+      sourceControl: {provider: 'source-control'},
+    });
+    mocks.buildAgentToolCatalogs.mockResolvedValue(new Map());
+    mocks.buildAgentToolSelectionCatalogs.mockResolvedValue(new Map());
+    mocks.createWorkspaceConnectionSnapshotLoader.mockReturnValue(vi.fn());
+    mocks.createProjectsModule.mockReturnValue({name: 'projects'});
+    mocks.createDefinitionsModule.mockReturnValue({name: 'definitions'});
+  });
+
+  it('returns the API modules in lifecycle order', async () => {
+    const modules = await defaultModules();
+
+    expect(modules.map((module) => module.name)).toEqual([
+      'auth',
+      'workspaces',
+      'secrets',
+      'agent',
+      'integrations',
+      'projects',
+      'definitions',
+      'workflows',
+      'annotations',
+      'runners',
+      'logs',
+      'triggers',
+      'dispatcher',
+    ]);
+  });
+
+  it('uses the leased-step loader and namespaced Linear secrets', async () => {
+    await defaultModules();
+
+    expect(mocks.createIntegrationsContext).toHaveBeenCalledWith({
+      secrets: {
+        deleteSecrets: mocks.deleteSecrets,
+        linear: {
+          deleteSecrets: expect.any(Function),
+          getSecret: expect.any(Function),
+          setSecrets: expect.any(Function),
+        },
+      },
+      agentTools: {loadLeasedAgentStep: mocks.loadRunningLeasedStep},
+    });
+
+    const integrationsOptions = mocks.createIntegrationsContext.mock.calls[0]?.[0] as {
+      secrets: {
+        linear: {
+          deleteSecrets: (params: {namespace: string}) => unknown;
+          getSecret: (params: {namespace: string}) => unknown;
+          setSecrets: (params: {namespace: string}) => unknown;
+        };
+      };
+    };
+    integrationsOptions.secrets.linear.getSecret({namespace: 'workspace'});
+    integrationsOptions.secrets.linear.setSecrets({namespace: 'workspace'});
+    integrationsOptions.secrets.linear.deleteSecrets({namespace: 'workspace'});
+
+    expect(mocks.getSecret).toHaveBeenCalledWith({
+      namespace: 'system/integrations/linear/workspace',
+    });
+    expect(mocks.setSecrets).toHaveBeenCalledWith({
+      namespace: 'system/integrations/linear/workspace',
+    });
+    expect(mocks.deleteSecrets).toHaveBeenCalledWith({
+      namespace: 'system/integrations/linear/workspace',
+    });
+  });
+});

--- a/libs/api/server/src/modules.ts
+++ b/libs/api/server/src/modules.ts
@@ -1,0 +1,90 @@
+import {annotationsModule} from '@shipfox/annotations';
+import {agentModule} from '@shipfox/api-agent';
+import {authModule} from '@shipfox/api-auth';
+import {createDefinitionsModule} from '@shipfox/api-definitions';
+import {dispatcherModule} from '@shipfox/api-dispatcher';
+import {
+  buildAgentToolCatalogs,
+  buildAgentToolSelectionCatalogs,
+  createIntegrationsContext,
+  createWorkspaceConnectionSnapshotLoader,
+  getIntegrationConnectionById,
+} from '@shipfox/api-integration-core';
+import {logsModule} from '@shipfox/api-logs';
+import {createProjectsModule} from '@shipfox/api-projects';
+import {runnersModule} from '@shipfox/api-runners';
+import {deleteSecrets, getSecret, secretsModule, setSecrets} from '@shipfox/api-secrets';
+import {triggersModule} from '@shipfox/api-triggers';
+import {
+  loadRunningLeasedStep,
+  setAgentToolMaterializationServices,
+  setSourceControl,
+  workflowsModule,
+} from '@shipfox/api-workflows';
+import {workspacesModule} from '@shipfox/api-workspaces';
+import type {ShipfoxModule} from '@shipfox/node-module';
+
+export async function defaultModules(): Promise<ShipfoxModule[]> {
+  const integrations = await createIntegrationsContext({
+    secrets: {
+      deleteSecrets,
+      linear: {
+        getSecret: (params) =>
+          getSecret({
+            ...params,
+            namespace: `system/integrations/linear/${params.namespace}`,
+          }),
+        setSecrets: (params) =>
+          setSecrets({
+            ...params,
+            namespace: `system/integrations/linear/${params.namespace}`,
+          }),
+        deleteSecrets: (params) =>
+          deleteSecrets({
+            ...params,
+            namespace: `system/integrations/linear/${params.namespace}`,
+          }),
+      },
+    },
+    agentTools: {loadLeasedAgentStep: loadRunningLeasedStep},
+  });
+  const [agentToolSelectionCatalogs, agentToolCatalogs] = await Promise.all([
+    buildAgentToolSelectionCatalogs(integrations.registry),
+    buildAgentToolCatalogs(integrations.registry),
+  ]);
+  const loadWorkspaceConnectionSnapshot = createWorkspaceConnectionSnapshotLoader(
+    integrations.registry,
+  );
+
+  // The checkout-token route resolves intents and mints credentials through the
+  // source-control service; wire it into the workflows module before serving.
+  setSourceControl(integrations.sourceControl);
+  setAgentToolMaterializationServices({
+    catalogs: agentToolCatalogs,
+    loadWorkspaceConnectionSnapshot,
+    getIntegrationConnectionById,
+  });
+  const projectsModule = createProjectsModule({sourceControl: integrations.sourceControl});
+  const definitionsModule = createDefinitionsModule({
+    sourceControl: integrations.sourceControl,
+    agentToolSelectionCatalogs,
+    loadWorkspaceConnectionSnapshot,
+    getIntegrationConnectionById,
+  });
+
+  return [
+    authModule,
+    workspacesModule,
+    secretsModule,
+    agentModule,
+    integrations.module,
+    projectsModule,
+    definitionsModule,
+    workflowsModule,
+    annotationsModule,
+    runnersModule,
+    logsModule,
+    triggersModule,
+    dispatcherModule,
+  ];
+}

--- a/libs/api/server/src/server.test.ts
+++ b/libs/api/server/src/server.test.ts
@@ -222,6 +222,24 @@ describe('createServer', () => {
     expect(mocks.resetSubscribers).toHaveBeenCalledOnce();
   });
 
+  it('preserves a boot failure when cleanup steps fail', async () => {
+    const failure = new Error('migration failed');
+    const cleanupFailure = new Error('metrics shutdown failed');
+    mocks.initializeModules.mockRejectedValueOnce(failure);
+    mocks.shutdownServiceMetrics.mockRejectedValueOnce(cleanupFailure);
+
+    const result = createServer({modules: [module()]});
+
+    await expect(result).rejects.toBe(failure);
+    expect(mocks.closePostgresClient).toHaveBeenCalledOnce();
+    expect(mocks.resetPublishers).toHaveBeenCalledOnce();
+    expect(mocks.resetSubscribers).toHaveBeenCalledOnce();
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      {err: cleanupFailure, bootError: failure},
+      'Failed to clean up API server boot',
+    );
+  });
+
   it('stops once when stop is called twice', async () => {
     const server = await createServer({modules: [module()]});
     await server.start();
@@ -253,6 +271,33 @@ describe('createServer', () => {
     expect(mocks.resetSubscribers).toHaveBeenCalledOnce();
   });
 
+  it('waits for worker startup before stopping', async () => {
+    const server = await createServer({modules: [module()]});
+    let resolveWorkers: ((handle: ModuleWorkersHandle) => void) | undefined;
+    const workersStarted = new Promise<void>((resolve) => {
+      mocks.startModuleWorkers.mockImplementationOnce(
+        () =>
+          new Promise<ModuleWorkersHandle>((innerResolve) => {
+            resolveWorkers = innerResolve;
+            resolve();
+          }),
+      );
+    });
+
+    const start = server.start();
+    await workersStarted;
+    const stop = server.stop();
+
+    expect(mocks.closeApp).not.toHaveBeenCalled();
+
+    resolveWorkers?.(mocks.workersHandle);
+    await expect(start).rejects.toThrow('API server stopped during startup');
+    await stop;
+
+    expect(mocks.listen).not.toHaveBeenCalled();
+    expect(mocks.workersHandle.stop).toHaveBeenCalledOnce();
+  });
+
   it('stops resources in lifecycle order', async () => {
     const server = await createServer({modules: [module()]});
     await server.start();
@@ -274,6 +319,32 @@ describe('createServer', () => {
     expect(mocks.resetSubscribers.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.closeErrorMonitoring.mock.invocationCallOrder[0] ?? 0,
     );
+  });
+
+  it('continues teardown after an earlier cleanup failure', async () => {
+    const server = await createServer({modules: [module()]});
+    await server.start();
+    mocks.closeApp.mockRejectedValueOnce(new Error('close app failed'));
+    mocks.workersHandle.stop.mockRejectedValueOnce(new Error('stop workers failed'));
+    mocks.shutdownServiceMetrics.mockRejectedValueOnce(new Error('shutdown metrics failed'));
+    mocks.closePostgresClient.mockRejectedValueOnce(new Error('close Postgres failed'));
+    mocks.resetPublishers.mockImplementationOnce(() => {
+      throw new Error('reset publishers failed');
+    });
+    mocks.resetSubscribers.mockImplementationOnce(() => {
+      throw new Error('reset subscribers failed');
+    });
+    mocks.closeErrorMonitoring.mockRejectedValueOnce(new Error('close monitoring failed'));
+
+    const result = server.stop();
+
+    await expect(result).rejects.toBeInstanceOf(AggregateError);
+    expect(mocks.workersHandle.stop).toHaveBeenCalledOnce();
+    expect(mocks.shutdownServiceMetrics).toHaveBeenCalledOnce();
+    expect(mocks.closePostgresClient).toHaveBeenCalledOnce();
+    expect(mocks.resetPublishers).toHaveBeenCalledOnce();
+    expect(mocks.resetSubscribers).toHaveBeenCalledOnce();
+    expect(mocks.closeErrorMonitoring).toHaveBeenCalledWith(2_000);
   });
 
   it('reports worker failures after closing HTTP and error monitoring', async () => {

--- a/libs/api/server/src/server.test.ts
+++ b/libs/api/server/src/server.test.ts
@@ -4,7 +4,7 @@ import type {
   ShipfoxModule,
   StartModuleWorkersOptions,
 } from '@shipfox/node-module';
-import {createServer, runServer} from './server.js';
+import {createServer, runServer, type ServerHandle} from './server.js';
 
 const mocks = vi.hoisted(() => {
   const workersHandle = {stop: vi.fn()};
@@ -137,10 +137,25 @@ function resetMocks(): void {
   mocks.workersHandle.stop.mockResolvedValue(undefined);
 }
 
+const servers: ServerHandle[] = [];
+
+async function createTestServer(
+  options: Parameters<typeof createServer>[0],
+): Promise<ServerHandle> {
+  const server = await createServer(options);
+  servers.push(server);
+  return server;
+}
+
+async function stopTestServers(): Promise<void> {
+  await Promise.all(servers.splice(0).map((server) => server.stop().catch(() => undefined)));
+}
+
 describe('createServer', () => {
   beforeEach(resetMocks);
 
-  afterEach(() => {
+  afterEach(async () => {
+    await stopTestServers();
     vi.useRealTimers();
     vi.restoreAllMocks();
   });
@@ -148,7 +163,7 @@ describe('createServer', () => {
   it('initializes modules, metrics, startup tasks, and the HTTP app', async () => {
     const modules = [module()];
 
-    await createServer({modules});
+    await createTestServer({modules});
 
     expect(mocks.startServiceMetrics).toHaveBeenCalledWith({serviceName: 'api'});
     expect(mocks.createPostgresClient).toHaveBeenCalledOnce();
@@ -163,7 +178,7 @@ describe('createServer', () => {
   });
 
   it('starts module workers before listening for HTTP requests', async () => {
-    const server = await createServer({modules: [module()]});
+    const server = await createTestServer({modules: [module()]});
     let resolveWorkers: ((handle: ModuleWorkersHandle) => void) | undefined;
     const workersStarted = new Promise<void>((resolve) => {
       mocks.startModuleWorkers.mockImplementationOnce(
@@ -190,7 +205,7 @@ describe('createServer', () => {
 
   it('passes API_PORT to the HTTP listener when configured', async () => {
     mocks.apiConfig.API_PORT = 55_291;
-    const server = await createServer({modules: [module()]});
+    const server = await createTestServer({modules: [module()]});
 
     await server.start();
 
@@ -200,7 +215,7 @@ describe('createServer', () => {
   it('does not listen when module worker startup fails', async () => {
     const failure = new Error('worker boot failed');
     mocks.startModuleWorkers.mockRejectedValueOnce(failure);
-    const server = await createServer({modules: [module()]});
+    const server = await createTestServer({modules: [module()]});
 
     const result = server.start();
 
@@ -212,7 +227,7 @@ describe('createServer', () => {
     const failure = new Error('migration failed');
     mocks.initializeModules.mockRejectedValueOnce(failure);
 
-    const result = createServer({modules: [module()]});
+    const result = createTestServer({modules: [module()]});
 
     await expect(result).rejects.toBe(failure);
     expect(mocks.shutdownServiceMetrics.mock.invocationCallOrder[0]).toBeLessThan(
@@ -222,13 +237,26 @@ describe('createServer', () => {
     expect(mocks.resetSubscribers).toHaveBeenCalledOnce();
   });
 
+  it('rejects a second server while another server owns process resources', async () => {
+    const firstServer = await createTestServer({modules: [module()]});
+
+    const secondServer = createServer({modules: [module()]});
+
+    await expect(secondServer).rejects.toThrow(
+      'Cannot create a second API server before the existing server stops',
+    );
+    expect(mocks.startServiceMetrics).toHaveBeenCalledOnce();
+    expect(mocks.createPostgresClient).toHaveBeenCalledOnce();
+    await firstServer.stop();
+  });
+
   it('preserves a boot failure when cleanup steps fail', async () => {
     const failure = new Error('migration failed');
     const cleanupFailure = new Error('metrics shutdown failed');
     mocks.initializeModules.mockRejectedValueOnce(failure);
     mocks.shutdownServiceMetrics.mockRejectedValueOnce(cleanupFailure);
 
-    const result = createServer({modules: [module()]});
+    const result = createTestServer({modules: [module()]});
 
     await expect(result).rejects.toBe(failure);
     expect(mocks.closePostgresClient).toHaveBeenCalledOnce();
@@ -241,7 +269,7 @@ describe('createServer', () => {
   });
 
   it('stops once when stop is called twice', async () => {
-    const server = await createServer({modules: [module()]});
+    const server = await createTestServer({modules: [module()]});
     await server.start();
 
     const firstStop = server.stop();
@@ -259,7 +287,7 @@ describe('createServer', () => {
   });
 
   it('stops before workers start', async () => {
-    const server = await createServer({modules: [module()]});
+    const server = await createTestServer({modules: [module()]});
 
     await server.stop();
 
@@ -272,7 +300,7 @@ describe('createServer', () => {
   });
 
   it('waits for worker startup before stopping', async () => {
-    const server = await createServer({modules: [module()]});
+    const server = await createTestServer({modules: [module()]});
     let resolveWorkers: ((handle: ModuleWorkersHandle) => void) | undefined;
     const workersStarted = new Promise<void>((resolve) => {
       mocks.startModuleWorkers.mockImplementationOnce(
@@ -299,7 +327,7 @@ describe('createServer', () => {
   });
 
   it('stops resources in lifecycle order', async () => {
-    const server = await createServer({modules: [module()]});
+    const server = await createTestServer({modules: [module()]});
     await server.start();
 
     await server.stop();
@@ -322,7 +350,7 @@ describe('createServer', () => {
   });
 
   it('continues teardown after an earlier cleanup failure', async () => {
-    const server = await createServer({modules: [module()]});
+    const server = await createTestServer({modules: [module()]});
     await server.start();
     mocks.closeApp.mockRejectedValueOnce(new Error('close app failed'));
     mocks.workersHandle.stop.mockRejectedValueOnce(new Error('stop workers failed'));
@@ -347,9 +375,23 @@ describe('createServer', () => {
     expect(mocks.closeErrorMonitoring).toHaveBeenCalledWith(2_000);
   });
 
+  it('keeps process resources reserved until a failed stop succeeds on retry', async () => {
+    const server = await createTestServer({modules: [module()]});
+    mocks.closeApp.mockRejectedValueOnce(new Error('close app failed'));
+
+    await expect(server.stop()).rejects.toThrow('close app failed');
+    await expect(createServer({modules: [module()]})).rejects.toThrow(
+      'Cannot create a second API server before the existing server stops',
+    );
+
+    await server.stop();
+    const nextServer = await createTestServer({modules: [module()]});
+    await nextServer.stop();
+  });
+
   it('reports worker failures after closing HTTP and error monitoring', async () => {
     const onWorkerFailure = vi.fn();
-    const server = await createServer({modules: [module()], onWorkerFailure});
+    const server = await createTestServer({modules: [module()], onWorkerFailure});
     await server.start();
     const failure = new Error('poller failed');
     const failedWorker = worker();
@@ -372,7 +414,7 @@ describe('createServer', () => {
     vi.useFakeTimers();
     const onWorkerFailure = vi.fn();
     mocks.closeApp.mockReturnValueOnce(new Promise(() => undefined));
-    const server = await createServer({modules: [module()], onWorkerFailure});
+    const server = await createTestServer({modules: [module()], onWorkerFailure});
     await server.start();
 
     const failure = new Error('poller failed');
@@ -396,7 +438,7 @@ describe('createServer', () => {
     const onWorkerFailure = vi.fn();
     const closeFailure = new Error('onClose failed');
     mocks.closeApp.mockRejectedValueOnce(closeFailure);
-    const server = await createServer({modules: [module()], onWorkerFailure});
+    const server = await createTestServer({modules: [module()], onWorkerFailure});
     await server.start();
 
     await lastStartModuleWorkersOptions().onWorkerFailure?.(new Error('poller failed'), worker());

--- a/libs/api/server/src/server.test.ts
+++ b/libs/api/server/src/server.test.ts
@@ -1,0 +1,402 @@
+import type {
+  ModuleWorker,
+  ModuleWorkersHandle,
+  ShipfoxModule,
+  StartModuleWorkersOptions,
+} from '@shipfox/node-module';
+import {createServer, runServer} from './server.js';
+
+const mocks = vi.hoisted(() => {
+  const workersHandle = {stop: vi.fn()};
+  return {
+    captureException: vi.fn(),
+    closeApp: vi.fn(),
+    closeErrorMonitoring: vi.fn(),
+    closePostgresClient: vi.fn(),
+    createApp: vi.fn(),
+    createE2eAdminAuthMethod: vi.fn(),
+    createE2eRouteGroup: vi.fn(),
+    createPostgresClient: vi.fn(),
+    initializeModules: vi.fn(),
+    listen: vi.fn(),
+    logger: {error: vi.fn(), info: vi.fn()},
+    parseApiTrustProxy: vi.fn(),
+    registerModuleMetrics: vi.fn(),
+    resetPublishers: vi.fn(),
+    resetSubscribers: vi.fn(),
+    runModuleStartupTasks: vi.fn(),
+    shutdownServiceMetrics: vi.fn(),
+    startModuleWorkers: vi.fn(),
+    startServiceMetrics: vi.fn(),
+    workersHandle,
+    apiConfig: {
+      API_PORT: undefined as number | undefined,
+      API_TRUST_PROXY: 'false',
+      E2E_ENABLED: false,
+    },
+  };
+});
+
+vi.mock('@shipfox/node-error-monitoring', () => ({
+  captureException: mocks.captureException,
+  closeErrorMonitoring: mocks.closeErrorMonitoring,
+}));
+vi.mock('@shipfox/node-fastify', () => ({
+  closeApp: mocks.closeApp,
+  createApp: mocks.createApp,
+  listen: mocks.listen,
+}));
+vi.mock('@shipfox/node-module', () => ({
+  initializeModules: mocks.initializeModules,
+  registerModuleMetrics: mocks.registerModuleMetrics,
+  resetPublishers: mocks.resetPublishers,
+  resetSubscribers: mocks.resetSubscribers,
+  runModuleStartupTasks: mocks.runModuleStartupTasks,
+  startModuleWorkers: mocks.startModuleWorkers,
+}));
+vi.mock('@shipfox/node-opentelemetry', () => ({
+  logger: () => mocks.logger,
+  shutdownServiceMetrics: mocks.shutdownServiceMetrics,
+  startServiceMetrics: mocks.startServiceMetrics,
+}));
+vi.mock('@shipfox/node-postgres', () => ({
+  closePostgresClient: mocks.closePostgresClient,
+  createPostgresClient: mocks.createPostgresClient,
+}));
+vi.mock('./config.js', () => ({
+  config: mocks.apiConfig,
+  parseApiTrustProxy: mocks.parseApiTrustProxy,
+}));
+vi.mock('./e2e.js', () => ({
+  createE2eAdminAuthMethod: mocks.createE2eAdminAuthMethod,
+  createE2eRouteGroup: mocks.createE2eRouteGroup,
+}));
+
+function module(): ShipfoxModule {
+  return {name: 'test'};
+}
+
+function worker(taskQueue = 'runtime-queue'): ModuleWorker {
+  return {
+    taskQueue,
+    workflowsPath: '/tmp/workflows.js',
+    activities: () => ({}),
+    workflows: [],
+  };
+}
+
+function lastStartModuleWorkersOptions(): StartModuleWorkersOptions {
+  const options = mocks.startModuleWorkers.mock.calls.at(-1)?.[0];
+  if (!options) throw new Error('startModuleWorkers was not called');
+  return options as StartModuleWorkersOptions;
+}
+
+function resetMocks(): void {
+  vi.useRealTimers();
+  mocks.captureException.mockReset();
+  mocks.closeApp.mockReset();
+  mocks.closeErrorMonitoring.mockReset();
+  mocks.closePostgresClient.mockReset();
+  mocks.createApp.mockReset();
+  mocks.createE2eAdminAuthMethod.mockReset();
+  mocks.createE2eRouteGroup.mockReset();
+  mocks.createPostgresClient.mockReset();
+  mocks.initializeModules.mockReset();
+  mocks.listen.mockReset();
+  mocks.logger.error.mockReset();
+  mocks.logger.info.mockReset();
+  mocks.parseApiTrustProxy.mockReset();
+  mocks.registerModuleMetrics.mockReset();
+  mocks.resetPublishers.mockReset();
+  mocks.resetSubscribers.mockReset();
+  mocks.runModuleStartupTasks.mockReset();
+  mocks.shutdownServiceMetrics.mockReset();
+  mocks.startModuleWorkers.mockReset();
+  mocks.startServiceMetrics.mockReset();
+  mocks.workersHandle.stop.mockReset();
+  mocks.apiConfig.API_PORT = undefined;
+  mocks.apiConfig.API_TRUST_PROXY = 'false';
+  mocks.apiConfig.E2E_ENABLED = false;
+
+  mocks.closeApp.mockResolvedValue(undefined);
+  mocks.closeErrorMonitoring.mockResolvedValue(true);
+  mocks.closePostgresClient.mockResolvedValue(undefined);
+  mocks.createApp.mockResolvedValue({});
+  mocks.createE2eRouteGroup.mockReturnValue([]);
+  mocks.initializeModules.mockResolvedValue({
+    auth: [],
+    routes: [],
+    e2eRoutes: [],
+    workers: [worker()],
+  });
+  mocks.listen.mockResolvedValue('http://127.0.0.1:3000');
+  mocks.parseApiTrustProxy.mockReturnValue(false);
+  mocks.runModuleStartupTasks.mockResolvedValue(undefined);
+  mocks.shutdownServiceMetrics.mockResolvedValue(undefined);
+  mocks.startModuleWorkers.mockResolvedValue(mocks.workersHandle);
+  mocks.workersHandle.stop.mockResolvedValue(undefined);
+}
+
+describe('createServer', () => {
+  beforeEach(resetMocks);
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('initializes modules, metrics, startup tasks, and the HTTP app', async () => {
+    const modules = [module()];
+
+    await createServer({modules});
+
+    expect(mocks.startServiceMetrics).toHaveBeenCalledWith({serviceName: 'api'});
+    expect(mocks.createPostgresClient).toHaveBeenCalledOnce();
+    expect(mocks.initializeModules).toHaveBeenCalledWith({modules});
+    expect(mocks.registerModuleMetrics).toHaveBeenCalledWith({modules});
+    expect(mocks.runModuleStartupTasks).toHaveBeenCalledWith({modules});
+    expect(mocks.createApp).toHaveBeenCalledWith({
+      auth: [],
+      routes: [],
+      fastifyOptions: {trustProxy: false},
+    });
+  });
+
+  it('starts module workers before listening for HTTP requests', async () => {
+    const server = await createServer({modules: [module()]});
+    let resolveWorkers: ((handle: ModuleWorkersHandle) => void) | undefined;
+    const workersStarted = new Promise<void>((resolve) => {
+      mocks.startModuleWorkers.mockImplementationOnce(
+        () =>
+          new Promise<ModuleWorkersHandle>((innerResolve) => {
+            resolveWorkers = innerResolve;
+            resolve();
+          }),
+      );
+    });
+
+    const start = server.start();
+    await workersStarted;
+
+    expect(mocks.listen).not.toHaveBeenCalled();
+
+    resolveWorkers?.(mocks.workersHandle);
+    await start;
+
+    expect(mocks.startModuleWorkers.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.listen.mock.invocationCallOrder[0] ?? 0,
+    );
+  });
+
+  it('passes API_PORT to the HTTP listener when configured', async () => {
+    mocks.apiConfig.API_PORT = 55_291;
+    const server = await createServer({modules: [module()]});
+
+    await server.start();
+
+    expect(mocks.listen).toHaveBeenCalledWith({port: 55_291});
+  });
+
+  it('does not listen when module worker startup fails', async () => {
+    const failure = new Error('worker boot failed');
+    mocks.startModuleWorkers.mockRejectedValueOnce(failure);
+    const server = await createServer({modules: [module()]});
+
+    const result = server.start();
+
+    await expect(result).rejects.toBe(failure);
+    expect(mocks.listen).not.toHaveBeenCalled();
+  });
+
+  it('releases service metrics and Postgres when boot fails', async () => {
+    const failure = new Error('migration failed');
+    mocks.initializeModules.mockRejectedValueOnce(failure);
+
+    const result = createServer({modules: [module()]});
+
+    await expect(result).rejects.toBe(failure);
+    expect(mocks.shutdownServiceMetrics.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.closePostgresClient.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(mocks.resetPublishers).toHaveBeenCalledOnce();
+    expect(mocks.resetSubscribers).toHaveBeenCalledOnce();
+  });
+
+  it('stops once when stop is called twice', async () => {
+    const server = await createServer({modules: [module()]});
+    await server.start();
+
+    const firstStop = server.stop();
+    const secondStop = server.stop();
+    await firstStop;
+    await secondStop;
+
+    expect(mocks.closeApp).toHaveBeenCalledOnce();
+    expect(mocks.workersHandle.stop).toHaveBeenCalledOnce();
+    expect(mocks.shutdownServiceMetrics).toHaveBeenCalledOnce();
+    expect(mocks.closePostgresClient).toHaveBeenCalledOnce();
+    expect(mocks.resetPublishers).toHaveBeenCalledOnce();
+    expect(mocks.resetSubscribers).toHaveBeenCalledOnce();
+    expect(mocks.closeErrorMonitoring).toHaveBeenCalledWith(2_000);
+  });
+
+  it('stops before workers start', async () => {
+    const server = await createServer({modules: [module()]});
+
+    await server.stop();
+
+    expect(mocks.closeApp).toHaveBeenCalledOnce();
+    expect(mocks.workersHandle.stop).not.toHaveBeenCalled();
+    expect(mocks.shutdownServiceMetrics).toHaveBeenCalledOnce();
+    expect(mocks.closePostgresClient).toHaveBeenCalledOnce();
+    expect(mocks.resetPublishers).toHaveBeenCalledOnce();
+    expect(mocks.resetSubscribers).toHaveBeenCalledOnce();
+  });
+
+  it('stops resources in lifecycle order', async () => {
+    const server = await createServer({modules: [module()]});
+    await server.start();
+
+    await server.stop();
+
+    expect(mocks.closeApp.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.workersHandle.stop.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(mocks.workersHandle.stop.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.shutdownServiceMetrics.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(mocks.shutdownServiceMetrics.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.closePostgresClient.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(mocks.closePostgresClient.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.resetPublishers.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(mocks.resetSubscribers.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.closeErrorMonitoring.mock.invocationCallOrder[0] ?? 0,
+    );
+  });
+
+  it('reports worker failures after closing HTTP and error monitoring', async () => {
+    const onWorkerFailure = vi.fn();
+    const server = await createServer({modules: [module()], onWorkerFailure});
+    await server.start();
+    const failure = new Error('poller failed');
+    const failedWorker = worker();
+
+    await lastStartModuleWorkersOptions().onWorkerFailure?.(failure, failedWorker);
+
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      {err: failure, taskQueue: 'runtime-queue'},
+      'Module worker stopped unexpectedly',
+    );
+    expect(mocks.captureException).toHaveBeenCalledWith(failure);
+    expect(mocks.closeApp).toHaveBeenCalledOnce();
+    expect(mocks.closeErrorMonitoring).toHaveBeenCalledWith(2_000);
+    expect(mocks.closeErrorMonitoring.mock.invocationCallOrder[0]).toBeLessThan(
+      onWorkerFailure.mock.invocationCallOrder[0] ?? 0,
+    );
+  });
+
+  it('reports a timed-out HTTP close before invoking the worker failure hook', async () => {
+    vi.useFakeTimers();
+    const onWorkerFailure = vi.fn();
+    mocks.closeApp.mockReturnValueOnce(new Promise(() => undefined));
+    const server = await createServer({modules: [module()], onWorkerFailure});
+    await server.start();
+
+    const failure = new Error('poller failed');
+    const result = Promise.resolve(
+      lastStartModuleWorkersOptions().onWorkerFailure?.(failure, worker()),
+    );
+    await vi.advanceTimersByTimeAsync(10_000);
+    await result;
+
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      {timeoutMs: 10_000},
+      'Timed out closing HTTP server after worker failure',
+    );
+    expect(onWorkerFailure).toHaveBeenCalledWith(
+      failure,
+      expect.objectContaining({taskQueue: 'runtime-queue'}),
+    );
+  });
+
+  it('flushes error monitoring when HTTP close rejects', async () => {
+    const onWorkerFailure = vi.fn();
+    const closeFailure = new Error('onClose failed');
+    mocks.closeApp.mockRejectedValueOnce(closeFailure);
+    const server = await createServer({modules: [module()], onWorkerFailure});
+    await server.start();
+
+    await lastStartModuleWorkersOptions().onWorkerFailure?.(new Error('poller failed'), worker());
+
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      {err: closeFailure},
+      'Failed to close HTTP server after worker failure',
+    );
+    expect(mocks.closeErrorMonitoring).toHaveBeenCalledWith(2_000);
+    expect(mocks.closeErrorMonitoring.mock.invocationCallOrder[0]).toBeLessThan(
+      onWorkerFailure.mock.invocationCallOrder[0] ?? 0,
+    );
+  });
+});
+
+describe('runServer', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    resetMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('releases its server when startup fails', async () => {
+    const failure = new Error('listener unavailable');
+    mocks.listen.mockRejectedValueOnce(failure);
+
+    const result = runServer({modules: [module()]});
+
+    await expect(result).rejects.toBe(failure);
+    expect(mocks.closeApp).toHaveBeenCalledOnce();
+    expect(mocks.workersHandle.stop).toHaveBeenCalledOnce();
+    expect(mocks.shutdownServiceMetrics).toHaveBeenCalledOnce();
+    expect(mocks.closePostgresClient).toHaveBeenCalledOnce();
+    expect(mocks.resetPublishers).toHaveBeenCalledOnce();
+    expect(mocks.resetSubscribers).toHaveBeenCalledOnce();
+  });
+
+  it('installs SIGTERM and SIGINT handlers that stop before exiting successfully', async () => {
+    const handlers = new Map<string, () => void>();
+    const onceSpy = vi.spyOn(process, 'once').mockImplementation(((
+      signal: NodeJS.Signals,
+      listener: () => void,
+    ) => {
+      handlers.set(signal, listener as () => void);
+      return process;
+    }) as never);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+    const handle = await runServer({modules: [module()]});
+
+    expect(onceSpy).toHaveBeenCalledWith('SIGTERM', expect.any(Function));
+    expect(onceSpy).toHaveBeenCalledWith('SIGINT', expect.any(Function));
+
+    handlers.get('SIGTERM')?.();
+    await vi.waitFor(() => expect(exitSpy).toHaveBeenCalledWith(0));
+
+    expect(mocks.closeApp.mock.invocationCallOrder[0]).toBeLessThan(
+      exitSpy.mock.invocationCallOrder[0] ?? 0,
+    );
+    await handle.stop();
+  });
+
+  it('exits unsuccessfully when a module worker fails', async () => {
+    vi.spyOn(process, 'once').mockImplementation((() => process) as never);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+    await runServer({modules: [module()]});
+
+    await lastStartModuleWorkersOptions().onWorkerFailure?.(new Error('poller failed'), worker());
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/libs/api/server/src/server.test.ts
+++ b/libs/api/server/src/server.test.ts
@@ -323,7 +323,13 @@ describe('createServer', () => {
     await stop;
 
     expect(mocks.listen).not.toHaveBeenCalled();
+    expect(mocks.closeApp).toHaveBeenCalledOnce();
     expect(mocks.workersHandle.stop).toHaveBeenCalledOnce();
+    expect(mocks.shutdownServiceMetrics).toHaveBeenCalledOnce();
+    expect(mocks.closePostgresClient).toHaveBeenCalledOnce();
+    expect(mocks.resetPublishers).toHaveBeenCalledOnce();
+    expect(mocks.resetSubscribers).toHaveBeenCalledOnce();
+    expect(mocks.closeErrorMonitoring).toHaveBeenCalledWith(2_000);
   });
 
   it('stops resources in lifecycle order', async () => {

--- a/libs/api/server/src/server.ts
+++ b/libs/api/server/src/server.ts
@@ -1,0 +1,150 @@
+import {captureException, closeErrorMonitoring} from '@shipfox/node-error-monitoring';
+import {closeApp, createApp, listen} from '@shipfox/node-fastify';
+import {
+  initializeModules,
+  type ModuleWorker,
+  type ModuleWorkersHandle,
+  registerModuleMetrics,
+  resetPublishers,
+  resetSubscribers,
+  runModuleStartupTasks,
+  type ShipfoxModule,
+  startModuleWorkers,
+} from '@shipfox/node-module';
+import {logger, shutdownServiceMetrics, startServiceMetrics} from '@shipfox/node-opentelemetry';
+import {closePostgresClient, createPostgresClient} from '@shipfox/node-postgres';
+import {config, parseApiTrustProxy} from './config.js';
+import {createE2eAdminAuthMethod, createE2eRouteGroup} from './e2e.js';
+
+const WORKER_FAILURE_HTTP_SHUTDOWN_TIMEOUT_MS = 10_000;
+const ERROR_MONITORING_SHUTDOWN_TIMEOUT_MS = 2_000;
+
+export interface CreateServerOptions {
+  modules: ShipfoxModule[];
+  onWorkerFailure?: (error: unknown, worker: ModuleWorker) => void | Promise<void>;
+}
+
+export interface ServerHandle {
+  start(): Promise<string>;
+  stop(): Promise<void>;
+}
+
+export async function createServer(options: CreateServerOptions): Promise<ServerHandle> {
+  startServiceMetrics({serviceName: 'api'});
+  createPostgresClient();
+
+  try {
+    const {auth, routes, e2eRoutes, workers} = await initializeModules({modules: options.modules});
+    registerModuleMetrics({modules: options.modules});
+    await runModuleStartupTasks({modules: options.modules});
+
+    const e2eAuth = config.E2E_ENABLED ? [createE2eAdminAuthMethod(config)] : [];
+    const mountedE2eRoutes = createE2eRouteGroup(e2eRoutes, config);
+
+    logger().info('Creating HTTP server');
+    await createApp({
+      auth: [...auth, ...e2eAuth],
+      routes: [...routes, ...mountedE2eRoutes],
+      fastifyOptions: {trustProxy: parseApiTrustProxy(config.API_TRUST_PROXY)},
+    });
+
+    let workersHandle: ModuleWorkersHandle | undefined;
+    let stopPromise: Promise<void> | undefined;
+
+    return {
+      async start(): Promise<string> {
+        logger().info('Starting module workers');
+        workersHandle = await startModuleWorkers({
+          workers,
+          onWorkerFailure: (error, worker) =>
+            handleModuleWorkerFailure(error, worker, options.onWorkerFailure),
+        });
+
+        logger().info('Starting HTTP server');
+        const address =
+          config.API_PORT === undefined ? await listen() : await listen({port: config.API_PORT});
+        logger().info({address}, 'HTTP server listening');
+        return address;
+      },
+      stop: () =>
+        (stopPromise ??= (async () => {
+          await closeApp();
+          await workersHandle?.stop();
+          await shutdownServiceMetrics();
+          await closePostgresClient();
+          resetPublishers();
+          resetSubscribers();
+          await closeErrorMonitoring(ERROR_MONITORING_SHUTDOWN_TIMEOUT_MS);
+        })()),
+    };
+  } catch (error) {
+    await shutdownServiceMetrics();
+    await closePostgresClient();
+    resetPublishers();
+    resetSubscribers();
+    throw error;
+  }
+}
+
+export async function runServer(options: {modules: ShipfoxModule[]}): Promise<ServerHandle> {
+  const handle = await createServer({
+    modules: options.modules,
+    onWorkerFailure: () => process.exit(1),
+  });
+  try {
+    await handle.start();
+  } catch (error) {
+    await handle.stop();
+    throw error;
+  }
+
+  const stopAndExit = () => void handle.stop().finally(() => process.exit(0));
+  process.once('SIGTERM', stopAndExit);
+  process.once('SIGINT', stopAndExit);
+
+  return handle;
+}
+
+async function handleModuleWorkerFailure(
+  error: unknown,
+  worker: ModuleWorker,
+  onWorkerFailure: CreateServerOptions['onWorkerFailure'],
+): Promise<void> {
+  logger().error({err: error, taskQueue: worker.taskQueue}, 'Module worker stopped unexpectedly');
+  captureException(error);
+
+  try {
+    await closeHttpServerAfterWorkerFailure();
+    await closeErrorMonitoring(ERROR_MONITORING_SHUTDOWN_TIMEOUT_MS);
+  } finally {
+    await onWorkerFailure?.(error, worker);
+  }
+}
+
+async function closeHttpServerAfterWorkerFailure(): Promise<void> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<'timeout'>((resolve) => {
+    timeoutId = setTimeout(() => resolve('timeout'), WORKER_FAILURE_HTTP_SHUTDOWN_TIMEOUT_MS);
+  });
+  try {
+    const result = await Promise.race([closeApp().then(() => 'closed' as const), timeout]).finally(
+      () => {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+      },
+    );
+    if (result === 'timeout') {
+      logger().error(
+        {timeoutMs: WORKER_FAILURE_HTTP_SHUTDOWN_TIMEOUT_MS},
+        'Timed out closing HTTP server after worker failure',
+      );
+    }
+  } catch (error) {
+    logger().error({err: error}, 'Failed to close HTTP server after worker failure');
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}

--- a/libs/api/server/src/server.ts
+++ b/libs/api/server/src/server.ts
@@ -19,6 +19,8 @@ import {createE2eAdminAuthMethod, createE2eRouteGroup} from './e2e.js';
 const WORKER_FAILURE_HTTP_SHUTDOWN_TIMEOUT_MS = 10_000;
 const ERROR_MONITORING_SHUTDOWN_TIMEOUT_MS = 2_000;
 
+let hasActiveServer = false;
+
 export interface CreateServerOptions {
   modules: ShipfoxModule[];
   onWorkerFailure?: (error: unknown, worker: ModuleWorker) => void | Promise<void>;
@@ -30,6 +32,11 @@ export interface ServerHandle {
 }
 
 export async function createServer(options: CreateServerOptions): Promise<ServerHandle> {
+  if (hasActiveServer) {
+    throw new Error('Cannot create a second API server before the existing server stops');
+  }
+  hasActiveServer = true;
+
   try {
     startServiceMetrics({serviceName: 'api'});
     createPostgresClient();
@@ -51,9 +58,11 @@ export async function createServer(options: CreateServerOptions): Promise<Server
     let workersHandle: ModuleWorkersHandle | undefined;
     let startPromise: Promise<string> | undefined;
     let stopPromise: Promise<void> | undefined;
+    let stopped = false;
 
     const start = (): Promise<string> => {
-      if (stopPromise) return Promise.reject(new Error('Cannot start a stopped API server'));
+      if (stopPromise || stopped)
+        return Promise.reject(new Error('Cannot start a stopped API server'));
 
       startPromise ??= (async () => {
         logger().info('Starting module workers');
@@ -74,20 +83,30 @@ export async function createServer(options: CreateServerOptions): Promise<Server
       return startPromise;
     };
 
-    const stop = (): Promise<void> =>
-      (stopPromise ??= (async () => {
-        await startPromise?.catch(() => undefined);
-        const cleanupErrors = await runCleanupSteps([
-          () => closeApp(),
-          () => workersHandle?.stop(),
-          () => shutdownServiceMetrics(),
-          () => closePostgresClient(),
-          () => resetPublishers(),
-          () => resetSubscribers(),
-          () => closeErrorMonitoring(ERROR_MONITORING_SHUTDOWN_TIMEOUT_MS),
-        ]);
-        throwCleanupErrors(cleanupErrors, 'Failed to stop API server');
-      })());
+    const stop = (): Promise<void> => {
+      if (stopped) return Promise.resolve();
+
+      stopPromise ??= (async () => {
+        try {
+          await startPromise?.catch(() => undefined);
+          const cleanupErrors = await runCleanupSteps([
+            () => closeApp(),
+            () => workersHandle?.stop(),
+            () => shutdownServiceMetrics(),
+            () => closePostgresClient(),
+            () => resetPublishers(),
+            () => resetSubscribers(),
+            () => closeErrorMonitoring(ERROR_MONITORING_SHUTDOWN_TIMEOUT_MS),
+          ]);
+          throwCleanupErrors(cleanupErrors, 'Failed to stop API server');
+          stopped = true;
+          hasActiveServer = false;
+        } finally {
+          stopPromise = undefined;
+        }
+      })();
+      return stopPromise;
+    };
 
     return {start, stop};
   } catch (error) {
@@ -100,6 +119,7 @@ export async function createServer(options: CreateServerOptions): Promise<Server
     for (const cleanupError of cleanupErrors) {
       logger().error({err: cleanupError, bootError: error}, 'Failed to clean up API server boot');
     }
+    hasActiveServer = false;
     throw error;
   }
 }

--- a/libs/api/server/src/server.ts
+++ b/libs/api/server/src/server.ts
@@ -30,10 +30,10 @@ export interface ServerHandle {
 }
 
 export async function createServer(options: CreateServerOptions): Promise<ServerHandle> {
-  startServiceMetrics({serviceName: 'api'});
-  createPostgresClient();
-
   try {
+    startServiceMetrics({serviceName: 'api'});
+    createPostgresClient();
+
     const {auth, routes, e2eRoutes, workers} = await initializeModules({modules: options.modules});
     registerModuleMetrics({modules: options.modules});
     await runModuleStartupTasks({modules: options.modules});
@@ -49,10 +49,13 @@ export async function createServer(options: CreateServerOptions): Promise<Server
     });
 
     let workersHandle: ModuleWorkersHandle | undefined;
+    let startPromise: Promise<string> | undefined;
     let stopPromise: Promise<void> | undefined;
 
-    return {
-      async start(): Promise<string> {
+    const start = (): Promise<string> => {
+      if (stopPromise) return Promise.reject(new Error('Cannot start a stopped API server'));
+
+      startPromise ??= (async () => {
         logger().info('Starting module workers');
         workersHandle = await startModuleWorkers({
           workers,
@@ -60,28 +63,43 @@ export async function createServer(options: CreateServerOptions): Promise<Server
             handleModuleWorkerFailure(error, worker, options.onWorkerFailure),
         });
 
+        if (stopPromise) throw new Error('API server stopped during startup');
+
         logger().info('Starting HTTP server');
         const address =
           config.API_PORT === undefined ? await listen() : await listen({port: config.API_PORT});
         logger().info({address}, 'HTTP server listening');
         return address;
-      },
-      stop: () =>
-        (stopPromise ??= (async () => {
-          await closeApp();
-          await workersHandle?.stop();
-          await shutdownServiceMetrics();
-          await closePostgresClient();
-          resetPublishers();
-          resetSubscribers();
-          await closeErrorMonitoring(ERROR_MONITORING_SHUTDOWN_TIMEOUT_MS);
-        })()),
+      })();
+      return startPromise;
     };
+
+    const stop = (): Promise<void> =>
+      (stopPromise ??= (async () => {
+        await startPromise?.catch(() => undefined);
+        const cleanupErrors = await runCleanupSteps([
+          () => closeApp(),
+          () => workersHandle?.stop(),
+          () => shutdownServiceMetrics(),
+          () => closePostgresClient(),
+          () => resetPublishers(),
+          () => resetSubscribers(),
+          () => closeErrorMonitoring(ERROR_MONITORING_SHUTDOWN_TIMEOUT_MS),
+        ]);
+        throwCleanupErrors(cleanupErrors, 'Failed to stop API server');
+      })());
+
+    return {start, stop};
   } catch (error) {
-    await shutdownServiceMetrics();
-    await closePostgresClient();
-    resetPublishers();
-    resetSubscribers();
+    const cleanupErrors = await runCleanupSteps([
+      () => shutdownServiceMetrics(),
+      () => closePostgresClient(),
+      () => resetPublishers(),
+      () => resetSubscribers(),
+    ]);
+    for (const cleanupError of cleanupErrors) {
+      logger().error({err: cleanupError, bootError: error}, 'Failed to clean up API server boot');
+    }
     throw error;
   }
 }
@@ -94,7 +112,14 @@ export async function runServer(options: {modules: ShipfoxModule[]}): Promise<Se
   try {
     await handle.start();
   } catch (error) {
-    await handle.stop();
+    try {
+      await handle.stop();
+    } catch (cleanupError) {
+      logger().error(
+        {err: cleanupError, startError: error},
+        'Failed to clean up API server startup',
+      );
+    }
     throw error;
   }
 
@@ -103,6 +128,26 @@ export async function runServer(options: {modules: ShipfoxModule[]}): Promise<Se
   process.once('SIGINT', stopAndExit);
 
   return handle;
+}
+
+type CleanupStep = () => void | Promise<void>;
+
+async function runCleanupSteps(steps: CleanupStep[]): Promise<unknown[]> {
+  const cleanupErrors: unknown[] = [];
+  for (const step of steps) {
+    try {
+      await step();
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
+  }
+  return cleanupErrors;
+}
+
+function throwCleanupErrors(cleanupErrors: unknown[], message: string): void {
+  if (cleanupErrors.length === 0) return;
+  if (cleanupErrors.length === 1) throw cleanupErrors[0];
+  throw new AggregateError(cleanupErrors, message);
 }
 
 async function handleModuleWorkerFailure(

--- a/libs/api/server/tsconfig.build.json
+++ b/libs/api/server/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.tsx", "**/*.test.ts"]
+}

--- a/libs/api/server/tsconfig.json
+++ b/libs/api/server/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.test.json" }]
+}

--- a/libs/api/server/tsconfig.test.json
+++ b/libs/api/server/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "exclude": []
+}

--- a/libs/api/server/vitest.config.ts
+++ b/libs/api/server/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({}, import.meta.url) as UserConfigExport;

--- a/libs/shared/node/opentelemetry/src/index.ts
+++ b/libs/shared/node/opentelemetry/src/index.ts
@@ -29,7 +29,7 @@ export {contextWithMetadata, enrichSpanWithMetadata, getContextMetadata} from '.
 export {getFastifyInstrumentation, startInstanceInstrumentation} from './instance.js';
 export {logger} from './logger.js';
 export {extractContextFromAttributes, injectContextToAttributes} from './propagation.js';
-export {startServiceMetrics} from './service.js';
+export {shutdownServiceMetrics, startServiceMetrics} from './service.js';
 
 export async function shutdownInstrumentation() {
   await shutdownInstanceInstrumentation();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2919,6 +2919,82 @@ importers:
         specifier: workspace:*
         version: link:../../../tools/vitest
 
+  libs/api/server:
+    dependencies:
+      '@shipfox/annotations':
+        specifier: workspace:*
+        version: link:../annotations
+      '@shipfox/api-agent':
+        specifier: workspace:*
+        version: link:../agent
+      '@shipfox/api-auth':
+        specifier: workspace:*
+        version: link:../auth
+      '@shipfox/api-definitions':
+        specifier: workspace:*
+        version: link:../definitions
+      '@shipfox/api-dispatcher':
+        specifier: workspace:*
+        version: link:../dispatcher
+      '@shipfox/api-integration-core':
+        specifier: workspace:*
+        version: link:../integration/core
+      '@shipfox/api-logs':
+        specifier: workspace:*
+        version: link:../logs
+      '@shipfox/api-projects':
+        specifier: workspace:*
+        version: link:../projects
+      '@shipfox/api-runners':
+        specifier: workspace:*
+        version: link:../runners
+      '@shipfox/api-secrets':
+        specifier: workspace:*
+        version: link:../secrets
+      '@shipfox/api-triggers':
+        specifier: workspace:*
+        version: link:../triggers
+      '@shipfox/api-workflows':
+        specifier: workspace:*
+        version: link:../workflows
+      '@shipfox/api-workspaces':
+        specifier: workspace:*
+        version: link:../workspaces
+      '@shipfox/config':
+        specifier: workspace:*
+        version: link:../../shared/common/config
+      '@shipfox/node-error-monitoring':
+        specifier: workspace:*
+        version: link:../../shared/node/error-monitoring
+      '@shipfox/node-fastify':
+        specifier: workspace:*
+        version: link:../../shared/node/fastify
+      '@shipfox/node-module':
+        specifier: workspace:*
+        version: link:../../shared/node/module
+      '@shipfox/node-opentelemetry':
+        specifier: workspace:*
+        version: link:../../shared/node/opentelemetry
+      '@shipfox/node-postgres':
+        specifier: workspace:*
+        version: link:../../shared/node/postgres
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../tools/vitest
+
   libs/api/triggers:
     dependencies:
       '@shipfox/api-auth-context':


### PR DESCRIPTION
Adds @shipfox/api-server with the public API lifecycle, default module composition, and an early instrumentation entry point. It also exposes service-metrics shutdown for the lifecycle teardown.

Upstream and external distributions need the same server-composition contract. This extraction makes that contract package-consumable while preserving the current application behavior.

Considered migrating apps/api in this PR, but keeping the app unchanged makes the lifecycle extraction independently reviewable. ENG-955 will make the application a thin binary over this package.

Careful review: server startup and shutdown ordering, worker-failure handling, and the public package boundary.

Closes ENG-954

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces `@shipfox/api-server`, a reusable API server lifecycle with default modules and an early instrumentation preload. Implements ENG-954 without changing `apps/api`, and guards process-global resources to prevent overlapping servers and leaks.

- **New Features**
  - Public API: `defaultModules()`, `createServer()`, `runServer()`.
  - Instrumentation preload: `@shipfox/api-server/instrumentation` starts metrics early; `@shipfox/node-opentelemetry` now exports `shutdownServiceMetrics`.
  - Lifecycle: workers start before listen; start/stop are serialized; `stop()` is idempotent and continues teardown after failures (errors aggregated); startup failures clean up resources; worker failures trigger a safe shutdown and optional hook; `runServer` installs SIGTERM/SIGINT and exits 0/1; process-global guard rejects a second server while one is active and keeps the reservation until a failed stop succeeds on retry; stopping during worker startup waits for worker init to finish and then tears down without leaking resources.
  - E2E: gated `/__e2e` routes with an admin key; includes `API_PORT` and `API_TRUST_PROXY` parsing.

- **Migration**
  - Use `runServer({modules: await defaultModules()})` to start a standard server.
  - For custom composition or manual signal control, use `createServer()` instead.
  - Preload instrumentation with `node --import @shipfox/api-server/instrumentation`.

<sup>Written for commit 0cc16631f98d61f65aeea98620cc9e13cab5d35c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

