### PR TITLE
[e2e] Stabilize listener batching test

### DIFF
--- a/e2e/suites/flow/workflows/src/listener-helpers.ts
+++ b/e2e/suites/flow/workflows/src/listener-helpers.ts
@@ -207,6 +207,22 @@ export async function waitForListenerExecution(params: {
   });
 }
 
+export async function waitForListenerStatus(params: {
+  token: string;
+  runId: string;
+  jobKey: string;
+  listenerStatus: ListenerStatusDto;
+  timeoutMs: number;
+}): Promise<WorkflowRunDetailResponseDto> {
+  return await waitForRunDetailMatching({
+    token: params.token,
+    runId: params.runId,
+    timeoutMs: params.timeoutMs,
+    description: `listener job ${params.jobKey} status ${params.listenerStatus}`,
+    matches: (runDetail) => listenerStatusMatches({...params, runDetail}),
+  });
+}
+
 export async function waitForListenerResolution(params: {
   token: string;
   runId: string;

--- a/e2e/suites/flow/workflows/src/listener-jobs.ts
+++ b/e2e/suites/flow/workflows/src/listener-jobs.ts
@@ -235,50 +235,40 @@ export async function stepLogText(params: {
   return logText(logs.records);
 }
 
-export async function sendBatchPairUntilObserved(params: {
+export async function sendBatchPairAndAwaitExecution(params: {
   testCase: ListenerCase;
   runId: string;
   label: string;
+  sequence: number;
 }): Promise<{deliveryIds: string[]; runDetail: Awaited<ReturnType<typeof waitForRunTerminal>>}> {
-  let lastError: unknown;
-  for (let attempt = 1; attempt <= 6; attempt += 1) {
-    const deliveryIds = [
-      `${params.testCase.uniqueId}-${params.label}-${attempt}-a`,
-      `${params.testCase.uniqueId}-${params.label}-${attempt}-b`,
-    ];
-    for (const deliveryId of deliveryIds) {
-      params.testCase.fireDiagnostics.deliveryIds.push(deliveryId);
-      await postWebhookDelivery({
-        client: params.testCase.client,
-        connection: params.testCase.fireConnection,
-        deliveryId,
-        webhook: {body: {message: deliveryId, delivery_id: deliveryId}},
-      });
-    }
-
-    try {
-      const runDetail = await waitForRunDetailMatching({
-        token: params.testCase.token,
-        runId: params.runId,
-        timeoutMs: 8_000,
-        description: `batched listener deliveries ${deliveryIds.join(', ')}`,
-        matches: (candidate) =>
-          batchedListenerExecutionMatches({
-            runDetail: candidate,
-            jobKey: LISTENER_JOB,
-            sequence: 1,
-            deliveryIds,
-          }),
-      });
-      return {deliveryIds, runDetail};
-    } catch (error) {
-      lastError = error;
-    }
+  const deliveryIds = [
+    `${params.testCase.uniqueId}-${params.label}-a`,
+    `${params.testCase.uniqueId}-${params.label}-b`,
+  ];
+  for (const deliveryId of deliveryIds) {
+    params.testCase.fireDiagnostics.deliveryIds.push(deliveryId);
+    await postWebhookDelivery({
+      client: params.testCase.client,
+      connection: params.testCase.fireConnection,
+      deliveryId,
+      webhook: {body: {message: deliveryId, delivery_id: deliveryId}},
+    });
   }
 
-  throw lastError instanceof Error
-    ? lastError
-    : new Error('Batched listener deliveries were not observed');
+  const runDetail = await waitForRunDetailMatching({
+    token: params.testCase.token,
+    runId: params.runId,
+    timeoutMs: 8_000,
+    description: `batched listener deliveries ${deliveryIds.join(', ')}`,
+    matches: (candidate) =>
+      batchedListenerExecutionMatches({
+        runDetail: candidate,
+        jobKey: LISTENER_JOB,
+        sequence: params.sequence,
+        deliveryIds,
+      }),
+  });
+  return {deliveryIds, runDetail};
 }
 
 export const listenerWorkflows = {

--- a/e2e/suites/flow/workflows/tests/listener-jobs.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/listener-jobs.e2e.ts
@@ -2,6 +2,7 @@ import {
   findListenerExecutionByDeliveryIds,
   waitForListenerExecution,
   waitForListenerResolution,
+  waitForListenerStatus,
 } from '#listener-helpers.js';
 import {
   cleanupListenerCase,
@@ -9,7 +10,7 @@ import {
   LISTENER_JOB,
   type ListenerCase,
   listenerWorkflows,
-  sendBatchPairUntilObserved,
+  sendBatchPairAndAwaitExecution,
   sendFire,
   sendResolve,
   setupListenerCase,
@@ -210,7 +211,33 @@ test.describe('listener jobs', () => {
       });
       runId = await fireManualRun(testCase);
 
-      const batch = await sendBatchPairUntilObserved({testCase, runId, label: 'batch'});
+      await waitForListenerStatus({
+        token: testCase.token,
+        runId,
+        jobKey: LISTENER_JOB,
+        listenerStatus: 'listening',
+        timeoutMs: 8_000,
+      });
+      await sendBatchPairAndAwaitExecution({
+        testCase,
+        runId,
+        label: 'readiness',
+        sequence: 1,
+      });
+      await waitForListenerExecution({
+        token: testCase.token,
+        runId,
+        jobKey: LISTENER_JOB,
+        sequence: 1,
+        status: 'succeeded',
+        timeoutMs: 8_000,
+      });
+      const batch = await sendBatchPairAndAwaitExecution({
+        testCase,
+        runId,
+        label: 'batch',
+        sequence: 2,
+      });
       await sendResolve(testCase, 'resolve-batch');
       const terminal = await waitForRunTerminalOrFailedRunner({
         runId,
@@ -224,13 +251,13 @@ test.describe('listener jobs', () => {
         runDetail: terminal,
         token: testCase.token,
         jobKey: LISTENER_JOB,
-        sequence: 1,
+        sequence: 2,
         stepKey: 'show-batch',
       });
       expect(terminal.status).toBe('succeeded');
       expect(listen?.resolution_reason).toBe('until');
-      expect(listen?.job_executions).toHaveLength(1);
-      expect(listen?.job_executions[0]?.trigger_events.map((event) => event.delivery_id)).toEqual(
+      expect(listen?.job_executions).toHaveLength(2);
+      expect(listen?.job_executions[1]?.trigger_events.map((event) => event.delivery_id)).toEqual(
         batch.deliveryIds,
       );
       expect(logs).toContain(`batch_first=${batch.deliveryIds[0]}`);


### PR DESCRIPTION
Stabilize the listener batching flow test by replacing speculative webhook-pair retries with a bounded readiness handshake and one asserted batch.

The previous helper posted new real events after every observation timeout. Once the listener became active, its max-size batch could correctly combine deliveries from different attempts, leaving the test to wait for an impossible exact pair. The revised flow waits for the listener to be active, completes a readiness batch, and then asserts the next single batch.

This keeps the existing polling budget and removes the artificial retry behavior. The focused browser E2E could not start locally because this workspace is missing `@shipfox/vite/dist/index.js` for the client dev server; package build, test, type, and check tasks pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the listener batching E2E by replacing speculative webhook retries with a readiness handshake and asserting one deterministic batch. Waits for the listener to be active, completes a readiness batch, then validates the next single batch to remove flakiness.

- **Bug Fixes**
  - Added `waitForListenerStatus` to wait for `listening` before sending events.
  - Replaced `sendBatchPairUntilObserved` with `sendBatchPairAndAwaitExecution` using explicit sequence numbers.
  - Updated the test to run a readiness batch (sequence 1) and then assert the real batch (sequence 2), keeping the existing polling budget and removing artificial retries.

<sup>Written for commit 26b7b5ed6b5a210bd1fdda4486dda4703552867a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

