### PR TITLE
[provisioner-docker] Fix managed runner startup

### DIFF
--- a/libs/provisioner/docker/src/lifecycle.test.ts
+++ b/libs/provisioner/docker/src/lifecycle.test.ts
@@ -15,6 +15,12 @@ import {type DockerContainerView, type DockerEngine, DockerEngineError} from '#d
 import {createDockerLifecycle} from '#lifecycle.js';
 import type {DockerTemplateSpec} from '#templates.js';
 
+const observability = vi.hoisted(() => ({
+  logger: {error: vi.fn(), info: vi.fn(), warn: vi.fn()},
+}));
+
+vi.mock('@shipfox/node-opentelemetry', () => ({logger: () => observability.logger}));
+
 const NOW = new Date('2026-01-01T00:10:00.000Z');
 const RESERVATION_ID = '00000000-0000-4000-8000-000000000003';
 
@@ -27,6 +33,10 @@ const template: ProvisionerTemplate<DockerTemplateSpec> = {
 };
 
 describe('createDockerLifecycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('launch reports starting and creates a labeled container with resources and env', async () => {
     const engine = fakeEngine();
     const client = fakeClient();
@@ -44,7 +54,10 @@ describe('createDockerLifecycle', () => {
     expect(engine.created[0]).toMatchObject({
       name: 'runner-1',
       image: 'runner:latest',
-      env: {SHIPFOX_RUNNER_BOOTSTRAP_TOKEN: 'sf_rbt_secret'},
+      env: {
+        SHIPFOX_RUNNER_BOOTSTRAP_TOKEN: 'sf_rbt_secret',
+        SHIPFOX_RUNNER_PROVIDER_KIND: 'docker',
+      },
       nanoCpus: 1_500_000_000,
       memoryBytes: 2 * 1024 ** 3,
     });
@@ -116,6 +129,29 @@ describe('createDockerLifecycle', () => {
     await lifecycle.observe();
 
     expect(client.reportBodies[0]?.events[0]?.state).toBe('stopped');
+    expect(engine.removed).toEqual(['runner-1']);
+    expect(observability.logger.error).not.toHaveBeenCalled();
+  });
+
+  it('logs an unsuccessful container exit before removing it', async () => {
+    const engine = fakeEngine({
+      containers: [container({state: 'exited', exitCode: 1})],
+    });
+    const lifecycle = makeLifecycle({engine});
+
+    await lifecycle.observe();
+
+    expect(observability.logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerRunnerId: 'runner-1',
+        containerId: 'runner-1',
+        containerName: 'runner-1',
+        exitCode: 1,
+        oomKilled: false,
+        reason: 'exit-code-1',
+      }),
+      'Provisioned runner container exited unsuccessfully',
+    );
     expect(engine.removed).toEqual(['runner-1']);
   });
 

--- a/libs/provisioner/docker/src/lifecycle.ts
+++ b/libs/provisioner/docker/src/lifecycle.ts
@@ -122,7 +122,10 @@ async function launch(
     await context.engine.createAndStart({
       name: runner.providerRunnerId,
       image: runner.template.spec.image,
-      env: runner.runnerEnv,
+      env: {
+        ...runner.runnerEnv,
+        SHIPFOX_RUNNER_PROVIDER_KIND: context.providerKind,
+      },
       labels,
       nanoCpus: Math.round(runner.template.spec.cpu * 1_000_000_000),
       memoryBytes: parseMemoryToBytes(runner.template.spec.memory),
@@ -311,6 +314,21 @@ function recordContainerObservation(
     };
     recordLiveContainer(context, plan, container, parsed, labels, liveState);
     return;
+  }
+
+  if (mapped.state === 'failed') {
+    logger().error(
+      {
+        providerRunnerId: parsed.providerRunnerId,
+        ...(parsed.runnerInstanceId ? {runnerInstanceId: parsed.runnerInstanceId} : {}),
+        containerId: container.id,
+        containerName: container.name,
+        exitCode: container.exitCode ?? null,
+        oomKilled: container.oomKilled ?? false,
+        reason: mapped.reason,
+      },
+      'Provisioned runner container exited unsuccessfully',
+    );
   }
 
   plan.terminalActions.push({


### PR DESCRIPTION
Docker-managed runners received a bootstrap token without the provider kind required by managed enrollment. Their containers started successfully, then exited before consuming the token, leaving jobs pending while the provisioner repeatedly launched replacements.

The Docker adapter now injects its provider kind into each runner container. It also emits a structured error with runner identity, container identity, exit code, OOM status, and failure reason before removing an unsuccessful container; successful exits remain quiet.

Validated with the Docker provider test suite and test, type, check, and build tasks across its dependent package closure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes managed Docker runner startup by injecting the provider kind into the container env and adds structured error logs for unsuccessful exits. Prevents runners from exiting before consuming the bootstrap token and stops relaunch loops.

- **Bug Fixes**
  - Inject `SHIPFOX_RUNNER_PROVIDER_KIND` into runner env during launch to enable managed enrollment.
  - Log structured errors (runner/container IDs, exit code, OOM, reason) before removing unsuccessful containers; stay quiet on clean exits.

<sup>Written for commit 55627cb0c50598a4ac062844550bbca064d400b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

