### PR TITLE
[runner] Persist workspace provisioner capabilities

### DIFF
--- a/.changeset/bright-sparrows-grow.md
+++ b/.changeset/bright-sparrows-grow.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-runners": minor
+"@shipfox/api-runners-dto": minor
+---
+
+Adds fresh workspace provisioner capability snapshots for managed fallback policy.

--- a/libs/api/runners-dto/src/schemas/poll-demand.ts
+++ b/libs/api/runners-dto/src/schemas/poll-demand.ts
@@ -13,7 +13,7 @@ export const pollDemandTemplateSchema = z.object({
 export const pollDemandBodySchema = z.object({
   wait_seconds: z.number().int().min(0).optional(),
   max_reservations: z.number().int().min(0).max(1000),
-  templates: z.array(pollDemandTemplateSchema).min(1).max(100),
+  templates: z.array(pollDemandTemplateSchema).max(100),
 });
 
 export const demandStatSchema = z.object({

--- a/libs/api/runners/drizzle/0000_initial.sql
+++ b/libs/api/runners/drizzle/0000_initial.sql
@@ -78,6 +78,19 @@ CREATE TABLE "runners_provisioned_runners" (
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
+CREATE TABLE "runners_provisioner_capability_snapshots" (
+	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
+	"workspace_id" uuid NOT NULL,
+	"provisioner_id" uuid NOT NULL,
+	"template_key" text NOT NULL,
+	"labels" text[] NOT NULL,
+	"available_slots" integer NOT NULL,
+	"starting" integer NOT NULL,
+	"running" integer NOT NULL,
+	"advertised_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
 CREATE TABLE "runners_provisioner_tokens" (
 	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
 	"scope" "runners_provisioner_scope" NOT NULL,
@@ -172,6 +185,8 @@ CREATE UNIQUE INDEX "runners_provisioned_runners_provisioner_runner_unique" ON "
 CREATE INDEX "runners_provisioned_runners_workspace_state_updated_idx" ON "runners_provisioned_runners" USING btree ("state","updated_at");--> statement-breakpoint
 CREATE INDEX "runners_provisioned_runners_stale_reaper_idx" ON "runners_provisioned_runners" USING btree ("state","updated_at","reported_at");--> statement-breakpoint
 CREATE INDEX "runners_provisioned_runners_active_template_counts_idx" ON "runners_provisioned_runners" USING btree ("provisioner_id","state","template_key") WHERE "state" in ('starting', 'running') and "template_key" is not null;--> statement-breakpoint
+CREATE INDEX "runners_provisioner_capability_snapshots_workspace_active_idx" ON "runners_provisioner_capability_snapshots" USING btree ("workspace_id","advertised_at");--> statement-breakpoint
+CREATE INDEX "runners_provisioner_capability_snapshots_provisioner_idx" ON "runners_provisioner_capability_snapshots" USING btree ("provisioner_id");--> statement-breakpoint
 CREATE UNIQUE INDEX "runners_provisioner_tokens_hashed_token_unique" ON "runners_provisioner_tokens" USING btree ("hashed_token");--> statement-breakpoint
 CREATE INDEX "runners_provisioner_tokens_workspace_last_seen_idx" ON "runners_provisioner_tokens" USING btree ("workspace_id","last_seen_at" DESC NULLS LAST,"id" DESC NULLS LAST);--> statement-breakpoint
 CREATE UNIQUE INDEX "runners_rate_limits_window_unique" ON "runners_rate_limits" USING btree ("action","scope","identifier_hmac","window_start");--> statement-breakpoint

--- a/libs/api/runners/drizzle/meta/0000_snapshot.json
+++ b/libs/api/runners/drizzle/meta/0000_snapshot.json
@@ -754,6 +754,119 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
+    "public.runners_provisioner_capability_snapshots": {
+      "name": "runners_provisioner_capability_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available_slots": {
+          "name": "available_slots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starting": {
+          "name": "starting",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "running": {
+          "name": "running",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "advertised_at": {
+          "name": "advertised_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_provisioner_capability_snapshots_workspace_active_idx": {
+          "name": "runners_provisioner_capability_snapshots_workspace_active_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "advertised_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_provisioner_capability_snapshots_provisioner_idx": {
+          "name": "runners_provisioner_capability_snapshots_provisioner_idx",
+          "columns": [
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
     "public.runners_provisioner_tokens": {
       "name": "runners_provisioner_tokens",
       "schema": "",

--- a/libs/api/runners/src/core/entities/provisioner-capability-snapshot.ts
+++ b/libs/api/runners/src/core/entities/provisioner-capability-snapshot.ts
@@ -1,0 +1,12 @@
+export interface ProvisionerCapabilitySnapshot {
+  id: string;
+  workspaceId: string;
+  provisionerId: string;
+  templateKey: string;
+  labels: string[];
+  availableSlots: number;
+  starting: number;
+  running: number;
+  advertisedAt: Date;
+  createdAt: Date;
+}

--- a/libs/api/runners/src/core/index.ts
+++ b/libs/api/runners/src/core/index.ts
@@ -4,6 +4,7 @@ export type {
   ProvisionedRunner,
   ProvisionedRunnerState,
 } from './entities/provisioned-runner.js';
+export type {ProvisionerCapabilitySnapshot} from './entities/provisioner-capability-snapshot.js';
 export type {
   ActiveProvisionerToken,
   ProvisionerScope,
@@ -45,6 +46,7 @@ export {
   reconcileProvisionedRunners,
   reportProvisionedRunners,
 } from './provisioned-runners.js';
+export {hasActiveWorkspaceProvisionerCapability} from './provisioner-capability-snapshots.js';
 export {
   createInstallationProvisionerToken,
   createWorkspaceProvisionerToken,

--- a/libs/api/runners/src/core/provisioner-capability-snapshots.test.ts
+++ b/libs/api/runners/src/core/provisioner-capability-snapshots.test.ts
@@ -1,0 +1,35 @@
+import {eq} from 'drizzle-orm';
+import {config} from '#config.js';
+import {db} from '#db/db.js';
+import {publishWorkspaceProvisionerCapabilitySnapshot} from '#db/provisioner-capability-snapshots.js';
+import {provisionerCapabilitySnapshots} from '#db/schema/provisioner-capability-snapshots.js';
+import {provisionerTokenFactory} from '#test/index.js';
+import {hasActiveWorkspaceProvisionerCapability} from './provisioner-capability-snapshots.js';
+
+describe('workspace provisioner capability core', () => {
+  it('applies the configured active window to capability matching', async () => {
+    const workspaceId = crypto.randomUUID();
+    const provisioner = await provisionerTokenFactory.create({workspaceId});
+
+    await publishWorkspaceProvisionerCapabilitySnapshot({
+      workspaceId,
+      provisionerId: provisioner.id,
+      templates: [
+        {templateKey: 'linux', labels: ['linux'], availableSlots: 1, starting: 0, running: 0},
+      ],
+    });
+    await db()
+      .update(provisionerCapabilitySnapshots)
+      .set({
+        advertisedAt: new Date(Date.now() - (config.PROVISIONER_ACTIVE_WINDOW_SECONDS + 1) * 1000),
+      })
+      .where(eq(provisionerCapabilitySnapshots.provisionerId, provisioner.id));
+
+    const hasLinux = await hasActiveWorkspaceProvisionerCapability({
+      workspaceId,
+      requiredLabels: ['linux'],
+    });
+
+    expect(hasLinux).toBe(false);
+  });
+});

--- a/libs/api/runners/src/core/provisioner-capability-snapshots.ts
+++ b/libs/api/runners/src/core/provisioner-capability-snapshots.ts
@@ -1,0 +1,12 @@
+import {config} from '#config.js';
+import {hasActiveWorkspaceProvisionerCapability as hasActiveWorkspaceProvisionerCapabilityDb} from '#db/provisioner-capability-snapshots.js';
+
+export function hasActiveWorkspaceProvisionerCapability(params: {
+  workspaceId: string;
+  requiredLabels: string[];
+}): Promise<boolean> {
+  return hasActiveWorkspaceProvisionerCapabilityDb({
+    ...params,
+    windowSeconds: config.PROVISIONER_ACTIVE_WINDOW_SECONDS,
+  });
+}

--- a/libs/api/runners/src/db/db.ts
+++ b/libs/api/runners/src/db/db.ts
@@ -5,6 +5,7 @@ import {manualRegistrationTokens} from './schema/manual-registration-tokens.js';
 import {runnersOutbox} from './schema/outbox.js';
 import {pendingJobExecutions} from './schema/pending-job-executions.js';
 import {provisionedRunners} from './schema/provisioned-runners.js';
+import {provisionerCapabilitySnapshots} from './schema/provisioner-capability-snapshots.js';
 import {provisionerTokens} from './schema/provisioner-tokens.js';
 import {runnersRateLimits} from './schema/rate-limits.js';
 import {reservations} from './schema/reservations.js';
@@ -15,6 +16,7 @@ export const schema = {
   ephemeralRegistrationTokens,
   pendingJobExecutions,
   provisionedRunners,
+  provisionerCapabilitySnapshots,
   provisionerTokens,
   runnersRateLimits,
   reservations,

--- a/libs/api/runners/src/db/index.ts
+++ b/libs/api/runners/src/db/index.ts
@@ -57,6 +57,12 @@ export {
   reconcileProvisionedRunners,
   reportProvisionedRunners,
 } from './provisioned-runners.js';
+export {
+  hasActiveWorkspaceProvisionerCapability,
+  listActiveWorkspaceProvisionerCapabilitySnapshots,
+  listStaleWorkspaceProvisionerCapabilitySnapshots,
+  publishWorkspaceProvisionerCapabilitySnapshot,
+} from './provisioner-capability-snapshots.js';
 export type {CreateProvisionerTokenParams} from './provisioner-tokens.js';
 export {
   createProvisionerToken,

--- a/libs/api/runners/src/db/provisioner-capability-snapshots.test.ts
+++ b/libs/api/runners/src/db/provisioner-capability-snapshots.test.ts
@@ -1,0 +1,175 @@
+import {and, eq} from 'drizzle-orm';
+import {db} from '#db/db.js';
+import {
+  hasActiveWorkspaceProvisionerCapability,
+  listActiveWorkspaceProvisionerCapabilitySnapshots,
+  listStaleWorkspaceProvisionerCapabilitySnapshots,
+  publishWorkspaceProvisionerCapabilitySnapshot,
+} from '#db/provisioner-capability-snapshots.js';
+import {provisionerCapabilitySnapshots} from '#db/schema/provisioner-capability-snapshots.js';
+import {provisionerTokens} from '#db/schema/provisioner-tokens.js';
+import {provisionerTokenFactory} from '#test/index.js';
+
+describe('workspace provisioner capability snapshots', () => {
+  let workspaceId: string;
+
+  beforeEach(() => {
+    workspaceId = crypto.randomUUID();
+  });
+
+  it('atomically replaces one provisioner complete template snapshot', async () => {
+    const provisioner = await provisionerTokenFactory.create({workspaceId});
+
+    await publishWorkspaceProvisionerCapabilitySnapshot({
+      workspaceId,
+      provisionerId: provisioner.id,
+      templates: [template('linux', ['linux'], 4, 1, 3), template('macos', ['macos'], 2, 0, 2)],
+    });
+    await publishWorkspaceProvisionerCapabilitySnapshot({
+      workspaceId,
+      provisionerId: provisioner.id,
+      templates: [template('linux-arm64', ['linux', 'arm64'], 0, 1, 0)],
+    });
+
+    const rows = await snapshotsFor(provisioner.id);
+    expect(rows).toEqual([
+      expect.objectContaining({
+        templateKey: 'linux-arm64',
+        labels: ['arm64', 'linux'],
+        availableSlots: 0,
+        starting: 1,
+        running: 0,
+      }),
+    ]);
+  });
+
+  it('keeps zero-slot overlapping capability active for every workspace provisioner', async () => {
+    const first = await provisionerTokenFactory.create({workspaceId});
+    const second = await provisionerTokenFactory.create({workspaceId});
+
+    await publishWorkspaceProvisionerCapabilitySnapshot({
+      workspaceId,
+      provisionerId: first.id,
+      templates: [template('linux', ['linux', 'x64'], 0, 0, 1)],
+    });
+    await publishWorkspaceProvisionerCapabilitySnapshot({
+      workspaceId,
+      provisionerId: second.id,
+      templates: [template('linux-gpu', ['linux', 'gpu'], 2, 1, 1)],
+    });
+
+    const active = await listActiveWorkspaceProvisionerCapabilitySnapshots({
+      workspaceId,
+      windowSeconds: 60,
+    });
+    const hasLinux = await hasActiveWorkspaceProvisionerCapability({
+      workspaceId,
+      requiredLabels: ['linux'],
+      windowSeconds: 60,
+    });
+    const hasLinuxX64 = await hasActiveWorkspaceProvisionerCapability({
+      workspaceId,
+      requiredLabels: ['linux', 'x64'],
+      windowSeconds: 60,
+    });
+
+    expect(active).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({provisionerId: first.id, availableSlots: 0}),
+        expect.objectContaining({provisionerId: second.id, labels: ['gpu', 'linux']}),
+      ]),
+    );
+    expect(hasLinux).toBe(true);
+    expect(hasLinuxX64).toBe(true);
+  });
+
+  it('requires every advertised label to be present, not just an overlap', async () => {
+    const provisioner = await provisionerTokenFactory.create({workspaceId});
+
+    await publishWorkspaceProvisionerCapabilitySnapshot({
+      workspaceId,
+      provisionerId: provisioner.id,
+      templates: [template('linux', ['linux'], 1, 0, 0)],
+    });
+
+    const hasLinuxArm64 = await hasActiveWorkspaceProvisionerCapability({
+      workspaceId,
+      requiredLabels: ['linux', 'arm64'],
+      windowSeconds: 60,
+    });
+
+    expect(hasLinuxArm64).toBe(false);
+  });
+
+  it('excludes stale and revoked provisioner capability from active matching', async () => {
+    const staleProvisioner = await provisionerTokenFactory.create({workspaceId});
+    const revokedProvisioner = await provisionerTokenFactory.create({workspaceId});
+
+    await publishWorkspaceProvisionerCapabilitySnapshot({
+      workspaceId,
+      provisionerId: staleProvisioner.id,
+      templates: [template('stale-linux', ['linux'], 1, 0, 1)],
+    });
+    await publishWorkspaceProvisionerCapabilitySnapshot({
+      workspaceId,
+      provisionerId: revokedProvisioner.id,
+      templates: [template('revoked-macos', ['macos'], 1, 0, 1)],
+    });
+    await db()
+      .update(provisionerCapabilitySnapshots)
+      .set({advertisedAt: new Date(Date.now() - 61_000)})
+      .where(eq(provisionerCapabilitySnapshots.provisionerId, staleProvisioner.id));
+    await db()
+      .update(provisionerTokens)
+      .set({revokedAt: new Date()})
+      .where(eq(provisionerTokens.id, revokedProvisioner.id));
+
+    const active = await listActiveWorkspaceProvisionerCapabilitySnapshots({
+      workspaceId,
+      windowSeconds: 60,
+    });
+    const stale = await listStaleWorkspaceProvisionerCapabilitySnapshots({
+      workspaceId,
+      windowSeconds: 60,
+    });
+    const hasLinux = await hasActiveWorkspaceProvisionerCapability({
+      workspaceId,
+      requiredLabels: ['linux'],
+      windowSeconds: 60,
+    });
+    const hasMacos = await hasActiveWorkspaceProvisionerCapability({
+      workspaceId,
+      requiredLabels: ['macos'],
+      windowSeconds: 60,
+    });
+
+    expect(active).toEqual([]);
+    expect(stale.map((snapshot) => snapshot.provisionerId).sort()).toEqual(
+      [staleProvisioner.id, revokedProvisioner.id].sort(),
+    );
+    expect(hasLinux).toBe(false);
+    expect(hasMacos).toBe(false);
+  });
+
+  function snapshotsFor(provisionerId: string) {
+    return db()
+      .select()
+      .from(provisionerCapabilitySnapshots)
+      .where(
+        and(
+          eq(provisionerCapabilitySnapshots.workspaceId, workspaceId),
+          eq(provisionerCapabilitySnapshots.provisionerId, provisionerId),
+        ),
+      );
+  }
+
+  function template(
+    templateKey: string,
+    labels: string[],
+    availableSlots: number,
+    starting: number,
+    running: number,
+  ) {
+    return {templateKey, labels, availableSlots, starting, running};
+  }
+});

--- a/libs/api/runners/src/db/provisioner-capability-snapshots.ts
+++ b/libs/api/runners/src/db/provisioner-capability-snapshots.ts
@@ -1,0 +1,130 @@
+import {canonicalizeLabels} from '@shipfox/runner-labels';
+import {and, arrayContains, eq, gt, isNotNull, isNull, lte, or, sql} from 'drizzle-orm';
+import type {ProvisionerCapabilitySnapshot} from '#core/entities/provisioner-capability-snapshot.js';
+import {db} from './db.js';
+import type {ReservationTemplate} from './reservations.js';
+import {
+  provisionerCapabilitySnapshots,
+  toProvisionerCapabilitySnapshot,
+} from './schema/provisioner-capability-snapshots.js';
+import {provisionerTokens} from './schema/provisioner-tokens.js';
+
+export async function publishWorkspaceProvisionerCapabilitySnapshot(params: {
+  workspaceId: string;
+  provisionerId: string;
+  templates: ReservationTemplate[];
+}): Promise<void> {
+  await db().transaction(async (tx) => {
+    await tx
+      .delete(provisionerCapabilitySnapshots)
+      .where(eq(provisionerCapabilitySnapshots.provisionerId, params.provisionerId));
+
+    if (params.templates.length === 0) return;
+
+    await tx.insert(provisionerCapabilitySnapshots).values(
+      params.templates.map((template) => ({
+        workspaceId: params.workspaceId,
+        provisionerId: params.provisionerId,
+        templateKey: template.templateKey,
+        labels: [...canonicalizeLabels(template.labels)],
+        availableSlots: template.availableSlots,
+        starting: template.starting,
+        running: template.running,
+      })),
+    );
+  });
+}
+
+export async function listActiveWorkspaceProvisionerCapabilitySnapshots(params: {
+  workspaceId: string;
+  windowSeconds: number;
+}): Promise<ProvisionerCapabilitySnapshot[]> {
+  const rows = await db()
+    .select({snapshot: provisionerCapabilitySnapshots})
+    .from(provisionerCapabilitySnapshots)
+    .innerJoin(
+      provisionerTokens,
+      eq(provisionerTokens.id, provisionerCapabilitySnapshots.provisionerId),
+    )
+    .where(and(...activeWorkspaceProvisionerCapabilityConditions(params)));
+
+  return rows.map(({snapshot}) => toProvisionerCapabilitySnapshot(snapshot));
+}
+
+export async function listStaleWorkspaceProvisionerCapabilitySnapshots(params: {
+  workspaceId: string;
+  windowSeconds: number;
+}): Promise<ProvisionerCapabilitySnapshot[]> {
+  const rows = await db()
+    .select({snapshot: provisionerCapabilitySnapshots})
+    .from(provisionerCapabilitySnapshots)
+    .innerJoin(
+      provisionerTokens,
+      eq(provisionerTokens.id, provisionerCapabilitySnapshots.provisionerId),
+    )
+    .where(
+      and(
+        eq(provisionerCapabilitySnapshots.workspaceId, params.workspaceId),
+        or(
+          lte(
+            provisionerCapabilitySnapshots.advertisedAt,
+            sql`now() - (${params.windowSeconds} || ' seconds')::interval`,
+          ),
+          eq(provisionerTokens.scope, 'installation'),
+          isNull(provisionerTokens.workspaceId),
+          provisionerTokenIsUnavailable(),
+        ),
+      ),
+    );
+
+  return rows.map(({snapshot}) => toProvisionerCapabilitySnapshot(snapshot));
+}
+
+export async function hasActiveWorkspaceProvisionerCapability(params: {
+  workspaceId: string;
+  requiredLabels: string[];
+  windowSeconds: number;
+}): Promise<boolean> {
+  const [row] = await db()
+    .select({id: provisionerCapabilitySnapshots.id})
+    .from(provisionerCapabilitySnapshots)
+    .innerJoin(
+      provisionerTokens,
+      eq(provisionerTokens.id, provisionerCapabilitySnapshots.provisionerId),
+    )
+    .where(
+      and(
+        ...activeWorkspaceProvisionerCapabilityConditions(params),
+        arrayContains(provisionerCapabilitySnapshots.labels, [
+          ...canonicalizeLabels(params.requiredLabels),
+        ]),
+      ),
+    )
+    .limit(1);
+
+  return row !== undefined;
+}
+
+function activeWorkspaceProvisionerCapabilityConditions(params: {
+  workspaceId: string;
+  windowSeconds: number;
+}) {
+  return [
+    eq(provisionerCapabilitySnapshots.workspaceId, params.workspaceId),
+    eq(provisionerTokens.workspaceId, params.workspaceId),
+    eq(provisionerTokens.scope, 'workspace' as const),
+    isNull(provisionerTokens.revokedAt),
+    or(isNull(provisionerTokens.expiresAt), gt(provisionerTokens.expiresAt, sql`now()`)),
+    gt(
+      provisionerCapabilitySnapshots.advertisedAt,
+      sql`now() - (${params.windowSeconds} || ' seconds')::interval`,
+    ),
+  ];
+}
+
+function provisionerTokenIsUnavailable() {
+  return or(
+    isNotNull(provisionerTokens.revokedAt),
+    and(isNotNull(provisionerTokens.expiresAt), lte(provisionerTokens.expiresAt, sql`now()`)),
+  );
+}

--- a/libs/api/runners/src/db/schema/provisioner-capability-snapshots.ts
+++ b/libs/api/runners/src/db/schema/provisioner-capability-snapshots.ts
@@ -1,0 +1,46 @@
+import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
+import {index, integer, text, timestamp, uuid} from 'drizzle-orm/pg-core';
+import type {ProvisionerCapabilitySnapshot} from '#core/entities/provisioner-capability-snapshot.js';
+import {pgTable} from './common.js';
+
+export const provisionerCapabilitySnapshots = pgTable(
+  'provisioner_capability_snapshots',
+  {
+    id: uuidv7PrimaryKey(),
+    workspaceId: uuid('workspace_id').notNull(),
+    provisionerId: uuid('provisioner_id').notNull(),
+    templateKey: text('template_key').notNull(),
+    labels: text('labels').array().notNull(),
+    availableSlots: integer('available_slots').notNull(),
+    starting: integer('starting').notNull(),
+    running: integer('running').notNull(),
+    advertisedAt: timestamp('advertised_at', {withTimezone: true}).notNull().defaultNow(),
+    createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
+  },
+  (table) => [
+    index('runners_provisioner_capability_snapshots_workspace_active_idx').on(
+      table.workspaceId,
+      table.advertisedAt,
+    ),
+    index('runners_provisioner_capability_snapshots_provisioner_idx').on(table.provisionerId),
+  ],
+);
+
+export type ProvisionerCapabilitySnapshotDb = typeof provisionerCapabilitySnapshots.$inferSelect;
+
+export function toProvisionerCapabilitySnapshot(
+  row: ProvisionerCapabilitySnapshotDb,
+): ProvisionerCapabilitySnapshot {
+  return {
+    id: row.id,
+    workspaceId: row.workspaceId,
+    provisionerId: row.provisionerId,
+    templateKey: row.templateKey,
+    labels: row.labels,
+    availableSlots: row.availableSlots,
+    starting: row.starting,
+    running: row.running,
+    advertisedAt: row.advertisedAt,
+    createdAt: row.createdAt,
+  };
+}

--- a/libs/api/runners/src/presentation/routes/poll-demand.test.ts
+++ b/libs/api/runners/src/presentation/routes/poll-demand.test.ts
@@ -14,8 +14,10 @@ import {
   extractBearerToken,
 } from '@shipfox/node-fastify';
 import {vi} from '@shipfox/vitest/vi';
+import {eq} from 'drizzle-orm';
 import type {FastifyInstance, FastifyRequest} from 'fastify';
 import {db} from '#db/db.js';
+import {provisionerCapabilitySnapshots} from '#db/schema/provisioner-capability-snapshots.js';
 import {runningJobExecutions} from '#db/schema/running-job-executions.js';
 import {
   provisionedRunnerCountDivergenceCount,
@@ -137,6 +139,33 @@ describe('POST /provisioners/demand/poll', () => {
       reservations: [],
       terminate_provisioned_runner_ids: [],
     });
+    const snapshots = await db()
+      .select()
+      .from(provisionerCapabilitySnapshots)
+      .where(eq(provisionerCapabilitySnapshots.provisionerId, provisionerTokenId));
+    expect(snapshots).toEqual([
+      expect.objectContaining({
+        workspaceId,
+        labels: ['linux'],
+        availableSlots: 1,
+        starting: 0,
+        running: 1,
+      }),
+    ]);
+
+    const withdrawal = await app.inject({
+      method: 'POST',
+      url: '/provisioners/demand/poll',
+      headers: {authorization: `Bearer ${VALID_PROVISIONER_TOKEN}`},
+      payload: {wait_seconds: 0, max_reservations: 0, templates: []},
+    });
+    const clearedSnapshots = await db()
+      .select()
+      .from(provisionerCapabilitySnapshots)
+      .where(eq(provisionerCapabilitySnapshots.provisionerId, provisionerTokenId));
+
+    expect(withdrawal.statusCode).toBe(200);
+    expect(clearedSnapshots).toEqual([]);
   });
 
   it('returns terminate intent ids for active provisioned runners with cancelled latest jobs', async () => {

--- a/libs/api/runners/src/presentation/routes/poll-demand.ts
+++ b/libs/api/runners/src/presentation/routes/poll-demand.ts
@@ -6,6 +6,7 @@ import {pollDemandBodySchema, pollDemandResponseSchema} from '@shipfox/api-runne
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {config} from '#config.js';
 import {pollDemand, releaseReservationGrants} from '#core/demand.js';
+import {publishWorkspaceProvisionerCapabilitySnapshot} from '#db/provisioner-capability-snapshots.js';
 import type {ReservationGrant} from '#db/reservations.js';
 import type {CreateRunnersModuleOptions} from '#installation-provisioning.js';
 import {toPollDemandResponseDto} from '#presentation/dto/index.js';
@@ -50,6 +51,19 @@ export function createPollDemandRoute(options: CreateRunnersModuleOptions = {}) 
         }
       });
 
+      const templates = request.body.templates.map((template) => ({
+        templateKey: template.template_key,
+        labels: template.labels,
+        availableSlots: template.available_slots,
+        starting: template.starting,
+        running: template.running,
+      }));
+      await publishWorkspaceProvisionerCapabilitySnapshot({
+        workspaceId,
+        provisionerId: provisionerTokenId,
+        templates,
+      });
+
       const result = await pollDemand({
         workspaceId,
         provisionerId: provisionerTokenId,
@@ -57,13 +71,7 @@ export function createPollDemandRoute(options: CreateRunnersModuleOptions = {}) 
         waitSeconds: request.body.wait_seconds,
         ttlSeconds: config.RESERVATION_TTL_SECONDS,
         terminateIntentLimit: TERMINATE_INTENT_LIMIT,
-        templates: request.body.templates.map((template) => ({
-          templateKey: template.template_key,
-          labels: template.labels,
-          availableSlots: template.available_slots,
-          starting: template.starting,
-          running: template.running,
-        })),
+        templates,
         signal: abortController.signal,
       });
       responseReservations = result.reservations;

--- a/libs/api/runners/test/globalSetup.ts
+++ b/libs/api/runners/test/globalSetup.ts
@@ -8,6 +8,7 @@ export async function setup() {
   createPostgresClient();
 
   await runMigrations(db(), migrationsPath, '__drizzle_migrations_runners');
+  await db().execute(sql`TRUNCATE runners_provisioner_capability_snapshots CASCADE`);
   await db().execute(sql`TRUNCATE runners_provisioned_runners, runners_reservations CASCADE`);
   await db().execute(sql`TRUNCATE runners_provisioner_tokens CASCADE`);
   await db().execute(sql`TRUNCATE runners_ephemeral_registration_tokens CASCADE`);


### PR DESCRIPTION
Persist workspace provisioner capability snapshots

Managed installation capacity must be fallback rather than overflow. Workspace provisioner demand polls now replace each provisioner’s complete capability snapshot, including labels, observed availability, and freshness. Zero-slot and busy templates remain visible so they continue to block managed fallback while the provisioner is active; an empty snapshot withdraws capability immediately.

The new baseline table is folded into the initial runners migration because this schema remains pre-release. Active matching excludes stale, expired, and revoked provisioners while preserving intentional label overlap between provisioners.

Review focus: snapshot replacement semantics and the active-capability predicate that the installation allocator will consume.

Closes ENG-1086

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist workspace provisioner capability snapshots and add an active-capability check for the allocator. Fulfills ENG-1086 by blocking managed fallback when workspace provisioners are active, including zero-slot or busy templates.

- New Features
  - Add `runners_provisioner_capability_snapshots` with atomic per-provisioner replacement; stores template_key, labels, available_slots, starting, running, advertised_at.
  - POST `/provisioners/demand/poll` now records the snapshot; sending `templates: []` withdraws capability immediately. DTO updated in `@shipfox/api-runners-dto` to remove the minimum length on `templates`.
  - Active matching uses the configured freshness window and ignores expired, revoked, or installation-scoped tokens; label match is AND; overlapping labels across provisioners are preserved.
  - Export `hasActiveWorkspaceProvisionerCapability` in `@shipfox/api-runners`, and DB helpers: publish/listActive/listStale/hasActive.

- Migration
  - Run DB migrations. Provisioner clients can send `templates: []` to clear advertised capability.

<sup>Written for commit 378b24e3aacc925c808ea2918a6c51b6764bf46a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

