### PR TITLE
[integration/slack] Move webhooks onto shared processor

### DIFF
--- a/.changeset/calm-pandas-process.md
+++ b/.changeset/calm-pandas-process.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-integration-slack": minor
+---
+
+Adds shared processing for signed Slack event and command webhook deliveries.

--- a/libs/api/integration/slack/src/core/signature.test.ts
+++ b/libs/api/integration/slack/src/core/signature.test.ts
@@ -3,11 +3,11 @@ import {verifySlackSignature} from './signature.js';
 
 const secret = 'test-signing-secret';
 const timestamp = '1721300000';
-const rawBody = '{"type":"event_callback"}';
+const rawBody = Buffer.from('{"type":"event_callback"}');
 const now = Number(timestamp) * 1000;
 
 function signature(body = rawBody): string {
-  return `v0=${createHmac('sha256', secret).update(`v0:${timestamp}:${body}`).digest('hex')}`;
+  return `v0=${createHmac('sha256', secret).update(`v0:${timestamp}:`).update(body).digest('hex')}`;
 }
 
 describe('verifySlackSignature', () => {
@@ -24,7 +24,7 @@ describe('verifySlackSignature', () => {
   });
 
   it.each([
-    ['a tampered body', {rawBody: '{"type":"tampered"}'}],
+    ['a tampered body', {rawBody: Buffer.from('{"type":"tampered"}')}],
     ['a missing signature', {signature: undefined}],
     ['an empty signing secret', {signingSecret: ''}],
     ['a missing timestamp', {timestamp: undefined}],

--- a/libs/api/integration/slack/src/core/signature.ts
+++ b/libs/api/integration/slack/src/core/signature.ts
@@ -6,9 +6,23 @@ export interface VerifySlackSignatureParams {
   signingSecret: string;
   signature: string | undefined;
   timestamp: string | undefined;
-  rawBody: string;
+  rawBody: Uint8Array;
   now?: number | undefined;
   replayWindowMs?: number | undefined;
+}
+
+export function isSlackTimestampWithinReplayWindow(
+  timestamp: string,
+  now = Date.now(),
+  replayWindowMs = 300_000,
+): boolean {
+  if (!unixTimestampPattern.test(timestamp)) return false;
+
+  const timestampSeconds = Number(timestamp);
+  if (!Number.isSafeInteger(timestampSeconds)) return false;
+  const timestampMilliseconds = timestampSeconds * 1000;
+  if (!Number.isSafeInteger(timestampMilliseconds)) return false;
+  return Math.abs(now - timestampMilliseconds) <= replayWindowMs;
 }
 
 export function verifySlackSignature({
@@ -19,18 +33,14 @@ export function verifySlackSignature({
   now = Date.now(),
   replayWindowMs = 300_000,
 }: VerifySlackSignatureParams): boolean {
-  if (!signingSecret || !signature || !timestamp || !unixTimestampPattern.test(timestamp)) {
+  if (!signingSecret || !signature || !timestamp) {
     return false;
   }
-
-  const timestampSeconds = Number(timestamp);
-  if (!Number.isSafeInteger(timestampSeconds)) return false;
-  const timestampMilliseconds = timestampSeconds * 1000;
-  if (!Number.isSafeInteger(timestampMilliseconds)) return false;
-  if (Math.abs(now - timestampMilliseconds) > replayWindowMs) return false;
+  if (!isSlackTimestampWithinReplayWindow(timestamp, now, replayWindowMs)) return false;
 
   const expected = `v0=${createHmac('sha256', signingSecret)
-    .update(`v0:${timestamp}:${rawBody}`)
+    .update(`v0:${timestamp}:`)
+    .update(rawBody)
     .digest('hex')}`;
   const expectedBuffer = Buffer.from(expected, 'utf8');
   const receivedBuffer = Buffer.from(signature, 'utf8');

--- a/libs/api/integration/slack/src/core/webhook-processor.test.ts
+++ b/libs/api/integration/slack/src/core/webhook-processor.test.ts
@@ -1,0 +1,106 @@
+import {createHmac, randomUUID} from 'node:crypto';
+import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
+import {createStoredWebhookRequest} from '@shipfox/api-integration-core-dto';
+import {db} from '#db/db.js';
+import {upsertSlackInstallation} from '#db/installations.js';
+import {slackInstallations} from '#db/schema/installations.js';
+import {createSlackWebhookProcessor} from './webhook-processor.js';
+
+const signingSecret = 'test-signing-secret';
+
+function fakeConnection(): IntegrationConnection {
+  return {
+    id: randomUUID(),
+    workspaceId: randomUUID(),
+    provider: 'slack',
+    externalAccountId: 'T1',
+    slug: 'slack_acme',
+    displayName: 'Slack Acme',
+    lifecycleStatus: 'active',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+function signedEventRequest(input: {
+  receivedAt: string;
+  timestamp?: number;
+}): ReturnType<typeof createStoredWebhookRequest> {
+  const body = Buffer.from(
+    JSON.stringify({
+      type: 'event_callback',
+      team_id: 'T1',
+      api_app_id: 'A1',
+      event: {type: 'app_mention', channel: 'C1', user: 'U1', text: 'hello', ts: '1.0'},
+      event_id: 'Ev-delayed',
+      event_time: 1_721_300_000,
+    }),
+  );
+  const timestamp = `${input.timestamp ?? Math.floor(new Date(input.receivedAt).getTime() / 1000)}`;
+  const signature = `v0=${createHmac('sha256', signingSecret)
+    .update(`v0:${timestamp}:`)
+    .update(body)
+    .digest('hex')}`;
+  return createStoredWebhookRequest({
+    requestId: randomUUID(),
+    routeId: 'slack.event',
+    receivedAt: input.receivedAt,
+    rawQueryString: '',
+    headers: {
+      'content-type': 'application/json',
+      'x-slack-request-timestamp': timestamp,
+      'x-slack-signature': signature,
+    },
+    body,
+  });
+}
+
+describe('Slack webhook processor', () => {
+  beforeEach(async () => {
+    await db().delete(slackInstallations);
+  });
+
+  it('accepts an event delayed after a valid receipt', async () => {
+    const connection = fakeConnection();
+    const receivedAt = new Date(Date.now() - 10 * 60_000).toISOString();
+    await upsertSlackInstallation({
+      connectionId: connection.id,
+      teamId: 'T1',
+      teamName: 'Acme',
+      appId: 'A1',
+      botUserId: 'UBOT',
+      scopes: [],
+      status: 'installed',
+    });
+    const publishIntegrationEventReceived = vi.fn(() => Promise.resolve({published: true}));
+    const processor = createSlackWebhookProcessor({
+      coreDb: db,
+      claimWebhookDelivery: vi.fn(() => Promise.resolve({claimed: true})),
+      publishIntegrationEventReceived,
+      recordDeliveryOnly: vi.fn(() => Promise.resolve()),
+      getIntegrationConnectionById: vi.fn(() => Promise.resolve(connection)),
+    });
+
+    const result = await processor.process(signedEventRequest({receivedAt}));
+
+    expect(result).toMatchObject({outcome: 'processed', deliveryId: 'Ev-delayed'});
+    expect(publishIntegrationEventReceived).toHaveBeenCalledTimes(1);
+  });
+
+  it('discards an event stale at receipt', async () => {
+    const receivedAt = new Date().toISOString();
+    const processor = createSlackWebhookProcessor({
+      coreDb: db,
+      claimWebhookDelivery: vi.fn(() => Promise.resolve({claimed: true})),
+      publishIntegrationEventReceived: vi.fn(() => Promise.resolve({published: true})),
+      recordDeliveryOnly: vi.fn(() => Promise.resolve()),
+      getIntegrationConnectionById: vi.fn(),
+    });
+
+    const result = await processor.process(
+      signedEventRequest({receivedAt, timestamp: Math.floor(Date.now() / 1000) - 301}),
+    );
+
+    expect(result).toMatchObject({outcome: 'discarded', reason: 'stale_at_receipt'});
+  });
+});

--- a/libs/api/integration/slack/src/core/webhook-processor.ts
+++ b/libs/api/integration/slack/src/core/webhook-processor.ts
@@ -1,0 +1,154 @@
+import {Buffer} from 'node:buffer';
+import type {
+  ClaimWebhookDeliveryFn,
+  GetIntegrationConnectionByIdFn,
+  PublishIntegrationEventReceivedFn,
+  RecordDeliveryOnlyFn,
+  StoredWebhookRequest,
+  WebhookProcessingResult,
+} from '@shipfox/api-integration-core-dto';
+import {decodeWebhookBody} from '@shipfox/api-integration-core-dto';
+import {
+  slackEventsRequestSchema,
+  slackSlashCommandSchema,
+} from '@shipfox/api-integration-slack-dto';
+import {logger} from '@shipfox/node-opentelemetry';
+import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
+import {config} from '#config.js';
+import {isSlackTimestampWithinReplayWindow, verifySlackSignature} from '#core/signature.js';
+import {handleSlackCommand, handleSlackEvent, type SlackWebhookOutcome} from '#core/webhook.js';
+
+const SIGNATURE_HEADER = 'x-slack-signature';
+const TIMESTAMP_HEADER = 'x-slack-request-timestamp';
+
+export interface CreateSlackWebhookProcessorOptions {
+  coreDb: () => NodePgDatabase<Record<string, unknown>>;
+  claimWebhookDelivery: ClaimWebhookDeliveryFn;
+  publishIntegrationEventReceived: PublishIntegrationEventReceivedFn;
+  recordDeliveryOnly: RecordDeliveryOnlyFn;
+  getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
+}
+
+export type SlackWebhookProcessingResult =
+  | WebhookProcessingResult
+  | {outcome: 'processed'; challenge: string};
+
+export interface SlackWebhookProcessor {
+  process(request: StoredWebhookRequest): Promise<SlackWebhookProcessingResult>;
+}
+
+export function createSlackWebhookProcessor(
+  options: CreateSlackWebhookProcessorOptions,
+): SlackWebhookProcessor {
+  return {process: (request) => processSlackWebhookRequest(options, request)};
+}
+
+function processSlackWebhookRequest(
+  options: CreateSlackWebhookProcessorOptions,
+  request: StoredWebhookRequest,
+): Promise<SlackWebhookProcessingResult> {
+  if (request.route_id !== 'slack.event' && request.route_id !== 'slack.command') {
+    throw new Error(`Slack processor cannot process ${request.route_id} requests`);
+  }
+
+  const signature = request.headers[SIGNATURE_HEADER];
+  const timestamp = request.headers[TIMESTAMP_HEADER];
+  if (!signature || !timestamp) {
+    return Promise.resolve({outcome: 'discarded', reason: 'missing_required_input'});
+  }
+
+  const rawBody = decodeWebhookBody(request.body);
+  const receiptTime = new Date(request.received_at).getTime();
+  if (!isSlackTimestampWithinReplayWindow(timestamp, receiptTime)) {
+    return Promise.resolve({outcome: 'discarded', reason: 'stale_at_receipt'});
+  }
+  if (
+    !verifySlackSignature({
+      signingSecret: config.SLACK_SIGNING_SECRET,
+      signature,
+      timestamp,
+      rawBody,
+      now: receiptTime,
+    })
+  ) {
+    return Promise.resolve({outcome: 'discarded', reason: 'invalid_signature'});
+  }
+
+  return request.route_id === 'slack.event'
+    ? processSlackEvent(options, rawBody)
+    : processSlackCommand(options, rawBody);
+}
+
+async function processSlackEvent(
+  options: CreateSlackWebhookProcessorOptions,
+  rawBody: Uint8Array,
+): Promise<SlackWebhookProcessingResult> {
+  let rawPayload: unknown;
+  try {
+    rawPayload = JSON.parse(Buffer.from(rawBody).toString('utf8'));
+  } catch (error) {
+    logger().warn({err: error}, 'slack events payload JSON parse failed');
+    return {outcome: 'discarded', reason: 'malformed_payload'};
+  }
+
+  const event = slackEventsRequestSchema.safeParse(rawPayload);
+  if (!event.success) {
+    logger().warn({issues: event.error.issues}, 'slack events envelope failed schema validation');
+    return {outcome: 'discarded', reason: 'unsupported_event'};
+  }
+  const envelope = event.data;
+  if (envelope.type === 'url_verification') {
+    return {outcome: 'processed', challenge: envelope.challenge};
+  }
+
+  const result = await options.coreDb().transaction(async (tx) =>
+    handleSlackEvent({
+      tx,
+      deliveryId: envelope.event_id,
+      envelope,
+      claimWebhookDelivery: options.claimWebhookDelivery,
+      publishIntegrationEventReceived: options.publishIntegrationEventReceived,
+      recordDeliveryOnly: options.recordDeliveryOnly,
+      getIntegrationConnectionById: options.getIntegrationConnectionById,
+    }),
+  );
+  return toProcessingResult(result.outcome, envelope.event_id);
+}
+
+async function processSlackCommand(
+  options: CreateSlackWebhookProcessorOptions,
+  rawBody: Uint8Array,
+): Promise<WebhookProcessingResult> {
+  const command = slackSlashCommandSchema.safeParse(
+    Object.fromEntries(new URLSearchParams(Buffer.from(rawBody).toString('utf8'))),
+  );
+  if (!command.success) {
+    logger().warn({issues: command.error.issues}, 'slack command failed schema validation');
+    return {outcome: 'discarded', reason: 'unsupported_event'};
+  }
+
+  const result = await options.coreDb().transaction(async (tx) =>
+    handleSlackCommand({
+      tx,
+      deliveryId: command.data.trigger_id,
+      command: command.data,
+      publishIntegrationEventReceived: options.publishIntegrationEventReceived,
+      recordDeliveryOnly: options.recordDeliveryOnly,
+      getIntegrationConnectionById: options.getIntegrationConnectionById,
+    }),
+  );
+  return toProcessingResult(result.outcome, command.data.trigger_id);
+}
+
+function toProcessingResult(
+  outcome: SlackWebhookOutcome,
+  deliveryId: string,
+): WebhookProcessingResult {
+  if (outcome === 'published') return {outcome: 'processed', deliveryId};
+  if (outcome === 'duplicate') return {outcome: 'duplicate', deliveryId};
+  return {
+    outcome: 'discarded',
+    reason: outcome === 'unsupported-event' ? 'unsupported_event' : 'connection_unavailable',
+    deliveryId,
+  };
+}

--- a/libs/api/integration/slack/src/index.ts
+++ b/libs/api/integration/slack/src/index.ts
@@ -67,7 +67,7 @@ export {
   SLACK_BOT_SCOPES,
 } from '#core/scopes.js';
 export type {VerifySlackSignatureParams} from '#core/signature.js';
-export {verifySlackSignature} from '#core/signature.js';
+export {isSlackTimestampWithinReplayWindow, verifySlackSignature} from '#core/signature.js';
 export type {SlackInstallStateClaims} from '#core/state.js';
 export {signSlackInstallState, verifySlackInstallState} from '#core/state.js';
 export type {
@@ -85,6 +85,12 @@ export type {
   SlackWebhookOutcome,
 } from '#core/webhook.js';
 export {handleSlackCommand, handleSlackEvent, isSelfAuthoredSlackEvent} from '#core/webhook.js';
+export type {
+  CreateSlackWebhookProcessorOptions,
+  SlackWebhookProcessingResult,
+  SlackWebhookProcessor,
+} from '#core/webhook-processor.js';
+export {createSlackWebhookProcessor} from '#core/webhook-processor.js';
 export type {
   SlackInstallation,
   SlackInstallationStatus,

--- a/libs/api/integration/slack/src/presentation/routes/webhooks.test.ts
+++ b/libs/api/integration/slack/src/presentation/routes/webhooks.test.ts
@@ -1,5 +1,6 @@
 import {createHmac, randomUUID} from 'node:crypto';
 import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
+import {WEBHOOK_MAX_RAW_BODY_BYTES} from '@shipfox/api-integration-core-dto';
 import {closeApp, createApp} from '@shipfox/node-fastify';
 import {db} from '#db/db.js';
 import {getSlackInstallationByTeamId, upsertSlackInstallation} from '#db/installations.js';
@@ -157,6 +158,23 @@ describe('Slack webhook routes', () => {
     });
 
     expect(response.statusCode).toBe(400);
+    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(recordDeliveryOnly).not.toHaveBeenCalled();
+  });
+
+  it('rejects a body too large for the shared webhook request before processing it', async () => {
+    const {app, publishIntegrationEventReceived, recordDeliveryOnly} = await createTestApp();
+    const rawBody = 'a'.repeat(WEBHOOK_MAX_RAW_BODY_BYTES + 1);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/webhooks/integrations/slack/events',
+      headers: slackHeaders(rawBody, 'application/json'),
+      payload: rawBody,
+    });
+
+    expect(response.statusCode).toBe(413);
+    expect(response.json()).toEqual({code: 'body-too-large'});
     expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
     expect(recordDeliveryOnly).not.toHaveBeenCalled();
   });

--- a/libs/api/integration/slack/src/presentation/routes/webhooks.ts
+++ b/libs/api/integration/slack/src/presentation/routes/webhooks.ts
@@ -1,20 +1,26 @@
-import {Buffer} from 'node:buffer';
+import {randomUUID} from 'node:crypto';
 import type {
   ClaimWebhookDeliveryFn,
   GetIntegrationConnectionByIdFn,
   PublishIntegrationEventReceivedFn,
   RecordDeliveryOnlyFn,
+  StoredWebhookRequest,
 } from '@shipfox/api-integration-core-dto';
 import {
-  slackEventsRequestSchema,
-  slackSlashCommandSchema,
-} from '@shipfox/api-integration-slack-dto';
-import {createRawBodyPlugin, defineRoute, type RouteGroup} from '@shipfox/node-fastify';
-import {logger} from '@shipfox/node-opentelemetry';
+  createStoredWebhookRequest,
+  WEBHOOK_MAX_RAW_BODY_BYTES,
+} from '@shipfox/api-integration-core-dto';
+import {
+  ClientError,
+  createRawBodyPlugin,
+  defineRoute,
+  type RouteGroup,
+} from '@shipfox/node-fastify';
 import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
-import {config} from '#config.js';
-import {verifySlackSignature} from '#core/signature.js';
-import {handleSlackCommand, handleSlackEvent} from '#core/webhook.js';
+import {
+  createSlackWebhookProcessor,
+  type SlackWebhookProcessingResult,
+} from '#core/webhook-processor.js';
 
 export const SLACK_WEBHOOK_BODY_LIMIT = 1024 * 1024;
 export const SLASH_COMMAND_ACK = {response_type: 'ephemeral', text: 'Working on it.'} as const;
@@ -37,6 +43,7 @@ export interface CreateSlackWebhookRoutesOptions {
 }
 
 export function createSlackWebhookRoutes(options: CreateSlackWebhookRoutesOptions): RouteGroup[] {
+  const processor = createSlackWebhookProcessor(options);
   const eventsRoute = defineRoute({
     method: 'POST',
     path: '/',
@@ -44,59 +51,25 @@ export function createSlackWebhookRoutes(options: CreateSlackWebhookRoutesOption
     description: 'Slack Events API receiver.',
     options: {bodyLimit: SLACK_WEBHOOK_BODY_LIMIT},
     handler: async (request, reply) => {
-      const rawBody = rawRequestBody(request.body);
-      if (rawBody === undefined) {
+      const body = rawRequestBody(request.body);
+      if (!body) {
         reply.code(400);
         return {error: 'expected raw JSON body'};
       }
-      if (!hasValidSlackSignature(request.headers, rawBody)) {
-        reply.code(401);
-        return {error: 'invalid signature'};
-      }
-
-      let parsedJson: unknown;
-      try {
-        parsedJson = JSON.parse(rawBody);
-      } catch (error) {
-        logger().warn(
-          {errorName: error instanceof Error ? error.name : 'unknown'},
-          'slack events payload JSON parse failed',
-        );
-        reply.code(400);
-        return {error: 'malformed JSON'};
-      }
-
-      const parsed = slackEventsRequestSchema.safeParse(parsedJson);
-      if (!parsed.success) {
-        logger().warn(
-          {issues: parsed.error.issues},
-          'slack events envelope failed schema validation',
-        );
-        reply.code(200);
-        return null;
-      }
-      const eventRequest = parsed.data;
-      if (eventRequest.type === 'url_verification') {
-        reply.code(200);
-        return {challenge: eventRequest.challenge};
-      }
-
-      await options.coreDb().transaction(async (tx) => {
-        await handleSlackEvent({
-          tx,
-          deliveryId: eventRequest.event_id,
-          envelope: eventRequest,
-          claimWebhookDelivery: options.claimWebhookDelivery,
-          publishIntegrationEventReceived: options.publishIntegrationEventReceived,
-          recordDeliveryOnly: options.recordDeliveryOnly,
-          getIntegrationConnectionById: options.getIntegrationConnectionById,
-        });
-      });
-      reply.code(200);
-      return null;
+      const result = await processor.process(
+        createSlackStoredWebhookRequest(
+          {
+            routeId: 'slack.event',
+            body,
+            headers: request.headers,
+            rawQueryString: rawQueryString(request),
+          },
+          new Date().toISOString(),
+        ),
+      );
+      return sendSlackEventResponse(reply, result);
     },
   });
-
   const commandsRoute = defineRoute({
     method: 'POST',
     path: '/',
@@ -104,37 +77,23 @@ export function createSlackWebhookRoutes(options: CreateSlackWebhookRoutesOption
     description: 'Slack slash-command receiver.',
     options: {bodyLimit: SLACK_WEBHOOK_BODY_LIMIT},
     handler: async (request, reply) => {
-      const rawBody = rawRequestBody(request.body);
-      if (rawBody === undefined) {
+      const body = rawRequestBody(request.body);
+      if (!body) {
         reply.code(400);
         return {error: 'expected raw form body'};
       }
-      if (!hasValidSlackSignature(request.headers, rawBody)) {
-        reply.code(401);
-        return {error: 'invalid signature'};
-      }
-
-      const command = slackSlashCommandSchema.safeParse(
-        Object.fromEntries(new URLSearchParams(rawBody)),
+      const result = await processor.process(
+        createSlackStoredWebhookRequest(
+          {
+            routeId: 'slack.command',
+            body,
+            headers: request.headers,
+            rawQueryString: rawQueryString(request),
+          },
+          new Date().toISOString(),
+        ),
       );
-      if (!command.success) {
-        logger().warn({issues: command.error.issues}, 'slack command failed schema validation');
-        reply.code(200);
-        return SLASH_COMMAND_ACK;
-      }
-
-      await options.coreDb().transaction(async (tx) => {
-        await handleSlackCommand({
-          tx,
-          deliveryId: command.data.trigger_id,
-          command: command.data,
-          publishIntegrationEventReceived: options.publishIntegrationEventReceived,
-          recordDeliveryOnly: options.recordDeliveryOnly,
-          getIntegrationConnectionById: options.getIntegrationConnectionById,
-        });
-      });
-      reply.code(200);
-      return SLASH_COMMAND_ACK;
+      return sendSlackCommandResponse(reply, result);
     },
   });
 
@@ -154,20 +113,89 @@ export function createSlackWebhookRoutes(options: CreateSlackWebhookRoutesOption
   ];
 }
 
-function rawRequestBody(body: unknown): string | undefined {
-  return Buffer.isBuffer(body) ? body.toString('utf8') : undefined;
+function rawRequestBody(body: unknown): Uint8Array | undefined {
+  return body instanceof Uint8Array ? body : undefined;
 }
 
-function hasValidSlackSignature(
-  headers: Record<string, string | string[] | undefined>,
-  rawBody: string,
-): boolean {
-  const signature = headers['x-slack-signature'];
-  const timestamp = headers['x-slack-request-timestamp'];
-  return verifySlackSignature({
-    signingSecret: config.SLACK_SIGNING_SECRET,
-    signature: typeof signature === 'string' ? signature : undefined,
-    timestamp: typeof timestamp === 'string' ? timestamp : undefined,
-    rawBody,
-  });
+function rawQueryString(request: {raw: {url?: string | undefined}}): string {
+  return request.raw.url?.split('?')[1] ?? '';
+}
+
+function createSlackStoredWebhookRequest(
+  input: {
+    routeId: 'slack.event' | 'slack.command';
+    body: Uint8Array;
+    headers: Record<string, string | string[] | undefined>;
+    rawQueryString: string;
+  },
+  receivedAt: string,
+): StoredWebhookRequest {
+  if (input.body.byteLength > WEBHOOK_MAX_RAW_BODY_BYTES) {
+    throw new ClientError('Webhook request body is too large', 'body-too-large', {status: 413});
+  }
+  try {
+    return createStoredWebhookRequest({
+      requestId: randomUUID(),
+      routeId: input.routeId,
+      receivedAt,
+      rawQueryString: input.rawQueryString,
+      headers: slackWebhookHeaders(input.headers),
+      body: input.body,
+    });
+  } catch (error) {
+    throw new ClientError('Webhook request metadata is invalid', 'invalid-webhook-request', {
+      cause: error,
+    });
+  }
+}
+
+function slackWebhookHeaders(headers: Record<string, string | string[] | undefined>) {
+  return Object.fromEntries(
+    ['content-type', 'x-slack-signature', 'x-slack-request-timestamp'].flatMap((name) => {
+      const value = headers[name];
+      return typeof value === 'string' ? [[name, value]] : [];
+    }),
+  );
+}
+
+function sendSlackEventResponse(
+  reply: {code(statusCode: number): void},
+  result: SlackWebhookProcessingResult,
+) {
+  if (result.outcome === 'processed' && 'challenge' in result) {
+    reply.code(200);
+    return {challenge: result.challenge};
+  }
+  if (
+    result.outcome === 'discarded' &&
+    (result.reason === 'invalid_signature' ||
+      result.reason === 'missing_required_input' ||
+      result.reason === 'stale_at_receipt')
+  ) {
+    reply.code(401);
+    return {error: 'invalid signature'};
+  }
+  if (result.outcome === 'discarded' && result.reason === 'malformed_payload') {
+    reply.code(400);
+    return {error: 'malformed JSON'};
+  }
+  reply.code(200);
+  return null;
+}
+
+function sendSlackCommandResponse(
+  reply: {code(statusCode: number): void},
+  result: SlackWebhookProcessingResult,
+) {
+  if (
+    result.outcome === 'discarded' &&
+    (result.reason === 'invalid_signature' ||
+      result.reason === 'missing_required_input' ||
+      result.reason === 'stale_at_receipt')
+  ) {
+    reply.code(401);
+    return {error: 'invalid signature'};
+  }
+  reply.code(200);
+  return SLASH_COMMAND_ACK;
 }


### PR DESCRIPTION
Move Slack event and command delivery handling behind the shared stored-request processor.

The durable webhook receiver needs direct and queued Slack requests to follow one byte-faithful verification and dispatch path. The direct routes now only construct the stored request and preserve Slack's URL-verification challenge and fixed command acknowledgement.

The processor verifies signatures against the raw request bytes using ingress receipt time, so valid deliveries stay valid after queueing. It also preserves delivery claims, trigger IDs, response URLs, and existing integration-event publication behavior.

Closes ENG-1069

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move Slack events and slash commands onto a shared stored-request processor for byte-faithful verification and consistent handling across direct and queued deliveries. Addresses ENG-1069 by verifying signatures against raw bytes at receipt time so valid requests stay valid after queueing, while preserving URL verification and the fixed command ACK.

- New Features
  - Added `createSlackWebhookProcessor` in `@shipfox/api-integration-slack` to process events and commands and emit integration events with processed/duplicate/discarded outcomes.
  - Introduced `isSlackTimestampWithinReplayWindow` and updated `verifySlackSignature` to accept `Uint8Array` and HMAC the raw bytes using receipt time.
  - Routes now construct `createStoredWebhookRequest` and delegate to the processor; URL verification challenges and slash-command ACK are returned directly.

- Refactors
  - Enforced max raw body size using `WEBHOOK_MAX_RAW_BODY_BYTES` (returns 413 before processing).
  - Standardized responses: 401 for invalid/missing signature or stale-at-receipt, 400 for malformed JSON, 200 for valid events and command ACK.
  - Added tests for delayed deliveries, stale-at-receipt discards, and body-size rejection.
  - Exported processor types and helpers from `@shipfox/api-integration-slack`.

<sup>Written for commit 66d3aec674afb29c8634f962d6b010e5e3610494. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

