### PR TITLE
Enforce query resource ownership and cache-operation ownership

### DIFF
--- a/.changeset/calm-query-ownership.md
+++ b/.changeset/calm-query-ownership.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/client-shell": minor
+"@shipfox/client-auth": minor
+"@shipfox/client-integrations": patch
+---
+
+Enforces package-owned query policies and explicit cache-operation ownership across client resources.

--- a/docs/architecture/client-architecture.md
+++ b/docs/architecture/client-architecture.md
@@ -53,11 +53,14 @@ Components do not build snake_case transport payloads. Empty responses,
 redirect URLs, health checks, and opaque acknowledgements can remain transport
 values when they have no domain meaning.
 
-Each query option owns its key, request, mapping, cache policy, and pagination.
-Reuse that option from hooks, loaders, and coordinators. A mutation owns the
-cache updates for the resource it changes. Components report user intent and
-handle presentation effects such as closing a dialog or navigating. A named
-page or application coordinator owns a journey that must update more than one
+Each server-backed resource exposes a package-owned named
+`*QueryOptions` or `*InfiniteQueryOptions` factory from `hooks/api/`. The
+factory owns its key, request, mapping, cache policy, and pagination. Hooks,
+loaders, and coordinators reuse that factory; hooks do not build an inline raw
+`queryOptions` policy. A mutation hook owns the cache updates for the
+same-feature resource it changes. Components report user intent and handle
+presentation effects such as closing a dialog or navigating. A named page or
+application coordinator owns a journey that must update more than one
 feature's cache.
 
 Use `checkedApiRequest` from `@shipfox/client-api` for business responses. It
@@ -179,14 +182,20 @@ raw API requests, and leaf-component query-cache ownership. The repository
 verifier inventories production adapters and query hooks under `libs/client/**`
 and `libs/shared/react/ui/**`. It rejects direct API requests outside adapters,
 unparsed API responses, checked business responses returned without a mapper,
-inline query policies, query hooks outside adapters, and raw route-search
-parsing outside an owned route module. Both checks require zero production
-violations. Neither check has a migration baseline or broad allowlist. The
-step-log query is the only narrow query-policy exception; its per-view cursor
-and retry lifecycle is documented in
-[`clientArchitectureExceptions`](../../tools/client-architecture-policy/src/audit-client-architecture.ts).
-It also rejects deep imports into another feature's private modules and
-navigation or settings contributions that target a route owned by another
+inline query policies, query hooks outside adapters, direct query-client
+operations outside an owning adapter or named coordinator, and raw
+route-search parsing outside an owned route module. Both checks require zero
+production violations. Neither check has a migration baseline or broad
+allowlist. A shell/runtime or cross-feature coordinator that needs a direct
+query-client operation must be recorded in the
+[`cacheOperation` registry](../../tools/client-architecture-policy/src/audit-client-architecture.ts)
+with its exact source file, owner, reason, and focused test. The verifier
+rejects unregistered operations and stale registry records. The step-log query
+is the only narrow query-policy exception; its per-view cursor and retry
+lifecycle is recorded in the same
+[`clientArchitectureExceptions`](../../tools/client-architecture-policy/src/audit-client-architecture.ts)
+registry. It also rejects deep imports into another feature's private modules
+and navigation or settings contributions that target a route owned by another
 feature without an explicit `coordinator`.
 
 A completed feature package has `core/` domain models and policies with no UI

--- a/libs/client/auth/src/hooks/api/refresh-auth.ts
+++ b/libs/client/auth/src/hooks/api/refresh-auth.ts
@@ -1,5 +1,6 @@
 export {
   authRefreshQueryKey,
+  authRefreshQueryOptions,
   getAuthRefreshDelayMs,
   useRefreshAuth,
 } from '@shipfox/client-shell/runtime';

--- a/libs/client/auth/src/hooks/api/workspace-auth.ts
+++ b/libs/client/auth/src/hooks/api/workspace-auth.ts
@@ -1,6 +1,10 @@
 import {workspaceResponseSchema} from '@shipfox/api-workspaces-dto';
 import {checkedApiRequest} from '@shipfox/client-api';
-import {listUserWorkspaces, userWorkspacesQueryKey} from '@shipfox/client-shell/runtime';
+import {
+  listUserWorkspaces,
+  userWorkspacesQueryKey,
+  userWorkspacesQueryOptions,
+} from '@shipfox/client-shell/runtime';
 import {useMutation} from '@tanstack/react-query';
 import type {WorkspaceCreateCommand} from '#core/auth.js';
 import {useRefreshAuth} from './refresh-auth.js';
@@ -14,7 +18,7 @@ export async function createWorkspace(command: WorkspaceCreateCommand) {
   return toWorkspace(response);
 }
 
-export {listUserWorkspaces, userWorkspacesQueryKey};
+export {listUserWorkspaces, userWorkspacesQueryKey, userWorkspacesQueryOptions};
 
 export function useCreateWorkspaceAuth() {
   const refreshAuth = useRefreshAuth();

--- a/libs/client/integrations/src/application/complete-integration-callback.test.ts
+++ b/libs/client/integrations/src/application/complete-integration-callback.test.ts
@@ -1,0 +1,41 @@
+import {QueryClient} from '@tanstack/react-query';
+import type {IntegrationConnection} from '#core/models.js';
+import {integrationsQueryKeys} from '#hooks/api/integrations.js';
+import {completeIntegrationCallback} from './complete-integration-callback.js';
+
+const WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
+
+const connection: IntegrationConnection = {
+  id: '22222222-2222-4222-8222-222222222222',
+  workspaceId: WORKSPACE_ID,
+  provider: 'github',
+  externalAccountId: 'account',
+  slug: 'github-account',
+  displayName: 'GitHub',
+  lifecycleStatus: 'active',
+  capabilities: ['source_control'],
+  createdAt: '2026-07-23T00:00:00.000Z',
+  updatedAt: '2026-07-23T00:00:00.000Z',
+};
+
+describe('completeIntegrationCallback', () => {
+  test('invalidates the workspace connection views after callback completion', async () => {
+    const queryClient = new QueryClient();
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    const refreshAuth = vi.fn().mockResolvedValue({accessToken: 'access-token'});
+    const complete = vi.fn().mockResolvedValue(connection);
+
+    const result = await completeIntegrationCallback({
+      input: {code: 'grant-code'},
+      refreshAuth,
+      complete,
+      queryClient,
+    });
+
+    expect(result).toBe(connection);
+    expect(complete).toHaveBeenCalledWith({code: 'grant-code'}, 'access-token');
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: integrationsQueryKeys.connectionsByWorkspace(WORKSPACE_ID),
+    });
+  });
+});

--- a/libs/client/integrations/src/application/complete-integration-callback.ts
+++ b/libs/client/integrations/src/application/complete-integration-callback.ts
@@ -1,18 +1,21 @@
-import type {QueryClient} from '@tanstack/react-query';
+import {type QueryClient, useQueryClient} from '@tanstack/react-query';
+import {useCallback} from 'react';
 import type {IntegrationConnection} from '#core/models.js';
 import {integrationsQueryKeys} from '#hooks/api/integrations.js';
+
+export interface CompleteIntegrationCallbackOptions<TInput> {
+  input: TInput;
+  refreshAuth: () => Promise<{accessToken: string}>;
+  complete: (input: TInput, accessToken: string) => Promise<IntegrationConnection>;
+  queryClient: QueryClient;
+}
 
 export async function completeIntegrationCallback<TInput>({
   input,
   refreshAuth,
   complete,
   queryClient,
-}: {
-  input: TInput;
-  refreshAuth: () => Promise<{accessToken: string}>;
-  complete: (input: TInput, accessToken: string) => Promise<IntegrationConnection>;
-  queryClient: QueryClient;
-}): Promise<IntegrationConnection> {
+}: CompleteIntegrationCallbackOptions<TInput>): Promise<IntegrationConnection> {
   const session = await refreshAuth();
   const connection = await complete(input, session.accessToken);
   try {
@@ -23,4 +26,14 @@ export async function completeIntegrationCallback<TInput>({
     // Cache refresh is best effort: the successful callback is already committed server-side.
   }
   return connection;
+}
+
+export function useCompleteIntegrationCallback() {
+  const queryClient = useQueryClient();
+  return useCallback(
+    async <TInput>(
+      options: Omit<CompleteIntegrationCallbackOptions<TInput>, 'queryClient'>,
+    ): Promise<IntegrationConnection> => completeIntegrationCallback({...options, queryClient}),
+    [queryClient],
+  );
 }

--- a/libs/client/integrations/src/pages/linear-callback-page.tsx
+++ b/libs/client/integrations/src/pages/linear-callback-page.tsx
@@ -2,10 +2,9 @@ import {useRefreshAuth} from '@shipfox/client-auth';
 import {createSingleFlight} from '@shipfox/client-ui';
 import {FullPageLoader} from '@shipfox/react-ui/loader';
 import {toast} from '@shipfox/react-ui/toast';
-import {useQueryClient} from '@tanstack/react-query';
 import {useNavigate, useSearch} from '@tanstack/react-router';
 import {useEffect, useMemo, useState} from 'react';
-import {completeIntegrationCallback} from '#application/complete-integration-callback.js';
+import {useCompleteIntegrationCallback} from '#application/complete-integration-callback.js';
 import {CallbackStatusShell} from '#components/callback-status-shell.js';
 import type {IntegrationConnection} from '#core/models.js';
 import {useCompleteLinearCallbackMutation} from '#hooks/api/integrations.js';
@@ -31,7 +30,7 @@ export function LinearCallbackPage() {
   const search = useSearch({strict: false});
   const navigate = useNavigate();
   const refreshAuth = useRefreshAuth();
-  const queryClient = useQueryClient();
+  const completeIntegrationCallback = useCompleteIntegrationCallback();
   const {mutateAsync: completeLinearCallback} = useCompleteLinearCallbackMutation();
   const params = useMemo(() => parseLinearCallbackQuery(search), [search]);
   const workspaceId = useMemo(() => {
@@ -54,7 +53,6 @@ export function LinearCallbackPage() {
           input: params,
           refreshAuth,
           complete: async (query, token) => await completeLinearCallback({query, token}),
-          queryClient,
         }),
     );
 
@@ -90,7 +88,7 @@ export function LinearCallbackPage() {
     return () => {
       disposed = true;
     };
-  }, [completeLinearCallback, navigate, params, queryClient, refreshAuth]);
+  }, [completeIntegrationCallback, completeLinearCallback, navigate, params, refreshAuth]);
 
   if (!params) {
     return (

--- a/libs/client/integrations/src/pages/sentry-callback-page.tsx
+++ b/libs/client/integrations/src/pages/sentry-callback-page.tsx
@@ -6,10 +6,9 @@ import {Card} from '@shipfox/react-ui/card';
 import {FullPageLoader} from '@shipfox/react-ui/loader';
 import {toast} from '@shipfox/react-ui/toast';
 import {Header, Text} from '@shipfox/react-ui/typography';
-import {useQueryClient} from '@tanstack/react-query';
 import {Link, useNavigate, useSearch} from '@tanstack/react-router';
 import {useEffect, useMemo, useRef, useState} from 'react';
-import {completeIntegrationCallback} from '#application/complete-integration-callback.js';
+import {useCompleteIntegrationCallback} from '#application/complete-integration-callback.js';
 import type {IntegrationConnection} from '#core/models.js';
 import {connectSentry} from '#hooks/api/integrations.js';
 import {
@@ -28,7 +27,7 @@ export function SentryCallbackPage() {
   const navigate = useNavigate();
   const refreshAuth = useRefreshAuth();
   const {workspaces, isLoading} = useAuthState();
-  const queryClient = useQueryClient();
+  const completeIntegrationCallback = useCompleteIntegrationCallback();
 
   const params = useMemo(() => parseSentryCallbackParams(search), [search]);
   const storedWorkspaceId = useMemo(() => readSentryInstallWorkspace(window.sessionStorage), []);
@@ -114,7 +113,6 @@ export function SentryCallbackPage() {
               },
               token,
             }),
-          queryClient,
         }),
     );
 

--- a/libs/client/integrations/src/pages/slack-callback-page.tsx
+++ b/libs/client/integrations/src/pages/slack-callback-page.tsx
@@ -2,10 +2,9 @@ import {useRefreshAuth} from '@shipfox/client-auth';
 import {createSingleFlight} from '@shipfox/client-ui';
 import {FullPageLoader} from '@shipfox/react-ui/loader';
 import {toast} from '@shipfox/react-ui/toast';
-import {useQueryClient} from '@tanstack/react-query';
 import {useNavigate, useSearch} from '@tanstack/react-router';
 import {useEffect, useMemo, useState} from 'react';
-import {completeIntegrationCallback} from '#application/complete-integration-callback.js';
+import {useCompleteIntegrationCallback} from '#application/complete-integration-callback.js';
 import {CallbackStatusShell} from '#components/callback-status-shell.js';
 import type {IntegrationConnection} from '#core/models.js';
 import {useCompleteSlackCallbackMutation} from '#hooks/api/integrations.js';
@@ -30,7 +29,7 @@ export function SlackCallbackPage() {
   const search = useSearch({strict: false});
   const navigate = useNavigate();
   const refreshAuth = useRefreshAuth();
-  const queryClient = useQueryClient();
+  const completeIntegrationCallback = useCompleteIntegrationCallback();
   const {mutateAsync: completeSlackCallback} = useCompleteSlackCallbackMutation();
   const params = useMemo(() => parseSlackCallbackQuery(search), [search]);
   const workspaceId = useMemo(() => readSlackInstallWorkspace(window.sessionStorage), []);
@@ -48,7 +47,6 @@ export function SlackCallbackPage() {
           input: params,
           refreshAuth,
           complete: async (query, token) => await completeSlackCallback({query, token}),
-          queryClient,
         }),
     );
     request.then(
@@ -86,7 +84,7 @@ export function SlackCallbackPage() {
     return () => {
       disposed = true;
     };
-  }, [completeSlackCallback, navigate, params, queryClient, refreshAuth]);
+  }, [completeIntegrationCallback, completeSlackCallback, navigate, params, refreshAuth]);
 
   if (!params)
     return (

--- a/libs/client/integrations/src/routes/github-callback.tsx
+++ b/libs/client/integrations/src/routes/github-callback.tsx
@@ -4,10 +4,9 @@ import {defineRoute} from '@shipfox/client-shell/runtime';
 import {createSingleFlight} from '@shipfox/client-ui';
 import {FullPageLoader} from '@shipfox/react-ui/loader';
 import {toast} from '@shipfox/react-ui/toast';
-import {useQueryClient} from '@tanstack/react-query';
 import {useNavigate, useSearch} from '@tanstack/react-router';
 import {useEffect} from 'react';
-import {completeIntegrationCallback} from '#application/complete-integration-callback.js';
+import {useCompleteIntegrationCallback} from '#application/complete-integration-callback.js';
 import {completeGithubCallback} from '#hooks/api/integrations.js';
 
 interface GithubCallbackParams {
@@ -28,7 +27,7 @@ function GithubCallbackRoute() {
   const search = useSearch({strict: false});
   const navigate = useNavigate();
   const refreshAuth = useRefreshAuth();
-  const queryClient = useQueryClient();
+  const completeIntegrationCallback = useCompleteIntegrationCallback();
 
   useEffect(() => {
     const missing = missingCallbackParams(search);
@@ -54,7 +53,6 @@ function GithubCallbackRoute() {
           input: params,
           refreshAuth,
           complete: async (input, token) => await completeGithubCallback({...input, token}),
-          queryClient,
         })),
     );
     request
@@ -77,7 +75,7 @@ function GithubCallbackRoute() {
     return () => {
       disposed = true;
     };
-  }, [navigate, queryClient, refreshAuth, search]);
+  }, [completeIntegrationCallback, navigate, refreshAuth, search]);
 
   return <FullPageLoader />;
 }

--- a/libs/client/shell/src/hooks/api/session-auth.ts
+++ b/libs/client/shell/src/hooks/api/session-auth.ts
@@ -1,16 +1,39 @@
 import {loginResponseSchema} from '@shipfox/api-auth-dto';
 import {listUserWorkspacesResponseSchema} from '@shipfox/api-workspaces-dto';
 import {checkedApiRequest} from '@shipfox/client-api';
+import {type FetchQueryOptions, queryOptions} from '@tanstack/react-query';
 import type {AuthenticatedSession, WorkspaceSummary} from '#core/session.js';
 import {toAuthenticatedSession} from './session-mapper.js';
 
+export interface UserWorkspaces {
+  memberships: WorkspaceSummary[];
+}
+
+export const authRefreshQueryKey = ['auth', 'refresh'] as const;
+export const userWorkspacesQueryKey = ['workspaces', 'mine'] as const;
+
+type AuthRefreshQueryOptions = FetchQueryOptions<
+  AuthenticatedSession,
+  Error,
+  AuthenticatedSession,
+  typeof authRefreshQueryKey
+>;
+
+type UserWorkspacesQueryOptions = FetchQueryOptions<
+  UserWorkspaces,
+  Error,
+  UserWorkspaces,
+  typeof userWorkspacesQueryKey
+>;
+
 export async function listUserWorkspaces(
   token?: string,
-): Promise<{memberships: WorkspaceSummary[]}> {
+  signal?: AbortSignal,
+): Promise<UserWorkspaces> {
   const response = await checkedApiRequest(
     listUserWorkspacesResponseSchema,
     '/workspaces',
-    token ? {headers: {authorization: `Bearer ${token}`}} : {},
+    token ? {headers: {authorization: `Bearer ${token}`}, signal} : {signal},
   );
   return {
     memberships: response.memberships.map((membership) => ({
@@ -21,7 +44,30 @@ export async function listUserWorkspaces(
   };
 }
 
-export async function refreshAuthenticatedSession(): Promise<AuthenticatedSession> {
-  const response = await checkedApiRequest(loginResponseSchema, '/auth/refresh', {method: 'POST'});
+export function authRefreshQueryOptions(): AuthRefreshQueryOptions {
+  return queryOptions({
+    queryKey: authRefreshQueryKey,
+    queryFn: ({signal}) => refreshAuthenticatedSession(signal),
+    retry: false,
+    staleTime: 0,
+  });
+}
+
+export function userWorkspacesQueryOptions(token?: string): UserWorkspacesQueryOptions {
+  return queryOptions({
+    queryKey: userWorkspacesQueryKey,
+    queryFn: ({signal}) => listUserWorkspaces(token, signal),
+    retry: false,
+    staleTime: 0,
+  });
+}
+
+export async function refreshAuthenticatedSession(
+  signal?: AbortSignal,
+): Promise<AuthenticatedSession> {
+  const response = await checkedApiRequest(loginResponseSchema, '/auth/refresh', {
+    method: 'POST',
+    signal,
+  });
   return toAuthenticatedSession(response);
 }

--- a/libs/client/shell/src/runtime/auth.tsx
+++ b/libs/client/shell/src/runtime/auth.tsx
@@ -4,7 +4,11 @@ import {atom, useAtomValue, useSetAtom, useStore} from 'jotai';
 import type {PropsWithChildren} from 'react';
 import {useCallback, useEffect, useMemo} from 'react';
 import type {AuthenticatedSession, UserIdentity, WorkspaceSummary} from '#core/session.js';
-import {listUserWorkspaces, refreshAuthenticatedSession} from '#hooks/api/session-auth.js';
+import {
+  authRefreshQueryKey,
+  authRefreshQueryOptions,
+  userWorkspacesQueryOptions,
+} from '#hooks/api/session-auth.js';
 
 const REFRESH_EARLY_MS = 5 * 60 * 1000;
 const REFRESH_RETRY_DELAY_MS = 60_000;
@@ -31,8 +35,6 @@ export interface AuthStateValue extends AuthState {
 export const initialAuthState: AuthState = {status: 'loading'};
 export const authStateAtom = atom<AuthState>(initialAuthState);
 const authTransitionEpochAtom = atom(0);
-export const authRefreshQueryKey = ['auth', 'refresh'] as const;
-export const userWorkspacesQueryKey = ['workspaces', 'mine'] as const;
 
 export function toAuthenticatedState(
   session: AuthenticatedSession,
@@ -60,7 +62,13 @@ export function useAuthState(): AuthStateValue {
   );
 }
 
-export {listUserWorkspaces} from '#hooks/api/session-auth.js';
+export {
+  authRefreshQueryKey,
+  authRefreshQueryOptions,
+  listUserWorkspaces,
+  userWorkspacesQueryKey,
+  userWorkspacesQueryOptions,
+} from '#hooks/api/session-auth.js';
 
 function decodeBase64Url(value: string): string {
   const base64 = value
@@ -117,14 +125,10 @@ export function useAuthTransition() {
       queryClient.setQueryData(authRefreshQueryKey, session);
       let workspaces: WorkspaceSummary[] = [];
       try {
-        const hydratedWorkspaces = await queryClient.fetchQuery({
-          queryKey: userWorkspacesQueryKey,
-          queryFn: () => listUserWorkspaces(session.accessToken),
-          retry: false,
-          staleTime: 0,
-        });
+        const hydratedWorkspaces = await queryClient.fetchQuery(
+          userWorkspacesQueryOptions(session.accessToken),
+        );
         workspaces = hydratedWorkspaces.memberships;
-        queryClient.setQueryData(userWorkspacesQueryKey, hydratedWorkspaces);
       } catch {
         // The authenticated session remains usable while workspace hydration retries on the next route load.
       }
@@ -143,12 +147,7 @@ export function useRefreshAuth() {
   const {enterAuthenticated, enterGuest} = useAuthTransition();
   return useCallback(async () => {
     try {
-      const result = await queryClient.fetchQuery({
-        queryKey: authRefreshQueryKey,
-        queryFn: refreshAuthenticatedSession,
-        retry: false,
-        staleTime: 0,
-      });
+      const result = await queryClient.fetchQuery(authRefreshQueryOptions());
       await enterAuthenticated(result);
       return result;
     } catch (error) {

--- a/tools/client-architecture-policy/src/audit-client-architecture.ts
+++ b/tools/client-architecture-policy/src/audit-client-architecture.ts
@@ -1,4 +1,4 @@
-import {readdir, readFile} from 'node:fs/promises';
+import {access, readdir, readFile} from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
 import {fileURLToPath} from 'node:url';
@@ -13,6 +13,7 @@ export interface ClientArchitectureViolation {
     | 'unchecked-route-search'
     | 'inline-query-policy'
     | 'query-policy-outside-adapter'
+    | 'unregistered-query-client-operation'
     | 'unmapped-api-response'
     | 'unparsed-api-response';
 }
@@ -24,16 +25,54 @@ export interface ClientArchitectureInventory {
   reusableQueryPolicies: number;
 }
 
+export interface ClientArchitectureException {
+  file: string;
+  owner: string;
+  reason: string;
+  test: string;
+}
+
+export interface ClientArchitectureExceptionRegistry {
+  cacheOperation: readonly ClientArchitectureException[];
+  queryPolicy: readonly ClientArchitectureException[];
+}
+
 /**
- * Narrow exceptions must name the owning file and explain the state that the
- * shared query-options convention cannot safely represent.
+ * Narrow exceptions must identify the source owner, explain the boundary that
+ * cannot use the default contract, and point to a focused test.
  */
-export const clientArchitectureExceptions = {
-  queryPolicy: {
-    'libs/client/logs/src/hooks/api/step-logs.ts':
-      'The query merges a prior cursor snapshot and owns a per-view retry lifecycle.',
-  },
+const stepLogsQueryException = {
+  file: 'libs/client/logs/src/hooks/api/step-logs.ts',
+  owner: 'step-log query adapter',
+  reason: 'The query merges a prior cursor snapshot and owns a per-view retry lifecycle.',
+  test: 'libs/client/logs/src/hooks/api/step-logs-query.test.tsx',
 } as const;
+
+export const clientArchitectureExceptions = {
+  cacheOperation: [
+    {
+      file: 'libs/client/shell/src/runtime/auth.tsx',
+      owner: 'shell auth runtime',
+      reason: 'Auth transitions clear and reseed private cache state across principal changes.',
+      test: 'libs/client/auth/src/components/auth-provider.test.tsx',
+    },
+    {
+      file: 'libs/client/onboarding/src/workspace-setup-route.ts',
+      owner: 'workspace setup coordinator',
+      reason:
+        'Workspace setup combines query policies from several feature packages before routing.',
+      test: 'libs/client/onboarding/src/workspace-setup-route.test.tsx',
+    },
+    {
+      file: 'libs/client/integrations/src/application/complete-integration-callback.ts',
+      owner: 'integration callback coordinator',
+      reason:
+        'OAuth callback completion refreshes the integration cache after a cross-route handoff.',
+      test: 'libs/client/integrations/src/application/complete-integration-callback.test.ts',
+    },
+  ],
+  queryPolicy: [stepLogsQueryException],
+} as const satisfies ClientArchitectureExceptionRegistry;
 
 const rootDirectory = fileURLToPath(new URL('../../../', import.meta.url));
 const auditedDirectories = [
@@ -48,8 +87,47 @@ const checkedApiRequestCallPattern = /\bcheckedApiRequest\s*(?:<[^>]*>)?\s*\(/g;
 const unmappedApiResponsePattern =
   /(?:\breturn\s*(?:\(\s*)?|=>\s*(?:\(\s*)?)(?:await\s+)?checkedApiRequest\s*(?:<[^>]*>)?\s*\((?!\s*emptyResponseSchema\b)/g;
 const queryHookPattern = /\b(?:useQuery|useInfiniteQuery)\s*(?:<[^>]*>)?\s*\(/g;
-const queryPolicyPattern =
-  /(?:\.\.\.\s*)?(?:[A-Za-z_$][\w$]*QueryOptions|queryOptions|infiniteQueryOptions)\s*\(/;
+const queryPolicyFactoryPattern = /\b([A-Za-z_$][\w$]*(?:Infinite)?QueryOptions)\s*\(/g;
+const inlineQueryPolicyFactories = new Set(['queryOptions', 'infiniteQueryOptions']);
+const namedImportDeclarationPattern = /\bimport\s*\{([\s\S]*?)\}\s*from\s*['"]([^'"]+)['"]/g;
+const namedImportSpecifierPattern =
+  /(?:^|,)\s*(?:type\s+)?([A-Za-z_$][\w$]*)(?:\s+as\s+([A-Za-z_$][\w$]*))?\s*(?=,|$)/g;
+const reactQueryModuleName = '@tanstack/react-query';
+const queryClientHookName = 'useQueryClient';
+const queryClientOperationNames = [
+  'cancelQueries',
+  'clear',
+  'defaultQueryOptions',
+  'ensureInfiniteQueryData',
+  'ensureQueryData',
+  'getDefaultOptions',
+  'getMutationCache',
+  'getMutationDefaults',
+  'getQueryCache',
+  'fetchInfiniteQuery',
+  'fetchQuery',
+  'getQueriesData',
+  'getQueryData',
+  'getQueryDefaults',
+  'getQueryState',
+  'invalidateQueries',
+  'isFetching',
+  'isMutating',
+  'mount',
+  'prefetchInfiniteQuery',
+  'prefetchQuery',
+  'refetchQueries',
+  'removeQueries',
+  'resumePausedMutations',
+  'resetQueries',
+  'setQueriesData',
+  'setDefaultOptions',
+  'setMutationDefaults',
+  'setQueryData',
+  'setQueryDefaults',
+  'unmount',
+] as const;
+const queryClientParameterPattern = /\b([A-Za-z_$][\w$]*)\s*:\s*QueryClient\b/g;
 const routeSearchPattern = /\buseRouteSearch\s*\(/;
 const identifierStartPattern = /[A-Za-z_$]/;
 const identifierPartPattern = /[A-Za-z0-9_$]/;
@@ -127,6 +205,36 @@ export async function sourceFiles(directory: string): Promise<string[]> {
 function countMatches(source: string, pattern: RegExp): number {
   const flags = pattern.flags.includes('g') ? pattern.flags : `${pattern.flags}g`;
   return [...source.matchAll(new RegExp(pattern.source, flags))].length;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function importedBindings(source: string, moduleName: string, importedName: string): string[] {
+  const bindings = new Set<string>();
+  for (const match of source.matchAll(namedImportDeclarationPattern)) {
+    if (match[2] !== moduleName) continue;
+    for (const specifier of (match[1] ?? '').matchAll(namedImportSpecifierPattern)) {
+      if (specifier[1] === importedName) bindings.add(specifier[2] ?? importedName);
+    }
+  }
+  return [...bindings];
+}
+
+function queryPolicyFactoryNames(source: string): Set<string> {
+  return new Set([
+    ...inlineQueryPolicyFactories,
+    ...importedBindings(source, reactQueryModuleName, 'queryOptions'),
+    ...importedBindings(source, reactQueryModuleName, 'infiniteQueryOptions'),
+  ]);
+}
+
+function queryClientHookNames(source: string): string[] {
+  return [
+    queryClientHookName,
+    ...importedBindings(source, reactQueryModuleName, queryClientHookName),
+  ].filter((hookName, index, hookNames) => hookNames.indexOf(hookName) === index);
 }
 
 function capturedMatches(source: string, pattern: RegExp): string[] {
@@ -291,26 +399,151 @@ function findMatchingCallEnd(source: string, openParen: number): number {
 }
 
 function queryHookCalls(source: string): Array<{hasPolicy: boolean}> {
+  const inlineQueryPolicyNames = queryPolicyFactoryNames(source);
   return [...source.matchAll(new RegExp(queryHookPattern.source, 'g'))].map((match) => {
     const start = match.index ?? 0;
     const openParen = start + match[0].lastIndexOf('(');
     const end = findMatchingCallEnd(source, openParen);
     const argumentsSource = source.slice(openParen + 1, end);
-    return {hasPolicy: queryPolicyPattern.test(argumentsSource)};
+    const hasPolicy = [...argumentsSource.matchAll(queryPolicyFactoryPattern)].some(
+      ([, factoryName]) => !inlineQueryPolicyNames.has(factoryName ?? ''),
+    );
+    return {hasPolicy};
   });
 }
 
 function hasQueryPolicyException(file: string): boolean {
-  return Object.hasOwn(clientArchitectureExceptions.queryPolicy, file);
+  return clientArchitectureExceptions.queryPolicy.some((exception) => exception.file === file);
 }
 
-function validateExceptionRegistry(files: string[]): void {
-  const fileSet = new Set(files);
-  for (const [file, reason] of Object.entries(clientArchitectureExceptions.queryPolicy)) {
-    if (!reason.trim()) throw new Error(`Client architecture exception has no reason: ${file}`);
-    if (!fileSet.has(file))
-      throw new Error(`Client architecture exception file is not audited: ${file}`);
+function hasCacheOperationException(file: string): boolean {
+  return clientArchitectureExceptions.cacheOperation.some((exception) => exception.file === file);
+}
+
+function queryClientIdentifiers(source: string): string[] {
+  const identifiers = new Set<string>(['queryClient']);
+  const hookNames = queryClientHookNames(source);
+  const hookPattern = hookNames.map(escapeRegExp).join('|');
+  const queryClientBindingPattern = new RegExp(
+    `\\b(?:const|let|var)\\s+([A-Za-z_$][\\w$]*)\\s*=\\s*(?:${hookPattern})\\s*\\(`,
+    'g',
+  );
+  for (const match of source.matchAll(queryClientBindingPattern)) {
+    if (match[1]) identifiers.add(match[1]);
   }
+  for (const match of source.matchAll(queryClientParameterPattern)) {
+    if (match[1]) identifiers.add(match[1]);
+  }
+  const queryClientReturnTypePattern = new RegExp(
+    `\\b([A-Za-z_$][\\w$]*)\\s*:\\s*ReturnType<\\s*typeof\\s+(?:${hookPattern})\\s*>`,
+    'g',
+  );
+  for (const match of source.matchAll(queryClientReturnTypePattern)) {
+    if (match[1]) identifiers.add(match[1]);
+  }
+  return [...identifiers];
+}
+
+function queryClientMethodOperationCount(source: string): number {
+  const identifiers = queryClientIdentifiers(source).map(escapeRegExp).join('|');
+  const hookNames = queryClientHookNames(source).map(escapeRegExp).join('|');
+  const methods = queryClientOperationNames.join('|');
+  const operationPattern = new RegExp(
+    `\\b(?:${identifiers})(?:\\.|\\?\\.)(?:${methods})\\s*\\(`,
+    'g',
+  );
+  const directHookOperationPattern = new RegExp(
+    `\\b(?:${hookNames})\\s*\\(\\s*\\)(?:\\.|\\?\\.)(?:${methods})\\s*\\(`,
+    'g',
+  );
+  return countMatches(source, operationPattern) + countMatches(source, directHookOperationPattern);
+}
+
+function queryClientOperationCount(source: string): number {
+  const hookCallCount = queryClientHookNames(source).reduce(
+    (total, hookName) =>
+      total + countMatches(source, new RegExp(`\\b${escapeRegExp(hookName)}\\s*\\(`, 'g')),
+    0,
+  );
+  return queryClientMethodOperationCount(source) + hookCallCount;
+}
+
+function allExceptions(
+  registry: ClientArchitectureExceptionRegistry = clientArchitectureExceptions,
+): ClientArchitectureException[] {
+  return [...registry.cacheOperation, ...registry.queryPolicy];
+}
+
+export function validateExceptionRegistry(
+  files: string[],
+  testFiles: string[] | undefined = undefined,
+  registry: ClientArchitectureExceptionRegistry = clientArchitectureExceptions,
+): void {
+  const fileSet = new Set(files);
+  const testFileSet = new Set(testFiles ?? []);
+  const seen = new Set<string>();
+  for (const exception of allExceptions(registry)) {
+    const key = `${exception.file}:${exception.test}`;
+    if (seen.has(key)) throw new Error(`Duplicate client architecture exception: ${key}`);
+    seen.add(key);
+    if (!exception.file.trim()) throw new Error('Client architecture exception has no file');
+    if (!exception.owner.trim())
+      throw new Error(`Client architecture exception has no owner: ${exception.file}`);
+    if (!exception.reason.trim())
+      throw new Error(`Client architecture exception has no reason: ${exception.file}`);
+    if (!exception.test.trim())
+      throw new Error(`Client architecture exception has no focused test: ${exception.file}`);
+    if (!fileSet.has(exception.file))
+      throw new Error(`Client architecture exception file is not audited: ${exception.file}`);
+    if (testFiles !== undefined && !testFileSet.has(exception.test))
+      throw new Error(`Client architecture exception test does not exist: ${exception.test}`);
+  }
+}
+
+export function validateExceptionSourceUsage(
+  sources: ReadonlyMap<string, string>,
+  registry: ClientArchitectureExceptionRegistry = clientArchitectureExceptions,
+): void {
+  for (const exception of registry.cacheOperation) {
+    const source = sources.get(exception.file);
+    if (!source || queryClientMethodOperationCount(source) === 0) {
+      throw new Error(`Client architecture cache-operation exception is stale: ${exception.file}`);
+    }
+  }
+  for (const exception of registry.queryPolicy) {
+    const source = sources.get(exception.file);
+    const hasUnownedQueryPolicy =
+      source !== undefined && queryHookCalls(source).some((call) => !call.hasPolicy);
+    if (!source || !hasUnownedQueryPolicy) {
+      throw new Error(`Client architecture query-policy exception is stale: ${exception.file}`);
+    }
+  }
+}
+
+async function existingPaths(paths: string[]): Promise<string[]> {
+  const existing = await Promise.all(
+    paths.map(async (relativePath) => {
+      try {
+        await access(path.join(rootDirectory, relativePath));
+        return relativePath;
+      } catch {
+        return undefined;
+      }
+    }),
+  );
+  return existing.flatMap((relativePath) => (relativePath ? [relativePath] : []));
+}
+
+async function validateRepositoryExceptionRegistry(
+  entries: Array<{file: string; source: string}>,
+): Promise<void> {
+  const exceptions = allExceptions();
+  const testFiles = await existingPaths(exceptions.map((exception) => exception.test));
+  validateExceptionRegistry(
+    entries.map((entry) => entry.file),
+    testFiles,
+  );
+  validateExceptionSourceUsage(new Map(entries.map((entry) => [entry.file, entry.source])));
 }
 
 export function inventoryClientSource(
@@ -360,6 +593,9 @@ export function auditClientSource(file: string, source: string): ClientArchitect
   } else if (!isClientApi) {
     addViolation('query-policy-outside-adapter', queryHookCalls(source).length);
   }
+  if (!isAdapter && !isClientApi && !hasCacheOperationException(normalizedFile)) {
+    addViolation('unregistered-query-client-operation', queryClientOperationCount(source));
+  }
   if (!normalizedFile.includes('/src/routes/'))
     addViolation('unchecked-route-search', countMatches(source, routeSearchPattern));
   return violations;
@@ -367,25 +603,29 @@ export function auditClientSource(file: string, source: string): ClientArchitect
 
 export async function inventoryRepository(): Promise<ClientArchitectureInventory> {
   const files = (await Promise.all(auditedDirectories.map(sourceFiles))).flat();
-  validateExceptionRegistry(files.map(toRepositoryPath));
   const entries = await Promise.all(
     files.map(async (file) => ({
       file: toRepositoryPath(file),
-      inventory: inventoryClientSource(toRepositoryPath(file), await readFile(file, 'utf8')),
+      source: await readFile(file, 'utf8'),
     })),
   );
+  await validateRepositoryExceptionRegistry(entries);
+  const inventories = entries.map(({file, source}) => ({
+    file,
+    ...inventoryClientSource(file, source),
+  }));
   return {
-    adapterFiles: entries
-      .filter(({inventory}) => inventory.isAdapter)
+    adapterFiles: inventories
+      .filter(({isAdapter}) => isAdapter)
       .map(({file}) => file)
       .sort(),
-    checkedApiRequestCalls: entries.reduce(
-      (total, {inventory}) => total + inventory.checkedApiRequestCalls,
+    checkedApiRequestCalls: inventories.reduce(
+      (total, {checkedApiRequestCalls}) => total + checkedApiRequestCalls,
       0,
     ),
-    queryHooks: entries.reduce((total, {inventory}) => total + inventory.queryHooks, 0),
-    reusableQueryPolicies: entries.reduce(
-      (total, {inventory}) => total + inventory.reusableQueryPolicies,
+    queryHooks: inventories.reduce((total, {queryHooks}) => total + queryHooks, 0),
+    reusableQueryPolicies: inventories.reduce(
+      (total, {reusableQueryPolicies}) => total + reusableQueryPolicies,
       0,
     ),
   };
@@ -393,12 +633,14 @@ export async function inventoryRepository(): Promise<ClientArchitectureInventory
 
 export async function auditRepository(): Promise<ClientArchitectureViolation[]> {
   const files = (await Promise.all(auditedDirectories.map(sourceFiles))).flat();
-  validateExceptionRegistry(files.map(toRepositoryPath));
-  const violations = await Promise.all(
-    files.map(async (file) =>
-      auditClientSource(toRepositoryPath(file), await readFile(file, 'utf8')),
-    ),
+  const entries = await Promise.all(
+    files.map(async (file) => ({
+      file: toRepositoryPath(file),
+      source: await readFile(file, 'utf8'),
+    })),
   );
+  await validateRepositoryExceptionRegistry(entries);
+  const violations = entries.map(({file, source}) => auditClientSource(file, source));
   return violations
     .flat()
     .sort((left, right) =>

--- a/tools/client-architecture-policy/test/audit-client-architecture.test.ts
+++ b/tools/client-architecture-policy/test/audit-client-architecture.test.ts
@@ -2,11 +2,21 @@ import assert from 'node:assert/strict';
 import {mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import type {ClientArchitectureExceptionRegistry} from '../src/audit-client-architecture.js';
 import {
   auditClientSource,
+  auditRepository,
+  clientArchitectureExceptions,
   inventoryClientSource,
   sourceFiles,
+  validateExceptionRegistry,
+  validateExceptionSourceUsage,
 } from '../src/audit-client-architecture.js';
+
+const exceptionFileNotAuditedPattern = /exception file is not audited/;
+const exceptionTestDoesNotExistPattern = /exception test does not exist/;
+const cacheOperationExceptionStalePattern = /cache-operation exception is stale/;
+const queryPolicyExceptionStalePattern = /query-policy exception is stale/;
 
 describe('auditClientSource', () => {
   test('allows checked API requests in a feature adapter', () => {
@@ -242,6 +252,87 @@ export const projectsFeature = defineClientFeature({
     );
   });
 
+  test('rejects an inline TanStack query-options factory in a query hook', () => {
+    const violations = auditClientSource(
+      'libs/client/projects/src/hooks/api/projects.ts',
+      "useQuery(queryOptions({queryKey: ['projects'], queryFn: listProjects}));",
+    );
+
+    assert.deepEqual(violations, [
+      {
+        file: 'libs/client/projects/src/hooks/api/projects.ts',
+        occurrences: 1,
+        rule: 'inline-query-policy',
+      },
+    ]);
+  });
+
+  test('rejects an aliased TanStack query-options factory in a query hook', () => {
+    const violations = auditClientSource(
+      'libs/client/projects/src/hooks/api/projects.ts',
+      `import {queryOptions as buildQueryOptions} from '@tanstack/react-query';
+useQuery(buildQueryOptions({queryKey: ['projects'], queryFn: listProjects}));`,
+    );
+
+    assert.deepEqual(violations, [
+      {
+        file: 'libs/client/projects/src/hooks/api/projects.ts',
+        occurrences: 1,
+        rule: 'inline-query-policy',
+      },
+    ]);
+  });
+
+  test('requires a registry entry for direct query-client ownership outside adapters', () => {
+    const violations = auditClientSource(
+      'libs/client/projects/src/pages/project-page.tsx',
+      "import {useQueryClient} from '@tanstack/react-query';\nconst queryClient = useQueryClient();\nqueryClient.invalidateQueries({queryKey: ['projects']});",
+    );
+
+    assert.deepEqual(violations, [
+      {
+        file: 'libs/client/projects/src/pages/project-page.tsx',
+        occurrences: 2,
+        rule: 'unregistered-query-client-operation',
+      },
+    ]);
+  });
+
+  test('tracks aliased useQueryClient imports outside adapters', () => {
+    const violations = auditClientSource(
+      'libs/client/projects/src/pages/project-page.tsx',
+      `import {useQueryClient as useQC} from '@tanstack/react-query';
+const qc = useQC();
+qc.invalidateQueries({queryKey: ['projects']});`,
+    );
+
+    assert.deepEqual(violations, [
+      {
+        file: 'libs/client/projects/src/pages/project-page.tsx',
+        occurrences: 2,
+        rule: 'unregistered-query-client-operation',
+      },
+    ]);
+  });
+
+  test('allows same-feature cache effects inside a mutation adapter', () => {
+    const violations = auditClientSource(
+      'libs/client/projects/src/hooks/api/projects.ts',
+      "const queryClient = useQueryClient();\nqueryClient.invalidateQueries(projectQueryOptions('id'));",
+    );
+
+    assert.deepEqual(violations, []);
+  });
+
+  test('allows a registered coordinator to own direct query-client operations', () => {
+    const violations = auditClientSource(
+      'libs/client/onboarding/src/workspace-setup-route.ts',
+      "const cached = queryClient.getQueryData(['projects']);\nreturn queryClient.fetchQuery(projectQueryOptions('id'));",
+    );
+
+    assert.deepEqual(violations, []);
+  });
+
   test('keeps query hooks inside the adapter boundary', () => {
     const violations = auditClientSource(
       'libs/client/projects/src/pages/project-page.tsx',
@@ -335,5 +426,98 @@ export const projectsFeature = defineClientFeature({
       page.map((violation) => violation.rule),
       ['api-request-outside-adapter', 'unparsed-api-response'],
     );
+  });
+
+  test('rejects stale exception paths and missing focused tests', () => {
+    const registry: ClientArchitectureExceptionRegistry = {
+      cacheOperation: [
+        {
+          file: 'libs/client/projects/src/hooks/api/projects.ts',
+          owner: 'projects mutation adapter',
+          reason: 'The mutation owns same-feature cache effects.',
+          test: 'libs/client/projects/src/hooks/api/projects.test.ts',
+        },
+      ],
+      queryPolicy: [],
+    };
+
+    assert.throws(
+      () => validateExceptionRegistry(Object.keys(clientArchitectureExceptions), [], registry),
+      exceptionFileNotAuditedPattern,
+    );
+    assert.throws(
+      () =>
+        validateExceptionRegistry(
+          ['libs/client/projects/src/hooks/api/projects.ts'],
+          ['libs/client/projects/src/hooks/api/other.test.ts'],
+          registry,
+        ),
+      exceptionTestDoesNotExistPattern,
+    );
+    assert.throws(
+      () =>
+        validateExceptionRegistry(['libs/client/projects/src/hooks/api/projects.ts'], [], registry),
+      exceptionTestDoesNotExistPattern,
+    );
+  });
+
+  test('rejects an exception whose source no longer contains its operation', () => {
+    const registry: ClientArchitectureExceptionRegistry = {
+      cacheOperation: [
+        {
+          file: 'libs/client/projects/src/application/project-coordinator.ts',
+          owner: 'project coordinator',
+          reason: 'The coordinator refreshes a cross-route cache.',
+          test: 'libs/client/projects/src/application/project-coordinator.test.ts',
+        },
+      ],
+      queryPolicy: [],
+    };
+
+    assert.throws(
+      () =>
+        validateExceptionSourceUsage(
+          new Map([
+            [
+              'libs/client/projects/src/application/project-coordinator.ts',
+              'export function coordinate() { return true; }',
+            ],
+          ]),
+          registry,
+        ),
+      cacheOperationExceptionStalePattern,
+    );
+  });
+
+  test('rejects a query-policy exception whose source now owns its policy', () => {
+    const registry: ClientArchitectureExceptionRegistry = {
+      cacheOperation: [],
+      queryPolicy: [
+        {
+          file: 'libs/client/logs/src/hooks/api/step-logs.ts',
+          owner: 'step-log query adapter',
+          reason: 'The query has a special per-view policy.',
+          test: 'libs/client/logs/src/hooks/api/step-logs-query.test.tsx',
+        },
+      ],
+    };
+
+    assert.throws(
+      () =>
+        validateExceptionSourceUsage(
+          new Map([
+            [
+              'libs/client/logs/src/hooks/api/step-logs.ts',
+              'useQuery(stepLogsQueryOptions({projectId: "id"}));',
+            ],
+          ]),
+          registry,
+        ),
+      queryPolicyExceptionStalePattern,
+    );
+  });
+
+  test('accepts the production exception registry and source inventory', async () => {
+    assert.deepEqual(await auditRepository(), []);
   });
 });


### PR DESCRIPTION
Implements ENG-1185 by making client query-resource ownership explicit across package boundaries.

The architecture verifier now requires package-owned named query-options factories and validates a live exception registry for direct QueryClient operations, including owner, reason, and focused-test metadata with stale-entry checks. Auth/session and integration callback flows route through owned policies or named coordinators, and the client architecture guide documents the contract.

The review findings around aliased useQueryClient and aliased generic TanStack queryOptions are closed with binding-aware detection and regression tests.

Validation: targeted package check/type/test gates pass; 30 policy tests pass; the live repository audit passes with zero violations.

Closes ENG-1185

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make query resource ownership explicit across client packages and require explicit owners for direct `QueryClient` operations. Implements ENG-1185 with verifier rules, reusable query-options factories, and an integration callback coordinator.

- **New Features**
  - Architecture verifier: requires package-owned named `*QueryOptions` factories; rejects inline or aliased `queryOptions` from `@tanstack/react-query`; flags unregistered direct `QueryClient` operations; adds a `cacheOperation`/`queryPolicy` exception registry with owner, reason, and focused test; validates stale entries.
  - Auth/session: adds `authRefreshQueryOptions` and `userWorkspacesQueryOptions` in `@shipfox/client-shell/runtime` (re-exported in `@shipfox/client-auth`); hydration now uses these factories and propagates `AbortSignal`.
  - Integrations: adds `useCompleteIntegrationCallback` coordinator that refreshes connection views after OAuth; callback pages updated to use it.
  - Docs: updates the client architecture guide to document the contract and registry.

- **Migration**
  - Use package-owned `*QueryOptions` factories from each feature’s `hooks/api/` and remove inline or aliased `queryOptions` in hooks.
  - Register any direct `QueryClient` usage outside adapters/coordinators in the exception registry with owner, reason, and a focused test.
  - Replace manual callback cache handling with `useCompleteIntegrationCallback`.
  - Import `authRefreshQueryOptions` and `userWorkspacesQueryOptions` from `@shipfox/client-shell/runtime` or use `@shipfox/client-auth` re-exports.

<sup>Written for commit 9a7d8831bb2eed02a1f94fc09001bc8ddbdc1fe2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

