### PR TITLE
[runner-protocol] Prevent managed runner assignment timeouts

### DIFF
--- a/.changeset/calm-runners-poll.md
+++ b/.changeset/calm-runners-poll.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/runner-protocol": patch
+---
+
+Allows managed runners to wait through the assignment long-poll without hitting the HTTP client's default request timeout.

--- a/libs/runner/protocol/src/api-client.test.ts
+++ b/libs/runner/protocol/src/api-client.test.ts
@@ -133,6 +133,26 @@ describe('api-client auth contexts', () => {
     expect(calls[2]?.authorization).toBe('Bearer control-token');
   });
 
+  it('allows the assignment long-poll to outlive the ky default timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      stubFetch(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(() => resolve(jsonResponse({activation_token: null})), 10_001),
+          ),
+      );
+
+      const assignment = pollRunnerAssignment('control-token');
+      const expectation = expect(assignment).resolves.toBeNull();
+      await vi.advanceTimersByTimeAsync(10_001);
+
+      await expectation;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('registerRunnerSession sends the registration token and configured labels', async () => {
     stubFetch(() => jsonResponse(registerResponse()));
 
@@ -804,7 +824,7 @@ function jsonResponse(body: unknown, status = 200): Response {
   });
 }
 
-function stubFetch(handler: (url: string) => Response): void {
+function stubFetch(handler: (url: string) => Response | Promise<Response>): void {
   globalThis.fetch = vi.fn(async (input: Request | string | URL, init?: RequestInit) => {
     const request = input instanceof Request ? input : new Request(String(input), init);
     calls.push({

--- a/libs/runner/protocol/src/api-client.ts
+++ b/libs/runner/protocol/src/api-client.ts
@@ -49,6 +49,8 @@ import {config} from '#config.js';
 /** Media type the append endpoint expects for the raw NDJSON request body. */
 const LOG_NDJSON_CONTENT_TYPE = 'application/x-ndjson';
 export const ANNOTATION_POST_TIMEOUT_MS = 2_500;
+/** Allows the API's 30-second assignment long-poll plus transport overhead. */
+const RUNNER_ASSIGNMENT_POLL_TIMEOUT_MS = 45_000;
 
 const ANNOTATION_CAPPED_CODES = new Set([
   'annotation-body-too-large',
@@ -220,6 +222,7 @@ export async function pollRunnerAssignment(
   const response = await createRunnerControlClient(controlSessionToken).get(
     'runner-control/assignment',
     {
+      timeout: RUNNER_ASSIGNMENT_POLL_TIMEOUT_MS,
       ...(signal ? {signal} : {}),
     },
   );


### PR DESCRIPTION
## Summary

Managed runners wait on a 30-second assignment long-poll, but Ky aborted the request at its 10-second default timeout. Give the assignment request a 45-second timeout so the API can complete its bounded wait with transport overhead.

Add a regression test that advances beyond Ky's default timeout and verifies an empty assignment response still completes. Include a patch Changeset for `@shipfox/runner-protocol`.

## Validation

- `pnpm --filter=@shipfox/runner-protocol check`
- `pnpm --filter=@shipfox/runner-protocol type`
- `pnpm --filter=@shipfox/runner-protocol test`
- `pnpm --filter=@shipfox/runner-protocol build`
- `pnpm --filter=@shipfox/runner-orchestration test`
- `pnpm --filter=@shipfox/runner check`
- `pnpm --filter=@shipfox/runner type`
- `turbo check type test --filter=@shipfox/runner...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent managed runner assignment timeouts by giving the long-poll request a 45s timeout so the API’s 30s wait can finish. Adds a regression test and a patch changeset for `@shipfox/runner-protocol`.

- **Bug Fixes**
  - Introduced `RUNNER_ASSIGNMENT_POLL_TIMEOUT_MS` (45,000 ms) and applied it in `pollRunnerAssignment`.
  - Added a test that outlives the default client timeout and still resolves with no assignment; updated `stubFetch` to support async responses.

<sup>Written for commit ae27a7fd08892498b7d6a3fedd970223f5c624ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

