### PR TITLE
[api/server] Stabilize auth token interoperability test

### DIFF
--- a/libs/api/server/src/auth-token-interoperability.test.ts
+++ b/libs/api/server/src/auth-token-interoperability.test.ts
@@ -1,8 +1,11 @@
+import {createLeaseTokenAuthMethod, issueJobLeaseToken} from '@shipfox/api-auth';
 import {AUTH_LEASED_JOB, requireLeasedJobContext} from '@shipfox/api-auth-context';
 import {closeApp, createApp, defineRoute} from '@shipfox/node-fastify';
 import {afterEach, describe, expect, it} from '@shipfox/vitest/vi';
 
-process.env.AUTH_ROOT_KEY ??= 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=';
+vi.hoisted(() => {
+  process.env.AUTH_ROOT_KEY ??= 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=';
+});
 
 const leaseRoute = defineRoute({
   method: 'GET',
@@ -20,7 +23,6 @@ describe('Auth token interoperability', () => {
   });
 
   it('accepts an Auth-issued step lease through the server route boundary', async () => {
-    const {createLeaseTokenAuthMethod, issueJobLeaseToken} = await import('@shipfox/api-auth');
     const jobId = crypto.randomUUID();
     const stepId = crypto.randomUUID();
     const token = await issueJobLeaseToken({


### PR DESCRIPTION
Move Auth package loading out of the interoperability test timeout while preserving the real signed-token route assertion.

The broad `@shipfox/api-auth` root was dynamically imported inside the test body. On cold, contended CI workers that import consumed almost the entire five-second budget and occasionally timed out before the token and route work completed.

Vitest now hoists the canonical `AUTH_ROOT_KEY` setup before imports, allowing the Auth APIs to be statically loaded during collection. Increasing the timeout was considered, but that would preserve the same load-sensitive coupling rather than isolate the behavior under test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the auth token interoperability test by statically importing `@shipfox/api-auth` and hoisting `AUTH_ROOT_KEY`. This avoids cold CI timeouts and keeps the signed-token route assertion intact.

<sup>Written for commit 41799e3cdc047609873b5a6da2fc2464547284fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

