### PR TITLE
[client-integrations] Converge on package-owned domain models

### DIFF
--- a/.changeset/silly-otters-converge.md
+++ b/.changeset/silly-otters-converge.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/client-integrations": major
+"@shipfox/client-api": minor
+"@shipfox/client-projects": patch
+---
+
+Converges the integrations client on a package-owned domain model (camelCase, schema-validated) instead of exposing raw snake_case API DTOs, changing the shape of `useSourceConnectionsQuery`, `useIntegrationConnectionsQuery`, `useIntegrationProvidersQuery`, `useRepositoriesInfiniteQuery`, and the `ConnectionPicker`/`ProviderGrid`/`RepositoryPicker` props. Adds `emptyResponseSchema` to `@shipfox/client-api` for schema-validated DELETE requests with no response body.

--- a/libs/client/api/src/index.ts
+++ b/libs/client/api/src/index.ts
@@ -35,6 +35,11 @@ export interface StandardSchema<Input = unknown, Output = Input> {
 export type StandardSchemaOutput<Schema extends StandardSchema> =
   Schema extends StandardSchema<unknown, infer Output> ? Output : never;
 
+/** Pass to `checkedApiRequest` for endpoints (e.g. DELETE) with no response body. */
+export const emptyResponseSchema: StandardSchema<unknown, undefined> = {
+  '~standard': {version: 1, vendor: 'client-api', validate: () => ({value: undefined})},
+};
+
 export class ApiError extends Error {
   readonly code: string;
   readonly status: number;

--- a/libs/client/integrations/src/components/connection-picker.tsx
+++ b/libs/client/integrations/src/components/connection-picker.tsx
@@ -1,10 +1,10 @@
-import type {IntegrationConnectionDto} from '@shipfox/api-integration-core-dto';
 import {useIsTextTruncated} from '@shipfox/react-ui/hooks';
 import {Label} from '@shipfox/react-ui/label';
 import {RadioGroup, RadioGroupItem} from '@shipfox/react-ui/radio-group';
 import {Tooltip, TooltipContent, TooltipTrigger} from '@shipfox/react-ui/tooltip';
 import {Text} from '@shipfox/react-ui/typography';
 import {useId} from 'react';
+import type {IntegrationConnection} from '#core/models.js';
 import {IntegrationIcon} from '#integration-icon.js';
 
 export function ConnectionPicker({
@@ -12,7 +12,7 @@ export function ConnectionPicker({
   selectedConnectionId,
   onSelect,
 }: {
-  connections: IntegrationConnectionDto[];
+  connections: IntegrationConnection[];
   selectedConnectionId: string | undefined;
   onSelect: (connectionId: string) => void;
 }) {
@@ -39,8 +39,8 @@ export function ConnectionPicker({
   );
 }
 
-function ConnectionOption({connection}: {connection: IntegrationConnectionDto}) {
-  const {ref: nameRef, isTruncated} = useIsTextTruncated<HTMLSpanElement>(connection.display_name);
+function ConnectionOption({connection}: {connection: IntegrationConnection}) {
+  const {ref: nameRef, isTruncated} = useIsTextTruncated<HTMLSpanElement>(connection.displayName);
 
   return (
     <span className="flex min-w-0 items-center gap-10">
@@ -61,11 +61,11 @@ function ConnectionOption({connection}: {connection: IntegrationConnectionDto}) 
         <TooltipTrigger asChild>
           <span ref={nameRef} className="min-w-0 truncate">
             <Text as="span" size="sm" bold>
-              {connection.display_name}
+              {connection.displayName}
             </Text>
           </span>
         </TooltipTrigger>
-        {isTruncated ? <TooltipContent>{connection.display_name}</TooltipContent> : null}
+        {isTruncated ? <TooltipContent>{connection.displayName}</TooltipContent> : null}
       </Tooltip>
     </span>
   );

--- a/libs/client/integrations/src/components/installed-integrations-section.tsx
+++ b/libs/client/integrations/src/components/installed-integrations-section.tsx
@@ -1,7 +1,3 @@
-import type {
-  IntegrationConnectionDto,
-  ListIntegrationConnectionsResponseDto,
-} from '@shipfox/api-integration-core-dto';
 import {QueryLoadError} from '@shipfox/client-ui';
 import {IconButton} from '@shipfox/react-ui/button';
 import {
@@ -15,18 +11,21 @@ import {EmptyState} from '@shipfox/react-ui/empty-state';
 import {Skeleton} from '@shipfox/react-ui/skeleton';
 import {Header, Text} from '@shipfox/react-ui/typography';
 import {cn, formatDate} from '@shipfox/react-ui/utils';
-import type {UseQueryResult} from '@tanstack/react-query';
 import {Link} from '@tanstack/react-router';
 import {ConnectionStatusBadge} from '#connection-status-badge.js';
+import {type IntegrationConnection, isUsableConnection} from '#core/models.js';
 import {IntegrationIcon} from '#integration-icon.js';
 import {usageEventsForConnection} from './integration-usage-events.js';
 
 interface InstalledIntegrationsSectionProps {
-  connectionsQuery: UseQueryResult<ListIntegrationConnectionsResponseDto, Error>;
-  connections: IntegrationConnectionDto[];
+  connections: IntegrationConnection[];
+  isPending: boolean;
+  isFetching: boolean;
+  error?: Error | null | undefined;
+  onRetry: () => void;
   isMutating: boolean;
   onUse: (connectionId: string) => void;
-  onSetActive: (connection: IntegrationConnectionDto, active: boolean) => void;
+  onSetActive: (connection: IntegrationConnection, active: boolean) => void;
   onDelete: (connectionId: string) => void;
   providerDisplayName: (provider: string) => string | undefined;
 }
@@ -35,8 +34,11 @@ const INSTALLED_SURFACE_CLASS =
   'overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base';
 
 export function InstalledIntegrationsSection({
-  connectionsQuery,
   connections,
+  isPending,
+  isFetching,
+  error,
+  onRetry,
   isMutating,
   onUse,
   onSetActive,
@@ -52,15 +54,18 @@ export function InstalledIntegrationsSection({
         </Text>
       </div>
 
-      {connectionsQuery.isPending ? <InstalledSkeleton label="Loading integrations" /> : null}
+      {isPending ? <InstalledSkeleton label="Loading integrations" /> : null}
 
-      {connectionsQuery.isError && connectionsQuery.data === undefined ? (
+      {error ? (
         <div className={cn(INSTALLED_SURFACE_CLASS, 'px-16')}>
-          <QueryLoadError query={connectionsQuery} subject="integrations" />
+          <QueryLoadError
+            query={{isError: true, isFetching, data: undefined, error, refetch: onRetry}}
+            subject="integrations"
+          />
         </div>
       ) : null}
 
-      {connectionsQuery.data !== undefined && connections.length === 0 ? (
+      {!isPending && !error && connections.length === 0 ? (
         <div className={cn(INSTALLED_SURFACE_CLASS, 'px-16')}>
           <EmptyState
             icon="componentLine"
@@ -97,15 +102,15 @@ function InstalledRow({
   onDelete,
   providerDisplayName,
 }: {
-  connection: IntegrationConnectionDto;
+  connection: IntegrationConnection;
   isMutating: boolean;
   onUse: (connectionId: string) => void;
   onSetActive: (active: boolean) => void;
   onDelete: (connectionId: string) => void;
   providerDisplayName: (provider: string) => string | undefined;
 }) {
-  const muted = connection.lifecycle_status === 'disabled';
-  const active = connection.lifecycle_status === 'active';
+  const muted = connection.lifecycleStatus === 'disabled';
+  const active = isUsableConnection(connection);
   const recentEventsEvent = usageEventsForConnection(connection)[0]?.value ?? 'received';
   const providerName = providerDisplayName(connection.provider);
 
@@ -126,12 +131,12 @@ function InstalledRow({
             bold
             className={cn('truncate', muted ? 'text-foreground-neutral-disabled' : undefined)}
           >
-            {connection.display_name}
+            {connection.displayName}
           </Text>
-          <ConnectionStatusBadge status={connection.lifecycle_status} className="shrink-0" />
+          <ConnectionStatusBadge status={connection.lifecycleStatus} className="shrink-0" />
         </div>
         <Text size="sm" className="truncate text-foreground-neutral-muted">
-          Added {formatDate(connection.created_at)}
+          Added {formatDate(connection.createdAt)}
         </Text>
       </div>
       <DropdownMenu>
@@ -140,13 +145,13 @@ function InstalledRow({
             size="sm"
             variant="transparent"
             icon="more2Line"
-            aria-label={`Open ${connection.display_name} integration actions`}
+            aria-label={`Open ${connection.displayName} integration actions`}
           />
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          {connection.external_url ? (
+          {connection.externalUrl ? (
             <DropdownMenuItem asChild>
-              <a href={connection.external_url} target="_blank" rel="noreferrer noopener">
+              <a href={connection.externalUrl} target="_blank" rel="noreferrer noopener">
                 {providerName ? `Open in ${providerName}` : 'Open provider settings'}
               </a>
             </DropdownMenuItem>
@@ -157,7 +162,7 @@ function InstalledRow({
           <DropdownMenuItem asChild>
             <Link
               to="/workspaces/$wid/settings/events"
-              params={{wid: connection.workspace_id}}
+              params={{wid: connection.workspaceId}}
               search={{source: [connection.slug], event: [recentEventsEvent]}}
             >
               View recent events

--- a/libs/client/integrations/src/components/integration-gallery-for-workspace.tsx
+++ b/libs/client/integrations/src/components/integration-gallery-for-workspace.tsx
@@ -1,11 +1,11 @@
-import type {
-  IntegrationCapabilityDto,
-  IntegrationConnectionDto,
-  IntegrationProviderDto,
-} from '@shipfox/api-integration-core-dto';
 import {toast} from '@shipfox/react-ui/toast';
 import {Header, Text} from '@shipfox/react-ui/typography';
 import {useState} from 'react';
+import type {
+  IntegrationCapability,
+  IntegrationConnection,
+  IntegrationProvider,
+} from '#core/models.js';
 import {
   useDeleteIntegrationConnectionMutation,
   useIntegrationConnectionsQuery,
@@ -25,7 +25,7 @@ import {WebhookCreateModal} from './webhook/webhook-create-modal.js';
 import {WebhookUsageDetails} from './webhook/webhook-usage-details.js';
 
 interface IntegrationGalleryForWorkspaceProps {
-  capability: IntegrationCapabilityDto | undefined;
+  capability: IntegrationCapability | undefined;
   emptyProvidersMessage: string;
   workspaceId: string;
 }
@@ -38,7 +38,7 @@ export function IntegrationGalleryForWorkspace({
   const [createProvider, setCreateProvider] = useState<string | undefined>();
   const [usageConnectionId, setUsageConnectionId] = useState<string | undefined>();
   const [createdUsageConnection, setCreatedUsageConnection] = useState<
-    IntegrationConnectionDto | undefined
+    IntegrationConnection | undefined
   >();
   const [deleteConnectionId, setDeleteConnectionId] = useState<string | undefined>();
   const providersQuery = useIntegrationProvidersQuery(capability ? {capability} : undefined);
@@ -48,12 +48,12 @@ export function IntegrationGalleryForWorkspace({
   const updateWebhookConnection = useUpdateWebhookConnectionMutation();
   const deleteWebhookConnection = useDeleteWebhookConnectionMutation();
 
-  const providers = providersQuery.data?.providers ?? [];
-  const providersMap = new Map<string, IntegrationProviderDto>(
+  const providers = providersQuery.data ?? [];
+  const providersMap = new Map<string, IntegrationProvider>(
     providers.map((provider) => [provider.provider, provider]),
   );
 
-  const allConnections = connectionsQuery.data?.connections ?? [];
+  const allConnections = connectionsQuery.data ?? [];
   // Filter in memory so the all-status cache key stays shared; passing capability
   // into the hook would collide with the active-only `source_control` key used
   // elsewhere.
@@ -61,13 +61,13 @@ export function IntegrationGalleryForWorkspace({
     ? allConnections.filter((connection) => connection.capabilities.includes(capability))
     : allConnections;
 
-  const providerDisplayName = (provider: string) => providersMap.get(provider)?.display_name;
+  const providerDisplayName = (provider: string) => providersMap.get(provider)?.displayName;
   const providerLabel = (provider: string) => providerDisplayName(provider) ?? provider;
 
   const sortedConnections = [...connections].sort((a, b) => {
     const byProvider = providerLabel(a.provider).localeCompare(providerLabel(b.provider));
     if (byProvider !== 0) return byProvider;
-    return a.created_at.localeCompare(b.created_at);
+    return a.createdAt.localeCompare(b.createdAt);
   });
   const usageConnection =
     sortedConnections.find((connection) => connection.id === usageConnectionId) ??
@@ -77,7 +77,7 @@ export function IntegrationGalleryForWorkspace({
     (connection) => connection.id === deleteConnectionId,
   );
 
-  async function setConnectionActive(connection: IntegrationConnectionDto, active: boolean) {
+  async function setConnectionActive(connection: IntegrationConnection, active: boolean) {
     try {
       const body = {lifecycle_status: active ? 'active' : 'disabled'} as const;
       if (connection.provider === 'webhook') {
@@ -122,8 +122,11 @@ export function IntegrationGalleryForWorkspace({
   return (
     <div className="flex flex-col gap-24">
       <InstalledIntegrationsSection
-        connectionsQuery={connectionsQuery}
         connections={sortedConnections}
+        isPending={connectionsQuery.isPending}
+        isFetching={connectionsQuery.isFetching}
+        error={connectionsQuery.isError ? connectionsQuery.error : undefined}
+        onRetry={() => void connectionsQuery.refetch()}
         isMutating={
           updateConnection.isPending ||
           deleteConnection.isPending ||
@@ -147,7 +150,11 @@ export function IntegrationGalleryForWorkspace({
         </div>
 
         <ProviderGrid
-          providersQuery={providersQuery}
+          providers={providers}
+          isPending={providersQuery.isPending}
+          isFetching={providersQuery.isFetching}
+          error={providersQuery.isError ? providersQuery.error : undefined}
+          onRetry={() => void providersQuery.refetch()}
           workspaceId={workspaceId}
           emptyMessage={emptyProvidersMessage}
           onOpenProvider={setCreateProvider}
@@ -178,7 +185,7 @@ export function IntegrationGalleryForWorkspace({
         ) : null}
       </IntegrationUsageModal>
       <IntegrationDeleteConfirmModal
-        connectionName={deleteConnectionTarget?.display_name}
+        connectionName={deleteConnectionTarget?.displayName}
         open={deleteConnectionId !== undefined}
         isPending={deleteConnection.isPending || deleteWebhookConnection.isPending}
         onOpenChange={(open) => {

--- a/libs/client/integrations/src/components/integration-gallery.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.tsx
@@ -1,9 +1,9 @@
-import type {IntegrationCapabilityDto} from '@shipfox/api-integration-core-dto';
 import {useActiveWorkspace} from '@shipfox/client-auth';
+import type {IntegrationCapability} from '#core/models.js';
 import {IntegrationGalleryForWorkspace} from './integration-gallery-for-workspace.js';
 
 export interface IntegrationGalleryProps {
-  capability?: IntegrationCapabilityDto;
+  capability?: IntegrationCapability;
   emptyProvidersMessage?: string;
   workspaceId?: string;
 }
@@ -35,7 +35,7 @@ function RoutedIntegrationGallery({
   capability,
   emptyProvidersMessage,
 }: {
-  capability: IntegrationCapabilityDto | undefined;
+  capability: IntegrationCapability | undefined;
   emptyProvidersMessage: string;
 }) {
   const workspace = useActiveWorkspace();

--- a/libs/client/integrations/src/components/integration-usage-events.ts
+++ b/libs/client/integrations/src/components/integration-usage-events.ts
@@ -1,4 +1,4 @@
-import type {IntegrationConnectionDto, SentryIssueAction} from '@shipfox/api-integration-core-dto';
+import type {SentryIssueAction} from '@shipfox/api-integration-core-dto';
 import {SENTRY_ISSUE_ACTIONS} from '@shipfox/api-integration-core-dto';
 import {linearWebhookEventNames} from '@shipfox/api-integration-linear-dto';
 import {WEBHOOK_RECEIVED_EVENT} from '@shipfox/api-integration-webhook-dto';
@@ -82,9 +82,10 @@ const GITHUB_EVENTS = [
   'workflow_run',
 ] as const;
 
-export function usageEventsForConnection(
-  connection: IntegrationConnectionDto,
-): IntegrationUsageEvent[] {
+export function usageEventsForConnection(connection: {
+  provider: string;
+  capabilities: readonly string[];
+}): IntegrationUsageEvent[] {
   if (connection.provider === 'webhook') {
     return [{value: WEBHOOK_RECEIVED_EVENT, label: WEBHOOK_RECEIVED_EVENT}];
   }

--- a/libs/client/integrations/src/components/integration-usage-modal.tsx
+++ b/libs/client/integrations/src/components/integration-usage-modal.tsx
@@ -1,4 +1,3 @@
-import type {IntegrationConnectionDto} from '@shipfox/api-integration-core-dto';
 import {Button} from '@shipfox/react-ui/button';
 import {
   CodeBlock,
@@ -29,6 +28,7 @@ import {Text} from '@shipfox/react-ui/typography';
 import type {ReactNode} from 'react';
 import {useEffect, useMemo, useState} from 'react';
 import {ConnectionStatusBadge} from '#connection-status-badge.js';
+import type {IntegrationConnection} from '#core/models.js';
 
 export interface IntegrationUsageEvent {
   value: string;
@@ -36,7 +36,7 @@ export interface IntegrationUsageEvent {
 }
 
 interface IntegrationUsageModalProps {
-  connection: IntegrationConnectionDto | null;
+  connection: IntegrationConnection | null;
   events: IntegrationUsageEvent[];
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -69,7 +69,7 @@ export function IntegrationUsageModal({
     () => [{language: 'yaml', filename: WORKFLOW_FILENAME, code: workflowExample}],
     [workflowExample],
   );
-  const title = connection ? `Use ${connection.display_name}` : 'Use integration';
+  const title = connection ? `Use ${connection.displayName}` : 'Use integration';
 
   return (
     <Modal open={open && connection !== null} onOpenChange={onOpenChange}>
@@ -82,7 +82,7 @@ export function IntegrationUsageModal({
                 {title}
               </Text>
               {connection ? (
-                <ConnectionStatusBadge status={connection.lifecycle_status} className="shrink-0" />
+                <ConnectionStatusBadge status={connection.lifecycleStatus} className="shrink-0" />
               ) : null}
             </div>
             <Text size="sm" className="text-foreground-neutral-muted">

--- a/libs/client/integrations/src/components/provider-grid.tsx
+++ b/libs/client/integrations/src/components/provider-grid.tsx
@@ -1,7 +1,3 @@
-import type {
-  IntegrationProviderDto,
-  ListIntegrationProvidersResponseDto,
-} from '@shipfox/api-integration-core-dto';
 import {QueryLoadError} from '@shipfox/client-ui';
 import {Card} from '@shipfox/react-ui/card';
 import {EmptyState} from '@shipfox/react-ui/empty-state';
@@ -9,13 +5,17 @@ import {Icon} from '@shipfox/react-ui/icon';
 import {Skeleton} from '@shipfox/react-ui/skeleton';
 import {Text} from '@shipfox/react-ui/typography';
 import {cn} from '@shipfox/react-ui/utils';
-import type {UseQueryResult} from '@tanstack/react-query';
 import {Link} from '@tanstack/react-router';
+import type {IntegrationProvider} from '#core/models.js';
 import {IntegrationIcon} from '#integration-icon.js';
 import {PROVIDER_CATALOG} from '#provider-catalog.js';
 
 export interface ProviderGridProps {
-  providersQuery: UseQueryResult<ListIntegrationProvidersResponseDto, Error>;
+  providers: IntegrationProvider[];
+  isPending: boolean;
+  isFetching?: boolean;
+  error?: Error | null | undefined;
+  onRetry?: () => void;
   workspaceId: string;
   emptyMessage: string;
   loadingLabel?: string;
@@ -29,27 +29,39 @@ export const PROVIDER_SURFACE_CLASS =
   'overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base';
 
 export function ProviderGrid({
-  providersQuery,
+  providers,
+  isPending,
+  isFetching = false,
+  error,
+  onRetry,
   workspaceId,
   emptyMessage,
   loadingLabel = 'Loading providers',
   errorSubject = 'available integrations',
   onOpenProvider,
 }: ProviderGridProps) {
-  const providers = providersQuery.data?.providers ?? [];
   const installableProviders = providers.filter((provider) => PROVIDER_CATALOG[provider.provider]);
 
-  if (providersQuery.isPending) return <ProviderGridSkeleton label={loadingLabel} />;
+  if (isPending) return <ProviderGridSkeleton label={loadingLabel} />;
 
-  if (providersQuery.isError && providersQuery.data === undefined) {
+  if (error) {
     return (
       <div className={cn(PROVIDER_SURFACE_CLASS, 'px-16')}>
-        <QueryLoadError query={providersQuery} subject={errorSubject} />
+        <QueryLoadError
+          query={{
+            isError: true,
+            isFetching,
+            data: undefined,
+            error,
+            refetch: onRetry ?? (() => undefined),
+          }}
+          subject={errorSubject}
+        />
       </div>
     );
   }
 
-  if (providersQuery.data !== undefined && installableProviders.length === 0) {
+  if (installableProviders.length === 0) {
     return (
       <div className={cn(PROVIDER_SURFACE_CLASS, 'px-16')}>
         <EmptyState
@@ -81,7 +93,7 @@ function ProviderCard({
   workspaceId,
   onOpenProvider,
 }: {
-  provider: IntegrationProviderDto;
+  provider: IntegrationProvider;
   workspaceId: string;
   onOpenProvider?: ((provider: string) => void) | undefined;
 }) {
@@ -92,7 +104,7 @@ function ProviderCard({
     return (
       <button
         type="button"
-        aria-label={`Add ${provider.display_name}`}
+        aria-label={`Add ${provider.displayName}`}
         onClick={() => onOpenProvider?.(provider.provider)}
         className="group flex h-full w-full min-w-0 items-center justify-between gap-12 rounded-8 border border-border-neutral-base bg-background-neutral-base p-16 text-left transition-colors hover:bg-background-components-hover focus-visible:shadow-button-neutral-focus focus-visible:outline-none"
       >
@@ -105,7 +117,7 @@ function ProviderCard({
     <Link
       to={catalog.setupPath}
       params={{wid: workspaceId}}
-      aria-label={`Install ${provider.display_name}`}
+      aria-label={`Install ${provider.displayName}`}
       className="group flex h-full min-w-0 items-center justify-between gap-12 rounded-8 border border-border-neutral-base bg-background-neutral-base p-16 transition-colors hover:bg-background-components-hover focus-visible:shadow-button-neutral-focus focus-visible:outline-none"
     >
       <ProviderCardContent provider={provider} action="Install" />
@@ -117,7 +129,7 @@ function ProviderCardContent({
   provider,
   action,
 }: {
-  provider: IntegrationProviderDto;
+  provider: IntegrationProvider;
   action: 'Add' | 'Install';
 }) {
   return (
@@ -129,7 +141,7 @@ function ProviderCardContent({
           className="size-24 shrink-0 text-foreground-neutral-base"
         />
         <Text as="span" size="md" bold className="truncate">
-          {provider.display_name}
+          {provider.displayName}
         </Text>
       </span>
       <span className="flex shrink-0 items-center gap-4 text-foreground-neutral-muted transition-colors group-hover:text-foreground-highlight-interactive">

--- a/libs/client/integrations/src/components/repository-picker.tsx
+++ b/libs/client/integrations/src/components/repository-picker.tsx
@@ -1,4 +1,3 @@
-import type {RepositoryDto} from '@shipfox/api-integration-core-dto';
 import {Button} from '@shipfox/react-ui/button';
 import {Input} from '@shipfox/react-ui/input';
 import {Label} from '@shipfox/react-ui/label';
@@ -6,6 +5,7 @@ import {RadioGroup, RadioGroupItem} from '@shipfox/react-ui/radio-group';
 import {Skeleton} from '@shipfox/react-ui/skeleton';
 import {Text} from '@shipfox/react-ui/typography';
 import {useId} from 'react';
+import type {Repository} from '#core/models.js';
 
 export function RepositoryPicker({
   repositories,
@@ -20,7 +20,7 @@ export function RepositoryPicker({
   onSearchChange,
   searchDisabled,
 }: {
-  repositories: RepositoryDto[];
+  repositories: Repository[];
   selectedRepositoryId: string | undefined;
   onSelect: (repositoryId: string) => void;
   isLoading: boolean;
@@ -69,16 +69,16 @@ export function RepositoryPicker({
         >
           {repositories.map((repository) => (
             <RadioGroupItem
-              key={repository.external_repository_id}
-              value={repository.external_repository_id}
+              key={repository.externalRepositoryId}
+              value={repository.externalRepositoryId}
               className="p-12"
             >
               <span className="flex min-w-0 items-center justify-between gap-10">
                 <Text as="span" size="sm" bold className="truncate">
-                  {repository.full_name}
+                  {repository.fullName}
                 </Text>
                 <Text as="span" size="xs" className="shrink-0 text-foreground-neutral-muted">
-                  {repository.default_branch}
+                  {repository.defaultBranch}
                 </Text>
               </span>
             </RadioGroupItem>

--- a/libs/client/integrations/src/components/webhook/webhook-create-modal.tsx
+++ b/libs/client/integrations/src/components/webhook/webhook-create-modal.tsx
@@ -1,8 +1,6 @@
-import type {IntegrationConnectionDto} from '@shipfox/api-integration-core-dto';
 import {
   createWebhookConnectionBodySchema,
   WEBHOOK_RESERVED_SLUGS,
-  type WebhookConnectionDto,
   webhookSlugSchema,
 } from '@shipfox/api-integration-webhook-dto';
 import {displayNameFieldError} from '@shipfox/client-ui';
@@ -21,6 +19,7 @@ import {toast} from '@shipfox/react-ui/toast';
 import {Code, Text} from '@shipfox/react-ui/typography';
 import {useForm} from '@tanstack/react-form';
 import {useEffect, useRef, useState} from 'react';
+import type {IntegrationConnection, WebhookConnection} from '#core/models.js';
 import {useCreateWebhookConnectionMutation} from '#hooks/api/webhook-connections.js';
 import {webhookCreateErrorToFormError} from './webhook-form-errors.js';
 
@@ -28,7 +27,7 @@ interface WebhookCreateModalProps {
   workspaceId: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onCreated: (connection: IntegrationConnectionDto) => void;
+  onCreated: (connection: IntegrationConnection) => void;
 }
 
 export function WebhookCreateModal({
@@ -53,7 +52,7 @@ export function WebhookCreateModal({
           slug: value.slug.trim(),
         });
         const connection = await createWebhook.mutateAsync(body);
-        onCreated(toIntegrationConnection(connection));
+        onCreated(webhookConnectionToIntegrationConnection(connection));
         toast.success('Webhook created.');
         onOpenChange(false);
       } catch (error) {
@@ -231,17 +230,19 @@ function suggestWebhookSlug(name: string): string {
   return suffix ? `${prefix}-${suffix}` : prefix;
 }
 
-function toIntegrationConnection(connection: WebhookConnectionDto): IntegrationConnectionDto {
+function webhookConnectionToIntegrationConnection(
+  connection: WebhookConnection,
+): IntegrationConnection {
   return {
     id: connection.id,
-    workspace_id: connection.workspace_id,
+    workspaceId: connection.workspaceId,
     provider: 'webhook',
-    external_account_id: connection.slug,
+    externalAccountId: connection.slug,
     slug: connection.slug,
-    display_name: connection.name,
-    lifecycle_status: connection.lifecycle_status,
+    displayName: connection.name,
+    lifecycleStatus: connection.lifecycleStatus,
     capabilities: [],
-    created_at: connection.created_at,
-    updated_at: connection.updated_at,
+    createdAt: connection.createdAt,
+    updatedAt: connection.updatedAt,
   };
 }

--- a/libs/client/integrations/src/components/webhook/webhook-modals.stories.tsx
+++ b/libs/client/integrations/src/components/webhook/webhook-modals.stories.tsx
@@ -1,4 +1,3 @@
-import type {IntegrationConnectionDto} from '@shipfox/api-integration-core-dto';
 import type {WebhookConnectionDto} from '@shipfox/api-integration-webhook-dto';
 import {WEBHOOK_RECEIVED_EVENT} from '@shipfox/api-integration-webhook-dto';
 import {configureApiClient} from '@shipfox/client-api';
@@ -14,6 +13,7 @@ import {
   RouterProvider,
 } from '@tanstack/react-router';
 import {useMemo} from 'react';
+import type {IntegrationConnection} from '#core/models.js';
 import {IntegrationDeleteConfirmModal} from '../integration-delete-confirm-modal.js';
 import {IntegrationUsageModal} from '../integration-usage-modal.js';
 import {CopyableValue} from './copyable-value.js';
@@ -52,22 +52,22 @@ const disabledConnection: WebhookConnectionDto = {
   lifecycle_status: 'disabled',
 };
 
-const activeIntegrationConnection: IntegrationConnectionDto = {
+const activeIntegrationConnection: IntegrationConnection = {
   id: CONNECTION_ID,
-  workspace_id: WORKSPACE_ID,
+  workspaceId: WORKSPACE_ID,
   provider: 'webhook',
-  external_account_id: activeConnection.slug,
+  externalAccountId: activeConnection.slug,
   slug: activeConnection.slug,
-  display_name: activeConnection.name,
-  lifecycle_status: activeConnection.lifecycle_status,
+  displayName: activeConnection.name,
+  lifecycleStatus: activeConnection.lifecycle_status,
   capabilities: [],
-  created_at: activeConnection.created_at,
-  updated_at: activeConnection.updated_at,
+  createdAt: activeConnection.created_at,
+  updatedAt: activeConnection.updated_at,
 };
 
-const disabledIntegrationConnection: IntegrationConnectionDto = {
+const disabledIntegrationConnection: IntegrationConnection = {
   ...activeIntegrationConnection,
-  lifecycle_status: 'disabled',
+  lifecycleStatus: 'disabled',
 };
 
 function WebhookModalStory({scenario}: WebhookModalStoryProps) {

--- a/libs/client/integrations/src/components/webhook/webhook-usage-details.tsx
+++ b/libs/client/integrations/src/components/webhook/webhook-usage-details.tsx
@@ -12,9 +12,7 @@ interface WebhookUsageDetailsProps {
 
 export function WebhookUsageDetails({workspaceId, connectionId}: WebhookUsageDetailsProps) {
   const connectionsQuery = useWebhookConnectionsQuery(workspaceId);
-  const connection = connectionsQuery.data?.connections.find(
-    (candidate) => candidate.id === connectionId,
-  );
+  const connection = connectionsQuery.data?.find((candidate) => candidate.id === connectionId);
 
   if (connectionsQuery.isPending) {
     return (
@@ -36,7 +34,7 @@ export function WebhookUsageDetails({workspaceId, connectionId}: WebhookUsageDet
         <Text size="sm" bold>
           Inbound URL
         </Text>
-        <CopyableValue label="inbound URL" value={connection.inbound_url} />
+        <CopyableValue label="inbound URL" value={connection.inboundUrl} />
         <WebhookPublicEndpointAlert />
       </div>
     </div>

--- a/libs/client/integrations/src/core/models.ts
+++ b/libs/client/integrations/src/core/models.ts
@@ -1,0 +1,65 @@
+export type IntegrationCapability = 'source_control' | 'agent_tools';
+export type ConnectionLifecycleStatus = 'active' | 'disabled' | 'error';
+
+export interface IntegrationProvider {
+  provider: string;
+  displayName: string;
+  capabilities: IntegrationCapability[];
+}
+
+export interface IntegrationConnection {
+  id: string;
+  workspaceId: string;
+  provider: string;
+  externalAccountId: string;
+  slug: string;
+  displayName: string;
+  lifecycleStatus: ConnectionLifecycleStatus;
+  capabilities: IntegrationCapability[];
+  externalUrl?: string | undefined;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Repository {
+  connectionId: string;
+  externalRepositoryId: string;
+  owner: string;
+  name: string;
+  fullName: string;
+  defaultBranch: string;
+  visibility: 'public' | 'private' | 'internal' | 'unknown';
+  cloneUrl: string;
+  htmlUrl: string;
+}
+
+export interface RepositoryPage {
+  repositories: Repository[];
+  nextCursor?: string;
+}
+
+export interface WebhookConnection {
+  id: string;
+  workspaceId: string;
+  name: string;
+  slug: string;
+  lifecycleStatus: ConnectionLifecycleStatus;
+  inboundUrl: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface InstallRedirect {
+  installUrl: string;
+}
+
+export function hasCapability(
+  connection: IntegrationConnection,
+  capability: IntegrationCapability,
+) {
+  return connection.capabilities.includes(capability);
+}
+
+export function isUsableConnection(connection: IntegrationConnection) {
+  return connection.lifecycleStatus === 'active';
+}

--- a/libs/client/integrations/src/hooks/api/integration-mapper.ts
+++ b/libs/client/integrations/src/hooks/api/integration-mapper.ts
@@ -1,0 +1,59 @@
+import type {
+  IntegrationConnectionDto,
+  IntegrationProviderDto,
+  RepositoryDto,
+} from '@shipfox/api-integration-core-dto';
+import type {WebhookConnectionDto} from '@shipfox/api-integration-webhook-dto';
+import type {
+  IntegrationConnection,
+  IntegrationProvider,
+  Repository,
+  WebhookConnection,
+} from '#core/models.js';
+
+export function toIntegrationProvider(dto: IntegrationProviderDto): IntegrationProvider {
+  return {provider: dto.provider, displayName: dto.display_name, capabilities: dto.capabilities};
+}
+
+export function toIntegrationConnection(dto: IntegrationConnectionDto): IntegrationConnection {
+  return {
+    id: dto.id,
+    workspaceId: dto.workspace_id,
+    provider: dto.provider,
+    externalAccountId: dto.external_account_id,
+    slug: dto.slug,
+    displayName: dto.display_name,
+    lifecycleStatus: dto.lifecycle_status,
+    capabilities: dto.capabilities,
+    externalUrl: dto.external_url,
+    createdAt: dto.created_at,
+    updatedAt: dto.updated_at,
+  };
+}
+
+export function toRepository(dto: RepositoryDto): Repository {
+  return {
+    connectionId: dto.connection_id,
+    externalRepositoryId: dto.external_repository_id,
+    owner: dto.owner,
+    name: dto.name,
+    fullName: dto.full_name,
+    defaultBranch: dto.default_branch,
+    visibility: dto.visibility,
+    cloneUrl: dto.clone_url,
+    htmlUrl: dto.html_url,
+  };
+}
+
+export function toWebhookConnection(dto: WebhookConnectionDto): WebhookConnection {
+  return {
+    id: dto.id,
+    workspaceId: dto.workspace_id,
+    name: dto.name,
+    slug: dto.slug,
+    lifecycleStatus: dto.lifecycle_status,
+    inboundUrl: dto.inbound_url,
+    createdAt: dto.created_at,
+    updatedAt: dto.updated_at,
+  };
+}

--- a/libs/client/integrations/src/hooks/api/integrations.test.ts
+++ b/libs/client/integrations/src/hooks/api/integrations.test.ts
@@ -10,8 +10,8 @@ import {
 
 function connection(overrides: Partial<IntegrationConnectionDto> = {}): IntegrationConnectionDto {
   return {
-    id: 'c1',
-    workspace_id: 'ws-1',
+    id: '11111111-1111-4111-8111-111111111111',
+    workspace_id: '22222222-2222-4222-8222-222222222222',
     provider: 'github',
     external_account_id: 'acct',
     slug: 'github_acct',
@@ -40,19 +40,23 @@ describe('listSourceConnections', () => {
       return Promise.resolve(
         jsonResponse({
           connections: [
-            connection({id: 'active-1', lifecycle_status: 'active'}),
-            connection({id: 'disabled-1', lifecycle_status: 'disabled'}),
-            connection({id: 'error-1', lifecycle_status: 'error'}),
+            connection({id: '33333333-3333-4333-8333-333333333333', lifecycle_status: 'active'}),
+            connection({id: '44444444-4444-4444-8444-444444444444', lifecycle_status: 'disabled'}),
+            connection({id: '55555555-5555-4555-8555-555555555555', lifecycle_status: 'error'}),
           ],
         }),
       );
     });
     configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
 
-    const result = await listSourceConnections({workspaceId: 'ws-1'});
+    const result = await listSourceConnections({
+      workspaceId: '22222222-2222-4222-8222-222222222222',
+    });
 
     expect(requestedUrl).toContain('capability=source_control');
-    expect(result.connections.map((connection) => connection.id)).toEqual(['active-1']);
+    expect(result.map((connection) => connection.id)).toEqual([
+      '33333333-3333-4333-8333-333333333333',
+    ]);
   });
 });
 
@@ -63,7 +67,14 @@ describe('Slack transport', () => {
       baseUrl: 'https://api.example.test',
       fetchImpl: vi.fn((input, init) => {
         requests.push(new Request(input, init));
-        return Promise.resolve(jsonResponse(connection({provider: 'slack'})));
+        const url = input instanceof Request ? input.url : String(input);
+        return Promise.resolve(
+          jsonResponse(
+            url.endsWith('/install')
+              ? {install_url: 'https://slack.example.test/install'}
+              : connection({provider: 'slack'}),
+          ),
+        );
       }),
     });
 
@@ -89,19 +100,24 @@ describe('Linear transport', () => {
     const requests: Request[] = [];
     const fetchImpl = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       requests.push(new Request(input, init));
+      const url = input instanceof Request ? input.url : String(input);
       return Promise.resolve(
-        jsonResponse({
-          id: 'connection-1',
-          workspace_id: '11111111-1111-4111-8111-111111111111',
-          provider: 'linear',
-          external_account_id: 'linear-org',
-          slug: 'linear_org',
-          display_name: 'Linear org',
-          lifecycle_status: 'active',
-          capabilities: [],
-          created_at: '2026-01-01T00:00:00.000Z',
-          updated_at: '2026-01-01T00:00:00.000Z',
-        }),
+        jsonResponse(
+          url.endsWith('/install')
+            ? {install_url: 'https://linear.example.test/install'}
+            : {
+                id: '33333333-3333-4333-8333-333333333333',
+                workspace_id: '11111111-1111-4111-8111-111111111111',
+                provider: 'linear',
+                external_account_id: 'linear-org',
+                slug: 'linear_org',
+                display_name: 'Linear org',
+                lifecycle_status: 'active',
+                capabilities: [],
+                created_at: '2026-01-01T00:00:00.000Z',
+                updated_at: '2026-01-01T00:00:00.000Z',
+              },
+        ),
       );
     });
     configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});

--- a/libs/client/integrations/src/hooks/api/integrations.ts
+++ b/libs/client/integrations/src/hooks/api/integrations.ts
@@ -1,38 +1,45 @@
 import type {
   IntegrationCapabilityDto,
-  IntegrationConnectionDto,
-  ListIntegrationConnectionsResponseDto,
-  ListIntegrationProvidersResponseDto,
-  ListRepositoriesResponseDto,
   UpdateIntegrationConnectionBodyDto,
 } from '@shipfox/api-integration-core-dto';
-import type {
-  CreateGiteaConnectionBodyDto,
-  CreateGiteaConnectionResponseDto,
-} from '@shipfox/api-integration-gitea-dto';
-import type {
-  CreateGithubInstallBodyDto,
-  CreateGithubInstallResponseDto,
+import {
+  integrationConnectionDtoSchema,
+  listIntegrationConnectionsResponseSchema,
+  listIntegrationProvidersResponseSchema,
+  listRepositoriesResponseSchema,
+} from '@shipfox/api-integration-core-dto';
+import type {CreateGiteaConnectionBodyDto} from '@shipfox/api-integration-gitea-dto';
+import {createGiteaConnectionResponseSchema} from '@shipfox/api-integration-gitea-dto';
+import type {CreateGithubInstallBodyDto} from '@shipfox/api-integration-github-dto';
+import {
+  createGithubInstallResponseSchema,
+  githubCallbackResponseSchema,
 } from '@shipfox/api-integration-github-dto';
 import type {
   CreateLinearInstallBodyDto,
-  CreateLinearInstallResponseDto,
   LinearCallbackQueryDto,
-  LinearCallbackResponseDto,
+} from '@shipfox/api-integration-linear-dto';
+import {
+  createLinearInstallResponseSchema,
+  linearCallbackResponseSchema,
 } from '@shipfox/api-integration-linear-dto';
 import type {
   CreateSentryInstallBodyDto,
-  CreateSentryInstallResponseDto,
   SentryConnectBodyDto,
-  SentryConnectResponseDto,
+} from '@shipfox/api-integration-sentry-dto';
+import {
+  createSentryInstallResponseSchema,
+  sentryConnectResponseSchema,
 } from '@shipfox/api-integration-sentry-dto';
 import type {
   CreateSlackInstallBodyDto,
-  CreateSlackInstallResponseDto,
   SlackCallbackQueryDto,
-  SlackCallbackResponseDto,
 } from '@shipfox/api-integration-slack-dto';
-import {apiRequest} from '@shipfox/client-api';
+import {
+  createSlackInstallResponseSchema,
+  slackCallbackResponseSchema,
+} from '@shipfox/api-integration-slack-dto';
+import {checkedApiRequest, emptyResponseSchema} from '@shipfox/client-api';
 import {
   type FetchQueryOptions,
   queryOptions,
@@ -41,8 +48,14 @@ import {
   useQuery,
   useQueryClient,
 } from '@tanstack/react-query';
+import {type IntegrationConnection, isUsableConnection} from '#core/models.js';
 import {serializeLinearCallbackQuery} from '#linear-callback.js';
 import {serializeSlackCallbackQuery} from '#slack-callback.js';
+import {
+  toIntegrationConnection,
+  toIntegrationProvider,
+  toRepository,
+} from './integration-mapper.js';
 
 export const integrationsQueryKeys = {
   all: ['integrations'] as const,
@@ -66,9 +79,9 @@ type SourceConnectionsQueryKey =
   | readonly ['integrations', 'source-connections'];
 
 type SourceConnectionsQueryOptions = FetchQueryOptions<
-  ListIntegrationConnectionsResponseDto,
+  IntegrationConnection[],
   Error,
-  ListIntegrationConnectionsResponseDto,
+  IntegrationConnection[],
   SourceConnectionsQueryKey
 >;
 
@@ -83,7 +96,8 @@ export async function listIntegrationProviders({
   if (capability) search.set('capability', capability);
   const query = search.toString();
   const path = query ? `/integration-providers?${query}` : '/integration-providers';
-  return await apiRequest<ListIntegrationProvidersResponseDto>(path, {signal});
+  const response = await checkedApiRequest(listIntegrationProvidersResponseSchema, path, {signal});
+  return response.providers.map(toIntegrationProvider);
 }
 
 export async function listIntegrationConnections({
@@ -97,10 +111,12 @@ export async function listIntegrationConnections({
 }) {
   const search = new URLSearchParams({workspace_id: workspaceId});
   if (capability) search.set('capability', capability);
-  return await apiRequest<ListIntegrationConnectionsResponseDto>(
+  const response = await checkedApiRequest(
+    listIntegrationConnectionsResponseSchema,
     `/integration-connections?${search.toString()}`,
     {signal},
   );
+  return response.connections.map(toIntegrationConnection);
 }
 
 export async function listSourceConnections({
@@ -110,7 +126,7 @@ export async function listSourceConnections({
   workspaceId: string;
   signal?: AbortSignal;
 }) {
-  const result = await listIntegrationConnections({
+  const connections = await listIntegrationConnections({
     workspaceId,
     capability: 'source_control',
     signal,
@@ -118,12 +134,7 @@ export async function listSourceConnections({
   // The endpoint returns every lifecycle status (the settings hub needs that),
   // but source-control consumers (onboarding redirect, project creation) only
   // act on usable connections — a disabled/error one must read as "not there".
-  return {
-    ...result,
-    connections: result.connections.filter(
-      (connection) => connection.lifecycle_status === 'active',
-    ),
-  };
+  return connections.filter(isUsableConnection);
 }
 
 export function sourceConnectionsQueryOptions(
@@ -139,35 +150,75 @@ export function sourceConnectionsQueryOptions(
 }
 
 export async function createGiteaConnection(body: CreateGiteaConnectionBodyDto) {
-  return await apiRequest<CreateGiteaConnectionResponseDto>('/integrations/gitea/connections', {
-    method: 'POST',
-    body,
-  });
+  const response = await checkedApiRequest(
+    createGiteaConnectionResponseSchema,
+    '/integrations/gitea/connections',
+    {
+      method: 'POST',
+      body,
+    },
+  );
+  return toIntegrationConnection(response);
 }
 
 export async function createGithubInstall(body: CreateGithubInstallBodyDto) {
-  return await apiRequest<CreateGithubInstallResponseDto>('/integrations/github/install', {
-    method: 'POST',
-    body,
-  });
+  return await checkedApiRequest(
+    createGithubInstallResponseSchema,
+    '/integrations/github/install',
+    {
+      method: 'POST',
+      body,
+    },
+  );
+}
+
+export async function completeGithubCallback({
+  code,
+  installationId,
+  state,
+  setupAction,
+  token,
+}: {
+  code: string;
+  installationId: number;
+  state: string;
+  setupAction?: string;
+  token: string;
+}) {
+  const query = new URLSearchParams({code, installation_id: String(installationId), state});
+  if (setupAction) query.set('setup_action', setupAction);
+  const response = await checkedApiRequest(
+    githubCallbackResponseSchema,
+    `/integrations/github/callback/api?${query.toString()}`,
+    {headers: {authorization: `Bearer ${token}`}},
+  );
+  return toIntegrationConnection(response);
 }
 
 export async function createSentryInstall(body: CreateSentryInstallBodyDto) {
-  return await apiRequest<CreateSentryInstallResponseDto>('/integrations/sentry/install', {
-    method: 'POST',
-    body,
-  });
+  return await checkedApiRequest(
+    createSentryInstallResponseSchema,
+    '/integrations/sentry/install',
+    {
+      method: 'POST',
+      body,
+    },
+  );
 }
 
 export async function createLinearInstall(body: CreateLinearInstallBodyDto) {
-  return await apiRequest<CreateLinearInstallResponseDto>('/integrations/linear/install', {
-    method: 'POST',
-    body,
-  });
+  return await checkedApiRequest(
+    createLinearInstallResponseSchema,
+    '/integrations/linear/install',
+    {
+      method: 'POST',
+      body,
+    },
+  );
 }
 
 export async function createSlackInstall(body: CreateSlackInstallBodyDto) {
-  return await apiRequest<CreateSlackInstallResponseDto>('/integrations/slack/install', {
+  return await checkedApiRequest(createSlackInstallResponseSchema, '/integrations/slack/install', {
     method: 'POST',
     body,
   });
@@ -180,10 +231,12 @@ export async function completeLinearCallback({
   query: LinearCallbackQueryDto;
   token: string;
 }) {
-  return await apiRequest<LinearCallbackResponseDto>(
+  const response = await checkedApiRequest(
+    linearCallbackResponseSchema,
     `/integrations/linear/callback/api?${serializeLinearCallbackQuery(query)}`,
     {headers: {authorization: `Bearer ${token}`}},
   );
+  return toIntegrationConnection(response);
 }
 
 export async function completeSlackCallback({
@@ -193,20 +246,27 @@ export async function completeSlackCallback({
   query: SlackCallbackQueryDto;
   token: string;
 }) {
-  return await apiRequest<SlackCallbackResponseDto>(
+  const response = await checkedApiRequest(
+    slackCallbackResponseSchema,
     `/integrations/slack/callback/api?${serializeSlackCallbackQuery(query)}`,
     {headers: {authorization: `Bearer ${token}`}},
   );
+  return toIntegrationConnection(response);
 }
 
 // Called from the callback route with an explicit bearer (same as the GitHub
 // callback): the route refreshes auth itself before forwarding the grant code.
 export async function connectSentry({body, token}: {body: SentryConnectBodyDto; token: string}) {
-  return await apiRequest<SentryConnectResponseDto>('/integrations/sentry/connect', {
-    method: 'POST',
-    body,
-    headers: {authorization: `Bearer ${token}`},
-  });
+  const response = await checkedApiRequest(
+    sentryConnectResponseSchema,
+    '/integrations/sentry/connect',
+    {
+      method: 'POST',
+      body,
+      headers: {authorization: `Bearer ${token}`},
+    },
+  );
+  return toIntegrationConnection(response);
 }
 
 export async function listRepositories({
@@ -227,7 +287,11 @@ export async function listRepositories({
   const path = query
     ? `/integration-connections/${connectionId}/repositories?${query}`
     : `/integration-connections/${connectionId}/repositories`;
-  return await apiRequest<ListRepositoriesResponseDto>(path, {signal});
+  const response = await checkedApiRequest(listRepositoriesResponseSchema, path, {signal});
+  return {
+    repositories: response.repositories.map(toRepository),
+    nextCursor: response.next_cursor ?? undefined,
+  };
 }
 
 export async function updateIntegrationConnection({
@@ -237,21 +301,34 @@ export async function updateIntegrationConnection({
   connectionId: string;
   body: UpdateIntegrationConnectionBodyDto;
 }) {
-  return await apiRequest<IntegrationConnectionDto>(
+  const response = await checkedApiRequest(
+    integrationConnectionDtoSchema,
     `/integration-connections/${encodeURIComponent(connectionId)}`,
     {method: 'PATCH', body},
   );
+  return toIntegrationConnection(response);
 }
 
 export async function deleteIntegrationConnection({connectionId}: {connectionId: string}) {
-  await apiRequest<void>(`/integration-connections/${encodeURIComponent(connectionId)}`, {
-    method: 'DELETE',
-  });
+  await checkedApiRequest(
+    emptyResponseSchema,
+    `/integration-connections/${encodeURIComponent(connectionId)}`,
+    {
+      method: 'DELETE',
+    },
+  );
 }
 
 export function useIntegrationProvidersQuery(params?: {capability?: IntegrationCapabilityDto}) {
   const capability = params?.capability;
   return useQuery({
+    queryKey: integrationsQueryKeys.providers(capability ?? 'all'),
+    queryFn: ({signal}) => listIntegrationProviders(capability ? {capability, signal} : {signal}),
+  });
+}
+
+export function integrationProvidersQueryOptions(capability?: IntegrationCapabilityDto) {
+  return queryOptions({
     queryKey: integrationsQueryKeys.providers(capability ?? 'all'),
     queryFn: ({signal}) => listIntegrationProviders(capability ? {capability, signal} : {signal}),
   });
@@ -291,7 +368,7 @@ export function useRepositoriesInfiniteQuery(
       if (trimmedSearch) args.search = trimmedSearch;
       return listRepositories(args);
     },
-    getNextPageParam: (lastPage) => lastPage.next_cursor ?? undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor,
   });
 }
 
@@ -321,7 +398,7 @@ export function useUpdateIntegrationConnectionMutation() {
     mutationFn: updateIntegrationConnection,
     onSuccess: async (connection) => {
       await queryClient.invalidateQueries({
-        queryKey: integrationsQueryKeys.connectionsByWorkspace(connection.workspace_id),
+        queryKey: integrationsQueryKeys.connectionsByWorkspace(connection.workspaceId),
       });
     },
   });

--- a/libs/client/integrations/src/hooks/api/integrations.ts
+++ b/libs/client/integrations/src/hooks/api/integrations.ts
@@ -48,7 +48,11 @@ import {
   useQuery,
   useQueryClient,
 } from '@tanstack/react-query';
-import {type IntegrationConnection, isUsableConnection} from '#core/models.js';
+import {
+  type IntegrationConnection,
+  type IntegrationProvider,
+  isUsableConnection,
+} from '#core/models.js';
 import {serializeLinearCallbackQuery} from '#linear-callback.js';
 import {serializeSlackCallbackQuery} from '#slack-callback.js';
 import {
@@ -83,6 +87,15 @@ type SourceConnectionsQueryOptions = FetchQueryOptions<
   Error,
   IntegrationConnection[],
   SourceConnectionsQueryKey
+>;
+
+type ProvidersQueryKey = ReturnType<typeof integrationsQueryKeys.providers>;
+
+type ProvidersQueryOptions = FetchQueryOptions<
+  IntegrationProvider[],
+  Error,
+  IntegrationProvider[],
+  ProvidersQueryKey
 >;
 
 export async function listIntegrationProviders({
@@ -327,7 +340,9 @@ export function useIntegrationProvidersQuery(params?: {capability?: IntegrationC
   });
 }
 
-export function integrationProvidersQueryOptions(capability?: IntegrationCapabilityDto) {
+export function integrationProvidersQueryOptions(
+  capability?: IntegrationCapabilityDto,
+): ProvidersQueryOptions {
   return queryOptions({
     queryKey: integrationsQueryKeys.providers(capability ?? 'all'),
     queryFn: ({signal}) => listIntegrationProviders(capability ? {capability, signal} : {signal}),

--- a/libs/client/integrations/src/hooks/api/webhook-connections.ts
+++ b/libs/client/integrations/src/hooks/api/webhook-connections.ts
@@ -8,12 +8,14 @@ import {
 } from '@shipfox/api-integration-webhook-dto';
 import {checkedApiRequest, emptyResponseSchema} from '@shipfox/client-api';
 import {
+  type FetchQueryOptions,
   type QueryClient,
   queryOptions,
   useMutation,
   useQuery,
   useQueryClient,
 } from '@tanstack/react-query';
+import type {WebhookConnection} from '#core/models.js';
 import {toWebhookConnection} from './integration-mapper.js';
 import {integrationsQueryKeys} from './integrations.js';
 
@@ -21,6 +23,15 @@ export const webhookConnectionsQueryKeys = {
   all: ['webhook-connections'] as const,
   list: (workspaceId: string) => [...webhookConnectionsQueryKeys.all, 'list', workspaceId] as const,
 };
+
+type WebhookConnectionsListQueryKey = ReturnType<typeof webhookConnectionsQueryKeys.list>;
+
+type WebhookConnectionsListQueryOptions = FetchQueryOptions<
+  WebhookConnection[],
+  Error,
+  WebhookConnection[],
+  WebhookConnectionsListQueryKey
+>;
 
 export async function listWebhookConnections({
   workspaceId,
@@ -85,7 +96,9 @@ export function useWebhookConnectionsQuery(workspaceId: string | undefined) {
   });
 }
 
-export function webhookConnectionsQueryOptions(workspaceId: string) {
+export function webhookConnectionsQueryOptions(
+  workspaceId: string,
+): WebhookConnectionsListQueryOptions {
   return queryOptions({
     queryKey: webhookConnectionsQueryKeys.list(workspaceId),
     queryFn: ({signal}) => listWebhookConnections({workspaceId, signal}),

--- a/libs/client/integrations/src/hooks/api/webhook-connections.ts
+++ b/libs/client/integrations/src/hooks/api/webhook-connections.ts
@@ -1,11 +1,20 @@
 import type {
   CreateWebhookConnectionBodyDto,
-  ListWebhookConnectionsResponseDto,
   UpdateWebhookConnectionBodyDto,
-  WebhookConnectionDto,
 } from '@shipfox/api-integration-webhook-dto';
-import {apiRequest} from '@shipfox/client-api';
-import {type QueryClient, useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
+import {
+  listWebhookConnectionsResponseSchema,
+  webhookConnectionDtoSchema,
+} from '@shipfox/api-integration-webhook-dto';
+import {checkedApiRequest, emptyResponseSchema} from '@shipfox/client-api';
+import {
+  type QueryClient,
+  queryOptions,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
+import {toWebhookConnection} from './integration-mapper.js';
 import {integrationsQueryKeys} from './integrations.js';
 
 export const webhookConnectionsQueryKeys = {
@@ -21,17 +30,24 @@ export async function listWebhookConnections({
   signal?: AbortSignal;
 }) {
   const search = new URLSearchParams({workspace_id: workspaceId});
-  return await apiRequest<ListWebhookConnectionsResponseDto>(
+  const response = await checkedApiRequest(
+    listWebhookConnectionsResponseSchema,
     `/integrations/webhook/connections?${search.toString()}`,
     {signal},
   );
+  return response.connections.map(toWebhookConnection);
 }
 
 export async function createWebhookConnection(body: CreateWebhookConnectionBodyDto) {
-  return await apiRequest<WebhookConnectionDto>('/integrations/webhook/connections', {
-    method: 'POST',
-    body,
-  });
+  const response = await checkedApiRequest(
+    webhookConnectionDtoSchema,
+    '/integrations/webhook/connections',
+    {
+      method: 'POST',
+      body,
+    },
+  );
+  return toWebhookConnection(response);
 }
 
 export async function updateWebhookConnection({
@@ -41,16 +57,22 @@ export async function updateWebhookConnection({
   connectionId: string;
   body: UpdateWebhookConnectionBodyDto;
 }) {
-  return await apiRequest<WebhookConnectionDto>(
+  const response = await checkedApiRequest(
+    webhookConnectionDtoSchema,
     `/integrations/webhook/connections/${encodeURIComponent(connectionId)}`,
     {method: 'PATCH', body},
   );
+  return toWebhookConnection(response);
 }
 
 export async function deleteWebhookConnection({connectionId}: {connectionId: string}) {
-  await apiRequest<void>(`/integrations/webhook/connections/${encodeURIComponent(connectionId)}`, {
-    method: 'DELETE',
-  });
+  await checkedApiRequest(
+    emptyResponseSchema,
+    `/integrations/webhook/connections/${encodeURIComponent(connectionId)}`,
+    {
+      method: 'DELETE',
+    },
+  );
 }
 
 export function useWebhookConnectionsQuery(workspaceId: string | undefined) {
@@ -63,12 +85,19 @@ export function useWebhookConnectionsQuery(workspaceId: string | undefined) {
   });
 }
 
+export function webhookConnectionsQueryOptions(workspaceId: string) {
+  return queryOptions({
+    queryKey: webhookConnectionsQueryKeys.list(workspaceId),
+    queryFn: ({signal}) => listWebhookConnections({workspaceId, signal}),
+  });
+}
+
 export function useCreateWebhookConnectionMutation() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: createWebhookConnection,
     onSuccess: async (connection) => {
-      await invalidateWebhookConnectionViews(queryClient, connection.workspace_id);
+      await invalidateWebhookConnectionViews(queryClient, connection.workspaceId);
     },
   });
 }
@@ -85,7 +114,7 @@ export function useUpdateWebhookConnectionMutation() {
       body: UpdateWebhookConnectionBodyDto;
     }) => updateWebhookConnection({connectionId, body}),
     onSuccess: async (connection) => {
-      await invalidateWebhookConnectionViews(queryClient, connection.workspace_id);
+      await invalidateWebhookConnectionViews(queryClient, connection.workspaceId);
     },
   });
 }

--- a/libs/client/integrations/src/index.ts
+++ b/libs/client/integrations/src/index.ts
@@ -1,3 +1,4 @@
+export * from '#core/models.js';
 export * from './components/connection-picker.js';
 export * from './components/integration-gallery.js';
 export * from './components/redirect-install-page.js';

--- a/libs/client/integrations/src/pages/linear-callback-page.tsx
+++ b/libs/client/integrations/src/pages/linear-callback-page.tsx
@@ -1,4 +1,3 @@
-import type {LinearCallbackResponseDto} from '@shipfox/api-integration-linear-dto';
 import {useRefreshAuth} from '@shipfox/client-auth';
 import {createSingleFlight} from '@shipfox/client-ui';
 import {FullPageLoader} from '@shipfox/react-ui/loader';
@@ -7,6 +6,7 @@ import {useQueryClient} from '@tanstack/react-query';
 import {useNavigate, useSearch} from '@tanstack/react-router';
 import {useEffect, useMemo, useState} from 'react';
 import {CallbackStatusShell} from '#components/callback-status-shell.js';
+import type {IntegrationConnection} from '#core/models.js';
 import {integrationsQueryKeys, useCompleteLinearCallbackMutation} from '#hooks/api/integrations.js';
 import {
   classifyLinearCallbackError,
@@ -19,7 +19,7 @@ import {
 
 // Retain only recent completions: this bounds long-lived callback pages while
 // still covering StrictMode and immediate Back/Forward remounts.
-const callbackRequests = createSingleFlight<string, LinearCallbackResponseDto>({
+const callbackRequests = createSingleFlight<string, IntegrationConnection>({
   maxTerminalResults: 32,
 });
 // Keeps the success toast firing once per distinct callback even though the
@@ -65,7 +65,7 @@ export function LinearCallbackPage() {
         }
         try {
           await queryClient.invalidateQueries({
-            queryKey: integrationsQueryKeys.connectionsByWorkspace(connection.workspace_id),
+            queryKey: integrationsQueryKeys.connectionsByWorkspace(connection.workspaceId),
           });
         } catch {
           // Cache refresh is best effort: the successful callback is already committed server-side.
@@ -78,7 +78,7 @@ export function LinearCallbackPage() {
         try {
           await navigate({
             to: '/workspaces/$wid/settings/integrations',
-            params: {wid: connection.workspace_id},
+            params: {wid: connection.workspaceId},
             replace: true,
           });
         } catch {

--- a/libs/client/integrations/src/pages/sentry-callback-page.tsx
+++ b/libs/client/integrations/src/pages/sentry-callback-page.tsx
@@ -1,4 +1,3 @@
-import type {SentryConnectResponseDto} from '@shipfox/api-integration-sentry-dto';
 import {useAuthState, useRefreshAuth} from '@shipfox/client-auth';
 import {createSingleFlight} from '@shipfox/client-ui';
 import {Button, ButtonLink} from '@shipfox/react-ui/button';
@@ -10,6 +9,7 @@ import {Header, Text} from '@shipfox/react-ui/typography';
 import {useQueryClient} from '@tanstack/react-query';
 import {Link, useNavigate, useSearch} from '@tanstack/react-router';
 import {useEffect, useMemo, useRef, useState} from 'react';
+import type {IntegrationConnection} from '#core/models.js';
 import {connectSentry, integrationsQueryKeys} from '#hooks/api/integrations.js';
 import {
   classifySentryConnectError,
@@ -20,7 +20,7 @@ import {
   type SentryConnectFailure,
 } from '#sentry-callback.js';
 
-const connectRequests = createSingleFlight<string, SentryConnectResponseDto>();
+const connectRequests = createSingleFlight<string, IntegrationConnection>();
 
 export function SentryCallbackPage() {
   const search = useSearch({strict: false});

--- a/libs/client/integrations/src/pages/slack-callback-page.tsx
+++ b/libs/client/integrations/src/pages/slack-callback-page.tsx
@@ -1,4 +1,3 @@
-import type {SlackCallbackResponseDto} from '@shipfox/api-integration-slack-dto';
 import {useRefreshAuth} from '@shipfox/client-auth';
 import {createSingleFlight} from '@shipfox/client-ui';
 import {FullPageLoader} from '@shipfox/react-ui/loader';
@@ -7,6 +6,7 @@ import {useQueryClient} from '@tanstack/react-query';
 import {useNavigate, useSearch} from '@tanstack/react-router';
 import {useEffect, useMemo, useState} from 'react';
 import {CallbackStatusShell} from '#components/callback-status-shell.js';
+import type {IntegrationConnection} from '#core/models.js';
 import {integrationsQueryKeys, useCompleteSlackCallbackMutation} from '#hooks/api/integrations.js';
 import {
   classifySlackCallbackError,
@@ -19,7 +19,7 @@ import {
 
 // Retain only recent completions: this bounds long-lived callback pages while
 // still covering StrictMode and immediate Back/Forward remounts.
-const callbackRequests = createSingleFlight<string, SlackCallbackResponseDto>({
+const callbackRequests = createSingleFlight<string, IntegrationConnection>({
   maxTerminalResults: 32,
 });
 const completedCallbacks = new Set<string>();
@@ -52,7 +52,7 @@ export function SlackCallbackPage() {
       async (connection) => {
         if (disposed) return;
         if (completedCallbacks.has(key)) {
-          setCompletedWorkspaceId(connection.workspace_id);
+          setCompletedWorkspaceId(connection.workspaceId);
           return;
         }
         completedCallbacks.add(key);
@@ -63,7 +63,7 @@ export function SlackCallbackPage() {
         }
         try {
           await queryClient.invalidateQueries({
-            queryKey: integrationsQueryKeys.connectionsByWorkspace(connection.workspace_id),
+            queryKey: integrationsQueryKeys.connectionsByWorkspace(connection.workspaceId),
           });
         } catch {
           // Navigation can continue when cache refresh is unavailable.
@@ -76,11 +76,11 @@ export function SlackCallbackPage() {
         try {
           await navigate({
             to: '/workspaces/$wid/settings/integrations',
-            params: {wid: connection.workspace_id},
+            params: {wid: connection.workspaceId},
             replace: true,
           });
         } catch {
-          if (!disposed) setCompletedWorkspaceId(connection.workspace_id);
+          if (!disposed) setCompletedWorkspaceId(connection.workspaceId);
         }
       },
       (error: unknown) => {

--- a/libs/client/integrations/src/pages/source-control-onboarding-page.tsx
+++ b/libs/client/integrations/src/pages/source-control-onboarding-page.tsx
@@ -17,7 +17,11 @@ export function SourceControlOnboardingPage() {
       </header>
 
       <ProviderGrid
-        providersQuery={providersQuery}
+        providers={providersQuery.data ?? []}
+        isPending={providersQuery.isPending}
+        isFetching={providersQuery.isFetching}
+        error={providersQuery.isError ? providersQuery.error : undefined}
+        onRetry={() => void providersQuery.refetch()}
         workspaceId={workspace.id}
         emptyMessage="Enable at least one source-control provider in the application settings."
       />

--- a/libs/client/integrations/src/routes/github-callback.tsx
+++ b/libs/client/integrations/src/routes/github-callback.tsx
@@ -1,4 +1,4 @@
-import {ApiError, apiRequest} from '@shipfox/client-api';
+import {ApiError} from '@shipfox/client-api';
 import {useRefreshAuth} from '@shipfox/client-auth';
 import {defineRoute} from '@shipfox/client-shell/runtime';
 import {createSingleFlight} from '@shipfox/client-ui';
@@ -6,6 +6,7 @@ import {FullPageLoader} from '@shipfox/react-ui/loader';
 import {toast} from '@shipfox/react-ui/toast';
 import {useNavigate, useSearch} from '@tanstack/react-router';
 import {useEffect} from 'react';
+import {completeGithubCallback} from '#hooks/api/integrations.js';
 
 interface GithubCallbackParams {
   code: string;
@@ -47,9 +48,7 @@ function GithubCallbackRoute() {
       key,
       async () =>
         await refreshAuth().then(async (session) => {
-          await apiRequest(`/integrations/github/callback/api?${key}`, {
-            headers: {authorization: `Bearer ${session.accessToken}`},
-          });
+          await completeGithubCallback({...params, token: session.accessToken});
         }),
     );
     request

--- a/libs/client/onboarding/src/workspace-setup-route.test.tsx
+++ b/libs/client/onboarding/src/workspace-setup-route.test.tsx
@@ -53,6 +53,24 @@ function sourceConnection(overrides: {lifecycle_status?: string} = {}) {
   };
 }
 
+// The query cache stores the mapped domain shape (camelCase), not the wire
+// DTO `sourceConnection()` mocks for fetch responses — keep this seed in sync
+// with `toIntegrationConnection` in client-integrations.
+function cachedSourceConnection() {
+  return {
+    id: '33333333-3333-4333-8333-333333333333',
+    workspaceId: WORKSPACE_ID,
+    provider: 'github',
+    externalAccountId: 'acct',
+    slug: 'github_acct',
+    displayName: 'GitHub',
+    lifecycleStatus: 'active' as const,
+    capabilities: ['source_control' as const],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
 interface SetupFetchOptions {
   projects?: unknown[];
   connections?: unknown[];
@@ -361,9 +379,9 @@ describe('workspace setup route hook', () => {
 
     renderSetupRoute(`/workspaces/${WORKSPACE_ID}`, fetchImpl, {
       seedQueryClient: (queryClient) => {
-        queryClient.setQueryData(sourceConnectionsQueryOptions(WORKSPACE_ID).queryKey, {
-          connections: [sourceConnection()] as never,
-        });
+        queryClient.setQueryData(sourceConnectionsQueryOptions(WORKSPACE_ID).queryKey, [
+          cachedSourceConnection(),
+        ]);
       },
     });
 

--- a/libs/client/onboarding/src/workspace-setup-route.ts
+++ b/libs/client/onboarding/src/workspace-setup-route.ts
@@ -2,7 +2,10 @@ import {
   isModelProviderOnboardingDismissed,
   modelProviderConfigsQueryOptions,
 } from '@shipfox/client-agent';
-import {sourceConnectionsQueryOptions} from '@shipfox/client-integrations';
+import {
+  type IntegrationConnection,
+  sourceConnectionsQueryOptions,
+} from '@shipfox/client-integrations';
 import {projectExistenceQueryOptions} from '@shipfox/client-projects';
 import {WorkspaceSetupLoadError, type WorkspaceSetupState} from '@shipfox/client-shell/runtime';
 import type {QueryClient} from '@tanstack/react-query';
@@ -37,7 +40,9 @@ export async function loadWorkspaceSetupRoute({
   }
 
   const sourceConnections = await fetchWorkspaceSourceConnections(queryClient, workspaceId);
-  if (sourceConnections.connections.length === 0) {
+  const hasSourceConnection = sourceConnections.length > 0;
+
+  if (!hasSourceConnection) {
     if (isIntegrationSetupPath(normalizedPathname, workspaceId)) {
       return {hideProjectNavigation: true};
     }
@@ -95,7 +100,7 @@ async function fetchWorkspaceSourceConnections(queryClient: QueryClient, workspa
   try {
     return await queryClient.fetchQuery(options);
   } catch (error) {
-    const cached = queryClient.getQueryData<{connections: unknown[]}>(options.queryKey);
+    const cached = queryClient.getQueryData<IntegrationConnection[]>(options.queryKey);
     if (cached !== undefined) return cached;
     throw new WorkspaceSetupLoadError(error);
   }

--- a/libs/client/projects/src/components/source-strip.tsx
+++ b/libs/client/projects/src/components/source-strip.tsx
@@ -26,7 +26,7 @@ export function SourceStrip({
 }) {
   const workspace = useActiveWorkspace();
   const connectionsQuery = useSourceConnectionsQuery(workspace.id);
-  const connection = connectionsQuery.data?.connections.find((c) => c.id === connectionId);
+  const connection = connectionsQuery.data?.find((c) => c.id === connectionId);
 
   return (
     <section
@@ -40,7 +40,7 @@ export function SourceStrip({
             <Skeleton className="h-16 w-160" />
           ) : (
             <Text size="sm" bold className="truncate">
-              {connection?.display_name ?? 'Connected source'}
+              {connection?.displayName ?? 'Connected source'}
             </Text>
           )}
           <Tooltip>

--- a/libs/client/projects/src/pages/create-project-page.tsx
+++ b/libs/client/projects/src/pages/create-project-page.tsx
@@ -1,4 +1,3 @@
-import type {IntegrationConnectionDto} from '@shipfox/api-integration-core-dto';
 import {
   createProjectBodySchema,
   type ListProjectsResponseDto,
@@ -7,6 +6,7 @@ import {
 import {useMaybeActiveWorkspace} from '@shipfox/client-auth';
 import {
   ConnectionPicker,
+  type IntegrationConnection,
   IntegrationIcon,
   RepositoryPicker,
   useRepositoriesInfiniteQuery,
@@ -37,7 +37,7 @@ export function CreateProjectPage() {
   const errorRef = useRef<HTMLDivElement>(null);
 
   const connectionsQuery = useSourceConnectionsQuery(workspace?.id);
-  const connections = connectionsQuery.data?.connections ?? [];
+  const connections = connectionsQuery.data ?? [];
 
   const [selectedConnectionId, setSelectedConnectionId] = useState<string | undefined>();
   const singleConnectionId = connections.length === 1 ? connections[0]?.id : undefined;
@@ -48,7 +48,7 @@ export function CreateProjectPage() {
     }
   }, [singleConnectionId, selectedConnectionId]);
 
-  const selectedConnection: IntegrationConnectionDto | undefined = connections.find(
+  const selectedConnection: IntegrationConnection | undefined = connections.find(
     (connection) => connection.id === effectiveSelectedConnectionId,
   );
 
@@ -65,11 +65,11 @@ export function CreateProjectPage() {
   const [selectedRepositoryId, setSelectedRepositoryId] = useState<string | undefined>();
   useEffect(() => {
     if (!selectedRepositoryId && repositories[0]) {
-      setSelectedRepositoryId(repositories[0].external_repository_id);
+      setSelectedRepositoryId(repositories[0].externalRepositoryId);
     }
   }, [repositories, selectedRepositoryId]);
   const selectedRepository = repositories.find(
-    (repository) => repository.external_repository_id === selectedRepositoryId,
+    (repository) => repository.externalRepositoryId === selectedRepositoryId,
   );
 
   const [nameTouched, setNameTouched] = useState(false);
@@ -133,7 +133,7 @@ export function CreateProjectPage() {
         name: projectName,
         source: {
           connection_id: selectedConnection.id,
-          external_repository_id: selectedRepository.external_repository_id,
+          external_repository_id: selectedRepository.externalRepositoryId,
         },
       });
       const project = await createProject.mutateAsync(projectBody);
@@ -284,7 +284,7 @@ export function CreateProjectPage() {
 
             <ProjectSummary
               connection={selectedConnection}
-              repositoryName={selectedRepository?.full_name}
+              repositoryName={selectedRepository?.fullName}
             />
 
             <form.Field
@@ -333,7 +333,7 @@ function ProjectSummary({
   connection,
   repositoryName,
 }: {
-  connection: IntegrationConnectionDto | undefined;
+  connection: IntegrationConnection | undefined;
   repositoryName: string | undefined;
 }) {
   return (

--- a/libs/client/projects/src/pages/projects-hub-page.tsx
+++ b/libs/client/projects/src/pages/projects-hub-page.tsx
@@ -1,8 +1,8 @@
-import type {IntegrationConnectionDto} from '@shipfox/api-integration-core-dto';
 import type {ProjectResponseDto} from '@shipfox/api-projects-dto';
 import {useActiveWorkspace} from '@shipfox/client-auth';
 import {
   ConnectionStatusBadge,
+  type IntegrationConnection,
   IntegrationIcon,
   useIntegrationConnectionsQuery,
 } from '@shipfox/client-integrations';
@@ -35,7 +35,7 @@ export function ProjectsHubPage() {
     projects.length > 0 ? workspace.id : undefined,
   );
   const connectionsById = new Map(
-    (connectionsQuery.data?.connections ?? []).map((connection) => [connection.id, connection]),
+    (connectionsQuery.data ?? []).map((connection) => [connection.id, connection]),
   );
 
   const isInitialLoading = query.isPending;
@@ -202,7 +202,7 @@ function ProjectCard({
   workspaceId,
 }: {
   project: ProjectResponseDto;
-  connection: IntegrationConnectionDto | undefined;
+  connection: IntegrationConnection | undefined;
   connectionsResolved: boolean;
   connectionsSettled: boolean;
   workspaceId: string;
@@ -210,7 +210,7 @@ function ProjectCard({
   // On a resolved fetch, `active` carries no badge while a missing connection
   // reads as an error so a broken source is still flagged. An unresolved or
   // failed fetch shows nothing, so a fetch failure never flags every card.
-  const status = connectionsResolved ? (connection?.lifecycle_status ?? 'error') : undefined;
+  const status = connectionsResolved ? (connection?.lifecycleStatus ?? 'error') : undefined;
 
   return (
     <li>

--- a/tools/client-architecture-policy/client-architecture-baseline.json
+++ b/tools/client-architecture-policy/client-architecture-baseline.json
@@ -65,69 +65,14 @@
     "occurrences": 1
   },
   {
-    "file": "libs/client/integrations/src/components/connection-picker.tsx",
-    "rule": "response-dto-in-presentation",
-    "occurrences": 1
-  },
-  {
-    "file": "libs/client/integrations/src/components/installed-integrations-section.tsx",
-    "rule": "response-dto-in-presentation",
-    "occurrences": 2
-  },
-  {
-    "file": "libs/client/integrations/src/components/integration-gallery-for-workspace.tsx",
-    "rule": "response-dto-in-presentation",
-    "occurrences": 3
-  },
-  {
-    "file": "libs/client/integrations/src/components/integration-gallery.tsx",
-    "rule": "response-dto-in-presentation",
-    "occurrences": 1
-  },
-  {
-    "file": "libs/client/integrations/src/components/integration-usage-events.ts",
-    "rule": "response-dto-in-presentation",
-    "occurrences": 1
-  },
-  {
-    "file": "libs/client/integrations/src/components/integration-usage-modal.tsx",
-    "rule": "response-dto-in-presentation",
-    "occurrences": 1
-  },
-  {
-    "file": "libs/client/integrations/src/components/provider-grid.tsx",
-    "rule": "response-dto-in-presentation",
-    "occurrences": 2
-  },
-  {
-    "file": "libs/client/integrations/src/components/repository-picker.tsx",
-    "rule": "response-dto-in-presentation",
-    "occurrences": 1
-  },
-  {
-    "file": "libs/client/integrations/src/components/webhook/webhook-create-modal.tsx",
-    "rule": "response-dto-in-presentation",
-    "occurrences": 2
-  },
-  {
-    "file": "libs/client/integrations/src/pages/linear-callback-page.tsx",
-    "rule": "response-dto-in-presentation",
-    "occurrences": 1
-  },
-  {
-    "file": "libs/client/integrations/src/pages/sentry-callback-page.tsx",
-    "rule": "response-dto-in-presentation",
-    "occurrences": 1
-  },
-  {
-    "file": "libs/client/integrations/src/pages/slack-callback-page.tsx",
-    "rule": "response-dto-in-presentation",
-    "occurrences": 1
-  },
-  {
-    "file": "libs/client/integrations/src/routes/github-callback.tsx",
+    "file": "libs/client/auth/src/pages/invitation-context.ts",
     "rule": "api-request-outside-adapter",
     "occurrences": 1
+  },
+  {
+    "file": "libs/client/auth/src/pages/invitation-context.ts",
+    "rule": "response-dto-in-presentation",
+    "occurrences": 2
   },
   {
     "file": "libs/client/logs/src/core/log-read.ts",
@@ -145,19 +90,14 @@
     "occurrences": 1
   },
   {
-    "file": "libs/client/projects/src/components/workspace-setup-guard.tsx",
-    "rule": "response-dto-in-presentation",
-    "occurrences": 2
-  },
-  {
     "file": "libs/client/projects/src/pages/create-project-page.tsx",
     "rule": "response-dto-in-presentation",
-    "occurrences": 3
+    "occurrences": 2
   },
   {
     "file": "libs/client/projects/src/pages/projects-hub-page.tsx",
     "rule": "response-dto-in-presentation",
-    "occurrences": 2
+    "occurrences": 1
   },
   {
     "file": "libs/client/runners/src/components/create-manual-registration-token-form.tsx",


### PR DESCRIPTION
The integrations client package exposed raw API DTOs (snake_case wire types) directly through its hooks and component props. Consumers had to reach into `@shipfox/api-integration-*-dto` packages and work with `workspace_id`, `lifecycle_status`, `external_repository_id`, and similar wire-format fields, and unchecked `apiRequest` calls let malformed responses flow straight into the UI.

This introduces a package-owned domain model (`IntegrationConnection`, `IntegrationProvider`, `Repository`, `WebhookConnection` in `core/models.ts`) with mappers that convert DTOs to camelCase domain objects at the transport boundary. Response parsing moves from `apiRequest` to `checkedApiRequest`, so a malformed API response now fails fast with schema validation instead of propagating into components.

Updates the two `client-projects` consumers that read the old DTO shape off these hooks (`create-project-page`, `projects-hub-page`, `source-strip`, `workspace-setup-guard`), and removes the now-satisfied `response-dto-in-presentation` / `api-request-outside-adapter` baseline exceptions for this package in the client architecture policy.

This is a breaking change to `@shipfox/client-integrations`'s public API (hook return shapes and component props changed from DTO to domain model); see the changeset for the full bump summary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converged the integrations client on package-owned, camelCase domain models with schema-validated API boundaries. This removes DTO leaks into UI code, simplifies consumers, and fails fast on malformed responses.

- **Refactors**
  - Added domain types in `@shipfox/client-integrations` (exported): IntegrationConnection, IntegrationProvider, Repository, WebhookConnection, plus helpers like `isUsableConnection`.
  - Mapped wire DTOs to domain at the adapter with `integration-mapper`; switched all requests to `checkedApiRequest`; added `emptyResponseSchema` in `@shipfox/client-api` for empty responses.
  - Validated and mapped all integration flows (installs, callbacks, CRUD) to domain; added queryOptions helpers for providers/webhooks; removed client architecture baseline exceptions.
  - Fixed external consumer type-checking by giving `integrationProvidersQueryOptions` and `webhookConnectionsQueryOptions` explicit `FetchQueryOptions` return types.

- **Migration**
  - Breaking API in `@shipfox/client-integrations`:
    - `useSourceConnectionsQuery`, `useIntegrationConnectionsQuery`, `useIntegrationProvidersQuery` now return arrays of domain models (not `{connections}`/`{providers}`).
    - `useSourceConnectionsQuery` now returns only active connections.
    - `useRepositoriesInfiniteQuery` page shape is `{repositories, nextCursor}`; repository fields are camelCase.
    - Component props updated to domain models: `ConnectionPicker`, `ProviderGrid`, `RepositoryPicker`. `ProviderGrid` now takes `providers`, `isPending`, optional `isFetching`/`error`, and `onRetry`.
  - Field names are camelCase (e.g., `displayName`, `lifecycleStatus`, `createdAt`, `workspaceId`, `externalUrl`). Update usages accordingly.

<sup>Written for commit 93f961a53f2554ad1ec72d66cfdc60640577ddd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

