### PR TITLE
Parallelize external contract CI preparation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,8 @@ jobs:
     if: always() && (github.event_name != 'pull_request' || needs.release-classification.outputs.generated_release != 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 40
+    env:
+      SHIPFOX_TURBO_CONCURRENCY: "4"
 
     steps:
       - name: Check out repository
@@ -172,8 +174,20 @@ jobs:
       - name: Set up pnpm
         uses: ./.github/actions/setup-pnpm
 
-      - name: Verify external package contracts
-        run: turbo test:external --filter=@shipfox/application-release --filter=@shipfox/client-shell --concurrency=1
+      - name: Prepare external package contracts
+        run: |
+          turbo build type:emit \
+            --filter=@shipfox/application-release... \
+            --filter=@shipfox/api... \
+            --filter=@shipfox/client-shell... \
+            --filter=@shipfox/client-features... \
+            --concurrency="$SHIPFOX_TURBO_CONCURRENCY"
+
+      - name: Verify packed API runtime closure
+        run: pnpm --filter=@shipfox/application-release test:external
+
+      - name: Verify packed client composition
+        run: pnpm --filter=@shipfox/client-shell test:external
 
   publication-preflight:
     name: Package publication preflight


### PR DESCRIPTION
Reduce the external package contract check from a nine-minute critical path while preserving its full API and client closure coverage.

The dedicated job previously scheduled its entire Turbo prerequisite graph with concurrency one. On a scoped PR this serialized 96 cache misses across build, type-check, and declaration emission tasks, even though the two packed-consumer verifiers themselves took only about two minutes.

This prepares the same 297 prerequisite tasks with the standard four-way CI concurrency, then runs the API and client verifiers as separate sequential steps. The split keeps their isolated installs, compilers, and bundlers from competing on one runner and makes each phase visible in GitHub timing.

Using affected-package selection was considered, but the dynamically computed publication closures are not represented by the workspace dependency graph and representative API contract changes selected no external task. Running both verifier bodies concurrently was also avoided to keep runner resource usage bounded.

Please review the four preparation filters carefully; their dry-run task IDs exactly match the previous external-test prerequisite graph.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parallelized the external contract CI preparation to remove the serialized bottleneck while preserving full API and client closure coverage. Prerequisites now run with four-way Turbo concurrency, followed by two sequential verifiers for isolation and clearer timings.

- **Refactors**
  - Prepare the same prerequisite graph with `SHIPFOX_TURBO_CONCURRENCY=4` using `turbo build type:emit` and four filters (`@shipfox/application-release...`, `@shipfox/api...`, `@shipfox/client-shell...`, `@shipfox/client-features...`).
  - Split verification into two steps: `pnpm --filter=@shipfox/application-release test:external` and `pnpm --filter=@shipfox/client-shell test:external`.
  - Remove the single `turbo test:external --concurrency=1` run; keep filters precise to match the previous graph and avoid parallel verifier runs to cap runner usage.

<sup>Written for commit a757a57d41c8fb3fccd87238090da650a4494553. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

