### PR TITLE
Add administration action outbox event contract

### DIFF
--- a/.changeset/fuzzy-admin-events.md
+++ b/.changeset/fuzzy-admin-events.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-common-dto": minor
+---
+
+Adds the checked, redacted administration-action outbox event contract and constructor.

--- a/libs/api/common-dto/src/administration-action.test.ts
+++ b/libs/api/common-dto/src/administration-action.test.ts
@@ -1,0 +1,86 @@
+import {
+  ADMINISTRATION_ACTION_PERFORMED,
+  type AdministrationActionEventMap,
+  administrationActionEventSchema,
+  administrationActionEventSchemas,
+  administrationActionResultSchema,
+  administrationRoleSchema,
+  createAdministrationActionEvent,
+  createAdministrationActionEventFixture,
+} from './administration-action.js';
+
+const eventInput = {
+  actorId: '9b11d65a-f7e7-40ea-b421-06af012a9be5',
+  actorRole: 'admin-operator' as const,
+  requiredRole: 'admin-operator' as const,
+  command: 'auth.user.suspend',
+  targetType: 'user',
+  targetId: 'c0a8012e-0b6d-4d8f-8d5c-6d74102602b0',
+  reason: 'Requested by the support operator',
+  result: 'succeeded' as const,
+  correlationId: 'request-123',
+  idempotencyKeyFingerprint: 'a'.repeat(64),
+  occurredAt: '2026-07-26T12:00:00.000Z',
+};
+
+describe('administrationActionEventSchema', () => {
+  it('constructs and round-trips a redacted administration action event', () => {
+    const event = createAdministrationActionEvent(eventInput);
+    const roundTripped = administrationActionEventSchema.parse(JSON.parse(JSON.stringify(event)));
+
+    expect(roundTripped).toEqual(eventInput);
+  });
+
+  it('provides deterministic safe data for producer contract tests', () => {
+    const event = createAdministrationActionEventFixture({result: 'failed'});
+
+    expect(event).toMatchObject({
+      command: 'auth.user.suspend',
+      result: 'failed',
+      idempotencyKeyFingerprint: 'a'.repeat(64),
+    });
+  });
+
+  it.each([
+    'token',
+    'secret',
+    'email',
+    'databaseError',
+  ])('rejects an uncontracted %s field', (field) => {
+    const result = administrationActionEventSchema.safeParse({...eventInput, [field]: 'value'});
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects raw idempotency keys and malformed identifiers', () => {
+    expect(
+      administrationActionEventSchema.safeParse({
+        ...eventInput,
+        idempotencyKeyFingerprint: 'raw-idempotency-key',
+      }).success,
+    ).toBe(false);
+    expect(
+      administrationActionEventSchema.safeParse({...eventInput, command: 'User Suspend'}).success,
+    ).toBe(false);
+    expect(
+      administrationActionEventSchema.safeParse({...eventInput, reason: 'line\nwith-break'})
+        .success,
+    ).toBe(false);
+  });
+
+  it('accepts only the fixed administrator roles and safe action results', () => {
+    for (const role of ['admin-observer', 'admin-operator', 'admin-owner']) {
+      expect(administrationRoleSchema.safeParse(role).success).toBe(true);
+    }
+    expect(administrationRoleSchema.safeParse('admin-custom').success).toBe(false);
+    expect(administrationActionResultSchema.safeParse('succeeded').success).toBe(true);
+    expect(administrationActionResultSchema.safeParse('failed').success).toBe(true);
+    expect(administrationActionResultSchema.safeParse('database-error').success).toBe(false);
+  });
+
+  it('exposes one schema for the shared outbox event map', () => {
+    expect(Object.keys(administrationActionEventSchemas)).toEqual([
+      ADMINISTRATION_ACTION_PERFORMED,
+    ] satisfies Array<keyof AdministrationActionEventMap>);
+  });
+});

--- a/libs/api/common-dto/src/administration-action.ts
+++ b/libs/api/common-dto/src/administration-action.ts
@@ -1,0 +1,100 @@
+import {z} from 'zod';
+
+const CONTROL_OR_FORMAT_CHARACTER_RE = /[\p{Cc}\p{Cf}]/u;
+const safeIdentifierSchema = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(/^[a-z0-9][a-z0-9._-]*$/u);
+
+const safeReasonSchema = z
+  .string()
+  .min(1)
+  .max(512)
+  .refine((value) => !CONTROL_OR_FORMAT_CHARACTER_RE.test(value), {
+    message: 'must not contain control or format characters',
+  });
+
+const idempotencyKeyFingerprintSchema = z.string().regex(/^[a-f0-9]{64}$/u);
+
+export const ADMINISTRATION_ACTION_PERFORMED = 'administration.action.performed' as const;
+
+export const ADMINISTRATION_ROLES = ['admin-observer', 'admin-operator', 'admin-owner'] as const;
+
+export const administrationRoleSchema = z.enum(ADMINISTRATION_ROLES);
+export type AdministrationRole = z.infer<typeof administrationRoleSchema>;
+
+export const administrationActionResultSchema = z.enum(['succeeded', 'failed']);
+export type AdministrationActionResult = z.infer<typeof administrationActionResultSchema>;
+
+/**
+ * The redacted event shared by source-available administration producers.
+ * Strict parsing keeps producer mistakes from adding secrets, raw tokens, or
+ * unbounded payloads to the event contract.
+ */
+export const administrationActionEventSchema = z
+  .object({
+    actorId: z.string().uuid(),
+    actorRole: administrationRoleSchema,
+    requiredRole: administrationRoleSchema,
+    command: safeIdentifierSchema,
+    targetType: safeIdentifierSchema,
+    targetId: z.string().min(1).max(255),
+    reason: safeReasonSchema,
+    result: administrationActionResultSchema,
+    correlationId: z.string().min(1).max(255),
+    idempotencyKeyFingerprint: idempotencyKeyFingerprintSchema,
+    occurredAt: z.string().datetime({offset: true}),
+  })
+  .strict();
+
+export type AdministrationActionEvent = z.infer<typeof administrationActionEventSchema>;
+
+export interface CreateAdministrationActionEventInput {
+  actorId: string;
+  actorRole: AdministrationRole;
+  requiredRole: AdministrationRole;
+  command: string;
+  targetType: string;
+  targetId: string;
+  reason: string;
+  result: AdministrationActionResult;
+  correlationId: string;
+  idempotencyKeyFingerprint: string;
+  occurredAt: string;
+}
+
+/** Validates an event before a producer writes it through its transaction. */
+export function createAdministrationActionEvent(
+  input: CreateAdministrationActionEventInput,
+): AdministrationActionEvent {
+  return administrationActionEventSchema.parse(input);
+}
+
+/** Creates deterministic safe data for producer contract and outbox tests. */
+export function createAdministrationActionEventFixture(
+  overrides: Partial<CreateAdministrationActionEventInput> = {},
+): AdministrationActionEvent {
+  return createAdministrationActionEvent({
+    actorId: '9b11d65a-f7e7-40ea-b421-06af012a9be5',
+    actorRole: 'admin-operator',
+    requiredRole: 'admin-operator',
+    command: 'auth.user.suspend',
+    targetType: 'user',
+    targetId: 'c0a8012e-0b6d-4d8f-8d5c-6d74102602b0',
+    reason: 'Requested by the support operator',
+    result: 'succeeded',
+    correlationId: 'request-123',
+    idempotencyKeyFingerprint: 'a'.repeat(64),
+    occurredAt: '2026-07-26T12:00:00.000Z',
+    ...overrides,
+  });
+}
+
+export interface AdministrationActionEventMap {
+  [ADMINISTRATION_ACTION_PERFORMED]: AdministrationActionEvent;
+}
+
+export const administrationActionEventSchemas = {
+  [ADMINISTRATION_ACTION_PERFORMED]: administrationActionEventSchema,
+} satisfies Record<keyof AdministrationActionEventMap, z.ZodType>;

--- a/libs/api/common-dto/src/index.ts
+++ b/libs/api/common-dto/src/index.ts
@@ -1,2 +1,17 @@
+export {
+  ADMINISTRATION_ACTION_PERFORMED,
+  ADMINISTRATION_ROLES,
+  type AdministrationActionEvent,
+  type AdministrationActionEventMap,
+  type AdministrationActionResult,
+  type AdministrationRole,
+  administrationActionEventSchema,
+  administrationActionEventSchemas,
+  administrationActionResultSchema,
+  administrationRoleSchema,
+  type CreateAdministrationActionEventInput,
+  createAdministrationActionEvent,
+  createAdministrationActionEventFixture,
+} from './administration-action.js';
 export {displayNameSchema} from './schemas/display-name.js';
 export {emailSchema} from './schemas/email.js';


### PR DESCRIPTION
## Summary

- add the strict, redacted `administration.action.performed` outbox event contract
- validate fixed administrator roles, safe results, correlation metadata, and SHA-256 idempotency fingerprints
- add deterministic producer-test fixtures and contract coverage
- add the required `@shipfox/api-common-dto` minor changeset

## Validation

- `mise exec -- turbo check type test depcruise --filter=@shipfox/api-common-dto...`
- `mise exec -- pnpm check:published-artifacts`
- `mise exec -- pnpm check:api-context-inventory`
- `mise exec -- git diff --check`

Closes ENG-1268

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a strict, redacted `administration.action.performed` outbox event contract so modules can publish and validate admin actions via their own outbox. Meets ENG-1268 by enforcing fixed roles/results and SHA‑256 idempotency fingerprints while avoiding secrets and shared audit tables.

- **New Features**
  - Defines a checked event schema with fields: actor, requiredRole, command, target (type/id), reason, result, correlationId, SHA‑256 `idempotencyKeyFingerprint`, occurredAt; rejects extra fields and control/format chars.
  - Adds `createAdministrationActionEvent` and `createAdministrationActionEventFixture` for deterministic producer tests, plus schema coverage and a shared outbox event map.
  - Exposes event, types, and schemas from `@shipfox/api-common-dto`.

- **Dependencies**
  - Adds a minor changeset for `@shipfox/api-common-dto`.

<sup>Written for commit 194ca14bc815cf128027e241010a7a3fec6f470f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

