### PR TITLE
[integration/slack] Add agent tools adapter

### DIFF
--- a/.changeset/swift-owls-reply.md
+++ b/.changeset/swift-owls-reply.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-integration-slack": patch
+"@shipfox/api-integration-core": patch
+---
+
+Adds in-process Slack agent tools for reading conversations and acting on messages through the lease-authenticated gateway.

--- a/libs/api/integration/core/src/providers/modules.test.ts
+++ b/libs/api/integration/core/src/providers/modules.test.ts
@@ -49,8 +49,8 @@ describe('loadEnabledProviderModules', () => {
     expect(parts[0]?.provider).toMatchObject({
       provider: 'slack',
       displayName: 'Slack',
-      adapters: {},
     });
+    expect(parts[0]?.provider.adapters?.agent_tools).toBeDefined();
   });
 
   it('loads Jira when the provider is enabled', async () => {

--- a/libs/api/integration/core/src/providers/slack.ts
+++ b/libs/api/integration/core/src/providers/slack.ts
@@ -134,6 +134,7 @@ async function loadSlackModuleParts(
 
   return {
     provider: createSlackIntegrationProvider({
+      agentTools: {tokenStore},
       routes: {
         tokenStore,
         getExistingSlackConnection,
@@ -151,7 +152,7 @@ async function loadSlackModuleParts(
         getExistingSlackConnection,
         connectSlackInstallation,
         disconnectSlackInstallation,
-        connectionCapabilities: [],
+        connectionCapabilities: ['agent_tools'],
       }),
     ],
     database: {

--- a/libs/api/integration/slack/src/api/client.test.ts
+++ b/libs/api/integration/slack/src/api/client.test.ts
@@ -166,4 +166,74 @@ describe('createSlackApiClient', () => {
     });
     expect(JSON.stringify(mocks.warn.mock.calls)).not.toContain('secret-token');
   });
+
+  it.each([
+    {ok: true, channel: {id: 'C123'}},
+    {ok: false, error: 'channel_not_found'},
+  ])('passes through Slack Web API response %o', async (body) => {
+    mocks.post.mockReturnValue(resolves(body));
+
+    const result = await createSlackApiClient().callMethod({
+      method: 'conversations.history',
+      token: 'xoxb-secret',
+      arguments: {channel: 'C123'},
+    });
+
+    const [url, options] = mocks.post.mock.calls[0] as [
+      string,
+      {headers: {authorization: string}; body: URLSearchParams},
+    ];
+    expect(url).toBe('http://127.0.0.1:0/conversations.history');
+    expect(options.headers).toEqual({authorization: 'Bearer xoxb-secret'});
+    expect(options.body).toEqual(new URLSearchParams({channel: 'C123'}));
+    expect(result).toEqual(body);
+  });
+
+  it('serializes Slack method arguments as form values and omits nullish values', async () => {
+    mocks.post.mockReturnValue(resolves({ok: true}));
+    const blocks = [{type: 'section', text: {type: 'plain_text', text: 'Hello'}}];
+
+    await createSlackApiClient().callMethod({
+      method: 'chat.postMessage',
+      token: 'xoxb-secret',
+      arguments: {
+        blocks,
+        limit: 30,
+        inclusive: false,
+        types: 'public_channel,private_channel',
+        oldest: null,
+        latest: undefined,
+      },
+    });
+
+    const [, options] = mocks.post.mock.calls[0] as [string, {body: URLSearchParams}];
+    expect(Object.fromEntries(options.body)).toEqual({
+      blocks: JSON.stringify(blocks),
+      limit: '30',
+      inclusive: 'false',
+      types: 'public_channel,private_channel',
+    });
+    expect(options.body.has('oldest')).toBe(false);
+    expect(options.body.has('latest')).toBe(false);
+  });
+
+  it.each([
+    [httpError(429, {'retry-after': '17'}), 'rate-limited', 17],
+    [httpError(413), 'content-too-large', undefined],
+    [httpError(404), 'malformed-provider-response', undefined],
+  ])('maps Web API HTTP failures to %s', async (transportError, reason, retryAfterSeconds) => {
+    mocks.post.mockReturnValue(rejects(transportError));
+
+    const error = await createSlackApiClient()
+      .callMethod({
+        method: 'chat.postMessage',
+        token: 'xoxb-super-secret',
+        arguments: {channel: 'C123', text: 'sensitive body'},
+      })
+      .catch((thrown: unknown) => thrown);
+
+    expect(error).toMatchObject({reason, retryAfterSeconds});
+    expect(JSON.stringify(mocks.warn.mock.calls)).not.toContain('xoxb-super-secret');
+    expect(JSON.stringify(mocks.warn.mock.calls)).not.toContain('sensitive body');
+  });
 });

--- a/libs/api/integration/slack/src/api/client.ts
+++ b/libs/api/integration/slack/src/api/client.ts
@@ -18,9 +18,20 @@ export interface SlackAuthorization {
   scopes: string[];
 }
 
+export interface SlackWebApiResponse {
+  ok: boolean;
+  error?: string | undefined;
+  [key: string]: unknown;
+}
+
 export interface SlackApiClient {
   exchangeAuthorizationCode(input: {code: string}): Promise<SlackAuthorization>;
   revokeToken(input: {token: string}): Promise<void>;
+  callMethod(input: {
+    method: string;
+    token: string;
+    arguments: Record<string, unknown>;
+  }): Promise<SlackWebApiResponse>;
 }
 
 interface SlackOAuthAccessResponse {
@@ -62,6 +73,18 @@ export function createSlackApiClient(): SlackApiClient {
           timeout: SLACK_API_TIMEOUT_MS,
         });
       });
+    },
+
+    async callMethod(input) {
+      return await mapSlackWebApiError(input.method, () =>
+        ky
+          .post(slackApiUrl(input.method), {
+            headers: {authorization: `Bearer ${input.token}`},
+            body: slackMethodArguments(input.arguments),
+            timeout: SLACK_API_TIMEOUT_MS,
+          })
+          .json<SlackWebApiResponse>(),
+      );
     },
   };
 }
@@ -145,6 +168,67 @@ async function mapSlackError<T>(operation: string, request: () => Promise<T>): P
     );
     throw new SlackIntegrationProviderError('provider-unavailable', 'Slack request failed');
   }
+}
+
+async function mapSlackWebApiError<T>(method: string, request: () => Promise<T>): Promise<T> {
+  try {
+    return await request();
+  } catch (error) {
+    if (error instanceof SlackIntegrationProviderError) throw error;
+    if (error instanceof HTTPError) {
+      const {status, statusText, headers} = error.response;
+      logger().warn(
+        {operation: 'call-method', method, status, statusText},
+        'Slack API request rejected',
+      );
+      if (status === 429) {
+        throw new SlackIntegrationProviderError(
+          'rate-limited',
+          'Slack request was rate limited',
+          retryAfterSeconds(headers),
+        );
+      }
+      if (status === 413) {
+        throw new SlackIntegrationProviderError(
+          'content-too-large',
+          'Slack request content was too large',
+        );
+      }
+      if (status >= 500) {
+        throw new SlackIntegrationProviderError('provider-unavailable', 'Slack request failed');
+      }
+      throw new SlackIntegrationProviderError(
+        'malformed-provider-response',
+        'Slack request was rejected',
+      );
+    }
+    if (error instanceof TimeoutError) {
+      logger().warn({operation: 'call-method', method}, 'Slack API request timed out');
+      throw new SlackIntegrationProviderError('timeout', 'Slack request timed out');
+    }
+    logger().warn(
+      {
+        operation: 'call-method',
+        method,
+        errName: error instanceof Error ? error.name : typeof error,
+      },
+      'Slack API request failed',
+    );
+    throw new SlackIntegrationProviderError('provider-unavailable', 'Slack request failed');
+  }
+}
+
+function slackMethodArguments(input: Record<string, unknown>): URLSearchParams {
+  const body = new URLSearchParams();
+  for (const [key, value] of Object.entries(input)) {
+    if (value === null || value === undefined) continue;
+    const serialized =
+      typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean'
+        ? String(value)
+        : JSON.stringify(value);
+    if (serialized !== undefined) body.set(key, serialized);
+  }
+  return body;
 }
 
 function slackApiUrl(path: string): string {

--- a/libs/api/integration/slack/src/core/agent-tools-provider.test.ts
+++ b/libs/api/integration/slack/src/core/agent-tools-provider.test.ts
@@ -1,0 +1,256 @@
+import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
+import type {SlackWebApiResponse} from '#api/client.js';
+import {slackAgentToolCatalog, slackAgentToolSelectionCatalog} from '#core/agent-tools.js';
+import {SlackAgentToolsProvider} from '#core/agent-tools-provider.js';
+import {SlackBotTokenMissingError, SlackIntegrationProviderError} from '#core/errors.js';
+
+const mocks = vi.hoisted(() => ({warn: vi.fn()}));
+
+vi.mock('@shipfox/node-opentelemetry', () => ({logger: () => ({warn: mocks.warn})}));
+
+function slackConnection(
+  overrides: Partial<IntegrationConnection<'slack'>> = {},
+): IntegrationConnection<'slack'> {
+  const now = new Date();
+  return {
+    id: 'slack-connection-1',
+    workspaceId: 'workspace-1',
+    provider: 'slack',
+    externalAccountId: 'T123',
+    slug: 'slack-acme',
+    displayName: 'Slack Acme',
+    lifecycleStatus: 'active',
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+function catalogTool(id: string) {
+  const tool = slackAgentToolCatalog.find((candidate) => candidate.id === id);
+  if (!tool) throw new Error(`Unknown test tool: ${id}`);
+  return tool;
+}
+
+function providerOptions(
+  callMethod: (input: {
+    method: string;
+    token: string;
+    arguments: Record<string, unknown>;
+  }) => Promise<SlackWebApiResponse>,
+) {
+  return {
+    slack: {callMethod: vi.fn(callMethod)},
+    tokenStore: {getAccessToken: vi.fn().mockResolvedValue('xoxb-token')},
+  };
+}
+
+async function openSession(
+  options: ReturnType<typeof providerOptions>,
+  toolIds: string[],
+  connection = slackConnection(),
+) {
+  const provider = new SlackAgentToolsProvider(options);
+  return await provider.openSession({
+    connection,
+    tools: toolIds.map(catalogTool),
+    scope: {provider: 'slack'},
+  });
+}
+
+describe('SlackAgentToolsProvider', () => {
+  beforeEach(() => {
+    mocks.warn.mockReset();
+  });
+
+  it('returns the Slack agent tools catalogs', () => {
+    const options = providerOptions(async () => ({ok: true}));
+    const provider = new SlackAgentToolsProvider(options);
+
+    const catalog = provider.catalog();
+    const selectionCatalog = provider.selectionCatalog();
+
+    expect(catalog).toBe(slackAgentToolCatalog);
+    expect(selectionCatalog).toBe(slackAgentToolSelectionCatalog);
+  });
+
+  it('reads the stored bot token for the connection before opening a session', async () => {
+    const options = providerOptions(async () => ({ok: true}));
+    const provider = new SlackAgentToolsProvider(options);
+
+    await provider.openSession({
+      connection: slackConnection({id: 'slack-connection-7'}),
+      tools: [],
+      scope: {provider: 'slack'},
+    });
+
+    expect(options.tokenStore.getAccessToken).toHaveBeenCalledWith({
+      connectionId: 'slack-connection-7',
+    });
+  });
+
+  it('dispatches a read method and returns the Slack response as structured content', async () => {
+    const body = {ok: true, messages: [{text: 'Hello'}]};
+    const options = providerOptions(async () => body);
+    const session = await openSession(options, ['conversations_history']);
+
+    const result = await session.call({
+      toolId: 'conversations_history',
+      arguments: {channel: 'C123', limit: 10},
+    });
+
+    expect(options.slack.callMethod).toHaveBeenCalledWith({
+      method: 'conversations.history',
+      token: 'xoxb-token',
+      arguments: {channel: 'C123', limit: 10},
+    });
+    expect(result).toEqual({
+      content: [{type: 'text', text: JSON.stringify(body)}],
+      structuredContent: body,
+    });
+  });
+
+  it('passes a thread timestamp through to the message-posting method', async () => {
+    const options = providerOptions(async () => ({ok: true, ts: '456.000'}));
+    const session = await openSession(options, ['chat_postMessage']);
+
+    await session.call({
+      toolId: 'chat_postMessage',
+      arguments: {channel: 'C123', text: 'Reply', thread_ts: '123.000'},
+    });
+
+    expect(options.slack.callMethod).toHaveBeenCalledWith({
+      method: 'chat.postMessage',
+      token: 'xoxb-token',
+      arguments: {channel: 'C123', text: 'Reply', thread_ts: '123.000'},
+    });
+  });
+
+  it('rejects a tool that was not selected for the session', async () => {
+    const options = providerOptions(async () => ({ok: true}));
+    const session = await openSession(options, ['conversations_history']);
+
+    const result = await session.call({toolId: 'users_info', arguments: {user: 'U123'}});
+
+    expect(result).toEqual({
+      isError: true,
+      content: [{type: 'text', text: 'Unknown Slack tool: users_info'}],
+    });
+    expect(options.slack.callMethod).not.toHaveBeenCalled();
+  });
+
+  it('rejects a call missing a required parameter', async () => {
+    const options = providerOptions(async () => ({ok: true}));
+    const session = await openSession(options, ['conversations_replies']);
+
+    const result = await session.call({
+      toolId: 'conversations_replies',
+      arguments: {channel: 'C123'},
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [{type: 'text', text: 'Missing required parameter: ts'}],
+    });
+    expect(options.slack.callMethod).not.toHaveBeenCalled();
+  });
+
+  it('returns a Slack application error to the agent', async () => {
+    const options = providerOptions(async () => ({ok: false, error: 'channel_not_found'}));
+    const session = await openSession(options, ['conversations_history']);
+
+    const result = await session.call({
+      toolId: 'conversations_history',
+      arguments: {channel: 'C123'},
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [{type: 'text', text: 'channel_not_found'}],
+    });
+  });
+
+  it('returns auth failures with a stable access-denied code and logs only metadata', async () => {
+    const options = providerOptions(async () => ({ok: false, error: 'invalid_auth'}));
+    const session = await openSession(options, ['conversations_history']);
+
+    const result = await session.call({
+      toolId: 'conversations_history',
+      arguments: {channel: 'C123'},
+    });
+
+    expect(result).toMatchObject({
+      isError: true,
+      content: [{type: 'text', text: 'invalid_auth'}],
+      structuredContent: {code: 'access-denied'},
+    });
+    expect(mocks.warn).toHaveBeenCalledWith(
+      {connectionId: 'slack-connection-1', slackError: 'invalid_auth'},
+      'Slack API rejected integration credentials',
+    );
+    expect(JSON.stringify(mocks.warn.mock.calls)).not.toContain('xoxb-token');
+  });
+
+  it('returns an HTTP-200 rate-limit response with a stable code', async () => {
+    const options = providerOptions(async () => ({ok: false, error: 'ratelimited'}));
+    const session = await openSession(options, ['conversations_list']);
+
+    const result = await session.call({toolId: 'conversations_list', arguments: {}});
+
+    expect(result).toMatchObject({
+      isError: true,
+      structuredContent: {code: 'rate-limited'},
+    });
+  });
+
+  it('preserves retry details from a transport-level rate limit', async () => {
+    const options = providerOptions(() =>
+      Promise.reject(new SlackIntegrationProviderError('rate-limited', 'Try again later', 19)),
+    );
+    const session = await openSession(options, ['conversations_list']);
+
+    const result = await session.call({toolId: 'conversations_list', arguments: {}});
+
+    expect(result).toMatchObject({
+      isError: true,
+      content: [{type: 'text', text: 'Try again later'}],
+      structuredContent: {code: 'rate-limited', retryAfterSeconds: 19},
+    });
+  });
+
+  it('preserves content-too-large from a rejected Slack request', async () => {
+    const options = providerOptions(() =>
+      Promise.reject(
+        new SlackIntegrationProviderError('content-too-large', 'Slack content was too large'),
+      ),
+    );
+    const session = await openSession(options, ['chat_postMessage']);
+
+    const result = await session.call({
+      toolId: 'chat_postMessage',
+      arguments: {channel: 'C123', blocks: []},
+    });
+
+    expect(result).toMatchObject({
+      isError: true,
+      structuredContent: {code: 'content-too-large'},
+    });
+  });
+
+  it('does not call Slack when the bot token is missing', async () => {
+    const options = providerOptions(async () => ({ok: true}));
+    options.tokenStore.getAccessToken.mockRejectedValue(
+      new SlackBotTokenMissingError('slack-connection-1'),
+    );
+    const provider = new SlackAgentToolsProvider(options);
+
+    const result = provider.openSession({
+      connection: slackConnection(),
+      tools: [catalogTool('conversations_list')],
+      scope: {provider: 'slack'},
+    });
+
+    await expect(result).rejects.toBeInstanceOf(SlackBotTokenMissingError);
+    expect(options.slack.callMethod).not.toHaveBeenCalled();
+  });
+});

--- a/libs/api/integration/slack/src/core/agent-tools-provider.ts
+++ b/libs/api/integration/slack/src/core/agent-tools-provider.ts
@@ -1,0 +1,147 @@
+import type {
+  AgentToolSession,
+  AgentToolsProvider,
+  IntegrationConnection,
+  OpenAgentToolsSessionInput,
+} from '@shipfox/api-integration-core-dto';
+import {logger} from '@shipfox/node-opentelemetry';
+import type {SlackApiClient, SlackWebApiResponse} from '#api/client.js';
+import {
+  SLACK_TOOL_METHODS,
+  type SlackAgentToolCatalogEntry,
+  type SlackAgentToolId,
+  type SlackAgentToolRequiredScope,
+  slackAgentToolCatalog,
+  slackAgentToolSelectionCatalog,
+} from '#core/agent-tools.js';
+import {SlackIntegrationProviderError} from '#core/errors.js';
+import type {SlackTokenStore} from '#core/tokens.js';
+
+type SlackIntegrationConnection = IntegrationConnection<'slack'>;
+
+export type SlackToolCallResult = {
+  isError?: boolean | undefined;
+  content: readonly {type: 'text'; text: string}[];
+  structuredContent?: Record<string, unknown> | undefined;
+};
+
+export interface SlackAgentToolsProviderOptions {
+  slack: Pick<SlackApiClient, 'callMethod'>;
+  tokenStore: Pick<SlackTokenStore, 'getAccessToken'>;
+}
+
+export class SlackAgentToolsProvider
+  implements
+    AgentToolsProvider<
+      SlackIntegrationConnection,
+      SlackAgentToolRequiredScope,
+      unknown,
+      SlackToolCallResult
+    >
+{
+  constructor(private readonly options: SlackAgentToolsProviderOptions) {}
+
+  catalog() {
+    return slackAgentToolCatalog;
+  }
+
+  selectionCatalog() {
+    return slackAgentToolSelectionCatalog;
+  }
+
+  async openSession(
+    input: OpenAgentToolsSessionInput<
+      SlackIntegrationConnection,
+      SlackAgentToolRequiredScope,
+      unknown
+    >,
+  ): Promise<AgentToolSession<SlackToolCallResult>> {
+    const token = await this.options.tokenStore.getAccessToken({connectionId: input.connection.id});
+
+    return {
+      call: async (call) => {
+        const tool = input.tools.find((candidate) => candidate.id === call.toolId);
+        if (!tool) return slackToolError(`Unknown Slack tool: ${call.toolId}`);
+        const method = slackToolMethod(tool.id);
+        if (!method) return slackToolError(`Unknown Slack tool method: ${tool.id}`);
+        const missingParameter = missingRequiredParameter(tool, call.arguments);
+        if (missingParameter) {
+          return slackToolError(`Missing required parameter: ${missingParameter}`);
+        }
+
+        let body: SlackWebApiResponse;
+        try {
+          body = await this.options.slack.callMethod({
+            method,
+            token,
+            arguments: call.arguments,
+          });
+        } catch (error) {
+          if (error instanceof SlackIntegrationProviderError) {
+            return slackToolError(error.message, {
+              code: error.reason,
+              retryAfterSeconds: error.retryAfterSeconds,
+            });
+          }
+          throw error;
+        }
+
+        if (body.ok) return slackToolResult(body);
+        const slackError = typeof body.error === 'string' ? body.error : 'Slack request failed';
+        if (isSlackAccessError(slackError)) {
+          logger().warn(
+            {connectionId: input.connection.id, slackError},
+            'Slack API rejected integration credentials',
+          );
+          return slackToolError(slackError, {code: 'access-denied'});
+        }
+        if (slackError === 'ratelimited') {
+          return slackToolError(slackError, {code: 'rate-limited'});
+        }
+        return slackToolError(slackError);
+      },
+      close: () => Promise.resolve(),
+    };
+  }
+}
+
+function slackToolMethod(toolId: string): string | undefined {
+  return SLACK_TOOL_METHODS[toolId as SlackAgentToolId];
+}
+
+function missingRequiredParameter(
+  tool: SlackAgentToolCatalogEntry,
+  args: Record<string, unknown>,
+): string | undefined {
+  const required = tool.inputSchema.required;
+  if (!Array.isArray(required)) return undefined;
+  return required.find((parameter) => typeof parameter === 'string' && !(parameter in args));
+}
+
+function isSlackAccessError(error: string): boolean {
+  return error === 'invalid_auth' || error === 'token_revoked' || error === 'account_inactive';
+}
+
+function slackToolResult(body: SlackWebApiResponse): SlackToolCallResult {
+  return {
+    content: [{type: 'text', text: JSON.stringify(body)}],
+    structuredContent: body,
+  };
+}
+
+function slackToolError(
+  message: string,
+  options: {code?: string | undefined; retryAfterSeconds?: number | undefined} = {},
+): SlackToolCallResult {
+  const structuredContent = {
+    ...(options.code === undefined ? {} : {code: options.code}),
+    ...(options.retryAfterSeconds === undefined
+      ? {}
+      : {retryAfterSeconds: options.retryAfterSeconds}),
+  };
+  return {
+    isError: true,
+    content: [{type: 'text', text: message}],
+    ...(Object.keys(structuredContent).length === 0 ? {} : {structuredContent}),
+  };
+}

--- a/libs/api/integration/slack/src/core/agent-tools.test.ts
+++ b/libs/api/integration/slack/src/core/agent-tools.test.ts
@@ -1,0 +1,90 @@
+import {
+  SLACK_TOOL_METHODS,
+  type SlackAgentToolId,
+  slackAgentToolCatalog,
+  slackAgentToolSelectionCatalog,
+} from './agent-tools.js';
+
+const expectedTools = [
+  {id: 'conversations_history', sensitivity: 'read', requiredScope: 'read'},
+  {id: 'conversations_replies', sensitivity: 'read', requiredScope: 'read'},
+  {id: 'conversations_list', sensitivity: 'read', requiredScope: 'read'},
+  {id: 'users_info', sensitivity: 'read', requiredScope: 'read'},
+  {id: 'chat_postMessage', sensitivity: 'write', requiredScope: 'write'},
+  {id: 'chat_update', sensitivity: 'write', requiredScope: 'write'},
+  {id: 'reactions_add', sensitivity: 'write', requiredScope: 'write'},
+] as const;
+
+describe('slackAgentToolCatalog', () => {
+  it('defines the seven Slack tools with their access requirements', () => {
+    const tools = slackAgentToolCatalog.map(({id, sensitivity, requiredScope, sensitive}) => ({
+      id,
+      sensitivity,
+      requiredScope,
+      sensitive,
+    }));
+
+    expect(tools).toEqual(expectedTools.map((tool) => ({...tool, sensitive: false})));
+  });
+
+  it('documents every tool with an object input schema', () => {
+    const schemas = slackAgentToolCatalog.map(({description, inputSchema}) => ({
+      description,
+      type: inputSchema.type,
+    }));
+
+    expect(schemas).toHaveLength(7);
+    expect(
+      schemas.every(({description, type}) => description.length > 0 && type === 'object'),
+    ).toBe(true);
+  });
+
+  it('models Block Kit messages and Slack scalar parameters without narrowing valid calls', () => {
+    const postMessage = slackAgentToolCatalog.find(({id}) => id === 'chat_postMessage');
+    const listConversations = slackAgentToolCatalog.find(({id}) => id === 'conversations_list');
+    const history = slackAgentToolCatalog.find(({id}) => id === 'conversations_history');
+
+    expect(postMessage?.inputSchema).toMatchObject({
+      required: ['channel'],
+      properties: {
+        blocks: {type: 'array', items: {type: 'object'}},
+        thread_ts: {type: 'string'},
+      },
+    });
+    expect(listConversations?.inputSchema).toMatchObject({
+      properties: {types: {type: 'string'}, limit: {type: 'number'}},
+    });
+    expect(history?.inputSchema).toMatchObject({
+      properties: {oldest: {type: 'string'}, latest: {type: 'string'}},
+    });
+  });
+
+  it('maps every tool id to its dotted Slack Web API method', () => {
+    const methods = Object.fromEntries(
+      slackAgentToolCatalog.map(({id}) => [id, SLACK_TOOL_METHODS[id as SlackAgentToolId]]),
+    );
+
+    expect(methods).toEqual({
+      conversations_history: 'conversations.history',
+      conversations_replies: 'conversations.replies',
+      conversations_list: 'conversations.list',
+      users_info: 'users.info',
+      chat_postMessage: 'chat.postMessage',
+      chat_update: 'chat.update',
+      reactions_add: 'reactions.add',
+    });
+  });
+
+  it('exposes one standalone selector per tool with matching sensitivity', () => {
+    const selectors = slackAgentToolSelectionCatalog.selectors;
+
+    expect(selectors).toEqual(
+      expectedTools.map(({id, sensitivity}) => ({
+        token: id,
+        kind: 'standalone',
+        sensitivity,
+        sensitive: false,
+      })),
+    );
+  });
+});

--- a/libs/api/integration/slack/src/core/agent-tools.ts
+++ b/libs/api/integration/slack/src/core/agent-tools.ts
@@ -1,0 +1,189 @@
+import type {
+  AgentToolCatalogEntry,
+  AgentToolJsonSchema,
+  AgentToolSelectionCatalog,
+  AgentToolSelector,
+} from '@shipfox/api-integration-core-dto';
+
+export type SlackAgentToolRequiredScope = 'read' | 'write';
+export type SlackAgentToolCatalogEntry = AgentToolCatalogEntry<SlackAgentToolRequiredScope>;
+
+interface SlackAgentToolCatalogInput {
+  id: string;
+  description: string;
+  sensitivity: 'read' | 'write';
+  sensitive: boolean;
+  requiredScope: SlackAgentToolRequiredScope;
+  inputSchema: AgentToolJsonSchema;
+}
+
+const channelSchema = stringSchema('Slack channel ID');
+const cursorSchema = stringSchema('Next page cursor');
+const limitSchema = numberSchema('Maximum number of results to return');
+
+export const slackAgentToolCatalog = [
+  tool({
+    id: 'conversations_history',
+    description: 'List messages in a Slack channel or direct message.',
+    sensitivity: 'read',
+    sensitive: false,
+    requiredScope: 'read',
+    inputSchema: objectSchema(
+      {
+        channel: channelSchema,
+        cursor: cursorSchema,
+        limit: limitSchema,
+        oldest: stringSchema('Only messages after this Slack timestamp'),
+        latest: stringSchema('Only messages before this Slack timestamp'),
+        inclusive: booleanSchema('Include messages at the oldest or latest timestamp'),
+      },
+      ['channel'],
+    ),
+  }),
+  tool({
+    id: 'conversations_replies',
+    description: 'List replies in a Slack message thread.',
+    sensitivity: 'read',
+    sensitive: false,
+    requiredScope: 'read',
+    inputSchema: objectSchema(
+      {
+        channel: channelSchema,
+        ts: stringSchema('Slack timestamp of the parent message'),
+        cursor: cursorSchema,
+        limit: limitSchema,
+      },
+      ['channel', 'ts'],
+    ),
+  }),
+  tool({
+    id: 'conversations_list',
+    description: 'List Slack channels visible to the bot.',
+    sensitivity: 'read',
+    sensitive: false,
+    requiredScope: 'read',
+    inputSchema: objectSchema({
+      cursor: cursorSchema,
+      limit: limitSchema,
+      types: stringSchema('Comma-separated channel types, such as public_channel,private_channel'),
+      exclude_archived: booleanSchema('Exclude archived channels'),
+    }),
+  }),
+  tool({
+    id: 'users_info',
+    description: 'Look up a Slack user and profile by user ID.',
+    sensitivity: 'read',
+    sensitive: false,
+    requiredScope: 'read',
+    inputSchema: objectSchema({user: stringSchema('Slack user ID')}, ['user']),
+  }),
+  tool({
+    id: 'chat_postMessage',
+    description: 'Post a Slack message to a channel or thread. Provide text, blocks, or both.',
+    sensitivity: 'write',
+    sensitive: false,
+    requiredScope: 'write',
+    inputSchema: objectSchema(
+      {
+        channel: channelSchema,
+        text: stringSchema('Message text'),
+        thread_ts: stringSchema('Slack timestamp of the parent message when replying in a thread'),
+        blocks: arraySchema({type: 'object'}),
+      },
+      ['channel'],
+    ),
+  }),
+  tool({
+    id: 'chat_update',
+    description: 'Update a Slack message with text, blocks, or both.',
+    sensitivity: 'write',
+    sensitive: false,
+    requiredScope: 'write',
+    inputSchema: objectSchema(
+      {
+        channel: channelSchema,
+        ts: stringSchema('Slack timestamp of the message to update'),
+        text: stringSchema('Updated message text'),
+        blocks: arraySchema({type: 'object'}),
+      },
+      ['channel', 'ts'],
+    ),
+  }),
+  tool({
+    id: 'reactions_add',
+    description: 'Add an emoji reaction to a Slack message.',
+    sensitivity: 'write',
+    sensitive: false,
+    requiredScope: 'write',
+    inputSchema: objectSchema(
+      {
+        channel: channelSchema,
+        timestamp: stringSchema('Slack timestamp of the message'),
+        name: stringSchema('Emoji name without surrounding colons'),
+      },
+      ['channel', 'timestamp', 'name'],
+    ),
+  }),
+] as const satisfies readonly SlackAgentToolCatalogEntry[];
+
+export type SlackAgentToolId = (typeof slackAgentToolCatalog)[number]['id'];
+
+export const SLACK_TOOL_METHODS = {
+  conversations_history: 'conversations.history',
+  conversations_replies: 'conversations.replies',
+  conversations_list: 'conversations.list',
+  users_info: 'users.info',
+  chat_postMessage: 'chat.postMessage',
+  chat_update: 'chat.update',
+  reactions_add: 'reactions.add',
+} as const satisfies Record<SlackAgentToolId, string>;
+
+export const slackAgentToolSelectionCatalog =
+  buildSlackAgentToolSelectionCatalog(slackAgentToolCatalog);
+
+function buildSlackAgentToolSelectionCatalog(
+  catalog: readonly SlackAgentToolCatalogEntry[],
+): AgentToolSelectionCatalog {
+  return {
+    selectors: catalog.map(
+      (entry): AgentToolSelector => ({
+        token: entry.id,
+        kind: 'standalone',
+        sensitivity: entry.sensitivity,
+        sensitive: entry.sensitive,
+      }),
+    ),
+  };
+}
+
+function tool<const Entry extends SlackAgentToolCatalogInput>(input: Entry): Entry {
+  return input;
+}
+
+function objectSchema(
+  properties: Record<string, AgentToolJsonSchema>,
+  required: string[] = [],
+): AgentToolJsonSchema {
+  return {
+    type: 'object',
+    additionalProperties: false,
+    properties,
+    ...(required.length > 0 ? {required} : {}),
+  };
+}
+
+function stringSchema(description?: string): AgentToolJsonSchema {
+  return {type: 'string', ...(description ? {description} : {})};
+}
+
+function numberSchema(description?: string): AgentToolJsonSchema {
+  return {type: 'number', ...(description ? {description} : {})};
+}
+
+function booleanSchema(description: string): AgentToolJsonSchema {
+  return {type: 'boolean', description};
+}
+
+function arraySchema(items: AgentToolJsonSchema): AgentToolJsonSchema {
+  return {type: 'array', items};
+}

--- a/libs/api/integration/slack/src/core/install.test.ts
+++ b/libs/api/integration/slack/src/core/install.test.ts
@@ -50,6 +50,7 @@ function callbackParams(
   const slack: SlackApiClient = {
     exchangeAuthorizationCode: vi.fn(() => Promise.resolve(authorization())),
     revokeToken: vi.fn(() => Promise.resolve()),
+    callMethod: vi.fn(() => Promise.resolve({ok: true})),
   };
   return {
     slack,
@@ -101,6 +102,7 @@ describe('handleSlackCallback', () => {
         Promise.resolve(authorization({scopes: ['chat:write']})),
       ),
       revokeToken: vi.fn(() => Promise.resolve()),
+      callMethod: vi.fn(() => Promise.resolve({ok: true})),
     };
     const params = callbackParams({slack});
 

--- a/libs/api/integration/slack/src/index.test.ts
+++ b/libs/api/integration/slack/src/index.test.ts
@@ -1,4 +1,4 @@
-import {createSlackIntegrationProvider} from '#index.js';
+import {createSlackIntegrationProvider, slackAgentToolCatalog} from '#index.js';
 
 describe('createSlackIntegrationProvider', () => {
   it('does not mount webhook routes without route options', () => {
@@ -11,5 +11,15 @@ describe('createSlackIntegrationProvider', () => {
     expect(() => createSlackIntegrationProvider({routes: {}})).toThrow(
       'Slack webhook routes require every core persistence dependency',
     );
+  });
+
+  it('exposes the Slack agent-tools adapter when token access is configured', () => {
+    const provider = createSlackIntegrationProvider({
+      agentTools: {tokenStore: {getAccessToken: async () => 'xoxb-token'}},
+    });
+
+    const catalog = provider.adapters.agent_tools?.catalog();
+
+    expect(catalog).toBe(slackAgentToolCatalog);
   });
 });

--- a/libs/api/integration/slack/src/index.ts
+++ b/libs/api/integration/slack/src/index.ts
@@ -2,6 +2,8 @@ import {SLACK_PROVIDER} from '@shipfox/api-integration-slack-dto';
 import type {RouteGroup} from '@shipfox/node-fastify';
 import {createSlackApiClient, type SlackApiClient} from '#api/client.js';
 import {config} from '#config.js';
+import {SlackAgentToolsProvider} from '#core/agent-tools-provider.js';
+import type {SlackTokenStore} from '#core/tokens.js';
 import {closeDb, db} from '#db/db.js';
 import {getSlackInstallationByConnectionId} from '#db/installations.js';
 import {migrationsPath} from '#db/migrations.js';
@@ -22,8 +24,23 @@ type SlackRouteOptions = Partial<SlackInstallationRouteOptions> &
   Partial<CreateSlackWebhookRoutesOptions>;
 
 export type {SlackProvider} from '@shipfox/api-integration-slack-dto';
-export type {SlackApiClient, SlackAuthorization} from '#api/client.js';
+export type {SlackApiClient, SlackAuthorization, SlackWebApiResponse} from '#api/client.js';
 export {createSlackApiClient} from '#api/client.js';
+export type {
+  SlackAgentToolCatalogEntry,
+  SlackAgentToolId,
+  SlackAgentToolRequiredScope,
+} from '#core/agent-tools.js';
+export {
+  SLACK_TOOL_METHODS,
+  slackAgentToolCatalog,
+  slackAgentToolSelectionCatalog,
+} from '#core/agent-tools.js';
+export type {
+  SlackAgentToolsProviderOptions,
+  SlackToolCallResult,
+} from '#core/agent-tools-provider.js';
+export {SlackAgentToolsProvider} from '#core/agent-tools-provider.js';
 export {
   type DisconnectSlackInstallationParams,
   disconnectSlackInstallation,
@@ -94,6 +111,7 @@ export {closeDb, config, db, migrationsPath};
 
 export interface CreateSlackIntegrationProviderOptions {
   slack?: SlackApiClient | undefined;
+  agentTools?: {tokenStore: Pick<SlackTokenStore, 'getAccessToken'>} | undefined;
   getSlackInstallationByConnectionId?: typeof getSlackInstallationByConnectionId | undefined;
   routes?: SlackRouteOptions | undefined;
 }
@@ -104,6 +122,14 @@ export function createSlackIntegrationProvider(
   const slack = options.slack ?? createSlackApiClient();
   const getInstallationByConnectionId =
     options.getSlackInstallationByConnectionId ?? getSlackInstallationByConnectionId;
+  const adapters = options.agentTools
+    ? {
+        agent_tools: new SlackAgentToolsProvider({
+          slack,
+          tokenStore: options.agentTools.tokenStore,
+        }),
+      }
+    : {};
   if (
     options.routes &&
     !hasSlackInstallationRoutesOptions(options.routes) &&
@@ -122,7 +148,7 @@ export function createSlackIntegrationProvider(
     routes.push(
       createSlackIntegrationRoutes({
         slack,
-        connectionCapabilities: [],
+        connectionCapabilities: adapters.agent_tools ? ['agent_tools'] : [],
         tokenStore,
         getExistingSlackConnection,
         connectSlackInstallation,
@@ -137,7 +163,7 @@ export function createSlackIntegrationProvider(
   return {
     provider: SLACK_PROVIDER,
     displayName: 'Slack',
-    adapters: {},
+    adapters,
     async connectionExternalUrl(connection: {id: string}): Promise<string | undefined> {
       const installation = await getInstallationByConnectionId(connection.id);
       if (!installation) return undefined;

--- a/libs/api/integration/slack/src/presentation/routes/install.test.ts
+++ b/libs/api/integration/slack/src/presentation/routes/install.test.ts
@@ -63,6 +63,7 @@ function slackClient(overrides: Partial<SlackApiClient> = {}): SlackApiClient {
       }),
     ),
     revokeToken: vi.fn(() => Promise.resolve()),
+    callMethod: vi.fn(() => Promise.resolve({ok: true})),
     ...overrides,
   };
 }
@@ -86,6 +87,7 @@ async function createTestApp(
   options: {
     slack?: SlackApiClient | undefined;
     tokenStore?: Pick<SlackTokenStore, 'storeTokens'> | undefined;
+    agentTools?: {tokenStore: Pick<SlackTokenStore, 'getAccessToken'>} | undefined;
     connectSlackInstallation?:
       | ((input: ConnectSlackInstallationInput) => Promise<IntegrationConnection<'slack'>>)
       | undefined;
@@ -93,6 +95,7 @@ async function createTestApp(
 ): Promise<FastifyInstance> {
   const provider = createSlackIntegrationProvider({
     slack: options.slack ?? slackClient(),
+    agentTools: options.agentTools,
     routes: {
       tokenStore: options.tokenStore ?? {storeTokens: vi.fn(() => Promise.resolve())},
       getExistingSlackConnection: vi.fn(() => Promise.resolve(undefined)),
@@ -153,9 +156,23 @@ describe('Slack integration routes', () => {
     expect(res.statusCode).toBe(403);
   });
 
-  it('returns the connected Slack connection after a verified callback', async () => {
+  it.each([
+    {
+      capability: 'without agent tools',
+      agentTools: undefined,
+      expectedCapabilities: [],
+    },
+    {
+      capability: 'with agent tools',
+      agentTools: {tokenStore: {getAccessToken: vi.fn(() => Promise.resolve('xoxb-token'))}},
+      expectedCapabilities: ['agent_tools'],
+    },
+  ])('returns the connected Slack connection $capability', async ({
+    agentTools,
+    expectedCapabilities,
+  }) => {
     const tokenStore = {storeTokens: vi.fn(() => Promise.resolve())};
-    const app = await createTestApp({tokenStore});
+    const app = await createTestApp({tokenStore, agentTools});
     const workspaceId = '00000000-0000-4000-8000-000000000002';
     authenticatedMemberships = [{workspaceId, role: 'admin'}];
     const install = await app.inject({
@@ -173,7 +190,7 @@ describe('Slack integration routes', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toMatchObject({provider: 'slack', capabilities: []});
+    expect(res.json()).toMatchObject({provider: 'slack', capabilities: expectedCapabilities});
     expect(tokenStore.storeTokens).toHaveBeenCalledWith({
       connectionId: '00000000-0000-4000-8000-000000000001',
       botToken: 'xoxb-token',


### PR DESCRIPTION
Add an in-process Slack agent-tools adapter that exposes a curated Web API catalog through the lease-authenticated integration gateway.

Slack has no hosted MCP server, so agent steps could receive Slack events but could not read threads or reply through the existing tools path. The adapter resolves the connection bot token server-side, dispatches only authorized catalog methods, and preserves Slack error and retry details without exposing credentials to runners.

The provider now advertises `agent_tools` in install and E2E connection DTOs, with focused coverage for catalog selection, form serialization, capability wiring, and result/error mapping.

The transport intentionally uses form encoding for the Slack Web API rather than adding `@slack/web-api`, keeping the existing client seam and dependency surface.

Closes ENG-929