### PR TITLE
Fix affected image detection in pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,9 @@ jobs:
       # --affected skips images untouched by the PR. The Docker wrapper validates
       # PR builds with BuildKit's cache-only output, so no local image import runs.
       - name: Build images
+        env:
+          TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
+          TURBO_SCM_HEAD: ${{ github.event.pull_request.head.sha }}
         run: turbo image --affected --filter "${{ matrix.package }}"
 
   build-images:


### PR DESCRIPTION
Ensure PR image validation compares immutable base and head SHAs when Turbo determines affected packages.

Turbo's automatic GitHub base resolution looked for a local `main` ref that the checkout did not create, even with full history available. It therefore fell back to treating every file as changed and built all application images. Passing the pull request event SHAs restores dependency-aware image selection without changing main's image publishing behavior.

The existing per-image matrix remains in place for now. Unaffected matrix jobs still perform runner setup, but their image build tasks are skipped correctly; a dynamic matrix can be considered separately if runner setup becomes the next bottleneck.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix affected image detection in PRs by passing immutable base and head SHAs to `turbo`, so CI only builds images touched by the change.

- **Bug Fixes**
  - Set `TURBO_SCM_BASE` and `TURBO_SCM_HEAD` from `github.event.pull_request` to prevent `turbo` from treating all files as changed when a local `main` ref is missing.
  - Keeps per-image matrix behavior; unaffected jobs still set up the runner but skip image builds. Main branch publishing is unchanged.

<sup>Written for commit ebe6c3bcd97ab6a1ce2440eefceee740c68a72ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

