### PR TITLE
[provisioner-docker] Add copy-paste Docker Compose setup

### DIFF
--- a/apps/docs/content/docs/installation/runner-provisioner.mdx
+++ b/apps/docs/content/docs/installation/runner-provisioner.mdx
@@ -1,101 +1,144 @@
 ---
 title: "Run a Docker Runner Provisioner"
 sidebarTitle: "Runner Provisioner"
-description: "Start the Shipfox Docker runner provisioner from a source checkout and verify its runner-instance lifecycle."
+description: "Start the Shipfox Docker runner provisioner with Docker Compose and verify an ephemeral runner job."
 ---
 
 A [runner provisioner](/operations/runner-provisioners) creates runner instances,
 starts ephemeral compute, and activates each runner for at most one job. You do not
-hand a workspace registration credential to the provider. This guide deploys the Docker
-provisioner.
+hand a workspace registration credential to the provider. This guide deploys the
+published Docker provisioner and runner images as one compatible application release.
 
 ## Before you begin
 
-- A Docker daemon the provisioner can control (local socket or a reachable Docker host).
-- A runner container image, such as `shipfox-runner:ubuntu22`.
+- Docker Engine with Docker Compose.
 - Access to your workspace settings in the Shipfox dashboard.
-- A Shipfox source checkout with `mise install` and `pnpm install` complete.
+- A Shipfox project backed by a repository where you can add a workflow.
 
-## Create a provisioner token
+## Copy the deployment bundle
 
-<Steps>
-  <Step>
-
-    **Open Settings → Runner Provisioners**
-
-    In the dashboard, go to **Settings → Runner Provisioners**.
-  </Step>
-  <Step>
-
-    **Create the token**
-
-    Click **Create token** and copy the value. It is shown only once. Treat it like a
-    secret. A workspace token can provision only its workspace. An installation token
-    can serve host-approved workspaces, but the runner still receives its workspace
-    only after immutable assignment. You can revoke either token on the same page.
-  </Step>
-</Steps>
-
-## Write a templates file
-
-A template maps a label set to the container that provides it. Start with one template:
-
-```yaml
-templates:
-  docker-ubuntu22-2vcpu:
-    labels: [ubuntu22, ubuntu22-2vcpu]
-    image: shipfox-runner:ubuntu22
-    cpu: 2
-    memory: 4GiB
-    max_concurrency: 100
-    target_concurrency: 0
-```
-
-The full field semantics and selection rule live in the [Runner Provisioner reference](/reference/runner-provisioner#template-file-schema).
-
-## Start the provisioner
-
-Start the provisioner from the Shipfox source checkout. Replace the API URL and
-token with values from your deployment:
+Create an empty directory and copy the three deployment files:
 
 ```bash
-SHIPFOX_API_URL='<YOUR_SHIPFOX_API_URL>' \
-SHIPFOX_PROVISIONER_TOKEN='<YOUR_PROVISIONER_TOKEN>' \
-SHIPFOX_PROVISIONER_TEMPLATES_FILE=./templates.yaml \
-mise exec -- pnpm --filter=@shipfox/provisioner-docker dev
+mkdir shipfox-provisioner
+cd shipfox-provisioner
+
+curl -fsSLO https://raw.githubusercontent.com/ShipfoxHQ/shipfox/main/apps/provisioner-docker/compose.yaml
+curl -fsSL https://raw.githubusercontent.com/ShipfoxHQ/shipfox/main/apps/provisioner-docker/.env.example -o .env
+curl -fsSLO https://raw.githubusercontent.com/ShipfoxHQ/shipfox/main/apps/provisioner-docker/templates.yaml
 ```
 
-It authenticates on startup, then enters its control loop. On a shutdown signal
-it stops claiming new work and exits cleanly. Use your process supervisor to
-keep it running. All tuning variables are listed in the [Runner Provisioner
-reference](/reference/runner-provisioner).
+The bundle pins both public images to the same immutable application release.
+Do not replace either image tag with `latest` in a production deployment.
 
-## Verify it works
+## Add the provisioner token
 
-Fire a workflow whose `runner:` label matches one of your templates (for example
-`runner: ubuntu22`). Within a few seconds the provisioner creates a runner instance
-and starts a container with a one-use bootstrap token. The container enrolls, receives
-an immutable assignment, activates, claims one job, runs it, and exits. The run detail
-page shows the job leaving `pending` and streaming logs.
+In the dashboard, open **Settings → Runner Provisioners**. Create a token and
+copy it when shown. This page creates a workspace-scoped token. It can provision
+only that workspace.
 
-## Breaking protocol migration
+Replace `replace-with-your-provisioner-token` in `.env` with the token. Keep
+`.env` out of source control.
 
-Provisioners built against the former capacity protocol must migrate as one release:
+Start the provisioner:
 
-1. Replace capacity creation, capacity assignment, and batch registration-token calls
-   with runner-instance creation and bootstrap tokens.
-2. Start compute with `SHIPFOX_RUNNER_BOOTSTRAP_TOKEN`, never a workspace registration
-   token.
-3. Attach the provider runner ID, let the runner enroll, then assign its runner instance
-   to the owned reservation.
-4. Treat an unassigned runner as workspace-neutral. Do not send workspace metadata,
-   credentials, or job data through the provider.
+```bash
+docker compose up -d
+```
 
-Use `SHIPFOX_PROVISIONER_RUNNER_INSTANCE_BATCH_SIZE` in place of
-`SHIPFOX_PROVISIONER_REGISTRATION_TOKEN_BATCH_SIZE`. A template may set
-`target_concurrency` to maintain prewarmed, unassigned runners independently of demand.
+Compose mounts the Docker socket with read-write access because the provisioner
+must create and remove runner containers. It mounts `templates.yaml` read-only.
+The service restarts unless an operator stops it.
 
-## Related pages
+## Connect to a self-hosted API
+
+Skip this section for Shipfox Cloud. `SHIPFOX_API_URL` defaults to
+`https://api.shipfox.io`.
+
+For an API published on the Docker host, set these values in `.env`:
+
+```dotenv
+SHIPFOX_API_URL=http://host.docker.internal:3000
+SHIPFOX_RUNNER_API_URL=http://host.docker.internal:3000
+SHIPFOX_PROVISIONER_DOCKER_EXTRA_HOSTS=host.docker.internal:host-gateway
+```
+
+The Compose service adds the same host alias to the provisioner container. The
+extra-hosts variable adds it to each runner container. If the provisioner and
+runners must join an existing Docker network instead, set
+`SHIPFOX_PROVISIONER_DOCKER_NETWORK` to that network name. Attach the
+provisioner service to that network in `compose.yaml` too.
+
+Run `docker compose up -d` again after changing `.env`.
+
+## Verify the provisioner
+
+Check the rendered configuration and startup:
+
+```bash
+docker compose config --quiet
+docker compose ps
+docker compose logs provisioner
+```
+
+The config command exits with status `0`. The service is `Up`. Its logs contain
+`Provisioner authenticated` with a provisioner ID, workspace ID, `workspace`
+scope, and one template.
+
+Add this workflow to the project repository and sync it:
+
+```yaml
+# yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
+name: Docker provisioner check
+runner: [docker, ubuntu]
+
+triggers:
+  manual:
+    source: manual
+    event: fire
+
+jobs:
+  check:
+    steps:
+      - run: echo "Provisioned runner is streaming logs"
+```
+
+Run the workflow from the dashboard. Verify these signals:
+
+1. The job leaves `pending`.
+2. `docker ps --filter label=shipfox.template_key=docker-ubuntu` shows one
+   runner container while the job runs.
+3. The run detail page streams `Provisioned runner is streaming logs`.
+4. The job finishes.
+5. The runner container exits, then disappears after the provisioner reports
+   its terminal state.
+
+`docker compose logs provisioner` reports `Provisioner tick complete` with one
+or more launched runners when it handles the job.
+
+## Stop the provisioner
+
+```bash
+docker compose stop
+docker compose logs --tail 20 provisioner
+```
+
+The logs contain `Shutting down gracefully` and `Provisioner stopped`. The
+service exits after it flushes pending runner reports. `docker compose down`
+removes the stopped provisioner container and its Compose network. It does not
+remove active runner containers.
+
+## Recover from startup or job failures
+
+| Signal | Cause and recovery |
+| --- | --- |
+| `Fatal provisioner error` reports a rejected token, or the service restarts before `Provisioner authenticated`. | Replace `SHIPFOX_PROVISIONER_TOKEN` with a valid workspace-scoped token. Check that it was created in the target workspace and was not revoked. |
+| `Cannot list managed Docker containers` or `Provisioner startup reconciliation failed; advertising no free capacity until observe succeeds`. | Check that Docker is running and `/var/run/docker.sock` exists on the host. Keep the socket mount read-write. On a remote daemon, set `SHIPFOX_PROVISIONER_DOCKER_HOST` and remove the local socket mount. |
+| `Invalid Docker template config` or `Cannot parse Docker template config`. | Run `docker compose config --quiet`, then fix `templates.yaml`. Check its indentation and the [template schema](/reference/runner-provisioner#template-file-schema). Restart the service. |
+| `Cannot pull image` or `Failed to launch provisioned runner`. | Pull the runner image named in `templates.yaml`. Check registry access and keep the provisioner and runner on the same release tag. |
+| API requests fail or the service never logs `Provisioner authenticated`. | Check `SHIPFOX_API_URL` from the provisioner container. For a host API, use `host.docker.internal` as shown above. Set `SHIPFOX_RUNNER_API_URL` when runner containers need a different address. |
+| The job stays `pending` and no runner container appears. | Compare the workflow `runner` labels with `templates.yaml`. Every requested label must appear in one template. The checked bundle uses `[docker, ubuntu]`. |
+| The provisioner is authenticated but advertises zero free capacity. | Check for `advertising no free capacity` in the logs. Repair Docker access. If Docker is healthy, count managed containers and increase `max_concurrency` only when the host has enough CPU and memory. |
 
 <Cards>
   <Card title="Runner Provisioner reference" href="/reference/runner-provisioner">

--- a/apps/docs/content/docs/reference/runner-provisioner.mdx
+++ b/apps/docs/content/docs/reference/runner-provisioner.mdx
@@ -10,14 +10,14 @@ This page is the canonical reference for configuring the Docker runner provision
 
 | Variable | Purpose |
 | --- | --- |
-| `SHIPFOX_API_URL` | Base URL of the Shipfox API the provisioner connects to. |
-| `SHIPFOX_PROVISIONER_TOKEN` | Long-lived token that authenticates control-plane calls. Create it for the provisioner scope you intend to run and keep it secret. The value is shown once and can be revoked. |
+| `SHIPFOX_PROVISIONER_TOKEN` | Long-lived token that authenticates control-plane calls. The dashboard creates a workspace-scoped token on **Settings → Runner Provisioners**. Keep it secret. The value is shown once and can be revoked. |
 | `SHIPFOX_PROVISIONER_TEMPLATES_FILE` | Path to the YAML file describing the runner templates this provisioner can start. |
 
 ## Optional variables
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
+| `SHIPFOX_API_URL` | `https://api.shipfox.io` | Base URL of the Shipfox API the provisioner connects to. Set it for a self-hosted API. |
 | `SHIPFOX_RUNNER_API_URL` | `SHIPFOX_API_URL` | Base URL injected into runner containers as their `SHIPFOX_API_URL`. Set it when containers reach the API through a different address than the provisioner uses. |
 | `SHIPFOX_RUNNER_POLL_MAX_DURATION_MS` | `300000` | Injected into each runner as `SHIPFOX_POLL_MAX_DURATION_MS`: how long a started runner polls for a job before exiting. Use `0` to poll forever. |
 | `SHIPFOX_PROVISIONER_DOCKER_HOST` | local socket | Docker daemon host. Set a Docker host URL when the daemon is remote. |
@@ -39,7 +39,7 @@ The templates file maps label sets to the containers that provide them:
 templates:
   docker-ubuntu22-2vcpu:
     labels: [ubuntu22, ubuntu22-2vcpu]
-    image: shipfox-runner:ubuntu22
+    image: ghcr.io/shipfoxhq/runner:revision-0123456789abcdef0123456789abcdef01234567
     cpu: 2
     memory: 4GiB
     max_concurrency: 100
@@ -48,7 +48,7 @@ templates:
 | Field | Type | Description |
 | --- | --- | --- |
 | `labels` | `string[]` | Labels the started runner registers with. A template can serve any job whose required labels are all in this list. |
-| `image` | `string` | Container image to start. |
+| `image` | `string` | Container image to start. Optional. Defaults to `ghcr.io/shipfoxhq/runner:latest`. Production deployments should set a tag from the same application release as the provisioner. |
 | `cpu` | `number` | vCPUs allocated to the container. Also the template's selection cost. |
 | `memory` | `string` | Memory allocation, such as `4GiB`. |
 | `max_concurrency` | `number` | Cap on live containers started from this template. |

--- a/apps/provisioner-docker/.env.example
+++ b/apps/provisioner-docker/.env.example
@@ -1,0 +1,7 @@
+# Create this workspace-scoped token in Settings > Runner Provisioners.
+SHIPFOX_PROVISIONER_TOKEN=replace-with-your-provisioner-token
+
+# Shipfox Cloud uses this default. Set both URLs for a self-hosted API when the
+# provisioner container and runner containers need different addresses.
+SHIPFOX_API_URL=https://api.shipfox.io
+# SHIPFOX_RUNNER_API_URL=http://host.docker.internal:3000

--- a/apps/provisioner-docker/README.md
+++ b/apps/provisioner-docker/README.md
@@ -55,12 +55,17 @@ until observation succeeds.
 ## Runner image
 
 When a template omits `image`, the provisioner uses the published
-`ghcr.io/shipfoxhq/runner:latest` image. This moving tag is intentional so new
-published runner releases become the default without changing the template. A
-template may override it with a custom image, including an immutable digest, which
-must run the Shipfox runner process and consume the injected environment. Omit the
-key to use the default; a blank value is invalid. Docker may reuse a locally cached
-`latest` image, so refresh the image on the host to pick up a newer release.
+`ghcr.io/shipfoxhq/runner:latest` image. This moving tag is intended for local
+development. The deployment bundle pins an immutable runner tag that matches
+the provisioner image. A template may override the default with a custom image
+or immutable digest. The image must run the Shipfox runner process and consume
+the injected environment. A blank value is invalid.
+
+The production-shaped Compose bundle is
+[`compose.yaml`](compose.yaml), [`.env.example`](.env.example), and
+[`templates.yaml`](templates.yaml). The public
+[Docker provisioner guide](../docs/content/docs/installation/runner-provisioner.mdx)
+owns the operator workflow.
 
 - `SHIPFOX_API_URL`
 - `SHIPFOX_RUNNER_BOOTSTRAP_TOKEN`

--- a/apps/provisioner-docker/compose.yaml
+++ b/apps/provisioner-docker/compose.yaml
@@ -1,0 +1,20 @@
+name: shipfox-provisioner
+
+services:
+  provisioner:
+    image: ghcr.io/shipfoxhq/provisioner-docker:revision-c0046d30e158915f6375b319880abf7c4ddbb623
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      SHIPFOX_PROVISIONER_TEMPLATES_FILE: /etc/shipfox/templates.yaml
+    extra_hosts:
+      - host.docker.internal=host-gateway
+    volumes:
+      - type: bind
+        source: /var/run/docker.sock
+        target: /var/run/docker.sock
+      - type: bind
+        source: ./templates.yaml
+        target: /etc/shipfox/templates.yaml
+        read_only: true

--- a/apps/provisioner-docker/package.json
+++ b/apps/provisioner-docker/package.json
@@ -17,6 +17,7 @@
     "image": "shipfox-docker --setup-context --image provisioner-docker",
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
+    "test": "tsx --conditions=workspace-source --test test/*.test.mjs",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"
   },
@@ -25,6 +26,7 @@
     "@shipfox/provisioner-docker-provider": "workspace:*"
   },
   "devDependencies": {
+    "@shipfox/application-release": "workspace:*",
     "@shipfox/biome": "workspace:*",
     "@shipfox/docker": "workspace:*",
     "@shipfox/swc": "workspace:*",

--- a/apps/provisioner-docker/templates.yaml
+++ b/apps/provisioner-docker/templates.yaml
@@ -1,0 +1,8 @@
+templates:
+  docker-ubuntu:
+    labels: [docker, ubuntu]
+    image: ghcr.io/shipfoxhq/runner:revision-c0046d30e158915f6375b319880abf7c4ddbb623
+    cpu: 2
+    memory: 4GiB
+    max_concurrency: 4
+    target_concurrency: 0

--- a/apps/provisioner-docker/test/deployment-bundle.test.mjs
+++ b/apps/provisioner-docker/test/deployment-bundle.test.mjs
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import {execFileSync} from 'node:child_process';
+import {cpSync, mkdtempSync, realpathSync, rmSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import test from 'node:test';
+import {APPLICATION_RELEASE_IMAGES} from '@shipfox/application-release/dist/manifest.js';
+import {DEFAULT_SHIPFOX_API_URL} from '../../../libs/provisioner/core/src/defaults.ts';
+import {loadDockerTemplates} from '../../../libs/provisioner/docker/src/templates.ts';
+
+const bundleDirectory = join(import.meta.dirname, '..');
+const IMMUTABLE_RELEASE_TAG = /^revision-[0-9a-f]{40}$/;
+
+test('the deployment bundle matches the shipped application contracts', () => {
+  const directory = mkdtempSync(join(tmpdir(), 'shipfox-provisioner-compose-'));
+  try {
+    for (const file of ['compose.yaml', '.env.example', 'templates.yaml']) {
+      cpSync(join(bundleDirectory, file), join(directory, file));
+    }
+    cpSync(join(directory, '.env.example'), join(directory, '.env'));
+
+    const rendered = JSON.parse(
+      execFileSync('docker', ['compose', 'config', '--format', 'json'], {
+        cwd: directory,
+        encoding: 'utf8',
+      }),
+    );
+    const service = rendered.services.provisioner;
+    const provisionerReference = parseImageReference(service.image);
+
+    assert.equal(provisionerReference.repository, APPLICATION_RELEASE_IMAGES.provisioner);
+    assert.match(provisionerReference.tag, IMMUTABLE_RELEASE_TAG);
+    assert.equal(service.environment.SHIPFOX_API_URL, DEFAULT_SHIPFOX_API_URL);
+    assert.equal(
+      service.environment.SHIPFOX_PROVISIONER_TEMPLATES_FILE,
+      '/etc/shipfox/templates.yaml',
+    );
+    assert.equal(service.restart, 'unless-stopped');
+    assert.deepEqual(service.extra_hosts, ['host.docker.internal=host-gateway']);
+
+    assertVolume(service.volumes, '/var/run/docker.sock', '/var/run/docker.sock', false);
+    assertVolume(
+      service.volumes,
+      join(directory, 'templates.yaml'),
+      '/etc/shipfox/templates.yaml',
+      true,
+    );
+
+    const [template] = loadDockerTemplates(join(directory, 'templates.yaml'));
+    const runnerReference = parseImageReference(template.spec.image);
+    assert.equal(runnerReference.repository, APPLICATION_RELEASE_IMAGES.runner);
+    assert.equal(runnerReference.tag, provisionerReference.tag);
+    assert.deepEqual(template.labels, ['docker', 'ubuntu']);
+  } finally {
+    rmSync(directory, {recursive: true, force: true});
+  }
+});
+
+function parseImageReference(reference) {
+  assert.equal(reference.includes(':latest'), false);
+  const separator = reference.lastIndexOf(':');
+  assert.notEqual(separator, -1);
+  return {
+    repository: reference.slice(0, separator),
+    tag: reference.slice(separator + 1),
+  };
+}
+
+function assertVolume(volumes, source, target, readOnly) {
+  const volume = volumes.find((candidate) => candidate.target === target);
+  assert.ok(volume, `Expected a volume mounted at ${target}`);
+  assert.equal(volume.type, 'bind');
+  assert.equal(realpathSync(volume.source), realpathSync(source));
+  assert.equal(Boolean(volume.read_only), readOnly);
+}

--- a/libs/provisioner/core/src/config.ts
+++ b/libs/provisioner/core/src/config.ts
@@ -1,4 +1,5 @@
 import {createConfig, num, str, url} from '@shipfox/config';
+import {DEFAULT_SHIPFOX_API_URL} from '#defaults.js';
 
 /** The API caps reservations per poll at 1000; configuration may not ask for more. */
 const MAX_RESERVATIONS_PER_POLL = 1000;
@@ -8,7 +9,7 @@ const MAX_RUNNER_INSTANCE_BATCH = 1000;
 export const config = createConfig({
   SHIPFOX_API_URL: url({
     desc: 'Base URL of the Shipfox API the provisioner connects to. Defaults to https://api.shipfox.io; set it when using a self-hosted Shipfox API.',
-    default: 'https://api.shipfox.io',
+    default: DEFAULT_SHIPFOX_API_URL,
   }),
   SHIPFOX_RUNNER_API_URL: url({
     desc: 'Base URL injected into runner containers as SHIPFOX_API_URL. Defaults to SHIPFOX_API_URL; set it when containers reach the API through a different address than the provisioner uses.',

--- a/libs/provisioner/core/src/defaults.ts
+++ b/libs/provisioner/core/src/defaults.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_SHIPFOX_API_URL = 'https://api.shipfox.io';

--- a/libs/provisioner/core/src/index.ts
+++ b/libs/provisioner/core/src/index.ts
@@ -1,5 +1,6 @@
 export type {ProvisionerClient} from '#api-client.js';
 export {ProvisionerAuthenticationError} from '#api-client.js';
+export {DEFAULT_SHIPFOX_API_URL} from '#defaults.js';
 export {loggingLaunch} from '#launcher.js';
 export {type StartProvisionerOptions, startProvisioner} from '#provisioner.js';
 export type {ProviderRunnerTracker} from '#tracker.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -765,6 +765,9 @@ importers:
         specifier: workspace:*
         version: link:../../libs/provisioner/docker
     devDependencies:
+      '@shipfox/application-release':
+        specifier: workspace:*
+        version: link:../../tools/application-release
       '@shipfox/biome':
         specifier: workspace:*
         version: link:../../tools/biome


### PR DESCRIPTION
## Summary

- add a production-shaped three-file Docker Compose bundle with immutable provisioner and runner images from one application release
- replace the source-checkout setup with a copy-token-and-start operator path for Shipfox Cloud and self-hosted APIs
- document startup, healthy, degraded, shutdown, first-job, cleanup, and focused recovery signals
- add an app-owned drift check for Compose rendering, image repositories and release pairing, API defaults, mounts, restart behavior, networking, and the production template validator

## Validation

- `mise exec -- turbo check type test --filter=@shipfox/provisioner-docker...`
- `mise exec -- turbo check type test --filter=@shipfox/docs`
- `mise exec -- pnpm check:dependencies`
- `mise exec -- pnpm check:lockfile`
- `mise exec -- pnpm check:published-artifacts`
- `mise exec -- pnpm install --frozen-lockfile`
- both pinned OCI images resolve as `linux/amd64` and `linux/arm64` indexes
- installation guide readability is Flesch-Kincaid grade 8.8

The live workspace first-job drill was not run because this checkout has no provisioner token. The checked guide includes the exact matching workflow and observable verification sequence.

Closes ENG-1298

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ships a copy‑paste Docker Compose bundle for the Docker runner provisioner, letting operators deploy by copying three files, adding a token, and running `docker compose up -d`. Addresses Linear ENG-1298 and removes the need for a source checkout while pinning provisioner and runner images to the same application release.

- **New Features**
  - Added `apps/provisioner-docker/compose.yaml`, `.env.example`, and `templates.yaml` with immutable `ghcr.io/shipfoxhq/provisioner-docker` and `ghcr.io/shipfoxhq/runner` tags from the same release; mounts the Docker socket RW, templates RO, sets `restart: unless-stopped`, and adds `host.docker.internal`.
  - Rewrote the install guide to a Compose-first flow with startup/health signals and focused recovery; clarified workspace‑scoped tokens and default `SHIPFOX_API_URL`.
  - Added `apps/provisioner-docker/test/deployment-bundle.test.mjs` to prevent drift: validates Compose render, volumes, env defaults, immutable tags, matching release images via `@shipfox/application-release`, and template labels `[docker, ubuntu]`.
  - Introduced `DEFAULT_SHIPFOX_API_URL` and used it as the config default; exported from `libs/provisioner/core`.
  - Updated the reference docs to show pinned runner images in production and the Cloud default API URL.

- **Migration**
  - Copy `compose.yaml`, `.env.example` → `.env`, and `templates.yaml`; set `SHIPFOX_PROVISIONER_TOKEN`; run `docker compose up -d`.
  - For self‑hosted APIs, set `SHIPFOX_API_URL` and (if needed) `SHIPFOX_RUNNER_API_URL`; use `host.docker.internal` or a custom network.
  - Workflows should request labels matching the example template (e.g., `[docker, ubuntu]`); the guide includes a minimal test workflow.

<sup>Written for commit 4bcd67769192398d44cc61b006a070cf61acf31e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

