### PR TITLE
Expose the Agent inter-module API

### DIFF
--- a/.changeset/bright-herons-connect.md
+++ b/.changeset/bright-herons-connect.md
@@ -1,0 +1,8 @@
+---
+"@shipfox/api-agent-dto": minor
+"@shipfox/api-agent": patch
+"@shipfox/api-server": patch
+"@shipfox/api-workflows": patch
+---
+
+Adds the Agent inter-module API and moves Workflows agent configuration and runtime credential resolution behind it.

--- a/libs/api/agent-dto/package.json
+++ b/libs/api/agent-dto/package.json
@@ -28,6 +28,16 @@
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
       }
+    },
+    "./inter-module": {
+      "workspace-source": {
+        "types": "./src/inter-module.ts",
+        "default": "./src/inter-module.ts"
+      },
+      "default": {
+        "types": "./dist/inter-module.d.ts",
+        "default": "./dist/inter-module.js"
+      }
     }
   },
   "scripts": {
@@ -41,6 +51,7 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
+    "@shipfox/inter-module": "workspace:*",
     "@shipfox/workflow-document": "workspace:*",
     "zod": "catalog:"
   },

--- a/libs/api/agent-dto/src/inter-module.ts
+++ b/libs/api/agent-dto/src/inter-module.ts
@@ -1,0 +1,49 @@
+import {defineInterModuleContract, type InterModuleClient} from '@shipfox/inter-module';
+import {z} from 'zod';
+import {
+  agentRuntimeCredentialsResponseSchema,
+  agentThinkingSchema,
+  harnessSchema,
+  modelProviderRefSchema,
+} from '#schemas/index.js';
+
+const agentConfigInputSchema = z.object({
+  harness: harnessSchema.optional(),
+  provider: modelProviderRefSchema.optional(),
+  model: z.string().optional(),
+  thinking: agentThinkingSchema.optional(),
+});
+
+const resolvedAgentConfigSchema = z.object({
+  harness: harnessSchema,
+  provider: modelProviderRefSchema,
+  model: z.string(),
+  thinking: agentThinkingSchema,
+});
+
+export const agentInterModuleContract = defineInterModuleContract({
+  module: 'agent',
+  methods: {
+    resolveAgentConfig: {
+      input: z.object({workspaceId: z.string().uuid().nullable(), config: agentConfigInputSchema}),
+      output: resolvedAgentConfigSchema,
+      errors: {'agent-config-invalid': z.object({})},
+    },
+    resolveRuntimeCredentials: {
+      input: z.object({
+        workspaceId: z.string().uuid(),
+        harness: harnessSchema,
+        provider: modelProviderRefSchema,
+        model: z.string(),
+        thinking: agentThinkingSchema,
+      }),
+      output: agentRuntimeCredentialsResponseSchema,
+      errors: {
+        'model-provider-not-configured': z.object({}),
+        'model-provider-credentials-invalid': z.object({}),
+      },
+    },
+  },
+});
+
+export type AgentInterModuleClient = InterModuleClient<typeof agentInterModuleContract>;

--- a/libs/api/agent/package.json
+++ b/libs/api/agent/package.json
@@ -80,7 +80,6 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
-    "@shipfox/inter-module": "workspace:*",
     "@earendil-works/pi-ai": "catalog:",
     "@opentelemetry/api": "catalog:",
     "@shipfox/api-agent-dto": "workspace:*",

--- a/libs/api/agent/package.json
+++ b/libs/api/agent/package.json
@@ -80,6 +80,7 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
+    "@shipfox/inter-module": "workspace:*",
     "@earendil-works/pi-ai": "catalog:",
     "@opentelemetry/api": "catalog:",
     "@shipfox/api-agent-dto": "workspace:*",

--- a/libs/api/agent/src/index.ts
+++ b/libs/api/agent/src/index.ts
@@ -2,6 +2,7 @@ import type {ShipfoxModule} from '@shipfox/node-module';
 import type {AgentSecretsClient} from '#core/secrets-client.js';
 import {db, migrationsPath} from '#db/index.js';
 import {createAgentE2eRoutes} from '#presentation/e2eRoutes/index.js';
+import {createAgentInterModulePresentation} from '#presentation/inter-module.js';
 import {createAgentRoutes} from '#presentation/routes/index.js';
 
 export {
@@ -42,5 +43,6 @@ export function createAgentModule(params: {secrets: AgentSecretsClient}): Shipfo
     database: {db, migrationsPath},
     routes: createAgentRoutes(params.secrets),
     e2eRoutes: [createAgentE2eRoutes(params.secrets)],
+    interModulePresentations: [createAgentInterModulePresentation(params)],
   };
 }

--- a/libs/api/agent/src/presentation/inter-module.ts
+++ b/libs/api/agent/src/presentation/inter-module.ts
@@ -1,0 +1,77 @@
+import {agentInterModuleContract} from '@shipfox/api-agent-dto/inter-module';
+import {SecretDecryptionError} from '@shipfox/api-secrets';
+import {
+  createInterModuleKnownError,
+  defineInterModulePresentation,
+  type InterModulePresentation,
+} from '@shipfox/inter-module';
+import {
+  InvalidAgentModelError,
+  ModelProviderConfigNotFoundError,
+  UnsupportedHarnessProviderError,
+  UnsupportedHarnessThinkingError,
+  UnsupportedModelProviderError,
+} from '#core/errors.js';
+import {resolveAgentConfig} from '#core/resolve-agent-config.js';
+import {resolveRuntimeCredentials} from '#core/resolve-runtime-credentials.js';
+import {createWorkspaceAgentDefaultsResolver} from '#core/workspace-agent-defaults-resolver.js';
+import type {AgentSecretsClient} from '#core/secrets-client.js';
+
+export function createAgentInterModulePresentation(params: {secrets: AgentSecretsClient}): InterModulePresentation<
+  typeof agentInterModuleContract
+> {
+  return defineInterModulePresentation(agentInterModuleContract, {
+    resolveAgentConfig: async ({workspaceId, config}) => {
+      try {
+        const resolve =
+          workspaceId === null
+            ? resolveAgentConfig
+            : await createWorkspaceAgentDefaultsResolver(workspaceId);
+        return await resolve(config);
+      } catch (error) {
+        throw toResolveAgentConfigKnownError(error);
+      }
+    },
+    resolveRuntimeCredentials: async (input) => {
+      try {
+        return await resolveRuntimeCredentials(input, {secrets: params.secrets});
+      } catch (error) {
+        throw toResolveRuntimeCredentialsKnownError(error);
+      }
+    },
+  });
+}
+
+function toResolveAgentConfigKnownError(error: unknown): unknown {
+  if (
+    error instanceof InvalidAgentModelError ||
+    error instanceof UnsupportedHarnessProviderError ||
+    error instanceof UnsupportedHarnessThinkingError ||
+    error instanceof UnsupportedModelProviderError
+  ) {
+    return createInterModuleKnownError(
+      agentInterModuleContract.methods.resolveAgentConfig,
+      'agent-config-invalid',
+      {},
+    );
+  }
+  return error;
+}
+
+function toResolveRuntimeCredentialsKnownError(error: unknown): unknown {
+  if (error instanceof ModelProviderConfigNotFoundError) {
+    return createInterModuleKnownError(
+      agentInterModuleContract.methods.resolveRuntimeCredentials,
+      'model-provider-not-configured',
+      {},
+    );
+  }
+  if (error instanceof SecretDecryptionError) {
+    return createInterModuleKnownError(
+      agentInterModuleContract.methods.resolveRuntimeCredentials,
+      'model-provider-credentials-invalid',
+      {},
+    );
+  }
+  return error;
+}

--- a/libs/api/agent/src/presentation/inter-module.ts
+++ b/libs/api/agent/src/presentation/inter-module.ts
@@ -1,9 +1,10 @@
 import {agentInterModuleContract} from '@shipfox/api-agent-dto/inter-module';
-import {SecretDecryptionError} from '@shipfox/api-secrets';
+import {secretsInterModuleContract} from '@shipfox/api-secrets-dto/inter-module';
 import {
   createInterModuleKnownError,
   defineInterModulePresentation,
   type InterModulePresentation,
+  isInterModuleKnownError,
 } from '@shipfox/inter-module';
 import {
   InvalidAgentModelError,
@@ -14,12 +15,12 @@ import {
 } from '#core/errors.js';
 import {resolveAgentConfig} from '#core/resolve-agent-config.js';
 import {resolveRuntimeCredentials} from '#core/resolve-runtime-credentials.js';
-import {createWorkspaceAgentDefaultsResolver} from '#core/workspace-agent-defaults-resolver.js';
 import type {AgentSecretsClient} from '#core/secrets-client.js';
+import {createWorkspaceAgentDefaultsResolver} from '#core/workspace-agent-defaults-resolver.js';
 
-export function createAgentInterModulePresentation(params: {secrets: AgentSecretsClient}): InterModulePresentation<
-  typeof agentInterModuleContract
-> {
+export function createAgentInterModulePresentation(params: {
+  secrets: AgentSecretsClient;
+}): InterModulePresentation<typeof agentInterModuleContract> {
   return defineInterModulePresentation(agentInterModuleContract, {
     resolveAgentConfig: async ({workspaceId, config}) => {
       try {
@@ -66,7 +67,7 @@ function toResolveRuntimeCredentialsKnownError(error: unknown): unknown {
       {},
     );
   }
-  if (error instanceof SecretDecryptionError) {
+  if (isInterModuleKnownError(secretsInterModuleContract.methods.getSecretsByNamespace, error)) {
     return createInterModuleKnownError(
       agentInterModuleContract.methods.resolveRuntimeCredentials,
       'model-provider-credentials-invalid',

--- a/libs/api/integration/core/test/external/package.template.json
+++ b/libs/api/integration/core/test/external/package.template.json
@@ -9,7 +9,9 @@
   },
   "dependencies": {
     "@shipfox/api-integration-core": "file:./api-integration-core.tgz",
-    "@shipfox/api-integration-core-dto": "file:./api-integration-core-dto.tgz"
+    "@shipfox/api-integration-core-dto": "file:./api-integration-core-dto.tgz",
+    "@shipfox/api-workflows-dto": "file:./api-workflows-dto.tgz",
+    "@shipfox/inter-module": "file:./inter-module.tgz"
   },
   "devDependencies": {
     "@types/node": "^24.1.0",

--- a/libs/api/server/package.json
+++ b/libs/api/server/package.json
@@ -52,6 +52,7 @@
     "@shipfox/annotations": "workspace:*",
     "@shipfox/annotations-dto": "workspace:*",
     "@shipfox/api-agent": "workspace:*",
+    "@shipfox/api-agent-dto": "workspace:*",
     "@shipfox/api-auth": "workspace:*",
     "@shipfox/api-auth-dto": "workspace:*",
     "@shipfox/api-definitions": "workspace:*",

--- a/libs/api/server/src/modules.test.ts
+++ b/libs/api/server/src/modules.test.ts
@@ -1,6 +1,6 @@
 import {annotationsInterModuleContract} from '@shipfox/annotations-dto/inter-module';
-import {authInterModuleContract} from '@shipfox/api-auth-dto/inter-module';
 import {agentInterModuleContract} from '@shipfox/api-agent-dto/inter-module';
+import {authInterModuleContract} from '@shipfox/api-auth-dto/inter-module';
 import {definitionsInterModuleContract} from '@shipfox/api-definitions-dto/inter-module';
 import {projectsInterModuleContract} from '@shipfox/api-projects-dto';
 import {runnersInterModuleContract} from '@shipfox/api-runners-dto/inter-module';

--- a/libs/api/server/src/modules.test.ts
+++ b/libs/api/server/src/modules.test.ts
@@ -1,5 +1,6 @@
 import {annotationsInterModuleContract} from '@shipfox/annotations-dto/inter-module';
 import {authInterModuleContract} from '@shipfox/api-auth-dto/inter-module';
+import {agentInterModuleContract} from '@shipfox/api-agent-dto/inter-module';
 import {definitionsInterModuleContract} from '@shipfox/api-definitions-dto/inter-module';
 import {projectsInterModuleContract} from '@shipfox/api-projects-dto';
 import {runnersInterModuleContract} from '@shipfox/api-runners-dto/inter-module';
@@ -152,7 +153,15 @@ describe('defaultModules', () => {
         }),
       ],
     });
-    mocks.createAgentModule.mockReturnValue({name: 'agent'});
+    mocks.createAgentModule.mockReturnValue({
+      name: 'agent',
+      interModulePresentations: [
+        {
+          contract: agentInterModuleContract,
+          handlers: {resolveAgentConfig: vi.fn(), resolveRuntimeCredentials: vi.fn()},
+        },
+      ],
+    });
     mocks.createRunnersModule.mockReturnValue({
       name: 'runners',
       interModulePresentations: [

--- a/libs/api/server/src/modules.ts
+++ b/libs/api/server/src/modules.ts
@@ -1,6 +1,7 @@
 import {annotationsModule} from '@shipfox/annotations';
 import {annotationsInterModuleContract} from '@shipfox/annotations-dto/inter-module';
 import {createAgentModule} from '@shipfox/api-agent';
+import {agentInterModuleContract} from '@shipfox/api-agent-dto/inter-module';
 import {authModule} from '@shipfox/api-auth';
 import {config as authConfig} from '@shipfox/api-auth/config';
 import {
@@ -51,6 +52,7 @@ export async function defaultModules(
   const interModuleTransport = createInMemoryInterModuleTransport();
   const workflowsClient = interModuleTransport.createClient(workflowsInterModuleContract);
   const authClient = interModuleTransport.createClient(authInterModuleContract);
+  const agentClient = interModuleTransport.createClient(agentInterModuleContract);
   const runnersClient = interModuleTransport.createClient(runnersInterModuleContract);
   const projectsClient = interModuleTransport.createClient(projectsInterModuleContract);
   const definitionsClient = interModuleTransport.createClient(definitionsInterModuleContract);
@@ -60,76 +62,19 @@ export async function defaultModules(
     secrets: {
       deleteSecrets: async (params) => (await secretsClient.deleteSecrets(params)).deleted,
       linear: {
-        getSecret: async (params) =>
-          (
-            await secretsClient.getSecret({
-              ...params,
-              namespace: `system/integrations/linear/${params.namespace}`,
-            })
-          ).value,
-        setSecrets: async (params) => {
-          const {editedBy, ...secretParams} = params;
-          await secretsClient.setSecrets({
-            ...secretParams,
-            namespace: `system/integrations/linear/${secretParams.namespace}`,
-            ...(editedBy === undefined ? {} : {editedBy}),
-          });
-        },
-        deleteSecrets: async (params) =>
-          (
-            await secretsClient.deleteSecrets({
-              ...params,
-              namespace: `system/integrations/linear/${params.namespace}`,
-            })
-          ).deleted,
+        getSecret: async (params) => (await secretsClient.getSecret({...params, namespace: `system/integrations/linear/${params.namespace}`})).value,
+        setSecrets: async (params) => { const {editedBy, ...secretParams} = params; await secretsClient.setSecrets({...secretParams, namespace: `system/integrations/linear/${secretParams.namespace}`, ...(editedBy === undefined ? {} : {editedBy})}); },
+        deleteSecrets: async (params) => (await secretsClient.deleteSecrets({...params, namespace: `system/integrations/linear/${params.namespace}`})).deleted,
       },
       jira: {
-        getSecret: async (params) =>
-          (
-            await secretsClient.getSecret({
-              ...params,
-              namespace: `system/integrations/jira/${params.namespace}`,
-            })
-          ).value,
-        setSecrets: async (params) => {
-          const {editedBy, ...secretParams} = params;
-          await secretsClient.setSecrets({
-            ...secretParams,
-            namespace: `system/integrations/jira/${secretParams.namespace}`,
-            ...(editedBy === undefined ? {} : {editedBy}),
-          });
-        },
-        deleteSecrets: async (params) =>
-          (
-            await secretsClient.deleteSecrets({
-              ...params,
-              namespace: `system/integrations/jira/${params.namespace}`,
-            })
-          ).deleted,
+        getSecret: async (params) => (await secretsClient.getSecret({...params, namespace: `system/integrations/jira/${params.namespace}`})).value,
+        setSecrets: async (params) => { const {editedBy, ...secretParams} = params; await secretsClient.setSecrets({...secretParams, namespace: `system/integrations/jira/${secretParams.namespace}`, ...(editedBy === undefined ? {} : {editedBy})}); },
+        deleteSecrets: async (params) => (await secretsClient.deleteSecrets({...params, namespace: `system/integrations/jira/${params.namespace}`})).deleted,
       },
       slack: {
-        getSecret: async (params) =>
-          (
-            await secretsClient.getSecret({
-              ...params,
-              namespace: `system/integrations/slack/${params.namespace}`,
-            })
-          ).value,
-        setSecrets: async (params) => {
-          const {editedBy, ...secretParams} = params;
-          await secretsClient.setSecrets({
-            ...secretParams,
-            namespace: `system/integrations/slack/${secretParams.namespace}`,
-            ...(editedBy === undefined ? {} : {editedBy}),
-          });
-        },
-        deleteSecrets: async (params) =>
-          (
-            await secretsClient.deleteSecrets({
-              ...params,
-              namespace: `system/integrations/slack/${params.namespace}`,
-            })
-          ).deleted,
+        getSecret: async (params) => (await secretsClient.getSecret({...params, namespace: `system/integrations/slack/${params.namespace}`})).value,
+        setSecrets: async (params) => { const {editedBy, ...secretParams} = params; await secretsClient.setSecrets({...secretParams, namespace: `system/integrations/slack/${secretParams.namespace}`, ...(editedBy === undefined ? {} : {editedBy})}); },
+        deleteSecrets: async (params) => (await secretsClient.deleteSecrets({...params, namespace: `system/integrations/slack/${params.namespace}`})).deleted,
       },
     },
     agentTools: {workflows: workflowsClient},
@@ -171,6 +116,7 @@ export async function defaultModules(
     definitionsModule,
     createWorkflowsModule({
       annotations: annotationsClient,
+      agent: agentClient,
       definitions: definitionsClient,
       auth: authClient,
       projects: projectsClient,

--- a/libs/api/server/src/modules.ts
+++ b/libs/api/server/src/modules.ts
@@ -62,19 +62,76 @@ export async function defaultModules(
     secrets: {
       deleteSecrets: async (params) => (await secretsClient.deleteSecrets(params)).deleted,
       linear: {
-        getSecret: async (params) => (await secretsClient.getSecret({...params, namespace: `system/integrations/linear/${params.namespace}`})).value,
-        setSecrets: async (params) => { const {editedBy, ...secretParams} = params; await secretsClient.setSecrets({...secretParams, namespace: `system/integrations/linear/${secretParams.namespace}`, ...(editedBy === undefined ? {} : {editedBy})}); },
-        deleteSecrets: async (params) => (await secretsClient.deleteSecrets({...params, namespace: `system/integrations/linear/${params.namespace}`})).deleted,
+        getSecret: async (params) =>
+          (
+            await secretsClient.getSecret({
+              ...params,
+              namespace: `system/integrations/linear/${params.namespace}`,
+            })
+          ).value,
+        setSecrets: async (params) => {
+          const {editedBy, ...secretParams} = params;
+          await secretsClient.setSecrets({
+            ...secretParams,
+            namespace: `system/integrations/linear/${secretParams.namespace}`,
+            ...(editedBy === undefined ? {} : {editedBy}),
+          });
+        },
+        deleteSecrets: async (params) =>
+          (
+            await secretsClient.deleteSecrets({
+              ...params,
+              namespace: `system/integrations/linear/${params.namespace}`,
+            })
+          ).deleted,
       },
       jira: {
-        getSecret: async (params) => (await secretsClient.getSecret({...params, namespace: `system/integrations/jira/${params.namespace}`})).value,
-        setSecrets: async (params) => { const {editedBy, ...secretParams} = params; await secretsClient.setSecrets({...secretParams, namespace: `system/integrations/jira/${secretParams.namespace}`, ...(editedBy === undefined ? {} : {editedBy})}); },
-        deleteSecrets: async (params) => (await secretsClient.deleteSecrets({...params, namespace: `system/integrations/jira/${params.namespace}`})).deleted,
+        getSecret: async (params) =>
+          (
+            await secretsClient.getSecret({
+              ...params,
+              namespace: `system/integrations/jira/${params.namespace}`,
+            })
+          ).value,
+        setSecrets: async (params) => {
+          const {editedBy, ...secretParams} = params;
+          await secretsClient.setSecrets({
+            ...secretParams,
+            namespace: `system/integrations/jira/${secretParams.namespace}`,
+            ...(editedBy === undefined ? {} : {editedBy}),
+          });
+        },
+        deleteSecrets: async (params) =>
+          (
+            await secretsClient.deleteSecrets({
+              ...params,
+              namespace: `system/integrations/jira/${params.namespace}`,
+            })
+          ).deleted,
       },
       slack: {
-        getSecret: async (params) => (await secretsClient.getSecret({...params, namespace: `system/integrations/slack/${params.namespace}`})).value,
-        setSecrets: async (params) => { const {editedBy, ...secretParams} = params; await secretsClient.setSecrets({...secretParams, namespace: `system/integrations/slack/${secretParams.namespace}`, ...(editedBy === undefined ? {} : {editedBy})}); },
-        deleteSecrets: async (params) => (await secretsClient.deleteSecrets({...params, namespace: `system/integrations/slack/${params.namespace}`})).deleted,
+        getSecret: async (params) =>
+          (
+            await secretsClient.getSecret({
+              ...params,
+              namespace: `system/integrations/slack/${params.namespace}`,
+            })
+          ).value,
+        setSecrets: async (params) => {
+          const {editedBy, ...secretParams} = params;
+          await secretsClient.setSecrets({
+            ...secretParams,
+            namespace: `system/integrations/slack/${secretParams.namespace}`,
+            ...(editedBy === undefined ? {} : {editedBy}),
+          });
+        },
+        deleteSecrets: async (params) =>
+          (
+            await secretsClient.deleteSecrets({
+              ...params,
+              namespace: `system/integrations/slack/${params.namespace}`,
+            })
+          ).deleted,
       },
     },
     agentTools: {workflows: workflowsClient},

--- a/libs/api/workflows/package.json
+++ b/libs/api/workflows/package.json
@@ -41,7 +41,6 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
-    "@shipfox/api-agent": "workspace:*",
     "@shipfox/api-auth-context": "workspace:*",
     "@shipfox/api-auth-dto": "workspace:*",
     "@shipfox/api-agent-dto": "workspace:*",
@@ -72,6 +71,7 @@
   "devDependencies": {
     "@shipfox/annotations": "workspace:*",
     "@shipfox/api-auth": "workspace:*",
+    "@shipfox/api-agent": "workspace:*",
     "@shipfox/api-definitions": "workspace:*",
     "@shipfox/biome": "workspace:*",
     "@shipfox/depcruise": "workspace:*",

--- a/libs/api/workflows/src/core/agent-defaults.test.ts
+++ b/libs/api/workflows/src/core/agent-defaults.test.ts
@@ -1,0 +1,28 @@
+import type {AgentInterModuleClient} from '@shipfox/api-agent-dto/inter-module';
+import {createAgentDefaultsResolver} from './agent-defaults.js';
+
+describe('createAgentDefaultsResolver', () => {
+  test('omits unresolved optional fields from the inter-module input', async () => {
+    const resolveAgentConfig = vi.fn().mockResolvedValue({
+      harness: 'pi',
+      provider: 'anthropic',
+      model: 'claude-opus-4-8',
+      thinking: 'xhigh',
+    });
+    const agent = {resolveAgentConfig} as unknown as AgentInterModuleClient;
+    const resolve = createAgentDefaultsResolver(agent, crypto.randomUUID());
+
+    const defaults = await resolve({});
+
+    expect(defaults).toEqual({
+      harness: 'pi',
+      provider: 'anthropic',
+      model: 'claude-opus-4-8',
+      thinking: 'xhigh',
+    });
+    expect(resolveAgentConfig).toHaveBeenCalledWith({
+      workspaceId: expect.any(String),
+      config: {},
+    });
+  });
+});

--- a/libs/api/workflows/src/core/agent-defaults.ts
+++ b/libs/api/workflows/src/core/agent-defaults.ts
@@ -1,0 +1,27 @@
+import type {AgentThinking, Harness, ModelProviderRef} from '@shipfox/api-agent-dto';
+import type {AgentInterModuleClient} from '@shipfox/api-agent-dto/inter-module';
+
+export interface AgentDefaultsInput {
+  readonly harness?: Harness | undefined;
+  readonly provider?: ModelProviderRef | undefined;
+  readonly model?: string | undefined;
+  readonly thinking?: AgentThinking | undefined;
+}
+
+export interface ResolvedAgentDefaults {
+  readonly harness: Harness;
+  readonly provider: ModelProviderRef;
+  readonly model: string;
+  readonly thinking: AgentThinking;
+}
+
+export type AgentDefaultsResolver = (
+  input: AgentDefaultsInput,
+) => ResolvedAgentDefaults | Promise<ResolvedAgentDefaults>;
+
+export function createAgentDefaultsResolver(
+  agent: AgentInterModuleClient,
+  workspaceId: string | null,
+): AgentDefaultsResolver {
+  return async (config) => await agent.resolveAgentConfig({workspaceId, config});
+}

--- a/libs/api/workflows/src/core/agent-defaults.ts
+++ b/libs/api/workflows/src/core/agent-defaults.ts
@@ -23,5 +23,14 @@ export function createAgentDefaultsResolver(
   agent: AgentInterModuleClient,
   workspaceId: string | null,
 ): AgentDefaultsResolver {
-  return async (config) => await agent.resolveAgentConfig({workspaceId, config});
+  return async (config) =>
+    await agent.resolveAgentConfig({
+      workspaceId,
+      config: {
+        ...(config.harness === undefined ? {} : {harness: config.harness}),
+        ...(config.provider === undefined ? {} : {provider: config.provider}),
+        ...(config.model === undefined ? {} : {model: config.model}),
+        ...(config.thinking === undefined ? {} : {thinking: config.thinking}),
+      },
+    });
 }

--- a/libs/api/workflows/src/core/job-execution.ts
+++ b/libs/api/workflows/src/core/job-execution.ts
@@ -1,4 +1,4 @@
-import {catalogDefaultAgentResolver} from '@shipfox/api-agent/core/resolve-agent-config';
+import type {AgentInterModuleClient} from '@shipfox/api-agent-dto/inter-module';
 import type {LogOutcomeDto} from '@shipfox/api-workflows-dto';
 import {
   coerceStepOutputs,
@@ -26,6 +26,7 @@ import {
   recordWorkflowJobExecutionStepsSettled,
   recordWorkflowStepRestartEnqueued,
 } from '#metrics/instance.js';
+import {createAgentDefaultsResolver} from './agent-defaults.js';
 import {defaultStepConditionTrace, explicitConditionTrace} from './condition-trace.js';
 import type {JobExecution} from './entities/job-execution.js';
 import type {PersistedEvaluationTraceEntry, Step, StepStatusReason} from './entities/step.js';
@@ -83,6 +84,7 @@ interface PendingStepDispatchParams {
   readonly jobExecution: JobExecution;
   readonly context: WorkflowEvaluationContext;
   readonly tx: Tx;
+  readonly agent?: AgentInterModuleClient | undefined;
 }
 
 interface ResolvePendingStepParams {
@@ -92,6 +94,7 @@ interface ResolvePendingStepParams {
   readonly attempts: Awaited<ReturnType<typeof getStepAttemptsByJobExecutionId>>;
   readonly jobs: Awaited<ReturnType<typeof getDirectDependencyJobContexts>>;
   readonly tx: Tx;
+  readonly agent?: AgentInterModuleClient | undefined;
 }
 
 type StepConditionOutcome =
@@ -105,6 +108,7 @@ type StepConditionOutcome =
 async function nextStepForJobExecutionInTransaction(
   jobExecutionId: string,
   tx: Tx,
+  agent?: AgentInterModuleClient | undefined,
 ): Promise<NextStep> {
   const steps = await getStepsByJobExecutionIdForUpdate(jobExecutionId, tx);
   const hasNoSteps = steps.length === 0;
@@ -129,7 +133,7 @@ async function nextStepForJobExecutionInTransaction(
   const attempts = await getStepAttemptsByJobExecutionId(jobExecutionId, tx);
   const jobs = await getDirectDependencyJobContexts(jobExecution.jobId, tx);
 
-  return resolveNextPendingStep({jobExecutionId, steps, jobExecution, attempts, jobs, tx});
+  return resolveNextPendingStep({jobExecutionId, steps, jobExecution, attempts, jobs, tx, agent});
 }
 
 async function resolveNextPendingStep({
@@ -139,6 +143,7 @@ async function resolveNextPendingStep({
   attempts,
   jobs,
   tx,
+  agent,
 }: ResolvePendingStepParams): Promise<NextStep> {
   let skippedAny = false;
   let currentSteps = steps;
@@ -167,7 +172,7 @@ async function resolveNextPendingStep({
     });
     const condition = evaluateStepCondition({step: pending, context});
     if (condition.kind === 'run') {
-      return dispatchPendingStep({jobExecutionId, pending, jobExecution, context, tx});
+      return dispatchPendingStep({jobExecutionId, pending, jobExecution, context, tx, agent});
     }
 
     const skipped = await markStepSkipped(
@@ -208,12 +213,13 @@ async function dispatchPendingStepWithConfigPlan({
   jobExecution,
   context,
   tx,
+  agent,
 }: PendingStepDispatchParams): Promise<NextStep> {
   try {
-    const completed = completeStepDispatchConfig({
+    const completed = await completeStepDispatchConfig({
       step: pending,
       context,
-      resolveAgentDefaults: catalogDefaultAgentResolver,
+      resolveAgentDefaults: agent ? createAgentDefaultsResolver(agent, null) : undefined,
       definitionId: jobExecution.jobId,
     });
     const marked = await dispatchStepWithCompletedConfig(
@@ -258,7 +264,7 @@ async function dispatchPendingStepWithConfigPlan({
     });
     if (status) recordWorkflowJobExecutionStepsSettled(status);
     return status === null
-      ? nextStepForJobExecutionInTransaction(jobExecutionId, tx)
+      ? nextStepForJobExecutionInTransaction(jobExecutionId, tx, agent)
       : {kind: 'done', status};
   }
 }
@@ -333,6 +339,7 @@ export interface NextStepForLeasedJobExecutionParams {
   jobId: string;
   jobExecutionId: string;
   runnerSessionId: string;
+  agent?: AgentInterModuleClient | undefined;
 }
 
 export function nextStepForLeasedJobExecution(
@@ -342,16 +349,19 @@ export function nextStepForLeasedJobExecution(
     const leaseIsActive = await lockActiveJobExecutionLeaseForUpdate(params, tx);
     if (!leaseIsActive) throw new JobLeaseNotActiveError(params.jobExecutionId);
 
-    return nextStepForJobExecutionInTransaction(params.jobExecutionId, tx);
+    return nextStepForJobExecutionInTransaction(params.jobExecutionId, tx, params.agent);
   });
 }
 
-export function nextStepForJob(jobId: string): Promise<NextStep> {
+export function nextStepForJob(
+  jobId: string,
+  agent?: AgentInterModuleClient | undefined,
+): Promise<NextStep> {
   return withTransaction(async (tx) => {
     const jobExecution = await getLatestJobExecutionByJobId(jobId, tx);
     if (!jobExecution) throw new JobNotFoundError(jobId);
 
-    return nextStepForJobExecutionInTransaction(jobExecution.id, tx);
+    return nextStepForJobExecutionInTransaction(jobExecution.id, tx, agent);
   });
 }
 

--- a/libs/api/workflows/src/core/listener-execution-materialization.test.ts
+++ b/libs/api/workflows/src/core/listener-execution-materialization.test.ts
@@ -1,8 +1,9 @@
+import {resolveTestAgentDefaults} from '#test/fixtures/agent-inter-module.js';
 import {workflowModel} from '#test/index.js';
 import {materializeListenerExecution} from './listener-execution-materialization.js';
 
 describe('materializeListenerExecution', () => {
-  it('fails cleanly when agent integration materialization is unresolvable', () => {
+  it('fails cleanly when agent integration materialization is unresolvable', async () => {
     const model = workflowModel({
       jobs: {
         review: {
@@ -16,7 +17,7 @@ describe('materializeListenerExecution', () => {
       },
     });
 
-    const result = materializeListenerExecution({
+    const result = await materializeListenerExecution({
       model,
       run: {
         id: crypto.randomUUID(),
@@ -37,6 +38,7 @@ describe('materializeListenerExecution', () => {
       sequence: 1,
       triggerEvents: [],
       priorExecutions: [],
+      resolveAgentDefaults: resolveTestAgentDefaults,
     });
 
     expect(result).toMatchObject({

--- a/libs/api/workflows/src/core/listener-execution-materialization.ts
+++ b/libs/api/workflows/src/core/listener-execution-materialization.ts
@@ -1,8 +1,5 @@
-import {
-  type AgentDefaultsResolver,
-  catalogDefaultAgentResolver,
-} from '@shipfox/api-agent/core/resolve-agent-config';
-import type {WorkflowModel} from '@shipfox/api-definitions-dto';
+import type {WorkflowModel} from '@shipfox/api-definitions';
+import type {AgentDefaultsResolver} from './agent-defaults.js';
 import type {
   AgentToolMaterializationContext,
   AgentToolMaterializationSnapshot,
@@ -61,9 +58,9 @@ export interface MaterializedListenerExecution {
   readonly steps: readonly MaterializedWorkflowStep[];
 }
 
-export function materializeListenerExecution(
+export async function materializeListenerExecution(
   params: MaterializeListenerExecutionParams,
-): MaterializedListenerExecution {
+): Promise<MaterializedListenerExecution> {
   const fallbackName = `${params.job.key} #${params.sequence}`;
   let executionName = fallbackName;
   let evaluationTrace: readonly PersistedEvaluationTraceEntry[] = [];
@@ -95,11 +92,11 @@ export function materializeListenerExecution(
       context,
       definitionId: params.run.definitionId,
     });
-    steps = materializeJobExecutionSteps({
+    steps = await materializeJobExecutionSteps({
       model: params.model,
       job: modelJob,
       context,
-      resolveAgentDefaults: params.resolveAgentDefaults ?? catalogDefaultAgentResolver,
+      resolveAgentDefaults: params.resolveAgentDefaults,
       definitionId: params.run.definitionId,
       agentToolContext: params.agentToolContext,
       agentToolSnapshot: params.agentToolSnapshot,

--- a/libs/api/workflows/src/core/run-workflow.test.ts
+++ b/libs/api/workflows/src/core/run-workflow.test.ts
@@ -119,7 +119,7 @@ describe('runWorkflow', () => {
     expect(run.triggerSource).toBe('manual');
     expect(run.triggerEvent).toBe('fire');
     expect(run.triggerPayload).toEqual(triggerPayload);
-    expect(mockResolveAgentConfig).toHaveBeenCalledWith({workspaceId: null, config: {}});
+    expect(mockResolveAgentConfig).not.toHaveBeenCalled();
   });
 
   test('builds the workspace agent resolver only when the definition has an agent step', async () => {

--- a/libs/api/workflows/src/core/run-workflow.test.ts
+++ b/libs/api/workflows/src/core/run-workflow.test.ts
@@ -1,13 +1,14 @@
-import {createWorkflowModelSnapshot, type WorkflowModel} from '@shipfox/api-definitions-dto';
+import type {AgentInterModuleClient} from '@shipfox/api-agent-dto/inter-module';
+import type {WorkflowDefinition} from '@shipfox/api-definitions';
+import {createWorkflowModelSnapshot} from '@shipfox/api-definitions-dto';
 import type {DefinitionsInterModuleClient} from '@shipfox/api-definitions-dto/inter-module';
 import {workflowModel} from '#test/index.js';
 import type {TriggerPayload} from './entities/workflow-run.js';
 import {DefinitionNotFoundError, ProjectMismatchError} from './errors.js';
 import {runWorkflow} from './run-workflow.js';
 
-const mockCreateWorkspaceAgentDefaultsResolver = vi.hoisted(() => vi.fn());
-const mockWorkspaceAgentDefaultsResolver = vi.hoisted(() =>
-  vi.fn().mockReturnValue({
+const mockResolveAgentConfig = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
     harness: 'pi',
     provider: 'openai',
     model: 'gpt-5.5-pro',
@@ -15,48 +16,21 @@ const mockWorkspaceAgentDefaultsResolver = vi.hoisted(() =>
   }),
 );
 
-vi.mock('@shipfox/api-agent/core/resolve-agent-config', () => {
-  return {
-    catalogDefaultAgentResolver: vi.fn().mockReturnValue({
-      harness: 'pi',
-      provider: 'anthropic',
-      model: 'claude-opus-4-8',
-      thinking: 'xhigh',
-    }),
-  };
-});
+vi.mock('@shipfox/api-definitions', () => ({
+  DEFAULT_JOB_CHECKOUT: {
+    permissions: {contents: 'read'},
+    persistCredentials: true,
+  },
+  getDefinitionById: vi.fn(),
+}));
 
-vi.mock('@shipfox/api-agent/core/workspace-agent-defaults-resolver', () => {
-  return {
-    createWorkspaceAgentDefaultsResolver: mockCreateWorkspaceAgentDefaultsResolver,
-  };
-});
+import {getDefinitionById} from '@shipfox/api-definitions';
 
-function buildDefinition(
-  overrides?: Partial<{
-    id: string;
-    projectId: string;
-    name: string;
-    model: WorkflowModel;
-    sourceSnapshot: {content: string; format: 'yaml'} | null;
-  }>,
-) {
-  const model = workflowModel();
-  return {
-    id: crypto.randomUUID(),
-    projectId: crypto.randomUUID(),
-    name: 'Test Workflow',
-    model,
-    sourceSnapshot: null,
-    ...overrides,
-  };
-}
-
-function definitionsClient(
-  definition: ReturnType<typeof buildDefinition> | undefined,
-): DefinitionsInterModuleClient {
-  return {
-    getDefinitionForWorkflowRun: vi.fn().mockResolvedValue({
+const mockGetDefinitionById = vi.mocked(getDefinitionById);
+const definitions: DefinitionsInterModuleClient = {
+  getDefinitionForWorkflowRun: async ({definitionId}) => {
+    const definition = await mockGetDefinitionById(definitionId);
+    return {
       definition:
         definition === undefined
           ? null
@@ -67,7 +41,36 @@ function definitionsClient(
               model: createWorkflowModelSnapshot(definition.model),
               sourceSnapshot: definition.sourceSnapshot,
             },
-    }),
+    };
+  },
+};
+
+function buildDefinition(overrides?: Partial<WorkflowDefinition>): WorkflowDefinition {
+  const model = workflowModel();
+  const document = {
+    name: model.name,
+    jobs: {
+      build: {steps: [{run: 'echo hello'}]},
+    },
+  };
+  return {
+    id: crypto.randomUUID(),
+    projectId: crypto.randomUUID(),
+    configPath: '.shipfox/workflows/test.yml',
+    source: 'manual',
+    sha: null,
+    ref: null,
+    name: 'Test Workflow',
+    definition: document,
+    document,
+    model,
+    sourceSnapshot: null,
+    contentHash: null,
+    fetchedAt: new Date(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+    ...overrides,
   };
 }
 
@@ -83,24 +86,28 @@ function manualPayload(): TriggerPayload {
 describe('runWorkflow', () => {
   let workspaceId: string;
   let projectId: string;
+  const agent: AgentInterModuleClient = {
+    resolveAgentConfig: mockResolveAgentConfig,
+    resolveRuntimeCredentials: vi.fn(),
+  };
 
   beforeEach(() => {
     workspaceId = crypto.randomUUID();
     projectId = crypto.randomUUID();
-    mockCreateWorkspaceAgentDefaultsResolver.mockClear();
-    mockCreateWorkspaceAgentDefaultsResolver.mockResolvedValue(mockWorkspaceAgentDefaultsResolver);
-    mockWorkspaceAgentDefaultsResolver.mockClear();
+    mockResolveAgentConfig.mockClear();
   });
 
   test('creates a run from a valid definition with the provided manual trigger payload', async () => {
     const definition = buildDefinition({projectId});
+    mockGetDefinitionById.mockResolvedValue(definition);
     const triggerPayload = manualPayload();
 
-    const run = await runWorkflow(definitionsClient(definition), {
+    const run = await runWorkflow(definitions, {
       workspaceId,
       projectId,
       definitionId: definition.id,
       triggerPayload,
+      agent,
     });
 
     expect(run.id).toBeDefined();
@@ -112,7 +119,7 @@ describe('runWorkflow', () => {
     expect(run.triggerSource).toBe('manual');
     expect(run.triggerEvent).toBe('fire');
     expect(run.triggerPayload).toEqual(triggerPayload);
-    expect(mockCreateWorkspaceAgentDefaultsResolver).not.toHaveBeenCalled();
+    expect(mockResolveAgentConfig).toHaveBeenCalledWith({workspaceId: null, config: {}});
   });
 
   test('builds the workspace agent resolver only when the definition has an agent step', async () => {
@@ -122,26 +129,23 @@ describe('runWorkflow', () => {
       },
     });
     const definition = buildDefinition({projectId, model});
+    mockGetDefinitionById.mockResolvedValue(definition);
 
-    const run = await runWorkflow(definitionsClient(definition), {
+    const run = await runWorkflow(definitions, {
       workspaceId,
       projectId,
       definitionId: definition.id,
       triggerPayload: manualPayload(),
+      agent,
     });
 
     expect(run.id).toBeDefined();
-    expect(mockCreateWorkspaceAgentDefaultsResolver).toHaveBeenCalledWith(workspaceId);
-    expect(mockWorkspaceAgentDefaultsResolver).toHaveBeenCalledWith({
-      harness: undefined,
-      provider: undefined,
-      model: undefined,
-      thinking: undefined,
-    });
+    expect(mockResolveAgentConfig).toHaveBeenCalledWith({workspaceId, config: {}});
   });
 
   test('persists an integration trigger payload intact', async () => {
     const definition = buildDefinition({projectId});
+    mockGetDefinitionById.mockResolvedValue(definition);
     const triggerPayload: TriggerPayload = {
       provider: 'github',
       source: 'github_acme',
@@ -150,11 +154,12 @@ describe('runWorkflow', () => {
       data: {ref: 'main', headCommitSha: 'abc', externalRepositoryId: 'github:1'},
     };
 
-    const run = await runWorkflow(definitionsClient(definition), {
+    const run = await runWorkflow(definitions, {
       workspaceId,
       projectId,
       definitionId: definition.id,
       triggerPayload,
+      agent,
     });
 
     expect(run.triggerProvider).toBe('github');
@@ -166,26 +171,31 @@ describe('runWorkflow', () => {
   test('creates the run with the definition source snapshot', async () => {
     const sourceSnapshot = {content: 'name: Test Workflow\njobs: {}\n', format: 'yaml'} as const;
     const definition = buildDefinition({projectId, sourceSnapshot});
+    mockGetDefinitionById.mockResolvedValue(definition);
 
-    const run = await runWorkflow(definitionsClient(definition), {
+    const run = await runWorkflow(definitions, {
       workspaceId,
       projectId,
       definitionId: definition.id,
       triggerPayload: manualPayload(),
+      agent,
     });
 
     expect(run.sourceSnapshot).toEqual(sourceSnapshot);
   });
 
   test('throws DefinitionNotFoundError for unknown definition', async () => {
+    mockGetDefinitionById.mockResolvedValue(undefined);
+
     const unknownId = crypto.randomUUID();
 
     await expect(
-      runWorkflow(definitionsClient(undefined), {
+      runWorkflow(definitions, {
         workspaceId,
         projectId,
         definitionId: unknownId,
         triggerPayload: manualPayload(),
+        agent,
       }),
     ).rejects.toThrow(DefinitionNotFoundError);
   });
@@ -193,23 +203,29 @@ describe('runWorkflow', () => {
   test('throws ProjectMismatchError when definition.projectId does not match', async () => {
     const otherProjectId = crypto.randomUUID();
     const definition = buildDefinition({projectId: otherProjectId});
+    mockGetDefinitionById.mockResolvedValue(definition);
+
     await expect(
-      runWorkflow(definitionsClient(definition), {
+      runWorkflow(definitions, {
         workspaceId,
         projectId,
         definitionId: definition.id,
         triggerPayload: manualPayload(),
+        agent,
       }),
     ).rejects.toThrow(ProjectMismatchError);
   });
 
   test('passes inputs through to the run', async () => {
     const definition = buildDefinition({projectId});
-    const run = await runWorkflow(definitionsClient(definition), {
+    mockGetDefinitionById.mockResolvedValue(definition);
+
+    const run = await runWorkflow(definitions, {
       workspaceId,
       projectId,
       definitionId: definition.id,
       triggerPayload: manualPayload(),
+      agent,
       inputs: {env: 'staging'},
     });
 

--- a/libs/api/workflows/src/core/run-workflow.ts
+++ b/libs/api/workflows/src/core/run-workflow.ts
@@ -1,9 +1,9 @@
-import {catalogDefaultAgentResolver} from '@shipfox/api-agent/core/resolve-agent-config';
-import {createWorkspaceAgentDefaultsResolver} from '@shipfox/api-agent/core/workspace-agent-defaults-resolver';
+import type {AgentInterModuleClient} from '@shipfox/api-agent-dto/inter-module';
 import {workflowModelFromSnapshot} from '@shipfox/api-definitions-dto';
 import type {DefinitionsInterModuleClient} from '@shipfox/api-definitions-dto/inter-module';
 import type {SecretsInterModuleClient} from '@shipfox/api-secrets-dto/inter-module';
 import {createWorkflowRun} from '#db/workflow-runs.js';
+import {createAgentDefaultsResolver} from './agent-defaults.js';
 import type {TriggerPayload, WorkflowRun} from './entities/workflow-run.js';
 import {DefinitionNotFoundError, ProjectMismatchError} from './errors.js';
 import {modelHasAgentStep} from './step-config/materialize-workflow-model.js';
@@ -19,7 +19,7 @@ export interface RunWorkflowParams {
 
 export async function runWorkflow(
   definitions: DefinitionsInterModuleClient,
-  params: RunWorkflowParams,
+  params: RunWorkflowParams & {agent: AgentInterModuleClient},
   options: {secrets?: Pick<SecretsInterModuleClient, 'getVariablesByNamespace'>} = {},
 ): Promise<WorkflowRun> {
   const {definition} = await definitions.getDefinitionForWorkflowRun({
@@ -31,9 +31,10 @@ export async function runWorkflow(
     throw new ProjectMismatchError(definition.projectId, params.projectId);
   }
   const model = workflowModelFromSnapshot(definition.model);
-  const resolveAgentDefaults = modelHasAgentStep(model)
-    ? await createWorkspaceAgentDefaultsResolver(params.workspaceId)
-    : catalogDefaultAgentResolver;
+  const resolveAgentDefaults = createAgentDefaultsResolver(
+    params.agent,
+    modelHasAgentStep(model) ? params.workspaceId : null,
+  );
 
   return createWorkflowRun({
     workspaceId: params.workspaceId,

--- a/libs/api/workflows/src/core/step-config/agent.ts
+++ b/libs/api/workflows/src/core/step-config/agent.ts
@@ -1,11 +1,4 @@
 import {
-  InvalidAgentModelError,
-  UnsupportedHarnessProviderError,
-  UnsupportedHarnessThinkingError,
-  UnsupportedModelProviderError,
-} from '@shipfox/api-agent/core/errors';
-import type {AgentDefaultsResolver} from '@shipfox/api-agent/core/resolve-agent-config';
-import {
   AGENT_INTEGRATION_MCP_AUTH,
   AGENT_INTEGRATION_MCP_ENDPOINT,
   AGENT_INTEGRATION_MCP_SERVER_NAME,
@@ -14,8 +7,11 @@ import {
   type AgentThinking,
   type MaterializedAgentIntegrationConfigDto,
 } from '@shipfox/api-agent-dto';
-import type {WorkflowModel} from '@shipfox/api-definitions-dto';
+import {agentInterModuleContract} from '@shipfox/api-agent-dto/inter-module';
+import type {WorkflowModel} from '@shipfox/api-definitions';
 import type {ResolvedField, SiteResolvedField} from '@shipfox/expression';
+import {isInterModuleKnownError} from '@shipfox/inter-module';
+import type {AgentDefaultsResolver, ResolvedAgentDefaults} from '#core/agent-defaults.js';
 import {
   type AgentToolMaterializationContext,
   type AgentToolMaterializationSnapshot,
@@ -55,7 +51,7 @@ export interface ResolveAgentStepConfigParams {
   readonly context: WorkflowEvaluationContext;
   readonly mode: StepConfigMode;
   readonly definitionId: string;
-  readonly resolveAgentDefaults: AgentDefaultsResolver;
+  readonly resolveAgentDefaults?: AgentDefaultsResolver | undefined;
   readonly agentToolContext?: AgentToolMaterializationContext | undefined;
   readonly agentToolSnapshot?: AgentToolMaterializationSnapshot | null | undefined;
 }
@@ -68,7 +64,9 @@ export interface AgentStepConfig {
   readonly hasTemplates: boolean;
 }
 
-export function resolveAgentStepConfig(params: ResolveAgentStepConfigParams): AgentStepConfig {
+export async function resolveAgentStepConfig(
+  params: ResolveAgentStepConfigParams,
+): Promise<AgentStepConfig> {
   const fields = resolveAgentFields(params);
   const usesAuthoredMode = params.mode === 'authored';
 
@@ -78,17 +76,17 @@ export function resolveAgentStepConfig(params: ResolveAgentStepConfigParams): Ag
     fields.model?.kind === 'residual' || fields.provider?.kind === 'residual';
   if (hasDeferredModelOrProvider) return deferredAgentStepConfig(params, fields);
 
-  return agentStepConfigWithDefaults(params.step, params, fields);
+  return await agentStepConfigWithDefaults(params.step, params, fields);
 }
 
-export function completeAgentConfig(params: {
+export async function completeAgentConfig(params: {
   readonly config: Record<string, unknown>;
   readonly plan: StepConfigDispatchPlan;
   readonly context: WorkflowEvaluationContext;
-  readonly resolveAgentDefaults: AgentDefaultsResolver;
+  readonly resolveAgentDefaults?: AgentDefaultsResolver | undefined;
   readonly definitionId: string;
   readonly trace: PersistedEvaluationTraceEntry[];
-}): void {
+}): Promise<void> {
   const agent = params.plan.agent;
   if (agent === undefined) return;
 
@@ -117,7 +115,7 @@ export function completeAgentConfig(params: {
           params,
         });
 
-  const defaults = completeAgentDefaults({
+  const defaults = await completeAgentDefaults({
     harness: agent.harness ?? readConfigHarness(params.config),
     provider,
     model,
@@ -159,16 +157,18 @@ function completeAgentField(args: {
   return resolved.value;
 }
 
-export function completeAgentDefaults(params: {
+export async function completeAgentDefaults(params: {
   readonly harness: WorkflowModelAgentStep['harness'] | undefined;
   readonly provider: string | undefined;
   readonly model: string | undefined;
   readonly thinking: AgentThinking | undefined;
-  readonly resolveAgentDefaults: AgentDefaultsResolver;
+  readonly resolveAgentDefaults?: AgentDefaultsResolver | undefined;
   readonly definitionId: string;
-}): ReturnType<AgentDefaultsResolver> {
+}): Promise<ResolvedAgentDefaults> {
+  if (!params.resolveAgentDefaults) throw new Error('Agent defaults resolver is required');
+
   try {
-    return params.resolveAgentDefaults({
+    return await params.resolveAgentDefaults({
       harness: params.harness,
       provider: params.provider,
       model: params.model,
@@ -176,10 +176,8 @@ export function completeAgentDefaults(params: {
     });
   } catch (error) {
     if (
-      error instanceof UnsupportedModelProviderError ||
-      error instanceof UnsupportedHarnessProviderError ||
-      error instanceof UnsupportedHarnessThinkingError ||
-      error instanceof InvalidAgentModelError
+      isInterModuleKnownError(agentInterModuleContract.methods.resolveAgentConfig, error) &&
+      error.code === 'agent-config-invalid'
     ) {
       throw new AgentConfigUnresolvableError(params.definitionId, {cause: error});
     }
@@ -273,16 +271,16 @@ function deferredAgentStepConfig(
   };
 }
 
-function agentStepConfigWithDefaults(
+async function agentStepConfigWithDefaults(
   step: WorkflowModelAgentStep,
   params: ResolveAgentStepConfigParams,
   fields: AgentFieldResolutions,
-): AgentStepConfig {
+): Promise<AgentStepConfig> {
   const providerValue = frozenFieldValue(fields.provider);
   const modelValue = frozenFieldValue(fields.model);
   const promptIsDeferred = fields.prompt.kind === 'residual';
 
-  const resolved = completeAgentDefaults({
+  const resolved = await completeAgentDefaults({
     harness: step.harness,
     provider: providerValue,
     model: modelValue,

--- a/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
+++ b/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
@@ -1,5 +1,3 @@
-import {UnsupportedHarnessThinkingError} from '@shipfox/api-agent/core/errors';
-import type {AgentDefaultsResolver} from '@shipfox/api-agent/core/resolve-agent-config';
 import {
   AGENT_INTEGRATION_MCP_AUTH,
   AGENT_INTEGRATION_MCP_ENDPOINT,
@@ -8,7 +6,10 @@ import {
   type AgentIntegrationMcpServerConfigDto,
   type MaterializedAgentIntegrationConfigDto,
 } from '@shipfox/api-agent-dto';
+import {agentInterModuleContract} from '@shipfox/api-agent-dto/inter-module';
 import {parseWorkflowTemplate, planInterpolationField} from '@shipfox/expression';
+import {createInterModuleKnownError} from '@shipfox/inter-module';
+import type {AgentDefaultsResolver} from '#core/agent-defaults.js';
 import type {Step} from '#core/entities/step.js';
 import {AgentConfigUnresolvableError, InterpolationUnresolvableError} from '#core/errors.js';
 import {completeStepDispatchConfig} from './complete-step-dispatch-config.js';
@@ -112,7 +113,7 @@ function integrationMcpServers(
 }
 
 describe('completeStepDispatchConfig', () => {
-  it('copies frozen agent integrations from the dispatch plan', () => {
+  it('copies frozen agent integrations from the dispatch plan', async () => {
     const integrations = [materializedIntegration()];
     const pending = step({
       type: 'agent',
@@ -130,7 +131,7 @@ describe('completeStepDispatchConfig', () => {
       },
     });
 
-    const result = completeStepDispatchConfig({
+    const result = await completeStepDispatchConfig({
       step: pending,
       context,
       resolveAgentDefaults,
@@ -141,7 +142,7 @@ describe('completeStepDispatchConfig', () => {
     expect(result.config.mcpServers).toEqual(integrationMcpServers(integrations));
   });
 
-  it('serializes residual secret env values as secret bindings without writing env values', () => {
+  it('serializes residual secret env values as secret bindings without writing env values', async () => {
     const pending = step({
       config: {},
       configPlan: {
@@ -152,7 +153,7 @@ describe('completeStepDispatchConfig', () => {
       },
     });
 
-    const result = completeStepDispatchConfig({
+    const result = await completeStepDispatchConfig({
       step: pending,
       context,
       resolveAgentDefaults,
@@ -196,7 +197,7 @@ describe('completeStepDispatchConfig', () => {
     ]);
   });
 
-  it('rejects secret env bindings with malformed target names', () => {
+  it('rejects secret env bindings with malformed target names', async () => {
     const pending = step({
       config: {},
       configPlan: {
@@ -214,10 +215,10 @@ describe('completeStepDispatchConfig', () => {
         definitionId: 'def-1',
       });
 
-    expect(act).toThrow();
+    await expect(act()).rejects.toThrow();
   });
 
-  it('keeps fully resolved step config byte-identical apart from resolved env additions', () => {
+  it('keeps fully resolved step config byte-identical apart from resolved env additions', async () => {
     const pending = step({
       config: {run: 'echo "$SHA"'},
       configPlan: {
@@ -227,7 +228,7 @@ describe('completeStepDispatchConfig', () => {
       },
     });
 
-    const result = completeStepDispatchConfig({
+    const result = await completeStepDispatchConfig({
       step: pending,
       context,
       resolveAgentDefaults,
@@ -250,7 +251,7 @@ describe('completeStepDispatchConfig', () => {
     });
   });
 
-  it('completes deferred agent config with the resolved harness', () => {
+  it('completes deferred agent config with the resolved harness', async () => {
     const integration = materializedIntegration();
     const mcpServers = integrationMcpServers([integration]);
     const pending = step({
@@ -267,7 +268,7 @@ describe('completeStepDispatchConfig', () => {
       },
     });
 
-    const result = completeStepDispatchConfig({
+    const result = await completeStepDispatchConfig({
       step: pending,
       context,
       resolveAgentDefaults,
@@ -298,7 +299,7 @@ describe('completeStepDispatchConfig', () => {
     });
   });
 
-  it('wraps harness resolver errors as unresolvable agent config', () => {
+  it('wraps harness resolver errors as unresolvable agent config', async () => {
     const pending = step({
       type: 'agent',
       config: {},
@@ -311,13 +312,11 @@ describe('completeStepDispatchConfig', () => {
       },
     });
     const failingResolver: AgentDefaultsResolver = () => {
-      throw new UnsupportedHarnessThinkingError('claude', 'off', [
-        'low',
-        'medium',
-        'high',
-        'xhigh',
-        'max',
-      ]);
+      throw createInterModuleKnownError(
+        agentInterModuleContract.methods.resolveAgentConfig,
+        'agent-config-invalid',
+        {},
+      );
     };
 
     const act = () =>
@@ -328,10 +327,10 @@ describe('completeStepDispatchConfig', () => {
         definitionId: 'def-1',
       });
 
-    expect(act).toThrow(AgentConfigUnresolvableError);
+    await expect(act()).rejects.toThrow(AgentConfigUnresolvableError);
   });
 
-  it('throws when a server-side segment still survives dispatch', () => {
+  it('throws when a server-side segment still survives dispatch', async () => {
     const pending = step({
       config: {},
       configPlan: {
@@ -349,6 +348,6 @@ describe('completeStepDispatchConfig', () => {
         definitionId: 'def-1',
       });
 
-    expect(act).toThrow(InterpolationUnresolvableError);
+    await expect(act()).rejects.toThrow(InterpolationUnresolvableError);
   });
 });

--- a/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.ts
+++ b/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.ts
@@ -1,19 +1,19 @@
-import type {AgentDefaultsResolver} from '@shipfox/api-agent/core/resolve-agent-config';
 import {capTraceEntries} from '@shipfox/expression';
+import type {AgentDefaultsResolver} from '#core/agent-defaults.js';
 import type {PersistedEvaluationTraceEntry, Step} from '#core/entities/step.js';
 import {completeAgentConfig} from './agent.js';
 import {completeRunDispatchConfig} from './run.js';
 import type {WorkflowEvaluationContext} from './workflow-evaluation-context.js';
 
-export function completeStepDispatchConfig(params: {
+export async function completeStepDispatchConfig(params: {
   readonly step: Step;
   readonly context: WorkflowEvaluationContext;
-  readonly resolveAgentDefaults: AgentDefaultsResolver;
+  readonly resolveAgentDefaults?: AgentDefaultsResolver | undefined;
   readonly definitionId: string;
-}): {
+}): Promise<{
   readonly config: Record<string, unknown>;
   readonly trace: readonly PersistedEvaluationTraceEntry[];
-} {
+}> {
   const plan = params.step.configPlan;
   if (plan === null) return {config: params.step.config, trace: []};
 
@@ -27,7 +27,7 @@ export function completeStepDispatchConfig(params: {
     definitionId: params.definitionId,
     trace,
   });
-  completeAgentConfig({
+  await completeAgentConfig({
     config,
     plan,
     context: params.context,

--- a/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.test.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.test.ts
@@ -1,20 +1,28 @@
 import {
-  InvalidAgentModelError,
-  UnsupportedModelProviderError,
-} from '@shipfox/api-agent/core/errors';
-import type {AgentDefaultsResolver} from '@shipfox/api-agent/core/resolve-agent-config';
-import {
   AGENT_INTEGRATION_MCP_AUTH,
   AGENT_INTEGRATION_MCP_ENDPOINT,
   AGENT_INTEGRATION_MCP_SERVER_NAME,
   AGENT_INTEGRATION_MCP_TRANSPORT,
 } from '@shipfox/api-agent-dto';
+import {agentInterModuleContract} from '@shipfox/api-agent-dto/inter-module';
 import type {AgentToolCatalogEntry} from '@shipfox/api-integration-core';
+import {createInterModuleKnownError} from '@shipfox/inter-module';
+import type {AgentDefaultsResolver} from '#core/agent-defaults.js';
 import type {AgentToolMaterializationContext} from '#core/agent-tools.js';
 import {AgentConfigUnresolvableError, InterpolationUnresolvableError} from '#core/errors.js';
+import {resolveTestAgentDefaults} from '#test/fixtures/agent-inter-module.js';
 import {workflowModel} from '#test/index.js';
-import {materializeJobExecutionSteps} from './materialize-job-execution-steps.js';
+import {materializeJobExecutionSteps as materializeJobExecutionStepsImpl} from './materialize-job-execution-steps.js';
 import type {WorkflowEvaluationContext} from './workflow-evaluation-context.js';
+
+function materializeJobExecutionSteps(
+  params: Parameters<typeof materializeJobExecutionStepsImpl>[0],
+): ReturnType<typeof materializeJobExecutionStepsImpl> {
+  return materializeJobExecutionStepsImpl({
+    resolveAgentDefaults: resolveTestAgentDefaults,
+    ...params,
+  });
+}
 
 function template(source: string): string {
   return `\${{ ${source} }}`;
@@ -150,7 +158,7 @@ function githubAgentToolCatalog(): readonly AgentToolCatalogEntry[] {
 }
 
 describe('materializeJobExecutionSteps', () => {
-  it('prepends setup and resolves job-execution context fields', () => {
+  it('prepends setup and resolves job-execution context fields', async () => {
     const model = workflowModel({
       jobs: {
         review: {
@@ -167,7 +175,7 @@ describe('materializeJobExecutionSteps', () => {
     const job = model.jobs[0];
     if (!job) throw new Error('Expected workflow job');
 
-    const steps = materializeJobExecutionSteps({model, job, context: jobExecutionContext()});
+    const steps = await materializeJobExecutionSteps({model, job, context: jobExecutionContext()});
 
     expect(steps).toEqual([
       {
@@ -231,7 +239,7 @@ describe('materializeJobExecutionSteps', () => {
     ]);
   });
 
-  it('freezes resolved agent integration tools with default connection, repo, and token scope', () => {
+  it('freezes resolved agent integration tools with default connection, repo, and token scope', async () => {
     const model = workflowModel({
       jobs: {
         fix: {
@@ -256,7 +264,7 @@ describe('materializeJobExecutionSteps', () => {
     const job = model.jobs[0];
     if (!job) throw new Error('Expected workflow job');
 
-    const steps = materializeJobExecutionSteps({
+    const steps = await materializeJobExecutionSteps({
       model,
       job,
       context: jobExecutionContext(),
@@ -333,7 +341,7 @@ describe('materializeJobExecutionSteps', () => {
     ]);
   });
 
-  it('carries frozen integrations through the agent dispatch plan when prompt is deferred', () => {
+  it('carries frozen integrations through the agent dispatch plan when prompt is deferred', async () => {
     const model = workflowModel({
       jobs: {
         fix: {
@@ -360,7 +368,7 @@ describe('materializeJobExecutionSteps', () => {
     const job = model.jobs[0];
     if (!job) throw new Error('Expected workflow job');
 
-    const steps = materializeJobExecutionSteps({
+    const steps = await materializeJobExecutionSteps({
       model,
       job,
       context: jobExecutionContext(),
@@ -412,7 +420,7 @@ describe('materializeJobExecutionSteps', () => {
     ]);
   });
 
-  it('throws a permanent interpolation error for available missing value paths', () => {
+  it('throws a permanent interpolation error for available missing value paths', async () => {
     const model = workflowModel({
       jobs: {
         review: {
@@ -426,7 +434,7 @@ describe('materializeJobExecutionSteps', () => {
 
     let error: unknown;
     try {
-      materializeJobExecutionSteps({
+      await materializeJobExecutionSteps({
         model,
         job,
         context: {...baseContext, values: {...baseContext.values, inputs: {}}},
@@ -444,10 +452,7 @@ describe('materializeJobExecutionSteps', () => {
     });
   });
 
-  it.each([
-    new UnsupportedModelProviderError('unknown-provider'),
-    new InvalidAgentModelError('pi', 'anthropic', 'missing-model'),
-  ])('wraps known resolver errors as permanent agent config errors', (cause) => {
+  it('wraps known resolver errors as permanent agent config errors', async () => {
     const model = workflowModel({
       jobs: {
         review: {steps: [{prompt: 'Summarize the review.'}]},
@@ -456,7 +461,11 @@ describe('materializeJobExecutionSteps', () => {
     const job = model.jobs[0];
     if (!job) throw new Error('Expected workflow job');
     const resolveAgentDefaults = vi.fn<AgentDefaultsResolver>().mockImplementation(() => {
-      throw cause;
+      throw createInterModuleKnownError(
+        agentInterModuleContract.methods.resolveAgentConfig,
+        'agent-config-invalid',
+        {},
+      );
     });
 
     const materialize = () =>
@@ -468,11 +477,13 @@ describe('materializeJobExecutionSteps', () => {
         definitionId: 'def-1',
       });
 
-    expect(materialize).toThrow(AgentConfigUnresolvableError);
-    expect(materialize).toThrow('Agent configuration cannot be resolved for definition def-1');
+    await expect(materialize()).rejects.toThrow(AgentConfigUnresolvableError);
+    await expect(materialize()).rejects.toThrow(
+      'Agent configuration cannot be resolved for definition def-1',
+    );
   });
 
-  it('throws a permanent interpolation error for unsafe run interpolation', () => {
+  it('throws a permanent interpolation error for unsafe run interpolation', async () => {
     const model = workflowModel({
       jobs: {
         review: {steps: [{run: `echo \`${template('execution.index')}\``}]},
@@ -489,6 +500,6 @@ describe('materializeJobExecutionSteps', () => {
         definitionId: 'def-1',
       });
 
-    expect(materialize).toThrow(InterpolationUnresolvableError);
+    await expect(materialize()).rejects.toThrow(InterpolationUnresolvableError);
   });
 });

--- a/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.ts
@@ -1,9 +1,6 @@
-import {
-  type AgentDefaultsResolver,
-  catalogDefaultAgentResolver,
-} from '@shipfox/api-agent/core/resolve-agent-config';
-import type {WorkflowModel} from '@shipfox/api-definitions-dto';
+import type {WorkflowModel} from '@shipfox/api-definitions';
 import type {WorkflowExpression} from '@shipfox/expression';
+import type {AgentDefaultsResolver} from '#core/agent-defaults.js';
 import type {
   AgentToolMaterializationContext,
   AgentToolMaterializationSnapshot,
@@ -57,14 +54,14 @@ const SETUP_STEP: MaterializedWorkflowStep = {
   position: 0,
 };
 
-export function materializeJobExecutionSteps(
+export async function materializeJobExecutionSteps(
   params: MaterializeJobExecutionStepsParams,
-): readonly MaterializedWorkflowStep[] {
+): Promise<readonly MaterializedWorkflowStep[]> {
   const {
     model,
     job,
     context,
-    resolveAgentDefaults = catalogDefaultAgentResolver,
+    resolveAgentDefaults,
     definitionId = model.name,
     agentToolContext,
     agentToolSnapshot,
@@ -72,37 +69,39 @@ export function materializeJobExecutionSteps(
 
   return [
     SETUP_STEP,
-    ...job.steps.map((step, stepPosition) => {
-      // The trusted context exposes the stable job key; the authored display field remains `job.name`.
-      const stepContext = {...context.values, job: {key: job.key}};
-      const resolved = resolveStepConfig({
-        jobKey: job.key,
-        step,
-        workflowEnv: model.env,
-        workflowEnvTemplates: model.templates?.env,
-        jobEnv: job.env,
-        jobEnvTemplates: job.templates?.env,
-        context: stepContext,
-        site: context.site,
-        resolveAgentDefaults,
-        definitionId,
-        agentToolContext,
-        agentToolSnapshot,
-      });
-      return {
-        key: step.key ?? null,
-        name: resolved.name ?? stepDisplayName(step),
-        sourceLocation: step.sourceLocation ?? null,
-        status: 'pending' as const,
-        type: step.kind,
-        config: resolved.config,
-        ...(step.if === undefined ? {} : {condition: step.if}),
-        authoredConfig: resolved.authoredConfig,
-        ...materializedConfigPlan(resolved.configPlan, resolved.trace),
-        ...(resolved.diagnostics.length === 0 ? {} : {diagnostics: resolved.diagnostics}),
-        position: stepPosition + 1,
-      };
-    }),
+    ...(await Promise.all(
+      job.steps.map(async (step, stepPosition) => {
+        // The trusted context exposes the stable job key; the authored display field remains `job.name`.
+        const stepContext = {...context.values, job: {key: job.key}};
+        const resolved = await resolveStepConfig({
+          jobKey: job.key,
+          step,
+          workflowEnv: model.env,
+          workflowEnvTemplates: model.templates?.env,
+          jobEnv: job.env,
+          jobEnvTemplates: job.templates?.env,
+          context: stepContext,
+          site: context.site,
+          resolveAgentDefaults,
+          definitionId,
+          agentToolContext,
+          agentToolSnapshot,
+        });
+        return {
+          key: step.key ?? null,
+          name: resolved.name ?? stepDisplayName(step),
+          sourceLocation: step.sourceLocation ?? null,
+          status: 'pending' as const,
+          type: step.kind,
+          config: resolved.config,
+          ...(step.if === undefined ? {} : {condition: step.if}),
+          authoredConfig: resolved.authoredConfig,
+          ...materializedConfigPlan(resolved.configPlan, resolved.trace),
+          ...(resolved.diagnostics.length === 0 ? {} : {diagnostics: resolved.diagnostics}),
+          position: stepPosition + 1,
+        };
+      }),
+    )),
   ];
 }
 

--- a/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
@@ -1,18 +1,17 @@
-import {
-  InvalidAgentModelError,
-  UnsupportedModelProviderError,
-} from '@shipfox/api-agent/core/errors';
-import type {AgentDefaultsResolver} from '@shipfox/api-agent/core/resolve-agent-config';
+import {agentInterModuleContract} from '@shipfox/api-agent-dto/inter-module';
 import {
   DEFAULT_JOB_CHECKOUT,
   normalizeWorkflowDocument,
   type WorkflowModel,
 } from '@shipfox/api-definitions';
+import {createInterModuleKnownError} from '@shipfox/inter-module';
+import type {AgentDefaultsResolver} from '#core/agent-defaults.js';
 import {AgentConfigUnresolvableError, InterpolationUnresolvableError} from '#core/errors.js';
+import {resolveTestAgentDefaults} from '#test/fixtures/agent-inter-module.js';
 import {workflowModel} from '#test/index.js';
 import {
   materializeJobRunner,
-  materializeWorkflowModel,
+  materializeWorkflowModel as materializeWorkflowModelImpl,
   modelHasAgentStep,
 } from './materialize-workflow-model.js';
 import type {WorkflowEvaluationContext} from './workflow-evaluation-context.js';
@@ -20,6 +19,12 @@ import type {WorkflowEvaluationContext} from './workflow-evaluation-context.js';
 type TestWorkflowExpression = NonNullable<
   NonNullable<WorkflowModel['jobs'][number]['steps'][number]['gate']>['success']
 >;
+
+function materializeWorkflowModel(
+  params: Parameters<typeof materializeWorkflowModelImpl>[0],
+): ReturnType<typeof materializeWorkflowModelImpl> {
+  return materializeWorkflowModelImpl({resolveAgentDefaults: resolveTestAgentDefaults, ...params});
+}
 
 function expression(source: string): TestWorkflowExpression {
   return {language: 'cel', check: 'typed', source: source as TestWorkflowExpression['source']};
@@ -57,7 +62,7 @@ function creationContext(
 }
 
 describe('materializeWorkflowModel', () => {
-  it('converts workflow model jobs and steps to runtime rows', () => {
+  it('converts workflow model jobs and steps to runtime rows', async () => {
     const model = workflowModel({
       runner: 'ubuntu-latest',
       jobs: {
@@ -87,7 +92,7 @@ describe('materializeWorkflowModel', () => {
       },
     });
 
-    const rows = materializeWorkflowModel({model});
+    const rows = await materializeWorkflowModel({model});
 
     const setupStep = {
       key: null,
@@ -162,7 +167,7 @@ describe('materializeWorkflowModel', () => {
     ]);
   });
 
-  it('materializes an agent step as type "agent" with its config, alongside run steps', () => {
+  it('materializes an agent step as type "agent" with its config, alongside run steps', async () => {
     const model = workflowModel({
       jobs: {
         fix: {
@@ -191,7 +196,7 @@ describe('materializeWorkflowModel', () => {
       },
     });
 
-    const rows = materializeWorkflowModel({model});
+    const rows = await materializeWorkflowModel({model});
 
     expect(rows[0]?.steps[2]).toEqual({
       key: 'implement',
@@ -231,7 +236,7 @@ describe('materializeWorkflowModel', () => {
     });
   });
 
-  it('materializes prompt-only agent steps with catalog defaults before runner execution', () => {
+  it('materializes prompt-only agent steps with catalog defaults before runner execution', async () => {
     const model = workflowModel({
       jobs: {
         fix: {
@@ -240,7 +245,7 @@ describe('materializeWorkflowModel', () => {
       },
     });
 
-    const rows = materializeWorkflowModel({model});
+    const rows = await materializeWorkflowModel({model});
 
     expect(rows[0]?.steps[1]).toEqual({
       key: null,
@@ -260,7 +265,7 @@ describe('materializeWorkflowModel', () => {
     });
   });
 
-  it('materializes agent step tools into resolved config', () => {
+  it('materializes agent step tools into resolved config', async () => {
     const model = workflowModel({
       jobs: {
         fix: {
@@ -278,7 +283,7 @@ describe('materializeWorkflowModel', () => {
       },
     });
 
-    const rows = materializeWorkflowModel({model});
+    const rows = await materializeWorkflowModel({model});
 
     expect(rows[0]?.steps[1]?.config).toEqual({
       harness: 'pi',
@@ -290,7 +295,7 @@ describe('materializeWorkflowModel', () => {
     });
   });
 
-  it('materializes provider-only agent steps with that provider catalog default model', () => {
+  it('materializes provider-only agent steps with that provider catalog default model', async () => {
     const model = workflowModel({
       jobs: {
         fix: {
@@ -299,7 +304,7 @@ describe('materializeWorkflowModel', () => {
       },
     });
 
-    const rows = materializeWorkflowModel({model});
+    const rows = await materializeWorkflowModel({model});
 
     expect(rows[0]?.steps[1]?.config).toEqual({
       harness: 'pi',
@@ -310,7 +315,7 @@ describe('materializeWorkflowModel', () => {
     });
   });
 
-  it('passes checkout through to materialized jobs', () => {
+  it('passes checkout through to materialized jobs', async () => {
     const model = workflowModel({
       jobs: {
         build: {
@@ -323,7 +328,7 @@ describe('materializeWorkflowModel', () => {
       },
     });
 
-    const rows = materializeWorkflowModel({model});
+    const rows = await materializeWorkflowModel({model});
 
     expect(rows[0]?.checkout).toEqual({
       permissions: {contents: 'write'},
@@ -331,15 +336,15 @@ describe('materializeWorkflowModel', () => {
     });
   });
 
-  it('passes default checkout through to materialized jobs', () => {
+  it('passes default checkout through to materialized jobs', async () => {
     const model = workflowModel();
 
-    const rows = materializeWorkflowModel({model});
+    const rows = await materializeWorkflowModel({model});
 
     expect(rows[0]?.checkout).toEqual(DEFAULT_JOB_CHECKOUT);
   });
 
-  it('routes agent steps through the provided resolver', () => {
+  it('routes agent steps through the provided resolver', async () => {
     const model = workflowModel({
       jobs: {
         fix: {
@@ -354,7 +359,11 @@ describe('materializeWorkflowModel', () => {
       thinking: 'medium',
     });
 
-    const rows = materializeWorkflowModel({model, resolveAgentDefaults, definitionId: 'def-1'});
+    const rows = await materializeWorkflowModel({
+      model,
+      resolveAgentDefaults,
+      definitionId: 'def-1',
+    });
 
     expect(resolveAgentDefaults).toHaveBeenCalledWith({
       harness: undefined,
@@ -374,27 +383,30 @@ describe('materializeWorkflowModel', () => {
     });
   });
 
-  it.each([
-    new UnsupportedModelProviderError('unknown-provider'),
-    new InvalidAgentModelError('pi', 'anthropic', 'missing-model'),
-  ])('wraps known resolver errors as permanent agent config errors', (cause) => {
+  it('wraps known resolver errors as permanent agent config errors', async () => {
     const model = workflowModel({
       jobs: {
         fix: {steps: [{prompt: 'Fix the failing tests.'}]},
       },
     });
     const resolveAgentDefaults = vi.fn<AgentDefaultsResolver>().mockImplementation(() => {
-      throw cause;
+      throw createInterModuleKnownError(
+        agentInterModuleContract.methods.resolveAgentConfig,
+        'agent-config-invalid',
+        {},
+      );
     });
 
     const materialize = () =>
       materializeWorkflowModel({model, resolveAgentDefaults, definitionId: 'def-1'});
 
-    expect(materialize).toThrow(AgentConfigUnresolvableError);
-    expect(materialize).toThrow('Agent configuration cannot be resolved for definition def-1');
+    await expect(materialize()).rejects.toThrow(AgentConfigUnresolvableError);
+    await expect(materialize()).rejects.toThrow(
+      'Agent configuration cannot be resolved for definition def-1',
+    );
   });
 
-  it('re-throws unknown resolver errors unchanged', () => {
+  it('re-throws unknown resolver errors unchanged', async () => {
     const model = workflowModel({
       jobs: {
         fix: {steps: [{prompt: 'Fix the failing tests.'}]},
@@ -408,10 +420,10 @@ describe('materializeWorkflowModel', () => {
     const materialize = () =>
       materializeWorkflowModel({model, resolveAgentDefaults, definitionId: 'def-1'});
 
-    expect(materialize).toThrow(error);
+    await expect(materialize()).rejects.toThrow(error);
   });
 
-  it('materializes merged env for run steps only', () => {
+  it('materializes merged env for run steps only', async () => {
     const model = workflowModel({
       env: {SHARED: 'workflow', WORKFLOW_ONLY: 'yes'},
       jobs: {
@@ -431,7 +443,7 @@ describe('materializeWorkflowModel', () => {
       },
     });
 
-    const rows = materializeWorkflowModel({model});
+    const rows = await materializeWorkflowModel({model});
 
     expect(rows[0]?.steps[0]?.config).toEqual({});
     expect(rows[0]?.steps[1]?.config).toEqual({
@@ -452,7 +464,7 @@ describe('materializeWorkflowModel', () => {
     });
   });
 
-  it('omits env from run-step config when the merge is empty', () => {
+  it('omits env from run-step config when the merge is empty', async () => {
     const model = workflowModel({
       jobs: {
         build: {
@@ -461,12 +473,12 @@ describe('materializeWorkflowModel', () => {
       },
     });
 
-    const rows = materializeWorkflowModel({model});
+    const rows = await materializeWorkflowModel({model});
 
     expect(rows[0]?.steps[1]?.config).toEqual({run: 'npm test'});
   });
 
-  it('hoists run interpolation into generated env vars with shell references', () => {
+  it('hoists run interpolation into generated env vars with shell references', async () => {
     const model = workflowModel({
       jobs: {
         build: {
@@ -475,7 +487,7 @@ describe('materializeWorkflowModel', () => {
       },
     });
 
-    const rows = materializeWorkflowModel({model, context: creationContext()});
+    const rows = await materializeWorkflowModel({model, context: creationContext()});
 
     expect(rows[0]?.steps[1]?.config).toEqual({
       run: `echo "${shellRef('__sf_0')}" && echo "${shellRef('__sf_1')}"`,
@@ -489,7 +501,7 @@ describe('materializeWorkflowModel', () => {
     });
   });
 
-  it('hoists command secret assignments outside command substitutions', () => {
+  it('hoists command secret assignments outside command substitutions', async () => {
     const command = [
       `COMMAND_SECRET='${template('secrets.RUNTIME_TOKEN')}'`,
       'export COMMAND_SECRET',
@@ -503,7 +515,7 @@ describe('materializeWorkflowModel', () => {
       },
     });
 
-    const rows = materializeWorkflowModel({model, context: creationContext()});
+    const rows = await materializeWorkflowModel({model, context: creationContext()});
 
     expect(rows[0]?.steps[1]?.config).toEqual({
       run: [
@@ -526,7 +538,7 @@ describe('materializeWorkflowModel', () => {
     });
   });
 
-  it('freezes vars from the run-creation context into step config', () => {
+  it('freezes vars from the run-creation context into step config', async () => {
     const model = normalizeWorkflowDocument({
       name: 'vars workflow',
       runner: 'ubuntu-latest',
@@ -542,7 +554,7 @@ describe('materializeWorkflowModel', () => {
       },
     });
 
-    const rows = materializeWorkflowModel({
+    const rows = await materializeWorkflowModel({
       model,
       context: creationContext({...runContext(), vars: {REGION: 'west'}}),
     });
@@ -565,7 +577,7 @@ describe('materializeWorkflowModel', () => {
     });
   });
 
-  it('merges env before resolving and only resolves the winning values', () => {
+  it('merges env before resolving and only resolves the winning values', async () => {
     const model = workflowModel({
       env: {SHARED: template('event.missing'), WORKFLOW_ONLY: template('run.id')},
       jobs: {
@@ -581,7 +593,7 @@ describe('materializeWorkflowModel', () => {
       },
     });
 
-    const rows = materializeWorkflowModel({model, context: creationContext()});
+    const rows = await materializeWorkflowModel({model, context: creationContext()});
 
     expect(rows[0]?.steps[1]?.config).toEqual({
       run: 'echo ok',
@@ -604,7 +616,7 @@ describe('materializeWorkflowModel', () => {
     expect(rows[0]?.steps[1]?.diagnostics).toBeUndefined();
   });
 
-  it('throws a permanent interpolation error for available missing untrusted env paths', () => {
+  it('throws a permanent interpolation error for available missing untrusted env paths', async () => {
     const model = workflowModel({
       jobs: {
         build: {
@@ -615,7 +627,7 @@ describe('materializeWorkflowModel', () => {
 
     let error: unknown;
     try {
-      materializeWorkflowModel({
+      await materializeWorkflowModel({
         model,
         context: creationContext({...runContext(), event: {}}),
         definitionId: 'def-1',
@@ -633,7 +645,7 @@ describe('materializeWorkflowModel', () => {
     expect((error as Error).message).toContain("Use has(x) ? x : ''");
   });
 
-  it('preserves dispatch-time execution paths in the config plan at creation', () => {
+  it('preserves dispatch-time execution paths in the config plan at creation', async () => {
     const model = workflowModel({
       jobs: {
         build: {
@@ -642,7 +654,7 @@ describe('materializeWorkflowModel', () => {
       },
     });
 
-    const rows = materializeWorkflowModel({
+    const rows = await materializeWorkflowModel({
       model,
       context: creationContext(),
       definitionId: 'def-1',
@@ -661,7 +673,7 @@ describe('materializeWorkflowModel', () => {
     expect(rows[0]?.steps[1]?.diagnostics).toBeUndefined();
   });
 
-  it('reserves user env names when generating run interpolation env vars', () => {
+  it('reserves user env names when generating run interpolation env vars', async () => {
     const model = workflowModel({
       jobs: {
         build: {
@@ -670,7 +682,7 @@ describe('materializeWorkflowModel', () => {
       },
     });
 
-    const rows = materializeWorkflowModel({model, context: creationContext()});
+    const rows = await materializeWorkflowModel({model, context: creationContext()});
 
     expect(rows[0]?.steps[1]?.config).toEqual({
       run: `echo "${shellRef('__sf_1')}"`,
@@ -678,7 +690,7 @@ describe('materializeWorkflowModel', () => {
     });
   });
 
-  it('reserves deferred user env names when generating run interpolation env vars', () => {
+  it('reserves deferred user env names when generating run interpolation env vars', async () => {
     const model = workflowModel({
       jobs: {
         build: {
@@ -692,7 +704,7 @@ describe('materializeWorkflowModel', () => {
       },
     });
 
-    const rows = materializeWorkflowModel({model, context: creationContext()});
+    const rows = await materializeWorkflowModel({model, context: creationContext()});
 
     expect(rows[0]?.steps[1]?.config).toEqual({
       run: `echo "${shellRef('__sf_1')}"`,
@@ -711,7 +723,7 @@ describe('materializeWorkflowModel', () => {
     });
   });
 
-  it('resolves agent prompt, model, and provider before catalog defaults', () => {
+  it('resolves agent prompt, model, and provider before catalog defaults', async () => {
     const model = workflowModel({
       jobs: {
         fix: {
@@ -734,7 +746,7 @@ describe('materializeWorkflowModel', () => {
       thinking: 'medium',
     });
 
-    const rows = materializeWorkflowModel({
+    const rows = await materializeWorkflowModel({
       model,
       context: creationContext({
         ...runContext({name: 'gpt-5.5-pro'}),
@@ -767,7 +779,7 @@ describe('materializeWorkflowModel', () => {
     });
   });
 
-  it('keeps agent tools in the dispatch plan while config is deferred', () => {
+  it('keeps agent tools in the dispatch plan while config is deferred', async () => {
     const model = workflowModel({
       jobs: {
         fix: {
@@ -784,7 +796,7 @@ describe('materializeWorkflowModel', () => {
       },
     });
 
-    const rows = materializeWorkflowModel({
+    const rows = await materializeWorkflowModel({
       model,
       context: creationContext(),
       definitionId: 'def-1',
@@ -810,7 +822,7 @@ describe('materializeWorkflowModel', () => {
     ]);
   });
 
-  it('throws a permanent interpolation error for unsafe run interpolation', () => {
+  it('throws a permanent interpolation error for unsafe run interpolation', async () => {
     const model = workflowModel({
       jobs: {
         build: {steps: [{run: `echo \`${template('run.id')}\``}]},
@@ -820,10 +832,10 @@ describe('materializeWorkflowModel', () => {
     const materialize = () =>
       materializeWorkflowModel({model, context: creationContext(), definitionId: 'def-1'});
 
-    expect(materialize).toThrow(InterpolationUnresolvableError);
+    await expect(materialize()).rejects.toThrow(InterpolationUnresolvableError);
   });
 
-  it('throws a permanent interpolation error for a missing trusted run path', () => {
+  it('throws a permanent interpolation error for a missing trusted run path', async () => {
     const model = workflowModel({
       jobs: {
         build: {steps: [{run: `echo "${template('run.id')}"`}]},
@@ -833,10 +845,10 @@ describe('materializeWorkflowModel', () => {
     const materialize = () =>
       materializeWorkflowModel({model, context: creationContext({}), definitionId: 'def-1'});
 
-    expect(materialize).toThrow(InterpolationUnresolvableError);
+    await expect(materialize()).rejects.toThrow(InterpolationUnresolvableError);
   });
 
-  it('throws a permanent interpolation error for missing available agent prompt paths', () => {
+  it('throws a permanent interpolation error for missing available agent prompt paths', async () => {
     const model = workflowModel({
       jobs: {
         fix: {steps: [{prompt: template('inputs.ticket')}]},
@@ -845,7 +857,7 @@ describe('materializeWorkflowModel', () => {
 
     let error: unknown;
     try {
-      materializeWorkflowModel({
+      await materializeWorkflowModel({
         model,
         context: creationContext({...runContext(), inputs: {}}),
         definitionId: 'def-1',
@@ -861,7 +873,7 @@ describe('materializeWorkflowModel', () => {
     });
   });
 
-  it('throws a permanent interpolation error for a missing trusted agent model path', () => {
+  it('throws a permanent interpolation error for a missing trusted agent model path', async () => {
     const model = workflowModel({
       jobs: {
         fix: {steps: [{model: template('run.missing'), prompt: 'Fix it.'}]},
@@ -870,7 +882,7 @@ describe('materializeWorkflowModel', () => {
 
     let error: unknown;
     try {
-      materializeWorkflowModel({
+      await materializeWorkflowModel({
         model,
         context: creationContext(),
         definitionId: 'def-1',
@@ -886,7 +898,7 @@ describe('materializeWorkflowModel', () => {
     });
   });
 
-  it('degrades missing execution paths in step names', () => {
+  it('degrades missing execution paths in step names', async () => {
     const model = workflowModel({
       jobs: {
         review: {
@@ -900,7 +912,7 @@ describe('materializeWorkflowModel', () => {
       },
     });
 
-    const rows = materializeWorkflowModel({
+    const rows = await materializeWorkflowModel({
       model,
       context: creationContext(),
       definitionId: 'def-1',
@@ -919,7 +931,7 @@ describe('materializeWorkflowModel', () => {
     });
   });
 
-  it('degrades missing available untrusted paths in step names', () => {
+  it('degrades missing available untrusted paths in step names', async () => {
     const model = workflowModel({
       jobs: {
         review: {
@@ -933,7 +945,7 @@ describe('materializeWorkflowModel', () => {
       },
     });
 
-    const rows = materializeWorkflowModel({
+    const rows = await materializeWorkflowModel({
       model,
       context: creationContext({...runContext(), event: {}}),
       definitionId: 'def-1',
@@ -952,7 +964,7 @@ describe('materializeWorkflowModel', () => {
     });
   });
 
-  it('uses the display-name fallback when a degraded step name resolves empty', () => {
+  it('uses the display-name fallback when a degraded step name resolves empty', async () => {
     const model = workflowModel({
       jobs: {
         build: {
@@ -966,7 +978,7 @@ describe('materializeWorkflowModel', () => {
       },
     });
 
-    const rows = materializeWorkflowModel({
+    const rows = await materializeWorkflowModel({
       model,
       context: creationContext({...runContext(), event: {}}),
       definitionId: 'def-1',
@@ -985,7 +997,7 @@ describe('materializeWorkflowModel', () => {
     });
   });
 
-  it('skips listening job steps at workflow-run creation', () => {
+  it('skips listening job steps at workflow-run creation', async () => {
     const stepNameSource = `Review ${template('execution.index')}`;
     const model = normalizeWorkflowDocument({
       name: 'Listening workflow',
@@ -1001,7 +1013,7 @@ describe('materializeWorkflowModel', () => {
       },
     });
 
-    const rows = materializeWorkflowModel({
+    const rows = await materializeWorkflowModel({
       model,
       context: creationContext(),
       definitionId: 'def-1',
@@ -1014,7 +1026,7 @@ describe('materializeWorkflowModel', () => {
     });
   });
 
-  it('materializes one-shot siblings while skipping listening steps', () => {
+  it('materializes one-shot siblings while skipping listening steps', async () => {
     const model = normalizeWorkflowDocument({
       name: 'Mixed workflow',
       runner: 'ubuntu-latest',
@@ -1032,7 +1044,7 @@ describe('materializeWorkflowModel', () => {
       },
     });
 
-    const rows = materializeWorkflowModel({model, context: creationContext()});
+    const rows = await materializeWorkflowModel({model, context: creationContext()});
 
     const review = rows.find((job) => job.key === 'review');
     const build = rows.find((job) => job.key === 'build');
@@ -1042,18 +1054,18 @@ describe('materializeWorkflowModel', () => {
     expect(build?.steps[1]).toMatchObject({type: 'run', config: {run: 'npm test'}, position: 1});
   });
 
-  it('uses the supplied context for each materialization call', () => {
+  it('uses the supplied context for each materialization call', async () => {
     const model = workflowModel({
       jobs: {
         build: {steps: [{run: `echo "${template('run.id')}"`}]},
       },
     });
 
-    const first = materializeWorkflowModel({
+    const first = await materializeWorkflowModel({
       model,
       context: creationContext(runContext({id: 'run-a'})),
     });
-    const second = materializeWorkflowModel({
+    const second = await materializeWorkflowModel({
       model,
       context: creationContext(runContext({id: 'run-b'})),
     });
@@ -1062,10 +1074,10 @@ describe('materializeWorkflowModel', () => {
     expect(second[0]?.steps[1]?.config).toMatchObject({env: {__sf_0: 'run-b'}});
   });
 
-  it('gives a job with no user steps just the synthetic setup step', () => {
+  it('gives a job with no user steps just the synthetic setup step', async () => {
     const model = workflowModel({jobs: {noop: {steps: []}}});
 
-    const rows = materializeWorkflowModel({model});
+    const rows = await materializeWorkflowModel({model});
 
     expect(rows[0]?.steps).toEqual([
       {
@@ -1082,7 +1094,7 @@ describe('materializeWorkflowModel', () => {
     expect(rows[0]?.checkout).toEqual(DEFAULT_JOB_CHECKOUT);
   });
 
-  it('materializes step if as server-owned condition outside runner config', () => {
+  it('materializes step if as server-owned condition outside runner config', async () => {
     const model = normalizeWorkflowDocument({
       name: 'Conditional workflow',
       runner: 'ubuntu-latest',
@@ -1093,7 +1105,7 @@ describe('materializeWorkflowModel', () => {
       },
     });
 
-    const rows = materializeWorkflowModel({model});
+    const rows = await materializeWorkflowModel({model});
 
     const step = rows[0]?.steps[1];
     expect(step?.condition).toEqual({
@@ -1105,7 +1117,7 @@ describe('materializeWorkflowModel', () => {
     expect(step?.config).toEqual({run: 'npm test'});
   });
 
-  it('fails fast when the model contains an unresolved dependency id', () => {
+  it('fails fast when the model contains an unresolved dependency id', async () => {
     const model: WorkflowModel = {
       ...workflowModel(),
       jobs: [
@@ -1122,7 +1134,7 @@ describe('materializeWorkflowModel', () => {
       dependencies: [{from: 'missing', to: 'test'}],
     };
 
-    expect(() => materializeWorkflowModel({model})).toThrow(
+    await expect(materializeWorkflowModel({model})).rejects.toThrow(
       'Unresolved workflow model dependency "missing" for job "test"',
     );
   });

--- a/libs/api/workflows/src/core/step-config/materialize-workflow-model.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-workflow-model.ts
@@ -1,6 +1,6 @@
-import type {AgentDefaultsResolver} from '@shipfox/api-agent/core/resolve-agent-config';
-import type {WorkflowModel} from '@shipfox/api-definitions-dto';
+import type {WorkflowModel} from '@shipfox/api-definitions';
 import {canonicalizeLabels, findInvalidLabels, MAX_RUNNER_LABELS} from '@shipfox/runner-labels';
+import type {AgentDefaultsResolver} from '#core/agent-defaults.js';
 import type {
   AgentToolMaterializationContext,
   AgentToolMaterializationSnapshot,
@@ -38,9 +38,9 @@ export interface MaterializeWorkflowModelParams {
   readonly agentToolSnapshot?: AgentToolMaterializationSnapshot | null | undefined;
 }
 
-export function materializeWorkflowModel(
+export async function materializeWorkflowModel(
   params: MaterializeWorkflowModelParams,
-): readonly MaterializedWorkflowJob[] {
+): Promise<readonly MaterializedWorkflowJob[]> {
   const {
     model,
     context = {site: 'run-creation', values: {}},
@@ -51,31 +51,33 @@ export function materializeWorkflowModel(
   } = params;
   const jobsById = new Map(model.jobs.map((job) => [job.id, job]));
 
-  return model.jobs.map((job, position) => ({
-    key: job.key,
-    mode: job.mode,
-    ...(job.success === undefined ? {} : {success: job.success}),
-    ...(job.executionTimeoutMs === undefined ? {} : {executionTimeoutMs: job.executionTimeoutMs}),
-    checkout: job.checkout,
-    ...(job.listening === undefined ? {} : {listening: job.listening}),
-    ...(job.name === undefined ? {} : {name: job.name}),
-    ...(job.outputs === undefined ? {} : {outputs: job.outputs}),
-    dependencies: dependencySourceNames(job, jobsById),
-    runner: job.runner,
-    position,
-    steps:
-      job.mode === 'listening'
-        ? []
-        : materializeJobExecutionSteps({
-            model,
-            job,
-            context,
-            resolveAgentDefaults,
-            definitionId,
-            agentToolContext,
-            agentToolSnapshot,
-          }),
-  }));
+  return await Promise.all(
+    model.jobs.map(async (job, position) => ({
+      key: job.key,
+      mode: job.mode,
+      ...(job.success === undefined ? {} : {success: job.success}),
+      ...(job.executionTimeoutMs === undefined ? {} : {executionTimeoutMs: job.executionTimeoutMs}),
+      checkout: job.checkout,
+      ...(job.listening === undefined ? {} : {listening: job.listening}),
+      ...(job.name === undefined ? {} : {name: job.name}),
+      ...(job.outputs === undefined ? {} : {outputs: job.outputs}),
+      dependencies: dependencySourceNames(job, jobsById),
+      runner: job.runner,
+      position,
+      steps:
+        job.mode === 'listening'
+          ? []
+          : await materializeJobExecutionSteps({
+              model,
+              job,
+              context,
+              resolveAgentDefaults,
+              definitionId,
+              agentToolContext,
+              agentToolSnapshot,
+            }),
+    })),
+  );
 }
 
 export function materializeJobRunner(params: {

--- a/libs/api/workflows/src/core/step-config/resolve-step-config.ts
+++ b/libs/api/workflows/src/core/step-config/resolve-step-config.ts
@@ -1,11 +1,11 @@
-import type {AgentDefaultsResolver} from '@shipfox/api-agent/core/resolve-agent-config';
-import type {WorkflowEnvTemplates, WorkflowModel} from '@shipfox/api-definitions-dto';
+import type {WorkflowEnvTemplates, WorkflowModel} from '@shipfox/api-definitions';
 import {
   type AvailabilitySite,
   capTraceEntries,
   type EvaluationTraceLimitEntry,
   type WorkflowExpressionEvaluationContext,
 } from '@shipfox/expression';
+import type {AgentDefaultsResolver} from '#core/agent-defaults.js';
 import type {
   AgentToolMaterializationContext,
   AgentToolMaterializationSnapshot,
@@ -46,7 +46,7 @@ export interface ResolveStepConfigParams {
   readonly jobEnvTemplates: WorkflowEnvTemplates | undefined;
   readonly context: WorkflowExpressionEvaluationContext;
   readonly site: AvailabilitySite;
-  readonly resolveAgentDefaults: AgentDefaultsResolver;
+  readonly resolveAgentDefaults?: AgentDefaultsResolver | undefined;
   readonly definitionId: string;
   readonly agentToolContext?: AgentToolMaterializationContext | undefined;
   readonly agentToolSnapshot?: AgentToolMaterializationSnapshot | null | undefined;
@@ -62,11 +62,13 @@ interface BuiltStepConfig {
   readonly hasTemplates: boolean;
 }
 
-export function resolveStepConfig(params: ResolveStepConfigParams): ResolvedStepConfig {
+export async function resolveStepConfig(
+  params: ResolveStepConfigParams,
+): Promise<ResolvedStepConfig> {
   const context = evaluationContext(params);
-  const effective = buildStepConfig({...params, context, mode: 'effective'});
+  const effective = await buildStepConfig({...params, context, mode: 'effective'});
   const authoredConfig = effective.hasTemplates
-    ? buildStepConfig({...params, context, mode: 'authored'}).config
+    ? (await buildStepConfig({...params, context, mode: 'authored'})).config
     : null;
   const name = resolveStepName(params.step, context, params.definitionId);
 
@@ -80,9 +82,9 @@ export function resolveStepConfig(params: ResolveStepConfigParams): ResolvedStep
   };
 }
 
-function buildStepConfig(
+async function buildStepConfig(
   params: Omit<BuildStepConfigParams, 'context'> & {readonly context: WorkflowEvaluationContext},
-): BuiltStepConfig {
+): Promise<BuiltStepConfig> {
   const gate = gateConfigForStep(params.step);
   const outputs = outputsConfigForStep(params.step);
   const runStep = runStepOrNull(params.step);
@@ -102,7 +104,7 @@ function buildStepConfig(
   const agentStep = agentStepOrNull(params.step);
   if (agentStep === null) throw new Error(`Unsupported workflow step kind: ${params.step.kind}`);
 
-  const agent = resolveAgentStepConfig({...params, step: agentStep});
+  const agent = await resolveAgentStepConfig({...params, step: agentStep});
   return {
     config: {...agent.config, ...gate, ...outputs},
     configPlan: agent.configPlan,

--- a/libs/api/workflows/src/core/workflow-run-creation.test.ts
+++ b/libs/api/workflows/src/core/workflow-run-creation.test.ts
@@ -1,6 +1,7 @@
 import type {WorkflowModel} from '@shipfox/api-definitions-dto';
 import {buildModel, template} from '#test/helpers/workflow-runs.js';
 import type {TriggerPayload, WorkflowRun} from './entities/workflow-run.js';
+import type {MaterializedWorkflowJob} from './step-config/materialize-workflow-model.js';
 import {
   deriveInitialJobExecutionPlan,
   materializeWorkflowRunJobs,
@@ -14,7 +15,7 @@ const triggerPayload: TriggerPayload = {
 };
 
 describe('deriveInitialJobExecutionPlan', () => {
-  it('resolves initial execution name and runner templates from creation context', () => {
+  it('resolves initial execution name and runner templates from creation context', async () => {
     const model = buildModel({
       jobs: {
         deploy: {
@@ -26,7 +27,7 @@ describe('deriveInitialJobExecutionPlan', () => {
       },
     });
     const run = workflowRun({inputs: {environment: 'prod', runner: 'GPU'}});
-    const {modelJob, job} = materializedJob(model, run, {inputs: run.inputs});
+    const {modelJob, job} = await materializedJob(model, run, {inputs: run.inputs});
 
     const plan = deriveInitialJobExecutionPlan({
       run,
@@ -55,7 +56,7 @@ describe('deriveInitialJobExecutionPlan', () => {
     });
   });
 
-  it('resolves variables referenced only by job runner templates', () => {
+  it('resolves variables referenced only by job runner templates', async () => {
     const model = buildModel({
       jobs: {
         build: {
@@ -65,7 +66,7 @@ describe('deriveInitialJobExecutionPlan', () => {
       },
     });
     const run = workflowRun();
-    const {modelJob, job} = materializedJob(model, run, {vars: {RUNNER: 'GPU'}});
+    const {modelJob, job} = await materializedJob(model, run, {vars: {RUNNER: 'GPU'}});
 
     const plan = deriveInitialJobExecutionPlan({
       run,
@@ -81,7 +82,7 @@ describe('deriveInitialJobExecutionPlan', () => {
     expect(plan.runner).toEqual(['gpu', 'ubuntu-latest']);
   });
 
-  it('uses the fallback name for execution-name self references', () => {
+  it('uses the fallback name for execution-name self references', async () => {
     const model = buildModel({
       jobs: {
         deploy: {
@@ -91,7 +92,7 @@ describe('deriveInitialJobExecutionPlan', () => {
       },
     });
     const run = workflowRun();
-    const {modelJob, job} = materializedJob(model, run);
+    const {modelJob, job} = await materializedJob(model, run);
 
     const plan = deriveInitialJobExecutionPlan({
       run,
@@ -107,15 +108,18 @@ describe('deriveInitialJobExecutionPlan', () => {
   });
 });
 
-function materializedJob(
+async function materializedJob(
   model: WorkflowModel,
   run: WorkflowRun,
   context: {
     inputs?: Record<string, unknown> | null | undefined;
     vars?: Record<string, string> | undefined;
   } = {},
-) {
-  const [job] = materializeWorkflowRunJobs({
+): Promise<{
+  job: MaterializedWorkflowJob;
+  modelJob: WorkflowModel['jobs'][number];
+}> {
+  const [job] = await materializeWorkflowRunJobs({
     run,
     model,
     triggerPayload,

--- a/libs/api/workflows/src/core/workflow-run-creation.ts
+++ b/libs/api/workflows/src/core/workflow-run-creation.ts
@@ -1,8 +1,5 @@
-import {
-  type AgentDefaultsResolver,
-  catalogDefaultAgentResolver,
-} from '@shipfox/api-agent/core/resolve-agent-config';
-import type {WorkflowModel} from '@shipfox/api-definitions-dto';
+import type {WorkflowModel} from '@shipfox/api-definitions';
+import type {AgentDefaultsResolver} from './agent-defaults.js';
 import type {
   AgentToolMaterializationContext,
   AgentToolMaterializationSnapshot,
@@ -20,7 +17,7 @@ import {
 } from './step-config/materialize-workflow-model.js';
 import {resolveJobExecutionName} from './step-config/resolve-job-execution-name.js';
 
-export function materializeWorkflowRunJobs(params: {
+export async function materializeWorkflowRunJobs(params: {
   run: WorkflowRun;
   model: WorkflowModel;
   triggerPayload: TriggerPayload;
@@ -30,17 +27,17 @@ export function materializeWorkflowRunJobs(params: {
   definitionId: string;
   agentToolContext?: AgentToolMaterializationContext | undefined;
   agentToolSnapshot?: AgentToolMaterializationSnapshot | null | undefined;
-}): readonly MaterializedWorkflowJob[] {
+}): Promise<readonly MaterializedWorkflowJob[]> {
   const context = assembleCreationContext({
     run: params.run,
     triggerPayload: params.triggerPayload,
     inputs: params.inputs ?? null,
     vars: params.vars,
   });
-  return materializeWorkflowModel({
+  return await materializeWorkflowModel({
     model: params.model,
     context,
-    resolveAgentDefaults: params.resolveAgentDefaults ?? catalogDefaultAgentResolver,
+    resolveAgentDefaults: params.resolveAgentDefaults,
     definitionId: params.definitionId,
     agentToolContext: params.agentToolContext,
     agentToolSnapshot: params.agentToolSnapshot,

--- a/libs/api/workflows/src/db/job-listeners.ts
+++ b/libs/api/workflows/src/db/job-listeners.ts
@@ -1,10 +1,11 @@
-import type {AgentDefaultsResolver} from '@shipfox/api-agent/core/resolve-agent-config';
+import type {AgentInterModuleClient} from '@shipfox/api-agent-dto/inter-module';
 import {readPersistedWorkflowModel} from '@shipfox/api-definitions-dto';
 import {
   WORKFLOWS_JOB_ACTIVATED,
   type WorkflowsJobActivatedEventDto,
 } from '@shipfox/api-workflows-dto';
 import {and, asc, count, eq, inArray, isNull, notInArray, sql} from 'drizzle-orm';
+import {type AgentDefaultsResolver, createAgentDefaultsResolver} from '#core/agent-defaults.js';
 import {loadAgentToolMaterializationContext} from '#core/agent-tools.js';
 import {isJobTerminal, type JobStatus, type ResolutionReason} from '#core/entities/job.js';
 import type {JobExecutionStatus, WorkflowExecutionEvent} from '#core/entities/job-execution.js';
@@ -176,6 +177,7 @@ export interface DrainListenerEventsParams {
   expectedSequence: number;
   maxSize?: number | undefined;
   resolveAgentDefaults?: AgentDefaultsResolver | undefined;
+  agent?: AgentInterModuleClient | undefined;
 }
 
 export async function drainListenerEventsIntoExecution(
@@ -202,14 +204,18 @@ export async function drainListenerEventsIntoExecution(
             projectId: target.run.projectId,
           })
         : undefined;
-    const materialized = materializeListenerExecution({
+    const materialized = await materializeListenerExecution({
       model,
       run: toWorkflowRun(target.run),
       job: toJob(target.job),
       sequence: params.expectedSequence,
       triggerEvents: listenerTriggerEvents(bufferedEvents),
       priorExecutions: target.priorExecutions,
-      resolveAgentDefaults: params.resolveAgentDefaults,
+      resolveAgentDefaults:
+        params.resolveAgentDefaults ??
+        (params.agent
+          ? createAgentDefaultsResolver(params.agent, target.run.workspaceId)
+          : undefined),
       agentToolContext,
       agentToolSnapshot: target.attempt.agentToolMaterialization,
     });

--- a/libs/api/workflows/src/db/workflow-runs/run-create.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-create.test.ts
@@ -1,10 +1,10 @@
-import type {AgentDefaultsResolver} from '@shipfox/api-agent/core/resolve-agent-config';
 import {normalizeWorkflowDocument} from '@shipfox/api-definitions';
 import {WORKFLOWS_WORKFLOW_RUN_ATTEMPT_CREATED} from '@shipfox/api-workflows-dto';
 import {and, eq, sql} from 'drizzle-orm';
+import type {AgentDefaultsResolver} from '#core/agent-defaults.js';
 import {InterpolationUnresolvableError} from '#core/errors.js';
 import {nextStepForJob, recordStepResult} from '#core/job-execution.js';
-import {createTestSecretsClient} from '#test/fixtures/secrets-inter-module.js';
+import {resolveTestAgentDefaults} from '#test/fixtures/agent-inter-module.js';
 import {buildModel, expression, shellRef, template} from '#test/helpers/workflow-runs.js';
 import {db} from '../db.js';
 import {workflowsOutbox} from '../schema/outbox.js';
@@ -46,6 +46,7 @@ describe('workflow run queries', () => {
           subscriptionId: crypto.randomUUID(),
           userId: crypto.randomUUID(),
         },
+        resolveAgentDefaults: resolveTestAgentDefaults,
       });
 
       expect(run.id).toBeDefined();
@@ -122,6 +123,7 @@ describe('workflow run queries', () => {
           subscriptionId: crypto.randomUUID(),
           userId: crypto.randomUUID(),
         },
+        resolveAgentDefaults: resolveTestAgentDefaults,
       });
       const [build, deploy] = await getJobsByWorkflowRunId(run.id);
       if (!build || !deploy) throw new Error('Expected build and deploy jobs');
@@ -565,7 +567,6 @@ describe('workflow run queries', () => {
             subscriptionId: crypto.randomUUID(),
             userId: crypto.randomUUID(),
           },
-          secrets: createTestSecretsClient(),
         });
       } catch (caught) {
         error = caught;
@@ -844,6 +845,7 @@ describe('workflow run queries', () => {
           subscriptionId: crypto.randomUUID(),
           userId: crypto.randomUUID(),
         },
+        resolveAgentDefaults: resolveTestAgentDefaults,
       });
 
       const runJobs = await getJobsByWorkflowRunId(run.id);

--- a/libs/api/workflows/src/db/workflow-runs/run-create.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-create.test.ts
@@ -5,6 +5,7 @@ import type {AgentDefaultsResolver} from '#core/agent-defaults.js';
 import {InterpolationUnresolvableError} from '#core/errors.js';
 import {nextStepForJob, recordStepResult} from '#core/job-execution.js';
 import {resolveTestAgentDefaults} from '#test/fixtures/agent-inter-module.js';
+import {createTestSecretsClient} from '#test/fixtures/secrets-inter-module.js';
 import {buildModel, expression, shellRef, template} from '#test/helpers/workflow-runs.js';
 import {db} from '../db.js';
 import {workflowsOutbox} from '../schema/outbox.js';
@@ -567,6 +568,7 @@ describe('workflow run queries', () => {
             subscriptionId: crypto.randomUUID(),
             userId: crypto.randomUUID(),
           },
+          secrets: createTestSecretsClient(),
         });
       } catch (caught) {
         error = caught;

--- a/libs/api/workflows/src/db/workflow-runs/run-create.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-create.ts
@@ -1,12 +1,9 @@
-import {
-  type AgentDefaultsResolver,
-  catalogDefaultAgentResolver,
-} from '@shipfox/api-agent/core/resolve-agent-config';
 import {createWorkflowModelSnapshot, type WorkflowModel} from '@shipfox/api-definitions-dto';
 import type {SecretsInterModuleClient} from '@shipfox/api-secrets-dto/inter-module';
 import {analyzeContextKeyAccess, type ResolvedFieldSegment} from '@shipfox/expression';
 import {logger} from '@shipfox/node-opentelemetry';
 import {eq} from 'drizzle-orm';
+import type {AgentDefaultsResolver} from '#core/agent-defaults.js';
 import {
   createAgentToolMaterializationSnapshot,
   loadAgentToolMaterializationContext,
@@ -128,13 +125,13 @@ export async function createWorkflowRun(params: CreateWorkflowRunParams): Promis
       definitionId: params.definitionId,
       secrets: params.secrets,
     });
-    const materializedJobs = materializeWorkflowRunJobs({
+    const materializedJobs = await materializeWorkflowRunJobs({
       run,
       model: params.model,
       triggerPayload: params.triggerPayload,
       inputs: params.inputs ?? null,
       vars,
-      resolveAgentDefaults: params.resolveAgentDefaults ?? catalogDefaultAgentResolver,
+      resolveAgentDefaults: params.resolveAgentDefaults,
       definitionId: params.definitionId,
       agentToolContext,
       agentToolSnapshot: agentToolMaterialization,

--- a/libs/api/workflows/src/db/workflow-runs/run-rerun.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-rerun.test.ts
@@ -1,5 +1,5 @@
-import type {AgentDefaultsResolver} from '@shipfox/api-agent/core/resolve-agent-config';
 import {eq, inArray} from 'drizzle-orm';
+import type {AgentDefaultsResolver} from '#core/agent-defaults.js';
 import type {AgentToolMaterializationSnapshot} from '#core/agent-tools.js';
 import {NoFailedJobsError, RunNotTerminalError, SourceRunNotFoundError} from '#core/errors.js';
 import {nextStepForJob, recordStepResult} from '#core/job-execution.js';

--- a/libs/api/workflows/src/index.ts
+++ b/libs/api/workflows/src/index.ts
@@ -1,8 +1,8 @@
 import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 import type {AnnotationsInterModuleClient} from '@shipfox/annotations-dto/inter-module';
-import type {AuthInterModuleClient} from '@shipfox/api-auth-dto/inter-module';
 import type {AgentInterModuleClient} from '@shipfox/api-agent-dto/inter-module';
+import type {AuthInterModuleClient} from '@shipfox/api-auth-dto/inter-module';
 import type {DefinitionsInterModuleClient} from '@shipfox/api-definitions-dto/inter-module';
 import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
 import {

--- a/libs/api/workflows/src/index.ts
+++ b/libs/api/workflows/src/index.ts
@@ -2,6 +2,7 @@ import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 import type {AnnotationsInterModuleClient} from '@shipfox/annotations-dto/inter-module';
 import type {AuthInterModuleClient} from '@shipfox/api-auth-dto/inter-module';
+import type {AgentInterModuleClient} from '@shipfox/api-agent-dto/inter-module';
 import type {DefinitionsInterModuleClient} from '@shipfox/api-definitions-dto/inter-module';
 import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
 import {
@@ -78,6 +79,7 @@ const workflowsPath = resolve(packageRoot, 'dist/temporal/workflows/index.js');
 const subscriber = subscriberFactory<WorkflowsEventMapDto & RunnersEventMap>();
 
 export function createWorkflowsModule({
+  agent,
   definitions,
   annotations,
   auth,
@@ -85,6 +87,7 @@ export function createWorkflowsModule({
   runners,
   secrets,
 }: {
+  agent: AgentInterModuleClient;
   definitions: DefinitionsInterModuleClient;
   annotations: AnnotationsInterModuleClient;
   auth: AuthInterModuleClient;
@@ -95,7 +98,7 @@ export function createWorkflowsModule({
   return {
     name: 'workflows',
     database: {db, migrationsPath},
-    routes: createWorkflowRoutes(runners, auth, projects, annotations, secrets),
+    routes: createWorkflowRoutes({agent, annotations, auth, projects, runners, secrets}),
     metrics: registerWorkflowsServiceMetrics,
     publishers: [
       {name: 'workflows', table: workflowsOutbox, db, eventSchemas: workflowsEventSchemas},
@@ -113,12 +116,12 @@ export function createWorkflowsModule({
       {
         taskQueue: WORKFLOWS_TASK_QUEUE,
         workflowsPath,
-        activities: () => createOrchestrationActivities(runners, secrets),
+        activities: () => createOrchestrationActivities({agent, runners, secrets}),
         workflows: [],
       },
     ],
     interModulePresentations: [
-      createWorkflowsInterModulePresentation({definitions, runners, secrets}),
+      createWorkflowsInterModulePresentation({agent, definitions, runners, secrets}),
     ],
   };
 }

--- a/libs/api/workflows/src/presentation/inter-module.test.ts
+++ b/libs/api/workflows/src/presentation/inter-module.test.ts
@@ -42,6 +42,7 @@ describe('Workflows inter-module presentation', () => {
   it('returns only the resolved harness for Logs', async () => {
     mocks.getStepById.mockResolvedValue({config: {harness: 'claude'}});
     const presentation = createWorkflowsInterModulePresentation({
+      agent: {} as never,
       definitions: {} as never,
       runners: {} as never,
       secrets: {} as never,
@@ -94,6 +95,7 @@ describe('Workflows inter-module presentation', () => {
     mocks.getJobScope.mockResolvedValue({workspaceId: '00000000-0000-4000-8000-000000000010'});
     const runners = {getLeaseState: vi.fn().mockResolvedValue({active: true})};
     const presentation = createWorkflowsInterModulePresentation({
+      agent: {} as never,
       definitions: {} as never,
       runners: runners as never,
       secrets: {} as never,

--- a/libs/api/workflows/src/presentation/inter-module.ts
+++ b/libs/api/workflows/src/presentation/inter-module.ts
@@ -3,6 +3,7 @@ import {
   harnessSchema,
   materializedAgentStepConfigSchema,
 } from '@shipfox/api-agent-dto';
+import type {AgentInterModuleClient} from '@shipfox/api-agent-dto/inter-module';
 import type {DefinitionsInterModuleClient} from '@shipfox/api-definitions-dto/inter-module';
 import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-module';
 import type {SecretsInterModuleClient} from '@shipfox/api-secrets-dto/inter-module';
@@ -25,6 +26,7 @@ import {getJobScope, getStepById, getStepByIdForJobExecution} from '#db/index.js
 import {deliverEventToListener} from '#db/job-listener-events.js';
 
 export function createWorkflowsInterModulePresentation(params: {
+  agent: AgentInterModuleClient;
   definitions: DefinitionsInterModuleClient;
   secrets: Pick<SecretsInterModuleClient, 'getVariablesByNamespace'>;
   runners: RunnersInterModuleClient;
@@ -35,6 +37,7 @@ export function createWorkflowsInterModulePresentation(params: {
         const run = await runWorkflow(
           params.definitions,
           {
+            agent: params.agent,
             workspaceId: input.workspaceId,
             projectId: input.projectId,
             definitionId: input.definitionId,

--- a/libs/api/workflows/src/presentation/routes/agent-runtime-config.test.ts
+++ b/libs/api/workflows/src/presentation/routes/agent-runtime-config.test.ts
@@ -25,6 +25,7 @@ import {workflowModel} from '#test/factories/workflow-model.js';
 import {insertRunningJobLease, mintActiveLeaseToken} from '#test/fixtures/active-lease-token.js';
 import {resolveTestAgentDefaults} from '#test/fixtures/agent-inter-module.js';
 import {annotationsTestClient} from '#test/fixtures/annotations-inter-module.js';
+import {workflowsTestAuthClient} from '#test/fixtures/auth-inter-module.js';
 import {mintLeaseToken} from '#test/fixtures/lease-token.js';
 import {projectsTestClient} from '#test/fixtures/projects-inter-module.js';
 import {runnersTestClient} from '#test/fixtures/runners-inter-module.js';
@@ -60,6 +61,7 @@ describe('GET /runs/jobs/current/agent-runtime-config', () => {
         createLeaseTokenRouteGroup({
           agent: agentTestClient,
           annotations: annotationsTestClient,
+          auth: workflowsTestAuthClient,
           projects: projectsTestClient,
           runners: runnersTestClient,
           secrets,

--- a/libs/api/workflows/src/presentation/routes/agent-runtime-config.test.ts
+++ b/libs/api/workflows/src/presentation/routes/agent-runtime-config.test.ts
@@ -1,11 +1,19 @@
-import {createCustomModelProviderConfig, testAndSaveModelProviderConfig} from '@shipfox/api-agent';
+import {
+  agentModule,
+  createCustomModelProviderConfig,
+  testAndSaveModelProviderConfig,
+} from '@shipfox/api-agent';
 import {resolveRuntimeCredentials} from '@shipfox/api-agent/core/resolve-runtime-credentials';
+import {agentInterModuleContract} from '@shipfox/api-agent-dto/inter-module';
 import {createLeaseTokenAuthMethod} from '@shipfox/api-auth';
 import type {WorkflowModel} from '@shipfox/api-definitions-dto';
-import {secretsInterModuleContract} from '@shipfox/api-secrets-dto/inter-module';
-import {createInterModuleKnownError} from '@shipfox/inter-module';
+import {SecretDecryptionError} from '@shipfox/api-secrets';
 import {closeApp, createApp, type FastifyInstance} from '@shipfox/node-fastify';
 import {createCapturingLogger} from '@shipfox/node-log/test';
+import {
+  createInMemoryInterModuleTransport,
+  registerInterModulePresentations,
+} from '@shipfox/node-module/inter-module';
 import {eq} from 'drizzle-orm';
 import type {StepStatus} from '#core/entities/step.js';
 import {db} from '#db/db.js';
@@ -14,9 +22,10 @@ import {steps as stepsTable} from '#db/schema/steps.js';
 import {createWorkflowRun, getJobsByWorkflowRunId, getStepsByJobId} from '#db/workflow-runs.js';
 import {workflowModel} from '#test/factories/workflow-model.js';
 import {insertRunningJobLease, mintActiveLeaseToken} from '#test/fixtures/active-lease-token.js';
+import {resolveTestAgentDefaults} from '#test/fixtures/agent-inter-module.js';
 import {mintLeaseToken} from '#test/fixtures/lease-token.js';
+import {projectsTestClient} from '#test/fixtures/projects-inter-module.js';
 import {runnersTestClient} from '#test/fixtures/runners-inter-module.js';
-import {createTestSecretsClient} from '#test/fixtures/secrets-inter-module.js';
 import {createLeaseTokenRouteGroup} from './index.js';
 
 const {captureExceptionMock} = vi.hoisted(() => ({captureExceptionMock: vi.fn()}));
@@ -28,7 +37,10 @@ vi.mock('@shipfox/api-agent/core/resolve-runtime-credentials', async (importOrig
 vi.mock('@shipfox/node-error-monitoring', () => ({captureException: captureExceptionMock}));
 
 const URL = '/runs/jobs/current/agent-runtime-config';
-const secrets = createTestSecretsClient();
+const agentTransport = createInMemoryInterModuleTransport();
+const agentTestClient = agentTransport.createClient(agentInterModuleContract);
+registerInterModulePresentations({transport: agentTransport, modules: [agentModule]});
+agentTransport.seal();
 
 describe('GET /runs/jobs/current/agent-runtime-config', () => {
   let app: FastifyInstance;
@@ -37,7 +49,13 @@ describe('GET /runs/jobs/current/agent-runtime-config', () => {
   beforeAll(async () => {
     app = await createApp({
       auth: [createLeaseTokenAuthMethod()],
-      routes: [createLeaseTokenRouteGroup(runnersTestClient, undefined, undefined, secrets)],
+      routes: [
+        createLeaseTokenRouteGroup({
+          agent: agentTestClient,
+          projects: projectsTestClient,
+          runners: runnersTestClient,
+        }),
+      ],
       swagger: false,
       fastifyOptions: {loggerInstance: logger},
     });
@@ -178,7 +196,7 @@ describe('GET /runs/jobs/current/agent-runtime-config', () => {
           models: [{id: 'llama-3.1', label: 'Llama 3.1'}],
         },
       },
-      {probe: async () => undefined, secrets},
+      {probe: async () => undefined},
     );
     const {job, step} = await createRunningAgentStep({
       workspaceId,
@@ -351,13 +369,7 @@ describe('GET /runs/jobs/current/agent-runtime-config', () => {
 
   test('returns 409 and reports when workspace credentials cannot be decrypted', async () => {
     const {job, step} = await createRunningAgentStep();
-    vi.mocked(resolveRuntimeCredentials).mockRejectedValueOnce(
-      createInterModuleKnownError(
-        secretsInterModuleContract.methods.getSecretsByNamespace,
-        'secret-decryption-failed',
-        {},
-      ),
-    );
+    vi.mocked(resolveRuntimeCredentials).mockRejectedValueOnce(new SecretDecryptionError());
     const token = await mintActiveLeaseToken({jobId: job.id});
 
     const res = await app.inject({
@@ -369,7 +381,7 @@ describe('GET /runs/jobs/current/agent-runtime-config', () => {
     expect(res.statusCode).toBe(409);
     expect(res.json().code).toBe('model-provider-credentials-invalid');
     expect(captureExceptionMock).toHaveBeenCalledWith(
-      expect.objectContaining({name: 'InterModuleKnownError'}),
+      expect.objectContaining({name: 'SecretDecryptionError'}),
     );
     expect(JSON.stringify(res.json())).not.toContain('sk-');
   });
@@ -404,7 +416,7 @@ async function saveWorkspaceCredential(workspaceId: string, apiKey: string) {
       providerId: 'anthropic',
       credentials: {api_key: apiKey},
     },
-    {probe: async () => undefined, secrets},
+    {probe: async () => undefined},
   );
 }
 
@@ -463,7 +475,7 @@ async function createStep(params: {
     projectId: crypto.randomUUID(),
     definitionId: crypto.randomUUID(),
     model: workflowModel({jobs: {build: {steps: params.steps}}}),
-    resolveAgentDefaults: params.resolveAgentDefaults,
+    resolveAgentDefaults: params.resolveAgentDefaults ?? resolveTestAgentDefaults,
     triggerPayload: {
       source: 'manual',
       event: 'fire',

--- a/libs/api/workflows/src/presentation/routes/agent-runtime-config.test.ts
+++ b/libs/api/workflows/src/presentation/routes/agent-runtime-config.test.ts
@@ -381,7 +381,10 @@ describe('GET /runs/jobs/current/agent-runtime-config', () => {
     expect(res.statusCode).toBe(409);
     expect(res.json().code).toBe('model-provider-credentials-invalid');
     expect(captureExceptionMock).toHaveBeenCalledWith(
-      expect.objectContaining({name: 'SecretDecryptionError'}),
+      expect.objectContaining({
+        name: 'InterModuleKnownError',
+        code: 'model-provider-credentials-invalid',
+      }),
     );
     expect(JSON.stringify(res.json())).not.toContain('sk-');
   });

--- a/libs/api/workflows/src/presentation/routes/agent-runtime-config.test.ts
+++ b/libs/api/workflows/src/presentation/routes/agent-runtime-config.test.ts
@@ -1,5 +1,5 @@
 import {
-  agentModule,
+  createAgentModule,
   createCustomModelProviderConfig,
   testAndSaveModelProviderConfig,
 } from '@shipfox/api-agent';
@@ -7,7 +7,8 @@ import {resolveRuntimeCredentials} from '@shipfox/api-agent/core/resolve-runtime
 import {agentInterModuleContract} from '@shipfox/api-agent-dto/inter-module';
 import {createLeaseTokenAuthMethod} from '@shipfox/api-auth';
 import type {WorkflowModel} from '@shipfox/api-definitions-dto';
-import {SecretDecryptionError} from '@shipfox/api-secrets';
+import {secretsInterModuleContract} from '@shipfox/api-secrets-dto/inter-module';
+import {createInterModuleKnownError} from '@shipfox/inter-module';
 import {closeApp, createApp, type FastifyInstance} from '@shipfox/node-fastify';
 import {createCapturingLogger} from '@shipfox/node-log/test';
 import {
@@ -27,6 +28,7 @@ import {annotationsTestClient} from '#test/fixtures/annotations-inter-module.js'
 import {mintLeaseToken} from '#test/fixtures/lease-token.js';
 import {projectsTestClient} from '#test/fixtures/projects-inter-module.js';
 import {runnersTestClient} from '#test/fixtures/runners-inter-module.js';
+import {createTestSecretsClient} from '#test/fixtures/secrets-inter-module.js';
 import {createLeaseTokenRouteGroup} from './index.js';
 
 const {captureExceptionMock} = vi.hoisted(() => ({captureExceptionMock: vi.fn()}));
@@ -38,9 +40,13 @@ vi.mock('@shipfox/api-agent/core/resolve-runtime-credentials', async (importOrig
 vi.mock('@shipfox/node-error-monitoring', () => ({captureException: captureExceptionMock}));
 
 const URL = '/runs/jobs/current/agent-runtime-config';
+const secrets = createTestSecretsClient();
 const agentTransport = createInMemoryInterModuleTransport();
 const agentTestClient = agentTransport.createClient(agentInterModuleContract);
-registerInterModulePresentations({transport: agentTransport, modules: [agentModule]});
+registerInterModulePresentations({
+  transport: agentTransport,
+  modules: [createAgentModule({secrets})],
+});
 agentTransport.seal();
 
 describe('GET /runs/jobs/current/agent-runtime-config', () => {
@@ -56,6 +62,7 @@ describe('GET /runs/jobs/current/agent-runtime-config', () => {
           annotations: annotationsTestClient,
           projects: projectsTestClient,
           runners: runnersTestClient,
+          secrets,
         }),
       ],
       swagger: false,
@@ -198,7 +205,7 @@ describe('GET /runs/jobs/current/agent-runtime-config', () => {
           models: [{id: 'llama-3.1', label: 'Llama 3.1'}],
         },
       },
-      {probe: async () => undefined},
+      {probe: async () => undefined, secrets},
     );
     const {job, step} = await createRunningAgentStep({
       workspaceId,
@@ -371,7 +378,13 @@ describe('GET /runs/jobs/current/agent-runtime-config', () => {
 
   test('returns 409 and reports when workspace credentials cannot be decrypted', async () => {
     const {job, step} = await createRunningAgentStep();
-    vi.mocked(resolveRuntimeCredentials).mockRejectedValueOnce(new SecretDecryptionError());
+    vi.mocked(resolveRuntimeCredentials).mockRejectedValueOnce(
+      createInterModuleKnownError(
+        secretsInterModuleContract.methods.getSecretsByNamespace,
+        'secret-decryption-failed',
+        {},
+      ),
+    );
     const token = await mintActiveLeaseToken({jobId: job.id});
 
     const res = await app.inject({
@@ -421,7 +434,7 @@ async function saveWorkspaceCredential(workspaceId: string, apiKey: string) {
       providerId: 'anthropic',
       credentials: {api_key: apiKey},
     },
-    {probe: async () => undefined},
+    {probe: async () => undefined, secrets},
   );
 }
 

--- a/libs/api/workflows/src/presentation/routes/agent-runtime-config.test.ts
+++ b/libs/api/workflows/src/presentation/routes/agent-runtime-config.test.ts
@@ -23,6 +23,7 @@ import {createWorkflowRun, getJobsByWorkflowRunId, getStepsByJobId} from '#db/wo
 import {workflowModel} from '#test/factories/workflow-model.js';
 import {insertRunningJobLease, mintActiveLeaseToken} from '#test/fixtures/active-lease-token.js';
 import {resolveTestAgentDefaults} from '#test/fixtures/agent-inter-module.js';
+import {annotationsTestClient} from '#test/fixtures/annotations-inter-module.js';
 import {mintLeaseToken} from '#test/fixtures/lease-token.js';
 import {projectsTestClient} from '#test/fixtures/projects-inter-module.js';
 import {runnersTestClient} from '#test/fixtures/runners-inter-module.js';
@@ -52,6 +53,7 @@ describe('GET /runs/jobs/current/agent-runtime-config', () => {
       routes: [
         createLeaseTokenRouteGroup({
           agent: agentTestClient,
+          annotations: annotationsTestClient,
           projects: projectsTestClient,
           runners: runnersTestClient,
         }),

--- a/libs/api/workflows/src/presentation/routes/agent-runtime-config.ts
+++ b/libs/api/workflows/src/presentation/routes/agent-runtime-config.ts
@@ -1,15 +1,13 @@
-import {ModelProviderConfigNotFoundError} from '@shipfox/api-agent/core/errors';
-import {resolveRuntimeCredentials} from '@shipfox/api-agent/core/resolve-runtime-credentials';
 import {
   agentRuntimeCredentialsResponseSchema,
   type MaterializedAgentStepConfigDto,
   materializedAgentStepConfigSchema,
 } from '@shipfox/api-agent-dto';
-import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-module';
 import {
-  type SecretsInterModuleClient,
-  secretsInterModuleContract,
-} from '@shipfox/api-secrets-dto/inter-module';
+  type AgentInterModuleClient,
+  agentInterModuleContract,
+} from '@shipfox/api-agent-dto/inter-module';
+import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-module';
 import {agentRuntimeConfigQuerySchema} from '@shipfox/api-workflows-dto';
 import {isInterModuleKnownError} from '@shipfox/inter-module';
 import {captureException} from '@shipfox/node-error-monitoring';
@@ -17,10 +15,10 @@ import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {ZodError} from 'zod';
 import {loadRunningLeasedStep} from './leased-step.js';
 
-export function createAgentRuntimeConfigRoute(
-  runners: RunnersInterModuleClient,
-  secrets: SecretsInterModuleClient,
-) {
+export function createAgentRuntimeConfigRoute(params: {
+  agent: AgentInterModuleClient;
+  runners: RunnersInterModuleClient;
+}) {
   return defineRoute({
     method: 'GET',
     path: '/agent-runtime-config',
@@ -34,7 +32,11 @@ export function createAgentRuntimeConfigRoute(
     },
     errorHandler: (error) => {
       if (
-        isInterModuleKnownError(secretsInterModuleContract.methods.getSecretsByNamespace, error)
+        isInterModuleKnownError(
+          agentInterModuleContract.methods.resolveRuntimeCredentials,
+          error,
+        ) &&
+        error.code === 'model-provider-credentials-invalid'
       ) {
         captureException(error);
         throw new ClientError(
@@ -46,7 +48,13 @@ export function createAgentRuntimeConfigRoute(
           },
         );
       }
-      if (error instanceof ModelProviderConfigNotFoundError) {
+      if (
+        isInterModuleKnownError(
+          agentInterModuleContract.methods.resolveRuntimeCredentials,
+          error,
+        ) &&
+        error.code === 'model-provider-not-configured'
+      ) {
         throw new ClientError(
           'Model provider credentials are not configured',
           'model-provider-not-configured',
@@ -59,7 +67,12 @@ export function createAgentRuntimeConfigRoute(
     },
     handler: async (request, reply) => {
       const {step_id: stepId, attempt} = request.query;
-      const {step, workspaceId} = await loadRunningLeasedStep({runners, request, stepId, attempt});
+      const {step, workspaceId} = await loadRunningLeasedStep({
+        runners: params.runners,
+        request,
+        stepId,
+        attempt,
+      });
 
       if (step.type !== 'agent') {
         throw new ClientError('Step is not an agent step', 'step-not-agent', {status: 409});
@@ -78,16 +91,13 @@ export function createAgentRuntimeConfigRoute(
         throw error;
       }
 
-      const runtimeConfig = await resolveRuntimeCredentials(
-        {
-          workspaceId,
-          harness: agentConfig.harness,
-          provider: agentConfig.provider,
-          model: agentConfig.model,
-          thinking: agentConfig.thinking,
-        },
-        {secrets},
-      );
+      const runtimeConfig = await params.agent.resolveRuntimeCredentials({
+        workspaceId,
+        harness: agentConfig.harness,
+        provider: agentConfig.provider,
+        model: agentConfig.model,
+        thinking: agentConfig.thinking,
+      });
 
       reply.header('cache-control', 'no-store');
       return runtimeConfig;

--- a/libs/api/workflows/src/presentation/routes/checkout-token.test.ts
+++ b/libs/api/workflows/src/presentation/routes/checkout-token.test.ts
@@ -14,6 +14,7 @@ import {jobFactory} from '#test/factories/job.js';
 import {projectFactory} from '#test/factories/project.js';
 import {mintActiveLeaseToken} from '#test/fixtures/active-lease-token.js';
 import {agentTestClient} from '#test/fixtures/agent-inter-module.js';
+import {annotationsTestClient} from '#test/fixtures/annotations-inter-module.js';
 import {mintLeaseToken} from '#test/fixtures/lease-token.js';
 import {runnersTestClient} from '#test/fixtures/runners-inter-module.js';
 import {createLeaseTokenRouteGroup} from './index.js';
@@ -44,7 +45,12 @@ describe('POST /runs/jobs/current/checkout-token', () => {
     app = await createApp({
       auth: [createLeaseTokenAuthMethod()],
       routes: [
-        createLeaseTokenRouteGroup({agent: agentTestClient, projects, runners: runnersTestClient}),
+        createLeaseTokenRouteGroup({
+          agent: agentTestClient,
+          annotations: annotationsTestClient,
+          projects,
+          runners: runnersTestClient,
+        }),
       ],
       swagger: false,
       fastifyOptions: {loggerInstance: logger},

--- a/libs/api/workflows/src/presentation/routes/checkout-token.test.ts
+++ b/libs/api/workflows/src/presentation/routes/checkout-token.test.ts
@@ -17,6 +17,7 @@ import {agentTestClient} from '#test/fixtures/agent-inter-module.js';
 import {annotationsTestClient} from '#test/fixtures/annotations-inter-module.js';
 import {mintLeaseToken} from '#test/fixtures/lease-token.js';
 import {runnersTestClient} from '#test/fixtures/runners-inter-module.js';
+import {createTestSecretsClient} from '#test/fixtures/secrets-inter-module.js';
 import {createLeaseTokenRouteGroup} from './index.js';
 
 const mockGetProjectById = vi.fn();
@@ -28,6 +29,7 @@ const projects = {
 } as unknown as ProjectsModuleClient;
 
 const URL = '/runs/jobs/current/checkout-token';
+const secrets = createTestSecretsClient();
 
 const githubSpec = (token: string): CheckoutSpec => ({
   repositoryUrl: 'https://github.com/acme/repo.git',
@@ -50,6 +52,7 @@ describe('POST /runs/jobs/current/checkout-token', () => {
           annotations: annotationsTestClient,
           projects,
           runners: runnersTestClient,
+          secrets,
         }),
       ],
       swagger: false,

--- a/libs/api/workflows/src/presentation/routes/checkout-token.test.ts
+++ b/libs/api/workflows/src/presentation/routes/checkout-token.test.ts
@@ -267,7 +267,7 @@ describe('POST /runs/jobs/current/checkout-token', () => {
   });
 
   test('returns 404 when the run has no project linkage', async () => {
-    mockGetProjectById.mockResolvedValue(undefined);
+    mockGetProjectById.mockResolvedValue(null);
     const project = {id: crypto.randomUUID(), workspaceId: crypto.randomUUID()};
     const job = await jobFactory.create({}, {transient: {projectId: project.id}});
     const token = await mintActiveLeaseToken({jobId: job.id});

--- a/libs/api/workflows/src/presentation/routes/checkout-token.test.ts
+++ b/libs/api/workflows/src/presentation/routes/checkout-token.test.ts
@@ -13,6 +13,7 @@ import {clearSourceControl, setSourceControl} from '#core/source-control.js';
 import {jobFactory} from '#test/factories/job.js';
 import {projectFactory} from '#test/factories/project.js';
 import {mintActiveLeaseToken} from '#test/fixtures/active-lease-token.js';
+import {agentTestClient} from '#test/fixtures/agent-inter-module.js';
 import {mintLeaseToken} from '#test/fixtures/lease-token.js';
 import {runnersTestClient} from '#test/fixtures/runners-inter-module.js';
 import {createLeaseTokenRouteGroup} from './index.js';
@@ -42,7 +43,9 @@ describe('POST /runs/jobs/current/checkout-token', () => {
     setSourceControl({createCheckoutSpec} as unknown as IntegrationSourceControlService);
     app = await createApp({
       auth: [createLeaseTokenAuthMethod()],
-      routes: [createLeaseTokenRouteGroup(runnersTestClient, projects)],
+      routes: [
+        createLeaseTokenRouteGroup({agent: agentTestClient, projects, runners: runnersTestClient}),
+      ],
       swagger: false,
       fastifyOptions: {loggerInstance: logger},
     });
@@ -264,7 +267,7 @@ describe('POST /runs/jobs/current/checkout-token', () => {
   });
 
   test('returns 404 when the run has no project linkage', async () => {
-    mockGetProjectById.mockResolvedValue(null);
+    mockGetProjectById.mockResolvedValue(undefined);
     const project = {id: crypto.randomUUID(), workspaceId: crypto.randomUUID()};
     const job = await jobFactory.create({}, {transient: {projectId: project.id}});
     const token = await mintActiveLeaseToken({jobId: job.id});

--- a/libs/api/workflows/src/presentation/routes/checkout-token.test.ts
+++ b/libs/api/workflows/src/presentation/routes/checkout-token.test.ts
@@ -15,6 +15,7 @@ import {projectFactory} from '#test/factories/project.js';
 import {mintActiveLeaseToken} from '#test/fixtures/active-lease-token.js';
 import {agentTestClient} from '#test/fixtures/agent-inter-module.js';
 import {annotationsTestClient} from '#test/fixtures/annotations-inter-module.js';
+import {workflowsTestAuthClient} from '#test/fixtures/auth-inter-module.js';
 import {mintLeaseToken} from '#test/fixtures/lease-token.js';
 import {runnersTestClient} from '#test/fixtures/runners-inter-module.js';
 import {createTestSecretsClient} from '#test/fixtures/secrets-inter-module.js';
@@ -50,6 +51,7 @@ describe('POST /runs/jobs/current/checkout-token', () => {
         createLeaseTokenRouteGroup({
           agent: agentTestClient,
           annotations: annotationsTestClient,
+          auth: workflowsTestAuthClient,
           projects,
           runners: runnersTestClient,
           secrets,

--- a/libs/api/workflows/src/presentation/routes/get-step-secrets.test.ts
+++ b/libs/api/workflows/src/presentation/routes/get-step-secrets.test.ts
@@ -16,6 +16,7 @@ import {workflowModel} from '#test/factories/workflow-model.js';
 import {mintActiveLeaseToken} from '#test/fixtures/active-lease-token.js';
 import {agentTestClient} from '#test/fixtures/agent-inter-module.js';
 import {annotationsTestClient} from '#test/fixtures/annotations-inter-module.js';
+import {workflowsTestAuthClient} from '#test/fixtures/auth-inter-module.js';
 import {projectsTestClient} from '#test/fixtures/projects-inter-module.js';
 import {runnersTestClient} from '#test/fixtures/runners-inter-module.js';
 import {createTestSecretsClient} from '#test/fixtures/secrets-inter-module.js';
@@ -35,6 +36,7 @@ describe('GET /runs/jobs/current/steps/:stepId/secrets', () => {
         createLeaseTokenRouteGroup({
           agent: agentTestClient,
           annotations: annotationsTestClient,
+          auth: workflowsTestAuthClient,
           projects: projectsTestClient,
           runners: runnersTestClient,
           secrets,

--- a/libs/api/workflows/src/presentation/routes/get-step-secrets.test.ts
+++ b/libs/api/workflows/src/presentation/routes/get-step-secrets.test.ts
@@ -16,6 +16,7 @@ import {
 import {workflowModel} from '#test/factories/workflow-model.js';
 import {mintActiveLeaseToken} from '#test/fixtures/active-lease-token.js';
 import {agentTestClient} from '#test/fixtures/agent-inter-module.js';
+import {annotationsTestClient} from '#test/fixtures/annotations-inter-module.js';
 import {projectsTestClient} from '#test/fixtures/projects-inter-module.js';
 import {runnersTestClient} from '#test/fixtures/runners-inter-module.js';
 import {createLeaseTokenRouteGroup} from './index.js';
@@ -32,6 +33,7 @@ describe('GET /runs/jobs/current/steps/:stepId/secrets', () => {
       routes: [
         createLeaseTokenRouteGroup({
           agent: agentTestClient,
+          annotations: annotationsTestClient,
           projects: projectsTestClient,
           runners: runnersTestClient,
         }),

--- a/libs/api/workflows/src/presentation/routes/get-step-secrets.test.ts
+++ b/libs/api/workflows/src/presentation/routes/get-step-secrets.test.ts
@@ -1,4 +1,5 @@
 import {createLeaseTokenAuthMethod} from '@shipfox/api-auth';
+import {setSecrets} from '@shipfox/api-secrets';
 import {closeApp, createApp, type FastifyInstance} from '@shipfox/node-fastify';
 import {createCapturingLogger} from '@shipfox/node-log/test';
 import {eq} from 'drizzle-orm';
@@ -14,21 +15,27 @@ import {
 } from '#db/workflow-runs.js';
 import {workflowModel} from '#test/factories/workflow-model.js';
 import {mintActiveLeaseToken} from '#test/fixtures/active-lease-token.js';
+import {agentTestClient} from '#test/fixtures/agent-inter-module.js';
+import {projectsTestClient} from '#test/fixtures/projects-inter-module.js';
 import {runnersTestClient} from '#test/fixtures/runners-inter-module.js';
-import {createTestSecretsClient} from '#test/fixtures/secrets-inter-module.js';
 import {createLeaseTokenRouteGroup} from './index.js';
 
 const URL_PREFIX = '/runs/jobs/current/steps';
 
 describe('GET /runs/jobs/current/steps/:stepId/secrets', () => {
   let app: FastifyInstance;
-  const secrets = createTestSecretsClient();
   const {logger, lines: logLines, clear: clearLogLines} = createCapturingLogger();
 
   beforeAll(async () => {
     app = await createApp({
       auth: [createLeaseTokenAuthMethod()],
-      routes: [createLeaseTokenRouteGroup(runnersTestClient, undefined, undefined, secrets)],
+      routes: [
+        createLeaseTokenRouteGroup({
+          agent: agentTestClient,
+          projects: projectsTestClient,
+          runners: runnersTestClient,
+        }),
+      ],
       swagger: false,
       fastifyOptions: {loggerInstance: logger},
     });
@@ -58,10 +65,9 @@ describe('GET /runs/jobs/current/steps/:stepId/secrets', () => {
         segments: [{kind: 'secret', store: 'local', key: 'API_TOKEN'}],
       },
     ]);
-    await secrets.setSecrets({
+    await setSecrets({
       workspaceId: run.workspaceId,
       projectId: run.projectId,
-      namespace: '',
       values: {API_TOKEN: 'runtime-secret', UNUSED_TOKEN: 'unused-secret'},
     });
     const token = await mintActiveLeaseToken({jobId: job.id});
@@ -90,22 +96,13 @@ describe('GET /runs/jobs/current/steps/:stepId/secrets', () => {
         segments: [{kind: 'secret', store: 'local', key: 'API_TOKEN'}],
       },
     ]);
-    await secrets.setSecrets({
-      workspaceId: run.workspaceId,
-      namespace: '',
-      values: {API_TOKEN: 'workspace-secret'},
-    });
-    await secrets.setSecrets({
+    await setSecrets({workspaceId: run.workspaceId, values: {API_TOKEN: 'workspace-secret'}});
+    await setSecrets({
       workspaceId: run.workspaceId,
       projectId: run.projectId,
-      namespace: '',
       values: {API_TOKEN: 'project-secret'},
     });
-    await secrets.setSecrets({
-      workspaceId: hostileWorkspaceId,
-      namespace: '',
-      values: {API_TOKEN: 'hostile-secret'},
-    });
+    await setSecrets({workspaceId: hostileWorkspaceId, values: {API_TOKEN: 'hostile-secret'}});
     const token = await mintActiveLeaseToken({
       jobId: job.id,
       token: {workspaceId: hostileWorkspaceId, projectId: crypto.randomUUID()},

--- a/libs/api/workflows/src/presentation/routes/get-step-secrets.test.ts
+++ b/libs/api/workflows/src/presentation/routes/get-step-secrets.test.ts
@@ -1,5 +1,4 @@
 import {createLeaseTokenAuthMethod} from '@shipfox/api-auth';
-import {setSecrets} from '@shipfox/api-secrets';
 import {closeApp, createApp, type FastifyInstance} from '@shipfox/node-fastify';
 import {createCapturingLogger} from '@shipfox/node-log/test';
 import {eq} from 'drizzle-orm';
@@ -19,12 +18,14 @@ import {agentTestClient} from '#test/fixtures/agent-inter-module.js';
 import {annotationsTestClient} from '#test/fixtures/annotations-inter-module.js';
 import {projectsTestClient} from '#test/fixtures/projects-inter-module.js';
 import {runnersTestClient} from '#test/fixtures/runners-inter-module.js';
+import {createTestSecretsClient} from '#test/fixtures/secrets-inter-module.js';
 import {createLeaseTokenRouteGroup} from './index.js';
 
 const URL_PREFIX = '/runs/jobs/current/steps';
 
 describe('GET /runs/jobs/current/steps/:stepId/secrets', () => {
   let app: FastifyInstance;
+  const secrets = createTestSecretsClient();
   const {logger, lines: logLines, clear: clearLogLines} = createCapturingLogger();
 
   beforeAll(async () => {
@@ -36,6 +37,7 @@ describe('GET /runs/jobs/current/steps/:stepId/secrets', () => {
           annotations: annotationsTestClient,
           projects: projectsTestClient,
           runners: runnersTestClient,
+          secrets,
         }),
       ],
       swagger: false,
@@ -67,7 +69,7 @@ describe('GET /runs/jobs/current/steps/:stepId/secrets', () => {
         segments: [{kind: 'secret', store: 'local', key: 'API_TOKEN'}],
       },
     ]);
-    await setSecrets({
+    await secrets.setSecrets({
       workspaceId: run.workspaceId,
       projectId: run.projectId,
       values: {API_TOKEN: 'runtime-secret', UNUSED_TOKEN: 'unused-secret'},
@@ -98,13 +100,19 @@ describe('GET /runs/jobs/current/steps/:stepId/secrets', () => {
         segments: [{kind: 'secret', store: 'local', key: 'API_TOKEN'}],
       },
     ]);
-    await setSecrets({workspaceId: run.workspaceId, values: {API_TOKEN: 'workspace-secret'}});
-    await setSecrets({
+    await secrets.setSecrets({
+      workspaceId: run.workspaceId,
+      values: {API_TOKEN: 'workspace-secret'},
+    });
+    await secrets.setSecrets({
       workspaceId: run.workspaceId,
       projectId: run.projectId,
       values: {API_TOKEN: 'project-secret'},
     });
-    await setSecrets({workspaceId: hostileWorkspaceId, values: {API_TOKEN: 'hostile-secret'}});
+    await secrets.setSecrets({
+      workspaceId: hostileWorkspaceId,
+      values: {API_TOKEN: 'hostile-secret'},
+    });
     const token = await mintActiveLeaseToken({
       jobId: job.id,
       token: {workspaceId: hostileWorkspaceId, projectId: crypto.randomUUID()},

--- a/libs/api/workflows/src/presentation/routes/index.test.ts
+++ b/libs/api/workflows/src/presentation/routes/index.test.ts
@@ -7,9 +7,9 @@ import {
 } from '@shipfox/api-auth-context';
 import {type AuthMethod, ClientError, closeApp, createApp} from '@shipfox/node-fastify';
 import type {FastifyRequest} from 'fastify';
-import {workflowsTestAuthClient} from '#test/fixtures/auth-inter-module.js';
 import {agentTestClient} from '#test/fixtures/agent-inter-module.js';
 import {annotationsTestClient} from '#test/fixtures/annotations-inter-module.js';
+import {workflowsTestAuthClient} from '#test/fixtures/auth-inter-module.js';
 import {projectsTestClient} from '#test/fixtures/projects-inter-module.js';
 import {runnersTestClient} from '#test/fixtures/runners-inter-module.js';
 import {createTestSecretsClient} from '#test/fixtures/secrets-inter-module.js';

--- a/libs/api/workflows/src/presentation/routes/index.test.ts
+++ b/libs/api/workflows/src/presentation/routes/index.test.ts
@@ -8,6 +8,9 @@ import {
 import {type AuthMethod, ClientError, closeApp, createApp} from '@shipfox/node-fastify';
 import type {FastifyRequest} from 'fastify';
 import {workflowsTestAuthClient} from '#test/fixtures/auth-inter-module.js';
+import {agentTestClient} from '#test/fixtures/agent-inter-module.js';
+import {annotationsTestClient} from '#test/fixtures/annotations-inter-module.js';
+import {projectsTestClient} from '#test/fixtures/projects-inter-module.js';
 import {runnersTestClient} from '#test/fixtures/runners-inter-module.js';
 import {createTestSecretsClient} from '#test/fixtures/secrets-inter-module.js';
 import {createWorkflowRoutes} from './index.js';
@@ -32,13 +35,14 @@ afterEach(async () => {
 });
 
 describe('workflow route auth', () => {
-  const workflowRoutes = createWorkflowRoutes(
-    runnersTestClient,
-    workflowsTestAuthClient,
-    undefined,
-    undefined,
-    createTestSecretsClient(),
-  );
+  const workflowRoutes = createWorkflowRoutes({
+    agent: agentTestClient,
+    annotations: annotationsTestClient,
+    auth: workflowsTestAuthClient,
+    projects: projectsTestClient,
+    runners: runnersTestClient,
+    secrets: createTestSecretsClient(),
+  });
   test('uses user auth', () => {
     expect(workflowRoutes[0]?.auth).toBe(AUTH_USER);
   });

--- a/libs/api/workflows/src/presentation/routes/index.ts
+++ b/libs/api/workflows/src/presentation/routes/index.ts
@@ -1,4 +1,5 @@
 import type {AnnotationsInterModuleClient} from '@shipfox/annotations-dto/inter-module';
+import type {AgentInterModuleClient} from '@shipfox/api-agent-dto/inter-module';
 import {AUTH_LEASED_JOB, AUTH_USER} from '@shipfox/api-auth-context';
 import type {AuthInterModuleClient} from '@shipfox/api-auth-dto/inter-module';
 import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
@@ -17,77 +18,44 @@ import {createNextStepRoute} from './next-step.js';
 import {createReportStepRoute} from './report-step.js';
 import {rerunRunRoute} from './rerun-run.js';
 
-const unconfiguredProjects = {
-  getProjectById: () => {
-    throw new Error('Projects client is not configured');
-  },
-  requireProjectForWorkspace: () => {
-    throw new Error('Projects client is not configured');
-  },
-} as unknown as ProjectsModuleClient;
-const unconfiguredSecrets = {
-  getSecret: () => {
-    throw new Error('Secrets client is not configured');
-  },
-  getSecretsByNamespace: () => {
-    throw new Error('Secrets client is not configured');
-  },
-  getVariablesByNamespace: () => {
-    throw new Error('Secrets client is not configured');
-  },
-} as unknown as SecretsInterModuleClient;
+type WorkflowRouteClients = {
+  agent: AgentInterModuleClient;
+  annotations: AnnotationsInterModuleClient;
+  auth: AuthInterModuleClient;
+  projects: ProjectsModuleClient;
+  runners: RunnersInterModuleClient;
+  secrets: SecretsInterModuleClient;
+};
 
-const unconfiguredAnnotations = {
-  replaceOrRemoveAnnotation: () => {
-    throw new Error('Annotations client is not configured');
-  },
-} as unknown as AnnotationsInterModuleClient;
-const unconfiguredAuthClient = new Proxy({} as AuthInterModuleClient, {
-  get() {
-    throw new Error('Auth client is not configured');
-  },
-});
-
-export function createLeaseTokenRouteGroup(
-  runners: RunnersInterModuleClient,
-  projects: ProjectsModuleClient = unconfiguredProjects,
-  annotations: AnnotationsInterModuleClient = unconfiguredAnnotations,
-  secrets: SecretsInterModuleClient = unconfiguredSecrets,
-  auth: AuthInterModuleClient = unconfiguredAuthClient,
-): RouteGroup {
+export function createLeaseTokenRouteGroup(params: WorkflowRouteClients): RouteGroup {
   return {
+    // The lease token names the job, so the path carries no job id ("current").
     prefix: '/runs/jobs/current',
     auth: AUTH_LEASED_JOB,
     routes: [
-      createNextStepRoute(runners, annotations, auth),
-      createReportStepRoute(runners),
-      createCheckoutTokenRoute(runners, projects),
-      createAgentRuntimeConfigRoute(runners, secrets),
-      createGetStepSecretsRoute(runners, secrets),
+      createNextStepRoute(params),
+      createReportStepRoute(params.runners),
+      createCheckoutTokenRoute(params.runners, params.projects),
+      createAgentRuntimeConfigRoute(params),
+      createGetStepSecretsRoute(params.runners, params.secrets),
     ],
   };
 }
 
-export function createWorkflowRoutes(
-  runners: RunnersInterModuleClient,
-  auth: AuthInterModuleClient,
-  projects: ProjectsModuleClient = unconfiguredProjects,
-  annotations: AnnotationsInterModuleClient = unconfiguredAnnotations,
-  secrets: SecretsInterModuleClient = unconfiguredSecrets,
-): RouteGroup[] {
+export function createWorkflowRoutes(params: WorkflowRouteClients): RouteGroup[] {
   return [
     {
       prefix: '/workflows/runs',
       auth: AUTH_USER,
       routes: [
-        listRunsRoute(projects),
-        getRunAggregatesRoute(projects),
-        listRunAttemptsRoute(projects),
-        getRunRoute(projects),
-        cancelRunRoute(projects),
-        rerunRunRoute(projects),
+        listRunsRoute(params.projects),
+        getRunAggregatesRoute(params.projects),
+        listRunAttemptsRoute(params.projects),
+        getRunRoute(params.projects),
+        cancelRunRoute(params.projects),
+        rerunRunRoute(params.projects),
       ],
     },
-    createLeaseTokenRouteGroup(runners, projects, annotations, secrets, auth),
+    createLeaseTokenRouteGroup(params),
   ];
 }

--- a/libs/api/workflows/src/presentation/routes/next-step.test.ts
+++ b/libs/api/workflows/src/presentation/routes/next-step.test.ts
@@ -14,8 +14,10 @@ import {
 } from '#db/workflow-runs.js';
 import {insertRunningJobLease, mintActiveLeaseToken} from '#test/fixtures/active-lease-token.js';
 import {workflowsTestAuthClient} from '#test/fixtures/auth-inter-module.js';
+import {agentTestClient} from '#test/fixtures/agent-inter-module.js';
 import {arrangeJobWithSteps} from '#test/fixtures/job-with-steps.js';
 import {mintLeaseToken} from '#test/fixtures/lease-token.js';
+import {projectsTestClient} from '#test/fixtures/projects-inter-module.js';
 import {runnersTestClient} from '#test/fixtures/runners-inter-module.js';
 import {createTestSecretsClient} from '#test/fixtures/secrets-inter-module.js';
 import {createLeaseTokenRouteGroup} from './index.js';
@@ -58,13 +60,14 @@ describe('POST /runs/jobs/current/steps/next', () => {
     app = await createApp({
       auth: [createLeaseTokenAuthMethod()],
       routes: [
-        createLeaseTokenRouteGroup(
-          runnersTestClient,
-          undefined,
-          annotationsTestClient,
-          createTestSecretsClient(),
-          workflowsTestAuthClient,
-        ),
+        createLeaseTokenRouteGroup({
+          agent: agentTestClient,
+          annotations: annotationsTestClient,
+          auth: workflowsTestAuthClient,
+          projects: projectsTestClient,
+          runners: runnersTestClient,
+          secrets: createTestSecretsClient(),
+        }),
       ],
       swagger: false,
     });

--- a/libs/api/workflows/src/presentation/routes/next-step.test.ts
+++ b/libs/api/workflows/src/presentation/routes/next-step.test.ts
@@ -13,8 +13,8 @@ import {
   getWorkflowRunByAttemptId,
 } from '#db/workflow-runs.js';
 import {insertRunningJobLease, mintActiveLeaseToken} from '#test/fixtures/active-lease-token.js';
-import {workflowsTestAuthClient} from '#test/fixtures/auth-inter-module.js';
 import {agentTestClient} from '#test/fixtures/agent-inter-module.js';
+import {workflowsTestAuthClient} from '#test/fixtures/auth-inter-module.js';
 import {arrangeJobWithSteps} from '#test/fixtures/job-with-steps.js';
 import {mintLeaseToken} from '#test/fixtures/lease-token.js';
 import {projectsTestClient} from '#test/fixtures/projects-inter-module.js';

--- a/libs/api/workflows/src/presentation/routes/next-step.ts
+++ b/libs/api/workflows/src/presentation/routes/next-step.ts
@@ -1,4 +1,5 @@
 import type {AnnotationsInterModuleClient} from '@shipfox/annotations-dto/inter-module';
+import type {AgentInterModuleClient} from '@shipfox/api-agent-dto/inter-module';
 import {requireLeasedJobContext} from '@shipfox/api-auth-context';
 import type {AuthInterModuleClient} from '@shipfox/api-auth-dto/inter-module';
 import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-module';
@@ -9,11 +10,12 @@ import {JobLeaseNotActiveError, JobNotFoundError} from '#core/errors.js';
 import {nextStepForLeasedJobExecution} from '#core/job-execution.js';
 import {toStepDto} from '#presentation/dto/step.js';
 
-export function createNextStepRoute(
-  runners: RunnersInterModuleClient,
-  annotations: AnnotationsInterModuleClient,
-  auth: AuthInterModuleClient,
-) {
+export function createNextStepRoute(params: {
+  agent: AgentInterModuleClient;
+  annotations: AnnotationsInterModuleClient;
+  auth: AuthInterModuleClient;
+  runners: RunnersInterModuleClient;
+}) {
   return defineRoute({
     method: 'POST',
     path: '/steps/next',
@@ -35,15 +37,15 @@ export function createNextStepRoute(
     },
     handler: async (request) => {
       const leasedJob = requireLeasedJobContext(request);
-
       const next = await nextStepForLeasedJobExecution({
         jobId: leasedJob.jobId,
         jobExecutionId: leasedJob.jobExecutionId,
         runnerSessionId: leasedJob.runnerSessionId,
+        agent: params.agent,
       });
 
       if (next.kind === 'step') {
-        const {token: leaseToken} = await auth.mintJobLeaseToken({
+        const {token: leaseToken} = await params.auth.mintJobLeaseToken({
           workflowRunId: leasedJob.workflowRunId,
           ...(leasedJob.workflowRunAttempt === undefined
             ? {}
@@ -59,8 +61,8 @@ export function createNextStepRoute(
         });
         if (next.dispatched) {
           await warnAgentToolCapabilityMismatchOnDispatch({
-            annotations,
-            runners,
+            annotations: params.annotations,
+            runners: params.runners,
             leaseIdentity: leasedJob,
             step: next.step,
           });

--- a/libs/api/workflows/src/presentation/routes/report-step.test.ts
+++ b/libs/api/workflows/src/presentation/routes/report-step.test.ts
@@ -10,6 +10,7 @@ import {
 } from '#db/workflow-runs.js';
 import {insertRunningJobLease, mintActiveLeaseToken} from '#test/fixtures/active-lease-token.js';
 import {agentTestClient} from '#test/fixtures/agent-inter-module.js';
+import {annotationsTestClient} from '#test/fixtures/annotations-inter-module.js';
 import {arrangeJobWithSteps} from '#test/fixtures/job-with-steps.js';
 import {mintLeaseToken} from '#test/fixtures/lease-token.js';
 import {projectsTestClient} from '#test/fixtures/projects-inter-module.js';
@@ -33,6 +34,7 @@ describe('POST /runs/jobs/current/steps/:stepId/report', () => {
       routes: [
         createLeaseTokenRouteGroup({
           agent: agentTestClient,
+          annotations: annotationsTestClient,
           projects: projectsTestClient,
           runners: runnersTestClient,
         }),

--- a/libs/api/workflows/src/presentation/routes/report-step.test.ts
+++ b/libs/api/workflows/src/presentation/routes/report-step.test.ts
@@ -15,6 +15,7 @@ import {arrangeJobWithSteps} from '#test/fixtures/job-with-steps.js';
 import {mintLeaseToken} from '#test/fixtures/lease-token.js';
 import {projectsTestClient} from '#test/fixtures/projects-inter-module.js';
 import {runnersTestClient} from '#test/fixtures/runners-inter-module.js';
+import {createTestSecretsClient} from '#test/fixtures/secrets-inter-module.js';
 import {createLeaseTokenRouteGroup} from './index.js';
 
 function reportUrl(stepId: string): string {
@@ -37,6 +38,7 @@ describe('POST /runs/jobs/current/steps/:stepId/report', () => {
           annotations: annotationsTestClient,
           projects: projectsTestClient,
           runners: runnersTestClient,
+          secrets: createTestSecretsClient(),
         }),
       ],
       swagger: false,

--- a/libs/api/workflows/src/presentation/routes/report-step.test.ts
+++ b/libs/api/workflows/src/presentation/routes/report-step.test.ts
@@ -9,10 +9,11 @@ import {
   getWorkflowRunByAttemptId,
 } from '#db/workflow-runs.js';
 import {insertRunningJobLease, mintActiveLeaseToken} from '#test/fixtures/active-lease-token.js';
+import {agentTestClient} from '#test/fixtures/agent-inter-module.js';
 import {arrangeJobWithSteps} from '#test/fixtures/job-with-steps.js';
 import {mintLeaseToken} from '#test/fixtures/lease-token.js';
+import {projectsTestClient} from '#test/fixtures/projects-inter-module.js';
 import {runnersTestClient} from '#test/fixtures/runners-inter-module.js';
-import {createTestSecretsClient} from '#test/fixtures/secrets-inter-module.js';
 import {createLeaseTokenRouteGroup} from './index.js';
 
 function reportUrl(stepId: string): string {
@@ -30,12 +31,11 @@ describe('POST /runs/jobs/current/steps/:stepId/report', () => {
     app = await createApp({
       auth: [createLeaseTokenAuthMethod()],
       routes: [
-        createLeaseTokenRouteGroup(
-          runnersTestClient,
-          undefined,
-          undefined,
-          createTestSecretsClient(),
-        ),
+        createLeaseTokenRouteGroup({
+          agent: agentTestClient,
+          projects: projectsTestClient,
+          runners: runnersTestClient,
+        }),
       ],
       swagger: false,
     });

--- a/libs/api/workflows/src/presentation/routes/report-step.test.ts
+++ b/libs/api/workflows/src/presentation/routes/report-step.test.ts
@@ -11,6 +11,7 @@ import {
 import {insertRunningJobLease, mintActiveLeaseToken} from '#test/fixtures/active-lease-token.js';
 import {agentTestClient} from '#test/fixtures/agent-inter-module.js';
 import {annotationsTestClient} from '#test/fixtures/annotations-inter-module.js';
+import {workflowsTestAuthClient} from '#test/fixtures/auth-inter-module.js';
 import {arrangeJobWithSteps} from '#test/fixtures/job-with-steps.js';
 import {mintLeaseToken} from '#test/fixtures/lease-token.js';
 import {projectsTestClient} from '#test/fixtures/projects-inter-module.js';
@@ -36,6 +37,7 @@ describe('POST /runs/jobs/current/steps/:stepId/report', () => {
         createLeaseTokenRouteGroup({
           agent: agentTestClient,
           annotations: annotationsTestClient,
+          auth: workflowsTestAuthClient,
           projects: projectsTestClient,
           runners: runnersTestClient,
           secrets: createTestSecretsClient(),

--- a/libs/api/workflows/src/temporal/activities/index.ts
+++ b/libs/api/workflows/src/temporal/activities/index.ts
@@ -1,12 +1,13 @@
+import type {AgentInterModuleClient} from '@shipfox/api-agent-dto/inter-module';
 import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-module';
 import type {SecretsInterModuleClient} from '@shipfox/api-secrets-dto/inter-module';
 import {
   activateJobListenerActivity,
   bulkSetStepStatuses,
   createCancelRunnerJobsActivity,
+  createDrainListenerEventsActivity,
   createEnqueueJobExecutionForRunner,
   createReleaseLeaseActivity,
-  drainListenerEventsActivity,
   evaluateJobActivationsActivity,
   failJobExecutionAsTimedOutActivity,
   failRunAsTimedOutActivity,
@@ -22,34 +23,35 @@ import {
   settleListenerJobExecutionActivity,
 } from './orchestration-activities.js';
 
-export function createOrchestrationActivities(
-  runners: RunnersInterModuleClient,
-  secrets: Pick<SecretsInterModuleClient, 'getVariablesByNamespace'>,
-) {
+export function createOrchestrationActivities(params: {
+  agent: AgentInterModuleClient;
+  runners: RunnersInterModuleClient;
+  secrets: Pick<SecretsInterModuleClient, 'getVariablesByNamespace'>;
+}) {
   return {
     loadRunAttemptDag,
     setRunAttemptStatus,
     setJobStatus,
-    setJobExecutionStatus: async (params: Parameters<typeof setJobExecutionStatus>[0]) =>
-      await setJobExecutionStatus(params, secrets),
+    setJobExecutionStatus: async (activityParams: Parameters<typeof setJobExecutionStatus>[0]) =>
+      await setJobExecutionStatus(activityParams, params.secrets),
     bulkSetStepStatuses,
-    cancelRunnerJobsActivity: createCancelRunnerJobsActivity(runners),
-    enqueueJobExecutionForRunner: createEnqueueJobExecutionForRunner(runners),
+    cancelRunnerJobsActivity: createCancelRunnerJobsActivity(params.runners),
+    enqueueJobExecutionForRunner: createEnqueueJobExecutionForRunner(params.runners),
     evaluateJobActivationsActivity,
     failJobExecutionAsTimedOutActivity: async (
-      params: Parameters<typeof failJobExecutionAsTimedOutActivity>[0],
-    ) => await failJobExecutionAsTimedOutActivity(params, secrets),
+      activityParams: Parameters<typeof failJobExecutionAsTimedOutActivity>[0],
+    ) => await failJobExecutionAsTimedOutActivity(activityParams, params.secrets),
     failRunAsTimedOutActivity,
     activateJobListenerActivity,
-    drainListenerEventsActivity,
+    drainListenerEventsActivity: createDrainListenerEventsActivity(params.agent),
     peekListenerBufferActivity,
     resolveJobListenerActivity,
     settleListenerJobExecutionActivity,
     recordListenerFiringOutcomeActivity,
     resolveLeaseExpiredJobExecutionActivity: async (
-      params: Parameters<typeof resolveLeaseExpiredJobExecutionActivity>[0],
-    ) => await resolveLeaseExpiredJobExecutionActivity(params, secrets),
+      activityParams: Parameters<typeof resolveLeaseExpiredJobExecutionActivity>[0],
+    ) => await resolveLeaseExpiredJobExecutionActivity(activityParams, params.secrets),
     resolveJobStatusFromJobExecutionsActivity,
-    releaseLeaseActivity: createReleaseLeaseActivity(runners),
+    releaseLeaseActivity: createReleaseLeaseActivity(params.runners),
   };
 }

--- a/libs/api/workflows/src/temporal/activities/orchestration-activities.ts
+++ b/libs/api/workflows/src/temporal/activities/orchestration-activities.ts
@@ -1,3 +1,4 @@
+import type {AgentInterModuleClient} from '@shipfox/api-agent-dto/inter-module';
 import {
   type RunnersInterModuleClient,
   runnersInterModuleContract,
@@ -280,12 +281,9 @@ export async function activateJobListenerActivity(params: {
   return await activateJobListener(params);
 }
 
-export async function drainListenerEventsActivity(params: {
-  jobId: string;
-  expectedSequence: number;
-  maxSize?: number | undefined;
-}) {
-  return await drainListenerEventsIntoExecution(params);
+export function createDrainListenerEventsActivity(agent: AgentInterModuleClient) {
+  return async (params: {jobId: string; expectedSequence: number; maxSize?: number | undefined}) =>
+    await drainListenerEventsIntoExecution({...params, agent});
 }
 
 export async function peekListenerBufferActivity(params: {jobId: string}) {

--- a/libs/api/workflows/test/factories/workflow-model.test.ts
+++ b/libs/api/workflows/test/factories/workflow-model.test.ts
@@ -1,3 +1,4 @@
+import type {WorkflowModel} from '@shipfox/api-definitions-dto';
 import {workflowModel} from './workflow-model.js';
 
 describe('workflowModel', () => {
@@ -21,6 +22,9 @@ describe('workflowModel', () => {
       },
     });
 
-    expect(model.jobs.map((job) => job.runner)).toEqual([['ubuntu-22'], ['ubuntu-22', 'node-22']]);
+    expect(model.jobs.map((job: WorkflowModel['jobs'][number]) => job.runner)).toEqual([
+      ['ubuntu-22'],
+      ['ubuntu-22', 'node-22'],
+    ]);
   });
 });

--- a/libs/api/workflows/test/fixtures/agent-inter-module.ts
+++ b/libs/api/workflows/test/fixtures/agent-inter-module.ts
@@ -3,12 +3,7 @@ import type {AgentDefaultsResolver} from '#core/agent-defaults.js';
 
 export const agentTestClient: AgentInterModuleClient = {
   resolveAgentConfig({config}) {
-    return Promise.resolve({
-      harness: config.harness ?? 'pi',
-      provider: config.provider ?? 'anthropic',
-      model: config.model ?? 'claude-opus-4-8',
-      thinking: config.thinking ?? 'medium',
-    });
+    return Promise.resolve(resolveTestAgentDefaults(config));
   },
   resolveRuntimeCredentials({harness, provider, model, thinking}) {
     return Promise.resolve({
@@ -21,9 +16,12 @@ export const agentTestClient: AgentInterModuleClient = {
   },
 };
 
-export const resolveTestAgentDefaults: AgentDefaultsResolver = (config) => ({
-  harness: config.harness ?? 'pi',
-  provider: config.provider ?? 'anthropic',
-  model: config.model ?? 'claude-opus-4-8',
-  thinking: config.thinking ?? 'medium',
-});
+export const resolveTestAgentDefaults: AgentDefaultsResolver = (config) => {
+  const provider = config.provider ?? 'anthropic';
+  return {
+    harness: config.harness ?? 'pi',
+    provider,
+    model: config.model ?? (provider === 'openai' ? 'gpt-5.5-pro' : 'claude-opus-4-8'),
+    thinking: config.thinking ?? 'xhigh',
+  };
+};

--- a/libs/api/workflows/test/fixtures/agent-inter-module.ts
+++ b/libs/api/workflows/test/fixtures/agent-inter-module.ts
@@ -1,0 +1,29 @@
+import type {AgentInterModuleClient} from '@shipfox/api-agent-dto/inter-module';
+import type {AgentDefaultsResolver} from '#core/agent-defaults.js';
+
+export const agentTestClient: AgentInterModuleClient = {
+  resolveAgentConfig({config}) {
+    return Promise.resolve({
+      harness: config.harness ?? 'pi',
+      provider: config.provider ?? 'anthropic',
+      model: config.model ?? 'claude-opus-4-8',
+      thinking: config.thinking ?? 'medium',
+    });
+  },
+  resolveRuntimeCredentials({harness, provider, model, thinking}) {
+    return Promise.resolve({
+      harness,
+      provider_id: provider,
+      model,
+      thinking,
+      credentials: {api_key: 'test-agent-credential'},
+    });
+  },
+};
+
+export const resolveTestAgentDefaults: AgentDefaultsResolver = (config) => ({
+  harness: config.harness ?? 'pi',
+  provider: config.provider ?? 'anthropic',
+  model: config.model ?? 'claude-opus-4-8',
+  thinking: config.thinking ?? 'medium',
+});

--- a/libs/api/workflows/test/fixtures/annotations-inter-module.ts
+++ b/libs/api/workflows/test/fixtures/annotations-inter-module.ts
@@ -1,0 +1,5 @@
+import type {AnnotationsInterModuleClient} from '@shipfox/annotations-dto/inter-module';
+
+export const annotationsTestClient: AnnotationsInterModuleClient = {
+  replaceOrRemoveAnnotation: async () => ({}),
+};

--- a/libs/api/workflows/test/fixtures/projects-inter-module.ts
+++ b/libs/api/workflows/test/fixtures/projects-inter-module.ts
@@ -1,0 +1,8 @@
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+
+export const projectsTestClient = {
+  getProjectById: async () => ({project: undefined}),
+  requireProjectForWorkspace: () => {
+    throw new Error('Project is not configured');
+  },
+} as unknown as ProjectsModuleClient;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1858,6 +1858,9 @@ importers:
 
   libs/api/agent-dto:
     dependencies:
+      '@shipfox/inter-module':
+        specifier: workspace:*
+        version: link:../../shared/common/inter-module
       '@shipfox/workflow-document':
         specifier: workspace:*
         version: link:../../shared/workflow/document
@@ -3765,6 +3768,9 @@ importers:
       '@shipfox/api-agent':
         specifier: workspace:*
         version: link:../agent
+      '@shipfox/api-agent-dto':
+        specifier: workspace:*
+        version: link:../agent-dto
       '@shipfox/api-auth':
         specifier: workspace:*
         version: link:../auth
@@ -3996,9 +4002,6 @@ importers:
       '@shipfox/annotations-dto':
         specifier: workspace:*
         version: link:../annotations-dto
-      '@shipfox/api-agent':
-        specifier: workspace:*
-        version: link:../agent
       '@shipfox/api-agent-dto':
         specifier: workspace:*
         version: link:../agent-dto
@@ -4078,6 +4081,9 @@ importers:
       '@shipfox/annotations':
         specifier: workspace:*
         version: link:../annotations
+      '@shipfox/api-agent':
+        specifier: workspace:*
+        version: link:../agent
       '@shipfox/api-auth':
         specifier: workspace:*
         version: link:../auth
@@ -7546,10 +7552,6 @@ packages:
   '@aws-sdk/middleware-websocket@3.972.29':
     resolution: {integrity: sha512-Agv95NCgYyvuYUXt2PcFcOMrKCkhBFPhoH+nVMQh85RcXSCQrhAa4475plBOeomCihP26vKHT5KinVQT3iD14w==}
     engines: {node: '>= 14.0.0'}
-
-  '@aws-sdk/nested-clients@3.997.21':
-    resolution: {integrity: sha512-eC7Vl7Qom/BGhZjG9GEqPwdQ/fk45hg1t5LP4EUxG5d1fdshLbaxCiwh/tszUzDX/4mW40mu2QsbeJJRPBbqUw==}
-    engines: {node: '>=20.0.0'}
 
   '@aws-sdk/nested-clients@3.997.33':
     resolution: {integrity: sha512-dVZOroI/r3/ENvqNGgjMPul+jjlz9GddfVusgTXlVjfZj5isibOxecLkGQbRPp8XOuX+RAfjXLFgPkD1JS5xrw==}
@@ -16846,19 +16848,6 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/nested-clients@3.997.21':
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.975.3
-      '@aws-sdk/signature-v4-multi-region': 3.996.41
-      '@aws-sdk/types': 3.974.2
-      '@smithy/core': 3.29.5
-      '@smithy/fetch-http-handler': 5.6.7
-      '@smithy/node-http-handler': 4.9.7
-      '@smithy/types': 4.16.1
-      tslib: 2.8.1
-
   '@aws-sdk/nested-clients@3.997.33':
     dependencies:
       '@aws-sdk/core': 3.975.3
@@ -16889,7 +16878,7 @@ snapshots:
   '@aws-sdk/token-providers@3.1048.0':
     dependencies:
       '@aws-sdk/core': 3.975.3
-      '@aws-sdk/nested-clients': 3.997.21
+      '@aws-sdk/nested-clients': 3.997.33
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.29.5
       '@smithy/types': 4.16.1


### PR DESCRIPTION
Moves Agent default configuration and runtime credential resolution behind a producer-owned inter-module contract, then injects that client into Workflows routes, Temporal activities, and workflow execution.\n\nWorkflows previously imported Agent implementation internals and could fall back to catalog defaults without an explicit dependency. The new boundary makes Agent ownership explicit, keeps runtime credentials behind its producer, and makes missing route composition fail at compile time instead of as a runner 500.\n\nKnown Agent configuration failures are translated at the inter-module boundary; unknown infrastructure failures now preserve their original error identity. Review the contract error mapping and the explicit Agent client wiring in server composition.\n\nCloses ENG-1043

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose a producer-owned Agent inter-module API and migrate Workflows to use it for agent defaults and runtime credentials, omitting undefined fields at the boundary to avoid serialization errors. Also align server/route composition and test clients, and fix external pack dependencies (ENG-1043).

- New Features
  - Added `agentInterModuleContract` in `@shipfox/api-agent-dto/inter-module` with `resolveAgentConfig` and `resolveRuntimeCredentials`, plus an Agent inter-module presentation in `@shipfox/api-agent` that maps known config/provider/secret errors.
  - Server registers an Agent client and injects it into Workflows: module, routes, inter-module presentation, and Temporal activities via `createOrchestrationActivities` using `createDrainListenerEventsActivity`. Workflows resolve defaults with `createAgentDefaultsResolver` and translate known errors to 4xx. The agent runtime config route now calls `agent.resolveRuntimeCredentials` and maps known errors via `agentInterModuleContract`.
  - Composition/tests register the Agent presentation; tests use `agentTestClient`, `annotationsTestClient`, and `projectsTestClient`. External pack verification now includes `@shipfox/api-workflows-dto` and `@shipfox/inter-module`.

- Migration
  - Pass `agent: AgentInterModuleClient` into Workflows (`createWorkflowsModule`, route factories like `createLeaseTokenRouteGroup`/`createNextStepRoute`, `createWorkflowsInterModulePresentation`, and Temporal via `createOrchestrationActivities`).
  - Route factories now take a clients object; pass `agent`, `annotations`, `projects`, `runners`, `secrets`, and `auth` as required.
  - Update call sites to async helpers: `materializeWorkflowModel`, `materializeJobExecutionSteps`, `materializeListenerExecution`, `materializeWorkflowRunJobs`, `completeStepDispatchConfig`. Handle inter-module known errors where needed.

<sup>Written for commit 296403749a8d2b3d7cf4ec8cf611541d81c25ab7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

