### PR TITLE
[api-dispatcher] Document in-process outbox delivery

### DIFF
--- a/.changeset/green-foxes-document.md
+++ b/.changeset/green-foxes-document.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-dispatcher": patch
+---
+
+Document in-process outbox dispatching and its self-hosted configuration.

--- a/libs/api/dispatcher/README.md
+++ b/libs/api/dispatcher/README.md
@@ -1,0 +1,66 @@
+# Shipfox API Dispatcher
+
+Shipfox API Dispatcher drains module outboxes and sends events to subscribers.
+
+## What it does
+
+- **`dispatcherModule`**: Registers the in-process drainer and daily Temporal
+  retention work.
+- **In-process drainer**: Runs as a `ModuleService` in each API process. It
+  claims rows with PostgreSQL `SKIP LOCKED` and sends events to subscribers.
+- **Competing consumers**: Many API processes can drain the same outbox.
+  PostgreSQL claims and row leases keep them apart. No leader election is used.
+- **Retention**: Runs once a day on Temporal. Normal event delivery does not.
+
+## Setup
+
+Install the package from the registry:
+
+```sh
+pnpm add @shipfox/api-dispatcher
+```
+
+Register the module with the API module runner:
+
+```ts
+import {dispatcherModule} from '@shipfox/api-dispatcher';
+import {initializeModules} from '@shipfox/node-module';
+
+await initializeModules({
+  modules: [dispatcherModule],
+});
+```
+
+## Environment
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `OUTBOX_DISPATCHER_ENABLED` | `true` | Starts the in-process drainer. Set `false` to use legacy Temporal dispatch workflows. |
+| `OUTBOX_DISPATCH_POLL_MS` | `250` | Time in milliseconds that an idle drainer waits before it checks the outbox again. It must be a whole number greater than zero. |
+
+The default suits an all-in-one deployment. Each API process runs a drainer. No
+extra service is required.
+
+Dedicated drainer deployments are deferred. Do not set
+`OUTBOX_DISPATCHER_ENABLED=false` on the API tier to scale out the drainer. That
+setting restores the legacy Temporal dispatcher. Use the default until a
+dedicated-drainer deployment is available.
+
+## Behavior notes
+
+The drainer logs an escaped error and waits before it tries again. During
+shutdown, it stops claiming rows and waits for work in flight to finish.
+
+## Development
+
+```sh
+turbo check --filter=@shipfox/api-dispatcher
+turbo type --filter=@shipfox/api-dispatcher
+turbo test --filter=@shipfox/api-dispatcher
+```
+
+Tests use PostgreSQL. Start local services with `docker compose up -d`.
+
+## License
+
+MIT


### PR DESCRIPTION
Document the dispatcher package's shipped in-process drain model and its two self-hosting settings.

Maintainers need an accurate package-level contract now that normal delivery runs through a ModuleService rather than a Temporal polling loop. The README explains competing consumers, retention, shutdown behavior, and the current limit of the deferred dedicated-drainer setup.

The public self-hosting documentation remains intentionally general. It should not introduce internal event-delivery details before the async event bus has a dedicated documentation structure.

Closes ENG-1103

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the in-process outbox dispatcher in `@shipfox/api-dispatcher`, including setup, behavior, and self-hosting config. Clarifies the new `ModuleService` delivery model replacing the Temporal polling loop; closes ENG-1103.

- **Notes**
  - README covers competing consumers, daily retention, and error/shutdown behavior.
  - Self-hosting: `OUTBOX_DISPATCHER_ENABLED` and `OUTBOX_DISPATCH_POLL_MS`. Do not disable the dispatcher to “scale out” yet; a dedicated drainer is not available.

<sup>Written for commit edc1eec4708f966f2bb887ec85bbb31dd85e6ac8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

