### PR TITLE
Add whole-closure package publication preflight

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,24 @@ jobs:
       - name: Verify external package contracts
         run: turbo test:external --filter=@shipfox/application-release --filter=@shipfox/client-shell --concurrency=1
 
+  publication-preflight:
+    name: Package publication preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Set up mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
+
+      - name: Set up pnpm
+        uses: ./.github/actions/setup-pnpm
+
+      - name: Preflight package publication closure
+        run: pnpm run release:preflight
+
   tests:
     name: Unit and story tests
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "check:published-artifacts": "turbo verify --filter=@shipfox/package-release",
     "fix:dependencies": "pnpm --filter=@shipfox/dependency-policy fix",
     "release:publish": "turbo type build type:emit --filter='./libs/**' --filter='./tools/**' && pnpm --filter=@shipfox/package-release publish:closure",
+    "release:preflight": "turbo type build type:emit --filter='./libs/**' --filter='./tools/**' && pnpm --filter=@shipfox/package-release preflight",
     "test:external": "turbo test:external",
     "verify": "turbo verify"
   },

--- a/tools/package-release/README.md
+++ b/tools/package-release/README.md
@@ -26,3 +26,14 @@ pnpm --filter=@shipfox/package-release verify-generated-release -- \
 
 `classification` is either `generated-release` or `not-generated-release`.
 CI must use only `generated-release` to select a release-specific path.
+
+`pnpm run release:preflight` builds the public libraries and tools, stages every
+package in `publication-closure.json` plus every public tool, and packs each one
+without registry credentials. It validates productionized manifests, runtime
+dependency references, and packed entry-point files. Staging directories and
+tarballs live under the system temporary directory, so the source tree is not
+rewritten.
+
+Preflight proves that the planned packages can be transformed and packed as a
+coherent release closure. The real publish step still proves registry
+authorization, provenance, and that npm accepted each upload.

--- a/tools/package-release/package.json
+++ b/tools/package-release/package.json
@@ -13,6 +13,7 @@
     "check:fix": "shipfox-biome-check --write",
     "verify-generated-release": "node dist/generated-release-verifier.js",
     "publish:closure": "node dist/publish-productionized-closure.js",
+    "preflight": "node dist/publication-preflight.js",
     "test": "shipfox-vitest-run",
     "test:watch": "shipfox-vitest-watch",
     "type": "shipfox-tsc-check",

--- a/tools/package-release/src/productionized-manifest-packer.ts
+++ b/tools/package-release/src/productionized-manifest-packer.ts
@@ -41,13 +41,23 @@ export async function packProductionizedPackage<T>({
   const stagedManifestPath = join(stagedDirectory, 'package.json');
   const stagedManifest = JSON.parse(await readFile(stagedManifestPath, 'utf8')) as JsonRecord;
   const productionManifest = productionizeDependencyReferences(
-    productionizeManifest(stagedManifest),
+    productionizePackageManifest(stagedManifest),
     dependencyContext,
   );
-  delete productionManifest.devDependencies;
   await writeFile(stagedManifestPath, `${JSON.stringify(productionManifest, null, 2)}\n`);
 
   return packArtifact(stagedDirectory);
+}
+
+export function productionizePackageManifest(manifest: JsonRecord): JsonRecord {
+  const productionManifest = productionizeManifest(manifest);
+  const {devDependencies: _, imports, ...publishManifest} = productionManifest;
+  if (!isRecord(imports)) return publishManifest;
+
+  const publishImports = Object.fromEntries(
+    Object.entries(imports).filter(([specifier]) => !specifier.startsWith('#test/')),
+  );
+  return {...publishManifest, imports: publishImports};
 }
 
 export function run(

--- a/tools/package-release/src/publication-preflight.ts
+++ b/tools/package-release/src/publication-preflight.ts
@@ -1,0 +1,275 @@
+import {execFile} from 'node:child_process';
+import {globSync} from 'node:fs';
+import {mkdir, mkdtemp, readFile, rm} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {dirname, join, resolve} from 'node:path';
+import {pathToFileURL} from 'node:url';
+
+import {parse as parseYaml} from 'yaml';
+
+import {
+  mapWithConcurrency,
+  type PackageDependencyContext,
+  packProductionizedPackage,
+  run,
+} from './productionized-manifest-packer.js';
+import {
+  getRepositoryRoot,
+  loadPublicationClosure,
+  resolvePublicationManifests,
+} from './publish-productionized-closure.js';
+
+type DependencyMap = Record<string, string>;
+type JsonRecord = Record<string, unknown>;
+
+interface PackageManifest extends JsonRecord {
+  bin?: Record<string, string> | string;
+  dependencies?: DependencyMap;
+  name: string;
+  optionalDependencies?: DependencyMap;
+  peerDependencies?: DependencyMap;
+  private?: boolean;
+  version?: string;
+}
+
+interface PublicationPackage {
+  directory: string;
+  manifest: PackageManifest;
+  manifestPath: string;
+}
+
+const runtimeDependencyFields = [
+  'dependencies',
+  'optionalDependencies',
+  'peerDependencies',
+] as const;
+const semverRange =
+  /^(?:[~^]?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?|[~^]?\d+\.\d+|[~^]?\d+|\*|latest)$/u;
+
+export async function preflightPublicationClosure(root: string): Promise<void> {
+  const config = loadPublicationClosure(root);
+  const manifestPaths = resolvePublicationManifests(root, config.packages);
+  const packages = await readPublicationPackages(manifestPaths);
+  const packagesByName = new Map(packages.map((entry) => [entry.manifest.name, entry]));
+  const workspacePackages = await readWorkspacePackages(root);
+  const workspaceVersions = new Map(
+    [...workspacePackages].flatMap(([name, manifest]) =>
+      typeof manifest.version === 'string' ? [[name, manifest.version] as const] : [],
+    ),
+  );
+  const workspaceConfig = parseYaml(await readFile(join(root, 'pnpm-workspace.yaml'), 'utf8')) as {
+    catalog?: DependencyMap;
+    catalogs?: Record<string, DependencyMap>;
+  };
+  const dependencyContext = {workspaceConfig, workspaceVersions} satisfies PackageDependencyContext;
+
+  validatePublicationPlan(packages, packagesByName, workspacePackages);
+  const temporaryRoot = await mkdtemp(join(tmpdir(), 'shipfox-publication-preflight-'));
+  const tarballRoot = join(temporaryRoot, 'tarballs');
+  const stagingRoot = join(temporaryRoot, 'packages');
+
+  try {
+    await Promise.all([mkdir(tarballRoot), mkdir(stagingRoot)]);
+    const results = await mapWithConcurrency(packages, 3, async (entry) => {
+      const tarball = join(tarballRoot, `${safePackageName(entry.manifest.name)}.tgz`);
+      await packProductionizedPackage({
+        dependencyContext,
+        manifest: entry.manifest,
+        sourceDirectory: entry.directory,
+        stagingRoot,
+        packArtifact: (stagedDirectory) =>
+          run('pnpm', ['pack', '--out', tarball], stagedDirectory, {stdio: 'ignore'}),
+      });
+      await validatePackedPackage(entry, tarball, packagesByName);
+      return {name: entry.manifest.name, tarball};
+    });
+    process.stdout.write(
+      `Publication preflight plan: ${results.map(({name}) => name).join(', ')}\n` +
+        `Publication preflight passed: packed ${results.length} packages.\n`,
+    );
+  } finally {
+    await rm(temporaryRoot, {force: true, recursive: true});
+  }
+}
+
+function readPublicationPackages(manifestPaths: string[]): Promise<PublicationPackage[]> {
+  return Promise.all(
+    manifestPaths.map(async (manifestPath) => ({
+      directory: dirname(manifestPath),
+      manifest: JSON.parse(await readFile(manifestPath, 'utf8')) as PackageManifest,
+      manifestPath,
+    })),
+  );
+}
+
+async function readWorkspacePackages(root: string): Promise<Map<string, PackageManifest>> {
+  const manifestPaths = globSync(join(root, '{apps,e2e,infra,libs,tools,turbo}/**/package.json'), {
+    exclude: ['**/node_modules/**'],
+  });
+  const manifests = await Promise.all(
+    manifestPaths.map(async (path) => [path, JSON.parse(await readFile(path, 'utf8'))] as const),
+  );
+  const packages = new Map<string, PackageManifest>();
+  for (const [, manifest] of manifests) {
+    if (typeof manifest.name !== 'string') continue;
+    if (packages.has(manifest.name))
+      throw new Error(`Duplicate workspace package: ${manifest.name}`);
+    packages.set(manifest.name, manifest as PackageManifest);
+  }
+  return packages;
+}
+
+function validatePublicationPlan(
+  packages: PublicationPackage[],
+  packagesByName: ReadonlyMap<string, PublicationPackage>,
+  workspacePackages: ReadonlyMap<string, PackageManifest>,
+): void {
+  for (const entry of packages) {
+    const {manifest} = entry;
+    if (manifest.private === true)
+      throw new Error(`Publication package is private: ${manifest.name}`);
+    if (typeof manifest.version !== 'string')
+      throw new Error(`Publication package has no version: ${manifest.name}`);
+    for (const field of runtimeDependencyFields) {
+      for (const [dependency, reference] of Object.entries(manifest[field] ?? {})) {
+        if (typeof reference !== 'string') {
+          throw new Error(
+            `Publication package ${manifest.name} has invalid ${field} reference for ${dependency}`,
+          );
+        }
+        const workspacePackage = workspacePackages.get(dependency);
+        if (workspacePackage) {
+          if (workspacePackage.private === true) {
+            throw new Error(
+              `Publication package ${manifest.name} has private runtime dependency ${dependency}`,
+            );
+          }
+          if (!packagesByName.has(dependency)) {
+            throw new Error(
+              `Publication package ${manifest.name} depends on ${dependency} outside the release plan`,
+            );
+          }
+        } else if (!reference.startsWith('catalog:') && !semverRange.test(reference)) {
+          throw new Error(
+            `Publication package ${manifest.name} has unsupported external range ${dependency}@${reference}`,
+          );
+        }
+      }
+    }
+  }
+}
+
+async function validatePackedPackage(
+  entry: PublicationPackage,
+  tarball: string,
+  packagesByName: ReadonlyMap<string, PublicationPackage>,
+): Promise<void> {
+  const files = (await execFileText('tar', ['-tzf', tarball])).split('\n').filter(Boolean);
+  const packedManifestText = await execFileText('tar', ['-xOzf', tarball, 'package/package.json']);
+  const manifest = JSON.parse(packedManifestText) as PackageManifest;
+  const unsupported = findUnsupportedProtocol(manifest);
+  if (unsupported)
+    throw new Error(`Packed ${manifest.name} contains unsupported protocol at ${unsupported}`);
+  validatePackedDependencies(manifest, packagesByName);
+  for (const target of packageEntryTargets(manifest)) {
+    if (!target.startsWith('./')) continue;
+    const expectedPath = `package/${target.slice(2)}`;
+    if (!files.some((file) => matchesPackagePath(file, expectedPath))) {
+      throw new Error(`Packed ${manifest.name} is missing entry point ${target}`);
+    }
+  }
+  if (manifest.name !== entry.manifest.name || manifest.version !== entry.manifest.version) {
+    throw new Error(`Packed manifest differs from release plan for ${entry.manifest.name}`);
+  }
+}
+
+function matchesPackagePath(file: string, expectedPath: string): boolean {
+  if (!expectedPath.includes('*')) return file === expectedPath;
+  const [prefix, suffix] = expectedPath.split('*');
+  return file.startsWith(prefix ?? '') && file.endsWith(suffix ?? '');
+}
+
+function validatePackedDependencies(
+  manifest: PackageManifest,
+  packagesByName: ReadonlyMap<string, PublicationPackage>,
+): void {
+  for (const field of runtimeDependencyFields) {
+    for (const [name, reference] of Object.entries(manifest[field] ?? {})) {
+      const plannedVersion = packagesByName.get(name)?.manifest.version;
+      if (plannedVersion && !matchesPlannedVersion(reference, plannedVersion)) {
+        throw new Error(
+          `Packed ${manifest.name} has inconsistent release dependency ${name}@${reference}`,
+        );
+      }
+      if (
+        !packagesByName.has(name) &&
+        typeof reference === 'string' &&
+        !semverRange.test(reference)
+      ) {
+        throw new Error(`Packed ${manifest.name} has invalid external range ${name}@${reference}`);
+      }
+    }
+  }
+}
+
+function matchesPlannedVersion(reference: string, version: string): boolean {
+  return reference === version || reference === `^${version}` || reference === `~${version}`;
+}
+
+function packageEntryTargets(manifest: PackageManifest): string[] {
+  return exportTargets(manifest.exports).concat(
+    exportTargets(manifest.imports),
+    binTargets(manifest.bin),
+  );
+}
+
+function exportTargets(value: unknown): string[] {
+  if (typeof value === 'string') return [value];
+  if (!value || typeof value !== 'object') return [];
+  return Object.values(value).flatMap(exportTargets);
+}
+
+function binTargets(bin: PackageManifest['bin']): string[] {
+  if (typeof bin === 'string') return [bin];
+  return Object.values(bin ?? {});
+}
+
+export function findUnsupportedProtocol(value: unknown, path = 'package.json'): string | undefined {
+  if (typeof value === 'string') {
+    return value.startsWith('catalog:') || value.startsWith('workspace:') ? path : undefined;
+  }
+  if (!value || typeof value !== 'object') return undefined;
+  for (const [key, child] of Object.entries(value as JsonRecord)) {
+    const found = findUnsupportedProtocol(child, `${path}.${key}`);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+function execFileText(command: string, args: string[]): Promise<string> {
+  return new Promise((resolvePromise, reject) => {
+    execFile(command, args, (error, stdout, stderr) => {
+      if (error)
+        reject(new Error(`${command} ${args.join(' ')} failed: ${stderr || error.message}`));
+      else resolvePromise(stdout);
+    });
+  });
+}
+
+function safePackageName(name: string): string {
+  return name.replace('@shipfox/', '').replaceAll('/', '-');
+}
+
+async function main() {
+  await preflightPublicationClosure(getRepositoryRoot(import.meta.url));
+}
+
+const entryPoint = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : undefined;
+if (entryPoint === import.meta.url) {
+  main().catch((error) => {
+    process.stderr.write(
+      `Publication preflight failed: ${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  });
+}

--- a/tools/package-release/src/publish-productionized-closure.ts
+++ b/tools/package-release/src/publish-productionized-closure.ts
@@ -4,15 +4,21 @@ import {constants} from 'node:os';
 import {join, resolve} from 'node:path';
 import {fileURLToPath, pathToFileURL} from 'node:url';
 
-import {productionizeManifest} from '@shipfox/tool-utils';
+import {productionizePackageManifest} from './productionized-manifest-packer.js';
 
 type JsonRecord = Record<string, unknown>;
+const packageNamePattern = /^@shipfox\/[a-z0-9][a-z0-9._-]*$/u;
 
 interface PublishProductionizedClosureOptions<T> {
   onPrepared?: (restore: () => void) => void;
   packageNames: string[];
   publish: () => Promise<T> | T;
   root: string;
+}
+
+export interface PublicationClosureConfig {
+  packages: string[];
+  roots: string[];
 }
 
 export function findClosureManifests(root: string, packageNames: string[]): string[] {
@@ -40,12 +46,36 @@ export function findPublishableToolManifests(root: string): string[] {
   });
 }
 
-function productionizePublishManifest(manifest: JsonRecord): JsonRecord {
-  const productionized = productionizeManifest(manifest);
-  if (!('devDependencies' in productionized)) return productionized;
+export function loadPublicationClosure(root: string): PublicationClosureConfig {
+  const closurePath = join(root, 'publication-closure.json');
+  let config: unknown;
+  try {
+    config = JSON.parse(readFileSync(closurePath, 'utf8'));
+  } catch (error) {
+    throw new Error(`Could not read publication closure at ${closurePath}: ${String(error)}`);
+  }
+  if (!isClosureConfig(config)) {
+    throw new Error(`Invalid publication closure config at ${closurePath}`);
+  }
+  return config;
+}
 
-  const {devDependencies: _, ...publishManifest} = productionized;
-  return publishManifest;
+export function resolvePublicationManifests(root: string, packageNames: string[]): string[] {
+  const manifestPaths = [
+    ...findClosureManifests(root, packageNames),
+    ...findPublishableToolManifests(root),
+  ];
+  const names = new Set<string>();
+  for (const manifestPath of manifestPaths) {
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as JsonRecord;
+    if (typeof manifest.name !== 'string') {
+      throw new Error(`Publishable package has no name: ${manifestPath}`);
+    }
+    if (names.has(manifest.name))
+      throw new Error(`Duplicate publication package: ${manifest.name}`);
+    names.add(manifest.name);
+  }
+  return manifestPaths;
 }
 
 export async function publishProductionizedClosure<T>({
@@ -54,10 +84,7 @@ export async function publishProductionizedClosure<T>({
   publish,
   onPrepared,
 }: PublishProductionizedClosureOptions<T>): Promise<T> {
-  const manifestPaths = [
-    ...findClosureManifests(root, packageNames),
-    ...findPublishableToolManifests(root),
-  ];
+  const manifestPaths = resolvePublicationManifests(root, packageNames);
   const originalManifests = new Map(
     manifestPaths.map((manifestPath) => [manifestPath, readFileSync(manifestPath, 'utf8')]),
   );
@@ -69,7 +96,7 @@ export async function publishProductionizedClosure<T>({
 
   for (const [manifestPath, originalManifest] of originalManifests) {
     const manifest = JSON.parse(originalManifest) as JsonRecord;
-    const productionized = productionizePublishManifest(manifest);
+    const productionized = productionizePackageManifest(manifest);
     if (productionized === manifest) continue;
     writeFileSync(manifestPath, `${JSON.stringify(productionized, null, 2)}\n`);
   }
@@ -97,10 +124,7 @@ export function getRepositoryRoot(entryPoint: string): string {
 
 async function main() {
   const repositoryRoot = getRepositoryRoot(import.meta.url);
-  const closurePath = join(repositoryRoot, 'publication-closure.json');
-  const {packages: packageNames} = JSON.parse(readFileSync(closurePath, 'utf8')) as {
-    packages: string[];
-  };
+  const {packages: packageNames} = loadPublicationClosure(repositoryRoot);
   let restore: (() => void) | undefined;
   let stopPublish: (() => void) | undefined;
   const stop = (signal: NodeJS.Signals) => {
@@ -128,6 +152,21 @@ async function main() {
     process.removeListener('SIGINT', stop);
     process.removeListener('SIGTERM', stop);
   }
+}
+
+function isClosureConfig(value: unknown): value is PublicationClosureConfig {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return isPackageList(record.roots) && isPackageList(record.packages);
+}
+
+function isPackageList(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every((name) => typeof name === 'string' && packageNamePattern.test(name)) &&
+    new Set(value).size === value.length
+  );
 }
 
 const entryPoint = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : undefined;

--- a/tools/package-release/test/productionized-manifest-packer.test.ts
+++ b/tools/package-release/test/productionized-manifest-packer.test.ts
@@ -72,6 +72,36 @@ test('packs a staged production manifest without changing the source package', a
   assert.equal(await readFile(join(sourceDirectory, 'package.json'), 'utf8'), sourceManifest);
 });
 
+test('removes test-only internal imports from production manifests', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'shipfox-productionized-manifest-packer-'));
+  roots.push(root);
+  const sourceDirectory = join(root, 'source');
+  const stagingRoot = join(root, 'staging');
+  await mkdir(sourceDirectory, {recursive: true});
+  await mkdir(stagingRoot, {recursive: true});
+  await Promise.all([
+    writeFile(join(sourceDirectory, 'dist.js'), 'export {};'),
+    writeFile(
+      join(sourceDirectory, 'package.json'),
+      JSON.stringify({name: '@shipfox/example', imports: {'#test/*': './test/*'}}),
+    ),
+  ]);
+
+  const result = await packProductionizedPackage({
+    dependencyContext: {workspaceConfig: {}, workspaceVersions: new Map()},
+    manifest: {name: '@shipfox/example'},
+    packArtifact: async (stagedDirectory) =>
+      JSON.parse(await readFile(join(stagedDirectory, 'package.json'), 'utf8')) as Record<
+        string,
+        unknown
+      >,
+    sourceDirectory,
+    stagingRoot,
+  });
+
+  assert.deepEqual(result.imports, {});
+});
+
 async function pathExists(path: string): Promise<boolean> {
   try {
     await access(path);

--- a/tools/package-release/test/publication-preflight.test.ts
+++ b/tools/package-release/test/publication-preflight.test.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import {mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+
+import {preflightPublicationClosure} from '../src/publication-preflight.js';
+
+const roots: string[] = [];
+const missingEntryPointError = /missing entry point/u;
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, {force: true, recursive: true});
+});
+
+test('packs the complete closure without changing source manifests', async () => {
+  const root = createFixture();
+  const manifestPath = join(root, 'libs', 'example', 'package.json');
+  const sourceManifest = readFileSync(manifestPath, 'utf8');
+
+  await preflightPublicationClosure(root);
+
+  assert.equal(readFileSync(manifestPath, 'utf8'), sourceManifest);
+});
+
+test('cleans temporary staging and preserves source manifests when packing fails', async () => {
+  const root = createFixture({includeEntryPoint: false});
+  const manifestPath = join(root, 'libs', 'example', 'package.json');
+  const sourceManifest = readFileSync(manifestPath, 'utf8');
+
+  await assert.rejects(preflightPublicationClosure(root), missingEntryPointError);
+
+  assert.equal(readFileSync(manifestPath, 'utf8'), sourceManifest);
+});
+
+test('rejects a packed package with a missing bin entry point', async () => {
+  const root = createFixture({bin: './bin/cli.js'});
+
+  await assert.rejects(preflightPublicationClosure(root), missingEntryPointError);
+});
+
+function createFixture({
+  bin,
+  includeEntryPoint = true,
+}: {
+  bin?: string | Record<string, string>;
+  includeEntryPoint?: boolean;
+} = {}) {
+  const root = mkdtempSync(join(tmpdir(), 'shipfox-publication-preflight-test-'));
+  roots.push(root);
+  const packageDirectory = join(root, 'libs', 'example');
+  mkdirSync(join(packageDirectory, 'dist'), {recursive: true});
+  writeFileSync(join(root, 'pnpm-workspace.yaml'), 'packages:\n  - libs/*\n');
+  writeFileSync(
+    join(root, 'publication-closure.json'),
+    `${JSON.stringify({roots: ['@shipfox/example'], packages: ['@shipfox/example']}, null, 2)}\n`,
+  );
+  writeFileSync(
+    join(packageDirectory, 'package.json'),
+    `${JSON.stringify(
+      {
+        name: '@shipfox/example',
+        version: '1.0.0',
+        bin,
+        exports: {'.': './dist/index.js'},
+        imports: {'#*': './dist/*'},
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  if (includeEntryPoint) writeFileSync(join(packageDirectory, 'dist', 'index.js'), 'export {};\n');
+  return root;
+}


### PR DESCRIPTION
Add a release preflight that stages and packs every declared public package and tool before registry publication.

Release failures such as unresolved workspace references, private runtime dependencies, productionized manifest drift, or missing exported and CLI entry points previously surfaced only during the publish job. The preflight exercises the same closure discovery and productionization path without modifying source manifests or requiring npm write credentials.

The preflight runs in read-only CI and documents the boundary between local packing validation and registry publication guarantees.

Closes ENG-1166

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a publication preflight that stages and packs the full release closure before registry upload to catch broken manifests, invalid refs, and missing entry points early. Runs in read-only CI and uses the same closure discovery and productionization as the real publisher (ENG-1166).

- **New Features**
  - Add `release:preflight` at the root and `preflight` in `@shipfox/package-release`.
  - Load `publication-closure.json`, resolve all public packages and tools once, build artifacts, productionize manifests, and pack to temp dirs without touching source or needing npm creds.
  - Validate packed manifests for `workspace:`/`catalog:` refs, private runtime deps, missing export/bin files, inconsistent intra-closure versions, and invalid external ranges.
  - Add CI job “Package publication preflight” to run `pnpm run release:preflight`.
  - Update README with what preflight proves vs. what only real publication proves.

- **Refactors**
  - Introduce `productionizePackageManifest` and share `loadPublicationClosure` and `resolvePublicationManifests` between preflight and publisher.
  - Publisher now uses the shared productionization, including stripping dev deps and test-only `imports` (e.g., `#test/*`).
  - Add tests for preflight cleanup/no mutation and manifest productionization behavior.

<sup>Written for commit 4c0fefbffa453123ecc41247d4bae43096afd90e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

