### PR TITLE
Add configurable login methods

### DIFF
--- a/.changeset/bright-lemons-login.md
+++ b/.changeset/bright-lemons-login.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/node-module": minor
+"@shipfox/api-server": minor
+"@shipfox/api-auth": minor
+---
+
+Adds module login-method declarations, validates server compositions before startup, and adds password-login route configuration.

--- a/libs/api/auth/README.md
+++ b/libs/api/auth/README.md
@@ -46,6 +46,7 @@ Required environment:
 | `AUTH_REFRESH_TOKEN_EXPIRES_IN_DAYS` | `14` | Refresh token and cookie lifetime. |
 | `AUTH_REFRESH_ROTATION_GRACE_SECONDS` | `30` | Grace window for accepting a just-rotated refresh token during concurrent refreshes. |
 | `AUTH_REFRESH_COOKIE_NAME` | `shipfox_refresh_token` | HTTP cookie name for refresh sessions. |
+| `AUTH_PASSWORD_ENABLED` | `true` | Enables password and email-verification routes. Set to `false` when another module provides login. Server construction fails if no login method is available. |
 | `RATE_LIMIT_IDENTIFIER_SECRET` | none | Optional secret used to HMAC identifiers before storing rate-limit counters. When unset, the module derives a stable key from `AUTH_JWT_SECRET`. |
 | `CLIENT_BASE_URL` | `http://localhost:5173` | Base URL used in email verification and password reset links. |
 | `MAILER_TRANSPORT` | `console` | Mail transport. Set to `smtp` to send real mail. |
@@ -54,6 +55,8 @@ Required environment:
 | `SMTP_PORT` | `587` | SMTP server port. |
 | `SMTP_USER` | none | Optional SMTP user. |
 | `SMTP_PASSWORD` | none | Optional SMTP password. |
+
+When `AUTH_PASSWORD_ENABLED=false`, the module does not register signup, login, password-reset, password-change, or email-verification routes. Refresh, logout, and current-session routes stay available. Another module must contribute a login method before the API server starts.
 
 ## Security model
 
@@ -197,6 +200,8 @@ All routes are mounted under `/auth`.
 
 Protected routes use the `Authorization: Bearer <token>` header. The refresh flow uses an HTTP-only cookie on the `/auth` path.
 
+When password login is disabled, the password and email-verification rows in this table return `404`. Refresh, logout, and `me` remain registered.
+
 > [!IMPORTANT]
 > Refresh cookies are set with `secure: true`, `httpOnly: true`, and `sameSite: "lax"`. Local browser tests need HTTPS or a test path that handles secure cookies.
 
@@ -279,6 +284,8 @@ It makes an active, verified user with no password hash. If the email already
 exists, it returns that user unchanged. It does not change the name, email,
 status, verification state, or password. Repeated and concurrent callbacks are
 safe.
+
+This pre-verified user state lets an external login method create a session when password login and email-verification routes are disabled.
 
 `createSessionForUser` accepts either a `userId` or an `email`. It only creates
 a session for an active, verified user. It can throw `UserNotFoundError`,

--- a/libs/api/auth/src/config.ts
+++ b/libs/api/auth/src/config.ts
@@ -1,4 +1,4 @@
-import {createConfig, num, str} from '@shipfox/config';
+import {bool, createConfig, num, str} from '@shipfox/config';
 import {createConsoleMailer, createSmtpMailer, type Mailer} from '@shipfox/node-mailer';
 
 export const config = createConfig({
@@ -34,6 +34,10 @@ export const config = createConfig({
   AUTH_REFRESH_COOKIE_NAME: str({
     desc: 'Name of the browser cookie that stores the refresh token.',
     default: 'shipfox_refresh_token',
+  }),
+  AUTH_PASSWORD_ENABLED: bool({
+    desc: 'Whether password login is available. Use true or false. Defaults to true. When false, password and email-verification routes are not registered, and server startup requires another module to contribute a login method.',
+    default: true,
   }),
   RATE_LIMIT_IDENTIFIER_SECRET: str({
     desc: 'Optional secret used to HMAC identifiers before storing rate-limit counters. Leave it unset to derive a stable key from AUTH_JWT_SECRET.',

--- a/libs/api/auth/src/index.test.ts
+++ b/libs/api/auth/src/index.test.ts
@@ -4,6 +4,7 @@ import {
   authEventSchemas,
 } from '@shipfox/api-auth-dto';
 import {authModule} from './index.js';
+import {passwordLoginMethods} from './login-methods.js';
 
 vi.mock('#config.js', () => ({
   config: {
@@ -14,12 +15,19 @@ vi.mock('#config.js', () => ({
     AUTH_REFRESH_TOKEN_EXPIRES_IN_DAYS: 14,
     AUTH_REFRESH_ROTATION_GRACE_SECONDS: 30,
     AUTH_REFRESH_COOKIE_NAME: 'shipfox_refresh_token',
+    AUTH_PASSWORD_ENABLED: true,
     CLIENT_BASE_URL: 'https://app.example.test',
   },
   mailer: {send: vi.fn()},
 }));
 
 describe('authModule', () => {
+  test('declares password login only when password login is enabled', () => {
+    expect(passwordLoginMethods(true)).toEqual([{id: 'password'}]);
+    expect(passwordLoginMethods(false)).toEqual([]);
+    expect(authModule.loginMethods).toEqual([{id: 'password'}]);
+  });
+
   test('registers auth email outbox publisher and subscribers', () => {
     const publisher = authModule.publishers?.find((pub) => pub.name === 'auth');
     const events = authModule.subscribers?.map((subscriber) => subscriber.event);

--- a/libs/api/auth/src/index.ts
+++ b/libs/api/auth/src/index.ts
@@ -6,6 +6,7 @@ import {
 } from '@shipfox/api-auth-dto';
 import type {ShipfoxModule} from '@shipfox/node-module';
 import {subscriberFactory} from '@shipfox/node-module';
+import {config} from '#config.js';
 import {db} from '#db/db.js';
 import {migrationsPath} from '#db/migrations.js';
 import {authOutbox} from '#db/schema/outbox.js';
@@ -18,6 +19,7 @@ import {
   onEmailVerificationSendRequested,
   onPasswordResetSendRequested,
 } from '#presentation/subscribers/index.js';
+import {passwordLoginMethods} from './login-methods.js';
 
 export type {JobLeaseTokenClaims, RunnerSessionTokenClaims} from '@shipfox/api-auth-dto';
 export type {
@@ -59,6 +61,7 @@ export const authModule: ShipfoxModule = {
   name: 'auth',
   database: {db, migrationsPath},
   auth: [createJwtAuthMethod(), createLeaseTokenAuthMethod(), createRunnerSessionAuthMethod()],
+  loginMethods: passwordLoginMethods(config.AUTH_PASSWORD_ENABLED),
   routes: [authRoutes],
   e2eRoutes: [authE2eRoutes],
   publishers: [{name: 'auth', table: authOutbox, db, eventSchemas: authEventSchemas}],

--- a/libs/api/auth/src/login-methods.ts
+++ b/libs/api/auth/src/login-methods.ts
@@ -1,0 +1,5 @@
+import type {LoginMethod} from '@shipfox/node-module';
+
+export function passwordLoginMethods(passwordEnabled: boolean): LoginMethod[] {
+  return passwordEnabled ? [{id: 'password'}] : [];
+}

--- a/libs/api/auth/src/presentation/auth/refresh-cookie.test.ts
+++ b/libs/api/auth/src/presentation/auth/refresh-cookie.test.ts
@@ -5,6 +5,7 @@ vi.mock('#config.js', () => ({
   config: {
     AUTH_REFRESH_COOKIE_NAME: 'shipfox_refresh_token',
     AUTH_REFRESH_TOKEN_EXPIRES_IN_DAYS: 14,
+    AUTH_PASSWORD_ENABLED: true,
   },
 }));
 

--- a/libs/api/auth/src/presentation/routes/index.test.ts
+++ b/libs/api/auth/src/presentation/routes/index.test.ts
@@ -1,0 +1,67 @@
+import {createApp} from '@shipfox/node-fastify';
+import {createJwtAuthMethod} from '#presentation/auth/jwt-auth.js';
+import {buildAuthRoutes} from './index.js';
+
+const disabledPasswordPaths = [
+  '/auth/signup',
+  '/auth/verify-email/confirm',
+  '/auth/verify-email/resend',
+  '/auth/login',
+  '/auth/change-password',
+  '/auth/password-reset',
+  '/auth/password-reset/confirm',
+];
+
+describe('buildAuthRoutes', () => {
+  test('preserves the default route table when password login is enabled', () => {
+    const routes = buildAuthRoutes(true);
+
+    expect(routes.routes.map((route) => ('path' in route ? route.path : route.prefix))).toEqual([
+      '/signup',
+      '/verify-email/confirm',
+      '/verify-email/resend',
+      '/login',
+      '/refresh',
+      '/logout',
+      '/me',
+      '/change-password',
+      '/password-reset',
+      '/password-reset/confirm',
+    ]);
+  });
+
+  test('keeps only session lifecycle routes when password login is disabled', () => {
+    const routes = buildAuthRoutes(false);
+
+    expect(routes.routes.map((route) => ('path' in route ? route.path : route.prefix))).toEqual([
+      '/refresh',
+      '/logout',
+      '/me',
+    ]);
+  });
+
+  test('does not register password or email-verification routes when password login is disabled', async () => {
+    const app = await createApp({
+      auth: [createJwtAuthMethod()],
+      routes: [buildAuthRoutes(false)],
+      swagger: false,
+    });
+
+    try {
+      for (const url of disabledPasswordPaths) {
+        const response = await app.inject({method: 'POST', url});
+        expect(response.statusCode).toBe(404);
+      }
+
+      const refresh = await app.inject({method: 'POST', url: '/auth/refresh'});
+      const logout = await app.inject({method: 'POST', url: '/auth/logout'});
+      const me = await app.inject({method: 'GET', url: '/auth/me'});
+
+      expect(refresh.statusCode).not.toBe(404);
+      expect(logout.statusCode).not.toBe(404);
+      expect(me.statusCode).not.toBe(404);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/libs/api/auth/src/presentation/routes/index.ts
+++ b/libs/api/auth/src/presentation/routes/index.ts
@@ -1,4 +1,5 @@
 import type {RouteGroup} from '@shipfox/node-fastify';
+import {config} from '#config.js';
 import {authCookiePlugin} from '#presentation/auth/refresh-cookie.js';
 import {verifyEmailConfirmRoute} from './email-verification/verify-email-confirm.js';
 import {verifyEmailResendRoute} from './email-verification/verify-email-resend.js';
@@ -11,19 +12,24 @@ import {logoutRoute} from './session/logout.js';
 import {meRoute} from './session/me.js';
 import {refreshRoute} from './session/refresh.js';
 
-export const authRoutes: RouteGroup = {
-  prefix: '/auth',
-  plugins: [authCookiePlugin],
-  routes: [
-    signupRoute,
-    verifyEmailConfirmRoute,
-    verifyEmailResendRoute,
-    loginRoute,
-    refreshRoute,
-    logoutRoute,
-    meRoute,
-    changePasswordRoute,
-    passwordResetRequestRoute,
-    passwordResetConfirmRoute,
-  ],
-};
+export function buildAuthRoutes(passwordEnabled: boolean): RouteGroup {
+  const passwordRoutes = passwordEnabled
+    ? [signupRoute, verifyEmailConfirmRoute, verifyEmailResendRoute, loginRoute]
+    : [];
+
+  return {
+    prefix: '/auth',
+    plugins: [authCookiePlugin],
+    routes: [
+      ...passwordRoutes,
+      refreshRoute,
+      logoutRoute,
+      meRoute,
+      ...(passwordEnabled
+        ? [changePasswordRoute, passwordResetRequestRoute, passwordResetConfirmRoute]
+        : []),
+    ],
+  };
+}
+
+export const authRoutes = buildAuthRoutes(config.AUTH_PASSWORD_ENABLED);

--- a/libs/api/auth/test/routes.ts
+++ b/libs/api/auth/test/routes.ts
@@ -81,6 +81,7 @@ vi.mock('#config.js', () => ({
     AUTH_REFRESH_TOKEN_EXPIRES_IN_DAYS: 14,
     AUTH_REFRESH_ROTATION_GRACE_SECONDS: 30,
     AUTH_REFRESH_COOKIE_NAME: 'shipfox_refresh_token',
+    AUTH_PASSWORD_ENABLED: true,
     CLIENT_BASE_URL: testConfig.clientBaseUrl,
   },
   mailer: testConfig.mailer,

--- a/libs/api/server/README.md
+++ b/libs/api/server/README.md
@@ -40,7 +40,7 @@ node --import @shipfox/api-server/instrumentation ./dist/index.js
 
 ## Behavior Notes
 
-- **Custom composition**: Pass a module list to make a custom server.
+- **Custom composition**: Pass a module list to make a custom server. A module must declare a unique `loginMethods` entry. `createServer` throws before startup side effects when no login method is available.
 - **Signal handling**: `createServer` does not install signal handlers.
 - **Lifecycle**: `start` starts workers before the HTTP listener. `stop` is safe to call again.
 - **Process scope**: Run one server at a time.

--- a/libs/api/server/src/server.test.ts
+++ b/libs/api/server/src/server.test.ts
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => {
     createE2eAdminAuthMethod: vi.fn(),
     createE2eRouteGroup: vi.fn(),
     createPostgresClient: vi.fn(),
+    aggregateLoginMethods: vi.fn(),
     initializeModules: vi.fn(),
     listen: vi.fn(),
     logger: {error: vi.fn(), info: vi.fn()},
@@ -47,6 +48,7 @@ vi.mock('@shipfox/node-fastify', () => ({
   listen: mocks.listen,
 }));
 vi.mock('@shipfox/node-module', () => ({
+  aggregateLoginMethods: mocks.aggregateLoginMethods,
   initializeModules: mocks.initializeModules,
   registerModuleMetrics: mocks.registerModuleMetrics,
   resetPublishers: mocks.resetPublishers,
@@ -73,7 +75,7 @@ vi.mock('./e2e.js', () => ({
 }));
 
 function module(): ShipfoxModule {
-  return {name: 'test'};
+  return {name: 'test', loginMethods: [{id: 'test-login'}]};
 }
 
 function worker(taskQueue = 'runtime-queue'): ModuleWorker {
@@ -101,6 +103,7 @@ function resetMocks(): void {
   mocks.createE2eAdminAuthMethod.mockReset();
   mocks.createE2eRouteGroup.mockReset();
   mocks.createPostgresClient.mockReset();
+  mocks.aggregateLoginMethods.mockReset();
   mocks.initializeModules.mockReset();
   mocks.listen.mockReset();
   mocks.logger.error.mockReset();
@@ -122,6 +125,7 @@ function resetMocks(): void {
   mocks.closeErrorMonitoring.mockResolvedValue(true);
   mocks.closePostgresClient.mockResolvedValue(undefined);
   mocks.createApp.mockResolvedValue({});
+  mocks.aggregateLoginMethods.mockReturnValue([{id: 'test-login'}]);
   mocks.createE2eRouteGroup.mockReturnValue([]);
   mocks.initializeModules.mockResolvedValue({
     auth: [],
@@ -166,6 +170,7 @@ describe('createServer', () => {
     await createTestServer({modules});
 
     expect(mocks.startServiceMetrics).toHaveBeenCalledWith({serviceName: 'api'});
+    expect(mocks.aggregateLoginMethods).toHaveBeenCalledWith({modules});
     expect(mocks.createPostgresClient).toHaveBeenCalledOnce();
     expect(mocks.initializeModules).toHaveBeenCalledWith({modules});
     expect(mocks.registerModuleMetrics).toHaveBeenCalledWith({modules});
@@ -175,6 +180,28 @@ describe('createServer', () => {
       routes: [],
       fastifyOptions: {trustProxy: false},
     });
+  });
+
+  it('fails before startup side effects when no login method is configured', async () => {
+    const failure = new Error('No login methods are configured');
+    mocks.aggregateLoginMethods.mockImplementationOnce(() => {
+      throw failure;
+    });
+
+    const result = createTestServer({modules: [module()]});
+
+    await expect(result).rejects.toBe(failure);
+    expect(mocks.startServiceMetrics).not.toHaveBeenCalled();
+    expect(mocks.createPostgresClient).not.toHaveBeenCalled();
+  });
+
+  it('constructs and starts when a module contributes a login method', async () => {
+    const server = await createTestServer({modules: [module()]});
+
+    await server.start();
+
+    expect(mocks.startModuleWorkers).toHaveBeenCalledOnce();
+    expect(mocks.listen).toHaveBeenCalledOnce();
   });
 
   it('starts module workers before listening for HTTP requests', async () => {

--- a/libs/api/server/src/server.ts
+++ b/libs/api/server/src/server.ts
@@ -1,6 +1,7 @@
 import {captureException, closeErrorMonitoring} from '@shipfox/node-error-monitoring';
 import {closeApp, createApp, listen} from '@shipfox/node-fastify';
 import {
+  aggregateLoginMethods,
   initializeModules,
   type ModuleWorker,
   type ModuleWorkersHandle,
@@ -43,6 +44,7 @@ export async function createServer(options: CreateServerOptions): Promise<Server
   hasActiveServer = true;
 
   try {
+    aggregateLoginMethods({modules: options.modules});
     startServiceMetrics({serviceName: 'api'});
     createPostgresClient();
 

--- a/libs/shared/node/module/README.md
+++ b/libs/shared/node/module/README.md
@@ -1,6 +1,6 @@
 # Shipfox Module
 
-Module setup helpers for Shipfox API services. A module can list its database, auth methods, routes, outbox publishers, event handlers, service metrics, and Temporal workers in one object.
+Module setup helpers for Shipfox API services. A module can list its database, request auth, login methods, routes, outbox publishers, event handlers, service metrics, and Temporal workers in one object.
 
 ## What it does
 
@@ -9,6 +9,8 @@ Module setup helpers for Shipfox API services. A module can list its database, a
 - **`runModuleStartupTasks({modules})`**: Runs module startup tasks in declaration order after initialization.
 - **`startModuleWorkers({workers})`**: Creates Temporal workers and returns a handle that drains workers and closes their Temporal resources.
 - **`ShipfoxModule`**: Module contract used by API packages.
+- **`loginMethods`**: Declares user-facing ways to establish a Shipfox session.
+- **`aggregateLoginMethods({modules})`**: Checks that a composition has one or more unique login method identifiers.
 - **Publisher registry**: Adds outbox tables, drains pending events, and marks events as sent.
 - **Subscriber registry**: Adds and reads in-process event handlers by event type.
 
@@ -58,6 +60,7 @@ export const exampleModule: ShipfoxModule = {
   name: 'example',
   database: {db, migrationsPath},
   auth: [authMethod],
+  loginMethods: [{id: 'example-login'}],
   routes: [routes],
   metrics: registerExampleServiceMetrics,
   startupTasks: warmExampleCache,
@@ -66,6 +69,23 @@ export const exampleModule: ShipfoxModule = {
   workers: [{taskQueue: 'example', workflowsPath, activities, workflows: []}],
 };
 ```
+
+## Login methods
+
+A server composition must declare at least one login method. Server construction fails when none are declared. The error explains how to add a module contribution.
+
+External identity modules contribute their own stable identifier:
+
+```ts
+import type {ShipfoxModule} from '@shipfox/node-module';
+
+export const acmeSsoModule: ShipfoxModule = {
+  name: 'acme-sso',
+  loginMethods: [{id: 'acme-sso'}],
+};
+```
+
+Each identifier has one owning module. Duplicate identifiers fail during server construction. A module that contributes a login method must also create a login-ready session for a verified, active user.
 
 ## Development
 

--- a/libs/shared/node/module/src/index.ts
+++ b/libs/shared/node/module/src/index.ts
@@ -12,6 +12,11 @@ export {
   runModuleStartupTasks,
   startModuleWorkers,
 } from './initialize.js';
+export {
+  aggregateLoginMethods,
+  DuplicateLoginMethodError,
+  NoLoginMethodError,
+} from './login-methods.js';
 export type {
   DrainAllOptions,
   DrainAllResult,
@@ -38,6 +43,7 @@ export {getSubscribers, resetSubscribers, subscribe} from './registry.js';
 export type {ModuleSubscriber} from './subscriber.js';
 export {subscriberFactory} from './subscriber.js';
 export type {
+  LoginMethod,
   ModuleDatabase,
   ModuleMetricsRegistration,
   ModulePublisher,

--- a/libs/shared/node/module/src/login-methods.test.ts
+++ b/libs/shared/node/module/src/login-methods.test.ts
@@ -1,0 +1,76 @@
+import {
+  aggregateLoginMethods,
+  DuplicateLoginMethodError,
+  NoLoginMethodError,
+} from './login-methods.js';
+
+describe('aggregateLoginMethods', () => {
+  it('aggregates login methods in module order and skips modules without them', () => {
+    const loginMethods = aggregateLoginMethods({
+      modules: [
+        {name: 'database'},
+        {name: 'password', loginMethods: [{id: 'password'}]},
+        {name: 'sso', loginMethods: [{id: 'acme-sso'}]},
+      ],
+    });
+
+    expect(loginMethods).toEqual([{id: 'password'}, {id: 'acme-sso'}]);
+  });
+
+  it('rejects duplicate login methods from different modules', () => {
+    const result = () =>
+      aggregateLoginMethods({
+        modules: [
+          {name: 'password', loginMethods: [{id: 'password'}]},
+          {name: 'backup-password', loginMethods: [{id: 'password'}]},
+        ],
+      });
+
+    expect(result).toThrow(DuplicateLoginMethodError);
+    expect(result).toThrow('password');
+    try {
+      result();
+    } catch (error) {
+      expect(error).toMatchObject({
+        loginMethodId: 'password',
+        firstModule: 'password',
+        secondModule: 'backup-password',
+      });
+    }
+  });
+
+  it('rejects a module that repeats its own login method', () => {
+    const result = () =>
+      aggregateLoginMethods({
+        modules: [{name: 'password', loginMethods: [{id: 'password'}, {id: 'password'}]}],
+      });
+
+    expect(result).toThrow(DuplicateLoginMethodError);
+  });
+
+  it('rejects a composition with no login methods', () => {
+    const result = () => aggregateLoginMethods({modules: [{name: 'database'}]});
+
+    expect(result).toThrow(NoLoginMethodError);
+    expect(result).toThrow('Contribute a login method');
+  });
+
+  it('does not treat request authentication as a login method', () => {
+    const result = () =>
+      aggregateLoginMethods({
+        modules: [
+          {
+            name: 'request-auth',
+            auth: [
+              {
+                name: 'jwt',
+                authenticate: async () => undefined,
+              },
+            ],
+          },
+        ],
+      });
+
+    expect(result).toThrow(NoLoginMethodError);
+  });
+});

--- a/libs/shared/node/module/src/login-methods.ts
+++ b/libs/shared/node/module/src/login-methods.ts
@@ -1,0 +1,61 @@
+import type {LoginMethod, ShipfoxModule} from './types.js';
+
+export class NoLoginMethodError extends Error {
+  constructor() {
+    super(
+      'No login methods are configured. Contribute a login method from a module before starting the server.',
+    );
+    this.name = 'NoLoginMethodError';
+  }
+}
+
+export class DuplicateLoginMethodError extends Error {
+  public readonly loginMethodId: string;
+  public readonly firstModule: string;
+  public readonly secondModule: string;
+
+  constructor({
+    loginMethodId,
+    firstModule,
+    secondModule,
+  }: {
+    loginMethodId: string;
+    firstModule: string;
+    secondModule: string;
+  }) {
+    super(
+      `Duplicate login method "${loginMethodId}" contributed by modules "${firstModule}" and "${secondModule}". Each login method identifier must have one owning module.`,
+    );
+    this.name = 'DuplicateLoginMethodError';
+    this.loginMethodId = loginMethodId;
+    this.firstModule = firstModule;
+    this.secondModule = secondModule;
+  }
+}
+
+export function aggregateLoginMethods({
+  modules,
+}: {
+  modules: readonly ShipfoxModule[];
+}): LoginMethod[] {
+  const loginMethods: LoginMethod[] = [];
+  const moduleNamesByLoginMethodId = new Map<string, string>();
+
+  for (const module of modules) {
+    for (const loginMethod of module.loginMethods ?? []) {
+      const firstModule = moduleNamesByLoginMethodId.get(loginMethod.id);
+      if (firstModule !== undefined) {
+        throw new DuplicateLoginMethodError({
+          loginMethodId: loginMethod.id,
+          firstModule,
+          secondModule: module.name,
+        });
+      }
+      moduleNamesByLoginMethodId.set(loginMethod.id, module.name);
+      loginMethods.push(loginMethod);
+    }
+  }
+
+  if (loginMethods.length === 0) throw new NoLoginMethodError();
+  return loginMethods;
+}

--- a/libs/shared/node/module/src/types.ts
+++ b/libs/shared/node/module/src/types.ts
@@ -59,10 +59,20 @@ export type ModuleMetricsRegistration = () => void;
 
 export type ModuleStartupTasks = () => Promise<void>;
 
+/**
+ * A user-facing mechanism that establishes a standard Shipfox session.
+ * This is distinct from an `AuthMethod`, which authenticates requests after a
+ * session has been established.
+ */
+export interface LoginMethod {
+  id: string;
+}
+
 export interface ShipfoxModule {
   name: string;
   database?: ModuleDatabase | ModuleDatabase[];
   auth?: AuthMethod[];
+  loginMethods?: LoginMethod[];
   routes?: RouteExport[];
   e2eRoutes?: RouteExport[];
   publishers?: ModulePublisher[];


### PR DESCRIPTION
Adds module-level login-method declarations and validates them during API server construction. A distribution can disable password credentials while a custom module establishes standard Shipfox sessions.

This keeps user login mechanisms separate from request authentication. The server now fails before startup side effects when a composition has no user login path, rather than serving an unusable configuration.

The shared `loginMethods` declaration remains intentionally small (`{id}`). Contributing modules own their routes and session-establishing behavior, avoiding provider-specific logic in the shared package.

Review focus: the fail-before-side-effects gate and the password-disabled route table.

Closes ENG-937

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds module-level login method declarations and enforces at least one login path at server construction. Password login can be turned off while keeping refresh, logout, and me; the server now fails before startup if no login method is configured (ENG-937).

- **New Features**
  - `@shipfox/node-module`
    - Adds `loginMethods` on modules and `aggregateLoginMethods()` with clear errors for missing or duplicate IDs.
  - `@shipfox/api-auth`
    - Adds `AUTH_PASSWORD_ENABLED` (default `true`) and `passwordLoginMethods()`.
    - Routes now built via `buildAuthRoutes()`: when disabled, password and verification routes return 404; refresh/logout/me remain.
  - `@shipfox/api-server`
    - Calls `aggregateLoginMethods()` during `createServer`, failing before metrics/DB if none are provided.
  - Tests and docs updated.

- **Migration**
  - If keeping password login: no changes.
  - To disable password login: set `AUTH_PASSWORD_ENABLED=false` and add a module that declares a unique `loginMethods: [{id: 'your-login'}]` and can create a session for a verified, active user. Duplicate IDs across modules will fail server construction.

<sup>Written for commit 9b84144cb367160c98e2cf0d806ac4f5a95b5f05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

