### PR TITLE
[@shipfox/engineering-guidance] Publish deterministic engineering guidance bundle

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ listed there or when you need to place, update, or review documentation.
 | Introduces a shared package or changes a server dependency boundary. | [ADR 0004](adr/0004-shared-semantic-packages-and-server-dependency-boundaries.md) | Shared semantic package rules and server package classes. |
 | Changes repository documentation structure or adds a shared documentation surface. | [ADR 0005](adr/0005-repository-documentation-architecture.md) | Documentation ownership, routing, and progressive disclosure. |
 | Validates repository Markdown links, anchors, or documentation reachability. | [Repository documentation policy](../tools/repository-documentation-policy/README.md) | Deterministic link and orphan checks for engineering documentation. |
+| Builds or consumes the published engineering guidance bundle. | [Engineering guidance package](../tools/engineering-guidance/README.md) | The public manifest, locator contract, and deterministic bundle workflow. |
 | Changes webhook retry behavior. | [Webhook retry safety](architecture/webhook-retry-safety.md) | The current safety model for webhook retries. |
 | Adds or changes unit tests or Storybook stories. | [Testing guide](guides/testing.md) | Unit-test levels and Storybook rules. |
 | Adds or changes a visual test. | [Visual regression guidance](guides/testing.md#visual-regression) | Argos builds, screenshots, and review. |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7743,6 +7743,27 @@ importers:
         specifier: 'catalog:'
         version: 24.13.2
 
+  tools/engineering-guidance:
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../vitest
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.2
+
   tools/package-release:
     dependencies:
       '@shipfox/tool-utils':

--- a/tools/engineering-guidance/LICENSE
+++ b/tools/engineering-guidance/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Shipfox
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tools/engineering-guidance/README.md
+++ b/tools/engineering-guidance/README.md
@@ -1,0 +1,70 @@
+# @shipfox/engineering-guidance
+
+This package gives Shipfox tools one fixed copy of the engineering docs. It is
+for build tools and checks that need to read those docs.
+
+## Quick start
+
+Install it as a development dependency:
+
+```sh
+pnpm add -D @shipfox/engineering-guidance
+```
+
+Then read the bundle:
+
+```ts
+import {
+  getGuidanceBundleRoot,
+  readGuidanceManifest,
+} from '@shipfox/engineering-guidance';
+
+const root = getGuidanceBundleRoot();
+const manifest = readGuidanceManifest();
+
+console.log(root);
+console.log(manifest.source.commit);
+```
+
+`root` is the read-only bundle directory. The main entrypoint is
+`repository/docs/README.md`.
+
+## What is in the bundle
+
+The bundle starts with the upstream docs map. It includes approved root files
+and Markdown files that those roots reach. Each link to tracked source uses the
+source commit in a GitHub link. Each file has a SHA-256 hash in the manifest.
+
+Product docs and Cloud content are not copied. Change the source docs in the
+upstream repository. Do not edit a copied bundle.
+
+See the [manifest schema](schema/manifest.schema.json) for the metadata shape.
+
+## Limits
+
+This package is for development tools. It has no application runtime role. It
+does not run a post-install sync and does not write to the consumer repository.
+The consumer chooses when and where to copy the bundle.
+
+The published package contains the built bundle, its manifest, and a small
+locator API. It does not export TypeScript source.
+
+## Development
+
+Run the focused package checks:
+
+```sh
+turbo build --filter=@shipfox/engineering-guidance
+turbo type --filter=@shipfox/engineering-guidance
+turbo test --filter=@shipfox/engineering-guidance
+turbo verify --filter=@shipfox/engineering-guidance
+```
+
+`build` creates the bundle. `verify` checks file hashes and links.
+
+Read the [engineering documentation map](../../docs/README.md) and [ADR 0005](../../docs/adr/0005-repository-documentation-architecture.md)
+before changing the source or ownership rules.
+
+## License
+
+MIT

--- a/tools/engineering-guidance/package.json
+++ b/tools/engineering-guidance/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@shipfox/engineering-guidance",
+  "version": "1.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
+    "directory": "tools/engineering-guidance"
+  },
+  "license": "MIT",
+  "private": false,
+  "type": "module",
+  "files": [
+    "dist/index.js",
+    "dist/index.d.ts",
+    "dist/manifest.js",
+    "dist/manifest.d.ts",
+    "dist/bundle",
+    "schema"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "shipfox-swc && node dist/generate.js --build && shipfox-tsc-emit",
+    "prepack": "node dist/generate.js --ensure",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "test": "shipfox-vitest-run",
+    "test:watch": "shipfox-vitest-watch",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit",
+    "verify": "node dist/generate.js --verify"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*",
+    "@types/node": "catalog:"
+  }
+}

--- a/tools/engineering-guidance/schema/manifest.schema.json
+++ b/tools/engineering-guidance/schema/manifest.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/ShipfoxHQ/shipfox/blob/main/tools/engineering-guidance/schema/manifest.schema.json",
+  "title": "Shipfox engineering guidance manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "package", "source", "entrypoints", "files"],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "package": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version"],
+      "properties": {
+        "name": { "const": "@shipfox/engineering-guidance" },
+        "version": { "type": "string", "minLength": 1 }
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "commit"],
+      "properties": {
+        "repository": { "const": "ShipfoxHQ/shipfox" },
+        "commit": { "type": "string", "pattern": "^[a-f0-9]{40}$" }
+      }
+    },
+    "entrypoints": {
+      "type": "object",
+      "required": ["documentationMap"],
+      "patternProperties": {
+        "^[a-z][A-Za-z0-9]*$": {
+          "type": "string",
+          "pattern": "^repository/(?!.*(?:^|/)\\.\\.?/).+\\.md$"
+        }
+      },
+      "additionalProperties": false
+    },
+    "files": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path", "sha256", "kind"],
+        "properties": {
+          "path": {
+            "type": "string",
+            "pattern": "^repository/(?!.*(?:^|/)\\.\\.?/).+\\.md$"
+          },
+          "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+          "kind": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  }
+}

--- a/tools/engineering-guidance/src/generate.ts
+++ b/tools/engineering-guidance/src/generate.ts
@@ -1,0 +1,55 @@
+import {execFile} from 'node:child_process';
+import {readFile} from 'node:fs/promises';
+import {dirname, join, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {promisify} from 'node:util';
+
+import {generateFromRepository, validateGeneratedBundle} from './generator.js';
+
+const execFileAsync = promisify(execFile);
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const bundleRoot = join(packageRoot, 'dist', 'bundle');
+
+async function main(): Promise<void> {
+  const mode = process.argv[2] ?? '--build';
+  const packageManifest = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf8')) as {
+    version?: unknown;
+  };
+  if (typeof packageManifest.version !== 'string') {
+    throw new Error('Engineering guidance package.json has no version');
+  }
+
+  if (mode === '--build') {
+    await generateFromRepository(packageRoot, bundleRoot, packageManifest.version);
+    return;
+  }
+  if (mode === '--ensure') {
+    if (await hasGitRepository(packageRoot)) {
+      await generateFromRepository(packageRoot, bundleRoot, packageManifest.version);
+    } else {
+      await validateGeneratedBundle(bundleRoot);
+    }
+    return;
+  }
+  if (mode === '--verify') {
+    await validateGeneratedBundle(bundleRoot);
+    return;
+  }
+  throw new Error(`Unknown engineering guidance generator mode: ${mode}`);
+}
+
+async function hasGitRepository(directory: string): Promise<boolean> {
+  try {
+    await execFileAsync('git', ['-C', directory, 'rev-parse', '--show-toplevel']);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(
+    `Engineering guidance generation failed: ${error instanceof Error ? error.message : String(error)}\n`,
+  );
+  process.exitCode = 1;
+});

--- a/tools/engineering-guidance/src/generator.ts
+++ b/tools/engineering-guidance/src/generator.ts
@@ -1,0 +1,852 @@
+import {execFile} from 'node:child_process';
+import {createHash} from 'node:crypto';
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  realpath,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises';
+import {dirname, extname, isAbsolute, join, posix, relative, resolve} from 'node:path';
+import {promisify} from 'node:util';
+
+import {
+  assertGuidanceManifest,
+  type GuidanceManifest,
+  type GuidanceManifestFile,
+  guidanceManifestSchemaVersion,
+  guidancePackageName,
+  guidanceRepository,
+} from './manifest.js';
+
+const execFileAsync = promisify(execFile);
+const markdownExtension = '.md';
+const rootEntrypoints = ['AGENTS.md', 'CONTRIBUTING.md', 'WRITING.md', 'DESIGN.md'] as const;
+const excludedDirectoryNames = new Set([
+  '.cache',
+  '.changeset',
+  '.context',
+  '.git',
+  '.next',
+  '.turbo',
+  'build',
+  'coverage',
+  'dist',
+  'node_modules',
+  'out',
+  'test-results',
+]);
+const excludedPathPrefixes = [
+  'apps/docs/content/',
+  'apps/docs/WRITING.md',
+  'libs/client/shell/test/external/',
+] as const;
+const excludedPathSegments = new Set(['.cache', '.changeset', '.context', '.git', '.turbo']);
+const excludedFixtureSegments = new Set(['fixture', 'fixtures', 'test', 'tests', '__tests__']);
+const externalLinkPattern = /^(?:[a-z][a-z\d+.-]*:|\/\/)/iu;
+const atxHeadingPattern = /^ {0,3}#{1,6}\s+(.+?)\s*#*\s*$/u;
+const setextHeadingPattern = /^ {0,3}(?:=+|-+)\s*$/u;
+const fencePattern = /^\s{0,3}(`{3,}|~{3,})/u;
+const referenceLinkPattern = /^ {0,3}\[[^\]\n]+\]:[ \t]*(<[^>\n]+>|[^\s]+)[^\n]*$/u;
+const sourceCommitPattern = /^[a-f0-9]{40}$/u;
+const nonWhitespacePattern = /^\S+/u;
+const trailingSlashPattern = /\/$/u;
+const whitespacePattern = /\s/u;
+
+export interface GenerateGuidanceBundleOptions {
+  sourceRoot: string;
+  outputRoot: string;
+  packageVersion: string;
+  sourceCommit: string;
+  availableFiles?: Iterable<string>;
+}
+
+export interface GeneratedGuidanceBundle {
+  manifest: GuidanceManifest;
+  files: string[];
+  outputRoot: string;
+}
+
+export interface MarkdownLink {
+  line: number;
+  target: string;
+}
+
+interface ParsedMarkdownLink extends MarkdownLink {
+  destinationEnd: number;
+  destinationStart: number;
+  usesAngleBrackets: boolean;
+}
+
+interface ParsedTarget {
+  anchor: string | null;
+  fragment: string;
+  path: string;
+  query: string;
+}
+
+interface LocalTarget {
+  absolutePath: string;
+  isDirectory: boolean;
+  relativePath: string;
+}
+
+export async function generateGuidanceBundle(
+  options: GenerateGuidanceBundleOptions,
+): Promise<GeneratedGuidanceBundle> {
+  const sourceRoot = resolve(options.sourceRoot);
+  const outputRoot = resolve(options.outputRoot);
+  assertGenerationInputs(sourceRoot, outputRoot, options.packageVersion, options.sourceCommit);
+
+  const availableFiles = await normalizeAvailableFiles(sourceRoot, options.availableFiles);
+  const sourceFiles = await selectSourceFiles(sourceRoot, availableFiles);
+  const sourceContents = new Map<string, string>();
+  for (const sourceFile of sourceFiles) {
+    sourceContents.set(sourceFile, await readSourceText(sourceRoot, sourceFile));
+  }
+
+  const bundledFiles = new Map<string, string>();
+  for (const sourceFile of sourceFiles) {
+    const content = sourceContents.get(sourceFile) ?? '';
+    const rewritten = await rewriteMarkdown(
+      sourceRoot,
+      sourceFile,
+      content,
+      sourceFiles,
+      availableFiles,
+      sourceContents,
+      options.sourceCommit,
+    );
+    const outputPath = `repository/${sourceFile}`;
+    if (bundledFiles.has(outputPath)) {
+      throw new Error(`Duplicate guidance bundle output path: ${outputPath}`);
+    }
+    bundledFiles.set(outputPath, rewritten);
+  }
+
+  const manifestFiles = [...bundledFiles.entries()]
+    .sort(([left], [right]) => comparePaths(left, right))
+    .map(
+      ([filePath, content]) =>
+        ({
+          path: filePath,
+          sha256: sha256(content),
+          kind: fileKind(filePath.slice('repository/'.length)),
+        }) satisfies GuidanceManifestFile,
+    );
+  const manifest: GuidanceManifest = {
+    schemaVersion: guidanceManifestSchemaVersion,
+    package: {name: guidancePackageName, version: options.packageVersion},
+    source: {repository: guidanceRepository, commit: options.sourceCommit},
+    entrypoints: entrypointsFor(sourceFiles),
+    files: manifestFiles,
+  };
+  assertGuidanceManifest(manifest);
+
+  await writeGeneratedBundle(outputRoot, bundledFiles, manifest);
+  return {manifest, files: sourceFiles, outputRoot};
+}
+
+export async function validateGeneratedBundle(bundleRoot: string): Promise<GuidanceManifest> {
+  const root = resolve(bundleRoot);
+  const manifestPath = join(root, 'MANIFEST.json');
+  const value: unknown = JSON.parse(await readFile(manifestPath, 'utf8'));
+  assertGuidanceManifest(value);
+  const manifest = value;
+
+  const expectedFiles = new Set(['MANIFEST.json', ...manifest.files.map((file) => file.path)]);
+  const actualFiles = new Set(await filesUnder(root));
+  for (const expectedFile of expectedFiles) {
+    if (!actualFiles.has(expectedFile))
+      throw new Error(`Guidance bundle is missing ${expectedFile}`);
+  }
+  for (const actualFile of actualFiles) {
+    if (!expectedFiles.has(actualFile))
+      throw new Error(`Guidance bundle contains undeclared ${actualFile}`);
+  }
+
+  for (const file of manifest.files) {
+    const content = await readFile(join(root, file.path), 'utf8');
+    if (sha256(content) !== file.sha256) {
+      throw new Error(`Guidance bundle hash mismatch for ${file.path}`);
+    }
+    if (file.path.endsWith(markdownExtension)) {
+      await validatePackagedMarkdown(root, file.path, content);
+    }
+  }
+  return manifest;
+}
+
+export function extractMarkdownLinks(content: string): MarkdownLink[] {
+  return extractParsedMarkdownLinks(content).map(({line, target}) => ({line, target}));
+}
+
+export function anchorsFor(content: string): Set<string> {
+  const anchors = new Set<string>();
+  const usedSlugs = new Map<string, number>();
+  const lines = withoutFencedCode(normalizeLineEndings(content)).split('\n');
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? '';
+    const atxHeading = line.match(atxHeadingPattern);
+    const setextHeading = !atxHeading && lines[index + 1]?.match(setextHeadingPattern);
+    const heading = atxHeading?.[1] ?? (setextHeading ? line.trim() : null);
+    if (!heading) continue;
+
+    const baseSlug = slugifyHeading(heading);
+    if (!baseSlug) continue;
+    const duplicateCount = usedSlugs.get(baseSlug) ?? 0;
+    usedSlugs.set(baseSlug, duplicateCount + 1);
+    anchors.add(duplicateCount === 0 ? baseSlug : `${baseSlug}-${duplicateCount}`);
+  }
+  return anchors;
+}
+
+export function isIncludedGuidancePath(relativePath: string): boolean {
+  const normalized = normalizeRelativePath(relativePath);
+  if (!normalized.endsWith(markdownExtension)) return false;
+  if (
+    excludedPathPrefixes.some((prefix) => normalized === prefix || normalized.startsWith(prefix))
+  ) {
+    return false;
+  }
+  if (normalized.split('/').some((segment) => excludedFixtureSegments.has(segment))) return false;
+  if (normalized.split('/').some((segment) => excludedPathSegments.has(segment))) return false;
+  if (posix.basename(normalized) === 'CHANGELOG.md') return false;
+  return true;
+}
+
+async function selectSourceFiles(
+  sourceRoot: string,
+  availableFiles: Set<string>,
+): Promise<string[]> {
+  const markdownFiles = [...availableFiles].filter((file) => isIncludedGuidancePath(file));
+  const selected = new Set(markdownFiles.filter((file) => file.startsWith('docs/')));
+  for (const entrypoint of rootEntrypoints) {
+    if (availableFiles.has(entrypoint)) selected.add(entrypoint);
+  }
+  if (!selected.has('docs/README.md')) {
+    throw new Error('Guidance source is missing the required docs/README.md entrypoint');
+  }
+
+  const pending = [...selected];
+  while (pending.length > 0) {
+    const sourceFile = pending.pop();
+    if (!sourceFile) continue;
+    const content = await readSourceText(sourceRoot, sourceFile);
+    for (const link of extractParsedMarkdownLinks(content)) {
+      if (isExternalTarget(link.target)) continue;
+      const target = await resolveLocalTarget(sourceRoot, sourceFile, link.target);
+      if (!target || target.isDirectory) continue;
+      if (!availableFiles.has(target.relativePath)) {
+        if (isExcludedGuidancePath(target.relativePath)) continue;
+        throw new Error(
+          `${sourceFile}:${link.line} links to an untracked or unavailable file: ${link.target}`,
+        );
+      }
+      if (isReachableGuidancePath(target.relativePath) && !selected.has(target.relativePath)) {
+        selected.add(target.relativePath);
+        pending.push(target.relativePath);
+      }
+    }
+  }
+
+  return [...selected].sort(comparePaths);
+}
+
+async function rewriteMarkdown(
+  sourceRoot: string,
+  sourceFile: string,
+  content: string,
+  bundledFiles: string[],
+  availableFiles: Set<string>,
+  sourceContents: Map<string, string>,
+  sourceCommit: string,
+): Promise<string> {
+  const replacements: Array<{end: number; start: number; value: string}> = [];
+  const bundledSet = new Set(bundledFiles);
+  for (const link of extractParsedMarkdownLinks(content)) {
+    if (isExternalTarget(link.target)) continue;
+
+    const parsedTarget = parseTarget(link.target);
+    const target = await resolveLocalTarget(sourceRoot, sourceFile, link.target);
+    if (!target)
+      throw new Error(`${sourceFile}:${link.line} has an invalid local link: ${link.target}`);
+    if (
+      !availableFiles.has(target.relativePath) &&
+      !hasAvailableDescendant(target, availableFiles)
+    ) {
+      if (!isExcludedGuidancePath(target.relativePath)) {
+        throw new Error(`${sourceFile}:${link.line} links to an unavailable file: ${link.target}`);
+      }
+    }
+
+    if (parsedTarget.anchor) {
+      const targetContents = await readTargetText(sourceRoot, target, sourceContents);
+      if (targetContents && isMarkdownPath(target.relativePath)) {
+        const anchors = anchorsFor(targetContents);
+        if (!anchors.has(parsedTarget.anchor)) {
+          throw new Error(
+            `${sourceFile}:${link.line} links to missing anchor ${link.target} in ${target.relativePath}`,
+          );
+        }
+      }
+    }
+
+    let replacement: string | undefined;
+    if (bundledSet.has(target.relativePath)) {
+      const sourceOutputPath = `repository/${sourceFile}`;
+      const targetOutputPath = `repository/${target.relativePath}`;
+      const relativeTarget = posix.relative(posix.dirname(sourceOutputPath), targetOutputPath);
+      replacement = `${relativeTarget || posix.basename(targetOutputPath)}${parsedTarget.query}${parsedTarget.fragment}`;
+    } else if (
+      availableFiles.has(target.relativePath) ||
+      hasAvailableDescendant(target, availableFiles)
+    ) {
+      replacement = `${githubPermalink(target, sourceCommit)}${parsedTarget.query}${parsedTarget.fragment}`;
+    } else {
+      throw new Error(
+        `${sourceFile}:${link.line} links to a disallowed local file: ${link.target}`,
+      );
+    }
+
+    const replacementText =
+      link.usesAngleBrackets || whitespacePattern.test(replacement)
+        ? `<${replacement}>`
+        : replacement;
+    if (replacementText !== content.slice(link.destinationStart, link.destinationEnd)) {
+      replacements.push({
+        start: link.destinationStart,
+        end: link.destinationEnd,
+        value: replacementText,
+      });
+    }
+  }
+
+  let rewritten = content;
+  for (const replacement of replacements.sort((left, right) => right.start - left.start)) {
+    rewritten =
+      rewritten.slice(0, replacement.start) + replacement.value + rewritten.slice(replacement.end);
+  }
+  return normalizeLineEndings(rewritten);
+}
+
+async function validatePackagedMarkdown(
+  bundleRoot: string,
+  relativeFile: string,
+  content: string,
+): Promise<void> {
+  const repositoryRoot = join(bundleRoot, 'repository');
+  for (const link of extractParsedMarkdownLinks(content)) {
+    if (isExternalTarget(link.target)) continue;
+    const target = parseTarget(link.target);
+    if (target.path.startsWith('/')) {
+      throw new Error(
+        `${relativeFile}:${link.line} contains an absolute local link: ${link.target}`,
+      );
+    }
+    const sourceAbsolute = join(repositoryRoot, relativeFile.slice('repository/'.length));
+    const targetAbsolute = target.path
+      ? resolve(dirname(sourceAbsolute), target.path)
+      : sourceAbsolute;
+    if (!isWithin(repositoryRoot, targetAbsolute)) {
+      throw new Error(`${relativeFile}:${link.line} escapes the guidance bundle: ${link.target}`);
+    }
+    const resolved = await resolveBundleTarget(targetAbsolute);
+    if (!resolved)
+      throw new Error(`${relativeFile}:${link.line} has a broken link: ${link.target}`);
+    if (target.anchor) {
+      if (!(await isFile(resolved)) || !isMarkdownPath(resolved)) continue;
+      const targetContent = await readFile(resolved, 'utf8');
+      if (!anchorsFor(targetContent).has(target.anchor)) {
+        throw new Error(`${relativeFile}:${link.line} has a missing anchor: ${link.target}`);
+      }
+    }
+  }
+}
+
+async function writeGeneratedBundle(
+  outputRoot: string,
+  bundledFiles: Map<string, string>,
+  manifest: GuidanceManifest,
+): Promise<void> {
+  await mkdir(dirname(outputRoot), {recursive: true});
+  const temporaryRoot = await mkdtemp(join(dirname(outputRoot), '.engineering-guidance-'));
+  try {
+    for (const [filePath, content] of bundledFiles) {
+      const outputPath = join(temporaryRoot, filePath);
+      await mkdir(dirname(outputPath), {recursive: true});
+      await writeFile(outputPath, content, 'utf8');
+    }
+    await writeFile(join(temporaryRoot, 'MANIFEST.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+    await rm(outputRoot, {force: true, recursive: true});
+    await rename(temporaryRoot, outputRoot);
+  } catch (error) {
+    await rm(temporaryRoot, {force: true, recursive: true});
+    throw error;
+  }
+}
+
+function entrypointsFor(sourceFiles: string[]): Record<string, string> {
+  const sourceSet = new Set(sourceFiles);
+  const entrypoints: Record<string, string> = {
+    documentationMap: 'repository/docs/README.md',
+  };
+  const names: Array<[string, (typeof rootEntrypoints)[number]]> = [
+    ['agents', 'AGENTS.md'],
+    ['contributing', 'CONTRIBUTING.md'],
+    ['writing', 'WRITING.md'],
+    ['design', 'DESIGN.md'],
+  ];
+  for (const [name, sourceFile] of names) {
+    if (sourceSet.has(sourceFile)) entrypoints[name] = `repository/${sourceFile}`;
+  }
+  return entrypoints;
+}
+
+function fileKind(relativePath: string): string {
+  if (relativePath === 'docs/README.md') return 'documentation-map';
+  if (rootEntrypoints.includes(relativePath as (typeof rootEntrypoints)[number]))
+    return 'entrypoint';
+  if (relativePath.startsWith('docs/architecture/')) return 'architecture';
+  if (relativePath.startsWith('docs/adr/')) return 'adr';
+  if (relativePath.startsWith('docs/policies/')) return 'policy';
+  if (relativePath.startsWith('docs/guides/')) return 'guide';
+  if (relativePath.startsWith('.agents/skills/')) return 'agent-skill';
+  if (posix.basename(relativePath) === 'README.md') return 'package';
+  return 'subsystem';
+}
+
+function githubPermalink(target: LocalTarget, sourceCommit: string): string {
+  const targetPath = target.relativePath;
+  const kind = target.isDirectory ? 'tree' : 'blob';
+  return `https://github.com/${guidanceRepository}/${kind}/${sourceCommit}/${targetPath}`;
+}
+
+function parseTarget(target: string): ParsedTarget {
+  const hashIndex = target.indexOf('#');
+  const beforeFragment = hashIndex >= 0 ? target.slice(0, hashIndex) : target;
+  const fragment = hashIndex >= 0 ? target.slice(hashIndex) : '';
+  const queryIndex = beforeFragment.indexOf('?');
+  const pathPart = queryIndex >= 0 ? beforeFragment.slice(0, queryIndex) : beforeFragment;
+  const query = queryIndex >= 0 ? beforeFragment.slice(queryIndex) : '';
+  const anchorPart = hashIndex >= 0 ? target.slice(hashIndex + 1) : '';
+  let decodedPath: string;
+  let decodedAnchor: string;
+  try {
+    decodedPath = decodeURIComponent(pathPart.replaceAll('\\', '/'));
+    decodedAnchor = decodeURIComponent(anchorPart);
+  } catch {
+    throw new Error(`Invalid percent encoding in Markdown target: ${target}`);
+  }
+  return {
+    path: decodedPath,
+    query,
+    fragment,
+    anchor: decodedAnchor ? decodedAnchor.toLowerCase() : null,
+  };
+}
+
+async function resolveLocalTarget(
+  sourceRoot: string,
+  sourceFile: string,
+  rawTarget: string,
+): Promise<LocalTarget | null> {
+  const parsedTarget = parseTarget(rawTarget);
+  if (parsedTarget.path.startsWith('/')) {
+    throw new Error(`Absolute local Markdown target is not allowed: ${rawTarget}`);
+  }
+  const sourceAbsolute = join(sourceRoot, sourceFile);
+  const candidate = parsedTarget.path
+    ? resolve(dirname(sourceAbsolute), parsedTarget.path)
+    : sourceAbsolute;
+  if (!isWithin(sourceRoot, candidate)) {
+    throw new Error(`Markdown target escapes the repository: ${rawTarget}`);
+  }
+
+  const candidates = [candidate];
+  if (extname(candidate) === '') {
+    candidates.push(`${candidate}.md`, `${candidate}.mdx`, join(candidate, 'README.md'));
+  } else if (await isDirectory(candidate)) {
+    candidates.push(join(candidate, 'README.md'));
+  }
+  for (const possibleTarget of candidates) {
+    if (!(await isFileOrDirectory(possibleTarget))) continue;
+    await assertRealpathWithin(sourceRoot, possibleTarget);
+    return {
+      absolutePath: possibleTarget,
+      isDirectory: await isDirectory(possibleTarget),
+      relativePath: toRepositoryPath(sourceRoot, possibleTarget),
+    };
+  }
+  return null;
+}
+
+async function resolveBundleTarget(candidate: string): Promise<string | null> {
+  const candidates = [candidate];
+  if (extname(candidate) === '') {
+    candidates.push(`${candidate}.md`, `${candidate}.mdx`, join(candidate, 'README.md'));
+  } else if (await isDirectory(candidate)) {
+    candidates.push(join(candidate, 'README.md'));
+  }
+  for (const possibleTarget of candidates) {
+    if (await isFile(possibleTarget)) return possibleTarget;
+  }
+  return null;
+}
+
+async function normalizeAvailableFiles(
+  sourceRoot: string,
+  availableFiles: Iterable<string> | undefined,
+): Promise<Set<string>> {
+  const files = availableFiles ? [...availableFiles] : await filesUnder(sourceRoot);
+  const normalized = new Set<string>();
+  for (const file of files) {
+    const relativePath = normalizeRelativePath(file);
+    if (normalized.has(relativePath)) {
+      throw new Error(`Duplicate source path maps to ${relativePath}`);
+    }
+    if (await isFile(join(sourceRoot, relativePath))) normalized.add(relativePath);
+  }
+  return normalized;
+}
+
+async function readTargetText(
+  sourceRoot: string,
+  target: LocalTarget,
+  sourceContents: Map<string, string>,
+): Promise<string> {
+  const cached = sourceContents.get(target.relativePath);
+  if (cached !== undefined) return cached;
+  if (target.isDirectory || !isMarkdownPath(target.relativePath)) return '';
+  const content = await readSourceText(sourceRoot, target.relativePath);
+  sourceContents.set(target.relativePath, content);
+  return content;
+}
+
+async function readSourceText(sourceRoot: string, relativePath: string): Promise<string> {
+  const absolutePath = join(sourceRoot, relativePath);
+  const fileStats = await lstat(absolutePath);
+  if (fileStats.isSymbolicLink())
+    throw new Error(`Symlinked guidance source is not allowed: ${relativePath}`);
+  if (!fileStats.isFile()) throw new Error(`Guidance source is not a file: ${relativePath}`);
+  return normalizeLineEndings(await readFile(absolutePath, 'utf8'));
+}
+
+function assertGenerationInputs(
+  sourceRoot: string,
+  outputRoot: string,
+  packageVersion: string,
+  sourceCommit: string,
+): void {
+  if (!packageVersion) throw new Error('Guidance package version is required');
+  if (!sourceCommitPattern.test(sourceCommit)) {
+    throw new Error('Guidance source commit must be a full 40-character SHA-1');
+  }
+  if (outputRoot === sourceRoot || sourceRoot.startsWith(`${outputRoot}/`)) {
+    throw new Error('Guidance output root must not replace the repository root');
+  }
+}
+
+function isExternalTarget(target: string): boolean {
+  return externalLinkPattern.test(target);
+}
+
+function isExcludedGuidancePath(relativePath: string): boolean {
+  return !isIncludedGuidancePath(relativePath);
+}
+
+function isReachableGuidancePath(relativePath: string): boolean {
+  return (
+    isIncludedGuidancePath(relativePath) &&
+    (rootEntrypoints.includes(relativePath as (typeof rootEntrypoints)[number]) ||
+      relativePath.startsWith('apps/') ||
+      relativePath.startsWith('dev/') ||
+      relativePath.startsWith('e2e/') ||
+      relativePath.startsWith('infra/') ||
+      relativePath.startsWith('libs/') ||
+      relativePath.startsWith('tools/') ||
+      relativePath.startsWith('.agents/skills/'))
+  );
+}
+
+function hasAvailableDescendant(target: LocalTarget, availableFiles: Set<string>): boolean {
+  if (!target.isDirectory) return false;
+  const prefix = `${target.relativePath.replace(trailingSlashPattern, '')}/`;
+  return [...availableFiles].some((file) => file.startsWith(prefix));
+}
+
+function isMarkdownPath(filePath: string): boolean {
+  return filePath.toLowerCase().endsWith(markdownExtension);
+}
+
+function isWithin(root: string, candidate: string): boolean {
+  const normalizedRoot = resolve(root);
+  const normalizedCandidate = resolve(candidate);
+  return (
+    normalizedCandidate === normalizedRoot || normalizedCandidate.startsWith(`${normalizedRoot}/`)
+  );
+}
+
+async function assertRealpathWithin(root: string, candidate: string): Promise<void> {
+  const [realRoot, realCandidate] = await Promise.all([realpath(root), realpath(candidate)]);
+  if (!isWithin(realRoot, realCandidate)) {
+    throw new Error(`Guidance path escapes the repository: ${candidate}`);
+  }
+}
+
+function normalizeLineEndings(content: string): string {
+  return content.replace(/\r\n?/gu, '\n');
+}
+
+function normalizeRelativePath(file: string): string {
+  const normalized = posix.normalize(file.replaceAll('\\', '/'));
+  if (isAbsolute(normalized) || normalized === '..' || normalized.startsWith('../')) {
+    throw new Error(`Source path escapes the repository: ${file}`);
+  }
+  return normalized;
+}
+
+function toRepositoryPath(root: string, file: string): string {
+  return relative(root, file).split('\\').join('/');
+}
+
+function sha256(content: string): string {
+  return createHash('sha256').update(content, 'utf8').digest('hex');
+}
+
+function comparePaths(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function slugifyHeading(heading: string): string {
+  return heading
+    .replace(/!\[([^\]]*)\]\([^)]*\)/gu, '$1')
+    .replace(/\[([^\]]+)\]\([^)]*\)/gu, '$1')
+    .replace(/<[^>]+>/gu, '')
+    .replace(/[\u0060*_~]/gu, '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^\p{Letter}\p{Number}\s_-]/gu, '')
+    .replace(/\s+/gu, '-');
+}
+
+function withoutFencedCode(content: string): string {
+  let inFence = false;
+  return content
+    .split('\n')
+    .map((line) => {
+      if (fencePattern.test(line)) {
+        inFence = !inFence;
+        return '';
+      }
+      return inFence ? '' : line;
+    })
+    .join('\n');
+}
+
+function extractParsedMarkdownLinks(content: string): ParsedMarkdownLink[] {
+  const links: ParsedMarkdownLink[] = [];
+  const normalizedContent = normalizeLineEndings(content);
+  const lines = normalizedContent.split('\n');
+  let offset = 0;
+  let inFence = false;
+  for (const line of lines) {
+    if (fencePattern.test(line)) {
+      inFence = !inFence;
+      offset += line.length + 1;
+      continue;
+    }
+    if (!inFence) collectInlineLinks(line, offset, lineNumberAt(normalizedContent, offset), links);
+    offset += line.length + 1;
+  }
+  collectReferenceLinks(normalizedContent, links);
+  return links.sort((left, right) => left.destinationStart - right.destinationStart);
+}
+
+function collectInlineLinks(
+  line: string,
+  offset: number,
+  lineNumber: number,
+  links: ParsedMarkdownLink[],
+): void {
+  let searchFrom = 0;
+  while (searchFrom < line.length) {
+    const closeBracket = line.indexOf('](', searchFrom);
+    if (closeBracket < 0) return;
+    const destinationStartInLine = closeBracket + 2;
+    const parsed = parseInlineDestination(line, destinationStartInLine);
+    if (parsed) {
+      links.push({
+        line: lineNumber,
+        target: parsed.target,
+        destinationStart: offset + parsed.destinationStart,
+        destinationEnd: offset + parsed.destinationEnd,
+        usesAngleBrackets: parsed.usesAngleBrackets,
+      });
+    }
+    searchFrom = parsed ? parsed.closeParenthesis + 1 : destinationStartInLine + 1;
+  }
+}
+
+function parseInlineDestination(
+  line: string,
+  start: number,
+): {
+  closeParenthesis: number;
+  destinationEnd: number;
+  destinationStart: number;
+  target: string;
+  usesAngleBrackets: boolean;
+} | null {
+  let destinationStart = start;
+  while (whitespacePattern.test(line[destinationStart] ?? '')) destinationStart += 1;
+  if (line[destinationStart] === '<') {
+    const closeAngle = line.indexOf('>', destinationStart + 1);
+    if (closeAngle < 0) return null;
+    const target = line.slice(destinationStart + 1, closeAngle);
+    const closeParenthesis = findClosingParenthesis(line, closeAngle + 1);
+    if (closeParenthesis < 0) return null;
+    return {
+      closeParenthesis,
+      destinationStart: destinationStart + 1,
+      destinationEnd: closeAngle,
+      target,
+      usesAngleBrackets: true,
+    };
+  }
+  const closeParenthesis = findClosingParenthesis(line, destinationStart);
+  if (closeParenthesis < 0) return null;
+  const rawDestination = line.slice(destinationStart, closeParenthesis);
+  const token = rawDestination.match(nonWhitespacePattern)?.[0];
+  if (!token) return null;
+  return {
+    closeParenthesis,
+    destinationStart,
+    destinationEnd: destinationStart + token.length,
+    target: token,
+    usesAngleBrackets: false,
+  };
+}
+
+function findClosingParenthesis(line: string, start: number): number {
+  let depth = 0;
+  for (let index = start; index < line.length; index += 1) {
+    const character = line[index];
+    if (character === '(') depth += 1;
+    if (character !== ')') continue;
+    if (depth === 0) return index;
+    depth -= 1;
+  }
+  return -1;
+}
+
+function collectReferenceLinks(content: string, links: ParsedMarkdownLink[]): void {
+  const normalizedContent = normalizeLineEndings(content);
+  let offset = 0;
+  let inFence = false;
+  for (const line of normalizedContent.split('\n')) {
+    if (fencePattern.test(line)) {
+      inFence = !inFence;
+      offset += line.length + 1;
+      continue;
+    }
+    if (!inFence) {
+      const match = line.match(referenceLinkPattern);
+      const rawTarget = match?.[1];
+      if (rawTarget) {
+        const definitionEnd = line.indexOf(']:');
+        let rawStartInLine = definitionEnd + 2;
+        while (line[rawStartInLine] === ' ' || line[rawStartInLine] === '\t') {
+          rawStartInLine += 1;
+        }
+        const usesAngleBrackets = rawTarget.startsWith('<') && rawTarget.endsWith('>');
+        const rawStart = offset + rawStartInLine;
+        links.push({
+          line: lineNumberAt(normalizedContent, rawStart),
+          target: usesAngleBrackets ? rawTarget.slice(1, -1) : rawTarget,
+          destinationStart: rawStart + (usesAngleBrackets ? 1 : 0),
+          destinationEnd: rawStart + rawTarget.length - (usesAngleBrackets ? 1 : 0),
+          usesAngleBrackets,
+        });
+      }
+    }
+    offset += line.length + 1;
+  }
+}
+
+function lineNumberAt(content: string, index: number): number {
+  return content.slice(0, index).split('\n').length;
+}
+
+async function filesUnder(directory: string, rootDirectory = directory): Promise<string[]> {
+  const entries = await readdir(directory, {withFileTypes: true});
+  const files = await Promise.all(
+    entries.map((entry) => {
+      const entryPath = join(directory, entry.name);
+      if (entry.isDirectory()) {
+        if (excludedDirectoryNames.has(entry.name)) return [];
+        return filesUnder(entryPath, rootDirectory);
+      }
+      if (!entry.isFile()) return [];
+      return [toRepositoryPath(rootDirectory, entryPath)];
+    }),
+  );
+  return files.flat();
+}
+
+async function isFile(file: string): Promise<boolean> {
+  try {
+    return (await stat(file)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+async function isDirectory(directory: string): Promise<boolean> {
+  try {
+    return (await stat(directory)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function isFileOrDirectory(file: string): Promise<boolean> {
+  return (await isFile(file)) || (await isDirectory(file));
+}
+
+async function getGitOutput(root: string, args: string[]): Promise<string> {
+  const result = await execFileAsync('git', ['-C', root, ...args], {encoding: 'utf8'});
+  return result.stdout.trim();
+}
+
+export async function generateFromRepository(
+  packageRoot: string,
+  outputRoot: string,
+  packageVersion: string,
+): Promise<GeneratedGuidanceBundle> {
+  const sourceRoot = await getGitOutput(packageRoot, ['rev-parse', '--show-toplevel']);
+  const sourceCommit = await getGitOutput(sourceRoot, ['rev-parse', 'HEAD']);
+  const trackedOutput = await execFileAsync(
+    'git',
+    ['-C', sourceRoot, 'ls-files', '-co', '--exclude-standard', '-z'],
+    {encoding: 'utf8'},
+  );
+  const availableFiles = trackedOutput.stdout.split('\0').filter((file) => file.length > 0);
+  return generateGuidanceBundle({
+    sourceRoot,
+    outputRoot,
+    packageVersion,
+    sourceCommit,
+    availableFiles,
+  });
+}
+
+export function verifyBundle(bundleRoot: string): Promise<GuidanceManifest> {
+  return validateGeneratedBundle(bundleRoot);
+}

--- a/tools/engineering-guidance/src/index.ts
+++ b/tools/engineering-guidance/src/index.ts
@@ -1,0 +1,40 @@
+import {readFileSync} from 'node:fs';
+import {dirname, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+import {
+  assertGuidanceManifest,
+  type GuidanceManifest,
+  guidanceManifestSchemaVersion,
+  guidancePackageName,
+  guidanceRepository,
+  isGuidanceManifest,
+} from './manifest.js';
+
+const distRoot = dirname(fileURLToPath(import.meta.url));
+
+export const bundleRoot = resolve(distRoot, 'bundle');
+export const manifestPath = resolve(bundleRoot, 'MANIFEST.json');
+
+export type {GuidanceManifest};
+export {
+  assertGuidanceManifest,
+  guidanceManifestSchemaVersion,
+  guidancePackageName,
+  guidanceRepository,
+  isGuidanceManifest,
+};
+
+export function getGuidanceBundleRoot(): string {
+  return bundleRoot;
+}
+
+export function getGuidanceManifestPath(): string {
+  return manifestPath;
+}
+
+export function readGuidanceManifest(): GuidanceManifest {
+  const value: unknown = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  assertGuidanceManifest(value);
+  return value;
+}

--- a/tools/engineering-guidance/src/manifest.ts
+++ b/tools/engineering-guidance/src/manifest.ts
@@ -1,0 +1,121 @@
+export const guidancePackageName = '@shipfox/engineering-guidance';
+export const guidanceRepository = 'ShipfoxHQ/shipfox';
+export const guidanceManifestSchemaVersion = 1 as const;
+
+const commitPattern = /^[a-f0-9]{40}$/u;
+const entrypointNamePattern = /^[a-z][A-Za-z0-9]*$/u;
+const sha256Pattern = /^[a-f0-9]{64}$/u;
+
+export interface GuidanceManifestFile {
+  path: string;
+  sha256: string;
+  kind: string;
+}
+
+export interface GuidanceManifest {
+  schemaVersion: typeof guidanceManifestSchemaVersion;
+  package: {
+    name: typeof guidancePackageName;
+    version: string;
+  };
+  source: {
+    repository: typeof guidanceRepository;
+    commit: string;
+  };
+  entrypoints: Record<string, string>;
+  files: GuidanceManifestFile[];
+}
+
+export function assertGuidanceManifest(value: unknown): asserts value is GuidanceManifest {
+  if (!isRecord(value)) throw new Error('Guidance manifest must be an object');
+  if (value.schemaVersion !== guidanceManifestSchemaVersion) {
+    throw new Error(`Unsupported guidance manifest schema: ${String(value.schemaVersion)}`);
+  }
+
+  const packageValue = value.package;
+  if (!isRecord(packageValue) || packageValue.name !== guidancePackageName) {
+    throw new Error(`Guidance manifest package name must be ${guidancePackageName}`);
+  }
+  if (!isNonEmptyString(packageValue.version)) {
+    throw new Error('Guidance manifest package version must be a non-empty string');
+  }
+
+  const sourceValue = value.source;
+  if (!isRecord(sourceValue) || sourceValue.repository !== guidanceRepository) {
+    throw new Error(`Guidance manifest source repository must be ${guidanceRepository}`);
+  }
+  if (!isCommit(sourceValue.commit)) {
+    throw new Error('Guidance manifest source commit must be a full 40-character SHA-1');
+  }
+
+  if (!isRecord(value.entrypoints) || typeof value.entrypoints.documentationMap !== 'string') {
+    throw new Error('Guidance manifest must define entrypoints.documentationMap');
+  }
+  for (const [name, entrypoint] of Object.entries(value.entrypoints)) {
+    if (!entrypointNamePattern.test(name)) {
+      throw new Error(`Invalid guidance manifest entrypoint name: ${name}`);
+    }
+    assertManifestPath(entrypoint, `entrypoints.${name}`);
+  }
+
+  if (!Array.isArray(value.files) || value.files.length === 0) {
+    throw new Error('Guidance manifest must list at least one file');
+  }
+  let previousPath = '';
+  const paths = new Set<string>();
+  for (const [index, file] of value.files.entries()) {
+    if (!isRecord(file)) throw new Error(`Manifest file ${index} must be an object`);
+    if (!isNonEmptyString(file.path)) throw new Error(`Manifest file ${index} has no path`);
+    assertManifestPath(file.path, `files.${index}.path`);
+    if (file.path <= previousPath) {
+      throw new Error('Guidance manifest files must be sorted by path');
+    }
+    previousPath = file.path;
+    if (paths.has(file.path)) throw new Error(`Duplicate guidance manifest path: ${file.path}`);
+    paths.add(file.path);
+    if (!sha256Pattern.test(String(file.sha256))) {
+      throw new Error(`Invalid SHA-256 for guidance manifest file: ${file.path}`);
+    }
+    if (!isNonEmptyString(file.kind)) {
+      throw new Error(`Missing kind for guidance manifest file: ${file.path}`);
+    }
+  }
+  for (const [name, entrypoint] of Object.entries(value.entrypoints)) {
+    if (typeof entrypoint !== 'string' || !paths.has(entrypoint)) {
+      throw new Error(`Guidance manifest entrypoint ${name} is not listed in files`);
+    }
+  }
+}
+
+export function isGuidanceManifest(value: unknown): value is GuidanceManifest {
+  try {
+    assertGuidanceManifest(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function assertManifestPath(value: unknown, field: string): asserts value is string {
+  if (
+    typeof value !== 'string' ||
+    !value.startsWith('repository/') ||
+    value.includes('\\') ||
+    value.includes('//') ||
+    value.split('/').some((part) => part === '' || part === '.' || part === '..')
+  ) {
+    throw new Error(`Invalid ${field}: ${String(value)}`);
+  }
+}
+
+function isCommit(value: unknown): value is string {
+  return typeof value === 'string' && commitPattern.test(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/tools/engineering-guidance/test/generator.test.ts
+++ b/tools/engineering-guidance/test/generator.test.ts
@@ -1,0 +1,210 @@
+import assert from 'node:assert/strict';
+import {mkdir, mkdtemp, readdir, readFile, rm, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join, relative} from 'node:path';
+
+import {
+  anchorsFor,
+  extractMarkdownLinks,
+  generateGuidanceBundle,
+  isIncludedGuidancePath,
+  validateGeneratedBundle,
+} from '../src/generator.js';
+
+const sourceCommit = '0123456789abcdef0123456789abcdef01234567';
+const duplicateSourcePathPattern = /Duplicate source path/u;
+const missingAnchorPattern = /missing anchor/u;
+const traversalPattern = /escapes the repository/u;
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, {force: true, recursive: true})));
+});
+
+test('builds the approved documentation roots and recursive Markdown closure', async () => {
+  const sourceRoot = await createFixture({
+    'AGENTS.md': '[Map](docs/README.md)\n',
+    'CONTRIBUTING.md': '# Contributing\n',
+    'WRITING.md': '# Writing\n',
+    'DESIGN.md': '# Design\n',
+    'docs/README.md': `${[
+      '# Map',
+      '[Client](architecture/client.md)',
+      '[Package](../libs/example/README.md#usage)',
+      '[Product](../apps/docs/content/product.md)',
+      '[Source](../libs/example/src/index.ts)',
+    ].join('\n')}\n`,
+    'docs/architecture/client.md': '[Backend](backend.md)\n',
+    'docs/architecture/backend.md': '[Other package](../../libs/other/README.md)\n',
+    'docs/orphan.md': '# Included because docs is an approved root\n',
+    'libs/example/README.md': '# Example\n\n## Usage\n\n[Other](../other/README.md)\n',
+    'libs/example/src/index.ts': 'export const example = true;\n',
+    'libs/other/README.md': '# Other\n',
+    'apps/docs/content/product.md': '[Missing](nowhere.md)\n',
+    'apps/docs/WRITING.md': '[Missing](nowhere.md)\n',
+    '.changeset/example.md': '# Release metadata\n',
+    'libs/example/CHANGELOG.md': '# Changelog\n',
+    'libs/example/test/README.md': '# Fixture documentation\n',
+  });
+  const outputRoot = join(sourceRoot, 'generated');
+
+  const result = await generateGuidanceBundle({
+    sourceRoot,
+    outputRoot,
+    packageVersion: '1.0.0',
+    sourceCommit,
+    availableFiles: await fixtureFiles(sourceRoot),
+  });
+
+  assert.deepEqual(result.files, [
+    'AGENTS.md',
+    'CONTRIBUTING.md',
+    'DESIGN.md',
+    'WRITING.md',
+    'docs/README.md',
+    'docs/architecture/backend.md',
+    'docs/architecture/client.md',
+    'docs/orphan.md',
+    'libs/example/README.md',
+    'libs/other/README.md',
+  ]);
+  assert.equal(result.manifest.entrypoints.documentationMap, 'repository/docs/README.md');
+  assert.equal(result.manifest.files[0]?.path, 'repository/AGENTS.md');
+  assert.equal(
+    await readFile(join(outputRoot, 'repository/docs/README.md'), 'utf8'),
+    `${[
+      '# Map',
+      '[Client](architecture/client.md)',
+      '[Package](../libs/example/README.md#usage)',
+      `[Product](https://github.com/ShipfoxHQ/shipfox/blob/${sourceCommit}/apps/docs/content/product.md)`,
+      `[Source](https://github.com/ShipfoxHQ/shipfox/blob/${sourceCommit}/libs/example/src/index.ts)`,
+    ].join('\n')}\n`,
+  );
+  await assert.rejects(readFile(join(outputRoot, 'repository/apps/docs/content/product.md')));
+  await validateGeneratedBundle(outputRoot);
+});
+
+test('produces byte-identical output for identical inputs', async () => {
+  const sourceRoot = await createFixture({
+    'docs/README.md': '# Map\n[Guide](guides/guide.md)\n',
+    'docs/guides/guide.md': '# Guide\n',
+  });
+  const firstRoot = join(sourceRoot, 'one');
+  const secondRoot = join(sourceRoot, 'two');
+  const availableFiles = await fixtureFiles(sourceRoot);
+
+  await generateGuidanceBundle({
+    sourceRoot,
+    outputRoot: firstRoot,
+    packageVersion: '1.0.0',
+    sourceCommit,
+    availableFiles,
+  });
+  await generateGuidanceBundle({
+    sourceRoot,
+    outputRoot: secondRoot,
+    packageVersion: '1.0.0',
+    sourceCommit,
+    availableFiles,
+  });
+
+  const firstFiles = await readTree(firstRoot);
+  const secondFiles = await readTree(secondRoot);
+  assert.deepEqual(firstFiles, secondFiles);
+  assert.equal(firstFiles.get('MANIFEST.json'), secondFiles.get('MANIFEST.json'));
+});
+
+test('reports invalid anchors and repository traversal attempts', async () => {
+  const invalidAnchorRoot = await createFixture({
+    'docs/README.md': '[Guide](guide.md#missing)\n',
+    'docs/guide.md': '# Present\n',
+  });
+  await assert.rejects(
+    generateGuidanceBundle({
+      sourceRoot: invalidAnchorRoot,
+      outputRoot: join(invalidAnchorRoot, 'out'),
+      packageVersion: '1.0.0',
+      sourceCommit,
+      availableFiles: await fixtureFiles(invalidAnchorRoot),
+    }),
+    missingAnchorPattern,
+  );
+
+  const traversalRoot = await createFixture({
+    'docs/README.md': '[Outside](../../outside.md)\n',
+  });
+  await assert.rejects(
+    generateGuidanceBundle({
+      sourceRoot: traversalRoot,
+      outputRoot: join(traversalRoot, 'out'),
+      packageVersion: '1.0.0',
+      sourceCommit,
+      availableFiles: await fixtureFiles(traversalRoot),
+    }),
+    traversalPattern,
+  );
+});
+
+test('rejects duplicate source paths and disallowed documentation paths', async () => {
+  const sourceRoot = await createFixture({'docs/README.md': '# Map\n'});
+  await assert.rejects(
+    generateGuidanceBundle({
+      sourceRoot,
+      outputRoot: join(sourceRoot, 'out'),
+      packageVersion: '1.0.0',
+      sourceCommit,
+      availableFiles: ['docs/README.md', './docs/README.md'],
+    }),
+    duplicateSourcePathPattern,
+  );
+
+  assert.equal(isIncludedGuidancePath('apps/docs/content/product.md'), false);
+  assert.equal(isIncludedGuidancePath('apps/docs/WRITING.md'), false);
+  assert.equal(isIncludedGuidancePath('libs/example/CHANGELOG.md'), false);
+  assert.equal(isIncludedGuidancePath('.changeset/example.md'), false);
+  assert.equal(isIncludedGuidancePath('libs/example/test/README.md'), false);
+  assert.equal(isIncludedGuidancePath('docs/guides/testing.md'), true);
+});
+
+test('extracts links with source lines and ignores fenced examples', () => {
+  assert.deepEqual(
+    extractMarkdownLinks(
+      '# Guide\n\nRead [the map](docs/README.md).\n\n```md\n[example](missing.md)\n[example]: missing-reference.md\n```\n',
+    ),
+    [{line: 3, target: 'docs/README.md'}],
+  );
+  assert.deepEqual([...anchorsFor('# One\n# One\n')], ['one', 'one-1']);
+});
+
+async function createFixture(files: Record<string, string>): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'engineering-guidance-test-'));
+  roots.push(root);
+  await Promise.all(
+    Object.entries(files).map(async ([file, content]) => {
+      const filePath = join(root, file);
+      await mkdir(join(filePath, '..'), {recursive: true});
+      await writeFile(filePath, content);
+    }),
+  );
+  return root;
+}
+
+async function fixtureFiles(directory: string, rootDirectory = directory): Promise<string[]> {
+  const entries = await readdir(directory, {withFileTypes: true});
+  const files = await Promise.all(
+    entries.map((entry) => {
+      const entryPath = join(directory, entry.name);
+      if (entry.isDirectory()) return fixtureFiles(entryPath, rootDirectory);
+      return [relative(rootDirectory, entryPath).split('\\').join('/')];
+    }),
+  );
+  return files.flat();
+}
+
+async function readTree(root: string): Promise<Map<string, string>> {
+  const files = await fixtureFiles(root);
+  const values = await Promise.all(
+    files.map(async (file) => [file, await readFile(join(root, file), 'utf8')] as const),
+  );
+  return new Map(values);
+}

--- a/tools/engineering-guidance/tsconfig.build.json
+++ b/tools/engineering-guidance/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+}

--- a/tools/engineering-guidance/tsconfig.json
+++ b/tools/engineering-guidance/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.test.json" }]
+}

--- a/tools/engineering-guidance/tsconfig.test.json
+++ b/tools/engineering-guidance/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "exclude": []
+}

--- a/tools/engineering-guidance/turbo.json
+++ b/tools/engineering-guidance/turbo.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/{AGENTS.md,CONTRIBUTING.md,DESIGN.md,README.md,WRITING.md}",
+        "$TURBO_ROOT$/docs/**/*.md",
+        "$TURBO_ROOT$/e2e/**/*.md",
+        "$TURBO_ROOT$/{apps,infra,libs,tools}/**/*.md"
+      ],
+      "outputs": ["dist/**/*"]
+    },
+    "verify": {
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/docs/**/*.md",
+        "$TURBO_ROOT$/{AGENTS.md,CONTRIBUTING.md,DESIGN.md,README.md,WRITING.md}",
+        "$TURBO_ROOT$/{apps,infra,libs,tools}/**/*.md"
+      ]
+    }
+  }
+}

--- a/tools/engineering-guidance/vitest.config.ts
+++ b/tools/engineering-guidance/vitest.config.ts
@@ -1,0 +1,10 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig(
+  {
+    test: {
+      include: ['test/**/*.test.ts'],
+    },
+  },
+  import.meta.url,
+) as UserConfigExport;


### PR DESCRIPTION
## Summary

Shipfox engineering guidance is spread across the repository documentation map, root instructions, architecture records, policies, guides, and package READMEs. This change adds the public `@shipfox/engineering-guidance` development package so tools can consume one versioned, reproducible bundle.

The bundle follows the approved documentation roots and reachable engineering Markdown, validates local links and anchors, rewrites tracked non-bundle links to full-commit GitHub permalinks, and records sorted SHA-256 entries in `MANIFEST.json`. The package exposes a small locator API and publishes only the built bundle, schema, README, license, and compiled API files. It performs no install-time sync or consumer-repository writes.

The initial release Changeset remains owned by ENG-1202, as scoped by the project dependency graph.

Validation completed with the focused package build/check/type/test/verify gates, repository documentation-policy verification, dependency and lockfile audits, README readability checks, and both direct and productionized staged `pnpm pack` consumer smoke tests. The repository-wide publication preflight is still blocked by the existing unrelated `@shipfox/annotations-dto` missing `dist/index.d.ts` artifact.

Closes ENG-1200

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the public `@shipfox/engineering-guidance` package that builds a deterministic, versioned bundle of our engineering docs for tools to consume. Implements ENG-1200 by validating links/anchors, rewriting non-bundled links to commit permalinks, and exposing a tiny locator API.

- **New Features**
  - New `@shipfox/engineering-guidance` dev-only package with a versioned `MANIFEST.json` (SHA-256 per file, source commit, entrypoints).
  - Generator selects approved roots (`docs/**` and root entrypoints), keeps valid relative links, validates anchors, and permalinks non-bundled tracked links.
  - Small locator API: `getGuidanceBundleRoot()` and `readGuidanceManifest()`.
  - Publishes only the built bundle, schema, README, license, and compiled API; no install-time sync or writes.
  - Added focused tests and a manifest schema; linked from `docs/README.md`.

- **Migration**
  - Add `@shipfox/engineering-guidance` as a dev dependency where tools need engineering docs.
  - Read the bundle with `getGuidanceBundleRoot()` or `readGuidanceManifest()`.
  - Main entrypoint is `repository/docs/README.md`.

<sup>Written for commit 6d9b27109c7ec488eb4b203f932ce6bd47deab61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

