### PR TITLE
[swc] Restore shipfox-swc package binary

### DIFF
--- a/.changeset/gentle-otters-restore.md
+++ b/.changeset/gentle-otters-restore.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/swc": patch
+---
+
+Restores the `shipfox-swc` command in the published SWC package.


### PR DESCRIPTION
Republish @shipfox/swc with its documented `shipfox-swc` executable.

@shipfox/swc@1.2.5 was published with the npm-normalized `swc` binary even though this repository's manifest has long declared `shipfox-swc`. This patch changeset makes the version workflow republish from the current source, restoring external consumers without the temporary workaround.

No source manifest change is necessary: `tools/swc/package.json` already has the correct object-form bin. Review should focus on the patch-release scope.

Closes ENG-1025

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Republishes `@shipfox/swc` to restore the documented `shipfox-swc` binary; 1.2.5 incorrectly exposed `swc` and broke consumers. Addresses ENG-1025 with a patch release from the existing `tools/swc/package.json` (no code changes).

<sup>Written for commit 01602f88309cfab8f00b31c8b1bc1994d1fabd29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

