### PR TITLE
[api-auth] Stabilize database-backed tests

### DIFF
--- a/.changeset/calm-otters-wait.md
+++ b/.changeset/calm-otters-wait.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-auth": patch
+---
+
+Serializes real-database auth test files to prevent shared rate-limit state from causing intermittent failures.

--- a/libs/api/auth/vitest.config.ts
+++ b/libs/api/auth/vitest.config.ts
@@ -3,6 +3,9 @@ import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
 export default defineConfig(
   {
     test: {
+      // Test files share real PostgreSQL tables, including opportunistic rate-limit pruning.
+      // Keep files serial so one file cannot delete or lock another file's fixtures.
+      fileParallelism: false,
       globalSetup: ['test/globalSetup.ts'],
       setupFiles: ['test/setup.ts'],
     },


### PR DESCRIPTION
Serialize `@shipfox/api-auth` Vitest files that share real PostgreSQL tables and add the required patch changeset.

The rate-limit core tests use fixed windows and background pruning while route tests use current-time buckets and deliberate lock contention. Parallel files could therefore delete or lock another file's fixtures, causing intermittent counter mismatches, 503 responses, and timeouts in branch-wide gates.

Per-worker databases would preserve parallelism but require provisioning and migrating a separate database for every worker. File serialization is the smallest isolation boundary and leaves production behavior unchanged; the package suite increases from roughly 4 seconds to 19 seconds.

Validated with the branch-scoped Turbo build, test, and check gates, plus the focused 176-test API-auth suite and the original two-file reproduction.

Refs ENG-993

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serialize `@shipfox/api-auth` `Vitest` files to stabilize database-backed tests that share PostgreSQL tables, preventing rate-limit state collisions, timeouts, and 503s. Addresses ENG-993; test runtime increases from ~4s to ~19s.

- **Bug Fixes**
  - Set `fileParallelism: false` in `libs/api/auth/vitest.config.ts`.
  - Added patch changeset for `@shipfox/api-auth`.

<sup>Written for commit fb2f174811442301c95f70f04d7fd403f84ced60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

