### PR TITLE
Retire duplicated API import scanning

### DIFF
--- a/.changeset/curious-boundaries-scan.md
+++ b/.changeset/curious-boundaries-scan.md
@@ -1,0 +1,10 @@
+---
+"@shipfox/api-secrets-dto": patch
+"@shipfox/redact": patch
+"@shipfox/regex": patch
+"@shipfox/runner-labels": patch
+"@shipfox/expression": patch
+"@shipfox/workflow-document": patch
+---
+
+Adds Dependency Cruiser checks to all classified API packages so source-edge enforcement remains active after retiring the duplicate import scan.

--- a/api-contexts.cjs
+++ b/api-contexts.cjs
@@ -107,8 +107,8 @@ const apiArchitectureEdgePolicy = {
       rule: 'api-no-dto-implementation-imports',
       violation: 'DTO implementation import',
     },
-    // dto->dto is enforced separately: sourceEdgeViolation blocks specifiers ending in
-    // '/inter-module' regardless of this decision. Changing this value has no effect.
+    // Local DTO-to-DTO /inter-module imports are owned by the Biome plugin. This
+    // decision remains allow because the verifier only evaluates manifest edges.
     dto: {decision: 'allow'},
     'shared-semantic': {decision: 'allow'},
     'shared-infrastructure': {decision: 'allow'},

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -128,14 +128,20 @@ fixtures, cross-repository policy, and local verification.
 
 These checks enforce the rules:
 
-- The root [API architecture Biome plugins](../../tools/biome/plugins/api-architecture/README.md)
-  report local DTO import and export violations at the source expression.
-- `pnpm check:api-context-inventory` checks package classification, stale
-  registry entries, manifest edges, explicit export maps, and imports that
-  depend on context or same-context SPI ownership from `api-contexts.cjs`.
-- `.dependency-cruiser.cjs` checks resolved dependency boundaries.
-- `pnpm check:dependencies` checks dependency policy and manifest hygiene.
-- `pnpm check:published-artifacts` checks packed public entry points.
+| Owner | Enforced policy |
+| --- | --- |
+| Biome | Local import and export syntax, including DTO root and `/inter-module` source shape. |
+| Dependency Cruiser | Resolved source dependency graph, including context-aware API package edges. |
+| API architecture policy | Package inventory, classifications, declared manifest edges, and intended public-contract subpaths. |
+| Package release verification | Packed public entry-point correctness and external-consumer closure. |
+
+The root [API architecture Biome plugins](../../tools/biome/plugins/api-architecture/README.md)
+report local DTO import and export violations at the source expression.
+`pnpm check:api-context-inventory` checks package classification, stale registry
+entries, manifest edges, and structural `/inter-module` export parity. It does
+not parse source imports; use Dependency Cruiser for resolved source edges.
+`pnpm check:dependencies` checks dependency policy and manifest hygiene.
+`pnpm check:published-artifacts` checks packed public entry points.
 
 When adding a bounded context, classify its implementation and DTO packages in
 [`api-contexts.cjs`](../../api-contexts.cjs) before adding its dependencies.

--- a/libs/api/secrets-dto/package.json
+++ b/libs/api/secrets-dto/package.json
@@ -44,6 +44,7 @@
     "build": "shipfox-swc",
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
+    "depcruise": "shipfox-depcruise",
     "test": "shipfox-vitest-run",
     "test:watch": "shipfox-vitest-watch",
     "type": "shipfox-tsc-check",
@@ -55,6 +56,7 @@
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",
+    "@shipfox/depcruise": "workspace:*",
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",

--- a/libs/shared/common/redact/package.json
+++ b/libs/shared/common/redact/package.json
@@ -42,12 +42,14 @@
     "build": "shipfox-swc",
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
+    "depcruise": "shipfox-depcruise",
     "test": "shipfox-vitest-run",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",
+    "@shipfox/depcruise": "workspace:*",
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",

--- a/libs/shared/common/regex/package.json
+++ b/libs/shared/common/regex/package.json
@@ -36,6 +36,7 @@
     "build": "shipfox-swc",
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
+    "depcruise": "shipfox-depcruise",
     "test": "shipfox-vitest-run",
     "test:watch": "shipfox-vitest-watch",
     "type": "shipfox-tsc-check",
@@ -43,6 +44,7 @@
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",
+    "@shipfox/depcruise": "workspace:*",
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",

--- a/libs/shared/common/runner-labels/package.json
+++ b/libs/shared/common/runner-labels/package.json
@@ -33,12 +33,14 @@
     "build": "shipfox-swc",
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
+    "depcruise": "shipfox-depcruise",
     "test": "shipfox-vitest-run",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",
+    "@shipfox/depcruise": "workspace:*",
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",

--- a/libs/shared/expression/package.json
+++ b/libs/shared/expression/package.json
@@ -30,6 +30,7 @@
     "build": "shipfox-swc",
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
+    "depcruise": "shipfox-depcruise",
     "test": "shipfox-vitest-run",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"
@@ -41,6 +42,7 @@
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",
+    "@shipfox/depcruise": "workspace:*",
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",

--- a/libs/shared/workflow/document/package.json
+++ b/libs/shared/workflow/document/package.json
@@ -37,6 +37,7 @@
     "build": "shipfox-swc",
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
+    "depcruise": "shipfox-depcruise",
     "test": "shipfox-vitest-run",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"
@@ -46,6 +47,7 @@
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",
+    "@shipfox/depcruise": "workspace:*",
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3984,6 +3984,9 @@ importers:
       '@shipfox/biome':
         specifier: workspace:*
         version: link:../../../tools/biome
+      '@shipfox/depcruise':
+        specifier: workspace:*
+        version: link:../../../tools/depcruise
       '@shipfox/swc':
         specifier: workspace:*
         version: link:../../../tools/swc
@@ -6681,6 +6684,9 @@ importers:
       '@shipfox/biome':
         specifier: workspace:*
         version: link:../../../../tools/biome
+      '@shipfox/depcruise':
+        specifier: workspace:*
+        version: link:../../../../tools/depcruise
       '@shipfox/swc':
         specifier: workspace:*
         version: link:../../../../tools/swc
@@ -6699,6 +6705,9 @@ importers:
       '@shipfox/biome':
         specifier: workspace:*
         version: link:../../../../tools/biome
+      '@shipfox/depcruise':
+        specifier: workspace:*
+        version: link:../../../../tools/depcruise
       '@shipfox/swc':
         specifier: workspace:*
         version: link:../../../../tools/swc
@@ -6717,6 +6726,9 @@ importers:
       '@shipfox/biome':
         specifier: workspace:*
         version: link:../../../../tools/biome
+      '@shipfox/depcruise':
+        specifier: workspace:*
+        version: link:../../../../tools/depcruise
       '@shipfox/swc':
         specifier: workspace:*
         version: link:../../../../tools/swc
@@ -6745,6 +6757,9 @@ importers:
       '@shipfox/biome':
         specifier: workspace:*
         version: link:../../../tools/biome
+      '@shipfox/depcruise':
+        specifier: workspace:*
+        version: link:../../../tools/depcruise
       '@shipfox/swc':
         specifier: workspace:*
         version: link:../../../tools/swc
@@ -7552,6 +7567,9 @@ importers:
       '@shipfox/biome':
         specifier: workspace:*
         version: link:../../../../tools/biome
+      '@shipfox/depcruise':
+        specifier: workspace:*
+        version: link:../../../../tools/depcruise
       '@shipfox/swc':
         specifier: workspace:*
         version: link:../../../../tools/swc

--- a/tools/api-architecture-policy/src/api-context-inventory.ts
+++ b/tools/api-architecture-policy/src/api-context-inventory.ts
@@ -1,4 +1,4 @@
-import {readdir, readFile} from 'node:fs/promises';
+import {access, readdir, readFile} from 'node:fs/promises';
 import {createRequire} from 'node:module';
 import path from 'node:path';
 import process from 'node:process';
@@ -32,11 +32,7 @@ const dependencyGroups = [
   'optionalDependencies',
   'peerDependencies',
 ] as const;
-const importExpression =
-  /(?:import|export)\s+(?:type\s+)?(?:[^'"`]*?\s+from\s+)?['"]([^'"]+)['"]|import\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
-const sourceFileExpression = /\.(?:[cm]?[jt]sx?)$/;
-const dtoImplementationDetailExpression =
-  /(?:^|\/)(?:core|db|presentation|provider|test|tests|fixtures)(?:\/|\.|$)/;
+const importViolationSuffixExpression = / import$/;
 
 interface ClassifiedPath {
   classification: string;
@@ -57,10 +53,6 @@ function compareText(left: string, right: string): number {
   if (left < right) return -1;
   if (left > right) return 1;
   return 0;
-}
-
-function toPosixPath(value: string): string {
-  return value.split(path.sep).join('/');
 }
 
 function classifiedPaths(): ClassifiedPath[] {
@@ -89,17 +81,9 @@ function packagesByName(manifests: Map<string, PackageManifest>): Map<string, Cl
   return result;
 }
 
-function packageName(specifier: string): string {
-  return specifier
-    .split('/')
-    .slice(0, specifier.startsWith('@') ? 2 : 1)
-    .join('/');
-}
-
-function sourceEdgeViolation(
+function architectureEdgeViolation(
   importer: ClassifiedPath,
   target: ClassifiedPath | undefined,
-  specifier: string,
 ): string | undefined {
   if (!target) return undefined;
   const edge = apiArchitectureEdgePolicy[importer.classification]?.[target.classification];
@@ -107,10 +91,6 @@ function sourceEdgeViolation(
     throw new Error(
       `Missing API architecture edge policy decision: ${importer.classification} -> ${target.classification}`,
     );
-  }
-  if (importer.classification === 'dto' && target.classification === 'dto') {
-    if (specifier.endsWith('/inter-module')) return 'DTO inter-module import';
-    return undefined;
   }
   if (
     edge.decision === 'allow' ||
@@ -124,34 +104,26 @@ function manifestViolation(
   importer: ClassifiedPath,
   target: ClassifiedPath | undefined,
 ): string | undefined {
-  if (!target) return undefined;
-  if (target.classification === 'implementations') {
-    if (importer.classification === 'implementations' && importer.context !== target.context)
-      return 'Foreign implementation manifest edge';
-    if (importer.classification === 'dto') return 'DTO implementation manifest edge';
-    if (importer.classification === 'shared-semantic')
-      return 'Shared semantic implementation dependency';
-    if (importer.classification === 'spi' && importer.context !== target.context)
-      return 'Foreign SPI implementation manifest edge';
-  }
-  if (target.classification === 'spi') {
-    if (importer.classification === 'dto') return 'DTO SPI manifest edge';
-    if (importer.classification === 'shared-semantic') return 'Shared semantic SPI dependency';
-  }
-  if (
-    importer.classification === 'implementations' &&
-    target.classification === 'spi' &&
-    importer.context !== target.context
-  )
-    return 'Foreign same-context SPI manifest edge';
-  return undefined;
+  const violation = architectureEdgeViolation(importer, target);
+  return violation?.replace(importViolationSuffixExpression, ' manifest edge');
 }
 
-function dtoRootExportViolation(specifier: string): string | undefined {
-  if (specifier.includes('inter-module')) return 'DTO root exports inter-module contract';
-  if (dtoImplementationDetailExpression.test(specifier))
-    return 'DTO root exports implementation detail';
-  return undefined;
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch (error) {
+    if (typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT')
+      return false;
+    throw error;
+  }
+}
+
+function interModuleParityViolation(hasSource: boolean, hasExport: boolean): string | undefined {
+  if (hasSource === hasExport) return undefined;
+  return hasSource
+    ? 'DTO inter-module source has no explicit package export'
+    : 'DTO inter-module export has no source file';
 }
 
 async function findPackagePaths(directory: string, relativeDirectory = ''): Promise<string[]> {
@@ -188,38 +160,8 @@ async function readManifests(packagePaths: string[]): Promise<Map<string, Packag
   return new Map(manifests);
 }
 
-function sourceReExportsInterModule(source: string): boolean {
-  return source.includes('inter-module');
-}
-
 function hasInterModuleEntry(exports: PackageManifest['exports']): boolean {
   return typeof exports === 'object' && exports !== null && './inter-module' in exports;
-}
-
-async function sourceFiles(packagePath: string): Promise<string[]> {
-  const directory = path.join(repositoryRoot, packagePath);
-  const files: string[] = [];
-  const visit = async (currentDirectory: string): Promise<void> => {
-    const entries = await readdir(currentDirectory, {withFileTypes: true});
-    for (const entry of entries) {
-      if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name === 'coverage')
-        continue;
-      const absolutePath = path.join(currentDirectory, entry.name);
-      if (entry.isDirectory()) await visit(absolutePath);
-      if (entry.isFile() && sourceFileExpression.test(entry.name)) files.push(absolutePath);
-    }
-  };
-  await visit(directory);
-  return files;
-}
-
-function importSpecifiers(source: string): string[] {
-  const specifiers: string[] = [];
-  for (const match of source.matchAll(importExpression)) {
-    const specifier = match[1] ?? match[2];
-    if (specifier) specifiers.push(specifier);
-  }
-  return specifiers;
 }
 
 export function apiContextPackagePaths(): string[] {
@@ -251,19 +193,15 @@ export function auditApiContextInventory(packagePaths: string[]): string[] {
 
 export function auditPolicyFixture({
   dependencyGroup,
-  dtoHasInterModuleEntry = true,
-  dtoRootExportsInterModule = false,
-  dtoRootExportSpecifier,
+  dtoHasInterModuleEntry = false,
+  dtoHasInterModuleSource = false,
   importerPath,
-  sourceFile,
   targetPath,
 }: {
   dependencyGroup?: (typeof dependencyGroups)[number];
   dtoHasInterModuleEntry?: boolean;
-  dtoRootExportsInterModule?: boolean;
-  dtoRootExportSpecifier?: string;
+  dtoHasInterModuleSource?: boolean;
   importerPath: string;
-  sourceFile?: string;
   targetPath?: string;
 }): string[] {
   const classifications = new Map(classifiedPaths().map((entry) => [entry.packagePath, entry]));
@@ -272,21 +210,16 @@ export function auditPolicyFixture({
   const errors: string[] = [];
 
   if (importer) {
-    const sourceViolation = sourceEdgeViolation(
-      importer,
-      target,
-      sourceFile?.split(':').at(-1) ?? '',
-    );
-    if (sourceFile && sourceViolation) errors.push(`${sourceViolation}: ${sourceFile}`);
     const dependencyViolation = manifestViolation(importer, target);
     if (dependencyGroup && dependencyViolation)
       errors.push(`${dependencyViolation}: ${dependencyGroup}`);
   }
-  if (importer?.classification === 'dto' && dtoRootExportsInterModule && !dtoHasInterModuleEntry)
-    errors.push('DTO root exports inter-module contract');
-  if (importer?.classification === 'dto' && dtoRootExportSpecifier) {
-    const violation = dtoRootExportViolation(dtoRootExportSpecifier);
-    if (violation) errors.push(violation);
+  if (importer?.classification === 'dto') {
+    const parityViolation = interModuleParityViolation(
+      dtoHasInterModuleSource,
+      dtoHasInterModuleEntry,
+    );
+    if (parityViolation) errors.push(parityViolation);
   }
   return errors;
 }
@@ -310,32 +243,15 @@ export async function auditRepository(): Promise<string[]> {
       }
     }
     if (classification.classification === 'dto') {
-      const indexPath = path.join(repositoryRoot, packagePath, 'src/index.ts');
-      const indexSource = await readFile(indexPath, 'utf8');
-      for (const specifier of importSpecifiers(indexSource)) {
-        const violation = dtoRootExportViolation(specifier);
-        if (violation)
-          errors.push(`${violation}: dto-export:${packagePath}:src/index.ts:${specifier}`);
-      }
-      if (sourceReExportsInterModule(indexSource) && !hasInterModuleEntry(manifest.exports)) {
-        const violation = `dto-export:${packagePath}:package.json:missing-inter-module-entry`;
-        errors.push(`DTO contract has no explicit inter-module export: ${violation}`);
-      }
-    }
-  }
-
-  for (const [packagePath, classification] of classifications) {
-    for (const sourceFile of await sourceFiles(packagePath)) {
-      const source = await readFile(sourceFile, 'utf8');
-      const relativeFile = toPosixPath(path.relative(repositoryRoot, sourceFile));
-      for (const specifier of importSpecifiers(source)) {
-        const violation = sourceEdgeViolation(
-          classification,
-          packages.get(packageName(specifier)),
-          specifier,
-        );
-        if (violation) errors.push(`${violation}: import:${relativeFile}:${specifier}`);
-      }
+      const hasInterModuleSource = await fileExists(
+        path.join(repositoryRoot, packagePath, 'src/inter-module.ts'),
+      );
+      const hasInterModuleExport = hasInterModuleEntry(manifest.exports);
+      const parityViolation = interModuleParityViolation(
+        hasInterModuleSource,
+        hasInterModuleExport,
+      );
+      if (parityViolation) errors.push(`${parityViolation}: dto-export:${packagePath}`);
     }
   }
 

--- a/tools/api-architecture-policy/test/api-context-inventory.test.ts
+++ b/tools/api-architecture-policy/test/api-context-inventory.test.ts
@@ -19,26 +19,6 @@ describe('auditApiContextInventory', () => {
     assert.deepEqual(errors, []);
   });
 
-  test('rejects Auth root and deep implementation imports from consumer tests', () => {
-    const productionErrors = auditPolicyFixture({
-      importerPath: 'libs/api/runners',
-      sourceFile: 'src/consumer.test.ts:@shipfox/api-auth',
-      targetPath: 'libs/api/auth',
-    });
-    const testErrors = auditPolicyFixture({
-      importerPath: 'libs/api/runners',
-      sourceFile: 'test/consumer.test.ts:@shipfox/api-auth/core/job-lease-token',
-      targetPath: 'libs/api/auth',
-    });
-
-    assert.deepEqual(productionErrors, [
-      'Foreign implementation import: src/consumer.test.ts:@shipfox/api-auth',
-    ]);
-    assert.deepEqual(testErrors, [
-      'Foreign implementation import: test/consumer.test.ts:@shipfox/api-auth/core/job-lease-token',
-    ]);
-  });
-
   test('rejects a new foreign manifest edge and missing DTO inter-module export', () => {
     const manifestErrors = auditPolicyFixture({
       dependencyGroup: 'devDependencies',
@@ -47,58 +27,83 @@ describe('auditApiContextInventory', () => {
     });
     const dtoErrors = auditPolicyFixture({
       dtoHasInterModuleEntry: false,
-      dtoRootExportsInterModule: true,
+      dtoHasInterModuleSource: true,
       importerPath: 'libs/api/projects-dto',
     });
 
     assert.deepEqual(manifestErrors, ['Foreign implementation manifest edge: devDependencies']);
-    assert.deepEqual(dtoErrors, ['DTO root exports inter-module contract']);
+    assert.deepEqual(dtoErrors, ['DTO inter-module source has no explicit package export']);
+
+    const orphanExportErrors = auditPolicyFixture({
+      dtoHasInterModuleEntry: true,
+      importerPath: 'libs/api/projects-dto',
+    });
+    assert.deepEqual(orphanExportErrors, ['DTO inter-module export has no source file']);
   });
 
-  test('rejects implementation dependencies from DTOs, shared semantics, and foreign SPIs', () => {
-    const dtoErrors = auditPolicyFixture({
-      dependencyGroup: 'dependencies',
-      importerPath: 'libs/api/workflows-dto',
-      sourceFile: 'src/index.ts:@shipfox/api-workflows',
-      targetPath: 'libs/api/workflows',
-    });
-    const sharedSemanticErrors = auditPolicyFixture({
-      dependencyGroup: 'dependencies',
-      importerPath: 'libs/shared/common/runner-labels',
-      sourceFile: 'src/index.ts:@shipfox/api-runners',
-      targetPath: 'libs/api/runners',
-    });
-    const spiErrors = auditPolicyFixture({
-      dependencyGroup: 'dependencies',
-      importerPath: 'libs/api/integration/spi',
-      sourceFile: 'src/index.ts:@shipfox/api-workflows',
-      targetPath: 'libs/api/workflows',
-    });
-    assert.deepEqual(dtoErrors, [
-      'DTO implementation import: src/index.ts:@shipfox/api-workflows',
-      'DTO implementation manifest edge: dependencies',
-    ]);
-    assert.deepEqual(sharedSemanticErrors, [
-      'Shared semantic implementation import: src/index.ts:@shipfox/api-runners',
-      'Shared semantic implementation dependency: dependencies',
-    ]);
-    assert.deepEqual(spiErrors, [
-      'Foreign SPI implementation import: src/index.ts:@shipfox/api-workflows',
-      'Foreign SPI implementation manifest edge: dependencies',
-    ]);
+  test('validates every workspace dependency group through the shared edge policy', () => {
+    const dependencyGroups = [
+      'dependencies',
+      'devDependencies',
+      'optionalDependencies',
+      'peerDependencies',
+    ] as const;
+
+    for (const dependencyGroup of dependencyGroups) {
+      assert.deepEqual(
+        auditPolicyFixture({
+          dependencyGroup,
+          importerPath: 'libs/api/workflows-dto',
+          targetPath: 'libs/api/workflows',
+        }),
+        [`DTO implementation manifest edge: ${dependencyGroup}`],
+      );
+    }
+
+    assert.deepEqual(
+      auditPolicyFixture({
+        dependencyGroup: 'dependencies',
+        importerPath: 'libs/shared/common/runner-labels',
+        targetPath: 'libs/api/runners',
+      }),
+      ['Shared semantic implementation manifest edge: dependencies'],
+    );
+
+    assert.deepEqual(
+      auditPolicyFixture({
+        dependencyGroup: 'dependencies',
+        importerPath: 'libs/api/integration/spi',
+        targetPath: 'libs/api/workflows',
+      }),
+      ['Foreign SPI implementation manifest edge: dependencies'],
+    );
+
+    assert.deepEqual(
+      auditPolicyFixture({
+        dependencyGroup: 'dependencies',
+        importerPath: 'libs/api/projects-dto',
+        targetPath: 'libs/api/integration/spi',
+      }),
+      ['DTO SPI manifest edge: dependencies'],
+    );
+
+    assert.deepEqual(
+      auditPolicyFixture({
+        dependencyGroup: 'dependencies',
+        importerPath: 'libs/shared/common/runner-labels',
+        targetPath: 'libs/api/integration/spi',
+      }),
+      ['Shared semantic SPI manifest edge: dependencies'],
+    );
   });
 
   test('rejects foreign implementation dependencies on same-context SPIs', () => {
     const errors = auditPolicyFixture({
       dependencyGroup: 'dependencies',
       importerPath: 'libs/api/workflows',
-      sourceFile: 'src/core/agent-tools.ts:@shipfox/api-integration-spi',
       targetPath: 'libs/api/integration/spi',
     });
 
-    assert.deepEqual(errors, [
-      'Foreign same-context SPI import: src/core/agent-tools.ts:@shipfox/api-integration-spi',
-      'Foreign same-context SPI manifest edge: dependencies',
-    ]);
+    assert.deepEqual(errors, ['Foreign same-context SPI manifest edge: dependencies']);
   });
 });

--- a/tools/api-architecture-policy/turbo.json
+++ b/tools/api-architecture-policy/turbo.json
@@ -4,10 +4,9 @@
   "tasks": {
     "verify": {
       "inputs": [
-        "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/api-contexts.cjs",
         "$TURBO_ROOT$/libs/api/**/package.json",
-        "$TURBO_ROOT$/libs/api/**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}",
+        "$TURBO_ROOT$/libs/api/**/*-dto/src/inter-module.ts",
         "$TURBO_ROOT$/libs/shared/common/**/package.json",
         "$TURBO_ROOT$/libs/shared/expression/**/package.json",
         "$TURBO_ROOT$/libs/shared/node/**/package.json",


### PR DESCRIPTION
Retires the regex-based source-import scan from API context inventory now that Biome and Dependency Cruiser own source-edge enforcement.

- Keeps inventory validation focused on package classification, manifest edges, and DTO inter-module export parity.
- Wires Dependency Cruiser into all six classified packages that were missing the task.
- Documents enforcement ownership and narrows the verifier's Turbo inputs.

Closes ENG-1211

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retires the duplicate regex-based import scan in the API architecture policy and hands source-edge enforcement to Biome and Dependency Cruiser. The verifier now focuses on manifest edges, package classification, and DTO `/inter-module` export parity. Closes ENG-1211.

- **Refactors**
  - Removed source import scanning from `api-context-inventory`; rely on Biome and Dependency Cruiser for source edges.
  - Validate manifest edges and DTO `/inter-module` source/export parity without parsing imports.
  - Narrowed Turbo verify inputs to manifests and `*-dto/src/inter-module.ts`; updated docs to clarify enforcement ownership.

- **Dependencies**
  - Added `@shipfox/depcruise` and a `depcruise` script to six classified packages to keep source-edge checks active.

<sup>Written for commit e8c3a2cd1ead150162608680b5bb6f25994dfd68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

