### PR TITLE
[api-definitions] Configure workflow sync paths

### DIFF
--- a/.changeset/calm-stage-workflows.md
+++ b/.changeset/calm-stage-workflows.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-definitions": minor
+---
+
+Adds a configurable repository path for workflow definition sync.

--- a/apps/api/.env
+++ b/apps/api/.env
@@ -6,6 +6,9 @@ HOST=127.0.0.1
 E2E_ENABLED=true
 E2E_ADMIN_API_KEY=e2e-admin-api-key
 
+# Definitions
+# DEFINITION_WORKFLOW_PATH=.shipfox/workflows/
+
 # Logging
 LOG_LEVEL=info
 LOG_PRETTY=true

--- a/libs/api/definitions/src/config.ts
+++ b/libs/api/definitions/src/config.ts
@@ -6,6 +6,10 @@ export const config = createConfig({
     desc: 'Default runner label(s) applied to workflow jobs that do not declare a "runner" at the job or workflow level. Set it to a comma-separated list, for example ubuntu-latest or ubuntu-latest,node-22. Leave it empty to require every workflow job to declare runner labels explicitly; with no value set, a job without a runner fails definition validation.',
     default: '',
   }),
+  DEFINITION_WORKFLOW_PATH: str({
+    desc: 'Repository-relative path that contains workflow YAML files. Set a different path for each Shipfox instance when staging and production share a repository.',
+    default: '.shipfox/workflows/',
+  }),
 });
 
 export function parseDefinitionDefaultRunnerLabels(value: string): readonly string[] {
@@ -30,3 +34,5 @@ export function parseDefinitionDefaultRunnerLabels(value: string): readonly stri
 export const definitionDefaultRunnerLabels = parseDefinitionDefaultRunnerLabels(
   config.DEFINITION_DEFAULT_RUNNER_LABEL,
 );
+
+export const definitionWorkflowPath = config.DEFINITION_WORKFLOW_PATH;

--- a/libs/api/definitions/src/core/index.ts
+++ b/libs/api/definitions/src/core/index.ts
@@ -6,6 +6,7 @@ export {
 export {parseDefinition} from './parse-definition.js';
 export {
   classifySyncFailure,
+  DEFAULT_WORKFLOW_PATH,
   type DiscoverWorkflowFilesParams,
   discoverWorkflowFiles,
   type FetchAndParseWorkflowsParams,
@@ -18,7 +19,6 @@ export {
   type SyncFailureClassification,
   type SyncSourceContext,
   UNRESOLVED_SYNC_REF,
-  WORKFLOW_PREFIX,
 } from './sync-definitions.js';
 export {DEFAULT_RUN_TIMEOUT_MS} from './workflow-model/constants.js';
 export {normalizeWorkflowDocument} from './workflow-model/index.js';

--- a/libs/api/definitions/src/core/sync-definitions.test.ts
+++ b/libs/api/definitions/src/core/sync-definitions.test.ts
@@ -146,6 +146,27 @@ describe('discoverWorkflowFiles', () => {
     expect(result.paths).toEqual(['.shipfox/workflows/ci.yml', '.shipfox/workflows/deploy.yaml']);
   });
 
+  it('lists workflows under the configured repository path', async () => {
+    const listFiles = vi.fn(() =>
+      Promise.resolve({
+        files: [{path: '.shipfox/staging/workflows/ci.yml', type: 'file' as const, size: 64}],
+        nextCursor: null,
+      }),
+    );
+
+    const result = await discoverWorkflowFiles({
+      ...baseContext,
+      ref: 'main',
+      workflowPath: '.shipfox/staging/workflows/',
+      sourceControl: sourceControl({listFiles}),
+    });
+
+    expect(listFiles).toHaveBeenCalledWith(
+      expect.objectContaining({prefix: '.shipfox/staging/workflows/'}),
+    );
+    expect(result.paths).toEqual(['.shipfox/staging/workflows/ci.yml']);
+  });
+
   it('throws no-workflow-files when nothing matches the yaml extensions', async () => {
     const result = discoverWorkflowFiles({
       ...baseContext,
@@ -161,6 +182,21 @@ describe('discoverWorkflowFiles', () => {
     });
 
     await expect(result).rejects.toMatchObject({code: 'no-workflow-files'});
+  });
+
+  it('includes the configured repository path when no workflow files are found', async () => {
+    const result = discoverWorkflowFiles({
+      ...baseContext,
+      ref: 'main',
+      workflowPath: '.shipfox/production/workflows/',
+      sourceControl: sourceControl({
+        listFiles: vi.fn(() => Promise.resolve({files: [], nextCursor: null})),
+      }),
+    });
+
+    await expect(result).rejects.toThrow(
+      'No workflow files were found under .shipfox/production/workflows/',
+    );
   });
 
   it('throws too-many-files when the listing reports more pages', async () => {

--- a/libs/api/definitions/src/core/sync-definitions.ts
+++ b/libs/api/definitions/src/core/sync-definitions.ts
@@ -11,7 +11,7 @@ import {hasAgentStepIntegrations} from './has-agent-step-integrations.js';
 import type {DefinitionsSourceControl} from './integrations.js';
 import {parseDefinition} from './parse-definition.js';
 
-export const WORKFLOW_PREFIX = '.shipfox/workflows/';
+export const DEFAULT_WORKFLOW_PATH = '.shipfox/workflows/';
 export const MAX_WORKFLOW_FILES = 100;
 export const MAX_WORKFLOW_FILE_BYTES = 1_000_000;
 export const FILE_FETCH_CONCURRENCY = 4;
@@ -39,17 +39,19 @@ export async function resolveSyncSource(params: SyncSourceContext): Promise<Reso
 
 export interface DiscoverWorkflowFilesParams extends SyncSourceContext {
   ref: string;
+  workflowPath?: string | undefined;
 }
 
 export async function discoverWorkflowFiles(
   params: DiscoverWorkflowFilesParams,
 ): Promise<{paths: string[]}> {
+  const workflowPath = params.workflowPath ?? DEFAULT_WORKFLOW_PATH;
   const page = await params.sourceControl.listFiles({
     workspaceId: params.workspaceId,
     connectionId: params.sourceConnectionId,
     externalRepositoryId: params.sourceExternalRepositoryId,
     ref: params.ref,
-    prefix: WORKFLOW_PREFIX,
+    prefix: workflowPath,
     limit: MAX_WORKFLOW_FILES,
   });
   if (page.nextCursor) {
@@ -65,7 +67,7 @@ export async function discoverWorkflowFiles(
   if (paths.length === 0) {
     throw new DefinitionSyncPermanentError(
       'no-workflow-files',
-      `No workflow files were found under ${WORKFLOW_PREFIX}`,
+      `No workflow files were found under ${workflowPath}`,
     );
   }
 

--- a/libs/api/definitions/src/index.ts
+++ b/libs/api/definitions/src/index.ts
@@ -24,6 +24,7 @@ import {
   onProjectSourceCommitObserved,
 } from '#presentation/subscribers/index.js';
 import {createDefinitionSyncActivities, DEFINITIONS_TASK_QUEUE} from '#temporal/index.js';
+import {definitionWorkflowPath} from './config.js';
 
 export type {
   WorkflowDefinition,
@@ -79,7 +80,10 @@ export function createDefinitionsModule({
       {
         taskQueue: DEFINITIONS_TASK_QUEUE,
         workflowsPath,
-        activities: () => createDefinitionSyncActivities(sourceControl, agent, integrations),
+        activities: () =>
+          createDefinitionSyncActivities(sourceControl, agent, integrations, {
+            workflowPath: definitionWorkflowPath,
+          }),
         workflows: [],
       },
     ],

--- a/libs/api/definitions/src/temporal/activities/sync-activities.test.ts
+++ b/libs/api/definitions/src/temporal/activities/sync-activities.test.ts
@@ -180,6 +180,35 @@ describe('definition sync activities', () => {
     });
   });
 
+  describe('discoverDefinitionWorkflows', () => {
+    it('uses the configured workflow path', async () => {
+      const source = sourceControl({
+        listFiles: vi.fn(() =>
+          Promise.resolve({
+            files: [{path: '.shipfox/staging/workflows/ci.yml', type: 'file' as const, size: 64}],
+            nextCursor: null,
+          }),
+        ),
+      });
+      const activities = createDefinitionSyncActivities(source, agent, undefined, {
+        workflowPath: '.shipfox/staging/workflows/',
+      });
+
+      const result = await activities.discoverDefinitionWorkflows({
+        projectId,
+        workspaceId: crypto.randomUUID(),
+        sourceConnectionId,
+        sourceExternalRepositoryId: 'gitea:gitea-owner/platform',
+        sourceRef: 'main',
+      });
+
+      expect(result.paths).toEqual(['.shipfox/staging/workflows/ci.yml']);
+      expect(source.listFiles).toHaveBeenCalledWith(
+        expect.objectContaining({prefix: '.shipfox/staging/workflows/'}),
+      );
+    });
+  });
+
   describe('fetchAndApplyDefinitionWorkflows', () => {
     it('upserts workflow definitions and soft-deletes orphans', async () => {
       const activities = createDefinitionSyncActivities(sourceControl(), agent);

--- a/libs/api/definitions/src/temporal/activities/sync-activities.ts
+++ b/libs/api/definitions/src/temporal/activities/sync-activities.ts
@@ -52,14 +52,22 @@ export interface FetchAndApplyActivityResult {
   deletedCount: number;
 }
 
+export interface DefinitionSyncActivityOptions {
+  workflowPath: string;
+}
+
 export function createDefinitionSyncActivities(
   sourceControl: DefinitionsSourceControl,
   agent: AgentInterModuleClient,
   integrations?: IntegrationsModuleClient | undefined,
+  options?: DefinitionSyncActivityOptions | undefined,
 ) {
   return {
     prepareDefinitionSync: createPrepareDefinitionSyncActivity(sourceControl),
-    discoverDefinitionWorkflows: createDiscoverDefinitionWorkflowsActivity(sourceControl),
+    discoverDefinitionWorkflows: createDiscoverDefinitionWorkflowsActivity(
+      sourceControl,
+      options?.workflowPath,
+    ),
     fetchAndApplyDefinitionWorkflows: createFetchAndApplyActivity(
       sourceControl,
       agent,
@@ -94,7 +102,10 @@ function createPrepareDefinitionSyncActivity(sourceControl: DefinitionsSourceCon
   };
 }
 
-function createDiscoverDefinitionWorkflowsActivity(sourceControl: DefinitionsSourceControl) {
+function createDiscoverDefinitionWorkflowsActivity(
+  sourceControl: DefinitionsSourceControl,
+  workflowPath?: string | undefined,
+) {
   return async function discoverDefinitionWorkflows(
     input: SyncRefScopedInput,
   ): Promise<DiscoverWorkflowsActivityResult> {
@@ -103,6 +114,7 @@ function createDiscoverDefinitionWorkflowsActivity(sourceControl: DefinitionsSou
         ...input,
         ref: input.sourceCommitSha ?? input.sourceRef,
         sourceControl,
+        workflowPath,
       });
     });
   };

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -29,6 +29,7 @@
         "BROWSER",
         "BROWSER_ARGS",
         "CLIENT_BASE_URL",
+        "DEFINITION_*",
         "GITEA_BASE_URL",
         "HOST",
         "INTEGRATIONS_ENABLE_SLACK_PROVIDER",


### PR DESCRIPTION
Shipfox instances currently read workflow definitions from one fixed repository path. This prevents staging and production instances from sharing a repository while keeping separate workflow definitions.

This adds the DEFINITION_WORKFLOW_PATH runtime setting and preserves .shipfox/workflows/ as the default. The configured path is captured during module composition and passed to definition discovery for both initial and commit-triggered syncs. Sync failures report the selected path, and local Turbo development passes definition settings through to the API process.

The published api-definitions package includes a minor Changeset for the additive configuration surface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `DEFINITION_WORKFLOW_PATH` to configure where workflow YAMLs are read from so staging and production can share a repo with different paths. Default remains `.shipfox/workflows/`; errors and dev tooling now respect this path.

- **New Features**
  - Added configurable workflow path to `@shipfox/api-definitions` and wired it through module composition to discovery and Temporal activities.
  - Sync failures include the selected path for clearer debugging.
  - Turbo dev forwards `DEFINITION_*` env vars to the API process.
  - Exported `DEFAULT_WORKFLOW_PATH`.

- **Migration**
  - Optional: set `DEFINITION_WORKFLOW_PATH` in your environment (e.g., `apps/api/.env`) when using a non-default path.

<sup>Written for commit 9a04f9b9ec2ada2b4dd80a6b1068581a2a1ede92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

