### PR TITLE
Add engineering documentation map

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,98 @@
+# Engineering documentation
+
+This is the map for Shipfox engineering knowledge. It helps contributors and
+agents find the source that owns a topic. It does not repeat that source.
+
+Start with [CONTRIBUTING.md](../CONTRIBUTING.md) for a human contribution or
+[AGENTS.md](../AGENTS.md) for an agent task. Use this map when the task is not
+listed there or when you need to place, update, or review documentation.
+
+## Find context by task
+
+| Read when the task... | Canonical source | It owns |
+| --- | --- | --- |
+| Needs the product overview or a starting point outside engineering work. | [Root README](../README.md) | Product orientation and repository navigation. |
+| Starts a human contribution or needs the normal local workflow. | [Contributing guide](../CONTRIBUTING.md) | Prerequisites, initial setup, contribution workflow, and essential validation. |
+| Changes agent behavior or needs agent execution instructions. | [Agent instructions](../AGENTS.md) | Repository-specific agent execution, change hygiene, and conditional context loading. |
+| Adds, updates, or exempts a dependency. | [Dependency version policy](policies/dependency-versions.md) | Version ranges, exceptions, coordinated package families, and dependency checks. |
+| Changes a cross-package client composition seam. | [ADR 0001](adr/0001-client-composition-contract.md) | The public client composition contract and its decision rationale. |
+| Changes server module boundaries or an inter-module call. | [ADR 0002](adr/0002-api-inter-module-architecture.md) | Producer-owned inter-module contracts and bounded-context crossings. |
+| Changes client state, API adapters, forms, or feature-domain boundaries. | [ADR 0003](adr/0003-client-state-and-domain-architecture.md) | Client state ownership and domain architecture decisions. |
+| Introduces a shared package or changes a server dependency boundary. | [ADR 0004](adr/0004-shared-semantic-packages-and-server-dependency-boundaries.md) | Shared semantic package rules and server package classes. |
+| Changes repository documentation structure or adds a shared documentation surface. | [ADR 0005](adr/0005-repository-documentation-architecture.md) | Documentation ownership, routing, and progressive disclosure. |
+| Changes webhook retry behavior. | [Webhook retry safety](architecture/webhook-retry-safety.md) | The current safety model for webhook retries. |
+| Adds or changes end-to-end coverage. | [E2E guide](../e2e/README.md) | Suite levels, HTTP-first setup, screens, and E2E package boundaries. |
+| Mints, verifies, or carries an authentication token. | [Auth security model](../libs/api/auth/README.md#security-model) | Token authority, lifetime, trust boundaries, and logging constraints. |
+| Defines an inter-module contract or transport. | [Inter-module package README](../libs/shared/common/inter-module/README.md) | Contract primitives and transport responsibilities. |
+| Changes shared visual or interaction decisions. | [Design system](../DESIGN.md) | Repository-wide visual and interaction decisions. |
+| Writes engineering prose, a README, or a runbook. | [Writing guide](../WRITING.md) | Repository-wide prose structure, style, punctuation, and readability. |
+| Writes product or self-hosting documentation. | [Docs writing guide](../apps/docs/WRITING.md) | Product documentation page types, templates, and local terminology. |
+
+## Documentation contract
+
+Each fact has one canonical owner. Other documents may name the fact and link
+to its owner. They do not become a second handbook.
+
+Put a task trigger before every conditional context link. State what the link
+owns in the same sentence or table row. A reader can then decide whether to
+open the target before loading unrelated detail.
+
+Use the narrowest owner that fits the knowledge. A package or subsystem keeps
+its local rules even when the map links to them. Do not move local knowledge to
+the repository root only to improve discovery.
+
+Executable sources own values and contracts that code can expose or generate.
+Examples include scripts, manifests, schemas, defaults, and accepted values.
+Authored documentation explains how to use those facts and why they matter.
+
+## Place new knowledge
+
+| Add this kind of knowledge... | Place it in... | That location owns... |
+| --- | --- | --- |
+| Product orientation. | [Root README](../README.md) | Product introduction and repository navigation. |
+| Human setup or contribution workflow. | [Contributing guide](../CONTRIBUTING.md) | Contributor onboarding and normal change workflow. |
+| Agent-only execution behavior. | [Agent instructions](../AGENTS.md) or a justified nested `AGENTS.md`. | Agent instructions that do not apply to human contributors. |
+| Current cross-package system design. | `docs/architecture/`. | How a system works now. |
+| A durable architectural choice and its tradeoffs. | `docs/adr/`. | Decision context, alternatives, and consequences. |
+| A repository-wide rule. | `docs/policies/`. | Rules that changes must satisfy. |
+| A repository-wide procedure. | `docs/guides/`. | A cross-cutting task and its verification. |
+| Details shared by one subsystem. | Its nearest common README. | Subsystem structure and rules. |
+| One package's purpose, configuration, or constraints. | Its package README. | Package-specific use and local constraints. |
+| End-user or self-hosting information. | `apps/docs/content/`. | Product documentation for its readers. |
+| Fast-changing, machine-checkable facts. | Code, a schema, a manifest, or generated reference. | Executable contracts and values. |
+
+Repository engineering documentation and product documentation serve different
+readers. Product pages under `apps/docs/content/` follow the docs-app page
+types. They do not replace repository policies, architecture, or contributor
+guidance.
+
+## Source types
+
+| Source type | Purpose | Use it instead of |
+| --- | --- | --- |
+| Architecture document | Describe how a cross-cutting system works today. | A historical decision record. |
+| ADR | Record a durable decision, its alternatives, and its consequences. | A complete current operating guide. |
+| Policy | State a repository-wide rule that a change must meet. | A tutorial or runbook. |
+| Guide | Explain a cross-cutting procedure and how to verify it. | Stable reference facts. |
+| Subsystem README | Keep knowledge shared by a code subtree close to that subtree. | Repository-wide policy. |
+| Package README | Explain one package's purpose, public use, configuration, and constraints. | Unrelated system rules. |
+| Product documentation | Help product users and self-hosters use Shipfox. | Contributor or internal engineering guidance. |
+| Executable source | Define code-backed values and machine-checkable contracts. | Rationale that code cannot express. |
+
+## ADRs
+
+[The ADR index](adr/README.md) lists every repository-wide decision and its
+status. Read an ADR when your change touches its decision boundary. A later ADR
+supersedes an earlier one explicitly. Do not rewrite a historical decision to
+describe a newer design.
+
+## Maintain this map
+
+Update this map when a canonical source is added, moved, retired, or changes
+scope. Keep entries short: state the trigger, link to the owner, and name what
+it owns. Do not create empty category directories or placeholder pages only to
+fill a table.
+
+If a new documentation surface would create a second shared handbook or split
+shared engineering rules between humans and agents, update or supersede
+[ADR 0005](adr/0005-repository-documentation-architecture.md) first.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,21 @@
+# Architecture decision records
+
+Architecture decision records (ADRs) preserve durable engineering decisions.
+They record the context, alternatives, decision, and consequences at the time
+of the choice. They are not the complete operating guide for a system.
+
+Read an ADR when a change crosses its decision boundary. For the current
+documentation model and other engineering sources, start with the
+[engineering documentation map](../README.md).
+
+| ADR | Status | It owns |
+| --- | --- | --- |
+| [0001: Public client composition contract](0001-client-composition-contract.md) | Accepted | The public contract for composing Shipfox client features. |
+| [0002: Server inter-module architecture](0002-api-inter-module-architecture.md) | Accepted, amended by ADR 0004 | Producer-owned server contracts and bounded-context crossings. |
+| [0003: Client state and domain architecture](0003-client-state-and-domain-architecture.md) | Accepted | Client state ownership and feature-domain boundaries. |
+| [0004: Shared semantic packages and server dependency boundaries](0004-shared-semantic-packages-and-server-dependency-boundaries.md) | Accepted; amends ADR 0002 | Shared package admission and server dependency boundaries. |
+| [0005: Repository documentation architecture](0005-repository-documentation-architecture.md) | Accepted | Documentation ownership, routing, and progressive disclosure. |
+
+When a decision changes, add a new ADR that supersedes or amends the earlier
+record. Keep the original record intact so readers can understand why the
+repository made the earlier choice.


### PR DESCRIPTION
Add a task-routed engineering documentation map and an ADR index.

Repository guidance is distributed across entrypoints, ADRs, policies, subsystem READMEs, package READMEs, and product documentation. The map gives contributors and agents a single discovery surface while keeping detailed knowledge with its canonical owner.

The map uses trigger-first links, defines which document type owns each kind of knowledge, and keeps product documentation under `apps/docs/content/` separate from repository engineering documentation. The ADR index makes accepted status and the ADR 0002 to ADR 0004 amendment relationship visible without copying decision content.

Review the task triggers and ownership boundaries, especially whether each link routes to the correct canonical source.

Closes ENG-1153

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a task-routed engineering documentation map and an ADR index to give contributors and agents one place to find canonical engineering knowledge. Separates product docs under `apps/docs/content/` from repository engineering docs and surfaces ADR status and supersession (ENG-1153).

- **New Features**
  - `docs/README.md`: Map that routes common tasks to their canonical sources using trigger-first links and clear ownership rules.
  - `docs/adr/README.md`: Index of ADRs (0001–0005) with status and amendment relationships.

- **Migration**
  - No action required. Review task triggers and ownership boundaries; keep the map updated when canonical sources move or change scope.

<sup>Written for commit 916b517fba2c9c361de752ec0486f7a1ca533f44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

