### PR TITLE
Fall back to full CI when release images are missing

### DIFF
--- a/.github/scripts/package-release-workflow.mjs
+++ b/.github/scripts/package-release-workflow.mjs
@@ -3,9 +3,19 @@ import {mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 
+const DIGEST_PATTERN = /^sha256:[a-f0-9]{64}$/;
+const REVISION_PATTERN = /^[a-f0-9]{40}$/;
+
 function argument(name) {
   const index = process.argv.indexOf(`--${name}`);
   return index === -1 ? undefined : process.argv[index + 1];
+}
+
+function argumentValues(name) {
+  const option = `--${name}`;
+  return process.argv.flatMap((value, index) =>
+    value === option && process.argv[index + 1] ? [process.argv[index + 1]] : [],
+  );
 }
 
 function run(command, args) {
@@ -157,10 +167,10 @@ async function writeMainClassification(result) {
       `- Reason: \`${result.reason}\``,
       ...(result.releasePrUrl ? [`- Generated release PR: ${result.releasePrUrl}`] : []),
       ...(result.previousRevision
-        ? [`- Prior validated revision: \`${result.previousRevision}\``]
+        ? [`- Prior candidate revision: \`${result.previousRevision}\``]
         : []),
       result.versionOnlyMain
-        ? '- Application validation and image bytes can be reused from the prior revision.'
+        ? '- Application validation can use the fast path if prior image bytes are available.'
         : '- The workflow keeps the full main validation and build path.',
     ].join('\n'),
   );
@@ -196,7 +206,7 @@ async function classifyMain() {
     return;
   }
   const previousRevision = parentResult.stdout.trim();
-  if (!/^[a-f0-9]{40}$/.test(previousRevision)) {
+  if (!REVISION_PATTERN.test(previousRevision)) {
     await writeMainClassification(
       classificationResult(
         {},
@@ -331,6 +341,64 @@ async function classifyMain() {
   );
 }
 
+async function verifyImageReuse() {
+  const revision = argument('revision');
+  const imageRepositories = [...new Set(argumentValues('image-repository'))];
+  const references = imageRepositories.map(
+    (repository) => `${repository}:revision-${revision ?? ''}`,
+  );
+  let unavailableReferences = [];
+  let reason;
+
+  if (!REVISION_PATTERN.test(revision ?? '')) {
+    reason = 'prior-image-revision-invalid';
+  } else if (imageRepositories.length === 0) {
+    reason = 'application-image-repositories-missing';
+  } else {
+    const resolutions = await Promise.all(
+      references.map(async (reference) => {
+        const result = await run('oras', ['resolve', reference]);
+        return {
+          available: result.code === 0 && DIGEST_PATTERN.test(result.stdout.trim()),
+          reference,
+        };
+      }),
+    );
+    unavailableReferences = resolutions
+      .filter(({available}) => !available)
+      .map(({reference}) => reference);
+    reason =
+      unavailableReferences.length === 0
+        ? 'prior-application-images-available'
+        : 'prior-application-images-unavailable';
+  }
+
+  const versionOnlyMain = reason === 'prior-application-images-available';
+  await writeOutput({
+    version_only_main: String(versionOnlyMain),
+    reason,
+  });
+  await writeSummary(
+    [
+      '## Application image reuse classification',
+      '',
+      `- Result: **${versionOnlyMain ? 'version-only' : 'normal CI'}**`,
+      `- Reason: \`${reason}\``,
+      ...(revision ? [`- Prior revision: \`${revision}\``] : []),
+      ...(unavailableReferences.length > 0
+        ? [
+            '- Unavailable image references:',
+            ...unavailableReferences.map((reference) => `  - \`${reference}\``),
+          ]
+        : []),
+      versionOnlyMain
+        ? '- All prior image digests are available; image bytes can be reused.'
+        : '- The current release commit will run full validation and build its images once.',
+    ].join('\n'),
+  );
+  process.stdout.write(`${JSON.stringify({reason, unavailableReferences, versionOnlyMain})}\n`);
+}
+
 async function summarizeUpdate() {
   const before = JSON.parse(await readFile(argument('before'), 'utf8'));
   const after = JSON.parse(await readFile(argument('after'), 'utf8'));
@@ -371,6 +439,7 @@ const command = process.argv[2];
 if (command === 'plan') await plan();
 else if (command === 'authorize') await authorize();
 else if (command === 'classify-main') await classifyMain();
+else if (command === 'verify-image-reuse') await verifyImageReuse();
 else if (command === 'summarize-update') await summarizeUpdate();
 else if (command === 'summarize-publication') await summarizePublication();
 else throw new Error(`Unknown package release workflow command: ${command ?? '(missing)'}`);

--- a/.github/scripts/package-release-workflow.mjs
+++ b/.github/scripts/package-release-workflow.mjs
@@ -30,7 +30,7 @@ function run(command, args) {
       stderr += chunk;
     });
     child.once('error', reject);
-    child.once('exit', (code) => resolveCommand({code, stderr, stdout}));
+    child.once('close', (code) => resolveCommand({code, stderr, stdout}));
   });
 }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,9 +133,60 @@ jobs:
             --github-output "$GITHUB_OUTPUT" \
             --github-summary "$GITHUB_STEP_SUMMARY"
 
+  release-image-classification:
+    name: Verify reusable application image revision
+    needs: [release-classification]
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      needs.release-classification.result == 'success' &&
+      needs.release-classification.outputs.version_only_main == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      packages: read
+    outputs:
+      version_only_main: ${{ steps.classify-images.outputs.version_only_main || 'false' }}
+      reason: ${{ steps.classify-images.outputs.reason || 'prior-application-images-unavailable' }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Set up mise
+        uses: ./.github/actions/setup-mise
+        with:
+          tools: node
+
+      - name: Set up ORAS
+        uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2
+        with:
+          version: 1.3.3
+
+      - name: Log in to GHCR for image reuse classification
+        run: |
+          set -euo pipefail
+          printf '%s' "${{ secrets.GITHUB_TOKEN }}" \
+            | oras login ghcr.io --username "${{ github.actor }}" --password-stdin
+
+      - name: Classify reusable image revision
+        id: classify-images
+        env:
+          PREVIOUS_REVISION: ${{ needs.release-classification.outputs.version_only_previous_revision }}
+        run: |
+          node .github/scripts/package-release-workflow.mjs verify-image-reuse \
+            --revision "$PREVIOUS_REVISION" \
+            --image-repository ghcr.io/shipfoxhq/api \
+            --image-repository ghcr.io/shipfoxhq/client \
+            --image-repository ghcr.io/shipfoxhq/provisioner-docker \
+            --image-repository ghcr.io/shipfoxhq/provisioner-ec2 \
+            --image-repository ghcr.io/shipfoxhq/runner \
+            --github-output "$GITHUB_OUTPUT" \
+            --github-summary "$GITHUB_STEP_SUMMARY"
+
   release-mode:
     name: Select CI execution mode
-    needs: [release-classification]
+    needs: [release-classification, release-image-classification]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -150,11 +201,15 @@ jobs:
         env:
           CLASSIFICATION_RESULT: ${{ needs.release-classification.result }}
           GENERATED_RELEASE: ${{ needs.release-classification.outputs.generated_release }}
-          VERSION_ONLY_MAIN: ${{ needs.release-classification.outputs.version_only_main }}
+          IMAGE_CLASSIFICATION_RESULT: ${{ needs.release-image-classification.result }}
+          REUSABLE_IMAGES: ${{ needs.release-image-classification.outputs.version_only_main }}
+          VERSION_ONLY_MAIN_CANDIDATE: ${{ needs.release-classification.outputs.version_only_main }}
         run: |
           mode=normal
           if [[ "$CLASSIFICATION_RESULT" == success ]]; then
-            if [[ "$VERSION_ONLY_MAIN" == true ]]; then
+            if [[ "$VERSION_ONLY_MAIN_CANDIDATE" == true &&
+                  "$IMAGE_CLASSIFICATION_RESULT" == success &&
+                  "$REUSABLE_IMAGES" == true ]]; then
               mode=version-only-main
             elif [[ "$GENERATED_RELEASE" == true ]]; then
               mode=generated-release

--- a/docs/guides/release-pr-ci.md
+++ b/docs/guides/release-pr-ci.md
@@ -24,8 +24,11 @@ When the tree matches the generated Changesets output:
 - the application-release manifest records the prior image revision in
   `artifactReuse`.
 
-If GitHub metadata, the parent revision, generated tree, or any prior image
-digest cannot be resolved, the workflow uses normal validation or fails before
-publishing an incomplete application release. Ordinary source, configuration,
-dependency, Dockerfile, Packer, workflow, or application metadata changes keep
-the full `main` pipeline.
+If GitHub metadata, the parent revision, or generated tree cannot be resolved,
+the workflow uses normal validation. The version-only path also verifies every
+parent application-image revision tag before selecting reuse. If any tag is
+missing or does not resolve to an immutable digest, the current release commit
+runs the full `main` pipeline and builds its images once. It never substitutes
+an older image revision. Ordinary source, configuration, dependency,
+Dockerfile, Packer, workflow, or application metadata changes also keep the
+full `main` pipeline.

--- a/tools/package-release/test/package-release-workflow.test.ts
+++ b/tools/package-release/test/package-release-workflow.test.ts
@@ -16,10 +16,14 @@ const authorizedPattern = /authorized=true/;
 const createdPattern = /"result":"created"/;
 const releasePattern = /revision=release/;
 const releasePrPattern = /Release PR: #42/;
+const reusableImagesSummaryPattern = /image bytes can be reused/;
+const unavailableImagesPattern = /version_only_main=false/;
+const unavailableImagesReasonPattern = /reason=prior-application-images-unavailable/;
 const versionOnlyMainPattern = /version_only_main=true/;
 const versionOnlyReleasePrPattern =
   /version_only_release_pr=https:\/\/github\.com\/ShipfoxHQ\/shipfox\/pull\/999/;
 const versionOnlySummaryPattern = /version-only/;
+const imageDigest = `sha256:${'a'.repeat(64)}`;
 
 describe('package release workflow tool', () => {
   test('authorizes only merged release-App pull requests from the release branch', async () => {
@@ -146,6 +150,171 @@ describe('package release workflow tool', () => {
       assert.match(output, new RegExp(`version_only_previous_revision=${previousRevision}`));
       assert.match(output, versionOnlyReleasePrPattern);
       assert.match(await readFile(summaryPath, 'utf8'), versionOnlySummaryPattern);
+    } finally {
+      await rm(temporaryRoot, {force: true, recursive: true});
+    }
+  });
+
+  test('keeps version-only CI when every prior application image is available', async () => {
+    const temporaryRoot = await mkdtemp(join(tmpdir(), 'shipfox-image-reuse-test-'));
+    const binDirectory = join(temporaryRoot, 'bin');
+    const outputPath = join(temporaryRoot, 'output');
+    const summaryPath = join(temporaryRoot, 'summary');
+    const revision = 'fedcba9876543210fedcba9876543210fedcba98';
+
+    try {
+      await mkdir(binDirectory);
+      await writeExecutable(
+        join(binDirectory, 'oras'),
+        `#!/bin/sh\nprintf '%s\\n' '${imageDigest}'\n`,
+      );
+
+      await execFileAsync(
+        'node',
+        [
+          workflowTool,
+          'verify-image-reuse',
+          '--revision',
+          revision,
+          '--image-repository',
+          'ghcr.io/shipfoxhq/api',
+          '--image-repository',
+          'ghcr.io/shipfoxhq/client',
+          '--github-output',
+          outputPath,
+          '--github-summary',
+          summaryPath,
+        ],
+        {env: {...process.env, PATH: `${binDirectory}:${process.env.PATH}`}},
+      );
+
+      assert.match(await readFile(outputPath, 'utf8'), versionOnlyMainPattern);
+      assert.match(await readFile(summaryPath, 'utf8'), reusableImagesSummaryPattern);
+    } finally {
+      await rm(temporaryRoot, {force: true, recursive: true});
+    }
+  });
+
+  test('falls back to normal CI when a prior application image is unavailable', async () => {
+    const temporaryRoot = await mkdtemp(join(tmpdir(), 'shipfox-image-reuse-test-'));
+    const binDirectory = join(temporaryRoot, 'bin');
+    const outputPath = join(temporaryRoot, 'output');
+    const summaryPath = join(temporaryRoot, 'summary');
+    const revision = 'fedcba9876543210fedcba9876543210fedcba98';
+    const unavailableReference = `ghcr.io/shipfoxhq/client:revision-${revision}`;
+
+    try {
+      await mkdir(binDirectory);
+      await writeExecutable(
+        join(binDirectory, 'oras'),
+        `#!/bin/sh
+if [ "$2" = "${unavailableReference}" ]; then
+  exit 1
+fi
+printf '%s\\n' '${imageDigest}'
+`,
+      );
+
+      await execFileAsync(
+        'node',
+        [
+          workflowTool,
+          'verify-image-reuse',
+          '--revision',
+          revision,
+          '--image-repository',
+          'ghcr.io/shipfoxhq/api',
+          '--image-repository',
+          'ghcr.io/shipfoxhq/client',
+          '--github-output',
+          outputPath,
+          '--github-summary',
+          summaryPath,
+        ],
+        {env: {...process.env, PATH: `${binDirectory}:${process.env.PATH}`}},
+      );
+
+      const output = await readFile(outputPath, 'utf8');
+      assert.match(output, unavailableImagesPattern);
+      assert.match(output, unavailableImagesReasonPattern);
+      assert.match(await readFile(summaryPath, 'utf8'), new RegExp(unavailableReference));
+    } finally {
+      await rm(temporaryRoot, {force: true, recursive: true});
+    }
+  });
+
+  test('falls back to normal CI when a resolved image digest is malformed', async () => {
+    const temporaryRoot = await mkdtemp(join(tmpdir(), 'shipfox-image-reuse-test-'));
+    const binDirectory = join(temporaryRoot, 'bin');
+    const outputPath = join(temporaryRoot, 'output');
+    const summaryPath = join(temporaryRoot, 'summary');
+    const revision = 'fedcba9876543210fedcba9876543210fedcba98';
+    const imageReference = `ghcr.io/shipfoxhq/api:revision-${revision}`;
+
+    try {
+      await mkdir(binDirectory);
+      await writeExecutable(
+        join(binDirectory, 'oras'),
+        "#!/bin/sh\nprintf '%s\\n' 'sha256:not-an-immutable-digest'\n",
+      );
+
+      await execFileAsync(
+        'node',
+        [
+          workflowTool,
+          'verify-image-reuse',
+          '--revision',
+          revision,
+          '--image-repository',
+          'ghcr.io/shipfoxhq/api',
+          '--github-output',
+          outputPath,
+          '--github-summary',
+          summaryPath,
+        ],
+        {env: {...process.env, PATH: `${binDirectory}:${process.env.PATH}`}},
+      );
+
+      const output = await readFile(outputPath, 'utf8');
+      assert.match(output, unavailableImagesPattern);
+      assert.match(output, unavailableImagesReasonPattern);
+      assert.match(await readFile(summaryPath, 'utf8'), new RegExp(imageReference));
+    } finally {
+      await rm(temporaryRoot, {force: true, recursive: true});
+    }
+  });
+
+  test.each([
+    {
+      arguments: ['--revision', 'invalid-revision', '--image-repository', 'ghcr.io/shipfoxhq/api'],
+      reason: 'prior-image-revision-invalid',
+      scenario: 'the prior revision is invalid',
+    },
+    {
+      arguments: ['--revision', 'fedcba9876543210fedcba9876543210fedcba98'],
+      reason: 'application-image-repositories-missing',
+      scenario: 'no image repositories are provided',
+    },
+  ])('falls back to normal CI when $scenario', async ({arguments: commandArguments, reason}) => {
+    const temporaryRoot = await mkdtemp(join(tmpdir(), 'shipfox-image-reuse-test-'));
+    const outputPath = join(temporaryRoot, 'output');
+    const summaryPath = join(temporaryRoot, 'summary');
+
+    try {
+      await execFileAsync('node', [
+        workflowTool,
+        'verify-image-reuse',
+        ...commandArguments,
+        '--github-output',
+        outputPath,
+        '--github-summary',
+        summaryPath,
+      ]);
+
+      const output = await readFile(outputPath, 'utf8');
+      assert.match(output, unavailableImagesPattern);
+      assert.ok(output.includes(`reason=${reason}`));
+      assert.ok(!(await readFile(summaryPath, 'utf8')).includes('Unavailable image references:'));
     } finally {
       await rm(temporaryRoot, {force: true, recursive: true});
     }

--- a/tools/package-release/test/release-ci-workflow.test.ts
+++ b/tools/package-release/test/release-ci-workflow.test.ts
@@ -2,9 +2,11 @@ import assert from 'node:assert/strict';
 import {readFile} from 'node:fs/promises';
 import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
+import {parse} from 'yaml';
 
 const packageDirectory = dirname(fileURLToPath(import.meta.url));
 const workflowPath = resolve(packageDirectory, '../../../.github/workflows/ci.yml');
+const mainRefConditionPattern = /github\.ref == 'refs\/heads\/main'/;
 
 function readWorkflow() {
   return readFile(workflowPath, 'utf8');
@@ -38,12 +40,25 @@ describe('generated release CI path', () => {
 
   test('classifies version-only main commits and reuses immutable image digests', async () => {
     const workflow = await readWorkflow();
+    const parsedWorkflow = parse(workflow);
+    const releaseClassification = parsedWorkflow.jobs['release-classification'];
+    const imageClassification = parsedWorkflow.jobs['release-image-classification'];
 
     assert.ok(workflow.includes('classify-main'));
     assert.ok(workflow.includes('package-release-workflow.mjs classify-main'));
     assert.ok(workflow.includes('release-mode:'));
+    assert.equal(releaseClassification.permissions, undefined);
+    assert.equal(imageClassification.permissions.packages, 'read');
+    assert.match(imageClassification.if, mainRefConditionPattern);
     assert.ok(workflow.includes('mode=version-only-main'));
     assert.ok(workflow.includes('version_only_previous_revision'));
+    assert.ok(workflow.includes('steps.classify-images.outputs.version_only_main'));
+    assert.ok(workflow.includes('verify-image-reuse'));
+    assert.ok(workflow.includes('--image-repository ghcr.io/shipfoxhq/api'));
+    assert.ok(workflow.includes('--image-repository ghcr.io/shipfoxhq/client'));
+    assert.ok(workflow.includes('--image-repository ghcr.io/shipfoxhq/provisioner-docker'));
+    assert.ok(workflow.includes('--image-repository ghcr.io/shipfoxhq/provisioner-ec2'));
+    assert.ok(workflow.includes('--image-repository ghcr.io/shipfoxhq/runner'));
     assert.ok(workflow.includes('Reuse previous application image digest'));
     assert.ok(workflow.includes("needs.release-mode.outputs.mode == 'version-only-main'"));
     assert.ok(


### PR DESCRIPTION
GitHub Actions can replace an older pending `main` run even when running jobs are not canceled. A deterministic version-only release can therefore point at a direct parent whose application images were never built, causing the image-reuse matrix to fail while resolving the parent revision tag.

This change adds a main-only image availability classification step before selecting `version-only-main`. It verifies that all five direct-parent application image tags resolve to immutable SHA-256 digests. When every image exists, CI keeps the current fast retag path. If any image is missing or malformed, CI runs the normal validation path and builds the current revision once; it never substitutes an older revision.

The GHCR package-read permission remains isolated to the main-only classifier. The release workflow documentation and regression coverage now include successful reuse, missing images, malformed digests, invalid revisions, and missing repository inputs.

Validation: `mise exec -- turbo test type type:emit check --filter=@shipfox/package-release...` passes, including 56 package-release tests. YAML parsing and `git diff --check` also pass.
