### PR TITLE
[api-auth] Add administrator bootstrap controls

### DIFF
--- a/.changeset/admin-bootstrap-grants.md
+++ b/.changeset/admin-bootstrap-grants.md
@@ -1,0 +1,6 @@
+---
+'@shipfox/api-auth': minor
+'@shipfox/api-auth-dto': minor
+---
+
+Add first-owner bootstrap and administrator grant management routes.

--- a/libs/api/auth-dto/src/schemas/admin.ts
+++ b/libs/api/auth-dto/src/schemas/admin.ts
@@ -3,3 +3,62 @@ import {z} from 'zod';
 export const adminRoleSchema = z.enum(['admin-observer', 'admin-operator', 'admin-owner']);
 
 export type AdminRole = z.infer<typeof adminRoleSchema>;
+
+const timestampSchema = z.string().datetime();
+const CONTROL_OR_FORMAT_CHARACTER_RE = /[\p{Cc}\p{Cf}]/u;
+const reasonSchema = z
+  .string()
+  .min(1)
+  .max(512)
+  .refine((value) => !CONTROL_OR_FORMAT_CHARACTER_RE.test(value), {
+    message: 'must not contain control or format characters',
+  });
+
+export const adminGrantDtoSchema = z.object({
+  id: z.string().uuid(),
+  user_id: z.string().uuid(),
+  role: adminRoleSchema,
+  revoked_at: timestampSchema.nullable(),
+  created_at: timestampSchema,
+  updated_at: timestampSchema,
+});
+
+export type AdminGrantDto = z.infer<typeof adminGrantDtoSchema>;
+
+export const listAdminGrantsResponseSchema = z.object({
+  grants: z.array(adminGrantDtoSchema),
+});
+
+export type ListAdminGrantsResponseDto = z.infer<typeof listAdminGrantsResponseSchema>;
+
+export const bootstrapAdminOwnerBodySchema = z.object({
+  bootstrap_token: z.string().min(1).max(512),
+});
+
+export type BootstrapAdminOwnerBodyDto = z.infer<typeof bootstrapAdminOwnerBodySchema>;
+
+export const bootstrapAdminOwnerResponseSchema = adminGrantDtoSchema;
+
+export type BootstrapAdminOwnerResponseDto = z.infer<typeof bootstrapAdminOwnerResponseSchema>;
+
+export const grantAdminRoleBodySchema = z.object({
+  user_id: z.string().uuid(),
+  role: adminRoleSchema,
+  reason: reasonSchema,
+});
+
+export type GrantAdminRoleBodyDto = z.infer<typeof grantAdminRoleBodySchema>;
+
+export const grantAdminRoleResponseSchema = adminGrantDtoSchema;
+
+export type GrantAdminRoleResponseDto = z.infer<typeof grantAdminRoleResponseSchema>;
+
+export const revokeAdminGrantBodySchema = z.object({
+  reason: reasonSchema,
+});
+
+export type RevokeAdminGrantBodyDto = z.infer<typeof revokeAdminGrantBodySchema>;
+
+export const revokeAdminGrantResponseSchema = adminGrantDtoSchema;
+
+export type RevokeAdminGrantResponseDto = z.infer<typeof revokeAdminGrantResponseSchema>;

--- a/libs/api/auth-dto/src/schemas/index.ts
+++ b/libs/api/auth-dto/src/schemas/index.ts
@@ -8,7 +8,26 @@ export {
   authPasswordResetSendRequestedSchema,
   authUserSignedUpSchema,
 } from '../events.js';
-export {type AdminRole, adminRoleSchema} from './admin.js';
+export {
+  type AdminGrantDto,
+  type AdminRole,
+  adminGrantDtoSchema,
+  adminRoleSchema,
+  type BootstrapAdminOwnerBodyDto,
+  type BootstrapAdminOwnerResponseDto,
+  bootstrapAdminOwnerBodySchema,
+  bootstrapAdminOwnerResponseSchema,
+  type GrantAdminRoleBodyDto,
+  type GrantAdminRoleResponseDto,
+  grantAdminRoleBodySchema,
+  grantAdminRoleResponseSchema,
+  type ListAdminGrantsResponseDto,
+  listAdminGrantsResponseSchema,
+  type RevokeAdminGrantBodyDto,
+  type RevokeAdminGrantResponseDto,
+  revokeAdminGrantBodySchema,
+  revokeAdminGrantResponseSchema,
+} from './admin.js';
 export {
   type ChangePasswordBodyDto,
   changePasswordBodySchema,

--- a/libs/api/auth/README.md
+++ b/libs/api/auth/README.md
@@ -68,6 +68,7 @@ Required environment:
 | `AUTH_SIGNUP_ALLOWED_EMAILS` | none | Comma-separated exact email addresses allowed to create accounts. |
 | `AUTH_SIGNUP_NOT_ALLOWED_MESSAGE` | none | Description returned when the signup gate blocks an account. Defaults to "This Shipfox deployment does not accept new accounts right now." |
 | `CLIENT_BASE_URL` | `http://localhost:5173` | Base URL used in email verification and password reset links. |
+| `ADMIN_BOOTSTRAP_TOKEN` | none | Deployment secret accepted once to create the first administrator owner. Set it before bootstrap and remove or rotate it after successful bootstrap. |
 
 Email delivery uses the shared `@shipfox/node-mailer` configuration.
 
@@ -231,6 +232,19 @@ When password login is disabled, the password and email-verification rows in thi
 > [!IMPORTANT]
 > Refresh cookies are set with `secure: true`, `httpOnly: true`, and `sameSite: "lax"`. Local browser tests need HTTPS or a test path that handles secure cookies.
 
+### Administrator grants
+
+All routes are mounted under `/admin/v1/auth/admin-grants` and require an authenticated bearer token. Ownership is enforced in the core layer, not by route-level middleware.
+
+| Method | Path | Required role | Result |
+| --- | --- | --- | --- |
+| `POST` | `/bootstrap` | none (deployment token) | Claims the `admin-owner` role for the calling user using `ADMIN_BOOTSTRAP_TOKEN`. Fails with `409 bootstrap-closed` once an active owner exists. |
+| `GET` | `/` | `admin-owner` | Lists local administrator grants. |
+| `POST` | `/` | `admin-owner` | Grants a role to an active user. |
+| `DELETE` | `/:grantId` | `admin-owner` | Revokes a grant. Fails with `409 last-owner` when it would remove the final active owner. |
+
+`POST` and `DELETE` routes require an `Idempotency-Key` header; a repeated key replays the same result, and reusing a key with a different command returns `409 idempotency-key-reused`. Every mutation writes a redacted `administration.action.performed` outbox event.
+
 ### Rate limiting
 
 The public auth endpoints include an application-layer abuse baseline for open source installs:
@@ -240,6 +254,7 @@ The public auth endpoints include an application-layer abuse baseline for open s
 | `POST /auth/login` | 60 attempts per 5 minutes | 10 attempts per 15 minutes |
 | `POST /auth/password-reset` | 30 email-send attempts per hour | 3 email-send attempts per hour |
 | `POST /auth/verify-email/resend` | Shared with password reset | Shared with password reset |
+| `POST /admin/v1/auth/admin-grants/bootstrap` | 5 attempts per 15 minutes | n/a |
 
 Counters are stored in PostgreSQL as fixed windows in `auth_rate_limits`. IP addresses and email addresses are HMAC-SHA256 values before storage; raw identifiers are not persisted. The identifier key is derived from `AUTH_ROOT_KEY` separately from every token key.
 
@@ -389,6 +404,8 @@ The module creates tables with the `auth_` prefix:
 - `auth_refresh_tokens`
 - `auth_password_resets`
 - `auth_rate_limits`
+- `auth_admin_grants`
+- `auth_admin_command_results`
 
 Passwords use Argon2id. Password reset tokens and refresh tokens are opaque tokens stored as hashes. Email verification uses the shared email-challenges module.
 

--- a/libs/api/auth/drizzle/0002_burly_whizzer.sql
+++ b/libs/api/auth/drizzle/0002_burly_whizzer.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "auth_admin_command_results" (
+	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
+	"actor_id" uuid NOT NULL,
+	"idempotency_key_fingerprint" text NOT NULL,
+	"command" text NOT NULL,
+	"request_fingerprint" text NOT NULL,
+	"result" jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "auth_admin_command_results" ADD CONSTRAINT "auth_admin_command_results_actor_id_auth_users_id_fk" FOREIGN KEY ("actor_id") REFERENCES "public"."auth_users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "auth_admin_command_results_actor_key_unique" ON "auth_admin_command_results" USING btree ("actor_id","idempotency_key_fingerprint");

--- a/libs/api/auth/drizzle/meta/0002_snapshot.json
+++ b/libs/api/auth/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,791 @@
+{
+  "id": "49ca55f0-179d-429e-adaf-0d68a7927a7f",
+  "prevId": "39a76407-aeea-4575-96ce-61da4c8d77a8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_admin_command_results": {
+      "name": "auth_admin_command_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key_fingerprint": {
+          "name": "idempotency_key_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_fingerprint": {
+          "name": "request_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_admin_command_results_actor_key_unique": {
+          "name": "auth_admin_command_results_actor_key_unique",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_admin_command_results_actor_id_auth_users_id_fk": {
+          "name": "auth_admin_command_results_actor_id_auth_users_id_fk",
+          "tableFrom": "auth_admin_command_results",
+          "tableTo": "auth_users",
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_admin_grants": {
+      "name": "auth_admin_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "auth_admin_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_admin_grants_user_id_idx": {
+          "name": "auth_admin_grants_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_admin_grants_active_owners_idx": {
+          "name": "auth_admin_grants_active_owners_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"auth_admin_grants\".\"role\" = 'admin-owner' AND \"auth_admin_grants\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_admin_grants_active_user_role_unique": {
+          "name": "auth_admin_grants_active_user_role_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"auth_admin_grants\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_admin_grants_user_id_auth_users_id_fk": {
+          "name": "auth_admin_grants_user_id_auth_users_id_fk",
+          "tableFrom": "auth_admin_grants",
+          "tableTo": "auth_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_outbox": {
+      "name": "auth_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordering_key": {
+          "name": "ordering_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_attempts": {
+          "name": "dispatch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_dispatch_at": {
+          "name": "next_dispatch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_dispatch_error": {
+          "name": "last_dispatch_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_dispatch_failed_at": {
+          "name": "last_dispatch_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dead_lettered_at": {
+          "name": "dead_lettered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_outbox_pending_idx": {
+          "name": "auth_outbox_pending_idx",
+          "columns": [
+            {
+              "expression": "next_dispatch_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NULL AND \"dead_lettered_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_outbox_dispatched_retention_idx": {
+          "name": "auth_outbox_dispatched_retention_idx",
+          "columns": [
+            {
+              "expression": "dispatched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_password_resets": {
+      "name": "auth_password_resets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_password_resets_hashed_token_unique": {
+          "name": "auth_password_resets_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_password_resets_user_id_idx": {
+          "name": "auth_password_resets_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_password_resets_user_id_auth_users_id_fk": {
+          "name": "auth_password_resets_user_id_auth_users_id_fk",
+          "tableFrom": "auth_password_resets",
+          "tableTo": "auth_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_rate_limits": {
+      "name": "auth_rate_limits",
+      "schema": "",
+      "columns": {
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier_hmac": {
+          "name": "identifier_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_rate_limits_window_unique": {
+          "name": "auth_rate_limits_window_unique",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identifier_hmac",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "window_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_rate_limits_expires_at_idx": {
+          "name": "auth_rate_limits_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_refresh_tokens": {
+      "name": "auth_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_refresh_tokens_hashed_token_unique": {
+          "name": "auth_refresh_tokens_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_refresh_tokens_active_session_unique": {
+          "name": "auth_refresh_tokens_active_session_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"auth_refresh_tokens\".\"revoked_at\" IS NULL AND \"auth_refresh_tokens\".\"rotated_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_refresh_tokens_user_id_idx": {
+          "name": "auth_refresh_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_refresh_tokens_user_id_auth_users_id_fk": {
+          "name": "auth_refresh_tokens_user_id_auth_users_id_fk",
+          "tableFrom": "auth_refresh_tokens",
+          "tableTo": "auth_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_users": {
+      "name": "auth_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_password": {
+          "name": "hashed_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "auth_user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_users_email_unique": {
+          "name": "auth_users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.auth_admin_role": {
+      "name": "auth_admin_role",
+      "schema": "public",
+      "values": ["admin-observer", "admin-operator", "admin-owner"]
+    },
+    "public.auth_user_status": {
+      "name": "auth_user_status",
+      "schema": "public",
+      "values": ["active", "suspended", "deleted"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/api/auth/drizzle/meta/_journal.json
+++ b/libs/api/auth/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1785065259979,
       "tag": "0001_brainy_shriek",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1785075183023,
+      "tag": "0002_burly_whizzer",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/api/auth/package.json
+++ b/libs/api/auth/package.json
@@ -51,6 +51,7 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
+    "@shipfox/api-common-dto": "workspace:*",
     "@shipfox/api-auth-context": "workspace:*",
     "@fastify/cookie": "catalog:",
     "@node-rs/argon2": "catalog:",

--- a/libs/api/auth/src/config.ts
+++ b/libs/api/auth/src/config.ts
@@ -1,6 +1,10 @@
 import {bool, createConfig, num, str} from '@shipfox/config';
 
 export const config = createConfig({
+  ADMIN_BOOTSTRAP_TOKEN: str({
+    desc: 'Deployment secret accepted once to create the first administrator owner. Set it before bootstrap and remove or rotate it after successful bootstrap.',
+    default: undefined,
+  }),
   AUTH_JWT_EXPIRES_IN: str({
     desc: 'How long an access token stays valid. Accepts a duration string such as 15m, 1h, or 7d.',
     default: '15m',

--- a/libs/api/auth/src/core/administration.ts
+++ b/libs/api/auth/src/core/administration.ts
@@ -1,0 +1,172 @@
+import {createHash, timingSafeEqual} from 'node:crypto';
+import type {AdminRole} from '@shipfox/api-auth-dto';
+import {createAdministrationActionEvent} from '@shipfox/api-common-dto';
+import {config} from '#config.js';
+import {
+  bootstrapFirstAdminOwner as bootstrapFirstAdminOwnerInDb,
+  grantAdminRoleWithAudit,
+  listAdminGrants,
+  revokeAdminGrantWithAudit,
+} from '#db/admin-grants.js';
+import {requireAdminRole} from './admin-role.js';
+import type {AdminGrant} from './entities/admin-grant.js';
+import {
+  AdminBootstrapClosedError,
+  AdminGrantAlreadyExistsError,
+  AdminGrantNotFoundError,
+  AdminIdempotencyKeyReuseError,
+  InvalidAdminBootstrapTokenError,
+  LastAdminOwnerError,
+  UserNotFoundError,
+} from './errors.js';
+
+const ADMIN_OWNER_ROLE: AdminRole = 'admin-owner';
+const BOOTSTRAP_COMMAND = 'auth.admin_grant.bootstrap';
+const GRANT_COMMAND = 'auth.admin_grant.grant';
+const REVOKE_COMMAND = 'auth.admin_grant.revoke';
+
+export function hashAdministrationValue(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+export function administrationCommandFingerprint(command: string, input: unknown): string {
+  return hashAdministrationValue(`${command}:${JSON.stringify(input)}`);
+}
+
+function bootstrapTokenMatches(candidate: string, expected: string | undefined): boolean {
+  if (!expected) return false;
+  const candidateHash = Buffer.from(hashAdministrationValue(candidate), 'hex');
+  const expectedHash = Buffer.from(hashAdministrationValue(expected), 'hex');
+  return timingSafeEqual(candidateHash, expectedHash);
+}
+
+function administrationEvent(params: {
+  actorId: string;
+  actorRole: AdminRole;
+  command: string;
+  targetType: string;
+  targetId: string;
+  reason: string;
+  correlationId: string;
+  idempotencyKeyFingerprint: string;
+}) {
+  return createAdministrationActionEvent({
+    actorId: params.actorId,
+    actorRole: params.actorRole,
+    requiredRole: ADMIN_OWNER_ROLE,
+    command: params.command,
+    targetType: params.targetType,
+    targetId: params.targetId,
+    reason: params.reason,
+    result: 'succeeded',
+    correlationId: params.correlationId,
+    idempotencyKeyFingerprint: params.idempotencyKeyFingerprint,
+    occurredAt: new Date().toISOString(),
+  });
+}
+
+export interface AdministrationMutationContext {
+  actorId: string;
+  idempotencyKey: string;
+  correlationId: string;
+}
+
+export async function bootstrapFirstAdminOwner(
+  params: AdministrationMutationContext & {bootstrapToken: string},
+): Promise<AdminGrant> {
+  if (!bootstrapTokenMatches(params.bootstrapToken, config.ADMIN_BOOTSTRAP_TOKEN)) {
+    throw new InvalidAdminBootstrapTokenError();
+  }
+
+  return await bootstrapFirstAdminOwnerInDb({
+    userId: params.actorId,
+    actorId: params.actorId,
+    idempotencyKeyFingerprint: hashAdministrationValue(params.idempotencyKey),
+    requestFingerprint: administrationCommandFingerprint(BOOTSTRAP_COMMAND, {
+      actorId: params.actorId,
+    }),
+    event: administrationEvent({
+      actorId: params.actorId,
+      actorRole: ADMIN_OWNER_ROLE,
+      command: BOOTSTRAP_COMMAND,
+      targetType: 'user',
+      targetId: params.actorId,
+      reason: 'Initial administrator owner bootstrap',
+      correlationId: params.correlationId,
+      idempotencyKeyFingerprint: hashAdministrationValue(params.idempotencyKey),
+    }),
+  });
+}
+
+export async function listAdministratorGrants(params: {actorId: string}): Promise<AdminGrant[]> {
+  await requireAdminRole({userId: params.actorId, minimumRole: ADMIN_OWNER_ROLE});
+  return await listAdminGrants();
+}
+
+export async function grantAdministratorRole(
+  params: AdministrationMutationContext & {userId: string; role: AdminRole; reason: string},
+): Promise<AdminGrant> {
+  const actorRole = await requireAdminRole({
+    userId: params.actorId,
+    minimumRole: ADMIN_OWNER_ROLE,
+  });
+  return await grantAdminRoleWithAudit({
+    userId: params.userId,
+    role: params.role,
+    actorId: params.actorId,
+    idempotencyKeyFingerprint: hashAdministrationValue(params.idempotencyKey),
+    requestFingerprint: administrationCommandFingerprint(GRANT_COMMAND, {
+      userId: params.userId,
+      role: params.role,
+      reason: params.reason,
+    }),
+    event: administrationEvent({
+      actorId: params.actorId,
+      actorRole,
+      command: GRANT_COMMAND,
+      targetType: 'user',
+      targetId: params.userId,
+      reason: params.reason,
+      correlationId: params.correlationId,
+      idempotencyKeyFingerprint: hashAdministrationValue(params.idempotencyKey),
+    }),
+  });
+}
+
+export async function revokeAdministratorGrant(
+  params: AdministrationMutationContext & {grantId: string; reason: string},
+): Promise<AdminGrant> {
+  const actorRole = await requireAdminRole({
+    userId: params.actorId,
+    minimumRole: ADMIN_OWNER_ROLE,
+  });
+  return await revokeAdminGrantWithAudit({
+    grantId: params.grantId,
+    actorId: params.actorId,
+    idempotencyKeyFingerprint: hashAdministrationValue(params.idempotencyKey),
+    requestFingerprint: administrationCommandFingerprint(REVOKE_COMMAND, {
+      grantId: params.grantId,
+      reason: params.reason,
+    }),
+    event: administrationEvent({
+      actorId: params.actorId,
+      actorRole,
+      command: REVOKE_COMMAND,
+      targetType: 'admin-grant',
+      targetId: params.grantId,
+      reason: params.reason,
+      correlationId: params.correlationId,
+      idempotencyKeyFingerprint: hashAdministrationValue(params.idempotencyKey),
+    }),
+  });
+}
+
+export {
+  AdminBootstrapClosedError,
+  AdminGrantAlreadyExistsError,
+  AdminGrantNotFoundError,
+  AdminIdempotencyKeyReuseError,
+  InvalidAdminBootstrapTokenError,
+  LastAdminOwnerError,
+  UserNotFoundError,
+};

--- a/libs/api/auth/src/core/errors.ts
+++ b/libs/api/auth/src/core/errors.ts
@@ -97,6 +97,41 @@ export class LastAdminOwnerError extends Error {
   }
 }
 
+export class AdminGrantNotFoundError extends Error {
+  constructor() {
+    super('Administrator grant not found');
+    this.name = 'AdminGrantNotFoundError';
+  }
+}
+
+export class AdminGrantAlreadyExistsError extends Error {
+  constructor() {
+    super('Administrator grant already exists');
+    this.name = 'AdminGrantAlreadyExistsError';
+  }
+}
+
+export class AdminBootstrapClosedError extends Error {
+  constructor() {
+    super('First administrator owner has already been created');
+    this.name = 'AdminBootstrapClosedError';
+  }
+}
+
+export class InvalidAdminBootstrapTokenError extends Error {
+  constructor() {
+    super('Bootstrap token is invalid');
+    this.name = 'InvalidAdminBootstrapTokenError';
+  }
+}
+
+export class AdminIdempotencyKeyReuseError extends Error {
+  constructor() {
+    super('Idempotency key was already used for a different command');
+    this.name = 'AdminIdempotencyKeyReuseError';
+  }
+}
+
 export class TokenInvalidError extends Error {
   constructor(reason?: string) {
     super(reason ? `Invalid token: ${reason}` : 'Invalid token');

--- a/libs/api/auth/src/db/admin-grants.ts
+++ b/libs/api/auth/src/db/admin-grants.ts
@@ -1,11 +1,31 @@
 import type {AdminRole} from '@shipfox/api-auth-dto';
+import type {
+  AdministrationActionEvent,
+  AdministrationActionEventMap,
+} from '@shipfox/api-common-dto';
+import {writeOutboxEvent} from '@shipfox/node-outbox';
 import {and, asc, eq, isNull, sql} from 'drizzle-orm';
 import {highestAdminRole} from '#core/admin-role-model.js';
 import type {AdminGrant} from '#core/entities/admin-grant.js';
-import {LastAdminOwnerError} from '#core/errors.js';
+import {
+  AdminBootstrapClosedError,
+  AdminGrantAlreadyExistsError,
+  AdminGrantNotFoundError,
+  AdminIdempotencyKeyReuseError,
+  LastAdminOwnerError,
+  UserNotFoundError,
+} from '#core/errors.js';
 import {db} from './db.js';
+import {
+  type AdminCommandResultDb,
+  adminCommandResults,
+  type StoredAdminGrant,
+} from './schema/admin-command-results.js';
 import {adminGrants, toAdminGrant} from './schema/admin-grants.js';
+import {authOutbox} from './schema/outbox.js';
 import {users} from './schema/users.js';
+
+type Tx = Parameters<Parameters<ReturnType<typeof db>['transaction']>[0]>[0];
 
 export interface CreateAdminGrantParams {
   userId: string;
@@ -79,5 +99,242 @@ export async function revokeAdminGrant(params: {grantId: string}): Promise<Admin
       .returning();
     const row = updated[0];
     return row ? toAdminGrant(row) : undefined;
+  });
+}
+
+interface AuditedAdminCommandParams {
+  actorId: string;
+  idempotencyKeyFingerprint: string;
+  requestFingerprint: string;
+  event: AdministrationActionEvent;
+}
+
+function toStoredAdminGrant(grant: AdminGrant): StoredAdminGrant {
+  return {
+    id: grant.id,
+    userId: grant.userId,
+    role: grant.role,
+    revokedAt: grant.revokedAt?.toISOString() ?? null,
+    createdAt: grant.createdAt.toISOString(),
+    updatedAt: grant.updatedAt.toISOString(),
+  };
+}
+
+function fromStoredAdminGrant(grant: StoredAdminGrant): AdminGrant {
+  return {
+    id: grant.id,
+    userId: grant.userId,
+    role: grant.role,
+    revokedAt: grant.revokedAt ? new Date(grant.revokedAt) : null,
+    createdAt: new Date(grant.createdAt),
+    updatedAt: new Date(grant.updatedAt),
+  };
+}
+
+async function findCommandResult(
+  tx: Tx,
+  params: Pick<
+    AuditedAdminCommandParams,
+    'actorId' | 'idempotencyKeyFingerprint' | 'requestFingerprint'
+  > & {
+    command: string;
+  },
+): Promise<AdminGrant | undefined> {
+  const rows = await tx
+    .select()
+    .from(adminCommandResults)
+    .where(
+      and(
+        eq(adminCommandResults.actorId, params.actorId),
+        eq(adminCommandResults.idempotencyKeyFingerprint, params.idempotencyKeyFingerprint),
+      ),
+    )
+    .limit(1);
+  const result: AdminCommandResultDb | undefined = rows[0];
+  if (!result) return undefined;
+  if (
+    result.command !== params.command ||
+    result.requestFingerprint !== params.requestFingerprint
+  ) {
+    throw new AdminIdempotencyKeyReuseError();
+  }
+  return fromStoredAdminGrant(result.result.grant);
+}
+
+async function storeCommandResult(
+  tx: Tx,
+  params: AuditedAdminCommandParams,
+  grant: AdminGrant,
+): Promise<void> {
+  await tx.insert(adminCommandResults).values({
+    actorId: params.actorId,
+    idempotencyKeyFingerprint: params.idempotencyKeyFingerprint,
+    command: params.event.command,
+    requestFingerprint: params.requestFingerprint,
+    result: {grant: toStoredAdminGrant(grant)},
+  });
+}
+
+async function writeAdminAction(tx: Tx, event: AdministrationActionEvent): Promise<void> {
+  await writeOutboxEvent<AdministrationActionEventMap>(tx, authOutbox, {
+    type: 'administration.action.performed',
+    payload: event,
+  });
+}
+
+async function lockAdminCommand(
+  tx: Tx,
+  params: {actorId: string; idempotencyKeyFingerprint: string},
+) {
+  await tx.execute(
+    sql`select pg_advisory_xact_lock(hashtext(${`auth_admin_command:${params.actorId}:${params.idempotencyKeyFingerprint}`}))`,
+  );
+}
+
+export async function bootstrapFirstAdminOwner(
+  params: AuditedAdminCommandParams & {userId: string},
+): Promise<AdminGrant> {
+  return await db().transaction(async (tx) => {
+    await lockAdminCommand(tx, params);
+    await tx.execute(sql`select pg_advisory_xact_lock(hashtext('auth_admin_owner_grants'))`);
+
+    const existing = await findCommandResult(tx, {
+      ...params,
+      command: params.event.command,
+    });
+    if (existing) return existing;
+
+    const activeOwners = await tx
+      .select({id: adminGrants.id})
+      .from(adminGrants)
+      .innerJoin(users, eq(adminGrants.userId, users.id))
+      .where(
+        and(
+          eq(adminGrants.role, 'admin-owner'),
+          isNull(adminGrants.revokedAt),
+          eq(users.status, 'active'),
+        ),
+      )
+      .limit(1);
+    if (activeOwners.length > 0) throw new AdminBootstrapClosedError();
+
+    const userRows = await tx
+      .select({id: users.id, status: users.status})
+      .from(users)
+      .where(eq(users.id, params.userId))
+      .limit(1);
+    const user = userRows[0];
+    if (user?.status !== 'active') throw new UserNotFoundError(params.userId);
+
+    const rows = await tx
+      .insert(adminGrants)
+      .values({userId: params.userId, role: 'admin-owner'})
+      .returning();
+    const row = rows[0];
+    if (!row) throw new Error('Bootstrap grant insert returned no rows');
+
+    const grant = toAdminGrant(row);
+    await writeAdminAction(tx, params.event);
+    await storeCommandResult(tx, params, grant);
+    return grant;
+  });
+}
+
+export async function grantAdminRoleWithAudit(
+  params: AuditedAdminCommandParams & {userId: string; role: AdminRole},
+): Promise<AdminGrant> {
+  return await db().transaction(async (tx) => {
+    await lockAdminCommand(tx, params);
+    await tx.execute(sql`select pg_advisory_xact_lock(hashtext('auth_admin_owner_grants'))`);
+
+    const existing = await findCommandResult(tx, {
+      ...params,
+      command: params.event.command,
+    });
+    if (existing) return existing;
+
+    const userRows = await tx
+      .select({id: users.id, status: users.status})
+      .from(users)
+      .where(eq(users.id, params.userId))
+      .limit(1);
+    const user = userRows[0];
+    if (user?.status !== 'active') throw new UserNotFoundError(params.userId);
+
+    const activeRows = await tx
+      .select({id: adminGrants.id})
+      .from(adminGrants)
+      .where(
+        and(
+          eq(adminGrants.userId, params.userId),
+          eq(adminGrants.role, params.role),
+          isNull(adminGrants.revokedAt),
+        ),
+      )
+      .limit(1);
+    if (activeRows.length > 0) throw new AdminGrantAlreadyExistsError();
+
+    const rows = await tx
+      .insert(adminGrants)
+      .values({userId: params.userId, role: params.role})
+      .returning();
+    const row = rows[0];
+    if (!row) throw new Error('Administrator grant insert returned no rows');
+
+    const grant = toAdminGrant(row);
+    await writeAdminAction(tx, params.event);
+    await storeCommandResult(tx, params, grant);
+    return grant;
+  });
+}
+
+export async function revokeAdminGrantWithAudit(
+  params: AuditedAdminCommandParams & {grantId: string},
+): Promise<AdminGrant> {
+  return await db().transaction(async (tx) => {
+    await lockAdminCommand(tx, params);
+    await tx.execute(sql`select pg_advisory_xact_lock(hashtext('auth_admin_owner_grants'))`);
+
+    const existing = await findCommandResult(tx, {
+      ...params,
+      command: params.event.command,
+    });
+    if (existing) return existing;
+
+    const rows = await tx
+      .select()
+      .from(adminGrants)
+      .where(and(eq(adminGrants.id, params.grantId), isNull(adminGrants.revokedAt)))
+      .limit(1);
+    const grant = rows[0];
+    if (!grant) throw new AdminGrantNotFoundError();
+
+    if (grant.role === 'admin-owner') {
+      const activeOwners = await tx
+        .select({id: adminGrants.id})
+        .from(adminGrants)
+        .innerJoin(users, eq(adminGrants.userId, users.id))
+        .where(
+          and(
+            eq(adminGrants.role, 'admin-owner'),
+            isNull(adminGrants.revokedAt),
+            eq(users.status, 'active'),
+          ),
+        );
+      if (activeOwners.length <= 1) throw new LastAdminOwnerError();
+    }
+
+    const updated = await tx
+      .update(adminGrants)
+      .set({revokedAt: new Date(), updatedAt: new Date()})
+      .where(and(eq(adminGrants.id, grant.id), isNull(adminGrants.revokedAt)))
+      .returning();
+    const updatedRow = updated[0];
+    if (!updatedRow) throw new AdminGrantNotFoundError();
+
+    const revoked = toAdminGrant(updatedRow);
+    await writeAdminAction(tx, params.event);
+    await storeCommandResult(tx, params, revoked);
+    return revoked;
   });
 }

--- a/libs/api/auth/src/db/db.ts
+++ b/libs/api/auth/src/db/db.ts
@@ -1,5 +1,6 @@
 import {drizzle, type NodePgDatabase} from '@shipfox/node-drizzle';
 import {pgClient} from '@shipfox/node-postgres';
+import {adminCommandResults} from './schema/admin-command-results.js';
 import {adminGrants} from './schema/admin-grants.js';
 import {authOutbox} from './schema/outbox.js';
 import {passwordResets} from './schema/password-resets.js';
@@ -9,6 +10,7 @@ import {users} from './schema/users.js';
 
 export const schema = {
   adminGrants,
+  adminCommandResults,
   users,
   passwordResets,
   refreshTokens,

--- a/libs/api/auth/src/db/schema/admin-command-results.ts
+++ b/libs/api/auth/src/db/schema/admin-command-results.ts
@@ -1,0 +1,41 @@
+import type {AdminRole} from '@shipfox/api-auth-dto';
+import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
+import {jsonb, text, timestamp, uniqueIndex, uuid} from 'drizzle-orm/pg-core';
+import {pgTable} from './common.js';
+import {users} from './users.js';
+
+export interface StoredAdminGrant {
+  id: string;
+  userId: string;
+  role: AdminRole;
+  revokedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface StoredAdminCommandResult {
+  grant: StoredAdminGrant;
+}
+
+export const adminCommandResults = pgTable(
+  'admin_command_results',
+  {
+    id: uuidv7PrimaryKey(),
+    actorId: uuid('actor_id')
+      .notNull()
+      .references(() => users.id, {onDelete: 'cascade'}),
+    idempotencyKeyFingerprint: text('idempotency_key_fingerprint').notNull(),
+    command: text('command').notNull(),
+    requestFingerprint: text('request_fingerprint').notNull(),
+    result: jsonb('result').$type<StoredAdminCommandResult>().notNull(),
+    createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex('auth_admin_command_results_actor_key_unique').on(
+      table.actorId,
+      table.idempotencyKeyFingerprint,
+    ),
+  ],
+);
+
+export type AdminCommandResultDb = typeof adminCommandResults.$inferSelect;

--- a/libs/api/auth/src/index.test.ts
+++ b/libs/api/auth/src/index.test.ts
@@ -3,6 +3,7 @@ import {
   AUTH_USER_SIGNED_UP,
   authEventSchemas,
 } from '@shipfox/api-auth-dto';
+import {ADMINISTRATION_ACTION_PERFORMED} from '@shipfox/api-common-dto';
 import {createAuthModule} from './index.js';
 import {passwordLoginMethods} from './login-methods.js';
 
@@ -75,7 +76,7 @@ describe('authModule', () => {
         requireActiveMembership: vi.fn(),
       },
     });
-    expect(module.routes).toHaveLength(1);
+    expect(module.routes).toHaveLength(2);
     const signupPolicy = buildAuthRoutes.mock.calls[0]?.[2];
 
     expect(signupPolicy).toEqual(expect.objectContaining({isSignupAllowed: expect.any(Function)}));
@@ -95,8 +96,9 @@ describe('authModule', () => {
     const publisher = authModule.publishers?.find((pub) => pub.name === 'auth');
     const events = authModule.subscribers?.map((subscriber) => subscriber.event);
 
-    expect(publisher?.eventSchemas).toBe(authEventSchemas);
+    expect(publisher?.eventSchemas).not.toBe(authEventSchemas);
     expect(Object.keys(publisher?.eventSchemas ?? {}).sort()).toEqual([
+      ADMINISTRATION_ACTION_PERFORMED,
       AUTH_PASSWORD_RESET_SEND_REQUESTED,
       AUTH_USER_SIGNED_UP,
     ]);

--- a/libs/api/auth/src/index.ts
+++ b/libs/api/auth/src/index.ts
@@ -3,6 +3,7 @@ import {
   type AuthEventMap,
   authEventSchemas,
 } from '@shipfox/api-auth-dto';
+import {administrationActionEventSchemas} from '@shipfox/api-common-dto';
 import type {ShipfoxModule} from '@shipfox/node-module';
 import {subscriberFactory} from '@shipfox/node-module';
 import {config} from '#config.js';
@@ -16,9 +17,12 @@ import {createLeaseTokenAuthMethod} from '#presentation/auth/lease-token-auth.js
 import {createRunnerSessionAuthMethod} from '#presentation/auth/runner-session-auth.js';
 import {createAuthE2eRoutes} from '#presentation/e2eRoutes/index.js';
 import {createAuthInterModulePresentation} from '#presentation/inter-module.js';
+import {administrationRoutes} from '#presentation/routes/administration.js';
 import {buildAuthRoutes} from '#presentation/routes/index.js';
 import {onPasswordResetSendRequested} from '#presentation/subscribers/index.js';
 import {passwordLoginMethods} from './login-methods.js';
+
+const authPublisherEventSchemas = {...authEventSchemas, ...administrationActionEventSchemas};
 
 export type {AdminRole, JobLeaseTokenClaims, RunnerSessionTokenClaims} from '@shipfox/api-auth-dto';
 export {
@@ -29,6 +33,12 @@ export {
   requireAdminRole,
   revokeAdminGrant,
 } from '#core/admin-role.js';
+export {
+  bootstrapFirstAdminOwner,
+  grantAdministratorRole,
+  listAdministratorGrants,
+  revokeAdministratorGrant,
+} from '#core/administration.js';
 export type {
   CreateSessionForUserError,
   CreateSessionForUserParams,
@@ -41,9 +51,14 @@ export {findUserByEmail} from '#core/email-owner.js';
 export type {AdminGrant} from '#core/entities/admin-grant.js';
 export type {User, UserStatus} from '#core/entities/user.js';
 export {
+  AdminBootstrapClosedError,
+  AdminGrantAlreadyExistsError,
+  AdminGrantNotFoundError,
+  AdminIdempotencyKeyReuseError,
   AdminRoleRequiredError,
   AuthDependencyUnavailableError,
   EmailNotVerifiedError,
+  InvalidAdminBootstrapTokenError,
   InvalidCredentialsError,
   LastAdminOwnerError,
   SignupNotAllowedError,
@@ -95,9 +110,12 @@ export function createAuthModule({
     database: {db, migrationsPath, databaseNamespace: 'auth'},
     auth: [createJwtAuthMethod(), createLeaseTokenAuthMethod(), createRunnerSessionAuthMethod()],
     loginMethods: passwordLoginMethods(config.AUTH_PASSWORD_ENABLED),
-    routes: [buildAuthRoutes(config.AUTH_PASSWORD_ENABLED, workspaces, signupPolicy)],
+    routes: [
+      buildAuthRoutes(config.AUTH_PASSWORD_ENABLED, workspaces, signupPolicy),
+      administrationRoutes,
+    ],
     e2eRoutes: [createAuthE2eRoutes(workspaces)],
-    publishers: [{name: 'auth', table: authOutbox, db, eventSchemas: authEventSchemas}],
+    publishers: [{name: 'auth', table: authOutbox, db, eventSchemas: authPublisherEventSchemas}],
     subscribers: [subscriber(AUTH_PASSWORD_RESET_SEND_REQUESTED, onPasswordResetSendRequested)],
     interModulePresentations: [createAuthInterModulePresentation()],
   };

--- a/libs/api/auth/src/metrics/instance.ts
+++ b/libs/api/auth/src/metrics/instance.ts
@@ -3,7 +3,7 @@ import {instanceMetrics} from '@shipfox/node-opentelemetry';
 export type AuthTokenType = 'session' | 'job_lease' | 'runner_session';
 export type AuthTokenVerificationOutcome = 'ok' | 'rejected';
 export type AuthTokenRefreshOutcome = 'rotated' | 'grace' | 'rejected';
-export type AuthRateLimitAction = 'login' | 'email-send';
+export type AuthRateLimitAction = 'login' | 'email-send' | 'bootstrap';
 export type AuthRateLimitScope = 'ip' | 'email';
 export type AuthRateLimitOutcome = 'allowed' | 'blocked' | 'unavailable';
 

--- a/libs/api/auth/src/presentation/routes/administration.test.ts
+++ b/libs/api/auth/src/presentation/routes/administration.test.ts
@@ -1,0 +1,253 @@
+import {ADMINISTRATION_ACTION_PERFORMED} from '@shipfox/api-common-dto';
+import {sql} from 'drizzle-orm';
+import type {FastifyInstance} from 'fastify';
+import {db} from '#db/db.js';
+import {authOutbox} from '#db/schema/outbox.js';
+import {createAuthTestApp, createVerifiedSession, resetCapturedMail} from '#test/routes.js';
+
+const BOOTSTRAP_TOKEN = 'test-bootstrap-token';
+
+async function resetAdministrationState(): Promise<void> {
+  await db().execute(
+    sql`TRUNCATE auth_admin_command_results, auth_admin_grants, auth_outbox, auth_rate_limits CASCADE`,
+  );
+}
+
+function authHeaders(token: string, idempotencyKey: string) {
+  return {
+    authorization: `Bearer ${token}`,
+    'idempotency-key': idempotencyKey,
+  };
+}
+
+describe('Auth administration routes', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = await createAuthTestApp();
+  });
+
+  beforeEach(async () => {
+    resetCapturedMail();
+    await resetAdministrationState();
+  });
+
+  afterAll(async () => {
+    await resetAdministrationState();
+    await app.close();
+  });
+
+  test('requires an authenticated session for bootstrap', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/admin/v1/auth/admin-grants/bootstrap',
+      headers: {'idempotency-key': 'anonymous-bootstrap'},
+      payload: {bootstrap_token: BOOTSTRAP_TOKEN},
+    });
+
+    expect(response.statusCode).toBe(401);
+  });
+
+  test('rejects an invalid bootstrap token without writing a grant or event', async () => {
+    const account = await createVerifiedSession('admin-bootstrap-invalid');
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/admin/v1/auth/admin-grants/bootstrap',
+      headers: authHeaders(account.token, 'invalid-bootstrap'),
+      payload: {bootstrap_token: 'wrong-token'},
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json().code).toBe('bootstrap-token-invalid');
+    await expect(db().select().from(authOutbox)).resolves.toHaveLength(0);
+  });
+
+  test('rate-limits repeated bootstrap attempts by source IP', async () => {
+    const account = await createVerifiedSession('admin-bootstrap-rate-limit');
+
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/admin/v1/auth/admin-grants/bootstrap',
+        headers: authHeaders(account.token, `bootstrap-rate-limit-${attempt}`),
+        payload: {bootstrap_token: 'wrong-token'},
+      });
+      expect(response.statusCode).toBe(403);
+    }
+
+    const blocked = await app.inject({
+      method: 'POST',
+      url: '/admin/v1/auth/admin-grants/bootstrap',
+      headers: authHeaders(account.token, 'bootstrap-rate-limit-blocked'),
+      payload: {bootstrap_token: 'wrong-token'},
+    });
+    expect(blocked.statusCode).toBe(429);
+    expect(blocked.json().code).toBe('rate-limited');
+  });
+
+  test('bootstraps exactly one owner and permanently closes bootstrap', async () => {
+    const first = await createVerifiedSession('admin-bootstrap-first');
+    const second = await createVerifiedSession('admin-bootstrap-second');
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/admin/v1/auth/admin-grants/bootstrap',
+      headers: authHeaders(first.token, 'bootstrap-first'),
+      payload: {bootstrap_token: BOOTSTRAP_TOKEN},
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(response.json()).toMatchObject({user_id: first.userId, role: 'admin-owner'});
+
+    const repeated = await app.inject({
+      method: 'POST',
+      url: '/admin/v1/auth/admin-grants/bootstrap',
+      headers: authHeaders(first.token, 'bootstrap-first'),
+      payload: {bootstrap_token: BOOTSTRAP_TOKEN},
+    });
+    expect(repeated.statusCode).toBe(201);
+    expect(repeated.json().id).toBe(response.json().id);
+
+    const secondAttempt = await app.inject({
+      method: 'POST',
+      url: '/admin/v1/auth/admin-grants/bootstrap',
+      headers: authHeaders(second.token, 'bootstrap-second'),
+      payload: {bootstrap_token: BOOTSTRAP_TOKEN},
+    });
+    expect(secondAttempt.statusCode).toBe(409);
+    expect(secondAttempt.json().code).toBe('bootstrap-closed');
+
+    const events = await db().select().from(authOutbox);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.eventType).toBe(ADMINISTRATION_ACTION_PERFORMED);
+    expect(events[0]?.payload).toMatchObject({
+      actorId: first.userId,
+      actorRole: 'admin-owner',
+      requiredRole: 'admin-owner',
+      command: 'auth.admin_grant.bootstrap',
+      result: 'succeeded',
+    });
+    expect(JSON.stringify(events[0]?.payload)).not.toContain(BOOTSTRAP_TOKEN);
+  });
+
+  test('lets an owner list, grant, and revoke roles with idempotent audited mutations', async () => {
+    const owner = await createVerifiedSession('admin-grant-owner');
+    const target = await createVerifiedSession('admin-grant-target');
+
+    const bootstrap = await app.inject({
+      method: 'POST',
+      url: '/admin/v1/auth/admin-grants/bootstrap',
+      headers: authHeaders(owner.token, 'grant-bootstrap'),
+      payload: {bootstrap_token: BOOTSTRAP_TOKEN},
+    });
+    expect(bootstrap.statusCode).toBe(201);
+
+    const grant = await app.inject({
+      method: 'POST',
+      url: '/admin/v1/auth/admin-grants',
+      headers: authHeaders(owner.token, 'grant-observer'),
+      payload: {
+        user_id: target.userId,
+        role: 'admin-observer',
+        reason: 'Support investigation',
+      },
+    });
+    expect(grant.statusCode).toBe(201);
+
+    const repeatedGrant = await app.inject({
+      method: 'POST',
+      url: '/admin/v1/auth/admin-grants',
+      headers: authHeaders(owner.token, 'grant-observer'),
+      payload: {
+        user_id: target.userId,
+        role: 'admin-observer',
+        reason: 'Support investigation',
+      },
+    });
+    expect(repeatedGrant.statusCode).toBe(201);
+    expect(repeatedGrant.json().id).toBe(grant.json().id);
+
+    const grants = await app.inject({
+      method: 'GET',
+      url: '/admin/v1/auth/admin-grants',
+      headers: {authorization: `Bearer ${owner.token}`},
+    });
+    expect(grants.statusCode).toBe(200);
+    expect(grants.json().grants).toEqual(
+      expect.arrayContaining([expect.objectContaining({user_id: target.userId})]),
+    );
+
+    const revoked = await app.inject({
+      method: 'DELETE',
+      url: `/admin/v1/auth/admin-grants/${grant.json().id}`,
+      headers: authHeaders(owner.token, 'revoke-observer'),
+      payload: {reason: 'Support investigation complete'},
+    });
+    expect(revoked.statusCode).toBe(200);
+    expect(revoked.json()).toMatchObject({id: grant.json().id, revoked_at: expect.any(String)});
+
+    const repeatedRevoke = await app.inject({
+      method: 'DELETE',
+      url: `/admin/v1/auth/admin-grants/${grant.json().id}`,
+      headers: authHeaders(owner.token, 'revoke-observer'),
+      payload: {reason: 'Support investigation complete'},
+    });
+    expect(repeatedRevoke.statusCode).toBe(200);
+    expect(repeatedRevoke.json().revoked_at).toBe(revoked.json().revoked_at);
+
+    const events = await db().select().from(authOutbox);
+    expect(events).toHaveLength(3);
+    expect(events.map((event) => event.eventType)).toEqual(
+      Array(3).fill(ADMINISTRATION_ACTION_PERFORMED),
+    );
+  });
+
+  test('protects the final active owner and rejects idempotency-key reuse', async () => {
+    const owner = await createVerifiedSession('admin-final-owner');
+    const target = await createVerifiedSession('admin-final-target');
+
+    await app.inject({
+      method: 'POST',
+      url: '/admin/v1/auth/admin-grants/bootstrap',
+      headers: authHeaders(owner.token, 'final-bootstrap'),
+      payload: {bootstrap_token: BOOTSTRAP_TOKEN},
+    });
+
+    const firstGrant = await app.inject({
+      method: 'POST',
+      url: '/admin/v1/auth/admin-grants',
+      headers: authHeaders(owner.token, 'role-key'),
+      payload: {user_id: target.userId, role: 'admin-observer', reason: 'Initial review'},
+    });
+    expect(firstGrant.statusCode).toBe(201);
+
+    const reusedKey = await app.inject({
+      method: 'POST',
+      url: '/admin/v1/auth/admin-grants',
+      headers: authHeaders(owner.token, 'role-key'),
+      payload: {user_id: target.userId, role: 'admin-operator', reason: 'Different command'},
+    });
+    expect(reusedKey.statusCode).toBe(409);
+    expect(reusedKey.json().code).toBe('idempotency-key-reused');
+
+    const finalOwnerRevoke = await app.inject({
+      method: 'DELETE',
+      url: `/admin/v1/auth/admin-grants/${
+        (
+          await app.inject({
+            method: 'GET',
+            url: '/admin/v1/auth/admin-grants',
+            headers: {authorization: `Bearer ${owner.token}`},
+          })
+        )
+          .json()
+          .grants.find((grant: {user_id: string}) => grant.user_id === owner.userId).id
+      }`,
+      headers: authHeaders(owner.token, 'revoke-final-owner'),
+      payload: {reason: 'Attempt to remove final owner'},
+    });
+    expect(finalOwnerRevoke.statusCode).toBe(409);
+    expect(finalOwnerRevoke.json().code).toBe('last-owner');
+  });
+});

--- a/libs/api/auth/src/presentation/routes/administration.ts
+++ b/libs/api/auth/src/presentation/routes/administration.ts
@@ -1,0 +1,195 @@
+import {AUTH_USER} from '@shipfox/api-auth-context';
+import {
+  bootstrapAdminOwnerBodySchema,
+  bootstrapAdminOwnerResponseSchema,
+  grantAdminRoleBodySchema,
+  grantAdminRoleResponseSchema,
+  listAdminGrantsResponseSchema,
+  revokeAdminGrantBodySchema,
+  revokeAdminGrantResponseSchema,
+} from '@shipfox/api-auth-dto';
+import {ClientError, defineRoute, type RouteGroup} from '@shipfox/node-fastify';
+import type {FastifyRequest} from 'fastify';
+import {z} from 'zod';
+import {
+  bootstrapFirstAdminOwner,
+  grantAdministratorRole,
+  listAdministratorGrants,
+  revokeAdministratorGrant,
+} from '#core/administration.js';
+import type {AdminGrant} from '#core/entities/admin-grant.js';
+import {
+  AdminBootstrapClosedError,
+  AdminGrantAlreadyExistsError,
+  AdminGrantNotFoundError,
+  AdminIdempotencyKeyReuseError,
+  AdminRoleRequiredError,
+  InvalidAdminBootstrapTokenError,
+  LastAdminOwnerError,
+  UserNotFoundError,
+} from '#core/errors.js';
+import {getClientContext} from '#presentation/auth/jwt-auth.js';
+import {createAuthIpRateLimitPreHandler} from './rate-limit.js';
+
+const idempotencyKeyMaxLength = 256;
+
+function requireActorId(request: FastifyRequest): string {
+  const client = getClientContext(request);
+  if (!client) {
+    throw new ClientError('Authentication required', 'unauthorized', {status: 401});
+  }
+  return client.userId;
+}
+
+function requireIdempotencyKey(request: FastifyRequest): string {
+  const value = request.headers['idempotency-key'];
+  const key = Array.isArray(value) ? value[0] : value;
+  if (!key || key.trim().length === 0 || key.length > idempotencyKeyMaxLength) {
+    throw new ClientError('Idempotency-Key header is required', 'idempotency-key-required', {
+      status: 400,
+    });
+  }
+  return key;
+}
+
+function toAdminGrantDto(grant: AdminGrant) {
+  return {
+    id: grant.id,
+    user_id: grant.userId,
+    role: grant.role,
+    revoked_at: grant.revokedAt?.toISOString() ?? null,
+    created_at: grant.createdAt.toISOString(),
+    updated_at: grant.updatedAt.toISOString(),
+  };
+}
+
+function translateAdministrationError(error: unknown): never {
+  if (error instanceof AdminRoleRequiredError) {
+    throw new ClientError('Administrator owner role required', 'forbidden', {
+      status: 403,
+      details: {required_role: error.minimumRole},
+    });
+  }
+  if (error instanceof InvalidAdminBootstrapTokenError) {
+    throw new ClientError('Bootstrap token is invalid', 'bootstrap-token-invalid', {
+      status: 403,
+    });
+  }
+  if (error instanceof AdminBootstrapClosedError) {
+    throw new ClientError('First administrator owner already exists', 'bootstrap-closed', {
+      status: 409,
+    });
+  }
+  if (error instanceof AdminGrantAlreadyExistsError) {
+    throw new ClientError('Administrator grant already exists', 'grant-already-exists', {
+      status: 409,
+    });
+  }
+  if (error instanceof AdminGrantNotFoundError) {
+    throw new ClientError('Administrator grant not found', 'not-found', {status: 404});
+  }
+  if (error instanceof UserNotFoundError) {
+    throw new ClientError('User not found', 'not-found', {status: 404});
+  }
+  if (error instanceof LastAdminOwnerError) {
+    throw new ClientError('Cannot remove the final active administrator owner', 'last-owner', {
+      status: 409,
+    });
+  }
+  if (error instanceof AdminIdempotencyKeyReuseError) {
+    throw new ClientError(
+      'Idempotency-Key was already used for a different command',
+      'idempotency-key-reused',
+      {status: 409},
+    );
+  }
+  throw error;
+}
+
+const bootstrapRoute = defineRoute({
+  method: 'POST',
+  path: '/bootstrap',
+  description: 'Claim the first administrator owner role with the deployment bootstrap token.',
+  schema: {
+    body: bootstrapAdminOwnerBodySchema,
+    response: {201: bootstrapAdminOwnerResponseSchema},
+  },
+  preHandler: createAuthIpRateLimitPreHandler('bootstrap'),
+  errorHandler: translateAdministrationError,
+  handler: async (request, reply) => {
+    const actorId = requireActorId(request);
+    const grant = await bootstrapFirstAdminOwner({
+      actorId,
+      bootstrapToken: request.body.bootstrap_token,
+      idempotencyKey: requireIdempotencyKey(request),
+      correlationId: request.id,
+    });
+    reply.code(201);
+    return toAdminGrantDto(grant);
+  },
+});
+
+const listRoute = defineRoute({
+  method: 'GET',
+  path: '/',
+  description: 'List local administrator grants.',
+  schema: {response: {200: listAdminGrantsResponseSchema}},
+  errorHandler: translateAdministrationError,
+  handler: async (request) => ({
+    grants: (await listAdministratorGrants({actorId: requireActorId(request)})).map(
+      toAdminGrantDto,
+    ),
+  }),
+});
+
+const grantRoute = defineRoute({
+  method: 'POST',
+  path: '/',
+  description: 'Grant a local administrator role to an active user.',
+  schema: {
+    body: grantAdminRoleBodySchema,
+    response: {201: grantAdminRoleResponseSchema},
+  },
+  errorHandler: translateAdministrationError,
+  handler: async (request, reply) => {
+    const actorId = requireActorId(request);
+    const grant = await grantAdministratorRole({
+      actorId,
+      userId: request.body.user_id,
+      role: request.body.role,
+      reason: request.body.reason,
+      idempotencyKey: requireIdempotencyKey(request),
+      correlationId: request.id,
+    });
+    reply.code(201);
+    return toAdminGrantDto(grant);
+  },
+});
+
+const revokeRoute = defineRoute({
+  method: 'DELETE',
+  path: '/:grantId',
+  description: 'Revoke a local administrator grant.',
+  schema: {
+    params: z.object({grantId: z.string().uuid()}),
+    body: revokeAdminGrantBodySchema,
+    response: {200: revokeAdminGrantResponseSchema},
+  },
+  errorHandler: translateAdministrationError,
+  handler: async (request) => {
+    const grant = await revokeAdministratorGrant({
+      actorId: requireActorId(request),
+      grantId: request.params.grantId,
+      reason: request.body.reason,
+      idempotencyKey: requireIdempotencyKey(request),
+      correlationId: request.id,
+    });
+    return toAdminGrantDto(grant);
+  },
+});
+
+export const administrationRoutes: RouteGroup = {
+  prefix: '/admin/v1/auth/admin-grants',
+  auth: AUTH_USER,
+  routes: [bootstrapRoute, listRoute, grantRoute, revokeRoute],
+};

--- a/libs/api/auth/src/presentation/routes/rate-limit.ts
+++ b/libs/api/auth/src/presentation/routes/rate-limit.ts
@@ -8,7 +8,10 @@ import {
   checkAuthRateLimit,
 } from '#core/rate-limit.js';
 
-const policies: Record<AuthRateLimitAction, Record<AuthRateLimitScope, AuthRateLimitPolicy>> = {
+const policies: Record<
+  AuthRateLimitAction,
+  Partial<Record<AuthRateLimitScope, AuthRateLimitPolicy>>
+> = {
   login: {
     ip: {limit: 60, windowSeconds: 5 * 60},
     email: {limit: 10, windowSeconds: 15 * 60},
@@ -16,6 +19,9 @@ const policies: Record<AuthRateLimitAction, Record<AuthRateLimitScope, AuthRateL
   'email-send': {
     ip: {limit: 30, windowSeconds: 60 * 60},
     email: {limit: 3, windowSeconds: 60 * 60},
+  },
+  bootstrap: {
+    ip: {limit: 5, windowSeconds: 15 * 60},
   },
 };
 
@@ -34,12 +40,15 @@ async function enforceRateLimit(params: {
   scope: AuthRateLimitScope;
   identifier: string;
 }): Promise<void> {
+  const policy = policies[params.action][params.scope];
+  if (!policy) return;
+
   try {
     await checkAuthRateLimit({
       action: params.action,
       scope: params.scope,
       identifier: params.identifier,
-      ...policies[params.action][params.scope],
+      ...policy,
     });
   } catch (error) {
     if (error instanceof AuthRateLimitExceededError) {
@@ -114,6 +123,18 @@ export function createAuthRateLimitPreHandler(action: AuthRateLimitAction) {
       action,
       scope: 'email',
       identifier: request.body.email,
+    });
+  };
+}
+
+export function createAuthIpRateLimitPreHandler(action: AuthRateLimitAction) {
+  return async (request: FastifyRequest, reply: FastifyReply): Promise<void> => {
+    await enforceRateLimit({
+      request,
+      reply,
+      action,
+      scope: 'ip',
+      identifier: request.ip,
     });
   };
 }

--- a/libs/api/auth/test/globalSetup.ts
+++ b/libs/api/auth/test/globalSetup.ts
@@ -1,5 +1,8 @@
 import './env.js';
-import {initializeEmailChallengesForTests} from '@shipfox/api-email-challenges/test';
+import {
+  initializeEmailChallengesForTests,
+  resetEmailChallengesForTests,
+} from '@shipfox/api-email-challenges/test';
 import {runMigrations} from '@shipfox/node-drizzle';
 import {closePostgresClient, createPostgresClient} from '@shipfox/node-postgres';
 import {sql} from 'drizzle-orm';
@@ -11,8 +14,9 @@ export async function setup() {
 
   await runMigrations(db(), migrationsPath, '__drizzle_migrations_auth');
   await initializeEmailChallengesForTests();
+  await resetEmailChallengesForTests();
   await db().execute(
-    sql`TRUNCATE auth_admin_grants, auth_outbox, auth_password_resets, auth_rate_limits, auth_refresh_tokens, auth_users CASCADE`,
+    sql`TRUNCATE auth_admin_command_results, auth_admin_grants, auth_outbox, auth_password_resets, auth_rate_limits, auth_refresh_tokens, auth_users CASCADE`,
   );
 
   closeDb();

--- a/libs/api/auth/test/routes.ts
+++ b/libs/api/auth/test/routes.ts
@@ -8,6 +8,7 @@ import {and, desc, eq, sql} from 'drizzle-orm';
 import {db} from '#db/db.js';
 import {authOutbox} from '#db/schema/outbox.js';
 import {createJwtAuthMethod} from '#presentation/auth/jwt-auth.js';
+import {administrationRoutes} from '#presentation/routes/administration.js';
 import {buildAuthRoutes} from '#presentation/routes/index.js';
 
 const testConfig = vi.hoisted(
@@ -48,6 +49,7 @@ const workspaces = workspaceTestDoubles as unknown as WorkspacesInterModuleClien
 
 vi.mock('#config.js', () => ({
   config: {
+    ADMIN_BOOTSTRAP_TOKEN: 'test-bootstrap-token',
     AUTH_JWT_EXPIRES_IN: '15m',
     AUTH_REFRESH_TOKEN_EXPIRES_IN_DAYS: 14,
     AUTH_REFRESH_ROTATION_GRACE_SECONDS: 30,
@@ -147,7 +149,7 @@ export async function createAuthTestApp(params?: {
 }): Promise<FastifyInstance> {
   const appConfig: AppConfig = {
     auth: [createJwtAuthMethod()],
-    routes: [buildAuthRoutes(true, workspaces)],
+    routes: [buildAuthRoutes(true, workspaces), administrationRoutes],
     swagger: false,
   };
   if (params?.fastifyOptions) appConfig.fastifyOptions = params.fastifyOptions;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2169,6 +2169,9 @@ importers:
       '@shipfox/api-auth-dto':
         specifier: workspace:*
         version: link:../auth-dto
+      '@shipfox/api-common-dto':
+        specifier: workspace:*
+        version: link:../common-dto
       '@shipfox/api-email-challenges':
         specifier: workspace:*
         version: link:../email-challenges


### PR DESCRIPTION
Auth now owns the first-owner bootstrap and local administrator grant-management flow for the dashboard.

The change adds authenticated bootstrap with a deployment token, owner-only grant listing/grant/revoke routes, timing-safe token comparison, source-IP rate limiting, final-owner protection, and atomic idempotency-result plus redacted administration-event writes. DTO schemas and the Auth migration-backed command-result store complete the contract.

Validated with the full Auth suite (35 files, 218 tests), affected-package checks/types/dependency-cruise/build, database-boundary verification, published-artifact verification, and lockfile audit.

Closes ENG-1269

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds first-owner bootstrap and local admin grant management to `@shipfox/api-auth`, with owner-only routes, idempotent mutations, and audited outbox events. Implements ENG-1269 for secure bootstrap and role control in the dashboard, with README docs for setup and usage.

- **New Features**
  - First-owner bootstrap using `ADMIN_BOOTSTRAP_TOKEN` (timing-safe compare). Closes once an active owner exists.
  - Owner-only list, grant, and revoke routes; protects the final active owner.
  - Idempotent mutations stored in `auth_admin_command_results`; replays same result and rejects reused keys for different commands.
  - Redacted administration events published as `administration.action.performed`.
  - Source-IP rate limiting for bootstrap attempts.
  - Endpoints:
    - POST /admin/v1/auth/admin-grants/bootstrap
    - GET /admin/v1/auth/admin-grants
    - POST /admin/v1/auth/admin-grants
    - DELETE /admin/v1/auth/admin-grants/:grantId
  - README documents routes, rate limits, required env, and DB tables.

- **Migration**
  - Run Auth DB migrations.
  - Set `ADMIN_BOOTSTRAP_TOKEN` in environments before first bootstrap; remove or rotate after success.
  - No client changes required; server adds `@shipfox/api-common-dto` and new DTOs in `@shipfox/api-auth-dto`.

<sup>Written for commit 95b0fd89a69a71490c0fb5a777531b20901c2660. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

