### PR TITLE
Configure Renovate catalog update groups

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,10 @@
   "prCreation": "not-pending",
   "internalChecksFilter": "strict",
   "prHourlyLimit": 5,
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "groupName": null
+  },
   "packageRules": [
     {
       "description": "Group all GitHub Actions updates into one PR",
@@ -50,16 +54,18 @@
       "matchPackageNames": ["@shipfox/**"]
     },
     {
-      "description": "Group all @argos-ci NPM updates into one PR",
+      "description": "Argos CI packages share a review surface, but do not require a complete release before one available package can update.",
       "groupName": "argos-ci",
       "groupSlug": "argos-ci",
       "matchManagers": ["npm"],
-      "matchPackageNames": ["@argos-ci/**"]
+      "matchPackageNames": ["@argos-ci/**"],
+      "rangeStrategy": "bump"
     },
     {
-      "description": "TanStack Query: group related packages together and bump ranges to keep deps and peerDeps in sync across the monorepo",
+      "description": "TanStack Query packages share an integration surface, but one available package must not wait for every member to release. Bump catalog range minima while preserving their caret shape.",
       "groupName": "tanstack-query",
       "groupSlug": "tanstack-query",
+      "matchManagers": ["npm"],
       "matchPackageNames": [
         "@tanstack/react-query",
         "@tanstack/query-core",
@@ -68,11 +74,116 @@
       "rangeStrategy": "bump"
     },
     {
-      "description": "TanStack Router: group runtime and plugin packages together and bump ranges to avoid route typegen/runtime drift",
+      "description": "TanStack Router runtime and plugin packages share an integration surface, but one available package must not wait for every member to release. Bump catalog range minima while preserving their caret shape.",
       "groupName": "tanstack-router",
       "groupSlug": "tanstack-router",
-      "matchPackageNames": ["@tanstack/react-router", "@tanstack/router-plugin"],
+      "matchManagers": ["npm"],
+      "matchPackageNames": [
+        "@tanstack/react-router",
+        "@tanstack/router-core",
+        "@tanstack/router-plugin"
+      ],
       "rangeStrategy": "bump"
+    },
+    {
+      "description": "Biome ships its formatter and platform binaries as one exact release. Wait for all five members and combine major and non-major releases so the generated-output toolchain stays coherent.",
+      "groupName": "biome-distribution",
+      "groupSlug": "biome-distribution",
+      "matchManagers": ["npm"],
+      "matchPackageNames": [
+        "@biomejs/biome",
+        "@biomejs/cli-darwin-arm64",
+        "@biomejs/cli-darwin-x64",
+        "@biomejs/cli-linux-arm64",
+        "@biomejs/cli-linux-x64"
+      ],
+      "minimumGroupSize": 5,
+      "rangeStrategy": "bump",
+      "separateMajorMinor": false
+    },
+    {
+      "description": "Temporal SDK packages form one exact upstream release train and the workflow bundle requires matching members. Wait for all seven and combine major and non-major releases.",
+      "groupName": "temporal-sdk",
+      "groupSlug": "temporal-sdk",
+      "matchManagers": ["npm"],
+      "matchPackageNames": [
+        "@temporalio/activity",
+        "@temporalio/client",
+        "@temporalio/common",
+        "@temporalio/interceptors-opentelemetry",
+        "@temporalio/testing",
+        "@temporalio/worker",
+        "@temporalio/workflow"
+      ],
+      "minimumGroupSize": 7,
+      "rangeStrategy": "bump",
+      "separateMajorMinor": false
+    },
+    {
+      "description": "React and React DOM must share one upstream release. Wait for both catalog entries and combine major and non-major releases while retaining caret ranges; peer support ranges stay outside this rule.",
+      "groupName": "react-runtime",
+      "groupSlug": "react-runtime",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["react", "react-dom"],
+      "minimumGroupSize": 2,
+      "rangeStrategy": "bump",
+      "separateMajorMinor": false
+    },
+    {
+      "description": "Vitest and its Playwright browser adapter share one upstream release. Wait for both catalog entries and combine major and non-major releases while retaining caret ranges.",
+      "groupName": "vitest",
+      "groupSlug": "vitest",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["vitest", "@vitest/browser-playwright"],
+      "minimumGroupSize": 2,
+      "rangeStrategy": "bump",
+      "separateMajorMinor": false
+    },
+    {
+      "description": "Storybook core packages share one upstream release. Wait for all four catalog entries and combine major and non-major releases while retaining caret ranges.",
+      "groupName": "storybook-core",
+      "groupSlug": "storybook-core",
+      "matchManagers": ["npm"],
+      "matchPackageNames": [
+        "storybook",
+        "@storybook/addon-vitest",
+        "@storybook/react",
+        "@storybook/react-vite"
+      ],
+      "minimumGroupSize": 4,
+      "rangeStrategy": "bump",
+      "separateMajorMinor": false
+    },
+    {
+      "description": "Tailwind CSS and its Vite integration share one upstream release. Wait for both catalog entries and combine major and non-major releases while retaining caret ranges.",
+      "groupName": "tailwind-css",
+      "groupSlug": "tailwind-css",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["tailwindcss", "@tailwindcss/vite"],
+      "minimumGroupSize": 2,
+      "rangeStrategy": "bump",
+      "separateMajorMinor": false
+    },
+    {
+      "description": "React type packages are reviewed together, but one available type package must not wait for the other. Bump catalog range minima while preserving their caret shape.",
+      "groupName": "react-types",
+      "groupSlug": "react-types",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@types/react", "@types/react-dom"],
+      "rangeStrategy": "bump"
+    },
+    {
+      "description": "Vite and its React plugin are reviewed together, but one available package must not wait for the other. Bump catalog range minima while preserving their caret shape.",
+      "groupName": "vite",
+      "groupSlug": "vite",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["vite", "@vitejs/plugin-react"],
+      "rangeStrategy": "bump"
+    },
+    {
+      "description": "Do not enable pnpmDedupe: it runs after every pnpm lockfile update and can create unrelated lockfile churn. The committed lockfile audit owns deterministic duplicate enforcement.",
+      "matchManagers": ["npm"],
+      "postUpdateOptions": []
     },
     {
       "description": "Group pnpm updates across managers (packageManager field + npm:pnpm) into one PR",


### PR DESCRIPTION
Configure Renovate to update pnpm catalog entries by package family rather than relying on the broad npm patch/minor group.

The catalog migration made each direct dependency's version intent central, but selected upstream release trains must be reviewed as one change. This adds stable package-name groups for the policy families, holding complete-release families until every member is available and allowing grouped-only families to update promptly. Vulnerability alerts remain ungrouped, and pnpmDedupe stays disabled to avoid unrelated lockfile churn.

Complete-release groups intentionally wait for every member. In particular, a Storybook update can remain held if its Vitest addon has not shipped a matching release.

Closes ENG-982

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configures Renovate to group pnpm catalog updates by package family, holding complete-release trains until all members are available and letting independent groups bump promptly. Aligns catalog-backed dependencies with their release contracts and reduces noisy PRs. Addresses ENG-982.

- **New Features**
  - Adds family groups with two strategies:
    - Complete-release groups wait for all members and combine majors/minors: `@biomejs/*`, `@temporalio/*`, `react` + `react-dom`, `vitest` + `@vitest/browser-playwright`, `storybook` core (`storybook`, `@storybook/addon-vitest`, `@storybook/react`, `@storybook/react-vite`), `tailwindcss` + `@tailwindcss/vite`.
    - Bump-only groups update as available and keep caret ranges: `@tanstack/*` (Query/Router), `vite` + `@vitejs/plugin-react`, `@types/react` + `@types/react-dom`, `@argos-ci/*`.
  - Enables `vulnerabilityAlerts` with no grouping.
  - Uses `rangeStrategy: "bump"` and `minimumGroupSize` for complete-release sets to avoid partial trains.
  - Keeps `pnpmDedupe` off (`postUpdateOptions: []`) to prevent unrelated lockfile churn.

<sup>Written for commit 6e1e9b72c807036d32cec8aee788c926432290f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

