### PR TITLE
[package-release] Build Cloudflare Pages before artifact verification

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7907,6 +7907,9 @@ importers:
       '@shipfox/biome':
         specifier: workspace:*
         version: link:../biome
+      '@shipfox/cloudflare-pages':
+        specifier: workspace:*
+        version: link:../cloudflare-pages
       '@shipfox/swc':
         specifier: workspace:*
         version: link:../swc

--- a/tools/package-release/package.json
+++ b/tools/package-release/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",
+    "@shipfox/cloudflare-pages": "workspace:*",
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",


### PR DESCRIPTION
## Summary

Make the package artifact verifier depend on Cloudflare Pages so Turbo builds its dist entrypoints before packing every public tool.

This fixes the generated-release CI failure where the installed package declared dist/index.js but the tarball did not contain build output.

## Validation

- turbo verify --filter=@shipfox/package-release...
- turbo test --filter=@shipfox/package-release...
- pnpm run release:preflight
- pnpm check:dependencies
- pnpm check:lockfile
- pnpm install --frozen-lockfile --ignore-scripts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build Cloudflare Pages before verifying package artifacts to ensure dist files are present in published tarballs. This resolves generated-release CI failures from missing `dist/index.js`.

- **Bug Fixes**
  - Enforced build order by making `@shipfox/package-release` depend on `@shipfox/cloudflare-pages`, so Turbo builds dist before packing and verification.

- **Dependencies**
  - Added devDependency `@shipfox/cloudflare-pages` (workspace:*); updated `pnpm-lock.yaml`.

<sup>Written for commit e2f536122ea2f00362231b6bfdd331821076e277. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

