### PR TITLE
[e2e-flow-workflows] Stabilize listener batching readiness

### DIFF
--- a/.changeset/calm-foxes-listen.md
+++ b/.changeset/calm-foxes-listen.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-triggers": patch
+---
+
+Adds deterministic E2E listener-subscription readiness checks for workflow batching tests.

--- a/e2e/suites/flow/workflows/src/listener-helpers.ts
+++ b/e2e/suites/flow/workflows/src/listener-helpers.ts
@@ -7,7 +7,7 @@ import type {
   WorkflowRunJobDetailDto,
   WorkflowRunJobExecutionDetailDto,
 } from '@shipfox/api-workflows-dto';
-import type {createApiClient} from '@shipfox/e2e-core';
+import {createApiClient, pollUntil, requestJson} from '@shipfox/e2e-core';
 import {waitForRunDetailMatching} from './polling.js';
 import {postWebhookDelivery} from './webhook.js';
 
@@ -214,13 +214,38 @@ export async function waitForListenerStatus(params: {
   listenerStatus: ListenerStatusDto;
   timeoutMs: number;
 }): Promise<WorkflowRunDetailResponseDto> {
-  return await waitForRunDetailMatching({
-    token: params.token,
-    runId: params.runId,
-    timeoutMs: params.timeoutMs,
-    description: `listener job ${params.jobKey} status ${params.listenerStatus}`,
-    matches: (runDetail) => listenerStatusMatches({...params, runDetail}),
-  });
+  const client = createApiClient({token: params.token});
+  let diagnostic = `listener job ${params.jobKey} missing`;
+  return await pollUntil(
+    {
+      timeoutMs: params.timeoutMs,
+      intervalMs: 250,
+      maxIntervalMs: 250,
+      describe: () =>
+        `listener job ${params.jobKey} status ${params.listenerStatus}: ${diagnostic}`,
+    },
+    async () => {
+      const runDetail = await client.requestJson<WorkflowRunDetailResponseDto>(
+        'get',
+        `/workflows/runs/${encodeURIComponent(params.runId)}`,
+      );
+      const status = listenerStatusMatches({...params, runDetail});
+      diagnostic = status.diagnostic;
+      if (!status.matched) return null;
+
+      const job = findListenerJob(runDetail, params.jobKey);
+      if (!job) return null;
+      const readiness = await requestJson<{ready: boolean}>(
+        'get',
+        `/__e2e/triggers/listeners/${encodeURIComponent(job.id)}/readiness`,
+        {},
+      );
+      diagnostic = readiness.ready
+        ? `${status.diagnostic}, trigger subscriptions ready`
+        : `${status.diagnostic}, trigger subscriptions pending`;
+      return readiness.ready ? runDetail : null;
+    },
+  );
 }
 
 export async function waitForListenerResolution(params: {

--- a/libs/api/triggers/src/db/job-listener-subscriptions.ts
+++ b/libs/api/triggers/src/db/job-listener-subscriptions.ts
@@ -131,3 +131,12 @@ export async function findMatchingJobListenerSubscriptions(
     );
   return rows.map(toJobListenerSubscription);
 }
+
+export async function hasJobListenerSubscriptions(jobId: string): Promise<boolean> {
+  const [subscription] = await db()
+    .select({id: jobListenerSubscriptions.id})
+    .from(jobListenerSubscriptions)
+    .where(eq(jobListenerSubscriptions.jobId, jobId))
+    .limit(1);
+  return subscription !== undefined;
+}

--- a/libs/api/triggers/src/index.ts
+++ b/libs/api/triggers/src/index.ts
@@ -18,6 +18,7 @@ import type {WorkflowsModuleClient} from '@shipfox/api-workflows-dto/inter-modul
 import {type ShipfoxModule, subscriberFactory} from '@shipfox/node-module';
 import {db, migrationsPath, triggersOutbox} from '#db/index.js';
 import {registerTriggersServiceMetrics} from '#metrics/index.js';
+import {triggersE2eRoutes} from '#presentation/e2e-routes.js';
 import {createTriggerRoutes} from '#presentation/index.js';
 import {
   createOnIntegrationEventReceived,
@@ -76,6 +77,7 @@ export function createTriggersModule({workflows}: CreateTriggersModuleOptions): 
     name: 'triggers',
     database: {db, migrationsPath},
     routes: createTriggerRoutes(workflows),
+    e2eRoutes: [triggersE2eRoutes],
     metrics: registerTriggersServiceMetrics,
     publishers: [{name: 'triggers', table: triggersOutbox, db}],
     subscribers: [

--- a/libs/api/triggers/src/presentation/e2e-routes.test.ts
+++ b/libs/api/triggers/src/presentation/e2e-routes.test.ts
@@ -1,0 +1,44 @@
+import {closeApp, createApp} from '@shipfox/node-fastify';
+import {projectJobListenerSubscriptions} from '#db/job-listener-subscriptions.js';
+import {triggersE2eRoutes} from './e2e-routes.js';
+
+describe('triggers E2E routes', () => {
+  afterEach(async () => {
+    await closeApp();
+  });
+
+  test('reports a listener without projected subscriptions as not ready', async () => {
+    const jobId = crypto.randomUUID();
+    const app = await createApp({routes: [triggersE2eRoutes], swagger: false});
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/triggers/listeners/${jobId}/readiness`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ready: false});
+  });
+
+  test('reports a listener with projected subscriptions as ready', async () => {
+    const workspaceId = crypto.randomUUID();
+    const workflowRunId = crypto.randomUUID();
+    const jobId = crypto.randomUUID();
+    await projectJobListenerSubscriptions({
+      workspaceId,
+      workflowRunId,
+      jobId,
+      on: [{source: 'listener-source', event: 'received'}],
+      until: null,
+    });
+    const app = await createApp({routes: [triggersE2eRoutes], swagger: false});
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/triggers/listeners/${jobId}/readiness`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ready: true});
+  });
+});

--- a/libs/api/triggers/src/presentation/e2e-routes.ts
+++ b/libs/api/triggers/src/presentation/e2e-routes.ts
@@ -1,0 +1,24 @@
+import {defineRoute, type RouteGroup} from '@shipfox/node-fastify';
+import {z} from 'zod';
+import {hasJobListenerSubscriptions} from '#db/job-listener-subscriptions.js';
+
+const listenerReadinessParamsSchema = z.object({jobId: z.string().uuid()});
+const listenerReadinessResponseSchema = z.object({ready: z.boolean()});
+
+const listenerReadinessRoute = defineRoute({
+  method: 'GET',
+  path: '/listeners/:jobId/readiness',
+  description: 'Report whether trigger subscriptions for a listener job are ready in E2E tests.',
+  schema: {
+    params: listenerReadinessParamsSchema,
+    response: {200: listenerReadinessResponseSchema},
+  },
+  handler: async (request) => ({
+    ready: await hasJobListenerSubscriptions(request.params.jobId),
+  }),
+});
+
+export const triggersE2eRoutes: RouteGroup = {
+  prefix: '/triggers',
+  routes: [listenerReadinessRoute],
+};


### PR DESCRIPTION
Make listener batching E2E wait for the triggers module subscription projection before delivering readiness and batch events.

Workflow run detail can report a listener as listening before the asynchronous activation subscriber has projected its trigger subscriptions. The previous wait could therefore send both events into that gap, where they were discarded and no listener execution was created.

This adds an E2E-only projection readiness route and keeps the existing eight-second budget and single-shot webhook delivery. Extending the timeout would not recover already discarded events, while retrying deliveries would distort the exact two-event batch assertion.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes listener batching E2E by waiting for trigger subscription projection before sending readiness and batch events. Adds an E2E-only readiness endpoint in `@shipfox/api-triggers` and updates test helpers to poll it, preventing dropped events during async activation.

- **Bug Fixes**
  - Added GET `/triggers/listeners/:jobId/readiness` in `@shipfox/api-triggers` using `hasJobListenerSubscriptions`.
  - Registered via `e2eRoutes` and added tests for ready/not-ready cases.
  - Updated E2E `waitForListenerStatus` to poll readiness (keeps 8s budget, single webhook delivery).

<sup>Written for commit 310c92b1b7d4866ddc348225d191837b58e7f5bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

