### PR TITLE
[api-workspaces] Prefix Workspaces root table

### DIFF
--- a/.changeset/workspaces-database-prefix.md
+++ b/.changeset/workspaces-database-prefix.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-workspaces": patch
+---
+
+Prefixes the Workspaces root table in the migration baseline.

--- a/libs/api/workspaces/drizzle/0000_initial.sql
+++ b/libs/api/workspaces/drizzle/0000_initial.sql
@@ -38,7 +38,7 @@ CREATE TABLE "workspaces_outbox" (
 	"dead_lettered_at" timestamp with time zone
 );
 --> statement-breakpoint
-CREATE TABLE "workspaces" (
+CREATE TABLE "workspaces_workspaces" (
 	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
 	"name" text NOT NULL,
 	"status" "workspaces_workspace_status" DEFAULT 'active' NOT NULL,
@@ -48,8 +48,8 @@ CREATE TABLE "workspaces" (
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
-ALTER TABLE "workspaces_invitations" ADD CONSTRAINT "workspaces_invitations_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "public"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "workspaces_memberships" ADD CONSTRAINT "workspaces_memberships_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "public"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "workspaces_invitations" ADD CONSTRAINT "workspaces_invitations_workspace_id_workspaces_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "public"."workspaces_workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "workspaces_memberships" ADD CONSTRAINT "workspaces_memberships_workspace_id_workspaces_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "public"."workspaces_workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 CREATE UNIQUE INDEX "workspaces_invitations_hashed_token_unique" ON "workspaces_invitations" USING btree ("hashed_token");--> statement-breakpoint
 CREATE INDEX "workspaces_invitations_workspace_email_idx" ON "workspaces_invitations" USING btree ("workspace_id","email");--> statement-breakpoint
 CREATE UNIQUE INDEX "workspaces_memberships_user_workspace_unique" ON "workspaces_memberships" USING btree ("user_id","workspace_id");--> statement-breakpoint

--- a/libs/api/workspaces/drizzle/meta/0000_snapshot.json
+++ b/libs/api/workspaces/drizzle/meta/0000_snapshot.json
@@ -123,10 +123,10 @@
         }
       },
       "foreignKeys": {
-        "workspaces_invitations_workspace_id_workspaces_id_fk": {
-          "name": "workspaces_invitations_workspace_id_workspaces_id_fk",
+        "workspaces_invitations_workspace_id_workspaces_workspaces_id_fk": {
+          "name": "workspaces_invitations_workspace_id_workspaces_workspaces_id_fk",
           "tableFrom": "workspaces_invitations",
-          "tableTo": "workspaces",
+          "tableTo": "workspaces_workspaces",
           "columnsFrom": ["workspace_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
@@ -228,10 +228,10 @@
         }
       },
       "foreignKeys": {
-        "workspaces_memberships_workspace_id_workspaces_id_fk": {
-          "name": "workspaces_memberships_workspace_id_workspaces_id_fk",
+        "workspaces_memberships_workspace_id_workspaces_workspaces_id_fk": {
+          "name": "workspaces_memberships_workspace_id_workspaces_workspaces_id_fk",
           "tableFrom": "workspaces_memberships",
-          "tableTo": "workspaces",
+          "tableTo": "workspaces_workspaces",
           "columnsFrom": ["workspace_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
@@ -372,8 +372,8 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.workspaces": {
-      "name": "workspaces",
+    "public.workspaces_workspaces": {
+      "name": "workspaces_workspaces",
       "schema": "",
       "columns": {
         "id": {

--- a/libs/api/workspaces/src/db/schema/common.ts
+++ b/libs/api/workspaces/src/db/schema/common.ts
@@ -1,5 +1,3 @@
 import {pgTableCreator} from 'drizzle-orm/pg-core';
 
-export const pgTable = pgTableCreator((name) =>
-  name === 'workspaces' ? name : `workspaces_${name}`,
-);
+export const pgTable = pgTableCreator((name) => `workspaces_${name}`);

--- a/libs/api/workspaces/test/globalSetup.ts
+++ b/libs/api/workspaces/test/globalSetup.ts
@@ -8,7 +8,7 @@ export async function setup() {
   createPostgresClient();
 
   await runMigrations(db(), migrationsPath, '__drizzle_migrations_workspaces');
-  await db().execute(sql`TRUNCATE workspaces_outbox, workspaces CASCADE`);
+  await db().execute(sql`TRUNCATE workspaces_outbox, workspaces_workspaces CASCADE`);
 
   closeDb();
   await closePostgresClient();

--- a/tools/api-database-policy/src/api-database-boundaries.ts
+++ b/tools/api-database-policy/src/api-database-boundaries.ts
@@ -172,13 +172,6 @@ interface ReconciliationResult {
 const namespaceSuggestion = (owner: string, namespace: string): string =>
   `Use the ${owner} owner's ${namespace} schema factory and producer-owned boundary.`;
 
-function baselineEntry(
-  finding: Omit<DatabaseBoundaryBaselineEntry, 'trackingIssue' | 'removalCondition'>,
-  trackingIssue: string,
-  removalCondition: string,
-): DatabaseBoundaryBaselineEntry {
-  return {...finding, trackingIssue, removalCondition};
-}
 const databaseBoundaryBaseline: readonly DatabaseBoundaryBaselineEntry[] = Object.freeze([]);
 
 export {databaseBoundaryBaseline};

--- a/tools/api-database-policy/src/api-database-boundaries.ts
+++ b/tools/api-database-policy/src/api-database-boundaries.ts
@@ -179,10 +179,7 @@ function baselineEntry(
 ): DatabaseBoundaryBaselineEntry {
   return {...finding, trackingIssue, removalCondition};
 }
-const databaseBoundaryBaseline: readonly DatabaseBoundaryBaselineEntry[] = Object.freeze([
-  baselineEntry(
-    {
-]);
+const databaseBoundaryBaseline: readonly DatabaseBoundaryBaselineEntry[] = Object.freeze([]);
 
 export {databaseBoundaryBaseline};
 

--- a/tools/api-database-policy/src/api-database-boundaries.ts
+++ b/tools/api-database-policy/src/api-database-boundaries.ts
@@ -182,69 +182,6 @@ function baselineEntry(
 const databaseBoundaryBaseline: readonly DatabaseBoundaryBaselineEntry[] = Object.freeze([
   baselineEntry(
     {
-      owner: 'workspaces',
-      namespace: 'workspaces',
-      file: 'libs/api/workspaces/drizzle/0000_initial.sql',
-      line: 41,
-      object: 'workspaces',
-      rule: 'unprefixed-table',
-      suggestedBoundary: namespaceSuggestion('workspaces', 'workspaces'),
-    },
-    'ENG-1196',
-    'The Workspaces root table is renamed to workspaces_workspaces.',
-  ),
-  baselineEntry(
-    {
-      owner: 'workspaces',
-      namespace: 'workspaces',
-      file: 'libs/api/workspaces/drizzle/0000_initial.sql',
-      line: 51,
-      object: 'workspaces',
-      rule: 'unprefixed-table',
-      suggestedBoundary: namespaceSuggestion('workspaces', 'workspaces'),
-    },
-    'ENG-1196',
-    'The Workspaces root table is renamed to workspaces_workspaces.',
-  ),
-  baselineEntry(
-    {
-      owner: 'workspaces',
-      namespace: 'workspaces',
-      file: 'libs/api/workspaces/drizzle/0000_initial.sql',
-      line: 52,
-      object: 'workspaces',
-      rule: 'unprefixed-table',
-      suggestedBoundary: namespaceSuggestion('workspaces', 'workspaces'),
-    },
-    'ENG-1196',
-    'The Workspaces root table is renamed to workspaces_workspaces.',
-  ),
-  baselineEntry(
-    {
-      owner: 'workspaces',
-      namespace: 'workspaces',
-      file: 'libs/api/workspaces/drizzle/meta/0000_snapshot.json',
-      line: 7,
-      object: 'workspaces',
-      rule: 'unprefixed-table',
-      suggestedBoundary: namespaceSuggestion('workspaces', 'workspaces'),
-    },
-    'ENG-1196',
-    'The Workspaces root table is renamed to workspaces_workspaces.',
-  ),
-  baselineEntry(
-    {
-      owner: 'workspaces',
-      namespace: 'workspaces',
-      file: 'libs/api/workspaces/test/globalSetup.ts',
-      line: 11,
-      object: 'workspaces',
-      rule: 'unprefixed-table',
-      suggestedBoundary: namespaceSuggestion('workspaces', 'workspaces'),
-    },
-    'ENG-1196',
-    'The Workspaces root table is renamed to workspaces_workspaces.',
-  ),
 ]);
 
 export {databaseBoundaryBaseline};

--- a/tools/api-database-policy/test/api-database-boundaries.test.ts
+++ b/tools/api-database-policy/test/api-database-boundaries.test.ts
@@ -15,10 +15,7 @@ describe('database boundary verifier', () => {
     assert.equal(reconciliation.knownBaselineFindings.length, databaseBoundaryBaseline.length);
     assert.ok(databaseBoundaryBaseline.every((entry) => !entry.file.includes('*')));
     assert.ok(databaseBoundaryBaseline.every((entry) => !entry.object.includes('*')));
-    assert.deepEqual(
-      new Set(findings.map((finding) => finding.rule)),
-      new Set(),
-    );
+    assert.deepEqual(new Set(findings.map((finding) => finding.rule)), new Set());
   });
   test('fails closed when a finding is new or a baseline entry disappears', () => {
     const firstBaseline = {
@@ -28,7 +25,7 @@ describe('database boundary verifier', () => {
       line: 1,
       object: 'test',
       rule: 'unprefixed-table',
-      suggestedBoundary: 'Use the test owner\'s test schema factory and producer-owned boundary.',
+      suggestedBoundary: "Use the test owner's test schema factory and producer-owned boundary.",
       trackingIssue: 'TEST-1',
       removalCondition: 'Test baseline entry is removed.',
     } satisfies (typeof databaseBoundaryBaseline)[number];

--- a/tools/api-database-policy/test/api-database-boundaries.test.ts
+++ b/tools/api-database-policy/test/api-database-boundaries.test.ts
@@ -6,19 +6,6 @@ import {
   reconcileDatabaseBoundaryBaseline,
 } from '../src/api-database-boundaries.js';
 
-function findingFromBaseline(index: number): DatabaseBoundaryFinding {
-  const entry = databaseBoundaryBaseline[index];
-  assert.ok(entry);
-  return {
-    owner: entry.owner,
-    namespace: entry.namespace,
-    file: entry.file,
-    line: entry.line,
-    object: entry.object,
-    rule: entry.rule,
-    suggestedBoundary: entry.suggestedBoundary,
-  };
-}
 describe('database boundary verifier', () => {
   test('keeps the current repository findings as exact, issue-owned baseline entries', async () => {
     const findings = await auditApiDatabaseBoundaries();
@@ -30,15 +17,31 @@ describe('database boundary verifier', () => {
     assert.ok(databaseBoundaryBaseline.every((entry) => !entry.object.includes('*')));
     assert.deepEqual(
       new Set(findings.map((finding) => finding.rule)),
-      new Set(['unprefixed-table']),
+      new Set(),
     );
   });
   test('fails closed when a finding is new or a baseline entry disappears', () => {
-    const known = findingFromBaseline(0);
-    const firstBaseline = databaseBoundaryBaseline[0];
-    const secondBaseline = databaseBoundaryBaseline[1];
-    assert.ok(firstBaseline);
-    assert.ok(secondBaseline);
+    const firstBaseline = {
+      owner: 'test',
+      namespace: 'test',
+      file: 'test.ts',
+      line: 1,
+      object: 'test',
+      rule: 'unprefixed-table',
+      suggestedBoundary: 'Use the test owner\'s test schema factory and producer-owned boundary.',
+      trackingIssue: 'TEST-1',
+      removalCondition: 'Test baseline entry is removed.',
+    } satisfies (typeof databaseBoundaryBaseline)[number];
+    const secondBaseline = {...firstBaseline, line: 2, object: 'test_second'};
+    const known: DatabaseBoundaryFinding = {
+      owner: firstBaseline.owner,
+      namespace: firstBaseline.namespace,
+      file: firstBaseline.file,
+      line: firstBaseline.line,
+      object: firstBaseline.object,
+      rule: firstBaseline.rule,
+      suggestedBoundary: firstBaseline.suggestedBoundary,
+    };
     const disappeared = {...secondBaseline};
     const reconciliation = reconcileDatabaseBoundaryBaseline([known], [firstBaseline, disappeared]);
     assert.deepEqual(reconciliation.knownBaselineFindings, [known]);


### PR DESCRIPTION
The Workspaces root table bypassed the registered database namespace, leaving an exact temporary boundary finding. This updates the migration baseline and schema factory so the physical table is consistently named workspaces_workspaces, then removes the completed baseline entries.

Validation: Workspaces and dependent package checks passed; static verification reports no Workspaces finding. Fresh PostgreSQL catalog verification confirms the renamed table and foreign keys; it still reports four unrelated Agent findings tracked by ENG-1195.

Closes ENG-1196

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the Workspaces root table to workspaces_workspaces and aligned `@shipfox/api-workspaces` with the database namespace policy. Removes boundary exceptions and ships a patch changeset. Closes ENG-1196.

- **Refactors**
  - Updated migration baseline and snapshot; retargeted FKs to workspaces_workspaces.
  - Simplified `pgTable` to always prefix names with `workspaces_`.
  - Test setup truncates workspaces_workspaces.
  - Emptied database boundary baseline and updated policy tests to expect no `unprefixed-table` findings.

<sup>Written for commit 2716a430170184f32038a8aecd342fda12885b2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

