### PR TITLE
Fix runner image CI diagnostics

### DIFF
--- a/infra/images/runner/locals.aws.pkr.hcl
+++ b/infra/images/runner/locals.aws.pkr.hcl
@@ -1,3 +1,4 @@
 locals {
-  aws_architecture = var.architecture == "amd64" ? "x86_64" : "arm64"
+  aws_architecture    = var.architecture == "amd64" ? "x86_64" : "arm64"
+  ubuntu_architecture = var.architecture
 }

--- a/infra/images/runner/source.aws.pkr.hcl
+++ b/infra/images/runner/source.aws.pkr.hcl
@@ -12,7 +12,7 @@ source "amazon-ebs" "build_image" {
   source_ami_filter {
     filters = {
       architecture        = local.aws_architecture
-      name                = "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-${local.aws_architecture}-server-*"
+      name                = "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-${local.ubuntu_architecture}-server-*"
       root-device-type    = "ebs"
       virtualization-type = "hvm"
     }

--- a/infra/images/runner/src/runner-image.ts
+++ b/infra/images/runner/src/runner-image.ts
@@ -86,13 +86,7 @@ export async function buildRunnerImage(build: RunnerImageBuild): Promise<{amiId:
     });
     execFileSync('packer', ['init', '.'], {cwd: rootDir, stdio: 'inherit'});
     await rm(manifestPath, {force: true});
-    const output = execFileSync('packer', packerBuildArgs(build, workspacePath, rootDir), {
-      cwd: rootDir,
-      encoding: 'utf8',
-      // A full AMI bake (apt, node, pnpm install) streams well past the 1 MB default,
-      // and an ENOBUFS throw would discard the already-built AMI. Give it ample room.
-      maxBuffer: 256 * 1024 * 1024,
-    });
+    const output = runPackerBuild(build, workspacePath, rootDir);
     process.stdout.write(output);
     if (build.platform !== 'aws') return {amiId: null};
 
@@ -105,6 +99,31 @@ export async function buildRunnerImage(build: RunnerImageBuild): Promise<{amiId:
   } finally {
     await rm(stageDir, {force: true, recursive: true});
   }
+}
+
+function runPackerBuild(build: RunnerImageBuild, workspacePath: string, rootDir: string): string {
+  try {
+    return execFileSync('packer', packerBuildArgs(build, workspacePath, rootDir), {
+      cwd: rootDir,
+      encoding: 'utf8',
+      // A full AMI bake (apt, node, pnpm install) streams well past the 1 MB default,
+      // and an ENOBUFS throw would discard the already-built AMI. Give it ample room.
+      maxBuffer: 256 * 1024 * 1024,
+    });
+  } catch (error) {
+    writePackerFailureOutput(error);
+    throw error;
+  }
+}
+
+function writePackerFailureOutput(error: unknown): void {
+  if (!(error instanceof Error)) return;
+  const processError = error as NodeJS.ErrnoException & {
+    stdout?: string | Buffer;
+    stderr?: string | Buffer;
+  };
+  if (processError.stdout) process.stdout.write(processError.stdout);
+  if (processError.stderr) process.stderr.write(processError.stderr);
 }
 
 function isMissingManifest(error: unknown): boolean {


### PR DESCRIPTION
Correct the Canonical Ubuntu AMI lookup for amd64 builds and surface Packer output when a candidate build fails.

The previous image filter used EC2's x86_64 architecture value in Canonical's AMI name, which uses amd64 instead. Capturing the child process output in the wrapper makes future AWS or provisioning failures visible directly in the GitHub step instead of requiring an artifact download.

The companion Cloud IAM policy update is handled separately; this PR fixes the repository-side lookup and diagnostics.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Canonical Ubuntu AMI lookup for amd64 and surfaces `packer` output on failures to make runner image builds reliable and easier to debug.

- **Bug Fixes**
  - Split AWS vs Ubuntu architecture variables; Canonical AMI filter now uses `amd64` (not `x86_64`) so the correct Ubuntu 24.04 images are found.

- **Refactors**
  - Wrapped `packer build` in a helper that prints child stdout/stderr on errors.
  - Keeps large buffer to avoid ENOBUFS; error output now shows directly in the GitHub step.

<sup>Written for commit d8058631de2d1b2e5a3f72a600afa05605b2e2b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

