### PR TITLE
Add local worktree port leases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,9 +110,11 @@ SHIPFOX_OLLAMA_KEEP_ALIVE=2h mise run ollama:up
 ### Conductor Worktree Services
 
 Conductor workspaces run `dev/worktree-services.mjs up` during setup. This
-creates per-worktree Docker services, assigns ports from `CONDUCTOR_PORT`, and
-writes the generated app environment to `.context/local-services/env`, which is
-loaded by `mise.toml`.
+creates per-worktree Docker services, leases a 20-port block from
+`~/.shipfox/shipfox-port-leases.json`, and writes the generated app environment
+to `.context/local-services/env`, which is loaded by `mise.toml`. The port lease
+does not depend on Conductor environment variables, so it also works from an
+ordinary git worktree or clone.
 
 Common commands:
 
@@ -120,10 +122,14 @@ Common commands:
 mise exec -- node dev/worktree-services.mjs status
 mise exec -- node dev/worktree-services.mjs stop
 mise exec -- node dev/worktree-services.mjs destroy
+mise exec -- node dev/worktree-services.mjs cleanup
 ```
 
 `destroy` removes the worktree Docker volumes and generated local-service state.
 The shared Ollama service is intentionally not stopped during workspace archive.
+`cleanup` only reports leases whose workspace path no longer exists. Run
+`mise exec -- node dev/worktree-services.mjs cleanup --apply` to remove the
+reported leases.
 
 ## Writing Documentation
 

--- a/dev/worktree-services.mjs
+++ b/dev/worktree-services.mjs
@@ -1,13 +1,19 @@
 #!/usr/bin/env node
 import {spawnSync} from 'node:child_process';
 import {createHash} from 'node:crypto';
-import {existsSync, mkdirSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
-import {dirname, resolve} from 'node:path';
+import {existsSync, mkdirSync, readFileSync, rmdirSync, rmSync, writeFileSync} from 'node:fs';
+import {homedir} from 'node:os';
+import {basename, dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 
 const composeProjectNameMaxLength = 63;
 const composeProjectNamePrefix = 'shipfox-';
 const composeFileName = 'compose.yml';
+const portLeaseDirectory = resolve(homedir(), '.shipfox');
+const portLeasesFile = resolve(portLeaseDirectory, 'shipfox-port-leases.json');
+const portRangeStart = 20_000;
+const portRangeEnd = 45_999;
+const portBlockSize = 20;
 const stateDir = resolve('.context/local-services');
 const portsFile = resolve(stateDir, 'ports.env');
 const composeEnvFile = resolve(stateDir, 'compose.env');
@@ -17,17 +23,23 @@ const composeProjectNameLeadingDashes = /^-+/;
 const composeProjectNameTrailingDashes = /-+$/;
 
 if (isCliEntryPoint()) {
-  main(process.argv[2]);
+  main(process.argv.slice(2));
 }
 
-export function main(command) {
-  const commands = new Set(['up', 'stop', 'destroy', 'status']);
-  if (!commands.has(command)) {
+export function main(commandOrArgs) {
+  const [command, ...commandArgs] = Array.isArray(commandOrArgs) ? commandOrArgs : [commandOrArgs];
+  const commands = new Set(['up', 'stop', 'destroy', 'status', 'cleanup']);
+  if (!commands.has(command) || (command !== 'cleanup' && commandArgs.length > 0)) {
     usage();
     process.exit(1);
   }
 
-  const workspaceName = requireConductorWorkspace();
+  if (command === 'cleanup') {
+    cleanup(commandArgs);
+    return;
+  }
+
+  const workspaceName = basename(resolve());
   const projectName = resolveProjectName(workspaceName);
 
   switch (command) {
@@ -49,9 +61,7 @@ export function main(command) {
 function up(workspaceName, projectName) {
   mkdirSync(stateDir, {recursive: true});
 
-  const existing = readEnvFile(portsFile);
-  const ports =
-    Object.keys(existing).length > 0 ? portsFromEnv(existing) : portsFromBase(requireBasePort());
+  const ports = portsFromBase(leasePortBlock());
 
   writeEnvFile(portsFile, {
     SHIPFOX_WORKTREE_SERVICES_WORKSPACE: workspaceName,
@@ -85,12 +95,14 @@ function stop(projectName) {
 function destroy(projectName) {
   if (!existsSync(composeEnvFile)) {
     rmSync(stateDir, {recursive: true, force: true});
+    releasePortLease(resolve());
     return;
   }
   runDockerCompose(projectName, ['down', '-v', '--remove-orphans'], {
     composeFile: resolveComposeFile({allowRootFallback: true}),
   });
   rmSync(stateDir, {recursive: true, force: true});
+  releasePortLease(resolve());
 }
 
 function status(projectName) {
@@ -100,27 +112,147 @@ function status(projectName) {
   });
 }
 
-function requireConductorWorkspace() {
-  const name = process.env.CONDUCTOR_WORKSPACE_NAME;
-  if (!name) {
-    fail('This script must run from a Conductor workspace. CONDUCTOR_WORKSPACE_NAME is not set.');
-  }
-  return name;
-}
-
-function requireBasePort() {
-  const raw = process.env.CONDUCTOR_PORT;
-  const port = parseBasePort(raw);
-  if (port === undefined) {
-    fail('CONDUCTOR_PORT must be set to a valid base port for worktree services.');
-  }
-  return port;
-}
-
 function requireComposeState() {
   if (!existsSync(composeEnvFile)) {
     fail(`Missing ${relativePath(composeEnvFile)}. Run "worktree-services.mjs up" first.`);
   }
+}
+
+function cleanup(args) {
+  if (args.length > 1 || (args[0] !== undefined && args[0] !== '--apply')) {
+    usage();
+    process.exit(1);
+  }
+
+  const staleLeases = findStalePortLeases();
+  if (staleLeases.length === 0) {
+    printLine('No stale Shipfox port leases found.');
+    return;
+  }
+
+  for (const lease of staleLeases) {
+    printLine(`${lease.workspacePath} (${lease.base}-${lease.base + portBlockSize - 1})`);
+  }
+
+  if (args[0] === '--apply') {
+    removeStalePortLeases(staleLeases);
+    printLine(`Removed ${staleLeases.length} stale Shipfox port lease(s).`);
+    return;
+  }
+
+  printLine(
+    `Found ${staleLeases.length} stale Shipfox port lease(s). Run cleanup --apply to remove them.`,
+  );
+}
+
+export function leasePortBlock({workspacePath = resolve(), registryFile = portLeasesFile} = {}) {
+  const resolvedWorkspacePath = resolve(workspacePath);
+  return withPortLeaseLock(() => {
+    const registry = readPortLeaseRegistry(registryFile);
+    const existingLease = registry.leases[resolvedWorkspacePath];
+    if (existingLease) return existingLease.base;
+
+    const base = nextAvailablePortBlock(registry);
+    registry.leases[resolvedWorkspacePath] = {base, allocatedAt: new Date().toISOString()};
+    registry.nextBase = nextPortBlock(base);
+    writePortLeaseRegistry(registry, registryFile);
+    return base;
+  }, registryFile);
+}
+
+export function findStalePortLeases({registryFile = portLeasesFile} = {}) {
+  return withPortLeaseLock(() => {
+    const registry = readPortLeaseRegistry(registryFile);
+    return Object.entries(registry.leases)
+      .filter(([workspacePath]) => !existsSync(workspacePath))
+      .map(([workspacePath, lease]) => ({workspacePath, ...lease}));
+  }, registryFile);
+}
+
+export function removeStalePortLeases(staleLeases, {registryFile = portLeasesFile} = {}) {
+  withPortLeaseLock(() => {
+    const registry = readPortLeaseRegistry(registryFile);
+    for (const {workspacePath} of staleLeases) {
+      if (!existsSync(workspacePath)) delete registry.leases[workspacePath];
+    }
+    writePortLeaseRegistry(registry, registryFile);
+  }, registryFile);
+}
+
+function releasePortLease(workspacePath, registryFile = portLeasesFile) {
+  withPortLeaseLock(() => {
+    const registry = readPortLeaseRegistry(registryFile);
+    delete registry.leases[resolve(workspacePath)];
+    writePortLeaseRegistry(registry, registryFile);
+  }, registryFile);
+}
+
+function withPortLeaseLock(callback, registryFile) {
+  const lockDirectory = resolve(dirname(registryFile), 'shipfox-port-leases.lock');
+  mkdirSync(dirname(registryFile), {recursive: true});
+  try {
+    mkdirSync(lockDirectory);
+  } catch (error) {
+    if (error?.code === 'EEXIST') {
+      fail(
+        `Shipfox port lease registry is in use. Retry after the other workspace setup completes.`,
+      );
+    }
+    throw error;
+  }
+
+  try {
+    return callback();
+  } finally {
+    rmdirSync(lockDirectory);
+  }
+}
+
+function readPortLeaseRegistry(registryFile) {
+  if (!existsSync(registryFile)) {
+    return {
+      version: 1,
+      range: {start: portRangeStart, end: portRangeEnd, blockSize: portBlockSize},
+      nextBase: portRangeStart,
+      leases: {},
+    };
+  }
+
+  const registry = JSON.parse(readFileSync(registryFile, 'utf8'));
+  if (
+    registry.version !== 1 ||
+    registry.range?.start !== portRangeStart ||
+    registry.range?.end !== portRangeEnd ||
+    registry.range?.blockSize !== portBlockSize ||
+    !Number.isInteger(registry.nextBase) ||
+    !registry.leases ||
+    typeof registry.leases !== 'object'
+  ) {
+    fail(`Invalid Shipfox port lease registry: ${registryFile}`);
+  }
+  return registry;
+}
+
+function writePortLeaseRegistry(registry, registryFile) {
+  writeFileSync(registryFile, `${JSON.stringify(registry, null, 2)}\n`);
+}
+
+function nextAvailablePortBlock(registry) {
+  const leasedBases = new Set(Object.values(registry.leases).map((lease) => lease.base));
+  let candidate = registry.nextBase;
+  const capacity = (portRangeEnd - portRangeStart + 1) / portBlockSize;
+
+  for (let attempt = 0; attempt < capacity; attempt += 1) {
+    if (!leasedBases.has(candidate)) return candidate;
+    candidate = nextPortBlock(candidate);
+  }
+
+  fail('Shipfox port lease range is exhausted. Run cleanup to remove stale leases.');
+}
+
+function nextPortBlock(base) {
+  const nextBase = base + portBlockSize;
+  return nextBase + portBlockSize - 1 <= portRangeEnd ? nextBase : portRangeStart;
 }
 
 export function portsFromBase(base) {
@@ -141,41 +273,6 @@ export function portsFromBase(base) {
     slackApi: base + 12,
     otelTemporal: base + 13,
   };
-}
-
-function portsFromEnv(env) {
-  const base = numberFromEnv(env, 'SHIPFOX_PORT_BASE');
-  const ports = {
-    base,
-    client: numberFromEnv(env, 'SHIPFOX_CLIENT_PORT'),
-    api: numberFromEnv(env, 'SHIPFOX_API_PORT'),
-    postgres: numberFromEnv(env, 'SHIPFOX_POSTGRES_PORT'),
-    temporal: numberFromEnv(env, 'SHIPFOX_TEMPORAL_PORT'),
-    docs: optionalNumberFromEnv(env, 'SHIPFOX_DOCS_PORT') ?? base + 4,
-    garageS3: numberFromEnv(env, 'SHIPFOX_GARAGE_S3_PORT'),
-    giteaHttp: numberFromEnv(env, 'SHIPFOX_GITEA_HTTP_PORT'),
-    giteaSsh: numberFromEnv(env, 'SHIPFOX_GITEA_SSH_PORT'),
-    otelInstance: numberFromEnv(env, 'SHIPFOX_OTEL_INSTANCE_METRICS_PORT'),
-    otelService: numberFromEnv(env, 'SHIPFOX_OTEL_SERVICE_METRICS_PORT'),
-    linearMcp: optionalNumberFromEnv(env, 'SHIPFOX_LINEAR_MCP_PORT') ?? base + 10,
-    githubApi: optionalNumberFromEnv(env, 'SHIPFOX_GITHUB_API_PORT') ?? base + 11,
-    slackApi: optionalNumberFromEnv(env, 'SHIPFOX_SLACK_API_PORT') ?? base + 12,
-    otelTemporal: optionalNumberFromEnv(env, 'SHIPFOX_OTEL_TEMPORAL_METRICS_PORT') ?? base + 13,
-  };
-  return ports;
-}
-
-function numberFromEnv(env, key) {
-  const port = parsePort(env[key]);
-  if (port === undefined) {
-    fail(`${portsFile} contains an invalid ${key}: ${env[key] ?? '<missing>'}`);
-  }
-  return port;
-}
-
-function optionalNumberFromEnv(env, key) {
-  if (env[key] === undefined) return undefined;
-  return numberFromEnv(env, key);
 }
 
 function portEnv(ports) {
@@ -312,16 +409,6 @@ export function parseEnvFile(content) {
   return entries;
 }
 
-export function parsePort(raw) {
-  const port = Number(raw);
-  return Number.isInteger(port) && port > 0 && port <= 65_535 ? port : undefined;
-}
-
-export function parseBasePort(raw) {
-  const port = parsePort(raw);
-  return port !== undefined && port <= 65_522 ? port : undefined;
-}
-
 function writeEnvFile(file, values) {
   const body = `${Object.entries(values)
     .map(([key, value]) => `${key}=${value}`)
@@ -348,7 +435,7 @@ function relativePath(file) {
 }
 
 function usage() {
-  printError('Usage: node dev/worktree-services.mjs <up|stop|destroy|status>');
+  printError('Usage: node dev/worktree-services.mjs <up|stop|destroy|status|cleanup [--apply]>');
 }
 
 function fail(message) {

--- a/dev/worktree-services.mjs
+++ b/dev/worktree-services.mjs
@@ -1,7 +1,15 @@
 #!/usr/bin/env node
 import {spawnSync} from 'node:child_process';
 import {createHash} from 'node:crypto';
-import {existsSync, mkdirSync, readFileSync, rmdirSync, rmSync, writeFileSync} from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import {homedir} from 'node:os';
 import {basename, dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
@@ -23,7 +31,12 @@ const composeProjectNameLeadingDashes = /^-+/;
 const composeProjectNameTrailingDashes = /-+$/;
 
 if (isCliEntryPoint()) {
-  main(process.argv.slice(2));
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    printError(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
 }
 
 export function main(commandOrArgs) {
@@ -39,8 +52,9 @@ export function main(commandOrArgs) {
     return;
   }
 
-  const workspaceName = basename(resolve());
-  const projectName = resolveProjectName(workspaceName);
+  const workspacePath = resolve();
+  const workspaceName = basename(workspacePath);
+  const projectName = resolveProjectName(workspacePath);
 
   switch (command) {
     case 'up':
@@ -65,6 +79,7 @@ function up(workspaceName, projectName) {
 
   writeEnvFile(portsFile, {
     SHIPFOX_WORKTREE_SERVICES_WORKSPACE: workspaceName,
+    SHIPFOX_WORKTREE_SERVICES_WORKSPACE_PATH: resolve(),
     SHIPFOX_WORKTREE_SERVICES_PROJECT: projectName,
     SHIPFOX_PORT_BASE: String(ports.base),
     ...portEnv(ports),
@@ -218,7 +233,12 @@ function readPortLeaseRegistry(registryFile) {
     };
   }
 
-  const registry = JSON.parse(readFileSync(registryFile, 'utf8'));
+  let registry;
+  try {
+    registry = JSON.parse(readFileSync(registryFile, 'utf8'));
+  } catch {
+    fail(`Invalid Shipfox port lease registry: ${registryFile}`);
+  }
   if (
     registry.version !== 1 ||
     registry.range?.start !== portRangeStart ||
@@ -234,7 +254,9 @@ function readPortLeaseRegistry(registryFile) {
 }
 
 function writePortLeaseRegistry(registry, registryFile) {
-  writeFileSync(registryFile, `${JSON.stringify(registry, null, 2)}\n`);
+  const tempFile = `${registryFile}.${process.pid}.tmp`;
+  writeFileSync(tempFile, `${JSON.stringify(registry, null, 2)}\n`);
+  renameSync(tempFile, registryFile);
 }
 
 function nextAvailablePortBlock(registry) {
@@ -369,17 +391,22 @@ export function resolveComposeFile({
   fail(`Missing ${relativePath(workspaceComposeFile)}.`);
 }
 
-function resolveProjectName(workspaceName) {
+function resolveProjectName(workspacePath) {
   const existing = readEnvFile(portsFile);
-  return existing.SHIPFOX_WORKTREE_SERVICES_PROJECT || composeProjectName(workspaceName);
+  if (existing.SHIPFOX_WORKTREE_SERVICES_WORKSPACE_PATH === workspacePath) {
+    return existing.SHIPFOX_WORKTREE_SERVICES_PROJECT;
+  }
+  return composeProjectName(workspacePath);
 }
 
-export function composeProjectName(workspaceName) {
+export function composeProjectName(workspacePath) {
+  const resolvedWorkspacePath = resolve(workspacePath);
+  const workspaceName = basename(resolvedWorkspacePath);
   const normalized = workspaceName
     .toLowerCase()
     .replace(composeProjectNameInvalidChars, '-')
     .replace(composeProjectNameLeadingDashes, '');
-  const hash = createHash('sha256').update(workspaceName).digest('hex').slice(0, 8);
+  const hash = createHash('sha256').update(resolvedWorkspacePath).digest('hex').slice(0, 8);
   const suffixLength =
     composeProjectNameMaxLength - composeProjectNamePrefix.length - hash.length - 1;
   const suffix =
@@ -439,8 +466,7 @@ function usage() {
 }
 
 function fail(message) {
-  printError(message);
-  process.exit(1);
+  throw new Error(message);
 }
 
 function isCliEntryPoint() {

--- a/dev/worktree-services.test.mjs
+++ b/dev/worktree-services.test.mjs
@@ -7,10 +7,11 @@ import {describe, test} from 'node:test';
 import {
   appEnv,
   composeProjectName,
-  parseBasePort,
+  findStalePortLeases,
+  leasePortBlock,
   parseEnvFile,
-  parsePort,
   portsFromBase,
+  removeStalePortLeases,
   resolveComposeFile,
 } from './worktree-services.mjs';
 
@@ -18,24 +19,24 @@ const longShipfoxProjectName = /^shipfox-a+-[a-f0-9]{8}$/;
 
 describe('portsFromBase', () => {
   test('assigns stable offsets from the base port', () => {
-    const ports = portsFromBase(65_000);
+    const ports = portsFromBase(20_000);
 
     assert.deepEqual(ports, {
-      base: 65_000,
-      client: 65_000,
-      api: 65_001,
-      postgres: 65_002,
-      temporal: 65_003,
-      docs: 65_004,
-      garageS3: 65_005,
-      giteaHttp: 65_006,
-      giteaSsh: 65_007,
-      otelInstance: 65_008,
-      otelService: 65_009,
-      linearMcp: 65_010,
-      githubApi: 65_011,
-      slackApi: 65_012,
-      otelTemporal: 65_013,
+      base: 20_000,
+      client: 20_000,
+      api: 20_001,
+      postgres: 20_002,
+      temporal: 20_003,
+      docs: 20_004,
+      garageS3: 20_005,
+      giteaHttp: 20_006,
+      giteaSsh: 20_007,
+      otelInstance: 20_008,
+      otelService: 20_009,
+      linearMcp: 20_010,
+      githubApi: 20_011,
+      slackApi: 20_012,
+      otelTemporal: 20_013,
     });
   });
 });
@@ -72,14 +73,14 @@ describe('composeProjectName', () => {
 
 describe('appEnv', () => {
   test('sets runner container host access for worktree APIs', () => {
-    const env = appEnv(portsFromBase(55_290));
+    const env = appEnv(portsFromBase(20_000));
 
-    assert.equal(env.SHIPFOX_RUNNER_API_URL, 'http://host.docker.internal:55291');
+    assert.equal(env.SHIPFOX_RUNNER_API_URL, 'http://host.docker.internal:20001');
     assert.equal(env.SHIPFOX_PROVISIONER_DOCKER_EXTRA_HOSTS, 'host.docker.internal:host-gateway');
-    assert.equal(env.SHIPFOX_DOCS_PORT, '55294');
-    assert.equal(env.LINEAR_MCP_ENDPOINT, 'http://127.0.0.1:55300/mcp');
-    assert.equal(env.GITHUB_API_BASE_URL, 'http://127.0.0.1:55301');
-    assert.equal(env.SLACK_API_BASE_URL, 'http://127.0.0.1:55302');
+    assert.equal(env.SHIPFOX_DOCS_PORT, '20004');
+    assert.equal(env.LINEAR_MCP_ENDPOINT, 'http://127.0.0.1:20010/mcp');
+    assert.equal(env.GITHUB_API_BASE_URL, 'http://127.0.0.1:20011');
+    assert.equal(env.SLACK_API_BASE_URL, 'http://127.0.0.1:20012');
   });
 });
 
@@ -150,25 +151,46 @@ describe('parseEnvFile', () => {
   });
 });
 
-describe('parsePort', () => {
-  test('accepts TCP port bounds', () => {
-    assert.equal(parsePort('1'), 1);
-    assert.equal(parsePort('65535'), 65_535);
+describe('port leases', () => {
+  test('allocates 20-port blocks and reuses a workspace lease', () => {
+    const registryDirectory = mkdtempSync(join(tmpdir(), 'shipfox-port-leases-'));
+    const registryFile = join(registryDirectory, 'shipfox-port-leases.json');
+    const firstWorkspace = join(registryDirectory, 'first');
+    const secondWorkspace = join(registryDirectory, 'second');
+    mkdirSync(firstWorkspace);
+    mkdirSync(secondWorkspace);
+
+    try {
+      assert.equal(leasePortBlock({workspacePath: firstWorkspace, registryFile}), 20_000);
+      assert.equal(leasePortBlock({workspacePath: firstWorkspace, registryFile}), 20_000);
+      assert.equal(leasePortBlock({workspacePath: secondWorkspace, registryFile}), 20_020);
+    } finally {
+      rmSync(registryDirectory, {recursive: true, force: true});
+    }
   });
 
-  test('rejects missing, non-integer, and out-of-range values', () => {
-    assert.equal(parsePort(undefined), undefined);
-    assert.equal(parsePort(''), undefined);
-    assert.equal(parsePort('0'), undefined);
-    assert.equal(parsePort('12.5'), undefined);
-    assert.equal(parsePort('65536'), undefined);
-    assert.equal(parsePort('abc'), undefined);
-  });
-});
+  test('reports and removes only leases whose workspace no longer exists', () => {
+    const registryDirectory = mkdtempSync(join(tmpdir(), 'shipfox-port-leases-'));
+    const registryFile = join(registryDirectory, 'shipfox-port-leases.json');
+    const activeWorkspace = join(registryDirectory, 'active');
+    const deletedWorkspace = join(registryDirectory, 'deleted');
+    mkdirSync(activeWorkspace);
+    mkdirSync(deletedWorkspace);
 
-describe('parseBasePort', () => {
-  test('keeps the base port low enough for every service offset', () => {
-    assert.equal(parseBasePort('65522'), 65_522);
-    assert.equal(parseBasePort('65523'), undefined);
+    try {
+      leasePortBlock({workspacePath: activeWorkspace, registryFile});
+      leasePortBlock({workspacePath: deletedWorkspace, registryFile});
+      rmSync(deletedWorkspace, {recursive: true});
+
+      const staleLeases = findStalePortLeases({registryFile});
+
+      assert.equal(staleLeases.length, 1);
+      assert.equal(staleLeases[0].workspacePath, deletedWorkspace);
+      assert.equal(staleLeases[0].base, 20_020);
+      removeStalePortLeases(staleLeases, {registryFile});
+      assert.deepEqual(findStalePortLeases({registryFile}), []);
+    } finally {
+      rmSync(registryDirectory, {recursive: true, force: true});
+    }
   });
 });

--- a/dev/worktree-services.test.mjs
+++ b/dev/worktree-services.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {describe, test} from 'node:test';
@@ -16,6 +16,8 @@ import {
 } from './worktree-services.mjs';
 
 const longShipfoxProjectName = /^shipfox-a+-[a-f0-9]{8}$/;
+const normalizedShipfoxProjectName = /^shipfox-kolkata-workspace-[a-f0-9]{8}$/;
+const fallbackShipfoxProjectName = /^shipfox-workspace-[a-f0-9]{8}$/;
 
 describe('portsFromBase', () => {
   test('assigns stable offsets from the base port', () => {
@@ -42,22 +44,22 @@ describe('portsFromBase', () => {
 });
 
 describe('composeProjectName', () => {
-  test('normalizes workspace names into Compose project names', () => {
-    const projectName = composeProjectName('Kolkata ! Workspace');
+  test('uses the workspace name in a Compose project name', () => {
+    const projectName = composeProjectName('/tmp/Kolkata ! Workspace');
 
-    assert.equal(projectName, 'shipfox-kolkata-workspace-f5f09833');
+    assert.match(projectName, normalizedShipfoxProjectName);
   });
 
   test('caps project names at the Docker Compose limit with a stable hash suffix', () => {
-    const projectName = composeProjectName('a'.repeat(100));
+    const projectName = composeProjectName(`/tmp/${'a'.repeat(100)}`);
 
     assert.equal(projectName.length, 63);
     assert.match(projectName, longShipfoxProjectName);
   });
 
   test('keeps long workspace names distinct after truncation', () => {
-    const first = composeProjectName(`${'a'.repeat(100)}-first`);
-    const second = composeProjectName(`${'a'.repeat(100)}-second`);
+    const first = composeProjectName(`/tmp/${'a'.repeat(100)}`);
+    const second = composeProjectName(`/other/${'a'.repeat(100)}`);
 
     assert.notEqual(first, second);
     assert.equal(first.length, 63);
@@ -65,9 +67,9 @@ describe('composeProjectName', () => {
   });
 
   test('uses a fallback when normalization removes every character', () => {
-    const projectName = composeProjectName('!!!');
+    const projectName = composeProjectName('/tmp/!!!');
 
-    assert.equal(projectName, 'shipfox-workspace-e84c538e');
+    assert.match(projectName, fallbackShipfoxProjectName);
   });
 });
 
@@ -189,6 +191,21 @@ describe('port leases', () => {
       assert.equal(staleLeases[0].base, 20_020);
       removeStalePortLeases(staleLeases, {registryFile});
       assert.deepEqual(findStalePortLeases({registryFile}), []);
+    } finally {
+      rmSync(registryDirectory, {recursive: true, force: true});
+    }
+  });
+
+  test('releases the registry lock when the registry is invalid', () => {
+    const registryDirectory = mkdtempSync(join(tmpdir(), 'shipfox-port-leases-'));
+    const registryFile = join(registryDirectory, 'shipfox-port-leases.json');
+    const workspace = join(registryDirectory, 'workspace');
+    mkdirSync(workspace);
+    writeFileSync(registryFile, '{invalid');
+
+    try {
+      assert.throws(() => leasePortBlock({workspacePath: workspace, registryFile}));
+      assert.equal(existsSync(join(registryDirectory, 'shipfox-port-leases.lock')), false);
     } finally {
       rmSync(registryDirectory, {recursive: true, force: true});
     }


### PR DESCRIPTION
Replace Conductor-derived workspace ports with a Shipfox-owned, user-local lease registry that assigns contiguous 20-port blocks.

The existing mapping exceeded Conductor's guaranteed 10-port allocation and could collide with adjacent workspaces. The registry is keyed by workspace path, survives repeated setup, and lets ordinary worktrees use the same local-service flow without Conductor environment variables.

The archive hook releases a lease after Docker resources are removed. A new inspect-first cleanup command lists leases whose workspace paths no longer exist; --apply removes only those reported stale leases.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace Conductor-provided ports with a Shipfox-owned, local port lease registry that assigns stable, contiguous 20‑port blocks per workspace. This prevents cross-workspace collisions and enables the same local-service flow from ordinary git worktrees.

- **New Features**
  - Local lease registry at `~/.shipfox/shipfox-port-leases.json` assigns 20‑port blocks in 20000–45999, keyed by workspace path and persisted across setups.
  - New `cleanup` command lists leases whose workspace path no longer exists; run `cleanup --apply` to remove only those. Registry updates are locked with a filesystem lock, written atomically, and locks are released even on errors. `destroy` releases a lease after Docker resources are removed.

- **Refactors**
  - `up` now calls a lease allocator instead of using `CONDUCTOR_PORT`, and the workspace is derived from the current directory, removing the need for Conductor env vars. Compose project names now hash the workspace path to avoid collisions between same‑named folders.

<sup>Written for commit 134efa88dcff3116f7efb03b5fd2e811c1064ad4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

