### PR TITLE
Finalize client architecture enforcement ownership

### DIFF
--- a/docs/architecture/client-architecture.md
+++ b/docs/architecture/client-architecture.md
@@ -180,30 +180,49 @@ when adding, moving, or debugging an enforcement rule. It owns the boundary
 between Biome, Dependency Cruiser, executable contract tests, and repository
 policy.
 
-Run the affected package `check` and `pnpm check:client-architecture` after
-changing a client boundary. Package checks run the local Biome rules and report
-source locations for response DTO imports, DTO or framework imports in `core/`,
-raw API requests, and leaf-component query-cache ownership. The repository
-verifier inventories production adapters and query hooks under `libs/client/**`
-and `libs/shared/react/ui/**`. It rejects direct API requests outside adapters,
-unparsed API responses, checked business responses returned without a mapper,
-inline query policies, query hooks outside adapters, direct query-client
-operations outside an owning adapter or named coordinator. Both checks require
-zero production violations. Neither check has a migration baseline or broad
-allowlist. A shell/runtime or cross-feature coordinator that needs a direct
-query-client operation must be recorded in the
+Each invariant has one enforcement owner:
+
+| Owner | What it checks | Where to fix it |
+| --- | --- | --- |
+| Biome plugins | Local source shape: DTO and framework imports in `core/`, response DTOs in pages and components, raw `apiRequest`, leaf-component query-cache writes, raw route inputs, and direct browser storage. | Fix the import or call at the diagnostic location. Do not add `biome-ignore`. |
+| `@shipfox/client-architecture-policy` | Semantic and repository facts: checked requests outside adapters, raw responses inside adapters, DTO-to-domain mapping, reusable query policies, query-hook placement, cache-operation ownership, private feature imports, and feature contributions. | Move the code to its adapter, domain, or coordinator boundary; add an exact tested exception only when the boundary is intentional. |
+| Focused tests | Composition, cache effects, principal isolation, persistence, retries, and user journeys. | Update the owning contract or runtime test. |
+
+Package checks run the local Biome rules and report source locations. The
+repository verifier inventories production adapters and query hooks under
+`libs/client/**` and `libs/shared/react/ui/**`. Both checks require zero
+production violations. Neither check has a migration baseline or broad
+allowlist.
+
+A shell/runtime or cross-feature coordinator that needs a direct query-client
+operation must be recorded in the
 [`cacheOperation` registry](../../tools/client-architecture-policy/src/audit-client-architecture.ts)
 with its exact source file, owner, reason, and focused test. The verifier
 rejects unregistered operations and stale registry records. The step-log query
-is the only narrow query-policy exception; its per-view cursor and retry
+is the only narrow query-policy exception. Its per-view cursor and retry
 lifecycle is recorded in the same
 [`clientArchitectureExceptions`](../../tools/client-architecture-policy/src/audit-client-architecture.ts)
-registry. It also rejects deep imports into another feature's private modules
-and navigation or settings contributions that target a route owned by another
-feature without an explicit `coordinator`. Raw route-input parsing and direct
-browser-storage access are blocked separately, by the `no-raw-route-inputs`
-and `no-direct-browser-storage` Biome plugins in
-`tools/biome/plugins/client-architecture/`.
+registry. Every exception must name one owner, one reason, one owning boundary,
+and one focused test. Never use a baseline, package-wide allowlist,
+or unowned suppression.
+
+Run the affected package and its dependents after a client boundary change:
+
+```sh
+mise exec -- turbo check --filter=@shipfox/<package>...
+mise exec -- pnpm check:client-architecture
+```
+
+When changing a Biome plugin or the semantic verifier, also run the focused
+fixtures and packed external-consumer checks:
+
+```sh
+mise exec -- turbo test type --filter=@shipfox/biome --filter=@shipfox/client-architecture-policy
+mise exec -- pnpm check:client-architecture
+```
+
+The `no-raw-route-inputs` and `no-direct-browser-storage` Biome plugins in
+`tools/biome/plugins/client-architecture/` own those source-shape boundaries.
 
 A completed feature package has `core/` domain models and policies with no UI
 or transport imports; checked adapter functions that parse and map every

--- a/docs/guides/architecture-validation.md
+++ b/docs/guides/architecture-validation.md
@@ -173,8 +173,8 @@ mise exec -- pnpm check:dependencies
 mise exec -- pnpm check:published-artifacts
 ```
 
-The first two commands remain repository-specific migration gates. Do not copy
-their implementation into Cloud. Move shared rules into
+`check:client-architecture` is the Platform semantic client-policy gate. Do not
+copy its implementation into Cloud. Move shared rules into
 `@shipfox/architecture-policy` when that package is available.
 
 ## Cross-repository rules

--- a/tools/client-architecture-policy/src/audit-client-architecture.ts
+++ b/tools/client-architecture-policy/src/audit-client-architecture.ts
@@ -7,7 +7,7 @@ export interface ClientArchitectureViolation {
   file: string;
   occurrences: number;
   rule:
-    | 'api-request-outside-adapter'
+    | 'checked-api-request-outside-adapter'
     | 'non-owning-feature-contribution'
     | 'private-feature-import'
     | 'inline-query-policy'
@@ -80,7 +80,7 @@ const auditedDirectories = [
 ];
 const sourceFilePattern = /\.(?:ts|tsx)$/;
 const nonProductionSourcePattern = /\.(?:stories|test)\.(?:ts|tsx)$/;
-const apiRequestPattern = /\b(?:apiRequest|checkedApiRequest)\s*(?:<[^>]*>)?\s*\(/;
+const checkedApiRequestPattern = /\bcheckedApiRequest\s*(?:<[^>]*>)?\s*\(/;
 const uncheckedApiRequestPattern = /\bapiRequest\s*(?:<[^>]*>)?\s*\(/;
 const checkedApiRequestCallPattern = /\bcheckedApiRequest\s*(?:<[^>]*>)?\s*\(/g;
 const unmappedApiResponsePattern =
@@ -579,8 +579,11 @@ export function auditClientSource(file: string, source: string): ClientArchitect
     featureContributionOccurrences(normalizedFile, source),
   );
   if (!isAdapter && !isClientApi)
-    addViolation('api-request-outside-adapter', countMatches(source, apiRequestPattern));
-  if (!isClientApi)
+    addViolation(
+      'checked-api-request-outside-adapter',
+      countMatches(source, checkedApiRequestPattern),
+    );
+  if (isAdapter && !isClientApi)
     addViolation('unparsed-api-response', countMatches(source, uncheckedApiRequestPattern));
   if (isAdapter && !isClientApi) {
     addViolation('unmapped-api-response', countMatches(source, unmappedApiResponsePattern));

--- a/tools/client-architecture-policy/test/audit-client-architecture.test.ts
+++ b/tools/client-architecture-policy/test/audit-client-architecture.test.ts
@@ -134,27 +134,31 @@ export const projectsFeature = defineClientFeature({
     assert.deepEqual(violations, []);
   });
 
-  test('reports both unchecked and checked requests outside an adapter', () => {
+  test('leaves raw API request diagnostics outside adapters to Biome', () => {
     const violations = auditClientSource(
       'libs/client/projects/src/pages/project-page.tsx',
-      "apiRequest('/projects');\ncheckedApiRequest(schema, '/projects');",
+      "apiRequest('/projects');",
+    );
+
+    assert.deepEqual(violations, []);
+  });
+
+  test('reports a checked request used outside an adapter', () => {
+    const violations = auditClientSource(
+      'libs/client/projects/src/pages/project-page.tsx',
+      "checkedApiRequest(schema, '/projects');",
     );
 
     assert.deepEqual(violations, [
       {
         file: 'libs/client/projects/src/pages/project-page.tsx',
-        occurrences: 2,
-        rule: 'api-request-outside-adapter',
-      },
-      {
-        file: 'libs/client/projects/src/pages/project-page.tsx',
         occurrences: 1,
-        rule: 'unparsed-api-response',
+        rule: 'checked-api-request-outside-adapter',
       },
     ]);
   });
 
-  test('reports unparsed API responses from a feature adapter', () => {
+  test('reports raw API requests from a feature adapter', () => {
     const violations = auditClientSource(
       'libs/client/projects/src/hooks/api/list-projects.ts',
       "apiRequest('/projects');",
@@ -401,15 +405,12 @@ qc.invalidateQueries({queryKey: ['projects']});`,
     );
   });
 
-  test('reports remaining semantic boundary crossings', () => {
+  test('keeps source-local API request ownership out of the semantic verifier', () => {
     const page = auditClientSource(
       'libs/client/projects/src/pages/project-page.tsx',
       "import type {ProjectDto} from '@shipfox/api-projects-dto';\nimport {apiRequest} from '@shipfox/client-api';\napiRequest('/projects');",
     );
-    assert.deepEqual(
-      page.map((violation) => violation.rule),
-      ['api-request-outside-adapter', 'unparsed-api-response'],
-    );
+    assert.deepEqual(page, []);
   });
 
   test('rejects stale exception paths and missing focused tests', () => {


### PR DESCRIPTION
Retires the semantic verifier's duplicate raw `apiRequest` scan for non-adapter source while retaining checked-request enforcement outside adapters and raw-response enforcement inside adapters. Documents the final Biome, semantic-policy, and focused-test ownership model, exception requirements, and validation commands. Confirms the verifier has no migration baseline or broad allowlist.

Closes ENG-1188

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finalizes ownership between Biome and the semantic client verifier. Removes duplicate raw `apiRequest` scans outside adapters and keeps enforcement for `checkedApiRequest` outside adapters and raw responses inside adapters (ENG-1188).

- **Refactors**
  - Narrow semantic rule to `checked-api-request-outside-adapter`; raw `apiRequest` outside adapters is now owned by Biome.
  - Adjusted patterns and logic in `@shipfox/client-architecture-policy` to count only `checkedApiRequest` outside adapters and keep raw/ unmapped response checks inside adapters.
  - Updated tests to reflect the new ownership and expectations.
  - Expanded docs with the final enforcement table, strict exception requirements, and validation commands; clarified `check:client-architecture` as the Platform gate.

<sup>Written for commit 17e8fe27216d20aa1a8a9aeff7a255210bbd5ef0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

