### PR TITLE
[api-dispatcher] Guard outbox publisher registration at boot

### DIFF
--- a/.changeset/bright-otters-guard.md
+++ b/.changeset/bright-otters-guard.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-dispatcher": patch
+"@shipfox/node-module": minor
+---
+
+Makes an empty outbox publisher registry fail dispatcher boot and logs registered publishers safely.

--- a/libs/api/dispatcher/src/module.test.ts
+++ b/libs/api/dispatcher/src/module.test.ts
@@ -1,3 +1,7 @@
+import {registerPublisher, resetPublishers} from '@shipfox/node-module';
+import {createOutboxTable} from '@shipfox/node-outbox';
+import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
+import {pgTableCreator} from 'drizzle-orm/pg-core';
 import {
   DISPATCHER_WORKER_COUNT,
   DISPATCHER_WORKFLOW_ID,
@@ -11,15 +15,30 @@ const mocks = vi.hoisted(() => ({
     shutdownTimeoutMs: 5_000,
     start: vi.fn(),
   })),
+  info: vi.fn(),
 }));
 
 vi.mock('#core/outbox-drainer-service.js', () => ({
   createOutboxDrainerService: mocks.createOutboxDrainerService,
 }));
 
+vi.mock('@shipfox/node-opentelemetry', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@shipfox/node-opentelemetry')>()),
+  logger: () => ({info: mocks.info}),
+}));
+
+const table = createOutboxTable(pgTableCreator((name) => name));
+const db = (() => undefined) as unknown as () => NodePgDatabase<Record<string, unknown>>;
+
 describe('dispatcherModule', () => {
   beforeEach(() => {
+    resetPublishers();
     mocks.createOutboxDrainerService.mockClear();
+    mocks.info.mockReset();
+  });
+
+  afterEach(() => {
+    resetPublishers();
   });
 
   it('registers the Temporal dispatch workflows alongside retention when the in-process drainer is disabled', () => {
@@ -73,5 +92,27 @@ describe('dispatcherModule', () => {
 
     expect(mocks.createOutboxDrainerService).toHaveBeenCalledWith({pollMs: 500});
     expect(module.services?.[0]?.name).toBe('outbox-drainer');
+  });
+
+  it('fails boot when its publisher registry is empty', () => {
+    const startupTasks = createDispatcherModule({enabled: false}).startupTasks;
+
+    expect(startupTasks).toThrow(
+      'duplicate @shipfox/node-module instance split the publisher registry',
+    );
+  });
+
+  it('logs registered publisher names at boot', async () => {
+    registerPublisher({name: 'auth', table, db});
+    registerPublisher({name: 'workspaces', table, db});
+    const startupTasks = createDispatcherModule({enabled: false}).startupTasks;
+
+    await startupTasks?.();
+
+    expect(mocks.info).toHaveBeenCalledOnce();
+    expect(mocks.info).toHaveBeenCalledWith(
+      {publisherCount: 2, publisherNames: ['auth', 'workspaces']},
+      'Outbox dispatcher publishers registered',
+    );
   });
 });

--- a/libs/api/dispatcher/src/module.ts
+++ b/libs/api/dispatcher/src/module.ts
@@ -1,6 +1,7 @@
 import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
-import type {ShipfoxModule} from '@shipfox/node-module';
+import {getRegisteredPublisherNames, type ShipfoxModule} from '@shipfox/node-module';
+import {logger} from '@shipfox/node-opentelemetry';
 import {config} from '#config.js';
 import {
   DISPATCHER_TASK_QUEUE,
@@ -45,6 +46,21 @@ export function createDispatcherModule(
 
   return {
     name: 'dispatcher',
+    startupTasks: () => {
+      const publisherNames = getRegisteredPublisherNames();
+      if (publisherNames.length === 0) {
+        throw new Error(
+          'Outbox dispatcher has no registered publishers. This likely means a duplicate @shipfox/node-module instance split the publisher registry. Ensure the API server and dispatcher resolve the same package instance.',
+        );
+      }
+
+      logger().info(
+        {publisherCount: publisherNames.length, publisherNames},
+        'Outbox dispatcher publishers registered',
+      );
+
+      return Promise.resolve();
+    },
     ...(enabled ? {services: [createOutboxDrainerService({pollMs})]} : {}),
     workers: [
       {

--- a/libs/shared/node/module/src/index.ts
+++ b/libs/shared/node/module/src/index.ts
@@ -34,6 +34,7 @@ export {
   BATCH_SIZE,
   drainAll,
   getEventSchema,
+  getRegisteredPublisherNames,
   markDispatched,
   pruneDispatchedOutboxRows,
   recordDispatchFailure,

--- a/libs/shared/node/module/src/publisher-registry.test.ts
+++ b/libs/shared/node/module/src/publisher-registry.test.ts
@@ -4,6 +4,7 @@ import {pgTableCreator} from 'drizzle-orm/pg-core';
 import {z} from 'zod';
 import {
   getEventSchema,
+  getRegisteredPublisherNames,
   pruneDispatchedOutboxRows,
   registerPublisher,
   resetPublishers,
@@ -72,6 +73,35 @@ describe('getEventSchema', () => {
       registerPublisher({name: 'foo', table, db, eventSchemas: {'foo.created': fooSchema}});
 
     expect(register).not.toThrow();
+  });
+});
+
+describe('getRegisteredPublisherNames', () => {
+  beforeEach(() => {
+    resetPublishers();
+  });
+
+  afterEach(() => {
+    resetPublishers();
+  });
+
+  it('returns an empty array when no publishers are registered', () => {
+    expect(getRegisteredPublisherNames()).toEqual([]);
+  });
+
+  it('returns registered publisher names in registration order', () => {
+    registerPublisher({name: 'foo', table, db});
+    registerPublisher({name: 'bar', table, db});
+
+    expect(getRegisteredPublisherNames()).toEqual(['foo', 'bar']);
+  });
+
+  it('forgets registered publishers after resetPublishers', () => {
+    registerPublisher({name: 'foo', table, db});
+
+    resetPublishers();
+
+    expect(getRegisteredPublisherNames()).toEqual([]);
   });
 });
 

--- a/libs/shared/node/module/src/publisher-registry.ts
+++ b/libs/shared/node/module/src/publisher-registry.ts
@@ -94,6 +94,10 @@ export function registerPublisher(config: PublisherSource): void {
   }
 }
 
+export function getRegisteredPublisherNames(): string[] {
+  return _sources.map((source) => source.name);
+}
+
 export function getEventSchema(type: string): ZodType | undefined {
   return _schemasByType.get(type);
 }


### PR DESCRIPTION
Fail dispatcher startup when the publisher registry is empty and log the registered publisher names and count on a healthy boot.

The outbox registry is process-local state. A duplicate `@shipfox/node-module` resolution previously gave the dispatcher an empty registry, letting it report an idle queue while events remained undispatched. Failing during startup makes that deployment fault visible immediately and gives operators an actionable cause.

This intentionally detects only an empty dispatcher registry. ENG-1099 will remove the singleton dependency by passing an explicit registry to consumers, which addresses partial registry splits as well.

Closes ENG-1098

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail dispatcher startup if the outbox publisher registry is empty. Log publisher names and count on healthy boot to catch duplicate `@shipfox/node-module` resolution and avoid silently dropped outbox events (ENG-1098).

- **Bug Fixes**
  - `@shipfox/api-dispatcher`: add boot guard in `startupTasks` that throws on an empty registry and log publisher metadata via `@shipfox/node-opentelemetry`.
  - `@shipfox/node-module`: export `getRegisteredPublisherNames()` to support safe diagnostics.

<sup>Written for commit 4339248ab658a9d368ac9bf686634ad5d8c36f3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

