### PR TITLE
Expose the Projects inter-module API

### DIFF
--- a/.changeset/quiet-otters-connect.md
+++ b/.changeset/quiet-otters-connect.md
@@ -1,0 +1,10 @@
+---
+"@shipfox/api-projects-dto": minor
+"@shipfox/api-projects": minor
+"@shipfox/api-definitions": patch
+"@shipfox/api-secrets": patch
+"@shipfox/api-workflows": patch
+"@shipfox/api-server": patch
+---
+
+Adds the Projects inter-module contract and routes project lookup, ownership, and access decisions through injected clients.

--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -191,6 +191,20 @@ module.exports = {
           },
         ]
       : []),
+    ...(['@shipfox/api-definitions', '@shipfox/api-secrets', '@shipfox/api-workflows'].includes(
+      currentPackage.name,
+    )
+      ? [
+          {
+            name: 'projects-consumers-use-projects-inter-module-api',
+            comment:
+              'Projects consumers may use its DTO contract, but never import the Projects implementation package.',
+            severity: 'error',
+            from: {path: '^(src|test)/'},
+            to: {path: '^\\.\\./projects/(?:src|dist)/'},
+          },
+        ]
+      : []),
   ],
   options: {
     doNotFollow: {

--- a/libs/api/definitions/package.json
+++ b/libs/api/definitions/package.json
@@ -45,7 +45,6 @@
     "@shipfox/api-definitions-dto": "workspace:*",
     "@shipfox/api-integration-core": "workspace:*",
     "@shipfox/api-integration-core-dto": "workspace:*",
-    "@shipfox/api-projects": "workspace:*",
     "@shipfox/api-projects-dto": "workspace:*",
     "@shipfox/api-secrets-dto": "workspace:*",
     "@shipfox/config": "workspace:*",

--- a/libs/api/definitions/src/index.ts
+++ b/libs/api/definitions/src/index.ts
@@ -11,6 +11,7 @@ import type {
   IntegrationSourceControlService,
   LoadWorkspaceConnectionSnapshot,
 } from '@shipfox/api-integration-core';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
 import {
   PROJECT_SOURCE_BOUND,
   PROJECT_SOURCE_COMMIT_OBSERVED,
@@ -42,7 +43,6 @@ export {
   normalizeWorkflowDocument,
 } from '#core/index.js';
 export {db, definitionsOutbox, getDefinitionById, migrationsPath} from '#db/index.js';
-export {routes} from '#presentation/index.js';
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const workflowsPath = resolve(packageRoot, 'dist/temporal/workflows/index.js');
@@ -50,6 +50,7 @@ const workflowsPath = resolve(packageRoot, 'dist/temporal/workflows/index.js');
 const subscriber = subscriberFactory<DefinitionsEventMap & ProjectsEventMap>();
 
 export interface CreateDefinitionsModuleOptions {
+  projects: ProjectsModuleClient;
   sourceControl: IntegrationSourceControlService;
   agentToolSelectionCatalogs?: AgentToolSelectionCatalogs | undefined;
   loadWorkspaceConnectionSnapshot?: LoadWorkspaceConnectionSnapshot | undefined;
@@ -57,6 +58,7 @@ export interface CreateDefinitionsModuleOptions {
 }
 
 export function createDefinitionsModule({
+  projects,
   sourceControl,
   agentToolSelectionCatalogs,
   loadWorkspaceConnectionSnapshot,
@@ -77,6 +79,7 @@ export function createDefinitionsModule({
     name: 'definitions',
     database: {db, migrationsPath},
     routes: createDefinitionRoutes({
+      projects,
       agentToolSelectionCatalogs,
       loadWorkspaceConnectionSnapshot,
       getIntegrationConnectionById,

--- a/libs/api/definitions/src/presentation/index.ts
+++ b/libs/api/definitions/src/presentation/index.ts
@@ -1,1 +1,1 @@
-export {createDefinitionRoutes, definitionRoutes as routes} from './routes/index.js';
+export {createDefinitionRoutes} from './routes/index.js';

--- a/libs/api/definitions/src/presentation/routes/create-definition.test.ts
+++ b/libs/api/definitions/src/presentation/routes/create-definition.test.ts
@@ -1,24 +1,26 @@
 import {buildUserContext, setUserContext} from '@shipfox/api-auth-context';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
 import type {FastifyInstance} from 'fastify';
 import Fastify from 'fastify';
 import {serializerCompiler, validatorCompiler} from 'fastify-type-provider-zod';
-import {buildCreateDefinitionRoute, createDefinitionRoute} from './create-definition.js';
+import {buildCreateDefinitionRoute} from './create-definition.js';
 
 const projectAccessState = vi.hoisted(() => ({workspaceId: '', sourceConnectionId: ''}));
 
-vi.mock('@shipfox/api-projects', () => ({
-  ProjectNotFoundError: class ProjectNotFoundError extends Error {},
-  requireProjectAccess: vi.fn(({projectId}) =>
+const projects = {
+  getProjectById: vi.fn(({projectId}) =>
     Promise.resolve({
       project: {
         id: projectId,
         workspaceId: projectAccessState.workspaceId,
         sourceConnectionId: projectAccessState.sourceConnectionId,
+        sourceExternalRepositoryId: 'repo',
+        name: 'Project',
       },
-      workspaceId: projectAccessState.workspaceId,
     }),
   ),
-}));
+  requireProjectForWorkspace: vi.fn(),
+} as unknown as ProjectsModuleClient;
 
 describe('POST /api/definitions', () => {
   let app: FastifyInstance;
@@ -40,7 +42,7 @@ describe('POST /api/definitions', () => {
       );
       done();
     });
-    app.post('/api/definitions', createDefinitionRoute);
+    app.post('/api/definitions', buildCreateDefinitionRoute({projects}));
     await app.ready();
   });
 
@@ -100,6 +102,7 @@ jobs:
     appWithOptions.post(
       '/api/definitions',
       buildCreateDefinitionRoute({
+        projects,
         agentToolSelectionCatalogs: new Map(),
         loadWorkspaceConnectionSnapshot,
       }),
@@ -165,6 +168,7 @@ jobs:
     appWithOptions.post(
       '/api/definitions',
       buildCreateDefinitionRoute({
+        projects,
         agentToolSelectionCatalogs: new Map([
           [
             'github',

--- a/libs/api/definitions/src/presentation/routes/create-definition.ts
+++ b/libs/api/definitions/src/presentation/routes/create-definition.ts
@@ -8,7 +8,7 @@ import type {
   GetIntegrationConnectionByIdFn,
   LoadWorkspaceConnectionSnapshot,
 } from '@shipfox/api-integration-core';
-import {ProjectNotFoundError, requireProjectAccess} from '@shipfox/api-projects';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
 import {DefinitionParseError} from '#core/errors.js';
@@ -16,14 +16,16 @@ import {hasAgentStepIntegrations} from '#core/has-agent-step-integrations.js';
 import {parseDefinition} from '#core/parse-definition.js';
 import {upsertDefinition} from '#db/definitions.js';
 import {toDefinitionDto} from '#presentation/dto/index.js';
+import {requireProjectAccess} from './project-access.js';
 
 export interface CreateDefinitionRouteOptions {
+  projects: ProjectsModuleClient;
   agentToolSelectionCatalogs?: AgentToolSelectionCatalogs | undefined;
   loadWorkspaceConnectionSnapshot?: LoadWorkspaceConnectionSnapshot | undefined;
   getIntegrationConnectionById?: GetIntegrationConnectionByIdFn | undefined;
 }
 
-export function buildCreateDefinitionRoute(options: CreateDefinitionRouteOptions = {}) {
+export function buildCreateDefinitionRoute(options: CreateDefinitionRouteOptions) {
   return defineRoute({
     method: 'POST',
     path: '/',
@@ -47,14 +49,11 @@ export function buildCreateDefinitionRoute(options: CreateDefinitionRouteOptions
           status: 400,
         });
       }
-      if (error instanceof ProjectNotFoundError) {
-        throw new ClientError(error.message, 'project-not-found', {status: 404});
-      }
       throw error;
     },
     handler: async (request) => {
       const {project_id: projectId, config_path, source, yaml: yamlString, sha, ref} = request.body;
-      const {project} = await requireProjectAccess({request, projectId});
+      const project = await requireProjectAccess(request, projectId, options.projects);
 
       const structurallyParsed = parseDefinition(yamlString);
       const {
@@ -97,5 +96,3 @@ export function buildCreateDefinitionRoute(options: CreateDefinitionRouteOptions
     },
   });
 }
-
-export const createDefinitionRoute = buildCreateDefinitionRoute();

--- a/libs/api/definitions/src/presentation/routes/get-definition.test.ts
+++ b/libs/api/definitions/src/presentation/routes/get-definition.test.ts
@@ -1,21 +1,27 @@
 import {buildUserContext, setUserContext} from '@shipfox/api-auth-context';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
 import type {FastifyInstance} from 'fastify';
 import Fastify from 'fastify';
 import {serializerCompiler, validatorCompiler} from 'fastify-type-provider-zod';
 import {definitionFactory} from '#test/index.js';
-import {getDefinitionRoute} from './get-definition.js';
+import {buildGetDefinitionRoute} from './get-definition.js';
 
 const projectAccessState = vi.hoisted(() => ({workspaceId: ''}));
 
-vi.mock('@shipfox/api-projects', () => ({
-  ProjectNotFoundError: class ProjectNotFoundError extends Error {},
-  requireProjectAccess: vi.fn(({projectId}) =>
+const projects = {
+  getProjectById: vi.fn(({projectId}) =>
     Promise.resolve({
-      project: {id: projectId, workspaceId: projectAccessState.workspaceId},
-      workspaceId: projectAccessState.workspaceId,
+      project: {
+        id: projectId,
+        workspaceId: projectAccessState.workspaceId,
+        sourceConnectionId: crypto.randomUUID(),
+        sourceExternalRepositoryId: 'repo',
+        name: 'Project',
+      },
     }),
   ),
-}));
+  requireProjectForWorkspace: vi.fn(),
+} as unknown as ProjectsModuleClient;
 
 describe('GET /api/definitions/:id', () => {
   let app: FastifyInstance;
@@ -36,7 +42,7 @@ describe('GET /api/definitions/:id', () => {
       );
       done();
     });
-    app.get('/api/definitions/:id', getDefinitionRoute);
+    app.get('/api/definitions/:id', buildGetDefinitionRoute(projects));
     await app.ready();
   });
 

--- a/libs/api/definitions/src/presentation/routes/get-definition.ts
+++ b/libs/api/definitions/src/presentation/routes/get-definition.ts
@@ -1,37 +1,34 @@
 import {definitionResponseSchema} from '@shipfox/api-definitions-dto';
-import {ProjectNotFoundError, requireProjectAccess} from '@shipfox/api-projects';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
 import {getDefinitionById} from '#db/definitions.js';
 import {toDefinitionDto} from '#presentation/dto/index.js';
+import {requireProjectAccess} from './project-access.js';
 
-export const getDefinitionRoute = defineRoute({
-  method: 'GET',
-  path: '/:id',
-  description: 'Get a definition by ID',
-  schema: {
-    params: z.object({
-      id: z.string().uuid(),
-    }),
-    response: {
-      200: definitionResponseSchema,
+export function buildGetDefinitionRoute(projects: ProjectsModuleClient) {
+  return defineRoute({
+    method: 'GET',
+    path: '/:id',
+    description: 'Get a definition by ID',
+    schema: {
+      params: z.object({
+        id: z.string().uuid(),
+      }),
+      response: {
+        200: definitionResponseSchema,
+      },
     },
-  },
-  errorHandler: (error) => {
-    if (error instanceof ProjectNotFoundError) {
-      throw new ClientError('Definition not found', 'not-found', {status: 404});
-    }
-    throw error;
-  },
-  handler: async (request) => {
-    const {id} = request.params;
-    const definition = await getDefinitionById(id);
+    handler: async (request) => {
+      const {id} = request.params;
+      const definition = await getDefinitionById(id);
 
-    if (!definition) {
-      throw new ClientError('Definition not found', 'not-found', {status: 404});
-    }
-    await requireProjectAccess({request, projectId: definition.projectId});
+      if (!definition) {
+        throw new ClientError('Definition not found', 'not-found', {status: 404});
+      }
+      await requireProjectAccess(request, definition.projectId, projects);
 
-    return toDefinitionDto(definition);
-  },
-});
+      return toDefinitionDto(definition);
+    },
+  });
+}

--- a/libs/api/definitions/src/presentation/routes/index.test.ts
+++ b/libs/api/definitions/src/presentation/routes/index.test.ts
@@ -1,7 +1,14 @@
 import {AUTH_USER, buildUserContext, setUserContext} from '@shipfox/api-auth-context';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
 import {type AuthMethod, ClientError, closeApp, createApp} from '@shipfox/node-fastify';
 import type {FastifyRequest} from 'fastify';
-import {definitionRoutes} from './index.js';
+import {createDefinitionRoutes} from './index.js';
+
+const projects = {
+  getProjectById: vi.fn(),
+  requireProjectForWorkspace: vi.fn(),
+} as unknown as ProjectsModuleClient;
+const definitionRoutes = createDefinitionRoutes({projects});
 
 const fakeUserAuth: AuthMethod = {
   name: AUTH_USER,

--- a/libs/api/definitions/src/presentation/routes/index.ts
+++ b/libs/api/definitions/src/presentation/routes/index.ts
@@ -4,25 +4,23 @@ import {
   buildCreateDefinitionRoute,
   type CreateDefinitionRouteOptions,
 } from './create-definition.js';
-import {getDefinitionRoute} from './get-definition.js';
-import {listDefinitionsRoute} from './list-definitions.js';
+import {buildGetDefinitionRoute} from './get-definition.js';
+import {buildListDefinitionsRoute} from './list-definitions.js';
 import {validateDefinitionRoute} from './validate-definition.js';
 
 export interface DefinitionRouteOptions extends CreateDefinitionRouteOptions {}
 
-export function createDefinitionRoutes(options: DefinitionRouteOptions = {}): RouteGroup[] {
+export function createDefinitionRoutes(options: DefinitionRouteOptions): RouteGroup[] {
   return [
     {
       prefix: '/definitions',
       auth: AUTH_USER,
       routes: [
         buildCreateDefinitionRoute(options),
-        listDefinitionsRoute,
-        getDefinitionRoute,
+        buildListDefinitionsRoute(options.projects),
+        buildGetDefinitionRoute(options.projects),
         validateDefinitionRoute,
       ],
     },
   ];
 }
-
-export const definitionRoutes = createDefinitionRoutes();

--- a/libs/api/definitions/src/presentation/routes/list-definitions.test.ts
+++ b/libs/api/definitions/src/presentation/routes/list-definitions.test.ts
@@ -1,11 +1,12 @@
 import {buildUserContext, setUserContext} from '@shipfox/api-auth-context';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
 import {encodeStringIdCursor} from '@shipfox/node-drizzle';
 import type {FastifyInstance} from 'fastify';
 import Fastify from 'fastify';
 import {serializerCompiler, validatorCompiler} from 'fastify-type-provider-zod';
 import {markDefinitionSyncState} from '#db/index.js';
 import {definitionFactory} from '#test/index.js';
-import {listDefinitionsRoute} from './list-definitions.js';
+import {buildListDefinitionsRoute} from './list-definitions.js';
 
 const projectAccessState = vi.hoisted(() => ({
   workspaceId: '',
@@ -13,20 +14,20 @@ const projectAccessState = vi.hoisted(() => ({
   sourceExternalRepositoryId: '',
 }));
 
-vi.mock('@shipfox/api-projects', () => ({
-  ProjectNotFoundError: class ProjectNotFoundError extends Error {},
-  requireProjectAccess: vi.fn(({projectId}) =>
+const projects = {
+  getProjectById: vi.fn(({projectId}) =>
     Promise.resolve({
       project: {
         id: projectId,
         workspaceId: projectAccessState.workspaceId,
         sourceConnectionId: projectAccessState.sourceConnectionId,
         sourceExternalRepositoryId: projectAccessState.sourceExternalRepositoryId,
+        name: 'Project',
       },
-      workspaceId: projectAccessState.workspaceId,
     }),
   ),
-}));
+  requireProjectForWorkspace: vi.fn(),
+} as unknown as ProjectsModuleClient;
 
 describe('GET /api/definitions', () => {
   let app: FastifyInstance;
@@ -50,7 +51,7 @@ describe('GET /api/definitions', () => {
       );
       done();
     });
-    app.get('/api/definitions', listDefinitionsRoute);
+    app.get('/api/definitions', buildListDefinitionsRoute(projects));
     await app.ready();
   });
 

--- a/libs/api/definitions/src/presentation/routes/list-definitions.ts
+++ b/libs/api/definitions/src/presentation/routes/list-definitions.ts
@@ -2,48 +2,45 @@ import {
   definitionListQuerySchema,
   definitionListResponseSchema,
 } from '@shipfox/api-definitions-dto';
-import {ProjectNotFoundError, requireProjectAccess} from '@shipfox/api-projects';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
 import {decodeStringIdCursor, encodeStringIdCursor} from '@shipfox/node-drizzle';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {listDefinitions} from '#db/definitions.js';
 import {getLatestDefinitionSyncState} from '#db/sync-states.js';
 import {toDefinitionDto, toDefinitionSyncSummaryDto} from '#presentation/dto/index.js';
+import {requireProjectAccess} from './project-access.js';
 
-export const listDefinitionsRoute = defineRoute({
-  method: 'GET',
-  path: '/',
-  description: 'List all definitions for a project',
-  schema: {
-    querystring: definitionListQuerySchema,
-    response: {
-      200: definitionListResponseSchema,
+export function buildListDefinitionsRoute(projects: ProjectsModuleClient) {
+  return defineRoute({
+    method: 'GET',
+    path: '/',
+    description: 'List all definitions for a project',
+    schema: {
+      querystring: definitionListQuerySchema,
+      response: {
+        200: definitionListResponseSchema,
+      },
     },
-  },
-  errorHandler: (error) => {
-    if (error instanceof ProjectNotFoundError) {
-      throw new ClientError(error.message, 'project-not-found', {status: 404});
-    }
-    throw error;
-  },
-  handler: async (request) => {
-    const {project_id: projectId, limit, cursor} = request.query;
-    const decodedCursor = decodeStringIdCursor(cursor);
-    if (cursor && !decodedCursor) {
-      throw new ClientError('Invalid cursor', 'invalid-cursor', {status: 400});
-    }
+    handler: async (request) => {
+      const {project_id: projectId, limit, cursor} = request.query;
+      const decodedCursor = decodeStringIdCursor(cursor);
+      if (cursor && !decodedCursor) {
+        throw new ClientError('Invalid cursor', 'invalid-cursor', {status: 400});
+      }
 
-    const {project} = await requireProjectAccess({request, projectId});
-    const result = await listDefinitions({projectId, limit, cursor: decodedCursor});
-    const syncState = await getLatestDefinitionSyncState({
-      projectId,
-      sourceConnectionId: project.sourceConnectionId,
-      sourceExternalRepositoryId: project.sourceExternalRepositoryId,
-    });
+      const project = await requireProjectAccess(request, projectId, projects);
+      const result = await listDefinitions({projectId, limit, cursor: decodedCursor});
+      const syncState = await getLatestDefinitionSyncState({
+        projectId,
+        sourceConnectionId: project.sourceConnectionId,
+        sourceExternalRepositoryId: project.sourceExternalRepositoryId,
+      });
 
-    return {
-      definitions: result.definitions.map(toDefinitionDto),
-      sync: toDefinitionSyncSummaryDto(syncState),
-      next_cursor: result.nextCursor ? encodeStringIdCursor(result.nextCursor) : null,
-    };
-  },
-});
+      return {
+        definitions: result.definitions.map(toDefinitionDto),
+        sync: toDefinitionSyncSummaryDto(syncState),
+        next_cursor: result.nextCursor ? encodeStringIdCursor(result.nextCursor) : null,
+      };
+    },
+  });
+}

--- a/libs/api/definitions/src/presentation/routes/project-access.ts
+++ b/libs/api/definitions/src/presentation/routes/project-access.ts
@@ -1,0 +1,16 @@
+import {requireWorkspaceAccess} from '@shipfox/api-auth-context';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import {ClientError} from '@shipfox/node-fastify';
+import type {FastifyRequest} from 'fastify';
+
+export async function requireProjectAccess(
+  request: FastifyRequest,
+  projectId: string,
+  projects: ProjectsModuleClient,
+) {
+  const {project} = await projects.getProjectById({projectId});
+  if (project === null)
+    throw new ClientError('Project not found', 'project-not-found', {status: 404});
+  requireWorkspaceAccess({request, workspaceId: project.workspaceId});
+  return project;
+}

--- a/libs/api/projects-dto/package.json
+++ b/libs/api/projects-dto/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@shipfox/api-common-dto": "workspace:*",
+    "@shipfox/inter-module": "workspace:*",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/libs/api/projects-dto/src/index.ts
+++ b/libs/api/projects-dto/src/index.ts
@@ -1,3 +1,4 @@
 export * from './e2e/index.js';
 export * from './events.js';
+export * from './inter-module.js';
 export * from './schemas/index.js';

--- a/libs/api/projects-dto/src/inter-module.ts
+++ b/libs/api/projects-dto/src/inter-module.ts
@@ -1,0 +1,32 @@
+import {defineInterModuleContract, type InterModuleClient} from '@shipfox/inter-module';
+import {z} from 'zod';
+
+const idSchema = z.string().uuid();
+const projectSchema = z.object({
+  id: idSchema,
+  workspaceId: idSchema,
+  sourceConnectionId: idSchema,
+  sourceExternalRepositoryId: z.string(),
+  name: z.string(),
+});
+
+/** Producer-owned project lookup and workspace ownership operations. */
+export const projectsInterModuleContract = defineInterModuleContract({
+  module: 'projects',
+  methods: {
+    getProjectById: {
+      input: z.object({projectId: idSchema}),
+      output: z.object({project: projectSchema.nullable()}),
+    },
+    requireProjectForWorkspace: {
+      input: z.object({projectId: idSchema, workspaceId: idSchema}),
+      output: z.object({project: projectSchema}),
+      errors: {
+        'project-not-found': z.object({projectId: idSchema}),
+        'project-workspace-mismatch': z.object({projectId: idSchema, workspaceId: idSchema}),
+      },
+    },
+  },
+});
+
+export type ProjectsModuleClient = InterModuleClient<typeof projectsInterModuleContract>;

--- a/libs/api/projects/package.json
+++ b/libs/api/projects/package.json
@@ -44,6 +44,7 @@
     "@shipfox/api-integration-core": "workspace:*",
     "@shipfox/api-integration-core-dto": "workspace:*",
     "@shipfox/api-projects-dto": "workspace:*",
+    "@shipfox/inter-module": "workspace:*",
     "@shipfox/node-drizzle": "workspace:*",
     "@shipfox/node-fastify": "workspace:*",
     "@shipfox/node-module": "workspace:*",

--- a/libs/api/projects/src/index.ts
+++ b/libs/api/projects/src/index.ts
@@ -11,6 +11,7 @@ import {db, migrationsPath, projectsOutbox} from '#db/index.js';
 import {registerProjectsServiceMetrics} from '#metrics/index.js';
 import {projectsE2eRoutes} from '#presentation/e2eRoutes/index.js';
 import {createProjectRoutes} from '#presentation/index.js';
+import {createProjectsInterModulePresentation} from '#presentation/inter-module.js';
 import {onSourceCommitPushed} from '#presentation/subscribers/index.js';
 import {createProjectsMaintenanceActivities} from '#temporal/activities/index.js';
 import {PROJECTS_MAINTENANCE_TASK_QUEUE} from '#temporal/constants.js';
@@ -52,6 +53,7 @@ export function createProjectsModule({sourceControl}: CreateProjectsModuleOption
     e2eRoutes: [projectsE2eRoutes],
     metrics: registerProjectsServiceMetrics,
     publishers: [{name: 'projects', table: projectsOutbox, db, eventSchemas: projectsEventSchemas}],
+    interModulePresentations: [createProjectsInterModulePresentation()],
     subscribers: [subscriber(INTEGRATION_SOURCE_COMMIT_PUSHED, onSourceCommitPushed)],
     workers: [
       {

--- a/libs/api/projects/src/presentation/inter-module.ts
+++ b/libs/api/projects/src/presentation/inter-module.ts
@@ -1,0 +1,33 @@
+import {projectsInterModuleContract} from '@shipfox/api-projects-dto';
+import {
+  createInterModuleKnownError,
+  defineInterModulePresentation,
+  type InterModulePresentation,
+} from '@shipfox/inter-module';
+import {getProjectById} from '#db/projects.js';
+
+export function createProjectsInterModulePresentation(): InterModulePresentation<
+  typeof projectsInterModuleContract
+> {
+  return defineInterModulePresentation(projectsInterModuleContract, {
+    getProjectById: async ({projectId}) => ({project: (await getProjectById(projectId)) ?? null}),
+    requireProjectForWorkspace: async ({projectId, workspaceId}) => {
+      const project = await getProjectById(projectId);
+      if (project === undefined) {
+        throw createInterModuleKnownError(
+          projectsInterModuleContract.methods.requireProjectForWorkspace,
+          'project-not-found',
+          {projectId},
+        );
+      }
+      if (project.workspaceId !== workspaceId) {
+        throw createInterModuleKnownError(
+          projectsInterModuleContract.methods.requireProjectForWorkspace,
+          'project-workspace-mismatch',
+          {projectId, workspaceId},
+        );
+      }
+      return {project};
+    },
+  });
+}

--- a/libs/api/secrets/package.json
+++ b/libs/api/secrets/package.json
@@ -51,9 +51,10 @@
   },
   "dependencies": {
     "@shipfox/api-auth-context": "workspace:*",
-    "@shipfox/api-projects": "workspace:*",
+    "@shipfox/api-projects-dto": "workspace:*",
     "@shipfox/api-secrets-dto": "workspace:*",
     "@shipfox/config": "workspace:*",
+    "@shipfox/inter-module": "workspace:*",
     "@shipfox/node-drizzle": "workspace:*",
     "@shipfox/node-fastify": "workspace:*",
     "@shipfox/node-module": "workspace:*",

--- a/libs/api/secrets/src/index.ts
+++ b/libs/api/secrets/src/index.ts
@@ -1,9 +1,10 @@
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
 import {secretsEventSchemas} from '@shipfox/api-secrets-dto';
 import type {ShipfoxModule} from '@shipfox/node-module';
 import {db, migrationsPath, secretsOutbox} from '#db/index.js';
 import {registerSecretsServiceMetrics} from '#metrics/index.js';
 import {secretsE2eRoutes} from '#presentation/e2eRoutes/index.js';
-import {secretsRoutes} from '#presentation/routes/index.js';
+import {createSecretsRoutes} from '#presentation/routes/index.js';
 
 export {
   BUILTIN_LOCAL_STORE,
@@ -40,11 +41,19 @@ export {
   WorkspaceSecretCapExceededError,
 } from '#core/index.js';
 
+export function createSecretsModule(projects: ProjectsModuleClient): ShipfoxModule {
+  return {
+    name: 'secrets',
+    database: {db, migrationsPath},
+    routes: createSecretsRoutes(projects),
+    e2eRoutes: [secretsE2eRoutes],
+    metrics: registerSecretsServiceMetrics,
+    publishers: [{name: 'secrets', table: secretsOutbox, db, eventSchemas: secretsEventSchemas}],
+  };
+}
+
+// Migration setup imports this declaration only for the owned database metadata.
 export const secretsModule: ShipfoxModule = {
   name: 'secrets',
   database: {db, migrationsPath},
-  routes: secretsRoutes,
-  e2eRoutes: [secretsE2eRoutes],
-  metrics: registerSecretsServiceMetrics,
-  publishers: [{name: 'secrets', table: secretsOutbox, db, eventSchemas: secretsEventSchemas}],
 };

--- a/libs/api/secrets/src/presentation/routes/auth.ts
+++ b/libs/api/secrets/src/presentation/routes/auth.ts
@@ -1,5 +1,6 @@
 import {requireWorkspaceAccess} from '@shipfox/api-auth-context';
-import {requireProjectForWorkspace} from '@shipfox/api-projects';
+import {type ProjectsModuleClient, projectsInterModuleContract} from '@shipfox/api-projects-dto';
+import {isInterModuleKnownError} from '@shipfox/inter-module';
 import {ClientError} from '@shipfox/node-fastify';
 import type {FastifyRequest} from 'fastify';
 
@@ -8,30 +9,61 @@ export interface ManagementAccess {
   userId: string;
 }
 
-export async function requireManagementRead(params: {
-  request: FastifyRequest;
-  workspaceId: string;
-  projectId?: string | undefined;
-}): Promise<ManagementAccess> {
+export interface ManagementAccessHelpers {
+  requireManagementRead(params: {
+    request: FastifyRequest;
+    workspaceId: string;
+    projectId?: string | undefined;
+  }): Promise<ManagementAccess>;
+  requireManagementWrite(params: {
+    request: FastifyRequest;
+    workspaceId: string;
+    projectId?: string | undefined;
+  }): Promise<ManagementAccess>;
+}
+
+export function createManagementAccess(projects: ProjectsModuleClient): ManagementAccessHelpers {
+  return {
+    requireManagementRead: (params: {
+      request: FastifyRequest;
+      workspaceId: string;
+      projectId?: string | undefined;
+    }) => requireManagementRead(params, projects),
+    requireManagementWrite: (params: {
+      request: FastifyRequest;
+      workspaceId: string;
+      projectId?: string | undefined;
+    }) => requireManagementWrite(params, projects),
+  };
+}
+
+async function requireManagementRead(
+  params: {
+    request: FastifyRequest;
+    workspaceId: string;
+    projectId?: string | undefined;
+  },
+  projects: ProjectsModuleClient,
+): Promise<ManagementAccess> {
   const membership = requireWorkspaceAccess({
     request: params.request,
     workspaceId: params.workspaceId,
   });
   if (params.projectId) {
-    await requireProjectForWorkspace({
-      workspaceId: params.workspaceId,
-      projectId: params.projectId,
-    });
+    await requireProjectForWorkspace(params.workspaceId, params.projectId, projects);
   }
 
   return {workspaceId: params.workspaceId, userId: membership.userId};
 }
 
-export async function requireManagementWrite(params: {
-  request: FastifyRequest;
-  workspaceId: string;
-  projectId?: string | undefined;
-}): Promise<ManagementAccess> {
+async function requireManagementWrite(
+  params: {
+    request: FastifyRequest;
+    workspaceId: string;
+    projectId?: string | undefined;
+  },
+  projects: ProjectsModuleClient,
+): Promise<ManagementAccess> {
   const membership = requireWorkspaceAccess({
     request: params.request,
     workspaceId: params.workspaceId,
@@ -40,11 +72,25 @@ export async function requireManagementWrite(params: {
     throw new ClientError('Workspace admin role required', 'forbidden', {status: 403});
   }
   if (params.projectId) {
-    await requireProjectForWorkspace({
-      workspaceId: params.workspaceId,
-      projectId: params.projectId,
-    });
+    await requireProjectForWorkspace(params.workspaceId, params.projectId, projects);
   }
 
   return {workspaceId: params.workspaceId, userId: membership.userId};
+}
+
+async function requireProjectForWorkspace(
+  workspaceId: string,
+  projectId: string,
+  projects: ProjectsModuleClient,
+): Promise<void> {
+  try {
+    await projects.requireProjectForWorkspace({workspaceId, projectId});
+  } catch (error) {
+    if (
+      isInterModuleKnownError(projectsInterModuleContract.methods.requireProjectForWorkspace, error)
+    ) {
+      throw new ClientError('Project not found', 'project-not-found', {status: 404});
+    }
+    throw error;
+  }
 }

--- a/libs/api/secrets/src/presentation/routes/batch-secrets.ts
+++ b/libs/api/secrets/src/presentation/routes/batch-secrets.ts
@@ -3,31 +3,33 @@ import {defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
 import {setManagedSecrets} from '#core/index.js';
 import {toSecretDto} from '#presentation/dto/index.js';
-import {requireManagementWrite} from './auth.js';
+import type {ManagementAccessHelpers} from './auth.js';
 import {translateManagementError} from './errors.js';
 import {secretWarnings} from './warnings.js';
 
-export const batchSecretsRoute = defineRoute({
-  method: 'POST',
-  path: '/secrets::batch',
-  description: 'Create or update multiple user-managed secrets in one scope.',
-  schema: {
-    params: z.object({workspaceId: z.string().uuid()}),
-    body: batchSecretsBodySchema,
-    response: {200: batchSecretsResponseSchema},
-  },
-  errorHandler: translateManagementError,
-  handler: async (request) => {
-    const {workspaceId} = request.params;
-    const {project_id: projectId, entries} = request.body;
-    const access = await requireManagementWrite({request, workspaceId, projectId});
-    const secrets = await setManagedSecrets({
-      workspaceId,
-      projectId,
-      actorId: access.userId,
-      entries,
-    });
+export function batchSecretsRoute(accessControl: ManagementAccessHelpers) {
+  return defineRoute({
+    method: 'POST',
+    path: '/secrets::batch',
+    description: 'Create or update multiple user-managed secrets in one scope.',
+    schema: {
+      params: z.object({workspaceId: z.string().uuid()}),
+      body: batchSecretsBodySchema,
+      response: {200: batchSecretsResponseSchema},
+    },
+    errorHandler: translateManagementError,
+    handler: async (request) => {
+      const {workspaceId} = request.params;
+      const {project_id: projectId, entries} = request.body;
+      const access = await accessControl.requireManagementWrite({request, workspaceId, projectId});
+      const secrets = await setManagedSecrets({
+        workspaceId,
+        projectId,
+        actorId: access.userId,
+        entries,
+      });
 
-    return {secrets: secrets.map(toSecretDto), warnings: secretWarnings(entries)};
-  },
-});
+      return {secrets: secrets.map(toSecretDto), warnings: secretWarnings(entries)};
+    },
+  });
+}

--- a/libs/api/secrets/src/presentation/routes/batch-variables.ts
+++ b/libs/api/secrets/src/presentation/routes/batch-variables.ts
@@ -3,31 +3,33 @@ import {defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
 import {setManagedVariables} from '#core/index.js';
 import {toVariableDto} from '#presentation/dto/index.js';
-import {requireManagementWrite} from './auth.js';
+import type {ManagementAccessHelpers} from './auth.js';
 import {translateManagementError} from './errors.js';
 import {variableWarnings} from './warnings.js';
 
-export const batchVariablesRoute = defineRoute({
-  method: 'POST',
-  path: '/variables::batch',
-  description: 'Create or update multiple user-managed variables in one scope.',
-  schema: {
-    params: z.object({workspaceId: z.string().uuid()}),
-    body: batchVariablesBodySchema,
-    response: {200: batchVariablesResponseSchema},
-  },
-  errorHandler: translateManagementError,
-  handler: async (request) => {
-    const {workspaceId} = request.params;
-    const {project_id: projectId, entries} = request.body;
-    const access = await requireManagementWrite({request, workspaceId, projectId});
-    const variables = await setManagedVariables({
-      workspaceId,
-      projectId,
-      actorId: access.userId,
-      entries,
-    });
+export function batchVariablesRoute(accessControl: ManagementAccessHelpers) {
+  return defineRoute({
+    method: 'POST',
+    path: '/variables::batch',
+    description: 'Create or update multiple user-managed variables in one scope.',
+    schema: {
+      params: z.object({workspaceId: z.string().uuid()}),
+      body: batchVariablesBodySchema,
+      response: {200: batchVariablesResponseSchema},
+    },
+    errorHandler: translateManagementError,
+    handler: async (request) => {
+      const {workspaceId} = request.params;
+      const {project_id: projectId, entries} = request.body;
+      const access = await accessControl.requireManagementWrite({request, workspaceId, projectId});
+      const variables = await setManagedVariables({
+        workspaceId,
+        projectId,
+        actorId: access.userId,
+        entries,
+      });
 
-    return {variables: variables.map(toVariableDto), warnings: variableWarnings(entries)};
-  },
-});
+      return {variables: variables.map(toVariableDto), warnings: variableWarnings(entries)};
+    },
+  });
+}

--- a/libs/api/secrets/src/presentation/routes/delete-secret.ts
+++ b/libs/api/secrets/src/presentation/routes/delete-secret.ts
@@ -2,25 +2,27 @@ import {secretKeySchema, secretScopeQuerySchema} from '@shipfox/api-secrets-dto'
 import {defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
 import {deleteManagedSecret} from '#core/index.js';
-import {requireManagementWrite} from './auth.js';
+import type {ManagementAccessHelpers} from './auth.js';
 import {translateManagementError} from './errors.js';
 
-export const deleteSecretRoute = defineRoute({
-  method: 'DELETE',
-  path: '/secrets/:key',
-  description: 'Delete a user-managed secret.',
-  schema: {
-    params: z.object({workspaceId: z.string().uuid(), key: secretKeySchema}),
-    querystring: secretScopeQuerySchema,
-    response: {204: z.void()},
-  },
-  errorHandler: translateManagementError,
-  handler: async (request, reply) => {
-    const {workspaceId, key} = request.params;
-    const {project_id: projectId} = request.query;
-    const access = await requireManagementWrite({request, workspaceId, projectId});
+export function deleteSecretRoute(accessControl: ManagementAccessHelpers) {
+  return defineRoute({
+    method: 'DELETE',
+    path: '/secrets/:key',
+    description: 'Delete a user-managed secret.',
+    schema: {
+      params: z.object({workspaceId: z.string().uuid(), key: secretKeySchema}),
+      querystring: secretScopeQuerySchema,
+      response: {204: z.void()},
+    },
+    errorHandler: translateManagementError,
+    handler: async (request, reply) => {
+      const {workspaceId, key} = request.params;
+      const {project_id: projectId} = request.query;
+      const access = await accessControl.requireManagementWrite({request, workspaceId, projectId});
 
-    await deleteManagedSecret({workspaceId, projectId, key, actorId: access.userId});
-    return reply.status(204).send();
-  },
-});
+      await deleteManagedSecret({workspaceId, projectId, key, actorId: access.userId});
+      return reply.status(204).send();
+    },
+  });
+}

--- a/libs/api/secrets/src/presentation/routes/delete-variable.ts
+++ b/libs/api/secrets/src/presentation/routes/delete-variable.ts
@@ -2,25 +2,27 @@ import {secretKeySchema, secretScopeQuerySchema} from '@shipfox/api-secrets-dto'
 import {defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
 import {deleteManagedVariable} from '#core/index.js';
-import {requireManagementWrite} from './auth.js';
+import type {ManagementAccessHelpers} from './auth.js';
 import {translateManagementError} from './errors.js';
 
-export const deleteVariableRoute = defineRoute({
-  method: 'DELETE',
-  path: '/variables/:key',
-  description: 'Delete a user-managed variable.',
-  schema: {
-    params: z.object({workspaceId: z.string().uuid(), key: secretKeySchema}),
-    querystring: secretScopeQuerySchema,
-    response: {204: z.void()},
-  },
-  errorHandler: translateManagementError,
-  handler: async (request, reply) => {
-    const {workspaceId, key} = request.params;
-    const {project_id: projectId} = request.query;
-    const access = await requireManagementWrite({request, workspaceId, projectId});
+export function deleteVariableRoute(accessControl: ManagementAccessHelpers) {
+  return defineRoute({
+    method: 'DELETE',
+    path: '/variables/:key',
+    description: 'Delete a user-managed variable.',
+    schema: {
+      params: z.object({workspaceId: z.string().uuid(), key: secretKeySchema}),
+      querystring: secretScopeQuerySchema,
+      response: {204: z.void()},
+    },
+    errorHandler: translateManagementError,
+    handler: async (request, reply) => {
+      const {workspaceId, key} = request.params;
+      const {project_id: projectId} = request.query;
+      const access = await accessControl.requireManagementWrite({request, workspaceId, projectId});
 
-    await deleteManagedVariable({workspaceId, projectId, key, actorId: access.userId});
-    return reply.status(204).send();
-  },
-});
+      await deleteManagedVariable({workspaceId, projectId, key, actorId: access.userId});
+      return reply.status(204).send();
+    },
+  });
+}

--- a/libs/api/secrets/src/presentation/routes/errors.ts
+++ b/libs/api/secrets/src/presentation/routes/errors.ts
@@ -1,4 +1,3 @@
-import {ProjectNotFoundError} from '@shipfox/api-projects';
 import {ClientError} from '@shipfox/node-fastify';
 import {
   NamespaceValidationError,
@@ -55,9 +54,5 @@ export function translateManagementError(error: unknown): never {
   if (error instanceof UnknownSecretStoreError) {
     throw new ClientError('Unknown secret store', 'unknown-secret-store', {status: 400});
   }
-  if (error instanceof ProjectNotFoundError) {
-    throw new ClientError('Project not found', 'project-not-found', {status: 404});
-  }
-
   throw error;
 }

--- a/libs/api/secrets/src/presentation/routes/get-variable.ts
+++ b/libs/api/secrets/src/presentation/routes/get-variable.ts
@@ -7,26 +7,28 @@ import {defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
 import {getManagedVariable} from '#core/index.js';
 import {toVariableDto} from '#presentation/dto/index.js';
-import {requireManagementRead} from './auth.js';
+import type {ManagementAccessHelpers} from './auth.js';
 import {translateManagementError} from './errors.js';
 
-export const getVariableRoute = defineRoute({
-  method: 'GET',
-  path: '/variables/:key',
-  description: 'Read a user-managed variable.',
-  schema: {
-    params: z.object({workspaceId: z.string().uuid(), key: secretKeySchema}),
-    querystring: secretScopeQuerySchema,
-    response: {200: getVariableResponseSchema},
-  },
-  errorHandler: translateManagementError,
-  handler: async (request) => {
-    const {workspaceId, key} = request.params;
-    const {project_id: projectId} = request.query;
+export function getVariableRoute(accessControl: ManagementAccessHelpers) {
+  return defineRoute({
+    method: 'GET',
+    path: '/variables/:key',
+    description: 'Read a user-managed variable.',
+    schema: {
+      params: z.object({workspaceId: z.string().uuid(), key: secretKeySchema}),
+      querystring: secretScopeQuerySchema,
+      response: {200: getVariableResponseSchema},
+    },
+    errorHandler: translateManagementError,
+    handler: async (request) => {
+      const {workspaceId, key} = request.params;
+      const {project_id: projectId} = request.query;
 
-    await requireManagementRead({request, workspaceId, projectId});
-    const variable = await getManagedVariable({workspaceId, projectId, key});
+      await accessControl.requireManagementRead({request, workspaceId, projectId});
+      const variable = await getManagedVariable({workspaceId, projectId, key});
 
-    return {variable: toVariableDto(variable)};
-  },
-});
+      return {variable: toVariableDto(variable)};
+    },
+  });
+}

--- a/libs/api/secrets/src/presentation/routes/index.ts
+++ b/libs/api/secrets/src/presentation/routes/index.ts
@@ -1,5 +1,7 @@
 import {AUTH_USER} from '@shipfox/api-auth-context';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
 import type {RouteGroup} from '@shipfox/node-fastify';
+import {createManagementAccess} from './auth.js';
 import {batchSecretsRoute} from './batch-secrets.js';
 import {batchVariablesRoute} from './batch-variables.js';
 import {deleteSecretRoute} from './delete-secret.js';
@@ -10,20 +12,23 @@ import {listVariablesRoute} from './list-variables.js';
 import {putSecretRoute} from './put-secret.js';
 import {putVariableRoute} from './put-variable.js';
 
-export const secretsRoutes: RouteGroup[] = [
-  {
-    prefix: '/workspaces/:workspaceId',
-    auth: AUTH_USER,
-    routes: [
-      listSecretsRoute,
-      putSecretRoute,
-      batchSecretsRoute,
-      deleteSecretRoute,
-      listVariablesRoute,
-      getVariableRoute,
-      putVariableRoute,
-      batchVariablesRoute,
-      deleteVariableRoute,
-    ],
-  },
-];
+export function createSecretsRoutes(projects: ProjectsModuleClient): RouteGroup[] {
+  const access = createManagementAccess(projects);
+  return [
+    {
+      prefix: '/workspaces/:workspaceId',
+      auth: AUTH_USER,
+      routes: [
+        listSecretsRoute(access),
+        putSecretRoute(access),
+        batchSecretsRoute(access),
+        deleteSecretRoute(access),
+        listVariablesRoute(access),
+        getVariableRoute(access),
+        putVariableRoute(access),
+        batchVariablesRoute(access),
+        deleteVariableRoute(access),
+      ],
+    },
+  ];
+}

--- a/libs/api/secrets/src/presentation/routes/list-secrets.ts
+++ b/libs/api/secrets/src/presentation/routes/list-secrets.ts
@@ -3,39 +3,41 @@ import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
 import {listManagedSecrets} from '#core/index.js';
 import {toSecretDto} from '#presentation/dto/index.js';
-import {requireManagementRead} from './auth.js';
+import type {ManagementAccessHelpers} from './auth.js';
 import {decodeManagementCursor, encodeManagementCursor} from './cursor.js';
 import {translateManagementError} from './errors.js';
 
-export const listSecretsRoute = defineRoute({
-  method: 'GET',
-  path: '/secrets',
-  description: 'List user-managed secrets for a workspace or project scope.',
-  schema: {
-    params: z.object({workspaceId: z.string().uuid()}),
-    querystring: listSecretsQuerySchema,
-    response: {200: listSecretsResponseSchema},
-  },
-  errorHandler: translateManagementError,
-  handler: async (request) => {
-    const {workspaceId} = request.params;
-    const {project_id: projectId, limit, cursor} = request.query;
-    const decodedCursor = decodeManagementCursor(cursor);
-    if (cursor && !decodedCursor) {
-      throw new ClientError('Invalid cursor', 'invalid-cursor', {status: 400});
-    }
+export function listSecretsRoute(accessControl: ManagementAccessHelpers) {
+  return defineRoute({
+    method: 'GET',
+    path: '/secrets',
+    description: 'List user-managed secrets for a workspace or project scope.',
+    schema: {
+      params: z.object({workspaceId: z.string().uuid()}),
+      querystring: listSecretsQuerySchema,
+      response: {200: listSecretsResponseSchema},
+    },
+    errorHandler: translateManagementError,
+    handler: async (request) => {
+      const {workspaceId} = request.params;
+      const {project_id: projectId, limit, cursor} = request.query;
+      const decodedCursor = decodeManagementCursor(cursor);
+      if (cursor && !decodedCursor) {
+        throw new ClientError('Invalid cursor', 'invalid-cursor', {status: 400});
+      }
 
-    await requireManagementRead({request, workspaceId, projectId});
-    const result = await listManagedSecrets({
-      workspaceId,
-      projectId,
-      limit,
-      cursor: decodedCursor ?? undefined,
-    });
+      await accessControl.requireManagementRead({request, workspaceId, projectId});
+      const result = await listManagedSecrets({
+        workspaceId,
+        projectId,
+        limit,
+        cursor: decodedCursor ?? undefined,
+      });
 
-    return {
-      secrets: result.secrets.map(toSecretDto),
-      next_cursor: result.nextCursor ? encodeManagementCursor(result.nextCursor) : null,
-    };
-  },
-});
+      return {
+        secrets: result.secrets.map(toSecretDto),
+        next_cursor: result.nextCursor ? encodeManagementCursor(result.nextCursor) : null,
+      };
+    },
+  });
+}

--- a/libs/api/secrets/src/presentation/routes/list-variables.ts
+++ b/libs/api/secrets/src/presentation/routes/list-variables.ts
@@ -3,39 +3,41 @@ import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
 import {listManagedVariables} from '#core/index.js';
 import {toVariableListItemDto} from '#presentation/dto/index.js';
-import {requireManagementRead} from './auth.js';
+import type {ManagementAccessHelpers} from './auth.js';
 import {decodeManagementCursor, encodeManagementCursor} from './cursor.js';
 import {translateManagementError} from './errors.js';
 
-export const listVariablesRoute = defineRoute({
-  method: 'GET',
-  path: '/variables',
-  description: 'List user-managed variables for a workspace or project scope.',
-  schema: {
-    params: z.object({workspaceId: z.string().uuid()}),
-    querystring: listVariablesQuerySchema,
-    response: {200: listVariablesResponseSchema},
-  },
-  errorHandler: translateManagementError,
-  handler: async (request) => {
-    const {workspaceId} = request.params;
-    const {project_id: projectId, limit, cursor} = request.query;
-    const decodedCursor = decodeManagementCursor(cursor);
-    if (cursor && !decodedCursor) {
-      throw new ClientError('Invalid cursor', 'invalid-cursor', {status: 400});
-    }
+export function listVariablesRoute(accessControl: ManagementAccessHelpers) {
+  return defineRoute({
+    method: 'GET',
+    path: '/variables',
+    description: 'List user-managed variables for a workspace or project scope.',
+    schema: {
+      params: z.object({workspaceId: z.string().uuid()}),
+      querystring: listVariablesQuerySchema,
+      response: {200: listVariablesResponseSchema},
+    },
+    errorHandler: translateManagementError,
+    handler: async (request) => {
+      const {workspaceId} = request.params;
+      const {project_id: projectId, limit, cursor} = request.query;
+      const decodedCursor = decodeManagementCursor(cursor);
+      if (cursor && !decodedCursor) {
+        throw new ClientError('Invalid cursor', 'invalid-cursor', {status: 400});
+      }
 
-    await requireManagementRead({request, workspaceId, projectId});
-    const result = await listManagedVariables({
-      workspaceId,
-      projectId,
-      limit,
-      cursor: decodedCursor ?? undefined,
-    });
+      await accessControl.requireManagementRead({request, workspaceId, projectId});
+      const result = await listManagedVariables({
+        workspaceId,
+        projectId,
+        limit,
+        cursor: decodedCursor ?? undefined,
+      });
 
-    return {
-      variables: result.variables.map(toVariableListItemDto),
-      next_cursor: result.nextCursor ? encodeManagementCursor(result.nextCursor) : null,
-    };
-  },
-});
+      return {
+        variables: result.variables.map(toVariableListItemDto),
+        next_cursor: result.nextCursor ? encodeManagementCursor(result.nextCursor) : null,
+      };
+    },
+  });
+}

--- a/libs/api/secrets/src/presentation/routes/management.test.ts
+++ b/libs/api/secrets/src/presentation/routes/management.test.ts
@@ -4,7 +4,7 @@ import {
   setUserContext,
   type UserContextMembership,
 } from '@shipfox/api-auth-context';
-import {ProjectNotFoundError, requireProjectForWorkspace} from '@shipfox/api-projects';
+import {projectsInterModuleContract} from '@shipfox/api-projects-dto';
 import {
   SECRET_CREATED,
   SECRET_DELETED,
@@ -12,17 +12,22 @@ import {
   VARIABLE_CREATED,
   VARIABLE_DELETED,
 } from '@shipfox/api-secrets-dto';
+import {createInterModuleKnownError, defineInterModulePresentation} from '@shipfox/inter-module';
 import type {AuthMethod, FastifyRequest} from '@shipfox/node-fastify';
 import {ClientError, closeApp, createApp} from '@shipfox/node-fastify';
+import {createFakeInterModuleClients} from '@shipfox/node-module/inter-module/testing';
 import {and, eq, isNull, sql} from 'drizzle-orm';
 import {setSecrets} from '#core/index.js';
 import {db, secretsOutbox, secretValues, secretVariables} from '#db/index.js';
-import {secretsRoutes} from './index.js';
+import {createSecretsRoutes} from './index.js';
 
-vi.mock('@shipfox/api-projects', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@shipfox/api-projects')>();
-  return {...actual, requireProjectForWorkspace: vi.fn()};
-});
+const requireProjectForWorkspace = vi.fn();
+const projects = createFakeInterModuleClients({
+  projects: defineInterModulePresentation(projectsInterModuleContract, {
+    getProjectById: () => ({project: null}),
+    requireProjectForWorkspace: async (input) => await requireProjectForWorkspace(input),
+  }),
+}).projects;
 
 const USER_ID = '11111111-1111-4111-8111-111111111111';
 let authenticatedMemberships: UserContextMembership[] = [];
@@ -56,16 +61,21 @@ describe('secrets management routes', () => {
     workspaceId = crypto.randomUUID();
     projectId = crypto.randomUUID();
     authenticatedMemberships = [{workspaceId, role: 'admin'}];
-    vi.mocked(requireProjectForWorkspace).mockResolvedValue({
-      id: projectId,
-      workspaceId,
-      name: 'Project',
-      sourceConnectionId: crypto.randomUUID(),
-      sourceExternalRepositoryId: 'repo-1',
-      createdAt: new Date(),
-      updatedAt: new Date(),
+    requireProjectForWorkspace.mockResolvedValue({
+      project: {
+        id: projectId,
+        workspaceId,
+        name: 'Project',
+        sourceConnectionId: crypto.randomUUID(),
+        sourceExternalRepositoryId: 'repo-1',
+        createdAt: new Date(),
+      },
     });
-    app = await createApp({auth: [fakeUserAuth], routes: secretsRoutes, swagger: false});
+    app = await createApp({
+      auth: [fakeUserAuth],
+      routes: createSecretsRoutes(projects),
+      swagger: false,
+    });
     await app.ready();
   });
 
@@ -76,7 +86,7 @@ describe('secrets management routes', () => {
   });
 
   it('registers management routes under user auth', () => {
-    expect(secretsRoutes[0]?.auth).toBe(AUTH_USER);
+    expect(createSecretsRoutes(projects)[0]?.auth).toBe(AUTH_USER);
   });
 
   it('returns 401 unauthenticated and 403 for non-members', async () => {
@@ -423,8 +433,12 @@ describe('secrets management routes', () => {
   });
 
   it('returns 404 when project_id does not belong to the workspace', async () => {
-    vi.mocked(requireProjectForWorkspace).mockRejectedValueOnce(
-      new ProjectNotFoundError(projectId),
+    requireProjectForWorkspace.mockRejectedValueOnce(
+      createInterModuleKnownError(
+        projectsInterModuleContract.methods.requireProjectForWorkspace,
+        'project-not-found',
+        {projectId},
+      ),
     );
 
     const res = await app.inject({

--- a/libs/api/secrets/src/presentation/routes/put-secret.ts
+++ b/libs/api/secrets/src/presentation/routes/put-secret.ts
@@ -7,33 +7,35 @@ import {defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
 import {setManagedSecrets} from '#core/index.js';
 import {toSecretDto} from '#presentation/dto/index.js';
-import {requireManagementWrite} from './auth.js';
+import type {ManagementAccessHelpers} from './auth.js';
 import {translateManagementError} from './errors.js';
 import {secretWarnings} from './warnings.js';
 
-export const putSecretRoute = defineRoute({
-  method: 'PUT',
-  path: '/secrets/:key',
-  description: 'Create or update a user-managed secret.',
-  schema: {
-    params: z.object({workspaceId: z.string().uuid(), key: secretKeySchema}),
-    body: putSecretBodySchema,
-    response: {200: putSecretResponseSchema},
-  },
-  errorHandler: translateManagementError,
-  handler: async (request) => {
-    const {workspaceId, key} = request.params;
-    const {project_id: projectId, value} = request.body;
-    const access = await requireManagementWrite({request, workspaceId, projectId});
-    const entries = [{key, value}];
-    const [secret] = await setManagedSecrets({
-      workspaceId,
-      projectId,
-      actorId: access.userId,
-      entries,
-    });
-    if (!secret) throw new Error('Secret write returned no row');
+export function putSecretRoute(accessControl: ManagementAccessHelpers) {
+  return defineRoute({
+    method: 'PUT',
+    path: '/secrets/:key',
+    description: 'Create or update a user-managed secret.',
+    schema: {
+      params: z.object({workspaceId: z.string().uuid(), key: secretKeySchema}),
+      body: putSecretBodySchema,
+      response: {200: putSecretResponseSchema},
+    },
+    errorHandler: translateManagementError,
+    handler: async (request) => {
+      const {workspaceId, key} = request.params;
+      const {project_id: projectId, value} = request.body;
+      const access = await accessControl.requireManagementWrite({request, workspaceId, projectId});
+      const entries = [{key, value}];
+      const [secret] = await setManagedSecrets({
+        workspaceId,
+        projectId,
+        actorId: access.userId,
+        entries,
+      });
+      if (!secret) throw new Error('Secret write returned no row');
 
-    return {secret: toSecretDto(secret), warnings: secretWarnings(entries)};
-  },
-});
+      return {secret: toSecretDto(secret), warnings: secretWarnings(entries)};
+    },
+  });
+}

--- a/libs/api/secrets/src/presentation/routes/put-variable.ts
+++ b/libs/api/secrets/src/presentation/routes/put-variable.ts
@@ -7,33 +7,35 @@ import {defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
 import {setManagedVariables} from '#core/index.js';
 import {toVariableDto} from '#presentation/dto/index.js';
-import {requireManagementWrite} from './auth.js';
+import type {ManagementAccessHelpers} from './auth.js';
 import {translateManagementError} from './errors.js';
 import {variableWarnings} from './warnings.js';
 
-export const putVariableRoute = defineRoute({
-  method: 'PUT',
-  path: '/variables/:key',
-  description: 'Create or update a user-managed variable.',
-  schema: {
-    params: z.object({workspaceId: z.string().uuid(), key: secretKeySchema}),
-    body: putVariableBodySchema,
-    response: {200: putVariableResponseSchema},
-  },
-  errorHandler: translateManagementError,
-  handler: async (request) => {
-    const {workspaceId, key} = request.params;
-    const {project_id: projectId, value} = request.body;
-    const access = await requireManagementWrite({request, workspaceId, projectId});
-    const entries = [{key, value}];
-    const [variable] = await setManagedVariables({
-      workspaceId,
-      projectId,
-      actorId: access.userId,
-      entries,
-    });
-    if (!variable) throw new Error('Variable write returned no row');
+export function putVariableRoute(accessControl: ManagementAccessHelpers) {
+  return defineRoute({
+    method: 'PUT',
+    path: '/variables/:key',
+    description: 'Create or update a user-managed variable.',
+    schema: {
+      params: z.object({workspaceId: z.string().uuid(), key: secretKeySchema}),
+      body: putVariableBodySchema,
+      response: {200: putVariableResponseSchema},
+    },
+    errorHandler: translateManagementError,
+    handler: async (request) => {
+      const {workspaceId, key} = request.params;
+      const {project_id: projectId, value} = request.body;
+      const access = await accessControl.requireManagementWrite({request, workspaceId, projectId});
+      const entries = [{key, value}];
+      const [variable] = await setManagedVariables({
+        workspaceId,
+        projectId,
+        actorId: access.userId,
+        entries,
+      });
+      if (!variable) throw new Error('Variable write returned no row');
 
-    return {variable: toVariableDto(variable), warnings: variableWarnings(entries)};
-  },
-});
+      return {variable: toVariableDto(variable), warnings: variableWarnings(entries)};
+    },
+  });
+}

--- a/libs/api/server/package.json
+++ b/libs/api/server/package.json
@@ -57,6 +57,7 @@
     "@shipfox/api-integration-core": "workspace:*",
     "@shipfox/api-logs": "workspace:*",
     "@shipfox/api-projects": "workspace:*",
+    "@shipfox/api-projects-dto": "workspace:*",
     "@shipfox/api-runners": "workspace:*",
     "@shipfox/api-runners-dto": "workspace:*",
     "@shipfox/api-secrets": "workspace:*",
@@ -73,6 +74,7 @@
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",
+    "@shipfox/inter-module": "workspace:*",
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",

--- a/libs/api/server/src/modules.test.ts
+++ b/libs/api/server/src/modules.test.ts
@@ -1,5 +1,5 @@
-import {runnersInterModuleContract} from '@shipfox/api-runners-dto/inter-module';
 import {projectsInterModuleContract} from '@shipfox/api-projects-dto';
+import {runnersInterModuleContract} from '@shipfox/api-runners-dto/inter-module';
 import {workflowsInterModuleContract} from '@shipfox/api-workflows-dto/inter-module';
 import {defineInterModulePresentation} from '@shipfox/inter-module';
 import {defaultModules} from './modules.js';

--- a/libs/api/server/src/modules.test.ts
+++ b/libs/api/server/src/modules.test.ts
@@ -1,5 +1,7 @@
 import {runnersInterModuleContract} from '@shipfox/api-runners-dto/inter-module';
+import {projectsInterModuleContract} from '@shipfox/api-projects-dto';
 import {workflowsInterModuleContract} from '@shipfox/api-workflows-dto/inter-module';
+import {defineInterModulePresentation} from '@shipfox/inter-module';
 import {defaultModules} from './modules.js';
 
 const mocks = vi.hoisted(() => ({
@@ -8,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   createDefinitionsModule: vi.fn(),
   createIntegrationsContext: vi.fn(),
   createProjectsModule: vi.fn(),
+  createSecretsModule: vi.fn(),
   createTriggersModule: vi.fn(),
   createWorkflowsModule: vi.fn(),
   createWorkspaceConnectionSnapshotLoader: vi.fn(),
@@ -54,6 +57,7 @@ vi.mock('@shipfox/api-runners', () => ({
   },
 }));
 vi.mock('@shipfox/api-secrets', () => ({
+  createSecretsModule: mocks.createSecretsModule,
   deleteSecrets: mocks.deleteSecrets,
   getSecret: mocks.getSecret,
   secretsModule: {name: 'secrets'},
@@ -76,6 +80,7 @@ describe('defaultModules', () => {
     mocks.createDefinitionsModule.mockReset();
     mocks.createIntegrationsContext.mockReset();
     mocks.createProjectsModule.mockReset();
+    mocks.createSecretsModule.mockReset();
     mocks.createTriggersModule.mockReset();
     mocks.createWorkflowsModule.mockReset();
     mocks.createWorkspaceConnectionSnapshotLoader.mockReset();
@@ -95,7 +100,24 @@ describe('defaultModules', () => {
     mocks.buildAgentToolCatalogs.mockResolvedValue(new Map());
     mocks.buildAgentToolSelectionCatalogs.mockResolvedValue(new Map());
     mocks.createWorkspaceConnectionSnapshotLoader.mockReturnValue(vi.fn());
-    mocks.createProjectsModule.mockReturnValue({name: 'projects'});
+    mocks.createProjectsModule.mockReturnValue({
+      name: 'projects',
+      interModulePresentations: [
+        defineInterModulePresentation(projectsInterModuleContract, {
+          getProjectById: () => ({project: null}),
+          requireProjectForWorkspace: () => ({
+            project: {
+              id: crypto.randomUUID(),
+              workspaceId: crypto.randomUUID(),
+              sourceConnectionId: crypto.randomUUID(),
+              sourceExternalRepositoryId: 'repo',
+              name: 'Project',
+            },
+          }),
+        }),
+      ],
+    });
+    mocks.createSecretsModule.mockReturnValue({name: 'secrets'});
     mocks.createDefinitionsModule.mockReturnValue({name: 'definitions'});
     mocks.createWorkflowsModule.mockReturnValue({
       name: 'workflows',

--- a/libs/api/server/src/modules.ts
+++ b/libs/api/server/src/modules.ts
@@ -12,9 +12,10 @@ import {
 } from '@shipfox/api-integration-core';
 import {logsModule} from '@shipfox/api-logs';
 import {createProjectsModule} from '@shipfox/api-projects';
+import {projectsInterModuleContract} from '@shipfox/api-projects-dto';
 import {runnersModule as defaultRunnersModule} from '@shipfox/api-runners';
 import {runnersInterModuleContract} from '@shipfox/api-runners-dto/inter-module';
-import {deleteSecrets, getSecret, secretsModule, setSecrets} from '@shipfox/api-secrets';
+import {createSecretsModule, deleteSecrets, getSecret, setSecrets} from '@shipfox/api-secrets';
 import {createTriggersModule} from '@shipfox/api-triggers';
 import {
   createWorkflowsModule,
@@ -40,6 +41,7 @@ export async function defaultModules(
   const interModuleTransport = createInMemoryInterModuleTransport();
   const workflowsClient = interModuleTransport.createClient(workflowsInterModuleContract);
   const runnersClient = interModuleTransport.createClient(runnersInterModuleContract);
+  const projectsClient = interModuleTransport.createClient(projectsInterModuleContract);
   const integrations = await createIntegrationsContext({
     secrets: {
       deleteSecrets,
@@ -102,12 +104,14 @@ export async function defaultModules(
   // source-control service; wire it into the workflows module before serving.
   setSourceControl(integrations.sourceControl);
   setAgentToolMaterializationServices({
+    projects: projectsClient,
     catalogs: agentToolCatalogs,
     loadWorkspaceConnectionSnapshot,
     getIntegrationConnectionById,
   });
   const projectsModule = createProjectsModule({sourceControl: integrations.sourceControl});
   const definitionsModule = createDefinitionsModule({
+    projects: projectsClient,
     sourceControl: integrations.sourceControl,
     agentToolSelectionCatalogs,
     loadWorkspaceConnectionSnapshot,
@@ -117,12 +121,12 @@ export async function defaultModules(
   const modules = [
     authModule,
     workspacesModule,
-    secretsModule,
+    createSecretsModule(projectsClient),
     agentModule,
     integrations.module,
     projectsModule,
     definitionsModule,
-    createWorkflowsModule({runners: runnersClient}),
+    createWorkflowsModule({projects: projectsClient, runners: runnersClient}),
     annotationsModule,
     options.runnersModule ?? defaultRunnersModule,
     logsModule,

--- a/libs/api/workflows/package.json
+++ b/libs/api/workflows/package.json
@@ -47,7 +47,7 @@
     "@shipfox/annotations": "workspace:*",
     "@shipfox/api-definitions": "workspace:*",
     "@shipfox/api-integration-core": "workspace:*",
-    "@shipfox/api-projects": "workspace:*",
+    "@shipfox/api-projects-dto": "workspace:*",
     "@shipfox/api-runners": "workspace:*",
     "@shipfox/api-runners-dto": "workspace:*",
     "@shipfox/api-secrets": "workspace:*",

--- a/libs/api/workflows/src/core/agent-tools.ts
+++ b/libs/api/workflows/src/core/agent-tools.ts
@@ -12,7 +12,7 @@ import type {
   LoadWorkspaceConnectionSnapshot,
   WorkspaceConnectionSnapshot,
 } from '@shipfox/api-integration-core';
-import {getProjectById} from '@shipfox/api-projects';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
 import {AgentIntegrationMaterializationError} from './errors.js';
 
 type WorkflowModelJob = WorkflowModel['jobs'][number];
@@ -20,6 +20,7 @@ type WorkflowModelAgentStep = Extract<WorkflowModelJob['steps'][number], {kind: 
 type WorkflowModelStepIntegration = NonNullable<WorkflowModelAgentStep['integrations']>[number];
 
 interface AgentToolMaterializationServices {
+  readonly projects: ProjectsModuleClient;
   readonly catalogs: AgentToolCatalogs;
   readonly loadWorkspaceConnectionSnapshot: LoadWorkspaceConnectionSnapshot;
   readonly getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
@@ -74,8 +75,8 @@ export async function loadAgentToolMaterializationContext(params: {
     throw new AgentIntegrationMaterializationError('Agent tool materialization is not configured');
   }
 
-  const project = await getProjectById(params.projectId);
-  if (project === undefined) {
+  const {project} = await services.projects.getProjectById({projectId: params.projectId});
+  if (project === null) {
     throw new AgentIntegrationMaterializationError(
       `Project ${params.projectId} was not found while materializing agent integrations`,
     );

--- a/libs/api/workflows/src/core/checkout.test.ts
+++ b/libs/api/workflows/src/core/checkout.test.ts
@@ -1,5 +1,5 @@
 import type {CheckoutSpec, IntegrationSourceControlService} from '@shipfox/api-integration-core';
-import {getProjectById} from '@shipfox/api-projects';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
 import * as workflowRuns from '#db/workflow-runs.js';
 import {jobFactory} from '#test/factories/job.js';
 import {projectFactory} from '#test/factories/project.js';
@@ -10,16 +10,19 @@ import {
   WorkflowRunNotFoundError,
 } from './errors.js';
 
-vi.mock('@shipfox/api-projects', () => ({getProjectById: vi.fn()}));
-const mockGetProjectById = vi.mocked(getProjectById);
+const getProjectById = vi.fn();
+const projects = {
+  getProjectById,
+  requireProjectForWorkspace: vi.fn(),
+} as unknown as ProjectsModuleClient;
 
 describe('resolveCheckoutIntent', () => {
   it('resolves connection + repo from the project, using the project workspace', async () => {
     const project = projectFactory.build();
-    mockGetProjectById.mockResolvedValue(project);
+    getProjectById.mockResolvedValue({project});
     const job = await jobFactory.create({}, {transient: {projectId: project.id}});
 
-    const intent = await resolveCheckoutIntent(job.id);
+    const intent = await resolveCheckoutIntent(job.id, projects);
 
     expect(intent).toEqual({
       workspaceId: project.workspaceId,
@@ -31,41 +34,41 @@ describe('resolveCheckoutIntent', () => {
   });
 
   it('throws JobNotFoundError for an unknown job', async () => {
-    const act = resolveCheckoutIntent(crypto.randomUUID());
+    const act = resolveCheckoutIntent(crypto.randomUUID(), projects);
 
     await expect(act).rejects.toBeInstanceOf(JobNotFoundError);
   });
 
   it('resolves the checkout target while the parent job projection is still pending', async () => {
     const project = projectFactory.build();
-    mockGetProjectById.mockResolvedValue(project);
+    getProjectById.mockResolvedValue({project});
     const job = await jobFactory.create(
       {},
       {transient: {projectId: project.id, status: 'pending'}},
     );
 
-    const intent = await resolveCheckoutIntent(job.id);
+    const intent = await resolveCheckoutIntent(job.id, projects);
 
     expect(intent.connectionId).toBe(project.sourceConnectionId);
   });
 
   it('throws WorkflowRunNotFoundError when the run is missing', async () => {
     const project = projectFactory.build();
-    mockGetProjectById.mockResolvedValue(project);
+    getProjectById.mockResolvedValue({project});
     const job = await jobFactory.create({}, {transient: {projectId: project.id}});
     vi.spyOn(workflowRuns, 'getWorkflowRunByAttemptId').mockResolvedValue(undefined);
 
-    const act = resolveCheckoutIntent(job.id);
+    const act = resolveCheckoutIntent(job.id, projects);
 
     await expect(act).rejects.toBeInstanceOf(WorkflowRunNotFoundError);
   });
 
   it('throws CheckoutIntentUnresolvedError when the project is missing', async () => {
     const project = projectFactory.build();
-    mockGetProjectById.mockResolvedValue(undefined);
+    getProjectById.mockResolvedValue({project: null});
     const job = await jobFactory.create({}, {transient: {projectId: project.id}});
 
-    const act = resolveCheckoutIntent(job.id);
+    const act = resolveCheckoutIntent(job.id, projects);
 
     await expect(act).rejects.toBeInstanceOf(CheckoutIntentUnresolvedError);
   });
@@ -74,13 +77,13 @@ describe('resolveCheckoutIntent', () => {
 describe('createJobCheckoutSpec', () => {
   it('passes the resolved intent and an undefined ref to the service', async () => {
     const project = projectFactory.build();
-    mockGetProjectById.mockResolvedValue(project);
+    getProjectById.mockResolvedValue({project});
     const job = await jobFactory.create({}, {transient: {projectId: project.id}});
     const spec: CheckoutSpec = {repositoryUrl: 'https://github.com/acme/repo.git', ref: 'main'};
     const createCheckoutSpec = vi.fn().mockResolvedValue(spec);
     const sourceControl = {createCheckoutSpec} as unknown as IntegrationSourceControlService;
 
-    const result = await createJobCheckoutSpec({jobId: job.id, sourceControl});
+    const result = await createJobCheckoutSpec({jobId: job.id, sourceControl, projects});
 
     expect(result).toEqual({spec, persistCredentials: true});
     expect(createCheckoutSpec).toHaveBeenCalledWith({
@@ -94,7 +97,7 @@ describe('createJobCheckoutSpec', () => {
 
   it('passes requested write contents permission to the service', async () => {
     const project = projectFactory.build();
-    mockGetProjectById.mockResolvedValue(project);
+    getProjectById.mockResolvedValue({project});
     const job = await jobFactory.create(
       {},
       {transient: {projectId: project.id, checkout: {permissions: {contents: 'write'}}}},
@@ -103,7 +106,7 @@ describe('createJobCheckoutSpec', () => {
     const createCheckoutSpec = vi.fn().mockResolvedValue(spec);
     const sourceControl = {createCheckoutSpec} as unknown as IntegrationSourceControlService;
 
-    await createJobCheckoutSpec({jobId: job.id, sourceControl});
+    await createJobCheckoutSpec({jobId: job.id, sourceControl, projects});
 
     expect(createCheckoutSpec).toHaveBeenCalledWith(
       expect.objectContaining({permissions: {contents: 'write'}}),

--- a/libs/api/workflows/src/core/checkout.ts
+++ b/libs/api/workflows/src/core/checkout.ts
@@ -1,5 +1,5 @@
 import type {CheckoutSpec, IntegrationSourceControlService} from '@shipfox/api-integration-core';
-import {getProjectById} from '@shipfox/api-projects';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
 import {getJobById, getWorkflowRunByAttemptId} from '#db/workflow-runs.js';
 import {
   CheckoutIntentUnresolvedError,
@@ -20,15 +20,18 @@ export interface CheckoutIntent {
  * (`workflowRunId`/`workflowRunAttemptId`/`workspaceId` in the lease claim are informational).
  * Chain: job → attempt → run → project source metadata. Credential-free.
  */
-export async function resolveCheckoutIntent(jobId: string): Promise<CheckoutIntent> {
+export async function resolveCheckoutIntent(
+  jobId: string,
+  projects: ProjectsModuleClient,
+): Promise<CheckoutIntent> {
   const job = await getJobById(jobId);
   if (!job) throw new JobNotFoundError(jobId);
 
   const run = await getWorkflowRunByAttemptId(job.workflowRunAttemptId);
   if (!run) throw new WorkflowRunNotFoundError(job.workflowRunAttemptId);
 
-  const project = await getProjectById(run.projectId);
-  if (!project) throw new CheckoutIntentUnresolvedError(run.projectId);
+  const {project} = await projects.getProjectById({projectId: run.projectId});
+  if (project === null) throw new CheckoutIntentUnresolvedError(run.projectId);
 
   return {
     workspaceId: project.workspaceId,
@@ -47,11 +50,13 @@ export async function resolveCheckoutIntent(jobId: string): Promise<CheckoutInte
 export async function createJobCheckoutSpec({
   jobId,
   sourceControl,
+  projects,
 }: {
   jobId: string;
   sourceControl: IntegrationSourceControlService;
+  projects: ProjectsModuleClient;
 }): Promise<{spec: CheckoutSpec; persistCredentials: boolean}> {
-  const intent = await resolveCheckoutIntent(jobId);
+  const intent = await resolveCheckoutIntent(jobId, projects);
   const spec = await sourceControl.createCheckoutSpec({
     workspaceId: intent.workspaceId,
     connectionId: intent.connectionId,

--- a/libs/api/workflows/src/index.ts
+++ b/libs/api/workflows/src/index.ts
@@ -1,5 +1,6 @@
 import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
 import {
   RUNNER_JOB_CLAIMED,
   RUNNER_JOB_LEASE_EXPIRED,
@@ -72,11 +73,17 @@ const workflowsPath = resolve(packageRoot, 'dist/temporal/workflows/index.js');
 
 const subscriber = subscriberFactory<WorkflowsEventMapDto & RunnersEventMap>();
 
-export function createWorkflowsModule(params: {runners: RunnersInterModuleClient}): ShipfoxModule {
+export function createWorkflowsModule({
+  projects,
+  runners,
+}: {
+  projects: ProjectsModuleClient;
+  runners: RunnersInterModuleClient;
+}): ShipfoxModule {
   return {
     name: 'workflows',
     database: {db, migrationsPath},
-    routes: createWorkflowRoutes(params.runners),
+    routes: createWorkflowRoutes(runners, projects),
     metrics: registerWorkflowsServiceMetrics,
     publishers: [
       {name: 'workflows', table: workflowsOutbox, db, eventSchemas: workflowsEventSchemas},
@@ -94,7 +101,7 @@ export function createWorkflowsModule(params: {runners: RunnersInterModuleClient
       {
         taskQueue: WORKFLOWS_TASK_QUEUE,
         workflowsPath,
-        activities: () => createOrchestrationActivities(params.runners),
+        activities: () => createOrchestrationActivities(runners),
         workflows: [],
       },
     ],

--- a/libs/api/workflows/src/presentation/routes/cancel-run.test.ts
+++ b/libs/api/workflows/src/presentation/routes/cancel-run.test.ts
@@ -1,5 +1,5 @@
 import {buildUserContext, setUserContext} from '@shipfox/api-auth-context';
-import {requireProjectAccess} from '@shipfox/api-projects';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
 import {ClientError} from '@shipfox/node-fastify';
 import type {FastifyInstance} from 'fastify';
 import Fastify from 'fastify';
@@ -12,16 +12,11 @@ import {cancelRunRoute} from './cancel-run.js';
 
 const projectAccessState = vi.hoisted(() => ({workspaceId: ''}));
 
-vi.mock('@shipfox/api-projects', () => ({
-  requireProjectAccess: vi.fn(({projectId}) =>
-    Promise.resolve({
-      project: {id: projectId, workspaceId: projectAccessState.workspaceId},
-      workspaceId: projectAccessState.workspaceId,
-    }),
-  ),
-}));
-
-const mockRequireProjectAccess = vi.mocked(requireProjectAccess);
+const getProjectById = vi.fn();
+const projects = {
+  getProjectById,
+  requireProjectForWorkspace: vi.fn(),
+} as unknown as ProjectsModuleClient;
 
 describe('POST /api/workflows/runs/:id/cancel', () => {
   let app: FastifyInstance;
@@ -44,7 +39,7 @@ describe('POST /api/workflows/runs/:id/cancel', () => {
       );
       done();
     });
-    app.post('/api/workflows/runs/:id/cancel', cancelRunRoute);
+    app.post('/api/workflows/runs/:id/cancel', cancelRunRoute(projects));
     await app.ready();
   });
 
@@ -53,7 +48,7 @@ describe('POST /api/workflows/runs/:id/cancel', () => {
     projectId = crypto.randomUUID();
     definitionId = crypto.randomUUID();
     projectAccessState.workspaceId = workspaceId;
-    mockRequireProjectAccess.mockImplementation(({projectId: requestedProjectId}) =>
+    getProjectById.mockImplementation(({projectId: requestedProjectId}) =>
       Promise.resolve({
         project: {
           id: requestedProjectId,
@@ -61,10 +56,7 @@ describe('POST /api/workflows/runs/:id/cancel', () => {
           sourceConnectionId: crypto.randomUUID(),
           sourceExternalRepositoryId: `repo:${crypto.randomUUID()}`,
           name: 'Project',
-          createdAt: new Date(),
-          updatedAt: new Date(),
         },
-        workspaceId,
       }),
     );
   });
@@ -97,7 +89,7 @@ describe('POST /api/workflows/runs/:id/cancel', () => {
 
   test('maps a run disappearing during cancellation to 404', () => {
     let mapped: unknown;
-    const errorHandler = cancelRunRoute.errorHandler as (error: Error) => void;
+    const errorHandler = cancelRunRoute(projects).errorHandler as (error: Error) => void;
 
     try {
       errorHandler(new WorkflowRunNotFoundError(crypto.randomUUID()));
@@ -111,9 +103,7 @@ describe('POST /api/workflows/runs/:id/cancel', () => {
 
   test('returns 404 when project access is denied', async () => {
     const run = await createRun();
-    mockRequireProjectAccess.mockRejectedValueOnce(
-      new ClientError('Forbidden', 'forbidden', {status: 403}),
-    );
+    getProjectById.mockRejectedValueOnce(new ClientError('Forbidden', 'forbidden', {status: 403}));
 
     const res = await app.inject({
       method: 'POST',

--- a/libs/api/workflows/src/presentation/routes/cancel-run.ts
+++ b/libs/api/workflows/src/presentation/routes/cancel-run.ts
@@ -1,3 +1,4 @@
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
 import {workflowRunDtoSchema} from '@shipfox/api-workflows-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
@@ -6,32 +7,34 @@ import {cancelWorkflowRun} from '#db/index.js';
 import {toRunDto} from '#presentation/dto/index.js';
 import {requireAccessibleRun} from './require-accessible-run.js';
 
-export const cancelRunRoute = defineRoute({
-  method: 'POST',
-  path: '/:id/cancel',
-  description: 'Cancel an in-progress workflow run',
-  schema: {
-    params: z.object({
-      id: z.string().uuid(),
-    }),
-    response: {
-      200: workflowRunDtoSchema,
+export function cancelRunRoute(projects: ProjectsModuleClient) {
+  return defineRoute({
+    method: 'POST',
+    path: '/:id/cancel',
+    description: 'Cancel an in-progress workflow run',
+    schema: {
+      params: z.object({
+        id: z.string().uuid(),
+      }),
+      response: {
+        200: workflowRunDtoSchema,
+      },
     },
-  },
-  errorHandler: (error) => {
-    if (error instanceof WorkflowRunNotCancellableError) {
-      throw new ClientError(error.message, 'run-already-finished', {status: 409});
-    }
-    if (error instanceof WorkflowRunNotFoundError) {
-      throw new ClientError('Run not found', 'not-found', {status: 404});
-    }
-    throw error;
-  },
-  handler: async (request) => {
-    const {id} = request.params;
-    const run = await requireAccessibleRun({request, id});
+    errorHandler: (error) => {
+      if (error instanceof WorkflowRunNotCancellableError) {
+        throw new ClientError(error.message, 'run-already-finished', {status: 409});
+      }
+      if (error instanceof WorkflowRunNotFoundError) {
+        throw new ClientError('Run not found', 'not-found', {status: 404});
+      }
+      throw error;
+    },
+    handler: async (request) => {
+      const {id} = request.params;
+      const run = await requireAccessibleRun({request, id, projects});
 
-    const cancelled = await cancelWorkflowRun({workflowRunId: run.id});
-    return toRunDto(cancelled);
-  },
-});
+      const cancelled = await cancelWorkflowRun({workflowRunId: run.id});
+      return toRunDto(cancelled);
+    },
+  });
+}

--- a/libs/api/workflows/src/presentation/routes/checkout-token.test.ts
+++ b/libs/api/workflows/src/presentation/routes/checkout-token.test.ts
@@ -6,7 +6,7 @@ import {
   IntegrationProviderError,
   type IntegrationSourceControlService,
 } from '@shipfox/api-integration-core';
-import {getProjectById} from '@shipfox/api-projects';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
 import {closeApp, createApp, type FastifyInstance} from '@shipfox/node-fastify';
 import {createCapturingLogger} from '@shipfox/node-log/test';
 import {clearSourceControl, setSourceControl} from '#core/source-control.js';
@@ -17,8 +17,13 @@ import {mintLeaseToken} from '#test/fixtures/lease-token.js';
 import {runnersTestClient} from '#test/fixtures/runners-inter-module.js';
 import {createLeaseTokenRouteGroup} from './index.js';
 
-vi.mock('@shipfox/api-projects', () => ({getProjectById: vi.fn()}));
-const mockGetProjectById = vi.mocked(getProjectById);
+const mockGetProjectById = vi.fn();
+const projects = {
+  getProjectById: async ({projectId}: {projectId: string}) => ({
+    project: await mockGetProjectById(projectId),
+  }),
+  requireProjectForWorkspace: vi.fn(),
+} as unknown as ProjectsModuleClient;
 
 const URL = '/runs/jobs/current/checkout-token';
 
@@ -37,7 +42,7 @@ describe('POST /runs/jobs/current/checkout-token', () => {
     setSourceControl({createCheckoutSpec} as unknown as IntegrationSourceControlService);
     app = await createApp({
       auth: [createLeaseTokenAuthMethod()],
-      routes: [createLeaseTokenRouteGroup(runnersTestClient)],
+      routes: [createLeaseTokenRouteGroup(runnersTestClient, projects)],
       swagger: false,
       fastifyOptions: {loggerInstance: logger},
     });
@@ -259,7 +264,7 @@ describe('POST /runs/jobs/current/checkout-token', () => {
   });
 
   test('returns 404 when the run has no project linkage', async () => {
-    mockGetProjectById.mockResolvedValue(undefined);
+    mockGetProjectById.mockResolvedValue(null);
     const project = {id: crypto.randomUUID(), workspaceId: crypto.randomUUID()};
     const job = await jobFactory.create({}, {transient: {projectId: project.id}});
     const token = await mintActiveLeaseToken({jobId: job.id});

--- a/libs/api/workflows/src/presentation/routes/checkout-token.ts
+++ b/libs/api/workflows/src/presentation/routes/checkout-token.ts
@@ -1,7 +1,7 @@
 import {requireLeasedJobContext} from '@shipfox/api-auth-context';
 import {integrationRouteErrorHandler} from '@shipfox/api-integration-core';
-import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-module';
 import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-module';
 import {checkoutTokenResponseSchema} from '@shipfox/api-workflows-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {createJobCheckoutSpec} from '#core/checkout.js';

--- a/libs/api/workflows/src/presentation/routes/checkout-token.ts
+++ b/libs/api/workflows/src/presentation/routes/checkout-token.ts
@@ -1,6 +1,7 @@
 import {requireLeasedJobContext} from '@shipfox/api-auth-context';
 import {integrationRouteErrorHandler} from '@shipfox/api-integration-core';
 import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-module';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
 import {checkoutTokenResponseSchema} from '@shipfox/api-workflows-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {createJobCheckoutSpec} from '#core/checkout.js';
@@ -12,7 +13,10 @@ import {
 import {sourceControl} from '#core/source-control.js';
 import {toCheckoutTokenDto} from '#presentation/dto/checkout-token.js';
 
-export function createCheckoutTokenRoute(runners: RunnersInterModuleClient) {
+export function createCheckoutTokenRoute(
+  runners: RunnersInterModuleClient,
+  projects: ProjectsModuleClient,
+) {
   return defineRoute({
     method: 'POST',
     path: '/checkout-token',
@@ -52,6 +56,7 @@ export function createCheckoutTokenRoute(runners: RunnersInterModuleClient) {
       const checkout = await createJobCheckoutSpec({
         jobId: leasedJob.jobId,
         sourceControl: sourceControl(),
+        projects,
       });
 
       // The body carries short-lived git credentials; forbid any intermediary or

--- a/libs/api/workflows/src/presentation/routes/get-run-aggregates.test.ts
+++ b/libs/api/workflows/src/presentation/routes/get-run-aggregates.test.ts
@@ -1,4 +1,5 @@
 import {buildUserContext, setUserContext} from '@shipfox/api-auth-context';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
 import type {FastifyInstance} from 'fastify';
 import Fastify from 'fastify';
 import {serializerCompiler, validatorCompiler} from 'fastify-type-provider-zod';
@@ -8,15 +9,20 @@ import {getRunAggregatesRoute} from './get-run-aggregates.js';
 
 const projectAccessState = vi.hoisted(() => ({workspaceId: ''}));
 
-vi.mock('@shipfox/api-projects', () => ({
-  ProjectNotFoundError: class ProjectNotFoundError extends Error {},
-  requireProjectAccess: vi.fn(({projectId}) =>
+const projects = {
+  getProjectById: vi.fn(({projectId}) =>
     Promise.resolve({
-      project: {id: projectId, workspaceId: projectAccessState.workspaceId},
-      workspaceId: projectAccessState.workspaceId,
+      project: {
+        id: projectId,
+        workspaceId: projectAccessState.workspaceId,
+        sourceConnectionId: crypto.randomUUID(),
+        sourceExternalRepositoryId: 'repo',
+        name: 'Project',
+      },
     }),
   ),
-}));
+  requireProjectForWorkspace: vi.fn(),
+} as unknown as ProjectsModuleClient;
 
 describe('GET /api/workflows/runs/aggregates', () => {
   let app: FastifyInstance;
@@ -38,7 +44,7 @@ describe('GET /api/workflows/runs/aggregates', () => {
       );
       done();
     });
-    app.get('/api/workflows/runs/aggregates', getRunAggregatesRoute);
+    app.get('/api/workflows/runs/aggregates', getRunAggregatesRoute(projects));
     await app.ready();
   });
 

--- a/libs/api/workflows/src/presentation/routes/get-run-aggregates.ts
+++ b/libs/api/workflows/src/presentation/routes/get-run-aggregates.ts
@@ -1,69 +1,66 @@
-import {ProjectNotFoundError, requireProjectAccess} from '@shipfox/api-projects';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
 import {
   workflowRunAggregatesQuerySchema,
   workflowRunAggregatesResponseSchema,
 } from '@shipfox/api-workflows-dto';
-import {ClientError, defineRoute} from '@shipfox/node-fastify';
+import {defineRoute} from '@shipfox/node-fastify';
 import {logger} from '@shipfox/node-opentelemetry';
 import {getWorkflowRunAggregates} from '#db/index.js';
+import {requireProjectAccess} from './project-access.js';
 
-export const getRunAggregatesRoute = defineRoute({
-  method: 'GET',
-  path: '/aggregates',
-  description: 'Get faceted workflow run counts for a project',
-  schema: {
-    querystring: workflowRunAggregatesQuerySchema,
-    response: {
-      200: workflowRunAggregatesResponseSchema,
-    },
-  },
-  errorHandler: (error) => {
-    if (error instanceof ProjectNotFoundError) {
-      throw new ClientError(error.message, 'project-not-found', {status: 404});
-    }
-    throw error;
-  },
-  handler: async (request) => {
-    const startedAt = performance.now();
-    const {
-      project_id: projectId,
-      status,
-      definition_id: definitionId,
-      trigger_source: triggerSource,
-      created_from: createdFrom,
-      created_to: createdTo,
-    } = request.query;
-
-    const {project} = await requireProjectAccess({request, projectId});
-    const filters = {
-      status,
-      definitionId,
-      triggerSource,
-      createdFrom: createdFrom ? new Date(createdFrom) : undefined,
-      createdTo: createdTo ? new Date(createdTo) : undefined,
-    };
-    const aggregates = await getWorkflowRunAggregates({projectId: project.id, filters});
-
-    logger().info(
-      {
-        projectId: project.id,
-        filterKeys: Object.entries(filters)
-          .filter(([, value]) => value !== undefined)
-          .map(([key]) => key),
-        aggregateBucketSizes: {
-          status: aggregates.status.length,
-          triggerSource: aggregates.triggerSource.length,
-          workflow: aggregates.workflow.length,
-        },
-        durationMs: Math.round(performance.now() - startedAt),
+export function getRunAggregatesRoute(projects: ProjectsModuleClient) {
+  return defineRoute({
+    method: 'GET',
+    path: '/aggregates',
+    description: 'Get faceted workflow run counts for a project',
+    schema: {
+      querystring: workflowRunAggregatesQuerySchema,
+      response: {
+        200: workflowRunAggregatesResponseSchema,
       },
-      'Aggregated workflow runs',
-    );
+    },
+    handler: async (request) => {
+      const startedAt = performance.now();
+      const {
+        project_id: projectId,
+        status,
+        definition_id: definitionId,
+        trigger_source: triggerSource,
+        created_from: createdFrom,
+        created_to: createdTo,
+      } = request.query;
 
-    return {
-      status: aggregates.status,
-      trigger_source: aggregates.triggerSource,
-      workflow: aggregates.workflow,
-    };
-  },
-});
+      const project = await requireProjectAccess(request, projectId, projects);
+      const filters = {
+        status,
+        definitionId,
+        triggerSource,
+        createdFrom: createdFrom ? new Date(createdFrom) : undefined,
+        createdTo: createdTo ? new Date(createdTo) : undefined,
+      };
+      const aggregates = await getWorkflowRunAggregates({projectId: project.id, filters});
+
+      logger().info(
+        {
+          projectId: project.id,
+          filterKeys: Object.entries(filters)
+            .filter(([, value]) => value !== undefined)
+            .map(([key]) => key),
+          aggregateBucketSizes: {
+            status: aggregates.status.length,
+            triggerSource: aggregates.triggerSource.length,
+            workflow: aggregates.workflow.length,
+          },
+          durationMs: Math.round(performance.now() - startedAt),
+        },
+        'Aggregated workflow runs',
+      );
+
+      return {
+        status: aggregates.status,
+        trigger_source: aggregates.triggerSource,
+        workflow: aggregates.workflow,
+      };
+    },
+  });
+}

--- a/libs/api/workflows/src/presentation/routes/get-run.test.ts
+++ b/libs/api/workflows/src/presentation/routes/get-run.test.ts
@@ -1,5 +1,5 @@
 import {buildUserContext, setUserContext} from '@shipfox/api-auth-context';
-import {requireProjectAccess} from '@shipfox/api-projects';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
 import {ClientError} from '@shipfox/node-fastify';
 import {eq} from 'drizzle-orm';
 import type {FastifyInstance} from 'fastify';
@@ -40,16 +40,11 @@ async function recordStepResult(
   return recordJobExecutionStepResult({...rest, jobExecutionId: step.jobExecutionId});
 }
 
-vi.mock('@shipfox/api-projects', () => ({
-  requireProjectAccess: vi.fn(({projectId}) =>
-    Promise.resolve({
-      project: {id: projectId, workspaceId: projectAccessState.workspaceId},
-      workspaceId: projectAccessState.workspaceId,
-    }),
-  ),
-}));
-
-const mockRequireProjectAccess = vi.mocked(requireProjectAccess);
+const getProjectById = vi.fn();
+const projects = {
+  getProjectById,
+  requireProjectForWorkspace: vi.fn(),
+} as unknown as ProjectsModuleClient;
 
 describe('GET /api/workflows/runs/:id', () => {
   let app: FastifyInstance;
@@ -70,14 +65,14 @@ describe('GET /api/workflows/runs/:id', () => {
       );
       done();
     });
-    app.get('/api/workflows/runs/:id', getRunRoute);
+    app.get('/api/workflows/runs/:id', getRunRoute(projects));
     await app.ready();
   });
 
   beforeEach(() => {
     workspaceId = crypto.randomUUID();
     projectAccessState.workspaceId = workspaceId;
-    mockRequireProjectAccess.mockImplementation(({projectId}) =>
+    getProjectById.mockImplementation(({projectId}) =>
       Promise.resolve({
         project: {
           id: projectId,
@@ -85,10 +80,7 @@ describe('GET /api/workflows/runs/:id', () => {
           sourceConnectionId: crypto.randomUUID(),
           sourceExternalRepositoryId: `repo:${crypto.randomUUID()}`,
           name: 'Project',
-          createdAt: new Date(),
-          updatedAt: new Date(),
         },
-        workspaceId,
       }),
     );
   });
@@ -362,7 +354,7 @@ jobs:
         userId: crypto.randomUUID(),
       },
     });
-    mockRequireProjectAccess.mockRejectedValueOnce(
+    getProjectById.mockRejectedValueOnce(
       new ClientError('Not a member of this workspace', 'forbidden', {status: 403}),
     );
 
@@ -389,7 +381,7 @@ jobs:
         userId: crypto.randomUUID(),
       },
     });
-    mockRequireProjectAccess.mockRejectedValueOnce(new Error('database connection lost'));
+    getProjectById.mockRejectedValueOnce(new Error('database connection lost'));
 
     const res = await app.inject({
       method: 'GET',

--- a/libs/api/workflows/src/presentation/routes/get-run.ts
+++ b/libs/api/workflows/src/presentation/routes/get-run.ts
@@ -1,3 +1,4 @@
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
 import {workflowRunDetailResponseSchema} from '@shipfox/api-workflows-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
@@ -12,55 +13,57 @@ import {
 } from '#presentation/dto/index.js';
 import {requireAccessibleRun} from './require-accessible-run.js';
 
-export const getRunRoute = defineRoute({
-  method: 'GET',
-  path: '/:id',
-  description: 'Get a workflow run by ID with jobs and steps',
-  schema: {
-    params: z.object({
-      id: z.string().uuid(),
-    }),
-    querystring: z.object({
-      attempt: z.coerce.number().int().positive().optional(),
-    }),
-    response: {
-      200: workflowRunDetailResponseSchema,
+export function getRunRoute(projects: ProjectsModuleClient) {
+  return defineRoute({
+    method: 'GET',
+    path: '/:id',
+    description: 'Get a workflow run by ID with jobs and steps',
+    schema: {
+      params: z.object({
+        id: z.string().uuid(),
+      }),
+      querystring: z.object({
+        attempt: z.coerce.number().int().positive().optional(),
+      }),
+      response: {
+        200: workflowRunDetailResponseSchema,
+      },
     },
-  },
-  handler: async (request) => {
-    const {id} = request.params;
-    await requireAccessibleRun({request, id});
+    handler: async (request) => {
+      const {id} = request.params;
+      await requireAccessibleRun({request, id, projects});
 
-    const run = await getWorkflowRunDetail(id, request.query.attempt);
-    if (!run) {
-      throw new ClientError('Run not found', 'not-found', {status: 404});
-    }
+      const run = await getWorkflowRunDetail(id, request.query.attempt);
+      if (!run) {
+        throw new ClientError('Run not found', 'not-found', {status: 404});
+      }
 
-    const jobDtos = run.jobs.map((job) => ({
-      ...toJobDto(job),
-      job_executions: job.jobExecutions.map((jobExecution) => ({
-        ...toJobExecutionDto(jobExecution),
-        steps: jobExecution.steps.map((step) => {
-          const attempts = step.attempts.map(toStepAttemptDto);
-          const latestTerminalAttempt = attempts
-            .filter((attempt) => attempt.status !== 'running')
-            .at(-1);
-          return {
-            ...toStepDto(step),
-            exit_code: latestTerminalAttempt?.exit_code ?? null,
-            outputs: latestTerminalAttempt?.outputs ?? null,
-            response: latestTerminalAttempt?.response ?? null,
-            gate_result: latestTerminalAttempt?.gate_result ?? null,
-            attempts,
-          };
-        }),
-      })),
-    }));
+      const jobDtos = run.jobs.map((job) => ({
+        ...toJobDto(job),
+        job_executions: job.jobExecutions.map((jobExecution) => ({
+          ...toJobExecutionDto(jobExecution),
+          steps: jobExecution.steps.map((step) => {
+            const attempts = step.attempts.map(toStepAttemptDto);
+            const latestTerminalAttempt = attempts
+              .filter((attempt) => attempt.status !== 'running')
+              .at(-1);
+            return {
+              ...toStepDto(step),
+              exit_code: latestTerminalAttempt?.exit_code ?? null,
+              outputs: latestTerminalAttempt?.outputs ?? null,
+              response: latestTerminalAttempt?.response ?? null,
+              gate_result: latestTerminalAttempt?.gate_result ?? null,
+              attempts,
+            };
+          }),
+        })),
+      }));
 
-    return {
-      ...toRunDto(run, run.latestAttempt),
-      run_attempt: toRunAttemptDto(run.runAttempt),
-      jobs: jobDtos,
-    };
-  },
-});
+      return {
+        ...toRunDto(run, run.latestAttempt),
+        run_attempt: toRunAttemptDto(run.runAttempt),
+        jobs: jobDtos,
+      };
+    },
+  });
+}

--- a/libs/api/workflows/src/presentation/routes/index.ts
+++ b/libs/api/workflows/src/presentation/routes/index.ts
@@ -1,4 +1,5 @@
 import {AUTH_LEASED_JOB, AUTH_USER} from '@shipfox/api-auth-context';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
 import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-module';
 import type {RouteGroup} from '@shipfox/node-fastify';
 import {createAgentRuntimeConfigRoute} from './agent-runtime-config.js';
@@ -13,35 +14,49 @@ import {createNextStepRoute} from './next-step.js';
 import {createReportStepRoute} from './report-step.js';
 import {rerunRunRoute} from './rerun-run.js';
 
-export function createLeaseTokenRouteGroup(runners: RunnersInterModuleClient): RouteGroup {
+const unconfiguredProjects = {
+  getProjectById: () => {
+    throw new Error('Projects client is not configured');
+  },
+  requireProjectForWorkspace: () => {
+    throw new Error('Projects client is not configured');
+  },
+} as unknown as ProjectsModuleClient;
+
+export function createLeaseTokenRouteGroup(
+  runners: RunnersInterModuleClient,
+  projects: ProjectsModuleClient = unconfiguredProjects,
+): RouteGroup {
   return {
-    // The lease token names the job, so the path carries no job id ("current").
     prefix: '/runs/jobs/current',
     auth: AUTH_LEASED_JOB,
     routes: [
       createNextStepRoute(runners),
       createReportStepRoute(runners),
-      createCheckoutTokenRoute(runners),
+      createCheckoutTokenRoute(runners, projects),
       createAgentRuntimeConfigRoute(runners),
       createGetStepSecretsRoute(runners),
     ],
   };
 }
 
-export function createWorkflowRoutes(runners: RunnersInterModuleClient): RouteGroup[] {
+export function createWorkflowRoutes(
+  runners: RunnersInterModuleClient,
+  projects: ProjectsModuleClient = unconfiguredProjects,
+): RouteGroup[] {
   return [
     {
       prefix: '/workflows/runs',
       auth: AUTH_USER,
       routes: [
-        listRunsRoute,
-        getRunAggregatesRoute,
-        listRunAttemptsRoute,
-        getRunRoute,
-        cancelRunRoute,
-        rerunRunRoute,
+        listRunsRoute(projects),
+        getRunAggregatesRoute(projects),
+        listRunAttemptsRoute(projects),
+        getRunRoute(projects),
+        cancelRunRoute(projects),
+        rerunRunRoute(projects),
       ],
     },
-    createLeaseTokenRouteGroup(runners),
+    createLeaseTokenRouteGroup(runners, projects),
   ];
 }

--- a/libs/api/workflows/src/presentation/routes/list-run-attempts.test.ts
+++ b/libs/api/workflows/src/presentation/routes/list-run-attempts.test.ts
@@ -1,5 +1,5 @@
 import {buildUserContext, setUserContext} from '@shipfox/api-auth-context';
-import {requireProjectAccess} from '@shipfox/api-projects';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
 import {ClientError} from '@shipfox/node-fastify';
 import type {FastifyInstance} from 'fastify';
 import Fastify from 'fastify';
@@ -14,16 +14,11 @@ import {listRunAttemptsRoute} from './list-run-attempts.js';
 
 const projectAccessState = vi.hoisted(() => ({workspaceId: ''}));
 
-vi.mock('@shipfox/api-projects', () => ({
-  requireProjectAccess: vi.fn(({projectId}) =>
-    Promise.resolve({
-      project: {id: projectId, workspaceId: projectAccessState.workspaceId},
-      workspaceId: projectAccessState.workspaceId,
-    }),
-  ),
-}));
-
-const mockRequireProjectAccess = vi.mocked(requireProjectAccess);
+const getProjectById = vi.fn();
+const projects = {
+  getProjectById,
+  requireProjectForWorkspace: vi.fn(),
+} as unknown as ProjectsModuleClient;
 
 describe('GET /api/workflows/runs/:id/attempts', () => {
   let app: FastifyInstance;
@@ -46,7 +41,7 @@ describe('GET /api/workflows/runs/:id/attempts', () => {
       );
       done();
     });
-    app.get('/api/workflows/runs/:id/attempts', listRunAttemptsRoute);
+    app.get('/api/workflows/runs/:id/attempts', listRunAttemptsRoute(projects));
     await app.ready();
   });
 
@@ -55,7 +50,7 @@ describe('GET /api/workflows/runs/:id/attempts', () => {
     projectId = crypto.randomUUID();
     definitionId = crypto.randomUUID();
     projectAccessState.workspaceId = workspaceId;
-    mockRequireProjectAccess.mockImplementation(({projectId: requestedProjectId}) =>
+    getProjectById.mockImplementation(({projectId: requestedProjectId}) =>
       Promise.resolve({
         project: {
           id: requestedProjectId,
@@ -63,10 +58,7 @@ describe('GET /api/workflows/runs/:id/attempts', () => {
           sourceConnectionId: crypto.randomUUID(),
           sourceExternalRepositoryId: `repo:${crypto.randomUUID()}`,
           name: 'Project',
-          createdAt: new Date(),
-          updatedAt: new Date(),
         },
-        workspaceId,
       }),
     );
   });
@@ -121,9 +113,7 @@ describe('GET /api/workflows/runs/:id/attempts', () => {
       url: `/api/workflows/runs/${crypto.randomUUID()}/attempts`,
     });
     const run = await createRun();
-    mockRequireProjectAccess.mockRejectedValueOnce(
-      new ClientError('Forbidden', 'forbidden', {status: 403}),
-    );
+    getProjectById.mockRejectedValueOnce(new ClientError('Forbidden', 'forbidden', {status: 403}));
 
     const inaccessible = await app.inject({
       method: 'GET',

--- a/libs/api/workflows/src/presentation/routes/list-run-attempts.ts
+++ b/libs/api/workflows/src/presentation/routes/list-run-attempts.ts
@@ -1,3 +1,4 @@
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
 import {workflowRunAttemptsResponseSchema} from '@shipfox/api-workflows-dto';
 import {defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
@@ -5,23 +6,25 @@ import {listRunAttempts} from '#db/index.js';
 import {toRunAttemptDto} from '#presentation/dto/index.js';
 import {requireAccessibleRun} from './require-accessible-run.js';
 
-export const listRunAttemptsRoute = defineRoute({
-  method: 'GET',
-  path: '/:id/attempts',
-  description: 'List attempts in a workflow run lineage',
-  schema: {
-    params: z.object({
-      id: z.string().uuid(),
-    }),
-    response: {
-      200: workflowRunAttemptsResponseSchema,
+export function listRunAttemptsRoute(projects: ProjectsModuleClient) {
+  return defineRoute({
+    method: 'GET',
+    path: '/:id/attempts',
+    description: 'List attempts in a workflow run lineage',
+    schema: {
+      params: z.object({
+        id: z.string().uuid(),
+      }),
+      response: {
+        200: workflowRunAttemptsResponseSchema,
+      },
     },
-  },
-  handler: async (request) => {
-    const {id} = request.params;
-    const run = await requireAccessibleRun({request, id});
-    const attempts = await listRunAttempts({workflowRunId: run.id, projectId: run.projectId});
+    handler: async (request) => {
+      const {id} = request.params;
+      const run = await requireAccessibleRun({request, id, projects});
+      const attempts = await listRunAttempts({workflowRunId: run.id, projectId: run.projectId});
 
-    return {attempts: attempts.map(toRunAttemptDto)};
-  },
-});
+      return {attempts: attempts.map(toRunAttemptDto)};
+    },
+  });
+}

--- a/libs/api/workflows/src/presentation/routes/list-runs.test.ts
+++ b/libs/api/workflows/src/presentation/routes/list-runs.test.ts
@@ -1,4 +1,5 @@
 import {buildUserContext, setUserContext} from '@shipfox/api-auth-context';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
 import {encodeTimestampIdCursor} from '@shipfox/node-drizzle';
 import {eq} from 'drizzle-orm';
 import type {FastifyInstance} from 'fastify';
@@ -12,15 +13,20 @@ import {listRunsRoute} from './list-runs.js';
 
 const projectAccessState = vi.hoisted(() => ({workspaceId: ''}));
 
-vi.mock('@shipfox/api-projects', () => ({
-  ProjectNotFoundError: class ProjectNotFoundError extends Error {},
-  requireProjectAccess: vi.fn(({projectId}) =>
+const projects = {
+  getProjectById: vi.fn(({projectId}) =>
     Promise.resolve({
-      project: {id: projectId, workspaceId: projectAccessState.workspaceId},
-      workspaceId: projectAccessState.workspaceId,
+      project: {
+        id: projectId,
+        workspaceId: projectAccessState.workspaceId,
+        sourceConnectionId: crypto.randomUUID(),
+        sourceExternalRepositoryId: 'repo',
+        name: 'Project',
+      },
     }),
   ),
-}));
+  requireProjectForWorkspace: vi.fn(),
+} as unknown as ProjectsModuleClient;
 
 describe('GET /api/workflows/runs', () => {
   let app: FastifyInstance;
@@ -42,7 +48,7 @@ describe('GET /api/workflows/runs', () => {
       );
       done();
     });
-    app.get('/api/workflows/runs', listRunsRoute);
+    app.get('/api/workflows/runs', listRunsRoute(projects));
     await app.ready();
   });
 

--- a/libs/api/workflows/src/presentation/routes/list-runs.ts
+++ b/libs/api/workflows/src/presentation/routes/list-runs.ts
@@ -1,4 +1,4 @@
-import {ProjectNotFoundError, requireProjectAccess} from '@shipfox/api-projects';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
 import {
   workflowRunListQuerySchema,
   workflowRunListResponseSchema,
@@ -8,76 +8,73 @@ import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {logger} from '@shipfox/node-opentelemetry';
 import {listWorkflowRuns} from '#db/index.js';
 import {toRunDto} from '#presentation/dto/index.js';
+import {requireProjectAccess} from './project-access.js';
 
-export const listRunsRoute = defineRoute({
-  method: 'GET',
-  path: '/',
-  description: 'List workflow runs for a project',
-  schema: {
-    querystring: workflowRunListQuerySchema,
-    response: {
-      200: workflowRunListResponseSchema,
-    },
-  },
-  errorHandler: (error) => {
-    if (error instanceof ProjectNotFoundError) {
-      throw new ClientError(error.message, 'project-not-found', {status: 404});
-    }
-    throw error;
-  },
-  handler: async (request) => {
-    const startedAt = performance.now();
-    const {
-      project_id: projectId,
-      limit,
-      cursor,
-      status,
-      definition_id: definitionId,
-      trigger_source: triggerSource,
-      created_from: createdFrom,
-      created_to: createdTo,
-    } = request.query;
-    const decodedCursor = decodeTimestampIdCursor(cursor);
-    if (cursor && !decodedCursor) {
-      throw new ClientError('Invalid cursor', 'invalid-cursor', {status: 400});
-    }
-
-    const {project} = await requireProjectAccess({request, projectId});
-
-    const filters = {
-      status,
-      definitionId,
-      triggerSource,
-      createdFrom: createdFrom ? new Date(createdFrom) : undefined,
-      createdTo: createdTo ? new Date(createdTo) : undefined,
-    };
-    const result = await listWorkflowRuns({
-      projectId: project.id,
-      limit,
-      cursor: decodedCursor,
-      filters,
-      includeTotal: !decodedCursor,
-    });
-
-    logger().info(
-      {
-        projectId: project.id,
-        filterKeys: Object.entries(filters)
-          .filter(([, value]) => value !== undefined)
-          .map(([key]) => key),
-        limit,
-        cursorPresent: Boolean(cursor),
-        resultCount: result.runs.length,
-        nextCursorPresent: Boolean(result.nextCursor),
-        durationMs: Math.round(performance.now() - startedAt),
+export function listRunsRoute(projects: ProjectsModuleClient) {
+  return defineRoute({
+    method: 'GET',
+    path: '/',
+    description: 'List workflow runs for a project',
+    schema: {
+      querystring: workflowRunListQuerySchema,
+      response: {
+        200: workflowRunListResponseSchema,
       },
-      'Listed workflow runs',
-    );
+    },
+    handler: async (request) => {
+      const startedAt = performance.now();
+      const {
+        project_id: projectId,
+        limit,
+        cursor,
+        status,
+        definition_id: definitionId,
+        trigger_source: triggerSource,
+        created_from: createdFrom,
+        created_to: createdTo,
+      } = request.query;
+      const decodedCursor = decodeTimestampIdCursor(cursor);
+      if (cursor && !decodedCursor) {
+        throw new ClientError('Invalid cursor', 'invalid-cursor', {status: 400});
+      }
 
-    return {
-      runs: result.runs.map((run) => toRunDto(run)),
-      next_cursor: result.nextCursor ? encodeTimestampIdCursor(result.nextCursor) : null,
-      filtered_total_count: result.filteredTotalCount,
-    };
-  },
-});
+      const project = await requireProjectAccess(request, projectId, projects);
+
+      const filters = {
+        status,
+        definitionId,
+        triggerSource,
+        createdFrom: createdFrom ? new Date(createdFrom) : undefined,
+        createdTo: createdTo ? new Date(createdTo) : undefined,
+      };
+      const result = await listWorkflowRuns({
+        projectId: project.id,
+        limit,
+        cursor: decodedCursor,
+        filters,
+        includeTotal: !decodedCursor,
+      });
+
+      logger().info(
+        {
+          projectId: project.id,
+          filterKeys: Object.entries(filters)
+            .filter(([, value]) => value !== undefined)
+            .map(([key]) => key),
+          limit,
+          cursorPresent: Boolean(cursor),
+          resultCount: result.runs.length,
+          nextCursorPresent: Boolean(result.nextCursor),
+          durationMs: Math.round(performance.now() - startedAt),
+        },
+        'Listed workflow runs',
+      );
+
+      return {
+        runs: result.runs.map((run) => toRunDto(run)),
+        next_cursor: result.nextCursor ? encodeTimestampIdCursor(result.nextCursor) : null,
+        filtered_total_count: result.filteredTotalCount,
+      };
+    },
+  });
+}

--- a/libs/api/workflows/src/presentation/routes/project-access.ts
+++ b/libs/api/workflows/src/presentation/routes/project-access.ts
@@ -1,0 +1,16 @@
+import {requireWorkspaceAccess} from '@shipfox/api-auth-context';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import {ClientError} from '@shipfox/node-fastify';
+import type {FastifyRequest} from 'fastify';
+
+export async function requireProjectAccess(
+  request: FastifyRequest,
+  projectId: string,
+  projects: ProjectsModuleClient,
+) {
+  const result = await projects.getProjectById({projectId});
+  if (result.project === null)
+    throw new ClientError('Project not found', 'project-not-found', {status: 404});
+  requireWorkspaceAccess({request, workspaceId: result.project.workspaceId});
+  return result.project;
+}

--- a/libs/api/workflows/src/presentation/routes/require-accessible-run.ts
+++ b/libs/api/workflows/src/presentation/routes/require-accessible-run.ts
@@ -1,22 +1,25 @@
-import {requireProjectAccess} from '@shipfox/api-projects';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
 import {ClientError} from '@shipfox/node-fastify';
 import type {FastifyRequest} from 'fastify';
 import type {WorkflowRun} from '#core/entities/workflow-run.js';
 import {getWorkflowRunById} from '#db/index.js';
+import {requireProjectAccess} from './project-access.js';
 
 export async function requireAccessibleRun({
   request,
   id,
+  projects,
 }: {
   request: FastifyRequest;
   id: string;
+  projects: ProjectsModuleClient;
 }): Promise<WorkflowRun> {
   const run = await getWorkflowRunById(id);
   if (!run) {
     throw new ClientError('Run not found', 'not-found', {status: 404});
   }
 
-  await requireProjectAccess({request, projectId: run.projectId}).catch((err: unknown) => {
+  await requireProjectAccess(request, run.projectId, projects).catch((err: unknown) => {
     if (err instanceof ClientError && (err.status === 403 || err.status === 404)) {
       throw new ClientError('Run not found', 'not-found', {status: 404});
     }

--- a/libs/api/workflows/src/presentation/routes/rerun-run.test.ts
+++ b/libs/api/workflows/src/presentation/routes/rerun-run.test.ts
@@ -1,5 +1,5 @@
 import {buildUserContext, setUserContext} from '@shipfox/api-auth-context';
-import {requireProjectAccess} from '@shipfox/api-projects';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
 import {ClientError} from '@shipfox/node-fastify';
 import type {FastifyInstance} from 'fastify';
 import Fastify from 'fastify';
@@ -15,16 +15,11 @@ import {rerunRunRoute} from './rerun-run.js';
 
 const projectAccessState = vi.hoisted(() => ({workspaceId: ''}));
 
-vi.mock('@shipfox/api-projects', () => ({
-  requireProjectAccess: vi.fn(({projectId}) =>
-    Promise.resolve({
-      project: {id: projectId, workspaceId: projectAccessState.workspaceId},
-      workspaceId: projectAccessState.workspaceId,
-    }),
-  ),
-}));
-
-const mockRequireProjectAccess = vi.mocked(requireProjectAccess);
+const getProjectById = vi.fn();
+const projects = {
+  getProjectById,
+  requireProjectForWorkspace: vi.fn(),
+} as unknown as ProjectsModuleClient;
 
 describe('POST /api/workflows/runs/:id/rerun', () => {
   let app: FastifyInstance;
@@ -46,7 +41,7 @@ describe('POST /api/workflows/runs/:id/rerun', () => {
       );
       done();
     });
-    app.post('/api/workflows/runs/:id/rerun', rerunRunRoute);
+    app.post('/api/workflows/runs/:id/rerun', rerunRunRoute(projects));
     await app.ready();
   });
 
@@ -54,7 +49,7 @@ describe('POST /api/workflows/runs/:id/rerun', () => {
     workspaceId = crypto.randomUUID();
     projectId = crypto.randomUUID();
     projectAccessState.workspaceId = workspaceId;
-    mockRequireProjectAccess.mockImplementation(({projectId: requestedProjectId}) =>
+    getProjectById.mockImplementation(({projectId: requestedProjectId}) =>
       Promise.resolve({
         project: {
           id: requestedProjectId,
@@ -62,10 +57,7 @@ describe('POST /api/workflows/runs/:id/rerun', () => {
           sourceConnectionId: crypto.randomUUID(),
           sourceExternalRepositoryId: `repo:${crypto.randomUUID()}`,
           name: 'Project',
-          createdAt: new Date(),
-          updatedAt: new Date(),
         },
-        workspaceId,
       }),
     );
   });
@@ -174,9 +166,7 @@ describe('POST /api/workflows/runs/:id/rerun', () => {
       payload: {mode: 'all'},
     });
     const source = await createTerminalRun('failed');
-    mockRequireProjectAccess.mockRejectedValueOnce(
-      new ClientError('Forbidden', 'forbidden', {status: 403}),
-    );
+    getProjectById.mockRejectedValueOnce(new ClientError('Forbidden', 'forbidden', {status: 403}));
 
     const inaccessible = await app.inject({
       method: 'POST',

--- a/libs/api/workflows/src/presentation/routes/rerun-run.ts
+++ b/libs/api/workflows/src/presentation/routes/rerun-run.ts
@@ -1,4 +1,5 @@
 import {requireUserContext} from '@shipfox/api-auth-context';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
 import {rerunWorkflowRunBodySchema, workflowRunResponseSchema} from '@shipfox/api-workflows-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
@@ -7,42 +8,44 @@ import {createRerunWorkflowRun} from '#db/index.js';
 import {toRunDto} from '#presentation/dto/index.js';
 import {requireAccessibleRun} from './require-accessible-run.js';
 
-export const rerunRunRoute = defineRoute({
-  method: 'POST',
-  path: '/:id/rerun',
-  description: 'Re-run a terminal workflow run',
-  schema: {
-    params: z.object({
-      id: z.string().uuid(),
-    }),
-    body: rerunWorkflowRunBodySchema,
-    response: {
-      200: workflowRunResponseSchema,
+export function rerunRunRoute(projects: ProjectsModuleClient) {
+  return defineRoute({
+    method: 'POST',
+    path: '/:id/rerun',
+    description: 'Re-run a terminal workflow run',
+    schema: {
+      params: z.object({
+        id: z.string().uuid(),
+      }),
+      body: rerunWorkflowRunBodySchema,
+      response: {
+        200: workflowRunResponseSchema,
+      },
     },
-  },
-  errorHandler: (error) => {
-    if (error instanceof SourceRunNotFoundError) {
-      throw new ClientError('Run not found', 'not-found', {status: 404});
-    }
-    if (error instanceof RunNotTerminalError) {
-      throw new ClientError('Run is not terminal', 'run-not-terminal', {status: 409});
-    }
-    if (error instanceof NoFailedJobsError) {
-      throw new ClientError('Run has no failed jobs', 'no-failed-jobs', {status: 409});
-    }
-    throw error;
-  },
-  handler: async (request) => {
-    const {id} = request.params;
-    const sourceRun = await requireAccessibleRun({request, id});
+    errorHandler: (error) => {
+      if (error instanceof SourceRunNotFoundError) {
+        throw new ClientError('Run not found', 'not-found', {status: 404});
+      }
+      if (error instanceof RunNotTerminalError) {
+        throw new ClientError('Run is not terminal', 'run-not-terminal', {status: 409});
+      }
+      if (error instanceof NoFailedJobsError) {
+        throw new ClientError('Run has no failed jobs', 'no-failed-jobs', {status: 409});
+      }
+      throw error;
+    },
+    handler: async (request) => {
+      const {id} = request.params;
+      const sourceRun = await requireAccessibleRun({request, id, projects});
 
-    const actor = requireUserContext(request);
-    const run = await createRerunWorkflowRun({
-      workflowRunId: sourceRun.id,
-      mode: request.body.mode,
-      actorUserId: actor.userId,
-    });
+      const actor = requireUserContext(request);
+      const run = await createRerunWorkflowRun({
+        workflowRunId: sourceRun.id,
+        mode: request.body.mode,
+        actorUserId: actor.userId,
+      });
 
-    return toRunDto(run, run.currentAttempt);
-  },
-});
+      return toRunDto(run, run.currentAttempt);
+    },
+  });
+}

--- a/libs/api/workflows/test/factories/project.ts
+++ b/libs/api/workflows/test/factories/project.ts
@@ -1,10 +1,15 @@
-import type {Project} from '@shipfox/api-projects';
 import {Factory} from 'fishery';
 
-// Build-only: the workflows routes resolve projects through a mocked
-// `getProjectById`, so these are never persisted (the projects table lives in
-// @shipfox/api-projects). Typed against the real `Project` so the mock cannot
-// drift from the contract under test.
+interface Project {
+  id: string;
+  workspaceId: string;
+  sourceConnectionId: string;
+  sourceExternalRepositoryId: string;
+  name: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
 export const projectFactory = Factory.define<Project>(({sequence}) => ({
   id: crypto.randomUUID(),
   workspaceId: crypto.randomUUID(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2171,9 +2171,6 @@ importers:
       '@shipfox/api-integration-core-dto':
         specifier: workspace:*
         version: link:../integration/core-dto
-      '@shipfox/api-projects':
-        specifier: workspace:*
-        version: link:../projects
       '@shipfox/api-projects-dto':
         specifier: workspace:*
         version: link:../projects-dto
@@ -3335,6 +3332,9 @@ importers:
       '@shipfox/api-projects-dto':
         specifier: workspace:*
         version: link:../projects-dto
+      '@shipfox/inter-module':
+        specifier: workspace:*
+        version: link:../../shared/common/inter-module
       '@shipfox/node-drizzle':
         specifier: workspace:*
         version: link:../../shared/node/drizzle
@@ -3417,6 +3417,9 @@ importers:
       '@shipfox/api-common-dto':
         specifier: workspace:*
         version: link:../common-dto
+      '@shipfox/inter-module':
+        specifier: workspace:*
+        version: link:../../shared/common/inter-module
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -3588,15 +3591,18 @@ importers:
       '@shipfox/api-auth-context':
         specifier: workspace:*
         version: link:../auth-context
-      '@shipfox/api-projects':
+      '@shipfox/api-projects-dto':
         specifier: workspace:*
-        version: link:../projects
+        version: link:../projects-dto
       '@shipfox/api-secrets-dto':
         specifier: workspace:*
         version: link:../secrets-dto
       '@shipfox/config':
         specifier: workspace:*
         version: link:../../shared/common/config
+      '@shipfox/inter-module':
+        specifier: workspace:*
+        version: link:../../shared/common/inter-module
       '@shipfox/node-drizzle':
         specifier: workspace:*
         version: link:../../shared/node/drizzle
@@ -3695,6 +3701,9 @@ importers:
       '@shipfox/api-projects':
         specifier: workspace:*
         version: link:../projects
+      '@shipfox/api-projects-dto':
+        specifier: workspace:*
+        version: link:../projects-dto
       '@shipfox/api-runners':
         specifier: workspace:*
         version: link:../runners
@@ -3738,6 +3747,9 @@ importers:
       '@shipfox/biome':
         specifier: workspace:*
         version: link:../../../tools/biome
+      '@shipfox/inter-module':
+        specifier: workspace:*
+        version: link:../../shared/common/inter-module
       '@shipfox/swc':
         specifier: workspace:*
         version: link:../../../tools/swc
@@ -3908,9 +3920,9 @@ importers:
       '@shipfox/api-integration-core':
         specifier: workspace:*
         version: link:../integration/core
-      '@shipfox/api-projects':
+      '@shipfox/api-projects-dto':
         specifier: workspace:*
-        version: link:../projects
+        version: link:../projects-dto
       '@shipfox/api-runners':
         specifier: workspace:*
         version: link:../runners


### PR DESCRIPTION
Expose a producer-owned Projects inter-module client and migrate Definitions, Secrets, and Workflows to use it for project lookup and workspace access decisions.

These consumers previously imported Projects implementation code directly, coupling their routes and job preparation to the producer persistence and policy internals. The contract keeps project data and ownership checks behind an injected client while preserving the existing authorization and not-found behavior.

Considered keeping direct imports behind shared helpers, but that would continue to leak the Projects implementation boundary. The API server now wires the client at composition time, and dependency-cruiser prevents these consumers from regressing to implementation imports.

Review focus: contract error semantics for missing projects versus workspace mismatches, plus the injected route factories in Definitions, Secrets, and Workflows.

Closes ENG-1040

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes a producer-owned Projects inter-module API and migrates Definitions, Secrets, and Workflows to an injected `ProjectsModuleClient` for project lookup and access. Decouples consumers from `@shipfox/api-projects` while preserving 404/403 behavior. Addresses ENG-1040.

- New Features
  - Added `projectsInterModuleContract` in `@shipfox/api-projects-dto` and producer presentation via `createProjectsInterModulePresentation` in `@shipfox/api-projects` (using `@shipfox/inter-module`).
  - Server composes an inter-module transport, builds a Projects client, and injects it into:
    - Definitions: `createDefinitionRoutes({ projects })`, local `project-access.ts` enforces workspace access; routes converted to factories.
    - Secrets: `createSecretsModule(projects)` and `createSecretsRoutes(projects)`; `ManagementAccessHelpers` wrap inter-module errors into client errors.
    - Workflows: `createWorkflowsModule({ projects, runners })`, routes converted to factories (e.g., `createCheckoutTokenRoute(runners, projects)`), helpers updated to accept `projects` (e.g., `resolveCheckoutIntent(jobId, projects)`).
  - `dependency-cruiser` rule prevents consumers from importing `@shipfox/api-projects` implementation.

- Migration
  - Inject the `projects` client:
    - Definitions: `createDefinitionRoutes({ projects })` and pass through `createDefinitionsModule({ projects, ... })`.
    - Secrets: use `createSecretsModule(projects)` and `createSecretsRoutes(projects)`.
    - Workflows: `createWorkflowsModule({ projects, runners })` and pass `projects` to route/group builders.
  - Replace consumer imports of `@shipfox/api-projects` with `@shipfox/api-projects-dto`.
  - Update Workflows core/helpers to accept `projects` (e.g., `resolveCheckoutIntent(jobId, projects)`).
  - In tests, use a fake `ProjectsModuleClient` or inter-module test helpers (e.g., `createFakeInterModuleClients`).

<sup>Written for commit 27c5c97892f4bb85b2957ba9d900dd54002acf41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

