### PR TITLE
[node-auth-root-key] Republish Node 24-compatible package

### DIFF
--- a/.changeset/clean-keys-compile.md
+++ b/.changeset/clean-keys-compile.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/node-auth-root-key": patch
+---
+
+Republishes the auth root key package with a dist-only runtime entry point for Node 24 consumers.


### PR DESCRIPTION
Republishes `@shipfox/node-auth-root-key` through the corrected package publication path.

Version 0.2.0 was produced before the release wrapper reliably resolved the repository root, so its npm manifest retained the `workspace-source` condition. Under Node 24, Cloud's Vitest suite then selected `src/index.ts` from `node_modules` and failed before route tests ran.

The repository-root and productionized-manifest fix is already on `main`; this changeset is intentionally the only diff needed to publish a dist-only `0.2.1` artifact. The release pipeline will propagate its normal internal dependency updates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Republishes `@shipfox/node-auth-root-key` as a dist-only build to restore Node 24 compatibility. Removes the `workspace-source` condition so Node 24 resolves compiled JS instead of `src/`.

<sup>Written for commit cdf702f6ee286fb9faae189a83f0ed34fdc2f684. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

