### PR TITLE
Isolate private query caches by principal

### DIFF
--- a/.changeset/quiet-otters-guard.md
+++ b/.changeset/quiet-otters-guard.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/client-auth": patch
+"@shipfox/client-shell": patch
+---
+
+Prevents private React Query data from persisting across logout and authenticated user changes.

--- a/libs/client/auth/src/components/auth-provider.test.tsx
+++ b/libs/client/auth/src/components/auth-provider.test.tsx
@@ -1,6 +1,8 @@
 import {configureApiClient} from '@shipfox/client-api';
+import {QueryClient, useQuery} from '@tanstack/react-query';
 import {render, screen, waitFor} from '@testing-library/react';
 import {useEffect, useRef} from 'react';
+import {useLoginAuth} from '#hooks/api/login-auth.js';
 import {useLogoutAuth} from '#hooks/api/logout-auth.js';
 import {useRefreshAuth} from '#hooks/api/refresh-auth.js';
 import {useAuthState} from '#hooks/use-auth-state.js';
@@ -15,6 +17,8 @@ const user = {
   created_at: '2026-04-27T00:00:00.000Z',
   updated_at: '2026-04-27T00:00:00.000Z',
 };
+
+const otherUser = {...user, id: '22222222-2222-4222-8222-222222222222', email: 'other@example.com'};
 
 function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
   return new Response(JSON.stringify(body), {
@@ -39,6 +43,28 @@ function StatusProbe() {
   );
 }
 
+function PrivateDataProbe() {
+  const auth = useAuthState();
+  const privateData = useQuery({
+    queryKey: ['private-data'],
+    queryFn: () => new Promise<string>(() => undefined),
+    enabled: auth.isAuthenticated,
+  });
+  const login = useLoginAuth();
+
+  return (
+    <div>
+      <span data-testid="private-data">{privateData.data ?? 'loading'}</span>
+      <button
+        type="button"
+        onClick={() => void login.mutateAsync({email: 'other@example.com', password: 'password'})}
+      >
+        Switch user
+      </button>
+    </div>
+  );
+}
+
 describe('AuthProvider', () => {
   beforeEach(() => {
     configureApiClient({
@@ -50,7 +76,9 @@ describe('AuthProvider', () => {
   });
 
   test('boots from a successful refresh', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({token: 'access-token', user}));
+    const fetchImpl = vi
+      .fn()
+      .mockImplementation(() => Promise.resolve(jsonResponse({token: 'access-token', user})));
     configureApiClient({fetchImpl});
 
     render(
@@ -64,21 +92,26 @@ describe('AuthProvider', () => {
   });
 
   test('treats refresh 401 as a guest session', async () => {
+    const queryClient = new QueryClient();
+    const cancelQueries = vi.spyOn(queryClient, 'cancelQueries');
     const fetchImpl = vi
       .fn()
       .mockResolvedValue(
         jsonResponse({code: 'unauthorized', message: 'Unauthorized'}, {status: 401}),
       );
     configureApiClient({fetchImpl});
+    queryClient.setQueryData(['private-data'], 'private data');
 
     render(
-      <AuthProvider>
+      <AuthProvider queryClient={queryClient}>
         <StatusProbe />
       </AuthProvider>,
     );
 
     await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('guest'));
     expect(screen.getByTestId('email')).toHaveTextContent('none');
+    expect(cancelQueries).toHaveBeenCalledTimes(1);
+    expect(queryClient.getQueryData(['private-data'])).toBeUndefined();
   });
 
   test('keeps the current session when refresh fails with a server error', async () => {
@@ -116,6 +149,41 @@ describe('AuthProvider', () => {
     expect(screen.getByTestId('email')).toHaveTextContent('noe@example.com');
   });
 
+  test('preserves private cached data when refresh returns the same user', async () => {
+    const queryClient = new QueryClient();
+    const cancelQueries = vi.spyOn(queryClient, 'cancelQueries');
+    const fetchImpl = vi
+      .fn()
+      .mockImplementation(() => Promise.resolve(jsonResponse({token: 'access-token', user})));
+    configureApiClient({fetchImpl});
+    queryClient.setQueryData(['private-data'], 'current user private data');
+    const onDone = vi.fn();
+
+    function RefreshAfterBootProbe() {
+      const auth = useAuthState();
+      const refresh = useRefreshAuth();
+      const didRefresh = useRef(false);
+
+      useEffect(() => {
+        if (auth.status !== 'authenticated' || didRefresh.current) return;
+        didRefresh.current = true;
+        void refresh().then(onDone);
+      }, [auth.status, refresh]);
+
+      return <StatusProbe />;
+    }
+
+    render(
+      <AuthProvider queryClient={queryClient}>
+        <RefreshAfterBootProbe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => expect(onDone).toHaveBeenCalledTimes(1));
+    expect(cancelQueries).not.toHaveBeenCalled();
+    expect(queryClient.getQueryData(['private-data'])).toBe('current user private data');
+  });
+
   test('deduplicates concurrent refresh calls', async () => {
     const fetchImpl = vi
       .fn()
@@ -144,14 +212,30 @@ describe('AuthProvider', () => {
   });
 
   test('logout clears local state even when the API call fails', async () => {
+    const queryClient = new QueryClient();
+    const cancelQueries = vi.spyOn(queryClient, 'cancelQueries');
     const fetchImpl = vi
       .fn()
       .mockResolvedValueOnce(jsonResponse({token: 'access-token', user}))
       .mockRejectedValueOnce(new Error('offline'));
     configureApiClient({fetchImpl});
+    queryClient.setQueryData(['private-data'], 'private data');
+    const onQueryAbort = vi.fn();
+    void queryClient
+      .fetchQuery({
+        queryKey: ['in-flight-private-data'],
+        queryFn: ({signal}) =>
+          new Promise<string>((_, reject) => {
+            signal.addEventListener('abort', () => {
+              onQueryAbort();
+              reject(signal.reason);
+            });
+          }),
+      })
+      .catch(() => undefined);
 
     render(
-      <AuthProvider>
+      <AuthProvider queryClient={queryClient}>
         <StatusProbe />
       </AuthProvider>,
     );
@@ -160,5 +244,91 @@ describe('AuthProvider', () => {
     screen.getByRole('button', {name: 'Logout'}).click();
 
     await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('guest'));
+    expect(cancelQueries).toHaveBeenCalledTimes(1);
+    expect(onQueryAbort).toHaveBeenCalledTimes(1);
+    expect(queryClient.getQueryData(['private-data'])).toBeUndefined();
+  });
+
+  test('does not restore a session when logout supersedes workspace hydration', async () => {
+    const workspaceRefreshStarted = vi.fn();
+    let workspaceRequestCount = 0;
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (!request.url.endsWith('/workspaces'))
+        return Promise.resolve(jsonResponse({token: 'access-token', user}));
+
+      workspaceRequestCount += 1;
+      if (workspaceRequestCount === 1) return Promise.resolve(jsonResponse({memberships: []}));
+
+      workspaceRefreshStarted();
+      return new Promise<Response>((_, reject) => {
+        request.signal.addEventListener('abort', () => reject(request.signal.reason));
+      });
+    });
+    configureApiClient({fetchImpl});
+
+    function LogoutDuringRefreshProbe() {
+      const auth = useAuthState();
+      const logout = useLogoutAuth();
+      const refresh = useRefreshAuth();
+      const didRefresh = useRef(false);
+
+      useEffect(() => {
+        if (auth.status !== 'authenticated' || didRefresh.current) return;
+        didRefresh.current = true;
+        void refresh();
+      }, [auth.status, refresh]);
+
+      return (
+        <div>
+          <span data-testid="status">{auth.status}</span>
+          <button type="button" onClick={() => void logout.mutateAsync()}>
+            Logout
+          </button>
+        </div>
+      );
+    }
+
+    render(
+      <AuthProvider>
+        <LogoutDuringRefreshProbe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => expect(workspaceRefreshStarted).toHaveBeenCalledTimes(1));
+    screen.getByRole('button', {name: 'Logout'}).click();
+
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('guest'));
+  });
+
+  test('does not render cached private data after a user switch', async () => {
+    const queryClient = new QueryClient();
+    const cancelQueries = vi.spyOn(queryClient, 'cancelQueries');
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const url = (input as Request).url;
+      if (url.endsWith('/auth/login'))
+        return Promise.resolve(jsonResponse({token: 'other-token', user: otherUser}));
+      if (url.endsWith('/workspaces')) return Promise.resolve(jsonResponse({memberships: []}));
+      return Promise.resolve(jsonResponse({token: 'access-token', user}));
+    });
+    configureApiClient({fetchImpl});
+    queryClient.setQueryData(['private-data'], 'User A private data');
+
+    render(
+      <AuthProvider queryClient={queryClient}>
+        <PrivateDataProbe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('private-data')).toHaveTextContent('User A private data'),
+    );
+    screen.getByRole('button', {name: 'Switch user'}).click();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('private-data')).not.toHaveTextContent('User A private data'),
+    );
+    expect(cancelQueries).toHaveBeenCalledTimes(1);
+    expect(queryClient.getQueryData(['private-data'])).toBeUndefined();
   });
 });

--- a/libs/client/auth/src/hooks/api/login-auth.ts
+++ b/libs/client/auth/src/hooks/api/login-auth.ts
@@ -1,41 +1,17 @@
 import type {LoginBodyDto, LoginResponseDto} from '@shipfox/api-auth-dto';
 import {apiRequest} from '@shipfox/client-api';
-import {useMutation, useQueryClient} from '@tanstack/react-query';
-import {useSetAtom} from 'jotai';
-import {authStateAtom, toAuthenticatedState} from '#state/auth.js';
-import {authRefreshQueryKey} from './refresh-auth.js';
-import {listUserWorkspaces, userWorkspacesQueryKey} from './workspace-auth.js';
+import {useMutation} from '@tanstack/react-query';
+import {useAuthTransition} from '#state/auth.js';
 
 export async function loginAuth(body: LoginBodyDto) {
   return await apiRequest<LoginResponseDto>('/auth/login', {method: 'POST', body});
 }
 
 export function useLoginAuth() {
-  const queryClient = useQueryClient();
-  const setState = useSetAtom(authStateAtom);
+  const {enterAuthenticated} = useAuthTransition();
 
   return useMutation({
     mutationFn: loginAuth,
-    onSuccess: async (result) => {
-      queryClient.setQueryData(authRefreshQueryKey, result);
-      // Resolve workspaces before flipping auth state to authenticated. A
-      // single atomic setState avoids the intermediate window where the user
-      // appears authenticated with zero workspaces, which sent users with
-      // workspaces straight to `/setup/workspaces/new` after form login.
-      let memberships: Awaited<ReturnType<typeof listUserWorkspaces>>['memberships'] = [];
-      try {
-        const workspaces = await queryClient.fetchQuery({
-          queryKey: userWorkspacesQueryKey,
-          queryFn: () => listUserWorkspaces(result.token),
-          retry: false,
-          staleTime: 0,
-        });
-        memberships = workspaces.memberships;
-        queryClient.setQueryData(userWorkspacesQueryKey, workspaces);
-      } catch {
-        // The user is authenticated even if workspace hydration fails.
-      }
-      setState(toAuthenticatedState(result, memberships));
-    },
+    onSuccess: enterAuthenticated,
   });
 }

--- a/libs/client/auth/src/hooks/api/logout-auth.ts
+++ b/libs/client/auth/src/hooks/api/logout-auth.ts
@@ -1,8 +1,6 @@
 import {apiRequest} from '@shipfox/client-api';
-import {useMutation, useQueryClient} from '@tanstack/react-query';
-import {useSetAtom} from 'jotai';
-import {authStateAtom} from '#state/auth.js';
-import {authRefreshQueryKey} from './refresh-auth.js';
+import {useMutation} from '@tanstack/react-query';
+import {useAuthTransition} from '#state/auth.js';
 
 async function logoutAuth() {
   try {
@@ -13,14 +11,10 @@ async function logoutAuth() {
 }
 
 export function useLogoutAuth() {
-  const queryClient = useQueryClient();
-  const setState = useSetAtom(authStateAtom);
+  const {enterGuest} = useAuthTransition();
 
   return useMutation({
     mutationFn: logoutAuth,
-    onSettled: () => {
-      setState({status: 'guest'});
-      queryClient.removeQueries({queryKey: authRefreshQueryKey});
-    },
+    onSettled: enterGuest,
   });
 }

--- a/libs/client/auth/src/hooks/api/password-reset-auth.ts
+++ b/libs/client/auth/src/hooks/api/password-reset-auth.ts
@@ -4,11 +4,8 @@ import type {
   PasswordResetRequestBodyDto,
 } from '@shipfox/api-auth-dto';
 import {apiRequest} from '@shipfox/client-api';
-import {useMutation, useQueryClient} from '@tanstack/react-query';
-import {useSetAtom} from 'jotai';
-import {authStateAtom, toAuthenticatedState} from '#state/auth.js';
-import {authRefreshQueryKey} from './refresh-auth.js';
-import {listUserWorkspaces, userWorkspacesQueryKey} from './workspace-auth.js';
+import {useMutation} from '@tanstack/react-query';
+import {useAuthTransition} from '#state/auth.js';
 
 export async function requestPasswordReset(body: PasswordResetRequestBodyDto) {
   await apiRequest<void>('/auth/password-reset', {method: 'POST', body});
@@ -26,26 +23,10 @@ export function useRequestPasswordResetAuth() {
 }
 
 export function useConfirmPasswordResetAuth() {
-  const queryClient = useQueryClient();
-  const setState = useSetAtom(authStateAtom);
+  const {enterAuthenticated} = useAuthTransition();
 
   return useMutation({
     mutationFn: confirmPasswordReset,
-    onSuccess: async (result) => {
-      setState(toAuthenticatedState(result));
-      queryClient.setQueryData(authRefreshQueryKey, result);
-      try {
-        const workspaces = await queryClient.fetchQuery({
-          queryKey: userWorkspacesQueryKey,
-          queryFn: () => listUserWorkspaces(result.token),
-          retry: false,
-          staleTime: 0,
-        });
-        setState(toAuthenticatedState(result, workspaces.memberships));
-        queryClient.setQueryData(userWorkspacesQueryKey, workspaces);
-      } catch {
-        // The user is authenticated even if workspace hydration fails.
-      }
-    },
+    onSuccess: enterAuthenticated,
   });
 }

--- a/libs/client/auth/src/hooks/api/verify-email-auth.ts
+++ b/libs/client/auth/src/hooks/api/verify-email-auth.ts
@@ -5,11 +5,8 @@ import type {
   VerifyEmailResendResponseDto,
 } from '@shipfox/api-auth-dto';
 import {apiRequest} from '@shipfox/client-api';
-import {useMutation, useQueryClient} from '@tanstack/react-query';
-import {useSetAtom} from 'jotai';
-import {authStateAtom, toAuthenticatedState} from '#state/auth.js';
-import {authRefreshQueryKey} from './refresh-auth.js';
-import {listUserWorkspaces, userWorkspacesQueryKey} from './workspace-auth.js';
+import {useMutation} from '@tanstack/react-query';
+import {useAuthTransition} from '#state/auth.js';
 
 async function verifyEmailAuth(body: VerifyEmailConfirmBodyDto) {
   return await apiRequest<VerifyEmailConfirmResponseDto>('/auth/verify-email/confirm', {
@@ -30,26 +27,10 @@ export function useResendEmailVerificationAuth() {
 }
 
 export function useVerifyEmailAuth() {
-  const queryClient = useQueryClient();
-  const setState = useSetAtom(authStateAtom);
+  const {enterAuthenticated} = useAuthTransition();
 
   return useMutation({
     mutationFn: verifyEmailAuth,
-    onSuccess: async (result) => {
-      setState(toAuthenticatedState(result));
-      queryClient.setQueryData(authRefreshQueryKey, result);
-      try {
-        const workspaces = await queryClient.fetchQuery({
-          queryKey: userWorkspacesQueryKey,
-          queryFn: () => listUserWorkspaces(result.token),
-          retry: false,
-          staleTime: 0,
-        });
-        setState(toAuthenticatedState(result, workspaces.memberships));
-        queryClient.setQueryData(userWorkspacesQueryKey, workspaces);
-      } catch {
-        // The user is authenticated even if workspace hydration fails.
-      }
-    },
+    onSuccess: enterAuthenticated,
   });
 }

--- a/libs/client/auth/src/state/auth.ts
+++ b/libs/client/auth/src/state/auth.ts
@@ -6,6 +6,7 @@ export {
   authStateAtom,
   initialAuthState,
   toAuthenticatedState,
+  useAuthTransition,
   type Workspace,
 } from '@shipfox/client-shell/runtime';
 

--- a/libs/client/shell/src/runtime/auth.tsx
+++ b/libs/client/shell/src/runtime/auth.tsx
@@ -34,6 +34,7 @@ export interface AuthStateValue extends AuthState {
 
 export const initialAuthState: AuthState = {status: 'loading'};
 export const authStateAtom = atom<AuthState>(initialAuthState);
+const authTransitionEpochAtom = atom(0);
 export const authRefreshQueryKey = ['auth', 'refresh'] as const;
 export const userWorkspacesQueryKey = ['workspaces', 'mine'] as const;
 
@@ -101,17 +102,36 @@ export function getAuthRefreshDelayMs(token: string, nowMs = Date.now()): number
   return exp === undefined ? undefined : exp * 1000 - nowMs - REFRESH_EARLY_MS;
 }
 
-export function useRefreshAuth() {
+export function useAuthTransition() {
   const queryClient = useQueryClient();
+  const store = useStore();
   const setState = useSetAtom(authStateAtom);
-  return useCallback(async () => {
-    try {
-      const result = await queryClient.fetchQuery({
-        queryKey: authRefreshQueryKey,
-        queryFn: refreshAuthRequest,
-        retry: false,
-        staleTime: 0,
-      });
+
+  const clearPrivateState = useCallback(async () => {
+    await queryClient.cancelQueries();
+    queryClient.clear();
+  }, [queryClient]);
+
+  const enterGuest = useCallback(async () => {
+    const transitionEpoch = store.get(authTransitionEpochAtom) + 1;
+    store.set(authTransitionEpochAtom, transitionEpoch);
+    await clearPrivateState();
+    if (store.get(authTransitionEpochAtom) !== transitionEpoch) return;
+    setState({status: 'guest'});
+  }, [clearPrivateState, setState, store]);
+
+  const enterAuthenticated = useCallback(
+    async (result: LoginResponseDto) => {
+      const transitionEpoch = store.get(authTransitionEpochAtom) + 1;
+      store.set(authTransitionEpochAtom, transitionEpoch);
+      const previousState = store.get(authStateAtom);
+      const principalChanged =
+        previousState.status === 'authenticated' && previousState.user?.id !== result.user.id;
+
+      if (principalChanged) await clearPrivateState();
+      if (store.get(authTransitionEpochAtom) !== transitionEpoch) return;
+
+      queryClient.setQueryData(authRefreshQueryKey, result);
       let memberships: MembershipWithWorkspaceDto[] = [];
       try {
         const workspaces = await queryClient.fetchQuery({
@@ -121,16 +141,38 @@ export function useRefreshAuth() {
           staleTime: 0,
         });
         memberships = workspaces.memberships;
+        queryClient.setQueryData(userWorkspacesQueryKey, workspaces);
       } catch {
-        // A valid session remains usable while workspace hydration retries on the next route load.
+        // The authenticated session remains usable while workspace hydration retries on the next route load.
       }
+      if (store.get(authTransitionEpochAtom) !== transitionEpoch) return;
+
       setState(toAuthenticatedState(result, memberships));
+    },
+    [clearPrivateState, queryClient, setState, store],
+  );
+
+  return {enterAuthenticated, enterGuest};
+}
+
+export function useRefreshAuth() {
+  const queryClient = useQueryClient();
+  const {enterAuthenticated, enterGuest} = useAuthTransition();
+  return useCallback(async () => {
+    try {
+      const result = await queryClient.fetchQuery({
+        queryKey: authRefreshQueryKey,
+        queryFn: refreshAuthRequest,
+        retry: false,
+        staleTime: 0,
+      });
+      await enterAuthenticated(result);
       return result;
     } catch (error) {
-      if (error instanceof ApiError && error.status === 401) setState({status: 'guest'});
+      if (error instanceof ApiError && error.status === 401) await enterGuest();
       throw error;
     }
-  }, [queryClient, setState]);
+  }, [enterAuthenticated, enterGuest, queryClient]);
 }
 
 export interface AuthRuntimeProps extends PropsWithChildren {


### PR DESCRIPTION
Isolates the React Query cache whenever an authenticated session becomes guest or changes to another user, while preserving healthy cache data across same-user token rotation.

A stale background refresh could otherwise repopulate a logged-out session after private data had been cleared. The shell now owns all session transitions, cancels in-flight queries, clears the cache, and rejects superseded transition commits.

Adds coverage for failed refresh, offline logout, in-flight query cancellation, principal switches, same-user refreshes, and logout during workspace hydration.

Closes ENG-1122

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates private React Query caches by principal. We now cancel in-flight requests and clear the cache on logout or user switch, while keeping cache intact on same-user token refresh. Fixes ENG-1122 by preventing stale refreshes from restoring a cleared session.

- **Bug Fixes**
  - Cancel in-flight queries and clear the cache on logout or principal change to prevent private data leaks.
  - Preserve cached data when refresh returns the same user; stale refreshes no longer repopulate a guest session.
  - Reject superseded transitions so workspace hydration can’t restore a session after logout.

- **Refactors**
  - Added useAuthTransition in `@shipfox/client-shell` to centralize guest/auth transitions.
  - Updated `@shipfox/client-auth` hooks (login, logout, verify email, password reset) to use the new transition API and defer workspace hydration to the shell.
  - Added tests for refresh failures, offline logout, in-flight cancellation, principal switches, and logout during hydration.

<sup>Written for commit 5abfac41c3b12ca2d90135d5c350fe482a7c306a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

