### PR TITLE
[provisioner-ec2] Add reconcile, reap, and terminate

### DIFF
--- a/.changeset/tame-otters-reconcile.md
+++ b/.changeset/tame-otters-reconcile.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/provisioner-ec2-provider": minor
+---
+
+Adds EC2 reconcile, periodic tick, and backend-driven terminate to the runner lifecycle, and reaps instances stuck past the registration deadline.

--- a/libs/provisioner/ec2/src/lifecycle.test.ts
+++ b/libs/provisioner/ec2/src/lifecycle.test.ts
@@ -23,6 +23,7 @@ vi.mock('#metrics/instance.js', () => ({
 }));
 
 const NOW = new Date('2026-01-01T00:10:00.000Z');
+const RECONCILE_INTERVAL_MS = 60_000;
 const RUNNER_INSTANCE_ID = '00000000-0000-4000-8000-000000000004';
 
 const template: ProvisionerTemplate<Ec2TemplateSpec> = {
@@ -114,6 +115,23 @@ describe('createEc2Lifecycle', () => {
 
     expect(tracker.countsByTemplate()).toEqual(
       new Map([['spot-small', {starting: 1, running: 0}]]),
+    );
+  });
+
+  it('reports a locally launched runner as terminated after the DescribeInstances grace window', async () => {
+    const now = new Date(NOW);
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({client, now: () => now});
+
+    await lifecycle.launch(launch());
+    now.setTime(now.getTime() + RECONCILE_INTERVAL_MS);
+    await lifecycle.observe();
+
+    expect(client.reportBodies.flatMap((body) => body.events)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({state: 'starting'}),
+        expect.objectContaining({provider_runner_id: 'runner-1', state: 'terminated'}),
+      ]),
     );
   });
 
@@ -294,6 +312,156 @@ describe('createEc2Lifecycle', () => {
     expect(client.reportBodies[0]?.events[0]).toMatchObject({state: 'running'});
     expect(tracker.countsByTemplate().size).toBe(0);
   });
+
+  it('reconciles adopted instances and sends their observed ids to the backend', async () => {
+    const client = fakeClient({
+      reconcileResponse: {
+        runners: [reconciledRunner('runner-1', 'keep')],
+        terminated_absent_provider_runner_ids: [],
+      },
+    });
+    const tracker = testTracker();
+    const lifecycle = makeLifecycle({
+      client,
+      engine: fakeEngine({instances: [instance({state: 'running'})]}),
+      tracker,
+    });
+
+    await lifecycle.reconcile();
+
+    expect(client.reconcileBodies).toEqual([{observed_provider_runner_ids: ['runner-1']}]);
+    expect(tracker.countsByTemplate()).toEqual(
+      new Map([['spot-small', {starting: 0, running: 1}]]),
+    );
+  });
+
+  it('reconcile falls back to local observe when the observed id count exceeds the API limit', async () => {
+    const engine = fakeEngine({
+      instances: Array.from({length: 5001}, (_, index) =>
+        instance({state: 'running', instanceId: `i-${index}`, providerRunnerId: `runner-${index}`}),
+      ),
+    });
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.reconcile();
+
+    expect(client.reconcileBodies).toEqual([]);
+    expect(client.reportBodies.map((body) => body.events.length)).toEqual([
+      1000, 1000, 1000, 1000, 1000, 1,
+    ]);
+  });
+
+  it('terminates and reports instances with backend terminate intent', async () => {
+    const engine = fakeEngine({instances: [instance({state: 'running'})]});
+    const client = fakeClient({
+      reconcileResponse: {
+        runners: [reconciledRunner('runner-1', 'terminate')],
+        terminated_absent_provider_runner_ids: [],
+      },
+    });
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.reconcile();
+
+    expect(engine.terminated).toEqual(['i-123']);
+    expect(client.reportBodies.flatMap((body) => body.events)).toMatchObject([
+      {provider_runner_id: 'runner-1', state: 'terminated', reason: 'backend-terminate'},
+    ]);
+  });
+
+  it('terminates an instance with backend terminate intent even when its labels are unresolvable', async () => {
+    const engine = fakeEngine({
+      instances: [instance({state: 'running', templateKey: 'unknown-template', labels: ''})],
+    });
+    const client = fakeClient({
+      reconcileResponse: {
+        runners: [reconciledRunner('runner-1', 'terminate')],
+        terminated_absent_provider_runner_ids: [],
+      },
+    });
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.reconcile();
+
+    expect(engine.terminated).toEqual(['i-123']);
+  });
+
+  it('reaps a pending instance past its registration deadline even when its labels are unresolvable', async () => {
+    const engine = fakeEngine({
+      instances: [
+        instance({
+          state: 'pending',
+          launchTime: new Date('2026-01-01T00:00:00.000Z'),
+          templateKey: 'unknown-template',
+          labels: '',
+        }),
+      ],
+    });
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({engine, client, registrationDeadlineMs: 60_000});
+
+    await lifecycle.observe();
+
+    expect(engine.terminated).toEqual(['i-123']);
+  });
+
+  it('reaps a pending instance past its registration deadline', async () => {
+    const engine = fakeEngine({
+      instances: [instance({state: 'pending', launchTime: new Date('2026-01-01T00:00:00.000Z')})],
+    });
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({engine, client, registrationDeadlineMs: 60_000});
+
+    await lifecycle.observe();
+
+    expect(engine.terminated).toEqual(['i-123']);
+    expect(client.reportBodies[0]?.events[0]).toMatchObject({
+      state: 'terminated',
+      reason: 'registration-deadline',
+    });
+  });
+
+  it('periodically reconciles and otherwise observes', async () => {
+    const now = new Date(NOW);
+    const client = fakeClient({
+      reconcileResponse: {runners: [], terminated_absent_provider_runner_ids: []},
+    });
+    const lifecycle = makeLifecycle({client, now: () => now});
+
+    await lifecycle.tick();
+    now.setTime(now.getTime() + RECONCILE_INTERVAL_MS - 1);
+    await lifecycle.tick();
+    now.setTime(now.getTime() + 1);
+    await lifecycle.tick();
+
+    expect(client.reconcileBodies).toHaveLength(2);
+  });
+
+  it('logs backend absent ids while reconciling an empty observed set', async () => {
+    const client = fakeClient({
+      reconcileResponse: {runners: [], terminated_absent_provider_runner_ids: ['vanished-runner']},
+    });
+    const lifecycle = makeLifecycle({client});
+
+    await lifecycle.reconcile();
+
+    expect(client.reconcileBodies).toEqual([{observed_provider_runner_ids: []}]);
+  });
+
+  it('terminates only managed instances matching requested ids', async () => {
+    const engine = fakeEngine({
+      instances: [
+        instance({state: 'running'}),
+        instance({state: 'running', instanceId: 'i-456', providerRunnerId: 'runner-2'}),
+      ],
+    });
+    const lifecycle = makeLifecycle({engine});
+
+    await lifecycle.terminate(['runner-2', 'absent-runner']);
+
+    expect(engine.terminated).toEqual(['i-456']);
+  });
 });
 
 function makeLifecycle(
@@ -301,6 +469,8 @@ function makeLifecycle(
     engine?: ReturnType<typeof fakeEngine>;
     client?: ReturnType<typeof fakeClient>;
     tracker?: ProviderRunnerTracker;
+    registrationDeadlineMs?: number;
+    now?: () => Date;
   } = {},
 ) {
   return createEc2Lifecycle({
@@ -310,7 +480,9 @@ function makeLifecycle(
     tracker: args.tracker ?? testTracker(),
     templates: [template],
     providerKind: 'ec2',
-    now: () => NOW,
+    registrationDeadlineMs: args.registrationDeadlineMs ?? 300_000,
+    reconcileIntervalMs: RECONCILE_INTERVAL_MS,
+    now: args.now ?? (() => NOW),
   });
 }
 
@@ -328,28 +500,36 @@ function launch(): ProviderRunnerLaunch<Ec2TemplateSpec> {
 function instance(args: {
   state: Ec2InstanceView['state'];
   stateTransitionReason?: string;
+  launchTime?: Date;
+  instanceId?: string;
+  providerRunnerId?: string;
+  templateKey?: string;
+  labels?: string;
 }): Ec2InstanceView {
   return {
-    instanceId: 'i-123',
+    instanceId: args.instanceId ?? 'i-123',
     state: args.state,
     tags: {
       'shipfox.runner_instance_id': RUNNER_INSTANCE_ID,
-      'shipfox.provider_runner_id': 'runner-1',
+      'shipfox.provider_runner_id': args.providerRunnerId ?? 'runner-1',
       'shipfox.provisioner_id': '00000000-0000-4000-8000-000000000001',
       'shipfox.reservation_id': '00000000-0000-4000-8000-000000000003',
-      'shipfox.template_key': 'spot-small',
-      'shipfox.labels': 'ubuntu22',
+      'shipfox.template_key': args.templateKey ?? 'spot-small',
+      'shipfox.labels': args.labels ?? 'ubuntu22',
     },
     ...(args.stateTransitionReason ? {stateTransitionReason: args.stateTransitionReason} : {}),
+    ...(args.launchTime ? {launchTime: args.launchTime} : {}),
   };
 }
 
 function fakeEngine(
   options: {instances?: Ec2InstanceView[]; runError?: Error; listError?: Error} = {},
-): Ec2Engine & {runArgs: Parameters<Ec2Engine['runInstance']>[0][]} {
+): Ec2Engine & {runArgs: Parameters<Ec2Engine['runInstance']>[0][]; terminated: string[]} {
   const runArgs: Parameters<Ec2Engine['runInstance']>[0][] = [];
+  const terminated: string[] = [];
   return {
     runArgs,
+    terminated,
     runInstance: (args) => {
       runArgs.push(args);
       return options.runError
@@ -360,27 +540,46 @@ function fakeEngine(
       options.listError
         ? Promise.reject(options.listError)
         : Promise.resolve(options.instances ?? []),
-    terminate: () => Promise.resolve(),
+    terminate: (instanceIds) => {
+      terminated.push(...instanceIds);
+      return Promise.resolve();
+    },
   };
 }
 
 function fakeClient(
-  options: {reportErrors?: Error[]; attachResult?: {attached: boolean}} = {},
+  options: {
+    reportErrors?: Error[];
+    attachResult?: {attached: boolean};
+    reconcileResponse?: Awaited<ReturnType<ProvisionerClient['reconcileRunnerInstances']>>;
+  } = {},
 ): ProvisionerClient & {
   reportBodies: ReportRunnerInstancesBodyDto[];
+  reconcileBodies: Array<{observed_provider_runner_ids: string[]}>;
   attachments: Array<{runnerInstanceId: string; providerRunnerId: string}>;
 } {
   const reportBodies: ReportRunnerInstancesBodyDto[] = [];
+  const reconcileBodies: Array<{observed_provider_runner_ids: string[]}> = [];
   const attachments: Array<{runnerInstanceId: string; providerRunnerId: string}> = [];
   const reportErrors = [...(options.reportErrors ?? [])];
   return {
     reportBodies,
+    reconcileBodies,
     attachments,
     getIdentity: () =>
       Promise.resolve({id: 'provisioner', scope: 'installation', workspace_id: null}),
     pollDemand: () =>
       Promise.resolve({stats: [], reservations: [], terminate_provider_runner_ids: []}),
     createRunnerInstances: () => Promise.resolve({runner_instances: []}),
+    reconcileRunnerInstances: (body) => {
+      reconcileBodies.push(body);
+      return Promise.resolve(
+        options.reconcileResponse ?? {
+          runners: [],
+          terminated_absent_provider_runner_ids: [],
+        },
+      );
+    },
     attachRunnerInstanceProviderId: (runnerInstanceId, providerRunnerId) => {
       attachments.push({runnerInstanceId, providerRunnerId});
       return Promise.resolve(options.attachResult ?? {attached: true});
@@ -394,8 +593,17 @@ function fakeClient(
         ? Promise.reject(error)
         : Promise.resolve({accepted: body.events.length, reservations_released: 0});
     },
-    reconcileRunnerInstances: () =>
-      Promise.resolve({runners: [], terminated_absent_provider_runner_ids: []}),
+  };
+}
+
+function reconciledRunner(providerRunnerId: string, desiredIntent: 'keep' | 'terminate') {
+  return {
+    provider_runner_id: providerRunnerId,
+    state: 'running' as const,
+    reservation_id: '00000000-0000-4000-8000-000000000003',
+    runner_session_id: null,
+    bound_job: null,
+    desired_intent: desiredIntent,
   };
 }
 

--- a/libs/provisioner/ec2/src/lifecycle.ts
+++ b/libs/provisioner/ec2/src/lifecycle.ts
@@ -1,4 +1,7 @@
-import type {RunnerInstanceReportEventDto} from '@shipfox/api-runners-dto';
+import {
+  MAX_RECONCILE_OBSERVED_RUNNERS,
+  type RunnerInstanceReportEventDto,
+} from '@shipfox/api-runners-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import type {
   ProviderRunnerLaunch,
@@ -25,12 +28,17 @@ type TrackerSeed = {
 };
 
 type LocallyLaunchedRunner = {
+  runnerInstanceId: string;
   templateKey: string;
+  launchedAt: Date;
 };
 
 export interface Ec2Lifecycle {
   launch(launch: ProviderRunnerLaunch<Ec2TemplateSpec>): Promise<void>;
   observe(): Promise<void>;
+  reconcile(): Promise<void>;
+  tick(): Promise<void>;
+  terminate(providerRunnerIds: readonly string[]): Promise<void>;
   flush(): Promise<void>;
 }
 
@@ -41,6 +49,8 @@ export interface Ec2LifecycleOptions {
   readonly tracker: ProviderRunnerTracker;
   readonly templates: readonly ProvisionerTemplate<Ec2TemplateSpec>[];
   readonly providerKind: string;
+  readonly registrationDeadlineMs: number;
+  readonly reconcileIntervalMs: number;
   readonly now?: () => Date;
   readonly renderUserData?: (launch: ProviderRunnerLaunch<Ec2TemplateSpec>) => string;
 }
@@ -52,10 +62,13 @@ interface Ec2LifecycleContext {
   readonly tracker: ProviderRunnerTracker;
   readonly templatesByKey: ReadonlyMap<string, ProvisionerTemplate<Ec2TemplateSpec>>;
   readonly providerKind: string;
+  readonly registrationDeadlineMs: number;
+  readonly reconcileIntervalMs: number;
   readonly now: () => Date;
   readonly renderUserData?: (launch: ProviderRunnerLaunch<Ec2TemplateSpec>) => string;
   readonly locallyLaunched: Map<string, LocallyLaunchedRunner>;
   readonly pendingReports: RunnerInstanceReportEventDto[];
+  lastReconciledAt?: Date;
 }
 
 /**
@@ -71,6 +84,8 @@ export function createEc2Lifecycle(options: Ec2LifecycleOptions): Ec2Lifecycle {
     tracker: options.tracker,
     templatesByKey: new Map(options.templates.map((template) => [template.key, template])),
     providerKind: options.providerKind,
+    registrationDeadlineMs: options.registrationDeadlineMs,
+    reconcileIntervalMs: options.reconcileIntervalMs,
     now: options.now ?? (() => new Date()),
     ...(options.renderUserData ? {renderUserData: options.renderUserData} : {}),
     locallyLaunched: new Map(),
@@ -80,6 +95,9 @@ export function createEc2Lifecycle(options: Ec2LifecycleOptions): Ec2Lifecycle {
   return {
     launch: (launch) => launchRunner(context, launch),
     observe: () => observe(context),
+    reconcile: () => reconcile(context),
+    tick: () => tick(context),
+    terminate: (ids) => terminate(context, ids),
     flush: () => flush(context),
   };
 }
@@ -108,7 +126,11 @@ async function launchRunner(
       rootDeviceName: launch.template.spec.rootDeviceName,
       ...(context.renderUserData ? {userData: context.renderUserData(launch)} : {}),
     });
-    context.locallyLaunched.set(launch.providerRunnerId, {templateKey: launch.template.key});
+    context.locallyLaunched.set(launch.providerRunnerId, {
+      runnerInstanceId: launch.runnerInstanceId,
+      templateKey: launch.template.key,
+      launchedAt: new Date(context.now()),
+    });
     recordEc2Launch(launch.template.spec.market, 'launched');
     logger().info(
       {
@@ -136,15 +158,91 @@ async function launchRunner(
 async function observe(context: Ec2LifecycleContext): Promise<void> {
   await reportEvents(context, []);
   const instances = await context.engine.listManaged(context.identity.id);
+  await applyObservedInstances(context, instances, new Set());
+}
+
+async function reconcile(context: Ec2LifecycleContext): Promise<void> {
+  await reportEvents(context, []);
+  const instances = await context.engine.listManaged(context.identity.id);
+  const observedProviderRunnerIds = observedRunnerIds(instances);
+  if (observedProviderRunnerIds.length > MAX_RECONCILE_OBSERVED_RUNNERS) {
+    logger().error(
+      {
+        observedCount: observedProviderRunnerIds.length,
+        maxObserved: MAX_RECONCILE_OBSERVED_RUNNERS,
+      },
+      'Skipping backend reconcile because observed EC2 runner count exceeds the API limit',
+    );
+    await applyObservedInstances(context, instances, new Set());
+    return;
+  }
+
+  const response = await context.client.reconcileRunnerInstances({
+    observed_provider_runner_ids: observedProviderRunnerIds,
+  });
+  const terminateIntentIds = new Set(
+    response.runners
+      .filter((runner) => runner.desired_intent === 'terminate')
+      .map((runner) => runner.provider_runner_id),
+  );
+  if (response.terminated_absent_provider_runner_ids.length > 0) {
+    logger().info(
+      {providerRunnerIds: response.terminated_absent_provider_runner_ids},
+      'Backend terminated provisioned runners absent from EC2',
+    );
+  }
+
+  await applyObservedInstances(context, instances, terminateIntentIds);
+  context.lastReconciledAt = new Date(context.now());
+}
+
+function tick(context: Ec2LifecycleContext): Promise<void> {
+  const needsReconcile =
+    !context.lastReconciledAt ||
+    context.now().getTime() - context.lastReconciledAt.getTime() >= context.reconcileIntervalMs;
+  if (needsReconcile) return reconcile(context);
+  return observe(context);
+}
+
+async function terminate(
+  context: Ec2LifecycleContext,
+  providerRunnerIds: readonly string[],
+): Promise<void> {
+  if (providerRunnerIds.length === 0) return;
+
+  const requestedIds = new Set(providerRunnerIds);
+  const instances = await context.engine.listManaged(context.identity.id);
+  const matchingInstances = instances.filter((instance) =>
+    requestedIds.has(parseInstanceIdentity(instance).providerRunnerId),
+  );
+  await terminateInstances(context, matchingInstances, 'backend-terminate');
+}
+
+async function applyObservedInstances(
+  context: Ec2LifecycleContext,
+  instances: readonly Ec2InstanceView[],
+  terminateIntentIds: ReadonlySet<string>,
+): Promise<void> {
   const trackerRunners: TrackerSeed[] = [];
   const events: RunnerInstanceReportEventDto[] = [];
   const observedIds = new Set<string>();
+  const reapInstances: Ec2InstanceView[] = [];
+  const terminateIntentInstances: Ec2InstanceView[] = [];
 
   for (const instance of instances) {
     const identity = parseInstanceIdentity(instance);
     if (!identity.providerRunnerId) continue;
     observedIds.add(identity.providerRunnerId);
     context.locallyLaunched.delete(identity.providerRunnerId);
+
+    if (terminateIntentIds.has(identity.providerRunnerId)) {
+      terminateIntentInstances.push(instance);
+      continue;
+    }
+    if (isPastRegistrationDeadline(instance, context)) {
+      reapInstances.push(instance);
+      continue;
+    }
 
     const template = identity.templateKey
       ? context.templatesByKey.get(identity.templateKey)
@@ -177,16 +275,82 @@ async function observe(context: Ec2LifecycleContext): Promise<void> {
     }
   }
 
-  // DescribeInstances is eventually consistent. Retaining a locally successful
-  // launch until AWS returns it avoids turning that gap into a free capacity slot.
-  for (const [providerRunnerId, launched] of context.locallyLaunched) {
-    if (!observedIds.has(providerRunnerId)) {
-      trackerRunners.push({providerRunnerId, templateKey: launched.templateKey, state: 'starting'});
-    }
-  }
-
+  synthesizeAbsentLaunchedRunners(context, observedIds, trackerRunners, events);
   context.tracker.replaceAll(trackerRunners);
-  await reportEvents(context, events);
+  if (events.length > 0) await reportEvents(context, events);
+  await terminateInstances(context, terminateIntentInstances, 'backend-terminate');
+  await terminateInstances(context, reapInstances, 'registration-deadline');
+}
+
+function synthesizeAbsentLaunchedRunners(
+  context: Ec2LifecycleContext,
+  observedIds: ReadonlySet<string>,
+  trackerRunners: TrackerSeed[],
+  events: RunnerInstanceReportEventDto[],
+): void {
+  for (const [providerRunnerId, launched] of context.locallyLaunched) {
+    if (observedIds.has(providerRunnerId)) continue;
+    const launchAgeMs = context.now().getTime() - launched.launchedAt.getTime();
+    if (launchAgeMs < context.reconcileIntervalMs) {
+      trackerRunners.push({providerRunnerId, templateKey: launched.templateKey, state: 'starting'});
+      continue;
+    }
+    context.locallyLaunched.delete(providerRunnerId);
+    const template = context.templatesByKey.get(launched.templateKey);
+    if (!template) continue;
+    events.push({
+      runner_instance_id: launched.runnerInstanceId,
+      provider_runner_id: providerRunnerId,
+      template_key: template.key,
+      labels: [...template.labels],
+      state: 'terminated',
+      reported_at: context.now().toISOString(),
+      provider_kind: context.providerKind,
+    });
+  }
+}
+
+function isPastRegistrationDeadline(
+  instance: Ec2InstanceView,
+  context: Ec2LifecycleContext,
+): boolean {
+  return (
+    instance.state === 'pending' &&
+    instance.launchTime !== undefined &&
+    context.now().getTime() - instance.launchTime.getTime() >= context.registrationDeadlineMs
+  );
+}
+
+async function terminateInstances(
+  context: Ec2LifecycleContext,
+  instances: readonly Ec2InstanceView[],
+  reason: string,
+): Promise<void> {
+  if (instances.length === 0) return;
+  await context.engine.terminate(instances.map((instance) => instance.instanceId));
+  const events = instances.flatMap((instance) => {
+    const identity = parseInstanceIdentity(instance);
+    const template = identity.templateKey
+      ? context.templatesByKey.get(identity.templateKey)
+      : undefined;
+    const labels = identity.labels.length > 0 ? identity.labels : (template?.labels ?? []);
+    if (!identity.providerRunnerId || labels.length === 0) return [];
+    return [eventForInstance(context, instance, 'terminated', labels, reason)];
+  });
+  if (events.length > 0) await reportEvents(context, events);
+  for (const instance of instances) {
+    const identity = parseInstanceIdentity(instance);
+    context.locallyLaunched.delete(identity.providerRunnerId);
+    context.tracker.remove(identity.providerRunnerId);
+  }
+}
+
+function observedRunnerIds(instances: readonly Ec2InstanceView[]): string[] {
+  return [
+    ...new Set(
+      instances.map((instance) => parseInstanceIdentity(instance).providerRunnerId).filter(Boolean),
+    ),
+  ];
 }
 
 async function attachProviderIdentity(


### PR DESCRIPTION
Adds periodic reconcile against the backend's reconcile endpoint, backend-driven terminate, and reaping of instances stuck past their registration deadline to the EC2 provisioner lifecycle. Mirrors the Docker provider's existing reconcile/reap paths.

The provisioner could already launch, observe, and report EC2 runner instances, but had no way to correct drift against the backend's view or clean up instances that never registered.

Also fixes an ordering bug found during review: the per-instance loop checked whether labels were resolvable before checking terminate intent or the registration deadline, so an instance with an unresolvable template/labels tag would never be terminated even when the backend explicitly commanded it. Added regression tests for both paths, plus a test mirroring the Docker lifecycle's existing coverage for the observed-count API limit fallback.

Closes ENG-1011

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds reconcile, backend-driven terminate, and reaping to the EC2 provisioner lifecycle to correct drift and clean up stuck instances. Addresses ENG-1011 by matching the Docker provider’s reconcile/reap behavior.

- **New Features**
  - Periodic reconcile via `tick()` sends observed provider runner IDs; falls back to local observe when the count exceeds the API limit.
  - Backend-driven terminate by ID and during reconcile; reports `backend-terminate`.
  - Reaps pending instances past the registration deadline; reports `registration-deadline` and works even if labels are missing.
  - Treats locally launched runners not returned by EC2 after a short grace window as terminated.
  - Adds logging via `@shipfox/node-opentelemetry`.

- **Bug Fixes**
  - Checks terminate intent and registration-deadline before label resolution so unresolvable labels no longer block termination.

<sup>Written for commit 7f888315aa0384ab263715e5e720b98244ce0c7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

