### PR TITLE
Converge auth session and invitation state onto shared domain types

### DIFF
--- a/.changeset/calm-otters-migrate.md
+++ b/.changeset/calm-otters-migrate.md
@@ -1,0 +1,10 @@
+---
+"@shipfox/client-shell": major
+"@shipfox/client-auth": major
+"@shipfox/client-invitations": major
+"@shipfox/client-integrations": patch
+"@shipfox/client-projects": patch
+"@shipfox/client-workspace-settings": patch
+---
+
+Converges auth session and invitation state onto shared camelCase domain types validated at the API boundary, replacing the raw snake_case DTOs previously returned by login, signup, password reset, email verification, workspace creation, and invitation preview. `AuthState.user`, `useRefreshAuth()`, and `usePreviewInvitation()` now resolve to `UserIdentity`/`AuthenticatedSession`/`InvitationPreview` shapes (for example `accessToken` instead of `token`, `workspaceName` instead of `workspace_name`). Also moves the shared `AuthShell` component and session mapping helpers into `@shipfox/client-shell`, breaking the former `client-auth` ↔ `client-invitations` circular dependency.

--- a/libs/client/auth/package.json
+++ b/libs/client/auth/package.json
@@ -75,6 +75,7 @@
     "@shipfox/api-auth-dto": "workspace:*",
     "@shipfox/api-workspaces-dto": "workspace:*",
     "@shipfox/client-api": "workspace:*",
+    "@shipfox/client-invitations": "workspace:*",
     "@shipfox/client-shell": "workspace:*",
     "@shipfox/client-ui": "workspace:*",
     "@shipfox/react-ui": "workspace:*",

--- a/libs/client/auth/src/components/email-code-verification.tsx
+++ b/libs/client/auth/src/components/email-code-verification.tsx
@@ -1,10 +1,10 @@
+import {AuthShell} from '@shipfox/client-shell/runtime';
 import {Button} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
 import {FormField, FormFieldInput} from '@shipfox/react-ui/form-field';
 import type {HeaderProps} from '@shipfox/react-ui/typography';
 import type {FormEvent, ReactNode, Ref} from 'react';
 import {useCallback, useEffect, useRef, useState} from 'react';
-import {AuthShell} from './auth-shell.js';
 
 const EIGHT_DIGIT_CODE_RE = /^\d{8}$/u;
 

--- a/libs/client/auth/src/continuation.ts
+++ b/libs/client/auth/src/continuation.ts
@@ -1,4 +1,4 @@
-export {AuthActions, AuthShell, type AuthShellProps} from './components/auth-shell.js';
+export {AuthActions, AuthShell, type AuthShellProps} from '@shipfox/client-shell/runtime';
 export {
   EmailCodeVerification,
   type EmailCodeVerificationProps,

--- a/libs/client/auth/src/hooks/api/auth-mapper.test.ts
+++ b/libs/client/auth/src/hooks/api/auth-mapper.test.ts
@@ -1,0 +1,77 @@
+import type {SignupResponseDto} from '@shipfox/api-auth-dto';
+import {toSignupResult} from './auth-mapper.js';
+
+const baseUser: SignupResponseDto['user'] = {
+  id: '11111111-1111-4111-8111-111111111111',
+  email: 'signup@example.com',
+  name: null,
+  email_verified_at: null,
+  status: 'active',
+  created_at: '2026-04-27T00:00:00.000Z',
+  updated_at: '2026-04-27T00:00:00.000Z',
+};
+
+describe('toSignupResult', () => {
+  test('maps only the user when no challenge, membership, or accept error is present', () => {
+    const result = toSignupResult({user: baseUser});
+
+    expect(result).toEqual({user: {id: baseUser.id, email: baseUser.email}});
+  });
+
+  test('maps the user name and email verification when present', () => {
+    const result = toSignupResult({
+      user: {...baseUser, name: 'Ada', email_verified_at: '2026-04-27T00:00:00.000Z'},
+    });
+
+    expect(result.user).toEqual({
+      id: baseUser.id,
+      email: baseUser.email,
+      name: 'Ada',
+      emailVerifiedAt: '2026-04-27T00:00:00.000Z',
+    });
+  });
+
+  test('maps the email challenge into camelCase fields', () => {
+    const result = toSignupResult({
+      user: baseUser,
+      email_challenge: {
+        id: '22222222-2222-4222-8222-222222222222',
+        next_resend_available_at: '2026-04-27T00:01:00.000Z',
+      },
+    });
+
+    expect(result.emailChallenge).toEqual({
+      id: '22222222-2222-4222-8222-222222222222',
+      nextResendAvailableAt: '2026-04-27T00:01:00.000Z',
+    });
+  });
+
+  test('maps the invitation membership into camelCase fields', () => {
+    const result = toSignupResult({
+      user: baseUser,
+      membership: {
+        id: '33333333-3333-4333-8333-333333333333',
+        user_id: baseUser.id,
+        workspace_id: '44444444-4444-4444-8444-444444444444',
+      },
+    });
+
+    expect(result.membership).toEqual({
+      id: '33333333-3333-4333-8333-333333333333',
+      userId: baseUser.id,
+      workspaceId: '44444444-4444-4444-8444-444444444444',
+    });
+  });
+
+  test('maps the invitation accept error as-is', () => {
+    const result = toSignupResult({
+      user: baseUser,
+      accept_error: {code: 'invitation-expired', message: 'This invitation has expired.'},
+    });
+
+    expect(result.acceptError).toEqual({
+      code: 'invitation-expired',
+      message: 'This invitation has expired.',
+    });
+  });
+});

--- a/libs/client/auth/src/hooks/api/auth-mapper.ts
+++ b/libs/client/auth/src/hooks/api/auth-mapper.ts
@@ -1,0 +1,39 @@
+import type {SignupResponseDto} from '@shipfox/api-auth-dto';
+import {
+  toAuthenticatedSession,
+  toUserIdentity,
+  type UserIdentity,
+} from '@shipfox/client-shell/runtime';
+
+export {toAuthenticatedSession};
+
+export interface SignupResult {
+  user: UserIdentity;
+  emailChallenge?: {id: string; nextResendAvailableAt: string};
+  membership?: {id: string; userId: string; workspaceId: string};
+  acceptError?: {code: string; message: string};
+}
+
+export function toSignupResult(dto: SignupResponseDto): SignupResult {
+  return {
+    user: toUserIdentity(dto.user),
+    ...(dto.email_challenge
+      ? {
+          emailChallenge: {
+            id: dto.email_challenge.id,
+            nextResendAvailableAt: dto.email_challenge.next_resend_available_at,
+          },
+        }
+      : {}),
+    ...(dto.membership
+      ? {
+          membership: {
+            id: dto.membership.id,
+            userId: dto.membership.user_id,
+            workspaceId: dto.membership.workspace_id,
+          },
+        }
+      : {}),
+    ...(dto.accept_error ? {acceptError: dto.accept_error} : {}),
+  };
+}

--- a/libs/client/auth/src/hooks/api/login-auth.test.ts
+++ b/libs/client/auth/src/hooks/api/login-auth.test.ts
@@ -37,7 +37,7 @@ describe('loginAuth', () => {
     const result = await loginAuth(body);
 
     const request = fetchImpl.mock.calls[0]?.[0] as Request;
-    expect(result.token).toBe('access-token');
+    expect(result.accessToken).toBe('access-token');
     expect(request.url).toBe('https://api.example.test/auth/login');
     expect(request.method).toBe('POST');
     expect(requestBody).toEqual(body);

--- a/libs/client/auth/src/hooks/api/login-auth.ts
+++ b/libs/client/auth/src/hooks/api/login-auth.ts
@@ -1,10 +1,15 @@
-import type {LoginBodyDto, LoginResponseDto} from '@shipfox/api-auth-dto';
-import {apiRequest} from '@shipfox/client-api';
+import {type LoginBodyDto, loginResponseSchema} from '@shipfox/api-auth-dto';
+import {checkedApiRequest} from '@shipfox/client-api';
 import {useMutation} from '@tanstack/react-query';
 import {useAuthTransition} from '#state/auth.js';
+import {toAuthenticatedSession} from './auth-mapper.js';
 
 export async function loginAuth(body: LoginBodyDto) {
-  return await apiRequest<LoginResponseDto>('/auth/login', {method: 'POST', body});
+  const response = await checkedApiRequest(loginResponseSchema, '/auth/login', {
+    method: 'POST',
+    body,
+  });
+  return toAuthenticatedSession(response);
 }
 
 export function useLoginAuth() {

--- a/libs/client/auth/src/hooks/api/password-reset-auth.test.ts
+++ b/libs/client/auth/src/hooks/api/password-reset-auth.test.ts
@@ -60,7 +60,7 @@ describe('confirmPasswordReset', () => {
     const result = await confirmPasswordReset(body);
 
     const request = fetchImpl.mock.calls[0]?.[0] as Request;
-    expect(result.token).toBe('reset-access-token');
+    expect(result.accessToken).toBe('reset-access-token');
     expect(request.url).toBe('https://api.example.test/auth/password-reset/confirm');
     expect(request.method).toBe('POST');
     expect(requestBody).toEqual(body);

--- a/libs/client/auth/src/hooks/api/password-reset-auth.ts
+++ b/libs/client/auth/src/hooks/api/password-reset-auth.ts
@@ -1,21 +1,27 @@
-import type {
-  PasswordResetConfirmBodyDto,
-  PasswordResetConfirmResponseDto,
-  PasswordResetRequestBodyDto,
+import {
+  type PasswordResetConfirmBodyDto,
+  type PasswordResetRequestBodyDto,
+  passwordResetConfirmResponseSchema,
 } from '@shipfox/api-auth-dto';
-import {apiRequest} from '@shipfox/client-api';
+import {apiRequest, checkedApiRequest} from '@shipfox/client-api';
 import {useMutation} from '@tanstack/react-query';
 import {useAuthTransition} from '#state/auth.js';
+import {toAuthenticatedSession} from './auth-mapper.js';
 
 export async function requestPasswordReset(body: PasswordResetRequestBodyDto) {
   await apiRequest<void>('/auth/password-reset', {method: 'POST', body});
 }
 
 export async function confirmPasswordReset(body: PasswordResetConfirmBodyDto) {
-  return await apiRequest<PasswordResetConfirmResponseDto>('/auth/password-reset/confirm', {
-    method: 'POST',
-    body,
-  });
+  const response = await checkedApiRequest(
+    passwordResetConfirmResponseSchema,
+    '/auth/password-reset/confirm',
+    {
+      method: 'POST',
+      body,
+    },
+  );
+  return toAuthenticatedSession(response);
 }
 
 export function useRequestPasswordResetAuth() {

--- a/libs/client/auth/src/hooks/api/signup-auth.ts
+++ b/libs/client/auth/src/hooks/api/signup-auth.ts
@@ -1,9 +1,14 @@
-import type {SignupBodyDto, SignupResponseDto} from '@shipfox/api-auth-dto';
-import {apiRequest} from '@shipfox/client-api';
+import {type SignupBodyDto, signupResponseSchema} from '@shipfox/api-auth-dto';
+import {checkedApiRequest} from '@shipfox/client-api';
 import {useMutation} from '@tanstack/react-query';
+import {toSignupResult} from './auth-mapper.js';
 
 async function signupAuth(body: SignupBodyDto) {
-  return await apiRequest<SignupResponseDto>('/auth/signup', {method: 'POST', body});
+  const response = await checkedApiRequest(signupResponseSchema, '/auth/signup', {
+    method: 'POST',
+    body,
+  });
+  return toSignupResult(response);
 }
 
 export function useSignupAuth() {

--- a/libs/client/auth/src/hooks/api/verify-email-auth.ts
+++ b/libs/client/auth/src/hooks/api/verify-email-auth.ts
@@ -1,22 +1,28 @@
-import type {
-  VerifyEmailConfirmBodyDto,
-  VerifyEmailConfirmResponseDto,
-  VerifyEmailResendBodyDto,
-  VerifyEmailResendResponseDto,
+import {
+  type VerifyEmailConfirmBodyDto,
+  type VerifyEmailResendBodyDto,
+  verifyEmailConfirmResponseSchema,
+  verifyEmailResendResponseSchema,
 } from '@shipfox/api-auth-dto';
-import {apiRequest} from '@shipfox/client-api';
+import {checkedApiRequest} from '@shipfox/client-api';
 import {useMutation} from '@tanstack/react-query';
 import {useAuthTransition} from '#state/auth.js';
+import {toAuthenticatedSession} from './auth-mapper.js';
 
 async function verifyEmailAuth(body: VerifyEmailConfirmBodyDto) {
-  return await apiRequest<VerifyEmailConfirmResponseDto>('/auth/verify-email/confirm', {
-    method: 'POST',
-    body,
-  });
+  const response = await checkedApiRequest(
+    verifyEmailConfirmResponseSchema,
+    '/auth/verify-email/confirm',
+    {
+      method: 'POST',
+      body,
+    },
+  );
+  return toAuthenticatedSession(response);
 }
 
 async function resendEmailVerificationAuth(body: VerifyEmailResendBodyDto) {
-  return await apiRequest<VerifyEmailResendResponseDto>('/auth/verify-email/resend', {
+  return await checkedApiRequest(verifyEmailResendResponseSchema, '/auth/verify-email/resend', {
     method: 'POST',
     body,
   });

--- a/libs/client/auth/src/hooks/api/workspace-auth.ts
+++ b/libs/client/auth/src/hooks/api/workspace-auth.ts
@@ -1,11 +1,16 @@
-import type {CreateWorkspaceBodyDto, WorkspaceResponseDto} from '@shipfox/api-workspaces-dto';
-import {apiRequest} from '@shipfox/client-api';
+import {type CreateWorkspaceBodyDto, workspaceResponseSchema} from '@shipfox/api-workspaces-dto';
+import {checkedApiRequest} from '@shipfox/client-api';
 import {listUserWorkspaces, userWorkspacesQueryKey} from '@shipfox/client-shell/runtime';
 import {useMutation} from '@tanstack/react-query';
 import {useRefreshAuth} from './refresh-auth.js';
+import {toWorkspace} from './workspace-mapper.js';
 
 export async function createWorkspace(body: CreateWorkspaceBodyDto) {
-  return await apiRequest<WorkspaceResponseDto>('/workspaces', {method: 'POST', body});
+  const response = await checkedApiRequest(workspaceResponseSchema, '/workspaces', {
+    method: 'POST',
+    body,
+  });
+  return toWorkspace(response);
 }
 
 export {listUserWorkspaces, userWorkspacesQueryKey};

--- a/libs/client/auth/src/hooks/api/workspace-mapper.test.ts
+++ b/libs/client/auth/src/hooks/api/workspace-mapper.test.ts
@@ -1,0 +1,21 @@
+import type {WorkspaceResponseDto} from '@shipfox/api-workspaces-dto';
+import {toWorkspace} from './workspace-mapper.js';
+
+describe('toWorkspace', () => {
+  test.each([
+    'active',
+    'suspended',
+    'deleted',
+  ] as const)('maps a %s workspace to its domain shape', (status) => {
+    const dto: WorkspaceResponseDto = {
+      id: '11111111-1111-4111-8111-111111111111',
+      name: 'Acme',
+      status,
+      settings: {},
+      created_at: '2026-04-27T00:00:00.000Z',
+      updated_at: '2026-04-27T00:00:00.000Z',
+    };
+
+    expect(toWorkspace(dto)).toEqual({id: dto.id, name: dto.name, status});
+  });
+});

--- a/libs/client/auth/src/hooks/api/workspace-mapper.ts
+++ b/libs/client/auth/src/hooks/api/workspace-mapper.ts
@@ -1,0 +1,11 @@
+import type {WorkspaceResponseDto} from '@shipfox/api-workspaces-dto';
+
+export interface Workspace {
+  id: string;
+  name: string;
+  status: 'active' | 'suspended' | 'deleted';
+}
+
+export function toWorkspace(dto: WorkspaceResponseDto): Workspace {
+  return {id: dto.id, name: dto.name, status: dto.status};
+}

--- a/libs/client/auth/src/index.ts
+++ b/libs/client/auth/src/index.ts
@@ -1,6 +1,5 @@
 export * from './components/auth-guard.js';
 export * from './components/auth-provider.js';
-export * from './components/auth-shell.js';
 export {WorkspaceCrumb, type WorkspaceCrumbProps} from './components/workspace-crumb.js';
 export {WorkspaceSwitcher, type WorkspaceSwitcherProps} from './components/workspace-switcher.js';
 export * from './hooks/index.js';

--- a/libs/client/auth/src/pages/invitation-context.ts
+++ b/libs/client/auth/src/pages/invitation-context.ts
@@ -1,39 +1,16 @@
-import type {
-  PreviewInvitationPendingDto,
-  PreviewInvitationResponseDto,
-} from '@shipfox/api-workspaces-dto';
-import {apiRequest} from '@shipfox/client-api';
-import {useQuery} from '@tanstack/react-query';
+import {
+  type InvitationPreview,
+  pendingInvitation,
+  usePreviewInvitation,
+} from '@shipfox/client-invitations';
 import {parseRedirectContext} from '#/components/redirect-context.js';
 
 export function extractInvitationToken(redirect: unknown): string | undefined {
   return parseRedirectContext(redirect).invitationToken;
 }
 
-async function fetchPreview(token: string): Promise<PreviewInvitationResponseDto> {
-  const params = new URLSearchParams({token});
-  return await apiRequest<PreviewInvitationResponseDto>(
-    `/invitations/preview?${params.toString()}`,
-  );
-}
-
-export function pendingInvitation(
-  data: PreviewInvitationResponseDto | undefined,
-): PreviewInvitationPendingDto | undefined {
-  return data?.status === 'pending' ? data : undefined;
-}
-
-/**
- * Mirrors the hook in `@shipfox/client-invitations` but lives in `client-auth`
- * to avoid a circular dependency. Signup/login pages call this to lock the
- * email field when arriving from an invitation link.
- */
 export function useInvitationContext(token: string | undefined) {
-  return useQuery({
-    queryKey: ['invitations', 'preview', token ?? ''] as const,
-    queryFn: () => fetchPreview(token as string),
-    enabled: Boolean(token),
-    retry: false,
-    staleTime: 30_000,
-  });
+  return usePreviewInvitation(token);
 }
+
+export {type InvitationPreview, pendingInvitation};

--- a/libs/client/auth/src/pages/login-page.test.tsx
+++ b/libs/client/auth/src/pages/login-page.test.tsx
@@ -70,7 +70,7 @@ describe('LoginPage', () => {
         return Promise.resolve(
           jsonResponse({
             status: 'pending',
-            workspace_id: 'workspace-1',
+            workspace_id: '11111111-1111-4111-8111-111111111111',
             workspace_name: 'Invite Workspace',
             email: 'invitee@example.com',
             invited_by_display: 'owner@example.com',

--- a/libs/client/auth/src/pages/login-page.tsx
+++ b/libs/client/auth/src/pages/login-page.tsx
@@ -1,4 +1,5 @@
 import {loginBodySchema} from '@shipfox/api-auth-dto';
+import {AuthShell} from '@shipfox/client-shell/runtime';
 import {Button, ButtonLink} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
 import {FormField, FormFieldInput, fieldError} from '@shipfox/react-ui/form-field';
@@ -8,7 +9,6 @@ import {useForm} from '@tanstack/react-form';
 import {Link, useSearch} from '@tanstack/react-router';
 import {useAtom} from 'jotai';
 import {useEffect, useRef, useState} from 'react';
-import {AuthShell} from '#/components/auth-shell.js';
 import {useLoginAuth} from '#hooks/api/login-auth.js';
 import {authFormDraftAtom, initialAuthFormDraft} from '#state/auth.js';
 import {loginErrorToFormError} from './form-errors.js';
@@ -81,7 +81,7 @@ export function LoginPage() {
     ? `/invitations/accept?token=${encodeURIComponent(invitationToken)}`
     : undefined;
   const headerTitle = invitationPending
-    ? `Join ${invitationPending.workspace_name}`
+    ? `Join ${invitationPending.workspaceName}`
     : 'Connect to Shipfox';
   const headerDescription = invitationPending
     ? 'Log in to accept your invitation.'

--- a/libs/client/auth/src/pages/logout-page.tsx
+++ b/libs/client/auth/src/pages/logout-page.tsx
@@ -1,7 +1,7 @@
+import {AuthShell} from '@shipfox/client-shell/runtime';
 import {Text} from '@shipfox/react-ui/typography';
 import {useNavigate, useRouter, useSearch} from '@tanstack/react-router';
 import {useEffect} from 'react';
-import {AuthShell} from '#/components/auth-shell.js';
 import {sanitizeRedirectPath} from '#/components/redirect-target.js';
 import {useLogoutAuth} from '#hooks/api/logout-auth.js';
 

--- a/libs/client/auth/src/pages/password-reset-page.tsx
+++ b/libs/client/auth/src/pages/password-reset-page.tsx
@@ -2,6 +2,7 @@ import {
   passwordResetConfirmBodySchema,
   passwordResetRequestBodySchema,
 } from '@shipfox/api-auth-dto';
+import {AuthShell} from '@shipfox/client-shell/runtime';
 import {Button, ButtonLink} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
 import {FormField, FormFieldInput, fieldError} from '@shipfox/react-ui/form-field';
@@ -11,12 +12,10 @@ import {useForm} from '@tanstack/react-form';
 import {Link, useNavigate, useSearch} from '@tanstack/react-router';
 import {useAtom} from 'jotai';
 import {useEffect, useRef, useState} from 'react';
-import {AuthShell} from '#/components/auth-shell.js';
 import {
   useConfirmPasswordResetAuth,
   useRequestPasswordResetAuth,
 } from '#hooks/api/password-reset-auth.js';
-import {useRefreshAuth} from '#hooks/api/refresh-auth.js';
 import {authFormDraftAtom, initialAuthFormDraft} from '#state/auth.js';
 import {
   passwordResetConfirmErrorToFormError,
@@ -148,7 +147,6 @@ function PasswordResetRequest() {
 
 function PasswordResetConfirm({token}: {token: string}) {
   const confirmPasswordReset = useConfirmPasswordResetAuth();
-  const refreshAuth = useRefreshAuth();
   const navigate = useNavigate();
   const [, setAuthFormDraft] = useAtom(authFormDraftAtom);
   const [formError, setFormError] = useState<string | undefined>();
@@ -163,7 +161,6 @@ function PasswordResetConfirm({token}: {token: string}) {
           new_password: value.new_password,
         });
         await confirmPasswordReset.mutateAsync(body);
-        await refreshAuth();
         setAuthFormDraft(initialAuthFormDraft);
         toast.success('Your password has been changed. You are now logged in.');
         await navigate({to: '/', replace: true});

--- a/libs/client/auth/src/pages/signup-page.test.tsx
+++ b/libs/client/auth/src/pages/signup-page.test.tsx
@@ -137,7 +137,7 @@ describe('SignupPage', () => {
         return Promise.resolve(
           jsonResponse({
             status: 'pending',
-            workspace_id: 'workspace-1',
+            workspace_id: '11111111-1111-4111-8111-111111111111',
             workspace_name: 'Invite Workspace',
             email: 'invitee@example.com',
             invited_by_display: 'owner@example.com',

--- a/libs/client/auth/src/pages/signup-page.tsx
+++ b/libs/client/auth/src/pages/signup-page.tsx
@@ -1,4 +1,5 @@
 import {signupBodySchema} from '@shipfox/api-auth-dto';
+import {AuthShell} from '@shipfox/client-shell/runtime';
 import {displayNameFieldError} from '@shipfox/client-ui';
 import {Button, ButtonLink} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
@@ -10,7 +11,6 @@ import {useForm} from '@tanstack/react-form';
 import {Link, useNavigate, useSearch} from '@tanstack/react-router';
 import {useAtom} from 'jotai';
 import {useEffect, useRef, useState} from 'react';
-import {AuthShell} from '#/components/auth-shell.js';
 import {EmailCodeVerification} from '#/components/email-code-verification.js';
 import {useRefreshAuth} from '#hooks/api/refresh-auth.js';
 import {useSignupAuth} from '#hooks/api/signup-auth.js';
@@ -67,16 +67,16 @@ export function SignupPage() {
             // Refresh failures don't block the success message — the next API
             // call's 401 handling will re-route the user.
           }
-          toast.success(`You joined ${invitationPending.workspace_name}.`);
+          toast.success(`You joined ${invitationPending.workspaceName}.`);
           await navigate({
             to: '/workspaces/$wid',
-            params: {wid: result.membership.workspace_id},
+            params: {wid: result.membership.workspaceId},
           });
           return;
         }
 
-        if (invitationToken && result.accept_error) {
-          toast.error(result.accept_error.message);
+        if (invitationToken && result.acceptError) {
+          toast.error(result.acceptError.message);
           await navigate({
             to: '/invitations/accept',
             search: {token: invitationToken},
@@ -84,12 +84,12 @@ export function SignupPage() {
           return;
         }
 
-        if (!result.email_challenge) {
+        if (!result.emailChallenge) {
           throw new Error('Signup did not return an email verification challenge');
         }
-        setEmailChallenge({email: result.user.email, id: result.email_challenge.id});
+        setEmailChallenge({email: result.user.email, id: result.emailChallenge.id});
         setResendError(undefined);
-        setNextResendAvailableAt(result.email_challenge.next_resend_available_at);
+        setNextResendAvailableAt(result.emailChallenge.nextResendAvailableAt);
       } catch (error) {
         const mapped = signupErrorToFormError(error);
         if (mapped.kind === 'field') {
@@ -181,7 +181,7 @@ export function SignupPage() {
   }
 
   const headerTitle = invitationPending
-    ? `Join ${invitationPending.workspace_name}`
+    ? `Join ${invitationPending.workspaceName}`
     : 'Create your Shipfox account';
   const headerDescription = invitationPending
     ? `Create an account to accept your invitation.`

--- a/libs/client/integrations/src/pages/linear-callback-page.test.tsx
+++ b/libs/client/integrations/src/pages/linear-callback-page.test.tsx
@@ -13,7 +13,7 @@ vi.mock('@shipfox/client-auth', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@shipfox/client-auth')>();
   return {
     ...actual,
-    useRefreshAuth: () => () => Promise.resolve({token: 'test-token'}),
+    useRefreshAuth: () => () => Promise.resolve({accessToken: 'test-token'}),
   };
 });
 

--- a/libs/client/integrations/src/pages/linear-callback-page.tsx
+++ b/libs/client/integrations/src/pages/linear-callback-page.tsx
@@ -50,7 +50,8 @@ export function LinearCallbackPage() {
       key,
       async () =>
         await refreshAuth().then(
-          async (session) => await completeLinearCallback({query: params, token: session.token}),
+          async (session) =>
+            await completeLinearCallback({query: params, token: session.accessToken}),
         ),
     );
 

--- a/libs/client/integrations/src/pages/sentry-callback-page.test.tsx
+++ b/libs/client/integrations/src/pages/sentry-callback-page.test.tsx
@@ -13,7 +13,7 @@ vi.mock('@shipfox/client-auth', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@shipfox/client-auth')>();
   return {
     ...actual,
-    useRefreshAuth: () => () => Promise.resolve({token: 'test-token'}),
+    useRefreshAuth: () => () => Promise.resolve({accessToken: 'test-token'}),
   };
 });
 

--- a/libs/client/integrations/src/pages/sentry-callback-page.tsx
+++ b/libs/client/integrations/src/pages/sentry-callback-page.tsx
@@ -108,7 +108,7 @@ export function SentryCallbackPage() {
               code: params.code,
               installation_id: params.installationId,
             },
-            token: session.token,
+            token: session.accessToken,
           }),
         ),
     );

--- a/libs/client/integrations/src/pages/slack-callback-page.tsx
+++ b/libs/client/integrations/src/pages/slack-callback-page.tsx
@@ -44,7 +44,8 @@ export function SlackCallbackPage() {
       key,
       async () =>
         await refreshAuth().then(
-          async (session) => await completeSlackCallback({query: params, token: session.token}),
+          async (session) =>
+            await completeSlackCallback({query: params, token: session.accessToken}),
         ),
     );
     request.then(

--- a/libs/client/integrations/src/routes/github-callback.tsx
+++ b/libs/client/integrations/src/routes/github-callback.tsx
@@ -48,7 +48,7 @@ function GithubCallbackRoute() {
       async () =>
         await refreshAuth().then(async (session) => {
           await apiRequest(`/integrations/github/callback/api?${key}`, {
-            headers: {authorization: `Bearer ${session.token}`},
+            headers: {authorization: `Bearer ${session.accessToken}`},
           });
         }),
     );

--- a/libs/client/integrations/test/render.tsx
+++ b/libs/client/integrations/test/render.tsx
@@ -41,11 +41,7 @@ function authState(workspaces: TestWorkspace[]): AuthState {
     user: {
       id: '22222222-2222-4222-8222-222222222222',
       email: 'user@example.com',
-      name: null,
-      email_verified_at: new Date().toISOString(),
-      status: 'active',
-      created_at: new Date().toISOString(),
-      updated_at: new Date().toISOString(),
+      emailVerifiedAt: new Date().toISOString(),
     },
     workspaces,
   };

--- a/libs/client/invitations/package.json
+++ b/libs/client/invitations/package.json
@@ -63,7 +63,6 @@
     "@shipfox/api-auth-dto": "workspace:*",
     "@shipfox/api-workspaces-dto": "workspace:*",
     "@shipfox/client-api": "workspace:*",
-    "@shipfox/client-auth": "workspace:*",
     "@shipfox/client-shell": "workspace:*",
     "@shipfox/client-ui": "workspace:*",
     "@shipfox/react-ui": "workspace:*",

--- a/libs/client/invitations/src/complete-acceptance.ts
+++ b/libs/client/invitations/src/complete-acceptance.ts
@@ -8,7 +8,7 @@ import type {NavigateOptions} from '@tanstack/react-router';
  * routes the user into the workspace home.
  *
  * `refreshAuth` is passed in so this helper stays a plain function (no hook).
- * Call sites construct it via `useRefreshAuth()` from `@shipfox/client-auth`.
+ * Call sites construct it via `useRefreshAuth()` from `@shipfox/client-shell/runtime`.
  */
 export async function completeInvitationAcceptance(params: {
   workspaceId: string;

--- a/libs/client/invitations/src/core/invitation-preview.ts
+++ b/libs/client/invitations/src/core/invitation-preview.ts
@@ -1,0 +1,18 @@
+export type InvitationPreview =
+  | {
+      status: 'pending';
+      workspaceId: string;
+      workspaceName: string;
+      email: string;
+      invitedByDisplay?: string;
+      expiresAt: string;
+    }
+  | {status: 'expired'; workspaceName: string; expiresAt: string}
+  | {status: 'already_used'; workspaceName: string}
+  | {status: 'invalid'};
+
+export function pendingInvitation(
+  preview: InvitationPreview | undefined,
+): Extract<InvitationPreview, {status: 'pending'}> | undefined {
+  return preview?.status === 'pending' ? preview : undefined;
+}

--- a/libs/client/invitations/src/hooks/api/invitation-preview-mapper.test.ts
+++ b/libs/client/invitations/src/hooks/api/invitation-preview-mapper.test.ts
@@ -1,0 +1,36 @@
+import {describe, expect, it} from '@shipfox/vitest/vi';
+import {toInvitationPreview} from './invitation-preview-mapper.js';
+
+describe('toInvitationPreview', () => {
+  it.each([
+    [
+      {
+        status: 'pending' as const,
+        workspace_id: '11111111-1111-4111-8111-111111111111',
+        workspace_name: 'Acme',
+        email: 'member@example.com',
+        invited_by_display: 'Owner',
+        expires_at: '2026-08-01T00:00:00.000Z',
+      },
+      {
+        status: 'pending',
+        workspaceId: '11111111-1111-4111-8111-111111111111',
+        workspaceName: 'Acme',
+        email: 'member@example.com',
+        invitedByDisplay: 'Owner',
+        expiresAt: '2026-08-01T00:00:00.000Z',
+      },
+    ],
+    [
+      {status: 'expired' as const, workspace_name: 'Acme', expires_at: '2026-08-01T00:00:00.000Z'},
+      {status: 'expired', workspaceName: 'Acme', expiresAt: '2026-08-01T00:00:00.000Z'},
+    ],
+    [
+      {status: 'already_used' as const, workspace_name: 'Acme'},
+      {status: 'already_used', workspaceName: 'Acme'},
+    ],
+    [{status: 'invalid' as const}, {status: 'invalid'}],
+  ])('maps %s previews into the invitation domain', (dto, expected) => {
+    expect(toInvitationPreview(dto)).toEqual(expected);
+  });
+});

--- a/libs/client/invitations/src/hooks/api/invitation-preview-mapper.ts
+++ b/libs/client/invitations/src/hooks/api/invitation-preview-mapper.ts
@@ -1,0 +1,22 @@
+import type {PreviewInvitationResponseDto} from '@shipfox/api-workspaces-dto';
+import type {InvitationPreview} from '#core/invitation-preview.js';
+
+export function toInvitationPreview(dto: PreviewInvitationResponseDto): InvitationPreview {
+  switch (dto.status) {
+    case 'pending':
+      return {
+        status: dto.status,
+        workspaceId: dto.workspace_id,
+        workspaceName: dto.workspace_name,
+        email: dto.email,
+        ...(dto.invited_by_display ? {invitedByDisplay: dto.invited_by_display} : {}),
+        expiresAt: dto.expires_at,
+      };
+    case 'expired':
+      return {status: dto.status, workspaceName: dto.workspace_name, expiresAt: dto.expires_at};
+    case 'already_used':
+      return {status: dto.status, workspaceName: dto.workspace_name};
+    case 'invalid':
+      return {status: dto.status};
+  }
+}

--- a/libs/client/invitations/src/hooks/api/preview-invitation.ts
+++ b/libs/client/invitations/src/hooks/api/preview-invitation.ts
@@ -1,23 +1,31 @@
-import type {PreviewInvitationResponseDto} from '@shipfox/api-workspaces-dto';
-import {apiRequest} from '@shipfox/client-api';
-import {useQuery} from '@tanstack/react-query';
+import {previewInvitationResponseSchema} from '@shipfox/api-workspaces-dto';
+import {checkedApiRequest} from '@shipfox/client-api';
+import {queryOptions, useQuery} from '@tanstack/react-query';
+import type {InvitationPreview} from '#core/invitation-preview.js';
+import {toInvitationPreview} from './invitation-preview-mapper.js';
 
 export const previewInvitationQueryKey = (token: string) =>
   ['invitations', 'preview', token] as const;
 
-async function previewInvitation(token: string): Promise<PreviewInvitationResponseDto> {
+async function previewInvitation(token: string): Promise<InvitationPreview> {
   const params = new URLSearchParams({token});
-  return await apiRequest<PreviewInvitationResponseDto>(
+  const response = await checkedApiRequest(
+    previewInvitationResponseSchema,
     `/invitations/preview?${params.toString()}`,
   );
+  return toInvitationPreview(response);
 }
 
-export function usePreviewInvitation(token: string | undefined) {
-  return useQuery({
-    queryKey: previewInvitationQueryKey(token ?? ''),
-    queryFn: () => previewInvitation(token as string),
+export function previewInvitationQueryOptions(token: string) {
+  return queryOptions({
+    queryKey: previewInvitationQueryKey(token),
+    queryFn: () => previewInvitation(token),
     enabled: Boolean(token),
     retry: false,
     staleTime: 30_000,
   });
+}
+
+export function usePreviewInvitation(token: string | undefined) {
+  return useQuery(previewInvitationQueryOptions(token ?? ''));
 }

--- a/libs/client/invitations/src/index.ts
+++ b/libs/client/invitations/src/index.ts
@@ -1,7 +1,9 @@
+export {type InvitationPreview, pendingInvitation} from '#core/invitation-preview.js';
 export {completeInvitationAcceptance} from './complete-acceptance.js';
 export {useAcceptInvitation} from './hooks/api/accept-invitation.js';
 export {
   previewInvitationQueryKey,
+  previewInvitationQueryOptions,
   usePreviewInvitation,
 } from './hooks/api/preview-invitation.js';
 export {InvitationAcceptPage} from './pages/invitation-accept-page.js';

--- a/libs/client/invitations/src/pages/invitation-accept-page.tsx
+++ b/libs/client/invitations/src/pages/invitation-accept-page.tsx
@@ -1,4 +1,4 @@
-import {AuthShell, useAuthState, useRefreshAuth} from '@shipfox/client-auth';
+import {AuthShell, useAuthState, useRefreshAuth} from '@shipfox/client-shell/runtime';
 import {createSingleFlight} from '@shipfox/client-ui';
 import {Button} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
@@ -74,7 +74,7 @@ export function InvitationAcceptPage() {
 
     hasKickedAccept.current = true;
     invitationAccepts
-      .run(token, async () => await runAccept({token, workspaceName: data.workspace_name}))
+      .run(token, async () => await runAccept({token, workspaceName: data.workspaceName}))
       .catch(() => {
         // The mutation surfaces its error via accept.error; the UI re-renders
         // into the auth-match-error state below.
@@ -137,7 +137,7 @@ export function InvitationAcceptPage() {
     return (
       <AuthShell title="Invitation expired" description="The link is no longer accepting joins.">
         <Callout role="alert" type="error">
-          This invitation expired on {formatDate(data.expires_at)}. Ask your administrator to send a
+          This invitation expired on {formatDate(data.expiresAt)}. Ask your administrator to send a
           new one.
         </Callout>
         <GoHomeButton navigate={navigate} />
@@ -150,12 +150,12 @@ export function InvitationAcceptPage() {
       toast.info(`This invitation has already been accepted.`),
     );
     return (
-      <AuthShell title="Invitation already used" description={data.workspace_name}>
+      <AuthShell title="Invitation already used" description={data.workspaceName}>
         <Callout role="alert" type="info">
           This invitation has already been accepted.{' '}
           {auth.isAuthenticated
-            ? `Open your dashboard to access ${data.workspace_name} if your account is a member.`
-            : `Log in to access ${data.workspace_name}.`}
+            ? `Open your dashboard to access ${data.workspaceName} if your account is a member.`
+            : `Log in to access ${data.workspaceName}.`}
         </Callout>
         {auth.isAuthenticated ? null : (
           <Button asChild className="w-full">
@@ -168,8 +168,8 @@ export function InvitationAcceptPage() {
   }
 
   const inviterLine =
-    data.invited_by_display != null
-      ? `Invited by ${data.invited_by_display} to join as ${data.email}.`
+    data.invitedByDisplay != null
+      ? `Invited by ${data.invitedByDisplay} to join as ${data.email}.`
       : `Invited to join as ${data.email}.`;
 
   if (!auth.isAuthenticated) {
@@ -177,7 +177,7 @@ export function InvitationAcceptPage() {
     const signupHref = `/auth/signup?redirect=${encodeURIComponent(redirect)}`;
     const loginHref = `/auth/login?redirect=${encodeURIComponent(redirect)}`;
     return (
-      <AuthShell title={data.workspace_name} description={inviterLine}>
+      <AuthShell title={data.workspaceName} description={inviterLine}>
         <div className="flex flex-col gap-16">
           <Button asChild className="w-full">
             <Link to={signupHref}>Create account</Link>
@@ -199,7 +199,7 @@ export function InvitationAcceptPage() {
     const redirect = `/invitations/accept?token=${encodeURIComponent(token)}`;
     const logoutHref = `/auth/logout?redirect=${encodeURIComponent(redirect)}`;
     return (
-      <AuthShell title={data.workspace_name} description={inviterLine}>
+      <AuthShell title={data.workspaceName} description={inviterLine}>
         <Callout role="alert" type="warning">
           You're signed in as {auth.user?.email}, but this invitation is for {data.email}.
         </Callout>
@@ -223,15 +223,15 @@ export function InvitationAcceptPage() {
   // result. Show either the pending state or the error state.
   if (accept.isError) {
     return (
-      <AuthShell title={data.workspace_name} description={inviterLine}>
+      <AuthShell title={data.workspaceName} description={inviterLine}>
         <Callout role="alert" type="error">
-          We couldn't add you to {data.workspace_name}. Try again in a moment.
+          We couldn't add you to {data.workspaceName}. Try again in a moment.
         </Callout>
         <Button
           className="w-full"
           isLoading={accept.isPending}
           onClick={() => {
-            runAccept({token, workspaceName: data.workspace_name}).catch(() => {
+            runAccept({token, workspaceName: data.workspaceName}).catch(() => {
               // The mutation state drives the rendered error; avoid an
               // unhandled rejection from the click handler.
             });
@@ -244,11 +244,11 @@ export function InvitationAcceptPage() {
   }
 
   return (
-    <AuthShell title={data.workspace_name} description={inviterLine}>
+    <AuthShell title={data.workspaceName} description={inviterLine}>
       <div className="flex flex-col items-center gap-12" aria-live="polite">
         <ShipfoxLoader />
         <Text size="sm" className="text-foreground-neutral-subtle">
-          Adding you to {data.workspace_name}…
+          Adding you to {data.workspaceName}…
         </Text>
       </div>
     </AuthShell>

--- a/libs/client/projects/src/pages/create-project-page.stories.tsx
+++ b/libs/client/projects/src/pages/create-project-page.stories.tsx
@@ -39,10 +39,7 @@ const authState: AuthState = {
     id: '22222222-2222-4222-8222-222222222222',
     email: 'platform@example.com',
     name: 'Platform Engineer',
-    email_verified_at: '2026-01-01T00:00:00.000Z',
-    status: 'active',
-    created_at: '2026-01-01T00:00:00.000Z',
-    updated_at: '2026-01-01T00:00:00.000Z',
+    emailVerifiedAt: '2026-01-01T00:00:00.000Z',
   },
   workspaces: [{id: WORKSPACE_ID, name: 'Acme', membershipId: 'membership-1'}],
 };

--- a/libs/client/projects/test/pages.tsx
+++ b/libs/client/projects/test/pages.tsx
@@ -28,11 +28,7 @@ const authState: AuthState = {
   user: {
     id: '22222222-2222-4222-8222-222222222222',
     email: 'user@example.com',
-    name: null,
-    email_verified_at: new Date().toISOString(),
-    status: 'active',
-    created_at: new Date().toISOString(),
-    updated_at: new Date().toISOString(),
+    emailVerifiedAt: new Date().toISOString(),
   },
   workspaces: [{id: PROJECT_TEST_WID, name: 'Acme', membershipId: 'm-1'}],
 };

--- a/libs/client/shell/src/components/auth-shell.tsx
+++ b/libs/client/shell/src/components/auth-shell.tsx
@@ -33,7 +33,6 @@ export function AuthShell({
       >
         <div className="h-full w-full bg-[radial-gradient(circle,rgba(230,62,0,0.48)_1.6px,transparent_1.8px)] bg-[length:44px_44px]" />
       </div>
-
       <section
         className={className ?? 'relative flex w-full max-w-[384px] flex-col items-stretch gap-28'}
         aria-labelledby="auth-title"

--- a/libs/client/shell/src/core/session.ts
+++ b/libs/client/shell/src/core/session.ts
@@ -1,0 +1,22 @@
+export interface UserIdentity {
+  id: string;
+  email: string;
+  name?: string;
+  emailVerifiedAt?: string;
+}
+
+export interface AuthenticatedSession {
+  accessToken: string;
+  user: UserIdentity;
+}
+
+export interface WorkspaceMembership {
+  id: string;
+  workspaceId: string;
+}
+
+export interface WorkspaceSummary {
+  id: string;
+  name: string;
+  membershipId: string;
+}

--- a/libs/client/shell/src/hooks/api/session-mapper.test.ts
+++ b/libs/client/shell/src/hooks/api/session-mapper.test.ts
@@ -1,0 +1,44 @@
+import type {LoginResponseDto, UserDto} from '@shipfox/api-auth-dto';
+import {toAuthenticatedSession, toUserIdentity} from './session-mapper.js';
+
+const baseUser: UserDto = {
+  id: '11111111-1111-4111-8111-111111111111',
+  email: 'user@example.com',
+  name: null,
+  email_verified_at: null,
+  status: 'active',
+  created_at: '2026-04-27T00:00:00.000Z',
+  updated_at: '2026-04-27T00:00:00.000Z',
+};
+
+describe('toUserIdentity', () => {
+  test('omits name and emailVerifiedAt when the DTO carries neither', () => {
+    expect(toUserIdentity(baseUser)).toEqual({id: baseUser.id, email: baseUser.email});
+  });
+
+  test('maps name and email_verified_at into camelCase when present', () => {
+    const identity = toUserIdentity({
+      ...baseUser,
+      name: 'Ada',
+      email_verified_at: '2026-04-27T00:00:00.000Z',
+    });
+
+    expect(identity).toEqual({
+      id: baseUser.id,
+      email: baseUser.email,
+      name: 'Ada',
+      emailVerifiedAt: '2026-04-27T00:00:00.000Z',
+    });
+  });
+});
+
+describe('toAuthenticatedSession', () => {
+  test('maps the token to accessToken and the user through toUserIdentity', () => {
+    const dto: LoginResponseDto = {token: 'access-token', user: baseUser};
+
+    expect(toAuthenticatedSession(dto)).toEqual({
+      accessToken: 'access-token',
+      user: {id: baseUser.id, email: baseUser.email},
+    });
+  });
+});

--- a/libs/client/shell/src/hooks/api/session-mapper.ts
+++ b/libs/client/shell/src/hooks/api/session-mapper.ts
@@ -1,0 +1,15 @@
+import type {LoginResponseDto, UserDto} from '@shipfox/api-auth-dto';
+import type {AuthenticatedSession, UserIdentity} from '#core/session.js';
+
+export function toUserIdentity(dto: UserDto): UserIdentity {
+  return {
+    id: dto.id,
+    email: dto.email,
+    ...(dto.name ? {name: dto.name} : {}),
+    ...(dto.email_verified_at ? {emailVerifiedAt: dto.email_verified_at} : {}),
+  };
+}
+
+export function toAuthenticatedSession(dto: LoginResponseDto): AuthenticatedSession {
+  return {accessToken: dto.token, user: toUserIdentity(dto.user)};
+}

--- a/libs/client/shell/src/runtime/auth.tsx
+++ b/libs/client/shell/src/runtime/auth.tsx
@@ -1,10 +1,12 @@
-import type {LoginResponseDto, UserDto} from '@shipfox/api-auth-dto';
-import type {MembershipWithWorkspaceDto} from '@shipfox/api-workspaces-dto';
-import {ApiError, apiRequest, configureApiClient} from '@shipfox/client-api';
+import {loginResponseSchema} from '@shipfox/api-auth-dto';
+import {listUserWorkspacesResponseSchema} from '@shipfox/api-workspaces-dto';
+import {ApiError, checkedApiRequest, configureApiClient} from '@shipfox/client-api';
 import {useQueryClient} from '@tanstack/react-query';
 import {atom, useAtomValue, useSetAtom, useStore} from 'jotai';
 import type {PropsWithChildren} from 'react';
 import {useCallback, useEffect, useMemo} from 'react';
+import type {AuthenticatedSession, UserIdentity, WorkspaceSummary} from '#core/session.js';
+import {toAuthenticatedSession} from '#hooks/api/session-mapper.js';
 
 const REFRESH_EARLY_MS = 5 * 60 * 1000;
 const REFRESH_RETRY_DELAY_MS = 60_000;
@@ -12,16 +14,12 @@ const BASE64_URL_REPLACEMENTS = {dash: /-/g, underscore: /_/g} as const;
 
 export type AuthStatus = 'loading' | 'authenticated' | 'guest';
 
-export interface Workspace {
-  id: string;
-  name: string;
-  membershipId: string;
-}
+export type Workspace = WorkspaceSummary;
 
 export interface AuthState {
   status: AuthStatus;
   token?: string;
-  user?: UserDto;
+  user?: UserIdentity;
   workspaces?: Workspace[];
 }
 
@@ -39,18 +37,14 @@ export const authRefreshQueryKey = ['auth', 'refresh'] as const;
 export const userWorkspacesQueryKey = ['workspaces', 'mine'] as const;
 
 export function toAuthenticatedState(
-  result: LoginResponseDto,
-  memberships: MembershipWithWorkspaceDto[] = [],
+  session: AuthenticatedSession,
+  workspaces: WorkspaceSummary[] = [],
 ): AuthState {
   return {
     status: 'authenticated',
-    token: result.token,
-    user: result.user,
-    workspaces: memberships.map((membership) => ({
-      id: membership.workspace_id,
-      name: membership.workspace_name,
-      membershipId: membership.id,
-    })),
+    token: session.accessToken,
+    user: session.user,
+    workspaces,
   };
 }
 
@@ -69,14 +63,23 @@ export function useAuthState(): AuthStateValue {
 }
 
 export async function listUserWorkspaces(token?: string) {
-  return await apiRequest<{memberships: MembershipWithWorkspaceDto[]}>(
+  const response = await checkedApiRequest(
+    listUserWorkspacesResponseSchema,
     '/workspaces',
     token ? {headers: {authorization: `Bearer ${token}`}} : {},
   );
+  return {
+    memberships: response.memberships.map((membership) => ({
+      id: membership.workspace_id,
+      name: membership.workspace_name,
+      membershipId: membership.id,
+    })),
+  };
 }
 
-async function refreshAuthRequest() {
-  return await apiRequest<LoginResponseDto>('/auth/refresh', {method: 'POST'});
+async function refreshAuthRequest(): Promise<AuthenticatedSession> {
+  const response = await checkedApiRequest(loginResponseSchema, '/auth/refresh', {method: 'POST'});
+  return toAuthenticatedSession(response);
 }
 
 function decodeBase64Url(value: string): string {
@@ -121,33 +124,33 @@ export function useAuthTransition() {
   }, [clearPrivateState, setState, store]);
 
   const enterAuthenticated = useCallback(
-    async (result: LoginResponseDto) => {
+    async (session: AuthenticatedSession) => {
       const transitionEpoch = store.get(authTransitionEpochAtom) + 1;
       store.set(authTransitionEpochAtom, transitionEpoch);
       const previousState = store.get(authStateAtom);
       const principalChanged =
-        previousState.status === 'authenticated' && previousState.user?.id !== result.user.id;
+        previousState.status === 'authenticated' && previousState.user?.id !== session.user.id;
 
       if (principalChanged) await clearPrivateState();
       if (store.get(authTransitionEpochAtom) !== transitionEpoch) return;
 
-      queryClient.setQueryData(authRefreshQueryKey, result);
-      let memberships: MembershipWithWorkspaceDto[] = [];
+      queryClient.setQueryData(authRefreshQueryKey, session);
+      let workspaces: WorkspaceSummary[] = [];
       try {
-        const workspaces = await queryClient.fetchQuery({
+        const hydratedWorkspaces = await queryClient.fetchQuery({
           queryKey: userWorkspacesQueryKey,
-          queryFn: () => listUserWorkspaces(result.token),
+          queryFn: () => listUserWorkspaces(session.accessToken),
           retry: false,
           staleTime: 0,
         });
-        memberships = workspaces.memberships;
-        queryClient.setQueryData(userWorkspacesQueryKey, workspaces);
+        workspaces = hydratedWorkspaces.memberships;
+        queryClient.setQueryData(userWorkspacesQueryKey, hydratedWorkspaces);
       } catch {
         // The authenticated session remains usable while workspace hydration retries on the next route load.
       }
       if (store.get(authTransitionEpochAtom) !== transitionEpoch) return;
 
-      setState(toAuthenticatedState(result, memberships));
+      setState(toAuthenticatedState(session, workspaces));
     },
     [clearPrivateState, queryClient, setState, store],
   );
@@ -188,7 +191,7 @@ export function AuthRuntime({children, effects = true}: AuthRuntimeProps) {
     if (!effects) return;
     configureApiClient({
       getAccessToken: () => store.get(authStateAtom).token,
-      refreshAccessToken: async () => (await refreshAuth()).token,
+      refreshAccessToken: async () => (await refreshAuth()).accessToken,
     });
   }, [effects, refreshAuth, store]);
 

--- a/libs/client/shell/src/runtime/index.ts
+++ b/libs/client/shell/src/runtime/index.ts
@@ -1,5 +1,13 @@
+export {AuthActions, AuthShell, type AuthShellProps} from '#components/auth-shell.js';
 export {WorkspaceCrumb, type WorkspaceCrumbProps} from '#components/workspace-crumb.js';
 export {WorkspaceSwitcher} from '#components/workspace-switcher.js';
+export type {
+  AuthenticatedSession,
+  UserIdentity,
+  WorkspaceMembership,
+  WorkspaceSummary,
+} from '#core/session.js';
+export {toAuthenticatedSession, toUserIdentity} from '#hooks/api/session-mapper.js';
 export * from '../compose/compose-routes.js';
 export * from '../compose/errors.js';
 export * from '../compose/merge-config.js';

--- a/libs/client/workspace-settings/test/pages.tsx
+++ b/libs/client/workspace-settings/test/pages.tsx
@@ -22,11 +22,7 @@ const authState: AuthState = {
   user: {
     id: '22222222-2222-4222-8222-222222222222',
     email: 'user@example.com',
-    name: null,
-    email_verified_at: new Date().toISOString(),
-    status: 'active',
-    created_at: new Date().toISOString(),
-    updated_at: new Date().toISOString(),
+    emailVerifiedAt: new Date().toISOString(),
   },
   workspaces: [{id: WORKSPACE_SETTINGS_TEST_WID, name: 'Acme', membershipId: 'm-1'}],
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4549,6 +4549,9 @@ importers:
       '@shipfox/client-api':
         specifier: workspace:*
         version: link:../api
+      '@shipfox/client-invitations':
+        specifier: workspace:*
+        version: link:../invitations
       '@shipfox/client-shell':
         specifier: workspace:*
         version: link:../shell
@@ -4934,9 +4937,6 @@ importers:
       '@shipfox/client-api':
         specifier: workspace:*
         version: link:../api
-      '@shipfox/client-auth':
-        specifier: workspace:*
-        version: link:../auth
       '@shipfox/client-shell':
         specifier: workspace:*
         version: link:../shell

--- a/tools/client-architecture-policy/client-architecture-baseline.json
+++ b/tools/client-architecture-policy/client-architecture-baseline.json
@@ -65,16 +65,6 @@
     "occurrences": 1
   },
   {
-    "file": "libs/client/auth/src/pages/invitation-context.ts",
-    "rule": "api-request-outside-adapter",
-    "occurrences": 1
-  },
-  {
-    "file": "libs/client/auth/src/pages/invitation-context.ts",
-    "rule": "response-dto-in-presentation",
-    "occurrences": 2
-  },
-  {
     "file": "libs/client/integrations/src/components/connection-picker.tsx",
     "rule": "response-dto-in-presentation",
     "occurrences": 1
@@ -163,11 +153,6 @@
     "file": "libs/client/projects/src/pages/create-project-page.tsx",
     "rule": "response-dto-in-presentation",
     "occurrences": 3
-  },
-  {
-    "file": "libs/client/projects/src/pages/project-workflows-page.tsx",
-    "rule": "response-dto-in-presentation",
-    "occurrences": 2
   },
   {
     "file": "libs/client/projects/src/pages/projects-hub-page.tsx",
@@ -318,6 +303,11 @@
     "file": "libs/client/workflows/src/core/entities/workflow-run.ts",
     "rule": "core-api-dto-import",
     "occurrences": 1
+  },
+  {
+    "file": "libs/client/workflows/src/pages/project-workflows-page.tsx",
+    "rule": "response-dto-in-presentation",
+    "occurrences": 2
   },
   {
     "file": "libs/client/workspace-settings/src/components/members/workspace-members-section.tsx",


### PR DESCRIPTION
Login, signup, password reset, email verification, workspace creation, and invitation preview returned raw snake_case API DTOs straight from `client-auth` and `client-invitations` hooks, and `client-invitations` depended on `client-auth` just to reuse its `AuthShell` component and invitation-preview hook — a circular dependency once `client-auth` needed to depend back on `client-invitations` for invitation preview.

This validates every response against its Zod schema via `checkedApiRequest` and maps it to a camelCase domain shape (`AuthenticatedSession`, `UserIdentity`, `Workspace`, `InvitationPreview`) before it reaches page components, instead of pages reaching into raw wire DTOs directly. It moves the shared `AuthShell` component and session-mapping helpers (`toAuthenticatedSession`/`toUserIdentity`) into `client-shell`, which both packages already depend on, breaking the circular dependency without introducing a new one.

Downstream consumers in `client-integrations`, `client-projects`, and `client-workspace-settings` are updated to match the new field names (`accessToken` instead of `token`, `workspaceName` instead of `workspace_name`, etc). These are the public-API-breaking parts of this change, called out in the changeset as `major` for `client-shell`/`client-auth`/`client-invitations`.

Areas that need careful review:
- `libs/client/shell/src/core/session.ts` is the new single source of truth for `toAuthenticatedSession`/`toUserIdentity` — `client-auth`'s `auth-mapper.ts` now re-exports/reuses it instead of duplicating.
- `AuthShell` moved from `client-auth` to `client-shell`; all four `client-auth` pages (login/signup/password-reset/logout) and `client-invitations`' invitation-accept page now share the one copy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converges auth and invitation flows onto validated, camelCase domain types and moves shared auth UI/mappers into `@shipfox/client-shell`, removing the former circular dependency. Hooks now return domain shapes (`AuthenticatedSession`, `InvitationPreview`), and all API responses are schema-checked.

- **Refactors**
  - Validate login/refresh, password reset, verify email, workspace create, and invitation preview with Zod via `checkedApiRequest`.
  - Map to domain types: `AuthenticatedSession`/`UserIdentity` (from `@shipfox/client-shell/runtime`), `Workspace`/`WorkspaceSummary`, `InvitationPreview`.
  - Move `AuthShell` and session mappers to `@shipfox/client-shell` and export `toAuthenticatedSession`/`toUserIdentity`.
  - Centralize invitation preview in `@shipfox/client-invitations` (exports `pendingInvitation`, `previewInvitationQueryOptions`); `client-auth` uses `usePreviewInvitation`.
  - `createWorkspace` and auth hooks return domain shapes (`accessToken`, minimal `Workspace`).

- **Migration**
  - Import `AuthShell`, `toAuthenticatedSession`, `toUserIdentity`, and `listUserWorkspaces` from `@shipfox/client-shell/runtime`.
  - Replace `token` with `accessToken` (e.g., `useRefreshAuth()`, integration callback pages, API client refresh).
  - Use camelCase fields: `workspaceName`, `invitedByDisplay`, `expiresAt`, `emailVerifiedAt`.
  - Use `usePreviewInvitation`/`previewInvitationQueryOptions` from `@shipfox/client-invitations`.
  - `signup` returns `SignupResult` with `emailChallenge`, `membership.workspaceId`, and `acceptError`.

<sup>Written for commit ea70430f83b32dc7c7e7777a10174e32dd20f27f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

