### PR TITLE
[api/auth] Add signed-up domain event

### DIFF
--- a/.changeset/bright-otters-enroll.md
+++ b/.changeset/bright-otters-enroll.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-auth-dto": minor
+---
+
+Adds the auth user signed-up event contract for durable signup lifecycle integrations.

--- a/libs/api/auth-dto/src/events.ts
+++ b/libs/api/auth-dto/src/events.ts
@@ -3,6 +3,7 @@ import {z} from 'zod';
 const emailLinkSchema = z.string().url();
 
 export const AUTH_PASSWORD_RESET_SEND_REQUESTED = 'auth.password_reset.send_requested' as const;
+export const AUTH_USER_SIGNED_UP = 'auth.user.signed_up' as const;
 
 export const authPasswordResetSendRequestedSchema = z.object({
   email: z.string().email(),
@@ -13,10 +14,20 @@ export type AuthPasswordResetSendRequestedEvent = z.infer<
   typeof authPasswordResetSendRequestedSchema
 >;
 
+export const authUserSignedUpSchema = z.object({
+  userId: z.string(),
+  email: z.string().email(),
+  name: z.string().optional(),
+  viaInvitation: z.boolean(),
+});
+export type AuthUserSignedUpEvent = z.infer<typeof authUserSignedUpSchema>;
+
 export interface AuthEventMap {
   [AUTH_PASSWORD_RESET_SEND_REQUESTED]: AuthPasswordResetSendRequestedEvent;
+  [AUTH_USER_SIGNED_UP]: AuthUserSignedUpEvent;
 }
 
 export const authEventSchemas = {
   [AUTH_PASSWORD_RESET_SEND_REQUESTED]: authPasswordResetSendRequestedSchema,
+  [AUTH_USER_SIGNED_UP]: authUserSignedUpSchema,
 } satisfies Record<keyof AuthEventMap, z.ZodType>;

--- a/libs/api/auth-dto/src/schemas/index.ts
+++ b/libs/api/auth-dto/src/schemas/index.ts
@@ -1,9 +1,12 @@
 export {
   AUTH_PASSWORD_RESET_SEND_REQUESTED,
+  AUTH_USER_SIGNED_UP,
   type AuthEventMap,
   type AuthPasswordResetSendRequestedEvent,
+  type AuthUserSignedUpEvent,
   authEventSchemas,
   authPasswordResetSendRequestedSchema,
+  authUserSignedUpSchema,
 } from '../events.js';
 export {
   type ChangePasswordBodyDto,

--- a/libs/api/auth/src/core/auth.test.ts
+++ b/libs/api/auth/src/core/auth.test.ts
@@ -1,4 +1,4 @@
-import {AUTH_PASSWORD_RESET_SEND_REQUESTED} from '@shipfox/api-auth-dto';
+import {AUTH_PASSWORD_RESET_SEND_REQUESTED, AUTH_USER_SIGNED_UP} from '@shipfox/api-auth-dto';
 import {userAccessTokenKey} from '@shipfox/node-auth-root-key';
 import type {Mailer, MailMessage} from '@shipfox/node-mailer';
 import {hashOpaqueToken} from '@shipfox/node-tokens';
@@ -14,6 +14,7 @@ import {
   provisionUser,
   requestPasswordReset,
   signup,
+  signupWithInvitation,
 } from '#core/auth.js';
 import {
   AuthDependencyUnavailableError,
@@ -136,6 +137,15 @@ describe('auth core', () => {
     expect(user.emailChallenge.id).toEqual(expect.any(String));
     expect(user.emailChallenge.nextResendAvailableAt).toBeInstanceOf(Date);
     expect(captured).toHaveLength(1);
+
+    const events = await outboxEventsTo(email, AUTH_USER_SIGNED_UP);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.payload).toEqual({
+      userId: user.id,
+      email,
+      name: 'Sign Up',
+      viaInvitation: false,
+    });
   });
 
   test('signup rejects duplicate email with a business error', async () => {
@@ -147,6 +157,33 @@ describe('auth core', () => {
     });
 
     await expect(promise).rejects.toBeInstanceOf(EmailTakenError);
+  });
+
+  test('signup with an invitation writes the signed-up event with its user insert', async () => {
+    const email = `signup-invitation-${crypto.randomUUID()}@example.com`;
+    const userId = crypto.randomUUID();
+    const workspaceId = crypto.randomUUID();
+    workspaces.preflightInvitationAcceptance.mockResolvedValueOnce(undefined);
+    workspaces.acceptInvitation.mockResolvedValueOnce({
+      membership: {id: crypto.randomUUID(), userId, workspaceId},
+    });
+
+    const result = await signupWithInvitation({
+      email,
+      password: 'correct horse battery staple',
+      name: 'Invited User',
+      invitationToken: `invite-${crypto.randomUUID()}`,
+      workspaces,
+    });
+
+    const events = await outboxEventsTo(email, AUTH_USER_SIGNED_UP);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.payload).toEqual({
+      userId: result.user.id,
+      email,
+      name: 'Invited User',
+      viaInvitation: true,
+    });
   });
 
   test('provisionUser creates a verified, password-less user with a normalized email', async () => {

--- a/libs/api/auth/src/core/auth.ts
+++ b/libs/api/auth/src/core/auth.ts
@@ -187,6 +187,7 @@ export async function signup(params: SignupParams & {sourceIp?: string}): Promis
     email: params.email,
     hashedPassword,
     name: params.name ?? null,
+    signedUp: {viaInvitation: false},
   });
 
   const emailChallenge = await createEmailChallenge({
@@ -236,6 +237,7 @@ export async function signupWithInvitation(
     hashedPassword,
     name: params.name ?? null,
     emailVerifiedAt: new Date(),
+    signedUp: {viaInvitation: true},
   });
 
   // Step 3: Accept the invitation through the workspaces module boundary.

--- a/libs/api/auth/src/db/users.ts
+++ b/libs/api/auth/src/db/users.ts
@@ -1,7 +1,10 @@
+import {AUTH_USER_SIGNED_UP, type AuthEventMap} from '@shipfox/api-auth-dto';
+import {writeOutboxEvent} from '@shipfox/node-outbox';
 import {eq} from 'drizzle-orm';
 import type {User} from '#core/entities/user.js';
 import {EmailTakenError} from '#core/errors.js';
 import {db} from './db.js';
+import {authOutbox} from './schema/outbox.js';
 import {toUser, type UserDb, users} from './schema/users.js';
 
 export interface CreateUserParams {
@@ -9,6 +12,7 @@ export interface CreateUserParams {
   hashedPassword: string | null;
   name?: string | null;
   emailVerifiedAt?: Date | null;
+  signedUp?: {viaInvitation: boolean};
 }
 
 export interface ProvisionUserParams {
@@ -29,27 +33,41 @@ function isAuthUsersEmailUniqueViolation(error: unknown): boolean {
 }
 
 export async function createUser(params: CreateUserParams): Promise<User> {
-  let rows: UserDb[];
   try {
-    rows = await db()
-      .insert(users)
-      .values({
-        email: params.email,
-        hashedPassword: params.hashedPassword,
-        name: params.name ?? null,
-        emailVerifiedAt: params.emailVerifiedAt ?? null,
-      })
-      .returning();
+    return await db().transaction(async (tx) => {
+      const rows: UserDb[] = await tx
+        .insert(users)
+        .values({
+          email: params.email,
+          hashedPassword: params.hashedPassword,
+          name: params.name ?? null,
+          emailVerifiedAt: params.emailVerifiedAt ?? null,
+        })
+        .returning();
+
+      const row = rows[0];
+      if (!row) throw new Error('Insert returned no rows');
+
+      const user = toUser(row);
+      if (params.signedUp) {
+        await writeOutboxEvent<AuthEventMap>(tx, authOutbox, {
+          type: AUTH_USER_SIGNED_UP,
+          payload: {
+            userId: user.id,
+            email: user.email,
+            ...(user.name ? {name: user.name} : {}),
+            viaInvitation: params.signedUp.viaInvitation,
+          },
+        });
+      }
+      return user;
+    });
   } catch (error) {
     if (isAuthUsersEmailUniqueViolation(error)) {
       throw new EmailTakenError(params.email);
     }
     throw error;
   }
-
-  const row = rows[0];
-  if (!row) throw new Error('Insert returned no rows');
-  return toUser(row);
 }
 
 export async function provisionUser(params: ProvisionUserParams): Promise<User> {

--- a/libs/api/auth/src/index.test.ts
+++ b/libs/api/auth/src/index.test.ts
@@ -1,4 +1,8 @@
-import {AUTH_PASSWORD_RESET_SEND_REQUESTED, authEventSchemas} from '@shipfox/api-auth-dto';
+import {
+  AUTH_PASSWORD_RESET_SEND_REQUESTED,
+  AUTH_USER_SIGNED_UP,
+  authEventSchemas,
+} from '@shipfox/api-auth-dto';
 import {createAuthModule} from './index.js';
 import {passwordLoginMethods} from './login-methods.js';
 
@@ -40,6 +44,7 @@ describe('authModule', () => {
     expect(publisher?.eventSchemas).toBe(authEventSchemas);
     expect(Object.keys(publisher?.eventSchemas ?? {}).sort()).toEqual([
       AUTH_PASSWORD_RESET_SEND_REQUESTED,
+      AUTH_USER_SIGNED_UP,
     ]);
     expect(events).toEqual(expect.arrayContaining([AUTH_PASSWORD_RESET_SEND_REQUESTED]));
   });


### PR DESCRIPTION
Adds the generic `auth.user.signed_up` outbox contract and emits it atomically whenever password signup creates a user, including invitation-based signup.

Cloud onboarding subscribers need a durable, provider-neutral signup signal. Keeping the event write in the user-insert transaction prevents a created account from being missed by downstream consumers.

The event intentionally contains only auth lifecycle data: user ID, email, optional name, and invitation origin. It does not introduce growth, analytics, or delivery-provider concerns into the OSS auth module.

Closes ENG-1107

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a durable outbox event `auth.user.signed_up` and emits it inside the user insert transaction for both normal and invitation signups, so downstream services can reliably react to new users. Fulfills ENG-1107 by providing a provider-neutral signup signal for cloud onboarding.

- **New Features**
  - Added `AUTH_USER_SIGNED_UP` and schema in `@shipfox/api-auth-dto` with payload: userId, email, optional name, viaInvitation.
  - Emit the event atomically in `createUser`; `signup` sets `viaInvitation=false`, `signupWithInvitation=true`.
  - Exposed in `authEventSchemas` and module publisher; added tests for both signup paths.

- **Dependencies**
  - `@shipfox/api-auth-dto`: minor release.

<sup>Written for commit b95b510fd3643aaf85926f2d1bf519b28b587ab4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

