### PR TITLE
[api/auth] Add stable refresh-session context

### DIFF
--- a/.changeset/bright-lobsters-sprint.md
+++ b/.changeset/bright-lobsters-sprint.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-auth": minor
+---
+
+Adds authenticated refresh-session context resolution with stable identity across access-token refreshes.

--- a/libs/api/auth/README.md
+++ b/libs/api/auth/README.md
@@ -250,6 +250,7 @@ It also exports lower-level pieces for tests and advanced integration:
 - `issueRunnerSessionToken(claims)` / `verifyRunnerSessionToken(token)`: mint and verify runner session tokens.
 - `issueJobLeaseToken(claims)` / `verifyJobLeaseToken(token)`: mint and verify job lease tokens.
 - `getClientContext(request)`: reads the authenticated user context from a Fastify request.
+- `getAuthenticatedSessionContext(request)`: resolves an authenticated request to its user ID and active refresh-session ID.
 - `findUserByEmail({email})`: read-only lookup of the current owner of a normalized email; see below.
 - Entity types: `User`, `UserStatus`, `RefreshToken`, `PasswordReset`, and `EmailOwner`.
 
@@ -332,6 +333,24 @@ public contract.
 `createJwtAuthMethod`, `createRunnerSessionAuthMethod`, and
 `createLeaseTokenAuthMethod` make request-auth methods. They do not add a
 user-facing login method.
+
+### Authenticated session context
+
+`getAuthenticatedSessionContext(request)` returns the stable refresh-session
+identity behind an authenticated user request:
+
+```ts
+import {getAuthenticatedSessionContext} from '@shipfox/api-auth';
+
+const session = await getAuthenticatedSessionContext(request);
+// {userId, refreshSessionId}
+```
+
+The refresh-session ID remains the same when its refresh token rotates. The
+helper verifies that the session is active and belongs to the authenticated user,
+and returns the standard `401 unauthorized` error for a missing, malformed,
+expired, or revoked session. It exposes neither refresh-token material nor
+storage details.
 
 ## Data Model
 

--- a/libs/api/auth/drizzle/0000_initial.sql
+++ b/libs/api/auth/drizzle/0000_initial.sql
@@ -35,6 +35,7 @@ CREATE TABLE "auth_rate_limits" (
 --> statement-breakpoint
 CREATE TABLE "auth_refresh_tokens" (
 	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
+	"session_id" uuid DEFAULT uuidv7() NOT NULL,
 	"user_id" uuid NOT NULL,
 	"hashed_token" text NOT NULL,
 	"expires_at" timestamp with time zone NOT NULL,
@@ -65,5 +66,6 @@ CREATE INDEX "auth_password_resets_user_id_idx" ON "auth_password_resets" USING 
 CREATE UNIQUE INDEX "auth_rate_limits_window_unique" ON "auth_rate_limits" USING btree ("action","scope","identifier_hmac","window_start");--> statement-breakpoint
 CREATE INDEX "auth_rate_limits_expires_at_idx" ON "auth_rate_limits" USING btree ("expires_at");--> statement-breakpoint
 CREATE UNIQUE INDEX "auth_refresh_tokens_hashed_token_unique" ON "auth_refresh_tokens" USING btree ("hashed_token");--> statement-breakpoint
+CREATE UNIQUE INDEX "auth_refresh_tokens_active_session_unique" ON "auth_refresh_tokens" USING btree ("user_id","session_id") WHERE "auth_refresh_tokens"."revoked_at" IS NULL AND "auth_refresh_tokens"."rotated_at" IS NULL;--> statement-breakpoint
 CREATE INDEX "auth_refresh_tokens_user_id_idx" ON "auth_refresh_tokens" USING btree ("user_id");--> statement-breakpoint
 CREATE UNIQUE INDEX "auth_users_email_unique" ON "auth_users" USING btree ("email");

--- a/libs/api/auth/drizzle/meta/0000_snapshot.json
+++ b/libs/api/auth/drizzle/meta/0000_snapshot.json
@@ -143,6 +143,13 @@
           "notNull": true,
           "default": "uuidv7()"
         },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
         "user_id": {
           "name": "user_id",
           "type": "uuid",
@@ -411,6 +418,28 @@
             }
           ],
           "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_refresh_tokens_active_session_unique": {
+          "name": "auth_refresh_tokens_active_session_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"auth_refresh_tokens\".\"revoked_at\" IS NULL AND \"auth_refresh_tokens\".\"rotated_at\" IS NULL",
           "concurrently": false,
           "method": "btree",
           "with": {}

--- a/libs/api/auth/src/core/auth.test.ts
+++ b/libs/api/auth/src/core/auth.test.ts
@@ -334,6 +334,32 @@ describe('auth core', () => {
     expect(refreshed.user.id).toBe(user.id);
   });
 
+  test('keeps the refresh-session identity stable across a token refresh', async () => {
+    const user = await userFactory.create({emailVerifiedAt: new Date()});
+    const initial = await login({email: user.email, password: user.plainPassword});
+    const refreshed = await refreshAccessToken({refreshToken: initial.refreshToken});
+    const initialClaims = await verifyUserToken({
+      token: initial.token,
+      secret: userAccessTokenKey(),
+    });
+    const refreshedClaims = await verifyUserToken({
+      token: refreshed.token,
+      secret: userAccessTokenKey(),
+    });
+
+    expect(refreshedClaims.refreshSessionId).toBe(initialClaims.refreshSessionId);
+  });
+
+  test('issues different refresh-session identities for separate sessions of one user', async () => {
+    const user = await userFactory.create({emailVerifiedAt: new Date()});
+    const first = await login({email: user.email, password: user.plainPassword});
+    const second = await login({email: user.email, password: user.plainPassword});
+    const firstClaims = await verifyUserToken({token: first.token, secret: userAccessTokenKey()});
+    const secondClaims = await verifyUserToken({token: second.token, secret: userAccessTokenKey()});
+
+    expect(secondClaims.refreshSessionId).not.toBe(firstClaims.refreshSessionId);
+  });
+
   test('refreshAccessToken tolerates a concurrent reuse within the grace window', async () => {
     const user = await userFactory.create({emailVerifiedAt: new Date()});
     const loginResult = await login({email: user.email, password: user.plainPassword});
@@ -485,6 +511,21 @@ describe('auth core', () => {
       hashedToken: hashOpaqueToken(loginResult.refreshToken),
     });
     expect(active).toBeUndefined();
+  });
+
+  test('logout revokes the active successor when presented a rotated refresh token', async () => {
+    const user = await userFactory.create({emailVerifiedAt: new Date()});
+    const loginResult = await login({email: user.email, password: user.plainPassword});
+    const refreshed = await refreshAccessToken({refreshToken: loginResult.refreshToken});
+
+    await logout({refreshToken: loginResult.refreshToken});
+
+    const successor = refreshed.refreshToken
+      ? await refreshTokenDb.findActiveRefreshTokenByHash({
+          hashedToken: hashOpaqueToken(refreshed.refreshToken),
+        })
+      : undefined;
+    expect(successor).toBeUndefined();
   });
 
   test('getCurrentUser returns the user', async () => {

--- a/libs/api/auth/src/core/auth.ts
+++ b/libs/api/auth/src/core/auth.ts
@@ -18,7 +18,7 @@ import {
   createRefreshToken,
   findActiveRefreshTokenByHash,
   findRefreshTokenByHash,
-  revokeRefreshTokenByHash,
+  revokeRefreshSession,
   revokeRefreshTokensForUser,
   rotateRefreshToken,
 } from '#db/refresh-tokens.js';
@@ -73,6 +73,7 @@ function recordRefreshOutcome(outcome: AuthTokenRefreshOutcome): void {
 async function signAccessToken(
   user: User,
   workspaces: WorkspacesInterModuleClient,
+  refreshSessionId: string,
 ): Promise<string> {
   const memberships = await workspaces
     .listMembershipsForTokenClaims({userId: user.id})
@@ -84,6 +85,7 @@ async function signAccessToken(
     email: user.email,
     name: user.name,
     memberships: memberships.memberships,
+    refreshSessionId,
     secret: userAccessTokenKey(),
     expiresIn: config.AUTH_JWT_EXPIRES_IN,
   });
@@ -95,14 +97,28 @@ function isWithinRotationGrace(refreshToken: RefreshToken): boolean {
   return Date.now() - refreshToken.rotatedAt.getTime() <= graceMs;
 }
 
-async function createRefreshSession(user: User): Promise<string> {
+async function createRefreshSession(
+  user: User,
+  refreshSessionId: string,
+): Promise<{refreshToken: string; refreshSessionId: string}> {
   const refreshToken = generateOpaqueToken('refreshToken');
-  await createRefreshToken({
+  const session = await createRefreshToken({
+    sessionId: refreshSessionId,
     userId: user.id,
     hashedToken: hashOpaqueToken(refreshToken),
     expiresAt: daysFromNow(config.AUTH_REFRESH_TOKEN_EXPIRES_IN_DAYS),
   });
-  return refreshToken;
+  return {refreshToken, refreshSessionId: session.sessionId};
+}
+
+async function createSessionTokens(
+  user: User,
+  workspaces: WorkspacesInterModuleClient,
+): Promise<{token: string; refreshToken: string}> {
+  const refreshSessionId = crypto.randomUUID();
+  const token = await signAccessToken(user, workspaces, refreshSessionId);
+  const {refreshToken} = await createRefreshSession(user, refreshSessionId);
+  return {token, refreshToken};
 }
 
 function passwordResetLink(rawToken: string): string {
@@ -271,8 +287,7 @@ export async function signupWithInvitation(
 
   // Step 4: Issue session. signAccessToken reads memberships through the
   // workspaces module API, so a successful accept is reflected in the JWT.
-  const token = await signAccessToken(user, params.workspaces);
-  const refreshToken = await createRefreshSession(user);
+  const {token, refreshToken} = await createSessionTokens(user, params.workspaces);
 
   if (acceptError) {
     return {token, refreshToken, user, membership, acceptError};
@@ -334,8 +349,7 @@ export async function login(params: LoginParams): Promise<LoginResult> {
     throw new EmailNotVerifiedError();
   }
 
-  const token = await signAccessToken(user, params.workspaces);
-  const refreshToken = await createRefreshSession(user);
+  const {token, refreshToken} = await createSessionTokens(user, params.workspaces);
 
   return {token, refreshToken, user};
 }
@@ -377,8 +391,7 @@ export async function createSessionForUser(
     throw new InvalidCredentialsError();
   }
 
-  const token = await signAccessToken(user, params.workspaces);
-  const refreshToken = await createRefreshSession(user);
+  const {token, refreshToken} = await createSessionTokens(user, params.workspaces);
 
   return {token, refreshToken, user};
 }
@@ -403,7 +416,7 @@ export async function refreshAccessToken(params: {
 
   const user = await findUserById({id: current.userId});
   if (user?.status !== 'active') {
-    await revokeRefreshTokenByHash({hashedToken: currentHashedToken});
+    await revokeRefreshSession({sessionId: current.sessionId, userId: current.userId});
     recordRefreshOutcome('rejected');
     throw new TokenInvalidError('Refresh token is invalid or expired');
   }
@@ -412,7 +425,7 @@ export async function refreshAccessToken(params: {
   // second tab); past it, reuse of a retired token means a compromised session.
   if (current.rotatedAt) {
     if (isWithinRotationGrace(current)) {
-      const token = await signAccessToken(user, params.workspaces);
+      const token = await signAccessToken(user, params.workspaces, current.sessionId);
       recordRefreshOutcome('grace');
       return {token, refreshToken: undefined, user};
     }
@@ -436,12 +449,12 @@ export async function refreshAccessToken(params: {
       recordRefreshOutcome('rejected');
       throw new TokenInvalidError('Refresh token is invalid or expired');
     }
-    const token = await signAccessToken(user, params.workspaces);
+    const token = await signAccessToken(user, params.workspaces, latest.sessionId);
     recordRefreshOutcome('grace');
     return {token, refreshToken: undefined, user};
   }
 
-  const token = await signAccessToken(user, params.workspaces);
+  const token = await signAccessToken(user, params.workspaces, current.sessionId);
   recordRefreshOutcome('rotated');
   return {token, refreshToken: nextRefreshToken, user};
 }
@@ -476,8 +489,7 @@ export async function confirmEmailVerification(params: {
     throw new TokenInvalidError('Verification code is invalid or expired');
   }
 
-  const token = await signAccessToken(verifiedUser, params.workspaces);
-  const refreshToken = await createRefreshSession(verifiedUser);
+  const {token, refreshToken} = await createSessionTokens(verifiedUser, params.workspaces);
 
   return {token, refreshToken, user: verifiedUser};
 }
@@ -548,8 +560,7 @@ export async function confirmPasswordReset(params: {
 
   await revokeRefreshTokensForUser({userId: consumed.userId});
 
-  const token = await signAccessToken(user, params.workspaces);
-  const refreshToken = await createRefreshSession(user);
+  const {token, refreshToken} = await createSessionTokens(user, params.workspaces);
 
   return {token, refreshToken, user};
 }
@@ -587,7 +598,11 @@ export async function changePassword(params: {
 
 export async function logout(params: {refreshToken?: string | undefined}): Promise<void> {
   if (!params.refreshToken) return;
-  await revokeRefreshTokenByHash({hashedToken: hashOpaqueToken(params.refreshToken)});
+  const refreshToken = await findRefreshTokenByHash({
+    hashedToken: hashOpaqueToken(params.refreshToken),
+  });
+  if (!refreshToken) return;
+  await revokeRefreshSession({sessionId: refreshToken.sessionId, userId: refreshToken.userId});
 }
 
 export interface GetCurrentUserResult {

--- a/libs/api/auth/src/core/entities/refresh-token.ts
+++ b/libs/api/auth/src/core/entities/refresh-token.ts
@@ -1,5 +1,6 @@
 export interface RefreshToken {
   id: string;
+  sessionId: string;
   userId: string;
   hashedToken: string;
   expiresAt: Date;

--- a/libs/api/auth/src/core/jwt.ts
+++ b/libs/api/auth/src/core/jwt.ts
@@ -12,6 +12,7 @@ export type TokenMembership = z.infer<typeof tokenMembershipSchema>;
 
 export const userTokenClaimsSchema = z.object({
   sub: z.string().uuid(),
+  refreshSessionId: z.string().uuid().optional(),
   email: z.string().email(),
   name: z.string().nullable().optional(),
   memberships: z.array(tokenMembershipSchema),
@@ -22,6 +23,7 @@ export const userTokenClaimsSchema = z.object({
 export type UserTokenClaims = z.infer<typeof userTokenClaimsSchema>;
 
 export interface SignUserTokenParams {
+  refreshSessionId?: string | undefined;
   userId: string;
   email: string;
   name?: string | null | undefined;
@@ -41,6 +43,7 @@ export async function signUserToken(params: SignUserTokenParams): Promise<string
       email: params.email,
       name: params.name ?? null,
       memberships: params.memberships,
+      refreshSessionId: params.refreshSessionId,
     },
     secret: params.secret,
     expiresIn: params.expiresIn,

--- a/libs/api/auth/src/db/refresh-tokens.test.ts
+++ b/libs/api/auth/src/db/refresh-tokens.test.ts
@@ -1,8 +1,10 @@
 import {hashOpaqueToken} from '@shipfox/node-tokens';
 import {
   createRefreshToken,
+  findActiveRefreshSession,
   findActiveRefreshTokenByHash,
   findRefreshTokenByHash,
+  revokeRefreshSession,
   revokeRefreshTokenByHash,
   revokeRefreshTokensForUser,
   rotateRefreshToken,
@@ -41,6 +43,24 @@ describe('refresh-tokens db', () => {
     const found = await findActiveRefreshTokenByHash({hashedToken});
 
     expect(found).toBeUndefined();
+  });
+
+  test('finds only the active session owned by the requested user', async () => {
+    const user = await createUser({email: emailFor('rt-session'), hashedPassword: 'h'});
+    const otherUser = await createUser({email: emailFor('rt-session-other'), hashedPassword: 'h'});
+    const sessionId = crypto.randomUUID();
+    await createRefreshToken({
+      userId: user.id,
+      sessionId,
+      hashedToken: hashOpaqueToken(`active-${crypto.randomUUID()}`),
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+
+    const found = await findActiveRefreshSession({sessionId, userId: user.id});
+    const otherUserFound = await findActiveRefreshSession({sessionId, userId: otherUser.id});
+
+    expect(found?.sessionId).toBe(sessionId);
+    expect(otherUserFound).toBeUndefined();
   });
 
   test('rotates a token once, creates the successor, and only the first caller wins', async () => {
@@ -137,6 +157,28 @@ describe('refresh-tokens db', () => {
     const found = await findActiveRefreshTokenByHash({hashedToken});
 
     expect(found).toBeUndefined();
+  });
+
+  test('revokes every token in one refresh-session lineage', async () => {
+    const user = await createUser({email: emailFor('rt-revoke-session'), hashedPassword: 'h'});
+    const currentHashedToken = hashOpaqueToken(`current-${crypto.randomUUID()}`);
+    const nextHashedToken = hashOpaqueToken(`next-${crypto.randomUUID()}`);
+    const created = await createRefreshToken({
+      userId: user.id,
+      hashedToken: currentHashedToken,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    await rotateRefreshToken({
+      id: created.id,
+      currentHashedToken,
+      nextHashedToken,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+
+    await revokeRefreshSession({sessionId: created.sessionId, userId: user.id});
+
+    expect(await findRefreshTokenByHash({hashedToken: currentHashedToken})).toBeUndefined();
+    expect(await findActiveRefreshTokenByHash({hashedToken: nextHashedToken})).toBeUndefined();
   });
 
   test('revokes all user refresh tokens except the selected session', async () => {

--- a/libs/api/auth/src/db/refresh-tokens.ts
+++ b/libs/api/auth/src/db/refresh-tokens.ts
@@ -4,6 +4,7 @@ import {db} from './db.js';
 import {refreshTokens, toRefreshToken} from './schema/refresh-tokens.js';
 
 export interface CreateRefreshTokenParams {
+  sessionId?: string | undefined;
   userId: string;
   hashedToken: string;
   expiresAt: Date;
@@ -13,6 +14,7 @@ export async function createRefreshToken(params: CreateRefreshTokenParams): Prom
   const rows = await db()
     .insert(refreshTokens)
     .values({
+      sessionId: params.sessionId,
       userId: params.userId,
       hashedToken: params.hashedToken,
       expiresAt: params.expiresAt,
@@ -39,6 +41,29 @@ export async function findActiveRefreshTokenByHash(params: {
     .where(
       and(
         eq(refreshTokens.hashedToken, params.hashedToken),
+        isNull(refreshTokens.revokedAt),
+        isNull(refreshTokens.rotatedAt),
+        gt(refreshTokens.expiresAt, sql`now()`),
+      ),
+    )
+    .limit(1);
+
+  const row = rows[0];
+  if (!row) return undefined;
+  return toRefreshToken(row);
+}
+
+export async function findActiveRefreshSession(params: {
+  sessionId: string;
+  userId: string;
+}): Promise<RefreshToken | undefined> {
+  const rows = await db()
+    .select()
+    .from(refreshTokens)
+    .where(
+      and(
+        eq(refreshTokens.sessionId, params.sessionId),
+        eq(refreshTokens.userId, params.userId),
         isNull(refreshTokens.revokedAt),
         isNull(refreshTokens.rotatedAt),
         gt(refreshTokens.expiresAt, sql`now()`),
@@ -113,6 +138,7 @@ export async function rotateRefreshToken(params: {
     const successorRows = await tx
       .insert(refreshTokens)
       .values({
+        sessionId: rotated.sessionId,
         userId: rotated.userId,
         hashedToken: params.nextHashedToken,
         expiresAt: params.expiresAt,
@@ -130,6 +156,22 @@ export async function revokeRefreshTokenByHash(params: {hashedToken: string}): P
     .update(refreshTokens)
     .set({revokedAt: sql`now()`, updatedAt: sql`now()`})
     .where(and(eq(refreshTokens.hashedToken, params.hashedToken), isNull(refreshTokens.revokedAt)));
+}
+
+export async function revokeRefreshSession(params: {
+  sessionId: string;
+  userId: string;
+}): Promise<void> {
+  await db()
+    .update(refreshTokens)
+    .set({revokedAt: sql`now()`, updatedAt: sql`now()`})
+    .where(
+      and(
+        eq(refreshTokens.sessionId, params.sessionId),
+        eq(refreshTokens.userId, params.userId),
+        isNull(refreshTokens.revokedAt),
+      ),
+    );
 }
 
 export async function revokeRefreshTokensForUser(params: {

--- a/libs/api/auth/src/db/schema/refresh-tokens.ts
+++ b/libs/api/auth/src/db/schema/refresh-tokens.ts
@@ -1,4 +1,5 @@
 import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
+import {sql} from 'drizzle-orm';
 import {index, text, timestamp, uniqueIndex, uuid} from 'drizzle-orm/pg-core';
 import type {RefreshToken} from '#core/entities/refresh-token.js';
 import {pgTable} from './common.js';
@@ -8,6 +9,7 @@ export const refreshTokens = pgTable(
   'refresh_tokens',
   {
     id: uuidv7PrimaryKey(),
+    sessionId: uuid('session_id').notNull().default(sql`uuidv7()`),
     userId: uuid('user_id')
       .notNull()
       .references(() => users.id, {onDelete: 'cascade'}),
@@ -21,6 +23,9 @@ export const refreshTokens = pgTable(
   },
   (table) => [
     uniqueIndex('auth_refresh_tokens_hashed_token_unique').on(table.hashedToken),
+    uniqueIndex('auth_refresh_tokens_active_session_unique')
+      .on(table.userId, table.sessionId)
+      .where(sql`${table.revokedAt} IS NULL AND ${table.rotatedAt} IS NULL`),
     index('auth_refresh_tokens_user_id_idx').on(table.userId),
   ],
 );
@@ -31,6 +36,7 @@ export type RefreshTokenCreateDb = typeof refreshTokens.$inferInsert;
 export function toRefreshToken(row: RefreshTokenDb): RefreshToken {
   return {
     id: row.id,
+    sessionId: row.sessionId,
     userId: row.userId,
     hashedToken: row.hashedToken,
     expiresAt: row.expiresAt,

--- a/libs/api/auth/src/index.ts
+++ b/libs/api/auth/src/index.ts
@@ -44,7 +44,13 @@ export {
   issueRunnerSessionToken,
   verifyRunnerSessionToken,
 } from '#core/runner-session-token.js';
-export {createJwtAuthMethod} from '#presentation/auth/jwt-auth.js';
+export {
+  type AuthenticatedSessionContext,
+  createJwtAuthMethod,
+  getAuthenticatedSessionContext,
+  type RefreshSessionId,
+  type UserId,
+} from '#presentation/auth/jwt-auth.js';
 export {createLeaseTokenAuthMethod} from '#presentation/auth/lease-token-auth.js';
 export {
   authCookiePlugin,

--- a/libs/api/auth/src/presentation/auth/jwt-auth.test.ts
+++ b/libs/api/auth/src/presentation/auth/jwt-auth.test.ts
@@ -1,10 +1,16 @@
 import {userAccessTokenKey} from '@shipfox/node-auth-root-key';
+import {hashOpaqueToken} from '@shipfox/node-tokens';
 import type {FastifyInstance} from 'fastify';
 import Fastify from 'fastify';
 import {serializerCompiler, validatorCompiler} from 'fastify-type-provider-zod';
 import {signUserToken} from '#core/jwt.js';
+import {
+  createRefreshToken,
+  revokeRefreshTokenByHash,
+  rotateRefreshToken,
+} from '#db/refresh-tokens.js';
 import {createUser, findUserById} from '#db/users.js';
-import {createJwtAuthMethod, getClientContext} from './jwt-auth.js';
+import {createJwtAuthMethod, getAuthenticatedSessionContext, getClientContext} from './jwt-auth.js';
 
 const SECRET = userAccessTokenKey();
 
@@ -28,6 +34,7 @@ describe('jwt-auth', () => {
     app.get('/protected', (request) => {
       return {client: getClientContext(request)};
     });
+    app.get('/session', async (request) => await getAuthenticatedSessionContext(request));
     await app.ready();
   });
 
@@ -129,6 +136,100 @@ describe('jwt-auth', () => {
     expect(res.statusCode).toBe(200);
     expect(res.json().client.userId).toBe(userId);
     expect(res.json().client.email).toBe(email);
+  });
+
+  test('resolves the active refresh-session identity from an authenticated request', async () => {
+    const user = await createUser({email: emailFor('jwt-session'), hashedPassword: 'h'});
+    const rawRefreshToken = `refresh-${crypto.randomUUID()}`;
+    const refreshToken = await createRefreshToken({
+      userId: user.id,
+      hashedToken: hashOpaqueToken(rawRefreshToken),
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const initialToken = await signUserToken({
+      userId: user.id,
+      email: user.email,
+      memberships: [],
+      refreshSessionId: refreshToken.sessionId,
+      secret: SECRET,
+      expiresIn: '7d',
+    });
+    await rotateRefreshToken({
+      id: refreshToken.id,
+      currentHashedToken: hashOpaqueToken(rawRefreshToken),
+      nextHashedToken: hashOpaqueToken(`refresh-${crypto.randomUUID()}`),
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const refreshedToken = await signUserToken({
+      userId: user.id,
+      email: user.email,
+      memberships: [],
+      refreshSessionId: refreshToken.sessionId,
+      secret: SECRET,
+      expiresIn: '7d',
+    });
+
+    const initial = await app.inject({
+      method: 'GET',
+      url: '/session',
+      headers: {authorization: `Bearer ${initialToken}`},
+    });
+    const refreshed = await app.inject({
+      method: 'GET',
+      url: '/session',
+      headers: {authorization: `Bearer ${refreshedToken}`},
+    });
+
+    expect(initial.statusCode).toBe(200);
+    expect(refreshed.statusCode).toBe(200);
+    expect(initial.json()).toEqual({userId: user.id, refreshSessionId: refreshToken.sessionId});
+    expect(refreshed.json()).toEqual(initial.json());
+  });
+
+  test('rejects an authenticated token after its refresh session is revoked', async () => {
+    const user = await createUser({email: emailFor('jwt-session-revoked'), hashedPassword: 'h'});
+    const rawRefreshToken = `refresh-${crypto.randomUUID()}`;
+    const refreshToken = await createRefreshToken({
+      userId: user.id,
+      hashedToken: hashOpaqueToken(rawRefreshToken),
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const token = await signUserToken({
+      userId: user.id,
+      email: user.email,
+      memberships: [],
+      refreshSessionId: refreshToken.sessionId,
+      secret: SECRET,
+      expiresIn: '7d',
+    });
+    await revokeRefreshTokenByHash({hashedToken: hashOpaqueToken(rawRefreshToken)});
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/session',
+      headers: {authorization: `Bearer ${token}`},
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('rejects an authenticated token without a refresh-session claim', async () => {
+    const user = await createUser({email: emailFor('jwt-old-format'), hashedPassword: 'h'});
+    const token = await signUserToken({
+      userId: user.id,
+      email: user.email,
+      memberships: [],
+      secret: SECRET,
+      expiresIn: '7d',
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/session',
+      headers: {authorization: `Bearer ${token}`},
+    });
+
+    expect(res.statusCode).toBe(401);
   });
 
   test('helpers remain available', () => {

--- a/libs/api/auth/src/presentation/auth/jwt-auth.ts
+++ b/libs/api/auth/src/presentation/auth/jwt-auth.ts
@@ -6,12 +6,26 @@ import {
   type UserContext,
 } from '@shipfox/api-auth-context';
 import {userAccessTokenKey} from '@shipfox/node-auth-root-key';
-import type {AuthMethod} from '@shipfox/node-fastify';
+import {type AuthMethod, ClientError} from '@shipfox/node-fastify';
 import type {FastifyRequest} from 'fastify';
+import type {RefreshToken} from '#core/entities/refresh-token.js';
+import type {User} from '#core/entities/user.js';
+import type {UserTokenClaims} from '#core/jwt.js';
 import {verifyUserToken} from '#core/jwt.js';
+import {findActiveRefreshSession} from '#db/refresh-tokens.js';
 import {createBearerTokenAuthMethod} from './bearer-token-auth.js';
 
+const AUTHENTICATED_SESSION_CONTEXT_KEY = Symbol.for('@shipfox/api-auth/session');
+
 export type ClientContext = UserContext;
+
+export type UserId = User['id'];
+export type RefreshSessionId = RefreshToken['sessionId'];
+
+export type AuthenticatedSessionContext = {
+  userId: UserId;
+  refreshSessionId: RefreshSessionId;
+};
 
 export interface CreateJwtAuthMethodOptions {
   secret: string;
@@ -19,6 +33,45 @@ export interface CreateJwtAuthMethodOptions {
 
 export function getClientContext(request: FastifyRequest): ClientContext | null {
   return getUserContext(request);
+}
+
+function setAuthenticatedSessionContext(request: FastifyRequest, claims: UserTokenClaims): void {
+  (request as unknown as Record<symbol, unknown>)[AUTHENTICATED_SESSION_CONTEXT_KEY] = {
+    userId: claims.sub,
+    refreshSessionId: claims.refreshSessionId,
+  };
+}
+
+function getAuthenticatedSessionTokenContext(request: FastifyRequest): {
+  userId: UserId;
+  refreshSessionId: RefreshSessionId | undefined;
+} | null {
+  return (
+    ((request as unknown as Record<symbol, unknown>)[AUTHENTICATED_SESSION_CONTEXT_KEY] as
+      | {userId: UserId; refreshSessionId: RefreshSessionId | undefined}
+      | undefined) ?? null
+  );
+}
+
+/**
+ * Resolves the active refresh session backing an authenticated user request.
+ * The session check intentionally happens only for consumers that need browser-session binding.
+ */
+export async function getAuthenticatedSessionContext(
+  request: FastifyRequest,
+): Promise<AuthenticatedSessionContext> {
+  const client = getClientContext(request);
+  const token = getAuthenticatedSessionTokenContext(request);
+  if (!client || !token || token.userId !== client.userId || !token.refreshSessionId)
+    throw new ClientError('Invalid or expired token', 'unauthorized', {status: 401});
+
+  const session = await findActiveRefreshSession({
+    sessionId: token.refreshSessionId,
+    userId: client.userId,
+  });
+  if (!session) throw new ClientError('Invalid or expired token', 'unauthorized', {status: 401});
+
+  return {userId: client.userId, refreshSessionId: session.sessionId};
 }
 
 export function createJwtAuthMethod(): AuthMethod {
@@ -34,6 +87,7 @@ export function createJwtAuthMethod(): AuthMethod {
         memberships: claims.memberships,
       });
       setUserContext(request, clientContext);
+      setAuthenticatedSessionContext(request, claims);
     },
   });
 }


### PR DESCRIPTION
Adds a public getAuthenticatedSessionContext() seam to @shipfox/api-auth.

Cloud needs to bind authenticated OAuth attempts to the browser refresh session, rather than a short-lived access token. Access tokens now carry a stable, non-secret session ID that survives refresh-token rotation; the helper verifies that the corresponding session is still active and belongs to the authenticated user.

The implementation keeps the normal JWT path stateless and performs the database lookup only for consumers that opt into browser-session binding. It also revokes refresh-session lineages as a unit, avoiding a grace-window successor remaining active after logout.

The initial auth baseline includes the active-session constraint because this deployment is pre-migration. Review the refresh-token lineage and the public request-context boundary in particular.

Closes ENG-1121

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a stable, validated refresh-session context to `@shipfox/api-auth` so flows can bind to one browser session across access-token refreshes. Also updates logout to revoke the whole refresh-session lineage. Addresses ENG-1121.

- **New Features**
  - Export `getAuthenticatedSessionContext(request)` → `{userId, refreshSessionId}`; verifies the session is active and owned by the user; returns 401 when invalid. Runs a DB check only when used.
  - Access tokens now include an optional `refreshSessionId` claim; tokens for one session keep the same ID across refreshes.
  - DB: add `session_id` to `auth_refresh_tokens` and a unique index on active, unrotated `(user_id, session_id)`; rotation preserves `session_id`.
  - New helpers: `findActiveRefreshSession`, `revokeRefreshSession`; `logout` revokes the entire refresh-session lineage.
  - Expose types `AuthenticatedSessionContext`, `RefreshSessionId`, `UserId`; README updated.

- **Migration**
  - Apply the `auth_refresh_tokens` migration adding `session_id` and the unique index.
  - Existing JWT auth flows are unchanged; only callers of `getAuthenticatedSessionContext` are gated on an active session.
  - Tokens issued before this change lack `refreshSessionId` and will be rejected by the new helper; refresh or re-login before calling it.

<sup>Written for commit 1d9a78c3e42e600658abf6d774b85c40ec7fdff5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

