### PR TITLE
Align agent skills with shared standards

### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -1,104 +1,37 @@
 ---
 name: commit
-description: "ALWAYS use this skill when committing changes. Follows Shipfox conventions for branch safety, validation checks, commit messages, and Linear ticket references. Trigger on commit, commit changes, save changes, make a commit, or create commit."
+description: "ALWAYS use this skill when committing changes. Applies Shipfox agent sequencing for branch checks, scoped validation, and commit creation. Trigger on commit, commit changes, save changes, make a commit, or create commit."
 allowed-tools: Bash
 ---
 
 # Commit Changes
 
-Commit staged changes, or all modified files if nothing is staged, following
-Shipfox's engineering practices.
+Create a commit after applying the shared contributor rules and the agent
+workflow below.
 
-This skill is shared by Claude and Codex. Claude loads it from
-`.claude/skills/commit`; Codex loads the same directory through
-`.codex/skills/commit`.
+Before committing, read the
+[contributor review standard](../../../CONTRIBUTING.md#prepare-a-change-for-review).
+It owns the shared branch-safety and commit-message rules that humans and
+agents follow.
 
-## Prerequisites
-
-Before committing, check the current branch:
-
-```bash
-git branch --show-current
-```
-
-If you're on `main`, create a feature branch first. Do not ask for confirmation
-when a clear branch name can be inferred, and do not commit directly to `main`.
-
-Derive a short, kebab-case branch name from the intent of the changes. If a
-Linear ticket is in the command arguments or inferrable from context, prefix
-the branch with it:
-
-```bash
-# With a ticket reference
-git checkout -b fox-123-add-label-validation
-
-# Without a ticket reference
-git checkout -b add-label-validation
-```
+When choosing validation, read the
+[local development and release workflow](../../../docs/guides/local-development-and-release-workflow.md).
+It owns task selection and the validation scope for the changed package.
 
 ## Process
 
-### Step 1: Understand the Changes
-
-```bash
-git status
-git diff
-git diff --cached
-```
-
-Review what is staged vs. unstaged. Stage the appropriate files if nothing is
-already staged.
-
-### Step 2: Run Conformity Checks
-
-Run all three checks before committing. If any check fails, stop and report the
-error. Do not commit failing changes.
-
-```bash
-mise exec -- turbo build --filter '...[origin/main]'
-mise exec -- turbo test --filter '...[origin/main]'
-mise exec -- turbo check --filter '...[origin/main]'
-```
-
-### Step 3: Write the Commit Message
-
-**Format:**
-
-```text
-<subject>
-
-<body>
-
-<footer>
-```
-
-Only the subject is required. Add a body when the change needs context beyond
-what the subject conveys. Add a footer to reference Linear tickets.
-
-**Subject line rules:**
-
-- Short sentence describing the change at a high level from a business/product
-  perspective
-- Use imperative mood: "Add runner label validation" not "Added runner label
-  validation"
-- Maximum ~70 characters
-- No period at the end
-- Never includes a `Co-authored-by` or `Co-Authored-By` trailer
-
-**Body guidelines:**
-
-- Explain what and why, not how
-- Include motivation for the change
-- Contrast with previous behavior when relevant
-
-**Footer - Linear ticket references:**
-
-```text
-Fixes LINEAR-123   # links and signals the ticket is resolved
-Refs LINEAR-123    # links without closing
-```
-
-### Step 4: Create the Commit
+1. Inspect `git branch --show-current`, `git status`, `git diff`, and
+   `git diff --cached`.
+2. Apply the contributor branch rule. If a new feature branch is needed, infer
+   a short kebab-case name from the change and issue context.
+3. Stage only the intended files when nothing is staged. Preserve an existing
+   deliberate staging set.
+4. Run the validation selected by the shared workflow. Use the repository's
+   agent execution instructions for pinned tooling and package filters. Stop
+   and report failures before committing.
+5. Write the commit message using the contributor standard. Infer it from the
+   diff when the user has not provided one.
+6. Create the commit. Use a heredoc when the message needs a body or footer:
 
 ```bash
 git commit -m "$(cat <<'EOF'
@@ -106,50 +39,9 @@ Subject line here
 
 Optional body explaining why.
 
-Refs LINEAR-123
+Refs ENG-123
 EOF
 )"
 ```
 
-If command arguments or the user request provide commit message guidance, use
-them. Otherwise infer the message from the diff.
-
-## Examples
-
-### Simple Fix
-
-```text
-Fix registration token expiry not being enforced
-
-Tokens were validated by existence but not by expiry date, allowing
-stale tokens to register new runners. Add the expiry check and return
-401 when the token is expired.
-
-Fixes LINEAR-456
-```
-
-### Feature
-
-```text
-Add per-organization runner concurrency limits
-
-Prevents a single org from exhausting the shared runner pool by
-introducing a configurable per-org cap.
-
-Refs LINEAR-123
-```
-
-### Refactor
-
-```text
-Extract token validation into a shared helper
-
-Duplicate parsing logic existed in three route handlers. No behavior
-change.
-```
-
-## Principles
-
-- Each commit should be a single, stable change
-- The repository should be in a working state after each commit
-- Commits should be independently reviewable
+Report the commit hash, subject, files included, and validation results.

--- a/.agents/skills/generate-changeset/SKILL.md
+++ b/.agents/skills/generate-changeset/SKILL.md
@@ -1,121 +1,42 @@
 ---
 name: generate-changeset
-description: "Generate a changeset file for the current branch following Shipfox's changeset rules. Trigger when the user asks to add a changeset, document a change for release, bump versions, or when preparing a PR that touches libs/ or tools/."
+description: "Generate a Changeset file for the current branch using Shipfox agent automation. Trigger when the user asks to add a Changeset, document a change for release, bump versions, or prepare a PR that touches published packages."
 allowed-tools: Read, Write, Bash, Glob, Grep
 ---
 
-# Generate Changeset (Agent Path)
+# Generate Changeset
 
-Agents cannot drive the interactive `pnpm exec changeset` prompt. This skill is
-the non-interactive equivalent: it writes a properly-formatted
-`.changeset/*.md` file directly.
+Agents cannot drive the interactive `pnpm exec changeset` prompt. This skill
+creates the equivalent `.changeset/*.md` file directly.
 
-See [CONTRIBUTING.md#publishing--changesets](../../../CONTRIBUTING.md#publishing--changesets)
-for the canonical rule on **when** a changeset is required and which bump
-level to pick. The skill below covers **how** to author the file.
+When a change may affect a published package, read the
+[Changesets and publishing workflow](../../../docs/guides/local-development-and-release-workflow.md#publish-packages-with-changesets).
+It owns when a Changeset is required, package eligibility, bump levels, and
+the shared summary rules.
 
 ## Process
 
-### Step 1: Confirm a changeset is needed
+1. Inspect `git diff origin/main...HEAD --name-only` and apply the shared
+   workflow to decide whether a Changeset is required.
+2. For each changed package, walk upward to its nearest `package.json`. Read
+   its `name` and `private` fields. Include only eligible published packages.
+3. Apply the shared bump-level policy. If the change is breaking, explain the
+   major-version impact and ask the user before writing it.
+4. Generate an unused three-word filename under `.changeset/` and write the
+   standard Changesets front matter with the selected package names and bumps.
+5. Write the summary using the shared workflow. Do not create a release pull
+   request or run the publisher.
+6. Report the filename, package bumps, and summary. The calling workflow is
+   responsible for committing the file with the implementation.
 
-```bash
-git diff origin/main...HEAD --name-only
-```
-
-If the diff only touches `apps/`, `e2e/`, the workspace root, docs, or repo
-config, stop and report that no changeset is needed. Otherwise continue.
-
-### Step 2: Identify the affected packages
-
-For each modified path under `libs/` or `tools/`, walk up to the nearest
-`package.json` and read its `name` field. Build the list of unique package
-names touched in the diff.
-
-```bash
-git diff origin/main...HEAD --name-only -- 'libs/**' 'tools/**' \
-  | xargs -n1 dirname 2>/dev/null \
-  | sort -u
-```
-
-Then for each directory, find the closest `package.json` and read its `name`.
-
-Skip any package whose `package.json` has `"private": true` — changesets for
-private packages are silently dropped at release time. In this repo, all
-`libs/*` and `tools/*` packages are public, but verify rather than assume.
-
-### Step 3: Choose the bump level
-
-Pick based on what was implemented in the diff:
-
-- `patch` — bug fixes, internal refactors, dependency bumps, performance work
-- `minor` — new features, additive public API, new exported symbols
-- `major` — breaking changes to public API, removed exports, renamed types
-
-When in doubt between `patch` and `minor`, default to `patch`. Never silently
-pick `major` — flag breaking changes to the user before writing the file.
-
-### Step 4: Write the changeset file
-
-Filename: `.changeset/<adjective>-<noun>-<verb>.md` (e.g.
-`happy-lions-jump.md`). Generate three random words; do not reuse an existing
-filename.
-
-Content format (single package):
+## File shape
 
 ```markdown
 ---
 "@shipfox/api-runners": minor
 ---
 
-Adds per-organization runner concurrency limits to prevent shared-pool starvation.
+Adds per-organization runner concurrency limits.
 ```
 
-Multiple packages:
-
-```markdown
----
-"@shipfox/api-runners": minor
-"@shipfox/api-runners-dto": patch
----
-
-Adds per-organization runner concurrency limits to prevent shared-pool starvation.
-```
-
-### Step 5: Report
-
-Tell the user the filename, the packages and bumps included, and the summary.
-Remind them to commit it alongside the code change (the skill writes the file
-but does not commit).
-
-## Style rules
-
-1. **Present tense**: "Adds runner label validation", not "Added".
-2. **One sentence, packed**: lead with the area of the product when it helps
-   readability. Every word earns its place. No bracketed asides, no trailing
-   notes, no second paragraph.
-3. **One changeset per logical change**: if the diff bundles two unrelated
-   changes, write two changesets.
-
-## Worked example
-
-Diff:
-
-- Modified `libs/api/runners/src/core/limit.ts` to add a new public
-  `enforceOrgLimit()` export
-- Modified `libs/api/runners-dto/src/limit-dto.ts` to add the matching Zod
-  schema
-- Modified `apps/api/src/routes/runners.ts` to wire the route
-
-Output (`.changeset/keen-otters-soar.md`):
-
-```markdown
----
-"@shipfox/api-runners": minor
-"@shipfox/api-runners-dto": minor
----
-
-Adds per-organization runner concurrency limits with a matching DTO schema for the new admin endpoint.
-```
-
-The `apps/api` change is not listed — apps are private and the release flow
-ignores them.
+Use one front-matter entry per affected package.

--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -1,106 +1,39 @@
 ---
 name: pr
-description: "ALWAYS use this skill when creating pull requests. Follows Shipfox conventions for PR titles, descriptions, GitHub CLI usage, and Linear ticket references. Trigger on create PR, open PR, submit PR, make PR, push and create PR, or prepare changes for review."
+description: "ALWAYS use this skill when creating pull requests. Applies Shipfox agent sequencing for GitHub CLI review preparation and pull-request creation. Trigger on create PR, open PR, submit PR, make PR, push and create PR, or prepare changes for review."
 allowed-tools: Bash
 ---
 
 # Create Pull Request
 
-Create pull requests following Shipfox's engineering practices.
+Create a pull request after applying the shared contributor rules and the
+agent workflow below.
 
-This skill is shared by Claude and Codex. Claude loads it from `.claude/skills/pr`;
-Codex loads the same directory through `.codex/skills/pr`.
+Before opening a pull request, read the
+[contributor review standard](../../../CONTRIBUTING.md#prepare-a-change-for-review).
+It owns shared pull-request scope, title, description, and Linear-reference
+rules for humans and agents.
 
-**Requires**: GitHub CLI (`gh`) authenticated and available.
-
-## Prerequisites
-
-Before creating a PR, ensure all changes are committed.
-
-If there are uncommitted changes:
-
-- In Claude, invoke the `/commit` skill if it is available. Pass `$ARGUMENTS`
-  through so it can use any ticket or hint provided.
-- In Codex, commit the intended changes using the repository's normal commit
-  workflow, or ask the user before committing if the requested scope is unclear.
-
-```bash
-# Check for uncommitted changes
-git status --porcelain
-```
+When the change may affect a published package, read the
+[Changesets and publishing workflow](../../../docs/guides/local-development-and-release-workflow.md#publish-packages-with-changesets).
+It owns when a Changeset is required and how releases are published.
 
 ## Process
 
-### Step 1: Verify Branch State
-
-```bash
-# Check current branch, commits ahead of the PR base, and remote sync status
-git status
-git log origin/main..HEAD --oneline
-```
-
-Ensure:
-
-- All intended changes are committed
-- The branch is not `main` (PRs must come from a feature branch)
-- Push the branch if not already on remote: `git push -u origin HEAD`
-
-### Step 2: Analyze Changes
-
-```bash
-# Full commit history diverging from the PR base
-git log origin/main..HEAD
-
-# Full diff
-git diff origin/main...HEAD
-```
-
-Understand the scope and purpose of all changes before writing the description.
-
-### Step 3: Add a Changeset If Required
-
-If the diff includes non-trivial changes to any package under `libs/` or
-`tools/`, the PR must include a changeset under `.changeset/*.md`. See
-[CONTRIBUTING.md#publishing--changesets](../../../CONTRIBUTING.md#publishing--changesets)
-for the rule and bump-level guidance.
-
-Check whether a changeset is already in the branch:
-
-```bash
-git diff origin/main...HEAD --name-only -- '.changeset/*.md'
-```
-
-To add one, invoke the `generate-changeset` skill (Claude/Codex) or run
-`pnpm exec changeset` interactively. Commit the changeset before opening the
-PR.
-
-### Step 4: Write the PR Description
-
-Use this structure:
-
-```markdown
-<brief description of what the PR does>
-
-<why these changes are being made - the motivation>
-
-<alternative approaches considered, if any>
-
-<any additional context reviewers need>
-```
-
-**Do include:**
-
-- Clear explanation of the _why_, not just the _what_
-- Linear ticket reference if one exists (see Issue References below)
-- Notes on areas that need careful review
-
-**Do NOT include:**
-
-- "Test plan" sections
-- Checkbox lists of testing steps
-- Redundant summaries of the diff
-
-### Step 5: Create the PR
+1. Check `git status --porcelain`. If intended changes are uncommitted, use the
+   repository commit workflow. Ask before committing only when the intended
+   scope is unclear.
+2. Inspect `git status`, `git log origin/main..HEAD --oneline`, and
+   `git diff origin/main...HEAD`. Confirm the branch is not `main` and contains
+   only the intended review scope.
+3. Apply the shared Changeset rule. If one is required and absent, invoke the
+   `generate-changeset` skill or use `pnpm exec changeset` interactively, then
+   commit it before opening the pull request.
+4. Use the contributor standard to prepare the title, description, and Linear
+   reference. If it is unclear whether the change fully resolves an issue, ask
+   before choosing a closing keyword.
+5. Push the branch when needed with `git push -u origin HEAD`, then create the
+   pull request:
 
 ```bash
 gh pr create --base main --title "<title>" --body "$(cat <<'EOF'
@@ -109,106 +42,17 @@ EOF
 )"
 ```
 
-Pass `--draft` if the user request, command arguments, or task context contains
-`draft` or `--draft`.
+Pass `--draft` when the user request, task context, or arguments require it.
 
-## Title Format
+## Edit an existing pull request
 
-- If the change is scoped to a specific package, prefix with the package name in
-  square brackets: `[runner] Add label validation`
-- Otherwise use a short, business-level sentence:
-  `Add label validation for self-hosted runners`
-- Follow Google's "Writing good CL descriptions" guidelines: describe the change
-  at a high level; say _what_ changed and _why_ in the title if it fits
-  concisely.
-
-## PR Description Examples
-
-### Feature PR
-
-```markdown
-Add per-organization runner concurrency limits
-
-Organizations could previously exhaust the shared runner pool by queuing
-unbounded jobs. This introduces a per-org concurrency cap configurable
-via the admin panel, preventing starvation for other tenants.
-
-Considered a global queue with fair-scheduling, but per-org limits are
-simpler to reason about and easier to tune per customer.
-
-Closes LINEAR-123
-```
-
-### Bug Fix PR
-
-```markdown
-[runner] Fix registration token expiry not being enforced
-
-Registration tokens were validated by existence but not by expiry date,
-allowing tokens older than 1 hour to still register new runners. This
-adds the expiry check and returns a 401 when the token is stale.
-
-Fixes LINEAR-456
-```
-
-### Refactor PR
-
-```markdown
-[api/auth] Extract token validation into a shared helper
-
-Duplicate token-parsing logic existed in three route handlers. Moves it
-into `libs/api/auth/core/validateToken.ts`. No behavior change.
-
-Prepares for adding rate-limiting per token in LINEAR-789.
-```
-
-## Issue References
-
-Reference Linear tickets in the PR body. Linear's
-[magic words](https://linear.app/docs/github#link-through-pull-requests) decide
-whether merging closes the ticket.
-
-**Default to a closing keyword.** If merging the PR completes the ticket's work,
-use `Closes` / `Fixes` / `Resolves` so it moves to Done. Only use a non-closing
-keyword (`Refs`, `Part of`, `Related to`) when the PR is partial work that
-leaves the ticket open.
-
-| Keywords                        | Effect on merge                 |
-| ------------------------------- | ------------------------------- |
-| `Closes`, `Fixes`, `Resolves`   | Links **and** closes the ticket |
-| `Refs`, `Part of`, `Related to` | Links without closing           |
-
-```markdown
-Closes LINEAR-123
-```
-
-Include a reference whenever a ticket is named in the request, arguments, or
-branch name. When unsure whether the PR fully resolves it, ask rather than
-defaulting to `Refs`.
-
-## Guidelines
-
-- **One PR per feature/fix** - don't bundle unrelated changes
-- **Keep PRs small** - smaller PRs get faster, better reviews
-- **Explain the why** - code shows what; the description explains why
-- **Use draft PRs** for early feedback before the work is complete
-
-## Editing Existing PRs
-
-Use `gh api` to update a PR after creation (more reliable than `gh pr edit`):
+Use `gh api` to update an existing pull request:
 
 ```bash
-# Update description
-gh api -X PATCH repos/{owner}/{repo}/pulls/PR_NUMBER -f body="$(cat <<'EOF'
-Updated description here
-EOF
-)"
-
-# Update title
-gh api -X PATCH repos/{owner}/{repo}/pulls/PR_NUMBER -f title='[scope] New title'
-
-# Update both
 gh api -X PATCH repos/{owner}/{repo}/pulls/PR_NUMBER \
-  -f title='[scope] New title' \
+  -f title='New title' \
   -f body='New description'
 ```
+
+Report the pull-request URL, branch, included commits, validation status, and
+any follow-up work.

--- a/.agents/skills/readme-writer/SKILL.md
+++ b/.agents/skills/readme-writer/SKILL.md
@@ -1,238 +1,52 @@
 ---
 name: readme-writer
-description: "Use this skill to write or revise a README.md for a Shipfox workspace package (libs/*, tools/*). Follows the project's existing README shape, keeps prose ESL-friendly, and runs a readability check before finishing. Trigger on write a README, draft README, rewrite README, document this package, or improve the README."
+description: "Use this skill to write or revise a README.md for a Shipfox workspace package (libs/*, tools/*). It applies the shared package README standard and runs the repository readability check. Trigger on write a README, draft README, rewrite README, document this package, or improve the README."
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash
 ---
 
 # README Writer
 
-Write the README that the Shipfox workspace already converges on: short,
-scannable, code-first, and worded so a non-native English reader can use the
-package without re-reading a sentence.
+Use this workflow to document one package. It does not apply to the repository
+root README, design documents, or RFCs.
 
-## When to use this skill
+Before drafting a package README, read the
+[package README standard](../../../WRITING.md#package-readmes). It owns the
+required structure, prose style, public-surface rules, development guidance,
+and license section for human and agent authors.
 
-- A workspace package under `libs/` or `tools/` is missing a README, or its
-  README has drifted from the code.
-- A user asks to "write a README", "document this package", or "rewrite the
-  README so it's clearer".
+When deciding whether detail belongs in the package README, read the
+[engineering documentation map](../../../docs/README.md). It owns
+documentation placement and canonical ownership.
 
-This skill is for **package READMEs**, not for the repo-root README, design
-docs, or RFCs.
+## Gather the package contract
 
-## Inputs to gather first
+Read the public package surface in this order:
 
-Before writing, read the package source so the README reflects what actually
-ships. Open these in order:
+1. `package.json` for its name, exports, binaries, scripts, and dependencies.
+2. The root export entry point for consumer-visible symbols.
+3. Additional source files only as needed to understand those exports.
+4. A sibling `*-dto` package when it owns public DTO or event names.
+5. `drizzle/` or `migrations/` when the package owns persistent data.
 
-1. `package.json` — public name, `exports`, `bin` entries, `scripts`,
-   `dependencies`. The README's first line and install snippet come from
-   `name`.
-2. `src/index.ts` (or whatever `exports["."]` points at) — the symbols a
-   consumer can import.
-3. `src/**/*.ts` — only as needed to understand each exported symbol.
-4. Any sibling `*-dto` package — DTO/event names that belong in the public
-   contract section.
-5. `drizzle/` or `migrations/` — table prefix and schema, if the package owns
-   a database.
-
-Do not document symbols that aren't in `exports` or `bin`. Internal helpers
-stay internal.
-
-## Required structure
-
-Every package README follows the same shape. Use only the sections that apply
-to the package, but keep them in this order:
-
-```text
-# <Display Name>            ← required
-<one-line description>      ← required (1 sentence)
-
-## What it does             ← required
-## Installation / Setup     ← required
-## Usage                    ← required (one runnable snippet)
-## Environment              ← required when the package reads process.env
-## Routes / API / Data Model ← required when the package exposes one of these
-## Behavior Notes           ← optional, for non-obvious semantics
-## Development              ← required
-## License                  ← required
-```
-
-### Title and one-liner
-
-The title is the human-readable name (`Shipfox Outbox`, `Shipfox React UI`)
-for `@shipfox/*` runtime packages, or the literal package name (`@shipfox/biome`,
-`@shipfox/typescript`) for tooling packages whose CLI name matters. Match the
-convention already used by neighboring packages — do not rename one in a README
-pass.
-
-The one-liner answers "what is this for?" in one sentence. No marketing. Front
-the noun phrase ("Typed outbox helpers for Shipfox modules."), then add the
-when-to-reach-for-it clause if it fits in the same sentence.
-
-### "What it does"
-
-A bulleted list of the public surface. Each bullet starts with a `**bolded**`
-symbol name or concept and is followed by one sentence:
-
-```markdown
-- **`createOutboxTable(pgTable)`**: Creates a Drizzle table named `outbox`
-  for a module table namespace.
-- **`DomainEvent`**: Runtime event shape used by dispatchers.
-```
-
-Group related exports under one bullet (`**Interceptor helpers**`,
-`**Theme helpers**`) when listing each function would just create noise.
-
-### Installation / Setup
-
-For tooling packages published as devDependencies, show `pnpm add -D ...`. For
-workspace-private packages, show the `workspace:*` JSON snippet (see
-`libs/api/auth/README.md`). For libraries that could in theory ship publicly,
-show `pnpm add` and skip the `yarn` / `npm` aliases unless an existing README
-in the same folder already lists them — match the neighbor.
-
-### Usage
-
-Exactly one runnable code block that exercises the primary entry point. Keep
-it small enough that a reader can scan it without scrolling. Use TypeScript
-unless the package is JS-only. Import from the package root, not from internal
-paths. If the snippet needs setup (env vars, a wrapping provider), show the
-setup as a second smaller block under the same heading.
-
-### Environment, Routes, API, Data Model
-
-Use Markdown tables when there are more than three rows of repetitive
-information, and bullets otherwise. The auth README's environment and route
-tables are the reference shape:
-
-```markdown
-| Variable | Default | Purpose |
-| --- | --- | --- |
-| `AUTH_JWT_SECRET` | none | Secret used to sign and verify access tokens. |
-```
-
-Data Model sections name the table prefix (`auth_`, `runners_`) and list
-tables. Cryptographic details (Argon2id, opaque tokens stored as hashes) go
-here, not in Usage.
-
-### Development
-
-The same three-line block, scoped to the package via `--filter`:
-
-```markdown
-## Development
-
-\`\`\`sh
-turbo check --filter=@shipfox/<name>
-turbo type --filter=@shipfox/<name>
-turbo test --filter=@shipfox/<name>
-\`\`\`
-```
-
-Drop `test` if the package has no test target. Add `turbo build` only if the
-package emits a build output (most `libs/shared/node/*` packages don't).
-
-If tests need Docker services or fixtures, mention that under this section in
-one sentence, then point at `docker compose up -d`.
-
-### License
-
-Always:
-
-```markdown
-## License
-
-MIT
-```
-
-## Voice rules
-
-The repo-wide [WRITING.md](../../../WRITING.md) owns the general style,
-punctuation (strictly no em dashes), and language-level rules; follow it in
-every README. These are what additionally separate a Shipfox README from a
-generic one:
-
-1. **One idea per sentence.** If a sentence has more than one comma-joined
-   clause, split it. The audit script flags this indirectly via the
-   Flesch-Kincaid grade.
-2. **Plain words over clever words.** Prefer "uses" to "leverages", "checks"
-   to "validates", "sends" to "dispatches". Project nouns (`Drizzle`,
-   `Temporal`, `Fastify`, `Argon2id`) are not optional — keep them.
-3. **Active voice, present tense.** "The module creates tables with the
-   `auth_` prefix." Not "Tables will be created…".
-4. **No marketing adjectives.** Drop "powerful", "robust", "seamless",
-   "battle-tested". State what the package does, not how it feels.
-5. **No "we" / "you" unless instructing.** Setup and Usage sections may say
-   "Add scripts to your `package.json`". The rest reads as description, not
-   conversation.
-6. **No emoji, no badges, no ASCII art** in package READMEs. The repo-root
-   README is the only place those decisions get made.
-
-## Readability check
-
-After writing or editing a README, run the audit script:
-
-```sh
-node .claude/skills/readme-writer/scripts/readability.mjs <path-to-README.md>
-```
-
-It reports two numbers:
-
-- **Flesch-Kincaid grade** — target `<= 9`. The script is the same formula
-  US schools use to grade textbook reading level. Higher numbers mean longer
-  sentences or longer words. A README that scores 12+ almost always has one
-  sentence trying to say three things; split it.
-- **Top-1000 vocabulary coverage** — target `>= 60%`. The list in
-  `scripts/top1000.txt` is the same one shipped by the upstream readability
-  skill and is the practical floor of English an ESL reader is fluent in. The
-  script lists the most frequent words *outside* the top-1000 so you can scan
-  for unnecessary vocabulary. Project identifiers (`Shipfox`, `Drizzle`,
-  `Fastify`, `outbox`, `temporal`) will always show up here — that's fine.
-  What you're hunting is words like "leverages", "utilize", "facilitate",
-  "subsequent". Replace each one with a simpler word.
-
-The script strips fenced code blocks and inline backticks before scoring, so
-code examples and `npm` package names don't drag the numbers around. It exits
-non-zero when either threshold misses — useful if a future CI wants to gate
-on it, but for now treat the output as guidance.
-
-If a section legitimately needs a high-vocabulary word ("idempotent",
-"deterministic"), keep it. The goal is not to dumb the docs down; it is to
-remove vocabulary that adds nothing.
+Do not document symbols that the package does not export or ship.
 
 ## Workflow
 
-1. Read `package.json` and the public entry point.
-2. Sketch the section list from the "Required structure" above, dropping the
-   ones that don't apply.
-3. Draft each section, top to bottom. Stop after writing one Usage snippet.
-4. Run the readability script. Fix sentences flagged by the grade signal
-   first, then trim words flagged by the coverage signal.
-5. Re-read the file once end-to-end as if you were the user opening it from
-   `pnpm view` for the first time. Cut anything you skipped.
+1. Apply the package README standard, including only the sections that fit the
+   package.
+2. Use the inspected public contract for the package description, setup, and
+   runnable usage example. Link to schemas or configuration sources instead of
+   copying fast-changing values.
+3. Check nearby package READMEs only for local conventions or comparable
+   examples. They do not override the shared standard.
+4. Run the repository readability check:
 
-## Reference READMEs
+```sh
+node .agents/skills/readme-writer/scripts/readability.mjs <path-to-README.md>
+```
 
-When in doubt, copy the shape of an existing one:
+5. Apply the guidance in `WRITING.md` to improve the result, then reread the
+   README as a package consumer.
 
-- **Minimal library** — `libs/shared/node/outbox/README.md`
-- **Library with module declaration** — `libs/shared/node/module/README.md`
-- **Library with env config + bin scripts** — `libs/shared/node/postgres/README.md`
-- **API feature module with routes + data model** — `libs/api/auth/README.md`
-- **UI component library** — `libs/shared/react/ui/README.md`
-- **CLI tooling package** — `tools/biome/README.md`, `tools/typescript/README.md`
-
-If a new package doesn't match any of these, it probably wants the
-`libs/shared/node/outbox/README.md` skeleton.
-
-## Anti-patterns to refuse
-
-- Long preamble paragraphs before the first `## What it does` heading.
-- Marketing taglines under the title.
-- Documenting unexported internals.
-- Inventing API surface that doesn't exist in `exports`.
-- Adding a "Contributing" section — that belongs in the root `CONTRIBUTING.md`.
-- Duplicating environment defaults instead of reading them from the schema.
-- Replacing the Development block with a custom command set when `turbo check
-  / type / test --filter=` would do.
+Report the public sources inspected, the sections included, and the readability
+result.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,27 @@ surface and make sure the change is scoped to the contribution. The
 owns task selection, affected-package validation, local-service recovery,
 Conductor and Ollama recovery, Changesets, and package release procedures.
 
+## Prepare a change for review
+
+Use a focused feature branch. Do not commit or push directly to `main`. Name
+the branch after the change. Include the lowercase Linear issue key when the
+work has one.
+
+Keep each commit independently reviewable. Use an imperative subject of about
+70 characters or fewer. Do not end it with a period or add a co-author trailer.
+Add a body when readers need the motivation or the previous behavior. Add a
+footer such as `Refs ENG-123` when the commit needs an issue reference.
+
+Write a pull request title that explains the change at a business level. Prefix
+it with the package name in square brackets when one package owns the change.
+In the description, explain the change and its motivation. Include alternatives
+or review concerns when they matter. Do not add a test-plan checklist or repeat
+the diff.
+
+When a pull request completes its Linear issue, use `Closes`, `Fixes`, or
+`Resolves` with the issue key. Use `Refs`, `Part of`, or `Related to` only when
+the work is partial. Keep each pull request focused on one feature or fix.
+
 ## Find the context for your task
 
 Read the linked source before making the matching change. For a task not listed

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ listed there or when you need to place, update, or review documentation.
 | Read when the task... | Canonical source | It owns |
 | --- | --- | --- |
 | Needs the product overview or a starting point outside engineering work. | [Root README](../README.md) | Product orientation and repository navigation. |
-| Starts a human contribution or needs the normal local workflow. | [Contributing guide](../CONTRIBUTING.md) | Prerequisites, initial setup, contribution workflow, and essential validation. |
+| Starts a human contribution or needs branch, commit, or pull-request guidance. | [Contributing guide](../CONTRIBUTING.md) | Prerequisites, initial setup, contribution workflow, review standards, and essential validation. |
 | Needs local-task selection, service recovery, or package release procedures. | [Local development and release workflow](guides/local-development-and-release-workflow.md) | Mise, local services, Ollama, affected-package validation, Changesets, and publishing. |
 | Changes agent behavior or needs agent execution instructions. | [Agent instructions](../AGENTS.md) | Repository-specific agent execution, change hygiene, and conditional context loading. |
 | Adds, updates, or exempts a dependency. | [Dependency version policy](policies/dependency-versions.md) | Version ranges, exceptions, coordinated package families, and dependency checks. |

--- a/docs/guides/local-development-and-release-workflow.md
+++ b/docs/guides/local-development-and-release-workflow.md
@@ -113,6 +113,9 @@ Choose `patch` for fixes and internal refactors, `minor` for additive public
 API, and `major` for breaking public API. Commit the `.changeset/*.md` file
 with the change.
 
+Write one concise present-tense summary for each logical change. Keep unrelated
+release changes in separate Changesets.
+
 `update-release-pr` runs on `main` and opens or updates the generated release
 pull request only when unreleased changesets exist. Its cancelable concurrency
 means a newer `main` push supersedes an older pending update; it has no npm


### PR DESCRIPTION
Aligns repository agent skills with the shared documentation model.

The skills now load the canonical package README, release, and contributor guidance before acting. Human-facing commit, pull-request, and Changeset rules now live in normal repository documentation, while skills retain only agent sequencing and command behavior.

Closes ENG-1162

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns agent skills with the shared documentation model so human rules live in docs and skills focus on automation. Skills now load the contributor review standard, package README guidance, and release workflow before acting (ENG-1162).

- **Refactors**
  - Commit, PR, and Changeset skills now defer to the contributor review standard and the local development/release workflow; they keep only agent sequencing, scoped validation, and required commands (PRs use `gh`).
  - `generate-changeset` creates non‑interactive Changeset files using shared rules for eligibility, package selection, bump levels, and summaries; prompts before `major` changes and excludes private packages.
  - `readme-writer` applies the shared package README standard; readability script path is now `./.agents/skills/readme-writer/scripts/readability.mjs`.
  - Docs: CONTRIBUTING adds “Prepare a change for review” (branch naming, commit subjects, PR titles/descriptions, Linear keywords); docs map points to review guidance; release workflow clarifies concise, present‑tense Changeset summaries and one Changeset per logical change.

- **Migration**
  - No workflow changes for contributors; agents load canonical docs automatically.
  - If you run the readability check manually, use the new script path above.

<sup>Written for commit f4d1479266b5ec0f848b2b3c595db58697a812c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

