### PR TITLE
[client-workflows] Converge workflow caches on domain models

### DIFF
--- a/.changeset/calm-ravens-converge.md
+++ b/.changeset/calm-ravens-converge.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-workflows": patch
+---
+
+Converges workflow query caches on transport-independent domain models.

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-attempt-switcher.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-attempt-switcher.test.tsx
@@ -1,6 +1,7 @@
 import {configureApiClient} from '@shipfox/client-api';
 import {screen, waitFor, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import {toWorkflowRunAttempt} from '#hooks/api/workflow-run-mapper.js';
 import {workflowRunsQueryKeys} from '#hooks/api/workflow-runs.js';
 import {
   runAttemptsResponseDto,
@@ -145,12 +146,10 @@ describe('WorkflowRunAttemptSwitcher', () => {
     const {queryClient} = renderSwitcher({latestAttempt: 3});
     queryClient.setQueryData(
       workflowRunsQueryKeys.attempts(CURRENT_RUN_ID),
-      runAttemptsResponseDto({
-        attempts: [
-          workflowRunAttemptDto({id: ROOT_RUN_ID, attempt: 1}),
-          workflowRunAttemptDto({id: CURRENT_RUN_ID, attempt: 2}),
-        ],
-      }),
+      [
+        workflowRunAttemptDto({id: ROOT_RUN_ID, attempt: 1}),
+        workflowRunAttemptDto({id: CURRENT_RUN_ID, attempt: 2}),
+      ].map(toWorkflowRunAttempt),
     );
 
     await user.click(await screen.findByRole('button', {name: 'Switch attempt, currently 2 of 3'}));

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
@@ -1,4 +1,3 @@
-import type {WorkflowRunRerunModeDto} from '@shipfox/api-workflows-dto';
 import {TriggerSourceIcon} from '@shipfox/client-triggers';
 import {Badge} from '@shipfox/react-ui/badge';
 import {Button} from '@shipfox/react-ui/button';
@@ -20,6 +19,7 @@ import {
   type Job,
   WORKFLOW_RUN_STATUSES,
   type WorkflowRunDetail,
+  type WorkflowRunRerunMode,
 } from '#core/workflow-run.js';
 import {WorkflowRunDurationLabel} from '../workflow-run-duration-label.js';
 import {getWorkflowStatusVisual} from '../workflow-status/status-visuals.js';
@@ -43,7 +43,7 @@ export interface WorkflowRunSummaryProps {
   cancelling?: boolean | undefined;
   onCancel?: (() => void) | undefined;
   rerunPending?: boolean | undefined;
-  onRerun?: ((mode: WorkflowRunRerunModeDto) => void) | undefined;
+  onRerun?: ((mode: WorkflowRunRerunMode) => void) | undefined;
   latestAttempt?: number | undefined;
 }
 
@@ -207,7 +207,7 @@ function WorkflowRunActionSlot({
   cancelling: boolean;
   onCancel?: (() => void) | undefined;
   rerunPending: boolean;
-  onRerun?: ((mode: WorkflowRunRerunModeDto) => void) | undefined;
+  onRerun?: ((mode: WorkflowRunRerunMode) => void) | undefined;
 }) {
   if (action === 'none') return null;
 

--- a/libs/client/workflows/src/components/workflow-run-view/job-card.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/job-card.tsx
@@ -1,4 +1,3 @@
-import {agentConfigIssueSchema, stepErrorReasonSchema} from '@shipfox/api-workflows-dto';
 import {TriggerSourceIcon} from '@shipfox/client-triggers';
 import {Badge} from '@shipfox/react-ui/badge';
 import {Button} from '@shipfox/react-ui/button';
@@ -12,9 +11,11 @@ import type {ReactNode} from 'react';
 import {Fragment, useId, useRef, useState} from 'react';
 import {getWorkflowStatusVisual} from '#components/workflow-status/status-visuals.js';
 import {
+  AGENT_CONFIG_ISSUES,
   type Job,
   type JobExecution,
   type JobExecutionTime,
+  STEP_ERROR_REASONS,
   type Step,
   type StepError,
   type StepSourceLocation,
@@ -404,25 +405,33 @@ function toSelectedAttemptError(
 ): StepError | null {
   if (error === null) return null;
 
-  const reason = stepErrorReasonSchema.safeParse(error.reason);
-  const agentConfigIssue = agentConfigIssueSchema.safeParse(
-    error.agentConfigIssue ?? error.agent_config_issue,
-  );
+  const rawReason = error.reason;
+  const parsedReason =
+    typeof rawReason === 'string' &&
+    STEP_ERROR_REASONS.has(rawReason as StepError['reason'] & string)
+      ? (rawReason as NonNullable<StepError['reason']>)
+      : undefined;
+  const rawAgentConfigIssue = error.agentConfigIssue ?? error.agent_config_issue;
+  const agentConfigIssue =
+    typeof rawAgentConfigIssue === 'string' &&
+    AGENT_CONFIG_ISSUES.has(rawAgentConfigIssue as NonNullable<StepError['agentConfigIssue']>)
+      ? (rawAgentConfigIssue as NonNullable<StepError['agentConfigIssue']>)
+      : undefined;
   const exitCode = error.exitCode ?? error.exit_code;
-  const parsedReason = reason.success
-    ? reason.data
-    : agentConfigIssue.success
+  const resolvedReason = parsedReason
+    ? parsedReason
+    : agentConfigIssue
       ? 'agent_config_invalid'
       : undefined;
 
-  if (parsedReason === undefined) return null;
+  if (resolvedReason === undefined) return null;
 
   return {
     message: typeof error.message === 'string' ? error.message : '',
     exitCode: exitCode === null || typeof exitCode === 'number' ? exitCode : null,
     signal: typeof error.signal === 'string' ? error.signal : undefined,
-    reason: parsedReason,
-    agentConfigIssue: agentConfigIssue.success ? agentConfigIssue.data : undefined,
+    reason: resolvedReason,
+    agentConfigIssue,
     category: step.type === 'setup' ? 'setup' : 'user',
   };
 }

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -1,4 +1,3 @@
-import type {WorkflowRunRerunModeDto} from '@shipfox/api-workflows-dto';
 import {ApiError} from '@shipfox/client-api';
 import {QueryLoadError} from '@shipfox/client-ui';
 import {RelativeTimeProvider} from '@shipfox/react-ui/relative-time';
@@ -9,6 +8,7 @@ import {
   type JobExecution,
   resolveJobExecution,
   type StepSourceLocation,
+  type WorkflowRunRerunMode,
 } from '#core/workflow-run.js';
 import {
   type WorkflowRunSelectionInput,
@@ -160,7 +160,7 @@ function RunViewContent({
   const highlightedLineRange =
     sourceFocus?.location ?? resolvedSelection?.step?.sourceLocation ?? null;
   const sourceSnapshot = runData.sourceSnapshot;
-  async function rerun(mode: WorkflowRunRerunModeDto) {
+  async function rerun(mode: WorkflowRunRerunMode) {
     try {
       const run = await rerunMutation.mutateAsync({workflowRunId: runData.id, mode});
       toast.success('Re-run started');

--- a/libs/client/workflows/src/core/entities/job-execution.ts
+++ b/libs/client/workflows/src/core/entities/job-execution.ts
@@ -1,11 +1,14 @@
-import type {
-  WorkflowExecutionEventDto,
-  WorkflowRunJobExecutionDetailDto,
-} from '@shipfox/api-workflows-dto';
 import {type Duration, intervalToDuration} from 'date-fns';
-import {type Step, toStep} from './step.js';
+import type {Step} from './step.js';
 
-export type JobExecutionStatus = WorkflowRunJobExecutionDetailDto['status'];
+export type JobExecutionStatus = 'pending' | 'running' | 'succeeded' | 'failed' | 'cancelled';
+export interface WorkflowExecutionEvent {
+  source: string;
+  event: string;
+  deliveryId: string;
+  receivedAt: string;
+  data: unknown;
+}
 export type JobExecutionTime =
   | {state: 'fixed'; elapsed: Duration}
   | {state: 'live'; fromIso: string};
@@ -20,7 +23,7 @@ interface JobExecutionFields {
   name: string;
   status: JobExecutionStatus;
   statusReason: string | null;
-  triggerEvents: WorkflowExecutionEventDto[];
+  triggerEvents: WorkflowExecutionEvent[];
   queuedAt: string | null;
   startedAt: string | null;
   finishedAt: string | null;
@@ -37,7 +40,7 @@ export class JobExecution {
   name!: string;
   status!: JobExecutionStatus;
   statusReason!: string | null;
-  triggerEvents!: WorkflowExecutionEventDto[];
+  triggerEvents!: WorkflowExecutionEvent[];
   queuedAt!: string | null;
   startedAt!: string | null;
   finishedAt!: string | null;
@@ -61,25 +64,6 @@ export class JobExecution {
   get displayDuration(): JobExecutionDisplayDuration | null {
     return jobExecutionDisplayDurationFromTimestamps(this);
   }
-}
-
-export function toJobExecution(dto: WorkflowRunJobExecutionDetailDto): JobExecution {
-  return new JobExecution({
-    id: dto.id,
-    jobId: dto.job_id,
-    sequence: dto.sequence,
-    name: dto.name,
-    status: dto.status,
-    statusReason: dto.status_reason,
-    triggerEvents: dto.trigger_events ?? [],
-    queuedAt: dto.queued_at ?? null,
-    startedAt: dto.started_at ?? null,
-    finishedAt: dto.finished_at ?? null,
-    timedOutAt: dto.timed_out_at ?? null,
-    createdAt: dto.created_at,
-    updatedAt: dto.updated_at,
-    steps: dto.steps.map(toStep),
-  });
 }
 
 export function jobExecutionQueueTimeFromTimestamps({

--- a/libs/client/workflows/src/core/entities/job.ts
+++ b/libs/client/workflows/src/core/entities/job.ts
@@ -1,23 +1,45 @@
-import type {
-  JobListeningDto,
-  JobModeDto,
-  JobStatusDto,
-  JobStatusReasonDto,
-  ListenerStatusDto,
-  ResolutionReasonDto,
-  WorkflowRunJobDetailDto,
-} from '@shipfox/api-workflows-dto';
-import {
-  type JobExecution,
-  type JobExecutionDisplayDuration,
-  toJobExecution,
-} from './job-execution.js';
+import type {JobExecution, JobExecutionDisplayDuration} from './job-execution.js';
 
-export type JobStatus = JobStatusDto;
-export type JobMode = JobModeDto;
-export type ListenerStatus = ListenerStatusDto;
-export type ResolutionReason = ResolutionReasonDto;
-export type JobStatusReason = JobStatusReasonDto;
+export type JobStatus = 'pending' | 'running' | 'succeeded' | 'failed' | 'cancelled' | 'skipped';
+export type JobMode = 'one_shot' | 'listening';
+export type ListenerStatus = 'inactive' | 'listening' | 'resolved';
+export type ResolutionReason = 'until' | 'timeout' | 'max_executions' | 'cancelled';
+export type JobStatusReason =
+  | 'dependency_not_completed'
+  | 'condition_false'
+  | 'default_gate_rejected'
+  | 'condition_rejected'
+  | 'condition_errored'
+  | 'user_cancelled'
+  | 'run_cancelled'
+  | 'timed_out'
+  | 'runner_lost'
+  | 'step_failed'
+  | 'unknown';
+export interface JobListening {
+  on: Array<{
+    source: string;
+    event: string;
+    inputs?: Record<string, unknown> | undefined;
+    filter?: string | undefined;
+  }>;
+  until: Array<{
+    source: string;
+    event: string;
+    inputs?: Record<string, unknown> | undefined;
+    filter?: string | undefined;
+  }> | null;
+  timeoutMs: number | null;
+  maxExecutions: number | null;
+  batch: {
+    debounceMs?: number | undefined;
+    maxSize?: number | undefined;
+    maxWaitMs?: number | undefined;
+  } | null;
+  onResolve: 'finish' | 'cancel';
+  executionTimeoutMs: number | null;
+  name: string | null;
+}
 
 export type JobDisplayDuration = JobExecutionDisplayDuration;
 
@@ -48,7 +70,7 @@ interface JobFields {
   status: JobStatus;
   statusReason: JobStatusReason | null;
   carriedOver: boolean;
-  listening: JobListeningDto | null;
+  listening: JobListening | null;
   listenerStatus: ListenerStatus;
   resolutionReason: ResolutionReason | null;
   dependencies: string[];
@@ -67,7 +89,7 @@ export class Job {
   status!: JobStatus;
   statusReason!: JobStatusReason | null;
   carriedOver!: boolean;
-  listening!: JobListeningDto | null;
+  listening!: JobListening | null;
   listenerStatus!: ListenerStatus;
   resolutionReason!: ResolutionReason | null;
   dependencies!: string[];
@@ -123,27 +145,4 @@ export function defaultJobExecution(job: Job): JobExecution | undefined {
     if (!latest) return jobExecution;
     return jobExecution.sequence > latest.sequence ? jobExecution : latest;
   }, undefined);
-}
-
-export function toJob(dto: WorkflowRunJobDetailDto): Job {
-  const jobExecutions = dto.job_executions.map(toJobExecution);
-
-  return new Job({
-    id: dto.id,
-    runAttemptId: dto.run_attempt_id,
-    key: dto.key,
-    name: dto.name,
-    mode: dto.mode,
-    status: dto.status,
-    statusReason: dto.status_reason,
-    carriedOver: dto.carried_over,
-    listening: dto.listening,
-    listenerStatus: dto.listener_status,
-    resolutionReason: dto.resolution_reason,
-    dependencies: dto.dependencies,
-    position: dto.position,
-    createdAt: dto.created_at,
-    updatedAt: dto.updated_at,
-    jobExecutions,
-  });
 }

--- a/libs/client/workflows/src/core/entities/step-attempt.ts
+++ b/libs/client/workflows/src/core/entities/step-attempt.ts
@@ -1,7 +1,14 @@
-import type {StepAttemptDto, StepGateResultDto} from '@shipfox/api-workflows-dto';
 import {type Duration, intervalToDuration} from 'date-fns';
 
-export type StepGateResult = StepGateResultDto;
+export type StepGateResult =
+  | {kind: 'none'}
+  | {kind: 'not_evaluated'}
+  | {kind: 'passed'; passed: true; source: string; exitCode: number | null}
+  | {kind: 'failed'; passed: false; source: string; exitCode: number | null}
+  | {kind: 'uncheckable'; passed: false; uncheckable: true; reason: string; exitCode: number | null}
+  | {kind: 'evaluation_error'; reason: string; exitCode: number | null}
+  | {kind: 'unknown'; data: Record<string, unknown>}
+  | null;
 export type StepAttemptDisplayDuration =
   | {state: 'fixed'; elapsed: Duration}
   | {state: 'live'; fromIso: string};
@@ -44,24 +51,6 @@ export class StepAttempt {
   get displayDuration(): StepAttemptDisplayDuration | null {
     return stepAttemptDisplayDurationFromTimestamps(this);
   }
-}
-
-export function toStepAttempt(dto: StepAttemptDto, jobExecutionId: string): StepAttempt {
-  return new StepAttempt({
-    id: dto.id,
-    stepId: dto.step_id,
-    jobExecutionId,
-    attempt: dto.attempt,
-    executionOrder: dto.execution_order,
-    status: dto.status,
-    exitCode: dto.exit_code ?? null,
-    output: dto.output ?? null,
-    error: dto.error ?? null,
-    gateResult: dto.gate_result ?? null,
-    restartFeedback: dto.restart_feedback ?? null,
-    startedAt: dto.started_at,
-    finishedAt: dto.finished_at ?? null,
-  });
 }
 
 export function stepAttemptDisplayDurationFromTimestamps({

--- a/libs/client/workflows/src/core/entities/step.ts
+++ b/libs/client/workflows/src/core/entities/step.ts
@@ -1,15 +1,42 @@
-import type {
-  AgentConfigIssueDto,
-  StepErrorCategoryDto,
-  StepErrorReasonDto,
-  StepSourceLocationDto,
-  WorkflowRunStepDetailDto,
-} from '@shipfox/api-workflows-dto';
-import {type StepAttempt, toStepAttempt} from './step-attempt.js';
+import type {StepAttempt} from './step-attempt.js';
 
-export type StepErrorReason = StepErrorReasonDto;
-export type AgentConfigIssue = AgentConfigIssueDto;
-export type StepErrorCategory = StepErrorCategoryDto;
+export type StepErrorReason =
+  | 'checkout_failed'
+  | 'checkout_auth_failed'
+  | 'checkout_unavailable'
+  | 'git_unavailable'
+  | 'workspace_prep_failed'
+  | 'setup_aborted'
+  | 'config_unresolvable'
+  | 'output_invalid'
+  | 'agent_config_invalid'
+  | 'agent_invocation_failed';
+export type AgentConfigIssue =
+  | 'step_config_invalid'
+  | 'provider_not_configured'
+  | 'provider_unsupported'
+  | 'model_unavailable'
+  | 'credentials_invalid';
+export type StepErrorCategory = 'setup' | 'user';
+export const STEP_ERROR_REASONS = new Set<StepErrorReason>([
+  'checkout_failed',
+  'checkout_auth_failed',
+  'checkout_unavailable',
+  'git_unavailable',
+  'workspace_prep_failed',
+  'setup_aborted',
+  'config_unresolvable',
+  'output_invalid',
+  'agent_config_invalid',
+  'agent_invocation_failed',
+]);
+export const AGENT_CONFIG_ISSUES = new Set<AgentConfigIssue>([
+  'step_config_invalid',
+  'provider_not_configured',
+  'provider_unsupported',
+  'model_unavailable',
+  'credentials_invalid',
+]);
 
 export interface StepSourceLocation {
   startLine: number;
@@ -47,59 +74,4 @@ export interface Step {
   createdAt: string;
   updatedAt: string;
   attempts: StepAttempt[];
-}
-
-export function toStep(dto: WorkflowRunStepDetailDto): Step {
-  return {
-    id: dto.id,
-    jobExecutionId: dto.job_execution_id,
-    key: dto.key,
-    name: dto.name,
-    sourceLocation: dto.source_location ? toStepSourceLocation(dto.source_location) : null,
-    status: dto.status,
-    type: dto.type,
-    config: dto.config,
-    agentConfig: toAgentStepConfig(dto),
-    error: dto.error ? toStepError(dto.error) : null,
-    position: dto.position,
-    currentAttempt: dto.current_attempt,
-    createdAt: dto.created_at,
-    updatedAt: dto.updated_at,
-    attempts: dto.attempts.map((attempt) => toStepAttempt(attempt, dto.job_execution_id)),
-  };
-}
-
-function toStepSourceLocation(dto: StepSourceLocationDto): StepSourceLocation {
-  return {
-    startLine: dto.start_line,
-    endLine: dto.end_line,
-  };
-}
-
-function toStepError(dto: NonNullable<WorkflowRunStepDetailDto['error']>): StepError {
-  return {
-    message: dto.message,
-    exitCode: dto.exit_code ?? null,
-    signal: dto.signal,
-    reason: dto.reason,
-    agentConfigIssue: dto.agent_config_issue,
-    category: dto.category,
-  };
-}
-
-function toAgentStepConfig(dto: WorkflowRunStepDetailDto): AgentStepConfig | null {
-  if (dto.type !== 'agent') return null;
-
-  return {
-    provider: stringConfigValue(dto.config.provider),
-    model: stringConfigValue(dto.config.model),
-    thinking: stringConfigValue(dto.config.thinking),
-  };
-}
-
-function stringConfigValue(value: unknown): string | null {
-  if (typeof value !== 'string') return null;
-
-  const trimmedValue = value.trim();
-  return trimmedValue ? trimmedValue : null;
 }

--- a/libs/client/workflows/src/core/entities/workflow-run-attempt.ts
+++ b/libs/client/workflows/src/core/entities/workflow-run-attempt.ts
@@ -1,4 +1,3 @@
-import type {WorkflowRunAttemptDto} from '@shipfox/api-workflows-dto';
 import {type Duration, intervalToDuration} from 'date-fns';
 import type {WorkflowRunStatus} from './workflow-run.js';
 
@@ -46,19 +45,6 @@ export class WorkflowRunAttempt extends WorkflowRunAttemptSummary {
     this.id = fields.id;
     this.rerunMode = fields.rerunMode;
   }
-}
-
-export function toWorkflowRunAttempt(dto: WorkflowRunAttemptDto): WorkflowRunAttempt {
-  return new WorkflowRunAttempt({
-    id: dto.id,
-    workflowRunId: dto.workflow_run_id,
-    attempt: dto.attempt,
-    status: dto.status,
-    createdAt: dto.created_at,
-    startedAt: dto.started_at ?? null,
-    finishedAt: dto.finished_at ?? null,
-    rerunMode: dto.rerun_mode,
-  });
 }
 
 export function workflowRunAttemptDisplayDurationFromTimestamps({

--- a/libs/client/workflows/src/core/entities/workflow-run.ts
+++ b/libs/client/workflows/src/core/entities/workflow-run.ts
@@ -1,17 +1,8 @@
-import type {
-  WorkflowRunDetailResponseDto,
-  WorkflowRunListResponseDto,
-  WorkflowRunResponseDto,
-  WorkflowRunStatusDto,
-} from '@shipfox/api-workflows-dto';
-import {type Job, toJob, WORKFLOW_JOB_STATUSES} from './job.js';
-import {
-  toWorkflowRunAttempt,
-  type WorkflowRunAttempt,
-  WorkflowRunAttemptSummary,
-} from './workflow-run-attempt.js';
+import {type Job, WORKFLOW_JOB_STATUSES} from './job.js';
+import type {WorkflowRunAttempt, WorkflowRunAttemptSummary} from './workflow-run-attempt.js';
 
-export type WorkflowRunStatus = WorkflowRunStatusDto;
+export type WorkflowRunStatus = 'pending' | 'running' | 'succeeded' | 'failed' | 'cancelled';
+export type WorkflowRunRerunMode = 'all' | 'failed';
 export type WorkflowStatus = WorkflowRunStatus | (typeof WORKFLOW_JOB_STATUSES)[number];
 
 export const WORKFLOW_RUN_STATUSES = [
@@ -107,77 +98,4 @@ export function isWorkflowRunTerminal(status: WorkflowRunStatus): boolean {
 
 export function isWorkflowStatus(status: string): status is WorkflowStatus {
   return WORKFLOW_STATUSES.has(status as WorkflowStatus);
-}
-
-export function toWorkflowRun(dto: WorkflowRunResponseDto): WorkflowRun {
-  const triggerLabel = workflowRunTriggerLabel({
-    triggerSource: dto.trigger_source,
-    triggerEvent: dto.trigger_event,
-  });
-  const triggerDisplayLabel = workflowRunTriggerDisplayLabel({
-    triggerSource: dto.trigger_source,
-    triggerEvent: dto.trigger_event,
-  });
-
-  return {
-    id: dto.id,
-    projectId: dto.project_id,
-    definitionId: dto.definition_id,
-    name: dto.name,
-    currentAttempt: dto.current_attempt,
-    triggerProvider: dto.trigger_provider,
-    triggerSource: dto.trigger_source,
-    triggerEvent: dto.trigger_event,
-    triggerDisplayLabel,
-    triggerLabel,
-    triggerPayload: dto.trigger_payload,
-    inputs: dto.inputs ?? null,
-    sourceSnapshot: dto.source_snapshot ? toWorkflowSourceSnapshot(dto.source_snapshot) : null,
-    createdAt: dto.created_at,
-    updatedAt: dto.updated_at,
-    shortId: workflowRunShortId(dto.id),
-    isTemporary: dto.id.startsWith('temp-'),
-  };
-}
-
-export function toWorkflowRunListItem(dto: WorkflowRunResponseDto): WorkflowRunListItem {
-  return {
-    ...toWorkflowRun(dto),
-    status: dto.status,
-    latestAttempt: dto.latest_attempt,
-    runAttempt: new WorkflowRunAttemptSummary({
-      workflowRunId: dto.id,
-      attempt: dto.current_attempt,
-      status: dto.status,
-      createdAt: dto.created_at,
-      startedAt: dto.started_at ?? null,
-      finishedAt: dto.finished_at ?? null,
-    }),
-  };
-}
-
-export function toWorkflowRunDetail(dto: WorkflowRunDetailResponseDto): WorkflowRunDetail {
-  return {
-    ...toWorkflowRun(dto),
-    latestAttempt: dto.latest_attempt,
-    runAttempt: toWorkflowRunAttempt(dto.run_attempt),
-    jobs: dto.jobs.map(toJob),
-  };
-}
-
-export function toWorkflowRunListPage(dto: WorkflowRunListResponseDto): WorkflowRunListPage {
-  return {
-    runs: dto.runs.map(toWorkflowRunListItem),
-    nextCursor: dto.next_cursor,
-    filteredTotalCount: dto.filtered_total_count,
-  };
-}
-
-function toWorkflowSourceSnapshot(
-  dto: NonNullable<WorkflowRunResponseDto['source_snapshot']>,
-): WorkflowSourceSnapshot {
-  return {
-    content: dto.content,
-    format: dto.format,
-  };
 }

--- a/libs/client/workflows/src/core/workflow-run.test.ts
+++ b/libs/client/workflows/src/core/workflow-run.test.ts
@@ -1,4 +1,11 @@
 import {
+  toWorkflowRun,
+  toWorkflowRunAttempt,
+  toWorkflowRunDetail,
+  toWorkflowRunListItem,
+  toWorkflowRunListPage,
+} from '#hooks/api/workflow-run-mapper.js';
+import {
   workflowJobDto,
   workflowJobExecutionDto,
   workflowRunAttemptDto,
@@ -11,11 +18,6 @@ import {
 import {
   isWorkflowRunTerminal,
   isWorkflowStatus,
-  toWorkflowRun,
-  toWorkflowRunAttempt,
-  toWorkflowRunDetail,
-  toWorkflowRunListItem,
-  toWorkflowRunListPage,
   workflowRunShortId,
   workflowRunTriggerDisplayLabel,
   workflowRunTriggerLabel,
@@ -313,11 +315,11 @@ describe('workflow run model mapping', () => {
       listening: {
         on: [{source: 'github', event: 'deployment_status'}],
         until: [{source: 'slack', event: 'approval'}],
-        timeout_ms: 1_800_000,
-        max_executions: 10,
+        timeoutMs: 1_800_000,
+        maxExecutions: 10,
         batch: null,
-        on_resolve: 'finish',
-        execution_timeout_ms: null,
+        onResolve: 'finish',
+        executionTimeoutMs: null,
         name: null,
       },
       listenerStatus: 'listening',
@@ -328,8 +330,8 @@ describe('workflow run model mapping', () => {
         {
           source: 'github',
           event: 'deployment_status',
-          delivery_id: 'delivery-1',
-          received_at: '2026-05-07T01:00:00.000Z',
+          deliveryId: 'delivery-1',
+          receivedAt: '2026-05-07T01:00:00.000Z',
           data: {state: 'success'},
         },
       ],

--- a/libs/client/workflows/src/core/workflow-run.ts
+++ b/libs/client/workflows/src/core/workflow-run.ts
@@ -1,5 +1,6 @@
 export type {
   JobDisplayDuration,
+  JobListening,
   JobMode,
   JobStatus,
   JobStatusReason,
@@ -12,15 +13,15 @@ export {
   Job,
   resolveJobExecution,
   TERMINAL_WORKFLOW_JOB_STATUSES,
-  toJob,
   WORKFLOW_JOB_STATUSES,
 } from './entities/job.js';
 export type {
   JobExecutionDisplayDuration,
   JobExecutionStatus,
   JobExecutionTime,
+  WorkflowExecutionEvent,
 } from './entities/job-execution.js';
-export {JobExecution, toJobExecution} from './entities/job-execution.js';
+export {JobExecution} from './entities/job-execution.js';
 export type {
   AgentConfigIssue,
   AgentStepConfig,
@@ -30,17 +31,18 @@ export type {
   StepErrorReason,
   StepSourceLocation,
 } from './entities/step.js';
-export {toStep} from './entities/step.js';
+export {AGENT_CONFIG_ISSUES, STEP_ERROR_REASONS} from './entities/step.js';
 export type {
   StepAttemptDisplayDuration,
   StepGateResult,
 } from './entities/step-attempt.js';
-export {StepAttempt, toStepAttempt} from './entities/step-attempt.js';
+export {StepAttempt} from './entities/step-attempt.js';
 export type {
   WorkflowRun,
   WorkflowRunDetail,
   WorkflowRunListItem,
   WorkflowRunListPage,
+  WorkflowRunRerunMode,
   WorkflowRunStatus,
   WorkflowSourceSnapshot,
   WorkflowStatus,
@@ -49,18 +51,10 @@ export {
   isWorkflowRunTerminal,
   isWorkflowStatus,
   TERMINAL_WORKFLOW_RUN_STATUSES,
-  toWorkflowRun,
-  toWorkflowRunDetail,
-  toWorkflowRunListItem,
-  toWorkflowRunListPage,
   WORKFLOW_RUN_STATUSES,
   workflowRunShortId,
   workflowRunTriggerDisplayLabel,
   workflowRunTriggerLabel,
 } from './entities/workflow-run.js';
 export type {WorkflowRunAttemptDisplayDuration} from './entities/workflow-run-attempt.js';
-export {
-  toWorkflowRunAttempt,
-  WorkflowRunAttempt,
-  WorkflowRunAttemptSummary,
-} from './entities/workflow-run-attempt.js';
+export {WorkflowRunAttempt, WorkflowRunAttemptSummary} from './entities/workflow-run-attempt.js';

--- a/libs/client/workflows/src/hooks/api/workflow-run-mapper.ts
+++ b/libs/client/workflows/src/hooks/api/workflow-run-mapper.ts
@@ -1,0 +1,246 @@
+import type {
+  JobListeningDto,
+  StepAttemptDto,
+  StepGateResultDto,
+  WorkflowExecutionEventDto,
+  WorkflowRunAttemptDto,
+  WorkflowRunDetailResponseDto,
+  WorkflowRunJobDetailDto,
+  WorkflowRunJobExecutionDetailDto,
+  WorkflowRunListResponseDto,
+  WorkflowRunResponseDto,
+  WorkflowRunStepDetailDto,
+} from '@shipfox/api-workflows-dto';
+import {
+  Job,
+  JobExecution,
+  type JobListening,
+  type Step,
+  StepAttempt,
+  type StepGateResult,
+  type WorkflowExecutionEvent,
+  type WorkflowRun,
+  WorkflowRunAttempt,
+  WorkflowRunAttemptSummary,
+  type WorkflowRunDetail,
+  type WorkflowRunListItem,
+  type WorkflowRunListPage,
+  workflowRunShortId,
+  workflowRunTriggerDisplayLabel,
+  workflowRunTriggerLabel,
+} from '#core/workflow-run.js';
+
+export function toWorkflowRun(dto: WorkflowRunResponseDto): WorkflowRun {
+  return {
+    id: dto.id,
+    projectId: dto.project_id,
+    definitionId: dto.definition_id,
+    name: dto.name,
+    currentAttempt: dto.current_attempt,
+    triggerProvider: dto.trigger_provider,
+    triggerSource: dto.trigger_source,
+    triggerEvent: dto.trigger_event,
+    triggerDisplayLabel: workflowRunTriggerDisplayLabel({
+      triggerSource: dto.trigger_source,
+      triggerEvent: dto.trigger_event,
+    }),
+    triggerLabel: workflowRunTriggerLabel({
+      triggerSource: dto.trigger_source,
+      triggerEvent: dto.trigger_event,
+    }),
+    triggerPayload: dto.trigger_payload,
+    inputs: dto.inputs ?? null,
+    sourceSnapshot: dto.source_snapshot
+      ? {content: dto.source_snapshot.content, format: dto.source_snapshot.format}
+      : null,
+    createdAt: dto.created_at,
+    updatedAt: dto.updated_at,
+    shortId: workflowRunShortId(dto.id),
+    isTemporary: dto.id.startsWith('temp-'),
+  };
+}
+
+export function toWorkflowRunAttempt(dto: WorkflowRunAttemptDto): WorkflowRunAttempt {
+  return new WorkflowRunAttempt({
+    id: dto.id,
+    workflowRunId: dto.workflow_run_id,
+    attempt: dto.attempt,
+    status: dto.status,
+    createdAt: dto.created_at,
+    startedAt: dto.started_at ?? null,
+    finishedAt: dto.finished_at ?? null,
+    rerunMode: dto.rerun_mode,
+  });
+}
+
+export function toWorkflowRunListItem(dto: WorkflowRunResponseDto): WorkflowRunListItem {
+  return {
+    ...toWorkflowRun(dto),
+    status: dto.status,
+    latestAttempt: dto.latest_attempt,
+    runAttempt: new WorkflowRunAttemptSummary({
+      workflowRunId: dto.id,
+      attempt: dto.current_attempt,
+      status: dto.status,
+      createdAt: dto.created_at,
+      startedAt: dto.started_at ?? null,
+      finishedAt: dto.finished_at ?? null,
+    }),
+  };
+}
+
+export function toWorkflowRunListPage(dto: WorkflowRunListResponseDto): WorkflowRunListPage {
+  return {
+    runs: dto.runs.map(toWorkflowRunListItem),
+    nextCursor: dto.next_cursor,
+    filteredTotalCount: dto.filtered_total_count,
+  };
+}
+
+export function toWorkflowRunDetail(dto: WorkflowRunDetailResponseDto): WorkflowRunDetail {
+  return {
+    ...toWorkflowRun(dto),
+    latestAttempt: dto.latest_attempt,
+    runAttempt: toWorkflowRunAttempt(dto.run_attempt),
+    jobs: dto.jobs.map(toJob),
+  };
+}
+
+export function toJob(dto: WorkflowRunJobDetailDto): Job {
+  return new Job({
+    id: dto.id,
+    runAttemptId: dto.run_attempt_id,
+    key: dto.key,
+    name: dto.name,
+    mode: dto.mode,
+    status: dto.status,
+    statusReason: dto.status_reason,
+    carriedOver: dto.carried_over,
+    listening: dto.listening ? toJobListening(dto.listening) : null,
+    listenerStatus: dto.listener_status,
+    resolutionReason: dto.resolution_reason,
+    dependencies: dto.dependencies,
+    position: dto.position,
+    createdAt: dto.created_at,
+    updatedAt: dto.updated_at,
+    jobExecutions: dto.job_executions.map(toJobExecution),
+  });
+}
+
+export function toJobExecution(dto: WorkflowRunJobExecutionDetailDto): JobExecution {
+  return new JobExecution({
+    id: dto.id,
+    jobId: dto.job_id,
+    sequence: dto.sequence,
+    name: dto.name,
+    status: dto.status,
+    statusReason: dto.status_reason,
+    triggerEvents: (dto.trigger_events ?? []).map(toWorkflowExecutionEvent),
+    queuedAt: dto.queued_at ?? null,
+    startedAt: dto.started_at ?? null,
+    finishedAt: dto.finished_at ?? null,
+    timedOutAt: dto.timed_out_at ?? null,
+    createdAt: dto.created_at,
+    updatedAt: dto.updated_at,
+    steps: dto.steps.map(toStep),
+  });
+}
+
+export function toStep(dto: WorkflowRunStepDetailDto): Step {
+  return {
+    id: dto.id,
+    jobExecutionId: dto.job_execution_id,
+    key: dto.key,
+    name: dto.name,
+    sourceLocation: dto.source_location
+      ? {startLine: dto.source_location.start_line, endLine: dto.source_location.end_line}
+      : null,
+    status: dto.status,
+    type: dto.type,
+    config: dto.config,
+    agentConfig: toAgentStepConfig(dto),
+    error: dto.error
+      ? {
+          message: dto.error.message,
+          exitCode: dto.error.exit_code ?? null,
+          signal: dto.error.signal,
+          reason: dto.error.reason,
+          agentConfigIssue: dto.error.agent_config_issue,
+          category: dto.error.category,
+        }
+      : null,
+    position: dto.position,
+    currentAttempt: dto.current_attempt,
+    createdAt: dto.created_at,
+    updatedAt: dto.updated_at,
+    attempts: dto.attempts.map((attempt) => toStepAttempt(attempt, dto.job_execution_id)),
+  };
+}
+
+export function toStepAttempt(dto: StepAttemptDto, jobExecutionId: string): StepAttempt {
+  return new StepAttempt({
+    id: dto.id,
+    stepId: dto.step_id,
+    jobExecutionId,
+    attempt: dto.attempt,
+    executionOrder: dto.execution_order,
+    status: dto.status,
+    exitCode: dto.exit_code ?? null,
+    output: dto.output ?? null,
+    error: dto.error ?? null,
+    gateResult: toStepGateResult(dto.gate_result),
+    restartFeedback: dto.restart_feedback ?? null,
+    startedAt: dto.started_at,
+    finishedAt: dto.finished_at ?? null,
+  });
+}
+
+function toJobListening(dto: JobListeningDto): JobListening {
+  return {
+    on: dto.on,
+    until: dto.until,
+    timeoutMs: dto.timeout_ms,
+    maxExecutions: dto.max_executions,
+    batch: dto.batch
+      ? {
+          debounceMs: dto.batch.debounce_ms,
+          maxSize: dto.batch.max_size,
+          maxWaitMs: dto.batch.max_wait_ms,
+        }
+      : null,
+    onResolve: dto.on_resolve,
+    executionTimeoutMs: dto.execution_timeout_ms,
+    name: dto.name,
+  };
+}
+
+function toWorkflowExecutionEvent(dto: WorkflowExecutionEventDto): WorkflowExecutionEvent {
+  return {
+    source: dto.source,
+    event: dto.event,
+    deliveryId: dto.delivery_id,
+    receivedAt: dto.received_at,
+    data: dto.data,
+  };
+}
+
+function toStepGateResult(dto: StepGateResultDto): StepGateResult {
+  if (dto === null || dto.kind === 'none' || dto.kind === 'not_evaluated') return dto;
+  if (dto.kind === 'passed' || dto.kind === 'failed') return {...dto, exitCode: dto.exit_code};
+  if (dto.kind === 'uncheckable' || dto.kind === 'evaluation_error')
+    return {...dto, exitCode: dto.exit_code};
+  return dto;
+}
+
+function toAgentStepConfig(dto: WorkflowRunStepDetailDto): Step['agentConfig'] {
+  if (dto.type !== 'agent') return null;
+  return {
+    provider: stringConfigValue(dto.config.provider),
+    model: stringConfigValue(dto.config.model),
+    thinking: stringConfigValue(dto.config.thinking),
+  };
+}
+
+function stringConfigValue(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}

--- a/libs/client/workflows/src/hooks/api/workflow-runs.test.tsx
+++ b/libs/client/workflows/src/hooks/api/workflow-runs.test.tsx
@@ -1,12 +1,8 @@
-import type {
-  WorkflowRunDetailResponseDto,
-  WorkflowRunListResponseDto,
-} from '@shipfox/api-workflows-dto';
 import {configureApiClient} from '@shipfox/client-api';
 import {type InfiniteData, QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {act, cleanup, renderHook, waitFor} from '@testing-library/react';
 import type {ReactNode} from 'react';
-import {toWorkflowRun} from '#core/workflow-run.js';
+import type {WorkflowRunListPage} from '#core/workflow-run.js';
 import {
   runAttemptsResponseDto,
   workflowJobDto,
@@ -15,6 +11,7 @@ import {
   workflowRunDto,
   workflowRunListResponseDto,
 } from '#test/fixtures/workflow-run.js';
+import {toWorkflowRun, toWorkflowRunListPage} from './workflow-run-mapper.js';
 import {
   fireManualWorkflow,
   useCancelWorkflowRunMutation,
@@ -55,7 +52,7 @@ describe('workflow run API hooks', () => {
     configureApiClient({baseUrl: '', fetchImpl: undefined});
   });
 
-  test('maps list DTO pages to workflow run models while keeping the cache DTO-shaped', async () => {
+  test('maps list DTO pages to workflow run models before caching', async () => {
     const body = workflowRunListResponseDto({
       runs: [
         workflowRunDto({
@@ -92,19 +89,19 @@ describe('workflow run API hooks', () => {
     expect(result.current.data?.pages[0]?.nextCursor).toBe('cursor-2');
     expect(result.current.data?.pages[0]?.filteredTotalCount).toBe(8);
 
-    const cached = queryClient.getQueryData<
-      InfiniteData<WorkflowRunListResponseDto, string | undefined>
-    >(workflowRunsQueryKeys.list(PROJECT_ID, {}));
+    const cached = queryClient.getQueryData<InfiniteData<WorkflowRunListPage, string | undefined>>(
+      workflowRunsQueryKeys.list(PROJECT_ID, {}),
+    );
     expect(cached?.pages[0]?.runs[0]).toMatchObject({
-      trigger_provider: 'github',
-      trigger_source: 'github_acme',
-      trigger_event: 'push',
-      updated_at: '2026-05-07T01:02:00.000Z',
+      triggerProvider: 'github',
+      triggerSource: 'github_acme',
+      triggerEvent: 'push',
+      updatedAt: '2026-05-07T01:02:00.000Z',
     });
-    expect(cached?.pages[0]).not.toHaveProperty('nextCursor');
+    expect(cached?.pages[0]).toHaveProperty('nextCursor', 'cursor-2');
   });
 
-  test('maps detail DTOs to nested workflow run detail models while keeping the cache DTO-shaped', async () => {
+  test('maps detail DTOs to nested workflow run detail models before caching', async () => {
     const body = workflowRunDetailDto({
       id: RUN_ID,
       trigger_source: 'manual',
@@ -126,16 +123,14 @@ describe('workflow run API hooks', () => {
       jobs: [{name: 'build', runAttemptId: RUN_ID}],
     });
 
-    const cached = queryClient.getQueryData<WorkflowRunDetailResponseDto>(
-      workflowRunsQueryKeys.detail(RUN_ID),
-    );
+    const cached = queryClient.getQueryData(workflowRunsQueryKeys.detail(RUN_ID));
     expect(cached).toMatchObject({
       id: RUN_ID,
-      trigger_source: 'manual',
-      trigger_event: 'fire',
-      jobs: [{name: 'build', run_attempt_id: RUN_ID}],
+      triggerSource: 'manual',
+      triggerEvent: 'fire',
+      jobs: [{name: 'build', runAttemptId: RUN_ID}],
     });
-    expect(cached).not.toHaveProperty('triggerSource');
+    expect(cached).toHaveProperty('triggerSource', 'manual');
   });
 
   test('maps run attempts and caches them by workflow run id', async () => {
@@ -173,7 +168,9 @@ describe('workflow run API hooks', () => {
     expect(firstRequest(fetchImpl).url).toBe(
       `https://api.example.test/workflows/runs/${RUN_ID}/attempts`,
     );
-    expect(queryClient.getQueryData(workflowRunsQueryKeys.attempts(RUN_ID))).toEqual(body);
+    expect(queryClient.getQueryData(workflowRunsQueryKeys.attempts(RUN_ID))).toEqual(
+      result.current.data,
+    );
   });
 
   test('posts manual fire requests with and without inputs', async () => {
@@ -210,13 +207,12 @@ describe('workflow run API hooks', () => {
     configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
     const {result, queryClient} = renderWithQueryClient(() => useFireManualWorkflowMutation());
     const listKey = workflowRunsQueryKeys.list(PROJECT_ID, {});
-    queryClient.setQueryData<InfiniteData<WorkflowRunListResponseDto, string | undefined>>(
-      listKey,
-      {
-        pages: [workflowRunListResponseDto({runs: [], filtered_total_count: 0})],
-        pageParams: [undefined],
-      },
-    );
+    queryClient.setQueryData<InfiniteData<WorkflowRunListPage, string | undefined>>(listKey, {
+      pages: [
+        toWorkflowRunListPage(workflowRunListResponseDto({runs: [], filtered_total_count: 0})),
+      ],
+      pageParams: [undefined],
+    });
 
     const railListEntries = queryClient.getQueriesData({
       queryKey: workflowRunsQueryKeys.lists(PROJECT_ID),
@@ -229,18 +225,16 @@ describe('workflow run API hooks', () => {
 
     await waitFor(() => {
       const cached =
-        queryClient.getQueryData<InfiniteData<WorkflowRunListResponseDto, string | undefined>>(
-          listKey,
-        );
+        queryClient.getQueryData<InfiniteData<WorkflowRunListPage, string | undefined>>(listKey);
       expect(cached?.pages[0]?.runs[0]).toMatchObject({
-        project_id: PROJECT_ID,
-        definition_id: DEFINITION_ID,
+        projectId: PROJECT_ID,
+        definitionId: DEFINITION_ID,
         status: 'pending',
-        trigger_source: 'manual',
-        trigger_provider: null,
+        triggerSource: 'manual',
+        triggerProvider: null,
       });
       expect(cached?.pages[0]?.runs[0]?.id).toMatch(TEMP_RUN_ID_PATTERN);
-      expect(cached?.pages[0]?.filtered_total_count).toBe(1);
+      expect(cached?.pages[0]?.filteredTotalCount).toBe(1);
     });
 
     if (!resolveFire) throw new Error('Expected manual fire request');
@@ -262,13 +256,12 @@ describe('workflow run API hooks', () => {
     configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
     const {result, queryClient} = renderWithQueryClient(() => useFireManualWorkflowMutation());
     const listKey = workflowRunsQueryKeys.list(PROJECT_ID, {});
-    queryClient.setQueryData<InfiniteData<WorkflowRunListResponseDto, string | undefined>>(
-      listKey,
-      {
-        pages: [workflowRunListResponseDto({runs: [], filtered_total_count: 0})],
-        pageParams: [undefined],
-      },
-    );
+    queryClient.setQueryData<InfiniteData<WorkflowRunListPage, string | undefined>>(listKey, {
+      pages: [
+        toWorkflowRunListPage(workflowRunListResponseDto({runs: [], filtered_total_count: 0})),
+      ],
+      pageParams: [undefined],
+    });
 
     act(() => {
       result.current.mutate({projectId: PROJECT_ID, definitionId: DEFINITION_ID});
@@ -279,11 +272,9 @@ describe('workflow run API hooks', () => {
 
     await waitFor(() => {
       const cached =
-        queryClient.getQueryData<InfiniteData<WorkflowRunListResponseDto, string | undefined>>(
-          listKey,
-        );
+        queryClient.getQueryData<InfiniteData<WorkflowRunListPage, string | undefined>>(listKey);
       expect(cached?.pages[0]?.runs).toHaveLength(1);
-      expect(cached?.pages[0]?.filtered_total_count).toBe(1);
+      expect(cached?.pages[0]?.filteredTotalCount).toBe(1);
     });
 
     act(() => {
@@ -296,11 +287,9 @@ describe('workflow run API hooks', () => {
     let secondTempWorkflowRunId: string | undefined;
     await waitFor(() => {
       const cached =
-        queryClient.getQueryData<InfiniteData<WorkflowRunListResponseDto, string | undefined>>(
-          listKey,
-        );
+        queryClient.getQueryData<InfiniteData<WorkflowRunListPage, string | undefined>>(listKey);
       expect(cached?.pages[0]?.runs).toHaveLength(2);
-      expect(cached?.pages[0]?.filtered_total_count).toBe(2);
+      expect(cached?.pages[0]?.filteredTotalCount).toBe(2);
       secondTempWorkflowRunId = cached?.pages[0]?.runs[0]?.id;
       expect(secondTempWorkflowRunId).toMatch(TEMP_RUN_ID_PATTERN);
     });
@@ -311,11 +300,9 @@ describe('workflow run API hooks', () => {
 
     await waitFor(() => {
       const cached =
-        queryClient.getQueryData<InfiniteData<WorkflowRunListResponseDto, string | undefined>>(
-          listKey,
-        );
+        queryClient.getQueryData<InfiniteData<WorkflowRunListPage, string | undefined>>(listKey);
       expect(cached?.pages[0]?.runs.map((run) => run.id)).toEqual([secondTempWorkflowRunId]);
-      expect(cached?.pages[0]?.filtered_total_count).toBe(1);
+      expect(cached?.pages[0]?.filteredTotalCount).toBe(1);
     });
 
     act(() => {

--- a/libs/client/workflows/src/hooks/api/workflow-runs.ts
+++ b/libs/client/workflows/src/hooks/api/workflow-runs.ts
@@ -18,16 +18,20 @@ import {
 } from '@tanstack/react-query';
 import {
   isWorkflowRunTerminal,
+  type WorkflowRun,
+  type WorkflowRunAttempt,
+  WorkflowRunAttemptSummary,
+  type WorkflowRunDetail,
+  type WorkflowRunListItem,
+  type WorkflowRunListPage,
+  type WorkflowRunStatus,
+} from '#core/workflow-run.js';
+import {
   toWorkflowRunAttempt,
   toWorkflowRunDetail,
   toWorkflowRunListItem,
   toWorkflowRunListPage,
-  type WorkflowRun,
-  type WorkflowRunAttempt,
-  type WorkflowRunDetail,
-  type WorkflowRunListPage,
-  type WorkflowRunStatus,
-} from '#core/workflow-run.js';
+} from './workflow-run-mapper.js';
 
 export interface WorkflowRunFilters {
   status?: WorkflowRunStatus | undefined;
@@ -82,9 +86,11 @@ async function listWorkflowRunsDto({
   const params = new URLSearchParams({project_id: projectId, limit: String(limit)});
   if (cursor) params.set('cursor', cursor);
   appendFilters(params, filters);
-  return await apiRequest<WorkflowRunListResponseDto>(`/workflows/runs?${params.toString()}`, {
-    signal,
-  });
+  const response = await apiRequest<WorkflowRunListResponseDto>(
+    `/workflows/runs?${params.toString()}`,
+    {signal},
+  );
+  return toWorkflowRunListPage(response);
 }
 
 /**
@@ -113,16 +119,7 @@ export async function fireManualWorkflow({
 const ACTIVE_POLL_MS = 4_000;
 const IDLE_POLL_MS = 30_000;
 
-type RunListInfinite = InfiniteData<WorkflowRunListResponseDto, string | undefined>;
-
-function toWorkflowRunInfiniteData(
-  data: InfiniteData<WorkflowRunListResponseDto, string | undefined>,
-): InfiniteData<WorkflowRunListPage, string | undefined> {
-  return {
-    ...data,
-    pages: data.pages.map(toWorkflowRunListPage),
-  };
-}
+type RunListInfinite = InfiniteData<WorkflowRunListPage, string | undefined>;
 
 export function useWorkflowRunsInfiniteQuery(
   projectId: string | undefined,
@@ -148,8 +145,7 @@ export function useWorkflowRunsInfiniteQuery(
     initialPageParam: undefined as string | undefined,
     queryFn: ({pageParam, signal}) =>
       listWorkflowRunsDto({projectId: projectId ?? '', filters, limit, cursor: pageParam, signal}),
-    getNextPageParam: (lastPage) => lastPage.next_cursor ?? undefined,
-    select: toWorkflowRunInfiniteData,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
     placeholderData: keepPreviousData,
     staleTime: 2_000,
     refetchOnWindowFocus: true,
@@ -261,25 +257,36 @@ function buildTempRun({
   definitionId: string;
   name: string;
   createdAt: string;
-}): WorkflowRunDto {
+}): WorkflowRunListItem {
+  const id = `temp-${cryptoRandomId()}`;
   return {
-    id: `temp-${cryptoRandomId()}`,
-    project_id: projectId,
-    definition_id: definitionId,
+    id,
+    projectId,
+    definitionId,
     name,
     status: 'pending',
-    current_attempt: 1,
-    latest_attempt: 1,
-    trigger_provider: null,
-    trigger_source: 'manual',
-    trigger_event: 'fire',
-    trigger_payload: {source: 'manual', event: 'fire'},
+    currentAttempt: 1,
+    latestAttempt: 1,
+    triggerProvider: null,
+    triggerSource: 'manual',
+    triggerEvent: 'fire',
+    triggerPayload: {source: 'manual', event: 'fire'},
+    triggerDisplayLabel: 'fire',
+    triggerLabel: 'manual · fire',
     inputs: null,
-    source_snapshot: null,
-    created_at: createdAt,
-    updated_at: createdAt,
-    started_at: null,
-    finished_at: null,
+    sourceSnapshot: null,
+    createdAt,
+    updatedAt: createdAt,
+    shortId: id.slice(0, 8),
+    isTemporary: true,
+    runAttempt: new WorkflowRunAttemptSummary({
+      workflowRunId: id,
+      attempt: 1,
+      status: 'pending',
+      createdAt,
+      startedAt: null,
+      finishedAt: null,
+    }),
   };
 }
 
@@ -334,11 +341,11 @@ export function useFireManualWorkflowMutation() {
           if (!current || current.pages.length === 0) return current;
           const firstPage = current.pages[0];
           if (!firstPage) return current;
-          const nextFirstPage: WorkflowRunListResponseDto = {
+          const nextFirstPage: WorkflowRunListPage = {
             ...firstPage,
             runs: [tempRun, ...firstPage.runs],
-            filtered_total_count:
-              firstPage.filtered_total_count != null ? firstPage.filtered_total_count + 1 : null,
+            filteredTotalCount:
+              firstPage.filteredTotalCount != null ? firstPage.filteredTotalCount + 1 : null,
           };
           return {...current, pages: [nextFirstPage, ...current.pages.slice(1)]};
         });
@@ -362,9 +369,9 @@ export function useFireManualWorkflowMutation() {
             return {
               ...page,
               runs,
-              filtered_total_count:
-                page.filtered_total_count != null
-                  ? Math.max(0, page.filtered_total_count - removedCount)
+              filteredTotalCount:
+                page.filteredTotalCount != null
+                  ? Math.max(0, page.filteredTotalCount - removedCount)
                   : null,
             };
           });
@@ -432,13 +439,14 @@ export function useWorkflowRunAttemptQuery({
       : [...workflowRunsQueryKeys.all, 'detail'],
     enabled: Boolean(workflowRunId),
     queryFn: ({signal}) =>
-      getWorkflowRunDto({workflowRunId: workflowRunId ?? '', runAttempt, signal}),
-    select: toWorkflowRunDetail,
+      getWorkflowRunDto({workflowRunId: workflowRunId ?? '', runAttempt, signal}).then(
+        toWorkflowRunDetail,
+      ),
     staleTime: 2_000,
     refetchOnWindowFocus: true,
     refetchInterval: (query) => {
       const status: WorkflowRunDetail['runAttempt']['status'] | undefined =
-        query.state.data?.run_attempt.status;
+        query.state.data?.runAttempt.status;
       if (!status) return false;
       return isWorkflowRunTerminal(status) ? false : ACTIVE_POLL_MS;
     },
@@ -458,8 +466,10 @@ export function useWorkflowRunAttemptsQuery({
       ? workflowRunsQueryKeys.attempts(workflowRunId)
       : [...workflowRunsQueryKeys.all, 'attempts'],
     enabled: Boolean(workflowRunId) && enabled,
-    queryFn: ({signal}) => getWorkflowRunAttemptsDto({workflowRunId: workflowRunId ?? '', signal}),
-    select: (dto): WorkflowRunAttempt[] => dto.attempts.map(toWorkflowRunAttempt),
+    queryFn: ({signal}) =>
+      getWorkflowRunAttemptsDto({workflowRunId: workflowRunId ?? '', signal}).then(
+        (dto): WorkflowRunAttempt[] => dto.attempts.map(toWorkflowRunAttempt),
+      ),
     staleTime: 0,
     refetchOnMount: true,
     refetchOnWindowFocus: false,

--- a/libs/client/workflows/test/fixtures/workflow-run.ts
+++ b/libs/client/workflows/test/fixtures/workflow-run.ts
@@ -11,20 +11,22 @@ import type {
   WorkflowRunStatusDto,
   WorkflowRunStepDetailDto,
 } from '@shipfox/api-workflows-dto';
+import type {
+  Job,
+  Step,
+  StepAttempt,
+  WorkflowRunDetail,
+  WorkflowRunListItem,
+  WorkflowRunListPage,
+} from '#core/workflow-run.js';
 import {
-  type Job,
-  type Step,
-  type StepAttempt,
   toJob,
   toStep,
   toStepAttempt,
   toWorkflowRunDetail,
   toWorkflowRunListItem,
   toWorkflowRunListPage,
-  type WorkflowRunDetail,
-  type WorkflowRunListItem,
-  type WorkflowRunListPage,
-} from '#core/workflow-run.js';
+} from '#hooks/api/workflow-run-mapper.js';
 
 const RUN_ID = '11111111-1111-4111-8111-111111111111';
 const RUN_ATTEMPT_ID = '11111111-1111-4111-8111-111111111112';


### PR DESCRIPTION
Moves Workflows response translation out of the framework-free core and into the API adapter, so list pages, details, attempts, and optimistic manual runs share canonical domain models in React Query.

The cache previously kept snake_case DTO pages and relied on observer-level `select`, which left cache consumers and optimistic transforms coupled to transport fields. This makes the domain model the cache contract and keeps UI error and rerun types independent from workflow response DTOs.

The mapper remains at the API boundary because it is the single place that can safely understand both transport and domain shapes. Review the nested job, execution, step, and gate mappings carefully, along with the converted optimistic rollback path.

Refs ENG-1131

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converged React Query caches on transport‑independent workflow domain models by moving all DTO→domain mapping to the API adapter. Caches, optimistic updates, and UI now use camelCase domain shapes and no longer depend on `@shipfox/api-workflows-dto`. Refs ENG-1131.

- **Refactors**
  - Added `#hooks/api/workflow-run-mapper.ts` to map runs, list pages, details, attempts, jobs, job executions, steps, step attempts, gate results, trigger events, and job listening to domain models with camelCase fields.
  - Core now defines string‑union domain types (e.g., `WorkflowRunStatus`, `JobStatus`, `WorkflowRunRerunMode`, `WorkflowExecutionEvent`) and exposes helpers only; DTO mappers removed from core.
  - Updated hooks to return/cache domain models (`useWorkflowRunsInfiniteQuery`, `useWorkflowRunAttemptQuery`, `useWorkflowRunAttemptsQuery`); uses `nextCursor` and `filteredTotalCount`.
  - Optimistic manual fire seeds domain‑shaped temp runs with `triggerDisplayLabel`, `triggerLabel`, `shortId`, and `isTemporary`.
  - Normalized step error parsing using `STEP_ERROR_REASONS` and `AGENT_CONFIG_ISSUES`; components now use domain types.

- **Migration**
  - Import domain types from `#core/workflow-run.js` (e.g., `WorkflowRunRerunMode`, `JobListening`, `WorkflowExecutionEvent`) instead of DTO types.
  - In tests and cache seeding, use mappers from `#hooks/api/workflow-run-mapper.ts` and expect camelCase fields (`nextCursor`, `filteredTotalCount`, `triggerEvents[].deliveryId/receivedAt`, `gateResult.exitCode`, `listening.timeoutMs/maxExecutions/onResolve/executionTimeoutMs`, `batch.debounceMs/maxSize/maxWaitMs`).

<sup>Written for commit 5d5384c3cfb92702c951dcc5703db578039e1d00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

