### PR TITLE
[api-auth] Return 403 for blocked signups

### DIFF
--- a/.changeset/signup-not-allowed-response.md
+++ b/.changeset/signup-not-allowed-response.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-auth": patch
+---
+
+Return a bounded signup-not-allowed message from the password signup route.

--- a/libs/api/auth/src/presentation/routes/registration/signup.test.ts
+++ b/libs/api/auth/src/presentation/routes/registration/signup.test.ts
@@ -1,6 +1,9 @@
+import type {WorkspacesInterModuleClient} from '@shipfox/api-workspaces-dto/inter-module';
 import {workspacesInterModuleContract} from '@shipfox/api-workspaces-dto/inter-module';
 import {createInterModuleKnownError} from '@shipfox/inter-module';
+import {ClientError} from '@shipfox/node-fastify';
 import type {FastifyInstance} from 'fastify';
+import {SignupNotAllowedError} from '#core/errors.js';
 import {verifyUserToken} from '#core/jwt.js';
 import {
   acceptWorkspaceInvitationMock,
@@ -14,6 +17,7 @@ import {
   signup,
   uniqueEmail,
 } from '#test/routes.js';
+import {createSignupRoute} from './signup.js';
 
 describe('POST /auth/signup', () => {
   let app: FastifyInstance;
@@ -25,6 +29,28 @@ describe('POST /auth/signup', () => {
 
   beforeEach(() => {
     resetCapturedMail();
+  });
+
+  test('maps a denied signup to a bounded client error', () => {
+    const errorHandler = createSignupRoute({} as WorkspacesInterModuleClient).errorHandler as (
+      error: unknown,
+    ) => never;
+    const message = 'x'.repeat(501);
+    let mapped: unknown;
+
+    try {
+      errorHandler(new SignupNotAllowedError(message));
+    } catch (error) {
+      mapped = error;
+    }
+
+    expect(mapped).toBeInstanceOf(ClientError);
+    expect(mapped).toMatchObject({
+      message: 'x'.repeat(500),
+      status: 403,
+      code: 'signup-not-allowed',
+      details: {message: 'x'.repeat(500)},
+    });
   });
 
   afterAll(async () => {

--- a/libs/api/auth/src/presentation/routes/registration/signup.ts
+++ b/libs/api/auth/src/presentation/routes/registration/signup.ts
@@ -6,12 +6,15 @@ import {signup, signupWithInvitation} from '#core/auth.js';
 import {
   EmailTakenError,
   InvitationEmailMismatchError,
+  SignupNotAllowedError,
   TokenAlreadyUsedError,
   TokenExpiredError,
   TokenInvalidError,
 } from '#core/errors.js';
 import {setRefreshTokenCookie} from '#presentation/auth/refresh-cookie.js';
 import {toUserDto} from '#presentation/dto/user.js';
+
+const SIGNUP_NOT_ALLOWED_MESSAGE_MAX_LENGTH = 500;
 
 export function createSignupRoute(workspaces: WorkspacesInterModuleClient) {
   return defineRoute({
@@ -34,6 +37,13 @@ export function createSignupRoute(workspaces: WorkspacesInterModuleClient) {
       }
       if (error instanceof EmailTakenError) {
         throw new ClientError('Email already registered', 'email-taken', {status: 409});
+      }
+      if (error instanceof SignupNotAllowedError) {
+        const message = error.message.slice(0, SIGNUP_NOT_ALLOWED_MESSAGE_MAX_LENGTH);
+        throw new ClientError(message, 'signup-not-allowed', {
+          status: 403,
+          details: {message},
+        });
       }
       if (error instanceof TokenInvalidError) {
         throw new ClientError('Invitation token is invalid', 'invitation-token-invalid', {


### PR DESCRIPTION
Blocked password signups now return a stable 403 `signup-not-allowed` response. The deployment policy message is capped at 500 characters and exposed in safe response details for plain-text client rendering.

Closes ENG-1253

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocked password signups now return a consistent 403 with code `signup-not-allowed` from `POST /auth/signup`, matching ENG-1253. The deployment policy message is truncated to 500 characters and returned as the error message and in `details.message` for safe plain‑text rendering.

<sup>Written for commit 9f63516bb775f4029e06a8a08b218d7a60e579bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

