### PR TITLE
Fix ORAS setup in application release CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,7 +281,7 @@ jobs:
         uses: ./.github/actions/setup-pnpm
 
       - name: Set up ORAS
-        uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1
+        uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2
         with:
           version: 1.3.3
 


### PR DESCRIPTION
Upgrade the pinned `setup-oras` action from v1.2.4 to v2.0.1 for application release publication.

The prior action bundles a static CLI release table that stops at ORAS 1.3.0, so asking it for 1.3.3 fails before login or publication. It also declares Node 20, producing GitHub’s deprecation warning. v2.0.1 bundles ORAS 1.3.3 and runs on Node 24.

Pinning ORAS to 1.3.0 would avoid the immediate lookup failure, but would keep the deprecated action runtime and unnecessarily downgrade the CLI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade the application release workflow to use `oras-project/setup-oras` v2, enabling ORAS 1.3.3 and switching the action runtime to Node 24.

- **Bug Fixes**
  - Fixes ORAS install failure when requesting 1.3.3 (v1 only supported up to 1.3.0).
  - Removes the GitHub warning about the action running on deprecated Node 20.

<sup>Written for commit b1ad69378fb4e3089f43c3797547affe115dbbe6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

