### PR TITLE
[provisioner] Add EC2 provider scaffold

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -50,5 +50,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@shipfox/api", "@shipfox/client", "@shipfox/runner", "@shipfox/provisioner-docker"]
+  "ignore": ["@shipfox/api", "@shipfox/client", "@shipfox/runner", "@shipfox/provisioner-docker", "@shipfox/provisioner-ec2"]
 }

--- a/.changeset/vivid-moles-shine.md
+++ b/.changeset/vivid-moles-shine.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/provisioner-ec2-provider": minor
+---
+
+Adds the internal EC2 provisioner provider scaffold: config, the EC2 template spec, and a fail-fast template loader.

--- a/apps/provisioner-ec2/README.md
+++ b/apps/provisioner-ec2/README.md
@@ -1,0 +1,7 @@
+# @shipfox/provisioner-ec2
+
+This app will run the EC2 provisioner once its engine, lifecycle, and provider wiring
+land. It is intentionally not runnable in this scaffold issue and exits with an error.
+
+The current provider package, [`@shipfox/provisioner-ec2-provider`](../../libs/provisioner/ec2),
+only loads and validates EC2 template configuration.

--- a/apps/provisioner-ec2/package.json
+++ b/apps/provisioner-ec2/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@shipfox/provisioner-ec2",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
+    "directory": "apps/provisioner-ec2"
+  },
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "imports": {
+    "#*": "./src/*"
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "dev": "tsx watch --conditions=development --env-file-if-exists=../../.env --env-file-if-exists=.env --env-file-if-exists=.env.local src/index.ts",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "@shipfox/node-opentelemetry": "workspace:*",
+    "@shipfox/provisioner-ec2-provider": "workspace:*"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*",
+    "tsx": "catalog:"
+  }
+}

--- a/apps/provisioner-ec2/src/index.ts
+++ b/apps/provisioner-ec2/src/index.ts
@@ -1,0 +1,4 @@
+import {logger} from '@shipfox/node-opentelemetry';
+
+logger().error('EC2 provisioner is not wired yet; the control loop is added in a later issue.');
+process.exit(1);

--- a/apps/provisioner-ec2/tsconfig.build.json
+++ b/apps/provisioner-ec2/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.tsx", "**/*.test.ts"]
+}

--- a/apps/provisioner-ec2/tsconfig.dev.json
+++ b/apps/provisioner-ec2/tsconfig.dev.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "customConditions": ["development"]
+  }
+}

--- a/apps/provisioner-ec2/tsconfig.json
+++ b/apps/provisioner-ec2/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "references": [{ "path": "tsconfig.dev.json" }, { "path": "tsconfig.test.json" }]
+}

--- a/apps/provisioner-ec2/tsconfig.test.json
+++ b/apps/provisioner-ec2/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src"],
+  "exclude": []
+}

--- a/libs/provisioner/ec2/README.md
+++ b/libs/provisioner/ec2/README.md
@@ -1,0 +1,54 @@
+# @shipfox/provisioner-ec2-provider
+
+The EC2 provider scaffold for the Shipfox provisioner. It currently loads and validates
+EC2 template configuration for the provider-agnostic
+[`@shipfox/provisioner-core`](../core) control loop. The EC2 engine, lifecycle, and app
+wiring land in later issues.
+
+## Public API
+
+- `loadEc2Templates(filePath)` reads, parses, and validates EC2 template YAML.
+- `Ec2TemplateSpec` describes the EC2 launch details for a template.
+- `Ec2TemplateConfigError` identifies a missing, malformed, or invalid template file.
+
+## Template config
+
+The template file is YAML keyed by template name:
+
+```yaml
+templates:
+  ec2-ubuntu22-2vcpu-spot:
+    labels: [ubuntu22, ubuntu22-2vcpu]
+    ami: ami-0123456789abcdef0
+    instance_type: m6i.large
+    market: spot
+    spot_max_price: null
+    subnets: [subnet-aaa, subnet-bbb]
+    security_groups: [sg-runner]
+    iam_instance_profile: shipfox-runner
+    associate_public_ip: false
+    root_volume_gb: 100
+    max_concurrency: 200
+    cost: 5
+```
+
+Loading fails fast with a clear, file-scoped error on a missing file, malformed YAML, an
+invalid or unknown field, an unusable label, or an empty template set. Labels are
+canonicalized with the shared runner-label rules.
+
+`iam_instance_profile` is the IAM instance-profile name, not its ARN. For Spot templates,
+`spot_max_price: null` caps the request at the on-demand price and is the recommended
+default. Set `cost` to an explicit unitless ranking where lower values win template
+selection. Give a Spot template a lower cost than its on-demand equivalent so the planner
+prefers Spot before spilling to on-demand capacity.
+
+## Runtime configuration
+
+The provider reads the shared provisioner variables plus these EC2-specific variables:
+
+| Variable | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `SHIPFOX_PROVISIONER_TEMPLATES_FILE` | yes | - | YAML template file with EC2 launch and capacity configuration. |
+| `AWS_REGION` | yes | - | AWS region where runner instances launch. |
+| `SHIPFOX_PROVISIONER_EC2_REGISTRATION_DEADLINE_MS` | no | `300000` | Maximum time a launched instance may wait for runner registration. |
+| `SHIPFOX_PROVISIONER_EC2_RECONCILE_INTERVAL_MS` | no | `60000` | Interval for a full backend reconcile using EC2 instance tags. |

--- a/libs/provisioner/ec2/package.json
+++ b/libs/provisioner/ec2/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@shipfox/provisioner-ec2-provider",
+  "license": "MIT",
+  "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
+    "directory": "libs/provisioner/ec2"
+  },
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "imports": {
+    "#test/*": "./test/*",
+    "#*": "./src/*"
+  },
+  "exports": {
+    ".": {
+      "development": {
+        "types": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "test": "shipfox-vitest-run",
+    "test:watch": "shipfox-vitest-watch",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "@shipfox/config": "workspace:*",
+    "@shipfox/provisioner-core": "workspace:*",
+    "@shipfox/runner-labels": "workspace:*",
+    "js-yaml": "catalog:",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*",
+    "@types/js-yaml": "catalog:"
+  }
+}

--- a/libs/provisioner/ec2/src/config.test.ts
+++ b/libs/provisioner/ec2/src/config.test.ts
@@ -1,0 +1,15 @@
+import {requirePositiveInteger} from '#config.js';
+
+describe('requirePositiveInteger', () => {
+  it('returns a positive integer', () => {
+    const value = requirePositiveInteger('VALUE', 1);
+
+    expect(value).toBe(1);
+  });
+
+  it.each([0, -1, 1.5])('rejects %d', (value) => {
+    expect(() => requirePositiveInteger('VALUE', value)).toThrow(
+      `VALUE must be a positive integer; got ${value}.`,
+    );
+  });
+});

--- a/libs/provisioner/ec2/src/config.ts
+++ b/libs/provisioner/ec2/src/config.ts
@@ -1,0 +1,34 @@
+import {createConfig, num, str} from '@shipfox/config';
+
+export function requirePositiveInteger(name: string, value: number): number {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer; got ${value}.`);
+  }
+  return value;
+}
+
+export const config = createConfig({
+  SHIPFOX_PROVISIONER_TEMPLATES_FILE: str({
+    desc: 'Path to the YAML file describing the EC2 runner templates this provisioner can start. Required. Each template lists its labels, AMI, instance type, market, networking, and max_concurrency.',
+  }),
+  AWS_REGION: str({
+    desc: 'AWS region the runner instances launch in, such as us-east-1. Required. Read by the AWS SDK and by the provider.',
+  }),
+  SHIPFOX_PROVISIONER_EC2_REGISTRATION_DEADLINE_MS: num({
+    desc: 'How long a launched instance may run without a runner registering before the provisioner terminates it as stale, in milliseconds.',
+    default: 300_000,
+  }),
+  SHIPFOX_PROVISIONER_EC2_RECONCILE_INTERVAL_MS: num({
+    desc: 'How often the provisioner runs a full reconcile against the backend, re-deriving truth from EC2 instance tags, in milliseconds.',
+    default: 60_000,
+  }),
+});
+
+requirePositiveInteger(
+  'SHIPFOX_PROVISIONER_EC2_REGISTRATION_DEADLINE_MS',
+  config.SHIPFOX_PROVISIONER_EC2_REGISTRATION_DEADLINE_MS,
+);
+requirePositiveInteger(
+  'SHIPFOX_PROVISIONER_EC2_RECONCILE_INTERVAL_MS',
+  config.SHIPFOX_PROVISIONER_EC2_RECONCILE_INTERVAL_MS,
+);

--- a/libs/provisioner/ec2/src/index.ts
+++ b/libs/provisioner/ec2/src/index.ts
@@ -1,0 +1,6 @@
+export {
+  type Ec2Market,
+  Ec2TemplateConfigError,
+  type Ec2TemplateSpec,
+  loadEc2Templates,
+} from '#templates.js';

--- a/libs/provisioner/ec2/src/templates.test.ts
+++ b/libs/provisioner/ec2/src/templates.test.ts
@@ -1,0 +1,218 @@
+import {randomUUID} from 'node:crypto';
+import {mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {MAX_RUNNER_LABELS} from '@shipfox/runner-labels';
+import {Ec2TemplateConfigError, loadEc2Templates} from '#templates.js';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'provisioner-ec2-'));
+});
+
+afterEach(() => {
+  rmSync(dir, {recursive: true, force: true});
+});
+
+function writeTemplates(contents: string): string {
+  const path = join(dir, `${randomUUID()}.yaml`);
+  writeFileSync(path, contents);
+  return path;
+}
+
+function template(overrides: Record<string, string> = {}, extra = ''): string {
+  const defaults = `
+templates:
+  t:
+    labels: [ubuntu22]
+    ami: ami-0123456789abcdef0
+    instance_type: m6i.large
+    market: spot
+    spot_max_price: 0.05
+    subnets: [subnet-aaa]
+    security_groups: [sg-runner]
+    associate_public_ip: false
+    root_volume_gb: 100
+    max_concurrency: 100
+    cost: 5
+`;
+
+  return (
+    Object.entries(overrides).reduce(
+      (contents, [field, value]) =>
+        contents.replace(new RegExp(`^(\\s*${field}: ).*$`, 'm'), `$1${value}`),
+      defaults,
+    ) + extra
+  );
+}
+
+const VALID = `
+templates:
+  ec2-ubuntu22-2vcpu-spot:
+    labels: [ubuntu22, ubuntu22-2vcpu]
+    ami: ami-0123456789abcdef0
+    instance_type: m6i.large
+    market: spot
+    spot_max_price: 0.05
+    subnets: [subnet-aaa, subnet-bbb]
+    security_groups: [sg-runner]
+    iam_instance_profile: shipfox-runner
+    associate_public_ip: false
+    root_volume_gb: 100
+    max_concurrency: 200
+    cost: 5
+  ec2-ubuntu22-2vcpu-on-demand:
+    labels: [ubuntu22, ubuntu22-2vcpu-on-demand]
+    ami: ami-0123456789abcdef1
+    instance_type: m6i.large
+    market: on-demand
+    subnets: [subnet-ccc]
+    security_groups: [sg-runner]
+    associate_public_ip: true
+    root_volume_gb: 120
+    max_concurrency: 50
+    cost: 10
+`;
+
+describe('loadEc2Templates', () => {
+  it('maps each config entry to a provider-agnostic template', () => {
+    const path = writeTemplates(VALID);
+
+    const templates = loadEc2Templates(path);
+
+    expect(templates).toEqual([
+      {
+        key: 'ec2-ubuntu22-2vcpu-spot',
+        labels: ['ubuntu22', 'ubuntu22-2vcpu'],
+        maxConcurrency: 200,
+        cost: 5,
+        spec: {
+          ami: 'ami-0123456789abcdef0',
+          instanceType: 'm6i.large',
+          market: 'spot',
+          spotMaxPrice: 0.05,
+          subnets: ['subnet-aaa', 'subnet-bbb'],
+          securityGroups: ['sg-runner'],
+          iamInstanceProfile: 'shipfox-runner',
+          associatePublicIp: false,
+          rootVolumeGb: 100,
+        },
+      },
+      {
+        key: 'ec2-ubuntu22-2vcpu-on-demand',
+        labels: ['ubuntu22', 'ubuntu22-2vcpu-on-demand'],
+        maxConcurrency: 50,
+        cost: 10,
+        spec: {
+          ami: 'ami-0123456789abcdef1',
+          instanceType: 'm6i.large',
+          market: 'on-demand',
+          spotMaxPrice: null,
+          subnets: ['subnet-ccc'],
+          securityGroups: ['sg-runner'],
+          associatePublicIp: true,
+          rootVolumeGb: 120,
+        },
+      },
+    ]);
+  });
+
+  it('accepts a null spot price', () => {
+    const path = writeTemplates(template({spot_max_price: 'null'}));
+
+    const [loaded] = loadEc2Templates(path);
+
+    expect(loaded?.spec.spotMaxPrice).toBeNull();
+  });
+
+  it('canonicalizes labels (lowercase, dedupe, sort)', () => {
+    const path = writeTemplates(template({labels: '[Ubuntu22, ubuntu22, ubuntu22-4cpu]'}));
+
+    const [loaded] = loadEc2Templates(path);
+
+    expect(loaded?.labels).toEqual(['ubuntu22', 'ubuntu22-4cpu']);
+  });
+
+  it('throws when the file is missing', () => {
+    expect(() => loadEc2Templates(join(dir, 'missing.yaml'))).toThrow(Ec2TemplateConfigError);
+  });
+
+  it('throws on malformed YAML', () => {
+    const path = writeTemplates('templates: [unclosed');
+
+    expect(() => loadEc2Templates(path)).toThrow(Ec2TemplateConfigError);
+  });
+
+  it('throws when no templates are declared', () => {
+    const path = writeTemplates('templates: {}');
+
+    expect(() => loadEc2Templates(path)).toThrow('declares no templates');
+  });
+
+  it.each([
+    ['ami', {ami: 'ami-invalid'}],
+    ['instance_type', {instance_type: '"   "'}],
+    ['market', {market: 'reserved'}],
+    ['spot_max_price', {spot_max_price: '0'}],
+    ['subnets', {subnets: '[]'}],
+    ['security_groups', {security_groups: '[]'}],
+    ['associate_public_ip', {associate_public_ip: '"false"'}],
+    ['root_volume_gb', {root_volume_gb: '-1'}],
+    ['max_concurrency', {max_concurrency: '0'}],
+    ['cost', {cost: '0'}],
+  ])('throws when %s is invalid', (field, override) => {
+    const path = writeTemplates(template(override));
+
+    expect(() => loadEc2Templates(path)).toThrow(field);
+  });
+
+  it('throws when iam_instance_profile is blank', () => {
+    const path = writeTemplates(template({}, '    iam_instance_profile: "   "\n'));
+
+    expect(() => loadEc2Templates(path)).toThrow('iam_instance_profile');
+  });
+
+  it('throws when max_concurrency exceeds the limit', () => {
+    const path = writeTemplates(template({max_concurrency: '100001'}));
+
+    expect(() => loadEc2Templates(path)).toThrow('max_concurrency');
+  });
+
+  it('throws on a label that cannot be a runner label', () => {
+    const path = writeTemplates(template({labels: '["not a valid label"]'}));
+
+    expect(() => loadEc2Templates(path)).toThrow('invalid labels');
+  });
+
+  it('throws when labels are empty after normalization', () => {
+    const path = writeTemplates(template({labels: '["  "]'}));
+
+    expect(() => loadEc2Templates(path)).toThrow('no usable labels');
+  });
+
+  it('throws when there are more labels than allowed', () => {
+    const labels = Array.from({length: MAX_RUNNER_LABELS + 1}, (_, index) => `label-${index}`);
+    const path = writeTemplates(template({labels: `[${labels.join(', ')}]`}));
+
+    expect(() => loadEc2Templates(path)).toThrow(`the maximum is ${MAX_RUNNER_LABELS}`);
+  });
+
+  it('throws when on-demand includes a spot price', () => {
+    const path = writeTemplates(template({market: 'on-demand'}));
+
+    expect(() => loadEc2Templates(path)).toThrow('spot_max_price');
+  });
+
+  it('throws on an unknown template key', () => {
+    const path = writeTemplates(template({}, '    spot_maxprice: 0.05\n'));
+
+    expect(() => loadEc2Templates(path)).toThrow('spot_maxprice');
+  });
+
+  it('throws on an unknown file key', () => {
+    const path = writeTemplates(`${VALID}\nunknown: true`);
+
+    expect(() => loadEc2Templates(path)).toThrow('unknown');
+  });
+});

--- a/libs/provisioner/ec2/src/templates.ts
+++ b/libs/provisioner/ec2/src/templates.ts
@@ -1,0 +1,165 @@
+import {readFileSync} from 'node:fs';
+import type {ProvisionerTemplate} from '@shipfox/provisioner-core';
+import {canonicalizeLabels, findInvalidLabels, MAX_RUNNER_LABELS} from '@shipfox/runner-labels';
+import yaml from 'js-yaml';
+import {z} from 'zod';
+
+export type Ec2Market = 'spot' | 'on-demand';
+
+/** EC2-specific launch details the launcher needs to run one runner instance. */
+export interface Ec2TemplateSpec {
+  readonly ami: string;
+  readonly instanceType: string;
+  readonly market: Ec2Market;
+  readonly spotMaxPrice: number | null;
+  readonly subnets: readonly string[];
+  readonly securityGroups: readonly string[];
+  readonly iamInstanceProfile?: string;
+  readonly associatePublicIp: boolean;
+  readonly rootVolumeGb: number;
+}
+
+/** Raised when the template config file is missing, unparseable, or invalid. */
+export class Ec2TemplateConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'Ec2TemplateConfigError';
+  }
+}
+
+const MAX_TEMPLATE_CONCURRENCY = 100_000;
+
+const ec2TemplateSchema = z
+  .object({
+    labels: z.array(z.string()).min(1),
+    ami: z
+      .string()
+      .trim()
+      .regex(/^ami-[0-9a-f]+$/, 'must be an AMI id like "ami-0123456789abcdef0"'),
+    instance_type: z.string().trim().min(1),
+    market: z.enum(['spot', 'on-demand']),
+    spot_max_price: z.number().positive().nullish(),
+    subnets: z.array(z.string().trim().min(1)).min(1),
+    security_groups: z.array(z.string().trim().min(1)).min(1),
+    iam_instance_profile: z.string().trim().min(1).optional(),
+    associate_public_ip: z.boolean(),
+    root_volume_gb: z.number().int().positive(),
+    max_concurrency: z.number().int().positive().max(MAX_TEMPLATE_CONCURRENCY),
+    cost: z.number().positive(),
+  })
+  .strict()
+  .superRefine((spec, ctx) => {
+    if (spec.market === 'on-demand' && spec.spot_max_price != null) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['spot_max_price'],
+        message: 'spot_max_price is only valid when market is "spot".',
+      });
+    }
+  });
+
+const ec2TemplatesFileSchema = z
+  .object({
+    templates: z.record(z.string().min(1), ec2TemplateSchema),
+  })
+  .strict();
+
+/**
+ * Read, parse, and validate the local EC2 template config, returning the
+ * provider-agnostic templates the control loop drives. Fails fast with a clear,
+ * file-scoped error on any problem: missing file, malformed YAML, a field that does
+ * not validate, an invalid label, or an empty template set.
+ */
+export function loadEc2Templates(filePath: string): ProvisionerTemplate<Ec2TemplateSpec>[] {
+  const parsed = ec2TemplatesFileSchema.safeParse(parseYamlFile(filePath));
+  if (!parsed.success) {
+    throw new Ec2TemplateConfigError(
+      `Invalid EC2 template config at ${filePath}: ${formatIssues(parsed.error)}`,
+    );
+  }
+
+  const entries = Object.entries(parsed.data.templates);
+  if (entries.length === 0) {
+    throw new Ec2TemplateConfigError(
+      `EC2 template config at ${filePath} declares no templates; add at least one.`,
+    );
+  }
+
+  return entries.map(([key, spec]) => toTemplate(filePath, key, spec));
+}
+
+function toTemplate(
+  filePath: string,
+  key: string,
+  spec: z.infer<typeof ec2TemplateSchema>,
+): ProvisionerTemplate<Ec2TemplateSpec> {
+  const labels = canonicalizeLabels(spec.labels);
+  if (labels.length === 0) {
+    throw new Ec2TemplateConfigError(
+      `Template "${key}" in ${filePath} has no usable labels after normalization.`,
+    );
+  }
+  if (labels.length > MAX_RUNNER_LABELS) {
+    throw new Ec2TemplateConfigError(
+      `Template "${key}" in ${filePath} has ${labels.length} labels; the maximum is ${MAX_RUNNER_LABELS}.`,
+    );
+  }
+  const invalid = findInvalidLabels(labels);
+  if (invalid.length > 0) {
+    throw new Ec2TemplateConfigError(
+      `Template "${key}" in ${filePath} has invalid labels: ${invalid.join(', ')}.`,
+    );
+  }
+
+  return {
+    key,
+    labels,
+    maxConcurrency: spec.max_concurrency,
+    cost: spec.cost,
+    spec: {
+      ami: spec.ami,
+      instanceType: spec.instance_type,
+      market: spec.market,
+      spotMaxPrice: spec.spot_max_price ?? null,
+      subnets: spec.subnets,
+      securityGroups: spec.security_groups,
+      ...(spec.iam_instance_profile === undefined
+        ? {}
+        : {iamInstanceProfile: spec.iam_instance_profile}),
+      associatePublicIp: spec.associate_public_ip,
+      rootVolumeGb: spec.root_volume_gb,
+    },
+  };
+}
+
+function parseYamlFile(filePath: string): unknown {
+  let contents: string;
+  try {
+    contents = readFileSync(filePath, 'utf8');
+  } catch (error) {
+    throw new Ec2TemplateConfigError(
+      `Cannot read EC2 template config at ${filePath}: ${errorMessage(error)}`,
+    );
+  }
+
+  try {
+    return yaml.load(contents);
+  } catch (error) {
+    throw new Ec2TemplateConfigError(
+      `Cannot parse EC2 template config at ${filePath}: ${errorMessage(error)}`,
+    );
+  }
+}
+
+function formatIssues(error: z.ZodError): string {
+  return error.issues
+    .map((issue) => {
+      const path = issue.path.join('.');
+      return path ? `${path}: ${issue.message}` : issue.message;
+    })
+    .join('; ');
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/libs/provisioner/ec2/test/env.ts
+++ b/libs/provisioner/ec2/test/env.ts
@@ -1,0 +1,4 @@
+process.env.SHIPFOX_API_URL = 'https://api.test';
+process.env.SHIPFOX_PROVISIONER_TOKEN = 'test-provisioner-token';
+process.env.SHIPFOX_PROVISIONER_TEMPLATES_FILE = '/dev/null/templates.yaml';
+process.env.AWS_REGION = 'us-east-1';

--- a/libs/provisioner/ec2/tsconfig.build.json
+++ b/libs/provisioner/ec2/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.tsx", "**/*.test.ts"]
+}

--- a/libs/provisioner/ec2/tsconfig.json
+++ b/libs/provisioner/ec2/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.test.json" }]
+}

--- a/libs/provisioner/ec2/tsconfig.test.json
+++ b/libs/provisioner/ec2/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "exclude": []
+}

--- a/libs/provisioner/ec2/vitest.config.ts
+++ b/libs/provisioner/ec2/vitest.config.ts
@@ -1,0 +1,10 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig(
+  {
+    test: {
+      setupFiles: ['test/env.ts'],
+    },
+  },
+  import.meta.url,
+) as UserConfigExport;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -748,6 +748,31 @@ importers:
         specifier: 'catalog:'
         version: 4.22.4
 
+  apps/provisioner-ec2:
+    dependencies:
+      '@shipfox/node-opentelemetry':
+        specifier: workspace:*
+        version: link:../../libs/shared/node/opentelemetry
+      '@shipfox/provisioner-ec2-provider':
+        specifier: workspace:*
+        version: link:../../libs/provisioner/ec2
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../tools/biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../tools/typescript
+      tsx:
+        specifier: 'catalog:'
+        version: 4.22.4
+
   apps/runner:
     dependencies:
       '@shipfox/node-opentelemetry':
@@ -5751,6 +5776,43 @@ importers:
       '@types/dockerode':
         specifier: 'catalog:'
         version: 4.0.1
+      '@types/js-yaml':
+        specifier: 'catalog:'
+        version: 4.0.9
+
+  libs/provisioner/ec2:
+    dependencies:
+      '@shipfox/config':
+        specifier: workspace:*
+        version: link:../../shared/common/config
+      '@shipfox/provisioner-core':
+        specifier: workspace:*
+        version: link:../core
+      '@shipfox/runner-labels':
+        specifier: workspace:*
+        version: link:../../shared/common/runner-labels
+      js-yaml:
+        specifier: 'catalog:'
+        version: 4.2.0
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../tools/vitest
       '@types/js-yaml':
         specifier: 'catalog:'
         version: 4.0.9

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,7 @@ catalog:
   "@argos-ci/cli": "^5.0.0"
   "@argos-ci/playwright": "^7.0.0"
   "@argos-ci/storybook": "^6.0.0"
+  "@aws-sdk/client-ec2": "^3.1068.0"
   "@aws-sdk/client-s3": "^3.1068.0"
   "@aws-sdk/lib-storage": "^3.1068.0"
   "@aws-sdk/s3-request-presigner": "^3.1068.0"


### PR DESCRIPTION
Adds the AWS-free foundation for the EC2 runner provisioner: strict template loading, EC2-specific configuration, package and app scaffolds, and a minor changeset.

Self-hosted operators need invalid EC2 template configuration to fail before the provisioner can make lifecycle decisions. The loader validates launch and capacity inputs, canonicalizes runner labels, and rejects unknown YAML keys so later EC2 engine work has a reliable configuration contract.

The engine, lifecycle, user-data rendering, and runnable app wiring intentionally remain in their follow-up issues. The AWS SDK catalog entry is included now but has no package consumer until the engine issue.

Closes ENG-1007

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the EC2 provider scaffold with a strict YAML template loader and EC2-specific config, so invalid templates fail fast and future engine work has a reliable contract. Addresses ENG-1007 by validating launch/capacity inputs and canonicalizing runner labels.

- **New Features**
  - `@shipfox/provisioner-ec2-provider`: loads and validates EC2 template YAML; rejects unknown keys; canonicalizes labels; returns provider-agnostic templates for `@shipfox/provisioner-core`.
  - EC2 runtime config: required `SHIPFOX_PROVISIONER_TEMPLATES_FILE`, `AWS_REGION`; positive-integer guards for registration and reconcile timers.
  - App scaffold `@shipfox/provisioner-ec2`: not yet wired; logs and exits.

- **Dependencies**
  - Added `@aws-sdk/client-ec2` to the workspace catalog (no consumer yet).
  - Uses `js-yaml` and `zod` for parsing and validation.

<sup>Written for commit 491ca5466cb6acdcd05ddfad9bee79ec3a7d36c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

