### PR TITLE
Make checked API adapters the client business-response boundary

### DIFF
--- a/.changeset/checked-adapters-contract.md
+++ b/.changeset/checked-adapters-contract.md
@@ -1,0 +1,8 @@
+---
+"@shipfox/client-api": major
+"@shipfox/client-agent": major
+"@shipfox/client-integrations": major
+"@shipfox/client-workflows": major
+---
+
+Makes checked API adapters the only public business-response boundary and returns package-owned domain models from Agent, Integrations, and Workflows adapters.

--- a/docs/architecture/client-architecture.md
+++ b/docs/architecture/client-architecture.md
@@ -60,7 +60,10 @@ handle presentation effects such as closing a dialog or navigating. A named
 page or application coordinator owns a journey that must update more than one
 feature's cache.
 
-Use `@shipfox/client-api` for requests, auth refresh, and `ApiError` handling.
+Use `checkedApiRequest` from `@shipfox/client-api` for business responses. It
+validates the response at the transport boundary. The raw request primitive is
+private to `@shipfox/client-api`. Use `emptyResponseSchema` for a response with
+no domain value.
 
 ## Choose state by its source of truth
 
@@ -173,12 +176,18 @@ Run the affected package `check` and `pnpm check:client-architecture` after
 changing a client boundary. Package checks run the local Biome rules and report
 source locations for response DTO imports, DTO or framework imports in `core/`,
 raw API requests, and leaf-component query-cache ownership. The repository
-verifier checks direct API requests outside adapters, unparsed API responses,
-raw route-search parsing outside an owned route module, deep imports into
-another feature's private modules, and navigation or settings contributions
-that target a route owned by another feature without an explicit `coordinator`.
-Both checks require zero production violations. Neither check has a migration
-baseline or allowlist.
+verifier inventories production adapters and query hooks under `libs/client/**`
+and `libs/shared/react/ui/**`. It rejects direct API requests outside adapters,
+unparsed API responses, checked business responses returned without a mapper,
+inline query policies, query hooks outside adapters, and raw route-search
+parsing outside an owned route module. Both checks require zero production
+violations. Neither check has a migration baseline or broad allowlist. The
+step-log query is the only narrow query-policy exception; its per-view cursor
+and retry lifecycle is documented in
+[`clientArchitectureExceptions`](../../tools/client-architecture-policy/src/audit-client-architecture.ts).
+It also rejects deep imports into another feature's private modules and
+navigation or settings contributions that target a route owned by another
+feature without an explicit `coordinator`.
 
 A completed feature package has `core/` domain models and policies with no UI
 or transport imports; checked adapter functions that parse and map every

--- a/libs/client/agent/src/core/models.ts
+++ b/libs/client/agent/src/core/models.ts
@@ -84,6 +84,14 @@ export interface ProviderConfiguration {
   readonly defaultProviderId: string | null;
 }
 
+export interface DefaultModelProviderSelection {
+  readonly defaultProviderId: string | null;
+}
+
+export interface DefaultHarnessSelection {
+  readonly defaultHarnessId: HarnessId;
+}
+
 export interface ProviderCredentialsCommand {
   defaultModel?: string | null | undefined;
   credentials: Record<string, string>;

--- a/libs/client/agent/src/hooks/api/model-provider-mapper.ts
+++ b/libs/client/agent/src/hooks/api/model-provider-mapper.ts
@@ -5,11 +5,15 @@ import type {
   ModelProviderCatalogResponseDto,
   ModelProviderConfigDto,
   ModelProviderConfigResponseDto,
+  SetDefaultHarnessResponseDto,
+  SetDefaultModelProviderResponseDto,
 } from '@shipfox/api-agent-dto';
 import type {
   AgentModel,
   BuiltinProviderConfig,
   CustomProviderConfig,
+  DefaultHarnessSelection,
+  DefaultModelProviderSelection,
   ProviderCatalog,
   ProviderCatalogEntry,
   ProviderConfig,
@@ -51,6 +55,18 @@ export function toProviderConfiguration(
     defaultHarnessId: response.default_harness_id,
     defaultProviderId: response.default_provider_id,
   };
+}
+
+export function toDefaultModelProviderSelection(
+  response: SetDefaultModelProviderResponseDto,
+): DefaultModelProviderSelection {
+  return {defaultProviderId: response.default_provider_id};
+}
+
+export function toDefaultHarnessSelection(
+  response: SetDefaultHarnessResponseDto,
+): DefaultHarnessSelection {
+  return {defaultHarnessId: response.default_harness_id};
 }
 
 export function toProviderConfig(config: ModelProviderConfigResponseDto): ProviderConfig {

--- a/libs/client/agent/src/hooks/api/model-providers.test.ts
+++ b/libs/client/agent/src/hooks/api/model-providers.test.ts
@@ -134,7 +134,7 @@ describe('model provider transport', () => {
     });
 
     const request = fetchImpl.mock.calls[0]?.[0] as Request;
-    expect(result.default_provider_id).toBe('anthropic');
+    expect(result.defaultProviderId).toBe('anthropic');
     expect(request.url).toBe(
       `https://api.example.test/workspaces/${AGENT_TEST_WORKSPACE_ID}/agent/default-model-provider`,
     );
@@ -157,7 +157,7 @@ describe('model provider transport', () => {
     });
 
     const request = fetchImpl.mock.calls[0]?.[0] as Request;
-    expect(result.default_harness_id).toBe('claude');
+    expect(result.defaultHarnessId).toBe('claude');
     expect(request.url).toBe(
       `https://api.example.test/workspaces/${AGENT_TEST_WORKSPACE_ID}/agent/default-harness`,
     );

--- a/libs/client/agent/src/hooks/api/model-providers.ts
+++ b/libs/client/agent/src/hooks/api/model-providers.ts
@@ -19,6 +19,8 @@ import {
 import type {
   AgentModel,
   CreateCustomProviderCommand,
+  DefaultHarnessSelection,
+  DefaultModelProviderSelection,
   DiscoverProviderModelsCommand,
   HarnessId,
   ProviderCatalog,
@@ -38,6 +40,8 @@ import {
   toUpdateCustomProviderBody,
 } from './model-provider-command-mapper.js';
 import {
+  toDefaultHarnessSelection,
+  toDefaultModelProviderSelection,
   toProviderCatalog,
   toProviderConfig,
   toProviderConfiguration,
@@ -230,11 +234,13 @@ export async function setDefaultModelProvider({
 }: {
   workspaceId: string;
   providerId: string;
-}) {
-  return await checkedApiRequest(
-    setDefaultModelProviderResponseSchema,
-    `/workspaces/${workspaceId}/agent/default-model-provider`,
-    {method: 'PUT', body: toDefaultProviderBody(providerId)},
+}): Promise<DefaultModelProviderSelection> {
+  return toDefaultModelProviderSelection(
+    await checkedApiRequest(
+      setDefaultModelProviderResponseSchema,
+      `/workspaces/${workspaceId}/agent/default-model-provider`,
+      {method: 'PUT', body: toDefaultProviderBody(providerId)},
+    ),
   );
 }
 
@@ -244,11 +250,13 @@ export async function setDefaultHarness({
 }: {
   workspaceId: string;
   harnessId: HarnessId;
-}) {
-  return await checkedApiRequest(
-    setDefaultHarnessResponseSchema,
-    `/workspaces/${workspaceId}/agent/default-harness`,
-    {method: 'PUT', body: toDefaultHarnessBody(harnessId)},
+}): Promise<DefaultHarnessSelection> {
+  return toDefaultHarnessSelection(
+    await checkedApiRequest(
+      setDefaultHarnessResponseSchema,
+      `/workspaces/${workspaceId}/agent/default-harness`,
+      {method: 'PUT', body: toDefaultHarnessBody(harnessId)},
+    ),
   );
 }
 

--- a/libs/client/api/src/index.test.ts
+++ b/libs/client/api/src/index.test.ts
@@ -1,7 +1,7 @@
 import {z} from 'zod';
+import * as clientApi from './index.js';
 import {
   ApiError,
-  apiRequest,
   checkedApiRequest,
   configureApiClient,
   getErrorCode,
@@ -9,6 +9,10 @@ import {
   isInvalidApiResponseError,
   resetApiClient,
 } from './index.js';
+
+function transportRequest<T>(path: string, options: Parameters<typeof checkedApiRequest>[2] = {}) {
+  return checkedApiRequest(z.unknown(), path, options) as Promise<T>;
+}
 
 function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
   return new Response(JSON.stringify(body), {
@@ -18,7 +22,7 @@ function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
   });
 }
 
-describe('apiRequest', () => {
+describe('checked API transport', () => {
   beforeEach(() => {
     configureApiClient({
       baseUrl: 'https://api.example.test',
@@ -26,6 +30,10 @@ describe('apiRequest', () => {
       getAccessToken: undefined,
       refreshAccessToken: undefined,
     });
+  });
+
+  test('does not expose the raw transport primitive from the public client surface', () => {
+    expect('apiRequest' in clientApi).toBe(false);
   });
 
   test('preserves the native fetch receiver', async () => {
@@ -37,7 +45,7 @@ describe('apiRequest', () => {
     }) as typeof fetch;
 
     try {
-      const result = await apiRequest<{ok: boolean}>('/auth/refresh', {method: 'POST'});
+      const result = await transportRequest<{ok: boolean}>('/auth/refresh', {method: 'POST'});
 
       expect(result.ok).toBe(true);
       expect(receiver).toBe(globalThis);
@@ -50,7 +58,7 @@ describe('apiRequest', () => {
     const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ok: true}));
     configureApiClient({fetchImpl, getAccessToken: () => 'access-token'});
 
-    const result = await apiRequest<{ok: boolean}>('/auth/refresh', {method: 'POST'});
+    const result = await transportRequest<{ok: boolean}>('/auth/refresh', {method: 'POST'});
 
     expect(result.ok).toBe(true);
     const request = fetchImpl.mock.calls[0]?.[0] as Request;
@@ -68,7 +76,7 @@ describe('apiRequest', () => {
       );
     configureApiClient({fetchImpl});
 
-    const result = apiRequest('/auth/login', {method: 'POST'});
+    const result = transportRequest('/auth/login', {method: 'POST'});
 
     await expect(result).rejects.toMatchObject({
       code: 'invalid-credentials',
@@ -91,7 +99,7 @@ describe('apiRequest', () => {
       refreshAccessToken,
     });
 
-    const result = await apiRequest<{ok: boolean}>('/workspaces');
+    const result = await transportRequest<{ok: boolean}>('/workspaces');
 
     expect(result.ok).toBe(true);
     expect(refreshAccessToken).toHaveBeenCalledTimes(1);
@@ -110,7 +118,7 @@ describe('apiRequest', () => {
     const refreshAccessToken = vi.fn().mockResolvedValue('fresh-token');
     configureApiClient({fetchImpl, refreshAccessToken});
 
-    const result = apiRequest('/auth/login', {method: 'POST'});
+    const result = transportRequest('/auth/login', {method: 'POST'});
 
     await expect(result).rejects.toMatchObject({
       code: 'invalid-credentials',
@@ -122,7 +130,7 @@ describe('apiRequest', () => {
   test('normalizes network failures', async () => {
     configureApiClient({fetchImpl: vi.fn().mockRejectedValue(new Error('offline'))});
 
-    const result = apiRequest('/auth/login', {method: 'POST'});
+    const result = transportRequest('/auth/login', {method: 'POST'});
 
     await expect(result).rejects.toBeInstanceOf(ApiError);
     await expect(result).rejects.toMatchObject({code: 'network-error', status: 0});
@@ -152,7 +160,7 @@ describe('resetApiClient', () => {
 
     const freshFetch = vi.fn().mockResolvedValue(jsonResponse({ok: true}));
     configureApiClient({baseUrl: 'https://fresh.example.test', fetchImpl: freshFetch});
-    await apiRequest('/workspaces');
+    await transportRequest('/workspaces');
 
     expect(staleFetch).not.toHaveBeenCalled();
     const request = freshFetch.mock.calls[0]?.[0] as Request;

--- a/libs/client/api/src/index.ts
+++ b/libs/client/api/src/index.ts
@@ -190,7 +190,7 @@ function createRequestInit(options: ApiRequestOptions, headers: Headers): KyOpti
   return requestInit;
 }
 
-export async function apiRequest<T>(path: string, options: ApiRequestOptions = {}): Promise<T> {
+async function apiRequest<T>(path: string, options: ApiRequestOptions = {}): Promise<T> {
   const headers = new Headers(options.headers);
   const hasCallerAuthorization = headers.has('authorization');
   const accessToken = apiOptions.getAccessToken?.();

--- a/libs/client/integrations/src/components/redirect-install-page.test.tsx
+++ b/libs/client/integrations/src/components/redirect-install-page.test.tsx
@@ -26,9 +26,7 @@ function renderInstallPage(
 
 describe('RedirectInstallPage', () => {
   test('requests the install URL and leaves the app', async () => {
-    const installRequest = vi
-      .fn()
-      .mockResolvedValue({install_url: 'https://provider.test/install'});
+    const installRequest = vi.fn().mockResolvedValue({installUrl: 'https://provider.test/install'});
     const assignLocation = vi.fn();
     const beforeRedirect = vi.fn();
 
@@ -68,9 +66,7 @@ describe('RedirectInstallPage', () => {
   });
 
   test('requests the install URL exactly once in Strict Mode', async () => {
-    const installRequest = vi
-      .fn()
-      .mockResolvedValue({install_url: 'https://provider.test/install'});
+    const installRequest = vi.fn().mockResolvedValue({installUrl: 'https://provider.test/install'});
 
     renderInstallPage(
       {

--- a/libs/client/integrations/src/components/redirect-install-page.tsx
+++ b/libs/client/integrations/src/components/redirect-install-page.tsx
@@ -6,9 +6,10 @@ import {FullPageLoader} from '@shipfox/react-ui/loader';
 import {Text} from '@shipfox/react-ui/typography';
 import {Link} from '@tanstack/react-router';
 import {useEffect, useRef, useState} from 'react';
+import type {InstallRedirect} from '#core/models.js';
 
 interface RedirectInstallPageProps {
-  installRequest: (body: {workspace_id: string}) => Promise<{install_url: string}>;
+  installRequest: (body: {workspace_id: string}) => Promise<InstallRedirect>;
   errorFallbackMessage: string;
   loadingLabel?: string;
   /**
@@ -44,7 +45,7 @@ export function RedirectInstallPage({
     }
     installRequest({workspace_id: workspace.id})
       .then((response) => {
-        assignLocation(response.install_url);
+        assignLocation(response.installUrl);
       })
       .catch((error: unknown) => {
         setErrorMessage(error instanceof ApiError ? error.message : errorFallbackMessage);

--- a/libs/client/integrations/src/hooks/api/integration-mapper.ts
+++ b/libs/client/integrations/src/hooks/api/integration-mapper.ts
@@ -5,6 +5,7 @@ import type {
 } from '@shipfox/api-integration-core-dto';
 import type {WebhookConnectionDto} from '@shipfox/api-integration-webhook-dto';
 import type {
+  InstallRedirect,
   IntegrationConnection,
   IntegrationProvider,
   Repository,
@@ -13,6 +14,10 @@ import type {
 
 export function toIntegrationProvider(dto: IntegrationProviderDto): IntegrationProvider {
   return {provider: dto.provider, displayName: dto.display_name, capabilities: dto.capabilities};
+}
+
+export function toInstallRedirect(dto: {install_url: string}): InstallRedirect {
+  return {installUrl: dto.install_url};
 }
 
 export function toIntegrationConnection(dto: IntegrationConnectionDto): IntegrationConnection {

--- a/libs/client/integrations/src/hooks/api/integrations.test.ts
+++ b/libs/client/integrations/src/hooks/api/integrations.test.ts
@@ -78,7 +78,9 @@ describe('Slack transport', () => {
       }),
     });
 
-    await createSlackInstall({workspace_id: '11111111-1111-4111-8111-111111111111'});
+    const install = await createSlackInstall({
+      workspace_id: '11111111-1111-4111-8111-111111111111',
+    });
     await completeSlackCallback({
       query: {code: 'grant code', state: 'signed state'},
       token: 'session-token',
@@ -88,6 +90,7 @@ describe('Slack transport', () => {
     expect(await requests[0]?.json()).toEqual({
       workspace_id: '11111111-1111-4111-8111-111111111111',
     });
+    expect(install).toEqual({installUrl: 'https://slack.example.test/install'});
     expect(requests[1]?.url).toBe(
       'https://api.example.test/integrations/slack/callback/api?code=grant+code&state=signed+state',
     );
@@ -122,7 +125,9 @@ describe('Linear transport', () => {
     });
     configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
 
-    await createLinearInstall({workspace_id: '11111111-1111-4111-8111-111111111111'});
+    const install = await createLinearInstall({
+      workspace_id: '11111111-1111-4111-8111-111111111111',
+    });
     await completeLinearCallback({
       query: {code: 'grant code', state: 'signed state'},
       token: 'session-token',
@@ -140,6 +145,7 @@ describe('Linear transport', () => {
     expect(await requests[0]?.json()).toEqual({
       workspace_id: '11111111-1111-4111-8111-111111111111',
     });
+    expect(install).toEqual({installUrl: 'https://linear.example.test/install'});
     expect(requests[1]?.url).toBe(
       'https://api.example.test/integrations/linear/callback/api?code=grant+code&state=signed+state',
     );

--- a/libs/client/integrations/src/hooks/api/integrations.ts
+++ b/libs/client/integrations/src/hooks/api/integrations.ts
@@ -42,20 +42,26 @@ import {
 import {checkedApiRequest, emptyResponseSchema} from '@shipfox/client-api';
 import {
   type FetchQueryOptions,
+  type InfiniteData,
+  infiniteQueryOptions,
   queryOptions,
+  type UseInfiniteQueryOptions,
   useInfiniteQuery,
   useMutation,
   useQuery,
   useQueryClient,
 } from '@tanstack/react-query';
 import {
+  type InstallRedirect,
   type IntegrationConnection,
   type IntegrationProvider,
   isUsableConnection,
+  type RepositoryPage,
 } from '#core/models.js';
 import {serializeLinearCallbackQuery} from '#linear-callback.js';
 import {serializeSlackCallbackQuery} from '#slack-callback.js';
 import {
+  toInstallRedirect,
   toIntegrationConnection,
   toIntegrationProvider,
   toRepository,
@@ -98,13 +104,36 @@ type ProvidersQueryOptions = FetchQueryOptions<
   ProvidersQueryKey
 >;
 
+type ConnectionsQueryKey =
+  | ReturnType<typeof integrationsQueryKeys.connections>
+  | readonly ['integrations', 'connections'];
+
+type ConnectionsQueryOptions = FetchQueryOptions<
+  IntegrationConnection[],
+  Error,
+  IntegrationConnection[],
+  ConnectionsQueryKey
+>;
+
+type RepositoriesQueryKey =
+  | ReturnType<typeof integrationsQueryKeys.repositories>
+  | readonly ['integrations', 'repositories'];
+
+type RepositoriesInfiniteQueryOptions = UseInfiniteQueryOptions<
+  RepositoryPage,
+  Error,
+  InfiniteData<RepositoryPage, string | undefined>,
+  RepositoriesQueryKey,
+  string | undefined
+>;
+
 export async function listIntegrationProviders({
   capability,
   signal,
 }: {
   capability?: IntegrationCapabilityDto;
   signal?: AbortSignal;
-}) {
+}): Promise<IntegrationProvider[]> {
   const search = new URLSearchParams();
   if (capability) search.set('capability', capability);
   const query = search.toString();
@@ -121,7 +150,7 @@ export async function listIntegrationConnections({
   workspaceId: string;
   capability?: IntegrationCapabilityDto | undefined;
   signal?: AbortSignal | undefined;
-}) {
+}): Promise<IntegrationConnection[]> {
   const search = new URLSearchParams({workspace_id: workspaceId});
   if (capability) search.set('capability', capability);
   const response = await checkedApiRequest(
@@ -138,7 +167,7 @@ export async function listSourceConnections({
 }: {
   workspaceId: string;
   signal?: AbortSignal;
-}) {
+}): Promise<IntegrationConnection[]> {
   const connections = await listIntegrationConnections({
     workspaceId,
     capability: 'source_control',
@@ -162,7 +191,9 @@ export function sourceConnectionsQueryOptions(
   });
 }
 
-export async function createGiteaConnection(body: CreateGiteaConnectionBodyDto) {
+export async function createGiteaConnection(
+  body: CreateGiteaConnectionBodyDto,
+): Promise<IntegrationConnection> {
   const response = await checkedApiRequest(
     createGiteaConnectionResponseSchema,
     '/integrations/gitea/connections',
@@ -174,14 +205,14 @@ export async function createGiteaConnection(body: CreateGiteaConnectionBodyDto) 
   return toIntegrationConnection(response);
 }
 
-export async function createGithubInstall(body: CreateGithubInstallBodyDto) {
-  return await checkedApiRequest(
-    createGithubInstallResponseSchema,
-    '/integrations/github/install',
-    {
+export async function createGithubInstall(
+  body: CreateGithubInstallBodyDto,
+): Promise<InstallRedirect> {
+  return toInstallRedirect(
+    await checkedApiRequest(createGithubInstallResponseSchema, '/integrations/github/install', {
       method: 'POST',
       body,
-    },
+    }),
   );
 }
 
@@ -197,7 +228,7 @@ export async function completeGithubCallback({
   state: string;
   setupAction?: string;
   token: string;
-}) {
+}): Promise<IntegrationConnection> {
   const query = new URLSearchParams({code, installation_id: String(installationId), state});
   if (setupAction) query.set('setup_action', setupAction);
   const response = await checkedApiRequest(
@@ -208,33 +239,37 @@ export async function completeGithubCallback({
   return toIntegrationConnection(response);
 }
 
-export async function createSentryInstall(body: CreateSentryInstallBodyDto) {
-  return await checkedApiRequest(
-    createSentryInstallResponseSchema,
-    '/integrations/sentry/install',
-    {
+export async function createSentryInstall(
+  body: CreateSentryInstallBodyDto,
+): Promise<InstallRedirect> {
+  return toInstallRedirect(
+    await checkedApiRequest(createSentryInstallResponseSchema, '/integrations/sentry/install', {
       method: 'POST',
       body,
-    },
+    }),
   );
 }
 
-export async function createLinearInstall(body: CreateLinearInstallBodyDto) {
-  return await checkedApiRequest(
-    createLinearInstallResponseSchema,
-    '/integrations/linear/install',
-    {
+export async function createLinearInstall(
+  body: CreateLinearInstallBodyDto,
+): Promise<InstallRedirect> {
+  return toInstallRedirect(
+    await checkedApiRequest(createLinearInstallResponseSchema, '/integrations/linear/install', {
       method: 'POST',
       body,
-    },
+    }),
   );
 }
 
-export async function createSlackInstall(body: CreateSlackInstallBodyDto) {
-  return await checkedApiRequest(createSlackInstallResponseSchema, '/integrations/slack/install', {
-    method: 'POST',
-    body,
-  });
+export async function createSlackInstall(
+  body: CreateSlackInstallBodyDto,
+): Promise<InstallRedirect> {
+  return toInstallRedirect(
+    await checkedApiRequest(createSlackInstallResponseSchema, '/integrations/slack/install', {
+      method: 'POST',
+      body,
+    }),
+  );
 }
 
 export async function completeLinearCallback({
@@ -243,7 +278,7 @@ export async function completeLinearCallback({
 }: {
   query: LinearCallbackQueryDto;
   token: string;
-}) {
+}): Promise<IntegrationConnection> {
   const response = await checkedApiRequest(
     linearCallbackResponseSchema,
     `/integrations/linear/callback/api?${serializeLinearCallbackQuery(query)}`,
@@ -258,7 +293,7 @@ export async function completeSlackCallback({
 }: {
   query: SlackCallbackQueryDto;
   token: string;
-}) {
+}): Promise<IntegrationConnection> {
   const response = await checkedApiRequest(
     slackCallbackResponseSchema,
     `/integrations/slack/callback/api?${serializeSlackCallbackQuery(query)}`,
@@ -292,7 +327,7 @@ export async function listRepositories({
   cursor?: string;
   search?: string;
   signal?: AbortSignal;
-}) {
+}): Promise<RepositoryPage> {
   const params = new URLSearchParams();
   if (cursor) params.set('cursor', cursor);
   if (search) params.set('search', search);
@@ -303,7 +338,7 @@ export async function listRepositories({
   const response = await checkedApiRequest(listRepositoriesResponseSchema, path, {signal});
   return {
     repositories: response.repositories.map(toRepository),
-    nextCursor: response.next_cursor ?? undefined,
+    ...(response.next_cursor == null ? {} : {nextCursor: response.next_cursor}),
   };
 }
 
@@ -313,7 +348,7 @@ export async function updateIntegrationConnection({
 }: {
   connectionId: string;
   body: UpdateIntegrationConnectionBodyDto;
-}) {
+}): Promise<IntegrationConnection> {
   const response = await checkedApiRequest(
     integrationConnectionDtoSchema,
     `/integration-connections/${encodeURIComponent(connectionId)}`,
@@ -333,11 +368,7 @@ export async function deleteIntegrationConnection({connectionId}: {connectionId:
 }
 
 export function useIntegrationProvidersQuery(params?: {capability?: IntegrationCapabilityDto}) {
-  const capability = params?.capability;
-  return useQuery({
-    queryKey: integrationsQueryKeys.providers(capability ?? 'all'),
-    queryFn: ({signal}) => listIntegrationProviders(capability ? {capability, signal} : {signal}),
-  });
+  return useQuery(integrationProvidersQueryOptions(params?.capability));
 }
 
 export function integrationProvidersQueryOptions(
@@ -354,24 +385,30 @@ export function useSourceConnectionsQuery(workspaceId: string | undefined) {
 }
 
 export function useIntegrationConnectionsQuery(workspaceId: string | undefined) {
-  return useQuery({
+  return useQuery(integrationConnectionsQueryOptions(workspaceId));
+}
+
+export function integrationConnectionsQueryOptions(
+  workspaceId: string | undefined,
+): ConnectionsQueryOptions {
+  return queryOptions({
     queryKey: workspaceId
       ? integrationsQueryKeys.connections(workspaceId, 'all')
-      : [...integrationsQueryKeys.all, 'connections'],
+      : ([...integrationsQueryKeys.all, 'connections'] as const),
     enabled: Boolean(workspaceId),
     queryFn: ({signal}) => listIntegrationConnections({workspaceId: workspaceId ?? '', signal}),
   });
 }
 
-export function useRepositoriesInfiniteQuery(
+export function repositoriesInfiniteQueryOptions(
   connectionId: string | undefined,
   options?: {search?: string},
-) {
+): RepositoriesInfiniteQueryOptions {
   const trimmedSearch = options?.search?.trim() ?? '';
-  return useInfiniteQuery({
+  return infiniteQueryOptions({
     queryKey: connectionId
       ? integrationsQueryKeys.repositories(connectionId, trimmedSearch)
-      : [...integrationsQueryKeys.all, 'repositories'],
+      : ([...integrationsQueryKeys.all, 'repositories'] as const),
     enabled: Boolean(connectionId),
     initialPageParam: undefined as string | undefined,
     queryFn: ({pageParam, signal}) => {
@@ -385,6 +422,13 @@ export function useRepositoriesInfiniteQuery(
     },
     getNextPageParam: (lastPage) => lastPage.nextCursor,
   });
+}
+
+export function useRepositoriesInfiniteQuery(
+  connectionId: string | undefined,
+  options?: {search?: string},
+) {
+  return useInfiniteQuery(repositoriesInfiniteQueryOptions(connectionId, options));
 }
 
 export function useCreateGiteaConnectionMutation() {

--- a/libs/client/integrations/src/hooks/api/webhook-connections.ts
+++ b/libs/client/integrations/src/hooks/api/webhook-connections.ts
@@ -24,7 +24,9 @@ export const webhookConnectionsQueryKeys = {
   list: (workspaceId: string) => [...webhookConnectionsQueryKeys.all, 'list', workspaceId] as const,
 };
 
-type WebhookConnectionsListQueryKey = ReturnType<typeof webhookConnectionsQueryKeys.list>;
+type WebhookConnectionsListQueryKey =
+  | ReturnType<typeof webhookConnectionsQueryKeys.list>
+  | readonly ['webhook-connections', 'list'];
 
 type WebhookConnectionsListQueryOptions = FetchQueryOptions<
   WebhookConnection[],
@@ -87,21 +89,18 @@ export async function deleteWebhookConnection({connectionId}: {connectionId: str
 }
 
 export function useWebhookConnectionsQuery(workspaceId: string | undefined) {
-  return useQuery({
-    queryKey: workspaceId
-      ? webhookConnectionsQueryKeys.list(workspaceId)
-      : [...webhookConnectionsQueryKeys.all, 'list'],
-    enabled: Boolean(workspaceId),
-    queryFn: ({signal}) => listWebhookConnections({workspaceId: workspaceId ?? '', signal}),
-  });
+  return useQuery(webhookConnectionsQueryOptions(workspaceId));
 }
 
 export function webhookConnectionsQueryOptions(
-  workspaceId: string,
+  workspaceId: string | undefined,
 ): WebhookConnectionsListQueryOptions {
   return queryOptions({
-    queryKey: webhookConnectionsQueryKeys.list(workspaceId),
-    queryFn: ({signal}) => listWebhookConnections({workspaceId, signal}),
+    queryKey: workspaceId
+      ? webhookConnectionsQueryKeys.list(workspaceId)
+      : ([...webhookConnectionsQueryKeys.all, 'list'] as const),
+    enabled: Boolean(workspaceId),
+    queryFn: ({signal}) => listWebhookConnections({workspaceId: workspaceId ?? '', signal}),
   });
 }
 

--- a/libs/client/integrations/src/sentry-callback.ts
+++ b/libs/client/integrations/src/sentry-callback.ts
@@ -109,7 +109,7 @@ export function classifySentryConnectError(error: unknown): SentryConnectFailure
       return {kind: 'retryable', message: 'Sentry is unreachable. Try again.'};
     }
     if (error.status === 0 || error.code === 'network-error') {
-      // A network failure (apiRequest throws status 0) never reached the
+      // A network failure (the client transport reports status 0) never reached the
       // server, so the grant code is untouched and a plain Retry can recover.
       // Must precede the status < 500 branch, which would otherwise treat it as
       // a spent code and force a full restart.

--- a/libs/client/workflows/src/core/entities/workflow-run.ts
+++ b/libs/client/workflows/src/core/entities/workflow-run.ts
@@ -68,6 +68,10 @@ export interface WorkflowRunListPage {
   filteredTotalCount: number | null;
 }
 
+export interface ManualWorkflowLaunch {
+  workflowRunId: string;
+}
+
 export function workflowRunShortId(id: string): string {
   return id.length <= 8 ? id : id.slice(0, 8);
 }

--- a/libs/client/workflows/src/core/workflow-run.ts
+++ b/libs/client/workflows/src/core/workflow-run.ts
@@ -38,6 +38,7 @@ export type {
 } from './entities/step-attempt.js';
 export {StepAttempt} from './entities/step-attempt.js';
 export type {
+  ManualWorkflowLaunch,
   WorkflowRun,
   WorkflowRunDetail,
   WorkflowRunListItem,

--- a/libs/client/workflows/src/hooks/api/workflow-runs.test.tsx
+++ b/libs/client/workflows/src/hooks/api/workflow-runs.test.tsx
@@ -133,6 +133,17 @@ describe('workflow run API hooks', () => {
     expect(cached).toHaveProperty('triggerSource', 'manual');
   });
 
+  test('rejects malformed detail responses before they reach the query cache', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({id: RUN_ID, trigger_source: 'manual'}));
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    const {result, queryClient} = renderWithQueryClient(() => useWorkflowRunQuery(RUN_ID));
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toMatchObject({code: 'invalid-response'});
+    expect(queryClient.getQueryData(workflowRunsQueryKeys.detail(RUN_ID))).toBeUndefined();
+  });
+
   test('maps run attempts and caches them by workflow run id', async () => {
     const body = runAttemptsResponseDto({
       attempts: [
@@ -187,8 +198,8 @@ describe('workflow run API hooks', () => {
       inputs: {env: 'production'},
     });
 
-    expect(withoutInputs.workflow_run_id).toBe(RUN_ID);
-    expect(withInputs.workflow_run_id).toBe(RUN_ID);
+    expect(withoutInputs.workflowRunId).toBe(RUN_ID);
+    expect(withInputs.workflowRunId).toBe(RUN_ID);
     expect(postBodies).toEqual([{}, {inputs: {env: 'production'}}]);
     expect(firstRequest(fetchImpl).url).toBe(
       `https://api.example.test/workflow-definitions/${DEFINITION_ID}/fire-manual`,

--- a/libs/client/workflows/src/hooks/api/workflow-runs.ts
+++ b/libs/client/workflows/src/hooks/api/workflow-runs.ts
@@ -10,7 +10,11 @@ import {
 import {checkedApiRequest, type StandardSchema} from '@shipfox/client-api';
 import {
   type InfiniteData,
+  infiniteQueryOptions,
   keepPreviousData,
+  queryOptions,
+  type UseInfiniteQueryOptions,
+  type UseQueryOptions,
   useInfiniteQuery,
   useMutation,
   useQuery,
@@ -18,6 +22,7 @@ import {
 } from '@tanstack/react-query';
 import {
   isWorkflowRunTerminal,
+  type ManualWorkflowLaunch,
   type WorkflowRun,
   type WorkflowRunAttempt,
   WorkflowRunAttemptSummary,
@@ -52,6 +57,35 @@ export const workflowRunsQueryKeys = {
     [...workflowRunsQueryKeys.all, 'attempts', workflowRunId] as const,
 };
 
+type WorkflowRunsListQueryKey =
+  | ReturnType<typeof workflowRunsQueryKeys.list>
+  | readonly ['workflow-runs', 'list'];
+type WorkflowRunDetailQueryKey =
+  | ReturnType<typeof workflowRunsQueryKeys.detail>
+  | readonly ['workflow-runs', 'detail'];
+type WorkflowRunAttemptsQueryKey =
+  | ReturnType<typeof workflowRunsQueryKeys.attempts>
+  | readonly ['workflow-runs', 'attempts'];
+type WorkflowRunsInfiniteQueryOptions = UseInfiniteQueryOptions<
+  WorkflowRunListPage,
+  Error,
+  InfiniteData<WorkflowRunListPage, string | undefined>,
+  WorkflowRunsListQueryKey,
+  string | undefined
+>;
+type WorkflowRunDetailQueryOptions = UseQueryOptions<
+  WorkflowRunDetail,
+  Error,
+  WorkflowRunDetail,
+  WorkflowRunDetailQueryKey
+>;
+type WorkflowRunAttemptsQueryOptions = UseQueryOptions<
+  WorkflowRunAttempt[],
+  Error,
+  WorkflowRunAttempt[],
+  WorkflowRunAttemptsQueryKey
+>;
+
 function normalizeFilters(filters: WorkflowRunFilters) {
   return {
     status: filters.status ?? null,
@@ -70,7 +104,7 @@ function appendFilters(params: URLSearchParams, filters: WorkflowRunFilters) {
   if (filters.createdTo) params.set('created_to', filters.createdTo);
 }
 
-async function listWorkflowRunsDto({
+async function listWorkflowRuns({
   projectId,
   filters,
   limit = 50,
@@ -82,7 +116,7 @@ async function listWorkflowRunsDto({
   limit?: number;
   cursor?: string | undefined;
   signal?: AbortSignal;
-}) {
+}): Promise<WorkflowRunListPage> {
   const params = new URLSearchParams({project_id: projectId, limit: String(limit)});
   if (cursor) params.set('cursor', cursor);
   appendFilters(params, filters);
@@ -107,8 +141,8 @@ export async function fireManualWorkflow({
 }: {
   definitionId: string;
   inputs?: Record<string, unknown>;
-}) {
-  return await checkedApiRequest(
+}): Promise<ManualWorkflowLaunch> {
+  const response = await checkedApiRequest(
     manualWorkflowResponseSchema,
     `/workflow-definitions/${definitionId}/fire-manual`,
     {
@@ -116,6 +150,7 @@ export async function fireManualWorkflow({
       body: inputs ? {inputs} : {},
     },
   );
+  return {workflowRunId: response.workflow_run_id};
 }
 
 const ACTIVE_POLL_MS = 4_000;
@@ -128,6 +163,14 @@ export function useWorkflowRunsInfiniteQuery(
   filters: WorkflowRunFilters,
   limit = 50,
 ) {
+  return useInfiniteQuery(workflowRunsInfiniteQueryOptions(projectId, filters, limit));
+}
+
+export function workflowRunsInfiniteQueryOptions(
+  projectId: string | undefined,
+  filters: WorkflowRunFilters,
+  limit = 50,
+): WorkflowRunsInfiniteQueryOptions {
   // Polling is owned by react-query, not the page. Polling fast (4s) while
   // any non-terminal run is visible covers state transitions; polling slow
   // (30s) when idle covers brand-new external runs (webhook/schedule
@@ -139,14 +182,14 @@ export function useWorkflowRunsInfiniteQuery(
   // of rows can drop into a between-pages gap. Users who scrolled into
   // history opted into "reading mode": pause until they refocus, filter,
   // or scroll back.
-  return useInfiniteQuery({
+  return infiniteQueryOptions({
     queryKey: projectId
       ? workflowRunsQueryKeys.list(projectId, filters)
-      : [...workflowRunsQueryKeys.all, 'list'],
+      : ([...workflowRunsQueryKeys.all, 'list'] as const),
     enabled: Boolean(projectId),
     initialPageParam: undefined as string | undefined,
     queryFn: ({pageParam, signal}) =>
-      listWorkflowRunsDto({projectId: projectId ?? '', filters, limit, cursor: pageParam, signal}),
+      listWorkflowRuns({projectId: projectId ?? '', filters, limit, cursor: pageParam, signal}),
     getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
     placeholderData: keepPreviousData,
     staleTime: 2_000,
@@ -163,7 +206,7 @@ export function useWorkflowRunsInfiniteQuery(
   });
 }
 
-async function getWorkflowRunDto({
+async function getWorkflowRun({
   workflowRunId,
   runAttempt,
   signal,
@@ -171,39 +214,48 @@ async function getWorkflowRunDto({
   workflowRunId: string;
   runAttempt?: number | undefined;
   signal?: AbortSignal;
-}) {
+}): Promise<WorkflowRunDetail> {
   const params = new URLSearchParams();
   if (runAttempt) params.set('attempt', String(runAttempt));
   const query = params.size > 0 ? `?${params.toString()}` : '';
-  return await checkedApiRequest(
-    workflowRunDetailResponseSchema,
-    `/workflows/runs/${workflowRunId}${query}`,
-    {
-      signal,
-    },
+  return toWorkflowRunDetail(
+    await checkedApiRequest(
+      workflowRunDetailResponseSchema,
+      `/workflows/runs/${workflowRunId}${query}`,
+      {
+        signal,
+      },
+    ),
   );
 }
 
-async function getWorkflowRunAttemptsDto({
+async function getWorkflowRunAttempts({
   workflowRunId,
   signal,
 }: {
   workflowRunId: string;
   signal?: AbortSignal;
-}) {
-  return await checkedApiRequest(
+}): Promise<WorkflowRunAttempt[]> {
+  const response = await checkedApiRequest(
     workflowRunAttemptsResponseSchema,
     `/workflows/runs/${workflowRunId}/attempts`,
     {
       signal,
     },
   );
+  return response.attempts.map(toWorkflowRunAttempt);
 }
 
-async function cancelWorkflowRunDto({workflowRunId}: {workflowRunId: string}) {
-  return await checkedApiRequest(workflowRunDtoSchema, `/workflows/runs/${workflowRunId}/cancel`, {
-    method: 'POST',
-  });
+async function cancelWorkflowRun({
+  workflowRunId,
+}: {
+  workflowRunId: string;
+}): Promise<WorkflowRunListItem> {
+  return toWorkflowRunListItem(
+    await checkedApiRequest(workflowRunDtoSchema, `/workflows/runs/${workflowRunId}/cancel`, {
+      method: 'POST',
+    }),
+  );
 }
 
 export async function rerunWorkflowRun({
@@ -212,14 +264,12 @@ export async function rerunWorkflowRun({
 }: {
   workflowRunId: string;
   mode: WorkflowRunRerunModeDto;
-}) {
-  return await checkedApiRequest(
-    workflowRunResponseSchema,
-    `/workflows/runs/${workflowRunId}/rerun`,
-    {
+}): Promise<WorkflowRunListItem> {
+  return toWorkflowRunListItem(
+    await checkedApiRequest(workflowRunResponseSchema, `/workflows/runs/${workflowRunId}/rerun`, {
       method: 'POST',
       body: {mode} satisfies RerunWorkflowRunBodyDto,
-    },
+    }),
   );
 }
 
@@ -433,7 +483,7 @@ function lookupDefinitionName(
   definitionId: string,
 ): string | undefined {
   const entries = queryClient.getQueriesData<
-    InfiniteData<{definitions: Array<{id: string; project_id: string; name: string}>}>
+    InfiniteData<{definitions: Array<{id: string; name: string}>}>
   >({queryKey: ['definitions', 'list', projectId]});
   for (const [, data] of entries) {
     if (!data) continue;
@@ -456,17 +506,24 @@ export function useWorkflowRunAttemptQuery({
   workflowRunId: string | undefined;
   runAttempt?: number | undefined;
 }) {
+  return useQuery(workflowRunQueryOptions({workflowRunId, runAttempt}));
+}
+
+export function workflowRunQueryOptions({
+  workflowRunId,
+  runAttempt,
+}: {
+  workflowRunId: string | undefined;
+  runAttempt?: number | undefined;
+}): WorkflowRunDetailQueryOptions {
   // Poll a non-terminal run so the open run detail stays live (same cadence as the run
   // list); stop once the run is terminal.
-  return useQuery({
+  return queryOptions({
     queryKey: workflowRunId
       ? workflowRunsQueryKeys.detail(workflowRunId, runAttempt)
-      : [...workflowRunsQueryKeys.all, 'detail'],
+      : ([...workflowRunsQueryKeys.all, 'detail'] as const),
     enabled: Boolean(workflowRunId),
-    queryFn: ({signal}) =>
-      getWorkflowRunDto({workflowRunId: workflowRunId ?? '', runAttempt, signal}).then(
-        toWorkflowRunDetail,
-      ),
+    queryFn: ({signal}) => getWorkflowRun({workflowRunId: workflowRunId ?? '', runAttempt, signal}),
     staleTime: 2_000,
     refetchOnWindowFocus: true,
     refetchInterval: (query) => {
@@ -486,15 +543,22 @@ export function useWorkflowRunAttemptsQuery({
   workflowRunId: string | undefined;
   enabled: boolean;
 }) {
-  return useQuery({
+  return useQuery(workflowRunAttemptsQueryOptions({workflowRunId, enabled}));
+}
+
+export function workflowRunAttemptsQueryOptions({
+  workflowRunId,
+  enabled,
+}: {
+  workflowRunId: string | undefined;
+  enabled: boolean;
+}): WorkflowRunAttemptsQueryOptions {
+  return queryOptions({
     queryKey: workflowRunId
       ? workflowRunsQueryKeys.attempts(workflowRunId)
-      : [...workflowRunsQueryKeys.all, 'attempts'],
+      : ([...workflowRunsQueryKeys.all, 'attempts'] as const),
     enabled: Boolean(workflowRunId) && enabled,
-    queryFn: ({signal}) =>
-      getWorkflowRunAttemptsDto({workflowRunId: workflowRunId ?? '', signal}).then(
-        (dto): WorkflowRunAttempt[] => dto.attempts.map(toWorkflowRunAttempt),
-      ),
+    queryFn: ({signal}) => getWorkflowRunAttempts({workflowRunId: workflowRunId ?? '', signal}),
     staleTime: 0,
     refetchOnMount: true,
     refetchOnWindowFocus: false,
@@ -504,9 +568,9 @@ export function useWorkflowRunAttemptsQuery({
 export function useCancelWorkflowRunMutation(run: WorkflowRun | undefined) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async () => {
+    mutationFn: async (): Promise<WorkflowRunListItem> => {
       if (!run) throw new Error('Workflow run is not loaded');
-      return toWorkflowRunListItem(await cancelWorkflowRunDto({workflowRunId: run.id}));
+      return await cancelWorkflowRun({workflowRunId: run.id});
     },
     onSuccess: async () => {
       if (!run) return;

--- a/libs/client/workflows/src/index.ts
+++ b/libs/client/workflows/src/index.ts
@@ -5,6 +5,7 @@ export type {
   JobExecutionStatus,
   JobExecutionTime,
   JobStatus,
+  ManualWorkflowLaunch,
   Step,
   StepAttempt,
   StepAttemptDisplayDuration,
@@ -40,6 +41,9 @@ export {
   useWorkflowRunQuery,
   useWorkflowRunsInfiniteQuery,
   type WorkflowRunFilters,
+  workflowRunAttemptsQueryOptions,
+  workflowRunQueryOptions,
+  workflowRunsInfiniteQueryOptions,
   workflowRunsQueryKeys,
 } from './hooks/api/workflow-runs.js';
 export {ProjectWorkflowsPage} from './pages/project-workflows-page.js';

--- a/tools/client-architecture-policy/src/audit-client-architecture.ts
+++ b/tools/client-architecture-policy/src/audit-client-architecture.ts
@@ -11,8 +11,29 @@ export interface ClientArchitectureViolation {
     | 'non-owning-feature-contribution'
     | 'private-feature-import'
     | 'unchecked-route-search'
+    | 'inline-query-policy'
+    | 'query-policy-outside-adapter'
+    | 'unmapped-api-response'
     | 'unparsed-api-response';
 }
+
+export interface ClientArchitectureInventory {
+  adapterFiles: string[];
+  checkedApiRequestCalls: number;
+  queryHooks: number;
+  reusableQueryPolicies: number;
+}
+
+/**
+ * Narrow exceptions must name the owning file and explain the state that the
+ * shared query-options convention cannot safely represent.
+ */
+export const clientArchitectureExceptions = {
+  queryPolicy: {
+    'libs/client/logs/src/hooks/api/step-logs.ts':
+      'The query merges a prior cursor snapshot and owns a per-view retry lifecycle.',
+  },
+} as const;
 
 const rootDirectory = fileURLToPath(new URL('../../../', import.meta.url));
 const auditedDirectories = [
@@ -23,13 +44,47 @@ const sourceFilePattern = /\.(?:ts|tsx)$/;
 const nonProductionSourcePattern = /\.(?:stories|test)\.(?:ts|tsx)$/;
 const apiRequestPattern = /\b(?:apiRequest|checkedApiRequest)\s*(?:<[^>]*>)?\s*\(/;
 const uncheckedApiRequestPattern = /\bapiRequest\s*(?:<[^>]*>)?\s*\(/;
+const checkedApiRequestCallPattern = /\bcheckedApiRequest\s*(?:<[^>]*>)?\s*\(/g;
+const unmappedApiResponsePattern =
+  /(?:\breturn\s*(?:\(\s*)?|=>\s*(?:\(\s*)?)(?:await\s+)?checkedApiRequest\s*(?:<[^>]*>)?\s*\((?!\s*emptyResponseSchema\b)/g;
+const queryHookPattern = /\b(?:useQuery|useInfiniteQuery)\s*(?:<[^>]*>)?\s*\(/g;
+const queryPolicyPattern =
+  /(?:\.\.\.\s*)?(?:[A-Za-z_$][\w$]*QueryOptions|queryOptions|infiniteQueryOptions)\s*\(/;
 const routeSearchPattern = /\buseRouteSearch\s*\(/;
+const identifierStartPattern = /[A-Za-z_$]/;
+const identifierPartPattern = /[A-Za-z0-9_$]/;
+const regexFlagPattern = /[A-Za-z]/;
+const whitespacePattern = /\s/;
+const digitPattern = /[0-9]/;
+const regexLiteralPrefixKeywords = new Set([
+  'await',
+  'case',
+  'catch',
+  'delete',
+  'do',
+  'else',
+  'for',
+  'if',
+  'in',
+  'instanceof',
+  'of',
+  'return',
+  'switch',
+  'throw',
+  'typeof',
+  'void',
+  'while',
+  'with',
+  'yield',
+]);
 const excludedDirectoryNames = new Set([
   'dist',
   'node_modules',
   'test',
   'tests',
   '__tests__',
+  'fixtures',
+  '__fixtures__',
   'generated',
   '__generated__',
 ]);
@@ -45,6 +100,7 @@ const navigationTargetPattern = /\bto\s*:\s*['"]([^'"]+)['"]/gu;
 const settingsPathPattern = /\bpathSegment\s*:\s*['"]([^'"]+)['"]/gu;
 const registryDefinitionPattern = /\b(?:navigation|settingsSections)\s*(?::|=)\s*\[/u;
 const trailingSlashPattern = /\/+$/u;
+const generatedFilePattern = /\.gen\.(?:ts|tsx)$/;
 
 function toRepositoryPath(filePath: string): string {
   return path.relative(rootDirectory, filePath).split(path.sep).join('/');
@@ -58,7 +114,9 @@ export async function sourceFiles(directory: string): Promise<string[]> {
       if (entry.isDirectory()) {
         return excludedDirectoryNames.has(entry.name) ? [] : await sourceFiles(entryPath);
       }
-      return sourceFilePattern.test(entry.name) && !nonProductionSourcePattern.test(entry.name)
+      return sourceFilePattern.test(entry.name) &&
+        !nonProductionSourcePattern.test(entry.name) &&
+        !generatedFilePattern.test(entry.name)
         ? [entryPath]
         : [];
     }),
@@ -108,6 +166,174 @@ function featureContributionOccurrences(file: string, source: string): number {
 
   return occurrences;
 }
+
+function isIdentifierStart(character: string | undefined): boolean {
+  return character !== undefined && identifierStartPattern.test(character);
+}
+
+function isIdentifierPart(character: string | undefined): boolean {
+  return character !== undefined && identifierPartPattern.test(character);
+}
+
+function findRegexLiteralEnd(source: string, start: number): number {
+  let inCharacterClass = false;
+  let escaped = false;
+
+  for (let index = start + 1; index < source.length; index += 1) {
+    const character = source[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (character === '\n' || character === '\r') return source.length;
+    if (character === '[') {
+      inCharacterClass = true;
+      continue;
+    }
+    if (character === ']') {
+      inCharacterClass = false;
+      continue;
+    }
+    if (character === '/' && !inCharacterClass) {
+      let end = index + 1;
+      while (regexFlagPattern.test(source[end] ?? '')) end += 1;
+      return end;
+    }
+  }
+  return source.length;
+}
+
+function findMatchingCallEnd(source: string, openParen: number): number {
+  let depth = 0;
+  let quote: '"' | "'" | '`' | null = null;
+  let escaped = false;
+  let canEndExpression = false;
+
+  for (let index = openParen; index < source.length; index += 1) {
+    const character = source[index];
+    const nextCharacter = source[index + 1];
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (character === '\\') {
+        escaped = true;
+      } else if (character === quote) {
+        quote = null;
+        canEndExpression = true;
+      }
+      continue;
+    }
+    if (whitespacePattern.test(character ?? '')) continue;
+    if (character === '/' && nextCharacter === '/') {
+      const newline = source.indexOf('\n', index + 2);
+      if (newline === -1) return source.length;
+      index = newline;
+      continue;
+    }
+    if (character === '/' && nextCharacter === '*') {
+      const commentEnd = source.indexOf('*/', index + 2);
+      if (commentEnd === -1) return source.length;
+      index = commentEnd + 1;
+      continue;
+    }
+    if (character === '"' || character === "'" || character === '`') {
+      quote = character;
+      escaped = false;
+      canEndExpression = false;
+      continue;
+    }
+    if (character === '/' && !canEndExpression) {
+      index = findRegexLiteralEnd(source, index) - 1;
+      canEndExpression = true;
+      continue;
+    }
+    if (isIdentifierStart(character)) {
+      let end = index + 1;
+      while (isIdentifierPart(source[end])) end += 1;
+      canEndExpression = !regexLiteralPrefixKeywords.has(source.slice(index, end));
+      index = end - 1;
+      continue;
+    }
+    if (digitPattern.test(character ?? '')) {
+      canEndExpression = true;
+      continue;
+    }
+    if (character === '(') {
+      depth += 1;
+      canEndExpression = false;
+      continue;
+    }
+    if (character === ')' && --depth === 0) return index;
+    if (character === ')') {
+      canEndExpression = true;
+      continue;
+    }
+    if (character === ']' || character === '}') {
+      canEndExpression = true;
+      continue;
+    }
+    if (character === '+' || character === '-') {
+      if (nextCharacter === character) {
+        index += 1;
+        canEndExpression = true;
+      } else {
+        canEndExpression = false;
+      }
+      continue;
+    }
+    canEndExpression = false;
+  }
+  return source.length;
+}
+
+function queryHookCalls(source: string): Array<{hasPolicy: boolean}> {
+  return [...source.matchAll(new RegExp(queryHookPattern.source, 'g'))].map((match) => {
+    const start = match.index ?? 0;
+    const openParen = start + match[0].lastIndexOf('(');
+    const end = findMatchingCallEnd(source, openParen);
+    const argumentsSource = source.slice(openParen + 1, end);
+    return {hasPolicy: queryPolicyPattern.test(argumentsSource)};
+  });
+}
+
+function hasQueryPolicyException(file: string): boolean {
+  return Object.hasOwn(clientArchitectureExceptions.queryPolicy, file);
+}
+
+function validateExceptionRegistry(files: string[]): void {
+  const fileSet = new Set(files);
+  for (const [file, reason] of Object.entries(clientArchitectureExceptions.queryPolicy)) {
+    if (!reason.trim()) throw new Error(`Client architecture exception has no reason: ${file}`);
+    if (!fileSet.has(file))
+      throw new Error(`Client architecture exception file is not audited: ${file}`);
+  }
+}
+
+export function inventoryClientSource(
+  file: string,
+  source: string,
+): {
+  isAdapter: boolean;
+  checkedApiRequestCalls: number;
+  queryHooks: number;
+  reusableQueryPolicies: number;
+} {
+  const normalizedFile = file.split(path.sep).join('/');
+  const isAdapter = normalizedFile.includes('/src/hooks/api/');
+  const calls = queryHookCalls(source);
+  const reusableQueryPolicies = calls.filter((call) => call.hasPolicy).length;
+  return {
+    isAdapter,
+    checkedApiRequestCalls: countMatches(source, checkedApiRequestCallPattern),
+    queryHooks: calls.length,
+    reusableQueryPolicies,
+  };
+}
+
 export function auditClientSource(file: string, source: string): ClientArchitectureViolation[] {
   const violations: ClientArchitectureViolation[] = [];
   const normalizedFile = file.split(path.sep).join('/');
@@ -125,13 +351,49 @@ export function auditClientSource(file: string, source: string): ClientArchitect
     addViolation('api-request-outside-adapter', countMatches(source, apiRequestPattern));
   if (!isClientApi)
     addViolation('unparsed-api-response', countMatches(source, uncheckedApiRequestPattern));
+  if (isAdapter && !isClientApi) {
+    addViolation('unmapped-api-response', countMatches(source, unmappedApiResponsePattern));
+    const queryCalls = queryHookCalls(source);
+    if (!hasQueryPolicyException(normalizedFile)) {
+      addViolation('inline-query-policy', queryCalls.filter((call) => !call.hasPolicy).length);
+    }
+  } else if (!isClientApi) {
+    addViolation('query-policy-outside-adapter', queryHookCalls(source).length);
+  }
   if (!normalizedFile.includes('/src/routes/'))
     addViolation('unchecked-route-search', countMatches(source, routeSearchPattern));
   return violations;
 }
 
+export async function inventoryRepository(): Promise<ClientArchitectureInventory> {
+  const files = (await Promise.all(auditedDirectories.map(sourceFiles))).flat();
+  validateExceptionRegistry(files.map(toRepositoryPath));
+  const entries = await Promise.all(
+    files.map(async (file) => ({
+      file: toRepositoryPath(file),
+      inventory: inventoryClientSource(toRepositoryPath(file), await readFile(file, 'utf8')),
+    })),
+  );
+  return {
+    adapterFiles: entries
+      .filter(({inventory}) => inventory.isAdapter)
+      .map(({file}) => file)
+      .sort(),
+    checkedApiRequestCalls: entries.reduce(
+      (total, {inventory}) => total + inventory.checkedApiRequestCalls,
+      0,
+    ),
+    queryHooks: entries.reduce((total, {inventory}) => total + inventory.queryHooks, 0),
+    reusableQueryPolicies: entries.reduce(
+      (total, {inventory}) => total + inventory.reusableQueryPolicies,
+      0,
+    ),
+  };
+}
+
 export async function auditRepository(): Promise<ClientArchitectureViolation[]> {
   const files = (await Promise.all(auditedDirectories.map(sourceFiles))).flat();
+  validateExceptionRegistry(files.map(toRepositoryPath));
   const violations = await Promise.all(
     files.map(async (file) =>
       auditClientSource(toRepositoryPath(file), await readFile(file, 'utf8')),
@@ -147,7 +409,10 @@ export async function auditRepository(): Promise<ClientArchitectureViolation[]> 
 async function main(): Promise<void> {
   const violations = await auditRepository();
   if (violations.length === 0) {
-    process.stdout.write('Client architecture audit passed with zero violations\n');
+    const inventory = await inventoryRepository();
+    process.stdout.write(
+      `Client architecture audit passed with zero violations (${inventory.checkedApiRequestCalls} checked API calls, ${inventory.queryHooks} query hooks, ${inventory.reusableQueryPolicies} reusable query policies, ${inventory.adapterFiles.length} adapter files)\n`,
+    );
     return;
   }
   process.stderr.write(`Client architecture audit found ${violations.length} violation(s)\n`);

--- a/tools/client-architecture-policy/test/audit-client-architecture.test.ts
+++ b/tools/client-architecture-policy/test/audit-client-architecture.test.ts
@@ -2,7 +2,11 @@ import assert from 'node:assert/strict';
 import {mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import {auditClientSource, sourceFiles} from '../src/audit-client-architecture.js';
+import {
+  auditClientSource,
+  inventoryClientSource,
+  sourceFiles,
+} from '../src/audit-client-architecture.js';
 
 describe('auditClientSource', () => {
   test('allows checked API requests in a feature adapter', () => {
@@ -99,6 +103,8 @@ export const projectsFeature = defineClientFeature({
         writeFile(path.join(directory, 'dist', 'generated.ts'), ''),
         writeFile(path.join(directory, 'node_modules', 'package', 'dependency.ts'), ''),
         writeFile(path.join(directory, 'test', 'fixture.ts'), ''),
+        writeFile(path.join(directory, 'test', 'setup.ts'), ''),
+        writeFile(path.join(directory, 'src', 'route.gen.ts'), ''),
       ]);
 
       const files = await sourceFiles(directory);
@@ -151,6 +157,158 @@ export const projectsFeature = defineClientFeature({
         rule: 'unparsed-api-response',
       },
     ]);
+  });
+
+  test('reports a checked business response returned without a domain mapper', () => {
+    const violations = auditClientSource(
+      'libs/client/projects/src/hooks/api/list-projects.ts',
+      "return await checkedApiRequest(projectResponseSchema, '/projects');",
+    );
+
+    assert.deepEqual(violations, [
+      {
+        file: 'libs/client/projects/src/hooks/api/list-projects.ts',
+        occurrences: 1,
+        rule: 'unmapped-api-response',
+      },
+    ]);
+  });
+
+  test('reports checked responses from concise and parenthesized returns', () => {
+    assert.deepEqual(
+      auditClientSource(
+        'libs/client/projects/src/hooks/api/list-projects.ts',
+        "const listProjects = async () => checkedApiRequest(projectResponseSchema, '/projects');",
+      ),
+      [
+        {
+          file: 'libs/client/projects/src/hooks/api/list-projects.ts',
+          occurrences: 1,
+          rule: 'unmapped-api-response',
+        },
+      ],
+    );
+    assert.deepEqual(
+      auditClientSource(
+        'libs/client/projects/src/hooks/api/list-projects.ts',
+        "return (await checkedApiRequest(projectResponseSchema, '/projects'));",
+      ),
+      [
+        {
+          file: 'libs/client/projects/src/hooks/api/list-projects.ts',
+          occurrences: 1,
+          rule: 'unmapped-api-response',
+        },
+      ],
+    );
+    assert.deepEqual(
+      auditClientSource(
+        'libs/client/projects/src/hooks/api/delete-project.ts',
+        "const deleteProject = async () => (await checkedApiRequest(emptyResponseSchema, '/projects/id'));",
+      ),
+      [],
+    );
+  });
+
+  test('requires reusable query options for adapter-owned query hooks', () => {
+    const violations = auditClientSource(
+      'libs/client/projects/src/hooks/api/projects.ts',
+      "useQuery({queryKey: ['projects'], queryFn: () => listProjects({workspaceId: 'id'})});",
+    );
+
+    assert.deepEqual(violations, [
+      {
+        file: 'libs/client/projects/src/hooks/api/projects.ts',
+        occurrences: 1,
+        rule: 'inline-query-policy',
+      },
+    ]);
+  });
+
+  test('accepts a reusable query options policy and the documented step-log exception', () => {
+    assert.deepEqual(
+      auditClientSource(
+        'libs/client/projects/src/hooks/api/projects.ts',
+        "useQuery({...projectQueryOptions('id'), enabled: true});",
+      ),
+      [],
+    );
+    assert.deepEqual(
+      auditClientSource(
+        'libs/client/logs/src/hooks/api/step-logs.ts',
+        "useQuery({queryKey: ['step-logs'], queryFn: readLogs});",
+      ),
+      [],
+    );
+  });
+
+  test('keeps query hooks inside the adapter boundary', () => {
+    const violations = auditClientSource(
+      'libs/client/projects/src/pages/project-page.tsx',
+      "useQuery(projectQueryOptions('id'));",
+    );
+
+    assert.deepEqual(violations, [
+      {
+        file: 'libs/client/projects/src/pages/project-page.tsx',
+        occurrences: 1,
+        rule: 'query-policy-outside-adapter',
+      },
+    ]);
+  });
+
+  test('handles generic query hooks and regex literals while finding query policies', () => {
+    assert.deepEqual(
+      auditClientSource(
+        'libs/client/projects/src/hooks/api/projects.ts',
+        "useQuery<Project>({queryFn: () => /\\(/.test(value)});\nprojectQueryOptions('id');",
+      ),
+      [
+        {
+          file: 'libs/client/projects/src/hooks/api/projects.ts',
+          occurrences: 1,
+          rule: 'inline-query-policy',
+        },
+      ],
+    );
+    assert.deepEqual(
+      auditClientSource(
+        'libs/client/projects/src/pages/project-page.tsx',
+        'useQuery<Project>({queryFn: () => /\\(/.test(value)});',
+      ),
+      [
+        {
+          file: 'libs/client/projects/src/pages/project-page.tsx',
+          occurrences: 1,
+          rule: 'query-policy-outside-adapter',
+        },
+      ],
+    );
+  });
+
+  test('allows empty response contracts without a domain mapper', () => {
+    assert.deepEqual(
+      auditClientSource(
+        'libs/client/projects/src/hooks/api/delete-project.ts',
+        "return await checkedApiRequest(emptyResponseSchema, '/projects/id');",
+      ),
+      [],
+    );
+  });
+
+  test('summarizes checked requests and query policies for an adapter inventory', () => {
+    assert.deepEqual(
+      inventoryClientSource(
+        'libs/client/projects/src/hooks/api/projects.ts',
+        "checkedApiRequest(schema, '/projects');\nuseQuery(projectQueryOptions('id'));",
+      ),
+      {
+        isAdapter: true,
+        checkedApiRequestCalls: 1,
+        queryHooks: 1,
+        reusableQueryPolicies: 1,
+      },
+    );
   });
 
   test('reports raw route-search parsing outside an owned route module', () => {


### PR DESCRIPTION
## Summary

Make `checkedApiRequest` the only public business-response boundary for client feature runtime code. Agent, Integrations, and Workflows adapters now validate transport payloads, map them into package-owned domain models, and expose reusable query policies so React Query caches domain values.

The client architecture verifier now inventories production adapters and query hooks, rejects unchecked or unmapped response paths and inline query policies, and covers generic hooks, regex literals, concise returns, and parenthesized returns. The raw transport primitive remains private, and the package changes are covered by a Changeset.

## Validation

- Affected `check`, `type`, and `test`: 204/204 Turbo tasks
- Client architecture audit: zero violations
- Client architecture policy tests: 15/15
- Integrations tests: 139/139
- Packed `@shipfox/client-shell` external-consumer gate passed
- `git diff --check` passed

Closes ENG-1184

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `checkedApiRequest` the only public business-response boundary and updates adapters to validate DTOs, map to package-owned domain models, and expose reusable React Query options. The client-architecture audit now inventories adapters and enforces the checked-and-mapped contract with clear violations and a narrow documented exception (ENG-1184).

- **New Features**
  - `apiRequest` is no longer exported by `@shipfox/client-api`; adapters must use `checkedApiRequest`.
  - Agent: set-default endpoints return domain models `{defaultProviderId}` and `{defaultHarnessId}`.
  - Integrations: install flows return `InstallRedirect` (`installUrl`); providers, connections, and repositories export reusable `queryOptions`/`infiniteQueryOptions`.
  - Workflows: manual launches return `{workflowRunId}`; cancel/rerun/detail/attempts map to domain with `workflowRunsInfiniteQueryOptions`, `workflowRunQueryOptions`, and `workflowRunAttemptsQueryOptions`.
  - Repo audit inventories adapter files, checked calls, and query hooks; rejects unmapped checked responses, inline query policies, query hooks outside adapters, unchecked route search, and raw transport use; documents a single step-log policy exception.

- **Migration**
  - Use `checkedApiRequest` only inside adapter files and map to domain models; do not return checked responses directly (use `emptyResponseSchema` for void).
  - Replace inline `useQuery`/`useInfiniteQuery` configs with adapter-provided policies (e.g., `integrationConnectionsQueryOptions`, `repositoriesInfiniteQueryOptions`, `workflowRunsInfiniteQueryOptions`, `workflowRunQueryOptions`, `workflowRunAttemptsQueryOptions`, `webhookConnectionsQueryOptions`).
  - Update callers to new shapes:
    - `install_url` → `installUrl`
    - `default_provider_id` → `defaultProviderId`
    - `default_harness_id` → `defaultHarnessId`
    - `workflow_run_id` → `workflowRunId`
    - Repositories page returns `{repositories, nextCursor?}`

<sup>Written for commit c7afab4c14c22dc5de28d118b3122570dfb4c6c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

