### PR TITLE
[provisioner-ec2] Add EC2 provisioner runner lifecycle

### DIFF
--- a/.changeset/silent-otters-provision.md
+++ b/.changeset/silent-otters-provision.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/provisioner-ec2-provider": minor
+---
+
+Adds the EC2 provisioner lifecycle: launches runner instances, observes and reports their state to the backend, and reconciles AWS reality with tracked capacity.

--- a/libs/provisioner/ec2/package.json
+++ b/libs/provisioner/ec2/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-ec2": "catalog:",
+    "@shipfox/api-runners-dto": "workspace:*",
     "@shipfox/config": "workspace:*",
     "@shipfox/provisioner-core": "workspace:*",
     "@shipfox/runner-labels": "workspace:*",

--- a/libs/provisioner/ec2/src/index.ts
+++ b/libs/provisioner/ec2/src/index.ts
@@ -1,4 +1,9 @@
 export {
+  createEc2Lifecycle,
+  type Ec2Lifecycle,
+  type Ec2LifecycleOptions,
+} from '#lifecycle.js';
+export {
   type Ec2Market,
   Ec2TemplateConfigError,
   type Ec2TemplateSpec,

--- a/libs/provisioner/ec2/src/lifecycle.test.ts
+++ b/libs/provisioner/ec2/src/lifecycle.test.ts
@@ -1,0 +1,404 @@
+import type {ReportRunnerInstancesBodyDto} from '@shipfox/api-runners-dto';
+import type {
+  ProviderRunnerLaunch,
+  ProviderRunnerTracker,
+  ProvisionerClient,
+  ProvisionerTemplate,
+} from '@shipfox/provisioner-core';
+import {ProvisionerAuthenticationError} from '@shipfox/provisioner-core';
+import {type Ec2Engine, Ec2EngineError, type Ec2InstanceView} from '#ec2-engine.js';
+import {createEc2Lifecycle} from '#lifecycle.js';
+import type {Ec2TemplateSpec} from '#templates.js';
+
+const NOW = new Date('2026-01-01T00:10:00.000Z');
+const RUNNER_INSTANCE_ID = '00000000-0000-4000-8000-000000000004';
+
+const template: ProvisionerTemplate<Ec2TemplateSpec> = {
+  key: 'spot-small',
+  labels: ['ubuntu22'],
+  maxConcurrency: 10,
+  cost: 1,
+  spec: {
+    ami: 'ami-0123456789abcdef0',
+    instanceType: 'm6i.large',
+    market: 'spot',
+    spotMaxPrice: null,
+    subnets: ['subnet-a', 'subnet-b'],
+    securityGroups: ['sg-runner'],
+    associatePublicIp: false,
+    rootVolumeGb: 100,
+    rootDeviceName: '/dev/sda1',
+  },
+};
+
+describe('createEc2Lifecycle', () => {
+  it('attaches and reports starting before launching an instance', async () => {
+    const engine = fakeEngine();
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.launch(launch());
+
+    expect(client.attachments).toEqual([
+      {runnerInstanceId: RUNNER_INSTANCE_ID, providerRunnerId: 'runner-1'},
+    ]);
+    expect(client.reportBodies[0]?.events[0]).toMatchObject({
+      runner_instance_id: RUNNER_INSTANCE_ID,
+      provider_runner_id: 'runner-1',
+      state: 'starting',
+      provider_kind: 'ec2',
+    });
+    expect(engine.runArgs[0]).toMatchObject({
+      clientToken: 'runner-1',
+      ami: 'ami-0123456789abcdef0',
+      market: 'spot',
+      tags: {'shipfox.provider_runner_id': 'runner-1'},
+    });
+  });
+
+  it('reports a classified failure and rethrows when EC2 launch fails', async () => {
+    const error = new Ec2EngineError('insufficient-capacity', 'no capacity');
+    const lifecycle = makeLifecycle({engine: fakeEngine({runError: error})});
+
+    await expect(lifecycle.launch(launch())).rejects.toThrow(error);
+
+    expect(lifecycle).toBeDefined();
+  });
+
+  it('reports the classified failure when EC2 launch fails', async () => {
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({
+      engine: fakeEngine({runError: new Ec2EngineError('throttled', 'slow down')}),
+      client,
+    });
+
+    await expect(lifecycle.launch(launch())).rejects.toThrow(Ec2EngineError);
+
+    expect(client.reportBodies.flatMap((body) => body.events)).toMatchObject([
+      {state: 'starting'},
+      {state: 'failed', reason: 'throttled'},
+    ]);
+  });
+
+  it('preserves a just-launched instance in the tracker while DescribeInstances lags', async () => {
+    const tracker = testTracker();
+    const lifecycle = makeLifecycle({engine: fakeEngine(), tracker});
+
+    await lifecycle.launch(launch());
+    await lifecycle.observe();
+
+    expect(tracker.countsByTemplate()).toEqual(
+      new Map([['spot-small', {starting: 1, running: 0}]]),
+    );
+  });
+
+  it('rebuilds the tracker and reports observed running instances', async () => {
+    const tracker = testTracker();
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({
+      engine: fakeEngine({instances: [instance({state: 'running'})]}),
+      client,
+      tracker,
+    });
+
+    await lifecycle.observe();
+
+    expect(tracker.countsByTemplate()).toEqual(
+      new Map([['spot-small', {starting: 0, running: 1}]]),
+    );
+    expect(client.reportBodies[0]?.events[0]).toMatchObject({state: 'running'});
+  });
+
+  it('reports a Spot-reclaimed terminated instance as failed', async () => {
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({
+      engine: fakeEngine({
+        instances: [
+          instance({
+            state: 'terminated',
+            stateTransitionReason: 'Server.SpotInstanceTermination: capacity reclaimed',
+          }),
+        ],
+      }),
+      client,
+    });
+
+    await lifecycle.observe();
+
+    expect(client.reportBodies[0]?.events[0]).toMatchObject({
+      state: 'failed',
+      reason: 'spot-interruption',
+    });
+  });
+
+  it('propagates observation failures so the core loop degrades capacity to zero', async () => {
+    const error = new Ec2EngineError('unreachable', 'EC2 unavailable');
+    const lifecycle = makeLifecycle({engine: fakeEngine({listError: error})});
+
+    await expect(lifecycle.observe()).rejects.toThrow(error);
+  });
+
+  it('retries transiently failed reports on the next observation', async () => {
+    const client = fakeClient({reportErrors: [new Error('API unavailable')]});
+    const lifecycle = makeLifecycle({
+      engine: fakeEngine({instances: [instance({state: 'running'})]}),
+      client,
+    });
+
+    await lifecycle.observe();
+    await lifecycle.observe();
+
+    expect(client.reportBodies).toHaveLength(3);
+    expect(client.reportBodies[1]?.events[0]).toMatchObject({state: 'running'});
+  });
+
+  it('does not retry permanently invalid report batches', async () => {
+    const client = fakeClient({reportErrors: [httpError(400)]});
+    const lifecycle = makeLifecycle({
+      engine: fakeEngine({instances: [instance({state: 'running'})]}),
+      client,
+    });
+
+    await lifecycle.observe();
+    await lifecycle.flush();
+
+    expect(client.reportBodies).toHaveLength(1);
+  });
+
+  it('keeps authentication report failures fatal', async () => {
+    const lifecycle = makeLifecycle({
+      client: fakeClient({reportErrors: [new ProvisionerAuthenticationError(401)]}),
+    });
+
+    await expect(lifecycle.launch(launch())).rejects.toThrow(ProvisionerAuthenticationError);
+  });
+
+  it('reports a failed launch and never calls runInstance when provider identity attach is rejected', async () => {
+    const engine = fakeEngine();
+    const client = fakeClient({attachResult: {attached: false}});
+    const lifecycle = makeLifecycle({engine, client});
+
+    await expect(lifecycle.launch(launch())).rejects.toThrow(
+      `Provider identity was not attached for runner instance ${RUNNER_INSTANCE_ID}`,
+    );
+
+    expect(engine.runArgs).toHaveLength(0);
+    expect(client.reportBodies.flatMap((body) => body.events)).toMatchObject([{state: 'failed'}]);
+  });
+
+  it('rejects and reports a failure when the template has no subnets', async () => {
+    const emptySubnetsTemplate: ProvisionerTemplate<Ec2TemplateSpec> = {
+      ...template,
+      spec: {...template.spec, subnets: []},
+    };
+    const engine = fakeEngine();
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({engine, client});
+
+    await expect(lifecycle.launch({...launch(), template: emptySubnetsTemplate})).rejects.toThrow(
+      'Template spot-small has no subnets.',
+    );
+
+    expect(engine.runArgs).toHaveLength(0);
+    expect(client.reportBodies.flatMap((body) => body.events)).toMatchObject([
+      {state: 'starting'},
+      {state: 'failed'},
+    ]);
+  });
+
+  it('chunks report batches at 1000 events', async () => {
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({
+      engine: fakeEngine({
+        instances: Array.from({length: 1500}, () => instance({state: 'running'})),
+      }),
+      client,
+    });
+
+    await lifecycle.observe();
+
+    expect(client.reportBodies).toHaveLength(2);
+    expect(client.reportBodies[0]?.events).toHaveLength(1000);
+    expect(client.reportBodies[1]?.events).toHaveLength(500);
+  });
+
+  it('skips reporting and tracking an instance whose labels cannot be resolved', async () => {
+    const client = fakeClient();
+    const tracker = testTracker();
+    const unlabeledInstance: Ec2InstanceView = {
+      instanceId: 'i-999',
+      state: 'running',
+      tags: {
+        'shipfox.provider_runner_id': 'runner-unlabeled',
+        'shipfox.provisioner_id': '00000000-0000-4000-8000-000000000001',
+      },
+    };
+    const lifecycle = makeLifecycle({
+      engine: fakeEngine({instances: [unlabeledInstance]}),
+      client,
+      tracker,
+    });
+
+    await lifecycle.observe();
+
+    expect(client.reportBodies.flatMap((body) => body.events)).toHaveLength(0);
+    expect(tracker.countsByTemplate().size).toBe(0);
+  });
+
+  it('reports an instance with resolved labels but keeps it out of the tracker when the template key is unknown', async () => {
+    const client = fakeClient();
+    const tracker = testTracker();
+    const instanceWithoutTemplateKey: Ec2InstanceView = {
+      instanceId: 'i-888',
+      state: 'running',
+      tags: {
+        'shipfox.provider_runner_id': 'runner-no-template',
+        'shipfox.provisioner_id': '00000000-0000-4000-8000-000000000001',
+        'shipfox.labels': 'ubuntu22',
+      },
+    };
+    const lifecycle = makeLifecycle({
+      engine: fakeEngine({instances: [instanceWithoutTemplateKey]}),
+      client,
+      tracker,
+    });
+
+    await lifecycle.observe();
+
+    expect(client.reportBodies[0]?.events[0]).toMatchObject({state: 'running'});
+    expect(tracker.countsByTemplate().size).toBe(0);
+  });
+});
+
+function makeLifecycle(
+  args: {
+    engine?: ReturnType<typeof fakeEngine>;
+    client?: ReturnType<typeof fakeClient>;
+    tracker?: ProviderRunnerTracker;
+  } = {},
+) {
+  return createEc2Lifecycle({
+    engine: args.engine ?? fakeEngine(),
+    client: args.client ?? fakeClient(),
+    identity: {id: '00000000-0000-4000-8000-000000000001', workspaceId: null},
+    tracker: args.tracker ?? testTracker(),
+    templates: [template],
+    providerKind: 'ec2',
+    now: () => NOW,
+  });
+}
+
+function launch(): ProviderRunnerLaunch<Ec2TemplateSpec> {
+  return {
+    runnerInstanceId: RUNNER_INSTANCE_ID,
+    providerRunnerId: 'runner-1',
+    reservationId: '00000000-0000-4000-8000-000000000003',
+    bootstrapToken: 'sf_rbt_secret',
+    runnerEnv: {SHIPFOX_RUNNER_BOOTSTRAP_TOKEN: 'sf_rbt_secret'},
+    template,
+  };
+}
+
+function instance(args: {
+  state: Ec2InstanceView['state'];
+  stateTransitionReason?: string;
+}): Ec2InstanceView {
+  return {
+    instanceId: 'i-123',
+    state: args.state,
+    tags: {
+      'shipfox.runner_instance_id': RUNNER_INSTANCE_ID,
+      'shipfox.provider_runner_id': 'runner-1',
+      'shipfox.provisioner_id': '00000000-0000-4000-8000-000000000001',
+      'shipfox.reservation_id': '00000000-0000-4000-8000-000000000003',
+      'shipfox.template_key': 'spot-small',
+      'shipfox.labels': 'ubuntu22',
+    },
+    ...(args.stateTransitionReason ? {stateTransitionReason: args.stateTransitionReason} : {}),
+  };
+}
+
+function fakeEngine(
+  options: {instances?: Ec2InstanceView[]; runError?: Error; listError?: Error} = {},
+): Ec2Engine & {runArgs: Parameters<Ec2Engine['runInstance']>[0][]} {
+  const runArgs: Parameters<Ec2Engine['runInstance']>[0][] = [];
+  return {
+    runArgs,
+    runInstance: (args) => {
+      runArgs.push(args);
+      return options.runError
+        ? Promise.reject(options.runError)
+        : Promise.resolve(instance({state: 'pending'}));
+    },
+    listManaged: () =>
+      options.listError
+        ? Promise.reject(options.listError)
+        : Promise.resolve(options.instances ?? []),
+    terminate: () => Promise.resolve(),
+  };
+}
+
+function fakeClient(
+  options: {reportErrors?: Error[]; attachResult?: {attached: boolean}} = {},
+): ProvisionerClient & {
+  reportBodies: ReportRunnerInstancesBodyDto[];
+  attachments: Array<{runnerInstanceId: string; providerRunnerId: string}>;
+} {
+  const reportBodies: ReportRunnerInstancesBodyDto[] = [];
+  const attachments: Array<{runnerInstanceId: string; providerRunnerId: string}> = [];
+  const reportErrors = [...(options.reportErrors ?? [])];
+  return {
+    reportBodies,
+    attachments,
+    getIdentity: () =>
+      Promise.resolve({id: 'provisioner', scope: 'installation', workspace_id: null}),
+    pollDemand: () =>
+      Promise.resolve({stats: [], reservations: [], terminate_provider_runner_ids: []}),
+    createRunnerInstances: () => Promise.resolve({runner_instances: []}),
+    attachRunnerInstanceProviderId: (runnerInstanceId, providerRunnerId) => {
+      attachments.push({runnerInstanceId, providerRunnerId});
+      return Promise.resolve(options.attachResult ?? {attached: true});
+    },
+    assignRunnerInstances: (_reservationId, runnerInstanceIds) =>
+      Promise.resolve({runner_instance_ids: runnerInstanceIds}),
+    reportRunnerInstances: (body) => {
+      reportBodies.push(body);
+      const error = reportErrors.shift();
+      return error
+        ? Promise.reject(error)
+        : Promise.resolve({accepted: body.events.length, reservations_released: 0});
+    },
+    reconcileRunnerInstances: () =>
+      Promise.resolve({runners: [], terminated_absent_provider_runner_ids: []}),
+  };
+}
+
+function testTracker(): ProviderRunnerTracker {
+  const runners = new Map<string, {templateKey: string; state: 'starting' | 'running'}>();
+  return {
+    recordStarting: ({providerRunnerId, templateKey}) =>
+      runners.set(providerRunnerId, {templateKey, state: 'starting'}),
+    markRunning: (providerRunnerId) => {
+      const runner = runners.get(providerRunnerId);
+      if (runner) runner.state = 'running';
+    },
+    remove: (providerRunnerId) => runners.delete(providerRunnerId),
+    replaceAll: (nextRunners) => {
+      runners.clear();
+      for (const runner of nextRunners) runners.set(runner.providerRunnerId, {...runner});
+    },
+    countsByTemplate: () => {
+      const counts = new Map<string, {starting: number; running: number}>();
+      for (const runner of runners.values()) {
+        const current = counts.get(runner.templateKey) ?? {starting: 0, running: 0};
+        current[runner.state] += 1;
+        counts.set(runner.templateKey, current);
+      }
+      return counts;
+    },
+  };
+}
+
+function httpError(status: number): Error {
+  return Object.assign(new Error(`HTTP ${status}`), {response: {status}});
+}

--- a/libs/provisioner/ec2/src/lifecycle.ts
+++ b/libs/provisioner/ec2/src/lifecycle.ts
@@ -1,0 +1,296 @@
+import type {RunnerInstanceReportEventDto} from '@shipfox/api-runners-dto';
+import type {
+  ProviderRunnerLaunch,
+  ProviderRunnerTracker,
+  ProvisionerClient,
+  ProvisionerIdentity,
+  ProvisionerTemplate,
+} from '@shipfox/provisioner-core';
+import {ProvisionerAuthenticationError} from '@shipfox/provisioner-core';
+import {type Ec2Engine, Ec2EngineError, type Ec2InstanceView} from '#ec2-engine.js';
+import {buildInstanceTags, parseInstanceIdentity} from '#instance-identity.js';
+import type {Ec2TemplateSpec} from '#templates.js';
+
+const MAX_REPORT_BATCH = 1000;
+const MAX_REASON_LENGTH = 500;
+const SPOT_INTERRUPTION_REASON =
+  /spot|instance-terminated-by-price|instance-terminated-no-capacity/i;
+
+type TrackerSeed = {
+  providerRunnerId: string;
+  templateKey: string;
+  state: 'starting' | 'running';
+};
+
+type LocallyLaunchedRunner = {
+  templateKey: string;
+};
+
+export interface Ec2Lifecycle {
+  launch(launch: ProviderRunnerLaunch<Ec2TemplateSpec>): Promise<void>;
+  observe(): Promise<void>;
+  flush(): Promise<void>;
+}
+
+export interface Ec2LifecycleOptions {
+  readonly engine: Ec2Engine;
+  readonly client: ProvisionerClient;
+  readonly identity: ProvisionerIdentity;
+  readonly tracker: ProviderRunnerTracker;
+  readonly templates: readonly ProvisionerTemplate<Ec2TemplateSpec>[];
+  readonly providerKind: string;
+  readonly now?: () => Date;
+  readonly renderUserData?: (launch: ProviderRunnerLaunch<Ec2TemplateSpec>) => string;
+}
+
+interface Ec2LifecycleContext {
+  readonly engine: Ec2Engine;
+  readonly client: ProvisionerClient;
+  readonly identity: ProvisionerIdentity;
+  readonly tracker: ProviderRunnerTracker;
+  readonly templatesByKey: ReadonlyMap<string, ProvisionerTemplate<Ec2TemplateSpec>>;
+  readonly providerKind: string;
+  readonly now: () => Date;
+  readonly renderUserData?: (launch: ProviderRunnerLaunch<Ec2TemplateSpec>) => string;
+  readonly locallyLaunched: Map<string, LocallyLaunchedRunner>;
+  readonly pendingReports: RunnerInstanceReportEventDto[];
+}
+
+/**
+ * Owns the EC2-facing half of the provisioner lifecycle. AWS observations replace
+ * the local capacity view, except for newly launched instances that DescribeInstances
+ * has not made visible yet.
+ */
+export function createEc2Lifecycle(options: Ec2LifecycleOptions): Ec2Lifecycle {
+  const context: Ec2LifecycleContext = {
+    engine: options.engine,
+    client: options.client,
+    identity: options.identity,
+    tracker: options.tracker,
+    templatesByKey: new Map(options.templates.map((template) => [template.key, template])),
+    providerKind: options.providerKind,
+    now: options.now ?? (() => new Date()),
+    ...(options.renderUserData ? {renderUserData: options.renderUserData} : {}),
+    locallyLaunched: new Map(),
+    pendingReports: [],
+  };
+
+  return {
+    launch: (launch) => launchRunner(context, launch),
+    observe: () => observe(context),
+    flush: () => flush(context),
+  };
+}
+
+async function launchRunner(
+  context: Ec2LifecycleContext,
+  launch: ProviderRunnerLaunch<Ec2TemplateSpec>,
+): Promise<void> {
+  try {
+    await attachProviderIdentity(context, launch);
+    await reportEvents(context, [eventForLaunch(context, launch, 'starting')]);
+    await context.engine.runInstance({
+      clientToken: launch.providerRunnerId,
+      tags: buildInstanceTags({launch, identity: context.identity}),
+      ami: launch.template.spec.ami,
+      instanceType: launch.template.spec.instanceType,
+      market: launch.template.spec.market,
+      spotMaxPrice: launch.template.spec.spotMaxPrice,
+      subnetId: selectSubnet(launch),
+      securityGroupIds: launch.template.spec.securityGroups,
+      ...(launch.template.spec.iamInstanceProfile
+        ? {iamInstanceProfile: launch.template.spec.iamInstanceProfile}
+        : {}),
+      associatePublicIp: launch.template.spec.associatePublicIp,
+      rootVolumeGb: launch.template.spec.rootVolumeGb,
+      rootDeviceName: launch.template.spec.rootDeviceName,
+      ...(context.renderUserData ? {userData: context.renderUserData(launch)} : {}),
+    });
+    context.locallyLaunched.set(launch.providerRunnerId, {templateKey: launch.template.key});
+  } catch (error) {
+    await reportEvents(context, [eventForLaunch(context, launch, 'failed', errorReason(error))]);
+    throw error;
+  }
+}
+
+async function observe(context: Ec2LifecycleContext): Promise<void> {
+  await reportEvents(context, []);
+  const instances = await context.engine.listManaged(context.identity.id);
+  const trackerRunners: TrackerSeed[] = [];
+  const events: RunnerInstanceReportEventDto[] = [];
+  const observedIds = new Set<string>();
+
+  for (const instance of instances) {
+    const identity = parseInstanceIdentity(instance);
+    if (!identity.providerRunnerId) continue;
+    observedIds.add(identity.providerRunnerId);
+    context.locallyLaunched.delete(identity.providerRunnerId);
+
+    const template = identity.templateKey
+      ? context.templatesByKey.get(identity.templateKey)
+      : undefined;
+    const labels = identity.labels.length > 0 ? identity.labels : (template?.labels ?? []);
+    if (labels.length === 0) continue;
+
+    const mapped = mapInstanceState(instance);
+    events.push(eventForInstance(context, instance, mapped.state, labels, mapped.reason));
+    if ((mapped.state === 'starting' || mapped.state === 'running') && identity.templateKey) {
+      trackerRunners.push({
+        providerRunnerId: identity.providerRunnerId,
+        templateKey: identity.templateKey,
+        state: mapped.state,
+      });
+    }
+  }
+
+  // DescribeInstances is eventually consistent. Retaining a locally successful
+  // launch until AWS returns it avoids turning that gap into a free capacity slot.
+  for (const [providerRunnerId, launched] of context.locallyLaunched) {
+    if (!observedIds.has(providerRunnerId)) {
+      trackerRunners.push({providerRunnerId, templateKey: launched.templateKey, state: 'starting'});
+    }
+  }
+
+  context.tracker.replaceAll(trackerRunners);
+  await reportEvents(context, events);
+}
+
+async function attachProviderIdentity(
+  context: Ec2LifecycleContext,
+  launch: ProviderRunnerLaunch<Ec2TemplateSpec>,
+): Promise<void> {
+  const result = await context.client.attachRunnerInstanceProviderId(
+    launch.runnerInstanceId,
+    launch.providerRunnerId,
+  );
+  if (!result.attached) {
+    throw new Error(
+      `Provider identity was not attached for runner instance ${launch.runnerInstanceId}`,
+    );
+  }
+}
+
+async function reportEvents(
+  context: Ec2LifecycleContext,
+  events: readonly RunnerInstanceReportEventDto[],
+): Promise<void> {
+  const reports = [...context.pendingReports.splice(0), ...events];
+  for (let index = 0; index < reports.length; index += MAX_REPORT_BATCH) {
+    const batch = reports.slice(index, index + MAX_REPORT_BATCH);
+    try {
+      await context.client.reportRunnerInstances({events: batch});
+    } catch (error) {
+      if (error instanceof ProvisionerAuthenticationError) {
+        context.pendingReports.push(...reports.slice(index));
+        throw error;
+      }
+      if (responseStatus(error) === 400) continue;
+      context.pendingReports.push(...reports.slice(index));
+      return;
+    }
+  }
+}
+
+async function flush(context: Ec2LifecycleContext): Promise<void> {
+  try {
+    await reportEvents(context, []);
+  } catch {
+    // Shutdown must remain best-effort; the next process will re-observe AWS state.
+  }
+}
+
+function eventForLaunch(
+  context: Ec2LifecycleContext,
+  launch: ProviderRunnerLaunch<Ec2TemplateSpec>,
+  state: 'starting' | 'failed',
+  reason?: string,
+): RunnerInstanceReportEventDto {
+  return {
+    runner_instance_id: launch.runnerInstanceId,
+    provider_runner_id: launch.providerRunnerId,
+    ...(launch.reservationId ? {reservation_id: launch.reservationId} : {}),
+    template_key: launch.template.key,
+    labels: [...launch.template.labels],
+    state,
+    ...(reason ? {reason: truncateReason(reason)} : {}),
+    reported_at: context.now().toISOString(),
+    provider_kind: context.providerKind,
+  };
+}
+
+function eventForInstance(
+  context: Ec2LifecycleContext,
+  instance: Ec2InstanceView,
+  state: RunnerInstanceReportEventDto['state'],
+  labels: readonly string[],
+  reason?: string,
+): RunnerInstanceReportEventDto {
+  const identity = parseInstanceIdentity(instance);
+  return {
+    ...(identity.runnerInstanceId ? {runner_instance_id: identity.runnerInstanceId} : {}),
+    provider_runner_id: identity.providerRunnerId,
+    ...(identity.reservationId ? {reservation_id: identity.reservationId} : {}),
+    ...(identity.templateKey ? {template_key: identity.templateKey} : {}),
+    labels: [...labels],
+    state,
+    ...(reason ? {reason: truncateReason(reason)} : {}),
+    reported_at: context.now().toISOString(),
+    provider_kind: context.providerKind,
+  };
+}
+
+function mapInstanceState(instance: Ec2InstanceView): {
+  state: RunnerInstanceReportEventDto['state'];
+  reason?: string;
+} {
+  switch (instance.state) {
+    case 'pending':
+      return {state: 'starting'};
+    case 'running':
+      return {state: 'running'};
+    case 'shutting-down':
+    case 'stopping':
+      return {state: 'stopping'};
+    case 'stopped':
+    case 'terminated':
+      return isSpotInterruption(instance)
+        ? {state: 'failed', reason: 'spot-interruption'}
+        : {state: 'terminated'};
+    default:
+      return {state: 'running', reason: `ec2-state-${instance.state}`};
+  }
+}
+
+function isSpotInterruption(instance: Ec2InstanceView): boolean {
+  return SPOT_INTERRUPTION_REASON.test(
+    [instance.stateTransitionReason, instance.stateReasonCode, instance.stateReasonMessage]
+      .filter((value): value is string => value !== undefined)
+      .join(' '),
+  );
+}
+
+function selectSubnet(launch: ProviderRunnerLaunch<Ec2TemplateSpec>): string {
+  const subnets = launch.template.spec.subnets;
+  const hash = [...launch.providerRunnerId].reduce(
+    (sum, character) => sum + character.charCodeAt(0),
+    0,
+  );
+  const subnet = subnets[hash % subnets.length] ?? subnets[0];
+  if (!subnet) throw new Error(`Template ${launch.template.key} has no subnets.`);
+  return subnet;
+}
+
+function errorReason(error: unknown): string {
+  if (error instanceof Ec2EngineError) return error.reason;
+  return error instanceof Error ? error.message : String(error);
+}
+
+function responseStatus(error: unknown): number | undefined {
+  if (!(error instanceof Error)) return undefined;
+  const response = (error as Error & {response?: {status?: unknown}}).response;
+  return typeof response?.status === 'number' ? response.status : undefined;
+}
+
+function truncateReason(reason: string): string {
+  return reason.slice(0, MAX_REASON_LENGTH);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6051,6 +6051,9 @@ importers:
       '@aws-sdk/client-ec2':
         specifier: 'catalog:'
         version: 3.1088.0
+      '@shipfox/api-runners-dto':
+        specifier: workspace:*
+        version: link:../../api/runners-dto
       '@shipfox/config':
         specifier: workspace:*
         version: link:../../shared/common/config
@@ -7899,6 +7902,7 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.5.0':
     resolution: {integrity: sha512-+9hIcMngJ+yGUahXqZuZ8CoWKJE9SAZsFsM3QDvXpNsLbXZ9lqVzgBhOk/jTSYkOA0GLP9eu3teukqpLUojHMg==}
@@ -7912,6 +7916,7 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.5.0':
     resolution: {integrity: sha512-jB0wAvTLI4itx5VidqVUejPQFhRUxiZ9l9FvZ26D5fl6t3qme+ZB4PD3bTSeL1vZ8NI2Rx/zj6H9zcESuGHKGw==}


### PR DESCRIPTION
Implements the EC2-facing half of the provisioner control loop: `launch` attaches the provider identity, reports a `starting` event, and calls EC2 `RunInstances`; `observe` lists AWS-managed instances via `DescribeInstances`, maps instance state (including Spot-interruption detection) to the backend's runner-state enum, rebuilds the in-memory tracker from AWS reality, and reports state changes back to the API with buffered retry on transient failures.

This is the reliability heart of the EC2 provisioner: AWS-tagged instance state is durable truth, and a locally-launched instance is retained in the tracker until `DescribeInstances` catches up, so a launch is never mistaken for a vanished/terminated runner during the eventual-consistency window.

Mirrors `libs/provisioner/docker/src/lifecycle.ts`'s established shape. Report-retry buffering intentionally does not yet cap `pendingReports` the way the Docker version caps at `MAX_PENDING_REPORTS` — a naive drop-oldest cap would risk desyncing backend belief from AWS reality during a sustained outage, so bounding it needs a durable (e.g. disk-flush) design instead. Tracked as ENG-1118. Deduping the two lifecycle files' shared helpers into `provisioner-core` is tracked separately as ENG-1119.

Closes ENG-1010

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the EC2 provisioner lifecycle to launch EC2 runner instances, observe their state, and report updates to the backend. Improves reliability by reconciling AWS-tagged truth with local tracking and handling eventual consistency. Closes ENG-1010.

- **New Features**
  - Launch: attach provider identity, report “starting,” and call EC2 RunInstances with Shipfox tags and stable subnet selection.
  - Observe: use DescribeInstances to map EC2 states to runner states (Spot interruption → failed), rebuild the in-memory tracker, and keep just-launched instances until AWS shows them.
  - Reporting: batch at 1000 events, buffer and retry on transient failures, do not retry 400s, and surface auth errors; flush is best-effort.
  - Resilience: skip unlabeled instances; report labeled instances without a known template key but don’t track them.

- **Dependencies**
  - Added `@shipfox/api-runners-dto`.

<sup>Written for commit e9509abda1e763b2978916572ac0476fc8f62c8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

