### PR TITLE
[api-auth] Gate new account creation with signup policy

### DIFF
--- a/.changeset/signup-guard.md
+++ b/.changeset/signup-guard.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-auth": minor
+---
+
+Guards password and external-identity account creation with the signup policy.

--- a/libs/api/auth/src/core/auth.test.ts
+++ b/libs/api/auth/src/core/auth.test.ts
@@ -160,6 +160,71 @@ describe('auth core', () => {
     await expect(promise).rejects.toBeInstanceOf(EmailTakenError);
   });
 
+  test('signup normalizes the email before checking the policy', async () => {
+    const email = `signup-policy-${crypto.randomUUID()}@example.com`;
+    const isSignupAllowed = vi.fn().mockResolvedValue({allowed: true});
+
+    await signup({
+      email: `  ${email.toUpperCase()}  `,
+      password: 'correct horse battery staple',
+      signupPolicy: {isSignupAllowed},
+    });
+
+    expect(isSignupAllowed).toHaveBeenCalledWith({
+      email,
+      emailVerified: false,
+      source: 'password',
+    });
+  });
+
+  test('signup denies a new user when the policy does not allow it', async () => {
+    const email = `signup-policy-denied-${crypto.randomUUID()}@example.com`;
+    const isSignupAllowed = vi.fn().mockResolvedValue({allowed: false});
+
+    await expect(
+      signup({
+        email,
+        password: 'correct horse battery staple',
+        signupPolicy: {isSignupAllowed},
+      }),
+    ).rejects.toEqual(
+      expect.objectContaining({
+        name: 'SignupNotAllowedError',
+        message: 'This Shipfox deployment does not accept new accounts right now.',
+      }),
+    );
+    expect(await findUserByEmail({email})).toBeUndefined();
+  });
+
+  test('signup fails closed when the policy throws', async () => {
+    const email = `signup-policy-error-${crypto.randomUUID()}@example.com`;
+    const policyError = new Error('policy unavailable');
+    const isSignupAllowed = vi.fn().mockRejectedValue(policyError);
+
+    await expect(
+      signup({
+        email,
+        password: 'correct horse battery staple',
+        signupPolicy: {isSignupAllowed},
+      }),
+    ).rejects.toBe(policyError);
+    expect(await findUserByEmail({email})).toBeUndefined();
+  });
+
+  test('signup does not check the policy for an existing user', async () => {
+    const existing = await userFactory.create({emailVerifiedAt: new Date()});
+    const isSignupAllowed = vi.fn().mockResolvedValue({allowed: false});
+
+    await expect(
+      signup({
+        email: `  ${existing.email.toUpperCase()}  `,
+        password: 'correct horse battery staple',
+        signupPolicy: {isSignupAllowed},
+      }),
+    ).rejects.toBeInstanceOf(EmailTakenError);
+    expect(isSignupAllowed).not.toHaveBeenCalled();
+  });
+
   test('signup with an invitation writes the signed-up event with its user insert', async () => {
     const email = `signup-invitation-${crypto.randomUUID()}@example.com`;
     const userId = crypto.randomUUID();
@@ -175,6 +240,9 @@ describe('auth core', () => {
       name: 'Invited User',
       invitationToken: `invite-${crypto.randomUUID()}`,
       workspaces,
+      signupPolicy: {
+        isSignupAllowed: vi.fn().mockRejectedValue(new Error('policy unavailable')),
+      },
     });
 
     const events = await outboxEventsTo(email, AUTH_USER_SIGNED_UP);
@@ -199,24 +267,66 @@ describe('auth core', () => {
     expect(user.status).toBe('active');
   });
 
+  test('provisionUser normalizes the email before checking the policy', async () => {
+    const email = `provision-policy-${crypto.randomUUID()}@example.com`;
+    const isSignupAllowed = vi.fn().mockResolvedValue({allowed: true});
+
+    await provisionUser({
+      email: `  ${email.toUpperCase()}  `,
+      signupPolicy: {isSignupAllowed},
+    });
+
+    expect(isSignupAllowed).toHaveBeenCalledWith({
+      email,
+      emailVerified: true,
+      source: 'external-identity',
+    });
+  });
+
+  test('provisionUser denies a new user when the policy does not allow it', async () => {
+    const email = `provision-policy-denied-${crypto.randomUUID()}@example.com`;
+    const isSignupAllowed = vi.fn().mockResolvedValue({allowed: false, message: 'Closed beta'});
+
+    await expect(provisionUser({email, signupPolicy: {isSignupAllowed}})).rejects.toEqual(
+      expect.objectContaining({
+        name: 'SignupNotAllowedError',
+        message: 'Closed beta',
+      }),
+    );
+    expect(await findUserByEmail({email})).toBeUndefined();
+  });
+
+  test('provisionUser fails closed when the policy throws', async () => {
+    const email = `provision-policy-error-${crypto.randomUUID()}@example.com`;
+    const policyError = new Error('policy unavailable');
+    const isSignupAllowed = vi.fn().mockRejectedValue(policyError);
+
+    await expect(provisionUser({email, signupPolicy: {isSignupAllowed}})).rejects.toBe(policyError);
+    expect(await findUserByEmail({email})).toBeUndefined();
+  });
+
   test('provisionUser returns existing unverified and suspended users unchanged', async () => {
     const unverified = await userFactory.create();
     const suspended = await userFactory.create({emailVerifiedAt: new Date()});
     await db().update(users).set({status: 'suspended'}).where(eq(users.id, suspended.id));
     const storedUnverified = await findUserById({id: unverified.id});
     const storedSuspended = await findUserById({id: suspended.id});
+    const isSignupAllowed = vi.fn().mockResolvedValue({allowed: false});
 
     const existingUnverified = await provisionUser({
       email: `  ${unverified.email.toUpperCase()}  `,
       name: 'Replacement Name',
+      signupPolicy: {isSignupAllowed},
     });
     const existingSuspended = await provisionUser({
       email: `  ${suspended.email.toUpperCase()}  `,
       name: 'Replacement Name',
+      signupPolicy: {isSignupAllowed},
     });
 
     expect(existingUnverified).toEqual(storedUnverified);
     expect(existingSuspended).toEqual(storedSuspended);
+    expect(isSignupAllowed).not.toHaveBeenCalled();
   });
 
   test('provisionUser returns one unchanged user for concurrent callbacks', async () => {

--- a/libs/api/auth/src/core/auth.ts
+++ b/libs/api/auth/src/core/auth.ts
@@ -39,6 +39,7 @@ import {
   EmailTakenError,
   InvalidCredentialsError,
   InvitationEmailMismatchError,
+  SignupNotAllowedError,
   TokenAlreadyUsedError,
   TokenExpiredError,
   TokenInvalidError,
@@ -50,6 +51,29 @@ import type {SignupPolicy} from './ports.js';
 
 const RESET_TTL_HOURS = 1;
 const PASSWORD_VERIFICATION_PURPOSE = 'password-verification';
+const DEFAULT_SIGNUP_NOT_ALLOWED_MESSAGE =
+  'This Shipfox deployment does not accept new accounts right now.';
+
+const defaultSignupPolicy: SignupPolicy = {
+  isSignupAllowed: async () => ({allowed: true}),
+};
+
+async function assertSignupAllowed(params: {
+  signupPolicy?: SignupPolicy | undefined;
+  email: string;
+  emailVerified: boolean;
+  source: string;
+}): Promise<void> {
+  const result = await (params.signupPolicy ?? defaultSignupPolicy).isSignupAllowed({
+    email: params.email,
+    emailVerified: params.emailVerified,
+    source: params.source,
+  });
+
+  if (!result.allowed) {
+    throw new SignupNotAllowedError(result.message ?? DEFAULT_SIGNUP_NOT_ALLOWED_MESSAGE);
+  }
+}
 
 let dummyHashCache: string | undefined;
 async function getDummyHash(): Promise<string> {
@@ -171,8 +195,19 @@ export interface ProvisionUserParams {
  * Existing users are returned unchanged, including their password and profile.
  */
 export async function provisionUser(params: ProvisionUserParams): Promise<User> {
+  const email = emailSchema.parse(params.email);
+  const existing = await findUserByEmail({email});
+  if (existing) return existing;
+
+  await assertSignupAllowed({
+    signupPolicy: params.signupPolicy,
+    email,
+    emailVerified: true,
+    source: 'external-identity',
+  });
+
   return await provisionDbUser({
-    email: emailSchema.parse(params.email),
+    email,
     name: params.name ?? null,
   });
 }
@@ -182,7 +217,8 @@ export type SignupResult = User & {
 };
 
 export async function signup(params: SignupParams & {sourceIp?: string}): Promise<SignupResult> {
-  const existing = await findUserByEmail({email: params.email});
+  const email = emailSchema.parse(params.email);
+  const existing = await findUserByEmail({email});
   if (existing) {
     const canResumeVerification =
       existing.status === 'active' &&
@@ -199,12 +235,19 @@ export async function signup(params: SignupParams & {sourceIp?: string}): Promis
       });
       return {...existing, emailChallenge};
     }
-    throw new EmailTakenError(params.email);
+    throw new EmailTakenError(email);
   }
+
+  await assertSignupAllowed({
+    signupPolicy: params.signupPolicy,
+    email,
+    emailVerified: false,
+    source: 'password',
+  });
 
   const hashedPassword = await hashPassword({password: params.password});
   const user = await createDbUser({
-    email: params.email,
+    email,
     hashedPassword,
     name: params.name ?? null,
     signedUp: {viaInvitation: false},


### PR DESCRIPTION
Adds signup-policy enforcement to password and external-identity account creation, while preserving existing-user and invitation bypasses. Policy denials are translated into a client-facing 403 response so configured signup restrictions do not surface as unhandled 500s.

The policy remains optional with the existing allow-all default; runtime policy wiring is handled separately by ENG-1252.

Focused validation passed for Biome, core auth tests, the route denial-mapping test, type emit, build, and diff checks. The full signup route file still has three local email-challenge rate-limit failures (429) unrelated to this change.

Closes ENG-1251

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate new account creation behind a signup policy for both password and external-identity flows. Existing users and valid invitations bypass the gate; denials raise `SignupNotAllowedError` and return 403 to clients.

- **New Features**
  - Enforce the policy in `signup()` and `provisionUser()` using normalized email, `source` (`password` or `external-identity`), and `emailVerified` to meet ENG-1251.
  - In `provisionUser()`, check for an existing user before the gate; in `signup()`, skip the gate on a valid invitation.
  - Default allow-all when no policy is provided; fail closed by surfacing policy errors and blocking creation; use a default denial message when the policy omits one.

<sup>Written for commit 171609416c6dfa1d584b93b07df7d291a3762a55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

