### PR TITLE
[client-auth] Publish Node-safe redirect context

### DIFF
--- a/.changeset/calm-foxes-redirect.md
+++ b/.changeset/calm-foxes-redirect.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-auth": minor
+---
+
+Adds a Node-safe redirect-context entrypoint for shared authentication continuation parsing.

--- a/libs/client/auth/package.json
+++ b/libs/client/auth/package.json
@@ -49,6 +49,16 @@
         "default": "./dist/continuation.js"
       }
     },
+    "./redirect-context": {
+      "workspace-source": {
+        "types": "./src/redirect-context.ts",
+        "default": "./src/redirect-context.ts"
+      },
+      "default": {
+        "types": "./dist/redirect-context.d.ts",
+        "default": "./dist/redirect-context.js"
+      }
+    },
     "./routes/*": {
       "workspace-source": {
         "types": "./src/routes/*.tsx",

--- a/libs/client/auth/src/continuation.ts
+++ b/libs/client/auth/src/continuation.ts
@@ -3,4 +3,4 @@ export {
   EmailCodeVerification,
   type EmailCodeVerificationProps,
 } from './components/email-code-verification.js';
-export {parseRedirectContext, type RedirectContext} from './components/redirect-context.js';
+export {parseRedirectContext, type RedirectContext} from './redirect-context.js';

--- a/libs/client/auth/src/pages/invitation-context.ts
+++ b/libs/client/auth/src/pages/invitation-context.ts
@@ -3,7 +3,7 @@ import {
   pendingInvitation,
   usePreviewInvitation,
 } from '@shipfox/client-invitations';
-import {parseRedirectContext} from '#/components/redirect-context.js';
+import {parseRedirectContext} from '#/redirect-context.js';
 
 export function extractInvitationToken(redirect: unknown): string | undefined {
   return parseRedirectContext(redirect).invitationToken;

--- a/libs/client/auth/src/redirect-context.test.ts
+++ b/libs/client/auth/src/redirect-context.test.ts
@@ -1,6 +1,12 @@
-import {parseRedirectContext} from './redirect-context.js';
+import {parseRedirectContext, type RedirectContext} from '@shipfox/client-auth/redirect-context';
 
-describe('parseRedirectContext', () => {
+describe('@shipfox/client-auth/redirect-context', () => {
+  test('imports the parser and its type through the Node-safe public subpath', () => {
+    const context: RedirectContext = parseRedirectContext('/workspaces/acme');
+
+    expect(context).toEqual({returnTo: '/workspaces/acme'});
+  });
+
   test('returns an ordinary safe return path', () => {
     const context = parseRedirectContext('/workspaces/acme?tab=runs');
 
@@ -25,6 +31,10 @@ describe('parseRedirectContext', () => {
   test.each([
     ['/%2569nvitations/accept?token=double-encoded-token', 'double-encoded-token'],
     ['/%252569nvitations/accept?token=triple-encoded-token', 'triple-encoded-token'],
+    [
+      '/safe%255c..%255cinvitations/accept?token=encoded-backslash-token',
+      'encoded-backslash-token',
+    ],
   ])('separates an invitation token from a deeply encoded path: %s', (redirect, token) => {
     const context = parseRedirectContext(redirect);
 
@@ -41,6 +51,7 @@ describe('parseRedirectContext', () => {
     '/%252561uth/login',
     '/%E0%80%80',
     '/safe/%25252e%25252e/auth/login',
+    '/safe%255c..%255cauth/login',
   ])('rejects malformed or unsafe redirect %s', (redirect) => {
     const context = parseRedirectContext(redirect);
 

--- a/libs/client/auth/src/redirect-context.ts
+++ b/libs/client/auth/src/redirect-context.ts
@@ -1,4 +1,4 @@
-import {isAuthPath, resolveRedirectPath} from './redirect-target.js';
+import {isAuthPath, resolveRedirectPath} from './components/redirect-target.js';
 
 const INVITATION_ACCEPT_PATH = '/invitations/accept';
 


### PR DESCRIPTION
`@shipfox/client-auth` now exposes `parseRedirectContext` and `RedirectContext` through a dedicated `@shipfox/client-auth/redirect-context` subpath. The pure entrypoint does not evaluate React, UI, shell runtime, or the continuation barrel; the existing continuation export remains compatible by re-exporting it.

The Node test imports the public specifier directly and adds encoded-backslash regressions for both auth-path rejection and invitation-token isolation. A minor Changeset schedules the additive package release.

Validation: focused client-auth check/type/test/build/declaration emit, client architecture audit, packed client external-consumer verification, and a direct Node import of the emitted module all pass.

Remaining ENG-1235 work is in Cloud: upgrade to the released package, switch `core/providers.ts` to this subpath, remove the local fork/tests, and retain integration coverage.

Part of ENG-1235