### PR TITLE
[runner] Add managed runner enrollment wait

### DIFF
--- a/.changeset/bright-runners-wait.md
+++ b/.changeset/bright-runners-wait.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/runner-protocol": minor
+---
+
+Adds managed runner bootstrap enrollment, assignment waiting, and activation transport helpers.

--- a/apps/runner/README.md
+++ b/apps/runner/README.md
@@ -25,11 +25,16 @@ A setup failure (missing `git`, a denied credential, or an unreachable provider)
 fails the job before any step runs, with a machine-readable reason recorded on
 the step.
 
-At startup, the runner exchanges `SHIPFOX_RUNNER_REGISTRATION_TOKEN` for a short-lived runner
-session token using `SHIPFOX_RUNNER_LABELS`. The value can be a manual token
-(`sf_mrt_...`) or an ephemeral token (`sf_ert_...`). Job polling uses that session token.
-Heartbeat, step, checkout, and log calls use the per-job lease token returned by
-the claim response.
+At startup, the runner uses exactly one of two modes. Direct runners exchange
+`SHIPFOX_RUNNER_REGISTRATION_TOKEN` for a short-lived runner session token using
+`SHIPFOX_RUNNER_LABELS`. The value can be a manual token (`sf_mrt_...`) or an
+ephemeral token (`sf_ert_...`). Provisioner-managed runners exchange
+`SHIPFOX_RUNNER_BOOTSTRAP_TOKEN`, enroll with their labels and capabilities,
+heartbeat while waiting for their own assignment, then exchange the delivered
+activation token through the same registration endpoint. The bootstrap and
+control credentials are discarded before job polling. Job polling uses the
+resulting session token. Heartbeat, step, checkout, and log calls use the
+per-job lease token returned by the claim response.
 
 The runner refuses to start when `SHIPFOX_RUNNER_LABELS` is empty after trimming.
 When no job is claimed before `SHIPFOX_POLL_MAX_DURATION_MS`, it exits cleanly so
@@ -59,7 +64,10 @@ configured root is empty, the filesystem root (`/`), or a home directory.
 | Variable | Default | Description |
 | --- | --- | --- |
 | `SHIPFOX_API_URL` | — | Base URL of the Shipfox API. |
-| `SHIPFOX_RUNNER_REGISTRATION_TOKEN` | — | Manual (`sf_mrt_...`) or ephemeral (`sf_ert_...`) registration token. The runner exchanges it for a session token at startup. |
+| `SHIPFOX_RUNNER_REGISTRATION_TOKEN` | — | Manual (`sf_mrt_...`) or ephemeral (`sf_ert_...`) registration token. Set this or `SHIPFOX_RUNNER_BOOTSTRAP_TOKEN`, not both. |
+| `SHIPFOX_RUNNER_BOOTSTRAP_TOKEN` | — | One-use managed-runner bootstrap token. The runner enrolls and waits for an assignment before exchanging its activation token for a runner session. Set this or `SHIPFOX_RUNNER_REGISTRATION_TOKEN`, not both. |
+| `SHIPFOX_RUNNER_PROVIDER_KIND` | — | Provider kind the managed runner declares during enrollment, such as `ec2` or `docker`. Required with `SHIPFOX_RUNNER_BOOTSTRAP_TOKEN`. |
+| `SHIPFOX_RUNNER_PROTOCOL_VERSION` | `1` | Protocol version the managed runner declares during enrollment. |
 | `SHIPFOX_RUNNER_LABELS` | — | Comma-separated labels registered on this runner session, such as `linux,x64,self-hosted`. |
 | `SHIPFOX_RUNNER_WORKSPACE_ROOT` | OS temp dir | Parent directory for per-job workspaces (see above). |
 | `SHIPFOX_POLL_INTERVAL_MS` | `1000` | Base poll interval when requesting jobs. |

--- a/libs/runner/orchestration/src/core/runner.test.ts
+++ b/libs/runner/orchestration/src/core/runner.test.ts
@@ -5,6 +5,8 @@ vi.mock('#config.js', () => ({
     SHIPFOX_POLL_MAX_DURATION_MS: 1,
     SHIPFOX_HEARTBEAT_INTERVAL_MS: 10_000,
     SHIPFOX_HEARTBEAT_MAX_STALE_MS: 10_000,
+    SHIPFOX_RUNNER_PROVIDER_KIND: 'ec2',
+    SHIPFOX_RUNNER_PROTOCOL_VERSION: '1',
   },
 }));
 
@@ -37,8 +39,15 @@ vi.mock('@shipfox/runner-agent', () => ({
 
 vi.mock('@shipfox/runner-protocol', () => ({
   registerRunnerSession: vi.fn(),
+  consumeManagedRunnerBootstrapToken: vi.fn(),
+  managedRunnerEnrollmentConfig: vi.fn(() => ({providerKind: 'ec2', protocolVersion: '1'})),
+  exchangeRunnerBootstrapToken: vi.fn(),
+  enrollRunnerControlSession: vi.fn(),
+  heartbeatRunnerControlSession: vi.fn(),
+  pollRunnerAssignment: vi.fn(),
   requireRunnerLabels: vi.fn(),
   requestJob: vi.fn(),
+  runnerStartupMode: vi.fn(() => 'direct'),
   createLeaseClient: vi.fn(() => ({}) as never),
   runnerRegistrationToken: vi.fn(() => 'sf_mrt_runner-registration-token'),
   RunnerLabelsRequiredError: class RunnerLabelsRequiredError extends Error {},
@@ -55,13 +64,19 @@ vi.mock('@shipfox/runner-protocol', () => ({
 
 import {runnerToolCapabilities} from '@shipfox/runner-agent';
 import {
+  consumeManagedRunnerBootstrapToken,
   createLeaseClient,
+  enrollRunnerControlSession,
+  exchangeRunnerBootstrapToken,
   HTTPError,
+  heartbeatRunnerControlSession,
+  pollRunnerAssignment,
   RunnerLabelsRequiredError,
   RunnerSessionExhaustedError,
   registerRunnerSession,
   requestJob,
   requireRunnerLabels,
+  runnerStartupMode,
 } from '@shipfox/runner-protocol';
 import {
   cleanupJobCredentials,
@@ -89,7 +104,13 @@ const mockResolveWorkspaceRoot = vi.mocked(resolveWorkspaceRootFromEnv);
 const mockRunJobSteps = vi.mocked(runJobSteps);
 const mockCreateLeaseClient = vi.mocked(createLeaseClient);
 const mockRegisterRunnerSession = vi.mocked(registerRunnerSession);
+const mockConsumeManagedRunnerBootstrapToken = vi.mocked(consumeManagedRunnerBootstrapToken);
+const mockExchangeRunnerBootstrapToken = vi.mocked(exchangeRunnerBootstrapToken);
+const mockEnrollRunnerControlSession = vi.mocked(enrollRunnerControlSession);
+const mockHeartbeatRunnerControlSession = vi.mocked(heartbeatRunnerControlSession);
+const mockPollRunnerAssignment = vi.mocked(pollRunnerAssignment);
 const mockRequireRunnerLabels = vi.mocked(requireRunnerLabels);
+const mockRunnerStartupMode = vi.mocked(runnerStartupMode);
 const mockRequestJob = vi.mocked(requestJob);
 const mockStartHeartbeatLoop = vi.mocked(startHeartbeatLoop);
 const mockRunnerToolCapabilities = vi.mocked(runnerToolCapabilities);
@@ -116,6 +137,8 @@ beforeEach(() => {
   setPollConfig({interval: 1, maxInterval: 5, maxDuration: 1});
   mockResolveWorkspaceRoot.mockReturnValue(WORKSPACE_ROOT);
   mockRequireRunnerLabels.mockReturnValue(['local']);
+  mockRunnerStartupMode.mockReturnValue('direct');
+  mockConsumeManagedRunnerBootstrapToken.mockReturnValue('sf_rbt_bootstrap-token');
   mockRegisterRunnerSession.mockResolvedValue({
     session_id: '00000000-0000-0000-0000-000000000003',
     session_token: 'session-token',
@@ -129,6 +152,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   vi.restoreAllMocks();
 });
 
@@ -327,6 +351,77 @@ describe('startRunner', () => {
 
     expect(mockRegisterRunnerSession).toHaveBeenCalledTimes(1);
     expect(mockRequestJob).toHaveBeenCalledTimes(1);
+  });
+
+  it('enrolls, waits, activates, and uses the activation session for managed runners', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(0);
+    vi.stubEnv('SHIPFOX_RUNNER_BOOTSTRAP_TOKEN', 'sf_rbt_bootstrap-token');
+    vi.stubEnv('SHIPFOX_RUNNER_PROVIDER_KIND', 'ec2');
+    vi.stubEnv('SHIPFOX_RUNNER_PROTOCOL_VERSION', '1');
+    mockRunnerStartupMode.mockReturnValue('managed');
+    mockConsumeManagedRunnerBootstrapToken.mockReturnValue('sf_rbt_bootstrap-token');
+    mockExchangeRunnerBootstrapToken.mockResolvedValue({controlSessionToken: 'control-token'});
+    mockEnrollRunnerControlSession.mockResolvedValue();
+    mockHeartbeatRunnerControlSession.mockResolvedValue();
+    mockPollRunnerAssignment.mockResolvedValue('activation-token');
+    mockRequestJob.mockRejectedValue(new RunnerSessionExhaustedError());
+
+    await startRunner();
+
+    expect(mockConsumeManagedRunnerBootstrapToken).toHaveBeenCalledTimes(1);
+    expect(mockExchangeRunnerBootstrapToken).toHaveBeenCalledWith('sf_rbt_bootstrap-token');
+    expect(mockEnrollRunnerControlSession).toHaveBeenCalledWith({
+      controlSessionToken: 'control-token',
+      capabilities: {harnesses: {pi: {tools: ['read']}}},
+      providerKind: 'ec2',
+      protocolVersion: '1',
+    });
+    expect(mockHeartbeatRunnerControlSession).toHaveBeenCalledWith(
+      'control-token',
+      expect.any(AbortSignal),
+    );
+    expect(mockPollRunnerAssignment).toHaveBeenCalledWith('control-token', expect.any(AbortSignal));
+    expect(mockRegisterRunnerSession).toHaveBeenCalledWith({
+      capabilities: {harnesses: {pi: {tools: ['read']}}},
+      registrationToken: 'activation-token',
+    });
+    expect(mockRequestJob).toHaveBeenCalledWith('session-token');
+  });
+
+  it('retries a failed first direct registration', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(0);
+    mockRegisterRunnerSession
+      .mockRejectedValueOnce(new Error('api unavailable'))
+      .mockResolvedValueOnce({
+        session_id: '00000000-0000-0000-0000-000000000003',
+        session_token: 'session-token',
+        mode: 'manual',
+        max_claims: null,
+      });
+    mockRequestJob.mockRejectedValue(new RunnerSessionExhaustedError());
+
+    await startRunner();
+
+    expect(mockRegisterRunnerSession).toHaveBeenCalledTimes(2);
+    expect(mockRequestJob).toHaveBeenCalledTimes(1);
+  });
+
+  it('exits cleanly when shutdown aborts the managed assignment poll', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(0);
+    mockRunnerStartupMode.mockReturnValue('managed');
+    mockExchangeRunnerBootstrapToken.mockResolvedValue({controlSessionToken: 'control-token'});
+    mockEnrollRunnerControlSession.mockResolvedValue();
+    mockHeartbeatRunnerControlSession.mockResolvedValue();
+    mockPollRunnerAssignment.mockImplementation(async (_controlSessionToken, signal) => {
+      process.emit('SIGTERM');
+      await Promise.reject(new DOMException('The operation was aborted', 'AbortError'));
+      return signal?.aborted ? null : 'activation-token';
+    });
+
+    await expect(startRunner()).resolves.toBeUndefined();
+
+    expect(mockRegisterRunnerSession).not.toHaveBeenCalled();
+    expect(mockRequestJob).not.toHaveBeenCalled();
   });
 
   it('registers a new session when the current session is unauthorized', async () => {

--- a/libs/runner/orchestration/src/core/runner.ts
+++ b/libs/runner/orchestration/src/core/runner.ts
@@ -8,13 +8,20 @@ import {
 } from '@shipfox/node-resilient-loop';
 import {runnerToolCapabilities} from '@shipfox/runner-agent';
 import {
+  consumeManagedRunnerBootstrapToken,
   createLeaseClient,
+  enrollRunnerControlSession,
+  exchangeRunnerBootstrapToken,
   HTTPError,
+  heartbeatRunnerControlSession,
+  managedRunnerEnrollmentConfig,
+  pollRunnerAssignment,
   RunnerSessionExhaustedError,
   registerRunnerSession,
   requestJob,
   requireRunnerLabels,
   runnerRegistrationToken,
+  runnerStartupMode,
 } from '@shipfox/runner-protocol';
 import {
   cleanupJobCredentials,
@@ -55,6 +62,7 @@ export async function startRunner(): Promise<void> {
   // not silently fail every job.
   const workspaceRoot = resolveWorkspaceRootFromEnv();
   requireRunnerLabels();
+  const startupMode = runnerStartupMode();
 
   logger().info(
     {
@@ -66,9 +74,12 @@ export async function startRunner(): Promise<void> {
   );
 
   let currentInterval = config.SHIPFOX_POLL_INTERVAL_MS;
-  let runnerSession: RunnerSession | undefined;
-
   await interruptableSleep(withJitter(config.SHIPFOX_POLL_INTERVAL_MS));
+  let runnerSession: RunnerSession | undefined;
+  if (startupMode === 'managed') {
+    runnerSession = await initializeManagedRunnerSession();
+    if (!runnerSession) return;
+  }
   let pollDeadline = nextPollDeadline();
 
   while (running) {
@@ -106,6 +117,10 @@ export async function startRunner(): Promise<void> {
       pollDeadline = nextPollDeadline();
     } catch (pollError) {
       if (isUnauthorized(pollError)) {
+        if (startupMode === 'managed') {
+          logger().info('Activated runner session rejected; runner exiting');
+          return;
+        }
         runnerSession = undefined;
         logger().info('Runner session rejected; registering a new session');
         if (hasPollDeadlinePassed(pollDeadline)) {
@@ -174,7 +189,8 @@ export async function runJob(
   let currentLeaseToken = initialLeaseToken;
   let previousRenewedLeaseToken: string | undefined;
   let currentRenewedLeaseToken: string | undefined;
-  const secrets = [runnerSecret, initialLeaseToken];
+  const runnerSecrets = runnerSecret.length > 0 ? [runnerSecret] : [];
+  const secrets = [...runnerSecrets, initialLeaseToken];
   const leaseTokenSecretSubscribers = new Set<(secrets: string[]) => void>();
   const rotatingLeaseSecrets = () =>
     [previousRenewedLeaseToken, currentRenewedLeaseToken].filter(
@@ -185,7 +201,13 @@ export async function runJob(
     previousRenewedLeaseToken = currentRenewedLeaseToken;
     currentRenewedLeaseToken = leaseToken;
     currentLeaseToken = leaseToken;
-    secrets.splice(0, secrets.length, runnerSecret, initialLeaseToken, ...rotatingLeaseSecrets());
+    secrets.splice(
+      0,
+      secrets.length,
+      ...runnerSecrets,
+      initialLeaseToken,
+      ...rotatingLeaseSecrets(),
+    );
     for (const subscriber of leaseTokenSecretSubscribers) subscriber(rotatingLeaseSecrets());
   };
 
@@ -238,6 +260,81 @@ export async function runJob(
     await cleanupWorkspace(cwd);
     await cleanupJobLogs(logsDir);
   }
+}
+
+async function initializeManagedRunnerSession(): Promise<RunnerSession | undefined> {
+  const bootstrapToken = consumeManagedRunnerBootstrapToken();
+  const exchanged = await exchangeRunnerBootstrapToken(bootstrapToken);
+  const controlSessionToken = exchanged.controlSessionToken;
+  const enrollmentConfig = managedRunnerEnrollmentConfig();
+  await enrollRunnerControlSession({
+    controlSessionToken,
+    capabilities: runnerToolCapabilities(),
+    providerKind: enrollmentConfig.providerKind,
+    protocolVersion: enrollmentConfig.protocolVersion,
+  });
+  const activationToken = await waitForRunnerActivation(controlSessionToken);
+  if (!activationToken) return undefined;
+
+  const runnerSession = await registerRunnerSession({
+    capabilities: runnerToolCapabilities(),
+    registrationToken: activationToken,
+  });
+  logger().info({runnerSessionId: runnerSession.session_id}, 'Managed runner activated');
+  return runnerSession;
+}
+
+async function waitForRunnerActivation(controlSessionToken: string): Promise<string | undefined> {
+  const controller = new AbortController();
+  const abortOnShutdown = () => controller.abort();
+  shutdownController.signal.addEventListener('abort', abortOnShutdown, {once: true});
+  let heartbeatError: unknown;
+  let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+  const heartbeat = async () => {
+    try {
+      await heartbeatRunnerControlSession(controlSessionToken, controller.signal);
+    } catch (error) {
+      heartbeatError = error;
+      controller.abort();
+    }
+  };
+  try {
+    await heartbeat();
+    if (!running) return undefined;
+    if (heartbeatError) return handleControlSessionError(heartbeatError);
+    heartbeatTimer = setInterval(() => void heartbeat(), config.SHIPFOX_HEARTBEAT_INTERVAL_MS);
+    while (running && !controller.signal.aborted) {
+      try {
+        const activationToken = await pollRunnerAssignment(controlSessionToken, controller.signal);
+        if (activationToken) return activationToken;
+      } catch (error) {
+        if (!running) return undefined;
+        if (controller.signal.aborted && heartbeatError)
+          return handleControlSessionError(heartbeatError);
+        if (isTerminalControlSessionError(error)) return handleControlSessionError(error);
+        throw error;
+      }
+    }
+    return undefined;
+  } finally {
+    if (heartbeatTimer) clearInterval(heartbeatTimer);
+    shutdownController.signal.removeEventListener('abort', abortOnShutdown);
+    controller.abort();
+  }
+}
+
+function handleControlSessionError(error: unknown): undefined {
+  if (isTerminalControlSessionError(error)) {
+    logger().info('Runner control session is no longer usable; runner exiting');
+    return undefined;
+  }
+  throw error;
+}
+
+function isTerminalControlSessionError(error: unknown): boolean {
+  return (
+    error instanceof HTTPError && (error.response.status === 401 || error.response.status === 409)
+  );
 }
 
 function isUnauthorized(error: unknown): boolean {

--- a/libs/runner/protocol/src/api-client.test.ts
+++ b/libs/runner/protocol/src/api-client.test.ts
@@ -11,8 +11,12 @@ import {
   AgentRuntimeConfigRequestError,
   appendStepLogs,
   createLeaseClient,
+  enrollRunnerControlSession,
+  exchangeRunnerBootstrapToken,
   HTTPError,
   heartbeat,
+  heartbeatRunnerControlSession,
+  pollRunnerAssignment,
   RunnerSessionExhaustedError,
   registerRunnerSession,
   reportStep,
@@ -81,6 +85,54 @@ describe('runner labels', () => {
 });
 
 describe('api-client auth contexts', () => {
+  it('exchanges a bootstrap token without granting job-plane authority', async () => {
+    stubFetch(() =>
+      jsonResponse({
+        runner_instance_id: crypto.randomUUID(),
+        control_session_token: 'control-token',
+        expires_at: '2026-07-21T12:00:00.000Z',
+      }),
+    );
+
+    const session = await exchangeRunnerBootstrapToken('bootstrap-token');
+
+    expect(session).toEqual({controlSessionToken: 'control-token'});
+    expect(calls[0]?.url).toContain('runner-enrollment/exchange');
+    expect(calls[0]?.authorization).toBeNull();
+    expect(JSON.parse(calls[0]?.body ?? '{}')).toEqual({bootstrap_token: 'bootstrap-token'});
+  });
+
+  it('enrolls, heartbeats, and polls only with the control-session token', async () => {
+    stubFetch(() => new Response(null, {status: 204}));
+
+    await enrollRunnerControlSession({
+      controlSessionToken: 'control-token',
+      capabilities: TOOL_CAPABILITIES,
+      providerKind: 'ec2',
+      protocolVersion: '1',
+    });
+
+    expect(calls[0]?.url).toContain('runner-control/enrollment');
+    expect(calls[0]?.authorization).toBe('Bearer control-token');
+    expect(JSON.parse(calls[0]?.body ?? '{}')).toEqual({
+      labels: ['linux', 'x64'],
+      capabilities: TOOL_CAPABILITIES,
+      provider_kind: 'ec2',
+      protocol_version: '1',
+    });
+
+    stubFetch(() => jsonResponse({ok: true}));
+    await heartbeatRunnerControlSession('control-token');
+    expect(calls[1]?.url).toContain('runner-control/heartbeat');
+    expect(calls[1]?.authorization).toBe('Bearer control-token');
+
+    stubFetch(() => jsonResponse({activation_token: 'activation-token'}));
+    const activationToken = await pollRunnerAssignment('control-token');
+    expect(activationToken).toBe('activation-token');
+    expect(calls[2]?.url).toContain('runner-control/assignment');
+    expect(calls[2]?.authorization).toBe('Bearer control-token');
+  });
+
   it('registerRunnerSession sends the registration token and configured labels', async () => {
     stubFetch(() => jsonResponse(registerResponse()));
 

--- a/libs/runner/protocol/src/api-client.ts
+++ b/libs/runner/protocol/src/api-client.ts
@@ -19,6 +19,11 @@ import {
   type RunnerToolCapabilitiesDto,
   registerRunnerBodySchema,
   registerRunnerResponseSchema,
+  runnerAssignmentPollResponseSchema,
+  runnerBootstrapExchangeBodySchema,
+  runnerBootstrapExchangeResponseSchema,
+  runnerControlHeartbeatResponseSchema,
+  runnerEnrollmentBodySchema,
 } from '@shipfox/api-runners-dto';
 import {type StepSecretsResponseDto, stepSecretsResponseSchema} from '@shipfox/api-secrets-dto';
 import {
@@ -81,13 +86,6 @@ export type LogAppendFn = (args: {
 const baseUrl = config.SHIPFOX_API_URL.endsWith('/')
   ? config.SHIPFOX_API_URL
   : `${config.SHIPFOX_API_URL}/`;
-
-const registrationApi = ky.create({
-  baseUrl,
-  headers: {
-    Authorization: `Bearer ${config.SHIPFOX_RUNNER_REGISTRATION_TOKEN}`,
-  },
-});
 
 /**
  * The runner's registration bearer credential, exposed so the log masker can scrub it
@@ -153,7 +151,7 @@ export function requireRunnerLabels(): string[] {
 }
 
 export async function registerRunnerSession(
-  options: {capabilities?: RunnerToolCapabilitiesDto} = {},
+  options: {capabilities?: RunnerToolCapabilitiesDto; registrationToken?: string} = {},
 ): Promise<RegisterRunnerResponseDto> {
   const labels = configuredRunnerLabels();
 
@@ -163,9 +161,69 @@ export async function registerRunnerSession(
     labels,
     ...(options.capabilities ? {capabilities: options.capabilities} : {}),
   });
-  const response = await registrationApi.post('runners/register', {json: body});
+  const response = await createRegistrationApi(
+    options.registrationToken ?? config.SHIPFOX_RUNNER_REGISTRATION_TOKEN,
+  ).post('runners/register', {json: body});
 
   return registerRunnerResponseSchema.parse(await response.json());
+}
+
+function createRegistrationApi(registrationToken: string): KyInstance {
+  return ky.create({baseUrl, headers: {Authorization: `Bearer ${registrationToken}`}});
+}
+
+function createRunnerControlClient(controlSessionToken: string): KyInstance {
+  return ky.create({baseUrl, headers: {Authorization: `Bearer ${controlSessionToken}`}});
+}
+
+export async function exchangeRunnerBootstrapToken(
+  bootstrapToken: string,
+): Promise<{controlSessionToken: string}> {
+  const body = runnerBootstrapExchangeBodySchema.parse({bootstrap_token: bootstrapToken});
+  const response = await ky.post(new URL('runner-enrollment/exchange', baseUrl), {json: body});
+  const parsed = runnerBootstrapExchangeResponseSchema.parse(await response.json());
+  return {controlSessionToken: parsed.control_session_token};
+}
+
+export async function enrollRunnerControlSession(params: {
+  controlSessionToken: string;
+  capabilities: RunnerToolCapabilitiesDto;
+  providerKind: string;
+  protocolVersion: string;
+}): Promise<void> {
+  const body = runnerEnrollmentBodySchema.parse({
+    labels: configuredRunnerLabels(),
+    capabilities: params.capabilities,
+    provider_kind: params.providerKind,
+    protocol_version: params.protocolVersion,
+  });
+  await createRunnerControlClient(params.controlSessionToken).post('runner-control/enrollment', {
+    json: body,
+  });
+}
+
+export async function heartbeatRunnerControlSession(
+  controlSessionToken: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  const response = await createRunnerControlClient(controlSessionToken).post(
+    'runner-control/heartbeat',
+    signal ? {signal} : undefined,
+  );
+  runnerControlHeartbeatResponseSchema.parse(await response.json());
+}
+
+export async function pollRunnerAssignment(
+  controlSessionToken: string,
+  signal?: AbortSignal,
+): Promise<string | null> {
+  const response = await createRunnerControlClient(controlSessionToken).get(
+    'runner-control/assignment',
+    {
+      ...(signal ? {signal} : {}),
+    },
+  );
+  return runnerAssignmentPollResponseSchema.parse(await response.json()).activation_token;
 }
 
 function createRunnerSessionClient(sessionToken: string): KyInstance {

--- a/libs/runner/protocol/src/config.test.ts
+++ b/libs/runner/protocol/src/config.test.ts
@@ -1,0 +1,25 @@
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+describe('managed runner startup', () => {
+  it('consumes the bootstrap token without retaining it in configuration or the environment', async () => {
+    vi.stubEnv('SHIPFOX_RUNNER_REGISTRATION_TOKEN', '');
+    vi.stubEnv('SHIPFOX_RUNNER_BOOTSTRAP_TOKEN', 'sf_rbt_bootstrap-token');
+    vi.stubEnv('SHIPFOX_RUNNER_PROVIDER_KIND', 'ec2');
+    vi.resetModules();
+
+    const {config, consumeManagedRunnerBootstrapToken, runnerStartupMode} = await import(
+      '#config.js'
+    );
+
+    expect(runnerStartupMode()).toBe('managed');
+    expect(process.env.SHIPFOX_RUNNER_BOOTSTRAP_TOKEN).toBeUndefined();
+    expect(config.SHIPFOX_RUNNER_BOOTSTRAP_TOKEN).toBe('');
+    expect(consumeManagedRunnerBootstrapToken()).toBe('sf_rbt_bootstrap-token');
+    expect(() => consumeManagedRunnerBootstrapToken()).toThrow(
+      'SHIPFOX_RUNNER_BOOTSTRAP_TOKEN is required for managed startup.',
+    );
+  });
+});

--- a/libs/runner/protocol/src/config.ts
+++ b/libs/runner/protocol/src/config.ts
@@ -1,13 +1,65 @@
 import {createConfig, str} from '@shipfox/config';
 
+let bootstrapToken = process.env.SHIPFOX_RUNNER_BOOTSTRAP_TOKEN ?? '';
+delete process.env.SHIPFOX_RUNNER_BOOTSTRAP_TOKEN;
+
 export const config = createConfig({
   SHIPFOX_API_URL: str({
     desc: 'Base URL of the Shipfox API the runner connects to, such as https://api.shipfox.io. Required.',
   }),
   SHIPFOX_RUNNER_REGISTRATION_TOKEN: str({
-    desc: 'Manual or ephemeral registration token the runner exchanges for a short-lived runner session token at startup. Use a value starting with sf_mrt_ or sf_ert_. Required, with no default, so startup fails when it is missing rather than sending a predictable token.',
+    desc: 'Manual or ephemeral registration token the runner exchanges for a short-lived runner session token at startup. Use a value starting with sf_mrt_ or sf_ert_. Set this or SHIPFOX_RUNNER_BOOTSTRAP_TOKEN, but not both.',
+    default: '',
+  }),
+  SHIPFOX_RUNNER_BOOTSTRAP_TOKEN: str({
+    desc: 'One-use provisioner-managed bootstrap token. The runner exchanges it for a workspace-neutral control session before waiting for an assignment. Set this or SHIPFOX_RUNNER_REGISTRATION_TOKEN, but not both.',
+    default: '',
+  }),
+  SHIPFOX_RUNNER_PROVIDER_KIND: str({
+    desc: 'Provider kind the managed runner declares during enrollment, such as ec2 or docker. Required when SHIPFOX_RUNNER_BOOTSTRAP_TOKEN is set.',
+    default: '',
+  }),
+  SHIPFOX_RUNNER_PROTOCOL_VERSION: str({
+    desc: 'Runner protocol version the managed runner declares during enrollment. Use the version supported by this runner image.',
+    default: '1',
   }),
   SHIPFOX_RUNNER_LABELS: str({
     desc: 'Comma-separated labels this runner registers with, such as linux,x64,self-hosted. Required, with no default, so startup fails when labels are missing.',
   }),
 });
+
+export type RunnerStartupMode = 'direct' | 'managed';
+
+export function runnerStartupMode(): RunnerStartupMode {
+  const hasRegistrationToken = config.SHIPFOX_RUNNER_REGISTRATION_TOKEN.length > 0;
+  const hasBootstrapToken = bootstrapToken.length > 0;
+  if (hasRegistrationToken === hasBootstrapToken) {
+    throw new Error(
+      'Set exactly one of SHIPFOX_RUNNER_REGISTRATION_TOKEN or SHIPFOX_RUNNER_BOOTSTRAP_TOKEN.',
+    );
+  }
+  if (hasBootstrapToken && config.SHIPFOX_RUNNER_PROVIDER_KIND.length === 0) {
+    throw new Error(
+      'SHIPFOX_RUNNER_PROVIDER_KIND is required with SHIPFOX_RUNNER_BOOTSTRAP_TOKEN.',
+    );
+  }
+  return hasBootstrapToken ? 'managed' : 'direct';
+}
+
+export function consumeManagedRunnerBootstrapToken(): string {
+  if (bootstrapToken.length === 0)
+    throw new Error('SHIPFOX_RUNNER_BOOTSTRAP_TOKEN is required for managed startup.');
+  const token = bootstrapToken;
+  bootstrapToken = '';
+  return token;
+}
+
+export function managedRunnerEnrollmentConfig(): {
+  providerKind: string;
+  protocolVersion: string;
+} {
+  return {
+    providerKind: config.SHIPFOX_RUNNER_PROVIDER_KIND,
+    protocolVersion: config.SHIPFOX_RUNNER_PROTOCOL_VERSION,
+  };
+}

--- a/libs/runner/protocol/src/index.ts
+++ b/libs/runner/protocol/src/index.ts
@@ -5,11 +5,15 @@ export {
   appendStepLogs,
   configuredRunnerLabels,
   createLeaseClient,
+  enrollRunnerControlSession,
+  exchangeRunnerBootstrapToken,
   HTTPError,
   heartbeat,
+  heartbeatRunnerControlSession,
   type LeaseTokenSource,
   type LogAppendFn,
   type LogAppendOutcome,
+  pollRunnerAssignment,
   RunnerLabelsRequiredError,
   RunnerSessionExhaustedError,
   registerRunnerSession,
@@ -24,6 +28,12 @@ export {
   StepSecretsRequestError,
   writeStepAnnotations,
 } from '#api-client.js';
+export {
+  consumeManagedRunnerBootstrapToken,
+  managedRunnerEnrollmentConfig,
+  type RunnerStartupMode,
+  runnerStartupMode,
+} from '#config.js';
 export {
   createIntegrationToolsGatewayFetch,
   integrationToolsGatewayUrl,


### PR DESCRIPTION
Adds a managed startup path that exchanges a bootstrap token, enrolls the runner, keeps its control session healthy while it waits for its own assignment, and activates into the existing runner session protocol.

Provisioner-managed runners need to boot before a workspace is known. This keeps their pre-activation credentials off the job plane, consumes the bootstrap credential before polling, and preserves the existing direct registration path and retry behavior.

The control-session wait exits cleanly on shutdown, expiry, revocation, or activation-session rejection. The control APIs intentionally use only the control token; the activation token is used only to create the job-plane runner session.

Closes ENG-1091

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a managed startup mode for provisioner-managed runners: enroll via a bootstrap token, wait for assignment, then activate into the existing runner session. Keeps pre-activation credentials off the job plane and exits cleanly on shutdown, expiry, revocation, or activation rejection.

- **New Features**
  - `startRunner()` supports managed flow: exchange `SHIPFOX_RUNNER_BOOTSTRAP_TOKEN`, enroll control session (labels + capabilities), heartbeat while waiting, poll assignment, then register with the activation token.
  - Control APIs use only the control token; activation is used only for the job-plane session.
  - `@shipfox/runner-protocol`: adds `runnerStartupMode()`, `consumeManagedRunnerBootstrapToken()`, `managedRunnerEnrollmentConfig()`, and client helpers `exchangeRunnerBootstrapToken()`, `enrollRunnerControlSession()`, `heartbeatRunnerControlSession()`, `pollRunnerAssignment()`.
  - README documents new env vars and managed startup; tests cover managed flow, retries, and clean exits. Meets `ENG-1091`.

- **Migration**
  - Set exactly one of `SHIPFOX_RUNNER_REGISTRATION_TOKEN` or `SHIPFOX_RUNNER_BOOTSTRAP_TOKEN`.
  - For managed mode, set `SHIPFOX_RUNNER_PROVIDER_KIND` and optionally `SHIPFOX_RUNNER_PROTOCOL_VERSION` (default `1`).
  - `SHIPFOX_RUNNER_LABELS` remains required.

<sup>Written for commit e943a7f072cfdc71a128b9464b34cde5267c4f78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

