### PR TITLE
Route shared design guidance through DESIGN.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -755,17 +755,6 @@ To cover a component state a single render cannot reach (error states, populated
 
 ## Design System
 
-Always read [DESIGN.md](DESIGN.md) before making any visual or UI decisions. Token
-families, font choices, color usage, spacing conventions, and surface-level guidance
-(DAG view, log tails, status pills, runner tables, etc.) are all defined there.
-
-Two conventions trip up newcomers and must be enforced in review:
-
-1. **Spacing base is 1px.** `p-4` is 4px, not 16px. The Tailwind class names map
-   directly to pixels because `index.css` sets `--spacing: 1px`.
-2. **Brand orange is the focus ring and interactive highlight, not the primary
-   CTA fill.** The default primary button is inverted neutral. Reach for orange
-   for focus states, links, and "this is where you are" affordances only.
-
-Do not deviate without explicit user approval and a corresponding entry in the
-DESIGN.md decisions log.
+Before an agent creates or changes a visual or UI decision, read
+[DESIGN.md](DESIGN.md). It owns the shared design system and points to the
+code that owns exact token and component values.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,10 @@ Build a specific package and its dependencies:
 turbo build --filter=@shipfox/api...
 ```
 
+If your contribution creates or changes a visual or interaction decision, read
+the [design system](DESIGN.md). It owns shared design guidance and points to
+the code that owns exact token and component values.
+
 ## Dependency versions
 
 Read the [dependency version policy](docs/policies/dependency-versions.md) before

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,8 +1,16 @@
 # Design System — Shipfox
 
-Source of truth for visual and interaction decisions. Read this before writing any UI.
+`DESIGN.md` is the canonical design-system source for Shipfox. Read it when a
+change creates or changes a visual or interaction decision. It owns the shared
+visual language: tokens, components, accessibility, motion, status taxonomy,
+patterns, and review anti-patterns.
 
-The system is already built. The CSS lives in `libs/shared/react/ui/index.css` (chicago workspace) and the broader catalog of tokens and components lives in the shared `@shipfox/react-ui` package. This document explains what the system is and why it is shaped this way. It does not prescribe what individual product pages should look like — surface-level designs live with the features they belong to.
+The system is already built. [The shared CSS](libs/shared/react/ui/index.css)
+and [the `@shipfox/react-ui` package](libs/shared/react/ui/) are canonical for
+exact token and component values. When code and this document differ, use the
+code and update this document in the same change when its guidance has changed.
+This document explains the system and its rationale. It does not prescribe
+individual product pages. Surface-level designs live with their features.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ listed there or when you need to place, update, or review documentation.
 | Adds or changes end-to-end coverage. | [E2E guide](../e2e/README.md) | Suite levels, HTTP-first setup, screens, and E2E package boundaries. |
 | Mints, verifies, or carries an authentication token. | [Auth security model](../libs/api/auth/README.md#security-model) | Token authority, lifetime, trust boundaries, and logging constraints. |
 | Defines an inter-module contract or transport. | [Inter-module package README](../libs/shared/common/inter-module/README.md) | Contract primitives and transport responsibilities. |
-| Changes shared visual or interaction decisions. | [Design system](../DESIGN.md) | Repository-wide visual and interaction decisions. |
+| Creates or changes a visual or interaction decision. | [Design system](../DESIGN.md) | Shared tokens, components, accessibility, motion, status taxonomy, patterns, and review anti-patterns. Code owns exact token and component values. |
 | Writes engineering prose, a README, or a runbook. | [Writing guide](../WRITING.md) | Repository-wide prose structure, style, punctuation, and readability. |
 | Writes product or self-hosting documentation. | [Docs writing guide](../apps/docs/WRITING.md) | Product documentation page types, templates, and local terminology. |
 


### PR DESCRIPTION
Make `DESIGN.md` the canonical shared source for Shipfox visual and interaction guidance.

The agent and human entrypoints now retain trigger-first links, while the engineering documentation map identifies the design system scope and preserves code as the source of exact token and component values.

This removes the competing design handbook in `AGENTS.md` so shared guidance is equally discoverable by contributors and agents.

Closes ENG-1172

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route shared design-system guidance to DESIGN.md as the single canonical source for humans and agents, addressing ENG-1172. Code remains the source of truth for exact tokens and components in `libs/shared/react/ui/index.css` and `@shipfox/react-ui`.

- **Refactors**
  - Expanded DESIGN.md with scope/ownership and code-as-source notes.
  - Replaced design details in AGENTS.md with a trigger-first link to DESIGN.md.
  - Routed contributors via CONTRIBUTING.md and docs/README without duplicating guidance.

<sup>Written for commit 1602f7e002fc3471fd9b11601ca279fc5db67ef3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

