### PR TITLE
[package-release] Recover missed package publication

### DIFF
--- a/.changeset/resolute-foxes-retry.md
+++ b/.changeset/resolute-foxes-retry.md
@@ -1,0 +1,34 @@
+---
+"@shipfox/api-auth": patch
+"@shipfox/api-email-challenges": patch
+"@shipfox/api-integration-core": patch
+"@shipfox/api-integration-github": patch
+"@shipfox/api-integration-jira": patch
+"@shipfox/api-integration-linear": patch
+"@shipfox/api-runners": patch
+"@shipfox/api-runners-dto": patch
+"@shipfox/api-server": patch
+"@shipfox/api-triggers": patch
+"@shipfox/api-workflows": patch
+"@shipfox/api-workspaces": patch
+"@shipfox/client-agent": patch
+"@shipfox/client-auth": patch
+"@shipfox/client-config": patch
+"@shipfox/client-features": patch
+"@shipfox/client-integrations": patch
+"@shipfox/client-invitations": patch
+"@shipfox/client-logs": patch
+"@shipfox/client-projects": patch
+"@shipfox/client-runners": patch
+"@shipfox/client-secrets": patch
+"@shipfox/client-shell": patch
+"@shipfox/client-triggers": patch
+"@shipfox/client-ui": patch
+"@shipfox/client-workflows": patch
+"@shipfox/client-workspace-settings": patch
+"@shipfox/node-email": patch
+"@shipfox/react-ui": patch
+"@shipfox/application-release": patch
+---
+
+Republishes the affected release set after recovering package publication.

--- a/tools/package-release/src/publish-productionized-closure.ts
+++ b/tools/package-release/src/publish-productionized-closure.ts
@@ -2,7 +2,7 @@ import {type ChildProcess, spawn} from 'node:child_process';
 import {globSync, readFileSync, writeFileSync} from 'node:fs';
 import {constants} from 'node:os';
 import {join, resolve} from 'node:path';
-import {pathToFileURL} from 'node:url';
+import {fileURLToPath, pathToFileURL} from 'node:url';
 
 import {productionizeManifest} from '@shipfox/tool-utils';
 
@@ -73,8 +73,12 @@ export function publishChangesets(onSpawn?: (child: ChildProcess) => void): Prom
   });
 }
 
+export function getRepositoryRoot(entryPoint: string): string {
+  return resolve(fileURLToPath(new URL('../../..', entryPoint)));
+}
+
 async function main() {
-  const repositoryRoot = process.cwd();
+  const repositoryRoot = getRepositoryRoot(import.meta.url);
   const closurePath = join(repositoryRoot, 'publication-closure.json');
   const {packages: packageNames} = JSON.parse(readFileSync(closurePath, 'utf8')) as {
     packages: string[];

--- a/tools/package-release/test/publish-productionized-closure.test.ts
+++ b/tools/package-release/test/publish-productionized-closure.test.ts
@@ -2,9 +2,11 @@ import assert from 'node:assert/strict';
 import {mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
+import {pathToFileURL} from 'node:url';
 
 import {
   findClosureManifests,
+  getRepositoryRoot,
   publishProductionizedClosure,
 } from '../src/publish-productionized-closure.js';
 
@@ -14,6 +16,16 @@ const roots: string[] = [];
 const DUPLICATE_MANIFEST_ERROR = /Duplicate package manifest: @shipfox\/duplicate/u;
 const MISSING_MANIFEST_ERROR = /Publication closure package has no manifest: @shipfox\/missing/u;
 const SPAWN_FAILURE_ERROR = /spawn failed/u;
+
+test('resolves the repository root from the package entrypoint', () => {
+  const entryPoint = pathToFileURL(
+    '/workspace/tools/package-release/dist/publish-productionized-closure.js',
+  ).href;
+
+  const repositoryRoot = getRepositoryRoot(entryPoint);
+
+  assert.equal(repositoryRoot, '/workspace');
+});
 
 afterEach(() => {
   for (const root of roots.splice(0)) rmSync(root, {force: true, recursive: true});


### PR DESCRIPTION
Fixes package publication when the filtered pnpm script starts inside `tools/package-release`. The release tool now resolves the repository root from its entrypoint, so it can load the root closure configuration.

Adds patch releases for the public packages selected by the failed publication run, allowing a new release PR to retry them.

The direct local recovery attempts exposed a separate `@shipfox/application-release` workspace-protocol packaging issue; this PR does not address that issue, so it needs review before relying on the next publication run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failed package publication when `tools/package-release` runs via filtered `pnpm` by resolving the repo root from the package entrypoint, and queues patch releases to republish missed packages. Note: does not address the workspace-protocol packaging issue in `@shipfox/application-release`.

- **Bug Fixes**
  - Resolve repository root with `getRepositoryRoot(import.meta.url)` so the tool reliably loads the root `publication-closure.json`.
  - Add patch releases for the previously skipped public packages to retry publication in the next release PR.

<sup>Written for commit 8c1125bb6a4304050314f39810af4baab02add56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

