### PR TITLE
[e2e] Stabilize projected step log reads

### DIFF
--- a/e2e/observe/logs/src/index.test.ts
+++ b/e2e/observe/logs/src/index.test.ts
@@ -101,8 +101,8 @@ describe('fetchStepLogs', () => {
         statuses.push(response.status);
         return Promise.resolve(response);
       },
-      missingStreamRetryAttempts: 2,
       missingStreamRetryDelayMs: 0,
+      missingStreamRetryTimeoutMs: 1_000,
       stepId,
       token: 'user-token',
     });
@@ -111,12 +111,33 @@ describe('fetchStepLogs', () => {
     expect(result.records).toEqual([output('eventual logs\n')]);
   });
 
+  test('keeps waiting beyond five missing-stream responses', async () => {
+    const statuses: number[] = [];
+    const result = await fetchStepLogs({
+      attempt: 1,
+      fetch: () => {
+        const response =
+          statuses.length < 6
+            ? Response.json({code: 'not-found'}, {status: 404})
+            : Response.json(inline({ndjson: line(output('delayed logs\n'))}));
+        statuses.push(response.status);
+        return Promise.resolve(response);
+      },
+      missingStreamRetryDelayMs: 0,
+      stepId,
+      token: 'user-token',
+    });
+
+    expect(statuses).toEqual([404, 404, 404, 404, 404, 404, 200]);
+    expect(result.records).toEqual([output('delayed logs\n')]);
+  });
+
   test('keeps the missing stream failure readable after retry exhaustion', async () => {
     const result = fetchStepLogs({
       attempt: 1,
       fetch: () => Response.json({code: 'not-found'}, {status: 404}),
-      missingStreamRetryAttempts: 1,
       missingStreamRetryDelayMs: 0,
+      missingStreamRetryTimeoutMs: 0,
       stepId,
       token: 'user-token',
     });

--- a/e2e/observe/logs/src/index.ts
+++ b/e2e/observe/logs/src/index.ts
@@ -2,15 +2,15 @@ import {type LogRecord, parseLogRecordLine, type ReadLogsResponseDto} from '@shi
 import {type ApiFetch, createApiClient, E2eApiError} from '@shipfox/e2e-core';
 
 const NDJSON_LINE_SPLIT_RE = /\r?\n/u;
-const MISSING_STREAM_RETRY_ATTEMPTS = 5;
 const MISSING_STREAM_RETRY_DELAY_MS = 750;
+const MISSING_STREAM_RETRY_TIMEOUT_MS = 60_000;
 
 export interface FetchStepLogsOptions {
   apiUrl?: string | undefined;
   attempt: number;
   fetch?: ApiFetch | undefined;
-  missingStreamRetryAttempts?: number | undefined;
   missingStreamRetryDelayMs?: number | undefined;
+  missingStreamRetryTimeoutMs?: number | undefined;
   signal?: AbortSignal | undefined;
   stepId: string;
   token: string;
@@ -54,11 +54,10 @@ export async function fetchStepLogs(options: FetchStepLogsOptions): Promise<Step
   let cursor = 0;
   let ndjson = '';
   let truncated = false;
-  let missingStreamRetries = 0;
-  const missingStreamRetryAttempts =
-    options.missingStreamRetryAttempts ?? MISSING_STREAM_RETRY_ATTEMPTS;
   const missingStreamRetryDelayMs =
     options.missingStreamRetryDelayMs ?? MISSING_STREAM_RETRY_DELAY_MS;
+  const missingStreamRetryDeadline =
+    Date.now() + (options.missingStreamRetryTimeoutMs ?? MISSING_STREAM_RETRY_TIMEOUT_MS);
 
   while (true) {
     options.signal?.throwIfAborted();
@@ -71,13 +70,11 @@ export async function fetchStepLogs(options: FetchStepLogsOptions): Promise<Step
         {signal: options.signal},
       );
     } catch (error) {
-      if (
-        cursor === 0 &&
-        missingStreamRetries < missingStreamRetryAttempts &&
-        isMissingStreamError(error)
-      ) {
-        missingStreamRetries += 1;
-        await delay(missingStreamRetryDelayMs, options.signal);
+      if (cursor === 0 && isMissingStreamError(error) && Date.now() < missingStreamRetryDeadline) {
+        await delay(
+          Math.min(missingStreamRetryDelayMs, missingStreamRetryDeadline - Date.now()),
+          options.signal,
+        );
         continue;
       }
       throw error;


### PR DESCRIPTION
Workflow terminal state can become visible before the logs-owned step stream has been projected. The E2E log observer previously allowed only five retries, so four-worker CI runs could exhaust the 3.75-second budget and fail with a transient 404 even though the workflow succeeded.

Replace the fixed attempt count with a bounded 60-second readiness window while preserving the final structured 404 when the deadline expires. Add regression coverage for a stream that appears after more than five missing responses.

A longer fixed retry count was considered, but a time budget describes the readiness contract directly and remains predictable when individual requests have variable latency.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes E2E step log reads by replacing fixed retry attempts with a 60s readiness window to avoid flaky 404s under CI load. Adds regression tests to ensure we wait past five misses and still return a readable 404 on timeout.

- **Bug Fixes**
  - Use a deadline-based wait (`missingStreamRetryTimeoutMs`, default 60s) for missing stream 404s before the first record.
  - Keep retry delay (`missingStreamRetryDelayMs`) and bound each wait to the remaining window.
  - Preserve the final structured 404 if the deadline expires.
  - Added tests for waiting beyond five 404s and for readable failures on timeout.

- **Migration**
  - Remove `missingStreamRetryAttempts`; add `missingStreamRetryTimeoutMs`.
  - Update any callers overriding retries to set a timeout in ms.

<sup>Written for commit a960e3deb7c8e0083324dbe0ffb4ddb8b5939e3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

