### PR TITLE
Establish Biome client architecture plugin foundation

### DIFF
--- a/.changeset/calm-biome-verify.md
+++ b/.changeset/calm-biome-verify.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/biome": patch
+---
+
+Adds the client-architecture Biome plugin fixture harness and configurable check path for scoped validation.

--- a/biome.json
+++ b/biome.json
@@ -11,8 +11,34 @@
   "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
   "files": {
     "ignoreUnknown": false,
-    "includes": ["**", "!libs/client/shell/test/external/fixture/**"]
+    "includes": [
+      "**",
+      "!libs/client/shell/test/external/fixture",
+      "!tools/biome/plugins/client-architecture/fixtures"
+    ]
   },
+  "plugins": [
+    {
+      "path": "./tools/biome/plugins/client-architecture/fixture-boundary.grit",
+      "includes": [
+        "libs/client/**",
+        "libs/shared/react/ui/**",
+        "!**/dist/**",
+        "!**/node_modules/**",
+        "!**/*.test.ts",
+        "!**/*.test.tsx",
+        "!**/*.stories.ts",
+        "!**/*.stories.tsx",
+        "!**/test/**",
+        "!**/tests/**",
+        "!**/__tests__/**",
+        "!**/generated/**",
+        "!**/__generated__/**",
+        "!**/*.gen.ts",
+        "!**/*.gen.tsx"
+      ]
+    }
+  ],
   "formatter": {
     "enabled": true,
     "useEditorconfig": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7580,6 +7580,9 @@ importers:
       '@shipfox/typescript':
         specifier: workspace:*
         version: link:../typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../vitest
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.2

--- a/tools/biome/README.md
+++ b/tools/biome/README.md
@@ -1,15 +1,17 @@
 # @shipfox/biome
 
-Opinionated wrapper around Biome for formatting and linting across Shipfox repos. Ships platform-specific binaries and a unified CLI. It should be used with other packages from [Shipfox](https://www.shipfox.io/).
+Biome commands and bundled binaries for Shipfox packages.
 
 ## What it does
 
-- **`shipfox-biome-lint`**: Lint the current package using the workspace-level `biome.json`.
-- **`shipfox-biome-format`**: Format files using the workspace-level `biome.json`.
-- **`shipfox-biome-check`**: Run Biome check with assist rules enabled. This is the command most package `check` scripts use.
-- Cross-platform support via bundled Biome binaries (Darwin ARM64/x64, Linux ARM64/x64).
+- **`shipfox-biome-lint`**: Checks the current package with the root `biome.json`.
+- **`shipfox-biome-format`**: Formats files with the root `biome.json`.
+- **`shipfox-biome-check`**: Runs format, lint, and assist checks. Most package `check` scripts use it.
+- **Bundled binaries**: Includes Biome for macOS and Linux on ARM64 and x64.
 
 ## Installation
+
+Install the package as a development tool.
 
 ```bash
 pnpm add -D @shipfox/biome
@@ -17,7 +19,7 @@ pnpm add -D @shipfox/biome
 
 ## Usage
 
-Add scripts to your `package.json`:
+Add these scripts to `package.json`:
 
 ```json
 {
@@ -43,6 +45,9 @@ shipfox-biome-lint --fix
 shipfox-biome-check
 shipfox-biome-check --write
 
+# Check a focused fixture tree with an explicit config
+shipfox-biome-check --config-path path/to/biome.fixture.json path/to/fixtures/
+
 # Format
 shipfox-biome-format
 shipfox-biome-format --write
@@ -50,3 +55,23 @@ shipfox-biome-format --write
 # Format specific targets
 shipfox-biome-format --write src/ test/
 ```
+
+## Behavior Notes
+
+Package checks use the root `biome.json`. Pass `--config-path` only for a
+focused config, such as a fixture tree. The normal form reads files. The write
+form can change them. Check the result before you send a change for review.
+
+## Development
+
+Build and test the package and its fixture harness with:
+
+```sh
+turbo build --filter=@shipfox/biome
+turbo type --filter=@shipfox/biome
+turbo test --filter=@shipfox/biome
+```
+
+## License
+
+MIT

--- a/tools/biome/package.json
+++ b/tools/biome/package.json
@@ -19,6 +19,7 @@
   },
   "scripts": {
     "build": "shipfox-swc",
+    "test": "shipfox-vitest-run",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"
   },
@@ -34,6 +35,7 @@
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*",
     "@types/node": "catalog:"
   }
 }

--- a/tools/biome/plugins/client-architecture/README.md
+++ b/tools/biome/plugins/client-architecture/README.md
@@ -1,0 +1,37 @@
+# Client-architecture Biome plugins
+
+This directory holds Biome GritQL rules for client source. The root
+[`biome.json`](../../../../biome.json) loads each rule for production files in
+`libs/client/**` and `libs/shared/react/ui/**`.
+
+Each rule should be small. It should show a clear error at the code that needs
+the change. Keep each example short so the expected result is easy to see.
+
+## Rules
+
+- Give each rule a kebab-case name, such as `no-raw-api-request.grit`. Its rule
+  id is `client-architecture/<name>`.
+- Add `allowed.ts` and `rejected.ts` under `fixtures/<name>/` for each rule.
+  Cover aliases, namespace imports, and type-only imports when they apply.
+- Keep fixtures out of normal package checks. The fixture config includes them
+  and skips tests, stories, and generated files.
+- Put the rule id and the approved replacement boundary in each diagnostic.
+  Do not fix a client-architecture error with `biome-ignore`.
+- Keep rules local and based on source shape. Put cross-file checks, ownership
+  data, runtime flow, and behavior tests in
+  `@shipfox/client-architecture-policy` or a focused test.
+
+`fixture-boundary.grit` is the smoke rule for this foundation. Its sentinel is
+not a migrated production rule. Later issues add real rules beside it.
+
+## Fixture harness
+
+Run the focused harness with:
+
+```sh
+pnpm --filter=@shipfox/biome test
+```
+
+The harness uses the same `shipfox-biome-check` wrapper as package checks. It
+opts into `biome.fixture.json` for the fixture tree. It checks the rule id,
+replacement text, source location, and pass/fail result.

--- a/tools/biome/plugins/client-architecture/fixture-boundary.grit
+++ b/tools/biome/plugins/client-architecture/fixture-boundary.grit
@@ -1,0 +1,5 @@
+language js(typescript, jsx)
+
+`clientArchitectureFixtureViolation()` as $call where {
+  register_diagnostic(span=$call, message="client-architecture/fixture-boundary: replace this unapproved boundary with the approved feature-owned adapter or coordinator boundary.")
+}

--- a/tools/biome/plugins/client-architecture/fixtures/biome.fixture.json
+++ b/tools/biome/plugins/client-architecture/fixtures/biome.fixture.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+  "vcs": {
+    "enabled": false
+  },
+  "assist": {
+    "enabled": true
+  },
+  "formatter": {
+    "enabled": true,
+    "useEditorconfig": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineEnding": "lf",
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "plugins": [
+    {
+      "path": "../fixture-boundary.grit",
+      "includes": [
+        "**/*.ts",
+        "!**/*.test.ts",
+        "!**/*.stories.ts",
+        "!**/test/**",
+        "!**/tests/**",
+        "!**/__tests__/**",
+        "!**/generated/**",
+        "!**/__generated__/**",
+        "!**/*.gen.ts"
+      ]
+    }
+  ],
+  "files": {
+    "includes": [
+      "**/*.ts",
+      "!**/*.test.ts",
+      "!**/*.stories.ts",
+      "!**/test/**",
+      "!**/tests/**",
+      "!**/__tests__/**",
+      "!**/generated/**",
+      "!**/__generated__/**",
+      "!**/*.gen.ts"
+    ]
+  }
+}

--- a/tools/biome/plugins/client-architecture/fixtures/fixture-boundary/allowed.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/fixture-boundary/allowed.ts
@@ -1,0 +1,3 @@
+function approvedFeatureBoundary(): void {}
+
+approvedFeatureBoundary();

--- a/tools/biome/plugins/client-architecture/fixtures/fixture-boundary/generated/rejected.gen.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/fixture-boundary/generated/rejected.gen.ts
@@ -1,0 +1,3 @@
+function clientArchitectureFixtureViolation(): void {}
+
+clientArchitectureFixtureViolation();

--- a/tools/biome/plugins/client-architecture/fixtures/fixture-boundary/ignored.test.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/fixture-boundary/ignored.test.ts
@@ -1,0 +1,3 @@
+function clientArchitectureFixtureViolation(): void {}
+
+clientArchitectureFixtureViolation();

--- a/tools/biome/plugins/client-architecture/fixtures/fixture-boundary/rejected.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/fixture-boundary/rejected.ts
@@ -1,0 +1,3 @@
+function clientArchitectureFixtureViolation(): void {}
+
+clientArchitectureFixtureViolation();

--- a/tools/biome/src/biome-check.ts
+++ b/tools/biome/src/biome-check.ts
@@ -4,13 +4,30 @@ import {execSync} from 'node:child_process';
 import {buildShellCommand, getProjectBinaryPath, getWorkspaceFilePath} from '@shipfox/tool-utils';
 
 const binPath = getProjectBinaryPath('biome', import.meta.url);
-const biomeConfigFile = getWorkspaceFilePath('biome.json');
+let biomeConfigFile = getWorkspaceFilePath('biome.json');
 
 const extraArgs: string[] = [];
+const positionalArgs: string[] = [];
 
-if (process.argv.includes('--write') || process.argv.includes('--fix')) extraArgs.push('--write');
+for (let index = 2; index < process.argv.length; index += 1) {
+  const argument = process.argv[index];
+  if (argument === '--write' || argument === '--fix') {
+    extraArgs.push('--write');
+  } else if (argument === '--config-path') {
+    const configPath = process.argv[index + 1];
+    if (!configPath || configPath.startsWith('--'))
+      throw new Error('--config-path requires a path to a Biome configuration file');
+    biomeConfigFile = configPath;
+    index += 1;
+  } else if (argument?.startsWith('--config-path=')) {
+    biomeConfigFile = argument.slice('--config-path='.length);
+  } else if (argument?.startsWith('--')) {
+    extraArgs.push(argument);
+  } else if (argument) {
+    positionalArgs.push(argument);
+  }
+}
 
-const positionalArgs = process.argv.slice(2).filter((arg) => !arg.startsWith('--'));
 const targets = positionalArgs.length > 0 ? positionalArgs : [process.cwd()];
 
 const command = buildShellCommand([

--- a/tools/biome/test/client-architecture-plugins.test.ts
+++ b/tools/biome/test/client-architecture-plugins.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import {execFile} from 'node:child_process';
+import {dirname, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {promisify} from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const packageDirectory = dirname(fileURLToPath(import.meta.url));
+const workspaceRoot = resolve(packageDirectory, '../../..');
+const biomeCheck = resolve(workspaceRoot, 'tools/biome/bin/biome-check.js');
+const fixtureConfig = resolve(
+  workspaceRoot,
+  'tools/biome/plugins/client-architecture/fixtures/biome.fixture.json',
+);
+const fixtureRoot = resolve(
+  workspaceRoot,
+  'tools/biome/plugins/client-architecture/fixtures/fixture-boundary',
+);
+const diagnosticRulePattern = /client-architecture\/fixture-boundary/u;
+const replacementBoundaryPattern = /approved feature-owned adapter or coordinator boundary/u;
+const rejectedLocationPattern = /rejected\.ts:3/u;
+const testFixturePattern = /ignored\.test\.ts/u;
+const generatedFixturePattern = /rejected\.gen\.ts/u;
+
+describe('client-architecture Biome plugins', () => {
+  test('fails a rejected fixture through the package check wrapper', async () => {
+    await assert.rejects(
+      execFileAsync(process.execPath, [biomeCheck, '--config-path', fixtureConfig, fixtureRoot], {
+        cwd: workspaceRoot,
+      }),
+      (error: unknown) => {
+        const commandError = error as {stdout?: string; stderr?: string};
+        const output = `${commandError.stdout ?? ''}${commandError.stderr ?? ''}`;
+        assert.match(output, diagnosticRulePattern);
+        assert.match(output, replacementBoundaryPattern);
+        assert.match(output, rejectedLocationPattern);
+        assert.doesNotMatch(output, testFixturePattern);
+        assert.doesNotMatch(output, generatedFixturePattern);
+        return true;
+      },
+    );
+  });
+
+  test('passes an allowed fixture through the package check wrapper', async () => {
+    const {stdout, stderr} = await execFileAsync(
+      process.execPath,
+      [biomeCheck, '--config-path', fixtureConfig, resolve(fixtureRoot, 'allowed.ts')],
+      {cwd: workspaceRoot},
+    );
+
+    assert.doesNotMatch(`${stdout}${stderr}`, diagnosticRulePattern);
+  });
+});

--- a/tools/biome/tsconfig.test.json
+++ b/tools/biome/tsconfig.test.json
@@ -3,6 +3,12 @@
   "compilerOptions": {
     "rootDir": "."
   },
-  "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "include": [
+    "src",
+    "test",
+    "plugins/**/*.test.ts",
+    "vitest.config.ts",
+    "node_modules/@shipfox/vitest/globals.d.ts"
+  ],
   "exclude": []
 }

--- a/tools/biome/vitest.config.ts
+++ b/tools/biome/vitest.config.ts
@@ -1,0 +1,10 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig(
+  {
+    test: {
+      include: ['test/**/*.test.ts'],
+    },
+  },
+  import.meta.url,
+) as UserConfigExport;


### PR DESCRIPTION
Establishes the repository-owned Biome GritQL foundation for client-architecture enforcement.

The client architecture workstream needs local source-shape diagnostics to run in every package check, while cross-file and runtime guarantees remain in the semantic verifier. This adds scoped production registration, an allowed/rejected fixture harness, and `--config-path` support so fixture validation uses the same wrapper as package checks without migrating existing regex rules.

The rule and fixture conventions document naming, required pairs, suppression policy, and when a rule belongs in the semantic verifier.

Closes ENG-1181

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets up a repository-owned Biome GritQL plugin foundation for client architecture. Scoped plugin loading, a focused fixture harness, and `--config-path` in `shipfox-biome-check` make rules run the same in local checks and CI (ENG-1181).

- **New Features**
  - Register client-architecture plugins in root `biome.json` for `libs/client/**` and `libs/shared/react/ui/**`, excluding tests, stories, and generated code.
  - Add a fixture harness with `biome.fixture.json` and allowed/rejected fixtures; verifies rule id, message, and location through the same `shipfox-biome-check` wrapper via `--config-path`.
  - Introduce a smoke rule `fixture-boundary.grit` to validate the setup.
  - Enhance `shipfox-biome-check` to accept `--config-path`, forward extra flags, and target paths; defaults to the root config.
  - Document rule conventions: naming, required allowed/rejected pairs, suppression policy, and when a rule belongs in the semantic verifier.
  - Add tests to confirm rejected fixtures fail and allowed fixtures pass.

- **Dependencies**
  - Add `@shipfox/vitest` for running the fixture tests.

<sup>Written for commit 51f034bf1ec0bb170503f5633ea1d9e5ee91304d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/974?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

