### PR TITLE
[integration] Share generic webhook processing

### DIFF
--- a/.changeset/gentle-hooks-converge.md
+++ b/.changeset/gentle-hooks-converge.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-integration-webhook": minor
+---
+
+Adds the shared processor for generic webhook deliveries.

--- a/libs/api/integration/webhook/package.json
+++ b/libs/api/integration/webhook/package.json
@@ -40,12 +40,12 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
-    "@fastify/formbody": "catalog:",
     "@shipfox/api-auth-context": "workspace:*",
     "@shipfox/api-integration-core-dto": "workspace:*",
     "@shipfox/api-integration-webhook-dto": "workspace:*",
     "@shipfox/config": "workspace:*",
     "@shipfox/node-fastify": "workspace:*",
+    "@shipfox/node-opentelemetry": "workspace:*",
     "fastify-plugin": "^5.1.0",
     "zod": "catalog:"
   },

--- a/libs/api/integration/webhook/src/constants.ts
+++ b/libs/api/integration/webhook/src/constants.ts
@@ -1,5 +1,11 @@
 export const WEBHOOK_INBOUND_BODY_LIMIT = 1 * 1024 * 1024;
 
+export const WEBHOOK_ACCEPTED_CONTENT_TYPES = [
+  'application/json',
+  'application/x-www-form-urlencoded',
+  'text/plain',
+] as const;
+
 export const WEBHOOK_FORWARDED_HEADERS = [
   'content-type',
   'user-agent',

--- a/libs/api/integration/webhook/src/core/webhook-processor.test.ts
+++ b/libs/api/integration/webhook/src/core/webhook-processor.test.ts
@@ -1,0 +1,87 @@
+import {randomUUID} from 'node:crypto';
+import {
+  createStoredWebhookRequest,
+  type IntegrationConnection,
+} from '@shipfox/api-integration-core-dto';
+import {createGenericWebhookProcessor} from './webhook-processor.js';
+
+function fakeConnection(overrides: Partial<IntegrationConnection> = {}): IntegrationConnection {
+  const now = new Date();
+  return {
+    id: randomUUID(),
+    workspaceId: randomUUID(),
+    provider: 'webhook',
+    externalAccountId: 'stripe-prod',
+    slug: 'stripe_prod',
+    displayName: 'Stripe Production',
+    lifecycleStatus: 'active',
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+function genericWebhookRequest(connectionId: string) {
+  return createStoredWebhookRequest({
+    requestId: randomUUID(),
+    routeId: 'webhook.connection',
+    receivedAt: '2026-07-20T10:30:00.123Z',
+    rawQueryString: 'mode=test&tag=one&tag=two',
+    headers: {
+      'content-type': 'application/json',
+      'x-delivery-id': 'delivery-1',
+      authorization: '[redacted]',
+    },
+    body: new TextEncoder().encode('{"ok":true}'),
+    connectionId,
+  });
+}
+
+describe('GenericWebhookProcessor', () => {
+  it.each([
+    ['a missing connection', undefined],
+    ['an inactive connection', fakeConnection({lifecycleStatus: 'disabled'})],
+  ])('discards queued delivery for %s', async (_description, connection) => {
+    const publishIntegrationEventReceived = vi.fn(() => Promise.resolve({published: true}));
+    const processor = createGenericWebhookProcessor({
+      coreDb: () => ({transaction: (callback) => callback({})}),
+      getIntegrationConnectionById: vi.fn(() => Promise.resolve(connection)),
+      publishIntegrationEventReceived,
+    });
+
+    const result = await processor.process(genericWebhookRequest(randomUUID()));
+
+    expect(result).toEqual({outcome: 'discarded', reason: 'connection_unavailable'});
+    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+  });
+
+  it('publishes the compatible generic event envelope', async () => {
+    const connection = fakeConnection();
+    const publishIntegrationEventReceived = vi.fn(() => Promise.resolve({published: true}));
+    const processor = createGenericWebhookProcessor({
+      coreDb: () => ({transaction: (callback) => callback({})}),
+      getIntegrationConnectionById: vi.fn(() => Promise.resolve(connection)),
+      publishIntegrationEventReceived,
+    });
+
+    const result = await processor.process(genericWebhookRequest(connection.id));
+
+    expect(result).toEqual({outcome: 'processed', deliveryId: 'delivery-1'});
+    expect(publishIntegrationEventReceived).toHaveBeenCalledWith({
+      tx: {},
+      event: expect.objectContaining({
+        deliveryId: 'delivery-1',
+        payload: {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            'x-delivery-id': 'delivery-1',
+            authorization: '[redacted]',
+          },
+          query: {mode: 'test', tag: ['one', 'two']},
+          body: {ok: true},
+        },
+      }),
+    });
+  });
+});

--- a/libs/api/integration/webhook/src/core/webhook-processor.ts
+++ b/libs/api/integration/webhook/src/core/webhook-processor.ts
@@ -1,0 +1,128 @@
+import {Buffer} from 'node:buffer';
+import {
+  decodeWebhookBody,
+  type GetIntegrationConnectionByIdFn,
+  type IntegrationConnection,
+  type IntegrationTx,
+  type PublishIntegrationEventReceivedFn,
+  type StoredWebhookRequest,
+  type WebhookProcessingResult,
+} from '@shipfox/api-integration-core-dto';
+import {WEBHOOK_PROVIDER, WEBHOOK_RECEIVED_EVENT} from '@shipfox/api-integration-webhook-dto';
+import {logger} from '@shipfox/node-opentelemetry';
+import {redactHeaders, WEBHOOK_ACCEPTED_CONTENT_TYPES} from '#constants.js';
+
+const [JSON_CONTENT_TYPE, FORM_CONTENT_TYPE, TEXT_CONTENT_TYPE] = WEBHOOK_ACCEPTED_CONTENT_TYPES;
+
+export interface CreateGenericWebhookProcessorOptions {
+  coreDb: () => {
+    transaction<T>(callback: (tx: IntegrationTx) => Promise<T>): Promise<T>;
+  };
+  getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
+  publishIntegrationEventReceived: PublishIntegrationEventReceivedFn;
+}
+
+export interface GenericWebhookProcessor {
+  process(
+    request: StoredWebhookRequest,
+    connection?: IntegrationConnection | undefined,
+  ): Promise<WebhookProcessingResult>;
+}
+
+export function createGenericWebhookProcessor(
+  options: CreateGenericWebhookProcessorOptions,
+): GenericWebhookProcessor {
+  return {
+    process: (request, connection) => processWebhookRequest(options, request, connection),
+  };
+}
+
+async function processWebhookRequest(
+  options: CreateGenericWebhookProcessorOptions,
+  request: StoredWebhookRequest,
+  knownConnection?: IntegrationConnection | undefined,
+): Promise<WebhookProcessingResult> {
+  if (request.route_id !== 'webhook.connection') {
+    throw new Error(`Generic webhook processor cannot process ${request.route_id} requests`);
+  }
+
+  const connection =
+    knownConnection ??
+    (await options.getIntegrationConnectionById(request.path_parameters.connection_id));
+  if (
+    !connection ||
+    connection.provider !== WEBHOOK_PROVIDER ||
+    connection.lifecycleStatus !== 'active'
+  ) {
+    return {outcome: 'discarded', reason: 'connection_unavailable'};
+  }
+
+  const deliveryId = request.headers['x-delivery-id'] ?? request.request_id;
+  const body = parseWebhookBody(request);
+  if (!body.success) {
+    logger().warn({deliveryId, err: body.error}, 'generic webhook payload parsing failed');
+    return {outcome: 'discarded', reason: 'malformed_payload', deliveryId};
+  }
+
+  await options.coreDb().transaction(async (tx) => {
+    await options.publishIntegrationEventReceived({
+      tx,
+      event: {
+        provider: WEBHOOK_PROVIDER,
+        source: connection.slug,
+        event: WEBHOOK_RECEIVED_EVENT,
+        workspaceId: connection.workspaceId,
+        connectionId: connection.id,
+        connectionName: connection.displayName,
+        deliveryId,
+        receivedAt: request.received_at,
+        payload: {
+          method: request.method,
+          headers: redactHeaders(request.headers),
+          query: parseWebhookQuery(request.raw_query_string),
+          body: body.value,
+        },
+      },
+    });
+  });
+
+  return {outcome: 'processed', deliveryId};
+}
+
+function parseWebhookQuery(rawQueryString: string): Record<string, string | string[]> {
+  const query: Record<string, string | string[]> = {};
+
+  for (const [name, value] of new URLSearchParams(rawQueryString)) {
+    const existingValue = query[name];
+    if (existingValue === undefined) {
+      query[name] = value;
+    } else if (Array.isArray(existingValue)) {
+      existingValue.push(value);
+    } else {
+      query[name] = [existingValue, value];
+    }
+  }
+
+  return query;
+}
+
+function parseWebhookBody(
+  request: StoredWebhookRequest,
+): {success: true; value: unknown} | {success: false; error?: unknown} {
+  const body = Buffer.from(decodeWebhookBody(request.body));
+  const contentType = request.headers['content-type']?.split(';', 1)[0]?.trim().toLowerCase();
+
+  if (contentType === JSON_CONTENT_TYPE) {
+    try {
+      return {success: true, value: JSON.parse(body.toString('utf8'))};
+    } catch (error) {
+      return {success: false, error};
+    }
+  }
+  if (contentType === FORM_CONTENT_TYPE) {
+    return {success: true, value: Object.fromEntries(new URLSearchParams(body.toString('utf8')))};
+  }
+  if (contentType === TEXT_CONTENT_TYPE) return {success: true, value: body.toString('utf8')};
+
+  return {success: false};
+}

--- a/libs/api/integration/webhook/src/index.ts
+++ b/libs/api/integration/webhook/src/index.ts
@@ -13,6 +13,11 @@ import {createWebhookConnectionRoutes} from '#presentation/routes/connections.js
 import {createWebhookInboundRoutes} from '#presentation/routes/inbound.js';
 
 export {redactHeaders, WEBHOOK_FORWARDED_HEADERS, WEBHOOK_INBOUND_BODY_LIMIT} from '#constants.js';
+export type {
+  CreateGenericWebhookProcessorOptions,
+  GenericWebhookProcessor,
+} from '#core/webhook-processor.js';
+export {createGenericWebhookProcessor} from '#core/webhook-processor.js';
 
 export interface CreateWebhookIntegrationProviderOptions {
   coreDb: () => {

--- a/libs/api/integration/webhook/src/presentation/routes/inbound.test.ts
+++ b/libs/api/integration/webhook/src/presentation/routes/inbound.test.ts
@@ -54,11 +54,14 @@ describe('webhook inbound route', () => {
 
   it('publishes a JSON delivery envelope', async () => {
     const connection = fakeConnection();
-    const {app, publishIntegrationEventReceived} = await createTestApp({connection});
+    const {app, publishIntegrationEventReceived, getIntegrationConnectionById} =
+      await createTestApp({
+        connection,
+      });
 
     const res = await app.inject({
       method: 'POST',
-      url: `/webhook/${connection.id}?mode=test`,
+      url: `/webhook/${connection.id}?mode=test&tag=one&tag=two`,
       headers: {
         'content-type': 'application/json',
         'x-delivery-id': 'evt-1',
@@ -80,7 +83,7 @@ describe('webhook inbound route', () => {
       deliveryId: 'evt-1',
       payload: {
         method: 'POST',
-        query: {mode: 'test'},
+        query: {mode: 'test', tag: ['one', 'two']},
         body: {ok: true},
         headers: {
           'content-type': 'application/json',
@@ -89,6 +92,7 @@ describe('webhook inbound route', () => {
         },
       },
     });
+    expect(getIntegrationConnectionById).toHaveBeenCalledTimes(1);
   });
 
   it('publishes a form delivery envelope', async () => {
@@ -187,6 +191,7 @@ describe('webhook inbound route', () => {
     expect(res.statusCode).toBe(202);
     const deliveryId = publishIntegrationEventReceived.mock.calls[0]?.[0].event.deliveryId;
     expect(deliveryId).toMatch(UUID_RE);
+    expect(res.json().delivery_id).toBe(deliveryId);
   });
 
   it('rejects an overlong delivery ID header without publishing', async () => {

--- a/libs/api/integration/webhook/src/presentation/routes/inbound.ts
+++ b/libs/api/integration/webhook/src/presentation/routes/inbound.ts
@@ -1,36 +1,36 @@
-import type {Buffer} from 'node:buffer';
 import {randomUUID} from 'node:crypto';
-import formBodyPlugin from '@fastify/formbody';
 import type {
   GetIntegrationConnectionByIdFn,
   IntegrationTx,
   PublishIntegrationEventReceivedFn,
 } from '@shipfox/api-integration-core-dto';
-import {WEBHOOK_PROVIDER, WEBHOOK_RECEIVED_EVENT} from '@shipfox/api-integration-webhook-dto';
+import {
+  createStoredWebhookRequest,
+  type StoredWebhookRequest,
+  WEBHOOK_MAX_RAW_BODY_BYTES,
+} from '@shipfox/api-integration-core-dto';
+import {WEBHOOK_PROVIDER} from '@shipfox/api-integration-webhook-dto';
 import {ClientError, defineRoute, type RouteGroup} from '@shipfox/node-fastify';
 import type {FastifyPluginAsync} from 'fastify';
 import fp from 'fastify-plugin';
 import {z} from 'zod';
-import {redactHeaders, WEBHOOK_INBOUND_BODY_LIMIT} from '#constants.js';
+import {WEBHOOK_ACCEPTED_CONTENT_TYPES, WEBHOOK_INBOUND_BODY_LIMIT} from '#constants.js';
+import {createGenericWebhookProcessor} from '#core/webhook-processor.js';
 
 const MAX_DELIVERY_ID_HEADER_LENGTH = 200;
-const acceptedContentTypes = new Set([
-  'application/json',
-  'application/x-www-form-urlencoded',
-  'text/plain',
-]);
-const FORM_URLENCODED_CONTENT_TYPE_RE = /^application\/x-www-form-urlencoded(?:;.*)?$/i;
-
-const formBodyRoutePlugin: FastifyPluginAsync = fp(async (app) => {
-  await app.register(formBodyPlugin, {bodyLimit: WEBHOOK_INBOUND_BODY_LIMIT});
-
-  app.addContentTypeParser(
-    FORM_URLENCODED_CONTENT_TYPE_RE,
-    {parseAs: 'buffer', bodyLimit: WEBHOOK_INBOUND_BODY_LIMIT},
-    (_request, body: Buffer, done) => {
-      done(null, Object.fromEntries(new URLSearchParams(body.toString('utf8'))));
-    },
-  );
+const acceptedContentTypes = new Set<string>(WEBHOOK_ACCEPTED_CONTENT_TYPES);
+const rawWebhookBodyPlugin: FastifyPluginAsync = fp((app) => {
+  app.removeAllContentTypeParsers();
+  for (const contentType of acceptedContentTypes) {
+    app.addContentTypeParser(
+      contentType,
+      {parseAs: 'buffer', bodyLimit: WEBHOOK_INBOUND_BODY_LIMIT},
+      (_request, body, done) => {
+        done(null, body);
+      },
+    );
+  }
+  return Promise.resolve();
 });
 
 export interface CreateWebhookInboundRoutesOptions {
@@ -64,7 +64,12 @@ function deliveryIdFor(header: string | string[] | undefined): string {
   return value;
 }
 
+function hasDeliveryId(header: string | string[] | undefined): boolean {
+  return Boolean(Array.isArray(header) ? header[0] : header);
+}
+
 export function createWebhookInboundRoutes(options: CreateWebhookInboundRoutesOptions): RouteGroup {
+  const processor = createGenericWebhookProcessor(options);
   const inboundRoute = defineRoute({
     method: 'POST',
     path: '/:connectionId',
@@ -94,29 +99,25 @@ export function createWebhookInboundRoutes(options: CreateWebhookInboundRoutesOp
         throw new ClientError('Webhook connection not found', 'not-found', {status: 404});
       }
 
-      const deliveryId = deliveryIdFor(request.headers['x-delivery-id']);
-      const receivedAt = new Date().toISOString();
-      await options.coreDb().transaction(async (tx) => {
-        await options.publishIntegrationEventReceived({
-          tx,
-          event: {
-            provider: WEBHOOK_PROVIDER,
-            source: connection.slug,
-            event: WEBHOOK_RECEIVED_EVENT,
-            workspaceId: connection.workspaceId,
-            connectionId: connection.id,
-            connectionName: connection.displayName,
-            deliveryId,
-            receivedAt,
-            payload: {
-              method: request.method,
-              headers: redactHeaders(request.headers),
-              query: request.query,
-              body: request.body,
-            },
+      const deliveryHeader = request.headers['x-delivery-id'];
+      const deliveryId = deliveryIdFor(deliveryHeader);
+      const result = await processor.process(
+        createGenericStoredWebhookRequest(
+          {
+            body: request.body,
+            connectionId,
+            headers: request.headers,
+            rawQueryString: request.raw.url?.split('?')[1] ?? '',
+            requestId: hasDeliveryId(deliveryHeader) ? randomUUID() : deliveryId,
           },
-        });
-      });
+          new Date().toISOString(),
+        ),
+        connection,
+      );
+
+      if (result.outcome === 'discarded' && result.reason === 'malformed_payload') {
+        throw new ClientError('Malformed webhook payload', 'malformed-payload', {status: 400});
+      }
 
       reply.code(202);
       return {delivery_id: deliveryId};
@@ -126,7 +127,52 @@ export function createWebhookInboundRoutes(options: CreateWebhookInboundRoutesOp
   return {
     prefix: '/webhook',
     auth: [],
-    plugins: [formBodyRoutePlugin],
+    plugins: [rawWebhookBodyPlugin],
     routes: [inboundRoute],
   };
+}
+
+function createGenericStoredWebhookRequest(
+  input: {
+    body: unknown;
+    connectionId: string;
+    headers: Record<string, string | string[] | undefined>;
+    rawQueryString: string;
+    requestId: string;
+  },
+  receivedAt: string,
+): StoredWebhookRequest {
+  if (!(input.body instanceof Uint8Array)) {
+    throw new ClientError('Expected raw webhook body', 'invalid-webhook-request', {status: 400});
+  }
+  if (input.body.byteLength > WEBHOOK_MAX_RAW_BODY_BYTES) {
+    throw new ClientError('Webhook request body is too large', 'body-too-large', {status: 413});
+  }
+
+  try {
+    return createStoredWebhookRequest({
+      requestId: input.requestId,
+      routeId: 'webhook.connection',
+      receivedAt,
+      rawQueryString: input.rawQueryString,
+      headers: webhookHeaders(input.headers),
+      body: input.body,
+      connectionId: input.connectionId,
+    });
+  } catch (error) {
+    throw new ClientError('Webhook request metadata is invalid', 'invalid-webhook-request', {
+      cause: error,
+    });
+  }
+}
+
+function webhookHeaders(
+  headers: Record<string, string | string[] | undefined>,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(headers).flatMap(([name, value]) => {
+      if (value === undefined) return [];
+      return [[name.toLowerCase(), Array.isArray(value) ? value.join(', ') : value]];
+    }),
+  );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,9 +72,6 @@ catalogs:
     '@fastify/cors':
       specifier: ^11.0.1
       version: 11.2.0
-    '@fastify/formbody':
-      specifier: ^8.0.2
-      version: 8.0.2
     '@fastify/otel':
       specifier: ^0.19.0
       version: 0.19.0
@@ -3109,9 +3106,6 @@ importers:
 
   libs/api/integration/webhook:
     dependencies:
-      '@fastify/formbody':
-        specifier: 'catalog:'
-        version: 8.0.2
       '@shipfox/api-auth-context':
         specifier: workspace:*
         version: link:../../auth-context
@@ -3127,6 +3121,9 @@ importers:
       '@shipfox/node-fastify':
         specifier: workspace:*
         version: link:../../../shared/node/fastify
+      '@shipfox/node-opentelemetry':
+        specifier: workspace:*
+        version: link:../../../shared/node/opentelemetry
       fastify-plugin:
         specifier: ^5.1.0
         version: 5.1.0
@@ -8385,9 +8382,6 @@ packages:
 
   '@fastify/fast-json-stringify-compiler@5.0.3':
     resolution: {integrity: sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==}
-
-  '@fastify/formbody@8.0.2':
-    resolution: {integrity: sha512-84v5J2KrkXzjgBpYnaNRPqwgMsmY7ZDjuj0YVuMR3NXCJRCgKEZy/taSP1wUYGn0onfxJpLyRGDLa+NMaDJtnA==}
 
   '@fastify/forwarded@3.0.1':
     resolution: {integrity: sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==}
@@ -17589,11 +17583,6 @@ snapshots:
   '@fastify/fast-json-stringify-compiler@5.0.3':
     dependencies:
       fast-json-stringify: 6.3.0
-
-  '@fastify/formbody@8.0.2':
-    dependencies:
-      fast-querystring: 1.1.2
-      fastify-plugin: 5.1.0
 
   '@fastify/forwarded@3.0.1': {}
 


### PR DESCRIPTION
Moves generic webhook delivery parsing and event publication behind the shared stored-request processor used by durable ingress.

Direct requests retain their existing pre-acceptance connection lookup and 404 response, while queued deliveries resolve the connection during processing and discard unavailable connections. The adapter preserves the existing generic event payload shape for JSON, form, text, forwarded headers, and repeated query parameters.

The processor is exported so the composed webhook seam can dispatch durable generic deliveries without importing route internals. The direct route supplies its validated connection to avoid an extra lookup and an acceptance race.

Closes ENG-1070

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Share a single generic webhook processor for both direct and durable ingress to unify parsing and event publishing while preserving the existing event envelope. Addresses ENG-1070.

- New Features
  - Export `createGenericWebhookProcessor` to process `StoredWebhookRequest` and publish `WEBHOOK_RECEIVED_EVENT` for `webhook` connections.
  - Consistent parsing for `application/json`, `application/x-www-form-urlencoded`, and `text/plain`; preserves forwarded headers and repeated query params.
  - Delivery handling: honor `x-delivery-id`, discard queued deliveries when connection is missing/disabled, return 400 on malformed payloads for direct requests.

- Refactors
  - Inbound route builds a stored request and delegates to the processor; keeps pre-accept connection lookup and 202 response with `delivery_id`.
  - Replaced `@fastify/formbody` with raw buffer parsers; added `@shipfox/node-opentelemetry` and `WEBHOOK_ACCEPTED_CONTENT_TYPES`.
  - Exported processor types, added tests, and updated dependencies.

<sup>Written for commit 279adfa70129462baedcf793603cb0e7df0365e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

