### PR TITLE
[api/auth] Prevent flaky session eligibility test failures

### DIFF
--- a/libs/api/auth/src/core/auth.test.ts
+++ b/libs/api/auth/src/core/auth.test.ts
@@ -271,11 +271,14 @@ describe('auth core', () => {
     const suspended = await userFactory.create({emailVerifiedAt: new Date()});
     await db().update(users).set({status: 'suspended'}).where(eq(users.id, suspended.id));
 
-    const unverifiedResult = createSessionForUser({email: unverified.email});
-    const suspendedResult = createSessionForUser({email: suspended.email});
+    const unverifiedExpectation = expect(
+      createSessionForUser({email: unverified.email}),
+    ).rejects.toBeInstanceOf(EmailNotVerifiedError);
+    const suspendedExpectation = expect(
+      createSessionForUser({email: suspended.email}),
+    ).rejects.toBeInstanceOf(InvalidCredentialsError);
 
-    await expect(unverifiedResult).rejects.toBeInstanceOf(EmailNotVerifiedError);
-    await expect(suspendedResult).rejects.toBeInstanceOf(InvalidCredentialsError);
+    await Promise.all([unverifiedExpectation, suspendedExpectation]);
   });
 
   test('refreshAccessToken rotates the refresh token', async () => {


### PR DESCRIPTION
Attach both rejected-session expectations as each promise is created.

The test previously started both rejection paths before registering a handler for the second one. If that promise rejected first, Vitest reported an unhandled rejection even though its assertions later passed. Registering both handlers immediately removes that timing-dependent failure while preserving the eligibility checks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix flaky session eligibility test by attaching rejection expectations at promise creation for both `createSessionForUser` calls and awaiting them together. This removes timing-dependent unhandled rejections in `vitest` and stabilizes tests with no runtime changes.

<sup>Written for commit 9db99e773b150cb663484f1d0f6773c59cf1e2ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

