### PR TITLE
[integration/slack] Gate bot-token reads by installation

### DIFF
--- a/.changeset/brave-otters-guard.md
+++ b/.changeset/brave-otters-guard.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-integration-slack": patch
+---
+
+Prevents Slack bot tokens from being read for revoked, expired, or missing installations.

--- a/libs/api/integration/slack/src/core/errors.ts
+++ b/libs/api/integration/slack/src/core/errors.ts
@@ -74,3 +74,19 @@ export class SlackBotTokenMissingError extends Error {
     this.name = 'SlackBotTokenMissingError';
   }
 }
+
+export type SlackAccessTokenUnavailableReason =
+  | 'installation-not-found'
+  | 'not-installed'
+  | 'expired';
+
+export class SlackAccessTokenUnavailableError extends Error {
+  constructor(
+    public readonly connectionId: string,
+    public readonly reason: SlackAccessTokenUnavailableReason,
+    public readonly expiresAt?: Date,
+  ) {
+    super(`Slack access token is unavailable for connection: ${connectionId} (${reason})`);
+    this.name = 'SlackAccessTokenUnavailableError';
+  }
+}

--- a/libs/api/integration/slack/src/core/tokens.test.ts
+++ b/libs/api/integration/slack/src/core/tokens.test.ts
@@ -1,4 +1,5 @@
 import {SlackBotTokenMissingError, SlackConnectionNotFoundError} from '#core/errors.js';
+import {upsertSlackInstallation} from '#db/installations.js';
 import {
   createSlackTokenStore,
   type SlackConnectionResolverResult,
@@ -6,10 +7,10 @@ import {
   slackSecretsNamespace,
 } from './tokens.js';
 
-let secrets: SlackSecretsStore;
+let slackSecrets: SlackSecretsStore;
 
 beforeAll(async () => {
-  secrets = await import('@shipfox/api-secrets');
+  slackSecrets = await import('@shipfox/api-secrets');
 });
 
 function createConnectionContext() {
@@ -18,12 +19,41 @@ function createConnectionContext() {
   const resolveConnection = vi
     .fn<(connectionId: string) => Promise<SlackConnectionResolverResult | undefined>>()
     .mockResolvedValue({workspaceId});
+  const getSecret = vi.fn<SlackSecretsStore['getSecret']>((params) =>
+    slackSecrets.getSecret(params),
+  );
+  const secrets = {getSecret, setSecrets: slackSecrets.setSecrets};
   const store = createSlackTokenStore({resolveConnection, secrets});
 
-  return {workspaceId, connectionId, resolveConnection, store};
+  return {workspaceId, connectionId, getSecret, resolveConnection, store};
+}
+
+async function arrangeSlackInstallation({
+  connectionId,
+  status = 'installed',
+  tokenExpiresAt = null,
+}: {
+  connectionId: string;
+  status?: 'installed' | 'revoked';
+  tokenExpiresAt?: Date | null;
+}): Promise<void> {
+  await upsertSlackInstallation({
+    connectionId,
+    teamId: `T${crypto.randomUUID()}`,
+    teamName: 'Acme',
+    appId: 'A123',
+    botUserId: 'U123',
+    scopes: ['app_mentions:read'],
+    status,
+    tokenExpiresAt,
+  });
 }
 
 describe('createSlackTokenStore', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('stores and reads a bot token in the Slack system namespace', async () => {
     const {workspaceId, connectionId, store} = createConnectionContext();
 
@@ -32,10 +62,12 @@ describe('createSlackTokenStore', () => {
       botToken: 'xoxb-test-token',
       editedBy: crypto.randomUUID(),
     });
+    await arrangeSlackInstallation({connectionId});
+
     const result = await store.getAccessToken({connectionId});
 
     await expect(
-      secrets.getSecret({
+      slackSecrets.getSecret({
         workspaceId,
         namespace: slackSecretsNamespace(connectionId),
         key: 'BOT_TOKEN',
@@ -44,8 +76,76 @@ describe('createSlackTokenStore', () => {
     expect(result).toBe('xoxb-test-token');
   });
 
+  it('reads an installed bot token with a future expiry', async () => {
+    const {connectionId, store} = createConnectionContext();
+    await store.storeTokens({connectionId, botToken: 'xoxb-test-token'});
+    await arrangeSlackInstallation({
+      connectionId,
+      tokenExpiresAt: new Date(Date.now() + 60_000),
+    });
+
+    const result = await store.getAccessToken({connectionId});
+
+    expect(result).toBe('xoxb-test-token');
+  });
+
+  it('rejects a token whose expiry is exactly now', async () => {
+    vi.useFakeTimers();
+    const now = new Date('2026-07-18T15:00:00.000Z');
+    vi.setSystemTime(now);
+    const {connectionId, getSecret, store} = createConnectionContext();
+    await arrangeSlackInstallation({connectionId, tokenExpiresAt: now});
+
+    const result = store.getAccessToken({connectionId});
+
+    await expect(result).rejects.toMatchObject({
+      reason: 'expired',
+      expiresAt: now,
+    });
+    expect(getSecret).not.toHaveBeenCalled();
+  });
+
+  it('rejects a token whose expiry is in the past', async () => {
+    const {connectionId, getSecret, store} = createConnectionContext();
+    await arrangeSlackInstallation({
+      connectionId,
+      tokenExpiresAt: new Date(Date.now() - 60_000),
+    });
+
+    const result = store.getAccessToken({connectionId});
+
+    await expect(result).rejects.toMatchObject({
+      reason: 'expired',
+    });
+    expect(getSecret).not.toHaveBeenCalled();
+  });
+
+  it('rejects a revoked installation before reading the bot token', async () => {
+    const {connectionId, getSecret, store} = createConnectionContext();
+    await arrangeSlackInstallation({connectionId, status: 'revoked'});
+
+    const result = store.getAccessToken({connectionId});
+
+    await expect(result).rejects.toMatchObject({
+      reason: 'not-installed',
+    });
+    expect(getSecret).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing installation before reading the bot token', async () => {
+    const {connectionId, getSecret, store} = createConnectionContext();
+
+    const result = store.getAccessToken({connectionId});
+
+    await expect(result).rejects.toMatchObject({
+      reason: 'installation-not-found',
+    });
+    expect(getSecret).not.toHaveBeenCalled();
+  });
+
   it('throws a typed error when the bot token is missing', async () => {
     const {connectionId, store} = createConnectionContext();
+    await arrangeSlackInstallation({connectionId});
 
     const result = store.getAccessToken({connectionId});
 

--- a/libs/api/integration/slack/src/core/tokens.ts
+++ b/libs/api/integration/slack/src/core/tokens.ts
@@ -1,4 +1,9 @@
-import {SlackBotTokenMissingError, SlackConnectionNotFoundError} from '#core/errors.js';
+import {
+  SlackAccessTokenUnavailableError,
+  SlackBotTokenMissingError,
+  SlackConnectionNotFoundError,
+} from '#core/errors.js';
+import {getSlackInstallationByConnectionId, type SlackInstallation} from '#db/installations.js';
 
 const BOT_TOKEN_KEY = 'BOT_TOKEN';
 
@@ -40,6 +45,25 @@ export function slackSecretsNamespace(connectionId: string): string {
   return `system/integrations/slack/${connectionId}`;
 }
 
+function assertSlackInstallationServesToken(
+  connectionId: string,
+  installation: SlackInstallation | undefined,
+): asserts installation is SlackInstallation {
+  if (!installation) {
+    throw new SlackAccessTokenUnavailableError(connectionId, 'installation-not-found');
+  }
+  if (installation.status !== 'installed') {
+    throw new SlackAccessTokenUnavailableError(connectionId, 'not-installed');
+  }
+  if (installation.tokenExpiresAt !== null && installation.tokenExpiresAt.getTime() <= Date.now()) {
+    throw new SlackAccessTokenUnavailableError(
+      connectionId,
+      'expired',
+      installation.tokenExpiresAt,
+    );
+  }
+}
+
 export function createSlackTokenStore(params: CreateSlackTokenStoreParams): SlackTokenStore {
   async function resolveWorkspaceId(connectionId: string): Promise<string> {
     const connection = await params.resolveConnection(connectionId);
@@ -60,6 +84,8 @@ export function createSlackTokenStore(params: CreateSlackTokenStoreParams): Slac
 
     async getAccessToken(input) {
       const workspaceId = await resolveWorkspaceId(input.connectionId);
+      const installation = await getSlackInstallationByConnectionId(input.connectionId);
+      assertSlackInstallationServesToken(input.connectionId, installation);
       const token = await params.secrets.getSecret({
         workspaceId,
         namespace: slackSecretsNamespace(input.connectionId),

--- a/libs/api/integration/slack/src/index.ts
+++ b/libs/api/integration/slack/src/index.ts
@@ -29,6 +29,8 @@ export {
   disconnectSlackInstallation,
 } from '#core/disconnect.js';
 export {
+  SlackAccessTokenUnavailableError,
+  type SlackAccessTokenUnavailableReason,
   SlackAuthorizationScopeMismatchError,
   SlackBotTokenMissingError,
   SlackConnectionAlreadyLinkedError,


### PR DESCRIPTION
Gate Slack bot-token reads on the installation state before accessing the secret store.

A revoked, expired, or split-brain installation could otherwise still expose a stored bot token to the first agent-tools consumer. The token store now fails closed with a reason-tagged domain error and preserves non-expiring tokens.

Connection lifecycle remains owned by the agent-tools gateway, so this change avoids duplicating that broader authorization check. The read-time gate deliberately does not revoke tokens already held by an active session.

Closes ENG-998

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates Slack bot-token reads by installation status to prevent exposing tokens for revoked, expired, or missing installations. Adds a fail-closed check in `getAccessToken`, addressing ENG-998.

- **Bug Fixes**
  - Validate the Slack installation before reading the secret; block revoked, expired (including “expires now”), or missing installations.
  - Add `SlackAccessTokenUnavailableError` with reason (`installation-not-found` | `not-installed` | `expired`) and optional `expiresAt`; export from `@shipfox/api-integration-slack`.
  - Expand tests to cover gating behavior and edge cases; non-expiring tokens remain valid.

<sup>Written for commit f9432209de0f03f59fdb287636d035bc1e29c0b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

