### PR TITLE
Add verified fast CI for generated release PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,9 +110,7 @@ jobs:
 
       - name: Start test services
         if: github.event_name != 'pull_request' || needs.release-classification.outputs.generated_release != 'true'
-        id: test-services
-        run: docker compose up --wait -d postgres
-        background: true
+        run: docker compose up -d postgres
 
       - name: Set up mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
@@ -130,7 +128,7 @@ jobs:
 
       - name: Wait for test services
         if: github.event_name != 'pull_request' || needs.release-classification.outputs.generated_release != 'true'
-        wait: test-services
+        run: docker compose up --wait postgres
 
       - name: Verify external package contracts
         if: github.event_name != 'pull_request' || needs.release-classification.outputs.generated_release != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,72 @@ env:
 # Parallel jobs cannot share PR-written remote cache artifacts, so each job
 # rebuilds what its own Turbo graph needs.
 jobs:
+  release-classification:
+    name: Classify release PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      generated_release: ${{ steps.classify.outputs.generated_release || 'false' }}
+      reason: ${{ steps.classify.outputs.reason || 'not-a-release-pr' }}
+
+    steps:
+      - name: Check out repository
+        if: github.event_name == 'pull_request' && vars.FORCE_FULL_CI != 'true'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up mise
+        if: github.event_name == 'pull_request' && vars.FORCE_FULL_CI != 'true'
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
+
+      - name: Set up pnpm
+        if: github.event_name == 'pull_request' && vars.FORCE_FULL_CI != 'true'
+        uses: ./.github/actions/setup-pnpm
+
+      - name: Build generated-release verifier
+        if: github.event_name == 'pull_request' && vars.FORCE_FULL_CI != 'true'
+        run: turbo build --filter=@shipfox/package-release
+
+      - name: Verify generated release tree
+        id: classify
+        if: github.event_name == 'pull_request' && vars.FORCE_FULL_CI != 'true'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PULL_REQUEST_AUTHOR_ID: ${{ github.event.pull_request.user.id }}
+          RELEASE_BOT_APP_ID: ${{ vars.RELEASE_BOT_APP_ID }}
+        run: |
+          set +e
+          pnpm --silent --filter=@shipfox/package-release verify-generated-release -- \
+            --base "$BASE_SHA" \
+            --head "$HEAD_SHA" \
+            --repository "$GITHUB_REPOSITORY" \
+            --head-repository "$HEAD_REPOSITORY" \
+            --head-ref "$HEAD_REF" \
+            --author-id "$PULL_REQUEST_AUTHOR_ID" \
+            --release-app-id "$RELEASE_BOT_APP_ID" \
+            > "$RUNNER_TEMP/release-verification.json"
+          verifier_status=$?
+          set -e
+
+          result="$(tail -n 1 "$RUNNER_TEMP/release-verification.json")"
+          classification="$(jq -r '.classification // "unknown"' <<< "$result" 2>/dev/null || true)"
+          reason="$(jq -r '.reason // "verification-error"' <<< "$result" 2>/dev/null || true)"
+          generated_release=false
+          if [[ "$verifier_status" == 0 && "$classification" == generated-release ]]; then
+            generated_release=true
+          fi
+
+          echo "generated_release=$generated_release" >> "$GITHUB_OUTPUT"
+          echo "reason=$reason" >> "$GITHUB_OUTPUT"
+
   static-verification:
     name: Static verification
+    needs: [release-classification]
+    if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 40
     env:
@@ -45,6 +109,7 @@ jobs:
           fetch-depth: 0
 
       - name: Start test services
+        if: github.event_name != 'pull_request' || needs.release-classification.outputs.generated_release != 'true'
         id: test-services
         run: docker compose up --wait -d postgres
         background: true
@@ -56,19 +121,52 @@ jobs:
         uses: ./.github/actions/setup-pnpm
 
       - name: Run static verification
+        if: github.event_name != 'pull_request' || needs.release-classification.outputs.generated_release != 'true'
         run: turbo check type build depcruise $SHIPFOX_TURBO_AFFECTED --concurrency="$SHIPFOX_TURBO_CONCURRENCY"
 
       - name: Verify repository and package policies
+        if: github.event_name != 'pull_request' || needs.release-classification.outputs.generated_release != 'true'
         run: turbo verify --concurrency="$SHIPFOX_TURBO_CONCURRENCY"
 
       - name: Wait for test services
+        if: github.event_name != 'pull_request' || needs.release-classification.outputs.generated_release != 'true'
         wait: test-services
 
       - name: Verify external package contracts
+        if: github.event_name != 'pull_request' || needs.release-classification.outputs.generated_release != 'true'
         run: turbo test:external --filter=@shipfox/application-release --filter=@shipfox/client-shell --concurrency=1
+
+      - name: Verify release metadata and publication closure
+        if: github.event_name == 'pull_request' && needs.release-classification.outputs.generated_release == 'true'
+        run: |
+          turbo verify --filter=@shipfox/package-release...
+          turbo test --filter=@shipfox/package-release...
+          pnpm run release:preflight
+
+      - name: Summarize verified release CI
+        if: github.event_name == 'pull_request' && needs.release-classification.outputs.generated_release == 'true'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          {
+            echo '## Verified generated release CI'
+            echo
+            echo '- Classification: `generated-release` (deterministic tree verification passed)'
+            echo '- Files in release:'
+            git diff --name-only "$BASE_SHA" "$HEAD_SHA" | sed 's/^/  - `/' | sed 's/$/`/'
+            echo '- Package directories changed:'
+            git diff --name-only "$BASE_SHA" "$HEAD_SHA" | awk -F/ '/^(libs|tools)\// {print $1 "/" $2}' | sort -u | sed 's/^/  - `/' | sed 's/$/`/'
+            echo '- Checks run: frozen dependency install, package-release policy checks and tests, whole-closure `release:preflight`.'
+            echo '- Checks intentionally skipped: unit/story suite, E2E suite, and application image matrix.'
+            echo '- Preflight result: passed.'
+            echo '- Expected comparison: under 5 minutes and under 7.65 runner-minutes, versus the 13-minute / 51 runner-minute baseline.'
+          } >> "$GITHUB_STEP_SUMMARY"
 
   publication-preflight:
     name: Package publication preflight
+    needs: [release-classification]
+    if: always() && (github.event_name != 'pull_request' || needs.release-classification.outputs.generated_release != 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -87,6 +185,8 @@ jobs:
 
   tests:
     name: Unit and story tests
+    needs: [release-classification]
+    if: always() && (github.event_name != 'pull_request' || needs.release-classification.outputs.generated_release != 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 40
     env:
@@ -125,6 +225,8 @@ jobs:
 
   e2e:
     name: E2E tests
+    needs: [release-classification]
+    if: always() && (github.event_name != 'pull_request' || needs.release-classification.outputs.generated_release != 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -193,7 +295,8 @@ jobs:
   # permission. Main publishes images in `publish-images`.
   build-image:
     name: Build image (${{ matrix.image }})
-    if: github.ref != 'refs/heads/main'
+    needs: [release-classification]
+    if: always() && github.ref != 'refs/heads/main' && (github.event_name != 'pull_request' || needs.release-classification.outputs.generated_release != 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -233,7 +336,7 @@ jobs:
 
   build-images:
     name: Build images
-    needs: [build-image]
+    needs: [release-classification, build-image]
     if: always() && github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -241,11 +344,18 @@ jobs:
     steps:
       - name: Report image validation
         run: |
+          if [ "${{ needs.build-image.result }}" = "success" ]; then
+            echo "Image validation matrix completed."
+            exit 0
+          fi
+          if [ "${{ needs.release-classification.outputs.generated_release }}" = "true" ] && [ "${{ needs.build-image.result }}" = "skipped" ]; then
+            echo "Image validation matrix intentionally skipped for a verified generated release PR."
+            exit 0
+          fi
           if [ "${{ needs.build-image.result }}" != "success" ]; then
             echo "Image validation matrix result: ${{ needs.build-image.result }}"
             exit 1
           fi
-          echo "Image validation matrix completed."
 
   # Publishing stays in a main-only job so package write permission is granted
   # only after verification and E2E pass. It restores build output from Turbo's

--- a/docs/guides/release-pr-ci.md
+++ b/docs/guides/release-pr-ci.md
@@ -1,0 +1,9 @@
+# Generated release PR CI
+
+Changesets-generated release PRs use the fast CI path only when the repository-owned verifier reproduces their complete tree from the PR base revision. The release App identity and branch name narrow the candidate set; the regenerated tree comparison is the security boundary.
+
+The fast path keeps the required `Static verification`, `Unit and story tests`, `E2E tests`, and `Build images` contexts successful. It runs frozen dependency installation, package-release policy checks and tests, and the complete publication-closure preflight. The unit/story suite, E2E suite, and application image matrix are intentionally skipped.
+
+Any verification error, timeout, malformed result, source edit, or other mismatch fails closed to the normal CI path.
+
+To force full CI for every PR temporarily, set the repository Actions variable `FORCE_FULL_CI` to `true`.

--- a/tools/package-release/test/release-ci-workflow.test.ts
+++ b/tools/package-release/test/release-ci-workflow.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import {readFile} from 'node:fs/promises';
+import {dirname, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const packageDirectory = dirname(fileURLToPath(import.meta.url));
+const workflowPath = resolve(packageDirectory, '../../../.github/workflows/ci.yml');
+
+function readWorkflow() {
+  return readFile(workflowPath, 'utf8');
+}
+
+describe('generated release CI path', () => {
+  test('uses deterministic classification only for release PR fixture data', async () => {
+    const workflow = await readWorkflow();
+
+    assert.ok(workflow.includes('release-classification:'));
+    assert.ok(workflow.includes('--base "$BASE_SHA"'));
+    assert.ok(workflow.includes('--head "$HEAD_SHA"'));
+    assert.ok(workflow.includes('--release-app-id "$RELEASE_BOT_APP_ID"'));
+    assert.ok(workflow.includes('generated_release=false'));
+    assert.ok(workflow.includes('classification" == generated-release'));
+  });
+
+  test('runs normal CI for normal, malformed, and main-push fixture conditions', async () => {
+    const workflow = await readWorkflow();
+
+    assert.ok(
+      workflow.includes(
+        "github.event_name != 'pull_request' || needs.release-classification.outputs.generated_release != 'true'",
+      ),
+    );
+    assert.ok(
+      workflow.includes(
+        "always() && (github.event_name != 'pull_request' || needs.release-classification.outputs.generated_release != 'true')",
+      ),
+    );
+  });
+
+  test('keeps required checks successful when the image matrix is intentionally skipped', async () => {
+    const workflow = await readWorkflow();
+
+    assert.ok(workflow.includes('name: Static verification'));
+    assert.ok(workflow.includes('name: Unit and story tests'));
+    assert.ok(workflow.includes('name: E2E tests'));
+    assert.ok(workflow.includes('name: Build images'));
+    assert.ok(
+      workflow.includes('needs.release-classification.outputs.generated_release }}" = "true"') &&
+        workflow.includes('needs.build-image.result }}" = "skipped"'),
+    );
+  });
+});


### PR DESCRIPTION
Adds a fail-closed CI classification path for deterministic Changesets release PRs.

Generated release trees were paying for application, browser, E2E, and image validation even though they only contain version metadata. This preserves the existing required contexts while routing verified release trees through frozen installation, package-release validation, and whole-closure publication preflight; every other result keeps the normal CI path.

The release classifier treats an error, malformed output, source edit, or a forced fallback as non-release traffic. The image aggregator accepts a skipped matrix only for the verified path, so an unexpected skip remains blocking. `FORCE_FULL_CI=true` is documented as the immediate rollback.

Live generated-release runs still need timing and runner-minute capture before the issue can be closed.

Refs ENG-1169

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a verified fast CI path for Changesets-generated release PRs, keeping required checks green while skipping heavy suites. Falls back to full CI on any verification issue. Addresses ENG-1169.

- **New Features**
  - Adds `release-classification` job to deterministically verify generated release trees with `@shipfox/package-release`.
  - Routes verified PRs to frozen install, package-release checks/tests, and whole-closure `release:preflight`; others use normal CI.
  - Skips unit/story, E2E, and image matrix for verified PRs; image aggregator treats this skip as intentional so required contexts still pass.
  - Fails closed to full CI on errors, malformed output, source edits, or mismatches; set `FORCE_FULL_CI=true` to force full CI.
  - Adds guide at `docs/guides/release-pr-ci.md` and workflow tests to assert routing and required-check behavior.

- **Bug Fixes**
  - Uses standard Docker Compose start and wait commands so the release-path conditions remain valid in GitHub Actions.

<sup>Written for commit 706b705c81f74654b864c1ea5301ea3c9ed01e3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

