### PR TITLE
Define cross-repository architecture validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,5 +44,6 @@ here, use the full [engineering documentation map](docs/README.md).
 | Creates or updates a package README. | [Package README standard](WRITING.md#package-readmes) | Required sections, public API, local checks, and license. |
 | Writes product or self-hosting documentation. | [Docs writing guide](apps/docs/WRITING.md) | Product-documentation page types, templates, and terminology. |
 | Writes or reviews code comments, module exports, or non-trivial control flow. | [Code style policy](docs/policies/code-style.md) | Shared code-comment, import and export, and control-flow rules. |
+| Adds, moves, or debugs an architecture validation rule. | [Architecture validation guide](docs/guides/architecture-validation.md) | Tool selection, rule placement, cross-repository policy, fixtures, and verification. |
 | Changes a cross-package client composition seam, server module boundary, or shared server-package boundary. | [Engineering documentation map](docs/README.md) | The applicable ADR and its decision boundary. |
 | Changes repository documentation structure or adds a shared documentation surface. | [ADR 0005](docs/adr/0005-repository-documentation-architecture.md) | Documentation ownership, routing, and progressive disclosure. |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,5 +91,6 @@ here, use the full [engineering documentation map](docs/README.md).
 | Creates or updates a package README. | [Package README standard](WRITING.md#package-readmes) | Required sections, public API, local checks, and license. |
 | Writes product or self-hosting documentation. | [Docs writing guide](apps/docs/WRITING.md) | Product-documentation page types, templates, and terminology. |
 | Writes or reviews code comments, module exports, or non-trivial control flow. | [Code style policy](docs/policies/code-style.md) | Shared code-comment, import and export, and control-flow rules. |
+| Adds, moves, or debugs an architecture validation rule. | [Architecture validation guide](docs/guides/architecture-validation.md) | Tool selection, rule placement, cross-repository policy, fixtures, and verification. |
 | Changes a cross-package client composition seam, server module boundary, or shared server-package boundary. | [Engineering documentation map](docs/README.md) | The applicable ADR and its decision boundary. |
 | Changes repository documentation structure or adds a shared documentation surface. | [ADR 0005](docs/adr/0005-repository-documentation-architecture.md) | Documentation ownership, routing, and progressive disclosure. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,8 @@ listed there or when you need to place, update, or review documentation.
 | Changes client state, API adapters, or feature boundaries. | [Client architecture](architecture/client-architecture.md) | The current client model and architecture checks. |
 | Adds or changes a client form. | [Client form guidance](architecture/client-architecture.md#forms) | Form state, validation, fields, server errors, and saved drafts. |
 | Introduces a shared package or changes a server dependency boundary. | [ADR 0004](adr/0004-shared-semantic-packages-and-server-dependency-boundaries.md) | Shared semantic package rules and server package classes. |
+| Adds, moves, or debugs an architecture validation rule. | [Architecture validation guide](guides/architecture-validation.md) | Tool selection, rule placement, fixtures, exceptions, and local verification. |
+| Changes how architecture policy is shared with another repository. | [ADR 0007](adr/0007-cross-repository-architecture-validation.md) | Shared policy distribution, package metadata, versioning, and repository ownership. |
 | Changes repository documentation structure or adds a shared documentation surface. | [ADR 0005](adr/0005-repository-documentation-architecture.md) | Documentation ownership, routing, and progressive disclosure. |
 | Validates repository Markdown links, anchors, or documentation reachability. | [Repository documentation policy](../tools/repository-documentation-policy/README.md) | Deterministic link and orphan checks for engineering documentation. |
 | Changes webhook retry behavior. | [Webhook retry safety](architecture/webhook-retry-safety.md) | The current safety model for webhook retries. |

--- a/docs/adr/0003-client-state-and-domain-architecture.md
+++ b/docs/adr/0003-client-state-and-domain-architecture.md
@@ -392,5 +392,9 @@ imports from pages and components, blocked client-framework imports from `core/`
 dependency rules. Request schemas used for field validation remain allowed. Add a check only after at
 least one feature follows the target structure and proves the rule is practical.
 
+**ADR 0007 owns enforcement placement and cross-repository distribution.** Use the
+[architecture validation guide](../guides/architecture-validation.md) to select the tool and
+verification path for a rule derived from this record.
+
 **Exceptions update this record.** A repeated exception is an architecture change, not a local
 workaround.

--- a/docs/adr/0004-shared-semantic-packages-and-server-dependency-boundaries.md
+++ b/docs/adr/0004-shared-semantic-packages-and-server-dependency-boundaries.md
@@ -240,6 +240,10 @@ directory.
 **Names do not grant exceptions.** A package named `utils`, `shared`, or `common` remains forbidden
 until the architecture registry classifies it. The inventory check rejects unclassified packages.
 
+**ADR 0007 owns enforcement placement and cross-repository distribution.** Use the
+[architecture validation guide](../guides/architecture-validation.md) to select the tool and
+verification path for a rule derived from this record.
+
 ## Migration
 
 **The repository moves to this model in bounded steps.** The migration order is:

--- a/docs/adr/0007-cross-repository-architecture-validation.md
+++ b/docs/adr/0007-cross-repository-architecture-validation.md
@@ -1,0 +1,267 @@
+# Architecture decision record 0007: Cross-repository architecture validation
+
+- **Status:** Accepted.
+- **Date:** 2026-07-23.
+- **Decision owners:** Architecture policy and developer tooling.
+- **Related:** [ADR 0003: Client state and domain architecture](0003-client-state-and-domain-architecture.md),
+  [ADR 0004: Shared semantic packages and server dependency boundaries](0004-shared-semantic-packages-and-server-dependency-boundaries.md),
+  and [ADR 0005: Repository documentation architecture](0005-repository-documentation-architecture.md).
+
+## Context
+
+**Shipfox enforces architecture through several kinds of checks.** Biome plugins inspect local
+source shape. Dependency Cruiser inspects resolved imports. Repository verifiers inspect package
+classification, manifests, and exports. Tests inspect composed declarations and runtime behavior.
+
+**One analyzer cannot represent every invariant well.** A local syntax matcher cannot decide which
+package owns a route. An import graph cannot find an unused manifest dependency. A repository scan
+cannot prove a race or recovery path. Putting every rule in one custom script would replace these
+specialized models with a weaker parser.
+
+**Some current verifiers reconstruct syntax with regular expressions.** This duplicates parsing
+that Biome or Dependency Cruiser already performs. It also makes aliases, re-exports, dynamic
+imports, imported constants, and generated package entry points harder to handle consistently.
+
+**Architecture rules must also apply to the commercial Cloud repository.** Cloud consumes released
+`@shipfox/*` packages. The source-available repository must never depend on Cloud packages or Cloud
+source. Copying the rules or the source-available package registry into Cloud would create two
+policy versions that can drift.
+
+**A downstream repository sees packages, not upstream paths.** Cloud can inspect an installed
+`@shipfox/api-workspaces` manifest. It cannot safely infer that package's architecture class from a
+current checkout of another repository. Architecture identity must travel with the released
+package.
+
+**Policy changes and application changes ship on different schedules.** A new rule can reject
+Cloud code even when Cloud did not change. Downstream repositories need a reviewed, versioned
+upgrade path instead of receiving new blocking behavior implicitly.
+
+## Decision
+
+### Use specialized enforcement layers
+
+**Each invariant uses the narrowest tool that has the required facts.**
+
+| Required facts | Enforcement layer |
+| --- | --- |
+| Syntax and file location from one parsed file | Biome and a GritQL plugin |
+| Resolved static, dynamic, re-exported, or type-only import edges | Dependency Cruiser |
+| Actual feature, module, route, or registry declarations | Executable contract tests |
+| Workspace package inventory, manifests, architecture classes, and exports | Architecture policy verifier |
+| Runtime effects, concurrency, retries, persistence, or user journeys | Unit, integration, or end-to-end tests |
+
+**One rule has one enforcement owner.** Another layer can test the owning tool or provide a
+higher-level behavior check. It does not reimplement the same invariant with a second parser.
+
+**Diagnostics identify the rule and the replacement boundary.** A failure names a stable rule ID,
+the source and target facts, and the expected architecture. A contributor should not need to read
+the validator implementation to understand the repair.
+
+The [architecture validation guide](../guides/architecture-validation.md) owns the current
+tool-selection and rule-authoring procedure.
+
+### Share policy, not repository inventory
+
+**Shipfox will publish `@shipfox/architecture-policy`.** The package will contain:
+
+- The architecture-class vocabulary and fact schemas.
+- Pure rules over normalized facts.
+- Dependency Cruiser rule generation.
+- Repository and package-manifest checks.
+- Stable rule IDs, diagnostics, and policy test fixtures.
+- A command-line interface for local and continuous integration use.
+
+**Each repository owns one local architecture configuration.** It classifies local packages,
+composition roots, and repository-specific extensions. It also records exact temporary exceptions.
+The shared package contains no Cloud package paths or Cloud exception list.
+
+**The source-available repository owns the shared package.** Cloud consumes a released version as a
+development dependency. The source-available repository does not import Cloud code, configuration,
+or policy extensions.
+
+### Model repository direction as data
+
+**Shared rules compare architecture facts, not repository names.** A package fact contains a realm,
+class, and bounded context. The local configuration defines which realms can depend on which other
+realms.
+
+For example, Cloud can add this relation without adding a Cloud branch to the shared evaluator:
+
+```json
+{
+  "realms": {
+    "source-available": {
+      "mayDependOn": ["source-available"]
+    },
+    "cloud": {
+      "mayDependOn": ["source-available", "cloud"]
+    }
+  }
+}
+```
+
+**Realm direction does not weaken package boundaries.** An allowed realm edge still passes the
+package-class and bounded-context rules. A Cloud implementation cannot import a foreign Platform
+implementation merely because Cloud can depend on the source-available realm.
+
+**Platform does not need Cloud inventory.** Its local configuration declares only the realms and
+packages that it can see. Cloud adds its private realm, packages, and allowed upstream relation in
+its own configuration.
+
+### Carry package identity in released manifests
+
+**A published Shipfox package carries architecture metadata.** The installed `package.json`
+contains a versioned field with the package's architecture class, context, and dependency realm.
+
+```json
+{
+  "name": "@shipfox/api-workspaces",
+  "shipfox": {
+    "architecture": {
+      "schema": 1,
+      "realm": "source-available",
+      "kind": "implementation",
+      "context": "workspaces"
+    }
+  }
+}
+```
+
+**Local and installed packages use the same fact model.** A repository adapter marks whether a fact
+came from the workspace or an installed artifact. Policy rules use architecture identity rather
+than repository paths.
+
+**Shipfox packages that take part in policy need metadata.** A participating package with missing or
+invalid metadata fails discovery. Third-party packages remain external dependencies. Their versions
+and manifest shape stay under dependency policy unless an architecture rule classifies them
+explicitly.
+
+**Published metadata matches the installed version.** The package release process preserves or
+adds the metadata while productionizing the manifest. Packed-consumer checks prove that the field
+survives publication.
+
+**The local registry remains the migration source of truth.** Platform can generate published
+metadata from `api-contexts.cjs` while package manifests adopt the field. Cloud classifies its
+private local packages in its repository configuration because they are not published.
+
+### Normalize facts before evaluating policy
+
+**The shared policy consumes a JSON-compatible fact document.** Adapters can collect facts with
+Biome, Dependency Cruiser, workspace manifests, or executable loaders without coupling rules to
+one repository layout.
+
+| Fact | Required information |
+| --- | --- |
+| Package | Name, path, local or installed origin, realm, class, and bounded context |
+| Import edge | Source package, target package, source file, specifier, and import kind |
+| Manifest edge | Source package, target package, and dependency field |
+| Export | Package, public subpath, and resolved source or declaration target |
+| Composition | Declaring package, contribution owner, target owner, and explicit coordinator |
+
+**The first evaluator remains TypeScript.** The fact document stays serializable so a later policy
+engine can consume it without redesigning discovery. Shipfox does not add another policy language
+until the rule set or repository set makes that cost useful.
+
+### Version policy adoption
+
+**Repositories pin the shared policy package.** Cloud adopts a new release through an ordinary
+dependency update and runs its conformance checks in that pull request.
+
+**A newly enabled blocking rule is a breaking policy change.** The package either releases it under
+a breaking version or ships the rule disabled until each repository enables it explicitly. A
+diagnostic improvement that preserves accepted and rejected inputs is not breaking.
+
+**Rule IDs remain stable.** A renamed implementation does not rename the policy identity. A changed
+invariant gets a new rule ID or an explicit migration note.
+
+### Keep exceptions exact and local
+
+**An exception identifies one finding.** It records the rule ID, source, target, owner, reason,
+tracking issue, and removal condition or expiry. It cannot cover an entire package tree or disable a
+shared rule globally.
+
+**A repeated exception changes the architecture.** The owning architecture record must change
+before the policy admits a broad new dependency class or composition path.
+
+## Migration
+
+**Existing checks stay active until their responsibility moves.** The migration proceeds in these
+steps:
+
+1. Document the tool-selection and rule-authoring contract.
+2. Move file-local source-shape checks to Biome plugins.
+3. Generate import-boundary rules from architecture classifications for Dependency Cruiser.
+4. Replace source reconstruction of feature ownership with executable composition checks.
+5. Extract package inventory, manifest, and export rules into the shared fact model.
+6. Publish architecture metadata in packed `@shipfox/*` manifests.
+7. Publish `@shipfox/architecture-policy` and adopt it in Cloud.
+8. Remove a repository-specific verifier only after the shared owner checks the same inputs.
+
+**Migration does not weaken a gate.** A rule moves with equivalent rejected and accepted fixtures.
+The old check remains until the new check passes on both repositories that use the rule.
+
+## Consequences
+
+**Platform and Cloud use the same policy semantics.** Each repository keeps its own package list and
+temporary debt. Shared rules change through a released dependency.
+
+**Published packages become self-describing architecture nodes.** A downstream checker can reason
+about the installed version without cloning or copying the source repository.
+
+**Validation remains layered.** Contributors must choose a tool based on the facts a rule needs.
+The guide and stable rule IDs make that choice explicit.
+
+**Rule implementations become smaller.** Specialized parsers collect facts. Custom code focuses on
+Shipfox concepts such as package class, context ownership, composition, and exception policy.
+
+**Policy releases need compatibility care.** A new blocking rule can require coordinated cleanup in
+more than one repository. Versioned adoption makes that work visible.
+
+**Some repository-specific configuration remains.** Paths, private package classifications, and
+temporary exceptions cannot live in a shared package without coupling the repositories.
+
+## Rejected alternatives
+
+### Copy the validators into Cloud
+
+**Copied validators create independent policies.** Fixes, new package classes, and exception rules
+would need coordinated edits in both repositories. Installed package versions could still disagree
+with the copied upstream registry.
+
+### Put every rule in Biome
+
+**Biome plugins are strongest for local source shape.** They do not own resolved package graphs,
+workspace inventory, installed package metadata, composed feature values, or runtime behavior.
+
+### Build one repository scanner
+
+**One scanner would reimplement several parsers.** It would need to understand TypeScript imports,
+package resolution, JSON manifests, public exports, and executable composition. Specialized tools
+already own those models.
+
+### Adopt Nx for module boundaries
+
+**Nx provides project tags and module-boundary rules.** Shipfox already uses Turbo, Biome, and
+Dependency Cruiser. Adding another workspace graph and lint integration would duplicate current
+infrastructure without solving package-version metadata by itself.
+
+### Adopt Open Policy Agent immediately
+
+**A policy language can evaluate normalized facts well.** It also adds a language, binary,
+debugging model, and release surface. A JSON-compatible fact contract preserves this option while
+TypeScript remains sufficient.
+
+### Publish one central package catalog
+
+**A separate catalog can drift from installed package versions.** Metadata in each package artifact
+describes the version Cloud actually resolved. A catalog can remain a generated report, but it is
+not the downstream source of truth.
+
+## Updating this decision
+
+**A new enforcement engine must own facts that existing layers cannot express well.** Update this
+record before introducing a second shared policy package, a second package-class vocabulary, or a
+policy service that changes the versioning model.
+
+**A new repository adopts the shared contract through local classification.** It does not add its
+paths or private exceptions to the shared package.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,6 +16,7 @@ documentation model and other engineering sources, start with the
 | [0004: Shared semantic packages and server dependency boundaries](0004-shared-semantic-packages-and-server-dependency-boundaries.md) | Accepted; amends ADR 0002 | Shared package admission and server dependency boundaries. |
 | [0005: Repository documentation architecture](0005-repository-documentation-architecture.md) | Accepted | Documentation ownership, routing, and progressive disclosure. |
 | [0006: Database ownership boundaries](0006-database-ownership-boundaries.md) | Accepted; amends ADR 0002 | Owner-only database access and stable database namespaces. |
+| [0007: Cross-repository architecture validation](0007-cross-repository-architecture-validation.md) | Accepted | Validation layers, shared policy distribution, and downstream package metadata. |
 
 When a decision changes, add a new ADR that supersedes or amends the earlier
 record. Keep the original record intact so readers can understand why the

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -122,6 +122,10 @@ provider SPI is a same-context exception. It does not allow another context.
 ## Enforcement and updates
 
 This guide is the canonical current rule set for backend package boundaries.
+Read the [architecture validation guide](../guides/architecture-validation.md)
+when adding, moving, or debugging an enforcement rule. It owns tool selection,
+fixtures, cross-repository policy, and local verification.
+
 These checks enforce the rules:
 
 - `pnpm check:api-context-inventory` checks server package classification,

--- a/docs/architecture/client-architecture.md
+++ b/docs/architecture/client-architecture.md
@@ -172,6 +172,11 @@ React. Test an adapter with representative DTOs and its mapped domain model.
 Test query keys, cache effects, polling, and optimistic updates at the query
 boundary. Component tests prove rendered behavior. E2E tests prove journeys.
 
+Read the [architecture validation guide](../guides/architecture-validation.md)
+when adding, moving, or debugging an enforcement rule. It owns the boundary
+between Biome, Dependency Cruiser, executable contract tests, and repository
+policy.
+
 Run the affected package `check` and `pnpm check:client-architecture` after
 changing a client boundary. Package checks run the local Biome rules and report
 source locations for response DTO imports, DTO or framework imports in `core/`,

--- a/docs/guides/architecture-validation.md
+++ b/docs/guides/architecture-validation.md
@@ -1,0 +1,270 @@
+# Architecture validation
+
+This guide owns tool selection, rule placement, and local verification for
+architecture checks. Read it when adding, moving, or debugging an architecture
+rule. Architecture documents and decision records own the rule itself.
+
+[ADR 0007](../adr/0007-cross-repository-architecture-validation.md) owns the
+decision to use layered checks and a versioned cross-repository policy
+contract.
+
+## Principles
+
+**Use the strongest existing model for the invariant.** Match syntax with an
+abstract syntax tree. Inspect dependencies with a resolved graph. Validate
+feature ownership from composed feature values. Inspect manifests as JSON.
+Test runtime behavior by running it.
+
+**Give each rule one enforcement owner.** Do not keep a regular-expression
+scan after Biome or Dependency Cruiser owns the same inputs. A higher-level
+test can prove behavior without duplicating the lower-level parser.
+
+**Keep architecture meaning separate from repository layout.** Shared rules
+use package classes, bounded contexts, and ownership. Each repository maps its
+local paths and private packages to those concepts.
+
+**Fail at the narrowest useful location.** A local syntax problem should fail
+the package `check` task with a source span. A repository graph problem can
+fail a repository verifier. A behavior problem belongs in the focused test
+that exercises it.
+
+## Choose the enforcement layer
+
+| Use case | Tool | Use it when | Do not use it for |
+| --- | --- | --- | --- |
+| A forbidden call, import form, declaration, or framework use in one file | [Biome and GritQL](../../tools/biome/README.md) | The decision needs syntax and file location only. | Cross-file ownership, resolved targets, or runtime flow. |
+| A dependency between source modules or packages | [Dependency Cruiser](../../tools/depcruise/README.md) | The decision needs resolved static, dynamic, re-exported, or type-only imports. | Unused manifest edges, composed values, or behavior. |
+| A feature, module, route, provider, or registry composition invariant | A focused Vitest contract test | The declarations can be imported or evaluated as structured values. | Reconstructing those values from source text. |
+| Package classification, manifest edges, and public export shape | Repository architecture verifier | The decision needs workspace or installed-package metadata. | Local syntax that Biome can report more precisely. |
+| Dependency ranges, catalogs, and manifest hygiene | `@shipfox/dependency-policy` | The rule concerns dependency declarations rather than architecture ownership. | Bounded-context or feature ownership. |
+| Packed package entry points and production manifests | `@shipfox/package-release` | The rule concerns what an external consumer installs. | Internal source layout. |
+| Effects, concurrency, retries, persistence, or user journeys | Unit, integration, or end-to-end tests | The result depends on executing code or observing state. | Static package boundaries. |
+
+## Decide where a new rule belongs
+
+Use these questions in order:
+
+1. **Can one parsed file decide the result?** Add a Biome plugin.
+2. **Does the result depend on a resolved import edge?** Add a Dependency
+   Cruiser rule.
+3. **Can the real declarations be loaded as data?** Add an executable contract
+   test at their composition owner.
+4. **Does the result compare packages, manifests, classifications, or
+   exports?** Add a repository policy rule over normalized facts.
+5. **Does the result depend on execution order or state?** Add the lowest test
+   level that proves it.
+
+Do not approximate a later answer with an earlier tool. A file-local regular
+expression is not a substitute for a package graph or an executable feature
+manifest.
+
+## Biome rules
+
+**Biome owns local source shape.** Current client rules cover DTO and framework
+imports in `core/`, response DTO use in presentation code, raw API requests,
+and query-cache ownership in leaf components.
+
+Add a rule when:
+
+- One file contains all required evidence.
+- The rejected syntax has an unambiguous replacement.
+- File includes and excludes can define the allowed boundary.
+- The diagnostic should point to one syntax node.
+
+Every architecture plugin must:
+
+- Use a stable `<area>/<rule-name>` ID.
+- Include one allowed and one rejected fixture.
+- Cover aliases, namespace imports, and type-only imports when relevant.
+- Exclude generated, test, and story files only when the architecture rule
+  excludes them.
+- Name the approved replacement boundary in the diagnostic.
+
+Do not suppress an architecture plugin with `biome-ignore`. Change the source,
+the rule boundary, or the architecture decision.
+
+Run:
+
+```sh
+mise exec -- turbo check --filter=@shipfox/<package>...
+mise exec -- turbo test --filter=@shipfox/biome
+```
+
+## Dependency Cruiser rules
+
+**Dependency Cruiser owns resolved import topology.** Use it for allowed and
+forbidden layer dependencies, deep imports, cross-context implementation
+edges, cycles, and type-only dependency rules.
+
+Generate rules from architecture classifications when the same matrix applies
+to many packages. Do not repeat one package list in several rule definitions.
+
+A dependency rule must state:
+
+- The source class or package set.
+- The target class or package set.
+- Whether the edge can be direct, transitive, dynamic, or type-only.
+- The allowed composition or test-layer exception.
+- A stable rule ID and repair message.
+
+Run the changed package and its dependents:
+
+```sh
+mise exec -- turbo depcruise --filter=@shipfox/<package>...
+```
+
+Run all affected dependency checks after changing the shared configuration:
+
+```sh
+mise exec -- turbo depcruise --affected
+```
+
+## Executable contract tests
+
+**Use actual declarations when architecture is data.** Client feature
+manifests, server module lists, route registries, provider registries, and
+public composition options already have typed runtime values. Their owner
+should validate those values directly.
+
+Examples include:
+
+- Composing all default client features and checking route ownership.
+- Rejecting duplicate navigation, settings, route, or provider IDs.
+- Building the default server module graph and checking required
+  presentations.
+- Checking that a route implementation package is declared by the
+  composition package.
+
+Keep the invariant in a pure validator when both production composition and
+tests need it. Do not add a repository source scanner that tries to recover
+the same object literals.
+
+Run the package that owns the composition:
+
+```sh
+mise exec -- turbo test --filter=@shipfox/<composition-package>...
+```
+
+## Repository architecture policy
+
+**A repository verifier owns facts that cross files and manifests.** Current
+verifiers cover client architecture and the server package inventory while
+the shared policy package from ADR 0007 is built.
+
+Use the repository layer for:
+
+- Complete package classification.
+- Local and installed package architecture metadata.
+- Manifest dependency edges, including unused edges.
+- Root and subpath export contracts.
+- Exact temporary architecture exceptions.
+- Cross-repository realm and context rules.
+
+Do not parse imports with a repository regular expression when Dependency
+Cruiser can supply resolved edges. Do not parse object literals when a
+composition test can load them.
+
+Current Platform commands are:
+
+```sh
+mise exec -- pnpm check:client-architecture
+mise exec -- pnpm check:api-context-inventory
+mise exec -- pnpm check:dependencies
+mise exec -- pnpm check:published-artifacts
+```
+
+The first two commands remain repository-specific migration gates. Do not copy
+their implementation into Cloud. Move shared rules into
+`@shipfox/architecture-policy` when that package is available.
+
+## Cross-repository rules
+
+**A shared rule uses normalized package identity.** It must not depend on a
+Platform or Cloud checkout path. The rule receives local and installed
+package facts with the same shape.
+
+**Rules compare relations instead of repository names.** Each repository
+defines its realms and their allowed dependency direction. Cloud can declare
+that its local realm may depend on the source-available realm. The shared
+evaluator does not contain a Cloud-specific branch.
+
+An allowed realm edge still passes the package-class and bounded-context
+rules. A downstream implementation cannot import a foreign upstream
+implementation only because the repositories have an allowed dependency
+direction.
+
+The shared package owns:
+
+- Architecture classes and fact schemas.
+- Rules over package, import, manifest, export, and composition facts.
+- Dependency Cruiser rule generation.
+- Stable diagnostics and generic fixtures.
+
+Each repository owns:
+
+- Local package classification.
+- Composition roots and private package roles.
+- Local policy extensions.
+- Exact temporary exceptions.
+- The pinned policy-package version.
+
+Published `@shipfox/*` package manifests carry their architecture metadata.
+Cloud evaluates the installed metadata for the version it resolved. It does
+not copy `api-contexts.cjs` or inspect a different Platform checkout.
+
+A Shipfox package that takes part in policy must have valid metadata.
+Third-party packages remain under dependency policy unless an architecture
+rule classifies them explicitly.
+
+## Add or change a rule
+
+1. **Name the invariant and owner.** Link the architecture document, policy,
+   or ADR that defines the expected boundary.
+2. **List the required facts.** Include syntax, resolved imports, manifests,
+   exports, composition values, or runtime state.
+3. **Choose one enforcement owner.** Use the tool-selection questions above.
+4. **Assign a stable rule ID.** Keep the ID independent from implementation
+   file names.
+5. **Add accepted and rejected cases.** Include the variants that previously
+   made the rule hard to express.
+6. **Write an actionable diagnostic.** Name the replacement package, adapter,
+   contract, coordinator, or test layer.
+7. **Check the full input surface.** Include production, tests, setup,
+   manifests, or packed output when the owning architecture rule covers them.
+8. **Run focused validation.** Widen to affected packages and repository
+   verification when the shared configuration changes.
+9. **Update documentation only when the contract changes.** A parser refactor
+   does not change an ADR. A new allowed dependency class or repeated
+   exception does.
+
+## Exceptions
+
+**An exception is an exact architecture finding.** Record:
+
+- Rule ID.
+- Source package or file.
+- Target package, export, or owner.
+- Reason and responsible owner.
+- Tracking issue.
+- Removal condition or expiry.
+
+Do not add a package-wide allowlist, a generic ignored directory, or an
+unowned baseline. If several findings need the same exception, review the
+architecture decision before widening policy.
+
+## Current migration state
+
+The repository currently uses:
+
+- Root Biome plugins for migrated client source-shape rules.
+- `.dependency-cruiser.cjs` for package-local import topology.
+- `@shipfox/client-architecture-policy` for remaining client repository
+  checks.
+- `@shipfox/api-architecture-policy` and `api-contexts.cjs` for server package
+  inventory, manifest edges, imports, and DTO exports.
+- Focused composition tests for client and server runtime declarations.
+
+ADR 0007 targets a published `@shipfox/architecture-policy` package and
+architecture metadata in released manifests. Until that migration lands, keep
+the current gates passing and design new shared rules so their policy logic can
+move without copying repository discovery code.


### PR DESCRIPTION
## Summary

- define which validation layer owns source shape, resolved imports, executable composition, repository metadata, and runtime behavior
- define a versioned `@shipfox/architecture-policy` contract with normalized facts, published package metadata, and repository-local realm configuration
- add a rule-authoring guide with current commands, fixture and diagnostic requirements, exception policy, and the migration path for Platform and Cloud
- route the new guidance from the ADR index, documentation map, contributor instructions, and client and backend architecture docs

## Motivation

Architecture checks are moving out of repository-specific scripts, but the same rules must also work in the downstream Cloud repository. This records how both repositories can share policy semantics without copying package inventories, exceptions, or source scanners.

The new shared package and manifest metadata are migration targets described by the ADR; this pull request does not implement them.

## Validation

- `mise exec -- turbo verify --filter=@shipfox/repository-documentation-policy`
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defines cross-repository architecture validation with layered enforcement and a shared, versioned policy contract. Adds ADR 0007 and a rule-authoring guide so Platform and Cloud share policy without copying inventories or scanners.

- **New Features**
  - ADR 0007 assigns ownership to Biome (source shape), Dependency Cruiser (imports), executable composition tests, repository policy (manifests/exports), and runtime tests.
  - Introduces the `@shipfox/architecture-policy` design: normalized fact schemas, rule evaluation, Dependency Cruiser rule generation, CLI, and stable diagnostics; per-repo realm config and exact exceptions stay local.
  - Defines published manifest metadata (`shipfox.architecture`, schema v1) carrying realm, kind, and context for installed `@shipfox/*` packages.
  - Adds an architecture validation guide covering tool selection, rule placement, fixtures/diagnostics, exceptions, and migration; routes all relevant docs to it.

<sup>Written for commit fc7dba547d7b1490e99d76ca70d39189da377886. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

