### PR TITLE
[integration] Add Slack OAuth v2 connection flow

### DIFF
--- a/.changeset/bright-otters-sail.md
+++ b/.changeset/bright-otters-sail.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-integration-slack": minor
+"@shipfox/api-integration-core": minor
+---
+
+Adds the Slack OAuth connection flow with provider routes, secure bot-token storage, and E2E setup.

--- a/libs/api/integration/core/src/providers/slack.ts
+++ b/libs/api/integration/core/src/providers/slack.ts
@@ -1,27 +1,159 @@
+import {
+  type IntegrationConnection as CoreIntegrationConnection,
+  slugifyConnectionSlug,
+} from '@shipfox/api-integration-core-dto';
+import type {
+  ConnectSlackInstallationInput,
+  SlackSecretsStore,
+} from '@shipfox/api-integration-slack';
 import {config} from '#config.js';
-import {getIntegrationConnectionById} from '#db/connections.js';
+import {
+  deleteIntegrationConnection,
+  getIntegrationConnectionById,
+  resolveUniqueConnectionSlug,
+  upsertIntegrationConnection,
+} from '#db/connections.js';
 import {db} from '#db/db.js';
 import {publishIntegrationEventReceived, recordDeliveryOnly} from '#db/webhook-deliveries.js';
+import {retryConnectionSlugCollision} from '#providers/connection-slug.js';
 import type {IntegrationModuleParts, IntegrationProviderModule} from '#providers/types.js';
 
 const SLACK_MIGRATIONS_TABLE = '__drizzle_migrations_integrations_slack';
+const SLACK_SECRETS_NAMESPACE_PREFIX = 'system/integrations/slack/';
 
-async function loadSlackModuleParts(): Promise<IntegrationModuleParts> {
+type IntegrationDb = ReturnType<typeof db>;
+type IntegrationTx = Parameters<Parameters<IntegrationDb['transaction']>[0]>[0];
+
+async function loadSlackModuleParts(
+  options: Parameters<IntegrationProviderModule['load']>[0] = {},
+): Promise<IntegrationModuleParts> {
   const {
+    createSlackE2eRoutes,
     createSlackIntegrationProvider,
+    createSlackTokenStore,
     db: slackDb,
+    disconnectSlackInstallation: disconnectSlackInstallationRecords,
+    getSlackInstallationByTeamId,
     migrationsPath: slackMigrationsPath,
+    upsertSlackInstallation,
   } = await import('@shipfox/api-integration-slack');
+
+  async function getExistingSlackConnection(input: {
+    teamId: string;
+  }): Promise<CoreIntegrationConnection<'slack'> | undefined> {
+    const installation = await getSlackInstallationByTeamId(input.teamId);
+    if (!installation) return undefined;
+    const connection = await getIntegrationConnectionById(installation.connectionId);
+    if (!connection) return undefined;
+    return connection as CoreIntegrationConnection<'slack'>;
+  }
+
+  async function connectSlackInstallation(
+    input: ConnectSlackInstallationInput,
+  ): Promise<CoreIntegrationConnection<'slack'>> {
+    return await retryConnectionSlugCollision(() =>
+      db().transaction(async (tx) => {
+        const baseSlug = slugifyConnectionSlug(`slack_${input.teamName || input.teamId}`, {
+          fallback: 'slack',
+        });
+        const slug = await resolveUniqueConnectionSlug(
+          {
+            workspaceId: input.workspaceId,
+            provider: 'slack',
+            externalAccountId: input.teamId,
+            baseSlug,
+          },
+          {tx},
+        );
+        const connection = await upsertIntegrationConnection(
+          {
+            workspaceId: input.workspaceId,
+            provider: 'slack',
+            externalAccountId: input.teamId,
+            slug,
+            displayName: input.displayName,
+            lifecycleStatus: 'active',
+          },
+          {tx},
+        );
+        await upsertSlackInstallation(
+          {
+            connectionId: connection.id,
+            teamId: input.teamId,
+            teamName: input.teamName,
+            appId: input.appId,
+            botUserId: input.botUserId,
+            scopes: input.scopes,
+            tokenExpiresAt: input.tokenExpiresAt,
+            status: 'installed',
+          },
+          {tx},
+        );
+        return connection as CoreIntegrationConnection<'slack'>;
+      }),
+    );
+  }
+
+  async function disconnectSlackInstallation(input: {connectionId: string}): Promise<void> {
+    await disconnectSlackInstallationRecords<IntegrationTx>({
+      connectionId: input.connectionId,
+      getConnection: getIntegrationConnectionById,
+      deleteSecrets: (params) =>
+        options.secrets?.slack?.deleteSecrets({
+          ...params,
+          namespace: slackNamespaceSuffix(params.namespace),
+        }) ?? Promise.resolve(0),
+      transaction: (fn) => db().transaction((tx) => fn(tx)),
+      deleteConnection: (params, options) =>
+        deleteIntegrationConnection({id: params.connectionId}, options),
+    });
+  }
+
+  const fallbackSecrets: SlackSecretsStore = {
+    getSecret: () => Promise.resolve(null),
+    setSecrets: () => Promise.reject(new Error('Slack token storage is not configured')),
+  };
+  const secrets: SlackSecretsStore = options.secrets?.slack
+    ? {
+        getSecret: (params: Parameters<SlackSecretsStore['getSecret']>[0]) =>
+          options.secrets?.slack?.getSecret({
+            ...params,
+            namespace: slackNamespaceSuffix(params.namespace),
+          }) ?? Promise.resolve(null),
+        setSecrets: (params: Parameters<SlackSecretsStore['setSecrets']>[0]) =>
+          options.secrets?.slack?.setSecrets({
+            ...params,
+            namespace: slackNamespaceSuffix(params.namespace),
+          }) ?? Promise.resolve(),
+      }
+    : fallbackSecrets;
+  const tokenStore = createSlackTokenStore({
+    resolveConnection: async (connectionId) => getIntegrationConnectionById(connectionId),
+    secrets,
+  });
 
   return {
     provider: createSlackIntegrationProvider({
       routes: {
+        tokenStore,
+        getExistingSlackConnection,
+        connectSlackInstallation,
+        disconnectSlackInstallation,
         coreDb: db,
         publishIntegrationEventReceived,
         recordDeliveryOnly,
         getIntegrationConnectionById,
       },
     }),
+    e2eRoutes: [
+      createSlackE2eRoutes({
+        tokenStore,
+        getExistingSlackConnection,
+        connectSlackInstallation,
+        disconnectSlackInstallation,
+        connectionCapabilities: [],
+      }),
+    ],
     database: {
       db: slackDb,
       migrationsPath: slackMigrationsPath,
@@ -35,3 +167,10 @@ export const slackProviderModule: IntegrationProviderModule = {
   enabled: config.INTEGRATIONS_ENABLE_SLACK_PROVIDER,
   load: loadSlackModuleParts,
 };
+
+function slackNamespaceSuffix(namespace: string): string {
+  if (!namespace.startsWith(SLACK_SECRETS_NAMESPACE_PREFIX)) {
+    throw new Error('Slack provider attempted to access an unscoped secret namespace');
+  }
+  return namespace.slice(SLACK_SECRETS_NAMESPACE_PREFIX.length);
+}

--- a/libs/api/integration/core/src/providers/types.ts
+++ b/libs/api/integration/core/src/providers/types.ts
@@ -37,6 +37,7 @@ export interface IntegrationProviderModuleLoadOptions {
 export interface IntegrationProviderSecrets {
   github?: IntegrationProviderScopedSecrets | undefined;
   linear?: IntegrationProviderScopedSecrets | undefined;
+  slack?: IntegrationProviderScopedSecrets | undefined;
   deleteSecrets(params: {workspaceId: string; namespace: string}): Promise<number>;
 }
 

--- a/libs/api/integration/slack/package.json
+++ b/libs/api/integration/slack/package.json
@@ -41,14 +41,17 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
+    "@shipfox/api-auth-context": "workspace:*",
     "@shipfox/api-integration-core-dto": "workspace:*",
     "@shipfox/api-integration-slack-dto": "workspace:*",
+    "@shipfox/api-workspaces": "workspace:*",
     "@shipfox/config": "workspace:*",
     "@shipfox/node-drizzle": "workspace:*",
     "@shipfox/node-fastify": "workspace:*",
     "@shipfox/node-opentelemetry": "workspace:*",
     "@shipfox/node-postgres": "workspace:*",
     "drizzle-orm": "catalog:",
+    "ky": "catalog:",
     "zod": "catalog:"
   },
   "peerDependencies": {
@@ -62,6 +65,7 @@
     "@shipfox/vitest": "workspace:*",
     "@types/pg": "catalog:",
     "drizzle-kit": "catalog:",
+    "fastify": "catalog:",
     "fishery": "catalog:"
   }
 }

--- a/libs/api/integration/slack/src/api/client.test.ts
+++ b/libs/api/integration/slack/src/api/client.test.ts
@@ -1,0 +1,145 @@
+import {HTTPError, TimeoutError} from 'ky';
+import {
+  SlackEnterpriseInstallUnsupportedError,
+  SlackIntegrationProviderError,
+} from '#core/errors.js';
+import {createSlackApiClient} from './client.js';
+
+const mocks = vi.hoisted(() => ({post: vi.fn(), warn: vi.fn()}));
+
+vi.mock('@shipfox/node-opentelemetry', () => ({logger: () => ({warn: mocks.warn})}));
+vi.mock('ky', () => {
+  class HTTPError extends Error {
+    constructor(public response: {status: number; statusText?: string; headers: Headers}) {
+      super('http');
+      this.name = 'HTTPError';
+    }
+  }
+  class TimeoutError extends Error {
+    constructor() {
+      super('timeout');
+      this.name = 'TimeoutError';
+    }
+  }
+  return {default: {post: mocks.post}, HTTPError, TimeoutError};
+});
+
+function resolves(data: unknown) {
+  return {json: () => Promise.resolve(data)};
+}
+
+function rejects(error: unknown) {
+  return {json: () => Promise.reject(error)};
+}
+
+function httpError(status: number, headers: Record<string, string> = {}): HTTPError {
+  return new HTTPError(
+    {status, statusText: 'Rejected', headers: new Headers(headers)} as never,
+    {} as never,
+    {} as never,
+  );
+}
+
+function oauthSuccess(overrides: Record<string, unknown> = {}) {
+  return {
+    ok: true,
+    access_token: 'xoxb-token',
+    bot_user_id: 'U123',
+    app_id: 'A123',
+    team: {id: 'T123', name: 'Acme'},
+    scope: 'app_mentions:read,chat:write',
+    ...overrides,
+  };
+}
+
+describe('createSlackApiClient', () => {
+  beforeEach(() => {
+    mocks.post.mockReset();
+    mocks.warn.mockReset();
+  });
+
+  it('posts a form-encoded OAuth exchange and parses the Slack installation', async () => {
+    mocks.post.mockReturnValue(resolves(oauthSuccess()));
+
+    const result = await createSlackApiClient().exchangeAuthorizationCode({code: 'oauth-code'});
+
+    const [url, options] = mocks.post.mock.calls[0] as [string, {body: URLSearchParams}];
+    expect(url).toBe('http://127.0.0.1:0/oauth.v2.access');
+    expect(options.body).toEqual(
+      new URLSearchParams({
+        client_id: 'test-client-id',
+        client_secret: 'test-client-secret',
+        code: 'oauth-code',
+        redirect_uri: 'https://shipfox.example.com/integrations/slack/callback',
+      }),
+    );
+    expect(result).toEqual({
+      accessToken: 'xoxb-token',
+      botUserId: 'U123',
+      appId: 'A123',
+      teamId: 'T123',
+      teamName: 'Acme',
+      scopes: ['app_mentions:read', 'chat:write'],
+    });
+  });
+
+  it.each([
+    ['invalid_code', 'access-denied'],
+    ['service_unavailable', 'provider-unavailable'],
+    ['ratelimited', 'rate-limited'],
+  ])('maps Slack application error %s to %s', async (error, reason) => {
+    mocks.post.mockReturnValue(resolves({ok: false, error}));
+
+    const result = createSlackApiClient().exchangeAuthorizationCode({code: 'oauth-code'});
+
+    await expect(result).rejects.toMatchObject({reason});
+  });
+
+  it.each([
+    oauthSuccess({is_enterprise_install: true}),
+    oauthSuccess({team: null}),
+  ])('rejects unsupported Enterprise Grid installs', async (body) => {
+    mocks.post.mockReturnValue(resolves(body));
+
+    const result = createSlackApiClient().exchangeAuthorizationCode({code: 'oauth-code'});
+
+    await expect(result).rejects.toBeInstanceOf(SlackEnterpriseInstallUnsupportedError);
+  });
+
+  it.each([
+    [rejects(httpError(503)), 'provider-unavailable'],
+    [rejects(httpError(403)), 'access-denied'],
+    [rejects(new TimeoutError({} as never)), 'timeout'],
+  ])('maps transport failures without leaking OAuth secrets', async (response, reason) => {
+    mocks.post.mockReturnValue(response);
+
+    const error = await createSlackApiClient()
+      .exchangeAuthorizationCode({code: 'super-secret-code'})
+      .catch((thrown: unknown) => thrown);
+
+    expect(error).toMatchObject({reason});
+    expect(JSON.stringify([error, mocks.warn.mock.calls])).not.toContain('super-secret-code');
+    expect(JSON.stringify([error, mocks.warn.mock.calls])).not.toContain('test-client-secret');
+  });
+
+  it('rejects malformed success payloads', async () => {
+    mocks.post.mockReturnValue(resolves(oauthSuccess({access_token: undefined})));
+
+    const result = createSlackApiClient().exchangeAuthorizationCode({code: 'oauth-code'});
+
+    await expect(result).rejects.toBeInstanceOf(SlackIntegrationProviderError);
+    await expect(result).rejects.toMatchObject({reason: 'malformed-provider-response'});
+  });
+
+  it('revokes with a bearer token and never logs it', async () => {
+    mocks.post.mockResolvedValue(undefined);
+
+    await createSlackApiClient().revokeToken({token: 'secret-token'});
+
+    expect(mocks.post).toHaveBeenCalledWith('http://127.0.0.1:0/auth.revoke', {
+      headers: {authorization: 'Bearer secret-token'},
+      timeout: 10_000,
+    });
+    expect(JSON.stringify(mocks.warn.mock.calls)).not.toContain('secret-token');
+  });
+});

--- a/libs/api/integration/slack/src/api/client.ts
+++ b/libs/api/integration/slack/src/api/client.ts
@@ -1,0 +1,151 @@
+import {logger} from '@shipfox/node-opentelemetry';
+import ky, {HTTPError, TimeoutError} from 'ky';
+import {config} from '#config.js';
+import {
+  SlackEnterpriseInstallUnsupportedError,
+  SlackIntegrationProviderError,
+} from '#core/errors.js';
+
+const SLACK_API_TIMEOUT_MS = 10_000;
+
+export interface SlackAuthorization {
+  accessToken: string;
+  botUserId: string;
+  appId: string;
+  teamId: string;
+  teamName: string;
+  scopes: string[];
+}
+
+export interface SlackApiClient {
+  exchangeAuthorizationCode(input: {code: string}): Promise<SlackAuthorization>;
+  revokeToken(input: {token: string}): Promise<void>;
+}
+
+interface SlackOAuthAccessResponse {
+  ok?: unknown;
+  error?: unknown;
+  access_token?: unknown;
+  bot_user_id?: unknown;
+  app_id?: unknown;
+  team?: {id?: unknown; name?: unknown} | null | undefined;
+  scope?: unknown;
+  is_enterprise_install?: unknown;
+}
+
+export function createSlackApiClient(): SlackApiClient {
+  return {
+    async exchangeAuthorizationCode(input) {
+      const body = await mapSlackError('exchange-authorization-code', () =>
+        ky
+          .post(slackApiUrl('oauth.v2.access'), {
+            body: new URLSearchParams({
+              client_id: config.SLACK_OAUTH_CLIENT_ID,
+              client_secret: config.SLACK_OAUTH_CLIENT_SECRET,
+              code: input.code,
+              redirect_uri: config.SLACK_OAUTH_REDIRECT_URL,
+            }),
+            timeout: SLACK_API_TIMEOUT_MS,
+          })
+          .json<SlackOAuthAccessResponse>(),
+      );
+      return parseOAuthAccess(body);
+    },
+
+    async revokeToken(input) {
+      await mapSlackError('revoke-token', async () => {
+        await ky.post(slackApiUrl('auth.revoke'), {
+          headers: {authorization: `Bearer ${input.token}`},
+          timeout: SLACK_API_TIMEOUT_MS,
+        });
+      });
+    },
+  };
+}
+
+function parseOAuthAccess(body: SlackOAuthAccessResponse): SlackAuthorization {
+  if (body.ok !== true) {
+    throw new SlackIntegrationProviderError(
+      slackOAuthErrorReason(body.error),
+      'Slack authorization request failed',
+    );
+  }
+  if (body.is_enterprise_install === true || body.team == null) {
+    throw new SlackEnterpriseInstallUnsupportedError();
+  }
+  const {access_token: accessToken, bot_user_id: botUserId, app_id: appId, team, scope} = body;
+  if (
+    typeof accessToken !== 'string' ||
+    typeof botUserId !== 'string' ||
+    typeof appId !== 'string' ||
+    typeof team.id !== 'string' ||
+    typeof team.name !== 'string' ||
+    typeof scope !== 'string'
+  ) {
+    throw new SlackIntegrationProviderError(
+      'malformed-provider-response',
+      'Slack authorization response did not include the required installation details',
+    );
+  }
+  // Token rotation is intentionally unsupported until ENG-997 adds a rejection guard.
+  return {
+    accessToken,
+    botUserId,
+    appId,
+    teamId: team.id,
+    teamName: team.name,
+    scopes: scope
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean),
+  };
+}
+
+function slackOAuthErrorReason(error: unknown) {
+  if (error === 'service_unavailable' || error === 'internal_error') return 'provider-unavailable';
+  if (error === 'ratelimited') return 'rate-limited';
+  return 'access-denied';
+}
+
+async function mapSlackError<T>(operation: string, request: () => Promise<T>): Promise<T> {
+  try {
+    return await request();
+  } catch (error) {
+    if (error instanceof SlackIntegrationProviderError) throw error;
+    if (error instanceof HTTPError) {
+      const {status, statusText, headers} = error.response;
+      logger().warn({operation, status, statusText}, 'Slack API request rejected');
+      if (status === 429) {
+        throw new SlackIntegrationProviderError(
+          'rate-limited',
+          'Slack request was rate limited',
+          retryAfterSeconds(headers),
+        );
+      }
+      if (status >= 500) {
+        throw new SlackIntegrationProviderError('provider-unavailable', 'Slack request failed');
+      }
+      throw new SlackIntegrationProviderError('access-denied', 'Slack request was rejected');
+    }
+    if (error instanceof TimeoutError) {
+      logger().warn({operation}, 'Slack API request timed out');
+      throw new SlackIntegrationProviderError('timeout', 'Slack request timed out');
+    }
+    logger().warn(
+      {operation, errName: error instanceof Error ? error.name : typeof error},
+      'Slack API request failed',
+    );
+    throw new SlackIntegrationProviderError('provider-unavailable', 'Slack request failed');
+  }
+}
+
+function slackApiUrl(path: string): string {
+  return new URL(path, `${config.SLACK_API_BASE_URL}/`).toString();
+}
+
+function retryAfterSeconds(headers: Headers): number | undefined {
+  const retryAfter = headers.get('retry-after');
+  if (!retryAfter) return undefined;
+  const parsed = Number.parseInt(retryAfter, 10);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}

--- a/libs/api/integration/slack/src/connection-external-url.test.ts
+++ b/libs/api/integration/slack/src/connection-external-url.test.ts
@@ -1,0 +1,25 @@
+import type {SlackInstallation} from '#db/installations.js';
+import {createSlackIntegrationProvider} from '#index.js';
+
+describe('Slack connectionExternalUrl', () => {
+  it('resolves the Slack team URL from the installation row', async () => {
+    const provider = createSlackIntegrationProvider({
+      getSlackInstallationByConnectionId: () =>
+        Promise.resolve({teamId: 'T 123'} as SlackInstallation),
+    });
+
+    const result = await provider.connectionExternalUrl({id: crypto.randomUUID()});
+
+    expect(result).toBe('https://app.slack.com/client/T%20123');
+  });
+
+  it('returns undefined when the installation is missing', async () => {
+    const provider = createSlackIntegrationProvider({
+      getSlackInstallationByConnectionId: () => Promise.resolve(undefined),
+    });
+
+    const result = await provider.connectionExternalUrl({id: crypto.randomUUID()});
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/libs/api/integration/slack/src/core/disconnect.ts
+++ b/libs/api/integration/slack/src/core/disconnect.ts
@@ -1,0 +1,26 @@
+import {deleteSlackInstallationByConnectionId} from '#db/installations.js';
+import {slackSecretsNamespace} from './tokens.js';
+
+export interface DisconnectSlackInstallationParams<Tx = unknown> {
+  connectionId: string;
+  getConnection(connectionId: string): Promise<{workspaceId: string} | undefined>;
+  deleteSecrets(params: {workspaceId: string; namespace: string}): Promise<number>;
+  transaction<T>(fn: (tx: Tx) => Promise<T>): Promise<T>;
+  deleteConnection(params: {connectionId: string}, options: {tx: Tx}): Promise<boolean>;
+}
+
+export async function disconnectSlackInstallation<Tx = unknown>(
+  params: DisconnectSlackInstallationParams<Tx>,
+): Promise<void> {
+  const connection = await params.getConnection(params.connectionId);
+  if (connection) {
+    await params.deleteSecrets({
+      workspaceId: connection.workspaceId,
+      namespace: slackSecretsNamespace(params.connectionId),
+    });
+  }
+  await params.transaction(async (tx) => {
+    await deleteSlackInstallationByConnectionId(params.connectionId, {tx});
+    await params.deleteConnection({connectionId: params.connectionId}, {tx});
+  });
+}

--- a/libs/api/integration/slack/src/core/errors.ts
+++ b/libs/api/integration/slack/src/core/errors.ts
@@ -2,6 +2,44 @@ import {IntegrationProviderError} from '@shipfox/api-integration-core-dto';
 
 export class SlackIntegrationProviderError extends IntegrationProviderError {}
 
+export class SlackInstallStateError extends Error {
+  constructor(message = 'Invalid Slack install state') {
+    super(message);
+    this.name = 'SlackInstallStateError';
+  }
+}
+
+export class SlackInstallStateActorMismatchError extends Error {
+  constructor() {
+    super('Slack install state was created by a different user');
+    this.name = 'SlackInstallStateActorMismatchError';
+  }
+}
+
+export class SlackOAuthCallbackError extends Error {
+  constructor(
+    public readonly providerError: string,
+    public readonly providerDescription: string | undefined,
+  ) {
+    super(providerDescription ?? `Slack OAuth callback failed: ${providerError}`);
+    this.name = 'SlackOAuthCallbackError';
+  }
+}
+
+export class SlackAuthorizationScopeMismatchError extends Error {
+  constructor(public readonly missingScopes: string[]) {
+    super(`Slack authorization is missing required scopes: ${missingScopes.join(', ')}`);
+    this.name = 'SlackAuthorizationScopeMismatchError';
+  }
+}
+
+export class SlackEnterpriseInstallUnsupportedError extends Error {
+  constructor() {
+    super('Slack Enterprise Grid installations are not supported');
+    this.name = 'SlackEnterpriseInstallUnsupportedError';
+  }
+}
+
 export class SlackInstallationAlreadyLinkedError extends Error {
   constructor(teamId: string) {
     super(`Slack team is already linked to another Shipfox workspace: ${teamId}`);

--- a/libs/api/integration/slack/src/core/install.test.ts
+++ b/libs/api/integration/slack/src/core/install.test.ts
@@ -1,0 +1,153 @@
+import type {UserContextMembership} from '@shipfox/api-auth-context';
+import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
+import type {SlackApiClient} from '#api/client.js';
+import type {ConnectSlackInstallationInput} from './install.js';
+import {handleSlackCallback} from './install.js';
+import {signSlackInstallState} from './state.js';
+
+function authorization(overrides: Record<string, unknown> = {}) {
+  return {
+    accessToken: 'xoxb-token',
+    botUserId: 'U123',
+    appId: 'A123',
+    teamId: 'T123',
+    teamName: 'Acme',
+    scopes: [
+      'app_mentions:read',
+      'im:history',
+      'chat:write',
+      'channels:history',
+      'groups:history',
+      'channels:read',
+      'groups:read',
+      'users:read',
+      'reactions:read',
+      'reactions:write',
+      'commands',
+    ],
+    ...overrides,
+  };
+}
+
+function connection(overrides: Partial<IntegrationConnection<'slack'>> = {}) {
+  return {
+    id: '00000000-0000-4000-8000-000000000001',
+    workspaceId: '00000000-0000-4000-8000-000000000002',
+    provider: 'slack',
+    externalAccountId: 'T123',
+    slug: 'slack_acme',
+    displayName: 'Slack Acme',
+    lifecycleStatus: 'active',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } satisfies IntegrationConnection<'slack'>;
+}
+
+function callbackParams(
+  overrides: Partial<Parameters<typeof handleSlackCallback>[0]> = {},
+): Parameters<typeof handleSlackCallback>[0] {
+  const slack: SlackApiClient = {
+    exchangeAuthorizationCode: vi.fn(() => Promise.resolve(authorization())),
+    revokeToken: vi.fn(() => Promise.resolve()),
+  };
+  return {
+    slack,
+    tokenStore: {storeTokens: vi.fn(() => Promise.resolve())},
+    code: 'code',
+    state: signSlackInstallState({
+      workspaceId: '00000000-0000-4000-8000-000000000002',
+      userId: 'user-1',
+    }),
+    sessionUserId: 'user-1',
+    sessionMemberships: [
+      {workspaceId: '00000000-0000-4000-8000-000000000002', role: 'admin'},
+    ] satisfies UserContextMembership[],
+    requireWorkspaceMembership: vi.fn(() => Promise.resolve()),
+    getExistingSlackConnection: vi.fn(() => Promise.resolve(undefined)),
+    connectSlackInstallation: vi.fn(() => Promise.resolve(connection())),
+    disconnectSlackInstallation: vi.fn(() => Promise.resolve()),
+    ...overrides,
+  };
+}
+
+describe('handleSlackCallback', () => {
+  it('connects a Slack installation and stores its bot token', async () => {
+    const params = callbackParams();
+
+    const result = await handleSlackCallback(params);
+
+    expect(result).toMatchObject({provider: 'slack', externalAccountId: 'T123'});
+    expect(params.connectSlackInstallation).toHaveBeenCalledWith({
+      workspaceId: '00000000-0000-4000-8000-000000000002',
+      teamId: 'T123',
+      teamName: 'Acme',
+      appId: 'A123',
+      botUserId: 'U123',
+      scopes: authorization().scopes,
+      tokenExpiresAt: null,
+      displayName: 'Slack Acme',
+    } satisfies ConnectSlackInstallationInput);
+    expect(params.tokenStore.storeTokens).toHaveBeenCalledWith({
+      connectionId: '00000000-0000-4000-8000-000000000001',
+      botToken: 'xoxb-token',
+      editedBy: 'user-1',
+    });
+  });
+
+  it('revokes the minted token when scopes do not match', async () => {
+    const slack: SlackApiClient = {
+      exchangeAuthorizationCode: vi.fn(() =>
+        Promise.resolve(authorization({scopes: ['chat:write']})),
+      ),
+      revokeToken: vi.fn(() => Promise.resolve()),
+    };
+    const params = callbackParams({slack});
+
+    const result = handleSlackCallback(params);
+
+    await expect(result).rejects.toThrow('missing required scopes');
+    expect(slack.revokeToken).toHaveBeenCalledWith({token: 'xoxb-token'});
+    expect(params.connectSlackInstallation).not.toHaveBeenCalled();
+  });
+
+  it('revokes a cross-workspace installation attempt', async () => {
+    const params = callbackParams({
+      getExistingSlackConnection: vi.fn(() =>
+        Promise.resolve(connection({workspaceId: crypto.randomUUID()})),
+      ),
+    });
+
+    const result = handleSlackCallback(params);
+
+    await expect(result).rejects.toThrow('already linked');
+    expect(params.slack.revokeToken).not.toHaveBeenCalled();
+  });
+
+  it('compensates a newly created connection when token storage fails', async () => {
+    const params = callbackParams({
+      tokenStore: {storeTokens: vi.fn(() => Promise.reject(new Error('store failed')))},
+    });
+
+    const result = handleSlackCallback(params);
+
+    await expect(result).rejects.toThrow('store failed');
+    expect(params.slack.revokeToken).toHaveBeenCalledWith({token: 'xoxb-token'});
+    expect(params.disconnectSlackInstallation).toHaveBeenCalledWith({
+      connectionId: connection().id,
+    });
+  });
+
+  it('refreshes an existing connection token without disconnecting it on storage failure', async () => {
+    const params = callbackParams({
+      getExistingSlackConnection: vi.fn(() => Promise.resolve(connection())),
+      tokenStore: {storeTokens: vi.fn(() => Promise.reject(new Error('store failed')))},
+    });
+
+    const result = handleSlackCallback(params);
+
+    await expect(result).rejects.toThrow('store failed');
+    expect(params.disconnectSlackInstallation).not.toHaveBeenCalled();
+    expect(params.slack.revokeToken).not.toHaveBeenCalled();
+  });
+});

--- a/libs/api/integration/slack/src/core/install.ts
+++ b/libs/api/integration/slack/src/core/install.ts
@@ -1,0 +1,137 @@
+import type {UserContextMembership} from '@shipfox/api-auth-context';
+import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
+import {logger} from '@shipfox/node-opentelemetry';
+import type {SlackApiClient} from '#api/client.js';
+import type {SlackTokenStore} from '#core/tokens.js';
+import {
+  SlackInstallationAlreadyLinkedError,
+  SlackInstallStateActorMismatchError,
+  SlackOAuthCallbackError,
+} from './errors.js';
+import {assertSlackAuthorizationScopes} from './scopes.js';
+import {verifySlackInstallState} from './state.js';
+
+export interface ConnectSlackInstallationInput {
+  workspaceId: string;
+  teamId: string;
+  teamName: string;
+  appId: string;
+  botUserId: string;
+  scopes: string[];
+  tokenExpiresAt: Date | null;
+  displayName: string;
+}
+
+export interface HandleSlackCallbackParams {
+  slack: SlackApiClient;
+  tokenStore: Pick<SlackTokenStore, 'storeTokens'>;
+  code: string;
+  state: string;
+  sessionUserId: string;
+  sessionMemberships: ReadonlyArray<UserContextMembership>;
+  requireWorkspaceMembership: (params: {
+    workspaceId: string;
+    userId: string;
+    memberships: ReadonlyArray<UserContextMembership>;
+  }) => Promise<unknown>;
+  getExistingSlackConnection: (input: {
+    teamId: string;
+  }) => Promise<IntegrationConnection<'slack'> | undefined>;
+  connectSlackInstallation: (
+    input: ConnectSlackInstallationInput,
+  ) => Promise<IntegrationConnection<'slack'>>;
+  disconnectSlackInstallation: (input: {connectionId: string}) => Promise<void>;
+}
+
+export async function handleSlackCallback(
+  params: HandleSlackCallbackParams,
+): Promise<IntegrationConnection<'slack'>> {
+  const claims = verifySlackInstallState(params.state);
+  if (claims.userId !== params.sessionUserId) throw new SlackInstallStateActorMismatchError();
+  await params.requireWorkspaceMembership({
+    workspaceId: claims.workspaceId,
+    userId: claims.userId,
+    memberships: params.sessionMemberships,
+  });
+
+  const authorization = await params.slack.exchangeAuthorizationCode({code: params.code});
+  let connectedConnectionId: string | undefined;
+  let shouldDisconnectConnection = false;
+  let shouldRevokeToken = false;
+  try {
+    const existing = await params.getExistingSlackConnection({teamId: authorization.teamId});
+    if (existing && existing.workspaceId !== claims.workspaceId) {
+      throw new SlackInstallationAlreadyLinkedError(authorization.teamId);
+    }
+    shouldRevokeToken = !existing;
+    assertSlackAuthorizationScopes(authorization.scopes);
+    const connection = await params.connectSlackInstallation({
+      workspaceId: claims.workspaceId,
+      teamId: authorization.teamId,
+      teamName: authorization.teamName,
+      appId: authorization.appId,
+      botUserId: authorization.botUserId,
+      scopes: authorization.scopes,
+      tokenExpiresAt: null,
+      displayName: `Slack ${authorization.teamName}`,
+    });
+    connectedConnectionId = connection.id;
+    shouldDisconnectConnection = !existing;
+    await params.tokenStore.storeTokens({
+      connectionId: connection.id,
+      botToken: authorization.accessToken,
+      editedBy: claims.userId,
+    });
+    return connection;
+  } catch (error) {
+    if (shouldRevokeToken) await bestEffortRevokeToken(params.slack, authorization.accessToken);
+    if (connectedConnectionId && shouldDisconnectConnection) {
+      await bestEffortDisconnectSlackInstallation(params, connectedConnectionId);
+    }
+    throw error;
+  }
+}
+
+export async function handleSlackOAuthCallbackError(params: {
+  state: string;
+  error: string;
+  errorDescription?: string | undefined;
+  sessionUserId: string;
+  sessionMemberships: ReadonlyArray<UserContextMembership>;
+  requireWorkspaceMembership: (input: {
+    workspaceId: string;
+    userId: string;
+    memberships: ReadonlyArray<UserContextMembership>;
+  }) => Promise<unknown>;
+}): Promise<never> {
+  const claims = verifySlackInstallState(params.state);
+  if (claims.userId !== params.sessionUserId) throw new SlackInstallStateActorMismatchError();
+  await params.requireWorkspaceMembership({
+    workspaceId: claims.workspaceId,
+    userId: claims.userId,
+    memberships: params.sessionMemberships,
+  });
+  throw new SlackOAuthCallbackError(params.error, params.errorDescription);
+}
+
+async function bestEffortRevokeToken(slack: SlackApiClient, token: string): Promise<void> {
+  try {
+    await slack.revokeToken({token});
+  } catch (error) {
+    logger().warn({err: error}, 'Slack OAuth token revocation failed');
+  }
+}
+
+async function bestEffortDisconnectSlackInstallation(
+  params: HandleSlackCallbackParams,
+  connectionId: string,
+): Promise<void> {
+  try {
+    await params.disconnectSlackInstallation({connectionId});
+  } catch (error) {
+    logger().warn(
+      {err: error, connectionId},
+      'Slack connect compensation failed after token storage rejection',
+    );
+  }
+}

--- a/libs/api/integration/slack/src/core/scopes.test.ts
+++ b/libs/api/integration/slack/src/core/scopes.test.ts
@@ -1,0 +1,22 @@
+import {SlackAuthorizationScopeMismatchError} from './errors.js';
+import {assertSlackAuthorizationScopes, formatSlackBotScopes, SLACK_BOT_SCOPES} from './scopes.js';
+
+describe('Slack bot scopes', () => {
+  it('formats and accepts the complete required scope set', () => {
+    const result = () => assertSlackAuthorizationScopes([...SLACK_BOT_SCOPES]);
+
+    expect(formatSlackBotScopes()).toBe(SLACK_BOT_SCOPES.join(','));
+    expect(result).not.toThrow();
+  });
+
+  it('reports every missing scope', () => {
+    const result = () => assertSlackAuthorizationScopes(['chat:write']);
+
+    expect(result).toThrow(SlackAuthorizationScopeMismatchError);
+    try {
+      result();
+    } catch (error) {
+      expect(error).toMatchObject({missingScopes: expect.arrayContaining(['app_mentions:read'])});
+    }
+  });
+});

--- a/libs/api/integration/slack/src/core/scopes.ts
+++ b/libs/api/integration/slack/src/core/scopes.ts
@@ -1,0 +1,25 @@
+import {SlackAuthorizationScopeMismatchError} from './errors.js';
+
+export const SLACK_BOT_SCOPES = Object.freeze([
+  'app_mentions:read',
+  'im:history',
+  'chat:write',
+  'channels:history',
+  'groups:history',
+  'channels:read',
+  'groups:read',
+  'users:read',
+  'reactions:read',
+  'reactions:write',
+  'commands',
+]);
+
+export function formatSlackBotScopes(scopes = SLACK_BOT_SCOPES): string {
+  return scopes.join(',');
+}
+
+export function assertSlackAuthorizationScopes(scopes: string[]): void {
+  const grantedScopes = new Set(scopes);
+  const missingScopes = SLACK_BOT_SCOPES.filter((scope) => !grantedScopes.has(scope));
+  if (missingScopes.length > 0) throw new SlackAuthorizationScopeMismatchError(missingScopes);
+}

--- a/libs/api/integration/slack/src/core/state.test.ts
+++ b/libs/api/integration/slack/src/core/state.test.ts
@@ -1,0 +1,48 @@
+import {createHmac} from 'node:crypto';
+import {SlackInstallStateError} from './errors.js';
+import {signSlackInstallState, verifySlackInstallState} from './state.js';
+
+describe('Slack install state', () => {
+  it('round-trips signed workspace and user claims', () => {
+    const state = signSlackInstallState({
+      workspaceId: 'workspace-1',
+      userId: 'user-1',
+      nonce: 'nonce-1',
+      now: new Date('2026-07-07T12:00:00.000Z'),
+    });
+
+    const result = verifySlackInstallState(state, new Date('2026-07-07T12:05:00.000Z'));
+
+    expect(result).toEqual({workspaceId: 'workspace-1', userId: 'user-1'});
+  });
+
+  it.each(['tampered signature', 'expired state'])('rejects a %s', (kind) => {
+    const state = signSlackInstallState({
+      workspaceId: 'workspace-1',
+      userId: 'user-1',
+      nonce: 'nonce-1',
+      now: new Date('2026-07-07T12:00:00.000Z'),
+    });
+    const [payload] = state.split('.');
+    const input = kind === 'tampered signature' ? `${payload}.tampered` : state;
+    const now =
+      kind === 'expired state'
+        ? new Date('2026-07-07T12:31:00.000Z')
+        : new Date('2026-07-07T12:05:00.000Z');
+
+    const result = () => verifySlackInstallState(input, now);
+
+    expect(result).toThrow(SlackInstallStateError);
+  });
+
+  it('rejects a validly signed malformed payload', () => {
+    const payload = Buffer.from('not-json').toString('base64url');
+    const signature = createHmac('sha256', 'test-client-secret')
+      .update(payload)
+      .digest('base64url');
+
+    const result = () => verifySlackInstallState(`${payload}.${signature}`);
+
+    expect(result).toThrow('Invalid Slack install state payload');
+  });
+});

--- a/libs/api/integration/slack/src/core/state.ts
+++ b/libs/api/integration/slack/src/core/state.ts
@@ -1,0 +1,82 @@
+import {createHmac, randomUUID, timingSafeEqual} from 'node:crypto';
+import {config} from '#config.js';
+import {SlackInstallStateError} from './errors.js';
+
+const STATE_TTL_SECONDS = 30 * 60;
+
+interface SlackInstallStatePayload {
+  workspaceId: string;
+  userId: string;
+  nonce: string;
+  expiresAt: number;
+}
+
+export interface SlackInstallStateClaims {
+  workspaceId: string;
+  userId: string;
+}
+
+export function signSlackInstallState(params: {
+  workspaceId: string;
+  userId: string;
+  nonce?: string | undefined;
+  now?: Date | undefined;
+}): string {
+  const now = params.now ?? new Date();
+  const payload: SlackInstallStatePayload = {
+    workspaceId: params.workspaceId,
+    userId: params.userId,
+    nonce: params.nonce ?? randomUUID(),
+    expiresAt: Math.floor(now.getTime() / 1000) + STATE_TTL_SECONDS,
+  };
+  const encodedPayload = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${encodedPayload}.${sign(encodedPayload)}`;
+}
+
+export function verifySlackInstallState(
+  state: string,
+  now: Date = new Date(),
+): SlackInstallStateClaims {
+  const [encodedPayload, signature, extra] = state.split('.');
+  if (!encodedPayload || !signature || extra !== undefined) {
+    throw new SlackInstallStateError('Invalid Slack install state');
+  }
+  if (!constantTimeEqual(signature, sign(encodedPayload))) {
+    throw new SlackInstallStateError('Invalid Slack install state signature');
+  }
+  const payload = parsePayload(encodedPayload);
+  if (payload.expiresAt < Math.floor(now.getTime() / 1000)) {
+    throw new SlackInstallStateError('Expired Slack install state');
+  }
+  return {workspaceId: payload.workspaceId, userId: payload.userId};
+}
+
+function sign(encodedPayload: string): string {
+  return createHmac('sha256', config.SLACK_OAUTH_CLIENT_SECRET)
+    .update(encodedPayload)
+    .digest('base64url');
+}
+
+function constantTimeEqual(a: string, b: string): boolean {
+  const left = Buffer.from(a);
+  const right = Buffer.from(b);
+  if (left.length !== right.length) return false;
+  return timingSafeEqual(left, right);
+}
+
+function parsePayload(encodedPayload: string): SlackInstallStatePayload {
+  try {
+    const parsed = JSON.parse(Buffer.from(encodedPayload, 'base64url').toString('utf8'));
+    if (
+      typeof parsed.workspaceId !== 'string' ||
+      typeof parsed.userId !== 'string' ||
+      typeof parsed.nonce !== 'string' ||
+      typeof parsed.expiresAt !== 'number'
+    ) {
+      throw new Error('Invalid payload shape');
+    }
+    return parsed;
+  } catch (_error) {
+    throw new SlackInstallStateError('Invalid Slack install state payload');
+  }
+}

--- a/libs/api/integration/slack/src/db/installations.ts
+++ b/libs/api/integration/slack/src/db/installations.ts
@@ -115,6 +115,17 @@ export async function getSlackInstallationByConnectionId(
   return toSlackInstallation(row);
 }
 
+export async function deleteSlackInstallationByConnectionId(
+  connectionId: string,
+  options: {tx?: unknown} = {},
+): Promise<boolean> {
+  const executor = (options.tx ?? db()) as SlackDb | SlackTx;
+  const result = await executor
+    .delete(slackInstallations)
+    .where(eq(slackInstallations.connectionId, connectionId));
+  return (result.rowCount ?? 0) > 0;
+}
+
 export async function markSlackInstallationRevoked(
   connectionId: string,
   options: {tx?: unknown} = {},

--- a/libs/api/integration/slack/src/index.ts
+++ b/libs/api/integration/slack/src/index.ts
@@ -1,22 +1,56 @@
 import {SLACK_PROVIDER} from '@shipfox/api-integration-slack-dto';
+import type {RouteGroup} from '@shipfox/node-fastify';
+import {createSlackApiClient, type SlackApiClient} from '#api/client.js';
 import {config} from '#config.js';
 import {closeDb, db} from '#db/db.js';
+import {getSlackInstallationByConnectionId} from '#db/installations.js';
 import {migrationsPath} from '#db/migrations.js';
+import {
+  type CreateSlackIntegrationRoutesOptions,
+  createSlackIntegrationRoutes,
+} from '#presentation/routes/install.js';
 import {
   type CreateSlackWebhookRoutesOptions,
   createSlackWebhookRoutes,
 } from '#presentation/routes/webhooks.js';
 
+type SlackInstallationRouteOptions = Omit<
+  CreateSlackIntegrationRoutesOptions,
+  'slack' | 'connectionCapabilities'
+>;
+type SlackRouteOptions = Partial<SlackInstallationRouteOptions> &
+  Partial<CreateSlackWebhookRoutesOptions>;
+
 export type {SlackProvider} from '@shipfox/api-integration-slack-dto';
+export type {SlackApiClient, SlackAuthorization} from '#api/client.js';
+export {createSlackApiClient} from '#api/client.js';
 export {
+  type DisconnectSlackInstallationParams,
+  disconnectSlackInstallation,
+} from '#core/disconnect.js';
+export {
+  SlackAuthorizationScopeMismatchError,
   SlackBotTokenMissingError,
   SlackConnectionAlreadyLinkedError,
   SlackConnectionNotFoundError,
+  SlackEnterpriseInstallUnsupportedError,
   SlackInstallationAlreadyLinkedError,
+  SlackInstallStateActorMismatchError,
+  SlackInstallStateError,
   SlackIntegrationProviderError,
+  SlackOAuthCallbackError,
 } from '#core/errors.js';
+export type {ConnectSlackInstallationInput, HandleSlackCallbackParams} from '#core/install.js';
+export {handleSlackCallback, handleSlackOAuthCallbackError} from '#core/install.js';
+export {
+  assertSlackAuthorizationScopes,
+  formatSlackBotScopes,
+  SLACK_BOT_SCOPES,
+} from '#core/scopes.js';
 export type {VerifySlackSignatureParams} from '#core/signature.js';
 export {verifySlackSignature} from '#core/signature.js';
+export type {SlackInstallStateClaims} from '#core/state.js';
+export {signSlackInstallState, verifySlackInstallState} from '#core/state.js';
 export type {
   CreateSlackTokenStoreParams,
   GetSlackAccessTokenParams,
@@ -38,11 +72,16 @@ export type {
   UpsertSlackInstallationParams,
 } from '#db/installations.js';
 export {
+  deleteSlackInstallationByConnectionId,
   getSlackInstallationByConnectionId,
   getSlackInstallationByTeamId,
   markSlackInstallationRevoked,
   upsertSlackInstallation,
 } from '#db/installations.js';
+export {
+  type CreateSlackE2eRoutesOptions,
+  createSlackE2eRoutes,
+} from '#presentation/e2eRoutes/index.js';
 export {
   type CreateSlackWebhookRoutesOptions,
   createSlackWebhookRoutes,
@@ -52,27 +91,73 @@ export {
 export {closeDb, config, db, migrationsPath};
 
 export interface CreateSlackIntegrationProviderOptions {
-  routes?: Partial<CreateSlackWebhookRoutesOptions> | undefined;
+  slack?: SlackApiClient | undefined;
+  getSlackInstallationByConnectionId?: typeof getSlackInstallationByConnectionId | undefined;
+  routes?: SlackRouteOptions | undefined;
 }
 
 export function createSlackIntegrationProvider(
   options: CreateSlackIntegrationProviderOptions = {},
 ) {
-  if (options.routes && !hasSlackWebhookRoutesOptions(options.routes)) {
+  const slack = options.slack ?? createSlackApiClient();
+  const getInstallationByConnectionId =
+    options.getSlackInstallationByConnectionId ?? getSlackInstallationByConnectionId;
+  if (
+    options.routes &&
+    !hasSlackInstallationRoutesOptions(options.routes) &&
+    !hasSlackWebhookRoutesOptions(options.routes)
+  ) {
     throw new Error('Slack webhook routes require every core persistence dependency');
   }
-  const routes = options.routes ? createSlackWebhookRoutes(options.routes) : [];
+  const routes: RouteGroup[] = [];
+  if (options.routes && hasSlackInstallationRoutesOptions(options.routes)) {
+    const {
+      tokenStore,
+      getExistingSlackConnection,
+      connectSlackInstallation,
+      disconnectSlackInstallation,
+    } = options.routes;
+    routes.push(
+      createSlackIntegrationRoutes({
+        slack,
+        connectionCapabilities: [],
+        tokenStore,
+        getExistingSlackConnection,
+        connectSlackInstallation,
+        disconnectSlackInstallation,
+      }),
+    );
+  }
+  if (options.routes && hasSlackWebhookRoutesOptions(options.routes)) {
+    routes.push(...createSlackWebhookRoutes(options.routes));
+  }
 
   return {
     provider: SLACK_PROVIDER,
     displayName: 'Slack',
     adapters: {},
+    async connectionExternalUrl(connection: {id: string}): Promise<string | undefined> {
+      const installation = await getInstallationByConnectionId(connection.id);
+      if (!installation) return undefined;
+      return `https://app.slack.com/client/${encodeURIComponent(installation.teamId)}`;
+    },
     routes,
   };
 }
 
+function hasSlackInstallationRoutesOptions(
+  routes: SlackRouteOptions,
+): routes is SlackInstallationRouteOptions {
+  return (
+    routes.tokenStore !== undefined &&
+    routes.getExistingSlackConnection !== undefined &&
+    routes.connectSlackInstallation !== undefined &&
+    routes.disconnectSlackInstallation !== undefined
+  );
+}
+
 function hasSlackWebhookRoutesOptions(
-  routes: Partial<CreateSlackWebhookRoutesOptions>,
+  routes: SlackRouteOptions,
 ): routes is CreateSlackWebhookRoutesOptions {
   return (
     routes.coreDb !== undefined &&

--- a/libs/api/integration/slack/src/presentation/dto/integrations.ts
+++ b/libs/api/integration/slack/src/presentation/dto/integrations.ts
@@ -1,0 +1,1 @@
+export {toIntegrationConnectionDto} from '@shipfox/api-integration-core-dto';

--- a/libs/api/integration/slack/src/presentation/e2eRoutes/create-connection.ts
+++ b/libs/api/integration/slack/src/presentation/e2eRoutes/create-connection.ts
@@ -1,0 +1,82 @@
+import type {IntegrationCapability, IntegrationConnection} from '@shipfox/api-integration-core-dto';
+import {
+  createE2eSlackConnectionBodySchema,
+  createE2eSlackConnectionResponseSchema,
+} from '@shipfox/api-integration-slack-dto';
+import {ClientError, defineRoute} from '@shipfox/node-fastify';
+import {logger} from '@shipfox/node-opentelemetry';
+import type {ConnectSlackInstallationInput} from '#core/install.js';
+import type {SlackTokenStore} from '#core/tokens.js';
+import {toIntegrationConnectionDto} from '#presentation/dto/integrations.js';
+
+export interface CreateE2eSlackConnectionRouteOptions {
+  tokenStore: Pick<SlackTokenStore, 'storeTokens'>;
+  getExistingSlackConnection: (input: {
+    teamId: string;
+  }) => Promise<IntegrationConnection<'slack'> | undefined>;
+  connectSlackInstallation: (
+    input: ConnectSlackInstallationInput,
+  ) => Promise<IntegrationConnection<'slack'>>;
+  disconnectSlackInstallation: (input: {connectionId: string}) => Promise<void>;
+  connectionCapabilities: IntegrationCapability[];
+}
+
+export function createE2eSlackConnectionRoute(options: CreateE2eSlackConnectionRouteOptions) {
+  return defineRoute({
+    method: 'POST',
+    path: '/slack-connections',
+    description: 'Create a synthetic Slack connection for E2E tests.',
+    schema: {
+      body: createE2eSlackConnectionBodySchema,
+      response: {201: createE2eSlackConnectionResponseSchema},
+    },
+    handler: async (request, reply) => {
+      const body = request.body;
+      const existing = await options.getExistingSlackConnection({teamId: body.team_id});
+      if (existing && existing.workspaceId !== body.workspace_id) {
+        throw new ClientError(
+          'Slack team is already connected to another workspace',
+          'slack-connection-workspace-mismatch',
+          {status: 409},
+        );
+      }
+      const connection =
+        existing ??
+        (await options.connectSlackInstallation({
+          workspaceId: body.workspace_id,
+          teamId: body.team_id,
+          teamName: body.team_name,
+          appId: body.app_id,
+          botUserId: body.bot_user_id,
+          scopes: body.scopes,
+          tokenExpiresAt: null,
+          displayName: `Slack ${body.team_name}`,
+        }));
+      try {
+        await options.tokenStore.storeTokens({
+          connectionId: connection.id,
+          botToken: body.bot_token,
+        });
+      } catch (error) {
+        if (!existing) await bestEffortDisconnectSlackInstallation(options, connection.id);
+        throw error;
+      }
+      reply.code(201);
+      return toIntegrationConnectionDto(connection, {capabilities: options.connectionCapabilities});
+    },
+  });
+}
+
+async function bestEffortDisconnectSlackInstallation(
+  options: CreateE2eSlackConnectionRouteOptions,
+  connectionId: string,
+): Promise<void> {
+  try {
+    await options.disconnectSlackInstallation({connectionId});
+  } catch (error) {
+    logger().warn(
+      {err: error, connectionId},
+      'Slack E2E connection compensation failed after token storage rejection',
+    );
+  }
+}

--- a/libs/api/integration/slack/src/presentation/e2eRoutes/index.test.ts
+++ b/libs/api/integration/slack/src/presentation/e2eRoutes/index.test.ts
@@ -1,0 +1,96 @@
+import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
+import {closeApp, createApp} from '@shipfox/node-fastify';
+import {createSlackE2eRoutes} from './index.js';
+
+function connection(overrides: Partial<IntegrationConnection<'slack'>> = {}) {
+  return {
+    id: '00000000-0000-4000-8000-000000000001',
+    workspaceId: '00000000-0000-4000-8000-000000000002',
+    provider: 'slack',
+    externalAccountId: 'T123',
+    slug: 'slack_acme',
+    displayName: 'Slack Acme',
+    lifecycleStatus: 'active',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } satisfies IntegrationConnection<'slack'>;
+}
+
+describe('Slack E2E routes', () => {
+  afterEach(async () => {
+    await closeApp();
+  });
+
+  it('creates a connection and stores its bot token without returning it', async () => {
+    const tokenStore = {storeTokens: vi.fn(() => Promise.resolve())};
+    const app = await createApp({
+      routes: [
+        createSlackE2eRoutes({
+          tokenStore,
+          getExistingSlackConnection: vi.fn(() => Promise.resolve(undefined)),
+          connectSlackInstallation: vi.fn(() => Promise.resolve(connection())),
+          disconnectSlackInstallation: vi.fn(() => Promise.resolve()),
+          connectionCapabilities: [],
+        }),
+      ],
+      swagger: false,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/integrations/slack-connections',
+      payload: {
+        workspace_id: '00000000-0000-4000-8000-000000000002',
+        team_id: 'T123',
+        team_name: 'Acme',
+        app_id: 'A123',
+        bot_user_id: 'U123',
+        bot_token: 'xoxb-e2e-token',
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.json()).toMatchObject({provider: 'slack', capabilities: []});
+    expect(res.body).not.toContain('xoxb-e2e-token');
+    expect(tokenStore.storeTokens).toHaveBeenCalledWith({
+      connectionId: '00000000-0000-4000-8000-000000000001',
+      botToken: 'xoxb-e2e-token',
+    });
+  });
+
+  it('rejects a Slack team connected to another workspace', async () => {
+    const connectSlackInstallation = vi.fn(() => Promise.resolve(connection()));
+    const app = await createApp({
+      routes: [
+        createSlackE2eRoutes({
+          tokenStore: {storeTokens: vi.fn(() => Promise.resolve())},
+          getExistingSlackConnection: vi.fn(() =>
+            Promise.resolve(connection({workspaceId: '00000000-0000-4000-8000-000000000003'})),
+          ),
+          connectSlackInstallation,
+          disconnectSlackInstallation: vi.fn(() => Promise.resolve()),
+          connectionCapabilities: [],
+        }),
+      ],
+      swagger: false,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/integrations/slack-connections',
+      payload: {
+        workspace_id: '00000000-0000-4000-8000-000000000002',
+        team_id: 'T123',
+        team_name: 'Acme',
+        app_id: 'A123',
+        bot_user_id: 'U123',
+        bot_token: 'xoxb-e2e-token',
+      },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json()).toMatchObject({code: 'slack-connection-workspace-mismatch'});
+    expect(connectSlackInstallation).not.toHaveBeenCalled();
+  });
+});

--- a/libs/api/integration/slack/src/presentation/e2eRoutes/index.ts
+++ b/libs/api/integration/slack/src/presentation/e2eRoutes/index.ts
@@ -1,0 +1,11 @@
+import type {RouteGroup} from '@shipfox/node-fastify';
+import {
+  type CreateE2eSlackConnectionRouteOptions,
+  createE2eSlackConnectionRoute,
+} from './create-connection.js';
+
+export type CreateSlackE2eRoutesOptions = CreateE2eSlackConnectionRouteOptions;
+
+export function createSlackE2eRoutes(options: CreateSlackE2eRoutesOptions): RouteGroup {
+  return {prefix: '/integrations', routes: [createE2eSlackConnectionRoute(options)]};
+}

--- a/libs/api/integration/slack/src/presentation/routes/errors.ts
+++ b/libs/api/integration/slack/src/presentation/routes/errors.ts
@@ -1,0 +1,64 @@
+import {
+  ConnectionSlugConflictError,
+  type IntegrationProviderErrorReason,
+} from '@shipfox/api-integration-core-dto';
+import {ClientError} from '@shipfox/node-fastify';
+import {
+  SlackAuthorizationScopeMismatchError,
+  SlackConnectionAlreadyLinkedError,
+  SlackEnterpriseInstallUnsupportedError,
+  SlackInstallationAlreadyLinkedError,
+  SlackInstallStateActorMismatchError,
+  SlackInstallStateError,
+  SlackIntegrationProviderError,
+  SlackOAuthCallbackError,
+} from '#core/errors.js';
+
+function providerStatus(reason: IntegrationProviderErrorReason): number {
+  if (reason === 'rate-limited') return 429;
+  if (reason === 'timeout' || reason === 'provider-unavailable') return 503;
+  return 422;
+}
+
+export function slackRouteErrorHandler(error: unknown): never {
+  if (error instanceof SlackInstallStateError) {
+    throw new ClientError(error.message, 'invalid-slack-install-state', {status: 400});
+  }
+  if (error instanceof SlackInstallStateActorMismatchError) {
+    throw new ClientError(error.message, 'slack-install-state-actor-mismatch', {status: 403});
+  }
+  if (error instanceof SlackInstallationAlreadyLinkedError) {
+    throw new ClientError(error.message, 'slack-installation-already-linked', {status: 409});
+  }
+  if (error instanceof SlackConnectionAlreadyLinkedError) {
+    throw new ClientError(error.message, 'slack-connection-already-linked', {status: 409});
+  }
+  if (error instanceof SlackAuthorizationScopeMismatchError) {
+    throw new ClientError(error.message, 'slack-authorization-scope-mismatch', {
+      status: 422,
+      details: {missing_scopes: error.missingScopes},
+    });
+  }
+  if (error instanceof SlackEnterpriseInstallUnsupportedError) {
+    throw new ClientError(error.message, 'slack-enterprise-install-unsupported', {status: 422});
+  }
+  if (error instanceof SlackOAuthCallbackError) {
+    throw new ClientError(error.message, 'slack-oauth-callback-error', {
+      status: 422,
+      details: {
+        error: error.providerError,
+        ...(error.providerDescription ? {error_description: error.providerDescription} : {}),
+      },
+    });
+  }
+  if (error instanceof ConnectionSlugConflictError) {
+    throw new ClientError(error.message, 'slug-conflict', {status: 409});
+  }
+  if (error instanceof SlackIntegrationProviderError) {
+    throw new ClientError(error.message, error.reason, {
+      details: {retry_after_seconds: error.retryAfterSeconds},
+      status: providerStatus(error.reason),
+    });
+  }
+  throw error;
+}

--- a/libs/api/integration/slack/src/presentation/routes/install.test.ts
+++ b/libs/api/integration/slack/src/presentation/routes/install.test.ts
@@ -1,0 +1,182 @@
+import {
+  AUTH_USER,
+  buildUserContext,
+  setUserContext,
+  type UserContextMembership,
+} from '@shipfox/api-auth-context';
+import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
+import {type AuthMethod, ClientError, closeApp, createApp} from '@shipfox/node-fastify';
+import type {FastifyInstance, FastifyRequest} from 'fastify';
+import type {SlackApiClient} from '#api/client.js';
+import type {ConnectSlackInstallationInput} from '#core/install.js';
+import {verifySlackInstallState} from '#core/state.js';
+import type {SlackTokenStore} from '#core/tokens.js';
+import {createSlackIntegrationProvider} from '#index.js';
+
+vi.mock('@shipfox/api-workspaces', () => ({
+  requireWorkspaceMembership: vi.fn(() => Promise.resolve()),
+}));
+
+let authenticatedMemberships: UserContextMembership[] = [];
+
+const fakeUserAuth: AuthMethod = {
+  name: AUTH_USER,
+  authenticate: (request: FastifyRequest) => {
+    if (request.headers.authorization !== 'Bearer user') {
+      throw new ClientError('Invalid user token', 'unauthorized', {status: 401});
+    }
+    setUserContext(
+      request,
+      buildUserContext({
+        userId: 'user-1',
+        email: 'user@example.com',
+        memberships: authenticatedMemberships,
+      }),
+    );
+    return Promise.resolve();
+  },
+};
+
+function slackClient(overrides: Partial<SlackApiClient> = {}): SlackApiClient {
+  return {
+    exchangeAuthorizationCode: vi.fn(() =>
+      Promise.resolve({
+        accessToken: 'xoxb-token',
+        botUserId: 'U123',
+        appId: 'A123',
+        teamId: 'T123',
+        teamName: 'Acme',
+        scopes: [
+          'app_mentions:read',
+          'im:history',
+          'chat:write',
+          'channels:history',
+          'groups:history',
+          'channels:read',
+          'groups:read',
+          'users:read',
+          'reactions:read',
+          'reactions:write',
+          'commands',
+        ],
+      }),
+    ),
+    revokeToken: vi.fn(() => Promise.resolve()),
+    ...overrides,
+  };
+}
+
+function connection(input: Partial<IntegrationConnection<'slack'>> = {}) {
+  return {
+    id: '00000000-0000-4000-8000-000000000001',
+    workspaceId: '00000000-0000-4000-8000-000000000002',
+    provider: 'slack',
+    externalAccountId: 'T123',
+    slug: 'slack_acme',
+    displayName: 'Slack Acme',
+    lifecycleStatus: 'active',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...input,
+  } satisfies IntegrationConnection<'slack'>;
+}
+
+async function createTestApp(
+  options: {
+    slack?: SlackApiClient | undefined;
+    tokenStore?: Pick<SlackTokenStore, 'storeTokens'> | undefined;
+    connectSlackInstallation?:
+      | ((input: ConnectSlackInstallationInput) => Promise<IntegrationConnection<'slack'>>)
+      | undefined;
+  } = {},
+): Promise<FastifyInstance> {
+  const provider = createSlackIntegrationProvider({
+    slack: options.slack ?? slackClient(),
+    routes: {
+      tokenStore: options.tokenStore ?? {storeTokens: vi.fn(() => Promise.resolve())},
+      getExistingSlackConnection: vi.fn(() => Promise.resolve(undefined)),
+      connectSlackInstallation:
+        options.connectSlackInstallation ??
+        vi.fn((input: ConnectSlackInstallationInput) =>
+          Promise.resolve(connection({workspaceId: input.workspaceId})),
+        ),
+      disconnectSlackInstallation: vi.fn(() => Promise.resolve()),
+    },
+  });
+  const app = await createApp({auth: [fakeUserAuth], routes: provider.routes, swagger: false});
+  await app.ready();
+  return app;
+}
+
+describe('Slack integration routes', () => {
+  beforeEach(async () => {
+    authenticatedMemberships = [];
+    await closeApp();
+  });
+
+  afterEach(async () => {
+    await closeApp();
+  });
+
+  it('returns Slack’s bot-only OAuth URL with signed workspace state', async () => {
+    const app = await createTestApp();
+    const workspaceId = '00000000-0000-4000-8000-000000000002';
+    authenticatedMemberships = [{workspaceId, role: 'admin'}];
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/integrations/slack/install',
+      headers: {authorization: 'Bearer user'},
+      payload: {workspace_id: workspaceId},
+    });
+
+    const installUrl = new URL(res.json().install_url);
+    const state = installUrl.searchParams.get('state');
+    expect(res.statusCode).toBe(200);
+    expect(installUrl.origin + installUrl.pathname).toBe('https://slack.com/oauth/v2/authorize');
+    expect(installUrl.searchParams.get('scope')).toContain('app_mentions:read');
+    expect(installUrl.searchParams.has('user_scope')).toBe(false);
+    expect(verifySlackInstallState(state ?? '')).toEqual({workspaceId, userId: 'user-1'});
+  });
+
+  it('rejects install requests for a workspace the actor cannot access', async () => {
+    const app = await createTestApp();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/integrations/slack/install',
+      headers: {authorization: 'Bearer user'},
+      payload: {workspace_id: '00000000-0000-4000-8000-000000000002'},
+    });
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('returns the connected Slack connection after a verified callback', async () => {
+    const tokenStore = {storeTokens: vi.fn(() => Promise.resolve())};
+    const app = await createTestApp({tokenStore});
+    const workspaceId = '00000000-0000-4000-8000-000000000002';
+    authenticatedMemberships = [{workspaceId, role: 'admin'}];
+    const install = await app.inject({
+      method: 'POST',
+      url: '/integrations/slack/install',
+      headers: {authorization: 'Bearer user'},
+      payload: {workspace_id: workspaceId},
+    });
+    const state = new URL(install.json().install_url).searchParams.get('state');
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/integrations/slack/callback/api?code=code&state=${state}`,
+      headers: {authorization: 'Bearer user'},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({provider: 'slack', capabilities: []});
+    expect(tokenStore.storeTokens).toHaveBeenCalledWith({
+      connectionId: '00000000-0000-4000-8000-000000000001',
+      botToken: 'xoxb-token',
+      editedBy: 'user-1',
+    });
+  });
+});

--- a/libs/api/integration/slack/src/presentation/routes/install.ts
+++ b/libs/api/integration/slack/src/presentation/routes/install.ts
@@ -1,0 +1,117 @@
+import {AUTH_USER, requireUserContext, requireWorkspaceAccess} from '@shipfox/api-auth-context';
+import type {IntegrationCapability, IntegrationConnection} from '@shipfox/api-integration-core-dto';
+import {
+  createSlackInstallBodySchema,
+  createSlackInstallResponseSchema,
+  type SlackCallbackQueryDto,
+  slackCallbackQuerySchema,
+  slackCallbackResponseSchema,
+} from '@shipfox/api-integration-slack-dto';
+import {requireWorkspaceMembership} from '@shipfox/api-workspaces';
+import {defineRoute, type RouteGroup} from '@shipfox/node-fastify';
+import type {SlackApiClient} from '#api/client.js';
+import {config} from '#config.js';
+import {
+  type ConnectSlackInstallationInput,
+  handleSlackCallback,
+  handleSlackOAuthCallbackError,
+} from '#core/install.js';
+import {formatSlackBotScopes} from '#core/scopes.js';
+import {signSlackInstallState} from '#core/state.js';
+import type {SlackTokenStore} from '#core/tokens.js';
+import {toIntegrationConnectionDto} from '#presentation/dto/integrations.js';
+import {slackRouteErrorHandler} from './errors.js';
+
+export interface CreateSlackIntegrationRoutesOptions {
+  slack: SlackApiClient;
+  tokenStore: Pick<SlackTokenStore, 'storeTokens'>;
+  getExistingSlackConnection: (input: {
+    teamId: string;
+  }) => Promise<IntegrationConnection<'slack'> | undefined>;
+  connectSlackInstallation: (
+    input: ConnectSlackInstallationInput,
+  ) => Promise<IntegrationConnection<'slack'>>;
+  disconnectSlackInstallation: (input: {connectionId: string}) => Promise<void>;
+  connectionCapabilities: IntegrationCapability[];
+}
+
+export function createSlackIntegrationRoutes({
+  slack,
+  tokenStore,
+  getExistingSlackConnection,
+  connectSlackInstallation,
+  disconnectSlackInstallation,
+  connectionCapabilities,
+}: CreateSlackIntegrationRoutesOptions): RouteGroup {
+  const installRoute = defineRoute({
+    method: 'POST',
+    path: '/install',
+    auth: AUTH_USER,
+    description: 'Create a Slack OAuth authorization URL for a workspace.',
+    schema: {
+      body: createSlackInstallBodySchema,
+      response: {200: createSlackInstallResponseSchema},
+    },
+    handler: (request) => {
+      const {workspace_id: workspaceId} = request.body;
+      const actor = requireUserContext(request);
+      requireWorkspaceAccess({request, workspaceId});
+      const state = signSlackInstallState({workspaceId, userId: actor.userId});
+      const installUrl = new URL('https://slack.com/oauth/v2/authorize');
+      installUrl.searchParams.set('client_id', config.SLACK_OAUTH_CLIENT_ID);
+      installUrl.searchParams.set('scope', formatSlackBotScopes());
+      installUrl.searchParams.set('redirect_uri', config.SLACK_OAUTH_REDIRECT_URL);
+      installUrl.searchParams.set('state', state);
+      return {install_url: installUrl.toString()};
+    },
+  });
+
+  const callbackApiRoute = defineRoute({
+    method: 'GET',
+    path: '/callback/api',
+    auth: AUTH_USER,
+    description: 'Handle the Slack OAuth callback.',
+    schema: {
+      querystring: slackCallbackQuerySchema,
+      response: {200: slackCallbackResponseSchema},
+    },
+    errorHandler: slackRouteErrorHandler,
+    handler: async (request) => {
+      const actor = requireUserContext(request);
+      const query = request.query;
+      if (isSlackOAuthErrorCallback(query)) {
+        return await handleSlackOAuthCallbackError({
+          state: query.state,
+          error: query.error,
+          errorDescription: query.error_description,
+          sessionUserId: actor.userId,
+          sessionMemberships: actor.memberships,
+          requireWorkspaceMembership,
+        });
+      }
+      const connection = await handleSlackCallback({
+        slack,
+        tokenStore,
+        code: query.code,
+        state: query.state,
+        sessionUserId: actor.userId,
+        sessionMemberships: actor.memberships,
+        requireWorkspaceMembership,
+        getExistingSlackConnection,
+        connectSlackInstallation,
+        disconnectSlackInstallation,
+      });
+      return toIntegrationConnectionDto(connection, {capabilities: connectionCapabilities});
+    },
+  });
+
+  return {prefix: '/integrations/slack', routes: [installRoute, callbackApiRoute]};
+}
+
+function isSlackOAuthErrorCallback(query: SlackCallbackQueryDto): query is SlackCallbackQueryDto & {
+  error: string;
+  error_description?: string | undefined;
+  state: string;
+} {
+  return 'error' in query && typeof query.error === 'string';
+}

--- a/libs/api/server/src/modules.test.ts
+++ b/libs/api/server/src/modules.test.ts
@@ -96,13 +96,18 @@ describe('defaultModules', () => {
     ]);
   });
 
-  it('uses the leased-step loader and namespaced Linear secrets', async () => {
+  it('uses the leased-step loader and namespaced provider secrets', async () => {
     await defaultModules();
 
     expect(mocks.createIntegrationsContext).toHaveBeenCalledWith({
       secrets: {
         deleteSecrets: mocks.deleteSecrets,
         linear: {
+          deleteSecrets: expect.any(Function),
+          getSecret: expect.any(Function),
+          setSecrets: expect.any(Function),
+        },
+        slack: {
           deleteSecrets: expect.any(Function),
           getSecret: expect.any(Function),
           setSecrets: expect.any(Function),
@@ -118,11 +123,19 @@ describe('defaultModules', () => {
           getSecret: (params: {namespace: string}) => unknown;
           setSecrets: (params: {namespace: string}) => unknown;
         };
+        slack: {
+          deleteSecrets: (params: {namespace: string}) => unknown;
+          getSecret: (params: {namespace: string}) => unknown;
+          setSecrets: (params: {namespace: string}) => unknown;
+        };
       };
     };
     integrationsOptions.secrets.linear.getSecret({namespace: 'workspace'});
     integrationsOptions.secrets.linear.setSecrets({namespace: 'workspace'});
     integrationsOptions.secrets.linear.deleteSecrets({namespace: 'workspace'});
+    integrationsOptions.secrets.slack.getSecret({namespace: 'workspace'});
+    integrationsOptions.secrets.slack.setSecrets({namespace: 'workspace'});
+    integrationsOptions.secrets.slack.deleteSecrets({namespace: 'workspace'});
 
     expect(mocks.getSecret).toHaveBeenCalledWith({
       namespace: 'system/integrations/linear/workspace',
@@ -132,6 +145,15 @@ describe('defaultModules', () => {
     });
     expect(mocks.deleteSecrets).toHaveBeenCalledWith({
       namespace: 'system/integrations/linear/workspace',
+    });
+    expect(mocks.getSecret).toHaveBeenCalledWith({
+      namespace: 'system/integrations/slack/workspace',
+    });
+    expect(mocks.setSecrets).toHaveBeenCalledWith({
+      namespace: 'system/integrations/slack/workspace',
+    });
+    expect(mocks.deleteSecrets).toHaveBeenCalledWith({
+      namespace: 'system/integrations/slack/workspace',
     });
   });
 });

--- a/libs/api/server/src/modules.ts
+++ b/libs/api/server/src/modules.ts
@@ -45,6 +45,23 @@ export async function defaultModules(): Promise<ShipfoxModule[]> {
             namespace: `system/integrations/linear/${params.namespace}`,
           }),
       },
+      slack: {
+        getSecret: (params) =>
+          getSecret({
+            ...params,
+            namespace: `system/integrations/slack/${params.namespace}`,
+          }),
+        setSecrets: (params) =>
+          setSecrets({
+            ...params,
+            namespace: `system/integrations/slack/${params.namespace}`,
+          }),
+        deleteSecrets: (params) =>
+          deleteSecrets({
+            ...params,
+            namespace: `system/integrations/slack/${params.namespace}`,
+          }),
+      },
     },
     agentTools: {loadLeasedAgentStep: loadRunningLeasedStep},
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2870,6 +2870,9 @@ importers:
 
   libs/api/integration/slack:
     dependencies:
+      '@shipfox/api-auth-context':
+        specifier: workspace:*
+        version: link:../../auth-context
       '@shipfox/api-integration-core-dto':
         specifier: workspace:*
         version: link:../core-dto
@@ -2879,6 +2882,9 @@ importers:
       '@shipfox/api-secrets':
         specifier: workspace:*
         version: link:../../secrets
+      '@shipfox/api-workspaces':
+        specifier: workspace:*
+        version: link:../../workspaces
       '@shipfox/config':
         specifier: workspace:*
         version: link:../../../shared/common/config
@@ -2897,6 +2903,9 @@ importers:
       drizzle-orm:
         specifier: 'catalog:'
         version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
+      ky:
+        specifier: 'catalog:'
+        version: 2.0.2
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -2922,6 +2931,9 @@ importers:
       drizzle-kit:
         specifier: 'catalog:'
         version: 0.31.10
+      fastify:
+        specifier: 'catalog:'
+        version: 5.8.5
       fishery:
         specifier: 'catalog:'
         version: 2.4.0


### PR DESCRIPTION
Adds the server-side Slack OAuth v2 connect flow: signed install state, scope validation, token exchange, connection persistence, and HTTP-first E2E setup.

Slack teams need a provider-owned connect path before the client, inbound-event, and agent-tool work can use the common integrations framework. The implementation keeps Slack credentials in the existing scoped secrets seam and adds clean callback errors plus compensation for a newly created installation.

Because Slack can revoke an unrotated app authorization rather than only a transient credential, rollback intentionally does not revoke a token for an already connected team. This preserves a working integration during cross-workspace and same-workspace reconnect failures.

Closes ENG-927

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Slack OAuth v2 connect flow with signed install state, scope validation, token exchange, connection persistence, and HTTP-first E2E setup. Enables a provider-owned Slack connect path aligned with ENG-927 so future client, inbound-event, and agent-tool work use the common framework.

- **New Features**
  - Provider routes: install URL generation and OAuth callback with clean error mapping, including OAuth error callbacks.
  - Secure bot-token storage via namespaced secrets (`system/integrations/slack/...`) and a `SlackTokenStore`.
  - Connection create/refresh with unique slug resolution and external team URL (`app.slack.com/client/<team>`).
  - Scope enforcement for bot-only permissions and Enterprise Grid install rejection.
  - Best-effort compensation on failures: revoke newly minted tokens and disconnect newly created installations without touching existing ones.
  - E2E route to create synthetic Slack connections for tests without exposing tokens in responses.

- **Dependencies**
  - Adds `ky`, `zod`, and integrates `@shipfox/api-auth-context`, `@shipfox/api-workspaces`, `@shipfox/node-fastify`, `@shipfox/node-opentelemetry`.
  - Server secrets seam extended with a `slack` namespace in `system/integrations/slack/...`.

<sup>Written for commit 2f420c9327a780ff80a2278e43e171701cfc7488. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

