### PR TITLE
Disable Vercel previews for release PRs

### DIFF
--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -4,6 +4,11 @@
   "installCommand": "pnpm install",
   "buildCommand": "turbo run build --filter=@shipfox/docs",
   "devCommand": "turbo run dev --filter=@shipfox/docs",
+  "git": {
+    "deploymentEnabled": {
+      "changeset-release/main": false
+    }
+  },
   "regions": ["fra1", "iad1"],
   "trailingSlash": false,
   "headers": [

--- a/docs/vercel-preview-release-prs.md
+++ b/docs/vercel-preview-release-prs.md
@@ -1,0 +1,53 @@
+# Vercel release PR previews
+
+Vercel previews are disabled for the generated `changeset-release/main` branch.
+The configuration lives beside each deployed project so it is versioned and
+reviewed with its build settings.
+
+## Configuration source of truth
+
+- `apps/docs/vercel.json`
+- `libs/client/agent/vercel.json`
+- `libs/client/auth/vercel.json`
+- `libs/client/integrations/vercel.json`
+- `libs/client/logs/vercel.json`
+- `libs/client/runners/vercel.json`
+- `libs/client/secrets/vercel.json`
+- `libs/client/triggers/vercel.json`
+- `libs/client/workflows/vercel.json`
+- `libs/shared/react/ui/vercel.json`
+
+Each file sets `git.deploymentEnabled["changeset-release/main"]` to `false`.
+Vercel therefore does not create a preview deployment for that branch. Other
+branches remain enabled by default, including the production `main` branch.
+
+## Connected-project inventory
+
+The generated release PR [#938](https://github.com/ShipfoxHQ/shipfox/pull/938)
+currently reports Vercel statuses for these connected projects:
+
+- `client-agent`
+- `client-integrations`
+- `client-logs`
+- `client-runners`
+- `client-triggers`
+- `client-workflows`
+- `docs`
+- `react-ui`
+
+The matching configuration files are included in the source-of-truth list
+above. `client-auth` and `client-secrets` also keep the branch rule in their
+repository configuration so a later Vercel connection cannot reintroduce
+release-PR previews.
+
+## Verification and rollback
+
+After this change is merged, open or update a generated package release PR and
+confirm there are no Vercel GitHub statuses or queued builds. Then open a normal
+source PR that affects one of the projects above and confirm it receives the
+usual preview. Confirm a commit to `main` still creates the usual production
+deployment.
+
+To roll back, remove the `changeset-release/main` entry from every listed
+`vercel.json` file and merge the change. Use Vercel's Deployments page to
+redeploy a skipped commit if a preview is required after the fact.

--- a/libs/client/agent/vercel.json
+++ b/libs/client/agent/vercel.json
@@ -3,6 +3,11 @@
   "buildCommand": "turbo build && pnpm run storybook:build",
   "devCommand": "pnpm run storybook",
   "installCommand": "pnpm install",
+  "git": {
+    "deploymentEnabled": {
+      "changeset-release/main": false
+    }
+  },
   "framework": null,
   "outputDirectory": "./storybook-static"
 }

--- a/libs/client/auth/vercel.json
+++ b/libs/client/auth/vercel.json
@@ -3,6 +3,11 @@
   "buildCommand": "turbo build && pnpm run storybook:build",
   "devCommand": "pnpm run storybook",
   "installCommand": "pnpm install",
+  "git": {
+    "deploymentEnabled": {
+      "changeset-release/main": false
+    }
+  },
   "framework": null,
   "outputDirectory": "./storybook-static"
 }

--- a/libs/client/integrations/vercel.json
+++ b/libs/client/integrations/vercel.json
@@ -3,6 +3,11 @@
   "buildCommand": "turbo build && pnpm run storybook:build",
   "devCommand": "pnpm run storybook",
   "installCommand": "pnpm install",
+  "git": {
+    "deploymentEnabled": {
+      "changeset-release/main": false
+    }
+  },
   "framework": null,
   "outputDirectory": "./storybook-static"
 }

--- a/libs/client/logs/vercel.json
+++ b/libs/client/logs/vercel.json
@@ -3,6 +3,11 @@
   "buildCommand": "turbo build && pnpm run storybook:build",
   "devCommand": "pnpm run storybook",
   "installCommand": "pnpm install",
+  "git": {
+    "deploymentEnabled": {
+      "changeset-release/main": false
+    }
+  },
   "framework": null,
   "outputDirectory": "./storybook-static"
 }

--- a/libs/client/runners/vercel.json
+++ b/libs/client/runners/vercel.json
@@ -3,6 +3,11 @@
   "buildCommand": "turbo build && pnpm run storybook:build",
   "devCommand": "pnpm run storybook",
   "installCommand": "pnpm install",
+  "git": {
+    "deploymentEnabled": {
+      "changeset-release/main": false
+    }
+  },
   "framework": null,
   "outputDirectory": "./storybook-static"
 }

--- a/libs/client/secrets/vercel.json
+++ b/libs/client/secrets/vercel.json
@@ -3,6 +3,11 @@
   "buildCommand": "turbo build && pnpm run storybook:build",
   "devCommand": "pnpm run storybook",
   "installCommand": "pnpm install",
+  "git": {
+    "deploymentEnabled": {
+      "changeset-release/main": false
+    }
+  },
   "framework": null,
   "outputDirectory": "./storybook-static"
 }

--- a/libs/client/triggers/vercel.json
+++ b/libs/client/triggers/vercel.json
@@ -3,6 +3,11 @@
   "buildCommand": "turbo build && pnpm run storybook:build",
   "devCommand": "pnpm run storybook",
   "installCommand": "pnpm install",
+  "git": {
+    "deploymentEnabled": {
+      "changeset-release/main": false
+    }
+  },
   "framework": null,
   "outputDirectory": "./storybook-static"
 }

--- a/libs/client/workflows/vercel.json
+++ b/libs/client/workflows/vercel.json
@@ -3,6 +3,11 @@
   "buildCommand": "turbo build && pnpm run storybook:build",
   "devCommand": "pnpm run storybook",
   "installCommand": "pnpm install",
+  "git": {
+    "deploymentEnabled": {
+      "changeset-release/main": false
+    }
+  },
   "framework": null,
   "outputDirectory": "./storybook-static"
 }

--- a/libs/shared/react/ui/vercel.json
+++ b/libs/shared/react/ui/vercel.json
@@ -3,6 +3,11 @@
   "buildCommand": "turbo build && pnpm run storybook:build",
   "devCommand": "pnpm run storybook",
   "installCommand": "pnpm install",
+  "git": {
+    "deploymentEnabled": {
+      "changeset-release/main": false
+    }
+  },
   "framework": null,
   "outputDirectory": "./storybook-static"
 }


### PR DESCRIPTION
Disable Vercel deployment triggers for the generated `changeset-release/main` branch in every repository-owned Vercel configuration. Add the connected-project inventory plus verification and rollback guidance.

Generated package-release metadata does not need client, docs, or Storybook previews, but linked package version changes currently queue those builds. The branch-specific rule preserves previews for ordinary source PRs and production deployments from `main`.

Considered `ignoreCommand`, but `git.deploymentEnabled` prevents Vercel from triggering a deployment at all rather than creating an ignored deployment record.

Careful review: this is intentionally an exact branch rule. The documented post-merge check is a fresh generated release PR with no Vercel statuses or queued builds.

Refs ENG-1167

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop Vercel from creating preview deployments for the generated `changeset-release/main` branch across all connected projects. Set `git.deploymentEnabled["changeset-release/main"] = false` in each `vercel.json`, preserving normal PR previews and production deploys from `main`, and added docs with connected projects plus verification/rollback steps. Addresses ENG-1167.

<sup>Written for commit 11ee731399d325514c56b8cc7b97131aa0f5fb26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

