### PR TITLE
Add runners module composition seam

### DIFF
--- a/.changeset/bright-runners-compose.md
+++ b/.changeset/bright-runners-compose.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-runners": minor
+"@shipfox/api-server": minor
+---
+
+Adds host-configurable runners composition with batched installation workspace eligibility policy.

--- a/libs/api/runners/src/index.test.ts
+++ b/libs/api/runners/src/index.test.ts
@@ -1,0 +1,24 @@
+import {createRunnersModule, runnersModule} from './index.js';
+
+describe('createRunnersModule', () => {
+  it('preserves the default module composition when options are absent', () => {
+    const module = createRunnersModule();
+
+    expect(module.name).toBe(runnersModule.name);
+    expect(module.auth).toHaveLength(runnersModule.auth?.length ?? 0);
+    expect(module.routes).toHaveLength(runnersModule.routes?.length ?? 0);
+    expect(module.workers).toHaveLength(runnersModule.workers?.length ?? 0);
+  });
+
+  it('accepts an instance-local installation provisioning policy', () => {
+    const policy = {
+      filterEligibleWorkspaceIds: vi.fn().mockResolvedValue(new Set<string>()),
+    };
+
+    const module = createRunnersModule({installationProvisioning: {policy}});
+
+    expect(module.name).toBe('runners');
+    expect(module.routes).not.toBe(runnersModule.routes);
+    expect(policy.filterEligibleWorkspaceIds).not.toHaveBeenCalled();
+  });
+});

--- a/libs/api/runners/src/index.ts
+++ b/libs/api/runners/src/index.ts
@@ -7,12 +7,13 @@ import {
 } from '@shipfox/api-workflows-dto';
 import {type ShipfoxModule, subscriberFactory} from '@shipfox/node-module';
 import {db, migrationsPath, runnersOutbox} from '#db/index.js';
+import type {CreateRunnersModuleOptions} from '#installation-provisioning.js';
 import {registerRunnersServiceMetrics} from '#metrics/index.js';
 import {
   createProvisionerTokenAuthMethod,
   createRunnerRegistrationTokenAuthMethod,
+  createRunnerRoutes,
   onWorkflowsJobExecutionTimedOut,
-  routes,
 } from '#presentation/index.js';
 import {createRunnersMaintenanceActivities} from '#temporal/activities/index.js';
 import {RUNNERS_MAINTENANCE_TASK_QUEUE} from '#temporal/constants.js';
@@ -38,26 +39,36 @@ export {
   isJobLeaseActive,
   releaseJobExecution,
 } from '#db/index.js';
+export type {
+  CreateRunnersModuleOptions,
+  InstallationProvisioningPolicy,
+} from '#installation-provisioning.js';
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const workflowsPath = resolve(packageRoot, 'dist/temporal/workflows/index.js');
 
 const subscriber = subscriberFactory<WorkflowsEventMapDto>();
 
-export const runnersModule: ShipfoxModule = {
-  name: 'runners',
-  database: {db, migrationsPath},
-  auth: [createRunnerRegistrationTokenAuthMethod(), createProvisionerTokenAuthMethod()],
-  routes,
-  metrics: registerRunnersServiceMetrics,
-  publishers: [{name: 'runners', table: runnersOutbox, db, eventSchemas: runnersEventSchemas}],
-  subscribers: [subscriber(WORKFLOWS_JOB_EXECUTION_TIMED_OUT, onWorkflowsJobExecutionTimedOut)],
-  workers: [
-    {
-      taskQueue: RUNNERS_MAINTENANCE_TASK_QUEUE,
-      workflowsPath,
-      activities: createRunnersMaintenanceActivities,
-      workflows: [{name: 'stuckJobDetector', id: 'stuck-job-detector', cronSchedule: '* * * * *'}],
-    },
-  ],
-};
+export function createRunnersModule(options: CreateRunnersModuleOptions = {}): ShipfoxModule {
+  return {
+    name: 'runners',
+    database: {db, migrationsPath},
+    auth: [createRunnerRegistrationTokenAuthMethod(), createProvisionerTokenAuthMethod()],
+    routes: createRunnerRoutes(options),
+    metrics: registerRunnersServiceMetrics,
+    publishers: [{name: 'runners', table: runnersOutbox, db, eventSchemas: runnersEventSchemas}],
+    subscribers: [subscriber(WORKFLOWS_JOB_EXECUTION_TIMED_OUT, onWorkflowsJobExecutionTimedOut)],
+    workers: [
+      {
+        taskQueue: RUNNERS_MAINTENANCE_TASK_QUEUE,
+        workflowsPath,
+        activities: createRunnersMaintenanceActivities,
+        workflows: [
+          {name: 'stuckJobDetector', id: 'stuck-job-detector', cronSchedule: '* * * * *'},
+        ],
+      },
+    ],
+  };
+}
+
+export const runnersModule = createRunnersModule();

--- a/libs/api/runners/src/installation-provisioning.ts
+++ b/libs/api/runners/src/installation-provisioning.ts
@@ -1,0 +1,14 @@
+/**
+ * Lets an application host choose which workspaces may receive installation-provisioned capacity.
+ * The runners module passes candidate IDs in batches so host policy can apply its own entitlement
+ * or tenancy rules without exposing those rules from this package.
+ */
+export interface InstallationProvisioningPolicy {
+  filterEligibleWorkspaceIds(workspaceIds: readonly string[]): Promise<ReadonlySet<string>>;
+}
+
+export interface CreateRunnersModuleOptions {
+  installationProvisioning?: {
+    policy: InstallationProvisioningPolicy;
+  };
+}

--- a/libs/api/runners/src/presentation/index.ts
+++ b/libs/api/runners/src/presentation/index.ts
@@ -2,5 +2,5 @@ export {
   createProvisionerTokenAuthMethod,
   createRunnerRegistrationTokenAuthMethod,
 } from './auth/index.js';
-export {runnerRoutes as routes} from './routes/index.js';
+export {createRunnerRoutes, runnerRoutes as routes} from './routes/index.js';
 export {onWorkflowsJobExecutionTimedOut} from './subscribers/on-workflows-job-execution-timed-out.js';

--- a/libs/api/runners/src/presentation/routes/index.ts
+++ b/libs/api/runners/src/presentation/routes/index.ts
@@ -6,6 +6,7 @@ import {
   AUTH_USER,
 } from '@shipfox/api-auth-context';
 import type {RouteGroup} from '@shipfox/node-fastify';
+import type {CreateRunnersModuleOptions} from '#installation-provisioning.js';
 import {createManualRegistrationTokenRoute} from './create-manual-registration-token.js';
 import {createProvisionerTokenRoute} from './create-provisioner-token.js';
 import {getProvisionerMeRoute} from './get-provisioner-me.js';
@@ -15,7 +16,7 @@ import {listActiveRunnersRoute} from './list-active-runners.js';
 import {listManualRegistrationTokensRoute} from './list-manual-registration-tokens.js';
 import {listProvisionerTokensRoute} from './list-provisioner-tokens.js';
 import {mintRegistrationTokensRoute} from './mint-registration-tokens.js';
-import {pollDemandRoute} from './poll-demand.js';
+import {createPollDemandRoute, pollDemandRoute} from './poll-demand.js';
 import {reconcileProvisionedRunnersRoute} from './reconcile-provisioned-runners.js';
 import {registerRoute} from './register.js';
 import {reportProvisionedRunnersRoute} from './report-provisioned-runners.js';
@@ -82,5 +83,21 @@ export const provisionerRoutes: RouteGroup[] = [
     routes: [getProvisionerMeRoute],
   },
 ];
+
+export function createRunnerRoutes(options: CreateRunnersModuleOptions = {}): RouteGroup[] {
+  return [
+    ...runnerOnlyRoutes.map((route) =>
+      route.routes.includes(pollDemandRoute)
+        ? {
+            ...route,
+            routes: route.routes.map((r) =>
+              r === pollDemandRoute ? createPollDemandRoute(options) : r,
+            ),
+          }
+        : route,
+    ),
+    ...provisionerRoutes,
+  ];
+}
 
 export const runnerRoutes: RouteGroup[] = [...runnerOnlyRoutes, ...provisionerRoutes];

--- a/libs/api/runners/src/presentation/routes/poll-demand.test.ts
+++ b/libs/api/runners/src/presentation/routes/poll-demand.test.ts
@@ -22,7 +22,7 @@ import {
   provisionedRunnerTerminateIntentIssuedCount,
 } from '#metrics/instance.js';
 import {pendingJobFactory, provisionedRunnerFactory, runnerSessionFactory} from '#test/index.js';
-import {runnerRoutes} from './index.js';
+import {createRunnerRoutes, runnerRoutes} from './index.js';
 
 const VALID_PROVISIONER_TOKEN = 'valid-provisioner-token';
 const INSTALLATION_PROVISIONER_TOKEN = 'installation-provisioner-token';
@@ -336,5 +336,91 @@ describe('POST /provisioners/demand/poll', () => {
         lastHeartbeatAt: new Date('2025-01-01T00:00:00.000Z'),
         cancellationRequestedAt: params.cancellationRequestedAt ?? null,
       });
+  }
+});
+
+describe('POST /provisioners/demand/poll with installation provisioning configured', () => {
+  let app: FastifyInstance;
+  let workspaceId: string;
+  let provisionerTokenId: string;
+
+  const fakeProvisionerAuth: AuthMethod = {
+    name: AUTH_PROVISIONER_TOKEN,
+    authenticate: (request: FastifyRequest) => {
+      const rawToken = extractBearerToken(request.headers.authorization);
+      if (rawToken === INSTALLATION_PROVISIONER_TOKEN) {
+        setProvisionerContext(request, {scope: 'installation', provisionerTokenId});
+        return Promise.resolve();
+      }
+      setProvisionerContext(request, {scope: 'workspace', workspaceId, provisionerTokenId});
+      return Promise.resolve();
+    },
+  };
+
+  beforeAll(async () => {
+    app = await createApp({
+      auth: [
+        passthroughAuth(AUTH_USER),
+        passthroughAuth(AUTH_RUNNER_REGISTRATION_TOKEN),
+        passthroughAuth(AUTH_RUNNER_SESSION),
+        passthroughAuth(AUTH_LEASED_JOB),
+        fakeProvisionerAuth,
+      ],
+      routes: createRunnerRoutes({
+        installationProvisioning: {policy: {filterEligibleWorkspaceIds: vi.fn()}},
+      }),
+      swagger: false,
+    });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await closeApp();
+  });
+
+  beforeEach(() => {
+    workspaceId = crypto.randomUUID();
+    provisionerTokenId = crypto.randomUUID();
+  });
+
+  it('returns 501 for installation provisioner credentials', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/provisioners/demand/poll',
+      headers: {authorization: `Bearer ${INSTALLATION_PROVISIONER_TOKEN}`},
+      payload: body({max_reservations: 1}),
+    });
+
+    expect(res.statusCode).toBe(501);
+    expect(res.json().code).toBe('installation-provisioning-unavailable');
+  });
+
+  it('still serves workspace provisioner credentials', async () => {
+    await pendingJobFactory.create({workspaceId, requiredLabels: ['linux']});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/provisioners/demand/poll',
+      headers: {authorization: `Bearer ${VALID_PROVISIONER_TOKEN}`},
+      payload: body({max_reservations: 1}),
+    });
+
+    expect(res.statusCode).toBe(200);
+  });
+
+  function body(params: {max_reservations: number}) {
+    return {
+      wait_seconds: 0,
+      max_reservations: params.max_reservations,
+      templates: [
+        {
+          template_key: 'linux',
+          labels: ['linux'],
+          available_slots: 1,
+          starting: 0,
+          running: 0,
+        },
+      ],
+    };
   }
 });

--- a/libs/api/runners/src/presentation/routes/poll-demand.ts
+++ b/libs/api/runners/src/presentation/routes/poll-demand.ts
@@ -1,56 +1,76 @@
-import {requireWorkspaceProvisionerContext} from '@shipfox/api-auth-context';
+import {
+  requireProvisionerContext,
+  requireWorkspaceProvisionerContext,
+} from '@shipfox/api-auth-context';
 import {pollDemandBodySchema, pollDemandResponseSchema} from '@shipfox/api-runners-dto';
-import {defineRoute} from '@shipfox/node-fastify';
+import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {config} from '#config.js';
 import {pollDemand, releaseReservationGrants} from '#core/demand.js';
 import type {ReservationGrant} from '#db/reservations.js';
+import type {CreateRunnersModuleOptions} from '#installation-provisioning.js';
 import {toPollDemandResponseDto} from '#presentation/dto/index.js';
 
 const TERMINATE_INTENT_LIMIT = 1000;
 
-export const pollDemandRoute = defineRoute({
-  method: 'POST',
-  path: '/demand/poll',
-  description: 'Poll aggregate runner demand and reserve capacity for a provisioner',
-  schema: {
-    body: pollDemandBodySchema,
-    response: {
-      200: pollDemandResponseSchema,
+export function createPollDemandRoute(options: CreateRunnersModuleOptions = {}) {
+  return defineRoute({
+    method: 'POST',
+    path: '/demand/poll',
+    description: 'Poll aggregate runner demand and reserve capacity for a provisioner',
+    schema: {
+      body: pollDemandBodySchema,
+      response: {
+        200: pollDemandResponseSchema,
+      },
     },
-  },
-  handler: async (request, reply) => {
-    const {provisionerTokenId, workspaceId} = requireWorkspaceProvisionerContext(request);
-    const abortController = new AbortController();
-    let responseFinished = false;
-    let responseReservations: ReservationGrant[] = [];
-    reply.raw.on('finish', () => {
-      responseFinished = true;
-    });
-    reply.raw.on('close', () => {
-      if (!responseFinished) {
-        abortController.abort();
-        void releaseReservationGrants(responseReservations).catch(() => undefined);
+    handler: async (request, reply) => {
+      const provisionerContext = requireProvisionerContext(request);
+      // A host that configures installationProvisioning is opting in to installation-scoped
+      // demand polling, but this route doesn't apply the eligibility policy yet: fail loudly
+      // instead of silently ignoring it. Hosts that never opt in fall through to the
+      // requireWorkspaceProvisionerContext 403 below, same as before this option existed.
+      if (provisionerContext.scope === 'installation' && options.installationProvisioning) {
+        throw new ClientError(
+          'Installation demand allocation is unavailable',
+          'installation-provisioning-unavailable',
+          {status: 501},
+        );
       }
-    });
+      const {provisionerTokenId, workspaceId} = requireWorkspaceProvisionerContext(request);
+      const abortController = new AbortController();
+      let responseFinished = false;
+      let responseReservations: ReservationGrant[] = [];
+      reply.raw.on('finish', () => {
+        responseFinished = true;
+      });
+      reply.raw.on('close', () => {
+        if (!responseFinished) {
+          abortController.abort();
+          void releaseReservationGrants(responseReservations).catch(() => undefined);
+        }
+      });
 
-    const result = await pollDemand({
-      workspaceId,
-      provisionerId: provisionerTokenId,
-      maxReservations: request.body.max_reservations,
-      waitSeconds: request.body.wait_seconds,
-      ttlSeconds: config.RESERVATION_TTL_SECONDS,
-      terminateIntentLimit: TERMINATE_INTENT_LIMIT,
-      templates: request.body.templates.map((template) => ({
-        templateKey: template.template_key,
-        labels: template.labels,
-        availableSlots: template.available_slots,
-        starting: template.starting,
-        running: template.running,
-      })),
-      signal: abortController.signal,
-    });
-    responseReservations = result.reservations;
+      const result = await pollDemand({
+        workspaceId,
+        provisionerId: provisionerTokenId,
+        maxReservations: request.body.max_reservations,
+        waitSeconds: request.body.wait_seconds,
+        ttlSeconds: config.RESERVATION_TTL_SECONDS,
+        terminateIntentLimit: TERMINATE_INTENT_LIMIT,
+        templates: request.body.templates.map((template) => ({
+          templateKey: template.template_key,
+          labels: template.labels,
+          availableSlots: template.available_slots,
+          starting: template.starting,
+          running: template.running,
+        })),
+        signal: abortController.signal,
+      });
+      responseReservations = result.reservations;
 
-    return toPollDemandResponseDto(result);
-  },
-});
+      return toPollDemandResponseDto(result);
+    },
+  });
+}
+
+export const pollDemandRoute = createPollDemandRoute();

--- a/libs/api/server/src/index.ts
+++ b/libs/api/server/src/index.ts
@@ -1,3 +1,3 @@
-export {defaultModules} from './modules.js';
+export {type DefaultModulesOptions, defaultModules} from './modules.js';
 export type {CreateServerOptions, RunServerOptions, ServerHandle} from './server.js';
 export {createServer, runServer} from './server.js';

--- a/libs/api/server/src/modules.test.ts
+++ b/libs/api/server/src/modules.test.ts
@@ -115,6 +115,30 @@ describe('defaultModules', () => {
     ]);
   });
 
+  it('replaces only the runners module when a host provides one', async () => {
+    const runnersModule = {name: 'runners'};
+
+    const modules = await defaultModules({runnersModule});
+
+    expect(modules).toContain(runnersModule);
+    expect(modules.filter((module) => module.name === 'runners')).toEqual([runnersModule]);
+    expect(modules.map((module) => module.name)).toEqual([
+      'auth',
+      'workspaces',
+      'secrets',
+      'agent',
+      'integrations',
+      'projects',
+      'definitions',
+      'workflows',
+      'annotations',
+      'runners',
+      'logs',
+      'triggers',
+      'dispatcher',
+    ]);
+  });
+
   it('uses the leased-step loader and namespaced provider secrets', async () => {
     await defaultModules();
 

--- a/libs/api/server/src/modules.ts
+++ b/libs/api/server/src/modules.ts
@@ -12,7 +12,7 @@ import {
 } from '@shipfox/api-integration-core';
 import {logsModule} from '@shipfox/api-logs';
 import {createProjectsModule} from '@shipfox/api-projects';
-import {runnersModule} from '@shipfox/api-runners';
+import {runnersModule as defaultRunnersModule} from '@shipfox/api-runners';
 import {deleteSecrets, getSecret, secretsModule, setSecrets} from '@shipfox/api-secrets';
 import {createTriggersModule} from '@shipfox/api-triggers';
 import {
@@ -29,7 +29,13 @@ import {
   registerInterModulePresentations,
 } from '@shipfox/node-module/inter-module';
 
-export async function defaultModules(): Promise<ShipfoxModule[]> {
+export interface DefaultModulesOptions {
+  runnersModule?: ShipfoxModule;
+}
+
+export async function defaultModules(
+  options: DefaultModulesOptions = {},
+): Promise<ShipfoxModule[]> {
   const interModuleTransport = createInMemoryInterModuleTransport();
   const workflowsClient = interModuleTransport.createClient(workflowsInterModuleContract);
   const integrations = await createIntegrationsContext({
@@ -114,7 +120,7 @@ export async function defaultModules(): Promise<ShipfoxModule[]> {
     definitionsModule,
     createWorkflowsModule(),
     annotationsModule,
-    runnersModule,
+    options.runnersModule ?? defaultRunnersModule,
     logsModule,
     createTriggersModule({workflows: workflowsClient}),
     dispatcherModule,

--- a/tools/application-release/test/external/verify.mjs
+++ b/tools/application-release/test/external/verify.mjs
@@ -141,10 +141,16 @@ async function writeFixtureFiles(root, dependencies, runtimeEntryPoints, typeEnt
     ),
     writeFile(
       join(root, 'composition.ts'),
-      `import {createServer, defaultModules} from '@shipfox/api-server';
+      `import {createRunnersModule, type InstallationProvisioningPolicy} from '@shipfox/api-runners';
+import {createServer, defaultModules} from '@shipfox/api-server';
+
+const policy: InstallationProvisioningPolicy = {
+  filterEligibleWorkspaceIds: async (workspaceIds) => new Set(workspaceIds),
+};
+const runnersModule = createRunnersModule({installationProvisioning: {policy}});
 
 void createServer({
-  modules: [...(await defaultModules()), {name: 'external-dummy'}],
+  modules: [...(await defaultModules({runnersModule})), {name: 'external-dummy'}],
 });
 `,
     ),


### PR DESCRIPTION
Adds a public `createRunnersModule` factory and a batched installation-workspace eligibility policy contract, while preserving the existing disabled default module.

Commercial hosts need to supply private eligibility policy without making public Shipfox packages depend on Cloud code or copying the API module list. `defaultModules({runnersModule})` provides that replacement seam.

Installation demand allocation remains intentionally unavailable when a host opts in; the configured route fails explicitly until the follow-up allocator consumes the policy. Workspace provisioning behavior remains unchanged.

The packed external-consumer fixture type-checks the published composition surface.

Closes ENG-1087

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a host-configurable runners module seam in `@shipfox/api-runners` so hosts can provide an installation workspace eligibility policy without `@shipfox-cloud/*`. Default behavior is unchanged; when opted in, installation demand polling returns 501 until the allocator ships (ENG-1087).

- New Features
  - `@shipfox/api-runners`: `createRunnersModule(options)` with `installationProvisioning.policy` (`InstallationProvisioningPolicy`, `CreateRunnersModuleOptions` exports). Route composition via `createRunnerRoutes`; `poll-demand` returns 501 for installation-scoped credentials when configured; workspace polling unchanged.
  - `@shipfox/api-server`: `defaultModules({runnersModule})` to replace only the runners module (`DefaultModulesOptions` export).
  - Tests and an external fixture verify the public composition surface.

- Migration
  - To enable installation-scoped provisioning: implement `InstallationProvisioningPolicy.filterEligibleWorkspaceIds`, create the module with `createRunnersModule({installationProvisioning: {policy}})`, and pass it to `defaultModules({runnersModule})`.
  - No changes if you do not enable installation provisioning.

<sup>Written for commit 31dcbd4abe8bff6023609bac023238c0803ba68d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

