### PR TITLE
[integration] Add shared inbound webhook request contract

### DIFF
--- a/.changeset/tiny-hooks-arrive.md
+++ b/.changeset/tiny-hooks-arrive.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-integration-core-dto": minor
+---
+
+Adds the shared versioned inbound webhook request and processing contracts.

--- a/libs/api/integration/core-dto/src/index.ts
+++ b/libs/api/integration/core-dto/src/index.ts
@@ -4,3 +4,4 @@ export * from '#events.js';
 export * from '#ports.js';
 export * from '#schemas/index.js';
 export * from '#slug.js';
+export * from '#webhooks.js';

--- a/libs/api/integration/core-dto/src/webhooks.test.ts
+++ b/libs/api/integration/core-dto/src/webhooks.test.ts
@@ -1,0 +1,91 @@
+import {
+  createMaximumSizeStoredWebhookRequestFixture,
+  createStoredWebhookRequest,
+  decodeWebhookBody,
+  storedWebhookRequestSchema,
+  WEBHOOK_MAX_RAW_BODY_BYTES,
+  WEBHOOK_MAX_SERIALIZED_REQUEST_BYTES,
+  webhookProcessingResultSchema,
+} from './webhooks.js';
+
+const requestId = '9b11d65a-f7e7-40ea-b421-06af012a9be5';
+const receivedAt = '2026-07-20T10:30:00.123Z';
+
+describe('storedWebhookRequestSchema', () => {
+  it('round-trips exact body bytes from a direct adapter through the stored contract', () => {
+    const body = new Uint8Array([0, 255, 5, 128, 42]);
+    const directRequest = createStoredWebhookRequest({
+      requestId,
+      routeId: 'slack.command',
+      receivedAt,
+      rawQueryString: '',
+      headers: {'content-type': 'application/x-www-form-urlencoded'},
+      body,
+    });
+
+    const queuedRequest = storedWebhookRequestSchema.parse(
+      JSON.parse(JSON.stringify(directRequest)),
+    );
+
+    expect(queuedRequest.received_at).toBe(receivedAt);
+    expect(decodeWebhookBody(queuedRequest.body)).toEqual(body);
+  });
+
+  it('rejects unknown fields, routes, and schema versions', () => {
+    const request = createStoredWebhookRequest({
+      requestId,
+      routeId: 'github',
+      receivedAt,
+      rawQueryString: '',
+      headers: {'content-type': 'application/json'},
+      body: new Uint8Array(),
+    });
+
+    expect(storedWebhookRequestSchema.safeParse({...request, added_later: true}).success).toBe(
+      false,
+    );
+    expect(storedWebhookRequestSchema.safeParse({...request, schema_version: 2}).success).toBe(
+      false,
+    );
+    expect(storedWebhookRequestSchema.safeParse({...request, route_id: 'stripe'}).success).toBe(
+      false,
+    );
+  });
+
+  it('requires a generic connection identifier only for the generic route', () => {
+    const genericRequest = createStoredWebhookRequest({
+      requestId,
+      routeId: 'webhook.connection',
+      receivedAt,
+      rawQueryString: '',
+      headers: {'content-type': 'application/json'},
+      body: new Uint8Array(),
+      connectionId: 'c0a8012e-0b6d-4d8f-8d5c-6d74102602b0',
+    });
+
+    const withoutConnectionId = {
+      ...genericRequest,
+      path_parameters: {},
+    };
+
+    expect(storedWebhookRequestSchema.safeParse(withoutConnectionId).success).toBe(false);
+  });
+
+  it('keeps the maximum-size fixture below the SQS message limit', () => {
+    const fixture = createMaximumSizeStoredWebhookRequestFixture();
+    const serializedSize = new TextEncoder().encode(JSON.stringify(fixture)).byteLength;
+
+    expect(decodeWebhookBody(fixture.body)).toHaveLength(WEBHOOK_MAX_RAW_BODY_BYTES);
+    expect(serializedSize).toBeLessThan(WEBHOOK_MAX_SERIALIZED_REQUEST_BYTES);
+  });
+});
+
+describe('webhookProcessingResultSchema', () => {
+  it.each([
+    {outcome: 'processed'},
+    {outcome: 'duplicate', deliveryId: 'delivery-1'},
+    {outcome: 'discarded', reason: 'invalid_signature'},
+  ])('accepts the %s processing outcome', (result) => {
+    expect(webhookProcessingResultSchema.safeParse(result).success).toBe(true);
+  });
+});

--- a/libs/api/integration/core-dto/src/webhooks.ts
+++ b/libs/api/integration/core-dto/src/webhooks.ts
@@ -1,0 +1,217 @@
+import {z} from 'zod';
+
+export const WEBHOOK_REQUEST_SCHEMA_VERSION = 1 as const;
+export const WEBHOOK_MAX_RAW_BODY_BYTES = 512 * 1024;
+export const WEBHOOK_MAX_SERIALIZED_REQUEST_BYTES = 1024 * 1024;
+export const WEBHOOK_MAX_HEADER_BYTES = 64 * 1024;
+export const WEBHOOK_MAX_RAW_QUERY_STRING_LENGTH = 8 * 1024;
+
+const standardWebhookRouteIds = [
+  'github',
+  'gitea',
+  'linear',
+  'sentry',
+  'slack.event',
+  'slack.command',
+] as const;
+
+export const webhookRouteIds = [...standardWebhookRouteIds, 'webhook.connection'] as const;
+
+export const webhookRouteIdSchema = z.enum(webhookRouteIds);
+export type WebhookRouteId = z.infer<typeof webhookRouteIdSchema>;
+
+const base64Pattern = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
+function decodedBase64Length(value: string): number {
+  const paddingLength = value.endsWith('==') ? 2 : value.endsWith('=') ? 1 : 0;
+
+  return (value.length / 4) * 3 - paddingLength;
+}
+
+function headersByteLength(headers: Record<string, string>): number {
+  return new TextEncoder().encode(JSON.stringify(headers)).byteLength;
+}
+
+const webhookHeadersSchema = z
+  .record(z.string(), z.string().max(8 * 1024))
+  .refine(
+    (headers) =>
+      Object.keys(headers).every(
+        (name) => name === name.toLowerCase() && name.length > 0 && name.length <= 128,
+      ),
+    'Webhook header names must be lowercase and at most 128 characters',
+  )
+  .refine(
+    (headers) => headersByteLength(headers) <= WEBHOOK_MAX_HEADER_BYTES,
+    `Webhook headers must serialize to at most ${WEBHOOK_MAX_HEADER_BYTES} bytes`,
+  );
+
+const webhookBodySchema = z
+  .object({
+    encoding: z.literal('base64'),
+    data: z
+      .string()
+      .max(Math.ceil(WEBHOOK_MAX_RAW_BODY_BYTES / 3) * 4)
+      .regex(base64Pattern),
+  })
+  .strict()
+  .refine(
+    (body) => decodedBase64Length(body.data) <= WEBHOOK_MAX_RAW_BODY_BYTES,
+    `Webhook bodies must decode to at most ${WEBHOOK_MAX_RAW_BODY_BYTES} bytes`,
+  );
+
+const storedWebhookRequestBaseSchema = z.object({
+  schema_version: z.literal(WEBHOOK_REQUEST_SCHEMA_VERSION),
+  request_id: z.string().uuid(),
+  received_at: z.string().datetime({offset: true}),
+  method: z.literal('POST'),
+  raw_query_string: z.string().max(WEBHOOK_MAX_RAW_QUERY_STRING_LENGTH),
+  headers: webhookHeadersSchema,
+  body: webhookBodySchema,
+});
+
+const emptyPathParametersSchema = z.object({}).strict();
+const connectionPathParametersSchema = z.object({connection_id: z.string().uuid()}).strict();
+
+const standardWebhookRouteRequestSchema = storedWebhookRequestBaseSchema
+  .extend({
+    route_id: z.enum(standardWebhookRouteIds),
+    path_parameters: emptyPathParametersSchema,
+  })
+  .strict();
+
+const genericWebhookRouteRequestSchema = storedWebhookRequestBaseSchema
+  .extend({
+    route_id: z.literal('webhook.connection'),
+    path_parameters: connectionPathParametersSchema,
+  })
+  .strict();
+
+export const storedWebhookRequestSchema = z.discriminatedUnion('route_id', [
+  standardWebhookRouteRequestSchema,
+  genericWebhookRouteRequestSchema,
+]);
+export type StoredWebhookRequest = z.infer<typeof storedWebhookRequestSchema>;
+
+export const webhookProcessingResultSchema = z.discriminatedUnion('outcome', [
+  z.object({outcome: z.literal('processed'), deliveryId: z.string().min(1).optional()}).strict(),
+  z.object({outcome: z.literal('duplicate'), deliveryId: z.string().min(1)}).strict(),
+  z
+    .object({
+      outcome: z.literal('discarded'),
+      reason: z.enum([
+        'missing_required_input',
+        'invalid_signature',
+        'stale_at_receipt',
+        'malformed_payload',
+        'unsupported_event',
+        'connection_unavailable',
+      ]),
+      deliveryId: z.string().min(1).optional(),
+    })
+    .strict(),
+]);
+export type WebhookProcessingResult = z.infer<typeof webhookProcessingResultSchema>;
+
+export interface CreateStoredWebhookRequestInput {
+  requestId: string;
+  routeId: WebhookRouteId;
+  receivedAt: string;
+  rawQueryString: string;
+  headers: Record<string, string>;
+  body: Uint8Array;
+  connectionId?: string | undefined;
+}
+
+export function encodeWebhookBody(body: Uint8Array): string {
+  let encoded = '';
+
+  for (let index = 0; index < body.length; index += 3) {
+    const first = body[index] ?? 0;
+    const second = body[index + 1];
+    const third = body[index + 2];
+    const combined = (first << 16) | ((second ?? 0) << 8) | (third ?? 0);
+
+    encoded += 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'[
+      (combined >> 18) & 63
+    ];
+    encoded += 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'[
+      (combined >> 12) & 63
+    ];
+    encoded +=
+      second === undefined
+        ? '='
+        : 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'[(combined >> 6) & 63];
+    encoded +=
+      third === undefined
+        ? '='
+        : 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'[combined & 63];
+  }
+
+  return encoded;
+}
+
+export function decodeWebhookBody(body: z.infer<typeof webhookBodySchema>): Uint8Array {
+  const output = new Uint8Array(decodedBase64Length(body.data));
+  let outputIndex = 0;
+
+  for (let index = 0; index < body.data.length; index += 4) {
+    const chunk = body.data.slice(index, index + 4);
+    const values = chunk
+      .split('')
+      .map((character) =>
+        character === '='
+          ? 0
+          : 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'.indexOf(character),
+      );
+    const first = values[0] ?? 0;
+    const second = values[1] ?? 0;
+    const third = values[2] ?? 0;
+    const fourth = values[3] ?? 0;
+    const combined = (first << 18) | (second << 12) | (third << 6) | fourth;
+
+    output[outputIndex++] = (combined >> 16) & 255;
+    if (chunk[2] !== '=') output[outputIndex++] = (combined >> 8) & 255;
+    if (chunk[3] !== '=') output[outputIndex++] = combined & 255;
+  }
+
+  return output;
+}
+
+export function createStoredWebhookRequest(
+  input: CreateStoredWebhookRequestInput,
+): StoredWebhookRequest {
+  const pathParameters =
+    input.routeId === 'webhook.connection' ? {connection_id: input.connectionId} : {};
+
+  return storedWebhookRequestSchema.parse({
+    schema_version: WEBHOOK_REQUEST_SCHEMA_VERSION,
+    request_id: input.requestId,
+    route_id: input.routeId,
+    received_at: input.receivedAt,
+    method: 'POST',
+    path_parameters: pathParameters,
+    raw_query_string: input.rawQueryString,
+    headers: input.headers,
+    body: {encoding: 'base64', data: encodeWebhookBody(input.body)},
+  });
+}
+
+export function createMaximumSizeStoredWebhookRequestFixture(): StoredWebhookRequest {
+  const headers = Object.fromEntries(
+    Array.from({length: 8}, (_, index) => [
+      `x-fixture-${index}`,
+      'a'.repeat(index === 7 ? 8_000 : 8 * 1024),
+    ]),
+  );
+
+  return createStoredWebhookRequest({
+    requestId: '9b11d65a-f7e7-40ea-b421-06af012a9be5',
+    routeId: 'webhook.connection',
+    receivedAt: '2026-07-20T10:30:00.123Z',
+    rawQueryString: 'q='.padEnd(WEBHOOK_MAX_RAW_QUERY_STRING_LENGTH, 'q'),
+    headers,
+    body: new Uint8Array(WEBHOOK_MAX_RAW_BODY_BYTES),
+    connectionId: 'c0a8012e-0b6d-4d8f-8d5c-6d74102602b0',
+  });
+}


### PR DESCRIPTION
Adds the published, provider-neutral request envelope that direct HTTP adapters, the durable receiver, and queued processing can validate identically.

Webhook signatures and replay windows require exact raw bytes and an ingress-trusted receipt time. This contract keeps those properties intact while rejecting unknown fields and unsupported versions before delivery processing begins.

The request schema remains independent of Cloud and AWS. It also includes bounded metadata, closed route IDs, processing outcomes, and a maximum-size fixture that proves the complete serialized message remains below the SQS limit.

Closes ENG-1062

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a versioned, provider‑neutral inbound webhook request and processing contract in `@shipfox/api-integration-core-dto` so adapters and durable consumers preserve exact body bytes and receipt time and validate identically. Addresses ENG-1062 by enforcing strict schemas, size limits, and closed route IDs before processing.

- New Features
  - Added `storedWebhookRequestSchema` (v1) with strict validation, closed route IDs, and `webhook.connection` requiring `connection_id`.
  - Added `webhookProcessingResultSchema` with outcomes: processed, duplicate, discarded (with reasons).
  - Helpers: `createStoredWebhookRequest`, `createMaximumSizeStoredWebhookRequestFixture`, `encodeWebhookBody`, `decodeWebhookBody`; exported via `#webhooks.js`.
  - Limits enforced: body 512 KB, headers 64 KB total, raw query 8 KB, serialized request < 1 MB.
  - Tests cover exact body round‑trip, rejection of unknown fields/versions, required params for generic route, and size ceiling under SQS.

<sup>Written for commit 05a2685e0e2107c7fe23931b09c797a8feae3ae5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

