### PR TITLE
[api-database-policy] Register database ownership inventory

### DIFF
--- a/.changeset/strict-email-history.md
+++ b/.changeset/strict-email-history.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-email-challenges": major
+---
+
+Use the namespace-compliant `email_challenges` migration-history table for email challenge migrations.

--- a/api-databases.cjs
+++ b/api-databases.cjs
@@ -1,0 +1,211 @@
+function freezeEntries(entries) {
+  return Object.freeze(entries.map((entry) => Object.freeze({...entry})));
+}
+
+const databaseOwners = freezeEntries([
+  {id: 'agent', packagePath: 'libs/api/agent'},
+  {id: 'annotations', packagePath: 'libs/api/annotations'},
+  {id: 'auth', packagePath: 'libs/api/auth'},
+  {id: 'definitions', packagePath: 'libs/api/definitions'},
+  {id: 'email-challenges', packagePath: 'libs/api/email-challenges'},
+  {id: 'integrations', packagePath: 'libs/api/integration/core'},
+  {id: 'logs', packagePath: 'libs/api/logs'},
+  {id: 'projects', packagePath: 'libs/api/projects'},
+  {id: 'runners', packagePath: 'libs/api/runners'},
+  {id: 'secrets', packagePath: 'libs/api/secrets'},
+  {id: 'triggers', packagePath: 'libs/api/triggers'},
+  {id: 'workflows', packagePath: 'libs/api/workflows'},
+  {id: 'workspaces', packagePath: 'libs/api/workspaces'},
+]);
+
+const databaseMigrationUnits = freezeEntries([
+  {
+    id: 'agent',
+    ownerId: 'agent',
+    namespace: 'agent',
+    packagePath: 'libs/api/agent',
+    drizzleConfigPath: 'libs/api/agent/drizzle.config.ts',
+    migrationsPath: 'libs/api/agent/drizzle',
+  },
+  {
+    id: 'annotations',
+    ownerId: 'annotations',
+    namespace: 'annotations',
+    packagePath: 'libs/api/annotations',
+    drizzleConfigPath: 'libs/api/annotations/drizzle.config.ts',
+    migrationsPath: 'libs/api/annotations/drizzle',
+  },
+  {
+    id: 'auth',
+    ownerId: 'auth',
+    namespace: 'auth',
+    packagePath: 'libs/api/auth',
+    drizzleConfigPath: 'libs/api/auth/drizzle.config.ts',
+    migrationsPath: 'libs/api/auth/drizzle',
+  },
+  {
+    id: 'definitions',
+    ownerId: 'definitions',
+    namespace: 'definitions',
+    packagePath: 'libs/api/definitions',
+    drizzleConfigPath: 'libs/api/definitions/drizzle.config.ts',
+    migrationsPath: 'libs/api/definitions/drizzle',
+  },
+  {
+    id: 'email-challenges',
+    ownerId: 'email-challenges',
+    namespace: 'email_challenges',
+    packagePath: 'libs/api/email-challenges',
+    drizzleConfigPath: 'libs/api/email-challenges/drizzle.config.ts',
+    migrationsPath: 'libs/api/email-challenges/drizzle',
+  },
+  {
+    id: 'integrations',
+    ownerId: 'integrations',
+    namespace: 'integrations',
+    packagePath: 'libs/api/integration/core',
+    drizzleConfigPath: 'libs/api/integration/core/drizzle.config.ts',
+    migrationsPath: 'libs/api/integration/core/drizzle',
+  },
+  {
+    id: 'integrations-gitea',
+    ownerId: 'integrations',
+    namespace: 'integrations_gitea',
+    packagePath: 'libs/api/integration/gitea',
+    drizzleConfigPath: 'libs/api/integration/gitea/drizzle.config.ts',
+    migrationsPath: 'libs/api/integration/gitea/drizzle',
+  },
+  {
+    id: 'integrations-github',
+    ownerId: 'integrations',
+    namespace: 'integrations_github',
+    packagePath: 'libs/api/integration/github',
+    drizzleConfigPath: 'libs/api/integration/github/drizzle.config.ts',
+    migrationsPath: 'libs/api/integration/github/drizzle',
+  },
+  {
+    id: 'integrations-jira',
+    ownerId: 'integrations',
+    namespace: 'integrations_jira',
+    packagePath: 'libs/api/integration/jira',
+    drizzleConfigPath: 'libs/api/integration/jira/drizzle.config.ts',
+    migrationsPath: 'libs/api/integration/jira/drizzle',
+  },
+  {
+    id: 'integrations-linear',
+    ownerId: 'integrations',
+    namespace: 'integrations_linear',
+    packagePath: 'libs/api/integration/linear',
+    drizzleConfigPath: 'libs/api/integration/linear/drizzle.config.ts',
+    migrationsPath: 'libs/api/integration/linear/drizzle',
+  },
+  {
+    id: 'integrations-sentry',
+    ownerId: 'integrations',
+    namespace: 'integrations_sentry',
+    packagePath: 'libs/api/integration/sentry',
+    drizzleConfigPath: 'libs/api/integration/sentry/drizzle.config.ts',
+    migrationsPath: 'libs/api/integration/sentry/drizzle',
+  },
+  {
+    id: 'integrations-slack',
+    ownerId: 'integrations',
+    namespace: 'integrations_slack',
+    packagePath: 'libs/api/integration/slack',
+    drizzleConfigPath: 'libs/api/integration/slack/drizzle.config.ts',
+    migrationsPath: 'libs/api/integration/slack/drizzle',
+  },
+  {
+    id: 'logs',
+    ownerId: 'logs',
+    namespace: 'logs',
+    packagePath: 'libs/api/logs',
+    drizzleConfigPath: 'libs/api/logs/drizzle.config.ts',
+    migrationsPath: 'libs/api/logs/drizzle',
+  },
+  {
+    id: 'projects',
+    ownerId: 'projects',
+    namespace: 'projects',
+    packagePath: 'libs/api/projects',
+    drizzleConfigPath: 'libs/api/projects/drizzle.config.ts',
+    migrationsPath: 'libs/api/projects/drizzle',
+  },
+  {
+    id: 'runners',
+    ownerId: 'runners',
+    namespace: 'runners',
+    packagePath: 'libs/api/runners',
+    drizzleConfigPath: 'libs/api/runners/drizzle.config.ts',
+    migrationsPath: 'libs/api/runners/drizzle',
+  },
+  {
+    id: 'secrets',
+    ownerId: 'secrets',
+    namespace: 'secrets',
+    packagePath: 'libs/api/secrets',
+    drizzleConfigPath: 'libs/api/secrets/drizzle.config.ts',
+    migrationsPath: 'libs/api/secrets/drizzle',
+  },
+  {
+    id: 'triggers',
+    ownerId: 'triggers',
+    namespace: 'triggers',
+    packagePath: 'libs/api/triggers',
+    drizzleConfigPath: 'libs/api/triggers/drizzle.config.ts',
+    migrationsPath: 'libs/api/triggers/drizzle',
+  },
+  {
+    id: 'workflows',
+    ownerId: 'workflows',
+    namespace: 'workflows',
+    packagePath: 'libs/api/workflows',
+    drizzleConfigPath: 'libs/api/workflows/drizzle.config.ts',
+    migrationsPath: 'libs/api/workflows/drizzle',
+  },
+  {
+    id: 'workspaces',
+    ownerId: 'workspaces',
+    namespace: 'workspaces',
+    packagePath: 'libs/api/workspaces',
+    drizzleConfigPath: 'libs/api/workspaces/drizzle.config.ts',
+    migrationsPath: 'libs/api/workspaces/drizzle',
+  },
+]);
+
+const databaseDelegates = freezeEntries([
+  {
+    id: 'migration-runner',
+    packagePath: 'libs/shared/node/drizzle',
+    capability: 'migration-runner',
+  },
+  {
+    id: 'schema-table-factory',
+    packagePath: 'libs/shared/node/outbox',
+    capability: 'schema-table-factory',
+  },
+  {
+    id: 'owner-local-outbox-writer',
+    packagePath: 'libs/shared/node/outbox',
+    capability: 'owner-local-outbox-writer',
+  },
+  {
+    id: 'registered-outbox-dispatcher',
+    packagePath: 'libs/shared/node/module',
+    capability: 'registered-outbox-dispatcher',
+  },
+]);
+
+const databaseRegistry = Object.freeze({
+  owners: databaseOwners,
+  migrationUnits: databaseMigrationUnits,
+  delegates: databaseDelegates,
+});
+
+module.exports = {
+  apiDatabases: databaseRegistry,
+  databaseDelegates,
+  databaseMigrationUnits,
+  databaseOwners,
+  databaseRegistry,
+};

--- a/docs/adr/0006-database-ownership-boundaries.md
+++ b/docs/adr/0006-database-ownership-boundaries.md
@@ -38,8 +38,9 @@ views, triggers, database functions, and foreign keys.
 namespace as a name prefix. Its PostgreSQL types and explicit support object
 names use the same namespace. One `ShipfoxModule` owner can compose several
 migration units under one stable owner ID. The namespace is a database identity,
-not necessarily the module's display name; changing an existing migration
-history name requires a compatibility plan.
+not necessarily the module's display name. Migration-history names must use
+the registered namespace explicitly when a module's display name is not
+compliant.
 
 **Modules cross the boundary through producer-owned contracts.** A caller uses
 an inter-module operation for current state, an outbox event for a committed

--- a/docs/adr/0006-database-ownership-boundaries.md
+++ b/docs/adr/0006-database-ownership-boundaries.md
@@ -34,9 +34,12 @@ context does not grant access.
 lock, reference, or re-declare an owned table. This rule also covers raw SQL,
 views, triggers, database functions, and foreign keys.
 
-**Each database module has a stable namespace.** Its tables use the namespace
-as a name prefix. Its PostgreSQL types and explicit support object names use
-the same namespace.
+**Each database migration unit has a stable namespace.** Its tables use the
+namespace as a name prefix. Its PostgreSQL types and explicit support object
+names use the same namespace. One `ShipfoxModule` owner can compose several
+migration units under one stable owner ID. The namespace is a database identity,
+not necessarily the module's display name; changing an existing migration
+history name requires a compatibility plan.
 
 **Modules cross the boundary through producer-owned contracts.** A caller uses
 an inter-module operation for current state, an outbox event for a committed

--- a/docs/policies/database-boundaries.md
+++ b/docs/policies/database-boundaries.md
@@ -28,9 +28,10 @@ migration units to one composed module. The application root records those
 units under the owner's stable ID.
 
 A namespace is a database identity, not necessarily the module's display name.
-Existing migration-history names are compatibility-sensitive; the
-`email_challenges` namespace remains registered for the `email-challenges`
-module until its runtime migration-table contract is changed deliberately.
+Migration-history names must use the registered namespace explicitly when a
+module's display name is not compliant. The `email_challenges` namespace is
+used for both the application tables and the migration-history table of the
+`email-challenges` module.
 
 Examples include `runners`, `workflows`, `email_challenges`, and
 `integrations_github`.

--- a/docs/policies/database-boundaries.md
+++ b/docs/policies/database-boundaries.md
@@ -15,12 +15,22 @@ declares and migrates the object. A bounded context can contain more than one
 database module. Being in the same context does not grant access to another
 module's tables.
 
-Each database module registers one stable namespace. The namespace:
+Each database migration unit registers one stable namespace. The namespace:
 
 - Uses lowercase snake case.
 - Matches the module name when the module has one database.
 - Adds a stable qualifier when one module has several databases.
 - Does not change when a package or source directory moves.
+
+Database ownership follows the declaring `ShipfoxModule`, not package count. One
+owner can register several namespaces, and several packages can contribute
+migration units to one composed module. The application root records those
+units under the owner's stable ID.
+
+A namespace is a database identity, not necessarily the module's display name.
+Existing migration-history names are compatibility-sensitive; the
+`email_challenges` namespace remains registered for the `email-challenges`
+module until its runtime migration-table contract is changed deliberately.
 
 Examples include `runners`, `workflows`, `email_challenges`, and
 `integrations_github`.

--- a/libs/api/email-challenges/src/index.ts
+++ b/libs/api/email-challenges/src/index.ts
@@ -16,5 +16,9 @@ export {
 export {EmailChallengeError, type EmailChallengeErrorCode} from '#core/errors.js';
 export const emailChallengesModule: ShipfoxModule = {
   name: 'email-challenges',
-  database: {db, migrationsPath},
+  database: {
+    db,
+    migrationsPath,
+    migrationsTableName: '__drizzle_migrations_email_challenges',
+  },
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7580,6 +7580,27 @@ importers:
         specifier: 'catalog:'
         version: 24.13.2
 
+  tools/api-database-policy:
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../vitest
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.2
+
   tools/application-release:
     dependencies:
       ajv:

--- a/tools/api-database-policy/package.json
+++ b/tools/api-database-policy/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@shipfox/api-database-policy",
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "test": "shipfox-vitest-run",
+    "test:watch": "shipfox-vitest-watch",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit",
+    "verify": "node dist/api-database-registry.js"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*",
+    "@types/node": "catalog:"
+  }
+}

--- a/tools/api-database-policy/src/api-database-registry.ts
+++ b/tools/api-database-policy/src/api-database-registry.ts
@@ -1,0 +1,390 @@
+import {readdir, stat} from 'node:fs/promises';
+import {createRequire} from 'node:module';
+import path from 'node:path';
+import process from 'node:process';
+import {fileURLToPath} from 'node:url';
+
+const require = createRequire(import.meta.url);
+const {architecturePackages} = require('../../../api-contexts.cjs') as {
+  architecturePackages: ArchitecturePackages;
+};
+const {databaseRegistry} = require('../../../api-databases.cjs') as {
+  databaseRegistry: ApiDatabaseRegistry;
+};
+const repositoryRoot = fileURLToPath(new URL('../../../', import.meta.url));
+const namespaceExpression = /^[a-z][a-z0-9_]*$/;
+const expectedDelegates = [
+  {
+    id: 'migration-runner',
+    packagePath: 'libs/shared/node/drizzle',
+    capability: 'migration-runner',
+  },
+  {
+    id: 'schema-table-factory',
+    packagePath: 'libs/shared/node/outbox',
+    capability: 'schema-table-factory',
+  },
+  {
+    id: 'owner-local-outbox-writer',
+    packagePath: 'libs/shared/node/outbox',
+    capability: 'owner-local-outbox-writer',
+  },
+  {
+    id: 'registered-outbox-dispatcher',
+    packagePath: 'libs/shared/node/module',
+    capability: 'registered-outbox-dispatcher',
+  },
+] as const;
+
+export interface DatabaseOwner {
+  id: string;
+  packagePath: string;
+}
+
+export interface DatabaseMigrationUnit {
+  id: string;
+  ownerId: string;
+  namespace: string;
+  packagePath: string;
+  drizzleConfigPath: string;
+  migrationsPath: string;
+}
+
+export interface DatabaseDelegate {
+  id: string;
+  packagePath: string;
+  capability: string;
+}
+
+export interface ApiDatabaseRegistry {
+  owners: readonly DatabaseOwner[];
+  migrationUnits: readonly DatabaseMigrationUnit[];
+  delegates: readonly DatabaseDelegate[];
+}
+
+interface ArchitecturePackages {
+  [classification: string]: {
+    [context: string]: string[];
+  };
+}
+
+interface ClassifiedPath {
+  classification: string;
+  context: string;
+}
+
+export interface ValidateApiDatabaseRegistryOptions {
+  architecturePackages?: ArchitecturePackages;
+  discoveredDrizzleConfigPaths?: ReadonlySet<string>;
+  existingPaths?: ReadonlySet<string>;
+}
+
+export const apiDatabaseRegistry = databaseRegistry;
+
+function compareText(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+function classifiedPaths(packages: ArchitecturePackages): Map<string, ClassifiedPath> {
+  const result = new Map<string, ClassifiedPath>();
+
+  for (const [classification, contexts] of Object.entries(packages)) {
+    for (const [context, packagePaths] of Object.entries(contexts)) {
+      for (const packagePath of packagePaths) {
+        result.set(packagePath, {classification, context});
+      }
+    }
+  }
+
+  return result;
+}
+
+function addMissingPathError(
+  errors: string[],
+  existingPaths: ReadonlySet<string> | undefined,
+  registeredPath: string,
+): void {
+  if (existingPaths && !existingPaths.has(registeredPath)) {
+    errors.push(`Missing registered path: ${registeredPath}`);
+  }
+}
+
+function addUniqueIdentifierError(errors: string[], kind: string, values: readonly string[]): void {
+  const seen = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) errors.push(`Duplicate ${kind}: ${value}`);
+    seen.add(value);
+  }
+}
+
+function isNestedPath(parentPath: string, childPath: string): boolean {
+  const relativePath = path.posix.relative(parentPath, childPath);
+  return (
+    relativePath !== '' &&
+    relativePath !== '..' &&
+    !relativePath.startsWith('../') &&
+    !path.posix.isAbsolute(relativePath)
+  );
+}
+
+function validateExpectedDelegates(errors: string[], delegates: readonly DatabaseDelegate[]): void {
+  const delegatesById = new Map(delegates.map((delegate) => [delegate.id, delegate]));
+  for (const expectedDelegate of expectedDelegates) {
+    const delegate = delegatesById.get(expectedDelegate.id);
+    if (!delegate) {
+      errors.push(`Missing database delegate: ${expectedDelegate.id}`);
+      continue;
+    }
+    if (
+      delegate.packagePath !== expectedDelegate.packagePath ||
+      delegate.capability !== expectedDelegate.capability
+    ) {
+      errors.push(`Database delegate definition mismatch: ${expectedDelegate.id}`);
+    }
+  }
+  for (const delegate of delegates) {
+    if (!expectedDelegates.some((expected) => expected.id === delegate.id)) {
+      errors.push(`Unexpected database delegate: ${delegate.id}`);
+    }
+  }
+}
+
+export function validateApiDatabaseRegistry(
+  registry: ApiDatabaseRegistry = databaseRegistry,
+  options: ValidateApiDatabaseRegistryOptions = {},
+): string[] {
+  const packages = classifiedPaths(options.architecturePackages ?? architecturePackages);
+  const errors: string[] = [];
+  const ownerById = new Map<string, DatabaseOwner>();
+  const ownerClassificationById = new Map<string, ClassifiedPath>();
+
+  addUniqueIdentifierError(
+    errors,
+    'database owner ID',
+    registry.owners.map((owner) => owner.id),
+  );
+  addUniqueIdentifierError(
+    errors,
+    'migration unit ID',
+    registry.migrationUnits.map((unit) => unit.id),
+  );
+  addUniqueIdentifierError(
+    errors,
+    'database namespace',
+    registry.migrationUnits.map((unit) => unit.namespace),
+  );
+  addUniqueIdentifierError(
+    errors,
+    'migration unit package path',
+    registry.migrationUnits.map((unit) => unit.packagePath),
+  );
+  addUniqueIdentifierError(
+    errors,
+    'migration unit Drizzle config path',
+    registry.migrationUnits.map((unit) => unit.drizzleConfigPath),
+  );
+  addUniqueIdentifierError(
+    errors,
+    'migration unit migrations path',
+    registry.migrationUnits.map((unit) => unit.migrationsPath),
+  );
+  addUniqueIdentifierError(
+    errors,
+    'database delegate ID',
+    registry.delegates.map((delegate) => delegate.id),
+  );
+
+  for (const owner of registry.owners) {
+    ownerById.set(owner.id, owner);
+    addMissingPathError(errors, options.existingPaths, owner.packagePath);
+
+    const classification = packages.get(owner.packagePath);
+    if (!classification) {
+      errors.push(`Database owner package is not classified: ${owner.packagePath}`);
+      continue;
+    }
+    if (
+      classification.classification !== 'implementations' &&
+      classification.classification !== 'shared-infrastructure'
+    ) {
+      errors.push(
+        `Database owner package has an incompatible classification: ${owner.packagePath}`,
+      );
+      continue;
+    }
+    if (
+      classification.classification === 'implementations' &&
+      classification.context !== owner.id
+    ) {
+      errors.push(
+        `Database owner ID does not match API context: ${owner.id} (${classification.context})`,
+      );
+    }
+    if (
+      classification.classification === 'shared-infrastructure' &&
+      path.posix.basename(owner.packagePath) !== owner.id
+    ) {
+      errors.push(`Database owner ID does not match package path: ${owner.id}`);
+    }
+    ownerClassificationById.set(owner.id, classification);
+  }
+
+  const namespacesByOwner = new Map<string, number>();
+  for (const unit of registry.migrationUnits) {
+    const owner = ownerById.get(unit.ownerId);
+    if (!owner) {
+      errors.push(`Unknown database owner: ${unit.ownerId}`);
+    }
+
+    if (!namespaceExpression.test(unit.namespace)) {
+      errors.push(`Invalid database namespace: ${unit.namespace}`);
+    }
+
+    const ownerNamespaceCount = namespacesByOwner.get(unit.ownerId) ?? 0;
+    namespacesByOwner.set(unit.ownerId, ownerNamespaceCount + 1);
+
+    for (const registeredPath of [unit.packagePath, unit.drizzleConfigPath, unit.migrationsPath]) {
+      addMissingPathError(errors, options.existingPaths, registeredPath);
+    }
+    if (!isNestedPath(unit.packagePath, unit.drizzleConfigPath)) {
+      errors.push(`Drizzle config path is outside migration unit package: ${unit.id}`);
+    }
+    if (!isNestedPath(unit.packagePath, unit.migrationsPath)) {
+      errors.push(`Migrations path is outside migration unit package: ${unit.id}`);
+    }
+
+    const unitClassification = packages.get(unit.packagePath);
+    const ownerClassification = ownerClassificationById.get(unit.ownerId);
+    if (!unitClassification) {
+      errors.push(`Database migration unit package is not classified: ${unit.packagePath}`);
+    } else if (
+      ownerClassification &&
+      (unitClassification.classification !== ownerClassification.classification ||
+        unitClassification.context !== ownerClassification.context)
+    ) {
+      errors.push(`Database migration unit classification mismatch: ${unit.id}`);
+    }
+  }
+
+  for (const owner of registry.owners) {
+    if (!namespacesByOwner.has(owner.id)) {
+      errors.push(`Database owner has no namespace: ${owner.id}`);
+    }
+  }
+
+  for (const delegate of registry.delegates) {
+    addMissingPathError(errors, options.existingPaths, delegate.packagePath);
+    const classification = packages.get(delegate.packagePath);
+    if (!classification) {
+      errors.push(`Database delegate package is not classified: ${delegate.packagePath}`);
+    } else if (classification.classification !== 'shared-infrastructure') {
+      errors.push(`Database delegate is not neutral infrastructure: ${delegate.id}`);
+    }
+    if (!delegate.capability) {
+      errors.push(`Database delegate has no capability: ${delegate.id}`);
+    }
+  }
+
+  validateExpectedDelegates(errors, registry.delegates);
+
+  if (options.discoveredDrizzleConfigPaths) {
+    const registeredDrizzleConfigPaths = new Set(
+      registry.migrationUnits.map((unit) => unit.drizzleConfigPath),
+    );
+    for (const discoveredPath of options.discoveredDrizzleConfigPaths) {
+      if (!registeredDrizzleConfigPaths.has(discoveredPath)) {
+        errors.push(`Unregistered Drizzle config: ${discoveredPath}`);
+      }
+    }
+    for (const registeredPath of registeredDrizzleConfigPaths) {
+      if (!options.discoveredDrizzleConfigPaths.has(registeredPath)) {
+        errors.push(`Registered Drizzle config not discovered: ${registeredPath}`);
+      }
+    }
+  }
+
+  return errors.sort(compareText);
+}
+
+async function findDrizzleConfigPaths(
+  directory: string,
+  relativeDirectory: string,
+): Promise<string[]> {
+  const entries = await readdir(directory, {withFileTypes: true});
+  const paths: string[] = [];
+  for (const entry of entries) {
+    if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name === 'coverage') {
+      continue;
+    }
+    const relativePath = path.posix.join(relativeDirectory, entry.name);
+    const absolutePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      paths.push(...(await findDrizzleConfigPaths(absolutePath, relativePath)));
+    } else if (entry.isFile() && entry.name === 'drizzle.config.ts') {
+      paths.push(relativePath);
+    }
+  }
+  return paths;
+}
+
+async function repositoryDrizzleConfigPaths(): Promise<Set<string>> {
+  const paths = await findDrizzleConfigPaths(path.join(repositoryRoot, 'libs'), 'libs');
+  return new Set(paths);
+}
+
+async function existingRegistryPaths(registry: ApiDatabaseRegistry): Promise<Set<string>> {
+  const registeredPaths = new Set<string>();
+  for (const owner of registry.owners) registeredPaths.add(owner.packagePath);
+  for (const unit of registry.migrationUnits) {
+    registeredPaths.add(unit.packagePath);
+    registeredPaths.add(unit.drizzleConfigPath);
+    registeredPaths.add(unit.migrationsPath);
+  }
+  for (const delegate of registry.delegates) registeredPaths.add(delegate.packagePath);
+
+  const existingPaths = new Set<string>();
+  await Promise.all(
+    [...registeredPaths].map(async (registeredPath) => {
+      try {
+        await stat(path.join(repositoryRoot, registeredPath));
+        existingPaths.add(registeredPath);
+      } catch {
+        // The validator reports the path after the complete registry is checked.
+      }
+    }),
+  );
+  return existingPaths;
+}
+
+export async function auditApiDatabaseRegistry(
+  registry: ApiDatabaseRegistry = databaseRegistry,
+): Promise<string[]> {
+  const [paths, discoveredDrizzleConfigPaths] = await Promise.all([
+    existingRegistryPaths(registry),
+    repositoryDrizzleConfigPaths(),
+  ]);
+  return validateApiDatabaseRegistry(registry, {
+    discoveredDrizzleConfigPaths,
+    existingPaths: paths,
+  });
+}
+
+async function main(): Promise<void> {
+  const errors = await auditApiDatabaseRegistry();
+  if (errors.length === 0) {
+    process.stdout.write('API database registry passed\n');
+    return;
+  }
+  process.stderr.write(`API database registry failed (${errors.length} errors)\n`);
+  for (const error of errors) process.stderr.write(`- ${error}\n`);
+  process.exitCode = 1;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/tools/api-database-policy/test/api-database-registry.test.ts
+++ b/tools/api-database-policy/test/api-database-registry.test.ts
@@ -1,0 +1,175 @@
+import assert from 'node:assert/strict';
+import {
+  type ApiDatabaseRegistry,
+  apiDatabaseRegistry,
+  auditApiDatabaseRegistry,
+  validateApiDatabaseRegistry,
+} from '../src/api-database-registry.js';
+
+function registryFixture(): ApiDatabaseRegistry {
+  return {
+    owners: apiDatabaseRegistry.owners.map((owner) => ({...owner})),
+    migrationUnits: apiDatabaseRegistry.migrationUnits.map((unit) => ({...unit})),
+    delegates: apiDatabaseRegistry.delegates.map((delegate) => ({...delegate})),
+  };
+}
+
+function existingRegistryPaths(): Set<string> {
+  return new Set([
+    ...apiDatabaseRegistry.owners.map((owner) => owner.packagePath),
+    ...apiDatabaseRegistry.migrationUnits.flatMap((unit) => [
+      unit.packagePath,
+      unit.drizzleConfigPath,
+      unit.migrationsPath,
+    ]),
+    ...apiDatabaseRegistry.delegates.map((delegate) => delegate.packagePath),
+  ]);
+}
+
+describe('database registry', () => {
+  test('registers the current owners, migration units, and neutral delegates', async () => {
+    const errors = await auditApiDatabaseRegistry();
+    assert.deepEqual(errors, []);
+    assert.equal(apiDatabaseRegistry.owners.length, 13);
+    assert.equal(apiDatabaseRegistry.migrationUnits.length, 19);
+    assert.deepEqual(
+      apiDatabaseRegistry.migrationUnits
+        .filter((unit) => unit.ownerId === 'integrations')
+        .map((unit) => unit.namespace),
+      [
+        'integrations',
+        'integrations_gitea',
+        'integrations_github',
+        'integrations_jira',
+        'integrations_linear',
+        'integrations_sentry',
+        'integrations_slack',
+      ],
+    );
+    assert.deepEqual(
+      apiDatabaseRegistry.delegates.map((delegate) => delegate.capability),
+      [
+        'migration-runner',
+        'schema-table-factory',
+        'owner-local-outbox-writer',
+        'registered-outbox-dispatcher',
+      ],
+    );
+    assert.equal(
+      apiDatabaseRegistry.delegates.find(
+        (delegate) => delegate.id === 'registered-outbox-dispatcher',
+      )?.packagePath,
+      'libs/shared/node/module',
+    );
+  });
+
+  test('rejects missing registered paths', () => {
+    const registry = registryFixture();
+    const unit = registry.migrationUnits[0];
+    if (!unit) throw new Error('Expected an Agent migration unit');
+    unit.migrationsPath = 'libs/api/missing/drizzle';
+
+    const errors = validateApiDatabaseRegistry(registry, {
+      existingPaths: existingRegistryPaths(),
+    });
+
+    assert.deepEqual(errors, [
+      'Migrations path is outside migration unit package: agent',
+      'Missing registered path: libs/api/missing/drizzle',
+    ]);
+  });
+
+  test('rejects duplicate namespaces', () => {
+    const registry = registryFixture();
+    const unit = registry.migrationUnits[1];
+    if (!unit) throw new Error('Expected an Annotations migration unit');
+    unit.namespace = 'agent';
+
+    const errors = validateApiDatabaseRegistry(registry);
+
+    assert.deepEqual(errors, ['Duplicate database namespace: agent']);
+  });
+
+  test('rejects duplicate and out-of-package migration paths', () => {
+    const registry = registryFixture();
+    const unit = registry.migrationUnits[6];
+    if (!unit) throw new Error('Expected an Integrations Gitea migration unit');
+    unit.drizzleConfigPath = 'libs/api/integration/github/drizzle.config.ts';
+    unit.migrationsPath = 'libs/api/integration/github/drizzle';
+
+    const errors = validateApiDatabaseRegistry(registry);
+
+    assert.deepEqual(errors, [
+      'Drizzle config path is outside migration unit package: integrations-gitea',
+      'Duplicate migration unit Drizzle config path: libs/api/integration/github/drizzle.config.ts',
+      'Duplicate migration unit migrations path: libs/api/integration/github/drizzle',
+      'Migrations path is outside migration unit package: integrations-gitea',
+    ]);
+  });
+
+  test('rejects unknown owners', () => {
+    const registry = registryFixture();
+    const unit = registry.migrationUnits[0];
+    if (!unit) throw new Error('Expected an Agent migration unit');
+    unit.ownerId = 'unknown';
+
+    const errors = validateApiDatabaseRegistry(registry);
+
+    assert.deepEqual(errors, [
+      'Database owner has no namespace: agent',
+      'Unknown database owner: unknown',
+    ]);
+  });
+
+  test('rejects package and owner classification mismatches', () => {
+    const registry = registryFixture();
+    const owner = registry.owners[0];
+    if (!owner) throw new Error('Expected an Agent owner');
+    owner.packagePath = 'libs/api/auth';
+
+    const errors = validateApiDatabaseRegistry(registry);
+
+    assert.deepEqual(errors, [
+      'Database migration unit classification mismatch: agent',
+      'Database owner ID does not match API context: agent (auth)',
+    ]);
+  });
+
+  test('rejects namespace naming exceptions', () => {
+    const registry = registryFixture();
+    const unit = registry.migrationUnits[0];
+    if (!unit) throw new Error('Expected an Agent migration unit');
+    unit.namespace = 'Agent';
+
+    const errors = validateApiDatabaseRegistry(registry);
+
+    assert.deepEqual(errors, ['Invalid database namespace: Agent']);
+  });
+
+  test('rejects an unregistered Drizzle config', () => {
+    const discoveredDrizzleConfigPaths = new Set(
+      apiDatabaseRegistry.migrationUnits.map((unit) => unit.drizzleConfigPath),
+    );
+    discoveredDrizzleConfigPaths.add('libs/api/new-owner/drizzle.config.ts');
+
+    const errors = validateApiDatabaseRegistry(registryFixture(), {
+      discoveredDrizzleConfigPaths,
+    });
+
+    assert.deepEqual(errors, ['Unregistered Drizzle config: libs/api/new-owner/drizzle.config.ts']);
+  });
+
+  test('rejects missing or unexpected delegates', () => {
+    const registry = registryFixture();
+    registry.delegates = [];
+
+    const errors = validateApiDatabaseRegistry(registry);
+
+    assert.deepEqual(errors, [
+      'Missing database delegate: migration-runner',
+      'Missing database delegate: owner-local-outbox-writer',
+      'Missing database delegate: registered-outbox-dispatcher',
+      'Missing database delegate: schema-table-factory',
+    ]);
+  });
+});

--- a/tools/api-database-policy/tsconfig.build.json
+++ b/tools/api-database-policy/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/tools/api-database-policy/tsconfig.json
+++ b/tools/api-database-policy/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.test.json" }]
+}

--- a/tools/api-database-policy/tsconfig.test.json
+++ b/tools/api-database-policy/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "exclude": []
+}

--- a/tools/api-database-policy/turbo.json
+++ b/tools/api-database-policy/turbo.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "verify": {
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/api-contexts.cjs",
+        "$TURBO_ROOT$/api-databases.cjs",
+        "$TURBO_ROOT$/libs/api/**/package.json",
+        "$TURBO_ROOT$/libs/api/**/drizzle.config.ts",
+        "$TURBO_ROOT$/libs/api/**/drizzle/**",
+        "$TURBO_ROOT$/libs/shared/node/**/package.json"
+      ]
+    }
+  }
+}

--- a/tools/api-database-policy/vitest.config.ts
+++ b/tools/api-database-policy/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({}, import.meta.url) as UserConfigExport;


### PR DESCRIPTION
## Summary

Register the repository's database owners, migration units, namespaces, and neutral infrastructure delegates in one root inventory. Add an executable policy package that validates the inventory against the filesystem and API architecture classifications, including duplicate paths, package nesting, unregistered Drizzle configs, namespace rules, and exact delegate coverage.

The database-boundary policy and ADR distinguish a declaring `ShipfoxModule` owner from its migration units and document composed ownership. The published email-challenges module now explicitly uses the namespace-compliant `__drizzle_migrations_email_challenges` history table, and the breaking migration-table change is recorded in a major Changeset.

Pre-existing workflows/runners cross-owner findings remain outside this registry change.

Validation passed with the isolated email-challenges checks, sequential auth-dependent checks, database-policy checks, registry audit, API-context inventory, dependency policy, lockfile audit, and diff checks.

Closes ENG-1191