### PR TITLE
Update TypeScript to 6.0.3

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -475,7 +475,7 @@ catalogs:
       specifier: 1.1.38
       version: 1.1.38
     typescript:
-      specifier: ~6.0.1-rc
+      specifier: ^6.0.3
       version: 6.0.3
     vaul:
       specifier: ^1.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -161,7 +161,7 @@ catalog:
   "tsx": "^4.22.4"
   "tw-animate-css": "^1.4.0"
   "typebox": "1.1.38"
-  "typescript": "~6.0.1-rc"
+  "typescript": "^6.0.3"
   "vaul": "^1.1.1"
   "vite": "^8.0.3"
   "vitest": "^4.1.5"


### PR DESCRIPTION
Update the workspace TypeScript catalog from the release candidate to the stable `^6.0.3` range.

This aligns the repository toolchain with the requested TypeScript 6 stable release while keeping the lockfile catalog metadata consistent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the workspace to the stable `typescript` `^6.0.3`. This replaces the RC and aligns the toolchain with the TS 6 release.

- **Dependencies**
  - Bump `typescript` from `~6.0.1-rc` to `^6.0.3` in `pnpm-workspace.yaml` and `pnpm-lock.yaml` catalogs.

<sup>Written for commit caaa7c68fb31ef2bf78521ece228784ac4f57575. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

