### PR TITLE
Protect repository documentation navigation and discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ then a `gate` reruns the tests and sends the agent back until they pass.
 |---|---|
 | **Workflow** | A YAML file under `.shipfox/workflows/`, versioned and reviewed like code. One file, one workflow. |
 | **Trigger** | What starts a run: an event from a connected integration, or an on-demand fire. |
-| **Integration** | A connection to an external tool (GitHub, Sentry, Slack, Linear, ...) whose events start runs. Use the [generic webhook](apps/docs/content/docs/integrations/webhooks.mdx) to connect anything not built in. |
+| **Integration** | A connection to an external tool (GitHub, Sentry, Slack, Linear, ...) whose events start runs. Use the [generic webhook](apps/docs/content/docs/integrations/webhooks/index.mdx) to connect anything not built in. |
 | **Job** | A group of steps on one runner. Jobs form a DAG via `needs` and are isolated, so each re-clones the repo. |
 | **Step** | A `run` shell command or an agent (`model` + `prompt`, on the `pi` or `claude` harness). Runs in order within a job. |
 | **Gate** | A pass/fail [check on a step](apps/docs/content/docs/understand/feedback-loops.mdx) that retries from an earlier step when it fails. Bounded retry loops, no scripting. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,8 @@ listed there or when you need to place, update, or review documentation.
 | Needs the product overview or a starting point outside engineering work. | [Root README](../README.md) | Product orientation and repository navigation. |
 | Starts a human contribution or needs branch, commit, or pull-request guidance. | [Contributing guide](../CONTRIBUTING.md) | Prerequisites, initial setup, contribution workflow, review standards, and essential validation. |
 | Needs local-task selection, service recovery, or package release procedures. | [Local development and release workflow](guides/local-development-and-release-workflow.md) | Mise, local services, Ollama, affected-package validation, Changesets, and publishing. |
+| Needs the generated release-PR CI verification path. | [Generated release PR CI](guides/release-pr-ci.md) | The fast-path conditions and fail-closed verification behavior for Changesets release PRs. |
+| Needs to configure or review Vercel release-PR previews. | [Vercel release PR previews](vercel-preview-release-prs.md) | The repository-owned Vercel branch configuration and verification workflow. |
 | Changes agent behavior or needs agent execution instructions. | [Agent instructions](../AGENTS.md) | Repository-specific agent execution, change hygiene, and conditional context loading. |
 | Adds, updates, or exempts a dependency. | [Dependency version policy](policies/dependency-versions.md) | Version ranges, exceptions, coordinated package families, and dependency checks. |
 | Changes a cross-package client composition seam. | [ADR 0001](adr/0001-client-composition-contract.md) | The public client composition contract and its decision rationale. |
@@ -25,6 +27,7 @@ listed there or when you need to place, update, or review documentation.
 | Changes client state, API adapters, forms, or feature-domain boundaries. | [Client architecture](architecture/client-architecture.md) | The current client feature model, form rules, and architecture enforcement. |
 | Introduces a shared package or changes a server dependency boundary. | [ADR 0004](adr/0004-shared-semantic-packages-and-server-dependency-boundaries.md) | Shared semantic package rules and server package classes. |
 | Changes repository documentation structure or adds a shared documentation surface. | [ADR 0005](adr/0005-repository-documentation-architecture.md) | Documentation ownership, routing, and progressive disclosure. |
+| Validates repository Markdown links, anchors, or documentation reachability. | [Repository documentation policy](../tools/repository-documentation-policy/README.md) | Deterministic link and orphan checks for engineering documentation. |
 | Changes webhook retry behavior. | [Webhook retry safety](architecture/webhook-retry-safety.md) | The current safety model for webhook retries. |
 | Adds or changes unit tests, Storybook stories, or visual regression coverage. | [Testing guide](guides/testing.md) | Unit-test altitude, Storybook conventions, Argos ownership, build names, and review. |
 | Adds or changes end-to-end coverage. | [E2E guide](../e2e/README.md) | Suite levels, HTTP-first setup, screens, and E2E package boundaries. |

--- a/libs/shared/react/ui/README.md
+++ b/libs/shared/react/ui/README.md
@@ -96,7 +96,7 @@ pnpm --filter=@shipfox/react-ui storybook
 ```
 
 For repository-wide story ordering and Argos rules, read the
-[testing guide](../../../docs/guides/testing.md). This package captures stories
+[testing guide](../../../../docs/guides/testing.md). This package captures stories
 in light and dark under `turbo test`.
 
 ## Build

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7720,6 +7720,27 @@ importers:
         specifier: workspace:*
         version: link:../typescript
 
+  tools/repository-documentation-policy:
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../vitest
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.2
+
   tools/swc:
     dependencies:
       '@shipfox/tool-utils':

--- a/tools/repository-documentation-policy/README.md
+++ b/tools/repository-documentation-policy/README.md
@@ -1,0 +1,53 @@
+# Repository documentation policy
+
+## What it does
+
+This private verifier protects the repository engineering-documentation graph.
+It checks relative Markdown targets and headings, then confirms that shared
+documents are reachable from an approved entrypoint or index.
+
+Product pages under `apps/docs/content/` remain owned by the docs app's link
+checker. Changelogs and Changeset files are generated release metadata. Local
+`README.md` files are approved roots because package and subsystem documentation
+is intentionally discoverable beside the code that owns it. Agent skills are
+also explicit roots because they own agent-only workflow behavior while linking
+shared rules back to human-readable repository sources.
+
+## Installation / Setup
+
+The package is part of the workspace. Install the pinned workspace dependencies
+from the repository root:
+
+```sh
+mise exec -- pnpm install
+```
+
+## Usage
+
+Run the verifier through its Turbo task:
+
+```sh
+mise exec -- turbo verify --filter=@shipfox/repository-documentation-policy
+```
+
+The repository-wide `mise exec -- pnpm verify` command includes this package's
+`verify` task. A failure names the source file and line for a broken link or
+anchor. An orphan failure names the file and points to `docs/README.md` or the
+owning local index as the remediation point.
+
+## Development
+
+Read [ADR 0005](../../docs/adr/0005-repository-documentation-architecture.md)
+and the [engineering documentation map](../../docs/README.md) before changing
+the scope or reachability rules. Keep product-documentation validation in
+`apps/docs/scripts/check-links.mjs`.
+
+Run the focused package checks with:
+
+```sh
+mise exec -- turbo check type test verify --filter=@shipfox/repository-documentation-policy
+```
+
+## License
+
+MIT

--- a/tools/repository-documentation-policy/package.json
+++ b/tools/repository-documentation-policy/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@shipfox/repository-documentation-policy",
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "test": "shipfox-vitest-run",
+    "test:watch": "shipfox-vitest-watch",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit",
+    "verify": "node dist/repository-documentation.js"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*",
+    "@types/node": "catalog:"
+  }
+}

--- a/tools/repository-documentation-policy/src/repository-documentation.ts
+++ b/tools/repository-documentation-policy/src/repository-documentation.ts
@@ -1,0 +1,388 @@
+import {readdir, readFile, stat} from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import {fileURLToPath} from 'node:url';
+
+export type DocumentationViolation =
+  | {
+      kind: 'broken-link';
+      source: string;
+      line: number;
+      target: string;
+      reason: string;
+    }
+  | {
+      kind: 'missing-anchor';
+      source: string;
+      line: number;
+      target: string;
+      reason: string;
+    }
+  | {
+      kind: 'orphan';
+      file: string;
+      reason: string;
+    };
+
+export interface DocumentationCheckResult {
+  checkedFiles: string[];
+  violations: DocumentationViolation[];
+}
+
+export interface MarkdownLink {
+  line: number;
+  target: string;
+}
+
+/**
+ * These scope rules keep repository documentation separate from product-doc
+ * validation and generated release output. The paths are intentionally
+ * explicit so adding a new exception requires changing this policy.
+ */
+export const excludedDocumentationPaths = [
+  {path: '.changeset/', reason: 'Changeset files are release metadata.'},
+  {path: '.context/', reason: 'Workspace collaboration files are local state.'},
+  {path: 'apps/docs/WRITING.md', reason: 'The docs app owns its surface-specific writing guide.'},
+  {path: 'apps/docs/content/', reason: 'The docs app owns product documentation links.'},
+  {path: '**/CHANGELOG.md', reason: 'Changelogs are generated release output.'},
+  {
+    path: 'libs/client/shell/test/external/FINDINGS.md',
+    reason: 'External-consumer fixture findings are test artifacts.',
+  },
+] as const;
+
+const repositoryRoot = fileURLToPath(new URL('../../../', import.meta.url));
+const entrypointFiles = new Set([
+  'AGENTS.md',
+  'CLAUDE.md',
+  'CODE_OF_CONDUCT.md',
+  'CONTRIBUTING.md',
+  'DESIGN.md',
+  'README.md',
+  'SECURITY.md',
+  'WRITING.md',
+  'docs/README.md',
+  'docs/adr/README.md',
+]);
+const excludedDirectoryNames = new Set([
+  '.changeset',
+  '.context',
+  '.git',
+  '.next',
+  '.turbo',
+  'dist',
+  'node_modules',
+]);
+const markdownExtension = '.md';
+const markdownLinkPattern = /!?(?:\[[^\]\n]*\])\(([^)\n]+)\)/g;
+const markdownLinkTargetPattern = /^\S+/;
+const externalLinkPattern = /^(?:[a-z][a-z\d+.-]*:|\/\/)/i;
+const atxHeadingPattern = /^ {0,3}#{1,6}\s+(.+?)\s*#*\s*$/;
+const setextHeadingPattern = /^ {0,3}(?:=+|-+)\s*$/;
+const fencePattern = /^\s{0,3}(`{3,}|~{3,})/;
+
+export async function checkRepositoryDocumentation(
+  rootDirectory = repositoryRoot,
+): Promise<DocumentationCheckResult> {
+  const checkedFiles = await collectDocumentationFiles(rootDirectory);
+  const contents = new Map<string, string>(
+    await Promise.all(
+      checkedFiles.map(
+        async (file) => [file, await readFile(path.join(rootDirectory, file), 'utf8')] as const,
+      ),
+    ),
+  );
+  const anchorsByFile = new Map<string, Set<string>>(
+    checkedFiles.map((file) => [file, anchorsFor(contents.get(file) ?? '')] as const),
+  );
+  const checkedFileSet = new Set(checkedFiles);
+  const edges = new Map<string, Set<string>>();
+  const violations: DocumentationViolation[] = [];
+
+  for (const source of checkedFiles) {
+    const content = contents.get(source) ?? '';
+    const sourceEdges = new Set<string>();
+    edges.set(source, sourceEdges);
+
+    for (const link of extractMarkdownLinks(content)) {
+      const parsedTarget = parseTarget(link.target);
+      if (parsedTarget.kind === 'ignored') continue;
+
+      if (parsedTarget.kind === 'invalid') {
+        violations.push({
+          kind: 'broken-link',
+          source,
+          line: link.line,
+          target: link.target,
+          reason: parsedTarget.reason,
+        });
+        continue;
+      }
+
+      const targetFile = parsedTarget.path
+        ? await resolveDocumentationTarget(rootDirectory, source, parsedTarget.path)
+        : source;
+
+      if (!targetFile) {
+        violations.push({
+          kind: 'broken-link',
+          source,
+          line: link.line,
+          target: link.target,
+          reason: 'target does not exist',
+        });
+        continue;
+      }
+
+      if (parsedTarget.anchor && shouldCheckAnchor(targetFile, checkedFileSet)) {
+        const targetAnchors =
+          targetFile === source
+            ? anchorsByFile.get(source)
+            : (anchorsByFile.get(targetFile) ??
+              anchorsFor(await readFile(path.join(rootDirectory, targetFile), 'utf8')));
+        if (!targetAnchors?.has(parsedTarget.anchor)) {
+          violations.push({
+            kind: 'missing-anchor',
+            source,
+            line: link.line,
+            target: link.target,
+            reason: 'target heading does not exist',
+          });
+        }
+      }
+
+      if (checkedFileSet.has(targetFile)) sourceEdges.add(targetFile);
+    }
+  }
+
+  const reachable = reachableFiles(edges, checkedFiles.filter(isApprovedRoot));
+  for (const file of checkedFiles) {
+    if (!reachable.has(file) && !isApprovedRoot(file)) {
+      violations.push({
+        kind: 'orphan',
+        file,
+        reason:
+          'No approved entrypoint or documentation index links to this file. Add a contextual link from docs/README.md or the owning subsystem index.',
+      });
+    }
+  }
+
+  return {checkedFiles, violations};
+}
+
+export async function collectDocumentationFiles(rootDirectory: string): Promise<string[]> {
+  const files = await filesUnder(rootDirectory);
+  return files
+    .filter((file) => isIncludedDocumentationPath(toRepositoryPath(rootDirectory, file)))
+    .map((file) => toRepositoryPath(rootDirectory, file))
+    .sort();
+}
+
+export function extractMarkdownLinks(content: string): MarkdownLink[] {
+  const links: MarkdownLink[] = [];
+  const source = withoutFencedCode(content);
+
+  for (const match of source.matchAll(markdownLinkPattern)) {
+    const rawTarget = match[1]?.trim();
+    if (!rawTarget) continue;
+
+    const target = rawTarget.startsWith('<')
+      ? rawTarget.slice(1, rawTarget.indexOf('>'))
+      : rawTarget.match(markdownLinkTargetPattern)?.[0];
+    if (!target) continue;
+
+    links.push({line: lineNumberAt(source, match.index ?? 0), target});
+  }
+
+  return links;
+}
+
+function isIncludedDocumentationPath(relativePath: string): boolean {
+  if (!relativePath.endsWith(markdownExtension)) return false;
+  return !excludedDocumentationPaths.some(({path: excludedPath}) => {
+    if (excludedPath === '**/CHANGELOG.md')
+      return relativePath.endsWith('/CHANGELOG.md') || relativePath === 'CHANGELOG.md';
+    if (excludedPath.endsWith('/')) return relativePath.startsWith(excludedPath);
+    return relativePath === excludedPath;
+  });
+}
+
+function isApprovedRoot(relativePath: string): boolean {
+  return (
+    entrypointFiles.has(relativePath) ||
+    path.posix.basename(relativePath) === 'README.md' ||
+    relativePath.startsWith('.agents/skills/')
+  );
+}
+
+function parseTarget(
+  target: string,
+):
+  | {kind: 'ignored'}
+  | {kind: 'invalid'; reason: string}
+  | {kind: 'relative'; path: string; anchor: string | null} {
+  if (externalLinkPattern.test(target) || target.startsWith('/')) return {kind: 'ignored'};
+
+  const [rawPath, rawAnchor] = target.split('#', 2);
+  let decodedPath = rawPath ?? '';
+  let decodedAnchor = rawAnchor ?? '';
+  try {
+    decodedPath = decodeURIComponent(decodedPath);
+    decodedAnchor = decodeURIComponent(decodedAnchor);
+  } catch {
+    return {kind: 'invalid', reason: 'target contains invalid percent encoding'};
+  }
+
+  return {
+    kind: 'relative',
+    path: decodedPath,
+    anchor: decodedAnchor ? decodedAnchor.toLowerCase() : null,
+  };
+}
+
+async function resolveDocumentationTarget(
+  rootDirectory: string,
+  source: string,
+  target: string,
+): Promise<string | null> {
+  const sourceDirectory = path.dirname(path.join(rootDirectory, source));
+  const candidate = path.resolve(sourceDirectory, target);
+  const root = path.resolve(rootDirectory);
+  if (candidate !== root && !candidate.startsWith(`${root}${path.sep}`)) return null;
+
+  const candidates = [candidate];
+  if (path.extname(candidate) === '') {
+    candidates.push(`${candidate}.md`, `${candidate}.mdx`, path.join(candidate, 'README.md'));
+  } else if (await isDirectory(candidate)) {
+    candidates.push(path.join(candidate, 'README.md'));
+  }
+
+  for (const possibleTarget of candidates) {
+    if (await isFile(possibleTarget)) return toRepositoryPath(rootDirectory, possibleTarget);
+  }
+  if (await isDirectory(candidate)) return toRepositoryPath(rootDirectory, candidate);
+  return null;
+}
+
+function shouldCheckAnchor(targetFile: string, checkedFiles: Set<string>): boolean {
+  return checkedFiles.has(targetFile) && !targetFile.startsWith('apps/docs/content/');
+}
+
+function reachableFiles(edges: Map<string, Set<string>>, roots: string[]): Set<string> {
+  const reachable = new Set<string>();
+  const pending = [...roots];
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (!current || reachable.has(current)) continue;
+    reachable.add(current);
+    for (const target of edges.get(current) ?? []) pending.push(target);
+  }
+  return reachable;
+}
+
+function anchorsFor(content: string): Set<string> {
+  const anchors = new Set<string>();
+  const usedSlugs = new Map<string, number>();
+  const lines = withoutFencedCode(content).split('\n');
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? '';
+    const atxHeading = line.match(atxHeadingPattern);
+    const setextHeading = !atxHeading && lines[index + 1]?.match(setextHeadingPattern);
+    const heading = atxHeading?.[1] ?? (setextHeading ? line.trim() : null);
+    if (!heading) continue;
+
+    const baseSlug = slugifyHeading(heading);
+    if (!baseSlug) continue;
+    const duplicateCount = usedSlugs.get(baseSlug) ?? 0;
+    usedSlugs.set(baseSlug, duplicateCount + 1);
+    anchors.add(duplicateCount === 0 ? baseSlug : `${baseSlug}-${duplicateCount}`);
+  }
+
+  return anchors;
+}
+
+function slugifyHeading(heading: string): string {
+  return heading
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/<[^>]+>/g, '')
+    .replace(/[\u0060*_~]/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^\p{Letter}\p{Number}\s_-]/gu, '')
+    .replace(/\s+/g, '-');
+}
+
+function withoutFencedCode(content: string): string {
+  const lines = content.split('\n');
+  let inFence = false;
+  return lines
+    .map((line) => {
+      if (fencePattern.test(line)) {
+        inFence = !inFence;
+        return '';
+      }
+      return inFence ? '' : line;
+    })
+    .join('\n');
+}
+
+function lineNumberAt(content: string, index: number): number {
+  return content.slice(0, index).split('\n').length;
+}
+
+async function filesUnder(directory: string): Promise<string[]> {
+  const entries = await readdir(directory, {withFileTypes: true});
+  const files = await Promise.all(
+    entries.map((entry) => {
+      if (entry.isDirectory()) {
+        if (excludedDirectoryNames.has(entry.name)) return [];
+        return filesUnder(path.join(directory, entry.name));
+      }
+      return [path.join(directory, entry.name)];
+    }),
+  );
+  return files.flat();
+}
+
+async function isFile(file: string): Promise<boolean> {
+  try {
+    return (await stat(file)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+async function isDirectory(directory: string): Promise<boolean> {
+  try {
+    return (await stat(directory)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function toRepositoryPath(rootDirectory: string, file: string): string {
+  return path.relative(rootDirectory, file).split(path.sep).join('/');
+}
+
+function formatViolation(violation: DocumentationViolation): string {
+  if (violation.kind === 'orphan') {
+    return `- ${violation.file}: ${violation.reason}`;
+  }
+  return `- ${violation.source}:${violation.line} -> ${violation.target}: ${violation.reason}`;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const result = await checkRepositoryDocumentation();
+  if (result.violations.length > 0) {
+    process.stderr.write(
+      `Repository documentation validation failed:\n${result.violations.map(formatViolation).join('\n')}\n`,
+    );
+    process.exitCode = 1;
+  } else {
+    process.stdout.write(
+      `Repository documentation validation passed (${result.checkedFiles.length} files).\n`,
+    );
+  }
+}

--- a/tools/repository-documentation-policy/test/repository-documentation.test.ts
+++ b/tools/repository-documentation-policy/test/repository-documentation.test.ts
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict';
+import {mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  checkRepositoryDocumentation,
+  collectDocumentationFiles,
+  extractMarkdownLinks,
+} from '../src/repository-documentation.js';
+
+async function fixture(files: Record<string, string>): Promise<string> {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'repository-documentation-policy-'));
+  await Promise.all(
+    Object.entries(files).map(async ([file, content]) => {
+      const filePath = path.join(root, file);
+      await mkdir(path.dirname(filePath), {recursive: true});
+      await writeFile(filePath, content);
+    }),
+  );
+  return root;
+}
+
+describe('repository documentation policy', () => {
+  test('extracts links with line numbers and ignores fenced examples', () => {
+    assert.deepEqual(
+      extractMarkdownLinks(
+        '# Guide\n\nRead [the map](docs/README.md).\n\n```md\n[example](missing.md)\n```',
+      ),
+      [{line: 3, target: 'docs/README.md'}],
+    );
+  });
+
+  test('accepts local README roots and ADRs reachable through their index', async () => {
+    const root = await fixture({
+      'README.md': '[Guide](docs/guides/guide.md#guide)\n[Package](libs/example/README.md)',
+      'docs/README.md': '[ADR index](adr/README.md)',
+      'docs/adr/README.md': '[ADR](0001-example.md)',
+      'docs/adr/0001-example.md': '# Example decision',
+      'docs/guides/guide.md': '# Guide',
+      'libs/example/README.md': '# Package',
+    });
+    try {
+      const result = await checkRepositoryDocumentation(root);
+      assert.deepEqual(result.violations, []);
+    } finally {
+      await rm(root, {recursive: true});
+    }
+  });
+
+  test('reports a broken link and missing anchor with source locations', async () => {
+    const root = await fixture({
+      'README.md': '[Missing](docs/missing.md)\n[Guide](docs/guide.md#unknown)',
+      'docs/guide.md': '# Guide',
+    });
+    try {
+      const result = await checkRepositoryDocumentation(root);
+      assert.deepEqual(result.violations, [
+        {
+          kind: 'broken-link',
+          source: 'README.md',
+          line: 1,
+          target: 'docs/missing.md',
+          reason: 'target does not exist',
+        },
+        {
+          kind: 'missing-anchor',
+          source: 'README.md',
+          line: 2,
+          target: 'docs/guide.md#unknown',
+          reason: 'target heading does not exist',
+        },
+      ]);
+    } finally {
+      await rm(root, {recursive: true});
+    }
+  });
+
+  test('reports an orphan with a remediation hint', async () => {
+    const root = await fixture({
+      'README.md': '# Repository',
+      'docs/README.md': '# Map',
+      'docs/guides/orphan.md': '# Orphan',
+    });
+    try {
+      const result = await checkRepositoryDocumentation(root);
+      assert.deepEqual(result.violations, [
+        {
+          kind: 'orphan',
+          file: 'docs/guides/orphan.md',
+          reason:
+            'No approved entrypoint or documentation index links to this file. Add a contextual link from docs/README.md or the owning subsystem index.',
+        },
+      ]);
+    } finally {
+      await rm(root, {recursive: true});
+    }
+  });
+
+  test('keeps product docs, changelogs, and changesets outside this check', async () => {
+    const root = await fixture({
+      'README.md': '# Repository',
+      'apps/docs/content/docs/page.mdx': '[missing](nowhere.mdx)',
+      'apps/docs/WRITING.md': '[missing](nowhere.md)',
+      'libs/example/CHANGELOG.md': '[missing](nowhere.md)',
+      '.changeset/example.md': '[missing](nowhere.md)',
+    });
+    try {
+      assert.deepEqual(await collectDocumentationFiles(root), ['README.md']);
+      assert.deepEqual((await checkRepositoryDocumentation(root)).violations, []);
+    } finally {
+      await rm(root, {recursive: true});
+    }
+  });
+});

--- a/tools/repository-documentation-policy/tsconfig.build.json
+++ b/tools/repository-documentation-policy/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/tools/repository-documentation-policy/tsconfig.json
+++ b/tools/repository-documentation-policy/tsconfig.json
@@ -1,0 +1,1 @@
+{ "files": [], "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.test.json" }] }

--- a/tools/repository-documentation-policy/tsconfig.test.json
+++ b/tools/repository-documentation-policy/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "exclude": []
+}

--- a/tools/repository-documentation-policy/turbo.json
+++ b/tools/repository-documentation-policy/turbo.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "verify": {
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/{AGENTS.md,CLAUDE.md,CODE_OF_CONDUCT.md,CONTRIBUTING.md,DESIGN.md,README.md,SECURITY.md,WRITING.md}",
+        "$TURBO_ROOT$/.agents/**/*.md",
+        "$TURBO_ROOT$/docs/**/*.md",
+        "$TURBO_ROOT$/{apps,dev,e2e,infra,libs,tools}/**/*.md"
+      ]
+    }
+  }
+}

--- a/tools/repository-documentation-policy/vitest.config.ts
+++ b/tools/repository-documentation-policy/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({}, import.meta.url) as UserConfigExport;


### PR DESCRIPTION
Add deterministic validation for the repository engineering-documentation graph.

The new private `@shipfox/repository-documentation-policy` package runs through Turbo `verify`, checks relative Markdown targets and headings, and reports engineering documents that are unreachable from approved entrypoints or indexes. Its scope rules keep product-documentation validation in the docs app, while treating local READMEs and agent skills as intentional local roots and excluding generated release metadata.

This also repairs stale repository links and indexes two existing engineering guides so the repository passes its own new validation.

Closes ENG-1163

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a repository-wide documentation policy that validates Markdown links, anchors, and reachability for engineering docs. Runs in `turbo verify`, excludes product docs and generated files, and updates a few links and indexes so the repo passes (ENG-1163).

- New Features
  - Added private `@shipfox/repository-documentation-policy` with link, anchor, and orphan checks.
  - Approved roots: repo and docs indexes, local `README.md`, and `.agents/skills/`; excludes `apps/docs/content/`, changelogs, and `.changeset/`.
  - Integrated with Turbo `verify` and added unit tests; failures include file and line numbers.

- Bug Fixes
  - Fixed root README webhook link to `index.mdx`.
  - Fixed `@shipfox/react-ui` testing guide path.
  - Indexed release PR CI and Vercel preview guides, and added the repository documentation policy to `docs/README.md`.

<sup>Written for commit 405caf272d5edf43575edb4eca8deb82d410892d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

