### PR TITLE
[docs] Rename PostHog ingestion URL variable

### DIFF
--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -22,7 +22,7 @@ The production Vercel deployment requires these public browser variables:
 
 ```text
 NEXT_PUBLIC_POSTHOG_KEY=<project token>
-NEXT_PUBLIC_POSTHOG_HOST=<HTTPS ingestion host>
+NEXT_PUBLIC_POSTHOG_URL=<HTTPS ingestion URL>
 ```
 
 Set them only for the Vercel production environment. Local development and

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -5,18 +5,18 @@ const withMDX = createMDX();
 const workspaceRoot = fileURLToPath(new URL('../..', import.meta.url));
 const isVercelProduction = process.env.VERCEL_ENV === 'production';
 const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
-const posthogHost = process.env.NEXT_PUBLIC_POSTHOG_HOST;
+const posthogUrl = process.env.NEXT_PUBLIC_POSTHOG_URL;
 
-if (isVercelProduction && (!posthogKey || !posthogHost)) {
+if (isVercelProduction && (!posthogKey || !posthogUrl)) {
   throw new Error(
-    'NEXT_PUBLIC_POSTHOG_KEY and NEXT_PUBLIC_POSTHOG_HOST are required for the production docs deployment.',
+    'NEXT_PUBLIC_POSTHOG_KEY and NEXT_PUBLIC_POSTHOG_URL are required for the production docs deployment.',
   );
 }
 
-if (posthogHost) {
-  const parsedPosthogHost = new URL(posthogHost);
-  if (isVercelProduction && parsedPosthogHost.protocol !== 'https:')
-    throw new Error('NEXT_PUBLIC_POSTHOG_HOST must use HTTPS in production.');
+if (posthogUrl) {
+  const parsedPosthogUrl = new URL(posthogUrl);
+  if (isVercelProduction && parsedPosthogUrl.protocol !== 'https:')
+    throw new Error('NEXT_PUBLIC_POSTHOG_URL must use HTTPS in production.');
 }
 
 // The production docs deployment is mounted behind the cloud landing app at

--- a/apps/docs/src/instrumentation-client.ts
+++ b/apps/docs/src/instrumentation-client.ts
@@ -2,11 +2,11 @@ import posthog from 'posthog-js';
 import {sanitizePosthogCapture, sanitizeTrackedUrl} from '@/lib/docs-analytics-core';
 
 const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
-const posthogHost = process.env.NEXT_PUBLIC_POSTHOG_HOST;
+const posthogUrl = process.env.NEXT_PUBLIC_POSTHOG_URL;
 
-if (posthogKey && posthogHost) {
+if (posthogKey && posthogUrl) {
   posthog.init(posthogKey, {
-    api_host: posthogHost,
+    api_host: posthogUrl,
     defaults: '2025-05-24',
     autocapture: {
       element_attribute_ignorelist: ['href', 'src', 'value'],


### PR DESCRIPTION
Rename the public PostHog configuration variable from `NEXT_PUBLIC_POSTHOG_HOST` to `NEXT_PUBLIC_POSTHOG_URL`.

The old name suggested a bare hostname was valid, but the docs build validates and the PostHog client requires an absolute HTTPS URL. The new name makes the required `https://ph.shipfox.io` value clear in both deployment configuration and documentation.

No alternative was retained because accepting either name would leave an ambiguous, error-prone deployment interface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the PostHog env var from `NEXT_PUBLIC_POSTHOG_HOST` to `NEXT_PUBLIC_POSTHOG_URL` to make it clear an absolute HTTPS URL is required, and updated docs and runtime validation. This prevents misconfigurations and ensures analytics load reliably.

- **Migration**
  - In Vercel production, set `NEXT_PUBLIC_POSTHOG_URL=https://ph.shipfox.io` and remove `NEXT_PUBLIC_POSTHOG_HOST`.
  - The build now fails if the key or URL is missing, or if the URL is not HTTPS.

<sup>Written for commit 25dfc4610928f8d67945d54843000e94e7038ee3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

