### PR TITLE
[application-release] Guard packed workflow resolution

### DIFF
--- a/.changeset/curious-lobsters-guard.md
+++ b/.changeset/curious-lobsters-guard.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/application-release": patch
+---
+
+Adds packed-consumer guards for development resolution and Temporal workflow bundling.

--- a/dev/productionized-manifest-packer.mjs
+++ b/dev/productionized-manifest-packer.mjs
@@ -1,0 +1,69 @@
+import {readFile, writeFile} from 'node:fs/promises';
+
+import {productionizeManifest} from '../tools/utils/src/productionize.js';
+
+export function createProductionManifestPacker() {
+  const sourceManifests = new Map();
+  let receivedSignal;
+  const signalHandlers = new Map(
+    ['SIGINT', 'SIGTERM'].map((signal) => [signal, () => handleSignal(signal)]),
+  );
+
+  for (const [signal, handler] of signalHandlers) process.once(signal, handler);
+
+  return {
+    async pack(manifestPath, manifest, packArtifact) {
+      const sourceManifest = await readFile(manifestPath, 'utf8');
+      sourceManifests.set(manifestPath, sourceManifest);
+      await writeFile(
+        manifestPath,
+        `${JSON.stringify(productionizeManifest(manifest), null, 2)}\n`,
+      );
+      try {
+        return await packArtifact();
+      } finally {
+        await writeFile(manifestPath, sourceManifest);
+        sourceManifests.delete(manifestPath);
+      }
+    },
+    dispose() {
+      for (const [signal, handler] of signalHandlers) process.off(signal, handler);
+    },
+  };
+
+  function handleSignal(signal) {
+    if (receivedSignal) return;
+    receivedSignal = signal;
+    void restoreSourceManifests().finally(() => process.kill(process.pid, signal));
+  }
+
+  function restoreSourceManifests() {
+    return Promise.all(
+      [...sourceManifests].map(([manifestPath, sourceManifest]) =>
+        writeFile(manifestPath, sourceManifest),
+      ),
+    );
+  }
+}
+
+export async function mapWithConcurrency(values, concurrency, mapper) {
+  const results = new Array(values.length);
+  let nextIndex = 0;
+  let failure;
+
+  async function worker() {
+    while (nextIndex < values.length && !failure) {
+      const index = nextIndex;
+      nextIndex += 1;
+      try {
+        results[index] = await mapper(values[index], index);
+      } catch (error) {
+        failure ??= error;
+      }
+    }
+  }
+
+  await Promise.all(Array.from({length: concurrency}, () => worker()));
+  if (failure) throw failure;
+  return results;
+}

--- a/dev/productionized-manifest-packer.mjs
+++ b/dev/productionized-manifest-packer.mjs
@@ -1,9 +1,11 @@
+import {spawn} from 'node:child_process';
 import {readFile, writeFile} from 'node:fs/promises';
+import {basename} from 'node:path';
 
 import {productionizeManifest} from '../tools/utils/src/productionize.js';
 
 export function createProductionManifestPacker() {
-  const sourceManifests = new Map();
+  const activePacks = new Set();
   let receivedSignal;
   const signalHandlers = new Map(
     ['SIGINT', 'SIGTERM'].map((signal) => [signal, () => handleSignal(signal)]),
@@ -14,16 +16,27 @@ export function createProductionManifestPacker() {
   return {
     async pack(manifestPath, manifest, packArtifact) {
       const sourceManifest = await readFile(manifestPath, 'utf8');
-      sourceManifests.set(manifestPath, sourceManifest);
-      await writeFile(
-        manifestPath,
-        `${JSON.stringify(productionizeManifest(manifest), null, 2)}\n`,
-      );
+      const controller = new AbortController();
+      let resolveCompletion;
+      const activePack = {
+        completion: new Promise((resolve) => {
+          resolveCompletion = resolve;
+        }),
+        controller,
+      };
+      activePacks.add(activePack);
       try {
-        return await packArtifact();
+        await writeFile(
+          manifestPath,
+          `${JSON.stringify(productionizeManifest(manifest), null, 2)}\n`,
+        );
+        if (controller.signal.aborted)
+          throw new Error('Production manifest packing was interrupted');
+        return await packArtifact(controller.signal);
       } finally {
         await writeFile(manifestPath, sourceManifest);
-        sourceManifests.delete(manifestPath);
+        activePacks.delete(activePack);
+        resolveCompletion();
       }
     },
     dispose() {
@@ -34,16 +47,34 @@ export function createProductionManifestPacker() {
   function handleSignal(signal) {
     if (receivedSignal) return;
     receivedSignal = signal;
-    void restoreSourceManifests().finally(() => process.kill(process.pid, signal));
+    void stopActivePacks().finally(() => process.kill(process.pid, signal));
   }
 
-  function restoreSourceManifests() {
-    return Promise.all(
-      [...sourceManifests].map(([manifestPath, sourceManifest]) =>
-        writeFile(manifestPath, sourceManifest),
-      ),
-    );
+  async function stopActivePacks() {
+    for (const {controller} of activePacks) controller.abort();
+    await Promise.all([...activePacks].map(({completion}) => completion));
   }
+}
+
+export function run(command, args, cwd, {signal, stdio = 'inherit'} = {}) {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(command, args, {cwd, stdio});
+    const terminate = () => child.kill('SIGTERM');
+    const cleanup = () => signal?.removeEventListener('abort', terminate);
+
+    if (signal?.aborted) terminate();
+    else signal?.addEventListener('abort', terminate, {once: true});
+
+    child.once('error', (error) => {
+      cleanup();
+      reject(error);
+    });
+    child.once('exit', (code) => {
+      cleanup();
+      if (code === 0) resolvePromise();
+      else reject(new Error(`${basename(command)} ${args.join(' ')} exited with code ${code}`));
+    });
+  });
 }
 
 export async function mapWithConcurrency(values, concurrency, mapper) {

--- a/dev/productionized-manifest-packer.test.mjs
+++ b/dev/productionized-manifest-packer.test.mjs
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import {spawn} from 'node:child_process';
+import {access, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join, resolve} from 'node:path';
+import {afterEach, test} from 'node:test';
+import {pathToFileURL} from 'node:url';
+
+const roots = [];
+const helperUrl = pathToFileURL(resolve('dev/productionized-manifest-packer.mjs')).href;
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, {force: true, recursive: true})));
+});
+
+test('terminates an interrupted pack child before restoring its manifest', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'shipfox-productionized-manifest-packer-'));
+  roots.push(root);
+  const manifestPath = join(root, 'package.json');
+  const childPidPath = join(root, 'child.pid');
+  const workerPath = join(root, 'worker.mjs');
+  const sourceManifest = `${JSON.stringify({imports: {'#*': './src/*'}}, null, 2)}\n`;
+  await writeFile(manifestPath, sourceManifest);
+  await writeFile(
+    workerPath,
+    `import {createProductionManifestPacker, run} from ${JSON.stringify(helperUrl)};
+
+const [manifestPath, childPidPath] = process.argv.slice(2);
+const manifestPacker = createProductionManifestPacker();
+await manifestPacker.pack(manifestPath, {imports: {'#*': {development: './src/*', default: './dist/*'}}}, (signal) =>
+  run(process.execPath, ['--input-type=module', '--eval', \`import {writeFile} from 'node:fs/promises'; await writeFile(${JSON.stringify(childPidPath)}, String(process.pid)); setInterval(() => {}, 1_000);\`], process.cwd(), {signal, stdio: 'ignore'}),
+);
+`,
+  );
+  const worker = spawn(process.execPath, [workerPath, manifestPath, childPidPath], {
+    stdio: 'ignore',
+  });
+
+  const childPid = Number(await waitForFile(childPidPath));
+  const exit = waitForExit(worker);
+  worker.kill('SIGTERM');
+
+  const {signal} = await exit;
+  await waitForProcessExit(childPid);
+
+  assert.equal(signal, 'SIGTERM');
+  assert.equal(await readFile(manifestPath, 'utf8'), sourceManifest);
+});
+
+async function waitForFile(path) {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    try {
+      await access(path);
+      return readFile(path, 'utf8');
+    } catch {
+      await delay(20);
+    }
+  }
+  throw new Error(`Timed out waiting for ${path}`);
+}
+
+function waitForExit(child) {
+  return new Promise((resolveExit, reject) => {
+    child.once('error', reject);
+    child.once('exit', (code, signal) => resolveExit({code, signal}));
+  });
+}
+
+async function waitForProcessExit(pid) {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+      await delay(20);
+    } catch {
+      return;
+    }
+  }
+  throw new Error(`Process ${pid} remained alive after cancellation`);
+}
+
+function delay(milliseconds) {
+  return new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds));
+}

--- a/dev/published-package-artifacts.mjs
+++ b/dev/published-package-artifacts.mjs
@@ -11,9 +11,11 @@ const packageSources = {
   '@shipfox/application-release': 'tools/application-release',
   '@shipfox/react-ui': 'libs/shared/react/ui',
   '@shipfox/redact': 'libs/shared/common/redact',
+  '@shipfox/regex': 'libs/shared/common/regex',
 };
 const packageNames = Object.keys(packageSources);
 const registryShipfoxPackagePattern = /^@shipfox\+[^@]+@\d/u;
+export const developmentConditionImports = ['@shipfox/regex'];
 
 if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
   main().catch((error) => {
@@ -218,6 +220,18 @@ async function exerciseConsumer(root) {
       `const imports = ${JSON.stringify(imports)};
 const modules = await Promise.all(imports.map((specifier) => import(specifier)));
 if (modules.some((module) => Object.keys(module).length === 0)) throw new Error('An imported packed package has no exports.');`,
+    ],
+    root,
+  );
+  await run(
+    process.execPath,
+    [
+      '--conditions=development',
+      '--input-type=module',
+      '--eval',
+      `const imports = ${JSON.stringify(developmentConditionImports)};
+const modules = await Promise.all(imports.map((specifier) => import(specifier)));
+if (modules.some((module) => Object.keys(module).length === 0)) throw new Error('A development-condition import has no exports.');`,
     ],
     root,
   );

--- a/dev/published-package-artifacts.mjs
+++ b/dev/published-package-artifacts.mjs
@@ -5,7 +5,11 @@ import {basename, join, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 
 import {parse as parseYaml} from 'yaml';
-import {productionizeManifest} from '../tools/utils/src/productionize.js';
+
+import {
+  createProductionManifestPacker,
+  mapWithConcurrency,
+} from './productionized-manifest-packer.mjs';
 
 const repositoryRoot = resolve(fileURLToPath(new URL('..', import.meta.url)));
 const packageSources = {
@@ -16,7 +20,7 @@ const packageSources = {
 };
 const packageNames = Object.keys(packageSources);
 const registryShipfoxPackagePattern = /^@shipfox\+[^@]+@\d/u;
-export const developmentConditionImports = ['@shipfox/regex'];
+const developmentConditionImports = ['@shipfox/regex'];
 
 if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
   main().catch((error) => {
@@ -108,23 +112,19 @@ async function buildPackageArtifacts() {
 }
 
 async function packPackages(packages, tarballRoot) {
-  const tarballs = await mapWithConcurrency(packages, 3, async ([name, sourcePackage]) => {
-    const tarball = join(tarballRoot, `${safePackageName(name)}.tgz`);
-    const sourceManifest = await readFile(sourcePackage.manifestPath, 'utf8');
-    const productionManifest = `${JSON.stringify(
-      productionizeManifest(sourcePackage.manifest),
-      null,
-      2,
-    )}\n`;
-    await writeFile(sourcePackage.manifestPath, productionManifest);
-    try {
-      await run('pnpm', ['pack', '--out', tarball], sourcePackage.directory, {stdio: 'ignore'});
-    } finally {
-      await writeFile(sourcePackage.manifestPath, sourceManifest);
-    }
-    return [name, tarball];
-  });
-  return Object.fromEntries(tarballs);
+  const manifestPacker = createProductionManifestPacker();
+  try {
+    const tarballs = await mapWithConcurrency(packages, 3, async ([name, sourcePackage]) => {
+      const tarball = join(tarballRoot, `${safePackageName(name)}.tgz`);
+      await manifestPacker.pack(sourcePackage.manifestPath, sourcePackage.manifest, () =>
+        run('pnpm', ['pack', '--out', tarball], sourcePackage.directory, {stdio: 'ignore'}),
+      );
+      return [name, tarball];
+    });
+    return Object.fromEntries(tarballs);
+  } finally {
+    manifestPacker.dispose();
+  }
 }
 
 async function writeConsumerManifest(root, tarballs, reactUiPeers) {
@@ -268,22 +268,6 @@ if (typeof tool.createApplicationReleaseManifest !== 'function') throw new Error
 
 export function safePackageName(name) {
   return name.replace('@shipfox/', '').replaceAll('/', '-');
-}
-
-async function mapWithConcurrency(values, concurrency, mapper) {
-  const results = new Array(values.length);
-  let nextIndex = 0;
-
-  async function worker() {
-    while (nextIndex < values.length) {
-      const index = nextIndex;
-      nextIndex += 1;
-      results[index] = await mapper(values[index]);
-    }
-  }
-
-  await Promise.all(Array.from({length: concurrency}, () => worker()));
-  return results;
 }
 
 function run(command, args, cwd, {stdio = 'inherit'} = {}) {

--- a/dev/published-package-artifacts.mjs
+++ b/dev/published-package-artifacts.mjs
@@ -1,7 +1,6 @@
-import {spawn} from 'node:child_process';
 import {mkdir, mkdtemp, readdir, readFile, realpath, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
-import {basename, join, resolve} from 'node:path';
+import {join, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 
 import {parse as parseYaml} from 'yaml';
@@ -9,6 +8,7 @@ import {parse as parseYaml} from 'yaml';
 import {
   createProductionManifestPacker,
   mapWithConcurrency,
+  run,
 } from './productionized-manifest-packer.mjs';
 
 const repositoryRoot = resolve(fileURLToPath(new URL('..', import.meta.url)));
@@ -116,8 +116,8 @@ async function packPackages(packages, tarballRoot) {
   try {
     const tarballs = await mapWithConcurrency(packages, 3, async ([name, sourcePackage]) => {
       const tarball = join(tarballRoot, `${safePackageName(name)}.tgz`);
-      await manifestPacker.pack(sourcePackage.manifestPath, sourcePackage.manifest, () =>
-        run('pnpm', ['pack', '--out', tarball], sourcePackage.directory, {stdio: 'ignore'}),
+      await manifestPacker.pack(sourcePackage.manifestPath, sourcePackage.manifest, (signal) =>
+        run('pnpm', ['pack', '--out', tarball], sourcePackage.directory, {signal, stdio: 'ignore'}),
       );
       return [name, tarball];
     });
@@ -268,15 +268,4 @@ if (typeof tool.createApplicationReleaseManifest !== 'function') throw new Error
 
 export function safePackageName(name) {
   return name.replace('@shipfox/', '').replaceAll('/', '-');
-}
-
-function run(command, args, cwd, {stdio = 'inherit'} = {}) {
-  return new Promise((resolvePromise, reject) => {
-    const child = spawn(command, args, {cwd, stdio});
-    child.on('error', reject);
-    child.on('exit', (code) => {
-      if (code === 0) resolvePromise();
-      else reject(new Error(`${basename(command)} ${args.join(' ')} exited with code ${code}`));
-    });
-  });
 }

--- a/dev/published-package-artifacts.mjs
+++ b/dev/published-package-artifacts.mjs
@@ -5,6 +5,7 @@ import {basename, join, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 
 import {parse as parseYaml} from 'yaml';
+import {productionizeManifest} from '../tools/utils/src/productionize.js';
 
 const repositoryRoot = resolve(fileURLToPath(new URL('..', import.meta.url)));
 const packageSources = {
@@ -64,7 +65,14 @@ function readSourcePackages() {
       );
       if (manifest.name !== name) throw new Error(`Expected ${directory} to define ${name}`);
       if (manifest.private === true) throw new Error(`Representative package ${name} is private`);
-      return [name, {directory: join(repositoryRoot, directory), manifest}];
+      return [
+        name,
+        {
+          directory: join(repositoryRoot, directory),
+          manifest,
+          manifestPath: join(repositoryRoot, directory, 'package.json'),
+        },
+      ];
     }),
   );
 }
@@ -102,7 +110,18 @@ async function buildPackageArtifacts() {
 async function packPackages(packages, tarballRoot) {
   const tarballs = await mapWithConcurrency(packages, 3, async ([name, sourcePackage]) => {
     const tarball = join(tarballRoot, `${safePackageName(name)}.tgz`);
-    await run('pnpm', ['pack', '--out', tarball], sourcePackage.directory, {stdio: 'ignore'});
+    const sourceManifest = await readFile(sourcePackage.manifestPath, 'utf8');
+    const productionManifest = `${JSON.stringify(
+      productionizeManifest(sourcePackage.manifest),
+      null,
+      2,
+    )}\n`;
+    await writeFile(sourcePackage.manifestPath, productionManifest);
+    try {
+      await run('pnpm', ['pack', '--out', tarball], sourcePackage.directory, {stdio: 'ignore'});
+    } finally {
+      await writeFile(sourcePackage.manifestPath, sourceManifest);
+    }
     return [name, tarball];
   });
   return Object.fromEntries(tarballs);

--- a/dev/published-package-artifacts.test.mjs
+++ b/dev/published-package-artifacts.test.mjs
@@ -5,7 +5,6 @@ import {
   catalogDependencies,
   catalogRange,
   consumerDependencies,
-  developmentConditionImports,
   findUnsupportedProtocol,
   safePackageName,
 } from './published-package-artifacts.mjs';
@@ -67,12 +66,6 @@ describe('consumerDependencies', () => {
       react: '^19.0.0',
       'react-dom': '^19.0.0',
     });
-  });
-});
-
-describe('developmentConditionImports', () => {
-  test('covers the dist-only regex package', () => {
-    assert.deepEqual(developmentConditionImports, ['@shipfox/regex']);
   });
 });
 

--- a/dev/published-package-artifacts.test.mjs
+++ b/dev/published-package-artifacts.test.mjs
@@ -5,6 +5,7 @@ import {
   catalogDependencies,
   catalogRange,
   consumerDependencies,
+  developmentConditionImports,
   findUnsupportedProtocol,
   safePackageName,
 } from './published-package-artifacts.mjs';
@@ -66,6 +67,12 @@ describe('consumerDependencies', () => {
       react: '^19.0.0',
       'react-dom': '^19.0.0',
     });
+  });
+});
+
+describe('developmentConditionImports', () => {
+  test('covers the dist-only regex package', () => {
+    assert.deepEqual(developmentConditionImports, ['@shipfox/regex']);
   });
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6957,6 +6957,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.2
+      tsx:
+        specifier: 'catalog:'
+        version: 4.22.4
 
   tools/biome:
     dependencies:

--- a/tools/application-release/package.json
+++ b/tools/application-release/package.json
@@ -35,6 +35,7 @@
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",
-    "@types/node": "catalog:"
+    "@types/node": "catalog:",
+    "tsx": "catalog:"
   }
 }

--- a/tools/application-release/test/external/verify.mjs
+++ b/tools/application-release/test/external/verify.mjs
@@ -57,6 +57,12 @@ try {
   const tsc = resolve(repositoryRoot, 'tools/typescript/node_modules/typescript/bin/tsc');
   await run(process.execPath, [tsc, '--project', 'tsconfig.json'], fixtureRoot);
   await run(process.execPath, ['runtime-imports.mjs'], fixtureRoot);
+  await run(process.execPath, ['workflow-source-bundle.mjs'], fixtureRoot);
+  await run(
+    resolve(repositoryRoot, 'tools/application-release/node_modules/.bin/tsx'),
+    ['--conditions=development', 'development-conditions.mjs'],
+    fixtureRoot,
+  );
   await run(process.execPath, ['workflow-bundles.mjs'], fixtureRoot);
 } finally {
   await rm(fixtureRoot, {recursive: true, force: true});
@@ -128,6 +134,14 @@ void createServer({
     writeFile(
       join(root, 'workflow-bundles.mjs'),
       `Object.assign(process.env, {...${JSON.stringify(runtimeEnvironment(), null, 2)}, INTEGRATIONS_ENABLE_SENTRY_PROVIDER: 'true', NODE_ENV: 'production'});\n\nconst {readdir, readFile} = await import('node:fs/promises');\nconst {dirname, join} = await import('node:path');\nconst {defaultModules} = await import('@shipfox/api-server');\nconst {loadProductionWorkflowBundle} = await import('@shipfox/node-temporal');\nconst modules = await defaultModules();\nconst workflowPaths = new Set(\n  modules.flatMap((module) => module.workers ?? []).map((worker) => worker.workflowsPath),\n);\n\nif (!workflowPaths.size) throw new Error('Packed API server declares no workflow entrypoints.');\n\nconst bundles = new Map();\nfor (const workflowsPath of workflowPaths) {\n  const workflowBundle = loadProductionWorkflowBundle(workflowsPath);\n  bundles.set(workflowsPath, workflowBundle);\n\n  const code = await readFile(workflowBundle.codePath, 'utf8');\n  if (/@shipfox[/\\\\][^/\\\\]+[/\\\\]src[/\\\\]/u.test(code)) {\n    throw new Error(\n      \`Workflow bundle for \${workflowsPath} resolved a first-party source path.\`,\n    );\n  }\n}\n\nconst declaredCodePaths = new Set([...bundles.values()].map(({codePath}) => codePath));\nif (declaredCodePaths.size !== workflowPaths.size) {\n  throw new Error('Packed API workflow entrypoints do not map one-to-one to prebuilt bundles.');\n}\n\nconst workflowDirectories = new Set([...workflowPaths].map((workflowsPath) => dirname(workflowsPath)));\nconst emittedBundles = (\n  await Promise.all(\n    [...workflowDirectories].map(async (directory) =>\n      (await readdir(directory))\n        .filter((entry) => entry.endsWith('.bundle.js'))\n        .map((entry) => join(directory, entry)),\n    ),\n  )\n).flat();\nconst unreferencedBundles = emittedBundles.filter((codePath) => !declaredCodePaths.has(codePath));\nif (unreferencedBundles.length) {\n  throw new Error(\n    \`Packed API contains unreferenced workflow bundles: \${unreferencedBundles.join(', ')}\`,\n  );\n}\n\nconsole.log(\`Validated \${workflowPaths.size} packed API workflow bundles.\`);\n`,
+    ),
+    writeFile(
+      join(root, 'development-conditions.mjs'),
+      `Object.assign(process.env, ${JSON.stringify(runtimeEnvironment(), null, 2)});\n\nawait import('@shipfox/api-server/instrumentation');\nprocess.exit(0);\n`,
+    ),
+    writeFile(
+      join(root, 'workflow-source-bundle.mjs'),
+      `delete process.env.NODE_ENV;\n\nconst {createRequire} = await import('node:module');\nconst {fileURLToPath} = await import('node:url');\nconst {dirname, join} = await import('node:path');\nconst temporalRequire = createRequire(import.meta.resolve('@shipfox/node-temporal'));\nconst {bundleWorkflowCode} = await import(temporalRequire.resolve('@temporalio/worker'));\nconst packageEntryPoint = fileURLToPath(import.meta.resolve('@shipfox/api-definitions'));\nconst workflowsPath = join(\n  dirname(dirname(packageEntryPoint)),\n  'dist',\n  'temporal',\n  'workflows',\n  'index.js',\n);\n\nawait bundleWorkflowCode({workflowsPath});\nconsole.log('Bundled a packed API definitions workflow with Temporal defaults.');\n`,
     ),
   ]);
 }

--- a/tools/application-release/test/external/verify.mjs
+++ b/tools/application-release/test/external/verify.mjs
@@ -1,12 +1,12 @@
-import {spawn} from 'node:child_process';
 import {mkdir, mkdtemp, readdir, readFile, realpath, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
-import {basename, join, resolve} from 'node:path';
+import {join, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 
 import {
   createProductionManifestPacker,
   mapWithConcurrency,
+  run,
 } from '../../../../dev/productionized-manifest-packer.mjs';
 
 import {
@@ -39,8 +39,11 @@ try {
     const workspacePackage = workspacePackages.get(name);
     if (!workspacePackage) throw new Error(`Missing workspace package: ${name}`);
     const tarball = join(tarballRoot, `${safePackageName(name)}.tgz`);
-    await manifestPacker.pack(workspacePackage.manifestPath, workspacePackage.manifest, () =>
-      run('pnpm', ['pack', '--out', tarball], workspacePackage.directory, 'ignore'),
+    await manifestPacker.pack(workspacePackage.manifestPath, workspacePackage.manifest, (signal) =>
+      run('pnpm', ['pack', '--out', tarball], workspacePackage.directory, {
+        signal,
+        stdio: 'ignore',
+      }),
     );
     return [name, tarball];
   });
@@ -268,15 +271,4 @@ async function emitDeclarationFiles(packageNames) {
     ['exec', 'turbo', 'build', 'type:emit', ...packageNames.map((name) => `--filter=${name}`)],
     repositoryRoot,
   );
-}
-
-function run(command, args, cwd, stdio = 'inherit') {
-  return new Promise((resolvePromise, reject) => {
-    const child = spawn(command, args, {cwd, stdio});
-    child.on('error', reject);
-    child.on('exit', (code) => {
-      if (code === 0) resolvePromise();
-      else reject(new Error(`${basename(command)} ${args.join(' ')} exited with code ${code}`));
-    });
-  });
 }

--- a/tools/application-release/test/external/verify.mjs
+++ b/tools/application-release/test/external/verify.mjs
@@ -4,7 +4,10 @@ import {tmpdir} from 'node:os';
 import {basename, join, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 
-import {productionizeManifest} from '../../../utils/src/productionize.js';
+import {
+  createProductionManifestPacker,
+  mapWithConcurrency,
+} from '../../../../dev/productionized-manifest-packer.mjs';
 
 import {
   computePublicationClosure,
@@ -28,6 +31,7 @@ const closure = computePublicationClosure(
 await emitDeclarationFiles(closure);
 const fixtureRoot = await mkdtemp(join(tmpdir(), 'shipfox-api-runtime-'));
 const tarballRoot = join(fixtureRoot, 'tarballs');
+const manifestPacker = createProductionManifestPacker();
 
 try {
   await mkdir(tarballRoot);
@@ -35,18 +39,9 @@ try {
     const workspacePackage = workspacePackages.get(name);
     if (!workspacePackage) throw new Error(`Missing workspace package: ${name}`);
     const tarball = join(tarballRoot, `${safePackageName(name)}.tgz`);
-    const sourceManifest = await readFile(workspacePackage.manifestPath, 'utf8');
-    const productionManifest = `${JSON.stringify(
-      productionizeManifest(workspacePackage.manifest),
-      null,
-      2,
-    )}\n`;
-    await writeFile(workspacePackage.manifestPath, productionManifest);
-    try {
-      await run('pnpm', ['pack', '--out', tarball], workspacePackage.directory, 'ignore');
-    } finally {
-      await writeFile(workspacePackage.manifestPath, sourceManifest);
-    }
+    await manifestPacker.pack(workspacePackage.manifestPath, workspacePackage.manifest, () =>
+      run('pnpm', ['pack', '--out', tarball], workspacePackage.directory, 'ignore'),
+    );
     return [name, tarball];
   });
 
@@ -78,6 +73,7 @@ try {
   );
   await run(process.execPath, ['workflow-bundles.mjs'], fixtureRoot);
 } finally {
+  manifestPacker.dispose();
   await rm(fixtureRoot, {recursive: true, force: true});
 }
 
@@ -272,22 +268,6 @@ async function emitDeclarationFiles(packageNames) {
     ['exec', 'turbo', 'build', 'type:emit', ...packageNames.map((name) => `--filter=${name}`)],
     repositoryRoot,
   );
-}
-
-async function mapWithConcurrency(values, concurrency, mapper) {
-  const results = new Array(values.length);
-  let nextIndex = 0;
-
-  async function worker() {
-    while (nextIndex < values.length) {
-      const index = nextIndex;
-      nextIndex += 1;
-      results[index] = await mapper(values[index], index);
-    }
-  }
-
-  await Promise.all(Array.from({length: concurrency}, () => worker()));
-  return results;
 }
 
 function run(command, args, cwd, stdio = 'inherit') {

--- a/tools/application-release/test/external/verify.mjs
+++ b/tools/application-release/test/external/verify.mjs
@@ -4,6 +4,8 @@ import {tmpdir} from 'node:os';
 import {basename, join, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 
+import {productionizeManifest} from '../../../utils/src/productionize.js';
+
 import {
   computePublicationClosure,
   entryPointSupportsRuntimeImport,
@@ -33,7 +35,18 @@ try {
     const workspacePackage = workspacePackages.get(name);
     if (!workspacePackage) throw new Error(`Missing workspace package: ${name}`);
     const tarball = join(tarballRoot, `${safePackageName(name)}.tgz`);
-    await run('pnpm', ['pack', '--out', tarball], workspacePackage.directory, 'ignore');
+    const sourceManifest = await readFile(workspacePackage.manifestPath, 'utf8');
+    const productionManifest = `${JSON.stringify(
+      productionizeManifest(workspacePackage.manifest),
+      null,
+      2,
+    )}\n`;
+    await writeFile(workspacePackage.manifestPath, productionManifest);
+    try {
+      await run('pnpm', ['pack', '--out', tarball], workspacePackage.directory, 'ignore');
+    } finally {
+      await writeFile(workspacePackage.manifestPath, sourceManifest);
+    }
     return [name, tarball];
   });
 


### PR DESCRIPTION
Add packed-consumer checks for development-condition resolution and Temporal workflow bundling.

The release workflow now productionizes manifests before publishing. These fixtures apply that same reversible preparation before packing, so CI verifies the tarballs external consumers receive while source manifests remain available for local development.

Closes ENG-1024