### PR TITLE
[api-email-challenges] Add retry-safe challenge recovery

### DIFF
--- a/.changeset/swift-otters-recover.md
+++ b/.changeset/swift-otters-recover.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-email-challenges": minor
+---
+
+Adds retry-safe continuation-bound email challenge creation and timing recovery.

--- a/libs/api/auth/src/core/auth.ts
+++ b/libs/api/auth/src/core/auth.ts
@@ -175,6 +175,7 @@ export async function signup(params: SignupParams & {sourceIp?: string}): Promis
         email: existing.email,
         purpose: PASSWORD_VERIFICATION_PURPOSE,
         continuation: existing.id,
+        idempotencyKey: existing.id,
         sourceIp: params.sourceIp ?? '0.0.0.0',
       });
       return {...existing, emailChallenge};
@@ -194,6 +195,7 @@ export async function signup(params: SignupParams & {sourceIp?: string}): Promis
     email: user.email,
     purpose: PASSWORD_VERIFICATION_PURPOSE,
     continuation: user.id,
+    idempotencyKey: user.id,
     sourceIp: params.sourceIp ?? '0.0.0.0',
   });
 

--- a/libs/api/email-challenges/README.md
+++ b/libs/api/email-challenges/README.md
@@ -1,0 +1,31 @@
+# Email challenges
+
+`@shipfox/api-email-challenges` provides server-side email ownership challenges.
+
+## Create and recover a challenge
+
+Call `createEmailChallenge` with a caller-generated `idempotencyKey`. The key is scoped to the supplied purpose and continuation. Retrying the same tuple returns the existing active challenge instead of creating another code.
+
+If delivery fails after persistence, retrying may send a replacement code for the same challenge. Delivery can therefore occur more than once, but only the latest code remains valid.
+
+```ts
+const challenge = await createEmailChallenge({
+  email,
+  purpose: 'social-login',
+  continuation,
+  idempotencyKey,
+  sourceIp,
+});
+```
+
+Use `getEmailChallengeContinuation` after a lost response or browser refresh. It requires the same purpose, continuation, and idempotency key and returns only `expiresAt` and `nextResendAvailableAt`.
+
+```ts
+const timing = await getEmailChallengeContinuation({purpose, continuation, idempotencyKey});
+```
+
+The continuation read never returns an email address, code, proof, or delivery state. Missing, expired, terminal, and wrongly bound challenges return bounded `EmailChallengeError` outcomes.
+
+## Lifecycle
+
+Use `resendEmailChallenge`, `confirmEmailChallenge`, and `consumeEmailChallengeProof` with the original challenge handle. Existing resend limits, cooldowns, confirmation limits, proof-consumption semantics, and retention remain unchanged.

--- a/libs/api/email-challenges/drizzle/0000_lively_email_challenges.sql
+++ b/libs/api/email-challenges/drizzle/0000_lively_email_challenges.sql
@@ -3,12 +3,17 @@ CREATE TABLE "email_challenges_challenges" (
   "email" text,
   "purpose" text NOT NULL,
   "continuation_hmac" text,
+  "idempotency_hmac" text NOT NULL,
   "code_hmac" text,
   "expires_at" timestamp with time zone NOT NULL,
   "sent_count" integer DEFAULT 1 NOT NULL,
   "resend_count" integer DEFAULT 0 NOT NULL,
   "failed_attempt_count" integer DEFAULT 0 NOT NULL,
   "last_sent_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "delivery_state" text DEFAULT 'pending' NOT NULL,
+  "delivery_attempted_at" timestamp with time zone,
+  "delivered_at" timestamp with time zone,
+  "delivery_failed_at" timestamp with time zone,
   "confirmed_at" timestamp with time zone,
   "proof_expires_at" timestamp with time zone,
   "consumed_at" timestamp with time zone,
@@ -17,6 +22,7 @@ CREATE TABLE "email_challenges_challenges" (
   "created_at" timestamp with time zone DEFAULT now() NOT NULL,
   "terminal_at" timestamp with time zone
 );
+CREATE UNIQUE INDEX "email_challenges_idempotency_unique" ON "email_challenges_challenges" USING btree ("idempotency_hmac") WHERE "email_challenges_challenges"."terminal_at" IS NULL;
 CREATE INDEX "email_challenges_expiry_idx" ON "email_challenges_challenges" USING btree ("expires_at");
 CREATE INDEX "email_challenges_terminal_idx" ON "email_challenges_challenges" USING btree ("terminal_at");
 CREATE TABLE "email_challenges_send_limits" (

--- a/libs/api/email-challenges/drizzle/meta/0000_snapshot.json
+++ b/libs/api/email-challenges/drizzle/meta/0000_snapshot.json
@@ -33,6 +33,12 @@
           "primaryKey": false,
           "notNull": false
         },
+        "idempotency_hmac": {
+          "name": "idempotency_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
         "code_hmac": {
           "name": "code_hmac",
           "type": "text",
@@ -72,6 +78,31 @@
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
+        },
+        "delivery_state": {
+          "name": "delivery_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "delivery_attempted_at": {
+          "name": "delivery_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_failed_at": {
+          "name": "delivery_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
         },
         "confirmed_at": {
           "name": "confirmed_at",
@@ -118,6 +149,22 @@
         }
       },
       "indexes": {
+        "email_challenges_idempotency_unique": {
+          "name": "email_challenges_idempotency_unique",
+          "columns": [
+            {
+              "expression": "idempotency_hmac",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "where": "\"email_challenges_challenges\".\"terminal_at\" is null",
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
         "email_challenges_expiry_idx": {
           "name": "email_challenges_expiry_idx",
           "columns": [

--- a/libs/api/email-challenges/src/core/email-challenges.test.ts
+++ b/libs/api/email-challenges/src/core/email-challenges.test.ts
@@ -7,6 +7,7 @@ import {
   confirmEmailChallenge,
   consumeEmailChallengeProof,
   createEmailChallenge,
+  getEmailChallengeContinuation,
   resendEmailChallenge,
 } from './email-challenges.js';
 import {EmailChallengeError} from './errors.js';
@@ -26,6 +27,7 @@ describe('email challenges', () => {
       email: 'branded@example.com',
       purpose: 'signup',
       continuation: 'branded-browser',
+      idempotencyKey: 'branded-request',
       sourceIp: '127.0.0.2',
     });
     const verificationCode = sentCode(send);
@@ -40,12 +42,193 @@ describe('email challenges', () => {
     );
   });
 
+  test('reuses one active challenge for concurrent create retries and exposes only timing', async () => {
+    const send = vi.spyOn(mailer, 'send').mockResolvedValue();
+    const params = {
+      email: 'retry-safe@example.com',
+      purpose: 'social-login',
+      continuation: 'browser-a',
+      idempotencyKey: 'request-a',
+      sourceIp: '127.0.0.10',
+    };
+
+    const [first, second] = await Promise.all([
+      createEmailChallenge(params),
+      createEmailChallenge(params),
+    ]);
+    const continuation = await getEmailChallengeContinuation({
+      purpose: params.purpose,
+      continuation: params.continuation,
+      idempotencyKey: params.idempotencyKey,
+    });
+
+    expect(first).toEqual(second);
+    expect(continuation).toEqual({
+      expiresAt: first.expiresAt,
+      nextResendAvailableAt: first.nextResendAvailableAt,
+    });
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(await db().select().from(challenges).where(eq(challenges.id, first.id))).toHaveLength(1);
+    await expect(
+      getEmailChallengeContinuation({...params, continuation: 'browser-b'}),
+    ).rejects.toMatchObject({code: 'invalid'});
+    await expect(
+      getEmailChallengeContinuation({
+        purpose: params.purpose,
+        continuation: params.continuation,
+        idempotencyKey: 'missing-request',
+      }),
+    ).rejects.toMatchObject({code: 'invalid'});
+  });
+
+  test('expires continuation timing without exposing a terminal challenge', async () => {
+    const send = vi.spyOn(mailer, 'send').mockResolvedValue();
+    const params = {
+      email: 'expired@example.com',
+      purpose: 'social-login',
+      continuation: 'expired-browser',
+      idempotencyKey: 'expired-request',
+      sourceIp: '127.0.0.12',
+    };
+    const challenge = await createEmailChallenge(params);
+    await db()
+      .update(challenges)
+      .set({expiresAt: new Date(Date.now() - 1)})
+      .where(eq(challenges.id, challenge.id));
+
+    await expect(
+      getEmailChallengeContinuation({
+        purpose: params.purpose,
+        continuation: params.continuation,
+        idempotencyKey: params.idempotencyKey,
+      }),
+    ).rejects.toMatchObject({code: 'expired'});
+    const replacement = await createEmailChallenge(params);
+
+    expect(replacement.id).not.toBe(challenge.id);
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  test('allows a fresh challenge after a terminal attempt for a stable caller key', async () => {
+    const send = vi.spyOn(mailer, 'send').mockResolvedValue();
+    const params = {
+      email: 'terminal@example.com',
+      purpose: 'password-verification',
+      continuation: 'user-123',
+      idempotencyKey: 'user-123',
+      sourceIp: '127.0.0.15',
+    };
+    const challenge = await createEmailChallenge(params);
+    const validCode = sentCode(send);
+    const invalidCode = validCode === '00000000' ? '00000001' : '00000000';
+    await db()
+      .update(challenges)
+      .set({failedAttemptCount: 4})
+      .where(eq(challenges.id, challenge.id));
+
+    await expect(
+      confirmEmailChallenge({
+        id: challenge.id,
+        code: invalidCode,
+        continuation: params.continuation,
+      }),
+    ).rejects.toMatchObject({code: 'exhausted'});
+    const replacement = await createEmailChallenge(params);
+
+    expect(replacement.id).not.toBe(challenge.id);
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  test('recovers the same challenge after delivery failure without retaining a competing code', async () => {
+    const send = vi.spyOn(mailer, 'send').mockRejectedValueOnce(new Error('provider timeout'));
+    const params = {
+      email: 'delivery@example.com',
+      purpose: 'social-login',
+      continuation: 'delivery-browser',
+      idempotencyKey: 'delivery-request',
+      sourceIp: '127.0.0.11',
+    };
+
+    await expect(createEmailChallenge(params)).rejects.toThrow('provider timeout');
+    const failed = await db().select().from(challenges).where(eq(challenges.email, params.email));
+    expect(failed[0]?.deliveryState).toBe('failed');
+    send.mockResolvedValue();
+
+    const recovered = await createEmailChallenge(params);
+    const recoveryCode = sentCode(send);
+    await confirmEmailChallenge({
+      id: recovered.id,
+      code: recoveryCode,
+      continuation: params.continuation,
+    });
+
+    await expect(
+      getEmailChallengeContinuation({
+        purpose: params.purpose,
+        continuation: params.continuation,
+        idempotencyKey: params.idempotencyKey,
+      }),
+    ).rejects.toMatchObject({code: 'invalid'});
+    expect(
+      await db().select().from(challenges).where(eq(challenges.id, recovered.id)),
+    ).toHaveLength(1);
+  });
+
+  test('limits repeated delivery recovery attempts for one idempotency key', async () => {
+    const send = vi.spyOn(mailer, 'send').mockRejectedValue(new Error('provider timeout'));
+    const params = {
+      email: 'limited-delivery@example.com',
+      purpose: 'social-login',
+      continuation: 'limited-delivery-browser',
+      idempotencyKey: 'limited-delivery-request',
+      sourceIp: '127.0.0.13',
+    };
+
+    await expect(createEmailChallenge(params)).rejects.toThrow('provider timeout');
+    await expect(createEmailChallenge(params)).rejects.toThrow('provider timeout');
+    await expect(createEmailChallenge(params)).rejects.toThrow('provider timeout');
+
+    await expect(createEmailChallenge(params)).rejects.toMatchObject({code: 'exhausted'});
+    expect(send).toHaveBeenCalledTimes(3);
+  });
+
+  test('records resend delivery failure so creation can recover the same challenge', async () => {
+    const send = vi.spyOn(mailer, 'send').mockResolvedValue();
+    const params = {
+      email: 'resend-delivery@example.com',
+      purpose: 'social-login',
+      continuation: 'resend-delivery-browser',
+      idempotencyKey: 'resend-delivery-request',
+      sourceIp: '127.0.0.14',
+    };
+    const challenge = await createEmailChallenge(params);
+    await db()
+      .update(challenges)
+      .set({lastSentAt: new Date(Date.now() - 61_000)})
+      .where(eq(challenges.id, challenge.id));
+    send.mockRejectedValueOnce(new Error('provider timeout'));
+
+    await expect(
+      resendEmailChallenge({
+        id: challenge.id,
+        continuation: params.continuation,
+        sourceIp: params.sourceIp,
+      }),
+    ).rejects.toThrow('provider timeout');
+    const failed = await db().select().from(challenges).where(eq(challenges.id, challenge.id));
+    expect(failed[0]?.deliveryState).toBe('failed');
+    send.mockResolvedValue();
+
+    await expect(createEmailChallenge(params)).resolves.toMatchObject({id: challenge.id});
+  });
+
   test('replaces the code on resend and consumes only the same continuation idempotently', async () => {
     const send = vi.spyOn(mailer, 'send').mockResolvedValue();
     const challenge = await createEmailChallenge({
       email: ' Person@Example.com ',
       purpose: 'signup',
       continuation: 'browser-a',
+      idempotencyKey: 'person-request',
       sourceIp: '127.0.0.1',
     });
     const firstCode = sentCode(send);
@@ -100,6 +283,7 @@ describe('email challenges', () => {
         email: 'limit@example.com',
         purpose: `test-${index}`,
         continuation: `continuation-${index}`,
+        idempotencyKey: `request-${index}`,
         sourceIp: `10.0.0.${index}`,
       });
 
@@ -108,6 +292,7 @@ describe('email challenges', () => {
         email: 'limit@example.com',
         purpose: 'blocked',
         continuation: 'continuation-blocked',
+        idempotencyKey: 'blocked-request',
         sourceIp: '10.0.0.99',
       }),
     ).rejects.toBeInstanceOf(EmailChallengeError);
@@ -122,6 +307,7 @@ describe('email challenges', () => {
       email: 'attempts@example.com',
       purpose: 'signup',
       continuation: 'browser-a',
+      idempotencyKey: 'attempts-request',
       sourceIp: '10.0.1.1',
     });
     const validCode = sentCode(send);
@@ -142,6 +328,7 @@ describe('email challenges', () => {
       email: 'retry@example.com',
       purpose: 'signup',
       continuation: 'browser-a',
+      idempotencyKey: 'retry-request',
       sourceIp: '10.0.1.2',
     });
     const retryCode = sentCode(send);

--- a/libs/api/email-challenges/src/core/email-challenges.ts
+++ b/libs/api/email-challenges/src/core/email-challenges.ts
@@ -17,6 +17,7 @@ const resendCooldownMs = 60 * 1000;
 const maxSends = 3;
 const maxFailedAttempts = 5;
 const retentionMs = 24 * 60 * 60 * 1000;
+const deliveryRecoveryMs = 30 * 1000;
 
 function digest(domain: string, value: string) {
   return createHmac('sha256', emailChallengeKey()).update(`${domain}:${value}`).digest('hex');
@@ -49,12 +50,50 @@ export interface CreateEmailChallengeParams {
   email: string;
   purpose: string;
   continuation: string;
+  idempotencyKey: string;
   sourceIp: string;
 }
 export interface EmailChallengeHandle {
   id: string;
   expiresAt: Date;
   nextResendAvailableAt: Date;
+}
+
+export interface EmailChallengeContinuation {
+  expiresAt: Date;
+  nextResendAvailableAt: Date;
+}
+
+function handle(row: typeof challenges.$inferSelect): EmailChallengeHandle {
+  return {
+    id: row.id,
+    expiresAt: row.expiresAt,
+    nextResendAvailableAt: new Date(row.lastSentAt.getTime() + resendCooldownMs),
+  };
+}
+
+function idempotencyDigest(
+  params: Pick<CreateEmailChallengeParams, 'purpose' | 'continuation' | 'idempotencyKey'>,
+) {
+  return digest(
+    'idempotency',
+    JSON.stringify([params.purpose, params.continuation, params.idempotencyKey]),
+  );
+}
+
+async function recordDeliveryOutcome(
+  id: string,
+  deliveryAttemptedAt: Date,
+  outcome: 'delivered' | 'failed',
+) {
+  await db()
+    .update(challenges)
+    .set(
+      outcome === 'delivered'
+        ? {deliveryState: outcome, deliveredAt: new Date()}
+        : {deliveryState: outcome, deliveryFailedAt: new Date()},
+    )
+    .where(and(eq(challenges.id, id), eq(challenges.deliveryAttemptedAt, deliveryAttemptedAt)));
 }
 
 async function consumeLimit(
@@ -133,16 +172,80 @@ export async function createEmailChallenge(
   params: CreateEmailChallengeParams,
 ): Promise<EmailChallengeHandle> {
   const email = emailSchema.parse(params.email);
-  if (!params.purpose || !params.continuation)
+  if (!params.purpose || !params.continuation || !params.idempotencyKey)
     throw new EmailChallengeError(
       'invalid',
-      'Email challenge purpose and continuation are required',
+      'Email challenge purpose, continuation, and idempotency key are required',
     );
   const now = new Date();
-  const value = code();
-  const expiresAt = new Date(now.getTime() + ttlMs);
+  const idempotencyHmac = idempotencyDigest(params);
   try {
-    const row = await db().transaction(async (tx) => {
+    const created = await db().transaction(async (tx) => {
+      await tx.execute(
+        sql`select pg_advisory_xact_lock(hashtext(${`challenge:${idempotencyHmac}`}))`,
+      );
+      const existing = await tx
+        .select()
+        .from(challenges)
+        .where(and(eq(challenges.idempotencyHmac, idempotencyHmac), isNull(challenges.terminalAt)))
+        .limit(1)
+        .for('update');
+      const current = existing[0];
+      if (current) {
+        if (
+          !current.email ||
+          current.purpose !== params.purpose ||
+          !current.continuationHmac ||
+          !equal(current.continuationHmac, digest('continuation', params.continuation))
+        )
+          throw new EmailChallengeError('invalid', 'Email challenge is invalid');
+        if (current.expiresAt <= now) {
+          await tx
+            .update(challenges)
+            .set({...terminalUpdate(now), invalidatedAt: now})
+            .where(eq(challenges.id, current.id));
+          throw new EmailChallengeError('expired', 'Email challenge has expired');
+        }
+        if (current.terminalAt || current.confirmedAt)
+          throw new EmailChallengeError('invalid', 'Email challenge is invalid');
+        const deliveryStale =
+          current.deliveryState === 'pending' &&
+          (!current.deliveryAttemptedAt ||
+            current.deliveryAttemptedAt.getTime() + deliveryRecoveryMs <= now.getTime());
+        const shouldRecoverDelivery = current.deliveryState === 'failed' || deliveryStale;
+        if (!shouldRecoverDelivery) return {handle: handle(current), deliver: false as const};
+        if (current.sentCount >= maxSends)
+          throw new EmailChallengeError('exhausted', 'Email challenge resends are exhausted');
+
+        const value = code();
+        const expiresAt = new Date(now.getTime() + ttlMs);
+        await consumeSendLimits(tx, current.email, params.sourceIp, now);
+        const updated = await tx
+          .update(challenges)
+          .set({
+            codeHmac: digest('code', value),
+            sentCount: current.sentCount + 1,
+            resendCount: current.resendCount + 1,
+            lastSentAt: now,
+            expiresAt,
+            deliveryState: 'pending',
+            deliveryAttemptedAt: now,
+            deliveryFailedAt: null,
+          })
+          .where(eq(challenges.id, current.id))
+          .returning();
+        if (!updated[0]) throw new Error('Update returned no email challenge');
+        return {
+          handle: handle(updated[0]),
+          email: current.email,
+          value,
+          deliveryAttemptedAt: now,
+          deliver: true as const,
+        };
+      }
+
+      const value = code();
+      const expiresAt = new Date(now.getTime() + ttlMs);
       await consumeSendLimits(tx, email, params.sourceIp, now);
       const inserted = await tx
         .insert(challenges)
@@ -150,25 +253,79 @@ export async function createEmailChallenge(
           email,
           purpose: params.purpose,
           continuationHmac: digest('continuation', params.continuation),
+          idempotencyHmac,
           codeHmac: digest('code', value),
           expiresAt,
           lastSentAt: now,
+          deliveryAttemptedAt: now,
         })
         .returning();
       if (!inserted[0]) throw new Error('Insert returned no email challenge');
-      return inserted[0];
+      return {
+        handle: handle(inserted[0]),
+        email,
+        value,
+        deliveryAttemptedAt: now,
+        deliver: true as const,
+      };
     });
-    await deliver(email, value);
+    if (!created.deliver) return created.handle;
+    try {
+      await deliver(created.email, created.value);
+      await recordDeliveryOutcome(created.handle.id, created.deliveryAttemptedAt, 'delivered');
+    } catch (error) {
+      await recordDeliveryOutcome(created.handle.id, created.deliveryAttemptedAt, 'failed');
+      throw error;
+    }
     recordEmailChallenge('send', 'ok');
-    return {
-      id: row.id,
-      expiresAt,
-      nextResendAvailableAt: new Date(now.getTime() + resendCooldownMs),
-    };
+    return created.handle;
   } catch (error) {
     recordEmailChallenge('send', 'rejected');
     throw error;
   }
+}
+
+export async function getEmailChallengeContinuation(params: {
+  purpose: string;
+  continuation: string;
+  idempotencyKey: string;
+}): Promise<EmailChallengeContinuation> {
+  const now = new Date();
+  if (!params.purpose || !params.continuation || !params.idempotencyKey)
+    throw new EmailChallengeError('invalid', 'Email challenge is invalid');
+  const idempotencyHmac = idempotencyDigest(params);
+  const result = await db().transaction(async (tx) => {
+    await tx.execute(
+      sql`select pg_advisory_xact_lock(hashtext(${`challenge:${idempotencyHmac}`}))`,
+    );
+    const rows = await tx
+      .select()
+      .from(challenges)
+      .where(and(eq(challenges.idempotencyHmac, idempotencyHmac), isNull(challenges.terminalAt)))
+      .limit(1)
+      .for('update');
+    const current = rows[0];
+    if (
+      !current ||
+      current.purpose !== params.purpose ||
+      !current.continuationHmac ||
+      !equal(current.continuationHmac, digest('continuation', params.continuation)) ||
+      current.terminalAt ||
+      current.confirmedAt
+    )
+      return 'invalid' as const;
+    if (current.expiresAt <= now) {
+      await tx
+        .update(challenges)
+        .set({...terminalUpdate(now), invalidatedAt: now})
+        .where(eq(challenges.id, current.id));
+      return 'expired' as const;
+    }
+    return handle(current);
+  });
+  if (result === 'expired') throw new EmailChallengeError('expired', 'Email challenge has expired');
+  if (result === 'invalid') throw new EmailChallengeError('invalid', 'Email challenge is invalid');
+  return {expiresAt: result.expiresAt, nextResendAvailableAt: result.nextResendAvailableAt};
 }
 
 export async function resendEmailChallenge(params: {
@@ -220,13 +377,22 @@ export async function resendEmailChallenge(params: {
           lastSentAt: now,
           expiresAt: new Date(now.getTime() + ttlMs),
           failedAttemptCount: 0,
+          deliveryState: 'pending',
+          deliveryAttemptedAt: now,
+          deliveryFailedAt: null,
         })
         .where(eq(challenges.id, current.id))
         .returning();
       if (!updated[0]) throw new Error('Update returned no email challenge');
-      return {challenge: updated[0], email: current.email};
+      return {challenge: updated[0], email: current.email, deliveryAttemptedAt: now};
     });
-    await deliver(row.email, value);
+    try {
+      await deliver(row.email, value);
+      await recordDeliveryOutcome(row.challenge.id, row.deliveryAttemptedAt, 'delivered');
+    } catch (error) {
+      await recordDeliveryOutcome(row.challenge.id, row.deliveryAttemptedAt, 'failed');
+      throw error;
+    }
     recordEmailChallenge('resend', 'ok');
     return {
       id: row.challenge.id,

--- a/libs/api/email-challenges/src/db/schema/challenges.ts
+++ b/libs/api/email-challenges/src/db/schema/challenges.ts
@@ -1,5 +1,6 @@
 import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
-import {index, integer, text, timestamp} from 'drizzle-orm/pg-core';
+import {isNull} from 'drizzle-orm';
+import {index, integer, text, timestamp, uniqueIndex} from 'drizzle-orm/pg-core';
 import {pgTable} from './common.js';
 
 export const challenges = pgTable(
@@ -9,12 +10,17 @@ export const challenges = pgTable(
     email: text('email'),
     purpose: text('purpose').notNull(),
     continuationHmac: text('continuation_hmac'),
+    idempotencyHmac: text('idempotency_hmac').notNull(),
     codeHmac: text('code_hmac'),
     expiresAt: timestamp('expires_at', {withTimezone: true}).notNull(),
     sentCount: integer('sent_count').notNull().default(1),
     resendCount: integer('resend_count').notNull().default(0),
     failedAttemptCount: integer('failed_attempt_count').notNull().default(0),
     lastSentAt: timestamp('last_sent_at', {withTimezone: true}).notNull().defaultNow(),
+    deliveryState: text('delivery_state').notNull().default('pending'),
+    deliveryAttemptedAt: timestamp('delivery_attempted_at', {withTimezone: true}),
+    deliveredAt: timestamp('delivered_at', {withTimezone: true}),
+    deliveryFailedAt: timestamp('delivery_failed_at', {withTimezone: true}),
     confirmedAt: timestamp('confirmed_at', {withTimezone: true}),
     proofExpiresAt: timestamp('proof_expires_at', {withTimezone: true}),
     consumedAt: timestamp('consumed_at', {withTimezone: true}),
@@ -24,6 +30,9 @@ export const challenges = pgTable(
     terminalAt: timestamp('terminal_at', {withTimezone: true}),
   },
   (table) => [
+    uniqueIndex('email_challenges_idempotency_unique')
+      .on(table.idempotencyHmac)
+      .where(isNull(table.terminalAt)),
     index('email_challenges_expiry_idx').on(table.expiresAt),
     index('email_challenges_terminal_idx').on(table.terminalAt),
   ],

--- a/libs/api/email-challenges/src/index.ts
+++ b/libs/api/email-challenges/src/index.ts
@@ -8,7 +8,9 @@ export {
   confirmEmailChallenge,
   consumeEmailChallengeProof,
   createEmailChallenge,
+  type EmailChallengeContinuation,
   type EmailChallengeHandle,
+  getEmailChallengeContinuation,
   resendEmailChallenge,
 } from '#core/email-challenges.js';
 export {EmailChallengeError, type EmailChallengeErrorCode} from '#core/errors.js';

--- a/tools/application-release/test/external/verify.mjs
+++ b/tools/application-release/test/external/verify.mjs
@@ -73,6 +73,7 @@ try {
   const tsc = resolve(repositoryRoot, 'tools/typescript/node_modules/typescript/bin/tsc');
   await run(process.execPath, [tsc, '--project', 'tsconfig.json'], fixtureRoot);
   await run(process.execPath, ['runtime-imports.mjs'], fixtureRoot);
+  await run(process.execPath, ['email-challenge-contract.mjs'], fixtureRoot);
   await run(process.execPath, ['runners-composition.mjs'], fixtureRoot);
   await run(process.execPath, ['workflow-source-bundle.mjs'], fixtureRoot);
   await run(
@@ -164,6 +165,10 @@ const module = createRunnersModule({
 
 void module;
 `,
+    ),
+    writeFile(
+      join(root, 'email-challenge-contract.mjs'),
+      `Object.assign(process.env, ${JSON.stringify(runtimeEnvironment(), null, 2)});\n\nconst {createEmailChallenge, getEmailChallengeContinuation} = await import('@shipfox/api-email-challenges');\nif (typeof createEmailChallenge !== 'function' || typeof getEmailChallengeContinuation !== 'function') {\n  throw new Error('Packed email challenges package does not export retry-safe continuation contracts.');\n}\nconsole.log('Imported packed retry-safe email challenge continuation contracts.');\n`,
     ),
     writeFile(
       join(root, 'runners-composition.mjs'),


### PR DESCRIPTION
Adds idempotent, continuation-bound email challenge creation and a safe timing-recovery read for callers that lose a response or refresh the browser.

A persisted challenge could previously leave a caller unable to discover its expiry or cooldown, and a delivery failure could leave an attempt unable to progress. This keeps one active challenge per purpose, continuation, and caller-supplied idempotency key while bounding recovery delivery under the existing limits.

Considered relying on client-held challenge handles, but a server-side continuation lookup preserves the existing secret boundary and lets recovery work after browser state is lost.

The email-challenge migration is folded into the initial baseline because this package is pre-deployment. Reviewers should pay particular attention to the partial active-row unique index and attempt-guarded delivery-state updates.

Closes ENG-1139

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds retry-safe, continuation-bound email challenges with an idempotency key so clients can safely retry creation and recover timing after lost responses or delivery failures. Addresses ENG-1139 by preventing duplicate active codes while keeping resend and expiry limits.

- **New Features**
  - `createEmailChallenge` now requires `idempotencyKey` and reuses one active challenge per (purpose, continuation, key); delivery may retry, but only the latest code is valid.
  - Added `getEmailChallengeContinuation({purpose, continuation, idempotencyKey})` to return `expiresAt` and `nextResendAvailableAt` for recovery without exposing email, code, or delivery details.
  - Persist delivery state and outcomes (`pending`, `delivered`, `failed`) and allow bounded recovery for failed or stale deliveries; resend/create record outcomes consistently.
  - Schema changes: new `idempotency_hmac` and delivery columns; partial unique index on `idempotency_hmac` where `terminal_at` is null.
  - Updated auth signup to pass an `idempotencyKey`, refreshed README, added tests, and verified exports in an external script for `@shipfox/api-email-challenges`.

<sup>Written for commit 27c6f85c6e764ab5a872f3ddf0511c704c63c6c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

