### PR TITLE
[api] Exclude source assets from production image

### DIFF
--- a/apps/api/.dockerignore
+++ b/apps/api/.dockerignore
@@ -7,3 +7,12 @@
 !docker-entrypoint.sh
 !out
 !out/**
+
+# The workspace is built before Docker runs. Keep source and test assets out of
+# the context so pnpm deploy cannot copy them into the production dependency tree.
+out/full/**/src
+out/full/**/test
+out/full/**/tests
+out/full/**/fixture
+out/full/**/fixtures
+out/full/**/coverage


### PR DESCRIPTION
Exclude first-party source, tests, fixtures, and coverage output from the pruned workspace before it enters the API Docker build context.

The API is compiled outside Docker, but `turbo prune` copies the workspace source into `out/full` alongside the prebuilt `dist` directories. Because the Dockerfile re-includes all of `out`, `pnpm deploy` could copy those non-runtime assets into the production image. Filtering them at the context boundary keeps the existing build and production dependency flow intact.

Considered pruning packages and files after `pnpm deploy`, but Turbo already limits the workspace graph and `pnpm deploy --prod` owns the production dependency closure. Removing files from that closure would add unnecessary image-specific policy and risk breaking dependencies that declare tooling at runtime.

Refs ENG-965

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude first-party source, tests, fixtures, and coverage under `out/full/**` from the API Docker context so `pnpm deploy` won’t copy non-runtime assets into the image. This reduces the production image size and supports Linear ENG-965’s size-budget goal while keeping prebuilt `dist` output intact.

<sup>Written for commit 80e10e66aa29f23682c38406591c085a20be239d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

