### PR TITLE
[client-integrations] Fix typed logout redirect link

### DIFF
--- a/.changeset/typed-logout-link.md
+++ b/.changeset/typed-logout-link.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-integrations": patch
+---
+
+Fix the typed logout redirect link used when switching accounts after an integration callback failure.

--- a/libs/client/integrations/src/components/callback-status-shell.tsx
+++ b/libs/client/integrations/src/components/callback-status-shell.tsx
@@ -48,11 +48,8 @@ export function CallbackStatusShell({
           {switchAccount ? (
             <ButtonLink asChild className="min-h-44 w-full sm:w-fit">
               <Link
-                to={
-                  workspaceId
-                    ? `/auth/logout?redirect=${encodeURIComponent(logoutRedirect ?? '/')}`
-                    : '/auth/logout'
-                }
+                to="/auth/logout"
+                search={workspaceId ? {redirect: logoutRedirect ?? '/'} : undefined}
               >
                 Switch account
               </Link>

--- a/libs/client/integrations/src/pages/linear-callback-page.test.tsx
+++ b/libs/client/integrations/src/pages/linear-callback-page.test.tsx
@@ -128,11 +128,21 @@ describe('LinearCallbackPage', () => {
     renderCallback('?code=grant-code-account&state=signed-state-account');
 
     expect(await screen.findByRole('heading', {name: 'Different Shipfox account'})).toBeVisible();
-    expect(screen.getByRole('link', {name: 'Switch account'})).toHaveAttribute(
+    const switchAccountLink = screen.getByRole('link', {name: 'Switch account'});
+    const switchAccountUrl = new URL(
+      switchAccountLink.getAttribute('href') ?? '/',
+      window.location.origin,
+    );
+
+    expect(switchAccountLink).toHaveAttribute(
       'href',
       `/auth/logout?redirect=${encodeURIComponent(
         `/workspaces/${INTEGRATIONS_TEST_WID}/integrations/linear`,
       )}`,
+    );
+    expect(switchAccountUrl.pathname).toBe('/auth/logout');
+    expect(switchAccountUrl.searchParams.get('redirect')).toBe(
+      `/workspaces/${INTEGRATIONS_TEST_WID}/integrations/linear`,
     );
     expect(screen.getByRole('link', {name: 'Start over'})).toBeVisible();
   });


### PR DESCRIPTION
Use TanStack Router's typed search state for the callback recovery Switch account link instead of concatenating the redirect query into the route path. This preserves the workspace integration redirect while satisfying the generated route-path contract.

The focused callback coverage verifies the serialized logout URL and decoded redirect value, and the patch Changeset records the published-package fix.

Closes ENG-1239