### PR TITLE
Fix runner image candidate invocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,7 +354,7 @@ jobs:
           PACKER_LOG: "1"
           PACKER_LOG_PATH: ${{ runner.temp }}/packer-${{ matrix.architecture }}.log
           RUNNER_IMAGE_CANDIDATE_RESULT_PATH: ${{ runner.temp }}/runner-image-candidate-${{ matrix.architecture }}.json
-        run: pnpm --filter=@shipfox/runner-image image:candidate -- --output "$RUNNER_IMAGE_CANDIDATE_RESULT_PATH"
+        run: node infra/images/runner/bin/build-runner-image-candidate.js --output "$RUNNER_IMAGE_CANDIDATE_RESULT_PATH"
 
       - name: Report runner image candidate
         env:

--- a/infra/images/runner/README.md
+++ b/infra/images/runner/README.md
@@ -7,7 +7,7 @@
 Builds run the production deploy inside the target VM. This is required because the runner contains architecture-specific native payloads. The wrapper obtains the Node version from `mise`, prunes `@shipfox/runner`, and then invokes Packer.
 
 ```sh
-BUILD_ARCH=amd64 BUILD_ATTEMPT=1 BUILD_NUMBER=42 BUILD_REVISION=0123456789abcdef0123456789abcdef01234567 pnpm --filter=@shipfox/runner-image image:candidate -- --output /tmp/runner-image-candidate.json
+BUILD_ARCH=amd64 BUILD_ATTEMPT=1 BUILD_NUMBER=42 BUILD_REVISION=0123456789abcdef0123456789abcdef01234567 pnpm --filter=@shipfox/runner-image exec node ./bin/build-runner-image-candidate.js --output /tmp/runner-image-candidate.json
 BUILD_ARCH=amd64 BUILD_ATTEMPT=1 BUILD_NUMBER=42 BUILD_RUNNER_VERSION=0.1.0 pnpm --filter=@shipfox/runner-image exec node ./bin/build-runner-image.js ubuntu24 qemu
 ```
 


### PR DESCRIPTION
Fix the main-branch runner-image candidate job so it invokes the built CLI directly.\n\npnpm forwards the script separator into this command, causing Node to treat the required --output flag as a positional argument and fail before Packer can build an AMI. The documented local command now uses pnpm exec, which forwards the flag correctly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the main-branch runner-image candidate job by invoking the CLI directly so the `--output` flag is passed correctly, restoring AMI candidate builds. Updates the README to show the correct local command using `pnpm exec`.

- **Bug Fixes**
  - Workflow: replace `pnpm --filter=@shipfox/runner-image image:candidate -- --output ...` with `node infra/images/runner/bin/build-runner-image-candidate.js --output ...` to avoid `pnpm` script separator issues.
  - Docs: update example to `pnpm --filter=@shipfox/runner-image exec node ./bin/build-runner-image-candidate.js --output ...`.

<sup>Written for commit b2a88bb8bbf6ea97e69e6673f7b05e9a23a33863. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

