### PR TITLE
[docs] Fix theme-aware video hydration

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -16,7 +16,8 @@
     "start": "next start --port ${SHIPFOX_DOCS_PORT:-3500}",
     "type": "shipfox-tsc-check",
     "generate": "tsx --conditions=development scripts/generate.mjs",
-    "test": "pnpm generate && tsx scripts/check-writing.mjs && tsx scripts/check-links.mjs && tsx scripts/check-workflow-schema.mjs",
+    "test": "pnpm generate && pnpm test:unit && tsx scripts/check-writing.mjs && tsx scripts/check-links.mjs && tsx scripts/check-workflow-schema.mjs",
+    "test:unit": "tsx --test",
     "postinstall": "fumadocs-mdx"
   },
   "dependencies": {

--- a/apps/docs/src/app/components/docs-video.test.ts
+++ b/apps/docs/src/app/components/docs-video.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import {describe, it} from 'node:test';
+import {selectVideoMedia} from './docs-video';
+
+describe('selectVideoMedia', () => {
+  const light = {src: '/light.mp4', poster: '/light.jpg'};
+  const dark = {src: '/dark.mp4', poster: '/dark.jpg'};
+
+  it('keeps the server and initial client render on the same media', () => {
+    const serverMedia = selectVideoMedia({mounted: false, resolvedTheme: undefined, light, dark});
+    const initialClientMedia = selectVideoMedia({
+      mounted: false,
+      resolvedTheme: 'dark',
+      light,
+      dark,
+    });
+
+    assert.deepEqual(initialClientMedia, serverMedia);
+    assert.deepEqual(initialClientMedia, light);
+  });
+
+  it('uses the resolved dark theme after the client mounts', () => {
+    const media = selectVideoMedia({mounted: true, resolvedTheme: 'dark', light, dark});
+
+    assert.deepEqual(media, dark);
+  });
+
+  it('uses the resolved light theme after the client mounts', () => {
+    const media = selectVideoMedia({mounted: true, resolvedTheme: 'light', light, dark});
+
+    assert.deepEqual(media, light);
+  });
+});

--- a/apps/docs/src/app/components/docs-video.tsx
+++ b/apps/docs/src/app/components/docs-video.tsx
@@ -26,6 +26,25 @@ interface DocsVideoProps {
   height?: number;
 }
 
+interface VideoMedia {
+  src?: string;
+  poster?: string;
+}
+
+export function selectVideoMedia({
+  mounted,
+  resolvedTheme,
+  light,
+  dark,
+}: {
+  mounted: boolean;
+  resolvedTheme?: string;
+  light: VideoMedia;
+  dark: VideoMedia;
+}): VideoMedia {
+  return mounted && resolvedTheme === 'dark' ? dark : light;
+}
+
 /**
  * Autoplaying, muted, looping product clip that sits inline like an image and
  * opens a larger lightbox on click (Escape or a backdrop click closes it),
@@ -43,6 +62,7 @@ export function DocsVideo({
   height,
 }: DocsVideoProps) {
   const [expanded, setExpanded] = useState(false);
+  const [mounted, setMounted] = useState(false);
   const {resolvedTheme} = useTheme();
   const triggerRef = useRef<HTMLButtonElement>(null);
   const dialogRef = useRef<HTMLDivElement>(null);
@@ -51,10 +71,15 @@ export function DocsVideo({
   const resolvedLightPoster = withBase(lightPoster ?? poster ?? darkPoster);
   const resolvedDarkPoster = withBase(darkPoster ?? poster ?? lightPoster);
   const hasDarkVariant = resolvedDarkSrc !== resolvedLightSrc;
-  const activeSrc = hasDarkVariant && resolvedTheme === 'dark' ? resolvedDarkSrc : resolvedLightSrc;
-  const activePoster =
-    hasDarkVariant && resolvedTheme === 'dark' ? resolvedDarkPoster : resolvedLightPoster;
+  const activeMedia = selectVideoMedia({
+    mounted,
+    resolvedTheme: hasDarkVariant ? resolvedTheme : undefined,
+    light: {src: resolvedLightSrc, poster: resolvedLightPoster},
+    dark: {src: resolvedDarkSrc, poster: resolvedDarkPoster},
+  });
   const dialogLabel = label ?? 'Enlarged video';
+
+  useEffect(() => setMounted(true), []);
 
   useEffect(() => {
     if (!expanded) return;
@@ -102,9 +127,9 @@ export function DocsVideo({
         className="group relative my-6 block w-full cursor-zoom-in appearance-none border-0 bg-transparent p-0"
       >
         <ThemedVideo
-          key={activeSrc}
-          src={activeSrc}
-          poster={activePoster}
+          key={activeMedia.src}
+          src={activeMedia.src}
+          poster={activeMedia.poster}
           width={width}
           height={height}
         />
@@ -130,7 +155,12 @@ export function DocsVideo({
               aria-label="Close the enlarged video"
               className="absolute inset-0 cursor-zoom-out appearance-none border-0 bg-black/80 p-0 backdrop-blur-sm"
             />
-            <ThemedVideo key={activeSrc} src={activeSrc} poster={activePoster} expanded />
+            <ThemedVideo
+              key={activeMedia.src}
+              src={activeMedia.src}
+              poster={activeMedia.poster}
+              expanded
+            />
           </div>,
           document.body,
         )}


### PR DESCRIPTION
Fix the docs hero video so the server and browser render the same media during hydration.

The server cannot know the saved or system theme, so it rendered the light source while a dark-theme browser could select the dark source on its first React render. This delays theme-based selection until mount, preserves the single active video, and adds regression coverage for initial and post-mount selection.

Rendering both theme videos and hiding one with CSS was avoided because it would duplicate the loading and playback cost of the autoplaying media.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes theme-aware hydration for the docs hero video by keeping SSR and the first client render on the same media, then applying the resolved theme after mount. This removes flicker and prevents duplicate media loading.

- **Bug Fixes**
  - Defer theme-based selection until mount using `selectVideoMedia`.
  - Keep a single active video (no double-rendering of light/dark variants).
  - Add unit tests for initial vs post-mount selection (`docs-video.test.ts`).
  - Update `apps/docs/package.json` test script to include `pnpm test:unit` (`tsx --test`).

<sup>Written for commit 3101f3fe0072a34378e7064e34e18c4a2d9522f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

