### PR TITLE
Expose the composed webhook processor

### DIFF
--- a/.changeset/durable-webhooks-compose.md
+++ b/.changeset/durable-webhooks-compose.md
@@ -1,0 +1,13 @@
+---
+"@shipfox/api-integration-core-dto": minor
+"@shipfox/api-integration-core": minor
+"@shipfox/api-integration-gitea": minor
+"@shipfox/api-integration-github": minor
+"@shipfox/api-integration-linear": minor
+"@shipfox/api-integration-sentry": minor
+"@shipfox/api-integration-slack": minor
+"@shipfox/api-integration-webhook": minor
+"@shipfox/api-server": minor
+---
+
+Adds a composed webhook processor and optional provider-neutral delivery source for hosted API runtimes.

--- a/libs/api/integration/core-dto/src/webhooks.ts
+++ b/libs/api/integration/core-dto/src/webhooks.ts
@@ -113,6 +113,11 @@ export const webhookProcessingResultSchema = z.discriminatedUnion('outcome', [
 ]);
 export type WebhookProcessingResult = z.infer<typeof webhookProcessingResultSchema>;
 
+/** Processes one provider-neutral inbound webhook request. */
+export interface WebhookRequestProcessor {
+  process(request: StoredWebhookRequest): Promise<WebhookProcessingResult>;
+}
+
 export interface CreateStoredWebhookRequestInput {
   requestId: string;
   routeId: WebhookRouteId;

--- a/libs/api/integration/core/src/core/entities/provider.ts
+++ b/libs/api/integration/core/src/core/entities/provider.ts
@@ -1,6 +1,8 @@
 import type {
   IntegrationProvider as CoreIntegrationProvider,
   RegisteredIntegrationProvider as CoreRegisteredIntegrationProvider,
+  WebhookRequestProcessor,
+  WebhookRouteId,
 } from '@shipfox/api-integration-core-dto';
 import type {RouteExport} from '@shipfox/node-fastify';
 
@@ -17,5 +19,9 @@ export type {
   OpenAgentToolsSessionInput,
 } from '@shipfox/api-integration-core-dto';
 
-export type IntegrationProvider = CoreIntegrationProvider<string, RouteExport>;
+export type IntegrationProvider = CoreIntegrationProvider<string, RouteExport> & {
+  webhookProcessors?:
+    | Array<{routeIds: readonly WebhookRouteId[]; processor: WebhookRequestProcessor}>
+    | undefined;
+};
 export type RegisteredIntegrationProvider = CoreRegisteredIntegrationProvider<string, RouteExport>;

--- a/libs/api/integration/core/src/index.test.ts
+++ b/libs/api/integration/core/src/index.test.ts
@@ -1,0 +1,77 @@
+import type {
+  StoredWebhookRequest,
+  WebhookRequestProcessor,
+} from '@shipfox/api-integration-core-dto';
+import {type ModuleService, startModuleServices} from '@shipfox/node-module';
+import {createIntegrationsContext} from './index.js';
+
+const request = {
+  schema_version: 1,
+  request_id: 'a8a44e12-f4bd-4bd1-82d4-ccdba70a9f3e',
+  route_id: 'github',
+  received_at: '2026-07-20T12:00:00.000Z',
+  method: 'POST',
+  path_parameters: {},
+  raw_query_string: '',
+  headers: {},
+  body: {encoding: 'base64', data: ''},
+} as const satisfies StoredWebhookRequest;
+
+describe('createIntegrationsContext', () => {
+  it('binds the composed direct-route processor to an optional delivery source', async () => {
+    const directProcessor: WebhookRequestProcessor = {
+      process: vi.fn().mockResolvedValue({outcome: 'processed', deliveryId: 'delivery-1'}),
+    };
+    const stop = vi.fn().mockResolvedValue(undefined);
+    const service: ModuleService = {
+      name: 'queued-webhook-deliveries',
+      shutdownTimeoutMs: 1_000,
+      start: vi.fn().mockResolvedValue({finished: Promise.resolve(), stop}),
+    };
+    const deliverySource = {createService: vi.fn().mockReturnValue(service)};
+
+    const context = await createIntegrationsContext({
+      parts: [
+        {
+          provider: {provider: 'github', displayName: 'GitHub', adapters: {}},
+          webhookProcessors: [{routeIds: ['github'], processor: directProcessor}],
+        },
+      ],
+      webhookDeliverySource: deliverySource,
+    });
+
+    expect(context.module.services).toEqual([service]);
+    expect(deliverySource.createService).toHaveBeenCalledWith(context.webhookProcessor);
+
+    const result = await context.webhookProcessor.process(request);
+    const services = await startModuleServices({services: context.module.services ?? []});
+    await services.stop();
+
+    expect(result).toEqual({outcome: 'processed', deliveryId: 'delivery-1'});
+    expect(directProcessor.process).toHaveBeenCalledWith(request);
+    expect(stop).toHaveBeenCalledOnce();
+  });
+
+  it('does not register a service without a delivery source', async () => {
+    const context = await createIntegrationsContext({
+      parts: [{provider: {provider: 'github', displayName: 'GitHub', adapters: {}}}],
+    });
+
+    expect(context.module.services).toBeUndefined();
+  });
+
+  it('fails composition when a configured delivery source is invalid', async () => {
+    const sourceError = new Error('WEBHOOK_QUEUE_URL is required');
+
+    const result = createIntegrationsContext({
+      parts: [{provider: {provider: 'github', displayName: 'GitHub', adapters: {}}}],
+      webhookDeliverySource: {
+        createService: () => {
+          throw sourceError;
+        },
+      },
+    });
+
+    await expect(result).rejects.toThrow(sourceError);
+  });
+});

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -1,7 +1,13 @@
 import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
-import {integrationsEventSchemas} from '@shipfox/api-integration-core-dto';
-import type {ShipfoxModule} from '@shipfox/node-module';
+import {
+  integrationsEventSchemas,
+  type StoredWebhookRequest,
+  type WebhookProcessingResult,
+  type WebhookRequestProcessor,
+  type WebhookRouteId,
+} from '@shipfox/api-integration-core-dto';
+import type {ModuleService, ShipfoxModule} from '@shipfox/node-module';
 import {logger} from '@shipfox/node-opentelemetry';
 import type {IntegrationProvider} from '#core/entities/provider.js';
 import {
@@ -18,7 +24,11 @@ import {migrationsPath} from '#db/migrations.js';
 import {integrationsOutbox} from '#db/schema/outbox.js';
 import {createIntegrationRoutes, type LeasedAgentStepLoader} from '#presentation/routes/index.js';
 import {loadEnabledProviderModules} from '#providers/modules.js';
-import type {IntegrationModuleParts, IntegrationProviderSecrets} from '#providers/types.js';
+import type {
+  IntegrationModuleParts,
+  IntegrationProviderSecrets,
+  WebhookProcessorRegistration,
+} from '#providers/types.js';
 import {createIntegrationsMaintenanceActivities} from '#temporal/activities/index.js';
 import {INTEGRATIONS_MAINTENANCE_TASK_QUEUE} from '#temporal/constants.js';
 
@@ -124,6 +134,15 @@ export interface CreateIntegrationsModuleOptions {
         loadLeasedAgentStep: LeasedAgentStepLoader;
       }
     | undefined;
+  webhookDeliverySource?: WebhookDeliverySource | undefined;
+}
+
+/**
+ * Hosted runtimes implement this port to receive stored webhook requests. The
+ * integration module starts its returned service after migrations complete.
+ */
+export interface WebhookDeliverySource {
+  createService(processor: WebhookRequestProcessor): ModuleService;
 }
 
 export interface IntegrationsContext {
@@ -133,6 +152,7 @@ export interface IntegrationsContext {
     sourceControl: IntegrationSourceControlService;
   };
   sourceControl: IntegrationSourceControlService;
+  webhookProcessor: WebhookRequestProcessor;
   /**
    * Runs every enabled provider's one-shot boot-time tasks, after modules are initialized
    * (migrations done). Failures are isolated and logged, never rethrown, so a provider task
@@ -153,7 +173,10 @@ export async function createIntegrationsContext(
   const parts: IntegrationModuleParts[] =
     options.parts ??
     (options.providers
-      ? options.providers.map((provider) => ({provider}))
+      ? options.providers.map((provider) => ({
+          provider,
+          webhookProcessors: provider.webhookProcessors,
+        }))
       : await loadEnabledProviderModules({secrets: options.secrets}));
 
   const registry = createIntegrationProviderRegistry(parts.map((part) => part.provider));
@@ -161,6 +184,9 @@ export async function createIntegrationsContext(
     registry,
     getIntegrationConnectionById,
   });
+  const webhookProcessor = createComposedWebhookProcessor(
+    parts.flatMap((part) => part.webhookProcessors ?? []),
+  );
 
   async function runStartupTasks(): Promise<void> {
     for (const task of parts.flatMap((part) => part.startupTasks ?? [])) {
@@ -207,7 +233,41 @@ export async function createIntegrationsContext(
       },
       ...parts.flatMap((part) => part.workers ?? []),
     ],
+    ...(options.webhookDeliverySource
+      ? {services: [options.webhookDeliverySource.createService(webhookProcessor)]}
+      : {}),
   };
 
-  return {module, registry, capabilities: {sourceControl}, sourceControl, runStartupTasks};
+  return {
+    module,
+    registry,
+    capabilities: {sourceControl},
+    sourceControl,
+    webhookProcessor,
+    runStartupTasks,
+  };
+}
+
+function createComposedWebhookProcessor(
+  registrations: WebhookProcessorRegistration[],
+): WebhookRequestProcessor {
+  const processors = new Map<WebhookRouteId, WebhookRequestProcessor>();
+  for (const registration of registrations) {
+    for (const routeId of registration.routeIds) {
+      if (processors.has(routeId)) {
+        throw new Error(`Webhook processor is registered more than once for ${routeId}`);
+      }
+      processors.set(routeId, registration.processor);
+    }
+  }
+
+  return {
+    async process(request: StoredWebhookRequest): Promise<WebhookProcessingResult> {
+      const processor = processors.get(request.route_id);
+      if (!processor) {
+        throw new Error(`No webhook processor is configured for ${request.route_id}`);
+      }
+      return await processor.process(request);
+    },
+  };
 }

--- a/libs/api/integration/core/src/providers/gitea.ts
+++ b/libs/api/integration/core/src/providers/gitea.ts
@@ -79,15 +79,18 @@ async function loadGiteaModuleParts(): Promise<IntegrationModuleParts> {
     );
   }
 
+  const integrationProvider = createGiteaIntegrationProvider({
+    getExistingGiteaConnection,
+    connectGiteaConnection,
+    publishSourcePush,
+    recordDeliveryOnly,
+    getIntegrationConnectionById,
+    coreDb: db,
+  });
+
   return {
-    provider: createGiteaIntegrationProvider({
-      getExistingGiteaConnection,
-      connectGiteaConnection,
-      publishSourcePush,
-      recordDeliveryOnly,
-      getIntegrationConnectionById,
-      coreDb: db,
-    }),
+    provider: integrationProvider,
+    webhookProcessors: integrationProvider.webhookProcessors,
     database: {
       db: giteaDb,
       migrationsPath: giteaMigrationsPath,

--- a/libs/api/integration/core/src/providers/github.ts
+++ b/libs/api/integration/core/src/providers/github.ts
@@ -116,18 +116,21 @@ async function loadGithubModuleParts(
     );
   }
 
+  const integrationProvider = createGithubIntegrationProvider({
+    getExistingGithubConnection,
+    connectGithubInstallation,
+    publishIntegrationEventReceived,
+    publishSourcePush,
+    recordDeliveryOnly,
+    getIntegrationConnectionById,
+    coreDb: db,
+    deleteSecrets: options.secrets?.deleteSecrets,
+    agentTools: {tokenProvider},
+  });
+
   return {
-    provider: createGithubIntegrationProvider({
-      getExistingGithubConnection,
-      connectGithubInstallation,
-      publishIntegrationEventReceived,
-      publishSourcePush,
-      recordDeliveryOnly,
-      getIntegrationConnectionById,
-      coreDb: db,
-      deleteSecrets: options.secrets?.deleteSecrets,
-      agentTools: {tokenProvider},
-    }),
+    provider: integrationProvider,
+    webhookProcessors: integrationProvider.webhookProcessors,
     e2eRoutes: [
       createGithubE2eRoutes({
         getExistingGithubConnection,

--- a/libs/api/integration/core/src/providers/linear.ts
+++ b/libs/api/integration/core/src/providers/linear.ts
@@ -136,32 +136,35 @@ async function loadLinearModuleParts(
     secrets,
   });
 
+  const integrationProvider = createLinearIntegrationProvider({
+    agentTools: {tokenStore, endpoint: linearConfig.LINEAR_MCP_ENDPOINT},
+    cleanup: {
+      deleteConnectionRecords: async (connection, {tx}) => {
+        await deleteLinearInstallationByConnectionId(connection.id, {tx});
+      },
+      deleteConnectionSecrets: async (connection) => {
+        // Scoped secrets accept the provider-local suffix, after this helper validates its prefix.
+        await (options.secrets?.linear?.deleteSecrets({
+          workspaceId: connection.workspaceId,
+          namespace: linearNamespaceSuffix(linearSecretsNamespace(connection.id)),
+        }) ?? Promise.resolve());
+      },
+    },
+    routes: {
+      tokenStore,
+      getExistingLinearConnection,
+      connectLinearInstallation,
+      disconnectLinearInstallation,
+      publishIntegrationEventReceived,
+      recordDeliveryOnly,
+      getIntegrationConnectionById,
+      coreDb: db,
+    },
+  });
+
   return {
-    provider: createLinearIntegrationProvider({
-      agentTools: {tokenStore, endpoint: linearConfig.LINEAR_MCP_ENDPOINT},
-      cleanup: {
-        deleteConnectionRecords: async (connection, {tx}) => {
-          await deleteLinearInstallationByConnectionId(connection.id, {tx});
-        },
-        deleteConnectionSecrets: async (connection) => {
-          // Scoped secrets accept the provider-local suffix, after this helper validates its prefix.
-          await (options.secrets?.linear?.deleteSecrets({
-            workspaceId: connection.workspaceId,
-            namespace: linearNamespaceSuffix(linearSecretsNamespace(connection.id)),
-          }) ?? Promise.resolve());
-        },
-      },
-      routes: {
-        tokenStore,
-        getExistingLinearConnection,
-        connectLinearInstallation,
-        disconnectLinearInstallation,
-        publishIntegrationEventReceived,
-        recordDeliveryOnly,
-        getIntegrationConnectionById,
-        coreDb: db,
-      },
-    }),
+    provider: integrationProvider,
+    webhookProcessors: integrationProvider.webhookProcessors,
     e2eRoutes: [
       createLinearE2eRoutes({
         tokenStore,

--- a/libs/api/integration/core/src/providers/sentry.ts
+++ b/libs/api/integration/core/src/providers/sentry.ts
@@ -84,19 +84,22 @@ async function loadSentryModuleParts(): Promise<IntegrationModuleParts> {
     );
   }
 
+  const integrationProvider = createSentryIntegrationProvider({
+    getSentryInstallation: ({installationUuid}) =>
+      getSentryInstallationByInstallationUuid(installationUuid),
+    getConnectionById,
+    connectSentryInstallation,
+    persistVerifiedUnclaimedInstallation,
+    coreDb: db,
+    publishIntegrationEventReceived,
+    recordDeliveryOnly,
+    getIntegrationConnectionById,
+    updateConnectionLifecycleStatus: updateIntegrationConnectionLifecycleStatus,
+  });
+
   return {
-    provider: createSentryIntegrationProvider({
-      getSentryInstallation: ({installationUuid}) =>
-        getSentryInstallationByInstallationUuid(installationUuid),
-      getConnectionById,
-      connectSentryInstallation,
-      persistVerifiedUnclaimedInstallation,
-      coreDb: db,
-      publishIntegrationEventReceived,
-      recordDeliveryOnly,
-      getIntegrationConnectionById,
-      updateConnectionLifecycleStatus: updateIntegrationConnectionLifecycleStatus,
-    }),
+    provider: integrationProvider,
+    webhookProcessors: integrationProvider.webhookProcessors,
     database: {
       db: sentryDb,
       migrationsPath: sentryMigrationsPath,

--- a/libs/api/integration/core/src/providers/slack.ts
+++ b/libs/api/integration/core/src/providers/slack.ts
@@ -138,33 +138,36 @@ async function loadSlackModuleParts(
     secrets,
   });
 
+  const integrationProvider = createSlackIntegrationProvider({
+    agentTools: {tokenStore},
+    cleanup: {
+      deleteConnectionRecords: async (connection, {tx}) => {
+        await deleteSlackInstallationByConnectionId(connection.id, {tx});
+      },
+      deleteConnectionSecrets: async (connection) => {
+        // Scoped secrets accept the provider-local suffix, after this helper validates its prefix.
+        await (options.secrets?.slack?.deleteSecrets({
+          workspaceId: connection.workspaceId,
+          namespace: slackNamespaceSuffix(slackSecretsNamespace(connection.id)),
+        }) ?? Promise.resolve());
+      },
+    },
+    routes: {
+      tokenStore,
+      getExistingSlackConnection,
+      connectSlackInstallation,
+      disconnectSlackInstallation,
+      coreDb: db,
+      claimWebhookDelivery,
+      publishIntegrationEventReceived,
+      recordDeliveryOnly,
+      getIntegrationConnectionById,
+    },
+  });
+
   return {
-    provider: createSlackIntegrationProvider({
-      agentTools: {tokenStore},
-      cleanup: {
-        deleteConnectionRecords: async (connection, {tx}) => {
-          await deleteSlackInstallationByConnectionId(connection.id, {tx});
-        },
-        deleteConnectionSecrets: async (connection) => {
-          // Scoped secrets accept the provider-local suffix, after this helper validates its prefix.
-          await (options.secrets?.slack?.deleteSecrets({
-            workspaceId: connection.workspaceId,
-            namespace: slackNamespaceSuffix(slackSecretsNamespace(connection.id)),
-          }) ?? Promise.resolve());
-        },
-      },
-      routes: {
-        tokenStore,
-        getExistingSlackConnection,
-        connectSlackInstallation,
-        disconnectSlackInstallation,
-        coreDb: db,
-        claimWebhookDelivery,
-        publishIntegrationEventReceived,
-        recordDeliveryOnly,
-        getIntegrationConnectionById,
-      },
-    }),
+    provider: integrationProvider,
+    webhookProcessors: integrationProvider.webhookProcessors,
     e2eRoutes: [
       createSlackE2eRoutes({
         tokenStore,

--- a/libs/api/integration/core/src/providers/types.ts
+++ b/libs/api/integration/core/src/providers/types.ts
@@ -1,3 +1,4 @@
+import type {WebhookRequestProcessor, WebhookRouteId} from '@shipfox/api-integration-core-dto';
 import type {RouteExport} from '@shipfox/node-fastify';
 import type {ModuleDatabase, ModuleWorker} from '@shipfox/node-module';
 import type {IntegrationProvider} from '#core/entities/provider.js';
@@ -17,6 +18,12 @@ export interface IntegrationModuleParts {
   e2eRoutes?: RouteExport[] | undefined;
   workers?: ModuleWorker[] | undefined;
   startupTasks?: Array<() => Promise<void>> | undefined;
+  webhookProcessors?: WebhookProcessorRegistration[] | undefined;
+}
+
+export interface WebhookProcessorRegistration {
+  routeIds: readonly WebhookRouteId[];
+  processor: WebhookRequestProcessor;
 }
 
 /**

--- a/libs/api/integration/core/src/providers/webhook.ts
+++ b/libs/api/integration/core/src/providers/webhook.ts
@@ -15,16 +15,18 @@ export const webhookProviderModule: IntegrationProviderModule = {
   enabled: config.INTEGRATIONS_ENABLE_WEBHOOK_PROVIDER,
   load: async () => {
     const {createWebhookIntegrationProvider} = await import('@shipfox/api-integration-webhook');
+    const integrationProvider = createWebhookIntegrationProvider({
+      coreDb: db,
+      createIntegrationConnection,
+      listIntegrationConnections,
+      getIntegrationConnectionById,
+      updateIntegrationConnectionLifecycleStatus,
+      deleteIntegrationConnection,
+      publishIntegrationEventReceived,
+    });
     return {
-      provider: createWebhookIntegrationProvider({
-        coreDb: db,
-        createIntegrationConnection,
-        listIntegrationConnections,
-        getIntegrationConnectionById,
-        updateIntegrationConnectionLifecycleStatus,
-        deleteIntegrationConnection,
-        publishIntegrationEventReceived,
-      }),
+      provider: integrationProvider,
+      webhookProcessors: integrationProvider.webhookProcessors,
     };
   },
 };

--- a/libs/api/integration/gitea/src/index.ts
+++ b/libs/api/integration/gitea/src/index.ts
@@ -10,6 +10,7 @@ import {createGiteaApiClient, type GiteaApiClient} from '#api/client.js';
 import type {ConnectGiteaConnectionInput} from '#core/connect.js';
 import {giteaConnectionExternalUrl} from '#core/connection-url.js';
 import {GiteaSourceControlProvider} from '#core/source-control.js';
+import {createGiteaWebhookProcessor} from '#core/webhook-processor.js';
 import {closeDb, db} from '#db/db.js';
 import {migrationsPath} from '#db/migrations.js';
 import {createGiteaConnectionRoutes} from '#presentation/routes/connections.js';
@@ -61,6 +62,7 @@ export interface CreateGiteaIntegrationProviderOptions {
 
 export function createGiteaIntegrationProvider(options: CreateGiteaIntegrationProviderOptions) {
   const gitea = options.gitea ?? createGiteaApiClient();
+  const webhookProcessor = createGiteaWebhookProcessor(options);
 
   return {
     provider: giteaProviderKind,
@@ -82,7 +84,9 @@ export function createGiteaIntegrationProvider(options: CreateGiteaIntegrationPr
         publishSourcePush: options.publishSourcePush,
         recordDeliveryOnly: options.recordDeliveryOnly,
         getIntegrationConnectionById: options.getIntegrationConnectionById,
+        processor: webhookProcessor,
       }),
     ],
+    webhookProcessors: [{routeIds: ['gitea'] as const, processor: webhookProcessor}],
   };
 }

--- a/libs/api/integration/gitea/src/presentation/routes/webhooks.ts
+++ b/libs/api/integration/gitea/src/presentation/routes/webhooks.ts
@@ -18,7 +18,7 @@ import {
   WEBHOOK_BODY_LIMIT,
 } from '@shipfox/node-fastify';
 import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
-import {createGiteaWebhookProcessor} from '#core/webhook-processor.js';
+import {createGiteaWebhookProcessor, type GiteaWebhookProcessor} from '#core/webhook-processor.js';
 
 const SIGNATURE_HEADER = 'x-gitea-signature';
 const EVENT_HEADER = 'x-gitea-event';
@@ -29,10 +29,11 @@ export interface CreateGiteaWebhookRoutesOptions {
   publishSourcePush: PublishSourcePushFn;
   recordDeliveryOnly: RecordDeliveryOnlyFn;
   getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
+  processor?: GiteaWebhookProcessor | undefined;
 }
 
 export function createGiteaWebhookRoutes(options: CreateGiteaWebhookRoutesOptions): RouteGroup {
-  const processor = createGiteaWebhookProcessor(options);
+  const processor = options.processor ?? createGiteaWebhookProcessor(options);
   const pushRoute = defineRoute({
     method: 'POST',
     path: '/',

--- a/libs/api/integration/github/src/index.ts
+++ b/libs/api/integration/github/src/index.ts
@@ -10,6 +10,7 @@ import type {GithubInstallationTokenProvider} from '#api/installation-token-prov
 import {deleteGithubInstallationTokenSecret} from '#api/installation-token-provider.js';
 import {GithubAgentToolsProvider} from '#core/agent-tools.js';
 import {GithubSourceControlProvider} from '#core/source-control.js';
+import {createGithubWebhookProcessor} from '#core/webhook-processor.js';
 import {closeDb, db} from '#db/db.js';
 import {getGithubInstallationByConnectionId} from '#db/installations.js';
 import {migrationsPath} from '#db/migrations.js';
@@ -82,6 +83,7 @@ export function createGithubIntegrationProvider(options: CreateGithubIntegration
   const getInstallationByConnectionId =
     options.getGithubInstallationByConnectionId ?? getGithubInstallationByConnectionId;
   const deleteSecrets = options.deleteSecrets;
+  const webhookProcessor = createGithubWebhookProcessor(options);
 
   return {
     provider: 'github' as const,
@@ -123,7 +125,9 @@ export function createGithubIntegrationProvider(options: CreateGithubIntegration
                 deleteSecrets,
               })
           : undefined,
+        processor: webhookProcessor,
       }),
     ],
+    webhookProcessors: [{routeIds: ['github'] as const, processor: webhookProcessor}],
   };
 }

--- a/libs/api/integration/github/src/presentation/routes/webhooks.ts
+++ b/libs/api/integration/github/src/presentation/routes/webhooks.ts
@@ -19,7 +19,10 @@ import {
   WEBHOOK_BODY_LIMIT,
 } from '@shipfox/node-fastify';
 import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
-import {createGithubWebhookProcessor} from '#core/webhook-processor.js';
+import {
+  createGithubWebhookProcessor,
+  type GithubWebhookProcessor,
+} from '#core/webhook-processor.js';
 
 const SIGNATURE_HEADER = 'x-hub-signature-256';
 const EVENT_HEADER = 'x-github-event';
@@ -34,10 +37,11 @@ export interface CreateGithubWebhookRoutesOptions {
   deleteInstallationTokenSecret?:
     | ((params: {workspaceId: string; installationId: number}) => Promise<unknown>)
     | undefined;
+  processor?: GithubWebhookProcessor | undefined;
 }
 
 export function createGithubWebhookRoutes(options: CreateGithubWebhookRoutesOptions): RouteGroup {
-  const processor = createGithubWebhookProcessor(options);
+  const processor = options.processor ?? createGithubWebhookProcessor(options);
 
   const pushRoute = defineRoute({
     method: 'POST',

--- a/libs/api/integration/linear/src/index.ts
+++ b/libs/api/integration/linear/src/index.ts
@@ -3,6 +3,7 @@ import {createLinearApiClient, type LinearApiClient} from '#api/client.js';
 import {config} from '#config.js';
 import {LinearAgentToolsProvider} from '#core/agent-tools-provider.js';
 import type {LinearTokenStore} from '#core/tokens.js';
+import {createLinearWebhookProcessor} from '#core/webhook-processor.js';
 import {closeDb, db} from '#db/db.js';
 import {getLinearInstallationByConnectionId} from '#db/installations.js';
 import {migrationsPath} from '#db/migrations.js';
@@ -129,6 +130,10 @@ export function createLinearIntegrationProvider(
         agent_tools: new LinearAgentToolsProvider(options.agentTools),
       }
     : {};
+  const webhookProcessor =
+    options.routes && hasLinearWebhookRoutesOptions(options.routes)
+      ? createLinearWebhookProcessor(options.routes)
+      : undefined;
 
   const routes = options.routes
     ? [
@@ -139,8 +144,8 @@ export function createLinearIntegrationProvider(
         }),
       ]
     : [];
-  if (options.routes && hasLinearWebhookRoutesOptions(options.routes)) {
-    routes.push(createLinearWebhookRoutes(options.routes));
+  if (options.routes && hasLinearWebhookRoutesOptions(options.routes) && webhookProcessor) {
+    routes.push(createLinearWebhookRoutes({...options.routes, processor: webhookProcessor}));
   }
 
   return {
@@ -154,6 +159,9 @@ export function createLinearIntegrationProvider(
     },
     ...options.cleanup,
     routes,
+    webhookProcessors: webhookProcessor
+      ? [{routeIds: ['linear'] as const, processor: webhookProcessor}]
+      : undefined,
   };
 }
 

--- a/libs/api/integration/linear/src/presentation/routes/webhooks.ts
+++ b/libs/api/integration/linear/src/presentation/routes/webhooks.ts
@@ -18,7 +18,10 @@ import {
   WEBHOOK_BODY_LIMIT,
 } from '@shipfox/node-fastify';
 import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
-import {createLinearWebhookProcessor} from '#core/webhook-processor.js';
+import {
+  createLinearWebhookProcessor,
+  type LinearWebhookProcessor,
+} from '#core/webhook-processor.js';
 
 const DELIVERY_HEADER = 'linear-delivery';
 const EVENT_HEADER = 'linear-event';
@@ -29,10 +32,11 @@ export interface CreateLinearWebhookRoutesOptions {
   publishIntegrationEventReceived: PublishIntegrationEventReceivedFn;
   recordDeliveryOnly: RecordDeliveryOnlyFn;
   getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
+  processor?: LinearWebhookProcessor | undefined;
 }
 
 export function createLinearWebhookRoutes(options: CreateLinearWebhookRoutesOptions): RouteGroup {
-  const processor = createLinearWebhookProcessor(options);
+  const processor = options.processor ?? createLinearWebhookProcessor(options);
   const webhookRoute = defineRoute({
     method: 'POST',
     path: '/',

--- a/libs/api/integration/sentry/src/index.ts
+++ b/libs/api/integration/sentry/src/index.ts
@@ -9,6 +9,7 @@ import type {
 import type {ModuleWorker} from '@shipfox/node-module';
 import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
 import {createSentryApiClient, type SentryApiClient} from '#api/client.js';
+import {createSentryWebhookProcessor} from '#core/webhook-processor.js';
 import {closeDb, db} from '#db/db.js';
 import {
   getSentryInstallationByConnectionId,
@@ -84,6 +85,14 @@ export function createSentryIntegrationProvider(options: CreateSentryIntegration
     options.getSentryInstallationByConnectionId ?? getSentryInstallationByConnectionId;
   const persistUnclaimed =
     options.persistVerifiedUnclaimedInstallation ?? persistVerifiedUnclaimedInstallation;
+  const webhookProcessor = createSentryWebhookProcessor({
+    sentry,
+    coreDb: options.coreDb,
+    publishIntegrationEventReceived: options.publishIntegrationEventReceived,
+    recordDeliveryOnly: options.recordDeliveryOnly,
+    getIntegrationConnectionById: options.getIntegrationConnectionById,
+    updateConnectionLifecycleStatus: options.updateConnectionLifecycleStatus,
+  });
 
   return {
     provider: 'sentry' as const,
@@ -108,8 +117,10 @@ export function createSentryIntegrationProvider(options: CreateSentryIntegration
         recordDeliveryOnly: options.recordDeliveryOnly,
         getIntegrationConnectionById: options.getIntegrationConnectionById,
         updateConnectionLifecycleStatus: options.updateConnectionLifecycleStatus,
+        processor: webhookProcessor,
       }),
     ],
+    webhookProcessors: [{routeIds: ['sentry'] as const, processor: webhookProcessor}],
   };
 }
 

--- a/libs/api/integration/sentry/src/presentation/routes/webhooks.ts
+++ b/libs/api/integration/sentry/src/presentation/routes/webhooks.ts
@@ -10,13 +10,18 @@ import {
   rawBodyPlugin,
   WEBHOOK_BODY_LIMIT,
 } from '@shipfox/node-fastify';
-import {createSentryWebhookProcessor} from '#core/webhook-processor.js';
+import {
+  createSentryWebhookProcessor,
+  type SentryWebhookProcessor,
+} from '#core/webhook-processor.js';
 import type {SentryWebhookContext} from './webhook-context.js';
 
 export type {SentryWebhookContext} from './webhook-context.js';
 
-export function createSentryWebhookRoutes(context: SentryWebhookContext): RouteGroup {
-  const processor = createSentryWebhookProcessor(context);
+export function createSentryWebhookRoutes(
+  context: SentryWebhookContext & {processor?: SentryWebhookProcessor | undefined},
+): RouteGroup {
+  const processor = context.processor ?? createSentryWebhookProcessor(context);
   const webhookRoute = defineRoute({
     method: 'POST',
     path: '/',

--- a/libs/api/integration/slack/src/index.ts
+++ b/libs/api/integration/slack/src/index.ts
@@ -4,6 +4,7 @@ import {createSlackApiClient, type SlackApiClient} from '#api/client.js';
 import {config} from '#config.js';
 import {SlackAgentToolsProvider} from '#core/agent-tools-provider.js';
 import type {SlackTokenStore} from '#core/tokens.js';
+import {createSlackWebhookProcessor} from '#core/webhook-processor.js';
 import {closeDb, db} from '#db/db.js';
 import {getSlackInstallationByConnectionId} from '#db/installations.js';
 import {migrationsPath} from '#db/migrations.js';
@@ -153,6 +154,10 @@ export function createSlackIntegrationProvider(
     throw new Error('Slack webhook routes require every core persistence dependency');
   }
   const routes: RouteGroup[] = [];
+  const webhookProcessor =
+    options.routes && hasSlackWebhookRoutesOptions(options.routes)
+      ? createSlackWebhookProcessor(options.routes)
+      : undefined;
   if (options.routes && hasSlackInstallationRoutesOptions(options.routes)) {
     const {
       tokenStore,
@@ -171,8 +176,8 @@ export function createSlackIntegrationProvider(
       }),
     );
   }
-  if (options.routes && hasSlackWebhookRoutesOptions(options.routes)) {
-    routes.push(...createSlackWebhookRoutes(options.routes));
+  if (options.routes && hasSlackWebhookRoutesOptions(options.routes) && webhookProcessor) {
+    routes.push(...createSlackWebhookRoutes({...options.routes, processor: webhookProcessor}));
   }
 
   return {
@@ -186,6 +191,9 @@ export function createSlackIntegrationProvider(
     },
     ...options.cleanup,
     routes,
+    webhookProcessors: webhookProcessor
+      ? [{routeIds: ['slack.event', 'slack.command'] as const, processor: webhookProcessor}]
+      : undefined,
   };
 }
 

--- a/libs/api/integration/slack/src/presentation/routes/webhooks.ts
+++ b/libs/api/integration/slack/src/presentation/routes/webhooks.ts
@@ -20,6 +20,7 @@ import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
 import {
   createSlackWebhookProcessor,
   type SlackWebhookProcessingResult,
+  type SlackWebhookProcessor,
 } from '#core/webhook-processor.js';
 
 export const SLACK_WEBHOOK_BODY_LIMIT = 1024 * 1024;
@@ -40,10 +41,11 @@ export interface CreateSlackWebhookRoutesOptions {
   publishIntegrationEventReceived: PublishIntegrationEventReceivedFn;
   recordDeliveryOnly: RecordDeliveryOnlyFn;
   getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
+  processor?: SlackWebhookProcessor | undefined;
 }
 
 export function createSlackWebhookRoutes(options: CreateSlackWebhookRoutesOptions): RouteGroup[] {
-  const processor = createSlackWebhookProcessor(options);
+  const processor = options.processor ?? createSlackWebhookProcessor(options);
   const eventsRoute = defineRoute({
     method: 'POST',
     path: '/',

--- a/libs/api/integration/webhook/src/index.ts
+++ b/libs/api/integration/webhook/src/index.ts
@@ -9,6 +9,7 @@ import type {
 } from '@shipfox/api-integration-core-dto';
 import {WEBHOOK_PROVIDER} from '@shipfox/api-integration-webhook-dto';
 import {config} from '#config.js';
+import {createGenericWebhookProcessor} from '#core/webhook-processor.js';
 import {createWebhookConnectionRoutes} from '#presentation/routes/connections.js';
 import {createWebhookInboundRoutes} from '#presentation/routes/inbound.js';
 
@@ -34,6 +35,7 @@ export interface CreateWebhookIntegrationProviderOptions {
 
 export function createWebhookIntegrationProvider(options: CreateWebhookIntegrationProviderOptions) {
   const baseUrl = options.baseUrl ?? config.WEBHOOK_PUBLIC_URL;
+  const webhookProcessor = createGenericWebhookProcessor(options);
   return {
     provider: WEBHOOK_PROVIDER,
     displayName: 'Webhook',
@@ -51,7 +53,9 @@ export function createWebhookIntegrationProvider(options: CreateWebhookIntegrati
         coreDb: options.coreDb,
         getIntegrationConnectionById: options.getIntegrationConnectionById,
         publishIntegrationEventReceived: options.publishIntegrationEventReceived,
+        processor: webhookProcessor,
       }),
     ],
+    webhookProcessors: [{routeIds: ['webhook.connection'] as const, processor: webhookProcessor}],
   };
 }

--- a/libs/api/integration/webhook/src/presentation/routes/inbound.ts
+++ b/libs/api/integration/webhook/src/presentation/routes/inbound.ts
@@ -15,7 +15,10 @@ import type {FastifyPluginAsync} from 'fastify';
 import fp from 'fastify-plugin';
 import {z} from 'zod';
 import {WEBHOOK_ACCEPTED_CONTENT_TYPES, WEBHOOK_INBOUND_BODY_LIMIT} from '#constants.js';
-import {createGenericWebhookProcessor} from '#core/webhook-processor.js';
+import {
+  createGenericWebhookProcessor,
+  type GenericWebhookProcessor,
+} from '#core/webhook-processor.js';
 
 const MAX_DELIVERY_ID_HEADER_LENGTH = 200;
 const acceptedContentTypes = new Set<string>(WEBHOOK_ACCEPTED_CONTENT_TYPES);
@@ -39,6 +42,7 @@ export interface CreateWebhookInboundRoutesOptions {
   };
   getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
   publishIntegrationEventReceived: PublishIntegrationEventReceivedFn;
+  processor?: GenericWebhookProcessor | undefined;
 }
 
 const inboundParamsSchema = z.object({
@@ -69,7 +73,7 @@ function hasDeliveryId(header: string | string[] | undefined): boolean {
 }
 
 export function createWebhookInboundRoutes(options: CreateWebhookInboundRoutesOptions): RouteGroup {
-  const processor = createGenericWebhookProcessor(options);
+  const processor = options.processor ?? createGenericWebhookProcessor(options);
   const inboundRoute = defineRoute({
     method: 'POST',
     path: '/:connectionId',

--- a/libs/api/server/src/modules.test.ts
+++ b/libs/api/server/src/modules.test.ts
@@ -193,6 +193,7 @@ describe('defaultModules', () => {
         },
       },
       agentTools: {loadLeasedAgentStep: expect.any(Function)},
+      webhookDeliverySource: undefined,
     });
 
     const integrationsOptions = mocks.createIntegrationsContext.mock.calls[0]?.[0] as {
@@ -258,5 +259,15 @@ describe('defaultModules', () => {
     expect(mocks.deleteSecrets).toHaveBeenCalledWith({
       namespace: 'system/integrations/slack/workspace',
     });
+  });
+
+  it('passes an optional webhook delivery source to integration composition', async () => {
+    const webhookDeliverySource = {createService: vi.fn()};
+
+    await defaultModules({webhookDeliverySource});
+
+    expect(mocks.createIntegrationsContext).toHaveBeenCalledWith(
+      expect.objectContaining({webhookDeliverySource}),
+    );
   });
 });

--- a/libs/api/server/src/modules.ts
+++ b/libs/api/server/src/modules.ts
@@ -9,6 +9,7 @@ import {
   createIntegrationsContext,
   createWorkspaceConnectionSnapshotLoader,
   getIntegrationConnectionById,
+  type WebhookDeliverySource,
 } from '@shipfox/api-integration-core';
 import {logsModule} from '@shipfox/api-logs';
 import {createProjectsModule} from '@shipfox/api-projects';
@@ -32,6 +33,7 @@ import {
 
 export interface DefaultModulesOptions {
   runnersModule?: ShipfoxModule;
+  webhookDeliverySource?: WebhookDeliverySource | undefined;
 }
 
 export async function defaultModules(
@@ -89,6 +91,7 @@ export async function defaultModules(
     agentTools: {
       loadLeasedAgentStep: (params) => loadRunningLeasedStep({runners: runnersClient, ...params}),
     },
+    webhookDeliverySource: options.webhookDeliverySource,
   });
   const [agentToolSelectionCatalogs, agentToolCatalogs] = await Promise.all([
     buildAgentToolSelectionCatalogs(integrations.registry),


### PR DESCRIPTION
Expose the initialized webhook processors through an optional provider-neutral delivery source and attach its service to the API lifecycle.

Cloud needs queued delivery to converge on the exact processors used by direct webhook routes, without introducing Cloud or AWS dependencies into published Shipfox packages. Provider composition now registers those shared instances, while API composition keeps delivery disabled unless a source is supplied.

The source is a narrow hosted-runtime port that returns a normal module service. This keeps queue-specific lifecycle and configuration validation outside the public integration packages while preserving the existing startup and shutdown contract.

Closes ENG-1065

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose a composed, provider‑neutral webhook processor and let hosted API runtimes attach an optional delivery source so queued delivery uses the same processors as direct routes. Addresses ENG-1065 without adding cloud-specific deps to published packages.

- New Features
  - Added `WebhookRequestProcessor` to `@shipfox/api-integration-core-dto`.
  - `@shipfox/api-integration-core`: compose provider-registered processors, expose `webhookProcessor`, and add `WebhookDeliverySource` port that registers its service with the module when supplied.
  - Providers (`gitea`, `github`, `linear`, `sentry`, `slack`, `webhook`) now register `webhookProcessors` and reuse a single processor instance in both direct routes and queued delivery.
  - `@shipfox/api-server`: `defaultModules` accepts an optional `webhookDeliverySource` and passes it to integration composition.
  - Tests cover service wiring, no-op when absent, and invalid source failures.

- Migration
  - To enable queued delivery, implement `WebhookDeliverySource` and pass it to `defaultModules({ webhookDeliverySource })` or `createIntegrationsContext({ webhookDeliverySource })`.
  - No changes needed for direct webhook routes; delivery stays disabled unless a source is provided.

<sup>Written for commit 2ede5881c9b8de8720c0531d43c93f0387013a98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

