### PR TITLE
Add living client architecture guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,70 +112,12 @@ payload maps in the module's `*-dto` package, write outbox events in the same
 transaction as the state change, and register publisher tables on the module
 declaration.
 
-### Client packages
+### Client architecture and forms
 
-Client feature packages should expose both transport functions and React Query
-hooks. Use `@shipfox/client-api` for JSON requests, auth refresh, and `ApiError`
-handling; colocate query keys, raw request functions, and hooks in the feature's
-`hooks/api/*` module.
-
-### Form management
-
-Client forms use `@tanstack/react-form` driven by the `*BodySchema` Zod schemas
-from the matching `*-dto` package. Zod 3.24+ implements Standard Schema, so
-schemas pass directly to TanStack Form's `validators`:
-
-```ts
-const form = useForm({
-  defaultValues,
-  onSubmit: async ({value}) => { /* mutation */ },
-});
-
-<form.Field
-  name="email"
-  validators={{onBlur: bodySchema.shape.email, onSubmit: bodySchema.shape.email}}
->
-```
-
-Do not add `@tanstack/zod-form-adapter` or write custom Zod adapters: the
-adapter package is legacy (pinned to form-core v0.x) and unnecessary on v1+.
-
-Render every labeled input through `FormField` from `@shipfox/react-ui`, using
-`FormFieldInput` to inherit the field's id, `aria-invalid`, and
-`aria-describedby` automatically:
-
-```tsx
-<FormField label="Email" id="email" error={fieldError(field)}>
-  <FormFieldInput
-    type="email"
-    value={field.state.value}
-    onChange={(event) => field.handleChange(event.target.value)}
-    onBlur={field.handleBlur}
-  />
-</FormField>
-```
-
-Validation runs `onBlur` per field and `onSubmit` for the form. Show field
-errors only after the field has been blurred or after a submit attempt. See
-the `fieldError(field)` helper at the bottom of each page form for the
-boilerplate.
-
-Server errors are classified by a per-feature `errorToFormError(error)` pure
-function in `form-errors.ts`. It returns either
-`{kind: 'field', field, message}` (routed to
-`form.setFieldMeta(field, prev => ({...prev, errorMap: {...prev.errorMap, onServer: message}}))`)
-or `{kind: 'form', message}` (rendered in an `<Alert>` above the form).
-Use the `onServer` slot in `errorMap` (not `errors` directly) because
-TanStack Form v1 derives `field.state.meta.errors` from `errorMap`, so a
-direct write to `errors` gets overwritten on the next derived read.
-TanStack Form auto-clears `errorMap.onServer` on the next field validation
-(blur/change), which is the correct UX. Add a Vitest node test enumerating
-every `ApiError` code the feature handles, plus the unknown-error fallback.
-
-For draft persistence across navigation (auth flows), sync TanStack Form values
-into a Jotai atom on field blur and on form unmount only (never on every
-keystroke) and filter the atom shape explicitly so unrelated fields (e.g.
-signup's `name`) don't leak into a `{email, password}` draft.
+When a task adds or changes a client feature, API adapter, query, route state,
+form, atom, browser storage, or cross-feature client flow, read the
+[client architecture guide](docs/architecture/client-architecture.md). It owns
+the current client model, form rules, and architecture enforcement.
 
 ### E2E testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,12 +59,10 @@ format.
 
 ## Client architecture
 
-Client features follow [ADR 0003](docs/adr/0003-client-state-and-domain-architecture.md). API adapters
-validate response contracts and map them to package-owned domain models before caching. The
-`pnpm check:client-architecture` audit blocks new boundary violations while
-`tools/client-architecture-policy/client-architecture-baseline.json` records the remaining migration
-work. Do not add a baseline entry for new code. Move it to the approved adapter, `core/`, or resource
-mutation owner instead.
+When you add or change a client feature, API adapter, query, route state, form,
+atom, browser storage, or cross-feature client flow, read the
+[client architecture guide](docs/architecture/client-architecture.md). It owns
+the current client model, form rules, and architecture enforcement.
 
 ## Error reporting
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ listed there or when you need to place, update, or review documentation.
 | Changes a cross-package client composition seam. | [ADR 0001](adr/0001-client-composition-contract.md) | The public client composition contract and its decision rationale. |
 | Changes server module boundaries or an inter-module call. | [ADR 0002](adr/0002-api-inter-module-architecture.md) | Producer-owned inter-module contracts and bounded-context crossings. |
 | Adds or changes a backend module, DTO, outbox event, HTTP boundary, or server package dependency. | [Backend architecture](architecture/backend-architecture.md) | The current backend module model and package-boundary rules. |
-| Changes client state, API adapters, forms, or feature-domain boundaries. | [ADR 0003](adr/0003-client-state-and-domain-architecture.md) | Client state ownership and domain architecture decisions. |
+| Changes client state, API adapters, forms, or feature-domain boundaries. | [Client architecture](architecture/client-architecture.md) | The current client feature model, form rules, and architecture enforcement. |
 | Introduces a shared package or changes a server dependency boundary. | [ADR 0004](adr/0004-shared-semantic-packages-and-server-dependency-boundaries.md) | Shared semantic package rules and server package classes. |
 | Changes repository documentation structure or adds a shared documentation surface. | [ADR 0005](adr/0005-repository-documentation-architecture.md) | Documentation ownership, routing, and progressive disclosure. |
 | Changes webhook retry behavior. | [Webhook retry safety](architecture/webhook-retry-safety.md) | The current safety model for webhook retries. |

--- a/docs/architecture/client-architecture.md
+++ b/docs/architecture/client-architecture.md
@@ -1,0 +1,182 @@
+# Client architecture
+
+This guide owns the current client feature model and form rules. Read it when
+you add or change a client feature, API adapter, query, route state, form, atom,
+browser storage, or cross-feature client flow. Package READMEs own public APIs
+and package-specific usage. [ADR 0003](../adr/0003-client-state-and-domain-architecture.md)
+records the decision, alternatives, and consequences behind these rules.
+
+## Feature ownership
+
+A client feature owns its routes, API adapters, domain models, policies, pages,
+components, and client-owned state. Keep the package vertical. Do not create a
+central package that imports feature internals because it happens to compose a
+screen.
+
+Use the folders that the feature needs. Empty layers add no value.
+
+```text
+src/
+  feature.ts       Node-safe composition manifest
+  core/            Domain models, policies, reducers, and pure transforms
+  hooks/api/       HTTP transport, DTO mapping, query options, and mutations
+  routes/          Router adapters and checked search parameters
+  pages/           Screen orchestration
+  components/      Domain UI and local interaction state
+  state/           Cross-route or persisted client state only
+```
+
+Presentation imports `core/`. API adapters import `core/`. `core/` imports
+neither client frameworks nor API DTO packages. Put business rules, meaningful
+transforms, reducers, and command building in `core/`. Keep layout, focus,
+animation, navigation, cache invalidation, and feedback in presentation or API
+code.
+
+When changing a client composition seam, read
+[ADR 0001](../adr/0001-client-composition-contract.md). It owns feature
+manifests, routes, shell providers, navigation, settings sections, and runtime
+configuration composition.
+
+## API adapters and React Query
+
+DTOs stop at the API adapter. The adapter parses an untrusted response with the
+DTO package's Zod response schema, maps it to a package-owned domain model, and
+stores that model in React Query. Pages and components do not consume response
+DTOs as their main model.
+
+```text
+HTTP response -> response schema -> DTO -> mapper -> domain model -> query cache
+```
+
+Write adapters map a domain command or feature input to a request DTO.
+Components do not build snake_case transport payloads. Empty responses,
+redirect URLs, health checks, and opaque acknowledgements can remain transport
+values when they have no domain meaning.
+
+Each query option owns its key, request, mapping, cache policy, and pagination.
+Reuse that option from hooks, loaders, and coordinators. A mutation owns the
+cache updates for the resource it changes. Components report user intent and
+handle presentation effects such as closing a dialog or navigating. A named
+page or application coordinator owns a journey that must update more than one
+feature's cache.
+
+Use `@shipfox/client-api` for requests, auth refresh, and `ApiError` handling.
+
+## Choose state by its source of truth
+
+| State | Owner | Use it for |
+| --- | --- | --- |
+| Server state | React Query | Resources, request status, polling, pagination, and cache updates. |
+| Route state | TanStack Router | Resource identity, shareable filters, deep links, tabs, and history. |
+| Form state | TanStack Form | Draft values, field state, submission state, and validation. |
+| Local UI state | `useState` | Short-lived independent visual state. |
+| Complex workflow | Pure reducer | Coupled states, mutually exclusive modes, and named transitions. |
+| Cross-route client state | Jotai | Small synchronous client-owned values shared across distant routes. |
+| Persisted browser state | Typed storage adapter | Preferences, recovery hints, and best-effort dismissals. |
+
+Put a value in checked route parameters or search parameters when refresh,
+browser history, copied links, or another tab should preserve it. Keep private
+visual state local. Do not copy query data into local state only to filter or
+format it. Do not copy route state into Jotai.
+
+Use a discriminated reducer in `core/` when several values describe one
+workflow and invalid combinations are possible. Effects perform requests,
+focus changes, and navigation outside the reducer.
+
+Add a Jotai atom only after React Query, Router, Form, and local state do not
+fit. API resources stay in React Query. Authentication is shell-owned session
+state. Browser storage is a typed adapter with checked reads, explicit key
+scope and lifetime, and safe fallbacks. It never grants authority.
+
+## Forms
+
+TanStack Form owns an active draft. Use the matching request `*BodySchema` from
+the DTO package for field validation when its rules match the form. Zod 3.24+
+implements Standard Schema, so pass the schema directly to TanStack Form. Do
+not add `@tanstack/zod-form-adapter` or a custom adapter.
+
+```tsx
+const form = useForm({
+  defaultValues,
+  onSubmit: async ({value}) => saveProject(value),
+});
+
+<form.Field
+  name="name"
+  validators={{
+    onBlur: createProjectBodySchema.shape.name,
+    onSubmit: createProjectBodySchema.shape.name,
+  }}
+>
+  {(field) => (
+    <FormField label="Name" id="project-name" error={fieldError(field)}>
+      <FormFieldInput
+        value={field.state.value}
+        onChange={(event) => field.handleChange(event.target.value)}
+        onBlur={field.handleBlur}
+      />
+    </FormField>
+  )}
+</form.Field>
+```
+
+Render every labeled input with `FormField` and its matching field control from
+[`@shipfox/react-ui`](../../libs/shared/react/ui/README.md). The control
+inherits the field id, `aria-invalid`, and `aria-describedby`. Its package
+README owns the public components and API.
+
+Validate fields on blur and the complete form on submit. Show an error after a
+field has blurred or after a submit attempt. `fieldError(field)` extracts the
+first TanStack Form error for `FormField`.
+
+Map known server failures in a feature-owned pure `form-errors.ts` function.
+It returns either a field error or a form error. Apply a field error through
+the `onServer` error-map slot. Render a form error in an `Alert`. Never render
+an unknown error message directly.
+
+```ts
+form.setFieldMeta('name', (previous) => ({
+  ...previous,
+  errorMap: {...previous.errorMap, onServer: 'A project with this name exists.'},
+}));
+```
+
+TanStack Form derives visible errors from `errorMap`. A direct write to
+`errors` is overwritten on the next derived read. TanStack Form clears
+`onServer` on the next field validation, which removes a stale server error
+when the user edits the field. Add a Vitest node test for every handled
+`ApiError` code and the unknown-error fallback.
+
+A cross-route draft is an exception. Persist only the required fields in a
+feature-owned Jotai atom. Sync on blur and unmount, never each keystroke. Clear
+the draft after a successful completion. Filter the saved shape so fields from
+one form cannot leak into another form's draft.
+
+## Composition and feature boundaries
+
+Features own their route, navigation, and settings contributions. A settings
+layout owns the layout and workspace-wide settings concepts. It does not own
+every domain settings page.
+
+Cross-feature journeys use a named application or page coordinator. Features
+depend on another feature's public domain surface only. Do not deep-import a
+feature's components, query internals, or storage helpers.
+
+## Tests and enforcement
+
+Test pure domain models, policies, reducers, commands, and transforms without
+React. Test an adapter with representative DTOs and its mapped domain model.
+Test query keys, cache effects, polling, and optimistic updates at the query
+boundary. Component tests prove rendered behavior. E2E tests prove journeys.
+
+Run `pnpm check:client-architecture` after changing a client boundary. The
+check blocks new direct API requests outside adapters, DTO imports in
+presentation, DTO or framework imports in `core/`, and leaf-component query
+cache ownership. Its existing migration inventory is
+[`client-architecture-baseline.json`](../../tools/client-architecture-policy/client-architecture-baseline.json).
+Do not add a baseline entry for new code. Move the code to the appropriate
+adapter, `core/`, or mutation owner instead.
+
+Update this guide when the current operating model changes. Update ADR 0003,
+or add a new ADR, when the durable decision, ownership model, or accepted
+tradeoff changes.


### PR DESCRIPTION
Adds one current contributor guide for client feature ownership, state, API boundaries, form behavior, and architecture enforcement.

The rules were split between an ADR, CONTRIBUTING, and the agent handbook. Moving the operational guidance into docs lets human contributors and agents follow the same source, while ADR 0003 keeps the decision rationale.

The guide intentionally links to package documentation for public APIs and to ADR 0001 for client composition. Review the form error and draft-persistence rules because they replace the detailed AGENTS.md copy.

Closes ENG-1158

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a living client architecture guide that centralizes rules for feature ownership, state, API adapters, and forms. Removes duplicate guidance from `AGENTS.md` and `CONTRIBUTING.md`, updates docs links, and keeps ADR 0003 for rationale (ENG-1158).

- **Migration**
  - Read docs/architecture/client-architecture.md before changing client features.
  - Review updated form error handling and draft persistence rules; detailed guidance was removed from `AGENTS.md`.

<sup>Written for commit ae6023a5c5211265c42955f8007af8654926cce5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

