### PR TITLE
Make runner build identity and harness failures diagnosable

### DIFF
--- a/.changeset/diagnosable-runner-build.md
+++ b/.changeset/diagnosable-runner-build.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/docker": patch
+---
+
+Forwards runner build identity into runner image builds so runtime diagnostics can identify the build.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -699,6 +699,9 @@ jobs:
           BUILD_NUMBER: ${{ github.run_number }}
         run: |
           set -euo pipefail
+          # apps/runner is private and has no package version; use the versioned
+          # orchestration package that composes the runner runtime as its image version.
+          export RUNNER_VERSION="$(node -p "require('./libs/runner/orchestration/package.json').version")"
           # CI supplies the ref through the environment: the registry base
           # (IMAGE_REGISTRIES) plus the commit identity (BUILD_NUMBER, GITHUB_SHA,
           # GITHUB_REF_NAME). shipfox-docker assembles each app's sha-/build-/latest

--- a/apps/runner/Dockerfile
+++ b/apps/runner/Dockerfile
@@ -118,12 +118,18 @@ USER shipfox
 ARG IMAGE_SOURCE="https://github.com/ShipfoxHQ/shipfox"
 ARG IMAGE_REVISION
 ARG IMAGE_CREATED
+ARG BUILD_NUMBER
+ARG RUNNER_VERSION
 LABEL org.opencontainers.image.title="@shipfox/runner" \
       org.opencontainers.image.description="Shipfox runner" \
       org.opencontainers.image.licenses="MIT" \
       org.opencontainers.image.source=$IMAGE_SOURCE \
       org.opencontainers.image.revision=$IMAGE_REVISION \
       org.opencontainers.image.created=$IMAGE_CREATED
+ENV IMAGE_REVISION=$IMAGE_REVISION \
+    IMAGE_CREATED=$IMAGE_CREATED \
+    BUILD_NUMBER=$BUILD_NUMBER \
+    RUNNER_VERSION=$RUNNER_VERSION
 
 # tini as PID 1; --enable-source-maps maps stack traces back to TypeScript.
 # OpenTelemetry is started in-process by startRunner(), so it needs no preload

--- a/libs/runner/agent/src/core/errors.ts
+++ b/libs/runner/agent/src/core/errors.ts
@@ -1,4 +1,7 @@
-import type {AgentSessionRuntimeDiagnostic} from '@earendil-works/pi-coding-agent';
+import type {
+  AgentSessionRuntimeDiagnostic,
+  LoadExtensionsResult,
+} from '@earendil-works/pi-coding-agent';
 import type {AgentConfigIssueDto} from '@shipfox/api-workflows-dto';
 
 /**
@@ -24,26 +27,33 @@ export interface AgentHarnessEnvironment {
   readonly model: string;
   readonly thinking: string;
   readonly extensionPaths: readonly string[];
+  readonly resolvedExtensionPaths?: readonly string[];
 }
 
 export class AgentHarnessUnavailableError extends Error {
   public readonly diagnostics: readonly AgentSessionRuntimeDiagnostic[];
   public readonly environment: AgentHarnessEnvironment;
+  public readonly resourceLoaderErrors: readonly LoadExtensionsResult['errors'][number][];
 
   constructor({
     diagnostics,
     environment,
+    resourceLoaderErrors = [],
   }: {
     diagnostics: readonly AgentSessionRuntimeDiagnostic[];
     environment: AgentHarnessEnvironment;
+    resourceLoaderErrors?: readonly LoadExtensionsResult['errors'][number][];
   }) {
     const errors = diagnostics.filter((diagnostic) => diagnostic.type === 'error');
-    super(
-      `Pi extension setup failed: ${errors.map((diagnostic) => diagnostic.message).join('; ')}`,
-    );
+    const messages = [
+      ...errors.map((diagnostic) => diagnostic.message),
+      ...resourceLoaderErrors.map((resourceError) => resourceError.error),
+    ];
+    super(`Pi extension setup failed: ${messages.join('; ')}`);
     this.name = 'AgentHarnessUnavailableError';
     this.diagnostics = diagnostics;
     this.environment = environment;
+    this.resourceLoaderErrors = resourceLoaderErrors;
   }
 }
 

--- a/libs/runner/agent/src/core/package-versions.ts
+++ b/libs/runner/agent/src/core/package-versions.ts
@@ -1,0 +1,58 @@
+import {readFileSync} from 'node:fs';
+import {createRequire} from 'node:module';
+import {dirname, join} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const require = createRequire(import.meta.url);
+const packageVersionCache = new Map<string, string | undefined>();
+
+export interface PiPackageVersions {
+  readonly pi?: string;
+  readonly piMcpAdapter?: string;
+  readonly piWebAccess?: string;
+}
+
+/**
+ * Reads the versions of the packages that make up the Pi harness. Each lookup is best effort:
+ * diagnostics must still be emitted when a broken installation cannot resolve its own metadata.
+ */
+export function piPackageVersions(): PiPackageVersions {
+  const pi = packageVersion('@earendil-works/pi-coding-agent');
+  const piMcpAdapter = packageVersion('pi-mcp-adapter');
+  const piWebAccess = packageVersion('pi-web-access');
+
+  return {
+    ...(pi === undefined ? {} : {pi}),
+    ...(piMcpAdapter === undefined ? {} : {piMcpAdapter}),
+    ...(piWebAccess === undefined ? {} : {piWebAccess}),
+  };
+}
+
+function packageVersion(packageName: string): string | undefined {
+  if (packageVersionCache.has(packageName)) return packageVersionCache.get(packageName);
+
+  let version: string | undefined;
+  try {
+    const packageJsonPath = resolvePackageJson(packageName);
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
+      version?: unknown;
+    };
+    version = typeof packageJson.version === 'string' ? packageJson.version : undefined;
+  } catch {
+    version = undefined;
+  }
+
+  packageVersionCache.set(packageName, version);
+  return version;
+}
+
+function resolvePackageJson(packageName: string): string {
+  try {
+    return require.resolve(`${packageName}/package.json`);
+  } catch {
+    // Pi exposes its ESM entry but intentionally does not export package.json. Resolve the
+    // entry and walk back to the package root without assuming the deployed /app path.
+    const entry = fileURLToPath(import.meta.resolve(packageName));
+    return join(dirname(entry), '..', 'package.json');
+  }
+}

--- a/libs/runner/agent/src/core/pi-adapter.test.ts
+++ b/libs/runner/agent/src/core/pi-adapter.test.ts
@@ -301,6 +301,12 @@ describe('piHarnessAdapter', () => {
   it('fails before creating a Pi session when extension setup reports an error', async () => {
     createAgentSessionServicesMock.mockResolvedValue({
       ...piServices('/work', [{type: 'error', message: 'Unknown option: --mcp-config'}]),
+      resourceLoader: {
+        getExtensions: () => ({
+          extensions: [{resolvedPath: `${piWebAccessDirectory}/index.ts`}],
+          errors: [],
+        }),
+      },
     });
 
     const error = await piHarnessAdapter.run(invocation()).catch((caught) => caught);
@@ -314,6 +320,7 @@ describe('piHarnessAdapter', () => {
         model: 'claude-opus-4-8',
         thinking: 'high',
         extensionPaths: ['pi-web-access'],
+        resolvedExtensionPaths: [`${piWebAccessDirectory}/index.ts`],
       },
     });
     expect(createAgentSessionMock).not.toHaveBeenCalled();
@@ -331,7 +338,12 @@ describe('piHarnessAdapter', () => {
       },
     });
 
-    await expect(piHarnessAdapter.run(invocation())).rejects.toThrow(piPathError.error);
+    const error = await piHarnessAdapter.run(invocation()).catch((caught) => caught);
+    expect(error).toBeInstanceOf(AgentHarnessUnavailableError);
+    expect(error).toMatchObject({
+      message: `Pi extension setup failed: Unknown option: --mcp-config; ${piPathError.error}`,
+      resourceLoaderErrors: [piPathError],
+    });
     expect(createAgentSessionMock).not.toHaveBeenCalled();
   });
 

--- a/libs/runner/agent/src/core/pi-adapter.ts
+++ b/libs/runner/agent/src/core/pi-adapter.ts
@@ -124,17 +124,29 @@ async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult>
         additionalExtensionPaths: extensionDirectories,
       },
     });
+    const extensionResult = services.resourceLoader?.getExtensions?.();
+    assertPiServiceDiagnostics(
+      services.diagnostics,
+      {
+        cwd,
+        provider,
+        model: modelId,
+        thinking,
+        extensionPaths:
+          mcpConfig === undefined ? ['pi-web-access'] : ['pi-web-access', 'pi-mcp-adapter'],
+        ...(extensionResult === undefined
+          ? {}
+          : {
+              resolvedExtensionPaths: extensionResult.extensions.map(
+                (extension) => extension.resolvedPath,
+              ),
+            }),
+      },
+      extensionResult?.errors,
+    );
     assertPiExtensionsLoaded({
       resourceLoader: services.resourceLoader,
       directories: extensionDirectories,
-    });
-    assertPiServiceDiagnostics(services.diagnostics, {
-      cwd,
-      provider,
-      model: modelId,
-      thinking,
-      extensionPaths:
-        mcpConfig === undefined ? ['pi-web-access'] : ['pi-web-access', 'pi-mcp-adapter'],
     });
 
     const createdSession = await createAgentSessionFromServices({
@@ -253,10 +265,11 @@ interface PiMcpConfig {
 function assertPiServiceDiagnostics(
   diagnostics: Awaited<ReturnType<typeof createAgentSessionServices>>['diagnostics'],
   environment: AgentHarnessUnavailableError['environment'],
+  resourceLoaderErrors: AgentHarnessUnavailableError['resourceLoaderErrors'] = [],
 ): void {
   const errors = diagnostics.filter((diagnostic) => diagnostic.type === 'error');
-  if (errors.length === 0) return;
-  throw new AgentHarnessUnavailableError({diagnostics, environment});
+  if (errors.length === 0 && resourceLoaderErrors.length === 0) return;
+  throw new AgentHarnessUnavailableError({diagnostics, environment, resourceLoaderErrors});
 }
 
 function createInMemoryCredentialStore(credentials: Record<string, Credential>): CredentialStore {

--- a/libs/runner/agent/src/core/step.test.ts
+++ b/libs/runner/agent/src/core/step.test.ts
@@ -430,7 +430,7 @@ describe('executeAgentStep', () => {
       }),
     );
 
-    await executeAgentStep(buildAgentStep(), {cwd: '/work', runtime: RUNTIME});
+    await executeAgentStep(buildAgentStep({current_attempt: 3}), {cwd: '/work', runtime: RUNTIME});
 
     expect(errorLog).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -438,6 +438,7 @@ describe('executeAgentStep', () => {
         harness: 'pi',
         jobExecutionId: '00000000-0000-0000-0000-000000000003',
         stepId: '00000000-0000-0000-0000-000000000001',
+        attempt: 3,
         requestedExtensionPaths: ['pi-web-access'],
         resolvedExtensionPaths: ['/app/node_modules/pi-web-access/index.js'],
         runnerVersion: '0.1.13',

--- a/libs/runner/agent/src/core/step.test.ts
+++ b/libs/runner/agent/src/core/step.test.ts
@@ -41,6 +41,7 @@ import {
   AGENT_INTEGRATION_MCP_TRANSPORT,
 } from '@shipfox/api-agent-dto';
 import type {StepDto} from '@shipfox/api-workflows-dto';
+import {logger} from '@shipfox/node-opentelemetry';
 import {
   AgentConfigError,
   AgentHarnessUnavailableError,
@@ -86,6 +87,11 @@ describe('executeAgentStep', () => {
     gatewayFetch.mockReset();
     runAgentMock.mockReset();
     runClaudeMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
   });
 
   it('runs the agent and reports process-success with exit_code 0', async () => {
@@ -396,6 +402,60 @@ describe('executeAgentStep', () => {
       },
       exit_code: null,
     });
+  });
+
+  it('logs bounded harness diagnostics with step and build identity', async () => {
+    vi.stubEnv('RUNNER_VERSION', '0.1.13');
+    vi.stubEnv('IMAGE_REVISION', '0123456789abcdef');
+    vi.stubEnv('IMAGE_CREATED', '2026-07-27T10:00:00.000Z');
+    vi.stubEnv('BUILD_NUMBER', '42');
+    const errorLog = vi.spyOn(logger(), 'error').mockImplementation(() => undefined);
+    runAgentMock.mockRejectedValue(
+      new AgentHarnessUnavailableError({
+        diagnostics: Array.from({length: 6}, (_, index) => ({
+          type: 'error' as const,
+          message: `${index}:${'x'.repeat(600)}`,
+        })),
+        environment: {
+          cwd: '/work',
+          provider: 'anthropic',
+          model: 'claude-opus-4-8',
+          thinking: 'high',
+          extensionPaths: ['pi-web-access'],
+          resolvedExtensionPaths: ['/app/node_modules/pi-web-access/index.js'],
+        },
+        resourceLoaderErrors: [
+          {path: '/app/node_modules/pi-web-access', error: 'Extension path does not exist'},
+        ],
+      }),
+    );
+
+    await executeAgentStep(buildAgentStep(), {cwd: '/work', runtime: RUNTIME});
+
+    expect(errorLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'runner.agent_harness_unavailable',
+        harness: 'pi',
+        jobExecutionId: '00000000-0000-0000-0000-000000000003',
+        stepId: '00000000-0000-0000-0000-000000000001',
+        requestedExtensionPaths: ['pi-web-access'],
+        resolvedExtensionPaths: ['/app/node_modules/pi-web-access/index.js'],
+        runnerVersion: '0.1.13',
+        imageRevision: '0123456789abcdef',
+        imageCreated: '2026-07-27T10:00:00.000Z',
+        buildNumber: '42',
+      }),
+      'Agent harness unavailable',
+    );
+    const fields = errorLog.mock.calls[0]?.[0] as {
+      diagnostics: Array<{message: string}>;
+      resourceLoaderErrors: Array<{error: string}>;
+    };
+    expect(fields.diagnostics).toHaveLength(5);
+    expect(fields.diagnostics[0]?.message).toHaveLength(500);
+    expect(fields.resourceLoaderErrors).toEqual([
+      {path: '/app/node_modules/pi-web-access', error: 'Extension path does not exist'},
+    ]);
   });
 
   it('preserves response from invocation failures that can report it', async () => {

--- a/libs/runner/agent/src/core/step.ts
+++ b/libs/runner/agent/src/core/step.ts
@@ -95,6 +95,7 @@ export async function executeAgentStep(
     return await runSelectedHarness({
       jobExecutionId: step.job_execution_id,
       stepId: step.id,
+      attempt: step.current_attempt,
       cwd: options.cwd ?? process.cwd(),
       harness: options.runtime.harness,
       model: options.runtime.model,
@@ -118,6 +119,7 @@ export async function executeAgentStep(
 async function runSelectedHarness(params: {
   jobExecutionId: string;
   stepId: string;
+  attempt: number;
   cwd: string;
   harness: Harness;
   model: string;
@@ -136,6 +138,7 @@ async function runSelectedHarness(params: {
   const {
     jobExecutionId,
     stepId,
+    attempt,
     cwd,
     harness,
     model,
@@ -181,7 +184,7 @@ async function runSelectedHarness(params: {
     };
   } catch (error) {
     if (error instanceof AgentHarnessUnavailableError) {
-      logHarnessUnavailable({error, harness, jobExecutionId, stepId});
+      logHarnessUnavailable({error, harness, jobExecutionId, stepId, attempt});
     }
     const reason: StepErrorReasonDto =
       error instanceof AgentHarnessUnavailableError
@@ -203,8 +206,9 @@ function logHarnessUnavailable(params: {
   harness: Harness;
   jobExecutionId: string;
   stepId: string;
+  attempt: number;
 }): void {
-  const {error, harness, jobExecutionId, stepId} = params;
+  const {error, harness, jobExecutionId, stepId, attempt} = params;
   const {environment} = error;
   logger().error(
     {
@@ -212,6 +216,7 @@ function logHarnessUnavailable(params: {
       harness,
       jobExecutionId,
       stepId,
+      attempt,
       cwd: environment.cwd,
       provider: environment.provider,
       model: environment.model,

--- a/libs/runner/agent/src/core/step.ts
+++ b/libs/runner/agent/src/core/step.ts
@@ -25,7 +25,11 @@ import {
   createIntegrationToolsBridge,
   type IntegrationToolsBridge,
 } from '#core/integration-tools-bridge.js';
+import {piPackageVersions} from '#core/package-versions.js';
 import {piHarnessAdapter} from '#core/pi-adapter.js';
+
+const MAX_HARNESS_DIAGNOSTICS = 5;
+const MAX_HARNESS_DIAGNOSTIC_MESSAGE_LENGTH = 500;
 
 export async function executeAgentStep(
   step: StepDto,
@@ -89,6 +93,8 @@ export async function executeAgentStep(
 
   try {
     return await runSelectedHarness({
+      jobExecutionId: step.job_execution_id,
+      stepId: step.id,
       cwd: options.cwd ?? process.cwd(),
       harness: options.runtime.harness,
       model: options.runtime.model,
@@ -110,6 +116,8 @@ export async function executeAgentStep(
 }
 
 async function runSelectedHarness(params: {
+  jobExecutionId: string;
+  stepId: string;
   cwd: string;
   harness: Harness;
   model: string;
@@ -126,6 +134,8 @@ async function runSelectedHarness(params: {
   onSessionEntry: ((line: string) => void) | undefined;
 }): Promise<StepResult> {
   const {
+    jobExecutionId,
+    stepId,
     cwd,
     harness,
     model,
@@ -170,6 +180,9 @@ async function runSelectedHarness(params: {
       exit_code: 0,
     };
   } catch (error) {
+    if (error instanceof AgentHarnessUnavailableError) {
+      logHarnessUnavailable({error, harness, jobExecutionId, stepId});
+    }
     const reason: StepErrorReasonDto =
       error instanceof AgentHarnessUnavailableError
         ? 'agent_harness_unavailable'
@@ -183,6 +196,48 @@ async function runSelectedHarness(params: {
       error instanceof AgentInvocationError ? error.response : undefined,
     );
   }
+}
+
+function logHarnessUnavailable(params: {
+  error: AgentHarnessUnavailableError;
+  harness: Harness;
+  jobExecutionId: string;
+  stepId: string;
+}): void {
+  const {error, harness, jobExecutionId, stepId} = params;
+  const {environment} = error;
+  logger().error(
+    {
+      event: 'runner.agent_harness_unavailable',
+      harness,
+      jobExecutionId,
+      stepId,
+      cwd: environment.cwd,
+      provider: environment.provider,
+      model: environment.model,
+      thinking: environment.thinking,
+      requestedExtensionPaths: environment.extensionPaths,
+      ...(environment.resolvedExtensionPaths === undefined
+        ? {}
+        : {resolvedExtensionPaths: environment.resolvedExtensionPaths}),
+      diagnostics: error.diagnostics.slice(0, MAX_HARNESS_DIAGNOSTICS).map((diagnostic) => ({
+        type: diagnostic.type,
+        message: diagnostic.message.slice(0, MAX_HARNESS_DIAGNOSTIC_MESSAGE_LENGTH),
+      })),
+      resourceLoaderErrors: error.resourceLoaderErrors
+        .slice(0, MAX_HARNESS_DIAGNOSTICS)
+        .map((resourceError) => ({
+          path: resourceError.path,
+          error: resourceError.error.slice(0, MAX_HARNESS_DIAGNOSTIC_MESSAGE_LENGTH),
+        })),
+      packageVersions: piPackageVersions(),
+      ...(process.env.RUNNER_VERSION ? {runnerVersion: process.env.RUNNER_VERSION} : {}),
+      ...(process.env.IMAGE_REVISION ? {imageRevision: process.env.IMAGE_REVISION} : {}),
+      ...(process.env.IMAGE_CREATED ? {imageCreated: process.env.IMAGE_CREATED} : {}),
+      ...(process.env.BUILD_NUMBER ? {buildNumber: process.env.BUILD_NUMBER} : {}),
+    },
+    'Agent harness unavailable',
+  );
 }
 
 async function selectHarnessAdapter(harness: Harness): Promise<HarnessAdapter> {

--- a/libs/runner/execution/src/core/setup-step.test.ts
+++ b/libs/runner/execution/src/core/setup-step.test.ts
@@ -108,6 +108,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
 });
 
 describe('executeSetupStep', () => {
@@ -286,6 +287,26 @@ describe('executeSetupStep', () => {
     expect(log.writeOutputLine).toHaveBeenCalledWith(
       'Setup completed successfully. The job is ready to run.',
     );
+  });
+
+  it('writes the image and runner build identity', async () => {
+    vi.stubEnv('RUNNER_VERSION', '0.1.13');
+    vi.stubEnv('IMAGE_REVISION', '0123456789abcdef');
+    vi.stubEnv('IMAGE_CREATED', '2026-07-27T10:00:00.000Z');
+    vi.stubEnv('BUILD_NUMBER', '42');
+    const log = fakeLog();
+
+    await run(log);
+
+    expect(log.writeGroup).toHaveBeenCalledWith({
+      name: 'Runner environment',
+      lines: expect.arrayContaining([
+        'Runner version: 0.1.13',
+        'Runner image revision: 0123456789abcdef',
+        'Runner image created: 2026-07-27T10:00:00.000Z',
+        'Runner build number: 42',
+      ]),
+    });
   });
 
   it('writes structured setup lifecycle logs', async () => {

--- a/libs/runner/execution/src/core/setup-step.ts
+++ b/libs/runner/execution/src/core/setup-step.ts
@@ -360,10 +360,10 @@ function writeRunnerEnvironment(log: SetupLogSink | undefined, gitVersion: strin
 
 function buildMetadataLines(): string[] {
   const lines: string[] = [];
-  if (process.env.npm_package_version)
-    lines.push(`Runner package version: ${process.env.npm_package_version}`);
+  if (process.env.RUNNER_VERSION) lines.push(`Runner version: ${process.env.RUNNER_VERSION}`);
   if (process.env.IMAGE_REVISION)
     lines.push(`Runner image revision: ${process.env.IMAGE_REVISION}`);
+  if (process.env.IMAGE_CREATED) lines.push(`Runner image created: ${process.env.IMAGE_CREATED}`);
   if (process.env.BUILD_NUMBER) lines.push(`Runner build number: ${process.env.BUILD_NUMBER}`);
   return lines;
 }

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -317,6 +317,7 @@ describe('runJobSteps', () => {
       result: {success: true, response: '', error: null, exit_code: 0},
       logOutcome: 'drained',
       jobId: JOB_ID,
+      jobExecutionId: JOB_CONTEXT.jobExecutionId,
       stepLabel: 'build',
       signal: ac.signal,
     });
@@ -331,6 +332,46 @@ describe('runJobSteps', () => {
       logOutcome: 'drained',
       signal: ac.signal,
     });
+  });
+
+  it('logs failed step identity and bounded error context', async () => {
+    const error = vi.spyOn(logger(), 'error').mockImplementation(() => undefined);
+    const run = buildRunStep();
+    const ac = new AbortController();
+
+    await reportStepResult({
+      leaseClient,
+      step: run,
+      attempt: 3,
+      result: {
+        success: false,
+        error: {
+          reason: 'agent_config_invalid',
+          agent_config_issue: 'provider_not_configured',
+          message: 'x'.repeat(250),
+        },
+        exit_code: null,
+      },
+      logOutcome: 'drained',
+      jobId: JOB_ID,
+      jobExecutionId: JOB_CONTEXT.jobExecutionId,
+      stepLabel: 'build',
+      signal: ac.signal,
+    });
+
+    expect(error).toHaveBeenCalledWith(
+      {
+        jobId: JOB_ID,
+        jobExecutionId: JOB_CONTEXT.jobExecutionId,
+        stepId: run.id,
+        stepName: run.name,
+        attempt: 3,
+        reason: 'agent_config_invalid',
+        agentConfigIssue: 'provider_not_configured',
+        message: 'x'.repeat(200),
+      },
+      'Step build failed',
+    );
   });
 
   it('pullNextStep returns the step-scoped lease token', async () => {

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -139,6 +139,7 @@ export async function runJobSteps(params: {
         result: execution.result,
         logOutcome,
         jobId,
+        jobExecutionId: jobContext.jobExecutionId,
         stepLabel,
         signal,
       });
@@ -719,16 +720,32 @@ export async function reportStepResult(params: {
   result: StepResult;
   logOutcome: LogOutcomeDto;
   jobId: string;
+  jobExecutionId: string;
   stepLabel: string;
   signal: AbortSignal;
 }): Promise<{cancel: boolean}> {
-  const {leaseClient, step, attempt, result, logOutcome, jobId, stepLabel, signal} = params;
+  const {leaseClient, step, attempt, result, logOutcome, jobId, jobExecutionId, stepLabel, signal} =
+    params;
 
   if (result.success) {
-    logger().info({jobId, stepId: step.id, stepName: step.name}, `Step ${stepLabel} succeeded`);
+    logger().info(
+      {jobId, jobExecutionId, stepId: step.id, stepName: step.name, attempt},
+      `Step ${stepLabel} succeeded`,
+    );
   } else {
     logger().error(
-      {jobId, stepId: step.id, stepName: step.name, reason: result.error?.reason},
+      {
+        jobId,
+        jobExecutionId,
+        stepId: step.id,
+        stepName: step.name,
+        attempt,
+        reason: result.error?.reason,
+        ...(result.error?.agent_config_issue
+          ? {agentConfigIssue: result.error.agent_config_issue}
+          : {}),
+        ...(result.error?.message ? {message: result.error.message.slice(0, 200)} : {}),
+      },
       `Step ${stepLabel} failed`,
     );
   }

--- a/tools/docker/src/docker.ts
+++ b/tools/docker/src/docker.ts
@@ -169,6 +169,13 @@ if (imageName) {
     args.push(`--build-arg=IMAGE_REVISION=${process.env.GITHUB_SHA}`);
   if (!hasBuildArg('IMAGE_CREATED'))
     args.push(`--build-arg=IMAGE_CREATED=${new Date().toISOString()}`);
+  if (imageName === 'runner') {
+    if (process.env.BUILD_NUMBER && !hasBuildArg('BUILD_NUMBER'))
+      args.push(`--build-arg=BUILD_NUMBER=${process.env.BUILD_NUMBER}`);
+    const runnerVersion = process.env.RUNNER_VERSION ?? process.env.BUILD_RUNNER_VERSION;
+    if (runnerVersion && !hasBuildArg('RUNNER_VERSION'))
+      args.push(`--build-arg=RUNNER_VERSION=${runnerVersion}`);
+  }
 }
 
 const command = buildShellCommand(['docker', 'buildx', 'build', ...args, ...passthrough, '.']);

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -113,7 +113,7 @@
     "image": {
       "cache": false,
       "dependsOn": ["build", "@shipfox/worktree-services#build"],
-      "env": ["BUILD_NUMBER", "NODE_VERSION", "PNPM_VERSION"],
+      "env": ["BUILD_NUMBER", "NODE_VERSION", "PNPM_VERSION", "RUNNER_VERSION"],
       "passThroughEnv": ["IMAGE_REGISTRIES"]
     }
   }


### PR DESCRIPTION
When Pi harness startup fails, the runner now emits one bounded structured event connecting job execution and step IDs to requested/resolved extension paths, resource-loader diagnostics, Pi package versions, and image/build identity. Runner setup logs also expose runner version, image revision/created, and build number.

The Docker path carries BUILD_NUMBER and RUNNER_VERSION into the image. CI derives RUNNER_VERSION from @shipfox/runner-orchestration because apps/runner is private and unversioned, and Turbo allows it through to the image task. Step outcome logs include attempt, jobExecutionId, agentConfigIssue, and a bounded message. No new DTO field or error-monitoring wiring was added, per the issue scope.

Validation passed with the affected type/test/check graph, Docker package tests, runner image build and environment inspection, and CI YAML parsing.

Closes ENG-1310

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds structured logging for Pi harness startup failures and surfaces runner image/build identity so issues can be traced to a specific build. Connects diagnostics to job/step IDs and attempts, and records runner/image metadata end-to-end (ENG-1310).

- New Features
  - Emits runner.agent_harness_unavailable with jobExecutionId, stepId, attempt, requested and resolved extension paths, bounded diagnostics (5 max, 500 chars), bounded resource-loader errors, and Pi package versions; includes runnerVersion, imageRevision, imageCreated, and buildNumber.
  - Setup step logs runner version, image revision/created timestamp, and build number. Step result logs include attempt and jobExecutionId; on failure, add reason, optional agentConfigIssue, and a message capped to 200 chars.
  - CI sets RUNNER_VERSION from `@shipfox/runner-orchestration`; `@shipfox/docker` forwards `RUNNER_VERSION` and `BUILD_NUMBER` as Docker build args; `apps/runner` Dockerfile stores them and image metadata in ENV; `turbo.jsonc` exposes `RUNNER_VERSION` to the image task.

<sup>Written for commit 1cdc9927793b33a99dae2cd59f43d560f36369d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

