### PR TITLE
[e2e] Stabilize listener batching synchronization

### DIFF
--- a/e2e/suites/flow/workflows/src/listener-jobs.ts
+++ b/e2e/suites/flow/workflows/src/listener-jobs.ts
@@ -235,11 +235,12 @@ export async function stepLogText(params: {
   return logText(logs.records);
 }
 
-export async function sendBatchPairAndAwaitExecution(params: {
+export async function sendBatchPairAndAwaitMaterialization(params: {
   testCase: ListenerCase;
   runId: string;
   label: string;
   sequence: number;
+  timeoutMs: number;
 }): Promise<{deliveryIds: string[]; runDetail: Awaited<ReturnType<typeof waitForRunTerminal>>}> {
   const deliveryIds = [
     `${params.testCase.uniqueId}-${params.label}-a`,
@@ -258,7 +259,7 @@ export async function sendBatchPairAndAwaitExecution(params: {
   const runDetail = await waitForRunDetailMatching({
     token: params.testCase.token,
     runId: params.runId,
-    timeoutMs: 8_000,
+    timeoutMs: params.timeoutMs,
     description: `batched listener deliveries ${deliveryIds.join(', ')}`,
     matches: (candidate) =>
       batchedListenerExecutionMatches({

--- a/e2e/suites/flow/workflows/tests/listener-jobs.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/listener-jobs.e2e.ts
@@ -10,7 +10,7 @@ import {
   LISTENER_JOB,
   type ListenerCase,
   listenerWorkflows,
-  sendBatchPairAndAwaitExecution,
+  sendBatchPairAndAwaitMaterialization,
   sendFire,
   sendResolve,
   setupListenerCase,
@@ -19,6 +19,9 @@ import {
 } from '#listener-jobs.js';
 import {waitForRunTerminalOrFailedRunner} from '#runner.js';
 import {expect, test} from './fixtures.js';
+
+const LISTENER_FLOW_OBSERVATION_TIMEOUT_MS = 60_000;
+const LISTENER_RUN_TERMINAL_TIMEOUT_MS = 180_000;
 
 test.describe('listener jobs', () => {
   test('creates multiple executions before resolving on an until event', async ({
@@ -216,33 +219,20 @@ test.describe('listener jobs', () => {
         runId,
         jobKey: LISTENER_JOB,
         listenerStatus: 'listening',
-        timeoutMs: 8_000,
+        timeoutMs: LISTENER_FLOW_OBSERVATION_TIMEOUT_MS,
       });
-      await sendBatchPairAndAwaitExecution({
-        testCase,
-        runId,
-        label: 'readiness',
-        sequence: 1,
-      });
-      await waitForListenerExecution({
-        token: testCase.token,
-        runId,
-        jobKey: LISTENER_JOB,
-        sequence: 1,
-        status: 'succeeded',
-        timeoutMs: 8_000,
-      });
-      const batch = await sendBatchPairAndAwaitExecution({
+      const batch = await sendBatchPairAndAwaitMaterialization({
         testCase,
         runId,
         label: 'batch',
-        sequence: 2,
+        sequence: 1,
+        timeoutMs: LISTENER_FLOW_OBSERVATION_TIMEOUT_MS,
       });
       await sendResolve(testCase, 'resolve-batch');
       const terminal = await waitForRunTerminalOrFailedRunner({
         runId,
         token: testCase.token,
-        timeoutMs: 180_000,
+        timeoutMs: LISTENER_RUN_TERMINAL_TIMEOUT_MS,
         runner: testCase.runner,
       });
 
@@ -251,13 +241,13 @@ test.describe('listener jobs', () => {
         runDetail: terminal,
         token: testCase.token,
         jobKey: LISTENER_JOB,
-        sequence: 2,
+        sequence: 1,
         stepKey: 'show-batch',
       });
       expect(terminal.status).toBe('succeeded');
       expect(listen?.resolution_reason).toBe('until');
-      expect(listen?.job_executions).toHaveLength(2);
-      expect(listen?.job_executions[1]?.trigger_events.map((event) => event.delivery_id)).toEqual(
+      expect(listen?.job_executions).toHaveLength(1);
+      expect(listen?.job_executions[0]?.trigger_events.map((event) => event.delivery_id)).toEqual(
         batch.deliveryIds,
       );
       expect(logs).toContain(`batch_first=${batch.deliveryIds[0]}`);


### PR DESCRIPTION
Stabilize the listener batching flow test around causal product states.

The test previously sent a sacrificial batch after listener activation and required that unrelated execution to finish within eight seconds. Subscription readiness is already observed directly, so the test now sends one correlated pair, waits only for those delivery IDs to materialize into one execution, then resolves the listener and observes the terminal run. Readiness and materialization use 60-second observation guards while full-run completion keeps its 180-second guard.

Considered retaining the warm-up execution or retrying webhook pairs, but both weaken the batching contract and make scheduler latency part of the assertion.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the listener batching E2E by waiting for subscription readiness and real batch materialization, removing the warm-up execution and fixed 8s deadline. Reduces scheduler-latency flakiness while keeping the 180s terminal guard.

- **Bug Fixes**
  - Replaced fixed 8s waits with configurable timeouts; use 60s for readiness/materialization and keep 180s for terminal.
  - Dropped the warm-up run; send one correlated pair, wait for those delivery IDs to materialize in a single execution, then resolve; assertions updated to expect one execution with matching IDs.

<sup>Written for commit d8e4412fa54d7cdb635f83956702840b70448d1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

