### PR TITLE
Consolidate local development and release workflow documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,49 +1,22 @@
 # Agent guidelines
 
-Read [CONTRIBUTING.md](CONTRIBUTING.md) before working on this project.
+Read [CONTRIBUTING.md](CONTRIBUTING.md) when the task needs human contribution
+workflow or onboarding context.
 
-## Running tasks locally
+## Agent execution
 
-This project uses [mise](https://mise.jdx.dev/) to manage tool versions. `node`, `pnpm`, and `turbo` are all available in the shell: no `npx` needed.
+Use mise-managed tools. Prefix non-interactive commands with `mise exec --`.
+Use `turbo <task> --filter=@shipfox/<package>...` to validate the changed
+package and its dependencies before widening validation.
 
-```sh
-# Install dependencies
-pnpm install
+If the task needs task selection, local-service recovery, shared Ollama, or
+release procedures, read the
+[local development and release workflow guide](docs/guides/local-development-and-release-workflow.md).
+It owns those shared contributor procedures.
 
-# Build all packages
-turbo build
-
-# Check (lint + format + import sorting) / type-check / test
-turbo check
-turbo type
-turbo type:emit
-turbo test
-
-# Scope to a specific package
-turbo build --filter=@shipfox/api...
-
-# Start local services (Docker required)
-docker compose up -d
-
-# Dev mode with hot-reload (apps only)
-pnpm --filter=@shipfox/api dev
-```
-
-## Dependency management
-
-Read the [dependency version policy](docs/policies/dependency-versions.md)
-before adding, updating, or exempting a dependency. It defines catalog range
-rules, peer compatibility, coordinated Renovate families, and the contributor
-workflow.
-
-After a dependency change, run:
-
-```sh
-pnpm check:dependencies
-pnpm check:lockfile
-pnpm check:published-artifacts
-pnpm install --frozen-lockfile
-```
+If the task adds, updates, or exempts a dependency, read the
+[dependency version policy](docs/policies/dependency-versions.md). It owns
+dependency rules and required checks.
 
 ## Backend architecture
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,51 +11,42 @@ By participating, you are expected to uphold this code.
 
 ## Getting Started
 
-### Install tooling
+### Install tooling and dependencies
 
-[mise](https://mise.jdx.dev/) reads `mise.toml` and installs the correct versions of Node.js, pnpm, Turbo, and Ollama.
+[mise](https://mise.jdx.dev/) reads `mise.toml` and installs the correct versions
+of Node.js, pnpm, Turbo, and Ollama.
+
+Install the pinned tools and workspace dependencies:
 
 ```sh
 mise install
-```
-
-Use mise-managed tools directly after activation, or through `mise exec` in
-non-interactive scripts:
-
-```sh
 mise exec -- pnpm install
-mise exec -- turbo build
 ```
 
-### Start local services
+### Start services and build
 
 ```sh
 docker compose up -d
+mise exec -- turbo build
 ```
 
-### Install dependencies and build
+This creates a working local checkout. Use `mise exec --` for shell scripts and
+automation. Run `mise tasks` to discover repository tasks.
 
-```sh
-pnpm install
-turbo build
-```
+## Normal contribution workflow
 
-Build a specific package and its dependencies:
-
-```sh
-turbo build --filter=@shipfox/api...
-```
+Make a focused change. Run the smallest relevant validation before opening a
+pull request. Read the [local development and release workflow guide](docs/guides/local-development-and-release-workflow.md)
+when you need task selection, Conductor or Ollama recovery, affected-package
+validation, or package release procedures.
 
 If your contribution creates or changes a visual or interaction decision, read
 the [design system](DESIGN.md). It owns shared design guidance and points to
 the code that owns exact token and component values.
 
-## Dependency versions
-
-Read the [dependency version policy](docs/policies/dependency-versions.md) before
-adding, updating, or exempting a dependency. It defines catalog range rules,
-peer compatibility, coordinated Renovate families, and the transitive exception
-format.
+If you add, update, or exempt a dependency, read the
+[dependency version policy](docs/policies/dependency-versions.md). It defines
+version rules, exceptions, package families, and dependency checks.
 
 ## Client architecture
 
@@ -77,85 +68,6 @@ application log so self-hosters can diagnose it without Sentry. Log the error
 and only safe, bounded context such as the boundary's module, operation, or
 resource identifier. Never attach request bodies, headers, cookies, tokens, or
 payloads to either logs or reports.
-
-## Local Tooling
-
-### Mise Tasks
-
-The repository defines project tasks in `mise.toml`. List them with:
-
-```sh
-mise tasks
-```
-
-Mise tasks are safe to run from the main checkout or from a Conductor worktree.
-When a task needs the main checkout, it detects `CONDUCTOR_ROOT_PATH` and
-delegates to `mise -C "$CONDUCTOR_ROOT_PATH" run <task>`.
-
-### Shared Ollama
-
-Ollama is installed by mise and is used as a shared local service. It is started
-from the main checkout, not from each Conductor worktree, because the server is
-heavy and stateless.
-
-Conductor setup runs this automatically for local workspaces:
-
-```sh
-mise run ollama:up
-```
-
-From a worktree, that task delegates to the root checkout and runs the root
-`ollama:up` task. From the root checkout, it starts `ollama serve`, pulls
-`smollm2:135m-instruct-q2_K`, and then reports the API as ready. A background warmup request
-preloads the model with a 24 hour keep-alive, so callers can start using the
-Ollama HTTP API as soon as the pull completes.
-
-Useful commands:
-
-```sh
-mise run ollama:up       # start the shared server and pull smollm2:135m-instruct-q2_K
-mise run ollama:status   # show endpoint, root path, and managed process status
-mise run ollama:stop     # stop the server if this repo started it
-```
-
-The helper stores process state and logs under:
-
-```text
-$CONDUCTOR_ROOT_PATH/.context/shared-ollama/
-```
-
-The default endpoint is `http://127.0.0.1:11434`. Override it only when needed:
-
-```sh
-SHIPFOX_OLLAMA_BASE_URL=http://127.0.0.1:11500 mise run ollama:up
-SHIPFOX_OLLAMA_MODEL=other:model mise run ollama:up
-SHIPFOX_OLLAMA_KEEP_ALIVE=2h mise run ollama:up
-```
-
-### Conductor Worktree Services
-
-Conductor workspaces run `dev/worktree-services.mjs up` during setup. This
-creates per-worktree Docker services, leases a 20-port block from
-`~/.shipfox/shipfox-port-leases.json`, and writes the generated app environment
-to `.context/local-services/env`, which is loaded by `mise.toml`. Conductor
-workspaces use `CONDUCTOR_WORKSPACE_ID` as the stable lease identity, so a
-workspace rename keeps its ports. Ordinary git worktrees and clones fall back to
-their resolved path.
-
-Common commands:
-
-```sh
-mise exec -- node dev/worktree-services.mjs status
-mise exec -- node dev/worktree-services.mjs stop
-mise exec -- node dev/worktree-services.mjs destroy
-mise exec -- node dev/worktree-services.mjs cleanup
-```
-
-`destroy` removes the worktree Docker volumes and generated local-service state.
-The shared Ollama service is intentionally not stopped during workspace archive.
-`cleanup` only reports leases whose workspace path no longer exists. Run
-`mise exec -- node dev/worktree-services.mjs cleanup --apply` to remove the
-reported leases.
 
 ## Writing Documentation
 
@@ -184,61 +96,6 @@ package/
   dist/         Build output (git-ignored)
 ```
 
-## Common Scripts
-
-Available in most packages via `pnpm <script>`:
-
-| Script       | Description                                     |
-| ------------ | ----------------------------------------------- |
-| `build`      | Transpile source with [SWC](https://swc.rs/)    |
-| `dev`        | Start in watch mode with hot-reload (apps only) |
-| `type`       | Type-check and emit declarations                |
-| `lint`       | Check for lint errors                           |
-| `lint:fix`   | Auto-fix lint errors                            |
-| `format`     | Check formatting                                |
-| `format:fix` | Auto-fix formatting                             |
-| `test`       | Run tests once                                  |
-| `test:watch` | Run tests in watch mode                         |
-
-## Publishing & Changesets
-
-`libs/` and `tools/` packages publish to npm under `@shipfox/*`. `apps/`,
-`e2e/`, and the workspace root stay private.
-
-Every non-trivial PR touching `libs/` or `tools/` needs a changeset. Pure
-formatting or comment-only edits can skip it.
-
-```sh
-pnpm exec changeset          # humans
-# agents: invoke the `generate-changeset` skill
-```
-
-Pick the bump: `patch` for fixes/refactors, `minor` for additive API, `major`
-for breaking changes. Commit `.changeset/*.md` alongside the code.
-
-Trigger `.github/workflows/publish-packages.yml` from the Actions tab to
-publish.
-
-## Turbo Tasks
-
-[Turbo](https://turbo.build/) orchestrates tasks across the monorepo with caching and dependency ordering. Tasks are defined in `turbo.jsonc`:
-
-| Task | Description |
-| --- | --- |
-| `turbo build` | Build all packages in dependency order |
-| `turbo lint` / `turbo format` | Run checks across all packages |
-| `turbo type` | Type-check all packages in dependency order |
-| `turbo test` | Run tests across all packages |
-| `turbo verify` | Check repository and package invariants |
-| `turbo test:external` | Exercise built packages from clean consumers |
-| `turbo test:e2e` | Run Playwright E2E packages against a pre-started local stack |
-
-`--filter` scopes a task to a specific package:
-
-```sh
-turbo build --filter=@shipfox/api...
-turbo lint --filter=@shipfox/api-hello
-```
 
 ## E2E Testing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ listed there or when you need to place, update, or review documentation.
 | --- | --- | --- |
 | Needs the product overview or a starting point outside engineering work. | [Root README](../README.md) | Product orientation and repository navigation. |
 | Starts a human contribution or needs the normal local workflow. | [Contributing guide](../CONTRIBUTING.md) | Prerequisites, initial setup, contribution workflow, and essential validation. |
+| Needs local-task selection, service recovery, or package release procedures. | [Local development and release workflow](guides/local-development-and-release-workflow.md) | Mise, local services, Ollama, affected-package validation, Changesets, and publishing. |
 | Changes agent behavior or needs agent execution instructions. | [Agent instructions](../AGENTS.md) | Repository-specific agent execution, change hygiene, and conditional context loading. |
 | Adds, updates, or exempts a dependency. | [Dependency version policy](policies/dependency-versions.md) | Version ranges, exceptions, coordinated package families, and dependency checks. |
 | Changes a cross-package client composition seam. | [ADR 0001](adr/0001-client-composition-contract.md) | The public client composition contract and its decision rationale. |

--- a/docs/guides/local-development-and-release-workflow.md
+++ b/docs/guides/local-development-and-release-workflow.md
@@ -1,0 +1,123 @@
+# Local development and release workflow
+
+This guide owns detailed local-tooling recovery, validation selection, and
+package release procedures. It applies after a contributor has completed the
+initial setup in [CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+Scripts and task descriptions change with the repository. Read
+[mise.toml](../../mise.toml), [package.json](../../package.json), and
+[turbo.jsonc](../../turbo.jsonc) for the executable source of truth.
+
+## Choose a local workflow
+
+| When you need to... | Use... |
+| --- | --- |
+| See available project tasks. | `mise tasks` |
+| Run a Node, pnpm, or Turbo command from a non-interactive shell. | `mise exec -- <command>` |
+| Run the normal checks for one package and its dependencies. | `mise exec -- turbo <task> --filter=@shipfox/<package>...` |
+| Run all affected tasks before a broad change. | `mise exec -- turbo <task> --affected` |
+| Start local services in a normal checkout. | `docker compose up -d` |
+| Run browser end-to-end coverage. | The [E2E guide](../../e2e/README.md) |
+
+Use the narrowest task that proves the change. A package change normally needs
+its package checks, types, and tests. Run broader verification when a changed
+contract, shared tool, or dependency can affect other packages.
+
+## Mise and dependencies
+
+`mise.toml` pins the repository toolchain. Run `mise install` after cloning or
+when the tool versions change. Use `mise exec --` in scripts and automation so
+the command uses the pinned tools.
+
+Install workspace dependencies with:
+
+```sh
+mise exec -- pnpm install
+```
+
+Use `pnpm install --frozen-lockfile` when the committed lockfile must be
+verified without updating it.
+
+If you add, update, or exempt a dependency, read the
+[dependency version policy](../policies/dependency-versions.md). It defines
+catalog rules, exceptions, package families, and the required dependency
+checks.
+
+## Docker services and Conductor worktrees
+
+A normal checkout uses the repository Docker Compose stack:
+
+```sh
+docker compose up -d
+```
+
+Conductor workspaces use isolated services. Workspace setup normally starts
+them. If setup did not finish or the services need recovery, run:
+
+```sh
+mise exec -- node dev/worktree-services.mjs up
+```
+
+The command leases a worktree-specific 20-port block, starts PostgreSQL,
+Temporal, Garage, and Gitea, and writes the app environment to
+`.context/local-services/env`. Mise loads that file for later commands.
+
+| Need | Command |
+| --- | --- |
+| Inspect workspace services. | `mise exec -- node dev/worktree-services.mjs status` |
+| Stop services but keep their data. | `mise exec -- node dev/worktree-services.mjs stop` |
+| Remove services, volumes, generated state, and the port lease. | `mise exec -- node dev/worktree-services.mjs destroy` |
+| List stale port leases. | `mise exec -- node dev/worktree-services.mjs cleanup` |
+| Remove listed stale port leases. | `mise exec -- node dev/worktree-services.mjs cleanup --apply` |
+
+`destroy` is destructive. It removes the worktree Docker volumes and generated
+local-service state. It does not stop shared Ollama.
+
+## Shared Ollama
+
+Ollama is a shared service rooted at the main checkout. A Conductor workspace
+delegates these tasks to `CONDUCTOR_ROOT_PATH`, so run the same commands from
+the workspace or the root checkout.
+
+| Need | Command |
+| --- | --- |
+| Start the server, pull the configured model, and warm it. | `mise run ollama:up` |
+| Show endpoint, root, process, and health. | `mise run ollama:status` |
+| Stop a server started by this repository. | `mise run ollama:stop` |
+
+The default endpoint is `http://127.0.0.1:11434`. The default model and
+keep-alive period come from `dev/shared-ollama.mjs`. Set
+`SHIPFOX_OLLAMA_BASE_URL`, `SHIPFOX_OLLAMA_MODEL`, or
+`SHIPFOX_OLLAMA_KEEP_ALIVE` only when the local environment requires an
+override. Managed state and logs live under
+`$CONDUCTOR_ROOT_PATH/.context/shared-ollama/`.
+
+If `ollama:up` reports a live unverified process, stop that process manually
+before running the task again. The task will reuse a healthy server and only
+stops processes that it can verify as repository-managed.
+
+## Publish packages with Changesets
+
+Published packages live under `libs/` and `tools/`. Apps, end-to-end suites,
+and the workspace root are private.
+
+Add a Changeset for a non-trivial pull request that changes a published
+package. Documentation-only, formatting-only, and comment-only changes do not
+need one. Create it with:
+
+```sh
+pnpm exec changeset
+```
+
+Choose `patch` for fixes and internal refactors, `minor` for additive public
+API, and `major` for breaking public API. Commit the `.changeset/*.md` file
+with the change.
+
+The `publish-packages` GitHub workflow runs on `main`. Changesets opens or
+updates the generated release pull request, then publishes the release after
+that pull request merges. Do not run `release:publish` as a normal contributor
+workflow. It is the workflow command and requires its release environment.
+
+If a release or package-publishing incident needs tool-specific diagnosis, read
+the relevant package documentation under `tools/` and the workflow definition
+in [`.github/workflows/publish-packages.yml`](../../.github/workflows/publish-packages.yml).


### PR DESCRIPTION
Creates one canonical guide for local task selection, service recovery, shared Ollama, affected-package validation, Changesets, and package publishing.

CONTRIBUTING.md now keeps the short path to a working checkout, and AGENTS.md keeps only agent execution guidance with trigger-first links. This prevents the two entrypoints from becoming competing copies of operational documentation.

The guide links to mise, package, Turbo, dependency-policy, and workflow sources instead of copying their unstable inventories.

Closes ENG-1155

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates local development and release workflow docs into a single canonical guide and narrows contributor and agent entrypoints to their core roles. Aligns with ENG-1155 to remove duplicated ops docs and point to sources of truth.

- **Refactors**
  - Added docs/guides/local-development-and-release-workflow.md covering task selection (`turbo` filters/affected), `mise` toolchain use, Docker vs Conductor worktree services, shared Ollama, dependency checks, and publishing via `Changesets` and the GitHub workflow.
  - Trimmed CONTRIBUTING.md to the shortest path to a working checkout (`mise install`, install deps, start services, build), with `mise exec --`/`mise tasks` guidance and links to the new guide for procedures.
  - Slimmed AGENTS.md to agent execution basics (use `mise exec --`, validate with `turbo --filter`); defers workflow and dependency rules to the guide and the dependency policy.
  - Updated docs/README.md to route contributors to the new guide.
  - Replaced copied command inventories with links to `mise`, `turbo`, package, and workflow sources.

<sup>Written for commit ccc51f0f256e1f9a270a6fb5971f1c5f8ee8f948. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

