### PR TITLE
[@shipfox/api-server] Expose Auth module factory

### DIFF
--- a/.changeset/auth-module-factory.md
+++ b/.changeset/auth-module-factory.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-server": minor
+---
+
+Expose an Auth module factory on `defaultModules()` for application-specific composition.

--- a/libs/api/server/README.md
+++ b/libs/api/server/README.md
@@ -5,6 +5,7 @@ Runs a Shipfox API server.
 ## What it does
 
 - **`defaultModules()`**: Returns the standard module list.
+- **`DefaultAuthModuleFactory`**: Builds the Auth module with the composed Workspaces client.
 - **`createServer()`**: Builds an API server. The caller owns process signals.
 - **`runServer()`**: Starts the server. It listens for SIGTERM and SIGINT.
 - **`createLoginMethodsRoute()`**: Builds the public login-method catalog route. `createServer` mounts it automatically.
@@ -30,6 +31,18 @@ than creating another inter-module transport:
 ```ts
 const modules = await defaultModules({
   extension: ({workspaces}) => [createCloudModule({workspaces})],
+});
+```
+
+To provide an Auth module with an application-specific signup policy, use the
+Auth factory. Its returned module is included in the standard composition and
+its inter-module presentations are registered with the same transport:
+
+```ts
+import {createAuthModule} from '@shipfox/api-auth';
+
+const modules = await defaultModules({
+  authModule: ({workspaces}) => createAuthModule({workspaces, signupPolicy}),
 });
 ```
 

--- a/libs/api/server/src/index.ts
+++ b/libs/api/server/src/index.ts
@@ -1,4 +1,5 @@
 export {
+  type DefaultAuthModuleFactory,
   type DefaultModulesExtension,
   type DefaultModulesOptions,
   type DefaultRunnersModuleFactory,

--- a/libs/api/server/src/modules.test.ts
+++ b/libs/api/server/src/modules.test.ts
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => ({
   buildAgentToolCatalogs: vi.fn(),
   buildAgentToolSelectionCatalogs: vi.fn(),
   createAgentModule: vi.fn(),
+  createAuthModule: vi.fn(),
   createDefinitionsModule: vi.fn(),
   createIntegrationsContext: vi.fn(),
   createLogsModule: vi.fn(),
@@ -51,20 +52,7 @@ vi.mock('@shipfox/annotations', () => ({
   },
 }));
 vi.mock('@shipfox/api-auth', () => ({
-  createAuthModule: () => ({
-    name: 'auth',
-    interModulePresentations: [
-      {
-        contract: authInterModuleContract,
-        handlers: {
-          mintJobLeaseToken: vi.fn(),
-          mintRunnerSessionToken: vi.fn(),
-          getCurrentAdminRole: vi.fn(),
-          requireAdminRole: vi.fn(),
-        },
-      },
-    ],
-  }),
+  createAuthModule: mocks.createAuthModule,
 }));
 vi.mock('@shipfox/api-agent', () => ({createAgentModule: mocks.createAgentModule}));
 vi.mock('@shipfox/api-auth/config', () => ({
@@ -121,6 +109,7 @@ describe('defaultModules', () => {
     mocks.buildAgentToolCatalogs.mockReset();
     mocks.buildAgentToolSelectionCatalogs.mockReset();
     mocks.createAgentModule.mockReset();
+    mocks.createAuthModule.mockReset();
     mocks.createDefinitionsModule.mockReset();
     mocks.createIntegrationsContext.mockReset();
     mocks.createLogsModule.mockReset();
@@ -157,6 +146,20 @@ describe('defaultModules', () => {
     mocks.buildAgentToolCatalogs.mockResolvedValue(new Map());
     mocks.buildAgentToolSelectionCatalogs.mockResolvedValue(new Map());
     mocks.createWorkspaceConnectionSnapshotLoader.mockReturnValue(vi.fn());
+    mocks.createAuthModule.mockReturnValue({
+      name: 'auth',
+      interModulePresentations: [
+        {
+          contract: authInterModuleContract,
+          handlers: {
+            mintJobLeaseToken: vi.fn(),
+            mintRunnerSessionToken: vi.fn(),
+            getCurrentAdminRole: vi.fn(),
+            requireAdminRole: vi.fn(),
+          },
+        },
+      ],
+    });
     mocks.deleteSecrets.mockResolvedValue({deleted: 1});
     mocks.getSecret.mockResolvedValue({value: 'secret'});
     mocks.listMembershipsForTokenClaims.mockResolvedValue({memberships: []});
@@ -291,6 +294,43 @@ describe('defaultModules', () => {
     await defaultModules();
 
     expect(mocks.createRunnersModule).toHaveBeenCalledWith({auth: expect.any(Object)});
+  });
+
+  it('uses the default Auth module factory when none is supplied', async () => {
+    await defaultModules();
+
+    expect(mocks.createAuthModule).toHaveBeenCalledWith({workspaces: expect.any(Object)});
+  });
+
+  it('composes Auth with the shared Workspaces client and registers the supplied module', async () => {
+    const signupPolicy = {isSignupAllowed: vi.fn().mockResolvedValue({allowed: true})};
+    const customAuthModule = mocks.createAuthModule();
+    mocks.createAuthModule.mockClear();
+    let extensionWorkspaces: WorkspacesInterModuleClient | undefined;
+    const extension = vi.fn(({workspaces}: {workspaces: WorkspacesInterModuleClient}) => {
+      extensionWorkspaces = workspaces;
+      return [];
+    });
+    const authModule = vi.fn(({workspaces}: {workspaces: WorkspacesInterModuleClient}) =>
+      mocks.createAuthModule({workspaces, signupPolicy}),
+    );
+
+    const modules = await defaultModules({authModule, extension});
+    const authWorkspaces = authModule.mock.calls[0]?.[0].workspaces;
+
+    expect(authModule).toHaveBeenCalledWith({workspaces: expect.any(Object)});
+    expect(mocks.createAuthModule).toHaveBeenCalledWith({
+      workspaces: authWorkspaces,
+      signupPolicy,
+    });
+    expect(extension).toHaveBeenCalledWith({workspaces: authWorkspaces});
+    expect(extensionWorkspaces).toBe(authWorkspaces);
+    expect(modules).toContain(customAuthModule);
+    expect(
+      modules.flatMap((module) =>
+        (module.interModulePresentations ?? []).map(({contract}) => contract.module),
+      ),
+    ).toContain(authInterModuleContract.module);
   });
 
   it('lets a host replace only the Runners module with the composed Auth client', async () => {

--- a/libs/api/server/src/modules.ts
+++ b/libs/api/server/src/modules.ts
@@ -40,10 +40,14 @@ import {logger} from '@shipfox/node-opentelemetry';
 
 export interface DefaultModulesOptions {
   webhookDeliverySource?: WebhookDeliverySource | undefined;
+  authModule?: DefaultAuthModuleFactory | undefined;
   runnersModule?: DefaultRunnersModuleFactory | undefined;
   extension?: DefaultModulesExtension | undefined;
 }
 
+export type DefaultAuthModuleFactory = (options: {
+  workspaces: WorkspacesInterModuleClient;
+}) => ShipfoxModule;
 export type DefaultRunnersModuleFactory = (options: {auth: AuthInterModuleClient}) => ShipfoxModule;
 export type DefaultModulesExtension = (options: {
   workspaces: WorkspacesInterModuleClient;
@@ -165,7 +169,7 @@ export async function defaultModules(
 
   const modules = [
     emailChallengesModule,
-    createAuthModule({workspaces: workspacesClient}),
+    (options.authModule ?? createAuthModule)({workspaces: workspacesClient}),
     workspacesModule,
     createSecretsModule(projectsClient),
     createAgentModule({secrets: secretsClient}),


### PR DESCRIPTION
## Summary

Expose an optional Auth module factory through `defaultModules()` so consumers can inject application-specific signup policy while keeping the composed Workspaces client and inter-module registration in the API Server composition root.

The default path remains unchanged. Cloud adoption follows in ENG-1257 after this upstream package is published.

Closes ENG-1286

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose an optional Auth module factory in `@shipfox/api-server` so hosts can inject app-specific signup policy while keeping the shared Workspaces client and default module wiring. Defaults are unchanged. Supports ENG-1286.

- **New Features**
  - Add `authModule` option to `defaultModules()` to supply a custom Auth module.
  - Share the composed Workspaces client with the factory and register its presentations on the same transport.
  - Export `DefaultAuthModuleFactory` from the package.
  - Update README with a usage example; fallback remains `createAuthModule({workspaces})`.

<sup>Written for commit 6828ea25ec076f7426c4f180bd5181325316aa51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

