### PR TITLE
Gate new workflow work by workspace state

### DIFF
--- a/.changeset/suspended-workspace-job-admission.md
+++ b/.changeset/suspended-workspace-job-admission.md
@@ -1,6 +1,6 @@
 ---
-"@shipfox/api-triggers": patch
-"@shipfox/api-workflows": patch
+"@shipfox/api-triggers": minor
+"@shipfox/api-workflows": minor
 "@shipfox/api-workflows-dto": minor
 ---
 

--- a/.changeset/suspended-workspace-job-admission.md
+++ b/.changeset/suspended-workspace-job-admission.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/api-triggers": patch
+"@shipfox/api-workflows": patch
+"@shipfox/api-workflows-dto": minor
+---
+
+Reject new workflow work for suspended or deleted workspaces with stable non-retryable results.

--- a/docs/architecture/job-admission-paths.md
+++ b/docs/architecture/job-admission-paths.md
@@ -1,7 +1,7 @@
 # Job-admission paths
 
 This document maps the current paths that can admit new workflow work. It is
-the source for the follow-up workspace-suspension gates.
+the source for workspace admission behavior.
 
 ## Workspace operating-state contract
 
@@ -14,19 +14,23 @@ The result contains only the checked `status` fact. The known
 not expose workspace details, membership, suspension commands, or dashboard
 data.
 
-The future admission gate uses `status: suspended` to reject new work with the
-stable `workspace-suspended` result. It does not recheck work that was already
-queued or running before suspension.
+The admission gate allows only `status: active`. It rejects `suspended` with
+the stable `workspace-suspended` result and `deleted` with
+`workspace-deleted`. A missing workspace produces `workspace-not-found`. The
+gate fails closed for any status that the contract does not define.
+
+The gate does not recheck work that was already queued or running before
+suspension. Those jobs continue through execution.
 
 ## Current inventory
 
-| Path | Intake and routing owner | Admission boundary owner | Gate location for ENG-1274 |
+| Path | Intake and routing owner | Admission boundary owner | Gate location |
 | --- | --- | --- | --- |
 | Manual workflow run | Triggers route `POST /triggers/:definitionId/fire-manual` and `fireManualSubscription` | Workflows | `createWorkflowsInterModulePresentation.startRunFromTrigger`, before `runWorkflow` |
 | Scheduled workflow run | Triggers cron worker and `fireCronSubscription` | Workflows | The same `startRunFromTrigger` presentation |
 | Integration webhook to a workflow trigger | The enabled integration provider receives the webhook; Integrations publishes `INTEGRATION_EVENT_RECEIVED`; Triggers runs `dispatchIntegrationEvent` | Workflows | The same `startRunFromTrigger` presentation |
-| Integration webhook to a listening job | Integrations and Triggers route the event through `routeEventToJobListeners`; Workflows buffers and materializes the listener execution in `deliverEventToListener` | Workflows | `createWorkflowsInterModulePresentation.deliverEventToJobListener`, before listener execution materialization |
-| User-requested rerun | Workflows route `POST /workflows/runs/:id/rerun` calls `createRerunWorkflowRun` | Workflows | `rerunRunRoute` and `createRerunWorkflowRun`, before the new attempt graph is persisted |
+| Integration webhook to a listening job | Integrations and Triggers route the event through `routeEventToJobListeners`; Workflows buffers and materializes the listener execution in `deliverEventToListener` | Workflows | `createWorkflowsInterModulePresentation.deliverEventToJobListener`, before materialization for `fire` deliveries; `resolve` deliveries intentionally bypass the gate |
+| User-requested rerun | Workflows route `POST /workflows/runs/:id/rerun` calls `createRerunWorkflowRun` | Workflows | `rerunRunRoute`, before `createRerunWorkflowRun` persists the new attempt graph |
 
 The webhook intake family currently includes the generic webhook, GitHub,
 Gitea, Linear, Sentry, and Slack provider route groups. They validate and
@@ -38,12 +42,24 @@ gate.
 
 Workflow orchestration later sends an already-materialized job execution to
 Runners through `enqueueJobExecution`. This is execution of existing work, not
-new workspace admission. The suspension change must not reject this path, so
+new workspace admission. The admission gate does not reject this path, so
 queued and running jobs can finish normally.
 
-## Follow-up ownership
+## Admission decisions
 
-ENG-1274 has one independently owned admission implementation package:
-`@shipfox/api-workflows`. Triggers and Integrations remain responsible for
-their intake and retry behavior. Workspaces remains responsible for the
-status fact. No dashboard suspension route is part of this inventory change.
+- `resolve` deliveries are exempt from the gate because they terminate existing
+  listener work and do not materialize a new job execution.
+- Reruns are gated in `rerunRunRoute`, immediately before
+  `createRerunWorkflowRun` persists the new attempt graph.
+- Already queued or running work is not rechecked after a workspace changes
+  status.
+- Admission failures are permanent. Triggers records and skips the event
+  instead of replaying it, so webhook events received while a workspace is
+  suspended are discarded and do not resume after reactivation.
+
+## Ownership
+
+`@shipfox/api-workflows` owns the shared admission gate. Triggers and
+Integrations remain responsible for their intake and retry behavior. Workspaces
+remains responsible for the operating-state fact. No dashboard suspension route
+is part of this inventory.

--- a/libs/api/server/src/modules.ts
+++ b/libs/api/server/src/modules.ts
@@ -180,6 +180,7 @@ export async function defaultModules(
       projects: projectsClient,
       runners: runnersClient,
       secrets: secretsClient,
+      workspaces: workspacesClient,
       integrations: integrationsClient,
     }),
     annotationsModule,

--- a/libs/api/triggers/src/core/dispatch-integration-event.ts
+++ b/libs/api/triggers/src/core/dispatch-integration-event.ts
@@ -29,8 +29,9 @@ export interface DispatchIntegrationEventParams {
 // nothing about github, gitlab, etc.
 //
 // Continue-on-error: every matched subscription and listener is attempted so one broken
-// subscription cannot starve its siblings. A permanent failure (deleted definition, project
-// mismatch) is recorded and skipped; a transient one is recorded and re-thrown so the outbox
+// subscription cannot starve its siblings. A permanent admission failure (deleted definition,
+// project mismatch, suspended workspace) is recorded and skipped; a transient one is recorded
+// and re-thrown so the outbox
 // replays the whole event and converges (succeeded siblings dedup on the idempotency key). The
 // event reaches a terminal outcome only when no transient error remains: `routed` if any run
 // was created or any listening job matched, `discarded` if nothing matched, otherwise `errored`.

--- a/libs/api/triggers/src/core/route-event-to-job-listeners.test.ts
+++ b/libs/api/triggers/src/core/route-event-to-job-listeners.test.ts
@@ -1,3 +1,5 @@
+import {workflowsInterModuleContract} from '@shipfox/api-workflows-dto/inter-module';
+import {createInterModuleKnownError} from '@shipfox/inter-module';
 import {jobListenerSubscriptionFactory} from '#test/index.js';
 import type {TriggerHistoryRecorder} from './record-trigger-history.js';
 
@@ -192,6 +194,34 @@ describe('routeEventToJobListeners', () => {
       deliveredCount: 1,
       transientErrored: true,
       transientError: error,
+    });
+  });
+
+  it.each([
+    'workspace-not-found',
+    'workspace-suspended',
+    'workspace-deleted',
+  ] as const)('does not retry a %s workspace listener delivery', async (code) => {
+    const workspaceId = crypto.randomUUID();
+    await jobListenerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'pull_request_review',
+    });
+    const error = createInterModuleKnownError(
+      workflowsInterModuleContract.methods.deliverEventToJobListener,
+      code,
+      {workspaceId},
+    );
+    deliverEventToListener.mockRejectedValueOnce(error);
+
+    const result = await route({workspaceId});
+
+    expect(listenerDispatchErrored).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      engagedCount: 1,
+      acceptedJobCount: 0,
+      transientErrored: false,
     });
   });
 

--- a/libs/api/triggers/src/core/route-event-to-job-listeners.ts
+++ b/libs/api/triggers/src/core/route-event-to-job-listeners.ts
@@ -3,7 +3,10 @@ import {findMatchingJobListenerSubscriptions} from '#db/job-listener-subscriptio
 import {evaluateStoredFilter, type StoredFilterEvaluation} from './config.js';
 import type {JobListenerSubscription} from './entities/job-listener-subscription.js';
 import {type TriggerHistoryRecorder, toReason} from './record-trigger-history.js';
-import type {WorkflowsModuleClient} from './workflows-client.js';
+import {
+  isPermanentDeliverEventToJobListenerError,
+  type WorkflowsModuleClient,
+} from './workflows-client.js';
 
 export interface RouteEventToJobListenersParams {
   workflows: WorkflowsModuleClient;
@@ -90,7 +93,7 @@ export async function routeEventToJobListeners(
     } catch (error) {
       dispatchErrorCount += 1;
       await params.history.listenerDispatchErrored(subscription, toReason(error));
-      if (!sawTransientError) {
+      if (!isPermanentDeliverEventToJobListenerError(error) && !sawTransientError) {
         sawTransientError = true;
         firstTransientError = error;
       }

--- a/libs/api/triggers/src/core/workflows-client.test.ts
+++ b/libs/api/triggers/src/core/workflows-client.test.ts
@@ -8,7 +8,10 @@ import {
   defineInterModulePresentation,
 } from '@shipfox/inter-module';
 import {createFakeInterModuleClients} from '@shipfox/node-module/inter-module/testing';
-import {isPermanentStartRunError} from './workflows-client.js';
+import {
+  isPermanentDeliverEventToJobListenerError,
+  isPermanentStartRunError,
+} from './workflows-client.js';
 
 const input = {
   workspaceId: '00000000-0000-4000-8000-000000000001',
@@ -24,6 +27,20 @@ const input = {
   idempotencyKey: 'subscription-1:event-1',
 };
 
+const listenerInput = {
+  jobId: '00000000-0000-4000-8000-000000000006',
+  disposition: 'fire' as const,
+  eventRef: 'event-1',
+  deliveryId: 'delivery-1',
+  source: 'github',
+  event: 'push',
+  provider: 'github',
+  payload: {action: 'opened'},
+  receivedAt: '2026-07-26T00:00:00.000Z',
+};
+
+const listenerErrorInput = {...listenerInput, jobId: '00000000-0000-4000-8000-000000000007'};
+
 function localWorkflowsClient(): WorkflowsModuleClient {
   return createFakeInterModuleClients({
     workflows: defineInterModulePresentation(workflowsInterModuleContract, {
@@ -35,7 +52,16 @@ function localWorkflowsClient(): WorkflowsModuleClient {
           {definitionId},
         );
       },
-      deliverEventToJobListener: () => ({buffered: true, skipped: false}),
+      deliverEventToJobListener: ({jobId}) => {
+        if (jobId === listenerErrorInput.jobId) {
+          throw createInterModuleKnownError(
+            workflowsInterModuleContract.methods.deliverEventToJobListener,
+            'workspace-not-found',
+            {workspaceId: input.workspaceId},
+          );
+        }
+        return {buffered: true, skipped: false};
+      },
       getStepLogContext: () => ({harness: 'pi' as const}),
       getLeasedAgentToolContext: () => ({
         workspaceId: '00000000-0000-4000-8000-000000000006',
@@ -61,6 +87,15 @@ async function runConsumerSuite(client: WorkflowsModuleClient): Promise<void> {
 
   const result = client.startRunFromTrigger({...input, definitionId: crypto.randomUUID()});
   await expect(result).rejects.toSatisfy(isPermanentStartRunError);
+
+  await expect(client.deliverEventToJobListener(listenerInput)).resolves.toEqual({
+    buffered: true,
+    skipped: false,
+  });
+  await expect(client.deliverEventToJobListener(listenerErrorInput)).rejects.toMatchObject({
+    code: 'workspace-not-found',
+    details: {workspaceId: input.workspaceId},
+  });
 }
 
 describe('WorkflowsModuleClient consumer parity', () => {
@@ -69,5 +104,19 @@ describe('WorkflowsModuleClient consumer parity', () => {
 
     await runConsumerSuite(local);
     await runConsumerSuite(serializedWorkflowsClient(local));
+  });
+
+  test.each([
+    'workspace-not-found',
+    'workspace-suspended',
+    'workspace-deleted',
+  ] as const)('treats a %s listener delivery as permanent', (code) => {
+    const error = createInterModuleKnownError(
+      workflowsInterModuleContract.methods.deliverEventToJobListener,
+      code,
+      {workspaceId: input.workspaceId},
+    );
+
+    expect(isPermanentDeliverEventToJobListenerError(error)).toBe(true);
   });
 });

--- a/libs/api/triggers/src/core/workflows-client.ts
+++ b/libs/api/triggers/src/core/workflows-client.ts
@@ -6,13 +6,42 @@ import {isInterModuleKnownError} from '@shipfox/inter-module';
 
 export type {WorkflowsModuleClient};
 
+type StartRunKnownError = NonNullable<ReturnType<typeof startRunKnownError>>;
+
 /**
  * Workflows declares only failures that can never succeed on retry for trigger
- * run creation. Every other outcome is opaque and must remain retryable because
- * it may have committed before the caller stopped waiting.
+ * run creation, including workspace admission failures. Every other outcome is
+ * opaque and must remain retryable because it may have committed before the
+ * caller stopped waiting.
  */
-export function isPermanentStartRunError(error: unknown): boolean {
+export function isPermanentStartRunError(error: unknown): error is StartRunKnownError {
   return isInterModuleKnownError(workflowsInterModuleContract.methods.startRunFromTrigger, error);
+}
+
+/** Known listener admission failures cannot succeed by replaying the same event. */
+export function isPermanentDeliverEventToJobListenerError(error: unknown): boolean {
+  return isInterModuleKnownError(
+    workflowsInterModuleContract.methods.deliverEventToJobListener,
+    error,
+  );
+}
+
+export function isWorkspaceSuspendedError(
+  error: unknown,
+): error is Extract<StartRunKnownError, {code: 'workspace-suspended'}> {
+  return isPermanentStartRunError(error) && error.code === 'workspace-suspended';
+}
+
+export function isWorkspaceNotFoundError(
+  error: unknown,
+): error is Extract<StartRunKnownError, {code: 'workspace-not-found'}> {
+  return isPermanentStartRunError(error) && error.code === 'workspace-not-found';
+}
+
+export function isWorkspaceDeletedError(
+  error: unknown,
+): error is Extract<StartRunKnownError, {code: 'workspace-deleted'}> {
+  return isPermanentStartRunError(error) && error.code === 'workspace-deleted';
 }
 
 export function isInterpolationUnresolvableError(

--- a/libs/api/triggers/src/presentation/routes/fire-manual.test.ts
+++ b/libs/api/triggers/src/presentation/routes/fire-manual.test.ts
@@ -89,6 +89,72 @@ describe('POST /:definitionId/fire-manual', () => {
     });
   });
 
+  test('maps suspended workspace to 409', async () => {
+    const definitionId = crypto.randomUUID();
+    await triggerSubscriptionFactory.create({workspaceId, workflowDefinitionId: definitionId});
+    fireManualSubscriptionMock.mockRejectedValue(
+      createInterModuleKnownError(
+        workflowsInterModuleContract.methods.startRunFromTrigger,
+        'workspace-suspended',
+        {workspaceId},
+      ),
+    );
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/${definitionId}/fire-manual`,
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json()).toMatchObject({
+      code: 'workspace-suspended',
+      message: 'Workspace is suspended',
+    });
+  });
+
+  test('maps missing workspace to 404', async () => {
+    const definitionId = crypto.randomUUID();
+    await triggerSubscriptionFactory.create({workspaceId, workflowDefinitionId: definitionId});
+    fireManualSubscriptionMock.mockRejectedValue(
+      createInterModuleKnownError(
+        workflowsInterModuleContract.methods.startRunFromTrigger,
+        'workspace-not-found',
+        {workspaceId},
+      ),
+    );
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/${definitionId}/fire-manual`,
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json()).toMatchObject({code: 'workspace-not-found', message: 'Workspace not found'});
+  });
+
+  test('maps deleted workspace to 404', async () => {
+    const definitionId = crypto.randomUUID();
+    await triggerSubscriptionFactory.create({workspaceId, workflowDefinitionId: definitionId});
+    fireManualSubscriptionMock.mockRejectedValue(
+      createInterModuleKnownError(
+        workflowsInterModuleContract.methods.startRunFromTrigger,
+        'workspace-deleted',
+        {workspaceId},
+      ),
+    );
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/${definitionId}/fire-manual`,
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json()).toMatchObject({code: 'workspace-deleted', message: 'Workspace is deleted'});
+  });
+
   test('returns 404 when the manual trigger is unavailable', async () => {
     const res = await app.inject({
       method: 'POST',

--- a/libs/api/triggers/src/presentation/routes/fire-manual.ts
+++ b/libs/api/triggers/src/presentation/routes/fire-manual.ts
@@ -8,7 +8,12 @@ import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
 import {ManualTriggerNotFoundError} from '#core/errors.js';
 import {fireManualSubscription} from '#core/fire-manual.js';
-import {isInterpolationUnresolvableError} from '#core/workflows-client.js';
+import {
+  isInterpolationUnresolvableError,
+  isWorkspaceDeletedError,
+  isWorkspaceNotFoundError,
+  isWorkspaceSuspendedError,
+} from '#core/workflows-client.js';
 import {getManualSubscriptionByDefinitionId} from '#db/subscriptions.js';
 
 export function createFireManualTriggerRoute(workflows: WorkflowsModuleClient) {
@@ -36,6 +41,24 @@ export function createFireManualTriggerRoute(workflows: WorkflowsModuleClient) {
     errorHandler: (error) => {
       if (error instanceof ManualTriggerNotFoundError) {
         throw new ClientError(error.message, 'manual-trigger-not-found', {status: 404});
+      }
+      if (isWorkspaceSuspendedError(error)) {
+        throw new ClientError('Workspace is suspended', 'workspace-suspended', {
+          status: 409,
+          cause: error,
+        });
+      }
+      if (isWorkspaceDeletedError(error)) {
+        throw new ClientError('Workspace is deleted', 'workspace-deleted', {
+          status: 404,
+          cause: error,
+        });
+      }
+      if (isWorkspaceNotFoundError(error)) {
+        throw new ClientError('Workspace not found', 'workspace-not-found', {
+          status: 404,
+          cause: error,
+        });
       }
       if (isInterpolationUnresolvableError(error)) {
         throw new ClientError(

--- a/libs/api/workflows-dto/src/inter-module.test.ts
+++ b/libs/api/workflows-dto/src/inter-module.test.ts
@@ -47,6 +47,9 @@ describe('workflowsInterModuleContract', () => {
   });
 
   test.each([
+    ['workspace-not-found', {workspaceId: '00000000-0000-4000-8000-000000000010'}],
+    ['workspace-suspended', {workspaceId: '00000000-0000-4000-8000-000000000010'}],
+    ['workspace-deleted', {workspaceId: '00000000-0000-4000-8000-000000000010'}],
     ['definition-not-found', {definitionId: '00000000-0000-4000-8000-000000000001'}],
     ['project-mismatch', {}],
     ['agent-config-unresolvable', {definitionId: '00000000-0000-4000-8000-000000000001'}],
@@ -66,6 +69,16 @@ describe('workflowsInterModuleContract', () => {
     const parsed = schema.parse(details);
 
     expect(parsed).toEqual(details);
+  });
+
+  test.each([
+    ['workspace-not-found', {workspaceId: '00000000-0000-4000-8000-000000000010'}],
+    ['workspace-suspended', {workspaceId: '00000000-0000-4000-8000-000000000010'}],
+    ['workspace-deleted', {workspaceId: '00000000-0000-4000-8000-000000000010'}],
+  ] as const)('defines the %s listener-delivery failure', (code, details) => {
+    const schema = workflowsInterModuleContract.methods.deliverEventToJobListener.errors[code];
+
+    expect(schema.parse(details)).toEqual(details);
   });
 
   test.each([

--- a/libs/api/workflows-dto/src/inter-module.ts
+++ b/libs/api/workflows-dto/src/inter-module.ts
@@ -57,6 +57,9 @@ export const workflowsInterModuleContract = defineInterModuleContract({
       }),
       output: z.object({id: idSchema, name: z.string()}),
       errors: {
+        'workspace-not-found': z.object({workspaceId: idSchema}),
+        'workspace-suspended': z.object({workspaceId: idSchema}),
+        'workspace-deleted': z.object({workspaceId: idSchema}),
         'definition-not-found': z.object({definitionId: idSchema}),
         'project-mismatch': z.object({}),
         'agent-config-unresolvable': z.object({definitionId: idSchema}),
@@ -83,6 +86,11 @@ export const workflowsInterModuleContract = defineInterModuleContract({
         receivedAt: z.string().datetime(),
       }),
       output: z.object({buffered: z.boolean(), skipped: z.boolean()}),
+      errors: {
+        'workspace-not-found': z.object({workspaceId: idSchema}),
+        'workspace-suspended': z.object({workspaceId: idSchema}),
+        'workspace-deleted': z.object({workspaceId: idSchema}),
+      },
     },
     getStepLogContext: {
       input: z.object({stepId: idSchema}),

--- a/libs/api/workflows/package.json
+++ b/libs/api/workflows/package.json
@@ -51,6 +51,7 @@
     "@shipfox/api-runners-dto": "workspace:*",
     "@shipfox/api-secrets-dto": "workspace:*",
     "@shipfox/api-workflows-dto": "workspace:*",
+    "@shipfox/api-workspaces-dto": "workspace:*",
     "@shipfox/inter-module": "workspace:*",
     "@shipfox/expression": "workspace:*",
     "@shipfox/node-drizzle": "workspace:*",

--- a/libs/api/workflows/src/core/errors.ts
+++ b/libs/api/workflows/src/core/errors.ts
@@ -17,6 +17,27 @@ export class ProjectMismatchError extends Error {
   }
 }
 
+export class WorkspaceSuspendedError extends Error {
+  constructor(readonly workspaceId: string) {
+    super(`Workspace is suspended: ${workspaceId}`);
+    this.name = 'WorkspaceSuspendedError';
+  }
+}
+
+export class WorkspaceDeletedError extends Error {
+  constructor(readonly workspaceId: string) {
+    super(`Workspace is deleted: ${workspaceId}`);
+    this.name = 'WorkspaceDeletedError';
+  }
+}
+
+export class WorkspaceNotFoundError extends Error {
+  constructor(readonly workspaceId: string) {
+    super(`Workspace not found: ${workspaceId}`);
+    this.name = 'WorkspaceNotFoundError';
+  }
+}
+
 export class AgentConfigUnresolvableError extends Error {
   constructor(
     readonly definitionId: string,

--- a/libs/api/workflows/src/core/workspace-admission.test.ts
+++ b/libs/api/workflows/src/core/workspace-admission.test.ts
@@ -1,0 +1,64 @@
+import {workspacesInterModuleContract} from '@shipfox/api-workspaces-dto/inter-module';
+import {createInterModuleKnownError} from '@shipfox/inter-module';
+import {WorkspaceDeletedError, WorkspaceNotFoundError, WorkspaceSuspendedError} from './errors.js';
+import {assertWorkspaceAdmitsNewJobs} from './workspace-admission.js';
+
+const workspaceId = '00000000-0000-4000-8000-000000000001';
+
+describe('assertWorkspaceAdmitsNewJobs', () => {
+  test('allows active workspaces', async () => {
+    const getWorkspaceOperatingState = vi.fn().mockResolvedValue({status: 'active'});
+
+    await assertWorkspaceAdmitsNewJobs({getWorkspaceOperatingState}, workspaceId);
+
+    expect(getWorkspaceOperatingState).toHaveBeenCalledWith({workspaceId});
+  });
+
+  test.each([
+    ['suspended', WorkspaceSuspendedError],
+    ['deleted', WorkspaceDeletedError],
+  ] as const)('rejects %s workspaces', async (status, errorType) => {
+    const getWorkspaceOperatingState = vi.fn().mockResolvedValue({status});
+
+    await expect(
+      assertWorkspaceAdmitsNewJobs({getWorkspaceOperatingState}, workspaceId),
+    ).rejects.toBeInstanceOf(errorType);
+  });
+
+  test('translates a missing workspace from the Workspaces contract', async () => {
+    const error = createInterModuleKnownError(
+      workspacesInterModuleContract.methods.getWorkspaceOperatingState,
+      'workspace-not-found',
+      {workspaceId},
+    );
+    const getWorkspaceOperatingState = vi.fn().mockRejectedValue(error);
+
+    const caught = await assertWorkspaceAdmitsNewJobs(
+      {getWorkspaceOperatingState},
+      workspaceId,
+    ).catch((error: unknown) => error);
+
+    expect(caught).toBeInstanceOf(WorkspaceNotFoundError);
+    expect(caught).toMatchObject({
+      workspaceId,
+      name: 'WorkspaceNotFoundError',
+    });
+  });
+
+  test('rethrows transient Workspaces failures', async () => {
+    const error = new Error('workspace service unavailable');
+    const getWorkspaceOperatingState = vi.fn().mockRejectedValue(error);
+
+    await expect(
+      assertWorkspaceAdmitsNewJobs({getWorkspaceOperatingState}, workspaceId),
+    ).rejects.toBe(error);
+  });
+
+  test('fails closed for an unknown workspace status', async () => {
+    const getWorkspaceOperatingState = vi.fn().mockResolvedValue({status: 'unknown'});
+
+    await expect(
+      assertWorkspaceAdmitsNewJobs({getWorkspaceOperatingState}, workspaceId),
+    ).rejects.toThrow('Unhandled workspace status');
+  });
+});

--- a/libs/api/workflows/src/core/workspace-admission.ts
+++ b/libs/api/workflows/src/core/workspace-admission.ts
@@ -1,0 +1,43 @@
+import {
+  type WorkspacesInterModuleClient,
+  workspacesInterModuleContract,
+} from '@shipfox/api-workspaces-dto/inter-module';
+import {isInterModuleKnownError} from '@shipfox/inter-module';
+import {WorkspaceDeletedError, WorkspaceNotFoundError, WorkspaceSuspendedError} from './errors.js';
+
+export async function assertWorkspaceAdmitsNewJobs(
+  workspaces: Pick<WorkspacesInterModuleClient, 'getWorkspaceOperatingState'>,
+  workspaceId: string,
+): Promise<void> {
+  let state: Awaited<ReturnType<WorkspacesInterModuleClient['getWorkspaceOperatingState']>>;
+  try {
+    state = await workspaces.getWorkspaceOperatingState({workspaceId});
+  } catch (error) {
+    if (
+      isInterModuleKnownError(
+        workspacesInterModuleContract.methods.getWorkspaceOperatingState,
+        error,
+      ) &&
+      error.code === 'workspace-not-found'
+    ) {
+      throw new WorkspaceNotFoundError(error.details.workspaceId);
+    }
+    throw error;
+  }
+
+  const {status} = state;
+  switch (status) {
+    case 'active':
+      return;
+    case 'suspended':
+      throw new WorkspaceSuspendedError(workspaceId);
+    case 'deleted':
+      throw new WorkspaceDeletedError(workspaceId);
+    default:
+      return assertNever(status);
+  }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled workspace status: ${JSON.stringify(value)}`);
+}

--- a/libs/api/workflows/src/index.ts
+++ b/libs/api/workflows/src/index.ts
@@ -22,6 +22,7 @@ import {
   type WorkflowsEventMapDto,
   workflowsEventSchemas,
 } from '@shipfox/api-workflows-dto';
+import type {WorkspacesInterModuleClient} from '@shipfox/api-workspaces-dto/inter-module';
 import {type ShipfoxModule, subscriberFactory} from '@shipfox/node-module';
 import {db, migrationsPath, workflowsOutbox} from '#db/index.js';
 import {registerWorkflowsServiceMetrics} from '#metrics/index.js';
@@ -83,6 +84,7 @@ export function createWorkflowsModule({
   projects,
   runners,
   secrets,
+  workspaces,
 }: {
   agent: AgentInterModuleClient;
   definitions: DefinitionsInterModuleClient;
@@ -92,6 +94,7 @@ export function createWorkflowsModule({
   projects: ProjectsModuleClient;
   runners: RunnersInterModuleClient;
   secrets: SecretsInterModuleClient;
+  workspaces: WorkspacesInterModuleClient;
 }): ShipfoxModule {
   return {
     name: 'workflows',
@@ -104,6 +107,7 @@ export function createWorkflowsModule({
       projects,
       runners,
       secrets,
+      workspaces,
     }),
     metrics: registerWorkflowsServiceMetrics,
     publishers: [
@@ -135,6 +139,7 @@ export function createWorkflowsModule({
         projects,
         runners,
         secrets,
+        workspaces,
       }),
     ],
   };

--- a/libs/api/workflows/src/presentation/inter-module.test.ts
+++ b/libs/api/workflows/src/presentation/inter-module.test.ts
@@ -1,5 +1,6 @@
 import {workflowsInterModuleContract} from '@shipfox/api-workflows-dto/inter-module';
-import {isInterModuleKnownError} from '@shipfox/inter-module';
+import {workspacesInterModuleContract} from '@shipfox/api-workspaces-dto/inter-module';
+import {createInterModuleKnownError, isInterModuleKnownError} from '@shipfox/inter-module';
 import {InvalidJobRunnerLabelsError} from '#core/errors.js';
 import {
   AgentConfigUnresolvableError,
@@ -11,12 +12,16 @@ import {
 import {createWorkflowsInterModulePresentation, toStartRunKnownError} from './inter-module.js';
 
 const mocks = vi.hoisted(() => ({
+  deliverEventToListener: vi.fn(),
   getJobScope: vi.fn(),
   getStepById: vi.fn(),
   getStepByIdForJobExecution: vi.fn(),
 }));
 
 vi.mock('#db/index.js', () => mocks);
+vi.mock('#db/job-listener-events.js', () => ({
+  deliverEventToListener: mocks.deliverEventToListener,
+}));
 
 const input = {
   workspaceId: '00000000-0000-4000-8000-000000000001',
@@ -37,6 +42,8 @@ describe('Workflows inter-module presentation', () => {
     mocks.getJobScope.mockReset();
     mocks.getStepById.mockReset();
     mocks.getStepByIdForJobExecution.mockReset();
+    mocks.deliverEventToListener.mockReset();
+    mocks.deliverEventToListener.mockResolvedValue({buffered: true, skipped: false});
   });
 
   it('returns only the resolved harness for Logs', async () => {
@@ -48,6 +55,7 @@ describe('Workflows inter-module presentation', () => {
       projects: {} as never,
       runners: {} as never,
       secrets: {} as never,
+      workspaces: {getWorkspaceOperatingState: vi.fn()} as never,
     });
 
     const result = await presentation.handlers.getStepLogContext(
@@ -103,6 +111,7 @@ describe('Workflows inter-module presentation', () => {
       projects: {} as never,
       runners: runners as never,
       secrets: {} as never,
+      workspaces: {getWorkspaceOperatingState: vi.fn()} as never,
     });
 
     const result = await presentation.handlers.getLeasedAgentToolContext(input, {
@@ -145,5 +154,193 @@ describe('Workflows inter-module presentation', () => {
       isInterModuleKnownError(workflowsInterModuleContract.methods.startRunFromTrigger, result) &&
         result.code,
     ).toBe(code);
+  });
+
+  test('maps a missing workspace from the Workspace contract for start-run', async () => {
+    const getWorkspaceOperatingState = vi
+      .fn()
+      .mockRejectedValue(
+        createInterModuleKnownError(
+          workspacesInterModuleContract.methods.getWorkspaceOperatingState,
+          'workspace-not-found',
+          {workspaceId: input.workspaceId},
+        ),
+      );
+    const presentation = createWorkflowsInterModulePresentation({
+      agent: {} as never,
+      definitions: {} as never,
+      integrations: {} as never,
+      projects: {} as never,
+      runners: {} as never,
+      secrets: {} as never,
+      workspaces: {getWorkspaceOperatingState} as never,
+    });
+
+    const error = await Promise.resolve(
+      presentation.handlers.startRunFromTrigger(input, {
+        signal: new AbortController().signal,
+      }),
+    ).catch((caught: unknown) => caught);
+
+    expect(
+      isInterModuleKnownError(workflowsInterModuleContract.methods.startRunFromTrigger, error) &&
+        error.code,
+    ).toBe('workspace-not-found');
+  });
+
+  test.each([
+    ['suspended', 'workspace-suspended'],
+    ['deleted', 'workspace-deleted'],
+  ] as const)('rejects new workflow runs for %s workspaces before loading the definition', async (status, code) => {
+    const getWorkspaceOperatingState = vi.fn().mockResolvedValue({status});
+    const presentation = createWorkflowsInterModulePresentation({
+      agent: {} as never,
+      definitions: {} as never,
+      integrations: {} as never,
+      projects: {} as never,
+      runners: {} as never,
+      secrets: {} as never,
+      workspaces: {getWorkspaceOperatingState} as never,
+    });
+
+    const error = await Promise.resolve(
+      presentation.handlers.startRunFromTrigger(input, {
+        signal: new AbortController().signal,
+      }),
+    ).catch((caught: unknown) => caught);
+
+    expect(getWorkspaceOperatingState).toHaveBeenCalledWith({workspaceId: input.workspaceId});
+    expect(
+      isInterModuleKnownError(workflowsInterModuleContract.methods.startRunFromTrigger, error) &&
+        error.code,
+    ).toBe(code);
+  });
+
+  test('maps a missing workspace from the Workspace contract for listener delivery', async () => {
+    const jobId = '00000000-0000-4000-8000-000000000006';
+    const workspaceId = '00000000-0000-4000-8000-000000000007';
+    mocks.getJobScope.mockResolvedValue({workspaceId, projectId: input.projectId});
+    const getWorkspaceOperatingState = vi
+      .fn()
+      .mockRejectedValue(
+        createInterModuleKnownError(
+          workspacesInterModuleContract.methods.getWorkspaceOperatingState,
+          'workspace-not-found',
+          {workspaceId},
+        ),
+      );
+    const presentation = createWorkflowsInterModulePresentation({
+      agent: {} as never,
+      definitions: {} as never,
+      integrations: {} as never,
+      projects: {} as never,
+      runners: {} as never,
+      secrets: {} as never,
+      workspaces: {getWorkspaceOperatingState} as never,
+    });
+
+    const error = await Promise.resolve(
+      presentation.handlers.deliverEventToJobListener(
+        {
+          jobId,
+          disposition: 'fire',
+          eventRef: 'event-1',
+          deliveryId: 'delivery-1',
+          source: 'github',
+          event: 'push',
+          provider: 'github',
+          payload: {},
+          receivedAt: '2026-07-20T12:00:00.000Z',
+        },
+        {signal: new AbortController().signal},
+      ),
+    ).catch((caught: unknown) => caught);
+
+    expect(
+      isInterModuleKnownError(
+        workflowsInterModuleContract.methods.deliverEventToJobListener,
+        error,
+      ) && error.code,
+    ).toBe('workspace-not-found');
+  });
+
+  test.each([
+    ['suspended', 'workspace-suspended'],
+    ['deleted', 'workspace-deleted'],
+  ] as const)('rejects listener execution materialization for %s workspaces', async (status, code) => {
+    const jobId = '00000000-0000-4000-8000-000000000006';
+    const workspaceId = '00000000-0000-4000-8000-000000000007';
+    mocks.getJobScope.mockResolvedValue({workspaceId, projectId: input.projectId});
+    const getWorkspaceOperatingState = vi.fn().mockResolvedValue({status});
+    const presentation = createWorkflowsInterModulePresentation({
+      agent: {} as never,
+      definitions: {} as never,
+      integrations: {} as never,
+      projects: {} as never,
+      runners: {} as never,
+      secrets: {} as never,
+      workspaces: {getWorkspaceOperatingState} as never,
+    });
+
+    const error = await Promise.resolve(
+      presentation.handlers.deliverEventToJobListener(
+        {
+          jobId,
+          disposition: 'fire',
+          eventRef: 'event-1',
+          deliveryId: 'delivery-1',
+          source: 'github',
+          event: 'push',
+          provider: 'github',
+          payload: {},
+          receivedAt: '2026-07-20T12:00:00.000Z',
+        },
+        {signal: new AbortController().signal},
+      ),
+    ).catch((caught: unknown) => caught);
+
+    expect(getWorkspaceOperatingState).toHaveBeenCalledWith({workspaceId});
+    expect(mocks.deliverEventToListener).not.toHaveBeenCalled();
+    expect(
+      isInterModuleKnownError(
+        workflowsInterModuleContract.methods.deliverEventToJobListener,
+        error,
+      ) && error.code,
+    ).toBe(code);
+  });
+
+  test('allows resolve deliveries for suspended workspaces', async () => {
+    const jobId = '00000000-0000-4000-8000-000000000006';
+    mocks.getJobScope.mockResolvedValue({workspaceId: input.workspaceId});
+    const getWorkspaceOperatingState = vi.fn().mockResolvedValue({status: 'suspended'});
+    const presentation = createWorkflowsInterModulePresentation({
+      agent: {} as never,
+      definitions: {} as never,
+      integrations: {} as never,
+      projects: {} as never,
+      runners: {} as never,
+      secrets: {} as never,
+      workspaces: {getWorkspaceOperatingState} as never,
+    });
+
+    await expect(
+      presentation.handlers.deliverEventToJobListener(
+        {
+          jobId,
+          disposition: 'resolve',
+          eventRef: 'event-1',
+          deliveryId: 'delivery-1',
+          source: 'github',
+          event: 'push',
+          provider: 'github',
+          payload: {},
+          receivedAt: '2026-07-20T12:00:00.000Z',
+        },
+        {signal: new AbortController().signal},
+      ),
+    ).resolves.toEqual({buffered: true, skipped: false});
+    expect(mocks.getJobScope).not.toHaveBeenCalled();
+    expect(getWorkspaceOperatingState).not.toHaveBeenCalled();
+    expect(mocks.deliverEventToListener).toHaveBeenCalled();
   });
 });

--- a/libs/api/workflows/src/presentation/inter-module.ts
+++ b/libs/api/workflows/src/presentation/inter-module.ts
@@ -6,13 +6,20 @@ import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module'
 import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-module';
 import type {SecretsInterModuleClient} from '@shipfox/api-secrets-dto/inter-module';
 import {workflowsInterModuleContract} from '@shipfox/api-workflows-dto/inter-module';
+import type {WorkspacesInterModuleClient} from '@shipfox/api-workspaces-dto/inter-module';
 import {
   createInterModuleKnownError,
   defineInterModulePresentation,
+  type InterModuleKnownErrorFor,
   type InterModulePresentation,
 } from '@shipfox/inter-module';
 import {DEFAULT_HARNESS, harnessSchema} from '@shipfox/workflow-document';
-import {InvalidJobRunnerLabelsError} from '#core/errors.js';
+import {
+  InvalidJobRunnerLabelsError,
+  WorkspaceDeletedError,
+  WorkspaceNotFoundError,
+  WorkspaceSuspendedError,
+} from '#core/errors.js';
 import {
   AgentConfigUnresolvableError,
   AgentIntegrationMaterializationError,
@@ -21,12 +28,18 @@ import {
   ProjectMismatchError,
   runWorkflow,
 } from '#core/index.js';
+import {assertWorkspaceAdmitsNewJobs} from '#core/workspace-admission.js';
 import {getJobScope, getStepById, getStepByIdForJobExecution} from '#db/index.js';
 import {deliverEventToListener} from '#db/job-listener-events.js';
+
+type WorkspaceAdmissionKnownError = InterModuleKnownErrorFor<
+  typeof workflowsInterModuleContract.methods.deliverEventToJobListener
+>;
 
 export function createWorkflowsInterModulePresentation(params: {
   agent: AgentInterModuleClient;
   definitions: DefinitionsInterModuleClient;
+  workspaces: WorkspacesInterModuleClient;
   secrets: Pick<SecretsInterModuleClient, 'getVariablesByNamespace'>;
   runners: RunnersInterModuleClient;
   integrations: IntegrationsModuleClient;
@@ -35,6 +48,7 @@ export function createWorkflowsInterModulePresentation(params: {
   return defineInterModulePresentation(workflowsInterModuleContract, {
     startRunFromTrigger: async (input) => {
       try {
+        await assertWorkspaceAdmitsNewJobs(params.workspaces, input.workspaceId);
         const run = await runWorkflow(
           params.definitions,
           {
@@ -55,8 +69,20 @@ export function createWorkflowsInterModulePresentation(params: {
         throw toStartRunKnownError(error, input.definitionId);
       }
     },
-    deliverEventToJobListener: async (input) =>
-      await deliverEventToListener({...input, receivedAt: new Date(input.receivedAt)}),
+    deliverEventToJobListener: async (input) => {
+      const method = workflowsInterModuleContract.methods.deliverEventToJobListener;
+      try {
+        if (input.disposition === 'fire') {
+          const scope = await getJobScope(input.jobId);
+          if (scope) await assertWorkspaceAdmitsNewJobs(params.workspaces, scope.workspaceId);
+        }
+        return await deliverEventToListener({...input, receivedAt: new Date(input.receivedAt)});
+      } catch (error) {
+        const workspaceError = toWorkspaceAdmissionKnownError(method, error);
+        if (workspaceError !== undefined) throw workspaceError;
+        throw error;
+      }
+    },
     getStepLogContext: async ({stepId}) => {
       const step = await getStepById(stepId);
       const parsed = harnessSchema.safeParse(step?.config.harness);
@@ -98,6 +124,8 @@ export function createWorkflowsInterModulePresentation(params: {
 
 export function toStartRunKnownError(error: unknown, definitionId: string): unknown {
   const method = workflowsInterModuleContract.methods.startRunFromTrigger;
+  const workspaceError = toWorkspaceAdmissionKnownError(method, error);
+  if (workspaceError !== undefined) return workspaceError;
   if (error instanceof DefinitionNotFoundError) {
     return createInterModuleKnownError(method, 'definition-not-found', {definitionId});
   }
@@ -126,4 +154,28 @@ export function toStartRunKnownError(error: unknown, definitionId: string): unkn
     });
   }
   return error;
+}
+
+function toWorkspaceAdmissionKnownError(
+  method:
+    | typeof workflowsInterModuleContract.methods.startRunFromTrigger
+    | typeof workflowsInterModuleContract.methods.deliverEventToJobListener,
+  error: unknown,
+): WorkspaceAdmissionKnownError | undefined {
+  if (error instanceof WorkspaceSuspendedError) {
+    return createInterModuleKnownError(method, 'workspace-suspended', {
+      workspaceId: error.workspaceId,
+    });
+  }
+  if (error instanceof WorkspaceDeletedError) {
+    return createInterModuleKnownError(method, 'workspace-deleted', {
+      workspaceId: error.workspaceId,
+    });
+  }
+  if (error instanceof WorkspaceNotFoundError) {
+    return createInterModuleKnownError(method, 'workspace-not-found', {
+      workspaceId: error.workspaceId,
+    });
+  }
+  return undefined;
 }

--- a/libs/api/workflows/src/presentation/routes/index.test.ts
+++ b/libs/api/workflows/src/presentation/routes/index.test.ts
@@ -43,6 +43,7 @@ describe('workflow route auth', () => {
     projects: projectsTestClient,
     runners: runnersTestClient,
     secrets: createTestSecretsClient(),
+    workspaces: {getWorkspaceOperatingState: vi.fn()} as never,
   });
   test('uses user auth', () => {
     expect(workflowRoutes[0]?.auth).toBe(AUTH_USER);

--- a/libs/api/workflows/src/presentation/routes/index.ts
+++ b/libs/api/workflows/src/presentation/routes/index.ts
@@ -6,6 +6,7 @@ import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/i
 import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import type {RunnersInterModuleClient} from '@shipfox/api-runners-dto/inter-module';
 import type {SecretsInterModuleClient} from '@shipfox/api-secrets-dto/inter-module';
+import type {WorkspacesInterModuleClient} from '@shipfox/api-workspaces-dto/inter-module';
 import type {RouteGroup} from '@shipfox/node-fastify';
 import {createAgentRuntimeConfigRoute} from './agent-runtime-config.js';
 import {cancelRunRoute} from './cancel-run.js';
@@ -27,9 +28,12 @@ type WorkflowRouteClients = {
   projects: ProjectsModuleClient;
   runners: RunnersInterModuleClient;
   secrets: SecretsInterModuleClient;
+  workspaces: WorkspacesInterModuleClient;
 };
 
-export function createLeaseTokenRouteGroup(params: WorkflowRouteClients): RouteGroup {
+type LeaseTokenRouteClients = Omit<WorkflowRouteClients, 'workspaces'>;
+
+export function createLeaseTokenRouteGroup(params: LeaseTokenRouteClients): RouteGroup {
   return {
     // The lease token names the job, so the path carries no job id ("current").
     prefix: '/runs/jobs/current',
@@ -59,7 +63,7 @@ export function createWorkflowRoutes(params: WorkflowRouteClients): RouteGroup[]
         listRunAttemptsRoute(params.projects),
         getRunRoute(params.projects),
         cancelRunRoute(params.projects),
-        rerunRunRoute(params.projects),
+        rerunRunRoute(params.projects, params.workspaces),
       ],
     },
     createLeaseTokenRouteGroup(params),

--- a/libs/api/workflows/src/presentation/routes/rerun-run.test.ts
+++ b/libs/api/workflows/src/presentation/routes/rerun-run.test.ts
@@ -1,5 +1,10 @@
 import {buildUserContext, setUserContext} from '@shipfox/api-auth-context';
 import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
+import {
+  type WorkspacesInterModuleClient,
+  workspacesInterModuleContract,
+} from '@shipfox/api-workspaces-dto/inter-module';
+import {createInterModuleKnownError} from '@shipfox/inter-module';
 import {ClientError} from '@shipfox/node-fastify';
 import type {FastifyInstance} from 'fastify';
 import Fastify from 'fastify';
@@ -20,6 +25,8 @@ const projects = {
   getProjectById,
   requireProjectForWorkspace: vi.fn(),
 } as unknown as ProjectsModuleClient;
+const getWorkspaceOperatingState = vi.fn();
+const workspaces = {getWorkspaceOperatingState} as unknown as WorkspacesInterModuleClient;
 
 describe('POST /api/workflows/runs/:id/rerun', () => {
   let app: FastifyInstance;
@@ -41,7 +48,7 @@ describe('POST /api/workflows/runs/:id/rerun', () => {
       );
       done();
     });
-    app.post('/api/workflows/runs/:id/rerun', rerunRunRoute(projects));
+    app.post('/api/workflows/runs/:id/rerun', rerunRunRoute(projects, workspaces));
     await app.ready();
   });
 
@@ -60,6 +67,7 @@ describe('POST /api/workflows/runs/:id/rerun', () => {
         },
       }),
     );
+    getWorkspaceOperatingState.mockResolvedValue({status: 'active'});
   });
 
   async function createTerminalRun(status: 'succeeded' | 'failed' = 'failed') {
@@ -133,6 +141,55 @@ describe('POST /api/workflows/runs/:id/rerun', () => {
 
     expect(res.statusCode).toBe(409);
     expect(res.json().code).toBe('no-failed-jobs');
+  });
+
+  test('returns workspace-suspended before creating a new attempt', async () => {
+    const source = await createTerminalRun('failed');
+    getWorkspaceOperatingState.mockResolvedValueOnce({status: 'suspended'});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/workflows/runs/${source.id}/rerun`,
+      payload: {mode: 'all'},
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('workspace-suspended');
+    expect(getWorkspaceOperatingState).toHaveBeenCalledWith({workspaceId});
+  });
+
+  test('returns workspace-deleted before creating a new attempt', async () => {
+    const source = await createTerminalRun('failed');
+    getWorkspaceOperatingState.mockResolvedValueOnce({status: 'deleted'});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/workflows/runs/${source.id}/rerun`,
+      payload: {mode: 'all'},
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().code).toBe('workspace-deleted');
+  });
+
+  test('returns workspace-not-found before creating a new attempt', async () => {
+    const source = await createTerminalRun('failed');
+    getWorkspaceOperatingState.mockRejectedValueOnce(
+      createInterModuleKnownError(
+        workspacesInterModuleContract.methods.getWorkspaceOperatingState,
+        'workspace-not-found',
+        {workspaceId},
+      ),
+    );
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/workflows/runs/${source.id}/rerun`,
+      payload: {mode: 'all'},
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().code).toBe('workspace-not-found');
   });
 
   test('returns 409 when the source run is not terminal', async () => {

--- a/libs/api/workflows/src/presentation/routes/rerun-run.ts
+++ b/libs/api/workflows/src/presentation/routes/rerun-run.ts
@@ -1,14 +1,26 @@
 import {requireUserContext} from '@shipfox/api-auth-context';
 import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import {rerunWorkflowRunBodySchema, workflowRunResponseSchema} from '@shipfox/api-workflows-dto';
+import type {WorkspacesInterModuleClient} from '@shipfox/api-workspaces-dto/inter-module';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
-import {NoFailedJobsError, RunNotTerminalError, SourceRunNotFoundError} from '#core/errors.js';
+import {
+  NoFailedJobsError,
+  RunNotTerminalError,
+  SourceRunNotFoundError,
+  WorkspaceDeletedError,
+  WorkspaceNotFoundError,
+  WorkspaceSuspendedError,
+} from '#core/errors.js';
+import {assertWorkspaceAdmitsNewJobs} from '#core/workspace-admission.js';
 import {createRerunWorkflowRun} from '#db/index.js';
 import {toRunDto} from '#presentation/dto/index.js';
 import {requireAccessibleRun} from './require-accessible-run.js';
 
-export function rerunRunRoute(projects: ProjectsModuleClient) {
+export function rerunRunRoute(
+  projects: ProjectsModuleClient,
+  workspaces: WorkspacesInterModuleClient,
+) {
   return defineRoute({
     method: 'POST',
     path: '/:id/rerun',
@@ -32,11 +44,31 @@ export function rerunRunRoute(projects: ProjectsModuleClient) {
       if (error instanceof NoFailedJobsError) {
         throw new ClientError('Run has no failed jobs', 'no-failed-jobs', {status: 409});
       }
+      if (error instanceof WorkspaceSuspendedError) {
+        throw new ClientError('Workspace is suspended', 'workspace-suspended', {
+          status: 409,
+          cause: error,
+        });
+      }
+      if (error instanceof WorkspaceDeletedError) {
+        throw new ClientError('Workspace is deleted', 'workspace-deleted', {
+          status: 404,
+          cause: error,
+        });
+      }
+      if (error instanceof WorkspaceNotFoundError) {
+        throw new ClientError('Workspace not found', 'workspace-not-found', {
+          status: 404,
+          cause: error,
+        });
+      }
       throw error;
     },
     handler: async (request) => {
       const {id} = request.params;
       const sourceRun = await requireAccessibleRun({request, id, projects});
+
+      await assertWorkspaceAdmitsNewJobs(workspaces, sourceRun.workspaceId);
 
       const actor = requireUserContext(request);
       const run = await createRerunWorkflowRun({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4296,6 +4296,9 @@ importers:
       '@shipfox/api-workflows-dto':
         specifier: workspace:*
         version: link:../workflows-dto
+      '@shipfox/api-workspaces-dto':
+        specifier: workspace:*
+        version: link:../workspaces-dto
       '@shipfox/expression':
         specifier: workspace:*
         version: link:../../shared/expression


### PR DESCRIPTION
This change adds a shared workspace admission boundary for new workflow work. Only active workspaces may create trigger runs, materialize fire deliveries, or create rerun attempts; resolve deliveries and already queued or running work remain unaffected.

Workflows publishes stable workspace-not-found, workspace-suspended, and workspace-deleted outcomes. Triggers maps them consistently, records admission failures as permanent, and skips rather than replaying affected events. The architecture guide now documents the as-built paths and decisions.

Validation: 997 package tests (643 workflows, 247 triggers, 107 workflows DTO), dependent type graph, Biome, dependency cruise, repository documentation validation, and git diff checks.

Closes ENG-1274

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block new workflow work when a workspace is suspended, deleted, or missing; allow existing executions and resolve deliveries to proceed. Returns stable, non-retryable outcomes across workflows and triggers (ENG-1274).

- **New Features**
  - Shared admission gate in `@shipfox/api-workflows` using `getWorkspaceOperatingState`; only `active` workspaces may start new work.
  - Scope: manual/scheduled runs (`startRunFromTrigger`), listener deliveries with `disposition: 'fire'`, and reruns; queued/running jobs and `disposition: 'resolve'` deliveries are not gated.
  - Stable outcomes: `workspace-not-found`, `workspace-suspended`, `workspace-deleted`. `@shipfox/api-triggers` treats these as permanent for runs and listener deliveries (no replay); routes map to 409 (suspended) and 404 (not found/deleted) in `fire-manual` and rerun.
  - Inter-module updates: added `workspace-*` errors to `startRunFromTrigger` and `deliverEventToJobListener`; added helpers (`isPermanentDeliverEventToJobListenerError`, `isWorkspace*Error`); wired `workspaces` through server modules; docs updated.

- **Dependencies**
  - Added `@shipfox/api-workspaces-dto`; aligned changeset bumps across `@shipfox/api-triggers`, `@shipfox/api-workflows`, and `@shipfox/api-workflows-dto`.

<sup>Written for commit 890beac7d2227d21c3d98433b3b8d9f30570f6e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

