### PR TITLE
[node-temporal] Deduplicate Temporal package resolution

### DIFF
--- a/.changeset/calm-foxes-deliver.md
+++ b/.changeset/calm-foxes-deliver.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/node-temporal": patch
+---
+
+Provides the Temporal workflow peer at the package boundary to keep runtime singleton dependencies deduplicated.

--- a/libs/shared/node/temporal/package.json
+++ b/libs/shared/node/temporal/package.json
@@ -48,7 +48,8 @@
     "@temporalio/client": "catalog:",
     "@temporalio/common": "catalog:",
     "@temporalio/interceptors-opentelemetry": "catalog:",
-    "@temporalio/worker": "catalog:"
+    "@temporalio/worker": "catalog:",
+    "@temporalio/workflow": "catalog:"
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6752,6 +6752,9 @@ importers:
       '@temporalio/worker':
         specifier: 'catalog:'
         version: 1.18.1(@swc/helpers@0.5.23)(tslib@2.8.1)
+      '@temporalio/workflow':
+        specifier: 'catalog:'
+        version: 1.18.1
     devDependencies:
       '@shipfox/biome':
         specifier: workspace:*


### PR DESCRIPTION
Provide `@temporalio/workflow` directly from `@shipfox/node-temporal` and regenerate the lockfile so pnpm resolves the Temporal OpenTelemetry interceptor with one peer context.

The outbox registry is process-local state in `@shipfox/node-module`. Separate Temporal peer variants caused the API server and dispatcher to load different module instances, leaving the dispatcher's registry empty and stranding email events. Collapsing the production dependency closure restores dispatch without changing the registry design; the durable explicit-registry work remains scoped to ENG-1099.

Closes ENG-1097

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores outbox dispatch by deduplicating Temporal peer resolution. `@shipfox/node-temporal` now provides `@temporalio/workflow`, so the API server and dispatcher share one `@shipfox/node-module` registry (ENG-1097).

- **Bug Fixes**
  - Add `@temporalio/workflow` as a direct dependency of `@shipfox/node-temporal` to unify `@temporalio/interceptors-opentelemetry` and collapse duplicate module instances.
  - Regenerate `pnpm-lock.yaml` and add a changeset with a patch bump for `@shipfox/node-temporal`.

<sup>Written for commit c536d89e7be9d5cfbdc6896d3e0ce3685d56f89c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

