### PR TITLE
[api/workspaces] Add membership lifecycle events

### DIFF
--- a/.changeset/gentle-members-emit.md
+++ b/.changeset/gentle-members-emit.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-workspaces": patch
+"@shipfox/api-workspaces-dto": minor
+---
+
+Adds workspace member invitation and join lifecycle events to the workspaces outbox.

--- a/libs/api/workspaces-dto/src/events.ts
+++ b/libs/api/workspaces-dto/src/events.ts
@@ -1,7 +1,10 @@
 import {z} from 'zod';
+import {workspaceRoleSchema} from './schemas/membership.js';
 
 export const WORKSPACES_INVITATION_SEND_REQUESTED = 'workspaces.invitation.send_requested' as const;
 export const WORKSPACES_WORKSPACE_CREATED = 'workspaces.workspace.created' as const;
+export const WORKSPACES_MEMBER_INVITED = 'workspaces.member.invited' as const;
+export const WORKSPACES_MEMBER_JOINED = 'workspaces.member.joined' as const;
 
 export const workspacesInvitationSendRequestedSchema = z.object({
   email: z.string().email(),
@@ -20,12 +23,32 @@ export const workspaceCreatedEventSchema = z.object({
 });
 export type WorkspaceCreatedEvent = z.infer<typeof workspaceCreatedEventSchema>;
 
+export const workspacesMemberInvitedSchema = z.object({
+  workspaceId: z.string().uuid(),
+  invitedEmail: z.string().email(),
+  inviterUserId: z.string().uuid(),
+  role: workspaceRoleSchema,
+});
+export type WorkspacesMemberInvitedEvent = z.infer<typeof workspacesMemberInvitedSchema>;
+
+export const workspacesMemberJoinedSchema = z.object({
+  workspaceId: z.string().uuid(),
+  userId: z.string().uuid(),
+  email: z.string().email(),
+  viaInvitation: z.boolean(),
+});
+export type WorkspacesMemberJoinedEvent = z.infer<typeof workspacesMemberJoinedSchema>;
+
 export interface WorkspacesEventMap {
   [WORKSPACES_INVITATION_SEND_REQUESTED]: WorkspacesInvitationSendRequestedEvent;
   [WORKSPACES_WORKSPACE_CREATED]: WorkspaceCreatedEvent;
+  [WORKSPACES_MEMBER_INVITED]: WorkspacesMemberInvitedEvent;
+  [WORKSPACES_MEMBER_JOINED]: WorkspacesMemberJoinedEvent;
 }
 
 export const workspacesEventSchemas = {
   [WORKSPACES_INVITATION_SEND_REQUESTED]: workspacesInvitationSendRequestedSchema,
   [WORKSPACES_WORKSPACE_CREATED]: workspaceCreatedEventSchema,
+  [WORKSPACES_MEMBER_INVITED]: workspacesMemberInvitedSchema,
+  [WORKSPACES_MEMBER_JOINED]: workspacesMemberJoinedSchema,
 } satisfies Record<keyof WorkspacesEventMap, z.ZodType>;

--- a/libs/api/workspaces-dto/src/schemas/index.ts
+++ b/libs/api/workspaces-dto/src/schemas/index.ts
@@ -1,12 +1,18 @@
 export {
   WORKSPACES_INVITATION_SEND_REQUESTED,
+  WORKSPACES_MEMBER_INVITED,
+  WORKSPACES_MEMBER_JOINED,
   WORKSPACES_WORKSPACE_CREATED,
   type WorkspaceCreatedEvent,
   type WorkspacesEventMap,
   type WorkspacesInvitationSendRequestedEvent,
+  type WorkspacesMemberInvitedEvent,
+  type WorkspacesMemberJoinedEvent,
   workspaceCreatedEventSchema,
   workspacesEventSchemas,
   workspacesInvitationSendRequestedSchema,
+  workspacesMemberInvitedSchema,
+  workspacesMemberJoinedSchema,
 } from '../events.js';
 export {
   type E2eCreateInvitationBodyDto,

--- a/libs/api/workspaces/src/db/invitations.test.ts
+++ b/libs/api/workspaces/src/db/invitations.test.ts
@@ -1,5 +1,6 @@
+import {WORKSPACES_MEMBER_INVITED, WORKSPACES_MEMBER_JOINED} from '@shipfox/api-workspaces-dto';
 import {hashOpaqueToken} from '@shipfox/node-tokens';
-import {eq, sql} from 'drizzle-orm';
+import {and, eq, sql} from 'drizzle-orm';
 import {OpenInvitationExistsError} from '#core/errors.js';
 import {db} from './db.js';
 import {
@@ -11,6 +12,7 @@ import {
 } from './invitations.js';
 import {invitations} from './schema/invitations.js';
 import {memberships} from './schema/memberships.js';
+import {workspacesOutbox} from './schema/outbox.js';
 import {createWorkspace} from './workspaces.js';
 
 function emailFor(suffix: string): string {
@@ -38,6 +40,39 @@ describe('invitations db', () => {
 
     expect(invitation.workspaceId).toBe(workspace.id);
     expect(invitation.acceptedAt).toBeNull();
+  });
+
+  test('writes the member invited event when email delivery is skipped', async () => {
+    const inviter = await createUser({email: emailFor('inviter')});
+    const workspace = await createWorkspace({name: `Workspace ${crypto.randomUUID()}`});
+    const invitedEmail = emailFor('guest');
+
+    await createInvitation({
+      workspaceId: workspace.id,
+      email: invitedEmail,
+      hashedToken: hashOpaqueToken('inv-event'),
+      expiresAt: new Date(Date.now() + 86_400_000),
+      invitedByUserId: inviter.userId,
+      skipEmail: true,
+    });
+
+    const events = await db()
+      .select()
+      .from(workspacesOutbox)
+      .where(
+        and(
+          eq(workspacesOutbox.eventType, WORKSPACES_MEMBER_INVITED),
+          sql`${workspacesOutbox.payload}->>'workspaceId' = ${workspace.id}`,
+        ),
+      );
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.payload).toEqual({
+      workspaceId: workspace.id,
+      invitedEmail,
+      inviterUserId: inviter.userId,
+      role: 'admin',
+    });
   });
 
   test('rejects when an unexpired open invite already exists', async () => {
@@ -121,6 +156,24 @@ describe('invitations db', () => {
       expect(result.membership.userId).toBe(accepter.userId);
       expect(result.alreadyMember).toBe(false);
     }
+
+    const events = await db()
+      .select()
+      .from(workspacesOutbox)
+      .where(
+        and(
+          eq(workspacesOutbox.eventType, WORKSPACES_MEMBER_JOINED),
+          sql`${workspacesOutbox.payload}->>'workspaceId' = ${workspace.id}`,
+        ),
+      );
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.payload).toEqual({
+      workspaceId: workspace.id,
+      userId: accepter.userId,
+      email: accepter.email,
+      viaInvitation: true,
+    });
   });
 
   test('reconcileInvitationAcceptance accepts an existing member', async () => {

--- a/libs/api/workspaces/src/db/invitations.ts
+++ b/libs/api/workspaces/src/db/invitations.ts
@@ -1,5 +1,7 @@
 import {
   WORKSPACES_INVITATION_SEND_REQUESTED,
+  WORKSPACES_MEMBER_INVITED,
+  WORKSPACES_MEMBER_JOINED,
   type WorkspacesEventMap,
 } from '@shipfox/api-workspaces-dto';
 import {writeOutboxEvent} from '@shipfox/node-outbox';
@@ -85,6 +87,15 @@ export async function createInvitation(params: CreateInvitationParams): Promise<
 
     const row = rows[0];
     if (!row) throw new Error('Insert returned no rows');
+    await writeOutboxEvent<WorkspacesEventMap>(tx, workspacesOutbox, {
+      type: WORKSPACES_MEMBER_INVITED,
+      payload: {
+        workspaceId: params.workspaceId,
+        invitedEmail: params.email,
+        inviterUserId: params.invitedByUserId,
+        role: 'admin',
+      },
+    });
     if (params.sendEmail) {
       await writeOutboxEvent<WorkspacesEventMap>(tx, workspacesOutbox, {
         type: WORKSPACES_INVITATION_SEND_REQUESTED,
@@ -214,6 +225,15 @@ export async function reconcileInvitationAcceptance(params: {
       const createdRow = created[0];
       if (!createdRow) throw new Error('Insert returned no rows');
       membership = toMembership(createdRow);
+      await writeOutboxEvent<WorkspacesEventMap>(tx, workspacesOutbox, {
+        type: WORKSPACES_MEMBER_JOINED,
+        payload: {
+          workspaceId: invitation.workspaceId,
+          userId: params.acceptedByUserId,
+          email: invitation.email,
+          viaInvitation: true,
+        },
+      });
     }
 
     const updated = await tx

--- a/libs/api/workspaces/src/index.test.ts
+++ b/libs/api/workspaces/src/index.test.ts
@@ -1,5 +1,7 @@
 import {
   WORKSPACES_INVITATION_SEND_REQUESTED,
+  WORKSPACES_MEMBER_INVITED,
+  WORKSPACES_MEMBER_JOINED,
   WORKSPACES_WORKSPACE_CREATED,
   workspacesEventSchemas,
 } from '@shipfox/api-workspaces-dto';
@@ -24,6 +26,8 @@ describe('workspacesModule', () => {
     expect(Object.keys(publisher?.eventSchemas ?? {})).toEqual([
       WORKSPACES_INVITATION_SEND_REQUESTED,
       WORKSPACES_WORKSPACE_CREATED,
+      WORKSPACES_MEMBER_INVITED,
+      WORKSPACES_MEMBER_JOINED,
     ]);
     expect(events).toContain(WORKSPACES_INVITATION_SEND_REQUESTED);
   });


### PR DESCRIPTION
Add durable `workspaces.member.invited` and `workspaces.member.joined` outbox events, with shared DTO schemas and event-map exports.

Growth and other downstream consumers need generic membership lifecycle signals that do not depend on invitation email delivery. The invitation event is written on both delivery paths, while the join event is written only when accepting an invitation creates a membership.

The current workspace membership model is admin-only, so the invitation payload uses the existing canonical `admin` role schema rather than introducing new role persistence.

Closes ENG-1109

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds durable workspace membership lifecycle events so Growth and other consumers can track invites and joins without relying on email. Implements ENG-1109 by emitting `workspaces.member.invited` and `workspaces.member.joined` with shared DTO schemas.

- **New Features**
  - Emit `workspaces.member.invited` in `createInvitation` on all paths (including `skipEmail`); payload: `workspaceId`, `invitedEmail`, `inviterUserId`, `role` (`admin`).
  - Emit `workspaces.member.joined` in `reconcileInvitationAcceptance` when a membership row is created; payload: `workspaceId`, `userId`, `email`, `viaInvitation`.
  - Export constants, schemas, and types in `@shipfox/api-workspaces-dto` via `workspacesEventSchemas` and `WorkspacesEventMap`; tests verify outbox writes occur in the same transaction and the module publisher exposes the new events.

<sup>Written for commit 7573bef6ff2818e3c28bf4de2a1e80db48c2e297. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

