### PR TITLE
[api-database-policy] Verify migrations against a fresh PostgreSQL catalog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,6 +309,42 @@ jobs:
       - name: Wait for test services
         wait: test-services
 
+      - name: Build database catalog verifier
+        run: turbo build --filter=@shipfox/api-database-policy
+
+      - name: Verify fresh PostgreSQL catalog
+        env:
+          POSTGRES_HOST: 127.0.0.1
+          POSTGRES_PORT: "5432"
+          POSTGRES_USERNAME: shipfox
+          POSTGRES_PASSWORD: password
+          POSTGRES_DATABASE: api
+          POSTGRES_TLS_MODE: disable
+        run: |
+          set +e
+          pnpm --silent --filter=@shipfox/api-database-policy verify:catalog --json \
+            > "$RUNNER_TEMP/api-database-catalog.json"
+          verifier_exit=$?
+          set -e
+
+          # The catalog verifier is intentionally report-only until the exact
+          # Agent, Workspaces, and migration-history remediation issues land.
+          # Keep unexpected execution failures fatal; ENG-1199 will make any
+          # finding fatal once the temporary baseline is removed.
+          if (( verifier_exit > 1 )); then
+            exit "$verifier_exit"
+          fi
+          jq '{databaseName, serverVersion, counts, findings}' \
+            "$RUNNER_TEMP/api-database-catalog.json"
+
+      - name: Upload database catalog report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: api-database-catalog
+          path: ${{ runner.temp }}/api-database-catalog.json
+          if-no-files-found: ignore
+
       - name: Run tests
         env:
           ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7587,6 +7587,13 @@ importers:
         version: 24.13.2
 
   tools/api-database-policy:
+    dependencies:
+      '@shipfox/node-drizzle':
+        specifier: workspace:*
+        version: link:../../libs/shared/node/drizzle
+      '@shipfox/node-postgres':
+        specifier: workspace:*
+        version: link:../../libs/shared/node/postgres
     devDependencies:
       '@shipfox/biome':
         specifier: workspace:*

--- a/tools/api-database-policy/package.json
+++ b/tools/api-database-policy/package.json
@@ -11,7 +11,12 @@
     "test:watch": "shipfox-vitest-watch",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit",
-    "verify": "node dist/api-database-registry.js"
+    "verify": "node dist/api-database-registry.js",
+    "verify:catalog": "node dist/api-database-catalog.js"
+  },
+  "dependencies": {
+    "@shipfox/node-drizzle": "workspace:*",
+    "@shipfox/node-postgres": "workspace:*"
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",

--- a/tools/api-database-policy/src/api-database-catalog.ts
+++ b/tools/api-database-policy/src/api-database-catalog.ts
@@ -1,0 +1,617 @@
+import {randomUUID} from 'node:crypto';
+import {readdir, readFile} from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import {fileURLToPath} from 'node:url';
+import {drizzle, runMigrations} from '@shipfox/node-drizzle';
+import {closePostgresClient, createPostgresClient, type Pool} from '@shipfox/node-postgres';
+import {
+  type ApiDatabaseRegistry,
+  apiDatabaseRegistry,
+  auditApiDatabaseRegistry,
+  type DatabaseMigrationUnit,
+} from './api-database-registry.js';
+import {
+  auditPostgresCatalog,
+  type CatalogAuditReport,
+  type CatalogConstraint,
+  type CatalogEnum,
+  type CatalogMigrationUnitReport,
+  type CatalogNamespace,
+  type CatalogRelation,
+  type CatalogTrigger,
+  dedupeExpectedObjects,
+  type ExpectedCatalogObject,
+  type ExpectedMigrationHistory,
+  expectedHistoryForUnit,
+  formatCatalogJsonReport,
+  formatCatalogReport,
+  migrationHistoryName,
+  type PostgresCatalog,
+  parseMigrationSql,
+} from './catalog.js';
+
+const repositoryRoot = fileURLToPath(new URL('../../../', import.meta.url));
+const databaseNameExpression = /^[a-z][a-z0-9_]{0,62}$/;
+const sourceFileExpression = /\.[cm]?[jt]sx?$/;
+const sourceDirectoryName = 'src';
+const catalogExecutionErrorExitCode = 2;
+
+interface MigrationSource {
+  path: string;
+  source: string;
+}
+
+interface PreparedMigrationUnit {
+  unit: DatabaseMigrationUnit;
+  sources: readonly MigrationSource[];
+  runtimeHistoryName: string;
+}
+
+export interface VerifyCatalogOptions {
+  databaseName?: string;
+  registry?: ApiDatabaseRegistry;
+  repositoryRoot?: string;
+}
+
+export interface CatalogCliOptions {
+  databaseName?: string;
+  format: 'human' | 'json';
+  help: boolean;
+}
+
+function compareText(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+function quoteIdentifier(value: string): string {
+  if (!databaseNameExpression.test(value)) {
+    throw new Error(`Invalid PostgreSQL database name: ${value}`);
+  }
+  return `"${value}"`;
+}
+
+function generatedDatabaseName(): string {
+  return `shipfox_catalog_${randomUUID().replaceAll('-', '')}`;
+}
+
+function sourceFiles(directory: string): Promise<string[]> {
+  return readdir(directory, {withFileTypes: true}).then(async (entries) => {
+    const files: string[] = [];
+    for (const entry of entries) {
+      if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name === 'coverage') {
+        continue;
+      }
+      const entryPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) files.push(...(await sourceFiles(entryPath)));
+      else if (entry.isFile() && sourceFileExpression.test(entry.name)) files.push(entryPath);
+    }
+    return files.sort(compareText);
+  });
+}
+
+async function readMigrationSources(
+  unit: DatabaseMigrationUnit,
+  root: string,
+): Promise<readonly MigrationSource[]> {
+  const directory = path.join(root, unit.migrationsPath);
+  const entries = await readdir(directory, {withFileTypes: true});
+  const migrationFiles = entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.sql'))
+    .map((entry) => entry.name)
+    .sort(compareText);
+  return Promise.all(
+    migrationFiles.map(async (fileName) => ({
+      path: path.posix.join(unit.migrationsPath, fileName),
+      source: await readFile(path.join(directory, fileName), 'utf8'),
+    })),
+  );
+}
+
+async function currentHistoryLiteral(
+  unit: DatabaseMigrationUnit,
+  registry: ApiDatabaseRegistry,
+  root: string,
+): Promise<string | undefined> {
+  const owner = registry.owners.find((candidate) => candidate.id === unit.ownerId);
+  const packagePaths = new Set<string>([unit.packagePath]);
+  if (owner) packagePaths.add(owner.packagePath);
+  const files = (
+    await Promise.all(
+      [...packagePaths].map(async (packagePath) => {
+        try {
+          return await sourceFiles(path.join(root, packagePath, sourceDirectoryName));
+        } catch {
+          return [];
+        }
+      }),
+    )
+  ).flat();
+  const literal = `__drizzle_migrations_${unit.namespace}`;
+  const escapedLiteral = literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const literalExpression = new RegExp(`['"]${escapedLiteral}['"]`);
+  for (const file of files) {
+    const source = await readFile(file, 'utf8');
+    if (literalExpression.test(source)) return literal;
+  }
+  return undefined;
+}
+
+export async function resolveCurrentMigrationHistoryName({
+  unit,
+  registry,
+  root = repositoryRoot,
+}: {
+  unit: DatabaseMigrationUnit;
+  registry: ApiDatabaseRegistry;
+  root?: string;
+}): Promise<string> {
+  const explicitName = await currentHistoryLiteral(unit, registry, root);
+  if (explicitName) return explicitName;
+  const ownerUnits = registry.migrationUnits.filter(
+    (candidate) => candidate.ownerId === unit.ownerId,
+  );
+  const index = ownerUnits.findIndex((candidate) => candidate.id === unit.id);
+  const suffix = index > 0 ? `_${index}` : '';
+  return `__drizzle_migrations_${unit.ownerId}${suffix}`;
+}
+
+function prepareMigrationUnits(
+  registry: ApiDatabaseRegistry,
+  root: string,
+): Promise<readonly PreparedMigrationUnit[]> {
+  return Promise.all(
+    registry.migrationUnits.map(async (unit) => ({
+      unit,
+      sources: await readMigrationSources(unit, root),
+      runtimeHistoryName: await resolveCurrentMigrationHistoryName({unit, registry, root}),
+    })),
+  );
+}
+
+function expectedObjectsForUnits(
+  preparedUnits: readonly PreparedMigrationUnit[],
+): ExpectedCatalogObject[] {
+  return dedupeExpectedObjects(
+    preparedUnits.flatMap(({unit, sources}) =>
+      sources.flatMap(({path: sourcePath, source}) =>
+        parseMigrationSql({source, sourcePath, unit}),
+      ),
+    ),
+  );
+}
+
+function expectedHistoriesForUnits(
+  preparedUnits: readonly PreparedMigrationUnit[],
+): ExpectedMigrationHistory[] {
+  return preparedUnits.map(({unit, runtimeHistoryName}) =>
+    expectedHistoryForUnit(unit, runtimeHistoryName),
+  );
+}
+
+function migrationUnitReports(
+  preparedUnits: readonly PreparedMigrationUnit[],
+): CatalogMigrationUnitReport[] {
+  return preparedUnits.map(({unit, sources, runtimeHistoryName}) => ({
+    id: unit.id,
+    ownerId: unit.ownerId,
+    namespace: unit.namespace,
+    migrations: sources.length,
+    runtimeMigrationHistoryName: runtimeHistoryName,
+    canonicalMigrationHistoryName: migrationHistoryName(unit.namespace),
+  }));
+}
+
+async function queryRows<T extends Record<string, string | null>>(
+  pool: Pool,
+  query: string,
+): Promise<T[]> {
+  const result = await pool.query<T>(query);
+  return result.rows;
+}
+
+export async function readPostgresCatalog(pool: Pool): Promise<PostgresCatalog> {
+  const [namespaceRows, relationRows, enumRows, constraintRows, triggerRows] = await Promise.all([
+    queryRows<CatalogNamespace & Record<string, string | null>>(
+      pool,
+      `
+        SELECT n.oid::text AS oid, n.nspname AS name
+        FROM pg_namespace AS n
+        WHERE n.nspname IN ('public', 'drizzle')
+           OR (n.nspname NOT LIKE 'pg_%' AND n.nspname <> 'information_schema')
+        ORDER BY n.nspname
+      `,
+    ),
+    queryRows<Record<string, string | null>>(
+      pool,
+      `
+        SELECT
+          c.oid::text AS oid,
+          n.nspname AS schema_name,
+          c.relname AS name,
+          c.relkind AS relkind,
+          COALESCE(i.indrelid, dependency.refobjid)::text AS relation_oid
+        FROM pg_class AS c
+        JOIN pg_namespace AS n ON n.oid = c.relnamespace
+        LEFT JOIN pg_index AS i ON i.indexrelid = c.oid
+        LEFT JOIN (
+          SELECT objid, min(refobjid) AS refobjid
+          FROM pg_depend
+          WHERE classid = 'pg_class'::regclass
+            AND refclassid = 'pg_class'::regclass
+            AND deptype = 'a'
+          GROUP BY objid
+        ) AS dependency ON dependency.objid = c.oid
+        WHERE n.nspname NOT LIKE 'pg_%'
+          AND n.nspname <> 'information_schema'
+          AND c.relkind IN ('r', 'p', 'f', 'i', 'I', 'S', 'v', 'm')
+        ORDER BY n.nspname, c.relname
+      `,
+    ),
+    queryRows<Record<string, string | null>>(
+      pool,
+      `
+        SELECT t.oid::text AS oid, n.nspname AS schema_name, t.typname AS name
+        FROM pg_type AS t
+        JOIN pg_namespace AS n ON n.oid = t.typnamespace
+        WHERE t.typtype = 'e'
+          AND n.nspname NOT LIKE 'pg_%'
+          AND n.nspname <> 'information_schema'
+        ORDER BY n.nspname, t.typname
+      `,
+    ),
+    queryRows<Record<string, string | null>>(
+      pool,
+      `
+        SELECT
+          con.oid::text AS oid,
+          ns.nspname AS schema_name,
+          con.conname AS name,
+          con.contype AS type,
+          source.oid::text AS relation_oid,
+          source_ns.nspname AS relation_schema_name,
+          source.relname AS relation_name,
+          referenced.oid::text AS referenced_relation_oid,
+          referenced_ns.nspname AS referenced_relation_schema_name,
+          referenced.relname AS referenced_relation_name
+        FROM pg_constraint AS con
+        JOIN pg_namespace AS ns ON ns.oid = con.connamespace
+        LEFT JOIN pg_class AS source ON source.oid = con.conrelid
+        LEFT JOIN pg_namespace AS source_ns ON source_ns.oid = source.relnamespace
+        LEFT JOIN pg_class AS referenced ON referenced.oid = con.confrelid
+        LEFT JOIN pg_namespace AS referenced_ns ON referenced_ns.oid = referenced.relnamespace
+        WHERE ns.nspname NOT LIKE 'pg_%'
+          AND ns.nspname <> 'information_schema'
+        ORDER BY ns.nspname, con.conname
+      `,
+    ),
+    queryRows<Record<string, string | null>>(
+      pool,
+      `
+        SELECT
+          trigger.oid::text AS oid,
+          ns.nspname AS schema_name,
+          trigger.tgname AS name,
+          relation.oid::text AS relation_oid,
+          relation.relname AS relation_name
+        FROM pg_trigger AS trigger
+        JOIN pg_class AS relation ON relation.oid = trigger.tgrelid
+        JOIN pg_namespace AS ns ON ns.oid = relation.relnamespace
+        WHERE NOT trigger.tgisinternal
+          AND ns.nspname NOT LIKE 'pg_%'
+          AND ns.nspname <> 'information_schema'
+        ORDER BY ns.nspname, trigger.tgname
+      `,
+    ),
+  ]);
+
+  const namespaces: CatalogNamespace[] = namespaceRows.map((row) => ({
+    oid: row.oid,
+    name: row.name,
+  }));
+  const relations: CatalogRelation[] = relationRows.map((row) => ({
+    oid: row.oid ?? '',
+    schemaName: row.schema_name ?? '',
+    name: row.name ?? '',
+    relkind: row.relkind ?? '',
+    relationOid: row.relation_oid ?? null,
+  }));
+  const enums: CatalogEnum[] = enumRows.map((row) => ({
+    oid: row.oid ?? '',
+    schemaName: row.schema_name ?? '',
+    name: row.name ?? '',
+  }));
+  const constraints: CatalogConstraint[] = constraintRows.map((row) => ({
+    oid: row.oid ?? '',
+    schemaName: row.schema_name ?? '',
+    name: row.name ?? '',
+    type: row.type ?? '',
+    relationOid: row.relation_oid ?? null,
+    relationSchemaName: row.relation_schema_name ?? null,
+    relationName: row.relation_name ?? null,
+    referencedRelationOid: row.referenced_relation_oid ?? null,
+    referencedRelationSchemaName: row.referenced_relation_schema_name ?? null,
+    referencedRelationName: row.referenced_relation_name ?? null,
+  }));
+  const triggers: CatalogTrigger[] = triggerRows.map((row) => ({
+    oid: row.oid ?? '',
+    schemaName: row.schema_name ?? '',
+    name: row.name ?? '',
+    relationOid: row.relation_oid ?? '',
+    relationName: row.relation_name ?? '',
+  }));
+  return {namespaces, relations, enums, constraints, triggers};
+}
+
+async function serverVersion(pool: Pool): Promise<{version: string; versionNumber: number}> {
+  const result = await pool.query<{version: string; version_number: string}>(
+    `SELECT current_setting('server_version') AS version, current_setting('server_version_num') AS version_number`,
+  );
+  const row = result.rows[0];
+  if (!row) throw new Error('PostgreSQL did not return its server version');
+  return {version: row.version, versionNumber: Number(row.version_number)};
+}
+
+async function databaseExists(pool: Pool, databaseName: string): Promise<boolean> {
+  const result = await pool.query<{datname: string}>(
+    'SELECT datname FROM pg_database WHERE datname = $1',
+    [databaseName],
+  );
+  return result.rowCount === 1;
+}
+
+async function databaseHasUserObjects(pool: Pool): Promise<boolean> {
+  const namespaces = await pool.query<{count: string}>(`
+    SELECT count(*)::text AS count
+    FROM pg_namespace
+    WHERE nspname NOT LIKE 'pg_%'
+      AND nspname <> 'information_schema'
+      AND nspname <> 'public'
+  `);
+  if (Number(namespaces.rows[0]?.count ?? 0) > 0) return true;
+
+  const relations = await pool.query<{count: string}>(`
+    SELECT count(*)::text AS count
+    FROM pg_class AS c
+    JOIN pg_namespace AS n ON n.oid = c.relnamespace
+    WHERE n.nspname NOT LIKE 'pg_%'
+      AND n.nspname <> 'information_schema'
+      AND c.relkind IN ('r', 'p', 'f', 'i', 'I', 'S', 'v', 'm')
+  `);
+  if (Number(relations.rows[0]?.count ?? 0) > 0) return true;
+
+  const enums = await pool.query<{count: string}>(`
+    SELECT count(*)::text AS count
+    FROM pg_type AS t
+    JOIN pg_namespace AS n ON n.oid = t.typnamespace
+    WHERE t.typtype = 'e'
+      AND n.nspname NOT LIKE 'pg_%'
+      AND n.nspname <> 'information_schema'
+  `);
+  return Number(enums.rows[0]?.count ?? 0) > 0;
+}
+
+async function createDatabase(adminPool: Pool, databaseName: string): Promise<void> {
+  await adminPool.query(`CREATE DATABASE ${quoteIdentifier(databaseName)}`);
+}
+
+async function dropDatabase(adminPool: Pool, databaseName: string): Promise<void> {
+  await adminPool.query(`DROP DATABASE ${quoteIdentifier(databaseName)} WITH (FORCE)`);
+}
+
+async function closePool(): Promise<void> {
+  await closePostgresClient();
+}
+
+async function cleanupCatalogResources({
+  adminDatabaseName,
+  databaseName,
+  targetCreated,
+  adminPool,
+  targetPool,
+}: {
+  adminDatabaseName: string;
+  databaseName: string;
+  targetCreated: boolean;
+  adminPool: Pool | undefined;
+  targetPool: Pool | undefined;
+}): Promise<void> {
+  let cleanupError: unknown;
+  try {
+    if (targetPool) await closePool();
+    else if (adminPool) await closePool();
+  } catch (error) {
+    cleanupError = error;
+  }
+
+  if (targetCreated) {
+    // A failed shutdown can leave the shared client occupied; retry before opening the admin client.
+    try {
+      await closePool();
+    } catch (error) {
+      if (!cleanupError) cleanupError = error;
+    }
+    try {
+      const cleanupPool = createPostgresClient({database: adminDatabaseName});
+      await dropDatabase(cleanupPool, databaseName);
+    } catch (error) {
+      if (!cleanupError) cleanupError = error;
+    }
+    try {
+      await closePool();
+    } catch (error) {
+      if (!cleanupError) cleanupError = error;
+    }
+  }
+
+  if (cleanupError) throw cleanupError;
+}
+
+async function verifyRegistry(registry: ApiDatabaseRegistry): Promise<void> {
+  const errors = await auditApiDatabaseRegistry(registry);
+  if (errors.length > 0) {
+    throw new Error(`API database registry failed (${errors.length} errors): ${errors.join('; ')}`);
+  }
+}
+
+export async function verifyFreshCatalog({
+  databaseName: requestedDatabaseName,
+  registry = apiDatabaseRegistry,
+  repositoryRoot: root = repositoryRoot,
+}: VerifyCatalogOptions = {}): Promise<CatalogAuditReport> {
+  await verifyRegistry(registry);
+  const adminDatabaseName = process.env.POSTGRES_DATABASE || 'api';
+  const databaseName = requestedDatabaseName ?? generatedDatabaseName();
+  if (databaseName === adminDatabaseName) {
+    throw new Error('The catalog target must not be the configured administrative database');
+  }
+  quoteIdentifier(databaseName);
+
+  const generated = requestedDatabaseName === undefined;
+  let targetCreated = false;
+  let adminPool: Pool | undefined;
+  let targetPool: Pool | undefined;
+  let report: CatalogAuditReport | undefined;
+  let verificationError: unknown;
+  try {
+    adminPool = createPostgresClient({database: adminDatabaseName});
+    if (await databaseExists(adminPool, databaseName)) {
+      if (generated) throw new Error(`Generated catalog database already exists: ${databaseName}`);
+      await closePool();
+      targetPool = createPostgresClient({database: databaseName});
+      if (await databaseHasUserObjects(targetPool)) {
+        throw new Error(`Catalog target database is not empty: ${databaseName}`);
+      }
+      await closePool();
+      targetPool = undefined;
+    } else {
+      if (!generated) throw new Error(`Catalog target database does not exist: ${databaseName}`);
+      await createDatabase(adminPool, databaseName);
+      targetCreated = true;
+      await closePool();
+      adminPool = undefined;
+    }
+
+    const preparedUnits = await prepareMigrationUnits(registry, root);
+    const expectedObjects = expectedObjectsForUnits(preparedUnits);
+    const expectedHistories = expectedHistoriesForUnits(preparedUnits);
+    const reports = migrationUnitReports(preparedUnits);
+
+    targetPool = createPostgresClient({database: databaseName});
+    const version = await serverVersion(targetPool);
+    if (Math.floor(version.versionNumber / 10_000) !== 18) {
+      throw new Error(`Catalog verification requires PostgreSQL 18, found ${version.version}`);
+    }
+    const database = drizzle(targetPool);
+    for (const prepared of preparedUnits) {
+      await runMigrations(
+        database,
+        path.join(root, prepared.unit.migrationsPath),
+        prepared.runtimeHistoryName,
+      );
+    }
+    const catalog = await readPostgresCatalog(targetPool);
+    report = auditPostgresCatalog({
+      catalog,
+      expectedObjects,
+      expectedHistories,
+      migrationUnits: reports,
+      registry,
+      databaseName,
+      serverVersion: version.version,
+    });
+  } catch (error) {
+    verificationError = error;
+  }
+
+  let cleanupError: unknown;
+  try {
+    await cleanupCatalogResources({
+      adminDatabaseName,
+      databaseName,
+      targetCreated,
+      adminPool,
+      targetPool,
+    });
+  } catch (error) {
+    cleanupError = error;
+  }
+
+  if (verificationError) throw verificationError;
+  if (cleanupError) throw cleanupError;
+  if (!report) throw new Error('Catalog verification completed without a report');
+  return report;
+}
+
+export function parseCatalogCliArgs(
+  argv: readonly string[] = process.argv.slice(2),
+): CatalogCliOptions {
+  let databaseName: string | undefined;
+  let format: CatalogCliOptions['format'] = 'human';
+  let help = false;
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--help' || argument === '-h') {
+      help = true;
+    } else if (argument === '--json' || argument === '--format=json') {
+      format = 'json';
+    } else if (argument === '--format') {
+      const value = argv[index + 1];
+      if (value !== 'human' && value !== 'json')
+        throw new Error(`Unsupported catalog format: ${value}`);
+      format = value;
+      index += 1;
+    } else if (argument === '--database') {
+      databaseName = argv[index + 1];
+      if (!databaseName) throw new Error('--database requires a value');
+      index += 1;
+    } else if (argument?.startsWith('--database=')) {
+      databaseName = argument.slice('--database='.length);
+      if (!databaseName) throw new Error('--database requires a value');
+    } else {
+      throw new Error(`Unknown catalog option: ${argument}`);
+    }
+  }
+  return {
+    ...(databaseName ? {databaseName} : {}),
+    format,
+    help,
+  };
+}
+
+function catalogHelp(): string {
+  return [
+    'Usage: pnpm --filter=@shipfox/api-database-policy verify:catalog [options]',
+    '',
+    'Options:',
+    '  --database <name>  Audit an existing empty database instead of a generated temporary database',
+    '  --json             Emit the complete report as JSON',
+    '  --format <format>  Emit human or json output (default: human)',
+    '  --help             Show this help',
+  ].join('\n');
+}
+
+async function main(): Promise<void> {
+  const options = parseCatalogCliArgs();
+  if (options.help) {
+    process.stdout.write(`${catalogHelp()}\n`);
+    return;
+  }
+  const report = await verifyFreshCatalog(
+    options.databaseName ? {databaseName: options.databaseName} : {},
+  );
+  process.stdout.write(
+    options.format === 'json' ? formatCatalogJsonReport(report) : formatCatalogReport(report),
+  );
+  if (report.findings.length > 0) process.exitCode = 1;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`API database catalog verification failed: ${message}\n`);
+    process.exitCode = catalogExecutionErrorExitCode;
+  });
+}

--- a/tools/api-database-policy/src/catalog.ts
+++ b/tools/api-database-policy/src/catalog.ts
@@ -1,0 +1,1099 @@
+import type {ApiDatabaseRegistry, DatabaseMigrationUnit} from './api-database-registry.js';
+
+export type CatalogObjectKind =
+  | 'constraint'
+  | 'enum'
+  | 'index'
+  | 'migration-history'
+  | 'schema'
+  | 'sequence'
+  | 'table'
+  | 'trigger'
+  | 'view';
+
+export type CatalogFindingClassification = 'cross-owner' | 'misnamed' | 'missing' | 'unknown';
+
+export type CatalogObjectClassification = 'compliant' | CatalogFindingClassification;
+
+export interface ExpectedCatalogObject {
+  kind: Exclude<CatalogObjectKind, 'migration-history' | 'schema'>;
+  schemaName: string;
+  name: string;
+  ownerId: string;
+  migrationUnitId: string;
+  namespace: string;
+  relationName?: string;
+  sourcePath: string;
+  line: number;
+}
+
+export interface ExpectedMigrationHistory {
+  kind: 'migration-history';
+  schemaName: 'drizzle';
+  name: string;
+  runtimeName: string;
+  ownerId: string;
+  migrationUnitId: string;
+  namespace: string;
+  sourcePath: string;
+  line: number;
+}
+
+export interface CatalogNamespace {
+  oid: string;
+  name: string;
+}
+
+export interface CatalogRelation {
+  oid: string;
+  schemaName: string;
+  name: string;
+  relkind: string;
+  relationOid?: string | null;
+}
+
+export interface CatalogEnum {
+  oid: string;
+  schemaName: string;
+  name: string;
+}
+
+export interface CatalogConstraint {
+  oid: string;
+  schemaName: string;
+  name: string;
+  type: string;
+  relationOid: string | null;
+  relationSchemaName: string | null;
+  relationName: string | null;
+  referencedRelationOid: string | null;
+  referencedRelationSchemaName: string | null;
+  referencedRelationName: string | null;
+}
+
+export interface CatalogTrigger {
+  oid: string;
+  schemaName: string;
+  name: string;
+  relationOid: string;
+  relationName: string;
+}
+
+export interface PostgresCatalog {
+  namespaces: readonly CatalogNamespace[];
+  relations: readonly CatalogRelation[];
+  enums: readonly CatalogEnum[];
+  constraints: readonly CatalogConstraint[];
+  triggers: readonly CatalogTrigger[];
+}
+
+export interface CatalogMigrationUnitReport {
+  id: string;
+  ownerId: string;
+  namespace: string;
+  migrations: number;
+  runtimeMigrationHistoryName: string;
+  canonicalMigrationHistoryName: string;
+}
+
+export interface CatalogObjectReport {
+  classification: CatalogObjectClassification;
+  kind: CatalogObjectKind;
+  schemaName: string;
+  name: string;
+  ownerId?: string;
+  migrationUnitId?: string;
+  namespace?: string;
+  expectedName?: string;
+  relationName?: string | null;
+  referencedRelationName?: string | null;
+  referencedOwnerId?: string;
+  sourcePath?: string;
+  line?: number;
+}
+
+export interface CatalogFinding {
+  classification: CatalogFindingClassification;
+  kind: CatalogObjectKind;
+  schemaName: string;
+  name: string;
+  ownerId?: string;
+  migrationUnitId?: string;
+  namespace?: string;
+  expectedName?: string;
+  referencedOwnerId?: string;
+  sourcePath?: string;
+  line?: number;
+  message: string;
+}
+
+export interface CatalogReportCounts {
+  compliant: number;
+  constraints: number;
+  enums: number;
+  indexes: number;
+  migrationHistories: number;
+  schemas: number;
+  sequences: number;
+  tables: number;
+  triggers: number;
+  unknown: number;
+  views: number;
+}
+
+export interface CatalogAuditReport {
+  databaseName?: string;
+  serverVersion?: string;
+  migrationUnits: readonly CatalogMigrationUnitReport[];
+  objects: readonly CatalogObjectReport[];
+  findings: readonly CatalogFinding[];
+  counts: CatalogReportCounts;
+}
+
+interface ParsedIdentifier {
+  schemaName?: string;
+  name: string;
+  end: number;
+}
+
+interface ParsedTableRange {
+  start: number;
+  end: number;
+  schemaName: string;
+  name: string;
+}
+
+interface ParsedMigrationStatement {
+  kind: Exclude<CatalogObjectKind, 'migration-history' | 'schema'> | 'type';
+  name: ParsedIdentifier;
+  relationName?: string;
+  relationSchemaName?: string;
+  start: number;
+}
+
+const identifierStartExpression = /[A-Za-z_]/;
+const identifierPartExpression = /[A-Za-z0-9_$]/;
+const dollarQuoteTagStartExpression = /[A-Za-z_]/;
+const dollarQuoteTagPartExpression = /[A-Za-z0-9_]/;
+const enumExpression = /\bAS\s+ENUM\b/i;
+const ifNotExistsExpression = /^IF\s+NOT\s+EXISTS\b/i;
+const ifExistsExpression = /^IF\s+EXISTS\b/i;
+const whitespaceExpression = /\s/;
+const postgresIdentifierLimit = 63;
+
+function postgresIdentifierName(name: string): string {
+  if (Buffer.byteLength(name, 'utf8') <= postgresIdentifierLimit) return name;
+  let end = name.length;
+  while (end > 0 && Buffer.byteLength(name.slice(0, end), 'utf8') > postgresIdentifierLimit) {
+    end -= 1;
+  }
+  return name.slice(0, end);
+}
+
+function skipWhitespace(source: string, offset: number): number {
+  let cursor = offset;
+  while (cursor < source.length && whitespaceExpression.test(source[cursor] ?? '')) cursor += 1;
+  return cursor;
+}
+
+function readIdentifier(source: string, offset: number): ParsedIdentifier | undefined {
+  let cursor = skipWhitespace(source, offset);
+  const first = source[cursor];
+  if (first === '"') {
+    cursor += 1;
+    let value = '';
+    while (cursor < source.length) {
+      const character = source[cursor];
+      if (character === '"') {
+        if (source[cursor + 1] === '"') {
+          value += '"';
+          cursor += 2;
+          continue;
+        }
+        return {name: value, end: cursor + 1};
+      }
+      value += character;
+      cursor += 1;
+    }
+    return undefined;
+  }
+
+  if (!first || !identifierStartExpression.test(first)) return undefined;
+  const start = cursor;
+  cursor += 1;
+  while (cursor < source.length && identifierPartExpression.test(source[cursor] ?? '')) {
+    cursor += 1;
+  }
+  return {name: source.slice(start, cursor), end: cursor};
+}
+
+function readQualifiedIdentifier(source: string, offset: number): ParsedIdentifier | undefined {
+  const first = readIdentifier(source, offset);
+  if (!first) return undefined;
+  const dotOffset = skipWhitespace(source, first.end);
+  if (source[dotOffset] !== '.') return first;
+  const second = readIdentifier(source, dotOffset + 1);
+  if (!second) return first;
+  return {schemaName: first.name, name: second.name, end: second.end};
+}
+
+function dollarQuoteDelimiterAt(source: string, offset: number): string | undefined {
+  if (source[offset] !== '$') return undefined;
+  if (source[offset + 1] === '$') return '$$';
+  if (!dollarQuoteTagStartExpression.test(source[offset + 1] ?? '')) return undefined;
+  let cursor = offset + 2;
+  while (cursor < source.length && dollarQuoteTagPartExpression.test(source[cursor] ?? ''))
+    cursor += 1;
+  if (source[cursor] !== '$') return undefined;
+  return source.slice(offset, cursor + 1);
+}
+
+function statementEnd(source: string, offset: number): number {
+  let cursor = offset;
+  let inSingleQuote = false;
+  let inDoubleQuote = false;
+  while (cursor < source.length) {
+    const character = source[cursor];
+    if (inSingleQuote) {
+      if (character === '\\') {
+        cursor += 2;
+        continue;
+      }
+      if (character === "'") {
+        if (source[cursor + 1] === "'") {
+          cursor += 2;
+          continue;
+        }
+        inSingleQuote = false;
+      }
+      cursor += 1;
+      continue;
+    }
+    if (inDoubleQuote) {
+      if (character === '"') {
+        if (source[cursor + 1] === '"') {
+          cursor += 2;
+          continue;
+        }
+        inDoubleQuote = false;
+      }
+      cursor += 1;
+      continue;
+    }
+    if (character === "'") {
+      inSingleQuote = true;
+      cursor += 1;
+      continue;
+    }
+    if (character === '"') {
+      inDoubleQuote = true;
+      cursor += 1;
+      continue;
+    }
+    if (character === '-' && source[cursor + 1] === '-') {
+      const lineEnd = source.indexOf('\n', cursor + 2);
+      cursor = lineEnd === -1 ? source.length : lineEnd + 1;
+      continue;
+    }
+    if (character === '/' && source[cursor + 1] === '*') {
+      const commentEnd = source.indexOf('*/', cursor + 2);
+      cursor = commentEnd === -1 ? source.length : commentEnd + 2;
+      continue;
+    }
+    if (
+      character === '$' &&
+      (cursor === 0 || !identifierPartExpression.test(source[cursor - 1] ?? ''))
+    ) {
+      const delimiter = dollarQuoteDelimiterAt(source, cursor);
+      if (delimiter) {
+        const quoteEnd = source.indexOf(delimiter, cursor + delimiter.length);
+        cursor = quoteEnd === -1 ? source.length : quoteEnd + delimiter.length;
+        continue;
+      }
+    }
+    if (character === ';') return cursor;
+    cursor += 1;
+  }
+  return source.length;
+}
+
+function maskSqlForStatements(source: string): string {
+  const characters = source.split('');
+  const blank = (start: number, end: number): void => {
+    for (let index = start; index < end; index += 1) {
+      if (characters[index] !== '\n' && characters[index] !== '\r') characters[index] = ' ';
+    }
+  };
+
+  let cursor = 0;
+  while (cursor < source.length) {
+    const character = source[cursor];
+    if (character === '-' && source[cursor + 1] === '-') {
+      const lineEnd = source.indexOf('\n', cursor + 2);
+      const end = lineEnd === -1 ? source.length : lineEnd;
+      blank(cursor, end);
+      cursor = end;
+      continue;
+    }
+    if (character === '/' && source[cursor + 1] === '*') {
+      const commentEnd = source.indexOf('*/', cursor + 2);
+      const end = commentEnd === -1 ? source.length : commentEnd + 2;
+      blank(cursor, end);
+      cursor = end;
+      continue;
+    }
+    if (character === "'") {
+      const start = cursor;
+      cursor += 1;
+      while (cursor < source.length) {
+        if (source[cursor] === '\\') {
+          cursor += 2;
+          continue;
+        }
+        if (source[cursor] === "'") {
+          if (source[cursor + 1] === "'") {
+            cursor += 2;
+            continue;
+          }
+          cursor += 1;
+          break;
+        }
+        cursor += 1;
+      }
+      blank(start, cursor);
+      continue;
+    }
+    if (character === '"') {
+      const start = cursor;
+      cursor += 1;
+      while (cursor < source.length) {
+        if (source[cursor] === '"') {
+          if (source[cursor + 1] === '"') {
+            cursor += 2;
+            continue;
+          }
+          cursor += 1;
+          break;
+        }
+        cursor += 1;
+      }
+      blank(start, cursor);
+      continue;
+    }
+    if (
+      character === '$' &&
+      (cursor === 0 || !identifierPartExpression.test(source[cursor - 1] ?? ''))
+    ) {
+      const delimiter = dollarQuoteDelimiterAt(source, cursor);
+      if (delimiter) {
+        const start = cursor;
+        const quoteEnd = source.indexOf(delimiter, cursor + delimiter.length);
+        cursor = quoteEnd === -1 ? source.length : quoteEnd + delimiter.length;
+        blank(start, cursor);
+        continue;
+      }
+    }
+    cursor += 1;
+  }
+  return characters.join('');
+}
+
+function lineNumber(source: string, offset: number): number {
+  let line = 1;
+  for (let cursor = 0; cursor < offset; cursor += 1) {
+    if (source[cursor] === '\n') line += 1;
+  }
+  return line;
+}
+
+function firstKeywordOffset(source: string, keyword: string, offset: number, end: number): number {
+  const expression = new RegExp(`\\b${keyword}\\b`, 'i');
+  const match = expression.exec(source.slice(offset, end));
+  return match?.index === undefined ? -1 : offset + match.index;
+}
+
+function addParsedStatement(
+  statements: ParsedMigrationStatement[],
+  source: string,
+  match: RegExpExecArray,
+  kind: ParsedMigrationStatement['kind'],
+): ParsedMigrationStatement | undefined {
+  const nameOffset = skipWhitespace(source, (match.index ?? 0) + match[0].length);
+  const afterIfNotExists = ifNotExistsExpression.exec(source.slice(nameOffset));
+  const parsedName = readQualifiedIdentifier(
+    source,
+    afterIfNotExists ? nameOffset + afterIfNotExists[0].length : nameOffset,
+  );
+  if (!parsedName) return undefined;
+  const statement: ParsedMigrationStatement = {
+    kind,
+    name: parsedName,
+    start: match.index ?? 0,
+  };
+  statements.push(statement);
+  return statement;
+}
+
+function parseMigrationStatements(source: string): ParsedMigrationStatement[] {
+  const statements: ParsedMigrationStatement[] = [];
+  const searchableSource = maskSqlForStatements(source);
+  const createExpression =
+    /\bCREATE\s+(?:(?:OR\s+REPLACE|UNIQUE|CONCURRENTLY)\s+)*(MATERIALIZED\s+VIEW|FOREIGN\s+TABLE|TABLE|TYPE|INDEX|SEQUENCE|VIEW|TRIGGER)\b/gi;
+  let match = createExpression.exec(searchableSource);
+  while (match) {
+    const createMatch = match;
+    match = createExpression.exec(searchableSource);
+    const keyword = createMatch[1]?.toLowerCase();
+    if (!keyword) continue;
+    let kind = keyword as ParsedMigrationStatement['kind'];
+    if (keyword === 'materialized view') kind = 'view';
+    if (keyword === 'foreign table') kind = 'table';
+    const statement = addParsedStatement(statements, source, createMatch, kind);
+    if (!statement) continue;
+    const end = statementEnd(source, statement.name.end);
+    if (kind === 'index' || kind === 'trigger') {
+      const onOffset = firstKeywordOffset(searchableSource, 'ON', statement.name.end, end);
+      if (onOffset !== -1) {
+        const relation = readQualifiedIdentifier(source, onOffset + 2);
+        if (relation) {
+          statement.relationName = relation.name;
+          if (relation.schemaName) statement.relationSchemaName = relation.schemaName;
+        }
+      }
+    }
+  }
+
+  const alterExpression = /\bALTER\s+TABLE\b/gi;
+  const parsedConstraintOffsets = new Set<number>();
+  match = alterExpression.exec(searchableSource);
+  while (match) {
+    const alterMatch = match;
+    match = alterExpression.exec(searchableSource);
+    const tableOffset = skipWhitespace(source, (alterMatch.index ?? 0) + alterMatch[0].length);
+    const afterIfExists = ifExistsExpression.exec(searchableSource.slice(tableOffset));
+    const table = readQualifiedIdentifier(
+      source,
+      afterIfExists ? tableOffset + afterIfExists[0].length : tableOffset,
+    );
+    if (!table) continue;
+    const end = statementEnd(source, table.end);
+    const constraintOffset = firstKeywordOffset(searchableSource, 'CONSTRAINT', table.end, end);
+    if (constraintOffset === -1) continue;
+    const constraint = readIdentifier(source, constraintOffset + 'CONSTRAINT'.length);
+    if (!constraint) continue;
+    statements.push({
+      kind: 'constraint',
+      name: constraint,
+      relationName: table.name,
+      ...(table.schemaName ? {relationSchemaName: table.schemaName} : {}),
+      start: alterMatch.index ?? 0,
+    });
+    parsedConstraintOffsets.add(constraintOffset);
+  }
+
+  const tableRanges: ParsedTableRange[] = statements
+    .filter((statement) => statement.kind === 'table')
+    .map((statement) => ({
+      start: statement.start,
+      end: statementEnd(source, statement.name.end),
+      schemaName: statement.name.schemaName ?? 'public',
+      name: statement.name.name,
+    }));
+  const constraintExpression = /\bCONSTRAINT\b/gi;
+  match = constraintExpression.exec(searchableSource);
+  while (match) {
+    const constraintMatch = match;
+    match = constraintExpression.exec(searchableSource);
+    if (parsedConstraintOffsets.has(constraintMatch.index ?? 0)) continue;
+    const name = readIdentifier(source, (constraintMatch.index ?? 0) + constraintMatch[0].length);
+    if (!name) continue;
+    const range = tableRanges.find(
+      (candidate) =>
+        (constraintMatch.index ?? 0) >= candidate.start &&
+        (constraintMatch.index ?? 0) <= candidate.end,
+    );
+    statements.push({
+      kind: 'constraint',
+      name,
+      ...(range?.name ? {relationName: range.name} : {}),
+      ...(range?.schemaName ? {relationSchemaName: range.schemaName} : {}),
+      start: constraintMatch.index ?? 0,
+    });
+  }
+
+  return statements;
+}
+
+export function parseMigrationSql({
+  source,
+  sourcePath,
+  unit,
+}: {
+  source: string;
+  sourcePath: string;
+  unit: DatabaseMigrationUnit;
+}): ExpectedCatalogObject[] {
+  const result: ExpectedCatalogObject[] = [];
+  const searchableSource = maskSqlForStatements(source);
+  for (const statement of parseMigrationStatements(source)) {
+    if (statement.kind === 'type') {
+      const end = statementEnd(source, statement.name.end);
+      const statementText = searchableSource.slice(statement.name.end, end);
+      if (!enumExpression.test(statementText)) continue;
+    }
+    const kind = statement.kind === 'type' ? 'enum' : statement.kind;
+    result.push({
+      kind,
+      schemaName: statement.name.schemaName ?? 'public',
+      name: statement.name.name,
+      ownerId: unit.ownerId,
+      migrationUnitId: unit.id,
+      namespace: unit.namespace,
+      ...(statement.relationName ? {relationName: statement.relationName} : {}),
+      sourcePath,
+      line: lineNumber(source, statement.start),
+    });
+  }
+  return result;
+}
+
+export function migrationHistoryName(namespace: string): string {
+  return `__drizzle_migrations_${namespace}`;
+}
+
+export function ownerForObjectName(
+  name: string,
+  registry: ApiDatabaseRegistry,
+): {ownerId: string; namespace: string} | undefined {
+  const matches = registry.migrationUnits
+    .filter((unit) => name.startsWith(`${unit.namespace}_`))
+    .sort((left, right) => right.namespace.length - left.namespace.length);
+  const match = matches[0];
+  return match ? {ownerId: match.ownerId, namespace: match.namespace} : undefined;
+}
+
+function objectKey(kind: CatalogObjectKind, schemaName: string, name: string): string {
+  return `${kind}:${schemaName}:${name}`;
+}
+
+function actualRelationKind(relkind: string): CatalogObjectKind | undefined {
+  if (relkind === 'r' || relkind === 'p' || relkind === 'f') return 'table';
+  if (relkind === 'i' || relkind === 'I') return 'index';
+  if (relkind === 'S') return 'sequence';
+  if (relkind === 'v' || relkind === 'm') return 'view';
+  return undefined;
+}
+
+function expectedObjectStatus(
+  object: ExpectedCatalogObject,
+  registry: ApiDatabaseRegistry,
+): CatalogObjectClassification {
+  const owner = ownerForObjectName(object.name, registry);
+  if (owner && owner.ownerId !== object.ownerId) return 'cross-owner';
+  return object.name.startsWith(`${object.namespace}_`) ? 'compliant' : 'misnamed';
+}
+
+function addFinding(
+  findings: CatalogFinding[],
+  object: CatalogObjectReport,
+  classification: CatalogFindingClassification,
+  message: string,
+): void {
+  findings.push({
+    classification,
+    kind: object.kind,
+    schemaName: object.schemaName,
+    name: object.name,
+    ...(object.ownerId ? {ownerId: object.ownerId} : {}),
+    ...(object.migrationUnitId ? {migrationUnitId: object.migrationUnitId} : {}),
+    ...(object.namespace ? {namespace: object.namespace} : {}),
+    ...(object.expectedName ? {expectedName: object.expectedName} : {}),
+    ...(object.referencedOwnerId ? {referencedOwnerId: object.referencedOwnerId} : {}),
+    ...(object.sourcePath ? {sourcePath: object.sourcePath} : {}),
+    ...(object.line ? {line: object.line} : {}),
+    message,
+  });
+}
+
+function reportFromExpected(
+  object: ExpectedCatalogObject,
+  classification: CatalogObjectClassification,
+  actualName = object.name,
+): CatalogObjectReport {
+  return {
+    classification,
+    kind: object.kind,
+    schemaName: object.schemaName,
+    name: actualName,
+    ownerId: object.ownerId,
+    migrationUnitId: object.migrationUnitId,
+    namespace: object.namespace,
+    relationName: object.relationName ?? null,
+    sourcePath: object.sourcePath,
+    line: object.line,
+  };
+}
+
+function tableOwnerLookup(expectedObjects: readonly ExpectedCatalogObject[]): Map<string, string> {
+  const owners = new Map<string, string>();
+  for (const object of expectedObjects) {
+    if (object.kind === 'table') {
+      owners.set(`${object.schemaName}:${postgresIdentifierName(object.name)}`, object.ownerId);
+    }
+  }
+  return owners;
+}
+
+function ownerForRelation(
+  schemaName: string | null,
+  name: string | null,
+  tableOwners: ReadonlyMap<string, string>,
+  registry: ApiDatabaseRegistry,
+): string | undefined {
+  if (!schemaName || !name) return undefined;
+  return (
+    tableOwners.get(`${schemaName}:${name}`) ??
+    tableOwners.get(`${schemaName}:${postgresIdentifierName(name)}`) ??
+    ownerForObjectName(name, registry)?.ownerId
+  );
+}
+
+function crossOwnerForeignKey(
+  constraint: CatalogConstraint,
+  tableOwners: ReadonlyMap<string, string>,
+  registry: ApiDatabaseRegistry,
+): {sourceOwner: string; referencedOwner: string} | undefined {
+  if (constraint.type !== 'f') return undefined;
+  const sourceOwner = ownerForRelation(
+    constraint.relationSchemaName,
+    constraint.relationName,
+    tableOwners,
+    registry,
+  );
+  const referencedOwner = ownerForRelation(
+    constraint.referencedRelationSchemaName,
+    constraint.referencedRelationName,
+    tableOwners,
+    registry,
+  );
+  if (!sourceOwner || !referencedOwner || sourceOwner === referencedOwner) return undefined;
+  return {sourceOwner, referencedOwner};
+}
+
+function classifyUnexpectedRelation(
+  relation: CatalogRelation,
+  catalog: PostgresCatalog,
+  tableOwners: ReadonlyMap<string, string>,
+  registry: ApiDatabaseRegistry,
+): CatalogObjectClassification {
+  const kind = actualRelationKind(relation.relkind);
+  if (!kind) return 'unknown';
+  if ((kind === 'index' || kind === 'sequence') && relation.relationOid) {
+    const ownerRelation = [...catalog.relations].find(
+      (candidate) => candidate.oid === relation.relationOid,
+    );
+    if (
+      ownerRelation &&
+      actualRelationKind(ownerRelation.relkind) === 'table' &&
+      ownerForRelation(ownerRelation.schemaName, ownerRelation.name, tableOwners, registry)
+    ) {
+      return 'compliant';
+    }
+  }
+  return 'unknown';
+}
+
+function sortFindings(left: CatalogFinding, right: CatalogFinding): number {
+  const leftKey = [left.classification, left.schemaName, left.name, left.kind].join(':');
+  const rightKey = [right.classification, right.schemaName, right.name, right.kind].join(':');
+  return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0;
+}
+
+function sortObjects(left: CatalogObjectReport, right: CatalogObjectReport): number {
+  const leftKey = [left.schemaName, left.name, left.kind].join(':');
+  const rightKey = [right.schemaName, right.name, right.kind].join(':');
+  return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0;
+}
+
+export function auditPostgresCatalog({
+  catalog,
+  expectedObjects,
+  expectedHistories,
+  migrationUnits,
+  registry,
+  databaseName,
+  serverVersion,
+}: {
+  catalog: PostgresCatalog;
+  expectedObjects: readonly ExpectedCatalogObject[];
+  expectedHistories: readonly ExpectedMigrationHistory[];
+  migrationUnits: readonly CatalogMigrationUnitReport[];
+  registry: ApiDatabaseRegistry;
+  databaseName?: string;
+  serverVersion?: string;
+}): CatalogAuditReport {
+  const findings: CatalogFinding[] = [];
+  const objects: CatalogObjectReport[] = [];
+  const consumedActualKeys = new Set<string>();
+  const actualByKey = new Map<
+    string,
+    CatalogRelation | CatalogEnum | CatalogConstraint | CatalogTrigger
+  >();
+
+  for (const relation of catalog.relations) {
+    const kind = actualRelationKind(relation.relkind);
+    if (kind && relation.schemaName !== 'drizzle') {
+      actualByKey.set(objectKey(kind, relation.schemaName, relation.name), relation);
+    }
+  }
+  for (const enumObject of catalog.enums) {
+    actualByKey.set(objectKey('enum', enumObject.schemaName, enumObject.name), enumObject);
+  }
+  for (const constraint of catalog.constraints) {
+    actualByKey.set(objectKey('constraint', constraint.schemaName, constraint.name), constraint);
+  }
+  for (const trigger of catalog.triggers) {
+    actualByKey.set(objectKey('trigger', trigger.schemaName, trigger.name), trigger);
+  }
+
+  const tableOwners = tableOwnerLookup(expectedObjects);
+  for (const object of expectedObjects) {
+    const key = objectKey(object.kind, object.schemaName, postgresIdentifierName(object.name));
+    const actual = actualByKey.get(key);
+    if (!actual) {
+      const reportObject = reportFromExpected(object, 'missing');
+      objects.push(reportObject);
+      addFinding(
+        findings,
+        reportObject,
+        'missing',
+        `Missing ${object.kind} ${object.schemaName}.${object.name} declared by ${object.migrationUnitId}`,
+      );
+      continue;
+    }
+    consumedActualKeys.add(key);
+    let classification = expectedObjectStatus(object, registry);
+    const foreignKeyOwners =
+      object.kind === 'constraint' && 'type' in actual
+        ? crossOwnerForeignKey(actual, tableOwners, registry)
+        : undefined;
+    if (foreignKeyOwners) classification = 'cross-owner';
+    const reportObject = reportFromExpected(object, classification, actual.name);
+    objects.push(reportObject);
+    if (classification === 'misnamed') {
+      reportObject.expectedName = `${object.namespace}_...`;
+      addFinding(
+        findings,
+        reportObject,
+        'misnamed',
+        `${object.kind} ${object.schemaName}.${object.name} is owned by ${object.ownerId} but must use the ${object.namespace}_ namespace`,
+      );
+    } else if (classification === 'cross-owner') {
+      const foreignOwner =
+        foreignKeyOwners?.referencedOwner ?? ownerForObjectName(object.name, registry)?.ownerId;
+      if (foreignOwner) reportObject.referencedOwnerId = foreignOwner;
+      addFinding(
+        findings,
+        reportObject,
+        'cross-owner',
+        foreignKeyOwners
+          ? `Foreign key ${object.schemaName}.${actual.name} crosses from ${foreignKeyOwners.sourceOwner} to ${foreignKeyOwners.referencedOwner}`
+          : `${object.kind} ${object.schemaName}.${object.name} is declared by ${object.ownerId} but uses the ${foreignOwner ?? 'unknown'} namespace`,
+      );
+    }
+  }
+
+  const historyByName = new Map(
+    catalog.relations
+      .filter(
+        (relation) =>
+          relation.schemaName === 'drizzle' && actualRelationKind(relation.relkind) === 'table',
+      )
+      .map((relation) => [relation.name, relation]),
+  );
+  for (const history of expectedHistories) {
+    const actual = historyByName.get(history.runtimeName);
+    const reportObject: CatalogObjectReport = {
+      classification:
+        actual && history.runtimeName === history.name
+          ? 'compliant'
+          : actual
+            ? 'misnamed'
+            : 'missing',
+      kind: 'migration-history',
+      schemaName: history.schemaName,
+      name: actual?.name ?? history.name,
+      ownerId: history.ownerId,
+      migrationUnitId: history.migrationUnitId,
+      namespace: history.namespace,
+      expectedName: history.name,
+      sourcePath: history.sourcePath,
+      line: history.line,
+    };
+    objects.push(reportObject);
+    if (actual) {
+      consumedActualKeys.add(objectKey('migration-history', 'drizzle', actual.name));
+      if (history.runtimeName !== history.name) {
+        addFinding(
+          findings,
+          reportObject,
+          'misnamed',
+          `Migration history for ${history.migrationUnitId} uses ${history.runtimeName} instead of ${history.name}`,
+        );
+      }
+    } else {
+      addFinding(
+        findings,
+        reportObject,
+        'missing',
+        `Missing migration history drizzle.${history.name} for ${history.migrationUnitId}`,
+      );
+    }
+  }
+
+  for (const relation of catalog.relations) {
+    if (relation.schemaName === 'drizzle') {
+      if (actualRelationKind(relation.relkind) === 'table') {
+        const key = objectKey('migration-history', 'drizzle', relation.name);
+        if (!consumedActualKeys.has(key)) {
+          const reportObject: CatalogObjectReport = {
+            classification: 'unknown',
+            kind: 'migration-history',
+            schemaName: 'drizzle',
+            name: relation.name,
+          };
+          objects.push(reportObject);
+          addFinding(
+            findings,
+            reportObject,
+            'unknown',
+            `Unknown migration history drizzle.${relation.name}`,
+          );
+        }
+      }
+      continue;
+    }
+    const kind = actualRelationKind(relation.relkind);
+    if (!kind) continue;
+    const key = objectKey(kind, relation.schemaName, relation.name);
+    if (consumedActualKeys.has(key)) continue;
+    const classification = classifyUnexpectedRelation(relation, catalog, tableOwners, registry);
+    const reportObject: CatalogObjectReport = {
+      classification,
+      kind,
+      schemaName: relation.schemaName,
+      name: relation.name,
+    };
+    objects.push(reportObject);
+    if (classification !== 'compliant') {
+      addFinding(
+        findings,
+        reportObject,
+        classification,
+        `Unknown ${kind} ${relation.schemaName}.${relation.name}`,
+      );
+    }
+  }
+
+  for (const enumObject of catalog.enums) {
+    const key = objectKey('enum', enumObject.schemaName, enumObject.name);
+    if (consumedActualKeys.has(key)) continue;
+    const reportObject: CatalogObjectReport = {
+      classification: 'unknown',
+      kind: 'enum',
+      schemaName: enumObject.schemaName,
+      name: enumObject.name,
+    };
+    objects.push(reportObject);
+    addFinding(
+      findings,
+      reportObject,
+      'unknown',
+      `Unknown enum ${enumObject.schemaName}.${enumObject.name}`,
+    );
+  }
+
+  for (const constraint of catalog.constraints) {
+    if (constraint.schemaName === 'drizzle') continue;
+    const key = objectKey('constraint', constraint.schemaName, constraint.name);
+    if (consumedActualKeys.has(key)) continue;
+    const sourceOwner = ownerForRelation(
+      constraint.relationSchemaName,
+      constraint.relationName,
+      tableOwners,
+      registry,
+    );
+    const foreignKeyOwners = crossOwnerForeignKey(constraint, tableOwners, registry);
+    const classification: CatalogObjectClassification = foreignKeyOwners
+      ? 'cross-owner'
+      : sourceOwner
+        ? 'compliant'
+        : 'unknown';
+    const reportObject: CatalogObjectReport = {
+      classification,
+      kind: 'constraint',
+      schemaName: constraint.schemaName,
+      name: constraint.name,
+      ...(sourceOwner ? {ownerId: sourceOwner} : {}),
+      ...(foreignKeyOwners ? {referencedOwnerId: foreignKeyOwners.referencedOwner} : {}),
+      relationName: constraint.relationName,
+      referencedRelationName: constraint.referencedRelationName,
+    };
+    objects.push(reportObject);
+    if (foreignKeyOwners) {
+      addFinding(
+        findings,
+        reportObject,
+        'cross-owner',
+        `Foreign key ${constraint.schemaName}.${constraint.name} crosses from ${foreignKeyOwners.sourceOwner} to ${foreignKeyOwners.referencedOwner}`,
+      );
+    } else if (!sourceOwner) {
+      addFinding(
+        findings,
+        reportObject,
+        'unknown',
+        `Unknown constraint ${constraint.schemaName}.${constraint.name}`,
+      );
+    }
+  }
+
+  for (const trigger of catalog.triggers) {
+    const key = objectKey('trigger', trigger.schemaName, trigger.name);
+    if (consumedActualKeys.has(key)) continue;
+    const owner = ownerForRelation(trigger.schemaName, trigger.relationName, tableOwners, registry);
+    const reportObject: CatalogObjectReport = {
+      classification: owner ? 'compliant' : 'unknown',
+      kind: 'trigger',
+      schemaName: trigger.schemaName,
+      name: trigger.name,
+      ...(owner ? {ownerId: owner} : {}),
+      relationName: trigger.relationName,
+    };
+    objects.push(reportObject);
+    if (!owner)
+      addFinding(
+        findings,
+        reportObject,
+        'unknown',
+        `Unknown trigger ${trigger.schemaName}.${trigger.name}`,
+      );
+  }
+
+  for (const namespace of catalog.namespaces) {
+    if (namespace.name === 'public' || namespace.name === 'drizzle') continue;
+    const reportObject: CatalogObjectReport = {
+      classification: 'unknown',
+      kind: 'schema',
+      schemaName: namespace.name,
+      name: namespace.name,
+    };
+    objects.push(reportObject);
+    addFinding(findings, reportObject, 'unknown', `Unknown PostgreSQL schema ${namespace.name}`);
+  }
+
+  const counts: CatalogReportCounts = {
+    compliant: objects.filter((object) => object.classification === 'compliant').length,
+    constraints: catalog.constraints.length,
+    enums: catalog.enums.length,
+    indexes: catalog.relations.filter(
+      (relation) => actualRelationKind(relation.relkind) === 'index',
+    ).length,
+    migrationHistories: catalog.relations.filter(
+      (relation) =>
+        relation.schemaName === 'drizzle' && actualRelationKind(relation.relkind) === 'table',
+    ).length,
+    schemas: catalog.namespaces.length,
+    sequences: catalog.relations.filter(
+      (relation) => actualRelationKind(relation.relkind) === 'sequence',
+    ).length,
+    tables: catalog.relations.filter(
+      (relation) =>
+        relation.schemaName === 'public' && actualRelationKind(relation.relkind) === 'table',
+    ).length,
+    triggers: catalog.triggers.length,
+    unknown: objects.filter((object) => object.classification === 'unknown').length,
+    views: catalog.relations.filter((relation) => actualRelationKind(relation.relkind) === 'view')
+      .length,
+  };
+
+  return {
+    ...(databaseName ? {databaseName} : {}),
+    ...(serverVersion ? {serverVersion} : {}),
+    migrationUnits,
+    objects: [...objects].sort(sortObjects),
+    findings: [...findings].sort(sortFindings),
+    counts,
+  };
+}
+
+export function formatCatalogReport(report: CatalogAuditReport): string {
+  const lines = [
+    report.findings.length === 0
+      ? 'API database catalog verification passed'
+      : `API database catalog verification failed (${report.findings.length} findings)`,
+    ...(report.databaseName ? [`Database: ${report.databaseName}`] : []),
+    ...(report.serverVersion ? [`PostgreSQL: ${report.serverVersion}`] : []),
+    `Migration units: ${report.migrationUnits.length}`,
+    `Tables: ${report.counts.tables}`,
+    `Enums: ${report.counts.enums}`,
+    `Indexes: ${report.counts.indexes}`,
+    `Constraints: ${report.counts.constraints}`,
+    `Migration histories: ${report.counts.migrationHistories}`,
+    `Compliant objects: ${report.counts.compliant}`,
+  ];
+  if (report.findings.length > 0) {
+    lines.push('', 'Findings:');
+    for (const finding of report.findings) {
+      const location = `${finding.schemaName}.${finding.name}`;
+      const source = finding.sourcePath ? ` (${finding.sourcePath}:${finding.line ?? 1})` : '';
+      lines.push(`- [${finding.classification}] ${location}: ${finding.message}${source}`);
+    }
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+export function formatCatalogJsonReport(report: CatalogAuditReport): string {
+  return `${JSON.stringify(report, null, 2)}\n`;
+}
+
+export function expectedHistoryForUnit(
+  unit: DatabaseMigrationUnit,
+  runtimeName: string,
+  sourcePath = unit.migrationsPath,
+): ExpectedMigrationHistory {
+  return {
+    kind: 'migration-history',
+    schemaName: 'drizzle',
+    name: migrationHistoryName(unit.namespace),
+    runtimeName,
+    ownerId: unit.ownerId,
+    migrationUnitId: unit.id,
+    namespace: unit.namespace,
+    sourcePath,
+    line: 1,
+  };
+}
+
+export function dedupeExpectedObjects(
+  objects: readonly ExpectedCatalogObject[],
+): ExpectedCatalogObject[] {
+  const seen = new Map<string, ExpectedCatalogObject>();
+  const ownershipConflicts: ExpectedCatalogObject[] = [];
+  for (const object of objects) {
+    const key = objectKey(object.kind, object.schemaName, object.name);
+    const existing = seen.get(key);
+    if (!existing) {
+      seen.set(key, object);
+      continue;
+    }
+    // Repeated declarations by the same owner are deduplicated; ownership conflicts stay visible.
+    if (existing.ownerId !== object.ownerId || existing.namespace !== object.namespace) {
+      ownershipConflicts.push(object);
+    }
+  }
+  return [...seen.values(), ...ownershipConflicts].sort((left, right) => {
+    const leftKey = objectKey(left.kind, left.schemaName, left.name);
+    const rightKey = objectKey(right.kind, right.schemaName, right.name);
+    return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0;
+  });
+}

--- a/tools/api-database-policy/test/catalog.test.ts
+++ b/tools/api-database-policy/test/catalog.test.ts
@@ -1,0 +1,383 @@
+import assert from 'node:assert/strict';
+import {spawnSync} from 'node:child_process';
+import {readFileSync} from 'node:fs';
+import {fileURLToPath} from 'node:url';
+import {parseCatalogCliArgs} from '../src/api-database-catalog.js';
+import {
+  type ApiDatabaseRegistry,
+  apiDatabaseRegistry,
+  type DatabaseMigrationUnit,
+} from '../src/api-database-registry.js';
+import {
+  auditPostgresCatalog,
+  type CatalogAuditReport,
+  type CatalogConstraint,
+  type CatalogMigrationUnitReport,
+  type CatalogRelation,
+  dedupeExpectedObjects,
+  type ExpectedCatalogObject,
+  expectedHistoryForUnit,
+  formatCatalogJsonReport,
+  migrationHistoryName,
+  type PostgresCatalog,
+  parseMigrationSql,
+} from '../src/catalog.js';
+
+const unknownOptionExpression = /Unknown catalog option/;
+const invalidDatabaseNameExpression = /Invalid PostgreSQL database name: invalid-name/;
+
+const agentUnit: DatabaseMigrationUnit = {
+  id: 'agent',
+  ownerId: 'agent',
+  namespace: 'agent',
+  packagePath: 'libs/api/agent',
+  drizzleConfigPath: 'libs/api/agent/drizzle.config.ts',
+  migrationsPath: 'libs/api/agent/drizzle',
+};
+const workspacesUnit: DatabaseMigrationUnit = {
+  id: 'workspaces',
+  ownerId: 'workspaces',
+  namespace: 'workspaces',
+  packagePath: 'libs/api/workspaces',
+  drizzleConfigPath: 'libs/api/workspaces/drizzle.config.ts',
+  migrationsPath: 'libs/api/workspaces/drizzle',
+};
+
+const registry: ApiDatabaseRegistry = {
+  owners: [
+    {id: 'agent', packagePath: agentUnit.packagePath},
+    {id: 'workspaces', packagePath: workspacesUnit.packagePath},
+  ],
+  migrationUnits: [agentUnit, workspacesUnit],
+  delegates: [],
+};
+
+function relation(name: string, schemaName = 'public'): CatalogRelation {
+  return {oid: `${schemaName}-${name}`, schemaName, name, relkind: 'r'};
+}
+
+function expectedTable(unit: DatabaseMigrationUnit, name: string): ExpectedCatalogObject {
+  return {
+    kind: 'table',
+    schemaName: 'public',
+    name,
+    ownerId: unit.ownerId,
+    migrationUnitId: unit.id,
+    namespace: unit.namespace,
+    sourcePath: `${unit.migrationsPath}/0000_test.sql`,
+    line: 1,
+  };
+}
+
+function expectedConstraint(
+  unit: DatabaseMigrationUnit,
+  name: string,
+  relationName = 'agent_jobs',
+): ExpectedCatalogObject {
+  return {
+    kind: 'constraint',
+    schemaName: 'public',
+    name,
+    ownerId: unit.ownerId,
+    migrationUnitId: unit.id,
+    namespace: unit.namespace,
+    relationName,
+    sourcePath: `${unit.migrationsPath}/0000_test.sql`,
+    line: 1,
+  };
+}
+
+function unitReport(unit: DatabaseMigrationUnit): CatalogMigrationUnitReport {
+  return {
+    id: unit.id,
+    ownerId: unit.ownerId,
+    namespace: unit.namespace,
+    migrations: 1,
+    runtimeMigrationHistoryName: migrationHistoryName(unit.namespace),
+    canonicalMigrationHistoryName: migrationHistoryName(unit.namespace),
+  };
+}
+
+function catalog(
+  relations: readonly CatalogRelation[] = [],
+  constraints: readonly CatalogConstraint[] = [],
+): PostgresCatalog {
+  return {
+    namespaces: [
+      {oid: 'public', name: 'public'},
+      {oid: 'drizzle', name: 'drizzle'},
+    ],
+    relations: [...relations, relation(migrationHistoryName('agent'), 'drizzle')],
+    enums: [],
+    constraints,
+    triggers: [],
+  };
+}
+
+function audit(
+  expectedObjects: readonly ExpectedCatalogObject[],
+  postgresCatalog: PostgresCatalog,
+  expectedHistories = [expectedHistoryForUnit(agentUnit, migrationHistoryName('agent'))],
+): CatalogAuditReport {
+  return auditPostgresCatalog({
+    catalog: postgresCatalog,
+    expectedObjects,
+    expectedHistories,
+    migrationUnits: [unitReport(agentUnit)],
+    registry,
+  });
+}
+
+function readFixture(name: string): string {
+  return readFileSync(new URL(`./fixtures/catalog/${name}`, import.meta.url), 'utf8');
+}
+
+describe('PostgreSQL catalog verifier', () => {
+  test('parses current migration SQL, including inline constraints', () => {
+    const unit = apiDatabaseRegistry.migrationUnits.find((candidate) => candidate.id === 'agent');
+    if (!unit) throw new Error('Expected the Agent migration unit');
+
+    const objects = parseMigrationSql({
+      source: readFileSync(
+        new URL('../../../libs/api/agent/drizzle/0000_daffy_leopardon.sql', import.meta.url),
+        'utf8',
+      ),
+      sourcePath: 'libs/api/agent/drizzle/0000_daffy_leopardon.sql',
+      unit,
+    });
+
+    assert.deepEqual(
+      objects.map(({kind, name}) => `${kind}:${name}`),
+      [
+        'enum:model_provider_config_kind',
+        'table:model_provider_configs',
+        'table:agent_workspace_settings',
+        'index:model_provider_configs_workspace_provider_unique',
+        'constraint:model_provider_configs_custom_required_fields',
+      ],
+    );
+  });
+
+  test('parses ALTER TABLE IF EXISTS constraints against the real relation', () => {
+    const objects = parseMigrationSql({
+      source:
+        'ALTER TABLE IF EXISTS "public"."workspaces_runs" ADD CONSTRAINT "workspaces_runs_check" CHECK (true);',
+      sourcePath: 'test/fixtures/catalog/alter-if-exists.sql',
+      unit: workspacesUnit,
+    });
+
+    assert.deepEqual(
+      objects.map(({kind, name, relationName, schemaName}) => ({
+        kind,
+        name,
+        relationName,
+        schemaName,
+      })),
+      [
+        {
+          kind: 'constraint',
+          name: 'workspaces_runs_check',
+          relationName: 'workspaces_runs',
+          schemaName: 'public',
+        },
+      ],
+    );
+  });
+
+  test('ignores DDL-looking text inside dollar-quoted function bodies', () => {
+    const objects = parseMigrationSql({
+      source: `
+        CREATE FUNCTION "agent_fake"() RETURNS trigger
+        LANGUAGE plpgsql AS $fn$
+        BEGIN
+          EXECUTE format('ALTER TABLE %I ADD CONSTRAINT %I CHECK (true)', 'agent_phantom', 'agent_phantom_check');
+          RETURN NEW;
+        END;
+        $fn$;
+        CREATE TABLE "agent_jobs" ("id" uuid NOT NULL);
+        CREATE TABLE "agent_records" (
+          "description" text DEFAULT $$literal;with semicolon$$,
+          CONSTRAINT "agent_records_check" CHECK (true)
+        );
+      `,
+      sourcePath: 'test/fixtures/catalog/dollar-quoted.sql',
+      unit: agentUnit,
+    });
+
+    assert.deepEqual(
+      objects.map(({kind, name, relationName}) => ({kind, name, relationName})),
+      [
+        {kind: 'table', name: 'agent_jobs', relationName: undefined},
+        {kind: 'table', name: 'agent_records', relationName: undefined},
+        {kind: 'constraint', name: 'agent_records_check', relationName: 'agent_records'},
+      ],
+    );
+  });
+
+  test('classifies a foreign-owner fixture', () => {
+    const objects = parseMigrationSql({
+      source: readFixture('foreign.sql'),
+      sourcePath: 'test/fixtures/catalog/foreign.sql',
+      unit: agentUnit,
+    });
+    const report = audit(objects, catalog([relation('workspaces_runs')]));
+
+    assert.deepEqual(
+      report.findings.map(({classification, name}) => ({classification, name})),
+      [{classification: 'cross-owner', name: 'workspaces_runs'}],
+    );
+  });
+
+  test('classifies an unprefixed fixture', () => {
+    const objects = parseMigrationSql({
+      source: readFixture('unprefixed.sql'),
+      sourcePath: 'test/fixtures/catalog/unprefixed.sql',
+      unit: agentUnit,
+    });
+    const report = audit(objects, catalog([relation('jobs')]));
+
+    assert.deepEqual(
+      report.findings.map(({classification, name}) => ({classification, name})),
+      [{classification: 'misnamed', name: 'jobs'}],
+    );
+  });
+
+  test('reports a cross-owner foreign key exactly once', () => {
+    const foreignKeyName = 'agent_jobs_workspace_id_workspaces_runs_id_fk';
+    const constraint: CatalogConstraint = {
+      oid: 'constraint-1',
+      schemaName: 'public',
+      name: foreignKeyName,
+      type: 'f',
+      relationOid: 'public-agent_jobs',
+      relationSchemaName: 'public',
+      relationName: 'agent_jobs',
+      referencedRelationOid: 'public-workspaces_runs',
+      referencedRelationSchemaName: 'public',
+      referencedRelationName: 'workspaces_runs',
+    };
+    const report = audit(
+      [
+        expectedTable(agentUnit, 'agent_jobs'),
+        expectedTable(workspacesUnit, 'workspaces_runs'),
+        expectedConstraint(agentUnit, foreignKeyName),
+      ],
+      catalog([relation('agent_jobs'), relation('workspaces_runs')], [constraint]),
+    );
+
+    assert.deepEqual(
+      report.findings.map(({classification, name}) => ({classification, name})),
+      [{classification: 'cross-owner', name: foreignKeyName}],
+    );
+  });
+
+  test('matches PostgreSQL-truncated identifiers', () => {
+    const longName = `agent_${'long_constraint_name_'.repeat(5)}`;
+    const truncatedName = longName.slice(0, 63);
+    const report = audit(
+      [expectedTable(agentUnit, 'agent_jobs'), expectedConstraint(agentUnit, longName)],
+      catalog(
+        [relation('agent_jobs')],
+        [
+          {
+            oid: 'constraint-1',
+            schemaName: 'public',
+            name: truncatedName,
+            type: 'c',
+            relationOid: 'public-agent_jobs',
+            relationSchemaName: 'public',
+            relationName: 'agent_jobs',
+            referencedRelationOid: null,
+            referencedRelationSchemaName: null,
+            referencedRelationName: null,
+          },
+        ],
+      ),
+    );
+
+    assert.deepEqual(report.findings, []);
+  });
+
+  test('reports missing and unknown catalog objects', () => {
+    const report = audit(
+      [expectedTable(agentUnit, 'agent_jobs')],
+      catalog([relation('rogue_table')]),
+    );
+
+    assert.deepEqual(
+      report.findings.map(({classification, name}) => ({classification, name})),
+      [
+        {classification: 'missing', name: 'agent_jobs'},
+        {classification: 'unknown', name: 'rogue_table'},
+      ],
+    );
+  });
+
+  test('checks the runtime migration-history name against the canonical name', () => {
+    const runtimeName = `${migrationHistoryName('agent')}_legacy`;
+    const report = audit(
+      [expectedTable(agentUnit, 'agent_jobs')],
+      {
+        ...catalog([relation('agent_jobs')]),
+        relations: [relation('agent_jobs'), relation(runtimeName, 'drizzle')],
+      },
+      [expectedHistoryForUnit(agentUnit, runtimeName)],
+    );
+
+    assert.deepEqual(
+      report.findings.map(({classification, name}) => ({classification, name})),
+      [{classification: 'misnamed', name: runtimeName}],
+    );
+  });
+
+  test('keeps ownership-conflicting duplicate declarations visible', () => {
+    const objects = dedupeExpectedObjects([
+      expectedTable(agentUnit, 'agent_shared'),
+      expectedTable(workspacesUnit, 'agent_shared'),
+    ]);
+    assert.equal(objects.length, 2);
+
+    const report = audit(objects, catalog([relation('agent_shared')]));
+    assert.deepEqual(
+      report.findings.map(({classification, name}) => ({classification, name})),
+      [{classification: 'cross-owner', name: 'agent_shared'}],
+    );
+  });
+
+  test('emits a JSON report without connection details', () => {
+    const report = audit([expectedTable(agentUnit, 'jobs')], catalog([relation('jobs')]));
+    const json = formatCatalogJsonReport(report);
+
+    assert.equal(json.includes('password'), false);
+    assert.equal(json.includes('postgres://'), false);
+    assert.equal(JSON.parse(json).findings[0].classification, 'misnamed');
+  });
+
+  test('parses catalog CLI formats and rejects unknown options', () => {
+    assert.deepEqual(parseCatalogCliArgs(['--database', 'catalog', '--format', 'json']), {
+      databaseName: 'catalog',
+      format: 'json',
+      help: false,
+    });
+    assert.deepEqual(parseCatalogCliArgs(['--help']), {
+      format: 'human',
+      help: true,
+    });
+    assert.throws(() => parseCatalogCliArgs(['--unknown']), unknownOptionExpression);
+  });
+
+  test('uses a distinct exit code for catalog execution errors', () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        fileURLToPath(new URL('../dist/api-database-catalog.js', import.meta.url)),
+        '--database=invalid-name',
+      ],
+      {encoding: 'utf8'},
+    );
+
+    assert.equal(result.status, 2);
+    assert.equal(result.stdout, '');
+    assert.match(result.stderr, invalidDatabaseNameExpression);
+  });
+});

--- a/tools/api-database-policy/test/fixtures/catalog/foreign.sql
+++ b/tools/api-database-policy/test/fixtures/catalog/foreign.sql
@@ -1,0 +1,3 @@
+CREATE TABLE "workspaces_runs" (
+	"id" uuid PRIMARY KEY NOT NULL
+);

--- a/tools/api-database-policy/test/fixtures/catalog/unprefixed.sql
+++ b/tools/api-database-policy/test/fixtures/catalog/unprefixed.sql
@@ -1,0 +1,3 @@
+CREATE TABLE "jobs" (
+	"id" uuid PRIMARY KEY NOT NULL
+);


### PR DESCRIPTION
## Summary

Adds a fresh PostgreSQL 18 catalog verifier for every registered API migration unit. It creates a temporary empty database, applies the migrations, audits catalog ownership, naming, and migration-history drift, and emits human or JSON reports.

CI runs the verifier after test services start and uploads the JSON report. Existing baseline findings remain report-only until ENG-1199; unexpected execution failures now use a distinct exit code and fail CI.

The verifier also handles `ALTER TABLE IF EXISTS`, dollar-quoted SQL, ownership-conflicting declarations, and cleanup of generated catalog databases on failure.

Validation: `mise exec -- turbo check type test test:external verify --filter=@shipfox/api-database-policy`; real PostgreSQL 18.4 run completed with the expected five baseline findings (exit 1) and no temporary database left behind.

Closes ENG-1193

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a PostgreSQL 18 catalog verifier that runs all registered API migrations against a fresh empty DB, audits naming/ownership and migration-history drift, and emits human or JSON reports. CI runs the verifier and uploads the JSON report; findings are report-only per ENG-1193 (execution errors fail CI, ENG-1199 will make findings fatal).

- **New Features**
  - New CLI `pnpm --filter=@shipfox/api-database-policy verify:catalog` with `--json` and `--database` options.
  - Creates a temp database, runs Drizzle migrations, audits objects, and cleans up on failure.
  - Detects cross-owner objects, misnaming, missing/unknown objects, and migration-history name drift.
  - Robust parser supports `ALTER TABLE IF EXISTS`, dollar-quoted SQL, and PostgreSQL identifier truncation.
  - CI builds and runs the verifier, prints a concise JSON summary, and uploads the full report artifact.

- **Dependencies**
  - Added `@shipfox/node-drizzle` and `@shipfox/node-postgres`.

<sup>Written for commit 92bf62e7cd704056998a4d440d5935d48c4d3541. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

