### PR TITLE
[storybook] Add composed Storybook preview shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,9 @@ dist
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 
+# Storybook static build output
+storybook-static/
+
 # Turbo cache
 .turbo
 

--- a/apps/storybook/.gitignore
+++ b/apps/storybook/.gitignore
@@ -1,0 +1,1 @@
+storybook-static/

--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -1,0 +1,34 @@
+import {dirname, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import type {StorybookConfig} from '@storybook/react-vite';
+import {storybookRefs, storybooks} from '../preview-manifest.js';
+
+const configDir = dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = resolve(configDir, '../../..');
+
+const config: StorybookConfig = {
+  framework: '@storybook/react-vite',
+  stories: ['../src/**/*.mdx'],
+  addons: ['@storybook/addon-docs'],
+  refs: storybookRefs,
+  staticDirs: storybooks.map(({source, path}) => ({
+    from: resolve(repositoryRoot, source),
+    to: path,
+  })),
+  core: {
+    disableTelemetry: true,
+  },
+  viteFinal: async (viteConfig) => {
+    const [{default: react}, {default: tailwindcss}] = await Promise.all([
+      import('@vitejs/plugin-react'),
+      import('@tailwindcss/vite'),
+    ]);
+
+    viteConfig.plugins = viteConfig.plugins ?? [];
+    viteConfig.plugins.push(react(), tailwindcss());
+
+    return viteConfig;
+  },
+};
+
+export default config;

--- a/apps/storybook/.storybook/preview.css
+++ b/apps/storybook/.storybook/preview.css
@@ -1,0 +1,115 @@
+body {
+  margin: 0;
+  background: var(--background-neutral-background);
+  color: var(--foreground-neutral-base);
+  font-family: var(--font-display);
+}
+
+.shipfox-introduction {
+  min-height: 100vh;
+  box-sizing: border-box;
+  padding: 48px 24px 64px;
+}
+
+.shipfox-introduction__content {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.shipfox-introduction__eyebrow {
+  margin: 0;
+  color: var(--foreground-neutral-muted);
+  font-family: var(--font-code);
+  font-size: 12px;
+  line-height: 20px;
+  text-transform: uppercase;
+}
+
+.shipfox-introduction__title {
+  max-width: 720px;
+  margin: 16px 0 0;
+  color: var(--foreground-neutral-base);
+  font-size: 28px;
+  font-weight: 500;
+  line-height: 44px;
+}
+
+.shipfox-introduction__summary {
+  max-width: 720px;
+  margin: 16px 0 0;
+  color: var(--foreground-neutral-subtle);
+  font-size: 16px;
+  line-height: 24px;
+}
+
+.shipfox-introduction__section-title {
+  margin: 40px 0 0;
+  color: var(--foreground-neutral-base);
+  font-size: 18px;
+  font-weight: 500;
+  line-height: 28px;
+}
+
+.shipfox-introduction__links {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 8px;
+  margin: 16px 0 0;
+}
+
+.shipfox-introduction__link {
+  display: block;
+  padding: 16px;
+  border: 1px solid var(--border-neutral-base);
+  border-radius: 8px;
+  background: var(--background-components-base);
+  box-shadow: var(--shadow-border-base);
+  color: var(--foreground-neutral-base);
+  text-decoration: none;
+  transition:
+    background 150ms ease-out,
+    border-color 150ms ease-out;
+}
+
+.shipfox-introduction__link:hover {
+  border-color: var(--border-neutral-strong);
+  background: var(--background-components-hover);
+}
+
+.shipfox-introduction__link:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-button-neutral-focus);
+}
+
+.shipfox-introduction__link-title {
+  display: block;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 24px;
+}
+
+.shipfox-introduction__link-path {
+  display: block;
+  margin-top: 4px;
+  color: var(--foreground-neutral-muted);
+  font-family: var(--font-code);
+  font-size: 12px;
+  line-height: 20px;
+}
+
+.shipfox-introduction__note {
+  max-width: 720px;
+  margin: 40px 0 0;
+  padding: 16px;
+  border-left: 4px solid var(--border-highlights-interactive);
+  background: var(--background-components-base);
+  color: var(--foreground-neutral-subtle);
+  font-size: 13px;
+  line-height: 20px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .shipfox-introduction__link {
+    transition: none;
+  }
+}

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -1,0 +1,41 @@
+import '@shipfox/react-ui/index.css';
+import './preview.css';
+import {ThemeProvider} from '@shipfox/react-ui/theme';
+import type {Decorator, Preview} from '@storybook/react';
+
+const withTheme: Decorator = (Story, context) => {
+  const theme = context.globals.theme;
+
+  return (
+    <ThemeProvider key={theme} defaultTheme={theme} storageKey={`shipfox-storybook-theme-${theme}`}>
+      <Story />
+    </ThemeProvider>
+  );
+};
+
+const preview: Preview = {
+  decorators: [withTheme],
+  globalTypes: {
+    theme: {
+      name: 'Theme',
+      description: 'Global theme for the Storybook shell',
+      defaultValue: 'system',
+      toolbar: {
+        icon: 'sun',
+        items: [
+          {value: 'light', icon: 'sun', title: 'Light'},
+          {value: 'dark', icon: 'moon', title: 'Dark'},
+          {value: 'system', icon: 'info', title: 'System'},
+        ],
+        showName: true,
+      },
+    },
+  },
+  parameters: {
+    options: {
+      storySort: {method: 'alphabetical'},
+    },
+  },
+};
+
+export default preview;

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@shipfox/storybook",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
+    "directory": "apps/storybook"
+  },
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "pnpm run build:children && pnpm run storybook:build",
+    "build:children": "tsx scripts/build-children.ts",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "storybook": "pnpm run build:children && storybook dev -p 6015",
+    "storybook:build": "storybook build -o storybook-static",
+    "test": "shipfox-vitest-run",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "@shipfox/react-ui": "workspace:*",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*",
+    "@storybook/addon-docs": "catalog:",
+    "@storybook/react": "catalog:",
+    "@storybook/react-vite": "catalog:",
+    "@tailwindcss/vite": "catalog:",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitejs/plugin-react": "catalog:",
+    "storybook": "catalog:",
+    "tailwindcss": "catalog:",
+    "tsx": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/apps/storybook/preview-manifest.ts
+++ b/apps/storybook/preview-manifest.ts
@@ -1,0 +1,112 @@
+export type StorybookManifestEntry = {
+  readonly id: string;
+  readonly title: string;
+  readonly package: string;
+  readonly order: number;
+  readonly source: string;
+  readonly path: `/${string}/`;
+};
+
+export const storybooks = [
+  {
+    id: 'react-ui',
+    title: 'React UI',
+    package: '@shipfox/react-ui',
+    order: 1,
+    source: 'libs/shared/react/ui/storybook-static',
+    path: '/react-ui/',
+  },
+  {
+    id: 'client-agent',
+    title: 'Client Agent',
+    package: '@shipfox/client-agent',
+    order: 2,
+    source: 'libs/client/agent/storybook-static',
+    path: '/client-agent/',
+  },
+  {
+    id: 'client-auth',
+    title: 'Client Auth',
+    package: '@shipfox/client-auth',
+    order: 3,
+    source: 'libs/client/auth/storybook-static',
+    path: '/client-auth/',
+  },
+  {
+    id: 'client-integrations',
+    title: 'Client Integrations',
+    package: '@shipfox/client-integrations',
+    order: 4,
+    source: 'libs/client/integrations/storybook-static',
+    path: '/client-integrations/',
+  },
+  {
+    id: 'client-logs',
+    title: 'Client Logs',
+    package: '@shipfox/client-logs',
+    order: 5,
+    source: 'libs/client/logs/storybook-static',
+    path: '/client-logs/',
+  },
+  {
+    id: 'client-projects',
+    title: 'Client Projects',
+    package: '@shipfox/client-projects',
+    order: 6,
+    source: 'libs/client/projects/storybook-static',
+    path: '/client-projects/',
+  },
+  {
+    id: 'client-runners',
+    title: 'Client Runners',
+    package: '@shipfox/client-runners',
+    order: 7,
+    source: 'libs/client/runners/storybook-static',
+    path: '/client-runners/',
+  },
+  {
+    id: 'client-secrets',
+    title: 'Client Secrets',
+    package: '@shipfox/client-secrets',
+    order: 8,
+    source: 'libs/client/secrets/storybook-static',
+    path: '/client-secrets/',
+  },
+  {
+    id: 'client-triggers',
+    title: 'Client Triggers',
+    package: '@shipfox/client-triggers',
+    order: 9,
+    source: 'libs/client/triggers/storybook-static',
+    path: '/client-triggers/',
+  },
+  {
+    id: 'client-workflows',
+    title: 'Client Workflows',
+    package: '@shipfox/client-workflows',
+    order: 10,
+    source: 'libs/client/workflows/storybook-static',
+    path: '/client-workflows/',
+  },
+] as const satisfies readonly StorybookManifestEntry[];
+
+export const storybookManifest = storybooks;
+
+export type StorybookId = (typeof storybooks)[number]['id'];
+
+export type StorybookRef = {
+  title: string;
+  url: string;
+};
+
+export const storybookRefs = Object.fromEntries(
+  storybooks.map(({id, title, path}) => [id, {title, url: path}]),
+) as Record<StorybookId, StorybookRef>;
+
+export const storybookLinks = storybooks.map(({id, title, path}) => ({
+  id,
+  title,
+  url: path,
+}));
+
+export const storybookTurboFilters = storybooks.map(({package: packageName}) => packageName);

--- a/apps/storybook/scripts/build-children.ts
+++ b/apps/storybook/scripts/build-children.ts
@@ -1,0 +1,14 @@
+import {execFileSync} from 'node:child_process';
+import {dirname, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {storybookTurboFilters} from '../preview-manifest.js';
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const filters = storybookTurboFilters.flatMap((packageName) => ['--filter', packageName]);
+
+for (const task of ['build', 'storybook:build'] as const) {
+  execFileSync('pnpm', ['exec', 'turbo', task, '--concurrency=4', ...filters], {
+    cwd: repositoryRoot,
+    stdio: 'inherit',
+  });
+}

--- a/apps/storybook/src/introduction.mdx
+++ b/apps/storybook/src/introduction.mdx
@@ -1,0 +1,29 @@
+import {storybookLinks} from '../preview-manifest.js';
+
+<div className="shipfox-introduction">
+  <div className="shipfox-introduction__content">
+    <p className="shipfox-introduction__eyebrow">Shipfox / Storybook Preview</p>
+    <h1 className="shipfox-introduction__title">One catalog for every component surface.</h1>
+    <p className="shipfox-introduction__summary">
+      This composed Storybook is the local entry point for the ten package Storybooks built from
+      the same repository commit.
+    </p>
+
+    <h2 className="shipfox-introduction__section-title">Standalone Storybooks</h2>
+    <div className="shipfox-introduction__links">
+      {storybookLinks.map((storybook) => (
+        <a className="shipfox-introduction__link" href={storybook.url} key={storybook.id}>
+          <span className="shipfox-introduction__link-title">{storybook.title}</span>
+          <span className="shipfox-introduction__link-path">{storybook.url}</span>
+        </a>
+      ))}
+    </div>
+
+    <p className="shipfox-introduction__note">
+      Composition provides shared discovery and navigation, while each child keeps its own
+      Storybook configuration. Child-specific addons and toolbar globals do not automatically
+      synchronize with this shell; use the standalone links when you need the package-specific
+      experience.
+    </p>
+  </div>
+</div>

--- a/apps/storybook/test/preview-manifest.test.ts
+++ b/apps/storybook/test/preview-manifest.test.ts
@@ -1,0 +1,30 @@
+import {describe, expect, it} from '@shipfox/vitest/vitest';
+import {
+  storybookLinks,
+  storybookRefs,
+  storybooks,
+  storybookTurboFilters,
+} from '../preview-manifest.js';
+
+describe('storybook preview manifest', () => {
+  it('contains ten uniquely ordered Storybooks, including client-projects', () => {
+    expect(storybooks).toHaveLength(10);
+    expect(storybooks.map(({order}) => order)).toEqual(
+      Array.from({length: 10}, (_, index) => index + 1),
+    );
+    expect(new Set(storybooks.map(({id}) => id)).size).toBe(storybooks.length);
+    expect(storybooks.some(({id}) => id === 'client-projects')).toBe(true);
+  });
+
+  it('derives Composition refs and standalone links from the same entries', () => {
+    expect(Object.keys(storybookRefs)).toEqual(storybooks.map(({id}) => id));
+    expect(storybookLinks).toEqual(storybooks.map(({id, title, path: url}) => ({id, title, url})));
+    expect(Object.values(storybookRefs)).toEqual(
+      storybooks.map(({title, path: url}) => ({title, url})),
+    );
+  });
+
+  it('derives Turbo package filters from the manifest', () => {
+    expect(storybookTurboFilters).toEqual(storybooks.map(({package: packageName}) => packageName));
+  });
+});

--- a/apps/storybook/tsconfig.build.json
+++ b/apps/storybook/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@shipfox/ts-config/react",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": [".storybook", "preview-manifest.ts", "scripts", "vitest.config.ts"],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "src/**/*.mdx"]
+}

--- a/apps/storybook/tsconfig.json
+++ b/apps/storybook/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.test.json" }]
+}

--- a/apps/storybook/tsconfig.test.json
+++ b/apps/storybook/tsconfig.test.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": [
+    "test",
+    ".storybook",
+    "preview-manifest.ts",
+    "scripts",
+    "vitest.config.ts",
+    "node_modules/@shipfox/vitest/globals.d.ts"
+  ],
+  "exclude": ["src/**/*.mdx"]
+}

--- a/apps/storybook/turbo.json
+++ b/apps/storybook/turbo.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "cache": false,
+      "outputs": ["storybook-static/**/*"],
+      "dependsOn": ["^build"]
+    }
+  }
+}

--- a/apps/storybook/vitest.config.ts
+++ b/apps/storybook/vitest.config.ts
@@ -1,0 +1,10 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig(
+  {
+    test: {
+      include: ['test/**/*.test.ts'],
+    },
+  },
+  import.meta.url,
+) as UserConfigExport;

--- a/docs/policies/dependency-versions.md
+++ b/docs/policies/dependency-versions.md
@@ -278,7 +278,7 @@ take part in numeric equality.
 | Temporal SDK | `@temporalio/activity`, `@temporalio/client`, `@temporalio/common`, `@temporalio/interceptors-opentelemetry`, `@temporalio/testing`, `@temporalio/worker`, `@temporalio/workflow` | Yes. | Yes. | Exact. |
 | React runtime | `react`, `react-dom` | Yes. | Yes. | Caret. Peers stay separate. |
 | Vitest | `vitest`, `@vitest/browser-playwright` | Yes. | Yes. | Caret. |
-| Storybook core | `storybook`, `@storybook/addon-vitest`, `@storybook/react`, `@storybook/react-vite` | Yes. | Yes. | Caret. |
+| Storybook | `storybook`, `@storybook/addon-docs`, `@storybook/addon-vitest`, `@storybook/react`, `@storybook/react-vite` | Yes. | Yes. | Caret. |
 | Tailwind CSS | `tailwindcss`, `@tailwindcss/vite` | Yes. | Yes. | Caret. |
 | React type definitions | `@types/react`, `@types/react-dom` | No. | No. | Group only. |
 | TanStack Query | `@tanstack/query-core`, `@tanstack/react-query`, `@tanstack/react-query-devtools` | No. | No. | Group only. |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,9 @@ catalogs:
     '@sentry/node':
       specifier: ^10.44.0
       version: 10.58.0
+    '@storybook/addon-docs':
+      specifier: ^10.4.6
+      version: 10.4.6
     '@storybook/addon-vitest':
       specifier: ^10.3.6
       version: 10.4.6
@@ -824,6 +827,70 @@ importers:
       tsx:
         specifier: 'catalog:'
         version: 4.22.4
+
+  apps/storybook:
+    dependencies:
+      '@shipfox/react-ui':
+        specifier: workspace:*
+        version: link:../../libs/shared/react/ui
+      react:
+        specifier: 'catalog:'
+        version: 19.2.7
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../tools/biome
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../tools/vitest
+      '@storybook/addon-docs':
+        specifier: 'catalog:'
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1))
+      '@storybook/react':
+        specifier: 'catalog:'
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)
+      '@storybook/react-vite':
+        specifier: 'catalog:'
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1))
+      '@tailwindcss/vite':
+        specifier: 'catalog:'
+        version: 4.3.1(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.2
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: 'catalog:'
+        version: 6.0.2(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      storybook:
+        specifier: 'catalog:'
+        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      tailwindcss:
+        specifier: 'catalog:'
+        version: 4.3.2
+      tsx:
+        specifier: 'catalog:'
+        version: 4.22.4
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   dev: {}
 
@@ -9481,6 +9548,12 @@ packages:
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
 
+  '@mdx-js/react@3.1.1':
+    resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
+    peerDependencies:
+      '@types/react': '>=16'
+      react: '>=16'
+
   '@mistralai/mistralai@2.2.6':
     resolution: {integrity: sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==}
     peerDependencies:
@@ -11506,6 +11579,15 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@storybook/addon-docs@10.4.6':
+    resolution: {integrity: sha512-aWAfP5JMiT5a3zBJizwroCRzOCqZwDTJmvsYvwMD3ilIEa/kT1vhf6Xrbk4XIPhDwbh8Hpb/Gfnka1xBYEISWg==}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.4.6
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@storybook/addon-vitest@10.4.6':
     resolution: {integrity: sha512-VvskHge0GZy86LG6kcY5Ww34z8rDV8JBxqSdUpcJVsWfIvyX6MfAbqI76LlereSyBIJGZJZsqaLwRXsQoVY+0Q==}
@@ -18398,6 +18480,14 @@ snapshots:
 
   '@isaacs/cliui@9.0.0': {}
 
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      glob: 13.0.6
+      react-docgen-typescript: 2.4.0(typescript@6.0.3)
+      vite: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+    optionalDependencies:
+      typescript: 6.0.3
+
   '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       glob: 13.0.6
@@ -18652,6 +18742,12 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
+
+  '@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@types/mdx': 2.0.14
+      '@types/react': 19.2.17
+      react: 19.2.7
 
   '@mistralai/mistralai@2.2.6(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -20750,6 +20846,25 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@storybook/addon-docs@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1))':
+    dependencies:
+      '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1))
+      '@storybook/icons': 2.0.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@storybook/react-dom-shim': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      ts-dedent: 2.3.0
+    optionalDependencies:
+      '@types/react': 19.2.17
+    transitivePeerDependencies:
+      - '@types/react-dom'
+      - esbuild
+      - rollup
+      - vite
+      - webpack
+
   '@storybook/addon-vitest@10.4.6(@vitest/browser-playwright@4.1.9)(@vitest/browser@4.1.9(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9))(@vitest/runner@4.1.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vitest@4.1.9)':
     dependencies:
       '@storybook/global': 5.0.0
@@ -20764,6 +20879,17 @@ snapshots:
       - react
       - react-dom
 
+  '@storybook/builder-vite@10.4.6(esbuild@0.28.1)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1))':
+    dependencies:
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1))
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      ts-dedent: 2.3.0
+      vite: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - esbuild
+      - rollup
+      - webpack
+
   '@storybook/builder-vite@10.4.6(esbuild@0.28.1)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1))':
     dependencies:
       '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1))
@@ -20774,6 +20900,15 @@ snapshots:
       - esbuild
       - rollup
       - webpack
+
+  '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1))':
+    dependencies:
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      unplugin: 2.3.11
+    optionalDependencies:
+      esbuild: 0.28.1
+      vite: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      webpack: 5.107.2(esbuild@0.28.1)
 
   '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1))':
     dependencies:
@@ -20799,6 +20934,30 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@storybook/react-vite@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1))':
+    dependencies:
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@rollup/pluginutils': 5.4.0
+      '@storybook/builder-vite': 10.4.6(esbuild@0.28.1)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1))
+      '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)
+      empathic: 2.0.1
+      magic-string: 0.30.21
+      react: 19.2.7
+      react-docgen: 8.0.3
+      react-dom: 19.2.7(react@19.2.7)
+      resolve: 1.22.12
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      tsconfig-paths: 4.2.0
+      vite: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - esbuild
+      - rollup
+      - supports-color
+      - typescript
+      - webpack
 
   '@storybook/react-vite@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1))':
     dependencies:
@@ -21057,6 +21216,13 @@ snapshots:
       '@tailwindcss/oxide': 4.3.2
       postcss: 8.5.15
       tailwindcss: 4.3.2
+
+  '@tailwindcss/vite@4.3.1(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@tailwindcss/node': 4.3.1
+      '@tailwindcss/oxide': 4.3.1
+      tailwindcss: 4.3.1
+      vite: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@tailwindcss/vite@4.3.1(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
@@ -21461,10 +21627,29 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
+  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+
   '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+
+  '@vitest/browser-playwright@4.1.9(playwright@1.61.0)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)':
+    dependencies:
+      '@vitest/browser': 4.1.9(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/mocker': 4.1.9(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      playwright: 1.61.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
 
   '@vitest/browser-playwright@4.1.9(playwright@1.61.0)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)':
     dependencies:
@@ -21478,6 +21663,24 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
+
+  '@vitest/browser@4.1.9(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.9(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/utils': 4.1.9
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
 
   '@vitest/browser@4.1.9(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)':
     dependencies:
@@ -21512,6 +21715,14 @@ snapshots:
       '@vitest/utils': 4.1.9
       chai: 6.2.2
       tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.9(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.9(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
@@ -26873,6 +27084,22 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 24.13.2
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      terser: 5.48.0
+      tsx: 4.22.4
+      yaml: 2.9.0
+
   vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
@@ -26888,6 +27115,37 @@ snapshots:
       terser: 5.48.0
       tsx: 4.22.4
       yaml: 2.9.0
+
+  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.9
+      '@vitest/mocker': 4.1.9(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/runner': 4.1.9
+      '@vitest/snapshot': 4.1.9
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 24.13.2
+      '@vitest/browser-playwright': 4.1.9(playwright@1.61.0)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
+      happy-dom: 20.10.6
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -68,6 +68,7 @@ catalog:
   "@radix-ui/react-tooltip": "^1.2.8"
   "@remixicon/react": "^4.6.0"
   "@sentry/node": "^10.44.0"
+  '@storybook/addon-docs': ^10.4.6
   "@storybook/addon-vitest": "^10.3.6"
   "@storybook/react": "^10.0.0"
   "@storybook/react-vite": "^10.0.0"

--- a/renovate.json
+++ b/renovate.json
@@ -140,17 +140,18 @@
       "separateMajorMinor": false
     },
     {
-      "description": "Storybook core packages share one upstream release. Wait for all four catalog entries and combine major and non-major releases while retaining caret ranges.",
+      "description": "Storybook packages share one upstream release. Wait for all five catalog entries and combine major and non-major releases while retaining caret ranges.",
       "groupName": "storybook-core",
       "groupSlug": "storybook-core",
       "matchManagers": ["npm"],
       "matchPackageNames": [
         "storybook",
+        "@storybook/addon-docs",
         "@storybook/addon-vitest",
         "@storybook/react",
         "@storybook/react-vite"
       ],
-      "minimumGroupSize": 4,
+      "minimumGroupSize": 5,
       "rangeStrategy": "bump",
       "separateMajorMinor": false
     },


### PR DESCRIPTION
Add a private Storybook Composition shell for the ten existing package Storybooks.

The shell introduces one canonical manifest that derives Composition refs, standalone links, static mounts, and child build filters in the required stable order. The build orchestration compiles package outputs before rebuilding each child Storybook, includes client-projects, and then builds the local introduction shell. Storybook Docs is added through the workspace catalog with the existing Storybook family policy and Renovate grouping.

The shell build is explicitly non-cacheable because its nested manifest-driven Turbo calls are not represented as direct package dependencies; this keeps the manifest as the single inventory source while preventing stale composed output. The child package Storybook configurations remain unchanged.

The affected build, test, and check gates pass, along with dependency and lockfile audits.

Closes ENG-1173

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a manifest‑driven Storybook Composition shell that composes the ten package Storybooks into one local preview with links and shared theming. The build orchestrates all child Storybooks first and disables caching to prevent stale composed output. Closes ENG-1173.

- **New Features**
  - One manifest defines refs, standalone links, static mounts, and Turbo filters in a stable order (includes `@shipfox/client-projects`).
  - Shell uses `@storybook/react-vite` with `@storybook/addon-docs`; adds a light/dark/system theme toolbar via `@shipfox/react-ui` ThemeProvider; telemetry off.
  - Build script runs children `build` + `storybook:build` via Turbo, then builds the shell; shell task is non-cacheable.
  - Intro page lists all ten standalone Storybooks; child Storybook configs are unchanged.
  - Tests validate manifest size/order and the derived refs/links/filters.

- **Dependencies**
  - Added `@storybook/addon-docs` to the workspace catalog and the Storybook Renovate group.
  - Ignored `storybook-static/` outputs; updated lockfile.

<sup>Written for commit da477adb3ea45e2d657ce6d5182ebe68f5b3514a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

