### PR TITLE
Enforce static database ownership boundaries

### DIFF
--- a/.changeset/bright-databases-guard.md
+++ b/.changeset/bright-databases-guard.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/biome": minor
+---
+
+Publishes the generic database-boundaries GritQL guardrail for direct Drizzle table-factory imports.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "check:dependencies": "pnpm --filter=@shipfox/dependency-policy verify:dependencies",
     "check:api-context-inventory": "turbo verify --filter=@shipfox/api-architecture-policy",
+    "check:api-database-boundaries": "turbo verify:boundaries --filter=@shipfox/api-database-policy",
     "check:client-architecture": "turbo verify --filter=@shipfox/client-architecture-policy",
     "check:lockfile": "turbo build --filter=@shipfox/dependency-policy && pnpm --filter=@shipfox/dependency-policy verify:lockfile",
     "check:published-artifacts": "turbo verify --filter=@shipfox/package-release",

--- a/tools/api-database-policy/package.json
+++ b/tools/api-database-policy/package.json
@@ -12,6 +12,7 @@
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit",
     "verify": "node dist/api-database-registry.js",
+    "verify:boundaries": "node dist/api-database-boundaries.js",
     "verify:catalog": "node dist/api-database-catalog.js"
   },
   "dependencies": {

--- a/tools/api-database-policy/src/api-database-boundaries.ts
+++ b/tools/api-database-policy/src/api-database-boundaries.ts
@@ -1,0 +1,1831 @@
+import {readdir, readFile} from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import {fileURLToPath} from 'node:url';
+import {
+  type ApiDatabaseRegistry,
+  apiDatabaseRegistry,
+  auditApiDatabaseRegistry,
+  type DatabaseMigrationUnit,
+} from './api-database-registry.js';
+
+const repositoryRoot = fileURLToPath(new URL('../../../', import.meta.url));
+const sourceFileExpression = /\.(?:[cm]?[jt]sx?)$/u;
+const migrationFileExpression = /\.sql$/u;
+const snapshotFileExpression = /_snapshot\.json$/u;
+const ignoredDirectoryNames = new Set(['coverage', 'dist', 'node_modules']);
+const factoryBodyLookaheadLength = 240;
+const sqlReferenceLookbehindLength = 180;
+const namespaceExpression = /^[a-z][a-z0-9_]*$/u;
+const identifierExpression = '(?:"([^"]+)"|([A-Za-z_][\\w$]*))';
+const packageImportExpression = /import\s+(?:type\s+)?([\s\S]*?)\s+from\s+["']([^"']+)["']/gu;
+const namedImportExpression = /\{([^}]+)\}/u;
+const factoryExpression = /pgTableCreator\s*\(\s*\(\s*name\s*\)\s*=>\s*([\s\S]*?)\)\s*;?/u;
+const templateFactoryPrefixExpression = /`([^`]*)\$\{\s*name\s*\}/u;
+const stringFactoryPrefixExpression = /["']([^"']*)["']\s*\+\s*name/u;
+const unprefixedFactoryNameExpression = /name\s*===\s*["']([^"']+)["']\s*\?/gu;
+const importAliasExpression = /\s+as\s+/u;
+const firstCallArgumentExpression = /^\s*\(\s*(["'])([^"']+)\1/u;
+const registeredFactoryExpression = /export\s+const\s+pgTable\s*=\s*pgTableCreator/u;
+const inlineFactoryPrefixExpression = /=>\s*`([^`]*)\$\{\s*name\s*\}/u;
+const trailingUnderscoreExpression = /_+$/u;
+const declarationReferenceExpression = /\b(?:pgTable|pgEnum|index|uniqueIndex|check)\s*\([^\n]*$/u;
+const sqlTemplateExpression = /\bsql(?:\.raw)?\s*`[^`]*$/su;
+const sqlCallExpression = /\bsql(?:\.raw)?\s*\([^\n]*$/u;
+const sqlKeywordExpression =
+  /\b(?:SELECT\s+.+\s+FROM|TRUNCATE\s+(?:TABLE\s+)?[A-Za-z_"']|INSERT\s+INTO|UPDATE\s+[A-Za-z_"']+\s+SET|DELETE\s+FROM|(?:ALTER|DROP|CREATE)\s+(?:TABLE|TYPE|INDEX|VIEW|SEQUENCE|TRIGGER)|LOCK\s+TABLE)\b/iu;
+const migrationSqlKeywordExpression = /\b(?:ALTER|DROP|CREATE)\b/iu;
+const referencesKeywordExpression = /\bREFERENCES\b/iu;
+const dynamicSqlKeywordExpression =
+  /\b(?:FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE|ALTER|DROP|CREATE)\s+\$\{/giu;
+const dynamicRawSqlExpression = /\bsql\.raw\s*\([^\n]*\$\{/gu;
+const tableBindingImportExpression =
+  /import\s+\{([^}]+)\}\s+from\s+["'][^"']+\/(?:schema|runner-lease-table)[^"']*["']/gu;
+const objectBindingExpression =
+  /(?:export\s+)?const\s+([A-Za-z_$][\w$]*)\s*=\s*(?:pgTable|pgEnum)\b/gu;
+const migrationHistoryExpression = /__drizzle_migrations_([a-z][a-z0-9_]*)/gu;
+const fallbackHistoryExpression = /migrationsTableName\s*\?\?\s*moduleMigrationTableName/u;
+const optionalHistoryExpression = /migrationsTableName\?/u;
+const dynamicIdentifierExpression = /\$\{[^}]+\}/gu;
+const interpolationPresenceExpression = /\$\{/u;
+const interpolationBodyExpression = /^[^}]+/u;
+const plainIdentifierExpression = /^[A-Za-z_$][\w$]*$/u;
+const namespaceImportExpression = /\*\s+as\s+([A-Za-z_$][\w$]*)/u;
+const defaultImportExpression = /^\s*([A-Za-z_$][\w$]*)/u;
+const dynamicSqlRawKeywordExpression =
+  /\b(?:FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE|ALTER|DROP|CREATE)\b/iu;
+
+export type DatabaseBoundaryRule =
+  | 'direct-table-declaration'
+  | 'dynamic-sql-identifier'
+  | 'foreign-database-access'
+  | 'foreign-enum-declaration'
+  | 'foreign-key'
+  | 'foreign-migration'
+  | 'foreign-raw-sql'
+  | 'foreign-support-object'
+  | 'foreign-table-declaration'
+  | 'migration-history-instability'
+  | 'unprefixed-enum'
+  | 'unprefixed-support-object'
+  | 'unprefixed-table'
+  | 'unregistered-migration-unit';
+
+export interface DatabaseBoundaryFinding {
+  owner: string;
+  namespace: string;
+  file: string;
+  line: number;
+  object: string;
+  rule: DatabaseBoundaryRule;
+  suggestedBoundary: string;
+}
+
+export interface DatabaseBoundaryBaselineEntry {
+  owner: string;
+  namespace: string;
+  file: string;
+  line: number;
+  object: string;
+  rule: DatabaseBoundaryRule;
+  suggestedBoundary: string;
+  trackingIssue: string;
+  removalCondition: string;
+}
+
+export interface DatabaseBoundaryAuditOptions {
+  registry?: ApiDatabaseRegistry;
+  rootDirectory?: string;
+}
+
+export interface DatabaseBoundaryVerificationResult {
+  findings: DatabaseBoundaryFinding[];
+  knownBaselineFindings: DatabaseBoundaryFinding[];
+  newFindings: DatabaseBoundaryFinding[];
+  disappearedBaselineEntries: DatabaseBoundaryBaselineEntry[];
+  registryErrors: string[];
+}
+
+interface DatabaseObject {
+  kind: DatabaseObjectKind;
+  name: string;
+  namespace: string;
+  owner: string;
+}
+
+type DatabaseObjectKind =
+  | 'constraint'
+  | 'enum'
+  | 'index'
+  | 'sequence'
+  | 'table'
+  | 'trigger'
+  | 'view';
+
+interface AuditFile {
+  path: string;
+  source: string;
+}
+
+interface FactoryInfo {
+  prefix: string;
+  unprefixedNames: ReadonlySet<string>;
+}
+
+interface FileOwnerContext {
+  owner: string;
+  namespace: string;
+  unit?: DatabaseMigrationUnit;
+}
+
+interface AuditContext {
+  registry: ApiDatabaseRegistry;
+  rootDirectory: string;
+  units: DatabaseMigrationUnit[];
+  objects: Map<string, DatabaseObject>;
+  sortedNamespaces: readonly string[];
+  sqlObjectReferences: readonly SqlObjectReference[];
+  namespaceOwners: Map<string, string>;
+  ownerNamespaces: Map<string, Set<string>>;
+  factories: Map<string, FactoryInfo>;
+  packageOwners: Map<string, string>;
+  ownerPackages: Map<string, string>;
+}
+
+interface ObjectReference {
+  name: string;
+  index: number;
+  kind: DatabaseObjectKind;
+}
+
+interface SqlObjectReference {
+  name: string;
+  expression: RegExp;
+}
+
+interface ReconciliationResult {
+  knownBaselineFindings: DatabaseBoundaryFinding[];
+  newFindings: DatabaseBoundaryFinding[];
+  disappearedBaselineEntries: DatabaseBoundaryBaselineEntry[];
+}
+
+const namespaceSuggestion = (owner: string, namespace: string): string =>
+  `Use the ${owner} owner's ${namespace} schema factory and producer-owned boundary.`;
+
+function baselineEntry(
+  finding: Omit<DatabaseBoundaryBaselineEntry, 'trackingIssue' | 'removalCondition'>,
+  trackingIssue: string,
+  removalCondition: string,
+): DatabaseBoundaryBaselineEntry {
+  return {...finding, trackingIssue, removalCondition};
+}
+const databaseBoundaryBaseline: readonly DatabaseBoundaryBaselineEntry[] = Object.freeze([
+  baselineEntry(
+    {
+      owner: 'agent',
+      namespace: 'agent',
+      file: 'libs/api/agent/drizzle/0000_daffy_leopardon.sql',
+      line: 1,
+      object: 'model_provider_config_kind',
+      rule: 'unprefixed-enum',
+      suggestedBoundary: namespaceSuggestion('agent', 'agent'),
+    },
+    'ENG-1195',
+    'Agent migrations and schema use only agent_-prefixed database objects.',
+  ),
+  baselineEntry(
+    {
+      owner: 'auth',
+      namespace: 'auth',
+      file: 'libs/api/auth/test/globalSetup.ts',
+      line: 13,
+      object: 'emailChallengesModule.database',
+      rule: 'foreign-database-access',
+      suggestedBoundary: namespaceSuggestion('email-challenges', 'email_challenges'),
+    },
+    'ENG-1198',
+    'Auth tests migrate and clean only Auth-owned storage.',
+  ),
+  baselineEntry(
+    {
+      owner: 'auth',
+      namespace: 'auth',
+      file: 'libs/api/auth/test/globalSetup.ts',
+      line: 20,
+      object: '__drizzle_migrations_email_challenges',
+      rule: 'foreign-migration',
+      suggestedBoundary: namespaceSuggestion('email-challenges', 'email_challenges'),
+    },
+    'ENG-1198',
+    'Auth tests migrate and clean only Auth-owned storage.',
+  ),
+  baselineEntry(
+    {
+      owner: 'auth',
+      namespace: 'auth',
+      file: 'libs/api/auth/test/globalSetup.ts',
+      line: 22,
+      object: 'email_challenges_challenges',
+      rule: 'foreign-raw-sql',
+      suggestedBoundary: namespaceSuggestion('email-challenges', 'email_challenges'),
+    },
+    'ENG-1198',
+    'Auth tests migrate and clean only Auth-owned storage.',
+  ),
+  baselineEntry(
+    {
+      owner: 'auth',
+      namespace: 'auth',
+      file: 'libs/api/auth/test/globalSetup.ts',
+      line: 22,
+      object: 'email_challenges_send_limits',
+      rule: 'foreign-raw-sql',
+      suggestedBoundary: namespaceSuggestion('email-challenges', 'email_challenges'),
+    },
+    'ENG-1198',
+    'Auth tests migrate and clean only Auth-owned storage.',
+  ),
+  baselineEntry(
+    {
+      owner: 'neutral-infrastructure',
+      namespace: 'neutral',
+      file: 'libs/shared/node/module/src/initialize.ts',
+      line: 96,
+      object: 'moduleMigrationTableName',
+      rule: 'migration-history-instability',
+      suggestedBoundary:
+        'Require the registered database namespace on every ModuleDatabase declaration.',
+    },
+    'ENG-1194',
+    'ModuleDatabase requires a registered stable namespace and no positional fallback.',
+  ),
+  baselineEntry(
+    {
+      owner: 'neutral-infrastructure',
+      namespace: 'neutral',
+      file: 'libs/shared/node/module/src/types.ts',
+      line: 20,
+      object: 'migrationsTableName',
+      rule: 'migration-history-instability',
+      suggestedBoundary:
+        'Require the registered database namespace on every ModuleDatabase declaration.',
+    },
+    'ENG-1194',
+    'ModuleDatabase requires a registered stable namespace and no positional fallback.',
+  ),
+  baselineEntry(
+    {
+      owner: 'workflows',
+      namespace: 'workflows',
+      file: 'libs/api/workflows/src/db/runner-lease-table.ts',
+      line: 4,
+      object: 'pgTableCreator',
+      rule: 'foreign-table-declaration',
+      suggestedBoundary: namespaceSuggestion('runners', 'runners'),
+    },
+    'ENG-1197',
+    'Workflows no longer declares or locks Runners lease tables.',
+  ),
+  baselineEntry(
+    {
+      owner: 'workflows',
+      namespace: 'workflows',
+      file: 'libs/api/workflows/src/db/runner-lease-table.ts',
+      line: 12,
+      object: 'runners_runner_sessions',
+      rule: 'foreign-table-declaration',
+      suggestedBoundary: namespaceSuggestion('runners', 'runners'),
+    },
+    'ENG-1197',
+    'Workflows no longer declares or locks Runners lease tables.',
+  ),
+  baselineEntry(
+    {
+      owner: 'workflows',
+      namespace: 'workflows',
+      file: 'libs/api/workflows/src/db/runner-lease-table.ts',
+      line: 28,
+      object: 'runners_running_jobs',
+      rule: 'foreign-table-declaration',
+      suggestedBoundary: namespaceSuggestion('runners', 'runners'),
+    },
+    'ENG-1197',
+    'Workflows no longer declares or locks Runners lease tables.',
+  ),
+  baselineEntry(
+    {
+      owner: 'workflows',
+      namespace: 'workflows',
+      file: 'libs/api/workflows/src/db/runner-lease-table.ts',
+      line: 6,
+      object: 'runners_runner_session_scope',
+      rule: 'foreign-enum-declaration',
+      suggestedBoundary: namespaceSuggestion('runners', 'runners'),
+    },
+    'ENG-1197',
+    'Workflows no longer declares or locks Runners lease tables.',
+  ),
+  baselineEntry(
+    {
+      owner: 'workflows',
+      namespace: 'workflows',
+      file: 'libs/api/workflows/src/db/runner-lease-table.ts',
+      line: 8,
+      object: 'runners_runner_session_registration_token_kind',
+      rule: 'foreign-enum-declaration',
+      suggestedBoundary: namespaceSuggestion('runners', 'runners'),
+    },
+    'ENG-1197',
+    'Workflows no longer declares or locks Runners lease tables.',
+  ),
+  baselineEntry(
+    {
+      owner: 'agent',
+      namespace: 'agent',
+      file: 'libs/api/agent/drizzle/0000_daffy_leopardon.sql',
+      line: 2,
+      object: 'model_provider_configs',
+      rule: 'unprefixed-table',
+      suggestedBoundary: namespaceSuggestion('agent', 'agent'),
+    },
+    'ENG-1195',
+    'Agent migrations and schema use only agent_-prefixed database objects.',
+  ),
+  baselineEntry(
+    {
+      owner: 'agent',
+      namespace: 'agent',
+      file: 'libs/api/agent/drizzle/0000_daffy_leopardon.sql',
+      line: 18,
+      object: 'model_provider_configs_custom_required_fields',
+      rule: 'unprefixed-support-object',
+      suggestedBoundary: namespaceSuggestion('agent', 'agent'),
+    },
+    'ENG-1195',
+    'Agent migrations and schema use only agent_-prefixed database objects.',
+  ),
+  baselineEntry(
+    {
+      owner: 'agent',
+      namespace: 'agent',
+      file: 'libs/api/agent/drizzle/0000_daffy_leopardon.sql',
+      line: 28,
+      object: 'model_provider_configs_workspace_provider_unique',
+      rule: 'unprefixed-support-object',
+      suggestedBoundary: namespaceSuggestion('agent', 'agent'),
+    },
+    'ENG-1195',
+    'Agent migrations and schema use only agent_-prefixed database objects.',
+  ),
+  baselineEntry(
+    {
+      owner: 'agent',
+      namespace: 'agent',
+      file: 'libs/api/agent/drizzle/meta/0001_snapshot.json',
+      line: 7,
+      object: 'model_provider_configs',
+      rule: 'unprefixed-table',
+      suggestedBoundary: namespaceSuggestion('agent', 'agent'),
+    },
+    'ENG-1195',
+    'Agent migrations and schema use only agent_-prefixed database objects.',
+  ),
+  baselineEntry(
+    {
+      owner: 'agent',
+      namespace: 'agent',
+      file: 'libs/api/agent/drizzle/meta/0001_snapshot.json',
+      line: 32,
+      object: 'model_provider_config_kind',
+      rule: 'unprefixed-enum',
+      suggestedBoundary: namespaceSuggestion('agent', 'agent'),
+    },
+    'ENG-1195',
+    'Agent migrations and schema use only agent_-prefixed database objects.',
+  ),
+  baselineEntry(
+    {
+      owner: 'agent',
+      namespace: 'agent',
+      file: 'libs/api/agent/drizzle/meta/0001_snapshot.json',
+      line: 108,
+      object: 'model_provider_configs_workspace_provider_unique',
+      rule: 'unprefixed-support-object',
+      suggestedBoundary: namespaceSuggestion('agent', 'agent'),
+    },
+    'ENG-1195',
+    'Agent migrations and schema use only agent_-prefixed database objects.',
+  ),
+  baselineEntry(
+    {
+      owner: 'agent',
+      namespace: 'agent',
+      file: 'libs/api/agent/drizzle/meta/0001_snapshot.json',
+      line: 135,
+      object: 'model_provider_configs_custom_required_fields',
+      rule: 'unprefixed-support-object',
+      suggestedBoundary: namespaceSuggestion('agent', 'agent'),
+    },
+    'ENG-1195',
+    'Agent migrations and schema use only agent_-prefixed database objects.',
+  ),
+  baselineEntry(
+    {
+      owner: 'agent',
+      namespace: 'agent',
+      file: 'libs/api/agent/src/db/schema/model-provider-configs.ts',
+      line: 23,
+      object: 'model_provider_config_kind',
+      rule: 'unprefixed-enum',
+      suggestedBoundary: namespaceSuggestion('agent', 'agent'),
+    },
+    'ENG-1195',
+    'Agent migrations and schema use only agent_-prefixed database objects.',
+  ),
+  baselineEntry(
+    {
+      owner: 'agent',
+      namespace: 'agent',
+      file: 'libs/api/agent/src/db/schema/model-provider-configs.ts',
+      line: 29,
+      object: 'model_provider_configs',
+      rule: 'direct-table-declaration',
+      suggestedBoundary: 'Declare tables through the registered agent schema factory.',
+    },
+    'ENG-1195',
+    'Agent migrations and schema use only agent_-prefixed database objects.',
+  ),
+  baselineEntry(
+    {
+      owner: 'agent',
+      namespace: 'agent',
+      file: 'libs/api/agent/src/db/schema/model-provider-configs.ts',
+      line: 48,
+      object: 'model_provider_configs_workspace_provider_unique',
+      rule: 'unprefixed-support-object',
+      suggestedBoundary: namespaceSuggestion('agent', 'agent'),
+    },
+    'ENG-1195',
+    'Agent migrations and schema use only agent_-prefixed database objects.',
+  ),
+  baselineEntry(
+    {
+      owner: 'agent',
+      namespace: 'agent',
+      file: 'libs/api/agent/src/db/schema/model-provider-configs.ts',
+      line: 53,
+      object: 'model_provider_configs_custom_required_fields',
+      rule: 'unprefixed-support-object',
+      suggestedBoundary: namespaceSuggestion('agent', 'agent'),
+    },
+    'ENG-1195',
+    'Agent migrations and schema use only agent_-prefixed database objects.',
+  ),
+  baselineEntry(
+    {
+      owner: 'agent',
+      namespace: 'agent',
+      file: 'libs/api/agent/test/globalSetup.ts',
+      line: 11,
+      object: 'model_provider_configs',
+      rule: 'unprefixed-table',
+      suggestedBoundary: namespaceSuggestion('agent', 'agent'),
+    },
+    'ENG-1195',
+    'Agent migrations and schema use only agent_-prefixed database objects.',
+  ),
+
+  baselineEntry(
+    {
+      owner: 'workspaces',
+      namespace: 'workspaces',
+      file: 'libs/api/workspaces/drizzle/0000_initial.sql',
+      line: 41,
+      object: 'workspaces',
+      rule: 'unprefixed-table',
+      suggestedBoundary: namespaceSuggestion('workspaces', 'workspaces'),
+    },
+    'ENG-1196',
+    'The Workspaces root table is renamed to workspaces_workspaces.',
+  ),
+  baselineEntry(
+    {
+      owner: 'workspaces',
+      namespace: 'workspaces',
+      file: 'libs/api/workspaces/drizzle/0000_initial.sql',
+      line: 51,
+      object: 'workspaces',
+      rule: 'unprefixed-table',
+      suggestedBoundary: namespaceSuggestion('workspaces', 'workspaces'),
+    },
+    'ENG-1196',
+    'The Workspaces root table is renamed to workspaces_workspaces.',
+  ),
+  baselineEntry(
+    {
+      owner: 'workspaces',
+      namespace: 'workspaces',
+      file: 'libs/api/workspaces/drizzle/0000_initial.sql',
+      line: 52,
+      object: 'workspaces',
+      rule: 'unprefixed-table',
+      suggestedBoundary: namespaceSuggestion('workspaces', 'workspaces'),
+    },
+    'ENG-1196',
+    'The Workspaces root table is renamed to workspaces_workspaces.',
+  ),
+  baselineEntry(
+    {
+      owner: 'workspaces',
+      namespace: 'workspaces',
+      file: 'libs/api/workspaces/drizzle/meta/0000_snapshot.json',
+      line: 7,
+      object: 'workspaces',
+      rule: 'unprefixed-table',
+      suggestedBoundary: namespaceSuggestion('workspaces', 'workspaces'),
+    },
+    'ENG-1196',
+    'The Workspaces root table is renamed to workspaces_workspaces.',
+  ),
+  baselineEntry(
+    {
+      owner: 'workspaces',
+      namespace: 'workspaces',
+      file: 'libs/api/workspaces/test/globalSetup.ts',
+      line: 11,
+      object: 'workspaces',
+      rule: 'unprefixed-table',
+      suggestedBoundary: namespaceSuggestion('workspaces', 'workspaces'),
+    },
+    'ENG-1196',
+    'The Workspaces root table is renamed to workspaces_workspaces.',
+  ),
+]);
+
+export {databaseBoundaryBaseline};
+
+function compareText(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+function compareFindings(left: DatabaseBoundaryFinding, right: DatabaseBoundaryFinding): number {
+  return [
+    left.owner,
+    left.namespace,
+    left.file,
+    String(left.line).padStart(8, '0'),
+    left.object,
+    left.rule,
+    left.suggestedBoundary,
+  ]
+    .join('\u0000')
+    .localeCompare(
+      [
+        right.owner,
+        right.namespace,
+        right.file,
+        String(right.line).padStart(8, '0'),
+        right.object,
+        right.rule,
+        right.suggestedBoundary,
+      ].join('\u0000'),
+    );
+}
+
+function findingKey(finding: Pick<DatabaseBoundaryFinding, keyof DatabaseBoundaryFinding>): string {
+  return [
+    finding.owner,
+    finding.namespace,
+    finding.file,
+    finding.line,
+    finding.object,
+    finding.rule,
+    finding.suggestedBoundary,
+  ].join('\u0000');
+}
+
+function baselineKey(entry: DatabaseBoundaryBaselineEntry): string {
+  return findingKey(entry);
+}
+
+function toRepositoryPath(rootDirectory: string, absolutePath: string): string {
+  return path.relative(rootDirectory, absolutePath).split(path.sep).join('/');
+}
+
+function isPathInside(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative === '' || (relative !== '..' && !relative.startsWith(`..${path.sep}`));
+}
+
+function lineAt(source: string, index: number): number {
+  let line = 1;
+  for (let cursor = 0; cursor < index; cursor += 1) {
+    if (source[cursor] === '\n') line += 1;
+  }
+  return line;
+}
+
+function lineTextAt(source: string, index: number): string {
+  const lineStart = source.lastIndexOf('\n', index - 1) + 1;
+  const lineEnd = source.indexOf('\n', index) === -1 ? source.length : source.indexOf('\n', index);
+  return source.slice(lineStart, lineEnd);
+}
+
+function unquoteIdentifier(value: string): string {
+  return value.startsWith('"') && value.endsWith('"')
+    ? value.slice(1, -1).replaceAll('""', '"')
+    : value;
+}
+
+function identifierFromMatch(match: RegExpExecArray): string | undefined {
+  for (let index = match.length - 1; index >= 1; index -= 1) {
+    const value = match[index];
+    if (value) return unquoteIdentifier(value);
+  }
+  return undefined;
+}
+
+function addObject(
+  objects: Map<string, DatabaseObject>,
+  name: string,
+  kind: DatabaseObjectKind,
+  unit: DatabaseMigrationUnit,
+): void {
+  if (!name || name.startsWith('__drizzle_migrations_')) return;
+  const existing = objects.get(name);
+  if (existing) return;
+  objects.set(name, {kind, name, namespace: unit.namespace, owner: unit.ownerId});
+}
+
+function migrationObjectPatterns(
+  tableOperationExpression: string,
+): Array<[DatabaseObjectKind, RegExp]> {
+  return [
+    [
+      'enum',
+      new RegExp(
+        `\\bCREATE\\s+TYPE\\s+(?:${identifierExpression}\\.)?${identifierExpression}`,
+        'giu',
+      ),
+    ],
+    [
+      'table',
+      new RegExp(
+        `\\b${tableOperationExpression}(?:${identifierExpression}\\.)?${identifierExpression}`,
+        'giu',
+      ),
+    ],
+    [
+      'index',
+      new RegExp(
+        `\\bCREATE\\s+(?:UNIQUE\\s+)?INDEX\\s+(?:IF\\s+NOT\\s+EXISTS\\s+)?${identifierExpression}`,
+        'giu',
+      ),
+    ],
+    [
+      'view',
+      new RegExp(
+        `\\bCREATE\\s+(?:OR\\s+REPLACE\\s+)?VIEW\\s+(?:${identifierExpression}\\.)?${identifierExpression}`,
+        'giu',
+      ),
+    ],
+    [
+      'sequence',
+      new RegExp(
+        `\\bCREATE\\s+SEQUENCE\\s+(?:IF\\s+NOT\\s+EXISTS\\s+)?(?:${identifierExpression}\\.)?${identifierExpression}`,
+        'giu',
+      ),
+    ],
+    ['trigger', new RegExp(`\\bCREATE\\s+TRIGGER\\s+${identifierExpression}`, 'giu')],
+    ['constraint', new RegExp(`\\b(?:ADD\\s+)?CONSTRAINT\\s+${identifierExpression}`, 'giu')],
+  ];
+}
+
+function addMigrationObjects(
+  objects: Map<string, DatabaseObject>,
+  file: AuditFile,
+  unit: DatabaseMigrationUnit,
+): void {
+  for (const [kind, expression] of migrationObjectPatterns(
+    'CREATE\\s+TABLE\\s+(?:IF\\s+NOT\\s+EXISTS\\s+)?',
+  )) {
+    for (const match of file.source.matchAll(expression)) {
+      const name = identifierFromMatch(match);
+      if (name) addObject(objects, name, kind, unit);
+    }
+  }
+}
+
+function addSnapshotObjects(
+  objects: Map<string, DatabaseObject>,
+  file: AuditFile,
+  unit: DatabaseMigrationUnit,
+): void {
+  let snapshot: {
+    tables?: Record<string, SnapshotTable>;
+    enums?: Record<string, SnapshotEnum>;
+    sequences?: Record<string, SnapshotNamedObject>;
+    views?: Record<string, SnapshotNamedObject>;
+  };
+  try {
+    snapshot = JSON.parse(file.source) as typeof snapshot;
+  } catch {
+    return;
+  }
+
+  for (const [qualifiedName, table] of Object.entries(snapshot.tables ?? {})) {
+    addObject(objects, table.name || lastIdentifier(qualifiedName), 'table', unit);
+    for (const index of Object.values(table.indexes ?? {})) {
+      if (index.name) addObject(objects, index.name, 'index', unit);
+    }
+    for (const constraint of Object.values(table.uniqueConstraints ?? {})) {
+      if (constraint.name) addObject(objects, constraint.name, 'constraint', unit);
+    }
+    for (const constraint of Object.values(table.checkConstraints ?? {})) {
+      if (constraint.name) addObject(objects, constraint.name, 'constraint', unit);
+    }
+  }
+  for (const [qualifiedName, enumValue] of Object.entries(snapshot.enums ?? {})) {
+    addObject(objects, enumValue.name || lastIdentifier(qualifiedName), 'enum', unit);
+  }
+  for (const [qualifiedName, sequence] of Object.entries(snapshot.sequences ?? {})) {
+    addObject(objects, sequence.name || lastIdentifier(qualifiedName), 'sequence', unit);
+  }
+  for (const [qualifiedName, view] of Object.entries(snapshot.views ?? {})) {
+    addObject(objects, view.name || lastIdentifier(qualifiedName), 'view', unit);
+  }
+}
+
+interface SnapshotNamedObject {
+  name?: string;
+}
+
+interface SnapshotEnum extends SnapshotNamedObject {}
+
+interface SnapshotTable extends SnapshotNamedObject {
+  indexes?: Record<string, SnapshotNamedObject>;
+  uniqueConstraints?: Record<string, SnapshotNamedObject>;
+  checkConstraints?: Record<string, SnapshotNamedObject>;
+}
+
+function lastIdentifier(value: string): string {
+  return value.split('.').at(-1) ?? value;
+}
+
+function collectFactoryInfo(source: string): FactoryInfo | undefined {
+  const factoryMatch = source.match(factoryExpression);
+  if (!factoryMatch) return undefined;
+  const body = factoryMatch[1] ?? '';
+  const templatePrefix = body.match(templateFactoryPrefixExpression)?.[1];
+  const stringPrefix = body.match(stringFactoryPrefixExpression)?.[1];
+  const prefix = templatePrefix ?? stringPrefix ?? '';
+  const unprefixedNames = new Set<string>();
+  for (const match of body.matchAll(unprefixedFactoryNameExpression)) {
+    if (match[1]) unprefixedNames.add(match[1]);
+  }
+  return {prefix, unprefixedNames};
+}
+
+function factoryPhysicalName(
+  factory: FactoryInfo | undefined,
+  namespace: string,
+  logicalName: string,
+): string {
+  if (factory?.unprefixedNames.has(logicalName)) return logicalName;
+  if (factory?.prefix) return `${factory.prefix}${logicalName}`;
+  return `${namespace}_${logicalName}`;
+}
+
+async function walkFiles(directory: string): Promise<string[]> {
+  const entries = await readdir(directory, {withFileTypes: true}).catch(() => undefined);
+  if (!entries) return [];
+  const files: string[] = [];
+  for (const entry of entries) {
+    if (ignoredDirectoryNames.has(entry.name)) continue;
+    const absolutePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) files.push(...(await walkFiles(absolutePath)));
+    else if (entry.isFile()) files.push(absolutePath);
+  }
+  return files.sort(compareText);
+}
+
+async function readAuditFiles(paths: readonly string[]): Promise<AuditFile[]> {
+  const files = await Promise.all(
+    paths.map(async (filePath) => ({path: filePath, source: await readFile(filePath, 'utf8')})),
+  );
+  return files.sort((left, right) => compareText(left.path, right.path));
+}
+
+async function packageNames(
+  rootDirectory: string,
+  registry: ApiDatabaseRegistry,
+): Promise<Map<string, string>> {
+  const result = new Map<string, string>();
+  const paths = new Map<string, string>();
+  for (const owner of registry.owners) paths.set(owner.packagePath, owner.id);
+  for (const unit of registry.migrationUnits) paths.set(unit.packagePath, unit.ownerId);
+  for (const [packagePath, owner] of paths) {
+    try {
+      const manifest = JSON.parse(
+        await readFile(path.join(rootDirectory, packagePath, 'package.json'), 'utf8'),
+      ) as {name?: string};
+      if (manifest.name) result.set(manifest.name, owner);
+    } catch {
+      // Registry validation reports missing package paths separately.
+    }
+  }
+  return result;
+}
+
+function createAuditContext(
+  options: Required<Pick<DatabaseBoundaryAuditOptions, 'registry' | 'rootDirectory'>>,
+  migrationFiles: readonly AuditFile[],
+  snapshotFiles: readonly AuditFile[],
+  sourceFiles: readonly AuditFile[],
+): AuditContext {
+  const units = [...options.registry.migrationUnits].sort(
+    (left, right) => right.packagePath.length - left.packagePath.length,
+  );
+  const objects = new Map<string, DatabaseObject>();
+  for (const file of migrationFiles) {
+    const unit = units.find((candidate) =>
+      isPathInside(path.join(options.rootDirectory, candidate.migrationsPath), file.path),
+    );
+    if (unit) addMigrationObjects(objects, file, unit);
+  }
+  for (const file of snapshotFiles) {
+    const unit = units.find((candidate) =>
+      isPathInside(path.join(options.rootDirectory, candidate.migrationsPath), file.path),
+    );
+    if (unit) addSnapshotObjects(objects, file, unit);
+  }
+
+  const namespaceOwners = new Map<string, string>();
+  const ownerNamespaces = new Map<string, Set<string>>();
+  for (const unit of options.registry.migrationUnits) {
+    namespaceOwners.set(unit.namespace, unit.ownerId);
+    const namespaces = ownerNamespaces.get(unit.ownerId) ?? new Set<string>();
+    namespaces.add(unit.namespace);
+    ownerNamespaces.set(unit.ownerId, namespaces);
+  }
+  const ownerPackages = new Map<string, string>();
+  for (const owner of options.registry.owners) ownerPackages.set(owner.id, owner.packagePath);
+  for (const unit of options.registry.migrationUnits) {
+    ownerPackages.set(`unit:${unit.id}`, unit.packagePath);
+  }
+  const factories = new Map<string, FactoryInfo>();
+  for (const file of sourceFiles) {
+    if (!file.path.endsWith('/schema/common.ts')) continue;
+    const factory = collectFactoryInfo(file.source);
+    const packagePath = toRepositoryPath(
+      options.rootDirectory,
+      path.dirname(path.dirname(path.dirname(path.dirname(file.path)))),
+    );
+    if (factory) factories.set(packagePath, factory);
+  }
+
+  const sortedNamespaces = [...namespaceOwners.keys()].sort(
+    (left, right) => right.length - left.length || compareText(left, right),
+  );
+  const sqlObjectReferences = [...objects.keys()]
+    .sort((left, right) => right.length - left.length || compareText(left, right))
+    .map((name) => ({
+      name,
+      expression: new RegExp(`(?<![A-Za-z0-9_$])${escapeRegExp(name)}(?![A-Za-z0-9_$])`, 'gu'),
+    }));
+
+  return {
+    registry: options.registry,
+    rootDirectory: options.rootDirectory,
+    units,
+    objects,
+    sortedNamespaces,
+    sqlObjectReferences,
+    namespaceOwners,
+    ownerNamespaces,
+    factories,
+    packageOwners: new Map(),
+    ownerPackages,
+  };
+}
+
+function ownerContextForPath(
+  context: AuditContext,
+  absolutePath: string,
+): FileOwnerContext | undefined {
+  const repositoryPath = toRepositoryPath(context.rootDirectory, absolutePath);
+  const unit = context.units.find(
+    (candidate) =>
+      repositoryPath === candidate.packagePath ||
+      repositoryPath.startsWith(`${candidate.packagePath}/`),
+  );
+  if (unit) return {owner: unit.ownerId, namespace: unit.namespace, unit};
+  if (repositoryPath.startsWith('libs/shared/node/')) {
+    return {owner: 'neutral-infrastructure', namespace: 'neutral'};
+  }
+  return undefined;
+}
+
+function ownerPackagePathForContext(context: AuditContext, filePath: string): string | undefined {
+  const repositoryPath = toRepositoryPath(context.rootDirectory, filePath);
+  const candidates = [...context.ownerPackages.entries()]
+    .filter(
+      ([, packagePath]) =>
+        repositoryPath === packagePath || repositoryPath.startsWith(`${packagePath}/`),
+    )
+    .sort((left, right) => right[1].length - left[1].length);
+  return candidates[0]?.[1];
+}
+
+function objectByNamespace(context: AuditContext, name: string): DatabaseObject | undefined {
+  const exact = context.objects.get(name);
+  if (exact) return exact;
+  for (const namespace of context.sortedNamespaces) {
+    if (name.startsWith(`${namespace}_`)) {
+      return {
+        kind: 'table',
+        name,
+        namespace,
+        owner: context.namespaceOwners.get(namespace) ?? 'unknown',
+      };
+    }
+  }
+  return undefined;
+}
+
+function objectRule(kind: DatabaseObjectKind): DatabaseBoundaryRule {
+  if (kind === 'table') return 'unprefixed-table';
+  if (kind === 'enum') return 'unprefixed-enum';
+  return 'unprefixed-support-object';
+}
+
+function foreignObjectRule(kind: DatabaseObjectKind, migration: boolean): DatabaseBoundaryRule {
+  if (migration) return 'foreign-migration';
+  if (kind === 'table') return 'foreign-table-declaration';
+  if (kind === 'enum') return 'foreign-enum-declaration';
+  return 'foreign-support-object';
+}
+
+function addFinding(
+  findings: DatabaseBoundaryFinding[],
+  context: AuditContext,
+  filePath: string,
+  source: string,
+  index: number,
+  object: string,
+  rule: DatabaseBoundaryRule,
+  suggestedBoundary: string,
+  fileContextOverride?: FileOwnerContext,
+  ownerOverride?: string,
+  namespaceOverride?: string,
+): void {
+  const fileOwner = fileContextOverride ?? ownerContextForPath(context, filePath);
+  findings.push({
+    owner: ownerOverride ?? fileOwner?.owner ?? 'unknown',
+    namespace: namespaceOverride ?? fileOwner?.namespace ?? 'unknown',
+    file: toRepositoryPath(context.rootDirectory, filePath),
+    line: lineAt(source, index),
+    object,
+    rule,
+    suggestedBoundary,
+  });
+}
+
+function hasAllowedNamespacePrefix(context: AuditContext, owner: string, name: string): boolean {
+  return [...(context.ownerNamespaces.get(owner) ?? [])].some((namespace) =>
+    name.startsWith(`${namespace}_`),
+  );
+}
+
+function validateObjectReference(
+  findings: DatabaseBoundaryFinding[],
+  context: AuditContext,
+  file: AuditFile,
+  reference: ObjectReference,
+  migration: boolean,
+): void {
+  const fileContext = ownerContextForPath(context, file.path);
+  if (!fileContext || fileContext.owner === 'neutral-infrastructure') return;
+  const target = objectByNamespace(context, reference.name);
+  const targetOwner = target?.owner;
+  if (targetOwner && targetOwner !== fileContext.owner) {
+    addFinding(
+      findings,
+      context,
+      file.path,
+      file.source,
+      reference.index,
+      reference.name,
+      foreignObjectRule(reference.kind, migration),
+      namespaceSuggestion(targetOwner, target?.namespace ?? 'unknown'),
+      fileContext,
+    );
+    return;
+  }
+  if (
+    targetOwner === fileContext.owner &&
+    hasAllowedNamespacePrefix(context, targetOwner, reference.name)
+  ) {
+    return;
+  }
+  if (targetOwner === fileContext.owner || !namespaceExpression.test(reference.name)) {
+    addFinding(
+      findings,
+      context,
+      file.path,
+      file.source,
+      reference.index,
+      reference.name,
+      objectRule(reference.kind),
+      namespaceSuggestion(fileContext.owner, fileContext.namespace),
+      fileContext,
+    );
+    return;
+  }
+  if (!hasAllowedNamespacePrefix(context, fileContext.owner, reference.name)) {
+    addFinding(
+      findings,
+      context,
+      file.path,
+      file.source,
+      reference.index,
+      reference.name,
+      objectRule(reference.kind),
+      namespaceSuggestion(fileContext.owner, fileContext.namespace),
+      fileContext,
+    );
+  }
+}
+
+function parseSourceImports(source: string): {
+  directTableFunctions: Set<string>;
+  directTableCreatorFunctions: Set<string>;
+  localTableFunctions: Set<string>;
+} {
+  const directTableFunctions = new Set<string>();
+  const directTableCreatorFunctions = new Set<string>();
+  const localTableFunctions = new Set<string>();
+  for (const match of source.matchAll(/import\s+\{([^}]+)\}\s+from\s+["']([^"']+)["']/gu)) {
+    const imports = match[1] ?? '';
+    const moduleName = match[2] ?? '';
+    for (const item of imports.split(',')) {
+      const [originalValue, localValue] = item.trim().split(importAliasExpression);
+      const original = originalValue?.trim();
+      const local = localValue?.trim() || original;
+      if (!original || !local) continue;
+      if (moduleName === 'drizzle-orm/pg-core' && original === 'pgTable') {
+        directTableFunctions.add(local);
+      } else if (moduleName === 'drizzle-orm/pg-core' && original === 'pgTableCreator') {
+        directTableCreatorFunctions.add(local);
+      } else if (moduleName.endsWith('/common.js') && original === 'pgTable') {
+        localTableFunctions.add(local);
+      }
+    }
+  }
+  if (registeredFactoryExpression.test(source)) localTableFunctions.add('pgTable');
+  return {directTableFunctions, directTableCreatorFunctions, localTableFunctions};
+}
+
+function firstCallString(
+  source: string,
+  index: number,
+): {value: string; index: number} | undefined {
+  const tail = source.slice(index);
+  const match = tail.match(firstCallArgumentExpression);
+  if (!match || match.index === undefined) return undefined;
+  return {value: match[2] ?? '', index: index + match.index + match[0].indexOf(match[2] ?? '')};
+}
+
+function factoryForFile(context: AuditContext, filePath: string): FactoryInfo | undefined {
+  const packagePath = ownerPackagePathForContext(context, filePath);
+  return packagePath ? context.factories.get(packagePath) : undefined;
+}
+
+function factoryRuleAndBoundary(
+  fileContext: FileOwnerContext,
+  foreignOwner: string | undefined,
+  namespace: string,
+): {
+  rule: 'direct-table-declaration' | 'foreign-table-declaration';
+  suggestedBoundary: string;
+} {
+  if (foreignOwner && foreignOwner !== fileContext.owner) {
+    return {
+      rule: 'foreign-table-declaration',
+      suggestedBoundary: namespaceSuggestion(foreignOwner, namespace),
+    };
+  }
+  return {
+    rule: 'direct-table-declaration',
+    suggestedBoundary: `Declare tables through the registered ${fileContext.namespace} schema factory.`,
+  };
+}
+
+function auditFactories(
+  findings: DatabaseBoundaryFinding[],
+  context: AuditContext,
+  file: AuditFile,
+): void {
+  const fileContext = ownerContextForPath(context, file.path);
+  if (!fileContext || fileContext.owner === 'neutral-infrastructure') return;
+  const {directTableCreatorFunctions} = parseSourceImports(file.source);
+  for (const functionName of directTableCreatorFunctions) {
+    for (const match of file.source.matchAll(
+      new RegExp(`\\b${escapeRegExp(functionName)}\\s*\\(`, 'gu'),
+    )) {
+      const callIndex = match.index ?? 0;
+      const isRegisteredFactory =
+        file.path.endsWith('/schema/common.ts') && registeredFactoryExpression.test(file.source);
+      if (isRegisteredFactory) continue;
+      const body = file.source.slice(callIndex, callIndex + factoryBodyLookaheadLength);
+      const prefix = body.match(inlineFactoryPrefixExpression)?.[1] ?? '';
+      const namespace = prefix.replace(trailingUnderscoreExpression, '');
+      const foreignOwner = namespace ? context.namespaceOwners.get(namespace) : undefined;
+      const factoryBoundary = factoryRuleAndBoundary(fileContext, foreignOwner, namespace);
+      addFinding(
+        findings,
+        context,
+        file.path,
+        file.source,
+        callIndex,
+        functionName,
+        factoryBoundary.rule,
+        factoryBoundary.suggestedBoundary,
+        fileContext,
+      );
+      const bindingExpression = new RegExp(
+        `(?:const|let|var)\\s+([A-Za-z_$][\\w$]*)\\s*=\\s*${escapeRegExp(functionName)}\\s*\\(`,
+        'gu',
+      );
+      const tableBinding = [...file.source.matchAll(bindingExpression)].find(
+        (binding) => (binding.index ?? 0) <= callIndex,
+      )?.[1];
+      if (!tableBinding || !prefix) continue;
+      const tableExpression = new RegExp(`\\b${escapeRegExp(tableBinding)}\\s*\\(`, 'gu');
+      for (const tableMatch of file.source.matchAll(tableExpression)) {
+        const tableIndex = tableMatch.index ?? 0;
+        if (tableIndex <= callIndex) continue;
+        const firstArgument = firstCallString(file.source, tableIndex + tableMatch[0].length - 1);
+        if (!firstArgument) continue;
+        const object = `${prefix}${firstArgument.value}`;
+        addFinding(
+          findings,
+          context,
+          file.path,
+          file.source,
+          firstArgument.index,
+          object,
+          factoryBoundary.rule,
+          factoryBoundary.suggestedBoundary,
+          fileContext,
+        );
+      }
+    }
+  }
+}
+
+function auditSourceDeclarations(
+  findings: DatabaseBoundaryFinding[],
+  context: AuditContext,
+  file: AuditFile,
+): void {
+  const fileContext = ownerContextForPath(context, file.path);
+  if (!fileContext || fileContext.owner === 'neutral-infrastructure') return;
+  const imports = parseSourceImports(file.source);
+  const factory = factoryForFile(context, file.path);
+  const tableFunctions = new Set([
+    'pgTable',
+    ...imports.directTableFunctions,
+    ...imports.localTableFunctions,
+  ]);
+
+  for (const functionName of tableFunctions) {
+    for (const match of file.source.matchAll(
+      new RegExp(`\\b${escapeRegExp(functionName)}\\s*\\(`, 'gu'),
+    )) {
+      const callIndex = match.index ?? 0;
+      if (functionName === 'pgTableCreator') continue;
+      const firstArgument = firstCallString(file.source, callIndex + match[0].length - 1);
+      if (!firstArgument) continue;
+      const isDirect = imports.directTableFunctions.has(functionName);
+      const physicalName = isDirect
+        ? firstArgument.value
+        : factoryPhysicalName(factory, fileContext.namespace, firstArgument.value);
+      const target = objectByNamespace(context, physicalName);
+      if (
+        !isDirect &&
+        factory?.unprefixedNames.has(firstArgument.value) &&
+        (!target?.owner || target.owner === fileContext.owner)
+      ) {
+        continue;
+      }
+      if (!isDirect || (target?.owner && target.owner !== fileContext.owner)) {
+        validateObjectReference(
+          findings,
+          context,
+          file,
+          {kind: 'table', name: physicalName, index: firstArgument.index},
+          false,
+        );
+        continue;
+      }
+      addFinding(
+        findings,
+        context,
+        file.path,
+        file.source,
+        firstArgument.index,
+        physicalName,
+        'direct-table-declaration',
+        `Declare tables through the registered ${fileContext.namespace} schema factory.`,
+        fileContext,
+      );
+    }
+  }
+
+  for (const match of file.source.matchAll(/\bpgEnum\s*\(/gu)) {
+    const firstArgument = firstCallString(file.source, (match.index ?? 0) + match[0].length - 1);
+    if (!firstArgument) continue;
+    validateObjectReference(
+      findings,
+      context,
+      file,
+      {kind: 'enum', name: firstArgument.value, index: firstArgument.index},
+      false,
+    );
+  }
+
+  for (const match of file.source.matchAll(/\b(?:uniqueIndex|index|check|primaryKey)\s*\(/gu)) {
+    const firstArgument = firstCallString(file.source, (match.index ?? 0) + match[0].length - 1);
+    if (!firstArgument) continue;
+    validateObjectReference(
+      findings,
+      context,
+      file,
+      {kind: 'constraint', name: firstArgument.value, index: firstArgument.index},
+      false,
+    );
+  }
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+}
+
+function isSqlLikeReference(source: string, index: number): boolean {
+  const before = source.slice(Math.max(0, index - sqlReferenceLookbehindLength), index);
+  const line = lineTextAt(source, index);
+  if (declarationReferenceExpression.test(before)) return false;
+  const hasSqlTag = sqlTemplateExpression.test(before) || sqlCallExpression.test(before);
+  const hasSqlKeyword = sqlKeywordExpression.test(line);
+  if (!hasSqlTag && !hasSqlKeyword) return false;
+  return hasSqlTag || hasSqlKeyword;
+}
+
+function sqlRuleForObject(source: string, index: number): DatabaseBoundaryRule {
+  const line = lineTextAt(source, index);
+  if (referencesKeywordExpression.test(line)) return 'foreign-key';
+  return migrationSqlKeywordExpression.test(line) ? 'foreign-migration' : 'foreign-raw-sql';
+}
+
+function registeredTableBindings(source: string): Set<string> {
+  const bindings = new Set<string>();
+  for (const match of source.matchAll(tableBindingImportExpression)) {
+    const imports = match[1] ?? '';
+    for (const item of imports.split(',')) {
+      const [originalValue, localValue] = item.trim().split(importAliasExpression);
+      const local = localValue?.trim() || originalValue?.trim();
+      if (local) bindings.add(local);
+    }
+  }
+  for (const match of source.matchAll(objectBindingExpression)) {
+    if (match[1]) bindings.add(match[1]);
+  }
+  return bindings;
+}
+
+function isRegisteredSqlInterpolation(source: string, interpolationStart: number): boolean {
+  const expression =
+    source
+      .slice(interpolationStart + 2)
+      .match(interpolationBodyExpression)?.[0]
+      ?.trim() ?? '';
+  const identifier = expression.match(plainIdentifierExpression)?.[0] ?? expression.split('.')[0];
+  return identifier ? registeredTableBindings(source).has(identifier) : false;
+}
+
+function auditRawSql(
+  findings: DatabaseBoundaryFinding[],
+  context: AuditContext,
+  file: AuditFile,
+): void {
+  const fileContext = ownerContextForPath(context, file.path);
+  if (!fileContext || fileContext.owner === 'neutral-infrastructure') return;
+  for (const {name, expression} of context.sqlObjectReferences) {
+    expression.lastIndex = 0;
+    for (const match of file.source.matchAll(expression)) {
+      const offset = match.index ?? 0;
+      if (isSqlLikeReference(file.source, offset)) {
+        const reference = {kind: context.objects.get(name)?.kind ?? 'table', name, index: offset};
+        const target = objectByNamespace(context, name);
+        if (target?.owner && target.owner !== fileContext.owner) {
+          addFinding(
+            findings,
+            context,
+            file.path,
+            file.source,
+            offset,
+            name,
+            sqlRuleForObject(file.source, offset),
+            namespaceSuggestion(target.owner, target.namespace),
+            fileContext,
+          );
+        } else {
+          validateObjectReference(findings, context, file, reference, false);
+        }
+      }
+    }
+  }
+
+  for (const match of file.source.matchAll(dynamicSqlKeywordExpression)) {
+    const interpolationStart = (match.index ?? 0) + match[0].lastIndexOf('${');
+    if (isRegisteredSqlInterpolation(file.source, interpolationStart)) continue;
+    addFinding(
+      findings,
+      context,
+      file.path,
+      file.source,
+      match.index ?? 0,
+      '<dynamic identifier>',
+      'dynamic-sql-identifier',
+      `Use a registered ${fileContext.namespace} table or an owner operation instead of a dynamic SQL identifier.`,
+      fileContext,
+    );
+  }
+  for (const match of file.source.matchAll(dynamicRawSqlExpression)) {
+    if (!dynamicSqlRawKeywordExpression.test(match[0])) continue;
+    const interpolationStart = (match.index ?? 0) + match[0].lastIndexOf('${');
+    if (isRegisteredSqlInterpolation(file.source, interpolationStart)) continue;
+    addFinding(
+      findings,
+      context,
+      file.path,
+      file.source,
+      match.index ?? 0,
+      '<dynamic identifier>',
+      'dynamic-sql-identifier',
+      `Use a registered ${fileContext.namespace} table or an owner operation instead of a dynamic SQL identifier.`,
+      fileContext,
+    );
+  }
+}
+
+function parseImportBindings(importClause: string): string[] {
+  const names: string[] = [];
+  const named = importClause.match(namedImportExpression)?.[1];
+  if (named) {
+    for (const item of named.split(',')) {
+      const [originalValue, localValue] = item.trim().split(importAliasExpression);
+      const local = localValue?.trim() || originalValue?.trim();
+      if (local) names.push(local);
+    }
+  }
+  const namespace = importClause.match(namespaceImportExpression)?.[1];
+  if (namespace) names.push(namespace);
+  const defaultImport = importClause.match(defaultImportExpression)?.[1];
+  if (defaultImport) names.push(defaultImport);
+  return names;
+}
+
+function ownerForImportedPackage(
+  context: AuditContext,
+  importedPackage: string,
+): string | undefined {
+  const exact = context.packageOwners.get(importedPackage);
+  if (exact) return exact;
+  return [...context.packageOwners.entries()]
+    .filter(([packageName]) => importedPackage.startsWith(`${packageName}/`))
+    .sort((left, right) => right[0].length - left[0].length)[0]?.[1];
+}
+function auditForeignDatabaseAccess(
+  findings: DatabaseBoundaryFinding[],
+  context: AuditContext,
+  file: AuditFile,
+): void {
+  const fileContext = ownerContextForPath(context, file.path);
+  if (!fileContext || fileContext.owner === 'neutral-infrastructure') return;
+  for (const match of file.source.matchAll(packageImportExpression)) {
+    const importClause = match[1] ?? '';
+    const importedPackage = match[2] ?? '';
+    const targetOwner = ownerForImportedPackage(context, importedPackage);
+    if (!targetOwner || targetOwner === fileContext.owner) continue;
+    for (const binding of parseImportBindings(importClause)) {
+      const accessExpression = new RegExp(
+        `\\b${escapeRegExp(binding)}\\s*\\.\\s*database\\b`,
+        'gu',
+      );
+      for (const access of file.source.matchAll(accessExpression)) {
+        addFinding(
+          findings,
+          context,
+          file.path,
+          file.source,
+          access.index ?? 0,
+          `${binding}.database`,
+          'foreign-database-access',
+          namespaceSuggestion(
+            targetOwner,
+            [...(context.ownerNamespaces.get(targetOwner) ?? [])][0] ?? 'unknown',
+          ),
+          fileContext,
+        );
+      }
+    }
+  }
+}
+
+function auditSourceForeignKeys(
+  findings: DatabaseBoundaryFinding[],
+  context: AuditContext,
+  file: AuditFile,
+): void {
+  const fileContext = ownerContextForPath(context, file.path);
+  if (!fileContext || fileContext.owner === 'neutral-infrastructure') return;
+  for (const match of file.source.matchAll(packageImportExpression)) {
+    const targetOwner = ownerForImportedPackage(context, match[2] ?? '');
+    if (!targetOwner || targetOwner === fileContext.owner) continue;
+    for (const binding of parseImportBindings(match[1] ?? '')) {
+      const referenceExpression = new RegExp(
+        `\\.references\\s*\\(\\s*\\(\\s*\\)\\s*=>\\s*${escapeRegExp(binding)}(?:\\.[A-Za-z_$][\\w$]*)?`,
+        'gu',
+      );
+      for (const reference of file.source.matchAll(referenceExpression)) {
+        addFinding(
+          findings,
+          context,
+          file.path,
+          file.source,
+          reference.index ?? 0,
+          `${binding}.references`,
+          'foreign-key',
+          namespaceSuggestion(
+            targetOwner,
+            [...(context.ownerNamespaces.get(targetOwner) ?? [])][0] ?? 'unknown',
+          ),
+          fileContext,
+        );
+      }
+    }
+  }
+}
+function auditMigrationHistory(
+  findings: DatabaseBoundaryFinding[],
+  context: AuditContext,
+  file: AuditFile,
+): void {
+  const fileContext = ownerContextForPath(context, file.path);
+  if (!fileContext) return;
+  if (fileContext.owner !== 'neutral-infrastructure') {
+    for (const match of file.source.matchAll(migrationHistoryExpression)) {
+      const namespace = match[1] ?? '';
+      const owner = context.namespaceOwners.get(namespace);
+      if (owner && owner !== fileContext.owner) {
+        addFinding(
+          findings,
+          context,
+          file.path,
+          file.source,
+          match.index ?? 0,
+          `__drizzle_migrations_${namespace}`,
+          'foreign-migration',
+          namespaceSuggestion(owner, namespace),
+          fileContext,
+        );
+      }
+    }
+  }
+  if (file.path.endsWith('/libs/shared/node/module/src/initialize.ts')) {
+    const fallback = file.source.match(fallbackHistoryExpression);
+    if (fallback?.index !== undefined) {
+      addFinding(
+        findings,
+        context,
+        file.path,
+        file.source,
+        fallback.index,
+        'moduleMigrationTableName',
+        'migration-history-instability',
+        'Require the registered database namespace on every ModuleDatabase declaration.',
+        fileContext,
+        'neutral-infrastructure',
+        'neutral',
+      );
+    }
+  }
+  if (file.path.endsWith('/libs/shared/node/module/src/types.ts')) {
+    const optionalField = file.source.match(optionalHistoryExpression);
+    if (optionalField?.index !== undefined) {
+      addFinding(
+        findings,
+        context,
+        file.path,
+        file.source,
+        optionalField.index,
+        'migrationsTableName',
+        'migration-history-instability',
+        'Require the registered database namespace on every ModuleDatabase declaration.',
+        fileContext,
+        'neutral-infrastructure',
+        'neutral',
+      );
+    }
+  }
+}
+
+function auditMigrationFile(
+  findings: DatabaseBoundaryFinding[],
+  context: AuditContext,
+  file: AuditFile,
+): void {
+  const fileContext = ownerContextForPath(context, file.path);
+  if (!fileContext?.unit) return;
+  const patterns = migrationObjectPatterns(
+    '(?:CREATE\\s+TABLE|ALTER\\s+TABLE|DROP\\s+TABLE)\\s+(?:IF\\s+NOT\\s+EXISTS\\s+|IF\\s+EXISTS\\s+)?',
+  );
+  for (const [kind, expression] of patterns) {
+    for (const match of file.source.matchAll(expression)) {
+      const name = identifierFromMatch(match);
+      if (name)
+        validateObjectReference(
+          findings,
+          context,
+          file,
+          {kind, name, index: match.index ?? 0},
+          true,
+        );
+    }
+  }
+  for (const match of file.source.matchAll(
+    new RegExp(`\\bREFERENCES\\s+(?:${identifierExpression}\\.)?${identifierExpression}`, 'giu'),
+  )) {
+    const name = identifierFromMatch(match);
+    if (!name) continue;
+    const target = objectByNamespace(context, name);
+    if (target?.owner && target.owner !== fileContext.owner) {
+      addFinding(
+        findings,
+        context,
+        file.path,
+        file.source,
+        match.index ?? 0,
+        name,
+        'foreign-key',
+        namespaceSuggestion(target.owner, target.namespace),
+        fileContext,
+      );
+    } else {
+      validateObjectReference(
+        findings,
+        context,
+        file,
+        {kind: 'table', name, index: match.index ?? 0},
+        true,
+      );
+    }
+  }
+  if (interpolationPresenceExpression.test(file.source)) {
+    for (const match of file.source.matchAll(dynamicIdentifierExpression)) {
+      addFinding(
+        findings,
+        context,
+        file.path,
+        file.source,
+        match.index ?? 0,
+        '<dynamic identifier>',
+        'dynamic-sql-identifier',
+        `Keep ${fileContext.namespace} migration identifiers static and owner-local.`,
+        fileContext,
+      );
+    }
+  }
+}
+
+function auditSnapshotFile(
+  findings: DatabaseBoundaryFinding[],
+  context: AuditContext,
+  file: AuditFile,
+): void {
+  const fileContext = ownerContextForPath(context, file.path);
+  if (!fileContext?.unit) return;
+  let snapshot: {
+    tables?: Record<string, SnapshotTable>;
+    enums?: Record<string, SnapshotEnum>;
+  };
+  try {
+    snapshot = JSON.parse(file.source) as typeof snapshot;
+  } catch {
+    return;
+  }
+  const references: ObjectReference[] = [];
+  for (const [qualifiedName, table] of Object.entries(snapshot.tables ?? {})) {
+    references.push({
+      kind: 'table',
+      name: table.name || lastIdentifier(qualifiedName),
+      index: file.source.indexOf(table.name || lastIdentifier(qualifiedName)),
+    });
+    for (const index of Object.values(table.indexes ?? {})) {
+      if (index.name)
+        references.push({kind: 'index', name: index.name, index: file.source.indexOf(index.name)});
+    }
+    for (const constraint of Object.values(table.uniqueConstraints ?? {})) {
+      if (constraint.name)
+        references.push({
+          kind: 'constraint',
+          name: constraint.name,
+          index: file.source.indexOf(constraint.name),
+        });
+    }
+    for (const constraint of Object.values(table.checkConstraints ?? {})) {
+      if (constraint.name)
+        references.push({
+          kind: 'constraint',
+          name: constraint.name,
+          index: file.source.indexOf(constraint.name),
+        });
+    }
+  }
+  for (const [qualifiedName, enumValue] of Object.entries(snapshot.enums ?? {})) {
+    references.push({
+      kind: 'enum',
+      name: enumValue.name || lastIdentifier(qualifiedName),
+      index: file.source.indexOf(enumValue.name || lastIdentifier(qualifiedName)),
+    });
+  }
+  for (const reference of references) {
+    if (reference.index >= 0) validateObjectReference(findings, context, file, reference, true);
+  }
+}
+
+async function discoverFiles(
+  rootDirectory: string,
+  registry: ApiDatabaseRegistry,
+): Promise<{sourceFiles: AuditFile[]; migrationFiles: AuditFile[]; snapshotFiles: AuditFile[]}> {
+  const sourcePaths = await Promise.all([
+    walkFiles(path.join(rootDirectory, 'libs/api')),
+    walkFiles(path.join(rootDirectory, 'libs/shared/node')),
+    walkFiles(path.join(rootDirectory, 'apps/api')),
+  ]);
+  const sourceFilePaths = sourcePaths
+    .flat()
+    .filter((filePath) => sourceFileExpression.test(filePath) && !filePath.includes('/drizzle/'));
+  const migrationPaths = await Promise.all(
+    registry.migrationUnits.map((unit) => walkFiles(path.join(rootDirectory, unit.migrationsPath))),
+  );
+  const migrationFilePaths = migrationPaths
+    .flat()
+    .filter((filePath) => migrationFileExpression.test(filePath));
+  const snapshotFilePaths = migrationPaths.flatMap((paths) =>
+    paths
+      .filter((filePath) => snapshotFileExpression.test(filePath))
+      .sort(compareText)
+      .slice(-1),
+  );
+  const [sourceFiles, migrationFiles, snapshotFiles] = await Promise.all([
+    readAuditFiles(sourceFilePaths),
+    readAuditFiles(migrationFilePaths),
+    readAuditFiles(snapshotFilePaths),
+  ]);
+  return {sourceFiles, migrationFiles, snapshotFiles};
+}
+
+function findUnregisteredMigrationUnits(
+  findings: DatabaseBoundaryFinding[],
+  context: AuditContext,
+  files: readonly AuditFile[],
+): void {
+  const registered = new Set(context.registry.migrationUnits.map((unit) => unit.drizzleConfigPath));
+  for (const file of files) {
+    const repositoryPath = toRepositoryPath(context.rootDirectory, file.path);
+    if (!repositoryPath.endsWith('/drizzle.config.ts')) continue;
+    if (registered.has(repositoryPath)) continue;
+    addFinding(
+      findings,
+      context,
+      file.path,
+      file.source,
+      0,
+      repositoryPath,
+      'unregistered-migration-unit',
+      'Register this migration unit in api-databases.cjs before adding database objects.',
+    );
+  }
+}
+
+export async function auditApiDatabaseBoundaries(
+  options: DatabaseBoundaryAuditOptions = {},
+): Promise<DatabaseBoundaryFinding[]> {
+  const registry = options.registry ?? apiDatabaseRegistry;
+  const rootDirectory = options.rootDirectory ?? repositoryRoot;
+  const discovered = await discoverFiles(rootDirectory, registry);
+  const context = createAuditContext(
+    {registry, rootDirectory},
+    discovered.migrationFiles,
+    discovered.snapshotFiles,
+    discovered.sourceFiles,
+  );
+  context.packageOwners = await packageNames(rootDirectory, registry);
+  const findings: DatabaseBoundaryFinding[] = [];
+  for (const file of discovered.sourceFiles) {
+    auditFactories(findings, context, file);
+    auditSourceDeclarations(findings, context, file);
+    auditRawSql(findings, context, file);
+    auditForeignDatabaseAccess(findings, context, file);
+    auditSourceForeignKeys(findings, context, file);
+    auditMigrationHistory(findings, context, file);
+  }
+  for (const file of discovered.migrationFiles) {
+    auditRawSql(findings, context, file);
+    auditMigrationFile(findings, context, file);
+  }
+  for (const file of discovered.snapshotFiles) auditSnapshotFile(findings, context, file);
+  findUnregisteredMigrationUnits(findings, context, discovered.sourceFiles);
+  const unique = new Map<string, DatabaseBoundaryFinding>();
+  for (const finding of findings) unique.set(findingKey(finding), finding);
+  return [...unique.values()].sort(compareFindings);
+}
+
+export function reconcileDatabaseBoundaryBaseline(
+  findings: readonly DatabaseBoundaryFinding[],
+  baseline: readonly DatabaseBoundaryBaselineEntry[] = databaseBoundaryBaseline,
+): ReconciliationResult {
+  const baselineByKey = new Map(baseline.map((entry) => [baselineKey(entry), entry]));
+  const knownBaselineFindings: DatabaseBoundaryFinding[] = [];
+  const newFindings: DatabaseBoundaryFinding[] = [];
+  for (const finding of findings) {
+    if (baselineByKey.has(findingKey(finding))) knownBaselineFindings.push(finding);
+    else newFindings.push(finding);
+  }
+  const findingKeys = new Set(findings.map((finding) => findingKey(finding)));
+  const disappearedBaselineEntries = baseline.filter(
+    (entry) => !findingKeys.has(baselineKey(entry)),
+  );
+  return {
+    knownBaselineFindings: knownBaselineFindings.sort(compareFindings),
+    newFindings: newFindings.sort(compareFindings),
+    disappearedBaselineEntries: [...disappearedBaselineEntries],
+  };
+}
+
+export async function verifyApiDatabaseBoundaries(
+  options: DatabaseBoundaryAuditOptions = {},
+): Promise<DatabaseBoundaryVerificationResult> {
+  const findings = await auditApiDatabaseBoundaries(options);
+  const reconciliation = reconcileDatabaseBoundaryBaseline(findings, databaseBoundaryBaseline);
+  return {
+    findings,
+    ...reconciliation,
+    registryErrors: await auditApiDatabaseRegistry(options.registry ?? apiDatabaseRegistry),
+  };
+}
+
+function formatFinding(finding: DatabaseBoundaryFinding): string {
+  return `${finding.file}:${finding.line} ${finding.rule} owner=${finding.owner} namespace=${finding.namespace} object=${finding.object} boundary=${finding.suggestedBoundary}`;
+}
+
+async function main(): Promise<void> {
+  const result = await verifyApiDatabaseBoundaries();
+  if (result.knownBaselineFindings.length > 0) {
+    process.stdout.write(
+      `Known database-boundary baseline findings (${result.knownBaselineFindings.length}):\n`,
+    );
+    for (const finding of result.knownBaselineFindings)
+      process.stdout.write(`- ${formatFinding(finding)}\n`);
+  }
+  if (
+    result.registryErrors.length > 0 ||
+    result.newFindings.length > 0 ||
+    result.disappearedBaselineEntries.length > 0
+  ) {
+    process.stderr.write('API database-boundary verification failed\n');
+    for (const error of result.registryErrors) process.stderr.write(`- registry: ${error}\n`);
+    for (const finding of result.newFindings)
+      process.stderr.write(`- new: ${formatFinding(finding)}\n`);
+    for (const entry of result.disappearedBaselineEntries) {
+      process.stderr.write(
+        `- baseline disappeared: ${entry.file}:${entry.line} ${entry.rule} object=${entry.object} tracking=${entry.trackingIssue} removal=${entry.removalCondition}\n`,
+      );
+    }
+    process.exitCode = 1;
+    return;
+  }
+  process.stdout.write('API database-boundary verification passed\n');
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/tools/api-database-policy/test/api-database-boundaries.test.ts
+++ b/tools/api-database-policy/test/api-database-boundaries.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import {
+  auditApiDatabaseBoundaries,
+  type DatabaseBoundaryFinding,
+  databaseBoundaryBaseline,
+  reconcileDatabaseBoundaryBaseline,
+} from '../src/api-database-boundaries.js';
+
+function findingFromBaseline(index: number): DatabaseBoundaryFinding {
+  const entry = databaseBoundaryBaseline[index];
+  assert.ok(entry);
+  return {
+    owner: entry.owner,
+    namespace: entry.namespace,
+    file: entry.file,
+    line: entry.line,
+    object: entry.object,
+    rule: entry.rule,
+    suggestedBoundary: entry.suggestedBoundary,
+  };
+}
+describe('database boundary verifier', () => {
+  test('keeps the current repository findings as exact, issue-owned baseline entries', async () => {
+    const findings = await auditApiDatabaseBoundaries();
+    const reconciliation = reconcileDatabaseBoundaryBaseline(findings);
+    assert.deepEqual(reconciliation.newFindings, []);
+    assert.deepEqual(reconciliation.disappearedBaselineEntries, []);
+    assert.equal(reconciliation.knownBaselineFindings.length, databaseBoundaryBaseline.length);
+    assert.ok(databaseBoundaryBaseline.every((entry) => !entry.file.includes('*')));
+    assert.ok(databaseBoundaryBaseline.every((entry) => !entry.object.includes('*')));
+    assert.deepEqual(
+      new Set(findings.map((finding) => finding.rule)),
+      new Set([
+        'direct-table-declaration',
+        'foreign-database-access',
+        'foreign-enum-declaration',
+        'foreign-migration',
+        'foreign-raw-sql',
+        'foreign-table-declaration',
+        'migration-history-instability',
+        'unprefixed-enum',
+        'unprefixed-support-object',
+        'unprefixed-table',
+      ]),
+    );
+  });
+  test('fails closed when a finding is new or a baseline entry disappears', () => {
+    const known = findingFromBaseline(0);
+    const firstBaseline = databaseBoundaryBaseline[0];
+    const secondBaseline = databaseBoundaryBaseline[1];
+    assert.ok(firstBaseline);
+    assert.ok(secondBaseline);
+    const disappeared = {...secondBaseline};
+    const reconciliation = reconcileDatabaseBoundaryBaseline([known], [firstBaseline, disappeared]);
+    assert.deepEqual(reconciliation.knownBaselineFindings, [known]);
+    assert.deepEqual(reconciliation.newFindings, []);
+    assert.deepEqual(reconciliation.disappearedBaselineEntries, [disappeared]);
+    const newFinding = {...known, object: `${known.object}_new`};
+    const newResult = reconcileDatabaseBoundaryBaseline([newFinding], [firstBaseline]);
+    assert.deepEqual(newResult.knownBaselineFindings, []);
+    assert.deepEqual(newResult.newFindings, [newFinding]);
+  });
+});

--- a/tools/api-database-policy/test/api-database-boundary-fixtures.test.ts
+++ b/tools/api-database-policy/test/api-database-boundary-fixtures.test.ts
@@ -1,0 +1,258 @@
+import assert from 'node:assert/strict';
+import {mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {dirname, join} from 'node:path';
+import {
+  auditApiDatabaseBoundaries,
+  type DatabaseBoundaryFinding,
+} from '../src/api-database-boundaries.js';
+import type {ApiDatabaseRegistry} from '../src/api-database-registry.js';
+
+const fixtureRegistry: ApiDatabaseRegistry = {
+  owners: [
+    {id: 'alpha', packagePath: 'libs/api/alpha'},
+    {id: 'beta', packagePath: 'libs/api/beta'},
+    {id: 'integrations', packagePath: 'libs/api/integrations/core'},
+    {id: 'missing', packagePath: 'libs/api/missing'},
+  ],
+  migrationUnits: [
+    {
+      id: 'alpha',
+      ownerId: 'alpha',
+      namespace: 'alpha',
+      packagePath: 'libs/api/alpha',
+      drizzleConfigPath: 'libs/api/alpha/drizzle.config.ts',
+      migrationsPath: 'libs/api/alpha/drizzle',
+    },
+    {
+      id: 'beta',
+      ownerId: 'beta',
+      namespace: 'beta',
+      packagePath: 'libs/api/beta',
+      drizzleConfigPath: 'libs/api/beta/drizzle.config.ts',
+      migrationsPath: 'libs/api/beta/drizzle',
+    },
+    {
+      id: 'integrations-core',
+      ownerId: 'integrations',
+      namespace: 'integrations',
+      packagePath: 'libs/api/integrations/core',
+      drizzleConfigPath: 'libs/api/integrations/core/drizzle.config.ts',
+      migrationsPath: 'libs/api/integrations/core/drizzle',
+    },
+    {
+      id: 'integrations-provider',
+      ownerId: 'integrations',
+      namespace: 'integrations_provider',
+      packagePath: 'libs/api/integrations/provider',
+      drizzleConfigPath: 'libs/api/integrations/provider/drizzle.config.ts',
+      migrationsPath: 'libs/api/integrations/provider/drizzle',
+    },
+  ],
+  delegates: [],
+};
+const nonEmptyOutputPattern = /./u;
+
+async function writeFixture(
+  rootDirectory: string,
+  relativePath: string,
+  source: string,
+): Promise<void> {
+  const absolutePath = join(rootDirectory, relativePath);
+  await mkdir(dirname(absolutePath), {recursive: true});
+  await writeFile(absolutePath, source);
+}
+async function createFixtureRepository(rootDirectory: string): Promise<void> {
+  const packageManifests: ReadonlyArray<readonly [string, string]> = [
+    ['libs/api/alpha/package.json', '@fixture/alpha'],
+    ['libs/api/beta/package.json', '@fixture/beta'],
+    ['libs/api/integrations/core/package.json', '@fixture/integrations-core'],
+    ['libs/api/integrations/provider/package.json', '@fixture/integrations-provider'],
+  ];
+  for (const [relativePath, name] of packageManifests) {
+    await writeFixture(rootDirectory, relativePath, JSON.stringify({name}));
+  }
+  for (const unit of fixtureRegistry.migrationUnits) {
+    await writeFixture(rootDirectory, unit.drizzleConfigPath, 'export default {}');
+  }
+  await writeFixture(
+    rootDirectory,
+    'libs/api/alpha/drizzle/0000_legacy.sql',
+    [
+      'CREATE TABLE "alpha_owned" ("id" text PRIMARY KEY);',
+      'CREATE TABLE "legacy_table" ("id" text PRIMARY KEY);',
+      'ALTER TABLE "beta_owned" ADD COLUMN "foreign_column" text;',
+      'DROP TABLE "beta_owned";',
+    ].join('\n'),
+  );
+  await writeFixture(
+    rootDirectory,
+    'libs/api/beta/drizzle/0000_owned.sql',
+    'CREATE TABLE "beta_owned" ("id" text PRIMARY KEY);\n',
+  );
+  await writeFixture(
+    rootDirectory,
+    'libs/api/beta/src/db/schema/common.ts',
+    [
+      "import {pgTableCreator} from 'drizzle-orm/pg-core';",
+      `export const pgTable = pgTableCreator((name) => name === 'root' ? name : \`beta_\${name}\`);`,
+    ].join('\n'),
+  );
+  await writeFixture(
+    rootDirectory,
+    'libs/api/beta/src/accepted-root.ts',
+    [
+      "import {pgTable} from './db/schema/common.js';",
+      "export const rootTable = pgTable('root', {});",
+    ].join('\n'),
+  );
+  await writeFixture(
+    rootDirectory,
+    'libs/api/integrations/core/drizzle/0000_core.sql',
+    'CREATE TABLE "integrations_core_owned" ("id" text PRIMARY KEY);\n',
+  );
+  await writeFixture(
+    rootDirectory,
+    'libs/api/integrations/provider/drizzle/0000_provider.sql',
+    'CREATE TABLE "integrations_provider_owned" ("id" text PRIMARY KEY);\n',
+  );
+  await writeFixture(
+    rootDirectory,
+    'libs/api/alpha/src/db/schema/common.ts',
+    [
+      "import {pgTableCreator} from 'drizzle-orm/pg-core';",
+      `export const pgTable = pgTableCreator((name) => \`alpha_\${name}\`);`,
+    ].join('\n'),
+  );
+  await writeFixture(
+    rootDirectory,
+    'libs/api/alpha/src/db/schema/local.ts',
+    [
+      "import {pgTable} from './common.js';",
+      "export const localTable = pgTable('local', {});",
+    ].join('\n'),
+  );
+  await writeFixture(
+    rootDirectory,
+    'libs/api/alpha/src/violations.ts',
+    [
+      "import {pgEnum, pgTable, pgTableCreator, text} from 'drizzle-orm/pg-core';",
+      "import {ownedTable} from '@fixture/beta';",
+      "import {betaModule} from '@fixture/beta';",
+      "import {sql} from 'drizzle-orm';",
+      "export const unprefixedKind = pgEnum('kind', ['one']);",
+      "export const foreignTable = pgTable('beta_owned', {});",
+      "export const localTable = pgTable('alpha_declared', {});",
+      `const foreignTableCreator = pgTableCreator((name) => \`beta_\${name}\`);`,
+      "export const copiedTable = foreignTableCreator('copied');",
+      "export const crossOwnerReference = pgTable('alpha_reference', {",
+      "  foreignId: text('foreign_id').references(() => ownedTable.id),",
+      '});',
+      'betaModule.database;',
+      'const tableName = betaModule.name;',
+      'const selected = sql`SELECT * FROM beta_owned JOIN beta_owned ON true`;',
+      'const truncated = sql`TRUNCATE beta_owned`;',
+      'const locked = sql`LOCK TABLE beta_owned`;',
+      `const dynamic = sql\`SELECT * FROM \${tableName}\`;`,
+      'void [selected, truncated, locked, dynamic];',
+    ].join('\n'),
+  );
+  await writeFixture(
+    rootDirectory,
+    'libs/api/integrations/provider/src/db/schema/common.ts',
+    [
+      "import {pgTableCreator} from 'drizzle-orm/pg-core';",
+      `export const pgTable = pgTableCreator((name) => \`integrations_provider_\${name}\`);`,
+    ].join('\n'),
+  );
+  await writeFixture(
+    rootDirectory,
+    'libs/api/integrations/provider/src/accepted.ts',
+    [
+      "import {pgTable} from './db/schema/common.js';",
+      "import {sql} from 'drizzle-orm';",
+      "export const providerTable = pgTable('local', {});",
+      'export const sharedQuery = sql`SELECT * FROM integrations_core_owned`;',
+      'export const registeredQuery = sql`SELECT * FROM $' + '{providerTable}`;',
+    ].join('\n'),
+  );
+  await writeFixture(
+    rootDirectory,
+    'libs/api/alpha/drizzle/meta/0000_snapshot.json',
+    '{malformed snapshot',
+  );
+  await writeFixture(
+    rootDirectory,
+    'libs/shared/node/drizzle/src/registered-runner.ts',
+    [
+      "import {runMigrations} from '@fixture/migration-runner';",
+      "runMigrations('alpha', '__drizzle_migrations_alpha');",
+    ].join('\n'),
+  );
+  await writeFixture(
+    rootDirectory,
+    'libs/api/alpha/extra/drizzle.config.ts',
+    'export default {};\n',
+  );
+}
+function rulesByName(findings: readonly DatabaseBoundaryFinding[]): Set<string> {
+  return new Set(findings.map((finding) => finding.rule));
+}
+describe('database boundary verifier fixtures', () => {
+  test('rejects the required ownership and naming violations while accepting registered boundaries', async () => {
+    const rootDirectory = await mkdtemp(join(tmpdir(), 'shipfox-api-database-fixtures-'));
+    try {
+      await createFixtureRepository(rootDirectory);
+      const findings = await auditApiDatabaseBoundaries({
+        registry: fixtureRegistry,
+        rootDirectory,
+      });
+      const rules = rulesByName(findings);
+      for (const rule of [
+        'direct-table-declaration',
+        'dynamic-sql-identifier',
+        'foreign-database-access',
+        'foreign-key',
+        'foreign-migration',
+        'foreign-raw-sql',
+        'foreign-table-declaration',
+        'unprefixed-enum',
+        'unprefixed-table',
+        'unregistered-migration-unit',
+      ]) {
+        assert.ok(rules.has(rule), `fixture did not produce ${rule}`);
+      }
+      assert.ok(
+        findings.some(
+          (finding) =>
+            finding.file === 'libs/api/alpha/src/violations.ts' &&
+            finding.object === 'ownedTable.references' &&
+            finding.rule === 'foreign-key',
+        ),
+      );
+      assert.doesNotMatch(
+        findings
+          .filter((finding) => finding.file.includes('/accepted.ts'))
+          .map((finding) => finding.rule)
+          .join(','),
+        nonEmptyOutputPattern,
+      );
+      assert.doesNotMatch(
+        findings
+          .filter((finding) => finding.file === 'libs/api/beta/src/accepted-root.ts')
+          .map((finding) => finding.rule)
+          .join(','),
+        nonEmptyOutputPattern,
+      );
+      assert.doesNotMatch(
+        findings
+          .filter((finding) => finding.file.includes('registered-runner.ts'))
+          .map((finding) => finding.rule)
+          .join(','),
+        nonEmptyOutputPattern,
+      );
+    } finally {
+      await rm(rootDirectory, {force: true, recursive: true});
+    }
+  });
+});

--- a/tools/api-database-policy/turbo.json
+++ b/tools/api-database-policy/turbo.json
@@ -10,8 +10,26 @@
         "$TURBO_ROOT$/libs/api/**/package.json",
         "$TURBO_ROOT$/libs/api/**/drizzle.config.ts",
         "$TURBO_ROOT$/libs/api/**/drizzle/**",
-        "$TURBO_ROOT$/libs/shared/node/**/package.json"
+        "$TURBO_ROOT$/libs/api/**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}",
+        "$TURBO_ROOT$/libs/shared/node/**/package.json",
+        "$TURBO_ROOT$/libs/shared/node/**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}",
+        "$TURBO_ROOT$/apps/api/**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}"
       ]
+    },
+    "verify:boundaries": {
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/api-contexts.cjs",
+        "$TURBO_ROOT$/api-databases.cjs",
+        "$TURBO_ROOT$/libs/api/**/package.json",
+        "$TURBO_ROOT$/libs/api/**/drizzle.config.ts",
+        "$TURBO_ROOT$/libs/api/**/drizzle/**",
+        "$TURBO_ROOT$/libs/api/**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}",
+        "$TURBO_ROOT$/libs/shared/node/**/package.json",
+        "$TURBO_ROOT$/libs/shared/node/**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}",
+        "$TURBO_ROOT$/apps/api/**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}"
+      ],
+      "dependsOn": ["build"]
     }
   }
 }

--- a/tools/biome/README.md
+++ b/tools/biome/README.md
@@ -1,6 +1,6 @@
 # @shipfox/biome
 
-Biome commands, bundled binaries, and client-architecture plugins for Shipfox packages.
+Biome commands, bundled binaries, and architecture plugins for Shipfox packages.
 
 ## What it does
 
@@ -9,6 +9,7 @@ Biome commands, bundled binaries, and client-architecture plugins for Shipfox pa
 - **`shipfox-biome-check`**: Runs format, lint, and assist checks. Most package `check` scripts use it.
 - **Bundled binaries**: Includes Biome for macOS and Linux on ARM64 and x64.
 - **Client-architecture plugins**: Publishes five GritQL rules for external repositories. See the [plugin guide](plugins/client-architecture/README.md).
+- **Database-boundaries plugin**: Publishes a GritQL rule that rejects direct Drizzle table-factory imports. See the [plugin guide](plugins/database-boundaries/README.md).
 
 ## Installation
 
@@ -72,6 +73,15 @@ The package publishes these semver-governed asset paths:
 - `plugins/client-architecture/no-query-cache-ownership.grit`
 - `plugins/client-architecture/no-raw-api-request.grit`
 - `plugins/client-architecture/no-response-dto-in-presentation.grit`
+
+## Database-boundaries plugin
+
+- `plugins/database-boundaries/no-direct-table-declaration.grit`
+
+The database-boundaries rule rejects direct `pgTable` and `pgTableCreator`
+imports from `drizzle-orm/pg-core`. Configure it over database source paths and
+exclude the registered owner schema factory. See the [database-boundaries
+plugin guide](plugins/database-boundaries/README.md).
 
 Consumers reference the installed files from `biome.json`. Do not copy the
 GritQL source into the consumer repository. The [plugin guide](plugins/client-architecture/README.md)

--- a/tools/biome/package.json
+++ b/tools/biome/package.json
@@ -18,7 +18,9 @@
     "plugins/client-architecture/no-client-framework-in-core.grit",
     "plugins/client-architecture/no-query-cache-ownership.grit",
     "plugins/client-architecture/no-raw-api-request.grit",
-    "plugins/client-architecture/no-response-dto-in-presentation.grit"
+    "plugins/client-architecture/no-response-dto-in-presentation.grit",
+    "plugins/database-boundaries/README.md",
+    "plugins/database-boundaries/no-direct-table-declaration.grit"
   ],
   "exports": {
     "./package.json": "./package.json",
@@ -26,7 +28,8 @@
     "./plugins/client-architecture/no-client-framework-in-core.grit": "./plugins/client-architecture/no-client-framework-in-core.grit",
     "./plugins/client-architecture/no-query-cache-ownership.grit": "./plugins/client-architecture/no-query-cache-ownership.grit",
     "./plugins/client-architecture/no-raw-api-request.grit": "./plugins/client-architecture/no-raw-api-request.grit",
-    "./plugins/client-architecture/no-response-dto-in-presentation.grit": "./plugins/client-architecture/no-response-dto-in-presentation.grit"
+    "./plugins/client-architecture/no-response-dto-in-presentation.grit": "./plugins/client-architecture/no-response-dto-in-presentation.grit",
+    "./plugins/database-boundaries/no-direct-table-declaration.grit": "./plugins/database-boundaries/no-direct-table-declaration.grit"
   },
   "imports": {
     "#*": "./src/*"

--- a/tools/biome/plugins/database-boundaries/README.md
+++ b/tools/biome/plugins/database-boundaries/README.md
@@ -1,0 +1,26 @@
+# Database-boundaries Biome plugin
+
+This directory contains the published GritQL guardrail for database schema
+ownership. `no-direct-table-declaration.grit` rejects imports of `pgTable` or
+`pgTableCreator` directly from `drizzle-orm/pg-core`; database packages should
+import the owner-registered factory from their local schema boundary instead.
+
+The rule is intentionally generic. Configure its `includes` for database
+source and exclude the one registered factory file, for example:
+
+```json
+{
+  "plugins": [
+    {
+      "path": "./node_modules/@shipfox/biome/plugins/database-boundaries/no-direct-table-declaration.grit",
+      "includes": [
+        "**/libs/api/**/src/db/**",
+        "!**/libs/api/**/src/db/schema/common.ts"
+      ]
+    }
+  ]
+}
+```
+
+The diagnostic ID is `database-boundaries/no-direct-table-declaration` and is
+part of the published package contract.

--- a/tools/biome/plugins/database-boundaries/fixtures/biome.fixture.json
+++ b/tools/biome/plugins/database-boundaries/fixtures/biome.fixture.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+  "vcs": {
+    "enabled": false
+  },
+  "assist": {
+    "enabled": true
+  },
+  "formatter": {
+    "enabled": true,
+    "useEditorconfig": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineEnding": "lf",
+    "lineWidth": 100
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "bracketSpacing": false,
+      "trailingCommas": "all",
+      "semicolons": "always",
+      "arrowParentheses": "always"
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "plugins": [
+    {
+      "path": "../no-direct-table-declaration.grit",
+      "includes": ["**/no-direct-table-declaration/**"]
+    }
+  ]
+}

--- a/tools/biome/plugins/database-boundaries/fixtures/no-direct-table-declaration/allowed.ts
+++ b/tools/biome/plugins/database-boundaries/fixtures/no-direct-table-declaration/allowed.ts
@@ -1,0 +1,3 @@
+import {pgTable} from './common.js';
+
+export const allowedTable = pgTable('allowed_table');

--- a/tools/biome/plugins/database-boundaries/fixtures/no-direct-table-declaration/namespace-rejected.ts
+++ b/tools/biome/plugins/database-boundaries/fixtures/no-direct-table-declaration/namespace-rejected.ts
@@ -1,0 +1,2 @@
+import * as pgCore from 'drizzle-orm/pg-core';
+export const namespaced = pgCore.pgTable('namespaced', {});

--- a/tools/biome/plugins/database-boundaries/fixtures/no-direct-table-declaration/rejected.ts
+++ b/tools/biome/plugins/database-boundaries/fixtures/no-direct-table-declaration/rejected.ts
@@ -1,0 +1,6 @@
+// The owner schema factory must be used here.
+
+import {pgTable, pgTableCreator} from 'drizzle-orm/pg-core';
+
+export const rejectedTable = pgTable('rejected_table');
+export const rejectedFactory = pgTableCreator((name) => `owner_${name}`);

--- a/tools/biome/plugins/database-boundaries/no-direct-table-declaration.grit
+++ b/tools/biome/plugins/database-boundaries/no-direct-table-declaration.grit
@@ -1,0 +1,24 @@
+engine biome(1.0)
+language js(typescript, jsx)
+or {
+  JsImport() as $import where {
+    $import <: r".*drizzle-orm/pg-core.*",
+    $import <: r".*pgTable.*",
+    register_diagnostic(
+      span=$import,
+      message="database-boundaries/no-direct-table-declaration: declare database objects through the registered owner schema factory."
+    )
+  },
+  `$pgCore.pgTable($...)` as $match where {
+    register_diagnostic(
+      span=$match,
+      message="database-boundaries/no-direct-table-declaration: declare database objects through the registered owner schema factory."
+    )
+  },
+  `$pgCore.pgTableCreator($...)` as $match where {
+    register_diagnostic(
+      span=$match,
+      message="database-boundaries/no-direct-table-declaration: declare database objects through the registered owner schema factory."
+    )
+  }
+}

--- a/tools/biome/test/client-architecture-external.test.ts
+++ b/tools/biome/test/client-architecture-external.test.ts
@@ -22,6 +22,7 @@ const publishedPluginFiles = [
   'plugins/client-architecture/no-query-cache-ownership.grit',
   'plugins/client-architecture/no-raw-api-request.grit',
   'plugins/client-architecture/no-response-dto-in-presentation.grit',
+  'plugins/database-boundaries/no-direct-table-declaration.grit',
 ] as const;
 const externalRuleFixtures = [
   {
@@ -121,6 +122,7 @@ describe('packed client-architecture Biome plugins', () => {
         assert.ok(entries.includes(`package/${path}`), `Packed artifact is missing ${path}`);
       }
       assert.ok(entries.includes('package/plugins/client-architecture/README.md'));
+      assert.ok(entries.includes('package/plugins/database-boundaries/README.md'));
       assert.ok(
         !entries.some((entry) => entry.startsWith('package/plugins/client-architecture/fixtures/')),
         'Packed artifact must not publish repository fixtures',

--- a/tools/biome/test/database-boundaries-plugins.test.ts
+++ b/tools/biome/test/database-boundaries-plugins.test.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import {execFile} from 'node:child_process';
+import {dirname, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {promisify} from 'node:util';
+const execFileAsync = promisify(execFile);
+const packageDirectory = dirname(fileURLToPath(import.meta.url));
+const workspaceRoot = resolve(packageDirectory, '../../..');
+const diagnosticPattern = /database-boundaries\/no-direct-table-declaration/u;
+const rejectedLocationPattern = /rejected\.ts:3/u;
+const namespaceRejectedLocationPattern = /namespace-rejected\.ts:2/u;
+const fixtureRulePattern = /database-boundaries\//u;
+const biomeCheck = resolve(workspaceRoot, 'tools/biome/bin/biome-check.js');
+const fixtureConfig = resolve(
+  workspaceRoot,
+  'tools/biome/plugins/database-boundaries/fixtures/biome.fixture.json',
+);
+const fixtureRoot = resolve(workspaceRoot, 'tools/biome/plugins/database-boundaries/fixtures');
+
+describe('database-boundaries Biome plugin', () => {
+  test('rejects direct Drizzle table factories through the package check wrapper', async () => {
+    await assert.rejects(
+      execFileAsync(
+        process.execPath,
+        [
+          biomeCheck,
+          '--config-path',
+          fixtureConfig,
+          resolve(fixtureRoot, 'no-direct-table-declaration'),
+        ],
+        {cwd: workspaceRoot},
+      ),
+      (error: unknown) => {
+        const commandError = error as {stdout?: string; stderr?: string};
+        const output = `${commandError.stdout ?? ''}${commandError.stderr ?? ''}`;
+        assert.match(output, diagnosticPattern);
+        assert.match(output, rejectedLocationPattern);
+        assert.match(output, namespaceRejectedLocationPattern);
+        return true;
+      },
+    );
+  });
+  test('allows a table factory imported from the local schema boundary', async () => {
+    const {stdout, stderr} = await execFileAsync(
+      process.execPath,
+      [
+        biomeCheck,
+        '--config-path',
+        fixtureConfig,
+        resolve(fixtureRoot, 'no-direct-table-declaration', 'allowed.ts'),
+      ],
+      {cwd: workspaceRoot},
+    );
+    assert.doesNotMatch(`${stdout}${stderr}`, fixtureRulePattern);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a registry-backed static verifier for API database ownership and naming boundaries, with exact baseline reconciliation for existing findings.

Publishes the Biome GritQL guardrail for direct Drizzle table-factory imports and adds focused verifier and package-consumer fixtures.

Validation: `turbo check type test verify --filter=@shipfox/api-database-policy` and `turbo check type test --filter=@shipfox/biome`.

Closes ENG-1192

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a static, registry-backed verifier and a Biome guardrail to enforce database ownership and naming boundaries across API code, migrations, and snapshots. Blocks cross-owner access, direct Drizzle table factories, dynamic identifiers, and enforces correct prefixes. Satisfies ENG-1192.

- **New Features**
  - `@shipfox/api-database-policy`: New verifier scans source, migrations, and snapshots for:
    - direct table declarations, foreign object use, foreign keys, foreign database access
    - dynamic SQL identifiers, migration-history instability, unregistered migration units
  - Exact baseline reconciliation for existing findings; fails closed on new or missing items.
  - Repo script: `pnpm run check:api-database-boundaries` (Turbo `verify:boundaries` target added).
  - `@shipfox/biome`: Publishes `database-boundaries/no-direct-table-declaration` to forbid direct `pgTable`/`pgTableCreator` imports from `drizzle-orm/pg-core`; docs, fixtures, and tests included.
  - Expanded Turbo globs to include API, shared node, and `apps/api` TS/JS files; minor release for `@shipfox/biome`.

- **Migration**
  - Use your owner schema factory (e.g., `src/db/schema/common.ts`) instead of importing from `drizzle-orm/pg-core`.
  - Ensure object names are factory-prefixed to your namespace (e.g., `owner_<name>`); avoid dynamic identifiers in SQL and migrations.
  - Register all migration units in `api-databases.cjs`; run `pnpm run check:api-database-boundaries` locally/CI.

<sup>Written for commit 045384be25f2eb5ed6cb0a961734f2756992a241. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

