### PR TITLE
[client-api] Harden response boundary checks

### DIFF
--- a/.changeset/steady-contracts-validate.md
+++ b/.changeset/steady-contracts-validate.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-api": patch
+---
+
+Fixes Standard Schema response validation when successful results include an undefined issues property.

--- a/libs/client/api/src/index.test.ts
+++ b/libs/client/api/src/index.test.ts
@@ -171,6 +171,21 @@ describe('checkedApiRequest', () => {
     expect(result).toEqual({id: 'workspace-1'});
   });
 
+  test('accepts a Standard Schema success result with an undefined issues property', async () => {
+    configureApiClient({fetchImpl: vi.fn().mockResolvedValue(jsonResponse({id: 'workspace-1'}))});
+    const schema = {
+      '~standard': {
+        version: 1 as const,
+        vendor: 'test',
+        validate: (value: unknown) => ({value: value as {id: string}, issues: undefined}),
+      },
+    };
+
+    const result = await checkedApiRequest(schema, '/workspaces/workspace-1');
+
+    expect(result).toEqual({id: 'workspace-1'});
+  });
+
   test('keeps invalid responses distinct from transport errors without retaining the payload', async () => {
     configureApiClient({
       fetchImpl: vi.fn().mockResolvedValue(jsonResponse({secret: 'do-not-expose'})),
@@ -182,5 +197,11 @@ describe('checkedApiRequest', () => {
     await expect(result).rejects.toMatchObject({code: 'invalid-response'});
     await expect(result).rejects.not.toThrow('do-not-expose');
     await expect(result.catch(isInvalidApiResponseError)).resolves.toBe(true);
+  });
+
+  test('does not classify unrelated errors as invalid API responses', () => {
+    const result = isInvalidApiResponseError(new Error('unrelated'));
+
+    expect(result).toBe(false);
   });
 });

--- a/libs/client/api/src/index.ts
+++ b/libs/client/api/src/index.ts
@@ -229,6 +229,6 @@ export async function checkedApiRequest<Schema extends StandardSchema>(
 ): Promise<StandardSchemaOutput<Schema>> {
   const response = await apiRequest<unknown>(path, options);
   const result = await schema['~standard'].validate(response);
-  if ('issues' in result) throw new InvalidApiResponseError();
+  if (result.issues) throw new InvalidApiResponseError();
   return result.value as StandardSchemaOutput<Schema>;
 }

--- a/tools/client-architecture-policy/client-architecture-baseline.json
+++ b/tools/client-architecture-policy/client-architecture-baseline.json
@@ -1,247 +1,327 @@
 [
   {
     "file": "libs/client/agent/src/components/available-provider-card.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 1
   },
   {
     "file": "libs/client/agent/src/components/available-providers-grid.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 1
   },
   {
     "file": "libs/client/agent/src/components/change-default-model-form.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 1
   },
   {
     "file": "libs/client/agent/src/components/custom-model-provider-form.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 1
   },
   {
     "file": "libs/client/agent/src/components/custom-model-provider-payload.ts",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 2
   },
   {
     "file": "libs/client/agent/src/components/default-model-field.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 1
   },
   {
     "file": "libs/client/agent/src/components/harness-availability.ts",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 1
   },
   {
     "file": "libs/client/agent/src/components/model-provider-usage-target.ts",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 2
   },
   {
     "file": "libs/client/agent/src/components/model-providers-section.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 4
   },
   {
     "file": "libs/client/agent/src/components/provider-search.ts",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 1
   },
   {
     "file": "libs/client/agent/src/components/supported-model-provider-catalog-entry.ts",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 1
   },
   {
     "file": "libs/client/agent/src/components/test-and-save-form.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 2
   },
   {
     "file": "libs/client/agent/src/pages/model-provider-onboarding-page.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 1
   },
   {
     "file": "libs/client/auth/src/pages/invitation-context.ts",
-    "rule": "api-request-outside-adapter"
+    "rule": "api-request-outside-adapter",
+    "occurrences": 1
   },
   {
     "file": "libs/client/auth/src/pages/invitation-context.ts",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 2
   },
   {
     "file": "libs/client/integrations/src/components/connection-picker.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 1
   },
   {
     "file": "libs/client/integrations/src/components/installed-integrations-section.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 2
   },
   {
     "file": "libs/client/integrations/src/components/integration-gallery-for-workspace.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 3
   },
   {
     "file": "libs/client/integrations/src/components/integration-gallery.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 1
   },
   {
     "file": "libs/client/integrations/src/components/integration-usage-events.ts",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 1
   },
   {
     "file": "libs/client/integrations/src/components/integration-usage-modal.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 1
   },
   {
     "file": "libs/client/integrations/src/components/provider-grid.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 2
   },
   {
     "file": "libs/client/integrations/src/components/repository-picker.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 1
   },
   {
     "file": "libs/client/integrations/src/components/webhook/webhook-create-modal.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 2
   },
   {
     "file": "libs/client/integrations/src/pages/linear-callback-page.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 1
   },
   {
     "file": "libs/client/integrations/src/pages/sentry-callback-page.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 1
   },
   {
     "file": "libs/client/integrations/src/pages/slack-callback-page.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 1
   },
   {
     "file": "libs/client/integrations/src/routes/github-callback.tsx",
-    "rule": "api-request-outside-adapter"
+    "rule": "api-request-outside-adapter",
+    "occurrences": 1
   },
-  { "file": "libs/client/logs/src/core/log-read.ts", "rule": "core-api-dto-import" },
-  { "file": "libs/client/logs/src/core/log-tree.ts", "rule": "core-api-dto-import" },
+  {
+    "file": "libs/client/logs/src/core/log-read.ts",
+    "rule": "core-api-dto-import",
+    "occurrences": 1
+  },
+  {
+    "file": "libs/client/logs/src/core/log-tree.ts",
+    "rule": "core-api-dto-import",
+    "occurrences": 1
+  },
   {
     "file": "libs/client/projects/src/components/source-strip.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 1
   },
   {
     "file": "libs/client/projects/src/components/workspace-setup-guard.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 2
   },
   {
     "file": "libs/client/projects/src/pages/create-project-page.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 3
   },
   {
     "file": "libs/client/projects/src/pages/project-workflows-page.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 2
   },
   {
     "file": "libs/client/projects/src/pages/projects-hub-page.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 2
   },
   {
     "file": "libs/client/runners/src/components/create-manual-registration-token-form.tsx",
-    "rule": "leaf-query-cache-ownership"
+    "rule": "leaf-query-cache-ownership",
+    "occurrences": 2
   },
   {
     "file": "libs/client/runners/src/components/create-manual-registration-token-form.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 1
   },
   {
     "file": "libs/client/runners/src/components/create-provisioner-token-form.tsx",
-    "rule": "leaf-query-cache-ownership"
+    "rule": "leaf-query-cache-ownership",
+    "occurrences": 2
   },
   {
     "file": "libs/client/runners/src/components/create-provisioner-token-form.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 1
   },
   {
     "file": "libs/client/runners/src/components/manual-registration-token-format.ts",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 1
   },
   {
     "file": "libs/client/runners/src/components/manual-registration-token-list.tsx",
-    "rule": "leaf-query-cache-ownership"
+    "rule": "leaf-query-cache-ownership",
+    "occurrences": 2
   },
   {
     "file": "libs/client/runners/src/components/manual-registration-token-list.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 1
   },
   {
     "file": "libs/client/runners/src/components/manual-registration-tokens-settings-section.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 1
   },
   {
     "file": "libs/client/runners/src/components/provisioner-token-format.ts",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 1
   },
   {
     "file": "libs/client/runners/src/components/provisioner-token-list.tsx",
-    "rule": "leaf-query-cache-ownership"
+    "rule": "leaf-query-cache-ownership",
+    "occurrences": 3
   },
   {
     "file": "libs/client/runners/src/components/provisioner-token-list.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 1
   },
   {
     "file": "libs/client/runners/src/components/provisioner-tokens-settings-section.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 1
   },
   {
     "file": "libs/client/secrets/src/components/workspace-secrets-section.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 1
   },
   {
     "file": "libs/client/secrets/src/components/workspace-variables-section.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 1
   },
-  { "file": "libs/client/shell/src/runtime/auth.tsx", "rule": "api-request-outside-adapter" },
+  {
+    "file": "libs/client/shell/src/runtime/auth.tsx",
+    "rule": "api-request-outside-adapter",
+    "occurrences": 2
+  },
   {
     "file": "libs/client/triggers/src/components/events-filter-bar.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 2
   },
   {
     "file": "libs/client/triggers/src/components/trigger-event-detail.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 2
   },
   {
     "file": "libs/client/triggers/src/components/trigger-event-result.ts",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 1
   },
   {
     "file": "libs/client/triggers/src/components/trigger-event-row.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 1
   },
   {
     "file": "libs/client/triggers/src/components/types.ts",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 2
   },
   {
     "file": "libs/client/triggers/src/pages/events-page.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 1
   },
   {
     "file": "libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 1
   },
   {
     "file": "libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 1
   },
   {
     "file": "libs/client/workflows/src/core/entities/job-execution.ts",
-    "rule": "core-api-dto-import"
+    "rule": "core-api-dto-import",
+    "occurrences": 1
   },
-  { "file": "libs/client/workflows/src/core/entities/job.ts", "rule": "core-api-dto-import" },
+  {
+    "file": "libs/client/workflows/src/core/entities/job.ts",
+    "rule": "core-api-dto-import",
+    "occurrences": 1
+  },
   {
     "file": "libs/client/workflows/src/core/entities/step-attempt.ts",
-    "rule": "core-api-dto-import"
+    "rule": "core-api-dto-import",
+    "occurrences": 1
   },
-  { "file": "libs/client/workflows/src/core/entities/step.ts", "rule": "core-api-dto-import" },
+  {
+    "file": "libs/client/workflows/src/core/entities/step.ts",
+    "rule": "core-api-dto-import",
+    "occurrences": 1
+  },
   {
     "file": "libs/client/workflows/src/core/entities/workflow-run-attempt.ts",
-    "rule": "core-api-dto-import"
+    "rule": "core-api-dto-import",
+    "occurrences": 1
   },
   {
     "file": "libs/client/workflows/src/core/entities/workflow-run.ts",
-    "rule": "core-api-dto-import"
+    "rule": "core-api-dto-import",
+    "occurrences": 1
   },
   {
     "file": "libs/client/workspace-settings/src/components/members/workspace-members-section.tsx",
-    "rule": "response-dto-in-presentation"
+    "rule": "response-dto-in-presentation",
+    "occurrences": 1
   }
 ]

--- a/tools/client-architecture-policy/src/audit-client-architecture.ts
+++ b/tools/client-architecture-policy/src/audit-client-architecture.ts
@@ -5,6 +5,7 @@ import {fileURLToPath} from 'node:url';
 
 export interface ClientArchitectureViolation {
   file: string;
+  occurrences: number;
   rule:
     | 'api-request-outside-adapter'
     | 'core-api-dto-import'
@@ -21,24 +22,27 @@ const baselinePath = path.join(
 );
 const sourceFilePattern = /\.(?:ts|tsx)$/;
 const nonProductionSourcePattern = /\.(?:stories|test)\.(?:ts|tsx)$/;
-const apiDtoImportPattern = /from\s+['"]@shipfox\/api-[^'"]+-dto['"]/;
+const apiDtoImportPattern = /(?:from\s+|import\()['"]@shipfox\/api-[^'"]+-dto['"]/;
 const clientFrameworkImportPattern =
   /from\s+['"](?:react(?:-dom)?|jotai|@tanstack\/[^'"]+|@shipfox\/client-(?:api|shell|ui)|@shipfox\/react-ui(?:\/[^'"]+)?)['"]/;
-const apiRequestPattern = /\bapiRequest\s*(?:<[^>]*>)?\s*\(/;
+const apiRequestPattern = /\b(?:apiRequest|checkedApiRequest)\s*(?:<[^>]*>)?\s*\(/;
 const queryCachePattern =
   /\b(?:useQueryClient\s*\(|queryClient\.(?:invalidateQueries|removeQueries|resetQueries|setQueriesData|setQueryData))/;
 const responseDtoNamePattern = /\b[A-Za-z0-9_]+(?<!Body|Query)Dto\b/;
+const generatedDirectoryNames = new Set(['dist', 'node_modules']);
 
 function toRepositoryPath(filePath: string): string {
   return path.relative(rootDirectory, filePath).split(path.sep).join('/');
 }
 
-async function sourceFiles(directory: string): Promise<string[]> {
+export async function sourceFiles(directory: string): Promise<string[]> {
   const entries = await readdir(directory, {withFileTypes: true});
   const files = await Promise.all(
     entries.map(async (entry) => {
       const entryPath = path.join(directory, entry.name);
-      if (entry.isDirectory()) return await sourceFiles(entryPath);
+      if (entry.isDirectory()) {
+        return generatedDirectoryNames.has(entry.name) ? [] : await sourceFiles(entryPath);
+      }
       return sourceFilePattern.test(entry.name) && !nonProductionSourcePattern.test(entry.name)
         ? [entryPath]
         : [];
@@ -47,15 +51,32 @@ async function sourceFiles(directory: string): Promise<string[]> {
   return files.flat();
 }
 
-function hasResponseDtoImport(source: string): boolean {
+function countMatches(source: string, pattern: RegExp): number {
+  const flags = pattern.flags.includes('g') ? pattern.flags : `${pattern.flags}g`;
+  return [...source.matchAll(new RegExp(pattern.source, flags))].length;
+}
+
+function responseDtoCount(names: string): number {
+  return countMatches(names, responseDtoNamePattern);
+}
+
+function responseDtoImportCount(source: string): number {
+  let count = 0;
   const imports = source.matchAll(
     /import(?:\s+type)?\s+([^;]+?)\s+from\s+['"]@shipfox\/api-[^'"]+-dto['"]/g,
   );
   for (const match of imports) {
     const names = match[1] ?? '';
-    if (responseDtoNamePattern.test(names)) return true;
+    count += responseDtoCount(names);
   }
-  return false;
+  const inlineImports = source.matchAll(
+    /import\(['"]@shipfox\/api-[^'"]+-dto['"]\)\.([A-Za-z0-9_]+)/g,
+  );
+  for (const match of inlineImports) {
+    const name = match[1] ?? '';
+    count += responseDtoCount(name);
+  }
+  return count;
 }
 
 export function auditClientSource(file: string, source: string): ClientArchitectureViolation[] {
@@ -66,16 +87,21 @@ export function auditClientSource(file: string, source: string): ClientArchitect
   const isClientApi = normalizedFile.startsWith('libs/client/api/');
   const isPresentation =
     normalizedFile.includes('/src/pages/') || normalizedFile.includes('/src/components/');
-  if (isCore && apiDtoImportPattern.test(source))
-    violations.push({file, rule: 'core-api-dto-import'});
-  if (isCore && clientFrameworkImportPattern.test(source))
-    violations.push({file, rule: 'core-client-framework-import'});
-  if (!isAdapter && !isClientApi && apiRequestPattern.test(source))
-    violations.push({file, rule: 'api-request-outside-adapter'});
-  if (isPresentation && hasResponseDtoImport(source))
-    violations.push({file, rule: 'response-dto-in-presentation'});
-  if (normalizedFile.includes('/src/components/') && queryCachePattern.test(source))
-    violations.push({file, rule: 'leaf-query-cache-ownership'});
+  const addViolation = (rule: ClientArchitectureViolation['rule'], occurrences: number): void => {
+    if (occurrences > 0) violations.push({file, rule, occurrences});
+  };
+  if (isCore) {
+    addViolation('core-api-dto-import', countMatches(source, apiDtoImportPattern));
+    addViolation(
+      'core-client-framework-import',
+      countMatches(source, clientFrameworkImportPattern),
+    );
+  }
+  if (!isAdapter && !isClientApi)
+    addViolation('api-request-outside-adapter', countMatches(source, apiRequestPattern));
+  if (isPresentation) addViolation('response-dto-in-presentation', responseDtoImportCount(source));
+  if (normalizedFile.includes('/src/components/'))
+    addViolation('leaf-query-cache-ownership', countMatches(source, queryCachePattern));
   return violations;
 }
 
@@ -105,8 +131,12 @@ export function newViolations(
   violations: ClientArchitectureViolation[],
   baseline: ClientArchitectureViolation[],
 ): ClientArchitectureViolation[] {
-  const baselineKeys = new Set(baseline.map(violationKey));
-  return violations.filter((violation) => !baselineKeys.has(violationKey(violation)));
+  const baselineOccurrences = new Map(
+    baseline.map((violation) => [violationKey(violation), violation.occurrences]),
+  );
+  return violations.filter(
+    (violation) => violation.occurrences > (baselineOccurrences.get(violationKey(violation)) ?? 0),
+  );
 }
 
 async function main(): Promise<void> {

--- a/tools/client-architecture-policy/test/audit-client-architecture.test.ts
+++ b/tools/client-architecture-policy/test/audit-client-architecture.test.ts
@@ -1,5 +1,8 @@
 import assert from 'node:assert/strict';
-import {auditClientSource, newViolations} from '../src/audit-client-architecture.js';
+import {mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {auditClientSource, newViolations, sourceFiles} from '../src/audit-client-architecture.js';
 
 describe('auditClientSource', () => {
   test('allows API requests in a feature adapter', () => {
@@ -7,6 +10,89 @@ describe('auditClientSource', () => {
       'libs/client/projects/src/hooks/api/list-projects.ts',
       "import {apiRequest} from '@shipfox/client-api';\napiRequest('/projects');",
     );
+    assert.deepEqual(violations, []);
+  });
+
+  test('skips generated directories when finding source files', async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), 'client-architecture-policy-'));
+    try {
+      await mkdir(path.join(directory, 'src'));
+      await mkdir(path.join(directory, 'dist'));
+      await mkdir(path.join(directory, 'node_modules', 'package'), {recursive: true});
+      await Promise.all([
+        writeFile(path.join(directory, 'src', 'source.ts'), ''),
+        writeFile(path.join(directory, 'dist', 'generated.ts'), ''),
+        writeFile(path.join(directory, 'node_modules', 'package', 'dependency.ts'), ''),
+      ]);
+
+      const files = await sourceFiles(directory);
+
+      assert.deepEqual(files, [path.join(directory, 'src', 'source.ts')]);
+    } finally {
+      await rm(directory, {recursive: true});
+    }
+  });
+
+  test('allows API requests inside the client API package', () => {
+    const violations = auditClientSource(
+      'libs/client/api/src/index.ts',
+      "checkedApiRequest(schema, '/projects');",
+    );
+
+    assert.deepEqual(violations, []);
+  });
+
+  test('reports both unchecked and checked requests outside an adapter', () => {
+    const violations = auditClientSource(
+      'libs/client/projects/src/pages/project-page.tsx',
+      "apiRequest('/projects');\ncheckedApiRequest(schema, '/projects');",
+    );
+
+    assert.deepEqual(violations, [
+      {
+        file: 'libs/client/projects/src/pages/project-page.tsx',
+        occurrences: 2,
+        rule: 'api-request-outside-adapter',
+      },
+    ]);
+  });
+
+  test('reports inline response DTO imports in presentation', () => {
+    const violations = auditClientSource(
+      'libs/client/projects/src/pages/project-page.tsx',
+      "type Project = import('@shipfox/api-projects-dto').ProjectDto;",
+    );
+
+    assert.deepEqual(violations, [
+      {
+        file: 'libs/client/projects/src/pages/project-page.tsx',
+        occurrences: 1,
+        rule: 'response-dto-in-presentation',
+      },
+    ]);
+  });
+
+  test('reports inline API DTO imports in core', () => {
+    const violations = auditClientSource(
+      'libs/client/projects/src/core/project.ts',
+      "type Project = import('@shipfox/api-projects-dto').ProjectDto;",
+    );
+
+    assert.deepEqual(violations, [
+      {
+        file: 'libs/client/projects/src/core/project.ts',
+        occurrences: 1,
+        rule: 'core-api-dto-import',
+      },
+    ]);
+  });
+
+  test('allows inline request body and query DTO imports in presentation', () => {
+    const violations = auditClientSource(
+      'libs/client/projects/src/pages/project-page.tsx',
+      "type Body = import('@shipfox/api-projects-dto').CreateProjectBody;\ntype Query = import('@shipfox/api-projects-dto').ListProjectsQuery;",
+    );
+
     assert.deepEqual(violations, []);
   });
 
@@ -40,12 +126,25 @@ describe('auditClientSource', () => {
   test('reports only violations not present in the migration baseline', () => {
     const existing = {
       file: 'libs/client/auth/src/pages/login.tsx',
+      occurrences: 1,
       rule: 'api-request-outside-adapter',
     } as const;
     const added = {
       file: 'libs/client/auth/src/pages/signup.tsx',
+      occurrences: 1,
       rule: 'api-request-outside-adapter',
     } as const;
     assert.deepEqual(newViolations([existing, added], [existing]), [added]);
+  });
+
+  test('reports additional occurrences in a file already covered by the baseline', () => {
+    const baseline = {
+      file: 'libs/client/auth/src/pages/login.tsx',
+      occurrences: 1,
+      rule: 'api-request-outside-adapter',
+    } as const;
+    const current = {...baseline, occurrences: 2};
+
+    assert.deepEqual(newViolations([current], [baseline]), [current]);
   });
 });


### PR DESCRIPTION
Harden the client response trust boundary and the migration audit that enforces client architecture rules.

A Standard Schema validator may validly return a successful result with `issues: undefined`; the previous property-presence check rejected that response. The audit now detects direct checked requests and inline DTO imports, excludes generated files, and tracks violation counts so existing baseline entries cannot hide additional violations.

Considered leaving the file-and-rule baseline as a coarse ratchet. Recording occurrence counts preserves the existing baseline workflow while making additions within an existing entry visible.

Closes ENG-1124

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens client response validation and tightens the client architecture audit to enforce checked API boundaries and migration guardrails. Addresses ENG-1124 by ensuring `checkedApiRequest` and DTO imports cannot bypass the policy while preserving the baseline workflow.

- **Bug Fixes**
  - `@shipfox/client-api`: `checkedApiRequest` treats Standard Schema successes with `issues: undefined` as valid; only throws on truthy `issues`.
  - Added tests to keep invalid responses distinct from transport errors and avoid misclassifying unrelated errors.

- **Refactors**
  - Client architecture audit now:
    - Counts occurrences per rule and compares against baseline counts.
    - Flags both `apiRequest` and `checkedApiRequest` outside adapters.
    - Detects inline response/API DTO imports; allows Body/Query DTOs in presentation.
    - Skips `dist` and `node_modules` when scanning.
  - Baseline updated to include `occurrences`; tests cover new behavior.

<sup>Written for commit 4f1079e8534c8627e86032dcb6f2351e02277804. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

