### PR TITLE
[integrations] Add Slack inbound event receivers

### DIFF
--- a/.changeset/nimble-badgers-wave.md
+++ b/.changeset/nimble-badgers-wave.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-integration-slack": minor
+"@shipfox/api-integration-slack-dto": patch
+---
+
+Adds signed Slack Events API and slash-command receivers that publish normalized integration events without persisting command verification tokens.

--- a/libs/api/integration/core/src/providers/slack.ts
+++ b/libs/api/integration/core/src/providers/slack.ts
@@ -1,4 +1,7 @@
 import {config} from '#config.js';
+import {getIntegrationConnectionById} from '#db/connections.js';
+import {db} from '#db/db.js';
+import {publishIntegrationEventReceived, recordDeliveryOnly} from '#db/webhook-deliveries.js';
 import type {IntegrationModuleParts, IntegrationProviderModule} from '#providers/types.js';
 
 const SLACK_MIGRATIONS_TABLE = '__drizzle_migrations_integrations_slack';
@@ -11,7 +14,14 @@ async function loadSlackModuleParts(): Promise<IntegrationModuleParts> {
   } = await import('@shipfox/api-integration-slack');
 
   return {
-    provider: createSlackIntegrationProvider(),
+    provider: createSlackIntegrationProvider({
+      routes: {
+        coreDb: db,
+        publishIntegrationEventReceived,
+        recordDeliveryOnly,
+        getIntegrationConnectionById,
+      },
+    }),
     database: {
       db: slackDb,
       migrationsPath: slackMigrationsPath,

--- a/libs/api/integration/slack-dto/src/schemas/index.test.ts
+++ b/libs/api/integration/slack-dto/src/schemas/index.test.ts
@@ -9,6 +9,7 @@ import {
   slackEventNames,
   slackEventPayloadSchema,
   slackEventsRequestSchema,
+  slackSlashCommandPayloadSchema,
   slackSlashCommandSchema,
   slackUrlVerificationSchema,
 } from './index.js';
@@ -94,6 +95,12 @@ describe('Slack slash command schema', () => {
     const {command: _command, ...commandWithoutCommand} = slashCommand;
 
     expect(slackSlashCommandSchema.safeParse(commandWithoutCommand).success).toBe(false);
+  });
+
+  it('omits the Slack verification token from published command payloads', () => {
+    const result = slackSlashCommandPayloadSchema.parse(slashCommand);
+
+    expect(result).not.toHaveProperty('token');
   });
 });
 

--- a/libs/api/integration/slack-dto/src/schemas/index.ts
+++ b/libs/api/integration/slack-dto/src/schemas/index.ts
@@ -71,6 +71,9 @@ export const slackSlashCommandSchema = z.object({
 });
 export type SlackSlashCommandDto = z.infer<typeof slackSlashCommandSchema>;
 
+export const slackSlashCommandPayloadSchema = slackSlashCommandSchema.omit({token: true});
+export type SlackSlashCommandPayloadDto = z.infer<typeof slackSlashCommandPayloadSchema>;
+
 export const slackEventPayloadSchema = z
   .object({
     type: z.enum(slackApiEventTypes),
@@ -89,8 +92,6 @@ export const slackEventPayloadSchema = z
   })
   .passthrough();
 export type SlackEventPayloadDto = z.infer<typeof slackEventPayloadSchema>;
-
-export type SlackSlashCommandPayloadDto = SlackSlashCommandDto;
 
 export const createSlackInstallBodySchema = z.object({
   workspace_id: z.string().uuid(),

--- a/libs/api/integration/slack/package.json
+++ b/libs/api/integration/slack/package.json
@@ -45,8 +45,11 @@
     "@shipfox/api-integration-slack-dto": "workspace:*",
     "@shipfox/config": "workspace:*",
     "@shipfox/node-drizzle": "workspace:*",
+    "@shipfox/node-fastify": "workspace:*",
+    "@shipfox/node-opentelemetry": "workspace:*",
     "@shipfox/node-postgres": "workspace:*",
-    "drizzle-orm": "catalog:"
+    "drizzle-orm": "catalog:",
+    "zod": "catalog:"
   },
   "peerDependencies": {
     "@shipfox/api-secrets": "workspace:*"

--- a/libs/api/integration/slack/src/core/signature.test.ts
+++ b/libs/api/integration/slack/src/core/signature.test.ts
@@ -1,0 +1,45 @@
+import {createHmac} from 'node:crypto';
+import {verifySlackSignature} from './signature.js';
+
+const secret = 'test-signing-secret';
+const timestamp = '1721300000';
+const rawBody = '{"type":"event_callback"}';
+const now = Number(timestamp) * 1000;
+
+function signature(body = rawBody): string {
+  return `v0=${createHmac('sha256', secret).update(`v0:${timestamp}:${body}`).digest('hex')}`;
+}
+
+describe('verifySlackSignature', () => {
+  it('accepts a valid current Slack v0 signature', () => {
+    const result = verifySlackSignature({
+      signingSecret: secret,
+      signature: signature(),
+      timestamp,
+      rawBody,
+      now,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it.each([
+    ['a tampered body', {rawBody: '{"type":"tampered"}'}],
+    ['a missing signature', {signature: undefined}],
+    ['an empty signing secret', {signingSecret: ''}],
+    ['a missing timestamp', {timestamp: undefined}],
+    ['a malformed timestamp', {timestamp: 'not-a-timestamp'}],
+    ['a stale timestamp', {now: now + 300_001}],
+  ])('rejects %s', (_description, overrides) => {
+    const result = verifySlackSignature({
+      signingSecret: secret,
+      signature: signature(),
+      timestamp,
+      rawBody,
+      now,
+      ...overrides,
+    });
+
+    expect(result).toBe(false);
+  });
+});

--- a/libs/api/integration/slack/src/core/signature.ts
+++ b/libs/api/integration/slack/src/core/signature.ts
@@ -1,0 +1,41 @@
+import {createHmac, timingSafeEqual} from 'node:crypto';
+
+const unixTimestampPattern = /^\d+$/;
+
+export interface VerifySlackSignatureParams {
+  signingSecret: string;
+  signature: string | undefined;
+  timestamp: string | undefined;
+  rawBody: string;
+  now?: number | undefined;
+  replayWindowMs?: number | undefined;
+}
+
+export function verifySlackSignature({
+  signingSecret,
+  signature,
+  timestamp,
+  rawBody,
+  now = Date.now(),
+  replayWindowMs = 300_000,
+}: VerifySlackSignatureParams): boolean {
+  if (!signingSecret || !signature || !timestamp || !unixTimestampPattern.test(timestamp)) {
+    return false;
+  }
+
+  const timestampSeconds = Number(timestamp);
+  if (!Number.isSafeInteger(timestampSeconds)) return false;
+  const timestampMilliseconds = timestampSeconds * 1000;
+  if (!Number.isSafeInteger(timestampMilliseconds)) return false;
+  if (Math.abs(now - timestampMilliseconds) > replayWindowMs) return false;
+
+  const expected = `v0=${createHmac('sha256', signingSecret)
+    .update(`v0:${timestamp}:${rawBody}`)
+    .digest('hex')}`;
+  const expectedBuffer = Buffer.from(expected, 'utf8');
+  const receivedBuffer = Buffer.from(signature, 'utf8');
+  return (
+    expectedBuffer.length === receivedBuffer.length &&
+    timingSafeEqual(expectedBuffer, receivedBuffer)
+  );
+}

--- a/libs/api/integration/slack/src/core/webhook.test.ts
+++ b/libs/api/integration/slack/src/core/webhook.test.ts
@@ -1,0 +1,269 @@
+import {randomUUID} from 'node:crypto';
+import type {
+  GetIntegrationConnectionByIdFn,
+  IntegrationConnection,
+} from '@shipfox/api-integration-core-dto';
+import {db} from '#db/db.js';
+import {upsertSlackInstallation} from '#db/installations.js';
+import {slackInstallations} from '#db/schema/installations.js';
+import {handleSlackCommand, handleSlackEvent} from './webhook.js';
+
+function fakeConnection(overrides: Partial<IntegrationConnection> = {}): IntegrationConnection {
+  return {
+    id: randomUUID(),
+    workspaceId: randomUUID(),
+    provider: 'slack',
+    externalAccountId: 'T1',
+    slug: 'slack_acme',
+    displayName: 'Slack Acme',
+    lifecycleStatus: 'active',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function eventEnvelope(overrides: Record<string, unknown> = {}) {
+  return {
+    type: 'event_callback' as const,
+    team_id: 'T1',
+    api_app_id: 'A1',
+    event: {type: 'app_mention', channel: 'C1', user: 'U1', text: 'hello', ts: '1.0'},
+    event_id: 'Ev1',
+    event_time: 1_721_300_000,
+    ...overrides,
+  };
+}
+
+function command(overrides: Record<string, unknown> = {}) {
+  return {
+    token: 'shared-verification-token',
+    command: '/deploy',
+    team_id: 'T1',
+    channel_id: 'C1',
+    user_id: 'U1',
+    response_url: 'https://hooks.slack.com/commands/1',
+    trigger_id: '1337.42',
+    text: '',
+    ...overrides,
+  };
+}
+
+async function seedInstallation(
+  connection: IntegrationConnection,
+  status: 'installed' | 'revoked' = 'installed',
+) {
+  await upsertSlackInstallation({
+    connectionId: connection.id,
+    teamId: 'T1',
+    teamName: 'Acme',
+    appId: 'A1',
+    botUserId: 'UBOT',
+    scopes: [],
+    status,
+  });
+}
+
+function handlers(connection = fakeConnection()) {
+  return {
+    connection,
+    publishIntegrationEventReceived: vi.fn(() => Promise.resolve({published: true})),
+    recordDeliveryOnly: vi.fn(() => Promise.resolve()),
+    getIntegrationConnectionById: vi.fn<GetIntegrationConnectionByIdFn>(() =>
+      Promise.resolve(connection),
+    ),
+  };
+}
+
+describe('Slack webhook handlers', () => {
+  beforeEach(async () => {
+    await db().delete(slackInstallations);
+  });
+
+  it('publishes a supported event with a flattened payload', async () => {
+    const deps = handlers();
+    await seedInstallation(deps.connection);
+
+    const result = await handleSlackEvent({
+      tx: db(),
+      deliveryId: 'Ev1',
+      envelope: eventEnvelope(),
+      ...deps,
+    });
+
+    expect(result.outcome).toBe('published');
+    expect(deps.publishIntegrationEventReceived).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          event: 'app_mention',
+          deliveryId: 'Ev1',
+          payload: expect.objectContaining({
+            type: 'app_mention',
+            channel: 'C1',
+            team_id: 'T1',
+            event_id: 'Ev1',
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('reports a duplicate for a repeated Slack event delivery id', async () => {
+    const deps = handlers();
+    deps.publishIntegrationEventReceived.mockResolvedValue({published: false});
+    await seedInstallation(deps.connection);
+
+    const result = await handleSlackEvent({
+      tx: db(),
+      deliveryId: 'Ev-replayed',
+      envelope: eventEnvelope({event_id: 'Ev-replayed'}),
+      ...deps,
+    });
+
+    expect(result.outcome).toBe('duplicate');
+    expect(deps.publishIntegrationEventReceived).toHaveBeenCalledWith(
+      expect.objectContaining({event: expect.objectContaining({deliveryId: 'Ev-replayed'})}),
+    );
+  });
+
+  it.each([
+    ['a bot-authored event', {event: {type: 'message', bot_id: 'B1'}}],
+    ['an event from this installation bot', {event: {type: 'reaction_added', user: 'UBOT'}}],
+    [
+      'a nested edited bot message',
+      {event: {type: 'message', subtype: 'message_changed', message: {bot_id: 'B1'}}},
+    ],
+  ])('records and drops %s', async (_description, override) => {
+    const deps = handlers();
+    await seedInstallation(deps.connection);
+
+    const result = await handleSlackEvent({
+      tx: db(),
+      deliveryId: randomUUID(),
+      envelope: eventEnvelope(override),
+      ...deps,
+    });
+
+    expect(result.outcome).toBe('self-message');
+    expect(deps.publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(deps.recordDeliveryOnly).toHaveBeenCalledTimes(1);
+  });
+
+  it('records an unknown team without resolving a connection', async () => {
+    const deps = handlers();
+
+    const result = await handleSlackEvent({
+      tx: db(),
+      deliveryId: 'Ev-missing',
+      envelope: eventEnvelope({team_id: 'T-missing'}),
+      ...deps,
+    });
+
+    expect(result.outcome).toBe('unknown-team');
+    expect(deps.getIntegrationConnectionById).not.toHaveBeenCalled();
+    expect(deps.recordDeliveryOnly).toHaveBeenCalledWith(
+      expect.objectContaining({provider: 'slack', deliveryId: 'Ev-missing'}),
+    );
+  });
+
+  it('records an inactive connection', async () => {
+    const deps = handlers(fakeConnection({lifecycleStatus: 'disabled'}));
+    await seedInstallation(deps.connection);
+
+    const result = await handleSlackEvent({
+      tx: db(),
+      deliveryId: 'Ev-disabled',
+      envelope: eventEnvelope(),
+      ...deps,
+    });
+
+    expect(result.outcome).toBe('inactive-connection');
+    expect(deps.publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(deps.recordDeliveryOnly).toHaveBeenCalledTimes(1);
+  });
+
+  it('records a revoked installation without resolving a connection', async () => {
+    const deps = handlers();
+    await seedInstallation(deps.connection, 'revoked');
+
+    const result = await handleSlackEvent({
+      tx: db(),
+      deliveryId: 'Ev-revoked',
+      envelope: eventEnvelope(),
+      ...deps,
+    });
+
+    expect(result.outcome).toBe('revoked-installation');
+    expect(deps.getIntegrationConnectionById).not.toHaveBeenCalled();
+    expect(deps.recordDeliveryOnly).toHaveBeenCalledTimes(1);
+  });
+
+  it('records an installation whose connection is missing', async () => {
+    const deps = handlers();
+    deps.getIntegrationConnectionById.mockResolvedValue(undefined);
+    await seedInstallation(deps.connection);
+
+    const result = await handleSlackEvent({
+      tx: db(),
+      deliveryId: 'Ev-missing-connection',
+      envelope: eventEnvelope(),
+      ...deps,
+    });
+
+    expect(result.outcome).toBe('missing-connection');
+    expect(deps.recordDeliveryOnly).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops unsupported event types after resolving the installation', async () => {
+    const deps = handlers();
+    await seedInstallation(deps.connection);
+
+    const result = await handleSlackEvent({
+      tx: db(),
+      deliveryId: 'Ev-unsupported',
+      envelope: eventEnvelope({event: {type: 'channel_created'}}),
+      ...deps,
+    });
+
+    expect(result.outcome).toBe('unsupported-event');
+    expect(deps.publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(deps.recordDeliveryOnly).toHaveBeenCalledTimes(1);
+  });
+
+  it('publishes a command without its verification token', async () => {
+    const deps = handlers();
+    await seedInstallation(deps.connection);
+
+    const result = await handleSlackCommand({
+      tx: db(),
+      deliveryId: '1337.42',
+      command: command(),
+      ...deps,
+    });
+
+    expect(result.outcome).toBe('published');
+    expect(deps.publishIntegrationEventReceived).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          event: 'slash_command',
+          payload: expect.not.objectContaining({token: expect.anything()}),
+        }),
+      }),
+    );
+  });
+
+  it('reports a duplicate slash command delivery', async () => {
+    const deps = handlers();
+    deps.publishIntegrationEventReceived.mockResolvedValue({published: false});
+    await seedInstallation(deps.connection);
+
+    const result = await handleSlackCommand({
+      tx: db(),
+      deliveryId: '1337.42',
+      command: command(),
+      ...deps,
+    });
+
+    expect(result.outcome).toBe('duplicate');
+  });
+});

--- a/libs/api/integration/slack/src/core/webhook.ts
+++ b/libs/api/integration/slack/src/core/webhook.ts
@@ -1,0 +1,223 @@
+import type {
+  GetIntegrationConnectionByIdFn,
+  IntegrationConnection,
+  IntegrationTx,
+  PublishIntegrationEventReceivedFn,
+  RecordDeliveryOnlyFn,
+} from '@shipfox/api-integration-core-dto';
+import {
+  SLACK_PROVIDER,
+  SLACK_SLASH_COMMAND_EVENT,
+  type SlackEventBaseEnvelopeDto,
+  type SlackSlashCommandDto,
+  slackEventEnvelopeSchema,
+} from '@shipfox/api-integration-slack-dto';
+import {logger} from '@shipfox/node-opentelemetry';
+import {z} from 'zod';
+import {getSlackInstallationByTeamId, type SlackInstallation} from '#db/installations.js';
+
+const slackSelfAuthoredEventSchema = z
+  .object({
+    bot_id: z.string().optional(),
+    user: z.string().optional(),
+    message: z
+      .object({
+        bot_id: z.string().optional(),
+        user: z.string().optional(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
+
+export type SlackWebhookOutcome =
+  | 'published'
+  | 'duplicate'
+  | 'unknown-team'
+  | 'revoked-installation'
+  | 'missing-connection'
+  | 'inactive-connection'
+  | 'unsupported-event'
+  | 'self-message';
+
+interface SlackWebhookParams {
+  tx: IntegrationTx;
+  deliveryId: string;
+  publishIntegrationEventReceived: PublishIntegrationEventReceivedFn;
+  recordDeliveryOnly: RecordDeliveryOnlyFn;
+  getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
+}
+
+export interface HandleSlackEventParams extends SlackWebhookParams {
+  envelope: SlackEventBaseEnvelopeDto;
+}
+
+export interface HandleSlackCommandParams extends SlackWebhookParams {
+  command: SlackSlashCommandDto;
+}
+
+type SlackConnectionResolution =
+  | {kind: 'ok'; connection: IntegrationConnection; installation: SlackInstallation}
+  | {
+      kind: 'drop';
+      outcome: Exclude<
+        SlackWebhookOutcome,
+        'published' | 'duplicate' | 'unsupported-event' | 'self-message'
+      >;
+    };
+
+export async function handleSlackEvent(
+  params: HandleSlackEventParams,
+): Promise<{outcome: SlackWebhookOutcome}> {
+  const resolution = await resolveSlackConnection({
+    ...params,
+    teamId: params.envelope.team_id,
+  });
+  if (resolution.kind === 'drop') return resolution;
+
+  if (isSelfAuthoredSlackEvent(params.envelope.event, resolution.installation.botUserId)) {
+    await recordSlackDeliveryOnly(params);
+    return {outcome: 'self-message'};
+  }
+
+  const supported = slackEventEnvelopeSchema.safeParse(params.envelope);
+  if (!supported.success) {
+    logger().info(
+      {
+        deliveryId: params.deliveryId,
+        teamId: params.envelope.team_id,
+        type: params.envelope.event.type,
+      },
+      'slack webhook: unsupported event, dropping',
+    );
+    await recordSlackDeliveryOnly(params);
+    return {outcome: 'unsupported-event'};
+  }
+
+  const result = await params.publishIntegrationEventReceived({
+    tx: params.tx,
+    event: {
+      provider: SLACK_PROVIDER,
+      source: resolution.connection.slug,
+      event: supported.data.event.type,
+      workspaceId: resolution.connection.workspaceId,
+      connectionId: resolution.connection.id,
+      connectionName: resolution.connection.displayName,
+      deliveryId: params.deliveryId,
+      receivedAt: new Date().toISOString(),
+      payload: {
+        ...supported.data.event,
+        team_id: supported.data.team_id,
+        api_app_id: supported.data.api_app_id,
+        event_id: supported.data.event_id,
+        event_time: supported.data.event_time,
+      },
+    },
+  });
+
+  return {outcome: result.published ? 'published' : 'duplicate'};
+}
+
+export async function handleSlackCommand(
+  params: HandleSlackCommandParams,
+): Promise<{outcome: Exclude<SlackWebhookOutcome, 'unsupported-event' | 'self-message'>}> {
+  const resolution = await resolveSlackConnection({
+    ...params,
+    teamId: params.command.team_id,
+  });
+  if (resolution.kind === 'drop') return resolution;
+
+  const {token: _token, ...payload} = params.command;
+  const result = await params.publishIntegrationEventReceived({
+    tx: params.tx,
+    event: {
+      provider: SLACK_PROVIDER,
+      source: resolution.connection.slug,
+      event: SLACK_SLASH_COMMAND_EVENT,
+      workspaceId: resolution.connection.workspaceId,
+      connectionId: resolution.connection.id,
+      connectionName: resolution.connection.displayName,
+      deliveryId: params.deliveryId,
+      receivedAt: new Date().toISOString(),
+      payload,
+    },
+  });
+
+  return {outcome: result.published ? 'published' : 'duplicate'};
+}
+
+export function isSelfAuthoredSlackEvent(event: unknown, botUserId: string): boolean {
+  const parsed = slackSelfAuthoredEventSchema.safeParse(event);
+  if (!parsed.success) return false;
+  const nestedMessage = parsed.data.message;
+  return (
+    parsed.data.bot_id !== undefined ||
+    parsed.data.user === botUserId ||
+    nestedMessage?.bot_id !== undefined ||
+    nestedMessage?.user === botUserId
+  );
+}
+
+async function resolveSlackConnection(
+  params: SlackWebhookParams & {teamId: string},
+): Promise<SlackConnectionResolution> {
+  const installation = await getSlackInstallationByTeamId(params.teamId, {tx: params.tx});
+  if (!installation) {
+    logger().warn(
+      {deliveryId: params.deliveryId, teamId: params.teamId},
+      'slack webhook: unknown team, dropping',
+    );
+    await recordSlackDeliveryOnly(params);
+    return {kind: 'drop', outcome: 'unknown-team'};
+  }
+
+  if (installation.status !== 'installed') {
+    logger().info(
+      {
+        deliveryId: params.deliveryId,
+        teamId: params.teamId,
+        connectionId: installation.connectionId,
+      },
+      'slack webhook: installation is not installed, dropping',
+    );
+    await recordSlackDeliveryOnly(params);
+    return {kind: 'drop', outcome: 'revoked-installation'};
+  }
+
+  const connection = await params.getIntegrationConnectionById(installation.connectionId, {
+    tx: params.tx,
+  });
+  if (!connection) {
+    logger().warn(
+      {
+        deliveryId: params.deliveryId,
+        teamId: params.teamId,
+        connectionId: installation.connectionId,
+      },
+      'slack webhook: installation has no connection, dropping',
+    );
+    await recordSlackDeliveryOnly(params);
+    return {kind: 'drop', outcome: 'missing-connection'};
+  }
+
+  if (connection.lifecycleStatus !== 'active') {
+    logger().info(
+      {deliveryId: params.deliveryId, teamId: params.teamId, connectionId: connection.id},
+      'slack webhook: inactive connection, dropping',
+    );
+    await recordSlackDeliveryOnly(params);
+    return {kind: 'drop', outcome: 'inactive-connection'};
+  }
+
+  return {kind: 'ok', connection, installation};
+}
+
+async function recordSlackDeliveryOnly(
+  params: Pick<SlackWebhookParams, 'tx' | 'deliveryId' | 'recordDeliveryOnly'>,
+): Promise<void> {
+  await params.recordDeliveryOnly({
+    tx: params.tx,
+    provider: SLACK_PROVIDER,
+    deliveryId: params.deliveryId,
+  });
+}

--- a/libs/api/integration/slack/src/index.test.ts
+++ b/libs/api/integration/slack/src/index.test.ts
@@ -1,0 +1,15 @@
+import {createSlackIntegrationProvider} from '#index.js';
+
+describe('createSlackIntegrationProvider', () => {
+  it('does not mount webhook routes without route options', () => {
+    const provider = createSlackIntegrationProvider();
+
+    expect(provider.routes).toEqual([]);
+  });
+
+  it('rejects incomplete webhook route options', () => {
+    expect(() => createSlackIntegrationProvider({routes: {}})).toThrow(
+      'Slack webhook routes require every core persistence dependency',
+    );
+  });
+});

--- a/libs/api/integration/slack/src/index.ts
+++ b/libs/api/integration/slack/src/index.ts
@@ -2,6 +2,10 @@ import {SLACK_PROVIDER} from '@shipfox/api-integration-slack-dto';
 import {config} from '#config.js';
 import {closeDb, db} from '#db/db.js';
 import {migrationsPath} from '#db/migrations.js';
+import {
+  type CreateSlackWebhookRoutesOptions,
+  createSlackWebhookRoutes,
+} from '#presentation/routes/webhooks.js';
 
 export type {SlackProvider} from '@shipfox/api-integration-slack-dto';
 export {
@@ -11,6 +15,8 @@ export {
   SlackInstallationAlreadyLinkedError,
   SlackIntegrationProviderError,
 } from '#core/errors.js';
+export type {VerifySlackSignatureParams} from '#core/signature.js';
+export {verifySlackSignature} from '#core/signature.js';
 export type {
   CreateSlackTokenStoreParams,
   GetSlackAccessTokenParams,
@@ -20,6 +26,12 @@ export type {
   StoreSlackTokensParams,
 } from '#core/tokens.js';
 export {createSlackTokenStore, slackSecretsNamespace} from '#core/tokens.js';
+export type {
+  HandleSlackCommandParams,
+  HandleSlackEventParams,
+  SlackWebhookOutcome,
+} from '#core/webhook.js';
+export {handleSlackCommand, handleSlackEvent, isSelfAuthoredSlackEvent} from '#core/webhook.js';
 export type {
   SlackInstallation,
   SlackInstallationStatus,
@@ -31,13 +43,41 @@ export {
   markSlackInstallationRevoked,
   upsertSlackInstallation,
 } from '#db/installations.js';
+export {
+  type CreateSlackWebhookRoutesOptions,
+  createSlackWebhookRoutes,
+  SLACK_WEBHOOK_BODY_LIMIT,
+  SLASH_COMMAND_ACK,
+} from '#presentation/routes/webhooks.js';
 export {closeDb, config, db, migrationsPath};
 
-export function createSlackIntegrationProvider() {
+export interface CreateSlackIntegrationProviderOptions {
+  routes?: Partial<CreateSlackWebhookRoutesOptions> | undefined;
+}
+
+export function createSlackIntegrationProvider(
+  options: CreateSlackIntegrationProviderOptions = {},
+) {
+  if (options.routes && !hasSlackWebhookRoutesOptions(options.routes)) {
+    throw new Error('Slack webhook routes require every core persistence dependency');
+  }
+  const routes = options.routes ? createSlackWebhookRoutes(options.routes) : [];
+
   return {
     provider: SLACK_PROVIDER,
     displayName: 'Slack',
     adapters: {},
-    routes: [],
+    routes,
   };
+}
+
+function hasSlackWebhookRoutesOptions(
+  routes: Partial<CreateSlackWebhookRoutesOptions>,
+): routes is CreateSlackWebhookRoutesOptions {
+  return (
+    routes.coreDb !== undefined &&
+    routes.publishIntegrationEventReceived !== undefined &&
+    routes.recordDeliveryOnly !== undefined &&
+    routes.getIntegrationConnectionById !== undefined
+  );
 }

--- a/libs/api/integration/slack/src/presentation/routes/webhooks.test.ts
+++ b/libs/api/integration/slack/src/presentation/routes/webhooks.test.ts
@@ -1,0 +1,266 @@
+import {createHmac, randomUUID} from 'node:crypto';
+import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
+import {closeApp, createApp} from '@shipfox/node-fastify';
+import {db} from '#db/db.js';
+import {upsertSlackInstallation} from '#db/installations.js';
+import {slackInstallations} from '#db/schema/installations.js';
+import {createSlackWebhookRoutes, SLASH_COMMAND_ACK} from './webhooks.js';
+
+const signingSecret = 'test-signing-secret';
+
+function fakeConnection(): IntegrationConnection {
+  return {
+    id: randomUUID(),
+    workspaceId: randomUUID(),
+    provider: 'slack',
+    externalAccountId: 'T1',
+    slug: 'slack_acme',
+    displayName: 'Slack Acme',
+    lifecycleStatus: 'active',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+function slackHeaders(
+  rawBody: string,
+  contentType: string,
+  timestamp = `${Math.floor(Date.now() / 1000)}`,
+) {
+  const hex = createHmac('sha256', signingSecret)
+    .update(`v0:${timestamp}:${rawBody}`)
+    .digest('hex');
+  return {
+    'content-type': contentType,
+    'x-slack-request-timestamp': timestamp,
+    'x-slack-signature': `v0=${hex}`,
+  };
+}
+
+async function createTestApp(connection = fakeConnection()): Promise<{
+  app: Awaited<ReturnType<typeof createApp>>;
+  connection: IntegrationConnection;
+  publishIntegrationEventReceived: ReturnType<typeof vi.fn>;
+  recordDeliveryOnly: ReturnType<typeof vi.fn>;
+  getIntegrationConnectionById: ReturnType<typeof vi.fn>;
+}> {
+  const publishIntegrationEventReceived = vi.fn(() => Promise.resolve({published: true}));
+  const recordDeliveryOnly = vi.fn(() => Promise.resolve());
+  const getIntegrationConnectionById = vi.fn(() => Promise.resolve(connection));
+  const app = await createApp({
+    routes: createSlackWebhookRoutes({
+      coreDb: db,
+      publishIntegrationEventReceived,
+      recordDeliveryOnly,
+      getIntegrationConnectionById,
+    }),
+    swagger: false,
+  });
+  await app.ready();
+  return {
+    app,
+    connection,
+    publishIntegrationEventReceived,
+    recordDeliveryOnly,
+    getIntegrationConnectionById,
+  };
+}
+
+async function seedInstallation(connection: IntegrationConnection): Promise<void> {
+  await upsertSlackInstallation({
+    connectionId: connection.id,
+    teamId: 'T1',
+    teamName: 'Acme',
+    appId: 'A1',
+    botUserId: 'UBOT',
+    scopes: [],
+    status: 'installed',
+  });
+}
+
+describe('Slack webhook routes', () => {
+  beforeEach(async () => {
+    await closeApp();
+    await db().delete(slackInstallations);
+  });
+
+  afterEach(async () => {
+    await closeApp();
+  });
+
+  it('answers a signed URL verification before resolving an installation', async () => {
+    const {app, getIntegrationConnectionById} = await createTestApp();
+    const rawBody = JSON.stringify({
+      type: 'url_verification',
+      token: 'token',
+      challenge: 'challenge',
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/webhooks/integrations/slack/events',
+      headers: slackHeaders(rawBody, 'application/json'),
+      payload: rawBody,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({challenge: 'challenge'});
+    expect(getIntegrationConnectionById).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unsigned request before parsing its body', async () => {
+    const {app, publishIntegrationEventReceived, recordDeliveryOnly} = await createTestApp();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/webhooks/integrations/slack/events',
+      headers: {'content-type': 'application/json'},
+      payload: '{"type":',
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(recordDeliveryOnly).not.toHaveBeenCalled();
+  });
+
+  it('rejects a stale signed event before parsing it', async () => {
+    const {app, publishIntegrationEventReceived, recordDeliveryOnly} = await createTestApp();
+    const rawBody = JSON.stringify({
+      type: 'url_verification',
+      token: 'token',
+      challenge: 'challenge',
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/webhooks/integrations/slack/events',
+      headers: slackHeaders(rawBody, 'application/json', `${Math.floor(Date.now() / 1000) - 301}`),
+      payload: rawBody,
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(recordDeliveryOnly).not.toHaveBeenCalled();
+  });
+
+  it('rejects signed malformed event JSON', async () => {
+    const {app, publishIntegrationEventReceived, recordDeliveryOnly} = await createTestApp();
+    const rawBody = '{"type":';
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/webhooks/integrations/slack/events',
+      headers: slackHeaders(rawBody, 'application/json'),
+      payload: rawBody,
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(recordDeliveryOnly).not.toHaveBeenCalled();
+  });
+
+  it('publishes a signed event delivery through the route transaction', async () => {
+    const {app, connection, publishIntegrationEventReceived} = await createTestApp();
+    await seedInstallation(connection);
+    const rawBody = JSON.stringify({
+      type: 'event_callback',
+      team_id: 'T1',
+      api_app_id: 'A1',
+      event: {type: 'app_mention', channel: 'C1', user: 'U1', text: 'hello', ts: '1.0'},
+      event_id: 'Ev-route',
+      event_time: 1_721_300_000,
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/webhooks/integrations/slack/events',
+      headers: slackHeaders(rawBody, 'application/json'),
+      payload: rawBody,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(publishIntegrationEventReceived).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({event: 'app_mention', deliveryId: 'Ev-route'}),
+      }),
+    );
+  });
+
+  it('returns the fixed acknowledgement for a signed command that cannot resolve a team', async () => {
+    const {app, publishIntegrationEventReceived, recordDeliveryOnly} = await createTestApp();
+    const rawBody = new URLSearchParams({
+      token: 'verification-token',
+      command: '/deploy',
+      team_id: 'T-missing',
+      channel_id: 'C1',
+      user_id: 'U1',
+      response_url: 'https://hooks.slack.com/commands/1',
+      trigger_id: '1337.42',
+      text: '',
+    }).toString();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/webhooks/integrations/slack/commands',
+      headers: slackHeaders(rawBody, 'application/x-www-form-urlencoded'),
+      payload: rawBody,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual(SLASH_COMMAND_ACK);
+    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(recordDeliveryOnly).toHaveBeenCalledWith(
+      expect.objectContaining({provider: 'slack', deliveryId: '1337.42'}),
+    );
+  });
+
+  it('returns the acknowledgement for a signed command that fails validation', async () => {
+    const {app, publishIntegrationEventReceived, recordDeliveryOnly} = await createTestApp();
+    const rawBody = new URLSearchParams({team_id: 'T1'}).toString();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/webhooks/integrations/slack/commands',
+      headers: slackHeaders(rawBody, 'application/x-www-form-urlencoded'),
+      payload: rawBody,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual(SLASH_COMMAND_ACK);
+    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(recordDeliveryOnly).not.toHaveBeenCalled();
+  });
+
+  it('publishes a signed command without exposing its verification token', async () => {
+    const {app, connection, publishIntegrationEventReceived} = await createTestApp();
+    await seedInstallation(connection);
+    const rawBody = new URLSearchParams({
+      token: 'verification-token',
+      command: '/deploy',
+      team_id: 'T1',
+      channel_id: 'C1',
+      user_id: 'U1',
+      response_url: 'https://hooks.slack.com/commands/1',
+      trigger_id: '1337.43',
+      text: 'production',
+    }).toString();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/webhooks/integrations/slack/commands',
+      headers: slackHeaders(rawBody, 'application/x-www-form-urlencoded'),
+      payload: rawBody,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(publishIntegrationEventReceived).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          event: 'slash_command',
+          deliveryId: '1337.43',
+          payload: expect.not.objectContaining({token: expect.anything()}),
+        }),
+      }),
+    );
+  });
+});

--- a/libs/api/integration/slack/src/presentation/routes/webhooks.ts
+++ b/libs/api/integration/slack/src/presentation/routes/webhooks.ts
@@ -1,0 +1,170 @@
+import {Buffer} from 'node:buffer';
+import type {
+  GetIntegrationConnectionByIdFn,
+  PublishIntegrationEventReceivedFn,
+  RecordDeliveryOnlyFn,
+} from '@shipfox/api-integration-core-dto';
+import {
+  slackEventsRequestSchema,
+  slackSlashCommandSchema,
+} from '@shipfox/api-integration-slack-dto';
+import {createRawBodyPlugin, defineRoute, type RouteGroup} from '@shipfox/node-fastify';
+import {logger} from '@shipfox/node-opentelemetry';
+import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
+import {config} from '#config.js';
+import {verifySlackSignature} from '#core/signature.js';
+import {handleSlackCommand, handleSlackEvent} from '#core/webhook.js';
+
+export const SLACK_WEBHOOK_BODY_LIMIT = 1024 * 1024;
+export const SLASH_COMMAND_ACK = {response_type: 'ephemeral', text: 'Working on it.'} as const;
+
+const slackJsonRawBodyPlugin = createRawBodyPlugin({
+  contentType: 'application/json',
+  bodyLimit: SLACK_WEBHOOK_BODY_LIMIT,
+});
+const slackFormRawBodyPlugin = createRawBodyPlugin({
+  contentType: 'application/x-www-form-urlencoded',
+  bodyLimit: SLACK_WEBHOOK_BODY_LIMIT,
+});
+
+export interface CreateSlackWebhookRoutesOptions {
+  coreDb: () => NodePgDatabase<Record<string, unknown>>;
+  publishIntegrationEventReceived: PublishIntegrationEventReceivedFn;
+  recordDeliveryOnly: RecordDeliveryOnlyFn;
+  getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
+}
+
+export function createSlackWebhookRoutes(options: CreateSlackWebhookRoutesOptions): RouteGroup[] {
+  const eventsRoute = defineRoute({
+    method: 'POST',
+    path: '/',
+    auth: [],
+    description: 'Slack Events API receiver.',
+    options: {bodyLimit: SLACK_WEBHOOK_BODY_LIMIT},
+    handler: async (request, reply) => {
+      const rawBody = rawRequestBody(request.body);
+      if (rawBody === undefined) {
+        reply.code(400);
+        return {error: 'expected raw JSON body'};
+      }
+      if (!hasValidSlackSignature(request.headers, rawBody)) {
+        reply.code(401);
+        return {error: 'invalid signature'};
+      }
+
+      let parsedJson: unknown;
+      try {
+        parsedJson = JSON.parse(rawBody);
+      } catch (error) {
+        logger().warn(
+          {errorName: error instanceof Error ? error.name : 'unknown'},
+          'slack events payload JSON parse failed',
+        );
+        reply.code(400);
+        return {error: 'malformed JSON'};
+      }
+
+      const parsed = slackEventsRequestSchema.safeParse(parsedJson);
+      if (!parsed.success) {
+        logger().warn(
+          {issues: parsed.error.issues},
+          'slack events envelope failed schema validation',
+        );
+        reply.code(200);
+        return null;
+      }
+      const eventRequest = parsed.data;
+      if (eventRequest.type === 'url_verification') {
+        reply.code(200);
+        return {challenge: eventRequest.challenge};
+      }
+
+      await options.coreDb().transaction(async (tx) => {
+        await handleSlackEvent({
+          tx,
+          deliveryId: eventRequest.event_id,
+          envelope: eventRequest,
+          publishIntegrationEventReceived: options.publishIntegrationEventReceived,
+          recordDeliveryOnly: options.recordDeliveryOnly,
+          getIntegrationConnectionById: options.getIntegrationConnectionById,
+        });
+      });
+      reply.code(200);
+      return null;
+    },
+  });
+
+  const commandsRoute = defineRoute({
+    method: 'POST',
+    path: '/',
+    auth: [],
+    description: 'Slack slash-command receiver.',
+    options: {bodyLimit: SLACK_WEBHOOK_BODY_LIMIT},
+    handler: async (request, reply) => {
+      const rawBody = rawRequestBody(request.body);
+      if (rawBody === undefined) {
+        reply.code(400);
+        return {error: 'expected raw form body'};
+      }
+      if (!hasValidSlackSignature(request.headers, rawBody)) {
+        reply.code(401);
+        return {error: 'invalid signature'};
+      }
+
+      const command = slackSlashCommandSchema.safeParse(
+        Object.fromEntries(new URLSearchParams(rawBody)),
+      );
+      if (!command.success) {
+        logger().warn({issues: command.error.issues}, 'slack command failed schema validation');
+        reply.code(200);
+        return SLASH_COMMAND_ACK;
+      }
+
+      await options.coreDb().transaction(async (tx) => {
+        await handleSlackCommand({
+          tx,
+          deliveryId: command.data.trigger_id,
+          command: command.data,
+          publishIntegrationEventReceived: options.publishIntegrationEventReceived,
+          recordDeliveryOnly: options.recordDeliveryOnly,
+          getIntegrationConnectionById: options.getIntegrationConnectionById,
+        });
+      });
+      reply.code(200);
+      return SLASH_COMMAND_ACK;
+    },
+  });
+
+  return [
+    {
+      prefix: '/webhooks/integrations/slack/events',
+      auth: [],
+      plugins: [slackJsonRawBodyPlugin],
+      routes: [eventsRoute],
+    },
+    {
+      prefix: '/webhooks/integrations/slack/commands',
+      auth: [],
+      plugins: [slackFormRawBodyPlugin],
+      routes: [commandsRoute],
+    },
+  ];
+}
+
+function rawRequestBody(body: unknown): string | undefined {
+  return Buffer.isBuffer(body) ? body.toString('utf8') : undefined;
+}
+
+function hasValidSlackSignature(
+  headers: Record<string, string | string[] | undefined>,
+  rawBody: string,
+): boolean {
+  const signature = headers['x-slack-signature'];
+  const timestamp = headers['x-slack-request-timestamp'];
+  return verifySlackSignature({
+    signingSecret: config.SLACK_SIGNING_SECRET,
+    signature: typeof signature === 'string' ? signature : undefined,
+    timestamp: typeof timestamp === 'string' ? timestamp : undefined,
+    rawBody,
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2851,12 +2851,21 @@ importers:
       '@shipfox/node-drizzle':
         specifier: workspace:*
         version: link:../../../shared/node/drizzle
+      '@shipfox/node-fastify':
+        specifier: workspace:*
+        version: link:../../../shared/node/fastify
+      '@shipfox/node-opentelemetry':
+        specifier: workspace:*
+        version: link:../../../shared/node/opentelemetry
       '@shipfox/node-postgres':
         specifier: workspace:*
         version: link:../../../shared/node/postgres
       drizzle-orm:
         specifier: 'catalog:'
         version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
     devDependencies:
       '@shipfox/biome':
         specifier: workspace:*


### PR DESCRIPTION
Add signed Slack Events API and slash-command receivers that publish normalized integration events.

Slack activity needs to reach provider-agnostic triggers without exposing verification tokens or allowing unsigned, replayed, or bot-authored deliveries to start work. The receiver verifies Slack's v0 signature on raw JSON and form payloads, resolves active installations, records safe drop outcomes, and publishes events in the existing ingestion transaction.

The receiver keeps slash-command acknowledgements synchronous and minimal because matching workflows happens asynchronously. A durable pre-ack handoff would require a broader ingestion architecture change.

Review the signature boundary and the event/command payload normalization, especially the token-free command payload and self-message guard.

Closes ENG-928

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Slack inbound receivers for Events API and slash commands. They verify Slack v0 signatures, block replays and self/bot-authored messages, and publish normalized events without storing command verification tokens to satisfy ENG-928.

- **New Features**
  - Signed receivers at `/webhooks/integrations/slack/events` and `/webhooks/integrations/slack/commands`, validating the v0 signature on raw JSON/form bodies before parsing.
  - Normalize event payloads and omit the `token` field from slash-command payloads.
  - Drop deliveries for unknown teams, revoked installations, inactive connections, and messages authored by the installation bot; de-duplicate by delivery id.
  - Publish via the existing ingestion transaction; return a minimal synchronous slash-command ack `SLASH_COMMAND_ACK`.
  - Expose `createSlackWebhookRoutes` and mount routes through `createSlackIntegrationProvider` when core persistence options are provided.

- **Dependencies**
  - Added `@shipfox/node-fastify`, `@shipfox/node-opentelemetry`, and `zod`.

<sup>Written for commit 6c0f03b0f81e6b7003ad626a26d1fa0282d2dd78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

