### PR TITLE
[api-architecture-policy] Stabilize Dependency Cruiser tests

### DIFF
--- a/fixtures/depcruise-api-edges/config.cjs
+++ b/fixtures/depcruise-api-edges/config.cjs
@@ -1,33 +1,3 @@
-const {apiArchitectureEdgePolicy, createApiArchitectureRules} = require('../../api-contexts.cjs');
+const {createFixtureConfiguration} = require('./fixture-config.cjs');
 
-const architecturePackages = {
-  implementations: {
-    agent: ['packages/consumers/implementation-foreign'],
-    integrations: [
-      'packages/api/integration/core',
-      'packages/api/integration/provider-with-an-unrelated-name',
-      'packages/consumers/implementation-allowed',
-    ],
-  },
-  dto: {agent: ['packages/consumers/dto-foreign']},
-  'shared-semantic': {common: ['packages/consumers/semantic-foreign']},
-  'shared-infrastructure': {common: []},
-  spi: {
-    integrations: ['packages/api/integration/spi', 'packages/consumers/spi-allowed'],
-    auth: ['packages/consumers/spi-foreign'],
-  },
-  'composition-root': {api: []},
-};
-
-module.exports = {
-  forbidden: createApiArchitectureRules({
-    currentDirectory: process.env.DEPCRUISE_FIXTURE_PACKAGE || process.cwd(),
-    workspaceRoot: __dirname,
-    packages: architecturePackages,
-    edgePolicy: apiArchitectureEdgePolicy,
-  }),
-  options: {
-    doNotFollow: {path: 'node_modules'},
-    tsPreCompilationDeps: 'specify',
-  },
-};
+module.exports = createFixtureConfiguration(process.env.DEPCRUISE_FIXTURE_PACKAGE || process.cwd());

--- a/fixtures/depcruise-api-edges/fixture-config.cjs
+++ b/fixtures/depcruise-api-edges/fixture-config.cjs
@@ -1,0 +1,37 @@
+const {apiArchitectureEdgePolicy, createApiArchitectureRules} = require('../../api-contexts.cjs');
+
+const architecturePackages = {
+  implementations: {
+    agent: ['packages/consumers/implementation-foreign'],
+    integrations: [
+      'packages/api/integration/core',
+      'packages/api/integration/provider-with-an-unrelated-name',
+      'packages/consumers/implementation-allowed',
+    ],
+  },
+  dto: {agent: ['packages/consumers/dto-foreign']},
+  'shared-semantic': {common: ['packages/consumers/semantic-foreign']},
+  'shared-infrastructure': {common: []},
+  spi: {
+    integrations: ['packages/api/integration/spi', 'packages/consumers/spi-allowed'],
+    auth: ['packages/consumers/spi-foreign'],
+  },
+  'composition-root': {api: []},
+};
+
+function createFixtureConfiguration(currentDirectory) {
+  return {
+    forbidden: createApiArchitectureRules({
+      currentDirectory,
+      workspaceRoot: __dirname,
+      packages: architecturePackages,
+      edgePolicy: apiArchitectureEdgePolicy,
+    }),
+    options: {
+      doNotFollow: {path: 'node_modules'},
+      tsPreCompilationDeps: 'specify',
+    },
+  };
+}
+
+module.exports = {createFixtureConfiguration};

--- a/tools/api-architecture-policy/test/api-architecture-edge-policy.test.ts
+++ b/tools/api-architecture-policy/test/api-architecture-edge-policy.test.ts
@@ -1,18 +1,34 @@
 import assert from 'node:assert/strict';
-import {execFile} from 'node:child_process';
 import {createRequire} from 'node:module';
 import {dirname, resolve} from 'node:path';
-import {fileURLToPath} from 'node:url';
-import {promisify} from 'node:util';
+import {fileURLToPath, pathToFileURL} from 'node:url';
 
-const execFileAsync = promisify(execFile);
 const require = createRequire(import.meta.url);
 const packageDirectory = dirname(fileURLToPath(import.meta.url));
 const workspaceRoot = resolve(packageDirectory, '../../..');
 const fixtureRoot = resolve(workspaceRoot, 'fixtures/depcruise-api-edges');
-const fixtureConfig = resolve(fixtureRoot, 'config.cjs');
-const dependencyCruiser = resolve(workspaceRoot, 'tools/depcruise/node_modules/.bin/depcruise');
+const dependencyCruiserDirectory = resolve(
+  workspaceRoot,
+  'tools/depcruise/node_modules/dependency-cruiser',
+);
+const {main: dependencyCruiserMain} = require(
+  resolve(dependencyCruiserDirectory, 'package.json'),
+) as {main: string};
+const dependencyCruiserModule = import(
+  pathToFileURL(resolve(dependencyCruiserDirectory, dependencyCruiserMain)).href
+) as Promise<{
+  cruise: (
+    files: string[],
+    options: Record<string, unknown>,
+  ) => Promise<{output: string | Record<string, unknown>}>;
+}>;
 const noDependencyViolationsPattern = /no dependency violations found/u;
+const {createFixtureConfiguration} = require(resolve(fixtureRoot, 'fixture-config.cjs')) as {
+  createFixtureConfiguration: (currentDirectory: string) => {
+    forbidden: Array<Record<string, unknown>>;
+    options: Record<string, unknown>;
+  };
+};
 const {
   apiArchitectureEdgePolicy,
   architecturePackages,
@@ -33,16 +49,18 @@ const {
 
 async function runFixture(fixtureName: string): Promise<string> {
   const fixturePackage = resolve(fixtureRoot, 'packages/consumers', fixtureName);
-  try {
-    const result = await execFileAsync(dependencyCruiser, ['--config', fixtureConfig, '.'], {
-      cwd: fixturePackage,
-      env: {...process.env, DEPCRUISE_FIXTURE_PACKAGE: fixturePackage},
-    });
-    return `${result.stdout}${result.stderr}`;
-  } catch (error) {
-    const commandError = error as {stdout?: string; stderr?: string};
-    return `${commandError.stdout ?? ''}${commandError.stderr ?? ''}`;
-  }
+  const {options, ...ruleSet} = createFixtureConfiguration(fixturePackage);
+  const {cruise} = await dependencyCruiserModule;
+  const {output} = await cruise(['.'], {
+    ...options,
+    baseDir: fixturePackage,
+    outputType: 'err',
+    ruleSet,
+    validate: true,
+  });
+
+  assert.ok(typeof output === 'string');
+  return output;
 }
 
 describe('API Dependency Cruiser edge policy', () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stabilizes API architecture policy tests by calling the `dependency-cruiser` API directly and using a shared fixture config. This removes CLI flakiness and makes results consistent across environments.

- **Refactors**
  - Replaced CLI exec with programmatic `cruise` import from `dependency-cruiser`.
  - Extracted `fixture-config.cjs` with `createFixtureConfiguration`; simplified `config.cjs`.
  - Tests pass `baseDir`, `ruleSet`, and `options` directly (`outputType: 'err'`, `validate: true`) to avoid env/cwd issues.

<sup>Written for commit 20fe52e9a1ab26b235167a6738e01c33ef24f166. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

