### PR TITLE
[@shipfox/client-shell] Make branding assets reachable

### DIFF
--- a/.changeset/quiet-shell-assets.md
+++ b/.changeset/quiet-shell-assets.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-shell": minor
+---
+
+Expose shell branding assets through the package export map and warn when the Vite composition plugin is used without its manifest plugin.

--- a/libs/client/shell/package.json
+++ b/libs/client/shell/package.json
@@ -61,7 +61,8 @@
         "types": "./dist/vite/index.d.ts",
         "default": "./dist/vite/index.js"
       }
-    }
+    },
+    "./assets/*": "./assets/*"
   },
   "scripts": {
     "build": "shipfox-swc",

--- a/libs/client/shell/src/vite/plugin.test.ts
+++ b/libs/client/shell/src/vite/plugin.test.ts
@@ -3,6 +3,7 @@ import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {fileURLToPath} from 'node:url';
 import {type Plugin, type ResolvedConfig, build as viteBuild} from 'vite';
+import {shipfoxClientManifest} from './manifest.js';
 import {shipfoxClientComposition} from './plugin.js';
 
 const fixtureFeatures = fileURLToPath(new URL('../../test/fixtures/features.ts', import.meta.url));
@@ -22,13 +23,17 @@ function configResolvedHandler(hook: NonNullable<Plugin['configResolved']>): Con
   return hookHandler(hook) as ConfigResolvedHandler;
 }
 
-function configure(plugin: Plugin): void {
+function configure(plugin: Plugin, plugins = [plugin]): ReturnType<typeof vi.fn> {
   if (!plugin.configResolved) {
     throw new Error('Expected the composition plugin to implement configResolved.');
   }
+  const warn = vi.fn();
   configResolvedHandler(plugin.configResolved)({
     root: process.cwd(),
-  } as ResolvedConfig);
+    plugins,
+    logger: {warn} as unknown as ResolvedConfig['logger'],
+  } as unknown as ResolvedConfig);
+  return warn;
 }
 
 function resolveRouteImplementation(source: string): string | undefined {
@@ -83,6 +88,26 @@ describe('shipfoxClientComposition', () => {
 
   afterEach(async () => {
     await rm(directory, {recursive: true, force: true});
+  });
+
+  test('warns when the manifest plugin is not registered', () => {
+    const plugin = shipfoxClientComposition({features: fixtureFeatures});
+
+    const warn = configure(plugin);
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'shipfoxClientComposition() is registered without the "shipfox-client-manifest" plugin (shipfoxClientManifest()).',
+      ),
+    );
+  });
+
+  test('does not warn when the manifest plugin is registered', () => {
+    const plugin = shipfoxClientComposition({features: fixtureFeatures});
+
+    const warn = configure(plugin, [plugin, shipfoxClientManifest()]);
+
+    expect(warn).not.toHaveBeenCalled();
   });
 
   test('generates a static route tree and watches the manifest module graph', async () => {

--- a/libs/client/shell/src/vite/plugin.ts
+++ b/libs/client/shell/src/vite/plugin.ts
@@ -5,6 +5,8 @@ import {composeClientFeatures} from '#compose/compose-client-features.js';
 import {evaluateFeatures} from './evaluate-features.js';
 import {generateAppModule} from './generate.js';
 
+const manifestPluginName = 'shipfox-client-manifest';
+
 export interface ShipfoxClientCompositionOptions {
   features: string;
   out?: string;
@@ -66,6 +68,11 @@ export function shipfoxClientComposition({
     name: 'shipfox-client-composition',
     configResolved(resolvedConfig) {
       config = resolvedConfig;
+      if (!resolvedConfig.plugins.some(({name}) => name === manifestPluginName)) {
+        resolvedConfig.logger.warn(
+          `shipfoxClientComposition() is registered without the "${manifestPluginName}" plugin (shipfoxClientManifest()). Add shipfoxClientManifest() to the Vite plugins to serve Shipfox branding assets.`,
+        );
+      }
     },
     async buildStart() {
       await generate({

--- a/libs/client/shell/test/external/verify.mjs
+++ b/libs/client/shell/test/external/verify.mjs
@@ -58,9 +58,15 @@ const closureTypeEntryPoints = entryPoints
 const runtimeEntryPoints = entryPoints
   .filter(({target}) => entryPointSupportsRuntimeImport(target))
   .map(({specifier}) => specifier);
+const assetEntryPoints = entryPoints
+  .filter(({specifier}) => specifier.startsWith('@shipfox/client-shell/assets/'))
+  .map(({specifier}) => specifier);
 const typeEntryPoints = consumerTypeEntryPoints
   .filter(({target}) => entryPointSupportsTypeResolution(target))
   .map(({specifier}) => specifier);
+if (!assetEntryPoints.includes('@shipfox/client-shell/assets/favicon.svg')) {
+  throw new Error('Published surface does not include @shipfox/client-shell/assets/favicon.svg.');
+}
 const temporaryRoot = await mkdtemp(join(tmpdir(), 'shipfox-client-composition-'));
 const fixtureRoot = join(temporaryRoot, 'fixture');
 
@@ -88,6 +94,8 @@ try {
     });
     await validateFullClosureTypeDeclarations(fixtureRoot, closureTypeEntryPoints);
   }
+
+  await validateAssetResolution(fixtureRoot, assetEntryPoints, {linkMode});
 
   await run('pnpm', ['exec', 'vite', 'build'], fixtureRoot, {capture: true});
   await validateGeneratedModule(fixtureRoot);
@@ -304,6 +312,36 @@ process.stdout.write(JSON.stringify(resolved));`,
   }
 }
 
+async function validateAssetResolution(root, specifiers, {linkMode}) {
+  const packageName = '@shipfox/client-shell';
+  const packageRoots = linkMode
+    ? [await realpath(join(root, 'node_modules', ...packageName.split('/')))]
+    : installedPackageRoots(root, packageName);
+  for (const packageRoot of packageRoots) {
+    const resolution = await run(
+      process.execPath,
+      [
+        '--input-type=module',
+        '--eval',
+        `const specifiers = ${JSON.stringify(specifiers)};
+const resolved = Object.fromEntries(specifiers.map((specifier) => [specifier, import.meta.resolve(specifier)]));
+process.stdout.write(JSON.stringify(resolved));`,
+      ],
+      packageRoot,
+      {capture: true},
+    );
+    const resolved = JSON.parse(resolution.stdout);
+    const realPackageRoot = await realpath(packageRoot);
+    for (const specifier of specifiers) {
+      const resolvedPath = await realpath(fileURLToPath(resolved[specifier]));
+      if (!resolvedPath.startsWith(`${realPackageRoot}${sep}`)) {
+        throw new Error(`Published ${specifier} resolved outside ${packageName}: ${resolvedPath}`);
+      }
+      await readFile(resolvedPath);
+    }
+  }
+}
+
 async function validateFullClosureTypeDeclarations(root, specifiers) {
   const typeScriptCli = join(root, 'node_modules', 'typescript', 'bin', 'tsc');
   const specifiersByPackage = Map.groupBy(specifiers, packageNameFromSpecifier);
@@ -417,17 +455,17 @@ function listConcreteEntryPoints(name, workspacePackage) {
 }
 
 function concretePatternEntryPoints(entryPoint, packageDirectory) {
-  const runtimeTarget = defaultRuntimeTarget(entryPoint.target);
-  if (!runtimeTarget?.includes('*')) {
+  const targetPattern = defaultTarget(entryPoint.target);
+  if (!targetPattern?.includes('*')) {
     throw new Error(
-      `Wildcard export ${entryPoint.specifier} must define a default JavaScript target.`,
+      `Wildcard export ${entryPoint.specifier} must define a default target pattern.`,
     );
   }
 
-  const targetPattern = runtimeTarget.slice(2);
-  const globPattern = targetPattern.replace('*', '**/*');
+  const packageRelativePattern = targetPattern.slice(2);
+  const globPattern = packageRelativePattern.replace('*', '**/*');
   const capturePattern = new RegExp(
-    `^${targetPattern
+    `^${packageRelativePattern
       .split('*')
       .map((segment) => segment.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&'))
       .join('(.+)')}$`,
@@ -437,7 +475,7 @@ function concretePatternEntryPoints(entryPoint, packageDirectory) {
     const match = capturePattern.exec(relativePath);
     if (!match) {
       throw new Error(
-        `Wildcard export ${entryPoint.specifier} resolved ${relativePath} outside ${runtimeTarget}.`,
+        `Wildcard export ${entryPoint.specifier} resolved ${relativePath} outside ${targetPattern}.`,
       );
     }
     return {...entryPoint, specifier: entryPoint.specifier.replace('*', match[1])};
@@ -445,18 +483,18 @@ function concretePatternEntryPoints(entryPoint, packageDirectory) {
 
   if (!concreteEntryPoints.length) {
     throw new Error(
-      `Wildcard export ${entryPoint.specifier} did not resolve any files matching ${runtimeTarget}.`,
+      `Wildcard export ${entryPoint.specifier} did not resolve any files matching ${targetPattern}.`,
     );
   }
 
   return concreteEntryPoints;
 }
 
-function defaultRuntimeTarget(target) {
-  if (typeof target === 'string') return target.endsWith('.js') ? target : undefined;
+function defaultTarget(target) {
+  if (typeof target === 'string') return target;
   if (!target || typeof target !== 'object' || Array.isArray(target)) return undefined;
-  const defaultTarget = target.default;
-  return defaultTarget === undefined ? undefined : defaultRuntimeTarget(defaultTarget);
+  const nestedTarget = target.default;
+  return nestedTarget === undefined ? undefined : defaultTarget(nestedTarget);
 }
 
 function findWorkspaceRange(value, path = 'package.json') {


### PR DESCRIPTION
## Summary

Make the shell's branding assets directly consumable by downstream applications and make an incomplete Vite setup visible immediately.

The composition plugin now warns through Vite when the manifest plugin is omitted, preventing silent missing favicon and web-manifest behavior. The package export map and packed external-consumer verification now cover the published branding assets.

Closes ENG-1238

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `@shipfox/client-shell` branding assets importable and add a Vite warning when `shipfoxClientComposition()` runs without `shipfoxClientManifest()`. Prevents silent missing favicons and web manifests and addresses ENG-1238.

- **New Features**
  - Added `./assets/*` to the package exports so imports like `@shipfox/client-shell/assets/favicon.svg` resolve.
  - `shipfoxClientComposition()` now warns during Vite config if the manifest plugin is missing, prompting apps to include `shipfoxClientManifest()`.

<sup>Written for commit 9dd723fa25347aef978760705ae0963d42d42aaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

