### PR TITLE
[client-workflows] Show the configured provider in agent failure guidance

### DIFF
--- a/.changeset/real-agent-config.md
+++ b/.changeset/real-agent-config.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-workflows": patch
+---
+
+Uses the workflow step's agent configuration in failure guidance.

--- a/libs/client/workflows/src/components/workflow-run-view/job-card.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/job-card.tsx
@@ -390,7 +390,7 @@ function StepAttemptDetailPanel({
       {isAgentConfigFailure(step, selectedAttemptError) ? (
         <AgentConfigFailureCallout
           workspaceId={workspaceId}
-          config={null}
+          config={step.agentConfig}
           error={selectedAttemptError}
         />
       ) : null}

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -293,10 +293,10 @@ describe('WorkflowRunView', () => {
     expect(screen.queryByText('anthropic')).not.toBeInTheDocument();
     expect(screen.queryByText('claude-opus-4-8')).not.toBeInTheDocument();
     expect(screen.queryByText('high')).not.toBeInTheDocument();
-    expect(screen.getByText('Configure credentials for the selected provider')).toBeInTheDocument();
+    expect(screen.getByText('Configure credentials for anthropic')).toBeInTheDocument();
     expect(
       screen.getByText(
-        'This step uses the selected provider, but no workspace credentials are configured for that model provider. Configure the selected provider in Agents, then re-run the workflow.',
+        'This step uses anthropic, but no workspace credentials are configured for that model provider. Configure anthropic in Agents, then re-run the workflow.',
       ),
     ).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'Configure Agents'})).toHaveAttribute(
@@ -375,7 +375,7 @@ describe('WorkflowRunView', () => {
     expect(screen.queryByText('anthropic')).not.toBeInTheDocument();
     expect(screen.queryByText('claude-opus-4-8')).not.toBeInTheDocument();
     expect(screen.queryByText('high')).not.toBeInTheDocument();
-    expect(screen.getByText('Configure credentials for the selected provider')).toBeInTheDocument();
+    expect(screen.getByText('Configure credentials for anthropic')).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'Configure Agents'})).toHaveAttribute(
       'href',
       `/workspaces/${PROJECT_TEST_WID}/settings/agents`,


### PR DESCRIPTION
Agent configuration failures now show the provider from the workflow step configuration, so credential guidance identifies the provider that actually needs attention instead of falling back to generic wording.

Validation: mise exec -- rtk turbo type test check --filter=@shipfox/client-workflows...

Closes ENG-1304