### PR TITLE
Support independent stdout and OTLP log-level thresholds

### DIFF
--- a/.changeset/quiet-otel-logs.md
+++ b/.changeset/quiet-otel-logs.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/node-log": patch
+"@shipfox/node-opentelemetry": patch
+"@shipfox/api-server": patch
+---
+
+Adds independent stdout and file log thresholds and enables standard OpenTelemetry Pino log export in the API instrumentation preload.

--- a/libs/api/server/README.md
+++ b/libs/api/server/README.md
@@ -8,7 +8,7 @@ Runs a Shipfox API server.
 - **`createServer()`**: Builds an API server. The caller owns process signals.
 - **`runServer()`**: Starts the server. It listens for SIGTERM and SIGINT.
 - **`createLoginMethodsRoute()`**: Builds the public login-method catalog route. `createServer` mounts it automatically.
-- **Instrumentation preload**: Starts metrics early. Load it before feature modules.
+- **Instrumentation preload**: Starts metrics and optional logs early. Load it before feature modules.
 
 ## Installation
 

--- a/libs/api/server/src/instrumentation.ts
+++ b/libs/api/server/src/instrumentation.ts
@@ -8,5 +8,5 @@ const {version} = createRequire(import.meta.url)('../package.json') as {version:
 await startInstanceInstrumentation({
   serviceName: 'api',
   serviceVersion: version,
-  instrumentations: {fastify: true, http: true, pg: true, awsSdk: true},
+  instrumentations: {fastify: true, http: true, pg: true, awsSdk: true, pino: true},
 });

--- a/libs/shared/node/log/README.md
+++ b/libs/shared/node/log/README.md
@@ -18,9 +18,16 @@ Defaults include:
 Environment variables (via `@shipfox/config`):
 
 - `LOG_LEVEL` defaults to `info`. Set it to `silent` to suppress logs.
+- `LOG_STDOUT_LEVEL` defaults to `LOG_LEVEL`. It controls the minimum level written to stdout.
+- `LOG_FILE_LEVEL` defaults to `LOG_LEVEL`. It controls the minimum level written to `LOG_FILE`.
 - `LOG_PRETTY` defaults to `false`. Set it to `true` for pretty stdout logs.
 - `LOG_STDOUT` defaults to `true`. Set it to `false` to disable stdout logs.
 - `LOG_FILE` is optional. If set, logs are written to that file.
+
+`LOG_LEVEL` is the global minimum record level. Destination levels may be more
+restrictive, but not more verbose than `LOG_LEVEL`. A record written to stdout
+or the file is also available to OpenTelemetry when Pino instrumentation and an
+OTLP logs exporter are enabled.
 
 ## Installation
 
@@ -48,13 +55,16 @@ const moduleLogger = createLogger({
 moduleLogger.debug({ eventId: "evt_123" }, "Processing payment event");
 ```
 
-You can combine `LOG_PRETTY` and `LOG_LEVEL` during development for readability.
+You can combine `LOG_PRETTY` and `LOG_STDOUT_LEVEL` during development for
+readability. For example, `LOG_LEVEL=info` and `LOG_STDOUT_LEVEL=warn` keeps
+info records out of stdout while retaining them in the OpenTelemetry log stream.
 
 ## Development
 
 ```sh
 turbo check --filter=@shipfox/node-log
 turbo type --filter=@shipfox/node-log
+turbo test --filter=@shipfox/node-log
 ```
 
 ## License

--- a/libs/shared/node/log/package.json
+++ b/libs/shared/node/log/package.json
@@ -44,6 +44,7 @@
     "build": "shipfox-swc",
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
+    "test": "shipfox-vitest-run",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"
   },
@@ -56,6 +57,7 @@
     "@shipfox/biome": "workspace:*",
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
-    "@shipfox/typescript": "workspace:*"
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*"
   }
 }

--- a/libs/shared/node/log/src/config.test.ts
+++ b/libs/shared/node/log/src/config.test.ts
@@ -1,0 +1,18 @@
+import {describe, expect, it} from '@shipfox/vitest/vi';
+import {resolveDestinationLevel} from './config.js';
+
+describe('resolveDestinationLevel', () => {
+  it('defaults a destination to the global level', () => {
+    expect(resolveDestinationLevel(undefined, 'info', 'LOG_STDOUT_LEVEL')).toBe('info');
+  });
+
+  it('allows a destination to be more restrictive', () => {
+    expect(resolveDestinationLevel('warn', 'info', 'LOG_STDOUT_LEVEL')).toBe('warn');
+  });
+
+  it('rejects a destination that is more verbose than the global level', () => {
+    expect(() => resolveDestinationLevel('debug', 'info', 'LOG_STDOUT_LEVEL')).toThrow(
+      'LOG_STDOUT_LEVEL cannot be more verbose than LOG_LEVEL',
+    );
+  });
+});

--- a/libs/shared/node/log/src/config.ts
+++ b/libs/shared/node/log/src/config.ts
@@ -1,9 +1,33 @@
 import {bool, createConfig, str} from '@shipfox/config';
 
+export const logLevels = ['trace', 'debug', 'info', 'warn', 'error', 'fatal', 'silent'] as const;
+export type LogLevel = (typeof logLevels)[number];
+
+const levelRanks: Record<LogLevel, number> = {
+  trace: 0,
+  debug: 1,
+  info: 2,
+  warn: 3,
+  error: 4,
+  fatal: 5,
+  silent: 6,
+};
+
 export const config = createConfig({
   LOG_LEVEL: str({
     desc: 'Lowest log level that gets written. Accepts fatal, error, warn, info, debug, trace, or silent.',
+    choices: logLevels,
     default: 'info',
+  }),
+  LOG_STDOUT_LEVEL: str({
+    desc: 'Lowest log level written to standard output. Defaults to LOG_LEVEL and cannot be more verbose than LOG_LEVEL.',
+    choices: logLevels,
+    default: undefined,
+  }),
+  LOG_FILE_LEVEL: str({
+    desc: 'Lowest log level written to LOG_FILE. Defaults to LOG_LEVEL and cannot be more verbose than LOG_LEVEL.',
+    choices: logLevels,
+    default: undefined,
   }),
   LOG_PRETTY: bool({
     desc: 'Formats logs for human reading instead of JSON. Use it in local development.',
@@ -18,3 +42,15 @@ export const config = createConfig({
     default: undefined,
   }),
 });
+
+export function resolveDestinationLevel(
+  destination: LogLevel | undefined,
+  global: LogLevel,
+  destinationName: string,
+): LogLevel {
+  const resolved = destination ?? global;
+  if (levelRanks[resolved] < levelRanks[global]) {
+    throw new Error(`${destinationName} cannot be more verbose than LOG_LEVEL`);
+  }
+  return resolved;
+}

--- a/libs/shared/node/log/src/log.test.ts
+++ b/libs/shared/node/log/src/log.test.ts
@@ -1,0 +1,81 @@
+import {mkdtemp, readFile, rm} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+
+import {afterEach, describe, expect, it, vi} from '@shipfox/vitest/vi';
+import pino from 'pino';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+describe('log destination thresholds', () => {
+  it('applies the configured file threshold through the shared logger transport', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'shipfox-node-log-'));
+    const file = join(directory, 'application.log');
+
+    try {
+      vi.stubEnv('LOG_LEVEL', 'info');
+      vi.stubEnv('LOG_STDOUT_LEVEL', 'warn');
+      vi.stubEnv('LOG_FILE_LEVEL', 'error');
+      vi.stubEnv('LOG_STDOUT', 'false');
+      vi.stubEnv('LOG_FILE', file);
+      vi.stubEnv('LOG_PRETTY', 'false');
+      vi.resetModules();
+
+      const {createLogger} = await import('./log.js');
+      const logger = createLogger({});
+      logger.info('info');
+      logger.error('error');
+      await new Promise<void>((resolve, reject) =>
+        logger.flush((error?: Error) => (error ? reject(error) : resolve())),
+      );
+
+      await vi.waitFor(async () => {
+        const lines = (await readFile(file, 'utf8'))
+          .trim()
+          .split('\n')
+          .map((line) => JSON.parse(line).msg);
+        expect(lines).toEqual(['error']);
+      });
+    } finally {
+      await rm(directory, {recursive: true, force: true});
+    }
+  });
+
+  it('routes each accepted record to every destination at or above its threshold', () => {
+    const stdout: string[] = [];
+    const file: string[] = [];
+    const logger = pino(
+      {level: 'info'},
+      pino.multistream([
+        {level: 'warn', stream: {write: (line: string) => stdout.push(line)}},
+        {level: 'info', stream: {write: (line: string) => file.push(line)}},
+      ]),
+    );
+
+    logger.info('info');
+    logger.warn('warn');
+
+    expect(stdout.map((line) => JSON.parse(line).msg)).toEqual(['warn']);
+    expect(file.map((line) => JSON.parse(line).msg)).toEqual(['info', 'warn']);
+  });
+
+  it('drops records below the global level from every destination', () => {
+    const stdout: string[] = [];
+    const file: string[] = [];
+    const logger = pino(
+      {level: 'info'},
+      pino.multistream([
+        {level: 'warn', stream: {write: (line: string) => stdout.push(line)}},
+        {level: 'info', stream: {write: (line: string) => file.push(line)}},
+      ]),
+    );
+
+    logger.debug('debug');
+
+    expect(stdout).toEqual([]);
+    expect(file).toEqual([]);
+  });
+});

--- a/libs/shared/node/log/src/log.ts
+++ b/libs/shared/node/log/src/log.ts
@@ -1,49 +1,94 @@
-import {
-  type Level,
-  type LogFn,
-  type LoggerOptions,
-  pino,
-  stdSerializers,
-  stdTimeFunctions,
-  type TransportSingleOptions,
-} from 'pino';
-import {config} from './config.js';
+import {createRequire} from 'node:module';
+
+import type {Level, LogFn, LoggerOptions, TransportTargetOptions} from 'pino';
+import {config, resolveDestinationLevel} from './config.js';
 
 export type {Level, LogFn} from 'pino';
 
-const transports: TransportSingleOptions[] = [];
+type PinoModule = typeof import('pino');
+
+const require = createRequire(import.meta.url);
+let pinoModule: PinoModule | undefined;
+
+function getPino(): PinoModule {
+  if (!pinoModule) pinoModule = require('pino') as PinoModule;
+  return pinoModule;
+}
+
+const stdoutLevel = resolveDestinationLevel(
+  config.LOG_STDOUT_LEVEL,
+  config.LOG_LEVEL,
+  'LOG_STDOUT_LEVEL',
+);
+const fileLevel = resolveDestinationLevel(
+  config.LOG_FILE_LEVEL,
+  config.LOG_LEVEL,
+  'LOG_FILE_LEVEL',
+);
+
+const transports: TransportTargetOptions[] = [];
 if (config.LOG_STDOUT) {
   if (config.LOG_PRETTY) {
-    transports.push({target: 'pino-pretty', options: {colorize: true}});
+    transports.push({target: 'pino-pretty', level: stdoutLevel, options: {colorize: true}});
   } else {
-    transports.push({target: 'pino/file', options: {destination: 1}});
+    transports.push({target: 'pino/file', level: stdoutLevel, options: {destination: 1}});
   }
 }
 if (config.LOG_FILE) {
-  transports.push({target: 'pino/file', options: {destination: config.LOG_FILE, mkdir: true}});
+  transports.push({
+    target: 'pino/file',
+    level: fileLevel,
+    options: {destination: config.LOG_FILE, mkdir: true},
+  });
+}
+
+function createTransportStream() {
+  const pino = getPino();
+  return pino.multistream(
+    transports.map(({level, options, target}) => {
+      const stream =
+        options === undefined ? pino.transport({target}) : pino.transport({options, target});
+      return {level: level ?? config.LOG_LEVEL, stream};
+    }),
+  );
 }
 
 export const settings: LoggerOptions = {
   level: config.LOG_LEVEL,
   transport: {targets: transports},
-  timestamp: stdTimeFunctions.isoTime,
-  serializers: {
-    error: stdSerializers.errWithCause,
-    errors: (errors: unknown) => {
-      if (Array.isArray(errors))
-        return errors.map((error) => stdSerializers.errWithCause(error as Error));
-      return stdSerializers.errWithCause(errors as Error);
-    },
-    err: stdSerializers.errWithCause,
-    req: stdSerializers.req,
-    res: stdSerializers.res,
+  get timestamp() {
+    return getPino().stdTimeFunctions.isoTime;
+  },
+  get serializers() {
+    const {stdSerializers} = getPino();
+    return {
+      error: stdSerializers.errWithCause,
+      errors: (errors: unknown) => {
+        if (Array.isArray(errors))
+          return errors.map((error) => stdSerializers.errWithCause(error as Error));
+        return stdSerializers.errWithCause(errors as Error);
+      },
+      err: stdSerializers.errWithCause,
+      req: stdSerializers.req,
+      res: stdSerializers.res,
+    };
   },
 };
 
-const logger = pino(settings);
+type PinoLogger = Pick<ReturnType<PinoModule>, Level | 'flush'>;
+let logger: PinoLogger | undefined;
+
+function getLogger(): PinoLogger {
+  if (!logger) logger = createLogger({});
+  return logger;
+}
 
 export function createLogger(options: LoggerOptions) {
-  return pino({...settings, ...options});
+  const pino = getPino();
+  if (options.transport) return pino({...settings, ...options});
+
+  const {transport: _transport, ...loggerOptions} = {...settings, ...options};
+  return pino(loggerOptions, createTransportStream());
 }
 
 export type Logger = {
@@ -52,12 +97,19 @@ export type Logger = {
   flush: (cb?: (error?: Error) => void) => void;
 };
 
+function getLogMethod(level: Level): LogFn {
+  return (...args: unknown[]) => {
+    const currentLogger = getLogger();
+    Reflect.apply(currentLogger[level], currentLogger, args);
+  };
+}
+
 export const log: Logger = {
-  trace: logger.trace.bind(logger),
-  debug: logger.debug.bind(logger),
-  info: logger.info.bind(logger),
-  warn: logger.warn.bind(logger),
-  error: logger.error.bind(logger),
-  fatal: logger.fatal.bind(logger),
-  flush: logger.flush.bind(logger),
+  trace: getLogMethod('trace'),
+  debug: getLogMethod('debug'),
+  info: getLogMethod('info'),
+  warn: getLogMethod('warn'),
+  error: getLogMethod('error'),
+  fatal: getLogMethod('fatal'),
+  flush: (cb) => getLogger().flush(cb),
 };

--- a/libs/shared/node/log/vitest.config.ts
+++ b/libs/shared/node/log/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({}, import.meta.url) as UserConfigExport;

--- a/libs/shared/node/opentelemetry/README.md
+++ b/libs/shared/node/opentelemetry/README.md
@@ -1,6 +1,6 @@
 # Shipfox OpenTelemetry
 
-OpenTelemetry setup for Shipfox Node services. It starts tracing, Prometheus metrics, Fastify tracing, and trace-aware logging helpers.
+OpenTelemetry setup for Shipfox Node services. It starts tracing, OpenTelemetry logs, Prometheus metrics, Fastify tracing, and trace-aware logging helpers.
 
 ## What it does
 
@@ -10,17 +10,20 @@ OpenTelemetry setup for Shipfox Node services. It starts tracing, Prometheus met
 - **`getServiceMetricsProvider()`** returns the app metrics provider.
 - **`instanceMetrics`** re-exports OpenTelemetry `metrics`.
 - **`logger(options?)`** returns a logger with active trace IDs when a span exists.
-- **`shutdownInstrumentation()`** shuts down tracing and metrics.
+- **`shutdownInstrumentation()`** flushes and shuts down tracing, logs, and metrics.
 
 Environment variables:
 
 - `OTEL_SERVICE_NAME` is optional if you pass `serviceName` in code.
 - `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` is the exact OTLP HTTP trace endpoint.
-- `OTEL_EXPORTER_OTLP_ENDPOINT` is the base OTLP endpoint used when the trace-specific endpoint is unset.
-- `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_EXPORTER_OTLP_TIMEOUT`, and `OTEL_EXPORTER_OTLP_COMPRESSION` configure all OTLP signals. Their `OTEL_EXPORTER_OTLP_TRACES_*` variants take precedence for traces.
+- `OTEL_LOGS_EXPORTER` selects the standard logs exporter. Use `otlp` to export Pino records through OTLP or `none` to disable log export.
+- `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` is the exact OTLP HTTP logs endpoint. It takes precedence over the signal-independent endpoint.
+- `OTEL_EXPORTER_OTLP_ENDPOINT` is the base OTLP endpoint used when a signal-specific endpoint is unset.
+- `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_EXPORTER_OTLP_TIMEOUT`, and `OTEL_EXPORTER_OTLP_COMPRESSION` configure all OTLP signals. Their signal-specific `OTEL_EXPORTER_OTLP_TRACES_*` and `OTEL_EXPORTER_OTLP_LOGS_*` variants take precedence.
+- `OTEL_EXPORTER_OTLP_PROTOCOL` and `OTEL_EXPORTER_OTLP_LOGS_PROTOCOL` select the standard OTLP protocol.
 - `OTEL_RESOURCE_ATTRIBUTES` adds or overrides resource attributes such as deployment environment and release identity.
 - `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` configure the standard SDK sampler.
-- `OTEL_SDK_DISABLED` disables tracing and metrics when set to `true`.
+- `OTEL_SDK_DISABLED` disables tracing, logs, and metrics when set to `true`.
 - `OTEL_INSTANCE_METRICS_PORT` defaults to `9464`.
 - `OTEL_SERVICE_METRICS_PORT` defaults to `9474`.
 - `OTEL_DIAG_LOG_LEVEL` defaults to `none`.
@@ -86,7 +89,13 @@ meter.addBatchObservableCallback((observableResult) => {
 });
 ```
 
-## Traces (OTLP over HTTP)
+## Logs and traces
+
+Pino instrumentation sends records to the OpenTelemetry Logs API while the
+original Pino stream continues to receive records for stdout and file targets.
+Set `OTEL_LOGS_EXPORTER=otlp` and `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` to export
+logs. The SDK batches records and `shutdownInstrumentation()` flushes accepted
+records before returning.
 
 Set `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` to an exact OTLP HTTP trace endpoint, or set `OTEL_EXPORTER_OTLP_ENDPOINT` to a base endpoint. Leave both unset to disable trace export.
 
@@ -95,6 +104,8 @@ Set `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` to an exact OTLP HTTP trace endpoint, o
 ```bash
 export OTEL_SERVICE_NAME="billing-api"
 export OTEL_EXPORTER_OTLP_ENDPOINT="http://otel-collector:4318"
+export OTEL_LOGS_EXPORTER="otlp"
+export OTEL_EXPORTER_OTLP_LOGS_ENDPOINT="http://otel-collector:4318/v1/logs"
 export OTEL_RESOURCE_ATTRIBUTES="service.version=1.2.3,deployment.environment=production"
 export OTEL_INSTANCE_METRICS_PORT="9464"
 export OTEL_SERVICE_METRICS_PORT="9474"

--- a/libs/shared/node/opentelemetry/package.json
+++ b/libs/shared/node/opentelemetry/package.json
@@ -67,6 +67,8 @@
     "@shipfox/regex": "workspace:*"
   },
   "devDependencies": {
+    "@opentelemetry/api-logs": "catalog:",
+    "@opentelemetry/sdk-logs": "catalog:",
     "@shipfox/biome": "workspace:*",
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",

--- a/libs/shared/node/opentelemetry/src/common.ts
+++ b/libs/shared/node/opentelemetry/src/common.ts
@@ -20,7 +20,7 @@ export const env = createConfig({
     default: undefined,
   }),
   OTEL_EXPORTER_OTLP_ENDPOINT: url({
-    desc: 'Base OTLP endpoint used to export traces. The exporter appends /v1/traces. Leave it unset with OTEL_EXPORTER_OTLP_TRACES_ENDPOINT to disable trace export.',
+    desc: 'Base OTLP endpoint used to export telemetry signals. Signal-specific endpoints take precedence.',
     default: undefined,
   }),
   OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: url({
@@ -28,7 +28,7 @@ export const env = createConfig({
     default: undefined,
   }),
   OTEL_SDK_DISABLED: bool({
-    desc: 'Disables all OpenTelemetry tracing and metrics when set to true.',
+    desc: 'Disables all OpenTelemetry tracing, logs, and metrics when set to true.',
     default: false,
   }),
 });

--- a/libs/shared/node/opentelemetry/src/instance.test.ts
+++ b/libs/shared/node/opentelemetry/src/instance.test.ts
@@ -1,0 +1,109 @@
+import {context, type Span, TraceFlags, trace} from '@opentelemetry/api';
+import {logs} from '@opentelemetry/api-logs';
+import {PinoInstrumentation} from '@opentelemetry/instrumentation-pino';
+import {resourceFromAttributes} from '@opentelemetry/resources';
+import {InMemoryLogRecordExporter, SimpleLogRecordProcessor} from '@opentelemetry/sdk-logs';
+import {NodeSDK} from '@opentelemetry/sdk-node';
+import {createLogger} from '@shipfox/node-log';
+import {afterEach, beforeEach, describe, expect, it} from '@shipfox/vitest/vi';
+import {logger as contextLogger} from './logger.js';
+
+let exporter: InMemoryLogRecordExporter;
+let sdk: NodeSDK;
+let instrumentation: PinoInstrumentation;
+
+beforeEach(() => {
+  exporter = new InMemoryLogRecordExporter();
+  instrumentation = new PinoInstrumentation();
+  sdk = new NodeSDK({
+    autoDetectResources: false,
+    instrumentations: [instrumentation],
+    logRecordProcessors: [new SimpleLogRecordProcessor(exporter)],
+    metricReaders: [],
+    resource: resourceFromAttributes({'service.name': 'telemetry-test'}),
+    spanProcessors: [],
+  });
+  sdk.start();
+});
+
+afterEach(async () => {
+  instrumentation.disable();
+  await sdk.shutdown();
+  logs.disable();
+});
+
+describe('Pino log export', () => {
+  it('sends shared logger records to OTLP with trace context and resource metadata', async () => {
+    const logger = createLogger({
+      level: 'info',
+      transport: {target: 'pino/file', options: {destination: '/dev/null'}},
+    });
+
+    const traceId = '4bf92f3577b34da6a3ce929d0e0e4736';
+    const activeContext = trace.setSpan(context.active(), {
+      spanContext: () => ({
+        traceId,
+        spanId: '00f067aa0ba902b7',
+        traceFlags: TraceFlags.SAMPLED,
+        isRemote: false,
+      }),
+    } as unknown as Span);
+
+    context.with(activeContext, () => {
+      logger.info({organizationId: 'org-123'}, 'info message');
+      logger.warn('warn message');
+      logger.error({err: new Error('boom'), operation: 'sync'}, 'error message');
+    });
+
+    await new Promise<void>((resolve, reject) =>
+      logger.flush((error?: Error) => (error ? reject(error) : resolve())),
+    );
+
+    const records = [...exporter.getFinishedLogRecords()];
+    const firstRecord = records[0];
+    const errorRecord = records[2];
+    expect(records).toHaveLength(3);
+    expect(records.map((record) => record.body)).toEqual([
+      'info message',
+      'warn message',
+      'error message',
+    ]);
+    expect(firstRecord).toMatchObject({
+      attributes: {organizationId: 'org-123'},
+      resource: {attributes: {'service.name': 'telemetry-test'}},
+      severityText: 'info',
+      spanContext: {traceId},
+    });
+    expect(firstRecord?.attributes).not.toHaveProperty('trace_id');
+    expect(firstRecord?.attributes).not.toHaveProperty('span_id');
+    expect(errorRecord).toMatchObject({
+      attributes: {
+        'exception.message': 'boom',
+        'exception.type': 'Error',
+        operation: 'sync',
+      },
+      severityText: 'error',
+    });
+    expect(errorRecord?.hrTime).toBeDefined();
+
+    const configuredLogger = context.with(activeContext, () =>
+      contextLogger({
+        base: {component: 'context-aware'},
+        level: 'info',
+        transport: {target: 'pino/file', options: {destination: '/dev/null'}},
+      }),
+    );
+    context.with(activeContext, () => {
+      configuredLogger.info({requestId: 'req-123'}, 'context-aware message');
+    });
+    await new Promise<void>((resolve, reject) =>
+      configuredLogger.flush((error?: Error) => (error ? reject(error) : resolve())),
+    );
+
+    const contextRecord = exporter.getFinishedLogRecords()[3];
+    expect(contextRecord).toMatchObject({
+      attributes: {component: 'context-aware', requestId: 'req-123'},
+      spanContext: {traceId},
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ catalogs:
     '@opentelemetry/api':
       specifier: ^1.9.1
       version: 1.9.1
+    '@opentelemetry/api-logs':
+      specifier: ^0.219.0
+      version: 0.219.0
     '@opentelemetry/auto-instrumentations-node':
       specifier: ^0.77.0
       version: 0.77.0
@@ -141,6 +144,9 @@ catalogs:
     '@opentelemetry/resources':
       specifier: ^2.0.0
       version: 2.8.0
+    '@opentelemetry/sdk-logs':
+      specifier: ^0.219.0
+      version: 0.219.0
     '@opentelemetry/sdk-metrics':
       specifier: ^2.6.0
       version: 2.8.0
@@ -7002,6 +7008,9 @@ importers:
       '@shipfox/typescript':
         specifier: workspace:*
         version: link:../../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../../tools/vitest
 
   libs/shared/node/mailer:
     dependencies:
@@ -7161,6 +7170,12 @@ importers:
         specifier: workspace:*
         version: link:../../common/regex
     devDependencies:
+      '@opentelemetry/api-logs':
+        specifier: 'catalog:'
+        version: 0.219.0
+      '@opentelemetry/sdk-logs':
+        specifier: 'catalog:'
+        version: 0.219.0(@opentelemetry/api@1.9.1)
       '@shipfox/biome':
         specifier: workspace:*
         version: link:../../../../tools/biome

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,6 +31,7 @@ catalog:
   "@node-rs/argon2": "^2.0.2"
   "@octokit/webhooks": "^14.2.0"
   "@opentelemetry/api": "^1.9.1"
+  '@opentelemetry/api-logs': ^0.219.0
   "@opentelemetry/auto-instrumentations-node": "^0.77.0"
   "@opentelemetry/core": "^2.0.0"
   "@opentelemetry/exporter-prometheus": "^0.219.0"
@@ -47,6 +48,7 @@ catalog:
   "@opentelemetry/instrumentation-pino": "^0.65.0"
   "@opentelemetry/instrumentation-undici": "^0.29.0"
   "@opentelemetry/resources": "^2.0.0"
+  '@opentelemetry/sdk-logs': ^0.219.0
   "@opentelemetry/sdk-metrics": "^2.6.0"
   "@opentelemetry/sdk-node": "^0.219.0"
   "@opentelemetry/sdk-trace-node": "^2.6.0"


### PR DESCRIPTION
Adds independent stdout and file thresholds for `@shipfox/node-log` while preserving `LOG_LEVEL` as the global record floor. The API server instrumentation preload now enables Pino OpenTelemetry log export, with shared resource, trace-context, error-serialization, and shutdown coverage.

The default logger uses `pino.multistream` so destination thresholds remain effective even when only one output target is configured. Documentation, package metadata, and a patch Changeset are included.

Closes ENG-1284

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add independent stdout and file log-level thresholds to `@shipfox/node-log` and enable OTLP log export via Pino in the API server preload. This meets ENG-1284 by letting services keep verbose logs in OTLP while restricting stdout.

- **New Features**
  - `@shipfox/node-log`: new `LOG_STDOUT_LEVEL` and `LOG_FILE_LEVEL`, each defaulting to `LOG_LEVEL` and validated not to be more verbose than the global floor.
  - `LOG_LEVEL` remains the global minimum; `pino.multistream` keeps destination thresholds effective with any target mix.
  - `@shipfox/node-opentelemetry`: OTLP logs via Pino instrumentation with shared resource, trace context, error serialization, batching, and shutdown flush.
  - API server instrumentation preload enables `pino` logs export.
  - Backward compatible; stdout continues even if OTLP is disabled or fails.

- **Migration**
  - Set `LOG_LEVEL=info` and `LOG_STDOUT_LEVEL=warn` to limit stdout while keeping info in OTLP.
  - Enable OTLP logs with `OTEL_LOGS_EXPORTER=otlp` and `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` (or base `OTEL_EXPORTER_OTLP_ENDPOINT`).
  - No code changes; preload runs before app modules.

<sup>Written for commit 01837c7bc5cc9bc9ba0bb15ea5cb73dfb919b262. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

