### PR TITLE
[email] Add branded verification code emails

### DIFF
--- a/.changeset/warm-codes-arrive.md
+++ b/.changeset/warm-codes-arrive.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/node-email": minor
+"@shipfox/api-email-challenges": patch
+---
+
+Adds a branded verification-code email with warmer account setup copy.

--- a/libs/api/email-challenges/package.json
+++ b/libs/api/email-challenges/package.json
@@ -52,6 +52,7 @@
     "@shipfox/api-common-dto": "workspace:*",
     "@shipfox/config": "workspace:*",
     "@shipfox/node-drizzle": "workspace:*",
+    "@shipfox/node-email": "workspace:*",
     "@shipfox/node-auth-root-key": "workspace:*",
     "@shipfox/node-mailer": "workspace:*",
     "@shipfox/node-module": "workspace:*",

--- a/libs/api/email-challenges/src/core/email-challenges.test.ts
+++ b/libs/api/email-challenges/src/core/email-challenges.test.ts
@@ -19,6 +19,27 @@ function sentCode(send: ReturnType<typeof vi.fn>): string {
 }
 
 describe('email challenges', () => {
+  test('sends the verification code in a branded message', async () => {
+    const send = vi.spyOn(mailer, 'send').mockResolvedValue();
+
+    await createEmailChallenge({
+      email: 'branded@example.com',
+      purpose: 'signup',
+      continuation: 'branded-browser',
+      sourceIp: '127.0.0.2',
+    });
+    const verificationCode = sentCode(send);
+
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: 'branded@example.com',
+        subject: 'Your Shipfox verification code',
+        html: expect.stringContaining(verificationCode),
+        text: expect.stringContaining("You're almost there"),
+      }),
+    );
+  });
+
   test('replaces the code on resend and consumes only the same continuation idempotently', async () => {
     const send = vi.spyOn(mailer, 'send').mockResolvedValue();
     const challenge = await createEmailChallenge({

--- a/libs/api/email-challenges/src/core/email-challenges.ts
+++ b/libs/api/email-challenges/src/core/email-challenges.ts
@@ -1,6 +1,7 @@
 import {createHmac, randomInt, timingSafeEqual} from 'node:crypto';
 import {emailSchema} from '@shipfox/api-common-dto';
 import {emailChallengeKey} from '@shipfox/node-auth-root-key';
+import {renderEmail} from '@shipfox/node-email';
 import {mailer} from '@shipfox/node-mailer';
 import {and, eq, gt, isNull, lt, sql} from 'drizzle-orm';
 import {config} from '#config.js';
@@ -11,6 +12,7 @@ import {recordEmailChallenge} from '#metrics/instance.js';
 import {EmailChallengeError} from './errors.js';
 
 const ttlMs = 10 * 60 * 1000;
+const ttlMinutes = ttlMs / 60_000;
 const resendCooldownMs = 60 * 1000;
 const maxSends = 3;
 const maxFailedAttempts = 5;
@@ -120,11 +122,11 @@ async function consumeSendLimits(tx: Tx, email: string, sourceIp: string, now: D
 }
 
 async function deliver(email: string, value: string) {
-  await mailer.send({
-    to: email,
-    subject: 'Your Shipfox verification code',
-    text: `Your Shipfox verification code is ${value}. It expires in 10 minutes.`,
+  const message = await renderEmail('verification-code', {
+    verificationCode: value,
+    expiresInMinutes: ttlMinutes,
   });
+  await mailer.send({to: email, ...message});
 }
 
 export async function createEmailChallenge(

--- a/libs/shared/node/email/README.md
+++ b/libs/shared/node/email/README.md
@@ -16,6 +16,7 @@ sends.
 
 | Name | Data | Sent by |
 |------|------|---------|
+| `verification-code` | `{verificationCode, expiresInMinutes}` | `@shipfox/api-email-challenges` on signup / resend |
 | `verify-email` | `{verifyLink}` | `@shipfox/api-auth` on signup / resend |
 | `reset-password` | `{resetLink, expiresInHours}` | `@shipfox/api-auth` on password reset request |
 | `workspace-invitation` | `{email, workspaceName, inviterName, inviteLink}` | `@shipfox/api-workspaces` on invite |

--- a/libs/shared/node/email/emails/verification-code.mjml
+++ b/libs/shared/node/email/emails/verification-code.mjml
@@ -1,0 +1,58 @@
+<mjml lang="en">
+  <mj-head>
+    <mj-title>Your Shipfox verification code</mj-title>
+    <mj-preview>You're one quick step away. Use {{verificationCode}} to verify your email.</mj-preview>
+    <mj-include path="./partials/head-styles.mjml" />
+  </mj-head>
+  <mj-body background-color="#ffffff" width="600px">
+    <mj-section padding="40px 24px 0 24px">
+      <mj-column>
+        <mj-include path="./partials/header.mjml" />
+        <mj-text
+          align="center"
+          font-size="24px"
+          line-height="32px"
+          font-weight="600"
+          letter-spacing="-0.01em"
+          color="#0f0f10"
+          padding-bottom="24px"
+        >
+          Let's get you verified
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-section padding="0 24px">
+      <mj-column>
+        <mj-text align="center" padding-bottom="24px">
+          You're almost there. Enter this code to verify your email and finish setting up your
+          Shipfox account.
+        </mj-text>
+        <mj-text
+          align="center"
+          color="#0f0f10"
+          font-family="SFMono-Regular, Consolas, Liberation Mono, monospace"
+          font-size="32px"
+          font-weight="600"
+          letter-spacing="0.18em"
+          line-height="40px"
+          padding="0"
+        >
+          <div style="background-color: #f4f4f5; border-radius: 8px; padding: 20px 16px 20px 22px;">
+            {{verificationCode}}
+          </div>
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-section padding="0 24px 40px 24px">
+      <mj-column>
+        <mj-include path="./partials/footer.mjml" />
+        <mj-text color="#52525b" font-size="14px" line-height="20px">
+          This code expires in {{expiresInMinutes}} minutes. If you didn't request it, you can
+          safely ignore this email.
+        </mj-text>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>

--- a/libs/shared/node/email/src/template.ts
+++ b/libs/shared/node/email/src/template.ts
@@ -20,6 +20,7 @@ const logoUrl = new URL('/email-logo.png', config.CLIENT_BASE_URL).toString();
 // Subjects are plain text, not HTML, so compile them with `noEscape` to keep a
 // workspace name like `A&B` from turning into `A&amp;B` in the subject line.
 const subjects: Record<TemplateName, string> = {
+  'verification-code': 'Your Shipfox verification code',
   'verify-email': 'Verify your email',
   'reset-password': 'Reset your password',
   'workspace-invitation': 'Join {{workspaceName}} on Shipfox',

--- a/libs/shared/node/email/src/text.ts
+++ b/libs/shared/node/email/src/text.ts
@@ -1,4 +1,13 @@
-export type TemplateName = 'verify-email' | 'reset-password' | 'workspace-invitation';
+export type TemplateName =
+  | 'verification-code'
+  | 'verify-email'
+  | 'reset-password'
+  | 'workspace-invitation';
+
+export interface VerificationCodeData {
+  verificationCode: string;
+  expiresInMinutes: number;
+}
 
 export interface VerifyEmailData {
   verifyLink: string;
@@ -17,6 +26,7 @@ export interface WorkspaceInvitationData {
 }
 
 export interface TemplateVariables {
+  'verification-code': VerificationCodeData;
   'verify-email': VerifyEmailData;
   'reset-password': ResetPasswordData;
   'workspace-invitation': WorkspaceInvitationData;
@@ -25,6 +35,19 @@ export interface TemplateVariables {
 const signature = 'Thanks,\nThe Shipfox team';
 
 const builders: {[Name in TemplateName]: (data: TemplateVariables[Name]) => string} = {
+  'verification-code': ({verificationCode, expiresInMinutes}) =>
+    [
+      'Your Shipfox verification code',
+      '',
+      "You're almost there. Enter this code to verify your email and finish setting up your Shipfox account:",
+      '',
+      verificationCode,
+      '',
+      `This code expires in ${expiresInMinutes} minutes. If you didn't request it, you can safely ignore this email.`,
+      '',
+      signature,
+    ].join('\n'),
+
   'verify-email': ({verifyLink}) =>
     [
       'Verify your email',

--- a/libs/shared/node/email/test/template.test.ts
+++ b/libs/shared/node/email/test/template.test.ts
@@ -4,6 +4,24 @@ import {renderEmail} from '#template.js';
 const lineBreak = /[\r\n]/;
 
 describe('renderEmail', () => {
+  test('verification-code renders the code in branded html and standalone text', async () => {
+    const verificationCode = '12345678';
+
+    const email = await renderEmail('verification-code', {
+      verificationCode,
+      expiresInMinutes: 10,
+    });
+
+    expect(email.subject).toBe('Your Shipfox verification code');
+    expect(email.html).toContain("Let's get you verified");
+    expect(email.html).toContain('alt="Shipfox"');
+    expect(email.html).toContain(verificationCode);
+    expect(email.html).toContain('expires in 10 minutes');
+    expect(email.text).toContain("You're almost there");
+    expect(email.text).toContain(verificationCode);
+    expect(email.text).not.toContain('<');
+  });
+
   test('verify-email renders a branded html body, subject, and standalone text', async () => {
     const verifyLink = 'https://app.shipfox.io/auth/verify-email?token=abc123';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2424,6 +2424,9 @@ importers:
       '@shipfox/node-drizzle':
         specifier: workspace:*
         version: link:../../shared/node/drizzle
+      '@shipfox/node-email':
+        specifier: workspace:*
+        version: link:../../shared/node/email
       '@shipfox/node-mailer':
         specifier: workspace:*
         version: link:../../shared/node/mailer


### PR DESCRIPTION
Replace the raw plaintext signup verification message with a responsive Shipfox email that uses the shared logo, typography, colors, and footer treatment.

The new copy gives the account setup flow a warmer voice while keeping the eight-digit code and expiry prominent. A dedicated `verification-code` template preserves the existing link-based `verify-email` public API for compatibility, and both initial sends and resends now use the branded renderer.

Includes rendering and delivery coverage plus release changesets for the shared email and email-challenge packages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced plaintext signup verification emails with a responsive, branded `verification-code` template used for both initial sends and resends. Keeps the existing `verify-email` link flow intact, with tests and docs updated.

- **New Features**
  - Added `verification-code` email (MJML + text) with subject “Your Shipfox verification code” and expiry messaging.
  - Switched `@shipfox/api-email-challenges` to send via `renderEmail('verification-code', { verificationCode, expiresInMinutes })`; TTL now drives the copy.
  - Added rendering and delivery tests; documented the new template in `@shipfox/node-email` README; added `@shipfox/node-email` as a dependency and included changesets.

<sup>Written for commit 6f6e3769a8244035d9963c9904b5d908156ce552. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

