### PR TITLE
[client-shell] Harden packed consumer gate

### DIFF
--- a/.changeset/brave-otters-verify.md
+++ b/.changeset/brave-otters-verify.md
@@ -2,4 +2,4 @@
 "@shipfox/client-shell": patch
 ---
 
-Hardens packed client composition validation against release artifacts, undeclared route packages, and missing Storybook testing peers.
+Hardens packed client composition validation against release artifacts, undeclared route packages, and optional Storybook testing peers.

--- a/.changeset/brave-otters-verify.md
+++ b/.changeset/brave-otters-verify.md
@@ -2,4 +2,4 @@
 "@shipfox/client-shell": patch
 ---
 
-Hardens packed client composition validation against release artifacts and undeclared route packages.
+Hardens packed client composition validation against release artifacts, undeclared route packages, and missing Storybook testing peers.

--- a/.changeset/brave-otters-verify.md
+++ b/.changeset/brave-otters-verify.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-shell": patch
+---
+
+Hardens packed client composition validation against release artifacts and undeclared route packages.

--- a/docs/adr/0001-client-composition-contract.md
+++ b/docs/adr/0001-client-composition-contract.md
@@ -354,8 +354,9 @@ Packages keep the repository export conditions:
 - `shipfox-tsc-emit` emits declarations; and
 - ESM export maps define the public surface.
 
-The packed-consumer gate runs without source conditions. Changesets link the public client packages
-as one release group. `@shipfox/react-ui` stays outside that linked group.
+The packed-consumer gate verifies default, `development`, and `types` resolution against
+productionized tarballs with no source targets. Changesets link the public client packages as one
+release group. `@shipfox/react-ui` stays outside that linked group.
 
 ## Composition roots
 

--- a/libs/client/shell/package.json
+++ b/libs/client/shell/package.json
@@ -81,6 +81,7 @@
     "framer-motion": "catalog:"
   },
   "peerDependencies": {
+    "@storybook/react": "^10.4.6",
     "@tanstack/react-query": "^5.101.0",
     "@tanstack/react-router": "^1.170.16",
     "jotai": "^2.19.1",

--- a/libs/client/shell/package.json
+++ b/libs/client/shell/package.json
@@ -90,6 +90,11 @@
     "vite": "^8.0.3",
     "zod": "^4.4.3"
   },
+  "peerDependenciesMeta": {
+    "@storybook/react": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",
     "@shipfox/client-test-setup": "workspace:*",

--- a/libs/client/shell/test/external/FINDINGS.md
+++ b/libs/client/shell/test/external/FINDINGS.md
@@ -20,11 +20,16 @@ The fixture proves that:
 
 ## Distribution isolation
 
-Packed mode builds declarations and runtime files before creating tarballs. It installs every
-first-party package through `file:` overrides in a temporary consumer outside the workspace, rejects
-registry-resolved Shipfox packages, rejects `workspace:` ranges, and confirms runtime imports resolve
-through each package's default `dist` condition. Linked mode keeps the same behavior and type checks
-for faster local iteration.
+Packed mode builds declarations and runtime files before creating tarballs, then productionizes each
+manifest like `release:publish` so source conditions cannot leak into the consumer artifact. The
+fixture declares only the documented client composition roots, plus `@shipfox/client-config` for its
+own config proof, while `file:` overrides keep every first-party runtime dependency in the full
+closure on its local tarball. It rejects registry-resolved Shipfox packages and `workspace:` ranges
+across every installed closure package, checks that generated package imports are direct fixture
+dependencies, and confirms full-closure runtime and type imports resolve through `dist` under
+default, `development`, and `types` conditions. Linked mode keeps the
+minimal-consumer, generated-route, behavior, collision, and type checks for faster local iteration;
+its workspace packages intentionally resolve `development` to source.
 
 ## Collision diagnostic
 

--- a/libs/client/shell/test/external/FINDINGS.md
+++ b/libs/client/shell/test/external/FINDINGS.md
@@ -20,14 +20,15 @@ The fixture proves that:
 
 ## Distribution isolation
 
-Packed mode builds declarations and runtime files before creating tarballs, then productionizes each
-manifest like `release:publish` so source conditions cannot leak into the consumer artifact. The
-fixture declares only the documented client composition roots, plus `@shipfox/client-config` for its
-own config proof, while `file:` overrides keep every first-party runtime dependency in the full
-closure on its local tarball. It rejects registry-resolved Shipfox packages and `workspace:` ranges
-across every installed closure package, checks that generated package imports are direct fixture
-dependencies, and confirms full-closure runtime and type imports resolve through `dist` under
-default, `development`, and `types` conditions. Linked mode keeps the
+Packed mode builds declarations and runtime files before creating tarballs, then productionizes a
+temporary copy of each package manifest like `release:publish` so source conditions cannot leak into
+the consumer artifact or mutate the worktree. The fixture declares only the documented client
+composition roots, plus `@shipfox/client-config` for its own config proof, while `file:` overrides
+keep every first-party runtime dependency in the full closure on its local tarball. It rejects
+registry-resolved Shipfox packages and `workspace:` ranges across every installed closure package,
+checks that generated package imports are direct fixture dependencies, and confirms full-closure
+runtime imports resolve through `dist` under default and `development` conditions while TypeScript
+checks every packed declaration graph. Linked mode keeps the
 minimal-consumer, generated-route, behavior, collision, and type checks for faster local iteration;
 its workspace packages intentionally resolve `development` to source.
 

--- a/libs/client/shell/test/external/README.md
+++ b/libs/client/shell/test/external/README.md
@@ -18,9 +18,9 @@ The gate installs only the nine documented client composition roots, plus
 `@shipfox/client-config` used by the fixture's own config proof, as direct dependencies. It uses
 release-shaped local tarballs and overrides for the full `@shipfox/*` runtime closure. It verifies
 that generated package imports are declared direct dependencies, checks default and `development`
-condition resolution through `dist`, generates the composed TanStack router, builds and type-checks
-the consumer, runs the behavioral fixture, and asserts the exact rejected-collision diagnostic. CI
-runs this command during static verification.
+condition resolution through `dist`, type-checks every packed declaration graph, generates the
+composed TanStack router, builds and type-checks the consumer, runs the behavioral fixture, and
+asserts the exact rejected-collision diagnostic. CI runs this command during static verification.
 
 ## Run the linked iteration mode
 

--- a/libs/client/shell/test/external/README.md
+++ b/libs/client/shell/test/external/README.md
@@ -14,8 +14,11 @@ full client closure:
 pnpm --filter=@shipfox/client-shell test:external
 ```
 
-The gate installs only local tarballs for `@shipfox/*`, checks `dist` resolution under both the
-default and `development` conditions, generates the composed TanStack router, builds and type-checks
+The gate installs only the nine documented client composition roots, plus
+`@shipfox/client-config` used by the fixture's own config proof, as direct dependencies. It uses
+release-shaped local tarballs and overrides for the full `@shipfox/*` runtime closure. It verifies
+that generated package imports are declared direct dependencies, checks default and `development`
+condition resolution through `dist`, generates the composed TanStack router, builds and type-checks
 the consumer, runs the behavioral fixture, and asserts the exact rejected-collision diagnostic. CI
 runs this command during static verification.
 
@@ -26,7 +29,9 @@ pnpm --filter=@shipfox/client-shell test:external -- --link
 ```
 
 This copies the Vite template to a temporary directory and links the workspace-built closure. It
-runs the same generated-route, behavior, collision, and type assertions without packing tarballs.
+runs the same minimal-consumer, generated-route, behavior, collision, and type assertions without
+packing tarballs. The packed-only `development` check is omitted because linked workspace packages
+intentionally resolve that condition to source.
 
 Both modes remove their temporary directories after completion. The behavioral composition fixture
 uses Vitest with JSDOM and does not need browser E2E infrastructure.

--- a/libs/client/shell/test/external/fixture/package.json
+++ b/libs/client/shell/test/external/fixture/package.json
@@ -18,6 +18,7 @@
     "zod": "4.4.3"
   },
   "devDependencies": {
+    "@storybook/react": "10.4.6",
     "@types/node": "24.13.2",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",

--- a/libs/client/shell/test/external/verify.mjs
+++ b/libs/client/shell/test/external/verify.mjs
@@ -274,47 +274,53 @@ process.stdout.write(JSON.stringify(resolved));`,
 async function validateFullClosureTypeDeclarations(root, specifiers) {
   const typeScriptCli = join(root, 'node_modules', 'typescript', 'bin', 'tsc');
   const specifiersByPackage = Map.groupBy(specifiers, packageNameFromSpecifier);
+  const auditRoot = join(root, 'full-closure-types');
+  const typeFixtures = [];
   let auditIndex = 0;
   for (const [packageName, packageSpecifiers] of specifiersByPackage) {
     for (const packageRoot of installedPackageRoots(root, packageName)) {
-      const auditRoot = join(root, 'full-closure-types', String(auditIndex));
+      const packageAuditRoot = join(auditRoot, String(auditIndex));
       auditIndex += 1;
-      await writeTypeAudit(auditRoot, packageName, packageRoot, packageSpecifiers);
-      await run(process.execPath, [typeScriptCli, '--project', 'tsconfig.json'], auditRoot, {
-        capture: true,
-      });
+      await writeTypeAudit(packageAuditRoot, packageName, packageRoot, packageSpecifiers);
+      typeFixtures.push(relative(auditRoot, join(packageAuditRoot, 'types.ts')));
     }
   }
+
+  await writeTypeAuditConfig(auditRoot, typeFixtures);
+  await run(process.execPath, [typeScriptCli, '--project', 'tsconfig.json'], auditRoot, {
+    capture: true,
+  });
 }
 
 async function writeTypeAudit(root, packageName, packageRoot, specifiers) {
   const packageLink = join(root, 'node_modules', ...packageName.split('/'));
   await mkdir(dirname(packageLink), {recursive: true});
   await symlink(packageRoot, packageLink, 'dir');
-  await Promise.all([
-    writeFile(
-      join(root, 'tsconfig.json'),
-      `${JSON.stringify(
-        {
-          compilerOptions: {
-            strict: true,
-            target: 'ES2022',
-            lib: ['ES2022', 'DOM', 'DOM.Iterable'],
-            module: 'ESNext',
-            moduleResolution: 'bundler',
-            jsx: 'react-jsx',
-            skipLibCheck: true,
-            verbatimModuleSyntax: true,
-            noEmit: true,
-          },
-          include: ['types.ts'],
+  await writeTypeFixture(root, specifiers);
+}
+
+async function writeTypeAuditConfig(root, typeFixtures) {
+  await writeFile(
+    join(root, 'tsconfig.json'),
+    `${JSON.stringify(
+      {
+        compilerOptions: {
+          strict: true,
+          target: 'ES2022',
+          lib: ['ES2022', 'DOM', 'DOM.Iterable'],
+          module: 'ESNext',
+          moduleResolution: 'bundler',
+          jsx: 'react-jsx',
+          skipLibCheck: false,
+          verbatimModuleSyntax: true,
+          noEmit: true,
         },
-        null,
-        2,
-      )}\n`,
-    ),
-    writeTypeFixture(root, specifiers),
-  ]);
+        files: typeFixtures,
+      },
+      null,
+      2,
+    )}\n`,
+  );
 }
 
 function installedPackageRoots(root, packageName) {

--- a/libs/client/shell/test/external/verify.mjs
+++ b/libs/client/shell/test/external/verify.mjs
@@ -29,18 +29,29 @@ const {
 } = await import(
   pathToFileURL(join(repositoryRoot, 'tools/application-release/dist/package-closure.js')).href
 );
+const {productionizeManifest} = await import(
+  pathToFileURL(join(repositoryRoot, 'tools/utils/src/productionize.js')).href
+);
 const config = readPublicationClosureConfig(join(repositoryRoot, 'publication-closure.json'));
 const workspacePackages = readWorkspacePackages(repositoryRoot);
 validatePublicationState(workspacePackages, config, repositoryRoot);
 const clientRoots = config.roots.filter((root) => root.startsWith('@shipfox/client-'));
+const fixtureSupportPackages = ['@shipfox/client-config'];
+const consumerPackages = [...clientRoots, ...fixtureSupportPackages];
 const closure = computePublicationClosure(workspacePackages, clientRoots);
 const entryPoints = closure.flatMap((name) =>
   listConcreteEntryPoints(name, requiredPackage(workspacePackages, name)),
 );
+const consumerTypeEntryPoints = clientRoots.flatMap((name) =>
+  listConcreteEntryPoints(name, requiredPackage(workspacePackages, name)),
+);
+const closureTypeEntryPoints = entryPoints
+  .filter(({target}) => entryPointSupportsTypeResolution(target))
+  .map(({specifier}) => specifier);
 const runtimeEntryPoints = entryPoints
   .filter(({target}) => entryPointSupportsRuntimeImport(target))
   .map(({specifier}) => specifier);
-const typeEntryPoints = entryPoints
+const typeEntryPoints = consumerTypeEntryPoints
   .filter(({target}) => entryPointSupportsTypeResolution(target))
   .map(({specifier}) => specifier);
 const temporaryRoot = await mkdtemp(join(tmpdir(), 'shipfox-client-composition-'));
@@ -51,18 +62,27 @@ try {
   const packageSpecs = linkMode
     ? linkedPackageSpecs(closure, workspacePackages)
     : await packedPackageSpecs(closure, workspacePackages, temporaryRoot);
-  await configureFixture(fixtureRoot, packageSpecs);
+  await configureFixture(fixtureRoot, consumerPackages, packageSpecs);
   await writeTypeFixture(fixtureRoot, typeEntryPoints);
   await run('pnpm', ['install', '--prefer-offline', '--ignore-scripts'], fixtureRoot, {
     capture: true,
   });
 
-  if (linkMode) await validateLinkedPackages(fixtureRoot, closure, workspacePackages);
+  if (linkMode) await validateLinkedPackages(fixtureRoot, consumerPackages, workspacePackages);
   else {
     await validateInstalledPackages(fixtureRoot, closure, workspacePackages);
     await validateNoRegistryShipfoxPackages(fixtureRoot);
-    await validatePackageResolution(fixtureRoot, runtimeEntryPoints);
-    await validatePackageResolution(fixtureRoot, runtimeEntryPoints, ['development']);
+    await validatePackageResolution(fixtureRoot, runtimeEntryPoints, {
+      conditionLabel: 'default',
+    });
+    await validatePackageResolution(fixtureRoot, runtimeEntryPoints, {
+      nodeArgs: ['--conditions=development'],
+      conditionLabel: 'development',
+    });
+    await validatePackageResolution(fixtureRoot, closureTypeEntryPoints, {
+      nodeArgs: ['--conditions=types'],
+      conditionLabel: 'types',
+    });
   }
 
   await run('pnpm', ['exec', 'vite', 'build'], fixtureRoot, {capture: true});
@@ -109,16 +129,36 @@ async function packedPackageSpecs(names, packages, root) {
   const tarballs = await mapWithConcurrency(names, 4, async (name) => {
     const workspacePackage = requiredPackage(packages, name);
     const tarball = join(tarballRoot, `${safePackageName(name)}.tgz`);
-    await run('pnpm', ['pack', '--out', tarball], workspacePackage.directory, {capture: true});
+    await packProductionizedPackage(workspacePackage, tarball);
     return [name, `file:${tarball}`];
   });
   return Object.fromEntries(tarballs);
 }
 
-async function configureFixture(root, packageSpecs) {
+async function packProductionizedPackage(workspacePackage, tarball) {
+  const originalManifest = await readFile(workspacePackage.manifestPath, 'utf8');
+  const manifest = JSON.parse(originalManifest);
+  const productionized = productionizeManifest(manifest);
+  if (productionized !== manifest) {
+    await writeFile(workspacePackage.manifestPath, `${JSON.stringify(productionized, null, 2)}\n`);
+  }
+
+  try {
+    await run('pnpm', ['pack', '--out', tarball], workspacePackage.directory, {capture: true});
+  } finally {
+    if (productionized !== manifest) {
+      await writeFile(workspacePackage.manifestPath, originalManifest);
+    }
+  }
+}
+
+async function configureFixture(root, consumerPackages, packageSpecs) {
   const manifestPath = join(root, 'package.json');
   const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
-  manifest.dependencies = {...manifest.dependencies, ...packageSpecs};
+  const consumerDependencies = Object.fromEntries(
+    consumerPackages.map((name) => [name, packageSpecs[name]]),
+  );
+  manifest.dependencies = {...manifest.dependencies, ...consumerDependencies};
   await Promise.all([
     writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`),
     writeFile(
@@ -156,21 +196,24 @@ async function validateLinkedPackages(root, names, packages) {
 async function validateInstalledPackages(root, names, packages) {
   const realFixtureRoot = await realpath(root);
   for (const name of names) {
-    const installedManifestPath = join(root, 'node_modules', name, 'package.json');
-    const installedManifest = JSON.parse(await readFile(installedManifestPath, 'utf8'));
-    const expectedManifest = requiredPackage(packages, name).manifest;
-    if (installedManifest.version !== expectedManifest.version) {
-      throw new Error(
-        `Packed ${name} has version ${installedManifest.version}; expected ${expectedManifest.version}`,
+    for (const packageRoot of installedPackageRoots(root, name)) {
+      const installedManifest = JSON.parse(
+        await readFile(join(packageRoot, 'package.json'), 'utf8'),
       );
-    }
-    const workspaceRange = findWorkspaceRange(installedManifest);
-    if (workspaceRange)
-      throw new Error(`Packed ${name} contains a workspace range at ${workspaceRange}`);
-    validateDefaultInternalImports(name, installedManifest);
-    const installedRoot = await realpath(join(root, 'node_modules', name));
-    if (!installedRoot.startsWith(realFixtureRoot)) {
-      throw new Error(`Packed ${name} resolved outside the external consumer`);
+      const expectedManifest = requiredPackage(packages, name).manifest;
+      if (installedManifest.version !== expectedManifest.version) {
+        throw new Error(
+          `Packed ${name} has version ${installedManifest.version}; expected ${expectedManifest.version}`,
+        );
+      }
+      const workspaceRange = findWorkspaceRange(installedManifest);
+      if (workspaceRange)
+        throw new Error(`Packed ${name} contains a workspace range at ${workspaceRange}`);
+      validateDefaultInternalImports(name, installedManifest);
+      const installedRoot = await realpath(packageRoot);
+      if (!installedRoot.startsWith(realFixtureRoot)) {
+        throw new Error(`Packed ${name} resolved outside the external consumer`);
+      }
     }
   }
 }
@@ -178,6 +221,7 @@ async function validateInstalledPackages(root, names, packages) {
 function validateDefaultInternalImports(name, manifest) {
   const internalImports = manifest.imports?.['#*'];
   if (internalImports === undefined) return;
+  if (internalImports === './dist/*') return;
   if (
     !internalImports ||
     typeof internalImports !== 'object' ||
@@ -188,30 +232,44 @@ function validateDefaultInternalImports(name, manifest) {
   }
 }
 
-async function validatePackageResolution(root, specifiers, conditions = []) {
-  const resolution = await run(
-    process.execPath,
-    [
-      ...conditions.map((condition) => `--conditions=${condition}`),
-      '--input-type=module',
-      '--eval',
-      `const specifiers = ${JSON.stringify(specifiers)};
+async function validatePackageResolution(root, specifiers, {nodeArgs = [], conditionLabel}) {
+  const specifiersByPackage = Map.groupBy(specifiers, packageNameFromSpecifier);
+  for (const [packageName, packageSpecifiers] of specifiersByPackage) {
+    for (const packageRoot of installedPackageRoots(root, packageName)) {
+      const resolution = await run(
+        process.execPath,
+        [
+          ...nodeArgs,
+          '--input-type=module',
+          '--eval',
+          `const specifiers = ${JSON.stringify(packageSpecifiers)};
 const resolved = Object.fromEntries(specifiers.map((specifier) => [specifier, import.meta.resolve(specifier)]));
 process.stdout.write(JSON.stringify(resolved));`,
-    ],
-    root,
-    {capture: true},
-  );
-  const resolved = JSON.parse(resolution.stdout);
-  for (const specifier of specifiers) {
-    const resolvedPath = fileURLToPath(resolved[specifier]);
-    if (!resolvedPath.split(sep).includes('dist')) {
-      const conditionLabel = conditions.length ? conditions.join(', ') : 'default';
-      throw new Error(
-        `Packed ${specifier} resolved to source instead of dist under ${conditionLabel} conditions: ${resolvedPath}`,
+        ],
+        packageRoot,
+        {capture: true},
       );
+      const resolved = JSON.parse(resolution.stdout);
+      for (const specifier of packageSpecifiers) {
+        const resolvedPath = fileURLToPath(resolved[specifier]);
+        if (!resolvedPath.split(sep).includes('dist')) {
+          throw new Error(
+            `Packed ${specifier} resolved to source instead of dist under the ${conditionLabel} condition: ${resolvedPath}`,
+          );
+        }
+      }
     }
   }
+}
+
+function installedPackageRoots(root, packageName) {
+  const packageRoots = globSync(
+    join(root, 'node_modules/.pnpm/**/node_modules', packageName),
+  ).sort();
+  if (!packageRoots.length) {
+    throw new Error(`Packed closure package is not installed: ${packageName}`);
+  }
+  return packageRoots;
 }
 
 async function validateNoRegistryShipfoxPackages(root) {
@@ -229,6 +287,8 @@ async function validateNoRegistryShipfoxPackages(root) {
 
 async function validateGeneratedModule(root) {
   const generated = await readFile(join(root, 'src/shipfox-app.gen.ts'), 'utf8');
+  const manifest = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'));
+  const declaredDependencies = new Set(Object.keys(manifest.dependencies));
   const expectedImports = [
     '@shipfox/client-auth/routes/index',
     '@shipfox/client-invitations/routes/accept',
@@ -245,6 +305,22 @@ async function validateGeneratedModule(root) {
       throw new Error(`Generated default composition did not include ${JSON.stringify(expected)}.`);
     }
   }
+
+  for (const match of generated.matchAll(/\bfrom\s+['"]([^'"]+)['"]/gu)) {
+    const specifier = match[1];
+    if (specifier.startsWith('.') || specifier.startsWith('/')) continue;
+    const packageName = packageNameFromSpecifier(specifier);
+    if (!declaredDependencies.has(packageName)) {
+      throw new Error(
+        `Generated default composition imports undeclared package ${JSON.stringify(packageName)} from ${JSON.stringify(specifier)}.`,
+      );
+    }
+  }
+}
+
+function packageNameFromSpecifier(specifier) {
+  if (!specifier.startsWith('@')) return specifier.split('/')[0];
+  return specifier.split('/').slice(0, 2).join('/');
 }
 
 function requiredPackage(packages, name) {

--- a/libs/client/shell/test/external/verify.mjs
+++ b/libs/client/shell/test/external/verify.mjs
@@ -1,8 +1,18 @@
 import {spawn} from 'node:child_process';
 import {globSync} from 'node:fs';
-import {cp, mkdir, mkdtemp, readdir, readFile, realpath, rm, writeFile} from 'node:fs/promises';
+import {
+  cp,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
-import {basename, join, relative, resolve, sep} from 'node:path';
+import {basename, dirname, join, relative, resolve, sep} from 'node:path';
 import {fileURLToPath, pathToFileURL} from 'node:url';
 
 const repositoryRoot = resolve(fileURLToPath(new URL('../../../../..', import.meta.url)));
@@ -79,10 +89,7 @@ try {
       nodeArgs: ['--conditions=development'],
       conditionLabel: 'development',
     });
-    await validatePackageResolution(fixtureRoot, closureTypeEntryPoints, {
-      nodeArgs: ['--conditions=types'],
-      conditionLabel: 'types',
-    });
+    await validateFullClosureTypeDeclarations(fixtureRoot, closureTypeEntryPoints);
   }
 
   await run('pnpm', ['exec', 'vite', 'build'], fixtureRoot, {capture: true});
@@ -125,31 +132,33 @@ function linkedPackageSpecs(names, packages) {
 
 async function packedPackageSpecs(names, packages, root) {
   const tarballRoot = join(root, 'tarballs');
-  await mkdir(tarballRoot);
+  const stagingRoot = join(root, 'packages');
+  await Promise.all([
+    mkdir(tarballRoot),
+    mkdir(stagingRoot),
+    cp(join(repositoryRoot, 'pnpm-workspace.yaml'), join(stagingRoot, 'pnpm-workspace.yaml')),
+  ]);
   const tarballs = await mapWithConcurrency(names, 4, async (name) => {
     const workspacePackage = requiredPackage(packages, name);
     const tarball = join(tarballRoot, `${safePackageName(name)}.tgz`);
-    await packProductionizedPackage(workspacePackage, tarball);
+    await packProductionizedPackage(workspacePackage, tarball, stagingRoot);
     return [name, `file:${tarball}`];
   });
   return Object.fromEntries(tarballs);
 }
 
-async function packProductionizedPackage(workspacePackage, tarball) {
-  const originalManifest = await readFile(workspacePackage.manifestPath, 'utf8');
-  const manifest = JSON.parse(originalManifest);
+async function packProductionizedPackage(workspacePackage, tarball, stagingRoot) {
+  const packageRoot = join(stagingRoot, safePackageName(workspacePackage.manifest.name));
+  await cp(workspacePackage.directory, packageRoot, {recursive: true});
+
+  const manifestPath = join(packageRoot, 'package.json');
+  const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
   const productionized = productionizeManifest(manifest);
   if (productionized !== manifest) {
-    await writeFile(workspacePackage.manifestPath, `${JSON.stringify(productionized, null, 2)}\n`);
+    await writeFile(manifestPath, `${JSON.stringify(productionized, null, 2)}\n`);
   }
 
-  try {
-    await run('pnpm', ['pack', '--out', tarball], workspacePackage.directory, {capture: true});
-  } finally {
-    if (productionized !== manifest) {
-      await writeFile(workspacePackage.manifestPath, originalManifest);
-    }
-  }
+  await run('pnpm', ['pack', '--out', tarball], packageRoot, {capture: true});
 }
 
 async function configureFixture(root, consumerPackages, packageSpecs) {
@@ -260,6 +269,52 @@ process.stdout.write(JSON.stringify(resolved));`,
       }
     }
   }
+}
+
+async function validateFullClosureTypeDeclarations(root, specifiers) {
+  const typeScriptCli = join(root, 'node_modules', 'typescript', 'bin', 'tsc');
+  const specifiersByPackage = Map.groupBy(specifiers, packageNameFromSpecifier);
+  let auditIndex = 0;
+  for (const [packageName, packageSpecifiers] of specifiersByPackage) {
+    for (const packageRoot of installedPackageRoots(root, packageName)) {
+      const auditRoot = join(root, 'full-closure-types', String(auditIndex));
+      auditIndex += 1;
+      await writeTypeAudit(auditRoot, packageName, packageRoot, packageSpecifiers);
+      await run(process.execPath, [typeScriptCli, '--project', 'tsconfig.json'], auditRoot, {
+        capture: true,
+      });
+    }
+  }
+}
+
+async function writeTypeAudit(root, packageName, packageRoot, specifiers) {
+  const packageLink = join(root, 'node_modules', ...packageName.split('/'));
+  await mkdir(dirname(packageLink), {recursive: true});
+  await symlink(packageRoot, packageLink, 'dir');
+  await Promise.all([
+    writeFile(
+      join(root, 'tsconfig.json'),
+      `${JSON.stringify(
+        {
+          compilerOptions: {
+            strict: true,
+            target: 'ES2022',
+            lib: ['ES2022', 'DOM', 'DOM.Iterable'],
+            module: 'ESNext',
+            moduleResolution: 'bundler',
+            jsx: 'react-jsx',
+            skipLibCheck: true,
+            verbatimModuleSyntax: true,
+            noEmit: true,
+          },
+          include: ['types.ts'],
+        },
+        null,
+        2,
+      )}\n`,
+    ),
+    writeTypeFixture(root, specifiers),
+  ]);
 }
 
 function installedPackageRoots(root, packageName) {


### PR DESCRIPTION
Hardens the external client fixture so its direct dependencies mirror an application while still auditing every packed closure artifact.

The previous gate packed workspace manifests directly, which differed from the `release:publish` artifact: source conditions remained and could make development resolution look broken even though published tarballs resolve `dist`. It now productionizes each manifest only for packing, restores it afterward, and resolves full-closure runtime and type entry points from pnpm virtual-store roots. Generated-router import validation catches route packages a consumer has not declared.

The fixture directly uses `@shipfox/client-config` for its config contract; it is the only support package beyond the documented composition roots.

Closes ENG-1028

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the packed consumer gate to validate release-shaped `@shipfox/*` artifacts, enforce a minimal consumer, and audit the full closure’s runtime and types. Prevents source-condition leaks, undeclared imports, and worktree mutation. Closes ENG-1028.

- **New Features**
  - Packs from staged, productionized manifests (matches `release:publish`) into local tarballs so runs cannot modify the worktree.
  - Installs only the documented client roots plus `@shipfox/client-config` as direct deps; ensures the generated composition imports only declared packages.
  - Verifies runtime resolution to `dist` under `default` and `development`; audits all packed public declaration graphs across the full `@shipfox/*` closure in one strict TypeScript program.
  - Rejects registry-resolved `@shipfox/*`, `workspace:` ranges, artifacts resolving outside the external consumer, and internal `#*` defaults that point to source; linked mode intentionally skips the `development` check.

- **Dependencies**
  - Marks `@storybook/react` as an optional peer used only by the testing export; the external fixture installs it to validate that export.

<sup>Written for commit 939dc207cac4d009ab0e4a1759b46b1796d65be4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

