### PR TITLE
[provisioner/ec2] Add EC2 provider engine wrapper

### DIFF
--- a/libs/provisioner/ec2/package.json
+++ b/libs/provisioner/ec2/package.json
@@ -37,6 +37,7 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
+    "@aws-sdk/client-ec2": "catalog:",
     "@shipfox/config": "workspace:*",
     "@shipfox/provisioner-core": "workspace:*",
     "@shipfox/runner-labels": "workspace:*",

--- a/libs/provisioner/ec2/src/ec2-engine.test.ts
+++ b/libs/provisioner/ec2/src/ec2-engine.test.ts
@@ -1,0 +1,330 @@
+import {
+  DescribeInstancesCommand,
+  RunInstancesCommand,
+  TerminateInstancesCommand,
+} from '@aws-sdk/client-ec2';
+import {createEc2Engine, type RunInstanceArgs} from '#ec2-engine.js';
+import {SHIPFOX_TAGS} from '#instance-identity.js';
+
+const runArgs: RunInstanceArgs = {
+  clientToken: 'runner-1',
+  tags: {
+    [SHIPFOX_TAGS.provisionedRunnerId]: 'runner-1',
+    [SHIPFOX_TAGS.provisionerId]: 'provisioner-1',
+    Name: 'runner-1',
+  },
+  ami: 'ami-0123456789abcdef0',
+  instanceType: 'm6i.large',
+  market: 'on-demand',
+  spotMaxPrice: null,
+  subnetId: 'subnet-a',
+  securityGroupIds: ['sg-a'],
+  associatePublicIp: false,
+  rootVolumeGb: 100,
+  rootDeviceName: '/dev/sda1',
+  userData: '#cloud-config',
+};
+
+describe('createEc2Engine', () => {
+  it('runs one atomically tagged instance with launch settings', async () => {
+    const ec2 = fakeEc2();
+    const engine = createEc2Engine({region: 'eu-west-3', client: ec2 as never});
+    const expectedTags = Object.entries(runArgs.tags).map(([Key, Value]) => ({Key, Value}));
+
+    await engine.runInstance({...runArgs, iamInstanceProfile: 'runner-profile'});
+
+    expect(commandInput<RunInstancesCommand>(ec2.commands[0])).toMatchObject({
+      MinCount: 1,
+      MaxCount: 1,
+      ClientToken: 'runner-1',
+      ImageId: runArgs.ami,
+      InstanceType: runArgs.instanceType,
+      InstanceInitiatedShutdownBehavior: 'terminate',
+      IamInstanceProfile: {Name: 'runner-profile'},
+      UserData: Buffer.from('#cloud-config').toString('base64'),
+      TagSpecifications: [
+        {
+          ResourceType: 'instance',
+          Tags: expectedTags,
+        },
+        {ResourceType: 'volume', Tags: expectedTags},
+      ],
+      NetworkInterfaces: [
+        {
+          DeviceIndex: 0,
+          SubnetId: 'subnet-a',
+          Groups: ['sg-a'],
+          AssociatePublicIpAddress: false,
+          DeleteOnTermination: true,
+        },
+      ],
+      BlockDeviceMappings: [
+        {
+          DeviceName: '/dev/sda1',
+          Ebs: {VolumeSize: 100, VolumeType: 'gp3', DeleteOnTermination: true},
+        },
+      ],
+    });
+  });
+
+  it('omits an absent IAM instance profile', async () => {
+    const ec2 = fakeEc2();
+    const engine = createEc2Engine({region: 'eu-west-3', client: ec2 as never});
+
+    await engine.runInstance(runArgs);
+
+    expect(commandInput<RunInstancesCommand>(ec2.commands[0])).not.toHaveProperty(
+      'IamInstanceProfile',
+    );
+  });
+
+  it.each([true, false])('passes associatePublicIp=%s to the network interface', async (value) => {
+    const ec2 = fakeEc2();
+    const engine = createEc2Engine({region: 'eu-west-3', client: ec2 as never});
+
+    await engine.runInstance({...runArgs, associatePublicIp: value});
+
+    expect(commandInput<RunInstancesCommand>(ec2.commands[0]).NetworkInterfaces?.[0]).toMatchObject(
+      {
+        AssociatePublicIpAddress: value,
+      },
+    );
+  });
+
+  it('uses no market options for on-demand capacity', async () => {
+    const ec2 = fakeEc2();
+    const engine = createEc2Engine({region: 'eu-west-3', client: ec2 as never});
+
+    await engine.runInstance(runArgs);
+
+    expect(commandInput<RunInstancesCommand>(ec2.commands[0])).not.toHaveProperty(
+      'InstanceMarketOptions',
+    );
+  });
+
+  it('uses one-time Spot capacity with optional max price', async () => {
+    const ec2 = fakeEc2();
+    const engine = createEc2Engine({region: 'eu-west-3', client: ec2 as never});
+
+    await engine.runInstance({...runArgs, market: 'spot', spotMaxPrice: 0.05});
+
+    expect(commandInput<RunInstancesCommand>(ec2.commands[0]).InstanceMarketOptions).toEqual({
+      MarketType: 'spot',
+      SpotOptions: {
+        SpotInstanceType: 'one-time',
+        InstanceInterruptionBehavior: 'terminate',
+        MaxPrice: '0.05',
+      },
+    });
+  });
+
+  it('omits a Spot max price when no cap is configured', async () => {
+    const ec2 = fakeEc2();
+    const engine = createEc2Engine({region: 'eu-west-3', client: ec2 as never});
+
+    await engine.runInstance({...runArgs, market: 'spot'});
+
+    expect(commandInput<RunInstancesCommand>(ec2.commands[0]).InstanceMarketOptions).toEqual({
+      MarketType: 'spot',
+      SpotOptions: {SpotInstanceType: 'one-time', InstanceInterruptionBehavior: 'terminate'},
+    });
+  });
+
+  it('maps the launched EC2 instance', async () => {
+    const ec2 = fakeEc2({runOutput: {Instances: [instance({State: {Name: 'pending'}})]}});
+    const engine = createEc2Engine({region: 'eu-west-3', client: ec2 as never});
+
+    const result = await engine.runInstance(runArgs);
+
+    expect(result).toEqual({
+      instanceId: 'i-123',
+      tags: {Name: 'runner-1'},
+      state: 'pending',
+      launchTime: new Date('2026-07-18T12:00:00.000Z'),
+    });
+  });
+
+  it.each([
+    ['InsufficientInstanceCapacity', 'insufficient-capacity', true],
+    ['SpotMaxPriceTooLow', 'spot-price-too-low', true],
+    ['RequestLimitExceeded', 'throttled', true],
+    ['InvalidAMIID.NotFound', 'image-not-found', false],
+    ['AuthFailure', 'auth', false],
+    ['InvalidParameterValue', 'config-invalid', false],
+    ['ECONNREFUSED', 'unreachable', true],
+    ['UnexpectedFailure', 'unknown', false],
+  ])('classifies %s as %s', async (code, reason, retryable) => {
+    const error = awsError(code);
+    const ec2 = fakeEc2({runError: error});
+    const engine = createEc2Engine({region: 'eu-west-3', client: ec2 as never});
+
+    await expect(engine.runInstance(runArgs)).rejects.toMatchObject({reason, retryable});
+  });
+
+  it('paginates managed instances and surfaces termination reasons', async () => {
+    const ec2 = fakeEc2({
+      describeOutputs: [
+        {
+          Reservations: [
+            {
+              Instances: [
+                instance({
+                  State: {Name: 'terminated'},
+                  StateTransitionReason: 'User initiated (2026-07-18 12:01:00 GMT)',
+                  StateReason: {
+                    Code: 'Server.SpotInstanceTermination',
+                    Message: 'Spot capacity reclaimed',
+                  },
+                }),
+              ],
+            },
+          ],
+          NextToken: 'next-page',
+        },
+        {Reservations: [{Instances: [instance({InstanceId: 'i-456'})]}]},
+      ],
+    });
+    const engine = createEc2Engine({region: 'eu-west-3', client: ec2 as never});
+
+    const result = await engine.listManaged('provisioner-1');
+
+    expect(commandInput<DescribeInstancesCommand>(ec2.commands[0])).toEqual({
+      Filters: [{Name: `tag:${SHIPFOX_TAGS.provisionerId}`, Values: ['provisioner-1']}],
+      NextToken: undefined,
+    });
+    expect(commandInput<DescribeInstancesCommand>(ec2.commands[1]).NextToken).toBe('next-page');
+    expect(result[0]).toMatchObject({
+      instanceId: 'i-123',
+      state: 'terminated',
+      stateTransitionReason: 'User initiated (2026-07-18 12:01:00 GMT)',
+      stateReasonCode: 'Server.SpotInstanceTermination',
+      stateReasonMessage: 'Spot capacity reclaimed',
+    });
+    expect(result[1]?.instanceId).toBe('i-456');
+  });
+
+  it.each([
+    ['pending', 'pending'],
+    ['running', 'running'],
+    ['shutting-down', 'shutting-down'],
+    ['stopping', 'stopping'],
+    ['stopped', 'stopped'],
+    ['terminated', 'terminated'],
+    ['unrecognized', 'unknown'],
+  ])('maps the %s EC2 state to %s', async (state, expected) => {
+    const ec2 = fakeEc2({
+      describeOutputs: [{Reservations: [{Instances: [instance({State: {Name: state}})]}]}],
+    });
+    const engine = createEc2Engine({region: 'eu-west-3', client: ec2 as never});
+
+    const result = await engine.listManaged('provisioner-1');
+
+    expect(result[0]?.state).toBe(expected);
+  });
+
+  it('returns no managed instances when EC2 has no reservations', async () => {
+    const ec2 = fakeEc2({describeOutputs: [{}]});
+    const engine = createEc2Engine({region: 'eu-west-3', client: ec2 as never});
+
+    const result = await engine.listManaged('provisioner-1');
+
+    expect(result).toEqual([]);
+  });
+
+  it('terminates the requested instances', async () => {
+    const ec2 = fakeEc2();
+    const engine = createEc2Engine({region: 'eu-west-3', client: ec2 as never});
+
+    await engine.terminate(['i-123', 'i-456']);
+
+    expect(ec2.commands.map(commandInput<TerminateInstancesCommand>)).toEqual([
+      {InstanceIds: ['i-123']},
+      {InstanceIds: ['i-456']},
+    ]);
+  });
+
+  it('does not call EC2 to terminate an empty set', async () => {
+    const ec2 = fakeEc2();
+    const engine = createEc2Engine({region: 'eu-west-3', client: ec2 as never});
+
+    await engine.terminate([]);
+
+    expect(ec2.commands).toEqual([]);
+  });
+
+  it('treats absent EC2 instances as already terminated', async () => {
+    const ec2 = fakeEc2({terminateError: awsError('InvalidInstanceID.NotFound')});
+    const engine = createEc2Engine({region: 'eu-west-3', client: ec2 as never});
+
+    await expect(engine.terminate(['i-missing'])).resolves.toBeUndefined();
+  });
+
+  it('continues terminating present instances when one is already absent', async () => {
+    const ec2 = fakeEc2({
+      terminateErrorById: new Map([['i-gone', awsError('InvalidInstanceID.NotFound')]]),
+    });
+    const engine = createEc2Engine({region: 'eu-west-3', client: ec2 as never});
+
+    await engine.terminate(['i-gone', 'i-live']);
+
+    expect(ec2.commands.map(commandInput<TerminateInstancesCommand>)).toEqual([
+      {InstanceIds: ['i-gone']},
+      {InstanceIds: ['i-live']},
+    ]);
+  });
+});
+
+function fakeEc2(
+  options: {
+    runOutput?: unknown;
+    runError?: Error;
+    describeOutputs?: unknown[];
+    terminateError?: Error;
+    terminateErrorById?: Map<string, Error>;
+  } = {},
+) {
+  const commands: unknown[] = [];
+  const describeOutputs = [...(options.describeOutputs ?? [])];
+
+  return {
+    commands,
+    send(command: unknown) {
+      commands.push(command);
+      if (command instanceof RunInstancesCommand) {
+        if (options.runError) return Promise.reject(options.runError);
+        return Promise.resolve(options.runOutput ?? {Instances: [instance()]});
+      }
+      if (command instanceof DescribeInstancesCommand)
+        return Promise.resolve(describeOutputs.shift() ?? {});
+      if (command instanceof TerminateInstancesCommand) {
+        const instanceId = command.input.InstanceIds?.[0];
+        const terminateError =
+          options.terminateErrorById?.get(instanceId ?? '') ?? options.terminateError;
+        if (terminateError) return Promise.reject(terminateError);
+        return Promise.resolve({});
+      }
+      return Promise.reject(new Error('Unexpected EC2 command'));
+    },
+  };
+}
+
+function commandInput<T extends {input: unknown}>(command: unknown): T['input'] {
+  return (command as T).input;
+}
+
+function instance(overrides: Record<string, unknown> = {}) {
+  return {
+    InstanceId: 'i-123',
+    Tags: [{Key: 'Name', Value: 'runner-1'}],
+    State: {Name: 'running'},
+    LaunchTime: new Date('2026-07-18T12:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function awsError(name: string): Error {
+  const error = new Error(name);
+  error.name = name;
+  if (name === 'ECONNREFUSED') Object.assign(error, {code: name});
+  return error;
+}

--- a/libs/provisioner/ec2/src/ec2-engine.ts
+++ b/libs/provisioner/ec2/src/ec2-engine.ts
@@ -1,0 +1,284 @@
+import {
+  DescribeInstancesCommand,
+  EC2Client,
+  type Instance,
+  RunInstancesCommand,
+  type RunInstancesCommandInput,
+  TerminateInstancesCommand,
+} from '@aws-sdk/client-ec2';
+import {SHIPFOX_TAGS} from '#instance-identity.js';
+import type {Ec2Market} from '#templates.js';
+
+const TRANSIENT_REASONS = new Set<Ec2EngineErrorReason>([
+  'insufficient-capacity',
+  'spot-price-too-low',
+  'throttled',
+  'unreachable',
+]);
+
+export type Ec2EngineErrorReason =
+  | 'insufficient-capacity'
+  | 'spot-price-too-low'
+  | 'throttled'
+  | 'image-not-found'
+  | 'auth'
+  | 'config-invalid'
+  | 'unreachable'
+  | 'unknown';
+
+export class Ec2EngineError extends Error {
+  public readonly retryable: boolean;
+
+  constructor(
+    public readonly reason: Ec2EngineErrorReason,
+    message: string,
+    options?: {cause?: unknown},
+  ) {
+    super(message, options);
+    this.name = 'Ec2EngineError';
+    this.retryable = TRANSIENT_REASONS.has(reason);
+  }
+}
+
+export type Ec2InstanceState =
+  | 'pending'
+  | 'running'
+  | 'shutting-down'
+  | 'stopping'
+  | 'stopped'
+  | 'terminated'
+  | 'unknown';
+
+export interface Ec2InstanceView {
+  readonly instanceId: string;
+  readonly tags: Readonly<Record<string, string>>;
+  readonly state: Ec2InstanceState;
+  readonly stateTransitionReason?: string;
+  readonly stateReasonCode?: string;
+  readonly stateReasonMessage?: string;
+  readonly launchTime?: Date;
+}
+
+export interface RunInstanceArgs {
+  readonly clientToken: string;
+  readonly tags: Readonly<Record<string, string>>;
+  readonly ami: string;
+  readonly instanceType: string;
+  readonly market: Ec2Market;
+  readonly spotMaxPrice: number | null;
+  readonly subnetId: string;
+  readonly securityGroupIds: readonly string[];
+  readonly iamInstanceProfile?: string;
+  readonly associatePublicIp: boolean;
+  readonly rootVolumeGb: number;
+  readonly rootDeviceName: string;
+  readonly userData?: string;
+}
+
+export interface Ec2Engine {
+  runInstance(args: RunInstanceArgs): Promise<Ec2InstanceView>;
+  listManaged(provisionerId: string): Promise<Ec2InstanceView[]>;
+  terminate(instanceIds: readonly string[]): Promise<void>;
+}
+
+export interface CreateEc2EngineOptions {
+  readonly region: string;
+  readonly client?: EC2Client;
+}
+
+export function createEc2Engine(options: CreateEc2EngineOptions): Ec2Engine {
+  const client = options.client ?? new EC2Client({region: options.region});
+
+  return {
+    async runInstance(args) {
+      try {
+        const output = await client.send(
+          new RunInstancesCommand({
+            MinCount: 1,
+            MaxCount: 1,
+            ClientToken: args.clientToken,
+            ImageId: args.ami,
+            InstanceType: args.instanceType as RunInstancesCommandInput['InstanceType'],
+            TagSpecifications: (['instance', 'volume'] as const).map((ResourceType) => ({
+              ResourceType,
+              Tags: Object.entries(args.tags).map(([Key, Value]) => ({Key, Value})),
+            })),
+            InstanceInitiatedShutdownBehavior: 'terminate',
+            // A network interface is required for AssociatePublicIpAddress to work consistently.
+            NetworkInterfaces: [
+              {
+                DeviceIndex: 0,
+                SubnetId: args.subnetId,
+                Groups: [...args.securityGroupIds],
+                AssociatePublicIpAddress: args.associatePublicIp,
+                DeleteOnTermination: true,
+              },
+            ],
+            // A mismatched root device silently adds a volume and ignores the requested size.
+            BlockDeviceMappings: [
+              {
+                DeviceName: args.rootDeviceName,
+                Ebs: {
+                  VolumeSize: args.rootVolumeGb,
+                  VolumeType: 'gp3',
+                  DeleteOnTermination: true,
+                },
+              },
+            ],
+            ...(args.iamInstanceProfile
+              ? {IamInstanceProfile: {Name: args.iamInstanceProfile}}
+              : {}),
+            ...(args.market === 'spot'
+              ? {
+                  InstanceMarketOptions: {
+                    MarketType: 'spot' as const,
+                    SpotOptions: {
+                      SpotInstanceType: 'one-time' as const,
+                      InstanceInterruptionBehavior: 'terminate' as const,
+                      ...(args.spotMaxPrice != null ? {MaxPrice: String(args.spotMaxPrice)} : {}),
+                    },
+                  },
+                }
+              : {}),
+            ...(args.userData ? {UserData: Buffer.from(args.userData).toString('base64')} : {}),
+          }),
+        );
+        const instance = output.Instances?.[0];
+        if (!instance)
+          throw new Ec2EngineError('unknown', 'EC2 did not return a launched instance.');
+        return toInstanceView(instance);
+      } catch (error) {
+        throw mapEc2Error(error, 'Cannot launch EC2 runner instance.');
+      }
+    },
+
+    async listManaged(provisionerId) {
+      try {
+        const instances: Ec2InstanceView[] = [];
+        let nextToken: string | undefined;
+
+        do {
+          const output = await client.send(
+            new DescribeInstancesCommand({
+              NextToken: nextToken,
+              Filters: [{Name: `tag:${SHIPFOX_TAGS.provisionerId}`, Values: [provisionerId]}],
+            }),
+          );
+          for (const reservation of output.Reservations ?? []) {
+            for (const instance of reservation.Instances ?? [])
+              instances.push(toInstanceView(instance));
+          }
+          nextToken = output.NextToken;
+        } while (nextToken);
+
+        return instances;
+      } catch (error) {
+        throw mapEc2Error(error, 'Cannot list managed EC2 instances.');
+      }
+    },
+
+    async terminate(instanceIds) {
+      if (instanceIds.length === 0) return;
+
+      for (const instanceId of instanceIds) {
+        try {
+          await client.send(new TerminateInstancesCommand({InstanceIds: [instanceId]}));
+        } catch (error) {
+          if (errorName(error) === 'InvalidInstanceID.NotFound') continue;
+          throw mapEc2Error(error, 'Cannot terminate EC2 runner instance.');
+        }
+      }
+    },
+  };
+}
+
+function toInstanceView(instance: Instance): Ec2InstanceView {
+  if (!instance.InstanceId) throw new Ec2EngineError('unknown', 'EC2 instance has no instance id.');
+
+  return {
+    instanceId: instance.InstanceId,
+    tags: Object.fromEntries(
+      (instance.Tags ?? []).flatMap(({Key, Value}) =>
+        Key !== undefined && Value !== undefined ? [[Key, Value]] : [],
+      ),
+    ),
+    state: normalizeState(instance.State?.Name),
+    ...(instance.StateTransitionReason
+      ? {stateTransitionReason: instance.StateTransitionReason}
+      : {}),
+    ...(instance.StateReason?.Code ? {stateReasonCode: instance.StateReason.Code} : {}),
+    ...(instance.StateReason?.Message ? {stateReasonMessage: instance.StateReason.Message} : {}),
+    ...(instance.LaunchTime ? {launchTime: instance.LaunchTime} : {}),
+  };
+}
+
+function normalizeState(state: string | undefined): Ec2InstanceState {
+  switch (state) {
+    case 'pending':
+    case 'running':
+    case 'shutting-down':
+    case 'stopping':
+    case 'stopped':
+    case 'terminated':
+      return state;
+    default:
+      return 'unknown';
+  }
+}
+
+function mapEc2Error(error: unknown, message: string): Ec2EngineError {
+  if (error instanceof Ec2EngineError) return error;
+
+  const name = errorName(error);
+  const reason =
+    name === 'InsufficientInstanceCapacity'
+      ? 'insufficient-capacity'
+      : name === 'SpotMaxPriceTooLow'
+        ? 'spot-price-too-low'
+        : name === 'RequestLimitExceeded' ||
+            name.startsWith('Throttling') ||
+            name === 'EC2ThrottledException' ||
+            name === 'SlowDown'
+          ? 'throttled'
+          : name.startsWith('InvalidAMIID.')
+            ? 'image-not-found'
+            : ['AuthFailure', 'UnauthorizedOperation', 'Blocked', 'OptInRequired'].includes(name)
+              ? 'auth'
+              : name.startsWith('Invalid') ||
+                  name.startsWith('Missing') ||
+                  name.startsWith('Unsupported')
+                ? 'config-invalid'
+                : isUnreachable(error, name)
+                  ? 'unreachable'
+                  : 'unknown';
+
+  return new Ec2EngineError(reason, message, {cause: error});
+}
+
+function errorName(error: unknown): string {
+  return error instanceof Error ? error.name : '';
+}
+
+function isUnreachable(error: unknown, name: string): boolean {
+  if (name === 'TimeoutError') return true;
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    ['ECONNREFUSED', 'ENOTFOUND', 'ETIMEDOUT', 'ECONNRESET', 'EAI_AGAIN'].includes(
+      String(error.code),
+    )
+  ) {
+    return true;
+  }
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    '$metadata' in error &&
+    typeof error.$metadata === 'object' &&
+    error.$metadata !== null &&
+    'httpStatusCode' in error.$metadata &&
+    typeof error.$metadata.httpStatusCode === 'number' &&
+    error.$metadata.httpStatusCode >= 500
+  );
+}

--- a/libs/provisioner/ec2/src/instance-identity.test.ts
+++ b/libs/provisioner/ec2/src/instance-identity.test.ts
@@ -1,0 +1,80 @@
+import type {ProvisionedRunnerLaunch, ProvisionerIdentity} from '@shipfox/provisioner-core';
+import {buildInstanceTags, parseInstanceIdentity, SHIPFOX_TAGS} from '#instance-identity.js';
+import type {Ec2TemplateSpec} from '#templates.js';
+
+const identity: ProvisionerIdentity = {
+  id: '00000000-0000-4000-8000-000000000001',
+  workspaceId: '00000000-0000-4000-8000-000000000002',
+};
+
+const launch: ProvisionedRunnerLaunch<Ec2TemplateSpec> = {
+  provisionedRunnerId: 'runner-1',
+  reservationId: '00000000-0000-4000-8000-000000000003',
+  registrationToken: 'sf_ert_secret',
+  registrationTokenExpiresAt: '2026-01-01T00:00:00.000Z',
+  runnerEnv: {},
+  template: {
+    key: 'small',
+    labels: ['ubuntu22', 'ubuntu22-2vcpu'],
+    maxConcurrency: 1,
+    cost: 1,
+    spec: {
+      ami: 'ami-0123456789abcdef0',
+      instanceType: 'm6i.large',
+      market: 'spot',
+      spotMaxPrice: null,
+      subnets: ['subnet-a'],
+      securityGroups: ['sg-a'],
+      associatePublicIp: false,
+      rootVolumeGb: 100,
+      rootDeviceName: '/dev/sda1',
+    },
+  },
+};
+
+describe('instance identity tags', () => {
+  it('builds every Shipfox tag and an instance Name', () => {
+    const tags = buildInstanceTags({launch, identity});
+
+    expect(tags).toEqual({
+      [SHIPFOX_TAGS.provisionedRunnerId]: 'runner-1',
+      [SHIPFOX_TAGS.provisionerId]: identity.id,
+      [SHIPFOX_TAGS.reservationId]: launch.reservationId,
+      [SHIPFOX_TAGS.templateKey]: 'small',
+      [SHIPFOX_TAGS.workspaceId]: identity.workspaceId,
+      [SHIPFOX_TAGS.labels]: 'ubuntu22,ubuntu22-2vcpu',
+      Name: 'runner-1',
+    });
+  });
+
+  it('round-trips identity through tags and canonicalizes labels', () => {
+    const tags = buildInstanceTags({launch, identity});
+    tags[SHIPFOX_TAGS.labels] = 'Ubuntu22, ubuntu22-2vcpu, ubuntu22';
+
+    const parsed = parseInstanceIdentity({tags});
+
+    expect(parsed).toEqual({
+      provisionedRunnerId: 'runner-1',
+      provisionerId: identity.id,
+      reservationId: launch.reservationId,
+      templateKey: 'small',
+      workspaceId: identity.workspaceId,
+      labels: ['ubuntu22', 'ubuntu22-2vcpu'],
+    });
+  });
+
+  it('uses Name when the provisioned runner tag is absent', () => {
+    const tags = buildInstanceTags({launch, identity});
+    delete tags[SHIPFOX_TAGS.provisionedRunnerId];
+
+    const parsed = parseInstanceIdentity({tags});
+
+    expect(parsed.provisionedRunnerId).toBe('runner-1');
+  });
+
+  it('omits optional fields when their tags are absent', () => {
+    const parsed = parseInstanceIdentity({tags: {Name: 'runner-1'}});
+
+    expect(parsed).toEqual({provisionedRunnerId: 'runner-1', labels: []});
+  });
+});

--- a/libs/provisioner/ec2/src/instance-identity.ts
+++ b/libs/provisioner/ec2/src/instance-identity.ts
@@ -1,0 +1,60 @@
+import type {ProvisionedRunnerLaunch, ProvisionerIdentity} from '@shipfox/provisioner-core';
+import {canonicalizeLabels, parseLabelList} from '@shipfox/runner-labels';
+import type {Ec2TemplateSpec} from '#templates.js';
+
+export const SHIPFOX_TAGS = {
+  provisionedRunnerId: 'shipfox.provisioned_runner_id',
+  provisionerId: 'shipfox.provisioner_id',
+  reservationId: 'shipfox.reservation_id',
+  templateKey: 'shipfox.template_key',
+  workspaceId: 'shipfox.workspace_id',
+  labels: 'shipfox.labels',
+} as const;
+
+export interface ParsedInstanceIdentity {
+  readonly provisionedRunnerId: string;
+  readonly provisionerId?: string;
+  readonly reservationId?: string;
+  readonly templateKey?: string;
+  readonly workspaceId?: string;
+  readonly labels: readonly string[];
+}
+
+export function buildInstanceTags(args: {
+  launch: ProvisionedRunnerLaunch<Ec2TemplateSpec>;
+  identity: ProvisionerIdentity;
+}): Record<string, string> {
+  return {
+    [SHIPFOX_TAGS.provisionedRunnerId]: args.launch.provisionedRunnerId,
+    [SHIPFOX_TAGS.provisionerId]: args.identity.id,
+    [SHIPFOX_TAGS.reservationId]: args.launch.reservationId,
+    [SHIPFOX_TAGS.templateKey]: args.launch.template.key,
+    [SHIPFOX_TAGS.workspaceId]: args.identity.workspaceId,
+    [SHIPFOX_TAGS.labels]: args.launch.template.labels.join(','),
+    Name: args.launch.provisionedRunnerId,
+  };
+}
+
+export function parseInstanceIdentity(view: {
+  tags: Readonly<Record<string, string>>;
+}): ParsedInstanceIdentity {
+  const provisionedRunnerId = view.tags[SHIPFOX_TAGS.provisionedRunnerId] ?? view.tags.Name ?? '';
+  const labels = canonicalizeLabels(parseLabelList(view.tags[SHIPFOX_TAGS.labels] ?? ''));
+
+  return {
+    provisionedRunnerId,
+    ...(view.tags[SHIPFOX_TAGS.provisionerId]
+      ? {provisionerId: view.tags[SHIPFOX_TAGS.provisionerId]}
+      : {}),
+    ...(view.tags[SHIPFOX_TAGS.reservationId]
+      ? {reservationId: view.tags[SHIPFOX_TAGS.reservationId]}
+      : {}),
+    ...(view.tags[SHIPFOX_TAGS.templateKey]
+      ? {templateKey: view.tags[SHIPFOX_TAGS.templateKey]}
+      : {}),
+    ...(view.tags[SHIPFOX_TAGS.workspaceId]
+      ? {workspaceId: view.tags[SHIPFOX_TAGS.workspaceId]}
+      : {}),
+    labels,
+  };
+}

--- a/libs/provisioner/ec2/src/templates.test.ts
+++ b/libs/provisioner/ec2/src/templates.test.ts
@@ -97,6 +97,7 @@ describe('loadEc2Templates', () => {
           iamInstanceProfile: 'shipfox-runner',
           associatePublicIp: false,
           rootVolumeGb: 100,
+          rootDeviceName: '/dev/sda1',
         },
       },
       {
@@ -113,6 +114,7 @@ describe('loadEc2Templates', () => {
           securityGroups: ['sg-runner'],
           associatePublicIp: true,
           rootVolumeGb: 120,
+          rootDeviceName: '/dev/sda1',
         },
       },
     ]);
@@ -124,6 +126,15 @@ describe('loadEc2Templates', () => {
     const [loaded] = loadEc2Templates(path);
 
     expect(loaded?.spec.spotMaxPrice).toBeNull();
+  });
+
+  it('uses the default root device name and preserves an explicit value', () => {
+    const path = writeTemplates(template({}, '    root_device_name: /dev/xvda\n'));
+
+    const templates = loadEc2Templates(path);
+
+    expect(templates[0]?.spec.rootDeviceName).toBe('/dev/xvda');
+    expect(loadEc2Templates(writeTemplates(template()))[0]?.spec.rootDeviceName).toBe('/dev/sda1');
   });
 
   it('canonicalizes labels (lowercase, dedupe, sort)', () => {
@@ -171,6 +182,12 @@ describe('loadEc2Templates', () => {
     const path = writeTemplates(template({}, '    iam_instance_profile: "   "\n'));
 
     expect(() => loadEc2Templates(path)).toThrow('iam_instance_profile');
+  });
+
+  it('throws when root_device_name is blank', () => {
+    const path = writeTemplates(template({}, '    root_device_name: "   "\n'));
+
+    expect(() => loadEc2Templates(path)).toThrow('root_device_name');
   });
 
   it('throws when max_concurrency exceeds the limit', () => {

--- a/libs/provisioner/ec2/src/templates.ts
+++ b/libs/provisioner/ec2/src/templates.ts
@@ -17,6 +17,7 @@ export interface Ec2TemplateSpec {
   readonly iamInstanceProfile?: string;
   readonly associatePublicIp: boolean;
   readonly rootVolumeGb: number;
+  readonly rootDeviceName: string;
 }
 
 /** Raised when the template config file is missing, unparseable, or invalid. */
@@ -44,6 +45,7 @@ const ec2TemplateSchema = z
     iam_instance_profile: z.string().trim().min(1).optional(),
     associate_public_ip: z.boolean(),
     root_volume_gb: z.number().int().positive(),
+    root_device_name: z.string().trim().min(1).optional(),
     max_concurrency: z.number().int().positive().max(MAX_TEMPLATE_CONCURRENCY),
     cost: z.number().positive(),
   })
@@ -128,6 +130,7 @@ function toTemplate(
         : {iamInstanceProfile: spec.iam_instance_profile}),
       associatePublicIp: spec.associate_public_ip,
       rootVolumeGb: spec.root_volume_gb,
+      rootDeviceName: spec.root_device_name ?? '/dev/sda1',
     },
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ catalogs:
     '@argos-ci/storybook':
       specifier: ^6.0.0
       version: 6.0.7
+    '@aws-sdk/client-ec2':
+      specifier: ^3.1068.0
+      version: 3.1088.0
     '@aws-sdk/client-s3':
       specifier: ^3.1068.0
       version: 3.1070.0
@@ -5776,6 +5779,9 @@ importers:
 
   libs/provisioner/ec2:
     dependencies:
+      '@aws-sdk/client-ec2':
+        specifier: 'catalog:'
+        version: 3.1088.0
       '@shipfox/config':
         specifier: workspace:*
         version: link:../../shared/common/config
@@ -7281,6 +7287,10 @@ packages:
     resolution: {integrity: sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-ec2@3.1088.0':
+    resolution: {integrity: sha512-+qVKzYkYHst/gUmKTuJGmfQYSEIjuvZq0KgE4kMBT09Q95GkD5BV8+L7PCuWYsDAzq16mQ4kRwbk/kZhBKntLA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-s3@3.1070.0':
     resolution: {integrity: sha512-B/OUiCqGQ4Zr7v9gFFyiuitKN2c0PIgvOlQb5bYg1SM2y0F8a5JQ7FNsjRcl+d2PqYWLHwHx12CvZDyLn4KxIw==}
     engines: {node: '>=20.0.0'}
@@ -7289,36 +7299,72 @@ packages:
     resolution: {integrity: sha512-YofH63shc6YRdXjz80BJkpJW+Bkn0Cuu2dn4Rv7s9G2Idt58tgtzQEWxrR2xVljlVfIBeUjPuULnSVYLke3sUQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/core@3.975.3':
+    resolution: {integrity: sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-env@3.972.47':
     resolution: {integrity: sha512-3YoPwJczcc+MtX2xxXaYaOOWO6xKUJr1ZIIDIFuninr51BYONVVcF/CP8K2xfVRC/PztJjqKWxNGFH7BWQAw1Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.59':
+    resolution: {integrity: sha512-Ny5e4Mfh3QPmiAc0AiUe+cbTXDlxkU3Rc+EpWOfyWeWEy6yp7Fa1KmfNeCc+1a8by9zQ9gtohmiQUkMPScF3ng==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.49':
     resolution: {integrity: sha512-2UtGUPy+x3lqyceHrtC1uEuVxBZbDalPF6KAFqBwYgm4edWdBrZKNnCqzDs7KynWUvEC6mrR+ojRk+ZgQz9C2w==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-http@3.972.61':
+    resolution: {integrity: sha512-8jAjgStl5Ytq4+HF3X/9f+EmRinaRbGRRtQGktlPfBRVx73H+R1y48vIeXerQtYGFaUqkEp3fT6jP854rVO2yQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-ini@3.972.54':
     resolution: {integrity: sha512-Hx4gO4YRjFwitf3MVl3cDwYe1aryJthC4txVl9b+JAURovA50M2ywf9r8j1E/Q6SCTPT4qQpjOAbKYIC9CG+Vw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.3':
+    resolution: {integrity: sha512-WpuqYX4gGkx++fCTSWE8+41JzkZVcrI50SH48Ml4CsG1pyuHKyMmpw/FixBHDrmjoQ553PmeCLa/fZIcst+WyA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-login@3.972.53':
     resolution: {integrity: sha512-+71sluhkgPqdhbbD3UDwUpj24GCkng9HQx6z7qoBFb8dwkF4ktpOcVKDeHpgg8PvBgLYwAnUYLTEGRC/PniCiQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-login@3.972.65':
+    resolution: {integrity: sha512-xr9rgjYEdmC2Tpg2lwt9o+nOEaK9Qpd+dBjzrVCuWWyQfvhO91Ezu0Hh9ts2VUxOZxmS/k5T9msa34e4R1bnrQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-node@3.972.56':
     resolution: {integrity: sha512-iI+4o0dvQQ4NHel4FMDiFy5q2gaU/ryLK3niOsoPccAt9WLFRkV4XTYPWRr9XvmBUqEzXG73S4p/8gm0Lu/W3A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.69':
+    resolution: {integrity: sha512-wbJGGesd0Tl18bmUcbj1xJ+e7CpuRJ6PIpMywLFuUttGy615lua87cJ0EA8pFpY/QgPuUXbnupWBtSPJ9tyZhg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.972.47':
     resolution: {integrity: sha512-tAizPm9IFo/PHn06c+LQJlzfY2AGOlyF0CUljFejrU6LcZBjnk8pmbZK3/xoIDdnIzjEdbClfvY3mXfr818ZEg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-process@3.972.59':
+    resolution: {integrity: sha512-DlZF2/MhLlatDdlrIy3CUCpfdbLrKx+3SMjVo+WyHnPpwzkc/M3vwAHw4OVJf7DMvO+4vfRqSCMc/E9I1auN0g==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-sso@3.972.53':
     resolution: {integrity: sha512-pUXE3fu4tfEDV8BksIgf4dXvuIH10FhwHMl/wu8rBD5T1sMpryQWFVitH3kdPS90wlgrGYJQ/meQTSPacyZfeg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.973.3':
+    resolution: {integrity: sha512-hmdDHoy2G5Es2e8IgelNMYUuSQI6uCIAKZMJ2u2PdKDhxvbk1uWD/g4+R7R5c/tJfKEB1+KjjWiaoCr/S+ZTiQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.53':
     resolution: {integrity: sha512-JmMGlhVvSj8uSG9CpeDkJAXT35H89tc6v84iMgEIE75q4yp1MKVVKvopv6Gg28HJIR7hMNkojRF8H2m5W44wyg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.65':
+    resolution: {integrity: sha512-gHQb/Kt0chjk/JQDa/GJDqmAvEuVn8n7z10wK2h0LFM9TUDRkohgOO4aEF+s2sBLM0br7Cl5W6P7phgjrrJvLQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/eventstream-handler-node@3.972.22':
@@ -7339,6 +7385,10 @@ packages:
     resolution: {integrity: sha512-Yzj6NRYVZdBaCp7o1BwHGyeDBfixdeToLIAMprshIITEdl9wKVSiidVOfeaiH8FyeC1hBmBfDZFvs/aH1Y3xpw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-sdk-ec2@3.972.47':
+    resolution: {integrity: sha512-O8j+BCQAtmqDaTzCTgOA/JBpz2JUTgeQenNPhfQtkocdmFm714jMSyuzl8Lub2Nn1w0rC9m+NpVNaj4xugDcxg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-sdk-s3@3.972.52':
     resolution: {integrity: sha512-rerjP08onRqkBh0AcCqip6GkKvESapmLoTgi1xysZ4C6a1xMrIMtTBcEbUb6EY71oeajnigeUD4KwZjtIO+aWQ==}
     engines: {node: '>=20.0.0'}
@@ -7351,12 +7401,20 @@ packages:
     resolution: {integrity: sha512-eC7Vl7Qom/BGhZjG9GEqPwdQ/fk45hg1t5LP4EUxG5d1fdshLbaxCiwh/tszUzDX/4mW40mu2QsbeJJRPBbqUw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.33':
+    resolution: {integrity: sha512-dVZOroI/r3/ENvqNGgjMPul+jjlz9GddfVusgTXlVjfZj5isibOxecLkGQbRPp8XOuX+RAfjXLFgPkD1JS5xrw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/s3-request-presigner@3.1071.0':
     resolution: {integrity: sha512-7//gxCHWGq4NAAg0pRGcLWRfNshybJeB38MhQsCH7lbCy3cliEo4V6PFqxouiVCZ5qExRCDLCLOVqh5J6v2bTQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/signature-v4-multi-region@3.996.35':
     resolution: {integrity: sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.41':
+    resolution: {integrity: sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1048.0':
@@ -7367,8 +7425,16 @@ packages:
     resolution: {integrity: sha512-ks4X+kngC3PA5howV7Qu1TgG4bfC4jPykKdvw3nmBSXR9yZxRJouBholFSNQ5kY3L+Fgwyw+LCjzQmNi+KR91g==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/token-providers@3.1088.0':
+    resolution: {integrity: sha512-4ObatWt2qpJg5FBk4LOOKrTQYzaqeewAtdO3r9ZO8lH9YqLtpTzLyIdy0mJ+nVdfYOnqISkKNfmzP22bNDhwyw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/types@3.973.13':
     resolution: {integrity: sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.2':
+    resolution: {integrity: sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-locate-window@3.965.7':
@@ -7379,8 +7445,16 @@ packages:
     resolution: {integrity: sha512-StElZPEoBquWwNqw1AcfpzEyZqJvFxouG+mpDNYlcH6ZOrqd2CuIryv+8LV8gNHZUOyKyJF3Dq9vxaXEmDR9TQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/xml-builder@3.972.36':
+    resolution: {integrity: sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws/lambda-invoke-store@0.2.4':
     resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
     engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.7':
@@ -10783,12 +10857,24 @@ packages:
     resolution: {integrity: sha512-KoUi4M1f3BG6kzN1FnCwL7oyFptTbyBJKjR6yhSib+JHRdUmM1o+VwsFtJ66NZCkCzVfJMWRHJNo0R0jznp0Pg==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.29.5':
+    resolution: {integrity: sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.3.9':
     resolution: {integrity: sha512-ZlfJ/4Fa3jYb+3eaohPfG9utX9HmdhFNcFtpoGAhUhdynAOmGXtmigbi7eEiONKM+ykHw8RwKuDEb85Lx7t7fA==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/credential-provider-imds@4.4.10':
+    resolution: {integrity: sha512-MJenAe4OKRZUo1LdYYFDCsSHxaHvInIU/z52GsheO9vl1/VSySVCr0zkyKD6TFiGkSUaWGxvKZ/70OvgUZR5HQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/fetch-http-handler@5.4.7':
     resolution: {integrity: sha512-NslaM2ir0N2hisDmzXLstPaVINZheh8SokyOC++kzFPloZucL2R7Y7bS57mSzx/1Fc/fqmn7twjkeezTTrV0EA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.6.7':
+    resolution: {integrity: sha512-3zpg8yqqyXzoK2TsRDdkqVOj2RDBFfLXwCczOZ5c7TWB4eiaebfSCsbMjDPYB3PJ9ihV62QaeadZ+wLadZtNGA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/is-array-buffer@2.2.0':
@@ -10803,12 +10889,24 @@ packages:
     resolution: {integrity: sha512-f+DbsWUwSbtMu1a/j8Y93KiU1SRg9nyzfjereqn1BJ33QOTUXxdlYvVXMhAYl1vuR1Kmna5aIJe09KSIfyFNYw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/node-http-handler@4.9.7':
+    resolution: {integrity: sha512-wCU8HCLjAtAVqxxe0j2xff9LcEPw3yjBbg5IdQDIYFnxnPxbxcSLc7rgex7kqm9L/WYOnJEgaWQlfDkZleozMA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/signature-v4@5.4.7':
     resolution: {integrity: sha512-LwQZazFayImv+IOm0S0enoLeUJwmAlhGC5O6YCcLWezyu08dF46GOxPOq35OpBIHkgd7OvNvBStIFwVNyrvoBw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/signature-v4@5.6.6':
+    resolution: {integrity: sha512-efP6DN3UTFrzIsGO42/xcabv8jU7+9nwEdphFUH7yL0k010ERyAWaO41KFQIDLcFZLZ8xzIQr4wplFxNzslSGQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/types@4.14.4':
     resolution: {integrity: sha512-B2S9+UGm1+/pHkcx3ZoLVX1a+pmSk8rqxRR+ZsNqZaJ5q9FWX9AFGQVM4qG5+OBeQUZVy99HY8HqW8gK/wgXzQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.16.1':
+    resolution: {integrity: sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-buffer-from@2.2.0':
@@ -16520,6 +16618,18 @@ snapshots:
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
+  '@aws-sdk/client-ec2@3.1088.0':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/credential-provider-node': 3.972.69
+      '@aws-sdk/middleware-sdk-ec2': 3.972.47
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/fetch-http-handler': 5.6.7
+      '@smithy/node-http-handler': 4.9.7
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/client-s3@3.1070.0':
     dependencies:
       '@aws-crypto/sha1-browser': 5.2.0
@@ -16548,12 +16658,31 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.975.3':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@aws-sdk/xml-builder': 3.972.36
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.29.5
+      '@smithy/signature-v4': 5.6.6
+      '@smithy/types': 4.16.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-env@3.972.47':
     dependencies:
       '@aws-sdk/core': 3.974.22
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
       '@smithy/types': 4.14.4
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.59':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-http@3.972.49':
@@ -16564,6 +16693,16 @@ snapshots:
       '@smithy/fetch-http-handler': 5.4.7
       '@smithy/node-http-handler': 4.7.8
       '@smithy/types': 4.14.4
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.61':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/fetch-http-handler': 5.6.7
+      '@smithy/node-http-handler': 4.9.7
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.972.54':
@@ -16582,6 +16721,22 @@ snapshots:
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-ini@3.973.3':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/credential-provider-env': 3.972.59
+      '@aws-sdk/credential-provider-http': 3.972.61
+      '@aws-sdk/credential-provider-login': 3.972.65
+      '@aws-sdk/credential-provider-process': 3.972.59
+      '@aws-sdk/credential-provider-sso': 3.973.3
+      '@aws-sdk/credential-provider-web-identity': 3.972.65
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/credential-provider-imds': 4.4.10
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.53':
     dependencies:
       '@aws-sdk/core': 3.974.22
@@ -16589,6 +16744,15 @@ snapshots:
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
       '@smithy/types': 4.14.4
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.65':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-node@3.972.56':
@@ -16605,12 +16769,34 @@ snapshots:
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-node@3.972.69':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.59
+      '@aws-sdk/credential-provider-http': 3.972.61
+      '@aws-sdk/credential-provider-ini': 3.973.3
+      '@aws-sdk/credential-provider-process': 3.972.59
+      '@aws-sdk/credential-provider-sso': 3.973.3
+      '@aws-sdk/credential-provider-web-identity': 3.972.65
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/credential-provider-imds': 4.4.10
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.47':
     dependencies:
       '@aws-sdk/core': 3.974.22
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
       '@smithy/types': 4.14.4
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.59':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.972.53':
@@ -16623,6 +16809,16 @@ snapshots:
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-sso@3.973.3':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/token-providers': 3.1088.0
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.53':
     dependencies:
       '@aws-sdk/core': 3.974.22
@@ -16630,6 +16826,15 @@ snapshots:
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
       '@smithy/types': 4.14.4
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.65':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/eventstream-handler-node@3.972.22':
@@ -16659,6 +16864,15 @@ snapshots:
   '@aws-sdk/middleware-flexible-checksums@3.974.31':
     dependencies:
       '@aws-sdk/checksums': 3.1000.6
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-ec2@3.972.47':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/signature-v4': 5.6.6
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-sdk-s3@3.972.52':
@@ -16693,6 +16907,17 @@ snapshots:
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
+  '@aws-sdk/nested-clients@3.997.33':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/signature-v4-multi-region': 3.996.41
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/fetch-http-handler': 5.6.7
+      '@smithy/node-http-handler': 4.9.7
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/s3-request-presigner@3.1071.0':
     dependencies:
       '@aws-sdk/core': 3.974.22
@@ -16707,6 +16932,13 @@ snapshots:
       '@aws-sdk/types': 3.973.13
       '@smithy/signature-v4': 5.4.7
       '@smithy/types': 4.14.4
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.41':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/signature-v4': 5.6.6
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1048.0':
@@ -16727,9 +16959,23 @@ snapshots:
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
+  '@aws-sdk/token-providers@3.1088.0':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/types@3.973.13':
     dependencies:
       '@smithy/types': 4.14.4
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.2':
+    dependencies:
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/util-locate-window@3.965.7':
@@ -16742,7 +16988,14 @@ snapshots:
       fast-xml-parser: 5.7.3
       tslib: 2.8.1
 
+  '@aws-sdk/xml-builder@3.972.36':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws/lambda-invoke-store@0.2.4': {}
+
+  '@aws/lambda-invoke-store@0.3.0': {}
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -20059,16 +20312,33 @@ snapshots:
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
+  '@smithy/core@3.29.5':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.3.9':
     dependencies:
       '@smithy/core': 3.24.7
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
+  '@smithy/credential-provider-imds@4.4.10':
+    dependencies:
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@smithy/fetch-http-handler@5.4.7':
     dependencies:
       '@smithy/core': 3.24.7
       '@smithy/types': 4.14.4
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.6.7':
+    dependencies:
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/is-array-buffer@2.2.0':
@@ -20087,13 +20357,29 @@ snapshots:
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
+  '@smithy/node-http-handler@4.9.7':
+    dependencies:
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@smithy/signature-v4@5.4.7':
     dependencies:
       '@smithy/core': 3.24.7
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
+  '@smithy/signature-v4@5.6.6':
+    dependencies:
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@smithy/types@4.14.4':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/types@4.16.1':
     dependencies:
       tslib: 2.8.1
 


### PR DESCRIPTION
Adds the EC2 provider's internal AWS boundary: atomic instance and volume tagging, idempotent launch tokens, instance discovery, and resilient teardown. It also adds tag-based instance identity recovery and makes the root device name explicit in EC2 templates.

The provisioner must recover truth from tagged AWS state instead of process memory. Launches therefore tag resources at creation, and termination handles stale instance IDs independently so an expired ID cannot prevent a live runner from being terminated.

The engine and identity modules intentionally remain internal subpath modules for the lifecycle and app wiring that follow. The package is private, so no changeset is included.

Closes ENG-1008

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an EC2 engine wrapper that launches, tags, discovers, and terminates runner instances safely and idempotently. Fulfills ENG-1008 by recovering identity from tags and making the root device explicit in templates.

- New Features
  - Launch: atomic instance/volume tagging, idempotent `clientToken`, optional IAM profile, on‑demand or Spot (with optional max price), base64 user data, and explicit root volume mapping with a required device name.
  - Discovery: lists managed instances by `shipfox.provisioner_id` tag, paginates, and surfaces EC2 state/reason details.
  - Termination: per‑instance teardown that ignores `InvalidInstanceID.NotFound` so stale IDs don’t block live runner cleanup.
  - Identity: builds/parses `SHIPFOX_TAGS`, canonicalizes labels, and falls back to `Name` when runner ID tag is missing.
  - Templates: adds `root_device_name` (default `/dev/sda1`), with validation.

- Dependencies
  - Added `@aws-sdk/client-ec2`.

<sup>Written for commit 7700cefb10cbcb68f48cce1029badd981d433978. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

