### PR TITLE
[api] Add system CA certificates to runtime image

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -32,8 +32,12 @@ RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
 FROM base AS runtime
 ENV NODE_ENV=production
 
-# Run unprivileged: the service only reads its own files and never writes them.
-RUN groupadd --system shipfox && useradd --system --gid shipfox --no-create-home shipfox
+# Install the OS trust store for native TLS clients, then run unprivileged.
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --system shipfox \
+    && useradd --system --gid shipfox --no-create-home shipfox
 
 COPY --from=build /prod ./
 COPY --chmod=755 docker-entrypoint.sh /usr/local/bin/shipfox-entrypoint


### PR DESCRIPTION
Install Debian’s CA certificate bundle in the API runtime image and remove apt metadata after installation.

The slim Node base image does not include `/etc/ssl/certs` or `ca-certificates.crt`. Native TLS clients therefore fail before establishing secure connections with `NativeCertsNotFound`, even though Node has its own bundled roots.

Installing the operating system trust store in the runtime stage keeps native clients working while preserving the existing unprivileged runtime user and minimal production dependency closure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install Debian system CA certificates in the API runtime image to fix TLS failures for native clients. Keeps the unprivileged user and removes apt metadata to minimize image size.

- **Bug Fixes**
  - Install `ca-certificates` in the runtime stage so `/etc/ssl/certs` and `ca-certificates.crt` are available.
  - Clean `/var/lib/apt/lists` after install; retain unprivileged `shipfox` user setup.

<sup>Written for commit 74da1acb4366d0d1b3e1d7495c9524080e0bcedc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

