### PR TITLE
[provisioner-ec2] Add runner bootstrap user data

### DIFF
--- a/infra/images/runner/README.md
+++ b/infra/images/runner/README.md
@@ -20,11 +20,17 @@ Packer is pinned in `mise.toml`. Install QEMU and `xorriso` through the host ope
 Cloud-init writes `/etc/shipfox/runner.env`. The provider owns the values and must never bake them into the image:
 
 - `SHIPFOX_API_URL`: API base URL.
-- `SHIPFOX_RUNNER_REGISTRATION_TOKEN`: single-use runner registration token.
+- `SHIPFOX_RUNNER_BOOTSTRAP_TOKEN`: one-use managed-runner bootstrap token.
+- `SHIPFOX_RUNNER_PROVIDER_KIND`: provider identifier declared during enrollment, such as `ec2`.
+- `SHIPFOX_RUNNER_PROTOCOL_VERSION`: managed-runner protocol version. The current image supports `1`.
 - `SHIPFOX_RUNNER_LABELS`: comma-separated runner labels.
 - `SHIPFOX_POLL_MAX_DURATION_MS`: runner polling deadline. `0` means forever.
 - `SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS`: hard instance lifetime. Use a value comfortably above one job's maximum duration.
 - `AGENT_CUSTOM_PROVIDER_ALLOW_PRIVATE_NETWORKS=false`: required for cloud runners.
+
+The image derives its tool capabilities from its baked runner runtime and sends them during
+enrollment. Providers do not inject capabilities, workspace IDs, workspace registration tokens,
+or activation tokens into user data.
 
 `shipfox-runner.service` powers off immediately when the runner exits. Its SIGTERM drain budget is 90 seconds, after which systemd can force-kill the process and the backend re-reserves the job. `shipfox-max-lifetime.service` schedules a forced poweroff and falls back to a baked 3600-second limit when the configured value is missing or malformed. AWS builds also enable a Spot IMDSv2 watcher that stops the runner, allows it to drain briefly, then powers off.
 

--- a/libs/provisioner/ec2/README.md
+++ b/libs/provisioner/ec2/README.md
@@ -10,6 +10,12 @@ wiring land in later issues.
 - `loadEc2Templates(filePath)` reads, parses, and validates EC2 template YAML.
 - `Ec2TemplateSpec` describes the EC2 launch details for a template.
 - `Ec2TemplateConfigError` identifies a missing, malformed, or invalid template file.
+- `renderRunnerBootstrapUserData(options)` renders cloud-init for the prebaked managed-runner image.
+- `redactRunnerBootstrapUserData(options)` returns launch metadata that is safe to log.
+
+The user-data renderer writes the API URL, one-use bootstrap token, runner-declared labels,
+managed-runner protocol metadata, poll deadline, and watchdog lifetime. It never renders a
+workspace ID, workspace registration token, or activation token.
 
 ## Template config
 

--- a/libs/provisioner/ec2/src/index.ts
+++ b/libs/provisioner/ec2/src/index.ts
@@ -4,3 +4,9 @@ export {
   type Ec2TemplateSpec,
   loadEc2Templates,
 } from '#templates.js';
+export {
+  type RedactedRunnerBootstrapUserData,
+  type RunnerBootstrapUserDataOptions,
+  redactRunnerBootstrapUserData,
+  renderRunnerBootstrapUserData,
+} from '#user-data.js';

--- a/libs/provisioner/ec2/src/user-data.test.ts
+++ b/libs/provisioner/ec2/src/user-data.test.ts
@@ -1,0 +1,66 @@
+import {
+  type RunnerBootstrapUserDataOptions,
+  redactRunnerBootstrapUserData,
+  renderRunnerBootstrapUserData,
+} from '#user-data.js';
+
+const options: RunnerBootstrapUserDataOptions = {
+  apiUrl: 'https://api.shipfox.test',
+  bootstrapToken: 'sf_rbt_sensitive-bootstrap-token',
+  labels: ['linux', 'x64', 'self-hosted'],
+  pollMaxDurationMs: 300_000,
+  maxLifetimeSeconds: 3600,
+};
+
+describe('renderRunnerBootstrapUserData', () => {
+  it('writes the managed runner environment contract for cloud-init', () => {
+    const userData = renderRunnerBootstrapUserData(options);
+
+    expect(userData).toBe(`#cloud-config
+write_files:
+  - path: /etc/shipfox/runner.env
+    owner: root:root
+    permissions: '0600'
+    content: |
+      SHIPFOX_API_URL="https://api.shipfox.test"
+      SHIPFOX_RUNNER_BOOTSTRAP_TOKEN="sf_rbt_sensitive-bootstrap-token"
+      SHIPFOX_RUNNER_PROVIDER_KIND="ec2"
+      SHIPFOX_RUNNER_PROTOCOL_VERSION="1"
+      SHIPFOX_RUNNER_LABELS="linux,x64,self-hosted"
+      SHIPFOX_POLL_MAX_DURATION_MS="300000"
+      SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS="3600"
+`);
+  });
+
+  it('does not render workspace-scoped registration material', () => {
+    const userData = renderRunnerBootstrapUserData(options);
+
+    expect(userData).not.toContain('SHIPFOX_RUNNER_REGISTRATION_TOKEN');
+    expect(userData).not.toContain('WORKSPACE_ID');
+  });
+
+  it('rejects unsafe environment values', () => {
+    const invalidOptions = {...options, bootstrapToken: 'token\nWORKSPACE_ID=leaked'};
+
+    expect(() => renderRunnerBootstrapUserData(invalidOptions)).toThrow(
+      'SHIPFOX_RUNNER_BOOTSTRAP_TOKEN must not contain a line break.',
+    );
+  });
+});
+
+describe('redactRunnerBootstrapUserData', () => {
+  it('keeps bootstrap material out of launch-log metadata', () => {
+    const redacted = redactRunnerBootstrapUserData(options);
+
+    expect(redacted).toEqual({
+      envPath: '/etc/shipfox/runner.env',
+      labels: ['linux', 'x64', 'self-hosted'],
+      providerKind: 'ec2',
+      protocolVersion: '1',
+      pollMaxDurationMs: 300_000,
+      maxLifetimeSeconds: 3600,
+    });
+    expect(JSON.stringify(redacted)).not.toContain(options.bootstrapToken);
+    expect(JSON.stringify(redacted)).not.toContain(options.apiUrl);
+  });
+});

--- a/libs/provisioner/ec2/src/user-data.ts
+++ b/libs/provisioner/ec2/src/user-data.ts
@@ -1,0 +1,109 @@
+const CLOUD_INIT_HEADER = '#cloud-config';
+const RUNNER_ENV_PATH = '/etc/shipfox/runner.env';
+
+/** Values written into the runner image environment file at EC2 boot. */
+export interface RunnerBootstrapUserDataOptions {
+  readonly apiUrl: string;
+  readonly bootstrapToken: string;
+  readonly labels: readonly string[];
+  readonly pollMaxDurationMs: number;
+  readonly maxLifetimeSeconds: number;
+  readonly providerKind?: string;
+  readonly protocolVersion?: string;
+}
+
+/** A safe-to-log summary of rendered user data. It intentionally omits credentials and contents. */
+export interface RedactedRunnerBootstrapUserData {
+  readonly envPath: string;
+  readonly labels: readonly string[];
+  readonly providerKind: string;
+  readonly protocolVersion: string;
+  readonly pollMaxDurationMs: number;
+  readonly maxLifetimeSeconds: number;
+}
+
+interface RunnerBootstrapEnvironment {
+  readonly SHIPFOX_API_URL: string;
+  readonly SHIPFOX_RUNNER_BOOTSTRAP_TOKEN: string;
+  readonly SHIPFOX_RUNNER_PROVIDER_KIND: string;
+  readonly SHIPFOX_RUNNER_PROTOCOL_VERSION: string;
+  readonly SHIPFOX_RUNNER_LABELS: string;
+  readonly SHIPFOX_POLL_MAX_DURATION_MS: string;
+  readonly SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS: string;
+}
+
+/**
+ * Renders the cloud-init configuration consumed by the prebaked Shipfox runner image.
+ * The runner image starts its systemd units after cloud-init and reads the environment
+ * file written here. No workspace-scoped credential is included.
+ */
+export function renderRunnerBootstrapUserData(options: RunnerBootstrapUserDataOptions): string {
+  const environment = runnerBootstrapEnvironment(options);
+  const envFile = Object.entries(environment)
+    .map(([key, value]) => `${key}=${escapeEnvironmentValue(value)}`)
+    .join('\n');
+
+  return `${CLOUD_INIT_HEADER}
+write_files:
+  - path: ${RUNNER_ENV_PATH}
+    owner: root:root
+    permissions: '0600'
+    content: |
+${indent(envFile, 6)}
+`;
+}
+
+/** Returns only non-sensitive metadata suitable for structured launch logs. */
+export function redactRunnerBootstrapUserData(
+  options: RunnerBootstrapUserDataOptions,
+): RedactedRunnerBootstrapUserData {
+  const environment = runnerBootstrapEnvironment(options);
+  return {
+    envPath: RUNNER_ENV_PATH,
+    labels: options.labels,
+    providerKind: environment.SHIPFOX_RUNNER_PROVIDER_KIND,
+    protocolVersion: environment.SHIPFOX_RUNNER_PROTOCOL_VERSION,
+    pollMaxDurationMs: options.pollMaxDurationMs,
+    maxLifetimeSeconds: options.maxLifetimeSeconds,
+  };
+}
+
+function runnerBootstrapEnvironment(
+  options: RunnerBootstrapUserDataOptions,
+): RunnerBootstrapEnvironment {
+  const providerKind = options.providerKind ?? 'ec2';
+  const protocolVersion = options.protocolVersion ?? '1';
+  const values = {
+    SHIPFOX_API_URL: options.apiUrl,
+    SHIPFOX_RUNNER_BOOTSTRAP_TOKEN: options.bootstrapToken,
+    SHIPFOX_RUNNER_PROVIDER_KIND: providerKind,
+    SHIPFOX_RUNNER_PROTOCOL_VERSION: protocolVersion,
+    SHIPFOX_RUNNER_LABELS: options.labels.join(','),
+    SHIPFOX_POLL_MAX_DURATION_MS: String(options.pollMaxDurationMs),
+    SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS: String(options.maxLifetimeSeconds),
+  };
+
+  for (const [key, value] of Object.entries(values)) {
+    if (value.length === 0) throw new Error(`${key} must not be empty.`);
+    if (value.includes('\n') || value.includes('\r'))
+      throw new Error(`${key} must not contain a line break.`);
+  }
+  if (!Number.isInteger(options.pollMaxDurationMs) || options.pollMaxDurationMs < 0)
+    throw new Error('pollMaxDurationMs must be a non-negative integer.');
+  if (!Number.isInteger(options.maxLifetimeSeconds) || options.maxLifetimeSeconds <= 0)
+    throw new Error('maxLifetimeSeconds must be a positive integer.');
+
+  return values;
+}
+
+function escapeEnvironmentValue(value: string): string {
+  return JSON.stringify(value);
+}
+
+function indent(value: string, spaces: number): string {
+  const padding = ' '.repeat(spaces);
+  return value
+    .split('\n')
+    .map((line) => `${padding}${line}`)
+    .join('\n');
+}


### PR DESCRIPTION
Adds a cloud-init renderer for the EC2 provider's managed runner bootstrap contract, plus safe metadata for lifecycle logs.\n\nProvisioned EC2 runners must start without workspace authority. The renderer supplies only the API URL, one-use bootstrap token, routing labels, protocol metadata, polling deadline, and hard lifetime watchdog.\n\nThe runner image derives its own tool capabilities during enrollment, so providers do not inject a capability payload. The renderer also rejects line-break injection and has no workspace registration or activation credential surface.\n\nCareful review: the generated environment file must stay aligned with the runner image contract as the unified provisioner adapter is wired in ENG-1013.\n\nCloses ENG-1009

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements EC2 managed-runner bootstrap user data and safe launch-log metadata per ENG-1009, aligning the provisioner with the runner image contract.

- **New Features**
  - Adds `renderRunnerBootstrapUserData` to write `/etc/shipfox/runner.env` via cloud-init with API URL, one-use bootstrap token, provider kind `ec2`, protocol version `1`, labels, poll deadline, and max lifetime.
  - Rejects empty values and line-break injection; validates polling and lifetime integers.
  - Never renders workspace-scoped credentials or capability payloads; the image derives capabilities at enrollment.
  - Adds `redactRunnerBootstrapUserData` to log only safe metadata (no tokens or API URL).
  - Exports new APIs from `libs/provisioner/ec2/src/index.ts`; updates `README.md`; adds tests for rendering, validation, and redaction.

<sup>Written for commit 029a1ea693ce607588c5cd55240345c48f39182e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

