### PR TITLE
Migrate Logs and Integrations to Workflows API

### DIFF
--- a/.changeset/steady-workflows-migrate.md
+++ b/.changeset/steady-workflows-migrate.md
@@ -1,0 +1,9 @@
+---
+"@shipfox/api-integration-core": major
+"@shipfox/api-logs": major
+"@shipfox/api-server": patch
+"@shipfox/api-workflows": minor
+"@shipfox/api-workflows-dto": minor
+---
+
+Moves Logs and Integrations to injected Workflows inter-module clients with minimal log and leased agent-tool queries.

--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -203,6 +203,18 @@ module.exports = {
           },
         ]
       : []),
+    ...(['@shipfox/api-logs', '@shipfox/api-integration-core'].includes(currentPackage.name)
+      ? [
+          {
+            name: 'workflows-consumers-use-workflows-inter-module-api',
+            comment:
+              'Workflows consumers may use its DTO contract, but never import the Workflows implementation package.',
+            severity: 'error',
+            from: {path: '^(src|test)/'},
+            to: {path: '^\\.\\./workflows/(?:src|dist)/'},
+          },
+        ]
+      : []),
     ...(['@shipfox/api-definitions', '@shipfox/api-secrets', '@shipfox/api-workflows'].includes(
       currentPackage.name,
     )

--- a/libs/api/integration/core/package.json
+++ b/libs/api/integration/core/package.json
@@ -43,6 +43,8 @@
     "@modelcontextprotocol/sdk": "catalog:",
     "@shipfox/api-agent-dto": "workspace:*",
     "@shipfox/api-auth-context": "workspace:*",
+    "@shipfox/api-workflows-dto": "workspace:*",
+    "@shipfox/inter-module": "workspace:*",
     "@shipfox/api-integration-core-dto": "workspace:*",
     "@shipfox/api-integration-gitea": "workspace:*",
     "@shipfox/api-integration-github": "workspace:*",

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -7,6 +7,7 @@ import {
   type WebhookRequestProcessor,
   type WebhookRouteId,
 } from '@shipfox/api-integration-core-dto';
+import type {WorkflowsModuleClient} from '@shipfox/api-workflows-dto/inter-module';
 import type {ModuleService, ShipfoxModule} from '@shipfox/node-module';
 import {logger} from '@shipfox/node-opentelemetry';
 import type {IntegrationProvider} from '#core/entities/provider.js';
@@ -23,7 +24,7 @@ import {getIntegrationConnectionById} from '#db/connections.js';
 import {db} from '#db/db.js';
 import {migrationsPath} from '#db/migrations.js';
 import {integrationsOutbox} from '#db/schema/outbox.js';
-import {createIntegrationRoutes, type LeasedAgentStepLoader} from '#presentation/routes/index.js';
+import {createIntegrationRoutes} from '#presentation/routes/index.js';
 import {loadEnabledProviderModules} from '#providers/modules.js';
 import type {
   IntegrationModuleParts,
@@ -139,7 +140,7 @@ export interface CreateIntegrationsModuleOptions {
   secrets?: IntegrationProviderSecrets | undefined;
   agentTools?:
     | {
-        loadLeasedAgentStep: LeasedAgentStepLoader;
+        workflows: WorkflowsModuleClient;
       }
     | undefined;
   webhookDeliverySource?: WebhookDeliverySource | undefined;
@@ -217,7 +218,7 @@ export async function createIntegrationsContext(
     routes: createIntegrationRoutes(registry, sourceControl, {
       agentTools: options.agentTools
         ? {
-            loadLeasedAgentStep: options.agentTools.loadLeasedAgentStep,
+            workflows: options.agentTools.workflows,
             getIntegrationConnectionById,
           }
         : undefined,

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/index.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/index.ts
@@ -13,6 +13,7 @@ import {
 } from './resolve-authorized-tools.js';
 
 export type {LeasedAgentStepLoader} from './resolve-authorized-tools.js';
+export {createWorkflowsLeasedAgentStepLoader} from './resolve-authorized-tools.js';
 
 export interface CreateAgentToolsGatewayRoutesParams {
   loadLeasedAgentStep: LeasedAgentStepLoader;

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/resolve-authorized-tools.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/resolve-authorized-tools.test.ts
@@ -1,4 +1,6 @@
 import {setLeasedJobContext} from '@shipfox/api-auth-context';
+import {workflowsInterModuleContract} from '@shipfox/api-workflows-dto/inter-module';
+import {createInterModuleKnownError} from '@shipfox/inter-module';
 import {createIntegrationProviderRegistry} from '#core/providers/registry.js';
 import {
   agentStepConfig,
@@ -9,6 +11,7 @@ import {
   registryWithAgentTools,
 } from '#test/agent-tools-gateway-helpers.js';
 import {
+  createWorkflowsLeasedAgentStepLoader,
   mcpToolName,
   narrowMethodEnum,
   resolveAuthorizedIntegrationTools,
@@ -16,6 +19,39 @@ import {
 } from './resolve-authorized-tools.js';
 
 describe('resolveAuthorizedIntegrationTools', () => {
+  it.each([
+    ['lease-not-active', 404],
+    ['step-not-found', 404],
+    ['job-not-found', 404],
+    ['step-attempt-mismatch', 409],
+    ['step-not-running', 409],
+    ['leased-step-not-agent', 409],
+    ['agent-step-config-invalid', 409],
+  ] as const)('maps %s from Workflows to HTTP %i', async (code, status) => {
+    const request = {};
+    const lease = leaseContext();
+    setLeasedJobContext(request, lease);
+    const workflows = {
+      getLeasedAgentToolContext: () =>
+        Promise.reject(
+          createInterModuleKnownError(
+            workflowsInterModuleContract.methods.getLeasedAgentToolContext,
+            code,
+            {},
+          ),
+        ),
+    };
+    const loadLeasedAgentStep = createWorkflowsLeasedAgentStepLoader(workflows as never);
+
+    const error = await loadLeasedAgentStep({
+      request,
+      stepId: lease.currentStepId as string,
+      attempt: lease.currentStepAttempt as number,
+    }).catch((error: unknown) => error);
+
+    expect(error).toMatchObject({code, status});
+  });
+
   it('resolves namespaced tools with live descriptions and Anthropic-compatible method schemas', async () => {
     const request = {};
     const lease = leaseContext();

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/resolve-authorized-tools.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/resolve-authorized-tools.ts
@@ -4,6 +4,11 @@ import {
   materializedAgentStepConfigSchema,
 } from '@shipfox/api-agent-dto';
 import {requireLeasedJobContext} from '@shipfox/api-auth-context';
+import {
+  type WorkflowsModuleClient,
+  workflowsInterModuleContract,
+} from '@shipfox/api-workflows-dto/inter-module';
+import {isInterModuleKnownError} from '@shipfox/inter-module';
 import {ClientError} from '@shipfox/node-fastify';
 import type {IntegrationConnection} from '#core/entities/connection.js';
 import type {IntegrationProviderKind} from '#core/entities/provider.js';
@@ -16,9 +21,48 @@ export type LeasedAgentStepLoader = (params: {
   stepId: string;
   attempt: number;
 }) => Promise<{
-  step: {type: string; config: Record<string, unknown>};
   workspaceId: string;
+  integrations?: MaterializedAgentIntegrationConfigDto[];
+  step?: {type: string; config: Record<string, unknown>};
 }>;
+
+export function createWorkflowsLeasedAgentStepLoader(
+  workflows: WorkflowsModuleClient,
+): LeasedAgentStepLoader {
+  return async ({request, stepId, attempt}) => {
+    const leasedJob = requireLeasedJobContext(request);
+    try {
+      const context = await workflows.getLeasedAgentToolContext({
+        jobId: leasedJob.jobId,
+        jobExecutionId: leasedJob.jobExecutionId,
+        runnerSessionId: leasedJob.runnerSessionId,
+        stepId,
+        attempt,
+      });
+      return {
+        workspaceId: context.workspaceId,
+        integrations: context.integrations,
+      };
+    } catch (error) {
+      throw toLeasedAgentToolClientError(error);
+    }
+  };
+}
+
+function toLeasedAgentToolClientError(error: unknown): unknown {
+  const method = workflowsInterModuleContract.methods.getLeasedAgentToolContext;
+  if (!isInterModuleKnownError(method, error)) return error;
+
+  const status = [
+    'step-attempt-mismatch',
+    'step-not-running',
+    'leased-step-not-agent',
+    'agent-step-config-invalid',
+  ].includes(error.code)
+    ? 409
+    : 404;
+  return new ClientError(error.code.replaceAll('-', ' '), error.code, {status});
+}
 
 export interface AuthorizedIntegrationTool {
   mcpName: string;
@@ -49,18 +93,13 @@ export async function resolveAuthorizedIntegrationTools(
     });
   }
 
-  const {step, workspaceId} = await params.loadLeasedAgentStep({
+  const loaded = await params.loadLeasedAgentStep({
     request: params.request,
     stepId: leasedJob.currentStepId,
     attempt: leasedJob.currentStepAttempt,
   });
-  if (step.type !== 'agent') {
-    throw new ClientError('Current leased step is not an agent step', 'leased-step-not-agent', {
-      status: 409,
-    });
-  }
-
-  const integrations = parseAgentIntegrations(step.config);
+  const workspaceId = loaded.workspaceId;
+  const integrations = loaded.integrations ?? legacyIntegrations(loaded.step);
   const authorizedTools: AuthorizedIntegrationToolMap = new Map();
 
   for (const integration of integrations) {
@@ -102,6 +141,22 @@ export async function resolveAuthorizedIntegrationTools(
   return authorizedTools;
 }
 
+function legacyIntegrations(step: {type: string; config: Record<string, unknown>} | undefined) {
+  if (step?.type !== 'agent') {
+    throw new ClientError('Current leased step is not an agent step', 'leased-step-not-agent', {
+      status: 409,
+    });
+  }
+  try {
+    return materializedAgentStepConfigSchema.parse(step.config).integrations ?? [];
+  } catch (error) {
+    throw new ClientError('Agent step config is invalid', 'agent-step-config-invalid', {
+      status: 409,
+      cause: error,
+    });
+  }
+}
+
 export function sanitizeSlug(slug: string): string {
   return slug.replaceAll('-', '_');
 }
@@ -130,19 +185,6 @@ export function narrowMethodEnum(
 function toolInputSchema(tool: MaterializedAgentIntegrationToolConfigDto): AgentToolJsonSchema {
   const authorizedMethods = tool.methods?.map((method) => method.id) ?? [];
   return narrowMethodEnum(tool.inputSchema, authorizedMethods);
-}
-
-function parseAgentIntegrations(
-  config: Record<string, unknown>,
-): MaterializedAgentIntegrationConfigDto[] {
-  try {
-    return materializedAgentStepConfigSchema.parse(config).integrations ?? [];
-  } catch (error) {
-    throw new ClientError('Agent step config is invalid', 'agent-step-config-invalid', {
-      status: 409,
-      cause: error,
-    });
-  }
 }
 
 async function loadAuthorizedConnection(params: {

--- a/libs/api/integration/core/src/presentation/routes/index.ts
+++ b/libs/api/integration/core/src/presentation/routes/index.ts
@@ -1,10 +1,11 @@
+import type {WorkflowsModuleClient} from '@shipfox/api-workflows-dto/inter-module';
 import type {RouteExport} from '@shipfox/node-fastify';
 import type {IntegrationProviderRegistry} from '#core/providers/registry.js';
 import type {IntegrationSourceControlService} from '#core/source-control-service.js';
 import type {GetIntegrationConnectionByIdFn} from '#db/connections.js';
 import {
   createAgentToolsGatewayRoutes,
-  type LeasedAgentStepLoader,
+  createWorkflowsLeasedAgentStepLoader,
 } from './agent-tools-gateway/index.js';
 import {createListIntegrationConnectionsRoute} from './list-connections.js';
 import {createListIntegrationProvidersRoute} from './list-providers.js';
@@ -14,12 +15,10 @@ import {
   createUpdateIntegrationConnectionRoute,
 } from './manage-connections.js';
 
-export type {LeasedAgentStepLoader} from './agent-tools-gateway/index.js';
-
 export interface CreateIntegrationRoutesOptions {
   agentTools?:
     | {
-        loadLeasedAgentStep: LeasedAgentStepLoader;
+        workflows: WorkflowsModuleClient;
         getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
       }
     | undefined;
@@ -35,7 +34,7 @@ export function createIntegrationRoutes(
     ? [
         createAgentToolsGatewayRoutes({
           registry,
-          loadLeasedAgentStep: options.agentTools.loadLeasedAgentStep,
+          loadLeasedAgentStep: createWorkflowsLeasedAgentStepLoader(options.agentTools.workflows),
           getIntegrationConnectionById: options.agentTools.getIntegrationConnectionById,
         }),
       ]

--- a/libs/api/logs/package.json
+++ b/libs/api/logs/package.json
@@ -46,7 +46,6 @@
     "@shipfox/api-auth-context": "workspace:*",
     "@shipfox/api-agent-dto": "workspace:*",
     "@shipfox/api-logs-dto": "workspace:*",
-    "@shipfox/api-workflows": "workspace:*",
     "@shipfox/api-workflows-dto": "workspace:*",
     "@shipfox/config": "workspace:*",
     "@shipfox/node-drizzle": "workspace:*",
@@ -64,6 +63,7 @@
   "devDependencies": {
     "@shipfox/api-auth": "workspace:*",
     "@shipfox/api-auth-dto": "workspace:*",
+    "@shipfox/inter-module": "workspace:*",
     "@shipfox/biome": "workspace:*",
     "@shipfox/node-jwt": "workspace:*",
     "@shipfox/swc": "workspace:*",

--- a/libs/api/logs/src/core/append-logs.test.ts
+++ b/libs/api/logs/src/core/append-logs.test.ts
@@ -1,5 +1,8 @@
 import {type LogRecord, parseLogRecordLine} from '@shipfox/api-logs-dto';
-import {appendLogs, setStepLookupForTesting} from '#core/append-logs.js';
+import {workflowsInterModuleContract} from '@shipfox/api-workflows-dto/inter-module';
+import {defineInterModulePresentation} from '@shipfox/inter-module';
+import {createFakeInterModuleClients} from '@shipfox/node-module/inter-module/testing';
+import {appendLogs} from '#core/append-logs.js';
 import {LeaseStreamMismatchError, MalformedLogChunkError, OffsetGapError} from '#core/errors.js';
 import {jobAccountingFactory} from '#test/factories/job-accounting.js';
 import {
@@ -12,8 +15,6 @@ import {
   sessionLine,
 } from '#test/fixtures/ndjson.js';
 import {findAccounting, findStream, listChunks, listStreamClosedEvents} from '#test/queries.js';
-
-const mockSteps = new Map<string, {config: Record<string, unknown>}>();
 
 interface Ctx {
   jobId: string;
@@ -48,20 +49,6 @@ function recordsFromChunks(chunks: Awaited<ReturnType<typeof listChunks>>): LogR
 }
 
 describe('appendLogs', () => {
-  let restoreStepLookup: () => void;
-
-  beforeAll(() => {
-    restoreStepLookup = setStepLookupForTesting((stepId) => Promise.resolve(mockSteps.get(stepId)));
-  });
-
-  afterAll(() => {
-    restoreStepLookup();
-  });
-
-  beforeEach(() => {
-    mockSteps.clear();
-  });
-
   describe('offset-CAS', () => {
     it('extends committed_length and stores one runner chunk on an in-order append', async () => {
       const ctx = newCtx();
@@ -203,7 +190,14 @@ describe('appendLogs', () => {
     it('selects the Claude parser from the step harness', async () => {
       const ctx = newCtx();
       await allowLargeLogBudget(ctx);
-      mockSteps.set(ctx.stepId, {config: {harness: 'claude'}});
+      const workflows = createFakeInterModuleClients({
+        workflows: defineInterModulePresentation(workflowsInterModuleContract, {
+          startRunFromTrigger: vi.fn(),
+          deliverEventToJobListener: vi.fn(),
+          getStepLogContext: () => ({harness: 'claude'}),
+          getLeasedAgentToolContext: vi.fn(),
+        }),
+      }).workflows;
       const body = ndjsonBody(
         sessionLine(
           JSON.stringify({
@@ -216,7 +210,7 @@ describe('appendLogs', () => {
         ),
       );
 
-      await appendLogs({...ctx, attempt: 1, offset: 0, body});
+      await appendLogs({...ctx, attempt: 1, offset: 0, body}, workflows);
 
       const stream = await findStream({...ctx, attempt: 1});
       const rows = recordsFromChunks(await listChunks(stream?.id as string)).map((record) => {

--- a/libs/api/logs/src/core/append-logs.test.ts
+++ b/libs/api/logs/src/core/append-logs.test.ts
@@ -194,7 +194,7 @@ describe('appendLogs', () => {
         workflows: defineInterModulePresentation(workflowsInterModuleContract, {
           startRunFromTrigger: vi.fn(),
           deliverEventToJobListener: vi.fn(),
-          getStepLogContext: () => ({harness: 'claude'}),
+          getStepLogContext: () => ({harness: 'claude' as const}),
           getLeasedAgentToolContext: vi.fn(),
         }),
       }).workflows;

--- a/libs/api/logs/src/core/append-logs.ts
+++ b/libs/api/logs/src/core/append-logs.ts
@@ -1,12 +1,12 @@
 import {Buffer} from 'node:buffer';
-import {DEFAULT_HARNESS, type Harness, harnessSchema} from '@shipfox/api-agent-dto';
+import {DEFAULT_HARNESS, type Harness} from '@shipfox/api-agent-dto';
 import {
   type LogRecord,
   parseLogRecordLine,
   parseRawLogRecordLine,
   type RawLogRecord,
 } from '@shipfox/api-logs-dto';
-import {getStepById} from '@shipfox/api-workflows';
+import type {WorkflowsModuleClient} from '@shipfox/api-workflows-dto/inter-module';
 import {logger} from '@shipfox/node-opentelemetry';
 import {config} from '#config.js';
 import {accrueStoredBytes, claimCap, ensureJobAccounting, isJobCapped} from '#db/accounting.js';
@@ -29,18 +29,6 @@ import {closeStream, controlTombstone} from './close-stream.js';
 import {MalformedLogChunkError, OffsetGapError} from './errors.js';
 import {parseSessionRecord} from './session/parse-session.js';
 import type {AgentSessionRecord} from './session/session-record.js';
-
-type StepLookup = (stepId: string) => Promise<{config: Record<string, unknown>} | undefined>;
-
-let stepLookup: StepLookup = getStepById;
-
-export function setStepLookupForTesting(lookup: StepLookup): () => void {
-  const previous = stepLookup;
-  stepLookup = lookup;
-  return () => {
-    stepLookup = previous;
-  };
-}
 
 export interface AppendLogsParams {
   jobId: string;
@@ -137,10 +125,11 @@ function detectForgedType(line: string): string | undefined {
   }
 }
 
-async function getSessionHarness(stepId: string): Promise<Harness> {
-  const step = await stepLookup(stepId);
-  const parsed = harnessSchema.safeParse(step?.config.harness);
-  return parsed.success ? parsed.data : DEFAULT_HARNESS;
+async function getSessionHarness(
+  workflows: WorkflowsModuleClient | undefined,
+  stepId: string,
+): Promise<Harness> {
+  return workflows ? (await workflows.getStepLogContext({stepId})).harness : DEFAULT_HARNESS;
 }
 
 /**
@@ -273,7 +262,10 @@ function agentSessionRecord(
  * job contend on its single accounting row, so the path is multi-instance safe
  * but not lock-free.
  */
-export async function appendLogs(params: AppendLogsParams): Promise<AppendLogsResult> {
+export async function appendLogs(
+  params: AppendLogsParams,
+  workflows?: WorkflowsModuleClient,
+): Promise<AppendLogsResult> {
   let parsed: ParsedBody;
   try {
     parsed = parseAppendBody(params.body);
@@ -293,7 +285,7 @@ export async function appendLogs(params: AppendLogsParams): Promise<AppendLogsRe
   }
   const {declaredTotalBytes} = parsed;
   const sessionHarness = parsed.hasAgentSessionRecord
-    ? await getSessionHarness(params.stepId)
+    ? await getSessionHarness(workflows, params.stepId)
     : DEFAULT_HARNESS;
   const stored = buildStoredBody(parsed.records, sessionHarness);
   const commitByteLen = params.body.length;

--- a/libs/api/logs/src/index.ts
+++ b/libs/api/logs/src/index.ts
@@ -6,12 +6,13 @@ import {
   WORKFLOWS_STEP_ATTEMPT_TERMINATED,
   type WorkflowsEventMapDto,
 } from '@shipfox/api-workflows-dto';
+import type {WorkflowsModuleClient} from '@shipfox/api-workflows-dto/inter-module';
 import {type ShipfoxModule, subscriberFactory} from '@shipfox/node-module';
 import {db} from '#db/db.js';
 import {migrationsPath} from '#db/index.js';
 import {logsOutbox} from '#db/schema/outbox.js';
 import {registerLogsServiceMetrics} from '#metrics/service.js';
-import {logsRoutes} from '#presentation/routes/index.js';
+import {createLogsRoutes} from '#presentation/routes/index.js';
 import {onJobTerminated} from '#presentation/subscribers/on-job-terminated.js';
 import {onLogStreamClosed} from '#presentation/subscribers/on-log-stream-closed.js';
 import {onStepAttemptTerminated} from '#presentation/subscribers/on-step-attempt-terminated.js';
@@ -25,53 +26,55 @@ const workflowsPath = resolve(packageRoot, 'dist/temporal/workflows/index.js');
 
 const subscriber = subscriberFactory<WorkflowsEventMapDto & LogsEventMap>();
 
-export const logsModule: ShipfoxModule = {
-  name: 'logs',
-  database: {db, migrationsPath},
-  routes: logsRoutes,
-  metrics: registerLogsServiceMetrics,
-  // `logs.stream.closed` is written by the close paths: the job-terminated subscriber
-  // force-closes streams the runner never ended, and the closed event drives compaction.
-  publishers: [{name: 'logs', table: logsOutbox, db, eventSchemas: logsEventSchemas}],
-  subscribers: [
-    subscriber(WORKFLOWS_STEP_ATTEMPT_TERMINATED, onStepAttemptTerminated),
-    subscriber(WORKFLOWS_JOB_TERMINATED, onJobTerminated),
-    subscriber(LOG_STREAM_CLOSED, onLogStreamClosed),
-  ],
-  workers: [
-    {
-      taskQueue: LOGS_LIFECYCLE_TASK_QUEUE,
-      workflowsPath,
-      activities: createLogsActivities,
-      // Temporal cron schedules are fixed after creation, so making cadence configurable would
-      // look adjustable while keeping the old schedule. Tune LOG_RETENTION_DAYS for the horizon.
-      workflows: [
-        {
-          name: 'retentionSweepCron',
-          id: 'logs-retention-sweep',
-          cronSchedule: '0 * * * *',
-        },
-        // Offset from retention's top-of-hour sweep; stale-stream age is governed by
-        // LOG_STREAM_REAP_AFTER_SECONDS.
-        {
-          name: 'reapStaleOpenStreamsCron',
-          id: 'logs-reap-stale-open-streams',
-          cronSchedule: '5,15,25,35,45,55 * * * *',
-        },
-      ],
-    },
-    // Compaction runs on its own queue so long uploads cannot starve the lifecycle sweep.
-    {
-      taskQueue: LOGS_COMPACTION_TASK_QUEUE,
-      workflowsPath,
-      activities: createLogsActivities,
-      workflows: [
-        {
-          name: 'compactionReconcileCron',
-          id: 'logs-compaction-reconcile',
-          cronSchedule: '*/10 * * * *',
-        },
-      ],
-    },
-  ],
-};
+export function createLogsModule({workflows}: {workflows: WorkflowsModuleClient}): ShipfoxModule {
+  return {
+    name: 'logs',
+    database: {db, migrationsPath},
+    routes: createLogsRoutes(workflows),
+    metrics: registerLogsServiceMetrics,
+    // `logs.stream.closed` is written by the close paths: the job-terminated subscriber
+    // force-closes streams the runner never ended, and the closed event drives compaction.
+    publishers: [{name: 'logs', table: logsOutbox, db, eventSchemas: logsEventSchemas}],
+    subscribers: [
+      subscriber(WORKFLOWS_STEP_ATTEMPT_TERMINATED, onStepAttemptTerminated),
+      subscriber(WORKFLOWS_JOB_TERMINATED, onJobTerminated),
+      subscriber(LOG_STREAM_CLOSED, onLogStreamClosed),
+    ],
+    workers: [
+      {
+        taskQueue: LOGS_LIFECYCLE_TASK_QUEUE,
+        workflowsPath,
+        activities: createLogsActivities,
+        // Temporal cron schedules are fixed after creation, so making cadence configurable would
+        // look adjustable while keeping the old schedule. Tune LOG_RETENTION_DAYS for the horizon.
+        workflows: [
+          {
+            name: 'retentionSweepCron',
+            id: 'logs-retention-sweep',
+            cronSchedule: '0 * * * *',
+          },
+          // Offset from retention's top-of-hour sweep; stale-stream age is governed by
+          // LOG_STREAM_REAP_AFTER_SECONDS.
+          {
+            name: 'reapStaleOpenStreamsCron',
+            id: 'logs-reap-stale-open-streams',
+            cronSchedule: '5,15,25,35,45,55 * * * *',
+          },
+        ],
+      },
+      // Compaction runs on its own queue so long uploads cannot starve the lifecycle sweep.
+      {
+        taskQueue: LOGS_COMPACTION_TASK_QUEUE,
+        workflowsPath,
+        activities: createLogsActivities,
+        workflows: [
+          {
+            name: 'compactionReconcileCron',
+            id: 'logs-compaction-reconcile',
+            cronSchedule: '*/10 * * * *',
+          },
+        ],
+      },
+    ],
+  };
+}

--- a/libs/api/logs/src/presentation/routes/append-logs.test.ts
+++ b/libs/api/logs/src/presentation/routes/append-logs.test.ts
@@ -4,7 +4,8 @@ import {AUTH_USER} from '@shipfox/api-auth-context';
 import {type AuthMethod, closeApp, createApp, type FastifyInstance} from '@shipfox/node-fastify';
 import {mintLeaseToken} from '#test/fixtures/lease-token.js';
 import {endLine, ndjsonBody, outputLine, recordLine} from '#test/fixtures/ndjson.js';
-import {logsRoutes} from './index.js';
+import {createTestWorkflowsClient} from '#test/fixtures/workflows-client.js';
+import {createLogsRoutes} from './index.js';
 
 const NDJSON = 'application/x-ndjson';
 const JOB_EXECUTION_ID = '00000000-0000-4000-8000-0000000000ee';
@@ -36,7 +37,7 @@ describe('POST /runs/jobs/current/steps/:stepId/logs', () => {
   beforeAll(async () => {
     app = await createApp({
       auth: [createLeaseTokenAuthMethod(), stubUserAuth],
-      routes: logsRoutes,
+      routes: createLogsRoutes(createTestWorkflowsClient()),
       swagger: false,
     });
     await app.ready();

--- a/libs/api/logs/src/presentation/routes/append-logs.ts
+++ b/libs/api/logs/src/presentation/routes/append-logs.ts
@@ -5,62 +5,66 @@ import {
   appendLogsResponseSchema,
   offsetGapResponseSchema,
 } from '@shipfox/api-logs-dto';
+import type {WorkflowsModuleClient} from '@shipfox/api-workflows-dto/inter-module';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
 import {appendLogs} from '#core/append-logs.js';
 import {LeaseStreamMismatchError, MalformedLogChunkError, OffsetGapError} from '#core/errors.js';
 
-export const appendLogsRoute = defineRoute({
-  method: 'POST',
-  path: '/steps/:stepId/logs',
-  description: 'Append a chunk of logs for a step attempt of the leased job.',
-  schema: {
-    params: z.object({stepId: z.string().uuid()}),
-    querystring: appendLogsQuerySchema,
-    response: {
-      200: appendLogsResponseSchema,
-      409: offsetGapResponseSchema,
+export function createAppendLogsRoute(workflows: WorkflowsModuleClient) {
+  return defineRoute({
+    method: 'POST',
+    path: '/steps/:stepId/logs',
+    description: 'Append a chunk of logs for a step attempt of the leased job.',
+    schema: {
+      params: z.object({stepId: z.string().uuid()}),
+      querystring: appendLogsQuerySchema,
+      response: {
+        200: appendLogsResponseSchema,
+        409: offsetGapResponseSchema,
+      },
     },
-  },
-  errorHandler: (error) => {
-    if (error instanceof OffsetGapError) {
-      throw new ClientError('Append offset is ahead of the committed length', 'offset-gap', {
-        status: 409,
-        details: {committed_length: error.committedLength},
-      });
-    }
-    if (error instanceof MalformedLogChunkError) {
-      throw new ClientError(error.message, 'malformed-log-chunk', {status: 400});
-    }
-    if (error instanceof LeaseStreamMismatchError) {
-      throw new ClientError(error.message, 'lease-stream-mismatch', {status: 403});
-    }
-    throw error;
-  },
-  handler: async (request) => {
-    const leasedJob = requireLeasedJobContext(request);
-    const {stepId} = request.params;
-    const {attempt, offset} = request.query;
+    errorHandler: (error) => {
+      if (error instanceof OffsetGapError) {
+        throw new ClientError('Append offset is ahead of the committed length', 'offset-gap', {
+          status: 409,
+          details: {committed_length: error.committedLength},
+        });
+      }
+      if (error instanceof MalformedLogChunkError) {
+        throw new ClientError(error.message, 'malformed-log-chunk', {status: 400});
+      }
+      if (error instanceof LeaseStreamMismatchError) {
+        throw new ClientError(error.message, 'lease-stream-mismatch', {status: 403});
+      }
+      throw error;
+    },
+    handler: async (request) => {
+      const leasedJob = requireLeasedJobContext(request);
+      const {stepId} = request.params;
+      const {attempt, offset} = request.query;
 
-    // The scoped lease proves membership in the dispatched step attempt; active-step
-    // completion remains governed by workflow/report state, not the log append route.
-    if (leasedJob.currentStepId !== stepId || leasedJob.currentStepAttempt !== attempt) {
-      throw new ClientError('Step not found for leased job execution', 'step-not-found', {
-        status: 404,
-      });
-    }
+      if (leasedJob.currentStepId !== stepId || leasedJob.currentStepAttempt !== attempt) {
+        throw new ClientError('Step not found for leased job execution', 'step-not-found', {
+          status: 404,
+        });
+      }
 
-    const result = await appendLogs({
-      jobId: leasedJob.jobId,
-      workspaceId: leasedJob.workspaceId,
-      projectId: leasedJob.projectId,
-      workflowRunAttemptId: leasedJob.workflowRunAttemptId,
-      stepId,
-      attempt,
-      offset,
-      body: (request.body as Buffer | undefined) ?? Buffer.alloc(0),
-    });
+      const result = await appendLogs(
+        {
+          jobId: leasedJob.jobId,
+          workspaceId: leasedJob.workspaceId,
+          projectId: leasedJob.projectId,
+          workflowRunAttemptId: leasedJob.workflowRunAttemptId,
+          stepId,
+          attempt,
+          offset,
+          body: (request.body as Buffer | undefined) ?? Buffer.alloc(0),
+        },
+        workflows,
+      );
 
-    return {committed_length: result.committedLength, capped: result.capped};
-  },
-});
+      return {committed_length: result.committedLength, capped: result.capped};
+    },
+  });
+}

--- a/libs/api/logs/src/presentation/routes/index.ts
+++ b/libs/api/logs/src/presentation/routes/index.ts
@@ -1,27 +1,30 @@
 import {AUTH_LEASED_JOB, AUTH_USER} from '@shipfox/api-auth-context';
+import type {WorkflowsModuleClient} from '@shipfox/api-workflows-dto/inter-module';
 import {createRawBodyPlugin, type RouteGroup} from '@shipfox/node-fastify';
 import {config} from '#config.js';
-import {appendLogsRoute} from './append-logs.js';
+import {createAppendLogsRoute} from './append-logs.js';
 import {readLogsRoute} from './read-logs.js';
 
 // Keep the lease-authed append in its own Fastify scope so the raw NDJSON parser does not
 // disturb the JSON read route (or workflow routes). The body limit also bounds one-append
 // budget overshoot. The read route is session-authed and workspace-scoped via the row.
-export const logsRoutes: RouteGroup[] = [
-  {
-    prefix: '/runs/jobs/current',
-    auth: AUTH_LEASED_JOB,
-    plugins: [
-      createRawBodyPlugin({
-        contentType: 'application/x-ndjson',
-        bodyLimit: config.LOG_APPEND_BODY_LIMIT_BYTES,
-      }),
-    ],
-    routes: [appendLogsRoute],
-  },
-  {
-    prefix: '/steps',
-    auth: AUTH_USER,
-    routes: [readLogsRoute],
-  },
-];
+export function createLogsRoutes(workflows: WorkflowsModuleClient): RouteGroup[] {
+  return [
+    {
+      prefix: '/runs/jobs/current',
+      auth: AUTH_LEASED_JOB,
+      plugins: [
+        createRawBodyPlugin({
+          contentType: 'application/x-ndjson',
+          bodyLimit: config.LOG_APPEND_BODY_LIMIT_BYTES,
+        }),
+      ],
+      routes: [createAppendLogsRoute(workflows)],
+    },
+    {
+      prefix: '/steps',
+      auth: AUTH_USER,
+      routes: [readLogsRoute],
+    },
+  ];
+}

--- a/libs/api/logs/src/presentation/routes/read-logs.test.ts
+++ b/libs/api/logs/src/presentation/routes/read-logs.test.ts
@@ -35,9 +35,10 @@ import {
   compactStreamActivity,
 } from '#temporal/activities/compact-stream.js';
 import {ndjsonBody, outputLine, recordLine} from '#test/fixtures/ndjson.js';
+import {createTestWorkflowsClient} from '#test/fixtures/workflows-client.js';
 import {findStream} from '#test/queries.js';
 import {onStepAttemptTerminated} from '../subscribers/on-step-attempt-terminated.js';
-import {logsRoutes} from './index.js';
+import {createLogsRoutes} from './index.js';
 
 // AUTH_USER stub: a `Bearer user` request is a member of whatever workspace it names in the
 // `x-test-workspace` header, so each test grants or withholds access against the arranged
@@ -159,7 +160,7 @@ describe('GET /steps/:stepId/attempts/:attempt/logs', () => {
   beforeAll(async () => {
     app = await createApp({
       auth: [fakeUserAuth, stubLeaseAuth],
-      routes: logsRoutes,
+      routes: createLogsRoutes(createTestWorkflowsClient()),
       swagger: false,
     });
     await app.ready();

--- a/libs/api/logs/test/fixtures/workflows-client.ts
+++ b/libs/api/logs/test/fixtures/workflows-client.ts
@@ -10,7 +10,7 @@ export function createTestWorkflowsClient(): WorkflowsModuleClient {
     workflows: defineInterModulePresentation(workflowsInterModuleContract, {
       startRunFromTrigger: vi.fn(),
       deliverEventToJobListener: vi.fn(),
-      getStepLogContext: () => ({harness: 'pi'}),
+      getStepLogContext: () => ({harness: 'pi' as const}),
       getLeasedAgentToolContext: vi.fn(),
     }),
   }).workflows;

--- a/libs/api/logs/test/fixtures/workflows-client.ts
+++ b/libs/api/logs/test/fixtures/workflows-client.ts
@@ -1,0 +1,17 @@
+import {
+  type WorkflowsModuleClient,
+  workflowsInterModuleContract,
+} from '@shipfox/api-workflows-dto/inter-module';
+import {defineInterModulePresentation} from '@shipfox/inter-module';
+import {createFakeInterModuleClients} from '@shipfox/node-module/inter-module/testing';
+
+export function createTestWorkflowsClient(): WorkflowsModuleClient {
+  return createFakeInterModuleClients({
+    workflows: defineInterModulePresentation(workflowsInterModuleContract, {
+      startRunFromTrigger: vi.fn(),
+      deliverEventToJobListener: vi.fn(),
+      getStepLogContext: () => ({harness: 'pi'}),
+      getLeasedAgentToolContext: vi.fn(),
+    }),
+  }).workflows;
+}

--- a/libs/api/server/src/modules.test.ts
+++ b/libs/api/server/src/modules.test.ts
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   createAgentModule: vi.fn(),
   createDefinitionsModule: vi.fn(),
   createIntegrationsContext: vi.fn(),
+  createLogsModule: vi.fn(),
   createProjectsModule: vi.fn(),
   createSecretsModule: vi.fn(),
   createTriggersModule: vi.fn(),
@@ -24,7 +25,6 @@ const mocks = vi.hoisted(() => ({
   deleteSecrets: vi.fn(),
   getIntegrationConnectionById: vi.fn(),
   getSecret: vi.fn(),
-  loadRunningLeasedStep: vi.fn(),
   setAgentToolMaterializationServices: vi.fn(),
   setSecrets: vi.fn(),
   setSourceControl: vi.fn(),
@@ -54,7 +54,7 @@ vi.mock('@shipfox/api-integration-core', () => ({
   createWorkspaceConnectionSnapshotLoader: mocks.createWorkspaceConnectionSnapshotLoader,
   getIntegrationConnectionById: mocks.getIntegrationConnectionById,
 }));
-vi.mock('@shipfox/api-logs', () => ({logsModule: {name: 'logs'}}));
+vi.mock('@shipfox/api-logs', () => ({createLogsModule: mocks.createLogsModule}));
 vi.mock('@shipfox/api-projects', () => ({createProjectsModule: mocks.createProjectsModule}));
 vi.mock('@shipfox/api-runners', () => ({
   runnersModule: {
@@ -82,7 +82,6 @@ vi.mock('@shipfox/api-secrets', () => ({
 vi.mock('@shipfox/api-triggers', () => ({createTriggersModule: mocks.createTriggersModule}));
 vi.mock('@shipfox/api-workflows', () => ({
   createWorkflowsModule: mocks.createWorkflowsModule,
-  loadRunningLeasedStep: mocks.loadRunningLeasedStep,
   setAgentToolMaterializationServices: mocks.setAgentToolMaterializationServices,
   setSourceControl: mocks.setSourceControl,
   workflowsModule: {name: 'workflows'},
@@ -96,6 +95,7 @@ describe('defaultModules', () => {
     mocks.createAgentModule.mockReset();
     mocks.createDefinitionsModule.mockReset();
     mocks.createIntegrationsContext.mockReset();
+    mocks.createLogsModule.mockReset();
     mocks.createProjectsModule.mockReset();
     mocks.createSecretsModule.mockReset();
     mocks.createTriggersModule.mockReset();
@@ -104,7 +104,6 @@ describe('defaultModules', () => {
     mocks.deleteSecrets.mockReset();
     mocks.getIntegrationConnectionById.mockReset();
     mocks.getSecret.mockReset();
-    mocks.loadRunningLeasedStep.mockReset();
     mocks.setAgentToolMaterializationServices.mockReset();
     mocks.setSecrets.mockReset();
     mocks.setSourceControl.mockReset();
@@ -114,6 +113,7 @@ describe('defaultModules', () => {
       registry: {},
       sourceControl: {provider: 'source-control'},
     });
+    mocks.createLogsModule.mockReturnValue({name: 'logs'});
     mocks.buildAgentToolCatalogs.mockResolvedValue(new Map());
     mocks.buildAgentToolSelectionCatalogs.mockResolvedValue(new Map());
     mocks.createWorkspaceConnectionSnapshotLoader.mockReturnValue(vi.fn());
@@ -166,6 +166,8 @@ describe('defaultModules', () => {
           contract: workflowsInterModuleContract,
           handlers: {
             deliverEventToJobListener: vi.fn(),
+            getLeasedAgentToolContext: vi.fn(),
+            getStepLogContext: vi.fn(),
             startRunFromTrigger: vi.fn(),
           },
         },
@@ -232,7 +234,7 @@ describe('defaultModules', () => {
     ]);
   });
 
-  it('uses the leased-step loader and namespaced provider secrets', async () => {
+  it('injects Workflows into integrations and logs and namespaces provider secrets', async () => {
     await defaultModules();
 
     expect(mocks.createIntegrationsContext).toHaveBeenCalledWith({
@@ -254,7 +256,7 @@ describe('defaultModules', () => {
           setSecrets: expect.any(Function),
         },
       },
-      agentTools: {loadLeasedAgentStep: expect.any(Function)},
+      agentTools: {workflows: expect.objectContaining({getStepLogContext: expect.any(Function)})},
       webhookDeliverySource: undefined,
     });
 
@@ -264,12 +266,13 @@ describe('defaultModules', () => {
         jira: Pick<SecretsInterModuleClient, 'deleteSecrets' | 'getSecret' | 'setSecrets'>;
         slack: Pick<SecretsInterModuleClient, 'deleteSecrets' | 'getSecret' | 'setSecrets'>;
       };
-      agentTools: {loadLeasedAgentStep: (params: {stepId: string}) => unknown};
+      agentTools: {workflows: unknown};
     };
-    integrationsOptions.agentTools.loadLeasedAgentStep({stepId: 'step-1'});
-    expect(mocks.loadRunningLeasedStep).toHaveBeenCalledWith({
-      stepId: 'step-1',
-      runners: expect.objectContaining({enqueueJobExecution: expect.any(Function)}),
+    expect(integrationsOptions.agentTools.workflows).toEqual(
+      expect.objectContaining({getLeasedAgentToolContext: expect.any(Function)}),
+    );
+    expect(mocks.createLogsModule).toHaveBeenCalledWith({
+      workflows: expect.objectContaining({getStepLogContext: expect.any(Function)}),
     });
 
     const scope = {workspaceId: crypto.randomUUID(), projectId: null, namespace: 'workspace'};

--- a/libs/api/server/src/modules.ts
+++ b/libs/api/server/src/modules.ts
@@ -13,7 +13,7 @@ import {
   getIntegrationConnectionById,
   type WebhookDeliverySource,
 } from '@shipfox/api-integration-core';
-import {logsModule} from '@shipfox/api-logs';
+import {createLogsModule} from '@shipfox/api-logs';
 import {createProjectsModule} from '@shipfox/api-projects';
 import {projectsInterModuleContract} from '@shipfox/api-projects-dto';
 import {runnersModule as defaultRunnersModule} from '@shipfox/api-runners';
@@ -23,7 +23,6 @@ import {secretsInterModuleContract} from '@shipfox/api-secrets-dto/inter-module'
 import {createTriggersModule} from '@shipfox/api-triggers';
 import {
   createWorkflowsModule,
-  loadRunningLeasedStep,
   setAgentToolMaterializationServices,
   setSourceControl,
 } from '@shipfox/api-workflows';
@@ -126,9 +125,7 @@ export async function defaultModules(
           ).deleted,
       },
     },
-    agentTools: {
-      loadLeasedAgentStep: (params) => loadRunningLeasedStep({runners: runnersClient, ...params}),
-    },
+    agentTools: {workflows: workflowsClient},
     webhookDeliverySource: options.webhookDeliverySource,
   });
   const [agentToolSelectionCatalogs, agentToolCatalogs] = await Promise.all([
@@ -174,7 +171,7 @@ export async function defaultModules(
     }),
     annotationsModule,
     options.runnersModule ?? defaultRunnersModule,
-    logsModule,
+    createLogsModule({workflows: workflowsClient}),
     createTriggersModule({workflows: workflowsClient}),
     dispatcherModule,
   ];

--- a/libs/api/triggers/src/core/dispatch-integration-event.history-failure.test.ts
+++ b/libs/api/triggers/src/core/dispatch-integration-event.history-failure.test.ts
@@ -24,6 +24,11 @@ const {dispatchIntegrationEvent} = await import('./dispatch-integration-event.js
 const workflows = {
   startRunFromTrigger: (...args: unknown[]) => runWorkflow(...args),
   deliverEventToJobListener: (...args: unknown[]) => deliverEventToListener(...args),
+  getStepLogContext: async () => ({harness: 'pi' as const}),
+  getLeasedAgentToolContext: async () => ({
+    workspaceId: crypto.randomUUID(),
+    integrations: [],
+  }),
 };
 
 describe('dispatchIntegrationEvent resilience to history-write failure', () => {

--- a/libs/api/triggers/src/core/dispatch-integration-event.test.ts
+++ b/libs/api/triggers/src/core/dispatch-integration-event.test.ts
@@ -14,6 +14,11 @@ const {dispatchIntegrationEvent} = await import('./dispatch-integration-event.js
 const workflows = {
   startRunFromTrigger: (...args: unknown[]) => runWorkflow(...args),
   deliverEventToJobListener: (...args: unknown[]) => deliverEventToListener(...args),
+  getStepLogContext: async () => ({harness: 'pi' as const}),
+  getLeasedAgentToolContext: async () => ({
+    workspaceId: crypto.randomUUID(),
+    integrations: [],
+  }),
 };
 
 function definitionNotFound(_definitionId: string) {

--- a/libs/api/triggers/src/core/workflows-client.test.ts
+++ b/libs/api/triggers/src/core/workflows-client.test.ts
@@ -36,7 +36,7 @@ function localWorkflowsClient(): WorkflowsModuleClient {
         );
       },
       deliverEventToJobListener: () => ({buffered: true, skipped: false}),
-      getStepLogContext: () => ({harness: 'pi'}),
+      getStepLogContext: () => ({harness: 'pi' as const}),
       getLeasedAgentToolContext: () => ({
         workspaceId: '00000000-0000-4000-8000-000000000006',
         integrations: [],

--- a/libs/api/triggers/src/core/workflows-client.test.ts
+++ b/libs/api/triggers/src/core/workflows-client.test.ts
@@ -36,6 +36,11 @@ function localWorkflowsClient(): WorkflowsModuleClient {
         );
       },
       deliverEventToJobListener: () => ({buffered: true, skipped: false}),
+      getStepLogContext: () => ({harness: 'pi'}),
+      getLeasedAgentToolContext: () => ({
+        workspaceId: '00000000-0000-4000-8000-000000000006',
+        integrations: [],
+      }),
     }),
   }).workflows;
 }

--- a/libs/api/workflows-dto/package.json
+++ b/libs/api/workflows-dto/package.json
@@ -51,6 +51,7 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
+    "@shipfox/api-agent-dto": "workspace:*",
     "@shipfox/inter-module": "workspace:*",
     "zod": "catalog:"
   },

--- a/libs/api/workflows-dto/src/inter-module.test.ts
+++ b/libs/api/workflows-dto/src/inter-module.test.ts
@@ -31,6 +31,21 @@ describe('workflowsInterModuleContract', () => {
     expect(delivery.disposition).toBe('fire');
   });
 
+  test('accepts the minimal Logs and agent-tools query payloads', () => {
+    const stepId = '00000000-0000-4000-8000-000000000006';
+    const logContext = workflowsInterModuleContract.methods.getStepLogContext.input.parse({stepId});
+    const agentTools = workflowsInterModuleContract.methods.getLeasedAgentToolContext.input.parse({
+      jobId: '00000000-0000-4000-8000-000000000007',
+      jobExecutionId: '00000000-0000-4000-8000-000000000008',
+      runnerSessionId: '00000000-0000-4000-8000-000000000009',
+      stepId,
+      attempt: 1,
+    });
+
+    expect(logContext).toEqual({stepId});
+    expect(agentTools.attempt).toBe(1);
+  });
+
   test.each([
     ['definition-not-found', {definitionId: '00000000-0000-4000-8000-000000000001'}],
     ['project-mismatch', {}],
@@ -51,5 +66,22 @@ describe('workflowsInterModuleContract', () => {
     const parsed = schema.parse(details);
 
     expect(parsed).toEqual(details);
+  });
+
+  test.each([
+    'lease-not-active',
+    'step-not-found',
+    'job-not-found',
+    'step-attempt-mismatch',
+    'step-not-running',
+    'leased-step-not-agent',
+    'agent-step-config-invalid',
+  ])('defines the %s agent-tools failure', (code) => {
+    const schema =
+      workflowsInterModuleContract.methods.getLeasedAgentToolContext.errors[
+        code as keyof typeof workflowsInterModuleContract.methods.getLeasedAgentToolContext.errors
+      ];
+
+    expect(schema.parse({})).toEqual({});
   });
 });

--- a/libs/api/workflows-dto/src/inter-module.ts
+++ b/libs/api/workflows-dto/src/inter-module.ts
@@ -1,3 +1,4 @@
+import {harnessSchema, materializedAgentIntegrationSchema} from '@shipfox/api-agent-dto';
 import {defineInterModuleContract, type InterModuleClient} from '@shipfox/inter-module';
 import {z} from 'zod';
 
@@ -82,6 +83,32 @@ export const workflowsInterModuleContract = defineInterModuleContract({
         receivedAt: z.string().datetime(),
       }),
       output: z.object({buffered: z.boolean(), skipped: z.boolean()}),
+    },
+    getStepLogContext: {
+      input: z.object({stepId: idSchema}),
+      output: z.object({harness: harnessSchema}),
+    },
+    getLeasedAgentToolContext: {
+      input: z.object({
+        jobId: idSchema,
+        jobExecutionId: idSchema,
+        runnerSessionId: idSchema,
+        stepId: idSchema,
+        attempt: z.number().int().positive(),
+      }),
+      output: z.object({
+        workspaceId: idSchema,
+        integrations: z.array(materializedAgentIntegrationSchema),
+      }),
+      errors: {
+        'lease-not-active': z.object({}),
+        'step-not-found': z.object({}),
+        'job-not-found': z.object({}),
+        'step-attempt-mismatch': z.object({}),
+        'step-not-running': z.object({}),
+        'leased-step-not-agent': z.object({}),
+        'agent-step-config-invalid': z.object({}),
+      },
     },
   },
 });

--- a/libs/api/workflows/src/index.ts
+++ b/libs/api/workflows/src/index.ts
@@ -114,6 +114,8 @@ export function createWorkflowsModule({
         workflows: [],
       },
     ],
-    interModulePresentations: [createWorkflowsInterModulePresentation({definitions, secrets})],
+    interModulePresentations: [
+      createWorkflowsInterModulePresentation({definitions, runners, secrets}),
+    ],
   };
 }

--- a/libs/api/workflows/src/presentation/inter-module.test.ts
+++ b/libs/api/workflows/src/presentation/inter-module.test.ts
@@ -44,6 +44,7 @@ describe('Workflows inter-module presentation', () => {
     const presentation = createWorkflowsInterModulePresentation({
       definitions: {} as never,
       runners: {} as never,
+      secrets: {} as never,
     });
 
     const result = await presentation.handlers.getStepLogContext(
@@ -95,6 +96,7 @@ describe('Workflows inter-module presentation', () => {
     const presentation = createWorkflowsInterModulePresentation({
       definitions: {} as never,
       runners: runners as never,
+      secrets: {} as never,
     });
 
     const result = await presentation.handlers.getLeasedAgentToolContext(input, {

--- a/libs/api/workflows/src/presentation/inter-module.test.ts
+++ b/libs/api/workflows/src/presentation/inter-module.test.ts
@@ -8,7 +8,15 @@ import {
   InterpolationUnresolvableError,
   ProjectMismatchError,
 } from '#core/index.js';
-import {toStartRunKnownError} from './inter-module.js';
+import {createWorkflowsInterModulePresentation, toStartRunKnownError} from './inter-module.js';
+
+const mocks = vi.hoisted(() => ({
+  getJobScope: vi.fn(),
+  getStepById: vi.fn(),
+  getStepByIdForJobExecution: vi.fn(),
+}));
+
+vi.mock('#db/index.js', () => mocks);
 
 const input = {
   workspaceId: '00000000-0000-4000-8000-000000000001',
@@ -25,6 +33,85 @@ const input = {
 };
 
 describe('Workflows inter-module presentation', () => {
+  beforeEach(() => {
+    mocks.getJobScope.mockReset();
+    mocks.getStepById.mockReset();
+    mocks.getStepByIdForJobExecution.mockReset();
+  });
+
+  it('returns only the resolved harness for Logs', async () => {
+    mocks.getStepById.mockResolvedValue({config: {harness: 'claude'}});
+    const presentation = createWorkflowsInterModulePresentation({
+      definitions: {} as never,
+      runners: {} as never,
+    });
+
+    const result = await presentation.handlers.getStepLogContext(
+      {stepId: '00000000-0000-4000-8000-000000000006'},
+      {signal: new AbortController().signal},
+    );
+
+    expect(result).toEqual({harness: 'claude'});
+  });
+
+  it('returns materialized agent integrations for the active leased step', async () => {
+    const input = {
+      jobId: '00000000-0000-4000-8000-000000000006',
+      jobExecutionId: '00000000-0000-4000-8000-000000000007',
+      runnerSessionId: '00000000-0000-4000-8000-000000000008',
+      stepId: '00000000-0000-4000-8000-000000000009',
+      attempt: 1,
+    };
+    const integration = {
+      connectionId: 'connection-1',
+      connectionSlug: 'github',
+      provider: 'github',
+      requiredScope: [],
+      tools: [
+        {
+          id: 'files',
+          sensitivity: 'read' as const,
+          sensitive: false,
+          requiredScope: [],
+          inputSchema: {},
+        },
+      ],
+    };
+    mocks.getStepByIdForJobExecution.mockResolvedValue({
+      currentAttempt: input.attempt,
+      status: 'running',
+      type: 'agent',
+      config: {
+        harness: 'pi',
+        provider: 'openai',
+        model: 'gpt-5',
+        thinking: 'off',
+        prompt: 'Review the change.',
+        integrations: [integration],
+      },
+    });
+    mocks.getJobScope.mockResolvedValue({workspaceId: '00000000-0000-4000-8000-000000000010'});
+    const runners = {getLeaseState: vi.fn().mockResolvedValue({active: true})};
+    const presentation = createWorkflowsInterModulePresentation({
+      definitions: {} as never,
+      runners: runners as never,
+    });
+
+    const result = await presentation.handlers.getLeasedAgentToolContext(input, {
+      signal: new AbortController().signal,
+    });
+
+    expect(result).toEqual({
+      workspaceId: '00000000-0000-4000-8000-000000000010',
+      integrations: [integration],
+    });
+    expect(runners.getLeaseState).toHaveBeenCalledWith({
+      jobId: input.jobId,
+      jobExecutionId: input.jobExecutionId,
+      runnerSessionId: input.runnerSessionId,
+    });
+  });
+
   test.each([
     ['definition-not-found', () => new DefinitionNotFoundError(input.definitionId)],
     ['project-mismatch', () => new ProjectMismatchError(input.projectId, input.definitionId)],

--- a/libs/api/workflows/src/presentation/inter-module.ts
+++ b/libs/api/workflows/src/presentation/inter-module.ts
@@ -1,4 +1,10 @@
+import {
+  DEFAULT_HARNESS,
+  harnessSchema,
+  materializedAgentStepConfigSchema,
+} from '@shipfox/api-agent-dto';
 import type {DefinitionsInterModuleClient} from '@shipfox/api-definitions-dto/inter-module';
+import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-module';
 import type {SecretsInterModuleClient} from '@shipfox/api-secrets-dto/inter-module';
 import {workflowsInterModuleContract} from '@shipfox/api-workflows-dto/inter-module';
 import {
@@ -15,11 +21,13 @@ import {
   ProjectMismatchError,
   runWorkflow,
 } from '#core/index.js';
+import {getJobScope, getStepById, getStepByIdForJobExecution} from '#db/index.js';
 import {deliverEventToListener} from '#db/job-listener-events.js';
 
 export function createWorkflowsInterModulePresentation(params: {
   definitions: DefinitionsInterModuleClient;
   secrets: Pick<SecretsInterModuleClient, 'getVariablesByNamespace'>;
+  runners: RunnersInterModuleClient;
 }): InterModulePresentation<typeof workflowsInterModuleContract> {
   return defineInterModulePresentation(workflowsInterModuleContract, {
     startRunFromTrigger: async (input) => {
@@ -43,6 +51,42 @@ export function createWorkflowsInterModulePresentation(params: {
     },
     deliverEventToJobListener: async (input) =>
       await deliverEventToListener({...input, receivedAt: new Date(input.receivedAt)}),
+    getStepLogContext: async ({stepId}) => {
+      const step = await getStepById(stepId);
+      const parsed = harnessSchema.safeParse(step?.config.harness);
+      return {harness: parsed.success ? parsed.data : DEFAULT_HARNESS};
+    },
+    getLeasedAgentToolContext: async (input) => {
+      const method = workflowsInterModuleContract.methods.getLeasedAgentToolContext;
+      const {active: leaseIsActive} = await params.runners.getLeaseState({
+        jobId: input.jobId,
+        jobExecutionId: input.jobExecutionId,
+        runnerSessionId: input.runnerSessionId,
+      });
+      if (!leaseIsActive) throw createInterModuleKnownError(method, 'lease-not-active', {});
+
+      const step = await getStepByIdForJobExecution({
+        stepId: input.stepId,
+        jobExecutionId: input.jobExecutionId,
+      });
+      if (!step) throw createInterModuleKnownError(method, 'step-not-found', {});
+
+      const scope = await getJobScope(input.jobId);
+      if (!scope) throw createInterModuleKnownError(method, 'job-not-found', {});
+      if (step.currentAttempt !== input.attempt) {
+        throw createInterModuleKnownError(method, 'step-attempt-mismatch', {});
+      }
+      if (step.status !== 'running')
+        throw createInterModuleKnownError(method, 'step-not-running', {});
+      if (step.type !== 'agent')
+        throw createInterModuleKnownError(method, 'leased-step-not-agent', {});
+
+      const config = materializedAgentStepConfigSchema.safeParse(step.config);
+      if (!config.success) {
+        throw createInterModuleKnownError(method, 'agent-step-config-invalid', {});
+      }
+      return {workspaceId: scope.workspaceId, integrations: config.data.integrations ?? []};
+    },
   });
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2420,9 +2420,15 @@ importers:
       '@shipfox/api-integration-webhook':
         specifier: workspace:*
         version: link:../webhook
+      '@shipfox/api-workflows-dto':
+        specifier: workspace:*
+        version: link:../../workflows-dto
       '@shipfox/config':
         specifier: workspace:*
         version: link:../../../shared/common/config
+      '@shipfox/inter-module':
+        specifier: workspace:*
+        version: link:../../../shared/common/inter-module
       '@shipfox/node-drizzle':
         specifier: workspace:*
         version: link:../../../shared/node/drizzle
@@ -3213,9 +3219,6 @@ importers:
       '@shipfox/api-logs-dto':
         specifier: workspace:*
         version: link:../logs-dto
-      '@shipfox/api-workflows':
-        specifier: workspace:*
-        version: link:../workflows
       '@shipfox/api-workflows-dto':
         specifier: workspace:*
         version: link:../workflows-dto
@@ -3265,6 +3268,9 @@ importers:
       '@shipfox/biome':
         specifier: workspace:*
         version: link:../../../tools/biome
+      '@shipfox/inter-module':
+        specifier: workspace:*
+        version: link:../../shared/common/inter-module
       '@shipfox/node-jwt':
         specifier: workspace:*
         version: link:../../shared/node/jwt
@@ -4071,6 +4077,9 @@ importers:
 
   libs/api/workflows-dto:
     dependencies:
+      '@shipfox/api-agent-dto':
+        specifier: workspace:*
+        version: link:../agent-dto
       '@shipfox/inter-module':
         specifier: workspace:*
         version: link:../../shared/common/inter-module


### PR DESCRIPTION
Moves Logs and the integration agent-tools gateway to injected, producer-owned Workflows clients.

These consumers previously reached into Workflows implementation code, exposing full step state and tying their tests to implementation imports. The new contract returns only the resolved log harness or materialized integrations required for each use case; Workflows retains lease validation and maps stable known failures back to the gateway.

The migration also removes the old Logs global test replacement, adds producer and consumer coverage, and prevents the implementation dependency from returning through Dependency Cruiser. The public Logs and Integration Core factory changes are released as majors, with additive Workflows contract releases.

Closes ENG-1037

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates Logs and Integrations to injected Workflows inter-module clients. Workflows validates leases and returns minimal log and agent-tool contexts; consumers map known failures to 404/409. Fixes ENG-1037.

- **Refactors**
  - `@shipfox/api-logs`: switch to `createLogsModule({workflows})`; routes via `createLogsRoutes(workflows)` and `createAppendLogsRoute(workflows)`; `appendLogs` reads harness from `workflows.getStepLogContext`; remove test-only step lookup; add test `WorkflowsModuleClient` fixture.
  - `@shipfox/api-integration-core`: routes accept `{agentTools: {workflows}}`; agent-tools gateway uses `createWorkflowsLeasedAgentStepLoader(workflows)` and maps known errors to 404/409; falls back to legacy config when integrations are absent.
  - `@shipfox/api-workflows-dto`: add `getStepLogContext` and `getLeasedAgentToolContext` with typed known errors; depend on `@shipfox/api-agent-dto`.
  - `@shipfox/api-workflows`: implement new inter-module handlers, validate leases with Runners, and return minimal contexts.
  - Dependency boundary: enforce Logs/Integrations use the Workflows DTO only (Dependency Cruiser rule).
  - Server/tests: inject `workflows` into Integrations and Logs; update Triggers client doubles; fix Logs harness test types; fix Workflows presentation test dependencies.

- **Migration**
  - Host Logs with `createLogsModule({workflows})`.
  - Pass `agentTools: {workflows}` to Integration routes; provide a `WorkflowsModuleClient` from `@shipfox/api-workflows-dto/inter-module`.
  - Versioning: `@shipfox/api-integration-core` and `@shipfox/api-logs` are major; `@shipfox/api-workflows` and `@shipfox/api-workflows-dto` are minor; `@shipfox/api-server` is patch.

<sup>Written for commit ce03aa538d620905e8db01b9655d9c7f66d01352. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

