### PR TITLE
[api-dispatcher] Add pending-event backlog gauge

### DIFF
--- a/.changeset/steady-otters-watch.md
+++ b/.changeset/steady-otters-watch.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/node-module": minor
+"@shipfox/api-dispatcher": patch
+---
+
+Adds dispatcher backlog metrics from registered pending outbox rows.

--- a/libs/api/definitions/src/db/definitions.test.ts
+++ b/libs/api/definitions/src/db/definitions.test.ts
@@ -1,6 +1,7 @@
 import {DEFINITION_RESOLVED} from '@shipfox/api-definitions-dto';
 import {
   BATCH_SIZE,
+  countPendingOutboxRows,
   type DrainedEvent,
   drainAll,
   markDispatched,
@@ -738,6 +739,25 @@ describe('definition queries', () => {
         .update(definitionsOutbox)
         .set({dispatchedAt: sql`COALESCE(${definitionsOutbox.dispatchedAt}, now())`})
         .where(sql`${definitionsOutbox.payload}->>'projectId' = ${projectId}`);
+    });
+
+    test('countPendingOutboxRows counts pending rows but excludes dispatched and dead-lettered rows', async () => {
+      await insertOutboxRow({projectId, marker: 'pending'});
+      await insertOutboxRow({projectId, marker: 'dispatched', dispatchedAt: new Date()});
+      await insertOutboxRow({projectId, marker: 'dead-lettered', deadLetteredAt: new Date()});
+
+      const pendingRows = await countPendingOutboxRows();
+
+      expect(pendingRows).toBe(1);
+    });
+
+    test('countPendingOutboxRows sums pending rows across every registered publisher', async () => {
+      registerPublisher({name: 'definitions-second', table: definitionsOutbox, db: () => db()});
+      await insertOutboxRow({projectId, marker: 'pending'});
+
+      const pendingRows = await countPendingOutboxRows();
+
+      expect(pendingRows).toBe(2);
     });
 
     test('drainAll returns undispatched outbox events', async () => {

--- a/libs/api/dispatcher/src/metrics/index.ts
+++ b/libs/api/dispatcher/src/metrics/index.ts
@@ -1,1 +1,2 @@
 export {dispatchFailureCount, drainBatchSize, eventDispatchedCount} from './instance.js';
+export {registerDispatcherServiceMetrics} from './service.js';

--- a/libs/api/dispatcher/src/metrics/service.test.ts
+++ b/libs/api/dispatcher/src/metrics/service.test.ts
@@ -1,0 +1,48 @@
+const mocks = vi.hoisted(() => {
+  const gauge = {};
+  return {
+    addBatchObservableCallback: vi.fn(),
+    countPendingOutboxRows: vi.fn(),
+    createObservableGauge: vi.fn(() => gauge),
+    gauge,
+    getMeter: vi.fn(),
+    getServiceMetricsProvider: vi.fn(),
+  };
+});
+
+vi.mock('@shipfox/node-module', () => ({countPendingOutboxRows: mocks.countPendingOutboxRows}));
+vi.mock('@shipfox/node-opentelemetry', () => ({
+  getServiceMetricsProvider: mocks.getServiceMetricsProvider,
+}));
+
+import {registerDispatcherServiceMetrics} from './service.js';
+
+describe('registerDispatcherServiceMetrics', () => {
+  beforeEach(() => {
+    mocks.addBatchObservableCallback.mockReset();
+    mocks.countPendingOutboxRows.mockReset();
+    mocks.createObservableGauge.mockClear();
+    mocks.getMeter.mockReset();
+    mocks.getServiceMetricsProvider.mockReset();
+    mocks.getMeter.mockReturnValue({
+      createObservableGauge: mocks.createObservableGauge,
+      addBatchObservableCallback: mocks.addBatchObservableCallback,
+    });
+    mocks.getServiceMetricsProvider.mockReturnValue({getMeter: mocks.getMeter});
+  });
+
+  test('observes the pending rows across registered publishers', async () => {
+    mocks.countPendingOutboxRows.mockResolvedValue(7);
+
+    registerDispatcherServiceMetrics();
+    const callback = mocks.addBatchObservableCallback.mock.calls[0]?.[0];
+    const observer = {observe: vi.fn()};
+
+    await callback?.(observer);
+
+    expect(mocks.createObservableGauge).toHaveBeenCalledWith('dispatcher_pending_events', {
+      description: 'Outbox events awaiting dispatch, including claimed and retry-delayed events',
+    });
+    expect(observer.observe).toHaveBeenCalledWith(mocks.gauge, 7);
+  });
+});

--- a/libs/api/dispatcher/src/metrics/service.ts
+++ b/libs/api/dispatcher/src/metrics/service.ts
@@ -1,0 +1,17 @@
+import {countPendingOutboxRows} from '@shipfox/node-module';
+import {getServiceMetricsProvider} from '@shipfox/node-opentelemetry';
+
+export function registerDispatcherServiceMetrics(): void {
+  const meter = getServiceMetricsProvider().getMeter('dispatcher');
+
+  const pendingEvents = meter.createObservableGauge('dispatcher_pending_events', {
+    description: 'Outbox events awaiting dispatch, including claimed and retry-delayed events',
+  });
+
+  meter.addBatchObservableCallback(
+    async (observer) => {
+      observer.observe(pendingEvents, await countPendingOutboxRows());
+    },
+    [pendingEvents],
+  );
+}

--- a/libs/api/dispatcher/src/module.test.ts
+++ b/libs/api/dispatcher/src/module.test.ts
@@ -79,6 +79,7 @@ describe('dispatcherModule', () => {
       },
     ]);
     expect(module.services?.[0]?.name).toBe('outbox-drainer');
+    expect(module.metrics).toBeDefined();
   });
 
   it('does not register the in-process drainer when disabled', () => {

--- a/libs/api/dispatcher/src/module.ts
+++ b/libs/api/dispatcher/src/module.ts
@@ -10,6 +10,7 @@ import {
   OUTBOX_RETENTION_WORKFLOW_ID,
 } from '#core/constants.js';
 import {createOutboxDrainerService} from '#core/outbox-drainer-service.js';
+import {registerDispatcherServiceMetrics} from '#metrics/index.js';
 import {createActivities} from '#temporal/index.js';
 
 // Temporal's webpack bundler requires a compiled .js file. Whether running from
@@ -61,6 +62,7 @@ export function createDispatcherModule(
 
       return Promise.resolve();
     },
+    metrics: registerDispatcherServiceMetrics,
     ...(enabled ? {services: [createOutboxDrainerService({pollMs})]} : {}),
     workers: [
       {

--- a/libs/shared/node/module/src/index.ts
+++ b/libs/shared/node/module/src/index.ts
@@ -32,6 +32,7 @@ export type {
 } from './publisher-registry.js';
 export {
   BATCH_SIZE,
+  countPendingOutboxRows,
   drainAll,
   getEventSchema,
   getRegisteredPublisherNames,

--- a/libs/shared/node/module/src/publisher-registry.test.ts
+++ b/libs/shared/node/module/src/publisher-registry.test.ts
@@ -2,7 +2,13 @@ import {createOutboxTable} from '@shipfox/node-outbox';
 import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
 import {pgTableCreator} from 'drizzle-orm/pg-core';
 import {z} from 'zod';
+
+const mocks = vi.hoisted(() => ({warn: vi.fn()}));
+
+vi.mock('@shipfox/node-opentelemetry', () => ({logger: () => ({warn: mocks.warn})}));
+
 import {
+  countPendingOutboxRows,
   getEventSchema,
   getRegisteredPublisherNames,
   pruneDispatchedOutboxRows,
@@ -133,5 +139,42 @@ describe('pruneDispatchedOutboxRows', () => {
     });
 
     expect(results).toEqual([]);
+  });
+});
+
+describe('countPendingOutboxRows', () => {
+  beforeEach(() => {
+    mocks.warn.mockClear();
+    resetPublishers();
+  });
+
+  afterEach(() => {
+    resetPublishers();
+  });
+
+  it('returns zero when no publishers are registered', async () => {
+    const pendingRows = await countPendingOutboxRows();
+
+    expect(pendingRows).toBe(0);
+  });
+
+  it('logs failed sources and returns the counts from successful sources', async () => {
+    const failure = new Error('database unavailable');
+    const successfulDb = (() => ({
+      select: () => ({from: () => ({where: () => Promise.resolve([{count: 3}])})}),
+    })) as unknown as () => NodePgDatabase<Record<string, unknown>>;
+    const failedDb = (() => ({
+      select: () => ({from: () => ({where: () => Promise.reject(failure)})}),
+    })) as unknown as () => NodePgDatabase<Record<string, unknown>>;
+    registerPublisher({name: 'successful', table, db: successfulDb});
+    registerPublisher({name: 'failed', table, db: failedDb});
+
+    const pendingRows = await countPendingOutboxRows();
+
+    expect(pendingRows).toBe(3);
+    expect(mocks.warn).toHaveBeenCalledWith(
+      {err: failure, source: 'failed'},
+      'Failed to count pending outbox rows',
+    );
   });
 });

--- a/libs/shared/node/module/src/publisher-registry.ts
+++ b/libs/shared/node/module/src/publisher-registry.ts
@@ -1,3 +1,4 @@
+import {logger} from '@shipfox/node-opentelemetry';
 import type {DomainEvent, OutboxTable} from '@shipfox/node-outbox';
 import {and, eq, getTableName, inArray, isNull, type SQL, sql} from 'drizzle-orm';
 import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
@@ -100,6 +101,30 @@ export function getRegisteredPublisherNames(): string[] {
 
 export function getEventSchema(type: string): ZodType | undefined {
   return _schemasByType.get(type);
+}
+
+export async function countPendingOutboxRows(): Promise<number> {
+  const sources = [..._sources];
+  const results = await Promise.allSettled(
+    sources.map(async (source) => {
+      const [row] = await source
+        .db()
+        .select({count: sql<number>`count(*)::int`})
+        .from(source.table)
+        .where(and(isNull(source.table.dispatchedAt), isNull(source.table.deadLetteredAt)));
+      return row?.count ?? 0;
+    }),
+  );
+
+  return results.reduce((total, result, index) => {
+    if (result.status === 'fulfilled') return total + result.value;
+
+    logger().warn(
+      {err: result.reason, source: sources[index]?.name},
+      'Failed to count pending outbox rows',
+    );
+    return total;
+  }, 0);
 }
 
 export async function drainAll(options: DrainAllOptions = {}): Promise<DrainAllResult> {


### PR DESCRIPTION
Adds a service-level dispatcher_pending_events gauge backed by the registered outbox publishers.

Moving the dispatcher off its Temporal poll loop removes the previous UI visibility into queue depth. The gauge exposes pending rows, including claimed and retry-delayed events, so self-hosted operators can detect drain lag.

Each publisher count runs independently. Failed sources are logged and excluded from the observed total so a transient failure cannot suppress the entire metric scrape. Query timeout and pool-concurrency policy remain a follow-up because they apply to existing service gauges as well.

Closes ENG-1102

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a service-level `dispatcher_pending_events` gauge that reports pending outbox rows across all registered publishers. Restores backlog visibility after moving the dispatcher off Temporal and addresses ENG-1102.

- New Features
  - Added `registerDispatcherServiceMetrics()` to expose `dispatcher_pending_events` via the service metrics provider using an observable gauge.
  - Introduced `countPendingOutboxRows()` in `@shipfox/node-module` to sum rows where `dispatched_at` and `dead_lettered_at` are null across registered publishers.
  - Logs and excludes failed sources so healthy counts still report.
  - Wired the metric via the dispatcher module `metrics` hook and added tests for counting and observation.

<sup>Written for commit 3571b2fa8071818929d55d199275602335b4f03d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

