### PR TITLE
[jira-dto] Add shared Jira integration contracts

### DIFF
--- a/.changeset/quick-orcas-dance.md
+++ b/.changeset/quick-orcas-dance.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-integration-jira-dto": minor
+---
+
+Adds shared Jira OAuth, webhook, event, and agent-tool contracts.

--- a/libs/api/integration/jira-dto/package.json
+++ b/libs/api/integration/jira-dto/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@shipfox/api-integration-jira-dto",
+  "license": "MIT",
+  "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
+    "directory": "libs/api/integration/jira-dto"
+  },
+  "private": false,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "imports": {
+    "#test/*": "./test/*",
+    "#*": {
+      "workspace-source": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
+  },
+  "exports": {
+    ".": {
+      "development": {
+        "types": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "depcruise": "shipfox-depcruise",
+    "test": "shipfox-vitest-run",
+    "test:watch": "shipfox-vitest-watch",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "@shipfox/api-integration-core-dto": "workspace:*",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/depcruise": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*"
+  }
+}

--- a/libs/api/integration/jira-dto/src/agent-tools/index.ts
+++ b/libs/api/integration/jira-dto/src/agent-tools/index.ts
@@ -1,0 +1,28 @@
+import type {AgentToolCatalogEntry} from '@shipfox/api-integration-core-dto';
+import {z} from 'zod';
+
+export const jiraAgentToolIds = [
+  'get_issue',
+  'search_issues',
+  'get_issue_comments',
+  'get_issue_transitions',
+  'get_project',
+  'get_user',
+  'create_issue',
+  'update_issue',
+  'add_comment',
+  'transition_issue',
+  'assign_issue',
+] as const;
+
+export const jiraAgentToolIdSchema = z.enum(jiraAgentToolIds);
+export type JiraAgentToolId = z.infer<typeof jiraAgentToolIdSchema>;
+
+export const jiraAgentToolRequiredScopes = ['read', 'write'] as const;
+export const jiraAgentToolRequiredScopeSchema = z.enum(jiraAgentToolRequiredScopes);
+export type JiraAgentToolRequiredScope = z.infer<typeof jiraAgentToolRequiredScopeSchema>;
+
+export interface JiraAgentToolCatalogEntry
+  extends AgentToolCatalogEntry<JiraAgentToolRequiredScope> {
+  id: JiraAgentToolId;
+}

--- a/libs/api/integration/jira-dto/src/index.ts
+++ b/libs/api/integration/jira-dto/src/index.ts
@@ -1,0 +1,2 @@
+export * from './agent-tools/index.js';
+export * from './schemas/index.js';

--- a/libs/api/integration/jira-dto/src/schemas/index.test.ts
+++ b/libs/api/integration/jira-dto/src/schemas/index.test.ts
@@ -1,0 +1,162 @@
+import {
+  completeJiraSiteSelectionBodySchema,
+  createJiraInstallBodySchema,
+  JIRA_PROVIDER,
+  jiraAccessibleResourcesSchema,
+  jiraAgentToolIdSchema,
+  jiraAgentToolIds,
+  jiraAgentToolRequiredScopeSchema,
+  jiraCommentEventPayloadSchema,
+  jiraCommentWebhookEnvelopeSchema,
+  jiraCommentWebhookEventNames,
+  jiraIssueEventPayloadSchema,
+  jiraIssueWebhookEnvelopeSchema,
+  jiraIssueWebhookEventNames,
+  jiraWebhookEnvelopeSchema,
+  jiraWebhookEventNames,
+} from '../index.js';
+
+const issueWebhook = {
+  timestamp: 1_786_257_600_000,
+  issue_event_type_name: 'issue_created',
+  issue: {
+    id: '10001',
+    key: 'ENG-999',
+    fields: {
+      summary: 'Create Jira DTO contracts',
+      status: {id: '10000', name: 'To Do'},
+      assignee: null,
+      project: {id: '10000', key: 'ENG', name: 'Engineering'},
+    },
+  },
+  user: {accountId: 'account-1', displayName: 'Noé Charmet'},
+  changelog: {
+    id: '10001',
+    items: [{field: 'status', fromString: 'Backlog', toString: 'To Do'}],
+  },
+  matchedWebhookIds: [1],
+};
+
+const commentWebhook = {
+  timestamp: 1_786_257_600_000,
+  issue: issueWebhook.issue,
+  user: issueWebhook.user,
+  comment: {
+    id: '10002',
+    author: {accountId: 'account-2', displayName: 'Shipfox'},
+    body: {type: 'doc', version: 1, content: []},
+  },
+  matchedWebhookIds: [1],
+};
+
+describe('JIRA_PROVIDER', () => {
+  it('names the Jira provider id', () => {
+    expect(JIRA_PROVIDER).toBe('jira');
+  });
+});
+
+describe('Jira webhook vocabulary', () => {
+  it('enumerates the curated issue and comment event names', () => {
+    expect(jiraWebhookEventNames).toEqual([
+      'jira:issue_created',
+      'jira:issue_updated',
+      'jira:issue_deleted',
+      'comment_created',
+      'comment_updated',
+      'comment_deleted',
+    ]);
+  });
+
+  it.each(jiraIssueWebhookEventNames)('parses the supported issue event %s', (webhookEvent) => {
+    const result = jiraIssueWebhookEnvelopeSchema.parse({...issueWebhook, webhookEvent});
+
+    expect(result.webhookEvent).toBe(webhookEvent);
+  });
+
+  it.each(jiraCommentWebhookEventNames)('parses the supported comment event %s', (webhookEvent) => {
+    const result = jiraCommentWebhookEnvelopeSchema.parse({...commentWebhook, webhookEvent});
+
+    expect(result.webhookEvent).toBe(webhookEvent);
+  });
+
+  it('rejects unsupported webhook events from the supported event schema', () => {
+    const result = jiraWebhookEnvelopeSchema.safeParse({
+      ...issueWebhook,
+      webhookEvent: 'jira:worklog_updated',
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('Jira event payload schemas', () => {
+  it('parses issue payloads with the injected cloud id and retains raw provider fields', () => {
+    const result = jiraIssueEventPayloadSchema.parse({
+      ...issueWebhook,
+      webhookEvent: 'jira:issue_updated',
+      cloudId: 'cloud-1',
+      custom_provider_field: 'preserved',
+    });
+
+    expect(result.cloudId).toBe('cloud-1');
+    expect(result.custom_provider_field).toBe('preserved');
+  });
+
+  it('parses comment payloads with the injected cloud id', () => {
+    const result = jiraCommentEventPayloadSchema.parse({
+      ...commentWebhook,
+      webhookEvent: 'comment_created',
+      cloudId: 'cloud-1',
+    });
+
+    expect(result.comment.author.accountId).toBe('account-2');
+  });
+});
+
+describe('Jira OAuth and site selection schemas', () => {
+  it('requires a UUID workspace id for install requests', () => {
+    const result = createJiraInstallBodySchema.safeParse({workspace_id: 'workspace-1'});
+
+    expect(result.success).toBe(false);
+  });
+
+  it('parses accessible sites and a selected cloud id', () => {
+    const sites = jiraAccessibleResourcesSchema.parse([
+      {
+        cloud_id: 'cloud-1',
+        name: 'Shipfox',
+        url: 'https://shipfox.atlassian.net',
+        scopes: ['read:jira-work'],
+      },
+    ]);
+    const selection = completeJiraSiteSelectionBodySchema.parse({cloud_id: sites[0]?.cloud_id});
+
+    expect(selection.cloud_id).toBe('cloud-1');
+  });
+});
+
+describe('Jira agent tool vocabulary', () => {
+  it('enumerates catalog ids with read/write required scopes', () => {
+    expect(jiraAgentToolIds).toEqual([
+      'get_issue',
+      'search_issues',
+      'get_issue_comments',
+      'get_issue_transitions',
+      'get_project',
+      'get_user',
+      'create_issue',
+      'update_issue',
+      'add_comment',
+      'transition_issue',
+      'assign_issue',
+    ]);
+
+    const toolId = jiraAgentToolIdSchema.parse('add_comment');
+    const readScope = jiraAgentToolRequiredScopeSchema.parse('read');
+    const writeScope = jiraAgentToolRequiredScopeSchema.parse('write');
+
+    expect(toolId).toBe('add_comment');
+    expect(readScope).toBe('read');
+    expect(writeScope).toBe('write');
+  });
+});

--- a/libs/api/integration/jira-dto/src/schemas/index.ts
+++ b/libs/api/integration/jira-dto/src/schemas/index.ts
@@ -1,0 +1,182 @@
+import {integrationConnectionDtoSchema} from '@shipfox/api-integration-core-dto';
+import {z} from 'zod';
+
+export const JIRA_PROVIDER = 'jira';
+export type JiraProvider = typeof JIRA_PROVIDER;
+
+export const jiraIssueWebhookEventNames = [
+  'jira:issue_created',
+  'jira:issue_updated',
+  'jira:issue_deleted',
+] as const;
+export const jiraCommentWebhookEventNames = [
+  'comment_created',
+  'comment_updated',
+  'comment_deleted',
+] as const;
+export const jiraWebhookEventNames = [
+  ...jiraIssueWebhookEventNames,
+  ...jiraCommentWebhookEventNames,
+] as const;
+
+export const jiraWebhookEventNameSchema = z.enum(jiraWebhookEventNames);
+export type JiraIssueWebhookEventName = (typeof jiraIssueWebhookEventNames)[number];
+export type JiraCommentWebhookEventName = (typeof jiraCommentWebhookEventNames)[number];
+export type JiraWebhookEventName = z.infer<typeof jiraWebhookEventNameSchema>;
+
+export const jiraWebhookUserSchema = z
+  .object({
+    accountId: z.string().min(1),
+    displayName: z.string().min(1).optional(),
+  })
+  .passthrough();
+export type JiraWebhookUserDto = z.infer<typeof jiraWebhookUserSchema>;
+
+const jiraWebhookNamedResourceSchema = z
+  .object({
+    id: z.string().min(1).optional(),
+    name: z.string().min(1).optional(),
+  })
+  .passthrough();
+
+export const jiraWebhookIssueSchema = z
+  .object({
+    id: z.string().min(1),
+    key: z.string().min(1),
+    fields: z
+      .object({
+        summary: z.string().optional(),
+        status: jiraWebhookNamedResourceSchema.nullable().optional(),
+        assignee: jiraWebhookUserSchema.nullable().optional(),
+      })
+      .passthrough(),
+  })
+  .passthrough();
+export type JiraWebhookIssueDto = z.infer<typeof jiraWebhookIssueSchema>;
+
+const jiraWebhookChangelogItemSchema = z
+  .object({
+    field: z.string().min(1),
+    fieldtype: z.string().min(1).optional(),
+    fieldId: z.string().min(1).optional(),
+    from: z.string().nullable().optional(),
+    fromString: z.string().nullable().optional(),
+    to: z.string().nullable().optional(),
+    toString: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+export const jiraWebhookChangelogSchema = z
+  .object({
+    id: z.string().min(1).optional(),
+    items: z.array(jiraWebhookChangelogItemSchema),
+  })
+  .passthrough();
+export type JiraWebhookChangelogDto = z.infer<typeof jiraWebhookChangelogSchema>;
+
+export const jiraWebhookCommentSchema = z
+  .object({
+    id: z.string().min(1),
+    author: jiraWebhookUserSchema,
+    body: z.unknown(),
+  })
+  .passthrough();
+export type JiraWebhookCommentDto = z.infer<typeof jiraWebhookCommentSchema>;
+
+export const jiraWebhookBaseEnvelopeSchema = z
+  .object({
+    webhookEvent: z.string().min(1),
+    timestamp: z.number().int(),
+    issue: jiraWebhookIssueSchema,
+    user: jiraWebhookUserSchema,
+    matchedWebhookIds: z.array(z.number().int().positive()).optional(),
+  })
+  .passthrough();
+export type JiraWebhookBaseEnvelopeDto = z.infer<typeof jiraWebhookBaseEnvelopeSchema>;
+
+export const jiraIssueWebhookEnvelopeSchema = jiraWebhookBaseEnvelopeSchema.extend({
+  webhookEvent: z.enum(jiraIssueWebhookEventNames),
+  issue_event_type_name: z.string().min(1),
+  changelog: jiraWebhookChangelogSchema.optional(),
+});
+export type JiraIssueWebhookEnvelopeDto = z.infer<typeof jiraIssueWebhookEnvelopeSchema>;
+
+export const jiraCommentWebhookEnvelopeSchema = jiraWebhookBaseEnvelopeSchema.extend({
+  webhookEvent: z.enum(jiraCommentWebhookEventNames),
+  comment: jiraWebhookCommentSchema,
+});
+export type JiraCommentWebhookEnvelopeDto = z.infer<typeof jiraCommentWebhookEnvelopeSchema>;
+
+export const jiraWebhookEnvelopeSchema = z.discriminatedUnion('webhookEvent', [
+  jiraIssueWebhookEnvelopeSchema,
+  jiraCommentWebhookEnvelopeSchema,
+]);
+export type JiraWebhookEnvelopeDto = z.infer<typeof jiraWebhookEnvelopeSchema>;
+
+const jiraCloudIdSchema = z.string().min(1);
+
+export const jiraIssueEventPayloadSchema = jiraIssueWebhookEnvelopeSchema.extend({
+  cloudId: jiraCloudIdSchema,
+});
+export type JiraIssueEventPayloadDto = z.infer<typeof jiraIssueEventPayloadSchema>;
+
+export const jiraCommentEventPayloadSchema = jiraCommentWebhookEnvelopeSchema.extend({
+  cloudId: jiraCloudIdSchema,
+});
+export type JiraCommentEventPayloadDto = z.infer<typeof jiraCommentEventPayloadSchema>;
+
+export const jiraEventPayloadSchema = z.discriminatedUnion('webhookEvent', [
+  jiraIssueEventPayloadSchema,
+  jiraCommentEventPayloadSchema,
+]);
+export type JiraEventPayloadDto = z.infer<typeof jiraEventPayloadSchema>;
+
+export const createJiraInstallBodySchema = z.object({
+  workspace_id: z.string().uuid(),
+});
+export type CreateJiraInstallBodyDto = z.infer<typeof createJiraInstallBodySchema>;
+
+export const createJiraInstallResponseSchema = z.object({
+  install_url: z.string().url(),
+});
+export type CreateJiraInstallResponseDto = z.infer<typeof createJiraInstallResponseSchema>;
+
+export const jiraCallbackQuerySchema = z.union([
+  z.object({
+    code: z.string().min(1),
+    state: z.string().min(1),
+  }),
+  z.object({
+    error: z.string().min(1),
+    error_description: z.string().min(1).optional(),
+    state: z.string().min(1),
+  }),
+]);
+export type JiraCallbackQueryDto = z.infer<typeof jiraCallbackQuerySchema>;
+
+export const jiraAccessibleResourceSchema = z.object({
+  cloud_id: jiraCloudIdSchema,
+  name: z.string().min(1),
+  url: z.string().url(),
+  scopes: z.array(z.string().min(1)),
+});
+export type JiraAccessibleResourceDto = z.infer<typeof jiraAccessibleResourceSchema>;
+
+export const jiraAccessibleResourcesSchema = z.array(jiraAccessibleResourceSchema);
+export type JiraAccessibleResourcesDto = z.infer<typeof jiraAccessibleResourcesSchema>;
+
+export const jiraSiteSelectionResponseSchema = z.object({
+  sites: jiraAccessibleResourcesSchema.min(2),
+});
+export type JiraSiteSelectionResponseDto = z.infer<typeof jiraSiteSelectionResponseSchema>;
+
+export const completeJiraSiteSelectionBodySchema = z.object({
+  cloud_id: jiraCloudIdSchema,
+});
+export type CompleteJiraSiteSelectionBodyDto = z.infer<typeof completeJiraSiteSelectionBodySchema>;
+
+export const jiraCallbackResponseSchema = z.union([
+  integrationConnectionDtoSchema,
+  jiraSiteSelectionResponseSchema,
+]);
+export type JiraCallbackResponseDto = z.infer<typeof jiraCallbackResponseSchema>;

--- a/libs/api/integration/jira-dto/tsconfig.build.json
+++ b/libs/api/integration/jira-dto/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.tsx", "**/*.test.ts"]
+}

--- a/libs/api/integration/jira-dto/tsconfig.json
+++ b/libs/api/integration/jira-dto/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.test.json" }]
+}

--- a/libs/api/integration/jira-dto/tsconfig.test.json
+++ b/libs/api/integration/jira-dto/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "exclude": []
+}

--- a/libs/api/integration/jira-dto/vitest.config.ts
+++ b/libs/api/integration/jira-dto/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({}, import.meta.url) as UserConfigExport;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2635,6 +2635,34 @@ importers:
         specifier: workspace:*
         version: link:../../../../tools/vitest
 
+  libs/api/integration/jira-dto:
+    dependencies:
+      '@shipfox/api-integration-core-dto':
+        specifier: workspace:*
+        version: link:../core-dto
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../../tools/biome
+      '@shipfox/depcruise':
+        specifier: workspace:*
+        version: link:../../../../tools/depcruise
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../../tools/vitest
+
   libs/api/integration/linear:
     dependencies:
       '@modelcontextprotocol/sdk':


### PR DESCRIPTION
Adds the public Jira integration DTO package with OAuth install and site-selection schemas, the supported webhook-event vocabulary and normalized payload contracts, and stable agent-tool identifiers.

The Jira provider, client, and E2E work need one contract before they can be built independently. This preserves raw webhook fields for trigger authors while keeping Shipfox HTTP DTOs in snake_case.

The package intentionally contains no OAuth routes, provider implementation, or consumers; those remain in the follow-on Jira issues.

Refs ENG-999

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces `@shipfox/api-integration-jira-dto`, a shared package for Jira OAuth, site selection, webhooks, and agent tools. Standardizes schemas and event names to unblock the provider, client, and E2E; aligns with ENG-999.

- **New Features**
  - OAuth: install request/response, callback query, accessible resources, and site selection body.
  - Webhooks: curated event names; issue/comment envelopes; normalized payloads injecting `cloudId` while preserving raw fields.
  - Agent tools: catalog ID enum and required scopes `'read' | 'write'`.
  - Tests validate event vocabulary and schema parsing; no routes or provider implementation included.

<sup>Written for commit 51634291fd4cd20e933c5965a1176dd80f950930. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

