### PR TITLE
[client-auth] Converge session and invitation boundaries

### DIFF
--- a/.changeset/clever-otters-converge.md
+++ b/.changeset/clever-otters-converge.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/client-auth": patch
+"@shipfox/client-invitations": patch
+"@shipfox/client-shell": patch
+---
+
+Converges auth sessions and invitation responses on checked domain boundaries.

--- a/libs/client/auth/src/core/auth.ts
+++ b/libs/client/auth/src/core/auth.ts
@@ -1,0 +1,55 @@
+export interface LoginCommand {
+  email: string;
+  password: string;
+}
+
+export interface SignupCommand extends LoginCommand {
+  name: string;
+  invitationToken?: string;
+}
+
+export interface PasswordResetRequestCommand {
+  email: string;
+}
+
+export interface PasswordResetConfirmCommand {
+  token: string;
+  newPassword: string;
+}
+
+export interface VerifyEmailCommand {
+  email: string;
+  challengeId: string;
+  code: string;
+}
+
+export interface ResendEmailVerificationCommand {
+  email: string;
+  challengeId: string;
+}
+
+export interface WorkspaceCreateCommand {
+  name: string;
+}
+
+export interface Workspace {
+  id: string;
+  name: string;
+  status: 'active' | 'suspended' | 'deleted';
+}
+
+export interface SignupResult {
+  user: {
+    id: string;
+    email: string;
+    name?: string;
+    emailVerifiedAt?: string;
+  };
+  emailChallenge?: {id: string; nextResendAvailableAt: string};
+  membership?: {id: string; userId: string; workspaceId: string};
+  acceptError?: {code: string; message: string};
+}
+
+export interface EmailVerificationResendResult {
+  nextResendAvailableAt: string;
+}

--- a/libs/client/auth/src/hooks/api/auth-mapper.ts
+++ b/libs/client/auth/src/hooks/api/auth-mapper.ts
@@ -1,18 +1,8 @@
 import type {SignupResponseDto} from '@shipfox/api-auth-dto';
-import {
-  toAuthenticatedSession,
-  toUserIdentity,
-  type UserIdentity,
-} from '@shipfox/client-shell/runtime';
+import {toAuthenticatedSession, toUserIdentity} from '@shipfox/client-shell/runtime';
+import type {SignupResult} from '#core/auth.js';
 
 export {toAuthenticatedSession};
-
-export interface SignupResult {
-  user: UserIdentity;
-  emailChallenge?: {id: string; nextResendAvailableAt: string};
-  membership?: {id: string; userId: string; workspaceId: string};
-  acceptError?: {code: string; message: string};
-}
 
 export function toSignupResult(dto: SignupResponseDto): SignupResult {
   return {

--- a/libs/client/auth/src/hooks/api/login-auth.ts
+++ b/libs/client/auth/src/hooks/api/login-auth.ts
@@ -1,13 +1,14 @@
-import {type LoginBodyDto, loginResponseSchema} from '@shipfox/api-auth-dto';
+import {loginResponseSchema} from '@shipfox/api-auth-dto';
 import {checkedApiRequest} from '@shipfox/client-api';
 import {useMutation} from '@tanstack/react-query';
+import type {LoginCommand} from '#core/auth.js';
 import {useAuthTransition} from '#state/auth.js';
 import {toAuthenticatedSession} from './auth-mapper.js';
 
-export async function loginAuth(body: LoginBodyDto) {
+export async function loginAuth(command: LoginCommand) {
   const response = await checkedApiRequest(loginResponseSchema, '/auth/login', {
     method: 'POST',
-    body,
+    body: command,
   });
   return toAuthenticatedSession(response);
 }

--- a/libs/client/auth/src/hooks/api/password-reset-auth.test.ts
+++ b/libs/client/auth/src/hooks/api/password-reset-auth.test.ts
@@ -55,7 +55,7 @@ describe('confirmPasswordReset', () => {
       });
     });
     configureApiClient({fetchImpl});
-    const body = {token: 'reset-token', new_password: 'new password is long'};
+    const body = {token: 'reset-token', newPassword: 'new password is long'};
 
     const result = await confirmPasswordReset(body);
 
@@ -63,6 +63,6 @@ describe('confirmPasswordReset', () => {
     expect(result.accessToken).toBe('reset-access-token');
     expect(request.url).toBe('https://api.example.test/auth/password-reset/confirm');
     expect(request.method).toBe('POST');
-    expect(requestBody).toEqual(body);
+    expect(requestBody).toEqual({token: body.token, new_password: body.newPassword});
   });
 });

--- a/libs/client/auth/src/hooks/api/password-reset-auth.ts
+++ b/libs/client/auth/src/hooks/api/password-reset-auth.ts
@@ -1,24 +1,21 @@
-import {
-  type PasswordResetConfirmBodyDto,
-  type PasswordResetRequestBodyDto,
-  passwordResetConfirmResponseSchema,
-} from '@shipfox/api-auth-dto';
+import {passwordResetConfirmResponseSchema} from '@shipfox/api-auth-dto';
 import {apiRequest, checkedApiRequest} from '@shipfox/client-api';
 import {useMutation} from '@tanstack/react-query';
+import type {PasswordResetConfirmCommand, PasswordResetRequestCommand} from '#core/auth.js';
 import {useAuthTransition} from '#state/auth.js';
 import {toAuthenticatedSession} from './auth-mapper.js';
 
-export async function requestPasswordReset(body: PasswordResetRequestBodyDto) {
-  await apiRequest<void>('/auth/password-reset', {method: 'POST', body});
+export async function requestPasswordReset(command: PasswordResetRequestCommand) {
+  await apiRequest<void>('/auth/password-reset', {method: 'POST', body: command});
 }
 
-export async function confirmPasswordReset(body: PasswordResetConfirmBodyDto) {
+export async function confirmPasswordReset(command: PasswordResetConfirmCommand) {
   const response = await checkedApiRequest(
     passwordResetConfirmResponseSchema,
     '/auth/password-reset/confirm',
     {
       method: 'POST',
-      body,
+      body: {token: command.token, new_password: command.newPassword},
     },
   );
   return toAuthenticatedSession(response);

--- a/libs/client/auth/src/hooks/api/signup-auth.ts
+++ b/libs/client/auth/src/hooks/api/signup-auth.ts
@@ -1,12 +1,18 @@
-import {type SignupBodyDto, signupResponseSchema} from '@shipfox/api-auth-dto';
+import {signupResponseSchema} from '@shipfox/api-auth-dto';
 import {checkedApiRequest} from '@shipfox/client-api';
 import {useMutation} from '@tanstack/react-query';
+import type {SignupCommand} from '#core/auth.js';
 import {toSignupResult} from './auth-mapper.js';
 
-async function signupAuth(body: SignupBodyDto) {
+async function signupAuth(command: SignupCommand) {
   const response = await checkedApiRequest(signupResponseSchema, '/auth/signup', {
     method: 'POST',
-    body,
+    body: {
+      email: command.email,
+      password: command.password,
+      name: command.name,
+      ...(command.invitationToken ? {invitation_token: command.invitationToken} : {}),
+    },
   });
   return toSignupResult(response);
 }

--- a/libs/client/auth/src/hooks/api/verify-email-auth.ts
+++ b/libs/client/auth/src/hooks/api/verify-email-auth.ts
@@ -1,31 +1,41 @@
 import {
-  type VerifyEmailConfirmBodyDto,
-  type VerifyEmailResendBodyDto,
   verifyEmailConfirmResponseSchema,
   verifyEmailResendResponseSchema,
 } from '@shipfox/api-auth-dto';
 import {checkedApiRequest} from '@shipfox/client-api';
 import {useMutation} from '@tanstack/react-query';
+import type {
+  EmailVerificationResendResult,
+  ResendEmailVerificationCommand,
+  VerifyEmailCommand,
+} from '#core/auth.js';
 import {useAuthTransition} from '#state/auth.js';
 import {toAuthenticatedSession} from './auth-mapper.js';
 
-async function verifyEmailAuth(body: VerifyEmailConfirmBodyDto) {
+async function verifyEmailAuth(command: VerifyEmailCommand) {
   const response = await checkedApiRequest(
     verifyEmailConfirmResponseSchema,
     '/auth/verify-email/confirm',
     {
       method: 'POST',
-      body,
+      body: {email: command.email, challenge_id: command.challengeId, code: command.code},
     },
   );
   return toAuthenticatedSession(response);
 }
 
-async function resendEmailVerificationAuth(body: VerifyEmailResendBodyDto) {
-  return await checkedApiRequest(verifyEmailResendResponseSchema, '/auth/verify-email/resend', {
-    method: 'POST',
-    body,
-  });
+async function resendEmailVerificationAuth(command: ResendEmailVerificationCommand) {
+  const response = await checkedApiRequest(
+    verifyEmailResendResponseSchema,
+    '/auth/verify-email/resend',
+    {
+      method: 'POST',
+      body: {email: command.email, challenge_id: command.challengeId},
+    },
+  );
+  return {
+    nextResendAvailableAt: response.next_resend_available_at,
+  } satisfies EmailVerificationResendResult;
 }
 
 export function useResendEmailVerificationAuth() {

--- a/libs/client/auth/src/hooks/api/workspace-auth.ts
+++ b/libs/client/auth/src/hooks/api/workspace-auth.ts
@@ -1,14 +1,15 @@
-import {type CreateWorkspaceBodyDto, workspaceResponseSchema} from '@shipfox/api-workspaces-dto';
+import {workspaceResponseSchema} from '@shipfox/api-workspaces-dto';
 import {checkedApiRequest} from '@shipfox/client-api';
 import {listUserWorkspaces, userWorkspacesQueryKey} from '@shipfox/client-shell/runtime';
 import {useMutation} from '@tanstack/react-query';
+import type {WorkspaceCreateCommand} from '#core/auth.js';
 import {useRefreshAuth} from './refresh-auth.js';
 import {toWorkspace} from './workspace-mapper.js';
 
-export async function createWorkspace(body: CreateWorkspaceBodyDto) {
+export async function createWorkspace(command: WorkspaceCreateCommand) {
   const response = await checkedApiRequest(workspaceResponseSchema, '/workspaces', {
     method: 'POST',
-    body,
+    body: {name: command.name},
   });
   return toWorkspace(response);
 }

--- a/libs/client/auth/src/hooks/api/workspace-mapper.ts
+++ b/libs/client/auth/src/hooks/api/workspace-mapper.ts
@@ -1,10 +1,5 @@
 import type {WorkspaceResponseDto} from '@shipfox/api-workspaces-dto';
-
-export interface Workspace {
-  id: string;
-  name: string;
-  status: 'active' | 'suspended' | 'deleted';
-}
+import type {Workspace} from '#core/auth.js';
 
 export function toWorkspace(dto: WorkspaceResponseDto): Workspace {
   return {id: dto.id, name: dto.name, status: dto.status};

--- a/libs/client/auth/src/pages/password-reset-page.tsx
+++ b/libs/client/auth/src/pages/password-reset-page.tsx
@@ -160,7 +160,7 @@ function PasswordResetConfirm({token}: {token: string}) {
           token,
           new_password: value.new_password,
         });
-        await confirmPasswordReset.mutateAsync(body);
+        await confirmPasswordReset.mutateAsync({token: body.token, newPassword: body.new_password});
         setAuthFormDraft(initialAuthFormDraft);
         toast.success('Your password has been changed. You are now logged in.');
         await navigate({to: '/', replace: true});

--- a/libs/client/auth/src/pages/signup-page.tsx
+++ b/libs/client/auth/src/pages/signup-page.tsx
@@ -50,13 +50,18 @@ export function SignupPage() {
     onSubmit: async ({value}) => {
       setFormError(undefined);
       try {
-        const body = signupBodySchema.parse({
+        const parsed = signupBodySchema.parse({
           email: value.email,
           password: value.password,
           name: value.name,
           ...(invitationToken ? {invitation_token: invitationToken} : {}),
         });
-        const result = await signup.mutateAsync(body);
+        const result = await signup.mutateAsync({
+          email: parsed.email,
+          password: parsed.password,
+          name: parsed.name,
+          ...(parsed.invitation_token ? {invitationToken: parsed.invitation_token} : {}),
+        });
         skipDraftPersistRef.current = true;
         setAuthFormDraft(initialAuthFormDraft);
 
@@ -132,9 +137,9 @@ export function SignupPage() {
     try {
       const result = await resendEmailVerification.mutateAsync({
         email: emailChallenge.email,
-        challenge_id: emailChallenge.id,
+        challengeId: emailChallenge.id,
       });
-      setNextResendAvailableAt(result.next_resend_available_at);
+      setNextResendAvailableAt(result.nextResendAvailableAt);
       toast.success('If another verification email can be sent, it will arrive shortly.');
     } catch (error) {
       setResendError(authErrorMessage(error));
@@ -154,7 +159,7 @@ export function SignupPage() {
           try {
             await verifyEmail.mutateAsync({
               email: emailChallenge.email,
-              challenge_id: emailChallenge.id,
+              challengeId: emailChallenge.id,
               code,
             });
             await refreshAuth();

--- a/libs/client/auth/src/pages/workspace-onboarding-page.tsx
+++ b/libs/client/auth/src/pages/workspace-onboarding-page.tsx
@@ -43,8 +43,8 @@ export function WorkspaceOnboardingPage() {
     onSubmit: async ({value}) => {
       setFormError(undefined);
       try {
-        const body = createWorkspaceBodySchema.parse({name: value.name});
-        const created = await createWorkspace.mutateAsync(body);
+        const command = createWorkspaceBodySchema.parse({name: value.name});
+        const created = await createWorkspace.mutateAsync(command);
         toast.success('Workspace created.');
         // Pin the new workspace as the last-active one so a page refresh and
         // future visits to `/` land on it.

--- a/libs/client/invitations/src/core/invitation-acceptance.ts
+++ b/libs/client/invitations/src/core/invitation-acceptance.ts
@@ -1,0 +1,8 @@
+export interface InvitationAcceptance {
+  membership: {
+    id: string;
+    userId: string;
+    workspaceId: string;
+  };
+  alreadyMember: boolean;
+}

--- a/libs/client/invitations/src/hooks/api/accept-invitation.ts
+++ b/libs/client/invitations/src/hooks/api/accept-invitation.ts
@@ -1,15 +1,14 @@
-import type {
-  AcceptInvitationBodyDto,
-  AcceptInvitationResponseDto,
-} from '@shipfox/api-workspaces-dto';
-import {apiRequest} from '@shipfox/client-api';
+import {acceptInvitationResponseSchema} from '@shipfox/api-workspaces-dto';
+import {checkedApiRequest} from '@shipfox/client-api';
 import {useMutation} from '@tanstack/react-query';
+import {toInvitationAcceptance} from './invitation-acceptance-mapper.js';
 
-async function acceptInvitation(body: AcceptInvitationBodyDto) {
-  return await apiRequest<AcceptInvitationResponseDto>('/invitations/accept', {
+async function acceptInvitation(command: {token: string}) {
+  const response = await checkedApiRequest(acceptInvitationResponseSchema, '/invitations/accept', {
     method: 'POST',
-    body,
+    body: command,
   });
+  return toInvitationAcceptance(response);
 }
 
 export function useAcceptInvitation() {

--- a/libs/client/invitations/src/hooks/api/invitation-acceptance-mapper.test.ts
+++ b/libs/client/invitations/src/hooks/api/invitation-acceptance-mapper.test.ts
@@ -1,0 +1,23 @@
+import {toInvitationAcceptance} from './invitation-acceptance-mapper.js';
+
+describe('toInvitationAcceptance', () => {
+  test('maps the acceptance response into the invitation domain', () => {
+    const result = toInvitationAcceptance({
+      membership: {
+        id: '11111111-1111-4111-8111-111111111111',
+        user_id: '22222222-2222-4222-8222-222222222222',
+        workspace_id: '33333333-3333-4333-8333-333333333333',
+      },
+      already_member: true,
+    });
+
+    expect(result).toEqual({
+      membership: {
+        id: '11111111-1111-4111-8111-111111111111',
+        userId: '22222222-2222-4222-8222-222222222222',
+        workspaceId: '33333333-3333-4333-8333-333333333333',
+      },
+      alreadyMember: true,
+    });
+  });
+});

--- a/libs/client/invitations/src/hooks/api/invitation-acceptance-mapper.ts
+++ b/libs/client/invitations/src/hooks/api/invitation-acceptance-mapper.ts
@@ -1,0 +1,13 @@
+import type {AcceptInvitationResponseDto} from '@shipfox/api-workspaces-dto';
+import type {InvitationAcceptance} from '#core/invitation-acceptance.js';
+
+export function toInvitationAcceptance(dto: AcceptInvitationResponseDto): InvitationAcceptance {
+  return {
+    membership: {
+      id: dto.membership.id,
+      userId: dto.membership.user_id,
+      workspaceId: dto.membership.workspace_id,
+    },
+    alreadyMember: dto.already_member,
+  };
+}

--- a/libs/client/invitations/src/index.ts
+++ b/libs/client/invitations/src/index.ts
@@ -1,3 +1,4 @@
+export type {InvitationAcceptance} from '#core/invitation-acceptance.js';
 export {type InvitationPreview, pendingInvitation} from '#core/invitation-preview.js';
 export {completeInvitationAcceptance} from './complete-acceptance.js';
 export {useAcceptInvitation} from './hooks/api/accept-invitation.js';

--- a/libs/client/invitations/src/pages/invitation-accept-page.tsx
+++ b/libs/client/invitations/src/pages/invitation-accept-page.tsx
@@ -53,7 +53,7 @@ export function InvitationAcceptPage() {
   const runAccept = useCallback(
     async (params: {token: string; workspaceName: string}) => {
       const result = await accept.mutateAsync({token: params.token});
-      await completeAccept(result.membership.workspace_id, params.workspaceName);
+      await completeAccept(result.membership.workspaceId, params.workspaceName);
     },
     [accept, completeAccept],
   );

--- a/libs/client/shell/src/hooks/api/session-auth.ts
+++ b/libs/client/shell/src/hooks/api/session-auth.ts
@@ -1,0 +1,27 @@
+import {loginResponseSchema} from '@shipfox/api-auth-dto';
+import {listUserWorkspacesResponseSchema} from '@shipfox/api-workspaces-dto';
+import {checkedApiRequest} from '@shipfox/client-api';
+import type {AuthenticatedSession, WorkspaceSummary} from '#core/session.js';
+import {toAuthenticatedSession} from './session-mapper.js';
+
+export async function listUserWorkspaces(
+  token?: string,
+): Promise<{memberships: WorkspaceSummary[]}> {
+  const response = await checkedApiRequest(
+    listUserWorkspacesResponseSchema,
+    '/workspaces',
+    token ? {headers: {authorization: `Bearer ${token}`}} : {},
+  );
+  return {
+    memberships: response.memberships.map((membership) => ({
+      id: membership.workspace_id,
+      name: membership.workspace_name,
+      membershipId: membership.id,
+    })),
+  };
+}
+
+export async function refreshAuthenticatedSession(): Promise<AuthenticatedSession> {
+  const response = await checkedApiRequest(loginResponseSchema, '/auth/refresh', {method: 'POST'});
+  return toAuthenticatedSession(response);
+}

--- a/libs/client/shell/src/runtime/auth.tsx
+++ b/libs/client/shell/src/runtime/auth.tsx
@@ -1,12 +1,10 @@
-import {loginResponseSchema} from '@shipfox/api-auth-dto';
-import {listUserWorkspacesResponseSchema} from '@shipfox/api-workspaces-dto';
-import {ApiError, checkedApiRequest, configureApiClient} from '@shipfox/client-api';
+import {ApiError, configureApiClient} from '@shipfox/client-api';
 import {useQueryClient} from '@tanstack/react-query';
 import {atom, useAtomValue, useSetAtom, useStore} from 'jotai';
 import type {PropsWithChildren} from 'react';
 import {useCallback, useEffect, useMemo} from 'react';
 import type {AuthenticatedSession, UserIdentity, WorkspaceSummary} from '#core/session.js';
-import {toAuthenticatedSession} from '#hooks/api/session-mapper.js';
+import {listUserWorkspaces, refreshAuthenticatedSession} from '#hooks/api/session-auth.js';
 
 const REFRESH_EARLY_MS = 5 * 60 * 1000;
 const REFRESH_RETRY_DELAY_MS = 60_000;
@@ -62,25 +60,7 @@ export function useAuthState(): AuthStateValue {
   );
 }
 
-export async function listUserWorkspaces(token?: string) {
-  const response = await checkedApiRequest(
-    listUserWorkspacesResponseSchema,
-    '/workspaces',
-    token ? {headers: {authorization: `Bearer ${token}`}} : {},
-  );
-  return {
-    memberships: response.memberships.map((membership) => ({
-      id: membership.workspace_id,
-      name: membership.workspace_name,
-      membershipId: membership.id,
-    })),
-  };
-}
-
-async function refreshAuthRequest(): Promise<AuthenticatedSession> {
-  const response = await checkedApiRequest(loginResponseSchema, '/auth/refresh', {method: 'POST'});
-  return toAuthenticatedSession(response);
-}
+export {listUserWorkspaces} from '#hooks/api/session-auth.js';
 
 function decodeBase64Url(value: string): string {
   const base64 = value
@@ -165,7 +145,7 @@ export function useRefreshAuth() {
     try {
       const result = await queryClient.fetchQuery({
         queryKey: authRefreshQueryKey,
-        queryFn: refreshAuthRequest,
+        queryFn: refreshAuthenticatedSession,
         retry: false,
         staleTime: 0,
       });

--- a/tools/client-architecture-policy/client-architecture-baseline.json
+++ b/tools/client-architecture-policy/client-architecture-baseline.json
@@ -65,16 +65,6 @@
     "occurrences": 1
   },
   {
-    "file": "libs/client/auth/src/pages/invitation-context.ts",
-    "rule": "api-request-outside-adapter",
-    "occurrences": 1
-  },
-  {
-    "file": "libs/client/auth/src/pages/invitation-context.ts",
-    "rule": "response-dto-in-presentation",
-    "occurrences": 2
-  },
-  {
     "file": "libs/client/logs/src/core/log-read.ts",
     "rule": "core-api-dto-import",
     "occurrences": 1
@@ -168,11 +158,6 @@
     "file": "libs/client/secrets/src/components/workspace-variables-section.tsx",
     "rule": "response-dto-in-presentation",
     "occurrences": 1
-  },
-  {
-    "file": "libs/client/shell/src/runtime/auth.tsx",
-    "rule": "api-request-outside-adapter",
-    "occurrences": 2
   },
   {
     "file": "libs/client/triggers/src/components/events-filter-bar.tsx",


### PR DESCRIPTION
Converges auth, shell-session, workspace, and invitation client data on checked adapter boundaries with framework-free domain commands and results.

The auth flow previously allowed wire DTO shapes and transport field names to cross into state and page logic, which duplicated transition and invitation handling. The shell now owns one hydrated session transition path while adapters map requests and responses at the boundary.

This keeps the existing Jotai and React Query ownership model, rather than introducing another client-side store or moving server data into atoms. Reviewers should pay particular attention to the preserved refresh and workspace-hydration behavior across authentication transitions.

Closes ENG-1127

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converges auth, session, workspace, and invitation flows at checked adapter boundaries to stop DTOs leaking into UI and keep one session transition path in the shell. Addresses ENG-1127 by introducing domain commands/results and moving refresh/workspace listing into `@shipfox/client-shell` without changing refresh or workspace hydration behavior.

- **Refactors**
  - Introduced domain commands/results in `@shipfox/client-auth` (`LoginCommand`, `SignupCommand`, `PasswordReset*`, `VerifyEmail*`, `ResendEmailVerificationCommand`, `WorkspaceCreateCommand`, `Workspace`, `SignupResult`, `EmailVerificationResendResult`).
  - Added `InvitationAcceptance` in `@shipfox/client-invitations` with a mapper and tests; updated invitation accept page to use `membership.workspaceId`.
  - Mapped domain commands/results to API DTOs at adapters and normalized fields (e.g., `invitationToken` → `invitation_token`, `newPassword` → `new_password`, `challengeId` → `challenge_id`); verify-email resend now returns `EmailVerificationResendResult.nextResendAvailableAt`.
  - Moved session API calls into `@shipfox/client-shell` adapter (`session-auth.ts`: `listUserWorkspaces`, `refreshAuthenticatedSession`) and updated `runtime/auth.tsx` to use them.
  - Updated pages (signup, password reset, workspace onboarding, invitation accept) to use commands and new result shapes; removed DTOs from presentation and tightened API calls with `checkedApiRequest`.

<sup>Written for commit 23d4ac5c0aeb85714c59cea32e438b3ffbfebb6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

