### PR TITLE
Extract external package contract verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,14 +108,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Start test services
-        if: github.event_name != 'pull_request' || needs.release-classification.outputs.generated_release != 'true'
-        run: docker compose up -d postgres
-
       - name: Set up mise
         uses: ./.github/actions/setup-mise
         with:
-          tools: node npm:pnpm npm:turbo packer
+          tools: node npm:pnpm npm:turbo
 
       - name: Set up pnpm
         uses: ./.github/actions/setup-pnpm
@@ -127,14 +123,6 @@ jobs:
       - name: Verify repository and package policies
         if: github.event_name != 'pull_request' || needs.release-classification.outputs.generated_release != 'true'
         run: turbo verify --concurrency="$SHIPFOX_TURBO_CONCURRENCY"
-
-      - name: Wait for test services
-        if: github.event_name != 'pull_request' || needs.release-classification.outputs.generated_release != 'true'
-        run: docker compose up --wait postgres
-
-      - name: Verify external package contracts
-        if: github.event_name != 'pull_request' || needs.release-classification.outputs.generated_release != 'true'
-        run: turbo test:external --filter=@shipfox/application-release --filter=@shipfox/client-shell --concurrency=1
 
       - name: Verify release metadata and publication closure
         if: github.event_name == 'pull_request' && needs.release-classification.outputs.generated_release == 'true'
@@ -162,6 +150,30 @@ jobs:
             echo '- Preflight result: passed.'
             echo '- Expected comparison: under 5 minutes and under 7.65 runner-minutes, versus the 13-minute / 51 runner-minute baseline.'
           } >> "$GITHUB_STEP_SUMMARY"
+
+  external-package-contracts:
+    name: Verify external package contracts
+    needs: [release-classification]
+    if: always() && (github.event_name != 'pull_request' || needs.release-classification.outputs.generated_release != 'true')
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up mise
+        uses: ./.github/actions/setup-mise
+        with:
+          tools: node npm:pnpm npm:turbo
+
+      - name: Set up pnpm
+        uses: ./.github/actions/setup-pnpm
+
+      - name: Verify external package contracts
+        run: turbo test:external --filter=@shipfox/application-release --filter=@shipfox/client-shell --concurrency=1
 
   publication-preflight:
     name: Package publication preflight
@@ -370,7 +382,7 @@ jobs:
   # cache instead of inheriting artifacts from less-privileged jobs.
   publish-images:
     name: Publish app image (${{ matrix.image }})
-    needs: [static-verification, tests, e2e]
+    needs: [static-verification, external-package-contracts, tests, e2e]
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     # Multi-arch: linux/arm64 builds under QEMU emulation, slow on a cold gha BuildKit
@@ -425,7 +437,7 @@ jobs:
 
   publish-runner-image-candidate:
     name: Publish runner image candidate (${{ matrix.architecture }})
-    needs: [static-verification, tests, e2e]
+    needs: [static-verification, external-package-contracts, tests, e2e]
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 90


### PR DESCRIPTION
Run packed external-consumer contract verification independently from static checks.

This removes unnecessary Postgres and Packer setup from those checks, while keeping image publication gated on the extracted verification job. Separating the jobs lets static verification complete without waiting for the package-contract fixture work.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split external package contract verification into its own CI job so static checks run without Postgres/`packer` and finish faster. Image publication stays gated on the new verification job.

- **Refactors**
  - Added `external-package-contracts` job running `turbo test:external --filter=@shipfox/application-release --filter=@shipfox/client-shell`.
  - Removed Postgres setup/wait and `packer` from `static-verification`.
  - Updated `publish-images` and `publish-runner-image-candidate` to depend on `external-package-contracts`.

<sup>Written for commit e178e6cbe0506a995bbc05daf5b53cfdb9ec6036. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/966?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

