### PR TITLE
[client-invitations] Fix packed query declarations

### DIFF
--- a/.changeset/quiet-otters-fix.md
+++ b/.changeset/quiet-otters-fix.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-invitations": patch
+---
+
+Fixes invitation query declarations for packed TypeScript consumers.

--- a/libs/client/invitations/src/hooks/api/preview-invitation.ts
+++ b/libs/client/invitations/src/hooks/api/preview-invitation.ts
@@ -1,11 +1,18 @@
 import {previewInvitationResponseSchema} from '@shipfox/api-workspaces-dto';
 import {checkedApiRequest} from '@shipfox/client-api';
-import {queryOptions, useQuery} from '@tanstack/react-query';
+import {type FetchQueryOptions, queryOptions, useQuery} from '@tanstack/react-query';
 import type {InvitationPreview} from '#core/invitation-preview.js';
 import {toInvitationPreview} from './invitation-preview-mapper.js';
 
 export const previewInvitationQueryKey = (token: string) =>
   ['invitations', 'preview', token] as const;
+
+type PreviewInvitationQueryOptions = FetchQueryOptions<
+  InvitationPreview,
+  Error,
+  InvitationPreview,
+  ReturnType<typeof previewInvitationQueryKey>
+>;
 
 async function previewInvitation(token: string): Promise<InvitationPreview> {
   const params = new URLSearchParams({token});
@@ -16,7 +23,7 @@ async function previewInvitation(token: string): Promise<InvitationPreview> {
   return toInvitationPreview(response);
 }
 
-export function previewInvitationQueryOptions(token: string) {
+export function previewInvitationQueryOptions(token: string): PreviewInvitationQueryOptions {
   return queryOptions({
     queryKey: previewInvitationQueryKey(token),
     queryFn: () => previewInvitation(token),


### PR DESCRIPTION
Fixes the exported invitation query-options declaration for packed TypeScript consumers.

TanStack Query tags inferred query keys with internal unique symbols. The prior inferred return type emitted those symbols without imports, so a consumer compiling the published tarball failed with missing `dataTagSymbol` declarations. The helper now exposes the public `FetchQueryOptions` type while keeping the runtime query behavior unchanged.

An explicit type import was considered, but constraining the exported contract avoids leaking TanStack implementation details into the package declaration surface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the exported query options type for invitation preview so TypeScript consumers of the packed `@shipfox/client-invitations` build no longer hit missing `dataTagSymbol` errors. Switches the return type to the public `FetchQueryOptions` from `@tanstack/react-query`, with runtime behavior unchanged.

<sup>Written for commit f7e0adf9d80e3f22b00ee470bab2342b8dc582ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

