### PR TITLE
Define database ownership boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ here, use the full [engineering documentation map](docs/README.md).
 | Changes a published package or prepares a release. | [Changesets and publishing workflow](docs/guides/local-development-and-release-workflow.md#publish-packages-with-changesets) | Changeset rules, version bumps, summaries, and publishing. |
 | Adds, updates, or exempts a dependency. | [Dependency version policy](docs/policies/dependency-versions.md) | Version rules, exceptions, package families, and dependency checks. |
 | Adds or changes a backend module, DTO, outbox event, HTTP boundary, or server package dependency. | [Backend architecture](docs/architecture/backend-architecture.md) | The current backend module model and package-boundary rules. |
+| Adds or changes a table, migration, database query, foreign key, or transaction. | [Database boundary policy](docs/policies/database-boundaries.md) | Database ownership, access, naming, migration, and enforcement rules. |
 | Changes client state, API adapters, or feature boundaries. | [Client architecture](docs/architecture/client-architecture.md) | The current client model and architecture checks. |
 | Adds or changes a client form. | [Client form guidance](docs/architecture/client-architecture.md#forms) | Form state, validation, fields, server errors, and saved drafts. |
 | Adds or changes an environment variable, validator, or environment description. | [Configuration policy](docs/policies/configuration.md) | Configuration ownership, validation, and description rules. |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,7 @@ here, use the full [engineering documentation map](docs/README.md).
 | Changes a published package or prepares a release. | [Changesets and publishing workflow](docs/guides/local-development-and-release-workflow.md#publish-packages-with-changesets) | Changeset rules, version bumps, summaries, and publishing. |
 | Adds, updates, or exempts a dependency. | [Dependency version policy](docs/policies/dependency-versions.md) | Version rules, exceptions, package families, and dependency checks. |
 | Adds or changes a backend module, DTO, outbox event, HTTP boundary, or server package dependency. | [Backend architecture](docs/architecture/backend-architecture.md) | The current backend module model and package-boundary rules. |
+| Adds or changes a table, migration, database query, foreign key, or transaction. | [Database boundary policy](docs/policies/database-boundaries.md) | Database ownership, access, naming, migration, and enforcement rules. |
 | Changes client state, API adapters, or feature boundaries. | [Client architecture](docs/architecture/client-architecture.md) | The current client model and architecture checks. |
 | Adds or changes a client form. | [Client form guidance](docs/architecture/client-architecture.md#forms) | Form state, validation, fields, server errors, and saved drafts. |
 | Adds or changes an environment variable, validator, or environment description. | [Configuration policy](docs/policies/configuration.md) | Configuration ownership, validation, and description rules. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,9 @@ listed there or when you need to place, update, or review documentation.
 | Adds, updates, or exempts a dependency. | [Dependency version policy](policies/dependency-versions.md) | Version ranges, exceptions, coordinated package families, and dependency checks. |
 | Changes a cross-package client composition seam. | [ADR 0001](adr/0001-client-composition-contract.md) | The public client composition contract and its decision rationale. |
 | Changes server module boundaries or an inter-module call. | [ADR 0002](adr/0002-api-inter-module-architecture.md) | Producer-owned inter-module contracts and bounded-context crossings. |
+| Changes database ownership, cross-module persistence access, or namespace rules. | [ADR 0006](adr/0006-database-ownership-boundaries.md) | The decision and tradeoffs behind owner-only database access. |
 | Adds or changes a backend module, DTO, outbox event, HTTP boundary, or server package dependency. | [Backend architecture](architecture/backend-architecture.md) | The current backend module model and package-boundary rules. |
+| Adds or changes a table, migration, database query, foreign key, or transaction. | [Database boundary policy](policies/database-boundaries.md) | Database ownership, access, naming, migration, and enforcement rules. |
 | Adds or changes an environment variable, validator, or environment description. | [Configuration policy](policies/configuration.md) | Repository-wide configuration ownership, validation, and description rules. |
 | Adds a domain or provider error, translates a request failure, or reports an unexpected failure. | [Error handling](architecture/error-handling.md) | The current backend error model, client translation, and reporting boundaries. |
 | Adds a metric or changes instrumentation startup, naming, units, or labels. | [Observability](architecture/observability.md) | The current backend metrics model and cardinality constraints. |

--- a/docs/adr/0002-api-inter-module-architecture.md
+++ b/docs/adr/0002-api-inter-module-architecture.md
@@ -6,6 +6,7 @@
 - **Decision issue:** [Define the server inter-module architecture](https://linear.app/shipfox/issue/ENG-1032/define-the-api-inter-module-architecture-and-bounded-context-policy).
 - **Foundation delivery:** [Build the registered in-memory transport](https://linear.app/shipfox/issue/ENG-1033/build-the-registered-in-memory-inter-module-transport).
 - **Amended by:** [ADR 0004: Shared semantic packages and server dependency boundaries](0004-shared-semantic-packages-and-server-dependency-boundaries.md).
+- **Amended by:** [ADR 0006: Database ownership boundaries](0006-database-ownership-boundaries.md).
 
 ## Context
 

--- a/docs/adr/0006-database-ownership-boundaries.md
+++ b/docs/adr/0006-database-ownership-boundaries.md
@@ -68,12 +68,13 @@ need a new operation, snapshot, or reporting model.
 a foreign row lock inside an existing transaction. The operation needs one
 owner or an explicit consistency protocol.
 
-**Prefixing becomes a rule.** Existing unprefixed objects need a named legacy
-exception until a safe migration can rename them.
+**Prefixing becomes a rule.** Correct unprefixed objects in the unshipped
+migration baseline before the first deployment. After deployment, a rename
+needs a staged compatibility plan.
 
-**The first static gate has migration work.** Workflows currently re-declares
-and locks Runners-owned lease tables. That access must move behind an
-owner-provided protocol.
+**The first static gate has cleanup work.** The database boundary policy lists
+the pre-deploy baseline. Remove it before the gate becomes a zero-finding
+pull-request check.
 
 ## Rejected alternatives
 

--- a/docs/adr/0006-database-ownership-boundaries.md
+++ b/docs/adr/0006-database-ownership-boundaries.md
@@ -1,0 +1,101 @@
+# Architecture decision record 0006: Database ownership boundaries
+
+- **Status:** Accepted.
+- **Date:** 2026-07-23.
+- **Decision owners:** Server database boundaries.
+- **Amends:** [ADR 0002: Server inter-module architecture](0002-api-inter-module-architecture.md).
+
+## Context
+
+**Shipfox modules share one PostgreSQL database and connection setup.** Local
+Drizzle table creators usually prefix table names. Most prefixes identify the
+module that owns the migrations.
+
+**A naming rule does not enforce ownership.** A consumer can re-declare a
+foreign table with Drizzle. It can also name the table in raw Structured Query
+Language (SQL). Package import checks do not see either form.
+
+**The current documentation permits two readings.** ADR 0002 says a bounded
+context owns its data and transactions never cross contexts. The backend and
+module guides also describe modules that use shared database tables. That
+language leaves direct cross-module reads open.
+
+**Direct reads couple modules to storage details.** A consumer depends on table
+names, columns, migration order, locks, and transaction behavior. The producer
+cannot change its storage without coordinating every reader.
+
+## Decision
+
+**Every stored database object has one owning database module.** The module
+that declares and migrates an object is its owner. Being in the same bounded
+context does not grant access.
+
+**Only the owner queries its objects.** Other modules cannot read, write, join,
+lock, reference, or re-declare an owned table. This rule also covers raw SQL,
+views, triggers, database functions, and foreign keys.
+
+**Each database module has a stable namespace.** Its tables use the namespace
+as a name prefix. Its PostgreSQL types and explicit support object names use
+the same namespace.
+
+**Modules cross the boundary through producer-owned contracts.** A caller uses
+an inter-module operation for current state, an outbox event for a committed
+fact, or Temporal for durable work. Reporting and search use owner-published
+projections or snapshots.
+
+**Transactions never cross database owners.** One owner performs an atomic
+operation. Work that needs tables from two owners must move to one owner or use
+a new consistency protocol.
+
+**The composition root can run all migrations.** This does not grant access to
+business data. Module order starts storage. It does not allow shared table
+access.
+
+**Static checks will enforce the rule.** The repository will register database
+namespaces and audit schema declarations, migrations, foreign references, and
+raw SQL. The [database boundary policy](../policies/database-boundaries.md)
+defines the current rules and exception process.
+
+## Consequences
+
+**A module can change its storage behind its contract.** Consumers depend on
+business operations and published facts instead of table layouts.
+
+**Cross-module joins move behind an owner or into a projection.** Some reads
+need a new operation, snapshot, or reporting model.
+
+**Cross-module atomicity requires redesign.** A remote-style call cannot replace
+a foreign row lock inside an existing transaction. The operation needs one
+owner or an explicit consistency protocol.
+
+**Prefixing becomes a rule.** Existing unprefixed objects need a named legacy
+exception until a safe migration can rename them.
+
+**The first static gate has migration work.** Workflows currently re-declares
+and locks Runners-owned lease tables. That access must move behind an
+owner-provided protocol.
+
+## Rejected alternatives
+
+### Keep prefixing as a convention
+
+**A convention identifies the owner but cannot stop access.** It permits local
+schema copies and raw SQL. Reviews and package import checks can miss both.
+
+### Allow read-only access to foreign tables
+
+**Reads still depend on storage contracts and locks.** A read-only exception
+also tends to grow into joins, transaction coupling, and write requirements.
+
+### Allow access within one bounded context
+
+**A context can contain several independently migrated database modules.**
+Context membership alone does not identify which module can change a table or
+coordinate its migrations.
+
+### Use PostgreSQL roles as the only boundary
+
+**Database roles provide a stronger runtime boundary.** They also add deploy
+and connection-pool complexity. Static checks give earlier feedback and work
+with the current shared connection model. Roles remain a possible later
+defense.

--- a/docs/adr/0006-database-ownership-boundaries.md
+++ b/docs/adr/0006-database-ownership-boundaries.md
@@ -68,12 +68,11 @@ need a new operation, snapshot, or reporting model.
 a foreign row lock inside an existing transaction. The operation needs one
 owner or an explicit consistency protocol.
 
-**Prefixing becomes a rule.** Correct unprefixed objects in the unshipped
-migration baseline before the first deployment. After deployment, a rename
-needs a staged compatibility plan.
+**Prefixing becomes a rule.** Existing unprefixed objects must be renamed.
+Their migration plan must match the database's compatibility needs.
 
-**The first static gate has cleanup work.** The database boundary policy lists
-the pre-deploy baseline. Remove it before the gate becomes a zero-finding
+**The first static gate has cleanup work.** The database boundary policy allows
+exact temporary findings. Remove them before the gate becomes a zero-finding
 pull-request check.
 
 ## Rejected alternatives

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -15,6 +15,7 @@ documentation model and other engineering sources, start with the
 | [0003: Client state and domain architecture](0003-client-state-and-domain-architecture.md) | Accepted | Client state ownership and feature-domain boundaries. |
 | [0004: Shared semantic packages and server dependency boundaries](0004-shared-semantic-packages-and-server-dependency-boundaries.md) | Accepted; amends ADR 0002 | Shared package admission and server dependency boundaries. |
 | [0005: Repository documentation architecture](0005-repository-documentation-architecture.md) | Accepted | Documentation ownership, routing, and progressive disclosure. |
+| [0006: Database ownership boundaries](0006-database-ownership-boundaries.md) | Accepted; amends ADR 0002 | Owner-only database access and stable database namespaces. |
 
 When a decision changes, add a new ADR that supersedes or amends the earlier
 record. Keep the original record intact so readers can understand why the

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -12,9 +12,9 @@ Each backend capability exposes a declarative `ShipfoxModule`. It lists the
 database, routes, auth adapters, E2E routes, publishers, subscribers, workers,
 and metrics it owns. Feature packages do not wire their internals into an app.
 
-The application root puts modules in dependency order. A module that owns a
-shared database table comes before one that uses it. The root alone builds the
-full inter-module graph:
+The application root puts modules in dependency order and runs each module's
+migrations. Migration order does not grant access to another module's tables.
+The root alone builds the full inter-module graph:
 
 1. Create the transport for the application instance.
 2. Create typed clients from producer contracts.
@@ -30,6 +30,10 @@ hooks, or mutable default clients. The current composition lives in
 Read [ADR 0002](../adr/0002-api-inter-module-architecture.md) when changing an
 inter-module contract or its setup order. It owns history, transport behavior,
 and migration reasons.
+
+Read the [database boundary policy](../policies/database-boundaries.md) when
+changing a table, migration, query, foreign key, or transaction. It owns
+database access and naming rules.
 
 ## Feature package layers
 

--- a/docs/policies/database-boundaries.md
+++ b/docs/policies/database-boundaries.md
@@ -119,17 +119,7 @@ The gate must run in pull-request verification. A new exception needs a named
 owner, reason, tracking issue, and removal condition in this policy. Do not add
 a broad path or prefix allowlist.
 
-The pre-deploy remediation baseline contains these known violations:
-
-- Agent has four database object names without the `agent_` prefix.
-- The Workspaces root table is named `workspaces`, not
-  `workspaces_workspaces`.
-- Workflows declares and locks Runners lease tables.
-- Auth test setup migrates and truncates Email Challenges storage.
-- Module migration-history names can depend on a display name or array
-  position instead of the database namespace.
-
-Remove each violation before enabling the gate without a baseline. Because
-there is no deployed database state to preserve, correct unshipped migrations
-and snapshots directly. Do not add compatibility objects or copy these
-patterns.
+The first gate can carry exact temporary entries for known violations. Each
+entry names one object or source location, its tracking issue, and its removal
+condition. New findings fail immediately. Remove entries as fixes land and
+keep the target baseline empty.

--- a/docs/policies/database-boundaries.md
+++ b/docs/policies/database-boundaries.md
@@ -1,0 +1,127 @@
+# Database boundary policy
+
+This policy owns the database rules for the repository. It covers ownership,
+access, and names. Read it when adding or changing a table, migration, query,
+foreign key, transaction, or module database declaration.
+
+[ADR 0006](../adr/0006-database-ownership-boundaries.md) records why Shipfox
+uses owner-only database access. The [backend architecture](../architecture/backend-architecture.md)
+owns the current module and inter-module model.
+
+## Assign one owner
+
+**Every stored database object has one owning database module.** The owner
+declares and migrates the object. A bounded context can contain more than one
+database module. Being in the same context does not grant access to another
+module's tables.
+
+Each database module registers one stable namespace. The namespace:
+
+- Uses lowercase snake case.
+- Matches the module name when the module has one database.
+- Adds a stable qualifier when one module has several databases.
+- Does not change when a package or source directory moves.
+
+Examples include `runners`, `workflows`, `email_challenges`, and
+`integrations_github`.
+
+**Only the owner reads or changes its objects.** No other module can:
+
+- Select from, insert into, update, delete from, or truncate an owned table.
+- Join an owned table or lock one of its rows.
+- Add a foreign key, view, trigger, or database function that reads an owned
+  table.
+- Re-declare an owned table in Drizzle or another query tool.
+- Use raw Structured Query Language (SQL) to bypass the ownership boundary.
+
+The application composition root can run every module's migrations. This
+permission does not let it query business data.
+
+Named shared infrastructure can own stored data. Consumers still use its public
+API. They do not read its tables.
+
+## Name database objects
+
+**Every module-owned table starts with `<database_namespace>_`.** Use the
+module's table creator so the physical prefix is not repeated at each
+declaration.
+
+```ts
+import {pgTableCreator} from 'drizzle-orm/pg-core';
+
+export const pgTable = pgTableCreator((name) => `workflows_${name}`);
+```
+
+Use the same prefix for module-defined PostgreSQL types. Start explicit index,
+constraint, sequence, view, and trigger names with the table name or namespace.
+
+Use the namespace in the Drizzle migration history table:
+
+```text
+__drizzle_migrations_<database_namespace>
+```
+
+PostgreSQL system objects and extension-owned objects are outside this naming
+rule.
+
+The unprefixed `workspaces` table is a legacy exception. Do not copy this
+pattern. Rename it only through a reviewed compatibility plan.
+
+## Cross a database boundary
+
+**Call the owner instead of querying its tables.** Choose the boundary from the
+caller's need:
+
+| Need | Boundary |
+| --- | --- |
+| A current decision or current state | The owner's inter-module operation. |
+| A fact committed by the owner | The owner's outbox event. |
+| A durable wait, retry, timer, or recovery path | A Temporal workflow and owner-provided activity. |
+| Data for reporting or search | An owner-published projection or snapshot. |
+
+Do not expose a database handle, Drizzle schema, row type, query helper, or
+transaction through an inter-module contract.
+
+**Transactions do not cross database owners.** One owner performs every change
+in an atomic operation. Redesign an operation that needs tables from two
+owners. Do not hold one module's transaction open while calling another module.
+
+Store another module's ID as an opaque value when a local record refers to it.
+Do not add a cross-owner foreign key. The producer checks its own IDs through
+its public operation.
+
+## Migrations and tests
+
+**A migration changes only objects in its module's namespace.** It cannot
+create, alter, rename, or drop another module's objects. Moving ownership needs
+an accepted architecture decision and a staged compatibility plan.
+
+Package tests can query and truncate only their module's tables. Application
+integration and end-to-end setup can run all migrations. Business assertions
+still use public module boundaries.
+
+Migration ordering guarantees that every module can initialize its own storage.
+It does not grant a later module access to an earlier module's tables.
+
+## Enforcement
+
+The API architecture and Dependency Cruiser checks enforce package imports.
+They do not yet enforce database ownership or names.
+
+A repository database-boundary gate must use the registered package and
+database namespace inventory to check:
+
+- Drizzle table and PostgreSQL type declarations.
+- Generated migration SQL and Drizzle snapshots.
+- Explicit index, constraint, sequence, view, and trigger names.
+- Foreign keys and other references to a foreign namespace.
+- Raw SQL that names a module-owned object.
+- Direct `pgTable` or `pgTableCreator` use outside the owning schema factory.
+
+The gate must run in pull-request verification. A new exception needs a named
+owner, reason, tracking issue, and removal condition in this policy. Do not add
+a broad path or prefix allowlist.
+
+Workflows currently declares and locks Runners lease tables. This is a known
+violation. Move it to an owner-provided protocol before enabling the gate
+without exceptions. New code cannot copy that pattern.

--- a/docs/policies/database-boundaries.md
+++ b/docs/policies/database-boundaries.md
@@ -64,9 +64,6 @@ __drizzle_migrations_<database_namespace>
 PostgreSQL system objects and extension-owned objects are outside this naming
 rule.
 
-The unprefixed `workspaces` table is a legacy exception. Do not copy this
-pattern. Rename it only through a reviewed compatibility plan.
-
 ## Cross a database boundary
 
 **Call the owner instead of querying its tables.** Choose the boundary from the
@@ -122,6 +119,17 @@ The gate must run in pull-request verification. A new exception needs a named
 owner, reason, tracking issue, and removal condition in this policy. Do not add
 a broad path or prefix allowlist.
 
-Workflows currently declares and locks Runners lease tables. This is a known
-violation. Move it to an owner-provided protocol before enabling the gate
-without exceptions. New code cannot copy that pattern.
+The pre-deploy remediation baseline contains these known violations:
+
+- Agent has four database object names without the `agent_` prefix.
+- The Workspaces root table is named `workspaces`, not
+  `workspaces_workspaces`.
+- Workflows declares and locks Runners lease tables.
+- Auth test setup migrates and truncates Email Challenges storage.
+- Module migration-history names can depend on a display name or array
+  position instead of the database namespace.
+
+Remove each violation before enabling the gate without a baseline. Because
+there is no deployed database state to preserve, correct unshipped migrations
+and snapshots directly. Do not add compatibility objects or copy these
+patterns.

--- a/libs/shared/node/module/README.md
+++ b/libs/shared/node/module/README.md
@@ -41,7 +41,11 @@ const moduleServices = await startModuleServices({services});
 await listen();
 ```
 
-`initializeModules` runs module migrations first. It exposes auth methods and routes after that. Put modules with shared database needs earlier in the array. Call `registerModuleMetrics` once after instrumentation has started and migrations have run, so observable gauges can query shared storage safely.
+`initializeModules` runs module migrations first. It exposes auth methods and
+routes after that. Module order controls migration and initialization. It does
+not grant access to another module's tables. Call `registerModuleMetrics` after
+instrumentation starts and all migrations finish. Observable gauges can then
+query their owning module's storage.
 Worker and service startup failures reject before serving traffic. Call `runModuleStartupTasks` after initialization so migrations complete first. The returned worker handle is idempotent and stops workers before releasing the shared Temporal connection and client. A service handle is also idempotent. It stops services in reverse order and bounds each stop with the service timeout.
 
 ## Module Shape


### PR DESCRIPTION
Shipfox's server architecture says modules own their data, but the backend and module guides also allowed shared-table access. Existing architecture checks enforce package imports without seeing foreign table declarations or raw SQL.

This adds an ADR for the durable owner-only database decision and a canonical policy for namespace prefixes, table access, transactions, migrations, tests, and future static enforcement. It also removes the conflicting shared-table guidance and routes database changes to the new policy.

The database-specific CI gate and remediation remain follow-up work. The policy allows an exact temporary baseline for known findings while ensuring new findings fail immediately. Current violations stay in implementation tracking rather than durable policy.

Repository documentation verification passed for all 103 files. No Changeset is required because the change is documentation-only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Define owner-only database access across modules and introduce stable database namespaces. Adds ADR 0006 and a lifecycle-neutral database boundary policy; clarifies that migration order does not grant access.

- **New Features**
  - Added ADR 0006: owner-only access; no cross-module reads/writes/locks; single-owner transactions; producer-owned contracts; stable namespaces; planned static enforcement and PR gate.
  - Added database boundary policy: namespace and object naming; boundary-crossing guidance; migration and test scope; enforcement plan with precise temporary exceptions; lifecycle-neutral wording.
  - Updated docs map, backend architecture, `AGENTS.md`, `CONTRIBUTING.md`, and module README to route DB work to the policy; ADR 0002 amended to link ADR 0006; clarified the app root can run all migrations without data access.

<sup>Written for commit af908c0e734669e3c868f0296da0ea3850b10d20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

