### PR TITLE
Fix application release publishing

### DIFF
--- a/.changeset/clever-otters-publish.md
+++ b/.changeset/clever-otters-publish.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/application-release": patch
+---
+
+Fixes publishing application-release packages that use private workspace test tooling.

--- a/tools/package-release/src/publish-productionized-closure.ts
+++ b/tools/package-release/src/publish-productionized-closure.ts
@@ -33,13 +33,31 @@ export function findClosureManifests(root: string, packageNames: string[]): stri
   });
 }
 
+export function findPublishableToolManifests(root: string): string[] {
+  return globSync(join(root, 'tools/**/package.json')).filter((manifestPath) => {
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as JsonRecord;
+    return manifest.private !== true;
+  });
+}
+
+function productionizePublishManifest(manifest: JsonRecord): JsonRecord {
+  const productionized = productionizeManifest(manifest);
+  if (!('devDependencies' in productionized)) return productionized;
+
+  const {devDependencies: _, ...publishManifest} = productionized;
+  return publishManifest;
+}
+
 export async function publishProductionizedClosure<T>({
   root,
   packageNames,
   publish,
   onPrepared,
 }: PublishProductionizedClosureOptions<T>): Promise<T> {
-  const manifestPaths = findClosureManifests(root, packageNames);
+  const manifestPaths = [
+    ...findClosureManifests(root, packageNames),
+    ...findPublishableToolManifests(root),
+  ];
   const originalManifests = new Map(
     manifestPaths.map((manifestPath) => [manifestPath, readFileSync(manifestPath, 'utf8')]),
   );
@@ -51,7 +69,7 @@ export async function publishProductionizedClosure<T>({
 
   for (const [manifestPath, originalManifest] of originalManifests) {
     const manifest = JSON.parse(originalManifest) as JsonRecord;
-    const productionized = productionizeManifest(manifest);
+    const productionized = productionizePublishManifest(manifest);
     if (productionized === manifest) continue;
     writeFileSync(manifestPath, `${JSON.stringify(productionized, null, 2)}\n`);
   }

--- a/tools/package-release/test/publish-productionized-closure.test.ts
+++ b/tools/package-release/test/publish-productionized-closure.test.ts
@@ -6,6 +6,7 @@ import {pathToFileURL} from 'node:url';
 
 import {
   findClosureManifests,
+  findPublishableToolManifests,
   getRepositoryRoot,
   publishProductionizedClosure,
 } from '../src/publish-productionized-closure.js';
@@ -42,6 +43,12 @@ function createFixture(packages: Array<[string, JsonRecord]>) {
   }
 
   return root;
+}
+
+function createToolFixture(root: string, directory: string, manifest: JsonRecord) {
+  const packageDirectory = join(root, 'tools', directory);
+  mkdirSync(packageDirectory, {recursive: true});
+  writeFileSync(join(packageDirectory, 'package.json'), `${JSON.stringify(manifest, null, 2)}\n`);
 }
 
 function closureManifest(name: string) {
@@ -93,11 +100,39 @@ describe('findClosureManifests', () => {
   });
 });
 
+describe('findPublishableToolManifests', () => {
+  test('finds public tool manifests and ignores private tooling', () => {
+    const root = createFixture([]);
+    const publicToolPath = join(root, 'tools', 'public-tool', 'package.json');
+    createToolFixture(root, 'public-tool', {name: '@shipfox/public-tool', version: '1.0.0'});
+    createToolFixture(root, 'private-tool', {name: '@shipfox/private-tool', private: true});
+
+    const manifests = findPublishableToolManifests(root);
+
+    assert.deepEqual(manifests, [publicToolPath]);
+  });
+});
+
 describe('publishProductionizedClosure', () => {
   test('publishes productionized manifests and restores them after success', async () => {
-    const root = createFixture([['one', closureManifest('@shipfox/one')]]);
+    const root = createFixture([
+      [
+        'one',
+        {
+          ...closureManifest('@shipfox/one'),
+          devDependencies: {'@shipfox/private-tool': 'workspace:*'},
+        },
+      ],
+    ]);
     const manifestPath = join(root, 'libs', 'one', 'package.json');
+    const toolManifestPath = join(root, 'tools', 'public-tool', 'package.json');
     const originalManifest = readFileSync(manifestPath, 'utf8');
+    createToolFixture(root, 'public-tool', {
+      name: '@shipfox/public-tool',
+      version: '1.0.0',
+      devDependencies: {'@shipfox/private-tool': 'workspace:*'},
+    });
+    const originalToolManifest = readFileSync(toolManifestPath, 'utf8');
 
     const status = await publishProductionizedClosure({
       root,
@@ -108,12 +143,16 @@ describe('publishProductionizedClosure', () => {
         assert.deepEqual(manifest.exports, {
           '.': {types: './dist/index.d.ts', default: './dist/index.js'},
         });
+        assert.equal(manifest.devDependencies, undefined);
+        const toolManifest = JSON.parse(readFileSync(toolManifestPath, 'utf8'));
+        assert.equal(toolManifest.devDependencies, undefined);
         return 0;
       },
     });
 
     assert.equal(status, 0);
     assert.equal(readFileSync(manifestPath, 'utf8'), originalManifest);
+    assert.equal(readFileSync(toolManifestPath, 'utf8'), originalToolManifest);
   });
 
   test('restores manifests after a non-zero publish status or publish failure', async () => {


### PR DESCRIPTION
Prepare public tool manifests before Changesets publishes them, removing development-only dependencies from the temporary package manifest.

@shipfox/application-release retained a workspace reference to private release tooling while the existing artifact verifier only exercised staged manifests. pnpm therefore failed before publishing the public CLI. The release preparation now applies the same publish-safe treatment to every non-private tool package and restores the source manifests afterward.

Adds a patch changeset for @shipfox/application-release so the repaired publication path is exercised by the next release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failed publishes for `@shipfox/application-release` by preparing publish-safe manifests for all public tool packages and closures before Changesets runs. We strip devDependencies (e.g., workspace links to private tooling) and restore the originals afterward.

- **Bug Fixes**
  - Include non-private tool package manifests in the productionization step.
  - Remove devDependencies from publish manifests to avoid private workspace links.
  - Restore original manifests after publish or failure.
  - Add tests for tool discovery and a patch changeset for `@shipfox/application-release`.

<sup>Written for commit 930cf90899ab85b4242bd9ee44c7aeb44d6777a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

