### PR TITLE
Enforce feature-owned navigation and settings composition

### DIFF
--- a/.changeset/bright-features-compose.md
+++ b/.changeset/bright-features-compose.md
@@ -1,0 +1,13 @@
+---
+"@shipfox/client-agent": minor
+"@shipfox/client-integrations": minor
+"@shipfox/client-projects": minor
+"@shipfox/client-runners": minor
+"@shipfox/client-secrets": minor
+"@shipfox/client-shell": minor
+"@shipfox/client-triggers": minor
+"@shipfox/client-workflows": minor
+"@shipfox/client-workspace-settings": minor
+---
+
+Exposes typed feature-owned navigation and settings contributions and enforces coordinator-owned client composition.

--- a/docs/architecture/client-architecture.md
+++ b/docs/architecture/client-architecture.md
@@ -174,9 +174,11 @@ changing a client boundary. Package checks run the local Biome rules and report
 source locations for response DTO imports, DTO or framework imports in `core/`,
 raw API requests, and leaf-component query-cache ownership. The repository
 verifier checks direct API requests outside adapters, unparsed API responses,
-and raw route-search parsing outside an owned route module. Both checks require
-zero production violations. Neither check has a migration baseline or
-allowlist.
+raw route-search parsing outside an owned route module, deep imports into
+another feature's private modules, and navigation or settings contributions
+that target a route owned by another feature without an explicit `coordinator`.
+Both checks require zero production violations. Neither check has a migration
+baseline or allowlist.
 
 A completed feature package has `core/` domain models and policies with no UI
 or transport imports; checked adapter functions that parse and map every

--- a/libs/client/agent/src/feature.ts
+++ b/libs/client/agent/src/feature.ts
@@ -1,4 +1,14 @@
-import {defineClientFeature} from '@shipfox/client-shell';
+import {defineClientFeature, type SettingsSectionEntry} from '@shipfox/client-shell';
+
+export const agentSettingsSections = [
+  {
+    id: 'settings.agents',
+    pathSegment: 'agents',
+    label: 'Agents',
+    icon: 'robot2Line',
+    order: 400,
+  },
+] as const satisfies readonly SettingsSectionEntry[];
 
 export const agentFeature = defineClientFeature({
   id: 'shipfox.agent',
@@ -14,13 +24,5 @@ export const agentFeature = defineClientFeature({
       impl: '@shipfox/client-agent/routes/agents-settings',
     },
   ],
-  settingsSections: [
-    {
-      id: 'settings.agents',
-      pathSegment: 'agents',
-      label: 'Agents',
-      icon: 'robot2Line',
-      order: 400,
-    },
-  ],
+  settingsSections: agentSettingsSections,
 });

--- a/libs/client/features/src/index.test.ts
+++ b/libs/client/features/src/index.test.ts
@@ -1,3 +1,4 @@
+import {composeClientFeatures} from '@shipfox/client-shell/runtime';
 import {describe, expect, it} from '@shipfox/vitest/vi';
 import manifest from '../package.json' with {type: 'json'};
 import {defaultFeatures} from './index.js';
@@ -33,5 +34,32 @@ describe('defaultFeatures', () => {
     );
 
     expect([...routePackageNames].sort()).toEqual(peerPackageNames.sort());
+  });
+
+  it('composes each navigation and settings contribution exactly once', () => {
+    const composition = composeClientFeatures(defaultFeatures());
+
+    expect(composition.navigation.map(({id}) => id)).toEqual([
+      'nav.projects',
+      'nav.runs',
+      'nav.workflows',
+      'nav.settings',
+    ]);
+    expect(composition.settingsSections.map(({id}) => id)).toEqual([
+      'settings.members',
+      'settings.runners',
+      'settings.provisioners',
+      'settings.agents',
+      'settings.secrets',
+      'settings.variables',
+      'settings.integrations',
+      'settings.events',
+    ]);
+    expect(new Set(composition.navigation.map(({id}) => id)).size).toBe(
+      composition.navigation.length,
+    );
+    expect(new Set(composition.settingsSections.map(({id}) => id)).size).toBe(
+      composition.settingsSections.length,
+    );
   });
 });

--- a/libs/client/integrations/src/feature.ts
+++ b/libs/client/integrations/src/feature.ts
@@ -1,4 +1,14 @@
-import {defineClientFeature} from '@shipfox/client-shell';
+import {defineClientFeature, type SettingsSectionEntry} from '@shipfox/client-shell';
+
+export const integrationsSettingsSections = [
+  {
+    id: 'settings.integrations',
+    pathSegment: 'integrations',
+    label: 'Integrations',
+    icon: 'plugLine',
+    order: 700,
+  },
+] as const satisfies readonly SettingsSectionEntry[];
 
 export const integrationsFeature = defineClientFeature({
   id: 'shipfox.integrations',
@@ -59,13 +69,5 @@ export const integrationsFeature = defineClientFeature({
       impl: '@shipfox/client-integrations/routes/integrations-settings',
     },
   ],
-  settingsSections: [
-    {
-      id: 'settings.integrations',
-      pathSegment: 'integrations',
-      label: 'Integrations',
-      icon: 'plugLine',
-      order: 700,
-    },
-  ],
+  settingsSections: integrationsSettingsSections,
 });

--- a/libs/client/projects/src/feature.ts
+++ b/libs/client/projects/src/feature.ts
@@ -1,4 +1,15 @@
-import {defineClientFeature} from '@shipfox/client-shell';
+import {defineClientFeature, type NavTabEntry} from '@shipfox/client-shell';
+
+export const projectsNavigation = [
+  {
+    id: 'nav.projects',
+    scope: 'workspace',
+    label: 'Projects',
+    to: '/workspaces/$wid',
+    exact: true,
+    order: 100,
+  },
+] as const satisfies readonly NavTabEntry[];
 
 export const projectsFeature = defineClientFeature({
   id: 'shipfox.projects',
@@ -19,14 +30,5 @@ export const projectsFeature = defineClientFeature({
       impl: '@shipfox/client-projects/routes/project-index',
     },
   ],
-  navigation: [
-    {
-      id: 'nav.projects',
-      scope: 'workspace',
-      label: 'Projects',
-      to: '/workspaces/$wid',
-      exact: true,
-      order: 100,
-    },
-  ],
+  navigation: projectsNavigation,
 });

--- a/libs/client/runners/src/feature.ts
+++ b/libs/client/runners/src/feature.ts
@@ -1,4 +1,21 @@
-import {defineClientFeature} from '@shipfox/client-shell';
+import {defineClientFeature, type SettingsSectionEntry} from '@shipfox/client-shell';
+
+export const runnersSettingsSections = [
+  {
+    id: 'settings.runners',
+    pathSegment: 'runners',
+    label: 'Runners',
+    icon: 'settings3Line',
+    order: 200,
+  },
+  {
+    id: 'settings.provisioners',
+    pathSegment: 'provisioners',
+    label: 'Runner provisioners',
+    icon: 'serverLine',
+    order: 300,
+  },
+] as const satisfies readonly SettingsSectionEntry[];
 
 export const runnersFeature = defineClientFeature({
   id: 'shipfox.runners',
@@ -14,20 +31,5 @@ export const runnersFeature = defineClientFeature({
       impl: '@shipfox/client-runners/routes/provisioners-settings',
     },
   ],
-  settingsSections: [
-    {
-      id: 'settings.runners',
-      pathSegment: 'runners',
-      label: 'Runners',
-      icon: 'settings3Line',
-      order: 200,
-    },
-    {
-      id: 'settings.provisioners',
-      pathSegment: 'provisioners',
-      label: 'Runner provisioners',
-      icon: 'serverLine',
-      order: 300,
-    },
-  ],
+  settingsSections: runnersSettingsSections,
 });

--- a/libs/client/secrets/src/feature.ts
+++ b/libs/client/secrets/src/feature.ts
@@ -1,4 +1,15 @@
-import {defineClientFeature} from '@shipfox/client-shell';
+import {defineClientFeature, type SettingsSectionEntry} from '@shipfox/client-shell';
+
+export const secretsSettingsSections = [
+  {id: 'settings.secrets', pathSegment: 'secrets', label: 'Secrets', icon: 'keyLine', order: 500},
+  {
+    id: 'settings.variables',
+    pathSegment: 'variables',
+    label: 'Variables',
+    icon: 'bracesLine',
+    order: 600,
+  },
+] as const satisfies readonly SettingsSectionEntry[];
 
 export const secretsFeature = defineClientFeature({
   id: 'shipfox.secrets',
@@ -14,14 +25,5 @@ export const secretsFeature = defineClientFeature({
       impl: '@shipfox/client-secrets/routes/variables-settings',
     },
   ],
-  settingsSections: [
-    {id: 'settings.secrets', pathSegment: 'secrets', label: 'Secrets', icon: 'keyLine', order: 500},
-    {
-      id: 'settings.variables',
-      pathSegment: 'variables',
-      label: 'Variables',
-      icon: 'bracesLine',
-      order: 600,
-    },
-  ],
+  settingsSections: secretsSettingsSections,
 });

--- a/libs/client/shell/src/compose/compose-client-features.test.ts
+++ b/libs/client/shell/src/compose/compose-client-features.test.ts
@@ -1,0 +1,47 @@
+import {composeClientFeatures} from './compose-client-features.js';
+
+describe('composeClientFeatures', () => {
+  test('validates and returns one aggregate composition for the shell', () => {
+    const composition = composeClientFeatures([
+      {
+        id: 'acme.projects',
+        routes: [
+          {path: '/projects', parent: 'root', impl: 'projects'},
+          {
+            path: '/workspaces/$wid/settings/members',
+            parent: 'workspaceSettings',
+            impl: 'members',
+          },
+        ],
+        navigation: [{id: 'projects', scope: 'workspace', label: 'Projects', to: '/projects'}],
+        settingsSections: [
+          {id: 'members', pathSegment: 'members', label: 'Members', icon: 'userLine'},
+        ],
+      },
+    ]);
+
+    expect(composition.routes.map(({path}) => path)).toEqual([
+      '/projects',
+      '/workspaces/$wid/settings/members',
+    ]);
+    expect(composition.navigation.map(({id}) => id)).toEqual(['projects']);
+    expect(composition.settingsSections.map(({id}) => id)).toEqual(['members']);
+  });
+
+  test('fails deterministically for an owner-mismatched contribution', () => {
+    expect(() =>
+      composeClientFeatures([
+        {
+          id: 'shipfox.projects',
+          routes: [{path: '/projects', parent: 'root', impl: 'projects'}],
+        },
+        {
+          id: 'acme.shell',
+          navigation: [{id: 'projects', scope: 'workspace', label: 'Projects', to: '/projects'}],
+        },
+      ]),
+    ).toThrow(
+      'Navigation entry "projects" in feature "acme.shell" targets route "/projects" owned by feature "shipfox.projects". Declare coordinator: "acme.shell" to own this cross-feature contribution.',
+    );
+  });
+});

--- a/libs/client/shell/src/compose/compose-client-features.ts
+++ b/libs/client/shell/src/compose/compose-client-features.ts
@@ -1,0 +1,27 @@
+import type {ClientFeature, NavTabEntry, SettingsSectionEntry} from '#contract.js';
+import {navigationEntries, settingsEntries} from '#runtime/registries.js';
+import {type ComposedRoute, composeRoutes} from './compose-routes.js';
+import {mergeConfigShapes} from './merge-config.js';
+import {validateProviderIds} from './validate-providers.js';
+import {validateNavigation, validateSettingsSections} from './validate-registries.js';
+
+export interface ComposedClientFeatures {
+  configShape: ReturnType<typeof mergeConfigShapes>;
+  navigation: NavTabEntry[];
+  routes: ComposedRoute[];
+  settingsSections: SettingsSectionEntry[];
+}
+
+export function composeClientFeatures(features: readonly ClientFeature[]): ComposedClientFeatures {
+  const routes = composeRoutes(features);
+  validateProviderIds(features);
+  validateNavigation(features, routes);
+  validateSettingsSections(features, routes);
+
+  return {
+    configShape: mergeConfigShapes(features),
+    navigation: navigationEntries(features),
+    routes,
+    settingsSections: settingsEntries(features),
+  };
+}

--- a/libs/client/shell/src/compose/compose-routes.test.ts
+++ b/libs/client/shell/src/compose/compose-routes.test.ts
@@ -27,8 +27,15 @@ describe('composeRoutes', () => {
         override: true,
         impl: 'override',
         featureId: 'acme.insights',
+        ownerFeatureId: 'shipfox.base',
       },
-      {path: '/audit', parent: 'root', impl: 'audit', featureId: 'acme.audit'},
+      {
+        path: '/audit',
+        parent: 'root',
+        impl: 'audit',
+        featureId: 'acme.audit',
+        ownerFeatureId: 'acme.audit',
+      },
     ]);
   });
 

--- a/libs/client/shell/src/compose/compose-routes.ts
+++ b/libs/client/shell/src/compose/compose-routes.ts
@@ -4,6 +4,7 @@ import {normalizeRoutePath} from './normalize-route-path.js';
 
 export interface ComposedRoute extends RouteContribution {
   featureId: string;
+  ownerFeatureId: string;
 }
 
 export function composeRoutes(features: readonly ClientFeature[]): ComposedRoute[] {
@@ -26,6 +27,7 @@ export function composeRoutes(features: readonly ClientFeature[]): ComposedRoute
         routes.set(normalizedContribution.path, {
           ...normalizedContribution,
           featureId: feature.id,
+          ownerFeatureId: feature.id,
         });
         continue;
       }
@@ -53,6 +55,7 @@ export function composeRoutes(features: readonly ClientFeature[]): ComposedRoute
       routes.set(normalizedContribution.path, {
         ...normalizedContribution,
         featureId: feature.id,
+        ownerFeatureId: existing.ownerFeatureId,
       });
     }
   }

--- a/libs/client/shell/src/compose/validate-registries.test.ts
+++ b/libs/client/shell/src/compose/validate-registries.test.ts
@@ -1,3 +1,4 @@
+import {composeRoutes} from './compose-routes.js';
 import {validateNavigation, validateSettingsSections} from './validate-registries.js';
 
 const duplicateNavigationMessage = /projects.*shipfox\.one.*acme\.two/u;
@@ -52,6 +53,43 @@ describe('registry validation', () => {
     ).not.toThrow();
   });
 
+  test('rejects navigation that targets another feature without an explicit coordinator', () => {
+    const features = [
+      {
+        id: 'shipfox.projects',
+        routes: [{path: '/projects', parent: 'root' as const, impl: 'projects'}],
+      },
+      {
+        id: 'acme.shell',
+        navigation: [
+          {id: 'projects', scope: 'workspace' as const, label: 'Projects', to: '/projects'},
+        ],
+      },
+    ];
+
+    expect(() => validateNavigation(features, composeRoutes(features))).toThrow(
+      'Navigation entry "projects" in feature "acme.shell" targets route "/projects" owned by feature "shipfox.projects". Declare coordinator: "acme.shell" to own this cross-feature contribution.',
+    );
+  });
+
+  test('accepts cross-feature navigation for an explicit coordinator', () => {
+    const features = [
+      {
+        id: 'shipfox.projects',
+        routes: [{path: '/projects', parent: 'root' as const, impl: 'projects'}],
+      },
+      {
+        id: 'acme.shell',
+        coordinator: 'acme.shell',
+        navigation: [
+          {id: 'projects', scope: 'workspace' as const, label: 'Projects', to: '/projects'},
+        ],
+      },
+    ];
+
+    expect(() => validateNavigation(features, composeRoutes(features))).not.toThrow();
+  });
+
   test('names the id and both features for a duplicate settings section', () => {
     expect(() =>
       validateSettingsSections(
@@ -88,5 +126,30 @@ describe('registry validation', () => {
         [],
       ),
     ).toThrow(missingSettingsMessage);
+  });
+
+  test('rejects a settings section whose route belongs to another feature', () => {
+    const features = [
+      {
+        id: 'shipfox.projects',
+        routes: [
+          {
+            path: '/workspaces/$wid/settings/members',
+            parent: 'workspaceSettings' as const,
+            impl: 'projects-members',
+          },
+        ],
+      },
+      {
+        id: 'acme.shell',
+        settingsSections: [
+          {id: 'members', pathSegment: 'members', label: 'Members', icon: 'userLine' as const},
+        ],
+      },
+    ];
+
+    expect(() => validateSettingsSections(features, composeRoutes(features))).toThrow(
+      'Settings section "members" in feature "acme.shell" targets route "/workspaces/$wid/settings/members" owned by feature "shipfox.projects". Declare coordinator: "acme.shell" to own this cross-feature contribution.',
+    );
   });
 });

--- a/libs/client/shell/src/compose/validate-registries.ts
+++ b/libs/client/shell/src/compose/validate-registries.ts
@@ -2,11 +2,35 @@ import type {ClientFeature} from '#contract.js';
 import {NavCompositionError, SettingsCompositionError} from './errors.js';
 import {normalizeRoutePath} from './normalize-route-path.js';
 
+interface RouteReference {
+  path: string;
+  featureId?: string;
+  ownerFeatureId?: string;
+}
+
+type RouteReferences = Iterable<string | RouteReference>;
+
+function routeOwners(routeReferences: RouteReferences): Map<string, string | undefined> {
+  const owners = new Map<string, string | undefined>();
+  for (const route of routeReferences) {
+    const path = typeof route === 'string' ? route : route.path;
+    owners.set(
+      normalizeRoutePath(path),
+      typeof route === 'string' ? undefined : (route.ownerFeatureId ?? route.featureId),
+    );
+  }
+  return owners;
+}
+
+function hasExplicitCoordinator(feature: ClientFeature): boolean {
+  return feature.coordinator === feature.id;
+}
+
 export function validateNavigation(
   features: readonly ClientFeature[],
-  routePaths: Iterable<string>,
+  routeReferences: RouteReferences,
 ): void {
-  const routes = new Set([...routePaths].map(normalizeRoutePath));
+  const routes = routeOwners(routeReferences);
   const entries = new Map<string, string>();
   for (const feature of features) {
     for (const entry of feature.navigation ?? []) {
@@ -19,11 +43,19 @@ export function validateNavigation(
         );
       }
       const target = normalizeRoutePath(entry.to);
-      if (!routes.has(target)) {
+      const routeOwner = routes.get(target);
+      if (routeOwner === undefined && !routes.has(target)) {
         throw new NavCompositionError(
           entry.id,
           `Navigation entry "${entry.id}" in feature "${feature.id}" targets missing route "${target}".`,
           [feature.id],
+        );
+      }
+      if (routeOwner && routeOwner !== feature.id && !hasExplicitCoordinator(feature)) {
+        throw new NavCompositionError(
+          entry.id,
+          `Navigation entry "${entry.id}" in feature "${feature.id}" targets route "${target}" owned by feature "${routeOwner}". Declare coordinator: "${feature.id}" to own this cross-feature contribution.`,
+          [routeOwner, feature.id],
         );
       }
       entries.set(entry.id, feature.id);
@@ -33,9 +65,9 @@ export function validateNavigation(
 
 export function validateSettingsSections(
   features: readonly ClientFeature[],
-  routePaths: Iterable<string>,
+  routeReferences: RouteReferences,
 ): void {
-  const routes = new Set(routePaths);
+  const routes = routeOwners(routeReferences);
   const sections = new Map<string, string>();
   for (const feature of features) {
     for (const section of feature.settingsSections ?? []) {
@@ -48,11 +80,20 @@ export function validateSettingsSections(
         );
       }
       const path = `/workspaces/$wid/settings/${section.pathSegment}`;
-      if (!routes.has(path)) {
+      const normalizedPath = normalizeRoutePath(path);
+      const routeOwner = routes.get(normalizedPath);
+      if (routeOwner === undefined && !routes.has(normalizedPath)) {
         throw new SettingsCompositionError(
           section.id,
           `Settings section "${section.id}" in feature "${feature.id}" requires route "${path}".`,
           [feature.id],
+        );
+      }
+      if (routeOwner && routeOwner !== feature.id && !hasExplicitCoordinator(feature)) {
+        throw new SettingsCompositionError(
+          section.id,
+          `Settings section "${section.id}" in feature "${feature.id}" targets route "${path}" owned by feature "${routeOwner}". Declare coordinator: "${feature.id}" to own this cross-feature contribution.`,
+          [routeOwner, feature.id],
         );
       }
       sections.set(section.id, feature.id);

--- a/libs/client/shell/src/contract.ts
+++ b/libs/client/shell/src/contract.ts
@@ -35,6 +35,12 @@ export interface SettingsSectionEntry {
 
 export interface ClientFeature<S extends z.ZodRawShape = z.ZodRawShape> {
   id: string;
+  /**
+   * Set this to the feature id when the feature intentionally coordinates a
+   * navigation or settings contribution whose route belongs to another
+   * feature.
+   */
+  coordinator?: string;
   routes?: readonly RouteContribution[];
   providers?: readonly FeatureProvider[];
   navigation?: readonly NavTabEntry[];

--- a/libs/client/shell/src/runtime/compose-client-app.tsx
+++ b/libs/client/shell/src/runtime/compose-client-app.tsx
@@ -13,10 +13,7 @@ import {type AnyRouter, RouterProvider} from '@tanstack/react-router';
 import {createStore} from 'jotai';
 import {StrictMode, useEffect} from 'react';
 import {createRoot} from 'react-dom/client';
-import {composeRoutes} from '#compose/compose-routes.js';
-import {mergeConfigShapes} from '#compose/merge-config.js';
-import {validateProviderIds} from '#compose/validate-providers.js';
-import {validateNavigation, validateSettingsSections} from '#compose/validate-registries.js';
+import {composeClientFeatures} from '#compose/compose-client-features.js';
 import type {ClientFeature} from '#contract.js';
 import {useAuthState} from './auth.js';
 import {ChromeProvider, type ChromeSlots} from './chrome-context.js';
@@ -34,17 +31,8 @@ export function composeClientApp({
   chrome?: ChromeSlots;
   workspaceSetup?: WorkspaceSetupGate;
 }) {
-  const routes = composeRoutes(features);
-  validateProviderIds(features);
-  validateNavigation(
-    features,
-    routes.map((route) => route.path),
-  );
-  validateSettingsSections(
-    features,
-    routes.map((route) => route.path),
-  );
-  const config = loadConfig(mergeConfigShapes(features), {
+  const composition = composeClientFeatures(features);
+  const config = loadConfig(composition.configShape, {
     runtime: getWindowRuntimeConfig(),
     build: (import.meta as ImportMeta & {env?: Record<string, unknown>}).env,
   });

--- a/libs/client/shell/src/runtime/index.ts
+++ b/libs/client/shell/src/runtime/index.ts
@@ -8,6 +8,7 @@ export type {
   WorkspaceSummary,
 } from '#core/session.js';
 export {toAuthenticatedSession, toUserIdentity} from '#hooks/api/session-mapper.js';
+export * from '../compose/compose-client-features.js';
 export * from '../compose/compose-routes.js';
 export * from '../compose/errors.js';
 export * from '../compose/merge-config.js';

--- a/libs/client/shell/src/vite/plugin.ts
+++ b/libs/client/shell/src/vite/plugin.ts
@@ -1,11 +1,7 @@
 import {mkdir, readFile, realpath, writeFile} from 'node:fs/promises';
 import {dirname, resolve} from 'node:path';
 import type {Plugin, ResolvedConfig} from 'vite';
-import {composeRoutes} from '#compose/compose-routes.js';
-import {mergeConfigShapes} from '#compose/merge-config.js';
-import {validateProviderIds} from '#compose/validate-providers.js';
-import {validateNavigation, validateSettingsSections} from '#compose/validate-registries.js';
-import {navigationEntries, settingsEntries} from '#runtime/registries.js';
+import {composeClientFeatures} from '#compose/compose-client-features.js';
 import {evaluateFeatures} from './evaluate-features.js';
 import {generateAppModule} from './generate.js';
 
@@ -28,7 +24,7 @@ export function shipfoxClientComposition({
 
   async function assertRoutesResolve(
     resolveRoute: RouteResolver,
-    routes: ReturnType<typeof composeRoutes>,
+    routes: ReturnType<typeof composeClientFeatures>['routes'],
   ): Promise<void> {
     for (const route of routes) {
       const resolvedRoute = await resolveRoute(route.impl, outputPath());
@@ -48,26 +44,16 @@ export function shipfoxClientComposition({
     resolveRoute: RouteResolver;
   }): Promise<void> {
     const evaluated = await evaluateFeatures(featuresPath());
-    const routes = composeRoutes(evaluated.features);
-    validateProviderIds(evaluated.features);
-    validateNavigation(
-      evaluated.features,
-      routes.map((route) => route.path),
-    );
-    validateSettingsSections(
-      evaluated.features,
-      routes.map((route) => route.path),
-    );
-    mergeConfigShapes(evaluated.features);
-    await assertRoutesResolve(resolveRoute, routes);
+    const composition = composeClientFeatures(evaluated.features);
+    await assertRoutesResolve(resolveRoute, composition.routes);
 
     watchedFiles = new Set(evaluated.loadedFiles);
     for (const file of watchedFiles) addWatchFile(file);
 
     const output = generateAppModule({
-      routes,
-      navigation: navigationEntries(evaluated.features),
-      settingsSections: settingsEntries(evaluated.features),
+      routes: composition.routes,
+      navigation: composition.navigation,
+      settingsSections: composition.settingsSections,
     });
     const path = outputPath();
     const existing = await readFile(path, 'utf8').catch(() => undefined);

--- a/libs/client/triggers/src/feature.ts
+++ b/libs/client/triggers/src/feature.ts
@@ -1,4 +1,8 @@
-import {defineClientFeature} from '@shipfox/client-shell';
+import {defineClientFeature, type SettingsSectionEntry} from '@shipfox/client-shell';
+
+export const triggersSettingsSections = [
+  {id: 'settings.events', pathSegment: 'events', label: 'Events', icon: 'pulseLine', order: 800},
+] as const satisfies readonly SettingsSectionEntry[];
 
 export const triggersFeature = defineClientFeature({
   id: 'shipfox.triggers',
@@ -9,7 +13,5 @@ export const triggersFeature = defineClientFeature({
       impl: '@shipfox/client-triggers/routes/events-settings',
     },
   ],
-  settingsSections: [
-    {id: 'settings.events', pathSegment: 'events', label: 'Events', icon: 'pulseLine', order: 800},
-  ],
+  settingsSections: triggersSettingsSections,
 });

--- a/libs/client/workflows/src/feature.ts
+++ b/libs/client/workflows/src/feature.ts
@@ -1,4 +1,21 @@
-import {defineClientFeature} from '@shipfox/client-shell';
+import {defineClientFeature, type NavTabEntry} from '@shipfox/client-shell';
+
+export const workflowsNavigation = [
+  {
+    id: 'nav.runs',
+    scope: 'project',
+    label: 'Runs',
+    to: '/workspaces/$wid/projects/$pid/runs',
+    order: 100,
+  },
+  {
+    id: 'nav.workflows',
+    scope: 'project',
+    label: 'Workflows',
+    to: '/workspaces/$wid/projects/$pid/workflows',
+    order: 200,
+  },
+] as const satisfies readonly NavTabEntry[];
 
 export const workflowsFeature = defineClientFeature({
   id: 'shipfox.workflows',
@@ -19,20 +36,5 @@ export const workflowsFeature = defineClientFeature({
       impl: '@shipfox/client-workflows/routes/run-detail',
     },
   ],
-  navigation: [
-    {
-      id: 'nav.runs',
-      scope: 'project',
-      label: 'Runs',
-      to: '/workspaces/$wid/projects/$pid/runs',
-      order: 100,
-    },
-    {
-      id: 'nav.workflows',
-      scope: 'project',
-      label: 'Workflows',
-      to: '/workspaces/$wid/projects/$pid/workflows',
-      order: 200,
-    },
-  ],
+  navigation: workflowsNavigation,
 });

--- a/libs/client/workspace-settings/src/feature.ts
+++ b/libs/client/workspace-settings/src/feature.ts
@@ -1,5 +1,28 @@
-import {defineClientFeature} from '@shipfox/client-shell';
-import type {IconName} from '@shipfox/react-ui/icon';
+import {
+  defineClientFeature,
+  type NavTabEntry,
+  type SettingsSectionEntry,
+} from '@shipfox/client-shell';
+
+export const workspaceSettingsNavigation = [
+  {
+    id: 'nav.settings',
+    scope: 'workspace',
+    label: 'Settings',
+    to: '/workspaces/$wid/settings',
+    order: 200,
+  },
+] as const satisfies readonly NavTabEntry[];
+
+export const workspaceSettingsSections = [
+  {
+    id: 'settings.members',
+    pathSegment: 'members',
+    label: 'Members',
+    icon: 'userLine',
+    order: 100,
+  },
+] as const satisfies readonly SettingsSectionEntry[];
 
 export const workspaceSettingsFeature = defineClientFeature({
   id: 'shipfox.workspace-settings',
@@ -15,22 +38,6 @@ export const workspaceSettingsFeature = defineClientFeature({
       impl: '@shipfox/client-workspace-settings/routes/members',
     },
   ],
-  navigation: [
-    {
-      id: 'nav.settings',
-      scope: 'workspace',
-      label: 'Settings',
-      to: '/workspaces/$wid/settings',
-      order: 200,
-    },
-  ],
-  settingsSections: [
-    {
-      id: 'settings.members',
-      pathSegment: 'members',
-      label: 'Members',
-      icon: 'userLine' as IconName,
-      order: 100,
-    },
-  ],
+  navigation: workspaceSettingsNavigation,
+  settingsSections: workspaceSettingsSections,
 });

--- a/tools/client-architecture-policy/src/audit-client-architecture.ts
+++ b/tools/client-architecture-policy/src/audit-client-architecture.ts
@@ -6,7 +6,12 @@ import {fileURLToPath} from 'node:url';
 export interface ClientArchitectureViolation {
   file: string;
   occurrences: number;
-  rule: 'api-request-outside-adapter' | 'unchecked-route-search' | 'unparsed-api-response';
+  rule:
+    | 'api-request-outside-adapter'
+    | 'non-owning-feature-contribution'
+    | 'private-feature-import'
+    | 'unchecked-route-search'
+    | 'unparsed-api-response';
 }
 
 const rootDirectory = fileURLToPath(new URL('../../../', import.meta.url));
@@ -19,7 +24,27 @@ const nonProductionSourcePattern = /\.(?:stories|test)\.(?:ts|tsx)$/;
 const apiRequestPattern = /\b(?:apiRequest|checkedApiRequest)\s*(?:<[^>]*>)?\s*\(/;
 const uncheckedApiRequestPattern = /\bapiRequest\s*(?:<[^>]*>)?\s*\(/;
 const routeSearchPattern = /\buseRouteSearch\s*\(/;
-const generatedDirectoryNames = new Set(['dist', 'node_modules']);
+const excludedDirectoryNames = new Set([
+  'dist',
+  'node_modules',
+  'test',
+  'tests',
+  '__tests__',
+  'generated',
+  '__generated__',
+]);
+const privateFeatureImportPattern =
+  /(?:from\s+|import\s*\(\s*)['"]@shipfox\/client-[^/'"]+\/(?!feature(?:\/|['"])|routes(?:\/|['"])|continuation(?:\/|['"])|runtime(?:\/|['"])|testing(?:\/|['"])|vite(?:\/|['"]))(?:[^'"]+)['"]/;
+const featureManifestPathPattern = /^libs\/client\/([^/]+)\/src\/feature\.ts$/u;
+const featureDeclarationPattern = /defineClientFeature\(\s*\{\s*id\s*:\s*['"]([^'"]+)['"]/u;
+const featureIdPattern = /\bid\s*:\s*['"]([^'"]+)['"]/u;
+const coordinatorPattern = /\bcoordinator\s*:\s*['"]([^'"]+)['"]/u;
+const routeImplementationPattern = /\bimpl\s*:\s*['"](@shipfox\/client-[^/'"]+)\/routes\//gu;
+const routePathPattern = /\bpath\s*:\s*['"]([^'"]+)['"]/gu;
+const navigationTargetPattern = /\bto\s*:\s*['"]([^'"]+)['"]/gu;
+const settingsPathPattern = /\bpathSegment\s*:\s*['"]([^'"]+)['"]/gu;
+const registryDefinitionPattern = /\b(?:navigation|settingsSections)\s*(?::|=)\s*\[/u;
+const trailingSlashPattern = /\/+$/u;
 
 function toRepositoryPath(filePath: string): string {
   return path.relative(rootDirectory, filePath).split(path.sep).join('/');
@@ -31,7 +56,7 @@ export async function sourceFiles(directory: string): Promise<string[]> {
     entries.map(async (entry) => {
       const entryPath = path.join(directory, entry.name);
       if (entry.isDirectory()) {
-        return generatedDirectoryNames.has(entry.name) ? [] : await sourceFiles(entryPath);
+        return excludedDirectoryNames.has(entry.name) ? [] : await sourceFiles(entryPath);
       }
       return sourceFilePattern.test(entry.name) && !nonProductionSourcePattern.test(entry.name)
         ? [entryPath]
@@ -46,6 +71,43 @@ function countMatches(source: string, pattern: RegExp): number {
   return [...source.matchAll(new RegExp(pattern.source, flags))].length;
 }
 
+function capturedMatches(source: string, pattern: RegExp): string[] {
+  const flags = pattern.flags.includes('g') ? pattern.flags : `${pattern.flags}g`;
+  return [...source.matchAll(new RegExp(pattern.source, flags))].flatMap((match) =>
+    match[1] ? [match[1]] : [],
+  );
+}
+
+function normalizeManifestPath(value: string): string {
+  return value === '/' ? value : value.replace(trailingSlashPattern, '') || '/';
+}
+
+function featureContributionOccurrences(file: string, source: string): number {
+  const manifest = file.match(featureManifestPathPattern);
+  if (!manifest) return registryDefinitionPattern.test(source) ? 1 : 0;
+
+  const packageName = `@shipfox/client-${manifest[1]}`;
+  const featureId =
+    source.match(featureDeclarationPattern)?.[1] ?? source.match(featureIdPattern)?.[1];
+  const coordinatorId = source.match(coordinatorPattern)?.[1];
+  const hasExplicitCoordinator = featureId !== undefined && coordinatorId === featureId;
+  let occurrences = featureId === `shipfox.${manifest[1]}` ? 0 : 1;
+
+  for (const implementationPackage of capturedMatches(source, routeImplementationPattern)) {
+    if (implementationPackage !== packageName && !hasExplicitCoordinator) occurrences += 1;
+  }
+
+  const routes = new Set(capturedMatches(source, routePathPattern).map(normalizeManifestPath));
+  for (const target of capturedMatches(source, navigationTargetPattern)) {
+    if (!routes.has(normalizeManifestPath(target)) && !hasExplicitCoordinator) occurrences += 1;
+  }
+  for (const segment of capturedMatches(source, settingsPathPattern)) {
+    const target = normalizeManifestPath(`/workspaces/$wid/settings/${segment}`);
+    if (!routes.has(target) && !hasExplicitCoordinator) occurrences += 1;
+  }
+
+  return occurrences;
+}
 export function auditClientSource(file: string, source: string): ClientArchitectureViolation[] {
   const violations: ClientArchitectureViolation[] = [];
   const normalizedFile = file.split(path.sep).join('/');
@@ -54,6 +116,11 @@ export function auditClientSource(file: string, source: string): ClientArchitect
   const addViolation = (rule: ClientArchitectureViolation['rule'], occurrences: number): void => {
     if (occurrences > 0) violations.push({file, rule, occurrences});
   };
+  addViolation('private-feature-import', countMatches(source, privateFeatureImportPattern));
+  addViolation(
+    'non-owning-feature-contribution',
+    featureContributionOccurrences(normalizedFile, source),
+  );
   if (!isAdapter && !isClientApi)
     addViolation('api-request-outside-adapter', countMatches(source, apiRequestPattern));
   if (!isClientApi)

--- a/tools/client-architecture-policy/test/audit-client-architecture.test.ts
+++ b/tools/client-architecture-policy/test/audit-client-architecture.test.ts
@@ -13,16 +13,92 @@ describe('auditClientSource', () => {
     assert.deepEqual(violations, []);
   });
 
+  test('allows public feature contribution and route imports', () => {
+    const violations = auditClientSource(
+      'libs/client/features/src/index.ts',
+      "import {projectsFeature} from '@shipfox/client-projects/feature';\nimport {ProjectBreadcrumb} from '@shipfox/client-projects';\nimport route from '@shipfox/client-projects/routes/home';",
+    );
+
+    assert.deepEqual(violations, []);
+  });
+
+  test('reports private feature imports', () => {
+    const violations = auditClientSource(
+      'libs/client/features/src/index.ts',
+      "import {ProjectsPage} from '@shipfox/client-projects/src/pages/projects-page';",
+    );
+
+    assert.deepEqual(violations, [
+      {
+        file: 'libs/client/features/src/index.ts',
+        occurrences: 1,
+        rule: 'private-feature-import',
+      },
+    ]);
+  });
+
+  test('reports non-owning feature contributions', () => {
+    const violations = auditClientSource(
+      'libs/client/projects/src/feature.ts',
+      `import {defineClientFeature} from '@shipfox/client-shell';
+export const projectsFeature = defineClientFeature({
+  id: 'shipfox.projects',
+  routes: [{path: '/projects', parent: 'root', impl: '@shipfox/client-integrations/routes/integrations'}],
+  navigation: [{id: 'integrations', scope: 'workspace', label: 'Integrations', to: '/integrations'}],
+});`,
+    );
+
+    assert.deepEqual(violations, [
+      {
+        file: 'libs/client/projects/src/feature.ts',
+        occurrences: 2,
+        rule: 'non-owning-feature-contribution',
+      },
+    ]);
+  });
+
+  test('allows a non-owning contribution for a feature with an explicit coordinator', () => {
+    const violations = auditClientSource(
+      'libs/client/projects/src/feature.ts',
+      `import {defineClientFeature} from '@shipfox/client-shell';
+export const projectsFeature = defineClientFeature({
+  id: 'shipfox.projects',
+  coordinator: 'shipfox.projects',
+  routes: [{path: '/projects', parent: 'root', impl: '@shipfox/client-integrations/routes/integrations'}],
+  navigation: [{id: 'integrations', scope: 'workspace', label: 'Integrations', to: '/integrations'}],
+});`,
+    );
+
+    assert.deepEqual(violations, []);
+  });
+
+  test('requires navigation registries to be defined in a feature manifest', () => {
+    const violations = auditClientSource(
+      'libs/client/projects/src/navigation.ts',
+      "export const navigation = [{id: 'projects'}];",
+    );
+
+    assert.deepEqual(violations, [
+      {
+        file: 'libs/client/projects/src/navigation.ts',
+        occurrences: 1,
+        rule: 'non-owning-feature-contribution',
+      },
+    ]);
+  });
+
   test('skips generated directories when finding source files', async () => {
     const directory = await mkdtemp(path.join(os.tmpdir(), 'client-architecture-policy-'));
     try {
       await mkdir(path.join(directory, 'src'));
       await mkdir(path.join(directory, 'dist'));
       await mkdir(path.join(directory, 'node_modules', 'package'), {recursive: true});
+      await mkdir(path.join(directory, 'test'));
       await Promise.all([
         writeFile(path.join(directory, 'src', 'source.ts'), ''),
         writeFile(path.join(directory, 'dist', 'generated.ts'), ''),
         writeFile(path.join(directory, 'node_modules', 'package', 'dependency.ts'), ''),
+        writeFile(path.join(directory, 'test', 'fixture.ts'), ''),
       ]);
 
       const files = await sourceFiles(directory);


### PR DESCRIPTION
This PR makes navigation and settings contributions feature-owned and typed, centralizes shell composition, and makes cross-feature ownership explicit through a coordinator. It also extends the architecture audit and guidance to reject private feature imports and non-owning contributions.

Validation: the changed-client package checks passed across 52 packages, the architecture policy audit passed with 15 tests and zero violations, and the packed shell external-consumer tests passed.

Closes ENG-1186

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces feature-owned navigation and settings with a single shell entrypoint for composition and validation. Adds explicit coordinators for cross‑feature links and expands the architecture audit to block private imports and non‑owning contributions. Closes ENG-1186.

- **New Features**
  - Added `composeClientFeatures` in `@shipfox/client-shell` (exported via runtime) and wired it into the runtime and Vite plugin to compose routes, navigation, and settings.
  - Route composition now tracks `ownerFeatureId`; validation rejects navigation/settings that target routes owned by another feature unless the feature sets `coordinator` to its own id.
  - Architecture policy flags deep imports into private feature modules and non‑owning contributions (including registries defined outside a feature manifest).

- **Migration**
  - If you link navigation/settings to a route owned by another feature, set `coordinator` to your feature id.
  - Keep `navigation` and `settingsSections` in the feature manifest; export typed arrays when sharing.
  - Replace deep imports from other features with public entry points.

<sup>Written for commit 9bf5c179bb57c65364ad06efeb9b52c33f466a97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/981?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

