### PR TITLE
Add Auth-owned local administrator grants and role evaluation

### DIFF
--- a/.changeset/local-admin-roles.md
+++ b/.changeset/local-admin-roles.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/api-auth": minor
+"@shipfox/api-auth-dto": minor
+"@shipfox/client-shell": minor
+---
+
+Add Auth-owned local administrator grants and server-side role evaluation.

--- a/libs/api/auth-dto/src/inter-module.ts
+++ b/libs/api/auth-dto/src/inter-module.ts
@@ -1,5 +1,6 @@
 import {defineInterModuleContract, type InterModuleClient} from '@shipfox/inter-module';
 import {z} from 'zod';
+import {adminRoleSchema} from './schemas/admin.js';
 import {jobLeaseTokenClaimsSchema} from './schemas/job-lease-token.js';
 import {runnerSessionTokenClaimsSchema} from './schemas/runner-session-token.js';
 
@@ -20,6 +21,20 @@ export const authInterModuleContract = defineInterModuleContract({
     mintJobLeaseToken: {
       input: jobLeaseClaimsSchema,
       output: z.object({token: z.string().min(1)}),
+    },
+    getCurrentAdminRole: {
+      input: z.object({userId: z.string().uuid()}),
+      output: z.object({role: adminRoleSchema.nullable()}),
+    },
+    requireAdminRole: {
+      input: z.object({
+        userId: z.string().uuid(),
+        minimumRole: adminRoleSchema,
+      }),
+      output: z.object({role: adminRoleSchema}),
+      errors: {
+        'admin-role-required': z.object({requiredRole: adminRoleSchema}),
+      },
     },
   },
 });

--- a/libs/api/auth-dto/src/schemas/admin.ts
+++ b/libs/api/auth-dto/src/schemas/admin.ts
@@ -1,0 +1,5 @@
+import {z} from 'zod';
+
+export const adminRoleSchema = z.enum(['admin-observer', 'admin-operator', 'admin-owner']);
+
+export type AdminRole = z.infer<typeof adminRoleSchema>;

--- a/libs/api/auth-dto/src/schemas/auth.ts
+++ b/libs/api/auth-dto/src/schemas/auth.ts
@@ -1,5 +1,6 @@
 import {displayNameSchema, emailSchema} from '@shipfox/api-common-dto';
 import {z} from 'zod';
+import {adminRoleSchema} from './admin.js';
 import {userDtoSchema} from './user.js';
 
 export const passwordSchema = z.string().min(12).max(128);
@@ -66,6 +67,7 @@ export type LoginBodyDto = z.infer<typeof loginBodySchema>;
 export const loginResponseSchema = z.object({
   token: z.string(),
   user: userDtoSchema,
+  admin_role: adminRoleSchema.nullable().optional(),
 });
 
 export type LoginResponseDto = z.infer<typeof loginResponseSchema>;
@@ -76,6 +78,7 @@ export type RefreshResponseDto = z.infer<typeof refreshResponseSchema>;
 
 export const meResponseSchema = z.object({
   user: userDtoSchema,
+  admin_role: adminRoleSchema.nullable().optional(),
 });
 
 export type MeResponseDto = z.infer<typeof meResponseSchema>;

--- a/libs/api/auth-dto/src/schemas/index.ts
+++ b/libs/api/auth-dto/src/schemas/index.ts
@@ -8,6 +8,7 @@ export {
   authPasswordResetSendRequestedSchema,
   authUserSignedUpSchema,
 } from '../events.js';
+export {type AdminRole, adminRoleSchema} from './admin.js';
 export {
   type ChangePasswordBodyDto,
   changePasswordBodySchema,

--- a/libs/api/auth/drizzle/0001_brainy_shriek.sql
+++ b/libs/api/auth/drizzle/0001_brainy_shriek.sql
@@ -1,0 +1,14 @@
+CREATE TYPE "public"."auth_admin_role" AS ENUM('admin-observer', 'admin-operator', 'admin-owner');--> statement-breakpoint
+CREATE TABLE "auth_admin_grants" (
+	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"role" "auth_admin_role" NOT NULL,
+	"revoked_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "auth_admin_grants" ADD CONSTRAINT "auth_admin_grants_user_id_auth_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."auth_users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "auth_admin_grants_user_id_idx" ON "auth_admin_grants" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "auth_admin_grants_active_owners_idx" ON "auth_admin_grants" USING btree ("user_id") WHERE "auth_admin_grants"."role" = 'admin-owner' AND "auth_admin_grants"."revoked_at" IS NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "auth_admin_grants_active_user_role_unique" ON "auth_admin_grants" USING btree ("user_id","role") WHERE "auth_admin_grants"."revoked_at" IS NULL;--> statement-breakpoint

--- a/libs/api/auth/drizzle/meta/0001_snapshot.json
+++ b/libs/api/auth/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,702 @@
+{
+  "id": "39a76407-aeea-4575-96ce-61da4c8d77a8",
+  "prevId": "1ad0c574-e371-4c99-8d43-72c2c11e9bc3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_admin_grants": {
+      "name": "auth_admin_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "auth_admin_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_admin_grants_user_id_idx": {
+          "name": "auth_admin_grants_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_admin_grants_active_owners_idx": {
+          "name": "auth_admin_grants_active_owners_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"auth_admin_grants\".\"role\" = 'admin-owner' AND \"auth_admin_grants\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_admin_grants_active_user_role_unique": {
+          "name": "auth_admin_grants_active_user_role_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"auth_admin_grants\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_admin_grants_user_id_auth_users_id_fk": {
+          "name": "auth_admin_grants_user_id_auth_users_id_fk",
+          "tableFrom": "auth_admin_grants",
+          "tableTo": "auth_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_outbox": {
+      "name": "auth_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordering_key": {
+          "name": "ordering_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_attempts": {
+          "name": "dispatch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_dispatch_at": {
+          "name": "next_dispatch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_dispatch_error": {
+          "name": "last_dispatch_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_dispatch_failed_at": {
+          "name": "last_dispatch_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dead_lettered_at": {
+          "name": "dead_lettered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_outbox_pending_idx": {
+          "name": "auth_outbox_pending_idx",
+          "columns": [
+            {
+              "expression": "next_dispatch_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NULL AND \"dead_lettered_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_outbox_dispatched_retention_idx": {
+          "name": "auth_outbox_dispatched_retention_idx",
+          "columns": [
+            {
+              "expression": "dispatched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_password_resets": {
+      "name": "auth_password_resets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_password_resets_hashed_token_unique": {
+          "name": "auth_password_resets_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_password_resets_user_id_idx": {
+          "name": "auth_password_resets_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_password_resets_user_id_auth_users_id_fk": {
+          "name": "auth_password_resets_user_id_auth_users_id_fk",
+          "tableFrom": "auth_password_resets",
+          "tableTo": "auth_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_rate_limits": {
+      "name": "auth_rate_limits",
+      "schema": "",
+      "columns": {
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier_hmac": {
+          "name": "identifier_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_rate_limits_window_unique": {
+          "name": "auth_rate_limits_window_unique",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identifier_hmac",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "window_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_rate_limits_expires_at_idx": {
+          "name": "auth_rate_limits_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_refresh_tokens": {
+      "name": "auth_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_refresh_tokens_hashed_token_unique": {
+          "name": "auth_refresh_tokens_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_refresh_tokens_active_session_unique": {
+          "name": "auth_refresh_tokens_active_session_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"auth_refresh_tokens\".\"revoked_at\" IS NULL AND \"auth_refresh_tokens\".\"rotated_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_refresh_tokens_user_id_idx": {
+          "name": "auth_refresh_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_refresh_tokens_user_id_auth_users_id_fk": {
+          "name": "auth_refresh_tokens_user_id_auth_users_id_fk",
+          "tableFrom": "auth_refresh_tokens",
+          "tableTo": "auth_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_users": {
+      "name": "auth_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_password": {
+          "name": "hashed_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "auth_user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_users_email_unique": {
+          "name": "auth_users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.auth_admin_role": {
+      "name": "auth_admin_role",
+      "schema": "public",
+      "values": ["admin-observer", "admin-operator", "admin-owner"]
+    },
+    "public.auth_user_status": {
+      "name": "auth_user_status",
+      "schema": "public",
+      "values": ["active", "suspended", "deleted"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/api/auth/drizzle/meta/_journal.json
+++ b/libs/api/auth/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1784102113104,
       "tag": "0000_initial",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1785065259979,
+      "tag": "0001_brainy_shriek",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/api/auth/src/core/admin-role-model.ts
+++ b/libs/api/auth/src/core/admin-role-model.ts
@@ -1,0 +1,25 @@
+import type {AdminRole} from '@shipfox/api-auth-dto';
+
+export const ADMIN_ROLES: readonly AdminRole[] = [
+  'admin-observer',
+  'admin-operator',
+  'admin-owner',
+];
+
+const ADMIN_ROLE_RANK: Record<AdminRole, number> = {
+  'admin-observer': 1,
+  'admin-operator': 2,
+  'admin-owner': 3,
+};
+
+export function hasMinimumAdminRole(role: AdminRole, minimumRole: AdminRole): boolean {
+  return ADMIN_ROLE_RANK[role] >= ADMIN_ROLE_RANK[minimumRole];
+}
+
+export function highestAdminRole(roles: readonly AdminRole[]): AdminRole | null {
+  return roles.reduce<AdminRole | null>(
+    (highest, role) =>
+      highest === null || ADMIN_ROLE_RANK[role] > ADMIN_ROLE_RANK[highest] ? role : highest,
+    null,
+  );
+}

--- a/libs/api/auth/src/core/admin-role.test.ts
+++ b/libs/api/auth/src/core/admin-role.test.ts
@@ -1,0 +1,39 @@
+import {createAdminGrant} from '#db/admin-grants.js';
+import {userFactory} from '#test/index.js';
+import {hasMinimumAdminRole, highestAdminRole, requireAdminRole} from './admin-role.js';
+import type {AdminRoleRequiredError} from './errors.js';
+
+describe('admin role policy', () => {
+  test.each([
+    ['admin-observer', 'admin-observer', true],
+    ['admin-observer', 'admin-operator', false],
+    ['admin-operator', 'admin-observer', true],
+    ['admin-operator', 'admin-owner', false],
+    ['admin-owner', 'admin-observer', true],
+    ['admin-owner', 'admin-operator', true],
+    ['admin-owner', 'admin-owner', true],
+  ] as const)('%s satisfies %s: %s', (role, minimumRole, expected) => {
+    expect(hasMinimumAdminRole(role, minimumRole)).toBe(expected);
+  });
+
+  test('selects the highest role from fixed grants', () => {
+    expect(highestAdminRole(['admin-observer', 'admin-owner', 'admin-operator'])).toBe(
+      'admin-owner',
+    );
+    expect(highestAdminRole([])).toBeNull();
+  });
+
+  test('evaluates the current role from Auth storage for every required minimum', async () => {
+    const user = await userFactory.create({emailVerifiedAt: new Date()});
+    await createAdminGrant({userId: user.id, role: 'admin-operator'});
+
+    await expect(requireAdminRole({userId: user.id, minimumRole: 'admin-observer'})).resolves.toBe(
+      'admin-operator',
+    );
+    await expect(requireAdminRole({userId: user.id, minimumRole: 'admin-owner'})).rejects.toEqual(
+      expect.objectContaining<Partial<AdminRoleRequiredError>>({
+        minimumRole: 'admin-owner',
+      }),
+    );
+  });
+});

--- a/libs/api/auth/src/core/admin-role.ts
+++ b/libs/api/auth/src/core/admin-role.ts
@@ -1,0 +1,25 @@
+import type {AdminRole} from '@shipfox/api-auth-dto';
+import {findCurrentAdminRole, revokeAdminGrant as revokeAdminGrantInDb} from '#db/admin-grants.js';
+import {hasMinimumAdminRole} from './admin-role-model.js';
+import {AdminRoleRequiredError} from './errors.js';
+
+export {ADMIN_ROLES, hasMinimumAdminRole, highestAdminRole} from './admin-role-model.js';
+
+export async function getCurrentAdminRole(params: {userId: string}): Promise<AdminRole | null> {
+  return await findCurrentAdminRole(params);
+}
+
+export async function requireAdminRole(params: {
+  userId: string;
+  minimumRole: AdminRole;
+}): Promise<AdminRole> {
+  const role = await getCurrentAdminRole({userId: params.userId});
+  if (!role || !hasMinimumAdminRole(role, params.minimumRole)) {
+    throw new AdminRoleRequiredError(params.minimumRole);
+  }
+  return role;
+}
+
+export async function revokeAdminGrant(params: {grantId: string}) {
+  return await revokeAdminGrantInDb(params);
+}

--- a/libs/api/auth/src/core/auth.ts
+++ b/libs/api/auth/src/core/auth.ts
@@ -1,4 +1,4 @@
-import {emailSchema} from '@shipfox/api-auth-dto';
+import {type AdminRole, emailSchema} from '@shipfox/api-auth-dto';
 import {
   confirmEmailChallenge,
   consumeEmailChallengeProof,
@@ -31,6 +31,7 @@ import {
   updateUserPassword,
 } from '#db/users.js';
 import {type AuthTokenRefreshOutcome, recordTokenRefreshed} from '#metrics/index.js';
+import {getCurrentAdminRole} from './admin-role.js';
 import type {RefreshToken} from './entities/refresh-token.js';
 import type {User} from './entities/user.js';
 import {
@@ -139,11 +140,12 @@ async function createRefreshSession(
 async function createSessionTokens(
   user: User,
   workspaces: WorkspacesInterModuleClient,
-): Promise<{token: string; refreshToken: string}> {
+): Promise<{token: string; refreshToken: string; adminRole: AdminRole | null}> {
   const refreshSessionId = crypto.randomUUID();
   const token = await signAccessToken(user, workspaces, refreshSessionId);
+  const adminRole = await getCurrentAdminRole({userId: user.id});
   const {refreshToken} = await createRefreshSession(user, refreshSessionId);
-  return {token, refreshToken};
+  return {token, refreshToken, adminRole};
 }
 
 function passwordResetLink(rawToken: string): string {
@@ -335,12 +337,12 @@ export async function signupWithInvitation(
 
   // Step 4: Issue session. signAccessToken reads memberships through the
   // workspaces module API, so a successful accept is reflected in the JWT.
-  const {token, refreshToken} = await createSessionTokens(user, params.workspaces);
+  const {token, refreshToken, adminRole} = await createSessionTokens(user, params.workspaces);
 
   if (acceptError) {
-    return {token, refreshToken, user, membership, acceptError};
+    return {token, refreshToken, user, membership, acceptError, adminRole};
   }
-  return {token, refreshToken, user, membership};
+  return {token, refreshToken, user, membership, adminRole};
 }
 
 export interface CreateUserParams extends SignupParams {
@@ -374,6 +376,7 @@ export interface LoginResult {
   token: string;
   refreshToken: string;
   user: User;
+  adminRole: AdminRole | null;
 }
 
 export async function login(params: LoginParams): Promise<LoginResult> {
@@ -397,9 +400,9 @@ export async function login(params: LoginParams): Promise<LoginResult> {
     throw new EmailNotVerifiedError();
   }
 
-  const {token, refreshToken} = await createSessionTokens(user, params.workspaces);
+  const {token, refreshToken, adminRole} = await createSessionTokens(user, params.workspaces);
 
-  return {token, refreshToken, user};
+  return {token, refreshToken, user, adminRole};
 }
 
 export interface CreateSessionForUserParams {
@@ -412,6 +415,7 @@ export interface CreateSessionForUserResult {
   token: string;
   refreshToken: string;
   user: User;
+  adminRole: AdminRole | null;
 }
 
 export type CreateSessionForUserError =
@@ -439,9 +443,9 @@ export async function createSessionForUser(
     throw new InvalidCredentialsError();
   }
 
-  const {token, refreshToken} = await createSessionTokens(user, params.workspaces);
+  const {token, refreshToken, adminRole} = await createSessionTokens(user, params.workspaces);
 
-  return {token, refreshToken, user};
+  return {token, refreshToken, user, adminRole};
 }
 
 export interface RefreshAccessTokenResult {
@@ -449,6 +453,7 @@ export interface RefreshAccessTokenResult {
   /** Undefined on a grace-window hit: keep the existing cookie instead of rotating it. */
   refreshToken: string | undefined;
   user: User;
+  adminRole: AdminRole | null;
 }
 
 export async function refreshAccessToken(params: {
@@ -468,6 +473,7 @@ export async function refreshAccessToken(params: {
     recordRefreshOutcome('rejected');
     throw new TokenInvalidError('Refresh token is invalid or expired');
   }
+  const adminRole = await getCurrentAdminRole({userId: user.id});
 
   // Within the grace window a rotated token means a concurrent refresh (e.g. a
   // second tab); past it, reuse of a retired token means a compromised session.
@@ -475,7 +481,7 @@ export async function refreshAccessToken(params: {
     if (isWithinRotationGrace(current)) {
       const token = await signAccessToken(user, params.workspaces, current.sessionId);
       recordRefreshOutcome('grace');
-      return {token, refreshToken: undefined, user};
+      return {token, refreshToken: undefined, user, adminRole};
     }
     await revokeRefreshTokensForUser({userId: user.id});
     recordRefreshOutcome('rejected');
@@ -499,18 +505,19 @@ export async function refreshAccessToken(params: {
     }
     const token = await signAccessToken(user, params.workspaces, latest.sessionId);
     recordRefreshOutcome('grace');
-    return {token, refreshToken: undefined, user};
+    return {token, refreshToken: undefined, user, adminRole};
   }
 
   const token = await signAccessToken(user, params.workspaces, current.sessionId);
   recordRefreshOutcome('rotated');
-  return {token, refreshToken: nextRefreshToken, user};
+  return {token, refreshToken: nextRefreshToken, user, adminRole};
 }
 
 export interface ConfirmEmailVerificationResult {
   token: string;
   refreshToken: string;
   user: User;
+  adminRole: AdminRole | null;
 }
 
 export interface ResendEmailVerificationResult {
@@ -537,9 +544,12 @@ export async function confirmEmailVerification(params: {
     throw new TokenInvalidError('Verification code is invalid or expired');
   }
 
-  const {token, refreshToken} = await createSessionTokens(verifiedUser, params.workspaces);
+  const {token, refreshToken, adminRole} = await createSessionTokens(
+    verifiedUser,
+    params.workspaces,
+  );
 
-  return {token, refreshToken, user: verifiedUser};
+  return {token, refreshToken, user: verifiedUser, adminRole};
 }
 
 export async function resendEmailVerification(params: {
@@ -583,6 +593,7 @@ export interface ConfirmPasswordResetResult {
   token: string;
   refreshToken: string;
   user: User;
+  adminRole: AdminRole | null;
 }
 
 export async function confirmPasswordReset(params: {
@@ -608,9 +619,9 @@ export async function confirmPasswordReset(params: {
 
   await revokeRefreshTokensForUser({userId: consumed.userId});
 
-  const {token, refreshToken} = await createSessionTokens(user, params.workspaces);
+  const {token, refreshToken, adminRole} = await createSessionTokens(user, params.workspaces);
 
-  return {token, refreshToken, user};
+  return {token, refreshToken, user, adminRole};
 }
 
 export async function changePassword(params: {

--- a/libs/api/auth/src/core/entities/admin-grant.ts
+++ b/libs/api/auth/src/core/entities/admin-grant.ts
@@ -1,0 +1,10 @@
+import type {AdminRole} from '@shipfox/api-auth-dto';
+
+export interface AdminGrant {
+  id: string;
+  userId: string;
+  role: AdminRole;
+  revokedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/libs/api/auth/src/core/errors.ts
+++ b/libs/api/auth/src/core/errors.ts
@@ -80,6 +80,23 @@ export class AuthDependencyUnavailableError extends Error {
   }
 }
 
+export class AdminRoleRequiredError extends Error {
+  readonly minimumRole: import('@shipfox/api-auth-dto').AdminRole;
+
+  constructor(minimumRole: import('@shipfox/api-auth-dto').AdminRole) {
+    super(`Administrator role required: ${minimumRole}`);
+    this.name = 'AdminRoleRequiredError';
+    this.minimumRole = minimumRole;
+  }
+}
+
+export class LastAdminOwnerError extends Error {
+  constructor() {
+    super('Cannot remove the final active administrator owner');
+    this.name = 'LastAdminOwnerError';
+  }
+}
+
 export class TokenInvalidError extends Error {
   constructor(reason?: string) {
     super(reason ? `Invalid token: ${reason}` : 'Invalid token');

--- a/libs/api/auth/src/core/jwt.test.ts
+++ b/libs/api/auth/src/core/jwt.test.ts
@@ -30,6 +30,7 @@ describe('jwt', () => {
     expect(claims.email).toBe(email);
     expect(claims.name).toBe('Token User');
     expect(claims.memberships).toEqual(memberships);
+    expect(claims).not.toHaveProperty('adminRole');
     expect(claims.iat).toBeTypeOf('number');
     expect(claims.exp).toBeGreaterThan(claims.iat);
   });

--- a/libs/api/auth/src/db/admin-grants.test.ts
+++ b/libs/api/auth/src/db/admin-grants.test.ts
@@ -1,0 +1,57 @@
+import {eq} from 'drizzle-orm';
+import {LastAdminOwnerError} from '#core/errors.js';
+import {userFactory} from '#test/index.js';
+import {
+  createAdminGrant,
+  findCurrentAdminRole,
+  listAdminGrants,
+  revokeAdminGrant,
+} from './admin-grants.js';
+import {db} from './db.js';
+import {users} from './schema/users.js';
+
+describe('admin grants db', () => {
+  test('evaluates the highest active grant independently of workspace roles', async () => {
+    const user = await userFactory.create({emailVerifiedAt: new Date()});
+    const observer = await createAdminGrant({userId: user.id, role: 'admin-observer'});
+    await createAdminGrant({userId: user.id, role: 'admin-operator'});
+
+    expect(observer.userId).toBe(user.id);
+    expect(await findCurrentAdminRole({userId: user.id})).toBe('admin-operator');
+    expect((await listAdminGrants()).filter((grant) => grant.userId === user.id)).toHaveLength(2);
+  });
+
+  test('does not evaluate revoked grants or grants for suspended users', async () => {
+    const user = await userFactory.create({emailVerifiedAt: new Date()});
+    const grant = await createAdminGrant({userId: user.id, role: 'admin-owner'});
+
+    await expect(revokeAdminGrant({grantId: grant.id})).rejects.toBeInstanceOf(LastAdminOwnerError);
+    expect(await findCurrentAdminRole({userId: user.id})).toBe('admin-owner');
+
+    await db().update(users).set({status: 'suspended'}).where(eq(users.id, user.id));
+    expect(await findCurrentAdminRole({userId: user.id})).toBeNull();
+  });
+
+  test('prevents revoking the final active owner but permits replacement first', async () => {
+    const firstOwner = await userFactory.create({emailVerifiedAt: new Date()});
+    const secondOwner = await userFactory.create({emailVerifiedAt: new Date()});
+    const firstGrant = await createAdminGrant({userId: firstOwner.id, role: 'admin-owner'});
+    const secondGrant = await createAdminGrant({userId: secondOwner.id, role: 'admin-owner'});
+
+    await expect(revokeAdminGrant({grantId: firstGrant.id})).resolves.toMatchObject({
+      id: firstGrant.id,
+      revokedAt: expect.any(Date),
+    });
+    await expect(revokeAdminGrant({grantId: secondGrant.id})).rejects.toBeInstanceOf(
+      LastAdminOwnerError,
+    );
+    expect(await findCurrentAdminRole({userId: secondOwner.id})).toBe('admin-owner');
+  });
+
+  test('enforces one active grant of each fixed role per user', async () => {
+    const user = await userFactory.create({emailVerifiedAt: new Date()});
+    await createAdminGrant({userId: user.id, role: 'admin-observer'});
+
+    await expect(createAdminGrant({userId: user.id, role: 'admin-observer'})).rejects.toThrow();
+  });
+});

--- a/libs/api/auth/src/db/admin-grants.ts
+++ b/libs/api/auth/src/db/admin-grants.ts
@@ -1,0 +1,83 @@
+import type {AdminRole} from '@shipfox/api-auth-dto';
+import {and, asc, eq, isNull, sql} from 'drizzle-orm';
+import {highestAdminRole} from '#core/admin-role-model.js';
+import type {AdminGrant} from '#core/entities/admin-grant.js';
+import {LastAdminOwnerError} from '#core/errors.js';
+import {db} from './db.js';
+import {adminGrants, toAdminGrant} from './schema/admin-grants.js';
+import {users} from './schema/users.js';
+
+export interface CreateAdminGrantParams {
+  userId: string;
+  role: AdminRole;
+}
+
+export async function createAdminGrant(params: CreateAdminGrantParams): Promise<AdminGrant> {
+  const rows = await db()
+    .insert(adminGrants)
+    .values({userId: params.userId, role: params.role})
+    .returning();
+  const row = rows[0];
+  if (!row) throw new Error('Insert returned no rows');
+  return toAdminGrant(row);
+}
+
+export async function listAdminGrants(): Promise<AdminGrant[]> {
+  const rows = await db().select().from(adminGrants).orderBy(asc(adminGrants.createdAt));
+  return rows.map(toAdminGrant);
+}
+
+export async function findCurrentAdminRole(params: {userId: string}): Promise<AdminRole | null> {
+  const rows = await db()
+    .select({role: adminGrants.role})
+    .from(adminGrants)
+    .innerJoin(users, eq(adminGrants.userId, users.id))
+    .where(
+      and(
+        eq(adminGrants.userId, params.userId),
+        isNull(adminGrants.revokedAt),
+        eq(users.status, 'active'),
+      ),
+    );
+
+  return highestAdminRole(rows.map(({role}) => role));
+}
+
+export async function revokeAdminGrant(params: {grantId: string}): Promise<AdminGrant | undefined> {
+  return await db().transaction(async (tx) => {
+    // All owner grant changes share one lock so concurrent revocations cannot
+    // both observe the same final owner and leave the instance ownerless.
+    await tx.execute(sql`select pg_advisory_xact_lock(hashtext('auth_admin_owner_grants'))`);
+
+    const rows = await tx
+      .select()
+      .from(adminGrants)
+      .where(and(eq(adminGrants.id, params.grantId), isNull(adminGrants.revokedAt)))
+      .limit(1);
+    const grant = rows[0];
+    if (!grant) return undefined;
+
+    if (grant.role === 'admin-owner') {
+      const activeOwners = await tx
+        .select({id: adminGrants.id})
+        .from(adminGrants)
+        .innerJoin(users, eq(adminGrants.userId, users.id))
+        .where(
+          and(
+            eq(adminGrants.role, 'admin-owner'),
+            isNull(adminGrants.revokedAt),
+            eq(users.status, 'active'),
+          ),
+        );
+      if (activeOwners.length <= 1) throw new LastAdminOwnerError();
+    }
+
+    const updated = await tx
+      .update(adminGrants)
+      .set({revokedAt: new Date(), updatedAt: new Date()})
+      .where(and(eq(adminGrants.id, grant.id), isNull(adminGrants.revokedAt)))
+      .returning();
+    const row = updated[0];
+    return row ? toAdminGrant(row) : undefined;
+  });
+}

--- a/libs/api/auth/src/db/db.ts
+++ b/libs/api/auth/src/db/db.ts
@@ -1,5 +1,6 @@
 import {drizzle, type NodePgDatabase} from '@shipfox/node-drizzle';
 import {pgClient} from '@shipfox/node-postgres';
+import {adminGrants} from './schema/admin-grants.js';
 import {authOutbox} from './schema/outbox.js';
 import {passwordResets} from './schema/password-resets.js';
 import {authRateLimits} from './schema/rate-limits.js';
@@ -7,6 +8,7 @@ import {refreshTokens} from './schema/refresh-tokens.js';
 import {users} from './schema/users.js';
 
 export const schema = {
+  adminGrants,
   users,
   passwordResets,
   refreshTokens,

--- a/libs/api/auth/src/db/schema/admin-grants.ts
+++ b/libs/api/auth/src/db/schema/admin-grants.ts
@@ -1,0 +1,49 @@
+import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
+import {sql} from 'drizzle-orm';
+import {index, pgEnum, timestamp, uniqueIndex, uuid} from 'drizzle-orm/pg-core';
+import type {AdminGrant} from '#core/entities/admin-grant.js';
+import {pgTable} from './common.js';
+import {users} from './users.js';
+
+export const adminRoleEnum = pgEnum('auth_admin_role', [
+  'admin-observer',
+  'admin-operator',
+  'admin-owner',
+]);
+
+export const adminGrants = pgTable(
+  'admin_grants',
+  {
+    id: uuidv7PrimaryKey(),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, {onDelete: 'cascade'}),
+    role: adminRoleEnum('role').notNull(),
+    revokedAt: timestamp('revoked_at', {withTimezone: true}),
+    createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', {withTimezone: true}).notNull().defaultNow(),
+  },
+  (table) => [
+    index('auth_admin_grants_user_id_idx').on(table.userId),
+    index('auth_admin_grants_active_owners_idx')
+      .on(table.userId)
+      .where(sql`${table.role} = 'admin-owner' AND ${table.revokedAt} IS NULL`),
+    uniqueIndex('auth_admin_grants_active_user_role_unique')
+      .on(table.userId, table.role)
+      .where(sql`${table.revokedAt} IS NULL`),
+  ],
+);
+
+export type AdminGrantDb = typeof adminGrants.$inferSelect;
+export type AdminGrantCreateDb = typeof adminGrants.$inferInsert;
+
+export function toAdminGrant(row: AdminGrantDb): AdminGrant {
+  return {
+    id: row.id,
+    userId: row.userId,
+    role: row.role,
+    revokedAt: row.revokedAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}

--- a/libs/api/auth/src/index.ts
+++ b/libs/api/auth/src/index.ts
@@ -19,7 +19,15 @@ import {buildAuthRoutes} from '#presentation/routes/index.js';
 import {onPasswordResetSendRequested} from '#presentation/subscribers/index.js';
 import {passwordLoginMethods} from './login-methods.js';
 
-export type {JobLeaseTokenClaims, RunnerSessionTokenClaims} from '@shipfox/api-auth-dto';
+export type {AdminRole, JobLeaseTokenClaims, RunnerSessionTokenClaims} from '@shipfox/api-auth-dto';
+export {
+  ADMIN_ROLES,
+  getCurrentAdminRole,
+  hasMinimumAdminRole,
+  highestAdminRole,
+  requireAdminRole,
+  revokeAdminGrant,
+} from '#core/admin-role.js';
 export type {
   CreateSessionForUserError,
   CreateSessionForUserParams,
@@ -29,11 +37,14 @@ export type {
 export {createSessionForUser, provisionUser} from '#core/auth.js';
 export type {EmailOwner, FindUserByEmailParams} from '#core/email-owner.js';
 export {findUserByEmail} from '#core/email-owner.js';
+export type {AdminGrant} from '#core/entities/admin-grant.js';
 export type {User, UserStatus} from '#core/entities/user.js';
 export {
+  AdminRoleRequiredError,
   AuthDependencyUnavailableError,
   EmailNotVerifiedError,
   InvalidCredentialsError,
+  LastAdminOwnerError,
   SignupNotAllowedError,
   UserNotFoundError,
 } from '#core/errors.js';

--- a/libs/api/auth/src/presentation/dto/user.ts
+++ b/libs/api/auth/src/presentation/dto/user.ts
@@ -1,4 +1,4 @@
-import type {LoginResponseDto, UserDto} from '@shipfox/api-auth-dto';
+import type {AdminRole, LoginResponseDto, UserDto} from '@shipfox/api-auth-dto';
 import type {User} from '#core/entities/user.js';
 
 export function toUserDto(user: User): UserDto {
@@ -13,9 +13,14 @@ export function toUserDto(user: User): UserDto {
   };
 }
 
-export function toAuthSessionDto(result: {token: string; user: User}): LoginResponseDto {
+export function toAuthSessionDto(result: {
+  token: string;
+  user: User;
+  adminRole?: AdminRole | null;
+}): LoginResponseDto {
   return {
     token: result.token,
     user: toUserDto(result.user),
+    admin_role: result.adminRole ?? null,
   };
 }

--- a/libs/api/auth/src/presentation/inter-module.test.ts
+++ b/libs/api/auth/src/presentation/inter-module.test.ts
@@ -1,0 +1,47 @@
+import {authInterModuleContract} from '@shipfox/api-auth-dto/inter-module';
+import {isInterModuleKnownError} from '@shipfox/inter-module';
+import {createInMemoryInterModuleTransport} from '@shipfox/node-module/inter-module';
+import {createAdminGrant} from '#db/admin-grants.js';
+import {userFactory} from '#test/index.js';
+import {createAuthInterModulePresentation} from './inter-module.js';
+
+function createClient() {
+  const transport = createInMemoryInterModuleTransport();
+  const client = transport.createClient(authInterModuleContract);
+  transport.register(createAuthInterModulePresentation());
+  transport.seal();
+  return client;
+}
+
+describe('Auth inter-module administration role presentation', () => {
+  test('returns the current role from Auth storage', async () => {
+    const client = createClient();
+    const user = await userFactory.create({emailVerifiedAt: new Date()});
+    await createAdminGrant({userId: user.id, role: 'admin-owner'});
+
+    await expect(client.getCurrentAdminRole({userId: user.id})).resolves.toEqual({
+      role: 'admin-owner',
+    });
+    await expect(
+      client.requireAdminRole({userId: user.id, minimumRole: 'admin-operator'}),
+    ).resolves.toEqual({role: 'admin-owner'});
+  });
+
+  test('maps an insufficient current role to the declared known error', async () => {
+    const client = createClient();
+    const user = await userFactory.create({emailVerifiedAt: new Date()});
+    await createAdminGrant({userId: user.id, role: 'admin-observer'});
+
+    const error = await client
+      .requireAdminRole({userId: user.id, minimumRole: 'admin-owner'})
+      .catch((caught: unknown) => caught);
+
+    expect(isInterModuleKnownError(authInterModuleContract.methods.requireAdminRole, error)).toBe(
+      true,
+    );
+    if (isInterModuleKnownError(authInterModuleContract.methods.requireAdminRole, error)) {
+      expect(error.code).toBe('admin-role-required');
+      expect(error.details).toEqual({requiredRole: 'admin-owner'});
+    }
+  });
+});

--- a/libs/api/auth/src/presentation/inter-module.ts
+++ b/libs/api/auth/src/presentation/inter-module.ts
@@ -1,5 +1,11 @@
 import {authInterModuleContract} from '@shipfox/api-auth-dto/inter-module';
-import {defineInterModulePresentation, type InterModulePresentation} from '@shipfox/inter-module';
+import {
+  createInterModuleKnownError,
+  defineInterModulePresentation,
+  type InterModulePresentation,
+} from '@shipfox/inter-module';
+import {getCurrentAdminRole, requireAdminRole} from '#core/admin-role.js';
+import {AdminRoleRequiredError} from '#core/errors.js';
 import {issueJobLeaseToken} from '#core/job-lease-token.js';
 import {issueRunnerSessionToken} from '#core/runner-session-token.js';
 
@@ -9,5 +15,20 @@ export function createAuthInterModulePresentation(): InterModulePresentation<
   return defineInterModulePresentation(authInterModuleContract, {
     mintRunnerSessionToken: async (claims) => ({token: await issueRunnerSessionToken(claims)}),
     mintJobLeaseToken: async (claims) => ({token: await issueJobLeaseToken(claims)}),
+    getCurrentAdminRole: async ({userId}) => ({role: await getCurrentAdminRole({userId})}),
+    requireAdminRole: async ({userId, minimumRole}) => {
+      try {
+        return {role: await requireAdminRole({userId, minimumRole})};
+      } catch (error) {
+        if (error instanceof AdminRoleRequiredError) {
+          throw createInterModuleKnownError(
+            authInterModuleContract.methods.requireAdminRole,
+            'admin-role-required',
+            {requiredRole: error.minimumRole},
+          );
+        }
+        throw error;
+      }
+    },
   });
 }

--- a/libs/api/auth/src/presentation/routes/session/login.test.ts
+++ b/libs/api/auth/src/presentation/routes/session/login.test.ts
@@ -35,6 +35,7 @@ describe('POST /auth/login', () => {
     expect(res.statusCode).toBe(200);
     expect(res.json().token).toBeDefined();
     expect(res.json().user.email).toBe(email);
+    expect(res.json().admin_role).toBeNull();
     expect(res.headers['set-cookie']).toContain('shipfox_refresh_token=');
     expect(res.headers['set-cookie']).toContain('HttpOnly');
     expect(res.headers['set-cookie']).toContain('Secure');

--- a/libs/api/auth/src/presentation/routes/session/me.test.ts
+++ b/libs/api/auth/src/presentation/routes/session/me.test.ts
@@ -1,10 +1,11 @@
 import type {FastifyInstance} from 'fastify';
 import {signUserToken} from '#core/jwt.js';
+import {createAdminGrant} from '#db/admin-grants.js';
 import {
   createAuthTestApp,
+  createVerifiedSession,
   ROUTE_TEST_SECRET,
   resetCapturedMail,
-  signupVerifyLogin,
 } from '#test/routes.js';
 
 describe('GET /auth/me', () => {
@@ -23,7 +24,7 @@ describe('GET /auth/me', () => {
   });
 
   test('returns the signed-in user', async () => {
-    const account = await signupVerifyLogin(app, 'me');
+    const account = await createVerifiedSession('me');
 
     const res = await app.inject({
       method: 'GET',
@@ -33,6 +34,21 @@ describe('GET /auth/me', () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.json().user.email).toBe(account.email);
+    expect(res.json().admin_role).toBeNull();
+  });
+
+  test('returns the current Auth-owned role for dashboard presentation', async () => {
+    const account = await createVerifiedSession('me-admin');
+    await createAdminGrant({userId: account.userId, role: 'admin-observer'});
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/auth/me',
+      headers: {authorization: `Bearer ${account.token}`},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().admin_role).toBe('admin-observer');
   });
 
   test('transforms a token for a missing user into 404', async () => {

--- a/libs/api/auth/src/presentation/routes/session/me.ts
+++ b/libs/api/auth/src/presentation/routes/session/me.ts
@@ -1,6 +1,7 @@
 import {AUTH_USER} from '@shipfox/api-auth-context';
 import {meResponseSchema} from '@shipfox/api-auth-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
+import {getCurrentAdminRole} from '#core/admin-role.js';
 import {getCurrentUser} from '#core/auth.js';
 import {UserNotFoundError} from '#core/errors.js';
 import {getClientContext} from '#presentation/auth/jwt-auth.js';
@@ -30,6 +31,9 @@ export const meRoute = defineRoute({
 
     const result = await getCurrentUser({userId: client.userId});
 
-    return {user: toUserDto(result.user)};
+    return {
+      user: toUserDto(result.user),
+      admin_role: await getCurrentAdminRole({userId: client.userId}),
+    };
   },
 });

--- a/libs/api/auth/test/globalSetup.ts
+++ b/libs/api/auth/test/globalSetup.ts
@@ -12,7 +12,7 @@ export async function setup() {
   await runMigrations(db(), migrationsPath, '__drizzle_migrations_auth');
   await initializeEmailChallengesForTests();
   await db().execute(
-    sql`TRUNCATE auth_outbox, auth_password_resets, auth_rate_limits, auth_refresh_tokens, auth_users CASCADE`,
+    sql`TRUNCATE auth_admin_grants, auth_outbox, auth_password_resets, auth_rate_limits, auth_refresh_tokens, auth_users CASCADE`,
   );
 
   closeDb();

--- a/libs/api/runners/test/fixtures/auth.ts
+++ b/libs/api/runners/test/fixtures/auth.ts
@@ -82,4 +82,12 @@ export const runnersTestAuthClient: AuthInterModuleClient = {
   mintJobLeaseToken(claims) {
     return Promise.resolve({token: mintLeaseToken(claims)});
   },
+  getCurrentAdminRole() {
+    return Promise.resolve({role: null});
+  },
+  requireAdminRole(_input) {
+    return Promise.reject(
+      new Error('Administrator role checks are not configured in runner tests'),
+    );
+  },
 };

--- a/libs/api/server/src/modules.test.ts
+++ b/libs/api/server/src/modules.test.ts
@@ -58,6 +58,8 @@ vi.mock('@shipfox/api-auth', () => ({
         handlers: {
           mintJobLeaseToken: vi.fn(),
           mintRunnerSessionToken: vi.fn(),
+          getCurrentAdminRole: vi.fn(),
+          requireAdminRole: vi.fn(),
         },
       },
     ],

--- a/libs/api/workflows/test/fixtures/auth-inter-module.ts
+++ b/libs/api/workflows/test/fixtures/auth-inter-module.ts
@@ -8,4 +8,12 @@ export const workflowsTestAuthClient: AuthInterModuleClient = {
   async mintJobLeaseToken(claims) {
     return {token: await mintLeaseToken(claims)};
   },
+  getCurrentAdminRole() {
+    return Promise.resolve({role: null});
+  },
+  requireAdminRole() {
+    return Promise.reject(
+      new Error('Administrator role checks are not configured in workflow tests'),
+    );
+  },
 };

--- a/libs/client/shell/src/core/session.ts
+++ b/libs/client/shell/src/core/session.ts
@@ -1,8 +1,11 @@
+export type AdminRole = 'admin-observer' | 'admin-operator' | 'admin-owner';
+
 export interface UserIdentity {
   id: string;
   email: string;
   name?: string;
   emailVerifiedAt?: string;
+  adminRole?: AdminRole;
 }
 
 export interface AuthenticatedSession {

--- a/libs/client/shell/src/hooks/api/session-mapper.test.ts
+++ b/libs/client/shell/src/hooks/api/session-mapper.test.ts
@@ -1,5 +1,13 @@
 import type {LoginResponseDto, UserDto} from '@shipfox/api-auth-dto';
+import type {AdminRole} from '#core/session.js';
 import {toAuthenticatedSession, toUserIdentity} from './session-mapper.js';
+
+type Exact<Left, Right> =
+  (<Type>() => Type extends Left ? 1 : 2) extends <Type>() => Type extends Right ? 1 : 2
+    ? (<Type>() => Type extends Right ? 1 : 2) extends <Type>() => Type extends Left ? 1 : 2
+      ? true
+      : false
+    : false;
 
 const baseUser: UserDto = {
   id: '11111111-1111-4111-8111-111111111111',
@@ -33,6 +41,12 @@ describe('toUserIdentity', () => {
 });
 
 describe('toAuthenticatedSession', () => {
+  test('keeps the client role model aligned with the Auth DTO role model', () => {
+    const roleTypeContract: Exact<AdminRole, NonNullable<LoginResponseDto['admin_role']>> = true;
+
+    expect(roleTypeContract).toBe(true);
+  });
+
   test('maps the token to accessToken and the user through toUserIdentity', () => {
     const dto: LoginResponseDto = {token: 'access-token', user: baseUser};
 
@@ -40,5 +54,15 @@ describe('toAuthenticatedSession', () => {
       accessToken: 'access-token',
       user: {id: baseUser.id, email: baseUser.email},
     });
+  });
+
+  test('maps the current admin role separately from the user identity token claims', () => {
+    const dto: LoginResponseDto = {
+      token: 'access-token',
+      user: baseUser,
+      admin_role: 'admin-owner',
+    };
+
+    expect(toAuthenticatedSession(dto).user.adminRole).toBe('admin-owner');
   });
 });

--- a/libs/client/shell/src/hooks/api/session-mapper.ts
+++ b/libs/client/shell/src/hooks/api/session-mapper.ts
@@ -11,5 +11,11 @@ export function toUserIdentity(dto: UserDto): UserIdentity {
 }
 
 export function toAuthenticatedSession(dto: LoginResponseDto): AuthenticatedSession {
-  return {accessToken: dto.token, user: toUserIdentity(dto.user)};
+  return {
+    accessToken: dto.token,
+    user: {
+      ...toUserIdentity(dto.user),
+      ...(dto.admin_role ? {adminRole: dto.admin_role} : {}),
+    },
+  };
 }


### PR DESCRIPTION
Add Auth-owned, database-backed local administrator grants and server-side role evaluation.

The fixed observer/operator/owner hierarchy remains separate from workspace membership and out of stateless JWT claims. Auth exposes the current role only for dashboard presentation and provides the inter-module minimum-role check. Grant revocation is serialized and protects the final active owner; suspended users do not retain an effective administrator role.

This includes the Auth DTO and inter-module contract, database migration, client session mapping, dependent test fixtures, and focused coverage. No dashboard actions are exposed.

Closes ENG-1267

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Auth-owned, database-backed local administrator grants with server-side role checks. Exposes the current admin role for dashboard use and inter-module checks while keeping roles out of JWTs and protecting the last active owner; implements ENG-1267.

- New Features
  - Stores fixed admin roles in `auth_admin_grants` with `auth_admin_role` enum and safeguards (unique active per role, active-owner index, serialized revocation).
  - Core API: `getCurrentAdminRole`, `requireAdminRole` (hierarchy: observer < operator < owner, throws `AdminRoleRequiredError`), and `revokeAdminGrant` (prevents removing the final active owner).
  - Inter-module: adds `getCurrentAdminRole` and `requireAdminRole` with known error `admin-role-required`; updates API server composition test mock to register these handlers.
  - DTO/API: adds `admin_role` to login/refresh/signup/verify/password-reset results and `/auth/me`; roles are not included in JWT claims.
  - Client: `@shipfox/client-shell` maps `admin_role` to `user.adminRole`.

- Migration
  - Run the Auth DB migration.
  - Upgrade `@shipfox/api-auth`, `@shipfox/api-auth-dto`, and `@shipfox/client-shell`.
  - If other modules need admin checks, use the new inter-module methods and handle `admin-role-required`.
  - No JWT claim changes; no dashboard actions added.

<sup>Written for commit 78aec1bfd06bb978eccf151b3eaa1eea1bc5a5e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

