### PR TITLE
Harden API error reporting boundaries

### DIFF
--- a/.changeset/alert-boundaries-harden.md
+++ b/.changeset/alert-boundaries-harden.md
@@ -1,0 +1,16 @@
+---
+"@shipfox/node-error-monitoring": minor
+"@shipfox/node-fastify": patch
+"@shipfox/api-server": patch
+"@shipfox/node-module": minor
+"@shipfox/node-temporal": patch
+"@shipfox/api-dispatcher": patch
+"@shipfox/api-logs": patch
+"@shipfox/api-triggers": patch
+"@shipfox/api-runners": patch
+"@shipfox/api-agent": patch
+"@shipfox/api-integration-core": patch
+"@shipfox/api-integration-github": patch
+---
+
+Adds boundary-owned reporting for unexpected API runtime failures while preserving expected client and provider outcomes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,14 @@ adding, updating, or exempting a dependency. It defines catalog range rules,
 peer compatibility, coordinated Renovate families, and the transitive exception
 format.
 
+## Error reporting
+
+Report unexpected API-process failures at the earliest owning boundary. A catch
+that continues must report the failure, return or persist a recognized error, or
+document why it is intentionally non-actionable. Do not report expected client,
+validation, authentication, typed provider, cancellation, or idempotency paths.
+Never attach request bodies, headers, cookies, tokens, or payloads to reports.
+
 ## Local Tooling
 
 ### Mise Tasks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,11 @@ Report unexpected API-process failures at the earliest owning boundary. A catch
 that continues must report the failure, return or persist a recognized error, or
 document why it is intentionally non-actionable. Do not report expected client,
 validation, authentication, typed provider, cancellation, or idempotency paths.
-Never attach request bodies, headers, cookies, tokens, or payloads to reports.
+Every unexpected failure sent to Sentry must also be written to the structured
+application log so self-hosters can diagnose it without Sentry. Log the error
+and only safe, bounded context such as the boundary's module, operation, or
+resource identifier. Never attach request bodies, headers, cookies, tokens, or
+payloads to either logs or reports.
 
 ## Local Tooling
 

--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -1,5 +1,5 @@
 const mocks = vi.hoisted(() => ({
-  captureException: vi.fn(),
+  reportError: vi.fn(),
   closeErrorMonitoring: vi.fn(),
   logger: {
     error: vi.fn(),
@@ -14,8 +14,8 @@ vi.mock('@shipfox/api-server', () => ({
 }));
 
 vi.mock('@shipfox/node-error-monitoring', () => ({
-  captureException: mocks.captureException,
   closeErrorMonitoring: mocks.closeErrorMonitoring,
+  reportError: mocks.reportError,
 }));
 
 vi.mock('@shipfox/node-opentelemetry', () => ({
@@ -25,7 +25,7 @@ vi.mock('@shipfox/node-opentelemetry', () => ({
 describe('index', () => {
   beforeEach(() => {
     vi.resetModules();
-    mocks.captureException.mockReset();
+    mocks.reportError.mockReset();
     mocks.closeErrorMonitoring.mockReset();
     mocks.logger.error.mockReset();
     mocks.defaultModules.mockReset();
@@ -54,10 +54,10 @@ describe('index', () => {
 
     await expect(result).rejects.toThrow('exit 1');
     expect(mocks.logger.error).toHaveBeenCalledWith({error: failure}, 'Fatal startup error');
-    expect(mocks.captureException).toHaveBeenCalledOnce();
-    expect(mocks.captureException).toHaveBeenCalledWith(failure);
+    expect(mocks.reportError).toHaveBeenCalledTimes(2);
+    expect(mocks.reportError).toHaveBeenCalledWith(failure, {boundary: 'api.startup'});
     expect(mocks.closeErrorMonitoring).toHaveBeenCalledWith(2_000);
-    expect(mocks.captureException.mock.invocationCallOrder[0]).toBeLessThan(
+    expect(mocks.reportError.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.closeErrorMonitoring.mock.invocationCallOrder[0] ?? 0,
     );
     expect(mocks.closeErrorMonitoring.mock.invocationCallOrder[0]).toBeLessThan(

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,21 +1,18 @@
 import {defaultModules, runServer} from '@shipfox/api-server';
-import {captureException, closeErrorMonitoring} from '@shipfox/node-error-monitoring';
+import {closeErrorMonitoring, reportError} from '@shipfox/node-error-monitoring';
 import {logger} from '@shipfox/node-opentelemetry';
 
 const STARTUP_ERROR_MONITORING_SHUTDOWN_TIMEOUT_MS = 2_000;
-let hasReportedRunServerStartupFailure = false;
-
 try {
   await runServer({
     modules: await defaultModules(),
     onStartupFailure: (error) => {
-      captureException(error);
-      hasReportedRunServerStartupFailure = true;
+      reportError(error, {boundary: 'api.startup'});
     },
   });
 } catch (error) {
   logger().error({error}, 'Fatal startup error');
-  if (!hasReportedRunServerStartupFailure) captureException(error);
+  reportError(error, {boundary: 'api.startup'});
   try {
     await closeErrorMonitoring(STARTUP_ERROR_MONITORING_SHUTDOWN_TIMEOUT_MS);
   } finally {

--- a/libs/api/agent/package.json
+++ b/libs/api/agent/package.json
@@ -81,6 +81,7 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
+    "@shipfox/node-error-monitoring": "workspace:*",
     "@earendil-works/pi-ai": "catalog:",
     "@opentelemetry/api": "catalog:",
     "@shipfox/api-agent-dto": "workspace:*",

--- a/libs/api/agent/src/core/custom-model-provider-config-service.ts
+++ b/libs/api/agent/src/core/custom-model-provider-config-service.ts
@@ -12,6 +12,7 @@ import {
 } from '@shipfox/api-agent-dto';
 import {assertEgressAllowed} from '@shipfox/node-egress-guard';
 import {reportError} from '@shipfox/node-error-monitoring';
+import {logger} from '@shipfox/node-opentelemetry';
 import {
   deleteModelProviderConfig,
   getModelProviderConfig,
@@ -237,6 +238,10 @@ export async function updateCustomModelProviderConfig(
       existingSecrets,
       attemptedSecrets: newSecretCredentials,
     }).catch((rollbackError) => {
+      logger().error(
+        {err: rollbackError, workspaceId: params.workspaceId, providerId: params.providerId},
+        'Failed to roll back custom model provider secrets',
+      );
       reportError(rollbackError, {
         boundary: 'agent.cleanup',
         operation: 'rollback-secret-update',

--- a/libs/api/agent/src/core/custom-model-provider-config-service.ts
+++ b/libs/api/agent/src/core/custom-model-provider-config-service.ts
@@ -11,6 +11,7 @@ import {
   type UpdateCustomModelProviderHeaderRequestDto,
 } from '@shipfox/api-agent-dto';
 import {assertEgressAllowed} from '@shipfox/node-egress-guard';
+import {reportError} from '@shipfox/node-error-monitoring';
 import {
   deleteModelProviderConfig,
   getModelProviderConfig,
@@ -235,7 +236,13 @@ export async function updateCustomModelProviderConfig(
       namespace,
       existingSecrets,
       attemptedSecrets: newSecretCredentials,
-    }).catch(() => undefined);
+    }).catch((rollbackError) => {
+      reportError(rollbackError, {
+        boundary: 'agent.cleanup',
+        operation: 'rollback-secret-update',
+        extra: {workspaceId: params.workspaceId, providerId: params.providerId},
+      });
+    });
     throw error;
   }
 

--- a/libs/api/agent/src/core/model-provider-config-service.ts
+++ b/libs/api/agent/src/core/model-provider-config-service.ts
@@ -5,6 +5,7 @@ import {
   modelProviderCredentialKeysMatch,
   type SupportedModelProviderId,
 } from '@shipfox/api-agent-dto';
+import {reportError} from '@shipfox/node-error-monitoring';
 import {
   deleteModelProviderConfig as deleteModelProviderConfigRow,
   getModelProviderConfig,
@@ -108,7 +109,13 @@ export async function testAndSaveModelProviderConfig(
     workspaceId: params.workspaceId,
     namespace,
     expectedKeys: Object.keys(values),
-  }).catch(() => undefined);
+  }).catch((error) => {
+    reportError(error, {
+      boundary: 'agent.cleanup',
+      operation: 'prune-stale-secrets',
+      extra: {workspaceId: params.workspaceId, providerId: params.providerId},
+    });
+  });
 
   return config;
 }

--- a/libs/api/agent/src/core/model-provider-config-service.ts
+++ b/libs/api/agent/src/core/model-provider-config-service.ts
@@ -6,6 +6,7 @@ import {
   type SupportedModelProviderId,
 } from '@shipfox/api-agent-dto';
 import {reportError} from '@shipfox/node-error-monitoring';
+import {logger} from '@shipfox/node-opentelemetry';
 import {
   deleteModelProviderConfig as deleteModelProviderConfigRow,
   getModelProviderConfig,
@@ -110,6 +111,10 @@ export async function testAndSaveModelProviderConfig(
     namespace,
     expectedKeys: Object.keys(values),
   }).catch((error) => {
+    logger().error(
+      {err: error, workspaceId: params.workspaceId, providerId: params.providerId},
+      'Failed to prune stale model provider secrets',
+    );
     reportError(error, {
       boundary: 'agent.cleanup',
       operation: 'prune-stale-secrets',

--- a/libs/api/definitions/package.json
+++ b/libs/api/definitions/package.json
@@ -52,6 +52,7 @@
     "@shipfox/inter-module": "workspace:*",
     "@shipfox/node-drizzle": "workspace:*",
     "@shipfox/node-fastify": "workspace:*",
+    "@shipfox/node-error-monitoring": "workspace:*",
     "@shipfox/node-module": "workspace:*",
     "@shipfox/node-opentelemetry": "workspace:*",
     "@shipfox/node-outbox": "workspace:*",

--- a/libs/api/definitions/src/temporal/activities/sync-activities.test.ts
+++ b/libs/api/definitions/src/temporal/activities/sync-activities.test.ts
@@ -1,6 +1,7 @@
 import type {IntegrationSourceControlService} from '@shipfox/api-integration-core';
 import {integrationsInterModuleContract} from '@shipfox/api-integration-core-dto';
 import {createInterModuleKnownError} from '@shipfox/inter-module';
+import {isErrorReported} from '@shipfox/node-error-monitoring';
 import {ApplicationFailure} from '@temporalio/common';
 import {sql} from 'drizzle-orm';
 import {db, definitionSyncStates} from '#db/index.js';
@@ -141,6 +142,8 @@ describe('definition sync activities', () => {
         type: 'unknown',
         message: 'temporary outage',
       });
+      const error = await result.catch((error: unknown) => error);
+      expect(isErrorReported(error)).toBe(false);
     });
 
     it('preserves retryable provider error codes for workflow-level failure persistence', async () => {
@@ -170,6 +173,8 @@ describe('definition sync activities', () => {
         type: 'provider-timeout',
         message: 'integrations.resolveSourceRepository: provider-failure',
       });
+      const error = await result.catch((error: unknown) => error);
+      expect(isErrorReported(error)).toBe(true);
     });
   });
 

--- a/libs/api/definitions/src/temporal/activities/sync-activities.ts
+++ b/libs/api/definitions/src/temporal/activities/sync-activities.ts
@@ -1,4 +1,5 @@
 import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto';
+import {markErrorReported} from '@shipfox/node-error-monitoring';
 import {Context} from '@temporalio/activity';
 import {ApplicationFailure} from '@temporalio/common';
 import type {DefinitionSyncErrorCode} from '#core/entities/sync-state.js';
@@ -183,9 +184,10 @@ async function runWithPermanentTranslation<T>(operation: () => Promise<T>): Prom
       throw error;
     }
     const failure = classifySyncFailure(error);
-    if (!failure.retryable) {
-      throw ApplicationFailure.nonRetryable(failure.message, failure.code);
-    }
-    throw ApplicationFailure.retryable(failure.message, failure.code);
+    const translatedError = failure.retryable
+      ? ApplicationFailure.retryable(failure.message, failure.code)
+      : ApplicationFailure.nonRetryable(failure.message, failure.code);
+    if (failure.code !== 'unknown') markErrorReported(translatedError);
+    throw translatedError;
   }
 }

--- a/libs/api/dispatcher/src/core/outbox-drainer-service.test.ts
+++ b/libs/api/dispatcher/src/core/outbox-drainer-service.test.ts
@@ -2,6 +2,11 @@ import {createOutboxRegistry} from '@shipfox/node-module';
 import {createOutboxDrainerService} from './outbox-drainer-service.js';
 
 const context = {outboxRegistry: createOutboxRegistry()};
+const errorMonitoring = vi.hoisted(() => ({reportError: vi.fn()}));
+
+vi.mock('@shipfox/node-error-monitoring', () => errorMonitoring);
+
+afterEach(() => vi.clearAllMocks());
 
 describe('createOutboxDrainerService', () => {
   it('drains pending batches before idling and stops without another claim', async () => {
@@ -72,5 +77,28 @@ describe('createOutboxDrainerService', () => {
 
     expect(drain).toHaveBeenCalledTimes(2);
     expect(logError).toHaveBeenCalledWith(failure);
+  });
+
+  it('reports an unexpected drain-loop failure when no caller reporter is supplied', async () => {
+    const failure = new Error('database unavailable');
+    const drain = vi.fn().mockRejectedValueOnce(failure).mockResolvedValueOnce(false);
+    const service = createOutboxDrainerService({
+      pollMs: 25,
+      runDrainCycle: drain,
+      sleep: async (ms, signal) => {
+        if (ms === 1_000) return;
+        await new Promise<void>((resolve) =>
+          signal.addEventListener('abort', () => resolve(), {once: true}),
+        );
+      },
+    });
+
+    const handle = await service.start(context);
+    await vi.waitFor(() => expect(drain).toHaveBeenCalledTimes(2));
+    await handle.stop();
+
+    expect(errorMonitoring.reportError).toHaveBeenCalledWith(failure, {
+      boundary: 'dispatcher.drain',
+    });
   });
 });

--- a/libs/api/dispatcher/src/core/outbox-drainer-service.ts
+++ b/libs/api/dispatcher/src/core/outbox-drainer-service.ts
@@ -1,4 +1,5 @@
 import {setTimeout as sleep} from 'node:timers/promises';
+import {reportError} from '@shipfox/node-error-monitoring';
 import type {ModuleService} from '@shipfox/node-module';
 import {logger} from '@shipfox/node-opentelemetry';
 import {runDrainCycle} from '#core/run-drain-cycle.js';
@@ -15,8 +16,12 @@ interface OutboxDrainerServiceOptions {
 
 export function createOutboxDrainerService(options: OutboxDrainerServiceOptions): ModuleService {
   const wait = options.sleep ?? interruptibleSleep;
-  const logError =
-    options.logError ?? ((error) => logger().error({err: error}, 'Outbox drain failed'));
+  const reportDrainError =
+    options.logError ??
+    ((error) => {
+      logger().error({err: error}, 'Outbox drain failed');
+      reportError(error, {boundary: 'dispatcher.drain'});
+    });
 
   return {
     name: 'outbox-drainer',
@@ -29,7 +34,7 @@ export function createOutboxDrainerService(options: OutboxDrainerServiceOptions)
       const finished = runOutboxDrainer({
         drain,
         wait,
-        logError,
+        reportDrainError,
         pollMs: options.pollMs,
         signal: abortController.signal,
       });
@@ -48,7 +53,7 @@ export function createOutboxDrainerService(options: OutboxDrainerServiceOptions)
 interface RunOutboxDrainerOptions {
   readonly drain: (signal: AbortSignal) => Promise<boolean>;
   readonly wait: (ms: number, signal: AbortSignal) => Promise<void>;
-  readonly logError: (error: unknown) => void;
+  readonly reportDrainError: (error: unknown) => void;
   readonly pollMs: number;
   readonly signal: AbortSignal;
 }
@@ -60,7 +65,7 @@ async function runOutboxDrainer(options: RunOutboxDrainerOptions): Promise<void>
       if (!hasMore) await options.wait(options.pollMs, options.signal);
     } catch (error) {
       if (options.signal.aborted) return;
-      options.logError(error);
+      options.reportDrainError(error);
       await options.wait(ERROR_BACKOFF_MS, options.signal);
     }
   }

--- a/libs/api/dispatcher/src/core/run-drain-cycle.ts
+++ b/libs/api/dispatcher/src/core/run-drain-cycle.ts
@@ -1,4 +1,4 @@
-import {captureException} from '@shipfox/node-error-monitoring';
+import {reportError} from '@shipfox/node-error-monitoring';
 import {
   boundedMap,
   type DrainedEvent,
@@ -30,33 +30,29 @@ export async function runDrainCycle(
 
   const groups = groupRows(rows);
 
-  try {
-    await boundedMap(
-      groups,
-      DISPATCH_CONCURRENCY,
-      async (group) => {
-        const dispatchedClaims: OutboxDispatchClaim[] = [];
+  await boundedMap(
+    groups,
+    DISPATCH_CONCURRENCY,
+    async (group) => {
+      const dispatchedClaims: OutboxDispatchClaim[] = [];
 
-        for (const row of group.rows) {
-          if (signal?.aborted) break;
-          const succeeded = await dispatchRow(outboxRegistry, row);
-          if (!succeeded) break;
-          dispatchedClaims.push(claimFromRow(row));
-        }
+      for (const row of group.rows) {
+        if (signal?.aborted) break;
+        const succeeded = await dispatchRow(outboxRegistry, row);
+        if (!succeeded) break;
+        dispatchedClaims.push(claimFromRow(row));
+      }
 
-        if (dispatchedClaims.length > 0) {
-          await markDispatched(outboxRegistry, group.source, dispatchedClaims);
-          eventDispatchedCount.add(dispatchedClaims.length, {
-            module: group.source,
-            outcome: 'succeeded',
-          });
-        }
-      },
-      {stopOnError: false, signal},
-    );
-  } catch (error) {
-    logger().warn({err: error}, 'Outbox dispatch groups completed with errors');
-  }
+      if (dispatchedClaims.length > 0) {
+        await markDispatched(outboxRegistry, group.source, dispatchedClaims);
+        eventDispatchedCount.add(dispatchedClaims.length, {
+          module: group.source,
+          outcome: 'succeeded',
+        });
+      }
+    },
+    {stopOnError: false, signal},
+  );
 
   return hasMore;
 }
@@ -96,7 +92,11 @@ async function dispatchClaimedRow(
     } catch (error) {
       const errorContext = failureFromHandler(row, error);
       logger().error({err: error, ...errorContext}, 'Handler failed for outbox event');
-      captureException(error, {extra: errorContext});
+      reportError(error, {
+        boundary: 'dispatcher.handler',
+        tags: {module: row.source, eventType: row.event.type},
+        extra: {eventId: row.id},
+      });
       dispatchFailure ??= errorContext;
     }
   }
@@ -142,6 +142,11 @@ async function renewRowClaim(outboxRegistry: OutboxRegistry, row: DrainedEvent):
       {err: error, source: row.source, eventId: row.id},
       'Failed to renew outbox dispatch claim',
     );
+    reportError(error, {
+      boundary: 'dispatcher.claim-renewal',
+      tags: {module: row.source, eventType: row.event.type},
+      extra: {eventId: row.id},
+    });
   }
 }
 
@@ -207,7 +212,16 @@ function validatePayload(
     })),
   };
   logger().error({err: result.error, ...errorContext}, 'Invalid outbox payload at drain');
-  captureException(result.error, {extra: errorContext});
+  reportError(result.error, {
+    boundary: 'dispatcher.payload',
+    tags: {module: row.source, eventType: row.event.type},
+    extra: {
+      eventId: row.id,
+      issueCount: result.error.issues.length,
+      issuePaths: result.error.issues.map((issue) => issue.path.join('.')).join(','),
+      issueCodes: result.error.issues.map((issue) => issue.code).join(','),
+    },
+  });
   return {success: false, failure: errorContext};
 }
 

--- a/libs/api/integration/core/package.json
+++ b/libs/api/integration/core/package.json
@@ -60,6 +60,7 @@
     "@shipfox/node-fastify": "workspace:*",
     "@shipfox/node-module": "workspace:*",
     "@shipfox/node-opentelemetry": "workspace:*",
+    "@shipfox/node-error-monitoring": "workspace:*",
     "@shipfox/node-outbox": "workspace:*",
     "@shipfox/node-postgres": "workspace:*",
     "@shipfox/node-temporal": "workspace:*",

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -9,6 +9,7 @@ import {
 } from '@shipfox/api-integration-core-dto';
 import type {WorkflowsModuleClient} from '@shipfox/api-workflows-dto/inter-module';
 import type {WorkspacesInterModuleClient} from '@shipfox/api-workspaces-dto/inter-module';
+import {reportError} from '@shipfox/node-error-monitoring';
 import type {ModuleService, ShipfoxModule} from '@shipfox/node-module';
 import {logger} from '@shipfox/node-opentelemetry';
 import type {IntegrationProvider} from '#core/entities/provider.js';
@@ -225,6 +226,7 @@ export async function createIntegrationsContext(
         await task();
       } catch (error) {
         logger().error({err: error}, 'Integration startup task failed, continuing boot');
+        reportError(error, {boundary: 'integration.startup'});
       }
     }
   }

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/dispatch.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/dispatch.ts
@@ -1,4 +1,5 @@
 import type {CallToolResult} from '@modelcontextprotocol/sdk/types.js';
+import {reportError} from '@shipfox/node-error-monitoring';
 import {IntegrationProviderError} from '#core/errors.js';
 import type {
   AgentToolCatalogEntry,
@@ -48,7 +49,11 @@ async function dispatchIntegrationToolCall(
       arguments: input.arguments,
     });
   } catch (error) {
-    return toolError(errorResult(error));
+    const result = errorResult(error);
+    if (result.code === 'provider-unavailable') {
+      reportError(error, {boundary: 'integration.agent-tool'});
+    }
+    return toolError(result);
   } finally {
     await closeSession(session);
   }
@@ -83,8 +88,9 @@ function agentToolCatalogEntry(input: IntegrationToolDispatchInput): AgentToolCa
 async function closeSession(session: {close?(): Promise<void>} | undefined): Promise<void> {
   try {
     await session?.close?.();
-  } catch {
+  } catch (error) {
     // Cleanup must not mask the tool result returned to the runner.
+    reportError(error, {boundary: 'integration.agent-tool', operation: 'close-session'});
   }
 }
 

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/dispatch.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/dispatch.ts
@@ -1,5 +1,6 @@
 import type {CallToolResult} from '@modelcontextprotocol/sdk/types.js';
 import {reportError} from '@shipfox/node-error-monitoring';
+import {logger} from '@shipfox/node-opentelemetry';
 import {IntegrationProviderError} from '#core/errors.js';
 import type {
   AgentToolCatalogEntry,
@@ -51,6 +52,10 @@ async function dispatchIntegrationToolCall(
   } catch (error) {
     const result = errorResult(error);
     if (result.code === 'provider-unavailable') {
+      logger().error(
+        {err: error, provider: input.authorizedTool.integration.provider},
+        'Integration agent tool provider was unavailable',
+      );
       reportError(error, {boundary: 'integration.agent-tool'});
     }
     return toolError(result);
@@ -90,6 +95,7 @@ async function closeSession(session: {close?(): Promise<void>} | undefined): Pro
     await session?.close?.();
   } catch (error) {
     // Cleanup must not mask the tool result returned to the runner.
+    logger().error({err: error}, 'Failed to close integration agent tool session');
     reportError(error, {boundary: 'integration.agent-tool', operation: 'close-session'});
   }
 }

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/index.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/index.ts
@@ -3,6 +3,7 @@ import type {Transport} from '@modelcontextprotocol/sdk/shared/transport.js';
 import {AUTH_LEASED_JOB, requireLeasedJobContext} from '@shipfox/api-auth-context';
 import {reportError} from '@shipfox/node-error-monitoring';
 import {defineRoute, type RouteGroup} from '@shipfox/node-fastify';
+import {logger} from '@shipfox/node-opentelemetry';
 import type {IntegrationProviderRegistry} from '#core/providers/registry.js';
 import type {GetIntegrationConnectionByIdFn} from '#db/connections.js';
 import {createIntegrationToolCallRecorder} from './audit.js';
@@ -52,12 +53,14 @@ export function createAgentToolsGatewayRoutes(
           await server.connect(transport as unknown as Transport);
           reply.raw.on('close', () => {
             void transport.close().catch((error) => {
+              logger().error({err: error}, 'Failed to close integration agent tool transport');
               reportError(error, {
                 boundary: 'integration.agent-tool',
                 operation: 'close-transport',
               });
             });
             void server.close().catch((error) => {
+              logger().error({err: error}, 'Failed to close integration agent tool server');
               reportError(error, {
                 boundary: 'integration.agent-tool',
                 operation: 'close-server',

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/index.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/index.ts
@@ -1,6 +1,7 @@
 import {StreamableHTTPServerTransport} from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import type {Transport} from '@modelcontextprotocol/sdk/shared/transport.js';
 import {AUTH_LEASED_JOB, requireLeasedJobContext} from '@shipfox/api-auth-context';
+import {reportError} from '@shipfox/node-error-monitoring';
 import {defineRoute, type RouteGroup} from '@shipfox/node-fastify';
 import type {IntegrationProviderRegistry} from '#core/providers/registry.js';
 import type {GetIntegrationConnectionByIdFn} from '#db/connections.js';
@@ -50,8 +51,18 @@ export function createAgentToolsGatewayRoutes(
 
           await server.connect(transport as unknown as Transport);
           reply.raw.on('close', () => {
-            void transport.close();
-            void server.close();
+            void transport.close().catch((error) => {
+              reportError(error, {
+                boundary: 'integration.agent-tool',
+                operation: 'close-transport',
+              });
+            });
+            void server.close().catch((error) => {
+              reportError(error, {
+                boundary: 'integration.agent-tool',
+                operation: 'close-server',
+              });
+            });
           });
 
           reply.hijack();

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/mcp-server.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/mcp-server.ts
@@ -5,6 +5,7 @@ import {
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import {reportError} from '@shipfox/node-error-monitoring';
+import {logger} from '@shipfox/node-opentelemetry';
 import {INVALID_METHOD_LABEL, type IntegrationToolCallRecorder, NO_METHOD_LABEL} from './audit.js';
 import type {
   AuthorizedIntegrationTool,
@@ -122,6 +123,7 @@ function recordToolCall(
     recordCall?.(record);
   } catch (error) {
     // Audit and metrics must not affect MCP responses.
+    logger().error({err: error}, 'Failed to record integration agent tool audit event');
     reportError(error, {boundary: 'integration.agent-tool', operation: 'audit'});
   }
 }

--- a/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/mcp-server.ts
+++ b/libs/api/integration/core/src/presentation/routes/agent-tools-gateway/mcp-server.ts
@@ -4,6 +4,7 @@ import {
   type CallToolResult,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
+import {reportError} from '@shipfox/node-error-monitoring';
 import {INVALID_METHOD_LABEL, type IntegrationToolCallRecorder, NO_METHOD_LABEL} from './audit.js';
 import type {
   AuthorizedIntegrationTool,
@@ -119,8 +120,9 @@ function recordToolCall(
 ): void {
   try {
     recordCall?.(record);
-  } catch {
+  } catch (error) {
     // Audit and metrics must not affect MCP responses.
+    reportError(error, {boundary: 'integration.agent-tool', operation: 'audit'});
   }
 }
 

--- a/libs/api/integration/github/package.json
+++ b/libs/api/integration/github/package.json
@@ -51,6 +51,7 @@
     "@shipfox/node-fastify": "workspace:*",
     "@shipfox/node-postgres": "workspace:*",
     "@shipfox/node-opentelemetry": "workspace:*",
+    "@shipfox/node-error-monitoring": "workspace:*",
     "drizzle-orm": "catalog:",
     "ky": "catalog:",
     "octokit": "catalog:",

--- a/libs/api/integration/github/src/api/shared-installation-token-cache.ts
+++ b/libs/api/integration/github/src/api/shared-installation-token-cache.ts
@@ -1,4 +1,5 @@
 import {setTimeout as sleepTimeout} from 'node:timers/promises';
+import {reportError} from '@shipfox/node-error-monitoring';
 import {logger} from '@shipfox/node-opentelemetry';
 import {GithubIntegrationProviderError} from '#core/errors.js';
 import {
@@ -135,6 +136,11 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
           {installationId: params.installationId, reason: classified.reason, error: writeError},
           'github installation token backoff write failed',
         );
+        reportError(writeError, {
+          boundary: 'integration.cache',
+          operation: 'write-backoff-envelope',
+          extra: {installationId: params.installationId},
+        });
       });
 
       if (
@@ -179,6 +185,11 @@ export class SharedInstallationTokenCache implements InstallationTokenCache {
         {installationId: params.installationId, expiresAt: token.expiresAt.toISOString(), error},
         'github installation token cache write failed after mint',
       );
+      reportError(error, {
+        boundary: 'integration.cache',
+        operation: 'write-minted-token',
+        extra: {installationId: params.installationId},
+      });
     }
 
     logger().info(

--- a/libs/api/logs/package.json
+++ b/libs/api/logs/package.json
@@ -50,6 +50,7 @@
     "@shipfox/api-workflows-dto": "workspace:*",
     "@shipfox/config": "workspace:*",
     "@shipfox/node-drizzle": "workspace:*",
+    "@shipfox/node-error-monitoring": "workspace:*",
     "@shipfox/node-fastify": "workspace:*",
     "@shipfox/node-module": "workspace:*",
     "@shipfox/node-opentelemetry": "workspace:*",

--- a/libs/api/logs/src/api/object-storage.ts
+++ b/libs/api/logs/src/api/object-storage.ts
@@ -10,6 +10,7 @@ import {
 import {Upload} from '@aws-sdk/lib-storage';
 import {getSignedUrl} from '@aws-sdk/s3-request-presigner';
 import {reportError} from '@shipfox/node-error-monitoring';
+import {logger} from '@shipfox/node-opentelemetry';
 import {config} from '#config.js';
 import {type LogObjectKeyParams, logObjectKey} from '#core/entities/log-object.js';
 
@@ -142,6 +143,10 @@ export async function putCompactedObject(params: PutCompactedObjectParams): Prom
       'abort',
       () => {
         void upload.abort().catch((error) => {
+          logger().error(
+            {err: error, objectKey: params.key},
+            'Failed to abort multipart log upload',
+          );
           reportError(error, {
             boundary: 'logs.cleanup',
             operation: 'abort-multipart-upload',
@@ -153,6 +158,7 @@ export async function putCompactedObject(params: PutCompactedObjectParams): Prom
     );
     if (params.signal.aborted) {
       await upload.abort().catch((error) => {
+        logger().error({err: error, objectKey: params.key}, 'Failed to abort multipart log upload');
         reportError(error, {
           boundary: 'logs.cleanup',
           operation: 'abort-multipart-upload',

--- a/libs/api/logs/src/api/object-storage.ts
+++ b/libs/api/logs/src/api/object-storage.ts
@@ -9,6 +9,7 @@ import {
 } from '@aws-sdk/client-s3';
 import {Upload} from '@aws-sdk/lib-storage';
 import {getSignedUrl} from '@aws-sdk/s3-request-presigner';
+import {reportError} from '@shipfox/node-error-monitoring';
 import {config} from '#config.js';
 import {type LogObjectKeyParams, logObjectKey} from '#core/entities/log-object.js';
 
@@ -140,12 +141,24 @@ export async function putCompactedObject(params: PutCompactedObjectParams): Prom
     params.signal.addEventListener(
       'abort',
       () => {
-        void upload.abort().catch(() => undefined);
+        void upload.abort().catch((error) => {
+          reportError(error, {
+            boundary: 'logs.cleanup',
+            operation: 'abort-multipart-upload',
+            extra: {objectKey: params.key},
+          });
+        });
       },
       {once: true},
     );
     if (params.signal.aborted) {
-      await upload.abort().catch(() => undefined);
+      await upload.abort().catch((error) => {
+        reportError(error, {
+          boundary: 'logs.cleanup',
+          operation: 'abort-multipart-upload',
+          extra: {objectKey: params.key},
+        });
+      });
       throw new Error('Compaction upload aborted before it started');
     }
   }

--- a/libs/api/logs/src/core/reap-stale-open-streams.ts
+++ b/libs/api/logs/src/core/reap-stale-open-streams.ts
@@ -1,3 +1,4 @@
+import {reportError} from '@shipfox/node-error-monitoring';
 import {logger} from '@shipfox/node-opentelemetry';
 import {db} from '#db/db.js';
 import {listStaleOpenStreams} from '#db/streams.js';
@@ -53,6 +54,7 @@ export async function reapStaleOpenStreams(
     } catch (error) {
       result.failed += 1;
       logger().error({err: error, streamId: stream.id}, 'Failed to reap stale open log stream');
+      reportError(error, {boundary: 'logs.maintenance', extra: {streamId: stream.id}});
     }
   }
 

--- a/libs/api/logs/src/core/retention.ts
+++ b/libs/api/logs/src/core/retention.ts
@@ -1,3 +1,4 @@
+import {reportError} from '@shipfox/node-error-monitoring';
 import {logger} from '@shipfox/node-opentelemetry';
 import {deleteObjectsByPrefix} from '#api/object-storage.js';
 import {config} from '#config.js';
@@ -116,6 +117,7 @@ export async function runRetentionSweep(
           {err: error, streamId: stream.id},
           'Failed to delete expired log stream objects',
         );
+        reportError(error, {boundary: 'logs.maintenance', extra: {streamId: stream.id}});
         continue;
       }
 
@@ -129,6 +131,7 @@ export async function runRetentionSweep(
           {err: error, streamId: stream.id},
           'Failed to delete expired log stream row',
         );
+        reportError(error, {boundary: 'logs.maintenance', extra: {streamId: stream.id}});
         continue;
       }
 
@@ -143,6 +146,7 @@ export async function runRetentionSweep(
             {err: error, streamId: stream.id},
             'Failed to reload raced expired log stream',
           );
+          reportError(error, {boundary: 'logs.maintenance', extra: {streamId: stream.id}});
           continue;
         }
         if (current) {
@@ -159,6 +163,7 @@ export async function runRetentionSweep(
               {err: error, streamId: stream.id},
               'Failed to delete raced expired log stream',
             );
+            reportError(error, {boundary: 'logs.maintenance', extra: {streamId: stream.id}});
             continue;
           }
         }

--- a/libs/api/logs/src/temporal/activities/compact-stream.ts
+++ b/libs/api/logs/src/temporal/activities/compact-stream.ts
@@ -1,3 +1,4 @@
+import {reportError} from '@shipfox/node-error-monitoring';
 import {Context} from '@temporalio/activity';
 import {compactedObjectKey, deleteObject, putCompactedObject} from '#api/object-storage.js';
 import {compactedGzipStream} from '#core/compaction.js';
@@ -79,7 +80,13 @@ async function compactStream(
     stats.lastSeq !== expected.maxSeq ||
     stats.uncompressedBytes !== expected.uncompressedBytes
   ) {
-    await deleteObject(uploadKey).catch(() => undefined);
+    await deleteObject(uploadKey).catch((error) => {
+      reportError(error, {
+        boundary: 'logs.cleanup',
+        operation: 'delete-invalid-compaction-object',
+        extra: {streamId: stream.id, objectKey: uploadKey},
+      });
+    });
     throw new Error(
       `Compaction integrity check failed for stream ${stream.id}: streamed ${stats.chunkCount} chunks / ${stats.uncompressedBytes} bytes up to seq ${stats.lastSeq}, table holds ${expected.count} / ${expected.uncompressedBytes} bytes up to seq ${expected.maxSeq}`,
     );

--- a/libs/api/logs/src/temporal/activities/compact-stream.ts
+++ b/libs/api/logs/src/temporal/activities/compact-stream.ts
@@ -1,4 +1,5 @@
 import {reportError} from '@shipfox/node-error-monitoring';
+import {logger} from '@shipfox/node-opentelemetry';
 import {Context} from '@temporalio/activity';
 import {compactedObjectKey, deleteObject, putCompactedObject} from '#api/object-storage.js';
 import {compactedGzipStream} from '#core/compaction.js';
@@ -81,6 +82,10 @@ async function compactStream(
     stats.uncompressedBytes !== expected.uncompressedBytes
   ) {
     await deleteObject(uploadKey).catch((error) => {
+      logger().error(
+        {err: error, streamId: stream.id, objectKey: uploadKey},
+        'Failed to delete invalid compacted log object',
+      );
       reportError(error, {
         boundary: 'logs.cleanup',
         operation: 'delete-invalid-compaction-object',

--- a/libs/api/logs/src/temporal/activities/compaction-reconcile.ts
+++ b/libs/api/logs/src/temporal/activities/compaction-reconcile.ts
@@ -1,3 +1,4 @@
+import {reportError} from '@shipfox/node-error-monitoring';
 import {logger} from '@shipfox/node-opentelemetry';
 import {temporalClient} from '@shipfox/node-temporal';
 import {config} from '#config.js';
@@ -41,6 +42,7 @@ export async function compactionReconcileActivity(): Promise<{restarted: number;
         {err: error, streamId: stream.id},
         'Failed to re-drive stale stream compaction',
       );
+      reportError(error, {boundary: 'logs.maintenance', extra: {streamId: stream.id}});
     }
   }
 

--- a/libs/api/runners/package.json
+++ b/libs/api/runners/package.json
@@ -48,6 +48,7 @@
     "@shipfox/config": "workspace:*",
     "@shipfox/inter-module": "workspace:*",
     "@shipfox/node-drizzle": "workspace:*",
+    "@shipfox/node-error-monitoring": "workspace:*",
     "@shipfox/node-auth-root-key": "workspace:*",
     "@shipfox/node-fastify": "workspace:*",
     "@shipfox/node-module": "workspace:*",

--- a/libs/api/runners/src/presentation/routes/poll-demand.ts
+++ b/libs/api/runners/src/presentation/routes/poll-demand.ts
@@ -4,6 +4,7 @@ import {
 } from '@shipfox/api-auth-context';
 import type {PollDemandTemplateDto} from '@shipfox/api-runners-dto';
 import {pollDemandBodySchema, pollDemandResponseSchema} from '@shipfox/api-runners-dto';
+import {reportError} from '@shipfox/node-error-monitoring';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {config} from '#config.js';
 import {pollDemand, releaseReservationGrants} from '#core/demand.js';
@@ -50,7 +51,13 @@ export function createPollDemandRoute(options: CreateRunnersModuleOptions = {}) 
       reply.raw.on('close', () => {
         if (!responseFinished) {
           abortController.abort();
-          void releaseReservationGrants(responseReservations).catch(() => undefined);
+          void releaseReservationGrants(responseReservations).catch((error) => {
+            reportError(error, {
+              boundary: 'runners.cleanup',
+              operation: 'release-disconnected-reservations',
+              extra: {reservationCount: responseReservations.length},
+            });
+          });
         }
       });
       const provisionerContext = requireProvisionerContext(request);

--- a/libs/api/runners/src/presentation/routes/poll-demand.ts
+++ b/libs/api/runners/src/presentation/routes/poll-demand.ts
@@ -6,6 +6,7 @@ import type {PollDemandTemplateDto} from '@shipfox/api-runners-dto';
 import {pollDemandBodySchema, pollDemandResponseSchema} from '@shipfox/api-runners-dto';
 import {reportError} from '@shipfox/node-error-monitoring';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
+import {logger} from '@shipfox/node-opentelemetry';
 import {config} from '#config.js';
 import {pollDemand, releaseReservationGrants} from '#core/demand.js';
 import {publishWorkspaceProvisionerCapabilitySnapshot} from '#db/provisioner-capability-snapshots.js';
@@ -52,6 +53,10 @@ export function createPollDemandRoute(options: CreateRunnersModuleOptions = {}) 
         if (!responseFinished) {
           abortController.abort();
           void releaseReservationGrants(responseReservations).catch((error) => {
+            logger().error(
+              {err: error, reservationCount: responseReservations.length},
+              'Failed to release reservations after provisioner disconnect',
+            );
             reportError(error, {
               boundary: 'runners.cleanup',
               operation: 'release-disconnected-reservations',

--- a/libs/api/server/src/modules.ts
+++ b/libs/api/server/src/modules.ts
@@ -30,6 +30,7 @@ import {
   createInMemoryInterModuleTransport,
   registerInterModulePresentations,
 } from '@shipfox/node-module/inter-module';
+import {logger} from '@shipfox/node-opentelemetry';
 
 export interface DefaultModulesOptions {
   webhookDeliverySource?: WebhookDeliverySource | undefined;
@@ -40,6 +41,10 @@ export async function defaultModules(
 ): Promise<ShipfoxModule[]> {
   const interModuleTransport = createInMemoryInterModuleTransport({
     reportInternalError: (error, context) => {
+      logger().error(
+        {err: error, module: context.module, method: context.method, phase: context.phase},
+        'Inter-module call failed unexpectedly',
+      );
       reportError(error, {
         boundary: 'inter-module',
         operation: `${context.module}.${context.method}`,

--- a/libs/api/server/src/modules.ts
+++ b/libs/api/server/src/modules.ts
@@ -23,6 +23,7 @@ import {createWorkflowsModule} from '@shipfox/api-workflows';
 import {workflowsInterModuleContract} from '@shipfox/api-workflows-dto/inter-module';
 import {workspacesModule} from '@shipfox/api-workspaces';
 import {workspacesInterModuleContract} from '@shipfox/api-workspaces-dto/inter-module';
+import {reportError} from '@shipfox/node-error-monitoring';
 import {durationToSeconds} from '@shipfox/node-jwt';
 import type {ShipfoxModule} from '@shipfox/node-module';
 import {
@@ -37,7 +38,15 @@ export interface DefaultModulesOptions {
 export async function defaultModules(
   options: DefaultModulesOptions = {},
 ): Promise<ShipfoxModule[]> {
-  const interModuleTransport = createInMemoryInterModuleTransport();
+  const interModuleTransport = createInMemoryInterModuleTransport({
+    reportInternalError: (error, context) => {
+      reportError(error, {
+        boundary: 'inter-module',
+        operation: `${context.module}.${context.method}`,
+        tags: {module: context.module, method: context.method, phase: context.phase},
+      });
+    },
+  });
   const workflowsClient = interModuleTransport.createClient(workflowsInterModuleContract);
   const authClient = interModuleTransport.createClient(authInterModuleContract);
   const agentClient = interModuleTransport.createClient(agentInterModuleContract);

--- a/libs/api/server/src/server.test.ts
+++ b/libs/api/server/src/server.test.ts
@@ -12,7 +12,8 @@ const mocks = vi.hoisted(() => {
   const workersHandle = {stop: vi.fn()};
   const servicesHandle = {stop: vi.fn()};
   return {
-    captureException: vi.fn(),
+    markErrorReported: vi.fn(),
+    reportError: vi.fn(),
     closeApp: vi.fn(),
     closeErrorMonitoring: vi.fn(),
     closePostgresClient: vi.fn(),
@@ -42,8 +43,9 @@ const mocks = vi.hoisted(() => {
 });
 
 vi.mock('@shipfox/node-error-monitoring', () => ({
-  captureException: mocks.captureException,
   closeErrorMonitoring: mocks.closeErrorMonitoring,
+  markErrorReported: mocks.markErrorReported,
+  reportError: mocks.reportError,
 }));
 vi.mock('@shipfox/node-fastify', () => ({
   closeApp: mocks.closeApp,
@@ -113,7 +115,8 @@ function lastStartModuleServicesOptions(): {
 
 function resetMocks(): void {
   vi.useRealTimers();
-  mocks.captureException.mockReset();
+  mocks.markErrorReported.mockReset();
+  mocks.reportError.mockReset();
   mocks.closeApp.mockReset();
   mocks.closeErrorMonitoring.mockReset();
   mocks.closePostgresClient.mockReset();
@@ -492,7 +495,10 @@ describe('createServer', () => {
       {err: failure, taskQueue: 'runtime-queue'},
       'Module worker stopped unexpectedly',
     );
-    expect(mocks.captureException).toHaveBeenCalledWith(failure);
+    expect(mocks.reportError).toHaveBeenCalledWith(failure, {
+      boundary: 'api.runtime',
+      tags: {taskQueue: 'runtime-queue'},
+    });
     expect(mocks.closeApp).toHaveBeenCalledOnce();
     expect(mocks.closeErrorMonitoring).toHaveBeenCalledWith(2_000);
     expect(mocks.closeErrorMonitoring.mock.invocationCallOrder[0]).toBeLessThan(
@@ -513,7 +519,10 @@ describe('createServer', () => {
       {err: failure, service: 'runtime-service'},
       'Module service stopped unexpectedly',
     );
-    expect(mocks.captureException).toHaveBeenCalledWith(failure);
+    expect(mocks.reportError).toHaveBeenCalledWith(failure, {
+      boundary: 'api.runtime',
+      tags: {service: 'runtime-service'},
+    });
     expect(mocks.closeApp).toHaveBeenCalledOnce();
     expect(mocks.closeErrorMonitoring).toHaveBeenCalledWith(2_000);
     expect(mocks.closeErrorMonitoring.mock.invocationCallOrder[0]).toBeLessThan(

--- a/libs/api/server/src/server.ts
+++ b/libs/api/server/src/server.ts
@@ -1,4 +1,4 @@
-import {captureException, closeErrorMonitoring} from '@shipfox/node-error-monitoring';
+import {closeErrorMonitoring, markErrorReported, reportError} from '@shipfox/node-error-monitoring';
 import {closeApp, createApp, listen} from '@shipfox/node-fastify';
 import {
   aggregateLoginMethods,
@@ -116,10 +116,23 @@ export async function createServer(options: CreateServerOptions): Promise<Server
             () => workersHandle?.stop(),
             () => shutdownServiceMetrics(),
             () => closePostgresClient(),
-            async () => {
-              await closeErrorMonitoring(ERROR_MONITORING_SHUTDOWN_TIMEOUT_MS);
-            },
           ]);
+          for (const cleanupError of cleanupErrors) {
+            reportError(cleanupError, {boundary: 'api.shutdown', operation: 'cleanup'});
+          }
+          try {
+            const errorMonitoringClosed = await closeErrorMonitoring(
+              ERROR_MONITORING_SHUTDOWN_TIMEOUT_MS,
+            );
+            if (!errorMonitoringClosed) {
+              logger().error('Timed out closing error monitoring during API shutdown');
+              cleanupErrors.push(
+                new Error('Timed out closing error monitoring during API shutdown'),
+              );
+            }
+          } catch (error) {
+            cleanupErrors.push(error);
+          }
           throwCleanupErrors(cleanupErrors, 'Failed to stop API server');
           stopped = true;
           hasActiveServer = false;
@@ -138,6 +151,7 @@ export async function createServer(options: CreateServerOptions): Promise<Server
     ]);
     for (const cleanupError of cleanupErrors) {
       logger().error({err: cleanupError, bootError: error}, 'Failed to clean up API server boot');
+      reportError(cleanupError, {boundary: 'api.startup', operation: 'cleanup'});
     }
     hasActiveServer = false;
     throw error;
@@ -168,11 +182,22 @@ export async function runServer(options: RunServerOptions): Promise<ServerHandle
         {err: cleanupError, startError: error},
         'Failed to clean up API server startup',
       );
+      reportError(cleanupError, {
+        boundary: 'api.startup',
+        operation: 'cleanup-after-failed-start',
+      });
     }
     throw error;
   }
 
-  const stopAndExit = () => void handle.stop().finally(() => process.exit(0));
+  const stopAndExit = () =>
+    void handle.stop().then(
+      () => process.exit(0),
+      (error) => {
+        reportError(error, {boundary: 'api.shutdown', operation: 'signal-stop'});
+        process.exit(1);
+      },
+    );
   process.once('SIGTERM', stopAndExit);
   process.once('SIGINT', stopAndExit);
 
@@ -210,7 +235,9 @@ async function runCleanupSteps(steps: CleanupStep[]): Promise<unknown[]> {
 function throwCleanupErrors(cleanupErrors: unknown[], message: string): void {
   if (cleanupErrors.length === 0) return;
   if (cleanupErrors.length === 1) throw cleanupErrors[0];
-  throw new AggregateError(cleanupErrors, message);
+  const aggregate = new AggregateError(cleanupErrors, message);
+  markErrorReported(aggregate);
+  throw aggregate;
 }
 
 async function handleModuleWorkerFailure(
@@ -246,11 +273,19 @@ async function handleModuleRuntimeFailure(options: {
   onFailure(): void | Promise<void>;
 }): Promise<void> {
   logger().error({err: options.error, ...options.fields}, options.message);
-  captureException(options.error);
+  reportError(options.error, {
+    boundary: 'api.runtime',
+    tags: options.fields,
+  });
 
   try {
     await closeHttpServerAfterRuntimeFailure();
-    await closeErrorMonitoring(ERROR_MONITORING_SHUTDOWN_TIMEOUT_MS);
+    const errorMonitoringClosed = await closeErrorMonitoring(ERROR_MONITORING_SHUTDOWN_TIMEOUT_MS);
+    if (!errorMonitoringClosed) {
+      logger().error('Timed out closing error monitoring after module runtime failure');
+    }
+  } catch (error) {
+    logger().error({err: error}, 'Failed to close error monitoring after module runtime failure');
   } finally {
     await options.onFailure();
   }
@@ -270,13 +305,13 @@ async function closeHttpServerAfterRuntimeFailure(): Promise<void> {
       },
     );
     if (result === 'timeout') {
-      logger().error(
-        {timeoutMs: RUNTIME_FAILURE_HTTP_SHUTDOWN_TIMEOUT_MS},
-        'Timed out closing HTTP server after module runtime failure',
-      );
+      const error = new Error('Timed out closing HTTP server after module runtime failure');
+      logger().error({timeoutMs: RUNTIME_FAILURE_HTTP_SHUTDOWN_TIMEOUT_MS}, error.message);
+      reportError(error, {boundary: 'api.runtime', operation: 'close-http-timeout'});
     }
   } catch (error) {
     logger().error({err: error}, 'Failed to close HTTP server after module runtime failure');
+    reportError(error, {boundary: 'api.runtime', operation: 'close-http'});
   } finally {
     if (timeoutId) {
       clearTimeout(timeoutId);

--- a/libs/api/server/src/server.ts
+++ b/libs/api/server/src/server.ts
@@ -118,6 +118,7 @@ export async function createServer(options: CreateServerOptions): Promise<Server
             () => closePostgresClient(),
           ]);
           for (const cleanupError of cleanupErrors) {
+            logger().error({err: cleanupError}, 'Failed to clean up API server during shutdown');
             reportError(cleanupError, {boundary: 'api.shutdown', operation: 'cleanup'});
           }
           try {
@@ -194,6 +195,7 @@ export async function runServer(options: RunServerOptions): Promise<ServerHandle
     void handle.stop().then(
       () => process.exit(0),
       (error) => {
+        logger().error({err: error}, 'Failed to stop API server after shutdown signal');
         reportError(error, {boundary: 'api.shutdown', operation: 'signal-stop'});
         process.exit(1);
       },

--- a/libs/api/triggers/package.json
+++ b/libs/api/triggers/package.json
@@ -51,6 +51,7 @@
     "@shipfox/expression": "workspace:*",
     "@shipfox/inter-module": "workspace:*",
     "@shipfox/node-drizzle": "workspace:*",
+    "@shipfox/node-error-monitoring": "workspace:*",
     "@shipfox/node-fastify": "workspace:*",
     "@shipfox/node-module": "workspace:*",
     "@shipfox/node-opentelemetry": "workspace:*",

--- a/libs/api/triggers/src/core/drain-cron-schedules.ts
+++ b/libs/api/triggers/src/core/drain-cron-schedules.ts
@@ -1,3 +1,4 @@
+import {reportError} from '@shipfox/node-error-monitoring';
 import {logger} from '@shipfox/node-opentelemetry';
 import {advanceCronSchedule, claimDueCronSchedules, selectDbNow} from '#db/cron-schedules.js';
 import {db} from '#db/db.js';
@@ -84,6 +85,11 @@ export async function drainDueCronSchedules(
           {err: error, subscriptionId: schedule.subscriptionId},
           'cron drain: transient fire failure; schedule left due for retry',
         );
+        reportError(error, {
+          boundary: 'triggers.maintenance',
+          operation: 'drain-cron-schedules',
+          extra: {subscriptionId: schedule.subscriptionId},
+        });
       }
       params.onScheduleProcessed?.();
     }

--- a/libs/api/triggers/src/core/record-trigger-history.ts
+++ b/libs/api/triggers/src/core/record-trigger-history.ts
@@ -1,3 +1,4 @@
+import {reportError} from '@shipfox/node-error-monitoring';
 import {logger} from '@shipfox/node-opentelemetry';
 import type {JobListenerSubscription} from '#core/entities/job-listener-subscription.js';
 import type {TriggerEventOrigin} from '#core/entities/received-event.js';
@@ -140,6 +141,11 @@ async function safe<T>(
       {err: error, label, eventRef, ...(subscriptionId ? {subscriptionId} : {})},
       'trigger history write failed; ignored (best-effort)',
     );
+    reportError(error, {
+      boundary: 'triggers.history',
+      operation: label,
+      extra: {eventRef, subscriptionId},
+    });
     return undefined;
   }
 }

--- a/libs/shared/node/error-monitoring/README.md
+++ b/libs/shared/node/error-monitoring/README.md
@@ -5,7 +5,7 @@ Sentry integration for Shipfox Node services. It reads Sentry settings from envi
 ## What it does
 
 - **`import '@shipfox/node-error-monitoring/init'`** starts Sentry from environment config.
-- **`reportError(error, context)`** reports an unexpected failure through an isolated Sentry scope.
+- **`reportError(error, context)`** reports an unexpected failure through an isolated Sentry scope. It does not write a log entry itself.
 - **`markErrorReported(error)`** and **`isErrorReported(error)`** prevent duplicate reports when a failure crosses boundaries.
 - **`captureException(error)`** remains available for backward compatibility.
 - **`addEventProcessor(processor)`** adds a custom Sentry event processor.
@@ -35,10 +35,12 @@ import "@shipfox/node-error-monitoring/init";
 import {
   reportError,
 } from "@shipfox/node-error-monitoring";
+import {logger} from "@shipfox/node-opentelemetry";
 
 try {
   await riskyOperation();
 } catch (err) {
+  logger().error({err}, "Failed to refresh cache");
   reportError(err, {boundary: "api.runtime", operation: "refresh-cache"});
 }
 ```
@@ -48,6 +50,12 @@ try {
 The earliest boundary that owns an unexpected failure reports it. A catch that
 continues must report the failure, return or persist a recognized error, or
 document why the failure is intentionally non-actionable.
+
+`reportError` is intentionally Sentry-only. Every call site must also write a
+structured error log before reporting so a self-hosted deployment without Sentry
+still has the error, its cause chain, and safe diagnostic context. Keep the log
+context equivalent to the report context and never add untrusted input merely
+for local debugging.
 
 Report unknown HTTP failures, API startup/runtime/shutdown failures, Temporal
 activity and workflow-code defects, lifecycle failures, dispatcher and outbox

--- a/libs/shared/node/error-monitoring/README.md
+++ b/libs/shared/node/error-monitoring/README.md
@@ -5,7 +5,9 @@ Sentry integration for Shipfox Node services. It reads Sentry settings from envi
 ## What it does
 
 - **`import '@shipfox/node-error-monitoring/init'`** starts Sentry from environment config.
-- **`captureException(error)`** reports an error to Sentry.
+- **`reportError(error, context)`** reports an unexpected failure through an isolated Sentry scope.
+- **`markErrorReported(error)`** and **`isErrorReported(error)`** prevent duplicate reports when a failure crosses boundaries.
+- **`captureException(error)`** remains available for backward compatibility.
 - **`addEventProcessor(processor)`** adds a custom Sentry event processor.
 - **`closeErrorMonitoring()`** flushes pending events and shuts down the Sentry client.
 
@@ -31,27 +33,35 @@ npm install @shipfox/node-error-monitoring
 import "@shipfox/node-error-monitoring/init";
 
 import {
-  captureException,
-  addEventProcessor,
-  closeErrorMonitoring,
+  reportError,
 } from "@shipfox/node-error-monitoring";
 
 try {
   await riskyOperation();
 } catch (err) {
-  captureException(err);
+  reportError(err, {boundary: "api.runtime", operation: "refresh-cache"});
 }
-
-addEventProcessor((event) => {
-  event.tags = {...event.tags, service: "billing-api"};
-  return event;
-});
-
-process.on("SIGTERM", async () => {
-  await closeErrorMonitoring();
-  process.exit(0);
-});
 ```
+
+## Reporting policy
+
+The earliest boundary that owns an unexpected failure reports it. A catch that
+continues must report the failure, return or persist a recognized error, or
+document why the failure is intentionally non-actionable.
+
+Report unknown HTTP failures, API startup/runtime/shutdown failures, Temporal
+activity and workflow-code defects, lifecycle failures, dispatcher and outbox
+infrastructure failures, inter-module defects, and best-effort cleanup failures.
+
+Do not report client, validation, authentication, signature, known-domain, typed
+provider, rate-limit, expected-timeout, cancellation, idempotency, or already
+reported failures. Do not report metrics-recording failures.
+
+Use tags only for bounded classifications such as a boundary, operation, module,
+event type, task queue, or outcome. Use extras for safe diagnostic identifiers
+such as a request, event, workflow, stream, or installation ID. Never include
+request bodies, headers, cookies, tokens, event payloads, activity arguments, or
+inter-module input or output in either tags or extras.
 
 Configure via environment variables before starting your app:
 

--- a/libs/shared/node/error-monitoring/package.json
+++ b/libs/shared/node/error-monitoring/package.json
@@ -44,6 +44,8 @@
     "build": "shipfox-swc",
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
+    "test": "shipfox-vitest-run",
+    "test:watch": "shipfox-vitest-watch",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"
   },
@@ -55,6 +57,8 @@
     "@shipfox/biome": "workspace:*",
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
-    "@shipfox/typescript": "workspace:*"
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*",
+    "vitest": "catalog:"
   }
 }

--- a/libs/shared/node/error-monitoring/src/index.ts
+++ b/libs/shared/node/error-monitoring/src/index.ts
@@ -1,1 +1,7 @@
 export {addEventProcessor, captureException, close as closeErrorMonitoring} from '@sentry/node';
+export {
+  type ErrorReportContext,
+  isErrorReported,
+  markErrorReported,
+  reportError,
+} from './report-error.js';

--- a/libs/shared/node/error-monitoring/src/init.ts
+++ b/libs/shared/node/error-monitoring/src/init.ts
@@ -9,6 +9,7 @@ Sentry.init({
   dsn: config.SENTRY_DSN,
   environment: config.SENTRY_ENVIRONMENT,
   release,
+  sendDefaultPii: false,
   skipOpenTelemetrySetup: true,
 });
 

--- a/libs/shared/node/error-monitoring/src/report-error.test.ts
+++ b/libs/shared/node/error-monitoring/src/report-error.test.ts
@@ -1,0 +1,116 @@
+import * as sentry from '@sentry/node';
+
+vi.mock('@sentry/node', () => ({
+  captureException: vi.fn(),
+  withScope: vi.fn(),
+}));
+
+import {isErrorReported, markErrorReported, reportError} from './report-error.js';
+
+const scope = {
+  setExtras: vi.fn(),
+  setTag: vi.fn(),
+  setTags: vi.fn(),
+};
+
+function resetSentry(): void {
+  vi.mocked(sentry.captureException).mockReset();
+  vi.mocked(sentry.withScope).mockReset();
+  scope.setExtras.mockReset();
+  scope.setTag.mockReset();
+  scope.setTags.mockReset();
+  vi.mocked(sentry.withScope).mockImplementation((callback) => callback(scope));
+  vi.mocked(sentry.captureException).mockReturnValue('event-id');
+}
+
+describe('reportError', () => {
+  test('normalizes a non-Error throw without serializing its value', () => {
+    resetSentry();
+    const eventId = reportError({secret: 'do-not-capture'}, {boundary: 'test'});
+
+    expect(eventId).toBe('event-id');
+    expect(sentry.captureException).toHaveBeenCalledWith(expect.any(Error));
+    expect(vi.mocked(sentry.captureException).mock.calls[0]?.[0].message).toBe(
+      'Non-Error value thrown',
+    );
+    expect(vi.mocked(sentry.captureException).mock.calls[0]?.[0]).not.toHaveProperty('secret');
+  });
+
+  test('uses a local scope for boundary, tags, and extras', () => {
+    resetSentry();
+    const error = new Error('unexpected');
+
+    const eventId = reportError(error, {
+      boundary: 'api.runtime',
+      operation: 'worker.run',
+      tags: {worker: 'outbox'},
+      extra: {attempt: 2},
+    });
+
+    expect(eventId).toBe('event-id');
+    expect(sentry.withScope).toHaveBeenCalledOnce();
+    expect(scope.setTag).toHaveBeenCalledWith('boundary', 'api.runtime');
+    expect(scope.setTag).toHaveBeenCalledWith('operation', 'worker.run');
+    expect(scope.setTags).toHaveBeenCalledWith({worker: 'outbox'});
+    expect(scope.setExtras).toHaveBeenCalledWith({attempt: 2});
+    expect(isErrorReported(error)).toBe(true);
+  });
+
+  test('suppresses an error reported by an earlier boundary', () => {
+    resetSentry();
+    const error = new Error('unexpected');
+    markErrorReported(error);
+
+    const eventId = reportError(error, {boundary: 'http.unhandled'});
+
+    expect(eventId).toBeUndefined();
+    expect(sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  test('deduplicates a frozen error without throwing', () => {
+    resetSentry();
+    const error = Object.freeze(new Error('unexpected'));
+
+    const firstEventId = reportError(error, {boundary: 'test'});
+    const secondEventId = reportError(error, {boundary: 'http.unhandled'});
+
+    expect(firstEventId).toBe('event-id');
+    expect(secondEventId).toBeUndefined();
+    expect(sentry.captureException).toHaveBeenCalledTimes(1);
+  });
+
+  test('deduplicates a non-Error object throw', () => {
+    resetSentry();
+    const thrown = {reason: 'unexpected'};
+
+    reportError(thrown, {boundary: 'test'});
+    const eventId = reportError(thrown, {boundary: 'http.unhandled'});
+
+    expect(eventId).toBeUndefined();
+    expect(sentry.captureException).toHaveBeenCalledTimes(1);
+  });
+
+  test('only marks errors after Sentry accepts the capture', () => {
+    resetSentry();
+    const error = new Error('unexpected');
+    vi.mocked(sentry.captureException).mockReturnValue(undefined);
+
+    const eventId = reportError(error, {boundary: 'test'});
+
+    expect(eventId).toBeUndefined();
+    expect(isErrorReported(error)).toBe(false);
+  });
+
+  test('does not throw when Sentry capture fails', () => {
+    resetSentry();
+    const error = new Error('unexpected');
+    vi.mocked(sentry.captureException).mockImplementation(() => {
+      throw new Error('Sentry unavailable');
+    });
+
+    const eventId = reportError(error, {boundary: 'test'});
+
+    expect(eventId).toBeUndefined();
+    expect(isErrorReported(error)).toBe(false);
+  });
+});

--- a/libs/shared/node/error-monitoring/src/report-error.ts
+++ b/libs/shared/node/error-monitoring/src/report-error.ts
@@ -1,0 +1,66 @@
+import * as Sentry from '@sentry/node';
+
+const errorReportedMarker = Symbol.for('@shipfox/error-reported');
+const reportedErrors = new WeakSet<object>();
+
+export interface ErrorReportContext {
+  boundary: string;
+  operation?: string;
+  tags?: Record<string, string | number | boolean>;
+  extra?: Record<string, string | number | boolean | null | undefined>;
+}
+
+type MarkableError = Error & {[errorReportedMarker]?: true};
+
+function toReportableError(error: unknown): Error {
+  if (error instanceof Error) return error;
+  return new Error('Non-Error value thrown');
+}
+
+function isObject(value: unknown): value is object {
+  return typeof value === 'object' && value !== null;
+}
+
+export function markErrorReported(error: unknown): void {
+  if (!isObject(error)) return;
+  reportedErrors.add(error);
+  try {
+    Object.defineProperty(error, errorReportedMarker, {
+      configurable: false,
+      enumerable: false,
+      value: true,
+      writable: false,
+    });
+  } catch {
+    // The WeakSet is the local source of truth when a frozen error rejects a marker.
+  }
+}
+
+export function isErrorReported(error: unknown): boolean {
+  return (
+    isObject(error) &&
+    (reportedErrors.has(error) || (error as MarkableError)[errorReportedMarker] === true)
+  );
+}
+
+export function reportError(error: unknown, context: ErrorReportContext): string | undefined {
+  if (isErrorReported(error)) return undefined;
+
+  const reportableError = toReportableError(error);
+  try {
+    const eventId = Sentry.withScope((scope) => {
+      scope.setTag('boundary', context.boundary);
+      if (context.operation) scope.setTag('operation', context.operation);
+      if (context.tags) scope.setTags(context.tags);
+      if (context.extra) scope.setExtras(context.extra);
+      return Sentry.captureException(reportableError);
+    });
+    if (eventId) {
+      markErrorReported(error);
+      markErrorReported(reportableError);
+    }
+    return eventId;
+  } catch {
+    return undefined;
+  }
+}

--- a/libs/shared/node/error-monitoring/vitest.config.ts
+++ b/libs/shared/node/error-monitoring/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig} from 'vitest/config';
+
+export default defineConfig({test: {globals: true}});

--- a/libs/shared/node/fastify/src/errorHandler.test.ts
+++ b/libs/shared/node/fastify/src/errorHandler.test.ts
@@ -1,9 +1,16 @@
 import {z} from 'zod';
+
+const errorMonitoring = vi.hoisted(() => ({reportError: vi.fn()}));
+
+vi.mock('@shipfox/node-error-monitoring', () => errorMonitoring);
+
 import {ClientError} from './clientError.js';
 import {closeApp, createApp} from './index.js';
 
 afterEach(async () => {
+  expect(errorMonitoring.reportError).not.toHaveBeenCalled();
   await closeApp();
+  vi.clearAllMocks();
 });
 
 describe('default error handler', () => {
@@ -211,5 +218,16 @@ describe('default error handler', () => {
     const res = await app.inject({method: 'GET', url: '/boom'});
     expect(res.statusCode).toBe(500);
     expect(res.json()).toEqual({code: 'server-error'});
+    expect(errorMonitoring.reportError).toHaveBeenCalledTimes(1);
+    expect(errorMonitoring.reportError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        boundary: 'http.unhandled',
+        operation: 'GET /boom',
+        tags: {method: 'GET', route: '/boom'},
+        extra: expect.objectContaining({requestId: expect.any(String)}),
+      }),
+    );
+    errorMonitoring.reportError.mockClear();
   });
 });

--- a/libs/shared/node/fastify/src/errorHandler.ts
+++ b/libs/shared/node/fastify/src/errorHandler.ts
@@ -1,4 +1,4 @@
-import {captureException} from '@shipfox/node-error-monitoring';
+import {reportError} from '@shipfox/node-error-monitoring';
 import type {FastifyReply, FastifyRequest} from 'fastify';
 import {ClientError} from './clientError.js';
 
@@ -44,7 +44,16 @@ export function errorHandler(error: unknown, request: FastifyRequest, reply: Fas
   }
 
   request.log.error(error);
-  captureException(error);
+  const route = (request.routeOptions.url ?? 'unknown').split('?')[0] ?? 'unknown';
+  reportError(error, {
+    boundary: 'http.unhandled',
+    operation: `${request.method} ${route}`,
+    tags: {
+      method: request.method,
+      route,
+    },
+    extra: {requestId: request.id},
+  });
   return reply.code(500).send({code: 'server-error'});
 }
 

--- a/libs/shared/node/module/package.json
+++ b/libs/shared/node/module/package.json
@@ -63,6 +63,7 @@
     "@shipfox/inter-module": "workspace:*",
     "@shipfox/node-drizzle": "workspace:*",
     "@shipfox/node-fastify": "workspace:*",
+    "@shipfox/node-error-monitoring": "workspace:*",
     "@shipfox/node-opentelemetry": "workspace:*",
     "@shipfox/node-outbox": "workspace:*",
     "@shipfox/node-temporal": "workspace:*",

--- a/libs/shared/node/module/src/initialize.test.ts
+++ b/libs/shared/node/module/src/initialize.test.ts
@@ -33,6 +33,8 @@ const mocks = vi.hoisted(() => ({
   createTemporalWorker: vi.fn(),
   createTemporalWorkerConnection: vi.fn(),
   workflowStart: vi.fn(),
+  markErrorReported: vi.fn(),
+  reportError: vi.fn(),
   logger: {
     error: vi.fn(),
     info: vi.fn(),
@@ -48,6 +50,11 @@ vi.mock('@shipfox/node-temporal', () => ({
   createTemporalWorker: mocks.createTemporalWorker,
   createTemporalWorkerConnection: mocks.createTemporalWorkerConnection,
   temporalClient: () => ({workflow: {start: mocks.workflowStart}}),
+}));
+
+vi.mock('@shipfox/node-error-monitoring', () => ({
+  markErrorReported: mocks.markErrorReported,
+  reportError: mocks.reportError,
 }));
 
 vi.mock('@shipfox/node-opentelemetry', () => ({
@@ -168,6 +175,7 @@ describe('startModuleServices', () => {
     mocks.logger.error.mockReset();
     mocks.logger.info.mockReset();
     mocks.logger.warn.mockReset();
+    mocks.reportError.mockReset();
   });
 
   afterEach(() => {
@@ -256,14 +264,10 @@ describe('startModuleServices', () => {
       ],
     });
 
-    await handle.stop();
+    await expect(handle.stop()).rejects.toBe(failure);
 
     expect(firstHandle.stop).toHaveBeenCalledOnce();
     expect(secondHandle.stop).toHaveBeenCalledOnce();
-    expect(mocks.logger.warn).toHaveBeenCalledWith(
-      {err: failure, service: 'second'},
-      'Failed to stop module service',
-    );
   });
 
   it('bounds service shutdown and observes a late stop failure', async () => {
@@ -281,19 +285,20 @@ describe('startModuleServices', () => {
     const handle = await startModuleServices({services: [service]});
 
     const stop = handle.stop();
+    const stopped = stop.catch((error: unknown) => error);
     await vi.advanceTimersByTimeAsync(10);
-    await stop;
+    await expect(stopped).resolves.toMatchObject({
+      name: 'ModuleServiceShutdownTimeoutError',
+      message: 'Timed out stopping module service slow after 10ms',
+    });
     rejectStop(failure);
     await flushMicrotasks();
 
-    expect(mocks.logger.error).toHaveBeenCalledWith(
-      {service: 'slow', timeoutMs: 10},
-      'Timed out stopping module service',
-    );
-    expect(mocks.logger.warn).toHaveBeenCalledWith(
-      {err: failure, service: 'slow'},
-      'Module service stop failed after timeout',
-    );
+    expect(mocks.reportError).toHaveBeenCalledWith(failure, {
+      boundary: 'module.service',
+      operation: 'stop-after-timeout',
+      tags: {service: 'slow'},
+    });
   });
 
   it('reports unexpected service completion but suppresses completion during deliberate shutdown', async () => {
@@ -665,20 +670,12 @@ describe('startModuleWorkers', () => {
     expect(connection.close).not.toHaveBeenCalled();
     rejectRun(failure);
 
-    await firstStop;
+    await expect(firstStop).rejects.toBeInstanceOf(AggregateError);
 
     expect(secondStop).toBe(firstStop);
     expect(firstWorker.shutdown).toHaveBeenCalledOnce();
     expect(secondWorker.shutdown).toHaveBeenCalledOnce();
     expect(onWorkerFailure).not.toHaveBeenCalled();
-    expect(mocks.logger.warn).toHaveBeenCalledWith(
-      {err: shutdownFailure},
-      'Failed to shut down module worker',
-    );
-    expect(mocks.logger.error).toHaveBeenCalledWith(
-      {err: failure},
-      'Module worker stopped with an error',
-    );
     expect(connection.close.mock.invocationCallOrder[0]).toBeGreaterThan(
       secondWorker.shutdown.mock.invocationCallOrder[0] ?? 0,
     );

--- a/libs/shared/node/module/src/initialize.ts
+++ b/libs/shared/node/module/src/initialize.ts
@@ -1,4 +1,5 @@
 import {runMigrations} from '@shipfox/node-drizzle';
+import {markErrorReported, reportError} from '@shipfox/node-error-monitoring';
 import type {AuthMethod, RouteExport} from '@shipfox/node-fastify';
 import {logger} from '@shipfox/node-opentelemetry';
 import {
@@ -56,6 +57,7 @@ export interface ModuleServicesHandle {
 
 interface StartedModuleWorker {
   worker: Worker;
+  taskQueue: string;
   runPromise?: Promise<void>;
 }
 
@@ -161,6 +163,7 @@ export function registerModuleMetrics(options: {
       mod.metrics(options.context);
     } catch (error) {
       logger().warn({err: error, module: mod.name}, 'Failed to register module metrics');
+      reportError(error, {boundary: 'module.metrics', tags: {module: mod.name}});
     }
   }
 }
@@ -193,7 +196,11 @@ export async function startModuleServices(
     }
   } catch (error) {
     stopping = true;
-    await stopStartedModuleServices(services);
+    try {
+      await stopStartedModuleServices(services);
+    } catch (cleanupError) {
+      throw new AggregateError([error, cleanupError], 'Failed to start module services');
+    }
     throw error;
   }
 
@@ -239,6 +246,11 @@ function reportModuleServiceFailure(
         {err: handlerError, serviceErr: error, service: service.name},
         'Module service failure handler failed',
       );
+      reportError(handlerError, {
+        boundary: 'module.service',
+        operation: 'failure-callback',
+        tags: {service: service.name},
+      });
     });
     return;
   }
@@ -246,8 +258,26 @@ function reportModuleServiceFailure(
 }
 
 async function stopStartedModuleServices(services: StartedModuleService[]): Promise<void> {
+  const errors: unknown[] = [];
   for (const service of [...services].reverse()) {
-    await stopModuleService(service);
+    try {
+      await stopModuleService(service);
+    } catch (error) {
+      reportError(error, {
+        boundary: 'module.service',
+        operation: 'stop',
+        tags: {service: service.definition.name},
+      });
+      errors.push(error);
+    }
+  }
+  throwLifecycleErrors(errors, 'Failed to stop module services');
+}
+
+export class ModuleServiceShutdownTimeoutError extends Error {
+  constructor(service: string, timeoutMs: number) {
+    super(`Timed out stopping module service ${service} after ${timeoutMs}ms`);
+    this.name = 'ModuleServiceShutdownTimeoutError';
   }
 }
 
@@ -270,24 +300,22 @@ async function stopModuleService(service: StartedModuleService): Promise<void> {
 
   if (result.status === 'stopped') return;
   if (result.status === 'failed') {
-    logger().warn(
-      {err: result.error, service: service.definition.name},
-      'Failed to stop module service',
-    );
-    return;
+    throw result.error;
   }
 
-  logger().error(
-    {service: service.definition.name, timeoutMs: service.definition.shutdownTimeoutMs},
-    'Timed out stopping module service',
+  const timeoutError = new ModuleServiceShutdownTimeoutError(
+    service.definition.name,
+    service.definition.shutdownTimeoutMs,
   );
   void stopResult.then((lateResult) => {
     if (lateResult.status !== 'failed') return;
-    logger().warn(
-      {err: lateResult.error, service: service.definition.name},
-      'Module service stop failed after timeout',
-    );
+    reportError(lateResult.error, {
+      boundary: 'module.service',
+      operation: 'stop-after-timeout',
+      tags: {service: service.definition.name},
+    });
   });
+  throw timeoutError;
 }
 
 /**
@@ -320,7 +348,7 @@ export async function startModuleWorkers(
             activities: workerDef.activities(options.context),
           }),
         });
-        const startedWorker: StartedModuleWorker = {worker};
+        const startedWorker: StartedModuleWorker = {worker, taskQueue: workerDef.taskQueue};
         workers.push(startedWorker);
 
         for (const workflow of workerDef.workflows) {
@@ -351,6 +379,11 @@ export async function startModuleWorkers(
                   {err: handlerError, workerErr: error, taskQueue: workerDef.taskQueue},
                   'Module worker failure handler failed',
                 );
+                reportError(handlerError, {
+                  boundary: 'module.worker',
+                  operation: 'failure-callback',
+                  tags: {taskQueue: workerDef.taskQueue},
+                });
               },
             );
             return;
@@ -370,7 +403,11 @@ export async function startModuleWorkers(
     }
   } catch (error) {
     stopping = true;
-    await cleanUpFailedModuleWorkerStartup({error, workers, connection});
+    try {
+      await cleanUpFailedModuleWorkerStartup({error, workers, connection});
+    } catch (cleanupError) {
+      throw new AggregateError([error, cleanupError], 'Failed to start module workers');
+    }
     throw error;
   }
 
@@ -387,28 +424,57 @@ async function stopModuleWorkers(options: {
   workers: StartedModuleWorker[];
   connection: NativeConnection;
 }): Promise<void> {
-  for (const {worker} of options.workers) {
+  const errors: unknown[] = [];
+  for (const {worker, taskQueue} of options.workers) {
     try {
       worker.shutdown();
     } catch (error) {
-      logger().warn({err: error}, 'Failed to shut down module worker');
+      reportError(error, {
+        boundary: 'module.worker',
+        operation: 'shutdown',
+        tags: {taskQueue},
+      });
+      errors.push(error);
     }
   }
 
   const results = await Promise.allSettled(
-    options.workers.flatMap(({runPromise}) => (runPromise ? [runPromise] : [])),
+    options.workers.map(({runPromise}) => runPromise ?? Promise.resolve()),
   );
-  for (const result of results) {
+  for (const [index, result] of results.entries()) {
     if (result.status === 'rejected') {
-      logger().error({err: result.reason}, 'Module worker stopped with an error');
+      const worker = options.workers[index];
+      reportError(result.reason, {
+        boundary: 'module.worker',
+        operation: 'run',
+        ...(worker ? {tags: {taskQueue: worker.taskQueue}} : {}),
+      });
+      errors.push(result.reason);
     }
   }
 
   try {
     await options.connection.close();
+  } catch (error) {
+    reportError(error, {boundary: 'module.worker', operation: 'close-connection'});
+    errors.push(error);
   } finally {
-    await closeTemporalClient();
+    try {
+      await closeTemporalClient();
+    } catch (error) {
+      reportError(error, {boundary: 'module.worker', operation: 'close-client'});
+      errors.push(error);
+    }
   }
+  throwLifecycleErrors(errors, 'Failed to stop module workers');
+}
+
+function throwLifecycleErrors(errors: unknown[], message: string): void {
+  if (errors.length === 0) return;
+  if (errors.length === 1) throw errors[0];
+  const aggregate = new AggregateError(errors, message);
+  markErrorReported(aggregate);
+  throw aggregate;
 }
 
 async function cleanUpFailedModuleWorkerStartup(options: {
@@ -416,16 +482,9 @@ async function cleanUpFailedModuleWorkerStartup(options: {
   workers: StartedModuleWorker[];
   connection: NativeConnection | undefined;
 }): Promise<void> {
-  try {
-    if (options.connection) {
-      await stopModuleWorkers({workers: options.workers, connection: options.connection});
-    } else {
-      await closeTemporalClient();
-    }
-  } catch (cleanupError) {
-    logger().error(
-      {err: cleanupError, workerErr: options.error},
-      'Failed to clean up module worker startup resources',
-    );
+  if (options.connection) {
+    await stopModuleWorkers({workers: options.workers, connection: options.connection});
+  } else {
+    await closeTemporalClient();
   }
 }

--- a/libs/shared/node/module/src/initialize.ts
+++ b/libs/shared/node/module/src/initialize.ts
@@ -263,6 +263,10 @@ async function stopStartedModuleServices(services: StartedModuleService[]): Prom
     try {
       await stopModuleService(service);
     } catch (error) {
+      logger().error(
+        {err: error, service: service.definition.name},
+        'Failed to stop module service',
+      );
       reportError(error, {
         boundary: 'module.service',
         operation: 'stop',
@@ -309,6 +313,10 @@ async function stopModuleService(service: StartedModuleService): Promise<void> {
   );
   void stopResult.then((lateResult) => {
     if (lateResult.status !== 'failed') return;
+    logger().error(
+      {err: lateResult.error, service: service.definition.name},
+      'Module service stop failed after timeout',
+    );
     reportError(lateResult.error, {
       boundary: 'module.service',
       operation: 'stop-after-timeout',
@@ -429,6 +437,7 @@ async function stopModuleWorkers(options: {
     try {
       worker.shutdown();
     } catch (error) {
+      logger().error({err: error, taskQueue}, 'Failed to shut down module worker');
       reportError(error, {
         boundary: 'module.worker',
         operation: 'shutdown',
@@ -444,6 +453,10 @@ async function stopModuleWorkers(options: {
   for (const [index, result] of results.entries()) {
     if (result.status === 'rejected') {
       const worker = options.workers[index];
+      logger().error(
+        {err: result.reason, ...(worker ? {taskQueue: worker.taskQueue} : {})},
+        'Module worker stopped with an error',
+      );
       reportError(result.reason, {
         boundary: 'module.worker',
         operation: 'run',
@@ -456,12 +469,14 @@ async function stopModuleWorkers(options: {
   try {
     await options.connection.close();
   } catch (error) {
+    logger().error({err: error}, 'Failed to close module worker connection');
     reportError(error, {boundary: 'module.worker', operation: 'close-connection'});
     errors.push(error);
   } finally {
     try {
       await closeTemporalClient();
     } catch (error) {
+      logger().error({err: error}, 'Failed to close module Temporal client');
       reportError(error, {boundary: 'module.worker', operation: 'close-client'});
       errors.push(error);
     }

--- a/libs/shared/node/module/src/inter-module/dispatch.test.ts
+++ b/libs/shared/node/module/src/inter-module/dispatch.test.ts
@@ -6,6 +6,7 @@ import {
   type InterModulePresentationHandlers,
   isInterModuleKnownError,
 } from '@shipfox/inter-module';
+import {isErrorReported} from '@shipfox/node-error-monitoring';
 import {SpanKind, SpanStatusCode} from '@shipfox/node-opentelemetry';
 import {z} from 'zod';
 import {createFakeTracer} from '#test/fake-tracer.js';
@@ -162,8 +163,13 @@ describe('inter-module dispatch: input validation', () => {
     );
     transport.seal();
 
-    await expect(client.withAsyncInputSchema({id: 'w-1'})).rejects.toThrow(InterModuleOpaqueError);
+    const rejection = await client
+      .withAsyncInputSchema({id: 'w-1'})
+      .catch((error: unknown) => error);
 
+    expect(rejection).toBeInstanceOf(InterModuleOpaqueError);
+    expect((rejection as Error).cause).toBeUndefined();
+    expect(isErrorReported(rejection)).toBe(true);
     expect(reports).toEqual([
       {phase: 'input-schema', module: 'edge', method: 'withAsyncInputSchema'},
     ]);

--- a/libs/shared/node/module/src/inter-module/dispatch.ts
+++ b/libs/shared/node/module/src/inter-module/dispatch.ts
@@ -4,7 +4,8 @@ import type {
   InterModuleKnownError,
   InterModuleMethodContract,
 } from '@shipfox/inter-module';
-import {type Span, SpanKind, type trace} from '@shipfox/node-opentelemetry';
+import {markErrorReported} from '@shipfox/node-error-monitoring';
+import {logger, type Span, SpanKind, type trace} from '@shipfox/node-opentelemetry';
 import {InterModuleOpaqueError, InterModuleValidationError} from './errors.js';
 import {isJsonSafeValue} from './json.js';
 import {reviveThrownKnownError} from './known-error-revive.js';
@@ -44,10 +45,13 @@ function drainReport(
   try {
     const result = reportInternalError(error, context);
     if (result && typeof result.then === 'function') {
-      result.then(undefined, () => undefined);
+      result.then(undefined, (reporterError) => {
+        logger().warn({err: reporterError}, 'Inter-module internal error reporter failed');
+      });
     }
-  } catch {
+  } catch (reporterError) {
     // The reporter's own synchronous failure never affects the caller's outcome.
+    logger().warn({err: reporterError}, 'Inter-module internal error reporter failed');
   }
 }
 
@@ -102,6 +106,7 @@ export interface RunInterModuleCallOptions {
   tracer: ReturnType<typeof trace.getTracer>;
   transportName: string;
   reportInternalError: InterModuleReportInternalError;
+  hasInternalReporter: boolean;
 }
 
 /**
@@ -152,7 +157,7 @@ export function runInterModuleCall(callOptions: RunInterModuleCallOptions): Prom
           endSpan(clientSpan, inputResolution.kind);
           throw inputResolution.kind === 'validation-error'
             ? new InterModuleValidationError(module, method)
-            : new InterModuleOpaqueError(module, method);
+            : createOpaqueError(callOptions);
         }
 
         return startActiveInterModuleSpan(
@@ -184,7 +189,7 @@ export function runInterModuleCall(callOptions: RunInterModuleCallOptions): Prom
             if (settlement.outcome === 'success') return settlement.value;
             if (settlement.outcome === 'known-error') throw settlement.error;
             if (settlement.outcome === 'cancelled') throw settlement.reason;
-            throw new InterModuleOpaqueError(module, method);
+            throw createOpaqueError(callOptions);
           },
         );
       },
@@ -192,6 +197,12 @@ export function runInterModuleCall(callOptions: RunInterModuleCallOptions): Prom
   } catch (error) {
     return Promise.reject(error);
   }
+}
+
+function createOpaqueError(callOptions: RunInterModuleCallOptions): InterModuleOpaqueError {
+  const error = new InterModuleOpaqueError(callOptions.module, callOptions.method);
+  if (callOptions.hasInternalReporter) markErrorReported(error);
+  return error;
 }
 
 type SafeParseResult =

--- a/libs/shared/node/module/src/inter-module/transport.ts
+++ b/libs/shared/node/module/src/inter-module/transport.ts
@@ -70,6 +70,7 @@ export function createInMemoryInterModuleTransport(
   const tracer = resolveInterModuleTracer(options.tracer);
   const reportInternalError: InterModuleReportInternalError =
     options.reportInternalError ?? (() => undefined);
+  const hasInternalReporter = options.reportInternalError !== undefined;
 
   let sealed = false;
   const clientContractByModule = new Map<
@@ -143,6 +144,7 @@ export function createInMemoryInterModuleTransport(
         tracer,
         transportName: TRANSPORT_NAME,
         reportInternalError,
+        hasInternalReporter,
       });
     });
   }

--- a/libs/shared/node/temporal/package.json
+++ b/libs/shared/node/temporal/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "@shipfox/config": "workspace:*",
+    "@shipfox/node-error-monitoring": "workspace:*",
     "@shipfox/node-opentelemetry": "workspace:*",
     "@temporalio/client": "catalog:",
     "@temporalio/common": "catalog:",

--- a/libs/shared/node/temporal/src/activity-error-interceptor.test.ts
+++ b/libs/shared/node/temporal/src/activity-error-interceptor.test.ts
@@ -1,0 +1,69 @@
+import {CancelledFailure} from '@temporalio/common';
+
+const errorMonitoring = vi.hoisted(() => ({isErrorReported: vi.fn(), reportError: vi.fn()}));
+
+vi.mock('@shipfox/node-error-monitoring', () => errorMonitoring);
+
+import {createActivityErrorInterceptor, getWorkerInterceptors} from './interceptors.js';
+
+const activityContext = {
+  info: {
+    activityId: 'activity-1',
+    activityType: 'compactStream',
+    attempt: 2,
+    taskQueue: 'logs',
+    workflowExecution: {runId: 'run-1', workflowId: 'workflow-1'},
+  },
+};
+
+afterEach(() => vi.clearAllMocks());
+
+describe('Temporal activity error interceptor', () => {
+  beforeEach(() => errorMonitoring.isErrorReported.mockReturnValue(false));
+
+  test('registers the activity interceptor', () => {
+    expect(getWorkerInterceptors().activityInbound).toEqual([createActivityErrorInterceptor]);
+  });
+
+  test('reports an unexpected activity attempt and rethrows the same error', async () => {
+    const error = new Error('activity failed');
+    const interceptor = createActivityErrorInterceptor(activityContext as never);
+
+    const result = interceptor.execute?.({args: [], headers: {} as never}, () =>
+      Promise.reject(error),
+    );
+
+    await expect(result).rejects.toBe(error);
+    expect(errorMonitoring.reportError).toHaveBeenCalledWith(error, {
+      boundary: 'temporal.activity',
+      tags: {activityType: 'compactStream', taskQueue: 'logs'},
+      extra: {
+        activityId: 'activity-1',
+        attempt: 2,
+        runId: 'run-1',
+        workflowId: 'workflow-1',
+      },
+    });
+  });
+
+  test('does not report cancellation or an error reported at an inner boundary', async () => {
+    const cancellation = new CancelledFailure('cancelled');
+    const interceptor = createActivityErrorInterceptor(activityContext as never);
+
+    const cancelled = interceptor.execute?.({args: [], headers: {} as never}, () =>
+      Promise.reject(cancellation),
+    );
+
+    await expect(cancelled).rejects.toBe(cancellation);
+    expect(errorMonitoring.reportError).not.toHaveBeenCalled();
+
+    const reported = new Error('already reported');
+    errorMonitoring.isErrorReported.mockReturnValue(true);
+    const result = interceptor.execute?.({args: [], headers: {} as never}, () =>
+      Promise.reject(reported),
+    );
+
+    await expect(result).rejects.toBe(reported);
+    expect(errorMonitoring.reportError).not.toHaveBeenCalled();
+  });
+});

--- a/libs/shared/node/temporal/src/interceptors.test.ts
+++ b/libs/shared/node/temporal/src/interceptors.test.ts
@@ -8,6 +8,7 @@ const makeWorkflowExporter = vi.hoisted(() => vi.fn());
 vi.mock('@shipfox/node-opentelemetry', () => ({
   getInstanceResource: () => telemetry.resource,
   getInstanceSpanProcessor: () => telemetry.processor,
+  logger: () => ({error: vi.fn()}),
 }));
 
 vi.mock('@temporalio/interceptors-opentelemetry', () => {

--- a/libs/shared/node/temporal/src/interceptors.test.ts
+++ b/libs/shared/node/temporal/src/interceptors.test.ts
@@ -49,7 +49,8 @@ describe('OpenTelemetry interceptors', () => {
 
     expect(client.workflow).toHaveLength(1);
     expect(worker.activity).toHaveLength(1);
-    expect(workflows).toHaveLength(1);
+    expect(worker.activityInbound).toHaveLength(1);
+    expect(workflows).toHaveLength(2);
   });
 
   it('keeps workflow export safe when tracing is disabled', () => {

--- a/libs/shared/node/temporal/src/interceptors.ts
+++ b/libs/shared/node/temporal/src/interceptors.ts
@@ -1,6 +1,8 @@
 import {createRequire} from 'node:module';
+import {isErrorReported, reportError} from '@shipfox/node-error-monitoring';
 import {getInstanceResource, getInstanceSpanProcessor} from '@shipfox/node-opentelemetry';
 import type {ClientInterceptors} from '@temporalio/client';
+import {CancelledFailure} from '@temporalio/common';
 import {
   makeWorkflowExporter,
   OpenTelemetryActivityInboundInterceptor,
@@ -8,7 +10,11 @@ import {
   type OpenTelemetrySinks,
   OpenTelemetryWorkflowClientInterceptor,
 } from '@temporalio/interceptors-opentelemetry';
-import type {InjectedSinks, WorkerInterceptors} from '@temporalio/worker';
+import type {
+  ActivityInboundCallsInterceptor,
+  InjectedSinks,
+  WorkerInterceptors,
+} from '@temporalio/worker';
 
 const require = createRequire(import.meta.url);
 const workflowInterceptorModule = require.resolve(
@@ -27,11 +33,40 @@ export function getWorkerInterceptors(): WorkerInterceptors {
         outbound: new OpenTelemetryActivityOutboundInterceptor(context),
       }),
     ],
+    activityInbound: [createActivityErrorInterceptor],
   };
 }
 
+export const createActivityErrorInterceptor = (
+  ctx: Parameters<NonNullable<WorkerInterceptors['activityInbound']>[number]>[0],
+) =>
+  ({
+    async execute(input, next) {
+      try {
+        return await next(input);
+      } catch (error) {
+        if (!(error instanceof CancelledFailure) && !isErrorReported(error)) {
+          reportError(error, {
+            boundary: 'temporal.activity',
+            tags: {activityType: ctx.info.activityType, taskQueue: ctx.info.taskQueue},
+            extra: {
+              attempt: ctx.info.attempt,
+              workflowId: ctx.info.workflowExecution?.workflowId,
+              runId: ctx.info.workflowExecution?.runId,
+              activityId: ctx.info.activityId,
+            },
+          });
+        }
+        throw error;
+      }
+    },
+  }) satisfies ActivityInboundCallsInterceptor;
+
 export function getWorkflowInterceptorModules(): string[] {
-  return [workflowInterceptorModule];
+  return [
+    workflowInterceptorModule,
+    new URL('./workflow-error-interceptor.js', import.meta.url).pathname,
+  ];
 }
 
 export function getWorkflowSinks(): InjectedSinks<OpenTelemetrySinks> {

--- a/libs/shared/node/temporal/src/interceptors.ts
+++ b/libs/shared/node/temporal/src/interceptors.ts
@@ -1,6 +1,6 @@
 import {createRequire} from 'node:module';
 import {isErrorReported, reportError} from '@shipfox/node-error-monitoring';
-import {getInstanceResource, getInstanceSpanProcessor} from '@shipfox/node-opentelemetry';
+import {getInstanceResource, getInstanceSpanProcessor, logger} from '@shipfox/node-opentelemetry';
 import type {ClientInterceptors} from '@temporalio/client';
 import {CancelledFailure} from '@temporalio/common';
 import {
@@ -46,6 +46,18 @@ export const createActivityErrorInterceptor = (
         return await next(input);
       } catch (error) {
         if (!(error instanceof CancelledFailure) && !isErrorReported(error)) {
+          logger().error(
+            {
+              err: error,
+              activityType: ctx.info.activityType,
+              taskQueue: ctx.info.taskQueue,
+              attempt: ctx.info.attempt,
+              workflowId: ctx.info.workflowExecution?.workflowId,
+              runId: ctx.info.workflowExecution?.runId,
+              activityId: ctx.info.activityId,
+            },
+            'Temporal activity failed unexpectedly',
+          );
           reportError(error, {
             boundary: 'temporal.activity',
             tags: {activityType: ctx.info.activityType, taskQueue: ctx.info.taskQueue},

--- a/libs/shared/node/temporal/src/worker.test.ts
+++ b/libs/shared/node/temporal/src/worker.test.ts
@@ -104,6 +104,7 @@ describe('createTemporalWorker', () => {
     mocks.workerCreate.mockReset();
     mocks.logger.error.mockReset();
     mocks.logger.info.mockReset();
+    mocks.logger.error.mockReset();
     mocks.getTemporalConnectionOptions.mockReset();
     mocks.temporalConnectionError.mockReset();
     mocks.getWorkerInterceptors.mockReset();

--- a/libs/shared/node/temporal/src/worker.test.ts
+++ b/libs/shared/node/temporal/src/worker.test.ts
@@ -5,7 +5,7 @@ import {createTemporalWorker, createTemporalWorkerConnection} from './worker.js'
 const mocks = vi.hoisted(() => ({
   nativeConnectionConnect: vi.fn(),
   workerCreate: vi.fn(),
-  logger: {info: vi.fn()},
+  logger: {error: vi.fn(), info: vi.fn()},
   getTemporalConnectionOptions: vi.fn(),
   temporalConnectionError: vi.fn(),
   getWorkerInterceptors: vi.fn(),
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   getWorkflowSinks: vi.fn(),
   installTemporalRuntime: vi.fn(),
   loadProductionWorkflowBundle: vi.fn(),
+  reportError: vi.fn(),
   temporalConfig: {
     TEMPORAL_NAMESPACE: 'test-namespace',
     TEMPORAL_TASK_QUEUE: 'test-queue',
@@ -27,6 +28,8 @@ vi.mock('@temporalio/worker', () => ({
 vi.mock('@shipfox/node-opentelemetry', () => ({
   logger: () => mocks.logger,
 }));
+
+vi.mock('@shipfox/node-error-monitoring', () => ({reportError: mocks.reportError}));
 
 vi.mock('./connection-options.js', () => ({
   getTemporalConnectionOptions: mocks.getTemporalConnectionOptions,
@@ -99,6 +102,7 @@ describe('createTemporalWorker', () => {
     vi.unstubAllEnvs();
     mocks.nativeConnectionConnect.mockReset();
     mocks.workerCreate.mockReset();
+    mocks.logger.error.mockReset();
     mocks.logger.info.mockReset();
     mocks.getTemporalConnectionOptions.mockReset();
     mocks.temporalConnectionError.mockReset();
@@ -107,6 +111,7 @@ describe('createTemporalWorker', () => {
     mocks.getWorkflowSinks.mockReset();
     mocks.installTemporalRuntime.mockReset();
     mocks.loadProductionWorkflowBundle.mockReset();
+    mocks.reportError.mockReset();
     mocks.nativeConnectionConnect.mockResolvedValue({});
     mocks.workerCreate.mockResolvedValue({});
     mocks.getTemporalConnectionOptions.mockReturnValue({address: 'temporal.example.test:7233'});
@@ -127,7 +132,7 @@ describe('createTemporalWorker', () => {
         connection,
         namespace: 'test-namespace',
         taskQueue: 'test-queue',
-        sinks: {exporter: {}},
+        sinks: expect.objectContaining({exporter: {}}),
       }),
     );
   });
@@ -174,6 +179,35 @@ describe('createTemporalWorker', () => {
     expect(createdWorkerOptions).not.toHaveProperty('bundlerOptions');
     expect(createdWorkerOptions?.interceptors).not.toHaveProperty('workflowModules');
     expect(mocks.loadProductionWorkflowBundle).toHaveBeenCalledWith('/tmp/workflows.js');
+  });
+
+  it('reports workflow defects through a replay-safe sink without workflow input', async () => {
+    await createTemporalWorker(workerOptions());
+
+    const createdWorkerOptions = mocks.workerCreate.mock.calls[0]?.[0];
+    const sink = createdWorkerOptions.sinks.shipfoxErrorMonitoring.reportWorkflowError;
+    const report = {
+      name: 'Error',
+      message: 'workflow failed',
+      stack: 'Error: workflow failed',
+      workflowType: 'dispatch',
+      taskQueue: 'workflows',
+      workflowId: 'workflow-1',
+      runId: 'run-1',
+      attempt: 3,
+    };
+
+    sink.fn({}, report);
+
+    expect(sink.callDuringReplay).toBe(false);
+    expect(mocks.reportError).toHaveBeenCalledWith(
+      expect.objectContaining({name: 'Error', message: 'workflow failed', stack: report.stack}),
+      {
+        boundary: 'temporal.workflow',
+        tags: {workflowType: 'dispatch', taskQueue: 'workflows'},
+        extra: {workflowId: 'workflow-1', runId: 'run-1', attempt: 3},
+      },
+    );
   });
 
   it('validates a production bundle before opening an internally owned connection', async () => {

--- a/libs/shared/node/temporal/src/worker.ts
+++ b/libs/shared/node/temporal/src/worker.ts
@@ -1,3 +1,4 @@
+import {reportError} from '@shipfox/node-error-monitoring';
 import {logger} from '@shipfox/node-opentelemetry';
 import {NativeConnection, Worker, type WorkerOptions} from '@temporalio/worker';
 import {loadProductionWorkflowBundle} from './bundle.js';
@@ -9,6 +10,7 @@ import {
   getWorkflowSinks,
 } from './interceptors.js';
 import {installTemporalRuntime} from './runtime.js';
+import type {WorkflowErrorReport} from './workflow-error-interceptor.js';
 
 export interface CreateWorkerOptions {
   connection?: NativeConnection;
@@ -53,7 +55,39 @@ export async function createTemporalWorker(options: CreateWorkerOptions): Promis
     namespace: config.TEMPORAL_NAMESPACE,
     taskQueue,
     activities: options.activities,
-    sinks: getWorkflowSinks(),
+    sinks: {
+      ...getWorkflowSinks(),
+      shipfoxErrorMonitoring: {
+        reportWorkflowError: {
+          callDuringReplay: false,
+          fn: (_info, report: WorkflowErrorReport) => {
+            const error = new Error(report.message);
+            error.name = report.name;
+            if (report.stack) error.stack = report.stack;
+            logger().error(
+              {
+                err: error,
+                workflowType: report.workflowType,
+                taskQueue: report.taskQueue,
+                workflowId: report.workflowId,
+                runId: report.runId,
+                attempt: report.attempt,
+              },
+              'Temporal workflow failed unexpectedly',
+            );
+            reportError(error, {
+              boundary: 'temporal.workflow',
+              tags: {workflowType: report.workflowType, taskQueue: report.taskQueue},
+              extra: {
+                workflowId: report.workflowId,
+                runId: report.runId,
+                attempt: report.attempt,
+              },
+            });
+          },
+        },
+      },
+    },
     interceptors: {
       ...getWorkerInterceptors(),
       ...workflowInterceptors,

--- a/libs/shared/node/temporal/src/workflow-error-interceptor.test.ts
+++ b/libs/shared/node/temporal/src/workflow-error-interceptor.test.ts
@@ -1,0 +1,57 @@
+const mocks = vi.hoisted(() => ({
+  reportWorkflowError: vi.fn(),
+  workflowInfo: vi.fn(),
+}));
+
+const temporal = vi.hoisted(() => ({TemporalFailure: class extends Error {}}));
+
+vi.mock('@temporalio/common', () => ({TemporalFailure: temporal.TemporalFailure}));
+
+vi.mock('@temporalio/workflow', () => ({
+  proxySinks: () => ({shipfoxErrorMonitoring: {reportWorkflowError: mocks.reportWorkflowError}}),
+  workflowInfo: mocks.workflowInfo,
+}));
+
+import {interceptors} from './workflow-error-interceptor.js';
+
+beforeEach(() => {
+  mocks.reportWorkflowError.mockReset();
+  mocks.workflowInfo.mockReturnValue({
+    workflowType: 'dispatch',
+    taskQueue: 'workflows',
+    workflowId: 'workflow-1',
+    runId: 'run-1',
+    attempt: 2,
+  });
+});
+
+describe('workflow error interceptor', () => {
+  test('reports workflow-code defects with safe workflow metadata and rethrows them', async () => {
+    const error = new Error('workflow failed');
+    const interceptor = interceptors().inbound?.[0];
+
+    const result = interceptor?.execute?.({} as never, () => Promise.reject(error));
+
+    await expect(result).rejects.toBe(error);
+    expect(mocks.reportWorkflowError).toHaveBeenCalledWith({
+      name: 'Error',
+      message: 'workflow failed',
+      stack: error.stack,
+      workflowType: 'dispatch',
+      taskQueue: 'workflows',
+      workflowId: 'workflow-1',
+      runId: 'run-1',
+      attempt: 2,
+    });
+  });
+
+  test('does not report Temporal control-flow failures', async () => {
+    const error = new temporal.TemporalFailure('cancelled');
+    const interceptor = interceptors().inbound?.[0];
+
+    const result = interceptor?.execute?.({} as never, () => Promise.reject(error));
+
+    await expect(result).rejects.toBe(error);
+    expect(mocks.reportWorkflowError).not.toHaveBeenCalled();
+  });
+});

--- a/libs/shared/node/temporal/src/workflow-error-interceptor.ts
+++ b/libs/shared/node/temporal/src/workflow-error-interceptor.ts
@@ -1,0 +1,60 @@
+import {TemporalFailure} from '@temporalio/common';
+import {
+  type Next,
+  proxySinks,
+  type Sinks,
+  type WorkflowExecuteInput,
+  type WorkflowInboundCallsInterceptor,
+  type WorkflowInterceptors,
+  workflowInfo,
+} from '@temporalio/workflow';
+
+interface ErrorMonitoringSinks extends Sinks {
+  shipfoxErrorMonitoring: {
+    reportWorkflowError(error: WorkflowErrorReport): void;
+  };
+}
+
+export interface WorkflowErrorReport {
+  name: string;
+  message: string;
+  stack?: string;
+  workflowType: string;
+  taskQueue: string;
+  workflowId: string;
+  runId: string;
+  attempt: number;
+}
+
+const {shipfoxErrorMonitoring} = proxySinks<ErrorMonitoringSinks>();
+
+class WorkflowErrorInterceptor implements WorkflowInboundCallsInterceptor {
+  async execute(
+    input: WorkflowExecuteInput,
+    next: Next<WorkflowInboundCallsInterceptor, 'execute'>,
+  ): Promise<unknown> {
+    try {
+      return await next(input);
+    } catch (error) {
+      if (!(error instanceof TemporalFailure)) {
+        const info = workflowInfo();
+        const report: WorkflowErrorReport = {
+          name: error instanceof Error ? error.name : 'NonErrorThrown',
+          message: error instanceof Error ? error.message : 'Non-Error value thrown',
+          workflowType: info.workflowType,
+          taskQueue: info.taskQueue,
+          workflowId: info.workflowId,
+          runId: info.runId,
+          attempt: info.attempt,
+        };
+        if (error instanceof Error && error.stack) report.stack = error.stack;
+        shipfoxErrorMonitoring.reportWorkflowError(report);
+      }
+      throw error;
+    }
+  }
+}
+
+export function interceptors(): WorkflowInterceptors {
+  return {inbound: [new WorkflowErrorInterceptor()]};
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1813,6 +1813,9 @@ importers:
       '@shipfox/node-egress-guard':
         specifier: workspace:*
         version: link:../../shared/node/egress-guard
+      '@shipfox/node-error-monitoring':
+        specifier: workspace:*
+        version: link:../../shared/node/error-monitoring
       '@shipfox/node-fastify':
         specifier: workspace:*
         version: link:../../shared/node/fastify
@@ -2220,6 +2223,9 @@ importers:
       '@shipfox/node-drizzle':
         specifier: workspace:*
         version: link:../../shared/node/drizzle
+      '@shipfox/node-error-monitoring':
+        specifier: workspace:*
+        version: link:../../shared/node/error-monitoring
       '@shipfox/node-fastify':
         specifier: workspace:*
         version: link:../../shared/node/fastify
@@ -2518,6 +2524,9 @@ importers:
       '@shipfox/node-drizzle':
         specifier: workspace:*
         version: link:../../../shared/node/drizzle
+      '@shipfox/node-error-monitoring':
+        specifier: workspace:*
+        version: link:../../../shared/node/error-monitoring
       '@shipfox/node-fastify':
         specifier: workspace:*
         version: link:../../../shared/node/fastify
@@ -2747,6 +2756,9 @@ importers:
       '@shipfox/node-drizzle':
         specifier: workspace:*
         version: link:../../../shared/node/drizzle
+      '@shipfox/node-error-monitoring':
+        specifier: workspace:*
+        version: link:../../../shared/node/error-monitoring
       '@shipfox/node-fastify':
         specifier: workspace:*
         version: link:../../../shared/node/fastify
@@ -3344,6 +3356,9 @@ importers:
       '@shipfox/node-drizzle':
         specifier: workspace:*
         version: link:../../shared/node/drizzle
+      '@shipfox/node-error-monitoring':
+        specifier: workspace:*
+        version: link:../../shared/node/error-monitoring
       '@shipfox/node-fastify':
         specifier: workspace:*
         version: link:../../shared/node/fastify
@@ -3612,6 +3627,9 @@ importers:
       '@shipfox/node-drizzle':
         specifier: workspace:*
         version: link:../../shared/node/drizzle
+      '@shipfox/node-error-monitoring':
+        specifier: workspace:*
+        version: link:../../shared/node/error-monitoring
       '@shipfox/node-fastify':
         specifier: workspace:*
         version: link:../../shared/node/fastify
@@ -3980,6 +3998,9 @@ importers:
       '@shipfox/node-drizzle':
         specifier: workspace:*
         version: link:../../shared/node/drizzle
+      '@shipfox/node-error-monitoring':
+        specifier: workspace:*
+        version: link:../../shared/node/error-monitoring
       '@shipfox/node-fastify':
         specifier: workspace:*
         version: link:../../shared/node/fastify
@@ -6639,6 +6660,12 @@ importers:
       '@shipfox/typescript':
         specifier: workspace:*
         version: link:../../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../../tools/vitest
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   libs/shared/node/fastify:
     dependencies:
@@ -6775,6 +6802,9 @@ importers:
       '@shipfox/node-drizzle':
         specifier: workspace:*
         version: link:../drizzle
+      '@shipfox/node-error-monitoring':
+        specifier: workspace:*
+        version: link:../error-monitoring
       '@shipfox/node-fastify':
         specifier: workspace:*
         version: link:../fastify
@@ -7004,6 +7034,9 @@ importers:
       '@shipfox/config':
         specifier: workspace:*
         version: link:../../common/config
+      '@shipfox/node-error-monitoring':
+        specifier: workspace:*
+        version: link:../error-monitoring
       '@shipfox/node-opentelemetry':
         specifier: workspace:*
         version: link:../opentelemetry


### PR DESCRIPTION
Add a shared, deduplicating error-reporting boundary and wire it through API request handling, startup/shutdown, module lifecycles, Temporal execution, inter-module dispatch, and best-effort background work.

Unexpected failures previously reached Sentry inconsistently, often without ownership context, while errors crossing multiple boundaries could produce duplicate events. This gives each boundary safe, bounded metadata and preserves expected client, provider, cancellation, and retry behavior.

The implementation keeps reporting decisions at the boundary that owns the failure rather than adding global catch-all instrumentation. Known domain/provider failures remain excluded; opaque inter-module defects and unexpected Temporal workflow/activity failures are captured once.

Please review the reporting contract and marker semantics in `@shipfox/node-error-monitoring`, plus the Temporal workflow sink/interceptor split and module shutdown aggregation behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds boundary-owned, deduplicated error reporting across API, module, and Temporal runtimes using `@shipfox/node-error-monitoring`. Each unexpected failure is reported once with safe tags/extras and a matching structured log; expected client/provider/cancellation paths are not reported.

- **New Features**
  - Adds `reportError`, `markErrorReported`, and `isErrorReported` in `@shipfox/node-error-monitoring` (keeps `captureException`); uses a local Sentry scope and `sendDefaultPii: false`.
  - HTTP default error handler reports `http.unhandled` with method/route and `requestId`.
  - Temporal: adds an activity inbound error interceptor and a workflow inbound interceptor/sink to report defects (cancellations excluded); activities mark non-`unknown` `ApplicationFailure`s reported.
  - Inter-module: in-memory transport accepts `reportInternalError`; API wires it; opaque client errors are marked reported when a reporter exists to avoid duplicates.
  - API lifecycle: reports startup/runtime/shutdown failures and cleanup timeouts; aggregates and marks multi-error shutdowns reported.
  - Subsystems now report unexpected failures with scoped context:
    - Dispatcher: drain loop, handler, claim-renewal, and payload validation.
    - Integrations: agent tool provider unavailability and session/transport/server close/audit errors; GitHub installation token cache writes/backoff.
    - Logs: multipart aborts, invalid compaction object deletes, retention/reap/compaction reconcile.
    - Runners: reservation release on disconnect.
    - Triggers: cron drain and history writes.
  - CONTRIBUTING and `@shipfox/node-error-monitoring` README document the reporting policy.

- **Migration**
  - Use `reportError(error, {boundary, operation?, tags?, extra?})` at the owning boundary and write a matching structured error log. Do not include request bodies, headers, cookies, tokens, or payloads.
  - Temporal: ignore cancellations; when translating to `ApplicationFailure`, mark non-`unknown` errors reported to dedupe.
  - Inter-module: pass a `reportInternalError` when creating the transport; opaque errors from calls with a reporter are already marked reported.

<sup>Written for commit ac8daba28ad12f66bf1b4758d9f1b798300667be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

