### PR TITLE
[client-auth] Reject deeply encoded redirect bypasses

### DIFF
--- a/.changeset/quiet-paths-redirect.md
+++ b/.changeset/quiet-paths-redirect.md
@@ -1,0 +1,5 @@
+---
+'@shipfox/client-auth': patch
+---
+
+Reject deeply encoded authentication and invitation redirect paths before they can bypass path validation.

--- a/libs/client/auth/src/components/redirect-context.test.ts
+++ b/libs/client/auth/src/components/redirect-context.test.ts
@@ -23,11 +23,24 @@ describe('parseRedirectContext', () => {
   });
 
   test.each([
+    ['/%2569nvitations/accept?token=double-encoded-token', 'double-encoded-token'],
+    ['/%252569nvitations/accept?token=triple-encoded-token', 'triple-encoded-token'],
+  ])('separates an invitation token from a deeply encoded path: %s', (redirect, token) => {
+    const context = parseRedirectContext(redirect);
+
+    expect(context).toEqual({invitationToken: token});
+    expect(context.returnTo).toBeUndefined();
+  });
+
+  test.each([
     'https://attacker.example',
     '//attacker.example',
     '/auth/login',
     '/%61uth/login',
+    '/%2561uth/login',
+    '/%252561uth/login',
     '/%E0%80%80',
+    '/safe/%25252e%25252e/auth/login',
   ])('rejects malformed or unsafe redirect %s', (redirect) => {
     const context = parseRedirectContext(redirect);
 

--- a/libs/client/auth/src/components/redirect-context.ts
+++ b/libs/client/auth/src/components/redirect-context.ts
@@ -1,4 +1,4 @@
-import {sanitizeRedirectPath} from './redirect-target.js';
+import {isAuthPath, resolveRedirectPath} from './redirect-target.js';
 
 const INVITATION_ACCEPT_PATH = '/invitations/accept';
 
@@ -13,14 +13,11 @@ export interface RedirectContext {
  * short-lived invitation flow instead of forwarding it through generic redirects.
  */
 export function parseRedirectContext(value: unknown): RedirectContext {
-  const redirect = sanitizeRedirectPath(value);
-  if (!redirect) return {};
+  const resolved = resolveRedirectPath(value);
+  if (!resolved || isAuthPath(resolved.pathname)) return {};
 
-  const decoded = decodeURIComponent(redirect);
-  const [path, queryString = ''] = decoded.split('?', 2);
-  if (path !== INVITATION_ACCEPT_PATH) return {returnTo: redirect};
+  if (resolved.pathname !== INVITATION_ACCEPT_PATH) return {returnTo: resolved.redirect};
 
-  const params = new URLSearchParams(queryString);
-  const invitationToken = params.get('token');
+  const invitationToken = resolved.target.searchParams.get('token');
   return invitationToken ? {invitationToken} : {};
 }

--- a/libs/client/auth/src/components/redirect-target.test.ts
+++ b/libs/client/auth/src/components/redirect-target.test.ts
@@ -1,5 +1,13 @@
 import {sanitizeLogoutRedirectPath, sanitizeRedirectPath} from './redirect-target.js';
 
+function encodeRepeatedly(value: string, times: number): string {
+  let encoded = value;
+  for (let iteration = 0; iteration < times; iteration += 1) {
+    encoded = encodeURIComponent(encoded);
+  }
+  return encoded;
+}
+
 describe('sanitizeRedirectPath', () => {
   describe.each([
     ['simple absolute path', '/foo'],
@@ -41,8 +49,12 @@ describe('sanitizeRedirectPath', () => {
   });
 
   describe('decode-then-check defenses', () => {
-    test('rejects percent-encoded /auth/* path', () => {
-      const result = sanitizeRedirectPath('/%61uth/login');
+    test.each([
+      ['single-encoded', '/%61uth/login'],
+      ['double-encoded', '/%2561uth/login'],
+      ['triple-encoded', '/%252561uth/login'],
+    ])('rejects %s /auth/* path', (_label, input) => {
+      const result = sanitizeRedirectPath(input);
 
       expect(result).toBeUndefined();
     });
@@ -61,6 +73,30 @@ describe('sanitizeRedirectPath', () => {
 
     test('rejects malformed percent-encoded input', () => {
       const result = sanitizeRedirectPath('/%E0%80%80');
+
+      expect(result).toBeUndefined();
+    });
+
+    test('fails closed when the path exceeds the decode iteration cap', () => {
+      const deeplyEncodedAuthPath = `/${encodeRepeatedly('%61', 10)}uth/login`;
+
+      expect(sanitizeRedirectPath(deeplyEncodedAuthPath)).toBeUndefined();
+    });
+
+    test('rejects malformed percent-encoding that only surfaces after the first decode', () => {
+      const result = sanitizeRedirectPath('/%25E0%2580%2580');
+
+      expect(result).toBeUndefined();
+    });
+
+    test('rejects an /auth/* path disguised behind encoded dot segments', () => {
+      const result = sanitizeRedirectPath('/safe/%25252e%25252e/auth/login');
+
+      expect(result).toBeUndefined();
+    });
+
+    test('rejects a protocol-relative URL revealed only after multiple decodes', () => {
+      const result = sanitizeRedirectPath('/%25252fevil.com');
 
       expect(result).toBeUndefined();
     });
@@ -90,7 +126,16 @@ describe('sanitizeLogoutRedirectPath', () => {
     ['login route with a query', '/auth/login?redirect=/workspaces/abc'],
     ['raw invitation token', '/invitations/accept?token=sf_i_raw-token'],
     ['raw invitation token with trailing slash', '/invitations/accept/?token=sf_i_raw-token'],
+    ['double-encoded auth route', '/%2561uth/login'],
+    ['triple-encoded auth route', '/%252561uth/login'],
+    ['double-encoded invitation token', '/%2569nvitations/accept?token=sf_i_raw-token'],
+    ['triple-encoded invitation token', '/%252569nvitations/accept?token=sf_i_raw-token'],
     ['malformed percent encoding', '/%E0%80%80'],
+    [
+      'invitation token disguised behind encoded dot segments',
+      '/safe/%25252e%25252e/invitations/accept?token=sf_i_raw-token',
+    ],
+    ['auth route disguised behind encoded dot segments', '/safe/%25252e%25252e/auth/login'],
   ])('falls back for %s', (_label, input) => {
     test('returns login without forwarding unsafe state', () => {
       expect(sanitizeLogoutRedirectPath(input)).toBe('/auth/login');

--- a/libs/client/auth/src/components/redirect-target.ts
+++ b/libs/client/auth/src/components/redirect-target.ts
@@ -3,8 +3,38 @@ const LOGIN_PATH = '/auth/login';
 const INVITATION_ACCEPT_PATH = '/invitations/accept';
 const DEFAULT_LOGOUT_REDIRECT = LOGIN_PATH;
 const TRAILING_SLASHES = /\/+$/;
+const MAX_PATH_DECODE_ITERATIONS = 10;
 
-function resolveRedirectPath(value: unknown): URL | undefined {
+export interface ResolvedRedirectPath {
+  pathname: string;
+  redirect: string;
+  target: URL;
+}
+
+// Repeated decoding can reveal `.`/`..` segments or a `//host` prefix that were
+// hidden behind extra encoding layers (e.g. `%25252e%25252e` -> `..`). Those only
+// get collapsed and re-checked against the origin by feeding the fully-decoded,
+// percent-free string back through the URL parser; without this, a multiply
+// encoded `/safe/../auth/login` or `/safe/../invitations/accept?token=...`
+// evades the pathname checks below even though this loop "sees" the real path.
+function decodePathToFixedPoint(pathname: string): string | undefined {
+  let current = pathname;
+
+  for (let iteration = 0; iteration < MAX_PATH_DECODE_ITERATIONS; iteration += 1) {
+    let decoded: string;
+    try {
+      decoded = decodeURIComponent(current);
+    } catch {
+      return undefined;
+    }
+    if (decoded === current) return current;
+    current = decoded;
+  }
+
+  return undefined;
+}
+
+export function resolveRedirectPath(value: unknown): ResolvedRedirectPath | undefined {
   if (typeof value !== 'string' || !value.startsWith('/')) return undefined;
   let decoded: string;
   try {
@@ -19,27 +49,36 @@ function resolveRedirectPath(value: unknown): URL | undefined {
     return undefined;
   }
   if (target.origin !== REDIRECT_ORIGIN) return undefined;
-  return target;
+  const decodedPathname = decodePathToFixedPoint(target.pathname);
+  if (decodedPathname === undefined) return undefined;
+  let canonical: URL;
+  try {
+    canonical = new URL(decodedPathname, REDIRECT_ORIGIN);
+  } catch {
+    return undefined;
+  }
+  if (canonical.origin !== REDIRECT_ORIGIN) return undefined;
+  return {pathname: canonical.pathname, redirect: formatRedirectPath(target), target};
 }
 
 function formatRedirectPath(target: URL): string {
   return `${target.pathname}${target.search}${target.hash}`;
 }
 
-function isAuthPath(pathname: string): boolean {
+export function isAuthPath(pathname: string): boolean {
   return pathname === '/auth' || pathname.startsWith('/auth/');
 }
 
 // Resolves and canonicalizes an internal path before returning it, so browser URL
 // parsing cannot turn a seemingly safe path into an external or auth route.
 export function sanitizeRedirectPath(value: unknown): string | undefined {
-  const target = resolveRedirectPath(value);
-  if (!target || isAuthPath(target.pathname)) return undefined;
-  return formatRedirectPath(target);
+  const resolved = resolveRedirectPath(value);
+  if (!resolved || isAuthPath(resolved.pathname)) return undefined;
+  return resolved.redirect;
 }
 
-function containsInvitationToken(target: URL): boolean {
-  const normalizedPathname = target.pathname.replace(TRAILING_SLASHES, '') || '/';
+function containsInvitationToken(target: URL, pathname: string): boolean {
+  const normalizedPathname = pathname.replace(TRAILING_SLASHES, '') || '/';
   return normalizedPathname === INVITATION_ACCEPT_PATH && target.searchParams.has('token');
 }
 
@@ -50,10 +89,13 @@ function containsInvitationToken(target: URL): boolean {
  * survive this boundary. Invalid values fail closed to login.
  */
 export function sanitizeLogoutRedirectPath(value: unknown): string {
-  const target = resolveRedirectPath(value);
-  if (!target) return DEFAULT_LOGOUT_REDIRECT;
-  if (isAuthPath(target.pathname) || containsInvitationToken(target)) {
+  const resolved = resolveRedirectPath(value);
+  if (!resolved) return DEFAULT_LOGOUT_REDIRECT;
+  if (
+    isAuthPath(resolved.pathname) ||
+    containsInvitationToken(resolved.target, resolved.pathname)
+  ) {
     return DEFAULT_LOGOUT_REDIRECT;
   }
-  return formatRedirectPath(target);
+  return resolved.redirect;
 }


### PR DESCRIPTION
`@shipfox/client-auth` now resolves redirect pathnames to a bounded fixed point, reparses the percent-free result to collapse dot segments and re-check origin, then applies auth-path and invitation-token policies consistently across login and logout flows.

This closes deeply encoded `/auth/*` and `/invitations/accept` bypasses, including encoded dot-segment and protocol-relative cases. Regression coverage covers the redirect target, logout fallback, and redirect-context wrapper. A patch Changeset schedules the package release.

Validation: `mise exec -- turbo run check type test build type:emit --filter=@shipfox/client-auth...` (113/113 tasks passed; 156 client-auth tests passed), plus direct production-source redirect proofs.

Closes ENG-1234

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks deeply encoded redirect paths that could bypass auth and invitation checks in `@shipfox/client-auth`. Implements fixed-point decoding with re-parse + origin re-check, and applies the same rules across login and logout (ENG-1234).

- **Bug Fixes**
  - Decode pathnames to a fixed point with a 10-iteration cap; fail closed on malformed sequences.
  - Re-parse the decoded path to collapse dot segments and re-check origin.
  - Reject encoded `/auth/*`, encoded `/invitations/accept?token=...`, and protocol-relative paths across both flows.
  - Expanded tests for deep encodings and disguises; added a patch Changeset.

<sup>Written for commit f8e26164da35ddb937190dea752fd6459f21e0f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

