### PR TITLE
Keep event payload scrolling in the detail rail

### DIFF
--- a/.changeset/event-payload-scroll-rail.md
+++ b/.changeset/event-payload-scroll-rail.md
@@ -1,0 +1,5 @@
+---
+'@shipfox/client-shell': patch
+'@shipfox/client-triggers': patch
+---
+Move event payload scrolling to the detail rail and bound the desktop rail to the available viewport height.

--- a/libs/client/shell/src/components/main-layout.tsx
+++ b/libs/client/shell/src/components/main-layout.tsx
@@ -24,6 +24,9 @@ export function MainLayout({
   const matches = useMatches();
   if (!workspace) return <FullPageLoader />;
   const fullBleed = matches.some((match) => match.staticData.layout === 'full-bleed');
+  const appContentHeight = hideProjectNavigation
+    ? '[--app-content-h:calc(100dvh_-_56px)]'
+    : '[--app-content-h:calc(100dvh_-_96px)]';
   return (
     <div className="h-screen w-full flex flex-col bg-background-subtle-base">
       <NavBar hideProjectNavigation={hideProjectNavigation} />
@@ -35,7 +38,7 @@ export function MainLayout({
           <Outlet />
         </main>
       ) : (
-        <main className="flex-1 overflow-auto">
+        <main className={`flex-1 overflow-auto ${appContentHeight}`}>
           <div className="max-w-[1120px] mx-auto px-24 py-32">
             <Outlet />
           </div>

--- a/libs/client/triggers/src/components/trigger-event-detail.stories.tsx
+++ b/libs/client/triggers/src/components/trigger-event-detail.stories.tsx
@@ -26,8 +26,8 @@ const withRouter: Decorator = (Story) => {
   function StoryRoute() {
     return (
       <RelativeTimeProvider>
-        <div className="min-h-screen bg-background-subtle-base p-24">
-          <div className="ml-auto w-[400px]">
+        <div className="min-h-screen bg-background-subtle-base p-24 [--app-content-h:calc(100dvh_-_96px)]">
+          <div className="@container ml-auto w-[860px]">
             <Story />
           </div>
         </div>

--- a/libs/client/triggers/src/components/trigger-event-detail.tsx
+++ b/libs/client/triggers/src/components/trigger-event-detail.tsx
@@ -30,6 +30,8 @@ import {TriggerSourceIcon} from './trigger-source-icon.js';
 
 const PANEL_CLASS =
   'min-h-0 rounded-8 border border-border-neutral-base bg-background-neutral-base';
+const DETAIL_RAIL_CLASS =
+  '@min-[820px]:sticky @min-[820px]:top-16 @min-[820px]:max-h-[calc(var(--app-content-h,100dvh_-_96px)_-_32px)] @min-[820px]:min-h-[min(320px,calc(var(--app-content-h,100dvh_-_96px)_-_32px))]';
 
 export interface TriggerEventDetailProps {
   workspaceId: string;
@@ -69,7 +71,7 @@ export function TriggerEventDetailView({
   return (
     <aside
       aria-label="Event details"
-      className={cn(PANEL_CLASS, 'flex min-h-0 flex-col overflow-hidden')}
+      className={cn(PANEL_CLASS, DETAIL_RAIL_CLASS, 'flex min-h-0 flex-col overflow-hidden')}
     >
       <div className="flex shrink-0 flex-col gap-12 border-b border-border-neutral-base p-16">
         <Button
@@ -77,7 +79,7 @@ export function TriggerEventDetailView({
           variant="transparentMuted"
           size="sm"
           iconLeft="arrowLeftLine"
-          className="self-start min-[900px]:hidden"
+          className="self-start @min-[820px]:hidden"
           onClick={onBack}
         >
           Back to events
@@ -118,7 +120,10 @@ export function TriggerEventDetailView({
         </div>
       </div>
 
-      <div className="flex min-h-0 flex-1 flex-col gap-20 overflow-y-auto p-16 scrollbar">
+      <div
+        key={event.id}
+        className="flex min-h-0 flex-1 flex-col gap-20 overflow-y-auto p-16 scrollbar"
+      >
         <EventRuns workspaceId={workspaceId} event={event} />
         <EventPayload payload={formattedPayload} />
       </div>
@@ -140,7 +145,7 @@ function TriggerEventDetailPlaceholder() {
       aria-label="Event details"
       className={cn(
         PANEL_CLASS,
-        'hidden min-h-[240px] items-center justify-center p-24 min-[900px]:flex',
+        'hidden min-h-[240px] items-center justify-center p-24 @min-[820px]:flex',
       )}
     >
       <EmptyState icon="pulseLine" variant="compact" title="No event selected" />
@@ -152,14 +157,14 @@ function TriggerEventDetailLoading({onBack}: {onBack: () => void}) {
   return (
     <aside
       aria-label="Event details"
-      className={cn(PANEL_CLASS, 'flex min-h-[320px] flex-col gap-16 p-16')}
+      className={cn(PANEL_CLASS, DETAIL_RAIL_CLASS, 'flex min-h-[320px] flex-col gap-16 p-16')}
     >
       <Button
         type="button"
         variant="transparentMuted"
         size="sm"
         iconLeft="arrowLeftLine"
-        className="self-start min-[900px]:hidden"
+        className="self-start @min-[820px]:hidden"
         onClick={onBack}
       >
         Back to events
@@ -176,13 +181,16 @@ function TriggerEventDetailLoading({onBack}: {onBack: () => void}) {
 
 function TriggerEventDetailError({onBack, onRetry}: {onBack: () => void; onRetry: () => void}) {
   return (
-    <aside aria-label="Event details" className={cn(PANEL_CLASS, 'flex flex-col gap-16 p-16')}>
+    <aside
+      aria-label="Event details"
+      className={cn(PANEL_CLASS, DETAIL_RAIL_CLASS, 'flex min-h-[320px] flex-col gap-16 p-16')}
+    >
       <Button
         type="button"
         variant="transparentMuted"
         size="sm"
         iconLeft="arrowLeftLine"
-        className="self-start min-[900px]:hidden"
+        className="self-start @min-[820px]:hidden"
         onClick={onBack}
       >
         Back to events
@@ -293,15 +301,15 @@ function EventPayload({payload}: {payload: string}) {
       </Text>
       <CodeBlock
         data={data}
-        className="flex h-auto max-h-[min(360px,45vh)] flex-col rounded-8 bg-background-contrast-base shadow-none"
+        className="flex h-auto flex-col overflow-visible rounded-8 bg-background-contrast-base shadow-none"
       >
-        <CodeBlockHeader className="shrink-0 border-b border-border-contrast-base bg-background-contrast-base px-10 py-6">
+        <CodeBlockHeader className="sticky top-0 z-10 shrink-0 border-b border-border-contrast-base bg-background-contrast-base px-10 py-6">
           <CodeBlockFiles>
             {(item) => <CodeBlockFilename value={item.filename}>{item.filename}</CodeBlockFilename>}
           </CodeBlockFiles>
           <CodeBlockCopyButton />
         </CodeBlockHeader>
-        <CodeBlockBody className="min-h-0 overflow-auto scrollbar">
+        <CodeBlockBody className="min-h-0 scrollbar">
           {(item) => (
             <CodeBlockItem
               value={item.filename}

--- a/libs/client/triggers/src/pages/events-page.tsx
+++ b/libs/client/triggers/src/pages/events-page.tsx
@@ -37,7 +37,10 @@ export function EventsPage({workspaceId, filters, onFiltersChange}: EventsPagePr
 
   return (
     <RelativeTimeProvider>
-      <section className="flex min-w-0 flex-col gap-16" aria-labelledby="trigger-events-heading">
+      <section
+        className="@container flex min-w-0 flex-col gap-16"
+        aria-labelledby="trigger-events-heading"
+      >
         <div className="flex flex-col gap-4">
           <Header id="trigger-events-heading" variant="h3">
             Events
@@ -48,8 +51,8 @@ export function EventsPage({workspaceId, filters, onFiltersChange}: EventsPagePr
           </Text>
         </div>
 
-        <div className="grid min-h-0 gap-16 min-[900px]:grid-cols-[minmax(0,1fr)_minmax(360px,420px)]">
-          <div className={cn('min-w-0', selectedEventId && 'max-[899px]:hidden')}>
+        <div className="grid min-h-0 items-start gap-16 @min-[820px]:grid-cols-[minmax(0,1fr)_minmax(360px,420px)]">
+          <div className={cn('min-w-0', selectedEventId && '@max-[820px]:hidden')}>
             <EventsList
               events={events}
               query={query}


### PR DESCRIPTION
Large trigger-event payloads were constrained to a small code-block viewport while the detail rail stretched with the events list, leaving empty panel space and forcing nested scrolling.

This change bounds the desktop detail rail to the available settings content height, makes the rail body the vertical scrollport, and uses container queries so narrow layouts keep document scrolling. The payload header remains reachable for filename and copy actions, and the Storybook decorator now exercises the desktop container layout.

A patch changeset is included for the shell and triggers packages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep event payload scrolling inside the desktop detail rail and size the rail to the viewport height. Removes nested scrollbars, keeps the payload header sticky, and preserves page scrolling on narrow layouts.

- **Bug Fixes**
  - Bound the desktop rail to the viewport with a sticky top; its body is the only vertical scrollport.
  - Made the payload header sticky; removed nested overflow in the code block and reset scroll on event change.
  - Used container queries so narrow layouts keep page scrolling; updated Storybook to cover the desktop container.
  - Defined `--app-content-h` in the shell layout for height calc; added patch changesets for `@shipfox/client-shell` and `@shipfox/client-triggers`.

<sup>Written for commit 3d46e82db386d5c60e82b65ad65426605c06bfc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

