### PR TITLE
Add scoped provisioner identity contracts

### DIFF
--- a/.changeset/scoped-provisioners-arrive.md
+++ b/.changeset/scoped-provisioners-arrive.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/api-auth-context": major
+"@shipfox/api-runners": major
+"@shipfox/api-runners-dto": major
+---
+
+Adds scoped workspace and installation provisioner identities with explicit authorization boundaries.

--- a/libs/api/auth-context/src/index.ts
+++ b/libs/api/auth-context/src/index.ts
@@ -44,10 +44,9 @@ export function buildUserContext(params: BuildUserContextParams): UserContext {
   };
 }
 
-export interface ProvisionerContext {
-  provisionerTokenId: string;
-  workspaceId: string;
-}
+export type ProvisionerContext =
+  | {provisionerTokenId: string; scope: 'installation'}
+  | {provisionerTokenId: string; scope: 'workspace'; workspaceId: string};
 
 export type LeasedJobContext = JobLeaseTokenClaims;
 export type RunnerSessionContext = RunnerSessionTokenClaims;
@@ -128,6 +127,28 @@ export function requireProvisionerContext(request: RequestWithContext): Provisio
   const context = getProvisionerContext(request);
   if (!context) {
     throw new Error('Provisioner context is not available on this request');
+  }
+  return context;
+}
+
+export function requireWorkspaceProvisionerContext(
+  request: RequestWithContext,
+): Extract<ProvisionerContext, {scope: 'workspace'}> {
+  const context = requireProvisionerContext(request);
+  if (context.scope !== 'workspace') {
+    throw new ClientError('Workspace provisioner credential required', 'forbidden', {status: 403});
+  }
+  return context;
+}
+
+export function requireInstallationProvisionerContext(
+  request: RequestWithContext,
+): Extract<ProvisionerContext, {scope: 'installation'}> {
+  const context = requireProvisionerContext(request);
+  if (context.scope !== 'installation') {
+    throw new ClientError('Installation provisioner credential required', 'forbidden', {
+      status: 403,
+    });
   }
   return context;
 }

--- a/libs/api/auth-context/src/provisioner-context.test.ts
+++ b/libs/api/auth-context/src/provisioner-context.test.ts
@@ -1,0 +1,44 @@
+import {ClientError} from '@shipfox/node-fastify';
+import {
+  requireInstallationProvisionerContext,
+  requireWorkspaceProvisionerContext,
+  setProvisionerContext,
+} from './index.js';
+
+describe('provisioner context', () => {
+  it('returns only a workspace context from the workspace guard', () => {
+    const request = {};
+    const context = {
+      provisionerTokenId: crypto.randomUUID(),
+      scope: 'workspace' as const,
+      workspaceId: crypto.randomUUID(),
+    };
+    setProvisionerContext(request, context);
+
+    const result = requireWorkspaceProvisionerContext(request);
+
+    expect(result).toEqual(context);
+  });
+
+  it('returns only an installation context from the installation guard', () => {
+    const request = {};
+    const context = {provisionerTokenId: crypto.randomUUID(), scope: 'installation' as const};
+    setProvisionerContext(request, context);
+
+    const result = requireInstallationProvisionerContext(request);
+
+    expect(result).toEqual(context);
+  });
+
+  it('rejects a credential with the wrong scope', () => {
+    const request = {};
+    setProvisionerContext(request, {
+      provisionerTokenId: crypto.randomUUID(),
+      scope: 'installation',
+    });
+
+    expect(() => requireWorkspaceProvisionerContext(request)).toThrow(
+      new ClientError('Workspace provisioner credential required', 'forbidden', {status: 403}),
+    );
+  });
+});

--- a/libs/api/runners-dto/src/schemas/provisioner-token.test.ts
+++ b/libs/api/runners-dto/src/schemas/provisioner-token.test.ts
@@ -28,8 +28,17 @@ describe('provisioner token schemas', () => {
   it('parses provisioner identity responses', () => {
     const identity = {
       id: crypto.randomUUID(),
+      scope: 'workspace',
       workspace_id: crypto.randomUUID(),
     };
+
+    const result = provisionerIdentityResponseSchema.parse(identity);
+
+    expect(result).toEqual(identity);
+  });
+
+  it('parses installation provisioner identities without a workspace', () => {
+    const identity = {id: crypto.randomUUID(), scope: 'installation'};
 
     const result = provisionerIdentityResponseSchema.parse(identity);
 

--- a/libs/api/runners-dto/src/schemas/provisioner-token.ts
+++ b/libs/api/runners-dto/src/schemas/provisioner-token.ts
@@ -22,6 +22,7 @@ export const createProvisionerTokenResponseSchema = z.object({
   last_seen_at: z.string().nullable(),
   created_at: z.string(),
   updated_at: z.string(),
+  scope: z.literal('workspace'),
 });
 
 export type CreateProvisionerTokenResponseDto = z.infer<
@@ -40,6 +41,7 @@ export const provisionerTokenDtoSchema = z.object({
   last_seen_at: z.string().nullable(),
   created_at: z.string(),
   updated_at: z.string(),
+  scope: z.literal('workspace'),
 });
 
 export type ProvisionerTokenDto = z.infer<typeof provisionerTokenDtoSchema>;
@@ -56,9 +58,9 @@ export type RevokeProvisionerTokenResponseDto = z.infer<
   typeof revokeProvisionerTokenResponseSchema
 >;
 
-export const provisionerIdentityResponseSchema = z.object({
-  id: z.string().uuid(),
-  workspace_id: z.string().uuid(),
-});
+export const provisionerIdentityResponseSchema = z.discriminatedUnion('scope', [
+  z.object({id: z.string().uuid(), scope: z.literal('workspace'), workspace_id: z.string().uuid()}),
+  z.object({id: z.string().uuid(), scope: z.literal('installation')}),
+]);
 
 export type ProvisionerIdentityResponseDto = z.infer<typeof provisionerIdentityResponseSchema>;

--- a/libs/api/runners/drizzle/0000_initial.sql
+++ b/libs/api/runners/drizzle/0000_initial.sql
@@ -1,4 +1,5 @@
 CREATE TYPE "public"."runners_provisioned_runner_state" AS ENUM('starting', 'running', 'stopping', 'stopped', 'failed', 'terminated');--> statement-breakpoint
+CREATE TYPE "public"."runners_provisioner_scope" AS ENUM('workspace', 'installation');--> statement-breakpoint
 CREATE TYPE "public"."runners_runner_session_registration_token_kind" AS ENUM('manual', 'ephemeral');--> statement-breakpoint
 CREATE TYPE "public"."runners_runner_session_scope" AS ENUM('workspace');--> statement-breakpoint
 CREATE TABLE "runners_ephemeral_registration_tokens" (
@@ -79,7 +80,8 @@ CREATE TABLE "runners_provisioned_runners" (
 --> statement-breakpoint
 CREATE TABLE "runners_provisioner_tokens" (
 	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
-	"workspace_id" uuid NOT NULL,
+	"scope" "runners_provisioner_scope" NOT NULL,
+	"workspace_id" uuid,
 	"hashed_token" text NOT NULL,
 	"prefix" text NOT NULL,
 	"name" text,
@@ -89,7 +91,8 @@ CREATE TABLE "runners_provisioner_tokens" (
 	"revoked_at" timestamp with time zone,
 	"last_seen_at" timestamp with time zone,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
-	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "runners_provisioner_tokens_scope_workspace_ck" CHECK ((scope = 'workspace' AND workspace_id IS NOT NULL) OR (scope = 'installation' AND workspace_id IS NULL))
 );
 --> statement-breakpoint
 CREATE TABLE "runners_rate_limits" (

--- a/libs/api/runners/drizzle/meta/0000_snapshot.json
+++ b/libs/api/runners/drizzle/meta/0000_snapshot.json
@@ -787,11 +787,18 @@
           "notNull": true,
           "default": "uuidv7()"
         },
+        "scope": {
+          "name": "scope",
+          "type": "runners_provisioner_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
         "workspace_id": {
           "name": "workspace_id",
           "type": "uuid",
           "primaryKey": false,
-          "notNull": true
+          "notNull": false
         },
         "hashed_token": {
           "name": "hashed_token",
@@ -904,7 +911,12 @@
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},
-      "checkConstraints": {},
+      "checkConstraints": {
+        "runners_provisioner_tokens_scope_workspace_ck": {
+          "name": "runners_provisioner_tokens_scope_workspace_ck",
+          "value": "(scope = 'workspace' AND workspace_id IS NOT NULL) OR (scope = 'installation' AND workspace_id IS NULL)"
+        }
+      },
       "isRLSEnabled": false
     },
     "public.runners_rate_limits": {
@@ -1557,6 +1569,11 @@
       "name": "runners_provisioned_runner_state",
       "schema": "public",
       "values": ["starting", "running", "stopping", "stopped", "failed", "terminated"]
+    },
+    "public.runners_provisioner_scope": {
+      "name": "runners_provisioner_scope",
+      "schema": "public",
+      "values": ["workspace", "installation"]
     },
     "public.runners_runner_session_registration_token_kind": {
       "name": "runners_runner_session_registration_token_kind",

--- a/libs/api/runners/src/core/entities/provisioner-token.ts
+++ b/libs/api/runners/src/core/entities/provisioner-token.ts
@@ -1,6 +1,8 @@
-export interface ProvisionerToken {
+export type ProvisionerScope = 'installation' | 'workspace';
+
+export interface ProvisionerTokenBase {
   id: string;
-  workspaceId: string;
+  scope: ProvisionerScope;
   hashedToken: string;
   prefix: string;
   name: string | null;
@@ -12,5 +14,9 @@ export interface ProvisionerToken {
   createdAt: Date;
   updatedAt: Date;
 }
+
+export type ProvisionerToken =
+  | (ProvisionerTokenBase & {scope: 'installation'; workspaceId: null})
+  | (ProvisionerTokenBase & {scope: 'workspace'; workspaceId: string});
 
 export type ActiveProvisionerToken = ProvisionerToken & {lastSeenAt: Date};

--- a/libs/api/runners/src/core/index.ts
+++ b/libs/api/runners/src/core/index.ts
@@ -4,7 +4,11 @@ export type {
   ProvisionedRunner,
   ProvisionedRunnerState,
 } from './entities/provisioned-runner.js';
-export type {ActiveProvisionerToken, ProvisionerToken} from './entities/provisioner-token.js';
+export type {
+  ActiveProvisionerToken,
+  ProvisionerScope,
+  ProvisionerToken,
+} from './entities/provisioner-token.js';
 export type {RunnerSession} from './entities/runner-session.js';
 export {
   type MintEphemeralRegistrationTokenParams,
@@ -40,9 +44,11 @@ export {
   reportProvisionedRunners,
 } from './provisioned-runners.js';
 export {
+  createInstallationProvisionerToken,
   createWorkspaceProvisionerToken,
   listActiveProvisioners,
   listUsableProvisionerTokens,
+  revokeInstallationProvisionerToken,
   revokeWorkspaceProvisionerToken,
 } from './provisioner-tokens.js';
 export {

--- a/libs/api/runners/src/core/provisioner-tokens.test.ts
+++ b/libs/api/runners/src/core/provisioner-tokens.test.ts
@@ -4,8 +4,10 @@ import {db} from '#db/db.js';
 import {provisionerTokens} from '#db/schema/provisioner-tokens.js';
 import {provisionerTokenFactory} from '#test/index.js';
 import {
+  createInstallationProvisionerToken,
   createWorkspaceProvisionerToken,
   listUsableProvisionerTokens,
+  revokeInstallationProvisionerToken,
   revokeWorkspaceProvisionerToken,
 } from './provisioner-tokens.js';
 
@@ -32,6 +34,24 @@ describe('provisioner token core', () => {
       .where(eq(provisionerTokens.id, result.token.id));
     expect(rows[0]?.hashedToken).toBe(hashOpaqueToken(result.rawToken));
     expect(rows[0]?.hashedToken).not.toBe(result.rawToken);
+  });
+
+  it('creates and revokes an installation provisioner token without a workspace', async () => {
+    const createdByUserId = crypto.randomUUID();
+
+    const created = await createInstallationProvisionerToken({createdByUserId, name: 'cloud'});
+
+    expect(created.token).toMatchObject({
+      scope: 'installation',
+      workspaceId: null,
+      createdByUserId,
+    });
+    const revoked = await revokeInstallationProvisionerToken({
+      tokenId: created.token.id,
+      revokedByUserId: crypto.randomUUID(),
+    });
+    expect(revoked).toMatchObject({id: created.token.id, scope: 'installation'});
+    expect(revoked.revokedAt).toBeInstanceOf(Date);
   });
 
   it('lists usable tokens and excludes revoked tokens after revoke', async () => {

--- a/libs/api/runners/src/core/provisioner-tokens.ts
+++ b/libs/api/runners/src/core/provisioner-tokens.ts
@@ -3,6 +3,7 @@ import {
   createProvisionerToken,
   listActiveProvisionerTokens,
   listUsableProvisionerTokensByWorkspaceId,
+  revokeInstallationProvisionerToken as revokeInstallationProvisionerTokenDb,
   revokeProvisionerToken,
 } from '#db/provisioner-tokens.js';
 import {config} from '../config.js';
@@ -28,6 +29,7 @@ export async function createWorkspaceProvisionerToken(
   const expiresAt = params.ttlSeconds ? new Date(Date.now() + params.ttlSeconds * 1000) : undefined;
 
   const token = await createProvisionerToken({
+    scope: 'workspace',
     workspaceId: params.workspaceId,
     hashedToken: hashOpaqueToken(rawToken),
     prefix: extractDisplayPrefix(rawToken),
@@ -36,6 +38,28 @@ export async function createWorkspaceProvisionerToken(
     expiresAt,
   });
 
+  return {token, rawToken};
+}
+
+export interface CreateInstallationProvisionerTokenParams {
+  createdByUserId: string;
+  name?: string | undefined;
+  ttlSeconds?: number | undefined;
+}
+
+export async function createInstallationProvisionerToken(
+  params: CreateInstallationProvisionerTokenParams,
+): Promise<CreateWorkspaceProvisionerTokenResult> {
+  const rawToken = generateOpaqueToken('provisionerToken');
+  const expiresAt = params.ttlSeconds ? new Date(Date.now() + params.ttlSeconds * 1000) : undefined;
+  const token = await createProvisionerToken({
+    scope: 'installation',
+    hashedToken: hashOpaqueToken(rawToken),
+    prefix: extractDisplayPrefix(rawToken),
+    name: params.name,
+    createdByUserId: params.createdByUserId,
+    expiresAt,
+  });
   return {token, rawToken};
 }
 
@@ -56,6 +80,15 @@ export async function revokeWorkspaceProvisionerToken(params: {
   revokedByUserId: string;
 }): Promise<ProvisionerToken> {
   const token = await revokeProvisionerToken(params);
+  if (!token) throw new ProvisionerTokenNotFoundError(params.tokenId);
+  return token;
+}
+
+export async function revokeInstallationProvisionerToken(params: {
+  tokenId: string;
+  revokedByUserId: string;
+}): Promise<ProvisionerToken> {
+  const token = await revokeInstallationProvisionerTokenDb(params);
   if (!token) throw new ProvisionerTokenNotFoundError(params.tokenId);
   return token;
 }

--- a/libs/api/runners/src/db/provisioner-tokens.test.ts
+++ b/libs/api/runners/src/db/provisioner-tokens.test.ts
@@ -9,6 +9,7 @@ import {
   revokeProvisionerToken,
   touchProvisionerLastSeen,
 } from '#db/provisioner-tokens.js';
+import {provisionerTokens} from '#db/schema/provisioner-tokens.js';
 import {provisionerTokenFactory} from '#test/index.js';
 
 describe('provisioner token db', () => {
@@ -17,6 +18,7 @@ describe('provisioner token db', () => {
     const rawToken = 'sf_pt_test-token';
     const createdByUserId = crypto.randomUUID();
     const token = await createProvisionerToken({
+      scope: 'workspace',
       workspaceId,
       hashedToken: hashOpaqueToken(rawToken),
       prefix: rawToken.slice(0, 12),
@@ -35,6 +37,22 @@ describe('provisioner token db', () => {
     const result = await resolveProvisionerTokenByHash(hashOpaqueToken('sf_pt_unknown-token'));
 
     expect(result).toBeUndefined();
+  });
+
+  it('enforces valid scope and workspace combinations in PostgreSQL', async () => {
+    const insert = (scope: 'installation' | 'workspace', workspaceId: string | null) =>
+      db()
+        .insert(provisionerTokens)
+        .values({
+          scope,
+          workspaceId,
+          hashedToken: hashOpaqueToken(`${scope}-${workspaceId}`),
+          prefix: 'sf_pt_invalid',
+          createdByUserId: crypto.randomUUID(),
+        });
+
+    await expect(insert('installation', crypto.randomUUID())).rejects.toThrow();
+    await expect(insert('workspace', null)).rejects.toThrow();
   });
 
   it('lists usable tokens for a workspace', async () => {

--- a/libs/api/runners/src/db/provisioner-tokens.test.ts
+++ b/libs/api/runners/src/db/provisioner-tokens.test.ts
@@ -39,6 +39,12 @@ describe('provisioner token db', () => {
     expect(result).toBeUndefined();
   });
 
+  it('creates installation factory tokens without a workspace', async () => {
+    const token = await provisionerTokenFactory.create({scope: 'installation'});
+
+    expect(token).toMatchObject({scope: 'installation', workspaceId: null});
+  });
+
   it('enforces valid scope and workspace combinations in PostgreSQL', async () => {
     const insert = (scope: 'installation' | 'workspace', workspaceId: string | null) =>
       db()

--- a/libs/api/runners/src/db/provisioner-tokens.ts
+++ b/libs/api/runners/src/db/provisioner-tokens.ts
@@ -1,10 +1,15 @@
 import {and, desc, eq, gt, isNull, or, sql} from 'drizzle-orm';
-import type {ActiveProvisionerToken, ProvisionerToken} from '#core/entities/provisioner-token.js';
+import type {
+  ActiveProvisionerToken,
+  ProvisionerScope,
+  ProvisionerToken,
+} from '#core/entities/provisioner-token.js';
 import {db} from './db.js';
 import {provisionerTokens, toProvisionerToken} from './schema/provisioner-tokens.js';
 
 export interface CreateProvisionerTokenParams {
-  workspaceId: string;
+  scope: ProvisionerScope;
+  workspaceId?: string | undefined;
   hashedToken: string;
   prefix: string;
   createdByUserId: string;
@@ -18,7 +23,8 @@ export async function createProvisionerToken(
   const rows = await db()
     .insert(provisionerTokens)
     .values({
-      workspaceId: params.workspaceId,
+      scope: params.scope,
+      workspaceId: params.workspaceId ?? null,
       hashedToken: params.hashedToken,
       prefix: params.prefix,
       createdByUserId: params.createdByUserId,
@@ -32,6 +38,36 @@ export async function createProvisionerToken(
   return toProvisionerToken(row);
 }
 
+export async function revokeInstallationProvisionerToken(params: {
+  tokenId: string;
+  revokedByUserId: string;
+}): Promise<ProvisionerToken | undefined> {
+  const rows = await db()
+    .update(provisionerTokens)
+    .set({revokedAt: new Date(), revokedByUserId: params.revokedByUserId, updatedAt: new Date()})
+    .where(
+      and(
+        eq(provisionerTokens.id, params.tokenId),
+        eq(provisionerTokens.scope, 'installation'),
+        isNull(provisionerTokens.revokedAt),
+      ),
+    )
+    .returning();
+
+  const row = rows[0];
+  if (row) return toProvisionerToken(row);
+
+  const existingRows = await db()
+    .select()
+    .from(provisionerTokens)
+    .where(
+      and(eq(provisionerTokens.id, params.tokenId), eq(provisionerTokens.scope, 'installation')),
+    )
+    .limit(1);
+  const existingRow = existingRows[0];
+  return existingRow ? toProvisionerToken(existingRow) : undefined;
+}
+
 export async function listUsableProvisionerTokensByWorkspaceId(
   workspaceId: string,
 ): Promise<ProvisionerToken[]> {
@@ -42,6 +78,7 @@ export async function listUsableProvisionerTokensByWorkspaceId(
     .where(
       and(
         eq(provisionerTokens.workspaceId, workspaceId),
+        eq(provisionerTokens.scope, 'workspace'),
         isNull(provisionerTokens.revokedAt),
         or(isNull(provisionerTokens.expiresAt), gt(provisionerTokens.expiresAt, now)),
       ),
@@ -77,6 +114,7 @@ export async function revokeProvisionerToken(params: {
       and(
         eq(provisionerTokens.id, params.tokenId),
         eq(provisionerTokens.workspaceId, params.workspaceId),
+        eq(provisionerTokens.scope, 'workspace'),
         isNull(provisionerTokens.revokedAt),
       ),
     )
@@ -92,6 +130,7 @@ export async function revokeProvisionerToken(params: {
       and(
         eq(provisionerTokens.id, params.tokenId),
         eq(provisionerTokens.workspaceId, params.workspaceId),
+        eq(provisionerTokens.scope, 'workspace'),
       ),
     )
     .limit(1);
@@ -129,6 +168,7 @@ export async function listActiveProvisionerTokens(params: {
     .where(
       and(
         eq(provisionerTokens.workspaceId, params.workspaceId),
+        eq(provisionerTokens.scope, 'workspace'),
         isNull(provisionerTokens.revokedAt),
         or(isNull(provisionerTokens.expiresAt), gt(provisionerTokens.expiresAt, sql`now()`)),
         sql`${provisionerTokens.lastSeenAt} > now() - (${params.windowSeconds} || ' seconds')::interval`,

--- a/libs/api/runners/src/db/schema/provisioner-tokens.ts
+++ b/libs/api/runners/src/db/schema/provisioner-tokens.ts
@@ -1,13 +1,20 @@
 import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
-import {index, text, timestamp, uniqueIndex, uuid} from 'drizzle-orm/pg-core';
+import {sql} from 'drizzle-orm';
+import {check, index, pgEnum, text, timestamp, uniqueIndex, uuid} from 'drizzle-orm/pg-core';
 import type {ProvisionerToken} from '#core/entities/provisioner-token.js';
 import {pgTable} from './common.js';
+
+export const provisionerScopeEnum = pgEnum('runners_provisioner_scope', [
+  'workspace',
+  'installation',
+]);
 
 export const provisionerTokens = pgTable(
   'provisioner_tokens',
   {
     id: uuidv7PrimaryKey(),
-    workspaceId: uuid('workspace_id').notNull(),
+    scope: provisionerScopeEnum('scope').notNull(),
+    workspaceId: uuid('workspace_id'),
     hashedToken: text('hashed_token').notNull(),
     prefix: text('prefix').notNull(),
     name: text('name'),
@@ -26,6 +33,10 @@ export const provisionerTokens = pgTable(
       table.lastSeenAt.desc(),
       table.id.desc(),
     ),
+    check(
+      'runners_provisioner_tokens_scope_workspace_ck',
+      sql`(scope = 'workspace' AND workspace_id IS NOT NULL) OR (scope = 'installation' AND workspace_id IS NULL)`,
+    ),
   ],
 );
 
@@ -33,8 +44,28 @@ export type ProvisionerTokenDb = typeof provisionerTokens.$inferSelect;
 export type ProvisionerTokenInsertDb = typeof provisionerTokens.$inferInsert;
 
 export function toProvisionerToken(row: ProvisionerTokenDb): ProvisionerToken {
+  if (row.scope === 'installation') {
+    return {
+      id: row.id,
+      scope: 'installation',
+      workspaceId: null,
+      hashedToken: row.hashedToken,
+      prefix: row.prefix,
+      name: row.name,
+      createdByUserId: row.createdByUserId,
+      revokedByUserId: row.revokedByUserId,
+      expiresAt: row.expiresAt,
+      revokedAt: row.revokedAt,
+      lastSeenAt: row.lastSeenAt,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    };
+  }
+
+  if (!row.workspaceId) throw new Error('Workspace provisioner token has no workspace');
   return {
     id: row.id,
+    scope: 'workspace',
     workspaceId: row.workspaceId,
     hashedToken: row.hashedToken,
     prefix: row.prefix,

--- a/libs/api/runners/src/presentation/auth/provisioner-token-auth.ts
+++ b/libs/api/runners/src/presentation/auth/provisioner-token-auth.ts
@@ -48,10 +48,14 @@ export function createProvisionerTokenAuthMethod(): AuthMethod {
         });
       }
 
-      const context: ProvisionerContext = {
-        provisionerTokenId: provisionerToken.id,
-        workspaceId: provisionerToken.workspaceId,
-      };
+      const context: ProvisionerContext =
+        provisionerToken.scope === 'installation'
+          ? {provisionerTokenId: provisionerToken.id, scope: 'installation'}
+          : {
+              provisionerTokenId: provisionerToken.id,
+              scope: 'workspace',
+              workspaceId: provisionerToken.workspaceId,
+            };
 
       await touchProvisionerLastSeen({
         tokenId: provisionerToken.id,

--- a/libs/api/runners/src/presentation/dto/provisioner-token.ts
+++ b/libs/api/runners/src/presentation/dto/provisioner-token.ts
@@ -3,6 +3,7 @@ import type {ProvisionerToken} from '#core/entities/provisioner-token.js';
 export function toProvisionerTokenDto(token: ProvisionerToken): {
   id: string;
   workspace_id: string;
+  scope: 'workspace';
   prefix: string;
   name: string | null;
   created_by_user_id: string;
@@ -13,6 +14,9 @@ export function toProvisionerTokenDto(token: ProvisionerToken): {
   created_at: string;
   updated_at: string;
 } {
+  if (token.scope !== 'workspace') {
+    throw new Error('Installation provisioner tokens cannot be returned from workspace routes');
+  }
   return {
     id: token.id,
     workspace_id: token.workspaceId,
@@ -25,5 +29,6 @@ export function toProvisionerTokenDto(token: ProvisionerToken): {
     last_seen_at: token.lastSeenAt?.toISOString() ?? null,
     created_at: token.createdAt.toISOString(),
     updated_at: token.updatedAt.toISOString(),
+    scope: 'workspace',
   };
 }

--- a/libs/api/runners/src/presentation/routes/get-provisioner-me.ts
+++ b/libs/api/runners/src/presentation/routes/get-provisioner-me.ts
@@ -14,9 +14,8 @@ export const getProvisionerMeRoute = defineRoute({
   handler: (request) => {
     const context = requireProvisionerContext(request);
 
-    return {
-      id: context.provisionerTokenId,
-      workspace_id: context.workspaceId,
-    };
+    return context.scope === 'workspace'
+      ? {id: context.provisionerTokenId, scope: 'workspace', workspace_id: context.workspaceId}
+      : {id: context.provisionerTokenId, scope: 'installation'};
   },
 });

--- a/libs/api/runners/src/presentation/routes/mint-registration-tokens.test.ts
+++ b/libs/api/runners/src/presentation/routes/mint-registration-tokens.test.ts
@@ -51,7 +51,7 @@ describe('POST /provisioners/runner-registration-tokens/batch', () => {
       if (rawToken !== VALID_PROVISIONER_TOKEN) {
         throw new ClientError('Invalid provisioner token', 'unauthorized', {status: 401});
       }
-      setProvisionerContext(request, {workspaceId, provisionerTokenId});
+      setProvisionerContext(request, {scope: 'workspace', workspaceId, provisionerTokenId});
       return Promise.resolve();
     },
   };

--- a/libs/api/runners/src/presentation/routes/mint-registration-tokens.ts
+++ b/libs/api/runners/src/presentation/routes/mint-registration-tokens.ts
@@ -1,4 +1,4 @@
-import {requireProvisionerContext} from '@shipfox/api-auth-context';
+import {requireWorkspaceProvisionerContext} from '@shipfox/api-auth-context';
 import {
   mintRegistrationTokensBatchBodySchema,
   mintRegistrationTokensBatchResponseSchema,
@@ -65,7 +65,7 @@ export const mintRegistrationTokensRoute = defineRoute({
     throw error;
   },
   handler: async (request) => {
-    const {provisionerTokenId, workspaceId} = requireProvisionerContext(request);
+    const {provisionerTokenId, workspaceId} = requireWorkspaceProvisionerContext(request);
     const result = await mintEphemeralRegistrationTokensBatch({
       workspaceId,
       provisionerId: provisionerTokenId,

--- a/libs/api/runners/src/presentation/routes/poll-demand-release.test.ts
+++ b/libs/api/runners/src/presentation/routes/poll-demand-release.test.ts
@@ -28,7 +28,7 @@ describe('POST /provisioners/demand/poll reservation cleanup', () => {
         if (extractBearerToken(request.headers.authorization) !== VALID_PROVISIONER_TOKEN) {
           throw new Error('unauthorized');
         }
-        setProvisionerContext(request, {workspaceId, provisionerTokenId});
+        setProvisionerContext(request, {scope: 'workspace', workspaceId, provisionerTokenId});
         return Promise.resolve();
       },
     };

--- a/libs/api/runners/src/presentation/routes/poll-demand.test.ts
+++ b/libs/api/runners/src/presentation/routes/poll-demand.test.ts
@@ -25,6 +25,7 @@ import {pendingJobFactory, provisionedRunnerFactory, runnerSessionFactory} from 
 import {runnerRoutes} from './index.js';
 
 const VALID_PROVISIONER_TOKEN = 'valid-provisioner-token';
+const INSTALLATION_PROVISIONER_TOKEN = 'installation-provisioner-token';
 
 const passthroughAuth = (name: string): AuthMethod => ({
   name,
@@ -41,9 +42,13 @@ describe('POST /provisioners/demand/poll', () => {
     authenticate: (request: FastifyRequest) => {
       const rawToken = extractBearerToken(request.headers.authorization);
       if (rawToken !== VALID_PROVISIONER_TOKEN) {
+        if (rawToken === INSTALLATION_PROVISIONER_TOKEN) {
+          setProvisionerContext(request, {scope: 'installation', provisionerTokenId});
+          return Promise.resolve();
+        }
         throw new ClientError('Invalid provisioner token', 'unauthorized', {status: 401});
       }
-      setProvisionerContext(request, {workspaceId, provisionerTokenId});
+      setProvisionerContext(request, {scope: 'workspace', workspaceId, provisionerTokenId});
       return Promise.resolve();
     },
   };
@@ -90,6 +95,18 @@ describe('POST /provisioners/demand/poll', () => {
     });
     expect(res.json().reservations[0].reservation_id).toEqual(expect.any(String));
     expect(res.json().reservations[0].expires_at).toEqual(expect.any(String));
+  });
+
+  it('rejects installation provisioner credentials from workspace demand polling', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/provisioners/demand/poll',
+      headers: {authorization: `Bearer ${INSTALLATION_PROVISIONER_TOKEN}`},
+      payload: body({max_reservations: 1}),
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.json().code).toBe('forbidden');
   });
 
   it('returns stats without reservations in observe-only mode', async () => {

--- a/libs/api/runners/src/presentation/routes/poll-demand.ts
+++ b/libs/api/runners/src/presentation/routes/poll-demand.ts
@@ -1,4 +1,4 @@
-import {requireProvisionerContext} from '@shipfox/api-auth-context';
+import {requireWorkspaceProvisionerContext} from '@shipfox/api-auth-context';
 import {pollDemandBodySchema, pollDemandResponseSchema} from '@shipfox/api-runners-dto';
 import {defineRoute} from '@shipfox/node-fastify';
 import {config} from '#config.js';
@@ -19,7 +19,7 @@ export const pollDemandRoute = defineRoute({
     },
   },
   handler: async (request, reply) => {
-    const {provisionerTokenId, workspaceId} = requireProvisionerContext(request);
+    const {provisionerTokenId, workspaceId} = requireWorkspaceProvisionerContext(request);
     const abortController = new AbortController();
     let responseFinished = false;
     let responseReservations: ReservationGrant[] = [];

--- a/libs/api/runners/src/presentation/routes/provisioner-me.test.ts
+++ b/libs/api/runners/src/presentation/routes/provisioner-me.test.ts
@@ -3,8 +3,12 @@ import type {AuthMethod} from '@shipfox/node-fastify';
 import {closeApp, createApp} from '@shipfox/node-fastify';
 import {generateOpaqueToken} from '@shipfox/node-tokens';
 import type {FastifyInstance} from 'fastify';
+import {createInstallationProvisionerToken} from '#core/provisioner-tokens.js';
 import * as provisionerTokenDb from '#db/provisioner-tokens.js';
-import {revokeProvisionerToken} from '#db/provisioner-tokens.js';
+import {
+  revokeInstallationProvisionerToken,
+  revokeProvisionerToken,
+} from '#db/provisioner-tokens.js';
 import {createProvisionerTokenAuthMethod} from '#presentation/auth/index.js';
 import {provisionerTokenFactory} from '#test/index.js';
 import {provisionerRoutes} from './index.js';
@@ -47,9 +51,39 @@ describe('provisioner me route', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toEqual({id: token.id, workspace_id: workspaceId});
+    expect(res.json()).toEqual({id: token.id, scope: 'workspace', workspace_id: workspaceId});
     const touched = await provisionerTokenDb.resolveProvisionerTokenByHash(token.hashedToken);
     expect(touched?.lastSeenAt).toBeInstanceOf(Date);
+  });
+
+  it('returns an installation identity without a workspace', async () => {
+    const token = await createInstallationProvisionerToken({createdByUserId: crypto.randomUUID()});
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/provisioners/me',
+      headers: {authorization: `Bearer ${token.rawToken}`},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({id: token.token.id, scope: 'installation'});
+  });
+
+  it('rejects a revoked installation provisioner token', async () => {
+    const token = await createInstallationProvisionerToken({createdByUserId: crypto.randomUUID()});
+    await revokeInstallationProvisionerToken({
+      tokenId: token.token.id,
+      revokedByUserId: crypto.randomUUID(),
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/provisioners/me',
+      headers: {authorization: `Bearer ${token.rawToken}`},
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json().code).toBe('provisioner-token-revoked');
   });
 
   it('does not reject valid auth when the last-seen write fails', async () => {
@@ -74,7 +108,7 @@ describe('provisioner me route', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toEqual({id: token.id, workspace_id: workspaceId});
+    expect(res.json()).toEqual({id: token.id, scope: 'workspace', workspace_id: workspaceId});
   });
 
   it('returns 401 without an authorization header', async () => {

--- a/libs/api/runners/src/presentation/routes/reconcile-provisioned-runners.test.ts
+++ b/libs/api/runners/src/presentation/routes/reconcile-provisioned-runners.test.ts
@@ -48,7 +48,7 @@ describe('POST /provisioners/provisioned-runners/reconcile', () => {
       if (rawToken !== VALID_PROVISIONER_TOKEN) {
         throw new ClientError('Invalid provisioner token', 'unauthorized', {status: 401});
       }
-      setProvisionerContext(request, {workspaceId, provisionerTokenId});
+      setProvisionerContext(request, {scope: 'workspace', workspaceId, provisionerTokenId});
       return Promise.resolve();
     },
   };

--- a/libs/api/runners/src/presentation/routes/reconcile-provisioned-runners.ts
+++ b/libs/api/runners/src/presentation/routes/reconcile-provisioned-runners.ts
@@ -1,4 +1,4 @@
-import {requireProvisionerContext} from '@shipfox/api-auth-context';
+import {requireWorkspaceProvisionerContext} from '@shipfox/api-auth-context';
 import {
   reconcileProvisionedRunnersBodySchema,
   reconcileProvisionedRunnersResponseSchema,
@@ -18,7 +18,7 @@ export const reconcileProvisionedRunnersRoute = defineRoute({
     },
   },
   handler: async (request) => {
-    const {provisionerTokenId, workspaceId} = requireProvisionerContext(request);
+    const {provisionerTokenId, workspaceId} = requireWorkspaceProvisionerContext(request);
     const result = await reconcileProvisionedRunners({
       workspaceId,
       provisionerId: provisionerTokenId,

--- a/libs/api/runners/src/presentation/routes/report-provisioned-runners.test.ts
+++ b/libs/api/runners/src/presentation/routes/report-provisioned-runners.test.ts
@@ -42,7 +42,7 @@ describe('POST /provisioners/provisioned-runners/report', () => {
       if (rawToken !== VALID_PROVISIONER_TOKEN) {
         throw new ClientError('Invalid provisioner token', 'unauthorized', {status: 401});
       }
-      setProvisionerContext(request, {workspaceId, provisionerTokenId});
+      setProvisionerContext(request, {scope: 'workspace', workspaceId, provisionerTokenId});
       return Promise.resolve();
     },
   };

--- a/libs/api/runners/src/presentation/routes/report-provisioned-runners.ts
+++ b/libs/api/runners/src/presentation/routes/report-provisioned-runners.ts
@@ -1,4 +1,4 @@
-import {requireProvisionerContext} from '@shipfox/api-auth-context';
+import {requireWorkspaceProvisionerContext} from '@shipfox/api-auth-context';
 import {
   reportProvisionedRunnersBodySchema,
   reportProvisionedRunnersResponseSchema,
@@ -18,7 +18,7 @@ export const reportProvisionedRunnersRoute = defineRoute({
     },
   },
   handler: async (request) => {
-    const {provisionerTokenId, workspaceId} = requireProvisionerContext(request);
+    const {provisionerTokenId, workspaceId} = requireWorkspaceProvisionerContext(request);
     const result = await reportProvisionedRunners({
       workspaceId,
       provisionerId: provisionerTokenId,

--- a/libs/api/runners/test/factories/provisioner-token.ts
+++ b/libs/api/runners/test/factories/provisioner-token.ts
@@ -16,7 +16,7 @@ export const provisionerTokenFactory = Factory.define<
   onCreate((token) => {
     return createProvisionerToken({
       scope: token.scope,
-      workspaceId: token.workspaceId ?? undefined,
+      workspaceId: token.scope === 'workspace' ? token.workspaceId : undefined,
       hashedToken: token.hashedToken,
       prefix: token.prefix,
       name: token.name ?? undefined,

--- a/libs/api/runners/test/factories/provisioner-token.ts
+++ b/libs/api/runners/test/factories/provisioner-token.ts
@@ -15,7 +15,8 @@ export const provisionerTokenFactory = Factory.define<
 
   onCreate((token) => {
     return createProvisionerToken({
-      workspaceId: token.workspaceId,
+      scope: token.scope,
+      workspaceId: token.workspaceId ?? undefined,
       hashedToken: token.hashedToken,
       prefix: token.prefix,
       name: token.name ?? undefined,
@@ -26,6 +27,7 @@ export const provisionerTokenFactory = Factory.define<
 
   return {
     id: crypto.randomUUID(),
+    scope: 'workspace',
     workspaceId: crypto.randomUUID(),
     hashedToken: hashOpaqueToken(rawToken),
     prefix: extractDisplayPrefix(rawToken),

--- a/libs/client/runners/src/components/provisioner-token-format.test.ts
+++ b/libs/client/runners/src/components/provisioner-token-format.test.ts
@@ -8,6 +8,7 @@ import {
 
 const token: ProvisionerTokenDto = {
   id: '33333333-3333-4333-8333-333333333333',
+  scope: 'workspace',
   workspace_id: '11111111-1111-4111-8111-111111111111',
   prefix: 'sf_pt_abcde',
   name: 'Docker provisioner',

--- a/libs/client/runners/src/components/provisioner-tokens-settings-section.test.tsx
+++ b/libs/client/runners/src/components/provisioner-tokens-settings-section.test.tsx
@@ -22,6 +22,7 @@ function jsonResponse(body: unknown, init: ResponseInit = {}) {
 function provisionerToken(overrides: Partial<Record<string, string | null>> = {}) {
   return {
     id: PROVISIONER_TOKEN_ID,
+    scope: 'workspace',
     workspace_id: RUNNERS_TEST_WORKSPACE_ID,
     prefix: 'sf_pt_abcde',
     name: 'Docker provisioner',

--- a/libs/client/runners/src/components/token-settings-sections.stories.tsx
+++ b/libs/client/runners/src/components/token-settings-sections.stories.tsx
@@ -327,6 +327,7 @@ function manualToken(
 function provisionerToken(overrides: Partial<ProvisionerTokenDto> = {}): ProvisionerTokenDto {
   return {
     id: '33333333-3333-4333-8333-333333333333',
+    scope: 'workspace',
     workspace_id: WORKSPACE_ID,
     prefix: 'sf_pt_docker',
     name: 'Docker autoscaler',

--- a/libs/client/runners/src/hooks/api/provisioner-tokens.test.ts
+++ b/libs/client/runners/src/hooks/api/provisioner-tokens.test.ts
@@ -43,6 +43,7 @@ describe('provisioner token transports', () => {
       return jsonResponse(
         {
           id: tokenId,
+          scope: 'workspace',
           raw_token: 'sf_pt_raw-created-token',
           prefix: 'sf_pt_raw-c',
           name: 'Docker provisioner',
@@ -76,6 +77,7 @@ describe('provisioner token transports', () => {
     const fetchImpl = vi.fn().mockResolvedValue(
       jsonResponse({
         id: tokenId,
+        scope: 'workspace',
         workspace_id: workspaceId,
         prefix: 'sf_pt_abcde',
         name: 'Docker provisioner',

--- a/libs/provisioner/core/src/api-client.test.ts
+++ b/libs/provisioner/core/src/api-client.test.ts
@@ -27,11 +27,13 @@ function client() {
 
 describe('createProvisionerClient', () => {
   it('getIdentity sends the provisioner token to /provisioners/me and parses identity', async () => {
-    stubFetch(() => jsonResponse({id: PROVISIONER_ID, workspace_id: WORKSPACE_ID}));
+    stubFetch(() =>
+      jsonResponse({id: PROVISIONER_ID, scope: 'workspace', workspace_id: WORKSPACE_ID}),
+    );
 
     const identity = await client().getIdentity();
 
-    expect(identity).toEqual({id: PROVISIONER_ID, workspace_id: WORKSPACE_ID});
+    expect(identity).toEqual({id: PROVISIONER_ID, scope: 'workspace', workspace_id: WORKSPACE_ID});
     expect(calls[0]?.url).toContain('provisioners/me');
     expect(calls[0]?.method).toBe('GET');
     expect(calls[0]?.authorization).toBe(`Bearer ${TOKEN}`);

--- a/libs/provisioner/core/src/provisioner.test.ts
+++ b/libs/provisioner/core/src/provisioner.test.ts
@@ -164,7 +164,8 @@ function harness(options: {response: PollDemandResponseFixture; onPoll?: () => v
     pollBodies,
     mintBodies,
     client: {
-      getIdentity: () => Promise.resolve({id: 'provisioner', workspace_id: 'workspace'}),
+      getIdentity: () =>
+        Promise.resolve({id: 'provisioner', scope: 'workspace', workspace_id: 'workspace'}),
       pollDemand: (body) => {
         options.onPoll?.();
         pollBodies.push(body);

--- a/libs/provisioner/core/src/provisioner.ts
+++ b/libs/provisioner/core/src/provisioner.ts
@@ -86,6 +86,9 @@ export async function startProvisioner<Spec>(
   // Fail fast at startup if the token is rejected, rather than discovering it on the
   // first poll.
   const identity = await client.getIdentity();
+  if (identity.scope !== 'workspace') {
+    throw new Error('Provisioner daemon requires a workspace provisioner credential');
+  }
   logger().info(
     {
       provisionerId: identity.id,

--- a/libs/provisioner/core/src/tick.test.ts
+++ b/libs/provisioner/core/src/tick.test.ts
@@ -45,7 +45,8 @@ function harness(options: {response: PollDemandResponseFixture; mintError?: Erro
   const events: string[] = [];
 
   const client: ProvisionerClient = {
-    getIdentity: () => Promise.resolve({id: 'provisioner', workspace_id: 'workspace'}),
+    getIdentity: () =>
+      Promise.resolve({id: 'provisioner', scope: 'workspace', workspace_id: 'workspace'}),
     pollDemand: (body) => {
       events.push('poll');
       pollBodies.push(body);
@@ -264,7 +265,7 @@ describe('runProvisionerTick', () => {
     const launches: ProvisionedRunnerLaunch<null>[] = [];
     const tracker = createInMemoryTracker();
     const client: ProvisionerClient = {
-      getIdentity: () => Promise.resolve({id: 'p', workspace_id: 'w'}),
+      getIdentity: () => Promise.resolve({id: 'p', scope: 'workspace', workspace_id: 'w'}),
       pollDemand: () =>
         Promise.resolve({
           stats: [],

--- a/libs/provisioner/docker/src/lifecycle.test.ts
+++ b/libs/provisioner/docker/src/lifecycle.test.ts
@@ -611,6 +611,7 @@ function fakeClient(
     getIdentity: () =>
       Promise.resolve({
         id: '00000000-0000-4000-8000-000000000001',
+        scope: 'workspace',
         workspace_id: '00000000-0000-4000-8000-000000000002',
       }),
     pollDemand: () =>


### PR DESCRIPTION
Add explicit workspace and installation provisioner identities across the runner auth boundary.

Managed runners need an operator-plane credential that is never confused with a workspace principal. This adds scope-aware persistence, authentication context, credential issuance and revocation, and a discriminated `/provisioners/me` response. Existing provisioner APIs are now explicitly workspace-only, while direct manual runner registration remains unchanged.

The initial runners migration and its snapshot are updated in place because this schema has not been deployed. The release is marked major because provisioner consumers must parse the scoped identity contract.

Review focus: the scope/workspace database invariant and the fail-closed workspace route guard.

Refs ENG-1083

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds scoped provisioner identities for workspaces and installations, with strict auth guards across runner APIs and a fail-fast check in the provisioner daemon so operator-plane credentials cannot be confused with workspace principals. Satisfies ENG-1083 requirements for installation‑scoped managed runners.

- **New Features**
  - Scope-aware provisioner context and guards; workspace routes now require a workspace provisioner.
  - `/provisioners/me` returns `{scope: 'workspace' | 'installation'}` and includes `workspace_id` only for workspace scope.
  - Database: new `runners_provisioner_scope` enum and a check constraint enforcing valid scope/workspace combinations.
  - Core: added installation provisioner token issuance and revocation; workspace token flows remain unchanged.
  - DTOs: identity response is a discriminated union; workspace token DTOs include `scope: 'workspace'`.
  - Provisioner daemon rejects installation credentials at startup.

- **Migration**
  - Breaking changes in `@shipfox/api-auth-context`, `@shipfox/api-runners`, and `@shipfox/api-runners-dto`.
  - Update clients to parse the discriminated `/provisioners/me` response and handle `scope` in token DTOs.
  - Installation credentials are rejected by workspace-only endpoints (403), and the provisioner daemon requires a workspace provisioner token.

<sup>Written for commit 8c61a86d50d7bb7ee13dbe60fc38d01e74766ed5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

