### PR TITLE
[linear] Move webhooks onto shared processor

### DIFF
--- a/.changeset/swift-herons-glide.md
+++ b/.changeset/swift-herons-glide.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-integration-linear": minor
+"@shipfox/node-fastify": patch
+---
+
+Adds a shared Linear webhook processor that preserves raw-body signatures and receipt-time replay validation.

--- a/libs/api/integration/linear/src/core/webhook-processor.test.ts
+++ b/libs/api/integration/linear/src/core/webhook-processor.test.ts
@@ -1,0 +1,154 @@
+import {createHmac, randomUUID} from 'node:crypto';
+import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
+import {createStoredWebhookRequest} from '@shipfox/api-integration-core-dto';
+import {db} from '#db/db.js';
+import {upsertLinearInstallation} from '#db/installations.js';
+import {linearInstallations} from '#db/schema/installations.js';
+import {createLinearWebhookProcessor} from './webhook-processor.js';
+
+const WEBHOOK_SECRET = 'test-webhook-secret';
+
+function fakeConnection(overrides: Partial<IntegrationConnection> = {}): IntegrationConnection {
+  return {
+    id: randomUUID(),
+    workspaceId: randomUUID(),
+    provider: 'linear',
+    externalAccountId: 'org-1',
+    slug: 'Linear_Acme',
+    displayName: 'Linear Acme',
+    lifecycleStatus: 'active',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function signedRequest(input: {
+  body: Record<string, unknown>;
+  deliveryId?: string | undefined;
+  receivedAt: string;
+}) {
+  const rawBody = Buffer.from(JSON.stringify(input.body));
+  const signature = createHmac('sha256', WEBHOOK_SECRET).update(rawBody).digest('hex');
+
+  return createStoredWebhookRequest({
+    requestId: randomUUID(),
+    routeId: 'linear',
+    receivedAt: input.receivedAt,
+    rawQueryString: '',
+    headers: {
+      'content-type': 'application/json',
+      'linear-delivery': input.deliveryId ?? randomUUID(),
+      'linear-event': String(input.body.type),
+      'linear-signature': signature,
+    },
+    body: rawBody,
+  });
+}
+
+async function seedInstallation(input: {
+  connectionId: string;
+  organizationId: string;
+}): Promise<void> {
+  await upsertLinearInstallation({
+    connectionId: input.connectionId,
+    organizationId: input.organizationId,
+    organizationUrlKey: 'acme',
+    appUserId: 'app-user-1',
+    scopes: ['read', 'write'],
+    status: 'installed',
+  });
+}
+
+describe('Linear webhook processor', () => {
+  beforeEach(async () => {
+    await db().delete(linearInstallations);
+  });
+
+  it('accepts a delayed request that was valid when the adapter received it', async () => {
+    const connection = fakeConnection();
+    const receivedAt = new Date(Date.now() - 10 * 60_000).toISOString();
+    const webhookTimestamp = new Date(receivedAt).getTime();
+    const publishIntegrationEventReceived = vi.fn(() => Promise.resolve({published: true}));
+    const processor = createLinearWebhookProcessor({
+      coreDb: db,
+      publishIntegrationEventReceived,
+      recordDeliveryOnly: vi.fn(() => Promise.resolve()),
+      getIntegrationConnectionById: vi.fn(() => Promise.resolve(connection)),
+    });
+    await seedInstallation({connectionId: connection.id, organizationId: 'org-delayed'});
+    const request = signedRequest({
+      receivedAt,
+      body: {
+        action: 'create',
+        type: 'Issue',
+        organizationId: 'org-delayed',
+        webhookTimestamp,
+        data: {id: 'issue-1'},
+      },
+    });
+
+    const result = await processor.process(request);
+
+    expect(result).toMatchObject({outcome: 'processed'});
+    expect(publishIntegrationEventReceived).toHaveBeenCalledTimes(1);
+  });
+
+  it('discards a request that was stale when the adapter received it', async () => {
+    const receivedAt = new Date().toISOString();
+    const publishIntegrationEventReceived = vi.fn(() => Promise.resolve({published: true}));
+    const processor = createLinearWebhookProcessor({
+      coreDb: db,
+      publishIntegrationEventReceived,
+      recordDeliveryOnly: vi.fn(() => Promise.resolve()),
+      getIntegrationConnectionById: vi.fn(),
+    });
+    const request = signedRequest({
+      receivedAt,
+      body: {
+        action: 'create',
+        type: 'Issue',
+        organizationId: 'org-stale',
+        webhookTimestamp: new Date(receivedAt).getTime() - 60_001,
+        data: {id: 'issue-1'},
+      },
+    });
+
+    const result = await processor.process(request);
+
+    expect(result).toMatchObject({outcome: 'discarded', reason: 'stale_at_receipt'});
+    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+  });
+
+  it('records and drops an unsupported signed event', async () => {
+    const connection = fakeConnection();
+    const receivedAt = new Date().toISOString();
+    const deliveryId = randomUUID();
+    const recordDeliveryOnly = vi.fn(() => Promise.resolve());
+    const processor = createLinearWebhookProcessor({
+      coreDb: db,
+      publishIntegrationEventReceived: vi.fn(() => Promise.resolve({published: true})),
+      recordDeliveryOnly,
+      getIntegrationConnectionById: vi.fn(() => Promise.resolve(connection)),
+    });
+    await seedInstallation({connectionId: connection.id, organizationId: 'org-unsupported'});
+    const request = signedRequest({
+      deliveryId,
+      receivedAt,
+      body: {
+        action: 'create',
+        type: 'Reaction',
+        organizationId: 'org-unsupported',
+        webhookTimestamp: new Date(receivedAt).getTime(),
+        data: {id: 'reaction-1'},
+      },
+    });
+
+    const result = await processor.process(request);
+
+    expect(result).toEqual({outcome: 'discarded', reason: 'unsupported_event', deliveryId});
+    expect(recordDeliveryOnly).toHaveBeenCalledWith(
+      expect.objectContaining({provider: 'linear', deliveryId}),
+    );
+  });
+});

--- a/libs/api/integration/linear/src/core/webhook-processor.ts
+++ b/libs/api/integration/linear/src/core/webhook-processor.ts
@@ -1,0 +1,127 @@
+import {Buffer} from 'node:buffer';
+import {
+  decodeWebhookBody,
+  type GetIntegrationConnectionByIdFn,
+  type PublishIntegrationEventReceivedFn,
+  type RecordDeliveryOnlyFn,
+  type StoredWebhookRequest,
+  type WebhookProcessingResult,
+} from '@shipfox/api-integration-core-dto';
+import {
+  LINEAR_PROVIDER,
+  linearWebhookBaseEnvelopeSchema,
+} from '@shipfox/api-integration-linear-dto';
+import {verifyHexHmacSignature} from '@shipfox/node-fastify';
+import {logger} from '@shipfox/node-opentelemetry';
+import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
+import {config} from '#config.js';
+import {handleLinearWebhook} from '#core/webhook.js';
+
+const DELIVERY_HEADER = 'linear-delivery';
+const EVENT_HEADER = 'linear-event';
+const SIGNATURE_HEADER = 'linear-signature';
+const WEBHOOK_REPLAY_WINDOW_MS = 60_000;
+
+export interface CreateLinearWebhookProcessorOptions {
+  coreDb: () => NodePgDatabase<Record<string, unknown>>;
+  publishIntegrationEventReceived: PublishIntegrationEventReceivedFn;
+  recordDeliveryOnly: RecordDeliveryOnlyFn;
+  getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
+}
+
+export interface LinearWebhookProcessor {
+  process(request: StoredWebhookRequest): Promise<WebhookProcessingResult>;
+}
+
+export function createLinearWebhookProcessor(
+  options: CreateLinearWebhookProcessorOptions,
+): LinearWebhookProcessor {
+  return {process: (request) => processLinearWebhookRequest(options, request)};
+}
+
+async function processLinearWebhookRequest(
+  options: CreateLinearWebhookProcessorOptions,
+  request: StoredWebhookRequest,
+): Promise<WebhookProcessingResult> {
+  if (request.route_id !== 'linear') {
+    throw new Error(`Linear processor cannot process ${request.route_id} requests`);
+  }
+
+  const deliveryId = request.headers[DELIVERY_HEADER];
+  const event = request.headers[EVENT_HEADER];
+  const signature = request.headers[SIGNATURE_HEADER];
+  if (!deliveryId || !event || !signature) {
+    return {outcome: 'discarded', reason: 'missing_required_input'};
+  }
+
+  const rawBody = Buffer.from(decodeWebhookBody(request.body));
+  if (
+    !verifyHexHmacSignature({
+      rawBody,
+      signature,
+      secret: config.LINEAR_WEBHOOK_SIGNING_SECRET,
+    })
+  ) {
+    return {outcome: 'discarded', reason: 'invalid_signature', deliveryId};
+  }
+
+  let rawPayload: unknown;
+  try {
+    rawPayload = JSON.parse(rawBody.toString('utf8'));
+  } catch (error) {
+    logger().warn({deliveryId, err: error}, 'linear webhook payload JSON parse failed');
+    return {outcome: 'discarded', reason: 'malformed_payload', deliveryId};
+  }
+
+  const payload = linearWebhookBaseEnvelopeSchema.safeParse(rawPayload);
+  if (!payload.success) {
+    logger().warn(
+      {deliveryId, issues: payload.error.issues},
+      'linear webhook envelope failed schema validation',
+    );
+    await recordSignedDeliveryOnly(options, deliveryId);
+    return {outcome: 'discarded', reason: 'unsupported_event', deliveryId};
+  }
+
+  const receivedAt = new Date(request.received_at).getTime();
+  if (Math.abs(receivedAt - payload.data.webhookTimestamp) > WEBHOOK_REPLAY_WINDOW_MS) {
+    return {outcome: 'discarded', reason: 'stale_at_receipt', deliveryId};
+  }
+
+  if (event !== payload.data.type) {
+    logger().warn(
+      {deliveryId, event, type: payload.data.type},
+      'linear webhook event header did not match payload type',
+    );
+    await recordSignedDeliveryOnly(options, deliveryId);
+    return {outcome: 'discarded', reason: 'unsupported_event', deliveryId};
+  }
+
+  const result = await options.coreDb().transaction(async (tx) =>
+    handleLinearWebhook({
+      tx,
+      deliveryId,
+      payload: payload.data,
+      rawPayload,
+      publishIntegrationEventReceived: options.publishIntegrationEventReceived,
+      recordDeliveryOnly: options.recordDeliveryOnly,
+      getIntegrationConnectionById: options.getIntegrationConnectionById,
+    }),
+  );
+
+  if (result.outcome === 'published') return {outcome: 'processed', deliveryId};
+  if (result.outcome === 'duplicate') return {outcome: 'duplicate', deliveryId};
+  if (result.outcome === 'unsupported-event') {
+    return {outcome: 'discarded', reason: 'unsupported_event', deliveryId};
+  }
+  return {outcome: 'discarded', reason: 'connection_unavailable', deliveryId};
+}
+
+async function recordSignedDeliveryOnly(
+  options: Pick<CreateLinearWebhookProcessorOptions, 'coreDb' | 'recordDeliveryOnly'>,
+  deliveryId: string,
+): Promise<void> {
+  await options.coreDb().transaction(async (tx) => {
+    await options.recordDeliveryOnly({tx, provider: LINEAR_PROVIDER, deliveryId});
+  });
+}

--- a/libs/api/integration/linear/src/index.ts
+++ b/libs/api/integration/linear/src/index.ts
@@ -68,6 +68,11 @@ export {
 export type {HandleLinearWebhookOutcome, HandleLinearWebhookParams} from '#core/webhook.js';
 export {handleLinearWebhook} from '#core/webhook.js';
 export type {
+  CreateLinearWebhookProcessorOptions,
+  LinearWebhookProcessor,
+} from '#core/webhook-processor.js';
+export {createLinearWebhookProcessor} from '#core/webhook-processor.js';
+export type {
   LinearInstallation,
   LinearInstallationStatus,
   UpdateLinearInstallationTokenExpiryParams,

--- a/libs/api/integration/linear/src/presentation/routes/webhooks.test.ts
+++ b/libs/api/integration/linear/src/presentation/routes/webhooks.test.ts
@@ -1,5 +1,6 @@
 import {createHmac, randomUUID} from 'node:crypto';
 import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
+import {WEBHOOK_MAX_RAW_BODY_BYTES} from '@shipfox/api-integration-core-dto';
 import {closeApp, createApp} from '@shipfox/node-fastify';
 import type {FastifyInstance} from 'fastify';
 import {db} from '#db/db.js';
@@ -263,6 +264,42 @@ describe('Linear webhook route', () => {
     });
 
     expect(res.statusCode).toBe(401);
+    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(recordDeliveryOnly).not.toHaveBeenCalled();
+  });
+
+  it('rejects a body too large for the shared webhook request before processing it', async () => {
+    const {app, publishIntegrationEventReceived, recordDeliveryOnly} = await createTestApp();
+    const body = 'a'.repeat(WEBHOOK_MAX_RAW_BODY_BYTES + 1);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/integrations/linear',
+      headers: signedHeaders(body, 'Issue', randomUUID()),
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(413);
+    expect(res.json()).toEqual({code: 'body-too-large'});
+    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(recordDeliveryOnly).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid stored request metadata before processing it', async () => {
+    const {app, publishIntegrationEventReceived, recordDeliveryOnly} = await createTestApp();
+    const body = JSON.stringify(linearPayload());
+    const headers = signedHeaders(body, 'Issue', randomUUID());
+    headers['linear-event'] = 'a'.repeat(8 * 1024 + 1);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/integrations/linear',
+      headers,
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toEqual({code: 'invalid-webhook-request'});
     expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
     expect(recordDeliveryOnly).not.toHaveBeenCalled();
   });

--- a/libs/api/integration/linear/src/presentation/routes/webhooks.ts
+++ b/libs/api/integration/linear/src/presentation/routes/webhooks.ts
@@ -1,30 +1,28 @@
-import {Buffer} from 'node:buffer';
+import {randomUUID} from 'node:crypto';
 import type {
   GetIntegrationConnectionByIdFn,
-  IntegrationTx,
   PublishIntegrationEventReceivedFn,
   RecordDeliveryOnlyFn,
+  StoredWebhookRequest,
+  WebhookProcessingResult,
 } from '@shipfox/api-integration-core-dto';
 import {
-  LINEAR_PROVIDER,
-  linearWebhookBaseEnvelopeSchema,
-} from '@shipfox/api-integration-linear-dto';
+  createStoredWebhookRequest,
+  WEBHOOK_MAX_RAW_BODY_BYTES,
+} from '@shipfox/api-integration-core-dto';
 import {
+  ClientError,
   defineRoute,
   type RouteGroup,
   rawBodyPlugin,
-  verifyHexHmacSignature,
   WEBHOOK_BODY_LIMIT,
 } from '@shipfox/node-fastify';
-import {logger} from '@shipfox/node-opentelemetry';
 import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
-import {config} from '#config.js';
-import {handleLinearWebhook} from '#core/webhook.js';
+import {createLinearWebhookProcessor} from '#core/webhook-processor.js';
 
 const DELIVERY_HEADER = 'linear-delivery';
 const EVENT_HEADER = 'linear-event';
 const SIGNATURE_HEADER = 'linear-signature';
-const WEBHOOK_REPLAY_WINDOW_MS = 60_000;
 
 export interface CreateLinearWebhookRoutesOptions {
   coreDb: () => NodePgDatabase<Record<string, unknown>>;
@@ -34,6 +32,7 @@ export interface CreateLinearWebhookRoutesOptions {
 }
 
 export function createLinearWebhookRoutes(options: CreateLinearWebhookRoutesOptions): RouteGroup {
+  const processor = createLinearWebhookProcessor(options);
   const webhookRoute = defineRoute({
     method: 'POST',
     path: '/',
@@ -41,6 +40,7 @@ export function createLinearWebhookRoutes(options: CreateLinearWebhookRoutesOpti
     description: 'Linear webhook receiver.',
     options: {bodyLimit: WEBHOOK_BODY_LIMIT},
     handler: async (request, reply) => {
+      const receivedAt = new Date().toISOString();
       const deliveryHeader = request.headers[DELIVERY_HEADER];
       const event = request.headers[EVENT_HEADER];
       const signature = request.headers[SIGNATURE_HEADER];
@@ -59,76 +59,22 @@ export function createLinearWebhookRoutes(options: CreateLinearWebhookRoutesOpti
       }
 
       const body = request.body;
-      if (!Buffer.isBuffer(body)) {
+      if (!(body instanceof Uint8Array)) {
         reply.code(400);
         return {error: 'expected raw JSON body'};
       }
-      const rawBody = body.toString('utf8');
+      const result = await processor.process(
+        createLinearStoredWebhookRequest(
+          {
+            body,
+            headers: request.headers,
+            rawQueryString: request.raw.url?.split('?')[1] ?? '',
+          },
+          receivedAt,
+        ),
+      );
 
-      if (
-        !verifyHexHmacSignature({
-          rawBody,
-          signature,
-          secret: config.LINEAR_WEBHOOK_SIGNING_SECRET,
-        })
-      ) {
-        reply.code(401);
-        return {error: 'invalid signature'};
-      }
-
-      let parsedJson: unknown;
-      try {
-        parsedJson = JSON.parse(rawBody);
-      } catch (error) {
-        logger().warn(
-          {deliveryId: deliveryHeader, err: error},
-          'linear webhook payload JSON parse failed',
-        );
-        reply.code(400);
-        return {error: 'malformed JSON'};
-      }
-
-      const payload = linearWebhookBaseEnvelopeSchema.safeParse(parsedJson);
-      if (!payload.success) {
-        logger().warn(
-          {deliveryId: deliveryHeader, issues: payload.error.issues},
-          'linear webhook envelope failed schema validation',
-        );
-        await recordSignedDeliveryOnly(options, deliveryHeader);
-        reply.code(200);
-        return null;
-      }
-
-      if (Math.abs(Date.now() - payload.data.webhookTimestamp) > WEBHOOK_REPLAY_WINDOW_MS) {
-        reply.code(401);
-        return {error: 'stale webhook timestamp'};
-      }
-
-      if (event !== payload.data.type) {
-        logger().warn(
-          {deliveryId: deliveryHeader, event, type: payload.data.type},
-          'linear webhook event header did not match payload type',
-        );
-        await recordSignedDeliveryOnly(options, deliveryHeader);
-        reply.code(200);
-        return null;
-      }
-
-      await options.coreDb().transaction(async (tx) => {
-        await handleLinearWebhook({
-          tx,
-          // Linear documents this header as the delivery UUID; the signed timestamp is per-send.
-          deliveryId: deliveryHeader,
-          payload: payload.data,
-          rawPayload: parsedJson,
-          publishIntegrationEventReceived: options.publishIntegrationEventReceived,
-          recordDeliveryOnly: options.recordDeliveryOnly,
-          getIntegrationConnectionById: options.getIntegrationConnectionById,
-        });
-      });
-
-      reply.code(200);
-      return null;
+      return sendLinearWebhookResponse(reply, result);
     },
   });
 
@@ -140,15 +86,67 @@ export function createLinearWebhookRoutes(options: CreateLinearWebhookRoutesOpti
   };
 }
 
-async function recordSignedDeliveryOnly(
-  options: Pick<CreateLinearWebhookRoutesOptions, 'coreDb' | 'recordDeliveryOnly'>,
-  deliveryId: string,
-): Promise<void> {
-  await options.coreDb().transaction(async (tx: IntegrationTx) => {
-    await options.recordDeliveryOnly({
-      tx,
-      provider: LINEAR_PROVIDER,
-      deliveryId,
+function createLinearStoredWebhookRequest(
+  input: {
+    body: Uint8Array;
+    headers: Record<string, string | string[] | undefined>;
+    rawQueryString: string;
+  },
+  receivedAt: string,
+): StoredWebhookRequest {
+  if (input.body.byteLength > WEBHOOK_MAX_RAW_BODY_BYTES) {
+    throw new ClientError('Webhook request body is too large', 'body-too-large', {status: 413});
+  }
+
+  try {
+    return createStoredWebhookRequest({
+      requestId: randomUUID(),
+      routeId: 'linear',
+      receivedAt,
+      rawQueryString: input.rawQueryString,
+      headers: linearWebhookHeaders(input.headers),
+      body: input.body,
     });
-  });
+  } catch (error) {
+    throw new ClientError('Webhook request metadata is invalid', 'invalid-webhook-request', {
+      cause: error,
+    });
+  }
+}
+
+function linearWebhookHeaders(headers: Record<string, string | string[] | undefined>) {
+  return Object.fromEntries(
+    ['content-type', DELIVERY_HEADER, EVENT_HEADER, SIGNATURE_HEADER, 'linear-timestamp'].flatMap(
+      (name) => {
+        const value = headers[name];
+        return typeof value === 'string' ? [[name, value]] : [];
+      },
+    ),
+  );
+}
+
+function sendLinearWebhookResponse(
+  reply: {code(statusCode: number): void},
+  result: WebhookProcessingResult,
+) {
+  if (result.outcome !== 'discarded') {
+    reply.code(200);
+    return null;
+  }
+
+  if (result.reason === 'invalid_signature') {
+    reply.code(401);
+    return {error: 'invalid signature'};
+  }
+  if (result.reason === 'stale_at_receipt') {
+    reply.code(401);
+    return {error: 'stale webhook timestamp'};
+  }
+  if (result.reason === 'malformed_payload') {
+    reply.code(400);
+    return {error: 'malformed JSON'};
+  }
+
+  reply.code(200);
+  return null;
 }

--- a/libs/shared/node/fastify/src/webhook-signature.ts
+++ b/libs/shared/node/fastify/src/webhook-signature.ts
@@ -2,7 +2,7 @@ import {Buffer} from 'node:buffer';
 import {createHmac, timingSafeEqual} from 'node:crypto';
 
 export interface VerifyHexHmacSignatureParams {
-  rawBody: string;
+  rawBody: string | Uint8Array;
   signature: string;
   secret: string;
 }


### PR DESCRIPTION
Moves Linear webhook verification, replay-window validation, envelope parsing, and delivery handling behind the shared stored-request processor.

Queued delivery can execute long after ingress, so replay validation must compare Linear's signed timestamp with the adapter's trusted receipt time instead of consumer wall time. The direct route now constructs the same request envelope and maps processing outcomes back to its existing HTTP behavior.

The adapter rejects requests that cannot fit the durable envelope as client errors, preventing oversized bodies or unbounded metadata from reaching the generic 500 handler and Sentry before signature verification.

Exports the Linear processor for composition by the provider-neutral webhook delivery source. Review the outcome-to-response mapping and receipt-time boundary in particular.

Closes ENG-1067

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves Linear webhooks to a shared stored-request processor with raw-body HMAC verification and receipt-time replay validation. The route now builds a durable envelope and returns the same HTTP responses. Addresses ENG-1067.

- New Features
  - Added a shared Linear webhook processor in `@shipfox/api-integration-linear` that verifies raw-body signatures and checks replay against adapter receipt time for queued deliveries.
  - Route delegates to the processor by creating a stored webhook request envelope; preserves existing outcome-to-response behavior.

- Bug Fixes
  - Rejects oversized bodies (> `WEBHOOK_MAX_RAW_BODY_BYTES`) with 413 `body-too-large` and invalid stored-request metadata with 400 `invalid-webhook-request` before hitting the global error handler.
  - Updates `@shipfox/node-fastify` signature verifier to accept `Uint8Array` bodies.

<sup>Written for commit f13625b337f4e143d4c7d3109d59914c345141e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

