### PR TITLE
[docs] Add full PostHog analytics

### DIFF
--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -16,6 +16,24 @@ pnpm dev
 
 Open http://localhost:3500 with your browser to see the result.
 
+## Analytics
+
+The production Vercel deployment requires these public browser variables:
+
+```text
+NEXT_PUBLIC_POSTHOG_KEY=<project token>
+NEXT_PUBLIC_POSTHOG_HOST=<HTTPS ingestion host>
+```
+
+Set them only for the Vercel production environment. Local development and
+preview deployments omit both variables and do not send analytics. The values
+are included in browser code and visible in network requests, so neither value
+is a secret.
+
+The docs record every production session. In the PostHog project, keep session
+recording at 100% with no URL or event trigger, and keep request and response
+bodies, headers, and console logs disabled. Inputs are masked by the client SDK.
+
 ## Explore
 
 In the project, you can see:

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -3,11 +3,26 @@ import {createMDX} from 'fumadocs-mdx/next';
 
 const withMDX = createMDX();
 const workspaceRoot = fileURLToPath(new URL('../..', import.meta.url));
+const isVercelProduction = process.env.VERCEL_ENV === 'production';
+const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+const posthogHost = process.env.NEXT_PUBLIC_POSTHOG_HOST;
+
+if (isVercelProduction && (!posthogKey || !posthogHost)) {
+  throw new Error(
+    'NEXT_PUBLIC_POSTHOG_KEY and NEXT_PUBLIC_POSTHOG_HOST are required for the production docs deployment.',
+  );
+}
+
+if (posthogHost) {
+  const parsedPosthogHost = new URL(posthogHost);
+  if (isVercelProduction && parsedPosthogHost.protocol !== 'https:')
+    throw new Error('NEXT_PUBLIC_POSTHOG_HOST must use HTTPS in production.');
+}
 
 // The production docs deployment is mounted behind the cloud landing app at
 // www.shipfox.io/docs. Vercel previews stay rooted at / so preview URLs work
 // directly from the generated deployment URL.
-const basePath = process.env.VERCEL_ENV === 'production' ? '/docs' : '';
+const basePath = isVercelProduction ? '/docs' : '';
 
 /** @type {import('next').NextConfig} */
 const config = {

--- a/apps/docs/src/app/components/docs-analytics-tracker.tsx
+++ b/apps/docs/src/app/components/docs-analytics-tracker.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import {useEffect} from 'react';
+import {captureDocsEvent} from '@/lib/docs-analytics';
+import {destinationFromHref} from '@/lib/docs-analytics-core';
+
+const EDIT_ON_GITHUB_BASE =
+  'https://github.com/ShipfoxHQ/shipfox/edit/main/apps/docs/content/docs/';
+const CODE_BLOCK_SELECTOR = 'figure[data-docs-code-block]';
+
+export function DocsAnalyticsTracker() {
+  useEffect(() => {
+    function captureClick(event: MouseEvent) {
+      if (!(event.target instanceof Element)) return;
+
+      const copyButton = event.target.closest(
+        `${CODE_BLOCK_SELECTOR} button[aria-label="Copy Text"], ${CODE_BLOCK_SELECTOR} button[aria-label="Copied Text"]`,
+      );
+      if (copyButton) {
+        const codeBlock = copyButton.closest(CODE_BLOCK_SELECTOR);
+        if (!codeBlock) return;
+        const blocks = Array.from(document.querySelectorAll(CODE_BLOCK_SELECTOR));
+        const code = codeBlock.querySelector('code');
+        const languageClass = code
+          ? Array.from(code.classList).find((name) => name.startsWith('language-'))
+          : undefined;
+        captureDocsEvent('docs_code_copy_clicked', {
+          language: languageClass?.slice('language-'.length) || 'unknown',
+          block_index: blocks.indexOf(codeBlock),
+        });
+        return;
+      }
+
+      const anchor = event.target.closest<HTMLAnchorElement>('a[href]');
+      if (!anchor || anchor.dataset.docsAnalyticsCta !== undefined) return;
+      if (anchor.href.startsWith(EDIT_ON_GITHUB_BASE)) return;
+
+      const destination = destinationFromHref(anchor.href, window.location.href);
+      if (!destination || destination.origin === window.location.origin) return;
+      captureDocsEvent('docs_outbound_link_clicked', {
+        destination_origin: destination.origin,
+        destination_path: destination.pathname,
+      });
+    }
+
+    document.addEventListener('click', captureClick);
+    return () => document.removeEventListener('click', captureClick);
+  }, []);
+
+  return null;
+}

--- a/apps/docs/src/app/components/docs-card.tsx
+++ b/apps/docs/src/app/components/docs-card.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import {Card, type CardProps} from 'fumadocs-ui/components/card';
+import {captureDocsEvent} from '@/lib/docs-analytics';
+import {destinationFromHref} from '@/lib/docs-analytics-core';
+
+export function DocsCard({href, onClick, title, ...props}: CardProps) {
+  return (
+    <Card
+      {...props}
+      title={title}
+      href={href}
+      data-docs-analytics-cta=""
+      onClick={(event) => {
+        onClick?.(event);
+        if (event.defaultPrevented || !href) return;
+
+        const destination = destinationFromHref(href, window.location.href);
+        if (!destination) return;
+        captureDocsEvent('docs_cta_clicked', {
+          destination_path: destination.pathname,
+          ...(typeof title === 'string' ? {label: title} : {}),
+        });
+      }}
+    />
+  );
+}

--- a/apps/docs/src/app/components/integration-catalog.tsx
+++ b/apps/docs/src/app/components/integration-catalog.tsx
@@ -2,8 +2,10 @@
 
 import {Search, Webhook, X} from 'lucide-react';
 import Link from 'next/link';
-import {useMemo, useState} from 'react';
+import {useEffect, useMemo, useRef, useState} from 'react';
 import {siGithub, siLinear, siSentry, siSlack} from 'simple-icons';
+import {captureDocsEvent} from '@/lib/docs-analytics';
+import {nextCatalogSearchState, normalizeCatalogQuery} from '@/lib/docs-analytics-core';
 import {
   type CatalogIcon,
   type CatalogProvider,
@@ -17,6 +19,11 @@ import {
   INTEGRATION_CATALOG_CAPABILITIES,
   INTEGRATION_CATALOG_CATEGORIES,
 } from '@/lib/integration-catalog';
+import {
+  catalogFilterChangedProperties,
+  catalogResultClickedProperties,
+  catalogSearchProperties,
+} from '@/lib/integration-catalog-analytics';
 
 const availabilitySections = INTEGRATION_CATALOG_AVAILABILITIES;
 
@@ -27,6 +34,7 @@ interface IntegrationCatalogProps {
 export function IntegrationCatalog({providers}: IntegrationCatalogProps) {
   const [filters, setFilters] = useState(emptyCatalogFilters);
   const [filtersOpen, setFiltersOpen] = useState(false);
+  const lastCapturedQuery = useRef<string | null>(null);
   const filteredProviders = useMemo(
     () => filterProviders(providers, filters),
     [filters, providers],
@@ -35,8 +43,94 @@ export function IntegrationCatalog({providers}: IntegrationCatalogProps) {
   const activeFilterCount = filters.capability.length + filters.category.length;
   const hasFilters = filters.query.length > 0 || activeFilterCount > 0;
 
+  useEffect(() => {
+    const query = normalizeCatalogQuery(filters.query);
+    if (query.queryLength === 0) {
+      lastCapturedQuery.current = null;
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      const searchState = nextCatalogSearchState(lastCapturedQuery.current, query.dedupeKey);
+      lastCapturedQuery.current = searchState.lastQuery;
+      if (searchState.capture)
+        captureDocsEvent(
+          'docs_catalog_searched',
+          catalogSearchProperties(filters, filteredProviders.length),
+        );
+    }, 750);
+
+    return () => window.clearTimeout(timer);
+  }, [filteredProviders.length, filters]);
+
   function clearFilters() {
+    if (hasFilters)
+      captureDocsEvent(
+        'docs_catalog_filter_changed',
+        catalogFilterChangedProperties(providers, emptyCatalogFilters, {
+          facet: 'all',
+          value: 'all',
+          action: 'cleared',
+        }),
+      );
     setFilters(emptyCatalogFilters);
+  }
+
+  function toggleCapability(value: (typeof INTEGRATION_CATALOG_CAPABILITIES)[number]) {
+    const isSelected = filters.capability.includes(value);
+    const nextFilters = {
+      ...filters,
+      capability: toggleFilter(filters.capability, value),
+    };
+    setFilters(nextFilters);
+    captureDocsEvent(
+      'docs_catalog_filter_changed',
+      catalogFilterChangedProperties(providers, nextFilters, {
+        facet: 'capability',
+        value,
+        action: isSelected ? 'removed' : 'selected',
+      }),
+    );
+  }
+
+  function toggleCategory(value: (typeof INTEGRATION_CATALOG_CATEGORIES)[number]) {
+    const isSelected = filters.category.includes(value);
+    const nextFilters = {...filters, category: toggleFilter(filters.category, value)};
+    setFilters(nextFilters);
+    captureDocsEvent(
+      'docs_catalog_filter_changed',
+      catalogFilterChangedProperties(providers, nextFilters, {
+        facet: 'category',
+        value,
+        action: isSelected ? 'removed' : 'selected',
+      }),
+    );
+  }
+
+  function removeCapability(value: (typeof INTEGRATION_CATALOG_CAPABILITIES)[number]) {
+    const nextFilters = {...filters, capability: removeFilter(filters.capability, value)};
+    setFilters(nextFilters);
+    captureDocsEvent(
+      'docs_catalog_filter_changed',
+      catalogFilterChangedProperties(providers, nextFilters, {
+        facet: 'capability',
+        value,
+        action: 'removed',
+      }),
+    );
+  }
+
+  function removeCategory(value: (typeof INTEGRATION_CATALOG_CATEGORIES)[number]) {
+    const nextFilters = {...filters, category: removeFilter(filters.category, value)};
+    setFilters(nextFilters);
+    captureDocsEvent(
+      'docs_catalog_filter_changed',
+      catalogFilterChangedProperties(providers, nextFilters, {
+        facet: 'category',
+        value,
+        action: 'removed',
+      }),
+    );
   }
 
   return (
@@ -57,6 +151,7 @@ export function IntegrationCatalog({providers}: IntegrationCatalogProps) {
             id="integration-catalog-search"
             type="search"
             value={filters.query}
+            data-ph-no-autocapture=""
             onChange={(event) => setFilters((current) => ({...current, query: event.target.value}))}
             placeholder="Search by provider, type, or related term"
             className="h-11 w-full rounded-md border border-fd-border bg-fd-background py-2 pr-9 pl-10 text-sm text-fd-foreground outline-none placeholder:text-fd-muted-foreground focus-visible:ring-2 focus-visible:ring-fd-ring"
@@ -108,12 +203,7 @@ export function IntegrationCatalog({providers}: IntegrationCatalogProps) {
             selected={filters.capability}
             labels={catalogCapabilityLabels}
             counts={facetCounts.capability}
-            onToggle={(value) =>
-              setFilters((current) => ({
-                ...current,
-                capability: toggleFilter(current.capability, value),
-              }))
-            }
+            onToggle={toggleCapability}
           />
           <FacetGroup
             label="Type"
@@ -121,12 +211,7 @@ export function IntegrationCatalog({providers}: IntegrationCatalogProps) {
             selected={filters.category}
             labels={catalogCategoryLabels}
             counts={facetCounts.category}
-            onToggle={(value) =>
-              setFilters((current) => ({
-                ...current,
-                category: toggleFilter(current.category, value),
-              }))
-            }
+            onToggle={toggleCategory}
           />
         </div>
       </aside>
@@ -142,24 +227,14 @@ export function IntegrationCatalog({providers}: IntegrationCatalogProps) {
               <FilterChip
                 key={capability}
                 label={catalogCapabilityLabels[capability]}
-                onRemove={() =>
-                  setFilters((current) => ({
-                    ...current,
-                    capability: removeFilter(current.capability, capability),
-                  }))
-                }
+                onRemove={() => removeCapability(capability)}
               />
             ))}
             {filters.category.map((category) => (
               <FilterChip
                 key={category}
                 label={catalogCategoryLabels[category]}
-                onRemove={() =>
-                  setFilters((current) => ({
-                    ...current,
-                    category: removeFilter(current.category, category),
-                  }))
-                }
+                onRemove={() => removeCategory(category)}
               />
             ))}
           </div>
@@ -205,7 +280,21 @@ export function IntegrationCatalog({providers}: IntegrationCatalogProps) {
                   </h2>
                   <div className="grid gap-4 sm:grid-cols-2">
                     {sectionProviders.map((provider) => (
-                      <IntegrationCard key={provider.slug} provider={provider} />
+                      <IntegrationCard
+                        key={provider.slug}
+                        provider={provider}
+                        onNavigate={(target) =>
+                          captureDocsEvent(
+                            'docs_catalog_result_clicked',
+                            catalogResultClickedProperties(
+                              filters,
+                              filteredProviders,
+                              provider,
+                              target,
+                            ),
+                          )
+                        }
+                      />
                     ))}
                   </div>
                 </section>
@@ -286,13 +375,20 @@ function FilterChip({label, onRemove}: {label: string; onRemove: () => void}) {
   );
 }
 
-function IntegrationCard({provider}: {provider: CatalogProvider}) {
+function IntegrationCard({
+  provider,
+  onNavigate,
+}: {
+  provider: CatalogProvider;
+  onNavigate: (target: 'overview' | 'setup') => void;
+}) {
   return (
     <article className="flex min-h-56 flex-col rounded-lg border border-fd-border bg-fd-card p-5">
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0">
           <Link
             href={provider.overviewHref}
+            onClick={() => onNavigate('overview')}
             className="flex items-start gap-3 font-semibold text-fd-foreground outline-none hover:text-fd-primary hover:underline focus-visible:ring-2 focus-visible:ring-fd-ring"
           >
             <ProviderIcon icon={provider.icon} />
@@ -303,6 +399,7 @@ function IntegrationCard({provider}: {provider: CatalogProvider}) {
         {provider.setupHref ? (
           <Link
             href={provider.setupHref}
+            onClick={() => onNavigate('setup')}
             className="-mt-2 -mr-2 inline-flex min-h-11 shrink-0 items-center rounded-md px-2 text-sm font-medium text-fd-primary outline-none hover:underline focus-visible:ring-2 focus-visible:ring-fd-ring"
           >
             Set up

--- a/apps/docs/src/app/components/page-feedback.tsx
+++ b/apps/docs/src/app/components/page-feedback.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import posthog from 'posthog-js';
 import {useState} from 'react';
+import {captureDocsEvent} from '@/lib/docs-analytics';
 
 const GITHUB_EDIT_BASE = 'https://github.com/ShipfoxHQ/shipfox/edit/main/apps/docs/content/docs/';
 
@@ -10,7 +10,7 @@ export function PageFeedback({pageUrl, filePath}: {pageUrl: string; filePath: st
 
   const vote = (helpful: boolean) => {
     setVoted(true);
-    posthog.capture('docs_page_feedback', {page: pageUrl, helpful});
+    captureDocsEvent('docs_page_feedback', {page: pageUrl, helpful});
   };
 
   return (
@@ -40,6 +40,10 @@ export function PageFeedback({pageUrl, filePath}: {pageUrl: string; filePath: st
         href={`${GITHUB_EDIT_BASE}${filePath}`}
         target="_blank"
         rel="noreferrer"
+        data-docs-edit-link=""
+        onClick={() =>
+          captureDocsEvent('docs_edit_on_github_clicked', {page: pageUrl, file_path: filePath})
+        }
         className="underline underline-offset-4 transition-colors hover:text-fd-foreground"
       >
         Edit this page on GitHub

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -3,6 +3,7 @@ import {RootProvider} from 'fumadocs-ui/provider/next';
 import {Inter} from 'next/font/google';
 import localFont from 'next/font/local';
 import type {ReactNode} from 'react';
+import {DocsAnalyticsTracker} from '@/app/components/docs-analytics-tracker';
 import {basePath} from '@/url';
 
 const inter = Inter({
@@ -27,6 +28,7 @@ export default function Layout({children}: {children: ReactNode}) {
         <link rel="alternate" type="text/markdown" href="/llms.txt" />
       </head>
       <body className="flex flex-col min-h-screen">
+        <DocsAnalyticsTracker />
         {/* The search client fetches this URL as-is; Next does not apply basePath to
             it, so it must carry the /docs prefix in production (empty in dev). */}
         <RootProvider search={{options: {api: `${basePath}/api/search`}}}>{children}</RootProvider>

--- a/apps/docs/src/instrumentation-client.ts
+++ b/apps/docs/src/instrumentation-client.ts
@@ -1,10 +1,43 @@
 import posthog from 'posthog-js';
+import {sanitizePosthogCapture, sanitizeTrackedUrl} from '@/lib/docs-analytics-core';
 
 const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+const posthogHost = process.env.NEXT_PUBLIC_POSTHOG_HOST;
 
-if (posthogKey) {
+if (posthogKey && posthogHost) {
   posthog.init(posthogKey, {
-    api_host: 'https://ph.shipfox.io',
+    api_host: posthogHost,
     defaults: '2025-05-24',
+    autocapture: {
+      element_attribute_ignorelist: ['href', 'src', 'value'],
+    },
+    capture_pageview: 'history_change',
+    capture_pageleave: true,
+    capture_dead_clicks: true,
+    capture_heatmaps: true,
+    capture_performance: true,
+    capture_exceptions: true,
+    disable_session_recording: false,
+    enable_recording_console_log: false,
+    session_recording: {
+      maskAllInputs: true,
+      recordBody: false,
+      recordHeaders: false,
+      maskCapturedNetworkRequestFn: (request) => ({
+        ...request,
+        ...(request.name ? {name: sanitizeTrackedUrl(request.name)} : {}),
+      }),
+    },
+    person_profiles: 'identified_only',
+    before_send: sanitizePosthogCapture,
+    loaded: (client) => {
+      client.register({surface: 'docs'});
+      client.startSessionRecording({
+        sampling: true,
+        linked_flag: true,
+        url_trigger: true,
+        event_trigger: true,
+      });
+    },
   });
 }

--- a/apps/docs/src/lib/docs-analytics-core.test.ts
+++ b/apps/docs/src/lib/docs-analytics-core.test.ts
@@ -1,0 +1,130 @@
+import assert from 'node:assert/strict';
+import {describe, it} from 'node:test';
+import {
+  buildDocsEventProperties,
+  destinationFromHref,
+  nextCatalogSearchState,
+  normalizeCatalogQuery,
+  normalizeDocsLocation,
+  sanitizePosthogCapture,
+  sanitizeTrackedUrl,
+} from './docs-analytics-core';
+
+describe('normalizeCatalogQuery', () => {
+  it('normalizes a catalog query and preserves its length', () => {
+    const query = normalizeCatalogQuery('  Source   Control  ');
+
+    assert.deepEqual(query, {
+      query: 'source control',
+      queryLength: 14,
+      queryRedacted: false,
+      dedupeKey: 'source control',
+    });
+  });
+
+  it('limits the transmitted query without changing its measured length', () => {
+    const value = 'integration '.repeat(10).trim();
+    const query = normalizeCatalogQuery(value);
+
+    assert.equal(query.query, value.slice(0, 100));
+    assert.equal(query.queryLength, value.length);
+    assert.equal(query.queryRedacted, false);
+  });
+
+  for (const [name, value] of [
+    ['email', 'person@example.com'],
+    ['URL', 'https://example.com/private'],
+    ['credential assignment', 'client_secret=private-value'],
+    ['token-like value', 'prefix-abc123def456abc123def456abc123def456-suffix'],
+  ]) {
+    it(`redacts a query containing a ${name}`, () => {
+      const query = normalizeCatalogQuery(value);
+
+      assert.equal(query.query, '[redacted]');
+      assert.equal(query.queryRedacted, true);
+    });
+  }
+});
+
+describe('nextCatalogSearchState', () => {
+  it('deduplicates consecutive queries and resets after clearing', () => {
+    const first = nextCatalogSearchState(null, 'github');
+    const duplicate = nextCatalogSearchState(first.lastQuery, 'github');
+    const cleared = nextCatalogSearchState(duplicate.lastQuery, '');
+    const repeated = nextCatalogSearchState(cleared.lastQuery, 'github');
+
+    assert.equal(first.capture, true);
+    assert.equal(duplicate.capture, false);
+    assert.deepEqual(cleared, {capture: false, lastQuery: null});
+    assert.equal(repeated.capture, true);
+  });
+});
+
+describe('docs URL analytics', () => {
+  it('builds versioned docs event properties from a production path', () => {
+    const properties = buildDocsEventProperties('/docs/integrations/github', '/docs', {
+      provider: 'github',
+    });
+
+    assert.deepEqual(properties, {
+      surface: 'docs',
+      page_path: '/integrations/github',
+      docs_section: 'integrations',
+      schema_version: 1,
+      provider: 'github',
+    });
+  });
+
+  it('normalizes production and preview docs paths', () => {
+    const production = normalizeDocsLocation('/docs/integrations/github/', '/docs');
+    const preview = normalizeDocsLocation('/integrations/github/', '');
+
+    assert.deepEqual(production, {pagePath: '/integrations/github', docsSection: 'integrations'});
+    assert.deepEqual(preview, production);
+    assert.deepEqual(normalizeDocsLocation('/docs', '/docs'), {
+      pagePath: '/',
+      docsSection: 'home',
+    });
+  });
+
+  it('removes query strings and fragments from absolute and relative URLs', () => {
+    assert.equal(
+      sanitizeTrackedUrl('https://www.shipfox.io/docs?token=secret#section'),
+      'https://www.shipfox.io/docs',
+    );
+    assert.equal(sanitizeTrackedUrl('/docs/integrations?query=github'), '/docs/integrations');
+  });
+
+  it('sanitizes PostHog URL and referrer properties', () => {
+    const result = sanitizePosthogCapture({
+      uuid: '44b92a46-956f-4e6b-9994-d524f26f8d30',
+      event: '$pageview',
+      properties: {
+        $current_url: 'https://www.shipfox.io/docs?secret=value',
+        $referrer: 'https://example.com/source?campaign=private',
+        $session_entry_url: 'https://www.shipfox.io/docs?from=private#section',
+        retained: 'value',
+      },
+    });
+
+    assert.deepEqual(result?.properties, {
+      $current_url: 'https://www.shipfox.io/docs',
+      $referrer: 'https://example.com/source',
+      $session_entry_url: 'https://www.shipfox.io/docs',
+      retained: 'value',
+    });
+  });
+
+  it('classifies HTTP destinations without retaining query strings', () => {
+    const destination = destinationFromHref(
+      'https://github.com/ShipfoxHQ/shipfox?tab=readme#readme',
+      'https://www.shipfox.io/docs',
+    );
+
+    assert.deepEqual(destination, {
+      origin: 'https://github.com',
+      pathname: '/ShipfoxHQ/shipfox',
+    });
+    assert.equal(destinationFromHref('mailto:hello@shipfox.io', 'https://www.shipfox.io'), null);
+  });
+});

--- a/apps/docs/src/lib/docs-analytics-core.ts
+++ b/apps/docs/src/lib/docs-analytics-core.ts
@@ -1,0 +1,128 @@
+import type {CaptureResult} from 'posthog-js';
+
+const EMAIL_REGEX = /\b[^\s@]+@[^\s@]+\.[^\s@]+\b/i;
+const URL_SCHEME_REGEX = /\b[a-z][a-z\d+.-]*:\/\//i;
+const CREDENTIAL_ASSIGNMENT_REGEX =
+  /\b[\w.-]*(?:api[_-]?key|authorization|password|secret|token)[\w.-]*\s*[:=]\s*\S+/i;
+const TOKEN_REGEX = /[a-z\d_+/=-]{32,}/i;
+const URL_SUFFIX_REGEX = /[?#]/;
+const TRAILING_SLASH_REGEX = /\/+$/;
+const URL_PROPERTY_NAMES = [
+  '$current_url',
+  '$referrer',
+  '$initial_current_url',
+  '$initial_referrer',
+  '$session_entry_url',
+] as const;
+
+export interface CatalogQuery {
+  query: string;
+  queryLength: number;
+  queryRedacted: boolean;
+  dedupeKey: string;
+}
+
+export interface CatalogSearchState {
+  capture: boolean;
+  lastQuery: string | null;
+}
+
+export function buildDocsEventProperties<Properties extends object>(
+  pathname: string,
+  docsBasePath: string,
+  properties: Properties,
+) {
+  const {pagePath, docsSection} = normalizeDocsLocation(pathname, docsBasePath);
+  return {
+    surface: 'docs' as const,
+    page_path: pagePath,
+    docs_section: docsSection,
+    schema_version: 1 as const,
+    ...properties,
+  };
+}
+
+export function normalizeCatalogQuery(value: string): CatalogQuery {
+  const normalized = value.trim().toLocaleLowerCase().replaceAll(/\s+/g, ' ');
+  const queryRedacted = containsSensitiveQueryValue(normalized);
+
+  return {
+    query: queryRedacted ? '[redacted]' : normalized.slice(0, 100),
+    queryLength: normalized.length,
+    queryRedacted,
+    dedupeKey: normalized,
+  };
+}
+
+export function nextCatalogSearchState(
+  lastQuery: string | null,
+  currentQuery: string,
+): CatalogSearchState {
+  if (currentQuery.length === 0) return {capture: false, lastQuery: null};
+  if (currentQuery === lastQuery) return {capture: false, lastQuery};
+  return {capture: true, lastQuery: currentQuery};
+}
+
+export function normalizeDocsLocation(
+  pathname: string,
+  docsBasePath: string,
+): {pagePath: string; docsSection: string} {
+  const withoutBasePath =
+    docsBasePath && (pathname === docsBasePath || pathname.startsWith(`${docsBasePath}/`))
+      ? pathname.slice(docsBasePath.length)
+      : pathname;
+  const pagePath = normalizePathname(withoutBasePath);
+  const docsSection = pagePath === '/' ? 'home' : (pagePath.split('/')[1] ?? 'home');
+
+  return {pagePath, docsSection};
+}
+
+export function sanitizeTrackedUrl(value: string): string {
+  try {
+    const parsed = new URL(value, 'https://docs.invalid');
+    const sanitized = `${parsed.origin}${parsed.pathname}`;
+    return parsed.origin === 'https://docs.invalid' ? parsed.pathname : sanitized;
+  } catch {
+    return value.split(URL_SUFFIX_REGEX, 1)[0] ?? value;
+  }
+}
+
+export function sanitizePosthogCapture(result: CaptureResult | null): CaptureResult | null {
+  if (!result) return null;
+
+  const properties = {...result.properties};
+  for (const name of URL_PROPERTY_NAMES) {
+    const value = properties[name];
+    if (typeof value === 'string') properties[name] = sanitizeTrackedUrl(value);
+  }
+
+  return {...result, properties};
+}
+
+export function destinationFromHref(
+  href: string,
+  currentUrl: string,
+): {origin: string; pathname: string} | null {
+  try {
+    const destination = new URL(href, currentUrl);
+    if (destination.protocol !== 'http:' && destination.protocol !== 'https:') return null;
+    return {origin: destination.origin, pathname: normalizePathname(destination.pathname)};
+  } catch {
+    return null;
+  }
+}
+
+function containsSensitiveQueryValue(value: string): boolean {
+  return (
+    EMAIL_REGEX.test(value) ||
+    URL_SCHEME_REGEX.test(value) ||
+    CREDENTIAL_ASSIGNMENT_REGEX.test(value) ||
+    TOKEN_REGEX.test(value)
+  );
+}
+
+function normalizePathname(pathname: string): string {
+  const withLeadingSlash = pathname.startsWith('/') ? pathname : `/${pathname}`;
+  if (withLeadingSlash === '/') return withLeadingSlash;
+  return withLeadingSlash.replace(TRAILING_SLASH_REGEX, '');
+}

--- a/apps/docs/src/lib/docs-analytics.ts
+++ b/apps/docs/src/lib/docs-analytics.ts
@@ -1,0 +1,44 @@
+'use client';
+
+import posthog from 'posthog-js';
+import {buildDocsEventProperties} from '@/lib/docs-analytics-core';
+import type {CatalogCapability, CatalogCategory} from '@/lib/integration-catalog';
+import {basePath} from '@/url';
+
+interface CatalogContext {
+  query: string;
+  query_length: number;
+  query_redacted: boolean;
+  selected_capabilities: readonly CatalogCapability[];
+  selected_categories: readonly CatalogCategory[];
+}
+
+interface DocsAnalyticsEvents {
+  docs_page_feedback: {page: string; helpful: boolean};
+  docs_catalog_searched: CatalogContext & {result_count: number; has_results: boolean};
+  docs_catalog_filter_changed: CatalogContext & {
+    facet: 'capability' | 'category' | 'all';
+    value: string;
+    action: 'selected' | 'removed' | 'cleared';
+    result_count: number;
+  };
+  docs_catalog_result_clicked: CatalogContext & {
+    provider: string;
+    target: 'overview' | 'setup';
+    result_rank: number;
+    result_count: number;
+  };
+  docs_code_copy_clicked: {language: string; block_index: number};
+  docs_cta_clicked: {destination_path: string; label?: string};
+  docs_outbound_link_clicked: {destination_origin: string; destination_path: string};
+  docs_edit_on_github_clicked: {page: string; file_path: string};
+}
+
+export function captureDocsEvent<Event extends keyof DocsAnalyticsEvents>(
+  event: Event,
+  properties: DocsAnalyticsEvents[Event],
+): void {
+  if (typeof window === 'undefined') return;
+
+  posthog.capture(event, buildDocsEventProperties(window.location.pathname, basePath, properties));
+}

--- a/apps/docs/src/lib/integration-catalog-analytics.test.ts
+++ b/apps/docs/src/lib/integration-catalog-analytics.test.ts
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import {describe, it} from 'node:test';
+import type {CatalogFilters, CatalogProvider} from './integration-catalog';
+import {
+  catalogFilterChangedProperties,
+  catalogResultClickedProperties,
+  catalogSearchProperties,
+} from './integration-catalog-analytics';
+
+const providers: CatalogProvider[] = [
+  {
+    slug: 'github',
+    name: 'GitHub',
+    summary: 'Source control',
+    availability: 'available',
+    capabilities: ['source_control', 'events'],
+    categories: ['source-control'],
+    aliases: ['git'],
+    icon: 'github',
+    overviewHref: '/integrations/github',
+    setupHref: '/integrations/github/setup',
+    eventCount: 1,
+    toolCount: 1,
+  },
+  {
+    slug: 'sentry',
+    name: 'Sentry',
+    summary: 'Error events',
+    availability: 'available',
+    capabilities: ['events'],
+    categories: ['observability'],
+    aliases: ['monitoring'],
+    icon: 'sentry',
+    overviewHref: '/integrations/sentry',
+    eventCount: 1,
+    toolCount: 0,
+  },
+];
+
+describe('catalog analytics properties', () => {
+  it('builds a settled search payload with selected filters', () => {
+    const filters: CatalogFilters = {
+      query: ' GitHub ',
+      capability: ['events'],
+      category: ['source-control'],
+    };
+
+    const properties = catalogSearchProperties(filters, 1);
+
+    assert.deepEqual(properties, {
+      query: 'github',
+      query_length: 6,
+      query_redacted: false,
+      selected_capabilities: ['events'],
+      selected_categories: ['source-control'],
+      result_count: 1,
+      has_results: true,
+    });
+  });
+
+  it('reports the result count after a filter change', () => {
+    const filters: CatalogFilters = {
+      query: '',
+      capability: [],
+      category: ['observability'],
+    };
+
+    const properties = catalogFilterChangedProperties(providers, filters, {
+      facet: 'category',
+      value: 'observability',
+      action: 'selected',
+    });
+
+    assert.equal(properties.result_count, 1);
+    assert.equal(properties.action, 'selected');
+  });
+
+  it('reports the clicked target and rendered result rank', () => {
+    const filters: CatalogFilters = {query: '', capability: ['events'], category: []};
+
+    const properties = catalogResultClickedProperties(filters, providers, providers[1], 'setup');
+
+    assert.equal(properties.provider, 'sentry');
+    assert.equal(properties.target, 'setup');
+    assert.equal(properties.result_rank, 2);
+    assert.equal(properties.result_count, 2);
+  });
+});

--- a/apps/docs/src/lib/integration-catalog-analytics.ts
+++ b/apps/docs/src/lib/integration-catalog-analytics.ts
@@ -1,0 +1,56 @@
+import {normalizeCatalogQuery} from '@/lib/docs-analytics-core';
+import {
+  type CatalogFilters,
+  type CatalogProvider,
+  filterProviders,
+} from '@/lib/integration-catalog';
+
+export function catalogAnalyticsContext(filters: CatalogFilters) {
+  const query = normalizeCatalogQuery(filters.query);
+  return {
+    query: query.query,
+    query_length: query.queryLength,
+    query_redacted: query.queryRedacted,
+    selected_capabilities: filters.capability,
+    selected_categories: filters.category,
+  };
+}
+
+export function catalogSearchProperties(filters: CatalogFilters, resultCount: number) {
+  return {
+    ...catalogAnalyticsContext(filters),
+    result_count: resultCount,
+    has_results: resultCount > 0,
+  };
+}
+
+export function catalogFilterChangedProperties(
+  providers: readonly CatalogProvider[],
+  filters: CatalogFilters,
+  change: {
+    facet: 'capability' | 'category' | 'all';
+    value: string;
+    action: 'selected' | 'removed' | 'cleared';
+  },
+) {
+  return {
+    ...catalogAnalyticsContext(filters),
+    ...change,
+    result_count: filterProviders(providers, filters).length,
+  };
+}
+
+export function catalogResultClickedProperties(
+  filters: CatalogFilters,
+  filteredProviders: readonly CatalogProvider[],
+  provider: CatalogProvider,
+  target: 'overview' | 'setup',
+) {
+  return {
+    ...catalogAnalyticsContext(filters),
+    provider: provider.slug,
+    target,
+    result_rank: filteredProviders.findIndex((candidate) => candidate.slug === provider.slug) + 1,
+    result_count: filteredProviders.length,
+  };
+}

--- a/apps/docs/src/mdx-components.tsx
+++ b/apps/docs/src/mdx-components.tsx
@@ -1,12 +1,13 @@
 import {Accordion, Accordions} from 'fumadocs-ui/components/accordion';
 import {Callout} from 'fumadocs-ui/components/callout';
-import {Card, Cards} from 'fumadocs-ui/components/card';
+import {Cards} from 'fumadocs-ui/components/card';
 import {CodeBlock, Pre} from 'fumadocs-ui/components/codeblock';
 import {Step, Steps} from 'fumadocs-ui/components/steps';
 import {Tab, Tabs} from 'fumadocs-ui/components/tabs';
 import {TypeTable} from 'fumadocs-ui/components/type-table';
 import defaultMdxComponents from 'fumadocs-ui/mdx';
 import type {MDXComponents} from 'mdx/types';
+import {DocsCard} from '@/app/components/docs-card';
 import {DocsImage} from '@/app/components/docs-image';
 import {DocsVideo} from '@/app/components/docs-video';
 import {IntegrationCatalog as IntegrationCatalogClient} from '@/app/components/integration-catalog';
@@ -17,7 +18,7 @@ import {getIntegrationCatalog} from '@/lib/integration-catalog-source';
 export function getMDXComponents(components?: MDXComponents): MDXComponents {
   return {
     ...defaultMdxComponents,
-    Card,
+    Card: DocsCard,
     Cards,
     DocsImage,
     DocsVideo,
@@ -32,7 +33,7 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     TypeTable,
     img: DocsImage,
     pre: ({ref: _ref, ...props}) => (
-      <CodeBlock {...props}>
+      <CodeBlock {...props} data-docs-code-block="">
         <Pre>{props.children}</Pre>
       </CodeBlock>
     ),


### PR DESCRIPTION
Add full PostHog analytics to the Shipfox documentation site, including autocapture, navigation tracking, catalog demand events, quality signals, and full session replay.

The docs currently have almost no traffic, so recording every production session gives the team enough evidence to understand content demand and friction before introducing consent controls or downsampling. Catalog searches are normalized and sensitive-looking values are redacted before capture, while replay inputs remain masked and URL query strings are removed from analytics payloads.

The event contract is centralized so future consent and sampling policies can be introduced without changing individual docs components. PostHog initializes only when both public production variables are present, and Vercel production rejects missing or insecure configuration.

After deployment, the production PostHog project still needs its three dashboards created and the two public Vercel variables configured. Replay should remain at 100% with no URL or event trigger.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add full PostHog analytics to the docs site with safe autocapture, catalog demand tracking, and session replay. Events flow through a typed facade with URL/query sanitization and strict prod config checks.

- **New Features**
  - Added `captureDocsEvent` facade with versioned, `basePath`-aware properties and `before_send` URL sanitation.
  - Enabled `posthog-js` with masked inputs, no bodies/headers, sanitized network names, pageview/navigation tracking, and session replay.
  - Tracked docs interactions: code copy, CTAs (`DocsCard`), outbound links, page feedback, and “Edit on GitHub”.
  - Instrumented integration catalog: debounced search, filter changes, and result clicks with query normalization/redaction, dedupe, result rank/count.
  - Enforced production config: `NEXT_PUBLIC_POSTHOG_KEY` and HTTPS `NEXT_PUBLIC_POSTHOG_HOST` required; build fails if missing/invalid.
  - Added tests for URL/query sanitization and catalog analytics.

- **Migration**
  - Set `NEXT_PUBLIC_POSTHOG_KEY` and `NEXT_PUBLIC_POSTHOG_HOST` in the Vercel Production environment only.
  - In PostHog: keep session recording at 100% with no URL/event trigger; keep request/response bodies, headers, and console logs disabled.

<sup>Written for commit 3b86f53bab5f8e2022620bcc84a673824ad898d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

