### PR TITLE
[api-auth] Add the signup gating policy seam

### DIFF
--- a/.changeset/signup-policy-port.md
+++ b/.changeset/signup-policy-port.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-auth": minor
+---
+
+Adds the signup policy port and denial error to API Auth.

--- a/libs/api/auth/src/core/errors.ts
+++ b/libs/api/auth/src/core/errors.ts
@@ -47,6 +47,13 @@ export class EmailTakenError extends Error {
   }
 }
 
+export class SignupNotAllowedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SignupNotAllowedError';
+  }
+}
+
 export class InvalidCredentialsError extends Error {
   constructor() {
     super('Invalid credentials');

--- a/libs/api/auth/src/core/ports.ts
+++ b/libs/api/auth/src/core/ports.ts
@@ -1,0 +1,7 @@
+export interface SignupPolicy {
+  isSignupAllowed(params: {
+    email: string;
+    emailVerified: boolean;
+    source: string;
+  }): Promise<{allowed: true} | {allowed: false; message?: string}>;
+}

--- a/libs/api/auth/src/index.ts
+++ b/libs/api/auth/src/index.ts
@@ -33,6 +33,7 @@ export {
   AuthDependencyUnavailableError,
   EmailNotVerifiedError,
   InvalidCredentialsError,
+  SignupNotAllowedError,
   UserNotFoundError,
 } from '#core/errors.js';
 export {
@@ -40,6 +41,7 @@ export {
   jobLeaseParamsFrom,
   verifyJobLeaseToken,
 } from '#core/job-lease-token.js';
+export type {SignupPolicy} from '#core/ports.js';
 export {
   issueRunnerSessionToken,
   verifyRunnerSessionToken,


### PR DESCRIPTION
Adds the upstream seam required for signup gating.

@shipfox/api-auth now exposes the async SignupPolicy contract and SignupNotAllowedError so downstream modules can enforce account-creation eligibility while keeping the denial message owned by the policy.

Closes ENG-1249

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the signup gating seam to `@shipfox/api-auth` by introducing the async `SignupPolicy` contract and exporting `SignupNotAllowedError`, so downstream modules can enforce signup eligibility and surface policy-owned denial messages. Closes ENG-1249.

<sup>Written for commit 7c522812365fc7f7f1e8da54fc27f731532ced13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

