### PR TITLE
[e2e-client-workspaces] Stabilize terminal invitation coverage

### DIFF
--- a/e2e/suites/client/workspaces/tests/invitations-members.e2e.ts
+++ b/e2e/suites/client/workspaces/tests/invitations-members.e2e.ts
@@ -223,11 +223,16 @@ test('creates, rejects duplicate, and revokes a pending invitation from members 
   await expect(pendingInvitationRow).toBeHidden();
 });
 
-test('renders terminal public invitation states', async ({page, invitationAccept}) => {
+test('renders a missing-token public invitation as an invalid link', async ({
+  page,
+  invitationAccept,
+}) => {
   await invitationAccept.goto();
   await expect(invitationAccept.heading('Invalid link')).toBeVisible();
   await stableScreenshot(page, 'invitations/missing-token');
+});
 
+test('renders an invalid public invitation', async ({page, invitationAccept}) => {
   await page.route('**/invitations/preview?**', async (route) => {
     await route.fulfill({
       status: 200,
@@ -238,8 +243,9 @@ test('renders terminal public invitation states', async ({page, invitationAccept
   await invitationAccept.goto(`invalid-${randomUUID()}`);
   await expect(invitationAccept.heading('Invalid invitation')).toBeVisible();
   await stableScreenshot(page, 'invitations/invalid');
+});
 
-  await page.unroute('**/invitations/preview?**');
+test('renders an expired public invitation', async ({page, invitationAccept}) => {
   await page.route('**/invitations/preview?**', async (route) => {
     await route.fulfill({
       status: 200,


### PR DESCRIPTION
## Summary

The terminal invitation E2E test grouped the missing-token, invalid, and expired visual states under one 30-second budget. Under loaded CI, Argos stabilization could exhaust that shared budget after all three screenshots had been written.

Split the independent states into separate tests so each has isolated route handling and its own timeout budget, while preserving the existing assertions and Argos snapshot names. This avoids retries and timeout increases.

## Validation

- `mise exec -- turbo check type --filter=@shipfox/e2e-client-workspaces...`
- Full `@shipfox/e2e-client-workspaces` E2E suite against a fresh temporary database
- 30 terminal-state cases across two workers
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes terminal invitation E2E coverage by splitting the missing-token, invalid, and expired states into three independent tests. This prevents shared-timeout flakiness in CI while keeping existing assertions and Argos snapshot names.

- **Bug Fixes**
  - Each state now has isolated route handling and its own timeout budget.
  - Avoids retries or increasing global timeouts.

<sup>Written for commit dbd24b976d8709c37567afcc51fcf57fed54a3be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

