### PR TITLE
[client-workflows] Stabilize workflow source panel snapshots

### DIFF
--- a/libs/client/workflows/src/components/workflow-source-panel/workflow-source-panel.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-source-panel/workflow-source-panel.stories.tsx
@@ -61,6 +61,10 @@ async function captureHighlightedSourcePanel(
     },
     {timeout: 10_000},
   );
+  const loadedCodeFonts = await document.fonts.load('400 14px "Commit Mono"');
+  if (!loadedCodeFonts.some((font) => font.status === 'loaded')) {
+    throw new Error('Commit Mono has not loaded yet');
+  }
   await argosScreenshot(ctx, screenshotName);
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stabilize Workflow Source Panel visual snapshots by waiting for the `Commit Mono` font to load before taking Argos screenshots. Prevents fallback font rendering from causing flaky diffs.

<sup>Written for commit b9f9bcd434428aaeb4ebf5fa7f37053919742bb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

