### PR TITLE
[api/workflows] Decouple remaining test fixtures

### DIFF
--- a/.changeset/brisk-otters-align.md
+++ b/.changeset/brisk-otters-align.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-workflows": patch
+---
+
+Decouples workflow test fixtures from peer API implementations.

--- a/libs/api/workflows/package.json
+++ b/libs/api/workflows/package.json
@@ -70,8 +70,6 @@
     "zod": "catalog:"
   },
   "devDependencies": {
-    "@shipfox/api-definitions": "workspace:*",
-    "@shipfox/api-integration-core": "workspace:*",
     "@shipfox/biome": "workspace:*",
     "@shipfox/depcruise": "workspace:*",
     "@shipfox/node-log": "workspace:*",

--- a/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.test.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.test.ts
@@ -5,7 +5,7 @@ import {
   AGENT_INTEGRATION_MCP_TRANSPORT,
 } from '@shipfox/api-agent-dto';
 import {agentInterModuleContract} from '@shipfox/api-agent-dto/inter-module';
-import type {AgentToolCatalogEntry} from '@shipfox/api-integration-core';
+import type {AgentToolCatalogEntry} from '@shipfox/api-integration-spi';
 import {createInterModuleKnownError} from '@shipfox/inter-module';
 import type {AgentDefaultsResolver} from '#core/agent-defaults.js';
 import type {AgentToolMaterializationContext} from '#core/agent-tools.js';

--- a/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
@@ -1,16 +1,9 @@
 import {agentInterModuleContract} from '@shipfox/api-agent-dto/inter-module';
-import {
-  DEFAULT_JOB_CHECKOUT,
-  normalizeWorkflowDocument as normalizeWorkflowDocumentImpl,
-  type WorkflowModel,
-} from '@shipfox/api-definitions';
+import {DEFAULT_JOB_CHECKOUT, type WorkflowModel} from '@shipfox/api-definitions-dto';
 import {createInterModuleKnownError} from '@shipfox/inter-module';
 import type {AgentDefaultsResolver} from '#core/agent-defaults.js';
 import {AgentConfigUnresolvableError, InterpolationUnresolvableError} from '#core/errors.js';
-import {
-  agentValidationCatalog,
-  resolveTestAgentDefaults,
-} from '#test/fixtures/agent-inter-module.js';
+import {resolveTestAgentDefaults} from '#test/fixtures/agent-inter-module.js';
 import {workflowModel} from '#test/index.js';
 import {
   materializeJobRunner,
@@ -27,12 +20,6 @@ function materializeWorkflowModel(
   params: Parameters<typeof materializeWorkflowModelImpl>[0],
 ): ReturnType<typeof materializeWorkflowModelImpl> {
   return materializeWorkflowModelImpl({resolveAgentDefaults: resolveTestAgentDefaults, ...params});
-}
-
-function normalizeWorkflowDocument(
-  document: Parameters<typeof normalizeWorkflowDocumentImpl>[0],
-): ReturnType<typeof normalizeWorkflowDocumentImpl> {
-  return normalizeWorkflowDocumentImpl(document, {agentValidationCatalog});
 }
 
 function expression(source: string): TestWorkflowExpression {
@@ -548,7 +535,7 @@ describe('materializeWorkflowModel', () => {
   });
 
   it('freezes vars from the run-creation context into step config', async () => {
-    const model = normalizeWorkflowDocument({
+    const model = workflowModel({
       name: 'vars workflow',
       runner: 'ubuntu-latest',
       jobs: {
@@ -1008,14 +995,15 @@ describe('materializeWorkflowModel', () => {
 
   it('skips listening job steps at workflow-run creation', async () => {
     const stepNameSource = `Review ${template('execution.index')}`;
-    const model = normalizeWorkflowDocument({
+    const model = workflowModel({
       name: 'Listening workflow',
       runner: 'ubuntu-latest',
       jobs: {
         review: {
           listening: {
             on: [{source: 'github', event: 'pull_request_review'}],
-            max_executions: 3,
+            maxExecutions: 3,
+            onResolve: 'finish',
           },
           steps: [{name: stepNameSource, prompt: 'Summarize the review.'}],
         },
@@ -1036,14 +1024,15 @@ describe('materializeWorkflowModel', () => {
   });
 
   it('materializes one-shot siblings while skipping listening steps', async () => {
-    const model = normalizeWorkflowDocument({
+    const model = workflowModel({
       name: 'Mixed workflow',
       runner: 'ubuntu-latest',
       jobs: {
         review: {
           listening: {
             on: [{source: 'github', event: 'pull_request_review'}],
-            max_executions: 3,
+            maxExecutions: 3,
+            onResolve: 'finish',
           },
           steps: [{name: `Review ${template('execution.index')}`, prompt: 'Summarize it.'}],
         },
@@ -1104,12 +1093,12 @@ describe('materializeWorkflowModel', () => {
   });
 
   it('materializes step if as server-owned condition outside runner config', async () => {
-    const model = normalizeWorkflowDocument({
+    const model = workflowModel({
       name: 'Conditional workflow',
       runner: 'ubuntu-latest',
       jobs: {
         build: {
-          steps: [{if: template('false'), run: 'npm test'}],
+          steps: [{if: expression('false'), run: 'npm test'}],
         },
       },
     });
@@ -1121,7 +1110,6 @@ describe('materializeWorkflowModel', () => {
       language: 'cel',
       source: 'false',
       check: 'typed',
-      resultType: 'bool',
     });
     expect(step?.config).toEqual({run: 'npm test'});
   });

--- a/libs/api/workflows/src/db/workflow-runs/run-create.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-create.test.ts
@@ -1,15 +1,12 @@
-import {normalizeWorkflowDocument as normalizeWorkflowDocumentImpl} from '@shipfox/api-definitions';
 import {WORKFLOWS_WORKFLOW_RUN_ATTEMPT_CREATED} from '@shipfox/api-workflows-dto';
 import {and, eq, sql} from 'drizzle-orm';
 import type {AgentDefaultsResolver} from '#core/agent-defaults.js';
 import {InterpolationUnresolvableError} from '#core/errors.js';
 import {nextStepForJob, recordStepResult} from '#core/job-execution.js';
-import {
-  agentValidationCatalog,
-  resolveTestAgentDefaults,
-} from '#test/fixtures/agent-inter-module.js';
+import {resolveTestAgentDefaults} from '#test/fixtures/agent-inter-module.js';
 import {createTestSecretsClient} from '#test/fixtures/secrets-inter-module.js';
 import {buildModel, expression, shellRef, template} from '#test/helpers/workflow-runs.js';
+import {workflowModel} from '#test/index.js';
 import {db} from '../db.js';
 import {workflowsOutbox} from '../schema/outbox.js';
 import {workflowRuns} from '../schema/workflow-runs.js';
@@ -25,12 +22,6 @@ import {
   resolveJobStatusFromJobExecutions,
   updateJobExecutionStatus,
 } from '../workflow-runs.js';
-
-function normalizeWorkflowDocument(
-  document: Parameters<typeof normalizeWorkflowDocumentImpl>[0],
-): ReturnType<typeof normalizeWorkflowDocumentImpl> {
-  return normalizeWorkflowDocumentImpl(document, {agentValidationCatalog});
-}
 
 describe('workflow run queries', () => {
   let workspaceId: string;
@@ -339,7 +330,7 @@ describe('workflow run queries', () => {
       const displayNameSource = ['Review batch $', '{{ execution.index }}'].join('');
       const stepNameSource = ['Review $', '{{ execution.index }}'].join('');
       const promptSource = ['Review $', '{{ execution.events[0].data.body }}'].join('');
-      const model = normalizeWorkflowDocument({
+      const model = workflowModel({
         name: 'Listening workflow',
         runner: 'ubuntu-latest',
         jobs: {
@@ -348,10 +339,10 @@ describe('workflow run queries', () => {
             listening: {
               on: [{source: 'github', event: 'pull_request_review'}],
               until: [{source: 'github', event: 'pull_request'}],
-              timeout: '30d',
-              max_executions: 3,
-              batch: {debounce: '5s', max_size: 10, max_wait: '1h'},
-              on_resolve: 'cancel',
+              timeoutMs: 30 * 24 * 60 * 60 * 1000,
+              maxExecutions: 3,
+              batch: {debounceMs: 5000, maxSize: 10, maxWaitMs: 60 * 60 * 1000},
+              onResolve: 'cancel',
             },
             steps: [{name: stepNameSource, prompt: promptSource}],
           },
@@ -409,7 +400,7 @@ describe('workflow run queries', () => {
     test('persists the listening workflow model on the run attempt', async () => {
       const displayNameSource = ['Review batch $', '{{ execution.index }}'].join('');
       const promptSource = ['Review $', '{{ execution.events[0].data.body }}'].join('');
-      const model = normalizeWorkflowDocument({
+      const model = workflowModel({
         name: 'Listening workflow',
         runner: 'ubuntu-latest',
         jobs: {
@@ -418,10 +409,10 @@ describe('workflow run queries', () => {
             listening: {
               on: [{source: 'github', event: 'pull_request_review'}],
               until: [{source: 'github', event: 'pull_request'}],
-              timeout: '30d',
-              max_executions: 3,
-              batch: {debounce: '5s', max_size: 10, max_wait: '1h'},
-              on_resolve: 'cancel',
+              timeoutMs: 30 * 24 * 60 * 60 * 1000,
+              maxExecutions: 3,
+              batch: {debounceMs: 5000, maxSize: 10, maxWaitMs: 60 * 60 * 1000},
+              onResolve: 'cancel',
             },
             steps: [{prompt: promptSource}],
           },
@@ -450,7 +441,7 @@ describe('workflow run queries', () => {
     });
 
     test('does not load variables referenced only by listening job executions at run creation', async () => {
-      const model = normalizeWorkflowDocument({
+      const model = workflowModel({
         name: 'Listening vars workflow',
         runner: 'ubuntu-latest',
         jobs: {
@@ -458,6 +449,7 @@ describe('workflow run queries', () => {
             listening: {
               on: [{source: 'github', event: 'pull_request_review'}],
               until: [{source: 'github', event: 'pull_request'}],
+              onResolve: 'finish',
             },
             steps: [
               {
@@ -492,7 +484,7 @@ describe('workflow run queries', () => {
       {
         field: 'run',
         model: () =>
-          normalizeWorkflowDocument({
+          workflowModel({
             name: 'Missing run var',
             runner: 'ubuntu-latest',
             jobs: {build: {steps: [{run: `echo ${template('vars.REQUIRED')}`}]}},
@@ -502,7 +494,7 @@ describe('workflow run queries', () => {
       {
         field: 'env',
         model: () =>
-          normalizeWorkflowDocument({
+          workflowModel({
             name: 'Missing env var',
             runner: 'ubuntu-latest',
             jobs: {
@@ -516,7 +508,7 @@ describe('workflow run queries', () => {
       {
         field: 'agent.prompt',
         model: () =>
-          normalizeWorkflowDocument({
+          workflowModel({
             name: 'Missing prompt var',
             runner: 'ubuntu-latest',
             jobs: {fix: {steps: [{prompt: template('vars.REQUIRED')}]}},
@@ -526,7 +518,7 @@ describe('workflow run queries', () => {
       {
         field: 'agent.model',
         model: () =>
-          normalizeWorkflowDocument({
+          workflowModel({
             name: 'Missing model var',
             runner: 'ubuntu-latest',
             jobs: {fix: {steps: [{prompt: 'Fix it', model: template('vars.REQUIRED')}]}},
@@ -536,7 +528,7 @@ describe('workflow run queries', () => {
       {
         field: 'agent.provider',
         model: () =>
-          normalizeWorkflowDocument({
+          workflowModel({
             name: 'Missing provider var',
             runner: 'ubuntu-latest',
             jobs: {fix: {steps: [{prompt: 'Fix it', provider: template('vars.REQUIRED')}]}},
@@ -546,17 +538,23 @@ describe('workflow run queries', () => {
       {
         field: 'job.runner',
         model: () =>
-          normalizeWorkflowDocument({
+          workflowModel({
             name: 'Missing runner var',
             runner: 'ubuntu-latest',
-            jobs: {build: {runner: template('vars.REQUIRED'), steps: [{run: 'echo ok'}]}},
+            jobs: {
+              build: {
+                runner: [],
+                runnerTemplates: [template('vars.REQUIRED')],
+                steps: [{run: 'echo ok'}],
+              },
+            },
           }),
         expected: {field: 'job.runner', source: 'vars.REQUIRED'},
       },
       {
         field: 'step.name',
         model: () =>
-          normalizeWorkflowDocument({
+          workflowModel({
             name: 'Missing step name var',
             runner: 'ubuntu-latest',
             jobs: {build: {steps: [{name: template('vars.REQUIRED'), run: 'echo ok'}]}},
@@ -623,7 +621,7 @@ describe('workflow run queries', () => {
     });
 
     test('persists resolved step config and authored step config separately', async () => {
-      const model = normalizeWorkflowDocument({
+      const model = workflowModel({
         name: 'Interpolated workflow',
         runner: 'ubuntu-latest',
         env: {RUN_ID: template('run.id'), REF: template('event.ref')},
@@ -674,7 +672,7 @@ describe('workflow run queries', () => {
     });
 
     test('resolves webhook trigger payload body and headers into step config', async () => {
-      const model = normalizeWorkflowDocument({
+      const model = workflowModel({
         name: 'Webhook workflow',
         runner: 'ubuntu-latest',
         env: {
@@ -720,7 +718,7 @@ describe('workflow run queries', () => {
     });
 
     test('fails for missing available untrusted interpolation paths', async () => {
-      const model = normalizeWorkflowDocument({
+      const model = workflowModel({
         name: 'Diagnostic workflow',
         runner: 'ubuntu-latest',
         env: {REF: template('event.ref')},

--- a/libs/api/workflows/test/factories/workflow-model.ts
+++ b/libs/api/workflows/test/factories/workflow-model.ts
@@ -49,6 +49,7 @@ interface TestWorkflowJob {
   readonly success?: string | undefined;
   readonly outputs?: Readonly<Record<string, string>> | undefined;
   readonly env?: WorkflowModel['env'] | undefined;
+  readonly listening?: WorkflowModel['jobs'][number]['listening'] | undefined;
   readonly steps: readonly TestWorkflowStep[];
 }
 
@@ -70,7 +71,7 @@ export function workflowModel(input: TestWorkflowModelInput = {}): WorkflowModel
     return {
       id: jobId,
       key,
-      mode: 'one_shot' as const,
+      mode: job.listening === undefined ? ('one_shot' as const) : ('listening' as const),
       runner: normalizeStringArray(job.runner ?? input.runner ?? DEFAULT_RUNNER_LABELS),
       ...(job.runnerTemplates === undefined
         ? {}
@@ -90,6 +91,7 @@ export function workflowModel(input: TestWorkflowModelInput = {}): WorkflowModel
               {kind: 'literal' as const, value: job.name},
             ],
           }),
+      ...(job.listening === undefined ? {} : {listening: job.listening}),
       ...optionalScopedEnv(job.env),
       dependencies: normalizeStringArray(job.needs).map(stableId),
       steps: job.steps.map((step, stepIndex) => normalizeStep(step, jobId, stepIndex)),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4269,12 +4269,6 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
-      '@shipfox/api-definitions':
-        specifier: workspace:*
-        version: link:../definitions
-      '@shipfox/api-integration-core':
-        specifier: workspace:*
-        version: link:../integration/core
       '@shipfox/biome':
         specifier: workspace:*
         version: link:../../../tools/biome


### PR DESCRIPTION
Completes the remaining ENG-1148 workflow-test boundary cleanup by replacing Definitions normalization imports with DTO-backed workflow-model fixtures and using the Integrations SPI contract type.

The earlier migration removed peer modules and database setup, but a few test fixtures still loaded peer implementation code. This follow-up keeps consumer tests on the same package boundaries as production and removes the stale manifest edges.

The fixture models explicit listening-job DTO data rather than reproducing Definitions policy.

Closes ENG-1148

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decouples remaining Workflows tests from peer implementations by switching to DTO-backed fixtures and Integrations SPI types. Completes ENG-1148 for Workflows and removes stale dev dependencies.

- **Refactors**
  - Replace `normalizeWorkflowDocument` from `@shipfox/api-definitions` with `workflowModel` fixtures from `@shipfox/api-definitions-dto`.
  - Use `AgentToolCatalogEntry` from `@shipfox/api-integration-spi` instead of `@shipfox/api-integration-core`.
  - Update tests to model listening jobs via DTO fields (e.g., `maxExecutions`, `onResolve`, `timeoutMs`, batch `debounceMs`/`maxWaitMs`).
  - Test factory now accepts `listening` on jobs and supports runner templates.

- **Dependencies**
  - Remove devDeps on `@shipfox/api-definitions` and `@shipfox/api-integration-core`.
  - Add a patch changeset for `@shipfox/api-workflows`.

<sup>Written for commit 753295f2a5c6c85a4c9b735ebd27160b250e04f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

