### PR TITLE
[api-auth] Compose signup policies through the auth module

### DIFF
--- a/.changeset/auth-signup-policy-module.md
+++ b/.changeset/auth-signup-policy-module.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-auth": minor
+---
+
+Thread an optional signup policy through API Auth module composition in preparation for signup enforcement.

--- a/libs/api/auth/src/core/auth.ts
+++ b/libs/api/auth/src/core/auth.ts
@@ -46,6 +46,7 @@ import {
 } from './errors.js';
 import {signUserToken} from './jwt.js';
 import {hashPassword, verifyPassword} from './password.js';
+import type {SignupPolicy} from './ports.js';
 
 const RESET_TTL_HOURS = 1;
 const PASSWORD_VERIFICATION_PURPOSE = 'password-verification';
@@ -156,11 +157,13 @@ export interface SignupParams {
   email: string;
   password: string;
   name?: string | undefined;
+  signupPolicy?: SignupPolicy | undefined;
 }
 
 export interface ProvisionUserParams {
   email: string;
   name?: string | null | undefined;
+  signupPolicy?: SignupPolicy | undefined;
 }
 
 /**

--- a/libs/api/auth/src/index.test.ts
+++ b/libs/api/auth/src/index.test.ts
@@ -23,6 +23,9 @@ vi.mock('@shipfox/node-mailer', () => ({
 }));
 
 describe('authModule', () => {
+  const signupPolicy = {
+    isSignupAllowed: async () => ({allowed: true as const}),
+  };
   const authModule = createAuthModule({
     workspaces: {
       listMembershipsForTokenClaims: vi.fn(),
@@ -31,6 +34,7 @@ describe('authModule', () => {
       acceptInvitation: vi.fn(),
       requireActiveMembership: vi.fn(),
     },
+    signupPolicy,
   });
   test('declares password login only when password login is enabled', () => {
     expect(passwordLoginMethods(true)).toEqual([{id: 'password'}]);

--- a/libs/api/auth/src/index.ts
+++ b/libs/api/auth/src/index.ts
@@ -6,6 +6,7 @@ import {
 import type {ShipfoxModule} from '@shipfox/node-module';
 import {subscriberFactory} from '@shipfox/node-module';
 import {config} from '#config.js';
+import type {SignupPolicy} from '#core/ports.js';
 import {db} from '#db/db.js';
 import {migrationsPath} from '#db/migrations.js';
 import {authOutbox} from '#db/schema/outbox.js';
@@ -64,17 +65,21 @@ export {createRunnerSessionAuthMethod} from '#presentation/auth/runner-session-a
 
 const subscriber = subscriberFactory<AuthEventMap>();
 
+export interface CreateAuthModuleOptions {
+  workspaces: import('@shipfox/api-workspaces-dto/inter-module').WorkspacesInterModuleClient;
+  signupPolicy?: SignupPolicy;
+}
+
 export function createAuthModule({
   workspaces,
-}: {
-  workspaces: import('@shipfox/api-workspaces-dto/inter-module').WorkspacesInterModuleClient;
-}): ShipfoxModule {
+  signupPolicy,
+}: CreateAuthModuleOptions): ShipfoxModule {
   return {
     name: 'auth',
     database: {db, migrationsPath, databaseNamespace: 'auth'},
     auth: [createJwtAuthMethod(), createLeaseTokenAuthMethod(), createRunnerSessionAuthMethod()],
     loginMethods: passwordLoginMethods(config.AUTH_PASSWORD_ENABLED),
-    routes: [buildAuthRoutes(config.AUTH_PASSWORD_ENABLED, workspaces)],
+    routes: [buildAuthRoutes(config.AUTH_PASSWORD_ENABLED, workspaces, signupPolicy)],
     e2eRoutes: [createAuthE2eRoutes(workspaces)],
     publishers: [{name: 'auth', table: authOutbox, db, eventSchemas: authEventSchemas}],
     subscribers: [subscriber(AUTH_PASSWORD_RESET_SEND_REQUESTED, onPasswordResetSendRequested)],

--- a/libs/api/auth/src/presentation/routes/index.ts
+++ b/libs/api/auth/src/presentation/routes/index.ts
@@ -1,5 +1,6 @@
 import type {WorkspacesInterModuleClient} from '@shipfox/api-workspaces-dto/inter-module';
 import type {RouteGroup} from '@shipfox/node-fastify';
+import type {SignupPolicy} from '#core/ports.js';
 import {authCookiePlugin} from '#presentation/auth/refresh-cookie.js';
 import {createVerifyEmailConfirmRoute} from './email-verification/verify-email-confirm.js';
 import {verifyEmailResendRoute} from './email-verification/verify-email-resend.js';
@@ -15,10 +16,11 @@ import {createRefreshRoute} from './session/refresh.js';
 export function buildAuthRoutes(
   passwordEnabled: boolean,
   workspaces: WorkspacesInterModuleClient,
+  signupPolicy?: SignupPolicy,
 ): RouteGroup {
   const passwordRoutes = passwordEnabled
     ? [
-        createSignupRoute(workspaces),
+        createSignupRoute(workspaces, signupPolicy),
         createVerifyEmailConfirmRoute(workspaces),
         verifyEmailResendRoute,
         createLoginRoute(workspaces),

--- a/libs/api/auth/src/presentation/routes/registration/signup.ts
+++ b/libs/api/auth/src/presentation/routes/registration/signup.ts
@@ -11,12 +11,16 @@ import {
   TokenExpiredError,
   TokenInvalidError,
 } from '#core/errors.js';
+import type {SignupPolicy} from '#core/ports.js';
 import {setRefreshTokenCookie} from '#presentation/auth/refresh-cookie.js';
 import {toUserDto} from '#presentation/dto/user.js';
 
 const SIGNUP_NOT_ALLOWED_MESSAGE_MAX_LENGTH = 500;
 
-export function createSignupRoute(workspaces: WorkspacesInterModuleClient) {
+export function createSignupRoute(
+  workspaces: WorkspacesInterModuleClient,
+  signupPolicy?: SignupPolicy,
+) {
   return defineRoute({
     method: 'POST',
     path: '/signup',
@@ -73,7 +77,13 @@ export function createSignupRoute(workspaces: WorkspacesInterModuleClient) {
       const {email, password, name, invitation_token} = request.body;
 
       if (invitation_token === undefined) {
-        const result = await signup({email, password, name, sourceIp: request.ip});
+        const result = await signup({
+          email,
+          password,
+          name,
+          sourceIp: request.ip,
+          signupPolicy,
+        });
         reply.code(201);
         return {
           user: toUserDto(result),


### PR DESCRIPTION
Thread an optional `SignupPolicy` through `createAuthModule` into the password signup route and core parameter types, preserving existing callers and invitation bypass behavior.

This is the composition step for signup gating. The environment-backed default policy and enforcement calls are intentionally delivered by the linked ENG-1250 and ENG-1251 follow-ups.

Part of ENG-1252

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a pluggable `SignupPolicy` to the auth module and threads it through route composition into the password signup flow. Preps signup gating for ENG-1252 with no behavior change; invitation signups still bypass policy.

- **New Features**
  - `createAuthModule` now accepts optional `signupPolicy` in `CreateAuthModuleOptions` and passes it to `buildAuthRoutes` and `createSignupRoute`.
  - `buildAuthRoutes` and `createSignupRoute` accept optional `signupPolicy` and forward it to `signup` for non-invite flows.
  - Extended core types (`SignupParams`, `ProvisionUserParams`) with optional `signupPolicy`; tests updated.

<sup>Written for commit ba1d74aa21fcafd8d8bd566cc3d2599875071815. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

