### PR TITLE
[api-auth] Add environment-driven signup policy

### DIFF
--- a/.changeset/signup-policy-env.md
+++ b/.changeset/signup-policy-env.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-auth": minor
+---
+
+Adds the environment-variable signup policy and its Auth-prefixed configuration.

--- a/libs/api/auth/README.md
+++ b/libs/api/auth/README.md
@@ -63,6 +63,10 @@ Required environment:
 | `AUTH_REFRESH_ROTATION_GRACE_SECONDS` | `30` | Grace window for accepting a just-rotated refresh token during concurrent refreshes. |
 | `AUTH_REFRESH_COOKIE_NAME` | `shipfox_refresh_token` | HTTP cookie name for refresh sessions. |
 | `AUTH_PASSWORD_ENABLED` | `true` | Enables password and email-verification routes. Set to `false` when another module provides login. Server construction fails if no login method is available. |
+| `AUTH_SIGNUP_GATE_ENABLED` | `false` | Restricts new account creation to the configured signup email allowlist. Requires `AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS` or `AUTH_SIGNUP_ALLOWED_EMAILS` to be set. |
+| `AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS` | none | Comma-separated email domains allowed to create accounts, such as `shipfox.io,acme.com`. |
+| `AUTH_SIGNUP_ALLOWED_EMAILS` | none | Comma-separated exact email addresses allowed to create accounts. |
+| `AUTH_SIGNUP_NOT_ALLOWED_MESSAGE` | none | Description returned when the signup gate blocks an account. Defaults to "This Shipfox deployment does not accept new accounts right now." |
 | `CLIENT_BASE_URL` | `http://localhost:5173` | Base URL used in email verification and password reset links. |
 
 Email delivery uses the shared `@shipfox/node-mailer` configuration.

--- a/libs/api/auth/src/config.test.ts
+++ b/libs/api/auth/src/config.test.ts
@@ -1,0 +1,39 @@
+describe('signup gate configuration', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  test('uses the Auth-prefixed defaults', async () => {
+    vi.resetModules();
+
+    const {config} = await import('#config.js');
+
+    expect(config.AUTH_SIGNUP_GATE_ENABLED).toBe(false);
+    expect(config.AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS).toBe('');
+    expect(config.AUTH_SIGNUP_ALLOWED_EMAILS).toBe('');
+    expect(config.AUTH_SIGNUP_NOT_ALLOWED_MESSAGE).toBeUndefined();
+  });
+
+  test('fails startup when the enabled gate has no allowlist', async () => {
+    vi.stubEnv('AUTH_SIGNUP_GATE_ENABLED', 'true');
+    vi.stubEnv('AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS', ',  ');
+    vi.stubEnv('AUTH_SIGNUP_ALLOWED_EMAILS', ' , ');
+    vi.resetModules();
+
+    await expect(import('#config.js')).rejects.toThrow(
+      'AUTH_SIGNUP_GATE_ENABLED requires AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS or AUTH_SIGNUP_ALLOWED_EMAILS',
+    );
+  });
+
+  test('accepts an enabled gate with either allowlist', async () => {
+    vi.stubEnv('AUTH_SIGNUP_GATE_ENABLED', 'true');
+    vi.stubEnv('AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS', 'shipfox.io');
+    vi.resetModules();
+
+    const {config} = await import('#config.js');
+
+    expect(config.AUTH_SIGNUP_GATE_ENABLED).toBe(true);
+    expect(config.AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS).toBe('shipfox.io');
+  });
+});

--- a/libs/api/auth/src/config.ts
+++ b/libs/api/auth/src/config.ts
@@ -29,8 +29,38 @@ export const config = createConfig({
     desc: 'Whether password login is available. Use true or false. Defaults to true. When false, password and email-verification routes are not registered, and server startup requires another module to contribute a login method.',
     default: true,
   }),
+  AUTH_SIGNUP_GATE_ENABLED: bool({
+    desc: 'Whether new account creation is restricted to the configured signup email allowlist. Defaults to false, which allows every signup.',
+    default: false,
+  }),
+  AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS: str({
+    desc: 'Comma-separated email domains allowed to create accounts, such as shipfox.io,acme.com. Required when AUTH_SIGNUP_GATE_ENABLED is true unless AUTH_SIGNUP_ALLOWED_EMAILS is set.',
+    default: '',
+  }),
+  AUTH_SIGNUP_ALLOWED_EMAILS: str({
+    desc: 'Comma-separated exact email addresses allowed to create accounts. Required when AUTH_SIGNUP_GATE_ENABLED is true unless AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS is set.',
+    default: '',
+  }),
+  AUTH_SIGNUP_NOT_ALLOWED_MESSAGE: str({
+    desc: 'Description returned when the signup gate blocks an account. Optional. The default is This Shipfox deployment does not accept new accounts right now.',
+    default: undefined,
+  }),
   CLIENT_BASE_URL: str({
     desc: 'Base URL of the client app. Used to build links in emails such as password resets.',
     default: 'http://localhost:5173',
   }),
 });
+
+if (
+  config.AUTH_SIGNUP_GATE_ENABLED &&
+  !hasSignupAllowlistEntry(config.AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS) &&
+  !hasSignupAllowlistEntry(config.AUTH_SIGNUP_ALLOWED_EMAILS)
+) {
+  throw new Error(
+    'AUTH_SIGNUP_GATE_ENABLED requires AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS or AUTH_SIGNUP_ALLOWED_EMAILS to be set.',
+  );
+}
+
+function hasSignupAllowlistEntry(value: string): boolean {
+  return value.split(',').some((entry) => entry.trim().length > 0);
+}

--- a/libs/api/auth/src/core/signup-policy.test.ts
+++ b/libs/api/auth/src/core/signup-policy.test.ts
@@ -1,0 +1,78 @@
+import {config} from '#config.js';
+import {
+  createEnvironmentSignupPolicy,
+  DEFAULT_SIGNUP_NOT_ALLOWED_MESSAGE,
+} from './signup-policy.js';
+
+vi.mock('#config.js', () => ({
+  config: {
+    AUTH_SIGNUP_GATE_ENABLED: true,
+    AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS: ' Shipfox.io, acme.com ',
+    AUTH_SIGNUP_ALLOWED_EMAILS: ' Alice@Example.com, ',
+    AUTH_SIGNUP_NOT_ALLOWED_MESSAGE: undefined,
+  },
+}));
+
+describe('createEnvironmentSignupPolicy', () => {
+  afterEach(() => {
+    vi.mocked(config).AUTH_SIGNUP_GATE_ENABLED = true;
+    vi.mocked(config).AUTH_SIGNUP_NOT_ALLOWED_MESSAGE = undefined;
+  });
+
+  test('allows exact addresses and domains after normalization', async () => {
+    const policy = createEnvironmentSignupPolicy();
+
+    await expect(
+      policy.isSignupAllowed({
+        email: ' alice@example.com ',
+        emailVerified: false,
+        source: 'password',
+      }),
+    ).resolves.toEqual({allowed: true});
+    await expect(
+      policy.isSignupAllowed({
+        email: 'member@SHIPFOX.IO',
+        emailVerified: true,
+        source: 'oauth-google',
+      }),
+    ).resolves.toEqual({allowed: true});
+  });
+
+  test('does not match subdomains', async () => {
+    const policy = createEnvironmentSignupPolicy();
+
+    await expect(
+      policy.isSignupAllowed({
+        email: 'member@eu.shipfox.io',
+        emailVerified: true,
+        source: 'oauth-google',
+      }),
+    ).resolves.toEqual({allowed: false, message: DEFAULT_SIGNUP_NOT_ALLOWED_MESSAGE});
+  });
+
+  test('returns the configured denial message for an unmatched address', async () => {
+    vi.mocked(config).AUTH_SIGNUP_NOT_ALLOWED_MESSAGE = 'Ask your administrator for access.';
+    const policy = createEnvironmentSignupPolicy();
+
+    await expect(
+      policy.isSignupAllowed({
+        email: 'member@other.example',
+        emailVerified: true,
+        source: 'oauth-google',
+      }),
+    ).resolves.toEqual({allowed: false, message: 'Ask your administrator for access.'});
+  });
+
+  test('allows every address when the gate is disabled', async () => {
+    vi.mocked(config).AUTH_SIGNUP_GATE_ENABLED = false;
+    const policy = createEnvironmentSignupPolicy();
+
+    await expect(
+      policy.isSignupAllowed({
+        email: 'member@other.example',
+        emailVerified: false,
+        source: 'password',
+      }),
+    ).resolves.toEqual({allowed: true});
+  });
+});

--- a/libs/api/auth/src/core/signup-policy.ts
+++ b/libs/api/auth/src/core/signup-policy.ts
@@ -1,0 +1,42 @@
+import {config} from '#config.js';
+import type {SignupPolicy} from './ports.js';
+
+export const DEFAULT_SIGNUP_NOT_ALLOWED_MESSAGE =
+  'This Shipfox deployment does not accept new accounts right now.';
+
+/**
+ * Builds the default signup policy from the Auth module's environment settings.
+ *
+ * The allowlist is resolved once at startup. Environment values are normalized
+ * before matching, but the configured denial message is returned unchanged.
+ */
+export function createEnvironmentSignupPolicy(): SignupPolicy {
+  const allowedEmails = parseAllowlist(config.AUTH_SIGNUP_ALLOWED_EMAILS);
+  const allowedDomains = parseAllowlist(config.AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS);
+
+  return {
+    isSignupAllowed({email}) {
+      if (!config.AUTH_SIGNUP_GATE_ENABLED) return Promise.resolve({allowed: true});
+
+      const normalizedEmail = normalize(email);
+      if (allowedEmails.has(normalizedEmail)) return Promise.resolve({allowed: true});
+
+      const atIndex = normalizedEmail.lastIndexOf('@');
+      const domain = atIndex === -1 ? '' : normalizedEmail.slice(atIndex + 1);
+      if (allowedDomains.has(domain)) return Promise.resolve({allowed: true});
+
+      return Promise.resolve({
+        allowed: false,
+        message: config.AUTH_SIGNUP_NOT_ALLOWED_MESSAGE ?? DEFAULT_SIGNUP_NOT_ALLOWED_MESSAGE,
+      });
+    },
+  };
+}
+
+function parseAllowlist(value: string): ReadonlySet<string> {
+  return new Set(value.split(',').map(normalize).filter(Boolean));
+}
+
+function normalize(value: string): string {
+  return value.trim().toLowerCase();
+}

--- a/libs/api/auth/src/index.ts
+++ b/libs/api/auth/src/index.ts
@@ -47,6 +47,10 @@ export {
   verifyRunnerSessionToken,
 } from '#core/runner-session-token.js';
 export {
+  createEnvironmentSignupPolicy,
+  DEFAULT_SIGNUP_NOT_ALLOWED_MESSAGE,
+} from '#core/signup-policy.js';
+export {
   type AuthenticatedSessionContext,
   createJwtAuthMethod,
   getAuthenticatedSessionContext,


### PR DESCRIPTION
Add the default environment-backed signup policy for self-hosted API Auth deployments.

The Auth module now owns the module-prefixed `AUTH_SIGNUP_*` configuration, fail-fast validation for an enabled empty allowlist, normalized exact-email/domain matching, and the configurable/default denial message. The package README documents the setup contract and the changeset records the public package addition.

Validation completed:
- `mise exec -- turbo check --filter=@shipfox/api-auth`
- `mise exec -- turbo type --filter=@shipfox/api-auth`
- `mise exec -- turbo build --filter=@shipfox/api-auth...`
- Focused config and policy tests: 7 passed

The full Auth integration suite remains affected by the known local `api_test` email-challenge/rate-limit environment flake; the new policy tests and static/build checks pass.

Closes ENG-1250

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an environment-driven signup gate to `@shipfox/api-auth` so self-hosted deployments can allowlist emails or domains and show a custom denial message, with startup validation. Closes ENG-1250.

- **New Features**
  - Signup gating via env vars: enable gate, set allowed domains/emails, optional denial message; exact email and domain match with case/whitespace normalization.
  - Fail-fast startup if gating is enabled without any allowlist.
  - Exported `createEnvironmentSignupPolicy` and default denial message; README documents the setup.

- **Migration**
  - To enable gating: set AUTH_SIGNUP_GATE_ENABLED=true and provide AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS or AUTH_SIGNUP_ALLOWED_EMAILS; optionally set AUTH_SIGNUP_NOT_ALLOWED_MESSAGE.
  - No action needed if you want open signup (default).

<sup>Written for commit e12003acabe619ca095188bac8255aa7b41d63cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

