### PR TITLE
Make writing and code standards audience-neutral

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,23 +18,16 @@ If the task adds, updates, or exempts a dependency, read the
 [dependency version policy](docs/policies/dependency-versions.md). It owns
 dependency rules and required checks.
 
+If the task writes or reviews code comments, module exports, or non-trivial
+control flow, read the [code style policy](docs/policies/code-style.md). It owns
+the shared rules for those code decisions.
+
 ## Backend architecture
 
 If your task adds or changes a backend module, DTO, outbox event, HTTP boundary,
 or server package dependency, read the
 [backend architecture guide](docs/architecture/backend-architecture.md). It
 owns the current module model and package-boundary rules.
-
-## Module exports and imports
-
-Avoid broad barrel files inside modules. Prefer importing from the file that owns the
-symbol, such as `#core/auth.js` or `#presentation/dto/user.js`, rather than
-`#core/index.js` or another catch-all index.
-
-Package root exports should stay intentionally small: export only shared entities and
-functions that are part of the package's public API. Do not export internal DB helpers,
-routes, auth wiring, or test-only utilities from a package root unless another package
-is meant to depend on them directly.
 
 ## Codebase conventions
 
@@ -120,102 +113,6 @@ backend metrics model and cardinality constraints.
 If your task mints, verifies, or carries an authentication token, read the
 [Auth security model](libs/api/auth/README.md#security-model). It owns token
 authority, lifetime, trust boundaries, and logging constraints.
-
-## Code comments
-
-Default to fewer comments. Well-named functions, types, and variables carry the
-intent; the reader knows the language and the codebase, so a comment that
-restates the code is pure overhead: it adds nothing to read and silently rots
-when the code changes. The bar for a comment is: **would a competent reader be
-surprised or stuck without it?** If not, delete it.
-
-### Explain *why*, never *what*
-
-A comment earns its place by capturing intent the code cannot express: a
-non-obvious constraint, a workaround, a deliberate trade-off, or a subtlety that
-would otherwise read as a mistake. The good comments already in this codebase all
-answer "why":
-
-```ts
-// Algorithm-confusion guard: nothing outside the HS256 allowlist may verify.
-
-// Drizzle creates its migrations schema/table outside its own migration transaction.
-// Serialize migrators so parallel package tests do not race on that shared setup.
-
-// `request.routeOptions.url` is the route template (e.g. /public/cache/:id/chunk)
-// but can leak a query string in some Fastify edge cases. Strip it.
-```
-
-Delete comments that narrate the next line. These say nothing the code doesn't:
-
-```ts
-// bad: restates the code
-// Set test environment variable
-process.env.FOO = "bar";
-
-// bad: restates the function name
-// Helper function to create properly typed configs
-export function createConfig(...) {}
-```
-
-### Prefer self-documenting code over a comment
-
-When you feel the urge to explain a block, first try to make the explanation
-unnecessary: extract a named function, rename a variable, or reach for an
-idiomatic construct (`value ?? fallback`, early return, a typed enum). A good
-name beats a comment because it travels with every call site and can't drift out
-of sync. Only when the *why* genuinely can't live in the code does it become a
-comment, and if that why needs a paragraph, the awkwardness is usually the code;
-refactor first.
-
-### Keep control flow readable
-
-When a conditional expression is doing real work, name the decision before the
-branch. Prefer a small, intention-revealing variable such as `hasPendingStep`,
-`usesAuthoredMode`, or `shouldRetry` over repeating a compound expression inside
-`if`, ternary, or object-spread conditionals. Inline checks are fine for obvious
-single comparisons, but once a condition combines multiple concepts, give it a
-name so the branch reads like a sentence.
-
-Split long functions into focused units when they mix distinct responsibilities,
-such as loading state, validating preconditions, building a payload, handling an
-error branch, and applying the state change. Keep the top-level function as the
-orchestration path and move self-contained branches into helpers with names that
-describe the decision or action. Do not extract tiny helpers for their own sake;
-extract when it removes nesting, clarifies a branch, or gives a meaningful name
-to a reusable piece of logic.
-
-### Use JSDoc for documentation, not narration
-
-Reserve `/** ... */` for the public API of shared packages (exported functions,
-types, and config that other packages consume), where editor hover-docs add real
-value. JSDoc is also appropriate for usage documentation when a function is
-intended to be called outside its immediate module or local context and the
-caller needs to know constraints, ordering, side effects, or examples that are
-not obvious from the signature. Document parameters and behaviour that the
-signature can't convey; do not restate the type or the name:
-
-```ts
-/**
- * Verifies an HS256-signed token and validates its payload against `schema`.
- * Rejects any token whose `alg` header is outside the HS256 allowlist.
- *
- * @param audience - When set, jose rejects an `aud` mismatch before the schema runs.
- */
-```
-
-Self-evident functions need no docstring at all; one that echoes
-`getRunner(id): Runner` is noise. But when an internal function does earn a
-comment, prefer `/** ... */` over a loose `//`: it attaches to the symbol and
-surfaces on hover at every call site.
-
-### Keep planning and process out of the source
-
-No `// TODO`, `// v1 only`, `// added in follow-up PR`, or references to
-planning-doc decisions (`/plan-eng-review A1`) in module or function headers.
-Speculation about future work ("today X, tomorrow Y") and tracked tasks belong in
-`TODOS.md`, the issue tracker, or the design doc, not in code that outlives them.
-
 
 ## Design System
 

--- a/WRITING.md
+++ b/WRITING.md
@@ -9,9 +9,14 @@ Surface-specific rules build on top of this guide:
 
 - Docs app pages: [apps/docs/WRITING.md](apps/docs/WRITING.md)
   (page types, templates, schema rules).
-- Package READMEs: the `readme-writer` skill
-  (`.agents/skills/readme-writer/SKILL.md`) defines the required structure.
-- Code comments: see the "Code comments" section of [CLAUDE.md](CLAUDE.md).
+- Package READMEs: [the package README standard](#package-readmes) below.
+- Code comments and shared code style: [the code style policy](docs/policies/code-style.md).
+
+## Placement and ownership
+
+If you need to decide where documentation belongs or which source owns it,
+read the [engineering documentation map](docs/README.md). It defines
+documentation placement, scope, and contextual-link rules.
 
 ## Structure for skimming
 
@@ -81,3 +86,78 @@ Treat the output as guidance, not a gate:
   "utilize", "facilitate", or "subsequent" that add nothing.
 - Reference material (field tables, env-var lists) is exempt from the
   vocabulary floor; field names skew the count.
+
+## Package READMEs
+
+Package READMEs explain one package's purpose, public use, configuration, and
+local constraints. They follow this guide and keep repository-wide policy in
+its canonical source. Read the [engineering documentation map](docs/README.md)
+when deciding whether information belongs in a package README.
+
+Use the sections that apply, in this order:
+
+```text
+# <Display Name>             required
+<one-line description>       required
+
+## What it does              required
+## Installation / Setup      required
+## Usage                     required, with one runnable snippet
+## Environment               when the package reads process.env
+## Routes / API / Data Model when the package exposes one of these
+## Behavior Notes            optional, for non-obvious semantics
+## Development               required
+## License                   required
+```
+
+### Title and description
+
+Use a human-readable title for `@shipfox/*` runtime packages. Use the literal
+package name for tooling packages whose CLI name matters. Match the convention
+of neighboring packages.
+
+Write one sentence that answers what the package is for. Start with the noun
+phrase. Do not use marketing language.
+
+### Public surface and setup
+
+List the public surface under **What it does**. Start each bullet with the
+bolded exported symbol or concept, then explain it in one sentence. Group
+related exports when individual bullets would add noise.
+
+Under **Installation / Setup**, show the dependency command or `workspace:*`
+snippet that matches the package's distribution. Do not document unexported
+symbols or internal helpers.
+
+### Usage and reference details
+
+Include one small runnable TypeScript example that exercises the primary entry
+point. Import from the package root, not an internal path. If setup is needed,
+show it as a second smaller block in the same section.
+
+Use **Environment**, **Routes**, **API**, or **Data Model** only when they
+apply. Use a table for more than three repeated rows and bullets otherwise.
+Link to executable configuration or schemas instead of copying fast-changing
+defaults and accepted values.
+
+### Development and license
+
+Use the package-scoped commands that apply:
+
+```sh
+turbo check --filter=@shipfox/<name>
+turbo type --filter=@shipfox/<name>
+turbo test --filter=@shipfox/<name>
+```
+
+Omit `test` when the package has no test task. Add `turbo build` only when the
+package emits build output. Mention required services or fixtures in one
+sentence and link to their owner.
+
+End every package README with:
+
+```md
+## License
+
+MIT
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,8 @@ listed there or when you need to place, update, or review documentation.
 | Mints, verifies, or carries an authentication token. | [Auth security model](../libs/api/auth/README.md#security-model) | Token authority, lifetime, trust boundaries, and logging constraints. |
 | Defines an inter-module contract or transport. | [Inter-module package README](../libs/shared/common/inter-module/README.md) | Contract primitives and transport responsibilities. |
 | Creates or changes a visual or interaction decision. | [Design system](../DESIGN.md) | Shared tokens, components, accessibility, motion, status taxonomy, patterns, and review anti-patterns. Code owns exact token and component values. |
-| Writes engineering prose, a README, or a runbook. | [Writing guide](../WRITING.md) | Repository-wide prose structure, style, punctuation, and readability. |
+| Writes engineering prose, a package README, or a runbook. | [Writing guide](../WRITING.md) | Repository-wide prose structure, style, punctuation, readability, and package README structure. |
+| Writes or reviews code comments, module exports, or non-trivial control flow. | [Code style policy](policies/code-style.md) | Shared code-comment, import and export, and control-flow rules. |
 | Writes product or self-hosting documentation. | [Docs writing guide](../apps/docs/WRITING.md) | Product documentation page types, templates, and local terminology. |
 
 ## Documentation contract

--- a/docs/policies/code-style.md
+++ b/docs/policies/code-style.md
@@ -1,0 +1,69 @@
+# Code style policy
+
+This policy defines repository-wide rules for code comments, module exports,
+and readable control flow. It applies when writing or reviewing code. Package
+and subsystem guides may add local conventions when their boundary needs them.
+
+## Comments
+
+Default to fewer comments. Well-named functions, types, and variables explain
+intent. A comment that restates code adds reading cost. It can also drift from
+the code. Add a comment only when a competent reader would otherwise be
+surprised or stuck.
+
+### Explain why, not what
+
+A useful comment captures intent that code cannot express. It can record a
+constraint, workaround, tradeoff, or behavior that looks wrong at first. Do not
+narrate the next line.
+
+```ts
+// Algorithm-confusion guard: nothing outside the HS256 allowlist may verify.
+```
+
+```ts
+// Bad: restates the code.
+process.env.FOO = 'bar';
+```
+
+Prefer making a comment unnecessary. Extract a named function. Improve a
+variable name. Use an idiomatic construct before adding explanation. When a
+comment needs a paragraph, refactor the code first when practical.
+
+### Use JSDoc for shared APIs
+
+Use JSDoc for exported APIs in shared packages when callers need details that a
+signature cannot show. These details include constraints, ordering, side
+effects, and examples. Document behavior that is not obvious from a symbol's
+name or type. Do not restate the type or name.
+
+Use JSDoc for an internal symbol only when the same explanation helps at each
+call site. Otherwise, use a short comment beside the relevant code.
+
+### Keep process out of code
+
+Do not add TODOs, release plans, follow-up work, or plan references to source
+comments. Track future work in the issue tracker, `TODOS.md`, or a design
+document.
+
+## Module exports and imports
+
+Avoid broad barrel files inside modules. Import from the file that owns a
+symbol. For example, use `#core/auth.js` or `#presentation/dto/user.js`. Do not
+use a catch-all index file.
+
+Keep package-root exports small. Export shared entities and functions that are
+part of the package's public API. Do not export internal database helpers,
+routes, auth wiring, or test utilities unless another package needs them.
+
+## Readable control flow
+
+Name a conditional decision before branching when it combines multiple ideas.
+A name such as `hasPendingStep` or `shouldRetry` makes the branch read as a
+sentence. Inline checks work for obvious single comparisons.
+
+Split a function when it mixes distinct jobs. These jobs include loading state,
+checking preconditions, building a payload, handling an error, and applying a
+change. Keep the top-level function as the main path. Move self-contained
+branches into helpers with names that describe the decision or action. Do not
+extract tiny helpers without a clear benefit.


### PR DESCRIPTION
Establishes human-facing canonical sources for package README structure and shared code style, then routes agent guidance to those sources.

The README standard and comment, export, and control-flow rules previously lived only in agent-facing material. That made the rules harder for contributors to discover and risked separate guidance for people and agents.

The package README standard belongs in the repository writing guide, while code comments and code-style rules belong in a repository policy. Product documentation page types and templates remain in the docs-app writing guide.

Closes ENG-1154

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes writing and code standards audience-neutral by moving shared rules into repository docs so contributors and agents use the same sources. Adds a canonical code style policy and brings the package README standard into the writing guide. Closes ENG-1154.

- **New Features**
  - Added `docs/policies/code-style.md` with rules for comments (why vs what, JSDoc use, no TODO/process), module exports/imports, and readable control flow.
  - Moved the package README standard into `WRITING.md` with required sections, one runnable snippet, and dev commands.
  - Updated `docs/README.md` to map writing vs code-style ownership and link placement decisions to the engineering documentation map.
  - Trimmed `AGENTS.md` and linked to the canonical docs to remove duplicated comment/export/control-flow guidance.

<sup>Written for commit 62c93f4a218d4d9ae5e458908bd322177fabf993. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

