### PR TITLE
[runner-image] Build AMIs in eu-central-1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,7 +337,7 @@ jobs:
       - name: Configure candidate AWS credentials
         uses: aws-actions/configure-aws-credentials@00943011d9042930efac3dcd3a170e4273319bc8 # v5.1.0
         with:
-          aws-region: us-east-1
+          aws-region: eu-central-1
           role-duration-seconds: 7200
           role-session-name: shipfox-runner-image-candidate
           role-to-assume: ${{ secrets.AWS_RUNNER_IMAGE_ROLE_ARN }}

--- a/infra/images/runner/README.md
+++ b/infra/images/runner/README.md
@@ -11,7 +11,7 @@ BUILD_ARCH=amd64 BUILD_ATTEMPT=1 BUILD_NUMBER=42 BUILD_REVISION=0123456789abcdef
 BUILD_ARCH=amd64 BUILD_ATTEMPT=1 BUILD_NUMBER=42 BUILD_RUNNER_VERSION=0.1.0 pnpm --filter=@shipfox/runner-image exec node ./bin/build-runner-image.js ubuntu24 qemu
 ```
 
-The AMI source uses Canonical Ubuntu 24.04 and requires AWS credentials in `us-east-1`. The QEMU build defaults to a pinned Canonical Ubuntu 24.04 release image and configures its temporary Packer SSH access through a NoCloud seed; the final image locks that bootstrap account. To use a different QEMU source, set both `SHIPFOX_QEMU_SOURCE_IMAGE` and `SHIPFOX_QEMU_SOURCE_CHECKSUM` (for example, `sha256:<digest>`). Relative source paths resolve from the repository root.
+The AMI source uses Canonical Ubuntu 24.04 and requires AWS credentials in `eu-central-1`. The QEMU build defaults to a pinned Canonical Ubuntu 24.04 release image and configures its temporary Packer SSH access through a NoCloud seed; the final image locks that bootstrap account. To use a different QEMU source, set both `SHIPFOX_QEMU_SOURCE_IMAGE` and `SHIPFOX_QEMU_SOURCE_CHECKSUM` (for example, `sha256:<digest>`). Relative source paths resolve from the repository root.
 
 Packer is pinned in `mise.toml`. Install QEMU and `xorriso` through the host operating system before running a QEMU build.
 

--- a/infra/images/runner/source.aws.pkr.hcl
+++ b/infra/images/runner/source.aws.pkr.hcl
@@ -5,7 +5,7 @@ source "amazon-ebs" "build_image" {
   encrypt_boot                = true
   imds_support                = "v2.0"
   instance_type               = var.architecture == "amd64" ? "t3.large" : "t4g.large"
-  region                      = "us-east-1"
+  region                      = "eu-central-1"
   shutdown_behavior           = "terminate"
   ssh_username                = "ubuntu"
 

--- a/infra/images/runner/src/candidate.ts
+++ b/infra/images/runner/src/candidate.ts
@@ -36,7 +36,7 @@ export async function buildRunnerImageCandidate(
     throw new Error('Runner image candidate builds require candidate lifecycle metadata.');
   }
   const candidateId = build.candidateId;
-  const region = options.region ?? 'us-east-1';
+  const region = options.region ?? 'eu-central-1';
   const client = options.client ?? new EC2Client({region});
   const existingAmiId = await findRunnerImageCandidate(client, build.revision, build.architecture);
   if (existingAmiId) {
@@ -81,7 +81,7 @@ export function parseRunnerImageCandidateArgs(
   return {
     build,
     outputPath: required(values.output, '--output'),
-    region: env.AWS_REGION ?? 'us-east-1',
+    region: env.AWS_REGION ?? 'eu-central-1',
   };
 }
 

--- a/infra/images/runner/test/catalog.test.ts
+++ b/infra/images/runner/test/catalog.test.ts
@@ -29,7 +29,7 @@ function input(architecture: 'amd64' | 'arm64' = 'amd64') {
         createdAt: '2026-07-19T10:15:00Z',
         encrypted: true,
         imageOs: 'ubuntu24',
-        region: 'us-east-1',
+        region: 'eu-central-1',
         runnerVersion: '0.1.0',
         sourceAmi: 'ami-0123abc456def7890',
       },
@@ -130,7 +130,7 @@ describe('runner-image-catalog CLI', () => {
             builder_type: 'amazon-ebs',
             packer_run_uuid: 'run-123',
             build_time: 1_784_390_400,
-            artifact_id: 'us-east-1:ami-0123abc456def7890',
+            artifact_id: 'eu-central-1:ami-0123abc456def7890',
             custom_data: {
               architecture: 'amd64',
               build_attempt: '1',

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -161,7 +161,7 @@ describe('parsePackerAmiArtifact', () => {
           builder_type: 'amazon-ebs',
           packer_run_uuid: 'run-123',
           build_time: 1_784_390_400,
-          artifact_id: 'us-east-1:ami-0123abc456def7890',
+          artifact_id: 'eu-central-1:ami-0123abc456def7890',
           custom_data: {
             architecture: 'amd64',
             build_attempt: '1',
@@ -176,7 +176,7 @@ describe('parsePackerAmiArtifact', () => {
 
     expect(artifact).toEqual({
       amiId: 'ami-0123abc456def7890',
-      region: 'us-east-1',
+      region: 'eu-central-1',
       buildTime: 1_784_390_400,
       customData: {
         architecture: 'amd64',
@@ -288,7 +288,7 @@ describe('runner image candidates', () => {
       amiId: 'ami-0123abc456def7890',
       architecture: 'amd64',
       candidateId: `main-${revision}`,
-      region: 'us-east-1',
+      region: 'eu-central-1',
       revision,
       status: 'built',
     });


### PR DESCRIPTION
Move runner-image candidate publication from `us-east-1` to `eu-central-1` across GitHub credentials, Packer, candidate discovery, documentation, and fixtures.

The runner-image AWS account is intended to build AMIs in `eu-central-1`. Keeping the workflow, Packer source, and discovery client on one region prevents candidates from being built in one region and queried in another.

The corresponding Terraform-managed role policy must allow the build lifecycle in `eu-central-1`, including its regional EC2 and KMS conditions, before candidate publication can pass. The affected build, test, and check gates and the CI-equivalent Packer validation pass locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move runner-image candidate builds and publication to eu-central-1. Aligns CI, Packer, discovery, docs, and tests to the new region to avoid cross-region mismatches.

- **Migration**
  - Update the Terraform-managed IAM role to allow EC2 and KMS operations in eu-central-1 (regional conditions), so CI via `aws-actions/configure-aws-credentials` can publish candidates.

<sup>Written for commit 85f9e13e3e9160617c2d080556b807c46b348e38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

