### PR TITLE
Stabilize module database namespaces and migration histories

### DIFF
--- a/.changeset/stable-module-database-namespaces.md
+++ b/.changeset/stable-module-database-namespaces.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/node-module": major
+---
+
+Require every `ModuleDatabase` declaration to provide a stable database namespace and use it for the Drizzle migration-history table name.

--- a/libs/api/agent/src/index.ts
+++ b/libs/api/agent/src/index.ts
@@ -45,7 +45,7 @@ export {
 export function createAgentModule(params: {secrets: AgentSecretsClient}): ShipfoxModule {
   return {
     name: 'agent',
-    database: {db, migrationsPath},
+    database: {db, migrationsPath, databaseNamespace: 'agent'},
     routes: createAgentRoutes(params.secrets),
     e2eRoutes: [createAgentE2eRoutes(params.secrets)],
     interModulePresentations: [createAgentInterModulePresentation(params)],

--- a/libs/api/annotations/src/index.ts
+++ b/libs/api/annotations/src/index.ts
@@ -6,7 +6,7 @@ import {annotationsRoutes} from '#presentation/routes/index.js';
 
 export const annotationsModule: ShipfoxModule = {
   name: 'annotations',
-  database: {db, migrationsPath},
+  database: {db, migrationsPath, databaseNamespace: 'annotations'},
   routes: annotationsRoutes,
   interModulePresentations: [createAnnotationsInterModulePresentation()],
 };

--- a/libs/api/auth/src/index.ts
+++ b/libs/api/auth/src/index.ts
@@ -69,7 +69,7 @@ export function createAuthModule({
 }): ShipfoxModule {
   return {
     name: 'auth',
-    database: {db, migrationsPath},
+    database: {db, migrationsPath, databaseNamespace: 'auth'},
     auth: [createJwtAuthMethod(), createLeaseTokenAuthMethod(), createRunnerSessionAuthMethod()],
     loginMethods: passwordLoginMethods(config.AUTH_PASSWORD_ENABLED),
     routes: [buildAuthRoutes(config.AUTH_PASSWORD_ENABLED, workspaces)],

--- a/libs/api/definitions/src/index.ts
+++ b/libs/api/definitions/src/index.ts
@@ -62,7 +62,7 @@ export function createDefinitionsModule({
 
   return {
     name: 'definitions',
-    database: {db, migrationsPath},
+    database: {db, migrationsPath, databaseNamespace: 'definitions'},
     routes: createDefinitionRoutes({projects, agent, integrations}),
     publishers: [
       {name: 'definitions', table: definitionsOutbox, db, eventSchemas: definitionsEventSchemas},

--- a/libs/api/email-challenges/src/index.ts
+++ b/libs/api/email-challenges/src/index.ts
@@ -19,6 +19,6 @@ export const emailChallengesModule: ShipfoxModule = {
   database: {
     db,
     migrationsPath,
-    migrationsTableName: '__drizzle_migrations_email_challenges',
+    databaseNamespace: 'email_challenges',
   },
 };

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -238,7 +238,7 @@ export async function createIntegrationsContext(
     ],
     startupTasks: runStartupTasks,
     database: [
-      {db, migrationsPath},
+      {db, migrationsPath, databaseNamespace: 'integrations'},
       ...parts.flatMap((part) => (part.database ? [part.database] : [])),
     ],
     routes: createIntegrationRoutes(registry, sourceControl, {

--- a/libs/api/integration/core/src/providers/gitea.ts
+++ b/libs/api/integration/core/src/providers/gitea.ts
@@ -11,12 +11,6 @@ import {publishSourcePush, recordDeliveryOnly} from '#db/webhook-deliveries.js';
 import {retryConnectionSlugCollision, slugifyConnectionSlug} from '#providers/connection-slug.js';
 import type {IntegrationModuleParts, IntegrationProviderModule} from '#providers/types.js';
 
-// Stable migration-tracking table name for the Gitea provider database. This
-// must NOT depend on the provider's position in the module `database` array. A
-// positional name would shift if a provider is flag-disabled and silently
-// re-run migrations against existing tables.
-const GITEA_MIGRATIONS_TABLE = '__drizzle_migrations_integrations_gitea';
-
 async function loadGiteaModuleParts(): Promise<IntegrationModuleParts> {
   const {
     createGiteaIntegrationProvider,
@@ -91,7 +85,7 @@ async function loadGiteaModuleParts(): Promise<IntegrationModuleParts> {
     database: {
       db: giteaDb,
       migrationsPath: giteaMigrationsPath,
-      migrationsTableName: GITEA_MIGRATIONS_TABLE,
+      databaseNamespace: 'integrations_gitea',
     },
   };
 }

--- a/libs/api/integration/core/src/providers/github.ts
+++ b/libs/api/integration/core/src/providers/github.ts
@@ -19,12 +19,6 @@ import type {
   IntegrationProviderModuleLoadOptions,
 } from '#providers/types.js';
 
-// Stable migration-tracking table name for the GitHub provider database. This
-// must NOT depend on the provider's position in the module `database` array. A
-// positional name would shift if a provider is flag-disabled and silently
-// re-run migrations against existing tables.
-const GITHUB_MIGRATIONS_TABLE = '__drizzle_migrations_integrations_github';
-
 async function loadGithubModuleParts(
   options: IntegrationProviderModuleLoadOptions = {},
 ): Promise<IntegrationModuleParts> {
@@ -141,7 +135,7 @@ async function loadGithubModuleParts(
     database: {
       db: githubDb,
       migrationsPath: githubMigrationsPath,
-      migrationsTableName: GITHUB_MIGRATIONS_TABLE,
+      databaseNamespace: 'integrations_github',
     },
   };
 }

--- a/libs/api/integration/core/src/providers/jira.test.ts
+++ b/libs/api/integration/core/src/providers/jira.test.ts
@@ -26,7 +26,7 @@ describe('jiraProviderModule', () => {
     await runMigrations(
       jiraPart.database.db(),
       jiraPart.database.migrationsPath,
-      jiraPart.database.migrationsTableName,
+      `__drizzle_migrations_${jiraPart.database.databaseNamespace}`,
     );
     const connection = await upsertIntegrationConnection({
       workspaceId,

--- a/libs/api/integration/core/src/providers/jira.ts
+++ b/libs/api/integration/core/src/providers/jira.ts
@@ -16,7 +16,6 @@ import {db} from '#db/db.js';
 import {retryConnectionSlugCollision, slugifyConnectionSlug} from '#providers/connection-slug.js';
 import type {IntegrationModuleParts, IntegrationProviderModule} from '#providers/types.js';
 
-const JIRA_MIGRATIONS_TABLE = '__drizzle_migrations_integrations_jira';
 const JIRA_SECRETS_NAMESPACE_PREFIX = 'system/integrations/jira/';
 type IntegrationDb = ReturnType<typeof db>;
 type IntegrationTx = Parameters<Parameters<IntegrationDb['transaction']>[0]>[0];
@@ -154,7 +153,7 @@ async function loadJiraModuleParts(
           : {}),
       },
     }),
-    database: {db: jiraDb, migrationsPath, migrationsTableName: JIRA_MIGRATIONS_TABLE},
+    database: {db: jiraDb, migrationsPath, databaseNamespace: 'integrations_jira'},
   };
 }
 

--- a/libs/api/integration/core/src/providers/linear.test.ts
+++ b/libs/api/integration/core/src/providers/linear.test.ts
@@ -27,7 +27,7 @@ describe('linearProviderModule', () => {
     await runMigrations(
       linearPart.database.db(),
       linearPart.database.migrationsPath,
-      linearPart.database.migrationsTableName,
+      `__drizzle_migrations_${linearPart.database.databaseNamespace}`,
     );
     const app = await createTestApp([linearPart.provider]);
     const connection = await upsertIntegrationConnection({
@@ -99,7 +99,7 @@ describe('linearProviderModule', () => {
     await runMigrations(
       linearPart.database.db(),
       linearPart.database.migrationsPath,
-      linearPart.database.migrationsTableName,
+      `__drizzle_migrations_${linearPart.database.databaseNamespace}`,
     );
     const connection = await upsertIntegrationConnection({
       workspaceId: context.workspaceId,

--- a/libs/api/integration/core/src/providers/linear.ts
+++ b/libs/api/integration/core/src/providers/linear.ts
@@ -15,7 +15,6 @@ import {publishIntegrationEventReceived, recordDeliveryOnly} from '#db/webhook-d
 import {retryConnectionSlugCollision, slugifyConnectionSlug} from '#providers/connection-slug.js';
 import type {IntegrationModuleParts, IntegrationProviderModule} from '#providers/types.js';
 
-const LINEAR_MIGRATIONS_TABLE = '__drizzle_migrations_integrations_linear';
 const LINEAR_SECRETS_NAMESPACE_PREFIX = 'system/integrations/linear/';
 
 type IntegrationDb = ReturnType<typeof db>;
@@ -177,7 +176,7 @@ async function loadLinearModuleParts(
     database: {
       db: linearDb,
       migrationsPath: linearMigrationsPath,
-      migrationsTableName: LINEAR_MIGRATIONS_TABLE,
+      databaseNamespace: 'integrations_linear',
     },
   };
 }

--- a/libs/api/integration/core/src/providers/sentry.ts
+++ b/libs/api/integration/core/src/providers/sentry.ts
@@ -12,12 +12,6 @@ import {publishIntegrationEventReceived, recordDeliveryOnly} from '#db/webhook-d
 import {retryConnectionSlugCollision, slugifyConnectionSlug} from '#providers/connection-slug.js';
 import type {IntegrationModuleParts, IntegrationProviderModule} from '#providers/types.js';
 
-// Stable migration-tracking table name for the Sentry provider database. This
-// must NOT depend on the provider's position in the module `database` array. A
-// positional name would shift if a provider is flag-disabled and silently
-// re-run migrations against existing tables.
-const SENTRY_MIGRATIONS_TABLE = '__drizzle_migrations_integrations_sentry';
-
 async function loadSentryModuleParts(): Promise<IntegrationModuleParts> {
   const {
     createSentryIntegrationProvider,
@@ -100,7 +94,7 @@ async function loadSentryModuleParts(): Promise<IntegrationModuleParts> {
     database: {
       db: sentryDb,
       migrationsPath: sentryMigrationsPath,
-      migrationsTableName: SENTRY_MIGRATIONS_TABLE,
+      databaseNamespace: 'integrations_sentry',
     },
     workers: [createSentryMaintenanceWorker()],
   };

--- a/libs/api/integration/core/src/providers/slack.test.ts
+++ b/libs/api/integration/core/src/providers/slack.test.ts
@@ -30,7 +30,7 @@ describe('slackProviderModule', () => {
     await runMigrations(
       slackPart.database.db(),
       slackPart.database.migrationsPath,
-      slackPart.database.migrationsTableName,
+      `__drizzle_migrations_${slackPart.database.databaseNamespace}`,
     );
     const connection = await upsertIntegrationConnection({
       workspaceId,
@@ -81,7 +81,7 @@ describe('slackProviderModule', () => {
     await runMigrations(
       slackPart.database.db(),
       slackPart.database.migrationsPath,
-      slackPart.database.migrationsTableName,
+      `__drizzle_migrations_${slackPart.database.databaseNamespace}`,
     );
     const app = await createTestApp([slackPart.provider]);
     const connection = await upsertIntegrationConnection({
@@ -159,7 +159,7 @@ describe('slackProviderModule', () => {
     await runMigrations(
       slackPart.database.db(),
       slackPart.database.migrationsPath,
-      slackPart.database.migrationsTableName,
+      `__drizzle_migrations_${slackPart.database.databaseNamespace}`,
     );
     const connection = await upsertIntegrationConnection({
       workspaceId: context.workspaceId,

--- a/libs/api/integration/core/src/providers/slack.ts
+++ b/libs/api/integration/core/src/providers/slack.ts
@@ -19,7 +19,6 @@ import {
 import {retryConnectionSlugCollision, slugifyConnectionSlug} from '#providers/connection-slug.js';
 import type {IntegrationModuleParts, IntegrationProviderModule} from '#providers/types.js';
 
-const SLACK_MIGRATIONS_TABLE = '__drizzle_migrations_integrations_slack';
 const SLACK_SECRETS_NAMESPACE_PREFIX = 'system/integrations/slack/';
 
 type IntegrationDb = ReturnType<typeof db>;
@@ -180,7 +179,7 @@ async function loadSlackModuleParts(
     database: {
       db: slackDb,
       migrationsPath: slackMigrationsPath,
-      migrationsTableName: SLACK_MIGRATIONS_TABLE,
+      databaseNamespace: 'integrations_slack',
     },
   };
 }

--- a/libs/api/logs/src/index.ts
+++ b/libs/api/logs/src/index.ts
@@ -38,7 +38,7 @@ export function createLogsModule({
 
   return {
     name: 'logs',
-    database: {db, migrationsPath},
+    database: {db, migrationsPath, databaseNamespace: 'logs'},
     routes: createLogsRoutes(workflows),
     metrics: registerLogsServiceMetrics,
     // `logs.stream.closed` is written by the close paths: the job-terminated subscriber

--- a/libs/api/projects/src/index.ts
+++ b/libs/api/projects/src/index.ts
@@ -48,7 +48,7 @@ export interface CreateProjectsModuleOptions {
 export function createProjectsModule({integrations}: CreateProjectsModuleOptions): ShipfoxModule {
   return {
     name: 'projects',
-    database: {db, migrationsPath},
+    database: {db, migrationsPath, databaseNamespace: 'projects'},
     routes: createProjectRoutes(integrations),
     e2eRoutes: [projectsE2eRoutes],
     metrics: registerProjectsServiceMetrics,

--- a/libs/api/runners/src/index.ts
+++ b/libs/api/runners/src/index.ts
@@ -49,7 +49,7 @@ export function createRunnersModule({
 }: CreateRunnersModuleOptions & {auth: AuthInterModuleClient}): ShipfoxModule {
   return {
     name: 'runners',
-    database: {db, migrationsPath},
+    database: {db, migrationsPath, databaseNamespace: 'runners'},
     auth: [
       createRunnerRegistrationTokenAuthMethod(),
       createRunnerControlSessionAuthMethod(),

--- a/libs/api/secrets/src/index.ts
+++ b/libs/api/secrets/src/index.ts
@@ -45,7 +45,7 @@ export {
 export function createSecretsModule(projects: ProjectsModuleClient): ShipfoxModule {
   return {
     name: 'secrets',
-    database: {db, migrationsPath},
+    database: {db, migrationsPath, databaseNamespace: 'secrets'},
     routes: createSecretsRoutes(projects),
     e2eRoutes: [secretsE2eRoutes],
     metrics: registerSecretsServiceMetrics,
@@ -57,5 +57,5 @@ export function createSecretsModule(projects: ProjectsModuleClient): ShipfoxModu
 // Migration setup imports this declaration only for the owned database metadata.
 export const secretsModule: ShipfoxModule = {
   name: 'secrets',
-  database: {db, migrationsPath},
+  database: {db, migrationsPath, databaseNamespace: 'secrets'},
 };

--- a/libs/api/triggers/src/index.ts
+++ b/libs/api/triggers/src/index.ts
@@ -75,7 +75,7 @@ export interface CreateTriggersModuleOptions {
 export function createTriggersModule({workflows}: CreateTriggersModuleOptions): ShipfoxModule {
   return {
     name: 'triggers',
-    database: {db, migrationsPath},
+    database: {db, migrationsPath, databaseNamespace: 'triggers'},
     routes: createTriggerRoutes(workflows),
     e2eRoutes: [triggersE2eRoutes],
     metrics: registerTriggersServiceMetrics,

--- a/libs/api/workflows/src/index.ts
+++ b/libs/api/workflows/src/index.ts
@@ -95,7 +95,7 @@ export function createWorkflowsModule({
 }): ShipfoxModule {
   return {
     name: 'workflows',
-    database: {db, migrationsPath},
+    database: {db, migrationsPath, databaseNamespace: 'workflows'},
     routes: createWorkflowRoutes({
       agent,
       annotations,

--- a/libs/api/workspaces/src/index.ts
+++ b/libs/api/workspaces/src/index.ts
@@ -38,7 +38,7 @@ const subscriber = subscriberFactory<WorkspacesEventMap>();
 
 export const workspacesModule: ShipfoxModule = {
   name: 'workspaces',
-  database: {db, migrationsPath},
+  database: {db, migrationsPath, databaseNamespace: 'workspaces'},
   routes: workspacesRoutes,
   e2eRoutes: [workspacesE2eRoutes],
   publishers: [

--- a/libs/shared/node/module/README.md
+++ b/libs/shared/node/module/README.md
@@ -65,7 +65,7 @@ async function handleExampleCreated(payload: ExampleEventMap['example.created'])
 
 export const exampleModule: ShipfoxModule = {
   name: 'example',
-  database: {db, migrationsPath},
+  database: {db, migrationsPath, databaseNamespace: 'example'},
   auth: [authMethod],
   loginMethods: [{id: 'example-login'}],
   routes: [routes],
@@ -83,6 +83,11 @@ export const exampleModule: ShipfoxModule = {
   ],
 };
 ```
+
+Every database declaration requires a stable lowercase snake-case
+`databaseNamespace`. Initialization uses it for the Drizzle migration history
+table `__drizzle_migrations_<databaseNamespace>` and rejects invalid or
+duplicate namespaces before running migrations.
 
 ## Login methods
 

--- a/libs/shared/node/module/src/initialize.test.ts
+++ b/libs/shared/node/module/src/initialize.test.ts
@@ -1,4 +1,5 @@
 import {
+  initializeModules,
   registerModuleMetrics,
   runModuleStartupTasks as runStartupTasks,
   startModuleServices as startServices,
@@ -28,6 +29,7 @@ function startModuleWorkers(options: Omit<Parameters<typeof startWorkers>[0], 'c
 }
 
 const mocks = vi.hoisted(() => ({
+  runMigrations: vi.fn(),
   closeTemporalClient: vi.fn(),
   createTemporalClient: vi.fn(),
   createTemporalWorker: vi.fn(),
@@ -42,6 +44,10 @@ const mocks = vi.hoisted(() => ({
   },
   metricAdd: vi.fn(),
   metricRecord: vi.fn(),
+}));
+
+vi.mock('@shipfox/node-drizzle', () => ({
+  runMigrations: mocks.runMigrations,
 }));
 
 vi.mock('@shipfox/node-temporal', () => ({
@@ -66,6 +72,98 @@ vi.mock('@shipfox/node-opentelemetry', () => ({
     }),
   },
 }));
+
+function migrationModule(
+  name: string,
+  databaseNamespace: string,
+  extraDatabases: Array<{databaseNamespace: string}> = [],
+): ShipfoxModule {
+  return {
+    name,
+    database: [
+      ...[databaseNamespace, ...extraDatabases.map((database) => database.databaseNamespace)].map(
+        (namespace) => ({
+          db: () => undefined as never,
+          migrationsPath: `/migrations/${namespace}`,
+          databaseNamespace: namespace,
+        }),
+      ),
+    ],
+  };
+}
+
+describe('initializeModules database namespaces', () => {
+  beforeEach(() => {
+    mocks.runMigrations.mockReset();
+  });
+
+  it('derives stable migration histories when databases are reordered or removed', async () => {
+    await initializeModules({
+      modules: [
+        migrationModule('integrations', 'integrations', [
+          {databaseNamespace: 'integrations_github'},
+        ]),
+        migrationModule('auth', 'auth'),
+      ],
+    });
+
+    expect(mocks.runMigrations.mock.calls.map((call) => call[2])).toEqual([
+      '__drizzle_migrations_integrations',
+      '__drizzle_migrations_integrations_github',
+      '__drizzle_migrations_auth',
+    ]);
+
+    mocks.runMigrations.mockReset();
+
+    await initializeModules({
+      modules: [
+        migrationModule('auth', 'auth'),
+        migrationModule('integrations', 'integrations_github', [
+          {databaseNamespace: 'integrations'},
+        ]),
+      ],
+    });
+
+    expect(mocks.runMigrations.mock.calls.map((call) => call[2])).toEqual([
+      '__drizzle_migrations_auth',
+      '__drizzle_migrations_integrations_github',
+      '__drizzle_migrations_integrations',
+    ]);
+
+    mocks.runMigrations.mockReset();
+
+    await initializeModules({modules: [migrationModule('integrations', 'integrations')]});
+
+    expect(mocks.runMigrations.mock.calls.map((call) => call[2])).toEqual([
+      '__drizzle_migrations_integrations',
+    ]);
+  });
+
+  it('rejects duplicate namespaces before running any migrations', async () => {
+    await expect(
+      initializeModules({
+        modules: [migrationModule('first', 'shared'), migrationModule('second', 'shared')],
+      }),
+    ).rejects.toThrow(
+      'Duplicate database namespace "shared" declared by modules "first" and "second"',
+    );
+
+    expect(mocks.runMigrations).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    '',
+    'Integrations',
+    'integrations-github',
+    '_integrations',
+  ])('rejects invalid namespace %j before running any migrations', async (databaseNamespace) => {
+    await expect(
+      initializeModules({modules: [migrationModule('invalid', databaseNamespace)]}),
+    ).rejects.toThrow(`Invalid database namespace "${databaseNamespace}"`);
+
+    expect(mocks.runMigrations).not.toHaveBeenCalled();
+  });
+});
 
 describe('registerModuleMetrics', () => {
   it('invokes the metrics hook for each module that declares one', () => {

--- a/libs/shared/node/module/src/initialize.ts
+++ b/libs/shared/node/module/src/initialize.ts
@@ -26,6 +26,8 @@ export interface InitializeModulesOptions {
   modules: ShipfoxModule[];
 }
 
+const databaseNamespaceExpression = /^[a-z][a-z0-9_]*$/u;
+
 export interface InitializedModules {
   auth: AuthMethod[];
   routes: RouteExport[];
@@ -83,19 +85,27 @@ export async function initializeModules(
   const services: ModuleService[] = [];
   const outboxRegistry = createOutboxRegistry();
 
+  validateModuleDatabaseNamespaces(options.modules);
+
   for (const mod of options.modules) {
     logger().info({module: mod.name}, 'Initializing module');
 
     if (mod.database) {
       const databases = normalizeModuleDatabases(mod.database);
-      for (const [index, database] of databases.entries()) {
-        logger().info({module: mod.name, database: index}, 'Running migrations');
+      for (const database of databases) {
+        logger().info(
+          {module: mod.name, database: database.databaseNamespace},
+          'Running migrations',
+        );
         await runMigrations(
           database.db(),
           database.migrationsPath,
-          database.migrationsTableName ?? moduleMigrationTableName(mod.name, index),
+          migrationHistoryTableName(database.databaseNamespace),
         );
-        logger().info({module: mod.name, database: index}, 'Migrations complete');
+        logger().info(
+          {module: mod.name, database: database.databaseNamespace},
+          'Migrations complete',
+        );
       }
     }
 
@@ -141,9 +151,32 @@ function normalizeModuleDatabases(database: ModuleDatabase | ModuleDatabase[]): 
   return Array.isArray(database) ? database : [database];
 }
 
-function moduleMigrationTableName(moduleName: string, index: number): string {
-  if (index === 0) return `__drizzle_migrations_${moduleName}`;
-  return `__drizzle_migrations_${moduleName}_${index}`;
+function validateModuleDatabaseNamespaces(modules: readonly ShipfoxModule[]): void {
+  const owners = new Map<string, string>();
+
+  for (const mod of modules) {
+    if (!mod.database) continue;
+    for (const database of normalizeModuleDatabases(mod.database)) {
+      const {databaseNamespace} = database;
+      if (!databaseNamespaceExpression.test(databaseNamespace)) {
+        throw new Error(
+          `Invalid database namespace "${databaseNamespace}" declared by module "${mod.name}"; expected lowercase snake case`,
+        );
+      }
+
+      const existingOwner = owners.get(databaseNamespace);
+      if (existingOwner) {
+        throw new Error(
+          `Duplicate database namespace "${databaseNamespace}" declared by modules "${existingOwner}" and "${mod.name}"`,
+        );
+      }
+      owners.set(databaseNamespace, mod.name);
+    }
+  }
+}
+
+function migrationHistoryTableName(databaseNamespace: string): string {
+  return `__drizzle_migrations_${databaseNamespace}`;
 }
 
 /**

--- a/libs/shared/node/module/src/types.ts
+++ b/libs/shared/node/module/src/types.ts
@@ -10,14 +10,12 @@ export interface ModuleDatabase {
   db: () => NodePgDatabase<Record<string, unknown>>;
   migrationsPath: string;
   /**
-   * Stable name for this database's drizzle migration-tracking table. When
-   * omitted, the name is derived from the module name and the database's
-   * position in the module's `database` array. Set this for modules that
-   * compose databases conditionally (e.g. feature-flagged providers), where a
-   * positional name would shift if another database is added or removed and
-   * silently re-run migrations against existing tables.
+   * Stable database identity used for table prefixes and the Drizzle
+   * migration-tracking table. This is registered independently of the module's
+   * display name and must remain stable when modules or providers are moved,
+   * reordered, enabled, or disabled.
    */
-  migrationsTableName?: string;
+  databaseNamespace: string;
 }
 
 export interface ModulePublisher {

--- a/tools/api-database-policy/src/api-database-boundaries.ts
+++ b/tools/api-database-policy/src/api-database-boundaries.ts
@@ -234,34 +234,6 @@ const databaseBoundaryBaseline: readonly DatabaseBoundaryBaselineEntry[] = Objec
   ),
   baselineEntry(
     {
-      owner: 'neutral-infrastructure',
-      namespace: 'neutral',
-      file: 'libs/shared/node/module/src/initialize.ts',
-      line: 96,
-      object: 'moduleMigrationTableName',
-      rule: 'migration-history-instability',
-      suggestedBoundary:
-        'Require the registered database namespace on every ModuleDatabase declaration.',
-    },
-    'ENG-1194',
-    'ModuleDatabase requires a registered stable namespace and no positional fallback.',
-  ),
-  baselineEntry(
-    {
-      owner: 'neutral-infrastructure',
-      namespace: 'neutral',
-      file: 'libs/shared/node/module/src/types.ts',
-      line: 20,
-      object: 'migrationsTableName',
-      rule: 'migration-history-instability',
-      suggestedBoundary:
-        'Require the registered database namespace on every ModuleDatabase declaration.',
-    },
-    'ENG-1194',
-    'ModuleDatabase requires a registered stable namespace and no positional fallback.',
-  ),
-  baselineEntry(
-    {
       owner: 'workflows',
       namespace: 'workflows',
       file: 'libs/api/workflows/src/db/runner-lease-table.ts',

--- a/tools/api-database-policy/test/api-database-boundaries.test.ts
+++ b/tools/api-database-policy/test/api-database-boundaries.test.ts
@@ -36,7 +36,6 @@ describe('database boundary verifier', () => {
         'foreign-migration',
         'foreign-raw-sql',
         'foreign-table-declaration',
-        'migration-history-instability',
         'unprefixed-table',
       ]),
     );


### PR DESCRIPTION
Module migration-history table names were derived from module display names and database positions, so reordering or conditionally enabling providers could point migrations at a different history table.

This change makes `databaseNamespace` required on `ModuleDatabase`, validates lowercase snake-case namespaces and composition-wide uniqueness before migrations run, and derives canonical `__drizzle_migrations_<namespace>` history tables. All existing modules and integration providers are updated, with coverage for reorder/removal, duplicate namespaces, and invalid names.

This is a breaking `@shipfox/node-module` contract change and includes a major Changeset. The resolved ENG-1194 database-boundary baseline findings were removed.

Validation passed:
- `turbo check type test --filter=@shipfox/node-module...`
- `turbo test --filter=@shipfox/api-integration-core...`
- `pnpm check:api-database-boundaries`
- `turbo test:external --filter=@shipfox/node-module`
- `pnpm check:published-artifacts`

Closes ENG-1194

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require a stable `databaseNamespace` for every module database and derive `__drizzle_migrations_<namespace>` names to stop migration history from shifting when modules/providers move or toggle. Adds validation, updates all modules/providers and tests, and removes the ENG-1194 database-boundary baseline; closes ENG-1194.

- **Migration**
  - In `@shipfox/node-module`, replace `migrationsTableName` with required `databaseNamespace`; derive history tables from it and remove positional fallbacks.
  - Validate lowercase snake_case and server-wide uniqueness before running any migrations; add tests for reorder/removal, duplicates, and invalid names.
  - Set namespaces across all modules/providers and update tests; refresh README and database policy; include a major Changeset for `@shipfox/node-module`.

<sup>Written for commit fe7bf7596ce7a1c67b6cbc6df98002b15461c838. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

