### PR TITLE
Make Dependency Cruiser authoritative for API source boundaries

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -3,7 +3,7 @@ const path = require('node:path');
 const workspaceRoot = __dirname;
 const currentDirectory = process.cwd();
 const currentPackage = require(path.join(currentDirectory, 'package.json'));
-const {apiContextImplementationPaths} = require('./api-contexts.cjs');
+const {createApiArchitectureRules} = require('./api-contexts.cjs');
 
 const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 const toPosixPath = (value) => value.split(path.sep).join('/');
@@ -24,30 +24,10 @@ const currentE2eLayer =
 const e2eSourcePath = '^(?:src|test|tests)(?:/|$)|^playwright\\.config\\.ts$';
 const workspacePathPattern = (workspacePath) =>
   `^${escapeRegExp(toPosixPath(path.relative(currentDirectory, path.join(workspaceRoot, workspacePath))))}/`;
-const currentApiContext = Object.entries(apiContextImplementationPaths).find(([, packagePaths]) =>
-  packagePaths.some((packagePath) => {
-    const packageDirectory = path.join(workspaceRoot, packagePath);
-    const relativePath = path.relative(packageDirectory, currentDirectory);
-    return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath));
-  }),
-)?.[0];
-const crossContextImplementationPaths = currentApiContext
-  ? Object.entries(apiContextImplementationPaths)
-      .filter(([context]) => context !== currentApiContext)
-      .flatMap(([, packagePaths]) => packagePaths.map(workspacePathPattern))
-  : [];
-const currentApiContextRules = currentApiContext
-  ? [
-      {
-        name: 'api-no-cross-context-implementation-imports',
-        comment:
-          'API bounded contexts may use peer DTO and /inter-module contracts, but production code must not import another context implementation package root or subpath.',
-        severity: 'error',
-        from: {path: '^src/', pathNot: '\\.test\\.ts$'},
-        to: {path: crossContextImplementationPaths},
-      },
-    ]
-  : [];
+const currentApiArchitectureRules = createApiArchitectureRules({
+  currentDirectory,
+  workspaceRoot,
+});
 const isBelowWorkspacePath = (workspacePath) => {
   const relativePath = path.relative(path.join(workspaceRoot, workspacePath), currentDirectory);
   return relativePath !== '' && !relativePath.startsWith('..') && !path.isAbsolute(relativePath);
@@ -192,7 +172,7 @@ module.exports = {
         ]
       : []),
     ...currentE2eRules,
-    ...currentApiContextRules,
+    ...currentApiArchitectureRules,
     ...(currentPackage.name === '@shipfox/node-temporal'
       ? [
           {

--- a/api-contexts.cjs
+++ b/api-contexts.cjs
@@ -1,3 +1,5 @@
+const path = require('node:path');
+
 const architecturePackages = {
   implementations: {
     agent: ['libs/api/agent'],
@@ -82,10 +84,224 @@ const architecturePackages = {
   'composition-root': {api: ['libs/api/server']},
 };
 
-const apiContextImplementationPaths = architecturePackages.implementations;
+const apiArchitectureEdgePolicy = {
+  implementations: {
+    implementations: {
+      decision: 'same-context',
+      rule: 'api-no-foreign-implementation-imports',
+      violation: 'Foreign implementation import',
+    },
+    dto: {decision: 'allow'},
+    'shared-semantic': {decision: 'allow'},
+    'shared-infrastructure': {decision: 'allow'},
+    spi: {
+      decision: 'same-context',
+      rule: 'api-no-foreign-same-context-spi-imports',
+      violation: 'Foreign same-context SPI import',
+    },
+    'composition-root': {decision: 'allow'},
+  },
+  dto: {
+    implementations: {
+      decision: 'never',
+      rule: 'api-no-dto-implementation-imports',
+      violation: 'DTO implementation import',
+    },
+    // dto->dto is enforced separately: sourceEdgeViolation blocks specifiers ending in
+    // '/inter-module' regardless of this decision. Changing this value has no effect.
+    dto: {decision: 'allow'},
+    'shared-semantic': {decision: 'allow'},
+    'shared-infrastructure': {decision: 'allow'},
+    spi: {
+      decision: 'never',
+      rule: 'api-no-dto-spi-imports',
+      violation: 'DTO SPI import',
+    },
+    'composition-root': {decision: 'allow'},
+  },
+  'shared-semantic': {
+    implementations: {
+      decision: 'never',
+      rule: 'api-no-shared-semantic-implementation-imports',
+      violation: 'Shared semantic implementation import',
+    },
+    dto: {decision: 'allow'},
+    'shared-semantic': {decision: 'allow'},
+    'shared-infrastructure': {decision: 'allow'},
+    spi: {
+      decision: 'never',
+      rule: 'api-no-shared-semantic-spi-imports',
+      violation: 'Shared semantic SPI import',
+    },
+    'composition-root': {decision: 'allow'},
+  },
+  'shared-infrastructure': {
+    implementations: {decision: 'allow'},
+    dto: {decision: 'allow'},
+    'shared-semantic': {decision: 'allow'},
+    'shared-infrastructure': {decision: 'allow'},
+    spi: {decision: 'allow'},
+    'composition-root': {decision: 'allow'},
+  },
+  spi: {
+    implementations: {
+      decision: 'same-context',
+      rule: 'api-no-foreign-spi-implementation-imports',
+      violation: 'Foreign SPI implementation import',
+    },
+    dto: {decision: 'allow'},
+    'shared-semantic': {decision: 'allow'},
+    'shared-infrastructure': {decision: 'allow'},
+    spi: {
+      decision: 'same-context',
+      rule: 'api-no-foreign-spi-imports',
+      violation: 'Foreign SPI import',
+    },
+    'composition-root': {decision: 'allow'},
+  },
+  'composition-root': {
+    implementations: {decision: 'allow'},
+    dto: {decision: 'allow'},
+    'shared-semantic': {decision: 'allow'},
+    'shared-infrastructure': {decision: 'allow'},
+    spi: {decision: 'allow'},
+    'composition-root': {decision: 'allow'},
+  },
+};
+
+const validEdgeDecisions = new Set(['allow', 'same-context', 'never']);
+
+function validateApiArchitectureEdgePolicy(
+  packages = architecturePackages,
+  edgePolicy = apiArchitectureEdgePolicy,
+) {
+  const classifications = Object.keys(packages);
+  const errors = [];
+
+  for (const classification of classifications) {
+    const row = edgePolicy[classification];
+    if (!row) {
+      errors.push(`Missing API architecture edge policy row: ${classification}`);
+      continue;
+    }
+    for (const targetClassification of classifications) {
+      const edge = row[targetClassification];
+      if (!edge) {
+        errors.push(
+          `Missing API architecture edge policy decision: ${classification} -> ${targetClassification}`,
+        );
+        continue;
+      }
+      if (!validEdgeDecisions.has(edge.decision)) {
+        errors.push(
+          `Invalid API architecture edge policy decision: ${classification} -> ${targetClassification}`,
+        );
+      }
+      if (edge.decision !== 'allow' && (!edge.rule || !edge.violation)) {
+        errors.push(
+          `API architecture edge policy violation metadata is incomplete: ${classification} -> ${targetClassification}`,
+        );
+      }
+    }
+    for (const targetClassification of Object.keys(row)) {
+      if (!classifications.includes(targetClassification)) {
+        errors.push(
+          `API architecture edge policy references unknown classification: ${classification} -> ${targetClassification}`,
+        );
+      }
+    }
+  }
+
+  for (const classification of Object.keys(edgePolicy)) {
+    if (!classifications.includes(classification)) {
+      errors.push(`API architecture edge policy has unknown row: ${classification}`);
+    }
+  }
+
+  return errors.sort();
+}
+
+const edgePolicyErrors = validateApiArchitectureEdgePolicy();
+if (edgePolicyErrors.length > 0) {
+  throw new Error(edgePolicyErrors.join('\n'));
+}
+
+function architecturePackageEntries(packages) {
+  return Object.entries(packages).flatMap(([classification, contexts]) =>
+    Object.entries(contexts).flatMap(([context, packagePaths]) =>
+      packagePaths.map((packagePath) => ({classification, context, packagePath})),
+    ),
+  );
+}
+
+function toPosixPath(value) {
+  return value.split(path.sep).join('/');
+}
+
+function packageEntryForDirectory(currentDirectory, workspaceRoot, packages) {
+  return architecturePackageEntries(packages).find(({packagePath}) => {
+    const relativePath = path.relative(path.join(workspaceRoot, packagePath), currentDirectory);
+    return (
+      relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath))
+    );
+  });
+}
+
+function createApiArchitectureRules({
+  currentDirectory = process.cwd(),
+  workspaceRoot = __dirname,
+  packages = architecturePackages,
+  edgePolicy = apiArchitectureEdgePolicy,
+  sourcePath = '^(?!\\.\\./)(?!node_modules/)(?!dist/)(?!coverage/).*\\.(?:[cm]?[jt]sx?)$',
+}) {
+  const policyErrors = validateApiArchitectureEdgePolicy(packages, edgePolicy);
+  if (policyErrors.length > 0) throw new Error(policyErrors.join('\n'));
+
+  const importer = packageEntryForDirectory(currentDirectory, workspaceRoot, packages);
+  if (!importer) return [];
+
+  const targetEntries = architecturePackageEntries(packages);
+  const rules = [];
+  for (const targetClassification of Object.keys(packages)) {
+    const edge = edgePolicy[importer.classification][targetClassification];
+    if (edge.decision === 'allow') continue;
+
+    const targets = targetEntries.filter(
+      (target) =>
+        target.classification === targetClassification &&
+        (edge.decision === 'never' || target.context !== importer.context),
+    );
+    if (targets.length === 0) continue;
+
+    rules.push({
+      name: edge.rule,
+      comment: `${edge.violation}; this source boundary is controlled by api-contexts.cjs.`,
+      severity: 'error',
+      from: {path: sourcePath},
+      to: {
+        path: targets.map(
+          ({packagePath}) =>
+            `^${escapeRegExp(toPosixPath(path.relative(currentDirectory, path.join(workspaceRoot, packagePath))))}/`,
+        ),
+      },
+    });
+  }
+  return rules;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 const apiContextExemptPaths = {
   'shared-infrastructure': architecturePackages['shared-infrastructure'].api,
   'composition-root': architecturePackages['composition-root'].api,
 };
 
-module.exports = {architecturePackages, apiContextExemptPaths, apiContextImplementationPaths};
+module.exports = {
+  apiArchitectureEdgePolicy,
+  apiContextExemptPaths,
+  architecturePackages,
+  createApiArchitectureRules,
+  validateApiArchitectureEdgePolicy,
+};

--- a/fixtures/depcruise-api-edges/config.cjs
+++ b/fixtures/depcruise-api-edges/config.cjs
@@ -1,0 +1,33 @@
+const {apiArchitectureEdgePolicy, createApiArchitectureRules} = require('../../api-contexts.cjs');
+
+const architecturePackages = {
+  implementations: {
+    agent: ['packages/consumers/implementation-foreign'],
+    integrations: [
+      'packages/api/integration/core',
+      'packages/api/integration/provider-with-an-unrelated-name',
+      'packages/consumers/implementation-allowed',
+    ],
+  },
+  dto: {agent: ['packages/consumers/dto-foreign']},
+  'shared-semantic': {common: ['packages/consumers/semantic-foreign']},
+  'shared-infrastructure': {common: []},
+  spi: {
+    integrations: ['packages/api/integration/spi', 'packages/consumers/spi-allowed'],
+    auth: ['packages/consumers/spi-foreign'],
+  },
+  'composition-root': {api: []},
+};
+
+module.exports = {
+  forbidden: createApiArchitectureRules({
+    currentDirectory: process.env.DEPCRUISE_FIXTURE_PACKAGE || process.cwd(),
+    workspaceRoot: __dirname,
+    packages: architecturePackages,
+    edgePolicy: apiArchitectureEdgePolicy,
+  }),
+  options: {
+    doNotFollow: {path: 'node_modules'},
+    tsPreCompilationDeps: 'specify',
+  },
+};

--- a/fixtures/depcruise-api-edges/packages/api/integration/core/package.json
+++ b/fixtures/depcruise-api-edges/packages/api/integration/core/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@fixture/integration-runtime",
+  "private": true,
+  "type": "module"
+}

--- a/fixtures/depcruise-api-edges/packages/api/integration/core/src/index.ts
+++ b/fixtures/depcruise-api-edges/packages/api/integration/core/src/index.ts
@@ -1,0 +1,1 @@
+export const fixtureValue = 'integration-core';

--- a/fixtures/depcruise-api-edges/packages/api/integration/provider-with-an-unrelated-name/package.json
+++ b/fixtures/depcruise-api-edges/packages/api/integration/provider-with-an-unrelated-name/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@fixture/provider-contract-owner",
+  "private": true,
+  "type": "module"
+}

--- a/fixtures/depcruise-api-edges/packages/api/integration/provider-with-an-unrelated-name/src/index.ts
+++ b/fixtures/depcruise-api-edges/packages/api/integration/provider-with-an-unrelated-name/src/index.ts
@@ -1,0 +1,1 @@
+export const fixtureValue = 'integration-provider';

--- a/fixtures/depcruise-api-edges/packages/api/integration/spi/package.json
+++ b/fixtures/depcruise-api-edges/packages/api/integration/spi/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@fixture/integration-provider-ports",
+  "private": true,
+  "type": "module"
+}

--- a/fixtures/depcruise-api-edges/packages/api/integration/spi/src/index.ts
+++ b/fixtures/depcruise-api-edges/packages/api/integration/spi/src/index.ts
@@ -1,0 +1,1 @@
+export const fixtureValue = 'integration-spi';

--- a/fixtures/depcruise-api-edges/packages/consumers/dto-foreign/package.json
+++ b/fixtures/depcruise-api-edges/packages/consumers/dto-foreign/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@fixture/passive-contracts",
+  "private": true,
+  "type": "module"
+}

--- a/fixtures/depcruise-api-edges/packages/consumers/dto-foreign/src/index.ts
+++ b/fixtures/depcruise-api-edges/packages/consumers/dto-foreign/src/index.ts
@@ -1,0 +1,4 @@
+import {fixtureValue as implementationValue} from '../../../api/integration/provider-with-an-unrelated-name/src/index.ts';
+import {fixtureValue as spiValue} from '../../../api/integration/spi/src/index.ts';
+
+export {implementationValue, spiValue};

--- a/fixtures/depcruise-api-edges/packages/consumers/implementation-allowed/package.json
+++ b/fixtures/depcruise-api-edges/packages/consumers/implementation-allowed/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@fixture/integration-composition",
+  "private": true,
+  "type": "module"
+}

--- a/fixtures/depcruise-api-edges/packages/consumers/implementation-allowed/src/index.ts
+++ b/fixtures/depcruise-api-edges/packages/consumers/implementation-allowed/src/index.ts
@@ -1,0 +1,4 @@
+import {fixtureValue as providerValue} from '../../../api/integration/provider-with-an-unrelated-name/src/index.ts';
+import {fixtureValue as spiValue} from '../../../api/integration/spi/src/index.ts';
+
+export {providerValue, spiValue};

--- a/fixtures/depcruise-api-edges/packages/consumers/implementation-foreign/fixtures/consumer.cts
+++ b/fixtures/depcruise-api-edges/packages/consumers/implementation-foreign/fixtures/consumer.cts
@@ -1,0 +1,1 @@
+export {fixtureValue} from '../../../api/integration/provider-with-an-unrelated-name/src/index.ts';

--- a/fixtures/depcruise-api-edges/packages/consumers/implementation-foreign/fixtures/consumer.js
+++ b/fixtures/depcruise-api-edges/packages/consumers/implementation-foreign/fixtures/consumer.js
@@ -1,0 +1,1 @@
+export {fixtureValue} from '../../../api/integration/provider-with-an-unrelated-name/src/index.ts';

--- a/fixtures/depcruise-api-edges/packages/consumers/implementation-foreign/package.json
+++ b/fixtures/depcruise-api-edges/packages/consumers/implementation-foreign/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@fixture/consumer-implementation",
+  "private": true,
+  "type": "module"
+}

--- a/fixtures/depcruise-api-edges/packages/consumers/implementation-foreign/setup/consumer.cjs
+++ b/fixtures/depcruise-api-edges/packages/consumers/implementation-foreign/setup/consumer.cjs
@@ -1,0 +1,1 @@
+module.exports = require('../../../api/integration/provider-with-an-unrelated-name/src/index.ts');

--- a/fixtures/depcruise-api-edges/packages/consumers/implementation-foreign/setup/setup.mjs
+++ b/fixtures/depcruise-api-edges/packages/consumers/implementation-foreign/setup/setup.mjs
@@ -1,0 +1,1 @@
+export const fixtureModule = import('../../../api/integration/spi/src/index.ts');

--- a/fixtures/depcruise-api-edges/packages/consumers/implementation-foreign/src/consumer.ts
+++ b/fixtures/depcruise-api-edges/packages/consumers/implementation-foreign/src/consumer.ts
@@ -1,0 +1,3 @@
+import {fixtureValue} from '../../../api/integration/provider-with-an-unrelated-name/src/index.ts';
+
+export {fixtureValue};

--- a/fixtures/depcruise-api-edges/packages/consumers/implementation-foreign/test/consumer.ts
+++ b/fixtures/depcruise-api-edges/packages/consumers/implementation-foreign/test/consumer.ts
@@ -1,0 +1,1 @@
+export {fixtureValue} from '../../../api/integration/provider-with-an-unrelated-name/src/index.ts';

--- a/fixtures/depcruise-api-edges/packages/consumers/implementation-foreign/test/consumer.tsx
+++ b/fixtures/depcruise-api-edges/packages/consumers/implementation-foreign/test/consumer.tsx
@@ -1,0 +1,1 @@
+export {fixtureValue} from '../../../api/integration/provider-with-an-unrelated-name/src/index.ts';

--- a/fixtures/depcruise-api-edges/packages/consumers/implementation-foreign/tests/consumer.jsx
+++ b/fixtures/depcruise-api-edges/packages/consumers/implementation-foreign/tests/consumer.jsx
@@ -1,0 +1,1 @@
+export {fixtureValue} from '../../../api/integration/provider-with-an-unrelated-name/src/index.ts';

--- a/fixtures/depcruise-api-edges/packages/consumers/implementation-foreign/tests/consumer.mts
+++ b/fixtures/depcruise-api-edges/packages/consumers/implementation-foreign/tests/consumer.mts
@@ -1,0 +1,3 @@
+import type {fixtureValue} from '../../../api/integration/spi/src/index.ts';
+
+export type {fixtureValue};

--- a/fixtures/depcruise-api-edges/packages/consumers/implementation-foreign/vitest.config.mts
+++ b/fixtures/depcruise-api-edges/packages/consumers/implementation-foreign/vitest.config.mts
@@ -1,0 +1,1 @@
+export {fixtureValue} from '../../api/integration/provider-with-an-unrelated-name/src/index.ts';

--- a/fixtures/depcruise-api-edges/packages/consumers/semantic-foreign/package.json
+++ b/fixtures/depcruise-api-edges/packages/consumers/semantic-foreign/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@fixture/shared-language",
+  "private": true,
+  "type": "module"
+}

--- a/fixtures/depcruise-api-edges/packages/consumers/semantic-foreign/src/index.ts
+++ b/fixtures/depcruise-api-edges/packages/consumers/semantic-foreign/src/index.ts
@@ -1,0 +1,4 @@
+import {fixtureValue as implementationValue} from '../../../api/integration/provider-with-an-unrelated-name/src/index.ts';
+import {fixtureValue as spiValue} from '../../../api/integration/spi/src/index.ts';
+
+export {implementationValue, spiValue};

--- a/fixtures/depcruise-api-edges/packages/consumers/spi-allowed/package.json
+++ b/fixtures/depcruise-api-edges/packages/consumers/spi-allowed/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@fixture/integration-spi-consumer",
+  "private": true,
+  "type": "module"
+}

--- a/fixtures/depcruise-api-edges/packages/consumers/spi-allowed/src/index.ts
+++ b/fixtures/depcruise-api-edges/packages/consumers/spi-allowed/src/index.ts
@@ -1,0 +1,4 @@
+import {fixtureValue as implementationValue} from '../../../api/integration/core/src/index.ts';
+import {fixtureValue as spiValue} from '../../../api/integration/spi/src/index.ts';
+
+export {implementationValue, spiValue};

--- a/fixtures/depcruise-api-edges/packages/consumers/spi-foreign/package.json
+++ b/fixtures/depcruise-api-edges/packages/consumers/spi-foreign/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@fixture/foreign-spi-consumer",
+  "private": true,
+  "type": "module"
+}

--- a/fixtures/depcruise-api-edges/packages/consumers/spi-foreign/src/index.ts
+++ b/fixtures/depcruise-api-edges/packages/consumers/spi-foreign/src/index.ts
@@ -1,0 +1,4 @@
+import {fixtureValue as implementationValue} from '../../../api/integration/provider-with-an-unrelated-name/src/index.ts';
+import {fixtureValue as spiValue} from '../../../api/integration/spi/src/index.ts';
+
+export {implementationValue, spiValue};

--- a/tools/api-architecture-policy/src/api-context-inventory.ts
+++ b/tools/api-architecture-policy/src/api-context-inventory.ts
@@ -5,7 +5,17 @@ import process from 'node:process';
 import {fileURLToPath} from 'node:url';
 
 const require = createRequire(import.meta.url);
-const {architecturePackages} = require('../../../api-contexts.cjs') as {
+const {apiArchitectureEdgePolicy, architecturePackages} = require('../../../api-contexts.cjs') as {
+  apiArchitectureEdgePolicy: Record<
+    string,
+    Record<
+      string,
+      {
+        decision: 'allow' | 'same-context' | 'never';
+        violation?: string;
+      }
+    >
+  >;
   architecturePackages: Record<string, Record<string, string[]>>;
 };
 const repositoryRoot = fileURLToPath(new URL('../../../', import.meta.url));
@@ -25,6 +35,8 @@ const dependencyGroups = [
 const importExpression =
   /(?:import|export)\s+(?:type\s+)?(?:[^'"`]*?\s+from\s+)?['"]([^'"]+)['"]|import\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
 const sourceFileExpression = /\.(?:[cm]?[jt]sx?)$/;
+const dtoImplementationDetailExpression =
+  /(?:^|\/)(?:core|db|presentation|provider|test|tests|fixtures)(?:\/|\.|$)/;
 
 interface ClassifiedPath {
   classification: string;
@@ -84,37 +96,28 @@ function packageName(specifier: string): string {
     .join('/');
 }
 
-function importViolation(
+function sourceEdgeViolation(
   importer: ClassifiedPath,
   target: ClassifiedPath | undefined,
+  specifier: string,
 ): string | undefined {
   if (!target) return undefined;
+  const edge = apiArchitectureEdgePolicy[importer.classification]?.[target.classification];
+  if (!edge) {
+    throw new Error(
+      `Missing API architecture edge policy decision: ${importer.classification} -> ${target.classification}`,
+    );
+  }
+  if (importer.classification === 'dto' && target.classification === 'dto') {
+    if (specifier.endsWith('/inter-module')) return 'DTO inter-module import';
+    return undefined;
+  }
   if (
-    importer.classification === 'implementations' &&
-    target.classification === 'implementations' &&
-    importer.context !== target.context
+    edge.decision === 'allow' ||
+    (edge.decision === 'same-context' && importer.context === target.context)
   )
-    return 'Foreign implementation import';
-  if (importer.classification === 'dto' && target.classification === 'implementations')
-    return 'DTO implementation import';
-  if (importer.classification === 'dto' && target.classification === 'spi') return 'DTO SPI import';
-  if (importer.classification === 'shared-semantic' && target.classification === 'implementations')
-    return 'Shared semantic implementation import';
-  if (importer.classification === 'shared-semantic' && target.classification === 'spi')
-    return 'Shared semantic SPI import';
-  if (
-    importer.classification === 'implementations' &&
-    target.classification === 'spi' &&
-    importer.context !== target.context
-  )
-    return 'Foreign same-context SPI import';
-  if (
-    importer.classification === 'spi' &&
-    target.classification === 'implementations' &&
-    importer.context !== target.context
-  )
-    return 'Foreign SPI implementation import';
-  return undefined;
+    return undefined;
+  return edge.violation;
 }
 
 function manifestViolation(
@@ -141,6 +144,13 @@ function manifestViolation(
     importer.context !== target.context
   )
     return 'Foreign same-context SPI manifest edge';
+  return undefined;
+}
+
+function dtoRootExportViolation(specifier: string): string | undefined {
+  if (specifier.includes('inter-module')) return 'DTO root exports inter-module contract';
+  if (dtoImplementationDetailExpression.test(specifier))
+    return 'DTO root exports implementation detail';
   return undefined;
 }
 
@@ -243,6 +253,7 @@ export function auditPolicyFixture({
   dependencyGroup,
   dtoHasInterModuleEntry = true,
   dtoRootExportsInterModule = false,
+  dtoRootExportSpecifier,
   importerPath,
   sourceFile,
   targetPath,
@@ -250,6 +261,7 @@ export function auditPolicyFixture({
   dependencyGroup?: (typeof dependencyGroups)[number];
   dtoHasInterModuleEntry?: boolean;
   dtoRootExportsInterModule?: boolean;
+  dtoRootExportSpecifier?: string;
   importerPath: string;
   sourceFile?: string;
   targetPath?: string;
@@ -260,14 +272,22 @@ export function auditPolicyFixture({
   const errors: string[] = [];
 
   if (importer) {
-    const sourceViolation = importViolation(importer, target);
+    const sourceViolation = sourceEdgeViolation(
+      importer,
+      target,
+      sourceFile?.split(':').at(-1) ?? '',
+    );
     if (sourceFile && sourceViolation) errors.push(`${sourceViolation}: ${sourceFile}`);
     const dependencyViolation = manifestViolation(importer, target);
     if (dependencyGroup && dependencyViolation)
       errors.push(`${dependencyViolation}: ${dependencyGroup}`);
   }
   if (importer?.classification === 'dto' && dtoRootExportsInterModule && !dtoHasInterModuleEntry)
-    errors.push('DTO contract has no explicit inter-module export');
+    errors.push('DTO root exports inter-module contract');
+  if (importer?.classification === 'dto' && dtoRootExportSpecifier) {
+    const violation = dtoRootExportViolation(dtoRootExportSpecifier);
+    if (violation) errors.push(violation);
+  }
   return errors;
 }
 
@@ -292,6 +312,11 @@ export async function auditRepository(): Promise<string[]> {
     if (classification.classification === 'dto') {
       const indexPath = path.join(repositoryRoot, packagePath, 'src/index.ts');
       const indexSource = await readFile(indexPath, 'utf8');
+      for (const specifier of importSpecifiers(indexSource)) {
+        const violation = dtoRootExportViolation(specifier);
+        if (violation)
+          errors.push(`${violation}: dto-export:${packagePath}:src/index.ts:${specifier}`);
+      }
       if (sourceReExportsInterModule(indexSource) && !hasInterModuleEntry(manifest.exports)) {
         const violation = `dto-export:${packagePath}:package.json:missing-inter-module-entry`;
         errors.push(`DTO contract has no explicit inter-module export: ${violation}`);
@@ -304,7 +329,11 @@ export async function auditRepository(): Promise<string[]> {
       const source = await readFile(sourceFile, 'utf8');
       const relativeFile = toPosixPath(path.relative(repositoryRoot, sourceFile));
       for (const specifier of importSpecifiers(source)) {
-        const violation = importViolation(classification, packages.get(packageName(specifier)));
+        const violation = sourceEdgeViolation(
+          classification,
+          packages.get(packageName(specifier)),
+          specifier,
+        );
         if (violation) errors.push(`${violation}: import:${relativeFile}:${specifier}`);
       }
     }

--- a/tools/api-architecture-policy/test/api-architecture-edge-policy.test.ts
+++ b/tools/api-architecture-policy/test/api-architecture-edge-policy.test.ts
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import {execFile} from 'node:child_process';
+import {createRequire} from 'node:module';
+import {dirname, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {promisify} from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const require = createRequire(import.meta.url);
+const packageDirectory = dirname(fileURLToPath(import.meta.url));
+const workspaceRoot = resolve(packageDirectory, '../../..');
+const fixtureRoot = resolve(workspaceRoot, 'fixtures/depcruise-api-edges');
+const fixtureConfig = resolve(fixtureRoot, 'config.cjs');
+const dependencyCruiser = resolve(workspaceRoot, 'tools/depcruise/node_modules/.bin/depcruise');
+const noDependencyViolationsPattern = /no dependency violations found/u;
+const {
+  apiArchitectureEdgePolicy,
+  architecturePackages,
+  createApiArchitectureRules,
+  validateApiArchitectureEdgePolicy,
+} = require(resolve(workspaceRoot, 'api-contexts.cjs')) as {
+  apiArchitectureEdgePolicy: Record<string, Record<string, {decision: string}>>;
+  architecturePackages: Record<string, Record<string, string[]>>;
+  createApiArchitectureRules: (options: {
+    currentDirectory: string;
+    workspaceRoot: string;
+  }) => Array<{name: string}>;
+  validateApiArchitectureEdgePolicy: (
+    packages?: Record<string, Record<string, string[]>>,
+    edgePolicy?: Record<string, Record<string, {decision: string}>>,
+  ) => string[];
+};
+
+async function runFixture(fixtureName: string): Promise<string> {
+  const fixturePackage = resolve(fixtureRoot, 'packages/consumers', fixtureName);
+  try {
+    const result = await execFileAsync(dependencyCruiser, ['--config', fixtureConfig, '.'], {
+      cwd: fixturePackage,
+      env: {...process.env, DEPCRUISE_FIXTURE_PACKAGE: fixturePackage},
+    });
+    return `${result.stdout}${result.stderr}`;
+  } catch (error) {
+    const commandError = error as {stdout?: string; stderr?: string};
+    return `${commandError.stdout ?? ''}${commandError.stderr ?? ''}`;
+  }
+}
+
+describe('API Dependency Cruiser edge policy', () => {
+  test('declares an explicit decision for every registered classification pair', () => {
+    assert.deepEqual(validateApiArchitectureEdgePolicy(), []);
+
+    const expandedPackages = {
+      ...architecturePackages,
+      experimental: {future: ['packages/future']},
+    };
+    const errors = validateApiArchitectureEdgePolicy(expandedPackages, apiArchitectureEdgePolicy);
+    assert.deepEqual(errors, [
+      'Missing API architecture edge policy decision: composition-root -> experimental',
+      'Missing API architecture edge policy decision: dto -> experimental',
+      'Missing API architecture edge policy decision: implementations -> experimental',
+      'Missing API architecture edge policy decision: shared-infrastructure -> experimental',
+      'Missing API architecture edge policy decision: shared-semantic -> experimental',
+      'Missing API architecture edge policy decision: spi -> experimental',
+      'Missing API architecture edge policy row: experimental',
+    ]);
+  });
+
+  test('flags invalid decisions, incomplete violation metadata, and unknown classifications', () => {
+    const packages = {a: {ctx: ['packages/a']}, b: {ctx: ['packages/b']}};
+    const edgePolicy = {
+      a: {a: {decision: 'allow'}, b: {decision: 'bogus', rule: 'x', violation: 'y'}},
+      b: {a: {decision: 'never'}, b: {decision: 'allow'}, c: {decision: 'allow'}},
+      c: {a: {decision: 'allow'}, b: {decision: 'allow'}},
+    };
+
+    assert.deepEqual(validateApiArchitectureEdgePolicy(packages, edgePolicy), [
+      'API architecture edge policy has unknown row: c',
+      'API architecture edge policy references unknown classification: b -> c',
+      'API architecture edge policy violation metadata is incomplete: b -> a',
+      'Invalid API architecture edge policy decision: a -> b',
+    ]);
+  });
+
+  test('generates classification-aware rules for nested package paths', () => {
+    const rules = createApiArchitectureRules({
+      currentDirectory: resolve(workspaceRoot, 'libs/api/integration/core'),
+      workspaceRoot,
+    });
+
+    assert.deepEqual(
+      rules.map(({name}) => name),
+      ['api-no-foreign-implementation-imports'],
+    );
+  });
+
+  test('enforces every forbidden source-edge category across source variants and test roots', async () => {
+    const cases = [
+      [
+        'implementation-foreign',
+        ['api-no-foreign-implementation-imports', 'api-no-foreign-same-context-spi-imports'],
+      ],
+      ['dto-foreign', ['api-no-dto-implementation-imports', 'api-no-dto-spi-imports']],
+      [
+        'semantic-foreign',
+        ['api-no-shared-semantic-implementation-imports', 'api-no-shared-semantic-spi-imports'],
+      ],
+      ['spi-foreign', ['api-no-foreign-spi-implementation-imports', 'api-no-foreign-spi-imports']],
+    ] as const;
+
+    for (const [fixtureName, ruleNames] of cases) {
+      const output = await runFixture(fixtureName);
+      for (const ruleName of ruleNames) assert.match(output, new RegExp(ruleName, 'u'));
+      if (fixtureName === 'implementation-foreign') {
+        for (const sourcePath of [
+          'src/consumer.ts',
+          'test/consumer.ts',
+          'test/consumer.tsx',
+          'tests/consumer.mts',
+          'tests/consumer.jsx',
+          'fixtures/consumer.cts',
+          'fixtures/consumer.js',
+          'setup/setup.mjs',
+          'setup/consumer.cjs',
+          'vitest.config.mts',
+        ]) {
+          assert.ok(output.includes(sourcePath), `Dependency Cruiser did not report ${sourcePath}`);
+        }
+      }
+    }
+  });
+
+  test('preserves same-context Integrations implementation and SPI edges', async () => {
+    const output = await runFixture('implementation-allowed');
+    assert.match(output, noDependencyViolationsPattern);
+
+    const spiOutput = await runFixture('spi-allowed');
+    assert.match(spiOutput, noDependencyViolationsPattern);
+  });
+});

--- a/tools/api-architecture-policy/test/api-context-inventory.test.ts
+++ b/tools/api-architecture-policy/test/api-context-inventory.test.ts
@@ -52,7 +52,7 @@ describe('auditApiContextInventory', () => {
     });
 
     assert.deepEqual(manifestErrors, ['Foreign implementation manifest edge: devDependencies']);
-    assert.deepEqual(dtoErrors, ['DTO contract has no explicit inter-module export']);
+    assert.deepEqual(dtoErrors, ['DTO root exports inter-module contract']);
   });
 
   test('rejects implementation dependencies from DTOs, shared semantics, and foreign SPIs', () => {

--- a/tools/api-architecture-policy/turbo.json
+++ b/tools/api-architecture-policy/turbo.json
@@ -13,6 +13,13 @@
         "$TURBO_ROOT$/libs/shared/node/**/package.json",
         "$TURBO_ROOT$/libs/shared/workflow/**/package.json"
       ]
+    },
+    "test": {
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/api-contexts.cjs",
+        "$TURBO_ROOT$/fixtures/depcruise-api-edges/**"
+      ]
     }
   }
 }


### PR DESCRIPTION
Dependency Cruiser now derives API source-boundary rules from the declarative `apiArchitectureEdgePolicy` matrix in `api-contexts.cjs`. The TypeScript API architecture auditor consumes the same policy, keeping both enforcement paths aligned while retaining its DTO-specific and manifest checks.

The change covers nested registry-backed package paths, production and non-production source roots, JS/TS module variants, and allowed/forbidden edge fixtures. Policy validation now rejects missing classifications, unknown edges, invalid decisions, and incomplete violation metadata. The generated rule source scope also excludes sibling-package paths to avoid false positives from traversed dependencies.

Validation completed:
- `mise exec -- turbo test --filter=@shipfox/api-architecture-policy` — 12/12 tests passing
- `mise exec -- turbo type --filter=@shipfox/api-architecture-policy`
- `mise exec -- turbo check --filter=@shipfox/api-architecture-policy`
- `mise exec -- pnpm check:api-context-inventory`
- Focused Dependency Cruiser sweep across `libs/api/**` and governed shared packages — 43/43 clean

Closes ENG-1210

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dependency Cruiser now enforces API source boundaries from one declarative edge policy, making it the authority for registry-backed API imports. The TypeScript auditor reads the same policy for parity while keeping DTO syntax and manifest checks. Closes ENG-1210.

- **New Features**
  - Added `apiArchitectureEdgePolicy` with strict validation for missing/unknown/incomplete decisions, plus `validateApiArchitectureEdgePolicy` export.
  - Introduced `createApiArchitectureRules` and integrated it into `.dependency-cruiser.cjs` to generate per-package, classification-aware rules that cover prod code, tests, fixtures, setup, static/dynamic/type-only imports, and JS/TS variants.
  - Updated `@shipfox/api-architecture-policy` to consume the same policy for source-edge checks and tightened DTO root export checks for inter-module and implementation-detail re-exports.
  - Added focused fixtures and end-to-end Dependency Cruiser tests for nested packages and unrelated registry names; enforces all forbidden edge categories and preserves allowed same-context Integrations edges.

<sup>Written for commit e8b32b0fc8c38cfaf0a62c7748f9b1a287c9e216. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

