### PR TITLE
Increase CI concurrency on hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 40
     env:
-      SHIPFOX_TURBO_CONCURRENCY: "2"
+      SHIPFOX_TURBO_CONCURRENCY: "4"
 
     steps:
       - name: Check out repository
@@ -143,7 +143,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      SHIPFOX_TURBO_CONCURRENCY: "2"
+      # Reserve one of the runner's four CPUs for the API/client processes,
+      # Docker services, and Ollama-backed provider validation.
+      SHIPFOX_TURBO_CONCURRENCY: "3"
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
Use the four CPUs provided by GitHub-hosted runners for static verification instead of leaving half of the available capacity idle.

E2E concurrency increases from two to three tasks while retaining one CPU for its API/client processes, Docker services, and Ollama-backed provider validation. This improves suite parallelism without reintroducing the resource contention that made the E2E cap necessary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase CI concurrency on GitHub-hosted runners to use available CPU capacity and speed up checks. Static verification now runs with `SHIPFOX_TURBO_CONCURRENCY=4` (was 2); E2E runs with `SHIPFOX_TURBO_CONCURRENCY=3` (was 2) to reserve one CPU for API/client processes, Docker services, and Ollama-backed provider validation, improving parallelism without resource contention.

<sup>Written for commit 3fbc31045d81927255f93f12ddb5bd727db4a537. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

