### PR TITLE
Make PR agents close completed Linear tickets

### DIFF
--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -30,8 +30,18 @@ It owns when a Changeset is required and how releases are published.
    `generate-changeset` skill or use `pnpm exec changeset` interactively, then
    commit it before opening the pull request.
 4. Use the contributor standard to prepare the title, description, and Linear
-   reference. If it is unclear whether the change fully resolves an issue, ask
-   before choosing a closing keyword.
+   reference. Inspect the source issue and compare its requested scope with the
+   branch diff before choosing the keyword:
+   - Use `Closes ENG-123` when the task implements that issue and no requested
+     work remains. This is the default when the branch covers the full scope.
+   - Use `Refs ENG-123`, `Part of ENG-123`, or `Related to ENG-123` only when the
+     issue is an umbrella item, the pull request is an explicit partial step, or
+     a named requirement remains for another pull request. State the remaining
+     work in the description.
+   - Optional follow-up improvements do not make the work partial. Neither do a
+     draft pull request, a narrow implementation, or a `Refs` commit footer.
+   Ask only when the issue and diff contain conflicting evidence that cannot be
+   resolved by inspection.
 5. Push the branch when needed with `git push -u origin HEAD`, then create the
    pull request:
 
@@ -43,6 +53,10 @@ EOF
 ```
 
 Pass `--draft` when the user request, task context, or arguments require it.
+
+Before submission, inspect the final body. A pull request that completes a
+Linear issue must contain a closing line such as `Closes ENG-123`. This lets the
+Linear integration apply its merge automation.
 
 ## Edit an existing pull request
 


### PR DESCRIPTION
Make the PR workflow treat a fully implemented Linear issue as closing work by default.

The previous guidance only told agents to ask when issue completion was unclear. That encouraged conservative `Refs` references even when the branch covered the whole ticket, which linked the pull request without applying Linear's merge automation.

The workflow now compares the source issue with the branch diff, reserves non-closing references for explicit partial work, and checks completed-issue pull request bodies for a closing keyword before submission.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default PRs to close completed Linear issues by using a closing keyword and verifying it in the body. Clarifies when to use `Closes` vs `Refs` so Linear merge automation runs reliably.

- **Refactors**
  - Compare the Linear issue scope with the branch diff before choosing a keyword.
  - Default to `Closes ENG-123` when the branch covers the full scope; use `Refs/Part of/Related to` only for explicit partials and state remaining work.
  - Require a closing line in completed-issue PR bodies before submission to trigger Linear automation.

<sup>Written for commit 9d13454c1757d8b3e00e21f019eb8a6f059832eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

