### PR TITLE
[@shipfox/biome] Publish client-architecture rules externally

### DIFF
--- a/.changeset/publish-client-architecture-biome-rules.md
+++ b/.changeset/publish-client-architecture-biome-rules.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/biome": minor
+---
+
+Publish client-architecture Biome rules for external repositories.

--- a/tools/biome/README.md
+++ b/tools/biome/README.md
@@ -1,6 +1,6 @@
 # @shipfox/biome
 
-Biome commands and bundled binaries for Shipfox packages.
+Biome commands, bundled binaries, and client-architecture plugins for Shipfox packages.
 
 ## What it does
 
@@ -8,6 +8,7 @@ Biome commands and bundled binaries for Shipfox packages.
 - **`shipfox-biome-format`**: Formats files with the root `biome.json`.
 - **`shipfox-biome-check`**: Runs format, lint, and assist checks. Most package `check` scripts use it.
 - **Bundled binaries**: Includes Biome for macOS and Linux on ARM64 and x64.
+- **Client-architecture plugins**: Publishes five GritQL rules for external repositories. See the [plugin guide](plugins/client-architecture/README.md).
 
 ## Installation
 
@@ -61,6 +62,20 @@ shipfox-biome-format --write src/ test/
 Package checks use the root `biome.json`. Pass `--config-path` only for a
 focused config, such as a fixture tree. The normal form reads files. The write
 form can change them. Check the result before you send a change for review.
+
+## Client-architecture plugins
+
+The package publishes these semver-governed asset paths:
+
+- `plugins/client-architecture/no-api-dto-in-core.grit`
+- `plugins/client-architecture/no-client-framework-in-core.grit`
+- `plugins/client-architecture/no-query-cache-ownership.grit`
+- `plugins/client-architecture/no-raw-api-request.grit`
+- `plugins/client-architecture/no-response-dto-in-presentation.grit`
+
+Consumers reference the installed files from `biome.json`. Do not copy the
+GritQL source into the consumer repository. The [plugin guide](plugins/client-architecture/README.md)
+contains the external configuration example and the supported source globs.
 
 ## Development
 

--- a/tools/biome/package.json
+++ b/tools/biome/package.json
@@ -9,6 +9,25 @@
   "license": "MIT",
   "private": false,
   "type": "module",
+  "files": [
+    "README.md",
+    "bin",
+    "dist",
+    "plugins/client-architecture/README.md",
+    "plugins/client-architecture/no-api-dto-in-core.grit",
+    "plugins/client-architecture/no-client-framework-in-core.grit",
+    "plugins/client-architecture/no-query-cache-ownership.grit",
+    "plugins/client-architecture/no-raw-api-request.grit",
+    "plugins/client-architecture/no-response-dto-in-presentation.grit"
+  ],
+  "exports": {
+    "./package.json": "./package.json",
+    "./plugins/client-architecture/no-api-dto-in-core.grit": "./plugins/client-architecture/no-api-dto-in-core.grit",
+    "./plugins/client-architecture/no-client-framework-in-core.grit": "./plugins/client-architecture/no-client-framework-in-core.grit",
+    "./plugins/client-architecture/no-query-cache-ownership.grit": "./plugins/client-architecture/no-query-cache-ownership.grit",
+    "./plugins/client-architecture/no-raw-api-request.grit": "./plugins/client-architecture/no-raw-api-request.grit",
+    "./plugins/client-architecture/no-response-dto-in-presentation.grit": "./plugins/client-architecture/no-response-dto-in-presentation.grit"
+  },
   "imports": {
     "#*": "./src/*"
   },

--- a/tools/biome/plugins/client-architecture/README.md
+++ b/tools/biome/plugins/client-architecture/README.md
@@ -1,38 +1,81 @@
 # Client-architecture Biome plugins
 
-This directory holds Biome GritQL rules for client source. The root
-[`biome.json`](../../../../biome.json) loads each rule for production files in
-`libs/client/**` and `libs/shared/react/ui/**`.
+This directory contains the five published Biome GritQL rules for client
+source. Each rule emits a stable `client-architecture/<name>` diagnostic.
 
-Each rule should be small. It should show a clear error at the code that needs
-the change. Keep each example short so the expected result is easy to see.
+## Published rules
 
-## Rules
+- `no-api-dto-in-core` rejects API DTO imports from `src/core/**`.
+- `no-client-framework-in-core` rejects client framework imports from
+  `src/core/**`.
+- `no-response-dto-in-presentation` rejects response DTOs from pages and
+  components.
+- `no-raw-api-request` rejects raw API requests outside checked adapter paths.
+- `no-query-cache-ownership` rejects query-cache writes in leaf components.
 
-- Give each rule a kebab-case name, such as `no-raw-api-request.grit`. Its rule
-  id is `client-architecture/<name>`.
-- Add `allowed.ts` and `rejected.ts` under `fixtures/<name>/` for each rule.
-  Cover aliases, namespace imports, and type-only imports when they apply.
-- Keep fixtures out of normal package checks. The fixture config includes them
-  and skips tests, stories, and generated files.
-- Put the rule id and the approved replacement boundary in each diagnostic.
-  Do not fix a client-architecture error with `biome-ignore`.
-- Keep rules local and based on source shape. Put cross-file checks, ownership
-  data, runtime flow, and behavior tests in
-  `@shipfox/client-architecture-policy` or a focused test.
+The package exports each `.grit` file at the matching path under
+`plugins/client-architecture/`. These paths and diagnostic IDs are semver-
+governed public API. Removing or renaming one requires a compatible package
+release. The repository-local `fixture-boundary.grit` smoke rule is not part of
+the published external contract.
 
-The production rules currently cover:
+## External repositories
 
-- `no-api-dto-in-core` and `no-client-framework-in-core` for `src/core/**`.
-- `no-response-dto-in-presentation` for pages and components.
-- `no-raw-api-request` outside `@shipfox/client-api` and checked adapter paths.
-- `no-query-cache-ownership` for leaf components; named coordinators and
-  mutation/query adapters remain the ownership boundary.
+Install `@shipfox/biome` at the repository root so the configuration path stays
+stable across package managers and workspace layouts:
 
-`fixture-boundary.grit` is the smoke rule for this foundation. Its sentinel is
-not a migrated production rule. Later issues add real rules beside it.
+```sh
+pnpm add -D @shipfox/biome
+```
 
-## Fixture harness
+Reference the installed package files from the external repository's root
+`biome.json`:
+
+```json
+{
+  "plugins": [
+    {
+      "path": "./node_modules/@shipfox/biome/plugins/client-architecture/no-api-dto-in-core.grit",
+      "includes": ["**/libs/client/**/src/core/**"]
+    },
+    {
+      "path": "./node_modules/@shipfox/biome/plugins/client-architecture/no-client-framework-in-core.grit",
+      "includes": ["**/libs/client/**/src/core/**"]
+    },
+    {
+      "path": "./node_modules/@shipfox/biome/plugins/client-architecture/no-response-dto-in-presentation.grit",
+      "includes": [
+        "**/libs/client/**/src/pages/**",
+        "**/libs/client/**/src/components/**"
+      ]
+    },
+    {
+      "path": "./node_modules/@shipfox/biome/plugins/client-architecture/no-raw-api-request.grit",
+      "includes": [
+        "**/libs/client/**",
+        "**/libs/shared/react/ui/**",
+        "!**/libs/client/api/**",
+        "!**/libs/client/**/src/hooks/api/**"
+      ]
+    },
+    {
+      "path": "./node_modules/@shipfox/biome/plugins/client-architecture/no-query-cache-ownership.grit",
+      "includes": [
+        "**/libs/client/**/src/components/**",
+        "**/libs/shared/react/ui/**/src/components/**"
+      ]
+    }
+  ]
+}
+```
+
+Add the repository's standard exclusions for tests, stories, generated files,
+build output, and `node_modules` to each production include list. The globs
+above work from a different repository root and do not require copied `.grit`
+files. Keep cross-file ownership checks and runtime policy in
+`@shipfox/client-architecture-policy` or focused tests.
+
+## Local fixture harness
 
 Run the focused harness with:
 
@@ -41,5 +84,5 @@ pnpm --filter=@shipfox/biome test
 ```
 
 The harness uses the same `shipfox-biome-check` wrapper as package checks. It
-opts into `biome.fixture.json` for the fixture tree. It checks the rule id,
-replacement text, source location, and pass/fail result.
+checks rule IDs, replacement guidance, source locations, and pass/fail results
+for local and packed external fixtures.

--- a/tools/biome/plugins/client-architecture/fixtures/external-consumer/biome.json
+++ b/tools/biome/plugins/client-architecture/fixtures/external-consumer/biome.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+  "vcs": {
+    "enabled": false
+  },
+  "assist": {
+    "enabled": true
+  },
+  "formatter": {
+    "enabled": true,
+    "useEditorconfig": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineEnding": "lf",
+    "lineWidth": 100
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "bracketSpacing": false,
+      "trailingCommas": "all",
+      "semicolons": "always",
+      "arrowParentheses": "always"
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "files": {
+    "ignoreUnknown": false,
+    "includes": [
+      "**",
+      "!**/dist/**",
+      "!**/node_modules/**",
+      "!**/*.test.ts",
+      "!**/*.test.tsx",
+      "!**/*.stories.ts",
+      "!**/*.stories.tsx",
+      "!**/test/**",
+      "!**/tests/**",
+      "!**/__tests__/**",
+      "!**/generated/**",
+      "!**/__generated__/**",
+      "!**/*.gen.ts",
+      "!**/*.gen.tsx"
+    ]
+  },
+  "plugins": [
+    {
+      "path": "./node_modules/@shipfox/biome/plugins/client-architecture/no-api-dto-in-core.grit",
+      "includes": [
+        "**/libs/client/**/src/core/**",
+        "!**/dist/**",
+        "!**/node_modules/**",
+        "!**/*.test.ts",
+        "!**/*.test.tsx",
+        "!**/*.stories.ts",
+        "!**/*.stories.tsx",
+        "!**/test/**",
+        "!**/tests/**",
+        "!**/__tests__/**",
+        "!**/generated/**",
+        "!**/__generated__/**",
+        "!**/*.gen.ts",
+        "!**/*.gen.tsx"
+      ]
+    },
+    {
+      "path": "./node_modules/@shipfox/biome/plugins/client-architecture/no-client-framework-in-core.grit",
+      "includes": [
+        "**/libs/client/**/src/core/**",
+        "!**/dist/**",
+        "!**/node_modules/**",
+        "!**/*.test.ts",
+        "!**/*.test.tsx",
+        "!**/*.stories.ts",
+        "!**/*.stories.tsx",
+        "!**/test/**",
+        "!**/tests/**",
+        "!**/__tests__/**",
+        "!**/generated/**",
+        "!**/__generated__/**",
+        "!**/*.gen.ts",
+        "!**/*.gen.tsx"
+      ]
+    },
+    {
+      "path": "./node_modules/@shipfox/biome/plugins/client-architecture/no-response-dto-in-presentation.grit",
+      "includes": [
+        "**/libs/client/**/src/pages/**",
+        "**/libs/client/**/src/components/**",
+        "!**/dist/**",
+        "!**/node_modules/**",
+        "!**/*.test.ts",
+        "!**/*.test.tsx",
+        "!**/*.stories.ts",
+        "!**/*.stories.tsx",
+        "!**/test/**",
+        "!**/tests/**",
+        "!**/__tests__/**",
+        "!**/generated/**",
+        "!**/__generated__/**",
+        "!**/*.gen.ts",
+        "!**/*.gen.tsx"
+      ]
+    },
+    {
+      "path": "./node_modules/@shipfox/biome/plugins/client-architecture/no-raw-api-request.grit",
+      "includes": [
+        "**/libs/client/**",
+        "**/libs/shared/react/ui/**",
+        "!**/libs/client/api/**",
+        "!**/libs/client/**/src/hooks/api/**",
+        "!**/dist/**",
+        "!**/node_modules/**",
+        "!**/*.test.ts",
+        "!**/*.test.tsx",
+        "!**/*.stories.ts",
+        "!**/*.stories.tsx",
+        "!**/test/**",
+        "!**/tests/**",
+        "!**/__tests__/**",
+        "!**/generated/**",
+        "!**/__generated__/**",
+        "!**/*.gen.ts",
+        "!**/*.gen.tsx"
+      ]
+    },
+    {
+      "path": "./node_modules/@shipfox/biome/plugins/client-architecture/no-query-cache-ownership.grit",
+      "includes": [
+        "**/libs/client/**/src/components/**",
+        "**/libs/shared/react/ui/**/src/components/**",
+        "!**/dist/**",
+        "!**/node_modules/**",
+        "!**/*.test.ts",
+        "!**/*.test.tsx",
+        "!**/*.stories.ts",
+        "!**/*.stories.tsx",
+        "!**/test/**",
+        "!**/tests/**",
+        "!**/__tests__/**",
+        "!**/generated/**",
+        "!**/__generated__/**",
+        "!**/*.gen.ts",
+        "!**/*.gen.tsx"
+      ]
+    }
+  ]
+}

--- a/tools/biome/plugins/client-architecture/fixtures/external-consumer/libs/client/external/src/components/no-query-cache-ownership/allowed.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/external-consumer/libs/client/external/src/components/no-query-cache-ownership/allowed.ts
@@ -1,0 +1,3 @@
+import {useQuery} from '@tanstack/react-query';
+
+void useQuery;

--- a/tools/biome/plugins/client-architecture/fixtures/external-consumer/libs/client/external/src/components/no-query-cache-ownership/rejected.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/external-consumer/libs/client/external/src/components/no-query-cache-ownership/rejected.ts
@@ -1,0 +1,6 @@
+
+
+import {useQueryClient as useClient} from '@tanstack/react-query';
+
+const queryClient = useClient();
+queryClient.setQueryData(['projects'], []);

--- a/tools/biome/plugins/client-architecture/fixtures/external-consumer/libs/client/external/src/components/no-raw-api-request/allowed.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/external-consumer/libs/client/external/src/components/no-raw-api-request/allowed.ts
@@ -1,0 +1,3 @@
+import {checkedApiRequest} from '@shipfox/client-api';
+
+void checkedApiRequest;

--- a/tools/biome/plugins/client-architecture/fixtures/external-consumer/libs/client/external/src/components/no-raw-api-request/rejected.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/external-consumer/libs/client/external/src/components/no-raw-api-request/rejected.ts
@@ -1,0 +1,5 @@
+
+
+import {apiRequest as request} from '@shipfox/client-api';
+
+void request('/projects');

--- a/tools/biome/plugins/client-architecture/fixtures/external-consumer/libs/client/external/src/core/generated/rejected.gen.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/external-consumer/libs/client/external/src/core/generated/rejected.gen.ts
@@ -1,0 +1,5 @@
+
+
+import type {ProjectResponseDto as Project} from '@shipfox/api-projects-dto';
+
+export type {Project};

--- a/tools/biome/plugins/client-architecture/fixtures/external-consumer/libs/client/external/src/core/no-api-dto/allowed.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/external-consumer/libs/client/external/src/core/no-api-dto/allowed.ts
@@ -1,0 +1,3 @@
+export interface Project {
+  readonly id: string;
+}

--- a/tools/biome/plugins/client-architecture/fixtures/external-consumer/libs/client/external/src/core/no-api-dto/rejected.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/external-consumer/libs/client/external/src/core/no-api-dto/rejected.ts
@@ -1,0 +1,5 @@
+
+
+import type {ProjectResponseDto as Project} from '@shipfox/api-projects-dto';
+
+export type {Project};

--- a/tools/biome/plugins/client-architecture/fixtures/external-consumer/libs/client/external/src/core/no-client-framework/allowed.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/external-consumer/libs/client/external/src/core/no-client-framework/allowed.ts
@@ -1,0 +1,3 @@
+export interface Project {
+  readonly id: string;
+}

--- a/tools/biome/plugins/client-architecture/fixtures/external-consumer/libs/client/external/src/core/no-client-framework/rejected.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/external-consumer/libs/client/external/src/core/no-client-framework/rejected.ts
@@ -1,0 +1,5 @@
+
+
+import type {QueryClient as Client} from '@tanstack/react-query';
+
+export type {Client};

--- a/tools/biome/plugins/client-architecture/fixtures/external-consumer/libs/client/external/src/core/test/rejected.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/external-consumer/libs/client/external/src/core/test/rejected.ts
@@ -1,0 +1,5 @@
+
+
+import type {ProjectResponseDto as Project} from '@shipfox/api-projects-dto';
+
+export type {Project};

--- a/tools/biome/plugins/client-architecture/fixtures/external-consumer/libs/client/external/src/hooks/api/no-raw-api-request/allowed.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/external-consumer/libs/client/external/src/hooks/api/no-raw-api-request/allowed.ts
@@ -1,0 +1,3 @@
+import {apiRequest as request} from '@shipfox/client-api';
+
+void request('/projects');

--- a/tools/biome/plugins/client-architecture/fixtures/external-consumer/libs/client/external/src/pages/ignored.stories.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/external-consumer/libs/client/external/src/pages/ignored.stories.ts
@@ -1,0 +1,5 @@
+
+
+import type {ProjectResponseDto as Project} from '@shipfox/api-projects-dto';
+
+export type {Project};

--- a/tools/biome/plugins/client-architecture/fixtures/external-consumer/libs/client/external/src/pages/no-response-dto/allowed.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/external-consumer/libs/client/external/src/pages/no-response-dto/allowed.ts
@@ -1,0 +1,8 @@
+import type {
+  CreateProjectBodyDto,
+  ListProjectsQueryDto as ProjectsQuery,
+} from '@shipfox/api-projects-dto';
+import {createProjectBodySchema} from '@shipfox/api-projects-dto';
+
+export const projectNameSchema = createProjectBodySchema.shape.name;
+export type {CreateProjectBodyDto, ProjectsQuery};

--- a/tools/biome/plugins/client-architecture/fixtures/external-consumer/libs/client/external/src/pages/no-response-dto/rejected.ts
+++ b/tools/biome/plugins/client-architecture/fixtures/external-consumer/libs/client/external/src/pages/no-response-dto/rejected.ts
@@ -1,0 +1,10 @@
+
+
+import type {ProjectResponseDto as Project} from '@shipfox/api-projects-dto';
+import {type WorkspaceResponseDto as Workspace} from '@shipfox/api-workspaces-dto';
+
+export type {Project, Workspace};
+
+type DynamicProject = import('@shipfox/api-projects-dto').ProjectDto;
+
+export type {DynamicProject};

--- a/tools/biome/test/client-architecture-external.test.ts
+++ b/tools/biome/test/client-architecture-external.test.ts
@@ -1,0 +1,170 @@
+import assert from 'node:assert/strict';
+import {execFile} from 'node:child_process';
+import {cp, mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {dirname, join, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {promisify} from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const tarEntryLinePattern = /\r?\n/u;
+const testDirectory = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(testDirectory, '..');
+const fixtureTemplate = resolve(
+  packageRoot,
+  'plugins/client-architecture/fixtures/external-consumer',
+);
+const biomeBinary = resolve(packageRoot, 'node_modules/.bin/biome');
+const publishedPluginFiles = [
+  'plugins/client-architecture/no-api-dto-in-core.grit',
+  'plugins/client-architecture/no-client-framework-in-core.grit',
+  'plugins/client-architecture/no-query-cache-ownership.grit',
+  'plugins/client-architecture/no-raw-api-request.grit',
+  'plugins/client-architecture/no-response-dto-in-presentation.grit',
+] as const;
+const externalRuleFixtures = [
+  {
+    name: 'no-api-dto-in-core',
+    allowed: 'libs/client/external/src/core/no-api-dto/allowed.ts',
+    rejected: 'libs/client/external/src/core/no-api-dto/rejected.ts',
+  },
+  {
+    name: 'no-client-framework-in-core',
+    allowed: 'libs/client/external/src/core/no-client-framework/allowed.ts',
+    rejected: 'libs/client/external/src/core/no-client-framework/rejected.ts',
+  },
+  {
+    name: 'no-response-dto-in-presentation',
+    allowed: 'libs/client/external/src/pages/no-response-dto/allowed.ts',
+    rejected: 'libs/client/external/src/pages/no-response-dto/rejected.ts',
+  },
+  {
+    name: 'no-raw-api-request',
+    allowed: 'libs/client/external/src/components/no-raw-api-request/allowed.ts',
+    rejected: 'libs/client/external/src/components/no-raw-api-request/rejected.ts',
+  },
+  {
+    name: 'no-query-cache-ownership',
+    allowed: 'libs/client/external/src/components/no-query-cache-ownership/allowed.ts',
+    rejected: 'libs/client/external/src/components/no-query-cache-ownership/rejected.ts',
+  },
+] as const;
+const excludedFixtureFiles = [
+  'libs/client/external/src/core/test/rejected.ts',
+  'libs/client/external/src/pages/ignored.stories.ts',
+  'libs/client/external/src/core/generated/rejected.gen.ts',
+  'libs/client/external/src/core/dist/rejected.ts',
+  'node_modules/fixture/libs/client/external/src/core/rejected.ts',
+] as const;
+
+type CommandFailure = {
+  code?: number | string;
+  stderr?: string;
+  stdout?: string;
+};
+
+async function packBiome(destination: string): Promise<string> {
+  const {stdout} = await execFileAsync(
+    'npm',
+    ['pack', '--json', '--pack-destination', destination],
+    {cwd: packageRoot},
+  );
+  const metadata = JSON.parse(stdout) as Array<{filename?: string}>;
+  const filename = metadata[0]?.filename;
+  assert.ok(filename, 'npm pack did not return a tarball filename');
+  return join(destination, filename);
+}
+
+async function tarEntries(tarball: string): Promise<string[]> {
+  const {stdout} = await execFileAsync('tar', ['-tzf', tarball]);
+  return stdout.split(tarEntryLinePattern).filter(Boolean);
+}
+
+async function installPackedBiome(externalRoot: string, tarball: string): Promise<void> {
+  const packageDirectory = join(externalRoot, 'node_modules/@shipfox/biome');
+  await mkdir(packageDirectory, {recursive: true});
+  await execFileAsync('tar', ['-xzf', tarball, '-C', packageDirectory, '--strip-components', '1']);
+}
+
+async function runBiome(
+  externalRoot: string,
+  target: string,
+): Promise<{code: number; output: string}> {
+  try {
+    const {stdout, stderr} = await execFileAsync(
+      biomeBinary,
+      ['check', '--config-path', 'biome.json', target],
+      {cwd: externalRoot},
+    );
+    return {code: 0, output: `${stdout}${stderr}`};
+  } catch (error) {
+    const failure = error as CommandFailure;
+    return {
+      code: typeof failure.code === 'number' ? failure.code : 1,
+      output: `${failure.stdout ?? ''}${failure.stderr ?? ''}`,
+    };
+  }
+}
+
+function escapedRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+}
+
+describe('packed client-architecture Biome plugins', () => {
+  test('includes every supported plugin and its usage documentation', async () => {
+    const temporaryRoot = await mkdtemp(join(tmpdir(), 'shipfox-biome-pack-'));
+    try {
+      const tarball = await packBiome(temporaryRoot);
+      const entries = await tarEntries(tarball);
+      for (const path of publishedPluginFiles) {
+        assert.ok(entries.includes(`package/${path}`), `Packed artifact is missing ${path}`);
+      }
+      assert.ok(entries.includes('package/plugins/client-architecture/README.md'));
+      assert.ok(
+        !entries.some((entry) => entry.startsWith('package/plugins/client-architecture/fixtures/')),
+        'Packed artifact must not publish repository fixtures',
+      );
+    } finally {
+      await rm(temporaryRoot, {force: true, recursive: true});
+    }
+  });
+
+  test('runs from an installed package in an external repository root', async () => {
+    const temporaryRoot = await mkdtemp(join(tmpdir(), 'shipfox-biome-external-'));
+    try {
+      const tarball = await packBiome(temporaryRoot);
+      const externalRoot = join(temporaryRoot, 'consumer');
+      await cp(fixtureTemplate, externalRoot, {recursive: true});
+      await installPackedBiome(externalRoot, tarball);
+
+      const nodeModulesFixture = join(externalRoot, excludedFixtureFiles[4]);
+      await mkdir(dirname(nodeModulesFixture), {recursive: true});
+      await writeFile(
+        nodeModulesFixture,
+        "\n\nimport type {ProjectResponseDto as Project} from '@shipfox/api-projects-dto';\n\nexport type {Project};\n",
+      );
+
+      for (const fixture of externalRuleFixtures) {
+        const allowed = await runBiome(externalRoot, fixture.allowed);
+        assert.equal(allowed.code, 0, `${fixture.name} allowed fixture failed:\n${allowed.output}`);
+
+        const rejected = await runBiome(externalRoot, fixture.rejected);
+        assert.notEqual(rejected.code, 0, `${fixture.name} rejected fixture passed`);
+        assert.match(rejected.output, new RegExp(`client-architecture/${fixture.name}`, 'u'));
+        assert.match(rejected.output, new RegExp(`${escapedRegExp(fixture.rejected)}:3`, 'u'));
+      }
+
+      const fullFixture = await runBiome(externalRoot, '.');
+      assert.notEqual(fullFixture.code, 0, 'The external rejected fixtures unexpectedly passed');
+      for (const excludedPath of excludedFixtureFiles) {
+        assert.doesNotMatch(
+          fullFixture.output,
+          new RegExp(escapedRegExp(excludedPath), 'u'),
+          `Excluded fixture produced a diagnostic: ${excludedPath}`,
+        );
+      }
+    } finally {
+      await rm(temporaryRoot, {force: true, recursive: true});
+    }
+  });
+});


### PR DESCRIPTION
Publish the existing client-architecture GritQL rules as stable assets in `@shipfox/biome` so external repositories can consume them through package-relative paths.

The package documentation and manifest now define the five supported rules as a public contract, while a packed external-consumer fixture verifies the Cloud-like `libs/client/**` configuration, diagnostics, and source exclusions. The private fixture-boundary rule remains internal. Includes the required minor changeset.

Closes ENG-1205

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish the client-architecture GritQL rules as stable assets in `@shipfox/biome` so external repos can load them via package-relative paths. Establishes a small public API with docs and tests that validate packaging and usage (ENG-1205).

- **New Features**
  - Export five rules with stable diagnostic IDs under `plugins/client-architecture/*` and publish them via `files`/`exports` in `package.json` (fixture-only boundary rule stays internal).
  - Add usage docs with example `biome.json` config and supported `libs/client/**` and `libs/shared/react/ui/**` globs.
  - Add a packed external-consumer fixture and tests that verify published files, diagnostics, and standard source exclusions.

- **Migration**
  - Install `@shipfox/biome` at the repo root.
  - Reference plugins from `./node_modules/@shipfox/biome/plugins/client-architecture/...` in the root `biome.json`.
  - Include `**/libs/client/**` and `**/libs/shared/react/ui/**` and exclude tests, stories, generated files, build output, and `node_modules`.
  - Do not copy `.grit` files into consumer repos.

<sup>Written for commit a456cbc18aacca35fff4f6cc6e884f0af1473c16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

