### PR TITLE
[api/runners] Expose Runners inter-module API

### DIFF
--- a/.changeset/bright-runners-connect.md
+++ b/.changeset/bright-runners-connect.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/api-runners-dto": minor
+"@shipfox/api-runners": patch
+"@shipfox/api-workflows": major
+---
+
+Adds the Runners inter-module contract and requires the injected Runners client when composing Workflows.

--- a/libs/api/runners-dto/package.json
+++ b/libs/api/runners-dto/package.json
@@ -28,6 +28,16 @@
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
       }
+    },
+    "./inter-module": {
+      "workspace-source": {
+        "types": "./src/inter-module.ts",
+        "default": "./src/inter-module.ts"
+      },
+      "default": {
+        "types": "./dist/inter-module.d.ts",
+        "default": "./dist/inter-module.js"
+      }
     }
   },
   "scripts": {
@@ -41,6 +51,7 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
+    "@shipfox/inter-module": "workspace:*",
     "@shipfox/runner-labels": "workspace:*",
     "zod": "catalog:"
   },

--- a/libs/api/runners-dto/src/inter-module.test.ts
+++ b/libs/api/runners-dto/src/inter-module.test.ts
@@ -1,0 +1,40 @@
+import {runnersInterModuleContract} from './inter-module.js';
+
+const id = '00000000-0000-4000-8000-000000000001';
+
+describe('runnersInterModuleContract', () => {
+  test('accepts stable job-execution identities for idempotent commands', () => {
+    const input = runnersInterModuleContract.methods.enqueueJobExecution.input.parse({
+      workspaceId: id,
+      workflowRunId: id,
+      workflowRunAttemptId: id,
+      jobId: id,
+      jobExecutionId: id,
+      projectId: id,
+      requiredLabels: ['linux'],
+    });
+
+    expect(input.jobExecutionId).toBe(id);
+  });
+
+  test('exposes bounded JSON capability results', () => {
+    const result =
+      runnersInterModuleContract.methods.getEffectiveRunnerToolCapabilities.output.parse({
+        capabilities: {harnesses: {pi: {tools: ['read']}}},
+        reportFresh: true,
+      });
+
+    expect(result).toEqual({
+      capabilities: {harnesses: {pi: {tools: ['read']}}},
+      reportFresh: true,
+    });
+  });
+
+  test('defines the scheduling validation failure', () => {
+    const details = runnersInterModuleContract.methods.enqueueJobExecution.errors[
+      'empty-required-labels'
+    ].parse({});
+
+    expect(details).toEqual({});
+  });
+});

--- a/libs/api/runners-dto/src/inter-module.ts
+++ b/libs/api/runners-dto/src/inter-module.ts
@@ -1,0 +1,51 @@
+import {defineInterModuleContract, type InterModuleClient} from '@shipfox/inter-module';
+import {z} from 'zod';
+import {runnerToolCapabilitiesSchema} from '#schemas/tool-capabilities.js';
+
+const idSchema = z.string().uuid();
+
+export const runnersInterModuleContract = defineInterModuleContract({
+  module: 'runners',
+  methods: {
+    enqueueJobExecution: {
+      input: z.object({
+        workspaceId: idSchema,
+        workflowRunId: idSchema,
+        workflowRunAttemptId: idSchema,
+        jobId: idSchema,
+        jobExecutionId: idSchema,
+        projectId: idSchema,
+        requiredLabels: z.array(z.string()),
+      }),
+      output: z.object({}),
+      errors: {
+        'empty-required-labels': z.object({}),
+      },
+    },
+    releaseJobExecution: {
+      input: z.object({jobExecutionId: idSchema}),
+      output: z.object({}),
+    },
+    cancelJobs: {
+      input: z.object({jobIds: z.array(idSchema)}),
+      output: z.object({}),
+    },
+    getLeaseState: {
+      input: z.object({
+        jobId: idSchema,
+        jobExecutionId: idSchema,
+        runnerSessionId: idSchema,
+      }),
+      output: z.object({active: z.boolean()}),
+    },
+    getEffectiveRunnerToolCapabilities: {
+      input: z.object({runnerSessionId: idSchema}),
+      output: z.object({
+        capabilities: runnerToolCapabilitiesSchema,
+        reportFresh: z.boolean(),
+      }),
+    },
+  },
+});
+
+export type RunnersInterModuleClient = InterModuleClient<typeof runnersInterModuleContract>;

--- a/libs/api/runners/package.json
+++ b/libs/api/runners/package.json
@@ -45,6 +45,7 @@
     "@shipfox/api-runners-dto": "workspace:*",
     "@shipfox/api-workflows-dto": "workspace:*",
     "@shipfox/config": "workspace:*",
+    "@shipfox/inter-module": "workspace:*",
     "@shipfox/node-drizzle": "workspace:*",
     "@shipfox/node-fastify": "workspace:*",
     "@shipfox/node-module": "workspace:*",

--- a/libs/api/runners/src/index.ts
+++ b/libs/api/runners/src/index.ts
@@ -15,6 +15,7 @@ import {
   createRunnerRoutes,
   onWorkflowsJobExecutionTimedOut,
 } from '#presentation/index.js';
+import {createRunnersInterModulePresentation} from '#presentation/inter-module.js';
 import {createRunnersMaintenanceActivities} from '#temporal/activities/index.js';
 import {RUNNERS_MAINTENANCE_TASK_QUEUE} from '#temporal/constants.js';
 
@@ -27,18 +28,6 @@ export {
   mintEphemeralRegistrationToken,
   mintEphemeralRegistrationTokensBatch,
 } from '#core/ephemeral-registration-tokens.js';
-export {
-  type EffectiveRunnerToolCapabilitiesResult,
-  getEffectiveRunnerToolCapabilities,
-  unadvertisedRunnerTools,
-} from '#core/runner-tool-capabilities.js';
-export {
-  cancelRunnerJobs,
-  type EnqueueJobExecutionParams,
-  enqueueJobExecution,
-  isJobLeaseActive,
-  releaseJobExecution,
-} from '#db/index.js';
 export type {
   CreateRunnersModuleOptions,
   InstallationProvisioningPolicy,
@@ -68,6 +57,7 @@ export function createRunnersModule(options: CreateRunnersModuleOptions = {}): S
         ],
       },
     ],
+    interModulePresentations: [createRunnersInterModulePresentation()],
   };
 }
 

--- a/libs/api/runners/src/presentation/inter-module.test.ts
+++ b/libs/api/runners/src/presentation/inter-module.test.ts
@@ -1,0 +1,15 @@
+import {runnersInterModuleContract} from '@shipfox/api-runners-dto/inter-module';
+import {isInterModuleKnownError} from '@shipfox/inter-module';
+import {EmptyRequiredLabelsError} from '#core/errors.js';
+import {toEnqueueJobExecutionKnownError} from './inter-module.js';
+
+describe('Runners inter-module presentation', () => {
+  test('maps empty scheduling labels to the published contract error', () => {
+    const result = toEnqueueJobExecutionKnownError(new EmptyRequiredLabelsError());
+
+    expect(
+      isInterModuleKnownError(runnersInterModuleContract.methods.enqueueJobExecution, result) &&
+        result.code,
+    ).toBe('empty-required-labels');
+  });
+});

--- a/libs/api/runners/src/presentation/inter-module.ts
+++ b/libs/api/runners/src/presentation/inter-module.ts
@@ -1,0 +1,53 @@
+import {runnersInterModuleContract} from '@shipfox/api-runners-dto/inter-module';
+import {
+  createInterModuleKnownError,
+  defineInterModulePresentation,
+  type InterModulePresentation,
+} from '@shipfox/inter-module';
+import {EmptyRequiredLabelsError} from '#core/errors.js';
+import {getEffectiveRunnerToolCapabilities} from '#core/runner-tool-capabilities.js';
+import {
+  cancelRunnerJobs,
+  enqueueJobExecution,
+  isJobLeaseActive,
+  releaseJobExecution,
+} from '#db/job-executions.js';
+
+export function createRunnersInterModulePresentation(): InterModulePresentation<
+  typeof runnersInterModuleContract
+> {
+  return defineInterModulePresentation(runnersInterModuleContract, {
+    enqueueJobExecution: async (input) => {
+      try {
+        await enqueueJobExecution(input);
+        return {};
+      } catch (error) {
+        throw toEnqueueJobExecutionKnownError(error);
+      }
+    },
+    releaseJobExecution: async (input) => {
+      await releaseJobExecution(input);
+      return {};
+    },
+    cancelJobs: async (input) => {
+      await cancelRunnerJobs(input);
+      return {};
+    },
+    getLeaseState: async (input) => ({active: await isJobLeaseActive(input)}),
+    getEffectiveRunnerToolCapabilities: async (input) => {
+      const result = await getEffectiveRunnerToolCapabilities(input);
+      return {capabilities: result.capabilities, reportFresh: result.reportFresh};
+    },
+  });
+}
+
+export function toEnqueueJobExecutionKnownError(error: unknown): unknown {
+  if (error instanceof EmptyRequiredLabelsError) {
+    return createInterModuleKnownError(
+      runnersInterModuleContract.methods.enqueueJobExecution,
+      'empty-required-labels',
+      {},
+    );
+  }
+  return error;
+}

--- a/libs/api/server/package.json
+++ b/libs/api/server/package.json
@@ -58,6 +58,7 @@
     "@shipfox/api-logs": "workspace:*",
     "@shipfox/api-projects": "workspace:*",
     "@shipfox/api-runners": "workspace:*",
+    "@shipfox/api-runners-dto": "workspace:*",
     "@shipfox/api-secrets": "workspace:*",
     "@shipfox/api-triggers": "workspace:*",
     "@shipfox/api-workflows": "workspace:*",

--- a/libs/api/server/src/modules.test.ts
+++ b/libs/api/server/src/modules.test.ts
@@ -1,3 +1,4 @@
+import {runnersInterModuleContract} from '@shipfox/api-runners-dto/inter-module';
 import {workflowsInterModuleContract} from '@shipfox/api-workflows-dto/inter-module';
 import {defaultModules} from './modules.js';
 
@@ -35,7 +36,23 @@ vi.mock('@shipfox/api-integration-core', () => ({
 }));
 vi.mock('@shipfox/api-logs', () => ({logsModule: {name: 'logs'}}));
 vi.mock('@shipfox/api-projects', () => ({createProjectsModule: mocks.createProjectsModule}));
-vi.mock('@shipfox/api-runners', () => ({runnersModule: {name: 'runners'}}));
+vi.mock('@shipfox/api-runners', () => ({
+  runnersModule: {
+    name: 'runners',
+    interModulePresentations: [
+      {
+        contract: runnersInterModuleContract,
+        handlers: {
+          cancelJobs: vi.fn(),
+          enqueueJobExecution: vi.fn(),
+          getEffectiveRunnerToolCapabilities: vi.fn(),
+          getLeaseState: vi.fn(),
+          releaseJobExecution: vi.fn(),
+        },
+      },
+    ],
+  },
+}));
 vi.mock('@shipfox/api-secrets', () => ({
   deleteSecrets: mocks.deleteSecrets,
   getSecret: mocks.getSecret,
@@ -116,7 +133,21 @@ describe('defaultModules', () => {
   });
 
   it('replaces only the runners module when a host provides one', async () => {
-    const runnersModule = {name: 'runners'};
+    const runnersModule = {
+      name: 'runners',
+      interModulePresentations: [
+        {
+          contract: runnersInterModuleContract,
+          handlers: {
+            cancelJobs: vi.fn(),
+            enqueueJobExecution: vi.fn(),
+            getEffectiveRunnerToolCapabilities: vi.fn(),
+            getLeaseState: vi.fn(),
+            releaseJobExecution: vi.fn(),
+          },
+        },
+      ],
+    };
 
     const modules = await defaultModules({runnersModule});
 
@@ -161,7 +192,7 @@ describe('defaultModules', () => {
           setSecrets: expect.any(Function),
         },
       },
-      agentTools: {loadLeasedAgentStep: mocks.loadRunningLeasedStep},
+      agentTools: {loadLeasedAgentStep: expect.any(Function)},
     });
 
     const integrationsOptions = mocks.createIntegrationsContext.mock.calls[0]?.[0] as {
@@ -182,7 +213,14 @@ describe('defaultModules', () => {
           setSecrets: (params: {namespace: string}) => unknown;
         };
       };
+      agentTools: {loadLeasedAgentStep: (params: {stepId: string}) => unknown};
     };
+    integrationsOptions.agentTools.loadLeasedAgentStep({stepId: 'step-1'});
+    expect(mocks.loadRunningLeasedStep).toHaveBeenCalledWith({
+      stepId: 'step-1',
+      runners: expect.objectContaining({enqueueJobExecution: expect.any(Function)}),
+    });
+
     integrationsOptions.secrets.linear.getSecret({namespace: 'workspace'});
     integrationsOptions.secrets.linear.setSecrets({namespace: 'workspace'});
     integrationsOptions.secrets.linear.deleteSecrets({namespace: 'workspace'});

--- a/libs/api/server/src/modules.ts
+++ b/libs/api/server/src/modules.ts
@@ -13,6 +13,7 @@ import {
 import {logsModule} from '@shipfox/api-logs';
 import {createProjectsModule} from '@shipfox/api-projects';
 import {runnersModule as defaultRunnersModule} from '@shipfox/api-runners';
+import {runnersInterModuleContract} from '@shipfox/api-runners-dto/inter-module';
 import {deleteSecrets, getSecret, secretsModule, setSecrets} from '@shipfox/api-secrets';
 import {createTriggersModule} from '@shipfox/api-triggers';
 import {
@@ -38,6 +39,7 @@ export async function defaultModules(
 ): Promise<ShipfoxModule[]> {
   const interModuleTransport = createInMemoryInterModuleTransport();
   const workflowsClient = interModuleTransport.createClient(workflowsInterModuleContract);
+  const runnersClient = interModuleTransport.createClient(runnersInterModuleContract);
   const integrations = await createIntegrationsContext({
     secrets: {
       deleteSecrets,
@@ -84,7 +86,9 @@ export async function defaultModules(
           }),
       },
     },
-    agentTools: {loadLeasedAgentStep: loadRunningLeasedStep},
+    agentTools: {
+      loadLeasedAgentStep: (params) => loadRunningLeasedStep({runners: runnersClient, ...params}),
+    },
   });
   const [agentToolSelectionCatalogs, agentToolCatalogs] = await Promise.all([
     buildAgentToolSelectionCatalogs(integrations.registry),
@@ -118,7 +122,7 @@ export async function defaultModules(
     integrations.module,
     projectsModule,
     definitionsModule,
-    createWorkflowsModule(),
+    createWorkflowsModule({runners: runnersClient}),
     annotationsModule,
     options.runnersModule ?? defaultRunnersModule,
     logsModule,

--- a/libs/api/workflows/src/core/agent-tool-capability-warning.test.ts
+++ b/libs/api/workflows/src/core/agent-tool-capability-warning.test.ts
@@ -1,8 +1,18 @@
 import type {JobLeaseTokenClaims} from '@shipfox/api-auth';
 import {sql} from 'drizzle-orm';
 import {db} from '#db/db.js';
-import {warnAgentToolCapabilityMismatchOnDispatch} from './agent-tool-capability-warning.js';
+import {runnersTestClient} from '#test/fixtures/runners-inter-module.js';
+import {warnAgentToolCapabilityMismatchOnDispatch as warnAgentToolCapabilityMismatchOnDispatchImpl} from './agent-tool-capability-warning.js';
 import type {Step} from './entities/step.js';
+
+async function warnAgentToolCapabilityMismatchOnDispatch(
+  params: Omit<Parameters<typeof warnAgentToolCapabilityMismatchOnDispatchImpl>[0], 'runners'>,
+) {
+  return await warnAgentToolCapabilityMismatchOnDispatchImpl({
+    runners: runnersTestClient,
+    ...params,
+  });
+}
 
 function lease(params: Partial<JobLeaseTokenClaims> = {}): JobLeaseTokenClaims {
   const now = Math.floor(Date.now() / 1000);

--- a/libs/api/workflows/src/core/agent-tool-capability-warning.ts
+++ b/libs/api/workflows/src/core/agent-tool-capability-warning.ts
@@ -11,7 +11,7 @@ import {
   materializedAgentStepConfigSchema,
 } from '@shipfox/api-agent-dto';
 import type {LeasedJobContext} from '@shipfox/api-auth-context';
-import {getEffectiveRunnerToolCapabilities, unadvertisedRunnerTools} from '@shipfox/api-runners';
+import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-module';
 import {logger} from '@shipfox/node-opentelemetry';
 import {recordWorkflowAgentToolWarningFailed} from '#metrics/instance.js';
 import type {Step} from './entities/step.js';
@@ -22,6 +22,7 @@ type WarningFailureReason = 'budget' | 'lookup' | 'write';
 type WarningReason = 'known-absence' | 'harness-not-advertised' | 'unknown-or-stale';
 
 export async function warnAgentToolCapabilityMismatchOnDispatch(params: {
+  runners: RunnersInterModuleClient;
   leaseIdentity: LeasedJobContext;
   step: Step;
 }): Promise<void> {
@@ -34,9 +35,11 @@ export async function warnAgentToolCapabilityMismatchOnDispatch(params: {
   const harness = harnessSchema.safeParse(config.harness);
   if (!harness.success) return;
 
-  let effective: Awaited<ReturnType<typeof getEffectiveRunnerToolCapabilities>>;
+  let effective: Awaited<
+    ReturnType<RunnersInterModuleClient['getEffectiveRunnerToolCapabilities']>
+  >;
   try {
-    effective = await getEffectiveRunnerToolCapabilities({
+    effective = await params.runners.getEffectiveRunnerToolCapabilities({
       runnerSessionId: params.leaseIdentity.runnerSessionId,
     });
   } catch (error) {
@@ -48,11 +51,8 @@ export async function warnAgentToolCapabilityMismatchOnDispatch(params: {
     return;
   }
 
-  const missing = unadvertisedRunnerTools({
-    harness: harness.data,
-    requestedTools,
-    capabilities: effective.capabilities,
-  });
+  const advertised = new Set(effective.capabilities.harnesses[harness.data]?.tools ?? []);
+  const missing = requestedTools.filter((tool) => !advertised.has(tool));
   const context = `agent-tool-capability:${params.step.id}`;
 
   const operation =
@@ -67,7 +67,7 @@ export async function warnAgentToolCapabilityMismatchOnDispatch(params: {
             missing,
             reason: warningReason({
               reportFresh: effective.reportFresh,
-              harnessKnown: effective.harnessKnown(harness.data),
+              harnessKnown: effective.capabilities.harnesses[harness.data] !== undefined,
             }),
           }),
         };
@@ -103,7 +103,7 @@ export async function warnAgentToolCapabilityMismatchOnDispatch(params: {
         missing,
         reason: warningReason({
           reportFresh: effective.reportFresh,
-          harnessKnown: effective.harnessKnown(harness.data),
+          harnessKnown: effective.capabilities.harnesses[harness.data] !== undefined,
         }),
       },
       'Runner missing requested agent tools; dispatch is continuing',

--- a/libs/api/workflows/src/index.ts
+++ b/libs/api/workflows/src/index.ts
@@ -6,6 +6,7 @@ import {
   RUNNER_JOB_QUEUED,
   type RunnersEventMap,
 } from '@shipfox/api-runners-dto';
+import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-module';
 import {
   WORKFLOWS_JOB_EVENT_DELIVERED,
   WORKFLOWS_JOB_STEPS_SETTLED,
@@ -18,6 +19,7 @@ import {type ShipfoxModule, subscriberFactory} from '@shipfox/node-module';
 import {db, migrationsPath, workflowsOutbox} from '#db/index.js';
 import {registerWorkflowsServiceMetrics} from '#metrics/index.js';
 import {
+  createWorkflowRoutes,
   onJobEventDelivered,
   onJobStepsSettled,
   onRunnerJobClaimed,
@@ -25,7 +27,6 @@ import {
   onRunnerJobQueued,
   onWorkflowRunAttemptCreated,
   onWorkflowRunCancelled,
-  routes,
 } from '#presentation/index.js';
 import {createWorkflowsInterModulePresentation} from '#presentation/inter-module.js';
 import {createOrchestrationActivities, WORKFLOWS_TASK_QUEUE} from '#temporal/index.js';
@@ -64,7 +65,6 @@ export {
   migrationsPath,
   workflowsOutbox,
 } from '#db/index.js';
-export {routes} from '#presentation/index.js';
 export {loadRunningLeasedStep} from '#presentation/routes/leased-step.js';
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
@@ -72,11 +72,11 @@ const workflowsPath = resolve(packageRoot, 'dist/temporal/workflows/index.js');
 
 const subscriber = subscriberFactory<WorkflowsEventMapDto & RunnersEventMap>();
 
-export function createWorkflowsModule(): ShipfoxModule {
+export function createWorkflowsModule(params: {runners: RunnersInterModuleClient}): ShipfoxModule {
   return {
     name: 'workflows',
     database: {db, migrationsPath},
-    routes,
+    routes: createWorkflowRoutes(params.runners),
     metrics: registerWorkflowsServiceMetrics,
     publishers: [
       {name: 'workflows', table: workflowsOutbox, db, eventSchemas: workflowsEventSchemas},
@@ -94,12 +94,10 @@ export function createWorkflowsModule(): ShipfoxModule {
       {
         taskQueue: WORKFLOWS_TASK_QUEUE,
         workflowsPath,
-        activities: createOrchestrationActivities,
+        activities: () => createOrchestrationActivities(params.runners),
         workflows: [],
       },
     ],
     interModulePresentations: [createWorkflowsInterModulePresentation()],
   };
 }
-
-export const workflowsModule = createWorkflowsModule();

--- a/libs/api/workflows/src/presentation/index.ts
+++ b/libs/api/workflows/src/presentation/index.ts
@@ -1,4 +1,4 @@
-export {workflowRoutes as routes} from './routes/index.js';
+export {createWorkflowRoutes} from './routes/index.js';
 export {
   onJobEventDelivered,
   onJobStepsSettled,

--- a/libs/api/workflows/src/presentation/routes/agent-runtime-config.test.ts
+++ b/libs/api/workflows/src/presentation/routes/agent-runtime-config.test.ts
@@ -14,7 +14,8 @@ import {createWorkflowRun, getJobsByWorkflowRunId, getStepsByJobId} from '#db/wo
 import {workflowModel} from '#test/factories/workflow-model.js';
 import {insertRunningJobLease, mintActiveLeaseToken} from '#test/fixtures/active-lease-token.js';
 import {mintLeaseToken} from '#test/fixtures/lease-token.js';
-import {leaseTokenRouteGroup} from './index.js';
+import {runnersTestClient} from '#test/fixtures/runners-inter-module.js';
+import {createLeaseTokenRouteGroup} from './index.js';
 
 const {captureExceptionMock} = vi.hoisted(() => ({captureExceptionMock: vi.fn()}));
 vi.mock('@shipfox/api-agent/core/resolve-runtime-credentials', async (importOriginal) => {
@@ -33,7 +34,7 @@ describe('GET /runs/jobs/current/agent-runtime-config', () => {
   beforeAll(async () => {
     app = await createApp({
       auth: [createLeaseTokenAuthMethod()],
-      routes: [leaseTokenRouteGroup],
+      routes: [createLeaseTokenRouteGroup(runnersTestClient)],
       swagger: false,
       fastifyOptions: {loggerInstance: logger},
     });

--- a/libs/api/workflows/src/presentation/routes/agent-runtime-config.ts
+++ b/libs/api/workflows/src/presentation/routes/agent-runtime-config.ts
@@ -5,6 +5,7 @@ import {
   type MaterializedAgentStepConfigDto,
   materializedAgentStepConfigSchema,
 } from '@shipfox/api-agent-dto';
+import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-module';
 import {SecretDecryptionError} from '@shipfox/api-secrets';
 import {agentRuntimeConfigQuerySchema} from '@shipfox/api-workflows-dto';
 import {captureException} from '@shipfox/node-error-monitoring';
@@ -12,70 +13,72 @@ import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {ZodError} from 'zod';
 import {loadRunningLeasedStep} from './leased-step.js';
 
-export const agentRuntimeConfigRoute = defineRoute({
-  method: 'GET',
-  path: '/agent-runtime-config',
-  description:
-    "Returns the resolved harness, provider, model, thinking effort, and decrypted provider credential bundle for the runner's currently leased running agent step. The job is identified by the lease token and the step is bound to that job before credentials are returned.",
-  schema: {
-    querystring: agentRuntimeConfigQuerySchema,
-    response: {
-      200: agentRuntimeCredentialsResponseSchema,
+export function createAgentRuntimeConfigRoute(runners: RunnersInterModuleClient) {
+  return defineRoute({
+    method: 'GET',
+    path: '/agent-runtime-config',
+    description:
+      "Returns the resolved harness, provider, model, thinking effort, and decrypted provider credential bundle for the runner's currently leased running agent step. The job is identified by the lease token and the step is bound to that job before credentials are returned.",
+    schema: {
+      querystring: agentRuntimeConfigQuerySchema,
+      response: {
+        200: agentRuntimeCredentialsResponseSchema,
+      },
     },
-  },
-  errorHandler: (error) => {
-    if (error instanceof SecretDecryptionError) {
-      captureException(error);
-      throw new ClientError(
-        'Model provider credentials could not be decrypted',
-        'model-provider-credentials-invalid',
-        {
-          status: 409,
-          cause: error,
-        },
-      );
-    }
-    if (error instanceof ModelProviderConfigNotFoundError) {
-      throw new ClientError(
-        'Model provider credentials are not configured',
-        'model-provider-not-configured',
-        {
-          status: 409,
-        },
-      );
-    }
-    throw error;
-  },
-  handler: async (request, reply) => {
-    const {step_id: stepId, attempt} = request.query;
-    const {step, workspaceId} = await loadRunningLeasedStep({request, stepId, attempt});
-
-    if (step.type !== 'agent') {
-      throw new ClientError('Step is not an agent step', 'step-not-agent', {status: 409});
-    }
-
-    let agentConfig: MaterializedAgentStepConfigDto;
-    try {
-      agentConfig = materializedAgentStepConfigSchema.parse(step.config);
-    } catch (error) {
-      if (error instanceof ZodError) {
-        throw new ClientError('Agent step config is invalid', 'agent-step-config-invalid', {
-          status: 409,
-          cause: error,
-        });
+    errorHandler: (error) => {
+      if (error instanceof SecretDecryptionError) {
+        captureException(error);
+        throw new ClientError(
+          'Model provider credentials could not be decrypted',
+          'model-provider-credentials-invalid',
+          {
+            status: 409,
+            cause: error,
+          },
+        );
+      }
+      if (error instanceof ModelProviderConfigNotFoundError) {
+        throw new ClientError(
+          'Model provider credentials are not configured',
+          'model-provider-not-configured',
+          {
+            status: 409,
+          },
+        );
       }
       throw error;
-    }
+    },
+    handler: async (request, reply) => {
+      const {step_id: stepId, attempt} = request.query;
+      const {step, workspaceId} = await loadRunningLeasedStep({runners, request, stepId, attempt});
 
-    const runtimeConfig = await resolveRuntimeCredentials({
-      workspaceId,
-      harness: agentConfig.harness,
-      provider: agentConfig.provider,
-      model: agentConfig.model,
-      thinking: agentConfig.thinking,
-    });
+      if (step.type !== 'agent') {
+        throw new ClientError('Step is not an agent step', 'step-not-agent', {status: 409});
+      }
 
-    reply.header('cache-control', 'no-store');
-    return runtimeConfig;
-  },
-});
+      let agentConfig: MaterializedAgentStepConfigDto;
+      try {
+        agentConfig = materializedAgentStepConfigSchema.parse(step.config);
+      } catch (error) {
+        if (error instanceof ZodError) {
+          throw new ClientError('Agent step config is invalid', 'agent-step-config-invalid', {
+            status: 409,
+            cause: error,
+          });
+        }
+        throw error;
+      }
+
+      const runtimeConfig = await resolveRuntimeCredentials({
+        workspaceId,
+        harness: agentConfig.harness,
+        provider: agentConfig.provider,
+        model: agentConfig.model,
+        thinking: agentConfig.thinking,
+      });
+
+      reply.header('cache-control', 'no-store');
+      return runtimeConfig;
+    },
+  });
+}

--- a/libs/api/workflows/src/presentation/routes/checkout-token.test.ts
+++ b/libs/api/workflows/src/presentation/routes/checkout-token.test.ts
@@ -14,7 +14,8 @@ import {jobFactory} from '#test/factories/job.js';
 import {projectFactory} from '#test/factories/project.js';
 import {mintActiveLeaseToken} from '#test/fixtures/active-lease-token.js';
 import {mintLeaseToken} from '#test/fixtures/lease-token.js';
-import {leaseTokenRouteGroup} from './index.js';
+import {runnersTestClient} from '#test/fixtures/runners-inter-module.js';
+import {createLeaseTokenRouteGroup} from './index.js';
 
 vi.mock('@shipfox/api-projects', () => ({getProjectById: vi.fn()}));
 const mockGetProjectById = vi.mocked(getProjectById);
@@ -36,7 +37,7 @@ describe('POST /runs/jobs/current/checkout-token', () => {
     setSourceControl({createCheckoutSpec} as unknown as IntegrationSourceControlService);
     app = await createApp({
       auth: [createLeaseTokenAuthMethod()],
-      routes: [leaseTokenRouteGroup],
+      routes: [createLeaseTokenRouteGroup(runnersTestClient)],
       swagger: false,
       fastifyOptions: {loggerInstance: logger},
     });

--- a/libs/api/workflows/src/presentation/routes/checkout-token.ts
+++ b/libs/api/workflows/src/presentation/routes/checkout-token.ts
@@ -1,6 +1,6 @@
 import {requireLeasedJobContext} from '@shipfox/api-auth-context';
 import {integrationRouteErrorHandler} from '@shipfox/api-integration-core';
-import {isJobLeaseActive} from '@shipfox/api-runners';
+import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-module';
 import {checkoutTokenResponseSchema} from '@shipfox/api-workflows-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {createJobCheckoutSpec} from '#core/checkout.js';
@@ -12,50 +12,52 @@ import {
 import {sourceControl} from '#core/source-control.js';
 import {toCheckoutTokenDto} from '#presentation/dto/checkout-token.js';
 
-export const checkoutTokenRoute = defineRoute({
-  method: 'POST',
-  path: '/checkout-token',
-  description:
-    "Exchanges the runner's job lease for short-lived, read-only checkout credentials for the job's repository. The job is identified by the access token, so no job ID is needed. The checkout target is resolved server-side from the job's run and project; no credential material is stored on the job or run. Returns the repository URL, ref, and (when the provider needs auth) a short-lived credential that expires soon.",
-  schema: {
-    response: {
-      200: checkoutTokenResponseSchema,
+export function createCheckoutTokenRoute(runners: RunnersInterModuleClient) {
+  return defineRoute({
+    method: 'POST',
+    path: '/checkout-token',
+    description:
+      "Exchanges the runner's job lease for short-lived, read-only checkout credentials for the job's repository. The job is identified by the access token, so no job ID is needed. The checkout target is resolved server-side from the job's run and project; no credential material is stored on the job or run. Returns the repository URL, ref, and (when the provider needs auth) a short-lived credential that expires soon.",
+    schema: {
+      response: {
+        200: checkoutTokenResponseSchema,
+      },
     },
-  },
-  errorHandler: (error) => {
-    if (error instanceof JobNotFoundError) {
-      throw new ClientError(error.message, 'job-not-found', {status: 404});
-    }
-    if (error instanceof WorkflowRunNotFoundError) {
-      throw new ClientError(error.message, 'run-not-found', {status: 404});
-    }
-    if (error instanceof CheckoutIntentUnresolvedError) {
-      throw new ClientError(error.message, 'checkout-unavailable', {status: 404});
-    }
-    // Connection and provider errors (and the structural provider-error detection)
-    // map through the shared handler, which re-throws unknowns to the global handler.
-    return integrationRouteErrorHandler(error);
-  },
-  handler: async (request, reply) => {
-    const leasedJob = requireLeasedJobContext(request);
+    errorHandler: (error) => {
+      if (error instanceof JobNotFoundError) {
+        throw new ClientError(error.message, 'job-not-found', {status: 404});
+      }
+      if (error instanceof WorkflowRunNotFoundError) {
+        throw new ClientError(error.message, 'run-not-found', {status: 404});
+      }
+      if (error instanceof CheckoutIntentUnresolvedError) {
+        throw new ClientError(error.message, 'checkout-unavailable', {status: 404});
+      }
+      // Connection and provider errors (and the structural provider-error detection)
+      // map through the shared handler, which re-throws unknowns to the global handler.
+      return integrationRouteErrorHandler(error);
+    },
+    handler: async (request, reply) => {
+      const leasedJob = requireLeasedJobContext(request);
 
-    const leaseIsActive = await isJobLeaseActive({
-      jobId: leasedJob.jobId,
-      jobExecutionId: leasedJob.jobExecutionId,
-      runnerSessionId: leasedJob.runnerSessionId,
-    });
-    if (!leaseIsActive) {
-      throw new ClientError('Job lease is no longer active', 'lease-not-active', {status: 404});
-    }
+      const {active: leaseIsActive} = await runners.getLeaseState({
+        jobId: leasedJob.jobId,
+        jobExecutionId: leasedJob.jobExecutionId,
+        runnerSessionId: leasedJob.runnerSessionId,
+      });
+      if (!leaseIsActive) {
+        throw new ClientError('Job lease is no longer active', 'lease-not-active', {status: 404});
+      }
 
-    const checkout = await createJobCheckoutSpec({
-      jobId: leasedJob.jobId,
-      sourceControl: sourceControl(),
-    });
+      const checkout = await createJobCheckoutSpec({
+        jobId: leasedJob.jobId,
+        sourceControl: sourceControl(),
+      });
 
-    // The body carries short-lived git credentials; forbid any intermediary or
-    // client cache from retaining them.
-    reply.header('cache-control', 'no-store');
-    return toCheckoutTokenDto(checkout.spec, {persist: checkout.persistCredentials});
-  },
-});
+      // The body carries short-lived git credentials; forbid any intermediary or
+      // client cache from retaining them.
+      reply.header('cache-control', 'no-store');
+      return toCheckoutTokenDto(checkout.spec, {persist: checkout.persistCredentials});
+    },
+  });
+}

--- a/libs/api/workflows/src/presentation/routes/get-step-secrets.test.ts
+++ b/libs/api/workflows/src/presentation/routes/get-step-secrets.test.ts
@@ -15,7 +15,8 @@ import {
 } from '#db/workflow-runs.js';
 import {workflowModel} from '#test/factories/workflow-model.js';
 import {mintActiveLeaseToken} from '#test/fixtures/active-lease-token.js';
-import {leaseTokenRouteGroup} from './index.js';
+import {runnersTestClient} from '#test/fixtures/runners-inter-module.js';
+import {createLeaseTokenRouteGroup} from './index.js';
 
 const URL_PREFIX = '/runs/jobs/current/steps';
 
@@ -26,7 +27,7 @@ describe('GET /runs/jobs/current/steps/:stepId/secrets', () => {
   beforeAll(async () => {
     app = await createApp({
       auth: [createLeaseTokenAuthMethod()],
-      routes: [leaseTokenRouteGroup],
+      routes: [createLeaseTokenRouteGroup(runnersTestClient)],
       swagger: false,
       fastifyOptions: {loggerInstance: logger},
     });

--- a/libs/api/workflows/src/presentation/routes/get-step-secrets.ts
+++ b/libs/api/workflows/src/presentation/routes/get-step-secrets.ts
@@ -1,3 +1,4 @@
+import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-module';
 import {getSecret, SecretDecryptionError} from '@shipfox/api-secrets';
 import {
   materializedSecretBindingSchema,
@@ -14,72 +15,75 @@ import {loadRunningLeasedStep} from './leased-step.js';
 
 const secretBindingsSchema = z.array(materializedSecretBindingSchema);
 
-export const getStepSecretsRoute = defineRoute({
-  method: 'GET',
-  path: '/steps/:stepId/secrets',
-  description:
-    "Returns decrypted secret values referenced by the runner's currently leased running run step. The job scope and secret bindings are re-derived from server state; the runner supplies only the step id and current attempt.",
-  schema: {
-    params: stepSecretsParamsSchema,
-    querystring: stepSecretsQuerySchema,
-    response: {
-      200: stepSecretsResponseSchema,
+export function createGetStepSecretsRoute(runners: RunnersInterModuleClient) {
+  return defineRoute({
+    method: 'GET',
+    path: '/steps/:stepId/secrets',
+    description:
+      "Returns decrypted secret values referenced by the runner's currently leased running run step. The job scope and secret bindings are re-derived from server state; the runner supplies only the step id and current attempt.",
+    schema: {
+      params: stepSecretsParamsSchema,
+      querystring: stepSecretsQuerySchema,
+      response: {
+        200: stepSecretsResponseSchema,
+      },
     },
-  },
-  errorHandler: (error) => {
-    if (error instanceof SecretDecryptionError) {
-      captureException(error);
-      throw new ClientError('Step secret could not be decrypted', 'secret-value-invalid', {
-        status: 409,
-        cause: error,
-      });
-    }
-    throw error;
-  },
-  handler: async (request, reply) => {
-    const {stepId} = request.params;
-    const {attempt} = request.query;
-    const {leasedJob, step, workspaceId, projectId} = await loadRunningLeasedStep({
-      request,
-      stepId,
-      attempt,
-    });
-
-    if (step.type !== 'run') {
-      throw new ClientError('Step is not a run step', 'step-not-run', {status: 409});
-    }
-
-    const secretBindings = parseSecretBindings(step.config.secret_bindings);
-    const references = distinctSecretReferences(secretBindings);
-    const secrets = await Promise.all(
-      references.map(async (reference): Promise<StepSecretDto> => {
-        const value = await getSecret({
-          workspaceId,
-          projectId,
-          namespace: '',
-          key: reference.key,
-          store: reference.store,
+    errorHandler: (error) => {
+      if (error instanceof SecretDecryptionError) {
+        captureException(error);
+        throw new ClientError('Step secret could not be decrypted', 'secret-value-invalid', {
+          status: 409,
+          cause: error,
         });
-        if (value === null) {
-          throw new ClientError('Secret not found', 'secret-not-found', {status: 422});
-        }
-        return {...reference, value};
-      }),
-    );
+      }
+      throw error;
+    },
+    handler: async (request, reply) => {
+      const {stepId} = request.params;
+      const {attempt} = request.query;
+      const {leasedJob, step, workspaceId, projectId} = await loadRunningLeasedStep({
+        runners,
+        request,
+        stepId,
+        attempt,
+      });
 
-    logger().info(
-      {jobId: leasedJob.jobId, workspaceId, stepId, keyCount: references.length},
-      'Resolved step secrets',
-    );
-    logger().debug(
-      {jobId: leasedJob.jobId, workspaceId, stepId, keys: references.map((ref) => ref.key)},
-      'Resolved step secret keys',
-    );
+      if (step.type !== 'run') {
+        throw new ClientError('Step is not a run step', 'step-not-run', {status: 409});
+      }
 
-    reply.header('cache-control', 'no-store');
-    return {secrets};
-  },
-});
+      const secretBindings = parseSecretBindings(step.config.secret_bindings);
+      const references = distinctSecretReferences(secretBindings);
+      const secrets = await Promise.all(
+        references.map(async (reference): Promise<StepSecretDto> => {
+          const value = await getSecret({
+            workspaceId,
+            projectId,
+            namespace: '',
+            key: reference.key,
+            store: reference.store,
+          });
+          if (value === null) {
+            throw new ClientError('Secret not found', 'secret-not-found', {status: 422});
+          }
+          return {...reference, value};
+        }),
+      );
+
+      logger().info(
+        {jobId: leasedJob.jobId, workspaceId, stepId, keyCount: references.length},
+        'Resolved step secrets',
+      );
+      logger().debug(
+        {jobId: leasedJob.jobId, workspaceId, stepId, keys: references.map((ref) => ref.key)},
+        'Resolved step secret keys',
+      );
+
+      reply.header('cache-control', 'no-store');
+      return {secrets};
+    },
+  });
+}
 
 function parseSecretBindings(value: unknown): z.infer<typeof secretBindingsSchema> {
   try {

--- a/libs/api/workflows/src/presentation/routes/index.test.ts
+++ b/libs/api/workflows/src/presentation/routes/index.test.ts
@@ -7,7 +7,8 @@ import {
 } from '@shipfox/api-auth-context';
 import {type AuthMethod, ClientError, closeApp, createApp} from '@shipfox/node-fastify';
 import type {FastifyRequest} from 'fastify';
-import {workflowRoutes} from './index.js';
+import {runnersTestClient} from '#test/fixtures/runners-inter-module.js';
+import {createWorkflowRoutes} from './index.js';
 
 const fakeUserAuth: AuthMethod = {
   name: AUTH_USER,
@@ -29,6 +30,7 @@ afterEach(async () => {
 });
 
 describe('workflow route auth', () => {
+  const workflowRoutes = createWorkflowRoutes(runnersTestClient);
   test('uses user auth', () => {
     expect(workflowRoutes[0]?.auth).toBe(AUTH_USER);
   });

--- a/libs/api/workflows/src/presentation/routes/index.ts
+++ b/libs/api/workflows/src/presentation/routes/index.ts
@@ -1,42 +1,47 @@
 import {AUTH_LEASED_JOB, AUTH_USER} from '@shipfox/api-auth-context';
+import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-module';
 import type {RouteGroup} from '@shipfox/node-fastify';
-import {agentRuntimeConfigRoute} from './agent-runtime-config.js';
+import {createAgentRuntimeConfigRoute} from './agent-runtime-config.js';
 import {cancelRunRoute} from './cancel-run.js';
-import {checkoutTokenRoute} from './checkout-token.js';
+import {createCheckoutTokenRoute} from './checkout-token.js';
 import {getRunRoute} from './get-run.js';
 import {getRunAggregatesRoute} from './get-run-aggregates.js';
-import {getStepSecretsRoute} from './get-step-secrets.js';
+import {createGetStepSecretsRoute} from './get-step-secrets.js';
 import {listRunAttemptsRoute} from './list-run-attempts.js';
 import {listRunsRoute} from './list-runs.js';
-import {nextStepRoute} from './next-step.js';
-import {reportStepRoute} from './report-step.js';
+import {createNextStepRoute} from './next-step.js';
+import {createReportStepRoute} from './report-step.js';
 import {rerunRunRoute} from './rerun-run.js';
 
-export const leaseTokenRouteGroup: RouteGroup = {
-  // The lease token names the job, so the path carries no job id ("current").
-  prefix: '/runs/jobs/current',
-  auth: AUTH_LEASED_JOB,
-  routes: [
-    nextStepRoute,
-    reportStepRoute,
-    checkoutTokenRoute,
-    agentRuntimeConfigRoute,
-    getStepSecretsRoute,
-  ],
-};
-
-export const workflowRoutes: RouteGroup[] = [
-  {
-    prefix: '/workflows/runs',
-    auth: AUTH_USER,
+export function createLeaseTokenRouteGroup(runners: RunnersInterModuleClient): RouteGroup {
+  return {
+    // The lease token names the job, so the path carries no job id ("current").
+    prefix: '/runs/jobs/current',
+    auth: AUTH_LEASED_JOB,
     routes: [
-      listRunsRoute,
-      getRunAggregatesRoute,
-      listRunAttemptsRoute,
-      getRunRoute,
-      cancelRunRoute,
-      rerunRunRoute,
+      createNextStepRoute(runners),
+      createReportStepRoute(runners),
+      createCheckoutTokenRoute(runners),
+      createAgentRuntimeConfigRoute(runners),
+      createGetStepSecretsRoute(runners),
     ],
-  },
-  leaseTokenRouteGroup,
-];
+  };
+}
+
+export function createWorkflowRoutes(runners: RunnersInterModuleClient): RouteGroup[] {
+  return [
+    {
+      prefix: '/workflows/runs',
+      auth: AUTH_USER,
+      routes: [
+        listRunsRoute,
+        getRunAggregatesRoute,
+        listRunAttemptsRoute,
+        getRunRoute,
+        cancelRunRoute,
+        rerunRunRoute,
+      ],
+    },
+    createLeaseTokenRouteGroup(runners),
+  ];
+}

--- a/libs/api/workflows/src/presentation/routes/leased-step.ts
+++ b/libs/api/workflows/src/presentation/routes/leased-step.ts
@@ -1,5 +1,5 @@
 import {type LeasedJobContext, requireLeasedJobContext} from '@shipfox/api-auth-context';
-import {isJobLeaseActive} from '@shipfox/api-runners';
+import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-module';
 import {ClientError} from '@shipfox/node-fastify';
 import type {Step} from '#core/entities/step.js';
 import {getJobScope, getStepByIdForJobExecution} from '#db/index.js';
@@ -12,13 +12,14 @@ export interface LoadedRunningLeasedStep {
 }
 
 export async function loadRunningLeasedStep(params: {
+  runners: RunnersInterModuleClient;
   request: object;
   stepId: string;
   attempt: number;
 }): Promise<LoadedRunningLeasedStep> {
   const leasedJob = requireLeasedJobContext(params.request);
 
-  const leaseIsActive = await isJobLeaseActive({
+  const {active: leaseIsActive} = await params.runners.getLeaseState({
     jobId: leasedJob.jobId,
     jobExecutionId: leasedJob.jobExecutionId,
     runnerSessionId: leasedJob.runnerSessionId,

--- a/libs/api/workflows/src/presentation/routes/next-step.test.ts
+++ b/libs/api/workflows/src/presentation/routes/next-step.test.ts
@@ -14,7 +14,8 @@ import {
 import {insertRunningJobLease, mintActiveLeaseToken} from '#test/fixtures/active-lease-token.js';
 import {arrangeJobWithSteps} from '#test/fixtures/job-with-steps.js';
 import {mintLeaseToken} from '#test/fixtures/lease-token.js';
-import {leaseTokenRouteGroup} from './index.js';
+import {runnersTestClient} from '#test/fixtures/runners-inter-module.js';
+import {createLeaseTokenRouteGroup} from './index.js';
 
 const URL = '/runs/jobs/current/steps/next';
 
@@ -57,7 +58,7 @@ describe('POST /runs/jobs/current/steps/next', () => {
   beforeAll(async () => {
     app = await createApp({
       auth: [createLeaseTokenAuthMethod()],
-      routes: [leaseTokenRouteGroup],
+      routes: [createLeaseTokenRouteGroup(runnersTestClient)],
       swagger: false,
     });
     await app.ready();

--- a/libs/api/workflows/src/presentation/routes/next-step.ts
+++ b/libs/api/workflows/src/presentation/routes/next-step.ts
@@ -1,5 +1,6 @@
 import {issueJobLeaseToken, jobLeaseParamsFrom} from '@shipfox/api-auth';
 import {requireLeasedJobContext} from '@shipfox/api-auth-context';
+import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-module';
 import {nextStepResponseSchema} from '@shipfox/api-workflows-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {warnAgentToolCapabilityMismatchOnDispatch} from '#core/agent-tool-capability-warning.js';
@@ -7,56 +8,59 @@ import {JobLeaseNotActiveError, JobNotFoundError} from '#core/errors.js';
 import {nextStepForLeasedJobExecution} from '#core/job-execution.js';
 import {toStepDto} from '#presentation/dto/step.js';
 
-export const nextStepRoute = defineRoute({
-  method: 'POST',
-  path: '/steps/next',
-  description:
-    'Returns the next step for the runner to run on its job. The job is identified by the access token, so no job ID is needed. Calling this again before reporting the current step returns that same step, so retries are safe. When no runnable steps remain, the response reports that there are no more steps to run, along with the job status; the runner then stops. Finalization is driven server-side from recorded step results and dispatch-time skips, not by the runner calling a job-completion endpoint.',
-  schema: {
-    response: {
-      200: nextStepResponseSchema,
+export function createNextStepRoute(runners: RunnersInterModuleClient) {
+  return defineRoute({
+    method: 'POST',
+    path: '/steps/next',
+    description:
+      'Returns the next step for the runner to run on its job. The job is identified by the access token, so no job ID is needed. Calling this again before reporting the current step returns that same step, so retries are safe. When no runnable steps remain, the response reports that there are no more steps to run, along with the job status; the runner then stops. Finalization is driven server-side from recorded step results and dispatch-time skips, not by the runner calling a job-completion endpoint.',
+    schema: {
+      response: {
+        200: nextStepResponseSchema,
+      },
     },
-  },
-  errorHandler: (error) => {
-    if (error instanceof JobNotFoundError) {
-      throw new ClientError(error.message, 'job-not-found', {status: 404});
-    }
-    if (error instanceof JobLeaseNotActiveError) {
-      throw new ClientError('Job lease is no longer active', 'lease-not-active', {status: 404});
-    }
-    throw error;
-  },
-  handler: async (request) => {
-    const leasedJob = requireLeasedJobContext(request);
-
-    const next = await nextStepForLeasedJobExecution({
-      jobId: leasedJob.jobId,
-      jobExecutionId: leasedJob.jobExecutionId,
-      runnerSessionId: leasedJob.runnerSessionId,
-    });
-
-    if (next.kind === 'step') {
-      const leaseToken = await issueJobLeaseToken(
-        jobLeaseParamsFrom(leasedJob, {
-          currentStepId: next.step.id,
-          currentStepAttempt: next.step.currentAttempt,
-        }),
-      );
-      if (next.dispatched) {
-        await warnAgentToolCapabilityMismatchOnDispatch({
-          leaseIdentity: leasedJob,
-          step: next.step,
-        });
+    errorHandler: (error) => {
+      if (error instanceof JobNotFoundError) {
+        throw new ClientError(error.message, 'job-not-found', {status: 404});
       }
-      // The runner echoes this back on report so a stale report from a superseded
-      // attempt is ignored.
-      return {
-        kind: 'step' as const,
-        step: toStepDto(next.step),
-        attempt: next.step.currentAttempt,
-        lease_token: leaseToken,
-      };
-    }
-    return {kind: 'done' as const, status: next.status};
-  },
-});
+      if (error instanceof JobLeaseNotActiveError) {
+        throw new ClientError('Job lease is no longer active', 'lease-not-active', {status: 404});
+      }
+      throw error;
+    },
+    handler: async (request) => {
+      const leasedJob = requireLeasedJobContext(request);
+
+      const next = await nextStepForLeasedJobExecution({
+        jobId: leasedJob.jobId,
+        jobExecutionId: leasedJob.jobExecutionId,
+        runnerSessionId: leasedJob.runnerSessionId,
+      });
+
+      if (next.kind === 'step') {
+        const leaseToken = await issueJobLeaseToken(
+          jobLeaseParamsFrom(leasedJob, {
+            currentStepId: next.step.id,
+            currentStepAttempt: next.step.currentAttempt,
+          }),
+        );
+        if (next.dispatched) {
+          await warnAgentToolCapabilityMismatchOnDispatch({
+            runners,
+            leaseIdentity: leasedJob,
+            step: next.step,
+          });
+        }
+        // The runner echoes this back on report so a stale report from a superseded
+        // attempt is ignored.
+        return {
+          kind: 'step' as const,
+          step: toStepDto(next.step),
+          attempt: next.step.currentAttempt,
+          lease_token: leaseToken,
+        };
+      }
+      return {kind: 'done' as const, status: next.status};
+    },
+  });
+}

--- a/libs/api/workflows/src/presentation/routes/report-step.test.ts
+++ b/libs/api/workflows/src/presentation/routes/report-step.test.ts
@@ -11,7 +11,8 @@ import {
 import {insertRunningJobLease, mintActiveLeaseToken} from '#test/fixtures/active-lease-token.js';
 import {arrangeJobWithSteps} from '#test/fixtures/job-with-steps.js';
 import {mintLeaseToken} from '#test/fixtures/lease-token.js';
-import {leaseTokenRouteGroup} from './index.js';
+import {runnersTestClient} from '#test/fixtures/runners-inter-module.js';
+import {createLeaseTokenRouteGroup} from './index.js';
 
 function reportUrl(stepId: string): string {
   return `/runs/jobs/current/steps/${stepId}/report`;
@@ -27,7 +28,7 @@ describe('POST /runs/jobs/current/steps/:stepId/report', () => {
   beforeAll(async () => {
     app = await createApp({
       auth: [createLeaseTokenAuthMethod()],
-      routes: [leaseTokenRouteGroup],
+      routes: [createLeaseTokenRouteGroup(runnersTestClient)],
       swagger: false,
     });
     await app.ready();

--- a/libs/api/workflows/src/presentation/routes/report-step.ts
+++ b/libs/api/workflows/src/presentation/routes/report-step.ts
@@ -1,5 +1,5 @@
 import {requireLeasedJobContext} from '@shipfox/api-auth-context';
-import {isJobLeaseActive} from '@shipfox/api-runners';
+import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-module';
 import {reportStepBodySchema, reportStepResponseSchema} from '@shipfox/api-workflows-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
@@ -7,55 +7,57 @@ import {StepAttemptAheadError, StepNotFoundError, StepNotRunningError} from '#co
 import {recordStepResult} from '#core/job-execution.js';
 import {fromStepErrorDto} from '#presentation/dto/step.js';
 
-export const reportStepRoute = defineRoute({
-  method: 'POST',
-  path: '/steps/:stepId/report',
-  description:
-    'Reports whether a step succeeded or failed. The job is identified by the access token. Reporting the same step more than once is safe: once a step has finished, later reports for it are ignored. The runner does not call a separate job-completion endpoint — finalization is driven server-side from the recorded step results, and the `cancel` flag tells the runner to stop once the job has finished without full success.',
-  schema: {
-    params: z.object({stepId: z.string().uuid()}),
-    body: reportStepBodySchema,
-    response: {
-      200: reportStepResponseSchema,
+export function createReportStepRoute(runners: RunnersInterModuleClient) {
+  return defineRoute({
+    method: 'POST',
+    path: '/steps/:stepId/report',
+    description:
+      'Reports whether a step succeeded or failed. The job is identified by the access token. Reporting the same step more than once is safe: once a step has finished, later reports for it are ignored. The runner does not call a separate job-completion endpoint — finalization is driven server-side from the recorded step results, and the `cancel` flag tells the runner to stop once the job has finished without full success.',
+    schema: {
+      params: z.object({stepId: z.string().uuid()}),
+      body: reportStepBodySchema,
+      response: {
+        200: reportStepResponseSchema,
+      },
     },
-  },
-  errorHandler: (error) => {
-    if (error instanceof StepNotFoundError) {
-      throw new ClientError(error.message, 'step-not-found', {status: 404});
-    }
-    if (error instanceof StepNotRunningError) {
-      throw new ClientError(error.message, 'step-not-running', {status: 409});
-    }
-    if (error instanceof StepAttemptAheadError) {
-      throw new ClientError(error.message, 'step-attempt-ahead', {status: 409});
-    }
-    throw error;
-  },
-  handler: async (request) => {
-    const {stepId} = request.params;
-    const leasedJob = requireLeasedJobContext(request);
+    errorHandler: (error) => {
+      if (error instanceof StepNotFoundError) {
+        throw new ClientError(error.message, 'step-not-found', {status: 404});
+      }
+      if (error instanceof StepNotRunningError) {
+        throw new ClientError(error.message, 'step-not-running', {status: 409});
+      }
+      if (error instanceof StepAttemptAheadError) {
+        throw new ClientError(error.message, 'step-attempt-ahead', {status: 409});
+      }
+      throw error;
+    },
+    handler: async (request) => {
+      const {stepId} = request.params;
+      const leasedJob = requireLeasedJobContext(request);
 
-    const leaseIsActive = await isJobLeaseActive({
-      jobId: leasedJob.jobId,
-      jobExecutionId: leasedJob.jobExecutionId,
-      runnerSessionId: leasedJob.runnerSessionId,
-    });
-    if (!leaseIsActive) {
-      throw new ClientError('Job lease is no longer active', 'lease-not-active', {status: 404});
-    }
+      const {active: leaseIsActive} = await runners.getLeaseState({
+        jobId: leasedJob.jobId,
+        jobExecutionId: leasedJob.jobExecutionId,
+        runnerSessionId: leasedJob.runnerSessionId,
+      });
+      if (!leaseIsActive) {
+        throw new ClientError('Job lease is no longer active', 'lease-not-active', {status: 404});
+      }
 
-    const outcome = await recordStepResult({
-      jobExecutionId: leasedJob.jobExecutionId,
-      stepId,
-      status: request.body.status,
-      error: fromStepErrorDto(request.body.error),
-      output: request.body.output ?? null,
-      response: request.body.response ?? null,
-      exitCode: request.body.exit_code ?? request.body.error?.exit_code ?? null,
-      logOutcome: request.body.log_outcome,
-      ...(request.body.attempt !== undefined ? {attempt: request.body.attempt} : {}),
-    });
+      const outcome = await recordStepResult({
+        jobExecutionId: leasedJob.jobExecutionId,
+        stepId,
+        status: request.body.status,
+        error: fromStepErrorDto(request.body.error),
+        output: request.body.output ?? null,
+        response: request.body.response ?? null,
+        exitCode: request.body.exit_code ?? request.body.error?.exit_code ?? null,
+        logOutcome: request.body.log_outcome,
+        ...(request.body.attempt !== undefined ? {attempt: request.body.attempt} : {}),
+      });
 
-    return {ok: true, cancel: outcome.jobFinished && outcome.status === 'failed'};
-  },
-});
+      return {ok: true, cancel: outcome.jobFinished && outcome.status === 'failed'};
+    },
+  });
+}

--- a/libs/api/workflows/src/temporal/activities/index.ts
+++ b/libs/api/workflows/src/temporal/activities/index.ts
@@ -1,16 +1,17 @@
+import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-module';
 import {
   activateJobListenerActivity,
   bulkSetStepStatuses,
-  cancelRunnerJobsActivity,
+  createCancelRunnerJobsActivity,
+  createEnqueueJobExecutionForRunner,
+  createReleaseLeaseActivity,
   drainListenerEventsActivity,
-  enqueueJobExecutionForRunner,
   evaluateJobActivationsActivity,
   failJobExecutionAsTimedOutActivity,
   failRunAsTimedOutActivity,
   loadRunAttemptDag,
   peekListenerBufferActivity,
   recordListenerFiringOutcomeActivity,
-  releaseLeaseActivity,
   resolveJobListenerActivity,
   resolveJobStatusFromJobExecutionsActivity,
   resolveLeaseExpiredJobExecutionActivity,
@@ -20,15 +21,15 @@ import {
   settleListenerJobExecutionActivity,
 } from './orchestration-activities.js';
 
-export function createOrchestrationActivities() {
+export function createOrchestrationActivities(runners: RunnersInterModuleClient) {
   return {
     loadRunAttemptDag,
     setRunAttemptStatus,
     setJobStatus,
     setJobExecutionStatus,
     bulkSetStepStatuses,
-    cancelRunnerJobsActivity,
-    enqueueJobExecutionForRunner,
+    cancelRunnerJobsActivity: createCancelRunnerJobsActivity(runners),
+    enqueueJobExecutionForRunner: createEnqueueJobExecutionForRunner(runners),
     evaluateJobActivationsActivity,
     failJobExecutionAsTimedOutActivity,
     failRunAsTimedOutActivity,
@@ -40,6 +41,6 @@ export function createOrchestrationActivities() {
     recordListenerFiringOutcomeActivity,
     resolveLeaseExpiredJobExecutionActivity,
     resolveJobStatusFromJobExecutionsActivity,
-    releaseLeaseActivity,
+    releaseLeaseActivity: createReleaseLeaseActivity(runners),
   };
 }

--- a/libs/api/workflows/src/temporal/activities/orchestration-activities.ts
+++ b/libs/api/workflows/src/temporal/activities/orchestration-activities.ts
@@ -1,4 +1,8 @@
-import {cancelRunnerJobs, enqueueJobExecution, releaseJobExecution} from '@shipfox/api-runners';
+import {
+  type RunnersInterModuleClient,
+  runnersInterModuleContract,
+} from '@shipfox/api-runners-dto/inter-module';
+import {isInterModuleKnownError} from '@shipfox/inter-module';
 import {ApplicationFailure} from '@temporalio/common';
 import {defaultJobConditionTrace} from '#core/condition-trace.js';
 import type {JobStatus, JobStatusReason, ResolutionReason} from '#core/entities/job.js';
@@ -200,39 +204,45 @@ export async function resolveLeaseExpiredJobExecutionActivity(params: {
 // Best-effort lease cleanup on job finalization. Idempotent: deleting an
 // already-released (or already-reaped) lease is a no-op. The workflow wraps the
 // call so a persistent failure never blocks the DAG result.
-export async function releaseLeaseActivity(params: {jobExecutionId: string}): Promise<void> {
-  await releaseJobExecution({jobExecutionId: params.jobExecutionId});
+export function createReleaseLeaseActivity(runners: RunnersInterModuleClient) {
+  return async function releaseLeaseActivity(params: {jobExecutionId: string}): Promise<void> {
+    await runners.releaseJobExecution({jobExecutionId: params.jobExecutionId});
+  };
 }
 
-export async function enqueueJobExecutionForRunner(params: {
-  workspaceId: string;
-  workflowRunId: string;
-  jobId: string;
-  jobExecutionId: string;
-  runAttemptId: string;
-  projectId: string;
-  requiredLabels: string[];
-}): Promise<void> {
-  try {
-    await enqueueJobExecution({
-      workspaceId: params.workspaceId,
-      workflowRunId: params.workflowRunId,
-      workflowRunAttemptId: params.runAttemptId,
-      jobId: params.jobId,
-      jobExecutionId: params.jobExecutionId,
-      projectId: params.projectId,
-      requiredLabels: params.requiredLabels,
-    });
-  } catch (err) {
-    if (err instanceof Error && err.name === 'EmptyRequiredLabelsError') {
-      throw ApplicationFailure.nonRetryable(err.message, err.name);
+export function createEnqueueJobExecutionForRunner(runners: RunnersInterModuleClient) {
+  return async function enqueueJobExecutionForRunner(params: {
+    workspaceId: string;
+    workflowRunId: string;
+    jobId: string;
+    jobExecutionId: string;
+    runAttemptId: string;
+    projectId: string;
+    requiredLabels: string[];
+  }): Promise<void> {
+    try {
+      await runners.enqueueJobExecution({
+        workspaceId: params.workspaceId,
+        workflowRunId: params.workflowRunId,
+        workflowRunAttemptId: params.runAttemptId,
+        jobId: params.jobId,
+        jobExecutionId: params.jobExecutionId,
+        projectId: params.projectId,
+        requiredLabels: params.requiredLabels,
+      });
+    } catch (err) {
+      if (isInterModuleKnownError(runnersInterModuleContract.methods.enqueueJobExecution, err)) {
+        throw ApplicationFailure.nonRetryable(err.message, err.name);
+      }
+      throw err;
     }
-    throw err;
-  }
+  };
 }
 
-export async function cancelRunnerJobsActivity(params: {jobIds: string[]}): Promise<void> {
-  await cancelRunnerJobs({jobIds: params.jobIds});
+export function createCancelRunnerJobsActivity(runners: RunnersInterModuleClient) {
+  return async function cancelRunnerJobsActivity(params: {jobIds: string[]}): Promise<void> {
+    await runners.cancelJobs(params);
+  };
 }
 
 export async function failJobExecutionAsTimedOutActivity(params: {

--- a/libs/api/workflows/test/fixtures/runners-inter-module.ts
+++ b/libs/api/workflows/test/fixtures/runners-inter-module.ts
@@ -1,0 +1,52 @@
+import {runnerToolCapabilitiesSchema} from '@shipfox/api-runners-dto';
+import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-module';
+import {sql} from 'drizzle-orm';
+import {db} from '#db/db.js';
+
+export const runnersTestClient: RunnersInterModuleClient = {
+  enqueueJobExecution() {
+    return Promise.resolve({});
+  },
+  releaseJobExecution() {
+    return Promise.resolve({});
+  },
+  cancelJobs() {
+    return Promise.resolve({});
+  },
+  async getLeaseState({jobId, jobExecutionId, runnerSessionId}) {
+    const result = await db().execute<{active: boolean}>(sql`
+      SELECT EXISTS(
+        SELECT 1
+        FROM runners_running_jobs
+        WHERE job_id = ${jobId}
+          AND job_execution_id = ${jobExecutionId}
+          AND runner_session_id = ${runnerSessionId}
+      ) AS active
+    `);
+    return {active: result.rows[0]?.active ?? false};
+  },
+  async getEffectiveRunnerToolCapabilities({runnerSessionId}) {
+    const result = await db().execute<{
+      toolCapabilities: unknown;
+      toolCapabilitiesReportedAt: Date | string | null;
+    }>(sql`
+      SELECT
+        tool_capabilities AS "toolCapabilities",
+        tool_capabilities_reported_at AS "toolCapabilitiesReportedAt"
+      FROM runners_runner_sessions
+      WHERE id = ${runnerSessionId}
+    `);
+    const row = result.rows[0];
+    const reportedAt = row?.toolCapabilitiesReportedAt;
+    const reportFresh =
+      reportedAt !== null &&
+      reportedAt !== undefined &&
+      Date.now() - new Date(reportedAt).getTime() <= 60_000;
+    return {
+      capabilities: reportFresh
+        ? runnerToolCapabilitiesSchema.parse(row?.toolCapabilities ?? {harnesses: {}})
+        : {harnesses: {}},
+      reportFresh,
+    };
+  },
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3460,6 +3460,9 @@ importers:
       '@shipfox/config':
         specifier: workspace:*
         version: link:../../shared/common/config
+      '@shipfox/inter-module':
+        specifier: workspace:*
+        version: link:../../shared/common/inter-module
       '@shipfox/node-drizzle':
         specifier: workspace:*
         version: link:../../shared/node/drizzle
@@ -3554,6 +3557,9 @@ importers:
 
   libs/api/runners-dto:
     dependencies:
+      '@shipfox/inter-module':
+        specifier: workspace:*
+        version: link:../../shared/common/inter-module
       '@shipfox/runner-labels':
         specifier: workspace:*
         version: link:../../shared/common/runner-labels
@@ -3695,6 +3701,9 @@ importers:
       '@shipfox/api-runners':
         specifier: workspace:*
         version: link:../runners
+      '@shipfox/api-runners-dto':
+        specifier: workspace:*
+        version: link:../runners-dto
       '@shipfox/api-secrets':
         specifier: workspace:*
         version: link:../secrets


### PR DESCRIPTION
Workflows previously imported Runners' internals directly (job-lease queries, enqueue/cancel/release, and tool-capability lookups), coupling the two modules at the source level. This publishes a typed `RunnersInterModuleClient` contract (mirroring the Workflows inter-module API added in #819) and threads it through Workflows' routes and Temporal activities as an injected dependency instead of a direct import.

Route and activity factories that touched Runners directly are now parameterized by the client (`createWorkflowsModule`, `createNextStepRoute`, `createEnqueueJobExecutionForRunner`, etc.), and the package root of `@shipfox/api-runners` no longer exports the raw DB/core functions that existed only to serve that now-removed direct import path.

Areas that could use careful review:
- `libs/api/workflows/src/temporal/activities/orchestration-activities.ts` — the non-retryable-error classification for `enqueueJobExecution` now narrows through `isInterModuleKnownError`, matching the pattern already used by `@shipfox/api-triggers`'s Workflows client.
- `libs/api/server/src/modules.ts` — module composition order between `createWorkflowsModule` and `runnersModule` doesn't matter functionally (inter-module dispatch is registered after all modules are built, then sealed), but it's worth a second look given the array-order convention noted in CLAUDE.md.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposed the typed `RunnersInterModuleClient` in `@shipfox/api-runners-dto/inter-module` and added a Runners inter-module presentation in `@shipfox/api-runners`. Workflows now inject a `runners` client for lease state, enqueue/cancel/release, and capability lookups, fully decoupling `@shipfox/api-workflows` from Runners internals.

- **Refactors**
  - `@shipfox/api-runners` publishes `createRunnersInterModulePresentation` for the new contract and stops exporting raw DB/core functions; maps `EmptyRequiredLabelsError` to the `'empty-required-labels'` contract error.
  - Workflows route factories (`createWorkflowRoutes`, `createLeaseTokenRouteGroup`, `createNextStepRoute`, `createReportStepRoute`, `createAgentRuntimeConfigRoute`, `createGetStepSecretsRoute`) and Temporal activities (`createEnqueueJobExecutionForRunner`, `createCancelRunnerJobsActivity`, `createReleaseLeaseActivity`) now take a `runners` client; non-retryable classification for enqueue uses `isInterModuleKnownError`.
  - Lease checks use `runners.getLeaseState` and agent tool capability warnings read `capabilities.harnesses` directly from the client.

- **Migration**
  - Compose Workflows with `createWorkflowsModule({ runners })` and inject `runners` via `createWorkflowRoutes(runners)` (includes `createLeaseTokenRouteGroup(runners)`).
  - Create the client from an inter-module transport (see `libs/api/server/src/modules.ts`) and pass it through, including to `agentTools.loadLeasedAgentStep`.
  - Replace any direct imports from `@shipfox/api-runners` with calls on the `RunnersInterModuleClient`.

<sup>Written for commit 475ce555e7a2d2e6a6357ad83be0abc9c1927e34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

