### PR TITLE
[api/workspaces] Add workspace created domain event

### DIFF
--- a/.changeset/fresh-cats-create.md
+++ b/.changeset/fresh-cats-create.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-workspaces-dto": minor
+---
+
+Add a workspace-created domain event.

--- a/libs/api/workspaces-dto/src/events.ts
+++ b/libs/api/workspaces-dto/src/events.ts
@@ -1,6 +1,7 @@
 import {z} from 'zod';
 
 export const WORKSPACES_INVITATION_SEND_REQUESTED = 'workspaces.invitation.send_requested' as const;
+export const WORKSPACES_WORKSPACE_CREATED = 'workspaces.workspace.created' as const;
 
 export const workspacesInvitationSendRequestedSchema = z.object({
   email: z.string().email(),
@@ -12,10 +13,19 @@ export type WorkspacesInvitationSendRequestedEvent = z.infer<
   typeof workspacesInvitationSendRequestedSchema
 >;
 
+export const workspaceCreatedEventSchema = z.object({
+  workspaceId: z.string().nonempty(),
+  name: z.string().nonempty(),
+  creatorUserId: z.string().nonempty(),
+});
+export type WorkspaceCreatedEvent = z.infer<typeof workspaceCreatedEventSchema>;
+
 export interface WorkspacesEventMap {
   [WORKSPACES_INVITATION_SEND_REQUESTED]: WorkspacesInvitationSendRequestedEvent;
+  [WORKSPACES_WORKSPACE_CREATED]: WorkspaceCreatedEvent;
 }
 
 export const workspacesEventSchemas = {
   [WORKSPACES_INVITATION_SEND_REQUESTED]: workspacesInvitationSendRequestedSchema,
+  [WORKSPACES_WORKSPACE_CREATED]: workspaceCreatedEventSchema,
 } satisfies Record<keyof WorkspacesEventMap, z.ZodType>;

--- a/libs/api/workspaces-dto/src/schemas/index.ts
+++ b/libs/api/workspaces-dto/src/schemas/index.ts
@@ -1,7 +1,10 @@
 export {
   WORKSPACES_INVITATION_SEND_REQUESTED,
+  WORKSPACES_WORKSPACE_CREATED,
+  type WorkspaceCreatedEvent,
   type WorkspacesEventMap,
   type WorkspacesInvitationSendRequestedEvent,
+  workspaceCreatedEventSchema,
   workspacesEventSchemas,
   workspacesInvitationSendRequestedSchema,
 } from '../events.js';

--- a/libs/api/workspaces/src/core/workspaces.test.ts
+++ b/libs/api/workspaces/src/core/workspaces.test.ts
@@ -1,4 +1,8 @@
+import {WORKSPACES_WORKSPACE_CREATED} from '@shipfox/api-workspaces-dto';
+import {sql} from 'drizzle-orm';
+import {db} from '#db/db.js';
 import {findMembership} from '#db/memberships.js';
+import {workspacesOutbox} from '#db/schema/outbox.js';
 import {userFactory} from '#test/index.js';
 import {MembershipRequiredError, WorkspaceNotFoundError} from './errors.js';
 import {createWorkspaceForUser, requireWorkspaceMembership} from './workspaces.js';
@@ -17,6 +21,30 @@ describe('workspaces core', () => {
 
     expect(workspace.name).toBe('Core Workspace');
     expect(membership).toBeDefined();
+  });
+
+  test('createWorkspaceForUser emits a workspace created event in the transaction', async () => {
+    const user = userFactory.build();
+
+    const workspace = await createWorkspaceForUser({
+      name: 'Evented Workspace',
+      userId: user.userId,
+      userEmail: user.email,
+      userName: user.name,
+    });
+    const [event] = await db()
+      .select()
+      .from(workspacesOutbox)
+      .where(sql`${workspacesOutbox.payload}->>'workspaceId' = ${workspace.id}`);
+
+    expect(event).toMatchObject({
+      eventType: WORKSPACES_WORKSPACE_CREATED,
+      payload: {
+        workspaceId: workspace.id,
+        name: workspace.name,
+        creatorUserId: user.userId,
+      },
+    });
   });
 
   test('requireWorkspaceMembership returns the workspace + role when memberships include it', async () => {

--- a/libs/api/workspaces/src/core/workspaces.ts
+++ b/libs/api/workspaces/src/core/workspaces.ts
@@ -1,5 +1,10 @@
 import type {UserContextMembership} from '@shipfox/api-auth-context';
-import type {WorkspaceRole} from '@shipfox/api-workspaces-dto';
+import {
+  WORKSPACES_WORKSPACE_CREATED,
+  type WorkspaceRole,
+  type WorkspacesEventMap,
+} from '@shipfox/api-workspaces-dto';
+import {writeOutboxEvent} from '@shipfox/node-outbox';
 import {db} from '#db/db.js';
 import {
   findMembership,
@@ -10,6 +15,7 @@ import {
   removeMembership,
 } from '#db/memberships.js';
 import {memberships} from '#db/schema/memberships.js';
+import {workspacesOutbox} from '#db/schema/outbox.js';
 import {toWorkspace, workspaces} from '#db/schema/workspaces.js';
 import {getWorkspaceById} from '#db/workspaces.js';
 import type {Workspace} from './entities/workspace.js';
@@ -68,7 +74,18 @@ export async function createWorkspaceForUser(params: {
       userName: params.userName ?? null,
       workspaceId: workspaceRow.id,
     });
-    return toWorkspace(workspaceRow);
+    const workspace = toWorkspace(workspaceRow);
+
+    await writeOutboxEvent<WorkspacesEventMap>(tx, workspacesOutbox, {
+      type: WORKSPACES_WORKSPACE_CREATED,
+      payload: {
+        workspaceId: workspace.id,
+        name: workspace.name,
+        creatorUserId: params.userId,
+      },
+    });
+
+    return workspace;
   });
 }
 

--- a/libs/api/workspaces/src/index.test.ts
+++ b/libs/api/workspaces/src/index.test.ts
@@ -1,5 +1,6 @@
 import {
   WORKSPACES_INVITATION_SEND_REQUESTED,
+  WORKSPACES_WORKSPACE_CREATED,
   workspacesEventSchemas,
 } from '@shipfox/api-workspaces-dto';
 import {workspacesModule} from './index.js';
@@ -15,13 +16,14 @@ vi.mock('@shipfox/node-mailer', () => ({
 }));
 
 describe('workspacesModule', () => {
-  test('registers workspace invitation outbox publisher and subscriber', () => {
+  test('registers workspace outbox publisher and invitation subscriber', () => {
     const publisher = workspacesModule.publishers?.find((pub) => pub.name === 'workspaces');
     const events = workspacesModule.subscribers?.map((subscriber) => subscriber.event);
 
     expect(publisher?.eventSchemas).toBe(workspacesEventSchemas);
     expect(Object.keys(publisher?.eventSchemas ?? {})).toEqual([
       WORKSPACES_INVITATION_SEND_REQUESTED,
+      WORKSPACES_WORKSPACE_CREATED,
     ]);
     expect(events).toContain(WORKSPACES_INVITATION_SEND_REQUESTED);
   });


### PR DESCRIPTION
Adds the generic `workspaces.workspace.created` outbox contract and emits it in the same transaction that creates a workspace and its initial membership.

Workspace creation previously had no lifecycle signal, leaving downstream subscribers unable to react without coupling to workspace internals. The event exposes only the workspace, its name, and its creator, keeping the OSS contract strategy-neutral.

The existing workspaces publisher already drains the module outbox, so no new registration or integration path is required.

Closes ENG-1108

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit a `workspaces.workspace.created` outbox event when a workspace is created so downstream services can react without coupling to workspace internals. The event is written in the same transaction as workspace and membership creation and uses the existing workspaces publisher; no new wiring. Closes ENG-1108.

- **New Features**
  - Added `WORKSPACES_WORKSPACE_CREATED` and `workspaceCreatedEventSchema` to `@shipfox/api-workspaces-dto`, and updated the event map/schemas.
  - Emit the event from `createWorkspaceForUser` via `writeOutboxEvent` (`@shipfox/node-outbox`) with payload: `workspaceId`, `name`, `creatorUserId`.
  - Updated tests to assert event emission and module registration; added a changeset for a minor bump in `@shipfox/api-workspaces-dto`.

<sup>Written for commit 755d78f5141e6cf195b885653533073ca4161a62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

