### PR TITLE
[node-mailer] Centralize mailer configuration

### DIFF
--- a/.changeset/bright-otters-deliver.md
+++ b/.changeset/bright-otters-deliver.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/node-mailer": minor
+"@shipfox/api-auth": patch
+"@shipfox/api-workspaces": patch
+---
+
+Adds a configured shared mailer that owns SMTP delivery settings. `@shipfox/api-auth` and `@shipfox/api-workspaces` drop their own mailer environment variables and factory logic and use the shared `mailer` from `@shipfox/node-mailer` instead.

--- a/libs/api/auth/README.md
+++ b/libs/api/auth/README.md
@@ -49,12 +49,8 @@ Required environment:
 | `AUTH_PASSWORD_ENABLED` | `true` | Enables password and email-verification routes. Set to `false` when another module provides login. Server construction fails if no login method is available. |
 | `RATE_LIMIT_IDENTIFIER_SECRET` | none | Optional secret used to HMAC identifiers before storing rate-limit counters. When unset, the module derives a stable key from `AUTH_JWT_SECRET`. |
 | `CLIENT_BASE_URL` | `http://localhost:5173` | Base URL used in email verification and password reset links. |
-| `MAILER_TRANSPORT` | `console` | Mail transport. Set to `smtp` to send real mail. |
-| `MAILER_FROM` | `noreply@shipfox.local` | Sender used by auth emails. |
-| `SMTP_HOST` | none | Required when `MAILER_TRANSPORT=smtp`. |
-| `SMTP_PORT` | `587` | SMTP server port. |
-| `SMTP_USER` | none | Optional SMTP user. |
-| `SMTP_PASSWORD` | none | Optional SMTP password. |
+
+Email delivery uses the shared `@shipfox/node-mailer` configuration.
 
 When `AUTH_PASSWORD_ENABLED=false`, the module does not register signup, login, password-reset, password-change, or email-verification routes. Refresh, logout, and current-session routes stay available. Another module must contribute a login method before the API server starts.
 

--- a/libs/api/auth/src/config.ts
+++ b/libs/api/auth/src/config.ts
@@ -1,5 +1,4 @@
 import {bool, createConfig, num, str} from '@shipfox/config';
-import {createConsoleMailer, createSmtpMailer, type Mailer} from '@shipfox/node-mailer';
 
 export const config = createConfig({
   AUTH_JWT_SECRET: str({
@@ -47,46 +46,4 @@ export const config = createConfig({
     desc: 'Base URL of the client app. Used to build links in emails such as password resets.',
     default: 'http://localhost:5173',
   }),
-  MAILER_TRANSPORT: str({
-    desc: 'How emails are delivered. Use console to print them to the log, or smtp to send them through an SMTP server.',
-    choices: ['console', 'smtp'],
-    default: 'console',
-  }),
-  MAILER_FROM: str({
-    desc: 'Sender address shown on outgoing emails.',
-    default: 'noreply@shipfox.local',
-  }),
-  SMTP_HOST: str({
-    desc: 'Hostname of the SMTP server. Required when MAILER_TRANSPORT is smtp.',
-    default: undefined,
-  }),
-  SMTP_PORT: num({
-    desc: 'Port of the SMTP server.',
-    default: 587,
-  }),
-  SMTP_USER: str({
-    desc: 'Username for SMTP authentication. Leave it unset if the server needs no login.',
-    default: undefined,
-  }),
-  SMTP_PASSWORD: str({
-    desc: 'Password for SMTP authentication. Leave it unset if the server needs no login.',
-    default: undefined,
-  }),
 });
-
-function createMailer(): Mailer {
-  if (config.MAILER_TRANSPORT === 'smtp') {
-    if (!config.SMTP_HOST) throw new Error('SMTP_HOST is required when MAILER_TRANSPORT=smtp');
-    return createSmtpMailer({
-      host: config.SMTP_HOST,
-      port: config.SMTP_PORT,
-      ...(config.SMTP_USER ? {user: config.SMTP_USER} : {}),
-      ...(config.SMTP_PASSWORD ? {password: config.SMTP_PASSWORD} : {}),
-      from: config.MAILER_FROM,
-    });
-  }
-
-  return createConsoleMailer({from: config.MAILER_FROM});
-}
-
-export const mailer = createMailer();

--- a/libs/api/auth/src/index.test.ts
+++ b/libs/api/auth/src/index.test.ts
@@ -18,6 +18,9 @@ vi.mock('#config.js', () => ({
     AUTH_PASSWORD_ENABLED: true,
     CLIENT_BASE_URL: 'https://app.example.test',
   },
+}));
+
+vi.mock('@shipfox/node-mailer', () => ({
   mailer: {send: vi.fn()},
 }));
 

--- a/libs/api/auth/src/presentation/subscribers/email-send-requested.test.ts
+++ b/libs/api/auth/src/presentation/subscribers/email-send-requested.test.ts
@@ -16,7 +16,7 @@ const testMailer = vi.hoisted(
   },
 );
 
-vi.mock('#config.js', () => ({
+vi.mock('@shipfox/node-mailer', () => ({
   mailer: testMailer.mailer,
 }));
 

--- a/libs/api/auth/src/presentation/subscribers/on-email-verification-send-requested.ts
+++ b/libs/api/auth/src/presentation/subscribers/on-email-verification-send-requested.ts
@@ -1,6 +1,6 @@
 import type {AuthEmailVerificationSendRequestedEvent} from '@shipfox/api-auth-dto';
 import {renderEmail} from '@shipfox/node-email';
-import {mailer} from '#config.js';
+import {mailer} from '@shipfox/node-mailer';
 
 export async function onEmailVerificationSendRequested(
   payload: AuthEmailVerificationSendRequestedEvent,

--- a/libs/api/auth/src/presentation/subscribers/on-password-reset-send-requested.ts
+++ b/libs/api/auth/src/presentation/subscribers/on-password-reset-send-requested.ts
@@ -1,6 +1,6 @@
 import type {AuthPasswordResetSendRequestedEvent} from '@shipfox/api-auth-dto';
 import {renderEmail} from '@shipfox/node-email';
-import {mailer} from '#config.js';
+import {mailer} from '@shipfox/node-mailer';
 
 export async function onPasswordResetSendRequested(
   payload: AuthPasswordResetSendRequestedEvent,

--- a/libs/api/workspaces/README.md
+++ b/libs/api/workspaces/README.md
@@ -16,7 +16,7 @@ pnpm add @shipfox/api-workspaces
 ```
 
 Set `CLIENT_BASE_URL` to the public client URL. Invite emails use this URL for
-their accept links. Set up the shared mailer when invite email must be sent.
+their accept links. Configure `@shipfox/node-mailer` when invite email must be sent.
 
 ## Usage
 
@@ -39,7 +39,7 @@ const membership = await ensureMembership({
 | --- | --- | --- |
 | `CLIENT_BASE_URL` | `http://localhost:5173` | Base URL used in workspace invitation links. |
 
-The package also uses the shared mailer configuration when it sends invitation email.
+Invitation email uses the shared `@shipfox/node-mailer` configuration.
 
 ## Routes / API / Data Model
 

--- a/libs/api/workspaces/src/config.ts
+++ b/libs/api/workspaces/src/config.ts
@@ -1,51 +1,8 @@
-import {createConfig, num, str} from '@shipfox/config';
-import {createConsoleMailer, createSmtpMailer, type Mailer} from '@shipfox/node-mailer';
+import {createConfig, str} from '@shipfox/config';
 
 export const config = createConfig({
   CLIENT_BASE_URL: str({
     desc: 'Base URL of the client app. Used to build links in workspace invitation emails.',
     default: 'http://localhost:5173',
   }),
-  MAILER_TRANSPORT: str({
-    desc: 'How emails are delivered. Use console to print them to the log, or smtp to send them through an SMTP server.',
-    choices: ['console', 'smtp'],
-    default: 'console',
-  }),
-  MAILER_FROM: str({
-    desc: 'Sender address shown on outgoing emails.',
-    default: 'noreply@shipfox.local',
-  }),
-  SMTP_HOST: str({
-    desc: 'Hostname of the SMTP server. Required when MAILER_TRANSPORT is smtp.',
-    default: undefined,
-  }),
-  SMTP_PORT: num({
-    desc: 'Port of the SMTP server.',
-    default: 587,
-  }),
-  SMTP_USER: str({
-    desc: 'Username for SMTP authentication. Leave it unset if the server needs no login.',
-    default: undefined,
-  }),
-  SMTP_PASSWORD: str({
-    desc: 'Password for SMTP authentication. Leave it unset if the server needs no login.',
-    default: undefined,
-  }),
 });
-
-function createMailer(): Mailer {
-  if (config.MAILER_TRANSPORT === 'smtp') {
-    if (!config.SMTP_HOST) throw new Error('SMTP_HOST is required when MAILER_TRANSPORT=smtp');
-    return createSmtpMailer({
-      host: config.SMTP_HOST,
-      port: config.SMTP_PORT,
-      ...(config.SMTP_USER ? {user: config.SMTP_USER} : {}),
-      ...(config.SMTP_PASSWORD ? {password: config.SMTP_PASSWORD} : {}),
-      from: config.MAILER_FROM,
-    });
-  }
-
-  return createConsoleMailer({from: config.MAILER_FROM});
-}
-
-export const mailer = createMailer();

--- a/libs/api/workspaces/src/index.test.ts
+++ b/libs/api/workspaces/src/index.test.ts
@@ -8,6 +8,9 @@ vi.mock('#config.js', () => ({
   config: {
     CLIENT_BASE_URL: 'https://app.example.test',
   },
+}));
+
+vi.mock('@shipfox/node-mailer', () => ({
   mailer: {send: vi.fn()},
 }));
 

--- a/libs/api/workspaces/src/presentation/subscribers/invitation-send-requested.test.ts
+++ b/libs/api/workspaces/src/presentation/subscribers/invitation-send-requested.test.ts
@@ -16,7 +16,7 @@ const testMailer = vi.hoisted(
   },
 );
 
-vi.mock('#config.js', () => ({
+vi.mock('@shipfox/node-mailer', () => ({
   mailer: testMailer.mailer,
 }));
 

--- a/libs/api/workspaces/src/presentation/subscribers/on-invitation-send-requested.ts
+++ b/libs/api/workspaces/src/presentation/subscribers/on-invitation-send-requested.ts
@@ -1,6 +1,6 @@
 import type {WorkspacesInvitationSendRequestedEvent} from '@shipfox/api-workspaces-dto';
 import {renderEmail} from '@shipfox/node-email';
-import {mailer} from '#config.js';
+import {mailer} from '@shipfox/node-mailer';
 
 export async function onInvitationSendRequested(
   payload: WorkspacesInvitationSendRequestedEvent,

--- a/libs/shared/node/mailer/README.md
+++ b/libs/shared/node/mailer/README.md
@@ -6,24 +6,14 @@ Small mailer interface for Shipfox Node packages. It supports SMTP delivery for 
 
 - **`Mailer`**: Interface with one `send(message)` method.
 - **`MailMessage`**: Message shape with `to`, `subject`, `text`, and optional `html`.
+- **`mailer`**: Configured process-wide mailer that uses the environment variables below.
 - **`createConsoleMailer(options)`**: Logs mail through the Shipfox logger and can capture messages in an array.
 - **`createSmtpMailer(options)`**: Sends mail through `nodemailer`.
 
 ## Usage
 
 ```ts
-import {createConsoleMailer, createSmtpMailer, type Mailer} from '@shipfox/node-mailer';
-
-const mailer: Mailer =
-  process.env.MAILER_TRANSPORT === 'smtp'
-    ? createSmtpMailer({
-        host: 'smtp.example.com',
-        port: 587,
-        user: process.env.SMTP_USER,
-        password: process.env.SMTP_PASSWORD,
-        from: 'noreply@shipfox.local',
-      })
-    : createConsoleMailer({from: 'noreply@shipfox.local'});
+import {mailer} from '@shipfox/node-mailer';
 
 await mailer.send({
   to: 'user@example.com',
@@ -31,6 +21,17 @@ await mailer.send({
   text: 'Open this link to verify your email.',
 });
 ```
+
+## Configuration
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `MAILER_TRANSPORT` | `console` | Mail transport. Set to `smtp` to send real mail. |
+| `MAILER_FROM` | `noreply@shipfox.local` | Sender address shown on outgoing emails. |
+| `SMTP_HOST` | none | Required when `MAILER_TRANSPORT=smtp`. |
+| `SMTP_PORT` | `587` | SMTP server port. |
+| `SMTP_USER` | none | Optional SMTP user. |
+| `SMTP_PASSWORD` | none | Optional SMTP password. |
 
 ## Notes
 

--- a/libs/shared/node/mailer/package.json
+++ b/libs/shared/node/mailer/package.json
@@ -40,6 +40,7 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
+    "@shipfox/config": "workspace:*",
     "@shipfox/node-opentelemetry": "workspace:*",
     "nodemailer": "catalog:"
   },

--- a/libs/shared/node/mailer/src/config.test.ts
+++ b/libs/shared/node/mailer/src/config.test.ts
@@ -1,0 +1,76 @@
+import nodemailer from 'nodemailer';
+
+const loggerInfo = vi.hoisted(() => vi.fn());
+
+vi.mock('@shipfox/node-opentelemetry', () => ({
+  logger: () => ({info: loggerInfo}),
+}));
+
+describe('configured mailer', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    loggerInfo.mockClear();
+  });
+
+  test('uses the console mailer by default', async () => {
+    vi.stubEnv('MAILER_TRANSPORT', 'console');
+
+    const {mailer} = await import('./index.js');
+
+    await mailer.send({to: 'alice@example.com', subject: 'Welcome', text: 'Hello Alice'});
+
+    expect(loggerInfo).toHaveBeenCalledWith(
+      {
+        mailer: 'console',
+        from: 'noreply@shipfox.local',
+        to: 'alice@example.com',
+        subject: 'Welcome',
+        text: 'Hello Alice',
+      },
+      'mailer.send',
+    );
+  });
+
+  test('creates an SMTP mailer from environment configuration', async () => {
+    const sendMail = vi.fn().mockResolvedValue({messageId: '<test>'});
+    const createTransportSpy = vi
+      .spyOn(nodemailer, 'createTransport')
+      // biome-ignore lint/suspicious/noExplicitAny: nodemailer transport type is heavy; cast for the test
+      .mockReturnValue({sendMail} as any);
+    vi.stubEnv('MAILER_TRANSPORT', 'smtp');
+    vi.stubEnv('MAILER_FROM', 'support@shipfox.test');
+    vi.stubEnv('SMTP_HOST', 'smtp.example.com');
+    vi.stubEnv('SMTP_PORT', '465');
+    vi.stubEnv('SMTP_USER', 'user');
+    vi.stubEnv('SMTP_PASSWORD', 'pass');
+
+    const {mailer} = await import('./index.js');
+
+    await mailer.send({to: 'alice@example.com', subject: 'Welcome', text: 'Hello Alice'});
+
+    expect(createTransportSpy).toHaveBeenCalledWith({
+      host: 'smtp.example.com',
+      port: 465,
+      secure: true,
+      auth: {user: 'user', pass: 'pass'},
+    });
+    expect(sendMail).toHaveBeenCalledWith({
+      from: 'support@shipfox.test',
+      to: 'alice@example.com',
+      subject: 'Welcome',
+      text: 'Hello Alice',
+      html: undefined,
+    });
+  });
+
+  test('rejects SMTP configuration without a host', async () => {
+    vi.stubEnv('MAILER_TRANSPORT', 'smtp');
+    vi.stubEnv('SMTP_HOST', '');
+
+    const mailerModule = import('./index.js');
+
+    await expect(mailerModule).rejects.toThrow('SMTP_HOST is required when MAILER_TRANSPORT=smtp');
+  });
+});

--- a/libs/shared/node/mailer/src/config.ts
+++ b/libs/shared/node/mailer/src/config.ts
@@ -1,0 +1,49 @@
+import {createConfig, num, str} from '@shipfox/config';
+import {createConsoleMailer} from './console-mailer.js';
+import type {Mailer} from './mailer.js';
+import {createSmtpMailer} from './smtp-mailer.js';
+
+export const config = createConfig({
+  MAILER_TRANSPORT: str({
+    desc: 'How emails are delivered. Use console to print them to the log, or smtp to send them through an SMTP server.',
+    choices: ['console', 'smtp'],
+    default: 'console',
+  }),
+  MAILER_FROM: str({
+    desc: 'Sender address shown on outgoing emails.',
+    default: 'noreply@shipfox.local',
+  }),
+  SMTP_HOST: str({
+    desc: 'Hostname of the SMTP server. Required when MAILER_TRANSPORT is smtp.',
+    default: undefined,
+  }),
+  SMTP_PORT: num({
+    desc: 'Port of the SMTP server.',
+    default: 587,
+  }),
+  SMTP_USER: str({
+    desc: 'Username for SMTP authentication. Leave it unset if the server needs no login.',
+    default: undefined,
+  }),
+  SMTP_PASSWORD: str({
+    desc: 'Password for SMTP authentication. Leave it unset if the server needs no login.',
+    default: undefined,
+  }),
+});
+
+function createMailer(): Mailer {
+  if (config.MAILER_TRANSPORT === 'smtp') {
+    if (!config.SMTP_HOST) throw new Error('SMTP_HOST is required when MAILER_TRANSPORT=smtp');
+    return createSmtpMailer({
+      host: config.SMTP_HOST,
+      port: config.SMTP_PORT,
+      ...(config.SMTP_USER ? {user: config.SMTP_USER} : {}),
+      ...(config.SMTP_PASSWORD ? {password: config.SMTP_PASSWORD} : {}),
+      from: config.MAILER_FROM,
+    });
+  }
+
+  return createConsoleMailer({from: config.MAILER_FROM});
+}
+
+export const mailer = createMailer();

--- a/libs/shared/node/mailer/src/index.ts
+++ b/libs/shared/node/mailer/src/index.ts
@@ -1,3 +1,4 @@
+export {mailer} from './config.js';
 export {type ConsoleMailerOptions, createConsoleMailer} from './console-mailer.js';
 export type {Mailer, MailMessage} from './mailer.js';
 export {createSmtpMailer, type SmtpMailerOptions} from './smtp-mailer.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6456,6 +6456,9 @@ importers:
 
   libs/shared/node/mailer:
     dependencies:
+      '@shipfox/config':
+        specifier: workspace:*
+        version: link:../../common/config
       '@shipfox/node-opentelemetry':
         specifier: workspace:*
         version: link:../opentelemetry


### PR DESCRIPTION
Centralize mail transport configuration and configured delivery in `@shipfox/node-mailer`.

Auth and workspaces each constructed their own mailer from the same environment variables, which duplicated validation and allowed their delivery configuration to diverge. They now retain only domain-specific settings and use the shared configured mailer from their outbox subscribers.

The shared package keeps the existing transport factories for explicit use cases while adding the process-wide configured export. The accompanying changeset releases the new export and records the dependent package updates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized mail transport in `@shipfox/node-mailer` and switched `@shipfox/api-auth` and `@shipfox/api-workspaces` to use a shared, process-wide `mailer`. This removes duplicate setup and keeps delivery settings consistent.

- **Refactors**
  - Added a configured `mailer` export in `@shipfox/node-mailer` (reads `MAILER_TRANSPORT`, `MAILER_FROM`, `SMTP_*`); kept `createConsoleMailer` and `createSmtpMailer`.
  - Updated `@shipfox/api-auth` and `@shipfox/api-workspaces` to import the shared `mailer`; removed their local mailer env and factory code.
  - Updated docs/tests; `@shipfox/node-mailer` now depends on `@shipfox/config`.

- **Migration**
  - Set `MAILER_TRANSPORT`, `MAILER_FROM`, and `SMTP_*` once for the process; no per-package mailer config is needed.
  - When `MAILER_TRANSPORT=smtp`, `SMTP_HOST` must be set or initialization will fail.

<sup>Written for commit 578a9ce92d9ef8d263f2fe79bc2799873bfbd7a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

