### PR TITLE
[integrations] Fix composed webhook processor wiring

### DIFF
--- a/.changeset/focused-webhooks-heal.md
+++ b/.changeset/focused-webhooks-heal.md
@@ -1,0 +1,8 @@
+---
+"@shipfox/api-integration-core": minor
+"@shipfox/api-integration-core-dto": minor
+"@shipfox/api-integration-github": patch
+"@shipfox/api-integration-slack": patch
+---
+
+Fixes composed webhook processing and exposes Slack URL-verification responses through the shared contract.

--- a/libs/api/integration/core-dto/src/webhooks.test.ts
+++ b/libs/api/integration/core-dto/src/webhooks.test.ts
@@ -83,6 +83,7 @@ describe('storedWebhookRequestSchema', () => {
 describe('webhookProcessingResultSchema', () => {
   it.each([
     {outcome: 'processed'},
+    {outcome: 'processed', challenge: 'slack-url-verification'},
     {outcome: 'duplicate', deliveryId: 'delivery-1'},
     {outcome: 'discarded', reason: 'invalid_signature'},
   ])('accepts the %s processing outcome', (result) => {

--- a/libs/api/integration/core-dto/src/webhooks.ts
+++ b/libs/api/integration/core-dto/src/webhooks.ts
@@ -94,7 +94,13 @@ export const storedWebhookRequestSchema = z.discriminatedUnion('route_id', [
 export type StoredWebhookRequest = z.infer<typeof storedWebhookRequestSchema>;
 
 export const webhookProcessingResultSchema = z.discriminatedUnion('outcome', [
-  z.object({outcome: z.literal('processed'), deliveryId: z.string().min(1).optional()}).strict(),
+  z
+    .object({
+      outcome: z.literal('processed'),
+      deliveryId: z.string().min(1).optional(),
+      challenge: z.string().min(1).optional(),
+    })
+    .strict(),
   z.object({outcome: z.literal('duplicate'), deliveryId: z.string().min(1)}).strict(),
   z
     .object({

--- a/libs/api/integration/core/src/core/errors.ts
+++ b/libs/api/integration/core/src/core/errors.ts
@@ -52,4 +52,11 @@ export class IntegrationProviderUnavailableError extends Error {
   }
 }
 
+export class WebhookProcessorNotConfiguredError extends Error {
+  constructor(public readonly routeId: string) {
+    super(`No webhook processor is configured for ${routeId}`);
+    this.name = 'WebhookProcessorNotConfiguredError';
+  }
+}
+
 export {ConnectionSlugConflictError, IntegrationProviderError, type IntegrationProviderErrorReason};

--- a/libs/api/integration/core/src/index.test.ts
+++ b/libs/api/integration/core/src/index.test.ts
@@ -3,7 +3,7 @@ import type {
   WebhookRequestProcessor,
 } from '@shipfox/api-integration-core-dto';
 import {type ModuleService, startModuleServices} from '@shipfox/node-module';
-import {createIntegrationsContext} from './index.js';
+import {createIntegrationsContext, WebhookProcessorNotConfiguredError} from './index.js';
 
 const request = {
   schema_version: 1,
@@ -58,6 +58,38 @@ describe('createIntegrationsContext', () => {
     });
 
     expect(context.module.services).toBeUndefined();
+  });
+
+  it('rejects a queued request with no registered processor', async () => {
+    const context = await createIntegrationsContext({
+      parts: [{provider: {provider: 'github', displayName: 'GitHub', adapters: {}}}],
+    });
+
+    const result = context.webhookProcessor.process(request);
+
+    await expect(result).rejects.toEqual(new WebhookProcessorNotConfiguredError('github'));
+  });
+
+  it('fails composition when more than one processor handles a route', async () => {
+    const processor: WebhookRequestProcessor = {
+      process: vi.fn().mockResolvedValue({outcome: 'processed', deliveryId: 'delivery-1'}),
+    };
+
+    const result = createIntegrationsContext({
+      parts: [
+        {
+          provider: {provider: 'github', displayName: 'GitHub', adapters: {}},
+          webhookProcessors: [
+            {routeIds: ['github'], processor},
+            {routeIds: ['github'], processor},
+          ],
+        },
+      ],
+    });
+
+    await expect(result).rejects.toThrow(
+      'Webhook processor is registered more than once for github',
+    );
   });
 
   it('fails composition when a configured delivery source is invalid', async () => {

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -10,6 +10,7 @@ import {
 import type {ModuleService, ShipfoxModule} from '@shipfox/node-module';
 import {logger} from '@shipfox/node-opentelemetry';
 import type {IntegrationProvider} from '#core/entities/provider.js';
+import {WebhookProcessorNotConfiguredError} from '#core/errors.js';
 import {
   createIntegrationProviderRegistry,
   type IntegrationProviderRegistry,
@@ -35,6 +36,12 @@ import {INTEGRATIONS_MAINTENANCE_TASK_QUEUE} from '#temporal/constants.js';
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const maintenanceWorkflowsPath = resolve(packageRoot, 'dist/temporal/workflows/index.js');
 
+export type {
+  StoredWebhookRequest,
+  WebhookProcessingResult,
+  WebhookRequestProcessor,
+  WebhookRouteId,
+} from '@shipfox/api-integration-core-dto';
 export {
   buildProviderRepositoryId,
   MAX_REPOSITORY_FILE_BYTES,
@@ -73,6 +80,7 @@ export {
   IntegrationConnectionWorkspaceMismatchError,
   IntegrationProviderError,
   IntegrationProviderUnavailableError,
+  WebhookProcessorNotConfiguredError,
 } from '#core/errors.js';
 export type {
   AgentToolCallInput,
@@ -265,7 +273,7 @@ function createComposedWebhookProcessor(
     async process(request: StoredWebhookRequest): Promise<WebhookProcessingResult> {
       const processor = processors.get(request.route_id);
       if (!processor) {
-        throw new Error(`No webhook processor is configured for ${request.route_id}`);
+        throw new WebhookProcessorNotConfiguredError(request.route_id);
       }
       return await processor.process(request);
     },

--- a/libs/api/integration/github/src/index.test.ts
+++ b/libs/api/integration/github/src/index.test.ts
@@ -1,0 +1,50 @@
+import {githubInstallationTokenNamespace} from '#api/installation-token-envelope.js';
+import {createGithubIntegrationProvider} from '#index.js';
+
+const {createProcessor, state} = vi.hoisted(() => {
+  const state: {processorOptions: unknown} = {processorOptions: undefined};
+  return {
+    state,
+    createProcessor: vi.fn((options: unknown) => {
+      state.processorOptions = options;
+      return {process: vi.fn()};
+    }),
+  };
+});
+
+vi.mock('#core/webhook-processor.js', () => ({
+  createGithubWebhookProcessor: createProcessor,
+}));
+
+describe('createGithubIntegrationProvider', () => {
+  it('shares installation-token cleanup with the direct and composed processors', async () => {
+    const deleteSecrets = vi.fn(() => Promise.resolve(1));
+    createGithubIntegrationProvider({
+      github: {} as never,
+      getExistingGithubConnection: vi.fn(() => Promise.resolve(undefined)),
+      connectGithubInstallation: vi.fn() as never,
+      coreDb: vi.fn() as never,
+      publishIntegrationEventReceived: vi.fn(() => Promise.resolve({published: false})),
+      publishSourcePush: vi.fn(() => Promise.resolve({published: false})),
+      recordDeliveryOnly: vi.fn(() => Promise.resolve()),
+      getIntegrationConnectionById: vi.fn(() => Promise.resolve(undefined)),
+      deleteSecrets,
+    });
+    const processorOptions = state.processorOptions as {
+      deleteInstallationTokenSecret: (params: {
+        workspaceId: string;
+        installationId: number;
+      }) => Promise<unknown>;
+    };
+
+    await processorOptions.deleteInstallationTokenSecret({
+      workspaceId: 'workspace-1',
+      installationId: 123,
+    });
+
+    expect(deleteSecrets).toHaveBeenCalledWith({
+      workspaceId: 'workspace-1',
+      namespace: githubInstallationTokenNamespace(123),
+    });
+  });
+});

--- a/libs/api/integration/github/src/index.ts
+++ b/libs/api/integration/github/src/index.ts
@@ -83,7 +83,18 @@ export function createGithubIntegrationProvider(options: CreateGithubIntegration
   const getInstallationByConnectionId =
     options.getGithubInstallationByConnectionId ?? getGithubInstallationByConnectionId;
   const deleteSecrets = options.deleteSecrets;
-  const webhookProcessor = createGithubWebhookProcessor(options);
+  const deleteInstallationTokenSecret = deleteSecrets
+    ? (params: {workspaceId: string; installationId: number}) =>
+        deleteGithubInstallationTokenSecret({
+          workspaceId: params.workspaceId,
+          installationId: params.installationId,
+          deleteSecrets,
+        })
+    : undefined;
+  const webhookProcessor = createGithubWebhookProcessor({
+    ...options,
+    deleteInstallationTokenSecret,
+  });
 
   return {
     provider: 'github' as const,
@@ -117,14 +128,7 @@ export function createGithubIntegrationProvider(options: CreateGithubIntegration
         publishSourcePush: options.publishSourcePush,
         recordDeliveryOnly: options.recordDeliveryOnly,
         getIntegrationConnectionById: options.getIntegrationConnectionById,
-        deleteInstallationTokenSecret: deleteSecrets
-          ? (params) =>
-              deleteGithubInstallationTokenSecret({
-                workspaceId: params.workspaceId,
-                installationId: params.installationId,
-                deleteSecrets,
-              })
-          : undefined,
+        deleteInstallationTokenSecret,
         processor: webhookProcessor,
       }),
     ],

--- a/libs/api/integration/slack/src/core/webhook-processor.ts
+++ b/libs/api/integration/slack/src/core/webhook-processor.ts
@@ -29,12 +29,10 @@ export interface CreateSlackWebhookProcessorOptions {
   getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
 }
 
-export type SlackWebhookProcessingResult =
-  | WebhookProcessingResult
-  | {outcome: 'processed'; challenge: string};
+export type SlackWebhookProcessingResult = WebhookProcessingResult;
 
 export interface SlackWebhookProcessor {
-  process(request: StoredWebhookRequest): Promise<SlackWebhookProcessingResult>;
+  process(request: StoredWebhookRequest): Promise<WebhookProcessingResult>;
 }
 
 export function createSlackWebhookProcessor(
@@ -46,7 +44,7 @@ export function createSlackWebhookProcessor(
 function processSlackWebhookRequest(
   options: CreateSlackWebhookProcessorOptions,
   request: StoredWebhookRequest,
-): Promise<SlackWebhookProcessingResult> {
+): Promise<WebhookProcessingResult> {
   if (request.route_id !== 'slack.event' && request.route_id !== 'slack.command') {
     throw new Error(`Slack processor cannot process ${request.route_id} requests`);
   }
@@ -82,7 +80,7 @@ function processSlackWebhookRequest(
 async function processSlackEvent(
   options: CreateSlackWebhookProcessorOptions,
   rawBody: Uint8Array,
-): Promise<SlackWebhookProcessingResult> {
+): Promise<WebhookProcessingResult> {
   let rawPayload: unknown;
   try {
     rawPayload = JSON.parse(Buffer.from(rawBody).toString('utf8'));

--- a/libs/api/integration/slack/src/presentation/routes/webhooks.ts
+++ b/libs/api/integration/slack/src/presentation/routes/webhooks.ts
@@ -5,6 +5,7 @@ import type {
   PublishIntegrationEventReceivedFn,
   RecordDeliveryOnlyFn,
   StoredWebhookRequest,
+  WebhookProcessingResult,
 } from '@shipfox/api-integration-core-dto';
 import {
   createStoredWebhookRequest,
@@ -17,11 +18,7 @@ import {
   type RouteGroup,
 } from '@shipfox/node-fastify';
 import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
-import {
-  createSlackWebhookProcessor,
-  type SlackWebhookProcessingResult,
-  type SlackWebhookProcessor,
-} from '#core/webhook-processor.js';
+import {createSlackWebhookProcessor, type SlackWebhookProcessor} from '#core/webhook-processor.js';
 
 export const SLACK_WEBHOOK_BODY_LIMIT = 1024 * 1024;
 export const SLASH_COMMAND_ACK = {response_type: 'ephemeral', text: 'Working on it.'} as const;
@@ -162,7 +159,7 @@ function slackWebhookHeaders(headers: Record<string, string | string[] | undefin
 
 function sendSlackEventResponse(
   reply: {code(statusCode: number): void},
-  result: SlackWebhookProcessingResult,
+  result: WebhookProcessingResult,
 ) {
   if (result.outcome === 'processed' && 'challenge' in result) {
     reply.code(200);
@@ -187,7 +184,7 @@ function sendSlackEventResponse(
 
 function sendSlackCommandResponse(
   reply: {code(statusCode: number): void},
-  result: SlackWebhookProcessingResult,
+  result: WebhookProcessingResult,
 ) {
   if (
     result.outcome === 'discarded' &&


### PR DESCRIPTION
Fixes the composed webhook-processing seam used by direct routes and optional queued delivery.

GitHub installation lifecycle events now share the correctly wired installation-token cleanup callback in both paths. Missing queued route registrations now expose a typed error, and Slack URL-verification challenges are represented in the shared result contract so delivery-source implementations can handle the complete response shape.

The alternative was to keep Slack's challenge as a provider-only type and leave hosted consumers to infer it at runtime. Widening the shared contract preserves the direct response while making the queue port type-safe.

Fixes ENG-1065

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes composed webhook processing so direct and queued paths share GitHub installation-token cleanup and handle Slack URL verification through the shared result. Fixes ENG-1065.

- **Bug Fixes**
  - Composed processor now wires the same `deleteInstallationTokenSecret` to both direct and queued GitHub paths.
  - Queued requests without a registered processor now fail with `WebhookProcessorNotConfiguredError`.
  - Composition fails if a route is registered by more than one processor.

- **New Features**
  - Adds optional `challenge` to the `processed` outcome in `webhookProcessingResultSchema`, enabling Slack URL-verification via the shared `WebhookProcessingResult`.
  - Slack routes now rely solely on the shared result type.
  - Core re-exports `StoredWebhookRequest`, `WebhookProcessingResult`, `WebhookRequestProcessor`, and `WebhookRouteId` for consumers.

<sup>Written for commit 742ee2a602e565ab8ef760b9e291d80fcb425d07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

