### PR TITLE
[api-integration-linear] Link connections to installed app settings

### DIFF
--- a/.changeset/linear-installation-settings-url.md
+++ b/.changeset/linear-installation-settings-url.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-integration-linear": patch
+---
+
+Links Linear connections directly to the installed application's settings page.

--- a/libs/api/integration/linear/src/connection-external-url.test.ts
+++ b/libs/api/integration/linear/src/connection-external-url.test.ts
@@ -18,7 +18,7 @@ function installation(overrides: Partial<LinearInstallation> = {}): LinearInstal
 }
 
 describe('linear connectionExternalUrl', () => {
-  it('resolves the organization settings URL from the installation row', async () => {
+  it('resolves the organization application settings URL from the installation row', async () => {
     const connectionId = crypto.randomUUID();
     const provider = createLinearIntegrationProvider({
       getLinearInstallationByConnectionId: () =>
@@ -27,7 +27,7 @@ describe('linear connectionExternalUrl', () => {
 
     const url = await provider.connectionExternalUrl({id: connectionId});
 
-    expect(url).toBe('https://linear.app/acme/settings');
+    expect(url).toBe('https://linear.app/acme/settings/applications/test-client-id');
   });
 
   it('URL-encodes the organization URL key', async () => {
@@ -38,7 +38,7 @@ describe('linear connectionExternalUrl', () => {
 
     const url = await provider.connectionExternalUrl({id: crypto.randomUUID()});
 
-    expect(url).toBe('https://linear.app/a%2Fb%20c/settings');
+    expect(url).toBe('https://linear.app/a%2Fb%20c/settings/applications/test-client-id');
   });
 
   it('returns undefined when the installation row is missing', async () => {

--- a/libs/api/integration/linear/src/index.ts
+++ b/libs/api/integration/linear/src/index.ts
@@ -155,7 +155,7 @@ export function createLinearIntegrationProvider(
     async connectionExternalUrl(connection: {id: string}): Promise<string | undefined> {
       const installation = await getInstallationByConnectionId(connection.id);
       if (!installation?.organizationUrlKey) return undefined;
-      return `https://linear.app/${encodeURIComponent(installation.organizationUrlKey)}/settings`;
+      return `https://linear.app/${encodeURIComponent(installation.organizationUrlKey)}/settings/applications/${encodeURIComponent(config.LINEAR_OAUTH_CLIENT_ID)}`;
     },
     ...options.cleanup,
     routes,


### PR DESCRIPTION
Linear integration connection links now open the specific installed application settings page, making the Shipfox Linear installation directly manageable.

Includes a patch changeset for @shipfox/api-integration-linear.

Validation: mise exec -- pnpm turbo check type test --filter=@shipfox/api-integration-linear (108 tests passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Linear connection links now open the installed app’s settings page for the correct organization, using the org URL key and the configured client ID, so users can manage the Shipfox installation directly. Includes a patch release for `@shipfox/api-integration-linear`.

<sup>Written for commit c0d75e7e1b14de08eeafa2c2298bf1a25b181275. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

