### PR TITLE
Isolate private browser state across authenticated principals

### DIFF
--- a/.changeset/private-browser-state-isolation.md
+++ b/.changeset/private-browser-state-isolation.md
@@ -1,0 +1,11 @@
+---
+"@shipfox/react-ui": patch
+"@shipfox/client-ui": patch
+"@shipfox/client-shell": patch
+"@shipfox/client-auth": patch
+"@shipfox/client-agent": patch
+"@shipfox/client-projects": patch
+"@shipfox/client-integrations": patch
+---
+
+Isolates private browser state and React Query data across authenticated principal transitions.

--- a/e2e/screens/workspaces/src/index.ts
+++ b/e2e/screens/workspaces/src/index.ts
@@ -5,6 +5,10 @@ type Locator = ReturnType<Page['locator']>;
 type FixtureUse<T> = (fixture: T) => Promise<void>;
 const LAST_WORKSPACE_KEY = 'shipfox.lastWorkspaceId';
 
+function lastWorkspaceStorageKey(principalId: string): string {
+  return `${LAST_WORKSPACE_KEY}.principal.${encodeURIComponent(principalId)}`;
+}
+
 export class WorkspaceOnboardingScreen {
   constructor(private readonly page: Page) {}
 
@@ -61,11 +65,9 @@ export class WorkspaceHomeScreen {
     return new URL(this.page.url()).pathname.split('/')[2];
   }
 
-  async readMaybeLastWorkspaceId(): Promise<string | undefined> {
-    const raw = await this.page.evaluate(
-      (key) => window.localStorage.getItem(key),
-      LAST_WORKSPACE_KEY,
-    );
+  async readMaybeLastWorkspaceId(principalId: string): Promise<string | undefined> {
+    const key = lastWorkspaceStorageKey(principalId);
+    const raw = await this.page.evaluate((key) => window.localStorage.getItem(key), key);
     if (!raw) return undefined;
     let parsed: unknown;
     try {
@@ -76,10 +78,11 @@ export class WorkspaceHomeScreen {
     return typeof parsed === 'string' ? parsed : undefined;
   }
 
-  async readLastWorkspaceId(): Promise<string> {
-    const workspaceId = await this.readMaybeLastWorkspaceId();
+  async readLastWorkspaceId(principalId: string): Promise<string> {
+    const key = lastWorkspaceStorageKey(principalId);
+    const workspaceId = await this.readMaybeLastWorkspaceId(principalId);
     if (workspaceId === undefined) {
-      throw new Error(`localStorage[${LAST_WORKSPACE_KEY}] is not set`);
+      throw new Error(`localStorage[${key}] is not set`);
     }
     return workspaceId;
   }

--- a/e2e/suites/client/workspaces/tests/onboarding.e2e.ts
+++ b/e2e/suites/client/workspaces/tests/onboarding.e2e.ts
@@ -60,7 +60,7 @@ test.describe('workspace onboarding', () => {
     await setupShell.expectNavigationHidden();
     const workspaceId = workspaceHome.currentWorkspaceId();
     expect(workspaceId).toBeTruthy();
-    expect(await workspaceHome.readLastWorkspaceId()).toBe(workspaceId);
+    expect(await workspaceHome.readLastWorkspaceId(user.user.id)).toBe(workspaceId);
     await stableScreenshot(page, 'workspaces/onboarding-complete');
   });
 });

--- a/e2e/suites/client/workspaces/tests/workspace-switcher.e2e.ts
+++ b/e2e/suites/client/workspaces/tests/workspace-switcher.e2e.ts
@@ -39,7 +39,7 @@ test.describe('workspace switcher', () => {
     await workspaceSwitcher.open();
     await expect(workspaceSwitcher.workspaceOption(workspaceAName)).toBeVisible();
     await expect(workspaceSwitcher.workspaceOption(workspaceBName)).toBeVisible();
-    expect(await workspaceHome.readLastWorkspaceId()).toBe(newWorkspaceId);
+    expect(await workspaceHome.readLastWorkspaceId(user.user.id)).toBe(newWorkspaceId);
   });
 
   test('keeps Create workspace visible when search filters every workspace out', async ({

--- a/e2e/suites/client/workspaces/tests/workspace-switching.e2e.ts
+++ b/e2e/suites/client/workspaces/tests/workspace-switching.e2e.ts
@@ -29,7 +29,7 @@ test.describe('workspace switching', () => {
 
     await expect(page).toHaveURL(workspaceUrlRe(wsB.id));
     await expect(topNav.currentWorkspace(workspaceBName)).toBeVisible();
-    expect(await workspaceHome.readLastWorkspaceId()).toBe(wsB.id);
+    expect(await workspaceHome.readLastWorkspaceId(user.user.id)).toBe(wsB.id);
   });
 
   test('persists the active workspace across reload and via /', async ({
@@ -45,10 +45,10 @@ test.describe('workspace switching', () => {
 
     await workspaceHome.gotoIntegrations(wsB.id);
     await expect(page).toHaveURL(workspaceUrlRe(wsB.id));
-    await expect.poll(() => workspaceHome.readMaybeLastWorkspaceId()).toBe(wsB.id);
+    await expect.poll(() => workspaceHome.readMaybeLastWorkspaceId(user.user.id)).toBe(wsB.id);
     await page.reload();
     await expect(page).toHaveURL(workspaceUrlRe(wsB.id));
-    await expect.poll(() => workspaceHome.readMaybeLastWorkspaceId()).toBe(wsB.id);
+    await expect.poll(() => workspaceHome.readMaybeLastWorkspaceId(user.user.id)).toBe(wsB.id);
     await workspaceHome.gotoRoot();
 
     await expect(page).toHaveURL(workspaceUrlRe(wsB.id));

--- a/libs/client/agent/src/state/model-provider-onboarding.test.ts
+++ b/libs/client/agent/src/state/model-provider-onboarding.test.ts
@@ -29,10 +29,10 @@ describe('model provider onboarding dismissed state', () => {
   });
 
   test('keeps dismissed state isolated per workspace', () => {
-    const localStorage = createStorage({
-      'shipfox.modelProviderOnboardingDismissed': JSON.stringify({'workspace-1': true}),
-    });
+    const localStorage = createStorage();
     vi.stubGlobal('window', {localStorage});
+
+    dismissModelProviderOnboarding('workspace-1');
 
     expect(isModelProviderOnboardingDismissed('workspace-1')).toBe(true);
     expect(isModelProviderOnboardingDismissed('workspace-2')).toBe(false);
@@ -46,7 +46,7 @@ describe('model provider onboarding dismissed state', () => {
 
   test('treats corrupt JSON as empty state', () => {
     const localStorage = createStorage({
-      'shipfox.modelProviderOnboardingDismissed': '{',
+      'shipfox.modelProviderOnboardingDismissed.workspace.workspace-1': '{',
     });
     vi.stubGlobal('window', {localStorage});
 

--- a/libs/client/agent/src/state/model-provider-onboarding.ts
+++ b/libs/client/agent/src/state/model-provider-onboarding.ts
@@ -1,37 +1,27 @@
-import {createTypedBrowserStorage, localStorageOrUndefined} from '@shipfox/client-ui';
+import {
+  type BrowserStorageKey,
+  createTypedBrowserStorage,
+  localStorageOrUndefined,
+} from '@shipfox/client-ui';
 
-type DismissedMap = Record<string, true>;
-
-const dismissedStorage = createTypedBrowserStorage(localStorageOrUndefined, {
+const dismissedStorageKey = {
   key: 'shipfox.modelProviderOnboardingDismissed',
   lifetime: 'persistent',
   principalScope: 'workspace',
-  serialize: (dismissed: DismissedMap) => JSON.stringify(dismissed),
+  serialize: (dismissed: boolean) => JSON.stringify(dismissed),
   parse: (raw) => {
-    try {
-      const parsed: unknown = JSON.parse(raw);
-      return isDismissedMap(parsed) ? parsed : undefined;
-    } catch {
-      return undefined;
-    }
+    return raw === 'true' ? true : raw === 'false' ? false : undefined;
   },
-});
+} satisfies BrowserStorageKey<boolean>;
 
 export function isModelProviderOnboardingDismissed(workspaceId: string): boolean {
-  return Boolean(readDismissedMap()[workspaceId]);
+  return dismissedStorage(workspaceId).read() === true;
 }
 
 export function dismissModelProviderOnboarding(workspaceId: string): void {
-  const dismissed = readDismissedMap();
-  dismissed[workspaceId] = true;
-  dismissedStorage.write(dismissed);
+  dismissedStorage(workspaceId).write(true);
 }
 
-function readDismissedMap(): DismissedMap {
-  return dismissedStorage.read() ?? {};
-}
-
-function isDismissedMap(value: unknown): value is DismissedMap {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
-  return Object.values(value).every((entry) => entry === true);
+function dismissedStorage(workspaceId: string) {
+  return createTypedBrowserStorage(localStorageOrUndefined, dismissedStorageKey, {workspaceId});
 }

--- a/libs/client/auth/src/components/auth-provider.test.tsx
+++ b/libs/client/auth/src/components/auth-provider.test.tsx
@@ -1,5 +1,5 @@
-import {configureApiClient} from '@shipfox/client-api';
-import {QueryClient, useQuery} from '@tanstack/react-query';
+import {ApiError, configureApiClient} from '@shipfox/client-api';
+import {QueryClient, useQuery, useQueryClient} from '@tanstack/react-query';
 import {render, screen, waitFor} from '@testing-library/react';
 import {useEffect, useRef} from 'react';
 import {useLoginAuth} from '#hooks/api/login-auth.js';
@@ -45,12 +45,20 @@ function StatusProbe() {
 
 function PrivateDataProbe() {
   const auth = useAuthState();
+  const queryClient = useQueryClient();
+  const seeded = useRef(false);
   const privateData = useQuery({
     queryKey: ['private-data'],
     queryFn: () => new Promise<string>(() => undefined),
     enabled: auth.isAuthenticated,
   });
   const login = useLoginAuth();
+
+  useEffect(() => {
+    if (!auth.isAuthenticated || seeded.current) return;
+    seeded.current = true;
+    queryClient.setQueryData(['private-data'], 'User A private data');
+  }, [auth.isAuthenticated, queryClient]);
 
   return (
     <div>
@@ -114,6 +122,24 @@ describe('AuthProvider', () => {
     expect(queryClient.getQueryData(['private-data'])).toBeUndefined();
   });
 
+  test('clears a hydrated private cache before accepting the first principal', async () => {
+    const queryClient = new QueryClient();
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({token: 'other-token', user: otherUser}));
+    configureApiClient({fetchImpl});
+    queryClient.setQueryData(['private-data'], 'previous principal private data');
+
+    render(
+      <AuthProvider queryClient={queryClient}>
+        <StatusProbe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('authenticated'));
+    expect(queryClient.getQueryData(['private-data'])).toBeUndefined();
+  });
+
   test('keeps the current session when refresh fails with a server error', async () => {
     const fetchImpl = vi
       .fn()
@@ -156,21 +182,30 @@ describe('AuthProvider', () => {
       .fn()
       .mockImplementation(() => Promise.resolve(jsonResponse({token: 'access-token', user})));
     configureApiClient({fetchImpl});
-    queryClient.setQueryData(['private-data'], 'current user private data');
     const onDone = vi.fn();
+    const onReady = vi.fn();
 
     function RefreshAfterBootProbe() {
       const auth = useAuthState();
       const refresh = useRefreshAuth();
-      const didRefresh = useRef(false);
+      const queryClient = useQueryClient();
+      const didSeed = useRef(false);
 
       useEffect(() => {
-        if (auth.status !== 'authenticated' || didRefresh.current) return;
-        didRefresh.current = true;
-        void refresh().then(onDone);
-      }, [auth.status, refresh]);
+        if (auth.status !== 'authenticated' || didSeed.current) return;
+        didSeed.current = true;
+        queryClient.setQueryData(['private-data'], 'current user private data');
+        onReady();
+      }, [auth.status, queryClient]);
 
-      return <StatusProbe />;
+      return (
+        <>
+          <StatusProbe />
+          <button type="button" onClick={() => void refresh().then(onDone)}>
+            Refresh
+          </button>
+        </>
+      );
     }
 
     render(
@@ -179,6 +214,9 @@ describe('AuthProvider', () => {
       </AuthProvider>,
     );
 
+    await waitFor(() => expect(onReady).toHaveBeenCalledTimes(1));
+    cancelQueries.mockClear();
+    screen.getByRole('button', {name: 'Refresh'}).click();
     await waitFor(() => expect(onDone).toHaveBeenCalledTimes(1));
     expect(cancelQueries).not.toHaveBeenCalled();
     expect(queryClient.getQueryData(['private-data'])).toBe('current user private data');
@@ -211,6 +249,80 @@ describe('AuthProvider', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 
+  test('does not restore a stale refresh result after a principal transition', async () => {
+    let refreshRequestCount = 0;
+    let workspaceRequestCount = 0;
+    const initialWorkspaceRefresh = new Promise<Response>(() => undefined);
+    const onFreshRefresh = vi.fn();
+    const onRefreshError = vi.fn();
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const url = (input as Request).url;
+      if (url.endsWith('/auth/refresh')) {
+        refreshRequestCount += 1;
+        return refreshRequestCount === 1
+          ? Promise.resolve(jsonResponse({token: 'access-token', user}))
+          : Promise.resolve(jsonResponse({token: 'other-token-2', user: otherUser}));
+      }
+      if (url.endsWith('/auth/login'))
+        return Promise.resolve(jsonResponse({token: 'other-token', user: otherUser}));
+      if (url.endsWith('/workspaces')) {
+        workspaceRequestCount += 1;
+        return workspaceRequestCount === 1
+          ? initialWorkspaceRefresh
+          : Promise.resolve(jsonResponse({memberships: []}));
+      }
+      return Promise.resolve(jsonResponse({token: 'access-token', user}));
+    });
+    configureApiClient({fetchImpl});
+
+    function RefreshAndLoginProbe() {
+      const auth = useAuthState();
+      const login = useLoginAuth();
+      const refresh = useRefreshAuth();
+
+      useEffect(() => {
+        void refresh().catch(onRefreshError);
+      }, [refresh]);
+
+      return (
+        <div>
+          <span data-testid="email">{auth.user?.email ?? 'none'}</span>
+          <button
+            type="button"
+            onClick={() =>
+              void login.mutateAsync({email: 'other@example.com', password: 'password'})
+            }
+          >
+            Login as other user
+          </button>
+          <button type="button" onClick={() => void refresh().then(onFreshRefresh)}>
+            Refresh current principal
+          </button>
+        </div>
+      );
+    }
+
+    render(
+      <AuthProvider>
+        <RefreshAndLoginProbe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => expect(workspaceRequestCount).toBe(1));
+    screen.getByRole('button', {name: 'Login as other user'}).click();
+    await waitFor(() => expect(screen.getByTestId('email')).toHaveTextContent('other@example.com'));
+    await waitFor(() => expect(onRefreshError).toHaveBeenCalledTimes(1));
+    const refreshError = onRefreshError.mock.calls[0]?.[0];
+    expect(refreshError).toBeInstanceOf(ApiError);
+    expect(refreshError).toMatchObject({code: 'unauthorized', status: 401});
+
+    screen.getByRole('button', {name: 'Refresh current principal'}).click();
+    await waitFor(() => expect(onFreshRefresh).toHaveBeenCalledTimes(1));
+    expect(refreshRequestCount).toBe(2);
+
+    expect(screen.getByTestId('email')).toHaveTextContent('other@example.com');
+  });
+
   test('logout clears local state even when the API call fails', async () => {
     const queryClient = new QueryClient();
     const cancelQueries = vi.spyOn(queryClient, 'cancelQueries');
@@ -219,8 +331,16 @@ describe('AuthProvider', () => {
       .mockResolvedValueOnce(jsonResponse({token: 'access-token', user}))
       .mockRejectedValueOnce(new Error('offline'));
     configureApiClient({fetchImpl});
-    queryClient.setQueryData(['private-data'], 'private data');
     const onQueryAbort = vi.fn();
+
+    render(
+      <AuthProvider queryClient={queryClient}>
+        <StatusProbe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('authenticated'));
+    queryClient.setQueryData(['private-data'], 'private data');
     void queryClient
       .fetchQuery({
         queryKey: ['in-flight-private-data'],
@@ -233,14 +353,7 @@ describe('AuthProvider', () => {
           }),
       })
       .catch(() => undefined);
-
-    render(
-      <AuthProvider queryClient={queryClient}>
-        <StatusProbe />
-      </AuthProvider>,
-    );
-
-    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('authenticated'));
+    cancelQueries.mockClear();
     screen.getByRole('button', {name: 'Logout'}).click();
 
     await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('guest'));
@@ -312,7 +425,6 @@ describe('AuthProvider', () => {
       return Promise.resolve(jsonResponse({token: 'access-token', user}));
     });
     configureApiClient({fetchImpl});
-    queryClient.setQueryData(['private-data'], 'User A private data');
 
     render(
       <AuthProvider queryClient={queryClient}>
@@ -323,6 +435,7 @@ describe('AuthProvider', () => {
     await waitFor(() =>
       expect(screen.getByTestId('private-data')).toHaveTextContent('User A private data'),
     );
+    cancelQueries.mockClear();
     screen.getByRole('button', {name: 'Switch user'}).click();
 
     await waitFor(() =>

--- a/libs/client/auth/src/components/workspace-switcher.tsx
+++ b/libs/client/auth/src/components/workspace-switcher.tsx
@@ -11,7 +11,7 @@ import {Icon} from '@shipfox/react-ui/icon';
 import {useNavigate} from '@tanstack/react-router';
 import {useSetAtom} from 'jotai';
 import {useAuthState} from '#hooks/use-auth-state.js';
-import {lastWorkspaceIdAtom} from '#state/last-workspace.js';
+import {lastWorkspaceIdAtom, rememberLastWorkspaceId} from '#state/last-workspace.js';
 
 export interface WorkspaceSwitcherProps {
   activeWorkspaceId: string | undefined;
@@ -19,13 +19,14 @@ export interface WorkspaceSwitcherProps {
 }
 
 export function WorkspaceSwitcher({activeWorkspaceId, onSelect}: WorkspaceSwitcherProps) {
-  const {workspaces} = useAuthState();
+  const {user, workspaces} = useAuthState();
   const navigate = useNavigate();
   const setLastWorkspaceId = useSetAtom(lastWorkspaceIdAtom);
 
   const handleSelect = (workspaceId: string) => {
     try {
       setLastWorkspaceId(workspaceId);
+      if (user?.id) rememberLastWorkspaceId(user.id, workspaceId);
     } catch {
       // localStorage may throw in private browsing or quota-exceeded; persistence is best-effort.
     }

--- a/libs/client/auth/src/hooks/api/login-auth.ts
+++ b/libs/client/auth/src/hooks/api/login-auth.ts
@@ -18,6 +18,6 @@ export function useLoginAuth() {
 
   return useMutation({
     mutationFn: loginAuth,
-    onSuccess: enterAuthenticated,
+    onSuccess: (session) => enterAuthenticated(session),
   });
 }

--- a/libs/client/auth/src/hooks/api/logout-auth.ts
+++ b/libs/client/auth/src/hooks/api/logout-auth.ts
@@ -15,6 +15,6 @@ export function useLogoutAuth() {
 
   return useMutation({
     mutationFn: logoutAuth,
-    onSettled: enterGuest,
+    onSettled: () => enterGuest(),
   });
 }

--- a/libs/client/auth/src/hooks/api/password-reset-auth.ts
+++ b/libs/client/auth/src/hooks/api/password-reset-auth.ts
@@ -33,6 +33,6 @@ export function useConfirmPasswordResetAuth() {
 
   return useMutation({
     mutationFn: confirmPasswordReset,
-    onSuccess: enterAuthenticated,
+    onSuccess: (session) => enterAuthenticated(session),
   });
 }

--- a/libs/client/auth/src/hooks/api/verify-email-auth.ts
+++ b/libs/client/auth/src/hooks/api/verify-email-auth.ts
@@ -47,6 +47,6 @@ export function useVerifyEmailAuth() {
 
   return useMutation({
     mutationFn: verifyEmailAuth,
-    onSuccess: enterAuthenticated,
+    onSuccess: (session) => enterAuthenticated(session),
   });
 }

--- a/libs/client/auth/src/pages/workspace-onboarding-page.tsx
+++ b/libs/client/auth/src/pages/workspace-onboarding-page.tsx
@@ -12,7 +12,8 @@ import {useNavigate} from '@tanstack/react-router';
 import {useSetAtom} from 'jotai';
 import {useState} from 'react';
 import {useCreateWorkspaceAuth} from '#hooks/api/workspace-auth.js';
-import {lastWorkspaceIdAtom} from '#state/last-workspace.js';
+import {useAuthState} from '#hooks/use-auth-state.js';
+import {lastWorkspaceIdAtom, rememberLastWorkspaceId} from '#state/last-workspace.js';
 import {workspaceOnboardingErrorToFormError} from './form-errors.js';
 
 const previewMetrics = [
@@ -34,6 +35,7 @@ const previewBars = [
 
 export function WorkspaceOnboardingPage() {
   const createWorkspace = useCreateWorkspaceAuth();
+  const {user} = useAuthState();
   const navigate = useNavigate();
   const setLastWorkspaceId = useSetAtom(lastWorkspaceIdAtom);
   const [formError, setFormError] = useState<string | undefined>();
@@ -50,6 +52,7 @@ export function WorkspaceOnboardingPage() {
         // future visits to `/` land on it.
         try {
           setLastWorkspaceId(created.id);
+          if (user?.id) rememberLastWorkspaceId(user.id, created.id);
         } catch {
           // localStorage may throw in private browsing or quota-exceeded.
         }

--- a/libs/client/auth/src/routes/index.tsx
+++ b/libs/client/auth/src/routes/index.tsx
@@ -10,9 +10,11 @@ export default defineRoute({
     if (!auth.isAuthenticated) throw redirect({to: '/auth/login'});
     const [first, ...rest] = auth.workspaces;
     if (!first) throw redirect({to: '/setup/workspaces/new'});
-    const target =
-      [first, ...rest].find((workspace) => workspace.id === getLastWorkspaceId()) ?? first;
-    throw redirect({to: '/workspaces/$wid', params: {wid: target.id}});
+    const principalId = auth.user?.id;
+    const target = principalId
+      ? [first, ...rest].find((workspace) => workspace.id === getLastWorkspaceId(principalId))
+      : undefined;
+    throw redirect({to: '/workspaces/$wid', params: {wid: (target ?? first).id}});
   },
   component: FullPageLoader,
 });

--- a/libs/client/auth/src/state/last-workspace.test.ts
+++ b/libs/client/auth/src/state/last-workspace.test.ts
@@ -5,7 +5,7 @@ import {
   rememberLastWorkspaceId,
 } from './last-workspace.js';
 
-describe('lastWorkspaceIdAtom', () => {
+describe('last workspace state', () => {
   beforeEach(() => {
     window.localStorage.clear();
   });
@@ -14,21 +14,13 @@ describe('lastWorkspaceIdAtom', () => {
     window.localStorage.clear();
   });
 
-  test('initial value is undefined when storage is empty', () => {
-    const store = createStore();
-
-    expect(store.get(lastWorkspaceIdAtom)).toBeUndefined();
-  });
-
-  test('write persists to localStorage and round-trips through the atom', () => {
+  test('atom stores current UI selection without unscoped persistence', () => {
     const store = createStore();
 
     store.set(lastWorkspaceIdAtom, 'workspace-1');
 
-    expect(JSON.parse(window.localStorage.getItem('shipfox.lastWorkspaceId') ?? 'null')).toBe(
-      'workspace-1',
-    );
     expect(store.get(lastWorkspaceIdAtom)).toBe('workspace-1');
+    expect(window.localStorage.getItem('shipfox.lastWorkspaceId')).toBeNull();
   });
 
   test('subscribers receive updates when the atom is set', () => {
@@ -45,34 +37,35 @@ describe('lastWorkspaceIdAtom', () => {
     unsubscribe();
   });
 
-  test('syncs the atom when another tab updates last workspace storage', () => {
-    const store = createStore();
-    const unsubscribe = store.sub(lastWorkspaceIdAtom, () => undefined);
-    window.localStorage.setItem('shipfox.lastWorkspaceId', JSON.stringify('workspace-2'));
+  test('write persists to localStorage and can be read for the same principal', () => {
+    rememberLastWorkspaceId('principal-1', 'workspace-1');
 
-    window.dispatchEvent(
-      new StorageEvent('storage', {
-        key: 'shipfox.lastWorkspaceId',
-        storageArea: window.localStorage,
-      }),
-    );
-
-    expect(store.get(lastWorkspaceIdAtom)).toBe('workspace-2');
-    unsubscribe();
+    expect(
+      JSON.parse(
+        window.localStorage.getItem('shipfox.lastWorkspaceId.principal.principal-1') ?? 'null',
+      ),
+    ).toBe('workspace-1');
+    expect(getLastWorkspaceId('principal-1')).toBe('workspace-1');
   });
 
   test('rememberLastWorkspaceId persists a root redirect target', () => {
-    rememberLastWorkspaceId('workspace-1');
+    rememberLastWorkspaceId('principal-1', 'workspace-1');
 
-    const result = getLastWorkspaceId();
+    const result = getLastWorkspaceId('principal-1');
 
     expect(result).toBe('workspace-1');
   });
 
-  test('getLastWorkspaceId ignores malformed storage', () => {
-    window.localStorage.setItem('shipfox.lastWorkspaceId', '{');
+  test("does not reuse a different principal's root redirect target", () => {
+    rememberLastWorkspaceId('principal-a', 'workspace-a');
 
-    const result = getLastWorkspaceId();
+    expect(getLastWorkspaceId('principal-b')).toBeUndefined();
+  });
+
+  test('getLastWorkspaceId ignores malformed storage', () => {
+    window.localStorage.setItem('shipfox.lastWorkspaceId.principal.principal-1', '{');
+
+    const result = getLastWorkspaceId('principal-1');
 
     expect(result).toBeUndefined();
   });

--- a/libs/client/integrations/src/linear-callback.ts
+++ b/libs/client/integrations/src/linear-callback.ts
@@ -13,7 +13,10 @@ type WorkspaceStorage = BrowserStorage | undefined;
 const linearInstallWorkspaceStorageKey = {
   key: LINEAR_INSTALL_WORKSPACE_KEY,
   lifetime: 'session',
-  principalScope: 'workspace',
+  // This is a one-shot navigation hint, not private workspace state. It must
+  // remain readable on an OAuth callback before workspace hydration completes;
+  // the callback state and returned connection are the authoritative checks.
+  principalScope: 'global',
   serialize: (workspaceId: string) => workspaceId,
   parse: (value: string) => value || undefined,
 } satisfies BrowserStorageKey<string>;

--- a/libs/client/integrations/src/sentry-callback.ts
+++ b/libs/client/integrations/src/sentry-callback.ts
@@ -12,7 +12,9 @@ type WorkspaceStorage = BrowserStorage | undefined;
 const sentryInstallWorkspaceStorageKey = {
   key: SENTRY_INSTALL_WORKSPACE_KEY,
   lifetime: 'session',
-  principalScope: 'workspace',
+  // This is a one-shot navigation hint, not private workspace state. The
+  // callback validates it against the authenticated workspace list before use.
+  principalScope: 'global',
   serialize: (workspaceId: string) => workspaceId,
   parse: (value: string) => value || undefined,
 } satisfies BrowserStorageKey<string>;

--- a/libs/client/integrations/src/slack-callback.ts
+++ b/libs/client/integrations/src/slack-callback.ts
@@ -12,7 +12,10 @@ type WorkspaceStorage = BrowserStorage | undefined;
 const slackInstallWorkspaceStorageKey = {
   key: SLACK_INSTALL_WORKSPACE_KEY,
   lifetime: 'session',
-  principalScope: 'workspace',
+  // This is a one-shot navigation hint, not private workspace state. It must
+  // remain readable on an OAuth callback before workspace hydration completes;
+  // the callback state and returned connection are the authoritative checks.
+  principalScope: 'global',
   serialize: (workspaceId: string) => workspaceId,
   parse: (value: string) => value || undefined,
 } satisfies BrowserStorageKey<string>;

--- a/libs/client/projects/src/components/model-provider-reminder-banner.tsx
+++ b/libs/client/projects/src/components/model-provider-reminder-banner.tsx
@@ -59,11 +59,15 @@ function dismissReminder(workspaceId: string): void {
 }
 
 function reminderStorage(workspaceId: string) {
-  return createTypedBrowserStorage(sessionStorageOrUndefined, {
-    key: `shipfox.modelProviderReminder.dismissed.${workspaceId}`,
-    lifetime: 'session' as const,
-    principalScope: 'workspace' as const,
-    serialize: (dismissed: boolean) => JSON.stringify(dismissed),
-    parse: (raw: string) => raw === 'true',
-  });
+  return createTypedBrowserStorage(
+    sessionStorageOrUndefined,
+    {
+      key: 'shipfox.modelProviderReminder.dismissed',
+      lifetime: 'session' as const,
+      principalScope: 'workspace' as const,
+      serialize: (dismissed: boolean) => JSON.stringify(dismissed),
+      parse: (raw: string) => raw === 'true',
+    },
+    {workspaceId},
+  );
 }

--- a/libs/client/shell/src/components/workspace-switcher.tsx
+++ b/libs/client/shell/src/components/workspace-switcher.tsx
@@ -11,7 +11,7 @@ import {Icon} from '@shipfox/react-ui/icon';
 import {useNavigate} from '@tanstack/react-router';
 import {useSetAtom} from 'jotai';
 import {useAuthState} from '#runtime/auth.js';
-import {lastWorkspaceIdAtom} from '#runtime/last-workspace.js';
+import {lastWorkspaceIdAtom, rememberLastWorkspaceId} from '#runtime/last-workspace.js';
 
 export function WorkspaceSwitcher({
   activeWorkspaceId,
@@ -20,12 +20,13 @@ export function WorkspaceSwitcher({
   activeWorkspaceId?: string;
   onSelect?: () => void;
 }) {
-  const {workspaces} = useAuthState();
+  const {user, workspaces} = useAuthState();
   const navigate = useNavigate();
   const setLastWorkspaceId = useSetAtom(lastWorkspaceIdAtom);
   const selectWorkspace = (wid: string) => {
     try {
       setLastWorkspaceId(wid);
+      if (user?.id) rememberLastWorkspaceId(user.id, wid);
     } catch {
       // Local storage is best effort.
     }

--- a/libs/client/shell/src/runtime/anchors.tsx
+++ b/libs/client/shell/src/runtime/anchors.tsx
@@ -29,17 +29,17 @@ export function buildAnchorSkeleton({
     getParentRoute: () => rootRoute,
     path: anchorPaths.workspaceLayout,
     beforeLoad: async ({context, params, location}) => {
-      try {
-        rememberLastWorkspaceId(params.wid);
-      } catch {
-        // Local storage is best effort.
-      }
       const auth = context.auth;
       if (!auth || auth.isLoading || !context.queryClient) return;
       if (!auth.isAuthenticated)
         throw redirect({to: '/auth/login' as never, search: {redirect: location.href} as never});
       if (!auth.workspaces.some((workspace) => workspace.id === params.wid))
         throw redirect({to: '/'});
+      try {
+        if (auth.user?.id) rememberLastWorkspaceId(auth.user.id, params.wid);
+      } catch {
+        // Local storage is best effort.
+      }
       if (!context.workspaceSetup)
         throw new Error('Client composition includes workspace routes but no workspaceSetup gate.');
       return await context.workspaceSetup({

--- a/libs/client/shell/src/runtime/auth.tsx
+++ b/libs/client/shell/src/runtime/auth.tsx
@@ -1,5 +1,5 @@
 import {ApiError, configureApiClient} from '@shipfox/client-api';
-import {useQueryClient} from '@tanstack/react-query';
+import {type QueryClient, useQueryClient} from '@tanstack/react-query';
 import {atom, useAtomValue, useSetAtom, useStore} from 'jotai';
 import type {PropsWithChildren} from 'react';
 import {useCallback, useEffect, useMemo} from 'react';
@@ -9,10 +9,16 @@ import {
   authRefreshQueryOptions,
   userWorkspacesQueryOptions,
 } from '#hooks/api/session-auth.js';
+import {lastWorkspaceIdAtom} from './last-workspace.js';
 
 const REFRESH_EARLY_MS = 5 * 60 * 1000;
 const REFRESH_RETRY_DELAY_MS = 60_000;
 const BASE64_URL_REPLACEMENTS = {dash: /-/g, underscore: /_/g} as const;
+const refreshPromises = new WeakMap<QueryClient, Promise<AuthenticatedSession>>();
+
+function invalidateRefresh(queryClient: QueryClient): void {
+  refreshPromises.delete(queryClient);
+}
 
 export type AuthStatus = 'loading' | 'authenticated' | 'guest';
 
@@ -97,30 +103,49 @@ export function useAuthTransition() {
   const queryClient = useQueryClient();
   const store = useStore();
   const setState = useSetAtom(authStateAtom);
+  const setLastWorkspaceId = useSetAtom(lastWorkspaceIdAtom);
+
+  const beginAuthTransition = useCallback(() => {
+    const transitionEpoch = store.get(authTransitionEpochAtom) + 1;
+    store.set(authTransitionEpochAtom, transitionEpoch);
+    return transitionEpoch;
+  }, [store]);
 
   const clearPrivateState = useCallback(async () => {
     await queryClient.cancelQueries();
     queryClient.clear();
   }, [queryClient]);
 
-  const enterGuest = useCallback(async () => {
-    const transitionEpoch = store.get(authTransitionEpochAtom) + 1;
-    store.set(authTransitionEpochAtom, transitionEpoch);
-    await clearPrivateState();
-    if (store.get(authTransitionEpochAtom) !== transitionEpoch) return;
-    setState({status: 'guest'});
-  }, [clearPrivateState, setState, store]);
+  const enterGuest = useCallback(
+    async (transitionEpoch?: number) => {
+      const isExternalTransition = transitionEpoch === undefined;
+      const epoch = transitionEpoch ?? beginAuthTransition();
+      if (isExternalTransition) invalidateRefresh(queryClient);
+      if (store.get(authTransitionEpochAtom) !== epoch) return false;
+
+      await clearPrivateState();
+      if (store.get(authTransitionEpochAtom) !== epoch) return false;
+      setLastWorkspaceId(undefined);
+      setState({status: 'guest'});
+      return true;
+    },
+    [beginAuthTransition, clearPrivateState, queryClient, setLastWorkspaceId, setState, store],
+  );
 
   const enterAuthenticated = useCallback(
-    async (session: AuthenticatedSession) => {
-      const transitionEpoch = store.get(authTransitionEpochAtom) + 1;
-      store.set(authTransitionEpochAtom, transitionEpoch);
+    async (session: AuthenticatedSession, transitionEpoch?: number) => {
+      const isExternalTransition = transitionEpoch === undefined;
+      const epoch = transitionEpoch ?? beginAuthTransition();
+      if (isExternalTransition) invalidateRefresh(queryClient);
+      if (store.get(authTransitionEpochAtom) !== epoch) return false;
+
       const previousState = store.get(authStateAtom);
       const principalChanged =
-        previousState.status === 'authenticated' && previousState.user?.id !== session.user.id;
+        previousState.status !== 'authenticated' || previousState.user?.id !== session.user.id;
 
       if (principalChanged) await clearPrivateState();
-      if (store.get(authTransitionEpochAtom) !== transitionEpoch) return;
+      if (store.get(authTransitionEpochAtom) !== epoch) return false;
+      if (principalChanged) setLastWorkspaceId(undefined);
 
       queryClient.setQueryData(authRefreshQueryKey, session);
       let workspaces: WorkspaceSummary[] = [];
@@ -132,29 +157,56 @@ export function useAuthTransition() {
       } catch {
         // The authenticated session remains usable while workspace hydration retries on the next route load.
       }
-      if (store.get(authTransitionEpochAtom) !== transitionEpoch) return;
+      if (store.get(authTransitionEpochAtom) !== epoch) return false;
 
       setState(toAuthenticatedState(session, workspaces));
+      return true;
     },
-    [clearPrivateState, queryClient, setState, store],
+    [beginAuthTransition, clearPrivateState, queryClient, setLastWorkspaceId, setState, store],
   );
 
-  return {enterAuthenticated, enterGuest};
+  return {beginAuthTransition, enterAuthenticated, enterGuest};
 }
 
 export function useRefreshAuth() {
   const queryClient = useQueryClient();
-  const {enterAuthenticated, enterGuest} = useAuthTransition();
-  return useCallback(async () => {
-    try {
-      const result = await queryClient.fetchQuery(authRefreshQueryOptions());
-      await enterAuthenticated(result);
-      return result;
-    } catch (error) {
-      if (error instanceof ApiError && error.status === 401) await enterGuest();
-      throw error;
-    }
-  }, [enterAuthenticated, enterGuest, queryClient]);
+  const {beginAuthTransition, enterAuthenticated, enterGuest} = useAuthTransition();
+
+  return useCallback(() => {
+    const existingRefresh = refreshPromises.get(queryClient);
+    if (existingRefresh) return existingRefresh;
+
+    const transitionEpoch = beginAuthTransition();
+    const refresh = (async () => {
+      try {
+        const result = await queryClient.fetchQuery(authRefreshQueryOptions());
+        const accepted = await enterAuthenticated(result, transitionEpoch);
+        if (!accepted) {
+          throw new ApiError({
+            message: 'Authentication refresh was superseded.',
+            code: 'unauthorized',
+            status: 401,
+          });
+        }
+        return result;
+      } catch (error) {
+        if (error instanceof ApiError && error.status === 401) {
+          await enterGuest(transitionEpoch);
+        }
+        throw error;
+      }
+    })();
+    refreshPromises.set(queryClient, refresh);
+    void refresh.then(
+      () => {
+        if (refreshPromises.get(queryClient) === refresh) refreshPromises.delete(queryClient);
+      },
+      () => {
+        if (refreshPromises.get(queryClient) === refresh) refreshPromises.delete(queryClient);
+      },
+    );
+    return refresh;
+  }, [beginAuthTransition, enterAuthenticated, enterGuest, queryClient]);
 }
 
 export interface AuthRuntimeProps extends PropsWithChildren {

--- a/libs/client/shell/src/runtime/last-workspace.ts
+++ b/libs/client/shell/src/runtime/last-workspace.ts
@@ -1,14 +1,12 @@
 import {createTypedBrowserStorage, localStorageOrUndefined} from '@shipfox/client-ui';
 import {atom} from 'jotai';
 
-const lastWorkspaceStorageKey = 'shipfox.lastWorkspaceId';
-
-const lastWorkspaceStorage = createTypedBrowserStorage(localStorageOrUndefined, {
-  key: lastWorkspaceStorageKey,
+const lastWorkspaceStorageKey = {
+  key: 'shipfox.lastWorkspaceId',
   lifetime: 'persistent',
   principalScope: 'principal',
   serialize: (workspaceId: string) => JSON.stringify(workspaceId),
-  parse: (raw) => {
+  parse: (raw: string) => {
     try {
       const parsed: unknown = JSON.parse(raw);
       return typeof parsed === 'string' ? parsed : undefined;
@@ -16,33 +14,21 @@ const lastWorkspaceStorage = createTypedBrowserStorage(localStorageOrUndefined, 
       return undefined;
     }
   },
-});
+} as const;
 
-const storedLastWorkspaceIdAtom = atom<string | undefined>(getLastWorkspaceId());
+/** The current workspace selection for consumers that need in-memory UI state. */
+export const lastWorkspaceIdAtom = atom<string | undefined>(undefined);
 
-storedLastWorkspaceIdAtom.onMount = (setLastWorkspaceId) => {
-  if (typeof window === 'undefined') return undefined;
-
-  const syncFromStorage = (event: StorageEvent) => {
-    if (event.key === lastWorkspaceStorageKey) setLastWorkspaceId(getLastWorkspaceId());
-  };
-  window.addEventListener('storage', syncFromStorage);
-  return () => window.removeEventListener('storage', syncFromStorage);
-};
-
-export const lastWorkspaceIdAtom = atom(
-  (get) => get(storedLastWorkspaceIdAtom),
-  (_get, set, workspaceId: string | undefined) => {
-    set(storedLastWorkspaceIdAtom, workspaceId);
-    if (workspaceId === undefined) lastWorkspaceStorage.remove();
-    else lastWorkspaceStorage.write(workspaceId);
-  },
-);
-
-export function getLastWorkspaceId(): string | undefined {
-  return lastWorkspaceStorage.read();
+export function getLastWorkspaceId(principalId: string): string | undefined {
+  return lastWorkspaceStorage(principalId).read();
 }
 
-export function rememberLastWorkspaceId(workspaceId: string): void {
-  lastWorkspaceStorage.write(workspaceId);
+export function rememberLastWorkspaceId(principalId: string, workspaceId: string): void {
+  lastWorkspaceStorage(principalId).write(workspaceId);
+}
+
+function lastWorkspaceStorage(principalId: string) {
+  return createTypedBrowserStorage(localStorageOrUndefined, lastWorkspaceStorageKey, {
+    principalId,
+  });
 }

--- a/libs/client/ui/src/browser-storage.ts
+++ b/libs/client/ui/src/browser-storage.ts
@@ -1,4 +1,10 @@
-export type {BrowserStorage, BrowserStorageKey, TypedBrowserStorage} from '@shipfox/react-ui/utils';
+export type {
+  BrowserStorage,
+  BrowserStorageKey,
+  BrowserStorageScope,
+  BrowserStorageScopeProvider,
+  TypedBrowserStorage,
+} from '@shipfox/react-ui/utils';
 export {
   createTypedBrowserStorage,
   localStorageOrUndefined,

--- a/libs/shared/react/ui/src/utils/browser-storage.test.ts
+++ b/libs/shared/react/ui/src/utils/browser-storage.test.ts
@@ -1,0 +1,149 @@
+import {type BrowserStorage, createTypedBrowserStorage} from './browser-storage.js';
+
+const globalKey = {
+  key: 'shipfox.test.preference',
+  lifetime: 'persistent' as const,
+  principalScope: 'global' as const,
+  serialize: (value: string) => JSON.stringify(value),
+  parse: (value: string) => {
+    try {
+      const parsed: unknown = JSON.parse(value);
+      return typeof parsed === 'string' ? parsed : undefined;
+    } catch {
+      return undefined;
+    }
+  },
+};
+
+const privateKey = {
+  key: 'shipfox.test.private',
+  lifetime: 'persistent' as const,
+  principalScope: 'principal' as const,
+  serialize: (value: string) => JSON.stringify(value),
+  parse: (value: string) => {
+    try {
+      const parsed: unknown = JSON.parse(value);
+      return typeof parsed === 'string' ? parsed : undefined;
+    } catch {
+      return undefined;
+    }
+  },
+};
+
+const workspaceKey = {
+  key: 'shipfox.test.workspace',
+  lifetime: 'session' as const,
+  principalScope: 'workspace' as const,
+  serialize: (value: string) => value,
+  parse: (value: string) => value || undefined,
+};
+
+function storage(initial: Record<string, string> = {}): BrowserStorage {
+  const values = new Map(Object.entries(initial));
+  return {
+    getItem: vi.fn((name) => values.get(name) ?? null),
+    setItem: vi.fn((name, value) => values.set(name, value)),
+    removeItem: vi.fn((name) => values.delete(name)),
+  };
+}
+
+describe('createTypedBrowserStorage', () => {
+  it('serializes, validates, and removes global values', () => {
+    const raw = storage();
+    const preference = createTypedBrowserStorage(() => raw, globalKey);
+
+    preference.write('dark');
+    const read = preference.read();
+    preference.remove();
+
+    expect(read).toBe('dark');
+    expect(raw.removeItem).toHaveBeenCalledWith(globalKey.key);
+  });
+
+  it('isolates principal-scoped values by derived storage key', () => {
+    const raw = storage();
+    const principalA = createTypedBrowserStorage(() => raw, privateKey, {
+      principalId: 'principal-a',
+    });
+    const principalB = createTypedBrowserStorage(() => raw, privateKey, {
+      principalId: 'principal-b',
+    });
+
+    principalA.write('private A');
+
+    expect(principalA.read()).toBe('private A');
+    expect(principalB.read()).toBeUndefined();
+    expect(raw.getItem).toHaveBeenCalledWith('shipfox.test.private.principal.principal-b');
+  });
+
+  it('isolates workspace-scoped values and ignores an invalid scope', () => {
+    const raw = storage();
+    const workspaceA = createTypedBrowserStorage(() => raw, workspaceKey, {
+      workspaceId: 'workspace-a',
+    });
+    const workspaceB = createTypedBrowserStorage(() => raw, workspaceKey, {
+      workspaceId: 'workspace-b',
+    });
+    const invalidWorkspace = createTypedBrowserStorage(() => raw, workspaceKey, {
+      workspaceId: 'workspace/a',
+    });
+
+    workspaceA.write('workspace A');
+
+    expect(workspaceA.read()).toBe('workspace A');
+    expect(workspaceB.read()).toBeUndefined();
+    expect(invalidWorkspace.read()).toBeUndefined();
+    expect(raw.setItem).toHaveBeenCalledWith(
+      'shipfox.test.workspace.workspace.workspace-a',
+      'workspace A',
+    );
+  });
+
+  it('supports a scope provider without reusing a previous principal', () => {
+    const raw = storage();
+    let principalId: string | undefined = 'principal-a';
+    const privateStorage = createTypedBrowserStorage(
+      () => raw,
+      privateKey,
+      () => (principalId ? {principalId} : undefined),
+    );
+
+    privateStorage.write('private A');
+    principalId = 'principal-b';
+
+    expect(privateStorage.read()).toBeUndefined();
+  });
+
+  it('treats malformed persisted values as absent', () => {
+    const preference = createTypedBrowserStorage(
+      () => storage({'shipfox.test.preference': '{'}),
+      globalKey,
+    );
+
+    expect(preference.read()).toBeUndefined();
+  });
+
+  it('does not throw when storage is unavailable or rejects an operation', () => {
+    const unavailable = createTypedBrowserStorage<string>(() => {
+      throw new Error('storage unavailable');
+    }, globalKey);
+    const rejecting = createTypedBrowserStorage(
+      () => ({
+        getItem: () => {
+          throw new Error('blocked');
+        },
+        setItem: () => {
+          throw new Error('blocked');
+        },
+        removeItem: () => {
+          throw new Error('blocked');
+        },
+      }),
+      globalKey,
+    );
+
+    expect(unavailable.read()).toBeUndefined();
+    expect(() => rejecting.write('dark')).not.toThrow();
+    expect(() => rejecting.remove()).not.toThrow();
+  });
+});

--- a/libs/shared/react/ui/src/utils/browser-storage.ts
+++ b/libs/shared/react/ui/src/utils/browser-storage.ts
@@ -15,25 +15,54 @@ export interface BrowserStorageKey<T> {
   parse(value: string): T | undefined;
 }
 
+/** The validated identity used to derive a non-global browser-storage key. */
+export type BrowserStorageScope = {principalId: string} | {workspaceId: string};
+
+export type BrowserStorageScopeProvider<Scope extends BrowserStorageScope = BrowserStorageScope> =
+  () => Scope | undefined;
+
+const BROWSER_STORAGE_SCOPE_ID = /^[A-Za-z0-9][A-Za-z0-9._~-]{0,127}$/u;
+
 export interface TypedBrowserStorage<T> {
   read(): T | undefined;
   write(value: T): void;
   remove(): void;
 }
 
+export function createTypedBrowserStorage<T>(
+  getStorage: () => BrowserStorage | undefined,
+  definition: BrowserStorageKey<T> & {principalScope: 'global'},
+): TypedBrowserStorage<T>;
+export function createTypedBrowserStorage<T>(
+  getStorage: () => BrowserStorage | undefined,
+  definition: BrowserStorageKey<T> & {principalScope: 'workspace'},
+  scope: {workspaceId: string} | BrowserStorageScopeProvider<{workspaceId: string}>,
+): TypedBrowserStorage<T>;
+export function createTypedBrowserStorage<T>(
+  getStorage: () => BrowserStorage | undefined,
+  definition: BrowserStorageKey<T> & {principalScope: 'principal'},
+  scope: {principalId: string} | BrowserStorageScopeProvider<{principalId: string}>,
+): TypedBrowserStorage<T>;
+
 /**
  * Best-effort storage for non-authoritative browser preferences and recovery hints.
  * Reads validate untrusted persisted text, and every storage exception degrades to
- * an absent value so privacy mode and quota failures never interrupt user flows.
+ * an absent value so privacy mode, quota failures, and missing scopes never
+ * interrupt user flows. Non-global keys are derived from their validated scope.
  */
 export function createTypedBrowserStorage<T>(
   getStorage: () => BrowserStorage | undefined,
   definition: BrowserStorageKey<T>,
+  scope?: BrowserStorageScope | BrowserStorageScopeProvider,
 ): TypedBrowserStorage<T> {
+  const resolveKey = () => resolveBrowserStorageKey(definition, scope);
+
   return {
     read() {
       try {
-        const raw = getStorage()?.getItem(definition.key);
+        const key = resolveKey();
+        if (!key) return undefined;
+        const raw = getStorage()?.getItem(key);
         return raw === null || raw === undefined ? undefined : definition.parse(raw);
       } catch {
         return undefined;
@@ -41,19 +70,47 @@ export function createTypedBrowserStorage<T>(
     },
     write(value) {
       try {
-        getStorage()?.setItem(definition.key, definition.serialize(value));
+        const key = resolveKey();
+        if (!key) return;
+        getStorage()?.setItem(key, definition.serialize(value));
       } catch {
         // Persistence is intentionally non-authoritative.
       }
     },
     remove() {
       try {
-        getStorage()?.removeItem(definition.key);
+        const key = resolveKey();
+        if (!key) return;
+        getStorage()?.removeItem(key);
       } catch {
         // Persistence is intentionally non-authoritative.
       }
     },
   };
+}
+
+function resolveBrowserStorageKey<T>(
+  definition: BrowserStorageKey<T>,
+  scope: BrowserStorageScope | BrowserStorageScopeProvider | undefined,
+): string | undefined {
+  if (definition.principalScope === 'global') return definition.key;
+
+  const resolvedScope = typeof scope === 'function' ? scope() : scope;
+  const scopeId =
+    definition.principalScope === 'principal'
+      ? resolvedScope && 'principalId' in resolvedScope
+        ? resolvedScope.principalId
+        : undefined
+      : resolvedScope && 'workspaceId' in resolvedScope
+        ? resolvedScope.workspaceId
+        : undefined;
+
+  if (!isValidBrowserStorageScopeId(scopeId)) return undefined;
+  return `${definition.key}.${definition.principalScope}.${encodeURIComponent(scopeId)}`;
+}
+
+function isValidBrowserStorageScopeId(value: string | undefined): value is string {
+  return value !== undefined && BROWSER_STORAGE_SCOPE_ID.test(value);
 }
 
 export function localStorageOrUndefined(): BrowserStorage | undefined {

--- a/libs/shared/react/ui/src/utils/index.ts
+++ b/libs/shared/react/ui/src/utils/index.ts
@@ -1,5 +1,11 @@
 export {getInitial, getPlaceholderImageUrl} from './avatar.js';
-export type {BrowserStorage, BrowserStorageKey, TypedBrowserStorage} from './browser-storage.js';
+export type {
+  BrowserStorage,
+  BrowserStorageKey,
+  BrowserStorageScope,
+  BrowserStorageScopeProvider,
+  TypedBrowserStorage,
+} from './browser-storage.js';
 export {
   createTypedBrowserStorage,
   localStorageOrUndefined,


### PR DESCRIPTION
Private browser persistence and React Query data are now isolated by authenticated principal and workspace scope. Auth transition handling also linearizes concurrent refresh, login, and logout operations so stale results cannot overwrite the current session.

A superseded refresh now preserves the typed 401 error contract without retrying a request with a stale token. The public last-workspace atom remains available for compatibility but is cleared across principal transitions. One-shot OAuth callback handoffs remain explicitly global because they must be readable before workspace hydration.

Validation passed: forced Turbo typecheck (75/75 tasks), forced Turbo tests (46/46 tasks; 967 tests), client architecture audit, Biome, and diff checks.

Closes ENG-1187

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolate private browser storage and React Query data per authenticated principal and workspace to prevent cross-user leakage. Linearize auth transitions so stale refresh/login/logout can’t overwrite the current session (ENG-1187).

- **New Features**
  - Scope browser storage and React Query cache by principal/workspace; clear private cache on principal switch and before accepting the first principal.
  - Add typed, scoped storage in `@shipfox/react-ui` that validates data, supports global/principal/workspace scopes, and degrades safely when storage is unavailable.
  - Persist “last workspace” per principal and update redirect/switchers to read/write per-principal keys; keep `lastWorkspaceIdAtom` as in-memory UI state; OAuth install callback hints (`linear`, `slack`, `sentry`) remain global.

- **Bug Fixes**
  - Serialize refresh/login/logout via a per-`QueryClient` refresh gate; superseded refresh returns a typed 401 `ApiError` instead of restoring stale results.
  - Ensure logout always clears local private state and aborts in-flight private queries.

<sup>Written for commit 28fbdc3d636807d53f308f2c55043f7008cc0c2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

