### PR TITLE
[client-auth] Add sanitized logout redirects for invitation recovery

### DIFF
--- a/.changeset/bright-otters-logout.md
+++ b/.changeset/bright-otters-logout.md
@@ -1,0 +1,4 @@
+---
+"@shipfox/client-auth": patch
+---
+Adds a sanitized logout redirect that clears local and server auth state before returning to a safe same-origin destination.

--- a/libs/client/auth/src/components/redirect-target.test.ts
+++ b/libs/client/auth/src/components/redirect-target.test.ts
@@ -1,4 +1,4 @@
-import {sanitizeRedirectPath} from './redirect-target.js';
+import {sanitizeLogoutRedirectPath, sanitizeRedirectPath} from './redirect-target.js';
 
 describe('sanitizeRedirectPath', () => {
   describe.each([
@@ -63,6 +63,37 @@ describe('sanitizeRedirectPath', () => {
       const result = sanitizeRedirectPath('/%E0%80%80');
 
       expect(result).toBeUndefined();
+    });
+  });
+});
+
+describe('sanitizeLogoutRedirectPath', () => {
+  describe.each([
+    ['explicit login fallback', '/auth/login', '/auth/login'],
+    ['same-origin workspace path', '/workspaces/abc', '/workspaces/abc'],
+    [
+      'same-origin path with search and hash',
+      '/workspaces/abc?tab=runs#header',
+      '/workspaces/abc?tab=runs#header',
+    ],
+  ])('accepts %s', (_label, input, expected) => {
+    test('returns the safe destination', () => {
+      expect(sanitizeLogoutRedirectPath(input)).toBe(expected);
+    });
+  });
+
+  describe.each([
+    ['missing redirect', undefined],
+    ['external URL', 'https://attacker.example'],
+    ['protocol-relative URL', '//attacker.example'],
+    ['auth route other than login', '/auth/reset'],
+    ['login route with a query', '/auth/login?redirect=/workspaces/abc'],
+    ['raw invitation token', '/invitations/accept?token=sf_i_raw-token'],
+    ['raw invitation token with trailing slash', '/invitations/accept/?token=sf_i_raw-token'],
+    ['malformed percent encoding', '/%E0%80%80'],
+  ])('falls back for %s', (_label, input) => {
+    test('returns login without forwarding unsafe state', () => {
+      expect(sanitizeLogoutRedirectPath(input)).toBe('/auth/login');
     });
   });
 });

--- a/libs/client/auth/src/components/redirect-target.ts
+++ b/libs/client/auth/src/components/redirect-target.ts
@@ -1,8 +1,10 @@
 const REDIRECT_ORIGIN = 'https://shipfox-redirect.invalid';
+const LOGIN_PATH = '/auth/login';
+const INVITATION_ACCEPT_PATH = '/invitations/accept';
+const DEFAULT_LOGOUT_REDIRECT = LOGIN_PATH;
+const TRAILING_SLASHES = /\/+$/;
 
-// Resolves and canonicalizes an internal path before returning it, so browser URL
-// parsing cannot turn a seemingly safe path into an external or auth route.
-export function sanitizeRedirectPath(value: unknown): string | undefined {
+function resolveRedirectPath(value: unknown): URL | undefined {
   if (typeof value !== 'string' || !value.startsWith('/')) return undefined;
   let decoded: string;
   try {
@@ -17,6 +19,41 @@ export function sanitizeRedirectPath(value: unknown): string | undefined {
     return undefined;
   }
   if (target.origin !== REDIRECT_ORIGIN) return undefined;
-  if (target.pathname === '/auth' || target.pathname.startsWith('/auth/')) return undefined;
+  return target;
+}
+
+function formatRedirectPath(target: URL): string {
   return `${target.pathname}${target.search}${target.hash}`;
+}
+
+function isAuthPath(pathname: string): boolean {
+  return pathname === '/auth' || pathname.startsWith('/auth/');
+}
+
+// Resolves and canonicalizes an internal path before returning it, so browser URL
+// parsing cannot turn a seemingly safe path into an external or auth route.
+export function sanitizeRedirectPath(value: unknown): string | undefined {
+  const target = resolveRedirectPath(value);
+  if (!target || isAuthPath(target.pathname)) return undefined;
+  return formatRedirectPath(target);
+}
+
+function containsInvitationToken(target: URL): boolean {
+  const normalizedPathname = target.pathname.replace(TRAILING_SLASHES, '') || '/';
+  return normalizedPathname === INVITATION_ACCEPT_PATH && target.searchParams.has('token');
+}
+
+/**
+ * Returns the destination used by the shared logout route.
+ *
+ * Login is the only auth destination allowed, and invitation tokens never
+ * survive this boundary. Invalid values fail closed to login.
+ */
+export function sanitizeLogoutRedirectPath(value: unknown): string {
+  const target = resolveRedirectPath(value);
+  if (!target) return DEFAULT_LOGOUT_REDIRECT;
+  if (isAuthPath(target.pathname) || containsInvitationToken(target)) {
+    return DEFAULT_LOGOUT_REDIRECT;
+  }
+  return formatRedirectPath(target);
 }

--- a/libs/client/auth/src/pages/logout-page.test.tsx
+++ b/libs/client/auth/src/pages/logout-page.test.tsx
@@ -1,0 +1,75 @@
+import {configureApiClient} from '@shipfox/client-api';
+import {AuthRuntime} from '@shipfox/client-shell/runtime';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from '@tanstack/react-router';
+import {render, screen} from '@testing-library/react';
+import {Provider as JotaiProvider} from 'jotai';
+import {LogoutPage} from './logout-page.js';
+
+function renderLogoutPage(path: string) {
+  const rootRoute = createRootRoute({component: Outlet});
+  const logoutRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/auth/logout',
+    component: LogoutPage,
+  });
+  const loginRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/auth/login',
+    component: () => <h1>Login destination</h1>,
+  });
+  const workspaceRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/workspaces/$wid',
+    component: () => <h1>Workspace destination</h1>,
+  });
+  const router = createRouter({
+    history: createMemoryHistory({initialEntries: [path]}),
+    routeTree: rootRoute.addChildren([logoutRoute, loginRoute, workspaceRoute]),
+  });
+  const queryClient = new QueryClient();
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <JotaiProvider>
+        <AuthRuntime effects={false}>
+          <RouterProvider router={router} />
+        </AuthRuntime>
+      </JotaiProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe('LogoutPage', () => {
+  beforeEach(() => {
+    configureApiClient({baseUrl: 'https://api.example.test', getAccessToken: undefined});
+  });
+
+  test('logs out before following a safe same-origin redirect', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response(null, {status: 204}));
+    configureApiClient({fetchImpl});
+
+    renderLogoutPage('/auth/logout?redirect=%2Fworkspaces%2Facme');
+
+    expect(await screen.findByRole('heading', {name: 'Workspace destination'})).toBeVisible();
+    const request = fetchImpl.mock.calls[0]?.[0] as Request;
+    expect(request.url).toBe('https://api.example.test/auth/logout');
+    expect(request.method).toBe('POST');
+  });
+
+  test('falls back to login without forwarding an invitation token', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response(null, {status: 204}));
+    configureApiClient({fetchImpl});
+
+    renderLogoutPage('/auth/logout?redirect=%2Finvitations%2Faccept%3Ftoken%3Dsf_i_raw-token');
+
+    expect(await screen.findByRole('heading', {name: 'Login destination'})).toBeVisible();
+  });
+});

--- a/libs/client/auth/src/pages/logout-page.tsx
+++ b/libs/client/auth/src/pages/logout-page.tsx
@@ -1,27 +1,22 @@
 import {AuthShell} from '@shipfox/client-shell/runtime';
 import {Text} from '@shipfox/react-ui/typography';
-import {useNavigate, useRouter, useSearch} from '@tanstack/react-router';
+import {useRouter, useSearch} from '@tanstack/react-router';
 import {useEffect} from 'react';
-import {sanitizeRedirectPath} from '#/components/redirect-target.js';
+import {sanitizeLogoutRedirectPath} from '#/components/redirect-target.js';
 import {useLogoutAuth} from '#hooks/api/logout-auth.js';
 
 export function LogoutPage() {
   const logout = useLogoutAuth();
-  const navigate = useNavigate();
   const router = useRouter();
   const search = useSearch({strict: false}) as {redirect?: unknown};
-  const target = sanitizeRedirectPath(search.redirect);
+  const target = sanitizeLogoutRedirectPath(search.redirect);
 
   useEffect(() => {
     logout.mutateAsync().finally(() => {
-      if (target !== undefined) {
-        // Same-origin runtime path; let history drive route resolution.
-        router.history.replace(target);
-      } else {
-        navigate({to: '/auth/login', replace: true});
-      }
+      // Same-origin runtime path; let history drive route resolution.
+      router.history.replace(target);
     });
-  }, [logout.mutateAsync, navigate, router, target]);
+  }, [logout.mutateAsync, router, target]);
 
   return (
     <AuthShell title="Logging out" description="Ending your Shipfox session.">


### PR DESCRIPTION
Adds the shared logout redirect behavior needed by invitation collision recovery. Logout now sanitizes same-origin destinations and falls back to `/auth/login` when the redirect is external, auth-scoped, malformed, or contains an invitation token. The logout page always clears auth state before replacing the history destination, including API failure through the existing best-effort logout behavior.

The invitation-token matcher normalizes trailing slashes so `/invitations/accept/?token=...` cannot bypass sanitization. The separate login/signup redirect-context check is pre-existing and remains outside this issue.

Validation passed: client-auth tests; dependent check, type, build, and type emission; publication preflight for 97 packages; and packed client-shell external-consumer verification for 43 runtime packages and 170 public entry points.

Closes ENG-1190

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a sanitized logout redirect in `@shipfox/client-auth` to support invitation collision recovery (ENG-1190) and block unsafe redirects. Logout now always clears auth state, then navigates to a safe same‑origin path or falls back to `/auth/login`.

- **New Features**
  - Introduces `sanitizeLogoutRedirectPath` that accepts only same‑origin paths and rejects external/protocol‑relative URLs, auth routes, malformed encodings, and invitation tokens (handles trailing slashes).
  - Unsafe or auth-scoped redirects fall back to `/auth/login` without forwarding query state or tokens.
  - Logout page clears local and server auth before replace‑navigating; tests cover safe redirects and token-stripping fallbacks.

<sup>Written for commit bb4ce9bec1d589cd1d47e2f152ca893431647d06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

