### PR TITLE
Stop Auth tests owning Email Challenges storage

### DIFF
--- a/.changeset/email-owner-testing.md
+++ b/.changeset/email-owner-testing.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-email-challenges": minor
+---
+
+Adds an owner-owned test surface for initializing and resetting Email Challenges storage.

--- a/libs/api/auth/test/globalSetup.ts
+++ b/libs/api/auth/test/globalSetup.ts
@@ -1,5 +1,5 @@
 import './env.js';
-import {emailChallengesModule} from '@shipfox/api-email-challenges';
+import {initializeEmailChallengesForTests} from '@shipfox/api-email-challenges/test';
 import {runMigrations} from '@shipfox/node-drizzle';
 import {closePostgresClient, createPostgresClient} from '@shipfox/node-postgres';
 import {sql} from 'drizzle-orm';
@@ -10,16 +10,9 @@ export async function setup() {
   createPostgresClient();
 
   await runMigrations(db(), migrationsPath, '__drizzle_migrations_auth');
-  const emailChallengesDatabase = emailChallengesModule.database;
-  const emailChallengesMigrations =
-    emailChallengesDatabase && !Array.isArray(emailChallengesDatabase)
-      ? emailChallengesDatabase.migrationsPath
-      : undefined;
-  if (!emailChallengesMigrations)
-    throw new Error('Email challenges module has no database migrations');
-  await runMigrations(db(), emailChallengesMigrations, '__drizzle_migrations_email_challenges');
+  await initializeEmailChallengesForTests();
   await db().execute(
-    sql`TRUNCATE email_challenges_challenges, email_challenges_send_limits, auth_outbox, auth_password_resets, auth_rate_limits, auth_refresh_tokens, auth_users CASCADE`,
+    sql`TRUNCATE auth_outbox, auth_password_resets, auth_rate_limits, auth_refresh_tokens, auth_users CASCADE`,
   );
 
   closeDb();

--- a/libs/api/email-challenges/package.json
+++ b/libs/api/email-challenges/package.json
@@ -28,6 +28,16 @@
         "default": "./dist/index.js"
       }
     },
+    "./test": {
+      "workspace-source": {
+        "types": "./src/test.ts",
+        "default": "./src/test.ts"
+      },
+      "default": {
+        "types": "./dist/test.d.ts",
+        "default": "./dist/test.js"
+      }
+    },
     "./config": {
       "workspace-source": {
         "types": "./src/config.ts",

--- a/libs/api/email-challenges/src/test.ts
+++ b/libs/api/email-challenges/src/test.ts
@@ -1,0 +1,16 @@
+import {initializeModules} from '@shipfox/node-module';
+import {db} from '#db/db.js';
+import {challenges} from '#db/schema/challenges.js';
+import {sendLimits} from '#db/schema/send-limits.js';
+import {emailChallengesModule} from './index.js';
+
+/** Initialize the owner-declared Email Challenges storage for database-backed tests. */
+export async function initializeEmailChallengesForTests(): Promise<void> {
+  await initializeModules({modules: [emailChallengesModule]});
+}
+
+/** Reset Email Challenges storage without exposing its tables to consumers. */
+export async function resetEmailChallengesForTests(): Promise<void> {
+  await db().delete(challenges);
+  await db().delete(sendLimits);
+}

--- a/libs/api/email-challenges/test/globalSetup.ts
+++ b/libs/api/email-challenges/test/globalSetup.ts
@@ -1,13 +1,15 @@
 import './env.js';
-import {runMigrations} from '@shipfox/node-drizzle';
+import {
+  initializeEmailChallengesForTests,
+  resetEmailChallengesForTests,
+} from '@shipfox/api-email-challenges/test';
 import {closePostgresClient, createPostgresClient} from '@shipfox/node-postgres';
-import {sql} from 'drizzle-orm';
-import {closeDb, db} from '#db/db.js';
-import {migrationsPath} from '#db/migrations.js';
+import {closeDb} from '#db/db.js';
+
 export async function setup() {
   createPostgresClient();
-  await runMigrations(db(), migrationsPath, '__drizzle_migrations_email_challenges');
-  await db().execute(sql`TRUNCATE email_challenges_challenges, email_challenges_send_limits`);
+  await initializeEmailChallengesForTests();
+  await resetEmailChallengesForTests();
   closeDb();
   await closePostgresClient();
 }

--- a/tools/api-database-policy/src/api-database-boundaries.ts
+++ b/tools/api-database-policy/src/api-database-boundaries.ts
@@ -182,58 +182,6 @@ function baselineEntry(
 const databaseBoundaryBaseline: readonly DatabaseBoundaryBaselineEntry[] = Object.freeze([
   baselineEntry(
     {
-      owner: 'auth',
-      namespace: 'auth',
-      file: 'libs/api/auth/test/globalSetup.ts',
-      line: 13,
-      object: 'emailChallengesModule.database',
-      rule: 'foreign-database-access',
-      suggestedBoundary: namespaceSuggestion('email-challenges', 'email_challenges'),
-    },
-    'ENG-1198',
-    'Auth tests migrate and clean only Auth-owned storage.',
-  ),
-  baselineEntry(
-    {
-      owner: 'auth',
-      namespace: 'auth',
-      file: 'libs/api/auth/test/globalSetup.ts',
-      line: 20,
-      object: '__drizzle_migrations_email_challenges',
-      rule: 'foreign-migration',
-      suggestedBoundary: namespaceSuggestion('email-challenges', 'email_challenges'),
-    },
-    'ENG-1198',
-    'Auth tests migrate and clean only Auth-owned storage.',
-  ),
-  baselineEntry(
-    {
-      owner: 'auth',
-      namespace: 'auth',
-      file: 'libs/api/auth/test/globalSetup.ts',
-      line: 22,
-      object: 'email_challenges_challenges',
-      rule: 'foreign-raw-sql',
-      suggestedBoundary: namespaceSuggestion('email-challenges', 'email_challenges'),
-    },
-    'ENG-1198',
-    'Auth tests migrate and clean only Auth-owned storage.',
-  ),
-  baselineEntry(
-    {
-      owner: 'auth',
-      namespace: 'auth',
-      file: 'libs/api/auth/test/globalSetup.ts',
-      line: 22,
-      object: 'email_challenges_send_limits',
-      rule: 'foreign-raw-sql',
-      suggestedBoundary: namespaceSuggestion('email-challenges', 'email_challenges'),
-    },
-    'ENG-1198',
-    'Auth tests migrate and clean only Auth-owned storage.',
-  ),
-  baselineEntry(
-    {
       owner: 'workspaces',
       namespace: 'workspaces',
       file: 'libs/api/workspaces/drizzle/0000_initial.sql',

--- a/tools/api-database-policy/test/api-database-boundaries.test.ts
+++ b/tools/api-database-policy/test/api-database-boundaries.test.ts
@@ -30,12 +30,7 @@ describe('database boundary verifier', () => {
     assert.ok(databaseBoundaryBaseline.every((entry) => !entry.object.includes('*')));
     assert.deepEqual(
       new Set(findings.map((finding) => finding.rule)),
-      new Set([
-        'foreign-database-access',
-        'foreign-migration',
-        'foreign-raw-sql',
-        'unprefixed-table',
-      ]),
+      new Set(['unprefixed-table']),
     );
   });
   test('fails closed when a finding is new or a baseline entry disappears', () => {


### PR DESCRIPTION
Auth test setup no longer reads, migrates, names, or truncates Email Challenges storage directly. Email Challenges now owns the test initialization and reset capability, while Auth truncates only Auth-owned tables. The ENG-1198 database-boundary baseline findings are removed.

Validation passed:
- `mise exec -- turbo check type test --filter=@shipfox/api-auth... --filter=@shipfox/api-email-challenges...`
- `mise exec -- pnpm check:api-database-boundaries`
- Auth suite repeated against the same test database

Closes ENG-1198

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move Email Challenges test DB setup behind its owner boundary so Auth no longer migrates or truncates those tables. Add `@shipfox/api-email-challenges/test` with init/reset helpers, adopt it in both suites, and remove the ENG-1198 baseline (closes ENG-1198).

- **Refactors**
  - Auth tests call `initializeEmailChallengesForTests` and truncate only Auth tables.
  - Email Challenges exposes `initializeEmailChallengesForTests` and `resetEmailChallengesForTests` via `@shipfox/api-email-challenges/test`; both suites use them.
  - Updated database policy baseline and rule inventory after removing ENG-1198 findings.

<sup>Written for commit eefacf6d1974fb6ace208c7cbbd3260143d406c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

