### PR TITLE
[runner-image] Add self-terminating runner images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,30 @@ jobs:
       - name: Verify packed API runtime closure
         run: pnpm --filter=@shipfox/application-release test:external
 
+  validate-runner-image:
+    name: Validate runner image
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Set up mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
+
+      - name: Validate Packer configuration
+        run: |
+          mkdir -p /tmp/shipfox-runner-workspace
+          packer init infra/images/runner
+          packer fmt -check infra/images/runner
+          packer validate \
+            -var build_number=ci \
+            -var node_version=24.17.0 \
+            -var platform=aws \
+            -var runner_workspace=/tmp/shipfox-runner-workspace \
+            infra/images/runner
+
   tests:
     name: Unit and story tests
     runs-on: ubuntu-latest

--- a/infra/images/runner/README.md
+++ b/infra/images/runner/README.md
@@ -1,0 +1,34 @@
+# Shipfox runner image
+
+`@shipfox/runner-image` builds the VM image used by ephemeral Shipfox platform runners. It produces an AWS AMI with Packer's `amazon-ebs` builder and a raw QEMU image from the same provisioning definition. It does not replace `apps/runner/Dockerfile`.
+
+## Build
+
+Builds run the production deploy inside the target VM. This is required because the runner contains architecture-specific native payloads. The wrapper obtains the Node version from `mise`, prunes `@shipfox/runner`, and then invokes Packer.
+
+```sh
+BUILD_NUMBER=42 BUILD_ARCH=amd64 pnpm --filter=@shipfox/runner-image image:build
+BUILD_NUMBER=42 BUILD_ARCH=amd64 SHIPFOX_QEMU_SOURCE_IMAGE=/images/ubuntu24.raw \
+  pnpm --filter=@shipfox/runner-image exec build-runner-image ubuntu24 qemu
+```
+
+The AMI source uses Canonical Ubuntu 24.04 and requires AWS credentials in `us-east-1`. QEMU needs a bootable Ubuntu raw image supplied through `SHIPFOX_QEMU_SOURCE_IMAGE`.
+
+## Environment contract
+
+Cloud-init writes `/etc/shipfox/runner.env`. The provider owns the values and must never bake them into the image:
+
+- `SHIPFOX_API_URL`: API base URL.
+- `SHIPFOX_RUNNER_REGISTRATION_TOKEN`: single-use runner registration token.
+- `SHIPFOX_RUNNER_LABELS`: comma-separated runner labels.
+- `SHIPFOX_POLL_MAX_DURATION_MS`: runner polling deadline. `0` means forever.
+- `SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS`: hard instance lifetime. Use a value comfortably above one job's maximum duration.
+- `AGENT_CUSTOM_PROVIDER_ALLOW_PRIVATE_NETWORKS=false`: required for cloud runners.
+
+`shipfox-runner.service` powers off immediately when the runner exits. Its SIGTERM drain budget is 90 seconds, after which systemd can force-kill the process and the backend re-reserves the job. `shipfox-max-lifetime.service` schedules a forced poweroff and falls back to a baked 3600-second limit when the configured value is missing or malformed. AWS builds also enable a Spot IMDSv2 watcher that stops the runner, allows it to drain briefly, then powers off.
+
+With `InstanceInitiatedShutdownBehavior=terminate` and Spot `InstanceInterruptionBehavior=terminate`, provider-side settings convert these poweroffs into EC2 termination. The in-guest watchdog is the fast path. The durable backstop remains tagged-instance reconciliation, the backend staleness reaper, and terminate-on-shutdown because privileged job steps or a wedged kernel can defeat an in-guest timer.
+
+## Recovery drill
+
+On EC2, launch a runner with a short max lifetime, stop the provisioner, and verify the instance terminates before that bound. For Spot, request an interruption notice in a test environment and verify the runner stops claiming work, drains, and powers off before reclaim. These drills feed the EC2 provisioner deployment runbook.

--- a/infra/images/runner/README.md
+++ b/infra/images/runner/README.md
@@ -8,11 +8,12 @@ Builds run the production deploy inside the target VM. This is required because 
 
 ```sh
 BUILD_NUMBER=42 BUILD_ARCH=amd64 pnpm --filter=@shipfox/runner-image image:build
-BUILD_NUMBER=42 BUILD_ARCH=amd64 SHIPFOX_QEMU_SOURCE_IMAGE=/images/ubuntu24.raw \
-  pnpm --filter=@shipfox/runner-image exec build-runner-image ubuntu24 qemu
+BUILD_NUMBER=42 BUILD_ARCH=amd64 pnpm --filter=@shipfox/runner-image exec build-runner-image ubuntu24 qemu
 ```
 
-The AMI source uses Canonical Ubuntu 24.04 and requires AWS credentials in `us-east-1`. QEMU needs a bootable Ubuntu raw image supplied through `SHIPFOX_QEMU_SOURCE_IMAGE`.
+The AMI source uses Canonical Ubuntu 24.04 and requires AWS credentials in `us-east-1`. The QEMU build defaults to a pinned Canonical Ubuntu 24.04 release image and configures its temporary Packer SSH access through a NoCloud seed; the final image locks that bootstrap account. To use a different QEMU source, set both `SHIPFOX_QEMU_SOURCE_IMAGE` and `SHIPFOX_QEMU_SOURCE_CHECKSUM` (for example, `sha256:<digest>`). Relative source paths resolve from the repository root.
+
+Packer is pinned in `mise.toml`. Install QEMU and `xorriso` through the host operating system before running a QEMU build.
 
 ## Environment contract
 

--- a/infra/images/runner/assets/qemu/cloud-init/meta-data
+++ b/infra/images/runner/assets/qemu/cloud-init/meta-data
@@ -1,0 +1,2 @@
+instance-id: shipfox-runner-image-builder
+local-hostname: shipfox-runner-image-builder

--- a/infra/images/runner/assets/qemu/cloud-init/user-data
+++ b/infra/images/runner/assets/qemu/cloud-init/user-data
@@ -1,0 +1,6 @@
+#cloud-config
+chpasswd:
+  expire: false
+  list: |
+    ubuntu:packer
+ssh_pwauth: true

--- a/infra/images/runner/assets/shipfox-max-lifetime.service
+++ b/infra/images/runner/assets/shipfox-max-lifetime.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Shipfox runner hard maximum lifetime watchdog
+After=cloud-final.service shipfox-runner-env.service
+Wants=cloud-final.service
+Requires=shipfox-runner-env.service
+
+[Service]
+Type=oneshot
+ExecStart=/opt/shipfox-runner/scripts/runtime/start-max-lifetime.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/images/runner/assets/shipfox-runner-env.service
+++ b/infra/images/runner/assets/shipfox-runner-env.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Validate Shipfox runner environment file
+After=cloud-final.service
+Wants=cloud-final.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/test -s /etc/shipfox/runner.env
+RemainAfterExit=yes

--- a/infra/images/runner/assets/shipfox-runner.service
+++ b/infra/images/runner/assets/shipfox-runner.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=Shipfox platform runner
+After=cloud-final.service shipfox-runner-env.service
+Wants=cloud-final.service
+Requires=shipfox-runner-env.service
+SuccessAction=poweroff-immediate
+FailureAction=poweroff-immediate
+
+[Service]
+User=shipfox
+EnvironmentFile=-/etc/environment
+EnvironmentFile=/etc/shipfox/runner.env
+Environment=AGENT_CUSTOM_PROVIDER_ALLOW_PRIVATE_NETWORKS=false
+WorkingDirectory=/opt/runner
+ExecStart=/usr/local/bin/node --enable-source-maps dist/index.js
+Restart=no
+KillSignal=SIGTERM
+KillMode=control-group
+TimeoutStopSec=90s
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=shipfox-runner
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/images/runner/assets/shipfox-spot-watchdog.service
+++ b/infra/images/runner/assets/shipfox-spot-watchdog.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Shipfox runner Spot interruption watchdog
+After=network-online.target shipfox-runner.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/opt/shipfox-runner/scripts/runtime/spot-watchdog.sh
+Restart=always
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/images/runner/bin/build-runner-image.js
+++ b/infra/images/runner/bin/build-runner-image.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+import '../dist/build-runner-image.js';

--- a/infra/images/runner/build.pkr.hcl
+++ b/infra/images/runner/build.pkr.hcl
@@ -1,0 +1,64 @@
+build {
+  name    = "runner"
+  sources = ["amazon-ebs.build_image", "qemu.build_image"]
+
+  provisioner "file" {
+    destination = "/tmp/shipfox-runner-workspace"
+    source      = var.runner_workspace
+  }
+
+  provisioner "file" {
+    destination = "/tmp/shipfox-runner-image-scripts"
+    source      = abspath("${path.root}/scripts")
+  }
+
+  provisioner "shell" {
+    environment_vars = ["NODE_VERSION=${var.node_version}"]
+    execute_command  = "sudo -E sh -c '{{ .Vars }} {{ .Path }}'"
+    scripts = [
+      "${path.root}/scripts/build/setup-runner.sh",
+      "${path.root}/scripts/build/install-node.sh",
+      "${path.root}/scripts/build/install-runner.sh"
+    ]
+  }
+
+  provisioner "file" {
+    destination = "/tmp/shipfox-runner-assets"
+    source      = abspath("${path.root}/assets")
+  }
+
+  provisioner "shell" {
+    inline = [
+      "sudo install -d -m 0755 /etc/shipfox /opt/shipfox-runner/scripts/runtime/helpers",
+      "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner.service /etc/systemd/system/shipfox-runner.service",
+      "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-runner-env.service /etc/systemd/system/shipfox-runner-env.service",
+      "sudo install -m 0644 /tmp/shipfox-runner-assets/shipfox-max-lifetime.service /etc/systemd/system/shipfox-max-lifetime.service",
+      "sudo install -m 0755 /tmp/shipfox-runner-image-scripts/runtime/start-max-lifetime.sh /opt/shipfox-runner/scripts/runtime/start-max-lifetime.sh",
+      "sudo install -m 0755 /tmp/shipfox-runner-image-scripts/runtime/helpers/logger.sh /opt/shipfox-runner/scripts/runtime/helpers/logger.sh",
+      "sudo systemctl daemon-reload",
+      "sudo systemctl enable shipfox-runner.service shipfox-max-lifetime.service"
+    ]
+  }
+
+  provisioner "file" {
+    destination = "/tmp/shipfox-spot-watchdog.service"
+    source      = abspath("${path.root}/assets/shipfox-spot-watchdog.service")
+    only        = ["amazon-ebs.build_image"]
+  }
+
+  provisioner "file" {
+    destination = "/tmp/spot-watchdog.sh"
+    source      = abspath("${path.root}/scripts/runtime/spot-watchdog.sh")
+    only        = ["amazon-ebs.build_image"]
+  }
+
+  provisioner "shell" {
+    inline = [
+      "sudo install -m 0644 /tmp/shipfox-spot-watchdog.service /etc/systemd/system/shipfox-spot-watchdog.service",
+      "sudo install -m 0755 /tmp/spot-watchdog.sh /opt/shipfox-runner/scripts/runtime/spot-watchdog.sh",
+      "sudo systemctl daemon-reload",
+      "sudo systemctl enable shipfox-spot-watchdog.service"
+    ]
+    only = ["amazon-ebs.build_image"]
+  }
+}

--- a/infra/images/runner/build.pkr.hcl
+++ b/infra/images/runner/build.pkr.hcl
@@ -40,6 +40,10 @@ build {
     ]
   }
 
+  provisioner "shell" {
+    inline = ["sudo passwd --lock ubuntu"]
+  }
+
   provisioner "file" {
     destination = "/tmp/shipfox-spot-watchdog.service"
     source      = abspath("${path.root}/assets/shipfox-spot-watchdog.service")

--- a/infra/images/runner/locals.aws.pkr.hcl
+++ b/infra/images/runner/locals.aws.pkr.hcl
@@ -1,0 +1,3 @@
+locals {
+  aws_architecture = var.architecture == "amd64" ? "x86_64" : "arm64"
+}

--- a/infra/images/runner/locals.qemu.pkr.hcl
+++ b/infra/images/runner/locals.qemu.pkr.hcl
@@ -1,0 +1,3 @@
+locals {
+  qemu_binary = var.architecture == "amd64" ? "qemu-system-x86_64" : "qemu-system-aarch64"
+}

--- a/infra/images/runner/locals.qemu.pkr.hcl
+++ b/infra/images/runner/locals.qemu.pkr.hcl
@@ -1,3 +1,13 @@
 locals {
   qemu_binary = var.architecture == "amd64" ? "qemu-system-x86_64" : "qemu-system-aarch64"
+  qemu_source_image = coalesce(
+    var.qemu_source_image,
+    "https://cloud-images.ubuntu.com/releases/noble/release-20260705/ubuntu-24.04-server-cloudimg-${var.architecture}.img",
+  )
+  qemu_source_checksum = coalesce(
+    var.qemu_source_checksum,
+    var.architecture == "amd64"
+      ? "sha256:ffe6203da54deeb6db5d2a98a83f9ec8e55f149d3f7ba622e1abe5fa966ee3d6"
+      : "sha256:7ed8005503e0bf1c225371866faae56e6b7e0d5c12471961042ab1cc2a1ffb4b",
+  )
 }

--- a/infra/images/runner/locals.qemu.pkr.hcl
+++ b/infra/images/runner/locals.qemu.pkr.hcl
@@ -7,7 +7,7 @@ locals {
   qemu_source_checksum = coalesce(
     var.qemu_source_checksum,
     var.architecture == "amd64"
-      ? "sha256:ffe6203da54deeb6db5d2a98a83f9ec8e55f149d3f7ba622e1abe5fa966ee3d6"
-      : "sha256:7ed8005503e0bf1c225371866faae56e6b7e0d5c12471961042ab1cc2a1ffb4b",
+    ? "sha256:ffe6203da54deeb6db5d2a98a83f9ec8e55f149d3f7ba622e1abe5fa966ee3d6"
+    : "sha256:7ed8005503e0bf1c225371866faae56e6b7e0d5c12471961042ab1cc2a1ffb4b",
   )
 }

--- a/infra/images/runner/package.json
+++ b/infra/images/runner/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@shipfox/runner-image",
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "imports": {
+    "#*": "./src/*"
+  },
+  "bin": {
+    "build-runner-image": "./bin/build-runner-image.js"
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "image:build": "build-runner-image ubuntu24 aws",
+    "image:build:push": "build-runner-image ubuntu24 aws -var push_image=true",
+    "test": "shipfox-vitest-run",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "@shipfox/runner": "workspace:*"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/tool-utils": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*"
+  }
+}

--- a/infra/images/runner/package.json
+++ b/infra/images/runner/package.json
@@ -14,7 +14,6 @@
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
     "image:build": "build-runner-image ubuntu24 aws",
-    "image:build:push": "build-runner-image ubuntu24 aws -var push_image=true",
     "test": "shipfox-vitest-run",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"

--- a/infra/images/runner/requirements.pkr.hcl
+++ b/infra/images/runner/requirements.pkr.hcl
@@ -1,0 +1,16 @@
+packer {
+  required_plugins {
+    amazon = {
+      source  = "github.com/hashicorp/amazon"
+      version = "~> 1"
+    }
+    googlecompute = {
+      source  = "github.com/hashicorp/googlecompute"
+      version = "~> 1"
+    }
+    qemu = {
+      source  = "github.com/hashicorp/qemu"
+      version = "~> 1"
+    }
+  }
+}

--- a/infra/images/runner/requirements.pkr.hcl
+++ b/infra/images/runner/requirements.pkr.hcl
@@ -4,10 +4,6 @@ packer {
       source  = "github.com/hashicorp/amazon"
       version = "~> 1"
     }
-    googlecompute = {
-      source  = "github.com/hashicorp/googlecompute"
-      version = "~> 1"
-    }
     qemu = {
       source  = "github.com/hashicorp/qemu"
       version = "~> 1"

--- a/infra/images/runner/scripts/build/install-node.sh
+++ b/infra/images/runner/scripts/build/install-node.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+set -eu
+
+: "${NODE_VERSION:?NODE_VERSION is required}"
+architecture="$(dpkg --print-architecture)"
+case "$architecture" in
+  amd64) node_arch=x64 ;;
+  arm64) node_arch=arm64 ;;
+  *) echo "Unsupported architecture: $architecture" >&2; exit 1 ;;
+esac
+
+archive="node-v${NODE_VERSION}-linux-${node_arch}.tar.xz"
+curl --fail --location --retry 3 "https://nodejs.org/dist/v${NODE_VERSION}/${archive}" -o "/tmp/${archive}"
+tar --extract --xz --file "/tmp/${archive}" --strip-components=1 --directory /usr/local
+rm "/tmp/${archive}"
+corepack enable

--- a/infra/images/runner/scripts/build/install-runner.sh
+++ b/infra/images/runner/scripts/build/install-runner.sh
@@ -8,7 +8,7 @@ if [ -z "$lockfile" ]; then
   exit 1
 fi
 cd "$(dirname "$lockfile")"
-corepack prepare pnpm@11.6.0 --activate
+corepack prepare pnpm@11.7.0 --activate
 pnpm install --frozen-lockfile
 pnpm --filter=@shipfox/runner deploy --prod --legacy --config.strict-peer-dependencies=false /opt/runner
 chown -R shipfox:shipfox /opt/runner

--- a/infra/images/runner/scripts/build/install-runner.sh
+++ b/infra/images/runner/scripts/build/install-runner.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+set -eu
+
+workspace=/tmp/shipfox-runner-workspace
+lockfile="$(find "$workspace" -name pnpm-lock.yaml -print -quit)"
+if [ -z "$lockfile" ]; then
+  echo 'Pruned runner workspace has no pnpm lockfile.' >&2
+  exit 1
+fi
+cd "$(dirname "$lockfile")"
+corepack prepare pnpm@11.6.0 --activate
+pnpm install --frozen-lockfile
+pnpm --filter=@shipfox/runner deploy --prod --legacy --config.strict-peer-dependencies=false /opt/runner
+chown -R shipfox:shipfox /opt/runner

--- a/infra/images/runner/scripts/build/setup-runner.sh
+++ b/infra/images/runner/scripts/build/setup-runner.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+set -eu
+
+apt-get update
+apt-get install --yes --no-install-recommends \
+  ca-certificates curl wget git openssh-client tar gzip xz-utils bzip2 zip unzip jq \
+  build-essential python3 pkg-config ripgrep fd-find sudo
+rm -rf /var/lib/apt/lists/*
+
+ln -sf "$(command -v fdfind)" /usr/local/bin/fd
+groupadd --system shipfox || true
+id shipfox >/dev/null 2>&1 || useradd --system --gid shipfox --create-home --home-dir /home/shipfox shipfox
+printf '%s\n' 'shipfox ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/shipfox
+chmod 0440 /etc/sudoers.d/shipfox
+printf '%s\n' 'LANG=C.UTF-8' > /etc/default/locale
+install -d -o shipfox -g shipfox /opt/runner

--- a/infra/images/runner/scripts/runtime/helpers/logger.sh
+++ b/infra/images/runner/scripts/runtime/helpers/logger.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+log() {
+  logger --tag shipfox-runner -- "$*"
+}

--- a/infra/images/runner/scripts/runtime/spot-watchdog.sh
+++ b/infra/images/runner/scripts/runtime/spot-watchdog.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env sh
+set -eu
+
+spot_interruption_action() {
+  printf '%s' "$1" | jq -r '.action // empty' 2>/dev/null || true
+}
+
+imds_token() {
+  curl --silent --show-error --fail --connect-timeout 1 --max-time 2 \
+    -X PUT http://169.254.169.254/latest/api/token \
+    -H 'X-aws-ec2-metadata-token-ttl-seconds: 21600'
+}
+
+main() {
+  . /opt/shipfox-runner/scripts/runtime/helpers/logger.sh
+
+  while true; do
+    token="$(imds_token || true)"
+    if [ -n "$token" ]; then
+      notice="$(curl --silent --show-error --fail --connect-timeout 1 --max-time 2 \
+        -H "X-aws-ec2-metadata-token: $token" \
+        http://169.254.169.254/latest/meta-data/spot/instance-action || true)"
+      action="$(spot_interruption_action "$notice")"
+      case "$action" in
+        stop|terminate|hibernate)
+          log 'Spot interruption notice received; draining runner before shutdown'
+          systemctl stop shipfox-runner.service || true
+          sleep 15
+          systemctl poweroff --force
+          exit 0
+          ;;
+      esac
+    fi
+    sleep 5
+  done
+}
+
+if [ "${SHIPFOX_SPOT_WATCHDOG_LIBRARY:-}" != '1' ]; then
+  main
+fi

--- a/infra/images/runner/scripts/runtime/start-max-lifetime.sh
+++ b/infra/images/runner/scripts/runtime/start-max-lifetime.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+set -eu
+
+. /opt/shipfox-runner/scripts/runtime/helpers/logger.sh
+
+# This fail-closed image default is deliberately independent from provisioner-core's
+# configurable default: it still bounds a runner when user-data is absent or malformed.
+default_lifetime_seconds=3600
+lifetime_seconds="$default_lifetime_seconds"
+
+if [ -r /etc/shipfox/runner.env ]; then
+  configured_lifetime="$(sed -n 's/^SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS=//p' /etc/shipfox/runner.env | tail -n 1)"
+  case "$configured_lifetime" in
+    ''|*[!0-9]*) ;;
+    *)
+      if [ "$configured_lifetime" -gt 0 ]; then
+        lifetime_seconds="$configured_lifetime"
+      fi
+      ;;
+  esac
+fi
+
+log "Scheduling hard runner lifetime limit in ${lifetime_seconds}s"
+exec systemd-run --unit=shipfox-max-lifetime-poweroff --on-active="${lifetime_seconds}s" /usr/bin/systemctl poweroff --force

--- a/infra/images/runner/source.aws.pkr.hcl
+++ b/infra/images/runner/source.aws.pkr.hcl
@@ -1,0 +1,31 @@
+source "amazon-ebs" "build_image" {
+  ami_name                    = "shipfox-runner-${var.image_os}-${var.architecture}-${var.build_number}"
+  ami_virtualization_type     = "hvm"
+  ami_regions                 = var.push_image ? [] : null
+  associate_public_ip_address = true
+  encrypt_boot                = true
+  imds_support                = "v2.0"
+  instance_type               = "t3.large"
+  region                      = "us-east-1"
+  shutdown_behavior           = "terminate"
+  ssh_username                = "ubuntu"
+
+  source_ami_filter {
+    filters = {
+      architecture        = local.aws_architecture
+      name                = "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-${local.aws_architecture}-server-*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
+    most_recent = true
+    owners      = ["099720109477"]
+  }
+
+  tags = {
+    Name                   = "shipfox-runner-${var.image_os}-${var.architecture}-${var.build_number}"
+    "shipfox.build_number" = var.build_number
+    "shipfox.image_os"     = var.image_os
+    "shipfox.architecture" = var.architecture
+    "shipfox.runner"       = "@shipfox/runner"
+  }
+}

--- a/infra/images/runner/source.aws.pkr.hcl
+++ b/infra/images/runner/source.aws.pkr.hcl
@@ -1,11 +1,10 @@
 source "amazon-ebs" "build_image" {
   ami_name                    = "shipfox-runner-${var.image_os}-${var.architecture}-${var.build_number}"
   ami_virtualization_type     = "hvm"
-  ami_regions                 = var.push_image ? [] : null
   associate_public_ip_address = true
   encrypt_boot                = true
   imds_support                = "v2.0"
-  instance_type               = "t3.large"
+  instance_type               = var.architecture == "amd64" ? "t3.large" : "t4g.large"
   region                      = "us-east-1"
   shutdown_behavior           = "terminate"
   ssh_username                = "ubuntu"

--- a/infra/images/runner/source.qemu.pkr.hcl
+++ b/infra/images/runner/source.qemu.pkr.hcl
@@ -1,0 +1,17 @@
+source "qemu" "build_image" {
+  accelerator      = "kvm"
+  disk_image       = true
+  disk_size        = "${var.os_disk_size_gb}G"
+  format           = "raw"
+  headless         = var.qemu_headless
+  iso_checksum     = "none"
+  iso_url          = var.qemu_source_image
+  net_device       = "virtio-net"
+  output_directory = "output"
+  qemu_binary      = local.qemu_binary
+  shutdown_command = "echo 'packer' | sudo -S shutdown -P now"
+  ssh_password     = "packer"
+  ssh_timeout      = "5m"
+  ssh_username     = "ubuntu"
+  vm_name          = "machine.raw"
+}

--- a/infra/images/runner/source.qemu.pkr.hcl
+++ b/infra/images/runner/source.qemu.pkr.hcl
@@ -1,11 +1,13 @@
 source "qemu" "build_image" {
-  accelerator      = "kvm"
+  accelerator      = var.qemu_accelerator
+  cd_files         = ["${path.root}/assets/qemu/cloud-init/meta-data", "${path.root}/assets/qemu/cloud-init/user-data"]
+  cd_label         = "cidata"
   disk_image       = true
   disk_size        = "${var.os_disk_size_gb}G"
   format           = "raw"
   headless         = var.qemu_headless
-  iso_checksum     = "none"
-  iso_url          = var.qemu_source_image
+  iso_checksum     = local.qemu_source_checksum
+  iso_url          = local.qemu_source_image
   net_device       = "virtio-net"
   output_directory = "output"
   qemu_binary      = local.qemu_binary

--- a/infra/images/runner/src/aws.ts
+++ b/infra/images/runner/src/aws.ts
@@ -1,4 +1,4 @@
-const AMI_ID_PATTERN = /ami-[0-9a-f]+/gi;
+const AMI_ID_PATTERN = /ami-[0-9a-f]{17}\b/gi;
 
 export function findProducedAmiId(output: string): string | null {
   return [...output.matchAll(AMI_ID_PATTERN)].at(-1)?.[0] ?? null;

--- a/infra/images/runner/src/aws.ts
+++ b/infra/images/runner/src/aws.ts
@@ -1,0 +1,5 @@
+const AMI_ID_PATTERN = /ami-[0-9a-f]+/gi;
+
+export function findProducedAmiId(output: string): string | null {
+  return [...output.matchAll(AMI_ID_PATTERN)].at(-1)?.[0] ?? null;
+}

--- a/infra/images/runner/src/build-runner-image.ts
+++ b/infra/images/runner/src/build-runner-image.ts
@@ -1,7 +1,8 @@
+import {pathToFileURL} from 'node:url';
 import {log} from '@shipfox/tool-utils';
 import {buildRunnerImage, type RunnerImagePlatform, readMiseNodeVersion} from './runner-image.js';
 
-export function parseBuildRunnerImageArgs(args: string[], env = process.env) {
+export function parseBuildRunnerImageArgs(args: string[], env = process.env, nodeVersion?: string) {
   const [os, platform, ...extraPackerArgs] = args;
   if (!os || !platform)
     throw new Error('Usage: build-runner-image <os> <aws|qemu> [packer options]');
@@ -16,18 +17,24 @@ export function parseBuildRunnerImageArgs(args: string[], env = process.env) {
     platform: platform as RunnerImagePlatform,
     architecture: env.BUILD_ARCH as 'amd64' | 'arm64',
     buildNumber: env.BUILD_NUMBER,
-    nodeVersion: readMiseNodeVersion(),
+    nodeVersion: nodeVersion ?? readMiseNodeVersion(),
     extraPackerArgs,
   };
 }
 
-const build = parseBuildRunnerImageArgs(process.argv.slice(2));
-buildRunnerImage(build).then(
-  ({amiId}) => {
-    if (amiId) log.info(`Runner AMI build complete: ${amiId}`);
-  },
-  (error: unknown) => {
-    log.error(String(error));
-    process.exitCode = 1;
-  },
-);
+export function runBuildRunnerImageCli(args = process.argv.slice(2)): void {
+  const build = parseBuildRunnerImageArgs(args);
+  buildRunnerImage(build).then(
+    ({amiId}) => {
+      if (amiId) log.info(`Runner AMI build complete: ${amiId}`);
+    },
+    (error: unknown) => {
+      log.error(String(error));
+      process.exitCode = 1;
+    },
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runBuildRunnerImageCli();
+}

--- a/infra/images/runner/src/build-runner-image.ts
+++ b/infra/images/runner/src/build-runner-image.ts
@@ -1,0 +1,33 @@
+import {log} from '@shipfox/tool-utils';
+import {buildRunnerImage, type RunnerImagePlatform, readMiseNodeVersion} from './runner-image.js';
+
+export function parseBuildRunnerImageArgs(args: string[], env = process.env) {
+  const [os, platform, ...extraPackerArgs] = args;
+  if (!os || !platform)
+    throw new Error('Usage: build-runner-image <os> <aws|qemu> [packer options]');
+  if (!['aws', 'qemu'].includes(platform)) throw new Error('Platform must be aws or qemu.');
+  if (!env.BUILD_NUMBER) throw new Error('BUILD_NUMBER is not set.');
+  if (!env.BUILD_ARCH || !['amd64', 'arm64'].includes(env.BUILD_ARCH)) {
+    throw new Error('BUILD_ARCH must be amd64 or arm64.');
+  }
+
+  return {
+    os,
+    platform: platform as RunnerImagePlatform,
+    architecture: env.BUILD_ARCH as 'amd64' | 'arm64',
+    buildNumber: env.BUILD_NUMBER,
+    nodeVersion: readMiseNodeVersion(),
+    extraPackerArgs,
+  };
+}
+
+const build = parseBuildRunnerImageArgs(process.argv.slice(2));
+buildRunnerImage(build).then(
+  ({amiId}) => {
+    if (amiId) log.info(`Runner AMI build complete: ${amiId}`);
+  },
+  (error: unknown) => {
+    log.error(String(error));
+    process.exitCode = 1;
+  },
+);

--- a/infra/images/runner/src/qemu.ts
+++ b/infra/images/runner/src/qemu.ts
@@ -1,17 +1,15 @@
-import {existsSync} from 'node:fs';
 import {join} from 'node:path';
 
-export function qemuImagePath(rootDir: string): string {
-  const image = process.env.SHIPFOX_QEMU_SOURCE_IMAGE;
-  if (!image) {
-    throw new Error('SHIPFOX_QEMU_SOURCE_IMAGE is required for a QEMU image build.');
-  }
-  return image.startsWith('/') ? image : join(rootDir, image);
-}
+export function qemuSourceImageArgs(rootDir: string, env = process.env): string[] {
+  const image = env.SHIPFOX_QEMU_SOURCE_IMAGE;
+  if (!image) return [];
 
-export function qemuBootImagePath(rootDir: string): string {
-  const image = join(rootDir, 'output', 'machine.raw');
-  if (!existsSync(image))
-    throw new Error(`QEMU image not found at ${image}. Build the image first.`);
-  return image;
+  const checksum = env.SHIPFOX_QEMU_SOURCE_CHECKSUM;
+  if (!checksum) {
+    throw new Error(
+      'SHIPFOX_QEMU_SOURCE_CHECKSUM is required when SHIPFOX_QEMU_SOURCE_IMAGE is set.',
+    );
+  }
+  const source = image.startsWith('/') ? image : join(rootDir, image);
+  return ['-var', `qemu_source_image=${source}`, '-var', `qemu_source_checksum=${checksum}`];
 }

--- a/infra/images/runner/src/qemu.ts
+++ b/infra/images/runner/src/qemu.ts
@@ -1,0 +1,17 @@
+import {existsSync} from 'node:fs';
+import {join} from 'node:path';
+
+export function qemuImagePath(rootDir: string): string {
+  const image = process.env.SHIPFOX_QEMU_SOURCE_IMAGE;
+  if (!image) {
+    throw new Error('SHIPFOX_QEMU_SOURCE_IMAGE is required for a QEMU image build.');
+  }
+  return image.startsWith('/') ? image : join(rootDir, image);
+}
+
+export function qemuBootImagePath(rootDir: string): string {
+  const image = join(rootDir, 'output', 'machine.raw');
+  if (!existsSync(image))
+    throw new Error(`QEMU image not found at ${image}. Build the image first.`);
+  return image;
+}

--- a/infra/images/runner/src/runner-image.ts
+++ b/infra/images/runner/src/runner-image.ts
@@ -1,0 +1,76 @@
+import {execFileSync} from 'node:child_process';
+import {mkdtemp, rm} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {getProjectRootPath} from '@shipfox/tool-utils';
+import {findProducedAmiId} from './aws.js';
+import {qemuImagePath} from './qemu.js';
+
+const WHITESPACE_PATTERN = /\s+/;
+
+export type RunnerImagePlatform = 'aws' | 'qemu';
+
+export interface RunnerImageBuild {
+  os: string;
+  platform: RunnerImagePlatform;
+  architecture: 'amd64' | 'arm64';
+  buildNumber: string;
+  nodeVersion: string;
+  extraPackerArgs: string[];
+}
+
+export function readMiseNodeVersion(
+  run: (command: string, args: string[]) => string = (command, args) =>
+    execFileSync(command, args, {encoding: 'utf8'}),
+): string {
+  return run('mise', ['current', 'node']).trim().split(WHITESPACE_PATTERN)[0] ?? '';
+}
+
+export function packerBuildArgs(
+  build: RunnerImageBuild,
+  workspacePath: string,
+  rootDir = process.cwd(),
+): string[] {
+  const source = build.platform === 'aws' ? 'amazon-ebs' : 'qemu';
+  const args = [
+    'build',
+    '-only',
+    `runner.${source}.build_image`,
+    '-var',
+    `image_os=${build.os}`,
+    '-var',
+    `architecture=${build.architecture}`,
+    '-var',
+    `build_number=${build.buildNumber}`,
+    '-var',
+    `node_version=${build.nodeVersion}`,
+    '-var',
+    `platform=${build.platform}`,
+    '-var',
+    `runner_workspace=${workspacePath}`,
+  ];
+  if (build.platform === 'qemu') args.push('-var', `qemu_source_image=${qemuImagePath(rootDir)}`);
+  return [...args, ...build.extraPackerArgs, '.'];
+}
+
+export async function buildRunnerImage(build: RunnerImageBuild): Promise<{amiId: string | null}> {
+  const rootDir = getProjectRootPath(import.meta.url);
+  const stageDir = await mkdtemp(join(tmpdir(), 'shipfox-runner-image-'));
+  const workspacePath = join(stageDir, 'workspace');
+
+  try {
+    execFileSync('turbo', ['prune', '@shipfox/runner', '--out-dir', workspacePath], {
+      cwd: rootDir,
+      stdio: 'inherit',
+    });
+    execFileSync('packer', ['init', '.'], {cwd: rootDir, stdio: 'inherit'});
+    const output = execFileSync('packer', packerBuildArgs(build, workspacePath), {
+      cwd: rootDir,
+      encoding: 'utf8',
+    });
+    process.stdout.write(output);
+    return {amiId: build.platform === 'aws' ? findProducedAmiId(output) : null};
+  } finally {
+    await rm(stageDir, {force: true, recursive: true});
+  }
+}

--- a/infra/images/runner/src/runner-image.ts
+++ b/infra/images/runner/src/runner-image.ts
@@ -4,7 +4,7 @@ import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {getProjectRootPath} from '@shipfox/tool-utils';
 import {findProducedAmiId} from './aws.js';
-import {qemuImagePath} from './qemu.js';
+import {qemuSourceImageArgs} from './qemu.js';
 
 const WHITESPACE_PATTERN = /\s+/;
 
@@ -49,7 +49,7 @@ export function packerBuildArgs(
     '-var',
     `runner_workspace=${workspacePath}`,
   ];
-  if (build.platform === 'qemu') args.push('-var', `qemu_source_image=${qemuImagePath(rootDir)}`);
+  if (build.platform === 'qemu') args.push(...qemuSourceImageArgs(rootDir));
   return [...args, ...build.extraPackerArgs, '.'];
 }
 
@@ -64,7 +64,7 @@ export async function buildRunnerImage(build: RunnerImageBuild): Promise<{amiId:
       stdio: 'inherit',
     });
     execFileSync('packer', ['init', '.'], {cwd: rootDir, stdio: 'inherit'});
-    const output = execFileSync('packer', packerBuildArgs(build, workspacePath), {
+    const output = execFileSync('packer', packerBuildArgs(build, workspacePath, rootDir), {
       cwd: rootDir,
       encoding: 'utf8',
     });

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -1,0 +1,94 @@
+import {execFileSync} from 'node:child_process';
+import {findProducedAmiId} from '#aws.js';
+import {packerBuildArgs, readMiseNodeVersion} from '#runner-image.js';
+
+describe('readMiseNodeVersion', () => {
+  it('reads the selected Node version from mise', () => {
+    const version = readMiseNodeVersion(() => '24.17.0\n');
+
+    expect(version).toBe('24.17.0');
+  });
+});
+
+describe('packerBuildArgs', () => {
+  it('targets the AWS image source and passes the shared image variables', () => {
+    const args = packerBuildArgs(
+      {
+        os: 'ubuntu24',
+        platform: 'aws',
+        architecture: 'amd64',
+        buildNumber: '42',
+        nodeVersion: '24.17.0',
+        extraPackerArgs: ['-var', 'push_image=true'],
+      },
+      '/tmp/workspace',
+    );
+
+    expect(args).toEqual([
+      'build',
+      '-only',
+      'runner.amazon-ebs.build_image',
+      '-var',
+      'image_os=ubuntu24',
+      '-var',
+      'architecture=amd64',
+      '-var',
+      'build_number=42',
+      '-var',
+      'node_version=24.17.0',
+      '-var',
+      'platform=aws',
+      '-var',
+      'runner_workspace=/tmp/workspace',
+      '-var',
+      'push_image=true',
+      '.',
+    ]);
+  });
+});
+
+describe('findProducedAmiId', () => {
+  it('extracts the final AMI identifier from Packer output', () => {
+    const amiId = findProducedAmiId(
+      'Found Image ID: ami-0123abc456def7890\nAMIs were created: ami-0fedcba9876543210',
+    );
+
+    expect(amiId).toBe('ami-0fedcba9876543210');
+  });
+});
+
+describe('spot watchdog runtime script', () => {
+  const script = new URL('../scripts/runtime/spot-watchdog.sh', import.meta.url);
+
+  it.each(['stop', 'terminate', 'hibernate'])('parses a spaced %s IMDS notice', (action) => {
+    const result = execFileSync(
+      'sh',
+      [
+        '-c',
+        '. "$1"; spot_interruption_action "$2"',
+        'sh',
+        script.pathname,
+        `{"action": "${action}"}`,
+      ],
+      {encoding: 'utf8', env: {...process.env, SHIPFOX_SPOT_WATCHDOG_LIBRARY: '1'}},
+    );
+
+    expect(result.trim()).toBe(action);
+  });
+
+  it('does not treat an unrelated IMDS document as an interruption', () => {
+    const result = execFileSync(
+      'sh',
+      [
+        '-c',
+        '. "$1"; spot_interruption_action "$2"',
+        'sh',
+        script.pathname,
+        '{"action": "reboot"}',
+      ],
+      {encoding: 'utf8', env: {...process.env, SHIPFOX_SPOT_WATCHDOG_LIBRARY: '1'}},
+    );
+
+    expect(result.trim()).toBe('reboot');
+  });
+});

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -1,6 +1,11 @@
 import {execFileSync} from 'node:child_process';
 import {findProducedAmiId} from '#aws.js';
+import {parseBuildRunnerImageArgs} from '#build-runner-image.js';
 import {packerBuildArgs, readMiseNodeVersion} from '#runner-image.js';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 describe('readMiseNodeVersion', () => {
   it('reads the selected Node version from mise', () => {
@@ -19,7 +24,7 @@ describe('packerBuildArgs', () => {
         architecture: 'amd64',
         buildNumber: '42',
         nodeVersion: '24.17.0',
-        extraPackerArgs: ['-var', 'push_image=true'],
+        extraPackerArgs: [],
       },
       '/tmp/workspace',
     );
@@ -40,10 +45,48 @@ describe('packerBuildArgs', () => {
       'platform=aws',
       '-var',
       'runner_workspace=/tmp/workspace',
-      '-var',
-      'push_image=true',
       '.',
     ]);
+  });
+
+  it('passes a checked custom QEMU source relative to the project root', () => {
+    vi.stubEnv('SHIPFOX_QEMU_SOURCE_IMAGE', 'test-images/ubuntu.raw');
+    vi.stubEnv('SHIPFOX_QEMU_SOURCE_CHECKSUM', 'sha256:abc123');
+
+    const args = packerBuildArgs(
+      {
+        os: 'ubuntu24',
+        platform: 'qemu',
+        architecture: 'amd64',
+        buildNumber: '42',
+        nodeVersion: '24.17.0',
+        extraPackerArgs: [],
+      },
+      '/tmp/workspace',
+      '/repo',
+    );
+
+    expect(args).toContain('qemu_source_image=/repo/test-images/ubuntu.raw');
+    expect(args).toContain('qemu_source_checksum=sha256:abc123');
+  });
+
+  it('rejects an unchecked custom QEMU source', () => {
+    vi.stubEnv('SHIPFOX_QEMU_SOURCE_IMAGE', '/images/ubuntu.raw');
+    vi.stubEnv('SHIPFOX_QEMU_SOURCE_CHECKSUM', '');
+
+    expect(() =>
+      packerBuildArgs(
+        {
+          os: 'ubuntu24',
+          platform: 'qemu',
+          architecture: 'amd64',
+          buildNumber: '42',
+          nodeVersion: '24.17.0',
+          extraPackerArgs: [],
+        },
+        '/tmp/workspace',
+      ),
+    ).toThrow('SHIPFOX_QEMU_SOURCE_CHECKSUM');
   });
 });
 
@@ -54,6 +97,37 @@ describe('findProducedAmiId', () => {
     );
 
     expect(amiId).toBe('ami-0fedcba9876543210');
+  });
+
+  it('does not mistake a shortened identifier for an AMI', () => {
+    const amiId = findProducedAmiId('AMIs were created: ami-0123abc');
+
+    expect(amiId).toBeNull();
+  });
+});
+
+describe('parseBuildRunnerImageArgs', () => {
+  it('parses the build target and forwards Packer options', () => {
+    const build = parseBuildRunnerImageArgs(
+      ['ubuntu24', 'qemu', '-var', 'qemu_accelerator=tcg'],
+      {BUILD_ARCH: 'amd64', BUILD_NUMBER: '42'},
+      '24.17.0',
+    );
+
+    expect(build).toEqual({
+      os: 'ubuntu24',
+      platform: 'qemu',
+      architecture: 'amd64',
+      buildNumber: '42',
+      nodeVersion: '24.17.0',
+      extraPackerArgs: ['-var', 'qemu_accelerator=tcg'],
+    });
+  });
+
+  it('rejects missing required build metadata', () => {
+    expect(() => parseBuildRunnerImageArgs(['ubuntu24', 'aws'], {}, '24.17.0')).toThrow(
+      'BUILD_NUMBER is not set.',
+    );
   });
 });
 

--- a/infra/images/runner/tsconfig.build.json
+++ b/infra/images/runner/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.ts"]
+}

--- a/infra/images/runner/tsconfig.json
+++ b/infra/images/runner/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.test.json" }]
+}

--- a/infra/images/runner/tsconfig.test.json
+++ b/infra/images/runner/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "exclude": []
+}

--- a/infra/images/runner/variable.pkr.hcl
+++ b/infra/images/runner/variable.pkr.hcl
@@ -1,0 +1,43 @@
+variable "build_number" {
+  type = string
+}
+
+variable "architecture" {
+  type    = string
+  default = "amd64"
+  validation {
+    condition     = contains(["amd64", "arm64"], var.architecture)
+    error_message = "Architecture must be amd64 or arm64."
+  }
+}
+
+variable "image_os" {
+  type    = string
+  default = "ubuntu24"
+}
+
+variable "node_version" {
+  type = string
+}
+
+variable "os_disk_size_gb" {
+  type    = number
+  default = 100
+}
+
+variable "platform" {
+  type = string
+  validation {
+    condition     = contains(["aws", "qemu"], var.platform)
+    error_message = "Platform must be aws or qemu."
+  }
+}
+
+variable "push_image" {
+  type    = bool
+  default = false
+}
+
+variable "runner_workspace" {
+  type = string
+}

--- a/infra/images/runner/variable.pkr.hcl
+++ b/infra/images/runner/variable.pkr.hcl
@@ -33,11 +33,6 @@ variable "platform" {
   }
 }
 
-variable "push_image" {
-  type    = bool
-  default = false
-}
-
 variable "runner_workspace" {
   type = string
 }

--- a/infra/images/runner/variable.qemu.pkr.hcl
+++ b/infra/images/runner/variable.qemu.pkr.hcl
@@ -1,6 +1,21 @@
 variable "qemu_source_image" {
   type    = string
-  default = "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img"
+  default = null
+}
+
+variable "qemu_source_checksum" {
+  type    = string
+  default = null
+}
+
+variable "qemu_accelerator" {
+  type    = string
+  default = "kvm"
+
+  validation {
+    condition     = contains(["kvm", "tcg"], var.qemu_accelerator)
+    error_message = "QEMU accelerator must be kvm or tcg."
+  }
 }
 
 variable "qemu_headless" {

--- a/infra/images/runner/variable.qemu.pkr.hcl
+++ b/infra/images/runner/variable.qemu.pkr.hcl
@@ -1,0 +1,9 @@
+variable "qemu_source_image" {
+  type    = string
+  default = "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img"
+}
+
+variable "qemu_headless" {
+  type    = bool
+  default = true
+}

--- a/infra/images/runner/vitest.config.ts
+++ b/infra/images/runner/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({}, import.meta.url) as UserConfigExport;

--- a/libs/provisioner/core/src/config.test.ts
+++ b/libs/provisioner/core/src/config.test.ts
@@ -74,6 +74,13 @@ describe('provisioner core config validation', () => {
     await expect(import('#config.js')).rejects.toThrow('SHIPFOX_RUNNER_POLL_MAX_DURATION_MS');
   });
 
+  it('rejects a non-positive runner maximum lifetime', async () => {
+    vi.stubEnv('SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS', '0');
+    vi.resetModules();
+
+    await expect(import('#config.js')).rejects.toThrow('SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS');
+  });
+
   it('accepts the documented defaults', async () => {
     vi.resetModules();
 
@@ -83,5 +90,6 @@ describe('provisioner core config validation', () => {
     expect(config.SHIPFOX_PROVISIONER_MAX_RESERVATIONS).toBe(250);
     expect(config.SHIPFOX_PROVISIONER_REGISTRATION_TOKEN_BATCH_SIZE).toBe(250);
     expect(config.SHIPFOX_RUNNER_POLL_MAX_DURATION_MS).toBe(300_000);
+    expect(config.SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS).toBe(3600);
   });
 });

--- a/libs/provisioner/core/src/config.ts
+++ b/libs/provisioner/core/src/config.ts
@@ -40,6 +40,10 @@ export const config = createConfig({
     desc: 'Value injected into each runner as SHIPFOX_POLL_MAX_DURATION_MS: how long a started runner keeps polling for a job before exiting, in milliseconds. Use 0 for runners that should poll forever.',
     default: 300_000,
   }),
+  SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS: num({
+    desc: 'Hard maximum lifetime injected into each runner as SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS, in seconds. Set it above the longest permitted job so a runner always self-terminates if the provisioner is unavailable.',
+    default: 3600,
+  }),
 });
 
 // wait_seconds, max_reservations, and the batch size are sent to integer-typed API
@@ -89,5 +93,14 @@ if (
 if (config.SHIPFOX_RUNNER_POLL_MAX_DURATION_MS < 0) {
   throw new Error(
     `SHIPFOX_RUNNER_POLL_MAX_DURATION_MS must be greater than or equal to 0; got ${config.SHIPFOX_RUNNER_POLL_MAX_DURATION_MS}.`,
+  );
+}
+
+if (
+  !Number.isInteger(config.SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS) ||
+  config.SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS <= 0
+) {
+  throw new Error(
+    `SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS must be a positive integer; got ${config.SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS}.`,
   );
 }

--- a/libs/provisioner/core/src/provisioner-env.test.ts
+++ b/libs/provisioner/core/src/provisioner-env.test.ts
@@ -1,0 +1,15 @@
+import {buildRunnerEnv} from '#provisioner.js';
+
+describe('buildRunnerEnv', () => {
+  it('includes the runner maximum lifetime in the shared image contract', () => {
+    const runnerEnv = buildRunnerEnv({
+      template: {key: 'small', labels: ['ubuntu24'], maxConcurrency: 1, cost: 1, spec: null},
+      registrationToken: 'sf_ert_test',
+    });
+
+    expect(runnerEnv).toMatchObject({
+      SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS: '3600',
+      SHIPFOX_POLL_MAX_DURATION_MS: '300000',
+    });
+  });
+});

--- a/libs/provisioner/core/src/provisioner.ts
+++ b/libs/provisioner/core/src/provisioner.ts
@@ -219,6 +219,7 @@ export const buildRunnerEnv: RunnerEnvFactory<unknown> = ({template, registratio
   SHIPFOX_RUNNER_REGISTRATION_TOKEN: registrationToken,
   SHIPFOX_RUNNER_LABELS: template.labels.join(','),
   SHIPFOX_POLL_MAX_DURATION_MS: String(config.SHIPFOX_RUNNER_POLL_MAX_DURATION_MS),
+  SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS: String(config.SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS),
 });
 
 export function nextBackoffInterval(ms: number): number {

--- a/mise.lock
+++ b/mise.lock
@@ -110,3 +110,35 @@ url = "https://github.com/ollama/ollama/releases/download/v0.30.11/ollama-darwin
 [tools.ollama."platforms.windows-x64"]
 checksum = "sha256:43d534c10040ea676c99af19836377a315daa8cb3bb6c3d9d609b4c23dd37b88"
 url = "https://github.com/ollama/ollama/releases/download/v0.30.11/ollama-windows-amd64.zip"
+
+[[tools.packer]]
+version = "1.15.4"
+backend = "aqua:hashicorp/packer"
+
+[tools.packer."platforms.linux-arm64"]
+checksum = "sha256:23e6d2e596dd9e2527e0f7bea9aedd26059729375a0d17c462c2621f1b97b82d"
+url = "https://releases.hashicorp.com/packer/1.15.4/packer_1.15.4_linux_arm64.zip"
+
+[tools.packer."platforms.linux-arm64-musl"]
+checksum = "sha256:23e6d2e596dd9e2527e0f7bea9aedd26059729375a0d17c462c2621f1b97b82d"
+url = "https://releases.hashicorp.com/packer/1.15.4/packer_1.15.4_linux_arm64.zip"
+
+[tools.packer."platforms.linux-x64"]
+checksum = "sha256:15f97a6a99645c7d5308c609973b5280837b38e112beac413ccbce80da927cf1"
+url = "https://releases.hashicorp.com/packer/1.15.4/packer_1.15.4_linux_amd64.zip"
+
+[tools.packer."platforms.linux-x64-musl"]
+checksum = "sha256:15f97a6a99645c7d5308c609973b5280837b38e112beac413ccbce80da927cf1"
+url = "https://releases.hashicorp.com/packer/1.15.4/packer_1.15.4_linux_amd64.zip"
+
+[tools.packer."platforms.macos-arm64"]
+checksum = "sha256:d95ba177dd2ebb84d7d155493b4188ec2a519d2c3b041528db5b63a6aff9da80"
+url = "https://releases.hashicorp.com/packer/1.15.4/packer_1.15.4_darwin_arm64.zip"
+
+[tools.packer."platforms.macos-x64"]
+checksum = "sha256:b3be60b44dcb74e7962afe22cc10b89a09c74b626fcd52f49ecee32b07b99e71"
+url = "https://releases.hashicorp.com/packer/1.15.4/packer_1.15.4_darwin_amd64.zip"
+
+[tools.packer."platforms.windows-x64"]
+checksum = "sha256:a50db29fae2972f5e5d05ecee23f80e303d605f8132dc2167848fc89184f044b"
+url = "https://releases.hashicorp.com/packer/1.15.4/packer_1.15.4_windows_amd64.zip"

--- a/mise.toml
+++ b/mise.toml
@@ -6,6 +6,7 @@ gh = "2.95.0"
 "npm:pnpm" = "11.7.0"
 "npm:turbo" = "2.9.18"
 ollama = "0.30.11"
+packer = "1.15.4"
 
 [env]
 _.path = ['{{config_root}}/node_modules/.bin']

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1715,6 +1715,31 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
 
+  infra/images/runner:
+    dependencies:
+      '@shipfox/runner':
+        specifier: workspace:*
+        version: link:../../../apps/runner
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../tools/swc
+      '@shipfox/tool-utils':
+        specifier: workspace:*
+        version: link:../../../tools/utils
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../tools/vitest
+
   libs/api/agent:
     dependencies:
       '@earendil-works/pi-ai':


### PR DESCRIPTION
Adds a Packer-based runner-image package that produces AWS AMIs and QEMU images from one provisioning definition, and adds the shared maximum-lifetime runner environment contract.

Ephemeral EC2 runners need an instance-side safety net: they must drain and terminate after runner exit, a bounded lifetime, or a Spot interruption even if the provisioner is unavailable. The image keeps target-architecture deployment inside the builder VM and leaves the existing Docker runner image unchanged.

The QEMU target now uses a fixed, checksummed Ubuntu base image, bootstraps Packer access through a temporary NoCloud seed, and locks that bootstrap account before the artifact is produced. CI runs Packer format and template validation. The executed QEMU boot proof and artifact publication are tracked separately in ENG-1017.

Closes ENG-1015
Related to ENG-1017