### PR TITLE
[provisioner-ec2] Add runnable EC2 provisioner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,8 @@ jobs:
             image: client
           - package: "@shipfox/provisioner-docker"
             image: provisioner-docker
+          - package: "@shipfox/provisioner-ec2"
+            image: provisioner-ec2
           - package: "@shipfox/runner"
             image: runner
 

--- a/apps/provisioner-docker/README.md
+++ b/apps/provisioner-docker/README.md
@@ -37,7 +37,7 @@ until observation succeeds.
 
 | Variable | Required | Default | Purpose |
 | --- | --- | --- | --- |
-| `SHIPFOX_API_URL` | yes | — | Base URL of the Shipfox API. |
+| `SHIPFOX_API_URL` | no | `https://api.shipfox.io` | Base URL of the Shipfox API. Set it for a self-hosted API. |
 | `SHIPFOX_RUNNER_API_URL` | no | `SHIPFOX_API_URL` | API URL injected into runner containers as `SHIPFOX_API_URL`; set it when containers reach the API through a different address. |
 | `SHIPFOX_PROVISIONER_TOKEN` | yes | — | Long-lived provisioner token (keep it in `.env.local`, never commit it). |
 | `SHIPFOX_PROVISIONER_TEMPLATES_FILE` | yes | — | Path to the YAML template file (see `templates.example.yaml`). |

--- a/apps/provisioner-ec2/Dockerfile
+++ b/apps/provisioner-ec2/Dockerfile
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1
+
+ARG NODE_VERSION=24.16.0
+ARG PNPM_VERSION=11.6.0
+
+FROM node:${NODE_VERSION}-slim AS base
+ENV PNPM_HOME=/pnpm
+ENV PATH=$PNPM_HOME:$PATH
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
+WORKDIR /app
+
+FROM base AS build
+COPY out/json/ ./
+COPY out/full/ ./
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
+    pnpm install --frozen-lockfile --store-dir=/pnpm/store
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
+    pnpm --filter=@shipfox/provisioner-ec2 deploy --prod --legacy \
+      --store-dir=/pnpm/store --config.strict-peer-dependencies=false /prod
+
+FROM base AS runtime
+ENV NODE_ENV=production
+
+COPY --from=build /prod ./
+
+ARG IMAGE_SOURCE="https://github.com/ShipfoxHQ/shipfox"
+ARG IMAGE_REVISION
+ARG IMAGE_CREATED
+LABEL org.opencontainers.image.title="@shipfox/provisioner-ec2" \
+      org.opencontainers.image.description="Shipfox EC2 provisioner" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.source=$IMAGE_SOURCE \
+      org.opencontainers.image.revision=$IMAGE_REVISION \
+      org.opencontainers.image.created=$IMAGE_CREATED
+
+CMD ["node", "--enable-source-maps", "./dist/index.js"]

--- a/apps/provisioner-ec2/README.md
+++ b/apps/provisioner-ec2/README.md
@@ -1,7 +1,60 @@
 # @shipfox/provisioner-ec2
 
-This app will run the EC2 provisioner once its engine, lifecycle, and provider wiring
-land. It is intentionally not runnable in this scaffold issue and exits with an error.
+Runs one-job Shipfox runners on Amazon EC2 from a prebaked AMI.
 
-The current provider package, [`@shipfox/provisioner-ec2-provider`](../../libs/provisioner/ec2),
-only loads and validates EC2 template configuration.
+## What it does
+
+- **Starts runners**: Creates a runner instance and one-use bootstrap token before launch.
+- **Uses EC2 tags**: Finds and adopts its instances after a restart.
+- **Keeps state in sync**: Reports state, reaps missed enrollment, and applies terminate requests.
+- **Protects credentials**: Sends bootstrap data to the AMI. It never sends workspace registration credentials.
+
+## Setup
+
+Copy [`templates.example.yaml`](templates.example.yaml). Set
+`SHIPFOX_PROVISIONER_TEMPLATES_FILE` to that copy. Set `target_concurrency` above
+zero to keep ready runners without demand.
+
+The AMI must include the Shipfox runner and its shutdown watchdog. Cloud-init writes
+`/etc/shipfox/runner.env` with the API URL, one-use token, labels, poll time, and
+maximum lifetime. The AMI reads that file and shuts down when its watchdog exits.
+
+## Configuration
+
+| Variable | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `SHIPFOX_API_URL` | yes | — | Base URL of the Shipfox API. |
+| `SHIPFOX_RUNNER_API_URL` | no | `SHIPFOX_API_URL` | API URL injected into runner instances when they reach the API through a different address. |
+| `SHIPFOX_PROVISIONER_TOKEN` | yes | — | Long-lived provisioner token. |
+| `SHIPFOX_PROVISIONER_TEMPLATES_FILE` | yes | — | Path to the EC2 template YAML file. |
+| `AWS_REGION` | yes | — | AWS region where the provider launches instances. |
+| `SHIPFOX_PROVISIONER_EC2_REGISTRATION_DEADLINE_MS` | no | `300000` | Maximum time an EC2 instance may remain pending without runner enrollment. |
+| `SHIPFOX_PROVISIONER_EC2_RECONCILE_INTERVAL_MS` | no | `60000` | Interval between full EC2/backend reconciliation passes. |
+| `SHIPFOX_PROVISIONER_POLL_WAIT_SECONDS` | no | `30` | Demand long-poll duration. |
+| `SHIPFOX_PROVISIONER_POLL_INTERVAL_MS` | no | `1000` | Delay between healthy demand polls. |
+| `SHIPFOX_PROVISIONER_POLL_MAX_INTERVAL_MS` | no | `5000` | Maximum error-backoff interval. |
+| `SHIPFOX_PROVISIONER_MAX_RESERVATIONS` | no | `250` | Largest demand reservation request. |
+| `SHIPFOX_PROVISIONER_RUNNER_INSTANCE_BATCH_SIZE` | no | `250` | Runner instances created per control-plane request. |
+| `SHIPFOX_RUNNER_POLL_MAX_DURATION_MS` | no | `300000` | Idle polling lifetime injected into each runner. |
+| `SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS` | no | `3600` | Hard lifetime injected into each runner watchdog. |
+
+## Development
+
+```sh
+# Create apps/provisioner-ec2/.env.local with the required values.
+pnpm --filter=@shipfox/provisioner-ec2 dev
+
+turbo check --filter=@shipfox/provisioner-ec2
+turbo type --filter=@shipfox/provisioner-ec2
+turbo test --filter=@shipfox/provisioner-ec2-provider
+```
+
+Build the image with:
+
+```sh
+pnpm --filter=@shipfox/provisioner-ec2 image
+```
+
+## License
+
+MIT

--- a/apps/provisioner-ec2/README.md
+++ b/apps/provisioner-ec2/README.md
@@ -23,7 +23,7 @@ maximum lifetime. The AMI reads that file and shuts down when its watchdog exits
 
 | Variable | Required | Default | Purpose |
 | --- | --- | --- | --- |
-| `SHIPFOX_API_URL` | yes | — | Base URL of the Shipfox API. |
+| `SHIPFOX_API_URL` | no | `https://api.shipfox.io` | Base URL of the Shipfox API. Set it for a self-hosted API. |
 | `SHIPFOX_RUNNER_API_URL` | no | `SHIPFOX_API_URL` | API URL injected into runner instances when they reach the API through a different address. |
 | `SHIPFOX_PROVISIONER_TOKEN` | yes | — | Long-lived provisioner token. |
 | `SHIPFOX_PROVISIONER_TEMPLATES_FILE` | yes | — | Path to the EC2 template YAML file. |

--- a/apps/provisioner-ec2/package.json
+++ b/apps/provisioner-ec2/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "build": "shipfox-swc",
     "dev": "tsx watch --conditions=workspace-source --env-file-if-exists=../../.env --env-file-if-exists=.env --env-file-if-exists=.env.local src/index.ts",
+    "image": "shipfox-docker --setup-context --image provisioner-ec2",
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
     "type": "shipfox-tsc-check",
@@ -25,6 +26,7 @@
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",
+    "@shipfox/docker": "workspace:*",
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",

--- a/apps/provisioner-ec2/src/index.ts
+++ b/apps/provisioner-ec2/src/index.ts
@@ -1,4 +1,9 @@
 import {logger} from '@shipfox/node-opentelemetry';
+import {startEc2Provisioner} from '@shipfox/provisioner-ec2-provider';
 
-logger().error('EC2 provisioner is not wired yet; the control loop is added in a later issue.');
-process.exit(1);
+try {
+  await startEc2Provisioner();
+} catch (error) {
+  logger().error({error}, 'Fatal provisioner error');
+  process.exit(1);
+}

--- a/apps/provisioner-ec2/templates.example.yaml
+++ b/apps/provisioner-ec2/templates.example.yaml
@@ -1,0 +1,18 @@
+# Point SHIPFOX_PROVISIONER_TEMPLATES_FILE at a copy of this file.
+# The AMI must be a prebaked Shipfox runner image that reads /etc/shipfox/runner.env.
+templates:
+  ec2-ubuntu22-2vcpu-spot:
+    labels: [ubuntu22, ubuntu22-2vcpu]
+    ami: ami-0123456789abcdef0
+    instance_type: m6i.large
+    market: spot
+    spot_max_price: null
+    subnets: [subnet-0123456789abcdef0]
+    security_groups: [sg-0123456789abcdef0]
+    iam_instance_profile: shipfox-runner
+    associate_public_ip: false
+    root_volume_gb: 100
+    root_device_name: /dev/sda1
+    max_concurrency: 100
+    target_concurrency: 0
+    cost: 5

--- a/libs/api/runners/src/db/runner-instances.test.ts
+++ b/libs/api/runners/src/db/runner-instances.test.ts
@@ -1822,6 +1822,53 @@ describe('reconcileRunnerInstances', () => {
 });
 
 describe('runner instance provider attachment', () => {
+  it('updates the pre-created runner instance before its first lifecycle report', async () => {
+    const provisionerId = crypto.randomUUID();
+    const providerRunnerId = 'ec2-runner-1';
+    const [instance] = await db()
+      .insert(providerRunners)
+      .values({
+        provisionerId,
+        providerKind: 'ec2',
+        templateKey: 'linux',
+        labels: ['linux'],
+        state: 'starting',
+        reportedAt: new Date(),
+      })
+      .returning({id: providerRunners.id});
+    if (!instance) throw new Error('Runner instance insert returned no row');
+
+    const attached = await attachRunnerInstanceProviderId({
+      runnerInstanceId: instance.id,
+      provisionerId,
+      providerRunnerId,
+    });
+    await reportRunnerInstances({
+      workspaceId: null,
+      provisionerId,
+      events: [
+        {
+          providerRunnerId,
+          reservationId: null,
+          templateKey: 'linux',
+          labels: ['linux'],
+          state: 'starting',
+          reason: null,
+          runnerSessionId: null,
+          providerKind: 'ec2',
+          reportedAt: new Date(),
+        },
+      ],
+    });
+    const rows = await db()
+      .select()
+      .from(providerRunners)
+      .where(eq(providerRunners.provisionerId, provisionerId));
+
+    expect(attached).toBe(true);
+    expect(rows).toMatchObject([{id: instance.id, providerRunnerId, state: 'starting'}]);
+  });
+
   it('belongs to its provisioner until it receives one provider runner identity', async () => {
     const provisionerId = crypto.randomUUID();
     const [instance] = await db()

--- a/libs/provisioner/core/src/config.test.ts
+++ b/libs/provisioner/core/src/config.test.ts
@@ -82,10 +82,12 @@ describe('provisioner core config validation', () => {
   });
 
   it('accepts the documented defaults', async () => {
+    vi.stubEnv('SHIPFOX_API_URL', undefined);
     vi.resetModules();
 
     const {config} = await import('#config.js');
 
+    expect(config.SHIPFOX_API_URL).toBe('https://api.shipfox.io');
     expect(config.SHIPFOX_PROVISIONER_POLL_WAIT_SECONDS).toBe(30);
     expect(config.SHIPFOX_PROVISIONER_MAX_RESERVATIONS).toBe(250);
     expect(config.SHIPFOX_PROVISIONER_RUNNER_INSTANCE_BATCH_SIZE).toBe(250);

--- a/libs/provisioner/core/src/config.ts
+++ b/libs/provisioner/core/src/config.ts
@@ -7,7 +7,8 @@ const MAX_RUNNER_INSTANCE_BATCH = 1000;
 
 export const config = createConfig({
   SHIPFOX_API_URL: url({
-    desc: 'Base URL of the Shipfox API the provisioner connects to, such as https://api.shipfox.io. Required.',
+    desc: 'Base URL of the Shipfox API the provisioner connects to. Defaults to https://api.shipfox.io; set it when using a self-hosted Shipfox API.',
+    default: 'https://api.shipfox.io',
   }),
   SHIPFOX_RUNNER_API_URL: url({
     desc: 'Base URL injected into runner containers as SHIPFOX_API_URL. Defaults to SHIPFOX_API_URL; set it when containers reach the API through a different address than the provisioner uses.',

--- a/libs/provisioner/core/test/env.ts
+++ b/libs/provisioner/core/test/env.ts
@@ -1,4 +1,2 @@
-// config.ts requires control-plane connection env with no defaults. Set via
-// setupFiles so they land before any test imports config.
-process.env.SHIPFOX_API_URL = 'https://api.test';
+// config.ts requires a provisioner token. Set it via setupFiles before tests import config.
 process.env.SHIPFOX_PROVISIONER_TOKEN = 'test-provisioner-token';

--- a/libs/provisioner/ec2/src/index.ts
+++ b/libs/provisioner/ec2/src/index.ts
@@ -7,6 +7,7 @@ export {
   type RegisterEc2ServiceMetricsOptions,
   registerEc2ServiceMetrics,
 } from '#metrics/service.js';
+export {createEc2ProvisionerAdapter, startEc2Provisioner} from '#provisioner.js';
 export {
   type Ec2Market,
   Ec2TemplateConfigError,

--- a/libs/provisioner/ec2/src/lifecycle.test.ts
+++ b/libs/provisioner/ec2/src/lifecycle.test.ts
@@ -49,7 +49,7 @@ describe('createEc2Lifecycle', () => {
     vi.clearAllMocks();
   });
 
-  it('attaches and reports starting before launching an instance', async () => {
+  it('attaches its provider identity and reports starting before launching an instance', async () => {
     const engine = fakeEngine();
     const client = fakeClient();
     const lifecycle = makeLifecycle({engine, client});
@@ -217,7 +217,7 @@ describe('createEc2Lifecycle', () => {
     await expect(lifecycle.launch(launch())).rejects.toThrow(ProvisionerAuthenticationError);
   });
 
-  it('reports a failed launch and never calls runInstance when provider identity attach is rejected', async () => {
+  it('reports a failed launch and does not launch when provider identity attachment is rejected', async () => {
     const engine = fakeEngine();
     const client = fakeClient({attachResult: {attached: false}});
     const lifecycle = makeLifecycle({engine, client});

--- a/libs/provisioner/ec2/src/provisioner.ts
+++ b/libs/provisioner/ec2/src/provisioner.ts
@@ -1,0 +1,100 @@
+import {
+  type ProviderRunnerLaunch,
+  type ProvisionerAdapter,
+  type ProvisionerRuntime,
+  type ProvisionerTemplate,
+  startProvisioner,
+} from '@shipfox/provisioner-core';
+import {config} from '#config.js';
+import {createEc2Engine, type Ec2Engine} from '#ec2-engine.js';
+import {createEc2Lifecycle, type Ec2Lifecycle} from '#lifecycle.js';
+import {type Ec2TemplateSpec, loadEc2Templates} from '#templates.js';
+import {renderRunnerBootstrapUserData} from '#user-data.js';
+
+export interface CreateEc2ProvisionerAdapterOptions {
+  readonly engine: Ec2Engine;
+  readonly templates: readonly ProvisionerTemplate<Ec2TemplateSpec>[];
+  readonly registrationDeadlineMs: number;
+  readonly reconcileIntervalMs: number;
+}
+
+/**
+ * Compose the EC2 engine and lifecycle into the provider adapter consumed by the
+ * shared runner-instance provisioner runtime.
+ */
+export function createEc2ProvisionerAdapter(
+  options: CreateEc2ProvisionerAdapterOptions,
+): ProvisionerAdapter<Ec2TemplateSpec> {
+  let lifecycle: Ec2Lifecycle | undefined;
+
+  return {
+    loadTemplates: () => Promise.resolve(options.templates),
+    launch: (launch) => requireLifecycle(lifecycle).launch(launch),
+    terminate: (ids) => requireLifecycle(lifecycle).terminate(ids),
+    async onStart(runtime) {
+      lifecycle = createLifecycle(options, runtime);
+      await lifecycle.reconcile();
+    },
+    onTick: () => requireLifecycle(lifecycle).tick(),
+    onStop: () => lifecycle?.flush() ?? Promise.resolve(),
+  };
+}
+
+/** Starts the EC2 provider with its local template and AWS configuration. */
+export function startEc2Provisioner(): Promise<void> {
+  const templates = loadEc2Templates(config.SHIPFOX_PROVISIONER_TEMPLATES_FILE);
+  const engine = createEc2Engine({region: config.AWS_REGION});
+
+  return startProvisioner({
+    adapter: createEc2ProvisionerAdapter({
+      engine,
+      templates,
+      registrationDeadlineMs: config.SHIPFOX_PROVISIONER_EC2_REGISTRATION_DEADLINE_MS,
+      reconcileIntervalMs: config.SHIPFOX_PROVISIONER_EC2_RECONCILE_INTERVAL_MS,
+    }),
+  });
+}
+
+function createLifecycle(
+  options: CreateEc2ProvisionerAdapterOptions,
+  runtime: ProvisionerRuntime,
+): Ec2Lifecycle {
+  return createEc2Lifecycle({
+    engine: options.engine,
+    client: runtime.client,
+    identity: runtime.identity,
+    tracker: runtime.tracker,
+    templates: options.templates,
+    registrationDeadlineMs: options.registrationDeadlineMs,
+    reconcileIntervalMs: options.reconcileIntervalMs,
+    providerKind: 'ec2',
+    renderUserData,
+  });
+}
+
+function renderUserData(launch: ProviderRunnerLaunch<Ec2TemplateSpec>): string {
+  return renderRunnerBootstrapUserData({
+    apiUrl: requiredRunnerEnv(launch, 'SHIPFOX_API_URL'),
+    bootstrapToken: launch.bootstrapToken,
+    labels: launch.template.labels,
+    pollMaxDurationMs: numericRunnerEnv(launch, 'SHIPFOX_POLL_MAX_DURATION_MS'),
+    maxLifetimeSeconds: numericRunnerEnv(launch, 'SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS'),
+  });
+}
+
+function requireLifecycle(lifecycle: Ec2Lifecycle | undefined): Ec2Lifecycle {
+  if (!lifecycle) throw new Error('EC2 lifecycle has not been initialized.');
+  return lifecycle;
+}
+
+function requiredRunnerEnv(launch: ProviderRunnerLaunch<Ec2TemplateSpec>, name: string): string {
+  const value = launch.runnerEnv[name];
+  if (!value) throw new Error(`EC2 runner environment is missing ${name}.`);
+  return value;
+}
+
+function numericRunnerEnv(launch: ProviderRunnerLaunch<Ec2TemplateSpec>, name: string): number {
+  const value = Number(requiredRunnerEnv(launch, name));
+  if (!Number.isInteger(value)) throw new Error(`EC2 runner environment has invalid ${name}.`);
+  return value;
+}

--- a/libs/provisioner/ec2/src/templates.test.ts
+++ b/libs/provisioner/ec2/src/templates.test.ts
@@ -61,6 +61,7 @@ templates:
     associate_public_ip: false
     root_volume_gb: 100
     max_concurrency: 200
+    target_concurrency: 2
     cost: 5
   ec2-ubuntu22-2vcpu-on-demand:
     labels: [ubuntu22, ubuntu22-2vcpu-on-demand]
@@ -86,6 +87,7 @@ describe('loadEc2Templates', () => {
         key: 'ec2-ubuntu22-2vcpu-spot',
         labels: ['ubuntu22', 'ubuntu22-2vcpu'],
         maxConcurrency: 200,
+        targetConcurrency: 2,
         cost: 5,
         spec: {
           ami: 'ami-0123456789abcdef0',

--- a/libs/provisioner/ec2/src/templates.ts
+++ b/libs/provisioner/ec2/src/templates.ts
@@ -47,6 +47,7 @@ const ec2TemplateSchema = z
     root_volume_gb: z.number().int().positive(),
     root_device_name: z.string().trim().min(1).optional(),
     max_concurrency: z.number().int().positive().max(MAX_TEMPLATE_CONCURRENCY),
+    target_concurrency: z.number().int().nonnegative().max(MAX_TEMPLATE_CONCURRENCY).optional(),
     cost: z.number().positive(),
   })
   .strict()
@@ -117,6 +118,7 @@ function toTemplate(
     key,
     labels,
     maxConcurrency: spec.max_concurrency,
+    ...(spec.target_concurrency === undefined ? {} : {targetConcurrency: spec.target_concurrency}),
     cost: spec.cost,
     spec: {
       ami: spec.ami,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -763,6 +763,9 @@ importers:
       '@shipfox/biome':
         specifier: workspace:*
         version: link:../../tools/biome
+      '@shipfox/docker':
+        specifier: workspace:*
+        version: link:../../tools/docker
       '@shipfox/swc':
         specifier: workspace:*
         version: link:../../tools/swc


### PR DESCRIPTION
Adds the runnable EC2 provisioner application and composes its engine, lifecycle, bootstrap user data, periodic reconciliation, enrollment cleanup, and graceful report flush through the unified runner-instance runtime.

The EC2 provider previously had the engine and lifecycle pieces but no deployable adapter or image. This supplies the operational surface required for self-hosted and Cloud-managed deployments, including templates and startup configuration. Provider identity is attached before the first lifecycle report so it updates the runner instance created with the bootstrap token instead of creating a conflicting record.

The PostgreSQL regression test covers that persistence ordering. The image build passes locally. The scratch-AWS launch, enrollment, assignment, and job-completion flow still needs account credentials and was not run locally.

Closes ENG-1013

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a runnable EC2 provisioner app and image that composes the EC2 engine with the shared runner-instance runtime. Also defaults provisioners to `https://api.shipfox.io` to simplify setup. Addresses ENG-1013 by enabling template-driven EC2 launches, periodic reconciliation, and safe provider identity attachment.

- New Features
  - New deployable `@shipfox/provisioner-ec2` app with Dockerfile, example templates (with `target_concurrency`), and README.
  - EC2 adapter and `startEc2Provisioner` wiring in `@shipfox/provisioner-ec2-provider`; renders runner bootstrap user data and flushes on shutdown.
  - Attaches provider identity before the first lifecycle report to avoid duplicate runner records; adds DB regression test.
  - Provisioners default `SHIPFOX_API_URL` to `https://api.shipfox.io` (override for self-hosted).
  - CI builds/publishes the `provisioner-ec2` image; package adds `image` script via `@shipfox/docker`.

- Migration
  - Copy `templates.example.yaml`, set `SHIPFOX_PROVISIONER_TEMPLATES_FILE`, and tune `target_concurrency`.
  - Provide `SHIPFOX_PROVISIONER_TOKEN` and `AWS_REGION`; `SHIPFOX_API_URL` is optional (set for self-hosted).
  - Use a prebaked AMI that reads `/etc/shipfox/runner.env` and shuts down when the watchdog exits.
  - Build/run the `provisioner-ec2` image with the required environment variables.

<sup>Written for commit c9e5c06d58c98576f55dd74f88ff8e0b4b64a8ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

