### PR TITLE
[api/server] Expose composed Workspaces module extension

### DIFF
--- a/.changeset/bright-pandas-compose.md
+++ b/.changeset/bright-pandas-compose.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-server": minor
+---
+
+Adds a default-module extension factory with the composed Workspaces inter-module client.

--- a/libs/api/server/README.md
+++ b/libs/api/server/README.md
@@ -24,6 +24,15 @@ import {defaultModules, runServer} from '@shipfox/api-server';
 await runServer({modules: await defaultModules()});
 ```
 
+To add a module that creates sessions, use the composed Workspaces client rather
+than creating another inter-module transport:
+
+```ts
+const modules = await defaultModules({
+  extension: ({workspaces}) => [createCloudModule({workspaces})],
+});
+```
+
 Load the instrumentation entry before feature modules:
 
 ```sh

--- a/libs/api/server/src/index.ts
+++ b/libs/api/server/src/index.ts
@@ -1,4 +1,5 @@
 export {
+  type DefaultModulesExtension,
   type DefaultModulesOptions,
   type DefaultRunnersModuleFactory,
   defaultModules,

--- a/libs/api/server/src/modules.test.ts
+++ b/libs/api/server/src/modules.test.ts
@@ -10,7 +10,10 @@ import {
   secretsInterModuleContract,
 } from '@shipfox/api-secrets-dto/inter-module';
 import {workflowsInterModuleContract} from '@shipfox/api-workflows-dto/inter-module';
-import {workspacesInterModuleContract} from '@shipfox/api-workspaces-dto/inter-module';
+import {
+  type WorkspacesInterModuleClient,
+  workspacesInterModuleContract,
+} from '@shipfox/api-workspaces-dto/inter-module';
 import {defineInterModulePresentation} from '@shipfox/inter-module';
 import {defaultModules} from './modules.js';
 
@@ -30,6 +33,7 @@ const mocks = vi.hoisted(() => ({
   deleteSecrets: vi.fn(),
   getIntegrationConnectionById: vi.fn(),
   getSecret: vi.fn(),
+  listMembershipsForTokenClaims: vi.fn(),
   setSecrets: vi.fn(),
 }));
 
@@ -96,7 +100,7 @@ vi.mock('@shipfox/api-workspaces', () => ({
       {
         contract: workspacesInterModuleContract,
         handlers: {
-          listMembershipsForTokenClaims: vi.fn(),
+          listMembershipsForTokenClaims: mocks.listMembershipsForTokenClaims,
           preflightInvitationAcceptance: vi.fn(),
           acceptInvitation: vi.fn(),
           requireActiveMembership: vi.fn(),
@@ -123,6 +127,7 @@ describe('defaultModules', () => {
     mocks.deleteSecrets.mockReset();
     mocks.getIntegrationConnectionById.mockReset();
     mocks.getSecret.mockReset();
+    mocks.listMembershipsForTokenClaims.mockReset();
     mocks.setSecrets.mockReset();
 
     mocks.createIntegrationsContext.mockResolvedValue({
@@ -147,6 +152,7 @@ describe('defaultModules', () => {
     mocks.createWorkspaceConnectionSnapshotLoader.mockReturnValue(vi.fn());
     mocks.deleteSecrets.mockResolvedValue({deleted: 1});
     mocks.getSecret.mockResolvedValue({value: 'secret'});
+    mocks.listMembershipsForTokenClaims.mockResolvedValue({memberships: []});
     mocks.setSecrets.mockResolvedValue({});
     mocks.createProjectsModule.mockReturnValue({
       name: 'projects',
@@ -290,6 +296,27 @@ describe('defaultModules', () => {
       'triggers',
       'dispatcher',
     ]);
+  });
+
+  it('extends the default module list with the composed Workspaces client', async () => {
+    let workspaces: WorkspacesInterModuleClient | undefined;
+    const extensionModule = {name: 'cloud'};
+    const extension = vi.fn((options: {workspaces: WorkspacesInterModuleClient}) => {
+      workspaces = options.workspaces;
+      return [extensionModule];
+    });
+
+    const modules = await defaultModules({extension});
+    const userId = crypto.randomUUID();
+    const memberships = await workspaces?.listMembershipsForTokenClaims({userId});
+
+    expect(extension).toHaveBeenCalledWith({workspaces: expect.any(Object)});
+    expect(memberships).toEqual({memberships: []});
+    expect(mocks.listMembershipsForTokenClaims).toHaveBeenCalledWith(
+      {userId},
+      expect.objectContaining({signal: expect.any(AbortSignal)}),
+    );
+    expect(modules.at(-1)).toBe(extensionModule);
   });
 
   it('injects Workflows into integrations and logs and namespaces provider secrets', async () => {

--- a/libs/api/server/src/modules.ts
+++ b/libs/api/server/src/modules.ts
@@ -25,7 +25,10 @@ import {createTriggersModule} from '@shipfox/api-triggers';
 import {createWorkflowsModule} from '@shipfox/api-workflows';
 import {workflowsInterModuleContract} from '@shipfox/api-workflows-dto/inter-module';
 import {workspacesModule} from '@shipfox/api-workspaces';
-import {workspacesInterModuleContract} from '@shipfox/api-workspaces-dto/inter-module';
+import {
+  type WorkspacesInterModuleClient,
+  workspacesInterModuleContract,
+} from '@shipfox/api-workspaces-dto/inter-module';
 import {reportError} from '@shipfox/node-error-monitoring';
 import {durationToSeconds} from '@shipfox/node-jwt';
 import type {ShipfoxModule} from '@shipfox/node-module';
@@ -38,9 +41,13 @@ import {logger} from '@shipfox/node-opentelemetry';
 export interface DefaultModulesOptions {
   webhookDeliverySource?: WebhookDeliverySource | undefined;
   runnersModule?: DefaultRunnersModuleFactory | undefined;
+  extension?: DefaultModulesExtension | undefined;
 }
 
 export type DefaultRunnersModuleFactory = (options: {auth: AuthInterModuleClient}) => ShipfoxModule;
+export type DefaultModulesExtension = (options: {
+  workspaces: WorkspacesInterModuleClient;
+}) => ShipfoxModule[];
 
 export async function defaultModules(
   options: DefaultModulesOptions = {},
@@ -154,6 +161,7 @@ export async function defaultModules(
     agent: agentClient,
     integrations: integrationsClient,
   });
+  const extensionModules = options.extension?.({workspaces: workspacesClient}) ?? [];
 
   const modules = [
     emailChallengesModule,
@@ -182,6 +190,7 @@ export async function defaultModules(
     }),
     createTriggersModule({workflows: workflowsClient}),
     dispatcherModule,
+    ...extensionModules,
   ];
   registerInterModulePresentations({transport: interModuleTransport, modules});
   interModuleTransport.seal();


### PR DESCRIPTION
Expose the server-composed Workspaces inter-module client to optional default-module extensions.

Cloud social login needs this client when it creates a session so the first access token includes the user's existing memberships. Previously, a module appended by Cloud could only import platform internals or create a disconnected transport.

The extension remains provider-neutral and joins the normal module list before all presentations are registered and the transport is sealed. It is documented, exported as a public type, and released as a minor `@shipfox/api-server` change.

The affected-package test run retains a pre-existing timeout in `auth-token-interoperability.test.ts`, reproduced from `origin/main`; the new extension coverage passes in that run.

Closes ENG-1151

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose the composed Workspaces inter-module client to optional `defaultModules` extensions so Cloud auth can create first sessions with existing memberships. Adds an `extension` hook to `defaultModules` and ships a minor `@shipfox/api-server` release (meets ENG-1151).

- **New Features**
  - Add `extension` option to `defaultModules`, providing `{workspaces}` to extension factories; modules append before presentations register and the transport seals.
  - Export `DefaultModulesExtension` from `@shipfox/api-server`.
  - Document usage with a README example for session-creating modules.
  - Tests cover the extension and Workspaces client wiring (including AbortSignal propagation).

<sup>Written for commit 1b769ab75bc7d71e47532dada90676a50d04c5f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

