### PR TITLE
[storybook] Configure prebuilt Vercel hosting

### DIFF
--- a/apps/storybook/vercel.json
+++ b/apps/storybook/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
+  "git": {
+    "deploymentEnabled": false
+  }
+}


### PR DESCRIPTION
Configure the composed Storybook Vercel project for CI-uploaded Build Output API artifacts.

The project now uses Vercel's Other framework preset and disables all Git-triggered deployments, allowing CI to publish the assembled `.vercel/output` directory with `vercel deploy --prebuilt` without invoking Vercel builds.

Validation: `turbo run check type test build --filter=@shipfox/storybook... --concurrency=4` (28/28 tasks passed).

Refs ENG-1174

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configure the Storybook Vercel project for CI prebuilt deploys via the Build Output API. Turns off framework detection and Git-triggered deploys, letting CI upload `.vercel/output` with `vercel deploy --prebuilt` (fulfills ENG-1174).

<sup>Written for commit 325379aa6d21c8697d39126a9724f26721edf50a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

