### PR TITLE
[storybook] Stabilize preview smoke navigation

### DIFF
--- a/apps/storybook/test/smoke/preview.e2e.ts
+++ b/apps/storybook/test/smoke/preview.e2e.ts
@@ -83,16 +83,20 @@ test.describe('assembled Storybook preview', () => {
   test('serves standalone child URLs and refreshes deep links', async ({page, request}) => {
     const errors = collectBrowserErrors(page);
 
-    for (const storybook of storybooks) {
-      const storyId = await getRepresentativeStoryId(request, storybook.path);
+    const storyIds = await Promise.all(
+      storybooks.map(async (storybook) => getRepresentativeStoryId(request, storybook.path)),
+    );
 
-      const standaloneResponse = await page.goto(storybook.path);
-      expect(standaloneResponse?.ok()).toBe(true);
+    for (const [index, storybook] of storybooks.entries()) {
+      const standaloneResponse = await request.get(storybook.path);
+      expect(standaloneResponse.ok()).toBe(true);
+      expect(await standaloneResponse.text()).toContain('id="root"');
+
+      const deepLink = `${storybook.path}?path=/story/${storyIds[index]}`;
+      const deepLinkResponse = await page.goto(deepLink, {waitUntil: 'domcontentloaded'});
+      expect(deepLinkResponse?.ok()).toBe(true);
       await expect(page.locator('#root')).toBeVisible();
-
-      const deepLink = `${storybook.path}?path=/story/${storyId}`;
-      await page.goto(deepLink);
-      await page.reload();
+      await page.reload({waitUntil: 'domcontentloaded'});
       await expect(page.locator('#root')).toBeVisible();
     }
 


### PR DESCRIPTION
## Summary

The assembled Storybook deep-link smoke test performs enough serial browser work to exhaust its 60-second timeout on contended CI runners. The resulting closed request-context error masks the actual timeout.

This change uses lightweight HTTP assertions for standalone child pages and keeps browser coverage focused on deep-link boot and refresh behavior across every child Storybook. Representative story indexes are loaded concurrently, preserving coverage without increasing the timeout or adding retries.

Observed in the E2E job for #995: https://github.com/ShipfoxHQ/shipfox/actions/runs/29998970327/job/89179543986

## Validation

- mise exec -- turbo check type build --filter=@shipfox/storybook... --concurrency=4
- CI=1 mise exec -- pnpm run test:e2e from apps/storybook
- Focused smoke test passed five sequential runs before commit

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the Storybook preview smoke test to avoid CI timeouts and flakiness. Shifts standalone checks to lightweight HTTP assertions and keeps browser work focused on deep-link load and refresh.

- **Bug Fixes**
  - Fetch representative story IDs concurrently.
  - Validate standalone child URLs via `request.get` and check for `id="root"`.
  - Navigate deep links with `domcontentloaded` waits and verify `#root` before and after reload.

<sup>Written for commit 9fceb35d3b9790e05e621859695522b20beeb82d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

