### PR TITLE
[Vite/Vitest] Share workspace-source package resolution

### DIFF
--- a/.changeset/fuzzy-pumas-resolve.md
+++ b/.changeset/fuzzy-pumas-resolve.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/vite": patch
+"@shipfox/vitest": patch
+---
+
+Shares workspace-source package-import resolution between the Vite and Vitest tooling wrappers.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -447,6 +447,9 @@ catalogs:
     remark-gfm:
       specifier: ^4.0.1
       version: 4.0.1
+    resolve.exports:
+      specifier: ^2.0.3
+      version: 2.0.3
     shiki:
       specifier: ^4.0.0
       version: 4.3.1
@@ -7917,6 +7920,9 @@ importers:
       '@shipfox/tool-utils':
         specifier: workspace:*
         version: link:../utils
+      resolve.exports:
+        specifier: 'catalog:'
+        version: 2.0.3
       tsx:
         specifier: 'catalog:'
         version: 4.22.4
@@ -7933,12 +7939,18 @@ importers:
       '@shipfox/typescript':
         specifier: workspace:*
         version: link:../typescript
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   tools/vitest:
     dependencies:
       '@shipfox/tool-utils':
         specifier: workspace:*
         version: link:../utils
+      '@shipfox/vite':
+        specifier: workspace:*
+        version: link:../vite
       vite:
         specifier: 'catalog:'
         version: 8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -7955,6 +7967,14 @@ importers:
       '@shipfox/typescript':
         specifier: workspace:*
         version: link:../typescript
+
+  tools/vitest/test/external-fixture/consumer: {}
+
+  tools/vitest/test/external-fixture/default-consumer: {}
+
+  tools/vitest/test/external-fixture/dist-only-package: {}
+
+  tools/vitest/test/external-fixture/workspace-package: {}
 
 packages:
 
@@ -15974,6 +15994,10 @@ packages:
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  resolve.exports@2.0.3:
+    resolution: {integrity: sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==}
+    engines: {node: '>=10'}
 
   resolve@1.22.12:
     resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
@@ -26288,6 +26312,8 @@ snapshots:
   resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  resolve.exports@2.0.3: {}
 
   resolve@1.22.12:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -152,6 +152,7 @@ catalog:
   "react-markdown": "^9.1.0"
   "rehype-sanitize": "^6.0.0"
   "remark-gfm": "^4.0.1"
+  "resolve.exports": "^2.0.3"
   "shiki": "^4.0.0"
   "simple-icons": "^14.0.0"
   "sonner": "^2.0.7"

--- a/tools/vite/README.md
+++ b/tools/vite/README.md
@@ -9,6 +9,7 @@ Vite defaults and CLI wrappers for Shipfox frontend packages. It adds TypeScript
 - **`vite-dev`**: Runs the project-local Vite dev server.
 - **`vite-build`**: Runs `vite build --outDir dist`.
 - **`@shipfox/vite/client`**: Type entry that re-exports `vite/client`.
+- **`@shipfox/vite/workspace-source`**: Shared resolver for package-local source imports when the `workspace-source` condition is active.
 
 ## Installation
 

--- a/tools/vite/package.json
+++ b/tools/vite/package.json
@@ -20,21 +20,34 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
-    "./client": "./client.d.ts"
+    "./client": "./client.d.ts",
+    "./workspace-source": {
+      "workspace-source": {
+        "types": "./src/workspace-source.ts",
+        "default": "./src/workspace-source.ts"
+      },
+      "default": {
+        "types": "./dist/workspace-source.d.ts",
+        "default": "./dist/workspace-source.js"
+      }
+    }
   },
   "scripts": {
     "build": "shipfox-swc",
+    "test": "vitest run",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
     "@shipfox/tool-utils": "workspace:*",
+    "resolve.exports": "catalog:",
     "tsx": "catalog:",
     "vite": "catalog:"
   },
   "devDependencies": {
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
-    "@shipfox/typescript": "workspace:*"
+    "@shipfox/typescript": "workspace:*",
+    "vitest": "catalog:"
   }
 }

--- a/tools/vite/src/index.test.ts
+++ b/tools/vite/src/index.test.ts
@@ -1,0 +1,155 @@
+import {mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {type ConfigEnv, createServer, type UserConfig} from 'vite';
+import {afterEach, describe, expect, it} from 'vitest';
+import {defineConfig, type UserConfigExport} from './index.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, {force: true, recursive: true});
+  }
+});
+
+function resolveConfig(
+  configExport: UserConfigExport,
+  command: ConfigEnv['command'],
+): UserConfig | Promise<UserConfig> {
+  if (typeof configExport === 'function') {
+    return configExport({command, mode: command === 'serve' ? 'development' : 'production'});
+  }
+  return configExport;
+}
+
+function pluginNames(config: UserConfig): string[] {
+  return (config.plugins ?? []).flatMap((plugin) => {
+    if (plugin && typeof plugin === 'object' && 'name' in plugin) {
+      const name = plugin.name;
+      return typeof name === 'string' ? [name] : [];
+    }
+    return [];
+  });
+}
+
+describe('@shipfox/vite configuration', () => {
+  it('preserves caller plugins and installs the resolver only for serve', async () => {
+    const callerPlugin = {name: 'caller-plugin'};
+    const serveConfig = await resolveConfig(defineConfig({plugins: [callerPlugin]}), 'serve');
+    const buildConfig = await resolveConfig(defineConfig({plugins: [callerPlugin]}), 'build');
+
+    expect(pluginNames(serveConfig)).toEqual([
+      'caller-plugin',
+      'shipfox:workspace-source-resolver',
+    ]);
+    expect(pluginNames(buildConfig)).toEqual(['caller-plugin']);
+  });
+
+  it('does not reactivate the resolver when callers remove the source condition', async () => {
+    const config = await resolveConfig(
+      defineConfig({
+        resolve: {conditions: ['default']},
+        ssr: {resolve: {conditions: ['default']}},
+      }),
+      'serve',
+    );
+
+    expect(pluginNames(config)).toEqual([]);
+  });
+
+  it('does not install the resolver for build even when source conditions are explicit', async () => {
+    const config = await resolveConfig(
+      defineConfig({resolve: {conditions: ['workspace-source']}}),
+      'build',
+    );
+
+    expect(pluginNames(config)).toEqual([]);
+  });
+
+  it('resolves a source package import through Vite during serve', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'shipfox-vite-workspace-source-'));
+    temporaryDirectories.push(directory);
+    mkdirSync(join(directory, 'src', 'db'), {recursive: true});
+    writeFileSync(
+      join(directory, 'package.json'),
+      JSON.stringify({
+        name: 'fixture-vite-package',
+        type: 'module',
+        imports: {
+          '#*': {
+            'workspace-source': './src/*',
+            default: './dist/*',
+          },
+        },
+      }),
+    );
+    const importer = join(directory, 'src/index.ts');
+    writeFileSync(importer, '');
+    writeFileSync(join(directory, 'src/db/db.ts'), '');
+
+    const config = await resolveConfig(
+      defineConfig({logLevel: 'silent', root: directory}),
+      'serve',
+    );
+    const server = await createServer({...config, configFile: false});
+    try {
+      const resolved = await server.pluginContainer.resolveId('#db/db.js', importer);
+
+      expect(resolved?.id).toBe(realpathSync(join(directory, 'src/db/db.ts')));
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('resolves a default package export to compiled output during serve', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'shipfox-vite-workspace-default-'));
+    temporaryDirectories.push(directory);
+    const packageDirectory = join(directory, 'workspace-package');
+    mkdirSync(join(packageDirectory, 'dist'), {recursive: true});
+    mkdirSync(join(directory, 'src'), {recursive: true});
+    mkdirSync(join(directory, 'node_modules'), {recursive: true});
+    writeFileSync(
+      join(packageDirectory, 'package.json'),
+      JSON.stringify({
+        name: 'fixture-vite-default-package',
+        type: 'module',
+        exports: {
+          '.': {
+            'workspace-source': './src/index.ts',
+            default: './dist/index.js',
+          },
+        },
+      }),
+    );
+    writeFileSync(join(packageDirectory, 'dist/index.js'), '');
+    symlinkSync(
+      packageDirectory,
+      join(directory, 'node_modules', 'fixture-vite-default-package'),
+      'dir',
+    );
+    const importer = join(directory, 'src/index.ts');
+    writeFileSync(importer, '');
+
+    const config = await resolveConfig(
+      defineConfig({
+        logLevel: 'silent',
+        resolve: {conditions: ['default']},
+        root: directory,
+        ssr: {resolve: {conditions: ['default']}},
+      }),
+      'serve',
+    );
+    const server = await createServer({...config, configFile: false});
+    try {
+      const resolved = await server.pluginContainer.resolveId(
+        'fixture-vite-default-package',
+        importer,
+      );
+
+      expect(resolved?.id).toBe(realpathSync(join(packageDirectory, 'dist/index.js')));
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/tools/vite/src/index.ts
+++ b/tools/vite/src/index.ts
@@ -1,12 +1,13 @@
 import {
   type ConfigEnv,
+  defaultClientConditions,
+  defaultServerConditions,
   type UserConfig,
   type UserConfigExport,
   type UserConfigFnObject,
-  defaultClientConditions,
-  defaultServerConditions,
   defineConfig as viteDefinedConfig,
 } from 'vite';
+import {workspaceSourceResolver} from './workspace-source.js';
 
 export type {ConfigEnv, UserConfig, UserConfigExport, UserConfigFnObject} from 'vite';
 export {loadEnv} from 'vite';
@@ -14,17 +15,33 @@ export {loadEnv} from 'vite';
 export function defineConfig(configOrFn?: UserConfig | UserConfigFnObject): UserConfigExport {
   const mergeConfig = (config: UserConfig | undefined, command: ConfigEnv['command']) => {
     const sourceConditions = command === 'serve' ? ['workspace-source'] : [];
+    const resolveConditions = config?.resolve?.conditions ?? [
+      ...defaultClientConditions,
+      ...sourceConditions,
+    ];
+    const ssrResolveConditions = config?.ssr?.resolve?.conditions ?? [
+      ...defaultServerConditions,
+      ...sourceConditions,
+    ];
     return {
       ...config,
+      plugins: [
+        ...(config?.plugins ?? []),
+        ...(command === 'serve' &&
+        (resolveConditions.includes('workspace-source') ||
+          ssrResolveConditions.includes('workspace-source'))
+          ? [workspaceSourceResolver()]
+          : []),
+      ],
       resolve: {
         tsconfigPaths: true,
-        conditions: [...defaultClientConditions, ...sourceConditions],
+        conditions: resolveConditions,
         ...config?.resolve,
       },
       ssr: {
         ...config?.ssr,
         resolve: {
-          conditions: [...defaultServerConditions, ...sourceConditions],
+          conditions: ssrResolveConditions,
           ...config?.ssr?.resolve,
         },
       },

--- a/tools/vite/src/workspace-source.test.ts
+++ b/tools/vite/src/workspace-source.test.ts
@@ -1,0 +1,229 @@
+import {mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {basename, join, resolve as resolvePath} from 'node:path';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+import {workspaceSourceResolver} from './workspace-source.js';
+
+type ResolverContext = {
+  environment: {
+    config: {
+      resolve: {conditions: string[]};
+      ssr: {resolve: {conditions: string[]}};
+    };
+  };
+  resolve: ReturnType<typeof vi.fn>;
+};
+
+type ResolverHook = (
+  this: ResolverContext,
+  id: string,
+  importer: string | undefined,
+  options: {isEntry: boolean; ssr?: boolean},
+) => unknown;
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, {force: true, recursive: true});
+  }
+});
+
+function createFixture(
+  imports: Record<string, unknown>,
+  files: Record<string, string>,
+): {directory: string; importer: string} {
+  const directory = mkdtempSync(join(tmpdir(), 'shipfox-vite-workspace-source-'));
+  temporaryDirectories.push(directory);
+  writeFileSync(
+    join(directory, 'package.json'),
+    JSON.stringify({name: 'fixture-package', type: 'module', imports}),
+  );
+
+  for (const [file, contents] of Object.entries(files)) {
+    const path = join(directory, file);
+    mkdirSync(resolvePath(path, '..'), {recursive: true});
+    writeFileSync(path, contents);
+  }
+
+  return {directory, importer: join(directory, 'src/index.ts')};
+}
+
+function createContext(conditions = ['workspace-source']): ResolverContext {
+  return {
+    environment: {
+      config: {
+        resolve: {conditions},
+        ssr: {resolve: {conditions}},
+      },
+    },
+    resolve: vi.fn(async (id: string) => ({id})),
+  };
+}
+
+function resolveImport(
+  context: ResolverContext,
+  id: string,
+  importer: string,
+  ssr = false,
+): Promise<unknown> {
+  const plugin = workspaceSourceResolver();
+  const resolveId = plugin.resolveId as unknown as ResolverHook;
+  return Promise.resolve(resolveId.call(context, id, importer, {isEntry: false, ssr}));
+}
+
+describe('workspaceSourceResolver', () => {
+  it('resolves exact and wildcard package imports through source targets', async () => {
+    const fixture = createFixture(
+      {
+        '#exact': {
+          'workspace-source': './src/exact.ts',
+          default: './dist/exact.js',
+        },
+        '#wild/*': {
+          'workspace-source': './src/*',
+          default: './dist/*',
+        },
+      },
+      {
+        'src/index.ts': '',
+        'src/exact.ts': '',
+        'src/nested/value.ts': '',
+      },
+    );
+    const context = createContext();
+
+    await resolveImport(context, '#exact', fixture.importer);
+    await resolveImport(context, '#wild/nested/value.js', fixture.importer);
+
+    expect(context.resolve).toHaveBeenNthCalledWith(
+      1,
+      join(fixture.directory, 'src/exact.ts'),
+      fixture.importer,
+      {skipSelf: true},
+    );
+    expect(context.resolve).toHaveBeenNthCalledWith(
+      2,
+      join(fixture.directory, 'src/nested/value.js'),
+      fixture.importer,
+      {skipSelf: true},
+    );
+  });
+
+  it('preserves nested defaults inside the workspace-source branch', async () => {
+    const fixture = createFixture(
+      {
+        '#nested': {
+          'workspace-source': {
+            browser: './src/nested.js',
+            default: './src/nested.js',
+          },
+          default: './dist/nested.js',
+        },
+      },
+      {
+        'src/index.ts': '',
+        'src/nested.ts': '',
+      },
+    );
+    const context = createContext();
+
+    await resolveImport(context, '#nested', fixture.importer);
+
+    expect(context.resolve).toHaveBeenCalledWith(
+      join(fixture.directory, 'src/nested.js'),
+      fixture.importer,
+      {skipSelf: true},
+    );
+  });
+
+  it('keeps direct package-local test mappings and postfixes', async () => {
+    const fixture = createFixture(
+      {'#test/*': './test/*'},
+      {
+        'src/index.ts': '',
+        'test/helper.ts': '',
+      },
+    );
+    const context = createContext();
+
+    await resolveImport(context, '#test/helper.js?import#fragment', fixture.importer);
+
+    expect(context.resolve).toHaveBeenCalledWith(
+      `${join(fixture.directory, 'test/helper.js')}?import#fragment`,
+      fixture.importer,
+      {skipSelf: true},
+    );
+  });
+
+  it('does not claim imports without workspace-source or with dist-only targets', async () => {
+    const fixture = createFixture(
+      {
+        '#source/*': {
+          'workspace-source': './src/*',
+          default: './dist/*',
+        },
+        '#dist/*': {
+          default: './dist/*',
+        },
+      },
+      {
+        'src/index.ts': '',
+        'dist/only.js': '',
+      },
+    );
+    const disabledContext = createContext(['default']);
+    const enabledContext = createContext();
+
+    await resolveImport(disabledContext, '#source/missing.js', fixture.importer);
+    await resolveImport(enabledContext, '#dist/only.js', fixture.importer);
+
+    expect(disabledContext.resolve).not.toHaveBeenCalled();
+    expect(enabledContext.resolve).not.toHaveBeenCalled();
+  });
+
+  it('rejects targets outside the owning package', async () => {
+    const fixture = createFixture(
+      {'#outside': {'workspace-source': '../outside.ts'}},
+      {
+        'src/index.ts': '',
+      },
+    );
+    const outsideDirectory = mkdtempSync(join(tmpdir(), 'shipfox-vite-outside-'));
+    temporaryDirectories.push(outsideDirectory);
+    writeFileSync(join(outsideDirectory, 'outside.ts'), '');
+    const outsideTarget = `../${basename(outsideDirectory)}/outside.ts`;
+    const outsidePackage = JSON.parse(
+      readFileSync(join(fixture.directory, 'package.json'), 'utf8'),
+    ) as {imports: Record<string, unknown>; [key: string]: unknown};
+    outsidePackage.imports['#outside'] = {'workspace-source': outsideTarget};
+    writeFileSync(join(fixture.directory, 'package.json'), JSON.stringify(outsidePackage));
+    const context = createContext();
+
+    await resolveImport(context, '#outside', fixture.importer);
+
+    expect(context.resolve).not.toHaveBeenCalled();
+  });
+
+  it('finds the owning manifest through a package-manager-style symlink path', async () => {
+    const fixture = createFixture(
+      {'#*': {'workspace-source': './src/*', default: './dist/*'}},
+      {
+        'src/index.ts': '',
+        'src/db.ts': '',
+      },
+    );
+    const symlinkDirectory = join(fixture.directory, 'node_modules', 'fixture-package');
+    mkdirSync(resolvePath(symlinkDirectory, '..'), {recursive: true});
+    symlinkSync(fixture.directory, symlinkDirectory, 'dir');
+    const context = createContext();
+
+    await resolveImport(context, '#db.js', join(symlinkDirectory, 'src/index.ts'));
+
+    expect(context.resolve).toHaveBeenCalledWith(
+      join(symlinkDirectory, 'src/db.js'),
+      join(symlinkDirectory, 'src/index.ts'),
+      {skipSelf: true},
+    );
+  });
+});

--- a/tools/vite/src/workspace-source.ts
+++ b/tools/vite/src/workspace-source.ts
@@ -1,0 +1,233 @@
+import {readFileSync, realpathSync, statSync} from 'node:fs';
+import {dirname, extname, isAbsolute, join, relative, resolve as resolvePath} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {type Package, imports as resolvePackageImports} from 'resolve.exports';
+import type {Plugin} from 'vite';
+
+const workspaceSourceCondition = 'workspace-source';
+const packageImportPrefix = '#';
+const packagePostfixPattern = /[?#]/;
+
+type PackageManifest = Package & {
+  name: string;
+};
+
+type PackageInfo = {
+  directory: string;
+  manifest: PackageManifest;
+};
+
+function stripPostfix(value: string): string {
+  const postfixStart = value.search(packagePostfixPattern);
+  return postfixStart === -1 ? value : value.slice(0, postfixStart);
+}
+
+function splitPackageImport(id: string): {specifier: string; postfix: string} {
+  const postfixStart = id.slice(1).search(packagePostfixPattern);
+  if (postfixStart === -1) return {specifier: id, postfix: ''};
+
+  const absolutePostfixStart = postfixStart + 1;
+  return {
+    specifier: id.slice(0, absolutePostfixStart),
+    postfix: id.slice(absolutePostfixStart),
+  };
+}
+
+function toImporterPath(importer: string): string {
+  const cleanImporter = stripPostfix(importer);
+  if (cleanImporter.startsWith('file://')) return fileURLToPath(cleanImporter);
+  if (cleanImporter.startsWith('/@fs/')) return cleanImporter.slice('/@fs'.length);
+  return cleanImporter;
+}
+
+function removeDefaultBranches(value: unknown, preserveDefaults = false): unknown {
+  if (Array.isArray(value)) {
+    return value.map((nestedValue) => removeDefaultBranches(nestedValue, preserveDefaults));
+  }
+  if (value === null || typeof value !== 'object') return value;
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, nestedValue]) => [
+      key,
+      key === 'default' && !preserveDefaults
+        ? null
+        : removeDefaultBranches(nestedValue, preserveDefaults || key === workspaceSourceCondition),
+    ]),
+  );
+}
+
+function readPackageInfo(
+  packageJsonPath: string,
+  packageCache: Map<string, PackageInfo | null>,
+): PackageInfo | null {
+  const cached = packageCache.get(packageJsonPath);
+  if (cached !== undefined) return cached;
+
+  let packageInfo: PackageInfo | null = null;
+  try {
+    const manifest = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as PackageManifest;
+    if (typeof manifest.name === 'string') {
+      packageInfo = {
+        directory: dirname(packageJsonPath),
+        manifest,
+      };
+    }
+  } catch {
+    packageInfo = null;
+  }
+
+  packageCache.set(packageJsonPath, packageInfo);
+  return packageInfo;
+}
+
+function findOwningPackage(
+  importer: string,
+  packageCache: Map<string, PackageInfo | null>,
+  ownershipCache: Map<string, PackageInfo | null>,
+): PackageInfo | null {
+  const importerPath = toImporterPath(importer);
+  const cached = ownershipCache.get(importerPath);
+  if (cached !== undefined) return cached;
+  if (!isAbsolute(importerPath)) {
+    ownershipCache.set(importerPath, null);
+    return null;
+  }
+
+  let directory = dirname(importerPath);
+  while (true) {
+    const packageInfo = readPackageInfo(join(directory, 'package.json'), packageCache);
+    if (packageInfo) {
+      ownershipCache.set(importerPath, packageInfo);
+      return packageInfo;
+    }
+
+    const parentDirectory = dirname(directory);
+    if (parentDirectory === directory) break;
+    directory = parentDirectory;
+  }
+
+  ownershipCache.set(importerPath, null);
+  return null;
+}
+
+function isFile(path: string): boolean {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function sourceCandidates(path: string): string[] {
+  const extension = extname(path);
+  if (extension === '.js') return [path, `${path.slice(0, -3)}.ts`, `${path.slice(0, -3)}.tsx`];
+  if (extension === '.mjs') return [path, `${path.slice(0, -4)}.mts`];
+  if (extension === '.cjs') return [path, `${path.slice(0, -4)}.cts`];
+  return [path];
+}
+
+function isLexicallyWithinDirectory(directory: string, path: string): boolean {
+  const relativePath = relative(directory, path);
+  return relativePath === '' || (!relativePath.startsWith('..') && !isAbsolute(relativePath));
+}
+
+function isWithinDirectory(directory: string, path: string): boolean {
+  let directoryPath: string;
+  let candidatePath: string;
+  try {
+    directoryPath = realpathSync(directory);
+    candidatePath = realpathSync(path);
+  } catch {
+    return false;
+  }
+
+  const relativePath = relative(directoryPath, candidatePath);
+  return relativePath === '' || (!relativePath.startsWith('..') && !isAbsolute(relativePath));
+}
+
+function isDistTarget(packageDirectory: string, target: string): boolean {
+  const relativeTarget = relative(packageDirectory, target);
+  return relativeTarget === 'dist' || relativeTarget.startsWith(`dist${'/'}`);
+}
+
+function resolveSourceTarget(
+  packageInfo: PackageInfo,
+  specifier: string,
+  conditions: readonly string[],
+): string | undefined {
+  const imports = packageInfo.manifest.imports;
+  if (!imports) return undefined;
+
+  const sourceManifest = {
+    ...packageInfo.manifest,
+    imports: removeDefaultBranches(imports) as Package['imports'],
+  };
+
+  let mappedTargets: string[] | undefined;
+  try {
+    const resolvedTargets = resolvePackageImports(sourceManifest, specifier, {
+      conditions,
+      unsafe: true,
+    });
+    if (resolvedTargets) mappedTargets = resolvedTargets;
+  } catch {
+    return undefined;
+  }
+
+  for (const mappedTarget of mappedTargets ?? []) {
+    if (!mappedTarget.startsWith('./')) continue;
+
+    const absoluteTarget = resolvePath(packageInfo.directory, mappedTarget);
+    if (!isLexicallyWithinDirectory(packageInfo.directory, absoluteTarget)) continue;
+    if (isDistTarget(packageInfo.directory, absoluteTarget)) continue;
+
+    for (const candidate of sourceCandidates(absoluteTarget)) {
+      if (!isFile(candidate)) continue;
+      if (!isWithinDirectory(packageInfo.directory, candidate)) continue;
+      return absoluteTarget;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Composes package-import maps with Vite's filesystem resolver for workspace source.
+ * The plugin is intentionally inert unless the active environment opted into the
+ * repository's `workspace-source` condition.
+ */
+export function workspaceSourceResolver(): Plugin {
+  const packageCache = new Map<string, PackageInfo | null>();
+  const ownershipCache = new Map<string, PackageInfo | null>();
+
+  return {
+    name: 'shipfox:workspace-source-resolver',
+    enforce: 'pre',
+    resolveId(id, importer, options) {
+      if (!importer || !id.startsWith(packageImportPrefix)) return;
+
+      const conditions = options.ssr
+        ? (this.environment.config.ssr?.resolve?.conditions ?? [])
+        : (this.environment.config.resolve?.conditions ?? []);
+      if (!conditions.includes(workspaceSourceCondition)) return;
+
+      const effectiveConditions = conditions.map((condition) =>
+        condition === 'development|production'
+          ? this.environment.config.isProduction
+            ? 'production'
+            : 'development'
+          : condition,
+      );
+      effectiveConditions.push(options.kind === 'require-call' ? 'require' : 'import');
+
+      const packageInfo = findOwningPackage(importer, packageCache, ownershipCache);
+      if (!packageInfo) return;
+
+      const {specifier, postfix} = splitPackageImport(id);
+      const mappedTarget = resolveSourceTarget(packageInfo, specifier, effectiveConditions);
+      if (!mappedTarget) return;
+
+      return this.resolve(`${mappedTarget}${postfix}`, importer, {skipSelf: true});
+    },
+  };
+}

--- a/tools/vite/src/workspace-source.ts
+++ b/tools/vite/src/workspace-source.ts
@@ -1,5 +1,5 @@
 import {readFileSync, realpathSync, statSync} from 'node:fs';
-import {dirname, extname, isAbsolute, join, relative, resolve as resolvePath} from 'node:path';
+import {dirname, extname, isAbsolute, join, relative, resolve as resolvePath, sep} from 'node:path';
 import {fileURLToPath} from 'node:url';
 import {type Package, imports as resolvePackageImports} from 'resolve.exports';
 import type {Plugin} from 'vite';
@@ -147,7 +147,7 @@ function isWithinDirectory(directory: string, path: string): boolean {
 
 function isDistTarget(packageDirectory: string, target: string): boolean {
   const relativeTarget = relative(packageDirectory, target);
-  return relativeTarget === 'dist' || relativeTarget.startsWith(`dist${'/'}`);
+  return relativeTarget === 'dist' || relativeTarget.startsWith(`dist${sep}`);
 }
 
 function resolveSourceTarget(

--- a/tools/vite/vitest.config.ts
+++ b/tools/vite/vitest.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/tools/vitest/package.json
+++ b/tools/vitest/package.json
@@ -37,11 +37,13 @@
   },
   "scripts": {
     "build": "shipfox-swc",
+    "test": "vitest run",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
     "@shipfox/tool-utils": "workspace:*",
+    "@shipfox/vite": "workspace:*",
     "vite": "catalog:",
     "vitest": "catalog:"
   },

--- a/tools/vitest/src/config.test.ts
+++ b/tools/vitest/src/config.test.ts
@@ -1,0 +1,131 @@
+import {execFileSync} from 'node:child_process';
+import {cpSync, mkdirSync, mkdtempSync, rmSync, symlinkSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {describe, expect, it} from 'vitest';
+import {defineConfig, defineProject} from './config.js';
+
+const workspaceSourcePluginName = 'shipfox:workspace-source-resolver';
+
+function pluginNames(config: {plugins?: unknown[]}): string[] {
+  return (config.plugins ?? []).flatMap((plugin) => {
+    if (plugin && typeof plugin === 'object' && 'name' in plugin) {
+      const name = plugin.name;
+      return typeof name === 'string' ? [name] : [];
+    }
+    return [];
+  });
+}
+
+function linkToolingPackages(consumerDirectory: string): void {
+  mkdirSync(join(consumerDirectory, 'node_modules', '@shipfox'), {recursive: true});
+  symlinkSync(
+    fileURLToPath(new URL('../', import.meta.url)),
+    join(consumerDirectory, 'node_modules', '@shipfox', 'vitest'),
+    'dir',
+  );
+  symlinkSync(
+    fileURLToPath(new URL('../../vite/', import.meta.url)),
+    join(consumerDirectory, 'node_modules', '@shipfox', 'vite'),
+    'dir',
+  );
+}
+
+function runFixture(consumerDirectory: string): string {
+  const vitestBinary = fileURLToPath(new URL('../node_modules/.bin/vitest', import.meta.url));
+  return execFileSync(vitestBinary, ['run', '--config', 'vitest.config.ts'], {
+    cwd: consumerDirectory,
+    encoding: 'utf8',
+    env: {...process.env, CI: 'true'},
+  });
+}
+
+describe('Vitest configuration', () => {
+  it('preserves caller plugins and installs the shared resolver for source conditions', () => {
+    const callerPlugin = {name: 'caller-plugin'};
+    const config = defineConfig({plugins: [callerPlugin]}) as {plugins?: unknown[]};
+
+    expect(pluginNames(config)).toEqual(['caller-plugin', workspaceSourcePluginName]);
+  });
+
+  it('does not reactivate the resolver when callers remove workspace-source', () => {
+    const config = defineConfig({
+      plugins: [{name: 'caller-plugin'}],
+      resolve: {conditions: ['default']},
+      ssr: {resolve: {conditions: ['default']}},
+    }) as {plugins?: unknown[]};
+
+    expect(pluginNames(config)).toEqual(['caller-plugin']);
+  });
+
+  it('installs the resolver when only SSR retains workspace-source', () => {
+    const config = defineConfig({
+      resolve: {conditions: ['default']},
+      ssr: {resolve: {conditions: ['workspace-source']}},
+    }) as {plugins?: unknown[]};
+
+    expect(pluginNames(config)).toEqual([workspaceSourcePluginName]);
+  });
+
+  it('installs the same resolver for workspace projects', () => {
+    const config = defineProject({}, import.meta.url) as {plugins?: unknown[]};
+
+    expect(pluginNames(config)).toContain(workspaceSourcePluginName);
+  });
+
+  it('resolves a clean external-style fixture through the Vitest pipeline', () => {
+    const sourceFixture = fileURLToPath(new URL('../test/external-fixture/', import.meta.url));
+    const temporaryRoot = mkdtempSync(join(tmpdir(), 'shipfox-vitest-workspace-source-'));
+    const consumerDirectory = join(temporaryRoot, 'consumer');
+    const packageDirectory = join(temporaryRoot, 'workspace-package');
+    const distOnlyPackageDirectory = join(temporaryRoot, 'dist-only-package');
+
+    try {
+      cpSync(join(sourceFixture, 'consumer'), consumerDirectory, {recursive: true});
+      cpSync(join(sourceFixture, 'workspace-package'), packageDirectory, {recursive: true});
+      cpSync(join(sourceFixture, 'dist-only-package'), distOnlyPackageDirectory, {
+        recursive: true,
+      });
+      linkToolingPackages(consumerDirectory);
+      mkdirSync(join(consumerDirectory, 'node_modules'), {recursive: true});
+      symlinkSync(
+        packageDirectory,
+        join(consumerDirectory, 'node_modules', 'fixture-workspace-package'),
+        'dir',
+      );
+      symlinkSync(
+        distOnlyPackageDirectory,
+        join(consumerDirectory, 'node_modules', 'fixture-dist-only-package'),
+        'dir',
+      );
+
+      expect(runFixture(consumerDirectory)).toContain('1 passed');
+    } finally {
+      rmSync(temporaryRoot, {force: true, recursive: true});
+    }
+  });
+
+  it('loads compiled output through the Vitest pipeline with default conditions', () => {
+    const sourceFixture = fileURLToPath(new URL('../test/external-fixture/', import.meta.url));
+    const temporaryRoot = mkdtempSync(join(tmpdir(), 'shipfox-vitest-workspace-default-'));
+    const consumerDirectory = join(temporaryRoot, 'consumer');
+    const packageDirectory = join(temporaryRoot, 'workspace-package');
+
+    try {
+      cpSync(join(sourceFixture, 'default-consumer'), consumerDirectory, {recursive: true});
+      cpSync(join(sourceFixture, 'workspace-package'), packageDirectory, {recursive: true});
+      linkToolingPackages(consumerDirectory);
+      mkdirSync(join(consumerDirectory, 'node_modules'), {recursive: true});
+      symlinkSync(
+        packageDirectory,
+        join(consumerDirectory, 'node_modules', 'fixture-workspace-package'),
+        'dir',
+      );
+
+      expect(runFixture(consumerDirectory)).toContain('1 passed');
+    } finally {
+      rmSync(temporaryRoot, {force: true, recursive: true});
+    }
+  });
+});

--- a/tools/vitest/src/config.test.ts
+++ b/tools/vitest/src/config.test.ts
@@ -84,6 +84,7 @@ describe('Vitest configuration', () => {
     try {
       cpSync(join(sourceFixture, 'consumer'), consumerDirectory, {recursive: true});
       cpSync(join(sourceFixture, 'workspace-package'), packageDirectory, {recursive: true});
+      rmSync(join(packageDirectory, 'dist'), {force: true, recursive: true});
       cpSync(join(sourceFixture, 'dist-only-package'), distOnlyPackageDirectory, {
         recursive: true,
       });

--- a/tools/vitest/src/config.ts
+++ b/tools/vitest/src/config.ts
@@ -1,4 +1,5 @@
 import {getProjectRootPath} from '@shipfox/tool-utils';
+import {workspaceSourceResolver} from '@shipfox/vite/workspace-source';
 import {defaultClientConditions, defaultServerConditions} from 'vite';
 import {
   type TestProjectConfiguration,
@@ -18,6 +19,9 @@ export type UserConfigFnObject = () => Parameters<typeof vitestDefineConfig>[0];
 export type UserConfig = Parameters<typeof vitestDefineConfig>[0];
 
 type ConfigInput = UserConfig | UserWorkspaceConfig;
+type ResolveConfig = {
+  conditions?: string[];
+};
 type MergeableConfigInput = ConfigInput & {
   plugins?: unknown[];
   optimizeDeps?: {
@@ -40,7 +44,9 @@ type MergeableConfigInput = ConfigInput & {
 
 const maxWorkers = parseMaxWorkers(process.env.SHIPFOX_VITEST_MAX_WORKERS);
 const workerPoolDefaults = maxWorkers === undefined ? {} : {maxWorkers};
-const vitestServerConditions = defaultServerConditions.filter((condition) => condition !== 'module');
+const vitestServerConditions = defaultServerConditions.filter(
+  (condition) => condition !== 'module',
+);
 
 function parseMaxWorkers(value: string | undefined): number | undefined {
   if (!value) return undefined;
@@ -59,19 +65,34 @@ function createMergedConfig(resolvedConfig: ConfigInput, projectRoot?: string): 
   const existingTestConfig = mergeableConfig.test || {};
   const existingResolve = mergeableConfig.resolve || {};
   const existingSsrResolve = mergeableConfig.ssr?.resolve || {};
+  const resolveConditions = existingResolve.conditions ?? [
+    ...defaultClientConditions,
+    'workspace-source',
+  ];
+  const ssrResolveConditions = existingSsrResolve.conditions ?? [
+    ...vitestServerConditions,
+    'workspace-source',
+  ];
   const merged = {
     ...resolvedConfig,
-    plugins: [...existingPlugins],
+    plugins: [
+      ...existingPlugins,
+      ...(shouldResolveWorkspaceSource(
+        {conditions: resolveConditions},
+        {conditions: ssrResolveConditions},
+      )
+        ? [workspaceSourceResolver()]
+        : []),
+    ],
     resolve: {
       ...existingResolve,
-      conditions: existingResolve.conditions ?? [...defaultClientConditions, 'workspace-source'],
+      conditions: resolveConditions,
     },
     ssr: {
       ...mergeableConfig.ssr,
       resolve: {
         ...existingSsrResolve,
-        conditions:
-          existingSsrResolve.conditions ?? [...vitestServerConditions, 'workspace-source'],
+        conditions: ssrResolveConditions,
       },
     },
     optimizeDeps: {
@@ -103,6 +124,16 @@ function createMergedConfig(resolvedConfig: ConfigInput, projectRoot?: string): 
   }
 
   return merged as ConfigInput;
+}
+
+function shouldResolveWorkspaceSource(
+  resolve: ResolveConfig | undefined,
+  ssrResolve: ResolveConfig | undefined,
+): boolean {
+  return (
+    resolve?.conditions?.includes('workspace-source') === true ||
+    ssrResolve?.conditions?.includes('workspace-source') === true
+  );
 }
 
 function mergeConfig(config: ConfigInput, callerUrl?: string): ConfigInput {

--- a/tools/vitest/test/external-fixture/consumer/package.json
+++ b/tools/vitest/test/external-fixture/consumer/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "fixture-consumer",
+  "private": true,
+  "type": "module"
+}

--- a/tools/vitest/test/external-fixture/consumer/test/import.ts
+++ b/tools/vitest/test/external-fixture/consumer/test/import.ts
@@ -1,0 +1,8 @@
+import {expect, it} from '@shipfox/vitest/vi';
+import {result as distOnlyResult} from 'fixture-dist-only-package';
+import {values} from 'fixture-workspace-package';
+
+it('loads workspace source package imports without dist', () => {
+  expect(values).toEqual(['source-db', 'source-component']);
+  expect(distOnlyResult).toBe('dist-only-upstream');
+});

--- a/tools/vitest/test/external-fixture/consumer/vitest.config.ts
+++ b/tools/vitest/test/external-fixture/consumer/vitest.config.ts
@@ -1,0 +1,8 @@
+import {defineConfig} from '@shipfox/vitest';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['test/import.ts'],
+  },
+});

--- a/tools/vitest/test/external-fixture/default-consumer/package.json
+++ b/tools/vitest/test/external-fixture/default-consumer/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "fixture-default-consumer",
+  "private": true,
+  "type": "module"
+}

--- a/tools/vitest/test/external-fixture/default-consumer/test/import.ts
+++ b/tools/vitest/test/external-fixture/default-consumer/test/import.ts
@@ -1,0 +1,6 @@
+import {expect, it} from '@shipfox/vitest/vi';
+import {values} from 'fixture-workspace-package';
+
+it('loads compiled package output when workspace-source is disabled', () => {
+  expect(values).toEqual(['dist-db', 'dist-component']);
+});

--- a/tools/vitest/test/external-fixture/default-consumer/vitest.config.ts
+++ b/tools/vitest/test/external-fixture/default-consumer/vitest.config.ts
@@ -1,0 +1,10 @@
+import {defineConfig} from '@shipfox/vitest';
+
+export default defineConfig({
+  resolve: {conditions: ['default']},
+  ssr: {resolve: {conditions: ['default']}},
+  test: {
+    environment: 'node',
+    include: ['test/import.ts'],
+  },
+});

--- a/tools/vitest/test/external-fixture/dist-only-package/dist/index.js
+++ b/tools/vitest/test/external-fixture/dist-only-package/dist/index.js
@@ -1,0 +1,3 @@
+import {value} from '#value.js';
+
+export const result = value;

--- a/tools/vitest/test/external-fixture/dist-only-package/dist/value.js
+++ b/tools/vitest/test/external-fixture/dist-only-package/dist/value.js
@@ -1,0 +1,1 @@
+export const value = 'dist-only-upstream';

--- a/tools/vitest/test/external-fixture/dist-only-package/package.json
+++ b/tools/vitest/test/external-fixture/dist-only-package/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "fixture-dist-only-package",
+  "private": true,
+  "type": "module",
+  "imports": {
+    "#*": "./dist/*"
+  },
+  "exports": {
+    ".": "./dist/index.js"
+  }
+}

--- a/tools/vitest/test/external-fixture/workspace-package/dist/db/db.js
+++ b/tools/vitest/test/external-fixture/workspace-package/dist/db/db.js
@@ -1,0 +1,1 @@
+export const dbValue = 'dist-db';

--- a/tools/vitest/test/external-fixture/workspace-package/dist/index.js
+++ b/tools/vitest/test/external-fixture/workspace-package/dist/index.js
@@ -1,0 +1,4 @@
+import {dbValue} from '#db/db.js';
+import {componentValue} from '#ui/component.js';
+
+export const values = [dbValue, componentValue];

--- a/tools/vitest/test/external-fixture/workspace-package/dist/ui/component.js
+++ b/tools/vitest/test/external-fixture/workspace-package/dist/ui/component.js
@@ -1,0 +1,1 @@
+export const componentValue = 'dist-component';

--- a/tools/vitest/test/external-fixture/workspace-package/package.json
+++ b/tools/vitest/test/external-fixture/workspace-package/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "fixture-workspace-package",
+  "private": true,
+  "type": "module",
+  "imports": {
+    "#test/*": "./test/*",
+    "#*": {
+      "workspace-source": "./src/*",
+      "default": "./dist/*"
+    }
+  },
+  "exports": {
+    ".": {
+      "workspace-source": {
+        "types": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  }
+}

--- a/tools/vitest/test/external-fixture/workspace-package/src/db/db.ts
+++ b/tools/vitest/test/external-fixture/workspace-package/src/db/db.ts
@@ -1,0 +1,1 @@
+export const dbValue = 'source-db';

--- a/tools/vitest/test/external-fixture/workspace-package/src/index.ts
+++ b/tools/vitest/test/external-fixture/workspace-package/src/index.ts
@@ -1,0 +1,4 @@
+import {dbValue} from '#db/db.js';
+import {componentValue} from '#ui/component.js';
+
+export const values = [dbValue, componentValue];

--- a/tools/vitest/test/external-fixture/workspace-package/src/ui/component.tsx
+++ b/tools/vitest/test/external-fixture/workspace-package/src/ui/component.tsx
@@ -1,0 +1,1 @@
+export const componentValue = 'source-component';

--- a/tools/vitest/test/external-fixture/workspace-package/test/helper.ts
+++ b/tools/vitest/test/external-fixture/workspace-package/test/helper.ts
@@ -1,0 +1,1 @@
+export const helperValue = 'test-helper';

--- a/tools/vitest/tsconfig.test.json
+++ b/tools/vitest/tsconfig.test.json
@@ -4,5 +4,5 @@
     "rootDir": "."
   },
   "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
-  "exclude": []
+  "exclude": ["test/external-fixture"]
 }

--- a/tools/vitest/vitest.config.ts
+++ b/tools/vitest/vitest.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -11,7 +11,8 @@
     "CLIENT_URL",
     "ARGOS_TOKEN",
     "SHIPFOX_VITEST_MAX_WORKERS",
-    "CI"
+    "CI",
+    "PREVIEW_COMMIT_SHA"
   ],
   "tasks": {
     "build": {


### PR DESCRIPTION
Adds a shared workspace-source package-import resolver owned by @shipfox/vite and consumed by @shipfox/vitest.

The resolver handles conditional and wildcard package imports, symlinked workspace paths, package containment, query/fragment postfixes, and Vite's JavaScript-to-TypeScript fallback. Wrapper activation preserves caller plugins and explicit condition overrides while leaving production and default/dist resolution intact.

The PR also adds external source/default/dist-only fixtures, the public workspace-source export, package documentation, and Changesets for both published packages.

Closes ENG-1222

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared `workspace-source` package-import resolver in `@shipfox/vite` and integrates it into `@shipfox/vitest` to unify source-vs-dist resolution in dev/test. Also passes `PREVIEW_COMMIT_SHA` through Turbo to keep Storybook previews tied to the PR head. Closes ENG-1222.

- New Features
  - Shared resolver `@shipfox/vite/workspace-source` for package-local source when `workspace-source` is active; integrated into `@shipfox/vitest`.
  - Handles exact/wildcard `#` imports, query/hash postfixes, symlinked paths, JS→TS fallback; enforces package containment and skips `dist/*` cross‑platform.
  - Activation: Vite only on `serve`; Vitest installs if client or SSR keeps `workspace-source`; preserves caller plugins and explicit condition overrides; added tests and external fixtures.

- Dependencies
  - Added `resolve.exports`; `@shipfox/vitest` now depends on `@shipfox/vite`; patch releases for both.

<sup>Written for commit 89711893ba0016cd58dc24dd9b7622b635681dbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

