### PR TITLE
[integration/slack] Revoke installations on lifecycle events

### DIFF
--- a/.changeset/bright-otters-revoke.md
+++ b/.changeset/bright-otters-revoke.md
@@ -1,0 +1,8 @@
+---
+"@shipfox/api-integration-slack": minor
+"@shipfox/api-integration-slack-dto": minor
+"@shipfox/api-integration-core": minor
+"@shipfox/api-integration-core-dto": minor
+---
+
+Adds deduplicated Slack installation revocation for app uninstall and bot token-revocation events.

--- a/libs/api/integration/core-dto/src/ports.ts
+++ b/libs/api/integration/core-dto/src/ports.ts
@@ -57,6 +57,12 @@ export type RecordDeliveryOnlyFn = (params: {
   deliveryId: string;
 }) => Promise<void>;
 
+export type ClaimWebhookDeliveryFn = (params: {
+  tx: IntegrationTx;
+  provider: string;
+  deliveryId: string;
+}) => Promise<{claimed: boolean}>;
+
 export type GetIntegrationConnectionByIdFn = (
   id: string,
   options?: {tx?: IntegrationTx},

--- a/libs/api/integration/core/src/db/webhook-deliveries.test.ts
+++ b/libs/api/integration/core/src/db/webhook-deliveries.test.ts
@@ -9,6 +9,7 @@ import {db} from './db.js';
 import {integrationsOutbox} from './schema/outbox.js';
 import {integrationsWebhookDeliveries} from './schema/webhook-deliveries.js';
 import {
+  claimWebhookDelivery,
   publishIntegrationEventReceived,
   publishSourceCommitPushed,
   publishSourcePush,
@@ -164,6 +165,16 @@ describe('integration webhook delivery persistence', () => {
     await recordDeliveryOnly({tx: db(), provider: 'github', deliveryId});
 
     expect(await deliveriesFor('github', deliveryId)).toHaveLength(1);
+  });
+
+  it('reports whether it claimed a delivery', async () => {
+    const deliveryId = crypto.randomUUID();
+
+    const first = await claimWebhookDelivery({tx: db(), provider: 'github', deliveryId});
+    const duplicate = await claimWebhookDelivery({tx: db(), provider: 'github', deliveryId});
+
+    expect(first.claimed).toBe(true);
+    expect(duplicate.claimed).toBe(false);
   });
 });
 

--- a/libs/api/integration/core/src/db/webhook-deliveries.ts
+++ b/libs/api/integration/core/src/db/webhook-deliveries.ts
@@ -171,8 +171,10 @@ export interface RecordDeliveryOnlyParams {
   deliveryId: string;
 }
 
-export async function recordDeliveryOnly(params: RecordDeliveryOnlyParams): Promise<void> {
-  await params.tx
+export async function claimWebhookDelivery(
+  params: RecordDeliveryOnlyParams,
+): Promise<{claimed: boolean}> {
+  const inserted = await params.tx
     .insert(integrationsWebhookDeliveries)
     .values({
       provider: params.provider,
@@ -185,7 +187,13 @@ export async function recordDeliveryOnly(params: RecordDeliveryOnlyParams): Prom
         integrationsWebhookDeliveries.dedupScope,
         integrationsWebhookDeliveries.deliveryId,
       ],
-    });
+    })
+    .returning({deliveryId: integrationsWebhookDeliveries.deliveryId});
+  return {claimed: inserted.length > 0};
+}
+
+export async function recordDeliveryOnly(params: RecordDeliveryOnlyParams): Promise<void> {
+  await claimWebhookDelivery(params);
 }
 
 export interface PruneWebhookDeliveriesParams {
@@ -204,4 +212,5 @@ export async function pruneWebhookDeliveries(
 export type PublishIntegrationEventReceivedFn = typeof publishIntegrationEventReceived;
 export type PublishSourcePushFn = typeof publishSourcePush;
 export type PublishSourceCommitPushedFn = typeof publishSourceCommitPushed;
+export type ClaimWebhookDeliveryFn = typeof claimWebhookDelivery;
 export type RecordDeliveryOnlyFn = typeof recordDeliveryOnly;

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -98,6 +98,7 @@ export {createSourceControlIntegrationService} from '#core/source-control-servic
 export type {GetIntegrationConnectionByIdFn} from '#db/connections.js';
 export {getIntegrationConnectionById} from '#db/connections.js';
 export type {
+  ClaimWebhookDeliveryFn,
   PublishIntegrationEventReceivedFn,
   PublishIntegrationEventReceivedParams,
   PublishIntegrationEventReceivedResult,
@@ -106,7 +107,7 @@ export type {
   RecordDeliveryOnlyFn,
   RecordDeliveryOnlyParams,
 } from '#db/webhook-deliveries.js';
-export {pruneWebhookDeliveries} from '#db/webhook-deliveries.js';
+export {claimWebhookDelivery, pruneWebhookDeliveries} from '#db/webhook-deliveries.js';
 export {integrationRouteErrorHandler} from '#presentation/routes/errors.js';
 
 export interface CreateIntegrationsModuleOptions {

--- a/libs/api/integration/core/src/providers/slack.ts
+++ b/libs/api/integration/core/src/providers/slack.ts
@@ -14,7 +14,11 @@ import {
   upsertIntegrationConnection,
 } from '#db/connections.js';
 import {db} from '#db/db.js';
-import {publishIntegrationEventReceived, recordDeliveryOnly} from '#db/webhook-deliveries.js';
+import {
+  claimWebhookDelivery,
+  publishIntegrationEventReceived,
+  recordDeliveryOnly,
+} from '#db/webhook-deliveries.js';
 import {retryConnectionSlugCollision} from '#providers/connection-slug.js';
 import type {IntegrationModuleParts, IntegrationProviderModule} from '#providers/types.js';
 
@@ -141,6 +145,7 @@ async function loadSlackModuleParts(
         connectSlackInstallation,
         disconnectSlackInstallation,
         coreDb: db,
+        claimWebhookDelivery,
         publishIntegrationEventReceived,
         recordDeliveryOnly,
         getIntegrationConnectionById,

--- a/libs/api/integration/slack-dto/src/schemas/index.test.ts
+++ b/libs/api/integration/slack-dto/src/schemas/index.test.ts
@@ -1,7 +1,9 @@
 import {
   createE2eSlackConnectionBodySchema,
   createSlackInstallBodySchema,
+  SLACK_APP_UNINSTALLED_EVENT,
   SLACK_PROVIDER,
+  SLACK_TOKENS_REVOKED_EVENT,
   slackApiEventTypes,
   slackCallbackQuerySchema,
   slackEventBaseEnvelopeSchema,
@@ -9,8 +11,10 @@ import {
   slackEventNames,
   slackEventPayloadSchema,
   slackEventsRequestSchema,
+  slackLifecycleEventTypes,
   slackSlashCommandPayloadSchema,
   slackSlashCommandSchema,
+  slackTokensRevokedEventSchema,
   slackUrlVerificationSchema,
 } from './index.js';
 
@@ -45,6 +49,15 @@ describe('Slack event vocabulary', () => {
     expect(slackEventNames).toEqual(['app_mention', 'message', 'reaction_added', 'slash_command']);
     expect(slackApiEventTypes).not.toContain('slash_command');
   });
+
+  it('keeps lifecycle events out of published event names', () => {
+    expect(slackLifecycleEventTypes).toEqual([
+      SLACK_APP_UNINSTALLED_EVENT,
+      SLACK_TOKENS_REVOKED_EVENT,
+    ]);
+    expect(slackApiEventTypes).not.toContain(SLACK_APP_UNINSTALLED_EVENT);
+    expect(slackApiEventTypes).not.toContain(SLACK_TOKENS_REVOKED_EVENT);
+  });
 });
 
 describe('Slack event schemas', () => {
@@ -62,6 +75,15 @@ describe('Slack event schemas', () => {
 
     expect(slackEventEnvelopeSchema.safeParse(unsupportedEvent).success).toBe(false);
     expect(slackEventBaseEnvelopeSchema.safeParse(unsupportedEvent).success).toBe(true);
+  });
+
+  it.each([
+    {type: SLACK_TOKENS_REVOKED_EVENT, tokens: {bot: ['UBOT']}},
+    {type: SLACK_TOKENS_REVOKED_EVENT, tokens: {oauth: ['UOAUTH']}},
+  ])('accepts a tokens_revoked event', (event) => {
+    const result = slackTokensRevokedEventSchema.parse(event);
+
+    expect(result.type).toBe(SLACK_TOKENS_REVOKED_EVENT);
   });
 
   it('accepts the URL verification handshake', () => {

--- a/libs/api/integration/slack-dto/src/schemas/index.ts
+++ b/libs/api/integration/slack-dto/src/schemas/index.ts
@@ -6,9 +6,16 @@ export type SlackProvider = typeof SLACK_PROVIDER;
 
 export const slackApiEventTypes = ['app_mention', 'message', 'reaction_added'] as const;
 export const SLACK_SLASH_COMMAND_EVENT = 'slash_command' as const;
+export const SLACK_APP_UNINSTALLED_EVENT = 'app_uninstalled' as const;
+export const SLACK_TOKENS_REVOKED_EVENT = 'tokens_revoked' as const;
+export const slackLifecycleEventTypes = [
+  SLACK_APP_UNINSTALLED_EVENT,
+  SLACK_TOKENS_REVOKED_EVENT,
+] as const;
 export const slackEventNames = [...slackApiEventTypes, SLACK_SLASH_COMMAND_EVENT] as const;
 
 export type SlackApiEventType = (typeof slackApiEventTypes)[number];
+export type SlackLifecycleEventType = (typeof slackLifecycleEventTypes)[number];
 export type SlackEventName = (typeof slackEventNames)[number];
 
 export const slackInnerEventBaseSchema = z
@@ -22,6 +29,19 @@ export const slackInnerEventSchema = z
     type: z.enum(slackApiEventTypes),
   })
   .passthrough();
+
+export const slackTokensRevokedEventSchema = z
+  .object({
+    type: z.literal(SLACK_TOKENS_REVOKED_EVENT),
+    tokens: z
+      .object({
+        oauth: z.array(z.string()).optional(),
+        bot: z.array(z.string()).optional(),
+      })
+      .optional(),
+  })
+  .passthrough();
+export type SlackTokensRevokedEventDto = z.infer<typeof slackTokensRevokedEventSchema>;
 
 export const slackEventBaseEnvelopeSchema = z.object({
   type: z.literal('event_callback'),

--- a/libs/api/integration/slack/drizzle/0001_dark_tyrannus.sql
+++ b/libs/api/integration/slack/drizzle/0001_dark_tyrannus.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "integrations_slack_installations" ADD COLUMN "generation" integer DEFAULT 1 NOT NULL;

--- a/libs/api/integration/slack/drizzle/meta/0001_snapshot.json
+++ b/libs/api/integration/slack/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,139 @@
+{
+  "id": "5acf9796-7da0-4134-b7f8-000a1a5a7de0",
+  "prevId": "62801d4c-2399-4306-8d37-9773d10cbb02",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.integrations_slack_installations": {
+      "name": "integrations_slack_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integrations_slack_installations_connection_unique": {
+          "name": "integrations_slack_installations_connection_unique",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integrations_slack_installations_team_unique": {
+          "name": "integrations_slack_installations_team_unique",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/api/integration/slack/drizzle/meta/_journal.json
+++ b/libs/api/integration/slack/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1784372558063,
       "tag": "0000_calm_fantastic_four",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1784407778470,
+      "tag": "0001_dark_tyrannus",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/api/integration/slack/src/core/webhook.test.ts
+++ b/libs/api/integration/slack/src/core/webhook.test.ts
@@ -4,7 +4,7 @@ import type {
   IntegrationConnection,
 } from '@shipfox/api-integration-core-dto';
 import {db} from '#db/db.js';
-import {upsertSlackInstallation} from '#db/installations.js';
+import {getSlackInstallationByTeamId, upsertSlackInstallation} from '#db/installations.js';
 import {slackInstallations} from '#db/schema/installations.js';
 import {handleSlackCommand, handleSlackEvent} from './webhook.js';
 
@@ -30,7 +30,7 @@ function eventEnvelope(overrides: Record<string, unknown> = {}) {
     api_app_id: 'A1',
     event: {type: 'app_mention', channel: 'C1', user: 'U1', text: 'hello', ts: '1.0'},
     event_id: 'Ev1',
-    event_time: 1_721_300_000,
+    event_time: Math.floor(Date.now() / 1000) + 60,
     ...overrides,
   };
 }
@@ -69,6 +69,7 @@ function handlers(connection = fakeConnection()) {
     connection,
     publishIntegrationEventReceived: vi.fn(() => Promise.resolve({published: true})),
     recordDeliveryOnly: vi.fn(() => Promise.resolve()),
+    claimWebhookDelivery: vi.fn(() => Promise.resolve({claimed: true})),
     getIntegrationConnectionById: vi.fn<GetIntegrationConnectionByIdFn>(() =>
       Promise.resolve(connection),
     ),
@@ -124,6 +125,134 @@ describe('Slack webhook handlers', () => {
     expect(deps.publishIntegrationEventReceived).toHaveBeenCalledWith(
       expect.objectContaining({event: expect.objectContaining({deliveryId: 'Ev-replayed'})}),
     );
+  });
+
+  it('revokes an installation when Slack uninstalls the app', async () => {
+    const deps = handlers();
+    await seedInstallation(deps.connection);
+
+    const result = await handleSlackEvent({
+      tx: db(),
+      deliveryId: 'Ev-uninstalled',
+      envelope: eventEnvelope({event: {type: 'app_uninstalled'}}),
+      ...deps,
+    });
+
+    const installation = await getSlackInstallationByTeamId('T1');
+    expect(result.outcome).toBe('revoked');
+    expect(installation?.status).toBe('revoked');
+    expect(deps.claimWebhookDelivery).toHaveBeenCalledTimes(1);
+    expect(deps.publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(deps.getIntegrationConnectionById).not.toHaveBeenCalled();
+  });
+
+  it('revokes an installation when its bot token is revoked', async () => {
+    const deps = handlers();
+    await seedInstallation(deps.connection);
+
+    const result = await handleSlackEvent({
+      tx: db(),
+      deliveryId: 'Ev-bot-revoked',
+      envelope: eventEnvelope({event: {type: 'tokens_revoked', tokens: {bot: ['UBOT']}}}),
+      ...deps,
+    });
+
+    const installation = await getSlackInstallationByTeamId('T1');
+    expect(result.outcome).toBe('revoked');
+    expect(installation?.status).toBe('revoked');
+  });
+
+  it.each([
+    ['an OAuth token is revoked', {oauth: ['UOAUTH']}],
+    ['the revoked token set is missing', undefined],
+    ['the revoked bot token set is empty', {bot: []}],
+  ])('keeps an installation active when %s', async (_description, tokens) => {
+    const deps = handlers();
+    await seedInstallation(deps.connection);
+
+    const result = await handleSlackEvent({
+      tx: db(),
+      deliveryId: 'Ev-oauth-revoked',
+      envelope: eventEnvelope({event: {type: 'tokens_revoked', tokens}}),
+      ...deps,
+    });
+
+    const installation = await getSlackInstallationByTeamId('T1');
+    expect(result.outcome).toBe('unaffected-revocation');
+    expect(installation?.status).toBe('installed');
+    expect(deps.publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(deps.claimWebhookDelivery).toHaveBeenCalledTimes(1);
+  });
+
+  it('records an unknown lifecycle-event team without resolving a connection', async () => {
+    const deps = handlers();
+
+    const result = await handleSlackEvent({
+      tx: db(),
+      deliveryId: 'Ev-uninstalled-missing',
+      envelope: eventEnvelope({
+        team_id: 'T-missing',
+        event: {type: 'app_uninstalled'},
+      }),
+      ...deps,
+    });
+
+    expect(result.outcome).toBe('unknown-team');
+    expect(deps.getIntegrationConnectionById).not.toHaveBeenCalled();
+    expect(deps.claimWebhookDelivery).toHaveBeenCalledTimes(1);
+  });
+
+  it('records an already revoked lifecycle-event installation without throwing', async () => {
+    const deps = handlers();
+    await seedInstallation(deps.connection, 'revoked');
+
+    const result = await handleSlackEvent({
+      tx: db(),
+      deliveryId: 'Ev-uninstalled-replay',
+      envelope: eventEnvelope({event: {type: 'app_uninstalled'}}),
+      ...deps,
+    });
+
+    expect(result.outcome).toBe('revoked-installation');
+    expect(deps.claimWebhookDelivery).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not revoke an installation after a duplicate lifecycle delivery', async () => {
+    const deps = handlers();
+    deps.claimWebhookDelivery.mockResolvedValue({claimed: false});
+    await seedInstallation(deps.connection);
+
+    const result = await handleSlackEvent({
+      tx: db(),
+      deliveryId: 'Ev-uninstalled-duplicate',
+      envelope: eventEnvelope({event: {type: 'app_uninstalled'}}),
+      ...deps,
+    });
+
+    const installation = await getSlackInstallationByTeamId('T1');
+    expect(result.outcome).toBe('duplicate');
+    expect(installation?.status).toBe('installed');
+    expect(deps.getIntegrationConnectionById).not.toHaveBeenCalled();
+  });
+
+  it('does not revoke a reconnected installation for a delayed lifecycle event', async () => {
+    const deps = handlers();
+    await seedInstallation(deps.connection);
+    await seedInstallation(deps.connection);
+
+    const result = await handleSlackEvent({
+      tx: db(),
+      deliveryId: 'Ev-uninstalled-stale',
+      envelope: eventEnvelope({
+        event: {type: 'app_uninstalled'},
+        event_time: Math.floor(Date.now() / 1000) - 60,
+      }),
+      ...deps,
+    });
+
+    const installation = await getSlackInstallationByTeamId('T1');
+    expect(result.outcome).toBe('stale-lifecycle-event');
+    expect(installation?.status).toBe('installed');
   });
 
   it.each([

--- a/libs/api/integration/slack/src/core/webhook.ts
+++ b/libs/api/integration/slack/src/core/webhook.ts
@@ -1,4 +1,5 @@
 import type {
+  ClaimWebhookDeliveryFn,
   GetIntegrationConnectionByIdFn,
   IntegrationConnection,
   IntegrationTx,
@@ -6,15 +7,23 @@ import type {
   RecordDeliveryOnlyFn,
 } from '@shipfox/api-integration-core-dto';
 import {
+  SLACK_APP_UNINSTALLED_EVENT,
   SLACK_PROVIDER,
   SLACK_SLASH_COMMAND_EVENT,
   type SlackEventBaseEnvelopeDto,
+  type SlackLifecycleEventType,
   type SlackSlashCommandDto,
   slackEventEnvelopeSchema,
+  slackLifecycleEventTypes,
+  slackTokensRevokedEventSchema,
 } from '@shipfox/api-integration-slack-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import {z} from 'zod';
-import {getSlackInstallationByTeamId, type SlackInstallation} from '#db/installations.js';
+import {
+  getSlackInstallationByTeamId,
+  markSlackInstallationRevoked,
+  type SlackInstallation,
+} from '#db/installations.js';
 
 const slackSelfAuthoredEventSchema = z
   .object({
@@ -35,6 +44,9 @@ export type SlackWebhookOutcome =
   | 'duplicate'
   | 'unknown-team'
   | 'revoked-installation'
+  | 'revoked'
+  | 'unaffected-revocation'
+  | 'stale-lifecycle-event'
   | 'missing-connection'
   | 'inactive-connection'
   | 'unsupported-event'
@@ -50,6 +62,7 @@ interface SlackWebhookParams {
 
 export interface HandleSlackEventParams extends SlackWebhookParams {
   envelope: SlackEventBaseEnvelopeDto;
+  claimWebhookDelivery: ClaimWebhookDeliveryFn;
 }
 
 export interface HandleSlackCommandParams extends SlackWebhookParams {
@@ -60,15 +73,25 @@ type SlackConnectionResolution =
   | {kind: 'ok'; connection: IntegrationConnection; installation: SlackInstallation}
   | {
       kind: 'drop';
-      outcome: Exclude<
-        SlackWebhookOutcome,
-        'published' | 'duplicate' | 'unsupported-event' | 'self-message'
-      >;
+      outcome: SlackConnectionDropOutcome;
     };
+
+type SlackCommandOutcome = Exclude<
+  SlackWebhookOutcome,
+  | 'unsupported-event'
+  | 'self-message'
+  | 'revoked'
+  | 'unaffected-revocation'
+  | 'stale-lifecycle-event'
+>;
+type SlackConnectionDropOutcome = Exclude<SlackCommandOutcome, 'published' | 'duplicate'>;
 
 export async function handleSlackEvent(
   params: HandleSlackEventParams,
 ): Promise<{outcome: SlackWebhookOutcome}> {
+  const lifecycleType = asSlackLifecycleEventType(params.envelope.event.type);
+  if (lifecycleType) return handleSlackLifecycleEvent(params, lifecycleType);
+
   const resolution = await resolveSlackConnection({
     ...params,
     teamId: params.envelope.team_id,
@@ -120,7 +143,7 @@ export async function handleSlackEvent(
 
 export async function handleSlackCommand(
   params: HandleSlackCommandParams,
-): Promise<{outcome: Exclude<SlackWebhookOutcome, 'unsupported-event' | 'self-message'>}> {
+): Promise<{outcome: SlackCommandOutcome}> {
   const resolution = await resolveSlackConnection({
     ...params,
     teamId: params.command.team_id,
@@ -156,6 +179,120 @@ export function isSelfAuthoredSlackEvent(event: unknown, botUserId: string): boo
     nestedMessage?.bot_id !== undefined ||
     nestedMessage?.user === botUserId
   );
+}
+
+function asSlackLifecycleEventType(eventType: string): SlackLifecycleEventType | undefined {
+  return slackLifecycleEventTypes.find((type) => type === eventType);
+}
+
+async function handleSlackLifecycleEvent(
+  params: HandleSlackEventParams,
+  lifecycleType: SlackLifecycleEventType,
+): Promise<{outcome: SlackWebhookOutcome}> {
+  const claim = await params.claimWebhookDelivery({
+    tx: params.tx,
+    provider: SLACK_PROVIDER,
+    deliveryId: params.deliveryId,
+  });
+  if (!claim.claimed) {
+    logger().info(
+      {deliveryId: params.deliveryId, teamId: params.envelope.team_id, lifecycleType},
+      'slack lifecycle event: duplicate delivery, dropping',
+    );
+    return {outcome: 'duplicate'};
+  }
+
+  const installation = await getSlackInstallationByTeamId(params.envelope.team_id, {tx: params.tx});
+  if (!installation) {
+    logger().warn(
+      {deliveryId: params.deliveryId, teamId: params.envelope.team_id, lifecycleType},
+      'slack lifecycle event: unknown team, dropping',
+    );
+    return {outcome: 'unknown-team'};
+  }
+
+  if (installation.status !== 'installed') {
+    logger().info(
+      {
+        deliveryId: params.deliveryId,
+        teamId: params.envelope.team_id,
+        connectionId: installation.connectionId,
+        lifecycleType,
+      },
+      'slack lifecycle event: installation is not installed, dropping',
+    );
+    return {outcome: 'revoked-installation'};
+  }
+
+  if (
+    isSlackLifecycleEventOlderThanInstallation(params.envelope.event_time, installation.updatedAt)
+  ) {
+    logger().info(
+      {
+        deliveryId: params.deliveryId,
+        teamId: params.envelope.team_id,
+        connectionId: installation.connectionId,
+      },
+      'slack lifecycle event: predates the current installation, dropping',
+    );
+    return {outcome: 'stale-lifecycle-event'};
+  }
+
+  const revokesInstallation =
+    lifecycleType === SLACK_APP_UNINSTALLED_EVENT ||
+    slackTokensRevokedAffectsBot(params.envelope.event, installation.botUserId);
+  if (!revokesInstallation) {
+    logger().info(
+      {
+        deliveryId: params.deliveryId,
+        teamId: params.envelope.team_id,
+        connectionId: installation.connectionId,
+      },
+      'slack lifecycle event: token revocation does not affect installation bot, dropping',
+    );
+    return {outcome: 'unaffected-revocation'};
+  }
+
+  const revoked = await markSlackInstallationRevoked(installation.connectionId, {
+    tx: params.tx,
+    expectedGeneration: installation.generation,
+  });
+  if (!revoked) {
+    logger().info(
+      {
+        deliveryId: params.deliveryId,
+        teamId: params.envelope.team_id,
+        connectionId: installation.connectionId,
+      },
+      'slack lifecycle event: installation changed before revocation, dropping',
+    );
+    return {outcome: 'stale-lifecycle-event'};
+  }
+
+  logger().info(
+    {
+      deliveryId: params.deliveryId,
+      teamId: params.envelope.team_id,
+      connectionId: installation.connectionId,
+      lifecycleType,
+    },
+    'slack lifecycle event: installation revoked',
+  );
+  return {outcome: 'revoked'};
+}
+
+function slackTokensRevokedAffectsBot(event: unknown, botUserId: string): boolean {
+  const parsed = slackTokensRevokedEventSchema.safeParse(event);
+  // Only a named bot token proves this installation credential was revoked; OAuth-only and missing lists do not.
+  return parsed.success && (parsed.data.tokens?.bot?.includes(botUserId) ?? false);
+}
+
+function isSlackLifecycleEventOlderThanInstallation(
+  eventTime: number,
+  installationUpdatedAt: Date,
+): boolean {
+  // Slack event_time has second precision, so an event stamped in the installation second is not provably stale.
+  return eventTime < Math.floor(installationUpdatedAt.getTime() / 1000);
 }
 
 async function resolveSlackConnection(

--- a/libs/api/integration/slack/src/db/installations.test.ts
+++ b/libs/api/integration/slack/src/db/installations.test.ts
@@ -90,4 +90,19 @@ describe('slack installations', () => {
 
     expect(result?.status).toBe('revoked');
   });
+
+  it('does not revoke an installation updated after the lifecycle event was read', async () => {
+    const input = createInstallationInput();
+    const installation = await upsertSlackInstallation(input);
+    await upsertSlackInstallation(input);
+
+    const result = await markSlackInstallationRevoked(input.connectionId, {
+      expectedGeneration: installation.generation,
+    });
+
+    expect(result).toBeUndefined();
+    await expect(getSlackInstallationByConnectionId(input.connectionId)).resolves.toMatchObject({
+      status: 'installed',
+    });
+  });
 });

--- a/libs/api/integration/slack/src/db/installations.ts
+++ b/libs/api/integration/slack/src/db/installations.ts
@@ -1,5 +1,5 @@
 import {isUniqueViolation} from '@shipfox/node-drizzle';
-import {eq} from 'drizzle-orm';
+import {and, eq, sql} from 'drizzle-orm';
 import {
   SlackConnectionAlreadyLinkedError,
   SlackInstallationAlreadyLinkedError,
@@ -18,6 +18,7 @@ export interface SlackInstallation {
   botUserId: string;
   scopes: string[];
   status: SlackInstallationStatus;
+  generation: number;
   tokenExpiresAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
@@ -69,6 +70,7 @@ export async function upsertSlackInstallation(
           botUserId: params.botUserId,
           scopes: params.scopes,
           status: params.status,
+          generation: sql`${slackInstallations.generation} + 1`,
           tokenExpiresAt: params.tokenExpiresAt ?? null,
           updatedAt: now,
         },
@@ -128,13 +130,19 @@ export async function deleteSlackInstallationByConnectionId(
 
 export async function markSlackInstallationRevoked(
   connectionId: string,
-  options: {tx?: unknown} = {},
+  options: {tx?: unknown; expectedGeneration?: number | undefined} = {},
 ): Promise<SlackInstallation | undefined> {
   const executor = (options.tx ?? db()) as SlackDb | SlackTx;
+  const expectedInstallation = options.expectedGeneration
+    ? and(
+        eq(slackInstallations.connectionId, connectionId),
+        eq(slackInstallations.generation, options.expectedGeneration),
+      )
+    : eq(slackInstallations.connectionId, connectionId);
   const [row] = await executor
     .update(slackInstallations)
     .set({status: 'revoked', updatedAt: new Date()})
-    .where(eq(slackInstallations.connectionId, connectionId))
+    .where(expectedInstallation)
     .returning();
   if (!row) return undefined;
   return toSlackInstallation(row);

--- a/libs/api/integration/slack/src/db/schema/installations.ts
+++ b/libs/api/integration/slack/src/db/schema/installations.ts
@@ -1,5 +1,5 @@
 import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
-import {jsonb, text, timestamp, uniqueIndex, uuid} from 'drizzle-orm/pg-core';
+import {integer, jsonb, text, timestamp, uniqueIndex, uuid} from 'drizzle-orm/pg-core';
 import type {SlackInstallation} from '#db/installations.js';
 import {pgTable} from './common.js';
 
@@ -14,6 +14,7 @@ export const slackInstallations = pgTable(
     botUserId: text('bot_user_id').notNull(),
     scopes: jsonb('scopes').notNull().$type<string[]>(),
     status: text('status').notNull().$type<SlackInstallation['status']>(),
+    generation: integer('generation').notNull().default(1),
     tokenExpiresAt: timestamp('token_expires_at', {withTimezone: true}),
     createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', {withTimezone: true}).notNull().defaultNow(),
@@ -37,6 +38,7 @@ export function toSlackInstallation(row: SlackInstallationDb): SlackInstallation
     botUserId: row.botUserId,
     scopes: row.scopes,
     status: row.status,
+    generation: row.generation,
     tokenExpiresAt: row.tokenExpiresAt,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,

--- a/libs/api/integration/slack/src/index.ts
+++ b/libs/api/integration/slack/src/index.ts
@@ -189,6 +189,7 @@ function hasSlackWebhookRoutesOptions(
 ): routes is CreateSlackWebhookRoutesOptions {
   return (
     routes.coreDb !== undefined &&
+    routes.claimWebhookDelivery !== undefined &&
     routes.publishIntegrationEventReceived !== undefined &&
     routes.recordDeliveryOnly !== undefined &&
     routes.getIntegrationConnectionById !== undefined

--- a/libs/api/integration/slack/src/presentation/routes/webhooks.test.ts
+++ b/libs/api/integration/slack/src/presentation/routes/webhooks.test.ts
@@ -2,7 +2,7 @@ import {createHmac, randomUUID} from 'node:crypto';
 import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
 import {closeApp, createApp} from '@shipfox/node-fastify';
 import {db} from '#db/db.js';
-import {upsertSlackInstallation} from '#db/installations.js';
+import {getSlackInstallationByTeamId, upsertSlackInstallation} from '#db/installations.js';
 import {slackInstallations} from '#db/schema/installations.js';
 import {createSlackWebhookRoutes, SLASH_COMMAND_ACK} from './webhooks.js';
 
@@ -46,10 +46,12 @@ async function createTestApp(connection = fakeConnection()): Promise<{
 }> {
   const publishIntegrationEventReceived = vi.fn(() => Promise.resolve({published: true}));
   const recordDeliveryOnly = vi.fn(() => Promise.resolve());
+  const claimWebhookDelivery = vi.fn(() => Promise.resolve({claimed: true}));
   const getIntegrationConnectionById = vi.fn(() => Promise.resolve(connection));
   const app = await createApp({
     routes: createSlackWebhookRoutes({
       coreDb: db,
+      claimWebhookDelivery,
       publishIntegrationEventReceived,
       recordDeliveryOnly,
       getIntegrationConnectionById,
@@ -184,6 +186,31 @@ describe('Slack webhook routes', () => {
         event: expect.objectContaining({event: 'app_mention', deliveryId: 'Ev-route'}),
       }),
     );
+  });
+
+  it('revokes an installation after a signed app-uninstalled event', async () => {
+    const {app, connection, publishIntegrationEventReceived} = await createTestApp();
+    await seedInstallation(connection);
+    const rawBody = JSON.stringify({
+      type: 'event_callback',
+      team_id: 'T1',
+      api_app_id: 'A1',
+      event: {type: 'app_uninstalled'},
+      event_id: 'Ev-route-uninstalled',
+      event_time: Math.floor(Date.now() / 1000) + 60,
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/webhooks/integrations/slack/events',
+      headers: slackHeaders(rawBody, 'application/json'),
+      payload: rawBody,
+    });
+
+    const installation = await getSlackInstallationByTeamId('T1');
+    expect(response.statusCode).toBe(200);
+    expect(installation?.status).toBe('revoked');
+    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
   });
 
   it('returns the fixed acknowledgement for a signed command that cannot resolve a team', async () => {

--- a/libs/api/integration/slack/src/presentation/routes/webhooks.ts
+++ b/libs/api/integration/slack/src/presentation/routes/webhooks.ts
@@ -1,5 +1,6 @@
 import {Buffer} from 'node:buffer';
 import type {
+  ClaimWebhookDeliveryFn,
   GetIntegrationConnectionByIdFn,
   PublishIntegrationEventReceivedFn,
   RecordDeliveryOnlyFn,
@@ -29,6 +30,7 @@ const slackFormRawBodyPlugin = createRawBodyPlugin({
 
 export interface CreateSlackWebhookRoutesOptions {
   coreDb: () => NodePgDatabase<Record<string, unknown>>;
+  claimWebhookDelivery: ClaimWebhookDeliveryFn;
   publishIntegrationEventReceived: PublishIntegrationEventReceivedFn;
   recordDeliveryOnly: RecordDeliveryOnlyFn;
   getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
@@ -84,6 +86,7 @@ export function createSlackWebhookRoutes(options: CreateSlackWebhookRoutesOption
           tx,
           deliveryId: eventRequest.event_id,
           envelope: eventRequest,
+          claimWebhookDelivery: options.claimWebhookDelivery,
           publishIntegrationEventReceived: options.publishIntegrationEventReceived,
           recordDeliveryOnly: options.recordDeliveryOnly,
           getIntegrationConnectionById: options.getIntegrationConnectionById,


### PR DESCRIPTION
Adds signed Slack app-uninstall and bot-token-revocation handling that revokes the matching installation without changing the connection lifecycle.

Slack can retry or delay lifecycle deliveries after a reconnect. The handler now claims each delivery before mutation, rejects events older than the current installation, and uses a persisted installation generation to prevent a concurrent reconnect from being revoked.

`tokens_revoked` affects an installation only when Slack names its bot user ID; OAuth-only, missing, and empty bot token lists leave it installed.

Closes ENG-1016

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Safely revoke Slack installations on `app_uninstalled` and bot `tokens_revoked` events with deduped deliveries and stale-delivery protection. Addresses ENG-1016 and preserves the reconnect flow.

- **New Features**
  - Handle Slack lifecycle events: `app_uninstalled` and `tokens_revoked` (bot-only).
  - Deduplicate lifecycle deliveries via `claimWebhookDelivery` in `@shipfox/api-integration-core` and wire it into Slack webhooks.
  - Block stale retries using event_time vs installation updatedAt and a persisted installation `generation`.
  - Ignore OAuth-only or empty revocations and do not emit integration events for lifecycle events.
  - Add lifecycle schemas and types to `@shipfox/api-integration-slack-dto`.

- **Migration**
  - Run DB migrations: adds `generation` column to `integrations_slack_installations` (defaults to 1).
  - No config changes required. Existing installations are initialized automatically.

<sup>Written for commit 0e2bfd951857182c2ca16c5dc3706216340ba319. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

