### PR TITLE
[storybook] Assemble and verify the Storybook preview artifact

### DIFF
--- a/apps/storybook/.gitignore
+++ b/apps/storybook/.gitignore
@@ -1,1 +1,2 @@
 storybook-static/
+.vercel/

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -9,13 +9,16 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "pnpm run build:children && pnpm run storybook:build",
+    "build": "pnpm run build:children && pnpm run storybook:build && pnpm run artifact:assemble",
+    "artifact:assemble": "tsx scripts/assemble.ts",
+    "artifact:verify": "tsx scripts/verify.ts",
     "build:children": "tsx scripts/build-children.ts",
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
     "storybook": "pnpm run build:children && storybook dev -p 6015",
     "storybook:build": "storybook build -o storybook-static",
     "test": "shipfox-vitest-run",
+    "test:e2e": "pnpm run artifact:verify && shipfox-playwright-test",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"
   },
@@ -26,6 +29,7 @@
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",
+    "@shipfox/playwright": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",
     "@shipfox/vitest": "workspace:*",

--- a/apps/storybook/playwright.config.ts
+++ b/apps/storybook/playwright.config.ts
@@ -1,0 +1,18 @@
+import {defineConfig} from '@shipfox/playwright';
+
+export default defineConfig({
+  testDir: './test/smoke',
+  testMatch: '**/*.e2e.ts',
+  reporter: process.env.CI ? 'github' : 'list',
+  timeout: 60_000,
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    trace: 'retain-on-failure',
+  },
+  webServer: {
+    command: 'pnpm exec tsx scripts/serve-preview.ts',
+    url: 'http://127.0.0.1:4173/',
+    reuseExistingServer: !process.env.CI,
+    timeout: 30_000,
+  },
+});

--- a/apps/storybook/preview-manifest.ts
+++ b/apps/storybook/preview-manifest.ts
@@ -8,6 +8,8 @@ export type StorybookManifestEntry = {
   readonly url: `/${string}/index.html`;
 };
 
+export const storybookManifestVersion = 1;
+
 export const storybooks = [
   {
     id: 'react-ui',
@@ -111,7 +113,7 @@ export type StorybookRef = {
 };
 
 export const storybookRefs = Object.fromEntries(
-  storybooks.map(({id, title, url}) => [id, {title, url}]),
+  storybooks.map(({id, title, path}) => [id, {title, url: path}]),
 ) as Record<StorybookId, StorybookRef>;
 
 export const storybookLinks = storybooks.map(({id, title, url}) => ({

--- a/apps/storybook/scripts/artifact.ts
+++ b/apps/storybook/scripts/artifact.ts
@@ -1,0 +1,393 @@
+import {readdir, readFile, stat} from 'node:fs/promises';
+import {dirname, extname, relative, resolve, sep} from 'node:path';
+import {storybookManifestVersion, storybooks} from '../preview-manifest.js';
+
+export const defaultMaxFileBytes = 100 * 1024 * 1024;
+
+type FileMetric = {
+  path: string;
+  bytes: number;
+};
+
+export type ArtifactMetrics = {
+  fileCount: number;
+  bytes: number;
+  oversizedFiles: FileMetric[];
+};
+
+export type StorybookMetrics = ArtifactMetrics & {
+  id: string;
+};
+
+export type PreviewArtifactMetrics = {
+  shell: ArtifactMetrics;
+  children: StorybookMetrics[];
+  total: ArtifactMetrics;
+};
+
+type ValidateStorybookDirectoryOptions = {
+  artifactRoot: string;
+  directory: string;
+  label: string;
+  maxFileBytes: number;
+};
+
+type VerifyPreviewArtifactOptions = {
+  maxFileBytes?: number;
+  staticRoot: string;
+};
+
+const requiredFiles = ['index.html', 'iframe.html', 'index.json'] as const;
+const protocolPattern = /^[a-z][a-z\d+.-]*:/i;
+const queryOrHashPattern = /[?#]/;
+const styleBlockPattern = /<style[^>]*>([\s\S]*?)<\/style>/gi;
+const scriptBlockPattern = /(<script\b[^>]*>)[\s\S]*?<\/script>/gi;
+
+function isWithin(root: string, candidate: string): boolean {
+  return candidate === root || candidate.startsWith(`${root}${sep}`);
+}
+
+async function walkFiles(root: string, current = root): Promise<string[]> {
+  const entries = await readdir(current, {withFileTypes: true});
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const entryPath = resolve(current, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...(await walkFiles(root, entryPath)));
+      continue;
+    }
+
+    if (entry.isFile()) files.push(relative(root, entryPath));
+  }
+
+  return files;
+}
+
+async function collectMetrics(
+  root: string,
+  artifactRoot: string,
+  maxFileBytes: number,
+  excludedPrefixes: string[] = [],
+  excludedFiles: string[] = [],
+): Promise<ArtifactMetrics> {
+  const files = await walkFiles(root);
+  let bytes = 0;
+  let fileCount = 0;
+  const oversizedFiles: FileMetric[] = [];
+
+  for (const file of files) {
+    const normalizedFile = file.split(sep).join('/');
+    const isExcluded =
+      excludedFiles.includes(normalizedFile) ||
+      excludedPrefixes.some(
+        (prefix) => normalizedFile === prefix || normalizedFile.startsWith(`${prefix}/`),
+      );
+
+    if (isExcluded) continue;
+
+    const filePath = resolve(root, file);
+    const fileStats = await stat(filePath);
+    const artifactPath = relative(artifactRoot, filePath).split(sep).join('/');
+
+    fileCount += 1;
+    bytes += fileStats.size;
+    if (fileStats.size > maxFileBytes)
+      oversizedFiles.push({path: artifactPath, bytes: fileStats.size});
+  }
+
+  return {fileCount, bytes, oversizedFiles};
+}
+
+function shouldSkipReference(reference: string): boolean {
+  return (
+    reference.length === 0 ||
+    reference.startsWith('#') ||
+    reference.startsWith('//') ||
+    reference.startsWith('data:') ||
+    reference.startsWith('blob:') ||
+    reference.startsWith('mailto:') ||
+    protocolPattern.test(reference)
+  );
+}
+
+function resolveLocalReference(
+  reference: string,
+  sourceFile: string,
+  staticRoot: string,
+): string | null {
+  const trimmedReference = reference.trim();
+  if (shouldSkipReference(trimmedReference)) return null;
+
+  const pathOnly = trimmedReference.split(queryOrHashPattern, 1)[0];
+  if (pathOnly === undefined || pathOnly.length === 0) return null;
+
+  const candidate = pathOnly.startsWith('/')
+    ? resolve(staticRoot, `.${pathOnly}`)
+    : resolve(dirname(sourceFile), pathOnly);
+
+  if (!isWithin(staticRoot, candidate)) {
+    throw new Error(`local asset reference escapes the artifact: ${trimmedReference}`);
+  }
+
+  return candidate;
+}
+
+function findAssetReferences(content: string, includeCssUrls: boolean): string[] {
+  const references = new Set<string>();
+  const attributePattern = /\b(?:src|href)\s*=\s*["']([^"']+)["']/gi;
+  const cssPattern = /url\(\s*["']?([^"')]+)["']?\s*\)/gi;
+  const markupContent = includeCssUrls ? content : content.replace(scriptBlockPattern, '$1');
+
+  for (const match of markupContent.matchAll(attributePattern)) {
+    if (match[1] !== undefined) references.add(match[1]);
+  }
+
+  if (includeCssUrls) {
+    for (const match of content.matchAll(cssPattern)) {
+      if (match[1] !== undefined) references.add(match[1]);
+    }
+  } else {
+    for (const styleBlock of content.matchAll(styleBlockPattern)) {
+      const styleContent = styleBlock[1];
+      if (styleContent === undefined) continue;
+
+      for (const match of styleContent.matchAll(cssPattern)) {
+        if (match[1] !== undefined) references.add(match[1]);
+      }
+    }
+  }
+
+  return [...references];
+}
+
+async function validateReferencedAssets(directory: string, staticRoot: string): Promise<void> {
+  const files = await walkFiles(directory);
+  const filesToScan = files.filter((file) =>
+    ['.html', '.css'].includes(extname(file).toLowerCase()),
+  );
+
+  for (const file of filesToScan) {
+    const sourceFile = resolve(directory, file);
+    const content = await readFile(sourceFile, 'utf8');
+
+    for (const reference of findAssetReferences(content, extname(file).toLowerCase() === '.css')) {
+      const assetPath = resolveLocalReference(reference, sourceFile, staticRoot);
+      if (assetPath === null) continue;
+
+      let assetExists = false;
+      try {
+        assetExists = (await stat(assetPath)).isFile();
+      } catch {
+        assetExists = false;
+      }
+
+      if (!assetExists) {
+        const source = relative(staticRoot, sourceFile).split(sep).join('/');
+        throw new Error(`missing local asset ${reference} referenced by ${source}`);
+      }
+    }
+  }
+}
+
+export async function validateStorybookDirectory(
+  options: ValidateStorybookDirectoryOptions,
+): Promise<void> {
+  const {artifactRoot, directory, label, maxFileBytes} = options;
+
+  for (const file of requiredFiles) {
+    const filePath = resolve(directory, file);
+    let fileStats: Awaited<ReturnType<typeof stat>>;
+
+    try {
+      fileStats = await stat(filePath);
+    } catch {
+      throw new Error(`${label} is missing required ${file}`);
+    }
+
+    if (!fileStats.isFile() || fileStats.size === 0) {
+      throw new Error(`${label} has an empty or invalid ${file}`);
+    }
+  }
+
+  let index: unknown;
+  try {
+    index = JSON.parse(await readFile(resolve(directory, 'index.json'), 'utf8'));
+  } catch (error) {
+    throw new Error(
+      `${label} has an invalid index.json: ${error instanceof Error ? error.message : error}`,
+    );
+  }
+
+  const entries =
+    typeof index === 'object' && index !== null && 'entries' in index
+      ? (index as {entries?: unknown}).entries
+      : undefined;
+
+  if (typeof entries !== 'object' || entries === null || Array.isArray(entries)) {
+    throw new Error(`${label} index.json does not contain an entries object`);
+  }
+
+  if (Object.keys(entries).length === 0) {
+    throw new Error(`${label} index.json contains no stories or documentation entries`);
+  }
+
+  await validateReferencedAssets(directory, artifactRoot);
+
+  const metrics = await collectMetrics(directory, artifactRoot, maxFileBytes);
+  if (metrics.oversizedFiles.length > 0) {
+    const files = metrics.oversizedFiles
+      .map(({path, bytes}) => `${path} (${bytes} bytes)`)
+      .join(', ');
+    throw new Error(`${label} contains files over ${maxFileBytes} bytes: ${files}`);
+  }
+}
+
+function combineMetrics(metrics: ArtifactMetrics[]): ArtifactMetrics {
+  return {
+    fileCount: metrics.reduce((total, metric) => total + metric.fileCount, 0),
+    bytes: metrics.reduce((total, metric) => total + metric.bytes, 0),
+    oversizedFiles: metrics.flatMap((metric) => metric.oversizedFiles),
+  };
+}
+
+function formatValidationFailures(failures: string[]): string {
+  return [
+    'Storybook preview verification failed:',
+    ...failures.map((failure) => `- ${failure}`),
+  ].join('\n');
+}
+
+export async function verifyPreviewArtifact(
+  options: VerifyPreviewArtifactOptions,
+): Promise<PreviewArtifactMetrics> {
+  const maxFileBytes = options.maxFileBytes ?? defaultMaxFileBytes;
+  const failures: string[] = [];
+
+  try {
+    await validateStorybookDirectory({
+      artifactRoot: options.staticRoot,
+      directory: options.staticRoot,
+      label: 'Composition shell',
+      maxFileBytes,
+    });
+  } catch (error) {
+    failures.push(error instanceof Error ? error.message : String(error));
+  }
+
+  for (const entry of storybooks) {
+    try {
+      await validateStorybookDirectory({
+        artifactRoot: options.staticRoot,
+        directory: resolve(options.staticRoot, entry.id),
+        label: entry.id,
+        maxFileBytes,
+      });
+    } catch (error) {
+      failures.push(error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  if (failures.length > 0) throw new Error(formatValidationFailures(failures));
+
+  const shell = await collectMetrics(
+    options.staticRoot,
+    options.staticRoot,
+    maxFileBytes,
+    storybooks.map(({id}) => id),
+    ['preview-metadata.json'],
+  );
+  const children = await Promise.all(
+    storybooks.map(
+      async (entry): Promise<StorybookMetrics> => ({
+        id: entry.id,
+        ...(await collectMetrics(
+          resolve(options.staticRoot, entry.id),
+          options.staticRoot,
+          maxFileBytes,
+        )),
+      }),
+    ),
+  );
+  const total = combineMetrics([shell, ...children]);
+
+  if (total.oversizedFiles.length > 0) {
+    const files = total.oversizedFiles
+      .map(({path, bytes}) => `${path} (${bytes} bytes)`)
+      .join(', ');
+    throw new Error(`Storybook preview contains files over ${maxFileBytes} bytes: ${files}`);
+  }
+
+  return {shell, children, total};
+}
+
+const commitShaEnvironmentVariables = [
+  'PREVIEW_COMMIT_SHA',
+  'GITHUB_SHA',
+  'VERCEL_GIT_COMMIT_SHA',
+] as const;
+
+export function getCommitShaFromEnv(): string | undefined {
+  return commitShaEnvironmentVariables
+    .map((name) => process.env[name])
+    .find((value) => value !== undefined && value !== '');
+}
+
+export function getMaxFileBytes(): number {
+  const configuredValue = process.env.STORYBOOK_PREVIEW_MAX_FILE_BYTES;
+  if (configuredValue === undefined) return defaultMaxFileBytes;
+
+  const maxFileBytes = Number(configuredValue);
+  if (!Number.isSafeInteger(maxFileBytes) || maxFileBytes <= 0) {
+    throw new Error('STORYBOOK_PREVIEW_MAX_FILE_BYTES must be a positive integer');
+  }
+
+  return maxFileBytes;
+}
+
+export type PreviewMetadata = {
+  version: 1;
+  commitSha: string;
+  buildTime: string;
+  manifestVersion: typeof storybookManifestVersion;
+  pullRequest: {
+    number: number;
+    title: string | null;
+    url: string | null;
+    headSha: string | null;
+    headRef: string | null;
+    baseRef: string | null;
+  } | null;
+  metrics: PreviewArtifactMetrics;
+};
+
+export function assertPreviewMetadata(
+  metadata: unknown,
+  expectedCommitSha?: string,
+): asserts metadata is PreviewMetadata {
+  if (typeof metadata !== 'object' || metadata === null) {
+    throw new Error('preview-metadata.json must contain an object');
+  }
+
+  const candidate = metadata as Partial<PreviewMetadata>;
+  if (candidate.version !== 1) throw new Error('preview-metadata.json has an unsupported version');
+  if (typeof candidate.commitSha !== 'string' || candidate.commitSha.length === 0) {
+    throw new Error('preview-metadata.json is missing commitSha');
+  }
+  if (candidate.manifestVersion !== storybookManifestVersion) {
+    throw new Error('preview-metadata.json has an unsupported manifestVersion');
+  }
+  if (typeof candidate.buildTime !== 'string' || Number.isNaN(Date.parse(candidate.buildTime))) {
+    throw new Error('preview-metadata.json has an invalid buildTime');
+  }
+  if (expectedCommitSha !== undefined && candidate.commitSha !== expectedCommitSha) {
+    throw new Error(
+      `preview-metadata.json commitSha ${candidate.commitSha} does not match expected ${expectedCommitSha}`,
+    );
+  }
+}
+
+export function formatMetrics(metrics: PreviewArtifactMetrics): string {
+  return JSON.stringify(metrics, null, 2);
+}

--- a/apps/storybook/scripts/assemble.ts
+++ b/apps/storybook/scripts/assemble.ts
@@ -1,0 +1,231 @@
+import {execFileSync} from 'node:child_process';
+import {randomUUID} from 'node:crypto';
+import {cp, mkdir, mkdtemp, readFile, rename, rm, writeFile} from 'node:fs/promises';
+import {dirname, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {storybookManifestVersion, storybooks} from '../preview-manifest.js';
+import {
+  assertPreviewMetadata,
+  formatMetrics,
+  getCommitShaFromEnv,
+  getMaxFileBytes,
+  type PreviewMetadata,
+  validateStorybookDirectory,
+  verifyPreviewArtifact,
+} from './artifact.js';
+
+const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const repositoryRoot = resolve(appRoot, '../..');
+const shellOutput = resolve(appRoot, 'storybook-static');
+const outputParent = resolve(appRoot, '.vercel');
+const outputRoot = resolve(outputParent, 'output');
+
+const childIdPattern = storybooks.map(({id}) => id).join('|');
+
+const buildOutputConfig = {
+  version: 3,
+  routes: [
+    {handle: 'filesystem'},
+    {src: `^/(${childIdPattern})$`, dest: '/$1/index.html'},
+    {src: '^/([^/]+)/.*$', dest: '/$1/index.html'},
+    {src: '^/(.*)$', dest: '/index.html'},
+  ],
+};
+
+type StorybookIndex = {
+  entries?: Record<string, Record<string, unknown>>;
+};
+
+async function writeCompositionCompatibilityFiles(directory: string): Promise<void> {
+  const index = JSON.parse(
+    await readFile(resolve(directory, 'index.json'), 'utf8'),
+  ) as StorybookIndex;
+  const entries = index.entries ?? {};
+  const stories = Object.fromEntries(
+    Object.values(entries).map((entry) => {
+      if (typeof entry.id !== 'string')
+        throw new Error(`Storybook entry in ${directory} is missing an id`);
+
+      return [
+        entry.id,
+        {
+          ...entry,
+          kind: entry.title,
+          story: entry.name,
+          parameters: {fileName: entry.importPath},
+        },
+      ];
+    }),
+  );
+
+  await writeFile(
+    resolve(directory, 'stories.json'),
+    `${JSON.stringify({v: 3, stories}, null, 2)}\n`,
+    'utf8',
+  );
+  await writeFile(resolve(directory, 'metadata.json'), '{}\n', 'utf8');
+}
+
+function getCommitSha(): string {
+  const configuredSha = getCommitShaFromEnv();
+  if (configuredSha !== undefined) return configuredSha;
+
+  return execFileSync('git', ['rev-parse', 'HEAD'], {cwd: repositoryRoot, encoding: 'utf8'}).trim();
+}
+
+async function getGitHubEvent(): Promise<Record<string, unknown> | null> {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (eventPath === undefined || eventPath.length === 0) return null;
+
+  try {
+    return JSON.parse(await readFile(eventPath, 'utf8')) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function getPullRequestNumber(event: Record<string, unknown> | null): number | null {
+  const eventPullRequest = event?.pull_request;
+  const eventNumber =
+    typeof eventPullRequest === 'object' &&
+    eventPullRequest !== null &&
+    'number' in eventPullRequest
+      ? (eventPullRequest as {number?: unknown}).number
+      : undefined;
+  const configuredNumber = process.env.GITHUB_PR_NUMBER;
+  const number =
+    eventNumber ?? (configuredNumber === undefined ? undefined : Number(configuredNumber));
+
+  return typeof number === 'number' && Number.isInteger(number) && number > 0 ? number : null;
+}
+
+async function getPullRequestMetadata(): Promise<PreviewMetadata['pullRequest']> {
+  const event = await getGitHubEvent();
+  const eventPullRequest = event?.pull_request;
+  const pullRequest =
+    typeof eventPullRequest === 'object' && eventPullRequest !== null
+      ? (eventPullRequest as Record<string, unknown>)
+      : null;
+  const number = getPullRequestNumber(event);
+
+  if (number === null) return null;
+
+  const head =
+    typeof pullRequest?.head === 'object' && pullRequest.head !== null
+      ? (pullRequest.head as Record<string, unknown>)
+      : null;
+  const base =
+    typeof pullRequest?.base === 'object' && pullRequest.base !== null
+      ? (pullRequest.base as Record<string, unknown>)
+      : null;
+
+  return {
+    number,
+    title: typeof pullRequest?.title === 'string' ? pullRequest.title : null,
+    url: typeof pullRequest?.html_url === 'string' ? pullRequest.html_url : null,
+    headSha: typeof head?.sha === 'string' ? head.sha : null,
+    headRef: typeof head?.ref === 'string' ? head.ref : (process.env.GITHUB_HEAD_REF ?? null),
+    baseRef: typeof base?.ref === 'string' ? base.ref : (process.env.GITHUB_BASE_REF ?? null),
+  };
+}
+
+async function buildMetadata(metrics: PreviewMetadata['metrics']): Promise<PreviewMetadata> {
+  return {
+    version: 1,
+    commitSha: getCommitSha(),
+    buildTime: process.env.PREVIEW_BUILD_TIME ?? new Date().toISOString(),
+    manifestVersion: storybookManifestVersion,
+    pullRequest: await getPullRequestMetadata(),
+    metrics,
+  };
+}
+
+async function replaceOutputAtomically(stagedOutput: string): Promise<void> {
+  const previousOutput = resolve(outputParent, `.output-previous-${randomUUID()}`);
+  let movedPreviousOutput = false;
+
+  try {
+    await rename(outputRoot, previousOutput);
+    movedPreviousOutput = true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+
+  try {
+    await rename(stagedOutput, outputRoot);
+  } catch (error) {
+    if (movedPreviousOutput) await rename(previousOutput, outputRoot);
+    throw error;
+  }
+
+  if (movedPreviousOutput) {
+    try {
+      await rm(previousOutput, {recursive: true, force: true});
+    } catch (error) {
+      process.stderr.write(
+        `Warning: failed to remove previous preview output at ${previousOutput}: ${error instanceof Error ? error.message : error}\n`,
+      );
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const maxFileBytes = getMaxFileBytes();
+  await mkdir(outputParent, {recursive: true});
+
+  let stagedOutput: string | undefined;
+  try {
+    stagedOutput = await mkdtemp(resolve(outputParent, '.output-staging-'));
+    const stagedStaticRoot = resolve(stagedOutput, 'static');
+    await mkdir(stagedStaticRoot, {recursive: true});
+
+    await cp(shellOutput, stagedStaticRoot, {recursive: true});
+
+    for (const entry of storybooks) {
+      const source = resolve(repositoryRoot, entry.source);
+      await validateStorybookDirectory({
+        artifactRoot: source,
+        directory: source,
+        label: entry.id,
+        maxFileBytes,
+      });
+
+      const destination = resolve(stagedStaticRoot, entry.id);
+      await rm(destination, {recursive: true, force: true});
+      await cp(source, destination, {recursive: true});
+    }
+
+    await writeCompositionCompatibilityFiles(stagedStaticRoot);
+    for (const entry of storybooks) {
+      await writeCompositionCompatibilityFiles(resolve(stagedStaticRoot, entry.id));
+    }
+
+    const metrics = await verifyPreviewArtifact({staticRoot: stagedStaticRoot, maxFileBytes});
+    const metadata = await buildMetadata(metrics);
+    assertPreviewMetadata(metadata);
+    await writeFile(
+      resolve(stagedStaticRoot, 'preview-metadata.json'),
+      `${JSON.stringify(metadata, null, 2)}\n`,
+      'utf8',
+    );
+    await writeFile(
+      resolve(stagedOutput, 'config.json'),
+      `${JSON.stringify(buildOutputConfig, null, 2)}\n`,
+      'utf8',
+    );
+
+    const verifiedMetrics = await verifyPreviewArtifact({
+      staticRoot: stagedStaticRoot,
+      maxFileBytes,
+    });
+    process.stdout.write(`Assembled Storybook preview artifact at ${outputRoot}\n`);
+    process.stdout.write(`${formatMetrics(verifiedMetrics)}\n`);
+
+    await replaceOutputAtomically(stagedOutput);
+    stagedOutput = undefined;
+  } finally {
+    if (stagedOutput !== undefined) await rm(stagedOutput, {recursive: true, force: true});
+  }
+}
+
+await main();

--- a/apps/storybook/scripts/serve-preview.ts
+++ b/apps/storybook/scripts/serve-preview.ts
@@ -1,0 +1,103 @@
+import {readFile, stat} from 'node:fs/promises';
+import {createServer, type IncomingMessage, type ServerResponse} from 'node:http';
+import {dirname, extname, resolve, sep} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {storybookManifest} from '../preview-manifest.js';
+
+const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const staticRoot = resolve(appRoot, '.vercel/output/static');
+const port = Number(process.env.STORYBOOK_PREVIEW_PORT ?? 4173);
+const host = process.env.STORYBOOK_PREVIEW_HOST ?? '127.0.0.1';
+const leadingSlashPattern = /^\//;
+
+const contentTypes: Record<string, string> = {
+  '.css': 'text/css; charset=utf-8',
+  '.gif': 'image/gif',
+  '.html': 'text/html; charset=utf-8',
+  '.ico': 'image/x-icon',
+  '.jpeg': 'image/jpeg',
+  '.jpg': 'image/jpeg',
+  '.js': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.wasm': 'application/wasm',
+  '.webp': 'image/webp',
+  '.woff2': 'font/woff2',
+};
+
+function sendResponse(response: ServerResponse, statusCode: number, body: string): void {
+  response.statusCode = statusCode;
+  response.setHeader('content-type', 'text/plain; charset=utf-8');
+  response.end(body);
+}
+
+function isChildPath(pathname: string): boolean {
+  const firstSegment = pathname.split('/').filter(Boolean)[0];
+  return firstSegment !== undefined && storybookManifest.some(({id}) => id === firstSegment);
+}
+
+function resolveRequestPath(pathname: string): string {
+  const decodedPath = decodeURIComponent(pathname);
+  const candidate = resolve(staticRoot, `.${decodedPath}`);
+  if (candidate === staticRoot || candidate.startsWith(`${staticRoot}${sep}`)) return candidate;
+  throw new Error('request path escapes the preview artifact');
+}
+
+async function findFile(pathname: string): Promise<string | null> {
+  const candidate = resolveRequestPath(pathname);
+
+  try {
+    const candidateStats = await stat(candidate);
+    if (candidateStats.isFile()) return candidate;
+    if (candidateStats.isDirectory()) {
+      const indexPath = resolve(candidate, 'index.html');
+      return (await stat(indexPath)).isFile() ? indexPath : null;
+    }
+  } catch {
+    // Storybook uses client-side routes for deep links without a file extension.
+  }
+
+  if (pathname.includes('.')) return null;
+  return resolve(
+    staticRoot,
+    isChildPath(pathname)
+      ? `${pathname.replace(leadingSlashPattern, '')}/index.html`
+      : 'index.html',
+  );
+}
+
+async function handleRequest(request: IncomingMessage, response: ServerResponse): Promise<void> {
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    sendResponse(response, 405, 'Method Not Allowed');
+    return;
+  }
+
+  try {
+    const requestUrl = new URL(request.url ?? '/', `http://${host}:${port}`);
+    const filePath = await findFile(requestUrl.pathname);
+    if (filePath === null) {
+      sendResponse(response, 404, 'Not Found');
+      return;
+    }
+
+    const body = await readFile(filePath);
+    response.statusCode = 200;
+    response.setHeader(
+      'content-type',
+      contentTypes[extname(filePath)] ?? 'application/octet-stream',
+    );
+    response.setHeader('content-length', body.byteLength);
+    response.end(request.method === 'HEAD' ? undefined : body);
+  } catch (error) {
+    sendResponse(response, 400, error instanceof Error ? error.message : 'Bad Request');
+  }
+}
+
+const server = createServer((request, response) => {
+  void handleRequest(request, response);
+});
+
+server.listen(port, host, () => {
+  process.stdout.write(`Serving ${staticRoot} at http://${host}:${port}\n`);
+});

--- a/apps/storybook/scripts/verify.ts
+++ b/apps/storybook/scripts/verify.ts
@@ -1,0 +1,33 @@
+import {readFile} from 'node:fs/promises';
+import {dirname, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {
+  assertPreviewMetadata,
+  formatMetrics,
+  getCommitShaFromEnv,
+  getMaxFileBytes,
+  verifyPreviewArtifact,
+} from './artifact.js';
+
+const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const outputRoot = resolve(appRoot, '.vercel/output');
+const staticRoot = resolve(outputRoot, 'static');
+
+async function main(): Promise<void> {
+  const config = JSON.parse(await readFile(resolve(outputRoot, 'config.json'), 'utf8')) as {
+    version?: unknown;
+  };
+  if (config.version !== 3)
+    throw new Error('.vercel/output/config.json must use Build Output API version 3');
+
+  const metadata = JSON.parse(
+    await readFile(resolve(staticRoot, 'preview-metadata.json'), 'utf8'),
+  ) as unknown;
+  assertPreviewMetadata(metadata, getCommitShaFromEnv());
+
+  const metrics = await verifyPreviewArtifact({staticRoot, maxFileBytes: getMaxFileBytes()});
+  process.stdout.write(`Verified Storybook preview artifact at ${outputRoot}\n`);
+  process.stdout.write(`${formatMetrics(metrics)}\n`);
+}
+
+await main();

--- a/apps/storybook/test/artifact.test.ts
+++ b/apps/storybook/test/artifact.test.ts
@@ -1,0 +1,71 @@
+import {mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {afterEach, describe, expect, it} from '@shipfox/vitest/vitest';
+import {defaultMaxFileBytes, validateStorybookDirectory} from '../scripts/artifact.js';
+
+const temporaryDirectories: string[] = [];
+
+async function createFixture(
+  index: Record<string, unknown> = {story: {type: 'story'}},
+): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'shipfox-storybook-artifact-'));
+  temporaryDirectories.push(root);
+  await mkdir(join(root, 'assets'));
+  await writeFile(join(root, 'index.html'), '<script src="./assets/app.js"></script>');
+  await writeFile(join(root, 'iframe.html'), '<link href="./assets/app.css" rel="stylesheet">');
+  await writeFile(join(root, 'index.json'), JSON.stringify({v: 5, entries: index}));
+  await writeFile(join(root, 'assets/app.js'), 'export {};');
+  await writeFile(join(root, 'assets/app.css'), 'body { color: black; }');
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, {recursive: true, force: true})),
+  );
+});
+
+describe('Storybook artifact validation', () => {
+  it('accepts a complete Storybook output and its local assets', async () => {
+    const directory = await createFixture();
+
+    await expect(
+      validateStorybookDirectory({
+        artifactRoot: directory,
+        directory,
+        label: 'fixture',
+        maxFileBytes: defaultMaxFileBytes,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('rejects an empty Storybook index', async () => {
+    const directory = await createFixture({});
+
+    await expect(
+      validateStorybookDirectory({
+        artifactRoot: directory,
+        directory,
+        label: 'fixture',
+        maxFileBytes: defaultMaxFileBytes,
+      }),
+    ).rejects.toThrow('contains no stories or documentation entries');
+  });
+
+  it('rejects a missing local asset', async () => {
+    const directory = await createFixture();
+    await rm(join(directory, 'assets/app.js'));
+
+    await expect(
+      validateStorybookDirectory({
+        artifactRoot: directory,
+        directory,
+        label: 'fixture',
+        maxFileBytes: defaultMaxFileBytes,
+      }),
+    ).rejects.toThrow('missing local asset');
+  });
+});

--- a/apps/storybook/test/preview-manifest.test.ts
+++ b/apps/storybook/test/preview-manifest.test.ts
@@ -19,7 +19,9 @@ describe('storybook preview manifest', () => {
   it('derives Composition refs and standalone links from the same entries', () => {
     expect(Object.keys(storybookRefs)).toEqual(storybooks.map(({id}) => id));
     expect(storybookLinks).toEqual(storybooks.map(({id, title, url}) => ({id, title, url})));
-    expect(Object.values(storybookRefs)).toEqual(storybooks.map(({title, url}) => ({title, url})));
+    expect(Object.values(storybookRefs)).toEqual(
+      storybooks.map(({title, path}) => ({title, url: path})),
+    );
   });
 
   it('points each composed Storybook link at its static index document', () => {

--- a/apps/storybook/test/smoke/preview.e2e.ts
+++ b/apps/storybook/test/smoke/preview.e2e.ts
@@ -1,0 +1,101 @@
+import {type APIRequestContext, expect, type Page, test} from '@shipfox/playwright';
+import {storybooks} from '../../preview-manifest.js';
+
+type StorybookIndexEntry = {
+  id: string;
+  type: string;
+};
+
+type StorybookIndex = {
+  entries: Record<string, StorybookIndexEntry>;
+};
+
+const compositionStoryUrlPattern = /\/\?path=\/story\/react-ui_/;
+
+async function getRepresentativeStoryId(request: APIRequestContext, path: string): Promise<string> {
+  const response = await request.get(`${path}index.json`);
+  expect(response.ok()).toBe(true);
+
+  const index = (await response.json()) as StorybookIndex;
+  const story = Object.values(index.entries).find((entry) => entry.type === 'story');
+  if (story === undefined) throw new Error(`${path} has no representative story`);
+
+  return story.id;
+}
+
+function collectBrowserErrors(page: Page): string[] {
+  const errors: string[] = [];
+  page.on('console', (message) => {
+    if (message.type() === 'error') errors.push(`console: ${message.text()}`);
+  });
+  page.on('pageerror', (error) => errors.push(`page: ${error.message}`));
+  page.on('requestfailed', (request) => {
+    const errorText = request.failure()?.errorText;
+    if (errorText !== 'net::ERR_ABORTED') {
+      errors.push(`request: ${request.url()} ${errorText ?? 'failed'}`);
+    }
+  });
+  return errors;
+}
+
+test.describe('assembled Storybook preview', () => {
+  test('loads Composition refs and navigates to a standalone child', async ({page}) => {
+    const errors = collectBrowserErrors(page);
+
+    await page.goto('/');
+
+    const refs = await page.evaluate(() => {
+      const value = (window as Window & {REFS?: Record<string, {url: string}>}).REFS;
+      return value === undefined ? {} : value;
+    });
+    expect(Object.keys(refs)).toEqual(storybooks.map(({id}) => id));
+
+    for (const storybook of storybooks) {
+      await expect(page.locator('body')).toContainText(storybook.title);
+    }
+
+    await page.getByText('Accordion', {exact: true}).click();
+    await expect(page).toHaveURL(compositionStoryUrlPattern);
+    expect(errors).toEqual([]);
+  });
+
+  test('renders one representative story from every child without browser errors', async ({
+    browser,
+    request,
+  }) => {
+    const context = await browser.newContext();
+
+    for (const storybook of storybooks) {
+      const storyId = await getRepresentativeStoryId(request, storybook.path);
+      const page = await context.newPage();
+      const errors = collectBrowserErrors(page);
+      const response = await page.goto(`${storybook.path}iframe.html?id=${storyId}&viewMode=story`);
+
+      expect(response?.ok()).toBe(true);
+      await expect(page.locator('#storybook-root')).toBeVisible();
+      expect(errors).toEqual([]);
+      await page.close();
+    }
+
+    await context.close();
+  });
+
+  test('serves standalone child URLs and refreshes deep links', async ({page, request}) => {
+    const errors = collectBrowserErrors(page);
+
+    for (const storybook of storybooks) {
+      const storyId = await getRepresentativeStoryId(request, storybook.path);
+
+      const standaloneResponse = await page.goto(storybook.path);
+      expect(standaloneResponse?.ok()).toBe(true);
+      await expect(page.locator('#root')).toBeVisible();
+
+      const deepLink = `${storybook.path}?path=/story/${storyId}`;
+      await page.goto(deepLink);
+      await page.reload();
+      await expect(page.locator('#root')).toBeVisible();
+    }
+
+    expect(errors).toEqual([]);
+  });
+});

--- a/apps/storybook/tsconfig.build.json
+++ b/apps/storybook/tsconfig.build.json
@@ -5,6 +5,12 @@
     "outDir": "dist",
     "types": ["node"]
   },
-  "include": [".storybook", "preview-manifest.ts", "scripts", "vitest.config.ts"],
+  "include": [
+    ".storybook",
+    "playwright.config.ts",
+    "preview-manifest.ts",
+    "scripts",
+    "vitest.config.ts"
+  ],
   "exclude": ["**/*.test.ts", "**/*.test.tsx", "src/**/*.mdx"]
 }

--- a/apps/storybook/tsconfig.test.json
+++ b/apps/storybook/tsconfig.test.json
@@ -6,6 +6,7 @@
   "include": [
     "test",
     ".storybook",
+    "playwright.config.ts",
     "preview-manifest.ts",
     "scripts",
     "vitest.config.ts",

--- a/apps/storybook/turbo.json
+++ b/apps/storybook/turbo.json
@@ -4,8 +4,12 @@
   "tasks": {
     "build": {
       "cache": false,
-      "outputs": ["storybook-static/**/*"],
+      "outputs": ["storybook-static/**/*", ".vercel/**/*"],
       "dependsOn": ["^build"]
+    },
+    "test:e2e": {
+      "cache": false,
+      "dependsOn": ["build"]
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -843,6 +843,9 @@ importers:
       '@shipfox/biome':
         specifier: workspace:*
         version: link:../../tools/biome
+      '@shipfox/playwright':
+        specifier: workspace:*
+        version: link:../../tools/playwright
       '@shipfox/ts-config':
         specifier: workspace:*
         version: link:../../tools/ts-config


### PR DESCRIPTION
Builds the composed Storybook shell and ten child Storybooks into a deterministic Vercel static artifact. The pipeline records commit and pull-request metadata, validates the assembled tree and local assets, supports atomic publication, and verifies the result through a local HTTP server and Playwright smoke coverage.\n\nComposition refs use directory-form URLs while standalone links retain their static index documents, so the composed shell resolves child Storybooks correctly.\n\nValidation passed:\n- turbo test type check build depcruise --filter=@shipfox/storybook... --concurrency=4\n- turbo test:e2e --filter=@shipfox/storybook --concurrency=4\n- artifact assembly and verification, including empty commit-SHA environment fallback\n\nCloses ENG-1175

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Assembles a deterministic Storybook preview for Vercel by composing the shell and ten child Storybooks into `.vercel/output`, then validates and smoke-tests the result. Implements ENG-1175.

- **New Features**
  - Deterministic assembly into `.vercel/output` with Build Output v3 routes and atomic publish.
  - Strict validation: required files, non-empty `index.json` entries, local asset references, and per-file size limit via `STORYBOOK_PREVIEW_MAX_FILE_BYTES`.
  - Writes `preview-metadata.json` (commit SHA, build time, manifest version, PR data, metrics) and verifies it with `artifact:verify`.
  - Adds a local static server and Playwright smoke tests covering composition refs, standalone children, and deep links.
  - Composition refs now use directory paths; standalone links keep `index.html`. Assembly runs in `build`; verification runs in `test:e2e` (Turbo updated).

- **Dependencies**
  - Added `@shipfox/playwright` for smoke tests.

<sup>Written for commit 31dd7a0f947d73ce16c8fb06cb52461d11c3289d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

