### PR TITLE
Make CI mise setup tool-specific

### DIFF
--- a/.github/actions/setup-mise/action.yml
+++ b/.github/actions/setup-mise/action.yml
@@ -1,0 +1,21 @@
+name: Set up mise
+description: Install only the mise tools required by a CI job and restore its trusted cache.
+
+inputs:
+  tools:
+    description: Space-separated mise tool names required by the job.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set up selected mise tools
+      uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
+      with:
+        install_args: ${{ inputs.tools }}
+        # Keep each tool set isolated and invalidate it whenever the locked mise
+        # configuration changes. There is deliberately no cross-profile fallback.
+        cache_key: mise-ci-tools-v1-{{platform}}-{{install_args_hash}}-{{file_hash}}
+        # Pull requests may restore caches seeded by main, but only approved code
+        # may publish executable tool archives for later workflow runs.
+        cache_save: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,9 @@ jobs:
         background: true
 
       - name: Set up mise
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
+        uses: ./.github/actions/setup-mise
+        with:
+          tools: node npm:pnpm npm:turbo packer
 
       - name: Set up pnpm
         uses: ./.github/actions/setup-pnpm
@@ -77,7 +79,9 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up mise
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
+        uses: ./.github/actions/setup-mise
+        with:
+          tools: node npm:pnpm npm:turbo
 
       - name: Set up pnpm
         uses: ./.github/actions/setup-pnpm
@@ -107,7 +111,9 @@ jobs:
         background: true
 
       - name: Set up mise
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
+        uses: ./.github/actions/setup-mise
+        with:
+          tools: node npm:pnpm npm:turbo
 
       - name: Set up pnpm
         uses: ./.github/actions/setup-pnpm
@@ -149,7 +155,9 @@ jobs:
         background: true
 
       - name: Set up mise
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
+        uses: ./.github/actions/setup-mise
+        with:
+          tools: node npm:pnpm npm:turbo
 
       - name: Set up pnpm
         uses: ./.github/actions/setup-pnpm
@@ -218,7 +226,9 @@ jobs:
           fetch-depth: 0
 
       - name: Set up mise
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
+        uses: ./.github/actions/setup-mise
+        with:
+          tools: node npm:pnpm npm:turbo
 
       - name: Set up pnpm
         uses: ./.github/actions/setup-pnpm
@@ -271,7 +281,9 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up mise
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
+        uses: ./.github/actions/setup-mise
+        with:
+          tools: node npm:pnpm npm:turbo
 
       - name: Set up pnpm
         uses: ./.github/actions/setup-pnpm
@@ -322,7 +334,9 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up mise
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
+        uses: ./.github/actions/setup-mise
+        with:
+          tools: node npm:pnpm npm:turbo packer
 
       - name: Set up pnpm
         uses: ./.github/actions/setup-pnpm
@@ -382,7 +396,9 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up mise
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
+        uses: ./.github/actions/setup-mise
+        with:
+          tools: gh node npm:pnpm npm:turbo
 
       - name: Set up pnpm
         uses: ./.github/actions/setup-pnpm

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -34,7 +34,9 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up mise
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
+        uses: ./.github/actions/setup-mise
+        with:
+          tools: node npm:pnpm npm:turbo
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts


### PR DESCRIPTION
CI currently restores one mise cache containing every repository tool in every job, including large tools that most jobs never execute. This makes the common Node, pnpm, and Turbo setup pay for unrelated Packer, Ollama, and GitHub CLI installations.

Add a shared setup action that installs the tool set each job actually requires. Its cache key isolates profiles by platform, selected tools, and the locked mise configuration; pull requests may restore those caches, while only main can publish executable tool archives.

Packer remains available to static verification and runner-image publication, and the pinned GitHub CLI remains available to application-release publication. Ollama is omitted because no CI command starts or invokes the installed binary.

The first main run after merge will seed the new cache namespace for subsequent CI runs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make CI `mise` setup tool-specific so each job installs only what it needs. This speeds up runs and cuts cache size by avoiding unused tools.

- **Refactors**
  - Added `.github/actions/setup-mise` that wraps `jdx/mise-action` and installs selected tools via `install_args`.
  - Isolated caches by platform, selected tools, and locked config; PRs restore caches, only `main` saves them.
  - Updated `ci.yml` and `publish-packages.yml` to request minimal tool sets (e.g., `node`, `npm:pnpm`, `npm:turbo`, plus `packer` or `gh` where needed); removed unused Ollama.
  - First `main` run after merge will seed the new cache namespace.

<sup>Written for commit 9fe47b0cc242fe8e1e8df5d86b47e63bcb281fe8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

