### PR TITLE
Avoid rebuilding unchanged applications for release-only commits

### DIFF
--- a/.changeset/clever-otters-reuse.md
+++ b/.changeset/clever-otters-reuse.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/application-release": patch
+---
+
+Records explicit provenance when an application release reuses immutable image artifacts for a version-only main commit.

--- a/.github/scripts/package-release-workflow.mjs
+++ b/.github/scripts/package-release-workflow.mjs
@@ -130,6 +130,207 @@ async function authorize() {
   process.stdout.write(`${JSON.stringify({authorized, reason})}\n`);
 }
 
+function classificationResult(values, reason, message) {
+  return {
+    versionOnlyMain: values.versionOnlyMain ?? false,
+    previousRevision: values.previousRevision ?? '',
+    releasePrUrl: values.releasePrUrl ?? '',
+    releasePrNumber: values.releasePrNumber ?? '',
+    reason,
+    message,
+  };
+}
+
+async function writeMainClassification(result) {
+  await writeOutput({
+    version_only_main: String(result.versionOnlyMain),
+    version_only_previous_revision: result.previousRevision,
+    version_only_release_pr: result.releasePrUrl,
+    version_only_release_pr_number: result.releasePrNumber,
+    reason: result.reason,
+  });
+  await writeSummary(
+    [
+      '## Main commit classification',
+      '',
+      `- Result: **${result.versionOnlyMain ? 'version-only' : 'normal CI'}**`,
+      `- Reason: \`${result.reason}\``,
+      ...(result.releasePrUrl ? [`- Generated release PR: ${result.releasePrUrl}`] : []),
+      ...(result.previousRevision
+        ? [`- Prior validated revision: \`${result.previousRevision}\``]
+        : []),
+      result.versionOnlyMain
+        ? '- Application validation and image bytes can be reused from the prior revision.'
+        : '- The workflow keeps the full main validation and build path.',
+    ].join('\n'),
+  );
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+async function classifyMain() {
+  const revision = argument('revision');
+  const repository = argument('repository');
+  const expectedAppId = argument('release-app-id');
+  const invalidMetadata = !revision || !repository || !expectedAppId;
+
+  if (invalidMetadata) {
+    await writeMainClassification(
+      classificationResult(
+        {},
+        'missing-main-classification-metadata',
+        'The main commit classifier did not receive the required metadata.',
+      ),
+    );
+    return;
+  }
+
+  const parentResult = await run('git', ['rev-parse', `${revision}^1`]);
+  if (parentResult.code !== 0) {
+    await writeMainClassification(
+      classificationResult(
+        {},
+        'parent-revision-unavailable',
+        'The parent revision could not be resolved; normal main CI remains required.',
+      ),
+    );
+    return;
+  }
+  const previousRevision = parentResult.stdout.trim();
+  if (!/^[a-f0-9]{40}$/.test(previousRevision)) {
+    await writeMainClassification(
+      classificationResult(
+        {},
+        'parent-revision-invalid',
+        'The resolved parent is not a full Git revision; normal main CI remains required.',
+      ),
+    );
+    return;
+  }
+
+  const pullRequestsResult = await run('gh', [
+    'api',
+    `repos/${repository}/commits/${revision}/pulls`,
+    '--header',
+    'Accept: application/vnd.github+json',
+  ]);
+  if (pullRequestsResult.code !== 0) {
+    await writeMainClassification(
+      classificationResult(
+        {},
+        'merged-release-pr-unavailable',
+        'The merged pull request could not be resolved; normal main CI remains required.',
+      ),
+    );
+    return;
+  }
+
+  let pullRequests;
+  try {
+    pullRequests = JSON.parse(pullRequestsResult.stdout);
+  } catch {
+    await writeMainClassification(
+      classificationResult(
+        {},
+        'merged-release-pr-invalid',
+        'GitHub returned invalid pull request metadata; normal main CI remains required.',
+      ),
+    );
+    return;
+  }
+
+  const releasePullRequest = Array.isArray(pullRequests)
+    ? pullRequests.find(
+        (pullRequest) =>
+          typeof pullRequest.merged_at === 'string' &&
+          pullRequest.merge_commit_sha === revision &&
+          pullRequest.base?.ref === 'main',
+      )
+    : undefined;
+  const releasePrUrl = releasePullRequest?.html_url ?? '';
+  const releasePrNumber = releasePullRequest?.number ? String(releasePullRequest.number) : '';
+
+  if (!releasePullRequest) {
+    await writeMainClassification(
+      classificationResult(
+        {releasePrUrl, releasePrNumber},
+        'merged-release-pr-not-found',
+        'The commit is not the merged result of a pull request targeting main.',
+      ),
+    );
+    return;
+  }
+
+  const headRepository = releasePullRequest.head?.repo?.full_name ?? '';
+  const headRef = releasePullRequest.head?.ref ?? '';
+  const authorId = String(releasePullRequest.user?.id ?? '');
+  const metadataResult =
+    headRepository !== repository
+      ? 'head-repository-mismatch'
+      : headRef !== 'changeset-release/main'
+        ? 'release-branch-mismatch'
+        : authorId !== expectedAppId
+          ? 'release-app-mismatch'
+          : undefined;
+
+  if (metadataResult) {
+    await writeMainClassification(
+      classificationResult(
+        {releasePrUrl, releasePrNumber},
+        metadataResult,
+        'The merged pull request metadata is not an approved generated release.',
+      ),
+    );
+    return;
+  }
+
+  const verifierResult = await run('pnpm', [
+    '--silent',
+    '--filter=@shipfox/package-release',
+    'verify-generated-release',
+    '--',
+    '--base',
+    previousRevision,
+    '--head',
+    revision,
+    '--repository',
+    repository,
+    '--head-repository',
+    headRepository,
+    '--head-ref',
+    headRef,
+    '--author-id',
+    authorId,
+    '--release-app-id',
+    expectedAppId,
+  ]);
+  const verifierLine = verifierResult.stdout
+    .trim()
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .at(-1);
+  let verifier;
+  try {
+    verifier = verifierLine ? JSON.parse(verifierLine) : undefined;
+  } catch {
+    verifier = undefined;
+  }
+
+  const versionOnlyMain =
+    verifierResult.code === 0 && verifier?.classification === 'generated-release';
+  await writeMainClassification(
+    classificationResult(
+      versionOnlyMain
+        ? {versionOnlyMain: true, previousRevision, releasePrUrl, releasePrNumber}
+        : {releasePrUrl, releasePrNumber},
+      versionOnlyMain ? 'generated-tree-matches' : (verifier?.reason ?? 'verification-error'),
+      versionOnlyMain
+        ? 'The merged tree exactly matches the generated release output from its parent revision.'
+        : 'The merged tree is not a deterministic generated release; normal main CI remains required.',
+    ),
+  );
+}
+
 async function summarizeUpdate() {
   const before = JSON.parse(await readFile(argument('before'), 'utf8'));
   const after = JSON.parse(await readFile(argument('after'), 'utf8'));
@@ -169,6 +370,7 @@ async function summarizePublication() {
 const command = process.argv[2];
 if (command === 'plan') await plan();
 else if (command === 'authorize') await authorize();
+else if (command === 'classify-main') await classifyMain();
 else if (command === 'summarize-update') await summarizeUpdate();
 else if (command === 'summarize-publication') await summarizePublication();
 else throw new Error(`Unknown package release workflow command: ${command ?? '(missing)'}`);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,11 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 # Cancel superseded PR/branch runs before they finish, so rapid pushes stop paying
 # for CI work they already invalidated. main is never cancelled: every merged commit
-# must run to completion to publish its per-commit release artifacts.
+# must run to completion to publish or reuse its per-commit release artifacts.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
@@ -32,30 +33,33 @@ env:
 # rebuilds what its own Turbo graph needs.
 jobs:
   release-classification:
-    name: Classify release PR
+    name: Classify release PR or version-only main commit
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       generated_release: ${{ steps.classify.outputs.generated_release || 'false' }}
-      reason: ${{ steps.classify.outputs.reason || 'not-a-release-pr' }}
+      version_only_main: ${{ steps.classify-main.outputs.version_only_main || 'false' }}
+      version_only_previous_revision: ${{ steps.classify-main.outputs.version_only_previous_revision || '' }}
+      version_only_release_pr: ${{ steps.classify-main.outputs.version_only_release_pr || '' }}
+      reason: ${{ steps.classify.outputs.reason || steps.classify-main.outputs.reason || 'not-a-release-pr' }}
 
     steps:
       - name: Check out repository
-        if: github.event_name == 'pull_request' && vars.FORCE_FULL_CI != 'true'
+        if: (github.event_name == 'pull_request' || github.ref == 'refs/heads/main') && vars.FORCE_FULL_CI != 'true'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
 
       - name: Set up mise
-        if: github.event_name == 'pull_request' && vars.FORCE_FULL_CI != 'true'
+        if: (github.event_name == 'pull_request' || github.ref == 'refs/heads/main') && vars.FORCE_FULL_CI != 'true'
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
 
       - name: Set up pnpm
-        if: github.event_name == 'pull_request' && vars.FORCE_FULL_CI != 'true'
+        if: (github.event_name == 'pull_request' || github.ref == 'refs/heads/main') && vars.FORCE_FULL_CI != 'true'
         uses: ./.github/actions/setup-pnpm
 
       - name: Build generated-release verifier
-        if: github.event_name == 'pull_request' && vars.FORCE_FULL_CI != 'true'
+        if: (github.event_name == 'pull_request' || github.ref == 'refs/heads/main') && vars.FORCE_FULL_CI != 'true'
         run: turbo build --filter=@shipfox/package-release
 
       - name: Verify generated release tree
@@ -64,7 +68,7 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
           PULL_REQUEST_AUTHOR_ID: ${{ github.event.pull_request.user.id }}
           RELEASE_BOT_APP_ID: ${{ vars.RELEASE_BOT_APP_ID }}
@@ -93,9 +97,55 @@ jobs:
           echo "generated_release=$generated_release" >> "$GITHUB_OUTPUT"
           echo "reason=$reason" >> "$GITHUB_OUTPUT"
 
+      - name: Verify version-only main commit
+        id: classify-main
+        if: github.ref == 'refs/heads/main' && vars.FORCE_FULL_CI != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_BOT_APP_ID: ${{ vars.RELEASE_BOT_APP_ID }}
+          REVISION: ${{ github.sha }}
+        run: |
+          node .github/scripts/package-release-workflow.mjs classify-main \
+            --revision "$REVISION" \
+            --repository "$GITHUB_REPOSITORY" \
+            --release-app-id "$RELEASE_BOT_APP_ID" \
+            --github-output "$GITHUB_OUTPUT" \
+            --github-summary "$GITHUB_STEP_SUMMARY"
+
+  release-mode:
+    name: Select CI execution mode
+    needs: [release-classification]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      mode: ${{ steps.select.outputs.mode }}
+      previous_revision: ${{ needs.release-classification.outputs.version_only_previous_revision }}
+      release_pr: ${{ needs.release-classification.outputs.version_only_release_pr }}
+
+    steps:
+      - name: Normalize release classification
+        id: select
+        env:
+          CLASSIFICATION_RESULT: ${{ needs.release-classification.result }}
+          GENERATED_RELEASE: ${{ needs.release-classification.outputs.generated_release }}
+          VERSION_ONLY_MAIN: ${{ needs.release-classification.outputs.version_only_main }}
+        run: |
+          mode=normal
+          if [[ "$CLASSIFICATION_RESULT" == success ]]; then
+            if [[ "$VERSION_ONLY_MAIN" == true ]]; then
+              mode=version-only-main
+            elif [[ "$GENERATED_RELEASE" == true ]]; then
+              mode=generated-release
+            fi
+          fi
+
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
+          echo "Selected CI mode: $mode" >> "$GITHUB_STEP_SUMMARY"
+
   static-verification:
     name: Static verification
-    needs: [release-classification]
+    needs: [release-mode]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 40
@@ -117,44 +167,55 @@ jobs:
         uses: ./.github/actions/setup-pnpm
 
       - name: Run static verification
-        if: github.event_name != 'pull_request' || needs.release-classification.outputs.generated_release != 'true'
+        if: always() && (needs.release-mode.result != 'success' || needs.release-mode.outputs.mode == 'normal')
         run: turbo check type build depcruise $SHIPFOX_TURBO_AFFECTED --concurrency="$SHIPFOX_TURBO_CONCURRENCY"
 
       - name: Verify repository and package policies
-        if: github.event_name != 'pull_request' || needs.release-classification.outputs.generated_release != 'true'
+        if: always() && (needs.release-mode.result != 'success' || needs.release-mode.outputs.mode == 'normal')
         run: turbo verify --concurrency="$SHIPFOX_TURBO_CONCURRENCY"
 
       - name: Verify release metadata and publication closure
-        if: github.event_name == 'pull_request' && needs.release-classification.outputs.generated_release == 'true'
+        if: always() && needs.release-mode.result == 'success' && needs.release-mode.outputs.mode != 'normal'
         run: |
           turbo verify --filter=@shipfox/package-release...
           turbo test --filter=@shipfox/package-release...
           pnpm run release:preflight
 
       - name: Summarize verified release CI
-        if: github.event_name == 'pull_request' && needs.release-classification.outputs.generated_release == 'true'
+        if: always() && needs.release-mode.result == 'success' && needs.release-mode.outputs.mode != 'normal'
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ needs.release-mode.outputs.previous_revision || github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          RELEASE_MODE: ${{ needs.release-mode.outputs.mode }}
+          RELEASE_PR_URL: ${{ needs.release-mode.outputs.release_pr }}
         run: |
           {
-            echo '## Verified generated release CI'
+            if [[ "$RELEASE_MODE" == version-only-main ]]; then
+              echo '## Verified version-only main CI'
+              echo
+              echo '- Classification: `version-only-main` (deterministic tree verification passed)'
+              echo "- Generated release PR: ${RELEASE_PR_URL:-unavailable}"
+              echo "- Prior validated revision: \`${BASE_SHA}\`"
+            else
+              echo '## Verified generated release CI'
+              echo
+              echo '- Classification: `generated-release` (deterministic tree verification passed)'
+            fi
             echo
-            echo '- Classification: `generated-release` (deterministic tree verification passed)'
             echo '- Files in release:'
             git diff --name-only "$BASE_SHA" "$HEAD_SHA" | sed 's/^/  - `/' | sed 's/$/`/'
             echo '- Package directories changed:'
             git diff --name-only "$BASE_SHA" "$HEAD_SHA" | awk -F/ '/^(libs|tools)\// {print $1 "/" $2}' | sort -u | sed 's/^/  - `/' | sed 's/$/`/'
             echo '- Checks run: frozen dependency install, package-release policy checks and tests, whole-closure `release:preflight`.'
-            echo '- Checks intentionally skipped: unit/story suite, E2E suite, and application image matrix.'
+            echo '- Checks intentionally skipped: unit/story suite, E2E suite, application image rebuilds, and Packer runner candidates.'
             echo '- Preflight result: passed.'
             echo '- Expected comparison: under 5 minutes and under 7.65 runner-minutes, versus the 13-minute / 51 runner-minute baseline.'
           } >> "$GITHUB_STEP_SUMMARY"
 
   external-package-contracts:
     name: Verify external package contracts
-    needs: [release-classification]
-    if: always() && (github.event_name != 'pull_request' || needs.release-classification.outputs.generated_release != 'true')
+    needs: [release-mode]
+    if: always() && (needs.release-mode.result != 'success' || needs.release-mode.outputs.mode == 'normal')
     runs-on: ubuntu-latest
     timeout-minutes: 40
     env:
@@ -191,8 +252,8 @@ jobs:
 
   publication-preflight:
     name: Package publication preflight
-    needs: [release-classification]
-    if: always() && (github.event_name != 'pull_request' || needs.release-classification.outputs.generated_release != 'true')
+    needs: [release-mode]
+    if: always() && (needs.release-mode.result != 'success' || needs.release-mode.outputs.mode == 'normal')
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -213,8 +274,8 @@ jobs:
 
   tests:
     name: Unit and story tests
-    needs: [release-classification]
-    if: always() && (github.event_name != 'pull_request' || needs.release-classification.outputs.generated_release != 'true')
+    needs: [release-mode]
+    if: always() && (needs.release-mode.result != 'success' || needs.release-mode.outputs.mode == 'normal')
     runs-on: ubuntu-latest
     timeout-minutes: 40
     env:
@@ -255,8 +316,8 @@ jobs:
 
   e2e:
     name: E2E tests
-    needs: [release-classification]
-    if: always() && (github.event_name != 'pull_request' || needs.release-classification.outputs.generated_release != 'true')
+    needs: [release-mode]
+    if: always() && (needs.release-mode.result != 'success' || needs.release-mode.outputs.mode == 'normal')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -327,8 +388,8 @@ jobs:
   # permission. Main publishes images in `publish-images`.
   build-image:
     name: Build image (${{ matrix.image }})
-    needs: [release-classification]
-    if: always() && github.ref != 'refs/heads/main' && (github.event_name != 'pull_request' || needs.release-classification.outputs.generated_release != 'true')
+    needs: [release-mode]
+    if: always() && github.ref != 'refs/heads/main' && (needs.release-mode.result != 'success' || needs.release-mode.outputs.mode == 'normal')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -337,14 +398,19 @@ jobs:
         include: &app_image_matrix
           - package: "@shipfox/api"
             image: api
+            repository: ghcr.io/shipfoxhq/api
           - package: "@shipfox/client"
             image: client
+            repository: ghcr.io/shipfoxhq/client
           - package: "@shipfox/provisioner-docker"
             image: provisioner-docker
+            repository: ghcr.io/shipfoxhq/provisioner-docker
           - package: "@shipfox/provisioner-ec2"
             image: provisioner-ec2
+            repository: ghcr.io/shipfoxhq/provisioner-ec2
           - package: "@shipfox/runner"
             image: runner
+            repository: ghcr.io/shipfoxhq/runner
 
     steps:
       - name: Check out repository
@@ -370,7 +436,7 @@ jobs:
 
   build-images:
     name: Build images
-    needs: [release-classification, build-image]
+    needs: [release-mode, build-image]
     if: always() && github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -382,7 +448,7 @@ jobs:
             echo "Image validation matrix completed."
             exit 0
           fi
-          if [ "${{ needs.release-classification.outputs.generated_release }}" = "true" ] && [ "${{ needs.build-image.result }}" = "skipped" ]; then
+          if [ "${{ needs.release-mode.result }}" = "success" ] && [ "${{ needs.release-mode.outputs.mode }}" = "generated-release" ] && [ "${{ needs.build-image.result }}" = "skipped" ]; then
             echo "Image validation matrix intentionally skipped for a verified generated release PR."
             exit 0
           fi
@@ -396,8 +462,14 @@ jobs:
   # cache instead of inheriting artifacts from less-privileged jobs.
   publish-images:
     name: Publish app image (${{ matrix.image }})
-    needs: [static-verification, external-package-contracts, tests, e2e]
-    if: github.ref == 'refs/heads/main'
+    needs: [release-mode, static-verification, external-package-contracts, tests, e2e]
+    if: >-
+      always() && github.ref == 'refs/heads/main' &&
+      needs.release-mode.result == 'success' &&
+      needs.static-verification.result == 'success' &&
+      (needs.external-package-contracts.result == 'success' || (needs.release-mode.outputs.mode == 'version-only-main' && needs.external-package-contracts.result == 'skipped')) &&
+      (needs.tests.result == 'success' || needs.tests.result == 'skipped') &&
+      (needs.e2e.result == 'success' || needs.e2e.result == 'skipped')
     runs-on: ubuntu-latest
     # Multi-arch: linux/arm64 builds under QEMU emulation, slow on a cold gha BuildKit
     # cache (the runner image's apt layer most of all); the cache makes later runs fast.
@@ -414,28 +486,102 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
+      - name: Set up ORAS
+        uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2
+        with:
+          version: 1.3.3
+
       - name: Set up mise
+        if: needs.release-mode.outputs.mode != 'version-only-main'
         uses: ./.github/actions/setup-mise
         with:
           tools: node npm:pnpm npm:turbo
 
       - name: Set up pnpm
+        if: needs.release-mode.outputs.mode != 'version-only-main'
         uses: ./.github/actions/setup-pnpm
 
       - name: Set up QEMU
+        if: needs.release-mode.outputs.mode != 'version-only-main'
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
 
       - name: Set up Docker Buildx
+        if: needs.release-mode.outputs.mode != 'version-only-main'
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Log in to GHCR
+        if: needs.release-mode.outputs.mode != 'version-only-main'
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Log in to GHCR for ORAS
+        run: |
+          set -euo pipefail
+          printf '%s' "${{ secrets.GITHUB_TOKEN }}" \
+            | oras login ghcr.io --username "${{ github.actor }}" --password-stdin
+
+      - name: Resolve existing application image for this revision
+        id: existing-image
+        if: needs.release-mode.outputs.mode != 'version-only-main'
+        env:
+          APPLICATION_IMAGE_REPOSITORY: ${{ matrix.repository }}
+        run: |
+          set -euo pipefail
+          revision_reference="$APPLICATION_IMAGE_REPOSITORY:revision-$GITHUB_SHA"
+          resolve_error="$(mktemp)"
+          trap 'rm -f "$resolve_error"' EXIT
+
+          set +e
+          existing_digest="$(oras resolve "$revision_reference" 2>"$resolve_error")"
+          resolve_status=$?
+          set -e
+
+          if (( resolve_status == 0 )); then
+            if [[ ! "$existing_digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+              echo "Existing application image revision tag returned an invalid digest: $revision_reference -> $existing_digest" >&2
+              exit 1
+            fi
+            echo "digest=$existing_digest" >> "$GITHUB_OUTPUT"
+          elif grep -Eiq 'manifest unknown|not found|404' "$resolve_error"; then
+            echo 'digest=' >> "$GITHUB_OUTPUT"
+          else
+            cat "$resolve_error" >&2
+            exit "$resolve_status"
+          fi
+
+      - name: Reuse previous application image digest
+        if: needs.release-mode.outputs.mode == 'version-only-main'
+        env:
+          APPLICATION_IMAGE_REPOSITORY: ${{ matrix.repository }}
+          PREVIOUS_REVISION: ${{ needs.release-mode.outputs.previous_revision }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$PREVIOUS_REVISION" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "The version-only classifier did not provide a valid prior revision: $PREVIOUS_REVISION" >&2
+            exit 1
+          fi
+
+          previous_reference="$APPLICATION_IMAGE_REPOSITORY:revision-$PREVIOUS_REVISION"
+          digest="$(oras resolve "$previous_reference")"
+          if [[ ! "$digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+            echo "The prior application image revision tag did not resolve to an immutable digest: $previous_reference -> $digest" >&2
+            exit 1
+          fi
+
+          for tag in "revision-$GITHUB_SHA" "sha-${GITHUB_SHA:0:7}" "build-$GITHUB_RUN_NUMBER" latest; do
+            oras tag "$APPLICATION_IMAGE_REPOSITORY@$digest" "$tag"
+          done
+
+          {
+            echo "- Reused \`$APPLICATION_IMAGE_REPOSITORY@$digest\` from revision \`$PREVIOUS_REVISION\`."
+            echo "- New tags: \`revision-$GITHUB_SHA\`, \`sha-${GITHUB_SHA:0:7}\`, \`build-$GITHUB_RUN_NUMBER\`, and \`latest\`."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Build and push images
+        if: needs.release-mode.outputs.mode != 'version-only-main' && steps.existing-image.outputs.digest == ''
         env:
           BUILD_NUMBER: ${{ github.run_number }}
         run: |
@@ -449,10 +595,42 @@ jobs:
           export IMAGE_REGISTRIES="ghcr.io/$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
           turbo image --filter "${{ matrix.package }}"
 
+      - name: Retag existing application image for this revision
+        if: needs.release-mode.outputs.mode != 'version-only-main' && steps.existing-image.outputs.digest != ''
+        env:
+          APPLICATION_IMAGE_REPOSITORY: ${{ matrix.repository }}
+          EXISTING_IMAGE_DIGEST: ${{ steps.existing-image.outputs.digest }}
+        run: |
+          set -euo pipefail
+          for tag in "sha-${GITHUB_SHA:0:7}" "build-$GITHUB_RUN_NUMBER" latest; do
+            oras tag "$APPLICATION_IMAGE_REPOSITORY@$EXISTING_IMAGE_DIGEST" "$tag"
+          done
+
+      - name: Claim immutable application image revision tag
+        if: needs.release-mode.outputs.mode != 'version-only-main' && steps.existing-image.outputs.digest == ''
+        env:
+          APPLICATION_IMAGE_REPOSITORY: ${{ matrix.repository }}
+        run: |
+          set -euo pipefail
+          build_reference="$APPLICATION_IMAGE_REPOSITORY:build-$GITHUB_RUN_NUMBER"
+          digest="$(oras resolve "$build_reference")"
+          if [[ ! "$digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+            echo "The current application image did not resolve to an immutable digest: $build_reference -> $digest" >&2
+            exit 1
+          fi
+          oras tag "$APPLICATION_IMAGE_REPOSITORY@$digest" "revision-$GITHUB_SHA"
+
   publish-runner-image-candidate:
     name: Publish runner image candidate (${{ matrix.architecture }})
-    needs: [static-verification, external-package-contracts, tests, e2e]
-    if: github.ref == 'refs/heads/main'
+    needs: [release-mode, static-verification, external-package-contracts, tests, e2e]
+    if: >-
+      always() && github.ref == 'refs/heads/main' &&
+      needs.release-mode.result == 'success' &&
+      needs.release-mode.outputs.mode == 'normal' &&
+      needs.static-verification.result == 'success' &&
+      needs.external-package-contracts.result == 'success' &&
+      needs.tests.result == 'success' &&
+      needs.e2e.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 90
     strategy:
@@ -516,7 +694,7 @@ jobs:
 
   publish-application-release:
     name: Publish application release
-    needs: [publish-images]
+    needs: [release-mode, publish-images]
     if: github.ref == 'refs/heads/main' && needs.publish-images.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -583,8 +761,14 @@ jobs:
         if: steps.application-release.outputs.digest == ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PREVIOUS_REVISION: ${{ needs.release-mode.outputs.previous_revision }}
+          VERSION_ONLY_MAIN: ${{ needs.release-mode.outputs.mode == 'version-only-main' }}
         run: |
           build_started_at="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" --jq '.run_started_at')"
+          reuse_args=()
+          if [[ "$VERSION_ONLY_MAIN" == "true" ]]; then
+            reuse_args=(--reuse-from-revision "$PREVIOUS_REVISION")
+          fi
 
           node tools/application-release/bin/application-release.js create \
             --source-repository "https://github.com/$GITHUB_REPOSITORY" \
@@ -596,6 +780,7 @@ jobs:
             --build-started-at "$build_started_at" \
             --build-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
             --image-tag "build-$GITHUB_RUN_NUMBER" \
+            "${reuse_args[@]}" \
             --output application-release.json
 
           published_at="$(jq -r '.publishedAt' application-release.json)"

--- a/docs/guides/release-pr-ci.md
+++ b/docs/guides/release-pr-ci.md
@@ -7,3 +7,25 @@ The fast path keeps the required `Static verification`, `Unit and story tests`, 
 Any verification error, timeout, malformed result, source edit, or other mismatch fails closed to the normal CI path.
 
 To force full CI for every PR temporarily, set the repository Actions variable `FORCE_FULL_CI` to `true`.
+
+## Version-only commits on `main`
+
+After a verified release PR merges, `CI` classifies the resulting `main`
+commit from its GitHub pull request metadata and complete tree. The classifier
+also checks the first parent revision. It does not trust the commit title,
+branch, or author on its own.
+
+When the tree matches the generated Changesets output:
+
+- package-release verification and publication preflight still run;
+- unit and Storybook tests, E2E tests, and Packer runner candidates are skipped;
+- each application image gets an immutable full-revision tag on its first
+  successful build, and reruns or version-only commits retag from that digest;
+- the application-release manifest records the prior image revision in
+  `artifactReuse`.
+
+If GitHub metadata, the parent revision, generated tree, or any prior image
+digest cannot be resolved, the workflow uses normal validation or fails before
+publishing an incomplete application release. Ordinary source, configuration,
+dependency, Dockerfile, Packer, workflow, or application metadata changes keep
+the full `main` pipeline.

--- a/tools/application-release/README.md
+++ b/tools/application-release/README.md
@@ -87,6 +87,10 @@ The first successful publish owns the full source revision tag. A workflow
 rerun reuses that artifact and only moves `latest`, so the revision tag does
 not change.
 
+Version-only `main` commits reuse the previous commit's immutable image
+digests. Their manifest keeps the new source revision and records the previous
+image revision in `artifactReuse` with reason `version-only-main-commit`.
+
 `build.startedAt` records when CI starts. `publishedAt` records when all image
 checks finish.
 

--- a/tools/application-release/schema/v1.schema.json
+++ b/tools/application-release/schema/v1.schema.json
@@ -31,6 +31,7 @@
       }
     },
     "publishedAt": { "$ref": "#/$defs/timestamp" },
+    "artifactReuse": { "$ref": "#/$defs/artifactReuse" },
     "images": {
       "type": "object",
       "additionalProperties": false,
@@ -77,6 +78,15 @@
       "pattern": "^https://[^\\s/?#]+(?:[/?#][^\\s]*)?$"
     },
     "revision": { "type": "string", "pattern": "^[a-f0-9]{40}$" },
+    "artifactReuse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fromRevision", "reason"],
+      "properties": {
+        "fromRevision": { "$ref": "#/$defs/revision" },
+        "reason": { "const": "version-only-main-commit" }
+      }
+    },
     "digest": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
     "attestation": {
       "oneOf": [

--- a/tools/application-release/src/cli.ts
+++ b/tools/application-release/src/cli.ts
@@ -10,6 +10,7 @@ import {
 } from './package-closure.js';
 
 const POSITIVE_DECIMAL_PATTERN = /^[1-9]\d*$/;
+const REVISION_PATTERN = /^[a-f0-9]{40}$/;
 
 export interface CreateOptions {
   sourceRepository: string;
@@ -21,6 +22,7 @@ export interface CreateOptions {
   buildStartedAt: string;
   buildUrl: string;
   imageTag: string;
+  reuseFromRevision?: string;
   output: string;
   publicationConfig: string;
 }
@@ -40,6 +42,7 @@ export function parseCreateOptions(args: string[]): CreateOptions {
       'build-started-at': {type: 'string'},
       'build-url': {type: 'string'},
       'image-tag': {type: 'string'},
+      'reuse-from-revision': {type: 'string'},
       output: {type: 'string'},
       'publication-config': {type: 'string'},
     },
@@ -47,6 +50,11 @@ export function parseCreateOptions(args: string[]): CreateOptions {
 
   if (positionals.length !== 1 || positionals[0] !== 'create') {
     throw new Error('Usage: shipfox-application-release create [options]');
+  }
+
+  const reuseFromRevision = values['reuse-from-revision'];
+  if (reuseFromRevision && !REVISION_PATTERN.test(reuseFromRevision)) {
+    throw new Error('--reuse-from-revision must be a 40-character lowercase Git revision');
   }
 
   return {
@@ -59,13 +67,19 @@ export function parseCreateOptions(args: string[]): CreateOptions {
     buildStartedAt: required(values['build-started-at'], '--build-started-at'),
     buildUrl: required(values['build-url'], '--build-url'),
     imageTag: required(values['image-tag'], '--image-tag'),
+    reuseFromRevision,
     output: required(values.output, '--output'),
     publicationConfig: values['publication-config'] ?? 'publication-closure.json',
   };
 }
 
 export function createApplicationRelease(options: CreateOptions): void {
-  const images = resolveApplicationImages(options.imageTag, options.revision);
+  const images = resolveApplicationImages(
+    options.imageTag,
+    options.revision,
+    undefined,
+    options.reuseFromRevision,
+  );
   const publicationConfigPath = resolve(options.publicationConfig);
   const repositoryRoot = dirname(publicationConfigPath);
   const packages = createApplicationReleasePackages(
@@ -87,6 +101,14 @@ export function createApplicationRelease(options: CreateOptions): void {
     publishedAt: new Date().toISOString(),
     images,
     packages,
+    ...(options.reuseFromRevision
+      ? {
+          artifactReuse: {
+            fromRevision: options.reuseFromRevision,
+            reason: 'version-only-main-commit' as const,
+          },
+        }
+      : {}),
   });
 
   writeFileSync(options.output, `${JSON.stringify(manifest, null, 2)}\n`);

--- a/tools/application-release/src/manifest.ts
+++ b/tools/application-release/src/manifest.ts
@@ -57,6 +57,12 @@ export interface ApplicationReleaseInput {
   publishedAt: string;
   images: ApplicationImageSet;
   packages: ApplicationReleasePackage[];
+  artifactReuse?: ApplicationReleaseReuse;
+}
+
+export interface ApplicationReleaseReuse {
+  fromRevision: string;
+  reason: 'version-only-main-commit';
 }
 
 export interface ApplicationReleaseManifest {
@@ -70,6 +76,7 @@ export interface ApplicationReleaseManifest {
   publishedAt: string;
   images: ApplicationImageSet;
   packages: ApplicationReleasePackage[];
+  artifactReuse?: ApplicationReleaseReuse;
 }
 
 const validateManifest = createManifestValidator();
@@ -91,6 +98,7 @@ export function createApplicationReleaseManifest(
     publishedAt: timestamp(input.publishedAt, 'Publication time'),
     images: input.images,
     packages: input.packages,
+    ...(input.artifactReuse ? {artifactReuse: input.artifactReuse} : {}),
   };
 
   if (!validateManifest(manifest)) {

--- a/tools/application-release/src/oci.ts
+++ b/tools/application-release/src/oci.ts
@@ -40,12 +40,19 @@ export function resolveApplicationImages(
   tag: string,
   revision: string,
   registry: OciRegistry = orasRegistry(),
+  imageRevision = revision,
 ): ApplicationImageSet {
   return {
-    api: resolveImage(APPLICATION_RELEASE_IMAGES.api, tag, revision, registry),
-    client: resolveImage(APPLICATION_RELEASE_IMAGES.client, tag, revision, registry),
-    provisioner: resolveImage(APPLICATION_RELEASE_IMAGES.provisioner, tag, revision, registry),
-    runner: resolveImage(APPLICATION_RELEASE_IMAGES.runner, tag, revision, registry),
+    api: resolveImage(APPLICATION_RELEASE_IMAGES.api, tag, revision, registry, imageRevision),
+    client: resolveImage(APPLICATION_RELEASE_IMAGES.client, tag, revision, registry, imageRevision),
+    provisioner: resolveImage(
+      APPLICATION_RELEASE_IMAGES.provisioner,
+      tag,
+      revision,
+      registry,
+      imageRevision,
+    ),
+    runner: resolveImage(APPLICATION_RELEASE_IMAGES.runner, tag, revision, registry, imageRevision),
   };
 }
 
@@ -54,6 +61,7 @@ export function resolveImage(
   tag: string,
   revision: string,
   registry: OciRegistry,
+  imageRevision = revision,
 ): ApplicationImage {
   const taggedReference = `${repository}:${tag}`;
   const descriptor = registry.fetchDescriptor(taggedReference);
@@ -79,9 +87,9 @@ export function resolveImage(
     const actualRevision = config.config?.Labels?.['org.opencontainers.image.revision'];
     const platform = platformName(platformDescriptor.platform);
 
-    if (actualRevision !== revision) {
+    if (actualRevision !== imageRevision) {
       throw new Error(
-        `${taggedReference} (${platform}) has OCI revision ${JSON.stringify(actualRevision)}; expected ${revision}`,
+        `${taggedReference} (${platform}) has OCI revision ${JSON.stringify(actualRevision)}; expected ${imageRevision}`,
       );
     }
 

--- a/tools/application-release/test/cli.test.mjs
+++ b/tools/application-release/test/cli.test.mjs
@@ -52,6 +52,13 @@ describe('parseCreateOptions', () => {
     assert.equal(options.publicationConfig, '/tmp/publication-closure.json');
   });
 
+  test('accepts an artifact reuse source revision', () => {
+    const revision = 'fedcba9876543210fedcba9876543210fedcba98';
+    const options = parseCreateOptions([...args(), '--reuse-from-revision', revision]);
+
+    assert.equal(options.reuseFromRevision, revision);
+  });
+
   test('rejects a missing required argument', () => {
     const input = args();
     input.splice(input.indexOf('--revision'), 2);

--- a/tools/application-release/test/manifest.test.mjs
+++ b/tools/application-release/test/manifest.test.mjs
@@ -75,6 +75,22 @@ describe('createApplicationReleaseManifest', () => {
     assert.equal('publication' in manifest, false);
   });
 
+  test('records the source revision when application artifacts are reused', () => {
+    const manifest = createApplicationReleaseManifest({
+      ...input(),
+      artifactReuse: {
+        fromRevision: 'fedcba9876543210fedcba9876543210fedcba98',
+        reason: 'version-only-main-commit',
+      },
+    });
+
+    assert.deepEqual(manifest.artifactReuse, {
+      fromRevision: 'fedcba9876543210fedcba9876543210fedcba98',
+      reason: 'version-only-main-commit',
+    });
+    assert.equal(validateManifest(manifest), true, JSON.stringify(validateManifest.errors));
+  });
+
   test('matches the strict version 1 schema', () => {
     const manifest = createApplicationReleaseManifest(input());
 

--- a/tools/application-release/test/oci.test.mjs
+++ b/tools/application-release/test/oci.test.mjs
@@ -4,6 +4,7 @@ import {describe, test} from 'node:test';
 import {resolveApplicationImages} from '../dist/oci.js';
 
 const revision = '0123456789abcdef0123456789abcdef01234567';
+const reusedRevision = 'fedcba9876543210fedcba9876543210fedcba98';
 const digest = (character) => `sha256:${character.repeat(64)}`;
 const mismatchedRevisionError = /has OCI revision "other-revision"; expected 0123456789abcdef/;
 const multiPlatformError = /must be a multi-platform OCI image index/;
@@ -81,6 +82,17 @@ describe('resolveApplicationImages', () => {
       resolveApplicationImages('build-42', revision, registry({labelRevision: 'other-revision'}));
 
     assert.throws(resolve, mismatchedRevisionError);
+  });
+
+  test('accepts a reused image revision when it is explicitly provided', () => {
+    const images = resolveApplicationImages(
+      'build-42',
+      revision,
+      registry({labelRevision: reusedRevision}),
+      reusedRevision,
+    );
+
+    assert.equal(images.api.digest, digest('a'));
   });
 
   test('rejects a single-platform image manifest', () => {

--- a/tools/package-release/test/package-release-workflow.test.ts
+++ b/tools/package-release/test/package-release-workflow.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import {execFile} from 'node:child_process';
-import {mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
+import {chmod, mkdir, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {dirname, join, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
@@ -16,6 +16,10 @@ const authorizedPattern = /authorized=true/;
 const createdPattern = /"result":"created"/;
 const releasePattern = /revision=release/;
 const releasePrPattern = /Release PR: #42/;
+const versionOnlyMainPattern = /version_only_main=true/;
+const versionOnlyReleasePrPattern =
+  /version_only_release_pr=https:\/\/github\.com\/ShipfoxHQ\/shipfox\/pull\/999/;
+const versionOnlySummaryPattern = /version-only/;
 
 describe('package release workflow tool', () => {
   test('authorizes only merged release-App pull requests from the release branch', async () => {
@@ -83,4 +87,72 @@ describe('package release workflow tool', () => {
       await rm(temporaryRoot, {force: true, recursive: true});
     }
   });
+
+  test('classifies a main commit only after merged release metadata and tree verification', async () => {
+    const temporaryRoot = await mkdtemp(join(tmpdir(), 'shipfox-main-classification-test-'));
+    const binDirectory = join(temporaryRoot, 'bin');
+    const outputPath = join(temporaryRoot, 'output');
+    const summaryPath = join(temporaryRoot, 'summary');
+    const revision = '0123456789abcdef0123456789abcdef01234567';
+    const previousRevision = 'fedcba9876543210fedcba9876543210fedcba98';
+    const pullRequest = JSON.stringify([
+      {
+        base: {ref: 'main'},
+        head: {ref: 'changeset-release/main', repo: {full_name: 'ShipfoxHQ/shipfox'}},
+        html_url: 'https://github.com/ShipfoxHQ/shipfox/pull/999',
+        merge_commit_sha: revision,
+        merged_at: '2026-07-23T10:00:00Z',
+        number: 999,
+        user: {id: 123},
+      },
+    ]);
+
+    try {
+      await mkdir(binDirectory);
+      await writeExecutable(
+        join(binDirectory, 'git'),
+        `#!/bin/sh\nprintf '%s\\n' '${previousRevision}'\n`,
+      );
+      await writeExecutable(
+        join(binDirectory, 'gh'),
+        `#!/bin/sh\nprintf '%s\\n' '${pullRequest}'\n`,
+      );
+      await writeExecutable(
+        join(binDirectory, 'pnpm'),
+        '#!/bin/sh\nprintf \'%s\\n\' \'{"classification":"generated-release","reason":"generated-tree-matches"}\'\n',
+      );
+
+      await execFileAsync(
+        'node',
+        [
+          workflowTool,
+          'classify-main',
+          '--revision',
+          revision,
+          '--repository',
+          'ShipfoxHQ/shipfox',
+          '--release-app-id',
+          '123',
+          '--github-output',
+          outputPath,
+          '--github-summary',
+          summaryPath,
+        ],
+        {env: {...process.env, PATH: `${binDirectory}:${process.env.PATH}`}},
+      );
+
+      const output = await readFile(outputPath, 'utf8');
+      assert.match(output, versionOnlyMainPattern);
+      assert.match(output, new RegExp(`version_only_previous_revision=${previousRevision}`));
+      assert.match(output, versionOnlyReleasePrPattern);
+      assert.match(await readFile(summaryPath, 'utf8'), versionOnlySummaryPattern);
+    } finally {
+      await rm(temporaryRoot, {force: true, recursive: true});
+    }
+  });
 });
+
+async function writeExecutable(path: string, content: string): Promise<void> {
+  await writeFile(path, content);
+  await chmod(path, 0o755);
+}

--- a/tools/package-release/test/release-ci-workflow.test.ts
+++ b/tools/package-release/test/release-ci-workflow.test.ts
@@ -25,16 +25,43 @@ describe('generated release CI path', () => {
   test('runs normal CI for normal, malformed, and main-push fixture conditions', async () => {
     const workflow = await readWorkflow();
 
+    assert.ok(workflow.includes('mode=normal'));
+    assert.ok(workflow.includes("needs.release-mode.outputs.mode == 'normal'"));
     assert.ok(
       workflow.includes(
-        "github.event_name != 'pull_request' || needs.release-classification.outputs.generated_release != 'true'",
+        "needs.release-mode.result != 'success' || needs.release-mode.outputs.mode == 'normal'",
+      ),
+    );
+  });
+
+  test('classifies version-only main commits and reuses immutable image digests', async () => {
+    const workflow = await readWorkflow();
+
+    assert.ok(workflow.includes('classify-main'));
+    assert.ok(workflow.includes('package-release-workflow.mjs classify-main'));
+    assert.ok(workflow.includes('release-mode:'));
+    assert.ok(workflow.includes('mode=version-only-main'));
+    assert.ok(workflow.includes('version_only_previous_revision'));
+    assert.ok(workflow.includes('Reuse previous application image digest'));
+    assert.ok(workflow.includes("needs.release-mode.outputs.mode == 'version-only-main'"));
+    assert.ok(
+      workflow.includes(
+        "needs.release-mode.outputs.mode == 'version-only-main' && needs.external-package-contracts.result == 'skipped'",
       ),
     );
     assert.ok(
       workflow.includes(
-        "always() && (github.event_name != 'pull_request' || needs.release-classification.outputs.generated_release != 'true')",
+        'previous_reference="$APPLICATION_IMAGE_REPOSITORY:revision-$PREVIOUS_REVISION"',
       ),
     );
+    assert.ok(workflow.includes('for tag in "revision-$GITHUB_SHA" "sha-$' + '{GITHUB_SHA:0:7}"'));
+    assert.ok(workflow.includes('revision-$GITHUB_SHA'));
+    assert.ok(workflow.includes('Claim immutable application image revision tag'));
+    assert.ok(workflow.includes('Retag existing application image for this revision'));
+    assert.ok(!workflow.includes('previous_reference="$APPLICATION_IMAGE_REPOSITORY:sha-'));
+    assert.ok(workflow.includes('oras tag "$APPLICATION_IMAGE_REPOSITORY@$digest"'));
+    assert.ok(workflow.includes('--reuse-from-revision "$PREVIOUS_REVISION"'));
+    assert.ok(workflow.includes('application image rebuilds, and Packer runner candidates'));
   });
 
   test('keeps required checks successful when the image matrix is intentionally skipped', async () => {
@@ -45,7 +72,7 @@ describe('generated release CI path', () => {
     assert.ok(workflow.includes('name: E2E tests'));
     assert.ok(workflow.includes('name: Build images'));
     assert.ok(
-      workflow.includes('needs.release-classification.outputs.generated_release }}" = "true"') &&
+      workflow.includes('needs.release-mode.outputs.mode }}" = "generated-release"') &&
         workflow.includes('needs.build-image.result }}" = "skipped"'),
     );
   });


### PR DESCRIPTION
Verified Changesets release merges currently rerun application validation and rebuild runtime images even when the merged tree only updates package versions and changelogs. This adds deterministic version-only main classification and routes CI through an explicit release mode so unchanged runtime work can be skipped safely.

Version-only commits reuse immutable full-revision image digests, create the new per-commit tags by digest, and record the reuse source in the application-release manifest. Classifier failures fall back to normal validation, while missing or invalid image artifacts fail before publication.

The workflow keeps package-release verification and publication preflight, and the release documentation explains the mode selection and artifact reuse behavior. A small routing job keeps downstream conditions readable and centralizes the fail-closed policy.

Closes ENG-1171

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip rebuilding unchanged application images for verified, version-only Changesets merges into main. CI now classifies these commits, reuses the previous immutable image digests, and records provenance in the application-release manifest (implements ENG-1171).

- **New Features**
  - Added a main commit classifier and a release-mode selector with `normal`, `generated-release`, and `version-only-main`.
  - For `version-only-main`, skip tests and image rebuilds; reuse the prior revision’s image digests and retag (`revision-<sha>`, `sha-<short>`, `build-<run>`, `latest`) via `oras`.
  - Kept package-release checks and `release:preflight`; fail closed to full CI if verification or artifact resolution is incomplete.
  - Extended `@shipfox/application-release` with `artifactReuse` in the manifest and a `--reuse-from-revision` flag; updated schema, CLI, and docs.
  - Built and used the generated-release verifier in CI; updated tests and workflow logic under `@shipfox/package-release`.

<sup>Written for commit 498d3d4157e900861a542f41dd3903afcc9d52e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

