### PR TITLE
Normalize subsystem and package README routing

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ listed there or when you need to place, update, or review documentation.
 | Adds or changes end-to-end coverage. | [E2E guide](../e2e/README.md) | Suite levels, HTTP-first setup, screens, and E2E package boundaries. |
 | Mints, verifies, or carries an authentication token. | [Auth security model](../libs/api/auth/README.md#security-model) | Token authority, lifetime, trust boundaries, and logging constraints. |
 | Defines an inter-module contract or transport. | [Inter-module package README](../libs/shared/common/inter-module/README.md) | Contract primitives and transport responsibilities. |
+| Needs a package-local API, configuration, fixture, or operational constraint. | [Package README standard](../WRITING.md#package-readmes) | How to find and shape the owning package README; the README beside the package owns the local detail. |
 | Creates or changes a visual or interaction decision. | [Design system](../DESIGN.md) | Shared tokens, components, accessibility, motion, status taxonomy, patterns, and review anti-patterns. Code owns exact token and component values. |
 | Writes engineering prose, a package README, or a runbook. | [Writing guide](../WRITING.md) | Repository-wide prose structure, style, punctuation, readability, and package README structure. |
 | Writes or reviews code comments, module exports, or non-trivial control flow. | [Code style policy](policies/code-style.md) | Shared code-comment, import and export, and control-flow rules. |

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,8 +1,12 @@
 # E2E Testing
 
-This directory owns Shipfox end-to-end tests and their shared authoring tools. Use
+This subtree owns Shipfox end-to-end tests and their shared authoring tools. Use
 this guide to decide where a test belongs, how setup is allowed to work, and what
 reviewers should enforce.
+
+For repository-wide unit-test, Storybook, and visual-regression rules, read the
+[testing guide](../docs/guides/testing.md). This README owns the E2E-specific
+suite architecture, setup model, screens, drivers, and review constraints.
 
 ## Directory Map
 

--- a/libs/api/auth/README.md
+++ b/libs/api/auth/README.md
@@ -1,6 +1,13 @@
 # Shipfox API Auth
 
-Shipfox API Auth provides the server-side auth module for Shipfox APIs. It owns user accounts, email verification, login, refresh sessions, password reset, password change, JWT auth, and its PostgreSQL tables.
+Shipfox API Auth provides the server-side auth module for Shipfox APIs. This
+package owns user accounts, email verification, login, refresh sessions,
+password reset, password change, JWT auth, and its PostgreSQL tables.
+
+For repository-wide backend module, configuration, error, and observability
+rules, read the [backend architecture guide](../../../docs/architecture/backend-architecture.md).
+This README owns the local security model, package API, routes, data model, and
+auth-specific operational constraints.
 
 ## Example
 

--- a/libs/shared/common/inter-module/README.md
+++ b/libs/shared/common/inter-module/README.md
@@ -4,6 +4,11 @@ Browser-safe, Zod-only primitives for defining a producer-owned inter-module
 contract: stable method names, JSON-safe input/output schemas, and kebab-case
 known errors.
 
+For repository-wide backend module layering and dependency-boundary rules, read
+the [backend architecture guide](../../../../docs/architecture/backend-architecture.md).
+This README owns the package API and local constraints for defining and
+consuming inter-module contracts.
+
 This package defines contracts and clients. It never validates JSON safety,
 serializes a call, or dispatches one — that is a transport's job. The in-memory
 transport lives in `@shipfox/node-module/inter-module`.


### PR DESCRIPTION
Normalize the key subsystem and package README entrypoints so local ownership stays close to the code while repository-wide rules are routed to their canonical guides.

The documentation map previously exposed the major shared guides but did not give readers a task-routed way to find package-local configuration, fixtures, API details, and operational constraints. E2E, Auth, and inter-module READMEs now make their local scope explicit and link outward only for shared guidance.

This keeps published package documentation focused on package contracts instead of agent workflow instructions or copied repository policy.

Closes ENG-1160

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalized subsystem and package README entrypoints so local docs own package details and shared rules route to their canonical guides. Closes ENG-1160.

- **Refactors**
  - `docs/README.md`: added “Package README standard” to route package-local API/config/fixtures/ops details.
  - `e2e/README.md`: clarified subtree scope; linked to global testing guide; defined E2E-specific ownership.
  - `libs/api/auth/README.md`: clarified package scope; linked to backend architecture guide; defined local security model and API ownership.
  - `libs/shared/common/inter-module/README.md`: linked to backend architecture guide; defined local contract API and constraints; restated transport responsibilities.

<sup>Written for commit e7d458752f5bfb627bb96ad3690b5a2054b4501d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

