### PR TITLE
[client-agent] Converge provider state on domain models

### DIFF
--- a/.changeset/bright-foxes-converge.md
+++ b/.changeset/bright-foxes-converge.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-agent": major
+---
+
+Converges Agent model-provider queries and commands on client domain models.

--- a/libs/client/agent/src/components/available-provider-card.tsx
+++ b/libs/client/agent/src/components/available-provider-card.tsx
@@ -1,7 +1,7 @@
-import type {ModelProviderCatalogEntryDto} from '@shipfox/api-agent-dto';
 import {Icon} from '@shipfox/react-ui/icon';
 import {Text} from '@shipfox/react-ui/typography';
 import {cn} from '@shipfox/react-ui/utils';
+import type {SupportedProvider} from '#core/models.js';
 
 const SURFACE_CLASS =
   'overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base';
@@ -10,7 +10,7 @@ export function AvailableProviderCard({
   entry,
   onConfigure,
 }: {
-  entry: ModelProviderCatalogEntryDto;
+  entry: SupportedProvider;
   onConfigure: () => void;
 }) {
   return (

--- a/libs/client/agent/src/components/available-providers-grid.tsx
+++ b/libs/client/agent/src/components/available-providers-grid.tsx
@@ -1,19 +1,19 @@
-import type {ModelProviderCatalogEntryDto} from '@shipfox/api-agent-dto';
 import {Button} from '@shipfox/react-ui/button';
 import {EmptyState} from '@shipfox/react-ui/empty-state';
 import {Icon} from '@shipfox/react-ui/icon';
 import {Input} from '@shipfox/react-ui/input';
 import type {ReactNode} from 'react';
 import {useMemo, useRef, useState} from 'react';
+import type {SupportedProvider} from '#core/models.js';
+import {providerMatchesSearch} from '#core/provider-policy.js';
 import {AvailableProviderCard} from './available-provider-card.js';
-import {providerMatchesSearch} from './provider-search.js';
 
 export const PROVIDER_GRID_CLASS = 'grid grid-cols-2 gap-12 max-[760px]:grid-cols-1';
 
 const SEARCH_VISIBILITY_THRESHOLD = 8;
 const MAX_ECHOED_QUERY_LENGTH = 40;
 
-export function AvailableProvidersGrid<TEntry extends ModelProviderCatalogEntryDto>({
+export function AvailableProvidersGrid<TEntry extends SupportedProvider>({
   entries,
   onSelect,
   trailingCard,

--- a/libs/client/agent/src/components/change-default-model-form.tsx
+++ b/libs/client/agent/src/components/change-default-model-form.tsx
@@ -1,4 +1,3 @@
-import type {ModelProviderConfigDto} from '@shipfox/api-agent-dto';
 import {Button} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
 import {fieldError} from '@shipfox/react-ui/form-field';
@@ -6,6 +5,7 @@ import {ModalBody, ModalFooter} from '@shipfox/react-ui/modal';
 import {Text} from '@shipfox/react-ui/typography';
 import {useForm} from '@tanstack/react-form';
 import {useState} from 'react';
+import type {BuiltinProviderConfig, SupportedProvider} from '#core/models.js';
 import {useUpdateModelProviderDefaultModelMutation} from '#hooks/api/model-providers.js';
 import {
   DefaultModelField,
@@ -13,7 +13,6 @@ import {
   selectedModelForModelPayload,
 } from './default-model-field.js';
 import {modelProviderConfigErrorToFormError} from './form-errors.js';
-import type {SupportedModelProviderCatalogEntry} from './supported-model-provider-catalog-entry.js';
 
 const CHANGE_DEFAULT_MODEL_FORM_ID = 'model-provider-change-default-model-form';
 
@@ -24,21 +23,21 @@ export function ChangeDefaultModelForm({
   onSaved,
 }: {
   workspaceId: string;
-  entry: SupportedModelProviderCatalogEntry;
-  config: ModelProviderConfigDto;
+  entry: SupportedProvider;
+  config: BuiltinProviderConfig;
   onSaved: () => void;
 }) {
   const updateDefaultModel = useUpdateModelProviderDefaultModelMutation();
   const [formError, setFormError] = useState<string | undefined>();
   const form = useForm({
-    defaultValues: {default_model: defaultModelFormValue(config.default_model)},
+    defaultValues: {default_model: defaultModelFormValue(config.defaultModel)},
     onSubmit: async ({value}) => {
       setFormError(undefined);
       try {
         await updateDefaultModel.mutateAsync({
           workspaceId,
           providerId: entry.id,
-          body: {default_model: selectedModelForModelPayload(value.default_model)},
+          defaultModel: selectedModelForModelPayload(value.default_model),
         });
         onSaved();
       } catch (error) {

--- a/libs/client/agent/src/components/custom-model-provider-form.stories.tsx
+++ b/libs/client/agent/src/components/custom-model-provider-form.stories.tsx
@@ -1,9 +1,9 @@
-import type {CustomModelProviderConfigDto} from '@shipfox/api-agent-dto';
 import {configureApiClient} from '@shipfox/client-api';
 import {Modal, ModalContent, ModalHeader, ModalTitle} from '@shipfox/react-ui/modal';
 import type {Meta, StoryObj} from '@storybook/react';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {useMemo, useState} from 'react';
+import type {CustomProviderConfig} from '#core/models.js';
 import {CustomModelProviderForm} from './custom-model-provider-form.js';
 
 interface CustomModelProviderFormStoryProps {
@@ -61,31 +61,31 @@ export const EditStoredSecrets: Story = {
   args: {mode: 'edit'},
 };
 
-function customConfig(): CustomModelProviderConfigDto {
+function customConfig(): CustomProviderConfig {
   return {
     kind: 'custom',
-    provider_id: 'local-vllm',
-    display_name: 'Local vLLM',
+    providerId: 'local-vllm',
+    displayName: 'Local vLLM',
     api: 'openai-completions',
-    base_url: 'http://localhost:8000/v1',
+    baseUrl: 'http://localhost:8000/v1',
     headers: [{name: 'x-region', value: 'us'}],
-    secret_header_names: ['authorization'],
+    secretHeaderNames: ['authorization'],
     models: [
       {
         id: 'llama-3.1',
         label: 'Llama 3.1',
-        context_window: 128000,
-        max_output_tokens: 16384,
+        contextWindow: 128000,
+        maxOutputTokens: 16384,
       },
       {
         id: 'qwen-coder',
         label: 'Qwen Coder',
-        context_window: 32768,
-        max_output_tokens: 8192,
+        contextWindow: 32768,
+        maxOutputTokens: 8192,
       },
     ],
-    default_model: 'llama-3.1',
-    created_at: '2026-05-08T00:00:00.000Z',
-    updated_at: '2026-05-08T00:00:00.000Z',
+    defaultModel: 'llama-3.1',
+    createdAt: '2026-05-08T00:00:00.000Z',
+    updatedAt: '2026-05-08T00:00:00.000Z',
   };
 }

--- a/libs/client/agent/src/components/custom-model-provider-form.tsx
+++ b/libs/client/agent/src/components/custom-model-provider-form.tsx
@@ -1,4 +1,3 @@
-import type {CustomModelProviderConfigDto, ModelProviderApi} from '@shipfox/api-agent-dto';
 import {Badge} from '@shipfox/react-ui/badge';
 import {Button, IconButton} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
@@ -10,6 +9,7 @@ import {Text} from '@shipfox/react-ui/typography';
 import {useForm} from '@tanstack/react-form';
 import type {ReactNode, RefObject} from 'react';
 import {useEffect, useRef, useState} from 'react';
+import type {CustomProviderConfig, ProviderApi} from '#core/models.js';
 import {
   useCreateCustomModelProviderMutation,
   useDiscoverCustomModelProviderModelsBySlugMutation,
@@ -44,7 +44,7 @@ export function CustomModelProviderForm({
   onSaved,
 }: {
   workspaceId: string;
-  existingConfig?: CustomModelProviderConfigDto | undefined;
+  existingConfig?: CustomProviderConfig | undefined;
   onSaved: () => void;
 }) {
   const createMutation = useCreateCustomModelProviderMutation();
@@ -67,13 +67,13 @@ export function CustomModelProviderForm({
         if (existingConfig) {
           await updateMutation.mutateAsync({
             workspaceId,
-            providerId: existingConfig.provider_id,
-            body: buildUpdateCustomModelProviderBody(existingConfig, value),
+            providerId: existingConfig.providerId,
+            command: buildUpdateCustomModelProviderBody(existingConfig, value),
           });
         } else {
           await createMutation.mutateAsync({
             workspaceId,
-            body: buildCreateCustomModelProviderBody(value),
+            command: buildCreateCustomModelProviderBody(value),
           });
         }
         onSaved();
@@ -101,16 +101,16 @@ export function CustomModelProviderForm({
       const response = existingConfig
         ? await discoverBySlugMutation.mutateAsync({
             workspaceId,
-            providerId: existingConfig.provider_id,
-            body: buildDiscoverModelsBySlugBody(existingConfig, values),
+            providerId: existingConfig.providerId,
+            command: buildDiscoverModelsBySlugBody(existingConfig, values),
           })
         : await discoverMutation.mutateAsync({
             workspaceId,
-            body: buildDiscoverModelsBody(values),
+            command: buildDiscoverModelsBody(values),
           });
       if (!mountedRef.current) return;
       const existingIds = new Set(values.models.map((model) => model.id.trim()).filter(Boolean));
-      const discovered = response.models.filter((model) => !existingIds.has(model.id));
+      const discovered = response.filter((model) => !existingIds.has(model.id));
       form.setFieldValue('models', [
         ...values.models,
         ...discovered.map((model) => ({
@@ -234,7 +234,7 @@ export function CustomModelProviderForm({
                           <FormFieldSelect
                             value={field.state.value}
                             onChange={(event) =>
-                              field.handleChange(event.target.value as ModelProviderApi)
+                              field.handleChange(event.target.value as ProviderApi)
                             }
                             onBlur={field.handleBlur}
                           >

--- a/libs/client/agent/src/components/custom-model-provider-payload.test.ts
+++ b/libs/client/agent/src/components/custom-model-provider-payload.test.ts
@@ -1,4 +1,4 @@
-import type {CustomModelProviderConfigDto} from '@shipfox/api-agent-dto';
+import type {CustomProviderConfig} from '#core/models.js';
 import {
   buildCreateCustomModelProviderBody,
   buildDiscoverModelsBody,
@@ -61,21 +61,21 @@ describe('custom model provider payload mappers', () => {
 
     expect(body).toEqual({
       slug: 'local-vllm',
-      display_name: 'Local vLLM',
+      displayName: 'Local vLLM',
       api: 'openai-completions',
-      base_url: 'http://localhost:8000/v1',
-      api_key: 'sk-local',
+      baseUrl: 'http://localhost:8000/v1',
+      apiKey: 'sk-local',
       headers: [{name: 'authorization', value: 'Bearer token', secret: true}],
       models: [
         {
           id: 'llama-3.1',
           label: 'Llama 3.1',
-          context_window: 128000,
-          max_output_tokens: 16384,
-          input_image: true,
+          contextWindow: 128000,
+          maxOutputTokens: 16384,
+          inputImage: true,
         },
       ],
-      default_model: 'llama-3.1',
+      defaultModel: 'llama-3.1',
     });
   });
 
@@ -131,11 +131,11 @@ describe('custom model provider payload mappers', () => {
 
     expect(body).toEqual({
       api: 'openai-responses',
-      base_url: 'https://llm.example.test/v1',
-      api_key: 'sk-new',
+      baseUrl: 'https://llm.example.test/v1',
+      apiKey: 'sk-new',
       headers: [
-        {name: 'x-region', value: 'us'},
-        {name: 'authorization', value: 'Bearer new'},
+        {name: 'x-region', value: 'us', secret: false},
+        {name: 'authorization', value: 'Bearer new', secret: false},
       ],
     });
   });
@@ -146,25 +146,25 @@ describe('custom model provider payload mappers', () => {
   });
 });
 
-function customConfig(): CustomModelProviderConfigDto {
+function customConfig(): CustomProviderConfig {
   return {
     kind: 'custom',
-    provider_id: 'local-vllm',
-    display_name: 'Local vLLM',
+    providerId: 'local-vllm',
+    displayName: 'Local vLLM',
     api: 'openai-responses',
-    base_url: 'https://llm.example.test/v1',
+    baseUrl: 'https://llm.example.test/v1',
     headers: [{name: 'x-region', value: 'us'}],
-    secret_header_names: ['authorization'],
+    secretHeaderNames: ['authorization'],
     models: [
       {
         id: 'llama-3.1',
         label: 'Llama 3.1',
-        context_window: 128000,
-        max_output_tokens: 16384,
+        contextWindow: 128000,
+        maxOutputTokens: 16384,
       },
     ],
-    default_model: 'llama-3.1',
-    created_at: '2026-05-08T00:00:00.000Z',
-    updated_at: '2026-05-08T00:00:00.000Z',
+    defaultModel: 'llama-3.1',
+    createdAt: '2026-05-08T00:00:00.000Z',
+    updatedAt: '2026-05-08T00:00:00.000Z',
   };
 }

--- a/libs/client/agent/src/components/custom-model-provider-payload.ts
+++ b/libs/client/agent/src/components/custom-model-provider-payload.ts
@@ -1,15 +1,11 @@
 import type {
-  CreateCustomModelProviderBodyDto,
-  CustomAgentModelDto,
-  CustomModelProviderConfigDto,
-  DiscoverCustomModelProviderModelsBodyDto,
-  DiscoverCustomModelProviderModelsBySlugBodyDto,
-  ModelProviderApi,
-  UpdateCustomModelProviderBodyDto,
-} from '@shipfox/api-agent-dto';
-
-type CreateHeaderRequest = NonNullable<CreateCustomModelProviderBodyDto['headers']>[number];
-type UpdateHeaderRequest = NonNullable<UpdateCustomModelProviderBodyDto['headers']>[number];
+  AgentModel,
+  CreateCustomProviderCommand,
+  CustomProviderConfig,
+  DiscoverProviderModelsCommand,
+  ProviderApi,
+  UpdateCustomProviderCommand,
+} from '#core/models.js';
 
 export interface CustomModelProviderHeaderFormValue {
   client_id: string;
@@ -33,7 +29,7 @@ export interface CustomModelProviderModelFormValue {
 export interface CustomModelProviderFormValues {
   slug: string;
   display_name: string;
-  api: ModelProviderApi;
+  api: ProviderApi;
   base_url: string;
   api_key: string;
   headers: CustomModelProviderHeaderFormValue[];
@@ -65,13 +61,13 @@ export function createCustomModelProviderFormValues(): CustomModelProviderFormVa
 }
 
 export function editCustomModelProviderFormValues(
-  config: CustomModelProviderConfigDto,
+  config: CustomProviderConfig,
 ): CustomModelProviderFormValues {
   return {
-    slug: config.provider_id,
-    display_name: config.display_name,
+    slug: config.providerId,
+    display_name: config.displayName,
     api: config.api,
-    base_url: config.base_url,
+    base_url: config.baseUrl,
     api_key: '',
     headers: [
       ...config.headers.map((header) => ({
@@ -82,7 +78,7 @@ export function editCustomModelProviderFormValues(
         hasStoredValue: false,
         storedName: header.name,
       })),
-      ...config.secret_header_names.map((name) => ({
+      ...config.secretHeaderNames.map((name) => ({
         client_id: createFormRowId(),
         name,
         value: '',
@@ -92,45 +88,45 @@ export function editCustomModelProviderFormValues(
       })),
     ],
     models: config.models.map(modelFormValue),
-    default_model: config.default_model ?? '',
+    default_model: config.defaultModel ?? '',
   };
 }
 
 export function buildCreateCustomModelProviderBody(
   values: CustomModelProviderFormValues,
-): CreateCustomModelProviderBodyDto {
+): CreateCustomProviderCommand {
   return {
     slug: values.slug.trim(),
-    display_name: values.display_name.trim(),
+    displayName: values.display_name.trim(),
     api: values.api,
-    base_url: values.base_url.trim(),
-    ...(values.api_key.trim() ? {api_key: values.api_key.trim()} : {}),
+    baseUrl: values.base_url.trim(),
+    ...(values.api_key.trim() ? {apiKey: values.api_key.trim()} : {}),
     ...(requestHeaders(values.headers).length > 0 ? {headers: requestHeaders(values.headers)} : {}),
     models: requestModels(values.models),
-    ...(values.default_model.trim() ? {default_model: values.default_model.trim()} : {}),
+    ...(values.default_model.trim() ? {defaultModel: values.default_model.trim()} : {}),
   };
 }
 
 export function buildUpdateCustomModelProviderBody(
-  config: CustomModelProviderConfigDto,
+  config: CustomProviderConfig,
   values: CustomModelProviderFormValues,
-): UpdateCustomModelProviderBodyDto {
-  const body: UpdateCustomModelProviderBodyDto = {};
-  if (values.display_name.trim() !== config.display_name)
-    body.display_name = values.display_name.trim();
+): UpdateCustomProviderCommand {
+  const body: UpdateCustomProviderCommand = {};
+  if (values.display_name.trim() !== config.displayName)
+    body.displayName = values.display_name.trim();
   if (values.api !== config.api) body.api = values.api;
-  if (values.base_url.trim() !== config.base_url) body.base_url = values.base_url.trim();
-  if (values.api_key.trim()) body.api_key = values.api_key.trim();
+  if (values.base_url.trim() !== config.baseUrl) body.baseUrl = values.base_url.trim();
+  if (values.api_key.trim()) body.apiKey = values.api_key.trim();
   if (customHeadersDirty(config, values.headers)) body.headers = updateHeaders(values.headers);
   if (customModelsDirty(config, values.models)) body.models = requestModels(values.models);
 
   const nextDefault = values.default_model.trim() || null;
-  if (nextDefault !== config.default_model) body.default_model = nextDefault;
+  if (nextDefault !== config.defaultModel) body.defaultModel = nextDefault;
   return body;
 }
 
 export function customHeadersDirty(
-  config: CustomModelProviderConfigDto,
+  config: CustomProviderConfig,
   headers: CustomModelProviderHeaderFormValue[],
 ): boolean {
   return (
@@ -141,7 +137,7 @@ export function customHeadersDirty(
         value: header.value,
         secret: false,
       })),
-      ...config.secret_header_names.map((name) => ({
+      ...config.secretHeaderNames.map((name) => ({
         name: normalizeHeaderName(name),
         secret: true,
         keep: true,
@@ -151,24 +147,37 @@ export function customHeadersDirty(
 }
 
 export function customModelsDirty(
-  config: CustomModelProviderConfigDto,
+  config: CustomProviderConfig,
   models: CustomModelProviderModelFormValue[],
 ): boolean {
-  return JSON.stringify(requestModels(models)) !== JSON.stringify(config.models);
+  return (
+    JSON.stringify(requestModels(models)) !==
+    JSON.stringify(
+      config.models.map((model) => ({
+        id: model.id,
+        label: model.label,
+        ...(model.contextWindow === undefined ? {} : {contextWindow: model.contextWindow}),
+        ...(model.maxOutputTokens === undefined ? {} : {maxOutputTokens: model.maxOutputTokens}),
+        ...(model.inputImage ? {inputImage: true} : {}),
+        ...(model.reasoning ? {reasoning: true} : {}),
+      })),
+    )
+  );
 }
 
 export function buildDiscoverModelsBody(
   values: CustomModelProviderFormValues,
-): DiscoverCustomModelProviderModelsBodyDto {
+): DiscoverProviderModelsCommand {
   return {
     api: values.api,
-    base_url: values.base_url.trim(),
-    ...(values.api_key.trim() ? {api_key: values.api_key.trim()} : {}),
+    baseUrl: values.base_url.trim(),
+    ...(values.api_key.trim() ? {apiKey: values.api_key.trim()} : {}),
     ...(requestHeaders(values.headers).length > 0
       ? {
           headers: requestHeaders(values.headers).map(({name, value}) => ({
             name,
             value,
+            secret: false,
           })),
         }
       : {}),
@@ -176,13 +185,13 @@ export function buildDiscoverModelsBody(
 }
 
 export function buildDiscoverModelsBySlugBody(
-  config: CustomModelProviderConfigDto,
+  config: CustomProviderConfig,
   values: CustomModelProviderFormValues,
-): DiscoverCustomModelProviderModelsBySlugBodyDto {
-  const body: DiscoverCustomModelProviderModelsBySlugBodyDto = {};
+): DiscoverProviderModelsCommand {
+  const body: DiscoverProviderModelsCommand = {};
   if (values.api !== config.api) body.api = values.api;
-  if (values.base_url.trim() !== config.base_url) body.base_url = values.base_url.trim();
-  if (values.api_key.trim()) body.api_key = values.api_key.trim();
+  if (values.base_url.trim() !== config.baseUrl) body.baseUrl = values.base_url.trim();
+  if (values.api_key.trim()) body.apiKey = values.api_key.trim();
   body.headers = updateHeaders(values.headers);
   return body;
 }
@@ -200,8 +209,10 @@ export function createFormRowId(): string {
   return crypto.randomUUID();
 }
 
-function updateHeaders(headers: CustomModelProviderHeaderFormValue[]): UpdateHeaderRequest[] {
-  const result: UpdateHeaderRequest[] = [];
+function updateHeaders(
+  headers: CustomModelProviderHeaderFormValue[],
+): NonNullable<UpdateCustomProviderCommand['headers']> {
+  const result: NonNullable<UpdateCustomProviderCommand['headers']> = [];
   for (const header of headers) {
     const name = normalizeHeaderName(header.name);
     if (!name) continue;
@@ -219,7 +230,9 @@ function updateHeaders(headers: CustomModelProviderHeaderFormValue[]): UpdateHea
   return result;
 }
 
-function requestHeaders(headers: CustomModelProviderHeaderFormValue[]): CreateHeaderRequest[] {
+function requestHeaders(
+  headers: CustomModelProviderHeaderFormValue[],
+): NonNullable<CreateCustomProviderCommand['headers']> {
   return updateHeaders(headers).flatMap((header) =>
     'value' in header && header.value
       ? [{name: header.name, value: header.value, secret: header.secret}]
@@ -227,7 +240,9 @@ function requestHeaders(headers: CustomModelProviderHeaderFormValue[]): CreateHe
   );
 }
 
-function requestModels(models: CustomModelProviderModelFormValue[]): CustomAgentModelDto[] {
+function requestModels(
+  models: CustomModelProviderModelFormValue[],
+): CreateCustomProviderCommand['models'] {
   return models.flatMap((model) => {
     const id = model.id.trim();
     const label = model.label.trim();
@@ -236,25 +251,25 @@ function requestModels(models: CustomModelProviderModelFormValue[]): CustomAgent
       {
         id,
         label,
-        ...(model.context_window.trim() ? {context_window: Number(model.context_window)} : {}),
+        ...(model.context_window.trim() ? {contextWindow: Number(model.context_window)} : {}),
         ...(model.max_output_tokens.trim()
-          ? {max_output_tokens: Number(model.max_output_tokens)}
+          ? {maxOutputTokens: Number(model.max_output_tokens)}
           : {}),
-        ...(model.input_image ? {input_image: true} : {}),
+        ...(model.input_image ? {inputImage: true} : {}),
         ...(model.reasoning ? {reasoning: true} : {}),
       },
     ];
   });
 }
 
-function modelFormValue(model: CustomAgentModelDto): CustomModelProviderModelFormValue {
+function modelFormValue(model: AgentModel): CustomModelProviderModelFormValue {
   return {
     client_id: createFormRowId(),
     id: model.id,
     label: model.label,
-    context_window: model.context_window?.toString() ?? '',
-    max_output_tokens: model.max_output_tokens?.toString() ?? '',
-    input_image: model.input_image ?? false,
+    context_window: model.contextWindow?.toString() ?? '',
+    max_output_tokens: model.maxOutputTokens?.toString() ?? '',
+    input_image: model.inputImage ?? false,
     reasoning: model.reasoning ?? false,
   };
 }

--- a/libs/client/agent/src/components/default-model-field.tsx
+++ b/libs/client/agent/src/components/default-model-field.tsx
@@ -1,7 +1,7 @@
-import type {ModelProviderCatalogEntryDto} from '@shipfox/api-agent-dto';
 import {FormField, useFormField} from '@shipfox/react-ui/form-field';
 import {cn} from '@shipfox/react-ui/utils';
 import type {ComponentProps, ReactNode} from 'react';
+import type {SupportedProvider} from '#core/models.js';
 
 export const LATEST_MODEL_VALUE = '__latest__';
 
@@ -13,7 +13,7 @@ export function DefaultModelField({
   onChange,
   onBlur,
 }: {
-  entry: ModelProviderCatalogEntryDto;
+  entry: SupportedProvider;
   value: string;
   error: string | undefined;
   children?: ReactNode;
@@ -52,13 +52,13 @@ export function selectedModelForModelPayload(selectedModel: string): string | nu
   return selectedModel === LATEST_MODEL_VALUE ? null : selectedModel.trim();
 }
 
-function defaultModelLabel(entry: ModelProviderCatalogEntryDto): string {
-  const defaultModel = entry.default_model ?? entry.models[0]?.id ?? '';
+function defaultModelLabel(entry: SupportedProvider): string {
+  const defaultModel = entry.defaultModel ?? entry.models[0]?.id ?? '';
   return entry.models.find((model) => model.id === defaultModel)?.label ?? defaultModel;
 }
 
 function defaultModelDescription(
-  entry: ModelProviderCatalogEntryDto,
+  entry: SupportedProvider,
   selectedModel: string | undefined,
 ): string | undefined {
   if (selectedModel === LATEST_MODEL_VALUE) {

--- a/libs/client/agent/src/components/harness-availability.test.ts
+++ b/libs/client/agent/src/components/harness-availability.test.ts
@@ -1,28 +1,31 @@
-import {getHarnessDescriptor} from '@shipfox/api-agent-dto';
+import {getHarness} from '#core/harness-policy.js';
+import {toProviderConfig} from '#hooks/api/model-provider-mapper.js';
 import {customModelProviderConfig, modelProviderConfig} from '#test/fixtures/model-providers.js';
 import {compatibleHarnessIds, isHarnessAvailable} from './harness-availability.js';
 
 describe('harness availability', () => {
   test('marks pi available with any builtin provider config', () => {
-    const result = isHarnessAvailable(getHarnessDescriptor('pi'), [
-      modelProviderConfig({provider_id: 'openai'}),
+    const result = isHarnessAvailable(getHarness('pi'), [
+      toProviderConfig(modelProviderConfig({provider_id: 'openai'})),
     ]);
 
     expect(result).toBe(true);
   });
 
   test('marks pi available with only a custom provider config', () => {
-    const result = isHarnessAvailable(getHarnessDescriptor('pi'), [customModelProviderConfig()]);
+    const result = isHarnessAvailable(getHarness('pi'), [
+      toProviderConfig(customModelProviderConfig()),
+    ]);
 
     expect(result).toBe(true);
   });
 
   test('marks claude available only when Anthropic is configured', () => {
-    const openai = isHarnessAvailable(getHarnessDescriptor('claude'), [
-      modelProviderConfig({provider_id: 'openai'}),
+    const openai = isHarnessAvailable(getHarness('claude'), [
+      toProviderConfig(modelProviderConfig({provider_id: 'openai'})),
     ]);
-    const anthropic = isHarnessAvailable(getHarnessDescriptor('claude'), [
-      modelProviderConfig({provider_id: 'anthropic'}),
+    const anthropic = isHarnessAvailable(getHarness('claude'), [
+      toProviderConfig(modelProviderConfig({provider_id: 'anthropic'})),
     ]);
 
     expect(openai).toBe(false);
@@ -30,8 +33,8 @@ describe('harness availability', () => {
   });
 
   test('marks both harnesses unavailable when no providers are configured', () => {
-    expect(isHarnessAvailable(getHarnessDescriptor('pi'), [])).toBe(false);
-    expect(isHarnessAvailable(getHarnessDescriptor('claude'), [])).toBe(false);
+    expect(isHarnessAvailable(getHarness('pi'), [])).toBe(false);
+    expect(isHarnessAvailable(getHarness('claude'), [])).toBe(false);
   });
 
   test('returns compatible harnesses for builtin and custom providers', () => {

--- a/libs/client/agent/src/components/harness-availability.ts
+++ b/libs/client/agent/src/components/harness-availability.ts
@@ -1,35 +1,11 @@
-import {
-  DEFAULT_HARNESS,
-  type Harness,
-  type HarnessDescriptor,
-  listHarnessDescriptors,
-  type ModelProviderConfigResponseDto,
-} from '@shipfox/api-agent-dto';
-
-export function configSupportsHarness(
-  config: ModelProviderConfigResponseDto,
-  descriptor: HarnessDescriptor,
-): boolean {
-  if (config.kind === 'custom') return descriptor.id === DEFAULT_HARNESS;
-  return descriptor.supportedProviderIds.includes(config.provider_id);
-}
+import {compatibleHarnessIds, configSupportsHarness} from '#core/harness-policy.js';
+import type {HarnessDescriptor, ProviderConfig} from '#core/models.js';
 
 export function isHarnessAvailable(
   descriptor: HarnessDescriptor,
-  configs: ModelProviderConfigResponseDto[],
+  configs: readonly ProviderConfig[],
 ): boolean {
   return configs.some((config) => configSupportsHarness(config, descriptor));
 }
 
-export function compatibleHarnessIds({
-  isCustom,
-  providerId,
-}: {
-  isCustom: boolean;
-  providerId: string;
-}): Harness[] {
-  if (isCustom) return [DEFAULT_HARNESS];
-  return listHarnessDescriptors()
-    .filter((descriptor) => descriptor.supportedProviderIds.includes(providerId))
-    .map((descriptor) => descriptor.id);
-}
+export {compatibleHarnessIds};

--- a/libs/client/agent/src/components/harnesses-section.tsx
+++ b/libs/client/agent/src/components/harnesses-section.tsx
@@ -1,9 +1,3 @@
-import {
-  DEFAULT_HARNESS,
-  type Harness,
-  type HarnessDescriptor,
-  listHarnessDescriptors,
-} from '@shipfox/api-agent-dto';
 import {QueryLoadError} from '@shipfox/client-ui';
 import {IconButton} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
@@ -20,6 +14,8 @@ import {Tooltip, TooltipContent, TooltipTrigger} from '@shipfox/react-ui/tooltip
 import {Header, Text} from '@shipfox/react-ui/typography';
 import {cn} from '@shipfox/react-ui/utils';
 import {useRef, useState} from 'react';
+import {DEFAULT_HARNESS, listHarnesses} from '#core/harness-policy.js';
+import type {HarnessDescriptor, HarnessId} from '#core/models.js';
 import {
   useModelProviderConfigsQuery,
   useSetDefaultHarnessMutation,
@@ -38,13 +34,13 @@ export function WorkspaceHarnessesSection({workspaceId}: {workspaceId: string}) 
   const activeDefaultRequestRef = useRef<{workspaceId: string; id: number} | null>(null);
   const [pendingDefaultHarness, setPendingDefaultHarness] = useState<{
     workspaceId: string;
-    harnessId: Harness;
+    harnessId: HarnessId;
   } | null>(null);
   const [defaultError, setDefaultError] = useState<
-    {workspaceId: string; harnessId: Harness; message: string} | undefined
+    {workspaceId: string; harnessId: HarnessId; message: string} | undefined
   >();
   const configs = configsQuery.data?.configs ?? [];
-  const defaultHarnessId = configsQuery.data?.default_harness_id ?? DEFAULT_HARNESS;
+  const defaultHarnessId = configsQuery.data?.defaultHarnessId ?? DEFAULT_HARNESS;
   activeWorkspaceIdRef.current = workspaceId;
 
   function isActiveDefaultRequest(request: {workspaceId: string; id: number}) {
@@ -67,7 +63,7 @@ export function WorkspaceHarnessesSection({workspaceId}: {workspaceId: string}) 
     try {
       await setDefaultHarness.mutateAsync({
         workspaceId,
-        body: {harness_id: harness.id},
+        harnessId: harness.id,
       });
       if (!isActiveDefaultRequest(request)) return;
       toast.success(`${harness.label} is now the default harness`);
@@ -106,7 +102,7 @@ export function WorkspaceHarnessesSection({workspaceId}: {workspaceId: string}) 
 
       {configsQuery.data !== undefined ? (
         <ul className={cn('divide-y divide-border-neutral-base', SURFACE_CLASS)}>
-          {listHarnessDescriptors().map((harness) => (
+          {listHarnesses().map((harness) => (
             <HarnessRow
               key={harness.id}
               harness={harness}

--- a/libs/client/agent/src/components/model-provider-usage-modal.stories.tsx
+++ b/libs/client/agent/src/components/model-provider-usage-modal.stories.tsx
@@ -1,9 +1,6 @@
-import type {
-  CustomModelProviderConfigDto,
-  ModelProviderCatalogEntryDto,
-} from '@shipfox/api-agent-dto';
 import type {Meta, StoryObj} from '@storybook/react';
 import {useState} from 'react';
+import type {CustomProviderConfig, SupportedProvider} from '#core/models.js';
 import {ModelProviderUsageModal} from './model-provider-usage-modal.js';
 import {
   usageTargetFromCatalogEntry,
@@ -26,7 +23,7 @@ function ModelProviderUsageModalStory({variant}: ModelProviderUsageModalStoryPro
     <div className="min-h-screen bg-background-neutral-background p-24">
       <ModelProviderUsageModal
         target={target}
-        initialModel={target.default_model}
+        initialModel={target.defaultModel}
         workspaceDefaultHarnessId="claude"
         open={open}
         onOpenChange={setOpen}
@@ -55,14 +52,13 @@ export const CustomProvider: Story = {
   args: {variant: 'custom'},
 };
 
-function anthropicEntry(): ModelProviderCatalogEntryDto {
+function anthropicEntry(): SupportedProvider {
   return {
+    kind: 'supported',
     id: 'anthropic',
     label: 'Anthropic',
-    support_status: 'supported',
-    default_model: 'claude-opus-4-8',
-    credential_fields: [{key: 'api_key', label: 'API key', secret: true}],
-    unsupported_reason: null,
+    defaultModel: 'claude-opus-4-8',
+    credentialFields: [{key: 'api_key', label: 'API key', secret: true}],
     models: [
       {id: 'claude-opus-4-8', label: 'Claude Opus 4.8'},
       {id: 'claude-sonnet-4-8', label: 'Claude Sonnet 4.8'},
@@ -71,14 +67,13 @@ function anthropicEntry(): ModelProviderCatalogEntryDto {
   };
 }
 
-function longListEntry(): ModelProviderCatalogEntryDto {
+function longListEntry(): SupportedProvider {
   return {
+    kind: 'supported',
     id: 'cloudflare-workers-ai',
     label: 'Cloudflare Workers AI',
-    support_status: 'supported',
-    default_model: '@cf/moonshotai/kimi-k2.7-code',
-    credential_fields: [{key: 'api_token', label: 'API token', secret: true}],
-    unsupported_reason: null,
+    defaultModel: '@cf/moonshotai/kimi-k2.7-code',
+    credentialFields: [{key: 'api_token', label: 'API token', secret: true}],
     models: Array.from({length: 56}, (_, index) => ({
       id:
         index === 0
@@ -89,18 +84,18 @@ function longListEntry(): ModelProviderCatalogEntryDto {
   };
 }
 
-function customProviderConfig(): CustomModelProviderConfigDto {
+function customProviderConfig(): CustomProviderConfig {
   return {
     kind: 'custom',
-    provider_id: 'local-vllm',
-    display_name: 'Local vLLM',
+    providerId: 'local-vllm',
+    displayName: 'Local vLLM',
     api: 'openai-completions',
-    base_url: 'http://localhost:8000/v1',
+    baseUrl: 'http://localhost:8000/v1',
     headers: [],
-    secret_header_names: [],
+    secretHeaderNames: [],
     models: [{id: 'llama-3.1', label: 'Llama 3.1'}],
-    default_model: 'llama-3.1',
-    created_at: '2026-05-08T00:00:00.000Z',
-    updated_at: '2026-05-08T00:00:00.000Z',
+    defaultModel: 'llama-3.1',
+    createdAt: '2026-05-08T00:00:00.000Z',
+    updatedAt: '2026-05-08T00:00:00.000Z',
   };
 }

--- a/libs/client/agent/src/components/model-provider-usage-modal.test.tsx
+++ b/libs/client/agent/src/components/model-provider-usage-modal.test.tsx
@@ -1,6 +1,6 @@
 import {fireEvent, render, screen, waitFor, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {customModelProviderConfig, modelProviderEntry} from '#test/fixtures/model-providers.js';
+import type {CustomProviderConfig, SupportedProvider} from '#core/models.js';
 import {ModelProviderUsageModal} from './model-provider-usage-modal.js';
 import {
   usageTargetFromCatalogEntry,
@@ -12,8 +12,8 @@ const KIMI_MODEL_ROW_NAME = 'Copy Kimi K2.7 Code model id @cf/moonshotai/kimi-k2
 
 function renderUsageModal() {
   const onOpenChange = vi.fn();
-  const entry = modelProviderEntry({
-    default_model: 'claude-opus-4-8',
+  const entry = supportedProvider({
+    defaultModel: 'claude-opus-4-8',
     models: [
       {id: 'claude-opus-4-8', label: 'Claude Opus 4.8'},
       {id: '@cf/moonshotai/kimi-k2.7-code', label: 'Kimi K2.7 Code'},
@@ -79,7 +79,7 @@ describe('ModelProviderUsageModal', () => {
 
   test('uses the workspace default harness when it is compatible', async () => {
     const onOpenChange = vi.fn();
-    const entry = modelProviderEntry();
+    const entry = supportedProvider();
 
     render(
       <ModelProviderUsageModal
@@ -100,8 +100,8 @@ describe('ModelProviderUsageModal', () => {
 
   test('clamps the selected harness when the target changes', async () => {
     const onOpenChange = vi.fn();
-    const anthropic = modelProviderEntry();
-    const openai = modelProviderEntry({
+    const anthropic = supportedProvider();
+    const openai = supportedProvider({
       id: 'openai',
       label: 'OpenAI',
       models: [{id: 'gpt-5.5-pro', label: 'GPT-5.5 Pro'}],
@@ -144,7 +144,7 @@ describe('ModelProviderUsageModal', () => {
 
     render(
       <ModelProviderUsageModal
-        target={usageTargetFromCustomConfig(customModelProviderConfig())}
+        target={usageTargetFromCustomConfig(customProviderConfig())}
         initialModel="custom-model"
         workspaceDefaultHarnessId="claude"
         open
@@ -208,3 +208,31 @@ describe('ModelProviderUsageModal', () => {
     );
   });
 });
+
+function supportedProvider(overrides: Partial<SupportedProvider> = {}): SupportedProvider {
+  return {
+    kind: 'supported',
+    id: 'anthropic',
+    label: 'Anthropic',
+    defaultModel: 'claude-opus-4-8',
+    credentialFields: [{key: 'api_key', label: 'API key', secret: true}],
+    models: [{id: 'claude-opus-4-8', label: 'Claude Opus 4.8'}],
+    ...overrides,
+  };
+}
+
+function customProviderConfig(): CustomProviderConfig {
+  return {
+    kind: 'custom',
+    providerId: 'openai-compatible',
+    displayName: 'OpenAI Compatible',
+    api: 'openai-completions',
+    baseUrl: 'https://llm.example.test/v1',
+    headers: [],
+    secretHeaderNames: [],
+    models: [{id: 'custom-model', label: 'Custom Model'}],
+    defaultModel: 'custom-model',
+    createdAt: '2026-05-08T00:00:00.000Z',
+    updatedAt: '2026-05-08T00:00:00.000Z',
+  };
+}

--- a/libs/client/agent/src/components/model-provider-usage-modal.tsx
+++ b/libs/client/agent/src/components/model-provider-usage-modal.tsx
@@ -1,9 +1,3 @@
-import {
-  DEFAULT_HARNESS,
-  getHarnessDescriptor,
-  type Harness,
-  listHarnessDescriptors,
-} from '@shipfox/api-agent-dto';
 import {Button} from '@shipfox/react-ui/button';
 import {
   CodeBlock,
@@ -28,6 +22,8 @@ import {
 import {Tooltip, TooltipContent, TooltipTrigger} from '@shipfox/react-ui/tooltip';
 import {Code, Text} from '@shipfox/react-ui/typography';
 import {useEffect, useMemo, useRef, useState} from 'react';
+import {DEFAULT_HARNESS, getHarness, listHarnesses} from '#core/harness-policy.js';
+import type {HarnessId} from '#core/models.js';
 import {buildAgentWorkflowExample} from './agent-workflow-example.js';
 import {compatibleHarnessIds} from './harness-availability.js';
 import type {ModelProviderUsageTarget} from './model-provider-usage-target.js';
@@ -49,14 +45,14 @@ export function ModelProviderUsageModal({
   open: boolean;
   onOpenChange: (open: boolean) => void;
   closeFocusTarget?: HTMLElement | null | undefined;
-  workspaceDefaultHarnessId?: Harness | null | undefined;
+  workspaceDefaultHarnessId?: HarnessId | null | undefined;
 }) {
   const [selectedModel, setSelectedModel] = useState('');
-  const [selectedHarness, setSelectedHarness] = useState<Harness>(DEFAULT_HARNESS);
+  const [selectedHarness, setSelectedHarness] = useState<HarnessId>(DEFAULT_HARNESS);
 
   useEffect(() => {
     if (!target) return;
-    setSelectedModel(initialModel ?? target.default_model ?? target.models[0]?.id ?? '');
+    setSelectedModel(initialModel ?? target.defaultModel ?? target.models[0]?.id ?? '');
   }, [target, initialModel]);
 
   useEffect(() => {
@@ -72,14 +68,14 @@ export function ModelProviderUsageModal({
     () =>
       target
         ? compatibleHarnessIds({isCustom: target.isCustom, providerId: target.id})
-        : ([] as Harness[]),
+        : ([] as HarnessId[]),
     [target],
   );
   const harnessOptions = useMemo(
     () =>
       compatibleIds.map((harnessId) => ({
         value: harnessId,
-        label: getHarnessDescriptor(harnessId).label,
+        label: getHarness(harnessId).label,
       })),
     [compatibleIds],
   );
@@ -239,9 +235,9 @@ export function ModelProviderUsageModal({
 }
 
 function selectInitialHarness(
-  compatibleIds: Harness[],
-  workspaceDefaultHarnessId: Harness | null | undefined,
-): Harness {
+  compatibleIds: HarnessId[],
+  workspaceDefaultHarnessId: HarnessId | null | undefined,
+): HarnessId {
   if (workspaceDefaultHarnessId && compatibleIds.includes(workspaceDefaultHarnessId)) {
     return workspaceDefaultHarnessId;
   }
@@ -249,8 +245,8 @@ function selectInitialHarness(
   return compatibleIds[0] ?? DEFAULT_HARNESS;
 }
 
-function isHarness(value: string): value is Harness {
-  return listHarnessDescriptors().some((descriptor) => descriptor.id === value);
+function isHarness(value: string): value is HarnessId {
+  return listHarnesses().some((descriptor) => descriptor.id === value);
 }
 
 function ModelProviderModelRow({label, id}: {label: string; id: string}) {

--- a/libs/client/agent/src/components/model-provider-usage-target.ts
+++ b/libs/client/agent/src/components/model-provider-usage-target.ts
@@ -1,36 +1,33 @@
-import type {
-  CustomModelProviderConfigDto,
-  ModelProviderCatalogEntryDto,
-} from '@shipfox/api-agent-dto';
+import type {CustomProviderConfig, SupportedProvider} from '#core/models.js';
 
 export interface ModelProviderUsageTarget {
   id: string;
   label: string;
   isCustom: boolean;
-  models: Array<{id: string; label: string}>;
-  default_model: string | null;
+  models: ReadonlyArray<{id: string; label: string}>;
+  defaultModel: string | null;
 }
 
-export function usageTargetFromCatalogEntry(
-  entry: ModelProviderCatalogEntryDto,
-): ModelProviderUsageTarget {
+export function usageTargetFromCatalogEntry(entry: SupportedProvider): ModelProviderUsageTarget {
+  const provider = entry;
   return {
-    id: entry.id,
-    label: entry.label,
+    id: provider.id,
+    label: provider.label,
     isCustom: false,
-    models: entry.models,
-    default_model: entry.default_model,
+    models: provider.models,
+    defaultModel: provider.defaultModel,
   };
 }
 
 export function usageTargetFromCustomConfig(
-  config: CustomModelProviderConfigDto,
+  config: CustomProviderConfig,
 ): ModelProviderUsageTarget {
+  const provider = config;
   return {
-    id: config.provider_id,
-    label: config.display_name,
+    id: provider.providerId,
+    label: provider.displayName,
     isCustom: true,
-    models: config.models,
-    default_model: config.default_model,
+    models: provider.models,
+    defaultModel: provider.defaultModel,
   };
 }

--- a/libs/client/agent/src/components/model-providers-section.stories.tsx
+++ b/libs/client/agent/src/components/model-providers-section.stories.tsx
@@ -255,7 +255,7 @@ function catalogForScenario(scenario: Scenario): ModelProviderCatalogEntryDto[] 
 
 function configsForScenario(scenario: Scenario) {
   if (scenario === 'empty-configured' || scenario === 'configs-error') {
-    return {configs: [], default_provider_id: null};
+    return {configs: [], default_provider_id: null, default_harness_id: null};
   }
   if (scenario === 'all-configured') {
     return {
@@ -265,17 +265,20 @@ function configsForScenario(scenario: Scenario) {
         }),
       ),
       default_provider_id: 'anthropic',
+      default_harness_id: null,
     };
   }
   if (scenario === 'custom-configured') {
     return {
       configs: [providerConfig({provider_id: 'anthropic'}), customProviderConfig()],
       default_provider_id: 'local-vllm',
+      default_harness_id: null,
     };
   }
   return {
     configs: [providerConfig({provider_id: 'anthropic'})],
     default_provider_id: 'anthropic',
+    default_harness_id: null,
   };
 }
 

--- a/libs/client/agent/src/components/model-providers-section.tsx
+++ b/libs/client/agent/src/components/model-providers-section.tsx
@@ -1,9 +1,3 @@
-import type {
-  CustomModelProviderConfigDto,
-  ModelProviderCatalogEntryDto,
-  ModelProviderConfigDto,
-  ModelProviderConfigResponseDto,
-} from '@shipfox/api-agent-dto';
 import {QueryLoadError} from '@shipfox/client-ui';
 import {Button, IconButton} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
@@ -28,7 +22,22 @@ import {toast} from '@shipfox/react-ui/toast';
 import {Tooltip, TooltipContent, TooltipTrigger} from '@shipfox/react-ui/tooltip';
 import {Header, Text} from '@shipfox/react-ui/typography';
 import {cn} from '@shipfox/react-ui/utils';
-import {useEffect, useMemo, useRef, useState} from 'react';
+import {useEffect, useMemo, useReducer, useRef, useState} from 'react';
+import {
+  type ManagementModal,
+  managementModalReducer,
+} from '#core/model-provider-management-reducer.js';
+import type {
+  BuiltinProviderConfig,
+  CustomProviderConfig,
+  ProviderCatalogEntry,
+  ProviderConfig,
+  SupportedProvider,
+} from '#core/models.js';
+import {
+  isSupportedProvider,
+  availableProviders as selectAvailableProviders,
+} from '#core/provider-policy.js';
 import {
   useDeleteModelProviderConfigMutation,
   useModelProviderCatalogQuery,
@@ -47,23 +56,11 @@ import {
   usageTargetFromCustomConfig,
 } from './model-provider-usage-target.js';
 import {customProviderCardMatchesSearch} from './provider-search.js';
-import {
-  isSupportedCatalogEntry,
-  type SupportedModelProviderCatalogEntry,
-  toSupportedCatalogEntry,
-} from './supported-model-provider-catalog-entry.js';
 import {ModelProviderTestAndSaveForm} from './test-and-save-form.js';
 
 const SURFACE_CLASS =
   'overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base';
 
-type ModelProviderFormState =
-  | {mode: 'configure'; entry: SupportedModelProviderCatalogEntry; config?: undefined}
-  | {mode: 'edit'; entry: SupportedModelProviderCatalogEntry; config: ModelProviderConfigDto};
-type CustomModelProviderFormState =
-  | {mode: 'create'}
-  | {mode: 'edit'; config: CustomModelProviderConfigDto};
-type ModelFormState = {entry: SupportedModelProviderCatalogEntry; config: ModelProviderConfigDto};
 type UsageTarget = {
   target: ModelProviderUsageTarget;
   initialModel: string | null;
@@ -75,61 +72,45 @@ const USAGE_MODAL_OPEN_DELAY_MS = 250;
 export function WorkspaceModelProvidersSection({workspaceId}: {workspaceId: string}) {
   const catalogQuery = useModelProviderCatalogQuery();
   const configsQuery = useModelProviderConfigsQuery(workspaceId);
-  const [formState, setFormState] = useState<ModelProviderFormState | null>(null);
-  const [customFormState, setCustomFormState] = useState<CustomModelProviderFormState | null>(null);
-  const [modelFormState, setModelFormState] = useState<ModelFormState | null>(null);
-  const [usageTarget, setUsageTarget] = useState<UsageTarget | null>(null);
+  const [modal, dispatchModal] = useReducer(managementModalReducer, {kind: 'closed'});
   const [pendingUsageTarget, setPendingUsageTarget] = useState<UsageTarget | null>(null);
   const configuredProvidersRegionRef = useRef<HTMLElement | null>(null);
 
   const providers = catalogQuery.data?.providers ?? [];
   const configs = configsQuery.data?.configs ?? [];
   const configsLoaded = configsQuery.data !== undefined;
-  const defaultProviderId = configsQuery.data?.default_provider_id ?? null;
+  const defaultProviderId = configsQuery.data?.defaultProviderId ?? null;
   const providerById = useMemo(
     () =>
-      new Map<string, ModelProviderCatalogEntryDto>(
-        providers.map((provider) => [provider.id, provider]),
-      ),
+      new Map<string, ProviderCatalogEntry>(providers.map((provider) => [provider.id, provider])),
     [providers],
   );
-  const configuredIds = useMemo(
-    () => new Set<string>(configs.map((config) => config.provider_id)),
-    [configs],
-  );
-  const availableProviders = configsLoaded
-    ? providers.filter(
-        (provider): provider is SupportedModelProviderCatalogEntry =>
-          isSupportedCatalogEntry(provider) && !configuredIds.has(provider.id),
-      )
-    : [];
-  const unsupportedProviders = providers.filter(
-    (provider) => provider.support_status === 'unsupported',
-  );
-
-  function closeForm() {
-    setFormState(null);
-  }
-
-  function closeModelForm() {
-    setModelFormState(null);
-  }
-
-  function closeCustomForm() {
-    setCustomFormState(null);
-  }
+  const availableProviders = configsLoaded ? selectAvailableProviders(providers, configs) : [];
+  const unsupportedProviders = providers.filter((provider) => !isSupportedProvider(provider));
 
   useEffect(() => {
-    if (pendingUsageTarget === null || formState !== null || customFormState !== null)
-      return undefined;
+    if (pendingUsageTarget === null || modal.kind !== 'closed') return undefined;
 
     const timer = window.setTimeout(() => {
-      setUsageTarget(pendingUsageTarget);
+      dispatchModal({
+        type: 'show-usage',
+        providerId: pendingUsageTarget.target.id,
+        initialModel: pendingUsageTarget.initialModel,
+        restoreFocusToConfiguredProviders: pendingUsageTarget.restoreFocusToConfiguredProviders,
+      });
       setPendingUsageTarget(null);
     }, USAGE_MODAL_OPEN_DELAY_MS);
 
     return () => window.clearTimeout(timer);
-  }, [customFormState, formState, pendingUsageTarget]);
+  }, [modal.kind, pendingUsageTarget]);
+
+  const usageTarget = useMemo(() => {
+    if (modal.kind !== 'show-usage') return null;
+    const config = configs.find((item) => item.providerId === modal.providerId);
+    if (config?.kind === 'custom') return usageTargetFromCustomConfig(config);
+    const entry = providerById.get(modal.providerId);
+    return entry && isSupportedProvider(entry) ? usageTargetFromCatalogEntry(entry) : null;
+  }, [configs, modal, providerById]);
 
   return (
     <div className="flex min-w-0 flex-col gap-32">
@@ -169,39 +150,48 @@ export function WorkspaceModelProvidersSection({workspaceId}: {workspaceId: stri
         {configs.length > 0 ? (
           <ul className={cn('divide-y divide-border-neutral-base', SURFACE_CLASS)}>
             {configs.map((config) => {
-              const entry = toSupportedCatalogEntry(providerById.get(config.provider_id));
+              const catalogEntry = providerById.get(config.providerId);
+              const entry =
+                catalogEntry && isSupportedProvider(catalogEntry) ? catalogEntry : undefined;
               const builtinConfig = isBuiltinModelProviderConfig(config) ? config : undefined;
               const customConfig = isCustomModelProviderConfig(config) ? config : undefined;
               return (
                 <ConfiguredProviderRow
-                  key={config.provider_id}
+                  key={config.providerId}
                   workspaceId={workspaceId}
                   config={config}
                   entry={entry}
-                  isDefault={config.provider_id === defaultProviderId}
+                  isDefault={config.providerId === defaultProviderId}
                   onEdit={() => {
                     if (entry && builtinConfig) {
-                      setFormState({mode: 'edit', entry, config: builtinConfig});
+                      dispatchModal({type: 'edit-builtin', provider: entry, config: builtinConfig});
                     } else if (customConfig) {
-                      setCustomFormState({mode: 'edit', config: customConfig});
+                      dispatchModal({type: 'edit-custom', config: customConfig});
                     }
                   }}
                   onChangeDefaultModel={() => {
-                    if (entry && builtinConfig) setModelFormState({entry, config: builtinConfig});
+                    if (entry && builtinConfig)
+                      dispatchModal({
+                        type: 'change-default-model',
+                        provider: entry,
+                        config: builtinConfig,
+                      });
                   }}
                   onShowUsage={() => {
                     if (entry && builtinConfig) {
                       setPendingUsageTarget(null);
-                      setUsageTarget({
-                        target: usageTargetFromCatalogEntry(entry),
-                        initialModel: builtinConfig.default_model,
+                      dispatchModal({
+                        type: 'show-usage',
+                        providerId: entry.id,
+                        initialModel: builtinConfig.defaultModel,
                         restoreFocusToConfiguredProviders: false,
                       });
                     } else if (customConfig) {
                       setPendingUsageTarget(null);
-                      setUsageTarget({
-                        target: usageTargetFromCustomConfig(customConfig),
-                        initialModel: customConfig.default_model,
+                      dispatchModal({
+                        type: 'show-usage',
+                        providerId: customConfig.providerId,
+                        initialModel: customConfig.defaultModel,
                         restoreFocusToConfiguredProviders: false,
                       });
                     }
@@ -232,9 +222,9 @@ export function WorkspaceModelProvidersSection({workspaceId}: {workspaceId: stri
         {configsLoaded ? (
           <AvailableProvidersGrid
             entries={availableProviders}
-            onSelect={(entry) => setFormState({mode: 'configure', entry})}
+            onSelect={(entry) => dispatchModal({type: 'configure-builtin', provider: entry})}
             trailingCard={
-              <AddCustomProviderCard onConfigure={() => setCustomFormState({mode: 'create'})} />
+              <AddCustomProviderCard onConfigure={() => dispatchModal({type: 'create-custom'})} />
             }
             trailingCardMatchesSearch={customProviderCardMatchesSearch}
           />
@@ -267,7 +257,7 @@ export function WorkspaceModelProvidersSection({workspaceId}: {workspaceId: stri
                     {entry.label}
                   </Text>
                   <Text size="sm" className="text-foreground-neutral-muted">
-                    {entry.unsupported_reason}
+                    {entry.unsupportedReason}
                   </Text>
                 </div>
               </li>
@@ -276,33 +266,36 @@ export function WorkspaceModelProvidersSection({workspaceId}: {workspaceId: stri
         ) : null}
       </section>
 
-      <Modal open={formState !== null} onOpenChange={(open) => (open ? undefined : closeForm())}>
+      <Modal
+        open={modal.kind === 'configure-builtin' || modal.kind === 'edit-builtin'}
+        onOpenChange={(open) => (open ? undefined : dispatchModal({type: 'close'}))}
+      >
         <ModalContent aria-describedby={undefined}>
-          <ModalTitle className="sr-only">{modelProviderFormTitle(formState)}</ModalTitle>
+          <ModalTitle className="sr-only">{modelProviderFormTitle(modal)}</ModalTitle>
           <ModalHeader>
             <Text
               size="lg"
               aria-hidden="true"
               className="overflow-ellipsis overflow-hidden whitespace-nowrap"
             >
-              {modelProviderFormTitle(formState)}
+              {modelProviderFormTitle(modal)}
             </Text>
           </ModalHeader>
-          {formState ? (
+          {modal.kind === 'configure-builtin' || modal.kind === 'edit-builtin' ? (
             <ModelProviderTestAndSaveForm
               workspaceId={workspaceId}
-              entry={formState.entry}
-              existingConfig={formState.config}
+              entry={modal.provider}
+              existingConfig={modal.kind === 'edit-builtin' ? modal.config : undefined}
               onSaved={(savedDefaultModel) => {
-                toast.success(`${formState.entry.label} saved`);
-                if (formState.mode === 'configure' && configs.length === 0) {
+                toast.success(`${modal.provider.label} saved`);
+                if (modal.kind === 'configure-builtin' && configs.length === 0) {
                   setPendingUsageTarget({
-                    target: usageTargetFromCatalogEntry(formState.entry),
+                    target: usageTargetFromCatalogEntry(modal.provider),
                     initialModel: savedDefaultModel,
                     restoreFocusToConfiguredProviders: true,
                   });
                 }
-                closeForm();
+                dispatchModal({type: 'close'});
               }}
             />
           ) : null}
@@ -310,8 +303,8 @@ export function WorkspaceModelProvidersSection({workspaceId}: {workspaceId: stri
       </Modal>
 
       <Modal
-        open={modelFormState !== null}
-        onOpenChange={(open) => (open ? undefined : closeModelForm())}
+        open={modal.kind === 'change-default-model'}
+        onOpenChange={(open) => (open ? undefined : dispatchModal({type: 'close'}))}
       >
         <ModalContent aria-describedby={undefined}>
           <ModalTitle className="sr-only">Change default model</ModalTitle>
@@ -321,17 +314,18 @@ export function WorkspaceModelProvidersSection({workspaceId}: {workspaceId: stri
               aria-hidden="true"
               className="overflow-ellipsis overflow-hidden whitespace-nowrap"
             >
-              Change default model for {modelFormState?.entry.label}
+              Change default model for{' '}
+              {modal.kind === 'change-default-model' ? modal.provider.label : ''}
             </Text>
           </ModalHeader>
-          {modelFormState ? (
+          {modal.kind === 'change-default-model' ? (
             <ChangeDefaultModelForm
               workspaceId={workspaceId}
-              entry={modelFormState.entry}
-              config={modelFormState.config}
+              entry={modal.provider}
+              config={modal.config}
               onSaved={() => {
-                toast.success(`${modelFormState.entry.label} default model saved`);
-                closeModelForm();
+                toast.success(`${modal.provider.label} default model saved`);
+                dispatchModal({type: 'close'});
               }}
             />
           ) : null}
@@ -339,52 +333,50 @@ export function WorkspaceModelProvidersSection({workspaceId}: {workspaceId: stri
       </Modal>
 
       <ModelProviderUsageModal
-        target={usageTarget?.target ?? null}
-        initialModel={usageTarget?.initialModel ?? null}
-        workspaceDefaultHarnessId={configsQuery.data?.default_harness_id ?? null}
-        open={usageTarget !== null}
+        target={usageTarget}
+        initialModel={modal.kind === 'show-usage' ? modal.initialModel : null}
+        workspaceDefaultHarnessId={configsQuery.data?.defaultHarnessId ?? null}
+        open={modal.kind === 'show-usage'}
         closeFocusTarget={
-          usageTarget?.restoreFocusToConfiguredProviders
+          modal.kind === 'show-usage' && modal.restoreFocusToConfiguredProviders
             ? configuredProvidersRegionRef.current
             : null
         }
         onOpenChange={(open) => {
-          if (!open) setUsageTarget(null);
+          if (!open) dispatchModal({type: 'close'});
         }}
       />
 
       <Modal
-        open={customFormState !== null}
-        onOpenChange={(open) => (open ? undefined : closeCustomForm())}
+        open={modal.kind === 'create-custom' || modal.kind === 'edit-custom'}
+        onOpenChange={(open) => (open ? undefined : dispatchModal({type: 'close'}))}
       >
         <ModalContent
           aria-describedby={undefined}
           className="max-h-[calc(100vh-32px)] max-w-[760px]"
         >
-          <ModalTitle className="sr-only">
-            {customModelProviderFormTitle(customFormState)}
-          </ModalTitle>
+          <ModalTitle className="sr-only">{customModelProviderFormTitle(modal)}</ModalTitle>
           <ModalHeader>
             <div className="flex min-w-0 flex-col gap-2">
               <Text size="lg" aria-hidden="true" className="truncate">
-                {customModelProviderFormTitle(customFormState)}
+                {customModelProviderFormTitle(modal)}
               </Text>
               <Text size="sm" className="text-foreground-neutral-muted">
                 Connect an OpenAI-, Anthropic-, or Gemini-compatible endpoint.
               </Text>
             </div>
           </ModalHeader>
-          {customFormState ? (
+          {modal.kind === 'create-custom' || modal.kind === 'edit-custom' ? (
             <CustomModelProviderForm
               workspaceId={workspaceId}
-              existingConfig={customFormState.mode === 'edit' ? customFormState.config : undefined}
+              existingConfig={modal.kind === 'edit-custom' ? modal.config : undefined}
               onSaved={() => {
                 toast.success(
-                  customFormState.mode === 'edit'
-                    ? `${customFormState.config.display_name} saved`
+                  modal.kind === 'edit-custom'
+                    ? `${modal.config.displayName} saved`
                     : 'Custom provider saved',
                 );
-                closeCustomForm();
+                dispatchModal({type: 'close'});
               }}
             />
           ) : null}
@@ -394,27 +386,22 @@ export function WorkspaceModelProvidersSection({workspaceId}: {workspaceId: stri
   );
 }
 
-function modelProviderFormTitle(formState: ModelProviderFormState | null): string {
-  if (formState === null) return '';
-  if (formState.mode === 'edit') return `Edit credentials for ${formState.entry.label}`;
-  return `Configure ${formState.entry.label}`;
+function modelProviderFormTitle(modal: ManagementModal): string {
+  if (modal.kind === 'edit-builtin') return `Edit credentials for ${modal.provider.label}`;
+  if (modal.kind === 'configure-builtin') return `Configure ${modal.provider.label}`;
+  return '';
 }
 
-function customModelProviderFormTitle(formState: CustomModelProviderFormState | null): string {
-  if (formState === null) return '';
-  if (formState.mode === 'edit') return `Edit ${formState.config.display_name}`;
+function customModelProviderFormTitle(modal: ManagementModal): string {
+  if (modal.kind === 'edit-custom') return `Edit ${modal.config.displayName}`;
   return 'Add custom provider';
 }
 
-function isBuiltinModelProviderConfig(
-  config: ModelProviderConfigResponseDto,
-): config is ModelProviderConfigDto {
+function isBuiltinModelProviderConfig(config: ProviderConfig): config is BuiltinProviderConfig {
   return config.kind === 'builtin';
 }
 
-function isCustomModelProviderConfig(
-  config: ModelProviderConfigResponseDto,
-): config is CustomModelProviderConfigDto {
+function isCustomModelProviderConfig(config: ProviderConfig): config is CustomProviderConfig {
   return config.kind === 'custom';
 }
 
@@ -428,8 +415,8 @@ function ConfiguredProviderRow({
   onShowUsage,
 }: {
   workspaceId: string;
-  config: ModelProviderConfigResponseDto;
-  entry: SupportedModelProviderCatalogEntry | undefined;
+  config: ProviderConfig;
+  entry: SupportedProvider | undefined;
   isDefault: boolean;
   onEdit: () => void;
   onChangeDefaultModel: () => void;
@@ -441,7 +428,7 @@ function ConfiguredProviderRow({
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deleteError, setDeleteError] = useState<string | undefined>();
   const customConfig = isCustomModelProviderConfig(config) ? config : undefined;
-  const label = customConfig?.display_name ?? entry?.label ?? config.provider_id;
+  const label = customConfig?.displayName ?? entry?.label ?? config.providerId;
   const canUse = entry !== undefined || customConfig !== undefined;
   const canEdit = entry !== undefined || customConfig !== undefined;
   const isBuiltinConfig = isBuiltinModelProviderConfig(config);
@@ -451,7 +438,7 @@ function ConfiguredProviderRow({
     try {
       await setDefault.mutateAsync({
         workspaceId,
-        body: {provider_id: config.provider_id},
+        providerId: config.providerId,
       });
       toast.success(`${label} is now the default provider`);
     } catch (error) {
@@ -463,7 +450,7 @@ function ConfiguredProviderRow({
   async function handleDelete() {
     setDeleteError(undefined);
     try {
-      await deleteConfig.mutateAsync({workspaceId, providerId: config.provider_id});
+      await deleteConfig.mutateAsync({workspaceId, providerId: config.providerId});
       toast.success(`${label} deleted`);
       setDeleteOpen(false);
     } catch (error) {

--- a/libs/client/agent/src/components/test-and-save-form.tsx
+++ b/libs/client/agent/src/components/test-and-save-form.tsx
@@ -1,8 +1,3 @@
-import type {
-  ModelProviderCatalogEntryDto,
-  ModelProviderConfigDto,
-  SupportedModelProviderId,
-} from '@shipfox/api-agent-dto';
 import {Button} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
 import {FormField, FormFieldInput, fieldError} from '@shipfox/react-ui/form-field';
@@ -10,6 +5,7 @@ import {ModalBody, ModalFooter} from '@shipfox/react-ui/modal';
 import {Text} from '@shipfox/react-ui/typography';
 import {useForm} from '@tanstack/react-form';
 import {useState} from 'react';
+import type {BuiltinProviderConfig, SupportedProvider} from '#core/models.js';
 import {useUpsertModelProviderConfigMutation} from '#hooks/api/model-providers.js';
 import {
   DefaultModelField,
@@ -29,8 +25,8 @@ export function ModelProviderTestAndSaveForm({
   setAsDefaultOnSave = false,
 }: {
   workspaceId: string;
-  entry: ModelProviderCatalogEntryDto;
-  existingConfig?: ModelProviderConfigDto | undefined;
+  entry: SupportedProvider;
+  existingConfig?: BuiltinProviderConfig | undefined;
   onSaved: (savedDefaultModel: string | null) => void;
   setAsDefaultOnSave?: boolean | undefined;
 }) {
@@ -41,7 +37,7 @@ export function ModelProviderTestAndSaveForm({
     onSubmit: async ({value}) => {
       setFormError(undefined);
       const credentials = Object.fromEntries(
-        entry.credential_fields.map((credentialField) => [
+        entry.credentialFields.map((credentialField) => [
           credentialField.key,
           value[credentialField.key]?.trim() ?? '',
         ]),
@@ -55,11 +51,11 @@ export function ModelProviderTestAndSaveForm({
       try {
         await upsertConfig.mutateAsync({
           workspaceId,
-          providerId: entry.id as SupportedModelProviderId,
-          body: {
-            ...(defaultModel !== undefined ? {default_model: defaultModel} : {}),
+          providerId: entry.id,
+          command: {
+            ...(defaultModel !== undefined ? {defaultModel} : {}),
             credentials,
-            ...(setAsDefaultOnSave ? {set_as_default: true} : {}),
+            ...(setAsDefaultOnSave ? {setAsDefault: true} : {}),
           },
         });
         onSaved(selectedModelForCredentialsPayload(selectedModel));
@@ -102,7 +98,7 @@ export function ModelProviderTestAndSaveForm({
               )}
             </form.Field>
           ) : null}
-          {entry.credential_fields.map((credentialField) => (
+          {entry.credentialFields.map((credentialField) => (
             <form.Field
               key={credentialField.key}
               name={credentialField.key}
@@ -156,11 +152,11 @@ export function ModelProviderTestAndSaveForm({
 }
 
 function defaultFormValues(
-  entry: ModelProviderCatalogEntryDto,
-  existingConfig: ModelProviderConfigDto | undefined,
+  entry: SupportedProvider,
+  existingConfig: BuiltinProviderConfig | undefined,
 ): Record<string, string> {
   return {
-    default_model: defaultModelFormValue(existingConfig?.default_model),
-    ...Object.fromEntries(entry.credential_fields.map((field) => [field.key, ''])),
+    default_model: defaultModelFormValue(existingConfig?.defaultModel),
+    ...Object.fromEntries(entry.credentialFields.map((field) => [field.key, ''])),
   };
 }

--- a/libs/client/agent/src/core/harness-policy.test.ts
+++ b/libs/client/agent/src/core/harness-policy.test.ts
@@ -1,0 +1,15 @@
+import {listHarnessDescriptors} from '@shipfox/api-agent-dto';
+import {listHarnesses} from './harness-policy.js';
+
+describe('harness policy', () => {
+  test('stays aligned with the shared harness compatibility contract', () => {
+    expect(listHarnesses()).toEqual(
+      listHarnessDescriptors().map(({id, label, description, supportedProviderIds}) => ({
+        id,
+        label,
+        description,
+        supportedProviderIds,
+      })),
+    );
+  });
+});

--- a/libs/client/agent/src/core/harness-policy.ts
+++ b/libs/client/agent/src/core/harness-policy.ts
@@ -1,0 +1,83 @@
+import type {HarnessDescriptor, HarnessId, ProviderConfig} from './models.js';
+
+export const DEFAULT_HARNESS: HarnessId = 'pi';
+
+const harnesses: readonly HarnessDescriptor[] = [
+  {
+    id: 'pi',
+    label: 'pi',
+    description: 'Works with 30+ model providers',
+    supportedProviderIds: [
+      'anthropic',
+      'ant-ling',
+      'azure-openai-responses',
+      'openai',
+      'deepseek',
+      'nvidia',
+      'google',
+      'mistral',
+      'groq',
+      'cerebras',
+      'cloudflare-ai-gateway',
+      'cloudflare-workers-ai',
+      'xai',
+      'openrouter',
+      'vercel-ai-gateway',
+      'zai',
+      'zai-coding-cn',
+      'opencode',
+      'opencode-go',
+      'huggingface',
+      'fireworks',
+      'together',
+      'kimi-coding',
+      'minimax',
+      'minimax-cn',
+      'moonshotai',
+      'moonshotai-cn',
+      'xiaomi',
+      'xiaomi-token-plan-cn',
+      'xiaomi-token-plan-ams',
+      'xiaomi-token-plan-sgp',
+    ],
+  },
+  {
+    id: 'claude',
+    label: 'Claude',
+    description: 'Runs on your Anthropic API key',
+    supportedProviderIds: ['anthropic'],
+  },
+];
+
+export function listHarnesses(): readonly HarnessDescriptor[] {
+  return harnesses;
+}
+
+export function getHarness(id: HarnessId): HarnessDescriptor {
+  const harness = harnesses.find((item) => item.id === id);
+  if (harness === undefined) throw new Error(`Unknown harness: ${id}`);
+  return harness;
+}
+
+export function harnessSupportsProvider(harnessId: HarnessId, providerId: string): boolean {
+  return getHarness(harnessId).supportedProviderIds.includes(providerId);
+}
+
+export function configSupportsHarness(config: ProviderConfig, harness: HarnessDescriptor): boolean {
+  return config.kind === 'custom'
+    ? harness.id === DEFAULT_HARNESS
+    : harness.supportedProviderIds.includes(config.providerId);
+}
+
+export function compatibleHarnessIds({
+  isCustom,
+  providerId,
+}: {
+  isCustom: boolean;
+  providerId: string;
+}): HarnessId[] {
+  if (isCustom) return [DEFAULT_HARNESS];
+  return harnesses
+    .filter((harness) => harness.supportedProviderIds.includes(providerId))
+    .map((harness) => harness.id);
+}

--- a/libs/client/agent/src/core/model-provider-management-reducer.test.ts
+++ b/libs/client/agent/src/core/model-provider-management-reducer.test.ts
@@ -1,0 +1,59 @@
+import {type ManagementModal, managementModalReducer} from './model-provider-management-reducer.js';
+import type {BuiltinProviderConfig, CustomProviderConfig, SupportedProvider} from './models.js';
+
+const provider: SupportedProvider = {
+  kind: 'supported',
+  id: 'anthropic',
+  label: 'Anthropic',
+  defaultModel: 'claude-sonnet-4-5',
+  credentialFields: [],
+  models: [],
+};
+
+const builtinConfig: BuiltinProviderConfig = {
+  kind: 'builtin',
+  providerId: 'anthropic',
+  defaultModel: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+const customConfig: CustomProviderConfig = {
+  kind: 'custom',
+  providerId: 'local',
+  displayName: 'Local',
+  api: 'openai-completions',
+  baseUrl: 'https://example.test/v1',
+  headers: [],
+  secretHeaderNames: [],
+  models: [],
+  defaultModel: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+describe('managementModalReducer', () => {
+  test('always replaces the current modal with one valid mode', () => {
+    const initial: ManagementModal = {kind: 'configure-builtin', provider};
+
+    const state = managementModalReducer(initial, {type: 'edit-custom', config: customConfig});
+
+    expect(state).toEqual({kind: 'edit-custom', config: customConfig});
+  });
+
+  test.each([
+    {type: 'close'} as const,
+    {type: 'configure-builtin', provider} as const,
+    {type: 'edit-builtin', provider, config: builtinConfig} as const,
+    {type: 'change-default-model', provider, config: builtinConfig} as const,
+    {type: 'create-custom'} as const,
+    {type: 'edit-custom', config: customConfig} as const,
+    {type: 'show-usage', providerId: 'anthropic', initialModel: null} as const,
+  ])('accepts $type from every existing mode', (action) => {
+    const existing: ManagementModal = {kind: 'show-usage', providerId: 'local', initialModel: null};
+
+    const state = managementModalReducer(existing, action);
+
+    expect(state.kind).not.toBeUndefined();
+  });
+});

--- a/libs/client/agent/src/core/model-provider-management-reducer.ts
+++ b/libs/client/agent/src/core/model-provider-management-reducer.ts
@@ -19,6 +19,7 @@ export type ManagementModal =
       readonly kind: 'show-usage';
       readonly providerId: string;
       readonly initialModel: string | null;
+      readonly restoreFocusToConfiguredProviders?: boolean | undefined;
     };
 
 export type ManagementModalAction =
@@ -40,6 +41,7 @@ export type ManagementModalAction =
       readonly type: 'show-usage';
       readonly providerId: string;
       readonly initialModel: string | null;
+      readonly restoreFocusToConfiguredProviders?: boolean | undefined;
     };
 
 export function managementModalReducer(
@@ -60,6 +62,11 @@ export function managementModalReducer(
     case 'edit-custom':
       return {kind: 'edit-custom', config: action.config};
     case 'show-usage':
-      return {kind: 'show-usage', providerId: action.providerId, initialModel: action.initialModel};
+      return {
+        kind: 'show-usage',
+        providerId: action.providerId,
+        initialModel: action.initialModel,
+        restoreFocusToConfiguredProviders: action.restoreFocusToConfiguredProviders ?? false,
+      };
   }
 }

--- a/libs/client/agent/src/core/models.ts
+++ b/libs/client/agent/src/core/models.ts
@@ -83,3 +83,53 @@ export interface ProviderConfiguration {
   readonly defaultHarnessId: HarnessId | null;
   readonly defaultProviderId: string | null;
 }
+
+export interface ProviderCredentialsCommand {
+  defaultModel?: string | null | undefined;
+  credentials: Record<string, string>;
+  setAsDefault?: boolean | undefined;
+}
+
+export interface CustomProviderHeaderCommand {
+  name: string;
+  value?: string | undefined;
+  secret: boolean;
+  keep?: boolean | undefined;
+}
+
+export interface CustomProviderModelCommand {
+  id: string;
+  label: string;
+  contextWindow?: number | undefined;
+  maxOutputTokens?: number | undefined;
+  inputImage?: boolean | undefined;
+  reasoning?: boolean | undefined;
+}
+
+export interface CreateCustomProviderCommand {
+  slug: string;
+  displayName: string;
+  api: ProviderApi;
+  baseUrl: string;
+  apiKey?: string | undefined;
+  headers?: CustomProviderHeaderCommand[] | undefined;
+  models: CustomProviderModelCommand[];
+  defaultModel?: string | null | undefined;
+}
+
+export interface UpdateCustomProviderCommand {
+  displayName?: string | undefined;
+  api?: ProviderApi | undefined;
+  baseUrl?: string | undefined;
+  apiKey?: string | undefined;
+  headers?: CustomProviderHeaderCommand[] | undefined;
+  models?: CustomProviderModelCommand[] | undefined;
+  defaultModel?: string | null | undefined;
+}
+
+export interface DiscoverProviderModelsCommand {
+  api?: ProviderApi | undefined;
+  baseUrl?: string | undefined;
+  apiKey?: string | undefined;
+  headers?: CustomProviderHeaderCommand[] | undefined;
+}

--- a/libs/client/agent/src/core/onboarding-reducer.ts
+++ b/libs/client/agent/src/core/onboarding-reducer.ts
@@ -7,6 +7,7 @@ export type OnboardingState =
       readonly step: 'configure-provider';
       readonly harnessId: HarnessId;
       readonly provider: SupportedProvider;
+      readonly error?: string | undefined;
     }
   | {
       readonly step: 'saving-default-harness';

--- a/libs/client/agent/src/hooks/api/model-provider-command-mapper.ts
+++ b/libs/client/agent/src/hooks/api/model-provider-command-mapper.ts
@@ -1,0 +1,122 @@
+import type {
+  CreateCustomModelProviderBodyDto,
+  DiscoverCustomModelProviderModelsBodyDto,
+  DiscoverCustomModelProviderModelsBySlugBodyDto,
+  SetDefaultHarnessBodyDto,
+  SetDefaultModelProviderBodyDto,
+  UpdateCustomModelProviderBodyDto,
+  UpdateModelProviderConfigBodyDto,
+  UpdateModelProviderDefaultModelBodyDto,
+} from '@shipfox/api-agent-dto';
+import type {
+  CreateCustomProviderCommand,
+  CustomProviderHeaderCommand,
+  CustomProviderModelCommand,
+  DiscoverProviderModelsCommand,
+  ProviderCredentialsCommand,
+  UpdateCustomProviderCommand,
+} from '#core/models.js';
+
+export function toProviderCredentialsBody(
+  command: ProviderCredentialsCommand,
+): UpdateModelProviderConfigBodyDto {
+  return {
+    ...(command.defaultModel === undefined ? {} : {default_model: command.defaultModel}),
+    credentials: command.credentials,
+    ...(command.setAsDefault ? {set_as_default: true} : {}),
+  };
+}
+
+export function toDefaultModelBody(
+  defaultModel: string | null,
+): UpdateModelProviderDefaultModelBodyDto {
+  return {default_model: defaultModel};
+}
+
+export function toDefaultProviderBody(providerId: string): SetDefaultModelProviderBodyDto {
+  return {provider_id: providerId};
+}
+
+export function toDefaultHarnessBody(harnessId: 'pi' | 'claude'): SetDefaultHarnessBodyDto {
+  return {harness_id: harnessId};
+}
+
+export function toCreateCustomProviderBody(
+  command: CreateCustomProviderCommand,
+): CreateCustomModelProviderBodyDto {
+  return {
+    slug: command.slug,
+    display_name: command.displayName,
+    api: command.api,
+    base_url: command.baseUrl,
+    ...(command.apiKey ? {api_key: command.apiKey} : {}),
+    ...(command.headers?.length ? {headers: command.headers.map(toCreateHeader)} : {}),
+    models: command.models.map(toModel),
+    ...(command.defaultModel ? {default_model: command.defaultModel} : {}),
+  };
+}
+
+export function toUpdateCustomProviderBody(
+  command: UpdateCustomProviderCommand,
+): UpdateCustomModelProviderBodyDto {
+  return {
+    ...(command.displayName === undefined ? {} : {display_name: command.displayName}),
+    ...(command.api === undefined ? {} : {api: command.api}),
+    ...(command.baseUrl === undefined ? {} : {base_url: command.baseUrl}),
+    ...(command.apiKey === undefined ? {} : {api_key: command.apiKey}),
+    ...(command.headers === undefined ? {} : {headers: command.headers.map(toUpdateHeader)}),
+    ...(command.models === undefined ? {} : {models: command.models.map(toModel)}),
+    ...(command.defaultModel === undefined ? {} : {default_model: command.defaultModel}),
+  };
+}
+
+export function toDiscoverModelsBody(
+  command: DiscoverProviderModelsCommand,
+): DiscoverCustomModelProviderModelsBodyDto {
+  if (command.api === undefined || command.baseUrl === undefined) {
+    throw new Error('Model discovery requires an API and base URL.');
+  }
+  return {
+    api: command.api,
+    base_url: command.baseUrl,
+    ...(command.apiKey ? {api_key: command.apiKey} : {}),
+    ...(command.headers?.length
+      ? {headers: command.headers.flatMap(({name, value}) => (value ? [{name, value}] : []))}
+      : {}),
+  };
+}
+
+export function toDiscoverModelsBySlugBody(
+  command: DiscoverProviderModelsCommand,
+): DiscoverCustomModelProviderModelsBySlugBodyDto {
+  return {
+    ...(command.api === undefined ? {} : {api: command.api}),
+    ...(command.baseUrl === undefined ? {} : {base_url: command.baseUrl}),
+    ...(command.apiKey === undefined ? {} : {api_key: command.apiKey}),
+    ...(command.headers === undefined ? {} : {headers: command.headers.map(toUpdateHeader)}),
+  };
+}
+
+function toCreateHeader(header: CustomProviderHeaderCommand) {
+  return {name: header.name, value: header.value ?? '', secret: header.secret};
+}
+
+function toUpdateHeader(header: CustomProviderHeaderCommand) {
+  return {
+    name: header.name,
+    ...(header.value === undefined ? {} : {value: header.value}),
+    secret: header.secret,
+    ...(header.keep ? {keep: true} : {}),
+  };
+}
+
+function toModel(model: CustomProviderModelCommand) {
+  return {
+    id: model.id,
+    label: model.label,
+    ...(model.contextWindow === undefined ? {} : {context_window: model.contextWindow}),
+    ...(model.maxOutputTokens === undefined ? {} : {max_output_tokens: model.maxOutputTokens}),
+    ...(model.inputImage ? {input_image: true} : {}),
+    ...(model.reasoning ? {reasoning: true} : {}),
+  };
+}

--- a/libs/client/agent/src/hooks/api/model-provider-mapper.test.ts
+++ b/libs/client/agent/src/hooks/api/model-provider-mapper.test.ts
@@ -11,7 +11,7 @@ test('maps provider catalog entries before they reach the client domain', () => 
   expect(catalog.providers).toEqual([
     expect.objectContaining({
       kind: 'supported',
-      defaultModel: null,
+      defaultModel: 'claude-opus-4-8',
       credentialFields: [{key: 'api_key', label: 'API key', secret: true}],
     }),
   ]);

--- a/libs/client/agent/src/hooks/api/model-providers.test.ts
+++ b/libs/client/agent/src/hooks/api/model-providers.test.ts
@@ -47,7 +47,7 @@ describe('model provider transport', () => {
     const result = await listModelProviderConfigs({workspaceId: AGENT_TEST_WORKSPACE_ID});
 
     const request = fetchImpl.mock.calls[0]?.[0] as Request;
-    expect(result.default_provider_id).toBe('anthropic');
+    expect(result.defaultProviderId).toBe('anthropic');
     expect(request.url).toBe(
       `https://api.example.test/workspaces/${AGENT_TEST_WORKSPACE_ID}/agent/model-providers`,
     );
@@ -66,11 +66,11 @@ describe('model provider transport', () => {
     const result = await upsertModelProviderConfig({
       workspaceId: AGENT_TEST_WORKSPACE_ID,
       providerId: 'anthropic',
-      body,
+      command: {defaultModel: 'claude-haiku-4-5', credentials: {api_key: 'sk-ant-secret'}},
     });
 
     const request = fetchImpl.mock.calls[0]?.[0] as Request;
-    expect(result.provider_id).toBe('anthropic');
+    expect(result.providerId).toBe('anthropic');
     expect(request.url).toBe(
       `https://api.example.test/workspaces/${AGENT_TEST_WORKSPACE_ID}/agent/model-providers/anthropic`,
     );
@@ -102,21 +102,21 @@ describe('model provider transport', () => {
       return jsonResponse(modelProviderConfig({default_model: null}));
     });
     configureApiClient({fetchImpl});
-    const body = {default_model: null};
+    const defaultModel: string | null = null;
 
     const result = await updateModelProviderDefaultModel({
       workspaceId: AGENT_TEST_WORKSPACE_ID,
       providerId: 'anthropic',
-      body,
+      defaultModel,
     });
 
     const request = fetchImpl.mock.calls[0]?.[0] as Request;
-    expect(result.default_model).toBeNull();
+    expect(result.defaultModel).toBeNull();
     expect(request.url).toBe(
       `https://api.example.test/workspaces/${AGENT_TEST_WORKSPACE_ID}/agent/model-providers/anthropic/default-model`,
     );
     expect(request.method).toBe('PUT');
-    expect(requestBody).toEqual(body);
+    expect(requestBody).toEqual({default_model: defaultModel});
   });
 
   test('sets the default model provider', async () => {
@@ -126,11 +126,11 @@ describe('model provider transport', () => {
       return jsonResponse({default_provider_id: 'anthropic'});
     });
     configureApiClient({fetchImpl});
-    const body = {provider_id: 'anthropic'} as const;
+    const providerId = 'anthropic';
 
     const result = await setDefaultModelProvider({
       workspaceId: AGENT_TEST_WORKSPACE_ID,
-      body,
+      providerId,
     });
 
     const request = fetchImpl.mock.calls[0]?.[0] as Request;
@@ -139,7 +139,7 @@ describe('model provider transport', () => {
       `https://api.example.test/workspaces/${AGENT_TEST_WORKSPACE_ID}/agent/default-model-provider`,
     );
     expect(request.method).toBe('PUT');
-    expect(requestBody).toEqual(body);
+    expect(requestBody).toEqual({provider_id: providerId});
   });
 
   test('sets the default harness', async () => {
@@ -149,11 +149,11 @@ describe('model provider transport', () => {
       return jsonResponse({default_harness_id: 'claude'});
     });
     configureApiClient({fetchImpl});
-    const body = {harness_id: 'claude'} as const;
+    const harnessId = 'claude' as const;
 
     const result = await setDefaultHarness({
       workspaceId: AGENT_TEST_WORKSPACE_ID,
-      body,
+      harnessId,
     });
 
     const request = fetchImpl.mock.calls[0]?.[0] as Request;
@@ -162,6 +162,6 @@ describe('model provider transport', () => {
       `https://api.example.test/workspaces/${AGENT_TEST_WORKSPACE_ID}/agent/default-harness`,
     );
     expect(request.method).toBe('PUT');
-    expect(requestBody).toEqual(body);
+    expect(requestBody).toEqual({harness_id: harnessId});
   });
 });

--- a/libs/client/agent/src/hooks/api/model-providers.ts
+++ b/libs/client/agent/src/hooks/api/model-providers.ts
@@ -1,23 +1,14 @@
-import type {
-  CreateCustomModelProviderBodyDto,
-  CustomModelProviderConfigDto,
-  DiscoverCustomModelProviderModelsBodyDto,
-  DiscoverCustomModelProviderModelsBySlugBodyDto,
-  DiscoverCustomModelProviderModelsResponseDto,
-  ListModelProviderConfigsResponseDto,
-  ModelProviderCatalogResponseDto,
-  ModelProviderConfigDto,
-  ModelProviderRef,
-  SetDefaultHarnessBodyDto,
-  SetDefaultHarnessResponseDto,
-  SetDefaultModelProviderBodyDto,
-  SetDefaultModelProviderResponseDto,
-  SupportedModelProviderId,
-  UpdateCustomModelProviderBodyDto,
-  UpdateModelProviderConfigBodyDto,
-  UpdateModelProviderDefaultModelBodyDto,
+import {
+  customModelProviderConfigDtoSchema,
+  discoverCustomModelProviderModelsResponseSchema,
+  listModelProviderConfigsResponseSchema,
+  type ModelProviderRef,
+  modelProviderCatalogResponseSchema,
+  modelProviderConfigDtoSchema,
+  setDefaultHarnessResponseSchema,
+  setDefaultModelProviderResponseSchema,
 } from '@shipfox/api-agent-dto';
-import {apiRequest} from '@shipfox/client-api';
+import {checkedApiRequest, emptyResponseSchema} from '@shipfox/client-api';
 import {
   type FetchQueryOptions,
   queryOptions,
@@ -25,6 +16,32 @@ import {
   useQuery,
   useQueryClient,
 } from '@tanstack/react-query';
+import type {
+  AgentModel,
+  CreateCustomProviderCommand,
+  DiscoverProviderModelsCommand,
+  HarnessId,
+  ProviderCatalog,
+  ProviderConfig,
+  ProviderConfiguration,
+  ProviderCredentialsCommand,
+  UpdateCustomProviderCommand,
+} from '#core/models.js';
+import {
+  toCreateCustomProviderBody,
+  toDefaultHarnessBody,
+  toDefaultModelBody,
+  toDefaultProviderBody,
+  toDiscoverModelsBody,
+  toDiscoverModelsBySlugBody,
+  toProviderCredentialsBody,
+  toUpdateCustomProviderBody,
+} from './model-provider-command-mapper.js';
+import {
+  toProviderCatalog,
+  toProviderConfig,
+  toProviderConfiguration,
+} from './model-provider-mapper.js';
 
 export const modelProviderQueryKeys = {
   all: ['model-providers'] as const,
@@ -38,16 +55,22 @@ type ModelProviderConfigsQueryKey =
   | readonly ['model-providers', 'configs'];
 
 type ModelProviderConfigsQueryOptions = FetchQueryOptions<
-  ListModelProviderConfigsResponseDto,
+  ProviderConfiguration,
   Error,
-  ListModelProviderConfigsResponseDto,
+  ProviderConfiguration,
   ModelProviderConfigsQueryKey
 >;
 
-export async function getModelProviderCatalog({signal}: {signal?: AbortSignal} = {}) {
-  return await apiRequest<ModelProviderCatalogResponseDto>('/agent/model-provider-catalog', {
-    signal,
-  });
+export async function getModelProviderCatalog({
+  signal,
+}: {
+  signal?: AbortSignal;
+} = {}): Promise<ProviderCatalog> {
+  return toProviderCatalog(
+    await checkedApiRequest(modelProviderCatalogResponseSchema, '/agent/model-provider-catalog', {
+      signal,
+    }),
+  );
 }
 
 export async function listModelProviderConfigs({
@@ -56,10 +79,13 @@ export async function listModelProviderConfigs({
 }: {
   workspaceId: string;
   signal?: AbortSignal;
-}) {
-  return await apiRequest<ListModelProviderConfigsResponseDto>(
-    `/workspaces/${workspaceId}/agent/model-providers`,
-    {signal},
+}): Promise<ProviderConfiguration> {
+  return toProviderConfiguration(
+    await checkedApiRequest(
+      listModelProviderConfigsResponseSchema,
+      `/workspaces/${workspaceId}/agent/model-providers`,
+      {signal},
+    ),
   );
 }
 
@@ -78,72 +104,85 @@ export function modelProviderConfigsQueryOptions(
 export async function upsertModelProviderConfig({
   workspaceId,
   providerId,
-  body,
+  command,
 }: {
   workspaceId: string;
-  providerId: SupportedModelProviderId;
-  body: UpdateModelProviderConfigBodyDto;
-}) {
-  return await apiRequest<ModelProviderConfigDto>(
-    `/workspaces/${workspaceId}/agent/model-providers/${providerId}`,
-    {method: 'PUT', body},
+  providerId: string;
+  command: ProviderCredentialsCommand;
+}): Promise<ProviderConfig> {
+  return toProviderConfig(
+    await checkedApiRequest(
+      modelProviderConfigDtoSchema,
+      `/workspaces/${workspaceId}/agent/model-providers/${providerId}`,
+      {method: 'PUT', body: toProviderCredentialsBody(command)},
+    ),
   );
 }
 
 export async function createCustomModelProviderConfig({
   workspaceId,
-  body,
+  command,
 }: {
   workspaceId: string;
-  body: CreateCustomModelProviderBodyDto;
-}) {
-  return await apiRequest<CustomModelProviderConfigDto>(
-    `/workspaces/${workspaceId}/agent/custom-model-providers`,
-    {method: 'POST', body},
+  command: CreateCustomProviderCommand;
+}): Promise<ProviderConfig> {
+  return toProviderConfig(
+    await checkedApiRequest(
+      customModelProviderConfigDtoSchema,
+      `/workspaces/${workspaceId}/agent/custom-model-providers`,
+      {method: 'POST', body: toCreateCustomProviderBody(command)},
+    ),
   );
 }
 
 export async function updateCustomModelProviderConfig({
   workspaceId,
   providerId,
-  body,
+  command,
 }: {
   workspaceId: string;
   providerId: ModelProviderRef;
-  body: UpdateCustomModelProviderBodyDto;
-}) {
-  return await apiRequest<CustomModelProviderConfigDto>(
-    `/workspaces/${workspaceId}/agent/custom-model-providers/${providerId}`,
-    {method: 'PUT', body},
+  command: UpdateCustomProviderCommand;
+}): Promise<ProviderConfig> {
+  return toProviderConfig(
+    await checkedApiRequest(
+      customModelProviderConfigDtoSchema,
+      `/workspaces/${workspaceId}/agent/custom-model-providers/${providerId}`,
+      {method: 'PUT', body: toUpdateCustomProviderBody(command)},
+    ),
   );
 }
 
 export async function discoverCustomModelProviderModels({
   workspaceId,
-  body,
+  command,
 }: {
   workspaceId: string;
-  body: DiscoverCustomModelProviderModelsBodyDto;
-}) {
-  return await apiRequest<DiscoverCustomModelProviderModelsResponseDto>(
+  command: DiscoverProviderModelsCommand;
+}): Promise<readonly AgentModel[]> {
+  const response = await checkedApiRequest(
+    discoverCustomModelProviderModelsResponseSchema,
     `/workspaces/${workspaceId}/agent/custom-model-providers/discover-models`,
-    {method: 'POST', body},
+    {method: 'POST', body: toDiscoverModelsBody(command)},
   );
+  return response.models.map((model) => ({id: model.id, label: model.label}));
 }
 
 export async function discoverCustomModelProviderModelsBySlug({
   workspaceId,
   providerId,
-  body,
+  command,
 }: {
   workspaceId: string;
   providerId: ModelProviderRef;
-  body: DiscoverCustomModelProviderModelsBySlugBodyDto;
-}) {
-  return await apiRequest<DiscoverCustomModelProviderModelsResponseDto>(
+  command: DiscoverProviderModelsCommand;
+}): Promise<readonly AgentModel[]> {
+  const response = await checkedApiRequest(
+    discoverCustomModelProviderModelsResponseSchema,
     `/workspaces/${workspaceId}/agent/custom-model-providers/${providerId}/discover-models`,
-    {method: 'POST', body},
+    {method: 'POST', body: toDiscoverModelsBySlugBody(command)},
   );
+  return response.models.map((model) => ({id: model.id, label: model.label}));
 }
 
 export async function deleteModelProviderConfig({
@@ -153,54 +192,65 @@ export async function deleteModelProviderConfig({
   workspaceId: string;
   providerId: ModelProviderRef;
 }) {
-  return await apiRequest<void>(`/workspaces/${workspaceId}/agent/model-providers/${providerId}`, {
-    method: 'DELETE',
-  });
+  return await checkedApiRequest(
+    emptyResponseSchema,
+    `/workspaces/${workspaceId}/agent/model-providers/${providerId}`,
+    {method: 'DELETE'},
+  );
 }
 
 export async function updateModelProviderDefaultModel({
   workspaceId,
   providerId,
-  body,
+  defaultModel,
 }: {
   workspaceId: string;
-  providerId: SupportedModelProviderId;
-  body: UpdateModelProviderDefaultModelBodyDto;
-}) {
-  return await apiRequest<ModelProviderConfigDto>(
-    `/workspaces/${workspaceId}/agent/model-providers/${providerId}/default-model`,
-    {method: 'PUT', body},
+  providerId: string;
+  defaultModel: string | null;
+}): Promise<ProviderConfig> {
+  return toProviderConfig(
+    await checkedApiRequest(
+      modelProviderConfigDtoSchema,
+      `/workspaces/${workspaceId}/agent/model-providers/${providerId}/default-model`,
+      {method: 'PUT', body: toDefaultModelBody(defaultModel)},
+    ),
   );
 }
 
 export async function setDefaultModelProvider({
   workspaceId,
-  body,
+  providerId,
 }: {
   workspaceId: string;
-  body: SetDefaultModelProviderBodyDto;
+  providerId: string;
 }) {
-  return await apiRequest<SetDefaultModelProviderResponseDto>(
+  return await checkedApiRequest(
+    setDefaultModelProviderResponseSchema,
     `/workspaces/${workspaceId}/agent/default-model-provider`,
-    {method: 'PUT', body},
+    {method: 'PUT', body: toDefaultProviderBody(providerId)},
   );
 }
 
 export async function setDefaultHarness({
   workspaceId,
-  body,
+  harnessId,
 }: {
   workspaceId: string;
-  body: SetDefaultHarnessBodyDto;
+  harnessId: HarnessId;
 }) {
-  return await apiRequest<SetDefaultHarnessResponseDto>(
+  return await checkedApiRequest(
+    setDefaultHarnessResponseSchema,
     `/workspaces/${workspaceId}/agent/default-harness`,
-    {method: 'PUT', body},
+    {method: 'PUT', body: toDefaultHarnessBody(harnessId)},
   );
 }
 
 export function useModelProviderCatalogQuery() {
-  return useQuery({
+  return useQuery(modelProviderCatalogQueryOptions());
+}
+
+export function modelProviderCatalogQueryOptions() {
+  return queryOptions({
     queryKey: modelProviderQueryKeys.catalog(),
     queryFn: ({signal}) => getModelProviderCatalog({signal}),
     staleTime: 1000 * 60 * 60,

--- a/libs/client/agent/src/hooks/api/model-providers.ts
+++ b/libs/client/agent/src/hooks/api/model-providers.ts
@@ -61,6 +61,13 @@ type ModelProviderConfigsQueryOptions = FetchQueryOptions<
   ModelProviderConfigsQueryKey
 >;
 
+type ModelProviderCatalogQueryOptions = FetchQueryOptions<
+  ProviderCatalog,
+  Error,
+  ProviderCatalog,
+  ReturnType<typeof modelProviderQueryKeys.catalog>
+>;
+
 export async function getModelProviderCatalog({
   signal,
 }: {
@@ -249,7 +256,7 @@ export function useModelProviderCatalogQuery() {
   return useQuery(modelProviderCatalogQueryOptions());
 }
 
-export function modelProviderCatalogQueryOptions() {
+export function modelProviderCatalogQueryOptions(): ModelProviderCatalogQueryOptions {
   return queryOptions({
     queryKey: modelProviderQueryKeys.catalog(),
     queryFn: ({signal}) => getModelProviderCatalog({signal}),

--- a/libs/client/agent/src/pages/model-provider-onboarding-page.tsx
+++ b/libs/client/agent/src/pages/model-provider-onboarding-page.tsx
@@ -1,11 +1,3 @@
-import {
-  DEFAULT_HARNESS,
-  type Harness,
-  type HarnessDescriptor,
-  harnessSupportsProvider,
-  listHarnessDescriptors,
-  type ModelProviderCatalogEntryDto,
-} from '@shipfox/api-agent-dto';
 import {QueryLoadError} from '@shipfox/client-ui';
 import {Button} from '@shipfox/react-ui/button';
 import {Callout} from '@shipfox/react-ui/callout';
@@ -16,10 +8,14 @@ import {Skeleton} from '@shipfox/react-ui/skeleton';
 import {toast} from '@shipfox/react-ui/toast';
 import {Header, Text} from '@shipfox/react-ui/typography';
 import {cn} from '@shipfox/react-ui/utils';
-import {useEffect, useMemo, useState} from 'react';
+import {useEffect, useMemo, useReducer} from 'react';
 import {AvailableProvidersGrid, PROVIDER_GRID_CLASS} from '#components/available-providers-grid.js';
 import {modelProviderConfigErrorToFormError} from '#components/form-errors.js';
 import {ModelProviderTestAndSaveForm} from '#components/test-and-save-form.js';
+import {DEFAULT_HARNESS, harnessSupportsProvider, listHarnesses} from '#core/harness-policy.js';
+import type {HarnessDescriptor, HarnessId, SupportedProvider} from '#core/models.js';
+import {initialOnboardingState, onboardingReducer} from '#core/onboarding-reducer.js';
+import {isSupportedProvider} from '#core/provider-policy.js';
 import {
   useModelProviderCatalogQuery,
   useSetDefaultHarnessMutation,
@@ -40,27 +36,24 @@ export function ModelProviderOnboardingPage({
 }) {
   const catalogQuery = useModelProviderCatalogQuery();
   const setDefaultHarness = useSetDefaultHarnessMutation();
-  const [selectedHarness, setSelectedHarness] = useState<Harness | null>(null);
-  const [selectedEntry, setSelectedEntry] = useState<ModelProviderCatalogEntryDto | null>(null);
-  const [defaultHarnessError, setDefaultHarnessError] = useState<string | undefined>();
-  const [isSettingDefaultHarness, setIsSettingDefaultHarness] = useState(false);
-  const supportedProviders =
-    catalogQuery.data?.providers.filter((provider) => provider.support_status === 'supported') ??
-    [];
+  const [onboarding, dispatch] = useReducer(onboardingReducer, initialOnboardingState);
+  const supportedProviders = catalogQuery.data?.providers.filter(isSupportedProvider) ?? [];
   const filteredProviders = useMemo(() => {
-    if (selectedHarness === null) return [];
+    if (onboarding.step === 'choose-harness') return [];
     return supportedProviders.filter((provider) =>
-      harnessSupportsProvider(selectedHarness, provider.id),
+      harnessSupportsProvider(onboarding.harnessId, provider.id),
     );
-  }, [selectedHarness, supportedProviders]);
+  }, [onboarding, supportedProviders]);
 
   useEffect(() => {
     document
       .getElementById(
-        selectedHarness === null ? 'model-provider-harness-step' : 'model-provider-provider-step',
+        onboarding.step === 'choose-harness'
+          ? 'model-provider-harness-step'
+          : 'model-provider-provider-step',
       )
       ?.focus();
-  }, [selectedHarness]);
+  }, [onboarding.step]);
 
   function handleSkip() {
     try {
@@ -72,37 +65,43 @@ export function ModelProviderOnboardingPage({
   }
 
   async function handleProviderSaved() {
-    if (selectedEntry === null || selectedHarness === null) return;
+    if (onboarding.step !== 'configure-provider' && onboarding.step !== 'saving-default-harness')
+      return;
 
-    setDefaultHarnessError(undefined);
-    if (selectedHarness === DEFAULT_HARNESS) {
-      toast.success(`${selectedEntry.label} saved`);
+    const provider = onboarding.provider;
+    if (onboarding.step === 'configure-provider') dispatch({type: 'provider-saved'});
+    if (onboarding.harnessId === DEFAULT_HARNESS) {
+      toast.success(`${provider.label} saved`);
+      dispatch({type: 'default-harness-saved'});
       onConfigured();
       return;
     }
 
-    setIsSettingDefaultHarness(true);
     try {
       await setDefaultHarness.mutateAsync({
         workspaceId,
-        body: {harness_id: selectedHarness},
+        harnessId: onboarding.harnessId,
       });
-      toast.success(`${selectedEntry.label} saved`);
+      toast.success(`${provider.label} saved`);
+      dispatch({type: 'default-harness-saved'});
       onConfigured();
     } catch (error) {
       const mapped = modelProviderConfigErrorToFormError(error);
-      setDefaultHarnessError(mapped.message || 'Could not save default harness. Try again.');
-    } finally {
-      setIsSettingDefaultHarness(false);
+      dispatch({
+        type: 'default-harness-failed',
+        message: mapped.message || 'Could not save default harness. Try again.',
+      });
     }
   }
 
   const selectedHarnessDescriptor =
-    selectedHarness === null
+    onboarding.step === 'choose-harness'
       ? null
-      : listHarnessDescriptors().find((harness) => harness.id === selectedHarness);
+      : listHarnesses().find((harness) => harness.id === onboarding.harnessId);
   const headingId =
-    selectedHarness === null ? 'model-provider-harness-step' : 'model-provider-provider-step';
+    onboarding.step === 'choose-harness'
+      ? 'model-provider-harness-step'
+      : 'model-provider-provider-step';
 
   return (
     <div className="mx-auto flex w-full max-w-[640px] flex-col gap-20">
@@ -125,22 +124,23 @@ export function ModelProviderOnboardingPage({
       </header>
 
       <section aria-labelledby={headingId} className="flex flex-col gap-16">
-        {selectedHarness === null ? (
-          <HarnessPicker onSelect={setSelectedHarness} />
+        {onboarding.step === 'choose-harness' ? (
+          <HarnessPicker
+            onSelect={(harnessId) => dispatch({type: 'harness-selected', harnessId})}
+          />
         ) : (
           <>
             <div>
-              <Button type="button" variant="transparent" onClick={() => setSelectedHarness(null)}>
+              <Button type="button" variant="transparent" onClick={() => dispatch({type: 'back'})}>
                 Back
               </Button>
             </div>
             <ModelProviderPicker
-              key={selectedHarness}
+              key={onboarding.harnessId}
               catalogQuery={catalogQuery}
               supportedProviders={filteredProviders}
               onSelect={(entry) => {
-                setDefaultHarnessError(undefined);
-                setSelectedEntry(entry);
+                dispatch({type: 'provider-selected', provider: entry});
               }}
             />
           </>
@@ -148,17 +148,19 @@ export function ModelProviderOnboardingPage({
       </section>
 
       <Modal
-        open={selectedEntry !== null}
+        open={
+          onboarding.step === 'configure-provider' || onboarding.step === 'saving-default-harness'
+        }
         onOpenChange={(open) => {
-          if (!open && !isSettingDefaultHarness) {
-            setSelectedEntry(null);
-            setDefaultHarnessError(undefined);
-          }
+          if (!open && onboarding.step === 'configure-provider') dispatch({type: 'back'});
         }}
       >
         <ModalContent aria-describedby={undefined}>
           <ModalTitle className="sr-only">
-            {selectedEntry ? `Configure ${selectedEntry.label}` : ''}
+            {onboarding.step === 'configure-provider' ||
+            onboarding.step === 'saving-default-harness'
+              ? `Configure ${onboarding.provider.label}`
+              : ''}
           </ModalTitle>
           <ModalHeader>
             <Text
@@ -166,32 +168,36 @@ export function ModelProviderOnboardingPage({
               aria-hidden="true"
               className="overflow-ellipsis overflow-hidden whitespace-nowrap"
             >
-              {selectedEntry ? `Configure ${selectedEntry.label}` : ''}
+              {onboarding.step === 'configure-provider' ||
+              onboarding.step === 'saving-default-harness'
+                ? `Configure ${onboarding.provider.label}`
+                : ''}
             </Text>
           </ModalHeader>
-          {isSettingDefaultHarness ? (
+          {onboarding.step === 'saving-default-harness' ? (
             <div role="status" className="px-20 pb-8">
               <Text size="sm" className="text-foreground-neutral-muted">
                 Saving harness default...
               </Text>
             </div>
           ) : null}
-          {defaultHarnessError ? (
+          {onboarding.step === 'saving-default-harness' && onboarding.error ? (
             <div className="px-20 pb-8">
               <Callout role="alert" type="error">
                 <div className="flex flex-col gap-8">
                   <Text size="sm" bold>
                     Could not save default harness
                   </Text>
-                  <Text size="sm">{defaultHarnessError}</Text>
+                  <Text size="sm">{onboarding.error}</Text>
                 </div>
               </Callout>
             </div>
           ) : null}
-          {selectedEntry ? (
+          {onboarding.step === 'configure-provider' ||
+          onboarding.step === 'saving-default-harness' ? (
             <ModelProviderTestAndSaveForm
               workspaceId={workspaceId}
-              entry={selectedEntry}
+              entry={onboarding.provider}
               setAsDefaultOnSave
               onSaved={() => {
                 void handleProviderSaved();
@@ -204,10 +210,10 @@ export function ModelProviderOnboardingPage({
   );
 }
 
-function HarnessPicker({onSelect}: {onSelect: (harness: Harness) => void}) {
+function HarnessPicker({onSelect}: {onSelect: (harness: HarnessId) => void}) {
   return (
     <ul className={PROVIDER_GRID_CLASS} aria-label="Agent harnesses">
-      {listHarnessDescriptors().map((harness) => (
+      {listHarnesses().map((harness) => (
         <HarnessCard key={harness.id} harness={harness} onChoose={() => onSelect(harness.id)} />
       ))}
     </ul>
@@ -251,8 +257,8 @@ function ModelProviderPicker({
   onSelect,
 }: {
   catalogQuery: ReturnType<typeof useModelProviderCatalogQuery>;
-  supportedProviders: ModelProviderCatalogEntryDto[];
-  onSelect: (entry: ModelProviderCatalogEntryDto) => void;
+  supportedProviders: SupportedProvider[];
+  onSelect: (entry: SupportedProvider) => void;
 }) {
   if (catalogQuery.isPending) {
     return (

--- a/libs/client/agent/test/fixtures/model-providers.ts
+++ b/libs/client/agent/test/fixtures/model-providers.ts
@@ -27,7 +27,7 @@ export function modelProviderEntry(
     id: 'anthropic',
     label: 'Anthropic',
     support_status: 'supported',
-    default_model: null,
+    default_model: 'claude-opus-4-8',
     credential_fields: [{key: 'api_key', label: 'API key', secret: true}],
     unsupported_reason: null,
     models: [{id: 'claude-opus-4-8', label: 'Claude Opus 4.8'}],

--- a/libs/client/onboarding/src/workspace-setup-route.test.tsx
+++ b/libs/client/onboarding/src/workspace-setup-route.test.tsx
@@ -110,7 +110,11 @@ function setupFetch(options: SetupFetchOptions = {}) {
       if (providerConfigsFail)
         return Promise.resolve(jsonResponse({code: 'server-error'}, {status: 500}));
       return Promise.resolve(
-        jsonResponse({configs: providerConfigs, default_provider_id: defaultProviderId}),
+        jsonResponse({
+          configs: providerConfigs,
+          default_provider_id: defaultProviderId,
+          default_harness_id: null,
+        }),
       );
     }
     return Promise.resolve(jsonResponse({}, {status: 404}));
@@ -196,9 +200,9 @@ function projectStub() {
 
 function modelProviderConfig() {
   return {
+    kind: 'builtin',
     provider_id: 'anthropic',
     default_model: null,
-    key_fingerprints: {'credential:api_key': '...abcd'},
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
   };
@@ -358,9 +362,17 @@ describe('workspace setup route hook', () => {
     renderSetupRoute(`/workspaces/${WORKSPACE_ID}`, fetchImpl, {
       seedQueryClient: (queryClient) => {
         queryClient.setQueryData(modelProviderConfigsQueryOptions(WORKSPACE_ID).queryKey, {
-          configs: [modelProviderConfig()] as never,
-          default_provider_id: 'anthropic',
-          default_harness_id: null,
+          configs: [
+            {
+              kind: 'builtin',
+              providerId: 'anthropic',
+              defaultModel: null,
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+            },
+          ],
+          defaultProviderId: 'anthropic',
+          defaultHarnessId: null,
         });
       },
     });

--- a/libs/client/projects/src/components/model-provider-reminder-banner.tsx
+++ b/libs/client/projects/src/components/model-provider-reminder-banner.tsx
@@ -19,7 +19,7 @@ export function ModelProviderReminderBanner({workspaceId}: {workspaceId: string}
   const unconfigured =
     Array.isArray(configs) &&
     configs.length === 0 &&
-    configsQuery.data?.default_provider_id === null;
+    configsQuery.data?.defaultProviderId === null;
 
   if (!unconfigured || dismissed) return null;
 

--- a/libs/client/projects/src/components/model-provider-reminder-banner.tsx
+++ b/libs/client/projects/src/components/model-provider-reminder-banner.tsx
@@ -17,9 +17,7 @@ export function ModelProviderReminderBanner({workspaceId}: {workspaceId: string}
   const [dismissed, setDismissed] = useState(() => isReminderDismissed(workspaceId));
   const configs = configsQuery.data?.configs;
   const unconfigured =
-    Array.isArray(configs) &&
-    configs.length === 0 &&
-    configsQuery.data?.defaultProviderId === null;
+    Array.isArray(configs) && configs.length === 0 && configsQuery.data?.defaultProviderId === null;
 
   if (!unconfigured || dismissed) return null;
 

--- a/libs/client/projects/src/pages/create-project-page.stories.tsx
+++ b/libs/client/projects/src/pages/create-project-page.stories.tsx
@@ -150,7 +150,11 @@ function fetchForScenario(scenario: Scenario): typeof fetch {
     const method = input instanceof Request ? input.method : (init?.method ?? 'GET');
     if (url.pathname === `/workspaces/${WORKSPACE_ID}/agent/model-providers`) {
       return Promise.resolve(
-        jsonResponse({configs: [modelProviderConfig()], default_provider_id: 'openai'}),
+        jsonResponse({
+          configs: [modelProviderConfig()],
+          default_provider_id: 'openai',
+          default_harness_id: null,
+        }),
       );
     }
     if (url.pathname === '/integration-connections') {
@@ -312,6 +316,7 @@ function repository(overrides: Partial<RepositoryDto>): RepositoryDto {
 
 function modelProviderConfig() {
   return {
+    kind: 'builtin',
     workspace_id: WORKSPACE_ID,
     provider_id: 'openai',
     default_model: 'gpt-5.5-pro',

--- a/libs/client/projects/src/pages/create-project-page.test.tsx
+++ b/libs/client/projects/src/pages/create-project-page.test.tsx
@@ -163,7 +163,9 @@ describe('CreateProjectPage', () => {
     const fetchImpl = vi.fn((input: RequestInfo | URL) => {
       const request = input as Request;
       if (request.url.endsWith('/agent/model-providers')) {
-        return Promise.resolve(jsonResponse({configs: [], default_provider_id: null}));
+        return Promise.resolve(
+          jsonResponse({configs: [], default_provider_id: null, default_harness_id: null}),
+        );
       }
       if (request.url.includes('/integration-connections?')) {
         return Promise.resolve(jsonResponse({connections: [connectionDto()]}));

--- a/libs/client/projects/src/pages/projects-hub-page.test.tsx
+++ b/libs/client/projects/src/pages/projects-hub-page.test.tsx
@@ -40,7 +40,11 @@ describe('ProjectsHubPage', () => {
   test('shows and dismisses the model provider reminder when no provider is configured', async () => {
     const fetchImpl = createHubFetch({
       projects: jsonResponse({projects: [], next_cursor: null}),
-      modelProviders: jsonResponse({configs: [], default_provider_id: null}),
+      modelProviders: jsonResponse({
+        configs: [],
+        default_provider_id: null,
+        default_harness_id: null,
+      }),
     });
     configureApiClient({fetchImpl});
 
@@ -276,14 +280,15 @@ function modelProviderConfigsDto() {
   return {
     configs: [
       {
+        kind: 'builtin',
         provider_id: 'anthropic',
         default_model: null,
-        key_fingerprints: {'credential:api_key': '...abcd'},
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
       },
     ],
     default_provider_id: 'anthropic',
+    default_harness_id: null,
   };
 }
 


### PR DESCRIPTION
Converges Agent model-provider catalog/configuration data and mutation commands on client domain models, with reducer-owned management and onboarding workflows.

The UI previously retained transport DTOs and coordinated modal state through coupled nullable fields, which made domain behavior depend on API casing and left workflow transitions easy to desynchronize. DTO parsing and serialization now stay at the API adapter boundary; domain policy owns provider and harness decisions.

The harness policy has a parity test against the shared DTO contract so compatibility changes cannot drift silently. This is released as a major `@shipfox/client-agent` change because its exported query result changes from DTO-shaped fields to domain-shaped fields; `@shipfox/client-projects` is updated for the renamed field.

Closes ENG-1130

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converges Agent model‑provider queries and commands on client domain models, moving DTO mapping to the API adapter and letting reducers own modal and onboarding workflows. Ships a major in `@shipfox/client-agent`; fixes provider reminder formatting in `@shipfox/client-projects` and query declaration packaging.

- **Refactors**
  - Added domain types and policies in `#core` (`models`, `harness-policy`, provider search/policy).
  - Introduced API command mappers (`hooks/api/model-provider-command-mapper`) to translate domain commands to DTO bodies.
  - Centralized management and onboarding state via `managementModalReducer` (adds `restoreFocusToConfiguredProviders`) and onboarding reducer updates.
  - Replaced DTOs in UI with domain types (`SupportedProvider`, `ProviderConfig`, `BuiltinProviderConfig`, `CustomProviderConfig`).
  - Mapped transport with Zod schemas and camelCase fields; added harness policy parity test to lock compatibility.
  - Updated components/tests to use `listHarnesses`, `getHarness`, and `DEFAULT_HARNESS`.

- **Migration**
  - Domain result shapes replace DTOs in `@shipfox/client-agent`:
    - Catalog entries: use `SupportedProvider` (e.g., `defaultModel`).
    - Provider configs: use `ProviderConfig`/`BuiltinProviderConfig`/`CustomProviderConfig`.
    - Config list: access `defaultProviderId` and `defaultHarnessId` (camelCase).
  - Commands now accept domain commands:
    - `ProviderCredentialsCommand`, `UpdateCustomProviderCommand`, `CreateCustomProviderCommand`, `DiscoverProviderModelsCommand`.
  - Harness utilities now come from domain policy: `listHarnesses`/`getHarness` and `DEFAULT_HARNESS`.
  - Update downstream packages (e.g., `@shipfox/client-projects`) to new field names like `defaultProviderId`.

<sup>Written for commit 2115ae1cb7f4ea00b6da36c65a53c2987691d7df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

