### PR TITLE
[runner] Add installation fallback demand allocation

### DIFF
--- a/.changeset/steady-falcons-share.md
+++ b/.changeset/steady-falcons-share.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-runners": minor
+"@shipfox/api-runners-dto": minor
+---
+
+Adds installation-scoped fallback demand reservations across eligible workspaces.

--- a/libs/api/runners-dto/src/schemas/poll-demand.ts
+++ b/libs/api/runners-dto/src/schemas/poll-demand.ts
@@ -17,6 +17,7 @@ export const pollDemandBodySchema = z.object({
 });
 
 export const demandStatSchema = z.object({
+  workspace_id: z.string().uuid().optional(),
   labels: z.array(z.string()),
   queued: z.number().int().min(0),
   reserved: z
@@ -31,6 +32,7 @@ export const demandStatSchema = z.object({
 
 export const reservationGrantSchema = z.object({
   reservation_id: z.string().uuid(),
+  workspace_id: z.string().uuid().optional(),
   labels: z.array(z.string()),
   count: z.number().int().positive(),
   expires_at: z.string().datetime(),

--- a/libs/api/runners/src/db/reservations.test.ts
+++ b/libs/api/runners/src/db/reservations.test.ts
@@ -3,6 +3,7 @@ import {db} from '#db/db.js';
 import {
   deleteReservationsByIds,
   pollDemandAndReserve,
+  pollInstallationDemandAndReserve,
   releaseReservationUnits,
 } from '#db/reservations.js';
 import {reservations} from '#db/schema/reservations.js';
@@ -73,6 +74,26 @@ describe('pollDemandAndReserve', () => {
 
     const reserved = await activeReservedCount();
     expect(reserved).toBeLessThanOrEqual(5);
+  });
+
+  it('allocates eligible workspace heads in oldest-demand order without overselling templates', async () => {
+    const olderWorkspaceId = crypto.randomUUID();
+    const newerWorkspaceId = crypto.randomUUID();
+    await pendingJobFactory.create({workspaceId: olderWorkspaceId, requiredLabels: ['linux']});
+    await pendingJobFactory.create({workspaceId: newerWorkspaceId, requiredLabels: ['linux']});
+
+    const result = await pollInstallationDemandAndReserve({
+      provisionerId,
+      maxReservations: 5,
+      ttlSeconds: 60,
+      templates: [template('linux', ['linux'], 1)],
+      capabilityWindowSeconds: 60,
+      eligibleWorkspaceIds: new Set([olderWorkspaceId, newerWorkspaceId]),
+    });
+
+    expect(result.reservations).toEqual([
+      expect.objectContaining({workspaceId: olderWorkspaceId, labels: ['linux'], count: 1}),
+    ]);
   });
 
   it('does not count expired reservations against demand', async () => {

--- a/libs/api/runners/src/db/reservations.test.ts
+++ b/libs/api/runners/src/db/reservations.test.ts
@@ -96,6 +96,34 @@ describe('pollDemandAndReserve', () => {
     ]);
   });
 
+  it('reports committed installation grants before an aborted poll stops allocating', async () => {
+    const firstWorkspaceId = crypto.randomUUID();
+    const secondWorkspaceId = crypto.randomUUID();
+    const abortController = new AbortController();
+    const reportedReservations: string[] = [];
+    await pendingJobFactory.create({workspaceId: firstWorkspaceId, requiredLabels: ['linux']});
+    await pendingJobFactory.create({workspaceId: secondWorkspaceId, requiredLabels: ['linux']});
+
+    const result = await pollInstallationDemandAndReserve({
+      provisionerId,
+      maxReservations: 2,
+      ttlSeconds: 60,
+      templates: [template('linux', ['linux'], 2)],
+      capabilityWindowSeconds: 60,
+      eligibleWorkspaceIds: new Set([firstWorkspaceId, secondWorkspaceId]),
+      signal: abortController.signal,
+      onReservations: (reservations) => {
+        reportedReservations.push(...reservations.map((reservation) => reservation.reservationId));
+        abortController.abort();
+      },
+    });
+
+    expect(result.reservations).toHaveLength(1);
+    expect(reportedReservations).toEqual(
+      result.reservations.map((reservation) => reservation.reservationId),
+    );
+  });
+
   it('does not count expired reservations against demand', async () => {
     await createPendingJobs(1, ['linux']);
     await reservationFactory.create({

--- a/libs/api/runners/src/db/reservations.ts
+++ b/libs/api/runners/src/db/reservations.ts
@@ -3,6 +3,8 @@ import {and, asc, eq, gt, inArray, lt, sql} from 'drizzle-orm';
 import type {Tx} from './db.js';
 import {db} from './db.js';
 import {pendingJobExecutions} from './schema/pending-job-executions.js';
+import {provisionerCapabilitySnapshots} from './schema/provisioner-capability-snapshots.js';
+import {provisionerTokens} from './schema/provisioner-tokens.js';
 import {reservations} from './schema/reservations.js';
 
 export interface ReservationTemplate {
@@ -14,6 +16,7 @@ export interface ReservationTemplate {
 }
 
 export interface DemandStat {
+  workspaceId?: string;
   labels: string[];
   queued: number;
   reserved: number;
@@ -22,6 +25,7 @@ export interface DemandStat {
 
 export interface ReservationGrant {
   reservationId: string;
+  workspaceId?: string;
   labels: string[];
   count: number;
   expiresAt: Date;
@@ -33,6 +37,18 @@ export interface PollDemandAndReserveParams {
   maxReservations: number;
   ttlSeconds: number;
   templates: ReservationTemplate[];
+  capabilityWindowSeconds?: number;
+}
+
+export interface InstallationPollDemandAndReserveParams {
+  provisionerId: string;
+  maxReservations: number;
+  ttlSeconds: number;
+  templates: ReservationTemplate[];
+  capabilityWindowSeconds: number;
+  eligibleWorkspaceIds: ReadonlySet<string>;
+  signal?: AbortSignal;
+  onReservations?: (reservations: ReservationGrant[]) => void;
 }
 
 interface NormalizedTemplate {
@@ -60,8 +76,75 @@ export async function pollDemandAndReserveTx(
   params: PollDemandAndReserveParams,
 ): Promise<{stats: DemandStat[]; reservations: ReservationGrant[]}> {
   await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${params.workspaceId}))`);
+  return await pollDemandAndReserveLockedTx(tx, params);
+}
 
-  const demandRows = (
+export async function pollInstallationDemandAndReserve(
+  params: InstallationPollDemandAndReserveParams,
+): Promise<{stats: DemandStat[]; reservations: ReservationGrant[]}> {
+  const candidateWorkspaceIds = await listInstallationDemandWorkspaceIds(
+    params.eligibleWorkspaceIds,
+  );
+  const results: Array<{stats: DemandStat[]; reservations: ReservationGrant[]}> = [];
+  let remainingMaxReservations = params.maxReservations;
+  const remainingTemplates = params.templates.map((template) => ({
+    ...template,
+    labels: [...canonicalizeLabels(template.labels)],
+    remainingSlots: template.availableSlots,
+  }));
+  for (const workspaceId of candidateWorkspaceIds) {
+    if (params.signal?.aborted || remainingMaxReservations === 0) break;
+    const result = await db().transaction(async (tx) => {
+      const lockResult = await tx.execute<{locked: boolean}>(
+        sql`select pg_try_advisory_xact_lock(hashtext(${workspaceId})) as locked`,
+      );
+      const locked = lockResult.rows[0];
+      if (!locked?.locked) return {stats: [], reservations: []};
+      return await pollDemandAndReserveLockedTx(tx, {
+        workspaceId,
+        provisionerId: params.provisionerId,
+        maxReservations: remainingMaxReservations,
+        ttlSeconds: params.ttlSeconds,
+        templates: remainingTemplates.map((template) => ({
+          ...template,
+          availableSlots: template.remainingSlots,
+        })),
+        capabilityWindowSeconds: params.capabilityWindowSeconds,
+      });
+    });
+    results.push(result);
+    consumeInstallationTemplateSlots(remainingTemplates, result.reservations);
+    params.onReservations?.(result.reservations);
+    remainingMaxReservations -= result.reservations.reduce(
+      (total, reservation) => total + reservation.count,
+      0,
+    );
+  }
+  return {
+    stats: results.flatMap((result) => result.stats),
+    reservations: results.flatMap((result) => result.reservations),
+  };
+}
+
+function consumeInstallationTemplateSlots(
+  templates: NormalizedTemplate[],
+  reservations: ReservationGrant[],
+): void {
+  for (const reservation of reservations) {
+    const satisfyingTemplates = templates
+      .filter((template) => isSubset(reservation.labels, template.labels))
+      .sort(
+        (a, b) => a.labels.length - b.labels.length || a.templateKey.localeCompare(b.templateKey),
+      );
+    drawSlots(satisfyingTemplates, reservation.count);
+  }
+}
+
+async function pollDemandAndReserveLockedTx(
+  tx: Tx,
+  params: PollDemandAndReserveParams,
+): Promise<{stats: DemandStat[]; reservations: ReservationGrant[]}> {
+  let demandRows = (
     await tx
       .select({
         requiredLabels: pendingJobExecutions.requiredLabels,
@@ -75,6 +158,15 @@ export async function pollDemandAndReserveTx(
     ...row,
     oldestQueuedAt: new Date(row.oldestQueuedAt),
   }));
+  if (params.capabilityWindowSeconds !== undefined) {
+    const capabilityLabels = await listActiveWorkspaceCapabilityLabelsTx(tx, {
+      workspaceId: params.workspaceId,
+      windowSeconds: params.capabilityWindowSeconds,
+    });
+    demandRows = demandRows.filter(
+      (demand) => !capabilityLabels.some((labels) => isSubset(demand.requiredLabels, labels)),
+    );
+  }
 
   const activeReservationRows = await tx
     .select({
@@ -114,6 +206,8 @@ export async function pollDemandAndReserveTx(
   const stats: DemandStat[] = [];
   const grants: ReservationGrant[] = [];
   let remainingMaxReservations = params.maxReservations;
+  const workspaceIdField =
+    params.capabilityWindowSeconds === undefined ? {} : {workspaceId: params.workspaceId};
 
   for (const demand of sortDemandRows(demandRows)) {
     const satisfyingTemplates = templates
@@ -152,6 +246,7 @@ export async function pollDemandAndReserveTx(
       reservedAfterGrant += grant;
       grants.push({
         reservationId: inserted.id,
+        ...workspaceIdField,
         labels: demand.requiredLabels,
         count: grant,
         expiresAt: inserted.expiresAt,
@@ -159,6 +254,7 @@ export async function pollDemandAndReserveTx(
     }
 
     stats.push({
+      ...workspaceIdField,
       labels: demand.requiredLabels,
       queued: demand.queued,
       reserved: reservedAfterGrant,
@@ -167,6 +263,55 @@ export async function pollDemandAndReserveTx(
   }
 
   return {stats, reservations: grants};
+}
+
+async function listInstallationDemandWorkspaceIds(eligibleWorkspaceIds: ReadonlySet<string>) {
+  if (eligibleWorkspaceIds.size === 0) return [];
+  const rows = await db()
+    .select({
+      workspaceId: pendingJobExecutions.workspaceId,
+      oldestQueuedAt: sql<Date>`min(${pendingJobExecutions.createdAt})`,
+    })
+    .from(pendingJobExecutions)
+    .where(inArray(pendingJobExecutions.workspaceId, [...eligibleWorkspaceIds]))
+    .groupBy(pendingJobExecutions.workspaceId)
+    .orderBy(
+      asc(sql`min(${pendingJobExecutions.createdAt})`),
+      asc(pendingJobExecutions.workspaceId),
+    );
+  return rows.map((row) => row.workspaceId);
+}
+
+export async function listQueuedDemandWorkspaceIds(): Promise<string[]> {
+  const rows = await db()
+    .select({workspaceId: pendingJobExecutions.workspaceId})
+    .from(pendingJobExecutions)
+    .groupBy(pendingJobExecutions.workspaceId);
+  return rows.map((row) => row.workspaceId);
+}
+
+async function listActiveWorkspaceCapabilityLabelsTx(
+  tx: Tx,
+  params: {workspaceId: string; windowSeconds: number},
+): Promise<string[][]> {
+  const rows = await tx
+    .select({labels: provisionerCapabilitySnapshots.labels})
+    .from(provisionerCapabilitySnapshots)
+    .innerJoin(
+      provisionerTokens,
+      eq(provisionerTokens.id, provisionerCapabilitySnapshots.provisionerId),
+    )
+    .where(
+      and(
+        eq(provisionerCapabilitySnapshots.workspaceId, params.workspaceId),
+        eq(provisionerTokens.workspaceId, params.workspaceId),
+        eq(provisionerTokens.scope, 'workspace'),
+        sql`${provisionerCapabilitySnapshots.advertisedAt} > now() - (${params.windowSeconds} || ' seconds')::interval`,
+        sql`${provisionerTokens.revokedAt} is null`,
+        sql`(${provisionerTokens.expiresAt} is null or ${provisionerTokens.expiresAt} > now())`,
+      ),
+    );
+  return rows.map((row) => row.labels);
 }
 
 export async function deleteExpiredReservations(params?: {limit?: number}): Promise<number> {

--- a/libs/api/runners/src/presentation/dto/poll-demand.ts
+++ b/libs/api/runners/src/presentation/dto/poll-demand.ts
@@ -4,6 +4,7 @@ import type {PollDemandResult} from '#core/demand.js';
 export function toPollDemandResponseDto(result: PollDemandResult): PollDemandResponseDto {
   return {
     stats: result.stats.map((stat) => ({
+      ...(stat.workspaceId ? {workspace_id: stat.workspaceId} : {}),
       labels: stat.labels,
       queued: stat.queued,
       reserved: stat.reserved,
@@ -11,6 +12,7 @@ export function toPollDemandResponseDto(result: PollDemandResult): PollDemandRes
     })),
     reservations: result.reservations.map((reservation) => ({
       reservation_id: reservation.reservationId,
+      ...(reservation.workspaceId ? {workspace_id: reservation.workspaceId} : {}),
       labels: reservation.labels,
       count: reservation.count,
       expires_at: reservation.expiresAt.toISOString(),

--- a/libs/api/runners/src/presentation/routes/poll-demand.test.ts
+++ b/libs/api/runners/src/presentation/routes/poll-demand.test.ts
@@ -401,7 +401,9 @@ describe('POST /provisioners/demand/poll with installation provisioning configur
         fakeProvisionerAuth,
       ],
       routes: createRunnerRoutes(runnersTestAuthClient, {
-        installationProvisioning: {policy: {filterEligibleWorkspaceIds: vi.fn()}},
+        installationProvisioning: {
+          policy: {filterEligibleWorkspaceIds: vi.fn().mockResolvedValue(new Set())},
+        },
       }),
       swagger: false,
     });
@@ -417,7 +419,7 @@ describe('POST /provisioners/demand/poll with installation provisioning configur
     provisionerTokenId = crypto.randomUUID();
   });
 
-  it('returns 501 for installation provisioner credentials', async () => {
+  it('returns opaque empty demand when no workspace is eligible', async () => {
     const res = await app.inject({
       method: 'POST',
       url: '/provisioners/demand/poll',
@@ -425,8 +427,8 @@ describe('POST /provisioners/demand/poll with installation provisioning configur
       payload: body({max_reservations: 1}),
     });
 
-    expect(res.statusCode).toBe(501);
-    expect(res.json().code).toBe('installation-provisioning-unavailable');
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({stats: [], reservations: [], terminate_provider_runner_ids: []});
   });
 
   it('still serves workspace provisioner credentials', async () => {

--- a/libs/api/runners/src/presentation/routes/poll-demand.ts
+++ b/libs/api/runners/src/presentation/routes/poll-demand.ts
@@ -2,16 +2,32 @@ import {
   requireProvisionerContext,
   requireWorkspaceProvisionerContext,
 } from '@shipfox/api-auth-context';
+import type {PollDemandTemplateDto} from '@shipfox/api-runners-dto';
 import {pollDemandBodySchema, pollDemandResponseSchema} from '@shipfox/api-runners-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {config} from '#config.js';
 import {pollDemand, releaseReservationGrants} from '#core/demand.js';
 import {publishWorkspaceProvisionerCapabilitySnapshot} from '#db/provisioner-capability-snapshots.js';
-import type {ReservationGrant} from '#db/reservations.js';
+import {
+  listQueuedDemandWorkspaceIds,
+  pollInstallationDemandAndReserve,
+  type ReservationGrant,
+  type ReservationTemplate,
+} from '#db/reservations.js';
 import type {CreateRunnersModuleOptions} from '#installation-provisioning.js';
 import {toPollDemandResponseDto} from '#presentation/dto/index.js';
 
 const TERMINATE_INTENT_LIMIT = 1000;
+
+function toReservationTemplates(templates: PollDemandTemplateDto[]): ReservationTemplate[] {
+  return templates.map((template) => ({
+    templateKey: template.template_key,
+    labels: template.labels,
+    availableSlots: template.available_slots,
+    starting: template.starting,
+    running: template.running,
+  }));
+}
 
 export function createPollDemandRoute(options: CreateRunnersModuleOptions = {}) {
   return defineRoute({
@@ -25,19 +41,6 @@ export function createPollDemandRoute(options: CreateRunnersModuleOptions = {}) 
       },
     },
     handler: async (request, reply) => {
-      const provisionerContext = requireProvisionerContext(request);
-      // A host that configures installationProvisioning is opting in to installation-scoped
-      // demand polling, but this route doesn't apply the eligibility policy yet: fail loudly
-      // instead of silently ignoring it. Hosts that never opt in fall through to the
-      // requireWorkspaceProvisionerContext 403 below, same as before this option existed.
-      if (provisionerContext.scope === 'installation' && options.installationProvisioning) {
-        throw new ClientError(
-          'Installation demand allocation is unavailable',
-          'installation-provisioning-unavailable',
-          {status: 501},
-        );
-      }
-      const {provisionerTokenId, workspaceId} = requireWorkspaceProvisionerContext(request);
       const abortController = new AbortController();
       let responseFinished = false;
       let responseReservations: ReservationGrant[] = [];
@@ -50,14 +53,43 @@ export function createPollDemandRoute(options: CreateRunnersModuleOptions = {}) 
           void releaseReservationGrants(responseReservations).catch(() => undefined);
         }
       });
+      const provisionerContext = requireProvisionerContext(request);
+      if (provisionerContext.scope === 'installation') {
+        if (!options.installationProvisioning) {
+          throw new ClientError(
+            'Installation provisioner credentials are not accepted on this host',
+            'forbidden',
+            {
+              status: 403,
+            },
+          );
+        }
+        const candidateWorkspaceIds = await listQueuedDemandWorkspaceIds();
+        const eligibleWorkspaceIds =
+          await options.installationProvisioning.policy.filterEligibleWorkspaceIds(
+            candidateWorkspaceIds,
+          );
+        const templates = toReservationTemplates(request.body.templates);
+        const result = await pollInstallationDemandAndReserve({
+          provisionerId: provisionerContext.provisionerTokenId,
+          maxReservations: request.body.max_reservations,
+          ttlSeconds: config.RESERVATION_TTL_SECONDS,
+          templates,
+          capabilityWindowSeconds: config.PROVISIONER_ACTIVE_WINDOW_SECONDS,
+          eligibleWorkspaceIds,
+          signal: abortController.signal,
+          onReservations: (reservations) => {
+            responseReservations.push(...reservations);
+          },
+        });
+        return toPollDemandResponseDto({
+          ...result,
+          terminateRunnerInstanceIds: [],
+        });
+      }
+      const {provisionerTokenId, workspaceId} = requireWorkspaceProvisionerContext(request);
 
-      const templates = request.body.templates.map((template) => ({
-        templateKey: template.template_key,
-        labels: template.labels,
-        availableSlots: template.available_slots,
-        starting: template.starting,
-        running: template.running,
-      }));
+      const templates = toReservationTemplates(request.body.templates);
       await publishWorkspaceProvisionerCapabilitySnapshot({
         workspaceId,
         provisionerId: provisionerTokenId,


### PR DESCRIPTION
Adds installation-scoped polling that discovers host-approved workspace demand and grants opaque aggregate reservations.

Managed runners must serve as fallback rather than overflow. The allocator rechecks active customer-owned capability after each workspace lock, treats busy and zero-slot capability as present, preserves fair workspace ordering, and shares template capacity across every granted reservation. Disconnects release grants already created during an installation poll.

The host policy remains the only source of eligibility, so this generic package neither learns commercial entitlement rules nor exposes workflow data, secrets, or customer credentials to provisioners.

Fixes ENG-1088

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds installation-scoped fallback demand allocation: installation provisioners can reserve across eligible workspaces while preserving workspace capability precedence and aggregate template limits. Fixes ENG-1088.

- **New Features**
  - `POST /provisioners/demand/poll` serves installation-scope tokens when installation provisioning is enabled; if no workspace is eligible, returns empty demand.
  - Filters by host eligibility and excludes workspaces with active workspace capability (fallback, not overflow).
  - Allocates in oldest-demand order across eligible workspaces; shares template capacity across grants to avoid oversell.
  - Supports aborting installation polls: committed grants are reported before the abort; unreported grants are released on disconnect.
  - Response adds optional `workspace_id` on stats and reservations in `@shipfox/api-runners-dto`.

- **Migration**
  - To use installation provisioning, enable it on the host and implement `policy.filterEligibleWorkspaceIds`; otherwise installation tokens receive 403.
  - Consumers should accept the new optional `workspace_id` fields.

<sup>Written for commit 12b4cd76be2be377440ec53ad12426bc9dec14ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

