### PR TITLE
[api-auth] Default Auth module to environment signup policy

### DIFF
--- a/.changeset/default-signup-policy.md
+++ b/.changeset/default-signup-policy.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-auth": patch
+---
+
+Default the Auth module to its environment-backed signup policy when no custom policy is provided.

--- a/libs/api/auth/README.md
+++ b/libs/api/auth/README.md
@@ -14,7 +14,7 @@ auth-specific operational constraints.
 Register the module with the API module runner:
 
 ```ts
-import {createAuthModule, createEnvironmentSignupPolicy} from '@shipfox/api-auth';
+import {createAuthModule} from '@shipfox/api-auth';
 import {workspacesModule} from '@shipfox/api-workspaces';
 import {workspacesInterModuleContract} from '@shipfox/api-workspaces-dto/inter-module';
 import {createApp, listen} from '@shipfox/node-fastify';
@@ -26,8 +26,7 @@ import {createInMemoryInterModuleTransport} from '@shipfox/node-module/inter-mod
 
 const interModuleTransport = createInMemoryInterModuleTransport();
 const workspaces = interModuleTransport.createClient(workspacesInterModuleContract);
-const signupPolicy = createEnvironmentSignupPolicy();
-const modules = [workspacesModule, createAuthModule({workspaces, signupPolicy})];
+const modules = [workspacesModule, createAuthModule({workspaces})];
 registerInterModulePresentations({transport: interModuleTransport, modules});
 interModuleTransport.seal();
 const {auth, routes} = await initializeModules({
@@ -76,8 +75,8 @@ The signup gate is off by default. When it is on, provide at least one non-empty
 entry in `AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS` or `AUTH_SIGNUP_ALLOWED_EMAILS`.
 Startup fails when both lists are empty. Values are trimmed and lowercased.
 The policy matches exact email addresses or exact domains. It does not match
-subdomains or wildcards. Pass `createEnvironmentSignupPolicy()` to
-`createAuthModule` to apply these settings.
+subdomains or wildcards. `createAuthModule` applies these settings by default;
+pass a `signupPolicy` to replace the environment-backed policy.
 
 When `AUTH_PASSWORD_ENABLED=false`, the module does not register signup, login, password-reset, password-change, or email-verification routes. Refresh, logout, and current-session routes stay available. Another module must contribute a login method before the API server starts.
 
@@ -254,11 +253,10 @@ The package exports a module factory. Pass it the Workspaces inter-module client
 application composition:
 
 ```ts
-import {createAuthModule, createEnvironmentSignupPolicy} from '@shipfox/api-auth';
+import {createAuthModule} from '@shipfox/api-auth';
 
 const authModule = createAuthModule({
   workspaces,
-  signupPolicy: createEnvironmentSignupPolicy(),
 });
 ```
 
@@ -271,7 +269,7 @@ It also exports lower-level pieces for tests and advanced integration:
 - `createLeaseTokenAuthMethod()`: the Fastify auth method for job lease tokens.
 - `issueRunnerSessionToken(claims)` / `verifyRunnerSessionToken(token)`: mint and verify runner session tokens.
 - `issueJobLeaseToken(claims)` / `verifyJobLeaseToken(token)`: mint and verify job lease tokens.
-- `createEnvironmentSignupPolicy()`: creates the default signup policy from the `AUTH_SIGNUP_*` environment variables.
+- `createEnvironmentSignupPolicy()`: creates the environment-backed signup policy used by default. Pass `signupPolicy` to `createAuthModule` to replace it.
 - `getClientContext(request)`: reads the authenticated user context from a Fastify request.
 - `getAuthenticatedSessionContext(request)`: resolves an authenticated request to its user ID and active refresh-session ID.
 - `findUserByEmail({email})`: read-only lookup of the current owner of a normalized email; see below.

--- a/libs/api/auth/src/index.test.ts
+++ b/libs/api/auth/src/index.test.ts
@@ -6,6 +6,22 @@ import {
 import {createAuthModule} from './index.js';
 import {passwordLoginMethods} from './login-methods.js';
 
+type SignupPolicyLike = {
+  isSignupAllowed(params: {
+    email: string;
+    emailVerified: boolean;
+    source: string;
+  }): Promise<{allowed: true} | {allowed: false; message?: string}>;
+};
+
+const buildAuthRoutes = vi.hoisted(() =>
+  vi.fn((_passwordEnabled: boolean, _workspaces: unknown, _signupPolicy?: SignupPolicyLike) => ({
+    prefix: '/auth',
+    plugins: [],
+    routes: [],
+  })),
+);
+
 vi.mock('#config.js', () => ({
   config: {
     AUTH_JWT_EXPIRES_IN: '15m',
@@ -14,9 +30,15 @@ vi.mock('#config.js', () => ({
     AUTH_REFRESH_ROTATION_GRACE_SECONDS: 30,
     AUTH_REFRESH_COOKIE_NAME: 'shipfox_refresh_token',
     AUTH_PASSWORD_ENABLED: true,
+    AUTH_SIGNUP_GATE_ENABLED: true,
+    AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS: 'example.com',
+    AUTH_SIGNUP_ALLOWED_EMAILS: '',
+    AUTH_SIGNUP_NOT_ALLOWED_MESSAGE: undefined,
     CLIENT_BASE_URL: 'https://app.example.test',
   },
 }));
+
+vi.mock('#presentation/routes/index.js', () => ({buildAuthRoutes}));
 
 vi.mock('@shipfox/node-mailer', () => ({
   mailer: {send: vi.fn()},
@@ -40,6 +62,33 @@ describe('authModule', () => {
     expect(passwordLoginMethods(true)).toEqual([{id: 'password'}]);
     expect(passwordLoginMethods(false)).toEqual([]);
     expect(authModule.loginMethods).toEqual([{id: 'password'}]);
+  });
+
+  test('uses the environment signup policy when none is provided', async () => {
+    buildAuthRoutes.mockClear();
+    const module = createAuthModule({
+      workspaces: {
+        listMembershipsForTokenClaims: vi.fn(),
+        getWorkspaceCreator: vi.fn(),
+        preflightInvitationAcceptance: vi.fn(),
+        acceptInvitation: vi.fn(),
+        requireActiveMembership: vi.fn(),
+      },
+    });
+    expect(module.routes).toHaveLength(1);
+    const signupPolicy = buildAuthRoutes.mock.calls[0]?.[2];
+
+    expect(signupPolicy).toEqual(expect.objectContaining({isSignupAllowed: expect.any(Function)}));
+    await expect(
+      signupPolicy?.isSignupAllowed({
+        email: 'person@other.example',
+        emailVerified: false,
+        source: 'password',
+      }),
+    ).resolves.toEqual({
+      allowed: false,
+      message: 'This Shipfox deployment does not accept new accounts right now.',
+    });
   });
 
   test('registers auth email outbox publisher and subscribers', () => {

--- a/libs/api/auth/src/index.ts
+++ b/libs/api/auth/src/index.ts
@@ -7,6 +7,7 @@ import type {ShipfoxModule} from '@shipfox/node-module';
 import {subscriberFactory} from '@shipfox/node-module';
 import {config} from '#config.js';
 import type {SignupPolicy} from '#core/ports.js';
+import {createEnvironmentSignupPolicy} from '#core/signup-policy.js';
 import {db} from '#db/db.js';
 import {migrationsPath} from '#db/migrations.js';
 import {authOutbox} from '#db/schema/outbox.js';
@@ -87,7 +88,7 @@ export interface CreateAuthModuleOptions {
 
 export function createAuthModule({
   workspaces,
-  signupPolicy,
+  signupPolicy = createEnvironmentSignupPolicy(),
 }: CreateAuthModuleOptions): ShipfoxModule {
   return {
     name: 'auth',


### PR DESCRIPTION
Default `createAuthModule` to the environment-backed signup policy.

`createAuthModule({workspaces})` previously forwarded an undefined policy, so the core allow-all fallback bypassed the `AUTH_SIGNUP_*` configuration. The factory now creates the environment policy when no custom `signupPolicy` is provided, while preserving the custom policy composition seam.

The PR also updates the package guidance and adds module-composition coverage for the default behavior.

Closes ENG-1252

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default `@shipfox/api-auth`’s `createAuthModule` to the environment-backed signup policy so `AUTH_SIGNUP_*` settings are enforced when no custom policy is passed. Fixes the previous allow-all fallback and aligns with ENG-1252.

- **Bug Fixes**
  - Use `createEnvironmentSignupPolicy()` by default in `createAuthModule`; preserves the `signupPolicy` override.
  - Updated README and added tests to cover default policy behavior.

<sup>Written for commit b545a37c9e2cb184f1df4b0a3ede38e617d37104. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

