### PR TITLE
Expose Auth inter-module API

### DIFF
--- a/.changeset/quiet-otters-connect.md
+++ b/.changeset/quiet-otters-connect.md
@@ -1,10 +1,9 @@
 ---
-"@shipfox/api-projects-dto": minor
-"@shipfox/api-projects": minor
-"@shipfox/api-definitions": patch
-"@shipfox/api-secrets": patch
+"@shipfox/api-auth-dto": minor
+"@shipfox/api-auth": patch
+"@shipfox/api-runners": patch
 "@shipfox/api-workflows": patch
-"@shipfox/api-server": patch
+"@shipfox/api-logs": patch
 ---
 
-Adds the Projects inter-module contract and routes project lookup, ownership, and access decisions through injected clients.
+Adds the Auth inter-module token-minting contract and removes Auth implementation and configuration coupling from its consumers.

--- a/apps/api/.env
+++ b/apps/api/.env
@@ -17,6 +17,9 @@ CLIENT_BASE_URL=http://localhost:5173
 AUTH_JWT_SECRET=dev-only-jwt-secret-change-me
 AUTH_JWT_EXPIRES_IN=15m
 
+# Secret used to HMAC identifiers before storing runners rate-limit counters.
+RATE_LIMIT_IDENTIFIER_SECRET=dev-only-rate-limit-secret-change-me
+
 # Job lease capability token (job-scoped, HS256) — minted by Scheduling, verified by Orchestration
 AUTH_JOB_LEASE_TOKEN_SECRET=dev-only-lease-secret-change-me
 # AUTH_JOB_LEASE_TOKEN_EXPIRES_IN=90m

--- a/libs/api/auth-dto/package.json
+++ b/libs/api/auth-dto/package.json
@@ -28,6 +28,16 @@
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
       }
+    },
+    "./inter-module": {
+      "workspace-source": {
+        "types": "./src/inter-module.ts",
+        "default": "./src/inter-module.ts"
+      },
+      "default": {
+        "types": "./dist/inter-module.d.ts",
+        "default": "./dist/inter-module.js"
+      }
     }
   },
   "scripts": {
@@ -40,6 +50,7 @@
   },
   "dependencies": {
     "@shipfox/api-common-dto": "workspace:*",
+    "@shipfox/inter-module": "workspace:*",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/libs/api/auth-dto/src/inter-module.ts
+++ b/libs/api/auth-dto/src/inter-module.ts
@@ -1,0 +1,27 @@
+import {defineInterModuleContract, type InterModuleClient} from '@shipfox/inter-module';
+import {z} from 'zod';
+import {jobLeaseTokenClaimsSchema} from './schemas/job-lease-token.js';
+import {runnerSessionTokenClaimsSchema} from './schemas/runner-session-token.js';
+
+const runnerSessionClaimsSchema = runnerSessionTokenClaimsSchema.omit({
+  aud: true,
+  iat: true,
+  exp: true,
+});
+const jobLeaseClaimsSchema = jobLeaseTokenClaimsSchema.omit({aud: true, iat: true, exp: true});
+
+export const authInterModuleContract = defineInterModuleContract({
+  module: 'auth',
+  methods: {
+    mintRunnerSessionToken: {
+      input: runnerSessionClaimsSchema,
+      output: z.object({token: z.string().min(1)}),
+    },
+    mintJobLeaseToken: {
+      input: jobLeaseClaimsSchema,
+      output: z.object({token: z.string().min(1)}),
+    },
+  },
+});
+
+export type AuthInterModuleClient = InterModuleClient<typeof authInterModuleContract>;

--- a/libs/api/auth/package.json
+++ b/libs/api/auth/package.json
@@ -57,6 +57,7 @@
     "@shipfox/api-workspaces": "workspace:*",
     "@shipfox/api-workspaces-dto": "workspace:*",
     "@shipfox/config": "workspace:*",
+    "@shipfox/inter-module": "workspace:*",
     "@shipfox/node-drizzle": "workspace:*",
     "@shipfox/node-fastify": "workspace:*",
     "@shipfox/node-jwt": "workspace:*",

--- a/libs/api/auth/src/index.ts
+++ b/libs/api/auth/src/index.ts
@@ -14,6 +14,7 @@ import {createJwtAuthMethod} from '#presentation/auth/jwt-auth.js';
 import {createLeaseTokenAuthMethod} from '#presentation/auth/lease-token-auth.js';
 import {createRunnerSessionAuthMethod} from '#presentation/auth/runner-session-auth.js';
 import {authE2eRoutes} from '#presentation/e2eRoutes/index.js';
+import {createAuthInterModulePresentation} from '#presentation/inter-module.js';
 import {authRoutes} from '#presentation/routes/index.js';
 import {
   onEmailVerificationSendRequested,
@@ -71,4 +72,5 @@ export const authModule: ShipfoxModule = {
     subscriber(AUTH_EMAIL_VERIFICATION_SEND_REQUESTED, onEmailVerificationSendRequested),
     subscriber(AUTH_PASSWORD_RESET_SEND_REQUESTED, onPasswordResetSendRequested),
   ],
+  interModulePresentations: [createAuthInterModulePresentation()],
 };

--- a/libs/api/auth/src/presentation/inter-module.ts
+++ b/libs/api/auth/src/presentation/inter-module.ts
@@ -1,0 +1,13 @@
+import {authInterModuleContract} from '@shipfox/api-auth-dto/inter-module';
+import {defineInterModulePresentation, type InterModulePresentation} from '@shipfox/inter-module';
+import {issueJobLeaseToken} from '#core/job-lease-token.js';
+import {issueRunnerSessionToken} from '#core/runner-session-token.js';
+
+export function createAuthInterModulePresentation(): InterModulePresentation<
+  typeof authInterModuleContract
+> {
+  return defineInterModulePresentation(authInterModuleContract, {
+    mintRunnerSessionToken: async (claims) => ({token: await issueRunnerSessionToken(claims)}),
+    mintJobLeaseToken: async (claims) => ({token: await issueJobLeaseToken(claims)}),
+  });
+}

--- a/libs/api/integration/core/test/external/pnpm-workspace.yaml
+++ b/libs/api/integration/core/test/external/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
 overrides:
   "@shipfox/api-integration-core-dto": "file:./api-integration-core-dto.tgz"
+  "@shipfox/api-workflows-dto": "file:./api-workflows-dto.tgz"
+  "@shipfox/inter-module": "file:./inter-module.tgz"

--- a/libs/api/integration/core/test/external/verify.mjs
+++ b/libs/api/integration/core/test/external/verify.mjs
@@ -11,6 +11,8 @@ import {
 const fixtureSource = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(fixtureSource, '../..');
 const dtoPackageRoot = resolve(packageRoot, '../core-dto');
+const interModulePackageRoot = resolve(packageRoot, '../../../shared/common/inter-module');
+const workflowsDtoPackageRoot = resolve(packageRoot, '../../workflows-dto');
 const fixtureRoot = await mkdtemp(join(tmpdir(), 'api-integration-webhook-external-'));
 const manifestPacker = createProductionManifestPacker();
 
@@ -50,6 +52,8 @@ try {
   });
   await rename(join(fixtureRoot, 'package.template.json'), join(fixtureRoot, 'package.json'));
   await packPackage(dtoPackageRoot, join(fixtureRoot, 'api-integration-core-dto.tgz'));
+  await packPackage(interModulePackageRoot, join(fixtureRoot, 'inter-module.tgz'));
+  await packPackage(workflowsDtoPackageRoot, join(fixtureRoot, 'api-workflows-dto.tgz'));
   await packPackage(packageRoot, join(fixtureRoot, 'api-integration-core.tgz'));
   await run('pnpm', ['install', '--ignore-scripts'], fixtureRoot);
   await verifyInstalledExport('@shipfox/api-integration-core');

--- a/libs/api/logs/src/config.test.ts
+++ b/libs/api/logs/src/config.test.ts
@@ -47,48 +47,24 @@ describe('LOG_STREAM_REAP_AFTER_SECONDS validation', () => {
     vi.resetModules();
   });
 
-  // Reaping a stream a still-valid lease is appending to silently truncates live logs, so a value
-  // at or below the job lease TTL (default 90m = 5400s) must fail startup.
   it.each([
-    '0',
-    '-100',
-    '5400',
-  ])('fails startup when LOG_STREAM_REAP_AFTER_SECONDS is %s (at or below the default lease TTL)', async (value) => {
-    vi.stubEnv('LOG_STREAM_REAP_AFTER_SECONDS', value);
+    0, -100, 5400,
+  ])('rejects a reaper window of %d seconds for a 90-minute Auth lease', async (value) => {
+    vi.stubEnv('LOG_STREAM_REAP_AFTER_SECONDS', String(value));
     vi.resetModules();
 
-    await expect(import('#config.js')).rejects.toThrow('LOG_STREAM_REAP_AFTER_SECONDS');
+    const {validateLogStreamReapAfterSeconds} = await import('#config.js');
+
+    expect(() => validateLogStreamReapAfterSeconds(5400)).toThrow('LOG_STREAM_REAP_AFTER_SECONDS');
   });
 
-  it('accepts a value above the lease TTL', async () => {
-    vi.stubEnv('LOG_STREAM_REAP_AFTER_SECONDS', '9000');
-    vi.resetModules();
-
-    const {config} = await import('#config.js');
-
-    expect(config.LOG_STREAM_REAP_AFTER_SECONDS).toBe(9000);
-  });
-
-  // The check reads the actual configured lease TTL, not a hardcoded floor: raising the lease past
-  // the reaper window must fail startup even though the value clears the default lease.
-  it('fails when AUTH_JOB_LEASE_TOKEN_EXPIRES_IN is raised above the reaper window', async () => {
-    vi.stubEnv('AUTH_JOB_LEASE_TOKEN_EXPIRES_IN', '180m');
-    vi.stubEnv('LOG_STREAM_REAP_AFTER_SECONDS', '9000');
-    vi.resetModules();
-
-    await expect(import('#config.js')).rejects.toThrow('LOG_STREAM_REAP_AFTER_SECONDS');
-  });
-
-  // The converse: a small reaper window is fine when the lease is correspondingly small, proving
-  // the bound tracks the lease rather than a fixed 5400s floor.
-  it('accepts a small reaper window when the lease TTL is correspondingly small', async () => {
-    vi.stubEnv('AUTH_JOB_LEASE_TOKEN_EXPIRES_IN', '5m');
+  it('accepts a reaper window above the Auth lease lifetime', async () => {
     vi.stubEnv('LOG_STREAM_REAP_AFTER_SECONDS', '600');
     vi.resetModules();
 
-    const {config} = await import('#config.js');
+    const {validateLogStreamReapAfterSeconds} = await import('#config.js');
 
-    expect(config.LOG_STREAM_REAP_AFTER_SECONDS).toBe(600);
+    expect(() => validateLogStreamReapAfterSeconds(300)).not.toThrow();
   });
 });
 

--- a/libs/api/logs/src/config.ts
+++ b/libs/api/logs/src/config.ts
@@ -1,6 +1,4 @@
-import {config as authConfig} from '@shipfox/api-auth/config';
 import {bool, createConfig, num, str, url} from '@shipfox/config';
-import {durationToSeconds} from '@shipfox/node-jwt';
 
 export const config = createConfig({
   LOG_STORAGE_S3_ENDPOINT: url({
@@ -48,7 +46,7 @@ export const config = createConfig({
     default: 900,
   }),
   LOG_STREAM_REAP_AFTER_SECONDS: num({
-    desc: 'How long a log stream may stay open before the reaper cron force-closes it as abandoned. This is the backstop for a stream a runner started after its job already went terminal (the one-shot close sweep had already run); the reaper marks it truncated so it re-enters the compaction and retention lifecycle. Must be greater than AUTH_JOB_LEASE_TOKEN_EXPIRES_IN (the job lease lifetime, default 90 minutes) so a still-valid lease can never be force-closed mid-append, which would silently truncate live logs. Defaults to 7200 seconds (2 hours).',
+    desc: 'How long a log stream may stay open before the reaper cron force-closes it as abandoned. This is the backstop for a stream a runner started after its job already went terminal (the one-shot close sweep had already run); the reaper marks it truncated so it re-enters the compaction and retention lifecycle. The application validates that this exceeds the Auth job lease lifetime. Defaults to 7200 seconds (2 hours).',
     default: 7200,
   }),
   LOG_APPEND_BODY_LIMIT_BYTES: num({
@@ -115,16 +113,13 @@ if (!Number.isInteger(config.LOG_RETENTION_DAYS) || config.LOG_RETENTION_DAYS < 
   );
 }
 
-// A stream still accepts appends until its job lease expires, so reaping it any sooner would
-// truncate live logs. Validate against the real lease TTL read from auth's config (not a
-// hardcoded floor), so raising AUTH_JOB_LEASE_TOKEN_EXPIRES_IN can never silently outrun the
-// reaper window.
-const jobLeaseTtlSeconds = durationToSeconds(authConfig.AUTH_JOB_LEASE_TOKEN_EXPIRES_IN);
-if (
-  !Number.isFinite(config.LOG_STREAM_REAP_AFTER_SECONDS) ||
-  config.LOG_STREAM_REAP_AFTER_SECONDS <= jobLeaseTtlSeconds
-) {
-  throw new Error(
-    `LOG_STREAM_REAP_AFTER_SECONDS (${config.LOG_STREAM_REAP_AFTER_SECONDS}) must be greater than the job lease TTL (${jobLeaseTtlSeconds}s, from AUTH_JOB_LEASE_TOKEN_EXPIRES_IN=${authConfig.AUTH_JOB_LEASE_TOKEN_EXPIRES_IN}); a smaller value would let the reaper force-close a stream a still-valid lease is appending to and silently truncate live logs.`,
-  );
+export function validateLogStreamReapAfterSeconds(jobLeaseTokenTtlSeconds: number): void {
+  if (
+    !Number.isFinite(config.LOG_STREAM_REAP_AFTER_SECONDS) ||
+    config.LOG_STREAM_REAP_AFTER_SECONDS <= jobLeaseTokenTtlSeconds
+  ) {
+    throw new Error(
+      `LOG_STREAM_REAP_AFTER_SECONDS (${config.LOG_STREAM_REAP_AFTER_SECONDS}) must be greater than the Auth job lease TTL (${jobLeaseTokenTtlSeconds}s); a smaller value would let the reaper force-close a stream a still-valid lease is appending to and silently truncate live logs.`,
+    );
+  }
 }

--- a/libs/api/logs/src/index.ts
+++ b/libs/api/logs/src/index.ts
@@ -8,6 +8,7 @@ import {
 } from '@shipfox/api-workflows-dto';
 import type {WorkflowsModuleClient} from '@shipfox/api-workflows-dto/inter-module';
 import {type ShipfoxModule, subscriberFactory} from '@shipfox/node-module';
+import {validateLogStreamReapAfterSeconds} from '#config.js';
 import {db} from '#db/db.js';
 import {migrationsPath} from '#db/index.js';
 import {logsOutbox} from '#db/schema/outbox.js';
@@ -26,7 +27,15 @@ const workflowsPath = resolve(packageRoot, 'dist/temporal/workflows/index.js');
 
 const subscriber = subscriberFactory<WorkflowsEventMapDto & LogsEventMap>();
 
-export function createLogsModule({workflows}: {workflows: WorkflowsModuleClient}): ShipfoxModule {
+export function createLogsModule({
+  workflows,
+  jobLeaseTokenTtlSeconds,
+}: {
+  workflows: WorkflowsModuleClient;
+  jobLeaseTokenTtlSeconds: number;
+}): ShipfoxModule {
+  validateLogStreamReapAfterSeconds(jobLeaseTokenTtlSeconds);
+
   return {
     name: 'logs',
     database: {db, migrationsPath},

--- a/libs/api/runners/package.json
+++ b/libs/api/runners/package.json
@@ -40,8 +40,8 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
-    "@shipfox/api-auth": "workspace:*",
     "@shipfox/api-auth-context": "workspace:*",
+    "@shipfox/api-auth-dto": "workspace:*",
     "@shipfox/api-runners-dto": "workspace:*",
     "@shipfox/api-workflows-dto": "workspace:*",
     "@shipfox/config": "workspace:*",
@@ -61,6 +61,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@shipfox/api-auth": "workspace:*",
     "@shipfox/api-auth-dto": "workspace:*",
     "@shipfox/biome": "workspace:*",
     "@shipfox/node-jwt": "workspace:*",

--- a/libs/api/runners/src/config.test.ts
+++ b/libs/api/runners/src/config.test.ts
@@ -90,7 +90,7 @@ describe('RATE_LIMIT_IDENTIFIER_SECRET validation', () => {
     vi.resetModules();
   });
 
-  it('allows the secret to be omitted', async () => {
+  it('uses the existing JWT secret when no dedicated identifier secret is set', async () => {
     const previous = process.env.RATE_LIMIT_IDENTIFIER_SECRET;
     delete process.env.RATE_LIMIT_IDENTIFIER_SECRET;
     vi.resetModules();
@@ -98,7 +98,7 @@ describe('RATE_LIMIT_IDENTIFIER_SECRET validation', () => {
     try {
       const {config} = await import('#config.js');
 
-      expect(config.RATE_LIMIT_IDENTIFIER_SECRET).toBeUndefined();
+      expect(config.RATE_LIMIT_IDENTIFIER_SECRET).toBe(process.env.AUTH_JWT_SECRET);
     } finally {
       if (previous === undefined) {
         delete process.env.RATE_LIMIT_IDENTIFIER_SECRET;

--- a/libs/api/runners/src/config.ts
+++ b/libs/api/runners/src/config.ts
@@ -34,8 +34,8 @@ export const config = createConfig({
     default: 250,
   }),
   RATE_LIMIT_IDENTIFIER_SECRET: str({
-    desc: 'Optional secret used to HMAC identifiers before storing rate-limit counters. Leave it unset to derive a stable key from AUTH_JWT_SECRET.',
-    default: undefined,
+    desc: 'Secret used to HMAC identifiers before storing rate-limit counters. Set a dedicated value in production. When unset, the existing AUTH_JWT_SECRET environment value is used for compatibility with existing deployments.',
+    default: process.env.AUTH_JWT_SECRET,
   }),
   RESERVATION_TTL_SECONDS: num({
     desc: 'Lifetime of a count-based runner reservation, in seconds. Expired reservations stop counting against queued demand.',

--- a/libs/api/runners/src/core/job-executions.ts
+++ b/libs/api/runners/src/core/job-executions.ts
@@ -1,4 +1,4 @@
-import {issueJobLeaseToken} from '@shipfox/api-auth';
+import type {AuthInterModuleClient} from '@shipfox/api-auth-dto/inter-module';
 import {claimPendingJobExecution} from '#db/job-executions.js';
 import {jobExecutionClaimedCount} from '#metrics/instance.js';
 import {config} from '../config.js';
@@ -12,6 +12,7 @@ export interface ClaimJobExecutionResult {
 }
 
 export async function claimJobExecution(params: {
+  auth: AuthInterModuleClient;
   workspaceId: string;
   runnerSessionId: string;
   sessionLabels: string[];
@@ -27,7 +28,7 @@ export async function claimJobExecution(params: {
   }
   jobExecutionClaimedCount.add(1, {outcome: 'claimed'});
 
-  const leaseToken = await issueJobLeaseToken({
+  const {token: leaseToken} = await params.auth.mintJobLeaseToken({
     workflowRunId: claimed.workflowRunId,
     workflowRunAttemptId: claimed.workflowRunAttemptId,
     jobId: claimed.jobId,

--- a/libs/api/runners/src/core/rate-limit.test.ts
+++ b/libs/api/runners/src/core/rate-limit.test.ts
@@ -111,7 +111,7 @@ describe('checkRunnersRateLimit', () => {
     });
   });
 
-  it('uses the configured shared identifier secret when present', async () => {
+  it('uses the configured identifier secret', async () => {
     vi.resetModules();
     vi.doMock('#config.js', () => ({
       config: {
@@ -119,39 +119,33 @@ describe('checkRunnersRateLimit', () => {
         RUNNERS_RATE_LIMIT_TIMEOUT_MS: 250,
       },
     }));
-    vi.doMock('@shipfox/api-auth/config', () => ({
-      config: {
-        AUTH_JWT_SECRET: 'jwt-secret',
-      },
-    }));
 
     try {
-      const configuredSecretModule = await import('./rate-limit.js');
-      const configuredSecretHash = configuredSecretModule.hashRunnersRateLimitIdentifier({
+      const firstModule = await import('./rate-limit.js');
+      const firstHash = firstModule.hashRunnersRateLimitIdentifier({
         action: 'provisioner-mint',
         scope: 'provisioner',
         identifier: 'provisioner-token-id',
       });
       vi.doMock('#config.js', () => ({
         config: {
-          RATE_LIMIT_IDENTIFIER_SECRET: undefined,
+          RATE_LIMIT_IDENTIFIER_SECRET: 'a-different-configured-secret',
           RUNNERS_RATE_LIMIT_TIMEOUT_MS: 250,
         },
       }));
       vi.resetModules();
-      const derivedSecretModule = await import('./rate-limit.js');
-      const derivedSecretHash = derivedSecretModule.hashRunnersRateLimitIdentifier({
+      const secondModule = await import('./rate-limit.js');
+      const secondHash = secondModule.hashRunnersRateLimitIdentifier({
         action: 'provisioner-mint',
         scope: 'provisioner',
         identifier: 'provisioner-token-id',
       });
 
-      expect(configuredSecretHash).toMatch(HMAC_HEX_PATTERN);
-      expect(derivedSecretHash).toMatch(HMAC_HEX_PATTERN);
-      expect(configuredSecretHash).not.toBe(derivedSecretHash);
+      expect(firstHash).toMatch(HMAC_HEX_PATTERN);
+      expect(secondHash).toMatch(HMAC_HEX_PATTERN);
+      expect(firstHash).not.toBe(secondHash);
     } finally {
       vi.doUnmock('#config.js');
-      vi.doUnmock('@shipfox/api-auth/config');
       vi.resetModules();
     }
   });

--- a/libs/api/runners/src/core/rate-limit.ts
+++ b/libs/api/runners/src/core/rate-limit.ts
@@ -1,5 +1,3 @@
-import {createHmac} from 'node:crypto';
-import {config as authConfig} from '@shipfox/api-auth/config';
 import {
   checkRateLimit,
   hashRateLimitIdentifier,
@@ -56,7 +54,6 @@ export class RunnersRateLimitUnavailableError extends RateLimitUnavailableError<
 }
 
 const IDENTIFIER_HASH_DOMAIN = 'shipfox.runners.rate-limit.identifier.v1';
-const IDENTIFIER_SECRET_DERIVATION_DOMAIN = 'shipfox.runners.rate-limit.identifier-secret.v1';
 
 export function hashRunnersRateLimitIdentifier(params: {
   action: RunnersRateLimitAction;
@@ -111,11 +108,5 @@ export async function checkRunnersRateLimit(params: CheckRunnersRateLimitParams)
 }
 
 function effectiveIdentifierSecret(): Buffer | string {
-  if (config.RATE_LIMIT_IDENTIFIER_SECRET) {
-    return config.RATE_LIMIT_IDENTIFIER_SECRET;
-  }
-
-  return createHmac('sha256', authConfig.AUTH_JWT_SECRET)
-    .update(IDENTIFIER_SECRET_DERIVATION_DOMAIN)
-    .digest();
+  return config.RATE_LIMIT_IDENTIFIER_SECRET;
 }

--- a/libs/api/runners/src/core/runner-sessions.test.ts
+++ b/libs/api/runners/src/core/runner-sessions.test.ts
@@ -8,6 +8,7 @@ import {
   ephemeralRegistrationTokenFactory,
   manualRegistrationTokenFactory,
   providerRunnerFactory,
+  runnersTestAuthClient,
 } from '#test/index.js';
 import {
   EmptyRunnerLabelsError,
@@ -28,6 +29,7 @@ describe('registerRunnerSession', () => {
 
   it('canonicalizes labels, stores them, and embeds them in the session token', async () => {
     const result = await registerRunnerSession({
+      auth: runnersTestAuthClient,
       credential: {kind: 'manual', registrationTokenId, workspaceId},
       labels: [' Linux ', 'x64', 'linux'],
     });
@@ -55,6 +57,7 @@ describe('registerRunnerSession', () => {
   it('throws EmptyRunnerLabelsError when labels canonicalize to empty', async () => {
     await expect(
       registerRunnerSession({
+        auth: runnersTestAuthClient,
         credential: {kind: 'manual', registrationTokenId, workspaceId},
         labels: [' ', '\t'],
       }),
@@ -65,6 +68,7 @@ describe('registerRunnerSession', () => {
     const token = await ephemeralRegistrationTokenFactory.create({workspaceId});
 
     const result = await registerRunnerSession({
+      auth: runnersTestAuthClient,
       credential: {
         kind: 'ephemeral',
         ephemeralTokenId: token.id,
@@ -113,6 +117,7 @@ describe('registerRunnerSession', () => {
     });
 
     const result = await registerRunnerSession({
+      auth: runnersTestAuthClient,
       credential: {
         kind: 'ephemeral',
         ephemeralTokenId: token.id,
@@ -148,11 +153,11 @@ describe('registerRunnerSession', () => {
       providerRunnerId: token.providerRunnerId,
     };
 
-    await registerRunnerSession({credential, labels: ['linux']});
+    await registerRunnerSession({auth: runnersTestAuthClient, credential, labels: ['linux']});
 
-    await expect(registerRunnerSession({credential, labels: ['linux']})).rejects.toBeInstanceOf(
-      RegistrationTokenConsumedError,
-    );
+    await expect(
+      registerRunnerSession({auth: runnersTestAuthClient, credential, labels: ['linux']}),
+    ).rejects.toBeInstanceOf(RegistrationTokenConsumedError);
   });
 
   it('rejects consuming an ephemeral token for a different workspace', async () => {
@@ -160,6 +165,7 @@ describe('registerRunnerSession', () => {
 
     await expect(
       registerRunnerSession({
+        auth: runnersTestAuthClient,
         credential: {
           kind: 'ephemeral',
           ephemeralTokenId: token.id,

--- a/libs/api/runners/src/core/runner-sessions.ts
+++ b/libs/api/runners/src/core/runner-sessions.ts
@@ -1,4 +1,4 @@
-import {issueRunnerSessionToken} from '@shipfox/api-auth';
+import type {AuthInterModuleClient} from '@shipfox/api-auth-dto/inter-module';
 import type {RunnerToolCapabilitiesDto} from '@shipfox/api-runners-dto';
 import {canonicalizeLabels} from '@shipfox/runner-labels';
 import {createRunnerSessionConsumingEphemeralToken} from '#db/ephemeral-registration-tokens.js';
@@ -29,6 +29,7 @@ export type RunnerRegistrationCredential =
     };
 
 export async function registerRunnerSession(params: {
+  auth: AuthInterModuleClient;
   credential: RunnerRegistrationCredential;
   labels: string[];
   toolCapabilities?: RunnerToolCapabilitiesDto | null;
@@ -54,7 +55,7 @@ export async function registerRunnerSession(params: {
           toolCapabilities: params.toolCapabilities ?? null,
           maxClaims: 1,
         });
-  const sessionToken = await issueRunnerSessionToken({
+  const {token: sessionToken} = await params.auth.mintRunnerSessionToken({
     runnerSessionId: session.id,
     workspaceId: session.workspaceId,
     scope: session.scope,

--- a/libs/api/runners/src/db/job-executions.test.ts
+++ b/libs/api/runners/src/db/job-executions.test.ts
@@ -8,7 +8,7 @@ import {eq, sql} from 'drizzle-orm';
 import {EmptyRequiredLabelsError, RunnerSessionExhaustedError} from '#core/errors.js';
 import {claimJobExecution} from '#core/job-executions.js';
 import {detectAndExpireStuckJobs} from '#core/maintenance.js';
-import {pendingJobFactory, runnerSessionFactory} from '#test/index.js';
+import {pendingJobFactory, runnerSessionFactory, runnersTestAuthClient} from '#test/index.js';
 import {db} from './db.js';
 import {
   cancelRunnerJobs,
@@ -758,6 +758,7 @@ describe('claimJobExecution', () => {
     const created = await pendingJobFactory.create({workspaceId});
 
     const claimed = await claimJobExecution({
+      auth: runnersTestAuthClient,
       workspaceId,
       runnerSessionId,
       sessionLabels,
@@ -781,6 +782,7 @@ describe('claimJobExecution', () => {
 
   it('returns null and mints no token when the queue is empty', async () => {
     const claimed = await claimJobExecution({
+      auth: runnersTestAuthClient,
       workspaceId,
       runnerSessionId,
       sessionLabels,

--- a/libs/api/runners/src/index.test.ts
+++ b/libs/api/runners/src/index.test.ts
@@ -1,13 +1,16 @@
-import {createRunnersModule, runnersModule} from './index.js';
+import type {AuthInterModuleClient} from '@shipfox/api-auth-dto/inter-module';
+import {createRunnersModule} from './index.js';
+
+const auth = {} as AuthInterModuleClient;
 
 describe('createRunnersModule', () => {
   it('preserves the default module composition when options are absent', () => {
-    const module = createRunnersModule();
+    const module = createRunnersModule({auth});
 
-    expect(module.name).toBe(runnersModule.name);
-    expect(module.auth).toHaveLength(runnersModule.auth?.length ?? 0);
-    expect(module.routes).toHaveLength(runnersModule.routes?.length ?? 0);
-    expect(module.workers).toHaveLength(runnersModule.workers?.length ?? 0);
+    expect(module.name).toBe('runners');
+    expect(module.auth).toHaveLength(2);
+    expect(module.routes).toHaveLength(9);
+    expect(module.workers).toHaveLength(1);
   });
 
   it('accepts an instance-local installation provisioning policy', () => {
@@ -15,10 +18,9 @@ describe('createRunnersModule', () => {
       filterEligibleWorkspaceIds: vi.fn().mockResolvedValue(new Set<string>()),
     };
 
-    const module = createRunnersModule({installationProvisioning: {policy}});
+    const module = createRunnersModule({auth, installationProvisioning: {policy}});
 
     expect(module.name).toBe('runners');
-    expect(module.routes).not.toBe(runnersModule.routes);
     expect(policy.filterEligibleWorkspaceIds).not.toHaveBeenCalled();
   });
 });

--- a/libs/api/runners/src/index.ts
+++ b/libs/api/runners/src/index.ts
@@ -1,5 +1,6 @@
 import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
+import type {AuthInterModuleClient} from '@shipfox/api-auth-dto/inter-module';
 import {runnersEventSchemas} from '@shipfox/api-runners-dto';
 import {
   WORKFLOWS_JOB_EXECUTION_TIMED_OUT,
@@ -50,12 +51,15 @@ const workflowsPath = resolve(packageRoot, 'dist/temporal/workflows/index.js');
 
 const subscriber = subscriberFactory<WorkflowsEventMapDto>();
 
-export function createRunnersModule(options: CreateRunnersModuleOptions = {}): ShipfoxModule {
+export function createRunnersModule({
+  auth,
+  ...options
+}: CreateRunnersModuleOptions & {auth: AuthInterModuleClient}): ShipfoxModule {
   return {
     name: 'runners',
     database: {db, migrationsPath},
     auth: [createRunnerRegistrationTokenAuthMethod(), createProvisionerTokenAuthMethod()],
-    routes: createRunnerRoutes(options),
+    routes: createRunnerRoutes(auth, options),
     metrics: registerRunnersServiceMetrics,
     publishers: [{name: 'runners', table: runnersOutbox, db, eventSchemas: runnersEventSchemas}],
     subscribers: [subscriber(WORKFLOWS_JOB_EXECUTION_TIMED_OUT, onWorkflowsJobExecutionTimedOut)],
@@ -72,5 +76,3 @@ export function createRunnersModule(options: CreateRunnersModuleOptions = {}): S
     interModulePresentations: [createRunnersInterModulePresentation()],
   };
 }
-
-export const runnersModule = createRunnersModule();

--- a/libs/api/runners/src/presentation/index.ts
+++ b/libs/api/runners/src/presentation/index.ts
@@ -2,5 +2,5 @@ export {
   createProvisionerTokenAuthMethod,
   createRunnerRegistrationTokenAuthMethod,
 } from './auth/index.js';
-export {createRunnerRoutes, runnerRoutes as routes} from './routes/index.js';
+export {createRunnerRoutes, createRunnerRoutes as routes} from './routes/index.js';
 export {onWorkflowsJobExecutionTimedOut} from './subscribers/on-workflows-job-execution-timed-out.js';

--- a/libs/api/runners/src/presentation/routes/heartbeat.test.ts
+++ b/libs/api/runners/src/presentation/routes/heartbeat.test.ts
@@ -17,8 +17,8 @@ import {requestJobExecutionCancellation} from '#db/job-executions.js';
 import {runnerSessions} from '#db/schema/runner-sessions.js';
 import {runningJobExecutions} from '#db/schema/running-job-executions.js';
 import {createRunnerRegistrationTokenAuthMethod} from '#presentation/auth/index.js';
-import {pendingJobFactory, runnerSessionFactory} from '#test/index.js';
-import {runnerRoutes} from './index.js';
+import {pendingJobFactory, runnerSessionFactory, runnersTestAuthClient} from '#test/index.js';
+import {createRunnerRoutes} from './index.js';
 
 const fakeUserAuth: AuthMethod = {
   name: AUTH_USER,
@@ -57,7 +57,7 @@ describe('POST /runners/jobs/:jobId/heartbeat', () => {
         createLeaseTokenAuthMethod(),
         fakeProvisionerAuth,
       ],
-      routes: runnerRoutes,
+      routes: createRunnerRoutes(runnersTestAuthClient),
       swagger: false,
     });
     await app.ready();
@@ -82,6 +82,7 @@ describe('POST /runners/jobs/:jobId/heartbeat', () => {
   }> {
     const pending = await pendingJobFactory.create({workspaceId});
     const claimed = await claimJobExecution({
+      auth: runnersTestAuthClient,
       workspaceId,
       runnerSessionId,
       sessionLabels: ['linux', 'x64'],

--- a/libs/api/runners/src/presentation/routes/heartbeat.ts
+++ b/libs/api/runners/src/presentation/routes/heartbeat.ts
@@ -1,79 +1,82 @@
-import {issueJobLeaseToken, jobLeaseParamsFrom} from '@shipfox/api-auth';
 import {requireLeasedJobContext} from '@shipfox/api-auth-context';
+import type {AuthInterModuleClient} from '@shipfox/api-auth-dto/inter-module';
 import {heartbeatBodySchema, heartbeatResponseSchema} from '@shipfox/api-runners-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
 import {RunningJobExecutionNotFoundError} from '#core/errors.js';
 import {recordHeartbeat} from '#db/job-executions.js';
 
-export const heartbeatRoute = defineRoute({
-  method: 'POST',
-  path: '/:jobId/heartbeat',
-  description:
-    'Keeps a running job execution alive while the runner is still working on it. Returns whether the server has asked the runner to cancel.',
-  schema: {
-    params: z.object({jobId: z.string().uuid()}),
-    body: heartbeatBodySchema.nullish(),
-    response: {
-      200: heartbeatResponseSchema,
+export function createHeartbeatRoute(auth: AuthInterModuleClient) {
+  return defineRoute({
+    method: 'POST',
+    path: '/:jobId/heartbeat',
+    description:
+      'Keeps a running job execution alive while the runner is still working on it. Returns whether the server has asked the runner to cancel.',
+    schema: {
+      params: z.object({jobId: z.string().uuid()}),
+      body: heartbeatBodySchema.nullish(),
+      response: {
+        200: heartbeatResponseSchema,
+      },
     },
-  },
-  errorHandler: (error) => {
-    if (error instanceof RunningJobExecutionNotFoundError) {
-      throw new ClientError(error.message, 'running-job-execution-not-found', {status: 404});
-    }
-    throw error;
-  },
-  handler: async (request) => {
-    const {jobId} = request.params;
-    const lease = requireLeasedJobContext(request);
-    if (lease.jobId !== jobId) {
-      throw new ClientError('Lease token does not match job', 'lease-job-mismatch', {
-        status: 404,
+    errorHandler: (error) => {
+      if (error instanceof RunningJobExecutionNotFoundError) {
+        throw new ClientError(error.message, 'running-job-execution-not-found', {status: 404});
+      }
+      throw error;
+    },
+    handler: async (request) => {
+      const {jobId} = request.params;
+      const lease = requireLeasedJobContext(request);
+      if (lease.jobId !== jobId) {
+        throw new ClientError('Lease token does not match job', 'lease-job-mismatch', {
+          status: 404,
+        });
+      }
+
+      const heartbeatResult = await recordHeartbeat({
+        jobExecutionId: lease.jobExecutionId,
+        runnerSessionId: lease.runnerSessionId,
+        toolCapabilities: request.body?.capabilities ?? null,
       });
-    }
 
-    const heartbeatResult = await recordHeartbeat({
-      jobExecutionId: lease.jobExecutionId,
-      runnerSessionId: lease.runnerSessionId,
-      toolCapabilities: request.body?.capabilities ?? null,
-    });
+      if (
+        heartbeatResult.previousToolCapabilities &&
+        !sameToolCapabilities(
+          heartbeatResult.previousToolCapabilities,
+          heartbeatResult.currentToolCapabilities,
+        )
+      ) {
+        request.log.info(
+          {
+            runnerSessionId: lease.runnerSessionId,
+            jobExecutionId: lease.jobExecutionId,
+            previousHarnesses: Object.keys(heartbeatResult.previousToolCapabilities.harnesses),
+            currentHarnesses: heartbeatResult.currentToolCapabilities
+              ? Object.keys(heartbeatResult.currentToolCapabilities.harnesses)
+              : [],
+          },
+          'Runner heartbeat changed advertised tool capabilities',
+        );
+      }
 
-    if (
-      heartbeatResult.previousToolCapabilities &&
-      !sameToolCapabilities(
-        heartbeatResult.previousToolCapabilities,
-        heartbeatResult.currentToolCapabilities,
-      )
-    ) {
-      request.log.info(
-        {
-          runnerSessionId: lease.runnerSessionId,
-          jobExecutionId: lease.jobExecutionId,
-          previousHarnesses: Object.keys(heartbeatResult.previousToolCapabilities.harnesses),
-          currentHarnesses: heartbeatResult.currentToolCapabilities
-            ? Object.keys(heartbeatResult.currentToolCapabilities.harnesses)
-            : [],
-        },
-        'Runner heartbeat changed advertised tool capabilities',
-      );
-    }
+      const {token: leaseToken} = await auth.mintJobLeaseToken({
+        workflowRunId: heartbeatResult.runningJobExecution.workflowRunId,
+        workflowRunAttemptId: heartbeatResult.runningJobExecution.workflowRunAttemptId,
+        jobId: heartbeatResult.runningJobExecution.jobId,
+        jobExecutionId: heartbeatResult.runningJobExecution.jobExecutionId,
+        projectId: heartbeatResult.runningJobExecution.projectId,
+        workspaceId: heartbeatResult.runningJobExecution.workspaceId,
+        runnerSessionId: heartbeatResult.runningJobExecution.runnerSessionId,
+        ...(lease.currentStepId && lease.currentStepAttempt !== undefined
+          ? {currentStepId: lease.currentStepId, currentStepAttempt: lease.currentStepAttempt}
+          : {}),
+      });
 
-    const leaseToken = await issueJobLeaseToken(
-      jobLeaseParamsFrom(
-        heartbeatResult.runningJobExecution,
-        lease.currentStepId && lease.currentStepAttempt !== undefined
-          ? {
-              currentStepId: lease.currentStepId,
-              currentStepAttempt: lease.currentStepAttempt,
-            }
-          : undefined,
-      ),
-    );
-
-    return {cancel: heartbeatResult.cancellationRequested, lease_token: leaseToken};
-  },
-});
+      return {cancel: heartbeatResult.cancellationRequested, lease_token: leaseToken};
+    },
+  });
+}
 
 function sameToolCapabilities(left: unknown, right: unknown): boolean {
   return JSON.stringify(left) === JSON.stringify(right);

--- a/libs/api/runners/src/presentation/routes/index.ts
+++ b/libs/api/runners/src/presentation/routes/index.ts
@@ -5,13 +5,14 @@ import {
   AUTH_RUNNER_SESSION,
   AUTH_USER,
 } from '@shipfox/api-auth-context';
+import type {AuthInterModuleClient} from '@shipfox/api-auth-dto/inter-module';
 import type {RouteGroup} from '@shipfox/node-fastify';
 import type {CreateRunnersModuleOptions} from '#installation-provisioning.js';
 import {assignCapacityRoute} from './assign-capacity.js';
 import {createManualRegistrationTokenRoute} from './create-manual-registration-token.js';
 import {createProvisionerTokenRoute} from './create-provisioner-token.js';
 import {getProvisionerMeRoute} from './get-provisioner-me.js';
-import {heartbeatRoute} from './heartbeat.js';
+import {createHeartbeatRoute} from './heartbeat.js';
 import {listActiveProvisionersRoute} from './list-active-provisioners.js';
 import {listActiveRunnersRoute} from './list-active-runners.js';
 import {listManualRegistrationTokensRoute} from './list-manual-registration-tokens.js';
@@ -20,56 +21,58 @@ import {mintRegistrationTokensRoute} from './mint-registration-tokens.js';
 import {attachProviderRunnerRoute, createPlannedCapacityRoute} from './planned-capacity.js';
 import {createPollDemandRoute, pollDemandRoute} from './poll-demand.js';
 import {reconcileRunnerInstancesRoute} from './reconcile-runner-instances.js';
-import {registerRoute} from './register.js';
+import {createRegisterRoute} from './register.js';
 import {reportRunnerInstancesRoute} from './report-runner-instances.js';
-import {requestJobRoute} from './request-job.js';
+import {createRequestJobRoute} from './request-job.js';
 import {revokeManualRegistrationTokenRoute} from './revoke-manual-registration-token.js';
 import {revokeProvisionerTokenRoute} from './revoke-provisioner-token.js';
 
-const runnerOnlyRoutes: RouteGroup[] = [
-  {
-    prefix: '/workspaces/:workspaceId/runners/manual-registration-tokens',
-    auth: AUTH_USER,
-    routes: [
-      listManualRegistrationTokensRoute,
-      createManualRegistrationTokenRoute,
-      revokeManualRegistrationTokenRoute,
-    ],
-  },
-  {
-    prefix: '/workspaces/:workspaceId/runners/active',
-    auth: AUTH_USER,
-    routes: [listActiveRunnersRoute],
-  },
-  {
-    prefix: '/runners',
-    auth: AUTH_RUNNER_REGISTRATION_TOKEN,
-    routes: [registerRoute],
-  },
-  {
-    prefix: '/runners/jobs',
-    auth: AUTH_RUNNER_SESSION,
-    routes: [requestJobRoute],
-  },
-  {
-    prefix: '/runners/jobs',
-    auth: AUTH_LEASED_JOB,
-    routes: [heartbeatRoute],
-  },
-  {
-    prefix: '/provisioners',
-    auth: AUTH_PROVISIONER_TOKEN,
-    routes: [
-      pollDemandRoute,
-      createPlannedCapacityRoute,
-      attachProviderRunnerRoute,
-      assignCapacityRoute,
-      mintRegistrationTokensRoute,
-      reportRunnerInstancesRoute,
-      reconcileRunnerInstancesRoute,
-    ],
-  },
-];
+function createRunnerOnlyRoutes(auth: AuthInterModuleClient): RouteGroup[] {
+  return [
+    {
+      prefix: '/workspaces/:workspaceId/runners/manual-registration-tokens',
+      auth: AUTH_USER,
+      routes: [
+        listManualRegistrationTokensRoute,
+        createManualRegistrationTokenRoute,
+        revokeManualRegistrationTokenRoute,
+      ],
+    },
+    {
+      prefix: '/workspaces/:workspaceId/runners/active',
+      auth: AUTH_USER,
+      routes: [listActiveRunnersRoute],
+    },
+    {
+      prefix: '/runners',
+      auth: AUTH_RUNNER_REGISTRATION_TOKEN,
+      routes: [createRegisterRoute(auth)],
+    },
+    {
+      prefix: '/runners/jobs',
+      auth: AUTH_RUNNER_SESSION,
+      routes: [createRequestJobRoute(auth)],
+    },
+    {
+      prefix: '/runners/jobs',
+      auth: AUTH_LEASED_JOB,
+      routes: [createHeartbeatRoute(auth)],
+    },
+    {
+      prefix: '/provisioners',
+      auth: AUTH_PROVISIONER_TOKEN,
+      routes: [
+        pollDemandRoute,
+        createPlannedCapacityRoute,
+        attachProviderRunnerRoute,
+        assignCapacityRoute,
+        mintRegistrationTokensRoute,
+        reportRunnerInstancesRoute,
+        reconcileRunnerInstancesRoute,
+      ],
+    },
+  ];
+}
 
 export const provisionerRoutes: RouteGroup[] = [
   {
@@ -89,7 +92,11 @@ export const provisionerRoutes: RouteGroup[] = [
   },
 ];
 
-export function createRunnerRoutes(options: CreateRunnersModuleOptions = {}): RouteGroup[] {
+export function createRunnerRoutes(
+  auth: AuthInterModuleClient,
+  options: CreateRunnersModuleOptions = {},
+): RouteGroup[] {
+  const runnerOnlyRoutes = createRunnerOnlyRoutes(auth);
   return [
     ...runnerOnlyRoutes.map((route) =>
       route.routes.includes(pollDemandRoute)
@@ -104,5 +111,3 @@ export function createRunnerRoutes(options: CreateRunnersModuleOptions = {}): Ro
     ...provisionerRoutes,
   ];
 }
-
-export const runnerRoutes: RouteGroup[] = [...runnerOnlyRoutes, ...provisionerRoutes];

--- a/libs/api/runners/src/presentation/routes/list-active-runners.test.ts
+++ b/libs/api/runners/src/presentation/routes/list-active-runners.test.ts
@@ -14,8 +14,8 @@ import type {FastifyInstance, FastifyRequest} from 'fastify';
 import {db} from '#db/db.js';
 import {providerRunners} from '#db/schema/runner-instances.js';
 import {runningJobExecutions} from '#db/schema/running-job-executions.js';
-import {runnerSessionFactory} from '#test/index.js';
-import {runnerRoutes} from './index.js';
+import {runnerSessionFactory, runnersTestAuthClient} from '#test/index.js';
+import {createRunnerRoutes} from './index.js';
 
 let authenticatedMemberships: ReadonlyArray<UserContextMembership> = [];
 
@@ -59,7 +59,7 @@ describe('GET /workspaces/:workspaceId/runners/active', () => {
         passthroughAuth(AUTH_LEASED_JOB),
         passthroughAuth(AUTH_PROVISIONER_TOKEN),
       ],
-      routes: runnerRoutes,
+      routes: createRunnerRoutes(runnersTestAuthClient),
       swagger: false,
     });
     await app.ready();

--- a/libs/api/runners/src/presentation/routes/manual-registration-tokens.test.ts
+++ b/libs/api/runners/src/presentation/routes/manual-registration-tokens.test.ts
@@ -18,8 +18,8 @@ import {db} from '#db/db.js';
 import {revokeManualRegistrationToken} from '#db/manual-registration-tokens.js';
 import {manualRegistrationTokens} from '#db/schema/manual-registration-tokens.js';
 import {createRunnerRegistrationTokenAuthMethod} from '#presentation/auth/index.js';
-import {manualRegistrationTokenFactory} from '#test/index.js';
-import {runnerRoutes} from './index.js';
+import {manualRegistrationTokenFactory, runnersTestAuthClient} from '#test/index.js';
+import {createRunnerRoutes} from './index.js';
 
 let authenticatedMemberships: ReadonlyArray<UserContextMembership> = [];
 
@@ -63,7 +63,7 @@ describe('manual registration token routes', () => {
         createLeaseTokenAuthMethod(),
         fakeProvisionerAuth,
       ],
-      routes: runnerRoutes,
+      routes: createRunnerRoutes(runnersTestAuthClient),
       swagger: false,
     });
     await app.ready();
@@ -74,6 +74,7 @@ describe('manual registration token routes', () => {
   });
 
   test('uses the expected auth method for each runner route group', () => {
+    const runnerRoutes = createRunnerRoutes(runnersTestAuthClient);
     expect(runnerRoutes[0]?.auth).toBe(AUTH_USER);
     expect(runnerRoutes[1]?.auth).toBe(AUTH_USER);
     expect(runnerRoutes[2]?.auth).toBe(AUTH_RUNNER_REGISTRATION_TOKEN);

--- a/libs/api/runners/src/presentation/routes/mint-registration-tokens.test.ts
+++ b/libs/api/runners/src/presentation/routes/mint-registration-tokens.test.ts
@@ -24,8 +24,8 @@ import {ephemeralRegistrationTokens} from '#db/schema/ephemeral-registration-tok
 import {runnersRateLimits} from '#db/schema/rate-limits.js';
 import {reservations} from '#db/schema/reservations.js';
 import {createRunnerRegistrationTokenAuthMethod} from '#presentation/auth/index.js';
-import {ephemeralRegistrationTokenFactory} from '#test/index.js';
-import {runnerRoutes} from './index.js';
+import {ephemeralRegistrationTokenFactory, runnersTestAuthClient} from '#test/index.js';
+import {createRunnerRoutes} from './index.js';
 
 const VALID_PROVISIONER_TOKEN = 'valid-provisioner-token';
 
@@ -67,7 +67,7 @@ describe('POST /provisioners/runner-registration-tokens/batch', () => {
         passthroughAuth(AUTH_LEASED_JOB),
         fakeProvisionerAuth,
       ],
-      routes: runnerRoutes,
+      routes: createRunnerRoutes(runnersTestAuthClient),
       swagger: false,
     });
     await app.ready();

--- a/libs/api/runners/src/presentation/routes/poll-demand.test.ts
+++ b/libs/api/runners/src/presentation/routes/poll-demand.test.ts
@@ -23,8 +23,13 @@ import {
   providerRunnerCountDivergenceCount,
   providerRunnerTerminateIntentIssuedCount,
 } from '#metrics/instance.js';
-import {pendingJobFactory, providerRunnerFactory, runnerSessionFactory} from '#test/index.js';
-import {createRunnerRoutes, runnerRoutes} from './index.js';
+import {
+  pendingJobFactory,
+  providerRunnerFactory,
+  runnerSessionFactory,
+  runnersTestAuthClient,
+} from '#test/index.js';
+import {createRunnerRoutes} from './index.js';
 
 const VALID_PROVISIONER_TOKEN = 'valid-provisioner-token';
 const INSTALLATION_PROVISIONER_TOKEN = 'installation-provisioner-token';
@@ -64,7 +69,7 @@ describe('POST /provisioners/demand/poll', () => {
         passthroughAuth(AUTH_LEASED_JOB),
         fakeProvisionerAuth,
       ],
-      routes: runnerRoutes,
+      routes: createRunnerRoutes(runnersTestAuthClient),
       swagger: false,
     });
     await app.ready();
@@ -395,7 +400,7 @@ describe('POST /provisioners/demand/poll with installation provisioning configur
         passthroughAuth(AUTH_LEASED_JOB),
         fakeProvisionerAuth,
       ],
-      routes: createRunnerRoutes({
+      routes: createRunnerRoutes(runnersTestAuthClient, {
         installationProvisioning: {policy: {filterEligibleWorkspaceIds: vi.fn()}},
       }),
       swagger: false,

--- a/libs/api/runners/src/presentation/routes/reconcile-runner-instances.test.ts
+++ b/libs/api/runners/src/presentation/routes/reconcile-runner-instances.test.ts
@@ -26,8 +26,13 @@ import {
   providerRunnerTerminateIntentIssuedCount,
   reservationReleasedCount,
 } from '#metrics/instance.js';
-import {providerRunnerFactory, reservationFactory, runnerSessionFactory} from '#test/index.js';
-import {runnerRoutes} from './index.js';
+import {
+  providerRunnerFactory,
+  reservationFactory,
+  runnerSessionFactory,
+  runnersTestAuthClient,
+} from '#test/index.js';
+import {createRunnerRoutes} from './index.js';
 
 const VALID_PROVISIONER_TOKEN = 'valid-provisioner-token';
 
@@ -62,7 +67,7 @@ describe('POST /provisioners/runner-instances/reconcile', () => {
         passthroughAuth(AUTH_LEASED_JOB),
         fakeProvisionerAuth,
       ],
-      routes: runnerRoutes,
+      routes: createRunnerRoutes(runnersTestAuthClient),
       swagger: false,
     });
     await app.ready();

--- a/libs/api/runners/src/presentation/routes/register.test.ts
+++ b/libs/api/runners/src/presentation/routes/register.test.ts
@@ -18,8 +18,12 @@ import {ephemeralRegistrationTokens} from '#db/schema/ephemeral-registration-tok
 import {runnersRateLimits} from '#db/schema/rate-limits.js';
 import {runnerSessions} from '#db/schema/runner-sessions.js';
 import {createRunnerRegistrationTokenAuthMethod} from '#presentation/auth/index.js';
-import {ephemeralRegistrationTokenFactory, manualRegistrationTokenFactory} from '#test/index.js';
-import {runnerRoutes} from './index.js';
+import {
+  ephemeralRegistrationTokenFactory,
+  manualRegistrationTokenFactory,
+  runnersTestAuthClient,
+} from '#test/index.js';
+import {createRunnerRoutes} from './index.js';
 
 const fakeUserAuth: AuthMethod = {
   name: AUTH_USER,
@@ -52,7 +56,7 @@ describe('POST /runners/register', () => {
         createLeaseTokenAuthMethod(),
         fakeProvisionerAuth,
       ],
-      routes: runnerRoutes,
+      routes: createRunnerRoutes(runnersTestAuthClient),
       swagger: false,
     });
     await app.ready();

--- a/libs/api/runners/src/presentation/routes/register.ts
+++ b/libs/api/runners/src/presentation/routes/register.ts
@@ -1,3 +1,4 @@
+import type {AuthInterModuleClient} from '@shipfox/api-auth-dto/inter-module';
 import {registerRunnerBodySchema, registerRunnerResponseSchema} from '@shipfox/api-runners-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {
@@ -9,67 +10,70 @@ import {registerRunnerSession} from '#core/runner-sessions.js';
 import {getRunnerContext} from '#presentation/auth/index.js';
 import {createEphemeralRegisterRateLimitPreHandler} from './rate-limit.js';
 
-export const registerRoute = defineRoute({
-  method: 'POST',
-  path: '/register',
-  description: 'Exchange a runner registration token for a runner session token',
-  schema: {
-    body: registerRunnerBodySchema,
-    response: {
-      200: registerRunnerResponseSchema,
+export function createRegisterRoute(auth: AuthInterModuleClient) {
+  return defineRoute({
+    method: 'POST',
+    path: '/register',
+    description: 'Exchange a runner registration token for a runner session token',
+    schema: {
+      body: registerRunnerBodySchema,
+      response: {
+        200: registerRunnerResponseSchema,
+      },
     },
-  },
-  preHandler: createEphemeralRegisterRateLimitPreHandler(),
-  errorHandler: (error, request) => {
-    if (error instanceof EmptyRunnerLabelsError) {
-      throw new ClientError(error.message, 'empty-runner-labels', {status: 400});
-    }
-    if (error instanceof RegistrationTokenConsumedError) {
-      const runner = getRunnerContext(request);
-      if (runner.kind === 'ephemeral') {
-        request.log.warn(
+    preHandler: createEphemeralRegisterRateLimitPreHandler(),
+    errorHandler: (error, request) => {
+      if (error instanceof EmptyRunnerLabelsError) {
+        throw new ClientError(error.message, 'empty-runner-labels', {status: 400});
+      }
+      if (error instanceof RegistrationTokenConsumedError) {
+        const runner = getRunnerContext(request);
+        if (runner.kind === 'ephemeral') {
+          request.log.warn(
+            {
+              ephemeralTokenId: error.ephemeralTokenId,
+              provisionerId: runner.provisionerId,
+            },
+            'Ephemeral registration token reuse rejected',
+          );
+        }
+        throw new ClientError(
+          'Registration token has already been consumed',
+          'registration-token-consumed',
           {
-            ephemeralTokenId: error.ephemeralTokenId,
-            provisionerId: runner.provisionerId,
+            status: 409,
           },
-          'Ephemeral registration token reuse rejected',
         );
       }
-      throw new ClientError(
-        'Registration token has already been consumed',
-        'registration-token-consumed',
-        {
-          status: 409,
-        },
-      );
-    }
-    if (error instanceof RegistrationTokenExpiredError) {
-      throw new ClientError('Registration token has expired', 'registration-token-expired', {
-        status: 401,
+      if (error instanceof RegistrationTokenExpiredError) {
+        throw new ClientError('Registration token has expired', 'registration-token-expired', {
+          status: 401,
+        });
+      }
+      throw error;
+    },
+    handler: async (request) => {
+      const runner = getRunnerContext(request);
+      const result = await registerRunnerSession({
+        auth,
+        credential:
+          runner.kind === 'manual'
+            ? {
+                kind: 'manual',
+                registrationTokenId: runner.registrationTokenId,
+                workspaceId: runner.workspaceId,
+              }
+            : runner,
+        labels: request.body.labels,
+        toolCapabilities: request.body.capabilities ?? null,
       });
-    }
-    throw error;
-  },
-  handler: async (request) => {
-    const runner = getRunnerContext(request);
-    const result = await registerRunnerSession({
-      credential:
-        runner.kind === 'manual'
-          ? {
-              kind: 'manual',
-              registrationTokenId: runner.registrationTokenId,
-              workspaceId: runner.workspaceId,
-            }
-          : runner,
-      labels: request.body.labels,
-      toolCapabilities: request.body.capabilities ?? null,
-    });
 
-    return {
-      session_token: result.sessionToken,
-      session_id: result.session.id,
-      mode: result.mode,
-      max_claims: result.maxClaims,
-    };
-  },
-});
+      return {
+        session_token: result.sessionToken,
+        session_id: result.session.id,
+        mode: result.mode,
+        max_claims: result.maxClaims,
+      };
+    },
+  });
+}

--- a/libs/api/runners/src/presentation/routes/report-runner-instances.test.ts
+++ b/libs/api/runners/src/presentation/routes/report-runner-instances.test.ts
@@ -20,8 +20,8 @@ import {db} from '#db/db.js';
 import {providerRunners} from '#db/schema/runner-instances.js';
 import {runningJobExecutions} from '#db/schema/running-job-executions.js';
 import {providerRunnerTerminateIntentHonoredCount} from '#metrics/instance.js';
-import {providerRunnerFactory, runnerSessionFactory} from '#test/index.js';
-import {runnerRoutes} from './index.js';
+import {providerRunnerFactory, runnerSessionFactory, runnersTestAuthClient} from '#test/index.js';
+import {createRunnerRoutes} from './index.js';
 
 const VALID_PROVISIONER_TOKEN = 'valid-provisioner-token';
 
@@ -56,7 +56,7 @@ describe('POST /provisioners/runner-instances/report', () => {
         passthroughAuth(AUTH_LEASED_JOB),
         fakeProvisionerAuth,
       ],
-      routes: runnerRoutes,
+      routes: createRunnerRoutes(runnersTestAuthClient),
       swagger: false,
     });
     await app.ready();

--- a/libs/api/runners/src/presentation/routes/request-job.test.ts
+++ b/libs/api/runners/src/presentation/routes/request-job.test.ts
@@ -15,8 +15,9 @@ import {
   ephemeralRegistrationTokenFactory,
   manualRegistrationTokenFactory,
   pendingJobFactory,
+  runnersTestAuthClient,
 } from '#test/index.js';
-import {runnerRoutes} from './index.js';
+import {createRunnerRoutes} from './index.js';
 
 const fakeUserAuth: AuthMethod = {
   name: AUTH_USER,
@@ -44,7 +45,7 @@ describe('POST /runners/jobs/request', () => {
         createLeaseTokenAuthMethod(),
         fakeProvisionerAuth,
       ],
-      routes: runnerRoutes,
+      routes: createRunnerRoutes(runnersTestAuthClient),
       swagger: false,
     });
     await app.ready();

--- a/libs/api/runners/src/presentation/routes/request-job.ts
+++ b/libs/api/runners/src/presentation/routes/request-job.ts
@@ -1,47 +1,51 @@
 import {requireRunnerSessionContext} from '@shipfox/api-auth-context';
+import type {AuthInterModuleClient} from '@shipfox/api-auth-dto/inter-module';
 import {claimedJobResponseSchema} from '@shipfox/api-runners-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {RunnerSessionExhaustedError} from '#core/errors.js';
 import {claimJobExecution} from '#core/job-executions.js';
 
-export const requestJobRoute = defineRoute({
-  method: 'POST',
-  path: '/request',
-  description: 'Claim the next available job execution and receive its lease token',
-  schema: {
-    response: {
-      200: claimedJobResponseSchema,
+export function createRequestJobRoute(auth: AuthInterModuleClient) {
+  return defineRoute({
+    method: 'POST',
+    path: '/request',
+    description: 'Claim the next available job execution and receive its lease token',
+    schema: {
+      response: {
+        200: claimedJobResponseSchema,
+      },
     },
-  },
-  errorHandler: (error) => {
-    if (error instanceof RunnerSessionExhaustedError) {
-      throw new ClientError('Runner session claim limit exhausted', 'runner-session-exhausted', {
-        status: 409,
+    errorHandler: (error) => {
+      if (error instanceof RunnerSessionExhaustedError) {
+        throw new ClientError('Runner session claim limit exhausted', 'runner-session-exhausted', {
+          status: 409,
+        });
+      }
+      throw error;
+    },
+    handler: async (_request, reply) => {
+      const runner = requireRunnerSessionContext(_request);
+
+      const jobExecution = await claimJobExecution({
+        auth,
+        workspaceId: runner.workspaceId,
+        runnerSessionId: runner.runnerSessionId,
+        sessionLabels: runner.labels,
+        maxClaims: runner.maxClaims,
       });
-    }
-    throw error;
-  },
-  handler: async (_request, reply) => {
-    const runner = requireRunnerSessionContext(_request);
 
-    const jobExecution = await claimJobExecution({
-      workspaceId: runner.workspaceId,
-      runnerSessionId: runner.runnerSessionId,
-      sessionLabels: runner.labels,
-      maxClaims: runner.maxClaims,
-    });
+      if (!jobExecution) {
+        reply.status(204);
+        return;
+      }
 
-    if (!jobExecution) {
-      reply.status(204);
-      return;
-    }
-
-    return {
-      workflow_run_id: jobExecution.workflowRunId,
-      workflow_run_attempt_id: jobExecution.workflowRunAttemptId,
-      job_id: jobExecution.jobId,
-      job_execution_id: jobExecution.jobExecutionId,
-      lease_token: jobExecution.leaseToken,
-    };
-  },
-});
+      return {
+        workflow_run_id: jobExecution.workflowRunId,
+        workflow_run_attempt_id: jobExecution.workflowRunAttemptId,
+        job_id: jobExecution.jobId,
+        job_execution_id: jobExecution.jobExecutionId,
+        lease_token: jobExecution.leaseToken,
+      };
+    },
+  });
+}

--- a/libs/api/runners/test/env.ts
+++ b/libs/api/runners/test/env.ts
@@ -8,4 +8,5 @@ process.env.WORKSPACE_JWT_SECRET = 'test-secret';
 process.env.AUTH_JWT_SECRET = 'test-secret';
 process.env.AUTH_JOB_LEASE_TOKEN_SECRET = 'test-lease-secret';
 process.env.AUTH_RUNNER_SESSION_TOKEN_SECRET = 'test-runner-session-secret';
+process.env.RATE_LIMIT_IDENTIFIER_SECRET = 'test-rate-limit-secret';
 process.env.TZ = 'UTC';

--- a/libs/api/runners/test/fixtures/auth-inter-module.ts
+++ b/libs/api/runners/test/fixtures/auth-inter-module.ts
@@ -1,0 +1,30 @@
+import {JOB_LEASE_TOKEN_AUDIENCE, RUNNER_SESSION_TOKEN_AUDIENCE} from '@shipfox/api-auth-dto';
+import type {AuthInterModuleClient} from '@shipfox/api-auth-dto/inter-module';
+import {signHs256} from '@shipfox/node-jwt';
+
+const leaseSecret = process.env.AUTH_JOB_LEASE_TOKEN_SECRET ?? 'test-lease-secret';
+const runnerSessionSecret =
+  process.env.AUTH_RUNNER_SESSION_TOKEN_SECRET ?? 'test-runner-session-secret';
+
+export const runnersTestAuthClient: AuthInterModuleClient = {
+  async mintRunnerSessionToken(claims) {
+    return {
+      token: await signHs256({
+        payload: claims,
+        secret: runnerSessionSecret,
+        expiresIn: '1h',
+        audience: RUNNER_SESSION_TOKEN_AUDIENCE,
+      }),
+    };
+  },
+  async mintJobLeaseToken(claims) {
+    return {
+      token: await signHs256({
+        payload: claims,
+        secret: leaseSecret,
+        expiresIn: '90m',
+        audience: JOB_LEASE_TOKEN_AUDIENCE,
+      }),
+    };
+  },
+};

--- a/libs/api/runners/test/index.ts
+++ b/libs/api/runners/test/index.ts
@@ -14,3 +14,4 @@ export {
 export {reservationFactory} from './factories/reservation.js';
 export {providerRunnerFactory} from './factories/runner-instance.js';
 export {runnerSessionFactory} from './factories/runner-session.js';
+export {runnersTestAuthClient} from './fixtures/auth-inter-module.js';

--- a/libs/api/server/package.json
+++ b/libs/api/server/package.json
@@ -53,6 +53,7 @@
     "@shipfox/annotations-dto": "workspace:*",
     "@shipfox/api-agent": "workspace:*",
     "@shipfox/api-auth": "workspace:*",
+    "@shipfox/api-auth-dto": "workspace:*",
     "@shipfox/api-definitions": "workspace:*",
     "@shipfox/api-definitions-dto": "workspace:*",
     "@shipfox/api-dispatcher": "workspace:*",
@@ -71,6 +72,7 @@
     "@shipfox/config": "workspace:*",
     "@shipfox/node-error-monitoring": "workspace:*",
     "@shipfox/node-fastify": "workspace:*",
+    "@shipfox/node-jwt": "workspace:*",
     "@shipfox/node-module": "workspace:*",
     "@shipfox/node-opentelemetry": "workspace:*",
     "@shipfox/node-postgres": "workspace:*"

--- a/libs/api/server/src/modules.test.ts
+++ b/libs/api/server/src/modules.test.ts
@@ -1,4 +1,5 @@
 import {annotationsInterModuleContract} from '@shipfox/annotations-dto/inter-module';
+import {authInterModuleContract} from '@shipfox/api-auth-dto/inter-module';
 import {definitionsInterModuleContract} from '@shipfox/api-definitions-dto/inter-module';
 import {projectsInterModuleContract} from '@shipfox/api-projects-dto';
 import {runnersInterModuleContract} from '@shipfox/api-runners-dto/inter-module';
@@ -18,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   createIntegrationsContext: vi.fn(),
   createLogsModule: vi.fn(),
   createProjectsModule: vi.fn(),
+  createRunnersModule: vi.fn(),
   createSecretsModule: vi.fn(),
   createTriggersModule: vi.fn(),
   createWorkflowsModule: vi.fn(),
@@ -41,8 +43,24 @@ vi.mock('@shipfox/annotations', () => ({
     ],
   },
 }));
+vi.mock('@shipfox/api-auth', () => ({
+  authModule: {
+    name: 'auth',
+    interModulePresentations: [
+      {
+        contract: authInterModuleContract,
+        handlers: {
+          mintJobLeaseToken: vi.fn(),
+          mintRunnerSessionToken: vi.fn(),
+        },
+      },
+    ],
+  },
+}));
 vi.mock('@shipfox/api-agent', () => ({createAgentModule: mocks.createAgentModule}));
-vi.mock('@shipfox/api-auth', () => ({authModule: {name: 'auth'}}));
+vi.mock('@shipfox/api-auth/config', () => ({
+  config: {AUTH_JOB_LEASE_TOKEN_EXPIRES_IN: '90m'},
+}));
 vi.mock('@shipfox/api-definitions', () => ({
   createDefinitionsModule: mocks.createDefinitionsModule,
 }));
@@ -56,23 +74,7 @@ vi.mock('@shipfox/api-integration-core', () => ({
 }));
 vi.mock('@shipfox/api-logs', () => ({createLogsModule: mocks.createLogsModule}));
 vi.mock('@shipfox/api-projects', () => ({createProjectsModule: mocks.createProjectsModule}));
-vi.mock('@shipfox/api-runners', () => ({
-  runnersModule: {
-    name: 'runners',
-    interModulePresentations: [
-      {
-        contract: runnersInterModuleContract,
-        handlers: {
-          cancelJobs: vi.fn(),
-          enqueueJobExecution: vi.fn(),
-          getEffectiveRunnerToolCapabilities: vi.fn(),
-          getLeaseState: vi.fn(),
-          releaseJobExecution: vi.fn(),
-        },
-      },
-    ],
-  },
-}));
+vi.mock('@shipfox/api-runners', () => ({createRunnersModule: mocks.createRunnersModule}));
 vi.mock('@shipfox/api-secrets', () => ({
   createSecretsModule: mocks.createSecretsModule,
   deleteSecrets: mocks.deleteSecrets,
@@ -97,6 +99,7 @@ describe('defaultModules', () => {
     mocks.createIntegrationsContext.mockReset();
     mocks.createLogsModule.mockReset();
     mocks.createProjectsModule.mockReset();
+    mocks.createRunnersModule.mockReset();
     mocks.createSecretsModule.mockReset();
     mocks.createTriggersModule.mockReset();
     mocks.createWorkflowsModule.mockReset();
@@ -150,6 +153,21 @@ describe('defaultModules', () => {
       ],
     });
     mocks.createAgentModule.mockReturnValue({name: 'agent'});
+    mocks.createRunnersModule.mockReturnValue({
+      name: 'runners',
+      interModulePresentations: [
+        {
+          contract: runnersInterModuleContract,
+          handlers: {
+            cancelJobs: vi.fn(),
+            enqueueJobExecution: vi.fn(),
+            getEffectiveRunnerToolCapabilities: vi.fn(),
+            getLeaseState: vi.fn(),
+            releaseJobExecution: vi.fn(),
+          },
+        },
+      ],
+    });
     mocks.createDefinitionsModule.mockReturnValue({
       name: 'definitions',
       interModulePresentations: [
@@ -196,7 +214,7 @@ describe('defaultModules', () => {
     ]);
   });
 
-  it('replaces only the runners module when a host provides one', async () => {
+  it('injects Auth into a host-provided runners module factory', async () => {
     const runnersModule = {
       name: 'runners',
       interModulePresentations: [
@@ -213,9 +231,11 @@ describe('defaultModules', () => {
       ],
     };
 
-    const modules = await defaultModules({runnersModule});
+    const createRunnersModule = vi.fn(() => runnersModule);
+    const modules = await defaultModules({createRunnersModule});
 
     expect(modules).toContain(runnersModule);
+    expect(createRunnersModule).toHaveBeenCalledWith({auth: expect.any(Object)});
     expect(modules.filter((module) => module.name === 'runners')).toEqual([runnersModule]);
     expect(modules.map((module) => module.name)).toEqual([
       'auth',
@@ -273,6 +293,7 @@ describe('defaultModules', () => {
     );
     expect(mocks.createLogsModule).toHaveBeenCalledWith({
       workflows: expect.objectContaining({getStepLogContext: expect.any(Function)}),
+      jobLeaseTokenTtlSeconds: 5400,
     });
 
     const scope = {workspaceId: crypto.randomUUID(), projectId: null, namespace: 'workspace'};

--- a/libs/api/server/src/modules.ts
+++ b/libs/api/server/src/modules.ts
@@ -2,6 +2,11 @@ import {annotationsModule} from '@shipfox/annotations';
 import {annotationsInterModuleContract} from '@shipfox/annotations-dto/inter-module';
 import {createAgentModule} from '@shipfox/api-agent';
 import {authModule} from '@shipfox/api-auth';
+import {config as authConfig} from '@shipfox/api-auth/config';
+import {
+  type AuthInterModuleClient,
+  authInterModuleContract,
+} from '@shipfox/api-auth-dto/inter-module';
 import {createDefinitionsModule} from '@shipfox/api-definitions';
 import {definitionsInterModuleContract} from '@shipfox/api-definitions-dto/inter-module';
 import {dispatcherModule} from '@shipfox/api-dispatcher';
@@ -16,7 +21,7 @@ import {
 import {createLogsModule} from '@shipfox/api-logs';
 import {createProjectsModule} from '@shipfox/api-projects';
 import {projectsInterModuleContract} from '@shipfox/api-projects-dto';
-import {runnersModule as defaultRunnersModule} from '@shipfox/api-runners';
+import {createRunnersModule} from '@shipfox/api-runners';
 import {runnersInterModuleContract} from '@shipfox/api-runners-dto/inter-module';
 import {createSecretsModule} from '@shipfox/api-secrets';
 import {secretsInterModuleContract} from '@shipfox/api-secrets-dto/inter-module';
@@ -28,6 +33,7 @@ import {
 } from '@shipfox/api-workflows';
 import {workflowsInterModuleContract} from '@shipfox/api-workflows-dto/inter-module';
 import {workspacesModule} from '@shipfox/api-workspaces';
+import {durationToSeconds} from '@shipfox/node-jwt';
 import type {ShipfoxModule} from '@shipfox/node-module';
 import {
   createInMemoryInterModuleTransport,
@@ -35,7 +41,7 @@ import {
 } from '@shipfox/node-module/inter-module';
 
 export interface DefaultModulesOptions {
-  runnersModule?: ShipfoxModule;
+  createRunnersModule?: (options: {auth: AuthInterModuleClient}) => ShipfoxModule;
   webhookDeliverySource?: WebhookDeliverySource | undefined;
 }
 
@@ -44,6 +50,7 @@ export async function defaultModules(
 ): Promise<ShipfoxModule[]> {
   const interModuleTransport = createInMemoryInterModuleTransport();
   const workflowsClient = interModuleTransport.createClient(workflowsInterModuleContract);
+  const authClient = interModuleTransport.createClient(authInterModuleContract);
   const runnersClient = interModuleTransport.createClient(runnersInterModuleContract);
   const projectsClient = interModuleTransport.createClient(projectsInterModuleContract);
   const definitionsClient = interModuleTransport.createClient(definitionsInterModuleContract);
@@ -165,13 +172,17 @@ export async function defaultModules(
     createWorkflowsModule({
       annotations: annotationsClient,
       definitions: definitionsClient,
+      auth: authClient,
       projects: projectsClient,
       runners: runnersClient,
       secrets: secretsClient,
     }),
     annotationsModule,
-    options.runnersModule ?? defaultRunnersModule,
-    createLogsModule({workflows: workflowsClient}),
+    (options.createRunnersModule ?? createRunnersModule)({auth: authClient}),
+    createLogsModule({
+      workflows: workflowsClient,
+      jobLeaseTokenTtlSeconds: durationToSeconds(authConfig.AUTH_JOB_LEASE_TOKEN_EXPIRES_IN),
+    }),
     createTriggersModule({workflows: workflowsClient}),
     dispatcherModule,
   ];

--- a/libs/api/workflows/package.json
+++ b/libs/api/workflows/package.json
@@ -42,8 +42,8 @@
   },
   "dependencies": {
     "@shipfox/api-agent": "workspace:*",
-    "@shipfox/api-auth": "workspace:*",
     "@shipfox/api-auth-context": "workspace:*",
+    "@shipfox/api-auth-dto": "workspace:*",
     "@shipfox/api-agent-dto": "workspace:*",
     "@shipfox/annotations-dto": "workspace:*",
     "@shipfox/api-definitions-dto": "workspace:*",
@@ -71,8 +71,8 @@
   },
   "devDependencies": {
     "@shipfox/annotations": "workspace:*",
+    "@shipfox/api-auth": "workspace:*",
     "@shipfox/api-definitions": "workspace:*",
-    "@shipfox/api-auth-dto": "workspace:*",
     "@shipfox/biome": "workspace:*",
     "@shipfox/depcruise": "workspace:*",
     "@shipfox/node-jwt": "workspace:*",

--- a/libs/api/workflows/src/index.ts
+++ b/libs/api/workflows/src/index.ts
@@ -1,6 +1,7 @@
 import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 import type {AnnotationsInterModuleClient} from '@shipfox/annotations-dto/inter-module';
+import type {AuthInterModuleClient} from '@shipfox/api-auth-dto/inter-module';
 import type {DefinitionsInterModuleClient} from '@shipfox/api-definitions-dto/inter-module';
 import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
 import {
@@ -79,12 +80,14 @@ const subscriber = subscriberFactory<WorkflowsEventMapDto & RunnersEventMap>();
 export function createWorkflowsModule({
   definitions,
   annotations,
+  auth,
   projects,
   runners,
   secrets,
 }: {
   definitions: DefinitionsInterModuleClient;
   annotations: AnnotationsInterModuleClient;
+  auth: AuthInterModuleClient;
   projects: ProjectsModuleClient;
   runners: RunnersInterModuleClient;
   secrets: SecretsInterModuleClient;
@@ -92,7 +95,7 @@ export function createWorkflowsModule({
   return {
     name: 'workflows',
     database: {db, migrationsPath},
-    routes: createWorkflowRoutes(runners, projects, annotations, secrets),
+    routes: createWorkflowRoutes(runners, auth, projects, annotations, secrets),
     metrics: registerWorkflowsServiceMetrics,
     publishers: [
       {name: 'workflows', table: workflowsOutbox, db, eventSchemas: workflowsEventSchemas},

--- a/libs/api/workflows/src/presentation/routes/index.test.ts
+++ b/libs/api/workflows/src/presentation/routes/index.test.ts
@@ -7,6 +7,7 @@ import {
 } from '@shipfox/api-auth-context';
 import {type AuthMethod, ClientError, closeApp, createApp} from '@shipfox/node-fastify';
 import type {FastifyRequest} from 'fastify';
+import {workflowsTestAuthClient} from '#test/fixtures/auth-inter-module.js';
 import {runnersTestClient} from '#test/fixtures/runners-inter-module.js';
 import {createTestSecretsClient} from '#test/fixtures/secrets-inter-module.js';
 import {createWorkflowRoutes} from './index.js';
@@ -33,6 +34,7 @@ afterEach(async () => {
 describe('workflow route auth', () => {
   const workflowRoutes = createWorkflowRoutes(
     runnersTestClient,
+    workflowsTestAuthClient,
     undefined,
     undefined,
     createTestSecretsClient(),

--- a/libs/api/workflows/src/presentation/routes/index.ts
+++ b/libs/api/workflows/src/presentation/routes/index.ts
@@ -1,5 +1,6 @@
 import type {AnnotationsInterModuleClient} from '@shipfox/annotations-dto/inter-module';
 import {AUTH_LEASED_JOB, AUTH_USER} from '@shipfox/api-auth-context';
+import type {AuthInterModuleClient} from '@shipfox/api-auth-dto/inter-module';
 import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
 import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-module';
 import type {SecretsInterModuleClient} from '@shipfox/api-secrets-dto/inter-module';
@@ -41,18 +42,24 @@ const unconfiguredAnnotations = {
     throw new Error('Annotations client is not configured');
   },
 } as unknown as AnnotationsInterModuleClient;
+const unconfiguredAuthClient = new Proxy({} as AuthInterModuleClient, {
+  get() {
+    throw new Error('Auth client is not configured');
+  },
+});
 
 export function createLeaseTokenRouteGroup(
   runners: RunnersInterModuleClient,
   projects: ProjectsModuleClient = unconfiguredProjects,
   annotations: AnnotationsInterModuleClient = unconfiguredAnnotations,
   secrets: SecretsInterModuleClient = unconfiguredSecrets,
+  auth: AuthInterModuleClient = unconfiguredAuthClient,
 ): RouteGroup {
   return {
     prefix: '/runs/jobs/current',
     auth: AUTH_LEASED_JOB,
     routes: [
-      createNextStepRoute(runners, annotations),
+      createNextStepRoute(runners, annotations, auth),
       createReportStepRoute(runners),
       createCheckoutTokenRoute(runners, projects),
       createAgentRuntimeConfigRoute(runners, secrets),
@@ -63,6 +70,7 @@ export function createLeaseTokenRouteGroup(
 
 export function createWorkflowRoutes(
   runners: RunnersInterModuleClient,
+  auth: AuthInterModuleClient,
   projects: ProjectsModuleClient = unconfiguredProjects,
   annotations: AnnotationsInterModuleClient = unconfiguredAnnotations,
   secrets: SecretsInterModuleClient = unconfiguredSecrets,
@@ -80,6 +88,6 @@ export function createWorkflowRoutes(
         rerunRunRoute(projects),
       ],
     },
-    createLeaseTokenRouteGroup(runners, projects, annotations, secrets),
+    createLeaseTokenRouteGroup(runners, projects, annotations, secrets, auth),
   ];
 }

--- a/libs/api/workflows/src/presentation/routes/next-step.test.ts
+++ b/libs/api/workflows/src/presentation/routes/next-step.test.ts
@@ -13,6 +13,7 @@ import {
   getWorkflowRunByAttemptId,
 } from '#db/workflow-runs.js';
 import {insertRunningJobLease, mintActiveLeaseToken} from '#test/fixtures/active-lease-token.js';
+import {workflowsTestAuthClient} from '#test/fixtures/auth-inter-module.js';
 import {arrangeJobWithSteps} from '#test/fixtures/job-with-steps.js';
 import {mintLeaseToken} from '#test/fixtures/lease-token.js';
 import {runnersTestClient} from '#test/fixtures/runners-inter-module.js';
@@ -62,6 +63,7 @@ describe('POST /runs/jobs/current/steps/next', () => {
           undefined,
           annotationsTestClient,
           createTestSecretsClient(),
+          workflowsTestAuthClient,
         ),
       ],
       swagger: false,

--- a/libs/api/workflows/src/presentation/routes/next-step.ts
+++ b/libs/api/workflows/src/presentation/routes/next-step.ts
@@ -1,6 +1,6 @@
 import type {AnnotationsInterModuleClient} from '@shipfox/annotations-dto/inter-module';
-import {issueJobLeaseToken, jobLeaseParamsFrom} from '@shipfox/api-auth';
 import {requireLeasedJobContext} from '@shipfox/api-auth-context';
+import type {AuthInterModuleClient} from '@shipfox/api-auth-dto/inter-module';
 import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-module';
 import {nextStepResponseSchema} from '@shipfox/api-workflows-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
@@ -12,6 +12,7 @@ import {toStepDto} from '#presentation/dto/step.js';
 export function createNextStepRoute(
   runners: RunnersInterModuleClient,
   annotations: AnnotationsInterModuleClient,
+  auth: AuthInterModuleClient,
 ) {
   return defineRoute({
     method: 'POST',
@@ -42,12 +43,20 @@ export function createNextStepRoute(
       });
 
       if (next.kind === 'step') {
-        const leaseToken = await issueJobLeaseToken(
-          jobLeaseParamsFrom(leasedJob, {
-            currentStepId: next.step.id,
-            currentStepAttempt: next.step.currentAttempt,
-          }),
-        );
+        const {token: leaseToken} = await auth.mintJobLeaseToken({
+          workflowRunId: leasedJob.workflowRunId,
+          ...(leasedJob.workflowRunAttempt === undefined
+            ? {}
+            : {workflowRunAttempt: leasedJob.workflowRunAttempt}),
+          workflowRunAttemptId: leasedJob.workflowRunAttemptId,
+          jobId: leasedJob.jobId,
+          jobExecutionId: leasedJob.jobExecutionId,
+          projectId: leasedJob.projectId,
+          workspaceId: leasedJob.workspaceId,
+          runnerSessionId: leasedJob.runnerSessionId,
+          currentStepId: next.step.id,
+          currentStepAttempt: next.step.currentAttempt,
+        });
         if (next.dispatched) {
           await warnAgentToolCapabilityMismatchOnDispatch({
             annotations,

--- a/libs/api/workflows/test/env.ts
+++ b/libs/api/workflows/test/env.ts
@@ -7,5 +7,6 @@ process.env.POSTGRES_MAX_CONNECTIONS ??= '5';
 process.env.AUTH_JWT_SECRET = 'test-secret';
 process.env.AUTH_JOB_LEASE_TOKEN_SECRET = 'test-lease-secret';
 process.env.AUTH_RUNNER_SESSION_TOKEN_SECRET = 'test-runner-session-secret';
+process.env.RATE_LIMIT_IDENTIFIER_SECRET = 'test-rate-limit-secret';
 process.env.SECRETS_ENCRYPTION_KEK = 'ZmVkY2JhOTg3NjU0MzIxMGZlZGNiYTk4NzY1NDMyMTA=';
 process.env.TZ = 'UTC';

--- a/libs/api/workflows/test/fixtures/auth-inter-module.ts
+++ b/libs/api/workflows/test/fixtures/auth-inter-module.ts
@@ -1,0 +1,21 @@
+import {JOB_LEASE_TOKEN_AUDIENCE} from '@shipfox/api-auth-dto';
+import type {AuthInterModuleClient} from '@shipfox/api-auth-dto/inter-module';
+import {signHs256} from '@shipfox/node-jwt';
+
+const leaseSecret = process.env.AUTH_JOB_LEASE_TOKEN_SECRET ?? 'test-lease-secret';
+
+export const workflowsTestAuthClient: AuthInterModuleClient = {
+  mintRunnerSessionToken() {
+    throw new Error('Runner session token minting is not configured');
+  },
+  async mintJobLeaseToken(claims) {
+    return {
+      token: await signHs256({
+        payload: claims,
+        secret: leaseSecret,
+        expiresIn: '90m',
+        audience: JOB_LEASE_TOKEN_AUDIENCE,
+      }),
+    };
+  },
+};

--- a/libs/api/workflows/test/globalSetup.ts
+++ b/libs/api/workflows/test/globalSetup.ts
@@ -1,7 +1,8 @@
 import './env.js';
 import {annotationsModule} from '@shipfox/annotations';
 import {createAgentModule} from '@shipfox/api-agent';
-import {runnersModule} from '@shipfox/api-runners';
+import type {AuthInterModuleClient} from '@shipfox/api-auth-dto/inter-module';
+import {createRunnersModule} from '@shipfox/api-runners';
 import {runMigrations} from '@shipfox/node-drizzle';
 import {closePostgresClient, createPostgresClient} from '@shipfox/node-postgres';
 import {sql} from 'drizzle-orm';
@@ -9,6 +10,7 @@ import {closeDb, db, migrationsPath} from '#db/index.js';
 
 export async function setup() {
   createPostgresClient();
+  const runnersModule = createRunnersModule({auth: {} as AuthInterModuleClient});
 
   const agentModule = createAgentModule({
     secrets: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2008,6 +2008,9 @@ importers:
       '@shipfox/config':
         specifier: workspace:*
         version: link:../../shared/common/config
+      '@shipfox/inter-module':
+        specifier: workspace:*
+        version: link:../../shared/common/inter-module
       '@shipfox/node-drizzle':
         specifier: workspace:*
         version: link:../../shared/node/drizzle
@@ -2115,6 +2118,9 @@ importers:
       '@shipfox/api-common-dto':
         specifier: workspace:*
         version: link:../common-dto
+      '@shipfox/inter-module':
+        specifier: workspace:*
+        version: link:../../shared/common/inter-module
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -3466,12 +3472,12 @@ importers:
 
   libs/api/runners:
     dependencies:
-      '@shipfox/api-auth':
-        specifier: workspace:*
-        version: link:../auth
       '@shipfox/api-auth-context':
         specifier: workspace:*
         version: link:../auth-context
+      '@shipfox/api-auth-dto':
+        specifier: workspace:*
+        version: link:../auth-dto
       '@shipfox/api-runners-dto':
         specifier: workspace:*
         version: link:../runners-dto
@@ -3524,9 +3530,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
-      '@shipfox/api-auth-dto':
+      '@shipfox/api-auth':
         specifier: workspace:*
-        version: link:../auth-dto
+        version: link:../auth
       '@shipfox/biome':
         specifier: workspace:*
         version: link:../../../tools/biome
@@ -3713,6 +3719,9 @@ importers:
       '@shipfox/api-auth':
         specifier: workspace:*
         version: link:../auth
+      '@shipfox/api-auth-dto':
+        specifier: workspace:*
+        version: link:../auth-dto
       '@shipfox/api-definitions':
         specifier: workspace:*
         version: link:../definitions
@@ -3767,6 +3776,9 @@ importers:
       '@shipfox/node-fastify':
         specifier: workspace:*
         version: link:../../shared/node/fastify
+      '@shipfox/node-jwt':
+        specifier: workspace:*
+        version: link:../../shared/node/jwt
       '@shipfox/node-module':
         specifier: workspace:*
         version: link:../../shared/node/module
@@ -3941,12 +3953,12 @@ importers:
       '@shipfox/api-agent-dto':
         specifier: workspace:*
         version: link:../agent-dto
-      '@shipfox/api-auth':
-        specifier: workspace:*
-        version: link:../auth
       '@shipfox/api-auth-context':
         specifier: workspace:*
         version: link:../auth-context
+      '@shipfox/api-auth-dto':
+        specifier: workspace:*
+        version: link:../auth-dto
       '@shipfox/api-definitions-dto':
         specifier: workspace:*
         version: link:../definitions-dto
@@ -4017,9 +4029,9 @@ importers:
       '@shipfox/annotations':
         specifier: workspace:*
         version: link:../annotations
-      '@shipfox/api-auth-dto':
+      '@shipfox/api-auth':
         specifier: workspace:*
-        version: link:../auth-dto
+        version: link:../auth
       '@shipfox/api-definitions':
         specifier: workspace:*
         version: link:../definitions

--- a/tools/application-release/test/external/verify.mjs
+++ b/tools/application-release/test/external/verify.mjs
@@ -148,10 +148,15 @@ import {createServer, defaultModules} from '@shipfox/api-server';
 const policy: InstallationProvisioningPolicy = {
   filterEligibleWorkspaceIds: async (workspaceIds) => new Set(workspaceIds),
 };
-const runnersModule = createRunnersModule({installationProvisioning: {policy}});
 
 void createServer({
-  modules: [...(await defaultModules({runnersModule})), {name: 'external-dummy'}],
+  modules: [
+    ...(await defaultModules({
+      createRunnersModule: ({auth}) =>
+        createRunnersModule({auth, installationProvisioning: {policy}}),
+    })),
+    {name: 'external-dummy'},
+  ],
 });
 `,
     ),


### PR DESCRIPTION
Moves runner-session and job-lease token minting behind Auth's producer-owned inter-module contract, injecting narrow clients into Runners and Workflows instead of importing Auth implementation code.

The application root now injects Auth into every Runners module factory, including host-provided custom composition. It also supplies Logs with Auth's actual job-lease lifetime, so the stale-stream reaper cannot truncate a stream while a valid lease can still append.

A dedicated `RATE_LIMIT_IDENTIFIER_SECRET` remains recommended, while existing deployments fall back to their configured JWT secret until they add one. The contract uses JSON-safe claims and token-only responses, preserving the separate user-session, runner-session, and job-lease capability boundaries.

Closes ENG-1039