### PR TITLE
Generalize release verification contracts

### DIFF
--- a/.changeset/steady-foxes-verify.md
+++ b/.changeset/steady-foxes-verify.md
@@ -1,0 +1,9 @@
+---
+"@shipfox/api-definitions": patch
+"@shipfox/api-email-challenges": patch
+"@shipfox/api-runners": patch
+"@shipfox/api-server": patch
+"@shipfox/application-release": patch
+---
+
+Improves release verification with owner-defined packed contracts, discovery-driven artifact checks, and an early publication preflight.

--- a/libs/api/definitions/test/published/workflow-source-bundle.mjs
+++ b/libs/api/definitions/test/published/workflow-source-bundle.mjs
@@ -1,0 +1,17 @@
+delete process.env.NODE_ENV;
+
+const {createRequire} = await import('node:module');
+const {fileURLToPath} = await import('node:url');
+const {dirname, join} = await import('node:path');
+const temporalRequire = createRequire(import.meta.resolve('@shipfox/node-temporal'));
+const {bundleWorkflowCode} = await import(temporalRequire.resolve('@temporalio/worker'));
+const packageEntryPoint = fileURLToPath(import.meta.resolve('@shipfox/api-definitions'));
+const workflowsPath = join(
+  dirname(dirname(packageEntryPoint)),
+  'dist',
+  'temporal',
+  'workflows',
+  'index.js',
+);
+
+await bundleWorkflowCode({workflowsPath});

--- a/libs/api/email-challenges/test/published/continuation-contract.mjs
+++ b/libs/api/email-challenges/test/published/continuation-contract.mjs
@@ -1,0 +1,12 @@
+const {createEmailChallenge, getEmailChallengeContinuation} = await import(
+  '@shipfox/api-email-challenges'
+);
+
+if (
+  typeof createEmailChallenge !== 'function' ||
+  typeof getEmailChallengeContinuation !== 'function'
+) {
+  throw new Error(
+    'Packed email challenges package does not export retry-safe continuation contracts.',
+  );
+}

--- a/libs/api/runners/test/published/composition.mjs
+++ b/libs/api/runners/test/published/composition.mjs
@@ -1,0 +1,13 @@
+const {createRunnersModule} = await import('@shipfox/api-runners');
+const module = createRunnersModule({
+  auth: {},
+  installationProvisioning: {
+    policy: {
+      filterEligibleWorkspaceIds: async (workspaceIds) => new Set(workspaceIds),
+    },
+  },
+});
+
+if (module.name !== 'runners' || !module.routes?.length) {
+  throw new Error('Packed API runners does not compose the installation provisioning policy.');
+}

--- a/libs/api/runners/test/published/composition.ts
+++ b/libs/api/runners/test/published/composition.ts
@@ -1,0 +1,14 @@
+import type {AuthInterModuleClient} from '@shipfox/api-auth-dto/inter-module';
+import {createRunnersModule} from '@shipfox/api-runners';
+
+const auth = {} as AuthInterModuleClient;
+const module = createRunnersModule({
+  auth,
+  installationProvisioning: {
+    policy: {
+      filterEligibleWorkspaceIds: async (workspaceIds) => new Set(workspaceIds),
+    },
+  },
+});
+
+void module;

--- a/libs/api/server/src/auth-token-interoperability.test.ts
+++ b/libs/api/server/src/auth-token-interoperability.test.ts
@@ -48,5 +48,5 @@ describe('Auth token interoperability', () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual({job_id: jobId, step_id: stepId});
-  });
+  }, 15_000);
 });

--- a/libs/api/server/test/published/_environment.mjs
+++ b/libs/api/server/test/published/_environment.mjs
@@ -1,0 +1,61 @@
+export function publishedTestEnvironment() {
+  // Use the active workspace's isolated Postgres instead of a fixed CI port, which
+  // could point at an unrelated local database when this contract runs in a worktree.
+  const postgresHost = process.env.POSTGRES_HOST ?? '127.0.0.1';
+  const postgresPort = process.env.POSTGRES_PORT ?? '5432';
+  const postgresUsername = process.env.POSTGRES_USERNAME ?? 'shipfox';
+  const postgresPassword = process.env.POSTGRES_PASSWORD ?? 'password';
+  const postgresDatabase = 'api_test';
+
+  return {
+    AUTH_ROOT_KEY: 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=',
+    DATABASE_URL: `postgres://${postgresUsername}:${postgresPassword}@${postgresHost}:${postgresPort}/${postgresDatabase}`,
+    GITEA_BASE_URL: 'https://gitea.example.com',
+    GITEA_SERVICE_TOKEN: 'external-consumer-token',
+    GITEA_SERVICE_USERNAME: 'shipfox-bot',
+    GITEA_WEBHOOK_SECRET: 'external-consumer-webhook-secret',
+    GITHUB_API_BASE_URL: 'https://api.github.com',
+    GITHUB_APP_CLIENT_ID: 'external-consumer-client-id',
+    GITHUB_APP_CLIENT_SECRET: 'external-consumer-client-secret',
+    GITHUB_APP_ID: '1',
+    GITHUB_APP_PRIVATE_KEY: 'external-consumer-private-key',
+    GITHUB_APP_SLUG: 'shipfox-external-consumer',
+    GITHUB_APP_USERNAME: 'shipfox-external-consumer',
+    GITHUB_APP_WEBHOOK_SECRET: 'external-consumer-webhook-secret',
+    GITHUB_INSTALL_STATE_SECRET: 'external-consumer-install-state-secret',
+    JIRA_OAUTH_CLIENT_ID: 'external-consumer-client-id',
+    JIRA_OAUTH_CLIENT_SECRET: 'external-consumer-client-secret',
+    JIRA_OAUTH_REDIRECT_URL: 'https://shipfox.example.com/integrations/jira/callback',
+    JIRA_WEBHOOK_BASE_URL: 'https://shipfox.example.com',
+    JIRA_WEBHOOK_SIGNING_SECRET: 'external-consumer-webhook-secret',
+    LINEAR_MCP_ENDPOINT: 'https://mcp.linear.app/mcp',
+    LINEAR_OAUTH_CLIENT_ID: 'external-consumer-client-id',
+    LINEAR_OAUTH_CLIENT_SECRET: 'external-consumer-client-secret',
+    LINEAR_OAUTH_REDIRECT_URL: 'https://shipfox.example.com/integrations/linear/callback',
+    LINEAR_WEBHOOK_SIGNING_SECRET: 'external-consumer-webhook-secret',
+    SLACK_API_BASE_URL: 'https://slack.example.com/api',
+    SLACK_OAUTH_CLIENT_ID: 'external-consumer-client-id',
+    SLACK_OAUTH_CLIENT_SECRET: 'external-consumer-client-secret',
+    SLACK_OAUTH_REDIRECT_URL: 'https://shipfox.example.com/integrations/slack/callback',
+    SLACK_SIGNING_SECRET: 'external-consumer-signing-secret',
+    LOG_STORAGE_S3_ACCESS_KEY_ID: 'external-consumer-access-key',
+    LOG_STORAGE_S3_BUCKET: 'shipfox-logs',
+    LOG_STORAGE_S3_ENDPOINT: 'http://127.0.0.1:3900',
+    LOG_STORAGE_S3_FORCE_PATH_STYLE: 'true',
+    LOG_STORAGE_S3_REGION: 'garage',
+    LOG_STORAGE_S3_SECRET_ACCESS_KEY: 'external-consumer-secret-key',
+    POSTGRES_DATABASE: postgresDatabase,
+    POSTGRES_HOST: postgresHost,
+    POSTGRES_MAX_CONNECTIONS: '5',
+    POSTGRES_PASSWORD: postgresPassword,
+    POSTGRES_PORT: postgresPort,
+    POSTGRES_USERNAME: postgresUsername,
+    SECRETS_ENCRYPTION_KEK: 'ZmVkY2JhOTg3NjU0MzIxMGZlZGNiYTk4NzY1NDMyMTA=',
+    SENTRY_APP_CLIENT_ID: 'external-consumer-client-id',
+    SENTRY_APP_CLIENT_SECRET: 'external-consumer-client-secret',
+    SENTRY_APP_SLUG: 'shipfox-external-consumer',
+    SENTRY_APP_VERIFY_INSTALL: 'true',
+    TEMPORAL_ADDRESS: '127.0.0.1:7233',
+    WORKSPACE_JWT_SECRET: 'external-consumer-workspace-secret',
+  };
+}

--- a/libs/api/server/test/published/composition.ts
+++ b/libs/api/server/test/published/composition.ts
@@ -1,0 +1,19 @@
+import {createRunnersModule} from '@shipfox/api-runners';
+import {createServer, defaultModules} from '@shipfox/api-server';
+
+void createServer({
+  modules: [
+    ...(await defaultModules({
+      runnersModule: ({auth}) =>
+        createRunnersModule({
+          auth,
+          installationProvisioning: {
+            policy: {
+              filterEligibleWorkspaceIds: async (workspaceIds) => new Set(workspaceIds),
+            },
+          },
+        }),
+    })),
+    {name: 'external-dummy'},
+  ],
+});

--- a/libs/api/server/test/published/development-conditions.development.mjs
+++ b/libs/api/server/test/published/development-conditions.development.mjs
@@ -1,0 +1,3 @@
+await import('@shipfox/api-server/instrumentation');
+
+process.exit(0);

--- a/libs/api/server/test/published/login-methods-route.mjs
+++ b/libs/api/server/test/published/login-methods-route.mjs
@@ -1,0 +1,22 @@
+const {loginMethodsResponseSchema} = await import('@shipfox/api-auth-dto');
+const {createLoginMethodsRoute} = await import('@shipfox/api-server');
+const {createApp} = await import('@shipfox/node-fastify');
+
+const app = await createApp({
+  auth: [],
+  routes: [createLoginMethodsRoute({loginMethods: [{id: 'external-provider'}]})],
+  swagger: false,
+});
+
+try {
+  const response = await app.inject({method: 'GET', url: '/auth/login-methods'});
+  if (response.statusCode !== 200) {
+    throw new Error('Packed login-method catalog route did not respond.');
+  }
+  const body = loginMethodsResponseSchema.parse(response.json());
+  if (body.login_methods[0]?.id !== 'external-provider') {
+    throw new Error('Packed login-method catalog route returned an unexpected contract.');
+  }
+} finally {
+  await app.close();
+}

--- a/libs/api/server/test/published/workflow-bundles.mjs
+++ b/libs/api/server/test/published/workflow-bundles.mjs
@@ -1,0 +1,50 @@
+process.env.INTEGRATIONS_ENABLE_SENTRY_PROVIDER = 'true';
+process.env.NODE_ENV = 'production';
+
+const {readdir, readFile} = await import('node:fs/promises');
+const {dirname, join} = await import('node:path');
+const {defaultModules} = await import('@shipfox/api-server');
+const {loadProductionWorkflowBundle} = await import('@shipfox/node-temporal');
+const modules = await defaultModules();
+const workflowPaths = new Set(
+  modules.flatMap((module) => module.workers ?? []).map((worker) => worker.workflowsPath),
+);
+
+if (!workflowPaths.size) throw new Error('Packed API server declares no workflow entrypoints.');
+
+const bundles = new Map();
+for (const workflowsPath of workflowPaths) {
+  const workflowBundle = loadProductionWorkflowBundle(workflowsPath);
+  bundles.set(workflowsPath, workflowBundle);
+
+  const code = await readFile(workflowBundle.codePath, 'utf8');
+  if (/@shipfox[/\\][^/\\]+[/\\]src[/\\]/u.test(code)) {
+    throw new Error(`Workflow bundle for ${workflowsPath} resolved a first-party source path.`);
+  }
+}
+
+const declaredCodePaths = new Set([...bundles.values()].map(({codePath}) => codePath));
+if (declaredCodePaths.size !== workflowPaths.size) {
+  throw new Error('Packed API workflow entrypoints do not map one-to-one to prebuilt bundles.');
+}
+
+const workflowDirectories = new Set(
+  [...workflowPaths].map((workflowsPath) => dirname(workflowsPath)),
+);
+const emittedBundles = (
+  await Promise.all(
+    [...workflowDirectories].map(async (directory) =>
+      (
+        await readdir(directory)
+      )
+        .filter((entry) => entry.endsWith('.bundle.js'))
+        .map((entry) => join(directory, entry)),
+    ),
+  )
+).flat();
+const unreferencedBundles = emittedBundles.filter((codePath) => !declaredCodePaths.has(codePath));
+if (unreferencedBundles.length) {
+  throw new Error(
+    `Packed API contains unreferenced workflow bundles: ${unreferencedBundles.join(', ')}`,
+  );
+}

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "check:lockfile": "turbo build --filter=@shipfox/dependency-policy && pnpm --filter=@shipfox/dependency-policy verify:lockfile",
     "check:published-artifacts": "turbo verify --filter=@shipfox/package-release",
     "fix:dependencies": "pnpm --filter=@shipfox/dependency-policy fix",
-    "release:publish": "turbo type build type:emit --filter='./libs/**' --filter='./tools/**' && pnpm --filter=@shipfox/package-release publish:closure",
     "release:preflight": "turbo type build type:emit --filter='./libs/**' --filter='./tools/**' && pnpm --filter=@shipfox/package-release preflight",
+    "release:publish": "pnpm run release:preflight && pnpm --filter=@shipfox/package-release publish:closure",
     "test:external": "turbo test:external",
     "verify": "turbo verify"
   },

--- a/tools/application-release/README.md
+++ b/tools/application-release/README.md
@@ -64,6 +64,12 @@ dependency. The API gate packs the Node-composed API closure, and the client gat
 browser client closure before building a Vite consumer. Together they install all tarballs in a
 temporary consumer outside the workspace and resolve public declaration and runtime entry points.
 
+Packages can add packed-consumer checks under `test/published/`. The API gate discovers these
+files from the publication closure: `.ts` files are type-checked, `.mjs` files are executed, and
+`.development.mjs` files run with Node's `development` condition. The API server owns the single
+`_environment.mjs` provider used by runtime checks. This keeps feature contracts beside their
+owners without adding a central package or entry-point list to the release tool.
+
 Each image has a repository, digest, platform list, and attestation state. The
 image build does not publish provenance or a software bill of materials (SBOM)
 today. Both fields use `status: not-published` until those OCI artifacts exist.
@@ -91,7 +97,9 @@ turbo check --filter=@shipfox/application-release
 turbo type --filter=@shipfox/application-release
 turbo test --filter=@shipfox/application-release
 turbo build --filter=@shipfox/application-release
+turbo verify --filter=@shipfox/application-release
 turbo test:external --filter=@shipfox/application-release --filter=@shipfox/client-shell --concurrency=1
+pnpm run release:preflight
 ```
 
 ## License

--- a/tools/application-release/package.json
+++ b/tools/application-release/package.json
@@ -24,7 +24,8 @@
     "test": "pnpm run build && node --test test/*.test.mjs",
     "test:external": "node test/external/verify.mjs",
     "type": "shipfox-tsc-check",
-    "type:emit": "shipfox-tsc-emit"
+    "type:emit": "shipfox-tsc-emit",
+    "verify": "node dist/verify-publication-closure.js"
   },
   "dependencies": {
     "ajv": "catalog:",

--- a/tools/application-release/src/verify-publication-closure.ts
+++ b/tools/application-release/src/verify-publication-closure.ts
@@ -1,0 +1,46 @@
+import {existsSync} from 'node:fs';
+import {dirname, join, resolve} from 'node:path';
+import {fileURLToPath, pathToFileURL} from 'node:url';
+
+import {
+  createApplicationReleasePackages,
+  readPublicationClosureConfig,
+  readWorkspacePackages,
+} from './package-closure.js';
+
+export function verifyPublicationClosure(repositoryRoot: string): number {
+  const config = readPublicationClosureConfig(join(repositoryRoot, 'publication-closure.json'));
+  const packages = createApplicationReleasePackages(
+    readWorkspacePackages(repositoryRoot),
+    config,
+    repositoryRoot,
+  );
+  return packages.length;
+}
+
+function repositoryRootFromEntryPoint(entryPoint: string): string {
+  let directory = dirname(fileURLToPath(entryPoint));
+  while (true) {
+    if (existsSync(join(directory, 'publication-closure.json'))) return directory;
+    const parent = dirname(directory);
+    if (parent === directory) {
+      throw new Error('Could not find publication-closure.json above the package entrypoint');
+    }
+    directory = parent;
+  }
+}
+
+function main() {
+  const count = verifyPublicationClosure(repositoryRootFromEntryPoint(import.meta.url));
+  process.stdout.write(`Validated a ${count}-package application publication closure.\n`);
+}
+
+const entryPoint = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : undefined;
+if (entryPoint === import.meta.url) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`${String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/tools/application-release/test/external/verify.mjs
+++ b/tools/application-release/test/external/verify.mjs
@@ -1,7 +1,8 @@
+import {globSync} from 'node:fs';
 import {mkdir, mkdtemp, readdir, readFile, realpath, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
-import {join, resolve} from 'node:path';
-import {fileURLToPath} from 'node:url';
+import {basename, extname, join, resolve} from 'node:path';
+import {fileURLToPath, pathToFileURL} from 'node:url';
 import {mapWithConcurrency, packProductionizedPackage, run} from '@shipfox/package-release/packer';
 import {parse as parseYaml} from 'yaml';
 
@@ -65,7 +66,16 @@ try {
   const typeEntryPoints = entryPoints
     .filter(({target}) => entryPointSupportsTypeResolution(target))
     .map(({specifier}) => specifier);
-  await writeFixtureFiles(fixtureRoot, dependencies, runtimeEntryPoints, typeEntryPoints);
+  const publishedScenarios = listPublishedScenarios(closure, workspacePackages);
+  const publishedEnvironment = await readPublishedTestEnvironment(closure, workspacePackages);
+  const fixtureScenarios = await writeFixtureFiles(
+    fixtureRoot,
+    dependencies,
+    runtimeEntryPoints,
+    typeEntryPoints,
+    publishedScenarios,
+    publishedEnvironment,
+  );
   await run('pnpm', ['install', '--prefer-offline', '--ignore-scripts'], fixtureRoot);
   await validateInstalledPackages(fixtureRoot, closure, workspacePackages);
   await validateNoRegistryShipfoxPackages(fixtureRoot);
@@ -73,21 +83,33 @@ try {
   const tsc = resolve(repositoryRoot, 'tools/typescript/node_modules/typescript/bin/tsc');
   await run(process.execPath, [tsc, '--project', 'tsconfig.json'], fixtureRoot);
   await run(process.execPath, ['runtime-imports.mjs'], fixtureRoot);
-  await run(process.execPath, ['email-challenge-contract.mjs'], fixtureRoot);
-  await run(process.execPath, ['login-methods-route.mjs'], fixtureRoot);
-  await run(process.execPath, ['runners-composition.mjs'], fixtureRoot);
-  await run(process.execPath, ['workflow-source-bundle.mjs'], fixtureRoot);
-  await run(
-    resolve(repositoryRoot, 'tools/application-release/node_modules/.bin/tsx'),
-    ['--conditions=development', 'development-conditions.mjs'],
-    fixtureRoot,
-  );
-  await run(process.execPath, ['workflow-bundles.mjs'], fixtureRoot);
+  for (const scenario of fixtureScenarios.filter(({extension}) => extension === '.mjs')) {
+    const args = scenario.developmentCondition
+      ? ['--conditions=development', scenario.fixtureName]
+      : [scenario.fixtureName];
+    await run(process.execPath, args, fixtureRoot);
+  }
 } finally {
   await rm(fixtureRoot, {recursive: true, force: true});
 }
 
-async function writeFixtureFiles(root, dependencies, runtimeEntryPoints, typeEntryPoints) {
+async function writeFixtureFiles(
+  root,
+  dependencies,
+  runtimeEntryPoints,
+  typeEntryPoints,
+  publishedScenarios,
+  environment,
+) {
+  const fixtureScenarios = publishedScenarios.map(({packageName, sourcePath}) => {
+    const fixtureName = `${safePackageName(packageName)}-${basename(sourcePath)}`;
+    return {
+      developmentCondition: fixtureName.endsWith('.development.mjs'),
+      extension: extname(fixtureName),
+      fixtureName,
+      sourcePath,
+    };
+  });
   await Promise.all([
     writeFile(
       join(root, 'package.json'),
@@ -121,7 +143,12 @@ async function writeFixtureFiles(root, dependencies, runtimeEntryPoints, typeEnt
             strict: true,
             target: 'ES2024',
           },
-          include: ['types.ts', 'composition.ts', 'runners-composition.ts'],
+          include: [
+            'types.ts',
+            ...fixtureScenarios
+              .filter(({extension}) => extension === '.ts')
+              .map(({fixtureName}) => fixtureName),
+          ],
         },
         null,
         2,
@@ -138,98 +165,49 @@ async function writeFixtureFiles(root, dependencies, runtimeEntryPoints, typeEnt
         )}\n\n${typeEntryPoints.map((_, index) => `void (0 as unknown as typeof Entry${index});`).join('\n')}\n`,
     ),
     writeFile(
-      join(root, 'composition.ts'),
-      `import {createRunnersModule} from '@shipfox/api-runners';
-import {createServer, defaultModules} from '@shipfox/api-server';
-
-void createServer({
-  modules: [
-    ...(await defaultModules({
-      runnersModule: ({auth}) =>
-        createRunnersModule({
-          auth,
-          installationProvisioning: {
-            policy: {
-              filterEligibleWorkspaceIds: async (workspaceIds) => new Set(workspaceIds),
-            },
-          },
-        }),
-    })),
-    {name: 'external-dummy'},
-  ],
-});
-`,
-    ),
-    writeFile(
-      join(root, 'runners-composition.ts'),
-      `import {createRunnersModule} from '@shipfox/api-runners';
-import type {AuthInterModuleClient} from '@shipfox/api-auth-dto/inter-module';
-
-const auth = {} as AuthInterModuleClient;
-const module = createRunnersModule({
-  auth,
-  installationProvisioning: {
-    policy: {
-      filterEligibleWorkspaceIds: async (workspaceIds) => new Set(workspaceIds),
-    },
-  },
-});
-
-void module;
-`,
-    ),
-    writeFile(
-      join(root, 'email-challenge-contract.mjs'),
-      `Object.assign(process.env, ${JSON.stringify(runtimeEnvironment(), null, 2)});\n\nconst {createEmailChallenge, getEmailChallengeContinuation} = await import('@shipfox/api-email-challenges');\nif (typeof createEmailChallenge !== 'function' || typeof getEmailChallengeContinuation !== 'function') {\n  throw new Error('Packed email challenges package does not export retry-safe continuation contracts.');\n}\nconsole.log('Imported packed retry-safe email challenge continuation contracts.');\n`,
-    ),
-    writeFile(
-      join(root, 'runners-composition.mjs'),
-      `Object.assign(process.env, ${JSON.stringify(runtimeEnvironment(), null, 2)});\n\nconst {createRunnersModule} = await import('@shipfox/api-runners');\nconst module = createRunnersModule({\n  auth: {},\n  installationProvisioning: {\n    policy: {\n      filterEligibleWorkspaceIds: async (workspaceIds) => new Set(workspaceIds),\n    },\n  },\n});\nif (module.name !== 'runners' || !module.routes?.length) {\n  throw new Error('Packed API runners does not compose the installation provisioning policy.');\n}\nconsole.log('Composed packed API runners with an external installation policy.');\n`,
-    ),
-    writeFile(
       join(root, 'runtime-imports.mjs'),
-      `Object.assign(process.env, ${JSON.stringify(runtimeEnvironment(), null, 2)});\n\nconst entryPoints = ${JSON.stringify(runtimeEntryPoints, null, 2)};\nfor (const entryPoint of entryPoints) await import(entryPoint);\nconst {createServer, defaultModules} = await import('@shipfox/api-server');\nif (typeof createServer !== 'function' || typeof defaultModules !== 'function')\n  throw new Error('Packed API server does not export its composition API.');\nconst modules = [...(await defaultModules()), {name: 'external-dummy'}];\nif (modules.at(-1)?.name !== 'external-dummy')\n  throw new Error('Could not append an external module to the packed API server defaults.');\nconsole.log(\`Imported \${entryPoints.length} packed runtime entry points and composed API modules.\`);\nprocess.exit(0);\n`,
+      `Object.assign(process.env, ${JSON.stringify(environment, null, 2)});\n\nconst entryPoints = ${JSON.stringify(runtimeEntryPoints, null, 2)};\nfor (const entryPoint of entryPoints) await import(entryPoint);\nconst {createServer, defaultModules} = await import('@shipfox/api-server');\nif (typeof createServer !== 'function' || typeof defaultModules !== 'function')\n  throw new Error('Packed API server does not export its composition API.');\nconst modules = [...(await defaultModules()), {name: 'external-dummy'}];\nif (modules.at(-1)?.name !== 'external-dummy')\n  throw new Error('Could not append an external module to the packed API server defaults.');\nconsole.log(\`Imported \${entryPoints.length} packed runtime entry points and composed API modules.\`);\nprocess.exit(0);\n`,
     ),
-    writeFile(
-      join(root, 'login-methods-route.mjs'),
-      `Object.assign(process.env, ${JSON.stringify(runtimeEnvironment(), null, 2)});
-
-const {loginMethodsResponseSchema} = await import('@shipfox/api-auth-dto');
-const {createLoginMethodsRoute} = await import('@shipfox/api-server');
-const {createApp} = await import('@shipfox/node-fastify');
-
-const app = await createApp({
-  auth: [],
-  routes: [createLoginMethodsRoute({loginMethods: [{id: 'external-provider'}]})],
-  swagger: false,
-});
-
-try {
-  const response = await app.inject({method: 'GET', url: '/auth/login-methods'});
-  if (response.statusCode !== 200) throw new Error('Packed login-method catalog route did not respond.');
-  const body = loginMethodsResponseSchema.parse(response.json());
-  if (body.login_methods[0]?.id !== 'external-provider')
-    throw new Error('Packed login-method catalog route returned an unexpected contract.');
-} finally {
-  await app.close();
+    ...fixtureScenarios.map(async ({extension, fixtureName, sourcePath}) => {
+      const source = await readFile(sourcePath, 'utf8');
+      const contents =
+        extension === '.mjs'
+          ? `Object.assign(process.env, ${JSON.stringify(environment, null, 2)});\n\n${source}`
+          : source;
+      await writeFile(join(root, fixtureName), contents);
+    }),
+  ]);
+  return fixtureScenarios;
 }
 
-console.log('Validated the packed login-method catalog DTO and route contract.');
-`,
-    ),
-    writeFile(
-      join(root, 'workflow-bundles.mjs'),
-      `Object.assign(process.env, {...${JSON.stringify(runtimeEnvironment(), null, 2)}, INTEGRATIONS_ENABLE_SENTRY_PROVIDER: 'true', NODE_ENV: 'production'});\n\nconst {readdir, readFile} = await import('node:fs/promises');\nconst {dirname, join} = await import('node:path');\nconst {defaultModules} = await import('@shipfox/api-server');\nconst {loadProductionWorkflowBundle} = await import('@shipfox/node-temporal');\nconst modules = await defaultModules();\nconst workflowPaths = new Set(\n  modules.flatMap((module) => module.workers ?? []).map((worker) => worker.workflowsPath),\n);\n\nif (!workflowPaths.size) throw new Error('Packed API server declares no workflow entrypoints.');\n\nconst bundles = new Map();\nfor (const workflowsPath of workflowPaths) {\n  const workflowBundle = loadProductionWorkflowBundle(workflowsPath);\n  bundles.set(workflowsPath, workflowBundle);\n\n  const code = await readFile(workflowBundle.codePath, 'utf8');\n  if (/@shipfox[/\\\\][^/\\\\]+[/\\\\]src[/\\\\]/u.test(code)) {\n    throw new Error(\n      \`Workflow bundle for \${workflowsPath} resolved a first-party source path.\`,\n    );\n  }\n}\n\nconst declaredCodePaths = new Set([...bundles.values()].map(({codePath}) => codePath));\nif (declaredCodePaths.size !== workflowPaths.size) {\n  throw new Error('Packed API workflow entrypoints do not map one-to-one to prebuilt bundles.');\n}\n\nconst workflowDirectories = new Set([...workflowPaths].map((workflowsPath) => dirname(workflowsPath)));\nconst emittedBundles = (\n  await Promise.all(\n    [...workflowDirectories].map(async (directory) =>\n      (await readdir(directory))\n        .filter((entry) => entry.endsWith('.bundle.js'))\n        .map((entry) => join(directory, entry)),\n    ),\n  )\n).flat();\nconst unreferencedBundles = emittedBundles.filter((codePath) => !declaredCodePaths.has(codePath));\nif (unreferencedBundles.length) {\n  throw new Error(\n    \`Packed API contains unreferenced workflow bundles: \${unreferencedBundles.join(', ')}\`,\n  );\n}\n\nconsole.log(\`Validated \${workflowPaths.size} packed API workflow bundles.\`);\n`,
-    ),
-    writeFile(
-      join(root, 'development-conditions.mjs'),
-      `Object.assign(process.env, ${JSON.stringify(runtimeEnvironment(), null, 2)});\n\nawait import('@shipfox/api-server/instrumentation');\nprocess.exit(0);\n`,
-    ),
-    writeFile(
-      join(root, 'workflow-source-bundle.mjs'),
-      `delete process.env.NODE_ENV;\n\nconst {createRequire} = await import('node:module');\nconst {fileURLToPath} = await import('node:url');\nconst {dirname, join} = await import('node:path');\nconst temporalRequire = createRequire(import.meta.resolve('@shipfox/node-temporal'));\nconst {bundleWorkflowCode} = await import(temporalRequire.resolve('@temporalio/worker'));\nconst packageEntryPoint = fileURLToPath(import.meta.resolve('@shipfox/api-definitions'));\nconst workflowsPath = join(\n  dirname(dirname(packageEntryPoint)),\n  'dist',\n  'temporal',\n  'workflows',\n  'index.js',\n);\n\nawait bundleWorkflowCode({workflowsPath});\nconsole.log('Bundled a packed API definitions workflow with Temporal defaults.');\n`,
-    ),
-  ]);
+function listPublishedScenarios(names, workspacePackages) {
+  return names.flatMap((packageName) => {
+    const workspacePackage = workspacePackages.get(packageName);
+    if (!workspacePackage) throw new Error(`Missing workspace package: ${packageName}`);
+    return globSync(join(workspacePackage.directory, 'test/published/*.{mjs,ts}'))
+      .filter((sourcePath) => !basename(sourcePath).startsWith('_'))
+      .sort()
+      .map((sourcePath) => ({packageName, sourcePath}));
+  });
+}
+
+async function readPublishedTestEnvironment(names, workspacePackages) {
+  const environmentPaths = names.flatMap((name) => {
+    const workspacePackage = workspacePackages.get(name);
+    if (!workspacePackage) throw new Error(`Missing workspace package: ${name}`);
+    return globSync(join(workspacePackage.directory, 'test/published/_environment.mjs'));
+  });
+  if (environmentPaths.length !== 1) {
+    throw new Error(
+      `Packed API verification requires exactly one environment provider; found ${environmentPaths.length}`,
+    );
+  }
+  const environmentModule = await import(pathToFileURL(environmentPaths[0]).href);
+  const environment = environmentModule.publishedTestEnvironment?.();
+  if (!environment || typeof environment !== 'object' || Array.isArray(environment)) {
+    throw new Error('Packed API environment provider must return an environment object');
+  }
+  return environment;
 }
 
 async function validateInstalledPackages(root, names, workspacePackages) {
@@ -277,70 +255,6 @@ function findWorkspaceRange(value, path = 'package.json') {
     if (found) return found;
   }
   return undefined;
-}
-
-function runtimeEnvironment() {
-  // Prefer the active workspace's own Postgres connection (e.g. a Conductor
-  // worktree's isolated instance) over the fixed port CI's dedicated service
-  // listens on, so this fixture never migrates or mutates an unrelated
-  // Postgres instance that happens to also be reachable on the CI default.
-  const postgresHost = process.env.POSTGRES_HOST ?? '127.0.0.1';
-  const postgresPort = process.env.POSTGRES_PORT ?? '5432';
-  const postgresUsername = process.env.POSTGRES_USERNAME ?? 'shipfox';
-  const postgresPassword = process.env.POSTGRES_PASSWORD ?? 'password';
-  const postgresDatabase = 'api_test';
-
-  return {
-    AUTH_ROOT_KEY: 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=',
-    DATABASE_URL: `postgres://${postgresUsername}:${postgresPassword}@${postgresHost}:${postgresPort}/${postgresDatabase}`,
-    GITEA_BASE_URL: 'https://gitea.example.com',
-    GITEA_SERVICE_TOKEN: 'external-consumer-token',
-    GITEA_SERVICE_USERNAME: 'shipfox-bot',
-    GITEA_WEBHOOK_SECRET: 'external-consumer-webhook-secret',
-    GITHUB_API_BASE_URL: 'https://api.github.com',
-    GITHUB_APP_CLIENT_ID: 'external-consumer-client-id',
-    GITHUB_APP_CLIENT_SECRET: 'external-consumer-client-secret',
-    GITHUB_APP_ID: '1',
-    GITHUB_APP_PRIVATE_KEY: 'external-consumer-private-key',
-    GITHUB_APP_SLUG: 'shipfox-external-consumer',
-    GITHUB_APP_USERNAME: 'shipfox-external-consumer',
-    GITHUB_APP_WEBHOOK_SECRET: 'external-consumer-webhook-secret',
-    GITHUB_INSTALL_STATE_SECRET: 'external-consumer-install-state-secret',
-    JIRA_OAUTH_CLIENT_ID: 'external-consumer-client-id',
-    JIRA_OAUTH_CLIENT_SECRET: 'external-consumer-client-secret',
-    JIRA_OAUTH_REDIRECT_URL: 'https://shipfox.example.com/integrations/jira/callback',
-    JIRA_WEBHOOK_BASE_URL: 'https://shipfox.example.com',
-    JIRA_WEBHOOK_SIGNING_SECRET: 'external-consumer-webhook-secret',
-    LINEAR_MCP_ENDPOINT: 'https://mcp.linear.app/mcp',
-    LINEAR_OAUTH_CLIENT_ID: 'external-consumer-client-id',
-    LINEAR_OAUTH_CLIENT_SECRET: 'external-consumer-client-secret',
-    LINEAR_OAUTH_REDIRECT_URL: 'https://shipfox.example.com/integrations/linear/callback',
-    LINEAR_WEBHOOK_SIGNING_SECRET: 'external-consumer-webhook-secret',
-    SLACK_API_BASE_URL: 'https://slack.example.com/api',
-    SLACK_OAUTH_CLIENT_ID: 'external-consumer-client-id',
-    SLACK_OAUTH_CLIENT_SECRET: 'external-consumer-client-secret',
-    SLACK_OAUTH_REDIRECT_URL: 'https://shipfox.example.com/integrations/slack/callback',
-    SLACK_SIGNING_SECRET: 'external-consumer-signing-secret',
-    LOG_STORAGE_S3_ACCESS_KEY_ID: 'external-consumer-access-key',
-    LOG_STORAGE_S3_BUCKET: 'shipfox-logs',
-    LOG_STORAGE_S3_ENDPOINT: 'http://127.0.0.1:3900',
-    LOG_STORAGE_S3_FORCE_PATH_STYLE: 'true',
-    LOG_STORAGE_S3_REGION: 'garage',
-    LOG_STORAGE_S3_SECRET_ACCESS_KEY: 'external-consumer-secret-key',
-    POSTGRES_DATABASE: postgresDatabase,
-    POSTGRES_HOST: postgresHost,
-    POSTGRES_MAX_CONNECTIONS: '5',
-    POSTGRES_PASSWORD: postgresPassword,
-    POSTGRES_PORT: postgresPort,
-    POSTGRES_USERNAME: postgresUsername,
-    SECRETS_ENCRYPTION_KEK: 'ZmVkY2JhOTg3NjU0MzIxMGZlZGNiYTk4NzY1NDMyMTA=',
-    SENTRY_APP_CLIENT_ID: 'external-consumer-client-id',
-    SENTRY_APP_CLIENT_SECRET: 'external-consumer-client-secret',
-    SENTRY_APP_SLUG: 'shipfox-external-consumer',
-    SENTRY_APP_VERIFY_INSTALL: 'true',
-    TEMPORAL_ADDRESS: '127.0.0.1:7233',
-    WORKSPACE_JWT_SECRET: 'external-consumer-workspace-secret',
-  };
 }
 
 function safePackageName(name) {

--- a/tools/application-release/test/package-closure.test.mjs
+++ b/tools/application-release/test/package-closure.test.mjs
@@ -1,21 +1,15 @@
 import assert from 'node:assert/strict';
-import {resolve} from 'node:path';
 import {describe, test} from 'node:test';
-import {fileURLToPath} from 'node:url';
 
 import {
   assertApplicationReleasePackages,
   computePublicationClosure,
-  createApplicationReleasePackages,
   entryPointSupportsRuntimeImport,
   entryPointSupportsTypeResolution,
   listPublicPackageEntryPoints,
-  readPublicationClosureConfig,
-  readWorkspacePackages,
   validatePublicationState,
 } from '../dist/package-closure.js';
 
-const repositoryRoot = resolve(fileURLToPath(new URL('../../..', import.meta.url)));
 const MISSING_ROOT_ERROR = /Publication root is not a workspace package: @shipfox\/missing/u;
 const MISSING_RUNTIME_ERROR = /missing: @shipfox\/runtime/u;
 const PRIVATE_RUNTIME_ERROR = /Publication closure package is private: @shipfox\/private-runtime/u;
@@ -210,24 +204,5 @@ describe('publication closure', () => {
 
     assert.deepEqual(runtimeEntryPoints, ['@shipfox/example']);
     assert.deepEqual(typeEntryPoints, ['@shipfox/example', '@shipfox/example/types']);
-  });
-
-  test('keeps the repository closure and application-release package set exact', () => {
-    const config = readPublicationClosureConfig(
-      resolve(repositoryRoot, 'publication-closure.json'),
-    );
-    const workspacePackages = readWorkspacePackages(repositoryRoot);
-
-    const releasePackages = createApplicationReleasePackages(
-      workspacePackages,
-      config,
-      repositoryRoot,
-    );
-
-    assert.deepEqual(
-      releasePackages.map(({name}) => name),
-      config.packages,
-    );
-    assert.equal(releasePackages.length, 86);
   });
 });

--- a/tools/application-release/turbo.json
+++ b/tools/application-release/turbo.json
@@ -2,6 +2,14 @@
   "$schema": "https://turbo.build/schema.json",
   "extends": ["//"],
   "tasks": {
+    "verify": {
+      "dependsOn": ["$TURBO_EXTENDS$"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/publication-closure.json",
+        "$TURBO_ROOT$/{apps,e2e,infra,libs,tools,turbo}/**/package.json"
+      ]
+    },
     "test:external": {
       "dependsOn": ["$TURBO_EXTENDS$", "@shipfox/api#build", "@shipfox/api#type:emit"]
     }

--- a/tools/package-release/src/publish-productionized-closure.ts
+++ b/tools/package-release/src/publish-productionized-closure.ts
@@ -1,7 +1,7 @@
 import {type ChildProcess, spawn} from 'node:child_process';
-import {globSync, readFileSync, writeFileSync} from 'node:fs';
+import {existsSync, globSync, readFileSync, writeFileSync} from 'node:fs';
 import {constants} from 'node:os';
-import {join, resolve} from 'node:path';
+import {dirname, join, resolve} from 'node:path';
 import {fileURLToPath, pathToFileURL} from 'node:url';
 
 import {productionizePackageManifest} from './productionized-manifest-packer.js';
@@ -119,7 +119,15 @@ export function publishChangesets(onSpawn?: (child: ChildProcess) => void): Prom
 }
 
 export function getRepositoryRoot(entryPoint: string): string {
-  return resolve(fileURLToPath(new URL('../../..', entryPoint)));
+  let directory = dirname(fileURLToPath(entryPoint));
+  while (true) {
+    if (existsSync(join(directory, 'publication-closure.json'))) return directory;
+    const parent = dirname(directory);
+    if (parent === directory) {
+      throw new Error('Could not find publication-closure.json above the package entrypoint');
+    }
+    directory = parent;
+  }
 }
 
 async function main() {

--- a/tools/package-release/src/published-package-artifacts.ts
+++ b/tools/package-release/src/published-package-artifacts.ts
@@ -1,7 +1,7 @@
 import {globSync} from 'node:fs';
-import {mkdir, mkdtemp, readdir, readFile, realpath, rm, writeFile} from 'node:fs/promises';
+import {access, mkdir, mkdtemp, readdir, readFile, realpath, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
-import {join, resolve} from 'node:path';
+import {dirname, join, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 
 import {parse as parseYaml} from 'yaml';
@@ -16,17 +16,15 @@ import {
 
 type DependencyMap = Record<string, string>;
 
-interface PackageManifest extends Record<string, unknown> {
+export interface PackageManifest extends Record<string, unknown> {
+  bin?: Record<string, string> | string;
   dependencies?: DependencyMap;
+  exports?: unknown;
+  main?: string;
   name: string;
   peerDependencies?: DependencyMap;
   private?: boolean;
   version?: string;
-}
-
-interface ReactPeerDependencies {
-  react: string;
-  'react-dom': string;
 }
 
 interface SourcePackage {
@@ -44,19 +42,8 @@ type SourcePackageEntry = [string, SourcePackage];
 type SourcePackages = Map<string, SourcePackage>;
 
 const repositoryRoot = resolve(fileURLToPath(new URL('../../..', import.meta.url)));
-const packageSources = {
-  '@shipfox/api-common-dto': 'libs/api/common-dto',
-  '@shipfox/api-integration-core-dto': 'libs/api/integration/core-dto',
-  '@shipfox/api-projects-dto': 'libs/api/projects-dto',
-  '@shipfox/application-release': 'tools/application-release',
-  '@shipfox/inter-module': 'libs/shared/common/inter-module',
-  '@shipfox/react-ui': 'libs/shared/react/ui',
-  '@shipfox/redact': 'libs/shared/common/redact',
-  '@shipfox/regex': 'libs/shared/common/regex',
-} satisfies Record<string, string>;
-const packageNames = Object.keys(packageSources);
 const registryShipfoxPackagePattern = /^@shipfox\+[^@]+@\d/u;
-const developmentConditionImports = ['@shipfox/regex'];
+const runtimeModulePattern = /\.(?:[cm]?js|node)$/u;
 
 if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
   main().catch((error) => {
@@ -93,35 +80,44 @@ export async function main() {
       stagingRoot,
       dependencyContext,
     );
-    await writeConsumerManifest(fixtureRoot, tarballs, reactUiPeerDependencies(sourcePackages));
+    await writeConsumerManifest(fixtureRoot, tarballs);
     await run('pnpm', ['install', '--prefer-offline', '--ignore-scripts'], fixtureRoot);
     await validateInstalledPackages(fixtureRoot, sourcePackages, expectedDependencies);
     await validateNoRegistryShipfoxPackages(fixtureRoot);
-    await exerciseConsumer(fixtureRoot);
-    process.stdout.write(`Validated ${packageNames.length} packed published package artifacts.\n`);
+    await exerciseConsumer(fixtureRoot, sourcePackages);
+    process.stdout.write(`Validated ${sourcePackages.size} packed public tool artifacts.\n`);
   } finally {
     await rm(fixtureRoot, {recursive: true, force: true});
   }
 }
 
-function readSourcePackages(): Promise<SourcePackageEntry[]> {
-  return Promise.all(
-    Object.entries(packageSources).map(async ([name, directory]) => {
-      const manifest = JSON.parse(
-        await readFile(join(repositoryRoot, directory, 'package.json'), 'utf8'),
-      ) as PackageManifest;
-      if (manifest.name !== name) throw new Error(`Expected ${directory} to define ${name}`);
-      if (manifest.private === true) throw new Error(`Representative package ${name} is private`);
+async function readSourcePackages(): Promise<SourcePackageEntry[]> {
+  const entries = await Promise.all(
+    globSync(join(repositoryRoot, 'tools/**/package.json')).map(async (manifestPath) => {
+      const manifest = JSON.parse(await readFile(manifestPath, 'utf8')) as PackageManifest;
+      if (manifest.private === true) return undefined;
+      const {name} = manifest;
+      if (typeof name !== 'string')
+        throw new Error(`${manifestPath} does not define a package name`);
       return [
         name,
         {
-          directory: join(repositoryRoot, directory),
+          directory: dirname(manifestPath),
           manifest,
-          manifestPath: join(repositoryRoot, directory, 'package.json'),
+          manifestPath,
         },
       ] satisfies SourcePackageEntry;
     }),
   );
+  const sourcePackageEntries = entries.filter(
+    (entry): entry is SourcePackageEntry => entry !== undefined,
+  );
+  const names = new Set<string>();
+  for (const [name] of sourcePackageEntries) {
+    if (names.has(name)) throw new Error(`Duplicate public tool package: ${name}`);
+    names.add(name);
+  }
+  return sourcePackageEntries;
 }
 
 export function catalogDependencies(
@@ -136,7 +132,7 @@ export function catalogDependencies(
       (!reference.startsWith('catalog:') && !reference.startsWith('workspace:'))
     ) {
       throw new Error(
-        `Representative package ${manifest.name} must use a catalog or workspace reference for ${name}`,
+        `Published package ${manifest.name} must use a catalog or workspace reference for ${name}`,
       );
     }
     const resolved = resolveDependencyReference(name, reference, {
@@ -144,9 +140,7 @@ export function catalogDependencies(
       workspaceVersions,
     });
     if (typeof resolved !== 'string') {
-      throw new Error(
-        `Representative package ${manifest.name} has an invalid dependency for ${name}`,
-      );
+      throw new Error(`Published package ${manifest.name} has an invalid dependency for ${name}`);
     }
     dependencies[name] = resolved;
   }
@@ -207,17 +201,13 @@ async function readWorkspaceVersions(): Promise<Map<string, string>> {
   );
 }
 
-async function writeConsumerManifest(
-  root: string,
-  tarballs: DependencyMap,
-  reactUiPeers: ReactPeerDependencies,
-): Promise<void> {
+async function writeConsumerManifest(root: string, tarballs: DependencyMap): Promise<void> {
   const manifest = {
     name: 'shipfox-published-package-artifacts-consumer',
     version: '1.0.0',
     private: true,
     type: 'module',
-    dependencies: consumerDependencies(tarballs, reactUiPeers),
+    dependencies: consumerDependencies(tarballs),
   };
   await Promise.all([
     writeFile(join(root, 'package.json'), `${JSON.stringify(manifest, null, 2)}\n`),
@@ -228,33 +218,16 @@ async function writeConsumerManifest(
   ]);
 }
 
-export function consumerDependencies(
-  tarballs: DependencyMap,
-  reactUiPeers: ReactPeerDependencies,
-): DependencyMap {
-  return {
-    ...Object.fromEntries(
-      Object.entries(tarballs).map(([name, tarball]) => [name, `file:${tarball}`]),
-    ),
-    react: reactUiPeers.react,
-    'react-dom': reactUiPeers['react-dom'],
-  };
+export function consumerDependencies(tarballs: DependencyMap): DependencyMap {
+  return Object.fromEntries(
+    Object.entries(tarballs).map(([name, tarball]) => [name, `file:${tarball}`]),
+  );
 }
 
 export function consumerOverrides(tarballs: DependencyMap): DependencyMap {
   return Object.fromEntries(
     Object.entries(tarballs).map(([name, tarball]) => [name, `file:${tarball}`]),
   );
-}
-
-function reactUiPeerDependencies(sourcePackages: SourcePackages): ReactPeerDependencies {
-  const peerDependencies = sourcePackages.get('@shipfox/react-ui')?.manifest.peerDependencies;
-  const react = peerDependencies?.react;
-  const reactDom = peerDependencies?.['react-dom'];
-  if (typeof react !== 'string' || typeof reactDom !== 'string') {
-    throw new Error('@shipfox/react-ui must declare react and react-dom peer dependencies');
-  }
-  return {react, 'react-dom': reactDom};
 }
 
 async function validateInstalledPackages(
@@ -277,9 +250,26 @@ async function validateInstalledPackages(
     }
     validateCatalogRanges(name, manifest, expectedDependencies);
     validatePeerRanges(name, sourcePackage.manifest, manifest);
+    await validatePackageFiles(root, name, manifest);
     const packagePath = await realpath(join(root, 'node_modules', name));
     if (!packagePath.startsWith(fixturePath)) {
       throw new Error(`Packed ${name} resolved outside the external consumer`);
+    }
+  }
+}
+
+async function validatePackageFiles(
+  root: string,
+  name: string,
+  manifest: PackageManifest,
+): Promise<void> {
+  const binPaths =
+    typeof manifest.bin === 'string' ? [manifest.bin] : Object.values(manifest.bin ?? {});
+  for (const binPath of binPaths) {
+    try {
+      await access(join(root, 'node_modules', name, binPath));
+    } catch (error) {
+      throw new Error(`Packed ${name} is missing its executable ${binPath}`, {cause: error});
     }
   }
 }
@@ -340,13 +330,10 @@ async function validateNoRegistryShipfoxPackages(root: string): Promise<void> {
   }
 }
 
-async function exerciseConsumer(root: string): Promise<void> {
-  const imports = [
-    '@shipfox/api-integration-core-dto/inter-module',
-    '@shipfox/api-projects-dto/inter-module',
-    '@shipfox/redact',
-    '@shipfox/react-ui/button',
-  ];
+async function exerciseConsumer(root: string, sourcePackages: SourcePackages): Promise<void> {
+  const imports = [...sourcePackages].flatMap(([name, {manifest}]) =>
+    runtimeEntryPoints(name, manifest),
+  );
   await run(
     process.execPath,
     [
@@ -361,52 +348,52 @@ if (modules.some((module) => Object.keys(module).length === 0)) throw new Error(
   await run(
     process.execPath,
     [
-      '--input-type=module',
-      '--eval',
-      `const {createInterModuleClient} = await import('@shipfox/inter-module');
-const {projectsInterModuleContract} = await import('@shipfox/api-projects-dto/inter-module');
-const {integrationsInterModuleContract} = await import('@shipfox/api-integration-core-dto/inter-module');
-const projectId = '00000000-0000-4000-8000-000000000001';
-const projects = createInterModuleClient(projectsInterModuleContract, async () => ({project: null}));
-const integrations = createInterModuleClient(integrationsInterModuleContract, async () => ({
-  path: 'workflow.yml',
-  ref: 'main',
-  content: 'name: workflow',
-}));
-const project = await projects.getProjectById({projectId});
-const file = await integrations.fetchSourceFile({
-  workspaceId: '00000000-0000-4000-8000-000000000002',
-  connectionId: '00000000-0000-4000-8000-000000000003',
-  externalRepositoryId: 'shipfox/project',
-  ref: 'main',
-  path: 'workflow.yml',
-});
-if (project.project !== null || file.content !== 'name: workflow') throw new Error('Packed inter-module client did not execute its contract.');`,
-    ],
-    root,
-  );
-  await run(
-    process.execPath,
-    [
       '--conditions=development',
       '--input-type=module',
       '--eval',
-      `const imports = ${JSON.stringify(developmentConditionImports)};
+      `const imports = ${JSON.stringify(imports)};
 const modules = await Promise.all(imports.map((specifier) => import(specifier)));
 if (modules.some((module) => Object.keys(module).length === 0)) throw new Error('A development-condition import has no exports.');`,
     ],
     root,
   );
-  await run(
-    process.execPath,
-    [
-      '--input-type=module',
-      '--eval',
-      `const tool = await import('./node_modules/@shipfox/application-release/dist/manifest.js');
-if (typeof tool.createApplicationReleaseManifest !== 'function') throw new Error('Packed application-release is missing its manifest builder.');`,
-    ],
-    root,
+}
+
+export function runtimeEntryPoints(name: string, manifest: PackageManifest): string[] {
+  if (manifest.exports === undefined) {
+    return typeof manifest.main === 'string' && runtimeTarget(manifest.main) ? [name] : [];
+  }
+  if (typeof manifest.exports === 'string') {
+    return runtimeTarget(manifest.exports) ? [name] : [];
+  }
+  if (!isRecord(manifest.exports)) return [];
+  const exportsField = manifest.exports;
+  const subpaths = Object.keys(exportsField).filter((key) => key.startsWith('.'));
+  if (subpaths.length === 0) {
+    return exportTargets(exportsField).some(runtimeTarget) ? [name] : [];
+  }
+  return subpaths.flatMap((subpath) => {
+    const target = exportsField[subpath];
+    if (!exportTargets(target).some(runtimeTarget)) return [];
+    return [subpath === '.' ? name : `${name}/${subpath.slice(2)}`];
+  });
+}
+
+function exportTargets(value: unknown): string[] {
+  if (typeof value === 'string') return [value];
+  if (Array.isArray(value)) return value.flatMap(exportTargets);
+  if (!isRecord(value)) return [];
+  return Object.entries(value).flatMap(([condition, target]) =>
+    condition === 'types' ? [] : exportTargets(target),
   );
+}
+
+function runtimeTarget(target: string): boolean {
+  return runtimeModulePattern.test(target);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
 export function safePackageName(name: string): string {

--- a/tools/package-release/test/productionized-manifest-packer.test.ts
+++ b/tools/package-release/test/productionized-manifest-packer.test.ts
@@ -6,6 +6,7 @@ import {join} from 'node:path';
 import {packProductionizedPackage} from '../src/productionized-manifest-packer.js';
 
 const roots: string[] = [];
+const SOURCE_PATH_PATTERN = /src\//u;
 
 afterEach(async () => {
   await Promise.all(roots.splice(0).map((root) => rm(root, {force: true, recursive: true})));
@@ -63,7 +64,7 @@ test('packs a staged production manifest without changing the source package', a
     stagingRoot,
   });
 
-  assert.deepEqual(result.imports, {'#*': './dist/*'});
+  assert.doesNotMatch(JSON.stringify(result.imports), SOURCE_PATH_PATTERN);
   assert.equal(result.devDependencies, undefined);
   assert.deepEqual(result.dependencies, {ajv: '^8.18.0', '@shipfox/runtime': '1.2.3'});
   assert.equal(result.distContents, 'export {};');

--- a/tools/package-release/test/publish-productionized-closure.test.ts
+++ b/tools/package-release/test/publish-productionized-closure.test.ts
@@ -16,16 +16,20 @@ type JsonRecord = Record<string, unknown>;
 const roots: string[] = [];
 const DUPLICATE_MANIFEST_ERROR = /Duplicate package manifest: @shipfox\/duplicate/u;
 const MISSING_MANIFEST_ERROR = /Publication closure package has no manifest: @shipfox\/missing/u;
+const SOURCE_PATH_PATTERN = /src\//u;
 const SPAWN_FAILURE_ERROR = /spawn failed/u;
 
 test('resolves the repository root from the package entrypoint', () => {
+  const root = mkdtempSync(join(tmpdir(), 'shipfox-repository-root-'));
+  roots.push(root);
+  writeFileSync(join(root, 'publication-closure.json'), '{}\n');
   const entryPoint = pathToFileURL(
-    '/workspace/tools/package-release/dist/publish-productionized-closure.js',
+    join(root, 'tools/package-release/dist/publish-productionized-closure.js'),
   ).href;
 
   const repositoryRoot = getRepositoryRoot(entryPoint);
 
-  assert.equal(repositoryRoot, '/workspace');
+  assert.equal(repositoryRoot, root);
 });
 
 afterEach(() => {
@@ -139,10 +143,8 @@ describe('publishProductionizedClosure', () => {
       packageNames: ['@shipfox/one'],
       publish: () => {
         const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
-        assert.deepEqual(manifest.imports, {'#*': './dist/*'});
-        assert.deepEqual(manifest.exports, {
-          '.': {types: './dist/index.d.ts', default: './dist/index.js'},
-        });
+        assert.doesNotMatch(JSON.stringify(manifest.imports), SOURCE_PATH_PATTERN);
+        assert.doesNotMatch(JSON.stringify(manifest.exports), SOURCE_PATH_PATTERN);
         assert.equal(manifest.devDependencies, undefined);
         const toolManifest = JSON.parse(readFileSync(toolManifestPath, 'utf8'));
         assert.equal(toolManifest.devDependencies, undefined);

--- a/tools/package-release/test/published-package-artifacts.test.ts
+++ b/tools/package-release/test/published-package-artifacts.test.ts
@@ -6,6 +6,7 @@ import {
   consumerDependencies,
   consumerOverrides,
   findUnsupportedProtocol,
+  runtimeEntryPoints,
   safePackageName,
 } from '../src/published-package-artifacts.js';
 
@@ -64,23 +65,34 @@ describe('catalogRange', () => {
 });
 
 describe('consumerDependencies', () => {
-  test('declares React UI peers without relying on auto-install-peers', () => {
+  test('installs every packed artifact from its local tarball', () => {
     const tarballs = {
       '@shipfox/react-ui': '/tmp/react-ui.tgz',
       '@shipfox/redact': '/tmp/redact.tgz',
     };
 
-    const dependencies = consumerDependencies(tarballs, {
-      react: '^19.0.0',
-      'react-dom': '^19.0.0',
-    });
+    const dependencies = consumerDependencies(tarballs);
 
     assert.deepEqual(dependencies, {
       '@shipfox/react-ui': 'file:/tmp/react-ui.tgz',
       '@shipfox/redact': 'file:/tmp/redact.tgz',
-      react: '^19.0.0',
-      'react-dom': '^19.0.0',
     });
+  });
+});
+
+describe('runtimeEntryPoints', () => {
+  test('discovers runtime exports and excludes type-only or data exports', () => {
+    const entryPoints = runtimeEntryPoints('@shipfox/example', {
+      name: '@shipfox/example',
+      exports: {
+        '.': {types: './dist/index.d.ts', default: './dist/index.js'},
+        './client': './client.d.ts',
+        './config': './config.json',
+        './runner': './dist/runner.mjs',
+      },
+    });
+
+    assert.deepEqual(entryPoints, ['@shipfox/example', '@shipfox/example/runner']);
   });
 });
 

--- a/tools/package-release/turbo.json
+++ b/tools/package-release/turbo.json
@@ -7,20 +7,26 @@
         "$TURBO_EXTENDS$",
         "@shipfox/application-release#build",
         "@shipfox/application-release#type:emit",
-        "@shipfox/react-ui#build",
-        "@shipfox/react-ui#type:emit",
-        "@shipfox/redact#build",
-        "@shipfox/redact#type:emit",
-        "@shipfox/regex#build",
-        "@shipfox/regex#type:emit"
+        "@shipfox/biome#build",
+        "@shipfox/biome#type:emit",
+        "@shipfox/depcruise#build",
+        "@shipfox/docker#build",
+        "@shipfox/docker#type:emit",
+        "@shipfox/playwright#build",
+        "@shipfox/playwright#type:emit",
+        "@shipfox/swc#build",
+        "@shipfox/typescript#build",
+        "@shipfox/typescript#type:emit",
+        "@shipfox/vite#build",
+        "@shipfox/vite#type:emit",
+        "@shipfox/vitest#build",
+        "@shipfox/vitest#type:emit"
       ],
       "inputs": [
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/pnpm-lock.yaml",
         "$TURBO_ROOT$/pnpm-workspace.yaml",
-        "$TURBO_ROOT$/tools/application-release/package.json",
-        "$TURBO_ROOT$/libs/shared/common/{redact,regex}/package.json",
-        "$TURBO_ROOT$/libs/shared/react/ui/package.json"
+        "$TURBO_ROOT$/tools/**/package.json"
       ]
     }
   }


### PR DESCRIPTION
Move packed-consumer release scenarios into their owning packages and make both release-verification tools discover the packages, exports, and scenarios they need.

The previous checks encoded the repository's current package count, order, and representative fixture list in central tool code. That made unrelated package changes break release tests and required the verifier to know feature-specific API behavior. Package-owned `test/published/` contracts keep that coverage while allowing the verification tools to enforce stable publication invariants.

This also adds a non-mutating release preflight before publishing, so invalid closure manifests and productionization failures are detected before package manifests are rewritten or a publish begins.

The main review boundaries are the `test/published/` discovery convention, runtime entry-point filtering, and Turbo dependencies for public tool artifact verification.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generalizes release verification by moving packed-consumer checks into each package under `test/published/` and making the tools discover and run them. Adds a non-mutating preflight and an app-closure verify so invalid manifests and runtime targets are caught before publish; also stabilizes the auth token interoperability test.

- **New Features**
  - Discovers `test/published/` scenarios per package: `.ts` type-checks, `.mjs` runs, `.development.mjs` runs with the `development` condition.
  - Uses a single environment provider at `libs/api/server/test/published/_environment.mjs` for runtime checks.
  - Detects runtime entry points from `exports` and exercises only runtime targets.
  - Adds `release:preflight` (calls `@shipfox/package-release` `preflight:closure`) and `@shipfox/application-release` `verify` to validate the publication closure; `release:publish` now runs preflight first.
  - Public tool artifact checks now discover all `tools/**` packages, validate tarballs and executables, and import runtime exports without a central list.
  - Ensures productionized manifests and exports contain no `src/` paths.

- **Migration**
  - Move release scenarios into each package under `test/published/` and mark dev-only checks as `.development.mjs`.
  - Keep exactly one `_environment.mjs` provider owned by `@shipfox/api-server`.
  - Run `pnpm run release:preflight` before `release:publish` (now enforced).

<sup>Written for commit cae891f060e7737f7662ad169302c485aeaa4895. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

