### PR TITLE
Keep worktree service leases stable across renames

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,9 +133,10 @@ SHIPFOX_OLLAMA_KEEP_ALIVE=2h mise run ollama:up
 Conductor workspaces run `dev/worktree-services.mjs up` during setup. This
 creates per-worktree Docker services, leases a 20-port block from
 `~/.shipfox/shipfox-port-leases.json`, and writes the generated app environment
-to `.context/local-services/env`, which is loaded by `mise.toml`. The port lease
-does not depend on Conductor environment variables, so it also works from an
-ordinary git worktree or clone.
+to `.context/local-services/env`, which is loaded by `mise.toml`. Conductor
+workspaces use `CONDUCTOR_WORKSPACE_ID` as the stable lease identity, so a
+workspace rename keeps its ports. Ordinary git worktrees and clones fall back to
+their resolved path.
 
 Common commands:
 

--- a/dev/worktree-services.mjs
+++ b/dev/worktree-services.mjs
@@ -54,11 +54,12 @@ export function main(commandOrArgs) {
 
   const workspacePath = resolve();
   const workspaceName = basename(workspacePath);
-  const projectName = resolveProjectName(workspacePath);
+  const workspaceId = workspaceIdentity(workspacePath);
+  const projectName = resolveProjectName(workspacePath, workspaceId);
 
   switch (command) {
     case 'up':
-      up(workspaceName, projectName);
+      up(workspaceName, workspaceId, projectName);
       break;
     case 'stop':
       stop(projectName);
@@ -72,13 +73,14 @@ export function main(commandOrArgs) {
   }
 }
 
-function up(workspaceName, projectName) {
+function up(workspaceName, workspaceId, projectName) {
   mkdirSync(stateDir, {recursive: true});
 
-  const ports = portsFromBase(leasePortBlock());
+  const ports = portsFromBase(leasePortBlock({workspaceId}));
 
   writeEnvFile(portsFile, {
     SHIPFOX_WORKTREE_SERVICES_WORKSPACE: workspaceName,
+    SHIPFOX_WORKTREE_SERVICES_WORKSPACE_ID: workspaceId,
     SHIPFOX_WORKTREE_SERVICES_WORKSPACE_PATH: resolve(),
     SHIPFOX_WORKTREE_SERVICES_PROJECT: projectName,
     SHIPFOX_PORT_BASE: String(ports.base),
@@ -160,15 +162,40 @@ function cleanup(args) {
   );
 }
 
-export function leasePortBlock({workspacePath = resolve(), registryFile = portLeasesFile} = {}) {
+export function leasePortBlock({
+  workspaceId,
+  workspacePath = resolve(),
+  registryFile = portLeasesFile,
+} = {}) {
   const resolvedWorkspacePath = resolve(workspacePath);
+  const leaseWorkspaceId = workspaceId ?? resolvedWorkspacePath;
   return withPortLeaseLock(() => {
     const registry = readPortLeaseRegistry(registryFile);
-    const existingLease = registry.leases[resolvedWorkspacePath];
-    if (existingLease) return existingLease.base;
+    const existingLease = registry.leases[leaseWorkspaceId];
+    if (existingLease) {
+      existingLease.workspacePath = resolvedWorkspacePath;
+      writePortLeaseRegistry(registry, registryFile);
+      return existingLease.base;
+    }
+
+    const legacyLeaseKey = Object.entries(registry.leases).find(
+      ([leaseKey, lease]) =>
+        leaseKey === resolvedWorkspacePath || lease.workspacePath === resolvedWorkspacePath,
+    )?.[0];
+    if (legacyLeaseKey) {
+      const legacyLease = registry.leases[legacyLeaseKey];
+      delete registry.leases[legacyLeaseKey];
+      registry.leases[leaseWorkspaceId] = {...legacyLease, workspacePath: resolvedWorkspacePath};
+      writePortLeaseRegistry(registry, registryFile);
+      return legacyLease.base;
+    }
 
     const base = nextAvailablePortBlock(registry);
-    registry.leases[resolvedWorkspacePath] = {base, allocatedAt: new Date().toISOString()};
+    registry.leases[leaseWorkspaceId] = {
+      base,
+      allocatedAt: new Date().toISOString(),
+      workspacePath: resolvedWorkspacePath,
+    };
     registry.nextBase = nextPortBlock(base);
     writePortLeaseRegistry(registry, registryFile);
     return base;
@@ -179,25 +206,30 @@ export function findStalePortLeases({registryFile = portLeasesFile} = {}) {
   return withPortLeaseLock(() => {
     const registry = readPortLeaseRegistry(registryFile);
     return Object.entries(registry.leases)
-      .filter(([workspacePath]) => !existsSync(workspacePath))
-      .map(([workspacePath, lease]) => ({workspacePath, ...lease}));
+      .map(([workspaceId, lease]) => ({
+        workspaceId,
+        workspacePath: lease.workspacePath ?? workspaceId,
+        ...lease,
+      }))
+      .filter(({workspacePath}) => !existsSync(workspacePath));
   }, registryFile);
 }
 
 export function removeStalePortLeases(staleLeases, {registryFile = portLeasesFile} = {}) {
   withPortLeaseLock(() => {
     const registry = readPortLeaseRegistry(registryFile);
-    for (const {workspacePath} of staleLeases) {
-      if (!existsSync(workspacePath)) delete registry.leases[workspacePath];
+    for (const {workspaceId, workspacePath} of staleLeases) {
+      if (!existsSync(workspacePath)) delete registry.leases[workspaceId];
     }
     writePortLeaseRegistry(registry, registryFile);
   }, registryFile);
 }
 
 function releasePortLease(workspacePath, registryFile = portLeasesFile) {
+  const workspaceId = workspaceIdentity(workspacePath);
   withPortLeaseLock(() => {
     const registry = readPortLeaseRegistry(registryFile);
-    delete registry.leases[resolve(workspacePath)];
+    delete registry.leases[workspaceId];
     writePortLeaseRegistry(registry, registryFile);
   }, registryFile);
 }
@@ -391,22 +423,28 @@ export function resolveComposeFile({
   fail(`Missing ${relativePath(workspaceComposeFile)}.`);
 }
 
-function resolveProjectName(workspacePath) {
+function resolveProjectName(workspacePath, workspaceId) {
   const existing = readEnvFile(portsFile);
-  if (existing.SHIPFOX_WORKTREE_SERVICES_WORKSPACE_PATH === workspacePath) {
+  if (
+    existing.SHIPFOX_WORKTREE_SERVICES_WORKSPACE_ID === workspaceId ||
+    existing.SHIPFOX_WORKTREE_SERVICES_WORKSPACE_PATH === workspacePath
+  ) {
     return existing.SHIPFOX_WORKTREE_SERVICES_PROJECT;
   }
-  return composeProjectName(workspacePath);
+  return composeProjectName(workspacePath, workspaceId);
 }
 
-export function composeProjectName(workspacePath) {
+export function composeProjectName(
+  workspacePath,
+  workspaceId = resolve(workspacePath),
+) {
   const resolvedWorkspacePath = resolve(workspacePath);
   const workspaceName = basename(resolvedWorkspacePath);
   const normalized = workspaceName
     .toLowerCase()
     .replace(composeProjectNameInvalidChars, '-')
     .replace(composeProjectNameLeadingDashes, '');
-  const hash = createHash('sha256').update(resolvedWorkspacePath).digest('hex').slice(0, 8);
+  const hash = createHash('sha256').update(workspaceId).digest('hex').slice(0, 8);
   const suffixLength =
     composeProjectNameMaxLength - composeProjectNamePrefix.length - hash.length - 1;
   const suffix =
@@ -414,6 +452,10 @@ export function composeProjectName(workspacePath) {
       .slice(0, suffixLength)
       .replace(composeProjectNameTrailingDashes, '') || 'workspace';
   return `${composeProjectNamePrefix}${suffix}-${hash}`;
+}
+
+function workspaceIdentity(workspacePath) {
+  return process.env.CONDUCTOR_WORKSPACE_ID || resolve(workspacePath);
 }
 
 function readEnvFile(file) {

--- a/dev/worktree-services.test.mjs
+++ b/dev/worktree-services.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import {existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {existsSync, mkdirSync, mkdtempSync, renameSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {describe, test} from 'node:test';
@@ -166,6 +166,54 @@ describe('port leases', () => {
       assert.equal(leasePortBlock({workspacePath: firstWorkspace, registryFile}), 20_000);
       assert.equal(leasePortBlock({workspacePath: firstWorkspace, registryFile}), 20_000);
       assert.equal(leasePortBlock({workspacePath: secondWorkspace, registryFile}), 20_020);
+    } finally {
+      rmSync(registryDirectory, {recursive: true, force: true});
+    }
+  });
+
+  test('keeps a Conductor workspace lease after the workspace is renamed', () => {
+    const registryDirectory = mkdtempSync(join(tmpdir(), 'shipfox-port-leases-'));
+    const registryFile = join(registryDirectory, 'shipfox-port-leases.json');
+    const originalWorkspace = join(registryDirectory, 'original');
+    const renamedWorkspace = join(registryDirectory, 'renamed');
+    const workspaceId = 'conductor-workspace-123';
+    mkdirSync(originalWorkspace);
+
+    try {
+      assert.equal(
+        leasePortBlock({workspaceId, workspacePath: originalWorkspace, registryFile}),
+        20_000,
+      );
+      renameSync(originalWorkspace, renamedWorkspace);
+
+      assert.equal(
+        leasePortBlock({workspaceId, workspacePath: renamedWorkspace, registryFile}),
+        20_000,
+      );
+      assert.deepEqual(findStalePortLeases({registryFile}), []);
+    } finally {
+      rmSync(registryDirectory, {recursive: true, force: true});
+    }
+  });
+
+  test('migrates an existing path-keyed lease when Conductor provides an ID', () => {
+    const registryDirectory = mkdtempSync(join(tmpdir(), 'shipfox-port-leases-'));
+    const registryFile = join(registryDirectory, 'shipfox-port-leases.json');
+    const workspace = join(registryDirectory, 'workspace');
+    const workspaceId = 'conductor-workspace-123';
+    mkdirSync(workspace);
+    writeFileSync(
+      registryFile,
+      `${JSON.stringify({
+        version: 1,
+        range: {start: 20_000, end: 45_999, blockSize: 20},
+        nextBase: 20_020,
+        leases: {[workspace]: {base: 20_000, allocatedAt: '2026-07-22T00:00:00.000Z'}},
+      })}\n`,
+    );
+
+    try {
+      assert.equal(leasePortBlock({workspaceId, workspacePath: workspace, registryFile}), 20_000);
     } finally {
       rmSync(registryDirectory, {recursive: true, force: true});
     }


### PR DESCRIPTION
Conductor workspace paths can change when a workspace is renamed, which previously caused worktree services to allocate a new port block and Compose project identity.

Use `CONDUCTOR_WORKSPACE_ID` as the stable identity for leases and persisted service state, while retaining resolved-path fallback for ordinary Git worktrees and clones. Existing path-keyed leases migrate in place on their next setup run.

The cleanup command still uses the most recently recorded workspace path to identify removed worktrees.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep worktree service ports and Compose project identity stable across Conductor workspace renames by using `CONDUCTOR_WORKSPACE_ID`. Non-Conductor worktrees still use the resolved path.

- **Bug Fixes**
  - Use `CONDUCTOR_WORKSPACE_ID` as the stable key for port leases and Compose project names; fall back to resolved path.
  - Migrate existing path-keyed leases to the new ID on next setup without changing ports.
  - Store `workspacePath` in the lease registry so cleanup can detect removed worktrees reliably.
  - Write `SHIPFOX_WORKTREE_SERVICES_WORKSPACE_ID` to the env file; updated docs and tests to cover rename stability.

<sup>Written for commit eae13d7f530bb053046be083bb04977f985f9f1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

