### PR TITLE
Split package release PR updates from publication

### DIFF
--- a/.github/scripts/package-release-workflow.mjs
+++ b/.github/scripts/package-release-workflow.mjs
@@ -1,0 +1,174 @@
+import {spawn} from 'node:child_process';
+import {mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+
+function argument(name) {
+  const index = process.argv.indexOf(`--${name}`);
+  return index === -1 ? undefined : process.argv[index + 1];
+}
+
+function run(command, args) {
+  return new Promise((resolveCommand, reject) => {
+    const child = spawn(command, args, {stdio: ['ignore', 'pipe', 'pipe']});
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.once('error', reject);
+    child.once('exit', (code) => resolveCommand({code, stderr, stdout}));
+  });
+}
+
+async function writeOutput(values) {
+  const outputPath = argument('github-output');
+  if (!outputPath) return;
+  await writeFile(
+    outputPath,
+    `${Object.entries(values)
+      .map(([key, value]) => `${key}=${value}`)
+      .join('\n')}\n`,
+    {flag: 'a'},
+  );
+}
+
+async function writeSummary(summary) {
+  const summaryPath = argument('github-summary');
+  if (!summaryPath) return;
+  await writeFile(summaryPath, `${summary}\n`, {flag: 'a'});
+}
+
+async function plan() {
+  const temporaryRoot = await mkdtemp(join(tmpdir(), 'shipfox-release-plan-'));
+  const outputPath = join(temporaryRoot, 'release-plan.json');
+  try {
+    const result = await run('pnpm', ['exec', 'changeset', 'status', '--output', outputPath]);
+    const plan =
+      result.code === 0 ? JSON.parse(await readFile(outputPath, 'utf8')) : {releases: []};
+    const releases = Array.isArray(plan.releases) ? plan.releases : [];
+    const hasChangesets = releases.length > 0;
+    await writeOutput({has_changesets: String(hasChangesets)});
+    await writeSummary(
+      hasChangesets
+        ? `## Package release plan\n\n${releases.map(({name, newVersion}) => `- \`${name}@${newVersion}\``).join('\n')}`
+        : '## Package release PR\n\nNo unreleased changesets found; the release-PR updater is a no-op.',
+    );
+    process.stdout.write(`${JSON.stringify({hasChangesets, releases})}\n`);
+  } finally {
+    await rm(temporaryRoot, {force: true, recursive: true});
+  }
+}
+
+function releaseFromPullRequest(pullRequest, revision) {
+  return {
+    authorId: String(pullRequest.user?.id ?? ''),
+    baseRevision: pullRequest.base?.sha ?? '',
+    headRef: pullRequest.head?.ref ?? '',
+    headRepository: pullRequest.head?.repo?.full_name ?? '',
+    revision,
+  };
+}
+
+async function authorize() {
+  const eventName = argument('event-name');
+  const repository = argument('repository');
+  const expectedAppId = argument('release-app-id');
+  const revision = argument('revision');
+  let release = {
+    authorId: argument('author-id') ?? '',
+    baseRevision: argument('base') ?? '',
+    headRef: argument('head-ref') ?? '',
+    headRepository: argument('head-repository') ?? '',
+    revision: revision ?? '',
+  };
+
+  if (eventName === 'pull_request' && argument('merged') !== 'true') {
+    await writeOutput({authorized: 'false'});
+    return;
+  }
+  if (eventName === 'workflow_dispatch' && revision) {
+    const result = await run('gh', ['api', `repos/${repository}/commits/${revision}/pulls`]);
+    const pullRequest =
+      result.code === 0
+        ? JSON.parse(result.stdout).find(
+            (candidate) => candidate.merged_at !== null && candidate.merge_commit_sha === revision,
+          )
+        : undefined;
+    if (pullRequest) release = releaseFromPullRequest(pullRequest, revision);
+  }
+
+  const reason =
+    !release.revision ||
+    !release.baseRevision ||
+    !release.headRepository ||
+    !release.headRef ||
+    !release.authorId
+      ? 'missing-release-metadata'
+      : release.headRepository !== repository
+        ? 'head-repository-mismatch'
+        : release.headRef !== 'changeset-release/main'
+          ? 'release-branch-mismatch'
+          : release.authorId !== expectedAppId
+            ? 'release-app-mismatch'
+            : 'authorized';
+  const authorized = reason === 'authorized';
+  await writeOutput({
+    authorized: String(authorized),
+    author_id: authorized ? release.authorId : '',
+    base_sha: authorized ? release.baseRevision : '',
+    head_ref: authorized ? release.headRef : '',
+    head_repository: authorized ? release.headRepository : '',
+    revision: authorized ? release.revision : '',
+  });
+  await writeSummary(
+    `## Package publication authorization\n\n- Result: **${authorized ? 'authorized' : 'not authorized'}**\n- Reason: \`${reason}\``,
+  );
+  process.stdout.write(`${JSON.stringify({authorized, reason})}\n`);
+}
+
+async function summarizeUpdate() {
+  const before = JSON.parse(await readFile(argument('before'), 'utf8'));
+  const after = JSON.parse(await readFile(argument('after'), 'utf8'));
+  const beforeHead = before[0]?.headRefOid;
+  const afterHead = after[0]?.headRefOid;
+  const result =
+    !beforeHead && afterHead ? 'created' : beforeHead !== afterHead ? 'updated' : 'unchanged';
+  const number = after[0]?.number;
+  await writeSummary(
+    [
+      '## Package release PR',
+      '',
+      `- Trigger: \`${argument('trigger')}\``,
+      `- Result: **${result}**`,
+      ...(number ? [`- Release PR: #${number}`] : []),
+      '- Publication authority: none',
+      '- Batching: a newer `main` push cancels pending or running updater work; npm publication uses a separate non-cancelable workflow.',
+    ].join('\n'),
+  );
+  process.stdout.write(`${JSON.stringify({number, result})}\n`);
+}
+
+async function summarizePublication() {
+  await writeSummary(
+    [
+      '## npm package publication',
+      '',
+      `- Trigger: \`${argument('trigger')}\``,
+      `- Revision: \`${argument('revision')}\``,
+      '- Release tree: deterministically verified before publication.',
+      '- Publication: completed; the publisher is serialized and never canceled.',
+      '- Recovery: rerun this workflow with `workflow_dispatch` and the same exact merged revision. The closure publisher skips package versions already present in npm.',
+    ].join('\n'),
+  );
+}
+
+const command = process.argv[2];
+if (command === 'plan') await plan();
+else if (command === 'authorize') await authorize();
+else if (command === 'summarize-update') await summarizeUpdate();
+else if (command === 'summarize-publication') await summarizePublication();
+else throw new Error(`Unknown package release workflow command: ${command ?? '(missing)'}`);

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,23 +1,95 @@
 name: Publish packages
 
 on:
-  push:
+  pull_request:
     branches: [main]
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      revision:
+        description: Exact merged release revision to recover
+        required: true
+        type: string
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
   id-token: write
 
 concurrency:
-  group: publish-packages-${{ github.ref }}
+  group: npm-package-publication
   cancel-in-progress: false
 
 jobs:
-  release:
-    name: Open release PR or publish
+  authorize-release:
+    name: Authorize merged release
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 5
+    outputs:
+      authorized: ${{ steps.release.outputs.authorized }}
+      revision: ${{ steps.release.outputs.revision }}
+      base_sha: ${{ steps.release.outputs.base_sha }}
+      head_repository: ${{ steps.release.outputs.head_repository }}
+      head_ref: ${{ steps.release.outputs.head_ref }}
+      author_id: ${{ steps.release.outputs.author_id }}
+
+    steps:
+      - name: Identify merged generated release
+        id: release
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_MERGED: ${{ github.event.pull_request.merged }}
+          EVENT_REVISION: ${{ github.event.pull_request.merge_commit_sha }}
+          EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          EVENT_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          EVENT_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          EVENT_AUTHOR_ID: ${{ github.event.pull_request.user.id }}
+          INPUT_REVISION: ${{ inputs.revision }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [[ "$EVENT_NAME" == pull_request ]]; then
+            if [[ "$EVENT_MERGED" != true ]]; then
+              echo 'authorized=false' >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            revision="$EVENT_REVISION"
+            base_sha="$EVENT_BASE_SHA"
+            head_repository="$EVENT_HEAD_REPOSITORY"
+            head_ref="$EVENT_HEAD_REF"
+            author_id="$EVENT_AUTHOR_ID"
+          else
+            revision="$INPUT_REVISION"
+            release_pr="$(gh api "repos/$GITHUB_REPOSITORY/commits/$revision/pulls" | jq --arg revision "$revision" '[.[] | select(.merged_at != null and .merge_commit_sha == $revision)][0]')"
+            if [[ -z "$release_pr" || "$release_pr" == null ]]; then
+              echo 'authorized=false' >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            base_sha="$(jq -r '.base.sha' <<< "$release_pr")"
+            head_repository="$(jq -r '.head.repo.full_name' <<< "$release_pr")"
+            head_ref="$(jq -r '.head.ref' <<< "$release_pr")"
+            author_id="$(jq -r '.user.id' <<< "$release_pr")"
+          fi
+
+          if [[ -z "$revision" || "$head_repository" != "$GITHUB_REPOSITORY" || "$head_ref" != changeset-release/main || "$author_id" != "${{ vars.RELEASE_BOT_APP_ID }}" ]]; then
+            echo 'authorized=false' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          {
+            echo 'authorized=true'
+            echo "revision=$revision"
+            echo "base_sha=$base_sha"
+            echo "head_repository=$head_repository"
+            echo "head_ref=$head_ref"
+            echo "author_id=$author_id"
+          } >> "$GITHUB_OUTPUT"
+
+  publish:
+    name: Publish verified packages
+    needs: authorize-release
+    if: needs.authorize-release.outputs.authorized == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Mint App installation token
@@ -27,10 +99,11 @@ jobs:
           client-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
 
-      - name: Check out repository
+      - name: Check out exact merged revision
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
+          ref: ${{ needs.authorize-release.outputs.revision }}
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up mise
@@ -41,14 +114,28 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
 
-      - name: Open release PR or publish
-        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
-        with:
-          version: pnpm exec changeset version
-          publish: pnpm run release:publish
-          commit: "Version packages"
-          title: "Version packages"
-          commitMode: github-api
+      - name: Verify merged release tree
+        env:
+          BASE_SHA: ${{ needs.authorize-release.outputs.base_sha }}
+          HEAD_REPOSITORY: ${{ needs.authorize-release.outputs.head_repository }}
+          HEAD_REF: ${{ needs.authorize-release.outputs.head_ref }}
+          AUTHOR_ID: ${{ needs.authorize-release.outputs.author_id }}
+          RELEASE_BOT_APP_ID: ${{ vars.RELEASE_BOT_APP_ID }}
+          REVISION: ${{ needs.authorize-release.outputs.revision }}
+        run: |
+          turbo build --filter=@shipfox/package-release
+          pnpm --silent --filter=@shipfox/package-release verify-generated-release -- \
+            --base "$BASE_SHA" \
+            --head "$REVISION" \
+            --repository "$GITHUB_REPOSITORY" \
+            --head-repository "$HEAD_REPOSITORY" \
+            --head-ref "$HEAD_REF" \
+            --author-id "$AUTHOR_ID" \
+            --release-app-id "$RELEASE_BOT_APP_ID" \
+            | tee "$RUNNER_TEMP/release-verification.json"
+          jq -e '.classification == "generated-release"' "$RUNNER_TEMP/release-verification.json" >/dev/null
+
+      - name: Publish package closure
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_CONFIG_PROVENANCE: "true"
@@ -56,3 +143,19 @@ jobs:
           TURBO_TEAM: shipfox
           # Publish must never populate the shared cache — only read what CI built.
           TURBO_CACHE: local:rw,remote:r
+        run: pnpm run release:publish
+
+      - name: Summarize publication
+        env:
+          REVISION: ${{ needs.authorize-release.outputs.revision }}
+          TRIGGER: ${{ github.event_name }}
+        run: |
+          {
+            echo '## npm package publication'
+            echo
+            echo "- Trigger: \`$TRIGGER\`"
+            echo "- Revision: \`$REVISION\`"
+            echo '- Release tree: deterministically verified before publication.'
+            echo '- Publication: completed; the publisher is serialized and never canceled.'
+            echo '- Recovery: rerun this workflow with `workflow_dispatch` and the same exact merged revision. The closure publisher skips package versions already present in npm.'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -34,6 +34,11 @@ jobs:
       author_id: ${{ steps.release.outputs.author_id }}
 
     steps:
+      - name: Check out workflow tools
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
       - name: Identify merged generated release
         id: release
         env:
@@ -47,42 +52,18 @@ jobs:
           INPUT_REVISION: ${{ inputs.revision }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          if [[ "$EVENT_NAME" == pull_request ]]; then
-            if [[ "$EVENT_MERGED" != true ]]; then
-              echo 'authorized=false' >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-            revision="$EVENT_REVISION"
-            base_sha="$EVENT_BASE_SHA"
-            head_repository="$EVENT_HEAD_REPOSITORY"
-            head_ref="$EVENT_HEAD_REF"
-            author_id="$EVENT_AUTHOR_ID"
-          else
-            revision="$INPUT_REVISION"
-            release_pr="$(gh api "repos/$GITHUB_REPOSITORY/commits/$revision/pulls" | jq --arg revision "$revision" '[.[] | select(.merged_at != null and .merge_commit_sha == $revision)][0]')"
-            if [[ -z "$release_pr" || "$release_pr" == null ]]; then
-              echo 'authorized=false' >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-            base_sha="$(jq -r '.base.sha' <<< "$release_pr")"
-            head_repository="$(jq -r '.head.repo.full_name' <<< "$release_pr")"
-            head_ref="$(jq -r '.head.ref' <<< "$release_pr")"
-            author_id="$(jq -r '.user.id' <<< "$release_pr")"
-          fi
-
-          if [[ -z "$revision" || "$head_repository" != "$GITHUB_REPOSITORY" || "$head_ref" != changeset-release/main || "$author_id" != "${{ vars.RELEASE_BOT_APP_ID }}" ]]; then
-            echo 'authorized=false' >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          {
-            echo 'authorized=true'
-            echo "revision=$revision"
-            echo "base_sha=$base_sha"
-            echo "head_repository=$head_repository"
-            echo "head_ref=$head_ref"
-            echo "author_id=$author_id"
-          } >> "$GITHUB_OUTPUT"
+          node .github/scripts/package-release-workflow.mjs authorize \
+            --event-name "$EVENT_NAME" \
+            --merged "$EVENT_MERGED" \
+            --revision "${INPUT_REVISION:-$EVENT_REVISION}" \
+            --base "$EVENT_BASE_SHA" \
+            --head-repository "$EVENT_HEAD_REPOSITORY" \
+            --head-ref "$EVENT_HEAD_REF" \
+            --author-id "$EVENT_AUTHOR_ID" \
+            --repository "$GITHUB_REPOSITORY" \
+            --release-app-id "${{ vars.RELEASE_BOT_APP_ID }}" \
+            --github-output "$GITHUB_OUTPUT" \
+            --github-summary "$GITHUB_STEP_SUMMARY"
 
   publish:
     name: Publish verified packages
@@ -115,25 +96,16 @@ jobs:
         run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Verify merged release tree
-        env:
-          BASE_SHA: ${{ needs.authorize-release.outputs.base_sha }}
-          HEAD_REPOSITORY: ${{ needs.authorize-release.outputs.head_repository }}
-          HEAD_REF: ${{ needs.authorize-release.outputs.head_ref }}
-          AUTHOR_ID: ${{ needs.authorize-release.outputs.author_id }}
-          RELEASE_BOT_APP_ID: ${{ vars.RELEASE_BOT_APP_ID }}
-          REVISION: ${{ needs.authorize-release.outputs.revision }}
         run: |
           turbo build --filter=@shipfox/package-release
           pnpm --silent --filter=@shipfox/package-release verify-generated-release -- \
-            --base "$BASE_SHA" \
-            --head "$REVISION" \
+            --base "${{ needs.authorize-release.outputs.base_sha }}" \
+            --head "${{ needs.authorize-release.outputs.revision }}" \
             --repository "$GITHUB_REPOSITORY" \
-            --head-repository "$HEAD_REPOSITORY" \
-            --head-ref "$HEAD_REF" \
-            --author-id "$AUTHOR_ID" \
-            --release-app-id "$RELEASE_BOT_APP_ID" \
-            | tee "$RUNNER_TEMP/release-verification.json"
-          jq -e '.classification == "generated-release"' "$RUNNER_TEMP/release-verification.json" >/dev/null
+            --head-repository "${{ needs.authorize-release.outputs.head_repository }}" \
+            --head-ref "${{ needs.authorize-release.outputs.head_ref }}" \
+            --author-id "${{ needs.authorize-release.outputs.author_id }}" \
+            --release-app-id "${{ vars.RELEASE_BOT_APP_ID }}"
 
       - name: Publish package closure
         env:
@@ -146,16 +118,8 @@ jobs:
         run: pnpm run release:publish
 
       - name: Summarize publication
-        env:
-          REVISION: ${{ needs.authorize-release.outputs.revision }}
-          TRIGGER: ${{ github.event_name }}
         run: |
-          {
-            echo '## npm package publication'
-            echo
-            echo "- Trigger: \`$TRIGGER\`"
-            echo "- Revision: \`$REVISION\`"
-            echo '- Release tree: deterministically verified before publication.'
-            echo '- Publication: completed; the publisher is serialized and never canceled.'
-            echo '- Recovery: rerun this workflow with `workflow_dispatch` and the same exact merged revision. The closure publisher skips package versions already present in npm.'
-          } >> "$GITHUB_STEP_SUMMARY"
+          node .github/scripts/package-release-workflow.mjs summarize-publication \
+            --trigger "${{ github.event_name }}" \
+            --revision "${{ needs.authorize-release.outputs.revision }}" \
+            --github-summary "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/update-release-pr.yml
+++ b/.github/workflows/update-release-pr.yml
@@ -1,0 +1,135 @@
+name: Update package release PR
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: update-package-release-pr-main
+  cancel-in-progress: true
+
+jobs:
+  detect-changesets:
+    name: Detect unreleased changesets
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      has_changesets: ${{ steps.changesets.outputs.has_changesets }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Set up mise
+        uses: ./.github/actions/setup-mise
+        with:
+          tools: node npm:pnpm npm:turbo
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Detect unreleased changesets
+        id: changesets
+        run: |
+          set +e
+          pnpm exec changeset status --output "$RUNNER_TEMP/release-plan.json"
+          status=$?
+          set -e
+
+          if [[ $status -eq 0 ]] && jq -e '.releases | length > 0' "$RUNNER_TEMP/release-plan.json" >/dev/null; then
+            echo 'has_changesets=true' >> "$GITHUB_OUTPUT"
+            echo '## Package release plan' >> "$GITHUB_STEP_SUMMARY"
+            jq -r '.releases[] | "- `\(.name)@\(.newVersion)`"' "$RUNNER_TEMP/release-plan.json" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo 'has_changesets=false' >> "$GITHUB_OUTPUT"
+            echo '## Package release PR' >> "$GITHUB_STEP_SUMMARY"
+            echo 'No unreleased changesets found; the release-PR updater is a no-op.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  update-release-pr:
+    name: Update release PR
+    needs: detect-changesets
+    if: needs.detect-changesets.outputs.has_changesets == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Mint App installation token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
+
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Set up mise
+        uses: ./.github/actions/setup-mise
+        with:
+          tools: gh node npm:pnpm npm:turbo
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Snapshot standing release PR
+        id: before
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --base main \
+            --head changeset-release/main \
+            --state open \
+            --json number,updatedAt,headRefOid > "$RUNNER_TEMP/release-pr-before.json"
+
+      - name: Generate release PR
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
+        with:
+          version: pnpm exec changeset version
+          commit: "Version packages"
+          title: "Version packages"
+          commitMode: github-api
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Summarize release PR update
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --base main \
+            --head changeset-release/main \
+            --state open \
+            --json number,updatedAt,headRefOid > "$RUNNER_TEMP/release-pr-after.json"
+
+          before="$(jq -r '.[0].headRefOid // empty' "$RUNNER_TEMP/release-pr-before.json")"
+          after="$(jq -r '.[0].headRefOid // empty' "$RUNNER_TEMP/release-pr-after.json")"
+          number="$(jq -r '.[0].number // empty' "$RUNNER_TEMP/release-pr-after.json")"
+          result=unchanged
+          if [[ -z "$before" && -n "$after" ]]; then
+            result=created
+          elif [[ -n "$before" && "$before" != "$after" ]]; then
+            result=updated
+          fi
+
+          {
+            echo '## Package release PR'
+            echo
+            echo "- Trigger: \`$GITHUB_SHA\`"
+            echo "- Result: **$result**"
+            if [[ -n "$number" ]]; then
+              echo "- Release PR: #$number"
+            fi
+            echo '- Publication authority: none'
+            echo '- Batching: a newer `main` push cancels pending or running updater work; npm publication uses a separate non-cancelable workflow.'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/update-release-pr.yml
+++ b/.github/workflows/update-release-pr.yml
@@ -34,21 +34,7 @@ jobs:
 
       - name: Detect unreleased changesets
         id: changesets
-        run: |
-          set +e
-          pnpm exec changeset status --output "$RUNNER_TEMP/release-plan.json"
-          status=$?
-          set -e
-
-          if [[ $status -eq 0 ]] && jq -e '.releases | length > 0' "$RUNNER_TEMP/release-plan.json" >/dev/null; then
-            echo 'has_changesets=true' >> "$GITHUB_OUTPUT"
-            echo '## Package release plan' >> "$GITHUB_STEP_SUMMARY"
-            jq -r '.releases[] | "- `\(.name)@\(.newVersion)`"' "$RUNNER_TEMP/release-plan.json" >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo 'has_changesets=false' >> "$GITHUB_OUTPUT"
-            echo '## Package release PR' >> "$GITHUB_STEP_SUMMARY"
-            echo 'No unreleased changesets found; the release-PR updater is a no-op.' >> "$GITHUB_STEP_SUMMARY"
-          fi
+        run: node .github/scripts/package-release-workflow.mjs plan --github-output "$GITHUB_OUTPUT" --github-summary "$GITHUB_STEP_SUMMARY"
 
   update-release-pr:
     name: Update release PR
@@ -80,7 +66,6 @@ jobs:
         run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Snapshot standing release PR
-        id: before
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
@@ -112,24 +97,8 @@ jobs:
             --state open \
             --json number,updatedAt,headRefOid > "$RUNNER_TEMP/release-pr-after.json"
 
-          before="$(jq -r '.[0].headRefOid // empty' "$RUNNER_TEMP/release-pr-before.json")"
-          after="$(jq -r '.[0].headRefOid // empty' "$RUNNER_TEMP/release-pr-after.json")"
-          number="$(jq -r '.[0].number // empty' "$RUNNER_TEMP/release-pr-after.json")"
-          result=unchanged
-          if [[ -z "$before" && -n "$after" ]]; then
-            result=created
-          elif [[ -n "$before" && "$before" != "$after" ]]; then
-            result=updated
-          fi
-
-          {
-            echo '## Package release PR'
-            echo
-            echo "- Trigger: \`$GITHUB_SHA\`"
-            echo "- Result: **$result**"
-            if [[ -n "$number" ]]; then
-              echo "- Release PR: #$number"
-            fi
-            echo '- Publication authority: none'
-            echo '- Batching: a newer `main` push cancels pending or running updater work; npm publication uses a separate non-cancelable workflow.'
-          } >> "$GITHUB_STEP_SUMMARY"
+          node .github/scripts/package-release-workflow.mjs summarize-update \
+            --before "$RUNNER_TEMP/release-pr-before.json" \
+            --after "$RUNNER_TEMP/release-pr-after.json" \
+            --trigger "$GITHUB_SHA" \
+            --github-summary "$GITHUB_STEP_SUMMARY"

--- a/docs/guides/local-development-and-release-workflow.md
+++ b/docs/guides/local-development-and-release-workflow.md
@@ -113,10 +113,20 @@ Choose `patch` for fixes and internal refactors, `minor` for additive public
 API, and `major` for breaking public API. Commit the `.changeset/*.md` file
 with the change.
 
-The `publish-packages` GitHub workflow runs on `main`. Changesets opens or
-updates the generated release pull request, then publishes the release after
-that pull request merges. Do not run `release:publish` as a normal contributor
+`update-release-pr` runs on `main` and opens or updates the generated release
+pull request only when unreleased changesets exist. Its cancelable concurrency
+means a newer `main` push supersedes an older pending update; it has no npm
+publication authority. `publish-packages` runs only after a merged,
+deterministically verified `changeset-release/main` pull request, then checks
+out that exact merge revision and publishes under a separate non-cancelable
+concurrency group. Do not run `release:publish` as a normal contributor
 workflow. It is the workflow command and requires its release environment.
+
+If an npm operation is interrupted or only partly succeeds, use the
+`publish-packages` **Run workflow** control with the exact merged release
+revision. The publisher re-verifies the generated tree before retrying and its
+closure publisher skips versions already present in npm; do not create a new
+release PR merely to retry publication.
 
 If a release or package-publishing incident needs tool-specific diagnosis, read
 the relevant package documentation under `tools/` and the workflow definition

--- a/tools/package-release/test/package-release-workflow.test.ts
+++ b/tools/package-release/test/package-release-workflow.test.ts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import {execFile} from 'node:child_process';
+import {mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {dirname, join, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {promisify} from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const packageDirectory = dirname(fileURLToPath(import.meta.url));
+const workflowTool = resolve(
+  packageDirectory,
+  '../../../.github/scripts/package-release-workflow.mjs',
+);
+const authorizedPattern = /authorized=true/;
+const createdPattern = /"result":"created"/;
+const releasePattern = /revision=release/;
+const releasePrPattern = /Release PR: #42/;
+
+describe('package release workflow tool', () => {
+  test('authorizes only merged release-App pull requests from the release branch', async () => {
+    const temporaryRoot = await mkdtemp(join(tmpdir(), 'shipfox-release-workflow-test-'));
+    const outputPath = join(temporaryRoot, 'output');
+
+    try {
+      await execFileAsync('node', [
+        workflowTool,
+        'authorize',
+        '--event-name',
+        'pull_request',
+        '--merged',
+        'true',
+        '--revision',
+        'release',
+        '--base',
+        'base',
+        '--head-repository',
+        'ShipfoxHQ/shipfox',
+        '--head-ref',
+        'changeset-release/main',
+        '--author-id',
+        '123',
+        '--repository',
+        'ShipfoxHQ/shipfox',
+        '--release-app-id',
+        '123',
+        '--github-output',
+        outputPath,
+      ]);
+
+      assert.match(await readFile(outputPath, 'utf8'), authorizedPattern);
+      assert.match(await readFile(outputPath, 'utf8'), releasePattern);
+    } finally {
+      await rm(temporaryRoot, {force: true, recursive: true});
+    }
+  });
+
+  test('records whether a release PR was created, updated, or unchanged', async () => {
+    const temporaryRoot = await mkdtemp(join(tmpdir(), 'shipfox-release-workflow-test-'));
+    const beforePath = join(temporaryRoot, 'before.json');
+    const afterPath = join(temporaryRoot, 'after.json');
+    const summaryPath = join(temporaryRoot, 'summary');
+    try {
+      await writeFile(beforePath, '[]');
+      await writeFile(afterPath, '[{"number": 42, "headRefOid": "head"}]');
+
+      const {stdout} = await execFileAsync('node', [
+        workflowTool,
+        'summarize-update',
+        '--before',
+        beforePath,
+        '--after',
+        afterPath,
+        '--trigger',
+        'revision',
+        '--github-summary',
+        summaryPath,
+      ]);
+
+      assert.match(stdout, createdPattern);
+      assert.match(await readFile(summaryPath, 'utf8'), releasePrPattern);
+    } finally {
+      await rm(temporaryRoot, {force: true, recursive: true});
+    }
+  });
+});

--- a/tools/package-release/test/publish-workflows.test.ts
+++ b/tools/package-release/test/publish-workflows.test.ts
@@ -15,7 +15,7 @@ describe('package release workflows', () => {
     const workflow = await readWorkflow('update-release-pr.yml');
 
     assert.ok(workflow.includes('cancel-in-progress: true'));
-    assert.ok(workflow.includes('pnpm exec changeset status --output'));
+    assert.ok(workflow.includes('package-release-workflow.mjs plan'));
     assert.ok(workflow.includes("has_changesets == 'true'"));
     assert.ok(workflow.includes('version: pnpm exec changeset version'));
     assert.ok(!workflow.includes('release:publish'));
@@ -32,6 +32,6 @@ describe('package release workflows', () => {
     assert.ok(workflow.includes('ref: $' + '{{ needs.authorize-release.outputs.revision }}'));
     assert.ok(workflow.includes('verify-generated-release'));
     assert.ok(workflow.includes('NPM_CONFIG_PROVENANCE: "true"'));
-    assert.ok(workflow.includes('head_ref" != changeset-release/main'));
+    assert.ok(workflow.includes('package-release-workflow.mjs authorize'));
   });
 });

--- a/tools/package-release/test/publish-workflows.test.ts
+++ b/tools/package-release/test/publish-workflows.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import {readFile} from 'node:fs/promises';
+import {dirname, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const packageDirectory = dirname(fileURLToPath(import.meta.url));
+const workflowsDirectory = resolve(packageDirectory, '../../../.github/workflows');
+
+function readWorkflow(name: string) {
+  return readFile(resolve(workflowsDirectory, name), 'utf8');
+}
+
+describe('package release workflows', () => {
+  test('cancels superseded release-PR updates without publication authority', async () => {
+    const workflow = await readWorkflow('update-release-pr.yml');
+
+    assert.ok(workflow.includes('cancel-in-progress: true'));
+    assert.ok(workflow.includes('pnpm exec changeset status --output'));
+    assert.ok(workflow.includes("has_changesets == 'true'"));
+    assert.ok(workflow.includes('version: pnpm exec changeset version'));
+    assert.ok(!workflow.includes('release:publish'));
+    assert.ok(!workflow.includes('id-token: write'));
+  });
+
+  test('publishes only exact merged release revisions in non-cancelable isolation', async () => {
+    const workflow = await readWorkflow('publish-packages.yml');
+
+    assert.ok(workflow.includes('types: [closed]'));
+    assert.ok(workflow.includes('workflow_dispatch:'));
+    assert.ok(workflow.includes('Exact merged release revision to recover'));
+    assert.ok(workflow.includes('cancel-in-progress: false'));
+    assert.ok(workflow.includes('ref: $' + '{{ needs.authorize-release.outputs.revision }}'));
+    assert.ok(workflow.includes('verify-generated-release'));
+    assert.ok(workflow.includes('NPM_CONFIG_PROVENANCE: "true"'));
+    assert.ok(workflow.includes('head_ref" != changeset-release/main'));
+  });
+});


### PR DESCRIPTION
Separates the cancelable Changesets release-PR updater from npm publication.

Merge bursts now supersede stale updater runs without giving that workflow npm or OIDC publication authority. Publication is triggered only for a merged release-bot PR, re-verifies the exact merged tree, and uses isolated non-cancelable concurrency with an exact-revision recovery dispatch path.

The contributor release guide now describes the event/concurrency model and partial-publication recovery. Workflow tests protect the authorization, batching, provenance, and exact-checkout boundaries.

Closes ENG-1170

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the Changesets release PR updater from npm publication to improve safety and recovery (closes ENG-1170). Publication now runs only for merged, verified release PRs; updater runs are cancelable and never hold publish/OIDC rights.

- **New Features**
  - Added `update-release-pr.yml`: cancels superseded runs, detects unreleased changesets, and opens/updates `changeset-release/main` only when needed; no `id-token` and no `release:publish`.
  - Reworked `publish-packages.yml`: triggers on merged release PRs or `workflow_dispatch(revision)`, authorizes the release bot and branch, checks out the exact merge commit, verifies with `@shipfox/package-release`, and publishes with provenance under a serialized, non-cancelable group.
  - Extracted workflow plumbing into `.github/scripts/package-release-workflow.mjs` for release planning, authorization, and run summaries, keeping workflow YAML declarative.
  - Docs: described the event/concurrency model and manual recovery using the exact merged revision.
  - Tests: guard authorization, batching behavior, provenance, exact-checkout verification, and workflow plumbing.

<sup>Written for commit 09d8d5dfd8764490f79af4ada524af8674927fa0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

