### PR TITLE
Consolidate backend cross-cutting guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,42 +143,23 @@ enabled, waits for both to become ready, then runs `turbo test:e2e`. Diagnostics
 land in `.context/shipfox-e2e-logs/`; flow runner logs are attached to failed
 scenario results.
 
-### Configuration
+### Backend cross-cutting rules
 
-Each app and each package that reads the environment owns a `src/config.ts`. It
-calls `createConfig` from `@shipfox/config` (a thin wrapper over envalid) with one
-validator per variable: `str`, `num`, `bool`, `host`, `port`, `url`, or `email`. A
-validator with a `default` is optional; one without a default is required, so a
-missing value fails startup. Keep the file flat: declare the schema, then derive
-any helpers (such as a mailer) below it.
+If your task adds or changes an environment variable, validator, or environment
+description, read the [configuration policy](docs/policies/configuration.md). It
+owns repository-wide configuration rules.
 
-Document every variable with the validator's `desc` property, never a `//` comment
-beside it. `desc` stays attached to the schema: envalid's default reporter prints it
-when a required variable is missing at startup, and any config tooling can read it.
-A `//` comment never leaves the source file. When you find an existing `//` note on
-a config param, move it into `desc`.
+If your task adds a domain or provider error, translates a request failure, or
+reports an unexpected failure, read [error handling](docs/architecture/error-handling.md).
+It owns the backend error model and reporting boundaries.
 
-Write the descriptions for self-hosters, not for maintainers:
+If your task adds a metric or changes instrumentation startup, naming, units, or
+labels, read [observability](docs/architecture/observability.md). It owns the
+backend metrics model and cardinality constraints.
 
-- Plain language, one idea per sentence, present tense.
-- Say what the variable does and how to set it.
-- List the accepted values when the variable is constrained: enums like
-  `LOG_LEVEL` or `MAILER_TRANSPORT`, a URL, a comma-separated list.
-- Note when a variable is required, or when it depends on another (for example,
-  `SMTP_HOST` is required when `MAILER_TRANSPORT` is `smtp`).
-- No marketing words.
-
-```ts
-export const config = createConfig({
-  AUTH_JWT_SECRET: str({
-    desc: 'Secret used to sign and verify user access tokens (JWTs). Required, with no default, so startup fails when it is missing.',
-  }),
-  MAILER_TRANSPORT: str({
-    desc: 'How emails are delivered. Use console to print them to the log, or smtp to send them through an SMTP server.',
-    default: 'console',
-  }),
-});
-```
+If your task mints, verifies, or carries an authentication token, read the
+[Auth security model](libs/api/auth/README.md#security-model). It owns token
+authority, lifetime, trust boundaries, and logging constraints.
 
 ## Code comments
 
@@ -275,230 +256,6 @@ planning-doc decisions (`/plan-eng-review A1`) in module or function headers.
 Speculation about future work ("today X, tomorrow Y") and tracked tasks belong in
 `TODOS.md`, the issue tracker, or the design doc, not in code that outlives them.
 
-## Auth & token security
-
-The auth module issues two stateless bearer tokens, a **user session token** and
-a **job lease token**, each signed with a distinct key derived from
-`AUTH_ROOT_KEY`. Rotating the root invalidates every derived-token type. The full
-security model (trust boundaries, scope, threat model, and rotation) lives in
-`libs/api/auth/README.md#security-model`; read it before touching anything that
-mints, verifies, or carries either token.
-
-The job lease token is a single-job **capability**, not an identity. When working
-near it, keep its authority narrow:
-
-- **Keep the scope to one job.** Do not add claims that grant access beyond the
-  single job the lease names. It is not a runner identity, not workspace-wide, and
-  not a replacement for the long-lived runner credential.
-- **Keep a single issuer; everyone else verifies only.** Scheduling mints leases;
-  every other side does an in-process signature check with no callback. Treat the
-  runner and the agent workload it hosts as untrusted; they only present a token.
-- **Keep the lifetime bounded** and never trade the short TTL for convenience.
-- **Server state is the final gate.** A valid token must never be sufficient to
-  advance work on its own; on the lease path, terminal step/progression state
-  always wins (job finalization is enforced outside it), and cancellation rides on
-  the heartbeat response.
-- **Never log a raw token.** There is no automatic redaction; tokens must not reach
-  logs, traces, or error payloads. Secrets come from configuration, never code.
-
-If the no-revocation window proves too wide, bind the lease to live runner or job
-state; do not broaden what the token itself authorizes.
-
-## Error handling
-
-Error handling is a cross-layer concern, not an HTTP detail. The guiding
-principle is **let errors bubble up and translate them only when crossing a
-boundary**. Each layer owns one job, and the error changes shape only at the
-edges:
-
-```
-external system  →  api/core: typed error  →  presentation: ClientError  →  global handler  →  HTTP response
-```
-
-Never swallow or wrap an error unless you add meaning. If you can re-throw
-as-is, do. Do not catch errors just to log them; let unknowns reach the global
-handler.
-
-### Domain errors (`core` / `db`)
-
-Throw typed domain errors from domain and persistence code. Define them in
-`core/errors.ts` as plain `Error` subclasses with a human-readable message, a
-`name`, and any context as public readonly fields. They carry **no HTTP
-concerns** (no status, no client-facing code), which keeps them reusable by
-workers, subscribers, and jobs, not just routes:
-
-```ts
-export class WorkspaceNotFoundError extends Error {
-  constructor(workspaceId: string) {
-    super(`Workspace not found: ${workspaceId}`);
-    this.name = 'WorkspaceNotFoundError';
-  }
-}
-```
-
-### External and infrastructure errors (`api` / `core`)
-
-Catch errors from external systems (GitHub, GCP, etc.) at the layer that talks
-to them and re-throw them as a typed error carrying a `reason` enum (e.g.
-`IntegrationProviderError`) rather than letting raw SDK errors leak upward.
-Callers then branch on `reason` without depending on the SDK's error shapes.
-Pass `retryAfterSeconds` for backpressure reasons like `rate-limited`:
-
-```ts
-throw new IntegrationProviderError('rate-limited', message, retryAfterSeconds);
-```
-
-### Translating to HTTP responses (`presentation`)
-
-The presentation/request boundary is the only place that turns errors into
-client responses. Route `errorHandler`s are the default place to translate
-known domain errors to `ClientError`; re-throw anything you don't recognize so
-it reaches the global handler:
-
-```ts
-errorHandler: (error) => {
-  if (error instanceof WorkspaceNotFoundError)
-    throw new ClientError('Workspace not found', 'not-found', {status: 404});
-  if (error instanceof LastMemberError)
-    throw new ClientError(error.message, 'last-member', {status: 409});
-  throw error; // unrecognized → global handler
-},
-```
-
-`ClientError(message, code, params)` is the only error that produces a
-structured client response. `code` is a stable kebab-case string (`not-found`,
-`last-member`, `project-already-exists`). `params`:
-
-- `status`: HTTP status, **defaults to 400**; set it for any other 4xx.
-- `details`: structured data **returned to the client** (snake_case keys).
-- `data`: context **logged only**, never sent to the client.
-- `cause`: pass the original error when wrapping, so it stays in the chain for
-  logs and diagnostics. Sentry sees unknown errors that reach the global handler;
-  handled cases must capture explicitly if they need Sentry reporting.
-
-For external errors, map the `reason` enum to a status and client code here
-(e.g. `rate-limited` → 429).
-
-### The global handler
-
-The shared handler in `@shipfox/node-fastify` is the last resort. It sends
-`ClientError` as `{code, details?}` with its status, maps Fastify
-validation/known errors to 4xx codes, and logs + reports unknown errors to
-Sentry as a 500 `server-error`. Anything that reaches it untyped becomes an
-opaque 500, so translate errors you can describe before they get here.
-
-## Metrics & observability
-
-Metrics are emitted through OpenTelemetry and scraped by Prometheus. All the
-plumbing (the SDK, the Prometheus exporters, the meter providers) lives in
-`@shipfox/node-opentelemetry`; an app turns it on once at startup (the API does
-this in `apps/api/src/core/run.ts`) and feature packages only define and record
-instruments. Never add a metrics SDK or exporter to a feature package.
-
-The worked example is `libs/api/runners/src/metrics`. Copy its shape.
-
-### Two planes: instance vs service
-
-There are two separate meter providers on two ports, and the choice between
-them is about *what the number means*, not convenience.
-
-- **Instance metrics** (`instanceMetrics.getMeter(name)`, port 9464) are
-  counters and histograms recorded inline as an event happens: a job claimed,
-  a request served, a duration observed. Each pod exposes its own values and
-  Prometheus sums across pods. This is the default; reach for it first.
-- **Service metrics** (`getServiceMetricsProvider().getMeter(name)`, port 9474)
-  are observable gauges that read shared state (a queue depth, a backlog size,
-  a current count) through a callback that runs on each scrape. They live on a
-  separate provider because every pod reading the same database row would report
-  the same value, and Prometheus must not sum those copies. Use a service gauge
-  only for point-in-time state derived from shared storage.
-
-If you are counting things that happen, you want an instance counter. If you are
-reporting how many things currently exist, you want a service gauge.
-
-### Package layout
-
-Each feature package that emits metrics owns a `src/metrics/` folder:
-
-```text
-src/metrics/
-  instance.ts   Counters and histograms, created at module load, recorded inline.
-  service.ts    register<Module>ServiceMetrics(): observable gauges (omit if none).
-  index.ts      Re-exports the above.
-```
-
-Instance instruments are created at the top of `instance.ts` and exported, then
-imported and recorded where the event occurs. Creating them at import time is
-safe for tests: `instanceMetrics.getMeter` returns a no-op meter until an app
-starts instrumentation, so a test that merely imports the module records nothing
-and binds nothing.
-
-That same lazy resolution is a production trap. The metrics API has no proxy
-meter (unlike traces, which back-fill), so an instrument created before the app
-registers the global meter provider stays a no-op forever and never exports. The
-app must therefore start instance instrumentation **before** the module graph
-loads: preload it via `--import`, not from inside `run()`. See
-`apps/api/src/instrumentation.ts` (wired into the Dockerfile CMD and the dev
-script). A new app that calls `startInstanceInstrumentation` in-process after
-importing its feature modules will silently emit nothing.
-
-Service gauges are different. Reaching `getServiceMetricsProvider()` binds the
-metrics port, so it must never run at import time; it would break any unit test
-that imports the module. Fetch the meter, create the gauges, and attach their
-callbacks **inside** an exported `register<Module>ServiceMetrics()` function.
-Wire that function to the module via the `metrics` hook:
-
-```ts
-export const runnersModule: ShipfoxModule = {
-  name: 'runners',
-  // ...
-  metrics: registerRunnersServiceMetrics,
-};
-```
-
-`registerModuleMetrics` (called once from the app bootstrap, after
-`startServiceMetrics` and `initializeModules`) invokes every module's hook. A
-package with no shared-state gauge omits `metrics` entirely.
-
-### Naming
-
-Snake_case, prefixed with the module name: `runners_job_claimed`,
-`runners_pending_jobs`, `runners_claim_duration`. The prefix is the namespace;
-it keeps `workflows_*` and `runners_*` from colliding in one Prometheus tenant.
-
-Do not hand-append `_total` to counters or unit suffixes to histograms: the
-Prometheus exporter derives `_total`, `_milliseconds`, and friends from the
-instrument kind and its `unit`. Set `unit: 'ms'` and `advice.explicitBucketBoundaries`
-on histograms; the name stays unit-free.
-
-### Cardinality is the one rule that matters
-
-A metric label multiplies into one time series per distinct value. Labels must
-be **bounded and low-cardinality**: an outcome, a reason, a type, a conclusion,
-a provider, an OS: values you could list on one hand or one page.
-
-Never label a metric with an unbounded identifier: no `jobId`, `runId`,
-`workspaceId`, `organizationId`, `userId`, raw URL, or error message. One job ID
-in a label is one new time series per job forever; it melts Prometheus and the
-bill. When you need per-entity detail, that is what logs and traces are for;
-put the ID in a `logger()` field, not a metric label.
-
-Type the label set so the shape is enforced at every call site:
-
-```ts
-const jobClaimedCount = meter.createCounter<{outcome: 'claimed' | 'empty'}>(
-  'runners_job_claimed',
-  {description: 'Job-claim attempts by outcome'},
-);
-```
-
-### Where recording lives
-
-Metrics are observability, like logging, so they are allowed in `core` and `db`;
-record where the event is known most precisely, not only at the HTTP edge.
-Keep recording out of pure row-to-domain mappers and DTO converters. A service
-gauge's callback queries through the same `db/` functions the rest of the
-package uses; it does not reach for raw Drizzle.
 
 ## Unit Testing Strategy (Client Apps)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,17 +55,23 @@ atom, browser storage, or cross-feature client flow, read the
 [client architecture guide](docs/architecture/client-architecture.md). It owns
 the current client model, form rules, and architecture enforcement.
 
-## Error reporting
+## Backend cross-cutting rules
 
-Report unexpected API-process failures at the earliest owning boundary. A catch
-that continues must report the failure, return or persist a recognized error, or
-document why it is intentionally non-actionable. Do not report expected client,
-validation, authentication, typed provider, cancellation, or idempotency paths.
-Every unexpected failure sent to Sentry must also be written to the structured
-application log so self-hosters can diagnose it without Sentry. Log the error
-and only safe, bounded context such as the boundary's module, operation, or
-resource identifier. Never attach request bodies, headers, cookies, tokens, or
-payloads to either logs or reports.
+When your change adds or changes an environment variable, validator, or
+environment description, read the [configuration policy](docs/policies/configuration.md).
+It owns repository-wide configuration rules.
+
+When your change adds a domain or provider error, translates a request failure,
+or reports an unexpected failure, read [error handling](docs/architecture/error-handling.md).
+It owns the backend error model and reporting boundaries.
+
+When your change adds a metric or changes instrumentation startup, naming,
+units, or labels, read [observability](docs/architecture/observability.md). It
+owns the backend metrics model and cardinality constraints.
+
+When your change mints, verifies, or carries an authentication token, read the
+[Auth security model](libs/api/auth/README.md#security-model). It owns token
+authority, lifetime, trust boundaries, and logging constraints.
 
 ## Writing Documentation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,9 @@ listed there or when you need to place, update, or review documentation.
 | Changes a cross-package client composition seam. | [ADR 0001](adr/0001-client-composition-contract.md) | The public client composition contract and its decision rationale. |
 | Changes server module boundaries or an inter-module call. | [ADR 0002](adr/0002-api-inter-module-architecture.md) | Producer-owned inter-module contracts and bounded-context crossings. |
 | Adds or changes a backend module, DTO, outbox event, HTTP boundary, or server package dependency. | [Backend architecture](architecture/backend-architecture.md) | The current backend module model and package-boundary rules. |
+| Adds or changes an environment variable, validator, or environment description. | [Configuration policy](policies/configuration.md) | Repository-wide configuration ownership, validation, and description rules. |
+| Adds a domain or provider error, translates a request failure, or reports an unexpected failure. | [Error handling](architecture/error-handling.md) | The current backend error model, client translation, and reporting boundaries. |
+| Adds a metric or changes instrumentation startup, naming, units, or labels. | [Observability](architecture/observability.md) | The current backend metrics model and cardinality constraints. |
 | Changes client state, API adapters, forms, or feature-domain boundaries. | [Client architecture](architecture/client-architecture.md) | The current client feature model, form rules, and architecture enforcement. |
 | Introduces a shared package or changes a server dependency boundary. | [ADR 0004](adr/0004-shared-semantic-packages-and-server-dependency-boundaries.md) | Shared semantic package rules and server package classes. |
 | Changes repository documentation structure or adds a shared documentation surface. | [ADR 0005](adr/0005-repository-documentation-architecture.md) | Documentation ownership, routing, and progressive disclosure. |

--- a/docs/architecture/error-handling.md
+++ b/docs/architecture/error-handling.md
@@ -1,0 +1,76 @@
+# Error handling
+
+This guide owns the current error model for backend code. Read it when you add a
+domain error, call an external provider, translate a request failure, or report
+an unexpected failure. Package READMEs own their public error-reporting APIs and
+local constraints.
+
+Keep each error clear. Keep each boundary small.
+Use direct types. Keep client data safe.
+Keep logs short. Keep tags small. Avoid raw input.
+Log the cause. Name the task. Keep secrets out.
+
+## Translate at boundaries
+
+Let errors bubble until a boundary can add meaning. Do not catch an error only
+to log it. The normal flow is:
+
+```text
+external system -> core or db typed error -> presentation ClientError -> global handler -> HTTP response
+```
+
+Domain and persistence code throw typed errors with no HTTP concerns. Define a
+plain `Error` subclass in `core/errors.ts`. Give it a clear message and name.
+Add public readonly context only when callers need it.
+
+The layer that calls an external system catches SDK-specific failures. It
+re-throws a typed error with a stable reason enum. Include bounded retry context
+such as `retryAfterSeconds` for backpressure. Callers must not depend on an SDK
+error shape.
+
+## Turn known failures into client responses
+
+The presentation boundary translates known errors to `ClientError`. Route
+`errorHandler`s are the usual place. Re-throw unknown errors. The global handler
+then logs and reports them.
+
+```ts
+errorHandler: (error) => {
+  if (error instanceof WorkspaceNotFoundError)
+    throw new ClientError('Workspace not found', 'not-found', {status: 404});
+  throw error;
+},
+```
+
+`ClientError` is the structured client response. Its stable kebab-case `code`
+and optional snake_case `details` are safe for the client. Its `data` is for
+logs only. Its `cause` preserves the original error for diagnostics. Map typed
+provider reasons to a stable status and client code at this boundary.
+
+The global Fastify handler is the final fallback. It sends recognized client and
+validation failures as 4xx responses. It logs and reports unrecognized errors as
+a 500 `server-error`. An error without a useful translation is opaque to the
+client.
+
+## Report unexpected failures once
+
+The earliest boundary that owns an unexpected failure reports it. A catch that
+continues must report the failure. It can instead return or persist a recognized
+error. It can also explain why the failure is non-actionable. Log the error with
+safe, bounded context before calling `reportError`. This keeps diagnostics when
+Sentry is disabled.
+
+Report unknown HTTP, startup, runtime, shutdown, lifecycle, dispatcher, outbox,
+inter-module, Temporal, and best-effort cleanup failures. Do not report expected
+client, validation, authentication, signature, known-domain, typed-provider,
+rate-limit, expected-timeout, cancellation, idempotency, or already-reported
+failures. Do not report metrics-recording failures.
+
+Use bounded classifications such as boundary, operation, module, event type, or
+outcome. Never attach request bodies, headers, cookies, tokens, or payloads.
+Do not attach activity arguments or inter-module input and output either.
+
+`@shipfox/node-error-monitoring` owns Sentry startup, duplicate suppression,
+and its reporting API. Read its
+[package README](../../libs/shared/node/error-monitoring/README.md) when using
+or changing that package.

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -1,0 +1,70 @@
+# Observability
+
+This guide owns the current metrics model for backend code. Read it when you add
+an instrument, choose a metric provider, or change instrumentation startup.
+Package READMEs own library APIs and local operational setup.
+
+## Use the right metric plane
+
+Metrics use OpenTelemetry and Prometheus through `@shipfox/node-opentelemetry`.
+An app starts instrumentation once. Feature packages define and record their
+own instruments. Do not add an SDK or exporter to a feature package.
+
+Use instance metrics for events that happen. Counters and histograms are
+recorded inline. Each pod exposes them on port 9464. Prometheus sums them.
+Use service metrics only for a point-in-time value from shared storage, such as
+a queue depth. Observable gauges use port 9474. This stops Prometheus from
+summing the same shared value from every pod.
+
+## Initialize in the required order
+
+Create instance instruments at module load in `src/metrics/instance.ts`. Record
+them where the event is known most precisely. `instanceMetrics` is a no-op before
+instrumentation. This keeps imports safe in tests. It has no proxy meter, so an
+instrument created before startup stays a no-op forever.
+
+Preload instance instrumentation before the app module graph loads. The API uses
+[`@shipfox/api-server/instrumentation`](../../libs/api/server/src/instrumentation.ts)
+through `--import` in its development and container commands. Do not start it
+from inside `run()` after feature modules load.
+
+Service gauges must not bind a port during module import. Create their meter and
+callbacks inside `register<Module>ServiceMetrics()` in `src/metrics/service.ts`.
+Register that function on the module's `metrics` hook. The app starts the service
+provider and invokes module hooks after modules initialize.
+
+```text
+src/metrics/
+  instance.ts   Counters and histograms, created at module load.
+  service.ts    register<Module>ServiceMetrics() for shared-state gauges.
+  index.ts      Re-exports the metric modules.
+```
+
+## Name and label metrics safely
+
+Use snake_case names prefixed with the module, such as
+`runners_job_claimed` or `workflows_pending_runs`. Do not append `_total` to a
+counter. Do not append a unit suffix to a histogram name. The exporter derives
+those suffixes. Set `unit: 'ms'` and explicit histogram buckets where they help.
+
+Metric labels must be bounded and low-cardinality. Use an outcome, reason, type,
+conclusion, provider, or operating system. Never use an identifier, raw URL, or
+error message as a label. Do not label with job, run, workspace, organization,
+user, or request IDs. Put per-entity diagnostics in logs or traces instead.
+
+Type the allowed label shape at the instrument definition so each call site is
+checked:
+
+```ts
+const jobClaimedCount = meter.createCounter<{outcome: 'claimed' | 'empty'}>(
+  'runners_job_claimed',
+  {description: 'Job claim attempts by outcome'},
+);
+```
+
+Metrics may be recorded in `core` or `db`, but not in pure row mappers or DTO
+converters. A service-gauge callback uses normal package database functions. It
+does not use raw database access.
+
+Read the [OpenTelemetry package README](../../libs/shared/node/opentelemetry/README.md)
+for the library API, environment settings, exporters, tracing, and logging.

--- a/docs/policies/configuration.md
+++ b/docs/policies/configuration.md
@@ -1,0 +1,62 @@
+# Configuration policy
+
+This policy owns repository-wide environment rules. Read it when an app or
+package reads an environment variable. Also read it when you change a validator
+or document a setting. A package README owns local meaning and setup. Code,
+schemas, deployment manifests, and generated references own exact runtime
+values, defaults, and accepted inputs.
+
+Keep the rules close to the code.
+Use plain text.
+
+## Own configuration where it is read
+
+Each app and package that reads environment variables owns a flat
+`src/config.ts`. It calls `createConfig` from `@shipfox/config`. Use one
+validator for each variable it reads. Keep the schema first. Derive helpers
+below it.
+
+Use the validator that matches the value: `str`, `num`, `bool`, `host`, `port`,
+`url`, or `email`. A validator with a `default` is optional. Without a default,
+the setting is required. Startup fails when it is missing or invalid.
+
+`@shipfox/config` owns the library API and validator behavior. Read its
+[package README](../../libs/shared/common/config/README.md) when using or
+changing that package. Do not duplicate package-local setup or environment
+semantics here.
+
+## Describe every setting
+
+Give every validator a `desc`. Write it for a self-hoster in plain language:
+
+- State what the setting does and how to set it.
+- List accepted values for constrained settings.
+- State when a setting is required or depends on another setting.
+- Use one present-tense idea per sentence and no marketing language.
+
+Do not use a `//` comment beside a config parameter. The description stays with
+the schema. It appears in missing-config failures. A source comment does not.
+
+```ts
+export const config = createConfig({
+  AUTH_JWT_SECRET: str({
+    desc: 'Secret used to sign and verify user access tokens. Required, with no default, so startup fails when it is missing.',
+  }),
+  MAILER_TRANSPORT: str({
+    desc: 'How emails are delivered. Use console to write emails to the log, or smtp to send through an SMTP server.',
+    default: 'console',
+  }),
+});
+```
+
+## Preserve executable ownership
+
+Do not keep a hand-written copy of an app's environment contract in a
+repository-wide document. The owning `src/config.ts` and deployment manifest
+define current defaults and accepted inputs. Package READMEs explain local setup.
+They also explain constraints that code cannot express.
+
+Authentication secrets and token lifetime are not general configuration rules.
+When changing an Auth token or its setting, read the
+[Auth security model](../../libs/api/auth/README.md#security-model), which owns
+that trust boundary and its lifetime constraints.


### PR DESCRIPTION
Create canonical configuration, error-handling, and observability guides, then route contributors and agents to them by task.

The repository had the same backend rules spread across entrypoints and package documentation. This change gives each cross-cutting topic one current owner while preserving local API details in package READMEs.

Auth token authority, lifetime, and trust-boundary guidance remain in the Auth package README rather than being copied into a repository-wide guide.

Review the ownership boundaries and the trigger-first links in AGENTS.md, CONTRIBUTING.md, and docs/README.md.

Closes ENG-1157

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates backend cross-cutting guidance into canonical docs for configuration, error handling, and observability to remove duplication and clarify ownership. Docs-only change; implements ENG-1157.

- **Refactors**
  - Added: `docs/policies/configuration.md`, `docs/architecture/error-handling.md`, `docs/architecture/observability.md`.
  - Replaced inlined rules in `AGENTS.md` and `CONTRIBUTING.md` with a single “Backend cross-cutting rules” pointer to the new guides; updated `docs/README.md` index.
  - Kept Auth token authority, lifetime, and trust-boundary guidance in `libs/api/auth/README.md#security-model`.

<sup>Written for commit 0434a048bada2d414736942199e1ebea267cc868. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

