### PR TITLE
[provisioner-ec2] Add lifecycle observability metrics

### DIFF
--- a/libs/provisioner/ec2/package.json
+++ b/libs/provisioner/ec2/package.json
@@ -40,6 +40,7 @@
     "@aws-sdk/client-ec2": "catalog:",
     "@shipfox/api-runners-dto": "workspace:*",
     "@shipfox/config": "workspace:*",
+    "@shipfox/node-opentelemetry": "workspace:*",
     "@shipfox/provisioner-core": "workspace:*",
     "@shipfox/runner-labels": "workspace:*",
     "js-yaml": "catalog:",

--- a/libs/provisioner/ec2/src/index.ts
+++ b/libs/provisioner/ec2/src/index.ts
@@ -4,6 +4,10 @@ export {
   type Ec2LifecycleOptions,
 } from '#lifecycle.js';
 export {
+  type RegisterEc2ServiceMetricsOptions,
+  registerEc2ServiceMetrics,
+} from '#metrics/service.js';
+export {
   type Ec2Market,
   Ec2TemplateConfigError,
   type Ec2TemplateSpec,

--- a/libs/provisioner/ec2/src/lifecycle.test.ts
+++ b/libs/provisioner/ec2/src/lifecycle.test.ts
@@ -10,6 +10,18 @@ import {type Ec2Engine, Ec2EngineError, type Ec2InstanceView} from '#ec2-engine.
 import {createEc2Lifecycle} from '#lifecycle.js';
 import type {Ec2TemplateSpec} from '#templates.js';
 
+const observability = vi.hoisted(() => ({
+  logger: {error: vi.fn(), info: vi.fn()},
+  recordEc2Launch: vi.fn(),
+  recordEc2Termination: vi.fn(),
+}));
+
+vi.mock('@shipfox/node-opentelemetry', () => ({logger: () => observability.logger}));
+vi.mock('#metrics/instance.js', () => ({
+  recordEc2Launch: observability.recordEc2Launch,
+  recordEc2Termination: observability.recordEc2Termination,
+}));
+
 const NOW = new Date('2026-01-01T00:10:00.000Z');
 const RUNNER_INSTANCE_ID = '00000000-0000-4000-8000-000000000004';
 
@@ -32,6 +44,10 @@ const template: ProvisionerTemplate<Ec2TemplateSpec> = {
 };
 
 describe('createEc2Lifecycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('attaches and reports starting before launching an instance', async () => {
     const engine = fakeEngine();
     const client = fakeClient();
@@ -54,6 +70,14 @@ describe('createEc2Lifecycle', () => {
       market: 'spot',
       tags: {'shipfox.provider_runner_id': 'runner-1'},
     });
+    expect(observability.recordEc2Launch).toHaveBeenCalledWith('spot', 'launched');
+    expect(observability.logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provisioned_runner_id: 'runner-1',
+        aws_instance_id: 'i-123',
+      }),
+      'Launched EC2 runner instance',
+    );
   });
 
   it('reports a classified failure and rethrows when EC2 launch fails', async () => {
@@ -78,6 +102,7 @@ describe('createEc2Lifecycle', () => {
       {state: 'starting'},
       {state: 'failed', reason: 'throttled'},
     ]);
+    expect(observability.recordEc2Launch).toHaveBeenCalledWith('spot', 'throttled');
   });
 
   it('preserves a just-launched instance in the tracker while DescribeInstances lags', async () => {
@@ -129,6 +154,7 @@ describe('createEc2Lifecycle', () => {
       state: 'failed',
       reason: 'spot-interruption',
     });
+    expect(observability.recordEc2Termination).toHaveBeenCalledWith('spot-interruption');
   });
 
   it('propagates observation failures so the core loop degrades capacity to zero', async () => {

--- a/libs/provisioner/ec2/src/lifecycle.ts
+++ b/libs/provisioner/ec2/src/lifecycle.ts
@@ -1,4 +1,5 @@
 import type {RunnerInstanceReportEventDto} from '@shipfox/api-runners-dto';
+import {logger} from '@shipfox/node-opentelemetry';
 import type {
   ProviderRunnerLaunch,
   ProviderRunnerTracker,
@@ -9,6 +10,7 @@ import type {
 import {ProvisionerAuthenticationError} from '@shipfox/provisioner-core';
 import {type Ec2Engine, Ec2EngineError, type Ec2InstanceView} from '#ec2-engine.js';
 import {buildInstanceTags, parseInstanceIdentity} from '#instance-identity.js';
+import {recordEc2Launch, recordEc2Termination} from '#metrics/instance.js';
 import type {Ec2TemplateSpec} from '#templates.js';
 
 const MAX_REPORT_BATCH = 1000;
@@ -89,7 +91,7 @@ async function launchRunner(
   try {
     await attachProviderIdentity(context, launch);
     await reportEvents(context, [eventForLaunch(context, launch, 'starting')]);
-    await context.engine.runInstance({
+    const instance = await context.engine.runInstance({
       clientToken: launch.providerRunnerId,
       tags: buildInstanceTags({launch, identity: context.identity}),
       ami: launch.template.spec.ami,
@@ -107,7 +109,25 @@ async function launchRunner(
       ...(context.renderUserData ? {userData: context.renderUserData(launch)} : {}),
     });
     context.locallyLaunched.set(launch.providerRunnerId, {templateKey: launch.template.key});
+    recordEc2Launch(launch.template.spec.market, 'launched');
+    logger().info(
+      {
+        provisioned_runner_id: launch.providerRunnerId,
+        runner_instance_id: launch.runnerInstanceId,
+        aws_instance_id: instance.instanceId,
+      },
+      'Launched EC2 runner instance',
+    );
   } catch (error) {
+    recordEc2Launch(launch.template.spec.market, launchOutcome(error));
+    logger().error(
+      {
+        err: error,
+        provisioned_runner_id: launch.providerRunnerId,
+        runner_instance_id: launch.runnerInstanceId,
+      },
+      'Failed to launch EC2 runner instance',
+    );
     await reportEvents(context, [eventForLaunch(context, launch, 'failed', errorReason(error))]);
     throw error;
   }
@@ -133,6 +153,20 @@ async function observe(context: Ec2LifecycleContext): Promise<void> {
     if (labels.length === 0) continue;
 
     const mapped = mapInstanceState(instance);
+    if (mapped.state === 'failed' || mapped.state === 'terminated') {
+      const terminationReason =
+        mapped.reason === 'spot-interruption' ? 'spot-interruption' : 'observed-terminated';
+      recordEc2Termination(terminationReason);
+      logger().info(
+        {
+          provisioned_runner_id: identity.providerRunnerId,
+          ...(identity.runnerInstanceId ? {runner_instance_id: identity.runnerInstanceId} : {}),
+          aws_instance_id: instance.instanceId,
+          reason: terminationReason,
+        },
+        'Observed EC2 runner instance termination',
+      );
+    }
     events.push(eventForInstance(context, instance, mapped.state, labels, mapped.reason));
     if ((mapped.state === 'starting' || mapped.state === 'running') && identity.templateKey) {
       trackerRunners.push({
@@ -283,6 +317,13 @@ function selectSubnet(launch: ProviderRunnerLaunch<Ec2TemplateSpec>): string {
 function errorReason(error: unknown): string {
   if (error instanceof Ec2EngineError) return error.reason;
   return error instanceof Error ? error.message : String(error);
+}
+
+function launchOutcome(error: unknown): 'capacity' | 'throttled' | 'error' {
+  if (!(error instanceof Ec2EngineError)) return 'error';
+  if (error.reason === 'insufficient-capacity' || error.reason === 'spot-price-too-low')
+    return 'capacity';
+  return error.reason === 'throttled' ? 'throttled' : 'error';
 }
 
 function responseStatus(error: unknown): number | undefined {

--- a/libs/provisioner/ec2/src/metrics/index.ts
+++ b/libs/provisioner/ec2/src/metrics/index.ts
@@ -1,0 +1,11 @@
+export {
+  type Ec2LaunchOutcome,
+  type Ec2TerminationReason,
+  recordEc2Launch,
+  recordEc2ReconcileAbsent,
+  recordEc2Termination,
+} from './instance.js';
+export {
+  type RegisterEc2ServiceMetricsOptions,
+  registerEc2ServiceMetrics,
+} from './service.js';

--- a/libs/provisioner/ec2/src/metrics/instance.test.ts
+++ b/libs/provisioner/ec2/src/metrics/instance.test.ts
@@ -1,0 +1,53 @@
+const metricMocks = vi.hoisted(() => {
+  const counters = new Map<string, {add: ReturnType<typeof vi.fn>}>();
+  const createCounter = vi.fn((name: string) => {
+    const counter = {add: vi.fn()};
+    counters.set(name, counter);
+    return counter;
+  });
+
+  return {counters, createCounter};
+});
+
+vi.mock('@shipfox/node-opentelemetry', () => ({
+  instanceMetrics: {getMeter: () => ({createCounter: metricMocks.createCounter})},
+}));
+
+function counterAdd(name: string): ReturnType<typeof vi.fn> {
+  const counter = metricMocks.counters.get(name);
+  if (!counter) throw new Error(`Missing counter: ${name}`);
+  return counter.add;
+}
+
+let metrics: typeof import('./instance.js');
+
+describe('EC2 provisioner metrics', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    metricMocks.counters.clear();
+    metrics = await import('./instance.js');
+  });
+
+  it('records launch outcomes with bounded labels', () => {
+    metrics.recordEc2Launch('spot', 'capacity');
+
+    expect(counterAdd('ec2_provisioner_launch')).toHaveBeenCalledWith(1, {
+      market: 'spot',
+      outcome: 'capacity',
+    });
+  });
+
+  it('records termination reasons with bounded labels', () => {
+    metrics.recordEc2Termination('spot-interruption');
+
+    expect(counterAdd('ec2_provisioner_terminate')).toHaveBeenCalledWith(1, {
+      reason: 'spot-interruption',
+    });
+  });
+
+  it('records reconcile absence without labels', () => {
+    metrics.recordEc2ReconcileAbsent();
+
+    expect(counterAdd('ec2_provisioner_reconcile_absent')).toHaveBeenCalledWith(1);
+  });
+});

--- a/libs/provisioner/ec2/src/metrics/instance.ts
+++ b/libs/provisioner/ec2/src/metrics/instance.ts
@@ -1,0 +1,44 @@
+import {instanceMetrics} from '@shipfox/node-opentelemetry';
+
+const meter = instanceMetrics.getMeter('provisioner-ec2');
+
+const launchCount = meter.createCounter<{
+  market: 'spot' | 'on-demand';
+  outcome: 'launched' | 'capacity' | 'throttled' | 'error';
+}>('ec2_provisioner_launch', {
+  description: 'EC2 runner launch attempts by market and outcome',
+});
+
+const terminateCount = meter.createCounter<{
+  reason:
+    | 'backend-terminate'
+    | 'registration-deadline'
+    | 'spot-interruption'
+    | 'observed-terminated';
+}>('ec2_provisioner_terminate', {
+  description: 'EC2 runner instance terminations by reason',
+});
+
+const reconcileAbsentCount = meter.createCounter<Record<string, never>>(
+  'ec2_provisioner_reconcile_absent',
+  {description: 'EC2 runner instances the backend or AWS reported absent during reconciliation'},
+);
+
+export type Ec2LaunchOutcome = 'launched' | 'capacity' | 'throttled' | 'error';
+export type Ec2TerminationReason =
+  | 'backend-terminate'
+  | 'registration-deadline'
+  | 'spot-interruption'
+  | 'observed-terminated';
+
+export function recordEc2Launch(market: 'spot' | 'on-demand', outcome: Ec2LaunchOutcome): void {
+  launchCount.add(1, {market, outcome});
+}
+
+export function recordEc2Termination(reason: Ec2TerminationReason): void {
+  terminateCount.add(1, {reason});
+}
+
+export function recordEc2ReconcileAbsent(): void {
+  reconcileAbsentCount.add(1);
+}

--- a/libs/provisioner/ec2/src/metrics/service.test.ts
+++ b/libs/provisioner/ec2/src/metrics/service.test.ts
@@ -1,0 +1,51 @@
+const mocks = vi.hoisted(() => {
+  const gauge = {};
+  return {
+    addBatchObservableCallback: vi.fn(),
+    createObservableGauge: vi.fn(() => gauge),
+    gauge,
+    getMeter: vi.fn(),
+    getServiceMetricsProvider: vi.fn(),
+  };
+});
+
+vi.mock('@shipfox/node-opentelemetry', () => ({
+  getServiceMetricsProvider: mocks.getServiceMetricsProvider,
+}));
+
+import type {Ec2Engine} from '#ec2-engine.js';
+import {registerEc2ServiceMetrics} from './service.js';
+
+describe('registerEc2ServiceMetrics', () => {
+  beforeEach(() => {
+    mocks.addBatchObservableCallback.mockReset();
+    mocks.createObservableGauge.mockClear();
+    mocks.getMeter.mockReset();
+    mocks.getServiceMetricsProvider.mockReset();
+    mocks.getMeter.mockReturnValue({
+      createObservableGauge: mocks.createObservableGauge,
+      addBatchObservableCallback: mocks.addBatchObservableCallback,
+    });
+    mocks.getServiceMetricsProvider.mockReturnValue({getMeter: mocks.getMeter});
+  });
+
+  it('observes managed instances by bounded EC2 state', async () => {
+    const listManaged = vi
+      .fn()
+      .mockResolvedValue([{state: 'pending'}, {state: 'running'}, {state: 'running'}]);
+    const engine = {listManaged} as unknown as Ec2Engine;
+
+    registerEc2ServiceMetrics({engine, provisionerId: 'provisioner-1'});
+    const callback = mocks.addBatchObservableCallback.mock.calls[0]?.[0];
+    const observer = {observe: vi.fn()};
+
+    await callback?.(observer);
+
+    expect(mocks.createObservableGauge).toHaveBeenCalledWith('ec2_provisioner_managed_instances', {
+      description: 'EC2 runner instances currently managed by the provisioner, by EC2 state',
+    });
+    expect(listManaged).toHaveBeenCalledWith('provisioner-1');
+    expect(observer.observe).toHaveBeenCalledWith(mocks.gauge, 1, {state: 'pending'});
+    expect(observer.observe).toHaveBeenCalledWith(mocks.gauge, 2, {state: 'running'});
+  });
+});

--- a/libs/provisioner/ec2/src/metrics/service.ts
+++ b/libs/provisioner/ec2/src/metrics/service.ts
@@ -1,0 +1,27 @@
+import {getServiceMetricsProvider} from '@shipfox/node-opentelemetry';
+import type {Ec2Engine, Ec2InstanceState} from '#ec2-engine.js';
+
+export interface RegisterEc2ServiceMetricsOptions {
+  readonly engine: Ec2Engine;
+  readonly provisionerId: string;
+}
+
+export function registerEc2ServiceMetrics(options: RegisterEc2ServiceMetricsOptions): void {
+  const meter = getServiceMetricsProvider().getMeter('provisioner-ec2');
+  const managedInstances = meter.createObservableGauge<{
+    state: Ec2InstanceState;
+  }>('ec2_provisioner_managed_instances', {
+    description: 'EC2 runner instances currently managed by the provisioner, by EC2 state',
+  });
+
+  meter.addBatchObservableCallback(
+    async (observer) => {
+      const instances = await options.engine.listManaged(options.provisionerId);
+      const counts = new Map<Ec2InstanceState, number>();
+      for (const instance of instances)
+        counts.set(instance.state, (counts.get(instance.state) ?? 0) + 1);
+      for (const [state, count] of counts) observer.observe(managedInstances, count, {state});
+    },
+    [managedInstances],
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6057,6 +6057,9 @@ importers:
       '@shipfox/config':
         specifier: workspace:*
         version: link:../../shared/common/config
+      '@shipfox/node-opentelemetry':
+        specifier: workspace:*
+        version: link:../../shared/node/opentelemetry
       '@shipfox/provisioner-core':
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION
Adds bounded EC2 provisioner lifecycle counters, a managed-instance service gauge, and structured logs with runner and EC2 instance IDs.

Operators need visibility into launch failures, termination causes, and current managed capacity without using IDs as metric labels. The gauge resolves its meter only when registered, so importing the provider does not bind the service-metrics port.

The backend-termination, registration-deadline, and reconcile-absence metric APIs are exported now for ENG-1011's still-pending lifecycle paths rather than duplicating that concurrent work here.

Refs ENG-1012

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add bounded EC2 provisioner lifecycle metrics and structured logs to monitor launch outcomes, termination reasons, and managed capacity without high-cardinality labels. Implements ENG-1012 and exposes metrics APIs needed for upcoming lifecycle paths in ENG-1011.

- New Features
  - Counters: `ec2_provisioner_launch` (by market and outcome), `ec2_provisioner_terminate` (by reason), `ec2_provisioner_reconcile_absent` (no labels).
  - Service gauge: `ec2_provisioner_managed_instances` by EC2 state; meter resolved only when registered.
  - Structured logs on launch/termination with `provisioned_runner_id`, `runner_instance_id`, `aws_instance_id`.
  - Exported `registerEc2ServiceMetrics` and recorders for backend-termination, registration-deadline, and reconcile-absence.

- Dependencies
  - Added `@shipfox/node-opentelemetry`.

<sup>Written for commit 24c1c13094ecfd4ff5e4a6d131f7ebc004a3e4e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

