### PR TITLE
[runner] Activate assigned runner instances

### DIFF
--- a/.changeset/bright-otters-activate.md
+++ b/.changeset/bright-otters-activate.md
@@ -1,0 +1,8 @@
+---
+"@shipfox/api-runners": minor
+"@shipfox/api-runners-dto": minor
+"@shipfox/node-tokens": minor
+"@shipfox/api-workflows": patch
+---
+
+Adds assigned runner activation and descendant provisioner revocation.

--- a/libs/api/runners-dto/src/index.ts
+++ b/libs/api/runners-dto/src/index.ts
@@ -109,6 +109,7 @@ export {
   reservationGrantSchema,
   revokeManualRegistrationTokenResponseSchema,
   revokeProvisionerTokenResponseSchema,
+  runnerAssignmentPollResponseSchema,
   runnerBootstrapExchangeBodySchema,
   runnerBootstrapExchangeResponseSchema,
   runnerControlHeartbeatResponseSchema,

--- a/libs/api/runners-dto/src/schemas/index.ts
+++ b/libs/api/runners-dto/src/schemas/index.ts
@@ -130,6 +130,7 @@ export {
   type RunnerBootstrapExchangeBodyDto,
   type RunnerBootstrapExchangeResponseDto,
   type RunnerEnrollmentBodyDto,
+  runnerAssignmentPollResponseSchema,
   runnerBootstrapExchangeBodySchema,
   runnerBootstrapExchangeResponseSchema,
   runnerControlHeartbeatResponseSchema,

--- a/libs/api/runners-dto/src/schemas/register.ts
+++ b/libs/api/runners-dto/src/schemas/register.ts
@@ -20,7 +20,7 @@ export const registerRunnerBodySchema = z.object({
 export const registerRunnerResponseSchema = z.object({
   session_token: z.string().min(1),
   session_id: z.string().uuid(),
-  mode: z.enum(['manual', 'ephemeral']),
+  mode: z.enum(['manual', 'ephemeral', 'activation']),
   max_claims: z.number().int().positive().nullable(),
 });
 

--- a/libs/api/runners-dto/src/schemas/runner-enrollment.ts
+++ b/libs/api/runners-dto/src/schemas/runner-enrollment.ts
@@ -36,6 +36,9 @@ export const attachRunnerControlProviderIdBodySchema = z
   .object({provider_runner_id: z.string().min(1).max(255)})
   .strict();
 export const runnerControlHeartbeatResponseSchema = z.object({ok: z.literal(true)});
+export const runnerAssignmentPollResponseSchema = z.object({
+  activation_token: z.string().min(1).nullable(),
+});
 
 export type RunnerBootstrapExchangeBodyDto = z.infer<typeof runnerBootstrapExchangeBodySchema>;
 export type CreateRunnerInstancesBodyDto = z.infer<typeof createRunnerInstancesBodySchema>;

--- a/libs/api/runners/drizzle/0000_initial.sql
+++ b/libs/api/runners/drizzle/0000_initial.sql
@@ -1,6 +1,6 @@
 CREATE TYPE "public"."runners_provider_runner_state" AS ENUM('starting', 'running', 'stopping', 'stopped', 'failed', 'terminated');--> statement-breakpoint
 CREATE TYPE "public"."runners_provisioner_scope" AS ENUM('workspace', 'installation');--> statement-breakpoint
-CREATE TYPE "public"."runners_runner_session_registration_token_kind" AS ENUM('manual', 'ephemeral');--> statement-breakpoint
+CREATE TYPE "public"."runners_runner_session_registration_token_kind" AS ENUM('manual', 'ephemeral', 'activation');--> statement-breakpoint
 CREATE TYPE "public"."runners_runner_session_scope" AS ENUM('workspace');--> statement-breakpoint
 CREATE TABLE "runners_capacity_assignments" (
 	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
@@ -104,6 +104,18 @@ CREATE TABLE "runners_runner_bootstrap_tokens" (
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
+CREATE TABLE "runners_runner_activation_tokens" (
+	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
+	"runner_instance_id" uuid NOT NULL,
+	"hashed_token" text NOT NULL,
+	"prefix" text NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"consumed_at" timestamp with time zone,
+	"revoked_at" timestamp with time zone,
+	"consumed_session_id" uuid,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
 CREATE TABLE "runners_runner_control_sessions" (
 	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
 	"runner_instance_id" uuid NOT NULL,
@@ -175,6 +187,7 @@ CREATE TABLE "runners_runner_sessions" (
 	"scope" "runners_runner_session_scope" DEFAULT 'workspace' NOT NULL,
 	"registration_token_id" uuid NOT NULL,
 	"registration_token_kind" "runners_runner_session_registration_token_kind" NOT NULL,
+	"runner_instance_id" uuid,
 	"provisioner_id" uuid,
 	"provider_runner_id" text,
 	"labels" text[] NOT NULL,
@@ -182,10 +195,11 @@ CREATE TABLE "runners_runner_sessions" (
 	"tool_capabilities_reported_at" timestamp with time zone,
 	"max_claims" integer,
 	"claims_used" integer DEFAULT 0 NOT NULL,
+	"revoked_at" timestamp with time zone,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
-	CONSTRAINT "runners_runner_sessions_claims_ck" CHECK ("runners_runner_sessions"."claims_used" >= 0 AND (("runners_runner_sessions"."registration_token_kind" = 'manual' AND "runners_runner_sessions"."max_claims" IS NULL) OR ("runners_runner_sessions"."registration_token_kind" = 'ephemeral' AND "runners_runner_sessions"."max_claims" IS NOT NULL AND "runners_runner_sessions"."max_claims" > 0 AND "runners_runner_sessions"."claims_used" <= "runners_runner_sessions"."max_claims"))),
-	CONSTRAINT "runners_runner_sessions_link_ck" CHECK ((("runners_runner_sessions"."registration_token_kind" = 'manual' AND "runners_runner_sessions"."provisioner_id" IS NULL AND "runners_runner_sessions"."provider_runner_id" IS NULL) OR ("runners_runner_sessions"."registration_token_kind" = 'ephemeral' AND "runners_runner_sessions"."provisioner_id" IS NOT NULL AND "runners_runner_sessions"."provider_runner_id" IS NOT NULL)))
+	CONSTRAINT "runners_runner_sessions_claims_ck" CHECK ("runners_runner_sessions"."claims_used" >= 0 AND (("runners_runner_sessions"."registration_token_kind" = 'manual' AND "runners_runner_sessions"."max_claims" IS NULL) OR ("runners_runner_sessions"."registration_token_kind" in ('ephemeral', 'activation') AND "runners_runner_sessions"."max_claims" IS NOT NULL AND "runners_runner_sessions"."max_claims" > 0 AND "runners_runner_sessions"."claims_used" <= "runners_runner_sessions"."max_claims"))),
+	CONSTRAINT "runners_runner_sessions_link_ck" CHECK ((("runners_runner_sessions"."registration_token_kind" = 'manual' AND "runners_runner_sessions"."runner_instance_id" IS NULL AND "runners_runner_sessions"."provisioner_id" IS NULL AND "runners_runner_sessions"."provider_runner_id" IS NULL) OR ("runners_runner_sessions"."registration_token_kind" = 'ephemeral' AND "runners_runner_sessions"."runner_instance_id" IS NULL AND "runners_runner_sessions"."provisioner_id" IS NOT NULL AND "runners_runner_sessions"."provider_runner_id" IS NOT NULL) OR ("runners_runner_sessions"."registration_token_kind" = 'activation' AND "runners_runner_sessions"."runner_instance_id" IS NOT NULL AND "runners_runner_sessions"."provisioner_id" IS NOT NULL AND "runners_runner_sessions"."provider_runner_id" IS NOT NULL)))
 );
 --> statement-breakpoint
 CREATE TABLE "runners_running_jobs" (
@@ -222,6 +236,8 @@ CREATE INDEX "runners_pending_jobs_workspace_created_idx" ON "runners_pending_jo
 CREATE INDEX "runners_pending_jobs_job_id_idx" ON "runners_pending_jobs" USING btree ("job_id");--> statement-breakpoint
 CREATE UNIQUE INDEX "runners_runner_instances_provisioner_runner_unique" ON "runners_runner_instances" USING btree ("provisioner_id","provider_runner_id") WHERE "provider_runner_id" is not null;--> statement-breakpoint
 CREATE UNIQUE INDEX "runners_runner_bootstrap_tokens_hashed_token_unique" ON "runners_runner_bootstrap_tokens" USING btree ("hashed_token");--> statement-breakpoint
+CREATE UNIQUE INDEX "runners_runner_activation_tokens_hashed_token_unique" ON "runners_runner_activation_tokens" USING btree ("hashed_token");--> statement-breakpoint
+CREATE INDEX "runners_runner_activation_tokens_runner_instance_idx" ON "runners_runner_activation_tokens" USING btree ("runner_instance_id");--> statement-breakpoint
 CREATE INDEX "runners_runner_bootstrap_tokens_runner_instance_idx" ON "runners_runner_bootstrap_tokens" USING btree ("runner_instance_id");--> statement-breakpoint
 CREATE UNIQUE INDEX "runners_runner_control_sessions_hashed_token_unique" ON "runners_runner_control_sessions" USING btree ("hashed_token");--> statement-breakpoint
 CREATE UNIQUE INDEX "runners_runner_control_sessions_active_runner_instance_unique" ON "runners_runner_control_sessions" USING btree ("runner_instance_id") WHERE "closed_at" is null;--> statement-breakpoint

--- a/libs/api/runners/src/config.ts
+++ b/libs/api/runners/src/config.ts
@@ -14,6 +14,18 @@ export const config = createConfig({
     desc: 'Lifetime of a pre-workspace runner-control session in seconds. This session can only enroll, attach its provider identity, and report its own liveness.',
     default: 3600,
   }),
+  RUNNER_ACTIVATION_TOKEN_TTL_SECONDS: num({
+    desc: 'Lifetime of a one-use activation token in seconds. The token is issued only to an assigned runner-control session and creates one workspace runner session.',
+    default: 300,
+  }),
+  RUNNER_ASSIGNMENT_POLL_MAX_WAIT_SECONDS: num({
+    desc: 'Maximum time the runner assignment poll waits before returning no assignment, in seconds.',
+    default: 30,
+  }),
+  RUNNER_ASSIGNMENT_POLL_INTERVAL_MS: num({
+    desc: 'Delay between durable assignment reads while a runner-control session waits for an assignment, in milliseconds.',
+    default: 1000,
+  }),
   EPHEMERAL_REGISTRATION_TOKEN_TTL_SECONDS: num({
     desc: `Lifetime of a provisioner-minted runner registration token, in seconds. The token can be exchanged once by a runner before this time passes. Set this between 1 and ${EPHEMERAL_REGISTRATION_TOKEN_TTL_HARD_MAX_SECONDS}.`,
     default: 300,
@@ -134,6 +146,7 @@ if (
 for (const [name, value] of [
   ['RUNNER_BOOTSTRAP_TOKEN_TTL_SECONDS', config.RUNNER_BOOTSTRAP_TOKEN_TTL_SECONDS],
   ['RUNNER_CONTROL_SESSION_TTL_SECONDS', config.RUNNER_CONTROL_SESSION_TTL_SECONDS],
+  ['RUNNER_ACTIVATION_TOKEN_TTL_SECONDS', config.RUNNER_ACTIVATION_TOKEN_TTL_SECONDS],
 ] as const) {
   if (
     !Number.isInteger(value) ||
@@ -144,6 +157,14 @@ for (const [name, value] of [
       `${name} (${value}) must be a whole number of seconds between 1 and ${RUNNER_CONTROL_PLANE_TOKEN_TTL_HARD_MAX_SECONDS}.`,
     );
   }
+}
+
+for (const [name, value] of [
+  ['RUNNER_ASSIGNMENT_POLL_MAX_WAIT_SECONDS', config.RUNNER_ASSIGNMENT_POLL_MAX_WAIT_SECONDS],
+  ['RUNNER_ASSIGNMENT_POLL_INTERVAL_MS', config.RUNNER_ASSIGNMENT_POLL_INTERVAL_MS],
+] as const) {
+  if (!Number.isInteger(value) || value < 0)
+    throw new Error(`${name} (${value}) must be a whole number >= 0.`);
 }
 
 if (

--- a/libs/api/runners/src/core/entities/runner-session.ts
+++ b/libs/api/runners/src/core/entities/runner-session.ts
@@ -5,7 +5,8 @@ export interface RunnerSession {
   workspaceId: string;
   scope: 'workspace';
   registrationTokenId: string;
-  registrationTokenKind: 'manual' | 'ephemeral';
+  registrationTokenKind: 'manual' | 'ephemeral' | 'activation';
+  runnerInstanceId: string | null;
   provisionerId: string | null;
   providerRunnerId: string | null;
   labels: string[];
@@ -13,6 +14,7 @@ export interface RunnerSession {
   toolCapabilitiesReportedAt: Date | null;
   maxClaims: number | null;
   claimsUsed: number;
+  revokedAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/libs/api/runners/src/core/index.ts
+++ b/libs/api/runners/src/core/index.ts
@@ -42,6 +42,7 @@ export {
   revokeInstallationProvisionerToken,
   revokeWorkspaceProvisionerToken,
 } from './provisioner-tokens.js';
+export {getRunnerAssignment, issueRunnerActivationToken} from './runner-activation.js';
 export {
   attachRunnerControlProviderId,
   createRunnerInstancesWithBootstrapTokens,

--- a/libs/api/runners/src/core/runner-activation.ts
+++ b/libs/api/runners/src/core/runner-activation.ts
@@ -1,0 +1,72 @@
+import {extractDisplayPrefix, generateOpaqueToken, hashOpaqueToken} from '@shipfox/node-tokens';
+import {and, eq, isNull, sql} from 'drizzle-orm';
+import {db} from '#db/db.js';
+import {runnerActivationTokens} from '#db/schema/runner-activation-tokens.js';
+import {providerRunners} from '#db/schema/runner-instances.js';
+
+export async function issueRunnerActivationToken(params: {
+  runnerInstanceId: string;
+  provisionerId: string;
+  ttlSeconds: number;
+}): Promise<string | null> {
+  return await db().transaction(async (tx) => {
+    await tx.execute(
+      sql`select pg_advisory_xact_lock(hashtext(${`runners_activation:${params.runnerInstanceId}`}))`,
+    );
+    const [runner] = await tx
+      .select({
+        workspaceId: providerRunners.workspaceId,
+        runnerSessionId: providerRunners.runnerSessionId,
+        state: providerRunners.state,
+      })
+      .from(providerRunners)
+      .where(
+        and(
+          eq(providerRunners.id, params.runnerInstanceId),
+          eq(providerRunners.provisionerId, params.provisionerId),
+        ),
+      )
+      .limit(1)
+      .for('update');
+    if (!runner?.workspaceId || runner.runnerSessionId || runner.state !== 'running') return null;
+
+    await tx
+      .update(runnerActivationTokens)
+      .set({revokedAt: sql`now()`})
+      .where(
+        and(
+          eq(runnerActivationTokens.runnerInstanceId, params.runnerInstanceId),
+          isNull(runnerActivationTokens.consumedAt),
+          isNull(runnerActivationTokens.revokedAt),
+        ),
+      );
+    const rawToken = generateOpaqueToken('runnerActivationToken');
+    await tx.insert(runnerActivationTokens).values({
+      runnerInstanceId: params.runnerInstanceId,
+      hashedToken: hashOpaqueToken(rawToken),
+      prefix: extractDisplayPrefix(rawToken),
+      expiresAt: new Date(Date.now() + params.ttlSeconds * 1000),
+    });
+    return rawToken;
+  });
+}
+
+export async function getRunnerAssignment(params: {
+  runnerInstanceId: string;
+  provisionerId: string;
+}) {
+  const [runner] = await db()
+    .select({
+      workspaceId: providerRunners.workspaceId,
+      runnerSessionId: providerRunners.runnerSessionId,
+    })
+    .from(providerRunners)
+    .where(
+      and(
+        eq(providerRunners.id, params.runnerInstanceId),
+        eq(providerRunners.provisionerId, params.provisionerId),
+      ),
+    )
+    .limit(1);
+  return runner?.workspaceId && !runner.runnerSessionId ? runner : null;
+}

--- a/libs/api/runners/src/core/runner-control-sessions.ts
+++ b/libs/api/runners/src/core/runner-control-sessions.ts
@@ -1,9 +1,10 @@
 import type {RunnerToolCapabilitiesDto} from '@shipfox/api-runners-dto';
 import {extractDisplayPrefix, generateOpaqueToken, hashOpaqueToken} from '@shipfox/node-tokens';
 import {canonicalizeLabels} from '@shipfox/runner-labels';
-import {and, eq, gt, isNull, notInArray, sql} from 'drizzle-orm';
+import {and, eq, gt, isNull, notInArray, or, sql} from 'drizzle-orm';
 import {db} from '#db/db.js';
 import {terminalStates} from '#db/runner-instances.js';
+import {provisionerTokens} from '#db/schema/provisioner-tokens.js';
 import {runnerBootstrapTokens, runnerControlSessions} from '#db/schema/runner-control-sessions.js';
 import {providerRunners} from '#db/schema/runner-instances.js';
 
@@ -96,12 +97,18 @@ export async function exchangeRunnerBootstrapToken(params: {
 
 export async function resolveRunnerControlSession(rawToken: string) {
   const [session] = await db()
-    .select()
+    .select({
+      id: runnerControlSessions.id,
+      runnerInstanceId: runnerControlSessions.runnerInstanceId,
+      provisionerId: runnerControlSessions.provisionerId,
+    })
     .from(runnerControlSessions)
+    .leftJoin(provisionerTokens, eq(provisionerTokens.id, runnerControlSessions.provisionerId))
     .where(
       and(
         eq(runnerControlSessions.hashedToken, hashOpaqueToken(rawToken)),
         isNull(runnerControlSessions.closedAt),
+        or(isNull(provisionerTokens.id), isNull(provisionerTokens.revokedAt)),
         gt(runnerControlSessions.expiresAt, sql`now()`),
       ),
     )

--- a/libs/api/runners/src/core/runner-sessions.test.ts
+++ b/libs/api/runners/src/core/runner-sessions.test.ts
@@ -2,6 +2,7 @@ import {verifyRunnerSessionToken} from '@shipfox/api-auth';
 import {and, eq} from 'drizzle-orm';
 import {db} from '#db/db.js';
 import {ephemeralRegistrationTokens} from '#db/schema/ephemeral-registration-tokens.js';
+import {runnerActivationTokens} from '#db/schema/runner-activation-tokens.js';
 import {providerRunners} from '#db/schema/runner-instances.js';
 import {runnerSessions} from '#db/schema/runner-sessions.js';
 import {
@@ -15,6 +16,7 @@ import {
   RegistrationTokenConsumedError,
   RegistrationTokenWorkspaceMismatchError,
 } from './errors.js';
+import {issueRunnerActivationToken} from './runner-activation.js';
 import {registerRunnerSession} from './runner-sessions.js';
 
 describe('registerRunnerSession', () => {
@@ -211,5 +213,87 @@ describe('registerRunnerSession', () => {
           claimsUsed: 0,
         }),
     ).rejects.toThrow();
+  });
+});
+
+describe('activation runner sessions', () => {
+  let workspaceId: string;
+  let provisionerId: string;
+  let runnerInstanceId: string;
+
+  beforeEach(async () => {
+    workspaceId = crypto.randomUUID();
+    provisionerId = crypto.randomUUID();
+    const runner = await providerRunnerFactory.create({workspaceId, provisionerId});
+    runnerInstanceId = runner.id;
+  });
+
+  it('replaces an unconsumed activation token when assignment delivery is retried', async () => {
+    const firstToken = await issueRunnerActivationToken({
+      runnerInstanceId,
+      provisionerId,
+      ttlSeconds: 60,
+    });
+    const replacementToken = await issueRunnerActivationToken({
+      runnerInstanceId,
+      provisionerId,
+      ttlSeconds: 60,
+    });
+
+    const tokens = await db()
+      .select()
+      .from(runnerActivationTokens)
+      .where(eq(runnerActivationTokens.runnerInstanceId, runnerInstanceId));
+
+    expect(firstToken).not.toBeNull();
+    expect(replacementToken).not.toBeNull();
+    expect(replacementToken).not.toBe(firstToken);
+    expect(tokens).toHaveLength(2);
+    expect(tokens.filter((token) => token.revokedAt === null)).toHaveLength(1);
+    expect(tokens.filter((token) => token.revokedAt !== null)).toHaveLength(1);
+  });
+
+  it('allows only one concurrent registration to consume an activation token', async () => {
+    const rawToken = await issueRunnerActivationToken({
+      runnerInstanceId,
+      provisionerId,
+      ttlSeconds: 60,
+    });
+    const [activationToken] = await db()
+      .select()
+      .from(runnerActivationTokens)
+      .where(eq(runnerActivationTokens.runnerInstanceId, runnerInstanceId));
+    if (!rawToken || !activationToken) throw new Error('Activation token was not created');
+
+    const registrations = await Promise.allSettled([
+      registerRunnerSession({
+        auth: runnersTestAuthClient,
+        credential: {kind: 'activation', activationTokenId: activationToken.id, workspaceId},
+        labels: ['linux'],
+      }),
+      registerRunnerSession({
+        auth: runnersTestAuthClient,
+        credential: {kind: 'activation', activationTokenId: activationToken.id, workspaceId},
+        labels: ['linux'],
+      }),
+    ]);
+
+    const [storedToken] = await db()
+      .select()
+      .from(runnerActivationTokens)
+      .where(eq(runnerActivationTokens.id, activationToken.id));
+    const sessions = await db()
+      .select()
+      .from(runnerSessions)
+      .where(eq(runnerSessions.runnerInstanceId, runnerInstanceId));
+
+    expect(
+      registrations.filter((registration) => registration.status === 'fulfilled'),
+    ).toHaveLength(1);
+    expect(registrations.filter((registration) => registration.status === 'rejected')).toHaveLength(
+      1,
+    );
+    expect(storedToken?.consumedAt).toBeInstanceOf(Date);
+    expect(sessions).toHaveLength(1);
   });
 });

--- a/libs/api/runners/src/core/runner-sessions.ts
+++ b/libs/api/runners/src/core/runner-sessions.ts
@@ -2,14 +2,17 @@ import type {AuthInterModuleClient} from '@shipfox/api-auth-dto/inter-module';
 import type {RunnerToolCapabilitiesDto} from '@shipfox/api-runners-dto';
 import {canonicalizeLabels} from '@shipfox/runner-labels';
 import {createRunnerSessionConsumingEphemeralToken} from '#db/ephemeral-registration-tokens.js';
-import {createRunnerSession} from '#db/runner-sessions.js';
+import {
+  createRunnerSession,
+  createRunnerSessionConsumingActivationToken,
+} from '#db/runner-sessions.js';
 import type {RunnerSession} from './entities/runner-session.js';
 import {EmptyRunnerLabelsError} from './errors.js';
 
 export interface RegisterRunnerSessionResult {
   session: RunnerSession;
   sessionToken: string;
-  mode: 'manual' | 'ephemeral';
+  mode: 'manual' | 'ephemeral' | 'activation';
   maxClaims: number | null;
 }
 
@@ -26,7 +29,8 @@ export type RunnerRegistrationCredential =
       provisionerId: string;
       reservationId: string | null;
       providerRunnerId: string;
-    };
+    }
+  | {kind: 'activation'; activationTokenId: string; workspaceId: string};
 
 export async function registerRunnerSession(params: {
   auth: AuthInterModuleClient;
@@ -38,7 +42,7 @@ export async function registerRunnerSession(params: {
   if (labels.length === 0) throw new EmptyRunnerLabelsError();
 
   const mode = params.credential.kind;
-  const maxClaims = params.credential.kind === 'ephemeral' ? 1 : null;
+  const maxClaims = params.credential.kind === 'manual' ? null : 1;
   const session =
     params.credential.kind === 'manual'
       ? await createRunnerSession({
@@ -48,13 +52,19 @@ export async function registerRunnerSession(params: {
           labels,
           toolCapabilities: params.toolCapabilities ?? null,
         })
-      : await createRunnerSessionConsumingEphemeralToken({
-          ephemeralTokenId: params.credential.ephemeralTokenId,
-          workspaceId: params.credential.workspaceId,
-          labels,
-          toolCapabilities: params.toolCapabilities ?? null,
-          maxClaims: 1,
-        });
+      : params.credential.kind === 'ephemeral'
+        ? await createRunnerSessionConsumingEphemeralToken({
+            ephemeralTokenId: params.credential.ephemeralTokenId,
+            workspaceId: params.credential.workspaceId,
+            labels,
+            toolCapabilities: params.toolCapabilities ?? null,
+            maxClaims: 1,
+          })
+        : await createRunnerSessionConsumingActivationToken({
+            activationTokenId: params.credential.activationTokenId,
+            labels,
+            toolCapabilities: params.toolCapabilities ?? null,
+          });
   const {token: sessionToken} = await params.auth.mintRunnerSessionToken({
     runnerSessionId: session.id,
     workspaceId: session.workspaceId,

--- a/libs/api/runners/src/db/db.ts
+++ b/libs/api/runners/src/db/db.ts
@@ -9,6 +9,7 @@ import {provisionerCapabilitySnapshots} from './schema/provisioner-capability-sn
 import {provisionerTokens} from './schema/provisioner-tokens.js';
 import {runnersRateLimits} from './schema/rate-limits.js';
 import {reservations} from './schema/reservations.js';
+import {runnerActivationTokens} from './schema/runner-activation-tokens.js';
 import {runnerBootstrapTokens, runnerControlSessions} from './schema/runner-control-sessions.js';
 import {providerRunners} from './schema/runner-instances.js';
 import {runnerSessions} from './schema/runner-sessions.js';
@@ -26,6 +27,7 @@ export const schema = {
   runnerSessions,
   runnerBootstrapTokens,
   runnerControlSessions,
+  runnerActivationTokens,
   manualRegistrationTokens,
   runningJobExecutions,
   runnersOutbox,

--- a/libs/api/runners/src/db/job-executions.ts
+++ b/libs/api/runners/src/db/job-executions.ts
@@ -152,6 +152,7 @@ export async function claimPendingJobExecution(params: {
         .select({
           maxClaims: runnerSessions.maxClaims,
           claimsUsed: runnerSessions.claimsUsed,
+          revokedAt: runnerSessions.revokedAt,
           provisionerId: runnerSessions.provisionerId,
           providerRunnerId: runnerSessions.providerRunnerId,
         })
@@ -160,7 +161,12 @@ export async function claimPendingJobExecution(params: {
         .limit(1)
         .for('update');
 
-      if (!session || session.maxClaims === null || session.claimsUsed >= session.maxClaims) {
+      if (
+        !session ||
+        session.revokedAt ||
+        session.maxClaims === null ||
+        session.claimsUsed >= session.maxClaims
+      ) {
         throw new RunnerSessionExhaustedError(params.runnerSessionId);
       }
 

--- a/libs/api/runners/src/db/provisioner-tokens.test.ts
+++ b/libs/api/runners/src/db/provisioner-tokens.test.ts
@@ -1,5 +1,5 @@
 import {hashOpaqueToken} from '@shipfox/node-tokens';
-import {sql} from 'drizzle-orm';
+import {eq, sql} from 'drizzle-orm';
 import {db} from '#db/db.js';
 import {
   createProvisionerToken,
@@ -10,7 +10,11 @@ import {
   touchProvisionerLastSeen,
 } from '#db/provisioner-tokens.js';
 import {provisionerTokens} from '#db/schema/provisioner-tokens.js';
-import {provisionerTokenFactory} from '#test/index.js';
+import {runnerActivationTokens} from '#db/schema/runner-activation-tokens.js';
+import {runnerBootstrapTokens, runnerControlSessions} from '#db/schema/runner-control-sessions.js';
+import {providerRunners} from '#db/schema/runner-instances.js';
+import {runnerSessions} from '#db/schema/runner-sessions.js';
+import {providerRunnerFactory, provisionerTokenFactory} from '#test/index.js';
 
 describe('provisioner token db', () => {
   it('creates and resolves a token', async () => {
@@ -96,6 +100,115 @@ describe('provisioner token db', () => {
     expect(revoked?.id).toBe(token.id);
     expect(revoked?.revokedAt).toBeInstanceOf(Date);
     expect(revoked?.revokedByUserId).toBe(revokedByUserId);
+  });
+
+  it("cascades revocation to the provisioner's unclaimed runner credentials and sessions", async () => {
+    const workspaceId = crypto.randomUUID();
+    const provisioner = await provisionerTokenFactory.create({workspaceId});
+    const runner = await providerRunnerFactory.create({
+      workspaceId,
+      provisionerId: provisioner.id,
+      runnerSessionId: null,
+    });
+    const future = new Date(Date.now() + 60_000);
+    const tokenValue = (name: string) => hashOpaqueToken(`${name}-${crypto.randomUUID()}`);
+    await db()
+      .insert(runnerBootstrapTokens)
+      .values({
+        runnerInstanceId: runner.id,
+        provisionerId: provisioner.id,
+        hashedToken: tokenValue('bootstrap'),
+        prefix: 'bootstrap',
+        expiresAt: future,
+      });
+    await db()
+      .insert(runnerControlSessions)
+      .values({
+        runnerInstanceId: runner.id,
+        provisionerId: provisioner.id,
+        hashedToken: tokenValue('control'),
+        prefix: 'control',
+        expiresAt: future,
+      });
+    await db()
+      .insert(runnerActivationTokens)
+      .values({
+        runnerInstanceId: runner.id,
+        hashedToken: tokenValue('activation'),
+        prefix: 'activation',
+        expiresAt: future,
+      });
+    const [unclaimedSession] = await db()
+      .insert(runnerSessions)
+      .values({
+        workspaceId,
+        scope: 'workspace',
+        registrationTokenId: crypto.randomUUID(),
+        registrationTokenKind: 'activation',
+        runnerInstanceId: runner.id,
+        provisionerId: provisioner.id,
+        providerRunnerId: runner.providerRunnerId,
+        labels: ['linux'],
+        maxClaims: 1,
+        claimsUsed: 0,
+      })
+      .returning();
+    const [claimedSession] = await db()
+      .insert(runnerSessions)
+      .values({
+        workspaceId,
+        scope: 'workspace',
+        registrationTokenId: crypto.randomUUID(),
+        registrationTokenKind: 'activation',
+        runnerInstanceId: crypto.randomUUID(),
+        provisionerId: provisioner.id,
+        providerRunnerId: crypto.randomUUID(),
+        labels: ['linux'],
+        maxClaims: 1,
+        claimsUsed: 1,
+      })
+      .returning();
+    if (!unclaimedSession || !claimedSession) throw new Error('Runner sessions were not created');
+
+    await revokeProvisionerToken({
+      tokenId: provisioner.id,
+      workspaceId,
+      revokedByUserId: crypto.randomUUID(),
+    });
+
+    const [bootstrap] = await db()
+      .select()
+      .from(runnerBootstrapTokens)
+      .where(eq(runnerBootstrapTokens.runnerInstanceId, runner.id));
+    const [control] = await db()
+      .select()
+      .from(runnerControlSessions)
+      .where(eq(runnerControlSessions.runnerInstanceId, runner.id));
+    const [activation] = await db()
+      .select()
+      .from(runnerActivationTokens)
+      .where(eq(runnerActivationTokens.runnerInstanceId, runner.id));
+    const [terminatedRunner] = await db()
+      .select()
+      .from(providerRunners)
+      .where(eq(providerRunners.id, runner.id));
+    const [revokedSession] = await db()
+      .select()
+      .from(runnerSessions)
+      .where(eq(runnerSessions.id, unclaimedSession.id));
+    const [preservedSession] = await db()
+      .select()
+      .from(runnerSessions)
+      .where(eq(runnerSessions.id, claimedSession.id));
+
+    expect(bootstrap?.revokedAt).toBeInstanceOf(Date);
+    expect(control).toMatchObject({closeReason: 'provisioner-revoked'});
+    expect(control?.closedAt).toBeInstanceOf(Date);
+    expect(activation?.revokedAt).toBeInstanceOf(Date);
+    expect(terminatedRunner).toMatchObject({state: 'terminated'});
+    expect(terminatedRunner?.terminatedAt).toBeInstanceOf(Date);
+    expect(revokedSession?.revokedAt).toBeInstanceOf(Date);
+    expect(preservedSession?.revokedAt).toBeNull();
   });
 
   it('preserves the original revocation audit fields on repeat revoke', async () => {

--- a/libs/api/runners/src/db/provisioner-tokens.ts
+++ b/libs/api/runners/src/db/provisioner-tokens.ts
@@ -1,4 +1,4 @@
-import {and, desc, eq, gt, isNull, or, sql} from 'drizzle-orm';
+import {and, desc, eq, gt, inArray, isNull, or, sql} from 'drizzle-orm';
 import type {
   ActiveProvisionerToken,
   ProvisionerScope,
@@ -6,6 +6,10 @@ import type {
 } from '#core/entities/provisioner-token.js';
 import {db} from './db.js';
 import {provisionerTokens, toProvisionerToken} from './schema/provisioner-tokens.js';
+import {runnerActivationTokens} from './schema/runner-activation-tokens.js';
+import {runnerBootstrapTokens, runnerControlSessions} from './schema/runner-control-sessions.js';
+import {providerRunners} from './schema/runner-instances.js';
+import {runnerSessions} from './schema/runner-sessions.js';
 
 export interface CreateProvisionerTokenParams {
   scope: ProvisionerScope;
@@ -15,6 +19,60 @@ export interface CreateProvisionerTokenParams {
   createdByUserId: string;
   name?: string | undefined;
   expiresAt?: Date | undefined;
+}
+
+async function cascadeProvisionerRevocation(
+  tx: Parameters<Parameters<ReturnType<typeof db>['transaction']>[0]>[0],
+  provisionerId: string,
+) {
+  await tx
+    .update(runnerBootstrapTokens)
+    .set({revokedAt: sql`now()`})
+    .where(eq(runnerBootstrapTokens.provisionerId, provisionerId));
+  await tx
+    .update(runnerControlSessions)
+    .set({closedAt: sql`now()`, closeReason: 'provisioner-revoked'})
+    .where(
+      and(
+        eq(runnerControlSessions.provisionerId, provisionerId),
+        isNull(runnerControlSessions.closedAt),
+      ),
+    );
+  await tx
+    .update(runnerActivationTokens)
+    .set({revokedAt: sql`now()`})
+    .where(
+      and(
+        isNull(runnerActivationTokens.consumedAt),
+        isNull(runnerActivationTokens.revokedAt),
+        inArray(
+          runnerActivationTokens.runnerInstanceId,
+          tx
+            .select({id: providerRunners.id})
+            .from(providerRunners)
+            .where(eq(providerRunners.provisionerId, provisionerId)),
+        ),
+      ),
+    );
+  await tx
+    .update(providerRunners)
+    .set({state: 'terminated', terminatedAt: sql`now()`, updatedAt: sql`now()`})
+    .where(
+      and(
+        eq(providerRunners.provisionerId, provisionerId),
+        isNull(providerRunners.runnerSessionId),
+      ),
+    );
+  await tx
+    .update(runnerSessions)
+    .set({revokedAt: sql`now()`})
+    .where(
+      and(
+        eq(runnerSessions.provisionerId, provisionerId),
+        eq(runnerSessions.claimsUsed, 0),
+        isNull(runnerSessions.revokedAt),
+      ),
+    );
 }
 
 export async function createProvisionerToken(
@@ -42,17 +100,23 @@ export async function revokeInstallationProvisionerToken(params: {
   tokenId: string;
   revokedByUserId: string;
 }): Promise<ProvisionerToken | undefined> {
-  const rows = await db()
-    .update(provisionerTokens)
-    .set({revokedAt: new Date(), revokedByUserId: params.revokedByUserId, updatedAt: new Date()})
-    .where(
-      and(
-        eq(provisionerTokens.id, params.tokenId),
-        eq(provisionerTokens.scope, 'installation'),
-        isNull(provisionerTokens.revokedAt),
-      ),
-    )
-    .returning();
+  const rows = await db().transaction(async (tx) => {
+    const rows = await tx
+      .update(provisionerTokens)
+      .set({revokedAt: new Date(), revokedByUserId: params.revokedByUserId, updatedAt: new Date()})
+      .where(
+        and(
+          eq(provisionerTokens.id, params.tokenId),
+          eq(provisionerTokens.scope, 'installation'),
+          isNull(provisionerTokens.revokedAt),
+        ),
+      )
+      .returning();
+    if (rows[0]) {
+      await cascadeProvisionerRevocation(tx, params.tokenId);
+    }
+    return rows;
+  });
 
   const row = rows[0];
   if (row) return toProvisionerToken(row);
@@ -107,18 +171,22 @@ export async function revokeProvisionerToken(params: {
   workspaceId: string;
   revokedByUserId: string;
 }): Promise<ProvisionerToken | undefined> {
-  const rows = await db()
-    .update(provisionerTokens)
-    .set({revokedAt: new Date(), revokedByUserId: params.revokedByUserId, updatedAt: new Date()})
-    .where(
-      and(
-        eq(provisionerTokens.id, params.tokenId),
-        eq(provisionerTokens.workspaceId, params.workspaceId),
-        eq(provisionerTokens.scope, 'workspace'),
-        isNull(provisionerTokens.revokedAt),
-      ),
-    )
-    .returning();
+  const rows = await db().transaction(async (tx) => {
+    const rows = await tx
+      .update(provisionerTokens)
+      .set({revokedAt: new Date(), revokedByUserId: params.revokedByUserId, updatedAt: new Date()})
+      .where(
+        and(
+          eq(provisionerTokens.id, params.tokenId),
+          eq(provisionerTokens.workspaceId, params.workspaceId),
+          eq(provisionerTokens.scope, 'workspace'),
+          isNull(provisionerTokens.revokedAt),
+        ),
+      )
+      .returning();
+    if (rows[0]) await cascadeProvisionerRevocation(tx, params.tokenId);
+    return rows;
+  });
 
   const row = rows[0];
   if (row) return toProvisionerToken(row);

--- a/libs/api/runners/src/db/runner-sessions.test.ts
+++ b/libs/api/runners/src/db/runner-sessions.test.ts
@@ -41,6 +41,19 @@ describe('deleteExpiredRunnerSessions', () => {
     expect(remaining).toEqual([active]);
   });
 
+  it('deletes activation sessions using the ephemeral retention window', async () => {
+    const expired = await insertRunnerSession({kind: 'activation', createdDaysAgo: 8});
+    const active = await insertRunnerSession({kind: 'activation', createdDaysAgo: 6});
+
+    await deleteExpiredRunnerSessions({
+      manualRetentionDays: 30,
+      ephemeralRetentionDays: 7,
+      limit: 100,
+    });
+
+    expect(await listRunnerSessionIds([expired, active])).toEqual([active]);
+  });
+
   it('applies the retention window for each registration token kind independently', async () => {
     const manualExpired = await insertRunnerSession({kind: 'manual', createdDaysAgo: 31});
     const manualActive = await insertRunnerSession({kind: 'manual', createdDaysAgo: 8});
@@ -94,15 +107,14 @@ describe('deleteExpiredRunnerSessions', () => {
   });
 
   async function insertRunnerSession(params: {
-    kind: 'manual' | 'ephemeral';
+    kind: 'manual' | 'ephemeral' | 'activation';
     createdDaysAgo: number;
   }): Promise<string> {
     const id = crypto.randomUUID();
     const registrationTokenId = crypto.randomUUID();
     const createdAt = new Date(Date.now() - params.createdDaysAgo * 24 * 60 * 60 * 1000);
-    const provisionerId = params.kind === 'ephemeral' ? crypto.randomUUID() : null;
-    const providerRunnerId =
-      params.kind === 'ephemeral' ? `provisioned-${crypto.randomUUID()}` : null;
+    const provisionerId = params.kind === 'manual' ? null : crypto.randomUUID();
+    const providerRunnerId = params.kind === 'manual' ? null : `provisioned-${crypto.randomUUID()}`;
 
     await db()
       .insert(runnerSessions)
@@ -112,10 +124,11 @@ describe('deleteExpiredRunnerSessions', () => {
         scope: 'workspace',
         registrationTokenId,
         registrationTokenKind: params.kind,
+        runnerInstanceId: params.kind === 'activation' ? crypto.randomUUID() : null,
         provisionerId,
         providerRunnerId,
         labels: ['linux'],
-        maxClaims: params.kind === 'ephemeral' ? 1 : null,
+        maxClaims: params.kind === 'manual' ? null : 1,
         claimsUsed: 0,
         createdAt,
         updatedAt: createdAt,

--- a/libs/api/runners/src/db/runner-sessions.ts
+++ b/libs/api/runners/src/db/runner-sessions.ts
@@ -1,7 +1,10 @@
 import type {RunnerToolCapabilitiesDto} from '@shipfox/api-runners-dto';
-import {and, asc, eq, inArray, lt, notExists, or, sql} from 'drizzle-orm';
+import {and, asc, eq, gt, inArray, isNull, lt, notExists, or, sql} from 'drizzle-orm';
 import type {RunnerSession} from '#core/entities/runner-session.js';
 import {db} from './db.js';
+import {runnerActivationTokens} from './schema/runner-activation-tokens.js';
+import {runnerControlSessions} from './schema/runner-control-sessions.js';
+import {providerRunners} from './schema/runner-instances.js';
 import {runnerSessions, toRunnerSession} from './schema/runner-sessions.js';
 import {runningJobExecutions} from './schema/running-job-executions.js';
 
@@ -47,6 +50,79 @@ export async function getRunnerSessionById(runnerSessionId: string): Promise<Run
   return row ? toRunnerSession(row) : null;
 }
 
+export async function createRunnerSessionConsumingActivationToken(params: {
+  activationTokenId: string;
+  labels: string[];
+  toolCapabilities?: RunnerToolCapabilitiesDto | null;
+}) {
+  return await db().transaction(async (tx) => {
+    const [token] = await tx
+      .select({
+        id: runnerActivationTokens.id,
+        runnerInstanceId: runnerActivationTokens.runnerInstanceId,
+        workspaceId: providerRunners.workspaceId,
+        provisionerId: providerRunners.provisionerId,
+        providerRunnerId: providerRunners.providerRunnerId,
+      })
+      .from(runnerActivationTokens)
+      .innerJoin(providerRunners, eq(providerRunners.id, runnerActivationTokens.runnerInstanceId))
+      .where(
+        and(
+          eq(runnerActivationTokens.id, params.activationTokenId),
+          isNull(runnerActivationTokens.consumedAt),
+          isNull(runnerActivationTokens.revokedAt),
+          gt(runnerActivationTokens.expiresAt, sql`now()`),
+          isNull(providerRunners.runnerSessionId),
+        ),
+      )
+      .limit(1)
+      .for('update');
+    if (!token?.workspaceId || !token.providerRunnerId)
+      throw new Error('Runner activation token is invalid, expired, or has already been used');
+    const [session] = await tx
+      .insert(runnerSessions)
+      .values({
+        workspaceId: token.workspaceId,
+        scope: 'workspace',
+        registrationTokenId: token.id,
+        registrationTokenKind: 'activation',
+        runnerInstanceId: token.runnerInstanceId,
+        provisionerId: token.provisionerId,
+        providerRunnerId: token.providerRunnerId,
+        labels: params.labels,
+        toolCapabilities: params.toolCapabilities ?? null,
+        toolCapabilitiesReportedAt: params.toolCapabilities ? sql`now()` : null,
+        maxClaims: 1,
+        claimsUsed: 0,
+      })
+      .returning();
+    if (!session) throw new Error('Runner activation session insert returned no row');
+    await tx
+      .update(runnerActivationTokens)
+      .set({consumedAt: sql`now()`, consumedSessionId: session.id})
+      .where(eq(runnerActivationTokens.id, token.id));
+    await tx
+      .update(providerRunners)
+      .set({runnerSessionId: session.id, updatedAt: sql`now()`})
+      .where(
+        and(
+          eq(providerRunners.id, token.runnerInstanceId),
+          isNull(providerRunners.runnerSessionId),
+        ),
+      );
+    await tx
+      .update(runnerControlSessions)
+      .set({closedAt: sql`now()`, closeReason: 'activated'})
+      .where(
+        and(
+          eq(runnerControlSessions.runnerInstanceId, token.runnerInstanceId),
+          isNull(runnerControlSessions.closedAt),
+        ),
+      );
+    return toRunnerSession(session);
+  });
+}
+
 export interface DeleteExpiredRunnerSessionsParams {
   manualRetentionDays: number;
   ephemeralRetentionDays: number;
@@ -70,7 +146,7 @@ export async function deleteExpiredRunnerSessions(
             ),
           ),
           and(
-            eq(runnerSessions.registrationTokenKind, 'ephemeral'),
+            inArray(runnerSessions.registrationTokenKind, ['ephemeral', 'activation']),
             lt(
               runnerSessions.createdAt,
               sql`now() - (${params.ephemeralRetentionDays} || ' days')::interval`,

--- a/libs/api/runners/src/db/schema/runner-activation-tokens.ts
+++ b/libs/api/runners/src/db/schema/runner-activation-tokens.ts
@@ -1,0 +1,22 @@
+import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
+import {index, text, timestamp, uniqueIndex, uuid} from 'drizzle-orm/pg-core';
+import {pgTable} from './common.js';
+
+export const runnerActivationTokens = pgTable(
+  'runner_activation_tokens',
+  {
+    id: uuidv7PrimaryKey(),
+    runnerInstanceId: uuid('runner_instance_id').notNull(),
+    hashedToken: text('hashed_token').notNull(),
+    prefix: text('prefix').notNull(),
+    expiresAt: timestamp('expires_at', {withTimezone: true}).notNull(),
+    consumedAt: timestamp('consumed_at', {withTimezone: true}),
+    revokedAt: timestamp('revoked_at', {withTimezone: true}),
+    consumedSessionId: uuid('consumed_session_id'),
+    createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex('runners_runner_activation_tokens_hashed_token_unique').on(table.hashedToken),
+    index('runners_runner_activation_tokens_runner_instance_idx').on(table.runnerInstanceId),
+  ],
+);

--- a/libs/api/runners/src/db/schema/runner-sessions.ts
+++ b/libs/api/runners/src/db/schema/runner-sessions.ts
@@ -8,7 +8,7 @@ import {pgTable} from './common.js';
 export const runnerSessionScopeEnum = pgEnum('runners_runner_session_scope', ['workspace']);
 export const runnerSessionRegistrationTokenKindEnum = pgEnum(
   'runners_runner_session_registration_token_kind',
-  ['manual', 'ephemeral'],
+  ['manual', 'ephemeral', 'activation'],
 );
 
 export const runnerSessions = pgTable(
@@ -20,6 +20,7 @@ export const runnerSessions = pgTable(
     registrationTokenId: uuid('registration_token_id').notNull(),
     registrationTokenKind:
       runnerSessionRegistrationTokenKindEnum('registration_token_kind').notNull(),
+    runnerInstanceId: uuid('runner_instance_id'),
     provisionerId: uuid('provisioner_id'),
     providerRunnerId: text('provider_runner_id'),
     labels: text('labels').array().notNull(),
@@ -27,6 +28,7 @@ export const runnerSessions = pgTable(
     toolCapabilitiesReportedAt: timestamp('tool_capabilities_reported_at', {withTimezone: true}),
     maxClaims: integer('max_claims'),
     claimsUsed: integer('claims_used').notNull().default(0),
+    revokedAt: timestamp('revoked_at', {withTimezone: true}),
     createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', {withTimezone: true}).notNull().defaultNow(),
   },
@@ -38,11 +40,11 @@ export const runnerSessions = pgTable(
     ),
     check(
       'runners_runner_sessions_claims_ck',
-      sql`${table.claimsUsed} >= 0 AND ((${table.registrationTokenKind} = 'manual' AND ${table.maxClaims} IS NULL) OR (${table.registrationTokenKind} = 'ephemeral' AND ${table.maxClaims} IS NOT NULL AND ${table.maxClaims} > 0 AND ${table.claimsUsed} <= ${table.maxClaims}))`,
+      sql`${table.claimsUsed} >= 0 AND ((${table.registrationTokenKind} = 'manual' AND ${table.maxClaims} IS NULL) OR (${table.registrationTokenKind} in ('ephemeral', 'activation') AND ${table.maxClaims} IS NOT NULL AND ${table.maxClaims} > 0 AND ${table.claimsUsed} <= ${table.maxClaims}))`,
     ),
     check(
       'runners_runner_sessions_link_ck',
-      sql`((${table.registrationTokenKind} = 'manual' AND ${table.provisionerId} IS NULL AND ${table.providerRunnerId} IS NULL) OR (${table.registrationTokenKind} = 'ephemeral' AND ${table.provisionerId} IS NOT NULL AND ${table.providerRunnerId} IS NOT NULL))`,
+      sql`((${table.registrationTokenKind} = 'manual' AND ${table.runnerInstanceId} IS NULL AND ${table.provisionerId} IS NULL AND ${table.providerRunnerId} IS NULL) OR (${table.registrationTokenKind} = 'ephemeral' AND ${table.runnerInstanceId} IS NULL AND ${table.provisionerId} IS NOT NULL AND ${table.providerRunnerId} IS NOT NULL) OR (${table.registrationTokenKind} = 'activation' AND ${table.runnerInstanceId} IS NOT NULL AND ${table.provisionerId} IS NOT NULL AND ${table.providerRunnerId} IS NOT NULL))`,
     ),
     index('runners_runner_sessions_provider_runner_updated_idx')
       .on(table.workspaceId, table.provisionerId, table.providerRunnerId, table.updatedAt)
@@ -64,6 +66,7 @@ export function toRunnerSession(row: RunnerSessionDb): RunnerSession {
     scope: row.scope,
     registrationTokenId: row.registrationTokenId,
     registrationTokenKind: row.registrationTokenKind,
+    runnerInstanceId: row.runnerInstanceId,
     provisionerId: row.provisionerId,
     providerRunnerId: row.providerRunnerId,
     labels: row.labels,
@@ -71,6 +74,7 @@ export function toRunnerSession(row: RunnerSessionDb): RunnerSession {
     toolCapabilitiesReportedAt: row.toolCapabilitiesReportedAt,
     maxClaims: row.maxClaims,
     claimsUsed: row.claimsUsed,
+    revokedAt: row.revokedAt,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };

--- a/libs/api/runners/src/presentation/auth/runner-registration-token-auth.ts
+++ b/libs/api/runners/src/presentation/auth/runner-registration-token-auth.ts
@@ -1,9 +1,14 @@
 import {AUTH_RUNNER_REGISTRATION_TOKEN} from '@shipfox/api-auth-context';
 import {type AuthMethod, ClientError, extractBearerToken} from '@shipfox/node-fastify';
 import {getTokenType, hashOpaqueToken} from '@shipfox/node-tokens';
+import {and, eq, gt, isNull, or, sql} from 'drizzle-orm';
 import type {FastifyRequest} from 'fastify';
+import {db} from '#db/db.js';
 import {resolveEphemeralRegistrationTokenByHash} from '#db/ephemeral-registration-tokens.js';
 import {resolveManualRegistrationTokenByHash} from '#db/manual-registration-tokens.js';
+import {provisionerTokens} from '#db/schema/provisioner-tokens.js';
+import {runnerActivationTokens} from '#db/schema/runner-activation-tokens.js';
+import {providerRunners} from '#db/schema/runner-instances.js';
 
 const RUNNER_CONTEXT_KEY = 'runner';
 
@@ -20,7 +25,8 @@ export type RunnerRegistrationContext =
       provisionerId: string;
       reservationId: string | null;
       providerRunnerId: string;
-    };
+    }
+  | {kind: 'activation'; activationTokenId: string; workspaceId: string};
 
 export function getRunnerContext(request: FastifyRequest): RunnerRegistrationContext {
   const context = (request as unknown as Record<string, unknown>)[RUNNER_CONTEXT_KEY] as
@@ -44,6 +50,36 @@ export function createRunnerRegistrationTokenAuthMethod(): AuthMethod {
       }
 
       const tokenType = getTokenType(rawToken);
+
+      if (tokenType === 'runnerActivationToken') {
+        const [activation] = await db()
+          .select({id: runnerActivationTokens.id, workspaceId: providerRunners.workspaceId})
+          .from(runnerActivationTokens)
+          .innerJoin(
+            providerRunners,
+            eq(providerRunners.id, runnerActivationTokens.runnerInstanceId),
+          )
+          .leftJoin(provisionerTokens, eq(provisionerTokens.id, providerRunners.provisionerId))
+          .where(
+            and(
+              eq(runnerActivationTokens.hashedToken, hashOpaqueToken(rawToken)),
+              isNull(runnerActivationTokens.consumedAt),
+              isNull(runnerActivationTokens.revokedAt),
+              gt(runnerActivationTokens.expiresAt, sql`now()`),
+              or(isNull(provisionerTokens.id), isNull(provisionerTokens.revokedAt)),
+              isNull(providerRunners.runnerSessionId),
+            ),
+          )
+          .limit(1);
+        if (!activation?.workspaceId)
+          throw new ClientError('Invalid runner registration token', 'unauthorized', {status: 401});
+        (request as unknown as Record<string, unknown>)[RUNNER_CONTEXT_KEY] = {
+          kind: 'activation',
+          activationTokenId: activation.id,
+          workspaceId: activation.workspaceId,
+        } satisfies RunnerRegistrationContext;
+        return;
+      }
 
       if (tokenType === 'ephemeralRegistrationToken') {
         const ephemeralToken = await resolveEphemeralRegistrationTokenByHash(

--- a/libs/api/runners/src/presentation/routes/index.ts
+++ b/libs/api/runners/src/presentation/routes/index.ts
@@ -31,6 +31,7 @@ import {
   createRunnerInstancesRoute,
   enrollRunnerRoute,
   exchangeRunnerBootstrapRoute,
+  runnerAssignmentPollRoute,
   runnerControlHeartbeatRoute,
 } from './runner-enrollment.js';
 
@@ -86,7 +87,12 @@ const runnerControlRoutes: RouteGroup[] = [
   {prefix: '/runner-enrollment', routes: [exchangeRunnerBootstrapRoute]},
   {
     prefix: '/runner-control',
-    routes: [enrollRunnerRoute, attachRunnerControlProviderIdRoute, runnerControlHeartbeatRoute],
+    routes: [
+      enrollRunnerRoute,
+      attachRunnerControlProviderIdRoute,
+      runnerControlHeartbeatRoute,
+      runnerAssignmentPollRoute,
+    ],
   },
 ];
 

--- a/libs/api/runners/src/presentation/routes/runner-enrollment.test.ts
+++ b/libs/api/runners/src/presentation/routes/runner-enrollment.test.ts
@@ -160,4 +160,55 @@ describe('runner enrollment control plane', () => {
     expect(enrolled.statusCode).toBe(409);
     expect(enrolled.json()).toMatchObject({code: 'runner-control-session-invalid'});
   });
+
+  it('returns an activation token only for its assigned runner and closes control access after registration', async () => {
+    const created = await app.inject({
+      method: 'POST',
+      url: '/provisioners/runner-instances/batch',
+      headers: {authorization: `Bearer ${token}`},
+      payload: {runner_instances: [{}]},
+    });
+    const runner = created.json().runner_instances[0];
+    const exchanged = await app.inject({
+      method: 'POST',
+      url: '/runner-enrollment/exchange',
+      payload: {bootstrap_token: runner.bootstrap_token},
+    });
+    const controlToken = exchanged.json().control_session_token;
+    const workspaceId = crypto.randomUUID();
+    await db()
+      .update(providerRunners)
+      .set({
+        workspaceId,
+        reservationId: crypto.randomUUID(),
+        providerRunnerId: 'runner-activation-test',
+        state: 'running',
+      })
+      .where(eq(providerRunners.id, runner.runner_instance_id));
+
+    const assignment = await app.inject({
+      method: 'GET',
+      url: '/runner-control/assignment',
+      headers: {authorization: `Bearer ${controlToken}`},
+    });
+    expect(assignment.statusCode).toBe(200);
+    const activationToken = assignment.json().activation_token;
+    expect(typeof activationToken).toBe('string');
+
+    const registered = await app.inject({
+      method: 'POST',
+      url: '/runners/register',
+      headers: {authorization: `Bearer ${activationToken}`},
+      payload: {labels: ['linux']},
+    });
+    expect(registered.statusCode).toBe(200);
+    expect(registered.json()).toMatchObject({mode: 'activation', max_claims: 1});
+
+    const closed = await app.inject({
+      method: 'POST',
+      url: '/runner-control/heartbeat',
+      headers: {authorization: `Bearer ${controlToken}`},
+    });
+    expect(closed.statusCode).toBe(401);
+  });
 });

--- a/libs/api/runners/src/presentation/routes/runner-enrollment.test.ts
+++ b/libs/api/runners/src/presentation/routes/runner-enrollment.test.ts
@@ -10,6 +10,7 @@ import {
 import {eq} from 'drizzle-orm';
 import type {FastifyInstance, FastifyRequest} from 'fastify';
 import {db} from '#db/db.js';
+import {runnerActivationTokens} from '#db/schema/runner-activation-tokens.js';
 import {runnerBootstrapTokens, runnerControlSessions} from '#db/schema/runner-control-sessions.js';
 import {providerRunners} from '#db/schema/runner-instances.js';
 import {
@@ -210,5 +211,49 @@ describe('runner enrollment control plane', () => {
       headers: {authorization: `Bearer ${controlToken}`},
     });
     expect(closed.statusCode).toBe(401);
+  });
+
+  it('rejects registration with an expired activation token', async () => {
+    const created = await app.inject({
+      method: 'POST',
+      url: '/provisioners/runner-instances/batch',
+      headers: {authorization: `Bearer ${token}`},
+      payload: {runner_instances: [{}]},
+    });
+    const runner = created.json().runner_instances[0];
+    const exchanged = await app.inject({
+      method: 'POST',
+      url: '/runner-enrollment/exchange',
+      payload: {bootstrap_token: runner.bootstrap_token},
+    });
+    const workspaceId = crypto.randomUUID();
+    await db()
+      .update(providerRunners)
+      .set({
+        workspaceId,
+        reservationId: crypto.randomUUID(),
+        providerRunnerId: 'runner-expired',
+        state: 'running',
+      })
+      .where(eq(providerRunners.id, runner.runner_instance_id));
+    const assignment = await app.inject({
+      method: 'GET',
+      url: '/runner-control/assignment',
+      headers: {authorization: `Bearer ${exchanged.json().control_session_token}`},
+    });
+    const activationToken = assignment.json().activation_token;
+    await db()
+      .update(runnerActivationTokens)
+      .set({expiresAt: new Date(Date.now() - 1_000)})
+      .where(eq(runnerActivationTokens.runnerInstanceId, runner.runner_instance_id));
+
+    const registered = await app.inject({
+      method: 'POST',
+      url: '/runners/register',
+      headers: {authorization: `Bearer ${activationToken}`},
+      payload: {labels: ['linux']},
+    });
+
+    expect(registered.statusCode).toBe(401);
   });
 });

--- a/libs/api/runners/src/presentation/routes/runner-enrollment.ts
+++ b/libs/api/runners/src/presentation/routes/runner-enrollment.ts
@@ -6,6 +6,7 @@ import {
   attachRunnerControlProviderIdBodySchema,
   createRunnerInstancesBodySchema,
   createRunnerInstancesResponseSchema,
+  runnerAssignmentPollResponseSchema,
   runnerBootstrapExchangeBodySchema,
   runnerBootstrapExchangeResponseSchema,
   runnerControlHeartbeatResponseSchema,
@@ -14,6 +15,7 @@ import {
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
 import {config} from '#config.js';
+import {getRunnerAssignment, issueRunnerActivationToken} from '#core/runner-activation.js';
 import {
   attachRunnerControlProviderId,
   createRunnerInstancesWithBootstrapTokens,
@@ -139,5 +141,34 @@ export const runnerControlHeartbeatRoute = defineRoute({
     await touchRunnerControlSession(session.runnerInstanceId, session.provisionerId);
     runnerControlHeartbeatCount.add(1);
     return {ok: true};
+  },
+});
+
+export const runnerAssignmentPollRoute = defineRoute({
+  method: 'GET',
+  path: '/assignment',
+  description: 'Wait for only the authenticated runner instance assignment',
+  schema: {response: {200: runnerAssignmentPollResponseSchema}},
+  preHandler: authenticateRunnerControlSession,
+  handler: async (request, reply) => {
+    const session = requireRunnerControlSessionContext(request);
+    const deadline = Date.now() + config.RUNNER_ASSIGNMENT_POLL_MAX_WAIT_SECONDS * 1000;
+    const abortController = new AbortController();
+    reply.raw.on('close', () => abortController.abort());
+    while (Date.now() <= deadline) {
+      if (abortController.signal.aborted) return {activation_token: null};
+      const assignment = await getRunnerAssignment(session);
+      if (assignment) {
+        const activationToken = await issueRunnerActivationToken({
+          ...session,
+          ttlSeconds: config.RUNNER_ACTIVATION_TOKEN_TTL_SECONDS,
+        });
+        return {activation_token: activationToken};
+      }
+      await new Promise((resolve) =>
+        setTimeout(resolve, config.RUNNER_ASSIGNMENT_POLL_INTERVAL_MS),
+      );
+    }
+    return {activation_token: null};
   },
 });

--- a/libs/api/runners/test/factories/runner-session.ts
+++ b/libs/api/runners/test/factories/runner-session.ts
@@ -19,6 +19,7 @@ export const runnerSessionFactory = Factory.define<RunnerSession>(({onCreate}) =
     scope: 'workspace',
     registrationTokenId: crypto.randomUUID(),
     registrationTokenKind: 'manual',
+    runnerInstanceId: null,
     provisionerId: null,
     providerRunnerId: null,
     labels: ['linux', 'x64'],
@@ -26,6 +27,7 @@ export const runnerSessionFactory = Factory.define<RunnerSession>(({onCreate}) =
     toolCapabilitiesReportedAt: null,
     maxClaims: null,
     claimsUsed: 0,
+    revokedAt: null,
     createdAt: new Date(),
     updatedAt: new Date(),
   };

--- a/libs/api/workflows/src/db/runner-lease-table.ts
+++ b/libs/api/workflows/src/db/runner-lease-table.ts
@@ -6,7 +6,7 @@ const pgTable = pgTableCreator((name) => `runners_${name}`);
 export const runnerSessionScopeEnum = pgEnum('runners_runner_session_scope', ['workspace']);
 export const runnerSessionRegistrationTokenKindEnum = pgEnum(
   'runners_runner_session_registration_token_kind',
-  ['manual', 'ephemeral'],
+  ['manual', 'ephemeral', 'activation'],
 );
 
 export const runnerSessions = pgTable('runner_sessions', {

--- a/libs/shared/node/tokens/src/index.ts
+++ b/libs/shared/node/tokens/src/index.ts
@@ -14,6 +14,7 @@ export const tokenTypeParts = {
   ephemeralRegistrationToken: 'ert',
   runnerBootstrapToken: 'rbt',
   runnerControlSession: 'rcs',
+  runnerActivationToken: 'rat',
   provisionerToken: 'pt',
 } as const;
 


### PR DESCRIPTION
Adds a runner-controlled activation path for immutable workspace assignments. An enrolled runner long-polls only its own durable assignment, receives a one-use activation credential, and registers into a one-claim workspace session without ever supplying a workspace ID.

Managed runner activation previously depended on provisioner-delivered registration credentials, leaving the control-to-job-plane handoff and descendant revocation incomplete. This derives activation authority from the runner instance, closes the control session on success, and cascades provisioner revocation through bootstrap tokens, control sessions, activation tokens, unactivated instances, and unclaimed sessions.

The runner baseline is intentionally rewritten in place because this schema is pre-deployment. Reviewers should verify no shared environment has applied the initial runner migration.

Closes ENG-1090

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables runner-controlled activation for assigned instances. Runners long-poll their own assignment, receive a one-use activation token, and register without a workspace ID. Also enforces and cascades provisioner revocation across all unclaimed descendants.

- New Features
  - Added GET /runner-control/assignment to long-poll only the authenticated runner’s assignment and return an `activation_token` (or null); control sessions close after activation.
  - Issued one-use `runnerActivationToken`s tied to `runner_instance_id`; replaces any unconsumed token on reissue; registration accepts them via bearer auth and returns `mode: "activation"` with `max_claims = 1`.
  - Enforced revocation: control/registration reject revoked provisioners; job claiming blocks sessions with `revoked_at`; cascade revokes bootstrap/activation tokens, closes control sessions, terminates unactivated instances, and revokes unclaimed sessions when a provisioner is revoked.
  - Schema/DTO: new `runner_activation_tokens` table; `runner_sessions` adds `runner_instance_id` and `revoked_at`; registration kind enum includes `activation` and follows the ephemeral retention window; DTO exports `runnerAssignmentPollResponseSchema`; token type `runnerActivationToken` added in `@shipfox/node-tokens`.
  - Config: `RUNNER_ACTIVATION_TOKEN_TTL_SECONDS`, `RUNNER_ASSIGNMENT_POLL_MAX_WAIT_SECONDS`, `RUNNER_ASSIGNMENT_POLL_INTERVAL_MS`.

- Migration
  - Runner flow: enroll → attach provider ID → long-poll /runner-control/assignment → on token, call /runners/register with it; do not send a workspace ID. Expect `mode: "activation"` and `max_claims = 1`. Stop control heartbeats after activation.
  - Packages updated: `@shipfox/api-runners`, `@shipfox/api-runners-dto`, `@shipfox/node-tokens`, `@shipfox/api-workflows`.

Linked Linear issue ENG-1090: meets the requirement that runners cannot supply or see other workspaces, activation can’t rebind, control credentials close after activation, and provisioner revocation blocks all unclaimed descendants.

<sup>Written for commit f69287d3219ffd01ef04a2d5800f20451f18c443. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

