### PR TITLE
Add safe client persistence primitives

### DIFF
--- a/.changeset/bright-cats-dedupe.md
+++ b/.changeset/bright-cats-dedupe.md
@@ -1,0 +1,10 @@
+---
+"@shipfox/client-ui": minor
+"@shipfox/client-agent": patch
+"@shipfox/client-integrations": patch
+"@shipfox/client-invitations": patch
+"@shipfox/client-projects": patch
+"@shipfox/client-shell": patch
+---
+
+Adds safe browser persistence and bounded callback deduplication across client flows.

--- a/libs/client/agent/src/state/model-provider-onboarding.ts
+++ b/libs/client/agent/src/state/model-provider-onboarding.ts
@@ -1,31 +1,34 @@
-const MODEL_PROVIDER_ONBOARDING_STORAGE_KEY = 'shipfox.modelProviderOnboardingDismissed';
+import {createTypedBrowserStorage, localStorageOrUndefined} from '@shipfox/client-ui';
 
 type DismissedMap = Record<string, true>;
+
+const dismissedStorage = createTypedBrowserStorage(localStorageOrUndefined, {
+  key: 'shipfox.modelProviderOnboardingDismissed',
+  lifetime: 'persistent',
+  principalScope: 'workspace',
+  serialize: (dismissed: DismissedMap) => JSON.stringify(dismissed),
+  parse: (raw) => {
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      return isDismissedMap(parsed) ? parsed : undefined;
+    } catch {
+      return undefined;
+    }
+  },
+});
 
 export function isModelProviderOnboardingDismissed(workspaceId: string): boolean {
   return Boolean(readDismissedMap()[workspaceId]);
 }
 
 export function dismissModelProviderOnboarding(workspaceId: string): void {
-  if (typeof window === 'undefined') return;
-
   const dismissed = readDismissedMap();
   dismissed[workspaceId] = true;
-  window.localStorage.setItem(MODEL_PROVIDER_ONBOARDING_STORAGE_KEY, JSON.stringify(dismissed));
+  dismissedStorage.write(dismissed);
 }
 
 function readDismissedMap(): DismissedMap {
-  if (typeof window === 'undefined') return {};
-
-  try {
-    const raw = window.localStorage.getItem(MODEL_PROVIDER_ONBOARDING_STORAGE_KEY);
-    if (!raw) return {};
-    const parsed: unknown = JSON.parse(raw);
-    if (!isDismissedMap(parsed)) return {};
-    return parsed;
-  } catch {
-    return {};
-  }
+  return dismissedStorage.read() ?? {};
 }
 
 function isDismissedMap(value: unknown): value is DismissedMap {

--- a/libs/client/auth/src/state/last-workspace.test.ts
+++ b/libs/client/auth/src/state/last-workspace.test.ts
@@ -45,6 +45,22 @@ describe('lastWorkspaceIdAtom', () => {
     unsubscribe();
   });
 
+  test('syncs the atom when another tab updates last workspace storage', () => {
+    const store = createStore();
+    const unsubscribe = store.sub(lastWorkspaceIdAtom, () => undefined);
+    window.localStorage.setItem('shipfox.lastWorkspaceId', JSON.stringify('workspace-2'));
+
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: 'shipfox.lastWorkspaceId',
+        storageArea: window.localStorage,
+      }),
+    );
+
+    expect(store.get(lastWorkspaceIdAtom)).toBe('workspace-2');
+    unsubscribe();
+  });
+
   test('rememberLastWorkspaceId persists a root redirect target', () => {
     rememberLastWorkspaceId('workspace-1');
 

--- a/libs/client/integrations/src/pages/linear-callback-page.tsx
+++ b/libs/client/integrations/src/pages/linear-callback-page.tsx
@@ -17,6 +17,8 @@ import {
   serializeLinearCallbackQuery,
 } from '#linear-callback.js';
 
+// Retain only recent completions: this bounds long-lived callback pages while
+// still covering StrictMode and immediate Back/Forward remounts.
 const callbackRequests = createSingleFlight<string, LinearCallbackResponseDto>({
   maxTerminalResults: 32,
 });

--- a/libs/client/integrations/src/pages/linear-callback-page.tsx
+++ b/libs/client/integrations/src/pages/linear-callback-page.tsx
@@ -1,5 +1,6 @@
 import type {LinearCallbackResponseDto} from '@shipfox/api-integration-linear-dto';
 import {useRefreshAuth} from '@shipfox/client-auth';
+import {createSingleFlight} from '@shipfox/client-ui';
 import {FullPageLoader} from '@shipfox/react-ui/loader';
 import {toast} from '@shipfox/react-ui/toast';
 import {useQueryClient} from '@tanstack/react-query';
@@ -16,12 +17,9 @@ import {
   serializeLinearCallbackQuery,
 } from '#linear-callback.js';
 
-// Keyed by the callback's code+state. This page has no in-place Retry (failures
-// route to "Start over", which begins a fresh install with a new state+code), so
-// entries are intentionally never evicted: retaining them dedupes StrictMode and
-// remount re-runs so the single-use grant code is exchanged at most once. The
-// sibling Sentry page evicts on settle only because its Retry replays the code.
-const callbackRequests = new Map<string, Promise<LinearCallbackResponseDto>>();
+const callbackRequests = createSingleFlight<string, LinearCallbackResponseDto>({
+  maxTerminalResults: 32,
+});
 // Keeps the success toast firing once per distinct callback even though the
 // effect re-runs against the cached request as the mutation identity churns.
 const toastedCallbacks = new Set<string>();
@@ -46,13 +44,13 @@ export function LinearCallbackPage() {
 
     let disposed = false;
     const key = serializeLinearCallbackQuery(params);
-    let request = callbackRequests.get(key);
-    if (!request) {
-      request = refreshAuth().then(
-        async (session) => await completeLinearCallback({query: params, token: session.token}),
-      );
-      callbackRequests.set(key, request);
-    }
+    const request = callbackRequests.run(
+      key,
+      async () =>
+        await refreshAuth().then(
+          async (session) => await completeLinearCallback({query: params, token: session.token}),
+        ),
+    );
 
     request.then(
       async (connection) => {

--- a/libs/client/integrations/src/pages/sentry-callback-page.tsx
+++ b/libs/client/integrations/src/pages/sentry-callback-page.tsx
@@ -1,5 +1,6 @@
 import type {SentryConnectResponseDto} from '@shipfox/api-integration-sentry-dto';
 import {useAuthState, useRefreshAuth} from '@shipfox/client-auth';
+import {createSingleFlight} from '@shipfox/client-ui';
 import {Button, ButtonLink} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
 import {Card} from '@shipfox/react-ui/card';
@@ -19,12 +20,7 @@ import {
   type SentryConnectFailure,
 } from '#sentry-callback.js';
 
-// De-dupes concurrent attempts for the same installation+workspace+code
-// (double click, remount while in flight). Entries are evicted once the
-// request settles, so Retry, and any later attempt carrying a fresh grant
-// code, always issues a genuinely new request instead of replaying a cached
-// outcome.
-const connectRequests = new Map<string, Promise<SentryConnectResponseDto>>();
+const connectRequests = createSingleFlight<string, SentryConnectResponseDto>();
 
 export function SentryCallbackPage() {
   const search = useSearch({strict: false});
@@ -102,26 +98,20 @@ export function SentryCallbackPage() {
     setConnectingId(workspaceId);
     setFailure(undefined);
     const key = `${params.installationId}|${workspaceId}|${params.code}`;
-    let request = connectRequests.get(key);
-    if (!request) {
-      request = refreshAuth().then((session) =>
-        connectSentry({
-          body: {
-            workspace_id: workspaceId,
-            code: params.code,
-            installation_id: params.installationId,
-          },
-          token: session.token,
-        }),
-      );
-      // Evict on settle (success or failure) so the key never replays a stale
-      // outcome. Two-arg `then` keeps this cleanup branch from surfacing the
-      // rejection as unhandled — the main chain below owns the user-facing
-      // failure handling.
-      const evict = () => connectRequests.delete(key);
-      request.then(evict, evict);
-      connectRequests.set(key, request);
-    }
+    const request = connectRequests.run(
+      key,
+      async () =>
+        await refreshAuth().then((session) =>
+          connectSentry({
+            body: {
+              workspace_id: workspaceId,
+              code: params.code,
+              installation_id: params.installationId,
+            },
+            token: session.token,
+          }),
+        ),
+    );
 
     request
       .then(async () => {

--- a/libs/client/integrations/src/pages/slack-callback-page.tsx
+++ b/libs/client/integrations/src/pages/slack-callback-page.tsx
@@ -17,6 +17,8 @@ import {
   serializeSlackCallbackQuery,
 } from '#slack-callback.js';
 
+// Retain only recent completions: this bounds long-lived callback pages while
+// still covering StrictMode and immediate Back/Forward remounts.
 const callbackRequests = createSingleFlight<string, SlackCallbackResponseDto>({
   maxTerminalResults: 32,
 });

--- a/libs/client/integrations/src/pages/slack-callback-page.tsx
+++ b/libs/client/integrations/src/pages/slack-callback-page.tsx
@@ -1,5 +1,6 @@
 import type {SlackCallbackResponseDto} from '@shipfox/api-integration-slack-dto';
 import {useRefreshAuth} from '@shipfox/client-auth';
+import {createSingleFlight} from '@shipfox/client-ui';
 import {FullPageLoader} from '@shipfox/react-ui/loader';
 import {toast} from '@shipfox/react-ui/toast';
 import {useQueryClient} from '@tanstack/react-query';
@@ -16,9 +17,9 @@ import {
   serializeSlackCallbackQuery,
 } from '#slack-callback.js';
 
-// Requests and committed keys remain for the document lifetime so Strict Mode,
-// browser Back, and remounts never replay Slack's single-use grant code.
-const callbackRequests = new Map<string, Promise<SlackCallbackResponseDto>>();
+const callbackRequests = createSingleFlight<string, SlackCallbackResponseDto>({
+  maxTerminalResults: 32,
+});
 const completedCallbacks = new Set<string>();
 const toastedCallbacks = new Set<string>();
 
@@ -37,13 +38,13 @@ export function SlackCallbackPage() {
     if (!params) return;
     let disposed = false;
     const key = serializeSlackCallbackQuery(params);
-    let request = callbackRequests.get(key);
-    if (!request) {
-      request = refreshAuth().then(
-        async (session) => await completeSlackCallback({query: params, token: session.token}),
-      );
-      callbackRequests.set(key, request);
-    }
+    const request = callbackRequests.run(
+      key,
+      async () =>
+        await refreshAuth().then(
+          async (session) => await completeSlackCallback({query: params, token: session.token}),
+        ),
+    );
     request.then(
       async (connection) => {
         if (disposed) return;

--- a/libs/client/integrations/src/routes/github-callback.test.ts
+++ b/libs/client/integrations/src/routes/github-callback.test.ts
@@ -1,0 +1,17 @@
+import {ApiError} from '@shipfox/client-api';
+import {githubCallbackErrorMessage} from './github-callback.js';
+
+describe('githubCallbackErrorMessage', () => {
+  it('does not expose an API error message or request URL', () => {
+    const error = new ApiError({
+      code: 'request-failed',
+      message: 'GET https://api.example.test/integrations/github/callback failed',
+      status: 500,
+    });
+
+    const message = githubCallbackErrorMessage(error);
+
+    expect(message).toBe('GitHub could not be installed. Try again from settings.');
+    expect(message).not.toContain('https://');
+  });
+});

--- a/libs/client/integrations/src/routes/github-callback.tsx
+++ b/libs/client/integrations/src/routes/github-callback.tsx
@@ -1,6 +1,7 @@
 import {ApiError, apiRequest} from '@shipfox/client-api';
 import {useRefreshAuth} from '@shipfox/client-auth';
 import {defineRoute} from '@shipfox/client-shell/runtime';
+import {createSingleFlight} from '@shipfox/client-ui';
 import {FullPageLoader} from '@shipfox/react-ui/loader';
 import {toast} from '@shipfox/react-ui/toast';
 import {useNavigate, useSearch} from '@tanstack/react-router';
@@ -13,7 +14,7 @@ interface GithubCallbackParams {
   setupAction?: string;
 }
 
-const callbackRequests = new Map<string, Promise<void>>();
+const callbackRequests = createSingleFlight<string, void>({maxTerminalResults: 32});
 const toastedCallbacks = new Set<string>();
 
 export default defineRoute({component: GithubCallbackRoute});
@@ -40,14 +41,15 @@ function GithubCallbackRoute() {
     }
     let disposed = false;
     const key = encodeCallbackQuery(params);
-    const request =
-      callbackRequests.get(key) ??
-      refreshAuth().then(async (session) => {
-        await apiRequest(`/integrations/github/callback/api?${key}`, {
-          headers: {authorization: `Bearer ${session.token}`},
-        });
-      });
-    callbackRequests.set(key, request);
+    const request = callbackRequests.run(
+      key,
+      async () =>
+        await refreshAuth().then(async (session) => {
+          await apiRequest(`/integrations/github/callback/api?${key}`, {
+            headers: {authorization: `Bearer ${session.token}`},
+          });
+        }),
+    );
     request
       .then(() => {
         if (disposed) return;
@@ -108,7 +110,6 @@ function numberParam(value: unknown): number | undefined {
   return undefined;
 }
 function githubCallbackErrorMessage(error: unknown): string {
-  if (error instanceof ApiError) return error.message;
-  if (error instanceof Error) return error.message;
+  if (error instanceof ApiError) return 'GitHub could not be installed. Try again from settings.';
   return 'Could not install GitHub.';
 }

--- a/libs/client/integrations/src/routes/github-callback.tsx
+++ b/libs/client/integrations/src/routes/github-callback.tsx
@@ -14,6 +14,8 @@ interface GithubCallbackParams {
   setupAction?: string;
 }
 
+// Retain only recent completions: this bounds long-lived callback pages while
+// still covering StrictMode and immediate Back/Forward remounts.
 const callbackRequests = createSingleFlight<string, void>({maxTerminalResults: 32});
 const toastedCallbacks = new Set<string>();
 
@@ -109,7 +111,7 @@ function numberParam(value: unknown): number | undefined {
   }
   return undefined;
 }
-function githubCallbackErrorMessage(error: unknown): string {
+export function githubCallbackErrorMessage(error: unknown): string {
   if (error instanceof ApiError) return 'GitHub could not be installed. Try again from settings.';
   return 'Could not install GitHub.';
 }

--- a/libs/client/invitations/package.json
+++ b/libs/client/invitations/package.json
@@ -65,6 +65,7 @@
     "@shipfox/client-api": "workspace:*",
     "@shipfox/client-auth": "workspace:*",
     "@shipfox/client-shell": "workspace:*",
+    "@shipfox/client-ui": "workspace:*",
     "@shipfox/react-ui": "workspace:*",
     "@swc/helpers": "catalog:",
     "@tanstack/react-query": "catalog:"

--- a/libs/client/invitations/src/pages/invitation-accept-page.tsx
+++ b/libs/client/invitations/src/pages/invitation-accept-page.tsx
@@ -1,4 +1,5 @@
 import {AuthShell, useAuthState, useRefreshAuth} from '@shipfox/client-auth';
+import {createSingleFlight} from '@shipfox/client-ui';
 import {Button} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
 import {ShipfoxLoader} from '@shipfox/react-ui/loader';
@@ -11,9 +12,7 @@ import {completeInvitationAcceptance} from '#complete-acceptance.js';
 import {useAcceptInvitation} from '#hooks/api/accept-invitation.js';
 import {usePreviewInvitation} from '#hooks/api/preview-invitation.js';
 
-// Module-scoped guard so React StrictMode's double-mount in dev does not
-// fire the accept mutation twice for the same token.
-const inFlightAccepts = new Set<string>();
+const invitationAccepts = createSingleFlight<string, void>();
 const toastedTerminals = new Set<string>();
 const TOASTED_TERMINALS_MAX = 32;
 
@@ -65,7 +64,6 @@ export function InvitationAcceptPage() {
     if (!token) return;
     if (auth.isLoading) return;
     if (hasKickedAccept.current) return;
-    if (inFlightAccepts.has(token)) return;
     const data = preview.data;
     if (!data) return;
     if (data.status !== 'pending') return;
@@ -75,15 +73,11 @@ export function InvitationAcceptPage() {
     if (authedEmail !== data.email.toLowerCase()) return;
 
     hasKickedAccept.current = true;
-    inFlightAccepts.add(token);
-
-    runAccept({token, workspaceName: data.workspace_name})
+    invitationAccepts
+      .run(token, async () => await runAccept({token, workspaceName: data.workspace_name}))
       .catch(() => {
         // The mutation surfaces its error via accept.error; the UI re-renders
         // into the auth-match-error state below.
-      })
-      .finally(() => {
-        inFlightAccepts.delete(token);
       });
   }, [auth.isAuthenticated, auth.isLoading, auth.user?.email, preview.data, runAccept, token]);
 

--- a/libs/client/projects/src/components/model-provider-reminder-banner.tsx
+++ b/libs/client/projects/src/components/model-provider-reminder-banner.tsx
@@ -1,4 +1,5 @@
 import {useModelProviderConfigsQuery} from '@shipfox/client-agent';
+import {createTypedBrowserStorage, sessionStorageOrUndefined} from '@shipfox/client-ui';
 import {
   Alert,
   AlertActions,
@@ -10,8 +11,6 @@ import {
 import {Button} from '@shipfox/react-ui/button';
 import {Link} from '@tanstack/react-router';
 import {useState} from 'react';
-
-const REMINDER_SESSION_KEY_PREFIX = 'shipfox.modelProviderReminder.dismissed.';
 
 export function ModelProviderReminderBanner({workspaceId}: {workspaceId: string}) {
   const configsQuery = useModelProviderConfigsQuery(workspaceId);
@@ -54,25 +53,19 @@ export function ModelProviderReminderBanner({workspaceId}: {workspaceId: string}
 }
 
 function isReminderDismissed(workspaceId: string): boolean {
-  if (typeof window === 'undefined') return false;
-
-  try {
-    return window.sessionStorage.getItem(sessionKey(workspaceId)) === 'true';
-  } catch {
-    return false;
-  }
+  return reminderStorage(workspaceId).read() === true;
 }
 
 function dismissReminder(workspaceId: string): void {
-  if (typeof window === 'undefined') return;
-
-  try {
-    window.sessionStorage.setItem(sessionKey(workspaceId), 'true');
-  } catch {
-    // Session persistence is best-effort; showing the banner again is benign.
-  }
+  reminderStorage(workspaceId).write(true);
 }
 
-function sessionKey(workspaceId: string): string {
-  return `${REMINDER_SESSION_KEY_PREFIX}${workspaceId}`;
+function reminderStorage(workspaceId: string) {
+  return createTypedBrowserStorage(sessionStorageOrUndefined, {
+    key: `shipfox.modelProviderReminder.dismissed.${workspaceId}`,
+    lifetime: 'session' as const,
+    principalScope: 'workspace' as const,
+    serialize: (dismissed: boolean) => JSON.stringify(dismissed),
+    parse: (raw: string) => raw === 'true',
+  });
 }

--- a/libs/client/shell/package.json
+++ b/libs/client/shell/package.json
@@ -78,6 +78,7 @@
     "@shipfox/api-workspaces-dto": "workspace:*",
     "@shipfox/client-api": "workspace:*",
     "@shipfox/client-config": "workspace:*",
+    "@shipfox/client-ui": "workspace:*",
     "@shipfox/react-ui": "workspace:*",
     "@swc/helpers": "catalog:",
     "@tanstack/router-core": "catalog:",

--- a/libs/client/shell/src/runtime/last-workspace.ts
+++ b/libs/client/shell/src/runtime/last-workspace.ts
@@ -1,8 +1,10 @@
 import {createTypedBrowserStorage, localStorageOrUndefined} from '@shipfox/client-ui';
 import {atom} from 'jotai';
 
+const lastWorkspaceStorageKey = 'shipfox.lastWorkspaceId';
+
 const lastWorkspaceStorage = createTypedBrowserStorage(localStorageOrUndefined, {
-  key: 'shipfox.lastWorkspaceId',
+  key: lastWorkspaceStorageKey,
   lifetime: 'persistent',
   principalScope: 'principal',
   serialize: (workspaceId: string) => JSON.stringify(workspaceId),
@@ -17,6 +19,16 @@ const lastWorkspaceStorage = createTypedBrowserStorage(localStorageOrUndefined, 
 });
 
 const storedLastWorkspaceIdAtom = atom<string | undefined>(getLastWorkspaceId());
+
+storedLastWorkspaceIdAtom.onMount = (setLastWorkspaceId) => {
+  if (typeof window === 'undefined') return undefined;
+
+  const syncFromStorage = (event: StorageEvent) => {
+    if (event.key === lastWorkspaceStorageKey) setLastWorkspaceId(getLastWorkspaceId());
+  };
+  window.addEventListener('storage', syncFromStorage);
+  return () => window.removeEventListener('storage', syncFromStorage);
+};
 
 export const lastWorkspaceIdAtom = atom(
   (get) => get(storedLastWorkspaceIdAtom),

--- a/libs/client/shell/src/runtime/last-workspace.ts
+++ b/libs/client/shell/src/runtime/last-workspace.ts
@@ -1,22 +1,36 @@
-import {atomWithStorage} from 'jotai/utils';
+import {createTypedBrowserStorage, localStorageOrUndefined} from '@shipfox/client-ui';
+import {atom} from 'jotai';
 
-const storageKey = 'shipfox.lastWorkspaceId';
+const lastWorkspaceStorage = createTypedBrowserStorage(localStorageOrUndefined, {
+  key: 'shipfox.lastWorkspaceId',
+  lifetime: 'persistent',
+  principalScope: 'principal',
+  serialize: (workspaceId: string) => JSON.stringify(workspaceId),
+  parse: (raw) => {
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      return typeof parsed === 'string' ? parsed : undefined;
+    } catch {
+      return undefined;
+    }
+  },
+});
 
-export const lastWorkspaceIdAtom = atomWithStorage<string | undefined>(storageKey, undefined);
+const storedLastWorkspaceIdAtom = atom<string | undefined>(getLastWorkspaceId());
+
+export const lastWorkspaceIdAtom = atom(
+  (get) => get(storedLastWorkspaceIdAtom),
+  (_get, set, workspaceId: string | undefined) => {
+    set(storedLastWorkspaceIdAtom, workspaceId);
+    if (workspaceId === undefined) lastWorkspaceStorage.remove();
+    else lastWorkspaceStorage.write(workspaceId);
+  },
+);
 
 export function getLastWorkspaceId(): string | undefined {
-  if (typeof window === 'undefined') return undefined;
-  try {
-    const raw = window.localStorage.getItem(storageKey);
-    if (!raw) return undefined;
-    const parsed: unknown = JSON.parse(raw);
-    return typeof parsed === 'string' ? parsed : undefined;
-  } catch {
-    return undefined;
-  }
+  return lastWorkspaceStorage.read();
 }
 
 export function rememberLastWorkspaceId(workspaceId: string): void {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem(storageKey, JSON.stringify(workspaceId));
+  lastWorkspaceStorage.write(workspaceId);
 }

--- a/libs/client/ui/src/browser-storage.test.ts
+++ b/libs/client/ui/src/browser-storage.test.ts
@@ -1,0 +1,69 @@
+import {type BrowserStorage, createTypedBrowserStorage} from './browser-storage.js';
+
+const key = {
+  key: 'shipfox.test.preference',
+  lifetime: 'persistent' as const,
+  principalScope: 'global' as const,
+  serialize: (value: string) => JSON.stringify(value),
+  parse: (value: string) => {
+    try {
+      const parsed: unknown = JSON.parse(value);
+      return typeof parsed === 'string' ? parsed : undefined;
+    } catch {
+      return undefined;
+    }
+  },
+};
+
+function storage(initial: Record<string, string> = {}): BrowserStorage {
+  const values = new Map(Object.entries(initial));
+  return {
+    getItem: vi.fn((name) => values.get(name) ?? null),
+    setItem: vi.fn((name, value) => values.set(name, value)),
+    removeItem: vi.fn((name) => values.delete(name)),
+  };
+}
+
+describe('createTypedBrowserStorage', () => {
+  it('serializes, validates, and removes values', () => {
+    const raw = storage();
+    const preference = createTypedBrowserStorage(() => raw, key);
+
+    preference.write('dark');
+    const read = preference.read();
+    preference.remove();
+
+    expect(read).toBe('dark');
+    expect(raw.removeItem).toHaveBeenCalledWith(key.key);
+  });
+
+  it('treats malformed persisted values as absent', () => {
+    const preference = createTypedBrowserStorage(() => storage({[key.key]: '{'}), key);
+
+    expect(preference.read()).toBeUndefined();
+  });
+
+  it('does not throw when storage is unavailable or rejects an operation', () => {
+    const unavailable = createTypedBrowserStorage<string>(() => {
+      throw new Error('storage unavailable');
+    }, key);
+    const rejecting = createTypedBrowserStorage(
+      () => ({
+        getItem: () => {
+          throw new Error('blocked');
+        },
+        setItem: () => {
+          throw new Error('blocked');
+        },
+        removeItem: () => {
+          throw new Error('blocked');
+        },
+      }),
+      key,
+    );
+
+    expect(unavailable.read()).toBeUndefined();
+    expect(() => rejecting.write('dark')).not.toThrow();
+    expect(() => rejecting.remove()).not.toThrow();
+  });
+});

--- a/libs/client/ui/src/browser-storage.ts
+++ b/libs/client/ui/src/browser-storage.ts
@@ -1,0 +1,65 @@
+export interface BrowserStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+export interface BrowserStorageKey<T> {
+  /** Stable browser-storage key. */
+  key: string;
+  /** How long this value may remain useful: session or persistent. */
+  lifetime: 'session' | 'persistent';
+  /** Who may reuse it: global, workspace, or authenticated principal. */
+  principalScope: 'global' | 'workspace' | 'principal';
+  serialize(value: T): string;
+  parse(value: string): T | undefined;
+}
+
+export interface TypedBrowserStorage<T> {
+  read(): T | undefined;
+  write(value: T): void;
+  remove(): void;
+}
+
+/**
+ * Best-effort storage for non-authoritative browser preferences and recovery hints.
+ * Reads validate untrusted persisted text, and every storage exception degrades to
+ * an absent value so privacy mode and quota failures never interrupt user flows.
+ */
+export function createTypedBrowserStorage<T>(
+  getStorage: () => BrowserStorage | undefined,
+  definition: BrowserStorageKey<T>,
+): TypedBrowserStorage<T> {
+  return {
+    read() {
+      try {
+        const raw = getStorage()?.getItem(definition.key);
+        return raw === null || raw === undefined ? undefined : definition.parse(raw);
+      } catch {
+        return undefined;
+      }
+    },
+    write(value) {
+      try {
+        getStorage()?.setItem(definition.key, definition.serialize(value));
+      } catch {
+        // Persistence is intentionally non-authoritative.
+      }
+    },
+    remove() {
+      try {
+        getStorage()?.removeItem(definition.key);
+      } catch {
+        // Persistence is intentionally non-authoritative.
+      }
+    },
+  };
+}
+
+export function localStorageOrUndefined(): BrowserStorage | undefined {
+  return typeof window === 'undefined' ? undefined : window.localStorage;
+}
+
+export function sessionStorageOrUndefined(): BrowserStorage | undefined {
+  return typeof window === 'undefined' ? undefined : window.sessionStorage;
+}

--- a/libs/client/ui/src/index.ts
+++ b/libs/client/ui/src/index.ts
@@ -1,4 +1,6 @@
 export * from './annotation-card.js';
+export * from './browser-storage.js';
 export * from './display-name-field-error.js';
 export * from './load-error-copy.js';
 export * from './query-load-error.js';
+export * from './single-flight.js';

--- a/libs/client/ui/src/single-flight.test.ts
+++ b/libs/client/ui/src/single-flight.test.ts
@@ -38,4 +38,18 @@ describe('createSingleFlight', () => {
 
     expect(flight.terminalSize).toBe(2);
   });
+
+  it('does not retain an in-flight result cleared before settlement', async () => {
+    const flight = createSingleFlight<string, string>({maxTerminalResults: 1});
+    let resolve!: (value: string) => void;
+    const result = flight.run('callback', () => new Promise<string>((done) => (resolve = done)));
+    await Promise.resolve();
+
+    flight.clear('callback');
+    resolve('complete');
+    await result;
+    await Promise.resolve();
+
+    expect(flight.terminalSize).toBe(0);
+  });
 });

--- a/libs/client/ui/src/single-flight.test.ts
+++ b/libs/client/ui/src/single-flight.test.ts
@@ -1,0 +1,41 @@
+import {createSingleFlight} from './single-flight.js';
+
+describe('createSingleFlight', () => {
+  it('shares concurrent callers and evicts the active request after success', async () => {
+    const flight = createSingleFlight<string, string>();
+    let resolve!: (value: string) => void;
+    const operation = vi.fn(() => new Promise<string>((done) => (resolve = done)));
+
+    const first = flight.run('callback', operation);
+    const second = flight.run('callback', operation);
+    await Promise.resolve();
+    resolve('complete');
+
+    await expect(Promise.all([first, second])).resolves.toEqual(['complete', 'complete']);
+    await Promise.resolve();
+    expect(operation).toHaveBeenCalledOnce();
+    expect(flight.inFlightSize).toBe(0);
+  });
+
+  it('evicts rejected work so a later caller retries', async () => {
+    const flight = createSingleFlight<string, string>();
+    const operation = vi.fn().mockRejectedValueOnce(new Error('nope')).mockResolvedValueOnce('ok');
+
+    await expect(flight.run('callback', operation)).rejects.toThrow('nope');
+    await Promise.resolve();
+    await expect(flight.run('callback', operation)).resolves.toBe('ok');
+
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps only the requested number of terminal outcomes', async () => {
+    const flight = createSingleFlight<string, string>({maxTerminalResults: 2});
+
+    await flight.run('one', async () => 'one');
+    await flight.run('two', async () => 'two');
+    await flight.run('three', async () => 'three');
+    await Promise.resolve();
+
+    expect(flight.terminalSize).toBe(2);
+  });
+});

--- a/libs/client/ui/src/single-flight.ts
+++ b/libs/client/ui/src/single-flight.ts
@@ -20,6 +20,8 @@ export function createSingleFlight<Key, Value>({
 }: SingleFlightOptions = {}): SingleFlight<Key, Value> {
   const inFlight = new Map<Key, Promise<Value>>();
   const terminal = new Map<Key, Promise<Value>>();
+  const keyGenerations = new Map<Key, number>();
+  let globalGeneration = 0;
 
   const remember = (key: Key, result: Promise<Value>) => {
     if (maxTerminalResults <= 0) return;
@@ -43,10 +45,14 @@ export function createSingleFlight<Key, Value>({
       const active = inFlight.get(key);
       if (active) return active;
 
+      const keyGeneration = keyGenerations.get(key) ?? 0;
+      const runGeneration = globalGeneration;
       const result = Promise.resolve().then(operation);
       inFlight.set(key, result);
       const settle = () => {
         if (inFlight.get(key) === result) inFlight.delete(key);
+        if (runGeneration !== globalGeneration || keyGeneration !== (keyGenerations.get(key) ?? 0))
+          return;
         remember(key, result);
       };
       result.then(settle, settle);
@@ -56,9 +62,12 @@ export function createSingleFlight<Key, Value>({
       if (key === undefined) {
         inFlight.clear();
         terminal.clear();
+        keyGenerations.clear();
+        globalGeneration += 1;
       } else {
         inFlight.delete(key);
         terminal.delete(key);
+        keyGenerations.set(key, (keyGenerations.get(key) ?? 0) + 1);
       }
     },
     get inFlightSize() {

--- a/libs/client/ui/src/single-flight.ts
+++ b/libs/client/ui/src/single-flight.ts
@@ -1,0 +1,71 @@
+export interface SingleFlightOptions {
+  /** Number of settled outcomes to retain for remount deduplication. Defaults to 0. */
+  maxTerminalResults?: number;
+}
+
+export interface SingleFlight<Key, Value> {
+  run(key: Key, operation: () => Promise<Value>): Promise<Value>;
+  clear(key?: Key): void;
+  readonly inFlightSize: number;
+  readonly terminalSize: number;
+}
+
+/**
+ * Deduplicates concurrent work by key. Settled requests are always evicted from
+ * the active map; callers can opt into a bounded LRU terminal cache when a short
+ * remount window must not replay a single-use callback.
+ */
+export function createSingleFlight<Key, Value>({
+  maxTerminalResults = 0,
+}: SingleFlightOptions = {}): SingleFlight<Key, Value> {
+  const inFlight = new Map<Key, Promise<Value>>();
+  const terminal = new Map<Key, Promise<Value>>();
+
+  const remember = (key: Key, result: Promise<Value>) => {
+    if (maxTerminalResults <= 0) return;
+    terminal.delete(key);
+    terminal.set(key, result);
+    while (terminal.size > maxTerminalResults) {
+      const oldest = terminal.keys().next().value;
+      if (oldest === undefined) return;
+      terminal.delete(oldest);
+    }
+  };
+
+  return {
+    run(key, operation) {
+      const retained = terminal.get(key);
+      if (retained) {
+        terminal.delete(key);
+        terminal.set(key, retained);
+        return retained;
+      }
+      const active = inFlight.get(key);
+      if (active) return active;
+
+      const result = Promise.resolve().then(operation);
+      inFlight.set(key, result);
+      const settle = () => {
+        if (inFlight.get(key) === result) inFlight.delete(key);
+        remember(key, result);
+      };
+      result.then(settle, settle);
+      return result;
+    },
+    clear(key) {
+      if (key === undefined) {
+        inFlight.clear();
+        terminal.clear();
+      } else {
+        inFlight.delete(key);
+        terminal.delete(key);
+      }
+    },
+    get inFlightSize() {
+      return inFlight.size;
+    },
+    get terminalSize() {
+      return terminal.size;
+    },
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4949,6 +4949,9 @@ importers:
       '@shipfox/client-shell':
         specifier: workspace:*
         version: link:../shell
+      '@shipfox/client-ui':
+        specifier: workspace:*
+        version: link:../ui
       '@shipfox/react-ui':
         specifier: workspace:*
         version: link:../../shared/react/ui
@@ -5473,6 +5476,9 @@ importers:
       '@shipfox/client-config':
         specifier: workspace:*
         version: link:../config
+      '@shipfox/client-ui':
+        specifier: workspace:*
+        version: link:../ui
       '@shipfox/react-ui':
         specifier: workspace:*
         version: link:../../shared/react/ui


### PR DESCRIPTION
Adds typed best-effort browser storage and bounded single-flight request deduplication to the shared client UI package.

Callback flows retained requests and feedback markers for the document lifetime, while direct storage access could interrupt preference and recovery paths in private-browsing or quota-failure cases. This replaces those ad hoc paths across GitHub, Linear, Slack, Sentry, and invitations; it also hardens last-workspace, onboarding-dismissal, and reminder persistence.

The single-flight primitive defaults to settlement eviction and permits a bounded terminal cache only where one-time OAuth callbacks need short remount protection. Known feature error mappings remain local; the GitHub callback fallback no longer exposes raw API error messages.

Closes ENG-1126

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds typed best‑effort browser storage and bounded single‑flight deduplication so preferences and callbacks stay reliable in private mode, quota failures, remounts, and across tabs. Closes ENG-1126.

- **New Features**
  - `@shipfox/client-ui`: added `createTypedBrowserStorage`, `localStorageOrUndefined`, and `sessionStorageOrUndefined` for safe, typed read/write/remove with validation.
  - `@shipfox/client-ui`: added `createSingleFlight` with optional `maxTerminalResults` and `clear(key)` for short remount protection and control.
  - Switched OAuth callbacks (Linear, Slack, GitHub) and Sentry connect, plus invitation acceptance, to single‑flight; Linear/Slack/GitHub keep a 32‑entry terminal cache.
  - Replaced ad‑hoc storage with typed storage for onboarding dismissal, reminder banner (session), and last workspace.
  - GitHub callback now shows a safe, generic error message instead of raw API errors.
  - Added unit tests for storage, single‑flight, and GitHub error copy.

- **Bug Fixes**
  - Last workspace now syncs across tabs via storage events.
  - Clearing a single‑flight key no longer allows cleared in‑flight work to repopulate the terminal cache.

<sup>Written for commit 1afc97cc7a7641a35122069de147622536d2dac2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

