### PR TITLE
Complete ADR 0005 documentation convergence audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,18 +25,22 @@ here, use the full [engineering documentation map](docs/README.md).
 
 | Before editing when the task... | Read | It owns |
 | --- | --- | --- |
-| Needs task selection, local-service recovery, shared Ollama, affected-package validation, or package release procedures. | [Local development and release workflow](docs/guides/local-development-and-release-workflow.md) | Shared contributor procedures. |
+| Needs local tasks, service recovery, shared Ollama, or affected-package checks. | [Local development and release workflow](docs/guides/local-development-and-release-workflow.md) | Shared local-development and validation steps. |
+| Changes a published package or prepares a release. | [Changesets and publishing workflow](docs/guides/local-development-and-release-workflow.md#publish-packages-with-changesets) | Changeset rules, version bumps, summaries, and publishing. |
 | Adds, updates, or exempts a dependency. | [Dependency version policy](docs/policies/dependency-versions.md) | Version rules, exceptions, package families, and dependency checks. |
 | Adds or changes a backend module, DTO, outbox event, HTTP boundary, or server package dependency. | [Backend architecture](docs/architecture/backend-architecture.md) | The current backend module model and package-boundary rules. |
-| Changes client state, API adapters, forms, or feature-domain boundaries. | [Client architecture](docs/architecture/client-architecture.md) | The current client model, form rules, and architecture enforcement. |
+| Changes client state, API adapters, or feature boundaries. | [Client architecture](docs/architecture/client-architecture.md) | The current client model and architecture checks. |
+| Adds or changes a client form. | [Client form guidance](docs/architecture/client-architecture.md#forms) | Form state, validation, fields, server errors, and saved drafts. |
 | Adds or changes an environment variable, validator, or environment description. | [Configuration policy](docs/policies/configuration.md) | Configuration ownership, validation, and description rules. |
 | Adds a domain or provider error, translates a request failure, or reports an unexpected failure. | [Error handling](docs/architecture/error-handling.md) | The error model, client translation, and reporting boundaries. |
 | Adds a metric or changes instrumentation startup, naming, units, or labels. | [Observability](docs/architecture/observability.md) | The metrics model and cardinality constraints. |
 | Mints, verifies, or carries an authentication token. | [Auth security model](libs/api/auth/README.md#security-model) | Token authority, lifetime, trust boundaries, and logging constraints. |
-| Adds or changes unit tests, Storybook stories, or visual regression coverage. | [Testing guide](docs/guides/testing.md) | Test selection, Storybook conventions, and visual-review workflow. |
+| Adds or changes unit tests or Storybook stories. | [Testing guide](docs/guides/testing.md) | Test levels and Storybook rules. |
+| Adds or changes a visual test. | [Visual regression guidance](docs/guides/testing.md#visual-regression) | Argos builds, screenshots, and review. |
 | Adds or changes end-to-end coverage. | [E2E guide](e2e/README.md) | E2E suite structure, setup, screens, and package boundaries. |
 | Creates or changes a visual or interaction decision. | [Design system](DESIGN.md) | Shared design guidance; code owns exact token and component values. |
-| Writes engineering prose, a package README, or a runbook. | [Writing guide](WRITING.md) | Repository prose and package-README standards. |
+| Writes engineering prose or a runbook. | [Writing guide](WRITING.md) | Repository prose, style, punctuation, and readability. |
+| Creates or updates a package README. | [Package README standard](WRITING.md#package-readmes) | Required sections, public API, local checks, and license. |
 | Writes product or self-hosting documentation. | [Docs writing guide](apps/docs/WRITING.md) | Product-documentation page types, templates, and terminology. |
 | Writes or reviews code comments, module exports, or non-trivial control flow. | [Code style policy](docs/policies/code-style.md) | Shared code-comment, import and export, and control-flow rules. |
 | Changes a cross-package client composition seam, server module boundary, or shared server-package boundary. | [Engineering documentation map](docs/README.md) | The applicable ADR and its decision boundary. |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,18 +72,22 @@ here, use the full [engineering documentation map](docs/README.md).
 
 | When your task... | Read | It owns |
 | --- | --- | --- |
-| Needs task selection, local-service recovery, shared Ollama, affected-package validation, or package release procedures. | [Local development and release workflow](docs/guides/local-development-and-release-workflow.md) | Shared contributor procedures. |
+| Needs local tasks, service recovery, shared Ollama, or affected-package checks. | [Local development and release workflow](docs/guides/local-development-and-release-workflow.md) | Shared local-development and validation steps. |
+| Changes a published package or prepares a release. | [Changesets and publishing workflow](docs/guides/local-development-and-release-workflow.md#publish-packages-with-changesets) | Changeset rules, version bumps, summaries, and publishing. |
 | Adds, updates, or exempts a dependency. | [Dependency version policy](docs/policies/dependency-versions.md) | Version rules, exceptions, package families, and dependency checks. |
 | Adds or changes a backend module, DTO, outbox event, HTTP boundary, or server package dependency. | [Backend architecture](docs/architecture/backend-architecture.md) | The current backend module model and package-boundary rules. |
-| Changes client state, API adapters, forms, or feature-domain boundaries. | [Client architecture](docs/architecture/client-architecture.md) | The current client model, form rules, and architecture enforcement. |
+| Changes client state, API adapters, or feature boundaries. | [Client architecture](docs/architecture/client-architecture.md) | The current client model and architecture checks. |
+| Adds or changes a client form. | [Client form guidance](docs/architecture/client-architecture.md#forms) | Form state, validation, fields, server errors, and saved drafts. |
 | Adds or changes an environment variable, validator, or environment description. | [Configuration policy](docs/policies/configuration.md) | Configuration ownership, validation, and description rules. |
 | Adds a domain or provider error, translates a request failure, or reports an unexpected failure. | [Error handling](docs/architecture/error-handling.md) | The error model, client translation, and reporting boundaries. |
 | Adds a metric or changes instrumentation startup, naming, units, or labels. | [Observability](docs/architecture/observability.md) | The metrics model and cardinality constraints. |
 | Mints, verifies, or carries an authentication token. | [Auth security model](libs/api/auth/README.md#security-model) | Token authority, lifetime, trust boundaries, and logging constraints. |
-| Adds or changes unit tests, Storybook stories, or visual regression coverage. | [Testing guide](docs/guides/testing.md) | Test selection, Storybook conventions, and visual-review workflow. |
+| Adds or changes unit tests or Storybook stories. | [Testing guide](docs/guides/testing.md) | Test levels and Storybook rules. |
+| Adds or changes a visual test. | [Visual regression guidance](docs/guides/testing.md#visual-regression) | Argos builds, screenshots, and review. |
 | Adds or changes end-to-end coverage. | [E2E guide](e2e/README.md) | E2E suite structure, setup, screens, and package boundaries. |
 | Creates or changes a visual or interaction decision. | [Design system](DESIGN.md) | Shared design guidance; code owns exact token and component values. |
-| Writes engineering prose, a package README, or a runbook. | [Writing guide](WRITING.md) | Repository prose and package-README standards. |
+| Writes engineering prose or a runbook. | [Writing guide](WRITING.md) | Repository prose, style, punctuation, and readability. |
+| Creates or updates a package README. | [Package README standard](WRITING.md#package-readmes) | Required sections, public API, local checks, and license. |
 | Writes product or self-hosting documentation. | [Docs writing guide](apps/docs/WRITING.md) | Product-documentation page types, templates, and terminology. |
 | Writes or reviews code comments, module exports, or non-trivial control flow. | [Code style policy](docs/policies/code-style.md) | Shared code-comment, import and export, and control-flow rules. |
 | Changes a cross-package client composition seam, server module boundary, or shared server-package boundary. | [Engineering documentation map](docs/README.md) | The applicable ADR and its decision boundary. |

--- a/README.md
+++ b/README.md
@@ -114,9 +114,8 @@ token and trust model is documented in the
 
 ## Contributing
 
-Read [CONTRIBUTING.md](CONTRIBUTING.md) and the codebase conventions in
-[CLAUDE.md](CLAUDE.md) / [AGENTS.md](AGENTS.md) before opening a pull request. UI
-work should follow [DESIGN.md](DESIGN.md); E2E work follows [e2e/README.md](e2e/README.md).
+Read [CONTRIBUTING.md](CONTRIBUTING.md) before you open a pull request. Its task
+map links to the engineering guide for each change.
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,8 @@ listed there or when you need to place, update, or review documentation.
 | --- | --- | --- |
 | Needs the product overview or a starting point outside engineering work. | [Root README](../README.md) | Product orientation and repository navigation. |
 | Starts a human contribution or needs branch, commit, or pull-request guidance. | [Contributing guide](../CONTRIBUTING.md) | Prerequisites, initial setup, contribution workflow, review standards, and essential validation. |
-| Needs local-task selection, service recovery, or package release procedures. | [Local development and release workflow](guides/local-development-and-release-workflow.md) | Mise, local services, Ollama, affected-package validation, Changesets, and publishing. |
+| Needs local tasks, service recovery, shared Ollama, or affected-package checks. | [Local development and release workflow](guides/local-development-and-release-workflow.md) | Mise, local services, Ollama, and affected-package checks. |
+| Changes a published package or prepares a release. | [Changesets and publishing workflow](guides/local-development-and-release-workflow.md#publish-packages-with-changesets) | Changeset rules, version bumps, summaries, and publishing. |
 | Needs the generated release-PR CI verification path. | [Generated release PR CI](guides/release-pr-ci.md) | The fast-path conditions and fail-closed verification behavior for Changesets release PRs. |
 | Needs to configure or review Vercel release-PR previews. | [Vercel release PR previews](vercel-preview-release-prs.md) | The repository-owned Vercel branch configuration and verification workflow. |
 | Changes agent behavior or needs agent execution instructions. | [Agent instructions](../AGENTS.md) | Repository-specific agent execution, change hygiene, and conditional context loading. |
@@ -24,18 +25,21 @@ listed there or when you need to place, update, or review documentation.
 | Adds or changes an environment variable, validator, or environment description. | [Configuration policy](policies/configuration.md) | Repository-wide configuration ownership, validation, and description rules. |
 | Adds a domain or provider error, translates a request failure, or reports an unexpected failure. | [Error handling](architecture/error-handling.md) | The current backend error model, client translation, and reporting boundaries. |
 | Adds a metric or changes instrumentation startup, naming, units, or labels. | [Observability](architecture/observability.md) | The current backend metrics model and cardinality constraints. |
-| Changes client state, API adapters, forms, or feature-domain boundaries. | [Client architecture](architecture/client-architecture.md) | The current client feature model, form rules, and architecture enforcement. |
+| Changes client state, API adapters, or feature boundaries. | [Client architecture](architecture/client-architecture.md) | The current client model and architecture checks. |
+| Adds or changes a client form. | [Client form guidance](architecture/client-architecture.md#forms) | Form state, validation, fields, server errors, and saved drafts. |
 | Introduces a shared package or changes a server dependency boundary. | [ADR 0004](adr/0004-shared-semantic-packages-and-server-dependency-boundaries.md) | Shared semantic package rules and server package classes. |
 | Changes repository documentation structure or adds a shared documentation surface. | [ADR 0005](adr/0005-repository-documentation-architecture.md) | Documentation ownership, routing, and progressive disclosure. |
 | Validates repository Markdown links, anchors, or documentation reachability. | [Repository documentation policy](../tools/repository-documentation-policy/README.md) | Deterministic link and orphan checks for engineering documentation. |
 | Changes webhook retry behavior. | [Webhook retry safety](architecture/webhook-retry-safety.md) | The current safety model for webhook retries. |
-| Adds or changes unit tests, Storybook stories, or visual regression coverage. | [Testing guide](guides/testing.md) | Unit-test altitude, Storybook conventions, Argos ownership, build names, and review. |
+| Adds or changes unit tests or Storybook stories. | [Testing guide](guides/testing.md) | Unit-test levels and Storybook rules. |
+| Adds or changes a visual test. | [Visual regression guidance](guides/testing.md#visual-regression) | Argos builds, screenshots, and review. |
 | Adds or changes end-to-end coverage. | [E2E guide](../e2e/README.md) | Suite levels, HTTP-first setup, screens, and E2E package boundaries. |
 | Mints, verifies, or carries an authentication token. | [Auth security model](../libs/api/auth/README.md#security-model) | Token authority, lifetime, trust boundaries, and logging constraints. |
 | Defines an inter-module contract or transport. | [Inter-module package README](../libs/shared/common/inter-module/README.md) | Contract primitives and transport responsibilities. |
 | Needs a package-local API, configuration, fixture, or operational constraint. | [Package README standard](../WRITING.md#package-readmes) | How to find and shape the owning package README; the README beside the package owns the local detail. |
 | Creates or changes a visual or interaction decision. | [Design system](../DESIGN.md) | Shared tokens, components, accessibility, motion, status taxonomy, patterns, and review anti-patterns. Code owns exact token and component values. |
-| Writes engineering prose, a package README, or a runbook. | [Writing guide](../WRITING.md) | Repository-wide prose structure, style, punctuation, readability, and package README structure. |
+| Writes engineering prose or a runbook. | [Writing guide](../WRITING.md) | Repository prose, style, punctuation, and readability. |
+| Creates or updates a package README. | [Package README standard](../WRITING.md#package-readmes) | Required sections, public API, local checks, and license. |
 | Writes or reviews code comments, module exports, or non-trivial control flow. | [Code style policy](policies/code-style.md) | Shared code-comment, import and export, and control-flow rules. |
 | Writes product or self-hosting documentation. | [Docs writing guide](../apps/docs/WRITING.md) | Product documentation page types, templates, and local terminology. |
 


### PR DESCRIPTION
Completes the requirement-by-requirement acceptance audit for the repository documentation model defined by ADR 0005.

The audit found two remaining progressive-disclosure gaps. This change removes the root README handoff from human contributors to agent instructions, then gives client forms, visual tests, publishing, and package README authoring direct links to their canonical sections across the shared task routers.

The human and agent entrypoints continue to route technical work to the same sources. Detailed audit evidence and all eight representative journey results are recorded on ENG-1164.

Validation passed with the focused repository-documentation policy checks and the full 150-package `pnpm verify` gate. This documentation-only change does not require a Changeset.

Closes ENG-1164

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes the ADR 0005 documentation convergence audit by fixing two routing gaps and tightening task maps so contributors land on the right sections. Human and agent entrypoints now point to the same canonical docs; all verification checks pass. Closes ENG-1164.

- **Refactors**
  - Updated task tables in `CONTRIBUTING.md`, `AGENTS.md`, and `docs/README.md` to link directly to section anchors for client forms, visual tests, publishing, and package README authoring.
  - Kept `README.md` human-focused by removing the handoff to agent instructions; it now routes to the contributing task map.
  - Verified links and reachability with `@shipfox/repository-documentation-policy` and passed the full `pnpm verify` gate.

<sup>Written for commit 3ead0076a7cf27bb39ce6759633ba1c4190cdb63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

