### PR TITLE
[runner] Stabilize process group abort test

### DIFF
--- a/libs/runner/execution/src/core/run-step.test.ts
+++ b/libs/runner/execution/src/core/run-step.test.ts
@@ -713,7 +713,9 @@ describe('executeRunStep', () => {
 
   it('kills the entire process group on abort, including grandchildren', async () => {
     const step = buildStep({
-      config: {run: 'sleep 30 & echo "GRANDCHILD_PID=$!"; wait'},
+      config: {
+        run: 'sleep 30 & grandchild_pid=$!; echo "GRANDCHILD_PID=$grandchild_pid"; wait "$grandchild_pid"',
+      },
     });
     const output = collectOutput();
     const ac = new AbortController();


### PR DESCRIPTION
Stabilizes the run-step process-group abort fixture by waiting for the captured grandchild PID.

The fixture previously used operand-less Bash `wait`, which can return zero after reaping a SIGKILLed background process. Under broad macOS Turbo load, that allowed the shell result to appear successful even though abort had terminated the grandchild, blocking unrelated pull requests.

Waiting for the named PID propagates the killed process status deterministically while leaving production runner behavior unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the process-group abort test by waiting on the captured grandchild PID. This propagates the SIGKILL status instead of masking it with Bash’s operand-less `wait`, preventing flaky passes under heavy macOS Turbo load without changing runner behavior.

<sup>Written for commit e12ef9065685220cde9bf6df04d9a6527ce9e75e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

