### PR TITLE
Make webhook lifecycle retries fail closed

### DIFF
--- a/.changeset/steady-webhooks-retry.md
+++ b/.changeset/steady-webhooks-retry.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-integration-github": patch
+"@shipfox/api-integration-sentry": patch
+---
+
+Keeps GitHub credential cleanup and Sentry installation lifecycle handling safe across duplicate, concurrent, and reordered webhook delivery.

--- a/docs/architecture/webhook-retry-safety.md
+++ b/docs/architecture/webhook-retry-safety.md
@@ -1,0 +1,63 @@
+# Webhook retry safety
+
+Shipfox accepts provider webhooks at least once. A queued request can run more
+than once. SQS Standard can also run new requests before old ones.
+
+This audit covers handlers that change install state or call another system.
+Other event handlers save the provider delivery ID and outbox event in one
+database transaction.
+
+## Lifecycle handlers
+
+| Handler | Safety mechanism | Retry result |
+| --- | --- | --- |
+| GitHub `installation.deleted` and `installation.suspend` | The transaction returns the workspace and install IDs. Cleanup runs after commit. A duplicate returns the same IDs. Secret deletion is safe to repeat. | A cleanup error rejects the request. The next run sees the duplicate claim and tries cleanup again. |
+| Sentry `installation.created` | A pending row claims the install UUID and code hash before code exchange. A separate `exchange-succeeded` state is written only after a successful exchange. The installed state and delivery record share one transaction. | A retry skips exchange only when the durable success state or an installed row has the same code hash. An ambiguous `access-denied` response stays pending and fails closed. |
+| Sentry `installation.deleted` | Deletion writes a tombstone. It also writes one when creation has not arrived. Creation never changes a deleted row. | Repeated or reordered deletes keep the row deleted. A later creation saves its delivery without code exchange. |
+| Slack `app_uninstalled` and matching `tokens_revoked` | The handler claims the delivery before the update. It rejects old events. A generation check blocks a revoke that races with reconnect. | Duplicate and stale events save only their delivery claim. They do not revoke the current install. |
+
+## Disconnect handlers
+
+Linear and Slack delete secrets before database records. The connection row
+keeps the workspace ID and secret path until secret deletion works.
+
+Database deletion uses one transaction. A secret error leaves all records in
+place. A database rollback also keeps the connection handle. The retry repeats
+the safe secret deletion and removes the records.
+
+## Handlers with no queued lifecycle state
+
+- GitHub, Linear, and Slack browser callbacks use direct HTTP flows. They do not
+  use the stored webhook processor.
+- Gitea has no install lifecycle handler.
+- Linear webhooks publish domain events but do not change install state.
+- Generic webhook connections resolve current connection state but do not change
+  it.
+
+## Failure proof
+
+The focused tests inject these failures:
+
+- GitHub delivery commit followed by secret-store failure and duplicate retry.
+- Sentry code exchange followed by a failed state and delivery transaction. The
+  retry continues from the durable exchange checkpoint without exchanging again.
+- Sentry rejects a first exchange with `access-denied`. The claim remains pending
+  and no delivery is recorded as successful.
+- Sentry deletion delivered before creation.
+- Linear and Slack secret failure before record deletion.
+- Linear and Slack database failure after secret deletion.
+- Slack delayed revoke after a newer installation generation.
+
+## Sentry incomplete-install retention
+
+The daily Sentry cleanup uses the latest state-transition time, not the initial
+claim time. A slow exchange therefore receives a fresh retention window when it
+becomes installed. Pending claims older than the window are deleted so a later
+signed creation can claim the UUID again. `exchange-succeeded` and installed rows
+are tombstoned because they crossed a verified boundary and must not be revived.
+
+There is no transaction spanning Sentry's code exchange and Shipfox's database.
+If the process stops after Sentry spends the code but before Shipfox writes the
+success checkpoint, a retry cannot distinguish that event from an invalid or
+expired code. It deliberately remains pending and fails closed until retention
+releases the abandoned claim; it is never promoted from `access-denied` alone.

--- a/libs/api/integration/github/src/core/webhook-processor.test.ts
+++ b/libs/api/integration/github/src/core/webhook-processor.test.ts
@@ -1,10 +1,51 @@
 import {createHmac, randomUUID} from 'node:crypto';
-import {createStoredWebhookRequest, decodeWebhookBody} from '@shipfox/api-integration-core-dto';
+import {
+  createStoredWebhookRequest,
+  decodeWebhookBody,
+  type IntegrationConnection,
+} from '@shipfox/api-integration-core-dto';
+import {db} from '#db/db.js';
+import {githubInstallations} from '#db/schema/installations.js';
+import {githubInstallationFactory} from '#test/index.js';
 import {createGithubWebhookProcessor} from './webhook-processor.js';
 
 const WEBHOOK_SECRET = 'test-webhook-secret';
 
+function fakeConnection(id: string): IntegrationConnection {
+  return {
+    id,
+    workspaceId: randomUUID(),
+    provider: 'github',
+    externalAccountId: '123',
+    slug: 'github_shipfox',
+    displayName: 'GitHub shipfox',
+    lifecycleStatus: 'active',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+function signedInstallationRequest(deliveryId: string, installationId: number) {
+  const body = Buffer.from(JSON.stringify({action: 'deleted', installation: {id: installationId}}));
+  return createStoredWebhookRequest({
+    requestId: randomUUID(),
+    routeId: 'github',
+    receivedAt: new Date().toISOString(),
+    rawQueryString: '',
+    headers: {
+      'x-github-delivery': deliveryId,
+      'x-github-event': 'installation',
+      'x-hub-signature-256': `sha256=${createHmac('sha256', WEBHOOK_SECRET).update(body).digest('hex')}`,
+    },
+    body,
+  });
+}
+
 describe('GitHub webhook processor', () => {
+  beforeEach(async () => {
+    await db().delete(githubInstallations);
+  });
+
   it('discards a stored request with an invalid signature before opening a transaction', async () => {
     const coreDb = vi.fn();
     const processor = createGithubWebhookProcessor({
@@ -82,5 +123,44 @@ describe('GitHub webhook processor', () => {
 
     expect(Buffer.from(decodeWebhookBody(request.body))).toEqual(rawBody);
     expect(result).toMatchObject({outcome: 'discarded', reason: 'malformed_payload'});
+  });
+
+  it('retries credential cleanup after the delivery transaction commits', async () => {
+    const installationId = 8412;
+    const connectionId = randomUUID();
+    const connection = fakeConnection(connectionId);
+    const deliveryId = randomUUID();
+    await githubInstallationFactory.create({
+      connectionId,
+      installationId: String(installationId),
+    });
+    const publishIntegrationEventReceived = vi
+      .fn()
+      .mockResolvedValueOnce({published: true})
+      .mockResolvedValueOnce({published: false});
+    const deleteInstallationTokenSecret = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('secret store unavailable'))
+      .mockResolvedValueOnce(1);
+    const processor = createGithubWebhookProcessor({
+      coreDb: db,
+      publishIntegrationEventReceived,
+      publishSourcePush: vi.fn(),
+      recordDeliveryOnly: vi.fn(),
+      getIntegrationConnectionById: vi.fn(() => Promise.resolve(connection)),
+      deleteInstallationTokenSecret,
+    });
+    const request = signedInstallationRequest(deliveryId, installationId);
+
+    const firstAttempt = processor.process(request);
+    await expect(firstAttempt).rejects.toThrow('secret store unavailable');
+    const retryResult = await processor.process(request);
+
+    expect(retryResult).toEqual({outcome: 'duplicate', deliveryId});
+    expect(deleteInstallationTokenSecret).toHaveBeenCalledTimes(2);
+    expect(deleteInstallationTokenSecret).toHaveBeenLastCalledWith({
+      workspaceId: connection.workspaceId,
+      installationId,
+    });
   });
 });

--- a/libs/api/integration/github/src/core/webhook-processor.ts
+++ b/libs/api/integration/github/src/core/webhook-processor.ts
@@ -84,9 +84,12 @@ async function processGithubWebhookRequest(
       publishSourcePush: options.publishSourcePush,
       recordDeliveryOnly: options.recordDeliveryOnly,
       getIntegrationConnectionById: options.getIntegrationConnectionById,
-      deleteInstallationTokenSecret: options.deleteInstallationTokenSecret,
     }),
   );
+
+  if (result.installationTokenCleanup && options.deleteInstallationTokenSecret) {
+    await options.deleteInstallationTokenSecret(result.installationTokenCleanup);
+  }
 
   return result.outcome.startsWith('duplicate')
     ? {outcome: 'duplicate', deliveryId}

--- a/libs/api/integration/github/src/core/webhook.test.ts
+++ b/libs/api/integration/github/src/core/webhook.test.ts
@@ -299,70 +299,70 @@ describe('handleGithubEvent', () => {
     });
   });
 
-  it('requests cached installation token cleanup when the installation is deleted', async () => {
+  it('returns the cached installation token cleanup handle when the installation is deleted', async () => {
     const installationId = 7791;
     const connection = fakeConnection();
     await seedInstallation(installationId, connection.id);
     const handlers = deps({connection});
-    const deleteInstallationTokenSecret = vi.fn(() => Promise.resolve());
 
     const result = await handleGithubEvent({
       tx: db(),
       deliveryId: randomUUID(),
       event: 'installation',
       payload: {action: 'deleted', installation: {id: installationId}},
-      deleteInstallationTokenSecret,
       ...handlers,
     });
 
     expect(result.outcome).toBe('published-envelope');
-    expect(deleteInstallationTokenSecret).toHaveBeenCalledWith({
+    expect(result.installationTokenCleanup).toEqual({
       workspaceId: connection.workspaceId,
       installationId,
     });
   });
 
-  it('does not clean up cached installation tokens for duplicate lifecycle deliveries', async () => {
+  it('keeps the cleanup handle for duplicate lifecycle deliveries', async () => {
     const installationId = 7792;
     const connection = fakeConnection();
     await seedInstallation(installationId, connection.id);
     const handlers = deps({connection, publishIntegrationEventReceivedResult: {published: false}});
-    const deleteInstallationTokenSecret = vi.fn(() => Promise.resolve());
 
     const result = await handleGithubEvent({
       tx: db(),
       deliveryId: randomUUID(),
       event: 'installation',
       payload: {action: 'suspend', installation: {id: installationId}},
-      deleteInstallationTokenSecret,
       ...handlers,
     });
 
     expect(result.outcome).toBe('duplicate-envelope');
-    expect(deleteInstallationTokenSecret).not.toHaveBeenCalled();
+    expect(result.installationTokenCleanup).toEqual({
+      workspaceId: connection.workspaceId,
+      installationId,
+    });
   });
 
-  it('does not fail lifecycle webhook handling when cached token cleanup fails', async () => {
+  it('returns the cleanup handle for a deletion delivered after the connection is disabled', async () => {
     const installationId = 7793;
-    const connection = fakeConnection();
+    const connection = fakeConnection({lifecycleStatus: 'disabled'});
     await seedInstallation(installationId, connection.id);
     const handlers = deps({connection});
-    const deleteInstallationTokenSecret = vi.fn(() => Promise.reject(new Error('store down')));
 
     const result = await handleGithubEvent({
       tx: db(),
       deliveryId: randomUUID(),
       event: 'installation',
       payload: {action: 'deleted', installation: {id: installationId}},
-      deleteInstallationTokenSecret,
       ...handlers,
     });
 
-    expect(result.outcome).toBe('published-envelope');
-    expect(deleteInstallationTokenSecret).toHaveBeenCalledWith({
-      workspaceId: connection.workspaceId,
-      installationId,
+    expect(result).toEqual({
+      outcome: 'inactive-connection',
+      installationTokenCleanup: {
+        workspaceId: connection.workspaceId,
+        installationId,
+      },
     });
+    expect(handlers.recordDeliveryOnly).toHaveBeenCalledTimes(1);
   });
 
   it('publishes a bare resource envelope when action is malformed', async () => {

--- a/libs/api/integration/github/src/core/webhook.ts
+++ b/libs/api/integration/github/src/core/webhook.ts
@@ -30,9 +30,6 @@ export interface HandleGithubEventParams {
   publishSourcePush: PublishSourcePushFn;
   recordDeliveryOnly: RecordDeliveryOnlyFn;
   getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
-  deleteInstallationTokenSecret?:
-    | ((params: {workspaceId: string; installationId: number}) => Promise<unknown>)
-    | undefined;
 }
 
 export type HandleGithubEventOutcome =
@@ -47,13 +44,18 @@ export type HandleGithubEventOutcome =
   | 'inactive-connection'
   | 'no-installation-id';
 
+export interface HandleGithubEventResult {
+  outcome: HandleGithubEventOutcome;
+  installationTokenCleanup?: {workspaceId: string; installationId: number} | undefined;
+}
+
 function isBranchDeletion(after: string): boolean {
   return after === DELETED_BRANCH_SHA;
 }
 
 export async function handleGithubEvent(
   params: HandleGithubEventParams,
-): Promise<{outcome: HandleGithubEventOutcome}> {
+): Promise<HandleGithubEventResult> {
   const actionEnvelope = githubWebhookActionSchema.safeParse(params.payload);
   const action = actionEnvelope.success ? actionEnvelope.data.action : undefined;
   const installationEnvelope = githubWebhookInstallationSchema.safeParse(params.payload);
@@ -120,7 +122,13 @@ export async function handleGithubEvent(
       provider: GITHUB_SOURCE,
       deliveryId: params.deliveryId,
     });
-    return {outcome: 'inactive-connection'};
+    return withInstallationTokenCleanup(
+      {outcome: 'inactive-connection'},
+      params.event,
+      action,
+      connection.workspaceId,
+      installationId,
+    );
   }
 
   if (params.event === 'push') {
@@ -157,51 +165,28 @@ export async function handleGithubEvent(
     connection,
     event: eventName,
   });
-  if (result.outcome === 'published-envelope') {
-    await deleteInstallationTokenSecretBestEffort({
-      deleteInstallationTokenSecret: params.deleteInstallationTokenSecret,
-      event: params.event,
-      action,
-      deliveryId: params.deliveryId,
-      workspaceId: connection.workspaceId,
-      installationId,
-    });
-  }
-  return result;
+  return withInstallationTokenCleanup(
+    result,
+    params.event,
+    action,
+    connection.workspaceId,
+    installationId,
+  );
 }
 
 function shouldDeleteInstallationTokenSecret(event: string, action: string | undefined): boolean {
   return event === 'installation' && (action === 'deleted' || action === 'suspend');
 }
 
-async function deleteInstallationTokenSecretBestEffort(params: {
-  deleteInstallationTokenSecret:
-    | ((params: {workspaceId: string; installationId: number}) => Promise<unknown>)
-    | undefined;
-  event: string;
-  action: string | undefined;
-  deliveryId: string;
-  workspaceId: string;
-  installationId: number;
-}): Promise<void> {
-  if (!shouldDeleteInstallationTokenSecret(params.event, params.action)) return;
-
-  try {
-    await params.deleteInstallationTokenSecret?.({
-      workspaceId: params.workspaceId,
-      installationId: params.installationId,
-    });
-  } catch (error) {
-    logger().warn(
-      {
-        deliveryId: params.deliveryId,
-        installationId: params.installationId,
-        workspaceId: params.workspaceId,
-        error,
-      },
-      'github webhook installation token cleanup failed',
-    );
-  }
+function withInstallationTokenCleanup(
+  result: HandleGithubEventResult,
+  event: string,
+  action: string | undefined,
+  workspaceId: string,
+  installationId: number,
+): HandleGithubEventResult {
+  if (!shouldDeleteInstallationTokenSecret(event, action)) return result;
+  return {...result, installationTokenCleanup: {workspaceId, installationId}};
 }
 
 async function publishGithubPush(params: {

--- a/libs/api/integration/linear/src/core/disconnect.test.ts
+++ b/libs/api/integration/linear/src/core/disconnect.test.ts
@@ -12,6 +12,7 @@ const deleteLinearInstallationByConnectionIdMock = vi.mocked(
 describe('disconnectLinearInstallation', () => {
   beforeEach(() => {
     deleteLinearInstallationByConnectionIdMock.mockClear();
+    deleteLinearInstallationByConnectionIdMock.mockResolvedValue(true);
   });
 
   it('deletes stored tokens before deleting connection records', async () => {
@@ -41,5 +42,51 @@ describe('disconnectLinearInstallation', () => {
     expect(deleteLinearInstallationByConnectionIdMock).toHaveBeenCalledWith('connection-1', {tx});
     expect(deleteConnection).toHaveBeenCalledWith({connectionId: 'connection-1'}, {tx});
     expect(calls).toEqual(['secrets', 'connection']);
+  });
+
+  it('keeps connection records when secret deletion fails', async () => {
+    const transaction = vi.fn();
+    const deleteConnection = vi.fn();
+
+    const run = disconnectLinearInstallation({
+      connectionId: 'connection-1',
+      getConnection: vi.fn(() => Promise.resolve({workspaceId: 'workspace-1'})),
+      deleteSecrets: vi.fn(() => Promise.reject(new Error('secret store unavailable'))),
+      transaction,
+      deleteConnection,
+    });
+
+    await expect(run).rejects.toThrow('secret store unavailable');
+    expect(transaction).not.toHaveBeenCalled();
+    expect(deleteLinearInstallationByConnectionIdMock).not.toHaveBeenCalled();
+    expect(deleteConnection).not.toHaveBeenCalled();
+  });
+
+  it('retries idempotent secret deletion after the records transaction fails', async () => {
+    const tx = Symbol('tx');
+    const deleteSecrets = vi.fn(() => Promise.resolve(0));
+    const deleteConnection = vi.fn(() => Promise.resolve(true));
+    const transaction = vi
+      .fn()
+      .mockImplementationOnce(async (fn: (value: symbol) => Promise<unknown>) => {
+        await fn(tx);
+        throw new Error('database commit failed');
+      })
+      .mockImplementationOnce(async (fn: (value: symbol) => Promise<unknown>) => await fn(tx));
+    const params = {
+      connectionId: 'connection-1',
+      getConnection: vi.fn(() => Promise.resolve({workspaceId: 'workspace-1'})),
+      deleteSecrets,
+      transaction,
+      deleteConnection,
+    };
+
+    const firstAttempt = disconnectLinearInstallation(params);
+    await expect(firstAttempt).rejects.toThrow('database commit failed');
+    await disconnectLinearInstallation(params);
+
+    expect(deleteSecrets).toHaveBeenCalledTimes(2);
+    expect(deleteLinearInstallationByConnectionIdMock).toHaveBeenCalledTimes(2);
+    expect(deleteConnection).toHaveBeenCalledTimes(2);
   });
 });

--- a/libs/api/integration/sentry/src/config.ts
+++ b/libs/api/integration/sentry/src/config.ts
@@ -15,15 +15,14 @@ export const config = createConfig({
     default: true,
   }),
   SENTRY_UNCLAIMED_INSTALLATION_RETENTION_DAYS: num({
-    desc: 'How many days a verified-but-unclaimed Sentry installation may sit before the daily cleanup cron tombstones it. Must be at least 1; a smaller value moves the cutoff to now or the future and would tombstone freshly created, still-unclaimed installs. A reinstall always mints a fresh uuid, so a tombstone is never revived. Defaults to 7.',
+    desc: 'How many days an unclaimed Sentry installation or incomplete exchange may sit without a state transition. The daily cleanup releases pending claims and tombstones verified installs after this window. Must be at least 1. Defaults to 7.',
     default: 7,
   }),
 });
 
-// The daily cleanup cron tombstones every unclaimed install older than
-// `now - SENTRY_UNCLAIMED_INSTALLATION_RETENTION_DAYS`. A value below 1 moves that
-// cutoff to now or the future, which would wipe freshly created installs nobody has
-// claimed yet. Reject it at startup rather than let the 04:00 cron fail silently.
+// A value below 1 moves the cutoff to now or the future, which would expire fresh
+// claims before a browser can bind them. Reject it at startup rather than let the
+// 04:00 cron fail silently.
 export function assertRetentionDaysWithinBounds(days: number): void {
   if (!Number.isFinite(days) || days < 1) {
     throw new Error(

--- a/libs/api/integration/sentry/src/core/install.ts
+++ b/libs/api/integration/sentry/src/core/install.ts
@@ -89,7 +89,7 @@ export async function verifyAndPersistUnclaimedInstallation(
   });
 
   if (params.verifyInstall) {
-    await bestEffortVerifyInstallation({
+    await verifySentryInstallationBestEffort({
       sentry: params.sentry,
       installationUuid: params.installationUuid,
       token: authorization.token,
@@ -143,6 +143,9 @@ export async function handleSentryConnect(
     if (install.connectionId) {
       return resolveClaimedInstall(params, install.connectionId);
     }
+    if (!isVerifiedUnclaimed(install)) {
+      throw new SentryVerificationInProgressError(params.installationUuid);
+    }
     return claimVerifiedInstall(params, install);
   }
 
@@ -162,7 +165,7 @@ async function resolveClaimedInstall(
 
 async function claimVerifiedInstall(
   params: HandleSentryConnectParams,
-  install: SentryInstallation,
+  install: VerifiedUnclaimedSentryInstallation,
 ): Promise<IntegrationConnection<'sentry'>> {
   let authorization: SentryAuthorization;
   try {
@@ -188,7 +191,7 @@ async function claimVerifiedInstall(
     codeHash: hashAuthorizationCode(params.code),
   });
   if (params.verifyInstall) {
-    await bestEffortVerifyInstallation({
+    await verifySentryInstallationBestEffort({
       sentry: params.sentry,
       installationUuid: params.installationUuid,
       token: authorization.token,
@@ -222,7 +225,7 @@ async function claimBrowserFirst(
     codeHash: hashAuthorizationCode(params.code),
   });
   if (params.verifyInstall) {
-    await bestEffortVerifyInstallation({
+    await verifySentryInstallationBestEffort({
       sentry: params.sentry,
       installationUuid: params.installationUuid,
       token: result.authorization.token,
@@ -255,8 +258,19 @@ async function reconcileConcurrentClaim(
   throw new SentryVerificationInProgressError(params.installationUuid);
 }
 
-function isVerifiedUnclaimed(install: SentryInstallation): boolean {
-  return install.connectionId === null && install.status === 'installed';
+type VerifiedUnclaimedSentryInstallation = SentryInstallation & {
+  connectionId: null;
+  status: 'installed';
+  orgSlug: string;
+  codeHash: string;
+};
+
+function isVerifiedUnclaimed(
+  install: SentryInstallation,
+): install is VerifiedUnclaimedSentryInstallation {
+  return (
+    install.connectionId === null && install.status === 'installed' && install.codeHash !== null
+  );
 }
 
 function bindClaim(
@@ -273,7 +287,7 @@ function bindClaim(
   });
 }
 
-async function bestEffortVerifyInstallation(input: {
+export async function verifySentryInstallationBestEffort(input: {
   sentry: SentryApiClient;
   installationUuid: string;
   token: string;

--- a/libs/api/integration/sentry/src/core/webhook-processor.test.ts
+++ b/libs/api/integration/sentry/src/core/webhook-processor.test.ts
@@ -27,13 +27,14 @@ function fakeConnection(overrides: Partial<IntegrationConnection> = {}): Integra
   };
 }
 
-function sentryClient(): SentryApiClient {
+function sentryClient(overrides: Partial<SentryApiClient> = {}): SentryApiClient {
   return {
     exchangeAuthorizationCode: vi.fn(() =>
       Promise.resolve({token: 'tok', refreshToken: 'refresh', expiresAt: 'x'}),
     ),
     getInstallation: vi.fn(() => Promise.resolve({orgSlug: 'acme'})),
     verifyInstallation: vi.fn(() => Promise.resolve()),
+    ...overrides,
   };
 }
 
@@ -140,5 +141,164 @@ describe('Sentry webhook processor', () => {
 
     expect(result).toMatchObject({outcome: 'discarded', reason: 'invalid_signature'});
     expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+  });
+
+  it('continues from the durable exchange checkpoint after completion persistence fails', async () => {
+    const installationUuid = 'processor-installation-retry';
+    const deliveryId = randomUUID();
+    const exchangeAuthorizationCode = vi.fn(() =>
+      Promise.resolve({token: 'tok', refreshToken: 'refresh', expiresAt: 'x'}),
+    );
+    const recordDeliveryOnly = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('delivery persistence failed'))
+      .mockResolvedValueOnce(undefined);
+    const processor = createSentryWebhookProcessor({
+      sentry: sentryClient({exchangeAuthorizationCode}),
+      coreDb: db,
+      publishIntegrationEventReceived: vi.fn(() => Promise.resolve({published: true})),
+      recordDeliveryOnly,
+      getIntegrationConnectionById: vi.fn(() => Promise.resolve(fakeConnection())),
+      updateConnectionLifecycleStatus: vi.fn(() => Promise.resolve(undefined)),
+    });
+    const request = signedRequest({
+      deliveryId,
+      resource: 'installation',
+      body: {
+        action: 'created',
+        data: {
+          installation: {
+            uuid: installationUuid,
+            code: 'single-use-code',
+            organization: {slug: 'acme'},
+          },
+        },
+      },
+    });
+
+    const firstAttempt = processor.process(request);
+    await expect(firstAttempt).rejects.toThrow('delivery persistence failed');
+    const checkpoint = await db()
+      .select()
+      .from(sentryInstallations)
+      .where(eq(sentryInstallations.installationUuid, installationUuid));
+    const retryResult = await processor.process(request);
+    const [completed] = await db()
+      .select()
+      .from(sentryInstallations)
+      .where(eq(sentryInstallations.installationUuid, installationUuid));
+
+    expect(checkpoint[0]?.status).toBe('exchange-succeeded');
+    expect(retryResult).toEqual({outcome: 'processed', deliveryId});
+    expect(completed?.status).toBe('installed');
+    expect(exchangeAuthorizationCode).toHaveBeenCalledTimes(1);
+    expect(recordDeliveryOnly).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps deletion terminal when it races a pending installation exchange', async () => {
+    const installationUuid = 'processor-installation-delete-race';
+    let signalExchangeStarted = (): void => undefined;
+    const exchangeStarted = new Promise<void>((resolve) => {
+      signalExchangeStarted = resolve;
+    });
+    let finishExchange!: (authorization: {
+      token: string;
+      refreshToken: string;
+      expiresAt: string;
+    }) => void;
+    const exchangeResult = new Promise<{
+      token: string;
+      refreshToken: string;
+      expiresAt: string;
+    }>((resolve) => {
+      finishExchange = resolve;
+    });
+    const exchangeAuthorizationCode = vi.fn(() => {
+      signalExchangeStarted();
+      return exchangeResult;
+    });
+    const processor = createSentryWebhookProcessor({
+      sentry: sentryClient({exchangeAuthorizationCode}),
+      coreDb: db,
+      publishIntegrationEventReceived: vi.fn(() => Promise.resolve({published: true})),
+      recordDeliveryOnly: vi.fn(() => Promise.resolve()),
+      getIntegrationConnectionById: vi.fn(() => Promise.resolve(fakeConnection())),
+      updateConnectionLifecycleStatus: vi.fn(() => Promise.resolve(undefined)),
+    });
+    const creation = signedRequest({
+      resource: 'installation',
+      body: {
+        action: 'created',
+        data: {
+          installation: {
+            uuid: installationUuid,
+            code: 'single-use-code',
+            organization: {slug: 'acme'},
+          },
+        },
+      },
+    });
+    const deletion = signedRequest({
+      resource: 'installation',
+      body: {action: 'deleted', data: {installation: {uuid: installationUuid}}},
+    });
+
+    const creationAttempt = processor.process(creation);
+    await exchangeStarted;
+    const deletionResult = await processor.process(deletion);
+    finishExchange({token: 'tok', refreshToken: 'refresh', expiresAt: 'x'});
+    const creationResult = await creationAttempt;
+    const [installation] = await db()
+      .select()
+      .from(sentryInstallations)
+      .where(eq(sentryInstallations.installationUuid, installationUuid));
+
+    expect(creationResult.outcome).toBe('processed');
+    expect(deletionResult.outcome).toBe('processed');
+    expect(installation?.status).toBe('deleted');
+  });
+
+  it('keeps an out-of-order deletion as a monotonic tombstone', async () => {
+    const installationUuid = 'processor-installation-reordered';
+    const exchangeAuthorizationCode = vi.fn(() =>
+      Promise.resolve({token: 'tok', refreshToken: 'refresh', expiresAt: 'x'}),
+    );
+    const processor = createSentryWebhookProcessor({
+      sentry: sentryClient({exchangeAuthorizationCode}),
+      coreDb: db,
+      publishIntegrationEventReceived: vi.fn(() => Promise.resolve({published: true})),
+      recordDeliveryOnly: vi.fn(() => Promise.resolve()),
+      getIntegrationConnectionById: vi.fn(() => Promise.resolve(fakeConnection())),
+      updateConnectionLifecycleStatus: vi.fn(() => Promise.resolve(undefined)),
+    });
+    const deletion = signedRequest({
+      resource: 'installation',
+      body: {action: 'deleted', data: {installation: {uuid: installationUuid}}},
+    });
+    const creation = signedRequest({
+      resource: 'installation',
+      body: {
+        action: 'created',
+        data: {
+          installation: {
+            uuid: installationUuid,
+            code: 'single-use-code',
+            organization: {slug: 'acme'},
+          },
+        },
+      },
+    });
+
+    const deletionResult = await processor.process(deletion);
+    const creationResult = await processor.process(creation);
+    const [installation] = await db()
+      .select()
+      .from(sentryInstallations)
+      .where(eq(sentryInstallations.installationUuid, installationUuid));
+
+    expect(deletionResult.outcome).toBe('processed');
+    expect(creationResult.outcome).toBe('processed');
+    expect(installation?.status).toBe('deleted');
+    expect(exchangeAuthorizationCode).not.toHaveBeenCalled();
   });
 });

--- a/libs/api/integration/sentry/src/core/webhook-processor.ts
+++ b/libs/api/integration/sentry/src/core/webhook-processor.ts
@@ -24,8 +24,8 @@ import {
   normalizeSentryIssueAction,
 } from '#core/webhook.js';
 import {
+  completeSentryInstallationVerification,
   getSentryInstallationByInstallationUuid,
-  persistVerifiedUnclaimedInstallation,
 } from '#db/installations.js';
 import {verifySentrySignature} from './signature.js';
 
@@ -167,14 +167,18 @@ async function processInstallationResource(
     verifyInstall: config.SENTRY_APP_VERIFY_INSTALL,
     getSentryInstallation: ({installationUuid}) =>
       getSentryInstallationByInstallationUuid(installationUuid),
-    persistUnclaimedAndRecordDelivery: ({installationUuid, orgSlug, codeHash, deliveryId: id}) =>
+    persistUnclaimedAndRecordDelivery: ({installationUuid, codeHash, deliveryId: id}) =>
       context.coreDb().transaction(async (tx) => {
-        const persisted = await persistVerifiedUnclaimedInstallation(
-          {installationUuid, orgSlug, codeHash},
+        const completed = await completeSentryInstallationVerification(
+          {installationUuid, codeHash},
           {tx},
         );
         await context.recordDeliveryOnly({tx, provider: SENTRY_PROVIDER, deliveryId: id});
-        return persisted;
+        if (completed) return completed;
+
+        const current = await getSentryInstallationByInstallationUuid(installationUuid, {tx});
+        if (!current) throw new Error('Sentry installation verification lost its claim');
+        return current;
       }),
     recordDelivery: (id) => recordDeliveryOnly(context, id),
   });

--- a/libs/api/integration/sentry/src/core/webhook.ts
+++ b/libs/api/integration/sentry/src/core/webhook.ts
@@ -16,10 +16,12 @@ import {
   SentryInstallationUnclaimedError,
   SentryIntegrationProviderError,
 } from '#core/errors.js';
-import {verifyAndPersistUnclaimedInstallation} from '#core/install.js';
+import {hashAuthorizationCode, verifySentryInstallationBestEffort} from '#core/install.js';
 import {
+  claimSentryInstallationVerification,
   getSentryInstallationByInstallationUuid,
   markSentryInstallationDeleted,
+  markSentryInstallationExchangeSucceeded,
   type SentryInstallation,
 } from '#db/installations.js';
 
@@ -101,24 +103,24 @@ export interface HandleSentryInstallationCreatedParams {
     codeHash: string;
     deliveryId: string;
   }) => Promise<SentryInstallation>;
-  // Records the delivery for dedup without persisting an install (reconcile/no-op,
-  // missing code, or exchange failure → record-and-drop).
+  // Records the delivery for dedup without persisting an install (reconcile/no-op
+  // or missing claim input).
   recordDelivery: (deliveryId: string) => Promise<void>;
 }
 
 /**
  * The authoritative `installation.created` path. Whichever of webhook or browser
  * arrives first exchanges the single-use code and persists a verified-unclaimed
- * row; the other reconciles. Idempotent on the installation uuid. The exchange
- * runs outside any DB transaction; a short transaction wraps only persist +
- * delivery record. On an exchange failure the delivery is record-and-dropped
- * (204) — the browser may still win, or the code expired. Never logs the raw code.
+ * row; the other reconciles. The webhook writes a pending claim before the
+ * exchange and a durable checkpoint after it succeeds. Only that checkpoint can
+ * bypass the single-use exchange on retry. The installed transition and delivery
+ * record commit in one transaction. Never logs the raw code.
  */
 export async function handleSentryInstallationCreated(
   params: HandleSentryInstallationCreatedParams,
 ): Promise<void> {
   const existing = await params.getSentryInstallation({installationUuid: params.installationUuid});
-  if (existing) {
+  if (existing && (existing.status === 'installed' || existing.status === 'deleted')) {
     logger().debug(
       {deliveryId: params.deliveryId, installationUuid: params.installationUuid},
       'sentry webhook: installation.created for an existing row, reconciling',
@@ -127,58 +129,78 @@ export async function handleSentryInstallationCreated(
     return;
   }
 
-  if (!params.code) {
+  if (!params.code || !params.orgSlug) {
     logger().warn(
       {deliveryId: params.deliveryId, installationUuid: params.installationUuid},
-      'sentry webhook: installation.created without an authorization code, dropping',
+      'sentry webhook: installation.created without claim input, dropping',
     );
     await params.recordDelivery(params.deliveryId);
     return;
   }
 
-  try {
-    await verifyAndPersistUnclaimedInstallation({
+  const codeHash = hashAuthorizationCode(params.code);
+  let claimed =
+    existing ??
+    (await claimSentryInstallationVerification({
+      installationUuid: params.installationUuid,
+      orgSlug: params.orgSlug,
+      codeHash,
+    }));
+  if (claimed.status === 'installed' || claimed.status === 'deleted') {
+    await params.recordDelivery(params.deliveryId);
+    return;
+  }
+  if (claimed.codeHash !== codeHash) {
+    logger().warn(
+      {deliveryId: params.deliveryId, installationUuid: params.installationUuid},
+      'sentry webhook: installation.created does not match the pending claim, dropping',
+    );
+    await params.recordDelivery(params.deliveryId);
+    return;
+  }
+
+  let authorization: Awaited<ReturnType<SentryApiClient['exchangeAuthorizationCode']>> | undefined;
+  if (claimed.status === 'pending') {
+    try {
+      authorization = await params.sentry.exchangeAuthorizationCode({
+        installationUuid: params.installationUuid,
+        code: params.code,
+      });
+    } catch (error) {
+      if (!(error instanceof SentryIntegrationProviderError) || error.reason !== 'access-denied') {
+        throw error;
+      }
+
+      const current = await params.getSentryInstallation({
+        installationUuid: params.installationUuid,
+      });
+      const concurrentAttemptSucceeded =
+        current?.codeHash === codeHash &&
+        (current.status === 'exchange-succeeded' || current.status === 'installed');
+      if (!current || !concurrentAttemptSucceeded) throw error;
+      claimed = current;
+    }
+
+    if (authorization) {
+      await markSentryInstallationExchangeSucceeded({
+        installationUuid: params.installationUuid,
+        codeHash,
+      });
+    }
+  }
+
+  const completed = await params.persistUnclaimedAndRecordDelivery({
+    installationUuid: params.installationUuid,
+    orgSlug: claimed.orgSlug,
+    codeHash,
+    deliveryId: params.deliveryId,
+  });
+  if (authorization && completed.status === 'installed' && params.verifyInstall) {
+    await verifySentryInstallationBestEffort({
       sentry: params.sentry,
       installationUuid: params.installationUuid,
-      code: params.code,
-      orgSlug: params.orgSlug,
-      verifyInstall: params.verifyInstall,
-      persistVerifiedUnclaimedInstallation: ({installationUuid, orgSlug, codeHash}) =>
-        params.persistUnclaimedAndRecordDelivery({
-          installationUuid,
-          orgSlug,
-          codeHash,
-          deliveryId: params.deliveryId,
-        }),
+      token: authorization.token,
     });
-  } catch (error) {
-    if (error instanceof SentryIntegrationProviderError) {
-      // The Sentry exchange (or org-slug lookup) failed, so we never durably
-      // spent the code on a row we own. `reason` distinguishes a transient/expected
-      // drop (access-denied: the code was already spent, e.g. the browser won) from
-      // a likely misconfiguration (a bad client id/secret/slug fails every install)
-      // so log-based alerting can fire on the sustained case. Never logs the raw code.
-      logger().warn(
-        {
-          deliveryId: params.deliveryId,
-          installationUuid: params.installationUuid,
-          reason: error.reason,
-          err: error,
-        },
-        'sentry webhook: installation.created exchange failed, dropping',
-      );
-    } else {
-      // The exchange succeeded (the single-use code is now spent) but the persist
-      // transaction failed, so no row exists and Sentry will not usefully
-      // re-deliver — the install is stranded until a reinstall mints a fresh uuid.
-      // Log at error so alerting catches it; still record-and-drop because retrying
-      // a spent code cannot recover the row. Never logs the raw code.
-      logger().error(
-        {deliveryId: params.deliveryId, installationUuid: params.installationUuid, err: error},
-        'sentry webhook: installation.created persisted nothing after a successful exchange, install stranded until reinstall',
-      );
-    }
-    await params.recordDelivery(params.deliveryId);
   }
 }
 
@@ -191,9 +213,8 @@ export interface HandleSentryInstallationDeletedParams {
 }
 
 // Tombstones the install and disables its connection if one exists. An unknown
-// uuid (never installed, or reinstall mints a fresh uuid) only records the
-// delivery: there is no tombstone row to write. Runs entirely in the caller's
-// transaction — no exchange is needed.
+// uuid also gets a tombstone, so a reordered creation cannot restore it. The
+// state change and delivery record share the caller's transaction.
 export async function handleSentryInstallationDeleted(
   params: HandleSentryInstallationDeletedParams,
 ): Promise<void> {

--- a/libs/api/integration/sentry/src/db/installations.test.ts
+++ b/libs/api/integration/sentry/src/db/installations.test.ts
@@ -1,10 +1,14 @@
 import {randomUUID} from 'node:crypto';
+import {eq} from 'drizzle-orm';
 import {SentryInstallationAlreadyLinkedError} from '#core/errors.js';
 import {db} from './db.js';
 import {
+  claimSentryInstallationVerification,
+  completeSentryInstallationVerification,
   getSentryInstallationByInstallationUuid,
   listUnclaimedSentryInstallations,
   markSentryInstallationDeleted,
+  markSentryInstallationExchangeSucceeded,
   persistVerifiedUnclaimedInstallation,
   pruneUnclaimedSentryInstallations,
   upsertSentryInstallation,
@@ -99,10 +103,29 @@ describe('sentry installations persistence', () => {
     expect(deleted?.connectionId).toBe(connectionId);
   });
 
-  test('markSentryInstallationDeleted returns undefined when no row matches', async () => {
+  test('markSentryInstallationDeleted creates a tombstone when no row matches', async () => {
     const result = await markSentryInstallationDeleted({installationUuid: 'never-installed'});
 
-    expect(result).toBeUndefined();
+    expect(result.status).toBe('deleted');
+    expect(result.connectionId).toBeNull();
+    expect(result.orgSlug).toBe('');
+  });
+
+  test('upsert never restores a deleted tombstone', async () => {
+    const installationUuid = randomUUID();
+    await markSentryInstallationDeleted({installationUuid});
+
+    const reconnect = upsertSentryInstallation({
+      connectionId: randomUUID(),
+      installationUuid,
+      orgSlug: 'acme',
+      status: 'installed',
+    });
+
+    await expect(reconnect).rejects.toBeInstanceOf(SentryInstallationAlreadyLinkedError);
+    expect((await getSentryInstallationByInstallationUuid(installationUuid))?.status).toBe(
+      'deleted',
+    );
   });
 
   test('getSentryInstallationByInstallationUuid returns undefined for a miss', async () => {
@@ -123,6 +146,57 @@ describe('sentry installations persistence', () => {
     expect(persisted.connectionId).toBeNull();
     expect(persisted.status).toBe('installed');
     expect(persisted.codeHash).toBe('hash-1');
+  });
+
+  test('claimSentryInstallationVerification preserves the first pending code', async () => {
+    const installationUuid = randomUUID();
+    const first = await claimSentryInstallationVerification({
+      installationUuid,
+      orgSlug: 'acme',
+      codeHash: 'hash-1',
+    });
+
+    const second = await claimSentryInstallationVerification({
+      installationUuid,
+      orgSlug: 'other',
+      codeHash: 'hash-2',
+    });
+
+    expect(first.status).toBe('pending');
+    expect(second.status).toBe('pending');
+    expect(second.orgSlug).toBe('acme');
+    expect(second.codeHash).toBe('hash-1');
+  });
+
+  test('verification advances only from a matching pending claim through the exchange checkpoint', async () => {
+    const installationUuid = randomUUID();
+    await claimSentryInstallationVerification({
+      installationUuid,
+      orgSlug: 'acme',
+      codeHash: 'hash-1',
+    });
+
+    const prematureCompletion = await completeSentryInstallationVerification({
+      installationUuid,
+      codeHash: 'hash-1',
+    });
+    const mismatch = await markSentryInstallationExchangeSucceeded({
+      installationUuid,
+      codeHash: 'hash-2',
+    });
+    const exchanged = await markSentryInstallationExchangeSucceeded({
+      installationUuid,
+      codeHash: 'hash-1',
+    });
+    const completed = await completeSentryInstallationVerification({
+      installationUuid,
+      codeHash: 'hash-1',
+    });
+
+    expect(prematureCompletion).toBeUndefined();
+    expect(mismatch).toBeUndefined();
+    expect(exchanged?.status).toBe('exchange-succeeded');
+    expect(completed?.status).toBe('installed');
   });
 
   test('persistVerifiedUnclaimedInstallation never clobbers a claimed connection or downgrades status', async () => {
@@ -149,24 +223,42 @@ describe('sentry installations persistence', () => {
     expect(reconciled.codeHash).toBe('webhook-hash');
   });
 
-  test('listUnclaimedSentryInstallations returns only rows with no connection', async () => {
+  test('listUnclaimedSentryInstallations returns every non-deleted row with no connection', async () => {
     const claimedUuid = randomUUID();
-    const unclaimedUuid = randomUUID();
+    const pendingUuid = randomUUID();
+    const exchangedUuid = randomUUID();
+    const installedUuid = randomUUID();
     await upsertSentryInstallation({
       connectionId: randomUUID(),
       installationUuid: claimedUuid,
       orgSlug: 'acme',
       status: 'installed',
     });
+    await claimSentryInstallationVerification({
+      installationUuid: pendingUuid,
+      orgSlug: 'acme',
+      codeHash: 'pending-hash',
+    });
+    await claimSentryInstallationVerification({
+      installationUuid: exchangedUuid,
+      orgSlug: 'acme',
+      codeHash: 'exchanged-hash',
+    });
+    await markSentryInstallationExchangeSucceeded({
+      installationUuid: exchangedUuid,
+      codeHash: 'exchanged-hash',
+    });
     await persistVerifiedUnclaimedInstallation({
-      installationUuid: unclaimedUuid,
+      installationUuid: installedUuid,
       orgSlug: 'acme',
       codeHash: 'hash',
     });
 
     const unclaimed = await listUnclaimedSentryInstallations();
 
-    expect(unclaimed.map((row) => row.installationUuid)).toEqual([unclaimedUuid]);
+    expect(unclaimed.map((row) => row.installationUuid).sort()).toEqual(
+      [pendingUuid, exchangedUuid, installedUuid].sort(),
+    );
   });
 
   test('listUnclaimedSentryInstallations filters by age when olderThan is given', async () => {
@@ -184,25 +276,79 @@ describe('sentry installations persistence', () => {
     expect(await listUnclaimedSentryInstallations({olderThan: past})).toHaveLength(0);
   });
 
-  test('pruneUnclaimedSentryInstallations tombstones stale unclaimed rows and leaves fresh ones', async () => {
-    const staleUuid = randomUUID();
+  test('pruneUnclaimedSentryInstallations releases stale pending claims', async () => {
+    const installationUuid = randomUUID();
+    await claimSentryInstallationVerification({
+      installationUuid,
+      orgSlug: 'acme',
+      codeHash: 'stale-hash',
+    });
+
+    const result = await pruneUnclaimedSentryInstallations({
+      olderThan: new Date(Date.now() + 60_000),
+    });
+    const reclaimed = await claimSentryInstallationVerification({
+      installationUuid,
+      orgSlug: 'acme',
+      codeHash: 'fresh-hash',
+    });
+
+    expect(result).toEqual({releasedPending: 1, tombstoned: 0});
+    expect(reclaimed.status).toBe('pending');
+    expect(reclaimed.codeHash).toBe('fresh-hash');
+  });
+
+  test('pruneUnclaimedSentryInstallations tombstones stale exchanged and installed rows', async () => {
+    const exchangedUuid = randomUUID();
+    const installedUuid = randomUUID();
+    await claimSentryInstallationVerification({
+      installationUuid: exchangedUuid,
+      orgSlug: 'acme',
+      codeHash: 'exchanged-hash',
+    });
+    await markSentryInstallationExchangeSucceeded({
+      installationUuid: exchangedUuid,
+      codeHash: 'exchanged-hash',
+    });
     await persistVerifiedUnclaimedInstallation({
-      installationUuid: staleUuid,
+      installationUuid: installedUuid,
       orgSlug: 'acme',
       codeHash: 'hash',
     });
 
-    const youngResult = await pruneUnclaimedSentryInstallations({
-      olderThan: new Date(Date.now() - 60_000),
-    });
-    expect(youngResult.tombstoned).toBe(0);
-
-    const staleResult = await pruneUnclaimedSentryInstallations({
+    const result = await pruneUnclaimedSentryInstallations({
       olderThan: new Date(Date.now() + 60_000),
     });
-    expect(staleResult.tombstoned).toBe(1);
-    expect((await getSentryInstallationByInstallationUuid(staleUuid))?.status).toBe('deleted');
+
+    expect(result).toEqual({releasedPending: 0, tombstoned: 2});
+    expect((await getSentryInstallationByInstallationUuid(exchangedUuid))?.status).toBe('deleted');
+    expect((await getSentryInstallationByInstallationUuid(installedUuid))?.status).toBe('deleted');
     expect(await listUnclaimedSentryInstallations()).toHaveLength(0);
+  });
+
+  test('completing an old claim starts a fresh installed retention window', async () => {
+    const installationUuid = randomUUID();
+    const oldTimestamp = new Date(Date.now() - 120_000);
+    await claimSentryInstallationVerification({
+      installationUuid,
+      orgSlug: 'acme',
+      codeHash: 'hash',
+    });
+    await db()
+      .update(sentryInstallations)
+      .set({createdAt: oldTimestamp, updatedAt: oldTimestamp})
+      .where(eq(sentryInstallations.installationUuid, installationUuid));
+    await markSentryInstallationExchangeSucceeded({installationUuid, codeHash: 'hash'});
+    await completeSentryInstallationVerification({installationUuid, codeHash: 'hash'});
+
+    const result = await pruneUnclaimedSentryInstallations({
+      olderThan: new Date(Date.now() - 60_000),
+    });
+
+    expect(result).toEqual({releasedPending: 0, tombstoned: 0});
+    expect((await getSentryInstallationByInstallationUuid(installationUuid))?.status).toBe(
+      'installed',
+    );
   });
 
   test('pruneUnclaimedSentryInstallations never tombstones a claimed install', async () => {

--- a/libs/api/integration/sentry/src/db/installations.ts
+++ b/libs/api/integration/sentry/src/db/installations.ts
@@ -1,16 +1,20 @@
-import {and, eq, isNull, lt, sql} from 'drizzle-orm';
+import {and, eq, inArray, isNull, lt, ne, sql} from 'drizzle-orm';
 import {SentryInstallationAlreadyLinkedError} from '#core/errors.js';
 import {db} from './db.js';
 import {sentryInstallations, toSentryInstallation} from './schema/installations.js';
 
 export type SentryInstallationStatus = 'installed' | 'deleted';
+export type SentryInstallationRowStatus =
+  | 'pending'
+  | 'exchange-succeeded'
+  | SentryInstallationStatus;
 
 export interface SentryInstallation {
   id: string;
   connectionId: string | null;
   installationUuid: string;
   orgSlug: string;
-  status: string;
+  status: SentryInstallationRowStatus;
   codeHash: string | null;
   installerUserId: string | null;
   createdAt: Date;
@@ -27,6 +31,12 @@ export interface UpsertSentryInstallationParams {
 }
 
 export interface PersistVerifiedUnclaimedInstallationParams {
+  installationUuid: string;
+  orgSlug: string;
+  codeHash: string;
+}
+
+export interface ClaimSentryInstallationVerificationParams {
   installationUuid: string;
   orgSlug: string;
   codeHash: string;
@@ -53,15 +63,10 @@ export async function upsertSentryInstallation(
     })
     .onConflictDoUpdate({
       target: sentryInstallations.installationUuid,
-      // TOCTOU guard: allow the update only when this installation is unclaimed
-      // (connection_id IS NULL, the first claim of a verified-unclaimed row) or
-      // already owned by this same connection (idempotent reconnect). A concurrent
-      // claim of the same installation to a different workspace commits its own
-      // connection_id first; this losing transaction then sees a different non-null
-      // connection_id, the predicate is false, Postgres updates nothing, and the
-      // empty RETURNING below rolls it back instead of silently repointing the
-      // installation (cross-tenant event misroute).
-      setWhere: sql`${sentryInstallations.connectionId} is null or ${sentryInstallations.connectionId} = ${params.connectionId}`,
+      // A deleted UUID is terminal. Otherwise, allow the first claim of an
+      // unclaimed row or an idempotent reconnect by its current connection. This
+      // blocks both a concurrent cross-workspace claim and a claim racing deletion.
+      setWhere: sql`${sentryInstallations.status} <> 'deleted' and (${sentryInstallations.connectionId} is null or ${sentryInstallations.connectionId} = ${params.connectionId})`,
       set: {
         connectionId: params.connectionId,
         orgSlug: params.orgSlug,
@@ -80,9 +85,8 @@ export async function upsertSentryInstallation(
 /**
  * Inserts the verified-but-unclaimed install half (`connection_id = NULL`,
  * `status = 'installed'`) after a successful code exchange. Idempotent on the
- * installation uuid: a conflicting row refreshes only `code_hash`/`org_slug`/
- * `updated_at`, so a webhook that lands after a claim never clobbers the
- * `connection_id` it set nor downgrades a `deleted` tombstone back to installed.
+ * installation uuid: a pending row becomes installed, a claimed row keeps its
+ * `connection_id`, and a deleted tombstone never becomes installed again.
  */
 export async function persistVerifiedUnclaimedInstallation(
   params: PersistVerifiedUnclaimedInstallationParams,
@@ -101,23 +105,97 @@ export async function persistVerifiedUnclaimedInstallation(
     })
     .onConflictDoUpdate({
       target: sentryInstallations.installationUuid,
+      setWhere: ne(sentryInstallations.status, 'deleted'),
       set: {
         orgSlug: params.orgSlug,
+        status: 'installed',
         codeHash: params.codeHash,
         updatedAt: now,
       },
     })
     .returning();
 
-  if (!row) throw new Error('Sentry installation persist returned no rows');
+  if (!row) {
+    const existing = await getSentryInstallationByInstallationUuid(params.installationUuid, {
+      tx: executor,
+    });
+    if (existing) return existing;
+    throw new Error('Sentry installation persist returned no rows');
+  }
+  return toSentryInstallation(row);
+}
+
+export async function claimSentryInstallationVerification(
+  params: ClaimSentryInstallationVerificationParams,
+  options: {tx?: unknown} = {},
+): Promise<SentryInstallation> {
+  const executor = (options.tx ?? db()) as SentryDb | SentryTx;
+  const [inserted] = await executor
+    .insert(sentryInstallations)
+    .values({
+      connectionId: null,
+      installationUuid: params.installationUuid,
+      orgSlug: params.orgSlug,
+      status: 'pending',
+      codeHash: params.codeHash,
+    })
+    .onConflictDoNothing({target: sentryInstallations.installationUuid})
+    .returning();
+
+  if (inserted) return toSentryInstallation(inserted);
+
+  const existing = await getSentryInstallationByInstallationUuid(params.installationUuid, {
+    tx: executor,
+  });
+  if (!existing) throw new Error('Sentry installation verification claim returned no rows');
+  return existing;
+}
+
+export async function completeSentryInstallationVerification(
+  params: {installationUuid: string; codeHash: string},
+  options: {tx?: unknown} = {},
+): Promise<SentryInstallation | undefined> {
+  const executor = (options.tx ?? db()) as SentryDb | SentryTx;
+  const [row] = await executor
+    .update(sentryInstallations)
+    .set({status: 'installed', updatedAt: new Date()})
+    .where(
+      and(
+        eq(sentryInstallations.installationUuid, params.installationUuid),
+        eq(sentryInstallations.status, 'exchange-succeeded'),
+        eq(sentryInstallations.codeHash, params.codeHash),
+      ),
+    )
+    .returning();
+  if (!row) return undefined;
+  return toSentryInstallation(row);
+}
+
+export async function markSentryInstallationExchangeSucceeded(
+  params: {installationUuid: string; codeHash: string},
+  options: {tx?: unknown} = {},
+): Promise<SentryInstallation | undefined> {
+  const executor = (options.tx ?? db()) as SentryDb | SentryTx;
+  const [row] = await executor
+    .update(sentryInstallations)
+    .set({status: 'exchange-succeeded', updatedAt: new Date()})
+    .where(
+      and(
+        eq(sentryInstallations.installationUuid, params.installationUuid),
+        eq(sentryInstallations.status, 'pending'),
+        eq(sentryInstallations.codeHash, params.codeHash),
+      ),
+    )
+    .returning();
+  if (!row) return undefined;
   return toSentryInstallation(row);
 }
 
 /**
- * Verified installs no user has claimed yet (`connection_id IS NULL`,
- * `status='installed'`). Tombstoned rows are excluded so the TTL cron stays
- * idempotent and the unclaimed metric stays accurate. Pass `olderThan` to scope
- * to stale rows for the cron.
+ * Install claims no user has bound to a connection yet. This includes pending
+ * and exchanged claims so abandoned verification work remains observable.
+ * Tombstoned rows are excluded. Pass `olderThan` to scope by the most recent
+ * state transition for retention work.
  */
 export async function listUnclaimedSentryInstallations(
   params: {olderThan?: Date} = {},
@@ -126,10 +204,10 @@ export async function listUnclaimedSentryInstallations(
   const executor = (options.tx ?? db()) as SentryDb | SentryTx;
   const conditions = [
     isNull(sentryInstallations.connectionId),
-    eq(sentryInstallations.status, 'installed'),
+    inArray(sentryInstallations.status, ['pending', 'exchange-succeeded', 'installed']),
   ];
   if (params.olderThan) {
-    conditions.push(lt(sentryInstallations.createdAt, params.olderThan));
+    conditions.push(lt(sentryInstallations.updatedAt, params.olderThan));
   }
   const rows = await executor
     .select()
@@ -169,39 +247,62 @@ export async function getSentryInstallationByConnectionId(
 }
 
 /**
- * Tombstones verified-unclaimed installs older than `olderThan` (the TTL cleanup
- * cron). Bounds a never-claimed install rather than leaving it pending forever.
- * Returns how many rows were tombstoned. We hold no Sentry token for these rows
- * (tokens are never persisted), so the Sentry-side uninstall is out of scope here.
+ * Releases abandoned pending claims and tombstones verified-unclaimed installs
+ * older than `olderThan`. Pending claims have not durably completed an exchange,
+ * so deleting them allows a later signed creation to try again. Exchanged and
+ * installed rows stay terminal after expiry. We hold no Sentry token for these
+ * rows, so the Sentry-side uninstall is out of scope here.
  */
 export async function pruneUnclaimedSentryInstallations(
   params: {olderThan: Date},
   options: {tx?: unknown} = {},
-): Promise<{tombstoned: number}> {
+): Promise<{releasedPending: number; tombstoned: number}> {
   const executor = (options.tx ?? db()) as SentryDb | SentryTx;
-  const result = await executor
+  const releasedPending = await executor
+    .delete(sentryInstallations)
+    .where(
+      and(
+        isNull(sentryInstallations.connectionId),
+        eq(sentryInstallations.status, 'pending'),
+        lt(sentryInstallations.updatedAt, params.olderThan),
+      ),
+    );
+  const tombstoned = await executor
     .update(sentryInstallations)
     .set({status: 'deleted', updatedAt: new Date()})
     .where(
       and(
         isNull(sentryInstallations.connectionId),
-        eq(sentryInstallations.status, 'installed'),
-        lt(sentryInstallations.createdAt, params.olderThan),
+        inArray(sentryInstallations.status, ['exchange-succeeded', 'installed']),
+        lt(sentryInstallations.updatedAt, params.olderThan),
       ),
     );
-  return {tombstoned: result.rowCount ?? 0};
+  return {
+    releasedPending: releasedPending.rowCount ?? 0,
+    tombstoned: tombstoned.rowCount ?? 0,
+  };
 }
 
 export async function markSentryInstallationDeleted(
   params: {installationUuid: string},
   options: {tx?: unknown} = {},
-): Promise<SentryInstallation | undefined> {
+): Promise<SentryInstallation> {
   const executor = (options.tx ?? db()) as SentryDb | SentryTx;
   const [row] = await executor
-    .update(sentryInstallations)
-    .set({status: 'deleted', updatedAt: new Date()})
-    .where(eq(sentryInstallations.installationUuid, params.installationUuid))
+    .insert(sentryInstallations)
+    .values({
+      connectionId: null,
+      installationUuid: params.installationUuid,
+      // A reordered delete can arrive without organization data. Deleted rows never expose an organization URL.
+      orgSlug: '',
+      status: 'deleted',
+      codeHash: null,
+    })
+    .onConflictDoUpdate({
+      target: sentryInstallations.installationUuid,
+      set: {status: 'deleted', updatedAt: new Date()},
+    })
     .returning();
-  if (!row) return undefined;
+  if (!row) throw new Error('Sentry installation deletion returned no rows');
   return toSentryInstallation(row);
 }

--- a/libs/api/integration/sentry/src/db/schema/installations.ts
+++ b/libs/api/integration/sentry/src/db/schema/installations.ts
@@ -1,6 +1,6 @@
 import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
 import {text, timestamp, uniqueIndex, uuid} from 'drizzle-orm/pg-core';
-import type {SentryInstallation} from '#db/installations.js';
+import type {SentryInstallation, SentryInstallationRowStatus} from '#db/installations.js';
 import {pgTable} from './common.js';
 
 export const sentryInstallations = pgTable(
@@ -8,15 +8,15 @@ export const sentryInstallations = pgTable(
   {
     id: uuidv7PrimaryKey(),
     // Null until a logged-in user claims the verified install into a workspace.
-    // An unclaimed install (`connection_id IS NULL`, `status='installed'`) is
-    // persisted by the authoritative webhook before any browser claim arrives.
+    // Pending and verified installs remain unclaimed until the browser binds a
+    // connection. Deleted rows are terminal tombstones.
     connectionId: uuid('connection_id'),
     installationUuid: text('installation_uuid').notNull(),
     orgSlug: text('org_slug').notNull(),
-    status: text('status').notNull(),
-    // sha256(authorization code) of the exchange that verified this install.
-    // The claim presents the code and we match the hash, so a bare uuid alone
-    // cannot bind the install (IDOR guard) without storing a live credential.
+    status: text('status').notNull().$type<SentryInstallationRowStatus>(),
+    // sha256(authorization code) claimed for this install. The hash identifies
+    // which pending exchange reached the durable success checkpoint and keeps a
+    // bare uuid from binding an install (IDOR guard) without storing a credential.
     codeHash: text('code_hash'),
     installerUserId: uuid('installer_user_id'),
     createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),

--- a/libs/api/integration/sentry/src/presentation/routes/webhooks.test.ts
+++ b/libs/api/integration/sentry/src/presentation/routes/webhooks.test.ts
@@ -617,7 +617,7 @@ describe('Sentry webhook route', () => {
     expect(recordDeliveryOnly).toHaveBeenCalledTimes(1);
   });
 
-  test('installation/deleted with no matching row records the delivery and does not disable', async () => {
+  test('installation/deleted with no matching row writes a tombstone and does not disable', async () => {
     const {app, recordDeliveryOnly, updateConnectionLifecycleStatus} = await createTestApp();
     const deliveryId = randomUUID();
     const body = JSON.stringify(
@@ -635,6 +635,7 @@ describe('Sentry webhook route', () => {
     });
 
     expect(res.statusCode).toBe(204);
+    expect((await readInstallation('never-installed'))?.status).toBe('deleted');
     expect(updateConnectionLifecycleStatus).not.toHaveBeenCalled();
     expect(recordDeliveryOnly).toHaveBeenCalledTimes(1);
   });
@@ -719,7 +720,7 @@ describe('Sentry webhook route', () => {
     expect(recordDeliveryOnly).toHaveBeenCalledTimes(1);
   });
 
-  test('installation/created records-and-drops when the code exchange fails', async () => {
+  test('installation/created stays pending when access denied has no success checkpoint', async () => {
     const installationUuid = 'install-created-exchangefail';
     const {app, recordDeliveryOnly} = await createTestApp({
       sentry: sentryClient({
@@ -745,9 +746,9 @@ describe('Sentry webhook route', () => {
       payload: body,
     });
 
-    expect(res.statusCode).toBe(204);
-    expect(await readInstallation(installationUuid)).toBeUndefined();
-    expect(recordDeliveryOnly).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(500);
+    expect((await readInstallation(installationUuid))?.status).toBe('pending');
+    expect(recordDeliveryOnly).not.toHaveBeenCalled();
   });
 
   test('records the delivery only for a malformed installation payload', async () => {

--- a/libs/api/integration/sentry/src/temporal/activities/prune-unclaimed-installations.test.ts
+++ b/libs/api/integration/sentry/src/temporal/activities/prune-unclaimed-installations.test.ts
@@ -7,8 +7,7 @@ import {pruneUnclaimedSentryInstallationsActivity} from './prune-unclaimed-insta
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 // The activity derives its cutoff from SENTRY_UNCLAIMED_INSTALLATION_RETENTION_DAYS
-// (default 7), so rows are seeded with an explicit createdAt to straddle it; the
-// persist helpers always stamp createdAt=now and could not exercise the cutoff.
+// (default 7), so rows are seeded with an explicit updatedAt to straddle it.
 describe('pruneUnclaimedSentryInstallationsActivity', () => {
   beforeEach(async () => {
     await db().delete(sentryInstallations);
@@ -30,6 +29,7 @@ describe('pruneUnclaimedSentryInstallationsActivity', () => {
     const result = await pruneUnclaimedSentryInstallationsActivity();
 
     expect(result.tombstoned).toBe(1);
+    expect(result.releasedPending).toBe(0);
     expect((await getSentryInstallationByInstallationUuid(staleUuid))?.status).toBe('deleted');
   });
 
@@ -47,6 +47,28 @@ describe('pruneUnclaimedSentryInstallationsActivity', () => {
     const result = await pruneUnclaimedSentryInstallationsActivity();
 
     expect(result.tombstoned).toBe(0);
+    expect(result.releasedPending).toBe(0);
     expect((await getSentryInstallationByInstallationUuid(freshUuid))?.status).toBe('installed');
+  });
+
+  test('releases pending claims older than the retention window', async () => {
+    const staleUuid = randomUUID();
+    await db()
+      .insert(sentryInstallations)
+      .values({
+        connectionId: null,
+        installationUuid: staleUuid,
+        orgSlug: 'acme',
+        status: 'pending',
+        codeHash: 'hash',
+        createdAt: new Date(Date.now() - 8 * DAY_MS),
+        updatedAt: new Date(Date.now() - 8 * DAY_MS),
+      });
+
+    const result = await pruneUnclaimedSentryInstallationsActivity();
+    const installation = await getSentryInstallationByInstallationUuid(staleUuid);
+
+    expect(result).toEqual({releasedPending: 1, tombstoned: 0});
+    expect(installation).toBeUndefined();
   });
 });

--- a/libs/api/integration/sentry/src/temporal/activities/prune-unclaimed-installations.ts
+++ b/libs/api/integration/sentry/src/temporal/activities/prune-unclaimed-installations.ts
@@ -3,7 +3,10 @@ import {pruneUnclaimedSentryInstallations} from '#db/installations.js';
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
-export async function pruneUnclaimedSentryInstallationsActivity(): Promise<{tombstoned: number}> {
+export async function pruneUnclaimedSentryInstallationsActivity(): Promise<{
+  releasedPending: number;
+  tombstoned: number;
+}> {
   const olderThan = new Date(
     Date.now() - config.SENTRY_UNCLAIMED_INSTALLATION_RETENTION_DAYS * MS_PER_DAY,
   );

--- a/libs/api/integration/sentry/src/temporal/workflows/prune-unclaimed-installations-cron.ts
+++ b/libs/api/integration/sentry/src/temporal/workflows/prune-unclaimed-installations-cron.ts
@@ -8,7 +8,10 @@ const {pruneUnclaimedSentryInstallationsActivity} = proxyActivities<
 });
 
 export async function pruneUnclaimedSentryInstallationsCron(): Promise<void> {
-  const {tombstoned} = await pruneUnclaimedSentryInstallationsActivity();
+  const {releasedPending, tombstoned} = await pruneUnclaimedSentryInstallationsActivity();
+  if (releasedPending > 0) {
+    log.info('Released stale pending Sentry installation claims', {releasedPending});
+  }
   if (tombstoned > 0) {
     log.info('Tombstoned stale unclaimed Sentry installations', {tombstoned});
   }

--- a/libs/api/integration/slack/src/core/disconnect.test.ts
+++ b/libs/api/integration/slack/src/core/disconnect.test.ts
@@ -10,6 +10,7 @@ const deleteSlackInstallationByConnectionIdMock = vi.mocked(deleteSlackInstallat
 describe('disconnectSlackInstallation', () => {
   beforeEach(() => {
     deleteSlackInstallationByConnectionIdMock.mockClear();
+    deleteSlackInstallationByConnectionIdMock.mockResolvedValue(true);
   });
 
   it('deletes stored tokens before deleting connection records', async () => {
@@ -45,5 +46,51 @@ describe('disconnectSlackInstallation', () => {
     expect(deleteSlackInstallationByConnectionIdMock.mock.invocationCallOrder[0]).toBeLessThan(
       deleteConnection.mock.invocationCallOrder[0] ?? 0,
     );
+  });
+
+  it('keeps connection records when secret deletion fails', async () => {
+    const transaction = vi.fn();
+    const deleteConnection = vi.fn();
+
+    const run = disconnectSlackInstallation({
+      connectionId: 'connection-1',
+      getConnection: vi.fn(() => Promise.resolve({workspaceId: 'workspace-1'})),
+      deleteSecrets: vi.fn(() => Promise.reject(new Error('secret store unavailable'))),
+      transaction,
+      deleteConnection,
+    });
+
+    await expect(run).rejects.toThrow('secret store unavailable');
+    expect(transaction).not.toHaveBeenCalled();
+    expect(deleteSlackInstallationByConnectionIdMock).not.toHaveBeenCalled();
+    expect(deleteConnection).not.toHaveBeenCalled();
+  });
+
+  it('retries idempotent secret deletion after the records transaction fails', async () => {
+    const tx = Symbol('tx');
+    const deleteSecrets = vi.fn(() => Promise.resolve(0));
+    const deleteConnection = vi.fn(() => Promise.resolve(true));
+    const transaction = vi
+      .fn()
+      .mockImplementationOnce(async (fn: (value: symbol) => Promise<unknown>) => {
+        await fn(tx);
+        throw new Error('database commit failed');
+      })
+      .mockImplementationOnce(async (fn: (value: symbol) => Promise<unknown>) => await fn(tx));
+    const params = {
+      connectionId: 'connection-1',
+      getConnection: vi.fn(() => Promise.resolve({workspaceId: 'workspace-1'})),
+      deleteSecrets,
+      transaction,
+      deleteConnection,
+    };
+
+    const firstAttempt = disconnectSlackInstallation(params);
+    await expect(firstAttempt).rejects.toThrow('database commit failed');
+    await disconnectSlackInstallation(params);
+
+    expect(deleteSecrets).toHaveBeenCalledTimes(2);
+    expect(deleteSlackInstallationByConnectionIdMock).toHaveBeenCalledTimes(2);
+    expect(deleteConnection).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
Audits queued lifecycle and disconnect webhooks for safe retries and reordered delivery across GitHub, Sentry, Linear, and Slack.

At-least-once delivery exposed two unsafe failure windows: GitHub credential cleanup could be skipped after delivery deduplication, and Sentry could treat an ambiguous access-denied response as proof that a code had already succeeded. This moves GitHub cleanup after the database commit with a retryable handle, adds durable Sentry exchange checkpoints and monotonic deletion tombstones, bounds abandoned installation claims, and adds rollback and interleaving coverage for Linear and Slack disconnects.

A Sentry provider exchange and the database checkpoint cannot be atomic. This deliberately fails closed if the provider spends a code before the checkpoint: only durable same-code state may bypass exchange, while retention releases abandoned pending claims. The architecture note documents this boundary and the retry guarantees for each audited handler.

Review the Sentry state transitions and retention behavior carefully because they enforce the security boundary between an attempted exchange and a verified installation.

Closes ENG-1072

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes lifecycle webhook retries fail closed across GitHub, Sentry, Linear, and Slack. Prevents unsafe installs and ensures GitHub credential cleanup is retried safely after commit. Addresses Linear ENG-1072.

- **New Features**
  - `@shipfox/api-integration-github`: Move token cleanup after the DB commit and return a retryable cleanup handle. Duplicates safely return the same handle.
  - `@shipfox/api-integration-sentry`: Add pending claims with code-hash, a durable `exchange-succeeded` checkpoint, and monotonic `deleted` tombstones. Install + delivery record now commit together. Retention releases stale pending claims and tombstones exchanged/installed using the last state change time.
  - `@shipfox/api-integration-linear` and `@shipfox/api-integration-slack`: Disconnect deletes secrets first, then records in one transaction. On failures, records stay intact and retries remain idempotent.
  - Docs: Added an architecture note explaining the fail-closed boundary and retry guarantees.

- **Bug Fixes**
  - Prevent skipped GitHub credential cleanup after duplicate delivery.
  - Stop treating Sentry `access-denied` as proof of success; retries continue only from the durable checkpoint.
  - Keep Sentry deletions terminal, including out-of-order deliveries, so a later creation can’t revive a deleted install.

<sup>Written for commit ced097d3a1994647813fad5b0ae2f7c7880123aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

