### PR TITLE
[e2e] Expose Claude workflow failures before log reads

### DIFF
--- a/e2e/suites/flow/workflows/tests/claude-agent.e2e.ts
+++ b/e2e/suites/flow/workflows/tests/claude-agent.e2e.ts
@@ -127,10 +127,28 @@ test('runs Claude set_output through downstream interpolation', async ({suite}, 
       workflowYaml: OUTPUT_WORKFLOW_YAML,
       runnerEnv: fakeAnthropic.runnerEnv,
     });
-    const consumeStep = terminal.jobs
-      .find((job) => job.key === 'fix')
-      ?.job_executions.flatMap((execution) => execution.steps)
-      .find((step) => step.key === 'consume');
+    const fixJob = terminal.jobs.find((job) => job.key === 'fix');
+    const steps = fixJob?.job_executions.flatMap((execution) => execution.steps) ?? [];
+    const produceStep = steps.find((step) => step.key === 'produce');
+    const consumeStep = steps.find((step) => step.key === 'consume');
+    const executionSucceeded =
+      terminal.status === 'succeeded' &&
+      fixJob?.status === 'succeeded' &&
+      produceStep?.status === 'succeeded' &&
+      consumeStep?.status === 'succeeded';
+
+    if (!executionSucceeded) {
+      await testInfo.attach('run-detail.json', {
+        body: JSON.stringify(terminal, null, 2),
+        contentType: 'application/json',
+      });
+    }
+
+    expect(terminal.status).toBe('succeeded');
+    expect(fixJob?.status).toBe('succeeded');
+    expect(produceStep?.status).toBe('succeeded');
+    expect(consumeStep?.status).toBe('succeeded');
+
     if (consumeStep === undefined) throw new Error('consume step missing from run detail');
     const logs = await fetchStepLogs({
       stepId: consumeStep.id,
@@ -138,8 +156,6 @@ test('runs Claude set_output through downstream interpolation', async ({suite}, 
       token: suite.sessionToken,
     });
 
-    expect(terminal.status).toBe('succeeded');
-    expect(terminal.jobs.find((job) => job.key === 'fix')?.status).toBe('succeeded');
     expect(logText(logs.records)).toContain('agent_message=claude-tool-output-ok');
   } finally {
     await fakeModelProvider.stop().catch((error: unknown) => {


### PR DESCRIPTION
Make the Claude set_output flow test verify terminal run, job, and step outcomes before fetching downstream logs. Failed executions now attach the complete run detail for diagnosis.

An unexecuted downstream step can still report attempt 1 while having no log stream. Fetching that stream first retries a legitimate 404 and masks the upstream workflow failure. This change surfaces the original failure while preserving the existing projection retry behavior for successful steps.

Considered extending the log-read retry window, but that would only delay and further obscure legitimate no-stream failures.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Claude set_output e2e test verify run, job, and step success before reading downstream logs, so upstream failures aren’t hidden by missing log streams. Failed executions now attach full run details for easier debugging.

- **Bug Fixes**
  - Assert terminal run, `fix` job, `produce`, and `consume` step statuses before log fetch.
  - Attach `run-detail.json` when execution isn’t successful.
  - Keep existing log-read retry behavior for successful steps.

<sup>Written for commit 7cc0f73429245a764307236135b943dc992a9108. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

