### PR TITLE
Document runner-instance provisioner release contract

### DIFF
--- a/.changeset/bright-otters-prove.md
+++ b/.changeset/bright-otters-prove.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/application-release": patch
+---
+
+Verifies packed API runner composition with an installation provisioning policy.

--- a/apps/docs/content/docs/installation/runner-provisioner.mdx
+++ b/apps/docs/content/docs/installation/runner-provisioner.mdx
@@ -1,10 +1,13 @@
 ---
 title: "Run a Docker Runner Provisioner"
 sidebarTitle: "Runner Provisioner"
-description: "Start the Shipfox Docker runner provisioner from a source checkout and verify that it creates a runner for waiting work."
+description: "Start the Shipfox Docker runner provisioner from a source checkout and verify its runner-instance lifecycle."
 ---
 
-A [runner provisioner](/operations/runner-provisioners) starts ephemeral, single-job runner containers to meet demand. You don't hand-start runners or keep a fleet idle. This guide deploys the Docker provisioner.
+A [runner provisioner](/operations/runner-provisioners) creates runner instances,
+starts ephemeral compute, and activates each runner for at most one job. You do not
+hand a workspace registration credential to the provider. This guide deploys the Docker
+provisioner.
 
 ## Before you begin
 
@@ -26,7 +29,10 @@ A [runner provisioner](/operations/runner-provisioners) starts ephemeral, single
 
     **Create the token**
 
-    Click **Create token** and copy the value. It is shown only once. Treat it like a secret. It authenticates the provisioner to your workspace, and you can revoke it on the same page.
+    Click **Create token** and copy the value. It is shown only once. Treat it like a
+    secret. A workspace token can provision only its workspace. An installation token
+    can serve host-approved workspaces, but the runner still receives its workspace
+    only after immutable assignment. You can revoke either token on the same page.
   </Step>
 </Steps>
 
@@ -42,6 +48,7 @@ templates:
     cpu: 2
     memory: 4GiB
     max_concurrency: 100
+    target_concurrency: 0
 ```
 
 The full field semantics and selection rule live in the [Runner Provisioner reference](/reference/runner-provisioner#template-file-schema).
@@ -65,7 +72,28 @@ reference](/reference/runner-provisioner).
 
 ## Verify it works
 
-Fire a workflow whose `runner:` label matches one of your templates (for example `runner: ubuntu22`). Within a few seconds the provisioner starts a container. The container registers as a runner, claims the job, runs it, and exits. The run detail page shows the job leaving `pending` and streaming logs.
+Fire a workflow whose `runner:` label matches one of your templates (for example
+`runner: ubuntu22`). Within a few seconds the provisioner creates a runner instance
+and starts a container with a one-use bootstrap token. The container enrolls, receives
+an immutable assignment, activates, claims one job, runs it, and exits. The run detail
+page shows the job leaving `pending` and streaming logs.
+
+## Breaking protocol migration
+
+Provisioners built against the former capacity protocol must migrate as one release:
+
+1. Replace capacity creation, capacity assignment, and batch registration-token calls
+   with runner-instance creation and bootstrap tokens.
+2. Start compute with `SHIPFOX_RUNNER_BOOTSTRAP_TOKEN`, never a workspace registration
+   token.
+3. Attach the provider runner ID, let the runner enroll, then assign its runner instance
+   to the owned reservation.
+4. Treat an unassigned runner as workspace-neutral. Do not send workspace metadata,
+   credentials, or job data through the provider.
+
+Use `SHIPFOX_PROVISIONER_RUNNER_INSTANCE_BATCH_SIZE` in place of
+`SHIPFOX_PROVISIONER_REGISTRATION_TOKEN_BATCH_SIZE`. A template may set
+`target_concurrency` to maintain prewarmed, unassigned runners independently of demand.
 
 ## Related pages
 

--- a/apps/docs/content/docs/operations/runner-provisioners.mdx
+++ b/apps/docs/content/docs/operations/runner-provisioners.mdx
@@ -1,11 +1,12 @@
 ---
 title: "Runner Provisioners: Autoscale Runners on Demand"
 sidebarTitle: "Runner Provisioners"
-description: "Understand how the Docker provisioner starts single-job runners to meet changing job demand."
+description: "Understand how the Docker provisioner creates, enrolls, and assigns single-job runner instances to meet changing job demand."
 ---
 
-A **provisioner** watches how many jobs are waiting. It starts an ephemeral
-runner container for each reserved job, then lets the runner exit.
+A **provisioner** watches how many jobs are waiting. It creates a durable runner
+instance before it starts ephemeral compute, then the runner enrolls and is assigned
+to a reserved job. Each activated runner claims at most one job and exits.
 
 Use a provisioner when demand changes enough that a fixed runner fleet would sit
 idle or run out of capacity. One provisioner scales runner containers to the
@@ -23,10 +24,12 @@ The provisioner runs a continuous control loop against the Shipfox API:
 <Steps>
   <Step>
 
-    **Advertise capacity**
+    **Advertise capability**
 
-    The provisioner reports free slots for each template. Free slots equal
-    `max_concurrency` minus the containers already starting or running.
+    The provisioner reports labels and free slots for each template. Free slots equal
+    `max_concurrency` minus the containers already starting or running. A matching
+    workspace-owned provisioner always takes precedence over installation fallback,
+    even when it is busy or reports zero free slots.
   </Step>
   <Step>
 
@@ -37,28 +40,31 @@ The provisioner runs a continuous control loop against the Shipfox API:
   </Step>
   <Step>
 
-    **Mint ephemeral tokens**
+    **Create runner instances**
 
-    The provisioner mints one single-use **ephemeral registration token**
-    (`sf_ert_…`) for each reservation. The new runner uses it to register once.
-    This differs from the long-lived `sf_mrt_…` manual token; see
-    [token types](/reference/runner#token-types).
+    The provisioner creates one runner instance and one single-use bootstrap token
+    (`sf_rbt_…`) for every planned runner. The bootstrap token grants only enrollment:
+    it does not reveal a workspace, reservation, or job credential.
   </Step>
   <Step>
 
-    **Launch and reconcile**
+    **Launch, enroll, assign, and reconcile**
 
-    It starts one container per reservation. Each container gets the API URL,
-    ephemeral token, and template labels.
+    It starts one container per runner instance. The container exchanges its bootstrap
+    token for a workspace-neutral control session, declares its labels, and waits. The
+    provisioner assigns an enrolled instance only to its own reservation. The API then
+    issues an activation token for that immutable assignment.
 
-    The provisioner reports each container's state. After a restart, it compares
-    its records with Docker and removes containers that never registered. If
-    Docker is unreachable, it advertises zero capacity and backs off.
+    The provisioner reports each container's state. After a restart, it compares its
+    records with Docker and reconciles failed, expired, and unused runners. A template
+    can also keep `target_concurrency` enrolled runners ready without a reservation.
+    If Docker is unreachable, it advertises zero capacity and backs off.
   </Step>
 </Steps>
 
 Each provisioned runner claims one job, runs it, and exits. A burst starts more
-runners. Quiet periods leave no runner containers idle.
+runners. Quiet periods leave no runner containers idle unless the template deliberately
+keeps a small prewarmed pool.
 
 ## Templates
 
@@ -73,6 +79,7 @@ templates:
     cpu: 2
     memory: 4GiB
     max_concurrency: 100
+    target_concurrency: 0
 ```
 
 When several templates satisfy a job's labels, the provisioner chooses the one

--- a/apps/docs/content/docs/reference/runner-provisioner.mdx
+++ b/apps/docs/content/docs/reference/runner-provisioner.mdx
@@ -11,7 +11,7 @@ This page is the canonical reference for configuring the Docker runner provision
 | Variable | Purpose |
 | --- | --- |
 | `SHIPFOX_API_URL` | Base URL of the Shipfox API the provisioner connects to. |
-| `SHIPFOX_PROVISIONER_TOKEN` | Long-lived token that authenticates control-plane calls. Created on **Settings → Runner Provisioners**: the value is shown once and can be revoked there. |
+| `SHIPFOX_PROVISIONER_TOKEN` | Long-lived token that authenticates control-plane calls. Create it for the provisioner scope you intend to run and keep it secret. The value is shown once and can be revoked. |
 | `SHIPFOX_PROVISIONER_TEMPLATES_FILE` | Path to the YAML file describing the runner templates this provisioner can start. |
 
 ## Optional variables
@@ -27,8 +27,9 @@ This page is the canonical reference for configuring the Docker runner provision
 | `SHIPFOX_PROVISIONER_POLL_INTERVAL_MS` | `1000` | Wait between demand polls. Backs off toward the max after errors. |
 | `SHIPFOX_PROVISIONER_POLL_MAX_INTERVAL_MS` | `5000` | Largest poll backoff interval after repeated errors. |
 | `SHIPFOX_PROVISIONER_MAX_RESERVATIONS` | `250` | Most reservations requested in one poll. Also bounded by free template capacity and the API's cap of 1000. |
-| `SHIPFOX_PROVISIONER_REGISTRATION_TOKEN_BATCH_SIZE` | `250` | Ephemeral registration tokens minted per request (1–1000). Must not exceed the API's own batch limit. |
+| `SHIPFOX_PROVISIONER_RUNNER_INSTANCE_BATCH_SIZE` | `250` | Runner instances created per request (1–1000). Must not exceed the API's own batch limit. |
 | `SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS` | `120000` | How long a created container may stay unstarted before the provisioner reaps it as stale. |
+| `SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS` | `3600` | Hard maximum lifetime injected into each runner. Set it above the longest permitted job so a runner terminates if its provisioner is unavailable. |
 
 ## Template file schema
 
@@ -51,6 +52,7 @@ templates:
 | `cpu` | `number` | vCPUs allocated to the container. Also the template's selection cost. |
 | `memory` | `string` | Memory allocation, such as `4GiB`. |
 | `max_concurrency` | `number` | Cap on live containers started from this template. |
+| `target_concurrency` | `number` | Enrolled, unassigned runners to keep ready without demand. Defaults to `0`. Keep it at or below `max_concurrency`: the provisioner does not currently reject a template where it is higher. |
 
 **Template selection:** when several templates satisfy a job's labels, the provisioner picks the cheapest (fewest vCPUs), then the most specific.
 
@@ -58,7 +60,7 @@ templates:
 
 <Cards>
   <Card title="Runner Provisioners" href="/operations/runner-provisioners">
-    The control loop: advertise, poll, mint, launch.
+    The control loop: reserve, create runner instances, launch, enroll, and assign.
   </Card>
   <Card title="Run a provisioner" href="/installation/runner-provisioner">
     Prerequisites, token creation, and the launch command.

--- a/apps/docs/content/docs/reference/runner.mdx
+++ b/apps/docs/content/docs/reference/runner.mdx
@@ -14,7 +14,8 @@ environments](/understand/runners-and-execution-environments). To start one, see
 | Variable | Purpose |
 | --- | --- |
 | `SHIPFOX_API_URL` | Base URL of the Shipfox API the runner connects to, such as `https://api.shipfox.io`. |
-| `SHIPFOX_RUNNER_REGISTRATION_TOKEN` | Registration token the runner exchanges for a short-lived session token at startup. Accepts `sf_mrt_…` (manual) or `sf_ert_…` (ephemeral) tokens; see [Token types](#token-types). |
+| `SHIPFOX_RUNNER_REGISTRATION_TOKEN` | Registration token the runner exchanges for a short-lived session token at startup. Accepts `sf_mrt_…` (manual) or `sf_ert_…` (ephemeral) tokens; see [Token types](#token-types). Set this or `SHIPFOX_RUNNER_BOOTSTRAP_TOKEN`, but not both. |
+| `SHIPFOX_RUNNER_BOOTSTRAP_TOKEN` | One-use provisioner-managed bootstrap token (`sf_rbt_…`); see [Token types](#token-types). The runner exchanges it for a workspace-neutral control session before waiting for an assignment. Set this or `SHIPFOX_RUNNER_REGISTRATION_TOKEN`, but not both. |
 | `SHIPFOX_RUNNER_LABELS` | Comma-separated labels this runner registers with, such as `linux,x64,self-hosted`. |
 
 ## Label matching
@@ -27,6 +28,7 @@ A job is dispatched to a runner only when the runner's labels include **all** la
 | --- | --- | --- | --- |
 | `sf_mrt_` | Manual registration token | **Settings → Runners** in the dashboard | Long-lived; revocable in the dashboard; value shown once at creation. |
 | `sf_ert_` | Ephemeral registration token | A [runner provisioner](/reference/runner-provisioner) | Single-use; minted per provisioned runner; expires if unused. |
+| `sf_rbt_` | Bootstrap token | A [runner provisioner](/reference/runner-provisioner) | Single-use; grants only enrollment into a workspace-neutral control session, not a workspace, reservation, or job credential. |
 
 ## Optional variables
 

--- a/tools/application-release/test/external/verify.mjs
+++ b/tools/application-release/test/external/verify.mjs
@@ -73,6 +73,7 @@ try {
   const tsc = resolve(repositoryRoot, 'tools/typescript/node_modules/typescript/bin/tsc');
   await run(process.execPath, [tsc, '--project', 'tsconfig.json'], fixtureRoot);
   await run(process.execPath, ['runtime-imports.mjs'], fixtureRoot);
+  await run(process.execPath, ['runners-composition.mjs'], fixtureRoot);
   await run(process.execPath, ['workflow-source-bundle.mjs'], fixtureRoot);
   await run(
     resolve(repositoryRoot, 'tools/application-release/node_modules/.bin/tsx'),
@@ -118,7 +119,7 @@ async function writeFixtureFiles(root, dependencies, runtimeEntryPoints, typeEnt
             strict: true,
             target: 'ES2024',
           },
-          include: ['types.ts', 'composition.ts'],
+          include: ['types.ts', 'composition.ts', 'runners-composition.ts'],
         },
         null,
         2,
@@ -145,6 +146,28 @@ void createServer({
   ],
 });
 `,
+    ),
+    writeFile(
+      join(root, 'runners-composition.ts'),
+      `import {createRunnersModule} from '@shipfox/api-runners';
+import type {AuthInterModuleClient} from '@shipfox/api-auth-dto/inter-module';
+
+const auth = {} as AuthInterModuleClient;
+const module = createRunnersModule({
+  auth,
+  installationProvisioning: {
+    policy: {
+      filterEligibleWorkspaceIds: async (workspaceIds) => new Set(workspaceIds),
+    },
+  },
+});
+
+void module;
+`,
+    ),
+    writeFile(
+      join(root, 'runners-composition.mjs'),
+      `Object.assign(process.env, ${JSON.stringify(runtimeEnvironment(), null, 2)});\n\nconst {createRunnersModule} = await import('@shipfox/api-runners');\nconst module = createRunnersModule({\n  auth: {},\n  installationProvisioning: {\n    policy: {\n      filterEligibleWorkspaceIds: async (workspaceIds) => new Set(workspaceIds),\n    },\n  },\n});\nif (module.name !== 'runners' || !module.routes?.length) {\n  throw new Error('Packed API runners does not compose the installation provisioning policy.');\n}\nconsole.log('Composed packed API runners with an external installation policy.');\n`,
     ),
     writeFile(
       join(root, 'runtime-imports.mjs'),


### PR DESCRIPTION
Documents the runner-instance/bootstrap provisioner protocol and proves that the released API runners package can be composed by an external consumer with an application-owned installation policy.

The provisioner contract now covers workspace-neutral bootstrap enrollment, immutable assignment, one-job activation, and hot-pool capacity. The packed fixture uses only public entry points and keeps eligibility policy in the consuming application.

Closes ENG-1093

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the runner-instance provisioner contract and verifies the released `@shipfox/api-runners` can be composed with an app-owned installation provisioning policy. Updates install/ops/reference docs for bootstrap enrollment, immutable assignment, and hot-pool capacity. Closes ENG-1093.

- **New Features**
  - Docs: runner flow now creates a runner instance, enrolls with a bootstrap token, assigns immutably, runs one job, then exits; no workspace registration credential is handed to the provider.
  - Added token type `sf_rbt_…` and `SHIPFOX_RUNNER_BOOTSTRAP_TOKEN`; replaced batch var with `SHIPFOX_PROVISIONER_RUNNER_INSTANCE_BATCH_SIZE`; added `target_concurrency` and `SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS`.
  - Clarified precedence: workspace-owned provisioners always beat installation fallback; support prewarmed, unassigned pools.
  - Test fixture composes `@shipfox/api-runners` with an external installation provisioning policy to prove the released package works for third-party consumers.

- **Migration**
  - Replace capacity creation/assignment and ephemeral registration batches with runner-instance creation and bootstrap tokens.
  - Start compute with `SHIPFOX_RUNNER_BOOTSTRAP_TOKEN` only; never pass a workspace registration token.
  - Enroll first, then assign the instance to your reservation; treat unassigned runners as workspace-neutral.
  - Use `SHIPFOX_PROVISIONER_RUNNER_INSTANCE_BATCH_SIZE` and (optionally) `target_concurrency` to keep a small hot pool.

<sup>Written for commit 76fcf7451be301bb0f9b96af7d6630daf2243f70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

