### PR TITLE
[provisioner-docker] Default to the published runner image

### DIFF
--- a/apps/provisioner-docker/README.md
+++ b/apps/provisioner-docker/README.md
@@ -54,8 +54,9 @@ until observation succeeds.
 
 ## Runner image
 
-Each template `image` must run the Shipfox runner process and consume the injected
-environment:
+When a template omits `image`, the provisioner uses the published
+`ghcr.io/shipfoxhq/runner` image. A template may override it with a custom image,
+which must run the Shipfox runner process and consume the injected environment:
 
 - `SHIPFOX_API_URL`
 - `SHIPFOX_RUNNER_BOOTSTRAP_TOKEN`

--- a/apps/provisioner-docker/README.md
+++ b/apps/provisioner-docker/README.md
@@ -59,7 +59,8 @@ When a template omits `image`, the provisioner uses the published
 published runner releases become the default without changing the template. A
 template may override it with a custom image, including an immutable digest, which
 must run the Shipfox runner process and consume the injected environment. Omit the
-key to use the default; a blank value is invalid.
+key to use the default; a blank value is invalid. Docker may reuse a locally cached
+`latest` image, so refresh the image on the host to pick up a newer release.
 
 - `SHIPFOX_API_URL`
 - `SHIPFOX_RUNNER_BOOTSTRAP_TOKEN`

--- a/apps/provisioner-docker/README.md
+++ b/apps/provisioner-docker/README.md
@@ -55,8 +55,10 @@ until observation succeeds.
 ## Runner image
 
 When a template omits `image`, the provisioner uses the published
-`ghcr.io/shipfoxhq/runner` image. A template may override it with a custom image,
-which must run the Shipfox runner process and consume the injected environment:
+`ghcr.io/shipfoxhq/runner` image pinned to an immutable digest. A template may
+override it with a custom image, which must run the Shipfox runner process and
+consume the injected environment. Omit the key to use the default; a blank value
+is invalid.
 
 - `SHIPFOX_API_URL`
 - `SHIPFOX_RUNNER_BOOTSTRAP_TOKEN`

--- a/apps/provisioner-docker/README.md
+++ b/apps/provisioner-docker/README.md
@@ -55,10 +55,11 @@ until observation succeeds.
 ## Runner image
 
 When a template omits `image`, the provisioner uses the published
-`ghcr.io/shipfoxhq/runner` image pinned to an immutable digest. A template may
-override it with a custom image, which must run the Shipfox runner process and
-consume the injected environment. Omit the key to use the default; a blank value
-is invalid.
+`ghcr.io/shipfoxhq/runner:latest` image. This moving tag is intentional so new
+published runner releases become the default without changing the template. A
+template may override it with a custom image, including an immutable digest, which
+must run the Shipfox runner process and consume the injected environment. Omit the
+key to use the default; a blank value is invalid.
 
 - `SHIPFOX_API_URL`
 - `SHIPFOX_RUNNER_BOOTSTRAP_TOKEN`

--- a/apps/provisioner-docker/templates.example.yaml
+++ b/apps/provisioner-docker/templates.example.yaml
@@ -5,7 +5,6 @@
 templates:
   docker-ubuntu22-2vcpu:
     labels: [ubuntu22, ubuntu22-2vcpu]
-    image: shipfox-runner:ubuntu22
     cpu: 2
     memory: 4GiB
     max_concurrency: 100
@@ -13,7 +12,6 @@ templates:
 
   docker-ubuntu22-4vcpu:
     labels: [ubuntu22, ubuntu22-4vcpu]
-    image: shipfox-runner:ubuntu22
     cpu: 4
     memory: 8GiB
     max_concurrency: 50

--- a/libs/provisioner/docker/README.md
+++ b/libs/provisioner/docker/README.md
@@ -75,7 +75,8 @@ When a template omits `image`, it defaults to the published
 published runner releases become the default without changing the template. Any
 explicit image value, including an immutable digest, must run the Shipfox runner
 process and honor the injected environment. Omit the key to use the default; a
-blank value is invalid.
+blank value is invalid. Docker may reuse a locally cached `latest` image, so refresh
+the image on the host to pick up a newer release.
 
 - `SHIPFOX_API_URL`
 - `SHIPFOX_RUNNER_BOOTSTRAP_TOKEN`

--- a/libs/provisioner/docker/README.md
+++ b/libs/provisioner/docker/README.md
@@ -71,9 +71,11 @@ API through a different hostname or network address than the provisioner process
 ## Runner image
 
 When a template omits `image`, it defaults to the published
-`ghcr.io/shipfoxhq/runner` image pinned to an immutable digest. Any explicit image
-value must run the Shipfox runner process and honor the injected environment. Omit
-the key to use the default; a blank value is invalid.
+`ghcr.io/shipfoxhq/runner:latest` image. This moving tag is intentional so new
+published runner releases become the default without changing the template. Any
+explicit image value, including an immutable digest, must run the Shipfox runner
+process and honor the injected environment. Omit the key to use the default; a
+blank value is invalid.
 
 - `SHIPFOX_API_URL`
 - `SHIPFOX_RUNNER_BOOTSTRAP_TOKEN`

--- a/libs/provisioner/docker/README.md
+++ b/libs/provisioner/docker/README.md
@@ -71,8 +71,9 @@ API through a different hostname or network address than the provisioner process
 ## Runner image
 
 When a template omits `image`, it defaults to the published
-`ghcr.io/shipfoxhq/runner` image. Any explicit image value must run the Shipfox runner
-process and honor the injected environment:
+`ghcr.io/shipfoxhq/runner` image pinned to an immutable digest. Any explicit image
+value must run the Shipfox runner process and honor the injected environment. Omit
+the key to use the default; a blank value is invalid.
 
 - `SHIPFOX_API_URL`
 - `SHIPFOX_RUNNER_BOOTSTRAP_TOKEN`

--- a/libs/provisioner/docker/README.md
+++ b/libs/provisioner/docker/README.md
@@ -22,7 +22,6 @@ The template file is YAML keyed by template name:
 templates:
   docker-ubuntu22-2vcpu:
     labels: [ubuntu22, ubuntu22-2vcpu]
-    image: shipfox-runner:ubuntu22
     cpu: 2
     memory: 4GiB
     max_concurrency: 100
@@ -59,7 +58,7 @@ variables:
 
 | Variable | Required | Default | Purpose |
 | --- | --- | --- | --- |
-| `SHIPFOX_PROVISIONER_TEMPLATES_FILE` | yes | - | YAML template file describing labels, image, cpu, memory, and max concurrency. |
+| `SHIPFOX_PROVISIONER_TEMPLATES_FILE` | yes | - | YAML template file describing labels, optional image override, cpu, memory, and max concurrency. |
 | `SHIPFOX_PROVISIONER_DOCKER_HOST` | no | local Docker socket | Docker daemon host used by dockerode. |
 | `SHIPFOX_PROVISIONER_DOCKER_NETWORK` | no | - | Docker network attached to runner containers, useful for Compose-local API access. |
 | `SHIPFOX_PROVISIONER_DOCKER_EXTRA_HOSTS` | no | - | Comma-separated host mappings added to runner containers, such as `host.docker.internal:host-gateway`. |
@@ -71,8 +70,9 @@ API through a different hostname or network address than the provisioner process
 
 ## Runner image
 
-Template `image` values must point to an image that runs the Shipfox runner process and
-honors the injected environment:
+When a template omits `image`, it defaults to the published
+`ghcr.io/shipfoxhq/runner` image. Any explicit image value must run the Shipfox runner
+process and honor the injected environment:
 
 - `SHIPFOX_API_URL`
 - `SHIPFOX_RUNNER_BOOTSTRAP_TOKEN`

--- a/libs/provisioner/docker/src/config.ts
+++ b/libs/provisioner/docker/src/config.ts
@@ -2,7 +2,7 @@ import {createConfig, num, str} from '@shipfox/config';
 
 export const config = createConfig({
   SHIPFOX_PROVISIONER_TEMPLATES_FILE: str({
-    desc: 'Path to the YAML file describing the Docker runner templates this provisioner can start. Required. Each template lists its labels, image, cpu, memory, and max_concurrency.',
+    desc: 'Path to the YAML file describing the Docker runner templates this provisioner can start. Required. Each template lists its labels, cpu, memory, and max_concurrency, and may override the default runner image.',
   }),
   SHIPFOX_PROVISIONER_DOCKER_HOST: str({
     desc: 'Docker daemon host used by dockerode. Leave unset to use the local Docker socket, or set a Docker host URL when the daemon is remote.',

--- a/libs/provisioner/docker/src/templates.test.ts
+++ b/libs/provisioner/docker/src/templates.test.ts
@@ -4,10 +4,14 @@ import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {DEFAULT_RUNNER_IMAGE, DockerTemplateConfigError, loadDockerTemplates} from '#templates.js';
 
+const mocks = vi.hoisted(() => ({warn: vi.fn()}));
+vi.mock('@shipfox/node-opentelemetry', () => ({logger: () => mocks}));
+
 let dir: string;
 
 beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), 'provisioner-docker-'));
+  mocks.warn.mockReset();
 });
 
 afterEach(() => {
@@ -75,6 +79,10 @@ templates:
     const [template] = loadDockerTemplates(path);
 
     expect(template?.spec.image).toBe(DEFAULT_RUNNER_IMAGE);
+    expect(mocks.warn).toHaveBeenCalledWith(
+      {filePath: path, templateKey: 'docker-ubuntu22', image: DEFAULT_RUNNER_IMAGE},
+      'Docker template image omitted; using default runner image',
+    );
   });
 
   it('canonicalizes labels (lowercase, dedupe, sort)', () => {

--- a/libs/provisioner/docker/src/templates.test.ts
+++ b/libs/provisioner/docker/src/templates.test.ts
@@ -2,7 +2,7 @@ import {randomUUID} from 'node:crypto';
 import {mkdtempSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
-import {DockerTemplateConfigError, loadDockerTemplates} from '#templates.js';
+import {DEFAULT_RUNNER_IMAGE, DockerTemplateConfigError, loadDockerTemplates} from '#templates.js';
 
 let dir: string;
 
@@ -60,6 +60,21 @@ describe('loadDockerTemplates', () => {
         spec: {image: 'shipfox-runner:ubuntu22', cpu: 4, memory: '8GiB'},
       },
     ]);
+  });
+
+  it('defaults the image to the published Shipfox runner', () => {
+    const path = writeTemplates(`
+templates:
+  docker-ubuntu22:
+    labels: [ubuntu22]
+    cpu: 1
+    memory: 2g
+    max_concurrency: 1
+`);
+
+    const [template] = loadDockerTemplates(path);
+
+    expect(template?.spec.image).toBe(DEFAULT_RUNNER_IMAGE);
   });
 
   it('canonicalizes labels (lowercase, dedupe, sort)', () => {

--- a/libs/provisioner/docker/src/templates.ts
+++ b/libs/provisioner/docker/src/templates.ts
@@ -12,6 +12,7 @@ export interface DockerTemplateSpec {
   readonly memory: string;
 }
 
+export const DEFAULT_RUNNER_IMAGE = 'ghcr.io/shipfoxhq/runner';
 /** Raised when the template config file is missing, unparseable, or invalid. */
 export class DockerTemplateConfigError extends Error {
   constructor(message: string) {
@@ -24,7 +25,7 @@ const MAX_TEMPLATE_CONCURRENCY = 100_000;
 
 const dockerTemplateSchema = z.object({
   labels: z.array(z.string()).min(1),
-  image: z.string().trim().min(1),
+  image: z.string().trim().min(1).default(DEFAULT_RUNNER_IMAGE),
   cpu: z.number().positive(),
   memory: z.string().regex(MEMORY_PATTERN, 'must be a size like "4GiB", "512m", "2g", or "512"'),
   max_concurrency: z.number().int().positive().max(MAX_TEMPLATE_CONCURRENCY),

--- a/libs/provisioner/docker/src/templates.ts
+++ b/libs/provisioner/docker/src/templates.ts
@@ -13,8 +13,7 @@ export interface DockerTemplateSpec {
   readonly memory: string;
 }
 
-export const DEFAULT_RUNNER_IMAGE =
-  'ghcr.io/shipfoxhq/runner@sha256:1eee915cf6d18b7aab019d17b592d8334ebd22fbc7a47658eb8053c4b0dc8a06';
+export const DEFAULT_RUNNER_IMAGE = 'ghcr.io/shipfoxhq/runner:latest';
 /** Raised when the template config file is missing, unparseable, or invalid. */
 export class DockerTemplateConfigError extends Error {
   constructor(message: string) {

--- a/libs/provisioner/docker/src/templates.ts
+++ b/libs/provisioner/docker/src/templates.ts
@@ -1,4 +1,5 @@
 import {readFileSync} from 'node:fs';
+import {logger} from '@shipfox/node-opentelemetry';
 import type {ProvisionerTemplate} from '@shipfox/provisioner-core';
 import {canonicalizeLabels, findInvalidLabels, MAX_RUNNER_LABELS} from '@shipfox/runner-labels';
 import yaml from 'js-yaml';
@@ -12,7 +13,8 @@ export interface DockerTemplateSpec {
   readonly memory: string;
 }
 
-export const DEFAULT_RUNNER_IMAGE = 'ghcr.io/shipfoxhq/runner';
+export const DEFAULT_RUNNER_IMAGE =
+  'ghcr.io/shipfoxhq/runner@sha256:1eee915cf6d18b7aab019d17b592d8334ebd22fbc7a47658eb8053c4b0dc8a06';
 /** Raised when the template config file is missing, unparseable, or invalid. */
 export class DockerTemplateConfigError extends Error {
   constructor(message: string) {
@@ -43,7 +45,8 @@ const dockerTemplatesFileSchema = z.object({
  * not validate, an invalid label, or an empty template set.
  */
 export function loadDockerTemplates(filePath: string): ProvisionerTemplate<DockerTemplateSpec>[] {
-  const parsed = dockerTemplatesFileSchema.safeParse(parseYamlFile(filePath));
+  const raw = parseYamlFile(filePath);
+  const parsed = dockerTemplatesFileSchema.safeParse(raw);
   if (!parsed.success) {
     throw new DockerTemplateConfigError(
       `Invalid Docker template config at ${filePath}: ${formatIssues(parsed.error)}`,
@@ -57,7 +60,25 @@ export function loadDockerTemplates(filePath: string): ProvisionerTemplate<Docke
     );
   }
 
-  return entries.map(([key, spec]) => toTemplate(filePath, key, spec));
+  return entries.map(([key, spec]) => {
+    if (!hasImageField(raw, key)) {
+      logger().warn(
+        {filePath, templateKey: key, image: spec.image},
+        'Docker template image omitted; using default runner image',
+      );
+    }
+    return toTemplate(filePath, key, spec);
+  });
+}
+
+function hasImageField(raw: unknown, key: string): boolean {
+  if (!isRecord(raw) || !isRecord(raw.templates)) return false;
+  const template = raw.templates[key];
+  return isRecord(template) && Object.hasOwn(template, 'image');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
 }
 
 function toTemplate(


### PR DESCRIPTION
## Summary

Docker provisioner templates use the published `ghcr.io/shipfoxhq/runner:latest` image when `image` is omitted. The moving tag is intentional so new published runner releases become the default without changing templates. Docker may reuse a locally cached `latest`, so hosts must refresh the image to receive a newer release.

Explicit custom images remain supported, including immutable digest references. Omitted images emit a structured warning identifying the template; blank image values still fail validation.

Validation completed with the provider dependency closure:

- `turbo check --filter=@shipfox/provisioner-docker-provider...`
- `turbo type --filter=@shipfox/provisioner-docker-provider...`
- `turbo test --filter=@shipfox/provisioner-docker-provider...` (67 tests)
- `git diff --check`