### PR TITLE
[slack] Reject rotating OAuth grants

### DIFF
--- a/.changeset/brave-otters-shield.md
+++ b/.changeset/brave-otters-shield.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-integration-slack": patch
+---
+
+Rejects Slack OAuth grants that enable unsupported token rotation.

--- a/libs/api/integration/slack/src/api/client.test.ts
+++ b/libs/api/integration/slack/src/api/client.test.ts
@@ -2,6 +2,7 @@ import {HTTPError, TimeoutError} from 'ky';
 import {
   SlackEnterpriseInstallUnsupportedError,
   SlackIntegrationProviderError,
+  SlackTokenRotationUnsupportedError,
 } from '#core/errors.js';
 import {createSlackApiClient} from './client.js';
 
@@ -104,6 +105,29 @@ describe('createSlackApiClient', () => {
     const result = createSlackApiClient().exchangeAuthorizationCode({code: 'oauth-code'});
 
     await expect(result).rejects.toBeInstanceOf(SlackEnterpriseInstallUnsupportedError);
+  });
+
+  it.each([
+    oauthSuccess({expires_in: 43_200}),
+    oauthSuccess({refresh_token: 'xoxe-1-refresh'}),
+  ])('rejects rotation-enabled OAuth responses', async (body) => {
+    mocks.post.mockReturnValue(resolves(body));
+
+    const result = createSlackApiClient().exchangeAuthorizationCode({code: 'oauth-code'});
+
+    await expect(result).rejects.toBeInstanceOf(SlackTokenRotationUnsupportedError);
+  });
+
+  it('never embeds a rotating token value in the thrown error', async () => {
+    mocks.post.mockReturnValue(resolves(oauthSuccess({refresh_token: 'xoxe-secret-refresh'})));
+
+    const error = await createSlackApiClient()
+      .exchangeAuthorizationCode({code: 'oauth-code'})
+      .catch((thrown: unknown) => thrown);
+
+    expect(error).toBeInstanceOf(SlackTokenRotationUnsupportedError);
+    expect((error as Error).message).toBe('Slack token rotation is not supported');
+    expect(String(error)).not.toContain('xoxe-secret-refresh');
   });
 
   it.each([

--- a/libs/api/integration/slack/src/api/client.ts
+++ b/libs/api/integration/slack/src/api/client.ts
@@ -4,6 +4,7 @@ import {config} from '#config.js';
 import {
   SlackEnterpriseInstallUnsupportedError,
   SlackIntegrationProviderError,
+  SlackTokenRotationUnsupportedError,
 } from '#core/errors.js';
 
 const SLACK_API_TIMEOUT_MS = 10_000;
@@ -31,6 +32,8 @@ interface SlackOAuthAccessResponse {
   team?: {id?: unknown; name?: unknown} | null | undefined;
   scope?: unknown;
   is_enterprise_install?: unknown;
+  expires_in?: unknown;
+  refresh_token?: unknown;
 }
 
 export function createSlackApiClient(): SlackApiClient {
@@ -73,6 +76,12 @@ function parseOAuthAccess(body: SlackOAuthAccessResponse): SlackAuthorization {
   if (body.is_enterprise_install === true || body.team == null) {
     throw new SlackEnterpriseInstallUnsupportedError();
   }
+  // The bot-token store has no refresh path, so a rotating (expiring) token must never be persisted.
+  // Slack omits both fields when rotation is off, so presence of either signals rotation.
+  // The rejected token self-expires, matching the Enterprise Grid rejection path.
+  if (body.expires_in !== undefined || body.refresh_token !== undefined) {
+    throw new SlackTokenRotationUnsupportedError();
+  }
   const {access_token: accessToken, bot_user_id: botUserId, app_id: appId, team, scope} = body;
   if (
     typeof accessToken !== 'string' ||
@@ -87,7 +96,6 @@ function parseOAuthAccess(body: SlackOAuthAccessResponse): SlackAuthorization {
       'Slack authorization response did not include the required installation details',
     );
   }
-  // Token rotation is intentionally unsupported until ENG-997 adds a rejection guard.
   return {
     accessToken,
     botUserId,

--- a/libs/api/integration/slack/src/core/errors.ts
+++ b/libs/api/integration/slack/src/core/errors.ts
@@ -40,6 +40,13 @@ export class SlackEnterpriseInstallUnsupportedError extends Error {
   }
 }
 
+export class SlackTokenRotationUnsupportedError extends Error {
+  constructor() {
+    super('Slack token rotation is not supported');
+    this.name = 'SlackTokenRotationUnsupportedError';
+  }
+}
+
 export class SlackInstallationAlreadyLinkedError extends Error {
   constructor(teamId: string) {
     super(`Slack team is already linked to another Shipfox workspace: ${teamId}`);

--- a/libs/api/integration/slack/src/presentation/routes/errors.ts
+++ b/libs/api/integration/slack/src/presentation/routes/errors.ts
@@ -12,6 +12,7 @@ import {
   SlackInstallStateError,
   SlackIntegrationProviderError,
   SlackOAuthCallbackError,
+  SlackTokenRotationUnsupportedError,
 } from '#core/errors.js';
 
 function providerStatus(reason: IntegrationProviderErrorReason): number {
@@ -41,6 +42,9 @@ export function slackRouteErrorHandler(error: unknown): never {
   }
   if (error instanceof SlackEnterpriseInstallUnsupportedError) {
     throw new ClientError(error.message, 'slack-enterprise-install-unsupported', {status: 422});
+  }
+  if (error instanceof SlackTokenRotationUnsupportedError) {
+    throw new ClientError(error.message, 'slack-token-rotation-unsupported', {status: 422});
   }
   if (error instanceof SlackOAuthCallbackError) {
     throw new ClientError(error.message, 'slack-oauth-callback-error', {

--- a/libs/api/integration/slack/src/presentation/routes/install.test.ts
+++ b/libs/api/integration/slack/src/presentation/routes/install.test.ts
@@ -8,6 +8,7 @@ import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
 import {type AuthMethod, ClientError, closeApp, createApp} from '@shipfox/node-fastify';
 import type {FastifyInstance, FastifyRequest} from 'fastify';
 import type {SlackApiClient} from '#api/client.js';
+import {SlackTokenRotationUnsupportedError} from '#core/errors.js';
 import type {ConnectSlackInstallationInput} from '#core/install.js';
 import {verifySlackInstallState} from '#core/state.js';
 import type {SlackTokenStore} from '#core/tokens.js';
@@ -178,5 +179,34 @@ describe('Slack integration routes', () => {
       botToken: 'xoxb-token',
       editedBy: 'user-1',
     });
+  });
+
+  it('rejects a callback whose OAuth response enables token rotation', async () => {
+    const tokenStore = {storeTokens: vi.fn(() => Promise.resolve())};
+    const slack = slackClient({
+      exchangeAuthorizationCode: vi.fn(() =>
+        Promise.reject(new SlackTokenRotationUnsupportedError()),
+      ),
+    });
+    const app = await createTestApp({slack, tokenStore});
+    const workspaceId = '00000000-0000-4000-8000-000000000002';
+    authenticatedMemberships = [{workspaceId, role: 'admin'}];
+    const install = await app.inject({
+      method: 'POST',
+      url: '/integrations/slack/install',
+      headers: {authorization: 'Bearer user'},
+      payload: {workspace_id: workspaceId},
+    });
+    const state = new URL(install.json().install_url).searchParams.get('state');
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/integrations/slack/callback/api?code=code&state=${state}`,
+      headers: {authorization: 'Bearer user'},
+    });
+
+    expect(res.statusCode).toBe(422);
+    expect(res.json().code).toBe('slack-token-rotation-unsupported');
+    expect(tokenStore.storeTokens).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Rejects Slack OAuth grants that enable token rotation before the bot token reaches persistence.

The Slack bot-token store has no refresh path, so accepting a rotation-enabled grant would store an expiring credential as permanent and fail later without recovery. The callback now returns a typed 422 response instead.

Supporting rotation would require refresh-token storage and a refresh lifecycle, which is intentionally deferred. The rejected short-lived token is left to expire, matching the Enterprise Grid rejection path.

Closes ENG-997

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject Slack OAuth grants that enable token rotation to prevent storing expiring bot tokens; the OAuth callback now returns a typed 422 (`slack-token-rotation-unsupported`). Addresses ENG-997.

- **Bug Fixes**
  - Detect `expires_in` or `refresh_token` in OAuth response and throw `SlackTokenRotationUnsupportedError`.
  - Map the error to 422 in the route handler; never include token values in error messages.
  - Added tests for client parsing, error mapping, and route behavior.

<sup>Written for commit 86b8a0635d44dec7381aedfb0a9b58e184e561ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

