### PR TITLE
[integration] Add Slack provider DTO contract

### DIFF
--- a/.changeset/bright-sloths-build.md
+++ b/.changeset/bright-sloths-build.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-integration-slack-dto": patch
+---
+
+Adds the Slack integration provider contract with OAuth, event, command, and E2E schemas.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -26,6 +26,7 @@
       "@shipfox/api-integration-linear-dto",
       "@shipfox/api-integration-sentry",
       "@shipfox/api-integration-sentry-dto",
+      "@shipfox/api-integration-slack-dto",
       "@shipfox/api-integration-webhook",
       "@shipfox/api-integration-webhook-dto",
       "@shipfox/api-logs",

--- a/libs/api/integration/slack-dto/package.json
+++ b/libs/api/integration/slack-dto/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@shipfox/api-integration-slack-dto",
+  "license": "MIT",
+  "version": "3.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
+    "directory": "libs/api/integration/slack-dto"
+  },
+  "private": false,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "imports": {
+    "#test/*": "./test/*",
+    "#*": {
+      "workspace-source": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
+  },
+  "exports": {
+    ".": {
+      "development": {
+        "types": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "depcruise": "shipfox-depcruise",
+    "test": "shipfox-vitest-run",
+    "test:watch": "shipfox-vitest-watch",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "@shipfox/api-integration-core-dto": "workspace:*",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/depcruise": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*"
+  }
+}

--- a/libs/api/integration/slack-dto/src/index.ts
+++ b/libs/api/integration/slack-dto/src/index.ts
@@ -1,0 +1,1 @@
+export * from './schemas/index.js';

--- a/libs/api/integration/slack-dto/src/schemas/index.test.ts
+++ b/libs/api/integration/slack-dto/src/schemas/index.test.ts
@@ -1,0 +1,144 @@
+import {
+  createE2eSlackConnectionBodySchema,
+  createSlackInstallBodySchema,
+  SLACK_PROVIDER,
+  slackApiEventTypes,
+  slackCallbackQuerySchema,
+  slackEventBaseEnvelopeSchema,
+  slackEventEnvelopeSchema,
+  slackEventNames,
+  slackEventPayloadSchema,
+  slackEventsRequestSchema,
+  slackSlashCommandSchema,
+  slackUrlVerificationSchema,
+} from './index.js';
+
+const eventEnvelope = {
+  type: 'event_callback',
+  team_id: 'T123',
+  api_app_id: 'A123',
+  event: {type: 'app_mention', channel: 'C123', user: 'U123', text: 'Hello'},
+  event_id: 'Ev123',
+  event_time: 1_786_257_600,
+};
+
+const slashCommand = {
+  token: 'verification-token',
+  command: '/deploy',
+  team_id: 'T123',
+  channel_id: 'C123',
+  user_id: 'U123',
+  response_url: 'https://hooks.slack.com/commands/123',
+  trigger_id: 'trigger-123',
+  text: 'production',
+};
+
+describe('SLACK_PROVIDER', () => {
+  it('names the Slack provider id', () => {
+    expect(SLACK_PROVIDER).toBe('slack');
+  });
+});
+
+describe('Slack event vocabulary', () => {
+  it('exports the supported event names without mixing slash commands into API events', () => {
+    expect(slackEventNames).toEqual(['app_mention', 'message', 'reaction_added', 'slash_command']);
+    expect(slackApiEventTypes).not.toContain('slash_command');
+  });
+});
+
+describe('Slack event schemas', () => {
+  it('accepts supported Events API envelopes', () => {
+    const result = slackEventEnvelopeSchema.parse(eventEnvelope);
+
+    expect(result.event.type).toBe('app_mention');
+  });
+
+  it('keeps unsupported Events API envelopes available for record-and-drop handling', () => {
+    const unsupportedEvent = {
+      ...eventEnvelope,
+      event: {type: 'team_join', user: 'U123'},
+    };
+
+    expect(slackEventEnvelopeSchema.safeParse(unsupportedEvent).success).toBe(false);
+    expect(slackEventBaseEnvelopeSchema.safeParse(unsupportedEvent).success).toBe(true);
+  });
+
+  it('accepts the URL verification handshake', () => {
+    const payload = {
+      type: 'url_verification',
+      token: 'verification-token',
+      challenge: 'challenge-token',
+    };
+
+    expect(slackUrlVerificationSchema.safeParse(payload).success).toBe(true);
+    expect(slackEventsRequestSchema.safeParse(payload).success).toBe(true);
+  });
+});
+
+describe('Slack slash command schema', () => {
+  it('accepts a complete form body', () => {
+    const result = slackSlashCommandSchema.parse(slashCommand);
+
+    expect(result.command).toBe('/deploy');
+  });
+
+  it('defaults an omitted command text to an empty string', () => {
+    const {text: _text, ...commandWithoutText} = slashCommand;
+
+    const result = slackSlashCommandSchema.parse(commandWithoutText);
+
+    expect(result.text).toBe('');
+  });
+
+  it('rejects a form body without a command', () => {
+    const {command: _command, ...commandWithoutCommand} = slashCommand;
+
+    expect(slackSlashCommandSchema.safeParse(commandWithoutCommand).success).toBe(false);
+  });
+});
+
+describe('Slack payload schemas', () => {
+  it('accepts normalized event payloads while retaining Slack-specific fields', () => {
+    const result = slackEventPayloadSchema.parse({
+      type: 'reaction_added',
+      team_id: 'T123',
+      api_app_id: 'A123',
+      event_id: 'Ev123',
+      event_time: 1_786_257_600,
+      reaction: 'white_check_mark',
+      item: {type: 'message', channel: 'C123', ts: '123.456'},
+    });
+
+    expect(result.item).toEqual({type: 'message', channel: 'C123', ts: '123.456'});
+  });
+});
+
+describe('Slack OAuth and E2E schemas', () => {
+  it('rejects an install request with a non-UUID workspace id', () => {
+    const result = createSlackInstallBodySchema.safeParse({workspace_id: 'workspace-1'});
+
+    expect(result.success).toBe(false);
+  });
+
+  it.each([
+    {code: 'grant-code', state: 'signed-state'},
+    {error: 'access_denied', state: 'signed-state'},
+  ])('accepts Slack callback query %o', (query) => {
+    const result = slackCallbackQuerySchema.safeParse(query);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('defaults E2E scopes to a representative bot scope set', () => {
+    const result = createE2eSlackConnectionBodySchema.parse({
+      workspace_id: '5c3583d6-ffb9-4486-a80d-4cf55b567462',
+      team_id: 'T123',
+      team_name: 'Shipfox',
+      app_id: 'A123',
+      bot_user_id: 'U123',
+      bot_token: 'xoxb-token',
+    });
+
+    expect(result.scopes).toEqual(['app_mentions:read', 'chat:write']);
+  });
+});

--- a/libs/api/integration/slack-dto/src/schemas/index.ts
+++ b/libs/api/integration/slack-dto/src/schemas/index.ts
@@ -1,0 +1,135 @@
+import {integrationConnectionDtoSchema} from '@shipfox/api-integration-core-dto';
+import {z} from 'zod';
+
+export const SLACK_PROVIDER = 'slack';
+export type SlackProvider = typeof SLACK_PROVIDER;
+
+export const slackApiEventTypes = ['app_mention', 'message', 'reaction_added'] as const;
+export const SLACK_SLASH_COMMAND_EVENT = 'slash_command' as const;
+export const slackEventNames = [...slackApiEventTypes, SLACK_SLASH_COMMAND_EVENT] as const;
+
+export type SlackApiEventType = (typeof slackApiEventTypes)[number];
+export type SlackEventName = (typeof slackEventNames)[number];
+
+export const slackInnerEventBaseSchema = z
+  .object({
+    type: z.string().min(1),
+  })
+  .passthrough();
+
+export const slackInnerEventSchema = z
+  .object({
+    type: z.enum(slackApiEventTypes),
+  })
+  .passthrough();
+
+export const slackEventBaseEnvelopeSchema = z.object({
+  type: z.literal('event_callback'),
+  team_id: z.string().min(1),
+  api_app_id: z.string().min(1),
+  event: slackInnerEventBaseSchema,
+  event_id: z.string().min(1),
+  event_time: z.number().int(),
+  authorizations: z.array(z.unknown()).optional(),
+});
+export type SlackEventBaseEnvelopeDto = z.infer<typeof slackEventBaseEnvelopeSchema>;
+
+export const slackEventEnvelopeSchema = slackEventBaseEnvelopeSchema.extend({
+  event: slackInnerEventSchema,
+});
+export type SlackEventEnvelopeDto = z.infer<typeof slackEventEnvelopeSchema>;
+
+export const slackUrlVerificationSchema = z.object({
+  type: z.literal('url_verification'),
+  token: z.string().min(1),
+  challenge: z.string().min(1),
+});
+export type SlackUrlVerificationDto = z.infer<typeof slackUrlVerificationSchema>;
+
+export const slackEventsRequestSchema = z.discriminatedUnion('type', [
+  slackUrlVerificationSchema,
+  slackEventBaseEnvelopeSchema,
+]);
+export type SlackEventsRequestDto = z.infer<typeof slackEventsRequestSchema>;
+
+export const slackSlashCommandSchema = z.object({
+  token: z.string().min(1),
+  command: z.string().min(1),
+  team_id: z.string().min(1),
+  channel_id: z.string().min(1),
+  user_id: z.string().min(1),
+  response_url: z.string().url(),
+  trigger_id: z.string().min(1),
+  text: z.string().default(''),
+  team_domain: z.string().min(1).optional(),
+  channel_name: z.string().min(1).optional(),
+  user_name: z.string().min(1).optional(),
+  api_app_id: z.string().min(1).optional(),
+  is_enterprise_install: z.string().min(1).optional(),
+  enterprise_id: z.string().min(1).optional(),
+  enterprise_name: z.string().min(1).optional(),
+});
+export type SlackSlashCommandDto = z.infer<typeof slackSlashCommandSchema>;
+
+export const slackEventPayloadSchema = z
+  .object({
+    type: z.enum(slackApiEventTypes),
+    team_id: z.string().min(1),
+    api_app_id: z.string().min(1),
+    event_id: z.string().min(1),
+    event_time: z.number().int(),
+    channel: z.string().min(1).optional(),
+    channel_type: z.string().min(1).optional(),
+    user: z.string().min(1).optional(),
+    ts: z.string().min(1).optional(),
+    thread_ts: z.string().min(1).optional(),
+    text: z.string().optional(),
+    bot_id: z.string().min(1).optional(),
+    reaction: z.string().min(1).optional(),
+  })
+  .passthrough();
+export type SlackEventPayloadDto = z.infer<typeof slackEventPayloadSchema>;
+
+export type SlackSlashCommandPayloadDto = SlackSlashCommandDto;
+
+export const createSlackInstallBodySchema = z.object({
+  workspace_id: z.string().uuid(),
+});
+export type CreateSlackInstallBodyDto = z.infer<typeof createSlackInstallBodySchema>;
+
+export const createSlackInstallResponseSchema = z.object({
+  install_url: z.string().url(),
+});
+export type CreateSlackInstallResponseDto = z.infer<typeof createSlackInstallResponseSchema>;
+
+export const slackCallbackQuerySchema = z.union([
+  z.object({
+    code: z.string().min(1),
+    state: z.string().min(1),
+  }),
+  z.object({
+    error: z.string().min(1),
+    error_description: z.string().min(1).optional(),
+    state: z.string().min(1),
+  }),
+]);
+export type SlackCallbackQueryDto = z.infer<typeof slackCallbackQuerySchema>;
+
+export const slackCallbackResponseSchema = integrationConnectionDtoSchema;
+export type SlackCallbackResponseDto = z.infer<typeof slackCallbackResponseSchema>;
+
+export const createE2eSlackConnectionBodySchema = z.object({
+  workspace_id: z.string().uuid(),
+  team_id: z.string().min(1),
+  team_name: z.string().min(1),
+  app_id: z.string().min(1),
+  bot_user_id: z.string().min(1),
+  bot_token: z.string().min(1),
+  scopes: z.array(z.string().min(1)).min(1).default(['app_mentions:read', 'chat:write']),
+});
+export type CreateE2eSlackConnectionBodyDto = z.infer<typeof createE2eSlackConnectionBodySchema>;
+
+export const createE2eSlackConnectionResponseSchema = integrationConnectionDtoSchema;
+export type CreateE2eSlackConnectionResponseDto = z.infer<
+  typeof createE2eSlackConnectionResponseSchema
+>;

--- a/libs/api/integration/slack-dto/tsconfig.build.json
+++ b/libs/api/integration/slack-dto/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.tsx", "**/*.test.ts"]
+}

--- a/libs/api/integration/slack-dto/tsconfig.json
+++ b/libs/api/integration/slack-dto/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.test.json" }]
+}

--- a/libs/api/integration/slack-dto/tsconfig.test.json
+++ b/libs/api/integration/slack-dto/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "exclude": []
+}

--- a/libs/api/integration/slack-dto/vitest.config.ts
+++ b/libs/api/integration/slack-dto/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({}, import.meta.url) as UserConfigExport;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2822,6 +2822,34 @@ importers:
         specifier: workspace:*
         version: link:../../../../tools/vitest
 
+  libs/api/integration/slack-dto:
+    dependencies:
+      '@shipfox/api-integration-core-dto':
+        specifier: workspace:*
+        version: link:../core-dto
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../../tools/biome
+      '@shipfox/depcruise':
+        specifier: workspace:*
+        version: link:../../../../tools/depcruise
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../../tools/vitest
+
   libs/api/integration/webhook:
     dependencies:
       '@fastify/formbody':


### PR DESCRIPTION
Adds the browser-safe Slack DTO package that the provider, client, and E2E work can share. It defines the OAuth install and callback contracts, supported event vocabulary, event and slash-command payload schemas, and E2E connection setup.

Slack needs one stable event and payload contract before its receivers, OAuth routes, and client wiring can be implemented independently. The package mirrors the existing Linear DTO boundary so consumer surfaces remain provider-agnostic.

The Events API request schema intentionally accepts the base envelope for record-and-drop handling, while the supported envelope narrows publishing to the curated Slack event types.

Closes ENG-925

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces `@shipfox/api-integration-slack-dto`, a browser-safe schema package defining Slack OAuth, Events API, slash command, and E2E contracts so provider, client, and routes can ship independently. Aligns with ENG-925 by establishing a stable event and payload boundary.

- **New Features**
  - Exposes `SLACK_PROVIDER` and a curated event vocabulary (`app_mention`, `message`, `reaction_added`; plus `slash_command` for forms).
  - Adds Events API schemas: base envelope for record-and-drop and a narrowed envelope for supported events; includes `url_verification`.
  - Provides normalized event payload schema that retains Slack-specific fields.
  - Defines slash command form body with sensible defaults (e.g., empty `text` when omitted).
  - Implements OAuth install and callback schemas, plus E2E connection schemas with default bot scopes (`app_mentions:read`, `chat:write`).
  - Includes tests validating all schemas and wiring.

- **Dependencies**
  - New package `@shipfox/api-integration-slack-dto` using `zod` and `@shipfox/api-integration-core-dto`.

<sup>Written for commit ff83215d5465e2d96db9b6200651cd94090cbd9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

