### PR TITLE
Normalize inter-module contract exports

### DIFF
--- a/.changeset/tidy-contracts-migrate.md
+++ b/.changeset/tidy-contracts-migrate.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-integration-core-dto": major
+"@shipfox/api-projects-dto": major
+---
+
+Moves Projects and Integrations synchronous contracts to producer-owned inter-module entry points.

--- a/libs/api/definitions/src/core/integrations.ts
+++ b/libs/api/definitions/src/core/integrations.ts
@@ -1,7 +1,7 @@
 import {
   type IntegrationsModuleClient,
   integrationsInterModuleContract,
-} from '@shipfox/api-integration-core-dto';
+} from '@shipfox/api-integration-core-dto/inter-module';
 
 export type DefinitionsSourceControl = {
   resolveRepository: IntegrationsModuleClient['resolveSourceRepository'];

--- a/libs/api/definitions/src/core/sync-definitions.test.ts
+++ b/libs/api/definitions/src/core/sync-definitions.test.ts
@@ -1,5 +1,5 @@
 import type {IntegrationSourceControlService} from '@shipfox/api-integration-core';
-import {integrationsInterModuleContract} from '@shipfox/api-integration-core-dto';
+import {integrationsInterModuleContract} from '@shipfox/api-integration-core-dto/inter-module';
 import {createInterModuleKnownError} from '@shipfox/inter-module';
 import {LOWERCASE_SHA256_HEX_RE} from '@shipfox/regex';
 import {agentValidationCatalog} from '#test/agent-validation-catalog.js';

--- a/libs/api/definitions/src/core/sync-definitions.ts
+++ b/libs/api/definitions/src/core/sync-definitions.ts
@@ -1,9 +1,7 @@
 import {createHash} from 'node:crypto';
 import type {AgentValidationCatalog} from '@shipfox/api-agent-dto/inter-module';
-import {
-  integrationsInterModuleContract,
-  MAX_REPOSITORY_FILE_BYTES,
-} from '@shipfox/api-integration-core-dto';
+import {MAX_REPOSITORY_FILE_BYTES} from '@shipfox/api-integration-core-dto';
+import {integrationsInterModuleContract} from '@shipfox/api-integration-core-dto/inter-module';
 import {isInterModuleKnownError} from '@shipfox/inter-module';
 import {boundedMap} from '@shipfox/node-module';
 import type {IntegrationValidationContext} from './entities/integration-context.js';

--- a/libs/api/definitions/src/index.ts
+++ b/libs/api/definitions/src/index.ts
@@ -6,13 +6,13 @@ import {
   type DefinitionsEventMap,
   definitionsEventSchemas,
 } from '@shipfox/api-definitions-dto';
-import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto';
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
 import {
   PROJECT_SOURCE_BOUND,
   PROJECT_SOURCE_COMMIT_OBSERVED,
   type ProjectsEventMap,
 } from '@shipfox/api-projects-dto';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {type ShipfoxModule, subscriberFactory} from '@shipfox/node-module';
 import {logger} from '@shipfox/node-opentelemetry';
 import {createDefinitionsSourceControl} from '#core/integrations.js';

--- a/libs/api/definitions/src/presentation/routes/create-definition.test.ts
+++ b/libs/api/definitions/src/presentation/routes/create-definition.test.ts
@@ -1,6 +1,6 @@
 import {buildUserContext, setUserContext} from '@shipfox/api-auth-context';
-import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto';
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import type {FastifyInstance} from 'fastify';
 import Fastify from 'fastify';
 import {serializerCompiler, validatorCompiler} from 'fastify-type-provider-zod';

--- a/libs/api/definitions/src/presentation/routes/create-definition.ts
+++ b/libs/api/definitions/src/presentation/routes/create-definition.ts
@@ -4,8 +4,8 @@ import {
   definitionResponseSchema,
   definitionValidationErrorSchema,
 } from '@shipfox/api-definitions-dto';
-import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto';
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
 import {DefinitionParseError} from '#core/errors.js';

--- a/libs/api/definitions/src/presentation/routes/get-definition.test.ts
+++ b/libs/api/definitions/src/presentation/routes/get-definition.test.ts
@@ -1,5 +1,5 @@
 import {buildUserContext, setUserContext} from '@shipfox/api-auth-context';
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import type {FastifyInstance} from 'fastify';
 import Fastify from 'fastify';
 import {serializerCompiler, validatorCompiler} from 'fastify-type-provider-zod';

--- a/libs/api/definitions/src/presentation/routes/get-definition.ts
+++ b/libs/api/definitions/src/presentation/routes/get-definition.ts
@@ -1,5 +1,5 @@
 import {definitionResponseSchema} from '@shipfox/api-definitions-dto';
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
 import {getDefinitionById} from '#db/definitions.js';

--- a/libs/api/definitions/src/presentation/routes/index.test.ts
+++ b/libs/api/definitions/src/presentation/routes/index.test.ts
@@ -1,5 +1,5 @@
 import {AUTH_USER, buildUserContext, setUserContext} from '@shipfox/api-auth-context';
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {type AuthMethod, ClientError, closeApp, createApp} from '@shipfox/node-fastify';
 import type {FastifyRequest} from 'fastify';
 import {agentValidationCatalog} from '#test/agent-validation-catalog.js';

--- a/libs/api/definitions/src/presentation/routes/list-definitions.test.ts
+++ b/libs/api/definitions/src/presentation/routes/list-definitions.test.ts
@@ -1,5 +1,5 @@
 import {buildUserContext, setUserContext} from '@shipfox/api-auth-context';
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {encodeStringIdCursor} from '@shipfox/node-drizzle';
 import type {FastifyInstance} from 'fastify';
 import Fastify from 'fastify';

--- a/libs/api/definitions/src/presentation/routes/list-definitions.ts
+++ b/libs/api/definitions/src/presentation/routes/list-definitions.ts
@@ -2,7 +2,7 @@ import {
   definitionListQuerySchema,
   definitionListResponseSchema,
 } from '@shipfox/api-definitions-dto';
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {decodeStringIdCursor, encodeStringIdCursor} from '@shipfox/node-drizzle';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {listDefinitions} from '#db/definitions.js';

--- a/libs/api/definitions/src/presentation/routes/project-access.ts
+++ b/libs/api/definitions/src/presentation/routes/project-access.ts
@@ -1,5 +1,5 @@
 import {requireWorkspaceAccess} from '@shipfox/api-auth-context';
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {ClientError} from '@shipfox/node-fastify';
 import type {FastifyRequest} from 'fastify';
 

--- a/libs/api/definitions/src/temporal/activities/sync-activities.test.ts
+++ b/libs/api/definitions/src/temporal/activities/sync-activities.test.ts
@@ -1,5 +1,5 @@
 import type {IntegrationSourceControlService} from '@shipfox/api-integration-core';
-import {integrationsInterModuleContract} from '@shipfox/api-integration-core-dto';
+import {integrationsInterModuleContract} from '@shipfox/api-integration-core-dto/inter-module';
 import {createInterModuleKnownError} from '@shipfox/inter-module';
 import {isErrorReported} from '@shipfox/node-error-monitoring';
 import {ApplicationFailure} from '@temporalio/common';

--- a/libs/api/definitions/src/temporal/activities/sync-activities.ts
+++ b/libs/api/definitions/src/temporal/activities/sync-activities.ts
@@ -1,5 +1,5 @@
 import type {AgentInterModuleClient} from '@shipfox/api-agent-dto/inter-module';
-import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto';
+import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
 import {markErrorReported} from '@shipfox/node-error-monitoring';
 import {Context} from '@temporalio/activity';
 import {ApplicationFailure} from '@temporalio/common';

--- a/libs/api/integration/core-dto/package.json
+++ b/libs/api/integration/core-dto/package.json
@@ -28,6 +28,16 @@
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
       }
+    },
+    "./inter-module": {
+      "workspace-source": {
+        "types": "./src/inter-module.ts",
+        "default": "./src/inter-module.ts"
+      },
+      "default": {
+        "types": "./dist/inter-module.d.ts",
+        "default": "./dist/inter-module.js"
+      }
     }
   },
   "scripts": {

--- a/libs/api/integration/core-dto/src/index.ts
+++ b/libs/api/integration/core-dto/src/index.ts
@@ -1,7 +1,6 @@
 export * from '#contracts/index.js';
 export * from '#errors.js';
 export * from '#events.js';
-export * from '#inter-module.js';
 export * from '#ports.js';
 export * from '#schemas/index.js';
 export * from '#slug.js';

--- a/libs/api/integration/core-dto/src/inter-module.test.ts
+++ b/libs/api/integration/core-dto/src/inter-module.test.ts
@@ -1,0 +1,38 @@
+import {integrationsInterModuleContract} from './inter-module.js';
+
+describe('integrationsInterModuleContract', () => {
+  test('accepts a source repository lookup through the producer contract', () => {
+    const result = integrationsInterModuleContract.methods.resolveSourceRepository.output.parse({
+      connection: {
+        id: '00000000-0000-4000-8000-000000000001',
+        provider: 'github',
+        slug: 'github-main',
+      },
+      repository: {
+        externalRepositoryId: 'shipfox/project',
+        owner: 'shipfox',
+        name: 'project',
+        fullName: 'shipfox/project',
+        defaultBranch: 'main',
+        visibility: 'private',
+        cloneUrl: 'https://github.com/shipfox/project.git',
+        htmlUrl: 'https://github.com/shipfox/project',
+      },
+    });
+
+    expect(result.repository.fullName).toBe('shipfox/project');
+  });
+
+  test.each([
+    ['connection-not-found', {connectionId: '00000000-0000-4000-8000-000000000001'}],
+    ['provider-unavailable', {provider: 'github'}],
+    ['provider-failure', {reason: 'rate-limited', retryAfterSeconds: 30}],
+  ] as const)('defines the %s source failure', (code, details) => {
+    const schema =
+      integrationsInterModuleContract.methods.resolveSourceRepository.errors[
+        code as keyof typeof integrationsInterModuleContract.methods.resolveSourceRepository.errors
+      ];
+
+    expect(schema.parse(details)).toEqual(details);
+  });
+});

--- a/libs/api/integration/core/src/presentation/inter-module.ts
+++ b/libs/api/integration/core/src/presentation/inter-module.ts
@@ -1,4 +1,4 @@
-import {integrationsInterModuleContract} from '@shipfox/api-integration-core-dto';
+import {integrationsInterModuleContract} from '@shipfox/api-integration-core-dto/inter-module';
 import {
   createInterModuleKnownError,
   defineInterModulePresentation,

--- a/libs/api/integration/github/package.json
+++ b/libs/api/integration/github/package.json
@@ -45,7 +45,6 @@
     "@shipfox/api-auth-context": "workspace:*",
     "@shipfox/api-integration-core-dto": "workspace:*",
     "@shipfox/api-integration-github-dto": "workspace:*",
-    "@shipfox/api-workspaces": "workspace:*",
     "@shipfox/config": "workspace:*",
     "@shipfox/node-drizzle": "workspace:*",
     "@shipfox/node-fastify": "workspace:*",

--- a/libs/api/integration/jira/package.json
+++ b/libs/api/integration/jira/package.json
@@ -44,7 +44,6 @@
     "@shipfox/api-auth-context": "workspace:*",
     "@shipfox/api-integration-core-dto": "workspace:*",
     "@shipfox/api-integration-jira-dto": "workspace:*",
-    "@shipfox/api-workspaces": "workspace:*",
     "@shipfox/config": "workspace:*",
     "@shipfox/node-drizzle": "workspace:*",
     "@shipfox/node-fastify": "workspace:*",

--- a/libs/api/integration/linear/package.json
+++ b/libs/api/integration/linear/package.json
@@ -45,7 +45,6 @@
     "@shipfox/api-auth-context": "workspace:*",
     "@shipfox/api-integration-core-dto": "workspace:*",
     "@shipfox/api-integration-linear-dto": "workspace:*",
-    "@shipfox/api-workspaces": "workspace:*",
     "@shipfox/config": "workspace:*",
     "@shipfox/node-drizzle": "workspace:*",
     "@shipfox/node-fastify": "workspace:*",

--- a/libs/api/projects-dto/package.json
+++ b/libs/api/projects-dto/package.json
@@ -28,6 +28,16 @@
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
       }
+    },
+    "./inter-module": {
+      "workspace-source": {
+        "types": "./src/inter-module.ts",
+        "default": "./src/inter-module.ts"
+      },
+      "default": {
+        "types": "./dist/inter-module.d.ts",
+        "default": "./dist/inter-module.js"
+      }
     }
   },
   "scripts": {
@@ -35,6 +45,8 @@
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
     "depcruise": "shipfox-depcruise",
+    "test": "shipfox-vitest-run",
+    "test:watch": "shipfox-vitest-watch",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"
   },

--- a/libs/api/projects-dto/src/index.ts
+++ b/libs/api/projects-dto/src/index.ts
@@ -1,4 +1,3 @@
 export * from './e2e/index.js';
 export * from './events.js';
-export * from './inter-module.js';
 export * from './schemas/index.js';

--- a/libs/api/projects-dto/src/inter-module.test.ts
+++ b/libs/api/projects-dto/src/inter-module.test.ts
@@ -1,0 +1,36 @@
+import {projectsInterModuleContract} from './inter-module.js';
+
+describe('projectsInterModuleContract', () => {
+  test('accepts a project lookup through the producer contract', () => {
+    const projectId = '00000000-0000-4000-8000-000000000001';
+    const result = projectsInterModuleContract.methods.getProjectById.output.parse({
+      project: {
+        id: projectId,
+        workspaceId: '00000000-0000-4000-8000-000000000002',
+        sourceConnectionId: '00000000-0000-4000-8000-000000000003',
+        sourceExternalRepositoryId: 'shipfox/project',
+        name: 'Project',
+      },
+    });
+
+    expect(result.project?.id).toBe(projectId);
+  });
+
+  test.each([
+    ['project-not-found', {projectId: '00000000-0000-4000-8000-000000000001'}],
+    [
+      'project-workspace-mismatch',
+      {
+        projectId: '00000000-0000-4000-8000-000000000001',
+        workspaceId: '00000000-0000-4000-8000-000000000002',
+      },
+    ],
+  ] as const)('defines the %s failure', (code, details) => {
+    const schema =
+      projectsInterModuleContract.methods.requireProjectForWorkspace.errors[
+        code as keyof typeof projectsInterModuleContract.methods.requireProjectForWorkspace.errors
+      ];
+
+    expect(schema.parse(details)).toEqual(details);
+  });
+});

--- a/libs/api/projects/src/core/projects.test.ts
+++ b/libs/api/projects/src/core/projects.test.ts
@@ -1,5 +1,5 @@
-import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto';
-import {integrationsInterModuleContract} from '@shipfox/api-integration-core-dto';
+import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
+import {integrationsInterModuleContract} from '@shipfox/api-integration-core-dto/inter-module';
 import {createInterModuleKnownError} from '@shipfox/inter-module';
 import {sql} from 'drizzle-orm';
 import {db} from '#db/index.js';

--- a/libs/api/projects/src/core/projects.ts
+++ b/libs/api/projects/src/core/projects.ts
@@ -1,4 +1,4 @@
-import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto';
+import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
 import {
   PROJECT_CREATED,
   PROJECT_SOURCE_BOUND,

--- a/libs/api/projects/src/index.ts
+++ b/libs/api/projects/src/index.ts
@@ -1,10 +1,10 @@
 import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
-import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto';
 import {
   INTEGRATION_SOURCE_COMMIT_PUSHED,
   type IntegrationsEventMap,
 } from '@shipfox/api-integration-core-dto';
+import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
 import {projectsEventSchemas} from '@shipfox/api-projects-dto';
 import {type ShipfoxModule, subscriberFactory} from '@shipfox/node-module';
 import {db, migrationsPath, projectsOutbox} from '#db/index.js';

--- a/libs/api/projects/src/presentation/inter-module.ts
+++ b/libs/api/projects/src/presentation/inter-module.ts
@@ -1,4 +1,4 @@
-import {projectsInterModuleContract} from '@shipfox/api-projects-dto';
+import {projectsInterModuleContract} from '@shipfox/api-projects-dto/inter-module';
 import {
   createInterModuleKnownError,
   defineInterModulePresentation,

--- a/libs/api/projects/src/presentation/routes/create-project.ts
+++ b/libs/api/projects/src/presentation/routes/create-project.ts
@@ -2,7 +2,7 @@ import {AUTH_USER, requireUserContext, requireWorkspaceAccess} from '@shipfox/ap
 import {
   type IntegrationsModuleClient,
   integrationsInterModuleContract,
-} from '@shipfox/api-integration-core-dto';
+} from '@shipfox/api-integration-core-dto/inter-module';
 import {createProjectBodySchema, projectResponseSchema} from '@shipfox/api-projects-dto';
 import {isInterModuleKnownError} from '@shipfox/inter-module';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';

--- a/libs/api/projects/src/presentation/routes/index.ts
+++ b/libs/api/projects/src/presentation/routes/index.ts
@@ -1,4 +1,4 @@
-import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto';
+import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
 import type {RouteGroup} from '@shipfox/node-fastify';
 import {createProjectRoute} from './create-project.js';
 import {getProjectRoute} from './get-project.js';

--- a/libs/api/projects/src/presentation/routes/projects.test.ts
+++ b/libs/api/projects/src/presentation/routes/projects.test.ts
@@ -7,7 +7,7 @@ import {
 import {
   type IntegrationsModuleClient,
   integrationsInterModuleContract,
-} from '@shipfox/api-integration-core-dto';
+} from '@shipfox/api-integration-core-dto/inter-module';
 import {createInterModuleKnownError} from '@shipfox/inter-module';
 import type {AuthMethod} from '@shipfox/node-fastify';
 import {closeApp, createApp} from '@shipfox/node-fastify';

--- a/libs/api/projects/src/presentation/subscribers/on-source-commit-pushed.test.ts
+++ b/libs/api/projects/src/presentation/subscribers/on-source-commit-pushed.test.ts
@@ -1,9 +1,9 @@
 import {
   INTEGRATION_SOURCE_COMMIT_PUSHED,
   type IntegrationSourceCommitPushedEvent,
-  type IntegrationsModuleClient,
   type SourcePushPayload,
 } from '@shipfox/api-integration-core-dto';
+import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
 import {PROJECT_SOURCE_COMMIT_OBSERVED} from '@shipfox/api-projects-dto';
 import type {DomainEvent} from '@shipfox/node-outbox';
 import {and, eq, sql} from 'drizzle-orm';

--- a/libs/api/secrets/src/index.ts
+++ b/libs/api/secrets/src/index.ts
@@ -1,4 +1,4 @@
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {secretsEventSchemas} from '@shipfox/api-secrets-dto';
 import type {ShipfoxModule} from '@shipfox/node-module';
 import {db, migrationsPath, secretsOutbox} from '#db/index.js';

--- a/libs/api/secrets/src/presentation/routes/auth.ts
+++ b/libs/api/secrets/src/presentation/routes/auth.ts
@@ -1,5 +1,8 @@
 import {requireWorkspaceAccess} from '@shipfox/api-auth-context';
-import {type ProjectsModuleClient, projectsInterModuleContract} from '@shipfox/api-projects-dto';
+import {
+  type ProjectsModuleClient,
+  projectsInterModuleContract,
+} from '@shipfox/api-projects-dto/inter-module';
 import {isInterModuleKnownError} from '@shipfox/inter-module';
 import {ClientError} from '@shipfox/node-fastify';
 import type {FastifyRequest} from 'fastify';

--- a/libs/api/secrets/src/presentation/routes/index.ts
+++ b/libs/api/secrets/src/presentation/routes/index.ts
@@ -1,5 +1,5 @@
 import {AUTH_USER} from '@shipfox/api-auth-context';
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import type {RouteGroup} from '@shipfox/node-fastify';
 import {createManagementAccess} from './auth.js';
 import {batchSecretsRoute} from './batch-secrets.js';

--- a/libs/api/secrets/src/presentation/routes/management.test.ts
+++ b/libs/api/secrets/src/presentation/routes/management.test.ts
@@ -4,7 +4,7 @@ import {
   setUserContext,
   type UserContextMembership,
 } from '@shipfox/api-auth-context';
-import {projectsInterModuleContract} from '@shipfox/api-projects-dto';
+import {projectsInterModuleContract} from '@shipfox/api-projects-dto/inter-module';
 import {
   SECRET_CREATED,
   SECRET_DELETED,

--- a/libs/api/server/src/modules.test.ts
+++ b/libs/api/server/src/modules.test.ts
@@ -2,8 +2,8 @@ import {annotationsInterModuleContract} from '@shipfox/annotations-dto/inter-mod
 import {agentInterModuleContract} from '@shipfox/api-agent-dto/inter-module';
 import {authInterModuleContract} from '@shipfox/api-auth-dto/inter-module';
 import {definitionsInterModuleContract} from '@shipfox/api-definitions-dto/inter-module';
-import {integrationsInterModuleContract} from '@shipfox/api-integration-core-dto';
-import {projectsInterModuleContract} from '@shipfox/api-projects-dto';
+import {integrationsInterModuleContract} from '@shipfox/api-integration-core-dto/inter-module';
+import {projectsInterModuleContract} from '@shipfox/api-projects-dto/inter-module';
 import {runnersInterModuleContract} from '@shipfox/api-runners-dto/inter-module';
 import {
   type SecretsInterModuleClient,

--- a/libs/api/server/src/modules.ts
+++ b/libs/api/server/src/modules.ts
@@ -13,10 +13,10 @@ import {definitionsInterModuleContract} from '@shipfox/api-definitions-dto/inter
 import {dispatcherModule} from '@shipfox/api-dispatcher';
 import {emailChallengesModule} from '@shipfox/api-email-challenges';
 import {createIntegrationsContext, type WebhookDeliverySource} from '@shipfox/api-integration-core';
-import {integrationsInterModuleContract} from '@shipfox/api-integration-core-dto';
+import {integrationsInterModuleContract} from '@shipfox/api-integration-core-dto/inter-module';
 import {createLogsModule} from '@shipfox/api-logs';
 import {createProjectsModule} from '@shipfox/api-projects';
-import {projectsInterModuleContract} from '@shipfox/api-projects-dto';
+import {projectsInterModuleContract} from '@shipfox/api-projects-dto/inter-module';
 import {createRunnersModule} from '@shipfox/api-runners';
 import {runnersInterModuleContract} from '@shipfox/api-runners-dto/inter-module';
 import {createSecretsModule} from '@shipfox/api-secrets';

--- a/libs/api/triggers/package.json
+++ b/libs/api/triggers/package.json
@@ -44,7 +44,6 @@
     "@shipfox/api-auth-context": "workspace:*",
     "@shipfox/api-definitions-dto": "workspace:*",
     "@shipfox/api-integration-core-dto": "workspace:*",
-    "@shipfox/api-projects": "workspace:*",
     "@shipfox/api-triggers-dto": "workspace:*",
     "@shipfox/api-workflows-dto": "workspace:*",
     "@shipfox/config": "workspace:*",

--- a/libs/api/workflows/package.json
+++ b/libs/api/workflows/package.json
@@ -48,7 +48,6 @@
     "@shipfox/api-definitions-dto": "workspace:*",
     "@shipfox/api-projects-dto": "workspace:*",
     "@shipfox/api-integration-core-dto": "workspace:*",
-    "@shipfox/api-projects": "workspace:*",
     "@shipfox/api-runners": "workspace:*",
     "@shipfox/api-runners-dto": "workspace:*",
     "@shipfox/api-secrets-dto": "workspace:*",

--- a/libs/api/workflows/src/core/agent-tools.ts
+++ b/libs/api/workflows/src/core/agent-tools.ts
@@ -7,9 +7,9 @@ import type {
   AgentToolCatalogEntry,
   AgentToolCatalogMethod,
   IntegrationProviderKind,
-  IntegrationsModuleClient,
 } from '@shipfox/api-integration-core-dto';
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {AgentIntegrationMaterializationError} from './errors.js';
 
 type WorkflowModelJob = WorkflowModel['jobs'][number];

--- a/libs/api/workflows/src/core/checkout.test.ts
+++ b/libs/api/workflows/src/core/checkout.test.ts
@@ -1,5 +1,5 @@
-import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto';
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import * as workflowRuns from '#db/workflow-runs.js';
 import {jobFactory} from '#test/factories/job.js';
 import {projectFactory} from '#test/factories/project.js';

--- a/libs/api/workflows/src/core/checkout.ts
+++ b/libs/api/workflows/src/core/checkout.ts
@@ -1,5 +1,5 @@
-import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto';
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {getJobById, getWorkflowRunByAttemptId} from '#db/workflow-runs.js';
 import {
   CheckoutIntentUnresolvedError,

--- a/libs/api/workflows/src/core/run-workflow.ts
+++ b/libs/api/workflows/src/core/run-workflow.ts
@@ -1,8 +1,8 @@
 import type {AgentInterModuleClient} from '@shipfox/api-agent-dto/inter-module';
 import {workflowModelFromSnapshot} from '@shipfox/api-definitions-dto';
 import type {DefinitionsInterModuleClient} from '@shipfox/api-definitions-dto/inter-module';
-import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto';
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import type {SecretsInterModuleClient} from '@shipfox/api-secrets-dto/inter-module';
 import {createWorkflowRun} from '#db/workflow-runs.js';
 import {createAgentDefaultsResolver} from './agent-defaults.js';

--- a/libs/api/workflows/src/db/job-listeners.ts
+++ b/libs/api/workflows/src/db/job-listeners.ts
@@ -1,7 +1,7 @@
 import type {AgentInterModuleClient} from '@shipfox/api-agent-dto/inter-module';
 import {readPersistedWorkflowModel} from '@shipfox/api-definitions-dto';
-import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto';
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {
   WORKFLOWS_JOB_ACTIVATED,
   type WorkflowsJobActivatedEventDto,

--- a/libs/api/workflows/src/db/workflow-runs/run-create.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-create.ts
@@ -1,6 +1,6 @@
 import {createWorkflowModelSnapshot, type WorkflowModel} from '@shipfox/api-definitions-dto';
-import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto';
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import type {SecretsInterModuleClient} from '@shipfox/api-secrets-dto/inter-module';
 import {analyzeContextKeyAccess, type ResolvedFieldSegment} from '@shipfox/expression';
 import {logger} from '@shipfox/node-opentelemetry';

--- a/libs/api/workflows/src/index.ts
+++ b/libs/api/workflows/src/index.ts
@@ -4,8 +4,8 @@ import type {AnnotationsInterModuleClient} from '@shipfox/annotations-dto/inter-
 import type {AgentInterModuleClient} from '@shipfox/api-agent-dto/inter-module';
 import type {AuthInterModuleClient} from '@shipfox/api-auth-dto/inter-module';
 import type {DefinitionsInterModuleClient} from '@shipfox/api-definitions-dto/inter-module';
-import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto';
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {
   RUNNER_JOB_CLAIMED,
   RUNNER_JOB_LEASE_EXPIRED,

--- a/libs/api/workflows/src/presentation/inter-module.ts
+++ b/libs/api/workflows/src/presentation/inter-module.ts
@@ -1,8 +1,8 @@
 import {materializedAgentStepConfigSchema} from '@shipfox/api-agent-dto';
 import type {AgentInterModuleClient} from '@shipfox/api-agent-dto/inter-module';
 import type {DefinitionsInterModuleClient} from '@shipfox/api-definitions-dto/inter-module';
-import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto';
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-module';
 import type {SecretsInterModuleClient} from '@shipfox/api-secrets-dto/inter-module';
 import {workflowsInterModuleContract} from '@shipfox/api-workflows-dto/inter-module';

--- a/libs/api/workflows/src/presentation/routes/cancel-run.test.ts
+++ b/libs/api/workflows/src/presentation/routes/cancel-run.test.ts
@@ -1,5 +1,5 @@
 import {buildUserContext, setUserContext} from '@shipfox/api-auth-context';
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {ClientError} from '@shipfox/node-fastify';
 import type {FastifyInstance} from 'fastify';
 import Fastify from 'fastify';

--- a/libs/api/workflows/src/presentation/routes/cancel-run.ts
+++ b/libs/api/workflows/src/presentation/routes/cancel-run.ts
@@ -1,4 +1,4 @@
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {workflowRunDtoSchema} from '@shipfox/api-workflows-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';

--- a/libs/api/workflows/src/presentation/routes/checkout-token.test.ts
+++ b/libs/api/workflows/src/presentation/routes/checkout-token.test.ts
@@ -1,5 +1,5 @@
-import {integrationsInterModuleContract} from '@shipfox/api-integration-core-dto';
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import {integrationsInterModuleContract} from '@shipfox/api-integration-core-dto/inter-module';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {createInterModuleKnownError} from '@shipfox/inter-module';
 import {closeApp, createApp, type FastifyInstance} from '@shipfox/node-fastify';
 import {createCapturingLogger} from '@shipfox/node-log/test';

--- a/libs/api/workflows/src/presentation/routes/checkout-token.ts
+++ b/libs/api/workflows/src/presentation/routes/checkout-token.ts
@@ -2,8 +2,8 @@ import {requireLeasedJobContext} from '@shipfox/api-auth-context';
 import {
   type IntegrationsModuleClient,
   integrationsInterModuleContract,
-} from '@shipfox/api-integration-core-dto';
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+} from '@shipfox/api-integration-core-dto/inter-module';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-module';
 import {checkoutTokenResponseSchema} from '@shipfox/api-workflows-dto';
 import {isInterModuleKnownError} from '@shipfox/inter-module';

--- a/libs/api/workflows/src/presentation/routes/get-run-aggregates.test.ts
+++ b/libs/api/workflows/src/presentation/routes/get-run-aggregates.test.ts
@@ -1,5 +1,5 @@
 import {buildUserContext, setUserContext} from '@shipfox/api-auth-context';
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import type {FastifyInstance} from 'fastify';
 import Fastify from 'fastify';
 import {serializerCompiler, validatorCompiler} from 'fastify-type-provider-zod';

--- a/libs/api/workflows/src/presentation/routes/get-run-aggregates.ts
+++ b/libs/api/workflows/src/presentation/routes/get-run-aggregates.ts
@@ -1,4 +1,4 @@
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {
   workflowRunAggregatesQuerySchema,
   workflowRunAggregatesResponseSchema,

--- a/libs/api/workflows/src/presentation/routes/get-run.test.ts
+++ b/libs/api/workflows/src/presentation/routes/get-run.test.ts
@@ -1,5 +1,5 @@
 import {buildUserContext, setUserContext} from '@shipfox/api-auth-context';
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {ClientError} from '@shipfox/node-fastify';
 import {eq} from 'drizzle-orm';
 import type {FastifyInstance} from 'fastify';

--- a/libs/api/workflows/src/presentation/routes/get-run.ts
+++ b/libs/api/workflows/src/presentation/routes/get-run.ts
@@ -1,4 +1,4 @@
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {workflowRunDetailResponseSchema} from '@shipfox/api-workflows-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';

--- a/libs/api/workflows/src/presentation/routes/index.ts
+++ b/libs/api/workflows/src/presentation/routes/index.ts
@@ -2,8 +2,8 @@ import type {AnnotationsInterModuleClient} from '@shipfox/annotations-dto/inter-
 import type {AgentInterModuleClient} from '@shipfox/api-agent-dto/inter-module';
 import {AUTH_LEASED_JOB, AUTH_USER} from '@shipfox/api-auth-context';
 import type {AuthInterModuleClient} from '@shipfox/api-auth-dto/inter-module';
-import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto';
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-module';
 import type {SecretsInterModuleClient} from '@shipfox/api-secrets-dto/inter-module';
 import type {RouteGroup} from '@shipfox/node-fastify';

--- a/libs/api/workflows/src/presentation/routes/list-run-attempts.test.ts
+++ b/libs/api/workflows/src/presentation/routes/list-run-attempts.test.ts
@@ -1,5 +1,5 @@
 import {buildUserContext, setUserContext} from '@shipfox/api-auth-context';
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {ClientError} from '@shipfox/node-fastify';
 import type {FastifyInstance} from 'fastify';
 import Fastify from 'fastify';

--- a/libs/api/workflows/src/presentation/routes/list-run-attempts.ts
+++ b/libs/api/workflows/src/presentation/routes/list-run-attempts.ts
@@ -1,4 +1,4 @@
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {workflowRunAttemptsResponseSchema} from '@shipfox/api-workflows-dto';
 import {defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';

--- a/libs/api/workflows/src/presentation/routes/list-runs.test.ts
+++ b/libs/api/workflows/src/presentation/routes/list-runs.test.ts
@@ -1,5 +1,5 @@
 import {buildUserContext, setUserContext} from '@shipfox/api-auth-context';
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {encodeTimestampIdCursor} from '@shipfox/node-drizzle';
 import {eq} from 'drizzle-orm';
 import type {FastifyInstance} from 'fastify';

--- a/libs/api/workflows/src/presentation/routes/list-runs.ts
+++ b/libs/api/workflows/src/presentation/routes/list-runs.ts
@@ -1,4 +1,4 @@
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {
   workflowRunListQuerySchema,
   workflowRunListResponseSchema,

--- a/libs/api/workflows/src/presentation/routes/project-access.ts
+++ b/libs/api/workflows/src/presentation/routes/project-access.ts
@@ -1,5 +1,5 @@
 import {requireWorkspaceAccess} from '@shipfox/api-auth-context';
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {ClientError} from '@shipfox/node-fastify';
 import type {FastifyRequest} from 'fastify';
 

--- a/libs/api/workflows/src/presentation/routes/require-accessible-run.ts
+++ b/libs/api/workflows/src/presentation/routes/require-accessible-run.ts
@@ -1,4 +1,4 @@
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {ClientError} from '@shipfox/node-fastify';
 import type {FastifyRequest} from 'fastify';
 import type {WorkflowRun} from '#core/entities/workflow-run.js';

--- a/libs/api/workflows/src/presentation/routes/rerun-run.test.ts
+++ b/libs/api/workflows/src/presentation/routes/rerun-run.test.ts
@@ -1,5 +1,5 @@
 import {buildUserContext, setUserContext} from '@shipfox/api-auth-context';
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {ClientError} from '@shipfox/node-fastify';
 import type {FastifyInstance} from 'fastify';
 import Fastify from 'fastify';

--- a/libs/api/workflows/src/presentation/routes/rerun-run.ts
+++ b/libs/api/workflows/src/presentation/routes/rerun-run.ts
@@ -1,5 +1,5 @@
 import {requireUserContext} from '@shipfox/api-auth-context';
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {rerunWorkflowRunBodySchema, workflowRunResponseSchema} from '@shipfox/api-workflows-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';

--- a/libs/api/workflows/src/temporal/activities/index.ts
+++ b/libs/api/workflows/src/temporal/activities/index.ts
@@ -1,6 +1,6 @@
 import type {AgentInterModuleClient} from '@shipfox/api-agent-dto/inter-module';
-import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto';
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-module';
 import type {SecretsInterModuleClient} from '@shipfox/api-secrets-dto/inter-module';
 import {

--- a/libs/api/workflows/src/temporal/activities/orchestration-activities.ts
+++ b/libs/api/workflows/src/temporal/activities/orchestration-activities.ts
@@ -1,6 +1,6 @@
 import type {AgentInterModuleClient} from '@shipfox/api-agent-dto/inter-module';
-import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto';
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {
   type RunnersInterModuleClient,
   runnersInterModuleContract,

--- a/libs/api/workflows/test/fixtures/projects-inter-module.ts
+++ b/libs/api/workflows/test/fixtures/projects-inter-module.ts
@@ -1,4 +1,4 @@
-import type {ProjectsModuleClient} from '@shipfox/api-projects-dto';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 
 export const projectsTestClient = {
   getProjectById: async () => ({project: undefined}),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2750,9 +2750,6 @@ importers:
       '@shipfox/api-integration-github-dto':
         specifier: workspace:*
         version: link:../github-dto
-      '@shipfox/api-workspaces':
-        specifier: workspace:*
-        version: link:../../workspaces
       '@shipfox/config':
         specifier: workspace:*
         version: link:../../../shared/common/config
@@ -2857,9 +2854,6 @@ importers:
       '@shipfox/api-integration-jira-dto':
         specifier: workspace:*
         version: link:../jira-dto
-      '@shipfox/api-workspaces':
-        specifier: workspace:*
-        version: link:../../workspaces
       '@shipfox/config':
         specifier: workspace:*
         version: link:../../../shared/common/config
@@ -2955,9 +2949,6 @@ importers:
       '@shipfox/api-integration-linear-dto':
         specifier: workspace:*
         version: link:../linear-dto
-      '@shipfox/api-workspaces':
-        specifier: workspace:*
-        version: link:../../workspaces
       '@shipfox/config':
         specifier: workspace:*
         version: link:../../../shared/common/config
@@ -3968,9 +3959,6 @@ importers:
       '@shipfox/api-integration-core-dto':
         specifier: workspace:*
         version: link:../integration/core-dto
-      '@shipfox/api-projects':
-        specifier: workspace:*
-        version: link:../projects
       '@shipfox/api-triggers-dto':
         specifier: workspace:*
         version: link:../triggers-dto
@@ -4117,9 +4105,6 @@ importers:
       '@shipfox/api-integration-core-dto':
         specifier: workspace:*
         version: link:../integration/core-dto
-      '@shipfox/api-projects':
-        specifier: workspace:*
-        version: link:../projects
       '@shipfox/api-projects-dto':
         specifier: workspace:*
         version: link:../projects-dto

--- a/tools/api-architecture-policy/src/api-context-inventory.ts
+++ b/tools/api-architecture-policy/src/api-context-inventory.ts
@@ -70,16 +70,15 @@ const baseline: BaselineEntry[] = [
     violation: `import:${path}`,
   })),
   ...[
-    'libs/api/integration/github:package.json:dependencies:@shipfox/api-workspaces',
-    'libs/api/integration/jira:package.json:dependencies:@shipfox/api-workspaces',
-    'libs/api/integration/linear:package.json:dependencies:@shipfox/api-workspaces',
-    'libs/api/triggers:package.json:dependencies:@shipfox/api-projects',
-    'libs/api/workflows:package.json:dependencies:@shipfox/api-projects',
+    'libs/api/annotations:package.json:devDependencies:@shipfox/api-auth',
+    'libs/api/logs:package.json:devDependencies:@shipfox/api-auth',
+    'libs/api/runners:package.json:devDependencies:@shipfox/api-auth',
+    'libs/api/workflows:package.json:devDependencies:@shipfox/api-auth',
   ].map((path) => ({
-    issue: 'ENG-1143',
-    owner: 'Contract location and stale-edge migration',
+    issue: 'ENG-1145',
+    owner: 'Auth consumer-test migration',
     reason:
-      'The implementation edge is stale while the consumer migration moves to the explicit DTO subpath.',
+      'The manifest remains until the corresponding Auth implementation test import is replaced.',
     violation: `manifest:${path}`,
   })),
   ...[
@@ -96,30 +95,6 @@ const baseline: BaselineEntry[] = [
       'The manifest remains until consumer tests and setup stop depending on peer implementations.',
     violation: `manifest:${path}`,
   })),
-  {
-    issue: 'ENG-1143',
-    owner: 'Contract location and stale-edge migration',
-    reason: 'Projects still re-exports its synchronous contract from the DTO root.',
-    violation: 'dto-export:libs/api/projects-dto:src/index.ts:root-inter-module',
-  },
-  {
-    issue: 'ENG-1143',
-    owner: 'Contract location and stale-edge migration',
-    reason: 'Integrations still re-exports its synchronous contract from the DTO root.',
-    violation: 'dto-export:libs/api/integration/core-dto:src/index.ts:root-inter-module',
-  },
-  {
-    issue: 'ENG-1143',
-    owner: 'Contract location and stale-edge migration',
-    reason: 'Projects has not yet published the required inter-module subpath.',
-    violation: 'dto-export:libs/api/projects-dto:package.json:missing-inter-module-entry',
-  },
-  {
-    issue: 'ENG-1143',
-    owner: 'Contract location and stale-edge migration',
-    reason: 'Integrations has not yet published the required inter-module subpath.',
-    violation: 'dto-export:libs/api/integration/core-dto:package.json:missing-inter-module-entry',
-  },
 ];
 
 function compareText(left: string, right: string): number {

--- a/tools/package-release/src/productionized-manifest-packer.ts
+++ b/tools/package-release/src/productionized-manifest-packer.ts
@@ -130,7 +130,7 @@ function productionizeDependencyReferences(
   return productionManifest;
 }
 
-function resolveDependencyReference(
+export function resolveDependencyReference(
   name: string,
   reference: unknown,
   {workspaceConfig, workspaceVersions}: PackageDependencyContext,

--- a/tools/package-release/src/published-package-artifacts.ts
+++ b/tools/package-release/src/published-package-artifacts.ts
@@ -10,6 +10,7 @@ import {
   mapWithConcurrency,
   type PackageDependencyContext,
   packProductionizedPackage,
+  resolveDependencyReference,
   run,
 } from './productionized-manifest-packer.js';
 
@@ -44,7 +45,11 @@ type SourcePackages = Map<string, SourcePackage>;
 
 const repositoryRoot = resolve(fileURLToPath(new URL('../../..', import.meta.url)));
 const packageSources = {
+  '@shipfox/api-common-dto': 'libs/api/common-dto',
+  '@shipfox/api-integration-core-dto': 'libs/api/integration/core-dto',
+  '@shipfox/api-projects-dto': 'libs/api/projects-dto',
   '@shipfox/application-release': 'tools/application-release',
+  '@shipfox/inter-module': 'libs/shared/common/inter-module',
   '@shipfox/react-ui': 'libs/shared/react/ui',
   '@shipfox/redact': 'libs/shared/common/redact',
   '@shipfox/regex': 'libs/shared/common/regex',
@@ -73,7 +78,7 @@ export async function main() {
   const expectedDependencies = new Map(
     [...sourcePackages].map(([name, sourcePackage]) => [
       name,
-      catalogDependencies(sourcePackage.manifest, workspace),
+      catalogDependencies(sourcePackage.manifest, workspace, workspaceVersions),
     ]),
   );
   const fixtureRoot = await mkdtemp(join(tmpdir(), 'shipfox-published-artifacts-'));
@@ -122,13 +127,28 @@ function readSourcePackages(): Promise<SourcePackageEntry[]> {
 export function catalogDependencies(
   manifest: PackageManifest,
   workspaceConfig: WorkspaceConfig,
+  workspaceVersions: ReadonlyMap<string, string> = new Map(),
 ): DependencyMap {
   const dependencies: DependencyMap = {};
   for (const [name, reference] of Object.entries(manifest.dependencies ?? {})) {
-    if (typeof reference !== 'string' || !reference.startsWith('catalog:')) {
-      throw new Error(`Representative package ${manifest.name} must use a catalog for ${name}`);
+    if (
+      typeof reference !== 'string' ||
+      (!reference.startsWith('catalog:') && !reference.startsWith('workspace:'))
+    ) {
+      throw new Error(
+        `Representative package ${manifest.name} must use a catalog or workspace reference for ${name}`,
+      );
     }
-    dependencies[name] = catalogRange(reference, name, workspaceConfig);
+    const resolved = resolveDependencyReference(name, reference, {
+      workspaceConfig,
+      workspaceVersions,
+    });
+    if (typeof resolved !== 'string') {
+      throw new Error(
+        `Representative package ${manifest.name} has an invalid dependency for ${name}`,
+      );
+    }
+    dependencies[name] = resolved;
   }
   return dependencies;
 }
@@ -199,7 +219,13 @@ async function writeConsumerManifest(
     type: 'module',
     dependencies: consumerDependencies(tarballs, reactUiPeers),
   };
-  await writeFile(join(root, 'package.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+  await Promise.all([
+    writeFile(join(root, 'package.json'), `${JSON.stringify(manifest, null, 2)}\n`),
+    writeFile(
+      join(root, 'pnpm-workspace.yaml'),
+      `overrides: ${JSON.stringify(consumerOverrides(tarballs))}\n`,
+    ),
+  ]);
 }
 
 export function consumerDependencies(
@@ -213,6 +239,12 @@ export function consumerDependencies(
     react: reactUiPeers.react,
     'react-dom': reactUiPeers['react-dom'],
   };
+}
+
+export function consumerOverrides(tarballs: DependencyMap): DependencyMap {
+  return Object.fromEntries(
+    Object.entries(tarballs).map(([name, tarball]) => [name, `file:${tarball}`]),
+  );
 }
 
 function reactUiPeerDependencies(sourcePackages: SourcePackages): ReactPeerDependencies {
@@ -309,7 +341,12 @@ async function validateNoRegistryShipfoxPackages(root: string): Promise<void> {
 }
 
 async function exerciseConsumer(root: string): Promise<void> {
-  const imports = ['@shipfox/redact', '@shipfox/react-ui/button'];
+  const imports = [
+    '@shipfox/api-integration-core-dto/inter-module',
+    '@shipfox/api-projects-dto/inter-module',
+    '@shipfox/redact',
+    '@shipfox/react-ui/button',
+  ];
   await run(
     process.execPath,
     [
@@ -318,6 +355,33 @@ async function exerciseConsumer(root: string): Promise<void> {
       `const imports = ${JSON.stringify(imports)};
 const modules = await Promise.all(imports.map((specifier) => import(specifier)));
 if (modules.some((module) => Object.keys(module).length === 0)) throw new Error('An imported packed package has no exports.');`,
+    ],
+    root,
+  );
+  await run(
+    process.execPath,
+    [
+      '--input-type=module',
+      '--eval',
+      `const {createInterModuleClient} = await import('@shipfox/inter-module');
+const {projectsInterModuleContract} = await import('@shipfox/api-projects-dto/inter-module');
+const {integrationsInterModuleContract} = await import('@shipfox/api-integration-core-dto/inter-module');
+const projectId = '00000000-0000-4000-8000-000000000001';
+const projects = createInterModuleClient(projectsInterModuleContract, async () => ({project: null}));
+const integrations = createInterModuleClient(integrationsInterModuleContract, async () => ({
+  path: 'workflow.yml',
+  ref: 'main',
+  content: 'name: workflow',
+}));
+const project = await projects.getProjectById({projectId});
+const file = await integrations.fetchSourceFile({
+  workspaceId: '00000000-0000-4000-8000-000000000002',
+  connectionId: '00000000-0000-4000-8000-000000000003',
+  externalRepositoryId: 'shipfox/project',
+  ref: 'main',
+  path: 'workflow.yml',
+});
+if (project.project !== null || file.content !== 'name: workflow') throw new Error('Packed inter-module client did not execute its contract.');`,
     ],
     root,
   );

--- a/tools/package-release/test/published-package-artifacts.test.ts
+++ b/tools/package-release/test/published-package-artifacts.test.ts
@@ -4,6 +4,7 @@ import {
   catalogDependencies,
   catalogRange,
   consumerDependencies,
+  consumerOverrides,
   findUnsupportedProtocol,
   safePackageName,
 } from '../src/published-package-artifacts.js';
@@ -12,7 +13,7 @@ const workspace = {
   catalog: {react: '^19.1.1'},
   catalogs: {testing: {'@testing-library/react': '^16.3.0'}},
 };
-const directDependencyErrorPattern = /must use a catalog for react/u;
+const directDependencyErrorPattern = /must use a catalog or workspace reference for react/u;
 const missingCatalogEntryErrorPattern = /Catalog default does not define missing-package/u;
 
 describe('catalogDependencies', () => {
@@ -28,6 +29,21 @@ describe('catalogDependencies', () => {
       react: '^19.1.1',
       '@testing-library/react': '^16.3.0',
     });
+  });
+
+  test('resolves workspace dependency references', () => {
+    const manifest = {
+      name: '@fixture/package',
+      dependencies: {'@shipfox/inter-module': 'workspace:*'},
+    };
+
+    const dependencies = catalogDependencies(
+      manifest,
+      workspace,
+      new Map([['@shipfox/inter-module', '0.2.0']]),
+    );
+
+    assert.deepEqual(dependencies, {'@shipfox/inter-module': '0.2.0'});
   });
 
   test('rejects dependency versions outside a catalog', () => {
@@ -65,6 +81,16 @@ describe('consumerDependencies', () => {
       react: '^19.0.0',
       'react-dom': '^19.0.0',
     });
+  });
+});
+
+describe('consumerOverrides', () => {
+  test('pins transitive Shipfox dependencies to packed tarballs', () => {
+    const tarballs = {'@shipfox/inter-module': '/tmp/inter-module.tgz'};
+
+    const overrides = consumerOverrides(tarballs);
+
+    assert.deepEqual(overrides, {'@shipfox/inter-module': 'file:/tmp/inter-module.tgz'});
   });
 });
 


### PR DESCRIPTION
Moves the Projects and Integrations synchronous contracts to their producer-owned DTO `/inter-module` entry points, then removes the root re-exports and stale implementation manifest edges.

ADR 0004 requires one public contract location per producer. Keeping the contracts at the DTO root allowed consumers to bypass that boundary and left five implementation dependencies that no source import actually needed.

The packed-artifact verifier now installs the complete local Shipfox closure from tarballs and exercises both contract clients. This proves external consumers resolve the new subpaths without falling back to registry packages.

Closes ENG-1143

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves Projects and Integrations sync contracts to producer-owned DTO `/inter-module` subpaths and updates all consumers. Aligns with ENG-1143 and ADR-0004 to enforce one public contract per producer; removes stale implementation edges and hardens packed-artifact verification.

- **Refactors**
  - Added `./inter-module` export maps in `@shipfox/api-projects-dto` and `@shipfox/api-integration-core-dto`; removed root re-exports.
  - Updated imports across Definitions, Projects, Workflows, Secrets, and server to the new subpaths.
  - Dropped unused implementation deps in Integrations (GitHub, Jira, Linear), Triggers, and Workflows.
  - Extended packed-artifact verifier to resolve workspace refs, write consumer overrides, and exercise both inter-module clients via `@shipfox/inter-module`.

- **Migration**
  - Import `projectsInterModuleContract` and `ProjectsModuleClient` from `@shipfox/api-projects-dto/inter-module`.
  - Import `integrationsInterModuleContract` and `IntegrationsModuleClient` from `@shipfox/api-integration-core-dto/inter-module`.
  - Remove direct implementation package dependencies that are no longer needed.
  - Major version bump for `@shipfox/api-integration-core-dto` and `@shipfox/api-projects-dto`.

<sup>Written for commit 8a0f1709e74c4fab1a1cb5d252bc15b1644c5fd5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

