### PR TITLE
Enforce catalog dependency versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Set up pnpm
         uses: ./.github/actions/setup-pnpm
 
+      - name: Check direct dependency catalog policy
+        run: pnpm check:dependencies
+
       - name: Run static verification
         run: turbo check type build depcruise --concurrency="$SHIPFOX_TURBO_CONCURRENCY"
 

--- a/.syncpackrc.json
+++ b/.syncpackrc.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "./node_modules/syncpack/schema.json",
+  "customTypes": {
+    "optional": {
+      "path": "optionalDependencies",
+      "strategy": "versionsByName"
+    }
+  },
+  "versionGroups": [
+    {
+      "dependencies": ["fastify-plugin"],
+      "dependencyTypes": ["prod"],
+      "isIgnored": true,
+      "label": "Approved fastify-plugin multi-major migration"
+    },
+    {
+      "dependencyTypes": ["peer"],
+      "isIgnored": true,
+      "label": "Peer compatibility contracts"
+    },
+    {
+      "dependencyTypes": ["prod", "dev", "optional"],
+      "isIgnored": true,
+      "label": "Local workspace dependencies",
+      "specifierTypes": ["workspace-protocol"]
+    },
+    {
+      "dependencyTypes": ["prod", "dev", "optional", "pnpmCatalog"],
+      "label": "Catalog-backed direct dependencies",
+      "policy": "catalog",
+      "specifierTypes": [
+        "catalog",
+        "exact",
+        "range",
+        "range-complex",
+        "range-major",
+        "range-minor",
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "dependencyTypes": ["prod", "dev", "optional"],
+      "isBanned": true,
+      "label": "Direct sources require a named exception",
+      "specifierTypes": ["alias", "file", "git", "latest", "link", "tag", "unsupported", "url"]
+    },
+    {
+      "isIgnored": true,
+      "label": "Declarations outside direct dependency policy"
+    }
+  ]
+}

--- a/dev/syncpack.test.mjs
+++ b/dev/syncpack.test.mjs
@@ -1,0 +1,143 @@
+import assert from 'node:assert/strict';
+import {spawnSync} from 'node:child_process';
+import {mkdir, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {dirname, join, resolve} from 'node:path';
+import {describe, test} from 'node:test';
+import {fileURLToPath} from 'node:url';
+
+const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const syncpackBin = join(rootDir, 'node_modules/syncpack/index.cjs');
+const syncpackConfig = join(rootDir, '.syncpackrc.json');
+
+describe('Syncpack catalog policy', () => {
+  test('accepts catalog references, broad peers, and local workspace references', async () => {
+    await withFixture(({directory}) => {
+      const result = runSyncpack(directory, 'lint');
+
+      assert.equal(result.status, 0, result.stderr);
+    });
+  });
+
+  test('rejects a literal direct version', async () => {
+    await withFixture(async ({consumerFile, directory, writePackage}) => {
+      await writePackage(consumerFile, {
+        dependencies: {
+          '@fixture/local': 'workspace:*',
+          zod: '^4.4.3',
+        },
+        devDependencies: {
+          zod: 'catalog:',
+        },
+        name: '@fixture/consumer',
+        optionalDependencies: {
+          'optional-package': 'catalog:',
+        },
+        peerDependencies: {
+          react: '^19.0.0',
+        },
+        version: '1.0.0',
+      });
+
+      const literalVersion = runSyncpack(directory, 'lint');
+
+      assert.equal(literalVersion.status, 1, literalVersion.stdout);
+    });
+  });
+
+  test('rejects a second direct specification', async () => {
+    await withFixture(async ({directory, writePackage}) => {
+      await writePackage(join(directory, 'packages/second/package.json'), {
+        dependencies: {
+          zod: '^4.4.3',
+        },
+        name: '@fixture/second',
+        version: '1.0.0',
+      });
+
+      const secondSpecification = runSyncpack(directory, 'lint');
+
+      assert.equal(secondSpecification.status, 1, secondSpecification.stdout);
+    });
+  });
+
+  test('fix restores a catalog reference without changing unrelated manifest fields', async () => {
+    await withFixture(async ({consumerFile, directory, writePackage}) => {
+      await writePackage(consumerFile, {
+        ...catalogConsumerPackage,
+        dependencies: {
+          '@fixture/local': 'workspace:*',
+          zod: '^4.4.3',
+        },
+      });
+
+      const result = runSyncpack(directory, 'fix');
+      const fixed = JSON.parse(await readFile(consumerFile, 'utf8'));
+
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(fixed.dependencies.zod, 'catalog:');
+      assert.equal(fixed.dependencies['@fixture/local'], 'workspace:*');
+      assert.equal(fixed.optionalDependencies['optional-package'], 'catalog:');
+      assert.equal(fixed.peerDependencies.react, '^19.0.0');
+    });
+  });
+});
+
+const catalogConsumerPackage = {
+  dependencies: {
+    '@fixture/local': 'workspace:*',
+    zod: 'catalog:',
+  },
+  devDependencies: {
+    zod: 'catalog:',
+  },
+  name: '@fixture/consumer',
+  optionalDependencies: {
+    'optional-package': 'catalog:',
+  },
+  peerDependencies: {
+    react: '^19.0.0',
+  },
+  version: '1.0.0',
+};
+
+async function withFixture(run) {
+  const directory = await mkdtemp(join(tmpdir(), 'shipfox-syncpack-'));
+  const consumerFile = join(directory, 'packages/consumer/package.json');
+  const writePackage = async (path, contents) => {
+    await mkdir(dirname(path), {recursive: true});
+    await writeFile(path, `${JSON.stringify(contents, null, 2)}\n`);
+  };
+
+  try {
+    await writeFile(
+      join(directory, 'pnpm-workspace.yaml'),
+      "catalog:\n  optional-package: ^1.0.0\n  zod: ^4.4.3\npackages:\n  - 'packages/*'\n",
+    );
+    await writePackage(join(directory, 'package.json'), {
+      name: '@fixture/root',
+      private: true,
+      version: '1.0.0',
+    });
+    await writePackage(join(directory, 'packages/local/package.json'), {
+      name: '@fixture/local',
+      version: '1.0.0',
+    });
+    await writePackage(consumerFile, catalogConsumerPackage);
+
+    await run({consumerFile, directory, writePackage});
+  } finally {
+    await rm(directory, {force: true, recursive: true});
+  }
+}
+
+function runSyncpack(cwd, command) {
+  return spawnSync(
+    process.execPath,
+    [syncpackBin, command, '--config', syncpackConfig, '--no-ansi'],
+    {
+      cwd,
+      encoding: 'utf8',
+    },
+  );
+}

--- a/dev/syncpack.test.mjs
+++ b/dev/syncpack.test.mjs
@@ -61,6 +61,24 @@ describe('Syncpack catalog policy', () => {
     });
   });
 
+  test('rejects a direct source without a named exception', async () => {
+    await withFixture(async ({consumerFile, directory, writePackage}) => {
+      await writePackage(consumerFile, {
+        dependencies: {
+          '@fixture/local': 'workspace:*',
+          zod: 'git+https://github.com/colinhacks/zod.git',
+        },
+        name: '@fixture/consumer',
+        version: '1.0.0',
+      });
+
+      const bannedSource = runSyncpack(directory, 'lint');
+
+      assert.equal(bannedSource.status, 1, bannedSource.stderr);
+      assert.match(bannedSource.stderr, /Direct sources require a named exception/);
+    });
+  });
+
   test('fix restores a catalog reference without changing unrelated manifest fields', async () => {
     await withFixture(async ({consumerFile, directory, writePackage}) => {
       await writePackage(consumerFile, {

--- a/docs/policies/dependency-versions.md
+++ b/docs/policies/dependency-versions.md
@@ -37,6 +37,26 @@ external dependency names.
 
 The current workspace has no direct external file, link, Git, or URL dependency.
 
+## Checking direct dependencies
+
+Run the direct-dependency check after changing a workspace manifest:
+
+```sh
+pnpm check:dependencies
+```
+
+The check reads committed manifests and the workspace catalog. It does not read
+registry metadata.
+
+Use the fix command to restore eligible direct dependencies to `catalog:`:
+
+```sh
+pnpm fix:dependencies
+```
+
+The fix does not update dependencies or format manifests. A non-semver source
+needs a named exception in the repository policy configuration.
+
 ## Catalog and range rules
 
 The default catalog holds the version intent. It covers eligible direct external

--- a/package.json
+++ b/package.json
@@ -9,11 +9,14 @@
   "packageManager": "pnpm@11.7.0",
   "type": "module",
   "scripts": {
+    "check:dependencies": "syncpack lint --no-ansi",
+    "fix:dependencies": "syncpack fix --no-ansi",
     "test": "node --test dev/*.test.mjs",
     "release:publish": "turbo type build type:emit --filter='./libs/**' --filter='./tools/**' && changeset publish"
   },
   "devDependencies": {
     "@changesets/cli": "catalog:",
-    "@types/node": "catalog:"
+    "@types/node": "catalog:",
+    "syncpack": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -465,6 +465,9 @@ catalogs:
     storybook-addon-pseudo-states:
       specifier: ^10.0.0
       version: 10.4.6
+    syncpack:
+      specifier: ^15.3.2
+      version: 15.3.2
     tailwind-merge:
       specifier: ^3.2.0
       version: 3.6.0
@@ -509,6 +512,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.2
+      syncpack:
+        specifier: 'catalog:'
+        version: 15.3.2
 
   apps/api:
     dependencies:
@@ -15424,6 +15430,51 @@ packages:
     resolution: {integrity: sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
+  syncpack-darwin-arm64@15.3.2:
+    resolution: {integrity: sha512-rQwZOvWJbvUzhBySbKnvs+F5khmdkH2W/kTZo+zz6UfH651K9z2fiOYlcpDPX0L97m566gRxVmOr930ygB97ZQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  syncpack-darwin-x64@15.3.2:
+    resolution: {integrity: sha512-91CWe9Pamfmlm2nY8bCL5z8GYOafGJUm/nQqtvaQDZ9SS25c6Gn8LDfRu6JSKV0dcI1zOH3EiRCM0K/kn9Mpiw==}
+    cpu: [x64]
+    os: [darwin]
+
+  syncpack-linux-arm64-musl@15.3.2:
+    resolution: {integrity: sha512-IzI4Sr1rFDuF7FFbZ+ti+qA2/0Rp/aGNgzoUzNH28wYJkJMv9KBBr3Nygc1jsoO1+XE1JkYsXkJHuSFrwiwtgA==}
+    cpu: [arm64]
+    os: [linux]
+
+  syncpack-linux-arm64@15.3.2:
+    resolution: {integrity: sha512-eApeUFLb8yFHAFnCyHicDieTBW0eR3HsaKSWPMmz+VOQOpZYl0cmqbRLtunsYN6OykRi9Sl1faYjKmyETow7Gg==}
+    cpu: [arm64]
+    os: [linux]
+
+  syncpack-linux-x64-musl@15.3.2:
+    resolution: {integrity: sha512-dohyuYgUVHdSFz1KYW/XngyYSiSV3tarroYRsloYsT8bcSStkh2vJVBht0eMl1OFTh3Hb6lNEC12Pgtw4gWTcg==}
+    cpu: [x64]
+    os: [linux]
+
+  syncpack-linux-x64@15.3.2:
+    resolution: {integrity: sha512-xrzBZx3DjKoece2h3Olv/Y/U7b1eNorWTMiF407m0tO5KJp5u926TMeHlldaA5GRCkVJBe5VaI33WYTJF753oQ==}
+    cpu: [x64]
+    os: [linux]
+
+  syncpack-windows-arm64@15.3.2:
+    resolution: {integrity: sha512-ZGjVpyS8PW6Y69HyXOb8RYVWRQ+hlRklqdgOp+x+eqrCRidGho8z2nN5tleMGzcaMC7hg+qSPFh5u6Fy/BXr4w==}
+    cpu: [arm64]
+    os: [win32]
+
+  syncpack-windows-x64@15.3.2:
+    resolution: {integrity: sha512-9zKWNXGhd3rryQjcpBjs02pKgvIzuz3PUS+vKL4vWnDu5VoHad4e6TzL4pvn+VfAm4wXzcuS9fZkxLBEMPLerw==}
+    cpu: [x64]
+    os: [win32]
+
+  syncpack@15.3.2:
+    resolution: {integrity: sha512-RKYfXFQlrIWosTheNbyJg3xHNjTDrW2mOvwxAz3XGghrUDN4hDjhKPCTAQrUtGZw9hNeIr37qRO3/+EP927Vtg==}
+    engines: {node: '>=14.17.0'}
+    hasBin: true
+
   systeminformation@5.31.8:
     resolution: {integrity: sha512-/HGurKdgjYGbfwCPSokoX4WAlasVxuj1SnTukLiIYHPkjbDbN1PMATj8mkHpqkVzUF34y5ZyCY1TMKP32AI9rA==}
     engines: {node: '>=8.0.0'}
@@ -25733,6 +25784,41 @@ snapshots:
     dependencies:
       '@pkgr/core': 0.1.2
       tslib: 2.8.1
+
+  syncpack-darwin-arm64@15.3.2:
+    optional: true
+
+  syncpack-darwin-x64@15.3.2:
+    optional: true
+
+  syncpack-linux-arm64-musl@15.3.2:
+    optional: true
+
+  syncpack-linux-arm64@15.3.2:
+    optional: true
+
+  syncpack-linux-x64-musl@15.3.2:
+    optional: true
+
+  syncpack-linux-x64@15.3.2:
+    optional: true
+
+  syncpack-windows-arm64@15.3.2:
+    optional: true
+
+  syncpack-windows-x64@15.3.2:
+    optional: true
+
+  syncpack@15.3.2:
+    optionalDependencies:
+      syncpack-darwin-arm64: 15.3.2
+      syncpack-darwin-x64: 15.3.2
+      syncpack-linux-arm64: 15.3.2
+      syncpack-linux-arm64-musl: 15.3.2
+      syncpack-linux-x64: 15.3.2
+      syncpack-linux-x64-musl: 15.3.2
+      syncpack-windows-arm64: 15.3.2
+      syncpack-windows-x64: 15.3.2
 
   systeminformation@5.31.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -154,6 +154,7 @@ catalog:
   "sonner": "^2.0.7"
   "storybook": "^10.0.0"
   "storybook-addon-pseudo-states": "^10.0.0"
+  "syncpack": "^15.3.2"
   "tailwind-merge": "^3.2.0"
   "tailwindcss": "^4.1.13"
   "tsx": "^4.22.4"


### PR DESCRIPTION
Enforce catalog-backed direct dependency versions.

The catalog migration centralized version intent, but later manifest edits could still reintroduce literal direct ranges without a deterministic check.

This adds Syncpack catalog enforcement, a safe repair command, and a CI gate for direct production, development, and optional dependencies. Peer ranges remain compatibility contracts, local workspace references stay excluded, and the fastify-plugin migration is the only named direct-dependency exception.

Syncpack supplies a focused catalog policy and repair path without adding registry-dependent validation or manifest formatting to the check.

Closes ENG-981

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces catalog-backed versions for all direct dependencies using `syncpack`, with a CI gate and a safe auto-fix to prevent drift from the `pnpm` catalog. Peer ranges and workspace refs stay allowed; `fastify-plugin` is a named exception. Closes ENG-981.

- **New Features**
  - Adds `syncpack` policy to require `catalog:` for prod/dev/optional deps; peers and `workspace:` are ignored; bans non‑semver direct sources unless exempted.
  - Introduces `pnpm check:dependencies` in CI to block non-catalog direct versions.
  - Adds `pnpm fix:dependencies` to restore `catalog:` refs without formatting changes or registry calls.
  - Includes tests for policy, the banned-source rule, and the fix flow, plus docs on running the checks.

- **Dependencies**
  - Adds `syncpack@^15.3.2` to the workspace catalog and root `devDependencies`.

<sup>Written for commit 7c3f0032830199ff93d629f3d84bc089f8a703bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

