### PR TITLE
[biome] Stabilize packed artifact test timeout

### DIFF
--- a/tools/biome/test/client-architecture-external.test.ts
+++ b/tools/biome/test/client-architecture-external.test.ts
@@ -10,7 +10,7 @@ const execFileAsync = promisify(execFile);
 const tarEntryLinePattern = /\r?\n/u;
 const testDirectory = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(testDirectory, '..');
-const EXTERNAL_CONSUMER_TEST_TIMEOUT_MS = 30_000;
+const PACKED_PACKAGE_TEST_TIMEOUT_MS = 30_000;
 const fixtureTemplate = resolve(
   packageRoot,
   'plugins/client-architecture/fixtures/external-consumer',
@@ -113,24 +113,30 @@ function escapedRegExp(value: string): string {
 }
 
 describe('packed client-architecture Biome plugins', () => {
-  test('includes every supported plugin and its usage documentation', async () => {
-    const temporaryRoot = await mkdtemp(join(tmpdir(), 'shipfox-biome-pack-'));
-    try {
-      const tarball = await packBiome(temporaryRoot);
-      const entries = await tarEntries(tarball);
-      for (const path of publishedPluginFiles) {
-        assert.ok(entries.includes(`package/${path}`), `Packed artifact is missing ${path}`);
+  test(
+    'includes every supported plugin and its usage documentation',
+    async () => {
+      const temporaryRoot = await mkdtemp(join(tmpdir(), 'shipfox-biome-pack-'));
+      try {
+        const tarball = await packBiome(temporaryRoot);
+        const entries = await tarEntries(tarball);
+        for (const path of publishedPluginFiles) {
+          assert.ok(entries.includes(`package/${path}`), `Packed artifact is missing ${path}`);
+        }
+        assert.ok(entries.includes('package/plugins/client-architecture/README.md'));
+        assert.ok(entries.includes('package/plugins/database-boundaries/README.md'));
+        assert.ok(
+          !entries.some((entry) =>
+            entry.startsWith('package/plugins/client-architecture/fixtures/'),
+          ),
+          'Packed artifact must not publish repository fixtures',
+        );
+      } finally {
+        await rm(temporaryRoot, {force: true, recursive: true});
       }
-      assert.ok(entries.includes('package/plugins/client-architecture/README.md'));
-      assert.ok(entries.includes('package/plugins/database-boundaries/README.md'));
-      assert.ok(
-        !entries.some((entry) => entry.startsWith('package/plugins/client-architecture/fixtures/')),
-        'Packed artifact must not publish repository fixtures',
-      );
-    } finally {
-      await rm(temporaryRoot, {force: true, recursive: true});
-    }
-  });
+    },
+    PACKED_PACKAGE_TEST_TIMEOUT_MS,
+  );
 
   test(
     'runs from an installed package in an external repository root',
@@ -176,6 +182,6 @@ describe('packed client-architecture Biome plugins', () => {
         await rm(temporaryRoot, {force: true, recursive: true});
       }
     },
-    EXTERNAL_CONSUMER_TEST_TIMEOUT_MS,
+    PACKED_PACKAGE_TEST_TIMEOUT_MS,
   );
 });


### PR DESCRIPTION
The packed artifact manifest test invokes real `npm pack` and `tar` subprocesses but still used Vitest's five-second unit-test deadline. Under CI contention, Vitest stopped it at 5.015 seconds before any packaging assertion failed, while the sibling installed-package test already had a 30-second integration timeout.

Apply the shared packed-package timeout to both subprocess-backed tests so runner variance does not fail valid packaging checks.

Validated with the full `@shipfox/biome` suite, its filtered test and type dependency closures, Biome check, and 10 repeated runs of the affected test with the global timeout forced to 1 ms.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes packed artifact tests by using a shared 30s timeout for both subprocess-backed checks that run `npm pack`/`tar`, preventing flaky failures under CI load.

- **Bug Fixes**
  - Introduced `PACKED_PACKAGE_TEST_TIMEOUT_MS` (30s) and applied it to the packed-manifest and external-consumer tests.
  - Avoids `Vitest`’s 5s default killing valid packaging checks in `@shipfox/biome`.

<sup>Written for commit d53ec03e27bf79ad0d5776a3d6b49cd94410c3e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

