### PR TITLE
[client-features] Declare route packages as peers

### DIFF
--- a/.changeset/smart-ravens-depend.md
+++ b/.changeset/smart-ravens-depend.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-features": minor
+---
+
+Add peer dependencies for the default route packages. Apps can resolve generated route imports.

--- a/docs/adr/0001-client-composition-contract.md
+++ b/docs/adr/0001-client-composition-contract.md
@@ -338,6 +338,14 @@ Singleton-sensitive libraries are peers of the public client packages: `react`, 
 package exports a Vite plugin. `@tanstack/router-core` is a direct runtime dependency because emitted
 anchor declarations name its types.
 
+`@shipfox/client-features` also lists the default route packages as peers. Those peers are
+`@shipfox/client-auth`, `@shipfox/client-invitations`, `@shipfox/client-integrations`,
+`@shipfox/client-projects`, `@shipfox/client-workflows`, `@shipfox/client-agent`, and
+`@shipfox/client-workspace-settings`.
+
+This exposes the app requirement at install time. The generated router lives in the app, not in
+`client-features`. It imports each route by package name.
+
 Packages keep the repository export conditions:
 
 - `workspace-source` and `development` resolve `src` for repository work;
@@ -346,8 +354,8 @@ Packages keep the repository export conditions:
 - `shipfox-tsc-emit` emits declarations; and
 - ESM export maps define the public surface.
 
-The packed-consumer gate runs without source conditions. Changesets will add a linked client release
-group when ENG-938 makes the packages public. `@shipfox/react-ui` stays outside that linked group.
+The packed-consumer gate runs without source conditions. Changesets link the public client packages
+as one release group. `@shipfox/react-ui` stays outside that linked group.
 
 ## Composition roots
 
@@ -380,6 +388,21 @@ export default defineConfig({
   ],
 });
 ```
+
+Apps must declare `@shipfox/client-shell`, `@shipfox/client-features`, and every route package they
+use. The default route packages are:
+
+- `@shipfox/client-agent`
+- `@shipfox/client-auth`
+- `@shipfox/client-integrations`
+- `@shipfox/client-invitations`
+- `@shipfox/client-projects`
+- `@shipfox/client-workflows`
+- `@shipfox/client-workspace-settings`
+
+The generated `shipfox-app.gen.ts` lives in the app. It imports those routes by package name. With
+pnpm's isolated linker, the app cannot resolve those imports through `client-features` as transitive
+dependencies. `apps/client/package.json` shows the pattern.
 
 ## Worked examples
 
@@ -463,8 +486,8 @@ not mount a router or start network work. Tests may supply `features`, `config`,
 `store`. Omitted state gets local defaults. `shellDecorator` is the zero-config Storybook helper.
 `createShellDecorator(options)` creates a configured decorator.
 
-Auth remains stubbed in the prototype runtime. ENG-938 must add the real shell-owned `AuthRuntime`
-and its test value without changing this provider ownership.
+The shell-owned `AuthRuntime` configures token refresh and API client access. Test providers disable
+those effects while keeping the same provider ownership.
 
 Router and end-to-end fixtures use the generated application file. They do not hand-build a second
 route tree.
@@ -523,9 +546,9 @@ The linked and packed modes proved these behaviors:
 
 The packed mode also proves consumer type-checking from tarballs with no workspace fallback.
 
-## Migration map for ENG-938
+## ENG-938 implementation record
 
-ENG-938 implements the accepted contract in these slices.
+ENG-938 implemented the accepted contract through these slices.
 
 ### 1. Graduate the shell
 

--- a/libs/client/features/package.json
+++ b/libs/client/features/package.json
@@ -48,23 +48,30 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
+    "@shipfox/client-shell": "workspace:*",
+    "@swc/helpers": "catalog:"
+  },
+  "peerDependencies": {
     "@shipfox/client-agent": "workspace:*",
     "@shipfox/client-auth": "workspace:*",
     "@shipfox/client-integrations": "workspace:*",
     "@shipfox/client-invitations": "workspace:*",
     "@shipfox/client-projects": "workspace:*",
-    "@shipfox/client-shell": "workspace:*",
     "@shipfox/client-workflows": "workspace:*",
     "@shipfox/client-workspace-settings": "workspace:*",
-    "@swc/helpers": "catalog:"
-  },
-  "peerDependencies": {
     "@tanstack/react-router": "^1.170.16",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",
+    "@shipfox/client-agent": "workspace:*",
+    "@shipfox/client-auth": "workspace:*",
+    "@shipfox/client-integrations": "workspace:*",
+    "@shipfox/client-invitations": "workspace:*",
+    "@shipfox/client-projects": "workspace:*",
+    "@shipfox/client-workflows": "workspace:*",
+    "@shipfox/client-workspace-settings": "workspace:*",
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",

--- a/libs/client/features/src/index.test.ts
+++ b/libs/client/features/src/index.test.ts
@@ -1,5 +1,8 @@
 import {describe, expect, it} from '@shipfox/vitest/vi';
+import manifest from '../package.json' with {type: 'json'};
 import {defaultFeatures} from './index.js';
+
+const SHIPFOX_PACKAGE_PATTERN = /^(@shipfox\/[^/]+)\//u;
 
 describe('defaultFeatures', () => {
   it('composes the upstream client features in manifest order', () => {
@@ -12,5 +15,20 @@ describe('defaultFeatures', () => {
       'shipfox.agent',
       'shipfox.workspace-settings',
     ]);
+  });
+
+  it('declares every default route implementation package as a peer dependency', () => {
+    const peerPackageNames = Object.keys(manifest.peerDependencies ?? {}).filter((name) =>
+      name.startsWith('@shipfox/client-'),
+    );
+
+    const routePackageNames = new Set(
+      defaultFeatures()
+        .flatMap((feature) => feature.routes ?? [])
+        .map(({impl}) => SHIPFOX_PACKAGE_PATTERN.exec(impl)?.[1])
+        .filter((name): name is string => name !== undefined),
+    );
+
+    expect([...routePackageNames].sort()).toEqual(peerPackageNames.sort());
   });
 });

--- a/libs/client/features/tsconfig.test.json
+++ b/libs/client/features/tsconfig.test.json
@@ -3,6 +3,12 @@
   "compilerOptions": {
     "rootDir": "."
   },
-  "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "include": [
+    "src",
+    "test",
+    "package.json",
+    "vitest.config.ts",
+    "node_modules/@shipfox/vitest/globals.d.ts"
+  ],
   "exclude": []
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4456,6 +4456,16 @@ importers:
 
   libs/client/features:
     dependencies:
+      '@shipfox/client-shell':
+        specifier: workspace:*
+        version: link:../shell
+      '@swc/helpers':
+        specifier: 'catalog:'
+        version: 0.5.23
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
       '@shipfox/client-agent':
         specifier: workspace:*
         version: link:../agent
@@ -4471,22 +4481,12 @@ importers:
       '@shipfox/client-projects':
         specifier: workspace:*
         version: link:../projects
-      '@shipfox/client-shell':
-        specifier: workspace:*
-        version: link:../shell
       '@shipfox/client-workflows':
         specifier: workspace:*
         version: link:../workflows
       '@shipfox/client-workspace-settings':
         specifier: workspace:*
         version: link:../workspace-settings
-      '@swc/helpers':
-        specifier: 'catalog:'
-        version: 0.5.23
-    devDependencies:
-      '@shipfox/biome':
-        specifier: workspace:*
-        version: link:../../../tools/biome
       '@shipfox/swc':
         specifier: workspace:*
         version: link:../../../tools/swc


### PR DESCRIPTION
Declare the default client composition route packages as peers of `@shipfox/client-features` and retain them as development dependencies.

The consumer-local generated router imports those packages by name. Under pnpm isolated linking, applications cannot resolve them as transitive dependencies of `client-features`.

The ADR now documents the dependency contract and a manifest-sync test keeps route owners aligned with the peer list. `@shipfox/client-shell` remains a runtime dependency, while the minimal packed-consumer gate remains owned by ENG-1028.

Closes ENG-1026

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the default route packages peers of `@shipfox/client-features` so apps can resolve generated route imports under pnpm’s isolated linker. This aligns with ENG-1026 and unblocks `@shipfox-cloud/client` builds.

- **Dependencies**
  - Added peer deps: `@shipfox/client-agent`, `@shipfox/client-auth`, `@shipfox/client-integrations`, `@shipfox/client-invitations`, `@shipfox/client-projects`, `@shipfox/client-workflows`, `@shipfox/client-workspace-settings`.
  - Moved `@shipfox/client-shell` to a runtime dependency of `@shipfox/client-features`.
  - Added a test to keep the peer list in sync with route implementations in `defaultFeatures`.
  - Updated ADR to document the install-time requirement and composition roots.

<sup>Written for commit 5ac83b87219c8bac547824f1a3bb9fc286d0a8f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

