### PR TITLE
Publish shared email normalization and email-owner lookup seams

### DIFF
--- a/.changeset/tidy-hounds-normalize.md
+++ b/.changeset/tidy-hounds-normalize.md
@@ -1,0 +1,9 @@
+---
+"@shipfox/api-common-dto": minor
+"@shipfox/api-auth": minor
+"@shipfox/api-auth-dto": patch
+"@shipfox/api-workspaces-dto": patch
+"@shipfox/application-release": patch
+---
+
+Publishes a shared provider-neutral `emailSchema` in `@shipfox/api-common-dto` and adopts it across auth and workspace invitation inputs. Adds a read-only `findUserByEmail`/`EmailOwner` seam to `@shipfox/api-auth` for looking up the current owner of a normalized email without creating a session or mutating that user. Extends the packed external consumer gate to exercise both seams against PostgreSQL through installed tarballs.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
+      - name: Start test services
+        id: test-services
+        run: docker compose up --wait -d postgres
+        background: true
+
       - name: Set up mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
 
@@ -57,6 +62,9 @@ jobs:
 
       - name: Verify packed published package artifacts
         run: pnpm check:published-artifacts
+
+      - name: Wait for test services
+        wait: test-services
 
       - name: Verify packed API runtime closure
         run: pnpm --filter=@shipfox/application-release test:external

--- a/libs/api/auth-dto/src/schemas/auth.ts
+++ b/libs/api/auth-dto/src/schemas/auth.ts
@@ -1,15 +1,11 @@
-import {displayNameSchema} from '@shipfox/api-common-dto';
+import {displayNameSchema, emailSchema} from '@shipfox/api-common-dto';
 import {z} from 'zod';
 import {userDtoSchema} from './user.js';
 
 export const EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS = 60;
 
 export const passwordSchema = z.string().min(12).max(128);
-export const emailSchema = z
-  .string()
-  .email()
-  .max(254)
-  .transform((value) => value.toLowerCase());
+export {emailSchema};
 
 export const signupBodySchema = z.object({
   email: emailSchema,

--- a/libs/api/auth/README.md
+++ b/libs/api/auth/README.md
@@ -239,7 +239,8 @@ It also exports lower-level pieces for tests and advanced integration:
 - `issueRunnerSessionToken(claims)` / `verifyRunnerSessionToken(token)`: mint and verify runner session tokens.
 - `issueJobLeaseToken(claims)` / `verifyJobLeaseToken(token)`: mint and verify job lease tokens.
 - `getClientContext(request)`: reads the authenticated user context from a Fastify request.
-- Entity types: `User`, `UserStatus`, `RefreshToken`, `EmailVerification`, and `PasswordReset`.
+- `findUserByEmail({email})`: read-only lookup of the current owner of a normalized email; see below.
+- Entity types: `User`, `UserStatus`, `RefreshToken`, `EmailVerification`, `PasswordReset`, and `EmailOwner`.
 
 ### External identity callbacks
 
@@ -286,6 +287,29 @@ status, verification state, or password. Repeated and concurrent callbacks are
 safe.
 
 This pre-verified user state lets an external login method create a session when password login and email-verification routes are disabled.
+
+### Email ownership lookup
+
+`findUserByEmail({email})` answers "who currently owns this email?" without
+creating a session or changing that user:
+
+```ts
+import {findUserByEmail} from '@shipfox/api-auth';
+
+const owner = await findUserByEmail({email: rawEmail});
+if (owner) {
+  // owner: {id, email, status}
+}
+```
+
+It parses `rawEmail` through the same shared `emailSchema` used by every other
+auth entry point, so whitespace and casing differences resolve to the same
+owner. It returns an owner for every account status (`active`, `suspended`, or
+`deleted`), and `undefined` when no user owns the address. The returned
+`EmailOwner` is an explicit projection of `id`, `email`, and `status` only; it
+never carries a password hash, profile fields, or verification timestamps.
+This seam performs no writes, so it is safe to call before deciding whether to
+provision, link, or reject an identity.
 
 `createSessionForUser` accepts either a `userId` or an `email`. It only creates
 a session for an active, verified user. It can throw `UserNotFoundError`,

--- a/libs/api/auth/src/core/auth.test.ts
+++ b/libs/api/auth/src/core/auth.test.ts
@@ -165,11 +165,11 @@ describe('auth core', () => {
     const storedSuspended = await findUserById({id: suspended.id});
 
     const existingUnverified = await provisionUser({
-      email: unverified.email.toUpperCase(),
+      email: `  ${unverified.email.toUpperCase()}  `,
       name: 'Replacement Name',
     });
     const existingSuspended = await provisionUser({
-      email: suspended.email.toUpperCase(),
+      email: `  ${suspended.email.toUpperCase()}  `,
       name: 'Replacement Name',
     });
 
@@ -255,6 +255,27 @@ describe('auth core', () => {
     await expect(createSessionForUser({userId: suspended.id})).rejects.toBeInstanceOf(
       InvalidCredentialsError,
     );
+  });
+
+  test('createSessionForUser({email}) resolves surrounding whitespace and mixed case', async () => {
+    const user = await userFactory.create({emailVerifiedAt: new Date()});
+
+    const result = await createSessionForUser({email: `  ${user.email.toUpperCase()}  `});
+
+    expect(result.user.id).toBe(user.id);
+    expect(result.token).toEqual(expect.any(String));
+  });
+
+  test('createSessionForUser({email}) retains eligibility checks', async () => {
+    const unverified = await userFactory.create();
+    const suspended = await userFactory.create({emailVerifiedAt: new Date()});
+    await db().update(users).set({status: 'suspended'}).where(eq(users.id, suspended.id));
+
+    const unverifiedResult = createSessionForUser({email: unverified.email});
+    const suspendedResult = createSessionForUser({email: suspended.email});
+
+    await expect(unverifiedResult).rejects.toBeInstanceOf(EmailNotVerifiedError);
+    await expect(suspendedResult).rejects.toBeInstanceOf(InvalidCredentialsError);
   });
 
   test('refreshAccessToken rotates the refresh token', async () => {

--- a/libs/api/auth/src/core/auth.ts
+++ b/libs/api/auth/src/core/auth.ts
@@ -330,7 +330,7 @@ export async function createSessionForUser(
   const user = params.userId
     ? await findUserById({id: params.userId})
     : params.email
-      ? await findUserByEmail({email: params.email})
+      ? await findUserByEmail({email: emailSchema.parse(params.email)})
       : undefined;
 
   if (!user) {

--- a/libs/api/auth/src/core/email-owner.test.ts
+++ b/libs/api/auth/src/core/email-owner.test.ts
@@ -1,0 +1,104 @@
+import {generateOpaqueToken, hashOpaqueToken} from '@shipfox/node-tokens';
+import {eq} from 'drizzle-orm';
+import {ZodError} from 'zod';
+import {findUserByEmail} from '#core/email-owner.js';
+import {db} from '#db/db.js';
+import {emailVerifications} from '#db/schema/email-verifications.js';
+import {refreshTokens} from '#db/schema/refresh-tokens.js';
+import {users} from '#db/schema/users.js';
+import * as usersDb from '#db/users.js';
+import {userFactory} from '#test/index.js';
+
+describe('findUserByEmail (email owner)', () => {
+  test('returns undefined for a missing owner', async () => {
+    const result = await findUserByEmail({
+      email: `missing-${crypto.randomUUID()}@example.com`,
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  test.each([
+    'active',
+    'suspended',
+    'deleted',
+  ] as const)('returns the owner of a(n) %s account', async (status) => {
+    const user = await userFactory.create({emailVerifiedAt: new Date()});
+    await db().update(users).set({status}).where(eq(users.id, user.id));
+
+    const result = await findUserByEmail({email: user.email});
+
+    expect(result).toEqual({id: user.id, email: user.email, status});
+  });
+
+  test('projects only id, email, and status', async () => {
+    const user = await userFactory.create({emailVerifiedAt: new Date()});
+
+    const result = await findUserByEmail({email: user.email});
+
+    expect(Object.keys(result ?? {}).sort()).toEqual(['email', 'id', 'status']);
+  });
+
+  test('resolves surrounding whitespace and mixed case to the same owner', async () => {
+    const user = await userFactory.create();
+
+    const result = await findUserByEmail({email: `  ${user.email.toUpperCase()}  `});
+
+    expect(result).toEqual({id: user.id, email: user.email, status: 'active'});
+  });
+
+  test('performs no user, refresh-session, or email-verification writes', async () => {
+    const user = await userFactory.create({emailVerifiedAt: new Date()});
+    const rawRefreshToken = generateOpaqueToken('refreshToken');
+    await db()
+      .insert(refreshTokens)
+      .values({
+        userId: user.id,
+        hashedToken: hashOpaqueToken(rawRefreshToken),
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+    const rawVerificationToken = generateOpaqueToken('emailVerification');
+    await db()
+      .insert(emailVerifications)
+      .values({
+        userId: user.id,
+        hashedToken: hashOpaqueToken(rawVerificationToken),
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+
+    const beforeUser = await db().select().from(users).where(eq(users.id, user.id));
+    const beforeRefreshTokens = await db()
+      .select()
+      .from(refreshTokens)
+      .where(eq(refreshTokens.userId, user.id));
+    const beforeEmailVerifications = await db()
+      .select()
+      .from(emailVerifications)
+      .where(eq(emailVerifications.userId, user.id));
+
+    await findUserByEmail({email: user.email});
+
+    const afterUser = await db().select().from(users).where(eq(users.id, user.id));
+    const afterRefreshTokens = await db()
+      .select()
+      .from(refreshTokens)
+      .where(eq(refreshTokens.userId, user.id));
+    const afterEmailVerifications = await db()
+      .select()
+      .from(emailVerifications)
+      .where(eq(emailVerifications.userId, user.id));
+
+    expect(afterUser).toEqual(beforeUser);
+    expect(afterRefreshTokens).toEqual(beforeRefreshTokens);
+    expect(afterEmailVerifications).toEqual(beforeEmailVerifications);
+  });
+
+  test('rejects invalid email syntax without querying the database', async () => {
+    const findUserByEmailInDbSpy = vi.spyOn(usersDb, 'findUserByEmail');
+
+    const promise = findUserByEmail({email: 'not-an-email'});
+
+    await expect(promise).rejects.toBeInstanceOf(ZodError);
+    expect(findUserByEmailInDbSpy).not.toHaveBeenCalled();
+  });
+});

--- a/libs/api/auth/src/core/email-owner.ts
+++ b/libs/api/auth/src/core/email-owner.ts
@@ -1,0 +1,23 @@
+import {emailSchema} from '@shipfox/api-auth-dto';
+import {findUserByEmail as findUserByEmailInDb} from '#db/users.js';
+import type {User} from './entities/user.js';
+
+export type EmailOwner = Pick<User, 'id' | 'email' | 'status'>;
+
+export interface FindUserByEmailParams {
+  email: string;
+}
+
+/**
+ * Read-only lookup of the current owner of a normalized email. Performs no
+ * user, session, or verification writes; returns undefined when no user owns
+ * the address.
+ */
+export async function findUserByEmail(
+  params: FindUserByEmailParams,
+): Promise<EmailOwner | undefined> {
+  const email = emailSchema.parse(params.email);
+  const user = await findUserByEmailInDb({email});
+  if (!user) return undefined;
+  return {id: user.id, email: user.email, status: user.status};
+}

--- a/libs/api/auth/src/index.ts
+++ b/libs/api/auth/src/index.ts
@@ -29,6 +29,8 @@ export type {
   ProvisionUserParams,
 } from '#core/auth.js';
 export {createSessionForUser, provisionUser} from '#core/auth.js';
+export type {EmailOwner, FindUserByEmailParams} from '#core/email-owner.js';
+export {findUserByEmail} from '#core/email-owner.js';
 export type {User, UserStatus} from '#core/entities/user.js';
 export {
   AuthDependencyUnavailableError,

--- a/libs/api/auth/src/presentation/routes/registration/signup.test.ts
+++ b/libs/api/auth/src/presentation/routes/registration/signup.test.ts
@@ -36,7 +36,7 @@ describe('POST /auth/signup', () => {
     const email = uniqueEmail('signup');
 
     const res = await signup(app, {
-      email: email.toUpperCase(),
+      email: `  ${email.toUpperCase()}  `,
       password,
       name: '  New User  ',
     });
@@ -77,6 +77,16 @@ describe('POST /auth/signup', () => {
     await signup(app, {email, password});
 
     const res = await signup(app, {email, password});
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('email-taken');
+  });
+
+  test('transforms a whitespace/case-equivalent duplicate email into 409', async () => {
+    const email = uniqueEmail('duplicate-equivalent');
+    await signup(app, {email, password});
+
+    const res = await signup(app, {email: `  ${email.toUpperCase()}  `, password});
 
     expect(res.statusCode).toBe(409);
     expect(res.json().code).toBe('email-taken');

--- a/libs/api/common-dto/src/index.ts
+++ b/libs/api/common-dto/src/index.ts
@@ -1,1 +1,2 @@
 export {displayNameSchema} from './schemas/display-name.js';
+export {emailSchema} from './schemas/email.js';

--- a/libs/api/common-dto/src/schemas/email.test.ts
+++ b/libs/api/common-dto/src/schemas/email.test.ts
@@ -1,0 +1,63 @@
+import {emailSchema} from './email.js';
+
+describe('emailSchema', () => {
+  it('trims surrounding whitespace', () => {
+    const result = emailSchema.parse('  user@example.com  ');
+
+    expect(result).toBe('user@example.com');
+  });
+
+  it('lowercases the address', () => {
+    const result = emailSchema.parse('User@Example.COM');
+
+    expect(result).toBe('user@example.com');
+  });
+
+  it('preserves dots in the local part', () => {
+    const result = emailSchema.parse('First.Last@example.com');
+
+    expect(result).toBe('first.last@example.com');
+  });
+
+  it('preserves plus-addressing', () => {
+    const result = emailSchema.parse('user+tag@example.com');
+
+    expect(result).toBe('user+tag@example.com');
+  });
+
+  it('preserves provider-specific aliases unchanged', () => {
+    const result = emailSchema.parse('u.s.e.r+alias@googlemail.com');
+
+    expect(result).toBe('u.s.e.r+alias@googlemail.com');
+  });
+
+  it('rejects a blank value', () => {
+    const parse = () => emailSchema.parse('   ');
+
+    expect(parse).toThrow();
+  });
+
+  it('rejects invalid email syntax', () => {
+    const parse = () => emailSchema.parse('not-an-email');
+
+    expect(parse).toThrow();
+  });
+
+  it('accepts a 254-character address after normalization', () => {
+    const email = `${'a'.repeat(64)}@${'b'.repeat(185)}.com`;
+
+    const result = emailSchema.parse(email);
+
+    expect(email).toHaveLength(254);
+    expect(result).toBe(email);
+  });
+
+  it('rejects a 255-character address after normalization', () => {
+    const email = `${'a'.repeat(64)}@${'b'.repeat(186)}.com`;
+
+    const parse = () => emailSchema.parse(email);
+
+    expect(email).toHaveLength(255);
+    expect(parse).toThrow();
+  });
+});

--- a/libs/api/common-dto/src/schemas/email.ts
+++ b/libs/api/common-dto/src/schemas/email.ts
@@ -1,0 +1,6 @@
+import {z} from 'zod';
+
+export const emailSchema = z
+  .string()
+  .transform((value) => value.trim().toLowerCase())
+  .pipe(z.string().email().max(254));

--- a/libs/api/workspaces-dto/src/schemas/invitation.ts
+++ b/libs/api/workspaces-dto/src/schemas/invitation.ts
@@ -1,6 +1,5 @@
+import {emailSchema} from '@shipfox/api-common-dto';
 import {z} from 'zod';
-
-const invitationEmailSchema = z.string().trim().toLowerCase().email().max(254);
 
 export const invitationDtoSchema = z.object({
   id: z.string().uuid(),
@@ -17,7 +16,7 @@ export const invitationDtoSchema = z.object({
 export type InvitationDto = z.infer<typeof invitationDtoSchema>;
 
 export const createInvitationBodySchema = z.object({
-  email: invitationEmailSchema,
+  email: emailSchema,
 });
 
 export type CreateInvitationBodyDto = z.infer<typeof createInvitationBodySchema>;

--- a/libs/api/workspaces/src/presentation/routes/invitations/create.test.ts
+++ b/libs/api/workspaces/src/presentation/routes/invitations/create.test.ts
@@ -34,7 +34,7 @@ describe('POST /workspaces/:workspaceId/invitations', () => {
       method: 'POST',
       url: `/workspaces/${workspaceId}/invitations`,
       headers: {authorization: `Bearer ${owner.token}`},
-      payload: {email: inviteeEmail.toUpperCase()},
+      payload: {email: `  ${inviteeEmail.toUpperCase()}  `},
     });
 
     expect(res.statusCode).toBe(201);
@@ -59,6 +59,24 @@ describe('POST /workspaces/:workspaceId/invitations', () => {
       url: `/workspaces/${workspaceId}/invitations`,
       headers: {authorization: `Bearer ${owner.token}`},
       payload: {email: inviteeEmail},
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('open-invitation-exists');
+    expect(await invitationOutboxEventsTo(inviteeEmail)).toHaveLength(1);
+  });
+
+  test('transforms a whitespace/case-equivalent duplicate open invitation into 409', async () => {
+    const owner = await signupVerifyLogin(app, 'invite-create-duplicate-equivalent');
+    const workspaceId = await createWorkspace(app, owner.token);
+    const inviteeEmail = uniqueEmail('duplicate-invite-equivalent');
+    await createInvite(app, {token: owner.token, workspaceId, email: inviteeEmail});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/workspaces/${workspaceId}/invitations`,
+      headers: {authorization: `Bearer ${owner.token}`},
+      payload: {email: `  ${inviteeEmail.toUpperCase()}  `},
     });
 
     expect(res.statusCode).toBe(409);

--- a/tools/application-release/test/external/verify.mjs
+++ b/tools/application-release/test/external/verify.mjs
@@ -68,6 +68,7 @@ try {
   const tsc = resolve(repositoryRoot, 'tools/typescript/node_modules/typescript/bin/tsc');
   await run(process.execPath, [tsc, '--project', 'tsconfig.json'], fixtureRoot);
   await run(process.execPath, ['runtime-imports.mjs'], fixtureRoot);
+  await run(process.execPath, ['auth-email-seams.mjs'], fixtureRoot);
   await run(process.execPath, ['workflow-source-bundle.mjs'], fixtureRoot);
   await run(
     resolve(repositoryRoot, 'tools/application-release/node_modules/.bin/tsx'),
@@ -148,6 +149,10 @@ void createServer({
       `Object.assign(process.env, {...${JSON.stringify(runtimeEnvironment(), null, 2)}, INTEGRATIONS_ENABLE_SENTRY_PROVIDER: 'true', NODE_ENV: 'production'});\n\nconst {readdir, readFile} = await import('node:fs/promises');\nconst {dirname, join} = await import('node:path');\nconst {defaultModules} = await import('@shipfox/api-server');\nconst {loadProductionWorkflowBundle} = await import('@shipfox/node-temporal');\nconst modules = await defaultModules();\nconst workflowPaths = new Set(\n  modules.flatMap((module) => module.workers ?? []).map((worker) => worker.workflowsPath),\n);\n\nif (!workflowPaths.size) throw new Error('Packed API server declares no workflow entrypoints.');\n\nconst bundles = new Map();\nfor (const workflowsPath of workflowPaths) {\n  const workflowBundle = loadProductionWorkflowBundle(workflowsPath);\n  bundles.set(workflowsPath, workflowBundle);\n\n  const code = await readFile(workflowBundle.codePath, 'utf8');\n  if (/@shipfox[/\\\\][^/\\\\]+[/\\\\]src[/\\\\]/u.test(code)) {\n    throw new Error(\n      \`Workflow bundle for \${workflowsPath} resolved a first-party source path.\`,\n    );\n  }\n}\n\nconst declaredCodePaths = new Set([...bundles.values()].map(({codePath}) => codePath));\nif (declaredCodePaths.size !== workflowPaths.size) {\n  throw new Error('Packed API workflow entrypoints do not map one-to-one to prebuilt bundles.');\n}\n\nconst workflowDirectories = new Set([...workflowPaths].map((workflowsPath) => dirname(workflowsPath)));\nconst emittedBundles = (\n  await Promise.all(\n    [...workflowDirectories].map(async (directory) =>\n      (await readdir(directory))\n        .filter((entry) => entry.endsWith('.bundle.js'))\n        .map((entry) => join(directory, entry)),\n    ),\n  )\n).flat();\nconst unreferencedBundles = emittedBundles.filter((codePath) => !declaredCodePaths.has(codePath));\nif (unreferencedBundles.length) {\n  throw new Error(\n    \`Packed API contains unreferenced workflow bundles: \${unreferencedBundles.join(', ')}\`,\n  );\n}\n\nconsole.log(\`Validated \${workflowPaths.size} packed API workflow bundles.\`);\n`,
     ),
     writeFile(
+      join(root, 'auth-email-seams.mjs'),
+      `Object.assign(process.env, ${JSON.stringify(runtimeEnvironment(), null, 2)});\n\nconst {createPostgresClient, pgClient, closePostgresClient} = await import('@shipfox/node-postgres');\nconst {initializeModules} = await import('@shipfox/node-module');\nconst {authModule, provisionUser, findUserByEmail} = await import('@shipfox/api-auth');\nconst {emailSchema} = await import('@shipfox/api-common-dto');\n\ncreatePostgresClient();\ntry {\n  await initializeModules({modules: [authModule]});\n\n  const email = \`packed-consumer-\${crypto.randomUUID()}@example.com\`;\n  const equivalentInput = \`  \${email.toUpperCase()}  \`;\n  if (emailSchema.parse(equivalentInput) !== email) {\n    throw new Error('Packed emailSchema did not normalize the equivalent raw input.');\n  }\n\n  const user = await provisionUser({email});\n  try {\n    const owner = await findUserByEmail({email: equivalentInput});\n    if (!owner) throw new Error('Packed findUserByEmail did not resolve the provisioned owner.');\n    if (owner.id !== user.id || owner.email !== email || owner.status !== 'active') {\n      throw new Error('Packed findUserByEmail returned an unexpected owner.');\n    }\n    const keys = Object.keys(owner).sort();\n    if (keys.join(',') !== 'email,id,status') {\n      throw new Error(\`Packed EmailOwner projection leaked extra fields: \${keys.join(',')}\`);\n    }\n    console.log('Packed auth-email seams provisioned and looked up one owner via installed tarballs.');\n  } finally {\n    try {\n      await pgClient().query('DELETE FROM auth_users WHERE id = $1', [user.id]);\n    } catch (cleanupError) {\n      console.error('Packed auth-email seams cleanup failed:', cleanupError);\n    }\n  }\n} finally {\n  await closePostgresClient();\n}\n`,
+    ),
+    writeFile(
       join(root, 'development-conditions.mjs'),
       `Object.assign(process.env, ${JSON.stringify(runtimeEnvironment(), null, 2)});\n\nawait import('@shipfox/api-server/instrumentation');\nprocess.exit(0);\n`,
     ),
@@ -206,11 +211,21 @@ function findWorkspaceRange(value, path = 'package.json') {
 }
 
 function runtimeEnvironment() {
+  // Prefer the active workspace's own Postgres connection (e.g. a Conductor
+  // worktree's isolated instance) over the fixed port CI's dedicated service
+  // listens on, so this fixture never migrates or mutates an unrelated
+  // Postgres instance that happens to also be reachable on the CI default.
+  const postgresHost = process.env.POSTGRES_HOST ?? '127.0.0.1';
+  const postgresPort = process.env.POSTGRES_PORT ?? '5432';
+  const postgresUsername = process.env.POSTGRES_USERNAME ?? 'shipfox';
+  const postgresPassword = process.env.POSTGRES_PASSWORD ?? 'password';
+  const postgresDatabase = 'api_test';
+
   return {
     AUTH_JOB_LEASE_TOKEN_SECRET: 'external-consumer-lease-secret',
     AUTH_JWT_SECRET: 'external-consumer-jwt-secret',
     AUTH_RUNNER_SESSION_TOKEN_SECRET: 'external-consumer-runner-secret',
-    DATABASE_URL: 'postgres://shipfox:password@127.0.0.1:5432/api_test',
+    DATABASE_URL: `postgres://${postgresUsername}:${postgresPassword}@${postgresHost}:${postgresPort}/${postgresDatabase}`,
     GITEA_BASE_URL: 'https://gitea.example.com',
     GITEA_SERVICE_TOKEN: 'external-consumer-token',
     GITEA_SERVICE_USERNAME: 'shipfox-bot',
@@ -245,12 +260,12 @@ function runtimeEnvironment() {
     LOG_STORAGE_S3_FORCE_PATH_STYLE: 'true',
     LOG_STORAGE_S3_REGION: 'garage',
     LOG_STORAGE_S3_SECRET_ACCESS_KEY: 'external-consumer-secret-key',
-    POSTGRES_DATABASE: 'api_test',
-    POSTGRES_HOST: '127.0.0.1',
+    POSTGRES_DATABASE: postgresDatabase,
+    POSTGRES_HOST: postgresHost,
     POSTGRES_MAX_CONNECTIONS: '5',
-    POSTGRES_PASSWORD: 'password',
-    POSTGRES_PORT: '5432',
-    POSTGRES_USERNAME: 'shipfox',
+    POSTGRES_PASSWORD: postgresPassword,
+    POSTGRES_PORT: postgresPort,
+    POSTGRES_USERNAME: postgresUsername,
     SECRETS_ENCRYPTION_KEK: 'ZmVkY2JhOTg3NjU0MzIxMGZlZGNiYTk4NzY1NDMyMTA=',
     SENTRY_APP_CLIENT_ID: 'external-consumer-client-id',
     SENTRY_APP_CLIENT_SECRET: 'external-consumer-client-secret',


### PR DESCRIPTION
Publishes one provider-neutral `emailSchema` in `@shipfox/api-common-dto` and adopts it across auth and workspace invitation inputs, replacing two slightly divergent local definitions (one didn't trim before validating, the other trimmed in a different order). Exports a read-only `findUserByEmail`/`EmailOwner` seam from `@shipfox/api-auth` that normalizes input, reuses the existing indexed lookup, and projects only `id`/`email`/`status` — no user, session, or verification writes.

This is the first of the platform prerequisites for the Social Login project: Cloud will use this seam to detect whether an invitation email and a resolved provider identity belong to the same user, without a new HTTP route or provider-specific DTO.

Also:
- Normalizes `createSessionForUser`'s email lookup path through the same shared schema.
- Extends the packed external-consumer gate (`@shipfox/application-release test:external`) with a probe that boots the auth module, provisions a user, and looks it up with equivalent whitespace/case input against real PostgreSQL through installed tarballs — proving the published seams work outside the workspace.
- Adds Postgres startup to the `static-verification` CI job so that probe can run. The fixture prefers the active workspace's own Postgres connection settings over CI's fixed port/credentials, so it never migrates or mutates an unrelated Postgres instance running on the same conventional port.

Refs ENG-1046

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes a shared, provider-neutral `emailSchema` and a read-only `findUserByEmail`/`EmailOwner` seam to standardize email handling and let Cloud check the current owner without side effects. Unifies auth and invitations on the shared schema and adds an external-consumer probe with Postgres in CI to support Social Login (ENG-1046).

- New Features
  - `@shipfox/api-common-dto`: new `emailSchema` (trim, lowercase, validate syntax, max 254; no provider-specific canonicalization).
  - `@shipfox/api-auth`: export `findUserByEmail({email})` returning `EmailOwner` (`id`, `email`, `status`), normalized input, no writes.
  - `createSessionForUser({email})` now normalizes via the shared schema.
  - Adopt `emailSchema` in `@shipfox/api-auth-dto` and `@shipfox/api-workspaces-dto` invitation inputs; whitespace/case-equivalent duplicates now collide as expected.
  - `@shipfox/application-release`: add external consumer probe that provisions a user and resolves ownership via installed tarballs; CI starts Postgres for this check.

- Migration
  - Use `emailSchema` for auth and invitation email inputs.
  - Use `findUserByEmail` to check ownership before provisioning/linking in Cloud.
  - No DB changes; existing users and invitations remain compatible.

<sup>Written for commit 66864f34e0e20b8b8619d1031f5fc7b94cdd7571. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

