### PR TITLE
[client-projects] Converge Projects on domain models

### DIFF
--- a/.changeset/bright-projects-converge.md
+++ b/.changeset/bright-projects-converge.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/client-projects": minor
+"@shipfox/client-workflows": patch
+---
+
+Adds checked Projects domain models and resource-owned query cache policy.

--- a/libs/client/onboarding/src/workspace-setup-route.test.tsx
+++ b/libs/client/onboarding/src/workspace-setup-route.test.tsx
@@ -181,7 +181,17 @@ function GuardedRoute({label}: {label: string}) {
 }
 
 function projectStub() {
-  return {id: 'project-1', workspace_id: WORKSPACE_ID, name: 'Platform'};
+  return {
+    id: '22222222-2222-4222-8222-222222222222',
+    workspace_id: WORKSPACE_ID,
+    name: 'Platform',
+    source: {
+      connection_id: '33333333-3333-4333-8333-333333333333',
+      external_repository_id: 'platform',
+    },
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  };
 }
 
 function modelProviderConfig() {
@@ -241,7 +251,7 @@ describe('workspace setup route hook', () => {
       seedQueryClient: (queryClient) => {
         queryClient.setQueryData(projectExistenceQueryOptions(WORKSPACE_ID).queryKey, {
           projects: [projectStub()] as never,
-          next_cursor: null,
+          nextCursor: null,
         });
         // Existence has a freshness window, so explicit invalidation forces the
         // refetch whose failure exercises the cached fallback.
@@ -480,7 +490,7 @@ describe('workspace setup route hook', () => {
     projects = [projectStub()];
     queryClient.setQueryData(
       projectExistenceQueryOptions(WORKSPACE_ID).queryKey,
-      {projects: [], next_cursor: null},
+      {projects: [], nextCursor: null},
       {updatedAt: Date.now() - 31_000},
     );
 

--- a/libs/client/projects/src/chrome.tsx
+++ b/libs/client/projects/src/chrome.tsx
@@ -18,9 +18,9 @@ export function ProjectLayoutGuard() {
   const navigate = useNavigate();
   const project = useProjectQuery(pid).data;
   useEffect(() => {
-    if (project && project.workspace_id !== wid)
+    if (project && project.workspaceId !== wid)
       void navigate({to: '/workspaces/$wid', params: {wid}, replace: true});
   }, [navigate, project, wid]);
-  if (project && project.workspace_id !== wid) return null;
+  if (project && project.workspaceId !== wid) return null;
   return <Outlet />;
 }

--- a/libs/client/projects/src/components/project-switcher.test.tsx
+++ b/libs/client/projects/src/components/project-switcher.test.tsx
@@ -8,6 +8,7 @@ import {
   RouterProvider,
 } from '@tanstack/react-router';
 import {fireEvent, render, screen} from '@testing-library/react';
+import {toProject} from '#hooks/api/mappers.js';
 import {projectsQueryKeys} from '#hooks/api/projects.js';
 import {PROJECT_TEST_WID} from '#test/pages.js';
 import {ProjectSwitcher} from './project-switcher.js';
@@ -50,7 +51,7 @@ function renderProjectSwitcher({
     defaultOptions: {queries: {retry: false, staleTime: Number.POSITIVE_INFINITY}},
   });
   queryClient.setQueryData(projectsQueryKeys.list(PROJECT_TEST_WID), {
-    pages: [{projects, next_cursor: null}],
+    pages: [{projects: projects.map(toProject), nextCursor: null}],
     pageParams: [undefined],
   });
   const rootRoute = createRootRoute({component: Outlet});

--- a/libs/client/projects/src/components/source-strip.tsx
+++ b/libs/client/projects/src/components/source-strip.tsx
@@ -1,4 +1,3 @@
-import type {DefinitionSyncSummaryDto} from '@shipfox/api-definitions-dto';
 import {useActiveWorkspace} from '@shipfox/client-auth';
 import {useSourceConnectionsQuery} from '@shipfox/client-integrations';
 import {StatusBadge} from '@shipfox/react-ui/badge';
@@ -6,6 +5,7 @@ import {Icon, type IconName} from '@shipfox/react-ui/icon';
 import {Skeleton} from '@shipfox/react-ui/skeleton';
 import {Tooltip, TooltipContent, TooltipTrigger} from '@shipfox/react-ui/tooltip';
 import {Code, Text} from '@shipfox/react-ui/typography';
+import type {DefinitionSyncSummary} from '#core/definition.js';
 
 /**
  * We cannot cheaply resolve `external_repository_id` → `owner/repo`
@@ -21,7 +21,7 @@ export function SourceStrip({
 }: {
   connectionId: string;
   externalRepositoryId: string;
-  sync: DefinitionSyncSummaryDto | null | undefined;
+  sync: DefinitionSyncSummary | null | undefined;
   isPending: boolean;
 }) {
   const workspace = useActiveWorkspace();
@@ -69,7 +69,7 @@ function SyncBadge({
   sync,
   isPending,
 }: {
-  sync: DefinitionSyncSummaryDto | null | undefined;
+  sync: DefinitionSyncSummary | null | undefined;
   isPending: boolean;
 }) {
   if (isPending) return <StatusBadge variant="neutral">Loading</StatusBadge>;

--- a/libs/client/projects/src/core/definition.ts
+++ b/libs/client/projects/src/core/definition.ts
@@ -1,0 +1,31 @@
+export interface Definition {
+  id: string;
+  projectId: string;
+  configPath: string | null;
+  source: 'manual' | 'vcs';
+  sha: string | null;
+  ref: string | null;
+  name: string;
+  workflowDocument: unknown;
+  workflowModel: unknown;
+  manualTrigger: {name: string} | null;
+  fetchedAt: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface DefinitionSyncSummary {
+  ref: string | null;
+  status: 'pending' | 'syncing' | 'succeeded' | 'failed';
+  lastSyncAt: string;
+  startedAt: string | null;
+  finishedAt: string | null;
+  lastErrorCode: string | null;
+  lastErrorMessage: string | null;
+}
+
+export interface DefinitionList {
+  definitions: Definition[];
+  sync: DefinitionSyncSummary | null;
+  nextCursor: string | null;
+}

--- a/libs/client/projects/src/core/project.ts
+++ b/libs/client/projects/src/core/project.ts
@@ -1,0 +1,47 @@
+export interface ProjectSource {
+  connectionId: string;
+  externalRepositoryId: string;
+}
+
+export interface Project {
+  id: string;
+  workspaceId: string;
+  name: string;
+  source: ProjectSource;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ProjectList {
+  projects: Project[];
+  nextCursor: string | null;
+}
+
+export interface CreateProjectCommand {
+  workspaceId: string;
+  name: string;
+  source: ProjectSource;
+}
+
+const REPOSITORY_NAME_SPLIT_RE = /[/-]/;
+
+export function projectNameFromRepository(repositoryId: string): string {
+  return repositoryId
+    .trim()
+    .split(REPOSITORY_NAME_SPLIT_RE)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+export function selectProjectSource<T extends {externalRepositoryId: string}>(
+  repositories: T[],
+  selectedRepositoryId: string | undefined,
+): T | undefined {
+  if (selectedRepositoryId) {
+    return repositories.find(
+      (repository) => repository.externalRepositoryId === selectedRepositoryId,
+    );
+  }
+  return repositories[0];
+}

--- a/libs/client/projects/src/hooks/api/definitions.ts
+++ b/libs/client/projects/src/hooks/api/definitions.ts
@@ -1,12 +1,13 @@
-import type {DefinitionListResponseDto} from '@shipfox/api-definitions-dto';
-import {apiRequest} from '@shipfox/client-api';
-import {keepPreviousData, useInfiniteQuery, useQuery} from '@tanstack/react-query';
+import {definitionListResponseSchema} from '@shipfox/api-definitions-dto';
+import {checkedApiRequest} from '@shipfox/client-api';
+import {keepPreviousData, queryOptions, useInfiniteQuery, useQuery} from '@tanstack/react-query';
+import type {DefinitionList} from '#core/definition.js';
+import {toDefinitionList} from './mappers.js';
 
 export const definitionsQueryKeys = {
   all: ['definitions'] as const,
   list: (projectId: string) => [...definitionsQueryKeys.all, 'list', projectId] as const,
 };
-
 export async function listDefinitions({
   projectId,
   limit = 50,
@@ -16,35 +17,41 @@ export async function listDefinitions({
   projectId: string;
   limit?: number;
   cursor?: string | undefined;
-  signal?: AbortSignal;
-}) {
+  signal?: AbortSignal | undefined;
+}): Promise<DefinitionList> {
   const params = new URLSearchParams({project_id: projectId, limit: String(limit)});
   if (cursor) params.set('cursor', cursor);
-  return await apiRequest<DefinitionListResponseDto>(`/definitions?${params.toString()}`, {
-    signal,
-  });
+  return toDefinitionList(
+    await checkedApiRequest(definitionListResponseSchema, `/definitions?${params.toString()}`, {
+      signal,
+    }),
+  );
 }
-
-export function useDefinitionsInfiniteQuery(projectId: string | undefined, limit = 50) {
-  return useInfiniteQuery({
+export function definitionsInfiniteQueryOptions(projectId: string | undefined, limit = 50) {
+  return {
     queryKey: projectId
       ? definitionsQueryKeys.list(projectId)
-      : [...definitionsQueryKeys.all, 'list'],
+      : ([...definitionsQueryKeys.all, 'list'] as const),
     enabled: Boolean(projectId),
     initialPageParam: undefined as string | undefined,
-    queryFn: ({pageParam, signal}) =>
+    queryFn: ({pageParam, signal}: {pageParam: string | undefined; signal: AbortSignal}) =>
       listDefinitions({projectId: projectId ?? '', limit, cursor: pageParam, signal}),
-    getNextPageParam: (lastPage) => lastPage.next_cursor ?? undefined,
+    getNextPageParam: (lastPage: DefinitionList) => lastPage.nextCursor ?? undefined,
     placeholderData: keepPreviousData,
-  });
+  };
 }
-
-export function useDefinitionsQuery(projectId: string | undefined) {
-  return useQuery({
+export function definitionsQueryOptions(projectId: string | undefined) {
+  return queryOptions({
     queryKey: projectId
       ? definitionsQueryKeys.list(projectId)
-      : [...definitionsQueryKeys.all, 'list'],
+      : ([...definitionsQueryKeys.all, 'list'] as const),
     enabled: Boolean(projectId),
     queryFn: ({signal}) => listDefinitions({projectId: projectId ?? '', signal}),
   });
+}
+export function useDefinitionsInfiniteQuery(projectId: string | undefined, limit = 50) {
+  return useInfiniteQuery(definitionsInfiniteQueryOptions(projectId, limit));
+}
+export function useDefinitionsQuery(projectId: string | undefined) {
+  return useQuery(definitionsQueryOptions(projectId));
 }

--- a/libs/client/projects/src/hooks/api/definitions.ts
+++ b/libs/client/projects/src/hooks/api/definitions.ts
@@ -1,6 +1,14 @@
 import {definitionListResponseSchema} from '@shipfox/api-definitions-dto';
 import {checkedApiRequest} from '@shipfox/client-api';
-import {keepPreviousData, queryOptions, useInfiniteQuery, useQuery} from '@tanstack/react-query';
+import {
+  type InfiniteData,
+  keepPreviousData,
+  queryOptions,
+  type UseInfiniteQueryOptions,
+  type UseQueryOptions,
+  useInfiniteQuery,
+  useQuery,
+} from '@tanstack/react-query';
 import type {DefinitionList} from '#core/definition.js';
 import {toDefinitionList} from './mappers.js';
 
@@ -8,6 +16,23 @@ export const definitionsQueryKeys = {
   all: ['definitions'] as const,
   list: (projectId: string) => [...definitionsQueryKeys.all, 'list', projectId] as const,
 };
+
+type DefinitionListQueryKey =
+  | ReturnType<typeof definitionsQueryKeys.list>
+  | readonly ['definitions', 'list'];
+type DefinitionListInfiniteQueryOptions = UseInfiniteQueryOptions<
+  DefinitionList,
+  Error,
+  InfiniteData<DefinitionList, string | undefined>,
+  DefinitionListQueryKey,
+  string | undefined
+>;
+type DefinitionListQueryOptions = UseQueryOptions<
+  DefinitionList,
+  Error,
+  DefinitionList,
+  DefinitionListQueryKey
+>;
 export async function listDefinitions({
   projectId,
   limit = 50,
@@ -27,7 +52,10 @@ export async function listDefinitions({
     }),
   );
 }
-export function definitionsInfiniteQueryOptions(projectId: string | undefined, limit = 50) {
+export function definitionsInfiniteQueryOptions(
+  projectId: string | undefined,
+  limit = 50,
+): DefinitionListInfiniteQueryOptions {
   return {
     queryKey: projectId
       ? definitionsQueryKeys.list(projectId)
@@ -40,7 +68,7 @@ export function definitionsInfiniteQueryOptions(projectId: string | undefined, l
     placeholderData: keepPreviousData,
   };
 }
-export function definitionsQueryOptions(projectId: string | undefined) {
+export function definitionsQueryOptions(projectId: string | undefined): DefinitionListQueryOptions {
   return queryOptions({
     queryKey: projectId
       ? definitionsQueryKeys.list(projectId)

--- a/libs/client/projects/src/hooks/api/mappers.ts
+++ b/libs/client/projects/src/hooks/api/mappers.ts
@@ -1,0 +1,67 @@
+import type {DefinitionDto, DefinitionSyncSummaryDto} from '@shipfox/api-definitions-dto';
+import type {ProjectResponseDto} from '@shipfox/api-projects-dto';
+import type {Definition, DefinitionList, DefinitionSyncSummary} from '#core/definition.js';
+import type {Project, ProjectList} from '#core/project.js';
+
+export function toProject(dto: ProjectResponseDto): Project {
+  return {
+    id: dto.id,
+    workspaceId: dto.workspace_id,
+    name: dto.name,
+    source: {
+      connectionId: dto.source.connection_id,
+      externalRepositoryId: dto.source.external_repository_id,
+    },
+    createdAt: dto.created_at,
+    updatedAt: dto.updated_at,
+  };
+}
+
+export function toProjectList(dto: {
+  projects: ProjectResponseDto[];
+  next_cursor: string | null;
+}): ProjectList {
+  return {projects: dto.projects.map(toProject), nextCursor: dto.next_cursor};
+}
+
+export function toDefinition(dto: DefinitionDto): Definition {
+  return {
+    id: dto.id,
+    projectId: dto.project_id,
+    configPath: dto.config_path,
+    source: dto.source,
+    sha: dto.sha,
+    ref: dto.ref,
+    name: dto.name,
+    workflowDocument: dto.workflow_document,
+    workflowModel: dto.workflow_model,
+    manualTrigger: dto.manual_trigger,
+    fetchedAt: dto.fetched_at,
+    createdAt: dto.created_at,
+    updatedAt: dto.updated_at,
+  };
+}
+
+export function toDefinitionSyncSummary(dto: DefinitionSyncSummaryDto): DefinitionSyncSummary {
+  return {
+    ref: dto.ref,
+    status: dto.status,
+    lastSyncAt: dto.last_sync_at,
+    startedAt: dto.started_at,
+    finishedAt: dto.finished_at,
+    lastErrorCode: dto.last_error_code,
+    lastErrorMessage: dto.last_error_message,
+  };
+}
+
+export function toDefinitionList(dto: {
+  definitions: DefinitionDto[];
+  sync: DefinitionSyncSummaryDto | null;
+  next_cursor: string | null;
+}): DefinitionList {
+  return {
+    definitions: dto.definitions.map(toDefinition),
+    sync: dto.sync && toDefinitionSyncSummary(dto.sync),
+    nextCursor: dto.next_cursor,
+  };
+}

--- a/libs/client/projects/src/hooks/api/projects.test.ts
+++ b/libs/client/projects/src/hooks/api/projects.test.ts
@@ -59,11 +59,11 @@ describe('createProject', () => {
     });
     configureApiClient({fetchImpl});
     const body = {
-      workspace_id: '11111111-1111-4111-8111-111111111111',
+      workspaceId: '11111111-1111-4111-8111-111111111111',
       name: 'Platform',
       source: {
-        connection_id: '33333333-3333-4333-8333-333333333333',
-        external_repository_id: 'platform',
+        connectionId: '33333333-3333-4333-8333-333333333333',
+        externalRepositoryId: 'platform',
       },
     };
 
@@ -73,6 +73,13 @@ describe('createProject', () => {
     expect(result.name).toBe('Platform');
     expect(request.url).toBe('https://api.example.test/projects');
     expect(request.method).toBe('POST');
-    expect(requestBody).toEqual(body);
+    expect(requestBody).toEqual({
+      workspace_id: body.workspaceId,
+      name: body.name,
+      source: {
+        connection_id: body.source.connectionId,
+        external_repository_id: body.source.externalRepositoryId,
+      },
+    });
   });
 });

--- a/libs/client/projects/src/hooks/api/projects.ts
+++ b/libs/client/projects/src/hooks/api/projects.ts
@@ -1,32 +1,27 @@
-import type {
-  CreateProjectBodyDto,
-  ListProjectsResponseDto,
-  ProjectResponseDto,
-} from '@shipfox/api-projects-dto';
-import {apiRequest} from '@shipfox/client-api';
 import {
-  type FetchQueryOptions,
+  createProjectBodySchema,
+  listProjectsResponseSchema,
+  projectResponseSchema,
+} from '@shipfox/api-projects-dto';
+import {checkedApiRequest} from '@shipfox/client-api';
+import {
   keepPreviousData,
   queryOptions,
   useInfiniteQuery,
   useMutation,
   useQuery,
+  useQueryClient,
 } from '@tanstack/react-query';
+import type {CreateProjectCommand, Project, ProjectList} from '#core/project.js';
+import {toProject, toProjectList} from './mappers.js';
 
 export const projectsQueryKeys = {
   all: ['projects'] as const,
-  list: (workspaceId: string, search?: string) =>
-    [...projectsQueryKeys.all, 'list', workspaceId, search ?? ''] as const,
+  list: (workspaceId: string, search = '') =>
+    [...projectsQueryKeys.all, 'list', workspaceId, search] as const,
   exists: (workspaceId: string) => [...projectsQueryKeys.all, 'exists', workspaceId] as const,
   detail: (projectId: string) => [...projectsQueryKeys.all, 'detail', projectId] as const,
 };
-
-type ProjectExistenceQueryOptions = FetchQueryOptions<
-  ListProjectsResponseDto,
-  Error,
-  ListProjectsResponseDto,
-  ReturnType<typeof projectsQueryKeys.exists>
->;
 
 export async function listProjects({
   workspaceId,
@@ -39,28 +34,77 @@ export async function listProjects({
   limit?: number;
   cursor?: string | undefined;
   search?: string | undefined;
-  signal?: AbortSignal;
-}) {
+  signal?: AbortSignal | undefined;
+}): Promise<ProjectList> {
   const params = new URLSearchParams({workspace_id: workspaceId, limit: String(limit)});
   if (cursor) params.set('cursor', cursor);
   if (search) params.set('search', search);
-
-  return await apiRequest<ListProjectsResponseDto>(`/projects?${params.toString()}`, {signal});
+  return toProjectList(
+    await checkedApiRequest(listProjectsResponseSchema, `/projects?${params.toString()}`, {signal}),
+  );
 }
 
-export async function getProject(projectId: string) {
-  return await apiRequest<ProjectResponseDto>(`/projects/${projectId}`);
+export async function getProject(projectId: string): Promise<Project> {
+  return toProject(await checkedApiRequest(projectResponseSchema, `/projects/${projectId}`));
 }
 
-export async function createProject(body: CreateProjectBodyDto) {
-  return await apiRequest<ProjectResponseDto>('/projects', {method: 'POST', body});
+export async function createProject(command: CreateProjectCommand): Promise<Project> {
+  const body = createProjectBodySchema.parse({
+    workspace_id: command.workspaceId,
+    name: command.name,
+    source: {
+      connection_id: command.source.connectionId,
+      external_repository_id: command.source.externalRepositoryId,
+    },
+  });
+  return toProject(
+    await checkedApiRequest(projectResponseSchema, '/projects', {method: 'POST', body}),
+  );
 }
 
-export function projectExistenceQueryOptions(workspaceId: string): ProjectExistenceQueryOptions {
+export function projectsInfiniteQueryOptions(
+  workspaceId: string | undefined,
+  search?: string,
+  limit = 50,
+) {
+  const normalizedSearch = search?.trim() ?? '';
+  return {
+    queryKey: workspaceId
+      ? projectsQueryKeys.list(workspaceId, normalizedSearch)
+      : ([...projectsQueryKeys.all, 'list'] as const),
+    enabled: Boolean(workspaceId),
+    initialPageParam: undefined as string | undefined,
+    queryFn: ({pageParam, signal}: {pageParam: string | undefined; signal: AbortSignal}) =>
+      listProjects({
+        workspaceId: workspaceId ?? '',
+        limit,
+        cursor: pageParam,
+        search: normalizedSearch || undefined,
+        signal,
+      }),
+    getNextPageParam: (lastPage: ProjectList) => lastPage.nextCursor ?? undefined,
+    placeholderData: keepPreviousData,
+  };
+}
+
+export function projectExistenceQueryOptions(workspaceId: string | undefined) {
   return queryOptions({
-    queryKey: projectsQueryKeys.exists(workspaceId),
-    queryFn: ({signal}) => listProjects({workspaceId, limit: 1, signal}),
+    queryKey: workspaceId
+      ? projectsQueryKeys.exists(workspaceId)
+      : ([...projectsQueryKeys.all, 'exists'] as const),
+    enabled: Boolean(workspaceId),
+    queryFn: ({signal}) => listProjects({workspaceId: workspaceId ?? '', limit: 1, signal}),
     staleTime: 30_000,
+  });
+}
+
+export function projectQueryOptions(projectId: string | undefined) {
+  return queryOptions({
+    queryKey: projectId
+      ? projectsQueryKeys.detail(projectId)
+      : ([...projectsQueryKeys.all, 'detail'] as const),
+    enabled: Boolean(projectId),
+    queryFn: () => getProject(projectId ?? ''),
   });
 }
 
@@ -69,29 +113,30 @@ export function useProjectsInfiniteQuery(
   search?: string,
   limit = 50,
 ) {
-  return useInfiniteQuery({
-    queryKey: workspaceId
-      ? projectsQueryKeys.list(workspaceId, search)
-      : [...projectsQueryKeys.all, 'list'],
-    enabled: Boolean(workspaceId),
-    initialPageParam: undefined as string | undefined,
-    queryFn: ({pageParam, signal}) =>
-      listProjects({workspaceId: workspaceId ?? '', limit, cursor: pageParam, search, signal}),
-    getNextPageParam: (lastPage) => lastPage.next_cursor ?? undefined,
-    placeholderData: keepPreviousData,
-  });
+  return useInfiniteQuery(projectsInfiniteQueryOptions(workspaceId, search, limit));
 }
-
 export function useProjectQuery(projectId: string | undefined) {
-  return useQuery({
-    queryKey: projectId
-      ? projectsQueryKeys.detail(projectId)
-      : [...projectsQueryKeys.all, 'detail'],
-    enabled: Boolean(projectId),
-    queryFn: () => getProject(projectId ?? ''),
-  });
+  return useQuery(projectQueryOptions(projectId));
 }
 
 export function useCreateProjectMutation() {
-  return useMutation({mutationFn: createProject});
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: createProject,
+    onSuccess: async (project) => {
+      queryClient.setQueryData(projectsQueryKeys.detail(project.id), project);
+      queryClient.setQueryData<ProjectList>(projectsQueryKeys.exists(project.workspaceId), {
+        projects: [project],
+        nextCursor: null,
+      });
+      await queryClient.invalidateQueries({queryKey: projectsQueryKeys.list(project.workspaceId)});
+    },
+    onError: async (_error, command) => {
+      await queryClient.invalidateQueries({
+        queryKey: projectsQueryKeys.exists(command.workspaceId),
+        refetchType: 'active',
+      });
+      await queryClient.invalidateQueries({queryKey: projectsQueryKeys.list(command.workspaceId)});
+    },
+  });
 }

--- a/libs/client/projects/src/hooks/api/projects.ts
+++ b/libs/client/projects/src/hooks/api/projects.ts
@@ -5,8 +5,11 @@ import {
 } from '@shipfox/api-projects-dto';
 import {checkedApiRequest} from '@shipfox/client-api';
 import {
+  type InfiniteData,
   keepPreviousData,
   queryOptions,
+  type UseInfiniteQueryOptions,
+  type UseQueryOptions,
   useInfiniteQuery,
   useMutation,
   useQuery,
@@ -22,6 +25,31 @@ export const projectsQueryKeys = {
   exists: (workspaceId: string) => [...projectsQueryKeys.all, 'exists', workspaceId] as const,
   detail: (projectId: string) => [...projectsQueryKeys.all, 'detail', projectId] as const,
 };
+
+type ProjectListQueryKey =
+  | ReturnType<typeof projectsQueryKeys.list>
+  | readonly ['projects', 'list'];
+type ProjectExistenceQueryKey =
+  | ReturnType<typeof projectsQueryKeys.exists>
+  | readonly ['projects', 'exists'];
+type ProjectDetailQueryKey =
+  | ReturnType<typeof projectsQueryKeys.detail>
+  | readonly ['projects', 'detail'];
+
+type ProjectListInfiniteQueryOptions = UseInfiniteQueryOptions<
+  ProjectList,
+  Error,
+  InfiniteData<ProjectList, string | undefined>,
+  ProjectListQueryKey,
+  string | undefined
+>;
+type ProjectExistenceQueryOptions = UseQueryOptions<
+  ProjectList,
+  Error,
+  ProjectList,
+  ProjectExistenceQueryKey
+>;
+type ProjectDetailQueryOptions = UseQueryOptions<Project, Error, Project, ProjectDetailQueryKey>;
 
 export async function listProjects({
   workspaceId,
@@ -66,7 +94,7 @@ export function projectsInfiniteQueryOptions(
   workspaceId: string | undefined,
   search?: string,
   limit = 50,
-) {
+): ProjectListInfiniteQueryOptions {
   const normalizedSearch = search?.trim() ?? '';
   return {
     queryKey: workspaceId
@@ -87,7 +115,9 @@ export function projectsInfiniteQueryOptions(
   };
 }
 
-export function projectExistenceQueryOptions(workspaceId: string | undefined) {
+export function projectExistenceQueryOptions(
+  workspaceId: string | undefined,
+): ProjectExistenceQueryOptions {
   return queryOptions({
     queryKey: workspaceId
       ? projectsQueryKeys.exists(workspaceId)
@@ -98,7 +128,7 @@ export function projectExistenceQueryOptions(workspaceId: string | undefined) {
   });
 }
 
-export function projectQueryOptions(projectId: string | undefined) {
+export function projectQueryOptions(projectId: string | undefined): ProjectDetailQueryOptions {
   return queryOptions({
     queryKey: projectId
       ? projectsQueryKeys.detail(projectId)

--- a/libs/client/projects/src/index.ts
+++ b/libs/client/projects/src/index.ts
@@ -1,3 +1,12 @@
+export type {Definition, DefinitionList, DefinitionSyncSummary} from '#core/definition.js';
+export {
+  type CreateProjectCommand,
+  type Project,
+  type ProjectList,
+  type ProjectSource,
+  projectNameFromRepository,
+  selectProjectSource,
+} from '#core/project.js';
 export {ProjectBreadcrumb, ProjectLayoutGuard} from './chrome.js';
 export {ProjectCrumb, type ProjectCrumbProps} from './components/project-crumb.js';
 export {ProjectSwitcher, type ProjectSwitcherProps} from './components/project-switcher.js';

--- a/libs/client/projects/src/pages/create-project-page.tsx
+++ b/libs/client/projects/src/pages/create-project-page.tsx
@@ -1,8 +1,4 @@
-import {
-  createProjectBodySchema,
-  type ListProjectsResponseDto,
-  type ProjectResponseDto,
-} from '@shipfox/api-projects-dto';
+import {createProjectBodySchema} from '@shipfox/api-projects-dto';
 import {useMaybeActiveWorkspace} from '@shipfox/client-auth';
 import {
   ConnectionPicker,
@@ -20,18 +16,15 @@ import {FullPageLoader} from '@shipfox/react-ui/loader';
 import {toast} from '@shipfox/react-ui/toast';
 import {Header, Text} from '@shipfox/react-ui/typography';
 import {useForm} from '@tanstack/react-form';
-import {type QueryClient, useQueryClient} from '@tanstack/react-query';
 import {Link, Navigate, useNavigate} from '@tanstack/react-router';
 import {useEffect, useRef, useState} from 'react';
 import {ModelProviderReminderBanner} from '#components/model-provider-reminder-banner.js';
-import {projectsQueryKeys, useCreateProjectMutation} from '#hooks/api/projects.js';
+import {type CreateProjectCommand, projectNameFromRepository} from '#core/project.js';
+import {useCreateProjectMutation} from '#hooks/api/projects.js';
 import {projectErrorCopy} from '#project-error.js';
-
-const REPOSITORY_NAME_SPLIT_RE = /[/-]/;
 
 export function CreateProjectPage() {
   const workspace = useMaybeActiveWorkspace();
-  const queryClient = useQueryClient();
   const navigate = useNavigate();
   const createProject = useCreateProjectMutation();
   const errorRef = useRef<HTMLDivElement>(null);
@@ -128,18 +121,15 @@ export function CreateProjectPage() {
     }
 
     try {
-      const projectBody = createProjectBodySchema.parse({
-        workspace_id: workspace.id,
+      const command: CreateProjectCommand = {
+        workspaceId: workspace.id,
         name: projectName,
         source: {
-          connection_id: selectedConnection.id,
-          external_repository_id: selectedRepository.externalRepositoryId,
+          connectionId: selectedConnection.id,
+          externalRepositoryId: selectedRepository.externalRepositoryId,
         },
-      });
-      const project = await createProject.mutateAsync(projectBody);
-      setWorkspaceProjectExists(queryClient, workspace.id, project);
-      queryClient.setQueryData(projectsQueryKeys.detail(project.id), project);
-      await queryClient.invalidateQueries({queryKey: projectsQueryKeys.list(workspace.id)});
+      };
+      const project = await createProject.mutateAsync(command);
       toast.success('Project created.');
       await navigate({
         to: '/workspaces/$wid/projects/$pid',
@@ -148,11 +138,6 @@ export function CreateProjectPage() {
     } catch (error) {
       const copy = projectErrorCopy(error);
       if (copy.existingProjectId) {
-        await queryClient.invalidateQueries({
-          queryKey: projectsQueryKeys.exists(workspace.id),
-          refetchType: 'active',
-        });
-        await queryClient.invalidateQueries({queryKey: projectsQueryKeys.list(workspace.id)});
         toast.info('Project already exists.');
         await navigate({
           to: '/workspaces/$wid/projects/$pid',
@@ -356,15 +341,6 @@ function ProjectSummary({
   );
 }
 
-function projectNameFromRepository(repositoryId: string): string {
-  return repositoryId
-    .trim()
-    .split(REPOSITORY_NAME_SPLIT_RE)
-    .filter(Boolean)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(' ');
-}
-
 function useDebouncedValue<T>(value: T, delayMs: number): T {
   const [debounced, setDebounced] = useState(value);
   useEffect(() => {
@@ -372,15 +348,4 @@ function useDebouncedValue<T>(value: T, delayMs: number): T {
     return () => clearTimeout(handle);
   }, [value, delayMs]);
   return debounced;
-}
-
-function setWorkspaceProjectExists(
-  queryClient: QueryClient,
-  workspaceId: string,
-  project: ProjectResponseDto,
-) {
-  queryClient.setQueryData<ListProjectsResponseDto>(projectsQueryKeys.exists(workspaceId), {
-    projects: [project],
-    next_cursor: null,
-  });
 }

--- a/libs/client/projects/src/pages/projects-hub-page.test.tsx
+++ b/libs/client/projects/src/pages/projects-hub-page.test.tsx
@@ -84,14 +84,14 @@ describe('ProjectsHubPage', () => {
         if (url.searchParams.get('cursor') === 'cursor-1') {
           return Promise.resolve(
             jsonResponse({
-              projects: [projectDto({id: 'project-2', name: 'API'})],
+              projects: [projectDto({id: '11111111-1111-4111-8111-111111111113', name: 'API'})],
               next_cursor: null,
             }),
           );
         }
         return Promise.resolve(
           jsonResponse({
-            projects: [projectDto({id: 'project-1', name: 'Platform'})],
+            projects: [projectDto({id: '11111111-1111-4111-8111-111111111112', name: 'Platform'})],
             next_cursor: 'cursor-1',
           }),
         );
@@ -132,7 +132,7 @@ describe('ProjectsHubPage', () => {
         projects: jsonResponse({
           projects: [
             projectDto({
-              id: 'project-1',
+              id: '11111111-1111-4111-8111-111111111112',
               name: 'Platform',
               externalRepositoryId: 'github:octo/platform',
             }),
@@ -171,7 +171,7 @@ describe('ProjectsHubPage', () => {
     configureApiClient({
       fetchImpl: createHubFetch({
         projects: jsonResponse({
-          projects: [projectDto({id: 'project-1', name: 'Platform'})],
+          projects: [projectDto({id: '11111111-1111-4111-8111-111111111112', name: 'Platform'})],
           next_cursor: null,
         }),
         connections: jsonResponse(connectionsDto({lifecycleStatus})),
@@ -190,7 +190,7 @@ describe('ProjectsHubPage', () => {
     configureApiClient({
       fetchImpl: createHubFetch({
         projects: jsonResponse({
-          projects: [projectDto({id: 'project-1', name: 'Platform'})],
+          projects: [projectDto({id: '11111111-1111-4111-8111-111111111112', name: 'Platform'})],
           next_cursor: null,
         }),
         connections: jsonResponse({code: 'server-error'}, {status: 500}),
@@ -218,7 +218,7 @@ describe('ProjectsHubPage', () => {
 
 function createHubFetch({
   projects = jsonResponse({
-    projects: [projectDto({id: 'project-1', name: 'Platform'})],
+    projects: [projectDto({id: '11111111-1111-4111-8111-111111111112', name: 'Platform'})],
     next_cursor: null,
   }),
   connections = jsonResponse(connectionsDto()),

--- a/libs/client/projects/src/pages/projects-hub-page.tsx
+++ b/libs/client/projects/src/pages/projects-hub-page.tsx
@@ -1,4 +1,3 @@
-import type {ProjectResponseDto} from '@shipfox/api-projects-dto';
 import {useActiveWorkspace} from '@shipfox/client-auth';
 import {
   ConnectionStatusBadge,
@@ -18,6 +17,7 @@ import {Header, Text} from '@shipfox/react-ui/typography';
 import {Link} from '@tanstack/react-router';
 import {useEffect, useState} from 'react';
 import {ModelProviderReminderBanner} from '#components/model-provider-reminder-banner.js';
+import type {Project} from '#core/project.js';
 import {useProjectsInfiniteQuery} from '#hooks/api/projects.js';
 
 export function ProjectsHubPage() {
@@ -100,7 +100,7 @@ export function ProjectsHubPage() {
             {projects.map((project) => (
               <ProjectCard
                 project={project}
-                connection={connectionsById.get(project.source.connection_id)}
+                connection={connectionsById.get(project.source.connectionId)}
                 connectionsResolved={connectionsQuery.isSuccess}
                 connectionsSettled={connectionsQuery.isSuccess || connectionsQuery.isError}
                 key={project.id}
@@ -201,7 +201,7 @@ function ProjectCard({
   connectionsSettled,
   workspaceId,
 }: {
-  project: ProjectResponseDto;
+  project: Project;
   connection: IntegrationConnection | undefined;
   connectionsResolved: boolean;
   connectionsSettled: boolean;

--- a/libs/client/workflows/src/pages/project-workflows-page.tsx
+++ b/libs/client/workflows/src/pages/project-workflows-page.tsx
@@ -1,6 +1,11 @@
-import type {DefinitionDto, DefinitionSyncSummaryDto} from '@shipfox/api-definitions-dto';
 import {ApiError} from '@shipfox/client-api';
-import {SourceStrip, useDefinitionsInfiniteQuery, useProjectQuery} from '@shipfox/client-projects';
+import {
+  type Definition,
+  type DefinitionSyncSummary,
+  SourceStrip,
+  useDefinitionsInfiniteQuery,
+  useProjectQuery,
+} from '@shipfox/client-projects';
 import {QueryLoadError} from '@shipfox/client-ui';
 import {Button} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
@@ -42,14 +47,14 @@ function ProjectWorkflowsPageInner({projectId}: {projectId: string}) {
   const projectQuery = useProjectQuery(projectId);
   const definitionsQuery = useDefinitionsInfiniteQuery(projectId);
   const fireManual = useFireManualWorkflowMutation();
-  const [selectedDefinition, setSelectedDefinition] = useState<DefinitionDto | null>(null);
+  const [selectedDefinition, setSelectedDefinition] = useState<Definition | null>(null);
   const [runError, setRunError] = useState<{definitionId: string; message: string} | null>(null);
   const definitions = definitionsQuery.data?.pages.flatMap((page) => page.definitions) ?? [];
   const sync = definitionsQuery.data?.pages[0]?.sync;
 
-  async function handleRun(definition: DefinitionDto) {
+  async function handleRun(definition: Definition) {
     setRunError(null);
-    if (!definition.manual_trigger) return;
+    if (!definition.manualTrigger) return;
     try {
       await fireManual.mutateAsync({projectId, definitionId: definition.id});
       toast.success('Run queued');
@@ -91,8 +96,8 @@ function ProjectWorkflowsPageInner({projectId}: {projectId: string}) {
           </header>
 
           <SourceStrip
-            connectionId={projectQuery.data.source.connection_id}
-            externalRepositoryId={projectQuery.data.source.external_repository_id}
+            connectionId={projectQuery.data.source.connectionId}
+            externalRepositoryId={projectQuery.data.source.externalRepositoryId}
             sync={sync}
             isPending={definitionsQuery.isPending}
           />
@@ -148,10 +153,10 @@ function WorkflowDefinitionsList({
   onOpenDefinition,
   onRun,
 }: {
-  definitions: DefinitionDto[];
+  definitions: Definition[];
   isPending: boolean;
   isError: boolean;
-  sync: DefinitionSyncSummaryDto | null;
+  sync: DefinitionSyncSummary | null;
   runError: {definitionId: string; message: string} | null;
   runningDefinitionId: string | null;
   hasNextPage: boolean;
@@ -159,8 +164,8 @@ function WorkflowDefinitionsList({
   isFetchNextPageError: boolean;
   onRetry: () => void;
   onLoadMore: () => void;
-  onOpenDefinition: (definition: DefinitionDto) => void;
-  onRun: (definition: DefinitionDto) => void;
+  onOpenDefinition: (definition: Definition) => void;
+  onRun: (definition: Definition) => void;
 }) {
   if (isPending) {
     return (
@@ -232,7 +237,7 @@ function WorkflowDefinitionsList({
                           {definition.name}
                         </Text>
                         <Code className="truncate text-foreground-neutral-muted">
-                          {definition.config_path ?? 'Manual definition'}
+                          {definition.configPath ?? 'Manual definition'}
                         </Code>
                       </button>
                       {runErrorMessage ? (
@@ -243,10 +248,10 @@ function WorkflowDefinitionsList({
                     </div>
                   </TableCell>
                   <TableCell className="text-foreground-neutral-muted">
-                    <RelativeTime value={definition.updated_at} />
+                    <RelativeTime value={definition.updatedAt} />
                   </TableCell>
                   <TableCell>
-                    {definition.manual_trigger ? (
+                    {definition.manualTrigger ? (
                       <div className="flex justify-end opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
                         <Button size="xs" isLoading={isRunning} onClick={() => onRun(definition)}>
                           Run
@@ -287,15 +292,15 @@ function WorkflowDefinitionsList({
                     {definition.name}
                   </Text>
                   <Code className="break-words text-foreground-neutral-muted">
-                    {definition.config_path ?? 'Manual definition'}
+                    {definition.configPath ?? 'Manual definition'}
                   </Code>
                 </div>
               </button>
               <div className="flex items-center justify-between gap-8">
                 <Text size="xs" className="text-foreground-neutral-muted">
-                  Updated <RelativeTime value={definition.updated_at} />
+                  Updated <RelativeTime value={definition.updatedAt} />
                 </Text>
-                {definition.manual_trigger ? (
+                {definition.manualTrigger ? (
                   <Button size="sm" isLoading={isRunning} onClick={() => onRun(definition)}>
                     Run
                   </Button>
@@ -337,12 +342,12 @@ function sourceIcon(source: 'manual' | 'vcs'): IconName {
   return source === 'vcs' ? ('gitBranchLine' as IconName) : ('terminalLine' as IconName);
 }
 
-function WorkflowEmptyState({sync}: {sync: DefinitionSyncSummaryDto | null}) {
+function WorkflowEmptyState({sync}: {sync: DefinitionSyncSummary | null}) {
   const message =
-    sync?.status === 'failed' && sync.last_error_code === 'no-workflow-files'
+    sync?.status === 'failed' && sync.lastErrorCode === 'no-workflow-files'
       ? 'No workflow files found under .shipfox/workflows/.'
       : sync?.status === 'failed'
-        ? (sync.last_error_message ?? 'Workflow definitions could not be synced.')
+        ? (sync.lastErrorMessage ?? 'Workflow definitions could not be synced.')
         : sync?.status === 'syncing'
           ? 'Workflow definitions are being discovered.'
           : sync?.status === 'succeeded'
@@ -352,7 +357,7 @@ function WorkflowEmptyState({sync}: {sync: DefinitionSyncSummaryDto | null}) {
   return <EmptyState icon="flowChart" title="No workflows" description={message} />;
 }
 
-function WorkflowSyncAlert({sync}: {sync: DefinitionSyncSummaryDto | null | undefined}) {
+function WorkflowSyncAlert({sync}: {sync: DefinitionSyncSummary | null | undefined}) {
   if (sync?.status !== 'failed') return null;
 
   return (
@@ -362,7 +367,7 @@ function WorkflowSyncAlert({sync}: {sync: DefinitionSyncSummaryDto | null | unde
           Workflow sync failed
         </Text>
         <Text size="sm">
-          {sync.last_error_message ?? 'The latest workflow sync failed before definitions updated.'}
+          {sync.lastErrorMessage ?? 'The latest workflow sync failed before definitions updated.'}
         </Text>
       </div>
     </Callout>
@@ -373,14 +378,14 @@ function DefinitionSheet({
   definition,
   onOpenChange,
 }: {
-  definition: DefinitionDto | null;
+  definition: Definition | null;
   onOpenChange: (open: boolean) => void;
 }) {
   const normalizedJson = definition
     ? JSON.stringify(
         {
-          workflow_document: definition.workflow_document,
-          workflow_model: definition.workflow_model,
+          workflow_document: definition.workflowDocument,
+          workflow_model: definition.workflowModel,
         },
         null,
         2,
@@ -395,7 +400,7 @@ function DefinitionSheet({
             <SheetHeader>
               <SheetTitle>{definition.name}</SheetTitle>
               <SheetDescription>
-                {definition.config_path ?? 'Manual workflow definition'}
+                {definition.configPath ?? 'Manual workflow definition'}
               </SheetDescription>
             </SheetHeader>
             <SheetBody className="gap-18">


### PR DESCRIPTION
Converges Projects on checked, package-owned domain models and resource-owned React Query policy.

Project and definition responses are validated and mapped at the API boundary, so pages and downstream workflow consumers use camel-case models rather than transport DTOs. Project creation now accepts a domain command and owns its detail, existence, and list cache updates, while reusable query-option factories support the onboarding coordinator.

Keeping the existing DTOs in pages would leave unvalidated transport shapes in caches and spread cache-key knowledge across UI code. This keeps the public cache and command boundary explicit without changing navigation, duplicate recovery, source selection, or empty states.

Review the API mapper coverage and mutation cache effects closely: they define the canonical cached model and the post-create recovery behavior.

Closes ENG-1129

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches Projects and Definitions to checked, package-owned domain models and centralizes React Query cache policy in resource hooks. Updates UI and workflows to use camelCase models; project creation uses a domain command and owns cache updates (ENG-1129).

- **New Features**
  - Added domain types: `Project`, `ProjectList`, `CreateProjectCommand`, `Definition`, `DefinitionList`, `DefinitionSyncSummary`.
  - Validated API with `checkedApiRequest` and mapped via `toProject`, `toProjectList`, `toDefinition`, `toDefinitionList`, `toDefinitionSyncSummary`.
  - Introduced query option factories: `projectsInfiniteQueryOptions`, `projectQueryOptions`, `projectExistenceQueryOptions`, `definitionsQueryOptions`, `definitionsInfiniteQueryOptions`; existence has a 30s freshness window.
  - `useCreateProjectMutation` updates `detail`, seeds `exists`, and invalidates `list`; errors trigger targeted invalidations. Exported domain types and helpers from `@shipfox/client-projects` for `@shipfox/client-workflows`.

- **Refactors**
  - UI pages and tests consume camelCase models; DTOs are no longer cached in UI.
  - Renamed fields to camelCase (`workspaceId`, `nextCursor`, `connectionId`, `externalRepositoryId`) and updated usages.
  - Moved helpers to core: `projectNameFromRepository`, `selectProjectSource`.
  - Updated `SourceStrip` and the project workflows page to use domain types and new field names.
  - Preserved Projects query option declarations on public React Query option interfaces to avoid inaccessible TanStack symbols for packed consumers.

<sup>Written for commit 199008f3adc27e6db2cd0895fda02cd5c1644a3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

