### PR TITLE
[api-architecture-policy] Adopt shared architecture policy in Platform

### DIFF
--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -132,13 +132,15 @@ These checks enforce the rules:
 | --- | --- |
 | Biome | Local import and export syntax, including DTO root and `/inter-module` source shape. |
 | Dependency Cruiser | Resolved source dependency graph, including context-aware API package edges. |
-| API architecture policy | Package inventory, classifications, declared manifest edges, and intended public-contract subpaths. |
+| `@shipfox/architecture-policy` through the Platform adapter | Normalized package metadata, class and realm relationships, manifest edges, export intent, diagnostics, and exact exceptions. |
 | Package release verification | Packed public entry-point correctness and external-consumer closure. |
 
 The root [API architecture Biome plugins](../../tools/biome/plugins/api-architecture/README.md)
 report local DTO import and export violations at the source expression.
-`pnpm check:api-context-inventory` checks package classification, stale registry
-entries, manifest edges, and structural `/inter-module` export parity. It does
+`pnpm check:api-context-inventory` discovers the workspace facts and evaluates
+them through `@shipfox/architecture-policy`. Its local adapter reads
+`api-contexts.cjs` for classifications and bounded contexts, and it does not
+copy the class, realm, manifest, export, or exception decision trees. It does
 not parse source imports; use Dependency Cruiser for resolved source edges.
 `pnpm check:dependencies` checks dependency policy and manifest hygiene.
 `pnpm check:published-artifacts` checks packed public entry points.
@@ -152,9 +154,11 @@ when it meets ADR 0004's joint-ownership rules. Keep a same-context SPI narrow
 and unavailable to other contexts. Consumer tests use DTO fixtures or contract
 fakes; only composition and E2E tests may compose real modules.
 
-[`tools/api-architecture-policy`](../../tools/api-architecture-policy) enforces
-the registry without migration exceptions. Update it when the durable policy
-changes, never to admit a completed violation.
+[`tools/api-architecture-policy`](../../tools/api-architecture-policy) is the
+Platform discovery adapter for the shared policy. Update `api-contexts.cjs`
+when the local classification or Dependency Cruiser edge matrix changes, and
+update the shared package when a reusable policy rule changes. Neither layer
+may admit a completed violation with a baseline or broad exception.
 
 Update this guide when the current model changes. Update an ADR, or add one,
 when the durable decision, ownership model, or accepted tradeoff changes.

--- a/docs/guides/architecture-validation.md
+++ b/docs/guides/architecture-validation.md
@@ -147,9 +147,11 @@ mise exec -- turbo test --filter=@shipfox/<composition-package>...
 
 ## Repository architecture policy
 
-**A repository verifier owns facts that cross files and manifests.** Current
-verifiers cover client architecture and the server package inventory while
-the shared policy package from ADR 0007 is built.
+**A repository verifier owns facts that cross files and manifests.** Platform
+uses `@shipfox/architecture-policy` through the local adapter in
+`tools/api-architecture-policy`. The adapter discovers Platform packages,
+manifests, classifications, export intent, and local configuration; the shared
+evaluator owns the reusable policy decisions.
 
 Use the repository layer for:
 
@@ -174,8 +176,9 @@ mise exec -- pnpm check:published-artifacts
 ```
 
 `check:client-architecture` is the Platform semantic client-policy gate. Do not
-copy its implementation into Cloud. Move shared rules into
-`@shipfox/architecture-policy` when that package is available.
+copy its implementation into Cloud. The API architecture command keeps
+Platform discovery local and evaluates the normalized facts through the shared
+package.
 
 ## Cross-repository rules
 
@@ -260,11 +263,12 @@ The repository currently uses:
 - `.dependency-cruiser.cjs` for package-local import topology.
 - `@shipfox/client-architecture-policy` for remaining client repository
   checks.
-- `@shipfox/api-architecture-policy` and `api-contexts.cjs` for server package
-  inventory, manifest edges, imports, and DTO exports.
+- `@shipfox/api-architecture-policy` for Platform discovery and shared-policy
+  evaluation over server package metadata and DTO export intent.
+- `api-contexts.cjs` and `.dependency-cruiser.cjs` for the local classification
+  registry and resolved source-import topology.
 - Focused composition tests for client and server runtime declarations.
 
-ADR 0007 targets a published `@shipfox/architecture-policy` package and
-architecture metadata in released manifests. Until that migration lands, keep
-the current gates passing and design new shared rules so their policy logic can
-move without copying repository discovery code.
+ADR 0007's normalized evaluator is now adopted by Platform. The remaining
+publication of the package and architecture metadata in released manifests are
+tracked separately; keep the local adapter thin while those contracts land.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7590,6 +7590,10 @@ importers:
         version: link:../../../../tools/vitest
 
   tools/api-architecture-policy:
+    dependencies:
+      '@shipfox/architecture-policy':
+        specifier: workspace:*
+        version: link:../architecture-policy
     devDependencies:
       '@shipfox/biome':
         specifier: workspace:*

--- a/tools/api-architecture-policy/package.json
+++ b/tools/api-architecture-policy/package.json
@@ -13,6 +13,9 @@
     "type:emit": "shipfox-tsc-emit",
     "verify": "node dist/api-context-inventory.js"
   },
+  "dependencies": {
+    "@shipfox/architecture-policy": "workspace:*"
+  },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",
     "@shipfox/swc": "workspace:*",

--- a/tools/api-architecture-policy/src/api-context-inventory.ts
+++ b/tools/api-architecture-policy/src/api-context-inventory.ts
@@ -1,276 +1,61 @@
-import {access, readdir, readFile} from 'node:fs/promises';
-import {createRequire} from 'node:module';
-import path from 'node:path';
 import process from 'node:process';
 import {fileURLToPath} from 'node:url';
+import type {PolicyDiagnostic} from '@shipfox/architecture-policy';
+import {
+  apiContextPackagePaths,
+  discoverPlatformArchitecturePolicy,
+  evaluatePlatformArchitecturePolicy,
+} from './platform-architecture-policy.js';
 
-const require = createRequire(import.meta.url);
-const {apiArchitectureEdgePolicy, architecturePackages} = require('../../../api-contexts.cjs') as {
-  apiArchitectureEdgePolicy: Record<
-    string,
-    Record<
-      string,
-      {
-        decision: 'allow' | 'same-context' | 'never';
-        violation?: string;
-      }
-    >
-  >;
-  architecturePackages: Record<string, Record<string, string[]>>;
+export {
+  apiContextPackagePaths,
+  discoverPlatformArchitecturePolicy,
+  evaluatePlatformArchitecturePolicy,
 };
-const repositoryRoot = fileURLToPath(new URL('../../../', import.meta.url));
-const serverRoots = [
-  'libs/api',
-  'libs/shared/common',
-  'libs/shared/expression',
-  'libs/shared/node',
-  'libs/shared/workflow',
-];
-const dependencyGroups = [
-  'dependencies',
-  'devDependencies',
-  'optionalDependencies',
-  'peerDependencies',
-] as const;
-const importViolationSuffixExpression = / import$/;
 
-interface ClassifiedPath {
-  classification: string;
-  context?: string;
-  packagePath: string;
+/**
+ * Compatibility helper for callers that need to compare discovered package
+ * paths with the local registry. Policy evaluation itself uses normalized
+ * facts and the shared evaluator.
+ */
+export function auditApiContextInventory(packagePaths: readonly string[]): string[] {
+  const configured = new Set(apiContextPackagePaths());
+  const discovered = new Set(packagePaths);
+  const errors = [
+    ...[...discovered]
+      .filter((packagePath) => !configured.has(packagePath))
+      .map((packagePath) => `Unclassified server package: ${packagePath}`),
+    ...[...configured]
+      .filter((packagePath) => !discovered.has(packagePath))
+      .map((packagePath) => `Classified server package does not exist: ${packagePath}`),
+  ];
+  return errors.sort();
 }
 
-interface PackageManifest {
-  dependencies?: Record<string, string>;
-  devDependencies?: Record<string, string>;
-  exports?: Record<string, unknown> | string;
-  name?: string;
-  optionalDependencies?: Record<string, string>;
-  peerDependencies?: Record<string, string>;
+export function auditRepository(): Promise<PolicyDiagnostic[]> {
+  return evaluatePlatformArchitecturePolicy();
 }
 
-function compareText(left: string, right: string): number {
-  if (left < right) return -1;
-  if (left > right) return 1;
-  return 0;
-}
-
-function classifiedPaths(): ClassifiedPath[] {
-  return Object.entries(architecturePackages).flatMap(([classification, contexts]) =>
-    Object.entries(contexts).flatMap(([context, paths]) =>
-      paths.map((packagePath) => ({
-        classification,
-        ...(classification === 'implementations' ||
-        classification === 'dto' ||
-        classification === 'spi'
-          ? {context}
-          : {}),
-        packagePath,
-      })),
-    ),
-  );
-}
-
-function packagesByName(manifests: Map<string, PackageManifest>): Map<string, ClassifiedPath> {
-  const result = new Map<string, ClassifiedPath>();
-  const classifications = new Map(classifiedPaths().map((entry) => [entry.packagePath, entry]));
-  for (const [packagePath, manifest] of manifests) {
-    const classification = classifications.get(packagePath);
-    if (classification && manifest.name) result.set(manifest.name, classification);
-  }
-  return result;
-}
-
-function architectureEdgeViolation(
-  importer: ClassifiedPath,
-  target: ClassifiedPath | undefined,
-): string | undefined {
-  if (!target) return undefined;
-  const edge = apiArchitectureEdgePolicy[importer.classification]?.[target.classification];
-  if (!edge) {
-    throw new Error(
-      `Missing API architecture edge policy decision: ${importer.classification} -> ${target.classification}`,
-    );
-  }
-  if (
-    edge.decision === 'allow' ||
-    (edge.decision === 'same-context' && importer.context === target.context)
-  )
-    return undefined;
-  return edge.violation;
-}
-
-function manifestViolation(
-  importer: ClassifiedPath,
-  target: ClassifiedPath | undefined,
-): string | undefined {
-  const violation = architectureEdgeViolation(importer, target);
-  return violation?.replace(importViolationSuffixExpression, ' manifest edge');
-}
-
-async function fileExists(filePath: string): Promise<boolean> {
-  try {
-    await access(filePath);
-    return true;
-  } catch (error) {
-    if (typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT')
-      return false;
-    throw error;
-  }
-}
-
-function interModuleParityViolation(hasSource: boolean, hasExport: boolean): string | undefined {
-  if (hasSource === hasExport) return undefined;
-  return hasSource
-    ? 'DTO inter-module source has no explicit package export'
-    : 'DTO inter-module export has no source file';
-}
-
-async function findPackagePaths(directory: string, relativeDirectory = ''): Promise<string[]> {
-  const entries = await readdir(directory, {withFileTypes: true});
-  const packagePaths: string[] = [];
-  for (const entry of entries) {
-    if (entry.name === 'node_modules' || entry.name === 'dist') continue;
-    const relativePath = path.posix.join(relativeDirectory, entry.name);
-    const absolutePath = path.join(directory, entry.name);
-    if (entry.isDirectory())
-      packagePaths.push(...(await findPackagePaths(absolutePath, relativePath)));
-    if (entry.name === 'package.json') packagePaths.push(path.posix.dirname(relativePath));
-  }
-  return packagePaths;
-}
-
-async function repositoryPackagePaths(): Promise<string[]> {
-  const paths = await Promise.all(
-    serverRoots.map(async (root) => {
-      const relativePaths = await findPackagePaths(path.join(repositoryRoot, root));
-      return relativePaths.map((relativePath) => path.posix.join(root, relativePath));
-    }),
-  );
-  return paths.flat().sort(compareText);
-}
-
-async function readManifests(packagePaths: string[]): Promise<Map<string, PackageManifest>> {
-  const manifests = await Promise.all(
-    packagePaths.map(async (packagePath) => {
-      const text = await readFile(path.join(repositoryRoot, packagePath, 'package.json'), 'utf8');
-      return [packagePath, JSON.parse(text) as PackageManifest] as const;
-    }),
-  );
-  return new Map(manifests);
-}
-
-function hasInterModuleEntry(exports: PackageManifest['exports']): boolean {
-  return typeof exports === 'object' && exports !== null && './inter-module' in exports;
-}
-
-export function apiContextPackagePaths(): string[] {
-  return classifiedPaths()
-    .map(({packagePath}) => packagePath)
-    .sort(compareText);
-}
-
-export function auditApiContextInventory(packagePaths: string[]): string[] {
-  const classifications = new Map<string, string[]>();
-  const errors: string[] = [];
-  for (const {classification, packagePath} of classifiedPaths()) {
-    const entries = classifications.get(packagePath) ?? [];
-    entries.push(classification);
-    classifications.set(packagePath, entries);
-  }
-  for (const packagePath of packagePaths) {
-    const entries = classifications.get(packagePath) ?? [];
-    if (entries.length === 0) errors.push(`Unclassified server package: ${packagePath}`);
-    if (entries.length > 1)
-      errors.push(`Server package has multiple classifications: ${packagePath}`);
-  }
-  for (const packagePath of classifications.keys()) {
-    if (!packagePaths.includes(packagePath))
-      errors.push(`Classified server package does not exist: ${packagePath}`);
-  }
-  return errors.sort(compareText);
-}
-
-export function auditPolicyFixture({
-  dependencyGroup,
-  dtoHasInterModuleEntry = false,
-  dtoHasInterModuleSource = false,
-  importerPath,
-  targetPath,
-}: {
-  dependencyGroup?: (typeof dependencyGroups)[number];
-  dtoHasInterModuleEntry?: boolean;
-  dtoHasInterModuleSource?: boolean;
-  importerPath: string;
-  targetPath?: string;
-}): string[] {
-  const classifications = new Map(classifiedPaths().map((entry) => [entry.packagePath, entry]));
-  const importer = classifications.get(importerPath);
-  const target = targetPath ? classifications.get(targetPath) : undefined;
-  const errors: string[] = [];
-
-  if (importer) {
-    const dependencyViolation = manifestViolation(importer, target);
-    if (dependencyGroup && dependencyViolation)
-      errors.push(`${dependencyViolation}: ${dependencyGroup}`);
-  }
-  if (importer?.classification === 'dto') {
-    const parityViolation = interModuleParityViolation(
-      dtoHasInterModuleSource,
-      dtoHasInterModuleEntry,
-    );
-    if (parityViolation) errors.push(parityViolation);
-  }
-  return errors;
-}
-
-export async function auditRepository(): Promise<string[]> {
-  const packagePaths = await repositoryPackagePaths();
-  const manifests = await readManifests(packagePaths);
-  const classifications = new Map(classifiedPaths().map((entry) => [entry.packagePath, entry]));
-  const packages = packagesByName(manifests);
-  const errors = auditApiContextInventory(packagePaths);
-
-  for (const [packagePath, manifest] of manifests) {
-    const classification = classifications.get(packagePath);
-    if (!classification) continue;
-    for (const group of dependencyGroups) {
-      for (const dependency of Object.keys(manifest[group] ?? {})) {
-        const violation = manifestViolation(classification, packages.get(dependency));
-        if (violation) {
-          errors.push(`${violation}: manifest:${packagePath}:package.json:${group}:${dependency}`);
-        }
-      }
-    }
-    if (classification.classification === 'dto') {
-      const hasInterModuleSource = await fileExists(
-        path.join(repositoryRoot, packagePath, 'src/inter-module.ts'),
-      );
-      const hasInterModuleExport = hasInterModuleEntry(manifest.exports);
-      const parityViolation = interModuleParityViolation(
-        hasInterModuleSource,
-        hasInterModuleExport,
-      );
-      if (parityViolation) errors.push(`${parityViolation}: dto-export:${packagePath}`);
-    }
-  }
-
-  return errors.sort(compareText);
+function formatDiagnostic(diagnostic: PolicyDiagnostic): string {
+  const location = diagnostic.source
+    ? `${diagnostic.source}${diagnostic.target ? ` -> ${diagnostic.target}` : ''}`
+    : '';
+  return [diagnostic.ruleId, location, diagnostic.message].filter(Boolean).join(': ');
 }
 
 async function main(): Promise<void> {
-  const errors = await auditRepository();
-  if (errors.length === 0) {
+  const diagnostics = await auditRepository();
+  if (diagnostics.length === 0) {
     process.stdout.write('API architecture policy passed\n');
     return;
   }
-  process.stderr.write(`API architecture policy failed (${errors.length} errors)\n`);
-  for (const error of errors) process.stderr.write(`- ${error}\n`);
+  process.stderr.write(`API architecture policy failed (${diagnostics.length} errors)\n`);
+  for (const diagnostic of diagnostics) process.stderr.write(`- ${formatDiagnostic(diagnostic)}\n`);
   process.exitCode = 1;
 }
 
 if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
-  main().catch((error) => {
+  main().catch((error: unknown) => {
     const message = error instanceof Error ? error.message : String(error);
     process.stderr.write(`API architecture policy failed: ${message}\n`);
     process.exitCode = 1;

--- a/tools/api-architecture-policy/src/platform-architecture-policy.ts
+++ b/tools/api-architecture-policy/src/platform-architecture-policy.ts
@@ -1,0 +1,473 @@
+import {access, readdir, readFile} from 'node:fs/promises';
+import {createRequire} from 'node:module';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {
+  type ArchitectureClassConfiguration,
+  type ArchitectureFacts,
+  architecturePolicySchemaVersion,
+  type CompositionFact,
+  createDefaultRepositoryConfiguration,
+  evaluateArchitecturePolicy,
+  type LocalPackageClassification,
+  type ManifestEdgeFact,
+  type PackageFact,
+  type PolicyDiagnostic,
+  type PublicExportFact,
+  type RepositoryConfiguration,
+} from '@shipfox/architecture-policy';
+
+const require = createRequire(import.meta.url);
+const repositoryRoot = fileURLToPath(new URL('../../../', import.meta.url));
+const platformRealm = 'source-available';
+const serverRoots = [
+  'libs/api',
+  'libs/shared/common',
+  'libs/shared/expression',
+  'libs/shared/node',
+  'libs/shared/workflow',
+] as const;
+const dependencyGroups = [
+  'dependencies',
+  'devDependencies',
+  'optionalDependencies',
+  'peerDependencies',
+] as const;
+const registryClassNames = {
+  implementations: 'implementation',
+  dto: 'dto',
+  'shared-semantic': 'shared-semantic',
+  'shared-infrastructure': 'shared-infrastructure',
+  spi: 'spi',
+  'composition-root': 'composition-root',
+} as const;
+const contextAwareRegistryClasses = new Set(['implementations', 'dto', 'spi']);
+const leadingRelativePathExpression = /^\.\//u;
+const distPathExpression = /^dist\//u;
+const mjsPathExpression = /\.m?js$/u;
+const cjsPathExpression = /\.c?js$/u;
+const jsxPathExpression = /\.jsx?$/u;
+
+interface ArchitectureRegistryEntry {
+  architectureClass: string;
+  boundedContext: string | null;
+  packagePath: string;
+}
+
+interface ApiArchitectureEdge {
+  decision: 'allow' | 'same-context' | 'never';
+  rule?: string;
+}
+
+interface PackageManifest {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  exports?: unknown;
+  name?: string;
+  optionalDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  version?: string;
+}
+
+interface ApiContextRegistry {
+  apiArchitectureEdgePolicy: Record<string, Record<string, ApiArchitectureEdge>>;
+  architecturePackages: Record<string, Record<string, string[]>>;
+}
+
+const {
+  apiArchitectureEdgePolicy,
+  architecturePackages,
+}: ApiContextRegistry = require('../../../api-contexts.cjs');
+
+export interface PlatformArchitecturePolicyDiscovery {
+  configuration: RepositoryConfiguration;
+  facts: ArchitectureFacts;
+}
+
+export interface PlatformArchitecturePolicyOptions {
+  compositionFacts?: readonly CompositionFact[];
+}
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function toRepositoryPath(filePath: string): string {
+  return path.relative(repositoryRoot, filePath).split(path.sep).join('/');
+}
+
+function registryEntries(): ArchitectureRegistryEntry[] {
+  return Object.entries(architecturePackages).flatMap(([registryClass, contexts]) => {
+    const architectureClass =
+      registryClassNames[registryClass as keyof typeof registryClassNames] ?? registryClass;
+    return Object.entries(contexts).flatMap(([boundedContext, packagePaths]) =>
+      packagePaths.map((packagePath) => ({
+        architectureClass,
+        boundedContext: contextAwareRegistryClasses.has(registryClass) ? boundedContext : null,
+        packagePath,
+      })),
+    );
+  });
+}
+
+function registryEntriesByPath(): Map<string, ArchitectureRegistryEntry[]> {
+  const entries = new Map<string, ArchitectureRegistryEntry[]>();
+  for (const entry of registryEntries()) {
+    const existing = entries.get(entry.packagePath) ?? [];
+    existing.push(entry);
+    entries.set(entry.packagePath, existing);
+  }
+  return entries;
+}
+
+async function findPackagePaths(directory: string, relativeDirectory = ''): Promise<string[]> {
+  const entries = await readdir(directory, {withFileTypes: true});
+  const packagePaths: string[] = [];
+  for (const entry of entries) {
+    if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+    const relativePath = path.posix.join(relativeDirectory, entry.name);
+    const absolutePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      packagePaths.push(...(await findPackagePaths(absolutePath, relativePath)));
+    } else if (entry.name === 'package.json') {
+      packagePaths.push(path.posix.dirname(relativePath));
+    }
+  }
+  return packagePaths;
+}
+
+async function repositoryPackagePaths(): Promise<string[]> {
+  const paths = await Promise.all(
+    serverRoots.map(async (root) => {
+      const relativePaths = await findPackagePaths(path.join(repositoryRoot, root));
+      return relativePaths.map((relativePath) => path.posix.join(root, relativePath));
+    }),
+  );
+  return paths.flat().sort(compareText);
+}
+
+async function readManifests(
+  packagePaths: readonly string[],
+): Promise<Map<string, PackageManifest>> {
+  const manifests = await Promise.all(
+    packagePaths.map(async (packagePath) => {
+      const text = await readFile(path.join(repositoryRoot, packagePath, 'package.json'), 'utf8');
+      return [packagePath, JSON.parse(text) as PackageManifest] as const;
+    }),
+  );
+  return new Map(manifests);
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch (error) {
+    if (typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT')
+      return false;
+    throw error;
+  }
+}
+
+function packageNameForPath(
+  packagePath: string,
+  manifests: ReadonlyMap<string, PackageManifest>,
+): string {
+  return manifests.get(packagePath)?.name ?? `workspace:${packagePath}`;
+}
+
+function packageFactForPath(
+  packagePath: string,
+  manifest: PackageManifest,
+  classifiedEntries: ReadonlyMap<string, ArchitectureRegistryEntry[]>,
+): PackageFact {
+  const classification = classifiedEntries.get(packagePath)?.[0];
+  const isPolicyParticipant =
+    packagePath.startsWith('libs/api/') || packagePath.startsWith('libs/shared/');
+  const hasManifestName = typeof manifest.name === 'string' && manifest.name.length > 0;
+  return {
+    schemaVersion: architecturePolicySchemaVersion,
+    name: manifest.name ?? `workspace:${packagePath}`,
+    version: manifest.version ?? null,
+    path: packagePath,
+    origin: 'local',
+    policyParticipant: isPolicyParticipant,
+    realm: isPolicyParticipant ? platformRealm : null,
+    architectureClass: isPolicyParticipant
+      ? hasManifestName && classification?.architectureClass
+        ? classification.architectureClass
+        : 'unclassified'
+      : null,
+    boundedContext: isPolicyParticipant ? (classification?.boundedContext ?? null) : null,
+  };
+}
+
+function externalPackageFact(name: string): PackageFact {
+  return {
+    schemaVersion: architecturePolicySchemaVersion,
+    name,
+    version: null,
+    path: `node_modules/${name}`,
+    origin: 'installed',
+    policyParticipant: false,
+    realm: null,
+    architectureClass: null,
+    boundedContext: null,
+  };
+}
+
+function dependencyNames(
+  manifest: PackageManifest,
+  group: (typeof dependencyGroups)[number],
+): string[] {
+  return Object.keys(manifest[group] ?? {}).sort(compareText);
+}
+
+function createManifestEdges(
+  packagePaths: readonly string[],
+  manifests: ReadonlyMap<string, PackageManifest>,
+  packageFactsByName: ReadonlyMap<string, PackageFact>,
+): {edges: ManifestEdgeFact[]; externalFacts: PackageFact[]} {
+  const edges: ManifestEdgeFact[] = [];
+  const externalFacts = new Map<string, PackageFact>();
+  for (const packagePath of packagePaths) {
+    const source = packageFactsByName.get(packageNameForPath(packagePath, manifests));
+    if (!source?.policyParticipant) continue;
+    const manifest = manifests.get(packagePath);
+    if (!manifest) continue;
+    for (const dependencyGroup of dependencyGroups) {
+      for (const target of dependencyNames(manifest, dependencyGroup)) {
+        if (!packageFactsByName.has(target)) externalFacts.set(target, externalPackageFact(target));
+        edges.push({
+          schemaVersion: architecturePolicySchemaVersion,
+          source: source.name,
+          target,
+          dependencyGroup,
+        });
+      }
+    }
+  }
+  return {
+    edges,
+    externalFacts: [...externalFacts.values()].sort((left, right) =>
+      compareText(left.name, right.name),
+    ),
+  };
+}
+
+function exportSubpaths(exportsValue: unknown): Array<[string, unknown]> {
+  if (typeof exportsValue === 'string' || Array.isArray(exportsValue) || exportsValue === undefined)
+    return exportsValue === undefined ? [] : [['.', exportsValue]];
+  if (typeof exportsValue !== 'object' || exportsValue === null) return [['.', exportsValue]];
+  const entries = Object.entries(exportsValue);
+  return entries.some(([key]) => key.startsWith('.')) ? entries : [['.', exportsValue]];
+}
+
+function resolveExportTarget(value: unknown): string | null {
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value)) {
+    for (const candidate of value) {
+      const resolved = resolveExportTarget(candidate);
+      if (resolved) return resolved;
+    }
+    return null;
+  }
+  if (typeof value !== 'object' || value === null) return null;
+  const records = value as Record<string, unknown>;
+  for (const condition of ['workspace-source', 'types', 'import', 'require', 'default']) {
+    if (!(condition in records)) continue;
+    const resolved = resolveExportTarget(records[condition]);
+    if (resolved) return resolved;
+  }
+  for (const candidate of Object.values(records)) {
+    const resolved = resolveExportTarget(candidate);
+    if (resolved) return resolved;
+  }
+  return null;
+}
+
+function sourceTargetCandidates(target: string): string[] {
+  const normalized = target.replace(leadingRelativePathExpression, '');
+  const sourceRoot = normalized.replace(distPathExpression, 'src/');
+  const candidates = new Set([normalized, sourceRoot]);
+  for (const candidate of [...candidates]) {
+    candidates.add(candidate.replace(mjsPathExpression, '.mts'));
+    candidates.add(candidate.replace(cjsPathExpression, '.cts'));
+    candidates.add(candidate.replace(jsxPathExpression, '.tsx'));
+    candidates.add(candidate.replace(mjsPathExpression, '.ts'));
+    candidates.add(candidate.replace(cjsPathExpression, '.ts'));
+    candidates.add(candidate.replace(jsxPathExpression, '.ts'));
+  }
+  return [...candidates];
+}
+
+async function resolveSourceTarget(
+  packagePath: string,
+  target: string | null,
+): Promise<string | null> {
+  if (!target || target.includes('*') || target.includes('..')) return null;
+  for (const candidate of sourceTargetCandidates(target)) {
+    const absolutePath = path.join(repositoryRoot, packagePath, candidate);
+    if (await fileExists(absolutePath)) return toRepositoryPath(absolutePath);
+  }
+  return null;
+}
+
+async function createPublicExports(
+  packagePaths: readonly string[],
+  manifests: ReadonlyMap<string, PackageManifest>,
+  packageFactsByName: ReadonlyMap<string, PackageFact>,
+): Promise<{exports: PublicExportFact[]; exportIntent: Record<string, string[]>}> {
+  const exports: PublicExportFact[] = [];
+  const exportIntent = new Map<string, Set<string>>();
+  for (const packagePath of packagePaths) {
+    const manifest = manifests.get(packagePath);
+    const packageFact = packageFactsByName.get(packageNameForPath(packagePath, manifests));
+    if (!manifest || !packageFact?.policyParticipant) continue;
+    const entries = exportSubpaths(manifest.exports);
+    for (const [publicSubpath, value] of entries) {
+      const declaredTarget = resolveExportTarget(value);
+      exports.push({
+        schemaVersion: architecturePolicySchemaVersion,
+        package: packageFact.name,
+        publicSubpath,
+        // The repository adapter owns the explicit DTO contract source. The
+        // packed-package verifier owns resolving every other public entrypoint.
+        resolvedTarget:
+          publicSubpath === './inter-module'
+            ? await resolveSourceTarget(packagePath, declaredTarget)
+            : declaredTarget,
+      });
+    }
+    if (await fileExists(path.join(repositoryRoot, packagePath, 'src/inter-module.ts'))) {
+      const expected = exportIntent.get(packageFact.name) ?? new Set<string>();
+      expected.add('./inter-module');
+      exportIntent.set(packageFact.name, expected);
+    }
+  }
+  return {
+    exports: exports.sort((left, right) =>
+      compareText(
+        `${left.package}:${left.publicSubpath}`,
+        `${right.package}:${right.publicSubpath}`,
+      ),
+    ),
+    exportIntent: Object.fromEntries(
+      [...exportIntent.entries()]
+        .sort(([left], [right]) => compareText(left, right))
+        .map(([packageName, subpaths]) => [packageName, [...subpaths].sort(compareText)]),
+    ),
+  };
+}
+
+function createArchitectureClasses(): Record<string, ArchitectureClassConfiguration> {
+  const configuration = createDefaultRepositoryConfiguration();
+  for (const entry of registryEntries()) {
+    configuration.architectureClasses[entry.architectureClass] ??= {
+      requiresBoundedContext: entry.boundedContext !== null,
+    };
+  }
+  return configuration.architectureClasses;
+}
+
+function createClassRelationships(): RepositoryConfiguration['classRelationships'] {
+  const relationships: RepositoryConfiguration['classRelationships'] = {};
+  for (const [sourceRegistryClass, targetRows] of Object.entries(apiArchitectureEdgePolicy)) {
+    const sourceClass =
+      registryClassNames[sourceRegistryClass as keyof typeof registryClassNames] ??
+      sourceRegistryClass;
+    const row: RepositoryConfiguration['classRelationships'][string] = {};
+    for (const [targetRegistryClass, edge] of Object.entries(targetRows)) {
+      const targetClass =
+        registryClassNames[targetRegistryClass as keyof typeof registryClassNames] ??
+        targetRegistryClass;
+      row[targetClass] = {
+        decision: edge.decision,
+        ...(edge.rule ? {ruleId: edge.rule} : {}),
+      };
+    }
+    relationships[sourceClass] = row;
+  }
+  return relationships;
+}
+
+function createConfiguration(
+  manifests: ReadonlyMap<string, PackageManifest>,
+  classifiedEntries: ReadonlyMap<string, ArchitectureRegistryEntry[]>,
+  exportIntent: Record<string, string[]>,
+): RepositoryConfiguration {
+  const configuration = createDefaultRepositoryConfiguration();
+  configuration.realms = {[platformRealm]: {mayDependOn: [platformRealm]}};
+  configuration.architectureClasses = createArchitectureClasses();
+  configuration.classRelationships = createClassRelationships();
+  configuration.localPackages = registryEntries().map<LocalPackageClassification>((entry) => ({
+    path: entry.packagePath,
+    packageName: packageNameForPath(entry.packagePath, manifests),
+    realm: platformRealm,
+    architectureClass: entry.architectureClass,
+    boundedContext: entry.boundedContext,
+  }));
+  configuration.compositionRoots = registryEntries()
+    .filter(({architectureClass}) => architectureClass === 'composition-root')
+    .map(({packagePath}) => packageNameForPath(packagePath, manifests));
+  configuration.exportIntent = exportIntent;
+  configuration.extensions = {
+    platform: {
+      classificationSource: 'api-contexts.cjs',
+      dependencyCruiserSource: 'api-contexts.cjs',
+      classifiedPackageCount: classifiedEntries.size,
+    },
+  };
+  return configuration;
+}
+
+export async function discoverPlatformArchitecturePolicy(
+  options: PlatformArchitecturePolicyOptions = {},
+): Promise<PlatformArchitecturePolicyDiscovery> {
+  const packagePaths = await repositoryPackagePaths();
+  const manifests = await readManifests(packagePaths);
+  const classifiedEntries = registryEntriesByPath();
+  const packageFacts = packagePaths.map((packagePath) =>
+    packageFactForPath(packagePath, manifests.get(packagePath) ?? {}, classifiedEntries),
+  );
+  const packageFactsByName = new Map(
+    packageFacts.map((packageFact) => [packageFact.name, packageFact]),
+  );
+  const {edges: manifestEdges, externalFacts} = createManifestEdges(
+    packagePaths,
+    manifests,
+    packageFactsByName,
+  );
+  const {exports, exportIntent} = await createPublicExports(
+    packagePaths,
+    manifests,
+    packageFactsByName,
+  );
+  const configuration = createConfiguration(manifests, classifiedEntries, exportIntent);
+  const facts: ArchitectureFacts = {
+    schemaVersion: architecturePolicySchemaVersion,
+    packages: [...packageFacts, ...externalFacts],
+    // Dependency Cruiser remains the owner of resolved source edges. Its rules
+    // consume the same api-contexts.cjs classifications and edge matrix.
+    importEdges: [],
+    manifestEdges,
+    publicExports: exports,
+    compositionFacts: [...(options.compositionFacts ?? [])],
+  };
+  return {configuration, facts};
+}
+
+export async function evaluatePlatformArchitecturePolicy(
+  options: PlatformArchitecturePolicyOptions = {},
+): Promise<PolicyDiagnostic[]> {
+  const {facts, configuration} = await discoverPlatformArchitecturePolicy(options);
+  return evaluateArchitecturePolicy(facts, configuration);
+}
+
+export function apiContextPackagePaths(): string[] {
+  return registryEntries()
+    .map(({packagePath}) => packagePath)
+    .sort(compareText);
+}
+
+export {platformRealm, serverRoots};

--- a/tools/api-architecture-policy/test/api-context-inventory.test.ts
+++ b/tools/api-architecture-policy/test/api-context-inventory.test.ts
@@ -1,109 +1,82 @@
 import assert from 'node:assert/strict';
+import {evaluateArchitecturePolicy} from '@shipfox/architecture-policy';
 import {
   apiContextPackagePaths,
   auditApiContextInventory,
-  auditPolicyFixture,
   auditRepository,
+  discoverPlatformArchitecturePolicy,
 } from '../src/api-context-inventory.js';
 
-describe('auditApiContextInventory', () => {
-  test('requires every relevant server package to have one classification', () => {
-    const errors = auditApiContextInventory([...apiContextPackagePaths(), 'libs/api/new-context']);
-
-    assert.deepEqual(errors, ['Unclassified server package: libs/api/new-context']);
+describe('Platform architecture-policy adapter', () => {
+  test('keeps registry completeness as a narrow discovery check', () => {
+    assert.deepEqual(
+      auditApiContextInventory([...apiContextPackagePaths(), 'libs/api/new-context']),
+      ['Unclassified server package: libs/api/new-context'],
+    );
   });
 
-  test('accepts the repository inventory', async () => {
-    const errors = await auditRepository();
+  test('discovers normalized package, manifest, and export facts', async () => {
+    const {configuration, facts} = await discoverPlatformArchitecturePolicy();
 
-    assert.deepEqual(errors, []);
+    assert.equal(facts.schemaVersion, 1);
+    assert.equal(facts.importEdges.length, 0);
+    assert.ok(
+      facts.packages.some(
+        (packageFact) =>
+          packageFact.name === '@shipfox/api-runners' &&
+          packageFact.architectureClass === 'implementation' &&
+          packageFact.boundedContext === 'runners' &&
+          packageFact.realm === 'source-available',
+      ),
+    );
+    assert.ok(
+      facts.manifestEdges.some(
+        (edge) =>
+          edge.source === '@shipfox/api-runners' && edge.target === '@shipfox/api-runners-dto',
+      ),
+    );
+    assert.ok(
+      facts.publicExports.some(
+        (entry) =>
+          entry.package === '@shipfox/api-runners-dto' &&
+          entry.publicSubpath === './inter-module' &&
+          entry.resolvedTarget?.endsWith('libs/api/runners-dto/src/inter-module.ts'),
+      ),
+    );
+    assert.equal(configuration.realms['source-available']?.mayDependOn[0], 'source-available');
+    assert.equal(configuration.compositionRoots[0], '@shipfox/api-server');
+    assert.deepEqual(configuration.extensions, {
+      platform: {
+        classificationSource: 'api-contexts.cjs',
+        dependencyCruiserSource: 'api-contexts.cjs',
+        classifiedPackageCount: configuration.localPackages.length,
+      },
+    });
   });
 
-  test('rejects a new foreign manifest edge and missing DTO inter-module export', () => {
-    const manifestErrors = auditPolicyFixture({
+  test('accepts the current repository through the shared evaluator', async () => {
+    assert.deepEqual(await auditRepository(), []);
+  });
+
+  test('uses shared diagnostics for manifest and export policy', async () => {
+    const discovery = await discoverPlatformArchitecturePolicy();
+    const runners = discovery.facts.packages.find(({name}) => name === '@shipfox/api-runners');
+    const auth = discovery.facts.packages.find(({name}) => name === '@shipfox/api-auth');
+    assert.ok(runners);
+    assert.ok(auth);
+    discovery.facts.manifestEdges.push({
+      schemaVersion: 1,
+      source: runners.name,
+      target: auth.name,
       dependencyGroup: 'devDependencies',
-      importerPath: 'libs/api/runners',
-      targetPath: 'libs/api/auth',
     });
-    const dtoErrors = auditPolicyFixture({
-      dtoHasInterModuleEntry: false,
-      dtoHasInterModuleSource: true,
-      importerPath: 'libs/api/projects-dto',
-    });
-
-    assert.deepEqual(manifestErrors, ['Foreign implementation manifest edge: devDependencies']);
-    assert.deepEqual(dtoErrors, ['DTO inter-module source has no explicit package export']);
-
-    const orphanExportErrors = auditPolicyFixture({
-      dtoHasInterModuleEntry: true,
-      importerPath: 'libs/api/projects-dto',
-    });
-    assert.deepEqual(orphanExportErrors, ['DTO inter-module export has no source file']);
-  });
-
-  test('validates every workspace dependency group through the shared edge policy', () => {
-    const dependencyGroups = [
-      'dependencies',
-      'devDependencies',
-      'optionalDependencies',
-      'peerDependencies',
-    ] as const;
-
-    for (const dependencyGroup of dependencyGroups) {
-      assert.deepEqual(
-        auditPolicyFixture({
-          dependencyGroup,
-          importerPath: 'libs/api/workflows-dto',
-          targetPath: 'libs/api/workflows',
-        }),
-        [`DTO implementation manifest edge: ${dependencyGroup}`],
-      );
-    }
-
-    assert.deepEqual(
-      auditPolicyFixture({
-        dependencyGroup: 'dependencies',
-        importerPath: 'libs/shared/common/runner-labels',
-        targetPath: 'libs/api/runners',
-      }),
-      ['Shared semantic implementation manifest edge: dependencies'],
+    discovery.facts.publicExports = discovery.facts.publicExports.filter(
+      ({package: packageName, publicSubpath}) =>
+        !(packageName === '@shipfox/api-runners-dto' && publicSubpath === './inter-module'),
     );
 
-    assert.deepEqual(
-      auditPolicyFixture({
-        dependencyGroup: 'dependencies',
-        importerPath: 'libs/api/integration/spi',
-        targetPath: 'libs/api/workflows',
-      }),
-      ['Foreign SPI implementation manifest edge: dependencies'],
-    );
-
-    assert.deepEqual(
-      auditPolicyFixture({
-        dependencyGroup: 'dependencies',
-        importerPath: 'libs/api/projects-dto',
-        targetPath: 'libs/api/integration/spi',
-      }),
-      ['DTO SPI manifest edge: dependencies'],
-    );
-
-    assert.deepEqual(
-      auditPolicyFixture({
-        dependencyGroup: 'dependencies',
-        importerPath: 'libs/shared/common/runner-labels',
-        targetPath: 'libs/api/integration/spi',
-      }),
-      ['Shared semantic SPI manifest edge: dependencies'],
-    );
-  });
-
-  test('rejects foreign implementation dependencies on same-context SPIs', () => {
-    const errors = auditPolicyFixture({
-      dependencyGroup: 'dependencies',
-      importerPath: 'libs/api/workflows',
-      targetPath: 'libs/api/integration/spi',
-    });
-
-    assert.deepEqual(errors, ['Foreign same-context SPI manifest edge: dependencies']);
+    const diagnostics = evaluateArchitecturePolicy(discovery.facts, discovery.configuration);
+    assert.ok(diagnostics.some(({ruleId}) => ruleId === 'architecture/manifest-edge'));
+    assert.ok(diagnostics.some(({ruleId}) => ruleId === 'architecture/export-intent'));
   });
 });


### PR DESCRIPTION
Platform now consumes `@shipfox/architecture-policy` through one local discovery adapter. The adapter normalizes the existing `api-contexts.cjs` registry into shared package, manifest, and export facts; the shared evaluator owns reusable class, realm, manifest-edge, export-intent, and exception decisions. Dependency Cruiser remains the owner of resolved source-import topology.

This keeps Platform’s local classification and discovery concerns explicit while preventing a second implementation of the migrated architecture policy. The documentation now records the ownership boundary and the remaining publication follow-up.

Validated with the focused package/dependent checks, `check:api-context-inventory`, dependency policy, API Dependency Cruiser rules, repository-documentation validation, published-artifact verification, and `git diff --check`.

Closes ENG-1214

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adopted the shared architecture policy evaluator in Platform via a local adapter, replacing custom checks in `tools/api-architecture-policy`. Implements ENG-1214 by aligning with ADR 0007 while keeping Platform-specific discovery local.

- **Refactors**
  - Added `platform-architecture-policy` adapter to normalize package facts, manifest edges, and public exports, and map realm/class relationships from `api-contexts.cjs`.
  - Switched `auditRepository` to evaluate through `@shipfox/architecture-policy` and emit shared diagnostics.
  - Kept `auditApiContextInventory` as a narrow completeness check for classified vs. discovered packages.
  - Updated tests to validate discovered facts and shared rule diagnostics; updated docs to reflect the new flow.

- **Dependencies**
  - Added `@shipfox/architecture-policy` to `tools/api-architecture-policy`.

<sup>Written for commit f5f371389500c761993e2b3149275387eae2b439. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

