### PR TITLE
Refactor contributor and agent documentation entrypoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,121 +1,43 @@
 # Agent guidelines
 
-Read [CONTRIBUTING.md](CONTRIBUTING.md) when the task needs human contribution
-workflow or onboarding context.
+`CLAUDE.md` is a compatibility alias for this file.
 
-## Agent execution
+## Execution baseline
 
-Use mise-managed tools. Prefix non-interactive commands with `mise exec --`.
-Use `turbo <task> --filter=@shipfox/<package>...` to validate the changed
-package and its dependencies before widening validation.
+- Use mise-managed tools. Prefix non-interactive commands with `mise exec --`.
+- Inspect the relevant files and local instructions before editing. Preserve
+  unrelated user changes.
+- Keep changes focused on the requested task. Do not change generated output,
+  dependencies, versions, or release metadata unless the task requires it.
+- Validate the changed package and its dependents before widening validation:
 
-If the task needs task selection, local-service recovery, shared Ollama, or
-release procedures, read the
-[local development and release workflow guide](docs/guides/local-development-and-release-workflow.md).
-It owns those shared contributor procedures.
+  ```sh
+  turbo <task> --filter=@shipfox/<package>...
+  ```
 
-If the task adds, updates, or exempts a dependency, read the
-[dependency version policy](docs/policies/dependency-versions.md). It owns
-dependency rules and required checks.
+- Report the files changed, validation run, and any skipped checks or remaining
+  risks.
 
-If the task writes or reviews code comments, module exports, or non-trivial
-control flow, read the [code style policy](docs/policies/code-style.md). It owns
-the shared rules for those code decisions.
+## Read before editing
 
-## Backend architecture
+Read the linked source before making the matching change. For a task not listed
+here, use the full [engineering documentation map](docs/README.md).
 
-If your task adds or changes a backend module, DTO, outbox event, HTTP boundary,
-or server package dependency, read the
-[backend architecture guide](docs/architecture/backend-architecture.md). It
-owns the current module model and package-boundary rules.
-
-## Codebase conventions
-
-### Backend modules
-
-Backend feature packages are composed as declarative modules. A feature package
-typically exports a `ShipfoxModule` that declares its `database`, `routes`,
-`auth`, `e2eRoutes`, `publishers`, `subscribers`, and/or `workers`; apps should
-compose those module declarations rather than wiring feature internals directly.
-Module initialization runs in array order, so list modules with shared database
-dependencies before dependents.
-
-API feature packages usually follow a layered shape:
-
-```text
-src/
-  core/          Domain behavior, entities, providers, and typed errors
-  db/            Drizzle schema, migrations, persistence functions, row mappers
-  presentation/  Fastify routes, auth adapters, and DTO conversion
-```
-
-### HTTP routes
-
-Define HTTP endpoints with `defineRoute`, Zod schemas, and named auth methods
-from `@shipfox/node-fastify` / `@shipfox/api-auth-context`. Prefer route groups
-for shared prefixes, plugins, and inherited auth instead of repeating those
-concerns in each route.
-
-### DTOs and API contracts
-
-Public HTTP contracts live in sibling `*-dto` packages. Put Zod request/response
-schemas, inferred DTO types, and public event names/payload types there so the
-backend, client, and E2E helpers all share the same contract.
-
-Use camelCase for internal domain objects and snake_case for external HTTP DTOs.
-Keep the conversion centralized in `presentation/dto/*` files; route handlers
-should call a mapper like `toProjectDto()` rather than manually shaping response
-objects inline.
-
-### Persistence and events
-
-Drizzle schema files own row-to-domain mapping. A table file should define the
-table, infer DB types, and export `toX()` mappers; higher layers should work with
-domain objects rather than raw Drizzle rows where possible.
-
-Outbox events are part of a module's public contract. Define event names and
-payload maps in the module's `*-dto` package, write outbox events in the same
-transaction as the state change, and register publisher tables on the module
-declaration.
-
-### Client architecture and forms
-
-When a task adds or changes a client feature, API adapter, query, route state,
-form, atom, browser storage, or cross-feature client flow, read the
-[client architecture guide](docs/architecture/client-architecture.md). It owns
-the current client model, form rules, and architecture enforcement.
-
-### Testing
-
-If you add or change unit tests, Storybook stories, or visual regression
-coverage, read the [testing guide](docs/guides/testing.md). It owns test level
-selection, unit-test conventions, Storybook ordering, Argos build names, and
-visual review.
-
-If you add or reshape E2E coverage, read the [E2E guide](e2e/README.md). It
-owns suite architecture, HTTP-first setup, screens, drivers, dependencies, and
-the workflow-flow runbook routing.
-
-### Backend cross-cutting rules
-
-If your task adds or changes an environment variable, validator, or environment
-description, read the [configuration policy](docs/policies/configuration.md). It
-owns repository-wide configuration rules.
-
-If your task adds a domain or provider error, translates a request failure, or
-reports an unexpected failure, read [error handling](docs/architecture/error-handling.md).
-It owns the backend error model and reporting boundaries.
-
-If your task adds a metric or changes instrumentation startup, naming, units, or
-labels, read [observability](docs/architecture/observability.md). It owns the
-backend metrics model and cardinality constraints.
-
-If your task mints, verifies, or carries an authentication token, read the
-[Auth security model](libs/api/auth/README.md#security-model). It owns token
-authority, lifetime, trust boundaries, and logging constraints.
-
-## Design System
-
-Before an agent creates or changes a visual or UI decision, read
-[DESIGN.md](DESIGN.md). It owns the shared design system and points to the
-code that owns exact token and component values.
+| Before editing when the task... | Read | It owns |
+| --- | --- | --- |
+| Needs task selection, local-service recovery, shared Ollama, affected-package validation, or package release procedures. | [Local development and release workflow](docs/guides/local-development-and-release-workflow.md) | Shared contributor procedures. |
+| Adds, updates, or exempts a dependency. | [Dependency version policy](docs/policies/dependency-versions.md) | Version rules, exceptions, package families, and dependency checks. |
+| Adds or changes a backend module, DTO, outbox event, HTTP boundary, or server package dependency. | [Backend architecture](docs/architecture/backend-architecture.md) | The current backend module model and package-boundary rules. |
+| Changes client state, API adapters, forms, or feature-domain boundaries. | [Client architecture](docs/architecture/client-architecture.md) | The current client model, form rules, and architecture enforcement. |
+| Adds or changes an environment variable, validator, or environment description. | [Configuration policy](docs/policies/configuration.md) | Configuration ownership, validation, and description rules. |
+| Adds a domain or provider error, translates a request failure, or reports an unexpected failure. | [Error handling](docs/architecture/error-handling.md) | The error model, client translation, and reporting boundaries. |
+| Adds a metric or changes instrumentation startup, naming, units, or labels. | [Observability](docs/architecture/observability.md) | The metrics model and cardinality constraints. |
+| Mints, verifies, or carries an authentication token. | [Auth security model](libs/api/auth/README.md#security-model) | Token authority, lifetime, trust boundaries, and logging constraints. |
+| Adds or changes unit tests, Storybook stories, or visual regression coverage. | [Testing guide](docs/guides/testing.md) | Test selection, Storybook conventions, and visual-review workflow. |
+| Adds or changes end-to-end coverage. | [E2E guide](e2e/README.md) | E2E suite structure, setup, screens, and package boundaries. |
+| Creates or changes a visual or interaction decision. | [Design system](DESIGN.md) | Shared design guidance; code owns exact token and component values. |
+| Writes engineering prose, a package README, or a runbook. | [Writing guide](WRITING.md) | Repository prose and package-README standards. |
+| Writes product or self-hosting documentation. | [Docs writing guide](apps/docs/WRITING.md) | Product-documentation page types, templates, and terminology. |
+| Writes or reviews code comments, module exports, or non-trivial control flow. | [Code style policy](docs/policies/code-style.md) | Shared code-comment, import and export, and control-flow rules. |
+| Changes a cross-package client composition seam, server module boundary, or shared server-package boundary. | [Engineering documentation map](docs/README.md) | The applicable ADR and its decision boundary. |
+| Changes repository documentation structure or adds a shared documentation surface. | [ADR 0005](docs/adr/0005-repository-documentation-architecture.md) | Documentation ownership, routing, and progressive disclosure. |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,20 +1,16 @@
 # Contributing
 
-This project and everyone participating in it are governed by the Code of
-Conduct which can be found in the file [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
-By participating, you are expected to uphold this code.
+This project and everyone participating in it are governed by the
+[Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to
+uphold it.
 
 ## Prerequisites
 
-- [mise](https://mise.jdx.dev/): manages tool versions (Node.js, pnpm, [Turbo](https://turbo.build/), Ollama)
-- [Docker](https://docs.docker.com/get-docker/): runs local service dependencies (PostgreSQL, etc.)
+- [mise](https://mise.jdx.dev/) manages the pinned Node.js, pnpm, Turbo, and
+  Ollama versions.
+- [Docker](https://docs.docker.com/get-docker/) runs local service dependencies.
 
-## Getting Started
-
-### Install tooling and dependencies
-
-[mise](https://mise.jdx.dev/) reads `mise.toml` and installs the correct versions
-of Node.js, pnpm, Turbo, and Ollama.
+## Get started
 
 Install the pinned tools and workspace dependencies:
 
@@ -23,327 +19,51 @@ mise install
 mise exec -- pnpm install
 ```
 
-### Start services and build
+Start local dependencies and build the repository:
 
 ```sh
 docker compose up -d
 mise exec -- turbo build
 ```
 
-This creates a working local checkout. Use `mise exec --` for shell scripts and
-automation. Run `mise tasks` to discover repository tasks.
+Use `mise exec --` for shell scripts and automation. Run `mise tasks` to find
+repository tasks.
 
-## Normal contribution workflow
+## Normal contribution loop
 
-Make a focused change. Run the smallest relevant validation before opening a
-pull request. Read the [local development and release workflow guide](docs/guides/local-development-and-release-workflow.md)
-when you need task selection, Conductor or Ollama recovery, affected-package
-validation, or package release procedures.
-
-If your contribution creates or changes a visual or interaction decision, read
-the [design system](DESIGN.md). It owns shared design guidance and points to
-the code that owns exact token and component values.
-
-If you add, update, or exempt a dependency, read the
-[dependency version policy](docs/policies/dependency-versions.md). It defines
-version rules, exceptions, package families, and dependency checks.
-
-## Client architecture
-
-When you add or change a client feature, API adapter, query, route state, form,
-atom, browser storage, or cross-feature client flow, read the
-[client architecture guide](docs/architecture/client-architecture.md). It owns
-the current client model, form rules, and architecture enforcement.
-
-## Backend cross-cutting rules
-
-When your change adds or changes an environment variable, validator, or
-environment description, read the [configuration policy](docs/policies/configuration.md).
-It owns repository-wide configuration rules.
-
-When your change adds a domain or provider error, translates a request failure,
-or reports an unexpected failure, read [error handling](docs/architecture/error-handling.md).
-It owns the backend error model and reporting boundaries.
-
-When your change adds a metric or changes instrumentation startup, naming,
-units, or labels, read [observability](docs/architecture/observability.md). It
-owns the backend metrics model and cardinality constraints.
-
-When your change mints, verifies, or carries an authentication token, read the
-[Auth security model](libs/api/auth/README.md#security-model). It owns token
-authority, lifetime, trust boundaries, and logging constraints.
-
-## Writing Documentation
-
-All technical writing (docs pages, package READMEs, guides) follows
-[WRITING.md](WRITING.md): structure for skimming, sentence and word rules, a
-strict no-em-dash rule, and language-level targets with a readability script.
-Docs-app pages additionally follow
-[apps/docs/WRITING.md](apps/docs/WRITING.md).
-
-## Directory Structure
-
-```
-apps/           Application packages (deployable services)
-dev/            Local environment and Conductor workspace lifecycle
-e2e/            E2E harness, fixtures, screens, and suites
-libs/           Library packages (shared code, published or internal)
-tools/          Internal build, policy, and release tooling
-```
-
-Each package follows the same layout:
-
-```
-package/
-  src/          Source code
-  test/         Test factories and helpers
-  dist/         Build output (git-ignored)
-```
-
-
-## E2E Testing
-
-E2E tests live under `e2e/` and use
-[Playwright](https://playwright.dev/) against the local stack. The full authoring
-guide is [`e2e/README.md`](e2e/README.md); it defines the suite levels, setup
-rules, page-object rules, dependency boundaries, and review checklist.
-
-Start the local service dependencies, then use the repo E2E harness to start the
-API/client dev servers and run Playwright:
+Make a focused change, then run the smallest validation that proves it. Start
+with the changed package and its dependents:
 
 ```sh
-docker compose up -d
-mise run e2e -- --filter=@shipfox/e2e-client-auth
+mise exec -- turbo <task> --filter=@shipfox/<package>...
 ```
 
-The harness writes API/client logs and failure diagnostics to
-`.context/shipfox-e2e-logs/` locally. It also reads Conductor worktree ports from
-`.context/local-services/env` through mise, so the same command works in worktrees.
-If the API and client are already running, run E2E packages directly:
+Before opening a pull request, run the validation required by the changed
+surface and make sure the change is scoped to the contribution. The
+[local development and release workflow](docs/guides/local-development-and-release-workflow.md)
+owns task selection, affected-package validation, local-service recovery,
+Conductor and Ollama recovery, Changesets, and package release procedures.
 
-```sh
-turbo test:e2e --filter=@shipfox/e2e-client-auth
-```
+## Find the context for your task
 
-## Unit Testing Strategy (Client Apps)
+Read the linked source before making the matching change. For a task not listed
+here, use the full [engineering documentation map](docs/README.md).
 
-Client tests should default to the cheapest environment that can prove the
-behavior under test. React Testing Library is useful for DOM behavior, but it is
-too expensive for schema validation, request payload shaping, error-copy mapping,
-redirect sanitization, cache key generation, or other pure decisions.
-
-When adding or refactoring client tests:
-
-1. Put pure behavior in plain TypeScript helpers and test it in Vitest's `node`
-   environment. Examples include form parsing, DTO normalization, auth error
-   copy, URL sanitization, and token timing helpers.
-2. Keep React Testing Library for behavior that requires rendered React state:
-   provider wiring, hooks interacting with React Query/Jotai, focus/portal/menu
-   behavior, StrictMode idempotency, and a small number of page smoke tests.
-3. Move full user journeys to Playwright E2E instead of reproducing them through
-   a memory router, auth provider, query client, API mocks, and toast container in
-   every unit test.
-4. Avoid asserting schema details or exact request payloads in RTL page tests when
-   a Node helper test can cover the same branch directly.
-5. Avoid real timers in unit tests. Prefer immediate promises, fake timers, or
-   explicitly controlled promises over `setTimeout` sleeps.
-6. Use `fireEvent.change` for simple final-value form setup. Use
-   `userEvent.type` only when keyboard-level interaction semantics are the thing
-   being tested.
-
-Client packages that mix pure tests and DOM tests should split Vitest projects so
-`.test.ts` files can run in `node` without `test/setup.ts`, while `.test.tsx`
-files and browser-storage tests run in `jsdom`:
-
-```typescript
-export default defineConfig(
-  {
-    test: {
-      projects: [
-        {
-          extends: true,
-          test: {
-            name: 'node',
-            environment: 'node',
-            include: ['src/**/*.test.ts'],
-            exclude: ['src/state/local-storage-backed.test.ts'],
-          },
-        },
-        {
-          extends: true,
-          test: {
-            name: 'dom',
-            environment: 'jsdom',
-            include: ['src/**/*.test.tsx', 'src/state/local-storage-backed.test.ts'],
-            setupFiles: ['test/setup.ts'],
-          },
-        },
-      ],
-    },
-  },
-  import.meta.url,
-);
-```
-
-The target shape is many fast Node tests for branch-heavy behavior, a small RTL
-suite for React integration, and Playwright for user-visible journeys.
-
-### Render at the lowest altitude that proves the behavior
-
-A page-level harness (memory router + `QueryClient` + configured API client, e.g.
-`renderProjectPage` in `libs/client/*/test/pages.tsx`) is the heaviest way to
-mount a component, and every import re-evaluates that provider stack. Pick the
-lightest tier that can still exercise what the test asserts:
-
-| Tier | Use it for | How |
+| When your task... | Read | It owns |
 | --- | --- | --- |
-| `node` test | Pure decisions: filtering, formatting, URL/search-param shaping, status mapping. | Extract a helper, test it in the `node` project (`*.test.ts`, no DOM). |
-| `render()` | A presentational component that takes all its data through props and renders no router-aware child. | `render(<Component {...props} />)` from `@testing-library/react`, no providers. |
-| `renderWithRouter()` | A component that needs a router in context (its rows render `<Link>`, or it calls `useNavigate`) but fetches nothing. | A router-only helper (e.g. `libs/client/workflows/test/render.tsx`): memory router, no `QueryClient` or API client. |
-| Page harness | A page, or a component that genuinely fetches and navigates (React Query hooks + `useNavigate`). | `renderProjectPage` / the package's `test/pages.tsx`. |
-
-A page keeps a handful of harness-based smoke tests; it should not carry dozens of
-assertions that each remount the world when a lower tier proves the same branch.
-
-**Enforcement.** Harness usage must be justified in review, and a package that
-uses the page harness pins its harness importers with an allowlist guard test (see
-`libs/client/workflows/src/page-harness-budget.test.ts`). A new `#test/pages`
-import fails the guard until it is added to the allowlist, which is the moment a
-reviewer asks whether the test needs page wiring or should drop an altitude.
-
-## Visual Regression Testing
-
-Visual drift is caught on every PR via [Argos](https://argos-ci.com/). One Argos
-project receives one named build per source package (`react-ui` for
-`@shipfox/react-ui`, `client-auth` for `@shipfox/client-auth`,
-`e2e-client-auth` for `@shipfox/e2e-client-auth`, etc.) using Argos's
-[build-splitting](https://argos-ci.com/docs/build-splitting). Each build posts
-its own GitHub check, and a surface with both Storybook and E2E coverage gets
-two standalone builds in the same Argos project. Do not merge those captures
-through parallel or sharded Argos builds.
-
-### What's covered
-
-| Build name | Source | Captured |
-| --- | --- | --- |
-| `react-ui` | `@shipfox/react-ui` stories via `@storybook/addon-vitest` + `@argos-ci/storybook/vitest-plugin` | every story in **light + dark** (declared in `libs/shared/react/ui/.storybook/preview.tsx` as `parameters.argos.modes`) |
-| `client-workflows` | `@shipfox/client-workflows` stories via `@storybook/addon-vitest` + `@argos-ci/storybook/vitest-plugin` | every story in **dark** (declared in `libs/client/workflows/.storybook/preview.tsx` as `parameters.argos.modes`) |
-| `client-auth` | `@shipfox/client-auth` stories via `@storybook/addon-vitest` + `@argos-ci/storybook/vitest-plugin` | workspace switcher states in **dark** (declared in `libs/client/auth/.storybook/preview.tsx` as `parameters.argos.modes`) |
-| `e2e-client-auth` | `@shipfox/e2e-client-auth` Playwright specs via `@argos-ci/playwright` reporter | explicit `argosScreenshot()` calls at user-visible checkpoints |
-
-`react-ui` is the theming source of truth, so it captures every story in **light
-and dark**. Feature packages (`client-*`) compose those primitives, so they
-capture only the product's primary **dark** theme: theme correctness is already
-proven upstream in `react-ui`, and one theme per feature story roughly halves the
-Argos screenshots those builds cost. Keep new `client-*` `parameters.argos.modes`
-to `dark` only; reach for a second theme in a feature package only when it renders
-theme-specific markup that `react-ui` does not already cover.
-
-The goal is review-grade signal on UI drift, not 100% state coverage. Capture the
-states a reviewer would want to eyeball on a PR; skip anything that re-renders
-the same DOM as a covered state.
-
-### Run locally
-
-Storybook capture is part of the standard cached `test` task, not a separate
-`test:visual` task. That keeps cache policy consistent while Argos build names
-keep review surfaces separate. It is useful when iterating on a component:
-
-```sh
-turbo test --filter=@shipfox/react-ui
-```
-
-This runs Vitest in browser mode against every story, producing PNGs in
-`libs/shared/react/ui/screenshots/` (gitignored). No `ARGOS_TOKEN` is needed
-locally; the `argosVitestPlugin` only uploads when `process.env.CI` is set.
-
-Page snapshots ride on the existing E2E flow. When you run
-`turbo test:e2e --filter=@shipfox/e2e-client-auth` locally without `CI=true`,
-the Argos reporter is not active, so no screenshots are uploaded.
-
-### Add a new component snapshot
-
-Just add a story. `@storybook/addon-vitest` discovers `.stories.@(js|jsx|ts|tsx|mdx)`
-under `src/**` automatically and the Argos vitest plugin captures each one in the
-themes that package's `parameters.argos.modes` declares (light + dark in
-`react-ui`, dark only in feature packages). To cover a state that a single render
-can't reach (e.g. error states, populated lists), add it as a new story rather
-than driving interactions in `play`.
-
-### Add a new client-page snapshot
-
-In an `e2e/suites/client/<feature>` spec:
-
-```ts
-import {argosScreenshot} from '@shipfox/playwright';
-
-test('shows the empty state for new workspaces', async ({page, auth}) => {
-  // ...drive UI to the state you want to verify...
-  await expect(page.getByRole('heading', {name: 'No projects yet'})).toBeVisible();
-  await argosScreenshot(page, 'projects/empty-state');
-});
-```
-
-Conventions:
-
-- Snapshot **after** the assertions that prove the page reached the expected
-  state. `argosScreenshot` waits for fonts and stable layout, but it cannot
-  wait for content you have not asserted on.
-- Name snapshots `<surface>/<state>` (e.g. `auth/login`,
-  `projects/empty-state`). The directory-style prefix groups related shots in
-  the Argos UI.
-- Keep any generated entity data that is visible in a screenshot deterministic.
-  Random users, IDs, and hidden setup data are fine for isolation, but names,
-  titles, and other rendered text should use fixed values so Argos only reports
-  meaningful UI drift.
-
-New `e2e/suites/client/*` packages register their own Argos reporter in their
-`playwright.config.ts` with a `buildName` that matches the package name without
-the `@shipfox/` scope (e.g. `@shipfox/e2e-client-auth` →
-`'e2e-client-auth'`, `@shipfox/e2e-client-projects` →
-`'e2e-client-projects'`). One named Argos build per E2E module keeps PR checks
-scoped: a regression in the auth flow doesn't taint the review surface for
-projects.
-
-### Reviewing drift
-
-When a PR diff is non-trivial, both Argos checks may flip from green to "review
-required". Open the Argos build, mark each diff as accepted (intentional UI
-change) or rejected (regression). Approving a build updates the baseline once
-the PR merges to `main`.
-
-### Plumbing files
-
-- `libs/shared/react/ui/vitest.config.ts`: defines the `storybook` Vitest
-  project that wraps stories with `storybookTest()` and `argosVitestPlugin()`.
-  The plugin writes PNGs to `screenshots/` and uploads when `process.env.CI`
-  is set.
-- Client packages with Storybook use the same `storybook` Vitest project shape,
-  name the Argos build after their package without the `@shipfox/` scope, and
-  include a package-level `vercel.json` for Storybook deployment.
-- `turbo.jsonc` `globalPassThroughEnv` includes `ARGOS_TOKEN` and `CI` so
-  the Vitest plugin and Playwright reporter actually receive them when run
-  through Turbo. If you add another env var the visual flow needs (e.g. a
-  custom reference-branch override), allowlist it here.
-
-## Import Aliases
-
-Packages use Node.js [subpath imports](https://nodejs.org/api/packages.html#subpath-imports) (`imports` field in `package.json`) instead of TypeScript `paths`:
-
-| Pattern | Maps to | Example |
-| --- | --- | --- |
-| `#*` | `./src/*` | `import {foo} from '#core/foo.js'` |
-| `#test/*` | `./test/*` | `import {bar} from '#test/factories/bar.js'` |
-
-Node, TypeScript, and [Vitest](https://vitest.dev/) resolve these natively; no build-time rewriting needed.
-
-## Development Workflow
-
-Libraries (`libs/`) expose **conditional exports**:
-
-| Condition | Resolves to | Used by |
-| --- | --- | --- |
-| `workspace-source` | TypeScript source (`src/`) | `pnpm dev`, editor, tests |
-| `default` | Built output (`dist/`) | `turbo build`, CI |
-
-`pnpm dev` picks up library source changes immediately, no lib rebuild needed.
+| Needs task selection, local-service recovery, shared Ollama, affected-package validation, or package release procedures. | [Local development and release workflow](docs/guides/local-development-and-release-workflow.md) | Shared contributor procedures. |
+| Adds, updates, or exempts a dependency. | [Dependency version policy](docs/policies/dependency-versions.md) | Version rules, exceptions, package families, and dependency checks. |
+| Adds or changes a backend module, DTO, outbox event, HTTP boundary, or server package dependency. | [Backend architecture](docs/architecture/backend-architecture.md) | The current backend module model and package-boundary rules. |
+| Changes client state, API adapters, forms, or feature-domain boundaries. | [Client architecture](docs/architecture/client-architecture.md) | The current client model, form rules, and architecture enforcement. |
+| Adds or changes an environment variable, validator, or environment description. | [Configuration policy](docs/policies/configuration.md) | Configuration ownership, validation, and description rules. |
+| Adds a domain or provider error, translates a request failure, or reports an unexpected failure. | [Error handling](docs/architecture/error-handling.md) | The error model, client translation, and reporting boundaries. |
+| Adds a metric or changes instrumentation startup, naming, units, or labels. | [Observability](docs/architecture/observability.md) | The metrics model and cardinality constraints. |
+| Mints, verifies, or carries an authentication token. | [Auth security model](libs/api/auth/README.md#security-model) | Token authority, lifetime, trust boundaries, and logging constraints. |
+| Adds or changes unit tests, Storybook stories, or visual regression coverage. | [Testing guide](docs/guides/testing.md) | Test selection, Storybook conventions, and visual-review workflow. |
+| Adds or changes end-to-end coverage. | [E2E guide](e2e/README.md) | E2E suite structure, setup, screens, and package boundaries. |
+| Creates or changes a visual or interaction decision. | [Design system](DESIGN.md) | Shared design guidance; code owns exact token and component values. |
+| Writes engineering prose, a package README, or a runbook. | [Writing guide](WRITING.md) | Repository prose and package-README standards. |
+| Writes product or self-hosting documentation. | [Docs writing guide](apps/docs/WRITING.md) | Product-documentation page types, templates, and terminology. |
+| Writes or reviews code comments, module exports, or non-trivial control flow. | [Code style policy](docs/policies/code-style.md) | Shared code-comment, import and export, and control-flow rules. |
+| Changes a cross-package client composition seam, server module boundary, or shared server-package boundary. | [Engineering documentation map](docs/README.md) | The applicable ADR and its decision boundary. |
+| Changes repository documentation structure or adds a shared documentation surface. | [ADR 0005](docs/adr/0005-repository-documentation-architecture.md) | Documentation ownership, routing, and progressive disclosure. |


### PR DESCRIPTION
Refactor `CONTRIBUTING.md` and `AGENTS.md` into audience-specific task routers.

The entrypoints had become overlapping technical handbooks, which made shared guidance drift and forced agents to load unrelated contributor context. This keeps human bootstrap steps in the contributing guide and agent execution rules in the agent guide, while routing matching tasks directly to the same canonical sources.

The compact routing tables are intentionally duplicated as navigation only. They do not duplicate the procedures or technical rules owned by the linked documents. `CLAUDE.md` remains an alias for `AGENTS.md`.

Closes ENG-1161

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored `CONTRIBUTING.md` and `AGENTS.md` into focused entrypoints with compact task routers that point to the same canonical docs. This reduces overlap and drift and speeds up task routing for humans and agents. Closes ENG-1161.

- **Refactors**
  - `CONTRIBUTING.md`: trimmed to prerequisites, quick start, and a concise contribution loop; adds a small router to `docs/*` for task-specific rules.
  - `AGENTS.md`: adds an execution baseline (use `mise`, validate with `turbo <task> --filter=@shipfox/<package>...`, report changes/risks) and a matching router to canonical sources.
  - Keeps shared procedures and rules owned by their guides (dependency policy, architecture, testing, docs writing, ADRs), removing duplicated how-tos.
  - `CLAUDE.md` stays as an alias to `AGENTS.md` for compatibility.

- **Migration**
  - No workflow changes; follow the routers for task-specific guidance.
  - Existing links to `CLAUDE.md` continue to work.

<sup>Written for commit 104cb8aa0c6eb5a3a7e40819f9be1e6d5baa56d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

