### PR TITLE
Fix runner image credential configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,7 +340,7 @@ jobs:
           aws-region: us-east-1
           role-duration-seconds: 7200
           role-session-name: shipfox-runner-image-candidate
-          role-to-assume: ${{ secrets.AWS_RUNNER_IMAGE_CANDIDATE_ROLE_ARN }}
+          role-to-assume: ${{ secrets.AWS_RUNNER_IMAGE_ROLE_ARN }}
 
       - name: Build runner image tooling
         run: turbo build --filter=@shipfox/runner-image...

--- a/infra/images/runner/README.md
+++ b/infra/images/runner/README.md
@@ -40,7 +40,7 @@ After every successful merge to `main`, CI builds one candidate AMI per architec
 
 The candidate command writes its AMI ID, architecture, region, source SHA, and whether it built or reused the image to its required `--output` JSON file. The AMI tags are the discovery contract. Internal users resolve an available image by its exact source SHA and architecture with `shipfox.managed=true`, `shipfox.lifecycle=candidate`, `shipfox.revision`, and `shipfox.architecture`. Candidates also record their GitHub build metadata and an expiry timestamp for account-level cleanup.
 
-CI assumes `AWS_RUNNER_IMAGE_CANDIDATE_ROLE_ARN` through GitHub OIDC. The role must belong to the candidate account and trust only `ShipfoxHQ/shipfox` builds from `main`. Candidate AMIs must not be used by production provisioning.
+CI assumes `AWS_RUNNER_IMAGE_ROLE_ARN` through GitHub OIDC. The role must belong to the candidate account and trust only `ShipfoxHQ/shipfox` builds from `main`. Candidate AMIs must not be used by production provisioning.
 
 QEMU output is test-only and is not published as a distributed artifact. The supported consumer path is a local or CI build followed by a boot test:
 


### PR DESCRIPTION
Use the repository's deployed `AWS_RUNNER_IMAGE_ROLE_ARN` secret when CI assumes the candidate AMI build role.

The workflow referred to a candidate-specific secret name that is not configured in GitHub. GitHub expanded that value to an empty role ARN, causing credential resolution to fail before Packer could start. The runner-image runbook now documents the same secret name.

No alternative credential source was added because the existing GitHub OIDC role already has the required candidate-account trust and permissions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI role assumption for runner image candidate builds by using the repository secret `AWS_RUNNER_IMAGE_ROLE_ARN`. Prevents empty ARN expansion that caused OIDC credential resolution to fail before Packer started.

- **Bug Fixes**
  - Use `AWS_RUNNER_IMAGE_ROLE_ARN` for `role-to-assume` in the workflow.
  - Update the runner image README to reference the same secret; keep OIDC-only auth since the role already has the required trust and permissions.

<sup>Written for commit 1879cadc7226f58f3ee82404f1c028f606d35f0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

