### PR TITLE
Simplify integration navigation

### DIFF
--- a/apps/docs/content/docs/how-to/author-workflows/define-listener-success.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/define-listener-success.mdx
@@ -14,7 +14,7 @@ when a final event arrives.
 
 You need:
 
-- A custom webhook integration connection and its ingest URL.
+- A [custom webhook](/integrations/webhooks) integration connection and its ingest URL.
 - The integration connection slug. This guide uses `task_hook` as a placeholder.
 - A project that can sync workflow files.
 - An online runner with the `ubuntu-latest` label.

--- a/apps/docs/content/docs/how-to/author-workflows/index.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/index.mdx
@@ -8,6 +8,9 @@ Use these guides to change a workflow file and get a clear result. Most tasks
 need a project that can sync workflow files. Each guide also lists the runner,
 provider, integration connection, or repository access it needs.
 
+Use the [integrations catalog](/integrations) to find and connect a provider
+when a guide needs one.
+
 ## Start and route work
 
 <Cards>

--- a/apps/docs/content/docs/how-to/author-workflows/use-integration-tools.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/use-integration-tools.mdx
@@ -11,7 +11,7 @@ receives no write operation.
 
 You need:
 
-- A project connected to GitHub.
+- A project [connected to GitHub](/integrations/github/setup).
 - Its integration connection slug. This guide uses `github_acme` as a placeholder.
 - A GitHub integration connection that supports agent tools.
 - An online runner with the `ubuntu-latest` label.

--- a/apps/docs/content/docs/how-to/recipes/checks-on-push.mdx
+++ b/apps/docs/content/docs/how-to/recipes/checks-on-push.mdx
@@ -11,7 +11,7 @@ an agent to review the repository only after the test job succeeds.
 
 You need:
 
-- A Shipfox project connected to GitHub.
+- A Shipfox project [connected to GitHub](/integrations/github/setup).
 - The GitHub integration connection slug. This recipe uses `github_acme` as a placeholder.
 - An online runner with the `ubuntu-latest` label.
 - A configured model provider and workspace agent defaults.

--- a/apps/docs/content/docs/how-to/recipes/index.mdx
+++ b/apps/docs/content/docs/how-to/recipes/index.mdx
@@ -9,6 +9,9 @@ the basic workflow parts from [Understand](/understand). Replace the values
 noted in the recipe, then run it and change the commands or prompts to fit your
 repository.
 
+Use the [integrations catalog](/integrations) to connect a provider before you
+use a recipe that needs one.
+
 <Cards>
   <Card title="Run checks on every push" href="/how-to/recipes/checks-on-push">
     Run tests before an agent reviews each GitHub push.

--- a/apps/docs/content/docs/how-to/recipes/parallel-ci-agent-review.mdx
+++ b/apps/docs/content/docs/how-to/recipes/parallel-ci-agent-review.mdx
@@ -11,7 +11,7 @@ should start only after both checks pass.
 
 You need:
 
-- A project connected to GitHub. Find its integration connection slug in **Settings → Integrations**.
+- A project [connected to GitHub](/integrations/github/setup). Find its integration connection slug in **Settings → Integrations**.
 - An online runner with the `ubuntu-latest` label.
 - A configured model provider and workspace agent defaults.
 - A Node.js repository with `lint` and `test` scripts.

--- a/apps/docs/content/docs/how-to/set-up-work/index.mdx
+++ b/apps/docs/content/docs/how-to/set-up-work/index.mdx
@@ -11,14 +11,8 @@ needs.
 ## Connect external systems
 
 <Cards>
-  <Card title="Connect GitHub" href="/integrations/github/setup">
-    Install the GitHub App and create a workspace integration connection.
-  </Card>
-  <Card title="Connect Sentry" href="/integrations/sentry/setup">
-    Install the Sentry App and create a workspace integration connection.
-  </Card>
-  <Card title="Create a custom webhook" href="/integrations/webhooks/setup">
-    Receive events from a system without a built-in integration.
+  <Card title="Browse integrations" href="/integrations">
+    Find a provider in the catalog and connect it.
   </Card>
   <Card title="Inspect an integration connection" href="/how-to/set-up-work/manage-integration-connections">
     Find its slug and confirm recent events.

--- a/apps/docs/content/docs/how-to/set-up-work/manage-integration-connections.mdx
+++ b/apps/docs/content/docs/how-to/set-up-work/manage-integration-connections.mdx
@@ -10,11 +10,7 @@ task. It does not change the integration connection.
 ## Before you begin
 
 You need an existing integration connection and access to its settings. If you do not have
-one, use one of these setup guides:
-
-- [GitHub](/integrations/github/setup).
-- [Sentry](/integrations/sentry/setup).
-- [Custom webhook](/integrations/webhooks/setup).
+one, connect one from the [integrations catalog](/integrations).
 
 ## Copy the integration connection slug
 
@@ -36,6 +32,5 @@ Send one safe test event from the provider. Open the new event. Check that:
 3. The payload shows the test item you sent.
 4. The result shows if a workflow matched.
 
-The [Integrations reference](/integrations) lists provider events. Use
-[Troubleshoot event routing](/how-to/run-and-troubleshoot/event-routing) when
+Use [Troubleshoot event routing](/how-to/run-and-troubleshoot/event-routing) when
 delivery succeeds but no run appears.

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -19,11 +19,14 @@ Shipfox turns your engineering work into workflows that AI agents can run. You w
 />
 
 <Cards>
-  <Card title="See how it works" href="/understand">
-    The run model in one page: triggers, jobs, steps, agents, and runners.
-  </Card>
   <Card title="Get started" href="/getting-started">
     Connect a repository and run your first workflow in a few minutes.
+  </Card>
+  <Card title="Browse integrations" href="/integrations">
+    Find a provider in the catalog and connect it.
+  </Card>
+  <Card title="See how it works" href="/understand">
+    The run model in one page: triggers, jobs, steps, agents, and runners.
   </Card>
 </Cards>
 

--- a/apps/docs/content/docs/integrations/meta.json
+++ b/apps/docs/content/docs/integrations/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Integrations",
-  "pages": ["index", "github", "sentry", "webhooks", "linear", "slack"]
+  "pages": ["..."]
 }

--- a/apps/docs/content/docs/tutorials/index.mdx
+++ b/apps/docs/content/docs/tutorials/index.mdx
@@ -7,6 +7,9 @@ description: "Learn Shipfox by building complete projects and checking your work
 Tutorials help you learn by building a project. Each one gives you a safe
 starting point. Follow the steps in order and check your work as you go.
 
+Use the [integrations catalog](/integrations) to find and connect a provider
+when a tutorial needs one.
+
 <Cards>
   <Card title="Run your first workflow" href="/getting-started">
     Connect a project, then verify a command and agent in one run.


### PR DESCRIPTION
Make the integrations catalog the single discovery path across the documentation.

The homepage and Set Up Work previously duplicated provider discovery, while the sidebar required a hand-maintained provider list. Those paths could drift and become noisy as more providers were added.

The catalog is now the shared entry point. The Integrations folder auto-includes provider pages, preserving existing URLs, breadcrumbs, search, and previous/next navigation without a growing manual list. No redirects or route changes are needed.

Closes ENG-905

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes provider discovery by making the integrations catalog the single entry point across docs, meeting ENG-905. Removes hand‑maintained provider lists and updates links while preserving existing URLs, breadcrumbs, search, and navigation.

- **Refactors**
  - Added “Browse integrations” on the docs homepage and Set Up Work; removed provider-specific cards.
  - Updated guides, recipes, and tutorials to point to `/integrations` and provider setup pages (e.g., `/integrations/github/setup`, `/integrations/webhooks`).
  - Changed integrations `meta.json` to auto-include provider pages via `["..."]`, eliminating the manual sidebar list.

<sup>Written for commit d92538bd99d8265321c28efc2e483f69ab682812. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

