### PR TITLE
[integrations] Cascade provider cleanup on deletion

### DIFF
--- a/.changeset/tidy-wolves-clean.md
+++ b/.changeset/tidy-wolves-clean.md
@@ -1,0 +1,8 @@
+---
+"@shipfox/api-integration-core-dto": minor
+"@shipfox/api-integration-core": patch
+"@shipfox/api-integration-slack": minor
+"@shipfox/api-integration-linear": minor
+---
+
+Cascades provider installation and token deletion when removing a connection.

--- a/libs/api/integration/core-dto/src/contracts/integrations.ts
+++ b/libs/api/integration/core-dto/src/contracts/integrations.ts
@@ -218,6 +218,19 @@ export interface IntegrationProvider<
    * no external home or the provider-side record is missing.
    */
   connectionExternalUrl?(connection: Connection): Promise<string | undefined>;
+  /**
+   * Deletes provider-owned persistence rows for a connection inside the caller's
+   * transaction. The transaction belongs to the shared integration database, so
+   * provider persistence must use it. The core delete route owns the connection row.
+   * Providers without either cleanup hook remove only that core row.
+   */
+  deleteConnectionRecords?(connection: Connection, options: {tx: unknown}): Promise<void>;
+  /**
+   * Deletes provider-owned secrets after the connection transaction commits.
+   * External secret stores cannot participate in the database transaction, so a
+   * failure is logged after the connection has already been deleted.
+   */
+  deleteConnectionSecrets?(connection: Connection): Promise<void>;
 }
 
 export interface RegisteredIntegrationProvider<

--- a/libs/api/integration/core/src/presentation/routes/index.ts
+++ b/libs/api/integration/core/src/presentation/routes/index.ts
@@ -45,7 +45,7 @@ export function createIntegrationRoutes(
     createListIntegrationProvidersRoute(registry),
     createListIntegrationConnectionsRoute(registry),
     createUpdateIntegrationConnectionRoute(registry),
-    createDeleteIntegrationConnectionRoute(),
+    createDeleteIntegrationConnectionRoute(registry),
     createListRepositoriesRoute(sourceControl),
     ...agentToolsRoutes,
     ...providerRoutes,

--- a/libs/api/integration/core/src/presentation/routes/manage-connections.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/manage-connections.test.ts
@@ -110,6 +110,119 @@ describe('DELETE /integration-connections/:connectionId', () => {
     expect(reloaded).toBeUndefined();
   });
 
+  it('runs provider cleanup hooks while retaining ownership of the core row', async () => {
+    const deleteConnectionRecords = vi.fn(() => Promise.resolve());
+    const deleteConnectionSecrets = vi.fn(() => Promise.resolve());
+    const app = await createTestApp([
+      sourceProvider({
+        provider: 'slack',
+        displayName: 'Slack',
+        adapters: {},
+        deleteConnectionRecords,
+        deleteConnectionSecrets,
+      }),
+    ]);
+    const connection = await upsertIntegrationConnection({
+      workspaceId: context.workspaceId,
+      provider: 'slack',
+      externalAccountId: 'T123',
+      slug: 'slack_acme',
+      displayName: 'Slack Acme',
+    });
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/integration-connections/${connection.id}`,
+      headers: {authorization: 'Bearer user'},
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(deleteConnectionRecords).toHaveBeenCalledWith(connection, {
+      tx: expect.anything(),
+    });
+    expect(deleteConnectionSecrets).toHaveBeenCalledWith(connection);
+    await expect(getIntegrationConnectionById(connection.id)).resolves.toBeUndefined();
+  });
+
+  it('keeps the connection when provider record cleanup fails', async () => {
+    const deleteConnectionSecrets = vi.fn(() => Promise.resolve());
+    const app = await createTestApp([
+      sourceProvider({
+        provider: 'slack',
+        displayName: 'Slack',
+        adapters: {},
+        deleteConnectionRecords: () => Promise.reject(new Error('record cleanup failed')),
+        deleteConnectionSecrets,
+      }),
+    ]);
+    const connection = await upsertIntegrationConnection({
+      workspaceId: context.workspaceId,
+      provider: 'slack',
+      externalAccountId: 'T123',
+      slug: 'slack_acme',
+      displayName: 'Slack Acme',
+    });
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/integration-connections/${connection.id}`,
+      headers: {authorization: 'Bearer user'},
+    });
+
+    expect(res.statusCode).toBe(500);
+    await expect(getIntegrationConnectionById(connection.id)).resolves.toMatchObject({
+      id: connection.id,
+    });
+    expect(deleteConnectionSecrets).not.toHaveBeenCalled();
+  });
+
+  it('deletes the connection when provider secret cleanup fails after commit', async () => {
+    const app = await createTestApp([
+      sourceProvider({
+        provider: 'slack',
+        displayName: 'Slack',
+        adapters: {},
+        deleteConnectionSecrets: () => Promise.reject(new Error('secret cleanup failed')),
+      }),
+    ]);
+    const connection = await upsertIntegrationConnection({
+      workspaceId: context.workspaceId,
+      provider: 'slack',
+      externalAccountId: 'T123',
+      slug: 'slack_acme',
+      displayName: 'Slack Acme',
+    });
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/integration-connections/${connection.id}`,
+      headers: {authorization: 'Bearer user'},
+    });
+
+    expect(res.statusCode).toBe(204);
+    await expect(getIntegrationConnectionById(connection.id)).resolves.toBeUndefined();
+  });
+
+  it('deletes an unregistered provider connection without provider cleanup', async () => {
+    const app = await createTestApp([]);
+    const connection = await upsertIntegrationConnection({
+      workspaceId: context.workspaceId,
+      provider: 'slack',
+      externalAccountId: 'T123',
+      slug: 'slack_acme',
+      displayName: 'Slack Acme',
+    });
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/integration-connections/${connection.id}`,
+      headers: {authorization: 'Bearer user'},
+    });
+
+    expect(res.statusCode).toBe(204);
+    await expect(getIntegrationConnectionById(connection.id)).resolves.toBeUndefined();
+  });
+
   it('returns not-found for a missing connection', async () => {
     const app = await createTestApp([sourceProvider()]);
 

--- a/libs/api/integration/core/src/presentation/routes/manage-connections.ts
+++ b/libs/api/integration/core/src/presentation/routes/manage-connections.ts
@@ -11,6 +11,7 @@ import {
   getIntegrationConnectionById,
   updateIntegrationConnectionLifecycleStatus,
 } from '#db/connections.js';
+import {db} from '#db/db.js';
 import {toIntegrationConnectionDto} from '#presentation/dto/integrations.js';
 
 const connectionParamsSchema = z.object({
@@ -51,7 +52,7 @@ export function createUpdateIntegrationConnectionRoute(registry: IntegrationProv
   });
 }
 
-export function createDeleteIntegrationConnectionRoute() {
+export function createDeleteIntegrationConnectionRoute(registry: IntegrationProviderRegistry) {
   return defineRoute({
     method: 'DELETE',
     path: '/integration-connections/:connectionId',
@@ -70,7 +71,30 @@ export function createDeleteIntegrationConnectionRoute() {
       }
 
       requireWorkspaceAccess({request, workspaceId: connection.workspaceId});
-      await deleteIntegrationConnection({id: connection.id});
+      const provider = registry
+        .list()
+        .find((candidate) => candidate.provider === connection.provider);
+      const hasCleanupHooks =
+        provider?.deleteConnectionRecords !== undefined ||
+        provider?.deleteConnectionSecrets !== undefined;
+      if (!hasCleanupHooks) {
+        request.log.warn(
+          {connectionId: connection.id, provider: connection.provider},
+          'Deleting integration connection without provider cleanup',
+        );
+      }
+      await db().transaction(async (tx) => {
+        await provider?.deleteConnectionRecords?.(connection, {tx});
+        await deleteIntegrationConnection({id: connection.id}, {tx});
+      });
+      try {
+        await provider?.deleteConnectionSecrets?.(connection);
+      } catch (error) {
+        request.log.error(
+          {connectionId: connection.id, provider: connection.provider, err: error},
+          'Integration connection secret cleanup failed after connection deletion',
+        );
+      }
       reply.status(204);
     },
   });

--- a/libs/api/integration/core/src/providers/linear.test.ts
+++ b/libs/api/integration/core/src/providers/linear.test.ts
@@ -1,0 +1,136 @@
+import {
+  getLinearInstallationByConnectionId,
+  upsertLinearInstallation,
+} from '@shipfox/api-integration-linear';
+import {runMigrations} from '@shipfox/node-drizzle';
+import {getIntegrationConnectionById, upsertIntegrationConnection} from '#db/connections.js';
+import {db} from '#db/db.js';
+import {linearProviderModule} from '#providers/linear.js';
+import {createTestApp, useIntegrationRouteTest} from '#test/route-utils.js';
+
+describe('linearProviderModule', () => {
+  const context = useIntegrationRouteTest();
+
+  it('deletes the installation and tokens through the generic route before allowing a reinstall', async () => {
+    const deleteSecrets = vi.fn(() => Promise.resolve(2));
+    const scopedSecrets = {
+      getSecret: vi.fn(() => Promise.resolve(null)),
+      setSecrets: vi.fn(() => Promise.resolve()),
+      deleteSecrets,
+    };
+    const linearPart = await linearProviderModule.load({
+      secrets: {linear: scopedSecrets, deleteSecrets},
+    });
+    if (!linearPart.database) throw new Error('Linear provider database is not configured');
+    const organizationId = crypto.randomUUID();
+
+    await runMigrations(
+      linearPart.database.db(),
+      linearPart.database.migrationsPath,
+      linearPart.database.migrationsTableName,
+    );
+    const app = await createTestApp([linearPart.provider]);
+    const connection = await upsertIntegrationConnection({
+      workspaceId: context.workspaceId,
+      provider: 'linear',
+      externalAccountId: organizationId,
+      slug: 'linear_acme',
+      displayName: 'Linear Acme',
+    });
+    await upsertLinearInstallation({
+      connectionId: connection.id,
+      organizationId,
+      organizationUrlKey: 'acme',
+      appUserId: 'user-1',
+      scopes: ['read'],
+      status: 'installed',
+      tokenExpiresAt: null,
+    });
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/integration-connections/${connection.id}`,
+      headers: {authorization: 'Bearer user'},
+    });
+
+    expect(res.statusCode).toBe(204);
+    await expect(getIntegrationConnectionById(connection.id)).resolves.toBeUndefined();
+    await expect(getLinearInstallationByConnectionId(connection.id)).resolves.toBeUndefined();
+    expect(deleteSecrets).toHaveBeenCalledWith({
+      workspaceId: context.workspaceId,
+      namespace: connection.id,
+    });
+
+    const replacement = await upsertIntegrationConnection({
+      workspaceId: context.workspaceId,
+      provider: 'linear',
+      externalAccountId: organizationId,
+      slug: 'linear_acme_again',
+      displayName: 'Linear Acme',
+    });
+    await upsertLinearInstallation({
+      connectionId: replacement.id,
+      organizationId,
+      organizationUrlKey: 'acme',
+      appUserId: 'user-1',
+      scopes: ['read'],
+      status: 'installed',
+      tokenExpiresAt: null,
+    });
+
+    await expect(getLinearInstallationByConnectionId(replacement.id)).resolves.toMatchObject({
+      organizationId,
+    });
+  });
+
+  it('rolls back provider record cleanup when its transaction fails', async () => {
+    const deleteSecrets = vi.fn(() => Promise.resolve(2));
+    const scopedSecrets = {
+      getSecret: vi.fn(() => Promise.resolve(null)),
+      setSecrets: vi.fn(() => Promise.resolve()),
+      deleteSecrets,
+    };
+    const linearPart = await linearProviderModule.load({
+      secrets: {linear: scopedSecrets, deleteSecrets},
+    });
+    if (!linearPart.database) throw new Error('Linear provider database is not configured');
+    const organizationId = crypto.randomUUID();
+
+    await runMigrations(
+      linearPart.database.db(),
+      linearPart.database.migrationsPath,
+      linearPart.database.migrationsTableName,
+    );
+    const connection = await upsertIntegrationConnection({
+      workspaceId: context.workspaceId,
+      provider: 'linear',
+      externalAccountId: organizationId,
+      slug: 'linear_acme',
+      displayName: 'Linear Acme',
+    });
+    await upsertLinearInstallation({
+      connectionId: connection.id,
+      organizationId,
+      organizationUrlKey: 'acme',
+      appUserId: 'user-1',
+      scopes: ['read'],
+      status: 'installed',
+      tokenExpiresAt: null,
+    });
+
+    await expect(
+      db().transaction(async (tx) => {
+        await linearPart.provider.deleteConnectionRecords?.(connection, {tx});
+        throw new Error('transaction failed');
+      }),
+    ).rejects.toThrow('transaction failed');
+
+    await expect(getIntegrationConnectionById(connection.id)).resolves.toMatchObject({
+      id: connection.id,
+    });
+    await expect(getLinearInstallationByConnectionId(connection.id)).resolves.toMatchObject({
+      connectionId: connection.id,
+    });
+    expect(deleteSecrets).not.toHaveBeenCalled();
+  });
+});

--- a/libs/api/integration/core/src/providers/linear.ts
+++ b/libs/api/integration/core/src/providers/linear.ts
@@ -32,9 +32,11 @@ async function loadLinearModuleParts(
     createLinearE2eRoutes,
     createLinearIntegrationProvider,
     config: linearConfig,
+    deleteLinearInstallationByConnectionId,
     disconnectLinearInstallation: disconnectLinearInstallationRecords,
     getLinearInstallationByOrganizationId,
     db: linearDb,
+    linearSecretsNamespace,
     migrationsPath: linearMigrationsPath,
     upsertLinearInstallation,
   } = await import('@shipfox/api-integration-linear');
@@ -137,6 +139,18 @@ async function loadLinearModuleParts(
   return {
     provider: createLinearIntegrationProvider({
       agentTools: {tokenStore, endpoint: linearConfig.LINEAR_MCP_ENDPOINT},
+      cleanup: {
+        deleteConnectionRecords: async (connection, {tx}) => {
+          await deleteLinearInstallationByConnectionId(connection.id, {tx});
+        },
+        deleteConnectionSecrets: async (connection) => {
+          // Scoped secrets accept the provider-local suffix, after this helper validates its prefix.
+          await (options.secrets?.linear?.deleteSecrets({
+            workspaceId: connection.workspaceId,
+            namespace: linearNamespaceSuffix(linearSecretsNamespace(connection.id)),
+          }) ?? Promise.resolve());
+        },
+      },
       routes: {
         tokenStore,
         getExistingLinearConnection,

--- a/libs/api/integration/core/src/providers/slack.test.ts
+++ b/libs/api/integration/core/src/providers/slack.test.ts
@@ -4,8 +4,12 @@ import {
 } from '@shipfox/api-integration-slack';
 import {runMigrations} from '@shipfox/node-drizzle';
 import {getIntegrationConnectionById, upsertIntegrationConnection} from '#db/connections.js';
+import {db} from '#db/db.js';
+import {createTestApp, useIntegrationRouteTest} from '#test/route-utils.js';
 
 describe('slackProviderModule', () => {
+  const context = useIntegrationRouteTest();
+
   afterEach(() => {
     vi.unstubAllEnvs();
     vi.resetModules();
@@ -53,5 +57,140 @@ describe('slackProviderModule', () => {
       connectionId: connection.id,
       teamId,
     });
+  });
+
+  it('deletes the installation and token through the generic route before allowing a reinstall', async () => {
+    vi.stubEnv('INTEGRATIONS_ENABLE_SLACK_PROVIDER', 'true');
+    vi.resetModules();
+    const deleteSecrets = vi.fn(() => Promise.resolve(1));
+    const scopedSecrets = {
+      getSecret: vi.fn(() => Promise.resolve(null)),
+      setSecrets: vi.fn(() => Promise.resolve()),
+      deleteSecrets,
+    };
+    const {createPostgresClient} = await import('@shipfox/node-postgres');
+    createPostgresClient();
+    const {loadEnabledProviderModules} = await import('#providers/modules.js');
+    const parts = await loadEnabledProviderModules({
+      secrets: {slack: scopedSecrets, deleteSecrets},
+    });
+    const slackPart = parts.find((part) => part.provider.provider === 'slack');
+    if (!slackPart?.database) throw new Error('Slack provider database is not configured');
+    const teamId = `T${crypto.randomUUID()}`;
+
+    await runMigrations(
+      slackPart.database.db(),
+      slackPart.database.migrationsPath,
+      slackPart.database.migrationsTableName,
+    );
+    const app = await createTestApp([slackPart.provider]);
+    const connection = await upsertIntegrationConnection({
+      workspaceId: context.workspaceId,
+      provider: 'slack',
+      externalAccountId: teamId,
+      slug: `slack_${teamId}`,
+      displayName: 'Slack Acme',
+    });
+    await upsertSlackInstallation({
+      connectionId: connection.id,
+      teamId,
+      teamName: 'Acme',
+      appId: 'A123',
+      botUserId: 'U123',
+      scopes: ['app_mentions:read'],
+      status: 'installed',
+    });
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/integration-connections/${connection.id}`,
+      headers: {authorization: 'Bearer user'},
+    });
+
+    expect(res.statusCode).toBe(204);
+    await expect(getIntegrationConnectionById(connection.id)).resolves.toBeUndefined();
+    await expect(getSlackInstallationByConnectionId(connection.id)).resolves.toBeUndefined();
+    expect(deleteSecrets).toHaveBeenCalledWith({
+      workspaceId: context.workspaceId,
+      namespace: connection.id,
+    });
+
+    const replacement = await upsertIntegrationConnection({
+      workspaceId: context.workspaceId,
+      provider: 'slack',
+      externalAccountId: teamId,
+      slug: `slack_${teamId}_again`,
+      displayName: 'Slack Acme',
+    });
+    await upsertSlackInstallation({
+      connectionId: replacement.id,
+      teamId,
+      teamName: 'Acme',
+      appId: 'A123',
+      botUserId: 'U123',
+      scopes: ['app_mentions:read'],
+      status: 'installed',
+    });
+
+    await expect(getSlackInstallationByConnectionId(replacement.id)).resolves.toMatchObject({
+      teamId,
+    });
+  });
+
+  it('rolls back provider record cleanup when its transaction fails', async () => {
+    vi.stubEnv('INTEGRATIONS_ENABLE_SLACK_PROVIDER', 'true');
+    vi.resetModules();
+    const deleteSecrets = vi.fn(() => Promise.resolve(1));
+    const scopedSecrets = {
+      getSecret: vi.fn(() => Promise.resolve(null)),
+      setSecrets: vi.fn(() => Promise.resolve()),
+      deleteSecrets,
+    };
+    const {createPostgresClient} = await import('@shipfox/node-postgres');
+    createPostgresClient();
+    const {loadEnabledProviderModules} = await import('#providers/modules.js');
+    const parts = await loadEnabledProviderModules({
+      secrets: {slack: scopedSecrets, deleteSecrets},
+    });
+    const slackPart = parts.find((part) => part.provider.provider === 'slack');
+    if (!slackPart?.database) throw new Error('Slack provider database is not configured');
+    const teamId = `T${crypto.randomUUID()}`;
+
+    await runMigrations(
+      slackPart.database.db(),
+      slackPart.database.migrationsPath,
+      slackPart.database.migrationsTableName,
+    );
+    const connection = await upsertIntegrationConnection({
+      workspaceId: context.workspaceId,
+      provider: 'slack',
+      externalAccountId: teamId,
+      slug: `slack_${teamId}`,
+      displayName: 'Slack Acme',
+    });
+    await upsertSlackInstallation({
+      connectionId: connection.id,
+      teamId,
+      teamName: 'Acme',
+      appId: 'A123',
+      botUserId: 'U123',
+      scopes: ['app_mentions:read'],
+      status: 'installed',
+    });
+
+    await expect(
+      db().transaction(async (tx) => {
+        await slackPart.provider.deleteConnectionRecords?.(connection, {tx});
+        throw new Error('transaction failed');
+      }),
+    ).rejects.toThrow('transaction failed');
+
+    await expect(getIntegrationConnectionById(connection.id)).resolves.toMatchObject({
+      id: connection.id,
+    });
+    await expect(getSlackInstallationByConnectionId(connection.id)).resolves.toMatchObject({
+      connectionId: connection.id,
+    });
+    expect(deleteSecrets).not.toHaveBeenCalled();
   });
 });

--- a/libs/api/integration/core/src/providers/slack.ts
+++ b/libs/api/integration/core/src/providers/slack.ts
@@ -36,9 +36,11 @@ async function loadSlackModuleParts(
     createSlackIntegrationProvider,
     createSlackTokenStore,
     db: slackDb,
+    deleteSlackInstallationByConnectionId,
     disconnectSlackInstallation: disconnectSlackInstallationRecords,
     getSlackInstallationByTeamId,
     migrationsPath: slackMigrationsPath,
+    slackSecretsNamespace,
     upsertSlackInstallation,
   } = await import('@shipfox/api-integration-slack');
 
@@ -139,6 +141,18 @@ async function loadSlackModuleParts(
   return {
     provider: createSlackIntegrationProvider({
       agentTools: {tokenStore},
+      cleanup: {
+        deleteConnectionRecords: async (connection, {tx}) => {
+          await deleteSlackInstallationByConnectionId(connection.id, {tx});
+        },
+        deleteConnectionSecrets: async (connection) => {
+          // Scoped secrets accept the provider-local suffix, after this helper validates its prefix.
+          await (options.secrets?.slack?.deleteSecrets({
+            workspaceId: connection.workspaceId,
+            namespace: slackNamespaceSuffix(slackSecretsNamespace(connection.id)),
+          }) ?? Promise.resolve());
+        },
+      },
       routes: {
         tokenStore,
         getExistingSlackConnection,

--- a/libs/api/integration/linear/src/index.test.ts
+++ b/libs/api/integration/linear/src/index.test.ts
@@ -17,4 +17,15 @@ describe('createLinearIntegrationProvider', () => {
 
     expect(provider.adapters.agent_tools?.catalog()).toBe(linearAgentToolCatalog);
   });
+
+  it('exposes explicit connection cleanup without requiring routes', () => {
+    const deleteConnectionRecords = vi.fn(() => Promise.resolve());
+    const deleteConnectionSecrets = vi.fn(() => Promise.resolve());
+    const provider = createLinearIntegrationProvider({
+      cleanup: {deleteConnectionRecords, deleteConnectionSecrets},
+    });
+
+    expect(provider.deleteConnectionRecords).toBe(deleteConnectionRecords);
+    expect(provider.deleteConnectionSecrets).toBe(deleteConnectionSecrets);
+  });
 });

--- a/libs/api/integration/linear/src/index.ts
+++ b/libs/api/integration/linear/src/index.ts
@@ -74,6 +74,7 @@ export type {
   UpsertLinearInstallationParams,
 } from '#db/installations.js';
 export {
+  deleteLinearInstallationByConnectionId,
   getLinearInstallationByConnectionId,
   getLinearInstallationByOrganizationId,
   markLinearInstallationRevoked,
@@ -97,6 +98,15 @@ export interface CreateLinearIntegrationProviderOptions {
       }
     | undefined;
   getLinearInstallationByConnectionId?: typeof getLinearInstallationByConnectionId | undefined;
+  cleanup?:
+    | {
+        deleteConnectionRecords?: (
+          connection: {id: string},
+          options: {tx: unknown},
+        ) => Promise<void>;
+        deleteConnectionSecrets?: (connection: {id: string; workspaceId: string}) => Promise<void>;
+      }
+    | undefined;
   routes?:
     | (Omit<CreateLinearIntegrationRoutesOptions, 'linear' | 'connectionCapabilities'> &
         Partial<CreateLinearWebhookRoutesOptions>)
@@ -137,6 +147,7 @@ export function createLinearIntegrationProvider(
       if (!installation?.organizationUrlKey) return undefined;
       return `https://linear.app/${encodeURIComponent(installation.organizationUrlKey)}/settings`;
     },
+    ...options.cleanup,
     routes,
   };
 }

--- a/libs/api/integration/slack/src/core/disconnect.test.ts
+++ b/libs/api/integration/slack/src/core/disconnect.test.ts
@@ -1,0 +1,49 @@
+import {disconnectSlackInstallation} from './disconnect.js';
+
+vi.mock('#db/installations.js', () => ({
+  deleteSlackInstallationByConnectionId: vi.fn(() => Promise.resolve(true)),
+}));
+
+const {deleteSlackInstallationByConnectionId} = await import('#db/installations.js');
+const deleteSlackInstallationByConnectionIdMock = vi.mocked(deleteSlackInstallationByConnectionId);
+
+describe('disconnectSlackInstallation', () => {
+  beforeEach(() => {
+    deleteSlackInstallationByConnectionIdMock.mockClear();
+  });
+
+  it('deletes stored tokens before deleting connection records', async () => {
+    const tx = Symbol('tx');
+    const calls: string[] = [];
+    const deleteSecrets = vi.fn(() => {
+      calls.push('secrets');
+      return Promise.resolve(1);
+    });
+    const deleteConnection = vi.fn(() => {
+      calls.push('connection');
+      return Promise.resolve(true);
+    });
+
+    await disconnectSlackInstallation({
+      connectionId: 'connection-1',
+      getConnection: vi.fn(() => Promise.resolve({workspaceId: 'workspace-1'})),
+      deleteSecrets,
+      transaction: async (fn) => await fn(tx),
+      deleteConnection,
+    });
+
+    expect(deleteSecrets).toHaveBeenCalledWith({
+      workspaceId: 'workspace-1',
+      namespace: 'system/integrations/slack/connection-1',
+    });
+    expect(deleteSlackInstallationByConnectionIdMock).toHaveBeenCalledWith('connection-1', {tx});
+    expect(deleteConnection).toHaveBeenCalledWith({connectionId: 'connection-1'}, {tx});
+    expect(calls).toEqual(['secrets', 'connection']);
+    expect(deleteSecrets.mock.invocationCallOrder[0]).toBeLessThan(
+      deleteSlackInstallationByConnectionIdMock.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(deleteSlackInstallationByConnectionIdMock.mock.invocationCallOrder[0]).toBeLessThan(
+      deleteConnection.mock.invocationCallOrder[0] ?? 0,
+    );
+  });
+});

--- a/libs/api/integration/slack/src/index.test.ts
+++ b/libs/api/integration/slack/src/index.test.ts
@@ -22,4 +22,15 @@ describe('createSlackIntegrationProvider', () => {
 
     expect(catalog).toBe(slackAgentToolCatalog);
   });
+
+  it('exposes explicit connection cleanup without requiring routes', () => {
+    const deleteConnectionRecords = vi.fn(() => Promise.resolve());
+    const deleteConnectionSecrets = vi.fn(() => Promise.resolve());
+    const provider = createSlackIntegrationProvider({
+      cleanup: {deleteConnectionRecords, deleteConnectionSecrets},
+    });
+
+    expect(provider.deleteConnectionRecords).toBe(deleteConnectionRecords);
+    expect(provider.deleteConnectionSecrets).toBe(deleteConnectionSecrets);
+  });
 });

--- a/libs/api/integration/slack/src/index.ts
+++ b/libs/api/integration/slack/src/index.ts
@@ -113,6 +113,15 @@ export interface CreateSlackIntegrationProviderOptions {
   slack?: SlackApiClient | undefined;
   agentTools?: {tokenStore: Pick<SlackTokenStore, 'getAccessToken'>} | undefined;
   getSlackInstallationByConnectionId?: typeof getSlackInstallationByConnectionId | undefined;
+  cleanup?:
+    | {
+        deleteConnectionRecords?: (
+          connection: {id: string},
+          options: {tx: unknown},
+        ) => Promise<void>;
+        deleteConnectionSecrets?: (connection: {id: string; workspaceId: string}) => Promise<void>;
+      }
+    | undefined;
   routes?: SlackRouteOptions | undefined;
 }
 
@@ -169,6 +178,7 @@ export function createSlackIntegrationProvider(
       if (!installation) return undefined;
       return `https://app.slack.com/client/${encodeURIComponent(installation.teamId)}`;
     },
+    ...options.cleanup,
     routes,
   };
 }


### PR DESCRIPTION
Cascade Slack and Linear installation cleanup when deleting an integration connection.

The generic delete route previously removed only the core connection row, leaving provider installation records and scoped tokens behind. Provider cleanup hooks now remove records in the shared transaction and delete tokens after commit, so a temporary secret-store failure is logged without reporting a completed deletion as retryable.

Providers without cleanup hooks retain the existing core-only behavior and emit a warning for follow-up.

Closes ENG-996

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cascade cleanup on integration deletion for Slack and Linear: installation rows are removed inside the delete transaction, then provider-scoped secrets are deleted after commit to prevent orphaned data and unblock reinstall. Fixes ENG-996.

- **New Features**
  - Core delete route in `@shipfox/api-integration-core` runs provider cleanup from the registry: `deleteConnectionRecords` in-transaction, then `deleteConnectionSecrets` after commit; record-cleanup errors keep the connection, secret-cleanup errors are logged.
  - Provider contract in `@shipfox/api-integration-core-dto` adds `deleteConnectionRecords` and `deleteConnectionSecrets`; `@shipfox/api-integration-slack` and `@shipfox/api-integration-linear` implement both to remove installation rows and purge scoped tokens.
  - Providers without hooks continue core-only deletion and emit a warning.

<sup>Written for commit 68a603a02a00a5a36580a73b3fba33d0df5a77c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

