### PR TITLE
[biome] Enforce API DTO architecture boundaries

### DIFF
--- a/.changeset/steady-dtos-enforce.md
+++ b/.changeset/steady-dtos-enforce.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/biome": patch
+---
+
+Adds API DTO architecture Biome rules with source-local diagnostics and fixture coverage.

--- a/biome.json
+++ b/biome.json
@@ -14,7 +14,8 @@
     "includes": [
       "**",
       "!libs/client/shell/test/external/fixture",
-      "!tools/biome/plugins/client-architecture/fixtures"
+      "!tools/biome/plugins/client-architecture/fixtures",
+      "!tools/biome/plugins/api-architecture/fixtures"
     ]
   },
   "plugins": [
@@ -136,6 +137,33 @@
         "!**/__generated__/**",
         "!**/*.gen.ts",
         "!**/*.gen.tsx"
+      ]
+    },
+    {
+      "path": "./tools/biome/plugins/api-architecture/no-dto-root-inter-module.grit",
+      "includes": [
+        "**/libs/api/**/*-dto/src/index.ts",
+        "!**/dist/**",
+        "!**/node_modules/**",
+        "!**/coverage/**"
+      ]
+    },
+    {
+      "path": "./tools/biome/plugins/api-architecture/no-dto-root-implementation-detail.grit",
+      "includes": [
+        "**/libs/api/**/*-dto/src/index.ts",
+        "!**/dist/**",
+        "!**/node_modules/**",
+        "!**/coverage/**"
+      ]
+    },
+    {
+      "path": "./tools/biome/plugins/api-architecture/no-dto-inter-module-import.grit",
+      "includes": [
+        "**/libs/api/**/*-dto/**",
+        "!**/dist/**",
+        "!**/node_modules/**",
+        "!**/coverage/**"
       ]
     }
   ],

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -124,10 +124,12 @@ provider SPI is a same-context exception. It does not allow another context.
 This guide is the canonical current rule set for backend package boundaries.
 These checks enforce the rules:
 
-- `pnpm check:api-context-inventory` checks server package classification,
-  cross-context implementation imports and manifest edges, and DTO
-  `/inter-module` exports.
-- `.dependency-cruiser.cjs` checks declared dependency boundaries.
+- The root [API architecture Biome plugins](../../tools/biome/plugins/api-architecture/README.md)
+  report local DTO import and export violations at the source expression.
+- `pnpm check:api-context-inventory` checks package classification, stale
+  registry entries, manifest edges, explicit export maps, and imports that
+  depend on context or same-context SPI ownership from `api-contexts.cjs`.
+- `.dependency-cruiser.cjs` checks resolved dependency boundaries.
 - `pnpm check:dependencies` checks dependency policy and manifest hygiene.
 - `pnpm check:published-artifacts` checks packed public entry points.
 

--- a/tools/api-architecture-policy/src/api-context-inventory.ts
+++ b/tools/api-architecture-policy/src/api-context-inventory.ts
@@ -25,8 +25,6 @@ const dependencyGroups = [
 const importExpression =
   /(?:import|export)\s+(?:type\s+)?(?:[^'"`]*?\s+from\s+)?['"]([^'"]+)['"]|import\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
 const sourceFileExpression = /\.(?:[cm]?[jt]sx?)$/;
-const dtoImplementationDetailExpression =
-  /(?:^|\/)(?:core|db|presentation|provider|test|tests|fixtures)(?:\/|\.|$)/;
 
 interface ClassifiedPath {
   classification: string;
@@ -89,7 +87,6 @@ function packageName(specifier: string): string {
 function importViolation(
   importer: ClassifiedPath,
   target: ClassifiedPath | undefined,
-  specifier: string,
 ): string | undefined {
   if (!target) return undefined;
   if (
@@ -101,12 +98,6 @@ function importViolation(
   if (importer.classification === 'dto' && target.classification === 'implementations')
     return 'DTO implementation import';
   if (importer.classification === 'dto' && target.classification === 'spi') return 'DTO SPI import';
-  if (
-    importer.classification === 'dto' &&
-    target.classification === 'dto' &&
-    specifier.endsWith('/inter-module')
-  )
-    return 'DTO inter-module import';
   if (importer.classification === 'shared-semantic' && target.classification === 'implementations')
     return 'Shared semantic implementation import';
   if (importer.classification === 'shared-semantic' && target.classification === 'spi')
@@ -150,13 +141,6 @@ function manifestViolation(
     importer.context !== target.context
   )
     return 'Foreign same-context SPI manifest edge';
-  return undefined;
-}
-
-function dtoRootExportViolation(specifier: string): string | undefined {
-  if (specifier.includes('inter-module')) return 'DTO root exports inter-module contract';
-  if (dtoImplementationDetailExpression.test(specifier))
-    return 'DTO root exports implementation detail';
   return undefined;
 }
 
@@ -259,7 +243,6 @@ export function auditPolicyFixture({
   dependencyGroup,
   dtoHasInterModuleEntry = true,
   dtoRootExportsInterModule = false,
-  dtoRootExportSpecifier,
   importerPath,
   sourceFile,
   targetPath,
@@ -267,7 +250,6 @@ export function auditPolicyFixture({
   dependencyGroup?: (typeof dependencyGroups)[number];
   dtoHasInterModuleEntry?: boolean;
   dtoRootExportsInterModule?: boolean;
-  dtoRootExportSpecifier?: string;
   importerPath: string;
   sourceFile?: string;
   targetPath?: string;
@@ -278,18 +260,14 @@ export function auditPolicyFixture({
   const errors: string[] = [];
 
   if (importer) {
-    const sourceViolation = importViolation(importer, target, sourceFile?.split(':').at(-1) ?? '');
+    const sourceViolation = importViolation(importer, target);
     if (sourceFile && sourceViolation) errors.push(`${sourceViolation}: ${sourceFile}`);
     const dependencyViolation = manifestViolation(importer, target);
     if (dependencyGroup && dependencyViolation)
       errors.push(`${dependencyViolation}: ${dependencyGroup}`);
   }
   if (importer?.classification === 'dto' && dtoRootExportsInterModule && !dtoHasInterModuleEntry)
-    errors.push('DTO root exports inter-module contract');
-  if (importer?.classification === 'dto' && dtoRootExportSpecifier) {
-    const violation = dtoRootExportViolation(dtoRootExportSpecifier);
-    if (violation) errors.push(violation);
-  }
+    errors.push('DTO contract has no explicit inter-module export');
   return errors;
 }
 
@@ -314,11 +292,6 @@ export async function auditRepository(): Promise<string[]> {
     if (classification.classification === 'dto') {
       const indexPath = path.join(repositoryRoot, packagePath, 'src/index.ts');
       const indexSource = await readFile(indexPath, 'utf8');
-      for (const specifier of importSpecifiers(indexSource)) {
-        const violation = dtoRootExportViolation(specifier);
-        if (violation)
-          errors.push(`${violation}: dto-export:${packagePath}:src/index.ts:${specifier}`);
-      }
       if (sourceReExportsInterModule(indexSource) && !hasInterModuleEntry(manifest.exports)) {
         const violation = `dto-export:${packagePath}:package.json:missing-inter-module-entry`;
         errors.push(`DTO contract has no explicit inter-module export: ${violation}`);
@@ -331,11 +304,7 @@ export async function auditRepository(): Promise<string[]> {
       const source = await readFile(sourceFile, 'utf8');
       const relativeFile = toPosixPath(path.relative(repositoryRoot, sourceFile));
       for (const specifier of importSpecifiers(source)) {
-        const violation = importViolation(
-          classification,
-          packages.get(packageName(specifier)),
-          specifier,
-        );
+        const violation = importViolation(classification, packages.get(packageName(specifier)));
         if (violation) errors.push(`${violation}: import:${relativeFile}:${specifier}`);
       }
     }

--- a/tools/api-architecture-policy/test/api-context-inventory.test.ts
+++ b/tools/api-architecture-policy/test/api-context-inventory.test.ts
@@ -39,7 +39,7 @@ describe('auditApiContextInventory', () => {
     ]);
   });
 
-  test('rejects a new foreign manifest edge and DTO root contract export', () => {
+  test('rejects a new foreign manifest edge and missing DTO inter-module export', () => {
     const manifestErrors = auditPolicyFixture({
       dependencyGroup: 'devDependencies',
       importerPath: 'libs/api/runners',
@@ -52,7 +52,7 @@ describe('auditApiContextInventory', () => {
     });
 
     assert.deepEqual(manifestErrors, ['Foreign implementation manifest edge: devDependencies']);
-    assert.deepEqual(dtoErrors, ['DTO root exports inter-module contract']);
+    assert.deepEqual(dtoErrors, ['DTO contract has no explicit inter-module export']);
   });
 
   test('rejects implementation dependencies from DTOs, shared semantics, and foreign SPIs', () => {
@@ -100,13 +100,5 @@ describe('auditApiContextInventory', () => {
       'Foreign same-context SPI import: src/core/agent-tools.ts:@shipfox/api-integration-spi',
       'Foreign same-context SPI manifest edge: dependencies',
     ]);
-  });
-
-  test('rejects implementation details from DTO roots', () => {
-    const errors = auditPolicyFixture({
-      dtoRootExportSpecifier: './presentation/client.js',
-      importerPath: 'libs/api/workflows-dto',
-    });
-    assert.deepEqual(errors, ['DTO root exports implementation detail']);
   });
 });

--- a/tools/biome/plugins/api-architecture/README.md
+++ b/tools/biome/plugins/api-architecture/README.md
@@ -1,0 +1,42 @@
+# API architecture Biome plugins
+
+These Biome GritQL rules check local import and export shapes in API DTO
+packages. The root [`biome.json`](../../../../biome.json) loads them for
+matching files under `libs/api/**/*-dto/`.
+
+Each diagnostic points at the import or export that crosses the approved
+boundary. Do not fix an API architecture error with `biome-ignore`.
+
+## Rules
+
+- `no-dto-root-inter-module` keeps synchronous contracts at the producer DTO
+  `/inter-module` subpath instead of the DTO root.
+- `no-dto-root-implementation-detail` keeps `core`, `db`, `presentation`,
+  `provider`, and test support paths out of DTO roots.
+- `no-dto-inter-module-import` prevents a DTO package from consuming another
+  DTO package's synchronous client surface.
+
+The rules cover static imports, re-exports, dynamic imports, type-only imports,
+and side-effect imports. API consumer tests follow the same package boundary as
+production source. The production globs include `.test.ts`, `test/**`, and
+`tests/**`. They exclude only `dist`, `node_modules`, and `coverage` output.
+
+## Enforcement ownership
+
+Biome owns checks that need only one source expression.
+`@shipfox/api-architecture-policy` owns package classification, registry,
+manifest, and export-map checks. It also owns import rules that need context or
+same-context SPI ownership from `api-contexts.cjs`. Dependency Cruiser checks
+resolved dependency boundaries.
+
+## Fixture harness
+
+Run the focused harness with:
+
+```sh
+pnpm --filter=@shipfox/biome test
+```
+
+The fixtures mirror DTO package paths under `libs/api/`. Each rule has allowed
+and rejected trees. The rejected inter-module fixtures include source tests and
+setup files so the harness protects their production coverage.

--- a/tools/biome/plugins/api-architecture/fixtures/biome.fixture.json
+++ b/tools/biome/plugins/api-architecture/fixtures/biome.fixture.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+  "vcs": {
+    "enabled": false
+  },
+  "assist": {
+    "enabled": true
+  },
+  "formatter": {
+    "enabled": true,
+    "useEditorconfig": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineEnding": "lf",
+    "lineWidth": 100
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "bracketSpacing": false,
+      "trailingCommas": "all",
+      "semicolons": "always",
+      "arrowParentheses": "always"
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "plugins": [
+    {
+      "path": "../no-dto-root-inter-module.grit",
+      "includes": [
+        "**/no-dto-root-inter-module/**/libs/api/**/*-dto/src/index.ts",
+        "!**/dist/**",
+        "!**/node_modules/**",
+        "!**/coverage/**"
+      ]
+    },
+    {
+      "path": "../no-dto-root-implementation-detail.grit",
+      "includes": [
+        "**/no-dto-root-implementation-detail/**/libs/api/**/*-dto/src/index.ts",
+        "!**/dist/**",
+        "!**/node_modules/**",
+        "!**/coverage/**"
+      ]
+    },
+    {
+      "path": "../no-dto-inter-module-import.grit",
+      "includes": [
+        "**/no-dto-inter-module-import/**/libs/api/**/*-dto/**",
+        "!**/dist/**",
+        "!**/node_modules/**",
+        "!**/coverage/**"
+      ]
+    }
+  ],
+  "files": {
+    "includes": [
+      "**/*.ts",
+      "!**/dist/**",
+      "!**/node_modules/**",
+      "!**/coverage/**"
+    ]
+  }
+}

--- a/tools/biome/plugins/api-architecture/fixtures/no-dto-inter-module-import/allowed/libs/api/example-dto/src/allowed.ts
+++ b/tools/biome/plugins/api-architecture/fixtures/no-dto-inter-module-import/allowed/libs/api/example-dto/src/allowed.ts
@@ -1,0 +1,18 @@
+import '@shipfox/a-dto/contracts/side-effect';
+
+import * as clients from '@shipfox/a-dto/contracts/namespace';
+import {client as aliasedClient} from '@shipfox/a-dto/contracts/runtime';
+import type {Client} from '@shipfox/a-dto/contracts/types';
+
+export * from '@shipfox/a-dto/contracts/all';
+export {client} from '@shipfox/a-dto/contracts/export';
+export type {Client} from '@shipfox/a-dto/contracts/export-types';
+
+const dynamicClient = import('@shipfox/a-dto/contracts/dynamic');
+type ImportedClient = import('@shipfox/a-dto/contracts/import-type').Client;
+
+void aliasedClient;
+void clients;
+void dynamicClient;
+
+export type {Client, ImportedClient};

--- a/tools/biome/plugins/api-architecture/fixtures/no-dto-inter-module-import/rejected/libs/api/example-dto/src/rejected.test.ts
+++ b/tools/biome/plugins/api-architecture/fixtures/no-dto-inter-module-import/rejected/libs/api/example-dto/src/rejected.test.ts
@@ -1,0 +1,1 @@
+import '@shipfox/a-dto/inter-module/test-side-effect';

--- a/tools/biome/plugins/api-architecture/fixtures/no-dto-inter-module-import/rejected/libs/api/example-dto/src/rejected.ts
+++ b/tools/biome/plugins/api-architecture/fixtures/no-dto-inter-module-import/rejected/libs/api/example-dto/src/rejected.ts
@@ -1,0 +1,14 @@
+import '@shipfox/a-dto/inter-module/side-effect';
+
+import * as clients from '@shipfox/a-dto/inter-module/namespace';
+import {client as aliasedClient} from '@shipfox/a-dto/inter-module/runtime';
+import type {Client} from '@shipfox/a-dto/inter-module/types';
+
+const dynamicClient = import('@shipfox/a-dto/inter-module/dynamic');
+type ImportedClient = import('@shipfox/a-dto/inter-module/import-type').Client;
+
+void aliasedClient;
+void clients;
+void dynamicClient;
+
+export type {Client, ImportedClient};

--- a/tools/biome/plugins/api-architecture/fixtures/no-dto-inter-module-import/rejected/libs/api/example-dto/test/rejected.ts
+++ b/tools/biome/plugins/api-architecture/fixtures/no-dto-inter-module-import/rejected/libs/api/example-dto/test/rejected.ts
@@ -1,0 +1,3 @@
+export * from '@shipfox/a-dto/inter-module/all';
+export {client} from '@shipfox/a-dto/inter-module/export';
+export type {Client} from '@shipfox/a-dto/inter-module/export-types';

--- a/tools/biome/plugins/api-architecture/fixtures/no-dto-inter-module-import/rejected/libs/api/example-dto/test/setup.ts
+++ b/tools/biome/plugins/api-architecture/fixtures/no-dto-inter-module-import/rejected/libs/api/example-dto/test/setup.ts
@@ -1,0 +1,1 @@
+import '@shipfox/a-dto/inter-module/setup';

--- a/tools/biome/plugins/api-architecture/fixtures/no-dto-inter-module-import/rejected/libs/api/example-dto/tests/rejected.ts
+++ b/tools/biome/plugins/api-architecture/fixtures/no-dto-inter-module-import/rejected/libs/api/example-dto/tests/rejected.ts
@@ -1,0 +1,3 @@
+import * as clients from '@shipfox/a-dto/inter-module/namespace';
+
+void clients;

--- a/tools/biome/plugins/api-architecture/fixtures/no-dto-root-implementation-detail/allowed/libs/api/example-dto/src/index.ts
+++ b/tools/biome/plugins/api-architecture/fixtures/no-dto-root-implementation-detail/allowed/libs/api/example-dto/src/index.ts
@@ -1,0 +1,18 @@
+import 'core-contracts';
+
+import type {Row} from './database/types.js';
+import {toDto as mapToDto} from './presenter/mapper.js';
+import * as providers from './providers/index.js';
+
+export * from './fixture/index.js';
+export type {Fixture} from './test-support/types.js';
+export {fixture} from './testing/factory.js';
+
+const runtimePolicy = import('./core-utils/runtime.js');
+type StoredRow = import('./database/stored-row.js').StoredRow;
+
+void mapToDto;
+void providers;
+void runtimePolicy;
+
+export type {Row, StoredRow};

--- a/tools/biome/plugins/api-architecture/fixtures/no-dto-root-implementation-detail/rejected/libs/api/example-dto/src/index.ts
+++ b/tools/biome/plugins/api-architecture/fixtures/no-dto-root-implementation-detail/rejected/libs/api/example-dto/src/index.ts
@@ -1,0 +1,18 @@
+import 'core';
+
+import type {Row} from './db/types.js';
+import {toDto as mapToDto} from './presentation/mapper.js';
+import * as providers from './provider/index.js';
+
+export * from './fixtures/index.js';
+export {fixture} from './test/factory.js';
+export type {Fixture} from './tests/types.js';
+
+const runtimePolicy = import('./core/runtime.js');
+type StoredRow = import('./db/stored-row.js').StoredRow;
+
+void mapToDto;
+void providers;
+void runtimePolicy;
+
+export type {Row, StoredRow};

--- a/tools/biome/plugins/api-architecture/fixtures/no-dto-root-inter-module/allowed/libs/api/example-dto/src/index.ts
+++ b/tools/biome/plugins/api-architecture/fixtures/no-dto-root-inter-module/allowed/libs/api/example-dto/src/index.ts
@@ -1,0 +1,18 @@
+import '@shipfox/a-dto/contracts/side-effect';
+
+import * as clients from '@shipfox/a-dto/contracts/namespace';
+import {client as aliasedClient} from '@shipfox/a-dto/contracts/runtime';
+import type {Client} from '@shipfox/a-dto/contracts/types';
+
+export * from '@shipfox/a-dto/contracts/all';
+export {client} from '@shipfox/a-dto/contracts/export';
+export type {Client} from '@shipfox/a-dto/contracts/export-types';
+
+const dynamicClient = import('@shipfox/a-dto/contracts/dynamic');
+type ImportedClient = import('@shipfox/a-dto/contracts/import-type').Client;
+
+void aliasedClient;
+void clients;
+void dynamicClient;
+
+export type {Client, ImportedClient};

--- a/tools/biome/plugins/api-architecture/fixtures/no-dto-root-inter-module/rejected/libs/api/example-dto/src/index.ts
+++ b/tools/biome/plugins/api-architecture/fixtures/no-dto-root-inter-module/rejected/libs/api/example-dto/src/index.ts
@@ -1,0 +1,18 @@
+import '@shipfox/a-dto/inter-module/side-effect';
+
+import * as clients from '@shipfox/a-dto/inter-module/namespace';
+import {client as aliasedClient} from '@shipfox/a-dto/inter-module/runtime';
+import type {Client} from '@shipfox/a-dto/inter-module/types';
+
+export * from '@shipfox/a-dto/inter-module/all';
+export {client} from '@shipfox/a-dto/inter-module/export';
+export type {Client} from '@shipfox/a-dto/inter-module/export-types';
+
+const dynamicClient = import('@shipfox/a-dto/inter-module/dynamic');
+type ImportedClient = import('@shipfox/a-dto/inter-module/import-type').Client;
+
+void aliasedClient;
+void clients;
+void dynamicClient;
+
+export type {Client, ImportedClient};

--- a/tools/biome/plugins/api-architecture/no-dto-inter-module-import.grit
+++ b/tools/biome/plugins/api-architecture/no-dto-inter-module-import.grit
@@ -1,0 +1,19 @@
+engine biome(1.0)
+language js(typescript, jsx)
+
+or {
+  `import $_ from $source` as $match where { $source <: r".*@shipfox/[^/]+-dto/inter-module.*" },
+  `import * as $_ from $source` as $match where {
+    $source <: r".*@shipfox/[^/]+-dto/inter-module.*"
+  },
+  `import $source` as $match where { $source <: r".*@shipfox/[^/]+-dto/inter-module.*" },
+  `export {$_} from $source` as $match where { $source <: r".*@shipfox/[^/]+-dto/inter-module.*" },
+  `export type {$_} from $source` as $match where {
+    $source <: r".*@shipfox/[^/]+-dto/inter-module.*"
+  },
+  `export * from $source` as $match where { $source <: r".*@shipfox/[^/]+-dto/inter-module.*" },
+  `import($source)` as $match where { $source <: r".*@shipfox/[^/]+-dto/inter-module.*" },
+  TsImportType() as $match where { $match <: r".*@shipfox/[^/]+-dto/inter-module.*" }
+} where {
+  register_diagnostic(span=$match, message="api-architecture/no-dto-inter-module-import: consume producer DTO /inter-module contracts only from implementation or composition packages; DTO packages remain passive.")
+}

--- a/tools/biome/plugins/api-architecture/no-dto-root-implementation-detail.grit
+++ b/tools/biome/plugins/api-architecture/no-dto-root-implementation-detail.grit
@@ -1,0 +1,31 @@
+engine biome(1.0)
+language js(typescript, jsx)
+
+or {
+  `import $_ from $source` as $match where {
+    $source <: r".*(?:^|/|\x22|\x27)(?:core|db|presentation|provider|test|tests|fixtures)(?:/|\.|$|\x22|\x27).*"
+  },
+  `import * as $_ from $source` as $match where {
+    $source <: r".*(?:^|/|\x22|\x27)(?:core|db|presentation|provider|test|tests|fixtures)(?:/|\.|$|\x22|\x27).*"
+  },
+  `import $source` as $match where {
+    $source <: r".*(?:^|/|\x22|\x27)(?:core|db|presentation|provider|test|tests|fixtures)(?:/|\.|$|\x22|\x27).*"
+  },
+  `export {$_} from $source` as $match where {
+    $source <: r".*(?:^|/|\x22|\x27)(?:core|db|presentation|provider|test|tests|fixtures)(?:/|\.|$|\x22|\x27).*"
+  },
+  `export type {$_} from $source` as $match where {
+    $source <: r".*(?:^|/|\x22|\x27)(?:core|db|presentation|provider|test|tests|fixtures)(?:/|\.|$|\x22|\x27).*"
+  },
+  `export * from $source` as $match where {
+    $source <: r".*(?:^|/|\x22|\x27)(?:core|db|presentation|provider|test|tests|fixtures)(?:/|\.|$|\x22|\x27).*"
+  },
+  `import($source)` as $match where {
+    $source <: r".*(?:^|/|\x22|\x27)(?:core|db|presentation|provider|test|tests|fixtures)(?:/|\.|$|\x22|\x27).*"
+  },
+  TsImportType() as $match where {
+    $match <: r".*(?:^|/|\x22|\x27)(?:core|db|presentation|provider|test|tests|fixtures)(?:/|\.|$|\x22|\x27).*"
+  }
+} where {
+  register_diagnostic(span=$match, message="api-architecture/no-dto-root-implementation-detail: keep DTO roots on passive contract modules; implementation details stay behind their owning implementation package.")
+}

--- a/tools/biome/plugins/api-architecture/no-dto-root-inter-module.grit
+++ b/tools/biome/plugins/api-architecture/no-dto-root-inter-module.grit
@@ -1,0 +1,15 @@
+engine biome(1.0)
+language js(typescript, jsx)
+
+or {
+  `import $_ from $source` as $match where { $source <: r".*inter-module.*" },
+  `import * as $_ from $source` as $match where { $source <: r".*inter-module.*" },
+  `import $source` as $match where { $source <: r".*inter-module.*" },
+  `export {$_} from $source` as $match where { $source <: r".*inter-module.*" },
+  `export type {$_} from $source` as $match where { $source <: r".*inter-module.*" },
+  `export * from $source` as $match where { $source <: r".*inter-module.*" },
+  `import($source)` as $match where { $source <: r".*inter-module.*" },
+  TsImportType() as $match where { $match <: r".*inter-module.*" }
+} where {
+  register_diagnostic(span=$match, message="api-architecture/no-dto-root-inter-module: export synchronous contracts only from the producer DTO /inter-module subpath; keep the DTO root passive.")
+}

--- a/tools/biome/test/api-architecture-fixtures.d.ts
+++ b/tools/biome/test/api-architecture-fixtures.d.ts
@@ -1,0 +1,1 @@
+declare module '@shipfox/a-dto/inter-module/*';

--- a/tools/biome/test/api-architecture-plugins.test.ts
+++ b/tools/biome/test/api-architecture-plugins.test.ts
@@ -1,0 +1,145 @@
+import assert from 'node:assert/strict';
+import {execFile} from 'node:child_process';
+import {readFile} from 'node:fs/promises';
+import {dirname, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {promisify} from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const packageDirectory = dirname(fileURLToPath(import.meta.url));
+const workspaceRoot = resolve(packageDirectory, '../../..');
+const biomeCheck = resolve(workspaceRoot, 'tools/biome/bin/biome-check.js');
+const fixtureConfig = resolve(
+  workspaceRoot,
+  'tools/biome/plugins/api-architecture/fixtures/biome.fixture.json',
+);
+const fixtureRoot = resolve(workspaceRoot, 'tools/biome/plugins/api-architecture/fixtures');
+
+const pluginFixtures = [
+  {
+    approvedBoundaryPattern: /producer DTO \/inter-module subpath/u,
+    rejectedLocations: [
+      /src\/index\.ts:1:1/u,
+      /src\/index\.ts:3:1/u,
+      /src\/index\.ts:4:1/u,
+      /src\/index\.ts:5:1/u,
+      /src\/index\.ts:7:1/u,
+      /src\/index\.ts:8:1/u,
+      /src\/index\.ts:9:1/u,
+      /src\/index\.ts:11:23/u,
+      /src\/index\.ts:12:23/u,
+    ],
+    ruleName: 'no-dto-root-inter-module',
+  },
+  {
+    approvedBoundaryPattern: /passive contract modules/u,
+    rejectedLocations: [
+      /src\/index\.ts:1:1/u,
+      /src\/index\.ts:3:1/u,
+      /src\/index\.ts:4:1/u,
+      /src\/index\.ts:5:1/u,
+      /src\/index\.ts:7:1/u,
+      /src\/index\.ts:8:1/u,
+      /src\/index\.ts:9:1/u,
+      /src\/index\.ts:11:23/u,
+      /src\/index\.ts:12:18/u,
+    ],
+    ruleName: 'no-dto-root-implementation-detail',
+  },
+  {
+    approvedBoundaryPattern: /implementation or composition packages/u,
+    rejectedLocations: [
+      /src\/rejected\.ts:1:1/u,
+      /src\/rejected\.ts:3:1/u,
+      /src\/rejected\.ts:4:1/u,
+      /src\/rejected\.ts:5:1/u,
+      /src\/rejected\.ts:7:23/u,
+      /src\/rejected\.ts:8:23/u,
+      /src\/rejected\.test\.ts:1:1/u,
+      /test\/rejected\.ts:1:1/u,
+      /test\/rejected\.ts:2:1/u,
+      /test\/rejected\.ts:3:1/u,
+      /test\/setup\.ts:1:1/u,
+      /tests\/rejected\.ts:1:1/u,
+    ],
+    ruleName: 'no-dto-inter-module-import',
+  },
+] as const;
+
+describe('api-architecture Biome plugins', () => {
+  for (const fixture of pluginFixtures) {
+    const ruleRoot = resolve(fixtureRoot, fixture.ruleName);
+
+    test(`${fixture.ruleName} reports each rejected source expression`, async () => {
+      await assert.rejects(
+        execFileAsync(
+          process.execPath,
+          [biomeCheck, '--config-path', fixtureConfig, resolve(ruleRoot, 'rejected')],
+          {cwd: workspaceRoot},
+        ),
+        (error: unknown) => {
+          const commandError = error as {stdout?: string; stderr?: string};
+          const output = `${commandError.stdout ?? ''}${commandError.stderr ?? ''}`;
+          const rulePattern = new RegExp(`api-architecture/${fixture.ruleName}`, 'gu');
+
+          assert.equal(output.match(rulePattern)?.length, fixture.rejectedLocations.length);
+          assert.match(output, fixture.approvedBoundaryPattern);
+          for (const location of fixture.rejectedLocations) assert.match(output, location);
+          return true;
+        },
+      );
+    });
+
+    test(`${fixture.ruleName} accepts equivalent passive-contract expressions`, async () => {
+      const {stdout, stderr} = await execFileAsync(
+        process.execPath,
+        [biomeCheck, '--config-path', fixtureConfig, resolve(ruleRoot, 'allowed')],
+        {cwd: workspaceRoot},
+      );
+
+      assert.doesNotMatch(
+        `${stdout}${stderr}`,
+        new RegExp(`api-architecture/${fixture.ruleName}`, 'u'),
+      );
+    });
+  }
+
+  test('registers production rules without excluding tests or setup files', async () => {
+    const rootConfig = JSON.parse(await readFile(resolve(workspaceRoot, 'biome.json'), 'utf8')) as {
+      plugins: {includes: string[]; path: string}[];
+    };
+    const apiPlugins = rootConfig.plugins.filter(({path}) =>
+      path.startsWith('./tools/biome/plugins/api-architecture/'),
+    );
+
+    assert.deepEqual(apiPlugins, [
+      {
+        path: './tools/biome/plugins/api-architecture/no-dto-root-inter-module.grit',
+        includes: [
+          '**/libs/api/**/*-dto/src/index.ts',
+          '!**/dist/**',
+          '!**/node_modules/**',
+          '!**/coverage/**',
+        ],
+      },
+      {
+        path: './tools/biome/plugins/api-architecture/no-dto-root-implementation-detail.grit',
+        includes: [
+          '**/libs/api/**/*-dto/src/index.ts',
+          '!**/dist/**',
+          '!**/node_modules/**',
+          '!**/coverage/**',
+        ],
+      },
+      {
+        path: './tools/biome/plugins/api-architecture/no-dto-inter-module-import.grit',
+        includes: [
+          '**/libs/api/**/*-dto/**',
+          '!**/dist/**',
+          '!**/node_modules/**',
+          '!**/coverage/**',
+        ],
+      },
+    ]);
+  });
+});

--- a/tools/biome/test/client-architecture-external.test.ts
+++ b/tools/biome/test/client-architecture-external.test.ts
@@ -10,6 +10,7 @@ const execFileAsync = promisify(execFile);
 const tarEntryLinePattern = /\r?\n/u;
 const testDirectory = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(testDirectory, '..');
+const EXTERNAL_CONSUMER_TEST_TIMEOUT_MS = 30_000;
 const fixtureTemplate = resolve(
   packageRoot,
   'plugins/client-architecture/fixtures/external-consumer',
@@ -129,42 +130,50 @@ describe('packed client-architecture Biome plugins', () => {
     }
   });
 
-  test('runs from an installed package in an external repository root', async () => {
-    const temporaryRoot = await mkdtemp(join(tmpdir(), 'shipfox-biome-external-'));
-    try {
-      const tarball = await packBiome(temporaryRoot);
-      const externalRoot = join(temporaryRoot, 'consumer');
-      await cp(fixtureTemplate, externalRoot, {recursive: true});
-      await installPackedBiome(externalRoot, tarball);
+  test(
+    'runs from an installed package in an external repository root',
+    async () => {
+      const temporaryRoot = await mkdtemp(join(tmpdir(), 'shipfox-biome-external-'));
+      try {
+        const tarball = await packBiome(temporaryRoot);
+        const externalRoot = join(temporaryRoot, 'consumer');
+        await cp(fixtureTemplate, externalRoot, {recursive: true});
+        await installPackedBiome(externalRoot, tarball);
 
-      const nodeModulesFixture = join(externalRoot, excludedFixtureFiles[4]);
-      await mkdir(dirname(nodeModulesFixture), {recursive: true});
-      await writeFile(
-        nodeModulesFixture,
-        "\n\nimport type {ProjectResponseDto as Project} from '@shipfox/api-projects-dto';\n\nexport type {Project};\n",
-      );
-
-      for (const fixture of externalRuleFixtures) {
-        const allowed = await runBiome(externalRoot, fixture.allowed);
-        assert.equal(allowed.code, 0, `${fixture.name} allowed fixture failed:\n${allowed.output}`);
-
-        const rejected = await runBiome(externalRoot, fixture.rejected);
-        assert.notEqual(rejected.code, 0, `${fixture.name} rejected fixture passed`);
-        assert.match(rejected.output, new RegExp(`client-architecture/${fixture.name}`, 'u'));
-        assert.match(rejected.output, new RegExp(`${escapedRegExp(fixture.rejected)}:3`, 'u'));
-      }
-
-      const fullFixture = await runBiome(externalRoot, '.');
-      assert.notEqual(fullFixture.code, 0, 'The external rejected fixtures unexpectedly passed');
-      for (const excludedPath of excludedFixtureFiles) {
-        assert.doesNotMatch(
-          fullFixture.output,
-          new RegExp(escapedRegExp(excludedPath), 'u'),
-          `Excluded fixture produced a diagnostic: ${excludedPath}`,
+        const nodeModulesFixture = join(externalRoot, excludedFixtureFiles[4]);
+        await mkdir(dirname(nodeModulesFixture), {recursive: true});
+        await writeFile(
+          nodeModulesFixture,
+          "\n\nimport type {ProjectResponseDto as Project} from '@shipfox/api-projects-dto';\n\nexport type {Project};\n",
         );
+
+        for (const fixture of externalRuleFixtures) {
+          const allowed = await runBiome(externalRoot, fixture.allowed);
+          assert.equal(
+            allowed.code,
+            0,
+            `${fixture.name} allowed fixture failed:\n${allowed.output}`,
+          );
+
+          const rejected = await runBiome(externalRoot, fixture.rejected);
+          assert.notEqual(rejected.code, 0, `${fixture.name} rejected fixture passed`);
+          assert.match(rejected.output, new RegExp(`client-architecture/${fixture.name}`, 'u'));
+          assert.match(rejected.output, new RegExp(`${escapedRegExp(fixture.rejected)}:3`, 'u'));
+        }
+
+        const fullFixture = await runBiome(externalRoot, '.');
+        assert.notEqual(fullFixture.code, 0, 'The external rejected fixtures unexpectedly passed');
+        for (const excludedPath of excludedFixtureFiles) {
+          assert.doesNotMatch(
+            fullFixture.output,
+            new RegExp(escapedRegExp(excludedPath), 'u'),
+            `Excluded fixture produced a diagnostic: ${excludedPath}`,
+          );
+        }
+      } finally {
+        await rm(temporaryRoot, {force: true, recursive: true});
       }
-    } finally {
-      await rm(temporaryRoot, {force: true, recursive: true});
-    }
-  });
+    },
+    EXTERNAL_CONSUMER_TEST_TIMEOUT_MS,
+  );
 });


### PR DESCRIPTION
## Summary

API DTO source restrictions should fail in the normal Biome check instead of only in the separate architecture inventory scanner. This adds dedicated GritQL rules for DTO root purity and inter-module imports, registers them in the repository Biome configuration, and covers the supported import and re-export forms across source, test, and setup paths.

The API architecture policy continues to own package inventory, manifest, export-map, context, and SPI checks. The backend architecture guide documents that enforcement split, and a patch changeset publishes the new `@shipfox/biome` rules.

## Validation

- `mise exec -- turbo test --filter=@shipfox/biome --filter=@shipfox/api-architecture-policy`
- `mise exec -- turbo type --filter=@shipfox/biome --filter=@shipfox/api-architecture-policy`
- `mise exec -- turbo check --filter=@shipfox/biome --filter=@shipfox/api-architecture-policy`
- `mise exec -- pnpm check:api-context-inventory`
- targeted repository Biome scan across API sources and changed tooling
- `mise exec -- npm pack --dry-run --json ./tools/biome`

Closes ENG-1209

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves source‑local API DTO architecture checks into Biome so violations are flagged at the exact import/export. Keeps registry, manifest, export‑map, and context/SPI checks in `@shipfox/api-architecture-policy` to satisfy ENG-1209.

- **New Features**
  - Added Biome GritQL rules: `no-dto-root-inter-module`, `no-dto-root-implementation-detail`, `no-dto-inter-module-import`.
  - Registered plugins in root `biome.json` (covers `libs/api/**/*-dto/**`; excludes `dist`, `node_modules`, `coverage`; keeps tests and setup). Fixture dirs are excluded from repo scans.
  - Added focused fixture harness and tests validating allowed/rejected static imports, re‑exports, namespace/aliased imports, type‑only, dynamic, and side‑effect imports.
  - Published patch changeset for `@shipfox/biome`.

- **Refactors**
  - Removed superseded source‑local DTO checks from `@shipfox/api-architecture-policy` and updated tests; policy now reports only registry/manifest/export‑map/context‑owned issues and missing explicit `/inter-module` export.
  - Updated backend architecture docs to describe the Biome vs. policy enforcement split.
  - Increased timeout for the packed Biome external consumer test to 30s to reduce CI flakiness.

<sup>Written for commit d515bf17700fb93b3334dda4a273129ca1a3bf0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

