### PR TITLE
Classify runner harness startup failures

### DIFF
--- a/.changeset/classify-harness-failure.md
+++ b/.changeset/classify-harness-failure.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-workflows-dto": minor
+"@shipfox/client-workflows": minor
+---
+
+Classifies runner agent harness startup failures separately from user-fixable agent configuration errors.

--- a/e2e/suites/flow/workflows/src/expect.ts
+++ b/e2e/suites/flow/workflows/src/expect.ts
@@ -52,6 +52,7 @@ const stepErrorReasonSchema = z.enum([
   'output_invalid',
   'agent_config_invalid',
   'agent_invocation_failed',
+  'agent_harness_unavailable',
 ]);
 type AssertExact<Actual, Expected> = [Actual] extends [Expected]
   ? [Expected] extends [Actual]

--- a/libs/api/workflows-dto/src/schemas/step.test.ts
+++ b/libs/api/workflows-dto/src/schemas/step.test.ts
@@ -75,6 +75,7 @@ describe('stepErrorDtoSchema', () => {
     undefined,
     'workspace_prep_failed',
     'agent_invocation_failed',
+    'agent_harness_unavailable',
   ] as const)('rejects an agent config issue when reason is %s', (reason) => {
     const result = stepErrorDtoSchema.safeParse({
       message: 'Model provider credentials are not configured',
@@ -83,6 +84,18 @@ describe('stepErrorDtoSchema', () => {
     });
 
     expect(result.success).toBe(false);
+  });
+
+  it('accepts an agent harness availability failure without an agent config issue', () => {
+    const result = stepErrorDtoSchema.parse({
+      message: 'Pi extension setup failed: Unknown option: --mcp-config',
+      reason: 'agent_harness_unavailable',
+    });
+
+    expect(result).toEqual({
+      message: 'Pi extension setup failed: Unknown option: --mcp-config',
+      reason: 'agent_harness_unavailable',
+    });
   });
 });
 

--- a/libs/api/workflows-dto/src/schemas/step.ts
+++ b/libs/api/workflows-dto/src/schemas/step.ts
@@ -3,11 +3,12 @@ import {z} from 'zod';
 // Machine-readable cause of a step failure, for DB troubleshooting. The runner
 // reports it and the server stores it as-is. The `checkout_*`, `git_unavailable`,
 // `workspace_prep_failed`, and `setup_aborted` values cover setup-phase failures.
-// For agent steps the cause is split: `agent_config_invalid` is a user-fixable
-// configuration error (unknown provider, missing provider credentials on the runner,
-// wrong provider/model pair, missing model or prompt), while `agent_invocation_failed`
-// covers a genuine provider/API failure once the config is valid (network, 5xx, auth
-// rejected at call time). (Aborts are never reported: the step loop stops before reporting.)
+// For agent steps the cause is split three ways: `agent_config_invalid` is a user-fixable
+// configuration error and carries an `agent_config_issue`; `agent_invocation_failed`
+// covers a provider/API failure once the configuration is valid; and
+// `agent_harness_unavailable` means the runner could not start its harness, so the model
+// was never called. The latter carries no `agent_config_issue`, because every issue code
+// names a user-fixable cause. (Aborts are never reported: the step loop stops before reporting.)
 export const stepErrorReasonSchema = z.enum([
   'checkout_failed',
   'checkout_auth_failed',
@@ -19,6 +20,7 @@ export const stepErrorReasonSchema = z.enum([
   'output_invalid',
   'agent_config_invalid',
   'agent_invocation_failed',
+  'agent_harness_unavailable',
 ]);
 
 export type StepErrorReasonDto = z.infer<typeof stepErrorReasonSchema>;

--- a/libs/api/workflows/src/presentation/dto/step.test.ts
+++ b/libs/api/workflows/src/presentation/dto/step.test.ts
@@ -49,6 +49,26 @@ describe('fromStepErrorDto', () => {
     });
   });
 
+  it('round-trips an agent harness availability failure without inventing an issue code', () => {
+    const persisted = fromStepErrorDto({
+      message: 'Pi extension setup failed: Unknown option: --mcp-config',
+      reason: 'agent_harness_unavailable',
+    });
+
+    expect(persisted).toEqual({
+      message: 'Pi extension setup failed: Unknown option: --mcp-config',
+      reason: 'agent_harness_unavailable',
+    });
+
+    const dto = toStepDto(step({type: 'agent', error: persisted}));
+
+    expect(dto.error).toEqual({
+      message: 'Pi extension setup failed: Unknown option: --mcp-config',
+      reason: 'agent_harness_unavailable',
+      category: 'user',
+    });
+  });
+
   it('persists config error field and source diagnostics', () => {
     const persisted = fromStepErrorDto({
       message: 'Could not resolve env.VERSION',

--- a/libs/client/workflows/src/core/entities/step.ts
+++ b/libs/client/workflows/src/core/entities/step.ts
@@ -10,7 +10,8 @@ export type StepErrorReason =
   | 'config_unresolvable'
   | 'output_invalid'
   | 'agent_config_invalid'
-  | 'agent_invocation_failed';
+  | 'agent_invocation_failed'
+  | 'agent_harness_unavailable';
 export type AgentConfigIssue =
   | 'step_config_invalid'
   | 'provider_not_configured'
@@ -29,6 +30,7 @@ export const STEP_ERROR_REASONS = new Set<StepErrorReason>([
   'output_invalid',
   'agent_config_invalid',
   'agent_invocation_failed',
+  'agent_harness_unavailable',
 ]);
 export const AGENT_CONFIG_ISSUES = new Set<AgentConfigIssue>([
   'step_config_invalid',

--- a/libs/runner/agent/src/core/claude-adapter.test.ts
+++ b/libs/runner/agent/src/core/claude-adapter.test.ts
@@ -270,6 +270,7 @@ describe('claudeHarnessAdapter', () => {
     await expect(result).rejects.toThrow(
       new AgentConfigError(
         'Claude Anthropic API endpoint blocked by egress policy: host-denied (api.anthropic.com).',
+        'step_config_invalid',
       ),
     );
     expect(queryMock).not.toHaveBeenCalled();
@@ -365,6 +366,7 @@ describe('claudeHarnessAdapter', () => {
     await expect(result).rejects.toThrow(
       new AgentConfigError(
         'Claude Anthropic base URL override blocked by egress policy: host-denied (blocked.example.test).',
+        'step_config_invalid',
       ),
     );
     expect(queryMock).not.toHaveBeenCalled();

--- a/libs/runner/agent/src/core/egress.test.ts
+++ b/libs/runner/agent/src/core/egress.test.ts
@@ -50,6 +50,7 @@ describe('assertRunnerEgressAllowed', () => {
     await expect(result).rejects.toThrow(
       new AgentConfigError(
         'Claude endpoint blocked by egress policy: host-denied (api.anthropic.com).',
+        'step_config_invalid',
       ),
     );
   });

--- a/libs/runner/agent/src/core/egress.ts
+++ b/libs/runner/agent/src/core/egress.ts
@@ -12,6 +12,7 @@ export async function assertRunnerEgressAllowed(
     if (error instanceof EgressDeniedError) {
       throw new AgentConfigError(
         `${blockedTargetLabel} blocked by egress policy: ${error.reason} (${error.target}).`,
+        'step_config_invalid',
       );
     }
     throw error;

--- a/libs/runner/agent/src/core/errors.ts
+++ b/libs/runner/agent/src/core/errors.ts
@@ -1,3 +1,4 @@
+import type {AgentSessionRuntimeDiagnostic} from '@earendil-works/pi-coding-agent';
 import type {AgentConfigIssueDto} from '@shipfox/api-workflows-dto';
 
 /**
@@ -10,10 +11,39 @@ import type {AgentConfigIssueDto} from '@shipfox/api-workflows-dto';
 export class AgentConfigError extends Error {
   constructor(
     message: string,
-    public readonly agentConfigIssue: AgentConfigIssueDto = 'step_config_invalid',
+    public readonly agentConfigIssue: AgentConfigIssueDto,
   ) {
     super(message);
     this.name = 'AgentConfigError';
+  }
+}
+
+export interface AgentHarnessEnvironment {
+  readonly cwd: string;
+  readonly provider: string;
+  readonly model: string;
+  readonly thinking: string;
+  readonly extensionPaths: readonly string[];
+}
+
+export class AgentHarnessUnavailableError extends Error {
+  public readonly diagnostics: readonly AgentSessionRuntimeDiagnostic[];
+  public readonly environment: AgentHarnessEnvironment;
+
+  constructor({
+    diagnostics,
+    environment,
+  }: {
+    diagnostics: readonly AgentSessionRuntimeDiagnostic[];
+    environment: AgentHarnessEnvironment;
+  }) {
+    const errors = diagnostics.filter((diagnostic) => diagnostic.type === 'error');
+    super(
+      `Pi extension setup failed: ${errors.map((diagnostic) => diagnostic.message).join('; ')}`,
+    );
+    this.name = 'AgentHarnessUnavailableError';
+    this.diagnostics = diagnostics;
+    this.environment = environment;
   }
 }
 

--- a/libs/runner/agent/src/core/pi-adapter.test.ts
+++ b/libs/runner/agent/src/core/pi-adapter.test.ts
@@ -81,7 +81,7 @@ import {
   DEFAULT_CUSTOM_MODEL_MAX_OUTPUT_TOKENS,
   DEFAULT_CUSTOM_MODEL_REASONING,
 } from '@shipfox/api-agent-dto';
-import {AgentConfigError} from '#core/errors.js';
+import {AgentConfigError, AgentHarnessUnavailableError} from '#core/errors.js';
 import type {HarnessInvocation} from '#core/harness.js';
 import type {IntegrationToolsBridge} from '#core/integration-tools-bridge.js';
 import {piHarnessAdapter} from '#core/pi-adapter.js';
@@ -286,9 +286,19 @@ describe('piHarnessAdapter', () => {
       diagnostics: [{type: 'error', message: 'Unknown option: --mcp-config'}],
     });
 
-    await expect(piHarnessAdapter.run(invocation())).rejects.toThrow(
-      'Pi extension setup failed: Unknown option: --mcp-config',
-    );
+    const error = await piHarnessAdapter.run(invocation()).catch((caught) => caught);
+    expect(error).toBeInstanceOf(AgentHarnessUnavailableError);
+    expect(error).toMatchObject({
+      message: 'Pi extension setup failed: Unknown option: --mcp-config',
+      diagnostics: [{type: 'error', message: 'Unknown option: --mcp-config'}],
+      environment: {
+        cwd: '/work',
+        provider: 'anthropic',
+        model: 'claude-opus-4-8',
+        thinking: 'high',
+        extensionPaths: ['pi-web-access'],
+      },
+    });
     expect(createAgentSessionMock).not.toHaveBeenCalled();
   });
 
@@ -773,6 +783,7 @@ describe('piHarnessAdapter', () => {
     ).rejects.toThrow(
       new AgentConfigError(
         'Custom model provider endpoint blocked by egress policy: private-network (10.0.0.12).',
+        'step_config_invalid',
       ),
     );
     expect(registerProviderMock).not.toHaveBeenCalled();
@@ -795,6 +806,7 @@ describe('piHarnessAdapter', () => {
     ).rejects.toThrow(
       new AgentConfigError(
         'Custom model provider "custom" is invalid: "apiKey" or "oauth" is required when defining models',
+        'step_config_invalid',
       ),
     );
     expect(createAgentSessionMock).not.toHaveBeenCalled();

--- a/libs/runner/agent/src/core/pi-adapter.ts
+++ b/libs/runner/agent/src/core/pi-adapter.ts
@@ -21,7 +21,11 @@ import {
 import {logger} from '@shipfox/node-opentelemetry';
 import {Type} from 'typebox';
 import {assertRunnerEgressAllowed} from '#core/egress.js';
-import {AgentConfigError, AgentInvocationError} from '#core/errors.js';
+import {
+  AgentConfigError,
+  AgentHarnessUnavailableError,
+  AgentInvocationError,
+} from '#core/errors.js';
 import type {HarnessAdapter, HarnessInvocation, HarnessResult} from '#core/harness.js';
 import {
   OutputCollector,
@@ -113,7 +117,14 @@ async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult>
           mcpConfig === undefined ? ['pi-web-access'] : ['pi-web-access', 'pi-mcp-adapter'],
       },
     });
-    assertPiServiceDiagnostics(services.diagnostics);
+    assertPiServiceDiagnostics(services.diagnostics, {
+      cwd,
+      provider,
+      model: modelId,
+      thinking,
+      extensionPaths:
+        mcpConfig === undefined ? ['pi-web-access'] : ['pi-web-access', 'pi-mcp-adapter'],
+    });
 
     const createdSession = await createAgentSessionFromServices({
       services,
@@ -230,12 +241,11 @@ interface PiMcpConfig {
 
 function assertPiServiceDiagnostics(
   diagnostics: Awaited<ReturnType<typeof createAgentSessionServices>>['diagnostics'],
+  environment: AgentHarnessUnavailableError['environment'],
 ): void {
   const errors = diagnostics.filter((diagnostic) => diagnostic.type === 'error');
   if (errors.length === 0) return;
-  throw new AgentConfigError(
-    `Pi extension setup failed: ${errors.map((diagnostic) => diagnostic.message).join('; ')}`,
-  );
+  throw new AgentHarnessUnavailableError({diagnostics, environment});
 }
 
 async function createPiMcpConfig(
@@ -379,6 +389,7 @@ async function registerCustomProvider(
       error instanceof Error && error.message.length > 0
         ? `Custom model provider "${provider}" is invalid: ${error.message}`
         : `Custom model provider "${provider}" is invalid.`,
+      'step_config_invalid',
     );
   }
 }

--- a/libs/runner/agent/src/core/step.test.ts
+++ b/libs/runner/agent/src/core/step.test.ts
@@ -41,7 +41,11 @@ import {
   AGENT_INTEGRATION_MCP_TRANSPORT,
 } from '@shipfox/api-agent-dto';
 import type {StepDto} from '@shipfox/api-workflows-dto';
-import {AgentConfigError, AgentInvocationError} from '#core/errors.js';
+import {
+  AgentConfigError,
+  AgentHarnessUnavailableError,
+  AgentInvocationError,
+} from '#core/errors.js';
 import type {HarnessInvocation} from '#core/harness.js';
 import {executeAgentStep} from '#core/step.js';
 
@@ -367,6 +371,30 @@ describe('executeAgentStep', () => {
       message: 'Unknown provider "foo" for agent step.',
       reason: 'agent_config_invalid',
       agent_config_issue: 'provider_unsupported',
+    });
+  });
+
+  it('fails with agent_harness_unavailable without an agent config issue', async () => {
+    runAgentMock.mockRejectedValue(
+      new AgentHarnessUnavailableError({
+        diagnostics: [{type: 'error', message: 'Unknown option: --mcp-config'}],
+        environment: {
+          cwd: '/work',
+          provider: 'anthropic',
+          model: 'claude-opus-4-8',
+          thinking: 'high',
+          extensionPaths: ['pi-web-access', 'pi-mcp-adapter'],
+        },
+      }),
+    );
+    const result = await executeAgentStep(buildAgentStep(), {runtime: RUNTIME});
+    expect(result).toEqual({
+      success: false,
+      error: {
+        message: 'Pi extension setup failed: Unknown option: --mcp-config',
+        reason: 'agent_harness_unavailable',
+      },
+      exit_code: null,
     });
   });
 

--- a/libs/runner/agent/src/core/step.ts
+++ b/libs/runner/agent/src/core/step.ts
@@ -15,7 +15,11 @@ import {logger} from '@shipfox/node-opentelemetry';
 import type {StepResult} from '@shipfox/runner-execution';
 import {createIntegrationToolsGatewayFetch, type LeaseTokenSource} from '@shipfox/runner-protocol';
 import {z} from 'zod';
-import {AgentConfigError, AgentInvocationError} from '#core/errors.js';
+import {
+  AgentConfigError,
+  AgentHarnessUnavailableError,
+  AgentInvocationError,
+} from '#core/errors.js';
 import type {HarnessAdapter} from '#core/harness.js';
 import {
   createIntegrationToolsBridge,
@@ -167,7 +171,11 @@ async function runSelectedHarness(params: {
     };
   } catch (error) {
     const reason: StepErrorReasonDto =
-      error instanceof AgentConfigError ? 'agent_config_invalid' : 'agent_invocation_failed';
+      error instanceof AgentHarnessUnavailableError
+        ? 'agent_harness_unavailable'
+        : error instanceof AgentConfigError
+          ? 'agent_config_invalid'
+          : 'agent_invocation_failed';
     return agentFailure(
       error instanceof Error ? error.message : String(error),
       reason,


### PR DESCRIPTION
Classifies runner agent-harness startup failures separately from user-fixable agent configuration errors.

The runner now reports `agent_harness_unavailable` when Pi cannot start its harness, preserving the raw diagnostics and non-secret environment payload for the structured logging follow-up. The DTO, API mapper, client mirror, E2E assertion schema, and focused tests stay aligned, and the required minor changesets cover both published package surfaces.

ENG-1303 retains the run-view callout and user-facing copy. ENG-1310 retains the structured diagnostic event and build-identity work.

Closes ENG-1302

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies runner harness startup failures as non-user errors by introducing the `agent_harness_unavailable` reason. Supports ENG-1302 while preserving the run-view callout (ENG-1303) and structured diagnostics work (ENG-1310).

- New Features
  - New failure reason: `agent_harness_unavailable` when the Pi harness cannot start; no `agent_config_issue` is attached.
  - Runner now throws `AgentHarnessUnavailableError` with raw Pi diagnostics and a safe environment snapshot (cwd, provider, model, thinking, extension paths).
  - Updated DTOs, API mapper, client entities, E2E schema, and tests; minor releases for `@shipfox/api-workflows-dto` and `@shipfox/client-workflows`.
  - Explicitly tags config errors with `step_config_invalid` where applicable.

- Migration
  - If you switch on step error reasons, handle `agent_harness_unavailable`.
  - Do not expect `agent_config_issue` for `agent_harness_unavailable`.
  - No UI copy changes; server contracts only add the new enum value.

<sup>Written for commit 707e61cf71739c27b3f304c0a9453e99c9343a52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

