### PR TITLE
Document dependency workflows and validate package artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Run static verification
         run: turbo check type build depcruise --concurrency="$SHIPFOX_TURBO_CONCURRENCY"
 
+      - name: Verify packed published package artifacts
+        run: pnpm check:published-artifacts
+
       - name: Verify packed API runtime closure
         run: pnpm --filter=@shipfox/application-release test:external
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,22 @@ docker compose up -d
 pnpm --filter=@shipfox/api dev
 ```
 
+## Dependency management
+
+Read the [dependency version policy](docs/policies/dependency-versions.md)
+before adding, updating, or exempting a dependency. It defines catalog range
+rules, peer compatibility, coordinated Renovate families, and the contributor
+workflow.
+
+After a dependency change, run:
+
+```sh
+pnpm check:dependencies
+pnpm check:lockfile
+pnpm check:published-artifacts
+pnpm install --frozen-lockfile
+```
+
 ## Module exports and imports
 
 Avoid broad barrel files inside modules. Prefer importing from the file that owns the

--- a/dev/published-package-artifacts.mjs
+++ b/dev/published-package-artifacts.mjs
@@ -1,0 +1,265 @@
+import {spawn} from 'node:child_process';
+import {mkdir, mkdtemp, readdir, readFile, realpath, rm, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {basename, join, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+import {parse as parseYaml} from 'yaml';
+
+const repositoryRoot = resolve(fileURLToPath(new URL('..', import.meta.url)));
+const packageSources = {
+  '@shipfox/application-release': 'tools/application-release',
+  '@shipfox/react-ui': 'libs/shared/react/ui',
+  '@shipfox/redact': 'libs/shared/common/redact',
+};
+const packageNames = Object.keys(packageSources);
+const registryShipfoxPackagePattern = /^@shipfox\+[^@]+@\d/u;
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`Published package artifact validation failed: ${message}\n`);
+    process.exitCode = 1;
+  });
+}
+
+export async function main() {
+  const [workspaceText, sourcePackageEntries] = await Promise.all([
+    readFile(join(repositoryRoot, 'pnpm-workspace.yaml'), 'utf8'),
+    readSourcePackages(),
+  ]);
+  const workspace = parseYaml(workspaceText);
+  const sourcePackages = new Map(sourcePackageEntries);
+  const expectedDependencies = new Map(
+    [...sourcePackages].map(([name, sourcePackage]) => [
+      name,
+      catalogDependencies(sourcePackage.manifest, workspace),
+    ]),
+  );
+  const fixtureRoot = await mkdtemp(join(tmpdir(), 'shipfox-published-artifacts-'));
+  const tarballRoot = join(fixtureRoot, 'tarballs');
+
+  try {
+    await buildPackageArtifacts();
+    await mkdir(tarballRoot);
+    const tarballs = await packPackages([...sourcePackages], tarballRoot);
+    await writeConsumerManifest(fixtureRoot, tarballs, reactUiPeerDependencies(sourcePackages));
+    await run('pnpm', ['install', '--prefer-offline', '--ignore-scripts'], fixtureRoot);
+    await validateInstalledPackages(fixtureRoot, sourcePackages, expectedDependencies);
+    await validateNoRegistryShipfoxPackages(fixtureRoot);
+    await exerciseConsumer(fixtureRoot);
+    process.stdout.write(`Validated ${packageNames.length} packed published package artifacts.\n`);
+  } finally {
+    await rm(fixtureRoot, {recursive: true, force: true});
+  }
+}
+
+function readSourcePackages() {
+  return Promise.all(
+    Object.entries(packageSources).map(async ([name, directory]) => {
+      const manifest = JSON.parse(
+        await readFile(join(repositoryRoot, directory, 'package.json'), 'utf8'),
+      );
+      if (manifest.name !== name) throw new Error(`Expected ${directory} to define ${name}`);
+      if (manifest.private === true) throw new Error(`Representative package ${name} is private`);
+      return [name, {directory: join(repositoryRoot, directory), manifest}];
+    }),
+  );
+}
+
+export function catalogDependencies(manifest, workspaceConfig) {
+  const dependencies = {};
+  for (const [name, reference] of Object.entries(manifest.dependencies ?? {})) {
+    if (typeof reference !== 'string' || !reference.startsWith('catalog:')) {
+      throw new Error(`Representative package ${manifest.name} must use a catalog for ${name}`);
+    }
+    dependencies[name] = catalogRange(reference, name, workspaceConfig);
+  }
+  return dependencies;
+}
+
+export function catalogRange(reference, dependency, workspaceConfig) {
+  const catalogName = reference === 'catalog:' ? 'default' : reference.slice('catalog:'.length);
+  const catalog =
+    catalogName === 'default' ? workspaceConfig.catalog : workspaceConfig.catalogs?.[catalogName];
+  const range = catalog?.[dependency];
+  if (typeof range !== 'string') {
+    throw new Error(`Catalog ${catalogName} does not define ${dependency}`);
+  }
+  return range;
+}
+
+async function buildPackageArtifacts() {
+  await run(
+    'pnpm',
+    ['exec', 'turbo', 'build', 'type:emit', ...packageNames.map((name) => `--filter=${name}`)],
+    repositoryRoot,
+  );
+}
+
+async function packPackages(packages, tarballRoot) {
+  const tarballs = await mapWithConcurrency(packages, 3, async ([name, sourcePackage]) => {
+    const tarball = join(tarballRoot, `${safePackageName(name)}.tgz`);
+    await run('pnpm', ['pack', '--out', tarball], sourcePackage.directory, {stdio: 'ignore'});
+    return [name, tarball];
+  });
+  return Object.fromEntries(tarballs);
+}
+
+async function writeConsumerManifest(root, tarballs, reactUiPeers) {
+  const manifest = {
+    name: 'shipfox-published-package-artifacts-consumer',
+    version: '1.0.0',
+    private: true,
+    type: 'module',
+    dependencies: consumerDependencies(tarballs, reactUiPeers),
+  };
+  await writeFile(join(root, 'package.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
+export function consumerDependencies(tarballs, reactUiPeers) {
+  return {
+    ...Object.fromEntries(
+      Object.entries(tarballs).map(([name, tarball]) => [name, `file:${tarball}`]),
+    ),
+    react: reactUiPeers.react,
+    'react-dom': reactUiPeers['react-dom'],
+  };
+}
+
+function reactUiPeerDependencies(sourcePackages) {
+  const peerDependencies = sourcePackages.get('@shipfox/react-ui')?.manifest.peerDependencies;
+  const react = peerDependencies?.react;
+  const reactDom = peerDependencies?.['react-dom'];
+  if (typeof react !== 'string' || typeof reactDom !== 'string') {
+    throw new Error('@shipfox/react-ui must declare react and react-dom peer dependencies');
+  }
+  return {react, 'react-dom': reactDom};
+}
+
+async function validateInstalledPackages(root, packages, expectedDependencies) {
+  const fixturePath = await realpath(root);
+  for (const [name, sourcePackage] of packages) {
+    const manifestPath = join(root, 'node_modules', name, 'package.json');
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+    if (manifest.version !== sourcePackage.manifest.version) {
+      throw new Error(
+        `Packed ${name} has version ${manifest.version}; expected ${sourcePackage.manifest.version}`,
+      );
+    }
+    const unsupportedProtocol = findUnsupportedProtocol(manifest);
+    if (unsupportedProtocol) {
+      throw new Error(`Packed ${name} contains an unsupported protocol at ${unsupportedProtocol}`);
+    }
+    validateCatalogRanges(name, manifest, expectedDependencies);
+    validatePeerRanges(name, sourcePackage.manifest, manifest);
+    const packagePath = await realpath(join(root, 'node_modules', name));
+    if (!packagePath.startsWith(fixturePath)) {
+      throw new Error(`Packed ${name} resolved outside the external consumer`);
+    }
+  }
+}
+
+export function findUnsupportedProtocol(value, path = 'package.json') {
+  if (typeof value === 'string') {
+    return value.startsWith('catalog:') || value.startsWith('workspace:') ? path : undefined;
+  }
+  if (!value || typeof value !== 'object') return undefined;
+  for (const [key, child] of Object.entries(value)) {
+    const unsupportedProtocol = findUnsupportedProtocol(child, `${path}.${key}`);
+    if (unsupportedProtocol) return unsupportedProtocol;
+  }
+  return undefined;
+}
+
+function validateCatalogRanges(name, manifest, expectedDependencies) {
+  for (const [dependency, expectedRange] of Object.entries(expectedDependencies.get(name) ?? {})) {
+    const actualRange = manifest.dependencies?.[dependency];
+    if (actualRange !== expectedRange) {
+      throw new Error(
+        `Packed ${name} has ${dependency}@${actualRange ?? 'missing'}; expected ${expectedRange}`,
+      );
+    }
+  }
+}
+
+function validatePeerRanges(name, sourceManifest, packedManifest) {
+  const expectedPeers = sourceManifest.peerDependencies ?? {};
+  for (const [peer, expectedRange] of Object.entries(expectedPeers)) {
+    const actualRange = packedManifest.peerDependencies?.[peer];
+    if (actualRange !== expectedRange) {
+      throw new Error(
+        `Packed ${name} has peer ${peer}@${actualRange ?? 'missing'}; expected ${expectedRange}`,
+      );
+    }
+  }
+}
+
+async function validateNoRegistryShipfoxPackages(root) {
+  const virtualStore = await readdir(join(root, 'node_modules/.pnpm'), {withFileTypes: true});
+  const registryPackages = virtualStore
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => registryShipfoxPackagePattern.test(name));
+  if (registryPackages.length > 0) {
+    throw new Error(
+      `External consumer used registry Shipfox packages: ${registryPackages.join(', ')}`,
+    );
+  }
+}
+
+async function exerciseConsumer(root) {
+  const imports = ['@shipfox/redact', '@shipfox/react-ui/button'];
+  await run(
+    process.execPath,
+    [
+      '--input-type=module',
+      '--eval',
+      `const imports = ${JSON.stringify(imports)};
+const modules = await Promise.all(imports.map((specifier) => import(specifier)));
+if (modules.some((module) => Object.keys(module).length === 0)) throw new Error('An imported packed package has no exports.');`,
+    ],
+    root,
+  );
+  await run(
+    process.execPath,
+    [
+      '--input-type=module',
+      '--eval',
+      `const tool = await import('./node_modules/@shipfox/application-release/dist/manifest.js');
+if (typeof tool.createApplicationReleaseManifest !== 'function') throw new Error('Packed application-release is missing its manifest builder.');`,
+    ],
+    root,
+  );
+}
+
+export function safePackageName(name) {
+  return name.replace('@shipfox/', '').replaceAll('/', '-');
+}
+
+async function mapWithConcurrency(values, concurrency, mapper) {
+  const results = new Array(values.length);
+  let nextIndex = 0;
+
+  async function worker() {
+    while (nextIndex < values.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await mapper(values[index]);
+    }
+  }
+
+  await Promise.all(Array.from({length: concurrency}, () => worker()));
+  return results;
+}
+
+function run(command, args, cwd, {stdio = 'inherit'} = {}) {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(command, args, {cwd, stdio});
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code === 0) resolvePromise();
+      else reject(new Error(`${basename(command)} ${args.join(' ')} exited with code ${code}`));
+    });
+  });
+}

--- a/dev/published-package-artifacts.test.mjs
+++ b/dev/published-package-artifacts.test.mjs
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import {describe, test} from 'node:test';
+
+import {
+  catalogDependencies,
+  catalogRange,
+  consumerDependencies,
+  findUnsupportedProtocol,
+  safePackageName,
+} from './published-package-artifacts.mjs';
+
+const workspace = {
+  catalog: {react: '^19.1.1'},
+  catalogs: {testing: {'@testing-library/react': '^16.3.0'}},
+};
+const directDependencyErrorPattern = /must use a catalog for react/u;
+const missingCatalogEntryErrorPattern = /Catalog default does not define missing-package/u;
+
+describe('catalogDependencies', () => {
+  test('resolves default and named catalog references', () => {
+    const manifest = {
+      name: '@fixture/package',
+      dependencies: {react: 'catalog:', '@testing-library/react': 'catalog:testing'},
+    };
+
+    const dependencies = catalogDependencies(manifest, workspace);
+
+    assert.deepEqual(dependencies, {
+      react: '^19.1.1',
+      '@testing-library/react': '^16.3.0',
+    });
+  });
+
+  test('rejects dependency versions outside a catalog', () => {
+    const manifest = {name: '@fixture/package', dependencies: {react: '^19.1.1'}};
+
+    const action = () => catalogDependencies(manifest, workspace);
+
+    assert.throws(action, directDependencyErrorPattern);
+  });
+});
+
+describe('catalogRange', () => {
+  test('rejects a missing catalog entry', () => {
+    const action = () => catalogRange('catalog:', 'missing-package', workspace);
+
+    assert.throws(action, missingCatalogEntryErrorPattern);
+  });
+});
+
+describe('consumerDependencies', () => {
+  test('declares React UI peers without relying on auto-install-peers', () => {
+    const tarballs = {
+      '@shipfox/react-ui': '/tmp/react-ui.tgz',
+      '@shipfox/redact': '/tmp/redact.tgz',
+    };
+
+    const dependencies = consumerDependencies(tarballs, {
+      react: '^19.0.0',
+      'react-dom': '^19.0.0',
+    });
+
+    assert.deepEqual(dependencies, {
+      '@shipfox/react-ui': 'file:/tmp/react-ui.tgz',
+      '@shipfox/redact': 'file:/tmp/redact.tgz',
+      react: '^19.0.0',
+      'react-dom': '^19.0.0',
+    });
+  });
+});
+
+describe('findUnsupportedProtocol', () => {
+  test('reports the nested path of an unsupported package protocol', () => {
+    const manifest = {dependencies: {fixture: 'workspace:*'}};
+
+    const protocolPath = findUnsupportedProtocol(manifest);
+
+    assert.equal(protocolPath, 'package.json.dependencies.fixture');
+  });
+
+  test('accepts ordinary dependency ranges', () => {
+    const manifest = {dependencies: {fixture: '^1.0.0'}};
+
+    const protocolPath = findUnsupportedProtocol(manifest);
+
+    assert.equal(protocolPath, undefined);
+  });
+});
+
+describe('safePackageName', () => {
+  test('makes scoped package names suitable for tarballs', () => {
+    const tarballName = safePackageName('@shipfox/example/package');
+
+    assert.equal(tarballName, 'example-package');
+  });
+});

--- a/docs/policies/dependency-versions.md
+++ b/docs/policies/dependency-versions.md
@@ -57,6 +57,119 @@ pnpm fix:dependencies
 The fix does not update dependencies or format manifests. A non-semver source
 needs a named exception in the repository policy configuration.
 
+## Contributor workflow
+
+### Add a direct dependency
+
+Choose the dependency class before changing a manifest. Use `dependencies` for
+runtime code, `devDependencies` for repository tooling, and
+`optionalDependencies` only for an optional runtime companion. Local Shipfox
+packages use `workspace:`. Peer dependencies use the peer workflow below.
+
+Use pnpm to add an external direct dependency and create its default catalog
+entry in one change. Replace the placeholders with the affected package, npm
+package, and the lowest tested compatible version:
+
+```sh
+pnpm --filter @shipfox/<package> add <dependency>@^<minimum-tested-version> --save-catalog
+```
+
+Use `--save-dev` or `--save-optional` when the dependency belongs in those
+sections:
+
+```sh
+pnpm --filter @shipfox/<package> add <dependency>@^<minimum-tested-version> --save-catalog --save-dev
+pnpm --filter @shipfox/<package> add <dependency>@^<minimum-tested-version> --save-catalog --save-optional
+```
+
+The command writes the selected catalog range in `pnpm-workspace.yaml` and
+uses `catalog:` in the package manifest. Use the caret range by default. Choose
+an exact or tilde range only when the catalog and range rules below allow it.
+
+Run the checks before opening a pull request:
+
+```sh
+pnpm check:dependencies
+pnpm check:lockfile
+pnpm check:published-artifacts
+pnpm install --frozen-lockfile
+```
+
+### Update a dependency or family
+
+Update the catalog entry in `pnpm-workspace.yaml`, then regenerate the
+committed lockfile:
+
+```sh
+pnpm install
+pnpm check:dependencies
+pnpm check:lockfile
+pnpm check:published-artifacts
+```
+
+Update each member of an identical-version family to the same numeric version.
+The coordinated Renovate families below name those members and their range
+shape. Let Renovate make ordinary updates. Change a catalog by hand only for a
+reviewed exception, an urgent fix, or a supported-range correction.
+
+### Add or remove an exception
+
+Start by updating this policy with the dependency class, reason, owner,
+tracking issue, and removal condition. Add a narrowly named Syncpack group in
+`.syncpackrc.json` before the catalog policy group. Limit it to the dependency
+name and dependency type that need the exception. Do not exempt a whole scope
+or all direct dependencies.
+
+Remove the exception group and the policy entry when its removal condition is
+met. Return the direct dependency to `catalog:` and run:
+
+```sh
+pnpm fix:dependencies
+pnpm install
+pnpm check:dependencies
+pnpm check:lockfile
+pnpm check:published-artifacts
+```
+
+### Handle peer dependencies
+
+Peer dependencies are consumer compatibility contracts. Set the supported peer
+range directly in `peerDependencies`. Do not point it at a direct catalog
+range. Keep the matching local development dependency on `catalog:` so the
+workspace tests one installed version.
+
+Check every published package that changes a peer range:
+
+```sh
+pnpm check:dependencies
+pnpm check:published-artifacts
+```
+
+### Investigate a failed check
+
+Run the direct-policy check after a manifest edit. Use its fix command only
+when the dependency already belongs to an approved catalog:
+
+```sh
+pnpm check:dependencies
+pnpm fix:dependencies
+pnpm check:dependencies
+```
+
+For a lockfile audit failure, print the complete deterministic report. It shows
+the exact duplicate and curated-singleton versions from the committed lockfile:
+
+```sh
+pnpm check:lockfile -- --verbose
+```
+
+Do not add an override only to remove an ordinary duplicate. A new override is
+a curated singleton. It must reference a catalog entry and resolve once.
+
+Direct-policy and lockfile CI checks read committed files. Do not add
+`pnpm dedupe --check`, a latest-version lookup, or another registry-dependent
+check to those pull-request gates.
+
 ## Catalog and range rules
 
 The default catalog holds the version intent. It covers eligible direct external

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "check:dependencies": "syncpack lint --no-ansi",
     "check:lockfile": "node dev/dependency-lockfile-audit.mjs",
+    "check:published-artifacts": "node dev/published-package-artifacts.mjs",
     "fix:dependencies": "syncpack fix --no-ansi",
     "test": "node --test dev/*.test.mjs",
     "release:publish": "turbo type build type:emit --filter='./libs/**' --filter='./tools/**' && changeset publish"


### PR DESCRIPTION
Document the contributor path for catalog-managed dependency changes and add a CI check that installs representative packed artifacts in a clean consumer.

Monorepo builds can hide package metadata, generated files, and peer-resolution errors until publication. Validating tarballs before merge makes the policy enforceable and gives contributors a local way to diagnose those failures.

The check covers representative root-export, subpath-export-with-peers, and CLI/tool package shapes to keep CI focused.

Closes ENG-984

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI check that packs and installs representative packages in a clean consumer to catch missing files, bad ranges, and peer issues before merge. Documents a clear contributor workflow for catalog-managed dependencies and adds a local `pnpm check:published-artifacts` script. Closes ENG-984.

- **New Features**
  - CI: run `pnpm check:published-artifacts` to verify packed artifacts before merge.
  - Script `dev/published-package-artifacts.mjs`: packs `@shipfox/application-release`, `@shipfox/react-ui`, `@shipfox/redact`, installs into a clean consumer, validates catalog and peer ranges, rejects `catalog:`/`workspace:` leaks and registry `@shipfox` packages, and smoke-tests imports and CLI.
  - Tests: add `dev/published-package-artifacts.test.mjs` for helper coverage.
  - Docs: add contributor workflow and commands to `docs/policies/dependency-versions.md` and `AGENTS.md`; expose script via `check:published-artifacts` in `package.json`.

<sup>Written for commit a176a881adcf3a8a902ab7c32643b0dfac360299. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

