### PR TITLE
Prove client composition from an external Vite fixture

### DIFF
--- a/.changeset/calm-foxes-resolve.md
+++ b/.changeset/calm-foxes-resolve.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/react-ui": patch
+---
+
+Fixes compiled internal imports so external consumers resolve the package's dist artifacts.

--- a/biome.json
+++ b/biome.json
@@ -9,7 +9,10 @@
     }
   },
   "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
-  "files": { "ignoreUnknown": false },
+  "files": {
+    "ignoreUnknown": false,
+    "includes": ["**", "!libs/client/shell/test/external/fixture/**"]
+  },
   "formatter": {
     "enabled": true,
     "useEditorconfig": true,

--- a/libs/client/auth/package.json
+++ b/libs/client/auth/package.json
@@ -12,7 +12,11 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "imports": {
-    "#*": "./src/*",
+    "#*": {
+      "workspace-source": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    },
     "#test/*": "./test/*"
   },
   "exports": {

--- a/libs/client/auth/tsconfig.build.json
+++ b/libs/client/auth/tsconfig.build.json
@@ -2,7 +2,8 @@
   "extends": "@shipfox/ts-config/react",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "customConditions": ["workspace-source"]
   },
   "include": ["src"],
   "exclude": ["**/*.test.tsx", "**/*.test.ts"]

--- a/libs/client/config/tsconfig.build.json
+++ b/libs/client/config/tsconfig.build.json
@@ -2,7 +2,8 @@
   "extends": "@shipfox/ts-config/react",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "customConditions": ["workspace-source"]
   },
   "include": ["src"],
   "exclude": ["**/*.test.tsx", "**/*.test.ts"]

--- a/libs/client/shell/package.json
+++ b/libs/client/shell/package.json
@@ -12,7 +12,11 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "imports": {
-    "#*": "./src/*",
+    "#*": {
+      "workspace-source": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    },
     "#test/*": "./test/*"
   },
   "exports": {
@@ -61,6 +65,7 @@
     "@shipfox/client-config": "workspace:*",
     "@shipfox/react-ui": "workspace:*",
     "@swc/helpers": "^0.5.17",
+    "@tanstack/router-core": "^1.171.13",
     "jiti": "^2.7.0",
     "zod": "^4.4.3"
   },

--- a/libs/client/shell/test/external/FINDINGS.md
+++ b/libs/client/shell/test/external/FINDINGS.md
@@ -1,0 +1,53 @@
+# External composition findings
+
+Both the linked iteration mode and packed-tarball exit gate passed on 2026-07-16. The verifier
+computed and installed a 12-package `@shipfox/*` runtime closure.
+
+## Declaration portability
+
+The packed consumer's `tsc --noEmit` accepted a typed `Link` and `useSearch` for the added
+`/workspaces/$wid/insights` route. The generated router also resolved the toy package's emitted
+default `defineRoute(...)` declarations and the shell's anchor return types from `dist`.
+
+The packed verifier also checks that every installed `#*` import map defaults to `./dist/*` and
+that representative shell and toy-feature public entrypoints resolve beneath `dist`. This keeps the
+proof valid even while the tarballs still include source files.
+
+The proof exposed two package-boundary gaps before it passed:
+
+- Compiled client packages still mapped internal `#*` imports directly to `src`. Their package
+  manifests now use `workspace-source` and `development` for source, and `default` for `dist`.
+- The inferred anchor declarations name `@tanstack/router-core`. The shell now declares that direct
+  dependency so isolated pnpm consumers can resolve it.
+
+The fixture did not need `@storybook/react` at runtime or during its consumer type-check. The
+`ShellProviders` declaration's type-only Storybook import is erased at runtime; the fixture uses the
+same `skipLibCheck` setting as the existing external-consumer verifier.
+
+## Development-mode coverage
+
+The gate intentionally proves production builds and default package resolution; it does not start a
+Vite development server. The `development` condition still resolves to the TypeScript source that
+the packages currently ship. Plugin watch and regeneration behavior remains covered by ENG-961's
+focused tests. If published packages stop including source, external development-mode support needs
+a separate product decision and proof rather than making this release gate longer.
+
+## Generated-file developer experience
+
+The generated file keeps both forms of route implementation specifier readable:
+
+- App-local implementations use a path relative to `src/shipfox-app.gen.ts`, such as
+  `./features/override-impl`.
+- Packaged implementations use an exported package subpath, such as
+  `@shipfox/client-shell-fixture-feature/routes/insights`.
+
+The app's Node-evaluated feature manifest imports local TypeScript modules without a `.js` suffix so
+jiti resolves the source file. Route implementation modules are never evaluated by jiti.
+
+## Collision diagnostic
+
+The rejected build returned this diagnostic and a non-zero status:
+
+```text
+Route "/workspaces/$wid/insights" is contributed by both features "fixture.toy-feature" and "fixture.unapproved-collision". Set override: true to replace it explicitly.
+```

--- a/libs/client/shell/test/external/README.md
+++ b/libs/client/shell/test/external/README.md
@@ -1,0 +1,38 @@
+# External client composition fixture
+
+This fixture proves the candidate client composition contract from a Vite application outside the
+pnpm workspace. It is a manual evidence gate for ENG-962 and does not add a CI job.
+
+## Prerequisites
+
+Build runtime files, declarations, and the closure helper before running either mode:
+
+```sh
+turbo build type:emit \
+  --filter=@shipfox/client-shell-fixture-feature... \
+  --filter=@shipfox/application-release
+```
+
+## Run the fast linked mode
+
+```sh
+node libs/client/shell/test/external/verify.mjs --link
+```
+
+This copies the Vite template to a temporary directory and links the workspace-built closure. It
+runs a Vite build, one compact jsdom render test, a consumer type-check, and the rejected-collision
+build.
+
+## Run the packed exit gate
+
+```sh
+node libs/client/shell/test/external/verify.mjs
+```
+
+This computes the runtime workspace closure rooted at `@shipfox/client-shell` and the toy feature,
+packs every package, and installs only those tarballs for `@shipfox/*` dependencies. It repeats the
+linked checks against default `dist` exports and verifies no candidate package came from the
+workspace or registry.
+
+Both modes remove their temporary directories after completion. Neither mode needs browser E2E
+infrastructure or adds work to the normal CI test graph.

--- a/libs/client/shell/test/external/fixture/index.html
+++ b/libs/client/shell/test/external/fixture/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Shipfox client composition fixture</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/libs/client/shell/test/external/fixture/package.json
+++ b/libs/client/shell/test/external/fixture/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "shipfox-client-shell-external-fixture",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "test": "vitest run",
+    "type": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "5.101.0",
+    "@tanstack/react-router": "1.170.16",
+    "@tanstack/router-core": "1.171.13",
+    "jotai": "2.20.1",
+    "react": "19.2.7",
+    "react-dom": "19.2.7",
+    "zod": "4.4.3"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "6.9.1",
+    "@testing-library/react": "16.3.2",
+    "@types/node": "24.13.2",
+    "@types/react": "19.2.17",
+    "@types/react-dom": "19.2.3",
+    "@vitejs/plugin-react": "6.0.2",
+    "jsdom": "29.1.1",
+    "typescript": "6.0.3",
+    "vite": "8.0.16",
+    "vitest": "4.1.9"
+  }
+}

--- a/libs/client/shell/test/external/fixture/src/app.fixture.tsx
+++ b/libs/client/shell/test/external/fixture/src/app.fixture.tsx
@@ -1,10 +1,10 @@
 import '@testing-library/jest-dom/vitest';
 import {getLoadedConfig} from '@shipfox/client-config';
-import {providerProbe, resetProviderProbe} from '@shipfox/client-shell-fixture-feature';
+import type {ProviderProbeEntry} from '@shipfox/client-shell-fixture-feature';
 import {QueryClient} from '@tanstack/react-query';
 import {createMemoryHistory} from '@tanstack/react-router';
-import {act, render, screen} from '@testing-library/react';
-import {ClientApp} from './main.js';
+import {act, render, screen, waitFor} from '@testing-library/react';
+import {createClientAppElement} from './main.js';
 import {router} from './shipfox-app.gen.js';
 
 test('proves the external composition contract', async () => {
@@ -20,18 +20,25 @@ test('proves the external composition contract', async () => {
   }));
   window.scrollTo = vi.fn();
   window.__SHIPFOX_CONFIG__ = undefined;
-  const missingConfig = render(<ClientApp />);
+  const missingConfig = render(createClientAppElement(), {reactStrictMode: true});
 
   expect(await screen.findByRole('heading', {name: 'Configuration error'})).toBeVisible();
   expect(screen.getByText('fixtureGreeting')).toBeVisible();
   missingConfig.unmount();
 
   window.__SHIPFOX_CONFIG__ = {FIXTURE_GREETING: 'Hello from the fixture'};
-  resetProviderProbe();
+  let providers: readonly ProviderProbeEntry[] = [];
   router.update({
     history: createMemoryHistory({initialEntries: ['/workspaces/workspace/insights']}),
   });
-  render(<ClientApp />);
+  render(
+    createClientAppElement({
+      onProviders: (entries) => {
+        providers = entries;
+      },
+    }),
+    {reactStrictMode: true},
+  );
 
   expect(await screen.findByRole('heading', {name: 'Overridden insights'})).toBeVisible();
   expect(screen.queryByRole('heading', {name: 'Toy insights'})).not.toBeInTheDocument();
@@ -39,10 +46,11 @@ test('proves the external composition contract', async () => {
     'Insights first',
     'Insights second',
   ]);
-  expect(providerProbe.order).toEqual(['toy-feature', 'app-feature']);
-  expect(providerProbe.queryClients).toHaveLength(2);
-  expect(providerProbe.queryClients[0]).toBeInstanceOf(QueryClient);
-  expect(providerProbe.queryClients[1]).toBe(providerProbe.queryClients[0]);
+  await waitFor(() => expect(providers.map(({id}) => id)).toEqual(['toy-feature', 'app-feature']));
+  const queryClients = providers.map(({queryClient}) => queryClient);
+  expect(queryClients).toHaveLength(2);
+  expect(queryClients[0]).toBeInstanceOf(QueryClient);
+  expect(queryClients[1]).toBe(queryClients[0]);
   expect(getLoadedConfig<{fixtureGreeting: string}>().fixtureGreeting).toBe(
     'Hello from the fixture',
   );

--- a/libs/client/shell/test/external/fixture/src/app.fixture.tsx
+++ b/libs/client/shell/test/external/fixture/src/app.fixture.tsx
@@ -1,0 +1,64 @@
+import '@testing-library/jest-dom/vitest';
+import {getLoadedConfig} from '@shipfox/client-config';
+import {providerProbe, resetProviderProbe} from '@shipfox/client-shell-fixture-feature';
+import {QueryClient} from '@tanstack/react-query';
+import {createMemoryHistory} from '@tanstack/react-router';
+import {act, render, screen} from '@testing-library/react';
+import {ClientApp} from './main.js';
+import {router} from './shipfox-app.gen.js';
+
+test('proves the external composition contract', async () => {
+  window.matchMedia = vi.fn((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(() => false),
+  }));
+  window.scrollTo = vi.fn();
+  window.__SHIPFOX_CONFIG__ = undefined;
+  const missingConfig = render(<ClientApp />);
+
+  expect(await screen.findByRole('heading', {name: 'Configuration error'})).toBeVisible();
+  expect(screen.getByText('fixtureGreeting')).toBeVisible();
+  missingConfig.unmount();
+
+  window.__SHIPFOX_CONFIG__ = {FIXTURE_GREETING: 'Hello from the fixture'};
+  resetProviderProbe();
+  router.update({
+    history: createMemoryHistory({initialEntries: ['/workspaces/workspace/insights']}),
+  });
+  render(<ClientApp />);
+
+  expect(await screen.findByRole('heading', {name: 'Overridden insights'})).toBeVisible();
+  expect(screen.queryByRole('heading', {name: 'Toy insights'})).not.toBeInTheDocument();
+  expect(screen.getAllByRole('tab').map((tab) => tab.textContent)).toEqual([
+    'Insights first',
+    'Insights second',
+  ]);
+  expect(providerProbe.order).toEqual(['toy-feature', 'app-feature']);
+  expect(providerProbe.queryClients).toHaveLength(2);
+  expect(providerProbe.queryClients[0]).toBeInstanceOf(QueryClient);
+  expect(providerProbe.queryClients[1]).toBe(providerProbe.queryClients[0]);
+  expect(getLoadedConfig<{fixtureGreeting: string}>().fixtureGreeting).toBe(
+    'Hello from the fixture',
+  );
+
+  await act(() =>
+    router.navigate({
+      to: '/workspaces/$wid/settings/primary',
+      params: {wid: 'workspace'},
+    }),
+  );
+
+  expect(await screen.findByRole('heading', {name: 'Toy settings'})).toBeVisible();
+  expect(
+    Array.from(
+      screen.getByRole('navigation', {name: 'Workspace settings'}).querySelectorAll('a'),
+      (link) => link.textContent,
+    ),
+  ).toEqual(['Primary settings', 'Secondary settings']);
+});

--- a/libs/client/shell/test/external/fixture/src/features.collision.ts
+++ b/libs/client/shell/test/external/fixture/src/features.collision.ts
@@ -1,0 +1,15 @@
+import {defineClientFeature} from '@shipfox/client-shell';
+import {toyFeature} from '@shipfox/client-shell-fixture-feature';
+
+const collisionFeature = defineClientFeature({
+  id: 'fixture.unapproved-collision',
+  routes: [
+    {
+      path: '/workspaces/$wid/insights',
+      parent: 'workspaceLayout',
+      impl: './features/override-impl',
+    },
+  ],
+});
+
+export const features = [toyFeature, collisionFeature];

--- a/libs/client/shell/test/external/fixture/src/features.ts
+++ b/libs/client/shell/test/external/fixture/src/features.ts
@@ -1,0 +1,4 @@
+import {toyFeature} from '@shipfox/client-shell-fixture-feature';
+import {overrideFeature} from './features/override';
+
+export const features = [toyFeature, overrideFeature];

--- a/libs/client/shell/test/external/fixture/src/features/override-impl.tsx
+++ b/libs/client/shell/test/external/fixture/src/features/override-impl.tsx
@@ -1,0 +1,12 @@
+import {defineRoute} from '@shipfox/client-shell';
+
+function OverriddenInsights() {
+  return <h1>Overridden insights</h1>;
+}
+
+export default defineRoute({
+  component: OverriddenInsights,
+  validateSearch: (search: Record<string, unknown>) => ({
+    view: search.view === 'compact' ? ('compact' as const) : ('full' as const),
+  }),
+});

--- a/libs/client/shell/test/external/fixture/src/features/override.tsx
+++ b/libs/client/shell/test/external/fixture/src/features/override.tsx
@@ -1,11 +1,9 @@
 import {defineClientFeature} from '@shipfox/client-shell';
-import {recordProvider} from '@shipfox/client-shell-fixture-feature';
-import {useQueryClient} from '@tanstack/react-query';
-import type {PropsWithChildren} from 'react';
+import {ProviderProbe} from '@shipfox/client-shell-fixture-feature';
+import {createElement, type PropsWithChildren} from 'react';
 
 function AppFeatureProvider({children}: PropsWithChildren) {
-  recordProvider('app-feature', useQueryClient());
-  return children;
+  return createElement(ProviderProbe, {id: 'app-feature'}, children);
 }
 
 export const overrideFeature = defineClientFeature({

--- a/libs/client/shell/test/external/fixture/src/features/override.tsx
+++ b/libs/client/shell/test/external/fixture/src/features/override.tsx
@@ -1,0 +1,22 @@
+import {defineClientFeature} from '@shipfox/client-shell';
+import {recordProvider} from '@shipfox/client-shell-fixture-feature';
+import {useQueryClient} from '@tanstack/react-query';
+import type {PropsWithChildren} from 'react';
+
+function AppFeatureProvider({children}: PropsWithChildren) {
+  recordProvider('app-feature', useQueryClient());
+  return children;
+}
+
+export const overrideFeature = defineClientFeature({
+  id: 'fixture.app-override',
+  routes: [
+    {
+      path: '/workspaces/$wid/insights',
+      parent: 'workspaceLayout',
+      override: true,
+      impl: './features/override-impl',
+    },
+  ],
+  providers: [{id: 'fixture-app-provider', Component: AppFeatureProvider}],
+});

--- a/libs/client/shell/test/external/fixture/src/link-typecheck.tsx
+++ b/libs/client/shell/test/external/fixture/src/link-typecheck.tsx
@@ -1,0 +1,10 @@
+import {Link, useSearch} from '@tanstack/react-router';
+
+export function InsightsLink() {
+  const search = useSearch({from: '/workspaces/$wid/insights'});
+  return (
+    <Link to="/workspaces/$wid/insights" params={{wid: 'workspace'}} search={{view: search.view}}>
+      Insights
+    </Link>
+  );
+}

--- a/libs/client/shell/test/external/fixture/src/main.tsx
+++ b/libs/client/shell/test/external/fixture/src/main.tsx
@@ -6,12 +6,20 @@ import {
 } from '@shipfox/client-config';
 import {mergeConfigShapes} from '@shipfox/client-shell';
 import {ShellProviders} from '@shipfox/client-shell/testing';
+import {
+  type ProviderProbeEntry,
+  ProviderProbeObserver,
+} from '@shipfox/client-shell-fixture-feature';
 import {RouterProvider} from '@tanstack/react-router';
 import {createRoot} from 'react-dom/client';
 import {features} from './features.js';
 import {router} from './shipfox-app.gen.js';
 
-export function ClientApp() {
+export function createClientAppElement({
+  onProviders,
+}: {
+  onProviders?: (entries: readonly ProviderProbeEntry[]) => void;
+} = {}) {
   const config = loadConfig(mergeConfigShapes(features), {
     runtime: getWindowRuntimeConfig(),
     build: import.meta.env,
@@ -20,10 +28,11 @@ export function ClientApp() {
   setLoadedConfig(config.config);
   return (
     <ShellProviders features={features}>
+      {onProviders ? <ProviderProbeObserver onChange={onProviders} /> : null}
       <RouterProvider router={router} />
     </ShellProviders>
   );
 }
 
 const root = document.getElementById('root');
-if (root) createRoot(root).render(<ClientApp />);
+if (root) createRoot(root).render(createClientAppElement());

--- a/libs/client/shell/test/external/fixture/src/main.tsx
+++ b/libs/client/shell/test/external/fixture/src/main.tsx
@@ -1,0 +1,29 @@
+import {
+  ConfigErrorScreen,
+  getWindowRuntimeConfig,
+  loadConfig,
+  setLoadedConfig,
+} from '@shipfox/client-config';
+import {mergeConfigShapes} from '@shipfox/client-shell';
+import {ShellProviders} from '@shipfox/client-shell/testing';
+import {RouterProvider} from '@tanstack/react-router';
+import {createRoot} from 'react-dom/client';
+import {features} from './features.js';
+import {router} from './shipfox-app.gen.js';
+
+export function ClientApp() {
+  const config = loadConfig(mergeConfigShapes(features), {
+    runtime: getWindowRuntimeConfig(),
+    build: import.meta.env,
+  });
+  if (!config.ok) return <ConfigErrorScreen errors={config.errors} />;
+  setLoadedConfig(config.config);
+  return (
+    <ShellProviders features={features}>
+      <RouterProvider router={router} />
+    </ShellProviders>
+  );
+}
+
+const root = document.getElementById('root');
+if (root) createRoot(root).render(<ClientApp />);

--- a/libs/client/shell/test/external/fixture/tsconfig.json
+++ b/libs/client/shell/test/external/fixture/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "types": ["node", "vite/client", "vitest/globals"]
+  },
+  "include": ["src", "vite.config.ts", "vitest.config.ts"]
+}

--- a/libs/client/shell/test/external/fixture/vite.config.ts
+++ b/libs/client/shell/test/external/fixture/vite.config.ts
@@ -1,0 +1,16 @@
+import {shipfoxClientComposition} from '@shipfox/client-shell/vite';
+import react from '@vitejs/plugin-react';
+import {defineConfig} from 'vite';
+
+const features = process.env.SHIPFOX_COMPOSITION_COLLISION
+  ? './src/features.collision.ts'
+  : './src/features.ts';
+
+export default defineConfig({
+  build: {chunkSizeWarningLimit: 4_000},
+  plugins: [react(), shipfoxClientComposition({features})],
+  resolve: {
+    dedupe: ['react', 'react-dom', '@tanstack/react-query', '@tanstack/react-router', 'jotai'],
+    tsconfigPaths: true,
+  },
+});

--- a/libs/client/shell/test/external/fixture/vitest.config.ts
+++ b/libs/client/shell/test/external/fixture/vitest.config.ts
@@ -1,0 +1,15 @@
+import react from '@vitejs/plugin-react';
+import {defineConfig} from 'vitest/config';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    dedupe: ['react', 'react-dom', '@tanstack/react-query', '@tanstack/react-router', 'jotai'],
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    include: ['src/app.fixture.tsx'],
+    server: {deps: {inline: true}},
+  },
+});

--- a/libs/client/shell/test/external/toy-feature/package.json
+++ b/libs/client/shell/test/external/toy-feature/package.json
@@ -1,23 +1,10 @@
 {
-  "name": "@shipfox/client-config",
-  "license": "MIT",
+  "name": "@shipfox/client-shell-fixture-feature",
   "version": "0.0.1",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
-    "directory": "libs/client/config"
-  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "imports": {
-    "#*": {
-      "workspace-source": "./src/*",
-      "development": "./src/*",
-      "default": "./dist/*"
-    }
-  },
   "exports": {
     ".": {
       "development": {
@@ -28,39 +15,43 @@
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
       }
+    },
+    "./routes/*": {
+      "development": {
+        "types": "./src/routes/*.tsx",
+        "default": "./src/routes/*.tsx"
+      },
+      "default": {
+        "types": "./dist/routes/*.d.ts",
+        "default": "./dist/routes/*.js"
+      }
     }
   },
   "scripts": {
     "build": "shipfox-swc",
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
-    "test": "shipfox-vitest-run",
-    "test:watch": "shipfox-vitest-watch",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
-    "@shipfox/react-ui": "workspace:*",
+    "@shipfox/client-shell": "workspace:*",
     "@swc/helpers": "^0.5.17",
     "zod": "^4.4.3"
   },
   "peerDependencies": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "@tanstack/react-query": "^5.101.0",
+    "@tanstack/react-router": "^1.170.16",
+    "react": "^19.0.0"
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",
-    "@shipfox/client-test-setup": "workspace:*",
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",
-    "@shipfox/vitest": "workspace:*",
-    "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.3.0",
+    "@tanstack/react-query": "^5.101.0",
+    "@tanstack/react-router": "^1.170.16",
     "@types/react": "^19.1.11",
-    "@types/react-dom": "^19.1.7",
-    "jsdom": "^29.0.0",
-    "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react": "^19.1.1"
   }
 }

--- a/libs/client/shell/test/external/toy-feature/src/config.ts
+++ b/libs/client/shell/test/external/toy-feature/src/config.ts
@@ -1,0 +1,5 @@
+import {z} from 'zod';
+
+export const toyConfigShape = {
+  fixtureGreeting: z.string().min(1).describe('Greeting required by the external fixture feature.'),
+};

--- a/libs/client/shell/test/external/toy-feature/src/index.ts
+++ b/libs/client/shell/test/external/toy-feature/src/index.ts
@@ -2,7 +2,11 @@ import {defineClientFeature} from '@shipfox/client-shell';
 import {toyConfigShape} from './config.js';
 import {ToyFeatureProvider} from './provider.js';
 
-export {providerProbe, recordProvider, resetProviderProbe} from './provider.js';
+export {
+  ProviderProbe,
+  type ProviderProbeEntry,
+  ProviderProbeObserver,
+} from './provider.js';
 
 export const toyFeature = defineClientFeature({
   id: 'fixture.toy-feature',

--- a/libs/client/shell/test/external/toy-feature/src/index.ts
+++ b/libs/client/shell/test/external/toy-feature/src/index.ts
@@ -1,0 +1,60 @@
+import {defineClientFeature} from '@shipfox/client-shell';
+import {toyConfigShape} from './config.js';
+import {ToyFeatureProvider} from './provider.js';
+
+export {providerProbe, recordProvider, resetProviderProbe} from './provider.js';
+
+export const toyFeature = defineClientFeature({
+  id: 'fixture.toy-feature',
+  routes: [
+    {
+      path: '/workspaces/$wid/insights',
+      parent: 'workspaceLayout',
+      impl: '@shipfox/client-shell-fixture-feature/routes/insights',
+    },
+    {
+      path: '/workspaces/$wid/settings/primary',
+      parent: 'workspaceSettings',
+      impl: '@shipfox/client-shell-fixture-feature/routes/settings',
+    },
+    {
+      path: '/workspaces/$wid/settings/secondary',
+      parent: 'workspaceSettings',
+      impl: '@shipfox/client-shell-fixture-feature/routes/settings',
+    },
+  ],
+  providers: [{id: 'fixture-toy-provider', Component: ToyFeatureProvider}],
+  navigation: [
+    {
+      id: 'fixture-insights-first',
+      scope: 'workspace',
+      label: 'Insights first',
+      to: '/workspaces/$wid/insights',
+      order: 100,
+    },
+    {
+      id: 'fixture-insights-second',
+      scope: 'workspace',
+      label: 'Insights second',
+      to: '/workspaces/$wid/insights',
+      order: 200,
+    },
+  ],
+  settingsSections: [
+    {
+      id: 'fixture-primary-settings',
+      pathSegment: 'primary',
+      label: 'Primary settings',
+      icon: 'userLine',
+      order: 100,
+    },
+    {
+      id: 'fixture-secondary-settings',
+      pathSegment: 'secondary',
+      label: 'Secondary settings',
+      icon: 'settings3Line',
+      order: 200,
+    },
+  ],
+  configShape: toyConfigShape,
+});

--- a/libs/client/shell/test/external/toy-feature/src/provider.tsx
+++ b/libs/client/shell/test/external/toy-feature/src/provider.tsx
@@ -1,0 +1,25 @@
+import {type QueryClient, useQueryClient} from '@tanstack/react-query';
+import type {PropsWithChildren} from 'react';
+
+export const providerProbe: {
+  order: string[];
+  queryClients: QueryClient[];
+} = {
+  order: [],
+  queryClients: [],
+};
+
+export function resetProviderProbe(): void {
+  providerProbe.order.length = 0;
+  providerProbe.queryClients.length = 0;
+}
+
+export function recordProvider(id: string, queryClient: QueryClient): void {
+  providerProbe.order.push(id);
+  providerProbe.queryClients.push(queryClient);
+}
+
+export function ToyFeatureProvider({children}: PropsWithChildren) {
+  recordProvider('toy-feature', useQueryClient());
+  return children;
+}

--- a/libs/client/shell/test/external/toy-feature/src/provider.tsx
+++ b/libs/client/shell/test/external/toy-feature/src/provider.tsx
@@ -1,25 +1,33 @@
 import {type QueryClient, useQueryClient} from '@tanstack/react-query';
-import type {PropsWithChildren} from 'react';
+import {createContext, type PropsWithChildren, useContext, useEffect, useMemo} from 'react';
 
-export const providerProbe: {
-  order: string[];
-  queryClients: QueryClient[];
-} = {
-  order: [],
-  queryClients: [],
-};
-
-export function resetProviderProbe(): void {
-  providerProbe.order.length = 0;
-  providerProbe.queryClients.length = 0;
+export interface ProviderProbeEntry {
+  id: string;
+  queryClient: QueryClient;
 }
 
-export function recordProvider(id: string, queryClient: QueryClient): void {
-  providerProbe.order.push(id);
-  providerProbe.queryClients.push(queryClient);
+const ProviderProbeContext = createContext<readonly ProviderProbeEntry[]>([]);
+
+export function ProviderProbe({id, children}: PropsWithChildren<{id: string}>) {
+  const parentEntries = useContext(ProviderProbeContext);
+  const queryClient = useQueryClient();
+  const entries = useMemo(
+    () => [...parentEntries, {id, queryClient}],
+    [id, parentEntries, queryClient],
+  );
+  return <ProviderProbeContext value={entries}>{children}</ProviderProbeContext>;
+}
+
+export function ProviderProbeObserver({
+  onChange,
+}: {
+  onChange: (entries: readonly ProviderProbeEntry[]) => void;
+}) {
+  const entries = useContext(ProviderProbeContext);
+  useEffect(() => onChange(entries), [entries, onChange]);
+  return null;
 }
 
 export function ToyFeatureProvider({children}: PropsWithChildren) {
-  recordProvider('toy-feature', useQueryClient());
-  return children;
+  return <ProviderProbe id="toy-feature">{children}</ProviderProbe>;
 }

--- a/libs/client/shell/test/external/toy-feature/src/routes/insights.tsx
+++ b/libs/client/shell/test/external/toy-feature/src/routes/insights.tsx
@@ -1,0 +1,7 @@
+import {defineRoute} from '@shipfox/client-shell';
+
+function ToyInsights() {
+  return <h1>Toy insights</h1>;
+}
+
+export default defineRoute({component: ToyInsights});

--- a/libs/client/shell/test/external/toy-feature/src/routes/settings.tsx
+++ b/libs/client/shell/test/external/toy-feature/src/routes/settings.tsx
@@ -1,0 +1,7 @@
+import {defineRoute} from '@shipfox/client-shell';
+
+function ToySettings() {
+  return <h1>Toy settings</h1>;
+}
+
+export default defineRoute({component: ToySettings});

--- a/libs/client/shell/test/external/toy-feature/tsconfig.build.json
+++ b/libs/client/shell/test/external/toy-feature/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@shipfox/ts-config/react",
+  "compilerOptions": { "rootDir": "src", "outDir": "dist" },
+  "include": ["src"]
+}

--- a/libs/client/shell/test/external/toy-feature/tsconfig.json
+++ b/libs/client/shell/test/external/toy-feature/tsconfig.json
@@ -1,0 +1,1 @@
+{ "files": [], "references": [{ "path": "tsconfig.build.json" }] }

--- a/libs/client/shell/test/external/verify.mjs
+++ b/libs/client/shell/test/external/verify.mjs
@@ -1,0 +1,274 @@
+import {spawn} from 'node:child_process';
+import {cp, mkdir, mkdtemp, readdir, readFile, realpath, rm, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {basename, join, resolve, sep} from 'node:path';
+import {fileURLToPath, pathToFileURL} from 'node:url';
+
+const repositoryRoot = resolve(fileURLToPath(new URL('../../../../..', import.meta.url)));
+const externalRoot = fileURLToPath(new URL('.', import.meta.url));
+const fixtureTemplate = join(externalRoot, 'fixture');
+const roots = ['@shipfox/client-shell', '@shipfox/client-shell-fixture-feature'];
+const REGISTRY_SHIPFOX_PACKAGE_PATTERN = /^@shipfox\+[^@]+@\d/u;
+const linkMode = process.argv.includes('--link');
+
+if (process.argv.some((argument) => argument.startsWith('--') && argument !== '--link')) {
+  throw new Error('Usage: node verify.mjs [--link]');
+}
+
+const {computePublicationClosure, readWorkspacePackages} = await import(
+  pathToFileURL(join(repositoryRoot, 'tools/application-release/dist/package-closure.js')).href
+);
+const workspacePackages = readWorkspacePackages(repositoryRoot);
+const closure = computePublicationClosure(workspacePackages, roots);
+const temporaryRoot = await mkdtemp(join(tmpdir(), 'shipfox-client-composition-'));
+const fixtureRoot = join(temporaryRoot, 'fixture');
+
+try {
+  await cp(fixtureTemplate, fixtureRoot, {recursive: true});
+  const packageSpecs = linkMode
+    ? linkedPackageSpecs(closure, workspacePackages)
+    : await packedPackageSpecs(closure, workspacePackages, temporaryRoot);
+  await configureFixture(fixtureRoot, packageSpecs);
+  await run('pnpm', ['install', '--prefer-offline', '--ignore-scripts'], fixtureRoot);
+
+  if (linkMode) await validateLinkedPackages(fixtureRoot, closure, workspacePackages);
+  else {
+    await validateInstalledPackages(fixtureRoot, closure, workspacePackages);
+    await validateNoRegistryShipfoxPackages(fixtureRoot);
+    await validateDefaultPackageResolution(fixtureRoot);
+  }
+
+  await run('pnpm', ['exec', 'vite', 'build'], fixtureRoot);
+  await validateGeneratedModule(fixtureRoot);
+  await run('pnpm', ['exec', 'vitest', 'run'], fixtureRoot);
+  await run('pnpm', ['exec', 'tsc', '--noEmit'], fixtureRoot);
+
+  const collision = await run('pnpm', ['exec', 'vite', 'build'], fixtureRoot, {
+    capture: true,
+    allowFailure: true,
+    env: {SHIPFOX_COMPOSITION_COLLISION: '1'},
+  });
+  if (collision.code === 0) throw new Error('Collision fixture unexpectedly built successfully.');
+  const collisionOutput = `${collision.stdout}\n${collision.stderr}`;
+  for (const expected of [
+    '/workspaces/$wid/insights',
+    'fixture.toy-feature',
+    'fixture.unapproved-collision',
+  ]) {
+    if (!collisionOutput.includes(expected)) {
+      throw new Error(
+        `Collision output did not include ${JSON.stringify(expected)}.\n${collisionOutput}`,
+      );
+    }
+  }
+  const collisionLine = collisionOutput
+    .split('\n')
+    .find((line) => line.includes('is contributed by both features'))
+    ?.trim();
+
+  process.stdout.write(
+    `Verified external client composition in ${linkMode ? 'linked' : 'packed-tarball'} mode.\n`,
+  );
+  if (collisionLine) process.stdout.write(`Collision: ${collisionLine}\n`);
+} finally {
+  await rm(temporaryRoot, {recursive: true, force: true});
+}
+
+function linkedPackageSpecs(names, packages) {
+  return Object.fromEntries(
+    names.map((name) => {
+      const workspacePackage = requiredPackage(packages, name);
+      return [name, `link:${workspacePackage.directory}`];
+    }),
+  );
+}
+
+async function packedPackageSpecs(names, packages, root) {
+  const tarballRoot = join(root, 'tarballs');
+  await mkdir(tarballRoot);
+  const tarballs = await mapWithConcurrency(names, 4, async (name) => {
+    const workspacePackage = requiredPackage(packages, name);
+    const tarball = join(tarballRoot, `${safePackageName(name)}.tgz`);
+    await run('pnpm', ['pack', '--out', tarball], workspacePackage.directory, {capture: true});
+    return [name, `file:${tarball}`];
+  });
+  return Object.fromEntries(tarballs);
+}
+
+async function configureFixture(root, packageSpecs) {
+  const manifestPath = join(root, 'package.json');
+  const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+  manifest.dependencies = {...manifest.dependencies, ...packageSpecs};
+  await Promise.all([
+    writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`),
+    writeFile(
+      join(root, 'pnpm-workspace.yaml'),
+      `packages:\n  - .\noverrides:\n${Object.entries(packageSpecs)
+        .map(([name, specifier]) => `  ${JSON.stringify(name)}: ${JSON.stringify(specifier)}`)
+        .join('\n')}\n`,
+    ),
+  ]);
+}
+
+async function validateLinkedPackages(root, names, packages) {
+  for (const name of names) {
+    const installedRoot = await realpath(join(root, 'node_modules', name));
+    const expectedRoot = await realpath(requiredPackage(packages, name).directory);
+    if (installedRoot !== expectedRoot) {
+      throw new Error(`Linked ${name} resolved to ${installedRoot}; expected ${expectedRoot}`);
+    }
+  }
+}
+
+async function validateInstalledPackages(root, names, packages) {
+  const realFixtureRoot = await realpath(root);
+  for (const name of names) {
+    const installedManifestPath = join(root, 'node_modules', name, 'package.json');
+    const installedManifest = JSON.parse(await readFile(installedManifestPath, 'utf8'));
+    const expectedManifest = requiredPackage(packages, name).manifest;
+    if (installedManifest.version !== expectedManifest.version) {
+      throw new Error(
+        `Packed ${name} has version ${installedManifest.version}; expected ${expectedManifest.version}`,
+      );
+    }
+    const workspaceRange = findWorkspaceRange(installedManifest);
+    if (workspaceRange)
+      throw new Error(`Packed ${name} contains a workspace range at ${workspaceRange}`);
+    validateDefaultInternalImports(name, installedManifest);
+    const installedRoot = await realpath(join(root, 'node_modules', name));
+    if (!installedRoot.startsWith(realFixtureRoot)) {
+      throw new Error(`Packed ${name} resolved outside the external consumer`);
+    }
+  }
+}
+
+function validateDefaultInternalImports(name, manifest) {
+  const internalImports = manifest.imports?.['#*'];
+  if (internalImports === undefined) return;
+  if (
+    !internalImports ||
+    typeof internalImports !== 'object' ||
+    Array.isArray(internalImports) ||
+    internalImports.default !== './dist/*'
+  ) {
+    throw new Error(`Packed ${name} does not map the default #* condition to ./dist/*`);
+  }
+}
+
+async function validateDefaultPackageResolution(root) {
+  const specifiers = [
+    '@shipfox/client-shell',
+    '@shipfox/client-shell/testing',
+    '@shipfox/client-shell/vite',
+    '@shipfox/client-shell-fixture-feature',
+    '@shipfox/client-shell-fixture-feature/routes/insights',
+  ];
+  const resolution = await run(
+    process.execPath,
+    [
+      '--input-type=module',
+      '--eval',
+      `const specifiers = ${JSON.stringify(specifiers)};
+const resolved = Object.fromEntries(specifiers.map((specifier) => [specifier, import.meta.resolve(specifier)]));
+process.stdout.write(JSON.stringify(resolved));`,
+    ],
+    root,
+    {capture: true},
+  );
+  const resolved = JSON.parse(resolution.stdout);
+  for (const specifier of specifiers) {
+    const resolvedPath = fileURLToPath(resolved[specifier]);
+    if (!resolvedPath.split(sep).includes('dist')) {
+      throw new Error(`Packed ${specifier} resolved to source instead of dist: ${resolvedPath}`);
+    }
+  }
+}
+
+async function validateNoRegistryShipfoxPackages(root) {
+  const virtualStore = await readdir(join(root, 'node_modules/.pnpm'), {withFileTypes: true});
+  const registryPackages = virtualStore
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => REGISTRY_SHIPFOX_PACKAGE_PATTERN.test(name));
+  if (registryPackages.length) {
+    throw new Error(
+      `External consumer used registry Shipfox packages: ${registryPackages.join(', ')}`,
+    );
+  }
+}
+
+async function validateGeneratedModule(root) {
+  const generated = await readFile(join(root, 'src/shipfox-app.gen.ts'), 'utf8');
+  for (const expected of ['/workspaces/$wid/insights', './features/override-impl']) {
+    if (!generated.includes(expected)) {
+      throw new Error(`Generated module did not include ${JSON.stringify(expected)}.`);
+    }
+  }
+}
+
+function requiredPackage(packages, name) {
+  const workspacePackage = packages.get(name);
+  if (!workspacePackage) throw new Error(`Missing workspace package: ${name}`);
+  return workspacePackage;
+}
+
+function findWorkspaceRange(value, path = 'package.json') {
+  if (typeof value === 'string') return value.startsWith('workspace:') ? path : undefined;
+  if (!value || typeof value !== 'object') return undefined;
+  for (const [key, child] of Object.entries(value)) {
+    const found = findWorkspaceRange(child, `${path}.${key}`);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+function safePackageName(name) {
+  return name.replace('@shipfox/', '').replaceAll('/', '-');
+}
+
+async function mapWithConcurrency(values, concurrency, mapper) {
+  const results = new Array(values.length);
+  let nextIndex = 0;
+
+  async function worker() {
+    while (nextIndex < values.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await mapper(values[index], index);
+    }
+  }
+
+  await Promise.all(Array.from({length: concurrency}, () => worker()));
+  return results;
+}
+
+function run(command, args, cwd, options = {}) {
+  const {allowFailure = false, capture = false, env = {}} = options;
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      env: {...process.env, ...env},
+      stdio: capture ? ['ignore', 'pipe', 'pipe'] : 'inherit',
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr?.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      const result = {code: code ?? 1, stdout, stderr};
+      if (code === 0 || allowFailure) resolvePromise(result);
+      else {
+        reject(
+          new Error(
+            `${basename(command)} ${args.join(' ')} exited with code ${code}${capture ? `\n${stdout}\n${stderr}` : ''}`,
+          ),
+        );
+      }
+    });
+  });
+}

--- a/libs/client/shell/tsconfig.build.json
+++ b/libs/client/shell/tsconfig.build.json
@@ -1,6 +1,10 @@
 {
   "extends": "@shipfox/ts-config/react",
-  "compilerOptions": { "rootDir": "src", "outDir": "dist" },
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "customConditions": ["workspace-source"]
+  },
   "include": ["src"],
   "exclude": ["**/*.test.tsx", "**/*.test.ts"]
 }

--- a/libs/client/shell/tsconfig.test.json
+++ b/libs/client/shell/tsconfig.test.json
@@ -7,5 +7,5 @@
     }
   },
   "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
-  "exclude": []
+  "exclude": ["test/external"]
 }

--- a/libs/client/ui/package.json
+++ b/libs/client/ui/package.json
@@ -12,7 +12,11 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "imports": {
-    "#*": "./src/*"
+    "#*": {
+      "workspace-source": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/client/ui/tsconfig.build.json
+++ b/libs/client/ui/tsconfig.build.json
@@ -2,7 +2,8 @@
   "extends": "@shipfox/ts-config/react",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "customConditions": ["workspace-source"]
   },
   "include": ["src"],
   "exclude": ["**/*.test.tsx", "**/*.test.ts"]

--- a/libs/shared/react/ui/package.json
+++ b/libs/shared/react/ui/package.json
@@ -11,7 +11,11 @@
   "type": "module",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "workspace-source": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "style": "dist/styles.css",
   "sideEffects": [

--- a/libs/shared/react/ui/tsconfig.build.json
+++ b/libs/shared/react/ui/tsconfig.build.json
@@ -2,7 +2,8 @@
   "extends": "@shipfox/ts-config/react",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "customConditions": ["workspace-source"]
   },
   "include": ["src"],
   "exclude": ["**/*.test.tsx", "**/*.test.ts", "**/*.stories.tsx", "**/build-css-entry.ts"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4482,6 +4482,9 @@ importers:
       '@swc/helpers':
         specifier: ^0.5.17
         version: 0.5.23
+      '@tanstack/router-core':
+        specifier: ^1.171.13
+        version: 1.171.13
       jiti:
         specifier: ^2.7.0
         version: 2.7.0
@@ -4543,6 +4546,43 @@ importers:
       vite:
         specifier: ^8.0.3
         version: 8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+
+  libs/client/shell/test/external/toy-feature:
+    dependencies:
+      '@shipfox/client-shell':
+        specifier: workspace:*
+        version: link:../../..
+      '@swc/helpers':
+        specifier: ^0.5.17
+        version: 0.5.23
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../../../../tools/biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../../../../tools/typescript
+      '@tanstack/react-query':
+        specifier: ^5.101.0
+        version: 5.101.0(react@19.2.7)
+      '@tanstack/react-router':
+        specifier: ^1.170.16
+        version: 1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@types/react':
+        specifier: ^19.1.11
+        version: 19.2.17
+      react:
+        specifier: ^19.1.1
+        version: 19.2.7
 
   libs/client/test-setup:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,5 +20,6 @@ packages:
   - "infra/**"
   - "tools/**"
   - "turbo/**"
+  - "!libs/client/shell/test/external/fixture/**"
   - "!**/vite/types/**"
   - "!**/node_modules/**"


### PR DESCRIPTION
Prove the client composition contract from an out-of-workspace Vite app installed from packed tarballs.

Workspace source conditions could previously hide missing runtime and declaration dependencies. The external fixture computes the Shipfox package closure, installs only local tarballs, and exercises feature discovery, overrides, provider composition, shared query state, configuration, typed routes, and duplicate-route diagnostics. It also rejects workspace or registry fallbacks and verifies that default package resolution uses compiled `dist` entrypoints.

To make that clean consumer work, the affected client packages now use conditional internal import maps: workspace and development builds resolve source, while default consumers resolve compiled output. The shell also declares the router-core dependency named by its emitted declarations, and the public react-ui fix includes a patch changeset.

The verifier remains a manual evidence gate under `libs/client/shell/test/external`; this adds no recurring CI workflow or test time. The Docker manifest rewriting merged separately only changes pruned runtime manifests, so it cannot replace correct import maps in published tarballs.

Closes ENG-962

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an external Vite fixture and manual verifier to prove client composition from outside the workspace (linked and packed modes), now render‑pure to avoid StrictMode duplicates. Aligns package resolution so default consumers use compiled `dist` and adds a missing typed dependency; satisfies ENG-962.

- **New Features**
  - Adds a Vite fixture and `verify.mjs` runner under `libs/client/shell/test/external` with linked (`--link`) and packed‑tarball modes.
  - Verifies build, UI probes (override works), provider nesting with a shared `QueryClient`, nav/settings order, config merge/validation, collision failure without `override: true`, and consumer `tsc --noEmit` with typed `Link`/`useSearch`.

- **Bug Fixes**
  - Sets conditional `#*` import maps so `default` resolves `./dist/*` and adds `customConditions: ["workspace-source"]` in build tsconfigs across `@shipfox/client-shell`, `@shipfox/client-auth`, `@shipfox/client-config`, `@shipfox/client-ui`, and patches compiled internal imports in `@shipfox/react-ui`.
  - Declares `@tanstack/router-core` in `@shipfox/client-shell` to match emitted anchor types.
  - Makes the external fixture render‑pure: bootstraps config before React render and captures provider evidence via an observer to avoid StrictMode re‑render duplication.

<sup>Written for commit 8801ac61b87a7ad679b3d00bc3ec1850288fc7cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

