### PR TITLE
Enforce client architecture boundaries

### DIFF
--- a/.changeset/client-boundaries-enforce.md
+++ b/.changeset/client-boundaries-enforce.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/biome": patch
+"@shipfox/client-agent": patch
+---
+
+Enforces client architecture boundaries with Biome plugins and migrates the Agent presentation DTO import.

--- a/biome.json
+++ b/biome.json
@@ -21,8 +21,108 @@
     {
       "path": "./tools/biome/plugins/client-architecture/fixture-boundary.grit",
       "includes": [
-        "libs/client/**",
-        "libs/shared/react/ui/**",
+        "**/libs/client/**",
+        "**/libs/shared/react/ui/**",
+        "!**/dist/**",
+        "!**/node_modules/**",
+        "!**/*.test.ts",
+        "!**/*.test.tsx",
+        "!**/*.stories.ts",
+        "!**/*.stories.tsx",
+        "!**/test/**",
+        "!**/tests/**",
+        "!**/__tests__/**",
+        "!**/generated/**",
+        "!**/__generated__/**",
+        "!**/*.gen.ts",
+        "!**/*.gen.tsx"
+      ]
+    },
+    {
+      "path": "./tools/biome/plugins/client-architecture/no-api-dto-in-core.grit",
+      "includes": [
+        "**/libs/client/**/src/core/**",
+        "!**/dist/**",
+        "!**/node_modules/**",
+        "!**/*.test.ts",
+        "!**/*.test.tsx",
+        "!**/*.stories.ts",
+        "!**/*.stories.tsx",
+        "!**/test/**",
+        "!**/tests/**",
+        "!**/__tests__/**",
+        "!**/generated/**",
+        "!**/__generated__/**",
+        "!**/*.gen.ts",
+        "!**/*.gen.tsx"
+      ]
+    },
+    {
+      "path": "./tools/biome/plugins/client-architecture/no-client-framework-in-core.grit",
+      "includes": [
+        "**/libs/client/**/src/core/**",
+        "!**/dist/**",
+        "!**/node_modules/**",
+        "!**/*.test.ts",
+        "!**/*.test.tsx",
+        "!**/*.stories.ts",
+        "!**/*.stories.tsx",
+        "!**/test/**",
+        "!**/tests/**",
+        "!**/__tests__/**",
+        "!**/generated/**",
+        "!**/__generated__/**",
+        "!**/*.gen.ts",
+        "!**/*.gen.tsx"
+      ]
+    },
+    {
+      "path": "./tools/biome/plugins/client-architecture/no-response-dto-in-presentation.grit",
+      "includes": [
+        "**/libs/client/**/src/pages/**",
+        "**/libs/client/**/src/components/**",
+        "!**/dist/**",
+        "!**/node_modules/**",
+        "!**/*.test.ts",
+        "!**/*.test.tsx",
+        "!**/*.stories.ts",
+        "!**/*.stories.tsx",
+        "!**/test/**",
+        "!**/tests/**",
+        "!**/__tests__/**",
+        "!**/generated/**",
+        "!**/__generated__/**",
+        "!**/*.gen.ts",
+        "!**/*.gen.tsx"
+      ]
+    },
+    {
+      "path": "./tools/biome/plugins/client-architecture/no-raw-api-request.grit",
+      "includes": [
+        "**/libs/client/**",
+        "**/libs/shared/react/ui/**",
+        "!**/libs/client/api/**",
+        "!**/libs/client/**/src/hooks/api/**",
+        "!**/dist/**",
+        "!**/node_modules/**",
+        "!**/*.test.ts",
+        "!**/*.test.tsx",
+        "!**/*.stories.ts",
+        "!**/*.stories.tsx",
+        "!**/test/**",
+        "!**/tests/**",
+        "!**/__tests__/**",
+        "!**/generated/**",
+        "!**/__generated__/**",
+        "!**/*.gen.ts",
+        "!**/*.gen.tsx"
+      ]
+    },
+    {
+      "path": "./tools/biome/plugins/client-architecture/no-query-cache-ownership.grit",
+      "includes": [
+        "**/libs/client/**/src/components/**",
+        "**/libs/shared/react/ui/**/src/components/**",
         "!**/dist/**",
         "!**/node_modules/**",
         "!**/*.test.ts",

--- a/docs/architecture/client-architecture.md
+++ b/docs/architecture/client-architecture.md
@@ -169,12 +169,14 @@ React. Test an adapter with representative DTOs and its mapped domain model.
 Test query keys, cache effects, polling, and optimistic updates at the query
 boundary. Component tests prove rendered behavior. E2E tests prove journeys.
 
-Run `pnpm check:client-architecture` after changing a client boundary. The
-check requires zero violations across every production client package and shared
-React UI code. It blocks direct API requests outside adapters, unparsed API
-responses, response DTO imports in presentation, DTO or framework imports in
-`core/`, leaf-component query-cache ownership, and raw route-search parsing
-outside an owned route module. It has no migration baseline or allowlist.
+Run the affected package `check` and `pnpm check:client-architecture` after
+changing a client boundary. Package checks run the local Biome rules and report
+source locations for response DTO imports, DTO or framework imports in `core/`,
+raw API requests, and leaf-component query-cache ownership. The repository
+verifier checks direct API requests outside adapters, unparsed API responses,
+and raw route-search parsing outside an owned route module. Both checks require
+zero production violations. Neither check has a migration baseline or
+allowlist.
 
 A completed feature package has `core/` domain models and policies with no UI
 or transport imports; checked adapter functions that parse and map every

--- a/libs/client/agent/src/components/custom-model-provider-api-options.ts
+++ b/libs/client/agent/src/components/custom-model-provider-api-options.ts
@@ -1,12 +1,12 @@
-import type {ModelProviderApi} from '@shipfox/api-agent-dto';
+import type {ProviderApi} from '#core/models.js';
 
-export const MODEL_PROVIDER_API_OPTIONS: Array<{value: ModelProviderApi; label: string}> = [
+export const MODEL_PROVIDER_API_OPTIONS: Array<{value: ProviderApi; label: string}> = [
   {value: 'openai-completions', label: 'OpenAI Chat Completions'},
   {value: 'openai-responses', label: 'OpenAI Responses'},
   {value: 'anthropic-messages', label: 'Anthropic Messages'},
   {value: 'google-generative-ai', label: 'Google Generative AI'},
 ];
 
-export function modelProviderApiLabel(api: ModelProviderApi): string {
+export function modelProviderApiLabel(api: ProviderApi): string {
   return MODEL_PROVIDER_API_OPTIONS.find((option) => option.value === api)?.label ?? api;
 }

--- a/tools/biome/plugins/client-architecture/README.md
+++ b/tools/biome/plugins/client-architecture/README.md
@@ -21,6 +21,14 @@ the change. Keep each example short so the expected result is easy to see.
   data, runtime flow, and behavior tests in
   `@shipfox/client-architecture-policy` or a focused test.
 
+The production rules currently cover:
+
+- `no-api-dto-in-core` and `no-client-framework-in-core` for `src/core/**`.
+- `no-response-dto-in-presentation` for pages and components.
+- `no-raw-api-request` outside `@shipfox/client-api` and checked adapter paths.
+- `no-query-cache-ownership` for leaf components; named coordinators and
+  mutation/query adapters remain the ownership boundary.
+
 `fixture-boundary.grit` is the smoke rule for this foundation. Its sentinel is
 not a migrated production rule. Later issues add real rules beside it.
 

--- a/tools/biome/plugins/client-architecture/fixtures/biome.fixture.json
+++ b/tools/biome/plugins/client-architecture/fixtures/biome.fixture.json
@@ -14,6 +14,15 @@
     "lineEnding": "lf",
     "lineWidth": 100
   },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "bracketSpacing": false,
+      "trailingCommas": "all",
+      "semicolons": "always",
+      "arrowParentheses": "always"
+    }
+  },
   "linter": {
     "enabled": true,
     "rules": {
@@ -23,30 +32,43 @@
   "plugins": [
     {
       "path": "../fixture-boundary.grit",
-      "includes": [
-        "**/*.ts",
-        "!**/*.test.ts",
-        "!**/*.stories.ts",
-        "!**/test/**",
-        "!**/tests/**",
-        "!**/__tests__/**",
-        "!**/generated/**",
-        "!**/__generated__/**",
-        "!**/*.gen.ts"
-      ]
+      "includes": ["**/fixture-boundary/**"]
+    },
+    {
+      "path": "../no-api-dto-in-core.grit",
+      "includes": ["**/no-api-dto-in-core/**"]
+    },
+    {
+      "path": "../no-client-framework-in-core.grit",
+      "includes": ["**/no-client-framework-in-core/**"]
+    },
+    {
+      "path": "../no-response-dto-in-presentation.grit",
+      "includes": ["**/no-response-dto-in-presentation/**"]
+    },
+    {
+      "path": "../no-raw-api-request.grit",
+      "includes": ["**/no-raw-api-request/**"]
+    },
+    {
+      "path": "../no-query-cache-ownership.grit",
+      "includes": ["**/no-query-cache-ownership/**"]
     }
   ],
   "files": {
     "includes": [
       "**/*.ts",
       "!**/*.test.ts",
+      "!**/*.test.tsx",
       "!**/*.stories.ts",
+      "!**/*.stories.tsx",
       "!**/test/**",
       "!**/tests/**",
       "!**/__tests__/**",
       "!**/generated/**",
       "!**/__generated__/**",
-      "!**/*.gen.ts"
+      "!**/*.gen.ts",
+      "!**/*.gen.tsx"
     ]
   }
 }

--- a/tools/biome/plugins/client-architecture/fixtures/fixture-boundary/ignored.stories.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/fixture-boundary/ignored.stories.ts
@@ -1,0 +1,3 @@
+function clientArchitectureFixtureViolation(): void {}
+
+clientArchitectureFixtureViolation();

--- a/tools/biome/plugins/client-architecture/fixtures/no-api-dto-in-core/allowed.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/no-api-dto-in-core/allowed.ts
@@ -1,0 +1,3 @@
+export interface Project {
+  readonly id: string;
+}

--- a/tools/biome/plugins/client-architecture/fixtures/no-api-dto-in-core/generated/rejected.gen.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/no-api-dto-in-core/generated/rejected.gen.ts
@@ -1,0 +1,5 @@
+
+
+import type {ProjectResponseDto as Project} from '@shipfox/api-projects-dto';
+
+export type {Project};

--- a/tools/biome/plugins/client-architecture/fixtures/no-api-dto-in-core/ignored.stories.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/no-api-dto-in-core/ignored.stories.ts
@@ -1,0 +1,5 @@
+
+
+import type {ProjectResponseDto as Project} from '@shipfox/api-projects-dto';
+
+export type {Project};

--- a/tools/biome/plugins/client-architecture/fixtures/no-api-dto-in-core/ignored.test.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/no-api-dto-in-core/ignored.test.ts
@@ -1,0 +1,5 @@
+
+
+import type {ProjectResponseDto as Project} from '@shipfox/api-projects-dto';
+
+export type {Project};

--- a/tools/biome/plugins/client-architecture/fixtures/no-api-dto-in-core/rejected.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/no-api-dto-in-core/rejected.ts
@@ -1,0 +1,5 @@
+
+
+import type {ProjectResponseDto as Project} from '@shipfox/api-projects-dto';
+
+export type {Project};

--- a/tools/biome/plugins/client-architecture/fixtures/no-client-framework-in-core/allowed.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/no-client-framework-in-core/allowed.ts
@@ -1,0 +1,3 @@
+export interface Project {
+  readonly id: string;
+}

--- a/tools/biome/plugins/client-architecture/fixtures/no-client-framework-in-core/generated/rejected.gen.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/no-client-framework-in-core/generated/rejected.gen.ts
@@ -1,0 +1,5 @@
+
+
+import type {QueryClient as Client} from '@tanstack/react-query';
+
+export type {Client};

--- a/tools/biome/plugins/client-architecture/fixtures/no-client-framework-in-core/ignored.stories.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/no-client-framework-in-core/ignored.stories.ts
@@ -1,0 +1,5 @@
+
+
+import type {QueryClient as Client} from '@tanstack/react-query';
+
+export type {Client};

--- a/tools/biome/plugins/client-architecture/fixtures/no-client-framework-in-core/ignored.test.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/no-client-framework-in-core/ignored.test.ts
@@ -1,0 +1,5 @@
+
+
+import type {QueryClient as Client} from '@tanstack/react-query';
+
+export type {Client};

--- a/tools/biome/plugins/client-architecture/fixtures/no-client-framework-in-core/rejected.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/no-client-framework-in-core/rejected.ts
@@ -1,0 +1,5 @@
+
+
+import type {QueryClient as Client} from '@tanstack/react-query';
+
+export type {Client};

--- a/tools/biome/plugins/client-architecture/fixtures/no-query-cache-ownership/allowed.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/no-query-cache-ownership/allowed.ts
@@ -1,0 +1,5 @@
+import type {QueryClient} from '@tanstack/react-query';
+import {useQuery} from '@tanstack/react-query';
+
+void useQuery;
+void (null as QueryClient | null);

--- a/tools/biome/plugins/client-architecture/fixtures/no-query-cache-ownership/generated/rejected.gen.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/no-query-cache-ownership/generated/rejected.gen.ts
@@ -1,0 +1,5 @@
+
+
+import {useQueryClient as useClient} from '@tanstack/react-query';
+
+void useClient;

--- a/tools/biome/plugins/client-architecture/fixtures/no-query-cache-ownership/ignored.stories.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/no-query-cache-ownership/ignored.stories.ts
@@ -1,0 +1,5 @@
+
+
+import {useQueryClient as useClient} from '@tanstack/react-query';
+
+void useClient;

--- a/tools/biome/plugins/client-architecture/fixtures/no-query-cache-ownership/ignored.test.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/no-query-cache-ownership/ignored.test.ts
@@ -1,0 +1,5 @@
+
+
+import {useQueryClient as useClient} from '@tanstack/react-query';
+
+void useClient;

--- a/tools/biome/plugins/client-architecture/fixtures/no-query-cache-ownership/rejected.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/no-query-cache-ownership/rejected.ts
@@ -1,0 +1,6 @@
+
+
+import {useQueryClient as useClient} from '@tanstack/react-query';
+
+const queryClient = useClient();
+queryClient.setQueryData(['projects'], []);

--- a/tools/biome/plugins/client-architecture/fixtures/no-raw-api-request/allowed.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/no-raw-api-request/allowed.ts
@@ -1,0 +1,3 @@
+import {checkedApiRequest} from '@shipfox/client-api';
+
+void checkedApiRequest;

--- a/tools/biome/plugins/client-architecture/fixtures/no-raw-api-request/generated/rejected.gen.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/no-raw-api-request/generated/rejected.gen.ts
@@ -1,0 +1,5 @@
+
+
+import {apiRequest as request} from '@shipfox/client-api';
+
+void request('/projects');

--- a/tools/biome/plugins/client-architecture/fixtures/no-raw-api-request/ignored.stories.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/no-raw-api-request/ignored.stories.ts
@@ -1,0 +1,5 @@
+
+
+import {apiRequest as request} from '@shipfox/client-api';
+
+void request('/projects');

--- a/tools/biome/plugins/client-architecture/fixtures/no-raw-api-request/ignored.test.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/no-raw-api-request/ignored.test.ts
@@ -1,0 +1,5 @@
+
+
+import {apiRequest as request} from '@shipfox/client-api';
+
+void request('/projects');

--- a/tools/biome/plugins/client-architecture/fixtures/no-raw-api-request/rejected.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/no-raw-api-request/rejected.ts
@@ -1,0 +1,5 @@
+
+
+import {apiRequest as request} from '@shipfox/client-api';
+
+void request('/projects');

--- a/tools/biome/plugins/client-architecture/fixtures/no-response-dto-in-presentation/allowed.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/no-response-dto-in-presentation/allowed.ts
@@ -1,0 +1,8 @@
+import type {
+  CreateProjectBodyDto,
+  ListProjectsQueryDto as ProjectsQuery,
+} from '@shipfox/api-projects-dto';
+import {createProjectBodySchema} from '@shipfox/api-projects-dto';
+
+export const projectNameSchema = createProjectBodySchema.shape.name;
+export type {CreateProjectBodyDto, ProjectsQuery};

--- a/tools/biome/plugins/client-architecture/fixtures/no-response-dto-in-presentation/generated/rejected.gen.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/no-response-dto-in-presentation/generated/rejected.gen.ts
@@ -1,0 +1,5 @@
+
+
+import type {ProjectResponseDto as Project} from '@shipfox/api-projects-dto';
+
+export type {Project};

--- a/tools/biome/plugins/client-architecture/fixtures/no-response-dto-in-presentation/ignored.stories.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/no-response-dto-in-presentation/ignored.stories.ts
@@ -1,0 +1,5 @@
+
+
+import type {ProjectResponseDto as Project} from '@shipfox/api-projects-dto';
+
+export type {Project};

--- a/tools/biome/plugins/client-architecture/fixtures/no-response-dto-in-presentation/ignored.test.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/no-response-dto-in-presentation/ignored.test.ts
@@ -1,0 +1,5 @@
+
+
+import type {ProjectResponseDto as Project} from '@shipfox/api-projects-dto';
+
+export type {Project};

--- a/tools/biome/plugins/client-architecture/fixtures/no-response-dto-in-presentation/rejected.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/no-response-dto-in-presentation/rejected.ts
@@ -1,0 +1,10 @@
+
+
+import type {ProjectResponseDto as Project} from '@shipfox/api-projects-dto';
+import {type WorkspaceResponseDto as Workspace} from '@shipfox/api-workspaces-dto';
+
+export type {Project, Workspace};
+
+type DynamicProject = import('@shipfox/api-projects-dto').ProjectDto;
+
+export type {DynamicProject};

--- a/tools/biome/plugins/client-architecture/no-api-dto-in-core.grit
+++ b/tools/biome/plugins/client-architecture/no-api-dto-in-core.grit
@@ -1,0 +1,13 @@
+engine biome(1.0)
+language js(typescript, jsx)
+
+or {
+  `import $_ from $source` as $match,
+  `import($source)` as $match
+} where {
+  $source <: r".*@shipfox/api-.*-dto.*",
+  register_diagnostic(
+    span=$match,
+    message="client-architecture/no-api-dto-in-core: keep API DTO imports at the checked adapter boundary; core may depend only on domain models."
+  )
+}

--- a/tools/biome/plugins/client-architecture/no-client-framework-in-core.grit
+++ b/tools/biome/plugins/client-architecture/no-client-framework-in-core.grit
@@ -1,0 +1,20 @@
+engine biome(1.0)
+language js(typescript, jsx)
+
+or {
+  `import $_ from $source` as $match,
+  `import($source)` as $match
+} where {
+  $source <: or {
+    `'react'`,
+    `'react-dom'`,
+    `'jotai'`,
+    r".*@tanstack/.*",
+    r".*@shipfox/client-(api|shell|ui).*",
+    r".*@shipfox/react-ui.*"
+  },
+  register_diagnostic(
+    span=$match,
+    message="client-architecture/no-client-framework-in-core: keep client framework dependencies outside core; use a pure domain model or policy."
+  )
+}

--- a/tools/biome/plugins/client-architecture/no-query-cache-ownership.grit
+++ b/tools/biome/plugins/client-architecture/no-query-cache-ownership.grit
@@ -1,0 +1,57 @@
+engine biome(1.0)
+language js(typescript, jsx)
+
+or {
+  JsImport() as $import where {
+    $import <: r".*@tanstack/react-query.*",
+    $import <: contains JsNamedImportSpecifier() as $queryHook where {
+      $queryHook <: r".*\buseQueryClient\b.*",
+      register_diagnostic(
+        span=$queryHook,
+        message="client-architecture/no-query-cache-ownership: keep query-cache ownership in the query/mutation adapter or named coordinator, not a leaf component."
+      )
+    }
+  },
+  `useQueryClient($...)` as $match where {
+    register_diagnostic(
+      span=$match,
+      message="client-architecture/no-query-cache-ownership: keep query-cache ownership in the query/mutation adapter or named coordinator, not a leaf component."
+    )
+  },
+  `$queryClient.useQueryClient($...)` as $match where {
+    register_diagnostic(
+      span=$match,
+      message="client-architecture/no-query-cache-ownership: keep query-cache ownership in the query/mutation adapter or named coordinator, not a leaf component."
+    )
+  },
+  `$queryClient.invalidateQueries($...)` as $match where {
+    register_diagnostic(
+      span=$match,
+      message="client-architecture/no-query-cache-ownership: keep query-cache ownership in the query/mutation adapter or named coordinator, not a leaf component."
+    )
+  },
+  `$queryClient.removeQueries($...)` as $match where {
+    register_diagnostic(
+      span=$match,
+      message="client-architecture/no-query-cache-ownership: keep query-cache ownership in the query/mutation adapter or named coordinator, not a leaf component."
+    )
+  },
+  `$queryClient.resetQueries($...)` as $match where {
+    register_diagnostic(
+      span=$match,
+      message="client-architecture/no-query-cache-ownership: keep query-cache ownership in the query/mutation adapter or named coordinator, not a leaf component."
+    )
+  },
+  `$queryClient.setQueriesData($...)` as $match where {
+    register_diagnostic(
+      span=$match,
+      message="client-architecture/no-query-cache-ownership: keep query-cache ownership in the query/mutation adapter or named coordinator, not a leaf component."
+    )
+  },
+  `$queryClient.setQueryData($...)` as $match where {
+    register_diagnostic(
+      span=$match,
+      message="client-architecture/no-query-cache-ownership: keep query-cache ownership in the query/mutation adapter or named coordinator, not a leaf component."
+    )
+  }
+}

--- a/tools/biome/plugins/client-architecture/no-raw-api-request.grit
+++ b/tools/biome/plugins/client-architecture/no-raw-api-request.grit
@@ -1,0 +1,27 @@
+engine biome(1.0)
+language js(typescript, jsx)
+
+or {
+  JsImport() as $import where {
+    $import <: r".*@shipfox/client-api.*",
+    $import <: contains JsNamedImportSpecifier() as $raw where {
+      $raw <: r".*\bapiRequest\b.*",
+      register_diagnostic(
+        span=$raw,
+        message="client-architecture/no-raw-api-request: use checkedApiRequest from a feature-owned adapter instead of raw apiRequest here."
+      )
+    }
+  },
+  `apiRequest($...)` as $match where {
+    register_diagnostic(
+      span=$match,
+      message="client-architecture/no-raw-api-request: use checkedApiRequest from a feature-owned adapter instead of raw apiRequest here."
+    )
+  },
+  `$client.apiRequest($...)` as $match where {
+    register_diagnostic(
+      span=$match,
+      message="client-architecture/no-raw-api-request: use checkedApiRequest from a feature-owned adapter instead of raw apiRequest here."
+    )
+  }
+}

--- a/tools/biome/plugins/client-architecture/no-response-dto-in-presentation.grit
+++ b/tools/biome/plugins/client-architecture/no-response-dto-in-presentation.grit
@@ -1,0 +1,27 @@
+engine biome(1.0)
+language js(typescript, jsx)
+
+or {
+  JsImport() as $import where {
+    $import <: r".*@shipfox/api-.*-dto.*",
+    $import <: contains $name where {
+      $name <: r".*Dto\b.*",
+      $name <: not r".*BodyDto.*",
+      $name <: not r".*QueryDto.*"
+    },
+    register_diagnostic(
+      span=$name,
+      message="client-architecture/no-response-dto-in-presentation: response DTOs stop at the checked adapter; pages and components consume a package-owned domain model."
+    )
+  },
+  TsImportType() as $type where {
+    $type <: r".*@shipfox/api-.*-dto.*",
+    $type <: r".*Dto\b.*",
+    $type <: not r".*BodyDto.*",
+    $type <: not r".*QueryDto.*",
+    register_diagnostic(
+      span=$type,
+      message="client-architecture/no-response-dto-in-presentation: response DTOs stop at the checked adapter; pages and components consume a package-owned domain model."
+    )
+  }
+}

--- a/tools/biome/test/client-architecture-fixtures.d.ts
+++ b/tools/biome/test/client-architecture-fixtures.d.ts
@@ -1,0 +1,44 @@
+// Source-shape fixtures use these module names without adding runtime dependencies
+// to the tooling package.
+
+declare module '@shipfox/api-projects-dto' {
+  export interface ProjectResponseDto {
+    readonly id: string;
+  }
+
+  export interface CreateProjectBodyDto {
+    readonly name: string;
+  }
+
+  export interface ListProjectsQueryDto {
+    readonly cursor?: string;
+  }
+
+  export const createProjectBodySchema: {
+    readonly shape: {
+      readonly name: unknown;
+    };
+  };
+}
+
+declare module '@shipfox/api-workspaces-dto' {
+  export interface WorkspaceResponseDto {
+    readonly id: string;
+  }
+}
+
+declare module '@tanstack/react-query' {
+  export interface QueryClient {}
+
+  export function useQueryClient(): {
+    readonly setQueryData: (...args: unknown[]) => void;
+  };
+
+  export function useQuery(): unknown;
+}
+
+declare module '@shipfox/client-api' {
+  export function apiRequest(...args: unknown[]): unknown;
+
+  export function checkedApiRequest(...args: unknown[]): unknown;
+}

--- a/tools/biome/test/client-architecture-plugins.test.ts
+++ b/tools/biome/test/client-architecture-plugins.test.ts
@@ -12,42 +12,51 @@ const fixtureConfig = resolve(
   workspaceRoot,
   'tools/biome/plugins/client-architecture/fixtures/biome.fixture.json',
 );
-const fixtureRoot = resolve(
-  workspaceRoot,
-  'tools/biome/plugins/client-architecture/fixtures/fixture-boundary',
-);
-const diagnosticRulePattern = /client-architecture\/fixture-boundary/u;
-const replacementBoundaryPattern = /approved feature-owned adapter or coordinator boundary/u;
+const fixtureRoot = resolve(workspaceRoot, 'tools/biome/plugins/client-architecture/fixtures');
 const rejectedLocationPattern = /rejected\.ts:3/u;
 const testFixturePattern = /ignored\.test\.ts/u;
+const storyFixturePattern = /ignored\.stories\.ts/u;
 const generatedFixturePattern = /rejected\.gen\.ts/u;
 
+const fixtureRuleNames = [
+  'fixture-boundary',
+  'no-api-dto-in-core',
+  'no-client-framework-in-core',
+  'no-response-dto-in-presentation',
+  'no-raw-api-request',
+  'no-query-cache-ownership',
+] as const;
+
 describe('client-architecture Biome plugins', () => {
-  test('fails a rejected fixture through the package check wrapper', async () => {
-    await assert.rejects(
-      execFileAsync(process.execPath, [biomeCheck, '--config-path', fixtureConfig, fixtureRoot], {
-        cwd: workspaceRoot,
-      }),
-      (error: unknown) => {
-        const commandError = error as {stdout?: string; stderr?: string};
-        const output = `${commandError.stdout ?? ''}${commandError.stderr ?? ''}`;
-        assert.match(output, diagnosticRulePattern);
-        assert.match(output, replacementBoundaryPattern);
-        assert.match(output, rejectedLocationPattern);
-        assert.doesNotMatch(output, testFixturePattern);
-        assert.doesNotMatch(output, generatedFixturePattern);
-        return true;
-      },
-    );
-  });
+  for (const ruleName of fixtureRuleNames) {
+    const ruleRoot = resolve(fixtureRoot, ruleName);
 
-  test('passes an allowed fixture through the package check wrapper', async () => {
-    const {stdout, stderr} = await execFileAsync(
-      process.execPath,
-      [biomeCheck, '--config-path', fixtureConfig, resolve(fixtureRoot, 'allowed.ts')],
-      {cwd: workspaceRoot},
-    );
+    test(`${ruleName} fails a rejected fixture through the package check wrapper`, async () => {
+      await assert.rejects(
+        execFileAsync(process.execPath, [biomeCheck, '--config-path', fixtureConfig, ruleRoot], {
+          cwd: workspaceRoot,
+        }),
+        (error: unknown) => {
+          const commandError = error as {stdout?: string; stderr?: string};
+          const output = `${commandError.stdout ?? ''}${commandError.stderr ?? ''}`;
+          assert.match(output, new RegExp(`client-architecture/${ruleName}`, 'u'));
+          assert.match(output, rejectedLocationPattern);
+          assert.doesNotMatch(output, testFixturePattern);
+          assert.doesNotMatch(output, storyFixturePattern);
+          assert.doesNotMatch(output, generatedFixturePattern);
+          return true;
+        },
+      );
+    });
 
-    assert.doesNotMatch(`${stdout}${stderr}`, diagnosticRulePattern);
-  });
+    test(`${ruleName} passes an allowed fixture through the package check wrapper`, async () => {
+      const {stdout, stderr} = await execFileAsync(
+        process.execPath,
+        [biomeCheck, '--config-path', fixtureConfig, resolve(fixtureRoot, ruleName, 'allowed.ts')],
+        {cwd: workspaceRoot},
+      );
+
+      assert.doesNotMatch(`${stdout}${stderr}`, new RegExp(`client-architecture/${ruleName}`, 'u'));
+    });
+  }
 });

--- a/tools/client-architecture-policy/src/audit-client-architecture.ts
+++ b/tools/client-architecture-policy/src/audit-client-architecture.ts
@@ -6,14 +6,7 @@ import {fileURLToPath} from 'node:url';
 export interface ClientArchitectureViolation {
   file: string;
   occurrences: number;
-  rule:
-    | 'api-request-outside-adapter'
-    | 'core-api-dto-import'
-    | 'core-client-framework-import'
-    | 'leaf-query-cache-ownership'
-    | 'response-dto-in-presentation'
-    | 'unchecked-route-search'
-    | 'unparsed-api-response';
+  rule: 'api-request-outside-adapter' | 'unchecked-route-search' | 'unparsed-api-response';
 }
 
 const rootDirectory = fileURLToPath(new URL('../../../', import.meta.url));
@@ -23,14 +16,8 @@ const auditedDirectories = [
 ];
 const sourceFilePattern = /\.(?:ts|tsx)$/;
 const nonProductionSourcePattern = /\.(?:stories|test)\.(?:ts|tsx)$/;
-const apiDtoImportPattern = /(?:from\s+|import\()['"]@shipfox\/api-[^'"]+-dto['"]/;
-const clientFrameworkImportPattern =
-  /from\s+['"](?:react(?:-dom)?|jotai|@tanstack\/[^'"]+|@shipfox\/client-(?:api|shell|ui)|@shipfox\/react-ui(?:\/[^'"]+)?)['"]/;
 const apiRequestPattern = /\b(?:apiRequest|checkedApiRequest)\s*(?:<[^>]*>)?\s*\(/;
 const uncheckedApiRequestPattern = /\bapiRequest\s*(?:<[^>]*>)?\s*\(/;
-const queryCachePattern =
-  /\b(?:useQueryClient\s*\(|queryClient\.(?:invalidateQueries|removeQueries|resetQueries|setQueriesData|setQueryData))/;
-const responseDtoNamePattern = /\b[A-Za-z0-9_]+(?<!Body|Query)Dto\b/;
 const routeSearchPattern = /\buseRouteSearch\s*\(/;
 const generatedDirectoryNames = new Set(['dist', 'node_modules']);
 
@@ -59,54 +46,18 @@ function countMatches(source: string, pattern: RegExp): number {
   return [...source.matchAll(new RegExp(pattern.source, flags))].length;
 }
 
-function responseDtoCount(names: string): number {
-  return countMatches(names, responseDtoNamePattern);
-}
-
-function responseDtoImportCount(source: string): number {
-  let count = 0;
-  const imports = source.matchAll(
-    /import(?:\s+type)?\s+([^;]+?)\s+from\s+['"]@shipfox\/api-[^'"]+-dto['"]/g,
-  );
-  for (const match of imports) {
-    const names = match[1] ?? '';
-    count += responseDtoCount(names);
-  }
-  const inlineImports = source.matchAll(
-    /import\(['"]@shipfox\/api-[^'"]+-dto['"]\)\.([A-Za-z0-9_]+)/g,
-  );
-  for (const match of inlineImports) {
-    const name = match[1] ?? '';
-    count += responseDtoCount(name);
-  }
-  return count;
-}
-
 export function auditClientSource(file: string, source: string): ClientArchitectureViolation[] {
   const violations: ClientArchitectureViolation[] = [];
   const normalizedFile = file.split(path.sep).join('/');
-  const isCore = normalizedFile.includes('/src/core/');
   const isAdapter = normalizedFile.includes('/src/hooks/api/');
   const isClientApi = normalizedFile.startsWith('libs/client/api/');
-  const isPresentation =
-    normalizedFile.includes('/src/pages/') || normalizedFile.includes('/src/components/');
   const addViolation = (rule: ClientArchitectureViolation['rule'], occurrences: number): void => {
     if (occurrences > 0) violations.push({file, rule, occurrences});
   };
-  if (isCore) {
-    addViolation('core-api-dto-import', countMatches(source, apiDtoImportPattern));
-    addViolation(
-      'core-client-framework-import',
-      countMatches(source, clientFrameworkImportPattern),
-    );
-  }
   if (!isAdapter && !isClientApi)
     addViolation('api-request-outside-adapter', countMatches(source, apiRequestPattern));
   if (!isClientApi)
     addViolation('unparsed-api-response', countMatches(source, uncheckedApiRequestPattern));
-  if (isPresentation) addViolation('response-dto-in-presentation', responseDtoImportCount(source));
-  if (normalizedFile.includes('/src/components/'))
-    addViolation('leaf-query-cache-ownership', countMatches(source, queryCachePattern));
   if (!normalizedFile.includes('/src/routes/'))
     addViolation('unchecked-route-search', countMatches(source, routeSearchPattern));
   return violations;

--- a/tools/client-architecture-policy/test/audit-client-architecture.test.ts
+++ b/tools/client-architecture-policy/test/audit-client-architecture.test.ts
@@ -92,69 +92,14 @@ describe('auditClientSource', () => {
     ]);
   });
 
-  test('reports inline response DTO imports in presentation', () => {
-    const violations = auditClientSource(
-      'libs/client/projects/src/pages/project-page.tsx',
-      "type Project = import('@shipfox/api-projects-dto').ProjectDto;",
-    );
-
-    assert.deepEqual(violations, [
-      {
-        file: 'libs/client/projects/src/pages/project-page.tsx',
-        occurrences: 1,
-        rule: 'response-dto-in-presentation',
-      },
-    ]);
-  });
-
-  test('reports inline API DTO imports in core', () => {
-    const violations = auditClientSource(
-      'libs/client/projects/src/core/project.ts',
-      "type Project = import('@shipfox/api-projects-dto').ProjectDto;",
-    );
-
-    assert.deepEqual(violations, [
-      {
-        file: 'libs/client/projects/src/core/project.ts',
-        occurrences: 1,
-        rule: 'core-api-dto-import',
-      },
-    ]);
-  });
-
-  test('allows inline request body and query DTO imports in presentation', () => {
-    const violations = auditClientSource(
-      'libs/client/projects/src/pages/project-page.tsx',
-      "type Body = import('@shipfox/api-projects-dto').CreateProjectBody;\ntype Query = import('@shipfox/api-projects-dto').ListProjectsQuery;",
-    );
-
-    assert.deepEqual(violations, []);
-  });
-
-  test('reports each prohibited boundary crossing', () => {
-    const core = auditClientSource(
-      'libs/client/projects/src/core/project.ts',
-      "import type {ProjectDto} from '@shipfox/api-projects-dto';\nimport {useQuery} from '@tanstack/react-query';",
-    );
+  test('reports remaining semantic boundary crossings', () => {
     const page = auditClientSource(
       'libs/client/projects/src/pages/project-page.tsx',
       "import type {ProjectDto} from '@shipfox/api-projects-dto';\nimport {apiRequest} from '@shipfox/client-api';\napiRequest('/projects');",
     );
-    const component = auditClientSource(
-      'libs/client/projects/src/components/project-list.tsx',
-      "import {useQueryClient} from '@tanstack/react-query';\nuseQueryClient();",
-    );
-    assert.deepEqual(
-      core.map((violation) => violation.rule),
-      ['core-api-dto-import', 'core-client-framework-import'],
-    );
     assert.deepEqual(
       page.map((violation) => violation.rule),
-      ['api-request-outside-adapter', 'unparsed-api-response', 'response-dto-in-presentation'],
-    );
-    assert.deepEqual(
-      component.map((violation) => violation.rule),
-      ['leaf-query-cache-ownership'],
+      ['api-request-outside-adapter', 'unparsed-api-response'],
     );
   });
 });


### PR DESCRIPTION
Adds production-safe Biome enforcement for client API, DTO, core-framework, raw-request, and query-cache boundaries.

The plugins use workspace-relative production globs with test, story, and generated-code exclusions, backed by allowed and rejected fixture coverage. The Agent package's remaining response DTO import now consumes its domain model, while the repository verifier retains only semantic checks that are not covered by the structural plugins.

Closes ENG-1182

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces client architecture boundaries with production Biome plugins and removes overlapping regex checks. Blocks raw `apiRequest`, response DTOs in presentation, DTO/framework imports in `src/core`, and leaf query-cache writes; migrates Agent to a domain model.

- **New Features**
  - Adds Biome rules: `no-api-dto-in-core`, `no-client-framework-in-core`, `no-response-dto-in-presentation`, `no-raw-api-request`, `no-query-cache-ownership`.
  - Production-only globs with test/story/generated exclusions for `libs/client/**` and `libs/shared/react/ui/**`.
  - Allowed/rejected fixtures and tests (aliased and type-only imports covered).
  - Docs clarify package Biome checks vs repository verifier.
  - Aligns with Linear ENG-1182 acceptance criteria.

- **Refactors**
  - `@shipfox/client-agent`: switch response DTO type to `#core` domain model in `custom-model-provider-api-options.ts`.
  - Repository verifier now keeps only `api-request-outside-adapter`, `unparsed-api-response`, and `unchecked-route-search`.
  - Removes regex-only boundary checks now enforced by Biome.

<sup>Written for commit f66776a36f4c18a5fced85c0a75bfb695ff71768. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

