### PR TITLE
Validate the published webhook seam

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Verify packed API runtime closure
         run: pnpm --filter=@shipfox/application-release test:external
 
+      - name: Verify packed webhook processor seam
+        run: pnpm --filter=@shipfox/api-integration-core test:external
+
       - name: Verify packed client composition
         run: pnpm --filter=@shipfox/client-shell test:external
 

--- a/libs/api/integration/core/package.json
+++ b/libs/api/integration/core/package.json
@@ -35,6 +35,7 @@
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
     "test": "shipfox-vitest-run",
+    "test:external": "pnpm run build && pnpm run type:emit && node test/external/verify.mjs",
     "test:watch": "shipfox-vitest-watch",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"

--- a/libs/api/integration/core/test/external/package.template.json
+++ b/libs/api/integration/core/test/external/package.template.json
@@ -1,0 +1,18 @@
+{
+  "name": "api-integration-core-webhook-external-fixture",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "check": "tsc --project tsconfig.json --noEmit",
+    "build": "tsc --project tsconfig.json",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@shipfox/api-integration-core": "file:./api-integration-core.tgz",
+    "@shipfox/api-integration-core-dto": "file:./api-integration-core-dto.tgz"
+  },
+  "devDependencies": {
+    "@types/node": "^24.1.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/libs/api/integration/core/test/external/pnpm-workspace.yaml
+++ b/libs/api/integration/core/test/external/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+overrides:
+  "@shipfox/api-integration-core-dto": "file:./api-integration-core-dto.tgz"

--- a/libs/api/integration/core/test/external/src/index.ts
+++ b/libs/api/integration/core/test/external/src/index.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+
+import {createIntegrationsContext, type WebhookDeliverySource} from '@shipfox/api-integration-core';
+import {
+  createStoredWebhookRequest,
+  decodeWebhookBody,
+  type StoredWebhookRequest,
+  type WebhookRequestProcessor,
+} from '@shipfox/api-integration-core-dto';
+
+const directRequest = createStoredWebhookRequest({
+  requestId: 'c2503185-560a-49a5-a8b4-82976db1e652',
+  routeId: 'github',
+  receivedAt: '2026-07-20T18:00:00.000Z',
+  rawQueryString: '',
+  headers: {'x-github-event': 'push'},
+  body: new TextEncoder().encode('{"ref":"refs/heads/main"}'),
+});
+const queuedRequest = createStoredWebhookRequest({
+  requestId: 'c10cc13e-a8c7-4e6d-aadb-663c81124f2b',
+  routeId: 'github',
+  receivedAt: '2026-07-20T18:00:01.000Z',
+  rawQueryString: '',
+  headers: {'x-github-event': 'push'},
+  body: new Uint8Array([0, 1, 2, 254, 255]),
+});
+
+const processedRequests: StoredWebhookRequest[] = [];
+const processor: WebhookRequestProcessor = {
+  process(request) {
+    processedRequests.push(request);
+    return Promise.resolve({outcome: 'processed', deliveryId: request.request_id});
+  },
+};
+
+let queuedProcessor: WebhookRequestProcessor | undefined;
+const deliverySource: WebhookDeliverySource = {
+  createService(processor) {
+    queuedProcessor = processor;
+    return {
+      name: 'external-queued-webhook-deliveries',
+      shutdownTimeoutMs: 1_000,
+      start() {
+        return Promise.resolve({finished: Promise.resolve(), stop: () => Promise.resolve()});
+      },
+    };
+  },
+};
+
+const context = await createIntegrationsContext({
+  parts: [
+    {
+      provider: {provider: 'github', displayName: 'GitHub', adapters: {}},
+      webhookProcessors: [{routeIds: ['github'], processor}],
+    },
+  ],
+  webhookDeliverySource: deliverySource,
+});
+
+const directResult = await context.webhookProcessor.process(directRequest);
+const queuedResult = await queuedProcessor?.process(queuedRequest);
+
+assert.deepEqual(directResult, {outcome: 'processed', deliveryId: directRequest.request_id});
+assert.deepEqual(queuedResult, {outcome: 'processed', deliveryId: queuedRequest.request_id});
+assert.deepEqual(processedRequests, [directRequest, queuedRequest]);
+const processedQueuedRequest = processedRequests.at(1);
+assert.ok(processedQueuedRequest);
+assert.deepEqual(
+  decodeWebhookBody(processedQueuedRequest.body),
+  new Uint8Array([0, 1, 2, 254, 255]),
+);

--- a/libs/api/integration/core/test/external/tsconfig.json
+++ b/libs/api/integration/core/test/external/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2024"
+  },
+  "include": ["src"]
+}

--- a/libs/api/integration/core/test/external/verify.mjs
+++ b/libs/api/integration/core/test/external/verify.mjs
@@ -1,0 +1,63 @@
+import {access, cp, mkdtemp, readFile, rename, rm} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {dirname, join, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+import {
+  createProductionManifestPacker,
+  run,
+} from '../../../../../../dev/productionized-manifest-packer.mjs';
+
+const fixtureSource = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(fixtureSource, '../..');
+const dtoPackageRoot = resolve(packageRoot, '../core-dto');
+const fixtureRoot = await mkdtemp(join(tmpdir(), 'api-integration-webhook-external-'));
+const manifestPacker = createProductionManifestPacker();
+
+async function packPackage(root, destination) {
+  const manifestPath = join(root, 'package.json');
+  const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+  await manifestPacker.pack(manifestPath, manifest, (signal) =>
+    run('pnpm', ['pack', '--out', destination], root, {signal}),
+  );
+}
+
+async function verifyInstalledExport(packageName) {
+  const installedRoot = join(fixtureRoot, 'node_modules', packageName);
+  const manifest = JSON.parse(await readFile(join(installedRoot, 'package.json'), 'utf8'));
+  const publishedExport = manifest.exports?.['.'];
+  if (
+    !publishedExport ||
+    typeof publishedExport !== 'object' ||
+    typeof publishedExport.default !== 'string' ||
+    typeof publishedExport.types !== 'string'
+  ) {
+    throw new Error(`${packageName} is missing root runtime or type exports`);
+  }
+  if (JSON.stringify(manifest).includes('workspace:')) {
+    throw new Error(`${packageName} contains a workspace dependency range`);
+  }
+  await Promise.all([
+    access(join(installedRoot, publishedExport.default)),
+    access(join(installedRoot, publishedExport.types)),
+  ]);
+}
+
+try {
+  await cp(fixtureSource, fixtureRoot, {
+    recursive: true,
+    filter: (source) => source !== fileURLToPath(import.meta.url),
+  });
+  await rename(join(fixtureRoot, 'package.template.json'), join(fixtureRoot, 'package.json'));
+  await packPackage(dtoPackageRoot, join(fixtureRoot, 'api-integration-core-dto.tgz'));
+  await packPackage(packageRoot, join(fixtureRoot, 'api-integration-core.tgz'));
+  await run('pnpm', ['install', '--ignore-scripts'], fixtureRoot);
+  await verifyInstalledExport('@shipfox/api-integration-core');
+  await verifyInstalledExport('@shipfox/api-integration-core-dto');
+  await run('pnpm', ['run', 'check'], fixtureRoot);
+  await run('pnpm', ['run', 'build'], fixtureRoot);
+  await run('pnpm', ['run', 'start'], fixtureRoot);
+} finally {
+  manifestPacker.dispose();
+  await rm(fixtureRoot, {recursive: true, force: true});
+}


### PR DESCRIPTION
Add a packed external-consumer proof for the published webhook processor seam.

Cloud needs to process durable queue deliveries through the same public processor used by direct API routes. The new fixture installs productionized `@shipfox/api-integration-core` and `-core-dto` tarballs, checks their runtime and declaration exports, compiles an external adapter, and exercises both delivery paths. CI now runs that gate.

The fixture uses the real `WebhookDeliverySource` and `WebhookRequestProcessor` contract rather than duplicating processor behavior. Its isolated install skips lifecycle scripts and pins the DTO dependency to the packed tarball, so CI validates the intended release set rather than the registry's prior version.

Closes ENG-1073