### PR TITLE
Add checked client API boundaries

### DIFF
--- a/.changeset/bright-mice-bloom.md
+++ b/.changeset/bright-mice-bloom.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/client-api": minor
+"@shipfox/client-workspace-settings": patch
+---
+
+Adds checked client API response boundaries and domain-cached invitation queries.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,15 @@ adding, updating, or exempting a dependency. It defines catalog range rules,
 peer compatibility, coordinated Renovate families, and the transitive exception
 format.
 
+## Client architecture
+
+Client features follow [ADR 0003](docs/adr/0003-client-state-and-domain-architecture.md). API adapters
+validate response contracts and map them to package-owned domain models before caching. The
+`pnpm check:client-architecture` audit blocks new boundary violations while
+`tools/client-architecture-policy/client-architecture-baseline.json` records the remaining migration
+work. Do not add a baseline entry for new code. Move it to the approved adapter, `core/`, or resource
+mutation owner instead.
+
 ## Error reporting
 
 Report unexpected API-process failures at the earliest owning boundary. A catch

--- a/libs/client/api/src/index.test.ts
+++ b/libs/client/api/src/index.test.ts
@@ -1,9 +1,12 @@
+import {z} from 'zod';
 import {
   ApiError,
   apiRequest,
+  checkedApiRequest,
   configureApiClient,
   getErrorCode,
   isErrorWithCode,
+  isInvalidApiResponseError,
   resetApiClient,
 } from './index.js';
 
@@ -155,5 +158,29 @@ describe('resetApiClient', () => {
     const request = freshFetch.mock.calls[0]?.[0] as Request;
     expect(request.url).toBe('https://fresh.example.test/workspaces');
     expect(request.headers.get('authorization')).toBeNull();
+  });
+});
+
+describe('checkedApiRequest', () => {
+  test('returns the schema output', async () => {
+    configureApiClient({fetchImpl: vi.fn().mockResolvedValue(jsonResponse({id: 'workspace-1'}))});
+    const schema = z.object({id: z.string()});
+
+    const result = await checkedApiRequest(schema, '/workspaces/workspace-1');
+
+    expect(result).toEqual({id: 'workspace-1'});
+  });
+
+  test('keeps invalid responses distinct from transport errors without retaining the payload', async () => {
+    configureApiClient({
+      fetchImpl: vi.fn().mockResolvedValue(jsonResponse({secret: 'do-not-expose'})),
+    });
+    const schema = z.object({id: z.string()});
+
+    const result = checkedApiRequest(schema, '/workspaces/workspace-1');
+
+    await expect(result).rejects.toMatchObject({code: 'invalid-response'});
+    await expect(result).rejects.not.toThrow('do-not-expose');
+    await expect(result.catch(isInvalidApiResponseError)).resolves.toBe(true);
   });
 });

--- a/libs/client/api/src/index.ts
+++ b/libs/client/api/src/index.ts
@@ -16,6 +16,25 @@ export interface ApiRequestOptions {
   signal?: AbortSignal | undefined;
 }
 
+export interface StandardSchema<Input = unknown, Output = Input> {
+  readonly '~standard': {
+    readonly version: 1;
+    readonly vendor: string;
+    readonly validate: (
+      value: unknown,
+    ) =>
+      | {readonly value: Output; readonly issues?: undefined}
+      | {readonly value?: undefined; readonly issues: ReadonlyArray<unknown>}
+      | Promise<
+          | {readonly value: Output; readonly issues?: undefined}
+          | {readonly value?: undefined; readonly issues: ReadonlyArray<unknown>}
+        >;
+  };
+}
+
+export type StandardSchemaOutput<Schema extends StandardSchema> =
+  Schema extends StandardSchema<unknown, infer Output> ? Output : never;
+
 export class ApiError extends Error {
   readonly code: string;
   readonly status: number;
@@ -27,6 +46,15 @@ export class ApiError extends Error {
     this.code = params.code;
     this.status = params.status;
     this.details = params.details;
+  }
+}
+
+export class InvalidApiResponseError extends Error {
+  readonly code = 'invalid-response';
+
+  constructor() {
+    super('The server returned an invalid response.');
+    this.name = 'InvalidApiResponseError';
   }
 }
 
@@ -62,6 +90,10 @@ export function getErrorCode(error: unknown): string | undefined {
 
 export function isErrorWithCode(error: unknown, code: string): boolean {
   return getErrorCode(error) === code;
+}
+
+export function isInvalidApiResponseError(error: unknown): error is InvalidApiResponseError {
+  return error instanceof InvalidApiResponseError;
 }
 
 async function parseResponseBody(response: Response): Promise<unknown> {
@@ -182,4 +214,21 @@ export async function apiRequest<T>(path: string, options: ApiRequestOptions = {
     }
     throw error;
   }
+}
+
+/**
+ * Requests and validates a JSON response at the transport boundary.
+ *
+ * Invalid payloads intentionally expose no response body or validation details,
+ * which can contain unexpected sensitive values from an untrusted server.
+ */
+export async function checkedApiRequest<Schema extends StandardSchema>(
+  schema: Schema,
+  path: string,
+  options: ApiRequestOptions = {},
+): Promise<StandardSchemaOutput<Schema>> {
+  const response = await apiRequest<unknown>(path, options);
+  const result = await schema['~standard'].validate(response);
+  if ('issues' in result) throw new InvalidApiResponseError();
+  return result.value as StandardSchemaOutput<Schema>;
 }

--- a/libs/client/workspace-settings/src/components/members/workspace-members-section.tsx
+++ b/libs/client/workspace-settings/src/components/members/workspace-members-section.tsx
@@ -31,6 +31,7 @@ import {Code, Header, Text} from '@shipfox/react-ui/typography';
 import {formatDate} from '@shipfox/react-ui/utils';
 import {useForm} from '@tanstack/react-form';
 import {useState} from 'react';
+import type {Invitation} from '#core/invitation.js';
 import {useCreateInvitation} from '#hooks/api/create-invitation.js';
 import {useListInvitations} from '#hooks/api/list-invitations.js';
 import {useListMembers} from '#hooks/api/list-members.js';
@@ -194,7 +195,7 @@ function PendingInvitationsSection({
   workspaceName: string;
 }) {
   const query = useListInvitations(workspaceId);
-  const invitations = query.data?.invitations ?? [];
+  const invitations = query.data ?? [];
   const [inviteOpen, setInviteOpen] = useState(false);
 
   return (
@@ -249,16 +250,10 @@ function PendingInvitationsSection({
   );
 }
 
-function InvitationRow({
-  invitation,
-  workspaceId,
-}: {
-  invitation: import('@shipfox/api-workspaces-dto').InvitationDto;
-  workspaceId: string;
-}) {
+function InvitationRow({invitation, workspaceId}: {invitation: Invitation; workspaceId: string}) {
   const [open, setOpen] = useState(false);
   const revoke = useRevokeInvitation(workspaceId);
-  const expiresAt = new Date(invitation.expires_at);
+  const expiresAt = new Date(invitation.expiresAt);
   const expiresSoon = expiresAt.getTime() - Date.now() < EXPIRES_SOON_MS;
 
   async function handleRevoke() {
@@ -276,10 +271,10 @@ function InvitationRow({
       <TableCell>
         <Code variant="paragraph">{invitation.email}</Code>
       </TableCell>
-      <TableCell>{invitation.invited_by_display ?? '—'}</TableCell>
+      <TableCell>{invitation.invitedByDisplay ?? '—'}</TableCell>
       <TableCell>
         <div className="flex items-center gap-8">
-          <Text size="sm">{formatDate(invitation.expires_at)}</Text>
+          <Text size="sm">{formatDate(invitation.expiresAt)}</Text>
           {expiresSoon ? <Badge variant="warning">Soon</Badge> : null}
         </div>
       </TableCell>

--- a/libs/client/workspace-settings/src/core/invitation.ts
+++ b/libs/client/workspace-settings/src/core/invitation.ts
@@ -1,0 +1,15 @@
+export interface Invitation {
+  id: string;
+  workspaceId: string;
+  email: string;
+  expiresAt: string;
+  acceptedAt: string | null;
+  invitedByUserId: string;
+  invitedByDisplay: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateInvitationCommand {
+  email: string;
+}

--- a/libs/client/workspace-settings/src/hooks/api/create-invitation.ts
+++ b/libs/client/workspace-settings/src/hooks/api/create-invitation.ts
@@ -1,21 +1,31 @@
-import type {CreateInvitationBodyDto, InvitationDto} from '@shipfox/api-workspaces-dto';
-import {apiRequest} from '@shipfox/client-api';
+import {invitationDtoSchema} from '@shipfox/api-workspaces-dto';
+import {checkedApiRequest} from '@shipfox/client-api';
 import {useMutation, useQueryClient} from '@tanstack/react-query';
-import {listInvitationsQueryKey} from './list-invitations.js';
+import type {CreateInvitationCommand, Invitation} from '#core/invitation.js';
+import {toInvitation} from './invitation-mapper.js';
+import {listInvitationsQueryOptions} from './list-invitations.js';
 
-async function createInvitation(params: {workspaceId: string; body: CreateInvitationBodyDto}) {
-  return await apiRequest<InvitationDto>(`/workspaces/${params.workspaceId}/invitations`, {
-    method: 'POST',
-    body: params.body,
-  });
+async function createInvitation(params: {
+  workspaceId: string;
+  command: CreateInvitationCommand;
+}): Promise<Invitation> {
+  const response = await checkedApiRequest(
+    invitationDtoSchema,
+    `/workspaces/${params.workspaceId}/invitations`,
+    {
+      method: 'POST',
+      body: {email: params.command.email},
+    },
+  );
+  return toInvitation(response);
 }
 
 export function useCreateInvitation(workspaceId: string) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (body: CreateInvitationBodyDto) => createInvitation({workspaceId, body}),
+    mutationFn: (command: CreateInvitationCommand) => createInvitation({workspaceId, command}),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({queryKey: listInvitationsQueryKey(workspaceId)});
+      await queryClient.invalidateQueries(listInvitationsQueryOptions(workspaceId));
     },
   });
 }

--- a/libs/client/workspace-settings/src/hooks/api/invitation-mapper.test.ts
+++ b/libs/client/workspace-settings/src/hooks/api/invitation-mapper.test.ts
@@ -1,0 +1,29 @@
+import {toInvitation} from './invitation-mapper.js';
+
+describe('toInvitation', () => {
+  test('maps the transport response to the package domain model', () => {
+    const invitation = toInvitation({
+      id: 'f87901d8-4a7e-43e7-84f5-a9c73456657f',
+      workspace_id: 'ab03cfd0-1845-453b-867c-a661c8e62f13',
+      email: 'member@example.com',
+      expires_at: '2026-07-29T12:00:00.000Z',
+      accepted_at: null,
+      invited_by_user_id: 'b8d2ab85-9e38-4449-af50-8beaabf058e5',
+      invited_by_display: 'Noé',
+      created_at: '2026-07-22T12:00:00.000Z',
+      updated_at: '2026-07-22T12:00:00.000Z',
+    });
+
+    expect(invitation).toEqual({
+      id: 'f87901d8-4a7e-43e7-84f5-a9c73456657f',
+      workspaceId: 'ab03cfd0-1845-453b-867c-a661c8e62f13',
+      email: 'member@example.com',
+      expiresAt: '2026-07-29T12:00:00.000Z',
+      acceptedAt: null,
+      invitedByUserId: 'b8d2ab85-9e38-4449-af50-8beaabf058e5',
+      invitedByDisplay: 'Noé',
+      createdAt: '2026-07-22T12:00:00.000Z',
+      updatedAt: '2026-07-22T12:00:00.000Z',
+    });
+  });
+});

--- a/libs/client/workspace-settings/src/hooks/api/invitation-mapper.ts
+++ b/libs/client/workspace-settings/src/hooks/api/invitation-mapper.ts
@@ -1,0 +1,16 @@
+import type {InvitationDto} from '@shipfox/api-workspaces-dto';
+import type {Invitation} from '#core/invitation.js';
+
+export function toInvitation(dto: InvitationDto): Invitation {
+  return {
+    id: dto.id,
+    workspaceId: dto.workspace_id,
+    email: dto.email,
+    expiresAt: dto.expires_at,
+    acceptedAt: dto.accepted_at,
+    invitedByUserId: dto.invited_by_user_id,
+    invitedByDisplay: dto.invited_by_display,
+    createdAt: dto.created_at,
+    updatedAt: dto.updated_at,
+  };
+}

--- a/libs/client/workspace-settings/src/hooks/api/list-invitations.ts
+++ b/libs/client/workspace-settings/src/hooks/api/list-invitations.ts
@@ -1,17 +1,27 @@
-import type {ListInvitationsResponseDto} from '@shipfox/api-workspaces-dto';
-import {apiRequest} from '@shipfox/client-api';
-import {useQuery} from '@tanstack/react-query';
+import {listInvitationsResponseSchema} from '@shipfox/api-workspaces-dto';
+import {checkedApiRequest} from '@shipfox/client-api';
+import {queryOptions, useQuery} from '@tanstack/react-query';
+import type {Invitation} from '#core/invitation.js';
+import {toInvitation} from './invitation-mapper.js';
 
 export const listInvitationsQueryKey = (workspaceId: string) =>
   ['workspaces', workspaceId, 'invitations'] as const;
 
-async function listInvitations(workspaceId: string): Promise<ListInvitationsResponseDto> {
-  return await apiRequest<ListInvitationsResponseDto>(`/workspaces/${workspaceId}/invitations`);
+async function listInvitations(workspaceId: string): Promise<Invitation[]> {
+  const response = await checkedApiRequest(
+    listInvitationsResponseSchema,
+    `/workspaces/${workspaceId}/invitations`,
+  );
+  return response.invitations.map(toInvitation);
 }
 
-export function useListInvitations(workspaceId: string) {
-  return useQuery({
+export function listInvitationsQueryOptions(workspaceId: string) {
+  return queryOptions({
     queryKey: listInvitationsQueryKey(workspaceId),
     queryFn: () => listInvitations(workspaceId),
   });
+}
+
+export function useListInvitations(workspaceId: string) {
+  return useQuery(listInvitationsQueryOptions(workspaceId));
 }

--- a/libs/client/workspace-settings/src/hooks/api/revoke-invitation.ts
+++ b/libs/client/workspace-settings/src/hooks/api/revoke-invitation.ts
@@ -1,6 +1,6 @@
 import {apiRequest} from '@shipfox/client-api';
 import {useMutation, useQueryClient} from '@tanstack/react-query';
-import {listInvitationsQueryKey} from './list-invitations.js';
+import {listInvitationsQueryOptions} from './list-invitations.js';
 
 async function revokeInvitation(params: {workspaceId: string; invitationId: string}) {
   await apiRequest<void>(`/workspaces/${params.workspaceId}/invitations/${params.invitationId}`, {
@@ -13,7 +13,7 @@ export function useRevokeInvitation(workspaceId: string) {
   return useMutation({
     mutationFn: (invitationId: string) => revokeInvitation({workspaceId, invitationId}),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({queryKey: listInvitationsQueryKey(workspaceId)});
+      await queryClient.invalidateQueries(listInvitationsQueryOptions(workspaceId));
     },
   });
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "check:dependencies": "pnpm --filter=@shipfox/dependency-policy verify:dependencies",
     "check:api-context-inventory": "turbo verify --filter=@shipfox/api-architecture-policy",
+    "check:client-architecture": "turbo verify --filter=@shipfox/client-architecture-policy",
     "check:lockfile": "turbo build --filter=@shipfox/dependency-policy && pnpm --filter=@shipfox/dependency-policy verify:lockfile",
     "check:published-artifacts": "turbo verify --filter=@shipfox/package-release",
     "fix:dependencies": "pnpm --filter=@shipfox/dependency-policy fix",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7386,6 +7386,27 @@ importers:
         specifier: 'catalog:'
         version: 24.13.2
 
+  tools/client-architecture-policy:
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../vitest
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.2
+
   tools/depcruise:
     dependencies:
       '@shipfox/tool-utils':

--- a/tools/client-architecture-policy/client-architecture-baseline.json
+++ b/tools/client-architecture-policy/client-architecture-baseline.json
@@ -1,0 +1,247 @@
+[
+  {
+    "file": "libs/client/agent/src/components/available-provider-card.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/agent/src/components/available-providers-grid.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/agent/src/components/change-default-model-form.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/agent/src/components/custom-model-provider-form.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/agent/src/components/custom-model-provider-payload.ts",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/agent/src/components/default-model-field.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/agent/src/components/harness-availability.ts",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/agent/src/components/model-provider-usage-target.ts",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/agent/src/components/model-providers-section.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/agent/src/components/provider-search.ts",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/agent/src/components/supported-model-provider-catalog-entry.ts",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/agent/src/components/test-and-save-form.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/agent/src/pages/model-provider-onboarding-page.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/auth/src/pages/invitation-context.ts",
+    "rule": "api-request-outside-adapter"
+  },
+  {
+    "file": "libs/client/auth/src/pages/invitation-context.ts",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/integrations/src/components/connection-picker.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/integrations/src/components/installed-integrations-section.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/integrations/src/components/integration-gallery-for-workspace.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/integrations/src/components/integration-gallery.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/integrations/src/components/integration-usage-events.ts",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/integrations/src/components/integration-usage-modal.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/integrations/src/components/provider-grid.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/integrations/src/components/repository-picker.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/integrations/src/components/webhook/webhook-create-modal.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/integrations/src/pages/linear-callback-page.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/integrations/src/pages/sentry-callback-page.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/integrations/src/pages/slack-callback-page.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/integrations/src/routes/github-callback.tsx",
+    "rule": "api-request-outside-adapter"
+  },
+  { "file": "libs/client/logs/src/core/log-read.ts", "rule": "core-api-dto-import" },
+  { "file": "libs/client/logs/src/core/log-tree.ts", "rule": "core-api-dto-import" },
+  {
+    "file": "libs/client/projects/src/components/source-strip.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/projects/src/components/workspace-setup-guard.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/projects/src/pages/create-project-page.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/projects/src/pages/project-workflows-page.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/projects/src/pages/projects-hub-page.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/runners/src/components/create-manual-registration-token-form.tsx",
+    "rule": "leaf-query-cache-ownership"
+  },
+  {
+    "file": "libs/client/runners/src/components/create-manual-registration-token-form.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/runners/src/components/create-provisioner-token-form.tsx",
+    "rule": "leaf-query-cache-ownership"
+  },
+  {
+    "file": "libs/client/runners/src/components/create-provisioner-token-form.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/runners/src/components/manual-registration-token-format.ts",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/runners/src/components/manual-registration-token-list.tsx",
+    "rule": "leaf-query-cache-ownership"
+  },
+  {
+    "file": "libs/client/runners/src/components/manual-registration-token-list.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/runners/src/components/manual-registration-tokens-settings-section.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/runners/src/components/provisioner-token-format.ts",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/runners/src/components/provisioner-token-list.tsx",
+    "rule": "leaf-query-cache-ownership"
+  },
+  {
+    "file": "libs/client/runners/src/components/provisioner-token-list.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/runners/src/components/provisioner-tokens-settings-section.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/secrets/src/components/workspace-secrets-section.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/secrets/src/components/workspace-variables-section.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  { "file": "libs/client/shell/src/runtime/auth.tsx", "rule": "api-request-outside-adapter" },
+  {
+    "file": "libs/client/triggers/src/components/events-filter-bar.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/triggers/src/components/trigger-event-detail.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/triggers/src/components/trigger-event-result.ts",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/triggers/src/components/trigger-event-row.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/triggers/src/components/types.ts",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/triggers/src/pages/events-page.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx",
+    "rule": "response-dto-in-presentation"
+  },
+  {
+    "file": "libs/client/workflows/src/core/entities/job-execution.ts",
+    "rule": "core-api-dto-import"
+  },
+  { "file": "libs/client/workflows/src/core/entities/job.ts", "rule": "core-api-dto-import" },
+  {
+    "file": "libs/client/workflows/src/core/entities/step-attempt.ts",
+    "rule": "core-api-dto-import"
+  },
+  { "file": "libs/client/workflows/src/core/entities/step.ts", "rule": "core-api-dto-import" },
+  {
+    "file": "libs/client/workflows/src/core/entities/workflow-run-attempt.ts",
+    "rule": "core-api-dto-import"
+  },
+  {
+    "file": "libs/client/workflows/src/core/entities/workflow-run.ts",
+    "rule": "core-api-dto-import"
+  },
+  {
+    "file": "libs/client/workspace-settings/src/components/members/workspace-members-section.tsx",
+    "rule": "response-dto-in-presentation"
+  }
+]

--- a/tools/client-architecture-policy/package.json
+++ b/tools/client-architecture-policy/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@shipfox/client-architecture-policy",
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "test": "shipfox-vitest-run",
+    "test:watch": "shipfox-vitest-watch",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit",
+    "verify": "node dist/audit-client-architecture.js"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*",
+    "@types/node": "catalog:"
+  }
+}

--- a/tools/client-architecture-policy/src/audit-client-architecture.ts
+++ b/tools/client-architecture-policy/src/audit-client-architecture.ts
@@ -1,0 +1,132 @@
+import {readdir, readFile} from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import {fileURLToPath} from 'node:url';
+
+export interface ClientArchitectureViolation {
+  file: string;
+  rule:
+    | 'api-request-outside-adapter'
+    | 'core-api-dto-import'
+    | 'core-client-framework-import'
+    | 'leaf-query-cache-ownership'
+    | 'response-dto-in-presentation';
+}
+
+const rootDirectory = fileURLToPath(new URL('../../../', import.meta.url));
+const clientDirectory = path.join(rootDirectory, 'libs/client');
+const baselinePath = path.join(
+  rootDirectory,
+  'tools/client-architecture-policy/client-architecture-baseline.json',
+);
+const sourceFilePattern = /\.(?:ts|tsx)$/;
+const nonProductionSourcePattern = /\.(?:stories|test)\.(?:ts|tsx)$/;
+const apiDtoImportPattern = /from\s+['"]@shipfox\/api-[^'"]+-dto['"]/;
+const clientFrameworkImportPattern =
+  /from\s+['"](?:react(?:-dom)?|jotai|@tanstack\/[^'"]+|@shipfox\/client-(?:api|shell|ui)|@shipfox\/react-ui(?:\/[^'"]+)?)['"]/;
+const apiRequestPattern = /\bapiRequest\s*(?:<[^>]*>)?\s*\(/;
+const queryCachePattern =
+  /\b(?:useQueryClient\s*\(|queryClient\.(?:invalidateQueries|removeQueries|resetQueries|setQueriesData|setQueryData))/;
+const responseDtoNamePattern = /\b[A-Za-z0-9_]+(?<!Body|Query)Dto\b/;
+
+function toRepositoryPath(filePath: string): string {
+  return path.relative(rootDirectory, filePath).split(path.sep).join('/');
+}
+
+async function sourceFiles(directory: string): Promise<string[]> {
+  const entries = await readdir(directory, {withFileTypes: true});
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) return await sourceFiles(entryPath);
+      return sourceFilePattern.test(entry.name) && !nonProductionSourcePattern.test(entry.name)
+        ? [entryPath]
+        : [];
+    }),
+  );
+  return files.flat();
+}
+
+function hasResponseDtoImport(source: string): boolean {
+  const imports = source.matchAll(
+    /import(?:\s+type)?\s+([^;]+?)\s+from\s+['"]@shipfox\/api-[^'"]+-dto['"]/g,
+  );
+  for (const match of imports) {
+    const names = match[1] ?? '';
+    if (responseDtoNamePattern.test(names)) return true;
+  }
+  return false;
+}
+
+export function auditClientSource(file: string, source: string): ClientArchitectureViolation[] {
+  const violations: ClientArchitectureViolation[] = [];
+  const normalizedFile = file.split(path.sep).join('/');
+  const isCore = normalizedFile.includes('/src/core/');
+  const isAdapter = normalizedFile.includes('/src/hooks/api/');
+  const isClientApi = normalizedFile.startsWith('libs/client/api/');
+  const isPresentation =
+    normalizedFile.includes('/src/pages/') || normalizedFile.includes('/src/components/');
+  if (isCore && apiDtoImportPattern.test(source))
+    violations.push({file, rule: 'core-api-dto-import'});
+  if (isCore && clientFrameworkImportPattern.test(source))
+    violations.push({file, rule: 'core-client-framework-import'});
+  if (!isAdapter && !isClientApi && apiRequestPattern.test(source))
+    violations.push({file, rule: 'api-request-outside-adapter'});
+  if (isPresentation && hasResponseDtoImport(source))
+    violations.push({file, rule: 'response-dto-in-presentation'});
+  if (normalizedFile.includes('/src/components/') && queryCachePattern.test(source))
+    violations.push({file, rule: 'leaf-query-cache-ownership'});
+  return violations;
+}
+
+export async function auditRepository(): Promise<ClientArchitectureViolation[]> {
+  const files = await sourceFiles(clientDirectory);
+  const violations = await Promise.all(
+    files.map(async (file) =>
+      auditClientSource(toRepositoryPath(file), await readFile(file, 'utf8')),
+    ),
+  );
+  return violations
+    .flat()
+    .sort((left, right) =>
+      `${left.file}:${left.rule}`.localeCompare(`${right.file}:${right.rule}`),
+    );
+}
+
+export async function baselineViolations(): Promise<ClientArchitectureViolation[]> {
+  return JSON.parse(await readFile(baselinePath, 'utf8')) as ClientArchitectureViolation[];
+}
+
+function violationKey(violation: ClientArchitectureViolation): string {
+  return `${violation.file}:${violation.rule}`;
+}
+
+export function newViolations(
+  violations: ClientArchitectureViolation[],
+  baseline: ClientArchitectureViolation[],
+): ClientArchitectureViolation[] {
+  const baselineKeys = new Set(baseline.map(violationKey));
+  return violations.filter((violation) => !baselineKeys.has(violationKey(violation)));
+}
+
+async function main(): Promise<void> {
+  const [violations, baseline] = await Promise.all([auditRepository(), baselineViolations()]);
+  const newEntries = newViolations(violations, baseline);
+  if (newEntries.length === 0) {
+    process.stdout.write(
+      `Client architecture audit passed with ${baseline.length} baseline entries\n`,
+    );
+    return;
+  }
+  process.stderr.write(`Client architecture audit found ${newEntries.length} new violation(s)\n`);
+  for (const violation of newEntries)
+    process.stderr.write(`- ${violation.file}: ${violation.rule}\n`);
+  process.exitCode = 1;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((error: unknown) => {
+    process.stderr.write(`Client architecture audit failed: ${String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/tools/client-architecture-policy/test/audit-client-architecture.test.ts
+++ b/tools/client-architecture-policy/test/audit-client-architecture.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import {auditClientSource, newViolations} from '../src/audit-client-architecture.js';
+
+describe('auditClientSource', () => {
+  test('allows API requests in a feature adapter', () => {
+    const violations = auditClientSource(
+      'libs/client/projects/src/hooks/api/list-projects.ts',
+      "import {apiRequest} from '@shipfox/client-api';\napiRequest('/projects');",
+    );
+    assert.deepEqual(violations, []);
+  });
+
+  test('reports each prohibited boundary crossing', () => {
+    const core = auditClientSource(
+      'libs/client/projects/src/core/project.ts',
+      "import type {ProjectDto} from '@shipfox/api-projects-dto';\nimport {useQuery} from '@tanstack/react-query';",
+    );
+    const page = auditClientSource(
+      'libs/client/projects/src/pages/project-page.tsx',
+      "import type {ProjectDto} from '@shipfox/api-projects-dto';\nimport {apiRequest} from '@shipfox/client-api';\napiRequest('/projects');",
+    );
+    const component = auditClientSource(
+      'libs/client/projects/src/components/project-list.tsx',
+      "import {useQueryClient} from '@tanstack/react-query';\nuseQueryClient();",
+    );
+    assert.deepEqual(
+      core.map((violation) => violation.rule),
+      ['core-api-dto-import', 'core-client-framework-import'],
+    );
+    assert.deepEqual(
+      page.map((violation) => violation.rule),
+      ['api-request-outside-adapter', 'response-dto-in-presentation'],
+    );
+    assert.deepEqual(
+      component.map((violation) => violation.rule),
+      ['leaf-query-cache-ownership'],
+    );
+  });
+
+  test('reports only violations not present in the migration baseline', () => {
+    const existing = {
+      file: 'libs/client/auth/src/pages/login.tsx',
+      rule: 'api-request-outside-adapter',
+    } as const;
+    const added = {
+      file: 'libs/client/auth/src/pages/signup.tsx',
+      rule: 'api-request-outside-adapter',
+    } as const;
+    assert.deepEqual(newViolations([existing, added], [existing]), [added]);
+  });
+});

--- a/tools/client-architecture-policy/tsconfig.build.json
+++ b/tools/client-architecture-policy/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/tools/client-architecture-policy/tsconfig.json
+++ b/tools/client-architecture-policy/tsconfig.json
@@ -1,0 +1,1 @@
+{ "files": [], "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.test.json" }] }

--- a/tools/client-architecture-policy/tsconfig.test.json
+++ b/tools/client-architecture-policy/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "exclude": []
+}

--- a/tools/client-architecture-policy/vitest.config.ts
+++ b/tools/client-architecture-policy/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({}, import.meta.url) as UserConfigExport;


### PR DESCRIPTION
Adds a checked Standard Schema response boundary to the shared client API, then proves it on workspace invitations by mapping DTOs to domain models before React Query caches them. The PR also adds reusable query options and a baseline-aware architecture audit that prevents new boundary drift during the broader client migration.

Client features currently rely on unchecked generic response casts and can put DTOs directly into caches. This creates a stable paved road now, while preserving an explicit baseline for the existing migration work instead of blocking unrelated changes.

The audit intentionally compares against a checked-in production baseline rather than requiring a repository-wide migration in this PR. Future feature work must remove entries or follow the new adapter, core, and mutation ownership boundaries.

Closes ENG-1124

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a checked response boundary in `@shipfox/client-api` and maps workspace invitations to domain models before caching. Also adds a client architecture audit to block new boundary drift, meeting ENG-1124.

- **New Features**
  - Added `checkedApiRequest(schema, path)` to validate JSON responses and throw `InvalidApiResponseError` without exposing payload; tests included.
  - Workspace invitations now use checked DTO schemas and an `Invitation` domain model; React Query caches domain data via `listInvitationsQueryOptions`; added a small mapper.
  - Introduced `@shipfox/client-architecture-policy` with a migration baseline and a repo script `pnpm check:client-architecture`; updated CONTRIBUTING with adapter/core/mutation ownership rules.

- **Refactors**
  - Updated members UI to use domain fields (`expiresAt`, `invitedByDisplay`) instead of DTOs.
  - Mutations now invalidate queries via `listInvitationsQueryOptions` for consistent cache keys.

<sup>Written for commit 57b6faed1d48366564bdaa409f56b8a8ed1f3dcf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

