### PR TITLE
[client-logs] Converge log transport on domain models

### DIFF
--- a/.changeset/bright-logs-converge.md
+++ b/.changeset/bright-logs-converge.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-logs": major
+---
+
+Converges step-log snapshots on package-owned camelCase records validated at the transport boundary.

--- a/libs/client/logs/src/components/agent-session-rows.tsx
+++ b/libs/client/logs/src/components/agent-session-rows.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import type {SessionViewRow, SessionViewRowMeta} from '@shipfox/api-logs-dto';
 import {Icon} from '@shipfox/react-ui/icon';
 import {
   LogContent,
@@ -12,6 +11,7 @@ import {
 import {Tooltip, TooltipContent, TooltipTrigger} from '@shipfox/react-ui/tooltip';
 import {cn} from '@shipfox/react-ui/utils';
 import {Fragment, useState} from 'react';
+import type {SessionViewRow, SessionViewRowMeta} from '#core/log-model.js';
 
 const PREVIEW_CHAR_LIMIT = 1200;
 const WORD_SUMMARY_CHAR_LIMIT = 5000;

--- a/libs/client/logs/src/components/log-group.stories.tsx
+++ b/libs/client/logs/src/components/log-group.stories.tsx
@@ -13,8 +13,8 @@ const groupStart = (groupId: string, name: string): GroupStartLogRecord => ({
   v: 1,
   ts: at(0),
   type: 'group_start',
-  group_id: groupId,
-  parent_group_id: null,
+  groupId,
+  parentGroupId: null,
   name,
 });
 

--- a/libs/client/logs/src/components/log-view.stories.tsx
+++ b/libs/client/logs/src/components/log-view.stories.tsx
@@ -1,5 +1,5 @@
-import type {LogRecord, SessionViewRow} from '@shipfox/api-logs-dto';
 import type {Meta, StoryObj} from '@storybook/react';
+import type {LogRecord, SessionViewRow} from '#core/log-model.js';
 import {LogView, LogViewSkeleton} from './log-view.js';
 
 const ESC = String.fromCharCode(27);
@@ -28,15 +28,15 @@ const groupStart = (
   v: 1,
   ts: at(offset),
   type: 'group_start',
-  group_id: groupId,
-  parent_group_id: parentGroupId,
+  groupId,
+  parentGroupId,
   name,
 });
 const groupEnd = (groupId: string, offset: number): LogRecord => ({
   v: 1,
   ts: at(offset),
   type: 'group_end',
-  group_id: groupId,
+  groupId,
 });
 
 const showcaseRecords: LogRecord[] = [
@@ -53,8 +53,8 @@ const showcaseRecords: LogRecord[] = [
   out('running 42 tests\n', 10),
   out('FAIL client.test.ts > retries on 503\n', 11, 'stderr'),
   groupEnd('g3', 12),
-  {v: 1, ts: at(13), type: 'gap', dropped_bytes: 2048},
-  {v: 1, ts: at(14), type: 'end', total_bytes: 15_360},
+  {v: 1, ts: at(13), type: 'gap', droppedBytes: 2048},
+  {v: 1, ts: at(14), type: 'end', totalBytes: 15_360},
 ];
 
 // A pipeline nested three levels deep: Deploy > Build > Compile, and Deploy >
@@ -85,7 +85,7 @@ const nestedRecords: LogRecord[] = [
   groupEnd('g7', 14),
   groupEnd('g5', 14.5),
   groupEnd('g1', 15),
-  {v: 1, ts: at(15.2), type: 'end', total_bytes: 9_216},
+  {v: 1, ts: at(15.2), type: 'end', totalBytes: 9_216},
 ];
 
 const unifiedAgentRecords: LogRecord[] = [
@@ -155,7 +155,7 @@ const unifiedAgentRecords: LogRecord[] = [
     },
     4,
   ),
-  {v: 1, ts: at(5), type: 'end', total_bytes: 4096},
+  {v: 1, ts: at(5), type: 'end', totalBytes: 4096},
 ];
 
 const awaitingAgentRecords: LogRecord[] = [
@@ -415,7 +415,7 @@ const allAgentSessionTypeRecords: LogRecord[] = [
     16,
   ),
   session({kind: 'raw', timestamp: 0, label: 'Malformed session entry', raw: '{not-json'}, 17),
-  {v: 1, ts: at(20), type: 'end', total_bytes: 12_288},
+  {v: 1, ts: at(20), type: 'end', totalBytes: 12_288},
 ];
 
 const meta = {
@@ -483,7 +483,7 @@ export const MinimalOutput: Story = {
   args: {showLineNumbers: true},
   render: (args) => (
     <div className="max-w-3xl">
-      <LogView {...args} records={[{v: 1, ts: at(1), type: 'end', total_bytes: 0}]} />
+      <LogView {...args} records={[{v: 1, ts: at(1), type: 'end', totalBytes: 0}]} />
     </div>
   ),
 };

--- a/libs/client/logs/src/components/log-view.test.tsx
+++ b/libs/client/logs/src/components/log-view.test.tsx
@@ -1,5 +1,5 @@
-import type {LogRecord} from '@shipfox/api-logs-dto';
 import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import type {LogRecord} from '#core/log-model.js';
 import {LogView, LogViewSkeleton} from './log-view.js';
 
 const ts = new Date('2026-06-23T10:00:00.000Z').getTime();
@@ -58,7 +58,7 @@ describe('LogView', () => {
   });
 
   test('renders no-output copy before the end marker for an end-marker-only stream', () => {
-    render(<LogView records={[{v: 1, ts, type: 'end', total_bytes: 0}]} />);
+    render(<LogView records={[{v: 1, ts, type: 'end', totalBytes: 0}]} />);
 
     expect(screen.getByText('Step produced no output')).toBeDefined();
     expect(screen.getByText('End of log')).toBeDefined();
@@ -67,7 +67,7 @@ describe('LogView', () => {
 
   test.each([
     {record: {v: 1, ts, type: 'runner_lost'} as const, label: 'Runner disconnected'},
-    {record: {v: 1, ts, type: 'gap', dropped_bytes: 2048} as const, label: 'Output missing'},
+    {record: {v: 1, ts, type: 'gap', droppedBytes: 2048} as const, label: 'Output missing'},
     {record: {v: 1, ts, type: 'capped'} as const, label: 'Log size limit reached'},
   ])('does not show no-output copy for a $record.type marker-only stream', ({record, label}) => {
     render(<LogView records={[record]} />);

--- a/libs/client/logs/src/components/log-view.tsx
+++ b/libs/client/logs/src/components/log-view.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import type {LogRecord} from '@shipfox/api-logs-dto';
 import {Icon} from '@shipfox/react-ui/icon';
 import {LogContent, LogRow, LogRows, type LogTimestampMode} from '@shipfox/react-ui/log';
 import {Skeleton} from '@shipfox/react-ui/skeleton';
 import {type ReactNode, type UIEventHandler, useEffect, useMemo, useRef} from 'react';
+import type {LogRecord} from '#core/log-model.js';
 import {
   assertNever,
   buildLogTree,

--- a/libs/client/logs/src/components/system-markers.stories.tsx
+++ b/libs/client/logs/src/components/system-markers.stories.tsx
@@ -19,7 +19,7 @@ export const Playground: Story = {
     <div className="max-w-3xl">
       <LogRows>
         <EndMarker
-          record={{v: 1, ts, type: 'end', total_bytes: 15_360}}
+          record={{v: 1, ts, type: 'end', totalBytes: 15_360}}
           lineCount={412}
           durationMs={2100}
         />
@@ -32,11 +32,11 @@ export const Variants: Story = {
   render: () => (
     <div className="max-w-3xl">
       <LogRows>
-        <GapMarker record={{v: 1, ts, type: 'gap', dropped_bytes: 2048}} />
+        <GapMarker record={{v: 1, ts, type: 'gap', droppedBytes: 2048}} />
         <CappedMarker record={{v: 1, ts, type: 'capped'}} />
         <RunnerLostMarker record={{v: 1, ts, type: 'runner_lost'}} />
         <EndMarker
-          record={{v: 1, ts, type: 'end', total_bytes: 15_360}}
+          record={{v: 1, ts, type: 'end', totalBytes: 15_360}}
           lineCount={412}
           durationMs={2100}
         />

--- a/libs/client/logs/src/components/system-markers.tsx
+++ b/libs/client/logs/src/components/system-markers.tsx
@@ -93,7 +93,7 @@ export interface EndMarkerProps {
 export function EndMarker({record, lineCount, durationMs = null}: EndMarkerProps) {
   const meta = [
     `${lineCount} ${lineCount === 1 ? 'line' : 'lines'}`,
-    formatBytes(record.total_bytes),
+    formatBytes(record.totalBytes),
     ...(durationMs != null ? [formatDuration(durationMs)] : []),
   ].join(' · ');
 
@@ -111,7 +111,7 @@ export function GapMarker({record}: {record: GapLogRecord}) {
       icon="errorWarningLine"
       tone="warning"
       timestamp={new Date(record.ts)}
-      detail={`the runner fell behind and dropped ${formatBytes(record.dropped_bytes)}`}
+      detail={`the runner fell behind and dropped ${formatBytes(record.droppedBytes)}`}
     >
       Output missing
     </LogMarkerRow>

--- a/libs/client/logs/src/core/log-model.ts
+++ b/libs/client/logs/src/core/log-model.ts
@@ -1,0 +1,76 @@
+export interface SessionViewRowMeta {
+  label: string;
+  value: string;
+  inline?: boolean | undefined;
+}
+
+export type SessionViewRow =
+  | {
+      kind: 'message';
+      timestamp: number;
+      role: string;
+      label: string;
+      meta: readonly SessionViewRowMeta[];
+      text: string;
+      terminalFailure: boolean;
+    }
+  | {kind: 'thinking'; timestamp: number; text: string}
+  | {kind: 'tool-call'; timestamp: number; id: string | null; name: string; input: string}
+  | {
+      kind: 'tool-result';
+      timestamp: number;
+      toolCallId: string | null;
+      toolName: string;
+      output: string;
+      isError: boolean;
+    }
+  | {
+      kind: 'lifecycle';
+      timestamp: number;
+      label: string;
+      detail: string | null;
+      meta: readonly SessionViewRowMeta[];
+      tone: 'default' | 'warning' | 'error';
+      terminalFailure: boolean;
+    }
+  | {kind: 'raw'; timestamp: number; label: string; raw: string};
+
+interface LogRecordBase {
+  v: 1;
+  ts: number;
+}
+
+export type LogRecord =
+  | (LogRecordBase & {type: 'output'; stream: 'stdout' | 'stderr'; data: string})
+  | (LogRecordBase & {
+      type: 'group_start';
+      groupId: string;
+      parentGroupId: string | null;
+      name: string;
+    })
+  | (LogRecordBase & {type: 'group_end'; groupId: string})
+  | (LogRecordBase & {type: 'end'; totalBytes: number})
+  | (LogRecordBase & {type: 'gap'; droppedBytes: number})
+  | (LogRecordBase & {type: 'agent_session'; row: SessionViewRow})
+  | (LogRecordBase & {type: 'capped'})
+  | (LogRecordBase & {type: 'runner_lost'});
+
+export type LogSource = 'inline' | 'presigned';
+export type LogState = 'open' | 'closed' | 'compacted';
+
+export interface InlineLogRead {
+  mode: 'inline';
+  ndjson: string;
+  nextCursor: number;
+  hasMore: boolean;
+  state: 'open' | 'closed';
+  truncated: boolean;
+}
+
+export interface PresignedLogRead {
+  mode: 'presigned';
+  url: string;
+  expiresAt: string;
+  totalBytes: number;
+  truncated: boolean;
+}

--- a/libs/client/logs/src/core/log-read.test.ts
+++ b/libs/client/logs/src/core/log-read.test.ts
@@ -1,7 +1,6 @@
-import type {LogRecord, ReadLogsResponseDto} from '@shipfox/api-logs-dto';
+import type {InlineLogRead, LogRecord, PresignedLogRead} from './log-model.js';
 import {
   mergeLogRead,
-  parseLogNdjson,
   STEP_LOG_DRAIN_REFETCH_MS,
   STEP_LOG_LIVE_REFETCH_MS,
   type StepLogSnapshot,
@@ -16,75 +15,27 @@ const output = (data: string, ts = 1): LogRecord => ({
   data,
 });
 
-const line = (record: LogRecord): string => `${JSON.stringify(record)}\n`;
-const inline = (params: {
-  ndjson: string;
-  nextCursor?: number;
-  hasMore?: boolean;
-  state?: 'open' | 'closed';
-  truncated?: boolean;
-}): Extract<ReadLogsResponseDto, {mode: 'inline'}> => ({
+const inline = (params: Partial<InlineLogRead> = {}): InlineLogRead => ({
   mode: 'inline',
-  ndjson: params.ndjson,
-  next_cursor: params.nextCursor ?? 1,
-  has_more: params.hasMore ?? false,
-  state: params.state ?? 'open',
-  truncated: params.truncated ?? false,
+  ndjson: '',
+  nextCursor: 1,
+  hasMore: false,
+  state: 'open',
+  truncated: false,
+  ...params,
 });
 
-const presigned = (
-  params: Partial<Extract<ReadLogsResponseDto, {mode: 'presigned'}>> = {},
-): Extract<ReadLogsResponseDto, {mode: 'presigned'}> => ({
+const presigned = (params: Partial<PresignedLogRead> = {}): PresignedLogRead => ({
   mode: 'presigned',
-  url: params.url ?? 'https://storage.example.test/logs/object?sig=1',
-  state: params.state ?? 'closed',
-  expires_at: params.expires_at ?? '2026-06-23T10:00:00.000Z',
-  total_bytes: params.total_bytes ?? 128,
-  truncated: params.truncated ?? false,
-});
-
-describe('parseLogNdjson', () => {
-  test('returns an empty record list for an empty body', () => {
-    const records = parseLogNdjson('');
-
-    expect(records).toEqual([]);
-  });
-
-  test('parses multiple record lines', () => {
-    const first = output('first\n', 1);
-    const second = output('second\n', 2);
-
-    const records = parseLogNdjson(line(first) + line(second));
-
-    expect(records).toEqual([first, second]);
-  });
-
-  test('throws when a line is not a valid log record', () => {
-    const parse = () => parseLogNdjson('{"v":1,"ts":1,"type":"nope"}\n');
-
-    expect(parse).toThrow();
-  });
-
-  test('splits records on CRLF line breaks', () => {
-    const first = output('first\n', 1);
-    const second = output('second\n', 2);
-
-    const records = parseLogNdjson(`${JSON.stringify(first)}\r\n${JSON.stringify(second)}\r\n`);
-
-    expect(records).toEqual([first, second]);
-  });
-
-  test('skips blank lines between records', () => {
-    const record = output('only\n', 1);
-
-    const records = parseLogNdjson(`\n${line(record)}\n`);
-
-    expect(records).toEqual([record]);
-  });
+  url: 'https://storage.example.test/logs/object?sig=1',
+  expiresAt: '2026-06-23T10:00:00.000Z',
+  totalBytes: 128,
+  truncated: false,
+  ...params,
 });
 
 describe('mergeLogRead', () => {
-  test('appends inline records and advances the cursor', () => {
+  test('appends validated inline records and advances the cursor', () => {
     const previous: StepLogSnapshot = {
       records: [output('old\n', 1)],
       nextCursor: 3,
@@ -96,9 +47,12 @@ describe('mergeLogRead', () => {
       totalBytes: null,
       expiresAt: null,
     };
-    const response = inline({ndjson: line(output('new\n', 2)), nextCursor: 4, hasMore: true});
 
-    const snapshot = mergeLogRead(previous, {mode: 'inline', response});
+    const snapshot = mergeLogRead(previous, {
+      mode: 'inline',
+      response: inline({nextCursor: 4, hasMore: true}),
+      records: [output('new\n', 2)],
+    });
 
     expect(snapshot.records).toEqual([output('old\n', 1), output('new\n', 2)]);
     expect(snapshot.nextCursor).toBe(4);
@@ -106,7 +60,7 @@ describe('mergeLogRead', () => {
     expect(snapshot.complete).toBe(false);
   });
 
-  test('preserves records on an empty open inline page', () => {
+  test('does not advance the cursor when no validated records are supplied', () => {
     const previous: StepLogSnapshot = {
       records: [output('old\n', 1)],
       nextCursor: 3,
@@ -118,58 +72,45 @@ describe('mergeLogRead', () => {
       totalBytes: null,
       expiresAt: null,
     };
-    const response = inline({ndjson: '', nextCursor: 3, state: 'open'});
 
-    const snapshot = mergeLogRead(previous, {mode: 'inline', response});
+    const snapshot = mergeLogRead(previous, {
+      mode: 'inline',
+      response: inline({nextCursor: 3}),
+      records: [],
+    });
 
     expect(snapshot.records).toEqual(previous.records);
     expect(snapshot.nextCursor).toBe(3);
-    expect(snapshot.state).toBe('open');
-    expect(snapshot.complete).toBe(false);
   });
 
-  test('marks a closed drained inline stream complete', () => {
-    const response = inline({ndjson: line(output('done\n')), state: 'closed', hasMore: false});
+  test('replaces partial inline records with compacted records', () => {
+    const snapshot = mergeLogRead(
+      {
+        records: [output('partial\n', 1)],
+        nextCursor: 2,
+        source: 'inline',
+        state: 'closed',
+        complete: false,
+        hasMore: true,
+        truncated: false,
+        totalBytes: null,
+        expiresAt: null,
+      },
+      {
+        mode: 'presigned',
+        response: presigned({totalBytes: 256, truncated: true}),
+        records: [output('full\n', 2)],
+      },
+    );
 
-    const snapshot = mergeLogRead(undefined, {mode: 'inline', response});
-
-    expect(snapshot.records).toEqual([output('done\n')]);
-    expect(snapshot.state).toBe('closed');
-    expect(snapshot.complete).toBe(true);
-    expect(snapshot.hasMore).toBe(false);
-  });
-
-  test('replaces partial inline records with the compacted object records', () => {
-    const previous: StepLogSnapshot = {
-      records: [output('partial\n', 1)],
-      nextCursor: 2,
-      source: 'inline',
-      state: 'closed',
-      complete: false,
-      hasMore: true,
-      truncated: false,
-      totalBytes: null,
-      expiresAt: null,
-    };
-    const response = presigned({
-      expires_at: '2026-06-23T10:00:00.000Z',
-      total_bytes: 256,
+    expect(snapshot).toMatchObject({
+      records: [output('full\n', 2)],
+      source: 'presigned',
+      state: 'compacted',
+      complete: true,
+      totalBytes: 256,
       truncated: true,
     });
-
-    const snapshot = mergeLogRead(previous, {
-      mode: 'presigned',
-      response,
-      ndjson: line(output('full\n', 2)),
-    });
-
-    expect(snapshot.records).toEqual([output('full\n', 2)]);
-    expect(snapshot.source).toBe('presigned');
-    expect(snapshot.state).toBe('compacted');
-    expect(snapshot.complete).toBe(true);
-    expect(snapshot.totalBytes).toBe(256);
-    expect(snapshot.expiresAt).toBe('2026-06-23T10:00:00.000Z');
-    expect(snapshot.truncated).toBe(true);
   });
 });
 
@@ -187,33 +128,11 @@ describe('stepLogRefetchInterval', () => {
     ...overrides,
   });
 
-  test('does not poll before the first snapshot', () => {
-    const interval = stepLogRefetchInterval(undefined);
-
-    expect(interval).toBe(false);
-  });
-
-  test('polls quickly while draining buffered inline pages', () => {
-    const interval = stepLogRefetchInterval(snapshot({hasMore: true}));
-
-    expect(interval).toBe(STEP_LOG_DRAIN_REFETCH_MS);
-  });
-
-  test('polls at live-tail cadence for an open drained stream', () => {
-    const interval = stepLogRefetchInterval(snapshot({state: 'open', hasMore: false}));
-
-    expect(interval).toBe(STEP_LOG_LIVE_REFETCH_MS);
-  });
-
-  test('stops polling once the stream is complete', () => {
-    const interval = stepLogRefetchInterval(snapshot({state: 'closed', complete: true}));
-
-    expect(interval).toBe(false);
-  });
-
-  test('stops polling after a fetch errors out instead of re-polling the dead cursor', () => {
-    const interval = stepLogRefetchInterval(snapshot({hasMore: true}), true);
-
-    expect(interval).toBe(false);
+  test('keeps drain, live-tail, terminal, and error polling policies', () => {
+    expect(stepLogRefetchInterval(undefined)).toBe(false);
+    expect(stepLogRefetchInterval(snapshot({hasMore: true}))).toBe(STEP_LOG_DRAIN_REFETCH_MS);
+    expect(stepLogRefetchInterval(snapshot({}))).toBe(STEP_LOG_LIVE_REFETCH_MS);
+    expect(stepLogRefetchInterval(snapshot({complete: true}))).toBe(false);
+    expect(stepLogRefetchInterval(snapshot({}), true)).toBe(false);
   });
 });

--- a/libs/client/logs/src/core/log-read.ts
+++ b/libs/client/logs/src/core/log-read.ts
@@ -1,18 +1,13 @@
-import {type LogRecord, parseLogRecordLine, type ReadLogsResponseDto} from '@shipfox/api-logs-dto';
+import type {InlineLogRead, LogRecord, LogSource, LogState, PresignedLogRead} from './log-model.js';
 
 export const STEP_LOG_DRAIN_REFETCH_MS = 250;
 export const STEP_LOG_LIVE_REFETCH_MS = 2_000;
 
-const NDJSON_LINE_BREAK = /\r?\n/;
-
-type InlineReadLogsResponse = Extract<ReadLogsResponseDto, {mode: 'inline'}>;
-type PresignedReadLogsResponse = Extract<ReadLogsResponseDto, {mode: 'presigned'}>;
-
 export interface StepLogSnapshot {
   records: LogRecord[];
   nextCursor: number;
-  source: 'inline' | 'presigned';
-  state: 'open' | 'closed' | 'compacted';
+  source: LogSource;
+  state: LogState;
   complete: boolean;
   hasMore: boolean;
   truncated: boolean;
@@ -21,15 +16,8 @@ export interface StepLogSnapshot {
 }
 
 export type ResolvedStepLogRead =
-  | {mode: 'inline'; response: InlineReadLogsResponse}
-  | {mode: 'presigned'; response: PresignedReadLogsResponse; ndjson: string};
-
-export function parseLogNdjson(ndjson: string): LogRecord[] {
-  return ndjson
-    .split(NDJSON_LINE_BREAK)
-    .filter((line) => line.length > 0)
-    .map(parseLogRecordLine);
-}
+  | {mode: 'inline'; response: InlineLogRead; records: readonly LogRecord[]}
+  | {mode: 'presigned'; response: PresignedLogRead; records: readonly LogRecord[]};
 
 export function mergeLogRead(
   previous: StepLogSnapshot | undefined,
@@ -37,28 +25,27 @@ export function mergeLogRead(
 ): StepLogSnapshot {
   if (read.mode === 'presigned') {
     return {
-      records: parseLogNdjson(read.ndjson),
+      records: [...read.records],
       nextCursor: 0,
       source: 'presigned',
       state: 'compacted',
       complete: true,
       hasMore: false,
       truncated: read.response.truncated,
-      totalBytes: read.response.total_bytes,
-      expiresAt: read.response.expires_at,
+      totalBytes: read.response.totalBytes,
+      expiresAt: read.response.expiresAt,
     };
   }
 
-  const records = parseLogNdjson(read.response.ndjson);
-  const complete = read.response.state === 'closed' && !read.response.has_more;
+  const complete = read.response.state === 'closed' && !read.response.hasMore;
 
   return {
-    records: [...(previous?.records ?? []), ...records],
-    nextCursor: read.response.next_cursor,
+    records: [...(previous?.records ?? []), ...read.records],
+    nextCursor: read.response.nextCursor,
     source: 'inline',
     state: read.response.state,
     complete,
-    hasMore: read.response.has_more,
+    hasMore: read.response.hasMore,
     truncated: read.response.truncated,
     totalBytes: null,
     expiresAt: null,

--- a/libs/client/logs/src/core/log-tree.test.ts
+++ b/libs/client/logs/src/core/log-tree.test.ts
@@ -1,4 +1,4 @@
-import type {LogRecord} from '@shipfox/api-logs-dto';
+import type {LogRecord} from './log-model.js';
 import {buildLogTree, type GroupLogNode, type LogNode, stripTrailingNewline} from './log-tree.js';
 
 const out = (data: string, stream: 'stdout' | 'stderr' = 'stdout', ts = 0): LogRecord => ({
@@ -17,27 +17,27 @@ const gstart = (
   v: 1,
   ts,
   type: 'group_start',
-  group_id: groupId,
-  parent_group_id: parentGroupId,
+  groupId,
+  parentGroupId,
   name,
 });
 const gend = (groupId: string, ts = 0): LogRecord => ({
   v: 1,
   ts,
   type: 'group_end',
-  group_id: groupId,
+  groupId,
 });
 const end = (totalBytes = 0, ts = 0): LogRecord => ({
   v: 1,
   ts,
   type: 'end',
-  total_bytes: totalBytes,
+  totalBytes,
 });
 const gap = (droppedBytes = 0, ts = 0): LogRecord => ({
   v: 1,
   ts,
   type: 'gap',
-  dropped_bytes: droppedBytes,
+  droppedBytes,
 });
 const capped = (ts = 0): LogRecord => ({v: 1, ts, type: 'capped'});
 const runnerLost = (ts = 0): LogRecord => ({v: 1, ts, type: 'runner_lost'});
@@ -114,8 +114,8 @@ describe('buildLogTree', () => {
     const g1 = asGroup(tree.nodes[0]);
     const g2 = asGroup(g1.children[0]);
 
-    expect(g1.record.group_id).toBe('g1');
-    expect(g2.record.group_id).toBe('g2');
+    expect(g1.record.groupId).toBe('g1');
+    expect(g2.record.groupId).toBe('g2');
     expect(g2.children[0]?.kind).toBe('output');
   });
 
@@ -224,10 +224,10 @@ describe('buildLogTree', () => {
     expect(g1.children.map((n) => n.kind)).toEqual(['group', 'group']);
     const g2 = asGroup(g1.children[0]);
     const g3 = asGroup(g1.children[1]);
-    expect(g2.record.group_id).toBe('g2');
+    expect(g2.record.groupId).toBe('g2');
     expect(g2.closed).toBe(true);
     expect(g2.endTs).toBeNull();
-    expect(g3.record.group_id).toBe('g3');
+    expect(g3.record.groupId).toBe('g3');
     expect(g3.closed).toBe(true);
   });
 

--- a/libs/client/logs/src/core/log-tree.ts
+++ b/libs/client/logs/src/core/log-tree.ts
@@ -1,4 +1,4 @@
-import type {LogRecord} from '@shipfox/api-logs-dto';
+import type {LogRecord} from './log-model.js';
 
 /**
  * Pure render transform for the step-log read stream. The runner emits a flat,
@@ -119,11 +119,11 @@ export function buildLogTree(records: readonly LogRecord[]): LogTree {
         // own `group_end` was dropped under backlog pressure. Orphan-close those frames so a
         // dropped end never mis-parents the groups that follow. A parent whose own start was
         // dropped is not on the stack: it falls through to best-effort root placement.
-        const parentId = record.parent_group_id;
+        const parentId = record.parentGroupId;
         let parentIndex = -1;
         if (parentId !== null) {
           for (let i = stack.length - 1; i >= 0; i -= 1) {
-            if (stack[i]?.record.group_id === parentId) {
+            if (stack[i]?.record.groupId === parentId) {
               parentIndex = i;
               break;
             }
@@ -154,7 +154,7 @@ export function buildLogTree(records: readonly LogRecord[]): LogTree {
         // group_end close with it. An end with no matching open start is ignored.
         let matchIndex = -1;
         for (let i = stack.length - 1; i >= 0; i -= 1) {
-          if (stack[i]?.record.group_id === record.group_id) {
+          if (stack[i]?.record.groupId === record.groupId) {
             matchIndex = i;
             break;
           }

--- a/libs/client/logs/src/hooks/api/log-mapper.test.ts
+++ b/libs/client/logs/src/hooks/api/log-mapper.test.ts
@@ -1,0 +1,56 @@
+import {parseLogNdjson, toLogRead} from './log-mapper.js';
+
+const outputLine = (data: string, ts = 1): string =>
+  `${JSON.stringify({v: 1, ts, type: 'output', stream: 'stdout', data})}\n`;
+
+describe('parseLogNdjson', () => {
+  test('validates and maps records to package-owned camel-case fields', () => {
+    const records = parseLogNdjson(
+      `${JSON.stringify({
+        v: 1,
+        ts: 1,
+        type: 'group_start',
+        group_id: 'build',
+        parent_group_id: null,
+        name: 'Build',
+      })}\r\n${outputLine('done\n', 2)}`,
+    );
+
+    expect(records).toEqual([
+      {
+        v: 1,
+        ts: 1,
+        type: 'group_start',
+        groupId: 'build',
+        parentGroupId: null,
+        name: 'Build',
+      },
+      {v: 1, ts: 2, type: 'output', stream: 'stdout', data: 'done\n'},
+    ]);
+  });
+
+  test('rejects an invalid external record before a snapshot can be merged', () => {
+    expect(() => parseLogNdjson('{"v":1,"ts":1,"type":"nope"}\n')).toThrow();
+  });
+});
+
+describe('toLogRead', () => {
+  test('maps response envelopes to camel-case domain fields', () => {
+    expect(
+      toLogRead({
+        mode: 'presigned',
+        url: 'https://storage.example.test/logs/object?sig=1',
+        state: 'closed',
+        expires_at: '2026-06-23T10:00:00.000Z',
+        total_bytes: 128,
+        truncated: false,
+      }),
+    ).toEqual({
+      mode: 'presigned',
+      url: 'https://storage.example.test/logs/object?sig=1',
+      expiresAt: '2026-06-23T10:00:00.000Z',
+      totalBytes: 128,
+      truncated: false,
+    });
+  });
+});

--- a/libs/client/logs/src/hooks/api/log-mapper.ts
+++ b/libs/client/logs/src/hooks/api/log-mapper.ts
@@ -1,0 +1,75 @@
+import {
+  type LogRecord as LogRecordDto,
+  parseLogRecordLine,
+  type ReadLogsResponseDto,
+} from '@shipfox/api-logs-dto';
+import type {InlineLogRead, LogRecord, PresignedLogRead, SessionViewRow} from '#core/log-model.js';
+
+const NDJSON_LINE_BREAK = /\r?\n/;
+
+export function toLogRead(response: ReadLogsResponseDto): InlineLogRead | PresignedLogRead {
+  if (response.mode === 'presigned') {
+    return {
+      mode: 'presigned',
+      url: response.url,
+      expiresAt: response.expires_at,
+      totalBytes: response.total_bytes,
+      truncated: response.truncated,
+    };
+  }
+
+  return {
+    mode: 'inline',
+    ndjson: response.ndjson,
+    nextCursor: response.next_cursor,
+    hasMore: response.has_more,
+    state: response.state,
+    truncated: response.truncated,
+  };
+}
+
+/**
+ * The compacted object is fetched from a presigned external URL, so every line is
+ * validated at this boundary before it can enter the package-owned query snapshot.
+ */
+export function parseLogNdjson(ndjson: string): LogRecord[] {
+  return ndjson
+    .split(NDJSON_LINE_BREAK)
+    .filter((line) => line.length > 0)
+    .map((line) => toLogRecord(parseLogRecordLine(line)));
+}
+
+export function toLogRecord(record: LogRecordDto): LogRecord {
+  const base: {v: 1; ts: number} = {v: record.v, ts: record.ts};
+  switch (record.type) {
+    case 'output':
+      return {...base, type: record.type, stream: record.stream, data: record.data};
+    case 'group_start':
+      return {
+        ...base,
+        type: record.type,
+        groupId: record.group_id,
+        parentGroupId: record.parent_group_id,
+        name: record.name,
+      };
+    case 'group_end':
+      return {...base, type: record.type, groupId: record.group_id};
+    case 'end':
+      return {...base, type: record.type, totalBytes: record.total_bytes};
+    case 'gap':
+      return {...base, type: record.type, droppedBytes: record.dropped_bytes};
+    case 'agent_session':
+      return {...base, type: record.type, row: toSessionViewRow(record.row)};
+    case 'capped':
+    case 'runner_lost':
+      return {...base, type: record.type};
+  }
+}
+
+function toSessionViewRow(
+  row: Extract<LogRecordDto, {type: 'agent_session'}>['row'],
+): SessionViewRow {
+  return row.kind === 'message' || row.kind === 'lifecycle'
+    ? {...row, meta: row.meta.map((meta) => ({...meta}))}
+    : {...row};
+}

--- a/libs/client/logs/src/hooks/api/step-logs.test.ts
+++ b/libs/client/logs/src/hooks/api/step-logs.test.ts
@@ -45,7 +45,14 @@ describe('readStepAttemptLogsPage', () => {
     });
 
     const url = new URL(requestFrom(fetchImpl).url);
-    expect(result).toEqual(body);
+    expect(result).toEqual({
+      mode: 'inline',
+      ndjson: '',
+      nextCursor: 8,
+      hasMore: false,
+      state: 'open',
+      truncated: false,
+    });
     expect(url.pathname).toBe('/steps/11111111-1111-4111-8111-111111111111/attempts/2/logs');
     expect(url.searchParams.get('cursor')).toBe('7');
     expect(requestFrom(fetchImpl).method).toBe('GET');
@@ -62,5 +69,18 @@ describe('readStepAttemptLogsPage', () => {
     });
 
     await expect(result).rejects.toMatchObject({code: 'not-found', status: 404});
+  });
+
+  test('rejects an invalid response envelope before it can advance a cached cursor', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({mode: 'inline', next_cursor: 8}));
+    configureApiClient({fetchImpl});
+
+    const result = readStepAttemptLogsPage({
+      stepId: '11111111-1111-4111-8111-111111111111',
+      attempt: 1,
+      cursor: 7,
+    });
+
+    await expect(result).rejects.toMatchObject({code: 'invalid-response'});
   });
 });

--- a/libs/client/logs/src/hooks/api/step-logs.ts
+++ b/libs/client/logs/src/hooks/api/step-logs.ts
@@ -1,5 +1,5 @@
-import type {ReadLogsResponseDto} from '@shipfox/api-logs-dto';
-import {ApiError, apiRequest} from '@shipfox/client-api';
+import {readLogsResponseSchema} from '@shipfox/api-logs-dto';
+import {ApiError, checkedApiRequest} from '@shipfox/client-api';
 import {useQuery, useQueryClient} from '@tanstack/react-query';
 import {useRef} from 'react';
 import {
@@ -8,6 +8,7 @@ import {
   type StepLogSnapshot,
   stepLogRefetchInterval,
 } from '#core/log-read.js';
+import {parseLogNdjson, toLogRead} from './log-mapper.js';
 
 export const stepLogsQueryKeys = {
   all: ['step-logs'] as const,
@@ -27,12 +28,14 @@ export async function readStepAttemptLogsPage({
   attempt,
   cursor,
   signal,
-}: ReadStepAttemptLogsPageParams): Promise<ReadLogsResponseDto> {
+}: ReadStepAttemptLogsPageParams) {
   const params = new URLSearchParams({cursor: String(cursor)});
-  return await apiRequest<ReadLogsResponseDto>(
+  const response = await checkedApiRequest(
+    readLogsResponseSchema,
     `/steps/${encodeURIComponent(stepId)}/attempts/${attempt}/logs?${params.toString()}`,
     {signal},
   );
+  return toLogRead(response);
 }
 
 class StepLogObjectFetchError extends Error {
@@ -63,6 +66,12 @@ export interface UseStepAttemptLogsQueryOptions {
   initialErrorRetryDelayMs?: number;
 }
 
+/**
+ * Narrow React Query wrapper for step logs. Its query function can read the prior
+ * snapshot imperatively, but bounded missing-stream retries need a ref that resets
+ * when the step, attempt, or retry budget changes. Keep that lifecycle state here
+ * rather than exporting query options that could accidentally share it between views.
+ */
 export function useStepAttemptLogsQuery(
   stepId: string | undefined,
   attempt: number | undefined,
@@ -93,7 +102,7 @@ export function useStepAttemptLogsQuery(
     enabled,
     queryFn: async ({signal}) => {
       const previous = queryClient.getQueryData<StepLogSnapshot>(queryKey);
-      let response: ReadLogsResponseDto;
+      let response: Awaited<ReturnType<typeof readStepAttemptLogsPage>>;
       try {
         response = await readStepAttemptLogsPage({
           stepId: stepId ?? '',
@@ -121,10 +130,18 @@ export function useStepAttemptLogsQuery(
 
       if (response.mode === 'presigned') {
         const ndjson = await readPresignedLogObject(response.url, signal);
-        return mergeLogRead(previous, {mode: 'presigned', response, ndjson});
+        return mergeLogRead(previous, {
+          mode: 'presigned',
+          response,
+          records: parseLogNdjson(ndjson),
+        });
       }
 
-      return mergeLogRead(previous, {mode: 'inline', response});
+      return mergeLogRead(previous, {
+        mode: 'inline',
+        response,
+        records: parseLogNdjson(response.ndjson),
+      });
     },
     retry: (failureCount, error) => {
       if (initialErrorRetryCount <= 0) return false;

--- a/libs/client/logs/src/index.ts
+++ b/libs/client/logs/src/index.ts
@@ -1,3 +1,10 @@
+export type {
+  LogRecord,
+  LogSource,
+  LogState,
+  SessionViewRow,
+  SessionViewRowMeta,
+} from '#core/log-model.js';
 export type {StepLogSnapshot} from '#core/log-read.js';
 export {
   buildLogTree,


### PR DESCRIPTION
Converges step-log snapshots on package-owned camelCase records and validates API envelopes plus inline or presigned NDJSON at the Logs adapter boundary.

Logs previously cached API DTOs and allowed transport parsing to reach core rendering policy. This makes the trust boundary explicit so invalid external data cannot enter a snapshot, while preserving cursor merging, polling, compacted-object reads, and retry behavior.

A malformed record deliberately fails without advancing the cursor rather than being skipped, because accepting a partial stream would hide or corrupt log history. The package retains a narrow React Query wrapper because bounded missing-stream retry state must reset with the viewed step and attempt.

The public `StepLogSnapshot.records` model changes to the package-owned shape, so the included changeset is major.

Closes ENG-1133

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converges step-log transport on package-owned camelCase models and validates both API envelopes and NDJSON at the adapter boundary to harden the trust boundary. Updates `StepLogSnapshot.records` to the new shape (major) and addresses ENG-1133.

- **Refactors**
  - Store camelCase `LogRecord`/`SessionViewRow` in snapshots; updated stories, tests, and UI; export types from `@shipfox/client-logs`.
  - Validate envelopes with `readLogsResponseSchema` via `checkedApiRequest`; parse and map NDJSON through a new mapper; malformed records reject without advancing the cursor.
  - `mergeLogRead` now takes pre-validated `records` for inline and presigned modes; compacted reads replace partial inline; drain/live-tail polling and retry behavior unchanged.

- **Migration**
  - Replace DTO usages with `LogRecord` from `@shipfox/client-logs` and update fields: `group_id`→`groupId`, `parent_group_id`→`parentGroupId`, `total_bytes`→`totalBytes`, `dropped_bytes`→`droppedBytes`.
  - Remove any external NDJSON parsing; the package now validates and maps at the boundary.

<sup>Written for commit 6f49c141d8496bb54a60cb69f5f47c08c91b4383. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

