### PR TITLE
Productionize published npm manifests

### DIFF
--- a/.changeset/bright-otters-resolve.md
+++ b/.changeset/bright-otters-resolve.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/tool-utils": minor
+"@shipfox/application-release": patch
+"@shipfox/docker": patch
+---
+
+Productionizes published package manifests so external consumers resolve compiled dist output.

--- a/dev/publish-productionized-closure.mjs
+++ b/dev/publish-productionized-closure.mjs
@@ -1,0 +1,101 @@
+import {spawn} from 'node:child_process';
+import {globSync, readFileSync, writeFileSync} from 'node:fs';
+import {constants} from 'node:os';
+import {join, resolve} from 'node:path';
+import {pathToFileURL} from 'node:url';
+
+import {productionizeManifest} from '../tools/utils/src/productionize.js';
+
+export function findClosureManifests(root, packageNames) {
+  const manifestsByName = new Map();
+  for (const manifestPath of globSync(join(root, 'libs/**/package.json'))) {
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    if (!manifest.name) continue;
+    if (manifestsByName.has(manifest.name)) {
+      throw new Error(`Duplicate package manifest: ${manifest.name}`);
+    }
+    manifestsByName.set(manifest.name, manifestPath);
+  }
+
+  return packageNames.map((name) => {
+    const manifestPath = manifestsByName.get(name);
+    if (!manifestPath) throw new Error(`Publication closure package has no manifest: ${name}`);
+    return manifestPath;
+  });
+}
+
+export async function publishProductionizedClosure({root, packageNames, publish, onPrepared}) {
+  const manifestPaths = findClosureManifests(root, packageNames);
+  const originalManifests = new Map(
+    manifestPaths.map((manifestPath) => [manifestPath, readFileSync(manifestPath, 'utf8')]),
+  );
+  const restore = () => {
+    for (const [manifestPath, originalManifest] of originalManifests) {
+      writeFileSync(manifestPath, originalManifest);
+    }
+  };
+
+  for (const [manifestPath, originalManifest] of originalManifests) {
+    const manifest = JSON.parse(originalManifest);
+    const productionized = productionizeManifest(manifest);
+    if (productionized === manifest) continue;
+    writeFileSync(manifestPath, `${JSON.stringify(productionized, null, 2)}\n`);
+  }
+
+  try {
+    onPrepared?.(restore);
+    return await publish();
+  } finally {
+    restore();
+  }
+}
+
+export function publishChangesets(onSpawn) {
+  return new Promise((resolvePublish, reject) => {
+    const child = spawn('pnpm', ['exec', 'changeset', 'publish'], {stdio: 'inherit'});
+    onSpawn?.(child);
+    child.once('error', reject);
+    child.once('exit', (code) => resolvePublish(code ?? 1));
+  });
+}
+
+async function main() {
+  const repositoryRoot = process.cwd();
+  const closurePath = join(repositoryRoot, 'publication-closure.json');
+  const packageNames = JSON.parse(readFileSync(closurePath, 'utf8')).packages;
+  let restore;
+  let stopPublish;
+  const stop = (signal) => {
+    stopPublish?.();
+    restore?.();
+    process.exit(128 + constants.signals[signal]);
+  };
+
+  process.once('SIGINT', stop);
+  process.once('SIGTERM', stop);
+  try {
+    const status = await publishProductionizedClosure({
+      root: repositoryRoot,
+      packageNames,
+      publish: () =>
+        publishChangesets((child) => {
+          stopPublish = () => child.kill('SIGTERM');
+        }),
+      onPrepared: (nextRestore) => {
+        restore = nextRestore;
+      },
+    });
+    if (status !== 0) process.exitCode = status;
+  } finally {
+    process.removeListener('SIGINT', stop);
+    process.removeListener('SIGTERM', stop);
+  }
+}
+
+const entryPoint = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : undefined;
+if (entryPoint === import.meta.url) {
+  main().catch((error) => {
+    process.stderr.write(`${String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/dev/publish-productionized-closure.test.mjs
+++ b/dev/publish-productionized-closure.test.mjs
@@ -1,0 +1,130 @@
+import assert from 'node:assert/strict';
+import {mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {afterEach, describe, test} from 'node:test';
+
+import {
+  findClosureManifests,
+  publishProductionizedClosure,
+} from './publish-productionized-closure.mjs';
+
+const roots = [];
+const DUPLICATE_MANIFEST_ERROR = /Duplicate package manifest: @shipfox\/duplicate/u;
+const MISSING_MANIFEST_ERROR = /Publication closure package has no manifest: @shipfox\/missing/u;
+const SPAWN_FAILURE_ERROR = /spawn failed/u;
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, {force: true, recursive: true});
+});
+
+function createFixture(packages) {
+  const root = mkdtempSync(join(tmpdir(), 'shipfox-publish-'));
+  roots.push(root);
+
+  for (const [directory, manifest] of packages) {
+    const packageDirectory = join(root, 'libs', directory);
+    mkdirSync(packageDirectory, {recursive: true});
+    writeFileSync(join(packageDirectory, 'package.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+  }
+
+  return root;
+}
+
+function closureManifest(name) {
+  return {
+    name,
+    imports: {
+      '#*': {
+        types: './src/*',
+        'workspace-source': './src/*',
+        development: './src/*',
+        default: './dist/*',
+      },
+    },
+    exports: {
+      '.': {
+        development: {types: './src/index.ts', default: './src/index.ts'},
+        default: {types: './dist/index.d.ts', default: './dist/index.js'},
+      },
+    },
+  };
+}
+
+describe('findClosureManifests', () => {
+  test('finds every requested package manifest', () => {
+    const root = createFixture([['one', closureManifest('@shipfox/one')]]);
+
+    const manifests = findClosureManifests(root, ['@shipfox/one']);
+
+    assert.deepEqual(manifests, [join(root, 'libs', 'one', 'package.json')]);
+  });
+
+  test('rejects duplicate manifests', () => {
+    const root = createFixture([
+      ['one', closureManifest('@shipfox/duplicate')],
+      ['two', closureManifest('@shipfox/duplicate')],
+    ]);
+
+    const findDuplicates = () => findClosureManifests(root, ['@shipfox/duplicate']);
+
+    assert.throws(findDuplicates, DUPLICATE_MANIFEST_ERROR);
+  });
+
+  test('rejects missing manifests', () => {
+    const root = createFixture([['one', closureManifest('@shipfox/one')]]);
+
+    const findMissing = () => findClosureManifests(root, ['@shipfox/missing']);
+
+    assert.throws(findMissing, MISSING_MANIFEST_ERROR);
+  });
+});
+
+describe('publishProductionizedClosure', () => {
+  test('publishes productionized manifests and restores them after success', async () => {
+    const root = createFixture([['one', closureManifest('@shipfox/one')]]);
+    const manifestPath = join(root, 'libs', 'one', 'package.json');
+    const originalManifest = readFileSync(manifestPath, 'utf8');
+
+    const status = await publishProductionizedClosure({
+      root,
+      packageNames: ['@shipfox/one'],
+      publish: () => {
+        const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+        assert.deepEqual(manifest.imports, {'#*': './dist/*'});
+        assert.deepEqual(manifest.exports, {
+          '.': {types: './dist/index.d.ts', default: './dist/index.js'},
+        });
+        return 0;
+      },
+    });
+
+    assert.equal(status, 0);
+    assert.equal(readFileSync(manifestPath, 'utf8'), originalManifest);
+  });
+
+  test('restores manifests after a non-zero publish status or publish failure', async () => {
+    const root = createFixture([['one', closureManifest('@shipfox/one')]]);
+    const manifestPath = join(root, 'libs', 'one', 'package.json');
+    const originalManifest = readFileSync(manifestPath, 'utf8');
+
+    const status = await publishProductionizedClosure({
+      root,
+      packageNames: ['@shipfox/one'],
+      publish: async () => 1,
+    });
+    const publish = () =>
+      publishProductionizedClosure({
+        root,
+        packageNames: ['@shipfox/one'],
+        publish: () => {
+          throw new Error('spawn failed');
+        },
+      });
+
+    assert.equal(status, 1);
+    assert.equal(readFileSync(manifestPath, 'utf8'), originalManifest);
+    await assert.rejects(publish, SPAWN_FAILURE_ERROR);
+    assert.equal(readFileSync(manifestPath, 'utf8'), originalManifest);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "check:published-artifacts": "node dev/published-package-artifacts.mjs",
     "fix:dependencies": "syncpack fix --no-ansi",
     "test": "node --test dev/*.test.mjs",
-    "release:publish": "turbo type build type:emit --filter='./libs/**' --filter='./tools/**' && changeset publish"
+    "release:publish": "turbo type build type:emit --filter='./libs/**' --filter='./tools/**' && node dev/publish-productionized-closure.mjs"
   },
   "devDependencies": {
     "@changesets/cli": "catalog:",

--- a/tools/application-release/src/package-closure.ts
+++ b/tools/application-release/src/package-closure.ts
@@ -238,6 +238,16 @@ function validatePublishedPackage(
       `Publication closure package does not map internal imports to dist: ${packageLabel}`,
     );
   }
+  const sourceConditions = new Set(['development', 'workspace-source']);
+  const packedTargets = [
+    ...exportTargetPaths(manifest.imports, new Set([...sourceConditions, 'types'])),
+    ...exportTargetPaths(manifest.exports, sourceConditions),
+  ];
+  if (packedTargets.some((target) => target.includes('./src/'))) {
+    throw new Error(
+      `Publication closure package resolves to src after productionization: ${packageLabel}`,
+    );
+  }
   for (const script of ['build', 'type', 'type:emit']) {
     if (!manifest.scripts?.[script]) {
       throw new Error(

--- a/tools/application-release/test/package-closure.test.mjs
+++ b/tools/application-release/test/package-closure.test.mjs
@@ -19,6 +19,7 @@ const repositoryRoot = resolve(fileURLToPath(new URL('../../..', import.meta.url
 const MISSING_ROOT_ERROR = /Publication root is not a workspace package: @shipfox\/missing/u;
 const MISSING_RUNTIME_ERROR = /missing: @shipfox\/runtime/u;
 const PRIVATE_RUNTIME_ERROR = /Publication closure package is private: @shipfox\/private-runtime/u;
+const SOURCE_TARGET_ERROR = /resolves to src after productionization/u;
 const UNEXPECTED_RUNTIME_ERROR = /unexpected: @shipfox\/runtime/u;
 const INVALID_VERSION_ERROR = /has invalid version/u;
 
@@ -38,13 +39,15 @@ function workspacePackage(name, options = {}) {
         directory: directory.slice('/repo/'.length),
       },
       imports: {
-        '#*': {
-          'workspace-source': './src/*',
-          development: './src/*',
-          default: './dist/*',
-        },
+        ...(options.imports ?? {
+          '#*': {
+            'workspace-source': './src/*',
+            development: './src/*',
+            default: './dist/*',
+          },
+        }),
       },
-      exports: {'.': './dist/index.js'},
+      exports: options.exports ?? {'.': './dist/index.js'},
       scripts: {build: 'build', type: 'type', 'type:emit': 'type:emit'},
       dependencies: options.dependencies,
       optionalDependencies: options.optionalDependencies,
@@ -124,6 +127,51 @@ describe('publication closure', () => {
 
     assert.throws(validate, PRIVATE_RUNTIME_ERROR);
   });
+
+  test('allows source conditions when packed targets resolve to dist', () => {
+    const packages = new Map([['@shipfox/root', workspacePackage('@shipfox/root')]]);
+    const config = {roots: ['@shipfox/root'], packages: ['@shipfox/root']};
+
+    const closure = validatePublicationState(packages, config, '/repo');
+
+    assert.deepEqual(closure, ['@shipfox/root']);
+  });
+
+  for (const [field, options] of [
+    [
+      'imports',
+      {
+        imports: {
+          '#*': {
+            'workspace-source': './src/*',
+            development: './src/*',
+            default: './dist/*',
+          },
+          '#generated/*': {default: './src/generated/*'},
+        },
+      },
+    ],
+    [
+      'exports',
+      {
+        exports: {
+          '.': {
+            development: {types: './src/index.ts', default: './src/index.ts'},
+            default: {types: './dist/index.d.ts', default: './src/index.js'},
+          },
+        },
+      },
+    ],
+  ]) {
+    test(`rejects ${field} that resolves to source after productionization`, () => {
+      const packages = new Map([['@shipfox/root', workspacePackage('@shipfox/root', options)]]);
+      const config = {roots: ['@shipfox/root'], packages: ['@shipfox/root']};
+
+      const validate = () => validatePublicationState(packages, config, '/repo');
+
+      assert.throws(validate, SOURCE_TARGET_ERROR);
+    });
+  }
 
   test('rejects an application release missing an expected package', () => {
     const validate = () =>

--- a/tools/docker/src/turbo.ts
+++ b/tools/docker/src/turbo.ts
@@ -9,7 +9,14 @@ import {
   writeFileSync,
 } from 'node:fs';
 import {dirname, join, relative} from 'node:path';
-import {buildShellCommand, getProjectFilePath, getWorkspaceRootPath} from '@shipfox/tool-utils';
+import {
+  buildShellCommand,
+  getProjectFilePath,
+  getWorkspaceRootPath,
+  productionizeImports,
+} from '@shipfox/tool-utils';
+
+export {productionizeImports} from '@shipfox/tool-utils';
 
 /**
  * Prepare the Docker build context for a node app the "build outside Docker,
@@ -83,21 +90,6 @@ function productionizeSubpathImports(packageJsonPath: string) {
 
   manifest.imports = imports;
   writeFileSync(packageJsonPath, `${JSON.stringify(manifest, null, 2)}\n`);
-}
-
-export function productionizeImports(
-  imports: Record<string, unknown> | undefined,
-): Record<string, unknown> | undefined {
-  const subpathImports = imports?.['#*'];
-  const hasDistDefault =
-    typeof subpathImports === 'object' &&
-    subpathImports !== null &&
-    !Array.isArray(subpathImports) &&
-    (subpathImports as Record<string, unknown>).default === './dist/*';
-
-  if (subpathImports !== './src/*' && !hasDistDefault) return imports;
-
-  return {...imports, '#*': './dist/*'};
 }
 
 function buildsToDist(packageJsonPath: string): boolean {

--- a/tools/utils/package.json
+++ b/tools/utils/package.json
@@ -12,7 +12,8 @@
   "types": "src/index.d.ts",
   "type": "module",
   "scripts": {
-    "cli": "node src/index.js"
+    "cli": "node src/index.js",
+    "test": "node --test test/*.test.mjs"
   },
   "dependencies": {
     "@actions/core": "catalog:"

--- a/tools/utils/src/index.d.ts
+++ b/tools/utils/src/index.d.ts
@@ -1,3 +1,4 @@
 export * from './log.js';
 export * from './path.js';
+export * from './productionize.js';
 export * from './shell.js';

--- a/tools/utils/src/index.js
+++ b/tools/utils/src/index.js
@@ -1,3 +1,4 @@
 export * from './log.js';
 export * from './path.js';
+export * from './productionize.js';
 export * from './shell.js';

--- a/tools/utils/src/productionize.d.ts
+++ b/tools/utils/src/productionize.d.ts
@@ -1,0 +1,7 @@
+export function productionizeImports(
+  imports: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined;
+
+export function productionizeExports(exportsField: unknown): unknown;
+
+export function productionizeManifest<T extends Record<string, unknown>>(manifest: T): T;

--- a/tools/utils/src/productionize.js
+++ b/tools/utils/src/productionize.js
@@ -1,0 +1,68 @@
+const SOURCE_CONDITIONS = new Set(['development', 'workspace-source']);
+const IMPORT_SOURCE_CONDITIONS = new Set([...SOURCE_CONDITIONS, 'types']);
+
+/**
+ * Removes source-only package conditions from a manifest target while preserving
+ * references that do not need productionization.
+ */
+function productionizeTarget(target, excludedConditions = SOURCE_CONDITIONS) {
+  if (typeof target === 'string' || target === null || typeof target !== 'object') {
+    return target;
+  }
+
+  if (Array.isArray(target)) {
+    let changed = false;
+    const productionized = target.map((value) => {
+      const result = productionizeTarget(value, excludedConditions);
+      if (result !== value) changed = true;
+      return result;
+    });
+    return changed ? productionized : target;
+  }
+
+  let changed = false;
+  const productionized = {};
+  for (const [condition, value] of Object.entries(target)) {
+    if (excludedConditions.has(condition)) {
+      changed = true;
+      continue;
+    }
+
+    const result = productionizeTarget(value, excludedConditions);
+    if (result !== value) changed = true;
+    productionized[condition] = result;
+  }
+
+  if (!changed) return target;
+  if (Object.keys(productionized).length === 1 && 'default' in productionized) {
+    return productionized.default;
+  }
+  return productionized;
+}
+
+export function productionizeImports(imports) {
+  if (!imports) return imports;
+
+  const productionized = productionizeTarget(imports, IMPORT_SOURCE_CONDITIONS);
+  const subpathImports = imports['#*'];
+  const hasDistDefault =
+    subpathImports &&
+    typeof subpathImports === 'object' &&
+    !Array.isArray(subpathImports) &&
+    subpathImports.default === './dist/*';
+  if (subpathImports !== './src/*' && !hasDistDefault) return productionized;
+
+  return {...productionized, '#*': './dist/*'};
+}
+
+export function productionizeExports(exportsField) {
+  return productionizeTarget(exportsField);
+}
+
+export function productionizeManifest(manifest) {
+  const imports = productionizeImports(manifest.imports);
+  const exportsField = productionizeExports(manifest.exports);
+  if (imports === manifest.imports && exportsField === manifest.exports) return manifest;
+
+  return {...manifest, imports, exports: exportsField};
+}

--- a/tools/utils/test/productionize.test.mjs
+++ b/tools/utils/test/productionize.test.mjs
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  productionizeExports,
+  productionizeImports,
+  productionizeManifest,
+} from '../src/productionize.js';
+
+const SOURCE_PATH = /\.\/src\//u;
+
+test('productionizes legacy and conditional subpath imports', () => {
+  const legacyImports = {'#*': './src/*'};
+  const conditionalImports = {
+    '#*': {
+      types: './src/*',
+      'workspace-source': './src/*',
+      development: './src/*',
+      default: './dist/*',
+    },
+    '#test/*': './test/*',
+  };
+
+  const legacyResult = productionizeImports(legacyImports);
+  const conditionalResult = productionizeImports(conditionalImports);
+
+  assert.deepEqual(legacyResult, {'#*': './dist/*'});
+  assert.deepEqual(conditionalResult, {'#*': './dist/*', '#test/*': './test/*'});
+  assert.notEqual(legacyResult, legacyImports);
+  assert.notEqual(conditionalResult, conditionalImports);
+});
+
+test('preserves imports that do not need productionization', () => {
+  const imports = {'#test/*': './test/*'};
+
+  const result = productionizeImports(imports);
+
+  assert.equal(result, imports);
+});
+
+test('removes source type conditions from non-wildcard imports', () => {
+  const imports = {
+    '#generated': {types: './src/generated.ts', default: './dist/generated.js'},
+  };
+
+  const result = productionizeImports(imports);
+
+  assert.deepEqual(result, {'#generated': './dist/generated.js'});
+});
+
+test('preserves unchanged array targets by identity and productionizes mixed fallbacks', () => {
+  const unchanged = ['./dist/index.js', null];
+  const imports = {
+    '#unchanged': unchanged,
+    '#mixed': [{development: './src/mixed.ts', default: './dist/mixed.js'}, null],
+  };
+
+  const result = productionizeImports(imports);
+
+  assert.equal(result['#unchanged'], unchanged);
+  assert.deepEqual(result['#mixed'], ['./dist/mixed.js', null]);
+});
+
+test('productionizes exports with conditional, wildcard, string, and style targets', () => {
+  const exportsField = {
+    '.': {
+      development: {types: './src/index.ts', default: './src/index.ts'},
+      default: {types: './dist/index.d.ts', default: './dist/index.js'},
+    },
+    './core/*': {
+      'workspace-source': './src/core/*.ts',
+      default: './dist/core/*.js',
+    },
+    './styles.css': './dist/styles.css',
+    './theme/*': {style: './dist/theme/*.css', default: './dist/theme/*.js'},
+  };
+
+  const result = productionizeExports(exportsField);
+
+  assert.deepEqual(result, {
+    '.': {types: './dist/index.d.ts', default: './dist/index.js'},
+    './core/*': './dist/core/*.js',
+    './styles.css': './dist/styles.css',
+    './theme/*': {style: './dist/theme/*.css', default: './dist/theme/*.js'},
+  });
+});
+
+test('productionizes manifests without retaining source targets', () => {
+  const manifest = {
+    name: '@shipfox/example',
+    imports: {
+      '#*': {
+        'workspace-source': './src/*',
+        development: './src/*',
+        default: './dist/*',
+      },
+    },
+    exports: {
+      '.': {
+        development: {types: './src/index.ts', default: './src/index.ts'},
+        default: {types: './dist/index.d.ts', default: './dist/index.js'},
+      },
+    },
+  };
+
+  const result = productionizeManifest(manifest);
+
+  assert.deepEqual(result, {
+    name: '@shipfox/example',
+    imports: {'#*': './dist/*'},
+    exports: {'.': {types: './dist/index.d.ts', default: './dist/index.js'}},
+  });
+  assert.doesNotMatch(JSON.stringify(result), SOURCE_PATH);
+});
+
+test('preserves manifest identity when it is already productionized', () => {
+  const manifest = {
+    name: '@shipfox/example',
+    imports: {'#*': './dist/*'},
+    exports: {'.': './dist/index.js'},
+  };
+
+  const result = productionizeManifest(manifest);
+
+  assert.equal(result, manifest);
+});


### PR DESCRIPTION
Productionizes the npm publication closure so published package manifests point external consumers at `dist`, while source manifests retain workspace development conditions.

Temporal's default webpack resolver and consumers opting into the development condition could otherwise resolve non-shipped TypeScript source. The publish wrapper rewrites only the 80-package closure and restores it after publishing; validation keeps the source contract intact while guarding the packed result.

The implementation deliberately uses the existing Changesets flow instead of a separate pack/publish pipeline. The shared productionizer keeps Docker's pruned runtime manifests and published manifests consistent.

Closes ENG-1023

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Productionizes published npm manifests so external consumers resolve to compiled `dist` outputs, while workspace manifests keep development conditions. Addresses Linear `ENG-1023` by eliminating source resolution in the published closure (fixes defects #2 and #3).

- **New Features**
  - Shared manifest productionizer in `@shipfox/tool-utils` (`productionizeImports`, `productionizeExports`, `productionizeManifest`) to strip `development`/`workspace-source` conditions and collapse to `dist`.
  - Publish wrapper `dev/publish-productionized-closure.mjs` runs before `changeset publish`, rewrites only the closure, and restores after; `@shipfox/application-release` validator now asserts packed `imports`/`exports` never target `./src/`.

- **Refactors**
  - `tools/docker/src/turbo.ts` now consumes the shared `productionizeImports` and removes its local implementation.
  - `release:publish` executes the new publish wrapper; focused tests added for productionization, validator rules, and restore behavior.

<sup>Written for commit d5bd706a33ceac75d80430e3b5c6e66fb2f51ca4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

