### PR TITLE
[biome] Reuse packed artifact across validation tests

### DIFF
--- a/tools/biome/test/client-architecture-external.test.ts
+++ b/tools/biome/test/client-architecture-external.test.ts
@@ -65,6 +65,14 @@ type CommandFailure = {
   stdout?: string;
 };
 
+type PackedBiomeArtifact = {
+  entries: string[];
+  tarball: string;
+  temporaryRoot: string;
+};
+
+let packedBiomeArtifact: PackedBiomeArtifact | undefined;
+
 async function packBiome(destination: string): Promise<string> {
   const {stdout} = await execFileAsync(
     'npm',
@@ -113,37 +121,46 @@ function escapedRegExp(value: string): string {
 }
 
 describe('packed client-architecture Biome plugins', () => {
-  test(
-    'includes every supported plugin and its usage documentation',
-    async () => {
-      const temporaryRoot = await mkdtemp(join(tmpdir(), 'shipfox-biome-pack-'));
-      try {
-        const tarball = await packBiome(temporaryRoot);
-        const entries = await tarEntries(tarball);
-        for (const path of publishedPluginFiles) {
-          assert.ok(entries.includes(`package/${path}`), `Packed artifact is missing ${path}`);
-        }
-        assert.ok(entries.includes('package/plugins/client-architecture/README.md'));
-        assert.ok(entries.includes('package/plugins/database-boundaries/README.md'));
-        assert.ok(
-          !entries.some((entry) =>
-            entry.startsWith('package/plugins/client-architecture/fixtures/'),
-          ),
-          'Packed artifact must not publish repository fixtures',
-        );
-      } finally {
-        await rm(temporaryRoot, {force: true, recursive: true});
-      }
-    },
-    PACKED_PACKAGE_TEST_TIMEOUT_MS,
-  );
+  beforeAll(async () => {
+    const temporaryRoot = await mkdtemp(join(tmpdir(), 'shipfox-biome-pack-'));
+    try {
+      const tarball = await packBiome(temporaryRoot);
+      const entries = await tarEntries(tarball);
+      packedBiomeArtifact = {entries, tarball, temporaryRoot};
+    } catch (error) {
+      await rm(temporaryRoot, {force: true, recursive: true});
+      throw error;
+    }
+  }, PACKED_PACKAGE_TEST_TIMEOUT_MS);
+
+  afterAll(async () => {
+    if (packedBiomeArtifact) {
+      await rm(packedBiomeArtifact.temporaryRoot, {force: true, recursive: true});
+    }
+  });
+
+  test('includes every supported plugin and its usage documentation', () => {
+    assert.ok(packedBiomeArtifact, 'Packed Biome artifact setup did not complete');
+    const {entries} = packedBiomeArtifact;
+
+    for (const path of publishedPluginFiles) {
+      assert.ok(entries.includes(`package/${path}`), `Packed artifact is missing ${path}`);
+    }
+    assert.ok(entries.includes('package/plugins/client-architecture/README.md'));
+    assert.ok(entries.includes('package/plugins/database-boundaries/README.md'));
+    assert.ok(
+      !entries.some((entry) => entry.startsWith('package/plugins/client-architecture/fixtures/')),
+      'Packed artifact must not publish repository fixtures',
+    );
+  });
 
   test(
     'runs from an installed package in an external repository root',
     async () => {
+      assert.ok(packedBiomeArtifact, 'Packed Biome artifact setup did not complete');
+      const {tarball} = packedBiomeArtifact;
       const temporaryRoot = await mkdtemp(join(tmpdir(), 'shipfox-biome-external-'));
       try {
-        const tarball = await packBiome(temporaryRoot);
         const externalRoot = join(temporaryRoot, 'consumer');
         await cp(fixtureTemplate, externalRoot, {recursive: true});
         await installPackedBiome(externalRoot, tarball);


### PR DESCRIPTION
The packed Biome integration tests still invoke `npm pack` independently. Even after #1012 gave both calls an integration-test timeout, that duplicates the variable-latency packaging setup and makes both tests pay for CI process and filesystem contention.

This change builds the package once in `beforeAll`, records its tar entries, and reuses the same tarball for the external-consumer validation. Packaging keeps the explicit 30-second integration budget, while suite cleanup removes the shared temporary artifact.

Validated with `turbo check test --filter=@shipfox/biome...`, ten consecutive full-suite runs, and six concurrent focused-suite runs.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pack the Biome package once during test suite setup and reuse the tarball across validation tests. This removes duplicate `npm pack` runs, reduces CI contention, and stabilizes timeouts.

- **Refactors**
  - Add `beforeAll` to build once (keeps the 30s integration timeout).
  - Store tar entries and tarball path; tests use these instead of calling `npm pack`.
  - Add `afterAll` to clean up the shared temp directory.

<sup>Written for commit 8838d367b827696695e6bbf367f53bd7ca7ff12c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

