### PR TITLE
[node-error-monitoring] Flush reports before bounded runtimes return

### DIFF
--- a/.changeset/calm-foxes-flush.md
+++ b/.changeset/calm-foxes-flush.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/node-error-monitoring": minor
+---
+
+Expose a non-closing flush operation for bounded runtimes.

--- a/libs/shared/node/error-monitoring/README.md
+++ b/libs/shared/node/error-monitoring/README.md
@@ -9,6 +9,7 @@ Sentry integration for Shipfox Node services. It reads Sentry settings from envi
 - **`markErrorReported(error)`** and **`isErrorReported(error)`** prevent duplicate reports when a failure crosses boundaries.
 - **`captureException(error)`** remains available for backward compatibility.
 - **`addEventProcessor(processor)`** adds a custom Sentry event processor.
+- **`flushErrorMonitoring(timeout)`** waits for pending events without shutting down the client.
 - **`closeErrorMonitoring()`** flushes pending events and shuts down the Sentry client.
 
 Environment variables (via `@shipfox/config`):
@@ -44,6 +45,10 @@ try {
   reportError(err, {boundary: "api.runtime", operation: "refresh-cache"});
 }
 ```
+
+Call `flushErrorMonitoring(timeout)` before a bounded runtime such as an AWS
+Lambda invocation returns. Use `closeErrorMonitoring(timeout)` only when the
+process is shutting down.
 
 ## Reporting policy
 

--- a/libs/shared/node/error-monitoring/src/index.test.ts
+++ b/libs/shared/node/error-monitoring/src/index.test.ts
@@ -1,0 +1,6 @@
+import * as sentry from '@sentry/node';
+import {flushErrorMonitoring} from './index.js';
+
+test('exports the non-closing flush operation for bounded runtimes', () => {
+  expect(flushErrorMonitoring).toBe(sentry.flush);
+});

--- a/libs/shared/node/error-monitoring/src/index.ts
+++ b/libs/shared/node/error-monitoring/src/index.ts
@@ -1,4 +1,9 @@
-export {addEventProcessor, captureException, close as closeErrorMonitoring} from '@sentry/node';
+export {
+  addEventProcessor,
+  captureException,
+  close as closeErrorMonitoring,
+  flush as flushErrorMonitoring,
+} from '@sentry/node';
 export {
   type ErrorReportContext,
   isErrorReported,


### PR DESCRIPTION
Adds a public non-closing `flushErrorMonitoring(timeout)` export for bounded runtimes such as AWS Lambda. The package docs distinguish per-invocation flushing from client shutdown, and a root-export test protects the Sentry alias.

Cloud PR #118 will consume the released minor version at the Lambda entry point.

Validation:
- `turbo check type test build --filter=@shipfox/node-error-monitoring`
- `pnpm check:published-artifacts`
- `git diff --check`

Part of ENG-1228

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposed a non-closing `flushErrorMonitoring(timeout)` in `@shipfox/node-error-monitoring` so bounded runtimes (e.g., AWS Lambda) can flush Sentry events before returning. Supports Linear ENG-1228 by helping ensure unexpected failures are reported once even when execution continues.

- **New Features**
  - Added `flushErrorMonitoring(timeout)` (aliases `@sentry/node` `flush`) to wait for pending events without shutting down the client.
  - Updated README with guidance to call `flushErrorMonitoring` at the end of Lambda invocations and reserve `closeErrorMonitoring` for process shutdown.

<sup>Written for commit a80373fdaf5bd818c326455d11cc59cd15b07036. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

