### PR TITLE
Add deterministic generated release verifier

### DIFF
--- a/tools/package-release/README.md
+++ b/tools/package-release/README.md
@@ -1,0 +1,28 @@
+# Package release tooling
+
+`verify-generated-release` checks whether a pull request is exactly the output
+of `pnpm exec changeset version` from its declared base revision.
+
+The release App identity and `changeset-release/main` branch are required
+signals, but they are not a security boundary. An attacker can reproduce a
+branch name or create a pull request with similar metadata. The verifier creates
+an isolated checkout at the base revision, regenerates the version change, and
+compares the complete Git tree with the submitted head revision. Any extra or
+changed file, including a package manifest field, makes the result
+`not-generated-release`.
+
+The command prints exactly one JSON result to standard output:
+
+```sh
+pnpm --filter=@shipfox/package-release verify-generated-release -- \
+  --base "$BASE_SHA" \
+  --head "$HEAD_SHA" \
+  --repository "$GITHUB_REPOSITORY" \
+  --head-repository "$HEAD_REPOSITORY" \
+  --head-ref "$HEAD_REF" \
+  --author-id "$PULL_REQUEST_AUTHOR_ID" \
+  --release-app-id "$RELEASE_BOT_APP_ID"
+```
+
+`classification` is either `generated-release` or `not-generated-release`.
+CI must use only `generated-release` to select a release-specific path.

--- a/tools/package-release/package.json
+++ b/tools/package-release/package.json
@@ -4,12 +4,14 @@
   "private": true,
   "type": "module",
   "exports": {
+    "./generated-release-verifier": "./dist/generated-release-verifier.js",
     "./packer": "./dist/productionized-manifest-packer.js"
   },
   "scripts": {
     "build": "shipfox-swc",
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
+    "verify-generated-release": "node dist/generated-release-verifier.js",
     "publish:closure": "node dist/publish-productionized-closure.js",
     "test": "shipfox-vitest-run",
     "test:watch": "shipfox-vitest-watch",

--- a/tools/package-release/src/generated-release-verifier.ts
+++ b/tools/package-release/src/generated-release-verifier.ts
@@ -1,0 +1,221 @@
+import {spawn} from 'node:child_process';
+import {mkdtemp, rm} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+export type GeneratedReleaseClassification = 'generated-release' | 'not-generated-release';
+
+export interface GeneratedReleaseVerificationResult {
+  classification: GeneratedReleaseClassification;
+  reason:
+    | 'generated-tree-matches'
+    | 'head-repository-mismatch'
+    | 'release-branch-mismatch'
+    | 'release-app-mismatch'
+    | 'dependency-install-failed'
+    | 'version-command-failed'
+    | 'generated-tree-mismatch'
+    | 'verification-error';
+  message: string;
+}
+
+export interface ReleasePullRequestMetadata {
+  authorId: string;
+  headRef: string;
+  headRepository: string;
+  repository: string;
+}
+
+export interface VerifyGeneratedReleaseOptions {
+  baseRevision: string;
+  expectedReleaseAppId: string;
+  expectedReleaseBranch: string;
+  headRevision: string;
+  metadata: ReleasePullRequestMetadata;
+  repositoryRoot: string;
+}
+
+interface CommandResult {
+  stderr: string;
+  stdout: string;
+}
+
+type Command = (command: string, args: string[], cwd: string) => Promise<CommandResult>;
+
+/**
+ * Verifies the complete Git tree rather than trusting release-App identity.
+ * The App and branch checks narrow the candidate set, but either can be copied
+ * onto a malicious pull request; only regenerated content is the boundary.
+ */
+export async function verifyGeneratedRelease(
+  options: VerifyGeneratedReleaseOptions,
+  command: Command = run,
+): Promise<GeneratedReleaseVerificationResult> {
+  const metadataResult = verifyReleaseMetadata(options);
+  if (metadataResult) return metadataResult;
+
+  const repositoryRoot = resolve(options.repositoryRoot);
+  const temporaryRoot = await mkdtemp(join(tmpdir(), 'shipfox-generated-release-'));
+  const checkoutRoot = join(temporaryRoot, 'checkout');
+  let worktreeAdded = false;
+
+  try {
+    await command(
+      'git',
+      ['worktree', 'add', '--detach', checkoutRoot, options.baseRevision],
+      repositoryRoot,
+    );
+    worktreeAdded = true;
+
+    try {
+      await command('pnpm', ['install', '--frozen-lockfile', '--ignore-scripts'], checkoutRoot);
+    } catch (error) {
+      return rejection('dependency-install-failed', commandError(error));
+    }
+
+    try {
+      await command('pnpm', ['exec', 'changeset', 'version'], checkoutRoot);
+    } catch (error) {
+      return rejection('version-command-failed', commandError(error));
+    }
+
+    await command('git', ['add', '--all'], checkoutRoot);
+    const generatedTree = (await command('git', ['write-tree'], checkoutRoot)).stdout.trim();
+    const headTree = (
+      await command('git', ['rev-parse', `${options.headRevision}^{tree}`], repositoryRoot)
+    ).stdout.trim();
+
+    if (generatedTree !== headTree) {
+      return rejection(
+        'generated-tree-mismatch',
+        'The pull request tree is not the exact output of changeset version from its base revision.',
+      );
+    }
+
+    return {
+      classification: 'generated-release',
+      reason: 'generated-tree-matches',
+      message:
+        'The pull request tree exactly matches changeset version output from its base revision.',
+    };
+  } catch (error) {
+    return rejection('verification-error', commandError(error));
+  } finally {
+    if (worktreeAdded) {
+      try {
+        await command('git', ['worktree', 'remove', '--force', checkoutRoot], repositoryRoot);
+      } catch {
+        // Removing the containing temporary directory still prevents verifier state from persisting.
+      }
+    }
+    await rm(temporaryRoot, {recursive: true, force: true});
+  }
+}
+
+function verifyReleaseMetadata(
+  options: VerifyGeneratedReleaseOptions,
+): GeneratedReleaseVerificationResult | undefined {
+  const {metadata} = options;
+  if (metadata.headRepository !== metadata.repository) {
+    return rejection(
+      'head-repository-mismatch',
+      'The pull request head must come from this repository.',
+    );
+  }
+  if (metadata.headRef !== options.expectedReleaseBranch) {
+    return rejection(
+      'release-branch-mismatch',
+      'The pull request head is not the configured release branch.',
+    );
+  }
+  if (metadata.authorId !== options.expectedReleaseAppId) {
+    return rejection(
+      'release-app-mismatch',
+      'The pull request author is not the configured release App.',
+    );
+  }
+  return undefined;
+}
+
+function rejection(
+  reason: Exclude<GeneratedReleaseVerificationResult['reason'], 'generated-tree-matches'>,
+  message: string,
+): GeneratedReleaseVerificationResult {
+  return {classification: 'not-generated-release', reason, message};
+}
+
+function commandError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function run(command: string, args: string[], cwd: string): Promise<CommandResult> {
+  return new Promise((resolveCommand, reject) => {
+    const child = spawn(command, args, {cwd, stdio: ['ignore', 'pipe', 'pipe']});
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk;
+    });
+    child.once('error', reject);
+    child.once('exit', (code) => {
+      if (code === 0) return resolveCommand({stdout, stderr});
+      reject(new Error(`${command} ${args.join(' ')} exited with ${code}: ${stderr.trim()}`));
+    });
+  });
+}
+
+function readArgument(name: string): string | undefined {
+  const index = process.argv.indexOf(`--${name}`);
+  return index === -1 ? undefined : process.argv[index + 1];
+}
+
+async function main() {
+  const baseRevision = readArgument('base');
+  const headRevision = readArgument('head');
+  const repository = readArgument('repository');
+  const headRepository = readArgument('head-repository');
+  const headRef = readArgument('head-ref');
+  const authorId = readArgument('author-id');
+  const expectedReleaseAppId = readArgument('release-app-id');
+  const expectedReleaseBranch = readArgument('release-branch') ?? 'changeset-release/main';
+  const repositoryRoot = readArgument('repository-root') ?? process.cwd();
+
+  if (
+    !baseRevision ||
+    !headRevision ||
+    !repository ||
+    !headRepository ||
+    !headRef ||
+    !authorId ||
+    !expectedReleaseAppId
+  ) {
+    process.stdout.write(
+      `${JSON.stringify(rejection('verification-error', 'Missing required verifier arguments.'))}\n`,
+    );
+    process.exitCode = 2;
+    return;
+  }
+
+  const result = await verifyGeneratedRelease({
+    baseRevision,
+    expectedReleaseAppId,
+    expectedReleaseBranch,
+    headRevision,
+    metadata: {authorId, headRef, headRepository, repository},
+    repositoryRoot,
+  });
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    process.stdout.write(
+      `${JSON.stringify(rejection('verification-error', commandError(error)))}\n`,
+    );
+    process.exitCode = 1;
+  });
+}

--- a/tools/package-release/test/generated-release-verifier.test.ts
+++ b/tools/package-release/test/generated-release-verifier.test.ts
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+
+import {
+  type VerifyGeneratedReleaseOptions,
+  verifyGeneratedRelease,
+} from '../src/generated-release-verifier.js';
+
+const options: VerifyGeneratedReleaseOptions = {
+  baseRevision: 'base',
+  expectedReleaseAppId: '12345',
+  expectedReleaseBranch: 'changeset-release/main',
+  headRevision: 'head',
+  metadata: {
+    authorId: '12345',
+    headRef: 'changeset-release/main',
+    headRepository: 'ShipfoxHQ/shipfox',
+    repository: 'ShipfoxHQ/shipfox',
+  },
+  repositoryRoot: '/repository',
+};
+
+function commandWithTrees(generatedTree: string, headTree = generatedTree) {
+  const calls: string[][] = [];
+  const command = (_command: string, args: string[]) => {
+    calls.push(args);
+    if (args[0] === 'write-tree')
+      return Promise.resolve({stdout: `${generatedTree}\n`, stderr: ''});
+    if (args[0] === 'rev-parse') return Promise.resolve({stdout: `${headTree}\n`, stderr: ''});
+    return Promise.resolve({stdout: '', stderr: ''});
+  };
+  return {calls, command};
+}
+
+describe('verifyGeneratedRelease', () => {
+  test('classifies the exact generated tree as a generated release', async () => {
+    const {command, calls} = commandWithTrees('generated-tree');
+
+    const result = await verifyGeneratedRelease(options, command);
+
+    assert.deepEqual(result, {
+      classification: 'generated-release',
+      reason: 'generated-tree-matches',
+      message:
+        'The pull request tree exactly matches changeset version output from its base revision.',
+    });
+    assert.deepEqual(
+      calls.map((args) => args.slice(0, 3)),
+      [
+        ['worktree', 'add', '--detach'],
+        ['install', '--frozen-lockfile', '--ignore-scripts'],
+        ['exec', 'changeset', 'version'],
+        ['add', '--all'],
+        ['write-tree'],
+        ['rev-parse', 'head^{tree}'],
+        ['worktree', 'remove', '--force'],
+      ],
+    );
+  });
+
+  test('rejects a source or manifest change that the version command did not generate', async () => {
+    const {command} = commandWithTrees('generated-tree', 'tampered-tree');
+
+    const result = await verifyGeneratedRelease(options, command);
+
+    assert.equal(result.classification, 'not-generated-release');
+    assert.equal(result.reason, 'generated-tree-mismatch');
+  });
+
+  test.each([
+    ['wrong repository', {headRepository: 'fork/shipfox'}, 'head-repository-mismatch'],
+    ['wrong branch', {headRef: 'changeset-release/not-main'}, 'release-branch-mismatch'],
+    ['wrong app', {authorId: '999'}, 'release-app-mismatch'],
+  ])('rejects %s before creating a checkout', async (_name, metadata, reason) => {
+    const {command, calls} = commandWithTrees('generated-tree');
+
+    const result = await verifyGeneratedRelease(
+      {...options, metadata: {...options.metadata, ...metadata}},
+      command,
+    );
+
+    assert.equal(result.classification, 'not-generated-release');
+    assert.equal(result.reason, reason);
+    assert.deepEqual(calls, []);
+  });
+
+  test('fails closed when the version command fails and still removes its worktree', async () => {
+    const calls: string[][] = [];
+    const command = (_command: string, args: string[]) => {
+      calls.push(args);
+      if (args.join(' ') === 'exec changeset version')
+        return Promise.reject(new Error('changeset failed'));
+      return Promise.resolve({stdout: '', stderr: ''});
+    };
+
+    const result = await verifyGeneratedRelease(options, command);
+
+    assert.equal(result.reason, 'version-command-failed');
+    assert.deepEqual(calls.at(-1)?.slice(0, 3), ['worktree', 'remove', '--force']);
+  });
+});


### PR DESCRIPTION
Add a repository-owned verifier for Changesets-generated release pull requests.

Release PRs currently need a safe way to avoid expensive runtime validation, but branch names and bot identity alone can be copied onto a tampered pull request. The verifier checks the configured App and branch as candidate signals, then regenerates `changeset version` in an isolated checkout from the event base SHA and compares its complete Git tree against the submitted head SHA.

The command emits stable JSON classification and rejection reasons for CI consumption, rejects any non-reproducible source, manifest, configuration, or lockfile change, and cleans up its temporary worktree without mutating the caller's checkout. It intentionally does not choose CI paths; ENG-1169 owns that workflow wiring.

Fixes ENG-1165

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a deterministic verifier for Changesets-generated release PRs by regenerating `changeset version` from the base SHA and comparing the full Git tree to the PR head. Fixes ENG-1165; ENG-1169 will wire CI to use it.

- **New Features**
  - Adds `verify-generated-release` CLI under `@shipfox/package-release` (`scripts.verify-generated-release`, export `./generated-release-verifier`).
  - Validates release App id, release branch (default `changeset-release/main`), and that the head repository matches the base; then creates an isolated `git worktree` at base, runs `pnpm install --frozen-lockfile --ignore-scripts` and `pnpm exec changeset version`, and compares trees.
  - Emits one JSON result with `classification` (`generated-release` or `not-generated-release`) and a `reason`; fails closed on install/version errors and cleans up the worktree.
  - Rejects any non-reproducible source, manifest, config, or lockfile change.

- **Migration**
  - In CI, run `pnpm --filter=@shipfox/package-release verify-generated-release -- --base "$BASE_SHA" --head "$HEAD_SHA" --repository "$GITHUB_REPOSITORY" --head-repository "$HEAD_REPOSITORY" --head-ref "$HEAD_REF" --author-id "$PULL_REQUEST_AUTHOR_ID" --release-app-id "$RELEASE_BOT_APP_ID"`.
  - Use only `classification: "generated-release"` to select the release path.

<sup>Written for commit b06c87623148c47e975f02f8f1124e8914dea6af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

