### PR TITLE
[react-ui] Add Shiki diff line styling

### DIFF
--- a/.changeset/calm-diffs-glow.md
+++ b/.changeset/calm-diffs-glow.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/react-ui": patch
+---
+
+Adds Shiki-rendered styling for added and removed diff lines in code blocks.

--- a/libs/shared/react/ui/src/components/code-block/code-block-content.test.tsx
+++ b/libs/shared/react/ui/src/components/code-block/code-block-content.test.tsx
@@ -21,6 +21,10 @@ const highlightedHtml = [
 ].join('');
 
 describe('CodeBlockContent', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   test('highlights fallback-rendered lines', () => {
     renderCodeBlockContent({
       code: 'one\ntwo\nthree',
@@ -45,6 +49,55 @@ describe('CodeBlockContent', () => {
     expect(lines[1]?.textContent).toContain('- uses: actions/checkout@v3');
     expect(lines[1]?.classList.contains('diff')).toBe(false);
     expect(lines[1]?.classList.contains('remove')).toBe(false);
+  });
+
+  test('does not pass the diff transformer for YAML syntax highlighting', async () => {
+    const codeToHtmlMock = vi.mocked(codeToHtml);
+    codeToHtmlMock.mockResolvedValue(highlightedHtml);
+
+    renderCodeBlockContent({
+      code: 'steps:\n  - uses: actions/checkout@v3',
+      language: 'yaml',
+      syntaxHighlighting: true,
+    });
+
+    await waitFor(() => {
+      expect(codeToHtmlMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(codeToHtmlMock.mock.calls[0]?.[1].transformers).toBeUndefined();
+  });
+
+  test('passes a Shiki transformer that marks explicit diff content', async () => {
+    const codeToHtmlMock = vi.mocked(codeToHtml);
+    codeToHtmlMock.mockResolvedValue(highlightedHtml);
+
+    renderCodeBlockContent({
+      code: '--- a/workflow.yml\n-old value\n+new value\n+++ b/workflow.yml',
+      language: 'diff',
+      syntaxHighlighting: true,
+    });
+
+    await waitFor(() => {
+      expect(codeToHtmlMock).toHaveBeenCalledTimes(1);
+    });
+
+    const options = codeToHtmlMock.mock.calls[0]?.[1];
+    const transformer = options?.transformers?.[0];
+    const classes: string[] = [];
+    const context = {
+      source: '--- a/workflow.yml\n-old value\n+new value\n+++ b/workflow.yml',
+      addClassToHast: (_node: unknown, classNames: string[]) => {
+        classes.push(...classNames);
+      },
+    };
+
+    transformer?.line?.call(context as never, {} as never, 2);
+    transformer?.line?.call(context as never, {} as never, 3);
+    transformer?.line?.call(context as never, {} as never, 1);
+    transformer?.line?.call(context as never, {} as never, 4);
+
+    expect(classes).toEqual(['diff', 'remove', 'diff', 'add']);
   });
 
   test('highlights Shiki-rendered lines without re-highlighting on range-only changes', async () => {
@@ -154,11 +207,13 @@ describe('CodeBlockContent scroll-into-view', () => {
 
 function renderCodeBlockContent({
   code,
+  language,
   syntaxHighlighting,
   highlightedLineRange,
   scrollHighlightedIntoView,
 }: {
   code: string;
+  language?: string | undefined;
   syntaxHighlighting?: boolean | undefined;
   highlightedLineRange?: Parameters<typeof CodeBlockContent>[0]['highlightedLineRange'];
   scrollHighlightedIntoView?: boolean | undefined;
@@ -166,7 +221,7 @@ function renderCodeBlockContent({
   return render(
     <CodeBlockContentHost>
       <CodeBlockContent
-        language="text"
+        language={language ?? 'text'}
         highlightedLineRange={highlightedLineRange}
         {...(syntaxHighlighting === undefined ? {} : {syntaxHighlighting})}
         {...(scrollHighlightedIntoView === undefined ? {} : {scrollHighlightedIntoView})}

--- a/libs/shared/react/ui/src/components/code-block/code-block.stories.tsx
+++ b/libs/shared/react/ui/src/components/code-block/code-block.stories.tsx
@@ -134,6 +134,27 @@ export const DiffContent: Story = {
   render: () => <CodeBlockShowcase data={[diffFile]} syntaxHighlighting />,
 };
 
+export const DiffLineHighlighting: Story = {
+  play: async (ctx) => {
+    await waitFor(
+      () => {
+        if (!ctx.canvasElement.querySelector('.line.diff.add.highlighted-line')) {
+          throw new Error('Shiki diff line highlighting has not rendered yet');
+        }
+      },
+      {timeout: 10_000},
+    );
+    await argosScreenshot(ctx, 'CodeBlock DiffLineHighlighting');
+  },
+  render: () => (
+    <CodeBlockShowcase
+      data={[diffFile]}
+      syntaxHighlighting
+      highlightedLineRange={{startLine: 7, endLine: 8}}
+    />
+  ),
+};
+
 export const LineHighlighting: Story = {
   render: () => (
     <CodeBlockShowcase data={[workflowFile]} highlightedLineRange={{startLine: 3, endLine: 5}} />

--- a/libs/shared/react/ui/src/hooks/useShikiHighlight.ts
+++ b/libs/shared/react/ui/src/hooks/useShikiHighlight.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import {useEffect, useState} from 'react';
+import type {ShikiTransformer} from 'shiki';
 
 type ShikiThemes = {
   light: string;
@@ -14,6 +15,25 @@ type UseShikiHighlightOptions = {
   resolvedTheme: 'light' | 'dark';
   syntaxHighlighting: boolean;
 };
+
+function diffLineTransformer(): ShikiTransformer {
+  return {
+    name: '@shipfox/react-ui:diff-line-styling',
+    line(node, lineNumber) {
+      const line = this.source.split('\n')[lineNumber - 1] ?? '';
+
+      if (line.startsWith('+') && !line.startsWith('+++')) {
+        this.addClassToHast(node, ['diff', 'add']);
+      }
+
+      if (line.startsWith('-') && !line.startsWith('---')) {
+        this.addClassToHast(node, ['diff', 'remove']);
+      }
+
+      return node;
+    },
+  };
+}
 
 export function useShikiHighlight({
   code,
@@ -45,6 +65,7 @@ export function useShikiHighlight({
             dark: themes.dark,
           },
           defaultColor: resolvedTheme === 'dark' ? 'dark' : 'light',
+          ...(lang === 'diff' ? {transformers: [diffLineTransformer()]} : {}),
         });
 
         if (!cancelled) {


### PR DESCRIPTION
Add Shiki-native add/remove line classes when CodeBlock renders explicit `diff` syntax.

Code blocks previously had visual diff styles but no Shiki rendering path that attached those classes. This keeps generic source rendering, including YAML list markers, free of false deletion styling while making real diff content readable.

The transformer deliberately runs only for `language=\"diff\"` and excludes diff file headers. Storybook covers diff lines that overlap selected source-line highlighting.

Fixes ENG-591

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `shiki` transformer that tags added and removed lines in `diff` code blocks with explicit classes for clearer reading. Prevents YAML list markers from being mis-styled as deletions and addresses ENG-591.

- **New Features**
  - Apply `diff add`/`diff remove` classes via `shiki` only when `language` is `diff`, skipping file headers (`---`, `+++`).
  - Keep non-diff languages (e.g., YAML) free of diff styling.
  - Add Storybook example covering overlap with selected line highlights and tests verifying transformer behavior.

<sup>Written for commit c9185740e3e7989494f83941795a247cd5bc7efa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

