### PR TITLE
[client-runners] Converge runner token client models

### DIFF
--- a/.changeset/swift-runners-converge.md
+++ b/.changeset/swift-runners-converge.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-runners": major
+---
+
+Converges manual-registration-token and provisioner-token client state on package-owned camelCase models validated at the transport boundary, replacing raw wire DTOs in the public hooks and mutation signatures.

--- a/libs/client/runners/src/components/create-manual-registration-token-form.tsx
+++ b/libs/client/runners/src/components/create-manual-registration-token-form.tsx
@@ -1,4 +1,3 @@
-import type {CreateManualRegistrationTokenResponseDto} from '@shipfox/api-runners-dto';
 import {Button} from '@shipfox/react-ui/button';
 import {Callout, CalloutContent, CalloutDescription, CalloutTitle} from '@shipfox/react-ui/callout';
 import {FormField, FormFieldInput, fieldError} from '@shipfox/react-ui/form-field';
@@ -6,15 +5,14 @@ import {useCopyToClipboard} from '@shipfox/react-ui/hooks';
 import {ModalBody, ModalFooter} from '@shipfox/react-ui/modal';
 import {Code, Text} from '@shipfox/react-ui/typography';
 import {useForm} from '@tanstack/react-form';
-import {useQueryClient} from '@tanstack/react-query';
 import {useState} from 'react';
-import {
-  manualRegistrationTokenQueryKeys,
-  useCreateManualRegistrationTokenMutation,
-} from '#hooks/api/manual-registration-tokens.js';
+import type {CreatedManualRegistrationToken} from '#core/token.js';
+import {createTokenCommand} from '#core/token.js';
+import {useCreateManualRegistrationTokenMutation} from '#hooks/api/manual-registration-tokens.js';
 import {manualRegistrationTokenCreateErrorToFormError} from './form-errors.js';
 import {
   ExpirationSelect,
+  expirationCommand,
   expirationHint,
   type TokenExpirationOption,
 } from './token-expiration-select.js';
@@ -26,27 +24,19 @@ export function CreateManualRegistrationTokenForm({
   onCreated,
 }: {
   workspaceId: string;
-  onCreated: (token: CreateManualRegistrationTokenResponseDto) => void;
+  onCreated: (token: CreatedManualRegistrationToken) => void;
 }) {
-  const queryClient = useQueryClient();
-  const createToken = useCreateManualRegistrationTokenMutation();
+  const createToken = useCreateManualRegistrationTokenMutation(workspaceId);
   const [formError, setFormError] = useState<string | undefined>();
 
   const form = useForm({
     defaultValues: {name: '', expiration: '86400' as TokenExpirationOption},
     onSubmit: async ({value}) => {
       setFormError(undefined);
-      const trimmedName = value.name.trim();
-      const body = {
-        ...(trimmedName ? {name: trimmedName} : {}),
-        ...(value.expiration === 'never' ? {} : {ttl_seconds: Number(value.expiration)}),
-      };
+      const command = createTokenCommand(value.name, expirationCommand(value.expiration));
 
       try {
-        const token = await createToken.mutateAsync({workspaceId, body});
-        await queryClient.invalidateQueries({
-          queryKey: manualRegistrationTokenQueryKeys.list(workspaceId),
-        });
+        const token = await createToken.mutateAsync(command);
         onCreated(token);
       } catch (error) {
         const mapped = manualRegistrationTokenCreateErrorToFormError(error);
@@ -144,11 +134,11 @@ export function CreateManualRegistrationTokenForm({
 export function CreatedManualRegistrationTokenPanel({
   token,
 }: {
-  token: CreateManualRegistrationTokenResponseDto;
+  token: CreatedManualRegistrationToken;
 }) {
   const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle');
   const {copy} = useCopyToClipboard({
-    text: token.raw_token,
+    text: token.token,
     onCopy: () => {
       setCopyState('copied');
       window.setTimeout(() => setCopyState('idle'), 1500);
@@ -175,7 +165,7 @@ export function CreatedManualRegistrationTokenPanel({
         </div>
         <div className="flex items-center gap-8 max-[640px]:flex-col max-[640px]:items-stretch">
           <Code variant="paragraph" className="min-w-0 flex-1 break-all">
-            {token.raw_token}
+            {token.token}
           </Code>
           <Button
             size="sm"

--- a/libs/client/runners/src/components/create-provisioner-token-form.tsx
+++ b/libs/client/runners/src/components/create-provisioner-token-form.tsx
@@ -1,4 +1,3 @@
-import type {CreateProvisionerTokenResponseDto} from '@shipfox/api-runners-dto';
 import {Button} from '@shipfox/react-ui/button';
 import {Callout, CalloutContent, CalloutDescription, CalloutTitle} from '@shipfox/react-ui/callout';
 import {FormField, FormFieldInput, fieldError} from '@shipfox/react-ui/form-field';
@@ -6,15 +5,14 @@ import {useCopyToClipboard} from '@shipfox/react-ui/hooks';
 import {ModalBody, ModalFooter} from '@shipfox/react-ui/modal';
 import {Code, Text} from '@shipfox/react-ui/typography';
 import {useForm} from '@tanstack/react-form';
-import {useQueryClient} from '@tanstack/react-query';
 import {useState} from 'react';
-import {
-  provisionerTokenQueryKeys,
-  useCreateProvisionerTokenMutation,
-} from '#hooks/api/provisioner-tokens.js';
+import type {CreatedProvisionerToken} from '#core/token.js';
+import {createTokenCommand} from '#core/token.js';
+import {useCreateProvisionerTokenMutation} from '#hooks/api/provisioner-tokens.js';
 import {provisionerTokenCreateErrorToFormError} from './provisioner-token-form-errors.js';
 import {
   ExpirationSelect,
+  expirationCommand,
   expirationHint,
   type TokenExpirationOption,
 } from './token-expiration-select.js';
@@ -26,27 +24,19 @@ export function CreateProvisionerTokenForm({
   onCreated,
 }: {
   workspaceId: string;
-  onCreated: (token: CreateProvisionerTokenResponseDto) => void;
+  onCreated: (token: CreatedProvisionerToken) => void;
 }) {
-  const queryClient = useQueryClient();
-  const createToken = useCreateProvisionerTokenMutation();
+  const createToken = useCreateProvisionerTokenMutation(workspaceId);
   const [formError, setFormError] = useState<string | undefined>();
 
   const form = useForm({
     defaultValues: {name: '', expiration: '86400' as TokenExpirationOption},
     onSubmit: async ({value}) => {
       setFormError(undefined);
-      const trimmedName = value.name.trim();
-      const body = {
-        ...(trimmedName ? {name: trimmedName} : {}),
-        ...(value.expiration === 'never' ? {} : {ttl_seconds: Number(value.expiration)}),
-      };
+      const command = createTokenCommand(value.name, expirationCommand(value.expiration));
 
       try {
-        const token = await createToken.mutateAsync({workspaceId, body});
-        await queryClient.invalidateQueries({
-          queryKey: provisionerTokenQueryKeys.list(workspaceId),
-        });
+        const token = await createToken.mutateAsync(command);
         onCreated(token);
       } catch (error) {
         const mapped = provisionerTokenCreateErrorToFormError(error);
@@ -141,10 +131,10 @@ export function CreateProvisionerTokenForm({
   );
 }
 
-export function CreatedProvisionerTokenPanel({token}: {token: CreateProvisionerTokenResponseDto}) {
+export function CreatedProvisionerTokenPanel({token}: {token: CreatedProvisionerToken}) {
   const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle');
   const {copy} = useCopyToClipboard({
-    text: token.raw_token,
+    text: token.token,
     onCopy: () => {
       setCopyState('copied');
       window.setTimeout(() => setCopyState('idle'), 1500);
@@ -171,7 +161,7 @@ export function CreatedProvisionerTokenPanel({token}: {token: CreateProvisionerT
         </div>
         <div className="flex items-center gap-8 max-[640px]:flex-col max-[640px]:items-stretch">
           <Code variant="paragraph" className="min-w-0 flex-1 break-all">
-            {token.raw_token}
+            {token.token}
           </Code>
           <Button
             size="sm"

--- a/libs/client/runners/src/components/form-errors.test.ts
+++ b/libs/client/runners/src/components/form-errors.test.ts
@@ -10,10 +10,10 @@ describe('manualRegistrationTokenCreateErrorToFormError', () => {
     expect(result).toEqual({kind: 'form', message: 'Try later'});
   });
 
-  test('routes Error to a form-level alert with the error message', () => {
+  test('does not expose an unknown Error message', () => {
     const result = manualRegistrationTokenCreateErrorToFormError(new Error('boom'));
 
-    expect(result).toEqual({kind: 'form', message: 'boom'});
+    expect(result).toEqual({kind: 'form', message: 'Something went wrong. Try again.'});
   });
 
   test('falls back to generic copy for non-Error throwables', () => {

--- a/libs/client/runners/src/components/manual-registration-token-errors.ts
+++ b/libs/client/runners/src/components/manual-registration-token-errors.ts
@@ -8,6 +8,5 @@ export function manualRegistrationTokenErrorMessage(error: unknown): string {
     }
     return error.message;
   }
-  if (error instanceof Error) return error.message;
   return 'Something went wrong. Try again.';
 }

--- a/libs/client/runners/src/components/manual-registration-token-format.test.ts
+++ b/libs/client/runners/src/components/manual-registration-token-format.test.ts
@@ -1,18 +1,18 @@
+import {tokenDisplayName} from '#core/token.js';
 import {
   formatManualRegistrationTokenDate,
   formatManualRegistrationTokenTimestamp,
-  manualRegistrationTokenDisplayName,
 } from './manual-registration-token-format.js';
 
-describe('manualRegistrationTokenDisplayName', () => {
+describe('tokenDisplayName', () => {
   test('uses the token name when present', () => {
-    const result = manualRegistrationTokenDisplayName({name: 'Deploy runner'});
+    const result = tokenDisplayName({name: 'Deploy runner'});
 
     expect(result).toBe('Deploy runner');
   });
 
   test('falls back for unnamed tokens', () => {
-    const result = manualRegistrationTokenDisplayName({name: null});
+    const result = tokenDisplayName({name: null});
 
     expect(result).toBe('Unnamed token');
   });

--- a/libs/client/runners/src/components/manual-registration-token-format.ts
+++ b/libs/client/runners/src/components/manual-registration-token-format.ts
@@ -1,4 +1,3 @@
-import type {ManualRegistrationTokenDto} from '@shipfox/api-runners-dto';
 import {formatDate, formatTimestamp} from '@shipfox/react-ui/utils';
 
 export function formatManualRegistrationTokenDate(value: string | null): string {
@@ -9,10 +8,4 @@ export function formatManualRegistrationTokenDate(value: string | null): string 
 export function formatManualRegistrationTokenTimestamp(value: string | null): string | undefined {
   if (!value) return undefined;
   return formatTimestamp(value);
-}
-
-export function manualRegistrationTokenDisplayName(
-  token: Pick<ManualRegistrationTokenDto, 'name'>,
-): string {
-  return token.name || 'Unnamed token';
 }

--- a/libs/client/runners/src/components/manual-registration-token-list.tsx
+++ b/libs/client/runners/src/components/manual-registration-token-list.tsx
@@ -1,4 +1,3 @@
-import type {ManualRegistrationTokenDto} from '@shipfox/api-runners-dto';
 import {Button, IconButton} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
 import {
@@ -26,17 +25,13 @@ import {
   TableRow,
 } from '@shipfox/react-ui/table';
 import {Code, Text} from '@shipfox/react-ui/typography';
-import {useQueryClient} from '@tanstack/react-query';
 import {useState} from 'react';
-import {
-  manualRegistrationTokenQueryKeys,
-  useRevokeManualRegistrationTokenMutation,
-} from '#hooks/api/manual-registration-tokens.js';
+import {type ManualRegistrationToken, tokenDisplayName} from '#core/token.js';
+import {useRevokeManualRegistrationTokenMutation} from '#hooks/api/manual-registration-tokens.js';
 import {manualRegistrationTokenErrorMessage} from './manual-registration-token-errors.js';
 import {
   formatManualRegistrationTokenDate,
   formatManualRegistrationTokenTimestamp,
-  manualRegistrationTokenDisplayName,
 } from './manual-registration-token-format.js';
 import {TokenDate} from './token-date.js';
 import {TokenName} from './token-name.js';
@@ -46,7 +41,7 @@ export function ManualRegistrationTokenList({
   tokens,
 }: {
   workspaceId: string;
-  tokens: ManualRegistrationTokenDto[];
+  tokens: ManualRegistrationToken[];
 }) {
   return (
     <>
@@ -65,7 +60,7 @@ export function ManualRegistrationTokenList({
             {tokens.map((token) => (
               <TableRow key={token.id}>
                 <TableCell>
-                  <TokenName name={manualRegistrationTokenDisplayName(token)} />
+                  <TokenName name={tokenDisplayName(token)} />
                 </TableCell>
                 <TableCell>
                   <Code variant="paragraph" className="block truncate">
@@ -73,10 +68,10 @@ export function ManualRegistrationTokenList({
                   </Code>
                 </TableCell>
                 <TableCell>
-                  <ManualRegistrationTokenDate value={token.expires_at} />
+                  <ManualRegistrationTokenDate value={token.expiresAt} />
                 </TableCell>
                 <TableCell>
-                  <ManualRegistrationTokenDate value={token.created_at} />
+                  <ManualRegistrationTokenDate value={token.createdAt} />
                 </TableCell>
                 <TableCell className="text-right">
                   <RevokeManualRegistrationTokenButton workspaceId={workspaceId} token={token} />
@@ -97,7 +92,7 @@ export function ManualRegistrationTokenList({
           >
             <div className="flex items-start justify-between gap-12">
               <div className="min-w-0 flex-1">
-                <TokenName name={manualRegistrationTokenDisplayName(token)} />
+                <TokenName name={tokenDisplayName(token)} />
                 <Code variant="paragraph" className="block truncate text-foreground-neutral-muted">
                   {token.prefix}
                 </Code>
@@ -108,13 +103,13 @@ export function ManualRegistrationTokenList({
               <div>
                 <dt className="text-foreground-neutral-muted">Expires</dt>
                 <dd>
-                  <ManualRegistrationTokenDate value={token.expires_at} />
+                  <ManualRegistrationTokenDate value={token.expiresAt} />
                 </dd>
               </div>
               <div>
                 <dt className="text-foreground-neutral-muted">Created</dt>
                 <dd>
-                  <ManualRegistrationTokenDate value={token.created_at} />
+                  <ManualRegistrationTokenDate value={token.createdAt} />
                 </dd>
               </div>
             </dl>
@@ -140,19 +135,15 @@ function RevokeManualRegistrationTokenButton({
   token,
 }: {
   workspaceId: string;
-  token: ManualRegistrationTokenDto;
+  token: ManualRegistrationToken;
 }) {
-  const queryClient = useQueryClient();
-  const revokeToken = useRevokeManualRegistrationTokenMutation();
+  const revokeToken = useRevokeManualRegistrationTokenMutation(workspaceId);
   const [open, setOpen] = useState(false);
-  const tokenName = manualRegistrationTokenDisplayName(token);
+  const tokenName = tokenDisplayName(token);
 
   async function handleRevoke() {
     try {
-      await revokeToken.mutateAsync({workspaceId, tokenId: token.id});
-      await queryClient.invalidateQueries({
-        queryKey: manualRegistrationTokenQueryKeys.list(workspaceId),
-      });
+      await revokeToken.mutateAsync(token.id);
       setOpen(false);
     } catch {
       // React Query stores the error for the inline modal alert.

--- a/libs/client/runners/src/components/manual-registration-tokens-settings-section.tsx
+++ b/libs/client/runners/src/components/manual-registration-tokens-settings-section.tsx
@@ -1,4 +1,3 @@
-import type {CreateManualRegistrationTokenResponseDto} from '@shipfox/api-runners-dto';
 import {QueryLoadError} from '@shipfox/client-ui';
 import {Button} from '@shipfox/react-ui/button';
 import {Icon} from '@shipfox/react-ui/icon';
@@ -12,6 +11,7 @@ import {
 } from '@shipfox/react-ui/modal';
 import {Header, Text} from '@shipfox/react-ui/typography';
 import {useState} from 'react';
+import type {CreatedManualRegistrationToken} from '#core/token.js';
 import {useManualRegistrationTokensQuery} from '#hooks/api/manual-registration-tokens.js';
 import {
   CreatedManualRegistrationTokenPanel,
@@ -30,10 +30,8 @@ export function WorkspaceManualRegistrationTokensSettingsSection({
 }) {
   const tokensQuery = useManualRegistrationTokensQuery(workspaceId);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [createdToken, setCreatedToken] = useState<CreateManualRegistrationTokenResponseDto | null>(
-    null,
-  );
-  const tokens = tokensQuery.data?.manual_registration_tokens ?? [];
+  const [createdToken, setCreatedToken] = useState<CreatedManualRegistrationToken | null>(null);
+  const tokens = tokensQuery.data ?? [];
 
   function handleOpenChange(nextOpen: boolean) {
     setIsModalOpen(nextOpen);

--- a/libs/client/runners/src/components/provisioner-token-errors.ts
+++ b/libs/client/runners/src/components/provisioner-token-errors.ts
@@ -7,6 +7,5 @@ export function provisionerTokenErrorMessage(error: unknown): string {
     }
     return error.message;
   }
-  if (error instanceof Error) return error.message;
   return 'Something went wrong. Try again.';
 }

--- a/libs/client/runners/src/components/provisioner-token-form-errors.test.ts
+++ b/libs/client/runners/src/components/provisioner-token-form-errors.test.ts
@@ -21,10 +21,10 @@ describe('provisionerTokenCreateErrorToFormError', () => {
     });
   });
 
-  test('routes Error to a form-level alert with the error message', () => {
+  test('does not expose an unknown Error message', () => {
     const result = provisionerTokenCreateErrorToFormError(new Error('boom'));
 
-    expect(result).toEqual({kind: 'form', message: 'boom'});
+    expect(result).toEqual({kind: 'form', message: 'Something went wrong. Try again.'});
   });
 
   test('falls back to generic copy for non-Error throwables', () => {

--- a/libs/client/runners/src/components/provisioner-token-format.test.ts
+++ b/libs/client/runners/src/components/provisioner-token-format.test.ts
@@ -1,24 +1,25 @@
-import type {ProvisionerTokenDto} from '@shipfox/api-runners-dto';
+import {
+  type ProvisionerToken,
+  provisionerConnectionStatus,
+  provisionerTokenDisplayName,
+} from '#core/token.js';
 import {
   formatProvisionerTokenDate,
   formatProvisionerTokenTimestamp,
-  provisionerConnectionStatus,
-  provisionerTokenDisplayName,
 } from './provisioner-token-format.js';
 
-const token: ProvisionerTokenDto = {
+const token: ProvisionerToken = {
   id: '33333333-3333-4333-8333-333333333333',
-  scope: 'workspace',
-  workspace_id: '11111111-1111-4111-8111-111111111111',
+  workspaceId: '11111111-1111-4111-8111-111111111111',
   prefix: 'sf_pt_abcde',
   name: 'Docker provisioner',
-  created_by_user_id: '22222222-2222-4222-8222-222222222222',
-  revoked_by_user_id: null,
-  expires_at: '2026-05-09T00:00:00.000Z',
-  revoked_at: null,
-  last_seen_at: null,
-  created_at: '2026-05-08T00:00:00.000Z',
-  updated_at: '2026-05-08T00:00:00.000Z',
+  createdByUserId: '22222222-2222-4222-8222-222222222222',
+  revokedByUserId: null,
+  expiresAt: '2026-05-09T00:00:00.000Z',
+  revokedAt: null,
+  lastSeenAt: null,
+  createdAt: '2026-05-08T00:00:00.000Z',
+  updatedAt: '2026-05-08T00:00:00.000Z',
 };
 
 describe('provisionerTokenDisplayName', () => {
@@ -73,7 +74,7 @@ describe('provisionerConnectionStatus', () => {
 
   test('returns last seen when inactive with a last seen timestamp', () => {
     const result = provisionerConnectionStatus(
-      {...token, last_seen_at: '2026-05-08T01:00:00.000Z'},
+      {...token, lastSeenAt: '2026-05-08T01:00:00.000Z'},
       new Set(),
     );
 

--- a/libs/client/runners/src/components/provisioner-token-format.ts
+++ b/libs/client/runners/src/components/provisioner-token-format.ts
@@ -1,11 +1,4 @@
-import type {ProvisionerTokenDto} from '@shipfox/api-runners-dto';
-import type {DotVariant} from '@shipfox/react-ui/dot';
 import {formatDate, formatTimestamp} from '@shipfox/react-ui/utils';
-
-export type ProvisionerConnectionStatus =
-  | {kind: 'connected'; dotVariant: DotVariant; label: 'Connected'}
-  | {kind: 'last-seen'; dotVariant: DotVariant; label: 'Last seen'; lastSeenAt: string}
-  | {kind: 'never-connected'; dotVariant: DotVariant; label: 'Never connected'};
 
 export function formatProvisionerTokenDate(value: string | null): string {
   if (!value) return 'Never';
@@ -15,26 +8,4 @@ export function formatProvisionerTokenDate(value: string | null): string {
 export function formatProvisionerTokenTimestamp(value: string | null): string | undefined {
   if (!value) return undefined;
   return formatTimestamp(value);
-}
-
-export function provisionerTokenDisplayName(token: Pick<ProvisionerTokenDto, 'name'>): string {
-  return token.name || 'Unnamed provisioner';
-}
-
-export function provisionerConnectionStatus(
-  token: Pick<ProvisionerTokenDto, 'id' | 'last_seen_at'>,
-  activeIds: ReadonlySet<string>,
-): ProvisionerConnectionStatus {
-  if (activeIds.has(token.id)) {
-    return {kind: 'connected', dotVariant: 'success', label: 'Connected'};
-  }
-  if (token.last_seen_at) {
-    return {
-      kind: 'last-seen',
-      dotVariant: 'neutral',
-      label: 'Last seen',
-      lastSeenAt: token.last_seen_at,
-    };
-  }
-  return {kind: 'never-connected', dotVariant: 'neutral', label: 'Never connected'};
 }

--- a/libs/client/runners/src/components/provisioner-token-list.tsx
+++ b/libs/client/runners/src/components/provisioner-token-list.tsx
@@ -1,4 +1,3 @@
-import type {ProvisionerTokenDto} from '@shipfox/api-runners-dto';
 import {Button, IconButton} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
 import {Dot} from '@shipfox/react-ui/dot';
@@ -28,18 +27,17 @@ import {
   TableRow,
 } from '@shipfox/react-ui/table';
 import {Code, Text} from '@shipfox/react-ui/typography';
-import {useQueryClient} from '@tanstack/react-query';
 import {useState} from 'react';
 import {
-  provisionerTokenQueryKeys,
-  useRevokeProvisionerTokenMutation,
-} from '#hooks/api/provisioner-tokens.js';
+  type ProvisionerToken,
+  provisionerConnectionStatus,
+  provisionerTokenDisplayName,
+} from '#core/token.js';
+import {useRevokeProvisionerTokenMutation} from '#hooks/api/provisioner-tokens.js';
 import {provisionerTokenErrorMessage} from './provisioner-token-errors.js';
 import {
   formatProvisionerTokenDate,
   formatProvisionerTokenTimestamp,
-  provisionerConnectionStatus,
-  provisionerTokenDisplayName,
 } from './provisioner-token-format.js';
 import {TokenDate} from './token-date.js';
 import {TokenName} from './token-name.js';
@@ -50,7 +48,7 @@ export function ProvisionerTokenList({
   activeIds,
 }: {
   workspaceId: string;
-  tokens: ProvisionerTokenDto[];
+  tokens: ProvisionerToken[];
   activeIds: ReadonlySet<string>;
 }) {
   return (
@@ -82,10 +80,10 @@ export function ProvisionerTokenList({
                   <ProvisionerStatusCell token={token} activeIds={activeIds} />
                 </TableCell>
                 <TableCell>
-                  <ProvisionerTokenDate value={token.expires_at} />
+                  <ProvisionerTokenDate value={token.expiresAt} />
                 </TableCell>
                 <TableCell>
-                  <ProvisionerTokenDate value={token.created_at} />
+                  <ProvisionerTokenDate value={token.createdAt} />
                 </TableCell>
                 <TableCell className="text-right">
                   <RevokeProvisionerTokenButton workspaceId={workspaceId} token={token} />
@@ -120,13 +118,13 @@ export function ProvisionerTokenList({
               <div>
                 <dt className="text-foreground-neutral-muted">Expires</dt>
                 <dd>
-                  <ProvisionerTokenDate value={token.expires_at} />
+                  <ProvisionerTokenDate value={token.expiresAt} />
                 </dd>
               </div>
               <div>
                 <dt className="text-foreground-neutral-muted">Created</dt>
                 <dd>
-                  <ProvisionerTokenDate value={token.created_at} />
+                  <ProvisionerTokenDate value={token.createdAt} />
                 </dd>
               </div>
             </dl>
@@ -151,7 +149,7 @@ function ProvisionerStatusCell({
   token,
   activeIds,
 }: {
-  token: ProvisionerTokenDto;
+  token: ProvisionerToken;
   activeIds: ReadonlySet<string>;
 }) {
   const status = provisionerConnectionStatus(token, activeIds);
@@ -175,22 +173,15 @@ function RevokeProvisionerTokenButton({
   token,
 }: {
   workspaceId: string;
-  token: ProvisionerTokenDto;
+  token: ProvisionerToken;
 }) {
-  const queryClient = useQueryClient();
-  const revokeToken = useRevokeProvisionerTokenMutation();
+  const revokeToken = useRevokeProvisionerTokenMutation(workspaceId);
   const [open, setOpen] = useState(false);
   const tokenName = provisionerTokenDisplayName(token);
 
   async function handleRevoke() {
     try {
-      await revokeToken.mutateAsync({workspaceId, tokenId: token.id});
-      await queryClient.invalidateQueries({
-        queryKey: provisionerTokenQueryKeys.list(workspaceId),
-      });
-      await queryClient.invalidateQueries({
-        queryKey: provisionerTokenQueryKeys.active(workspaceId),
-      });
+      await revokeToken.mutateAsync(token.id);
       setOpen(false);
     } catch {
       // React Query stores the error for the inline modal alert.

--- a/libs/client/runners/src/components/provisioner-tokens-settings-section.tsx
+++ b/libs/client/runners/src/components/provisioner-tokens-settings-section.tsx
@@ -1,4 +1,3 @@
-import type {CreateProvisionerTokenResponseDto} from '@shipfox/api-runners-dto';
 import {QueryLoadError} from '@shipfox/client-ui';
 import {Button} from '@shipfox/react-ui/button';
 import {Icon} from '@shipfox/react-ui/icon';
@@ -13,6 +12,7 @@ import {
 import {RelativeTimeProvider} from '@shipfox/react-ui/relative-time';
 import {Header, Text} from '@shipfox/react-ui/typography';
 import {useMemo, useState} from 'react';
+import type {CreatedProvisionerToken} from '#core/token.js';
 import {
   useActiveProvisionersQuery,
   useProvisionerTokensQuery,
@@ -31,10 +31,10 @@ export function WorkspaceProvisionerTokensSettingsSection({workspaceId}: {worksp
   const tokensQuery = useProvisionerTokensQuery(workspaceId);
   const activeProvisionersQuery = useActiveProvisionersQuery(workspaceId);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [createdToken, setCreatedToken] = useState<CreateProvisionerTokenResponseDto | null>(null);
-  const tokens = tokensQuery.data?.tokens ?? [];
+  const [createdToken, setCreatedToken] = useState<CreatedProvisionerToken | null>(null);
+  const tokens = tokensQuery.data ?? [];
   const activeIds = useMemo(
-    () => new Set(activeProvisionersQuery.data?.provisioners.map((provisioner) => provisioner.id)),
+    () => new Set(activeProvisionersQuery.data?.map((provisioner) => provisioner.id)),
     [activeProvisionersQuery.data],
   );
 

--- a/libs/client/runners/src/components/token-expiration-select.test.ts
+++ b/libs/client/runners/src/components/token-expiration-select.test.ts
@@ -1,0 +1,15 @@
+import {expirationCommand} from './token-expiration-select.js';
+
+describe('expirationCommand', () => {
+  test('maps "never" to a non-expiring command', () => {
+    const result = expirationCommand('never');
+
+    expect(result).toEqual({kind: 'never'});
+  });
+
+  test('maps a TTL option to an expires-after command in seconds', () => {
+    const result = expirationCommand('86400');
+
+    expect(result).toEqual({kind: 'expires-after', seconds: 86_400});
+  });
+});

--- a/libs/client/runners/src/components/token-expiration-select.tsx
+++ b/libs/client/runners/src/components/token-expiration-select.tsx
@@ -26,6 +26,12 @@ export const expirationOptions: Array<{value: TokenExpirationOption; label: stri
   {value: 'never', label: 'Never'},
 ];
 
+export function expirationCommand(expiration: TokenExpirationOption) {
+  return expiration === 'never'
+    ? ({kind: 'never'} as const)
+    : ({kind: 'expires-after', seconds: Number(expiration)} as const);
+}
+
 export function expirationHint(expiration: TokenExpirationOption): string {
   if (expiration === 'never') return 'Token will not expire.';
   const expiresAt = new Date(Date.now() + Number(expiration) * 1000);

--- a/libs/client/runners/src/components/token-settings-sections.stories.tsx
+++ b/libs/client/runners/src/components/token-settings-sections.stories.tsx
@@ -7,6 +7,11 @@ import type {Decorator, Meta, StoryObj} from '@storybook/react';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import type {ReactNode} from 'react';
 import {within} from 'storybook/test';
+import type {
+  CreatedProvisionerToken,
+  ManualRegistrationToken,
+  ProvisionerToken,
+} from '#core/token.js';
 import {CreatedManualRegistrationTokenPanel} from './create-manual-registration-token-form.js';
 import {CreatedProvisionerTokenPanel} from './create-provisioner-token-form.js';
 import {
@@ -115,20 +120,20 @@ export const Statuses: Story = {
       <ProvisionerTokenList
         workspaceId={WORKSPACE_ID}
         tokens={[
-          provisionerToken({
+          provisionerTokenModel({
             id: '33333333-3333-4333-8333-333333333333',
             name: 'Docker autoscaler',
-            last_seen_at: NOW,
+            lastSeenAt: NOW,
           }),
-          provisionerToken({
+          provisionerTokenModel({
             id: '44444444-4444-4444-8444-444444444444',
             name: 'Kubernetes spot pool',
-            last_seen_at: EIGHT_MINUTES_AGO,
+            lastSeenAt: EIGHT_MINUTES_AGO,
           }),
-          provisionerToken({
+          provisionerTokenModel({
             id: '55555555-5555-4555-8555-555555555555',
             name: 'Buildkite migration pool',
-            last_seen_at: null,
+            lastSeenAt: null,
           }),
         ]}
         activeIds={new Set(['33333333-3333-4333-8333-333333333333'])}
@@ -151,18 +156,18 @@ export const Content: Story = {
           <ManualRegistrationTokenList
             workspaceId={WORKSPACE_ID}
             tokens={[
-              manualToken({name: 'Deploy runner', prefix: 'sf_mrt_deploy'}),
-              manualToken({
+              manualRegistrationToken({name: 'Deploy runner', prefix: 'sf_mrt_deploy'}),
+              manualRegistrationToken({
                 id: '66666666-6666-4666-8666-666666666666',
                 name: 'macOS build host',
                 prefix: 'sf_mrt_macos',
-                expires_at: null,
+                expiresAt: null,
               }),
             ]}
           />
           <ProvisionerTokenList
             workspaceId={WORKSPACE_ID}
-            tokens={provisionerTokens()}
+            tokens={provisionerTokenModels()}
             activeIds={new Set(['33333333-3333-4333-8333-333333333333'])}
           />
         </div>
@@ -172,7 +177,7 @@ export const Content: Story = {
           <ManualRegistrationTokenList
             workspaceId={WORKSPACE_ID}
             tokens={[
-              manualToken({
+              manualRegistrationToken({
                 name: 'self-hosted-runner-for-production-release-candidate-validation-on-metal',
                 prefix: 'sf_mrt_release_candidate_validation',
               }),
@@ -181,10 +186,10 @@ export const Content: Story = {
           <ProvisionerTokenList
             workspaceId={WORKSPACE_ID}
             tokens={[
-              provisionerToken({
+              provisionerTokenModel({
                 name: 'docker-provisioner-for-west-coast-gpu-burst-capacity-and-fallback',
                 prefix: 'sf_pt_west_coast_gpu_burst',
-                last_seen_at: EIGHT_MINUTES_AGO,
+                lastSeenAt: EIGHT_MINUTES_AGO,
               }),
             ]}
             activeIds={new Set()}
@@ -202,22 +207,17 @@ export const CreatedTokenPanels: Story = {
         <CreatedManualRegistrationTokenPanel
           token={{
             id: '77777777-7777-4777-8777-777777777777',
-            raw_token: 'sf_mrt_4nJvNrs23ExampleManualTokenValue',
+            token: 'sf_mrt_4nJvNrs23ExampleManualTokenValue',
             prefix: 'sf_mrt_4nJv',
             name: 'Deploy runner',
-            workspace_id: WORKSPACE_ID,
-            expires_at: EXPIRES_AT,
-            created_at: CREATED_AT,
+            workspaceId: WORKSPACE_ID,
+            expiresAt: EXPIRES_AT,
+            createdAt: CREATED_AT,
           }}
         />
       </StateExample>
       <StateExample label="Provisioner token reveal">
-        <CreatedProvisionerTokenPanel
-          token={{
-            ...provisionerToken({name: 'Docker autoscaler'}),
-            raw_token: 'sf_pt_Rv8YwrExampleProvisionerTokenValue',
-          }}
-        />
+        <CreatedProvisionerTokenPanel token={createdProvisionerToken()} />
       </StateExample>
     </StorySurface>
   ),
@@ -306,6 +306,55 @@ function provisionerTokens(): ProvisionerTokenDto[] {
       last_seen_at: null,
     }),
   ];
+}
+
+function manualRegistrationToken(
+  overrides: Partial<ManualRegistrationToken> = {},
+): ManualRegistrationToken {
+  return {
+    id: '22222222-2222-4222-8222-222222222222',
+    workspaceId: WORKSPACE_ID,
+    prefix: 'sf_mrt_deploy',
+    name: 'Deploy runner',
+    expiresAt: EXPIRES_AT,
+    revokedAt: null,
+    createdAt: CREATED_AT,
+    updatedAt: CREATED_AT,
+    ...overrides,
+  };
+}
+
+function provisionerTokenModel(overrides: Partial<ProvisionerToken> = {}): ProvisionerToken {
+  return {
+    ...manualRegistrationToken(),
+    createdByUserId: '99999999-9999-4999-8999-999999999999',
+    revokedByUserId: null,
+    lastSeenAt: NOW,
+    ...overrides,
+  };
+}
+
+function provisionerTokenModels(): ProvisionerToken[] {
+  return [
+    provisionerTokenModel({id: '33333333-3333-4333-8333-333333333333', name: 'Docker autoscaler'}),
+    provisionerTokenModel({
+      id: '44444444-4444-4444-8444-444444444444',
+      name: 'Kubernetes spot pool',
+      lastSeenAt: EIGHT_MINUTES_AGO,
+    }),
+    provisionerTokenModel({
+      id: '55555555-5555-4555-8555-555555555555',
+      name: 'Buildkite migration pool',
+      lastSeenAt: null,
+    }),
+  ];
+}
+
+function createdProvisionerToken(): CreatedProvisionerToken {
+  return {
+    ...provisionerTokenModel({name: 'Docker autoscaler'}),
+    token: 'sf_pt_Rv8YwrExampleProvisionerTokenValue',
+  };
 }
 
 function manualToken(

--- a/libs/client/runners/src/core/token.test.ts
+++ b/libs/client/runners/src/core/token.test.ts
@@ -1,0 +1,30 @@
+import {
+  createTokenCommand,
+  provisionerConnectionStatus,
+  provisionerTokenDisplayName,
+} from './token.js';
+
+describe('token domain policies', () => {
+  test('omits a blank token name while keeping its expiration policy', () => {
+    const result = createTokenCommand('  ', {kind: 'expires-after', seconds: 86_400});
+
+    expect(result).toEqual({expiration: {kind: 'expires-after', seconds: 86_400}});
+  });
+
+  test('derives provisioner status from active and last-seen state', () => {
+    const token = {id: 'token-1', name: null, lastSeenAt: '2026-07-22T10:00:00.000Z'};
+
+    expect(provisionerConnectionStatus(token, new Set(['token-1']))).toEqual({
+      kind: 'connected',
+      dotVariant: 'success',
+      label: 'Connected',
+    });
+    expect(provisionerConnectionStatus(token, new Set())).toEqual({
+      kind: 'last-seen',
+      dotVariant: 'neutral',
+      label: 'Last seen',
+      lastSeenAt: token.lastSeenAt,
+    });
+    expect(provisionerTokenDisplayName(token)).toBe('Unnamed provisioner');
+  });
+});

--- a/libs/client/runners/src/core/token.ts
+++ b/libs/client/runners/src/core/token.ts
@@ -1,0 +1,83 @@
+export interface ManualRegistrationToken {
+  id: string;
+  workspaceId: string;
+  prefix: string;
+  name: string | null;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ProvisionerToken extends ManualRegistrationToken {
+  createdByUserId: string;
+  revokedByUserId: string | null;
+  lastSeenAt: string | null;
+}
+
+export interface ActiveProvisioner {
+  id: string;
+  name: string | null;
+  prefix: string;
+  lastSeenAt: string;
+}
+
+export interface CreatedManualRegistrationToken {
+  token: string;
+  id: string;
+  prefix: string;
+  name: string | null;
+  workspaceId: string;
+  expiresAt: string | null;
+  createdAt: string;
+}
+
+export interface CreatedProvisionerToken extends CreatedManualRegistrationToken {
+  createdByUserId: string;
+  revokedByUserId: string | null;
+  revokedAt: string | null;
+  lastSeenAt: string | null;
+  updatedAt: string;
+}
+
+export type TokenExpiration = {kind: 'never'} | {kind: 'expires-after'; seconds: number};
+
+export interface CreateTokenCommand {
+  name?: string;
+  expiration: TokenExpiration;
+}
+
+export type ProvisionerConnectionStatus =
+  | {kind: 'connected'; dotVariant: 'success'; label: 'Connected'}
+  | {kind: 'last-seen'; dotVariant: 'neutral'; label: 'Last seen'; lastSeenAt: string}
+  | {kind: 'never-connected'; dotVariant: 'neutral'; label: 'Never connected'};
+
+export function createTokenCommand(name: string, expiration: TokenExpiration): CreateTokenCommand {
+  const trimmedName = name.trim();
+  return {expiration, ...(trimmedName ? {name: trimmedName} : {})};
+}
+
+export function tokenDisplayName(token: Pick<ManualRegistrationToken, 'name'>): string {
+  return token.name || 'Unnamed token';
+}
+
+export function provisionerTokenDisplayName(token: Pick<ProvisionerToken, 'name'>): string {
+  return token.name || 'Unnamed provisioner';
+}
+
+export function provisionerConnectionStatus(
+  token: Pick<ProvisionerToken, 'id' | 'lastSeenAt'>,
+  activeIds: ReadonlySet<string>,
+): ProvisionerConnectionStatus {
+  if (activeIds.has(token.id))
+    return {kind: 'connected', dotVariant: 'success', label: 'Connected'};
+  if (token.lastSeenAt) {
+    return {
+      kind: 'last-seen',
+      dotVariant: 'neutral',
+      label: 'Last seen',
+      lastSeenAt: token.lastSeenAt,
+    };
+  }
+  return {kind: 'never-connected', dotVariant: 'neutral', label: 'Never connected'};
+}

--- a/libs/client/runners/src/hooks/api/manual-registration-tokens.test.ts
+++ b/libs/client/runners/src/hooks/api/manual-registration-tokens.test.ts
@@ -35,20 +35,23 @@ describe('createManualRegistrationToken', () => {
       );
     });
     configureApiClient({fetchImpl});
-    const body = {name: 'Local runner', ttl_seconds: 86_400};
+    const command = {
+      name: 'Local runner',
+      expiration: {kind: 'expires-after' as const, seconds: 86_400},
+    };
 
     const result = await createManualRegistrationToken({
       workspaceId: '11111111-1111-4111-8111-111111111111',
-      body,
+      command,
     });
 
     const request = fetchImpl.mock.calls[0]?.[0] as Request;
-    expect(result.raw_token).toBe('sf_mrt_raw-created-token');
+    expect(result.token).toBe('sf_mrt_raw-created-token');
     expect(request.url).toBe(
       'https://api.example.test/workspaces/11111111-1111-4111-8111-111111111111/runners/manual-registration-tokens',
     );
     expect(request.method).toBe('POST');
-    expect(requestBody).toEqual(body);
+    expect(requestBody).toEqual({name: 'Local runner', ttl_seconds: 86_400});
   });
 });
 
@@ -78,7 +81,7 @@ describe('revokeManualRegistrationToken', () => {
     });
 
     const request = fetchImpl.mock.calls[0]?.[0] as Request;
-    expect(result.revoked_at).toBe('2026-05-08T01:00:00.000Z');
+    expect(result.revokedAt).toBe('2026-05-08T01:00:00.000Z');
     expect(request.url).toBe(
       'https://api.example.test/workspaces/11111111-1111-4111-8111-111111111111/runners/manual-registration-tokens/33333333-3333-4333-8333-333333333333/revoke',
     );

--- a/libs/client/runners/src/hooks/api/manual-registration-tokens.ts
+++ b/libs/client/runners/src/hooks/api/manual-registration-tokens.ts
@@ -1,11 +1,20 @@
-import type {
-  CreateManualRegistrationTokenBodyDto,
-  CreateManualRegistrationTokenResponseDto,
-  ListManualRegistrationTokensResponseDto,
-  RevokeManualRegistrationTokenResponseDto,
+import {
+  createManualRegistrationTokenResponseSchema,
+  listManualRegistrationTokensResponseSchema,
+  revokeManualRegistrationTokenResponseSchema,
 } from '@shipfox/api-runners-dto';
-import {apiRequest} from '@shipfox/client-api';
-import {useMutation, useQuery} from '@tanstack/react-query';
+import {checkedApiRequest} from '@shipfox/client-api';
+import {queryOptions, useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
+import type {
+  CreatedManualRegistrationToken,
+  CreateTokenCommand,
+  ManualRegistrationToken,
+} from '#core/token.js';
+import {
+  toCreatedManualRegistrationToken,
+  toCreateTokenBody,
+  toManualRegistrationToken,
+} from './token-mapper.js';
 
 export const manualRegistrationTokenQueryKeys = {
   all: ['manual-registration-tokens'] as const,
@@ -19,24 +28,28 @@ export async function listManualRegistrationTokens({
 }: {
   workspaceId: string;
   signal?: AbortSignal;
-}) {
-  return await apiRequest<ListManualRegistrationTokensResponseDto>(
+}): Promise<ManualRegistrationToken[]> {
+  const response = await checkedApiRequest(
+    listManualRegistrationTokensResponseSchema,
     `/workspaces/${workspaceId}/runners/manual-registration-tokens`,
     {signal},
   );
+  return response.manual_registration_tokens.map(toManualRegistrationToken);
 }
 
 export async function createManualRegistrationToken({
   workspaceId,
-  body,
+  command,
 }: {
   workspaceId: string;
-  body: CreateManualRegistrationTokenBodyDto;
-}) {
-  return await apiRequest<CreateManualRegistrationTokenResponseDto>(
+  command: CreateTokenCommand;
+}): Promise<CreatedManualRegistrationToken> {
+  const response = await checkedApiRequest(
+    createManualRegistrationTokenResponseSchema,
     `/workspaces/${workspaceId}/runners/manual-registration-tokens`,
-    {method: 'POST', body},
+    {method: 'POST', body: toCreateTokenBody(command)},
   );
+  return toCreatedManualRegistrationToken(response);
 }
 
 export async function revokeManualRegistrationToken({
@@ -45,27 +58,46 @@ export async function revokeManualRegistrationToken({
 }: {
   workspaceId: string;
   tokenId: string;
-}) {
-  return await apiRequest<RevokeManualRegistrationTokenResponseDto>(
+}): Promise<ManualRegistrationToken> {
+  const response = await checkedApiRequest(
+    revokeManualRegistrationTokenResponseSchema,
     `/workspaces/${workspaceId}/runners/manual-registration-tokens/${tokenId}/revoke`,
     {method: 'POST'},
   );
+  return toManualRegistrationToken(response);
+}
+
+export function manualRegistrationTokensQueryOptions(workspaceId: string) {
+  return queryOptions({
+    queryKey: manualRegistrationTokenQueryKeys.list(workspaceId),
+    queryFn: ({signal}) => listManualRegistrationTokens({workspaceId, signal}),
+  });
 }
 
 export function useManualRegistrationTokensQuery(workspaceId: string | undefined) {
   return useQuery({
-    queryKey: workspaceId
-      ? manualRegistrationTokenQueryKeys.list(workspaceId)
-      : [...manualRegistrationTokenQueryKeys.all, 'list'],
+    ...manualRegistrationTokensQueryOptions(workspaceId ?? ''),
     enabled: Boolean(workspaceId),
-    queryFn: ({signal}) => listManualRegistrationTokens({workspaceId: workspaceId ?? '', signal}),
   });
 }
 
-export function useCreateManualRegistrationTokenMutation() {
-  return useMutation({mutationFn: createManualRegistrationToken});
+export function useCreateManualRegistrationTokenMutation(workspaceId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (command: CreateTokenCommand) =>
+      createManualRegistrationToken({workspaceId, command}),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries(manualRegistrationTokensQueryOptions(workspaceId));
+    },
+  });
 }
 
-export function useRevokeManualRegistrationTokenMutation() {
-  return useMutation({mutationFn: revokeManualRegistrationToken});
+export function useRevokeManualRegistrationTokenMutation(workspaceId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (tokenId: string) => revokeManualRegistrationToken({workspaceId, tokenId}),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries(manualRegistrationTokensQueryOptions(workspaceId));
+    },
+  });
 }

--- a/libs/client/runners/src/hooks/api/manual-registration-tokens.ts
+++ b/libs/client/runners/src/hooks/api/manual-registration-tokens.ts
@@ -4,7 +4,13 @@ import {
   revokeManualRegistrationTokenResponseSchema,
 } from '@shipfox/api-runners-dto';
 import {checkedApiRequest} from '@shipfox/client-api';
-import {queryOptions, useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
+import {
+  type FetchQueryOptions,
+  queryOptions,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 import type {
   CreatedManualRegistrationToken,
   CreateTokenCommand,
@@ -21,6 +27,13 @@ export const manualRegistrationTokenQueryKeys = {
   list: (workspaceId: string) =>
     [...manualRegistrationTokenQueryKeys.all, 'list', workspaceId] as const,
 };
+
+type ManualRegistrationTokensQueryOptions = FetchQueryOptions<
+  ManualRegistrationToken[],
+  Error,
+  ManualRegistrationToken[],
+  ReturnType<typeof manualRegistrationTokenQueryKeys.list>
+>;
 
 export async function listManualRegistrationTokens({
   workspaceId,
@@ -67,7 +80,9 @@ export async function revokeManualRegistrationToken({
   return toManualRegistrationToken(response);
 }
 
-export function manualRegistrationTokensQueryOptions(workspaceId: string) {
+export function manualRegistrationTokensQueryOptions(
+  workspaceId: string,
+): ManualRegistrationTokensQueryOptions {
   return queryOptions({
     queryKey: manualRegistrationTokenQueryKeys.list(workspaceId),
     queryFn: ({signal}) => listManualRegistrationTokens({workspaceId, signal}),

--- a/libs/client/runners/src/hooks/api/provisioner-tokens.test.ts
+++ b/libs/client/runners/src/hooks/api/provisioner-tokens.test.ts
@@ -29,7 +29,7 @@ describe('provisioner token transports', () => {
     const result = await listProvisionerTokens({workspaceId});
 
     const request = fetchImpl.mock.calls[0]?.[0] as Request;
-    expect(result.tokens).toEqual([]);
+    expect(result).toEqual([]);
     expect(request.url).toBe(
       `https://api.example.test/workspaces/${workspaceId}/provisioners/tokens`,
     );
@@ -60,17 +60,20 @@ describe('provisioner token transports', () => {
       );
     });
     configureApiClient({fetchImpl});
-    const body = {name: 'Docker provisioner', ttl_seconds: 86_400};
+    const command = {
+      name: 'Docker provisioner',
+      expiration: {kind: 'expires-after' as const, seconds: 86_400},
+    };
 
-    const result = await createProvisionerToken({workspaceId, body});
+    const result = await createProvisionerToken({workspaceId, command});
 
     const request = fetchImpl.mock.calls[0]?.[0] as Request;
-    expect(result.raw_token).toBe('sf_pt_raw-created-token');
+    expect(result.token).toBe('sf_pt_raw-created-token');
     expect(request.url).toBe(
       `https://api.example.test/workspaces/${workspaceId}/provisioners/tokens`,
     );
     expect(request.method).toBe('POST');
-    expect(requestBody).toEqual(body);
+    expect(requestBody).toEqual({name: 'Docker provisioner', ttl_seconds: 86_400});
   });
 
   test('posts to the token revoke endpoint', async () => {
@@ -95,7 +98,7 @@ describe('provisioner token transports', () => {
     const result = await revokeProvisionerToken({workspaceId, tokenId});
 
     const request = fetchImpl.mock.calls[0]?.[0] as Request;
-    expect(result.revoked_at).toBe('2026-05-08T01:00:00.000Z');
+    expect(result.revokedAt).toBe('2026-05-08T01:00:00.000Z');
     expect(request.url).toBe(
       `https://api.example.test/workspaces/${workspaceId}/provisioners/tokens/${tokenId}/revoke`,
     );
@@ -120,7 +123,7 @@ describe('provisioner token transports', () => {
     const result = await listActiveProvisioners({workspaceId});
 
     const request = fetchImpl.mock.calls[0]?.[0] as Request;
-    expect(result.provisioners).toHaveLength(1);
+    expect(result).toHaveLength(1);
     expect(request.url).toBe(
       `https://api.example.test/workspaces/${workspaceId}/provisioners/active`,
     );

--- a/libs/client/runners/src/hooks/api/provisioner-tokens.ts
+++ b/libs/client/runners/src/hooks/api/provisioner-tokens.ts
@@ -5,7 +5,13 @@ import {
   revokeProvisionerTokenResponseSchema,
 } from '@shipfox/api-runners-dto';
 import {checkedApiRequest} from '@shipfox/client-api';
-import {queryOptions, useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
+import {
+  type FetchQueryOptions,
+  queryOptions,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 import type {
   ActiveProvisioner,
   CreatedProvisionerToken,
@@ -27,6 +33,20 @@ export const provisionerTokenQueryKeys = {
   active: (workspaceId: string) =>
     [...provisionerTokenQueryKeys.all, 'provisioners', workspaceId] as const,
 };
+
+type ProvisionerTokensQueryOptions = FetchQueryOptions<
+  ProvisionerToken[],
+  Error,
+  ProvisionerToken[],
+  ReturnType<typeof provisionerTokenQueryKeys.list>
+>;
+
+type ActiveProvisionersQueryOptions = FetchQueryOptions<
+  ActiveProvisioner[],
+  Error,
+  ActiveProvisioner[],
+  ReturnType<typeof provisionerTokenQueryKeys.active>
+>;
 
 export async function listProvisionerTokens({
   workspaceId,
@@ -88,7 +108,7 @@ export async function listActiveProvisioners({
   return response.provisioners.map(toActiveProvisioner);
 }
 
-export function provisionerTokensQueryOptions(workspaceId: string) {
+export function provisionerTokensQueryOptions(workspaceId: string): ProvisionerTokensQueryOptions {
   return queryOptions({
     queryKey: provisionerTokenQueryKeys.list(workspaceId),
     queryFn: ({signal}) => listProvisionerTokens({workspaceId, signal}),
@@ -97,7 +117,9 @@ export function provisionerTokensQueryOptions(workspaceId: string) {
   });
 }
 
-export function activeProvisionersQueryOptions(workspaceId: string) {
+export function activeProvisionersQueryOptions(
+  workspaceId: string,
+): ActiveProvisionersQueryOptions {
   return queryOptions({
     queryKey: provisionerTokenQueryKeys.active(workspaceId),
     queryFn: ({signal}) => listActiveProvisioners({workspaceId, signal}),

--- a/libs/client/runners/src/hooks/api/provisioner-tokens.ts
+++ b/libs/client/runners/src/hooks/api/provisioner-tokens.ts
@@ -1,12 +1,23 @@
-import type {
-  CreateProvisionerTokenBodyDto,
-  CreateProvisionerTokenResponseDto,
-  ListActiveProvisionersResponseDto,
-  ListProvisionerTokensResponseDto,
-  RevokeProvisionerTokenResponseDto,
+import {
+  createProvisionerTokenResponseSchema,
+  listActiveProvisionersResponseSchema,
+  listProvisionerTokensResponseSchema,
+  revokeProvisionerTokenResponseSchema,
 } from '@shipfox/api-runners-dto';
-import {apiRequest} from '@shipfox/client-api';
-import {useMutation, useQuery} from '@tanstack/react-query';
+import {checkedApiRequest} from '@shipfox/client-api';
+import {queryOptions, useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
+import type {
+  ActiveProvisioner,
+  CreatedProvisionerToken,
+  CreateTokenCommand,
+  ProvisionerToken,
+} from '#core/token.js';
+import {
+  toActiveProvisioner,
+  toCreatedProvisionerToken,
+  toCreateTokenBody,
+  toProvisionerToken,
+} from './token-mapper.js';
 
 const PROVISIONER_TOKEN_REFETCH_INTERVAL_MS = 30_000;
 
@@ -23,24 +34,28 @@ export async function listProvisionerTokens({
 }: {
   workspaceId: string;
   signal?: AbortSignal;
-}) {
-  return await apiRequest<ListProvisionerTokensResponseDto>(
+}): Promise<ProvisionerToken[]> {
+  const response = await checkedApiRequest(
+    listProvisionerTokensResponseSchema,
     `/workspaces/${workspaceId}/provisioners/tokens`,
     {signal},
   );
+  return response.tokens.map(toProvisionerToken);
 }
 
 export async function createProvisionerToken({
   workspaceId,
-  body,
+  command,
 }: {
   workspaceId: string;
-  body: CreateProvisionerTokenBodyDto;
-}) {
-  return await apiRequest<CreateProvisionerTokenResponseDto>(
+  command: CreateTokenCommand;
+}): Promise<CreatedProvisionerToken> {
+  const response = await checkedApiRequest(
+    createProvisionerTokenResponseSchema,
     `/workspaces/${workspaceId}/provisioners/tokens`,
-    {method: 'POST', body},
+    {method: 'POST', body: toCreateTokenBody(command)},
   );
+  return toCreatedProvisionerToken(response);
 }
 
 export async function revokeProvisionerToken({
@@ -49,11 +64,13 @@ export async function revokeProvisionerToken({
 }: {
   workspaceId: string;
   tokenId: string;
-}) {
-  return await apiRequest<RevokeProvisionerTokenResponseDto>(
+}): Promise<ProvisionerToken> {
+  const response = await checkedApiRequest(
+    revokeProvisionerTokenResponseSchema,
     `/workspaces/${workspaceId}/provisioners/tokens/${tokenId}/revoke`,
     {method: 'POST'},
   );
+  return toProvisionerToken(response);
 }
 
 export async function listActiveProvisioners({
@@ -62,41 +79,66 @@ export async function listActiveProvisioners({
 }: {
   workspaceId: string;
   signal?: AbortSignal;
-}) {
-  return await apiRequest<ListActiveProvisionersResponseDto>(
+}): Promise<ActiveProvisioner[]> {
+  const response = await checkedApiRequest(
+    listActiveProvisionersResponseSchema,
     `/workspaces/${workspaceId}/provisioners/active`,
     {signal},
   );
+  return response.provisioners.map(toActiveProvisioner);
 }
 
-export function useProvisionerTokensQuery(workspaceId: string | undefined) {
-  return useQuery({
-    queryKey: workspaceId
-      ? provisionerTokenQueryKeys.list(workspaceId)
-      : [...provisionerTokenQueryKeys.all, 'tokens'],
-    enabled: Boolean(workspaceId),
-    queryFn: ({signal}) => listProvisionerTokens({workspaceId: workspaceId ?? '', signal}),
+export function provisionerTokensQueryOptions(workspaceId: string) {
+  return queryOptions({
+    queryKey: provisionerTokenQueryKeys.list(workspaceId),
+    queryFn: ({signal}) => listProvisionerTokens({workspaceId, signal}),
     refetchInterval: PROVISIONER_TOKEN_REFETCH_INTERVAL_MS,
     refetchIntervalInBackground: false,
   });
 }
 
-export function useCreateProvisionerTokenMutation() {
-  return useMutation({mutationFn: createProvisionerToken});
+export function activeProvisionersQueryOptions(workspaceId: string) {
+  return queryOptions({
+    queryKey: provisionerTokenQueryKeys.active(workspaceId),
+    queryFn: ({signal}) => listActiveProvisioners({workspaceId, signal}),
+    refetchInterval: PROVISIONER_TOKEN_REFETCH_INTERVAL_MS,
+    refetchIntervalInBackground: false,
+  });
 }
 
-export function useRevokeProvisionerTokenMutation() {
-  return useMutation({mutationFn: revokeProvisionerToken});
+export function useProvisionerTokensQuery(workspaceId: string | undefined) {
+  return useQuery({
+    ...provisionerTokensQueryOptions(workspaceId ?? ''),
+    enabled: Boolean(workspaceId),
+  });
 }
 
 export function useActiveProvisionersQuery(workspaceId: string | undefined) {
   return useQuery({
-    queryKey: workspaceId
-      ? provisionerTokenQueryKeys.active(workspaceId)
-      : [...provisionerTokenQueryKeys.all, 'provisioners'],
+    ...activeProvisionersQueryOptions(workspaceId ?? ''),
     enabled: Boolean(workspaceId),
-    queryFn: ({signal}) => listActiveProvisioners({workspaceId: workspaceId ?? '', signal}),
-    refetchInterval: PROVISIONER_TOKEN_REFETCH_INTERVAL_MS,
-    refetchIntervalInBackground: false,
+  });
+}
+
+export function useCreateProvisionerTokenMutation(workspaceId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (command: CreateTokenCommand) => createProvisionerToken({workspaceId, command}),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries(provisionerTokensQueryOptions(workspaceId));
+    },
+  });
+}
+
+export function useRevokeProvisionerTokenMutation(workspaceId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (tokenId: string) => revokeProvisionerToken({workspaceId, tokenId}),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries(provisionerTokensQueryOptions(workspaceId)),
+        queryClient.invalidateQueries(activeProvisionersQueryOptions(workspaceId)),
+      ]);
+    },
   });
 }

--- a/libs/client/runners/src/hooks/api/token-mapper.test.ts
+++ b/libs/client/runners/src/hooks/api/token-mapper.test.ts
@@ -1,0 +1,161 @@
+import {
+  toActiveProvisioner,
+  toCreatedManualRegistrationToken,
+  toCreatedProvisionerToken,
+  toCreateTokenBody,
+  toManualRegistrationToken,
+  toProvisionerToken,
+} from './token-mapper.js';
+
+describe('toManualRegistrationToken', () => {
+  test('maps a transport token to its package-owned model', () => {
+    const result = toManualRegistrationToken({
+      id: '11111111-1111-4111-8111-111111111111',
+      workspace_id: '22222222-2222-4222-8222-222222222222',
+      prefix: 'sf_mrt_test',
+      name: null,
+      expires_at: null,
+      revoked_at: null,
+      created_at: '2026-07-22T10:00:00.000Z',
+      updated_at: '2026-07-22T10:00:00.000Z',
+    });
+
+    expect(result).toEqual({
+      id: '11111111-1111-4111-8111-111111111111',
+      workspaceId: '22222222-2222-4222-8222-222222222222',
+      prefix: 'sf_mrt_test',
+      name: null,
+      expiresAt: null,
+      revokedAt: null,
+      createdAt: '2026-07-22T10:00:00.000Z',
+      updatedAt: '2026-07-22T10:00:00.000Z',
+    });
+  });
+});
+
+describe('toProvisionerToken', () => {
+  test('maps a transport provisioner token to its package-owned model', () => {
+    const result = toProvisionerToken({
+      id: '33333333-3333-4333-8333-333333333333',
+      scope: 'workspace',
+      workspace_id: '22222222-2222-4222-8222-222222222222',
+      prefix: 'sf_pt_test',
+      name: 'Docker provisioner',
+      created_by_user_id: '44444444-4444-4444-8444-444444444444',
+      revoked_by_user_id: null,
+      expires_at: null,
+      revoked_at: null,
+      last_seen_at: '2026-07-22T09:00:00.000Z',
+      created_at: '2026-07-22T10:00:00.000Z',
+      updated_at: '2026-07-22T10:00:00.000Z',
+    });
+
+    expect(result).toEqual({
+      id: '33333333-3333-4333-8333-333333333333',
+      workspaceId: '22222222-2222-4222-8222-222222222222',
+      prefix: 'sf_pt_test',
+      name: 'Docker provisioner',
+      expiresAt: null,
+      revokedAt: null,
+      createdAt: '2026-07-22T10:00:00.000Z',
+      updatedAt: '2026-07-22T10:00:00.000Z',
+      createdByUserId: '44444444-4444-4444-8444-444444444444',
+      revokedByUserId: null,
+      lastSeenAt: '2026-07-22T09:00:00.000Z',
+    });
+  });
+});
+
+describe('toActiveProvisioner', () => {
+  test('maps a transport active provisioner to its package-owned model', () => {
+    const result = toActiveProvisioner({
+      id: '33333333-3333-4333-8333-333333333333',
+      name: 'Docker provisioner',
+      prefix: 'sf_pt_test',
+      last_seen_at: '2026-07-22T09:00:00.000Z',
+    });
+
+    expect(result).toEqual({
+      id: '33333333-3333-4333-8333-333333333333',
+      name: 'Docker provisioner',
+      prefix: 'sf_pt_test',
+      lastSeenAt: '2026-07-22T09:00:00.000Z',
+    });
+  });
+});
+
+describe('toCreatedManualRegistrationToken', () => {
+  test('maps a raw-token creation response to its package-owned model', () => {
+    const result = toCreatedManualRegistrationToken({
+      id: '77777777-7777-4777-8777-777777777777',
+      raw_token: 'sf_mrt_raw-created-token',
+      prefix: 'sf_mrt_test',
+      name: null,
+      workspace_id: '22222222-2222-4222-8222-222222222222',
+      expires_at: null,
+      created_at: '2026-07-22T10:00:00.000Z',
+    });
+
+    expect(result).toEqual({
+      token: 'sf_mrt_raw-created-token',
+      id: '77777777-7777-4777-8777-777777777777',
+      prefix: 'sf_mrt_test',
+      name: null,
+      workspaceId: '22222222-2222-4222-8222-222222222222',
+      expiresAt: null,
+      createdAt: '2026-07-22T10:00:00.000Z',
+    });
+  });
+});
+
+describe('toCreatedProvisionerToken', () => {
+  test('maps a raw-token provisioner creation response to its package-owned model', () => {
+    const result = toCreatedProvisionerToken({
+      id: '77777777-7777-4777-8777-777777777777',
+      raw_token: 'sf_pt_raw-created-token',
+      prefix: 'sf_pt_test',
+      name: 'Docker provisioner',
+      workspace_id: '22222222-2222-4222-8222-222222222222',
+      created_by_user_id: '44444444-4444-4444-8444-444444444444',
+      revoked_by_user_id: null,
+      expires_at: null,
+      revoked_at: null,
+      last_seen_at: null,
+      created_at: '2026-07-22T10:00:00.000Z',
+      updated_at: '2026-07-22T10:00:00.000Z',
+      scope: 'workspace',
+    });
+
+    expect(result).toEqual({
+      token: 'sf_pt_raw-created-token',
+      id: '77777777-7777-4777-8777-777777777777',
+      prefix: 'sf_pt_test',
+      name: 'Docker provisioner',
+      workspaceId: '22222222-2222-4222-8222-222222222222',
+      expiresAt: null,
+      createdAt: '2026-07-22T10:00:00.000Z',
+      createdByUserId: '44444444-4444-4444-8444-444444444444',
+      revokedByUserId: null,
+      revokedAt: null,
+      lastSeenAt: null,
+      updatedAt: '2026-07-22T10:00:00.000Z',
+    });
+  });
+});
+
+describe('toCreateTokenBody', () => {
+  test('omits both optional fields for an unnamed, non-expiring command', () => {
+    const result = toCreateTokenBody({expiration: {kind: 'never'}});
+
+    expect(result).toEqual({});
+  });
+
+  test('includes name and ttl_seconds for a named, expiring command', () => {
+    const result = toCreateTokenBody({
+      name: 'Local runner',
+      expiration: {kind: 'expires-after', seconds: 86_400},
+    });
+
+    expect(result).toEqual({name: 'Local runner', ttl_seconds: 86_400});
+  });
+});

--- a/libs/client/runners/src/hooks/api/token-mapper.ts
+++ b/libs/client/runners/src/hooks/api/token-mapper.ts
@@ -1,0 +1,79 @@
+import type {
+  ActiveProvisionerDto,
+  CreateManualRegistrationTokenResponseDto,
+  CreateProvisionerTokenResponseDto,
+  ManualRegistrationTokenDto,
+  ProvisionerTokenDto,
+} from '@shipfox/api-runners-dto';
+import type {
+  ActiveProvisioner,
+  CreatedManualRegistrationToken,
+  CreatedProvisionerToken,
+  CreateTokenCommand,
+  ManualRegistrationToken,
+  ProvisionerToken,
+} from '#core/token.js';
+
+export function toCreateTokenBody(command: CreateTokenCommand) {
+  return {
+    ...(command.name ? {name: command.name} : {}),
+    ...(command.expiration.kind === 'expires-after'
+      ? {ttl_seconds: command.expiration.seconds}
+      : {}),
+  };
+}
+
+export function toManualRegistrationToken(
+  dto: ManualRegistrationTokenDto,
+): ManualRegistrationToken {
+  return {
+    id: dto.id,
+    workspaceId: dto.workspace_id,
+    prefix: dto.prefix,
+    name: dto.name,
+    expiresAt: dto.expires_at,
+    revokedAt: dto.revoked_at,
+    createdAt: dto.created_at,
+    updatedAt: dto.updated_at,
+  };
+}
+
+export function toProvisionerToken(dto: ProvisionerTokenDto): ProvisionerToken {
+  return {
+    ...toManualRegistrationToken(dto),
+    createdByUserId: dto.created_by_user_id,
+    revokedByUserId: dto.revoked_by_user_id,
+    lastSeenAt: dto.last_seen_at,
+  };
+}
+
+export function toActiveProvisioner(dto: ActiveProvisionerDto): ActiveProvisioner {
+  return {id: dto.id, name: dto.name, prefix: dto.prefix, lastSeenAt: dto.last_seen_at};
+}
+
+export function toCreatedManualRegistrationToken(
+  dto: CreateManualRegistrationTokenResponseDto,
+): CreatedManualRegistrationToken {
+  return {
+    token: dto.raw_token,
+    id: dto.id,
+    prefix: dto.prefix,
+    name: dto.name,
+    workspaceId: dto.workspace_id,
+    expiresAt: dto.expires_at,
+    createdAt: dto.created_at,
+  };
+}
+
+export function toCreatedProvisionerToken(
+  dto: CreateProvisionerTokenResponseDto,
+): CreatedProvisionerToken {
+  return {
+    ...toCreatedManualRegistrationToken(dto),
+    createdByUserId: dto.created_by_user_id,
+    revokedByUserId: dto.revoked_by_user_id,
+    revokedAt: dto.revoked_at,
+    lastSeenAt: dto.last_seen_at,
+    updatedAt: dto.updated_at,
+  };
+}


### PR DESCRIPTION
Converge manual-registration and provisioner token state on package-owned camelCase models at the `@shipfox/client-runners` boundary.

Token UI previously consumed unchecked response DTOs, shaped transport request bodies, and changed React Query caches directly. This moves validation and DTO mapping into the API adapters, provides reusable query options, and makes mutations own cache invalidation so the UI only reports domain commands.

The alternative was to preserve the existing DTO and cache ownership split behind component-level adapters. That would retain the transport leakage and leave future token surfaces without a reusable domain boundary.

The package receives a major changeset because its re-exported hooks now accept domain commands and return domain models. Reviewers should pay particular attention to the one-time token mapping and the provisioner active-state invalidation.

Closes ENG-1135

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converged runner token state to package-owned camelCase models in `@shipfox/client-runners`, validated at the API boundary. Also fixed exported query option declarations to use public TanStack types so packed consumers compile cleanly (ENG-1135).

- **Refactors**
  - Added domain types and helpers in `#core/token` (`ManualRegistrationToken`, `ProvisionerToken`, `ActiveProvisioner`, `Created*`, `createTokenCommand`, `tokenDisplayName`, `provisionerConnectionStatus`).
  - Introduced schema-checked requests via `checkedApiRequest` and `token-mapper` to convert transport DTOs to domain models.
  - Queries now return domain arrays; added `queryOptions` helpers for tokens and active provisioners.
  - Exported query options now use public TanStack Query types (`FetchQueryOptions`, `queryOptions`) to avoid declaration build errors.
  - Mutations accept `CreateTokenCommand` and invalidate caches on success; created responses use `token` instead of `raw_token`.
  - Centralized expiration mapping with `expirationCommand`; tightened generic error copy for unknown errors.

- **Migration**
  - Hooks now require `workspaceId` and domain args:
    - `useCreateManualRegistrationTokenMutation(workspaceId).mutateAsync(command)` and `useRevokeManualRegistrationTokenMutation(workspaceId).mutateAsync(tokenId)` (same for provisioners).
    - Queries return domain arrays: `useManualRegistrationTokensQuery` → `ManualRegistrationToken[]`, `useProvisionerTokensQuery` → `ProvisionerToken[]`, `useActiveProvisionersQuery` → `ActiveProvisioner[]`.
  - Models are camelCase (`createdAt`, `expiresAt`, `lastSeenAt`, etc.); created token responses expose `token`.
  - Stop manually calling `queryClient.invalidateQueries`; adapters handle it.
  - Build create commands with `createTokenCommand(name, expirationCommand(option))`.

<sup>Written for commit 957db75d9774755eceb3066ba93e448b3f831f1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

