### PR TITLE
Add route ID guards for client settings

### DIFF
--- a/libs/client/shell/test/typecheck/types.tsx
+++ b/libs/client/shell/test/typecheck/types.tsx
@@ -1,9 +1,14 @@
-import {Link, useSearch} from '@tanstack/react-router';
+import {getRouteApi, Link, useSearch} from '@tanstack/react-router';
 import './shipfox-app.gen.js';
 
 export function CompositionTypes(): React.ReactNode {
   const search = useSearch({from: '/workspaces/$wid/projects/$pid/overview'});
   const tab: 'activity' | 'overview' = search.tab;
+
+  getRouteApi('/workspaces/$wid/projects/$pid/overview');
+
+  // @ts-expect-error The generated route tree rejects unknown route ids.
+  getRouteApi('/not-a-route');
 
   return (
     <>

--- a/libs/client/workspace-settings/test/typecheck/route-ids.tsx
+++ b/libs/client/workspace-settings/test/typecheck/route-ids.tsx
@@ -1,0 +1,7 @@
+import {getRouteApi} from '@tanstack/react-router';
+import './settings-composition.js';
+
+getRouteApi('/workspaces/$wid/settings/events');
+
+// @ts-expect-error The generated route tree rejects unknown route ids.
+getRouteApi('/workspaces/$wid/settings/_layout/events');

--- a/libs/client/workspace-settings/test/typecheck/settings-composition.tsx
+++ b/libs/client/workspace-settings/test/typecheck/settings-composition.tsx
@@ -1,0 +1,95 @@
+import {buildAnchorSkeleton, type RouterContext} from '@shipfox/client-shell/runtime';
+import {createRoute, createRouter} from '@tanstack/react-router';
+import agentsRoute from '#routes/agents.js';
+import eventsRoute from '#routes/events.js';
+import indexRoute from '#routes/index.js';
+import integrationsRoute from '#routes/integrations.js';
+import membersRoute from '#routes/members.js';
+import provisionersRoute from '#routes/provisioners.js';
+import runnersRoute from '#routes/runners.js';
+import secretsRoute from '#routes/secrets.js';
+import variablesRoute from '#routes/variables.js';
+
+const skeleton = buildAnchorSkeleton({navigation: [], settingsSections: []});
+
+const settingsIndexRoute = createRoute({
+  getParentRoute: () => skeleton.workspaceSettings,
+  path: '/',
+  ...indexRoute.options,
+});
+
+const membersRouteNode = createRoute({
+  getParentRoute: () => skeleton.workspaceSettings,
+  path: '/members',
+  ...membersRoute.options,
+});
+
+const runnersRouteNode = createRoute({
+  getParentRoute: () => skeleton.workspaceSettings,
+  path: '/runners',
+  ...runnersRoute.options,
+});
+
+const provisionersRouteNode = createRoute({
+  getParentRoute: () => skeleton.workspaceSettings,
+  path: '/provisioners',
+  ...provisionersRoute.options,
+});
+
+const agentsRouteNode = createRoute({
+  getParentRoute: () => skeleton.workspaceSettings,
+  path: '/agents',
+  ...agentsRoute.options,
+});
+
+const secretsRouteNode = createRoute({
+  getParentRoute: () => skeleton.workspaceSettings,
+  path: '/secrets',
+  ...secretsRoute.options,
+});
+
+const variablesRouteNode = createRoute({
+  getParentRoute: () => skeleton.workspaceSettings,
+  path: '/variables',
+  ...variablesRoute.options,
+});
+
+const integrationsRouteNode = createRoute({
+  getParentRoute: () => skeleton.workspaceSettings,
+  path: '/integrations',
+  ...integrationsRoute.options,
+});
+
+const eventsRouteNode = createRoute({
+  getParentRoute: () => skeleton.workspaceSettings,
+  path: '/events',
+  ...eventsRoute.options,
+});
+
+const workspaceSettings = skeleton.workspaceSettings.addChildren([
+  settingsIndexRoute,
+  membersRouteNode,
+  runnersRouteNode,
+  provisionersRouteNode,
+  agentsRouteNode,
+  secretsRouteNode,
+  variablesRouteNode,
+  integrationsRouteNode,
+  eventsRouteNode,
+]);
+
+const workspaceLayout = skeleton.workspaceLayout.addChildren([workspaceSettings]);
+
+const routeTree = skeleton.rootRoute.addChildren([workspaceLayout]);
+
+export const router = createRouter({
+  routeTree,
+  context: {auth: undefined, queryClient: undefined} satisfies RouterContext,
+  scrollRestoration: true,
+});
+
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: typeof router;
+  }
+}


### PR DESCRIPTION
Add compile-time route-ID guards for the workspace settings client feature.

The leaf package type-check previously had no registered composed router, which widened `getRouteApi(...)` IDs to `string` and allowed the stale `_layout` events path to pass. The new type-check fixture registers the real settings route implementations and asserts both the valid public ID and the stale internal-layout ID.

A shell-only assertion would document router behavior but would not validate calls retained in leaf source. The leaf fixture keeps that source in the registered-router program while remaining excluded from emitted declarations.

The fixture covers the settings subtree. If a settings page later targets another feature's route, extend its registered tree accordingly.

The linked client-group publish, including the next 0.3.0 release, remains release-owner work outside this PR.

Refs ENG-1030

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add compile-time route ID guards for workspace settings so only valid `getRouteApi(...)` paths type-check. This meets ENG-1030’s guard requirement and blocks stale IDs like `/workspaces/$wid/settings/_layout/events` from passing CI.

- **Bug Fixes**
  - Register the real settings subtree in a test-only router and assert `/workspaces/$wid/settings/events` is valid; reject the `_layout` path.
  - Mirror the guard in `@shipfox/client-shell` type-checks to reject unknown routes (e.g., `/not-a-route`), ensuring `getRouteApi` from `@tanstack/react-router` narrows to known IDs.

<sup>Written for commit a278ee75e444129f4f44e90307a3e6b056935465. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

