### PR TITLE
[docs] Add integration documentation drift checks

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -16,7 +16,7 @@
     "start": "next start --port ${SHIPFOX_DOCS_PORT:-3500}",
     "type": "shipfox-tsc-check",
     "generate": "tsx --conditions=development scripts/generate.mjs",
-    "test": "pnpm generate && pnpm test:unit && tsx scripts/check-writing.mjs && tsx scripts/check-links.mjs && tsx scripts/check-workflow-schema.mjs && tsx scripts/check-catalog.mjs",
+    "test": "pnpm generate && pnpm test:unit && tsx scripts/check-writing.mjs && tsx scripts/check-links.mjs && tsx scripts/check-workflow-schema.mjs && tsx scripts/check-catalog.mjs && tsx scripts/check-integration-docs.mjs",
     "test:unit": "tsx --test",
     "postinstall": "fumadocs-mdx"
   },
@@ -45,9 +45,11 @@
     "@shipfox/typescript": "workspace:*",
     "@tailwindcss/postcss": "catalog:",
     "@types/mdx": "catalog:",
+    "@types/js-yaml": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "github-slugger": "catalog:",
+    "js-yaml": "catalog:",
     "postcss": "catalog:",
     "tailwindcss": "catalog:",
     "tsx": "catalog:"

--- a/apps/docs/scripts/check-integration-docs.mjs
+++ b/apps/docs/scripts/check-integration-docs.mjs
@@ -1,0 +1,81 @@
+import {existsSync, readdirSync, readFileSync} from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {load} from 'js-yaml';
+import {catalogCategoryLabels} from '@/lib/integration-catalog';
+import {collectIntegrationDocIssues} from '@/lib/integration-docs-completeness';
+import {registeredIntegrationProviders} from '@/lib/registered-integration-providers';
+
+const docsRoot = fileURLToPath(new URL('..', import.meta.url));
+const integrationsRoot = path.join(docsRoot, 'content', 'docs', 'integrations');
+const generatedCatalogPath = path.join(
+  docsRoot,
+  'content',
+  'generated',
+  'integrations',
+  'catalog.json',
+);
+const triggerSourcesPath = path.join(
+  docsRoot,
+  'content',
+  'docs',
+  'reference',
+  'trigger-sources.mdx',
+);
+const frontmatterPattern = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/u;
+
+const issues = collectIntegrationDocIssues({
+  providers: registeredIntegrationProviders,
+  generatedCatalog: JSON.parse(readFileSync(generatedCatalogPath, 'utf8')),
+  integrationDirectories: readIntegrationDirectories(),
+  categoryLabels: catalogCategoryLabels,
+  triggerSources: readIfExists(triggerSourcesPath),
+});
+
+if (issues.length > 0) {
+  process.stderr.write(
+    `Integration documentation completeness check failed:\n${issues.join('\n')}\n`,
+  );
+  process.exitCode = 1;
+} else {
+  process.stdout.write('Integration documentation matches the registered provider manifest.\n');
+}
+
+function readIntegrationDirectories() {
+  return Object.fromEntries(
+    readdirSync(integrationsRoot, {withFileTypes: true})
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => [entry.name, readIntegrationDirectory(entry.name)]),
+  );
+}
+
+function readIntegrationDirectory(slug) {
+  const directory = path.join(integrationsRoot, slug);
+  const pages = readdirSync(directory, {withFileTypes: true})
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.mdx'))
+    .map((entry) => entry.name.slice(0, -'.mdx'.length));
+  const pageBodies = Object.fromEntries(
+    pages.map((page) => [page, readFileSync(path.join(directory, `${page}.mdx`), 'utf8')]),
+  );
+  const overview = pageBodies.index ? parseOverview(pageBodies.index) : undefined;
+  const metaPath = path.join(directory, 'meta.json');
+
+  return {
+    pages,
+    metaPages: existsSync(metaPath) ? JSON.parse(readFileSync(metaPath, 'utf8')).pages : undefined,
+    pageBodies,
+    overview,
+  };
+}
+
+function parseOverview(content) {
+  const match = frontmatterPattern.exec(content);
+  if (!match) return {body: content};
+  const frontmatter = load(match[1]);
+  const data = typeof frontmatter === 'object' && frontmatter !== null ? frontmatter : {};
+  return {catalog: data.catalog, status: data.status, body: match[2]};
+}
+
+function readIfExists(file) {
+  return existsSync(file) ? readFileSync(file, 'utf8') : undefined;
+}

--- a/apps/docs/scripts/generate.mjs
+++ b/apps/docs/scripts/generate.mjs
@@ -11,36 +11,38 @@ import {
 import {sentryEventCatalog} from '@shipfox/api-integration-sentry-dto';
 import {webhookEventCatalog} from '@shipfox/api-integration-webhook-dto';
 import {buildWorkflowJsonSchema, thinkingLevelsForHarness} from '@shipfox/workflow-document';
+import {registeredIntegrationProviders} from '@/lib/registered-integration-providers';
 import {slugForHeading} from './lib/slug.mjs';
 
 const docsRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
 const markdownLinkPattern = /^\[([^\]]+)\]\(([^)]*)\)$/;
-const integrationCatalogProviders = [
-  {
-    slug: 'github',
-    capabilities: ['events', 'agent_tools'],
+const dtoCatalogBySlug = {
+  github: {
     eventCatalog: githubEventCatalog,
     toolCatalog: githubAgentToolCatalog,
     toolSelectionCatalog: githubAgentToolSelectionCatalog,
   },
-  {
-    slug: 'sentry',
-    capabilities: ['events'],
+  sentry: {
     eventCatalog: sentryEventCatalog,
   },
-  {
-    slug: 'webhooks',
-    capabilities: ['events'],
+  webhooks: {
     eventCatalog: webhookEventCatalog,
   },
-];
+};
+const integrationCatalogProviders = registeredIntegrationProviders
+  .filter((provider) => provider.kind === 'catalog')
+  .map((provider) => ({...provider, ...dtoCatalogBySlug[provider.slug]}));
 const regions = [
   ['content/generated/reference/model-providers.mdx', renderModelProvidersTable],
   ...integrationCatalogProviders.flatMap((provider) => [
-    [
-      `content/generated/integrations/${provider.slug}/events.mdx`,
-      () => renderEventCatalog(provider.eventCatalog),
-    ],
+    ...(provider.eventCatalog
+      ? [
+          [
+            `content/generated/integrations/${provider.slug}/events.mdx`,
+            () => renderEventCatalog(provider.eventCatalog),
+          ],
+        ]
+      : []),
     ...(provider.toolCatalog
       ? [
           [
@@ -60,8 +62,9 @@ function renderIntegrationCatalogData() {
       integrationCatalogProviders.map((provider) => [
         provider.slug,
         {
+          availability: provider.availability,
           capabilities: provider.capabilities,
-          eventCount: provider.eventCatalog.events.length,
+          eventCount: provider.eventCatalog?.events.length ?? 0,
           toolCount: provider.toolCatalog?.length ?? 0,
         },
       ]),

--- a/apps/docs/src/lib/integration-docs-completeness.test.ts
+++ b/apps/docs/src/lib/integration-docs-completeness.test.ts
@@ -1,0 +1,198 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {type CatalogCategory, catalogCategoryLabels} from '@/lib/integration-catalog';
+import {
+  collectIntegrationDocIssues,
+  type IntegrationDocsCompletenessInput,
+} from '@/lib/integration-docs-completeness';
+import {registeredIntegrationProviders} from '@/lib/registered-integration-providers';
+
+const githubToolsIssuePattern = /Integration provider "github": add tools\.mdx/;
+const linearAvailabilityIssuePattern =
+  /Integration provider "linear": set catalog availability to "coming-soon"/;
+const sentryCapabilitiesIssuePattern =
+  /Integration provider "sentry": remove the stale "agent_tools" capability/;
+const cronSectionIssuePattern = /Built-in source "cron": add a "## cron" section/;
+
+const validInput: IntegrationDocsCompletenessInput = {
+  providers: registeredIntegrationProviders,
+  generatedCatalog: {
+    github: {
+      availability: 'available',
+      capabilities: ['source_control', 'events', 'agent_tools'],
+      eventCount: 1,
+      toolCount: 1,
+    },
+    sentry: {availability: 'available', capabilities: ['events'], eventCount: 1, toolCount: 0},
+    webhooks: {availability: 'available', capabilities: ['events'], eventCount: 1, toolCount: 0},
+    linear: {availability: 'coming-soon', capabilities: [], eventCount: 0, toolCount: 0},
+    slack: {availability: 'coming-soon', capabilities: [], eventCount: 0, toolCount: 0},
+  },
+  integrationDirectories: {
+    github: directory(
+      'github',
+      ['index', 'setup', 'events', 'tools'],
+      ['index', 'setup', 'events', 'tools'],
+      {
+        availability: 'available',
+        capabilities: ['source_control', 'events', 'agent_tools'],
+        categories: ['source-control'],
+        aliases: ['git'],
+      },
+    ),
+    sentry: directory('sentry', ['index', 'setup', 'events'], ['index', 'setup', 'events'], {
+      availability: 'available',
+      capabilities: ['events'],
+      categories: ['observability'],
+      aliases: ['errors'],
+    }),
+    webhooks: directory('webhooks', ['index', 'setup', 'events'], ['index', 'setup', 'events'], {
+      availability: 'available',
+      capabilities: ['events'],
+      categories: ['custom'],
+      aliases: ['hooks'],
+    }),
+    linear: directory(
+      'linear',
+      ['index'],
+      ['index'],
+      {
+        availability: 'coming-soon',
+        capabilities: [],
+        categories: ['issue-tracking'],
+        aliases: ['issues'],
+      },
+      'soon',
+    ),
+    slack: directory(
+      'slack',
+      ['index'],
+      ['index'],
+      {
+        availability: 'coming-soon',
+        capabilities: [],
+        categories: ['messaging'],
+        aliases: ['chat'],
+      },
+      'soon',
+    ),
+  },
+  categoryLabels: catalogCategoryLabels,
+  triggerSources: '## Sources at a glance\n| Cron | `cron` | `tick` |\n\n## cron',
+};
+
+test('accepts complete integration documentation', () => {
+  assert.deepEqual(collectIntegrationDocIssues(validInput), []);
+});
+
+test('reports provider-named fixes for missing and stale documentation', () => {
+  const github = validInput.integrationDirectories.github;
+  const linear = validInput.integrationDirectories.linear;
+  const sentry = validInput.integrationDirectories.sentry;
+  const linearOverview = catalogOverview(linear);
+  const sentryOverview = catalogOverview(sentry);
+  const input: IntegrationDocsCompletenessInput = {
+    ...validInput,
+    integrationDirectories: {
+      ...validInput.integrationDirectories,
+      github: {
+        ...github,
+        pages: ['index', 'setup', 'events'],
+        pageBodies: {...github.pageBodies, tools: ''},
+      },
+      linear: {
+        ...linear,
+        overview: {
+          ...linearOverview,
+          catalog: {...linearOverview.catalog, availability: 'available'},
+        },
+      },
+      sentry: {
+        ...sentry,
+        overview: {
+          ...sentryOverview,
+          catalog: {...sentryOverview.catalog, capabilities: ['events', 'agent_tools']},
+        },
+      },
+    },
+    triggerSources: '## Sources at a glance\n| Cron | `cron` | `tick` |',
+  };
+
+  const issues = collectIntegrationDocIssues(input);
+
+  assert.match(issues.join('\n'), githubToolsIssuePattern);
+  assert.match(issues.join('\n'), linearAvailabilityIssuePattern);
+  assert.match(issues.join('\n'), sentryCapabilitiesIssuePattern);
+  assert.match(issues.join('\n'), cronSectionIssuePattern);
+});
+
+test('uses the built-in source identifier for the source table row', () => {
+  const input: IntegrationDocsCompletenessInput = {
+    ...validInput,
+    triggerSources: '## Sources at a glance\n| Schedule | `cron` | `tick` |\n\n## cron',
+  };
+
+  assert.deepEqual(collectIntegrationDocIssues(input), []);
+});
+
+test('reports only the built-in-source diagnostic for its integration directory', () => {
+  const input: IntegrationDocsCompletenessInput = {
+    ...validInput,
+    integrationDirectories: {
+      ...validInput.integrationDirectories,
+      cron: directory('cron', ['index'], ['index'], {
+        availability: 'available',
+        capabilities: [],
+        categories: ['custom'],
+        aliases: ['schedule'],
+      }),
+    },
+  };
+
+  const issues = collectIntegrationDocIssues(input);
+
+  assert.deepEqual(
+    issues.filter((issue) => issue.includes('integrations/cron')),
+    [
+      'Built-in source "cron": remove integrations/cron; it is documented at /reference/trigger-sources.',
+    ],
+  );
+});
+
+function catalogOverview(directory: (typeof validInput.integrationDirectories)[string]) {
+  if (!directory.overview?.catalog) throw new Error('Fixture must include catalog frontmatter.');
+  return {
+    body: directory.overview.body,
+    catalog: directory.overview.catalog,
+    status: directory.overview.status,
+  };
+}
+
+function directory(
+  slug: string,
+  pages: string[],
+  metaPages: string[],
+  catalog: {
+    availability: string;
+    capabilities: string[];
+    categories: CatalogCategory[];
+    aliases: string[];
+  },
+  status?: string,
+) {
+  const categoryProse = catalog.categories
+    .map((category) => catalogCategoryLabels[category])
+    .join(' ');
+  const aliasProse = catalog.aliases.join(' ');
+  return {
+    pages,
+    metaPages,
+    pageBodies: {
+      index: `${categoryProse} ${aliasProse}`,
+      setup: 'Set up the integration.',
+      events: `generated/integrations/${slug}/events.mdx`,
+      tools: `generated/integrations/${slug}/tools.mdx`,
+    },
+    overview: {catalog, status, body: `${categoryProse} ${aliasProse}`},
+  };
+}

--- a/apps/docs/src/lib/integration-docs-completeness.ts
+++ b/apps/docs/src/lib/integration-docs-completeness.ts
@@ -1,0 +1,250 @@
+import type {
+  CatalogAvailability,
+  CatalogCapability,
+  CatalogCategory,
+} from '@/lib/integration-catalog';
+import type {RegisteredIntegrationProvider} from '@/lib/registered-integration-providers';
+
+export interface GeneratedIntegrationCatalogEntry {
+  availability: CatalogAvailability;
+  capabilities: readonly CatalogCapability[];
+  eventCount: number;
+  toolCount: number;
+}
+
+interface IntegrationCatalogFrontmatter {
+  availability?: unknown;
+  capabilities?: unknown;
+  categories?: unknown;
+  aliases?: unknown;
+}
+
+export interface IntegrationDocsDirectory {
+  pages: readonly string[];
+  metaPages?: readonly string[];
+  pageBodies: Readonly<Record<string, string>>;
+  overview?: {
+    catalog?: IntegrationCatalogFrontmatter;
+    status?: unknown;
+    body: string;
+  };
+}
+
+export interface IntegrationDocsCompletenessInput {
+  providers: readonly RegisteredIntegrationProvider[];
+  generatedCatalog: Readonly<Record<string, GeneratedIntegrationCatalogEntry>>;
+  integrationDirectories: Readonly<Record<string, IntegrationDocsDirectory>>;
+  categoryLabels: Readonly<Record<CatalogCategory, string>>;
+  triggerSources?: string;
+}
+
+const canonicalPages = ['index', 'setup', 'events', 'tools'];
+const hardcodedCountPattern = /\b\d+\s+(?:events?|tools?)\b/iu;
+
+export function collectIntegrationDocIssues(input: IntegrationDocsCompletenessInput): string[] {
+  const issues: string[] = [];
+  const manifestCatalogSlugs = new Set<string>();
+  const builtInSourceSlugs = new Set(
+    input.providers
+      .filter((provider) => provider.kind === 'built-in-source')
+      .map((provider) => provider.slug),
+  );
+
+  for (const provider of input.providers) {
+    if (provider.kind === 'catalog') {
+      manifestCatalogSlugs.add(provider.slug);
+      collectCatalogProviderIssues(input, provider, issues);
+    } else {
+      collectBuiltInSourceIssues(input, provider, issues);
+    }
+  }
+
+  for (const slug of Object.keys(input.generatedCatalog)) {
+    if (!manifestCatalogSlugs.has(slug))
+      issues.push(
+        `Integration provider "${slug}": add it to the registered provider manifest or remove its generated catalog entry.`,
+      );
+  }
+
+  for (const slug of Object.keys(input.integrationDirectories)) {
+    if (!manifestCatalogSlugs.has(slug) && !builtInSourceSlugs.has(slug))
+      issues.push(
+        `Integration provider "${slug}": add it to the registered provider manifest or remove its documentation directory.`,
+      );
+  }
+
+  return issues;
+}
+
+function collectCatalogProviderIssues(
+  input: IntegrationDocsCompletenessInput,
+  provider: Extract<RegisteredIntegrationProvider, {kind: 'catalog'}>,
+  issues: string[],
+): void {
+  const prefix = `Integration provider "${provider.slug}"`;
+  const generated = input.generatedCatalog[provider.slug];
+  const directory = input.integrationDirectories[provider.slug];
+
+  if (!generated)
+    issues.push(`${prefix}: add its entry to content/generated/integrations/catalog.json.`);
+  if (!directory) {
+    issues.push(`${prefix}: create integrations/${provider.slug}/ with an index.mdx overview.`);
+    return;
+  }
+
+  const overview = directory.overview;
+  if (!overview?.catalog) {
+    issues.push(
+      `${prefix}: add a catalog frontmatter block to integrations/${provider.slug}/index.mdx.`,
+    );
+  } else {
+    const catalog = overview.catalog;
+    if (catalog.availability !== provider.availability)
+      issues.push(`${prefix}: set catalog availability to "${provider.availability}".`);
+
+    const expectedSoonStatus = provider.availability === 'coming-soon';
+    if ((overview.status === 'soon') !== expectedSoonStatus)
+      issues.push(
+        `${prefix}: ${expectedSoonStatus ? 'set status to "soon"' : 'remove status "soon"'} so it matches availability.`,
+      );
+
+    const actualCapabilities = strings(catalog.capabilities);
+    for (const capability of provider.capabilities) {
+      if (!actualCapabilities.includes(capability))
+        issues.push(`${prefix}: add the "${capability}" capability to catalog frontmatter.`);
+    }
+    for (const capability of actualCapabilities) {
+      if (!provider.capabilities.includes(capability as CatalogCapability))
+        issues.push(
+          `${prefix}: remove the stale "${capability}" capability from catalog frontmatter.`,
+        );
+    }
+
+    const overviewProse = overview.body.toLocaleLowerCase();
+    for (const category of strings(catalog.categories)) {
+      const label = input.categoryLabels[category as CatalogCategory];
+      if (label && !overviewProse.includes(label.toLocaleLowerCase()))
+        issues.push(`${prefix}: mention category label "${label}" in overview prose for search.`);
+    }
+  }
+
+  if (overview) {
+    for (const alias of strings(overview.catalog?.aliases)) {
+      if (!overview.body.toLocaleLowerCase().includes(alias.toLocaleLowerCase()))
+        issues.push(`${prefix}: mention alias "${alias}" in overview prose for search.`);
+    }
+  }
+
+  collectReferencePageIssues(directory, provider, generated, 'events', issues);
+  collectReferencePageIssues(directory, provider, generated, 'tools', issues);
+
+  if (provider.availability === 'coming-soon') {
+    if (provider.capabilities.length > 0)
+      issues.push(
+        `${prefix}: coming-soon providers must not declare capabilities in the manifest.`,
+      );
+    for (const page of canonicalPages.slice(1)) {
+      if (directory.pages.includes(page))
+        issues.push(
+          `${prefix}: remove ${page}.mdx because coming-soon providers have no shipped reference pages.`,
+        );
+    }
+  } else if (!directory.pages.includes('setup')) {
+    issues.push(`${prefix}: add setup.mdx for the connectable provider.`);
+  }
+
+  const unexpectedPages = directory.pages.filter((page) => !canonicalPages.includes(page));
+  for (const page of unexpectedPages)
+    issues.push(`${prefix}: remove or register unsupported page ${page}.mdx.`);
+
+  const expectedMetaPages = canonicalPages.filter((page) => directory.pages.includes(page));
+  if (!sameStrings(directory.metaPages, expectedMetaPages))
+    issues.push(
+      `${prefix}: set meta.json pages to [${expectedMetaPages.join(', ')}] so it matches the existing pages in canonical order.`,
+    );
+
+  for (const page of ['index', 'setup']) {
+    const body = directory.pageBodies[page];
+    if (body && hardcodedCountPattern.test(body))
+      issues.push(
+        `${prefix}: derive event and tool counts from generated reference instead of hardcoding them in ${page}.mdx.`,
+      );
+  }
+}
+
+function collectReferencePageIssues(
+  directory: IntegrationDocsDirectory,
+  provider: Extract<RegisteredIntegrationProvider, {kind: 'catalog'}>,
+  generated: GeneratedIntegrationCatalogEntry | undefined,
+  page: 'events' | 'tools',
+  issues: string[],
+): void {
+  const capability: CatalogCapability = page === 'events' ? 'events' : 'agent_tools';
+  if (!provider.capabilities.includes(capability)) return;
+
+  const prefix = `Integration provider "${provider.slug}"`;
+  const count = page === 'events' ? generated?.eventCount : generated?.toolCount;
+  if (!count)
+    issues.push(
+      `${prefix}: ${capability} requires a generated catalog with a nonzero ${page} count.`,
+    );
+  if (!directory.pages.includes(page)) {
+    issues.push(`${prefix}: add ${page}.mdx for its ${capability} capability.`);
+    return;
+  }
+  if (!directory.metaPages?.includes(page))
+    issues.push(`${prefix}: list ${page} in integrations/${provider.slug}/meta.json.`);
+
+  const generatedPath = `generated/integrations/${provider.slug}/${page}.mdx`;
+  if (!directory.pageBodies[page]?.includes(generatedPath))
+    issues.push(`${prefix}: import the generated ${page} fragment from ${generatedPath}.`);
+}
+
+function collectBuiltInSourceIssues(
+  input: IntegrationDocsCompletenessInput,
+  provider: Extract<RegisteredIntegrationProvider, {kind: 'built-in-source'}>,
+  issues: string[],
+): void {
+  const prefix = `Built-in source "${provider.slug}"`;
+  if (input.integrationDirectories[provider.slug])
+    issues.push(
+      `${prefix}: remove integrations/${provider.slug}; it is documented at ${provider.docRoute}.`,
+    );
+
+  const source = input.triggerSources;
+  if (!source) {
+    issues.push(`${prefix}: add ${provider.docRoute}.mdx with its trigger source reference.`);
+    return;
+  }
+  if (!new RegExp(`^##\\s+${escapeRegExp(provider.anchor)}\\s*$`, 'imu').test(source))
+    issues.push(`${prefix}: add a "## ${provider.anchor}" section to ${provider.docRoute}.mdx.`);
+  const sourceTableRow = source
+    .split('\n')
+    .find((line) => line.startsWith('|') && line.includes(`\`${provider.slug}\``));
+  if (!sourceTableRow)
+    issues.push(
+      `${prefix}: add its \`${provider.slug}\` row to the "Sources at a glance" table in ${provider.docRoute}.mdx.`,
+    );
+  for (const event of provider.events) {
+    if (!source.includes(`\`${event}\``))
+      issues.push(`${prefix}: mention event "${event}" in ${provider.docRoute}.mdx.`);
+  }
+}
+
+function strings(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string')
+    : [];
+}
+
+function sameStrings(actual: readonly string[] | undefined, expected: readonly string[]): boolean {
+  return (
+    !!actual &&
+    actual.length === expected.length &&
+    actual.every((item, index) => item === expected[index])
+  );
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+}

--- a/apps/docs/src/lib/registered-integration-providers.ts
+++ b/apps/docs/src/lib/registered-integration-providers.ts
@@ -1,0 +1,52 @@
+import type {CatalogAvailability, CatalogCapability} from '@/lib/integration-catalog';
+
+interface RegisteredCatalogIntegrationProvider {
+  slug: string;
+  kind: 'catalog';
+  availability: CatalogAvailability;
+  capabilities: readonly CatalogCapability[];
+}
+
+interface RegisteredBuiltInSource {
+  slug: string;
+  kind: 'built-in-source';
+  availability: 'available';
+  events: readonly string[];
+  docRoute: '/reference/trigger-sources';
+  anchor: string;
+}
+
+export type RegisteredIntegrationProvider =
+  | RegisteredCatalogIntegrationProvider
+  | RegisteredBuiltInSource;
+
+export const registeredIntegrationProviders: readonly RegisteredIntegrationProvider[] = [
+  {
+    slug: 'github',
+    kind: 'catalog',
+    availability: 'available',
+    capabilities: ['source_control', 'events', 'agent_tools'],
+  },
+  {
+    slug: 'sentry',
+    kind: 'catalog',
+    availability: 'available',
+    capabilities: ['events'],
+  },
+  {
+    slug: 'webhooks',
+    kind: 'catalog',
+    availability: 'available',
+    capabilities: ['events'],
+  },
+  {slug: 'linear', kind: 'catalog', availability: 'coming-soon', capabilities: []},
+  {slug: 'slack', kind: 'catalog', availability: 'coming-soon', capabilities: []},
+  {
+    slug: 'cron',
+    kind: 'built-in-source',
+    availability: 'available',
+    events: ['tick'],
+    docRoute: '/reference/trigger-sources',
+    anchor: 'cron',
+  },
+];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -692,6 +692,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: 'catalog:'
         version: 4.3.2
+      '@types/js-yaml':
+        specifier: 'catalog:'
+        version: 4.0.9
       '@types/mdx':
         specifier: 'catalog:'
         version: 2.0.14
@@ -704,6 +707,9 @@ importers:
       github-slugger:
         specifier: 'catalog:'
         version: 2.0.0
+      js-yaml:
+        specifier: 'catalog:'
+        version: 4.2.0
       postcss:
         specifier: 'catalog:'
         version: 8.5.15


### PR DESCRIPTION
Add a manifest-backed docs validation that reconciles registered providers, generated DTO catalogs, and the real integrations content tree.

The catalog validator previously ran only during Next.js server rendering, so CI could accept missing provider pages or stale capability frontmatter. The standalone check makes those failures explicit and gives provider-named repairs for missing setup, events, tools, metadata, search terms, and cron trigger-source coverage.

Keeping the checks in the docs package avoids importing application bootstrap code and preserves the existing generated fragments as the provider-owned source for event and tool inventories.

Closes ENG-906

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a manifest-backed check that fails CI when integration docs drift from the registered providers or generated DTO catalogs. Aligns the docs tree, catalog JSON, and built-in source docs, and adds clear, provider-named diagnostics. Addresses ENG-906.

- **New Features**
  - New `scripts/check-integration-docs.mjs` validates docs against the provider manifest and generated catalogs.
  - Adds `src/lib/registered-integration-providers.ts` and uses it in `scripts/generate.mjs` (handles availability, optional DTOs).
  - Verifies overview frontmatter (availability, capabilities), required pages (setup/events/tools), `meta.json` order, and imports of generated fragments.
  - Prevents hardcoded event/tool counts; enforces search terms (categories, aliases).
  - Checks built-in sources (e.g., cron) are covered in `/reference/trigger-sources` with a section, table row, and events.
  - Provider-named diagnostics; unit tests added; wired into `pnpm test`.

- **Dependencies**
  - Adds `js-yaml` and `@types/js-yaml`.

<sup>Written for commit bc240330e095127fc9dde6309b36c472d7fd6bfb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

