### PR TITLE
Add non-Temporal API service lifecycle

### DIFF
--- a/.changeset/calm-services-settle.md
+++ b/.changeset/calm-services-settle.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/node-module": minor
+"@shipfox/api-server": minor
+---
+
+Adds a bounded lifecycle for non-Temporal API module services.

--- a/libs/api/server/README.md
+++ b/libs/api/server/README.md
@@ -42,7 +42,7 @@ node --import @shipfox/api-server/instrumentation ./dist/index.js
 
 - **Custom composition**: Pass a module list to make a custom server. A module must declare a unique `loginMethods` entry. `createServer` throws before startup side effects when no login method is available.
 - **Signal handling**: `createServer` does not install signal handlers.
-- **Lifecycle**: `start` starts workers before the HTTP listener. `stop` is safe to call again.
+- **Lifecycle**: `start` starts workers and module services before the HTTP listener. `stop` is safe to call again. It stops services before workers and shared clients.
 - **Process scope**: Run one server at a time.
 
 ## Development

--- a/libs/api/server/src/server.test.ts
+++ b/libs/api/server/src/server.test.ts
@@ -1,4 +1,6 @@
 import type {
+  ModuleService,
+  ModuleServicesHandle,
   ModuleWorker,
   ModuleWorkersHandle,
   ShipfoxModule,
@@ -8,6 +10,7 @@ import {createServer, runServer, type ServerHandle} from './server.js';
 
 const mocks = vi.hoisted(() => {
   const workersHandle = {stop: vi.fn()};
+  const servicesHandle = {stop: vi.fn()};
   return {
     captureException: vi.fn(),
     closeApp: vi.fn(),
@@ -27,9 +30,11 @@ const mocks = vi.hoisted(() => {
     resetSubscribers: vi.fn(),
     runModuleStartupTasks: vi.fn(),
     shutdownServiceMetrics: vi.fn(),
+    startModuleServices: vi.fn(),
     startModuleWorkers: vi.fn(),
     startServiceMetrics: vi.fn(),
     workersHandle,
+    servicesHandle,
     apiConfig: {
       API_PORT: undefined as number | undefined,
       API_TRUST_PROXY: 'false',
@@ -54,6 +59,7 @@ vi.mock('@shipfox/node-module', () => ({
   resetPublishers: mocks.resetPublishers,
   resetSubscribers: mocks.resetSubscribers,
   runModuleStartupTasks: mocks.runModuleStartupTasks,
+  startModuleServices: mocks.startModuleServices,
   startModuleWorkers: mocks.startModuleWorkers,
 }));
 vi.mock('@shipfox/node-opentelemetry', () => ({
@@ -87,10 +93,26 @@ function worker(taskQueue = 'runtime-queue'): ModuleWorker {
   };
 }
 
+function service(name = 'runtime-service'): ModuleService {
+  return {name, shutdownTimeoutMs: 10_000, start: vi.fn()};
+}
+
 function lastStartModuleWorkersOptions(): StartModuleWorkersOptions {
   const options = mocks.startModuleWorkers.mock.calls.at(-1)?.[0];
   if (!options) throw new Error('startModuleWorkers was not called');
   return options as StartModuleWorkersOptions;
+}
+
+function lastStartModuleServicesOptions(): {
+  services: ModuleService[];
+  onServiceFailure?: (error: unknown, service: ModuleService) => void | Promise<void>;
+} {
+  const options = mocks.startModuleServices.mock.calls.at(-1)?.[0];
+  if (!options) throw new Error('startModuleServices was not called');
+  return options as {
+    services: ModuleService[];
+    onServiceFailure?: (error: unknown, service: ModuleService) => void | Promise<void>;
+  };
 }
 
 function resetMocks(): void {
@@ -114,9 +136,11 @@ function resetMocks(): void {
   mocks.resetSubscribers.mockReset();
   mocks.runModuleStartupTasks.mockReset();
   mocks.shutdownServiceMetrics.mockReset();
+  mocks.startModuleServices.mockReset();
   mocks.startModuleWorkers.mockReset();
   mocks.startServiceMetrics.mockReset();
   mocks.workersHandle.stop.mockReset();
+  mocks.servicesHandle.stop.mockReset();
   mocks.apiConfig.API_PORT = undefined;
   mocks.apiConfig.API_TRUST_PROXY = 'false';
   mocks.apiConfig.E2E_ENABLED = false;
@@ -132,13 +156,16 @@ function resetMocks(): void {
     routes: [],
     e2eRoutes: [],
     workers: [worker()],
+    services: [service()],
   });
   mocks.listen.mockResolvedValue('http://127.0.0.1:3000');
   mocks.parseApiTrustProxy.mockReturnValue(false);
   mocks.runModuleStartupTasks.mockResolvedValue(undefined);
   mocks.shutdownServiceMetrics.mockResolvedValue(undefined);
   mocks.startModuleWorkers.mockResolvedValue(mocks.workersHandle);
+  mocks.startModuleServices.mockResolvedValue(mocks.servicesHandle);
   mocks.workersHandle.stop.mockResolvedValue(undefined);
+  mocks.servicesHandle.stop.mockResolvedValue(undefined);
 }
 
 const servers: ServerHandle[] = [];
@@ -201,6 +228,7 @@ describe('createServer', () => {
     await server.start();
 
     expect(mocks.startModuleWorkers).toHaveBeenCalledOnce();
+    expect(mocks.startModuleServices).toHaveBeenCalledOnce();
     expect(mocks.listen).toHaveBeenCalledOnce();
   });
 
@@ -230,6 +258,35 @@ describe('createServer', () => {
     );
   });
 
+  it('starts module services after workers and before listening for HTTP requests', async () => {
+    const server = await createTestServer({modules: [module()]});
+    let resolveServices: ((handle: ModuleServicesHandle) => void) | undefined;
+    const servicesStarted = new Promise<void>((resolve) => {
+      mocks.startModuleServices.mockImplementationOnce(
+        () =>
+          new Promise<ModuleServicesHandle>((innerResolve) => {
+            resolveServices = innerResolve;
+            resolve();
+          }),
+      );
+    });
+
+    const start = server.start();
+    await servicesStarted;
+
+    expect(mocks.listen).not.toHaveBeenCalled();
+    expect(mocks.startModuleWorkers.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.startModuleServices.mock.invocationCallOrder[0] ?? 0,
+    );
+
+    resolveServices?.(mocks.servicesHandle);
+    await start;
+
+    expect(mocks.startModuleServices.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.listen.mock.invocationCallOrder[0] ?? 0,
+    );
+  });
+
   it('passes API_PORT to the HTTP listener when configured', async () => {
     mocks.apiConfig.API_PORT = 55_291;
     const server = await createTestServer({modules: [module()]});
@@ -248,6 +305,20 @@ describe('createServer', () => {
 
     await expect(result).rejects.toBe(failure);
     expect(mocks.listen).not.toHaveBeenCalled();
+  });
+
+  it('does not listen when module service startup fails', async () => {
+    const failure = new Error('service configuration invalid');
+    mocks.startModuleServices.mockRejectedValueOnce(failure);
+    const server = await createTestServer({modules: [module()]});
+
+    const result = server.start();
+
+    await expect(result).rejects.toBe(failure);
+    expect(mocks.listen).not.toHaveBeenCalled();
+
+    await server.stop();
+    expect(mocks.workersHandle.stop).toHaveBeenCalledOnce();
   });
 
   it('releases service metrics and Postgres when boot fails', async () => {
@@ -305,6 +376,7 @@ describe('createServer', () => {
     await secondStop;
 
     expect(mocks.closeApp).toHaveBeenCalledOnce();
+    expect(mocks.servicesHandle.stop).toHaveBeenCalledOnce();
     expect(mocks.workersHandle.stop).toHaveBeenCalledOnce();
     expect(mocks.shutdownServiceMetrics).toHaveBeenCalledOnce();
     expect(mocks.closePostgresClient).toHaveBeenCalledOnce();
@@ -319,6 +391,7 @@ describe('createServer', () => {
     await server.stop();
 
     expect(mocks.closeApp).toHaveBeenCalledOnce();
+    expect(mocks.servicesHandle.stop).not.toHaveBeenCalled();
     expect(mocks.workersHandle.stop).not.toHaveBeenCalled();
     expect(mocks.shutdownServiceMetrics).toHaveBeenCalledOnce();
     expect(mocks.closePostgresClient).toHaveBeenCalledOnce();
@@ -351,6 +424,7 @@ describe('createServer', () => {
 
     expect(mocks.listen).not.toHaveBeenCalled();
     expect(mocks.closeApp).toHaveBeenCalledOnce();
+    expect(mocks.servicesHandle.stop).toHaveBeenCalledOnce();
     expect(mocks.workersHandle.stop).toHaveBeenCalledOnce();
     expect(mocks.shutdownServiceMetrics).toHaveBeenCalledOnce();
     expect(mocks.closePostgresClient).toHaveBeenCalledOnce();
@@ -366,6 +440,9 @@ describe('createServer', () => {
     await server.stop();
 
     expect(mocks.closeApp.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.servicesHandle.stop.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(mocks.servicesHandle.stop.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.workersHandle.stop.mock.invocationCallOrder[0] ?? 0,
     );
     expect(mocks.workersHandle.stop.mock.invocationCallOrder[0]).toBeLessThan(
@@ -400,6 +477,7 @@ describe('createServer', () => {
     const result = server.stop();
 
     await expect(result).rejects.toBeInstanceOf(AggregateError);
+    expect(mocks.servicesHandle.stop).toHaveBeenCalledOnce();
     expect(mocks.workersHandle.stop).toHaveBeenCalledOnce();
     expect(mocks.shutdownServiceMetrics).toHaveBeenCalledOnce();
     expect(mocks.closePostgresClient).toHaveBeenCalledOnce();
@@ -443,6 +521,27 @@ describe('createServer', () => {
     );
   });
 
+  it('reports service failures after closing HTTP and error monitoring', async () => {
+    const onServiceFailure = vi.fn();
+    const server = await createTestServer({modules: [module()], onServiceFailure});
+    await server.start();
+    const failure = new Error('poller failed');
+    const failedService = service();
+
+    await lastStartModuleServicesOptions().onServiceFailure?.(failure, failedService);
+
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      {err: failure, service: 'runtime-service'},
+      'Module service stopped unexpectedly',
+    );
+    expect(mocks.captureException).toHaveBeenCalledWith(failure);
+    expect(mocks.closeApp).toHaveBeenCalledOnce();
+    expect(mocks.closeErrorMonitoring).toHaveBeenCalledWith(2_000);
+    expect(mocks.closeErrorMonitoring.mock.invocationCallOrder[0]).toBeLessThan(
+      onServiceFailure.mock.invocationCallOrder[0] ?? 0,
+    );
+  });
+
   it('reports a timed-out HTTP close before invoking the worker failure hook', async () => {
     vi.useFakeTimers();
     const onWorkerFailure = vi.fn();
@@ -459,7 +558,7 @@ describe('createServer', () => {
 
     expect(mocks.logger.error).toHaveBeenCalledWith(
       {timeoutMs: 10_000},
-      'Timed out closing HTTP server after worker failure',
+      'Timed out closing HTTP server after module runtime failure',
     );
     expect(onWorkerFailure).toHaveBeenCalledWith(
       failure,
@@ -478,7 +577,7 @@ describe('createServer', () => {
 
     expect(mocks.logger.error).toHaveBeenCalledWith(
       {err: closeFailure},
-      'Failed to close HTTP server after worker failure',
+      'Failed to close HTTP server after module runtime failure',
     );
     expect(mocks.closeErrorMonitoring).toHaveBeenCalledWith(2_000);
     expect(mocks.closeErrorMonitoring.mock.invocationCallOrder[0]).toBeLessThan(
@@ -519,6 +618,7 @@ describe('runServer', () => {
     await expect(result).rejects.toBe(failure);
     expect(onStartupFailure).toHaveBeenCalledWith(failure);
     expect(mocks.closeApp).toHaveBeenCalledOnce();
+    expect(mocks.servicesHandle.stop).toHaveBeenCalledOnce();
     expect(mocks.workersHandle.stop).toHaveBeenCalledOnce();
     expect(mocks.shutdownServiceMetrics).toHaveBeenCalledOnce();
     expect(mocks.closePostgresClient).toHaveBeenCalledOnce();
@@ -557,10 +657,25 @@ describe('runServer', () => {
   it('exits unsuccessfully when a module worker fails', async () => {
     vi.spyOn(process, 'once').mockImplementation((() => process) as never);
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
-    await runServer({modules: [module()]});
+    const handle = await runServer({modules: [module()]});
 
     await lastStartModuleWorkersOptions().onWorkerFailure?.(new Error('poller failed'), worker());
 
     expect(exitSpy).toHaveBeenCalledWith(1);
+    await handle.stop();
+  });
+
+  it('exits unsuccessfully when a module service fails', async () => {
+    vi.spyOn(process, 'once').mockImplementation((() => process) as never);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+    const handle = await runServer({modules: [module()]});
+
+    await lastStartModuleServicesOptions().onServiceFailure?.(
+      new Error('poller failed'),
+      service(),
+    );
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    await handle.stop();
   });
 });

--- a/libs/api/server/src/server.ts
+++ b/libs/api/server/src/server.ts
@@ -3,6 +3,8 @@ import {closeApp, createApp, listen} from '@shipfox/node-fastify';
 import {
   aggregateLoginMethods,
   initializeModules,
+  type ModuleService,
+  type ModuleServicesHandle,
   type ModuleWorker,
   type ModuleWorkersHandle,
   registerModuleMetrics,
@@ -10,6 +12,7 @@ import {
   resetSubscribers,
   runModuleStartupTasks,
   type ShipfoxModule,
+  startModuleServices,
   startModuleWorkers,
 } from '@shipfox/node-module';
 import {logger, shutdownServiceMetrics, startServiceMetrics} from '@shipfox/node-opentelemetry';
@@ -17,7 +20,7 @@ import {closePostgresClient, createPostgresClient} from '@shipfox/node-postgres'
 import {config, parseApiTrustProxy} from './config.js';
 import {createE2eAdminAuthMethod, createE2eRouteGroup} from './e2e.js';
 
-const WORKER_FAILURE_HTTP_SHUTDOWN_TIMEOUT_MS = 10_000;
+const RUNTIME_FAILURE_HTTP_SHUTDOWN_TIMEOUT_MS = 10_000;
 const ERROR_MONITORING_SHUTDOWN_TIMEOUT_MS = 2_000;
 
 let hasActiveServer = false;
@@ -25,6 +28,7 @@ let hasActiveServer = false;
 export interface CreateServerOptions {
   modules: ShipfoxModule[];
   onWorkerFailure?: (error: unknown, worker: ModuleWorker) => void | Promise<void>;
+  onServiceFailure?: (error: unknown, service: ModuleService) => void | Promise<void>;
 }
 
 export interface ServerHandle {
@@ -48,7 +52,9 @@ export async function createServer(options: CreateServerOptions): Promise<Server
     startServiceMetrics({serviceName: 'api'});
     createPostgresClient();
 
-    const {auth, routes, e2eRoutes, workers} = await initializeModules({modules: options.modules});
+    const {auth, routes, e2eRoutes, workers, services} = await initializeModules({
+      modules: options.modules,
+    });
     registerModuleMetrics({modules: options.modules});
     await runModuleStartupTasks({modules: options.modules});
 
@@ -63,6 +69,7 @@ export async function createServer(options: CreateServerOptions): Promise<Server
     });
 
     let workersHandle: ModuleWorkersHandle | undefined;
+    let servicesHandle: ModuleServicesHandle | undefined;
     let startPromise: Promise<string> | undefined;
     let stopPromise: Promise<void> | undefined;
     let stopped = false;
@@ -77,6 +84,13 @@ export async function createServer(options: CreateServerOptions): Promise<Server
           workers,
           onWorkerFailure: (error, worker) =>
             handleModuleWorkerFailure(error, worker, options.onWorkerFailure),
+        });
+
+        logger().info('Starting module services');
+        servicesHandle = await startModuleServices({
+          services,
+          onServiceFailure: (error, service) =>
+            handleModuleServiceFailure(error, service, options.onServiceFailure),
         });
 
         if (stopPromise) throw new Error('API server stopped during startup');
@@ -98,6 +112,7 @@ export async function createServer(options: CreateServerOptions): Promise<Server
           await startPromise?.catch(() => undefined);
           const cleanupErrors = await runCleanupSteps([
             () => closeApp(),
+            () => servicesHandle?.stop(),
             () => workersHandle?.stop(),
             () => shutdownServiceMetrics(),
             () => closePostgresClient(),
@@ -137,6 +152,7 @@ export async function runServer(options: RunServerOptions): Promise<ServerHandle
     handle = await createServer({
       modules: options.modules,
       onWorkerFailure: () => process.exit(1),
+      onServiceFailure: () => process.exit(1),
     });
   } catch (error) {
     await reportStartupFailure(error, options.onStartupFailure);
@@ -204,21 +220,48 @@ async function handleModuleWorkerFailure(
   worker: ModuleWorker,
   onWorkerFailure: CreateServerOptions['onWorkerFailure'],
 ): Promise<void> {
-  logger().error({err: error, taskQueue: worker.taskQueue}, 'Module worker stopped unexpectedly');
-  captureException(error);
+  await handleModuleRuntimeFailure({
+    error,
+    fields: {taskQueue: worker.taskQueue},
+    message: 'Module worker stopped unexpectedly',
+    onFailure: () => onWorkerFailure?.(error, worker),
+  });
+}
+
+async function handleModuleServiceFailure(
+  error: unknown,
+  service: ModuleService,
+  onServiceFailure: CreateServerOptions['onServiceFailure'],
+): Promise<void> {
+  await handleModuleRuntimeFailure({
+    error,
+    fields: {service: service.name},
+    message: 'Module service stopped unexpectedly',
+    onFailure: () => onServiceFailure?.(error, service),
+  });
+}
+
+async function handleModuleRuntimeFailure(options: {
+  error: unknown;
+  fields: Record<string, string>;
+  message: string;
+  onFailure(): void | Promise<void>;
+}): Promise<void> {
+  logger().error({err: options.error, ...options.fields}, options.message);
+  captureException(options.error);
 
   try {
-    await closeHttpServerAfterWorkerFailure();
+    await closeHttpServerAfterRuntimeFailure();
     await closeErrorMonitoring(ERROR_MONITORING_SHUTDOWN_TIMEOUT_MS);
   } finally {
-    await onWorkerFailure?.(error, worker);
+    await options.onFailure();
   }
 }
 
-async function closeHttpServerAfterWorkerFailure(): Promise<void> {
+async function closeHttpServerAfterRuntimeFailure(): Promise<void> {
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<'timeout'>((resolve) => {
-    timeoutId = setTimeout(() => resolve('timeout'), WORKER_FAILURE_HTTP_SHUTDOWN_TIMEOUT_MS);
+    timeoutId = setTimeout(() => resolve('timeout'), RUNTIME_FAILURE_HTTP_SHUTDOWN_TIMEOUT_MS);
   });
   try {
     const result = await Promise.race([closeApp().then(() => 'closed' as const), timeout]).finally(
@@ -230,12 +273,12 @@ async function closeHttpServerAfterWorkerFailure(): Promise<void> {
     );
     if (result === 'timeout') {
       logger().error(
-        {timeoutMs: WORKER_FAILURE_HTTP_SHUTDOWN_TIMEOUT_MS},
-        'Timed out closing HTTP server after worker failure',
+        {timeoutMs: RUNTIME_FAILURE_HTTP_SHUTDOWN_TIMEOUT_MS},
+        'Timed out closing HTTP server after module runtime failure',
       );
     }
   } catch (error) {
-    logger().error({err: error}, 'Failed to close HTTP server after worker failure');
+    logger().error({err: error}, 'Failed to close HTTP server after module runtime failure');
   } finally {
     if (timeoutId) {
       clearTimeout(timeoutId);

--- a/libs/shared/node/module/README.md
+++ b/libs/shared/node/module/README.md
@@ -1,6 +1,6 @@
 # Shipfox Module
 
-Module setup helpers for Shipfox API services. A module can list its database, request auth, login methods, routes, outbox publishers, event handlers, service metrics, and Temporal workers in one object.
+Module setup helpers for Shipfox API services. A module can list its database, request auth, login methods, routes, outbox publishers, event handlers, service metrics, Temporal workers, and long-running services in one object.
 
 ## What it does
 
@@ -8,6 +8,7 @@ Module setup helpers for Shipfox API services. A module can list its database, r
 - **`registerModuleMetrics({modules})`**: Registers service-level metrics for modules that declare a metrics hook.
 - **`runModuleStartupTasks({modules})`**: Runs module startup tasks in declaration order after initialization.
 - **`startModuleWorkers({workers})`**: Creates Temporal workers and returns a handle that drains workers and closes their Temporal resources.
+- **`startModuleServices({services})`**: Starts long-running services and returns a handle that stops them within their declared timeouts.
 - **`ShipfoxModule`**: Module contract used by API packages.
 - **`loginMethods`**: Declares user-facing ways to establish a Shipfox session.
 - **`aggregateLoginMethods({modules})`**: Checks that a composition has one or more unique login method identifiers.
@@ -22,12 +23,13 @@ import {
   initializeModules,
   registerModuleMetrics,
   runModuleStartupTasks,
+  startModuleServices,
   startModuleWorkers,
 } from '@shipfox/node-module';
 import {authModule} from '@shipfox/api-auth';
 
 const modules = [authModule];
-const {auth, routes, workers} = await initializeModules({
+const {auth, routes, services, workers} = await initializeModules({
   modules,
 });
 registerModuleMetrics({modules});
@@ -35,11 +37,12 @@ await runModuleStartupTasks({modules});
 
 await createApp({auth, routes});
 const moduleWorkers = await startModuleWorkers({workers});
+const moduleServices = await startModuleServices({services});
 await listen();
 ```
 
 `initializeModules` runs module migrations first. It exposes auth methods and routes after that. Put modules with shared database needs earlier in the array. Call `registerModuleMetrics` once after instrumentation has started and migrations have run, so observable gauges can query shared storage safely.
-Worker startup failures reject `startModuleWorkers`, so call it before serving traffic when workers are required for app health. Call `runModuleStartupTasks` after initialization so migrations complete first. The returned worker handle is idempotent and stops workers before releasing the shared Temporal connection and client.
+Worker and service startup failures reject before serving traffic. Call `runModuleStartupTasks` after initialization so migrations complete first. The returned worker handle is idempotent and stops workers before releasing the shared Temporal connection and client. A service handle is also idempotent. It stops services in reverse order and bounds each stop with the service timeout.
 
 ## Module Shape
 
@@ -67,6 +70,13 @@ export const exampleModule: ShipfoxModule = {
   publishers: [{name: 'example', table: outbox, db}],
   subscribers: [subscriber('example.created', handleExampleCreated)],
   workers: [{taskQueue: 'example', workflowsPath, activities, workflows: []}],
+  services: [
+    {
+      name: 'example-poller',
+      shutdownTimeoutMs: 10_000,
+      start: async () => ({stop: async () => undefined, finished: new Promise(() => undefined)}),
+    },
+  ],
 };
 ```
 

--- a/libs/shared/node/module/src/index.ts
+++ b/libs/shared/node/module/src/index.ts
@@ -3,13 +3,16 @@ export {boundedMap} from './bounded-map.js';
 export type {
   InitializedModules,
   InitializeModulesOptions,
+  ModuleServicesHandle,
   ModuleWorkersHandle,
+  StartModuleServicesOptions,
   StartModuleWorkersOptions,
 } from './initialize.js';
 export {
   initializeModules,
   registerModuleMetrics,
   runModuleStartupTasks,
+  startModuleServices,
   startModuleWorkers,
 } from './initialize.js';
 export {
@@ -47,6 +50,8 @@ export type {
   ModuleDatabase,
   ModuleMetricsRegistration,
   ModulePublisher,
+  ModuleService,
+  ModuleServiceHandle,
   ModuleStartupTasks,
   ModuleWorker,
   ShipfoxModule,

--- a/libs/shared/node/module/src/initialize.test.ts
+++ b/libs/shared/node/module/src/initialize.test.ts
@@ -1,5 +1,10 @@
-import {registerModuleMetrics, runModuleStartupTasks, startModuleWorkers} from './initialize.js';
-import type {ModuleWorker, ShipfoxModule} from './types.js';
+import {
+  registerModuleMetrics,
+  runModuleStartupTasks,
+  startModuleServices,
+  startModuleWorkers,
+} from './initialize.js';
+import type {ModuleService, ModuleServiceHandle, ModuleWorker, ShipfoxModule} from './types.js';
 
 const mocks = vi.hoisted(() => ({
   closeTemporalClient: vi.fn(),
@@ -108,6 +113,252 @@ describe('runModuleStartupTasks', () => {
 
     await expect(result).rejects.toBe(failure);
     expect(later).not.toHaveBeenCalled();
+  });
+});
+
+function moduleService(overrides: Partial<ModuleService> = {}): ModuleService {
+  return {
+    name: 'test-service',
+    shutdownTimeoutMs: 100,
+    start: vi.fn(),
+    ...overrides,
+  };
+}
+
+function moduleServiceHandle(overrides: Partial<ModuleServiceHandle> = {}): ModuleServiceHandle {
+  return {
+    stop: vi.fn().mockResolvedValue(undefined),
+    finished: new Promise(() => undefined),
+    ...overrides,
+  };
+}
+
+describe('startModuleServices', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    mocks.logger.error.mockReset();
+    mocks.logger.info.mockReset();
+    mocks.logger.warn.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns a no-op handle when no services are declared', async () => {
+    const handle = await startModuleServices({services: []});
+
+    await handle.stop();
+  });
+
+  it('starts services sequentially', async () => {
+    const calls: string[] = [];
+    const first = moduleService({
+      name: 'first',
+      start: async () => {
+        calls.push('first:start');
+        await Promise.resolve();
+        calls.push('first:end');
+        return moduleServiceHandle();
+      },
+    });
+    const second = moduleService({
+      name: 'second',
+      start: () => {
+        calls.push('second');
+        return Promise.resolve(moduleServiceHandle());
+      },
+    });
+
+    const handle = await startModuleServices({services: [first, second]});
+
+    expect(calls).toEqual(['first:start', 'first:end', 'second']);
+    await handle.stop();
+  });
+
+  it('stops started services in reverse order when a later service fails to start', async () => {
+    const failure = new Error('invalid configuration');
+    const firstHandle = moduleServiceHandle();
+    const first = moduleService({name: 'first', start: vi.fn().mockResolvedValue(firstHandle)});
+    const second = moduleService({name: 'second', start: vi.fn().mockRejectedValue(failure)});
+
+    const result = startModuleServices({services: [first, second]});
+
+    await expect(result).rejects.toBe(failure);
+    expect(firstHandle.stop).toHaveBeenCalledOnce();
+  });
+
+  it('stops services in reverse startup order and only once', async () => {
+    const calls: string[] = [];
+    const firstHandle = moduleServiceHandle({
+      stop: vi.fn(() => {
+        calls.push('first');
+        return Promise.resolve();
+      }),
+    });
+    const secondHandle = moduleServiceHandle({
+      stop: vi.fn(() => {
+        calls.push('second');
+        return Promise.resolve();
+      }),
+    });
+    const first = moduleService({name: 'first', start: vi.fn().mockResolvedValue(firstHandle)});
+    const second = moduleService({name: 'second', start: vi.fn().mockResolvedValue(secondHandle)});
+    const handle = await startModuleServices({services: [first, second]});
+
+    const firstStop = handle.stop();
+    const secondStop = handle.stop();
+    await firstStop;
+    await secondStop;
+
+    expect(calls).toEqual(['second', 'first']);
+    expect(firstHandle.stop).toHaveBeenCalledOnce();
+    expect(secondHandle.stop).toHaveBeenCalledOnce();
+  });
+
+  it('continues stopping services after a stop failure', async () => {
+    const failure = new Error('service stop failed');
+    const firstHandle = moduleServiceHandle();
+    const secondHandle = moduleServiceHandle({stop: vi.fn().mockRejectedValue(failure)});
+    const handle = await startModuleServices({
+      services: [
+        moduleService({name: 'first', start: vi.fn().mockResolvedValue(firstHandle)}),
+        moduleService({name: 'second', start: vi.fn().mockResolvedValue(secondHandle)}),
+      ],
+    });
+
+    await handle.stop();
+
+    expect(firstHandle.stop).toHaveBeenCalledOnce();
+    expect(secondHandle.stop).toHaveBeenCalledOnce();
+    expect(mocks.logger.warn).toHaveBeenCalledWith(
+      {err: failure, service: 'second'},
+      'Failed to stop module service',
+    );
+  });
+
+  it('bounds service shutdown and observes a late stop failure', async () => {
+    vi.useFakeTimers();
+    const failure = new Error('late stop failure');
+    let rejectStop: (error: Error) => void = () => undefined;
+    const pendingStop = new Promise<void>((_resolve, reject) => {
+      rejectStop = reject;
+    });
+    const service = moduleService({
+      name: 'slow',
+      shutdownTimeoutMs: 10,
+      start: vi.fn().mockResolvedValue(moduleServiceHandle({stop: vi.fn(() => pendingStop)})),
+    });
+    const handle = await startModuleServices({services: [service]});
+
+    const stop = handle.stop();
+    await vi.advanceTimersByTimeAsync(10);
+    await stop;
+    rejectStop(failure);
+    await flushMicrotasks();
+
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      {service: 'slow', timeoutMs: 10},
+      'Timed out stopping module service',
+    );
+    expect(mocks.logger.warn).toHaveBeenCalledWith(
+      {err: failure, service: 'slow'},
+      'Module service stop failed after timeout',
+    );
+  });
+
+  it('reports unexpected service completion but suppresses completion during deliberate shutdown', async () => {
+    let resolveFinished: () => void = () => undefined;
+    const finished = new Promise<void>((resolve) => {
+      resolveFinished = resolve;
+    });
+    const onServiceFailure = vi.fn();
+    const service = moduleService({
+      name: 'finishing',
+      start: vi.fn().mockResolvedValue(moduleServiceHandle({finished})),
+    });
+    await startModuleServices({services: [service], onServiceFailure});
+
+    resolveFinished();
+    await flushMicrotasks();
+
+    expect(onServiceFailure).toHaveBeenCalledWith(
+      expect.objectContaining({message: 'Module service finishing stopped unexpectedly'}),
+      service,
+    );
+
+    let resolveStoppingFinished: () => void = () => undefined;
+    const stoppingFinished = new Promise<void>((resolve) => {
+      resolveStoppingFinished = resolve;
+    });
+    const stoppingFailure = vi.fn();
+    const stoppingService = moduleService({
+      name: 'stopping',
+      start: vi.fn().mockResolvedValue(
+        moduleServiceHandle({
+          finished: stoppingFinished,
+          stop: vi.fn(async () => resolveStoppingFinished()),
+        }),
+      ),
+    });
+    const stoppingHandle = await startModuleServices({
+      services: [stoppingService],
+      onServiceFailure: stoppingFailure,
+    });
+
+    await stoppingHandle.stop();
+    await flushMicrotasks();
+
+    expect(stoppingFailure).not.toHaveBeenCalled();
+  });
+
+  it('reports an unexpected service failure', async () => {
+    const failure = new Error('poller crashed');
+    const onServiceFailure = vi.fn();
+    const service = moduleService({
+      name: 'failing',
+      start: vi.fn().mockResolvedValue(moduleServiceHandle({finished: Promise.reject(failure)})),
+    });
+
+    await startModuleServices({services: [service], onServiceFailure});
+    await flushMicrotasks();
+
+    expect(onServiceFailure).toHaveBeenCalledWith(failure, service);
+  });
+
+  it('logs the original service failure when the runtime failure callback rejects', async () => {
+    const failure = new Error('poller crashed');
+    const handlerFailure = new Error('shutdown failed');
+    const onServiceFailure = vi.fn().mockRejectedValue(handlerFailure);
+    const service = moduleService({
+      name: 'failing',
+      start: vi.fn().mockResolvedValue(moduleServiceHandle({finished: Promise.reject(failure)})),
+    });
+
+    await startModuleServices({services: [service], onServiceFailure});
+    await flushMicrotasks();
+
+    expect(onServiceFailure).toHaveBeenCalledWith(failure, service);
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      {err: handlerFailure, serviceErr: failure, service: 'failing'},
+      'Module service failure handler failed',
+    );
+  });
+
+  it('logs runtime service failures when no failure callback is provided', async () => {
+    const failure = new Error('poller crashed');
+    const service = moduleService({
+      name: 'failing',
+      start: vi.fn().mockResolvedValue(moduleServiceHandle({finished: Promise.reject(failure)})),
+    });
+
+    await startModuleServices({services: [service]});
+    await flushMicrotasks();
+
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      {err: failure, service: 'failing'},
+      'Module service stopped unexpectedly',
+    );
   });
 });
 

--- a/libs/shared/node/module/src/initialize.ts
+++ b/libs/shared/node/module/src/initialize.ts
@@ -12,7 +12,13 @@ import {
 } from '@shipfox/node-temporal';
 import {registerPublisher} from './publisher-registry.js';
 import {subscribe} from './registry.js';
-import type {ModuleDatabase, ModuleWorker, ShipfoxModule} from './types.js';
+import type {
+  ModuleDatabase,
+  ModuleService,
+  ModuleServiceHandle,
+  ModuleWorker,
+  ShipfoxModule,
+} from './types.js';
 
 export interface InitializeModulesOptions {
   modules: ShipfoxModule[];
@@ -23,6 +29,7 @@ export interface InitializedModules {
   routes: RouteExport[];
   e2eRoutes: RouteExport[];
   workers: ModuleWorker[];
+  services: ModuleService[];
 }
 
 export interface StartModuleWorkersOptions {
@@ -34,9 +41,23 @@ export interface ModuleWorkersHandle {
   stop(): Promise<void>;
 }
 
+export interface StartModuleServicesOptions {
+  services: ModuleService[];
+  onServiceFailure?: (error: unknown, service: ModuleService) => void | Promise<void>;
+}
+
+export interface ModuleServicesHandle {
+  stop(): Promise<void>;
+}
+
 interface StartedModuleWorker {
   worker: Worker;
   runPromise?: Promise<void>;
+}
+
+interface StartedModuleService {
+  definition: ModuleService;
+  handle: ModuleServiceHandle;
 }
 
 /**
@@ -53,6 +74,7 @@ export async function initializeModules(
   const routes: RouteExport[] = [];
   const e2eRoutes: RouteExport[] = [];
   const workers: ModuleWorker[] = [];
+  const services: ModuleService[] = [];
 
   for (const mod of options.modules) {
     logger().info({module: mod.name}, 'Initializing module');
@@ -98,10 +120,14 @@ export async function initializeModules(
       workers.push(...mod.workers);
     }
 
+    if (mod.services) {
+      services.push(...mod.services);
+    }
+
     logger().info({module: mod.name}, 'Module initialized');
   }
 
-  return {auth, routes, e2eRoutes, workers};
+  return {auth, routes, e2eRoutes, workers, services};
 }
 
 function normalizeModuleDatabases(database: ModuleDatabase | ModuleDatabase[]): ModuleDatabase[] {
@@ -135,6 +161,122 @@ export async function runModuleStartupTasks(options: {modules: ShipfoxModule[]})
   for (const mod of options.modules) {
     await mod.startupTasks?.();
   }
+}
+
+export async function startModuleServices(
+  options: StartModuleServicesOptions,
+): Promise<ModuleServicesHandle> {
+  if (options.services.length === 0) return {stop: async () => undefined};
+
+  const services: StartedModuleService[] = [];
+  let stopping = false;
+  let stopPromise: Promise<void> | undefined;
+
+  try {
+    for (const definition of options.services) {
+      const handle = await definition.start();
+      const startedService = {definition, handle};
+      services.push(startedService);
+      observeModuleServiceCompletion({startedService, isStopping: () => stopping, options});
+      logger().info({service: definition.name}, 'Module service started');
+    }
+  } catch (error) {
+    stopping = true;
+    await stopStartedModuleServices(services);
+    throw error;
+  }
+
+  return {
+    stop: () => {
+      stopping = true;
+      stopPromise ??= stopStartedModuleServices(services);
+      return stopPromise;
+    },
+  };
+}
+
+function observeModuleServiceCompletion(options: {
+  startedService: StartedModuleService;
+  isStopping(): boolean;
+  options: StartModuleServicesOptions;
+}): void {
+  const {definition, handle} = options.startedService;
+  void handle.finished.then(
+    () => {
+      if (options.isStopping()) return;
+      reportModuleServiceFailure(
+        new Error(`Module service ${definition.name} stopped unexpectedly`),
+        definition,
+        options.options.onServiceFailure,
+      );
+    },
+    (error: unknown) => {
+      if (options.isStopping()) return;
+      reportModuleServiceFailure(error, definition, options.options.onServiceFailure);
+    },
+  );
+}
+
+function reportModuleServiceFailure(
+  error: unknown,
+  service: ModuleService,
+  onServiceFailure: StartModuleServicesOptions['onServiceFailure'],
+): void {
+  if (onServiceFailure) {
+    void Promise.resolve(onServiceFailure(error, service)).catch((handlerError) => {
+      logger().error(
+        {err: handlerError, serviceErr: error, service: service.name},
+        'Module service failure handler failed',
+      );
+    });
+    return;
+  }
+  logger().error({err: error, service: service.name}, 'Module service stopped unexpectedly');
+}
+
+async function stopStartedModuleServices(services: StartedModuleService[]): Promise<void> {
+  for (const service of [...services].reverse()) {
+    await stopModuleService(service);
+  }
+}
+
+async function stopModuleService(service: StartedModuleService): Promise<void> {
+  const stopResult = Promise.resolve()
+    .then(() => service.handle.stop())
+    .then(
+      () => ({status: 'stopped' as const}),
+      (error: unknown) => ({status: 'failed' as const, error}),
+    );
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<{status: 'timed-out'}>((resolve) => {
+    timeoutId = setTimeout(
+      () => resolve({status: 'timed-out'}),
+      service.definition.shutdownTimeoutMs,
+    );
+  });
+  const result = await Promise.race([stopResult, timeout]);
+  if (timeoutId) clearTimeout(timeoutId);
+
+  if (result.status === 'stopped') return;
+  if (result.status === 'failed') {
+    logger().warn(
+      {err: result.error, service: service.definition.name},
+      'Failed to stop module service',
+    );
+    return;
+  }
+
+  logger().error(
+    {service: service.definition.name, timeoutMs: service.definition.shutdownTimeoutMs},
+    'Timed out stopping module service',
+  );
+  void stopResult.then((lateResult) => {
+    if (lateResult.status !== 'failed') return;
+    logger().warn(
+      {err: lateResult.error, service: service.definition.name},
+      'Module service stop failed after timeout',
+    );
+  });
 }
 
 /**

--- a/libs/shared/node/module/src/types.ts
+++ b/libs/shared/node/module/src/types.ts
@@ -51,6 +51,17 @@ export interface ModuleWorker {
   workflows: WorkflowStart[];
 }
 
+export interface ModuleServiceHandle {
+  stop(): Promise<void>;
+  finished: Promise<void>;
+}
+
+export interface ModuleService {
+  name: string;
+  shutdownTimeoutMs: number;
+  start(): Promise<ModuleServiceHandle>;
+}
+
 /**
  * Hook for observable gauges over shared service state. Implementations must
  * fetch the service metrics provider inside the callback so ordinary module
@@ -79,6 +90,7 @@ export interface ShipfoxModule {
   publishers?: ModulePublisher[];
   subscribers?: ModuleSubscriber[];
   workers?: ModuleWorker[];
+  services?: ModuleService[];
   metrics?: ModuleMetricsRegistration;
   startupTasks?: ModuleStartupTasks;
   /**


### PR DESCRIPTION
Add a provider-neutral lifecycle for long-running API module services.

The Cloud durable-webhook consumer needs to start only after module initialization and to stop safely during API shutdown. This adds a service contract with fatal startup and runtime failure handling, reverse-order teardown, and per-service shutdown bounds while keeping Temporal worker ownership unchanged.

Considered extracting a generic supervisor for both services and Temporal workers. Kept the existing Temporal lifecycle separate because it owns a shared client and connection that ordinary services do not need.

Closes ENG-1063

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a provider-neutral lifecycle for long-running API module services. Services start after workers and before the HTTP listener, stop in reverse order with per-service timeouts, and fatal runtime failures trigger a graceful API shutdown. Closes ENG-1063.

- New Features
  - `@shipfox/node-module`
    - Adds `ModuleService` and `ModuleServiceHandle` types plus `startModuleServices({services, onServiceFailure})`.
    - `ShipfoxModule` can now declare `services` with bounded shutdown and reverse-order teardown.
    - Observes `handle.finished` to detect unexpected exits; startup failures roll back already-started services.
  - `@shipfox/api-server`
    - Integrates service lifecycle: start workers → services → HTTP; shutdown stops services before workers and shared clients.
    - Fails fast if a service fails to start; runtime service failures close HTTP, then error monitoring, and can trigger `process.exit(1)` in `runServer`.
    - Adds `onServiceFailure` option alongside `onWorkerFailure`; unified “module runtime failure” shutdown path.

- Migration
  - For long-running tasks, add `services` to your `ShipfoxModule`: each service supplies `{name, shutdownTimeoutMs, start}`.
  - `start()` must return `{stop, finished}`; `finished` resolves/rejects when the service ends.
  - Optionally handle fatal service failures by passing `onServiceFailure` to `createServer`; `runServer` exits on failure by default.

<sup>Written for commit a576007f3482e3d8fa63f34a43ed77d011d96536. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

