### PR TITLE
[integrations] Share GitHub and Gitea webhook processors

### DIFF
--- a/.changeset/quiet-webhooks-converge.md
+++ b/.changeset/quiet-webhooks-converge.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-integration-gitea": minor
+"@shipfox/api-integration-github": minor
+---
+
+Adds shared stored-request processors for GitHub and Gitea webhook reception.

--- a/libs/api/integration/gitea/src/core/webhook-processor.test.ts
+++ b/libs/api/integration/gitea/src/core/webhook-processor.test.ts
@@ -1,0 +1,83 @@
+import {createHmac, randomUUID} from 'node:crypto';
+import {createStoredWebhookRequest, decodeWebhookBody} from '@shipfox/api-integration-core-dto';
+import {createGiteaWebhookProcessor} from './webhook-processor.js';
+
+const WEBHOOK_SECRET = 'test-webhook-secret';
+
+describe('Gitea webhook processor', () => {
+  it('discards a stored request with an invalid signature before opening a transaction', async () => {
+    const coreDb = vi.fn();
+    const processor = createGiteaWebhookProcessor({
+      coreDb,
+      publishSourcePush: vi.fn(),
+      recordDeliveryOnly: vi.fn(),
+      getIntegrationConnectionById: vi.fn(),
+    });
+    const request = createStoredWebhookRequest({
+      requestId: randomUUID(),
+      routeId: 'gitea',
+      receivedAt: new Date().toISOString(),
+      rawQueryString: '',
+      headers: {
+        'x-gitea-delivery': randomUUID(),
+        'x-gitea-event': 'push',
+        'x-gitea-signature': 'not-a-valid-signature',
+      },
+      body: Buffer.from('{}'),
+    });
+
+    const result = await processor.process(request);
+
+    expect(result).toMatchObject({outcome: 'discarded', reason: 'invalid_signature'});
+    expect(coreDb).not.toHaveBeenCalled();
+  });
+
+  it('discards a stored request missing required provider headers', async () => {
+    const processor = createGiteaWebhookProcessor({
+      coreDb: vi.fn(),
+      publishSourcePush: vi.fn(),
+      recordDeliveryOnly: vi.fn(),
+      getIntegrationConnectionById: vi.fn(),
+    });
+    const request = createStoredWebhookRequest({
+      requestId: randomUUID(),
+      routeId: 'gitea',
+      receivedAt: new Date().toISOString(),
+      rawQueryString: '',
+      headers: {},
+      body: Buffer.from('{}'),
+    });
+
+    const result = await processor.process(request);
+
+    expect(result).toEqual({outcome: 'discarded', reason: 'missing_required_input'});
+  });
+
+  it('preserves the signed raw body from a stored request before reporting malformed JSON', async () => {
+    const rawBody = Buffer.from('{"message":"h\u00e9llo"');
+    const request = createStoredWebhookRequest({
+      requestId: randomUUID(),
+      routeId: 'gitea',
+      receivedAt: new Date().toISOString(),
+      rawQueryString: '',
+      headers: {
+        'x-gitea-delivery': randomUUID(),
+        'x-gitea-event': 'push',
+        'x-gitea-signature': createHmac('sha256', WEBHOOK_SECRET).update(rawBody).digest('hex'),
+      },
+      body: rawBody,
+    });
+    const processor = createGiteaWebhookProcessor({
+      coreDb: () =>
+        ({transaction: (callback: (tx: unknown) => Promise<unknown>) => callback({})}) as never,
+      publishSourcePush: vi.fn(),
+      recordDeliveryOnly: vi.fn(),
+      getIntegrationConnectionById: vi.fn(),
+    });
+
+    const result = await processor.process(request);
+
+    expect(Buffer.from(decodeWebhookBody(request.body))).toEqual(rawBody);
+    expect(result).toMatchObject({outcome: 'discarded', reason: 'malformed_payload'});
+  });
+});

--- a/libs/api/integration/gitea/src/core/webhook-processor.ts
+++ b/libs/api/integration/gitea/src/core/webhook-processor.ts
@@ -1,0 +1,90 @@
+import {Buffer} from 'node:buffer';
+import {
+  decodeWebhookBody,
+  type GetIntegrationConnectionByIdFn,
+  type PublishSourcePushFn,
+  type RecordDeliveryOnlyFn,
+  type StoredWebhookRequest,
+  type WebhookProcessingResult,
+} from '@shipfox/api-integration-core-dto';
+import {verifyHexHmacSignature} from '@shipfox/node-fastify';
+import {logger} from '@shipfox/node-opentelemetry';
+import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
+import {config} from '#config.js';
+import {
+  GiteaWebhookMalformedJsonError,
+  GiteaWebhookMalformedPushPayloadError,
+  handleGiteaWebhook,
+} from '#core/webhook.js';
+
+const DELIVERY_HEADER = 'x-gitea-delivery';
+const EVENT_HEADER = 'x-gitea-event';
+const SIGNATURE_HEADER = 'x-gitea-signature';
+
+export interface CreateGiteaWebhookProcessorOptions {
+  coreDb: () => NodePgDatabase<Record<string, unknown>>;
+  publishSourcePush: PublishSourcePushFn;
+  recordDeliveryOnly: RecordDeliveryOnlyFn;
+  getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
+}
+
+export interface GiteaWebhookProcessor {
+  process(request: StoredWebhookRequest): Promise<WebhookProcessingResult>;
+}
+
+export function createGiteaWebhookProcessor(
+  options: CreateGiteaWebhookProcessorOptions,
+): GiteaWebhookProcessor {
+  return {process: (request) => processGiteaWebhookRequest(options, request)};
+}
+
+async function processGiteaWebhookRequest(
+  options: CreateGiteaWebhookProcessorOptions,
+  request: StoredWebhookRequest,
+): Promise<WebhookProcessingResult> {
+  if (request.route_id !== 'gitea') {
+    throw new Error(`Gitea processor cannot process ${request.route_id} requests`);
+  }
+
+  const deliveryId = request.headers[DELIVERY_HEADER];
+  const event = request.headers[EVENT_HEADER];
+  const signature = request.headers[SIGNATURE_HEADER];
+  if (!deliveryId || !event || !signature) {
+    return {outcome: 'discarded', reason: 'missing_required_input'};
+  }
+
+  const rawBody = Buffer.from(decodeWebhookBody(request.body));
+  if (!verifyHexHmacSignature({rawBody, signature, secret: config.GITEA_WEBHOOK_SECRET})) {
+    return {outcome: 'discarded', reason: 'invalid_signature', deliveryId};
+  }
+
+  try {
+    const result = await options.coreDb().transaction(async (tx) =>
+      handleGiteaWebhook({
+        tx,
+        deliveryId,
+        event,
+        rawBody: rawBody.toString('utf8'),
+        publishSourcePush: options.publishSourcePush,
+        recordDeliveryOnly: options.recordDeliveryOnly,
+        getIntegrationConnectionById: options.getIntegrationConnectionById,
+      }),
+    );
+    return result.outcome === 'duplicate'
+      ? {outcome: 'duplicate', deliveryId}
+      : {outcome: 'processed', deliveryId};
+  } catch (error) {
+    if (error instanceof GiteaWebhookMalformedJsonError) {
+      logger().warn({deliveryId, err: error}, 'gitea webhook payload JSON parse failed');
+      return {outcome: 'discarded', reason: 'malformed_payload', deliveryId};
+    }
+    if (error instanceof GiteaWebhookMalformedPushPayloadError) {
+      logger().warn(
+        {deliveryId, issues: error.issues},
+        'gitea webhook push payload failed schema validation',
+      );
+      return {outcome: 'discarded', reason: 'unsupported_event', deliveryId};
+    }
+    throw error;
+  }
+}

--- a/libs/api/integration/gitea/src/index.ts
+++ b/libs/api/integration/gitea/src/index.ts
@@ -32,6 +32,11 @@ export {
   GiteaOrganizationNotFoundError,
 } from '#core/errors.js';
 export {GiteaSourceControlProvider} from '#core/source-control.js';
+export type {
+  CreateGiteaWebhookProcessorOptions,
+  GiteaWebhookProcessor,
+} from '#core/webhook-processor.js';
+export {createGiteaWebhookProcessor} from '#core/webhook-processor.js';
 export type {GiteaConnection, UpsertGiteaConnectionParams} from '#db/connections.js';
 export {
   getGiteaConnectionByConnectionId,

--- a/libs/api/integration/gitea/src/presentation/routes/webhooks.ts
+++ b/libs/api/integration/gitea/src/presentation/routes/webhooks.ts
@@ -1,24 +1,24 @@
-import {Buffer} from 'node:buffer';
+import {randomUUID} from 'node:crypto';
 import type {
   GetIntegrationConnectionByIdFn,
   PublishSourcePushFn,
   RecordDeliveryOnlyFn,
+  StoredWebhookRequest,
+  WebhookProcessingResult,
 } from '@shipfox/api-integration-core-dto';
 import {
+  createStoredWebhookRequest,
+  WEBHOOK_MAX_RAW_BODY_BYTES,
+} from '@shipfox/api-integration-core-dto';
+import {
+  ClientError,
   defineRoute,
   type RouteGroup,
   rawBodyPlugin,
-  verifyHexHmacSignature,
   WEBHOOK_BODY_LIMIT,
 } from '@shipfox/node-fastify';
-import {logger} from '@shipfox/node-opentelemetry';
 import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
-import {config} from '#config.js';
-import {
-  GiteaWebhookMalformedJsonError,
-  GiteaWebhookMalformedPushPayloadError,
-  handleGiteaWebhook,
-} from '#core/webhook.js';
+import {createGiteaWebhookProcessor} from '#core/webhook-processor.js';
 
 const SIGNATURE_HEADER = 'x-gitea-signature';
 const EVENT_HEADER = 'x-gitea-event';
@@ -32,6 +32,7 @@ export interface CreateGiteaWebhookRoutesOptions {
 }
 
 export function createGiteaWebhookRoutes(options: CreateGiteaWebhookRoutesOptions): RouteGroup {
+  const processor = createGiteaWebhookProcessor(options);
   const pushRoute = defineRoute({
     method: 'POST',
     path: '/',
@@ -56,49 +57,18 @@ export function createGiteaWebhookRoutes(options: CreateGiteaWebhookRoutesOption
         return {error: 'missing X-Gitea-Event header'};
       }
 
-      const body = request.body;
-      if (!Buffer.isBuffer(body)) {
+      if (!(request.body instanceof Uint8Array)) {
         reply.code(400);
         return {error: 'expected raw JSON body'};
       }
-      const rawBody = body.toString('utf8');
-
-      if (!verifyHexHmacSignature({rawBody, signature, secret: config.GITEA_WEBHOOK_SECRET})) {
-        reply.code(401);
-        return {error: 'invalid signature'};
-      }
-
-      try {
-        await options.coreDb().transaction(async (tx) => {
-          await handleGiteaWebhook({
-            tx,
-            deliveryId,
-            event,
-            rawBody,
-            publishSourcePush: options.publishSourcePush,
-            recordDeliveryOnly: options.recordDeliveryOnly,
-            getIntegrationConnectionById: options.getIntegrationConnectionById,
-          });
-        });
-      } catch (error) {
-        if (error instanceof GiteaWebhookMalformedJsonError) {
-          logger().warn({deliveryId, err: error}, 'gitea webhook payload JSON parse failed');
-          reply.code(400);
-          return {error: 'malformed JSON'};
-        }
-        if (error instanceof GiteaWebhookMalformedPushPayloadError) {
-          logger().warn(
-            {deliveryId, issues: error.issues},
-            'gitea webhook push payload failed schema validation',
-          );
-          reply.code(400);
-          return {error: 'malformed push payload'};
-        }
-        throw error;
-      }
-
-      reply.code(204);
-      return null;
+      const result = await processor.process(
+        createGiteaStoredWebhookRequest({
+          body: request.body,
+          headers: request.headers,
+          rawQueryString: request.raw.url?.split('?')[1] ?? '',
+        }),
+      );
+      return sendGiteaWebhookResponse(reply, result);
     },
   });
 
@@ -108,4 +78,57 @@ export function createGiteaWebhookRoutes(options: CreateGiteaWebhookRoutesOption
     plugins: [rawBodyPlugin],
     routes: [pushRoute],
   };
+}
+
+function createGiteaStoredWebhookRequest(input: {
+  body: Uint8Array;
+  headers: Record<string, string | string[] | undefined>;
+  rawQueryString: string;
+}): StoredWebhookRequest {
+  if (input.body.byteLength > WEBHOOK_MAX_RAW_BODY_BYTES) {
+    throw new ClientError('Webhook request body is too large', 'body-too-large', {status: 413});
+  }
+  try {
+    return createStoredWebhookRequest({
+      requestId: randomUUID(),
+      routeId: 'gitea',
+      receivedAt: new Date().toISOString(),
+      rawQueryString: input.rawQueryString,
+      headers: giteaWebhookHeaders(input.headers),
+      body: input.body,
+    });
+  } catch (error) {
+    throw new ClientError('Webhook request metadata is invalid', 'invalid-webhook-request', {
+      cause: error,
+    });
+  }
+}
+
+function giteaWebhookHeaders(headers: Record<string, string | string[] | undefined>) {
+  return Object.fromEntries(
+    ['content-type', DELIVERY_HEADER, EVENT_HEADER, SIGNATURE_HEADER].flatMap((name) => {
+      const value = headers[name];
+      return typeof value === 'string' ? [[name, value]] : [];
+    }),
+  );
+}
+
+function sendGiteaWebhookResponse(
+  reply: {code(statusCode: number): void},
+  result: WebhookProcessingResult,
+) {
+  if (result.outcome === 'discarded' && result.reason === 'invalid_signature') {
+    reply.code(401);
+    return {error: 'invalid signature'};
+  }
+  if (result.outcome === 'discarded' && result.reason === 'malformed_payload') {
+    reply.code(400);
+    return {error: 'malformed JSON'};
+  }
+  if (result.outcome === 'discarded' && result.reason === 'unsupported_event') {
+    reply.code(400);
+    return {error: 'malformed push payload'};
+  }
+  reply.code(204);
+  return null;
 }

--- a/libs/api/integration/github/src/core/webhook-processor.test.ts
+++ b/libs/api/integration/github/src/core/webhook-processor.test.ts
@@ -1,0 +1,86 @@
+import {createHmac, randomUUID} from 'node:crypto';
+import {createStoredWebhookRequest, decodeWebhookBody} from '@shipfox/api-integration-core-dto';
+import {createGithubWebhookProcessor} from './webhook-processor.js';
+
+const WEBHOOK_SECRET = 'test-webhook-secret';
+
+describe('GitHub webhook processor', () => {
+  it('discards a stored request with an invalid signature before opening a transaction', async () => {
+    const coreDb = vi.fn();
+    const processor = createGithubWebhookProcessor({
+      coreDb,
+      publishIntegrationEventReceived: vi.fn(),
+      publishSourcePush: vi.fn(),
+      recordDeliveryOnly: vi.fn(),
+      getIntegrationConnectionById: vi.fn(),
+    });
+    const request = createStoredWebhookRequest({
+      requestId: randomUUID(),
+      routeId: 'github',
+      receivedAt: new Date().toISOString(),
+      rawQueryString: '',
+      headers: {
+        'x-github-delivery': randomUUID(),
+        'x-github-event': 'push',
+        'x-hub-signature-256': 'sha256=not-a-valid-signature',
+      },
+      body: Buffer.from('{}'),
+    });
+
+    const result = await processor.process(request);
+
+    expect(result).toMatchObject({outcome: 'discarded', reason: 'invalid_signature'});
+    expect(coreDb).not.toHaveBeenCalled();
+  });
+
+  it('discards a stored request missing required provider headers', async () => {
+    const processor = createGithubWebhookProcessor({
+      coreDb: vi.fn(),
+      publishIntegrationEventReceived: vi.fn(),
+      publishSourcePush: vi.fn(),
+      recordDeliveryOnly: vi.fn(),
+      getIntegrationConnectionById: vi.fn(),
+    });
+    const request = createStoredWebhookRequest({
+      requestId: randomUUID(),
+      routeId: 'github',
+      receivedAt: new Date().toISOString(),
+      rawQueryString: '',
+      headers: {},
+      body: Buffer.from('{}'),
+    });
+
+    const result = await processor.process(request);
+
+    expect(result).toEqual({outcome: 'discarded', reason: 'missing_required_input'});
+  });
+
+  it('preserves the signed raw body from a stored request before reporting malformed JSON', async () => {
+    const rawBody = Buffer.from('{"message":"h\u00e9llo"');
+    const request = createStoredWebhookRequest({
+      requestId: randomUUID(),
+      routeId: 'github',
+      receivedAt: new Date().toISOString(),
+      rawQueryString: '',
+      headers: {
+        'x-github-delivery': randomUUID(),
+        'x-github-event': 'push',
+        'x-hub-signature-256': `sha256=${createHmac('sha256', WEBHOOK_SECRET).update(rawBody).digest('hex')}`,
+      },
+      body: rawBody,
+    });
+    const processor = createGithubWebhookProcessor({
+      coreDb: () =>
+        ({transaction: (callback: (tx: unknown) => Promise<unknown>) => callback({})}) as never,
+      publishIntegrationEventReceived: vi.fn(),
+      publishSourcePush: vi.fn(),
+      recordDeliveryOnly: vi.fn(),
+      getIntegrationConnectionById: vi.fn(),
+    });
+
+    const result = await processor.process(request);
+
+    expect(Buffer.from(decodeWebhookBody(request.body))).toEqual(rawBody);
+    expect(result).toMatchObject({outcome: 'discarded', reason: 'malformed_payload'});
+  });
+});

--- a/libs/api/integration/github/src/core/webhook-processor.ts
+++ b/libs/api/integration/github/src/core/webhook-processor.ts
@@ -1,0 +1,94 @@
+import {Buffer} from 'node:buffer';
+import {Webhooks} from '@octokit/webhooks';
+import {
+  decodeWebhookBody,
+  type GetIntegrationConnectionByIdFn,
+  type PublishIntegrationEventReceivedFn,
+  type PublishSourcePushFn,
+  type RecordDeliveryOnlyFn,
+  type StoredWebhookRequest,
+  type WebhookProcessingResult,
+} from '@shipfox/api-integration-core-dto';
+import {logger} from '@shipfox/node-opentelemetry';
+import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
+import {config} from '#config.js';
+import {handleGithubEvent} from '#core/webhook.js';
+
+const DELIVERY_HEADER = 'x-github-delivery';
+const EVENT_HEADER = 'x-github-event';
+const SIGNATURE_HEADER = 'x-hub-signature-256';
+
+export interface CreateGithubWebhookProcessorOptions {
+  coreDb: () => NodePgDatabase<Record<string, unknown>>;
+  publishIntegrationEventReceived: PublishIntegrationEventReceivedFn;
+  publishSourcePush: PublishSourcePushFn;
+  recordDeliveryOnly: RecordDeliveryOnlyFn;
+  getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
+  deleteInstallationTokenSecret?:
+    | ((params: {workspaceId: string; installationId: number}) => Promise<unknown>)
+    | undefined;
+}
+
+export interface GithubWebhookProcessor {
+  process(request: StoredWebhookRequest): Promise<WebhookProcessingResult>;
+}
+
+export function createGithubWebhookProcessor(
+  options: CreateGithubWebhookProcessorOptions,
+): GithubWebhookProcessor {
+  const webhooks = new Webhooks({secret: config.GITHUB_APP_WEBHOOK_SECRET});
+  return {process: (request) => processGithubWebhookRequest(options, webhooks, request)};
+}
+
+async function processGithubWebhookRequest(
+  options: CreateGithubWebhookProcessorOptions,
+  webhooks: Webhooks,
+  request: StoredWebhookRequest,
+): Promise<WebhookProcessingResult> {
+  if (request.route_id !== 'github') {
+    throw new Error(`GitHub processor cannot process ${request.route_id} requests`);
+  }
+
+  const deliveryId = request.headers[DELIVERY_HEADER];
+  const event = request.headers[EVENT_HEADER];
+  const signature = request.headers[SIGNATURE_HEADER];
+  if (!deliveryId || !event || !signature) {
+    return {outcome: 'discarded', reason: 'missing_required_input'};
+  }
+
+  const rawBody = Buffer.from(decodeWebhookBody(request.body));
+  let verified: boolean;
+  try {
+    verified = await webhooks.verify(rawBody.toString('utf8'), signature);
+  } catch (error) {
+    logger().warn({deliveryId, err: error}, 'github webhook signature verification threw');
+    verified = false;
+  }
+  if (!verified) return {outcome: 'discarded', reason: 'invalid_signature', deliveryId};
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(rawBody.toString('utf8'));
+  } catch (error) {
+    logger().warn({deliveryId, err: error}, 'github webhook payload JSON parse failed');
+    return {outcome: 'discarded', reason: 'malformed_payload', deliveryId};
+  }
+
+  const result = await options.coreDb().transaction(async (tx) =>
+    handleGithubEvent({
+      tx,
+      deliveryId,
+      event,
+      payload,
+      publishIntegrationEventReceived: options.publishIntegrationEventReceived,
+      publishSourcePush: options.publishSourcePush,
+      recordDeliveryOnly: options.recordDeliveryOnly,
+      getIntegrationConnectionById: options.getIntegrationConnectionById,
+      deleteInstallationTokenSecret: options.deleteInstallationTokenSecret,
+    }),
+  );
+
+  return result.outcome.startsWith('duplicate')
+    ? {outcome: 'duplicate', deliveryId}
+    : {outcome: 'processed', deliveryId};
+}

--- a/libs/api/integration/github/src/index.ts
+++ b/libs/api/integration/github/src/index.ts
@@ -49,6 +49,11 @@ export {handleGithubCallback} from '#core/install.js';
 export {signGithubInstallState, verifyGithubInstallState} from '#core/state.js';
 export type {HandleGithubEventOutcome} from '#core/webhook.js';
 export {handleGithubEvent} from '#core/webhook.js';
+export type {
+  CreateGithubWebhookProcessorOptions,
+  GithubWebhookProcessor,
+} from '#core/webhook-processor.js';
+export {createGithubWebhookProcessor} from '#core/webhook-processor.js';
 export type {GithubInstallation, UpsertGithubInstallationParams} from '#db/installations.js';
 export {
   getGithubInstallationByConnectionId,

--- a/libs/api/integration/github/src/presentation/routes/webhooks.ts
+++ b/libs/api/integration/github/src/presentation/routes/webhooks.ts
@@ -1,21 +1,25 @@
-import {Buffer} from 'node:buffer';
-import {Webhooks} from '@octokit/webhooks';
+import {randomUUID} from 'node:crypto';
 import type {
   GetIntegrationConnectionByIdFn,
   PublishIntegrationEventReceivedFn,
   PublishSourcePushFn,
   RecordDeliveryOnlyFn,
+  StoredWebhookRequest,
+  WebhookProcessingResult,
 } from '@shipfox/api-integration-core-dto';
 import {
+  createStoredWebhookRequest,
+  WEBHOOK_MAX_RAW_BODY_BYTES,
+} from '@shipfox/api-integration-core-dto';
+import {
+  ClientError,
   defineRoute,
   type RouteGroup,
   rawBodyPlugin,
   WEBHOOK_BODY_LIMIT,
 } from '@shipfox/node-fastify';
-import {logger} from '@shipfox/node-opentelemetry';
 import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
-import {config} from '#config.js';
-import {handleGithubEvent} from '#core/webhook.js';
+import {createGithubWebhookProcessor} from '#core/webhook-processor.js';
 
 const SIGNATURE_HEADER = 'x-hub-signature-256';
 const EVENT_HEADER = 'x-github-event';
@@ -33,7 +37,7 @@ export interface CreateGithubWebhookRoutesOptions {
 }
 
 export function createGithubWebhookRoutes(options: CreateGithubWebhookRoutesOptions): RouteGroup {
-  const webhooks = new Webhooks({secret: config.GITHUB_APP_WEBHOOK_SECRET});
+  const processor = createGithubWebhookProcessor(options);
 
   const pushRoute = defineRoute({
     method: 'POST',
@@ -59,50 +63,18 @@ export function createGithubWebhookRoutes(options: CreateGithubWebhookRoutesOpti
         return {error: 'missing X-GitHub-Event header'};
       }
 
-      const body = request.body;
-      if (!Buffer.isBuffer(body)) {
+      if (!(request.body instanceof Uint8Array)) {
         reply.code(400);
         return {error: 'expected raw JSON body'};
       }
-      const rawBody = body.toString('utf8');
-
-      let verified: boolean;
-      try {
-        verified = await webhooks.verify(rawBody, signature);
-      } catch (error) {
-        logger().warn({deliveryId, err: error}, 'github webhook signature verification threw');
-        verified = false;
-      }
-      if (!verified) {
-        reply.code(401);
-        return {error: 'invalid signature'};
-      }
-
-      let parsedJson: unknown;
-      try {
-        parsedJson = JSON.parse(rawBody);
-      } catch (error) {
-        logger().warn({deliveryId, err: error}, 'github webhook payload JSON parse failed');
-        reply.code(400);
-        return {error: 'malformed JSON'};
-      }
-
-      await options.coreDb().transaction(async (tx) => {
-        await handleGithubEvent({
-          tx,
-          deliveryId,
-          event,
-          payload: parsedJson,
-          publishIntegrationEventReceived: options.publishIntegrationEventReceived,
-          publishSourcePush: options.publishSourcePush,
-          recordDeliveryOnly: options.recordDeliveryOnly,
-          getIntegrationConnectionById: options.getIntegrationConnectionById,
-          deleteInstallationTokenSecret: options.deleteInstallationTokenSecret,
-        });
-      });
-
-      reply.code(204);
-      return null;
+      const result = await processor.process(
+        createGithubStoredWebhookRequest({
+          body: request.body,
+          headers: request.headers,
+          rawQueryString: request.raw.url?.split('?')[1] ?? '',
+        }),
+      );
+      return sendGithubWebhookResponse(reply, result);
     },
   });
 
@@ -112,4 +84,62 @@ export function createGithubWebhookRoutes(options: CreateGithubWebhookRoutesOpti
     plugins: [rawBodyPlugin],
     routes: [pushRoute],
   };
+}
+
+function createGithubStoredWebhookRequest(input: {
+  body: Uint8Array;
+  headers: Record<string, string | string[] | undefined>;
+  rawQueryString: string;
+}): StoredWebhookRequest {
+  if (input.body.byteLength > WEBHOOK_MAX_RAW_BODY_BYTES) {
+    throw new ClientError('Webhook request body is too large', 'body-too-large', {status: 413});
+  }
+  try {
+    return createStoredWebhookRequest({
+      requestId: randomUUID(),
+      routeId: 'github',
+      receivedAt: new Date().toISOString(),
+      rawQueryString: input.rawQueryString,
+      headers: githubWebhookHeaders(input.headers),
+      body: input.body,
+    });
+  } catch (error) {
+    throw new ClientError('Webhook request metadata is invalid', 'invalid-webhook-request', {
+      cause: error,
+    });
+  }
+}
+
+function githubWebhookHeaders(headers: Record<string, string | string[] | undefined>) {
+  return Object.fromEntries(
+    ['content-type', DELIVERY_HEADER, EVENT_HEADER, SIGNATURE_HEADER].flatMap((name) => {
+      const value = headers[name];
+      return typeof value === 'string' ? [[name, value]] : [];
+    }),
+  );
+}
+
+function sendGithubWebhookResponse(
+  reply: {code(statusCode: number): void},
+  result: WebhookProcessingResult,
+) {
+  if (result.outcome !== 'discarded') {
+    reply.code(204);
+    return null;
+  }
+
+  switch (result.reason) {
+    case 'invalid_signature':
+      reply.code(401);
+      return {error: 'invalid signature'};
+    case 'malformed_payload':
+      reply.code(400);
+      return {error: 'malformed JSON'};
+    case 'connection_unavailable':
+    case 'missing_required_input':
+    case 'stale_at_receipt':
+    case 'unsupported_event':
+      reply.code(204);
+      return null;
+  }
 }


### PR DESCRIPTION
Moves GitHub and Gitea webhook reception behind reusable stored-request processors while retaining the providers' existing direct HTTP response contracts.

Cloud durable ingress needs direct and queued deliveries to traverse the same signature verification, parsing, delivery-claim, and transactional publication path. The direct routes now only build the provider-specific stored request and map processing results back to their established responses.

The processors preserve exact raw bodies, delivery IDs, malformed-payload behavior, and source-push or integration-event publication. The changeset releases both public integration packages for Cloud consumers.

Closes ENG-1066

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies GitHub and Gitea webhook handling with shared stored-request processors, keeping existing HTTP response behavior. Addresses ENG-1066 by making direct and queued deliveries follow the same verification, parsing, and publishing path.

- **Refactors**
  - Added `createGithubWebhookProcessor` and `createGiteaWebhookProcessor` that take `StoredWebhookRequest` and return `WebhookProcessingResult`.
  - Routes now build `StoredWebhookRequest`, enforce `WEBHOOK_MAX_RAW_BODY_BYTES`, and delegate to processors.
  - Signature verification moved into processors: GitHub via `@octokit/webhooks`, Gitea via HMAC.
  - Preserves raw bodies, delivery IDs, and error semantics; maps outcomes to provider responses (401 invalid signature, 400 malformed JSON, 204 otherwise).
  - Added tests for invalid signatures, missing headers, and malformed payloads.
  - Exported processors from `@shipfox/api-integration-github` and `@shipfox/api-integration-gitea`, releasing minor versions.

<sup>Written for commit c4e2c36904309d2260c75c88d34494b37fd3bc4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

