### PR TITLE
[client-auth] Clarify sign-in outage message

### DIFF
--- a/libs/client/auth/src/pages/form-errors.test.ts
+++ b/libs/client/auth/src/pages/form-errors.test.ts
@@ -42,7 +42,7 @@ describe('loginErrorToFormError', () => {
 
     expect(result).toEqual({
       kind: 'form',
-      message: 'Sign-in protection is temporarily unavailable. Try again soon.',
+      message: 'Sign-in is temporarily unavailable. Try again soon.',
     });
   });
 

--- a/libs/client/auth/src/pages/form-utils.test.ts
+++ b/libs/client/auth/src/pages/form-utils.test.ts
@@ -8,10 +8,7 @@ describe('authErrorMessage', () => {
     ['email-taken', 'An account already exists for this email.'],
     ['token-invalid', 'This link is invalid or expired.'],
     ['rate-limited', 'Too many attempts. Wait a bit and try again.'],
-    [
-      'auth-rate-limit-unavailable',
-      'Sign-in protection is temporarily unavailable. Try again soon.',
-    ],
+    ['auth-rate-limit-unavailable', 'Sign-in is temporarily unavailable. Try again soon.'],
     ['network-error', 'We could not reach the API. Check your connection and try again.'],
   ])('maps %s to client copy', (code, message) => {
     const error = new ApiError({code, message: 'Server copy', status: 400});

--- a/libs/client/auth/src/pages/form-utils.ts
+++ b/libs/client/auth/src/pages/form-utils.ts
@@ -19,7 +19,7 @@ export function authErrorMessage(error: unknown): string {
     return 'Too many attempts. Wait a bit and try again.';
   }
   if (error.code === 'auth-rate-limit-unavailable') {
-    return 'Sign-in protection is temporarily unavailable. Try again soon.';
+    return 'Sign-in is temporarily unavailable. Try again soon.';
   }
   if (error.code === 'network-error') {
     return 'We could not reach the API. Check your connection and try again.';


### PR DESCRIPTION
Clarify the login error shown when the auth rate limiter is unavailable.

The previous message suggested that a separate sign-in protection feature was unavailable, which was misleading during a server-side failure. The new copy tells users that sign-in itself is temporarily unavailable and retains the retry guidance.

The underlying error code and retry behavior are unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the login error shown when the auth rate limiter is unavailable. Users now see "Sign-in is temporarily unavailable. Try again soon.", reducing confusion; error codes and retry behavior remain unchanged.

<sup>Written for commit 806f74a3ff3d220efe8335bbacffa8a19a8ab2b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

