### PR TITLE
Add living backend architecture guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,13 @@ pnpm check:published-artifacts
 pnpm install --frozen-lockfile
 ```
 
+## Backend architecture
+
+If your task adds or changes a backend module, DTO, outbox event, HTTP boundary,
+or server package dependency, read the
+[backend architecture guide](docs/architecture/backend-architecture.md). It
+owns the current module model and package-boundary rules.
+
 ## Module exports and imports
 
 Avoid broad barrel files inside modules. Prefer importing from the file that owns the

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ listed there or when you need to place, update, or review documentation.
 | Adds, updates, or exempts a dependency. | [Dependency version policy](policies/dependency-versions.md) | Version ranges, exceptions, coordinated package families, and dependency checks. |
 | Changes a cross-package client composition seam. | [ADR 0001](adr/0001-client-composition-contract.md) | The public client composition contract and its decision rationale. |
 | Changes server module boundaries or an inter-module call. | [ADR 0002](adr/0002-api-inter-module-architecture.md) | Producer-owned inter-module contracts and bounded-context crossings. |
+| Adds or changes a backend module, DTO, outbox event, HTTP boundary, or server package dependency. | [Backend architecture](architecture/backend-architecture.md) | The current backend module model and package-boundary rules. |
 | Changes client state, API adapters, forms, or feature-domain boundaries. | [ADR 0003](adr/0003-client-state-and-domain-architecture.md) | Client state ownership and domain architecture decisions. |
 | Introduces a shared package or changes a server dependency boundary. | [ADR 0004](adr/0004-shared-semantic-packages-and-server-dependency-boundaries.md) | Shared semantic package rules and server package classes. |
 | Changes repository documentation structure or adds a shared documentation surface. | [ADR 0005](adr/0005-repository-documentation-architecture.md) | Documentation ownership, routing, and progressive disclosure. |

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -1,0 +1,137 @@
+# Backend architecture
+
+This guide owns the backend module model and package-boundary rules. Read it
+when you add or change an API module, HTTP route, DTO, outbox event,
+cross-context dependency, or shared backend package. It links to ADRs for the
+reasons and rejected options. Package READMEs own package APIs, config, and
+operational details.
+
+## Module composition
+
+Each backend capability exposes a declarative `ShipfoxModule`. It lists the
+database, routes, auth adapters, E2E routes, publishers, subscribers, workers,
+and metrics it owns. Feature packages do not wire their internals into an app.
+
+The application root puts modules in dependency order. A module that owns a
+shared database table comes before one that uses it. The root alone builds the
+full inter-module graph:
+
+1. Create the transport for the application instance.
+2. Create typed clients from producer contracts.
+3. Pass each module only the clients it declares.
+4. Collect and register presentations from the returned modules.
+5. Seal the transport before migrations, workers, metrics, or listeners start.
+
+Clients may exist before a producer presentation is registered. Modules do not
+receive the registry. Do not use global setters, service locators, module-load
+hooks, or mutable default clients. The current composition lives in
+[`libs/api/server/src/modules.ts`](../../libs/api/server/src/modules.ts).
+
+Read [ADR 0002](../adr/0002-api-inter-module-architecture.md) when changing an
+inter-module contract or its setup order. It owns history, transport behavior,
+and migration reasons.
+
+## Feature package layers
+
+API feature packages usually use this shape:
+
+```text
+src/
+  core/          Domain behavior, entities, provider ports, and typed errors
+  db/            Drizzle tables, migrations, persistence, and row mappers
+  presentation/  Fastify routes, auth adapters, and DTO conversion
+```
+
+`core/` owns business behavior. `db/` maps database rows to domain objects.
+`presentation/` adapts requests and responses. A layer does not leak upward:
+routes do not build database rows, domain code does not shape HTTP responses,
+and DTO mappers do not hold business rules.
+
+An HTTP route uses `defineRoute`, a Zod schema, and the named auth method it
+needs. Keep route groups responsible for a shared prefix, plugin, or auth rule.
+Routes call a use case and convert the result with a mapper in
+`presentation/dto/`. Internal objects use camelCase. HTTP DTOs use snake_case.
+
+## Contracts, persistence, and events
+
+A producer owns its public contract in its sibling `*-dto` package. The DTO
+package holds passive Zod schemas, inferred types, HTTP shapes, event names,
+event payloads, protocol constants, and small encoding helpers. It does not
+hold producer rules, database helpers, config parsers, providers, or wiring.
+
+Keep synchronous producer operations in the explicit
+`<producer-dto>/inter-module` export. Do not re-export that contract from the
+DTO root. The producer maps its domain errors to contract-known errors in its
+presentation. Callers depend on the client type and known results, never a
+producer error class or implementation helper.
+
+Drizzle table files own row-to-domain mapping. Higher layers use domain objects
+when practical. An outbox event is a public producer contract. Define its name
+and payload in the producer DTO package. Write it in the same transaction as
+the state change. Register its publisher table in the module declaration.
+
+For contract primitives and transport-specific behavior, read the
+[inter-module package README](../../libs/shared/common/inter-module/README.md).
+It owns that package's public API and constraints.
+
+## Choose the boundary
+
+Use the narrowest boundary that matches the caller's need. A shared package is
+not a shortcut around a producer-owned decision.
+
+| Caller needs | Use | Owner |
+| --- | --- | --- |
+| A current decision or current state from another context | A producer `/inter-module` operation | The producer context |
+| A fact that a producer committed | A DTO outbox event | The producer context |
+| A durable wait, retry, timer, or recovery path | A Temporal workflow and activities | The workflow owner |
+| A HTTP, event, or stored-data shape | A DTO schema and versioned codec | The contract owner |
+| A deterministic, context-neutral algorithm | A registered shared semantic package | The named shared concept |
+| A business rule owned by one context | A producer operation or versioned producer snapshot | The producer context |
+
+If contexts use the same business words, add a named shared product-language
+package only when they jointly own the words and the API is small and stable.
+Consumer count alone does not make a concept shared. If ownership is unclear,
+resolve the context design before adding a generic `utils`, `common`, or
+`shared` package.
+
+Read [ADR 0004](../adr/0004-shared-semantic-packages-and-server-dependency-boundaries.md)
+before adding a shared package or changing a server dependency boundary. It
+owns admission rules, package classes, and decision reasons.
+
+## Imports and package exports
+
+Import the file that owns a symbol. Do not add broad internal barrels such as
+`#core/index.js`. Keep package-root exports small. Export only a public contract
+or shared entity that another package must use. Do not root-export database
+helpers, routes, auth wiring, module factories, or test support.
+
+An implementation package can import its own code, foreign DTOs and events,
+foreign `/inter-module` clients, registered shared semantics, and neutral
+infrastructure. It cannot import a foreign implementation. The composition
+root may import implementations only to build the graph. Integration and E2E
+tests can compose real modules. Consumer unit tests use a contract fake.
+
+DTO packages may use only contract-safe foundations and passive contracts. A
+DTO root never imports producer code or transport behavior. The Integrations
+provider SPI is a same-context exception. It does not allow another context.
+
+## Enforcement and updates
+
+This guide is the canonical current rule set for backend package boundaries.
+These checks enforce the rules:
+
+- `pnpm check:api-context-inventory` checks server package classification,
+  cross-context implementation imports and manifest edges, and DTO
+  `/inter-module` exports.
+- `.dependency-cruiser.cjs` checks declared dependency boundaries.
+- `pnpm check:dependencies` checks dependency policy and manifest hygiene.
+- `pnpm check:published-artifacts` checks packed public entry points.
+
+The architecture registry and allowed migration baselines live in
+[`api-contexts.cjs`](../../api-contexts.cjs) and
+[`tools/api-architecture-policy`](../../tools/api-architecture-policy). Update
+them with a boundary change. Do not add a broad exception. A test exception
+must name one path, owner, reason, and tracking issue.
+
+Update this guide when the current model changes. Update an ADR, or add one,
+when the durable decision, ownership model, or accepted tradeoff changes.


### PR DESCRIPTION
Add a living backend architecture guide that explains the current module model, package boundaries, contract ownership, and enforcement points.

Backend rules were spread between `AGENTS.md` and historical ADRs. The new guide gives contributors a current source of truth, preserves ADR 0002 and ADR 0004 for rationale, and keeps package-specific APIs in their owning READMEs.

The guide links to the executable boundary checks and is discoverable from both the engineering documentation map and an AGENTS.md task trigger.

Closes ENG-1156

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a living backend architecture guide that defines the current module model, package boundaries, and enforcement points. Makes the rules easy to find from `docs/README.md` and `AGENTS.md`.

- **New Features**
  - Added `docs/architecture/backend-architecture.md` covering modules, contracts/DTOs/events, imports/exports, and boundary enforcement.
  - Linked the guide from `docs/README.md` and `AGENTS.md` to direct backend tasks.
  - Satisfies ENG-1156 by consolidating scattered rules; ADR 0002 and ADR 0004 remain as rationale.

<sup>Written for commit bb0c530e8e0afeeef5d3484e1f5a20421b041240. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

