### PR TITLE
Fix manifest packer PID test race

### DIFF
--- a/dev/productionized-manifest-packer.test.mjs
+++ b/dev/productionized-manifest-packer.test.mjs
@@ -21,6 +21,7 @@ test('terminates an interrupted pack child before restoring its manifest', async
   const workerPath = join(root, 'worker.mjs');
   const sourceManifest = `${JSON.stringify({imports: {'#*': './src/*'}}, null, 2)}\n`;
   await writeFile(manifestPath, sourceManifest);
+  await writeFile(childPidPath, '');
   await writeFile(
     workerPath,
     `import {createProductionManifestPacker, run} from ${JSON.stringify(helperUrl)};
@@ -52,10 +53,11 @@ async function waitForFile(path) {
   while (Date.now() < deadline) {
     try {
       await access(path);
-      return readFile(path, 'utf8');
+      const contents = await readFile(path, 'utf8');
+      if (/^[1-9]\d*$/.test(contents.trim())) return contents;
     } catch {
-      await delay(20);
     }
+    await delay(20);
   }
   throw new Error(`Timed out waiting for ${path}`);
 }


### PR DESCRIPTION
Prevent the productionized manifest packer signal test from treating an empty PID file as a live process ID.

On a busy CI worker, the file can exist before its asynchronous write completes. The test then coerced an empty value to PID 0 and waited for that process group to exit. It now waits for a positive numeric PID and deliberately covers that empty-file timing window.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix flaky PID-handling in the productionized manifest packer test by waiting for a real PID instead of treating an empty PID file as PID 0. This removes CI timing races and stabilizes the test.

- **Bug Fixes**
  - Pre-create the child PID file and wait until it contains a positive integer (`/^[1-9]\d*$/`).
  - Always delay between checks to avoid tight-loop reads and cover async write timing.

<sup>Written for commit 88e268920655cd9c0c5ec9ae3eca808ff5f897ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

