### PR TITLE
Make API workflow resolution production-safe

### DIFF
--- a/.changeset/steady-tigers-resolve.md
+++ b/.changeset/steady-tigers-resolve.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/node-temporal": minor
+"@shipfox/docker": patch
+---
+
+Makes Temporal workflow bundling and Docker runtime import maps resolve compiled production files.

--- a/libs/shared/node/temporal/src/index.ts
+++ b/libs/shared/node/temporal/src/index.ts
@@ -13,7 +13,9 @@ export {
   getWorkflowInterceptorModules,
 } from './interceptors.js';
 export {
+  bundleProductionWorkflow,
   type CreateWorkerOptions,
   createTemporalWorker,
   createTemporalWorkerConnection,
+  productionWorkflowBundlerOptions,
 } from './worker.js';

--- a/libs/shared/node/temporal/src/worker.test.ts
+++ b/libs/shared/node/temporal/src/worker.test.ts
@@ -1,8 +1,14 @@
 import type {NativeConnection} from '@temporalio/worker';
 import type {CreateWorkerOptions} from './worker.js';
-import {createTemporalWorker, createTemporalWorkerConnection} from './worker.js';
+import {
+  bundleProductionWorkflow,
+  createTemporalWorker,
+  createTemporalWorkerConnection,
+  productionWorkflowBundlerOptions,
+} from './worker.js';
 
 const mocks = vi.hoisted(() => ({
+  bundleWorkflowCode: vi.fn(),
   nativeConnectionConnect: vi.fn(),
   workerCreate: vi.fn(),
   logger: {info: vi.fn()},
@@ -15,6 +21,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@temporalio/worker', () => ({
+  bundleWorkflowCode: mocks.bundleWorkflowCode,
   NativeConnection: {connect: mocks.nativeConnectionConnect},
   Worker: {create: mocks.workerCreate},
 }));
@@ -77,6 +84,8 @@ describe('createTemporalWorkerConnection', () => {
 
 describe('createTemporalWorker', () => {
   beforeEach(() => {
+    vi.unstubAllEnvs();
+    mocks.bundleWorkflowCode.mockReset();
     mocks.nativeConnectionConnect.mockReset();
     mocks.workerCreate.mockReset();
     mocks.logger.info.mockReset();
@@ -113,5 +122,62 @@ describe('createTemporalWorker', () => {
     expect(mocks.nativeConnectionConnect).not.toHaveBeenCalled();
     expect(mocks.workerCreate).toHaveBeenCalledWith(expect.objectContaining({connection}));
     expect(connection.close).not.toHaveBeenCalled();
+  });
+
+  it('keeps workspace development workflow resolution unchanged', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+
+    await createTemporalWorker(workerOptions());
+
+    expect(mocks.workerCreate).toHaveBeenCalledWith(
+      expect.not.objectContaining({bundlerOptions: expect.anything()}),
+    );
+  });
+
+  it('uses production workflow resolution in production', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+
+    await createTemporalWorker(workerOptions());
+
+    expect(mocks.workerCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bundlerOptions: expect.objectContaining({webpackConfigHook: expect.any(Function)}),
+      }),
+    );
+  });
+});
+
+describe('productionWorkflowBundlerOptions', () => {
+  it('uses production conditions without replacing Temporal resolution settings', () => {
+    const extensions = ['.ts', '.js'];
+    const extensionAlias = {'.js': ['.ts', '.js']};
+    const webpackConfig = {resolve: {extensions, extensionAlias}};
+
+    const result = productionWorkflowBundlerOptions().webpackConfigHook?.(webpackConfig);
+
+    expect(result?.resolve).toEqual(
+      expect.objectContaining({
+        extensions,
+        extensionAlias,
+        conditionNames: expect.arrayContaining(['webpack', 'production', 'node', 'import']),
+      }),
+    );
+    expect(result?.resolve?.conditionNames).not.toContain('development');
+    expect(result?.resolve?.conditionNames).not.toContain('workspace-source');
+  });
+});
+
+describe('bundleProductionWorkflow', () => {
+  it('uses the same production bundler options as a production worker', async () => {
+    mocks.bundleWorkflowCode.mockResolvedValue({code: 'workflow bundle'});
+
+    await bundleProductionWorkflow('/tmp/workflows.js');
+
+    expect(mocks.bundleWorkflowCode).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workflowsPath: '/tmp/workflows.js',
+        webpackConfigHook: expect.any(Function),
+      }),
+    );
   });
 });

--- a/libs/shared/node/temporal/src/worker.ts
+++ b/libs/shared/node/temporal/src/worker.ts
@@ -1,5 +1,5 @@
 import {logger} from '@shipfox/node-opentelemetry';
-import {NativeConnection, Worker} from '@temporalio/worker';
+import {type BundleOptions, bundleWorkflowCode, NativeConnection, Worker} from '@temporalio/worker';
 import {config} from './config.js';
 import {getTemporalConnectionOptions, temporalConnectionError} from './connection-options.js';
 import {getWorkerInterceptors, getWorkflowInterceptorModules} from './interceptors.js';
@@ -11,6 +11,34 @@ export interface CreateWorkerOptions {
   activities: object;
   maxConcurrentActivityTaskExecutions?: number;
   maxConcurrentWorkflowTaskExecutions?: number;
+}
+
+const productionWorkflowConditionNames = ['webpack', 'production', 'node', 'import', 'require'];
+
+/**
+ * Makes Temporal's runtime workflow bundler resolve first-party packages from compiled output.
+ */
+export function productionWorkflowBundlerOptions(): Pick<BundleOptions, 'webpackConfigHook'> {
+  return {
+    webpackConfigHook: (webpackConfig) => ({
+      ...webpackConfig,
+      resolve: {
+        ...webpackConfig.resolve,
+        conditionNames: productionWorkflowConditionNames,
+      },
+    }),
+  };
+}
+
+/**
+ * Bundles a workflow entrypoint with the same production resolution used by Temporal workers.
+ */
+export function bundleProductionWorkflow(workflowsPath: string) {
+  return bundleWorkflowCode({
+    workflowsPath,
+    workflowInterceptorModules: getWorkflowInterceptorModules(),
+    ...productionWorkflowBundlerOptions(),
+  });
 }
 
 export async function createTemporalWorkerConnection(): Promise<NativeConnection> {
@@ -35,6 +63,9 @@ export async function createTemporalWorker(options: CreateWorkerOptions): Promis
       ...getWorkerInterceptors(),
       workflowModules: getWorkflowInterceptorModules(),
     },
+    ...(process.env.NODE_ENV === 'production'
+      ? {bundlerOptions: productionWorkflowBundlerOptions()}
+      : {}),
     maxConcurrentActivityTaskExecutions: options.maxConcurrentActivityTaskExecutions ?? 10,
     maxConcurrentWorkflowTaskExecutions: options.maxConcurrentWorkflowTaskExecutions ?? 10,
   });

--- a/tools/application-release/test/external/verify.mjs
+++ b/tools/application-release/test/external/verify.mjs
@@ -52,6 +52,7 @@ try {
   const tsc = resolve(repositoryRoot, 'tools/typescript/node_modules/typescript/bin/tsc');
   await run(process.execPath, [tsc, '--project', 'tsconfig.json'], fixtureRoot);
   await run(process.execPath, ['runtime-imports.mjs'], fixtureRoot);
+  await run(process.execPath, ['workflow-bundles.mjs'], fixtureRoot);
 } finally {
   await rm(fixtureRoot, {recursive: true, force: true});
 }
@@ -118,6 +119,10 @@ void createServer({
     writeFile(
       join(root, 'runtime-imports.mjs'),
       `Object.assign(process.env, ${JSON.stringify(runtimeEnvironment(), null, 2)});\n\nconst entryPoints = ${JSON.stringify(runtimeEntryPoints, null, 2)};\nfor (const entryPoint of entryPoints) await import(entryPoint);\nconst {createServer, defaultModules} = await import('@shipfox/api-server');\nif (typeof createServer !== 'function' || typeof defaultModules !== 'function')\n  throw new Error('Packed API server does not export its composition API.');\nconst modules = [...(await defaultModules()), {name: 'external-dummy'}];\nif (modules.at(-1)?.name !== 'external-dummy')\n  throw new Error('Could not append an external module to the packed API server defaults.');\nconsole.log(\`Imported \${entryPoints.length} packed runtime entry points and composed API modules.\`);\nprocess.exit(0);\n`,
+    ),
+    writeFile(
+      join(root, 'workflow-bundles.mjs'),
+      `Object.assign(process.env, {...${JSON.stringify(runtimeEnvironment(), null, 2)}, NODE_ENV: 'production'});\n\nconst {defaultModules} = await import('@shipfox/api-server');\nconst {bundleProductionWorkflow} = await import('@shipfox/node-temporal');\nconst modules = await defaultModules();\nconst workflowPaths = new Set(\n  modules.flatMap((module) => module.workers ?? []).map((worker) => worker.workflowsPath),\n);\n\nif (!workflowPaths.size) throw new Error('Packed API server declares no workflow entrypoints.');\n\nfor (const workflowsPath of workflowPaths) {\n  const workflowBundle = await bundleProductionWorkflow(workflowsPath);\n  if (/@shipfox[/\\\\][^/\\\\]+[/\\\\]src[/\\\\]/u.test(workflowBundle.code)) {\n    throw new Error(\n      \`Workflow bundle for \${workflowsPath} resolved a first-party source path.\`,\n    );\n  }\n}\n\nconsole.log(\`Bundled \${workflowPaths.size} packed API workflow entrypoints with production resolution.\`);\n`,
     ),
   ]);
 }

--- a/tools/docker/package.json
+++ b/tools/docker/package.json
@@ -17,6 +17,7 @@
   },
   "scripts": {
     "build": "shipfox-swc",
+    "test": "pnpm run build && node --test test/*.test.mjs",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"
   },

--- a/tools/docker/src/turbo.ts
+++ b/tools/docker/src/turbo.ts
@@ -59,35 +59,45 @@ function overlayDist(prunedRoot: string) {
 }
 
 /**
- * Point a package's `#*` subpath imports at the built `dist/` instead of the
- * `src/` TypeScript, in the pruned context only. The image runs `dist/` with
- * plain `node`, so `import '#core/run.js'` must resolve to `./dist/core/run.js`;
- * the source map `"#*": "./src/*"` resolves it to a `.ts` file the image does
- * not ship, which crashes with ERR_MODULE_NOT_FOUND.
+ * Point a package's `#*` subpath imports at the built `dist/` in the pruned
+ * context only. The image runs `dist/` with Node and Temporal's Webpack bundler,
+ * so every condition must resolve `import '#core/run.js'` to
+ * `./dist/core/run.js` instead of source TypeScript.
  *
  * Done here, on the throwaway build context, rather than the two tempting spots:
- *  - Source package.json: `#*` has to stay the unconditional `./src/*`. It is an
- *    intra-package alias, and type-check / type-emit / tests all run against
- *    `src/` without activating the `development` condition, so a `default ->
- *    dist` map would resolve a package's own imports to its (not-yet-built)
- *    dist and fail type-checking (TS7016).
+ *  - Source package.json: `#*` has to retain its source conditions so local
+ *    development, type-checking, and tests resolve the workspace source.
  *  - swc emit: `jsc.paths` + `resolveFully` rewrites `#dir/file.js` but silently
  *    leaves bare `#file.js` (e.g. `#config.js`) as-is, producing broken output
  *    with no error.
  *
- * Rewriting the map here leaves source/dev/test untouched and lets Node's own
- * subpath resolver do the work, just aimed at `dist/`. The `development` branch
- * is kept only for symmetry with each package's `exports`; the image runs the
- * `default` branch.
+ * Rewriting the map here leaves source/dev/test untouched and ensures no source
+ * branch survives in the deployed manifest.
  */
 function productionizeSubpathImports(packageJsonPath: string) {
   const manifest = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
     imports?: Record<string, unknown>;
   };
-  if (manifest.imports?.['#*'] !== './src/*') return;
+  const imports = productionizeImports(manifest.imports);
+  if (imports === manifest.imports) return;
 
-  manifest.imports['#*'] = {development: './src/*', default: './dist/*'};
+  manifest.imports = imports;
   writeFileSync(packageJsonPath, `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
+export function productionizeImports(
+  imports: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  const subpathImports = imports?.['#*'];
+  const hasDistDefault =
+    typeof subpathImports === 'object' &&
+    subpathImports !== null &&
+    !Array.isArray(subpathImports) &&
+    (subpathImports as Record<string, unknown>).default === './dist/*';
+
+  if (subpathImports !== './src/*' && !hasDistDefault) return imports;
+
+  return {...imports, '#*': './dist/*'};
 }
 
 function buildsToDist(packageJsonPath: string): boolean {

--- a/tools/docker/test/turbo.test.mjs
+++ b/tools/docker/test/turbo.test.mjs
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {productionizeImports} from '../dist/turbo.js';
+
+test('productionizes legacy source subpath imports', () => {
+  const imports = {'#*': './src/*'};
+
+  const result = productionizeImports(imports);
+
+  assert.deepEqual(result, {'#*': './dist/*'});
+  assert.notEqual(result, imports);
+});
+
+test('productionizes conditional source subpath imports', () => {
+  const imports = {
+    '#*': {
+      'workspace-source': './src/*',
+      development: './src/*',
+      default: './dist/*',
+    },
+    '#test/*': './test/*',
+  };
+
+  const result = productionizeImports(imports);
+
+  assert.deepEqual(result, {'#*': './dist/*', '#test/*': './test/*'});
+  assert.notEqual(result, imports);
+});
+
+test('leaves missing subpath imports unchanged', () => {
+  const imports = {'#test/*': './test/*'};
+
+  const result = productionizeImports(imports);
+
+  assert.equal(result, imports);
+});
+
+test('leaves production subpath imports unchanged', () => {
+  const imports = {'#*': './dist/*'};
+
+  const result = productionizeImports(imports);
+
+  assert.equal(result, imports);
+});


### PR DESCRIPTION
Make Temporal workflow bundling resolve first-party API code from compiled `dist` output in production, while workspace development continues to use source resolution.

The published API image crashed because Temporal's runtime Webpack bundler selected the `development` package condition and then attempted to parse a package's TypeScript source from `node_modules`. This adds an explicit production condition hook, makes Docker runtime manifests eliminate source import-map branches, and validates the packed API closure by bundling every worker entrypoint without first-party `src` references.

Runtime bundling remains intentionally in place; ENG-964 will move those bundles to build time. The resolver hook preserves Temporal's existing Webpack resolution settings, and smoke coverage discovers worker paths instead of pinning the current module set.

Closes ENG-963

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Temporal workflow bundling resolve first‑party packages from compiled `dist` in production while keeping workspace development on `src`. Fixes worker startup crashes in the deployed API image by forcing production conditions (ENG-963).

- **Bug Fixes**
  - `@shipfox/node-temporal`: Force production package conditions in the runtime bundler via `productionWorkflowBundlerOptions`; `createTemporalWorker` applies it only when `NODE_ENV=production`. Exported `bundleProductionWorkflow` for offline bundling; tests cover both dev and prod paths.
  - `@shipfox/docker`: Pruned manifests now rewrite `imports` `#*` to `./dist/*`, collapsing legacy and conditional shapes; added unit tests and a test script.
  - External verification bundles every declared workflow entrypoint from the packed API and fails if any first‑party `src` path is referenced.

<sup>Written for commit 763fe542e31f4bf2985afe725d9b7b39ada695e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

