### PR TITLE
[application-release] Serialize packed runtime manifests

### DIFF
--- a/.changeset/steady-packs-serialize.md
+++ b/.changeset/steady-packs-serialize.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/application-release": patch
+---
+
+Serializes packed runtime manifests to prevent concurrent productionization races.

--- a/tools/application-release/test/external/verify.mjs
+++ b/tools/application-release/test/external/verify.mjs
@@ -35,7 +35,9 @@ const manifestPacker = createProductionManifestPacker();
 
 try {
   await mkdir(tarballRoot);
-  const tarballs = await mapWithConcurrency(closure, 4, async (name) => {
+  // `pack()` temporarily productionizes each source manifest. Serializing those
+  // mutations keeps pnpm from reading another package's transient manifest.
+  const tarballs = await mapWithConcurrency(closure, 1, async (name) => {
     const workspacePackage = workspacePackages.get(name);
     if (!workspacePackage) throw new Error(`Missing workspace package: ${name}`);
     const tarball = join(tarballRoot, `${safePackageName(name)}.tgz`);


### PR DESCRIPTION
Serialize the packed runtime consumer's temporary manifest rewrites.

The external-consumer verifier productionizes each source manifest before invoking `pnpm pack`. Running those rewrites concurrently allowed pnpm to observe another package's transient manifest and left the source tree in an inconsistent state, causing the release CI's Gitea tarball pack to fail intermittently.

Packing serially preserves the same closure validation while making every temporary manifest change isolated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serializes runtime manifest packing to prevent concurrent productionization races that broke Gitea tarball packs in release CI. Sets pack concurrency to 1 so temporary manifest rewrites are isolated and `pnpm` never reads another package’s transient manifest.

<sup>Written for commit ab84c0581db215e1d3fc362e2ea737a7e8c7773c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

