### PR TITLE
Expose runners module replacement seam

### DIFF
--- a/.changeset/bright-runners-replace.md
+++ b/.changeset/bright-runners-replace.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-server": minor
+---
+
+Adds a host factory for replacing only the default Runners module with the composed Auth client.

--- a/libs/api/server/src/index.ts
+++ b/libs/api/server/src/index.ts
@@ -1,3 +1,7 @@
-export {type DefaultModulesOptions, defaultModules} from './modules.js';
+export {
+  type DefaultModulesOptions,
+  type DefaultRunnersModuleFactory,
+  defaultModules,
+} from './modules.js';
 export type {CreateServerOptions, RunServerOptions, ServerHandle} from './server.js';
 export {createServer, runServer} from './server.js';

--- a/libs/api/server/src/modules.test.ts
+++ b/libs/api/server/src/modules.test.ts
@@ -254,6 +254,40 @@ describe('defaultModules', () => {
     expect(mocks.createRunnersModule).toHaveBeenCalledWith({auth: expect.any(Object)});
   });
 
+  it('lets a host replace only the Runners module with the composed Auth client', async () => {
+    const policy = {filterEligibleWorkspaceIds: vi.fn().mockResolvedValue(new Set<string>())};
+    const runnersModule = mocks.createRunnersModule({});
+    const createHostRunnersModule = vi.fn(({auth}) =>
+      mocks.createRunnersModule({auth, installationProvisioning: {policy}}),
+    );
+    mocks.createRunnersModule.mockClear();
+
+    const modules = await defaultModules({runnersModule: createHostRunnersModule});
+
+    expect(createHostRunnersModule).toHaveBeenCalledWith({auth: expect.any(Object)});
+    expect(mocks.createRunnersModule).toHaveBeenCalledWith({
+      auth: createHostRunnersModule.mock.calls[0]?.[0].auth,
+      installationProvisioning: {policy},
+    });
+    expect(modules.filter((module) => module.name === 'runners')).toEqual([runnersModule]);
+    expect(modules.map((module) => module.name)).toEqual([
+      'email-challenges',
+      'auth',
+      'workspaces',
+      'secrets',
+      'agent',
+      'integrations',
+      'projects',
+      'definitions',
+      'workflows',
+      'annotations',
+      'runners',
+      'logs',
+      'triggers',
+      'dispatcher',
+    ]);
+  });
+
   it('injects Workflows into integrations and logs and namespaces provider secrets', async () => {
     await defaultModules();
 

--- a/libs/api/server/src/modules.ts
+++ b/libs/api/server/src/modules.ts
@@ -4,7 +4,10 @@ import {createAgentModule} from '@shipfox/api-agent';
 import {agentInterModuleContract} from '@shipfox/api-agent-dto/inter-module';
 import {createAuthModule} from '@shipfox/api-auth';
 import {config as authConfig} from '@shipfox/api-auth/config';
-import {authInterModuleContract} from '@shipfox/api-auth-dto/inter-module';
+import {
+  type AuthInterModuleClient,
+  authInterModuleContract,
+} from '@shipfox/api-auth-dto/inter-module';
 import {createDefinitionsModule} from '@shipfox/api-definitions';
 import {definitionsInterModuleContract} from '@shipfox/api-definitions-dto/inter-module';
 import {dispatcherModule} from '@shipfox/api-dispatcher';
@@ -34,7 +37,10 @@ import {logger} from '@shipfox/node-opentelemetry';
 
 export interface DefaultModulesOptions {
   webhookDeliverySource?: WebhookDeliverySource | undefined;
+  runnersModule?: DefaultRunnersModuleFactory | undefined;
 }
+
+export type DefaultRunnersModuleFactory = (options: {auth: AuthInterModuleClient}) => ShipfoxModule;
 
 export async function defaultModules(
   options: DefaultModulesOptions = {},
@@ -168,7 +174,7 @@ export async function defaultModules(
       integrations: integrationsClient,
     }),
     annotationsModule,
-    createRunnersModule({auth: authClient}),
+    (options.runnersModule ?? createRunnersModule)({auth: authClient}),
     createLogsModule({
       workflows: workflowsClient,
       jobLeaseTokenTtlSeconds: durationToSeconds(authConfig.AUTH_JOB_LEASE_TOKEN_EXPIRES_IN),

--- a/tools/application-release/test/external/verify.mjs
+++ b/tools/application-release/test/external/verify.mjs
@@ -137,11 +137,22 @@ async function writeFixtureFiles(root, dependencies, runtimeEntryPoints, typeEnt
     ),
     writeFile(
       join(root, 'composition.ts'),
-      `import {createServer, defaultModules} from '@shipfox/api-server';
+      `import {createRunnersModule} from '@shipfox/api-runners';
+import {createServer, defaultModules} from '@shipfox/api-server';
 
 void createServer({
   modules: [
-    ...(await defaultModules()),
+    ...(await defaultModules({
+      runnersModule: ({auth}) =>
+        createRunnersModule({
+          auth,
+          installationProvisioning: {
+            policy: {
+              filterEligibleWorkspaceIds: async (workspaceIds) => new Set(workspaceIds),
+            },
+          },
+        }),
+    })),
     {name: 'external-dummy'},
   ],
 });


### PR DESCRIPTION
Adds a typed host factory to the API server's default module composition. The factory receives the internally composed Auth client, so Cloud can enable its private installation-provisioning policy without rebuilding the default module graph or its inter-module transport.\n\nThe default Runners module path, lifecycle order, transport registration, and sealing behavior remain unchanged. The packed external-consumer fixture now compiles this public composition path.\n\nCloses ENG-1150

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes a typed factory so hosts can replace only the Runners module while reusing the composed Auth client. Enables Cloud to attach a private installation-provisioning policy without rebuilding the default module graph. Closes ENG-1150.

- New Features
  - `@shipfox/api-server`: exports `DefaultRunnersModuleFactory`; `defaultModules` accepts `runnersModule`.
  - Factory receives `auth` (typed `AuthInterModuleClient`) and returns a custom `runners` module.
  - Preserves default module order, transport registration, and sealing.
  - External fixture shows usage with `@shipfox/api-runners` and a host-defined installation-provisioning policy.

<sup>Written for commit a7455e18c03405ab3efea0297fe8491bcd133330. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

