### PR TITLE
[client-agent] Add domain-model core for providers and harnesses

### DIFF
--- a/.changeset/tame-otters-converge.md
+++ b/.changeset/tame-otters-converge.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-agent": patch
+---
+
+Adds an internal domain-model core (harnesses, providers, onboarding and management-modal state) and a DTO-to-domain mapper for model providers, ahead of converging the package's scattered provider/model shapes onto it.

--- a/libs/client/agent/src/core/model-provider-management-reducer.ts
+++ b/libs/client/agent/src/core/model-provider-management-reducer.ts
@@ -1,0 +1,65 @@
+import type {BuiltinProviderConfig, CustomProviderConfig, SupportedProvider} from './models.js';
+
+export type ManagementModal =
+  | {readonly kind: 'closed'}
+  | {readonly kind: 'configure-builtin'; readonly provider: SupportedProvider}
+  | {
+      readonly kind: 'edit-builtin';
+      readonly provider: SupportedProvider;
+      readonly config: BuiltinProviderConfig;
+    }
+  | {
+      readonly kind: 'change-default-model';
+      readonly provider: SupportedProvider;
+      readonly config: BuiltinProviderConfig;
+    }
+  | {readonly kind: 'create-custom'}
+  | {readonly kind: 'edit-custom'; readonly config: CustomProviderConfig}
+  | {
+      readonly kind: 'show-usage';
+      readonly providerId: string;
+      readonly initialModel: string | null;
+    };
+
+export type ManagementModalAction =
+  | {readonly type: 'close'}
+  | {readonly type: 'configure-builtin'; readonly provider: SupportedProvider}
+  | {
+      readonly type: 'edit-builtin';
+      readonly provider: SupportedProvider;
+      readonly config: BuiltinProviderConfig;
+    }
+  | {
+      readonly type: 'change-default-model';
+      readonly provider: SupportedProvider;
+      readonly config: BuiltinProviderConfig;
+    }
+  | {readonly type: 'create-custom'}
+  | {readonly type: 'edit-custom'; readonly config: CustomProviderConfig}
+  | {
+      readonly type: 'show-usage';
+      readonly providerId: string;
+      readonly initialModel: string | null;
+    };
+
+export function managementModalReducer(
+  _state: ManagementModal,
+  action: ManagementModalAction,
+): ManagementModal {
+  switch (action.type) {
+    case 'close':
+      return {kind: 'closed'};
+    case 'configure-builtin':
+      return {kind: 'configure-builtin', provider: action.provider};
+    case 'edit-builtin':
+      return {kind: 'edit-builtin', provider: action.provider, config: action.config};
+    case 'change-default-model':
+      return {kind: 'change-default-model', provider: action.provider, config: action.config};
+    case 'create-custom':
+      return {kind: 'create-custom'};
+    case 'edit-custom':
+      return {kind: 'edit-custom', config: action.config};
+    case 'show-usage':
+      return {kind: 'show-usage', providerId: action.providerId, initialModel: action.initialModel};
+  }
+}

--- a/libs/client/agent/src/core/models.ts
+++ b/libs/client/agent/src/core/models.ts
@@ -1,0 +1,85 @@
+export type HarnessId = 'pi' | 'claude';
+export type ProviderApi =
+  | 'openai-completions'
+  | 'openai-responses'
+  | 'anthropic-messages'
+  | 'google-generative-ai';
+
+export interface HarnessDescriptor {
+  readonly id: HarnessId;
+  readonly label: string;
+  readonly description: string;
+  readonly supportedProviderIds: readonly string[];
+}
+
+export interface AgentModel {
+  readonly id: string;
+  readonly label: string;
+  readonly contextWindow?: number | undefined;
+  readonly maxOutputTokens?: number | undefined;
+  readonly inputImage?: boolean | undefined;
+  readonly reasoning?: boolean | undefined;
+}
+
+export interface CredentialField {
+  readonly key: string;
+  readonly label: string;
+  readonly secret: boolean;
+}
+
+export interface SupportedProvider {
+  readonly kind: 'supported';
+  readonly id: string;
+  readonly label: string;
+  readonly defaultModel: string | null;
+  readonly credentialFields: readonly CredentialField[];
+  readonly models: readonly AgentModel[];
+}
+
+export interface UnsupportedProvider {
+  readonly kind: 'unsupported';
+  readonly id: string;
+  readonly label: string;
+  readonly unsupportedReason: string;
+}
+
+export type ProviderCatalogEntry = SupportedProvider | UnsupportedProvider;
+
+export interface BuiltinProviderConfig {
+  readonly kind: 'builtin';
+  readonly providerId: string;
+  readonly defaultModel: string | null;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+export interface ProviderHeader {
+  readonly name: string;
+  readonly value: string;
+}
+
+export interface CustomProviderConfig {
+  readonly kind: 'custom';
+  readonly providerId: string;
+  readonly displayName: string;
+  readonly api: ProviderApi;
+  readonly baseUrl: string;
+  readonly headers: readonly ProviderHeader[];
+  readonly secretHeaderNames: readonly string[];
+  readonly models: readonly AgentModel[];
+  readonly defaultModel: string | null;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+export type ProviderConfig = BuiltinProviderConfig | CustomProviderConfig;
+
+export interface ProviderCatalog {
+  readonly providers: readonly ProviderCatalogEntry[];
+}
+
+export interface ProviderConfiguration {
+  readonly configs: readonly ProviderConfig[];
+  readonly defaultHarnessId: HarnessId | null;
+  readonly defaultProviderId: string | null;
+}

--- a/libs/client/agent/src/core/onboarding-reducer.test.ts
+++ b/libs/client/agent/src/core/onboarding-reducer.test.ts
@@ -1,0 +1,44 @@
+import type {SupportedProvider} from './models.js';
+import {initialOnboardingState, onboardingReducer} from './onboarding-reducer.js';
+
+const provider: SupportedProvider = {
+  kind: 'supported',
+  id: 'anthropic',
+  label: 'Anthropic',
+  defaultModel: 'claude',
+  credentialFields: [],
+  models: [],
+};
+
+test('cannot select a provider before selecting a harness', () => {
+  expect(onboardingReducer(initialOnboardingState, {type: 'provider-selected', provider})).toBe(
+    initialOnboardingState,
+  );
+});
+
+test('back steps back one screen at a time, keeping earlier selections', () => {
+  const choosingProvider = onboardingReducer(initialOnboardingState, {
+    type: 'harness-selected',
+    harnessId: 'claude',
+  });
+  const configuring = onboardingReducer(choosingProvider, {type: 'provider-selected', provider});
+  const saving = onboardingReducer(configuring, {type: 'provider-saved'});
+
+  expect(onboardingReducer(saving, {type: 'back'})).toEqual(configuring);
+  expect(onboardingReducer(configuring, {type: 'back'})).toEqual(choosingProvider);
+  expect(onboardingReducer(choosingProvider, {type: 'back'})).toBe(initialOnboardingState);
+  expect(onboardingReducer(initialOnboardingState, {type: 'back'})).toBe(initialOnboardingState);
+});
+
+test('keeps the selected provider while a default-harness request fails', () => {
+  const choosingProvider = onboardingReducer(initialOnboardingState, {
+    type: 'harness-selected',
+    harnessId: 'claude',
+  });
+  const configuring = onboardingReducer(choosingProvider, {type: 'provider-selected', provider});
+  const saving = onboardingReducer(configuring, {type: 'provider-saved'});
+
+  expect(
+    onboardingReducer(saving, {type: 'default-harness-failed', message: 'Try again.'}),
+  ).toEqual({...saving, error: 'Try again.'});
+});

--- a/libs/client/agent/src/core/onboarding-reducer.ts
+++ b/libs/client/agent/src/core/onboarding-reducer.ts
@@ -1,0 +1,63 @@
+import type {HarnessId, SupportedProvider} from './models.js';
+
+export type OnboardingState =
+  | {readonly step: 'choose-harness'}
+  | {readonly step: 'choose-provider'; readonly harnessId: HarnessId}
+  | {
+      readonly step: 'configure-provider';
+      readonly harnessId: HarnessId;
+      readonly provider: SupportedProvider;
+    }
+  | {
+      readonly step: 'saving-default-harness';
+      readonly harnessId: HarnessId;
+      readonly provider: SupportedProvider;
+      readonly error?: string | undefined;
+    };
+
+export type OnboardingAction =
+  | {readonly type: 'harness-selected'; readonly harnessId: HarnessId}
+  | {readonly type: 'back'}
+  | {readonly type: 'provider-selected'; readonly provider: SupportedProvider}
+  | {readonly type: 'provider-saved'}
+  | {readonly type: 'default-harness-failed'; readonly message: string}
+  | {readonly type: 'default-harness-saved'};
+
+export const initialOnboardingState: OnboardingState = {step: 'choose-harness'};
+
+function goBack(state: OnboardingState): OnboardingState {
+  switch (state.step) {
+    case 'choose-harness':
+      return state;
+    case 'choose-provider':
+      return initialOnboardingState;
+    case 'configure-provider':
+      return {step: 'choose-provider', harnessId: state.harnessId};
+    case 'saving-default-harness':
+      return {step: 'configure-provider', harnessId: state.harnessId, provider: state.provider};
+  }
+}
+
+export function onboardingReducer(
+  state: OnboardingState,
+  action: OnboardingAction,
+): OnboardingState {
+  switch (action.type) {
+    case 'harness-selected':
+      return {step: 'choose-provider', harnessId: action.harnessId};
+    case 'back':
+      return goBack(state);
+    case 'provider-selected':
+      return state.step === 'choose-provider'
+        ? {step: 'configure-provider', harnessId: state.harnessId, provider: action.provider}
+        : state;
+    case 'provider-saved':
+      return state.step === 'configure-provider'
+        ? {step: 'saving-default-harness', harnessId: state.harnessId, provider: state.provider}
+        : state;
+    case 'default-harness-failed':
+      return state.step === 'saving-default-harness' ? {...state, error: action.message} : state;
+    case 'default-harness-saved':
+      return initialOnboardingState;
+  }
+}

--- a/libs/client/agent/src/core/provider-policy.ts
+++ b/libs/client/agent/src/core/provider-policy.ts
@@ -1,0 +1,47 @@
+import type {
+  HarnessDescriptor,
+  ProviderCatalogEntry,
+  ProviderConfig,
+  SupportedProvider,
+} from './models.js';
+
+export function isSupportedProvider(entry: ProviderCatalogEntry): entry is SupportedProvider {
+  return entry.kind === 'supported';
+}
+
+export function supportsProvider(harness: HarnessDescriptor, providerId: string): boolean {
+  return harness.supportedProviderIds.includes(providerId);
+}
+
+export function availableProviders(
+  catalog: readonly ProviderCatalogEntry[],
+  configs: readonly ProviderConfig[],
+): SupportedProvider[] {
+  const configuredIds = new Set(configs.map((config) => config.providerId));
+  return catalog.filter(isSupportedProvider).filter((provider) => !configuredIds.has(provider.id));
+}
+
+export function providerMatchesSearch(entry: SupportedProvider, query: string): boolean {
+  const needle = query.trim().toLocaleLowerCase();
+  if (!needle) return true;
+  const terms = [
+    entry.id,
+    entry.label,
+    ...entry.models.flatMap((model) => [model.id, model.label]),
+  ];
+  return terms.some((term) => term.toLocaleLowerCase().includes(needle));
+}
+
+export function deriveProviderSlug(displayName: string): string {
+  return displayName
+    .trim()
+    .toLocaleLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+const PROVIDER_SLUG_RE = /^[a-z][a-z0-9-]{1,62}$/;
+
+export function isProviderSlugValid(slug: string): boolean {
+  return PROVIDER_SLUG_RE.test(slug);
+}

--- a/libs/client/agent/src/hooks/api/model-provider-mapper.test.ts
+++ b/libs/client/agent/src/hooks/api/model-provider-mapper.test.ts
@@ -1,0 +1,27 @@
+import {
+  modelProviderCatalogResponse,
+  modelProviderConfigsResponse,
+  modelProviderEntry,
+} from '#test/fixtures/model-providers.js';
+import {toProviderCatalog, toProviderConfiguration} from './model-provider-mapper.js';
+
+test('maps provider catalog entries before they reach the client domain', () => {
+  const catalog = toProviderCatalog(modelProviderCatalogResponse([modelProviderEntry()]));
+
+  expect(catalog.providers).toEqual([
+    expect.objectContaining({
+      kind: 'supported',
+      defaultModel: null,
+      credentialFields: [{key: 'api_key', label: 'API key', secret: true}],
+    }),
+  ]);
+});
+
+test('maps configuration response defaults and provider config fields', () => {
+  const configuration = toProviderConfiguration(modelProviderConfigsResponse());
+
+  expect(configuration.defaultProviderId).toBe('anthropic');
+  expect(configuration.configs[0]).toEqual(
+    expect.objectContaining({providerId: 'anthropic', defaultModel: null}),
+  );
+});

--- a/libs/client/agent/src/hooks/api/model-provider-mapper.ts
+++ b/libs/client/agent/src/hooks/api/model-provider-mapper.ts
@@ -1,0 +1,104 @@
+import type {
+  CustomModelProviderConfigDto,
+  ListModelProviderConfigsResponseDto,
+  ModelProviderCatalogEntryDto,
+  ModelProviderCatalogResponseDto,
+  ModelProviderConfigDto,
+  ModelProviderConfigResponseDto,
+} from '@shipfox/api-agent-dto';
+import type {
+  AgentModel,
+  BuiltinProviderConfig,
+  CustomProviderConfig,
+  ProviderCatalog,
+  ProviderCatalogEntry,
+  ProviderConfig,
+  ProviderConfiguration,
+} from '#core/models.js';
+
+export function toProviderCatalog(response: ModelProviderCatalogResponseDto): ProviderCatalog {
+  return {providers: response.providers.map(toProviderCatalogEntry)};
+}
+
+export function toProviderCatalogEntry(entry: ModelProviderCatalogEntryDto): ProviderCatalogEntry {
+  if (entry.support_status === 'unsupported') {
+    return {
+      kind: 'unsupported',
+      id: entry.id,
+      label: entry.label,
+      unsupportedReason: entry.unsupported_reason ?? 'Unsupported provider',
+    };
+  }
+  return {
+    kind: 'supported',
+    id: entry.id,
+    label: entry.label,
+    defaultModel: entry.default_model,
+    credentialFields: entry.credential_fields.map((field) => ({
+      key: field.key,
+      label: field.label,
+      secret: field.secret,
+    })),
+    models: entry.models.map(toAgentModel),
+  };
+}
+
+export function toProviderConfiguration(
+  response: ListModelProviderConfigsResponseDto,
+): ProviderConfiguration {
+  return {
+    configs: response.configs.map(toProviderConfig),
+    defaultHarnessId: response.default_harness_id,
+    defaultProviderId: response.default_provider_id,
+  };
+}
+
+export function toProviderConfig(config: ModelProviderConfigResponseDto): ProviderConfig {
+  return config.kind === 'builtin'
+    ? toBuiltinProviderConfig(config)
+    : toCustomProviderConfig(config);
+}
+
+export function toBuiltinProviderConfig(config: ModelProviderConfigDto): BuiltinProviderConfig {
+  return {
+    kind: 'builtin',
+    providerId: config.provider_id,
+    defaultModel: config.default_model,
+    createdAt: config.created_at,
+    updatedAt: config.updated_at,
+  };
+}
+
+export function toCustomProviderConfig(config: CustomModelProviderConfigDto): CustomProviderConfig {
+  return {
+    kind: 'custom',
+    providerId: config.provider_id,
+    displayName: config.display_name,
+    api: config.api,
+    baseUrl: config.base_url,
+    headers: config.headers.map((header) => ({name: header.name, value: header.value})),
+    secretHeaderNames: config.secret_header_names,
+    models: config.models.map(toAgentModel),
+    defaultModel: config.default_model,
+    createdAt: config.created_at,
+    updatedAt: config.updated_at,
+  };
+}
+
+function toAgentModel(model: {
+  id: string;
+  label: string;
+  context_window?: number | undefined;
+  max_output_tokens?: number | undefined;
+  input_image?: boolean | undefined;
+  reasoning?: boolean | undefined;
+}): AgentModel {
+  return {
+    id: model.id,
+    label: model.label,
+    ...(model.context_window === undefined ? {} : {contextWindow: model.context_window}),
+    ...(model.max_output_tokens === undefined ? {} : {maxOutputTokens: model.max_output_tokens}),
+    ...(model.input_image === undefined ? {} : {inputImage: model.input_image}),
+    ...(model.reasoning === undefined ? {} : {reasoning: model.reasoning}),
+  };
+}


### PR DESCRIPTION
Introduces `libs/client/agent/src/core` as the shared, DB/DTO-agnostic domain model for harnesses, model providers, and their catalogs: shared types (`models.ts`), pure state machines for the onboarding flow and the management-modal flow, and provider policy helpers (slug derivation, search matching, availability filtering). Also adds `hooks/api/model-provider-mapper.ts` to translate the wire DTOs (snake_case) into these camelCase domain types, keeping that conversion centralized per the package's DTO conventions.

The agent package currently has several ad hoc provider/model shapes scattered across its components and hooks. This lays the canonical domain model down first so follow-up PRs can converge the existing code onto it incrementally, rather than one large rewrite.

None of this is wired into the existing components yet - `core/*` and the new mapper have no consumers in this PR, so there's no behavior change. Follow-up PRs will migrate `model-providers.ts`, the onboarding page, and the management-modal components onto these types.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared domain model for harnesses and model providers, plus reducers and policy helpers, to unify provider/model shapes in `@shipfox/client-agent`. Centralizes mapping from `@shipfox/api-agent-dto` to camelCase domain types; no UI wiring yet.

- **New Features**
  - Core types for harnesses, catalogs, provider configs, and agent models.
  - Pure reducers for onboarding and the management modal, with onboarding tests.
  - Provider policy helpers: slug derivation, search matching, availability filtering.
  - DTO→domain mapper for catalog/config responses, with tests.

<sup>Written for commit 29a56d91908b76fa4d767d251545059c40da2d75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

