### PR TITLE
[provisioner-docker-provider] Harden template schema and cost

### DIFF
--- a/.changeset/strict-docker-template-schema.md
+++ b/.changeset/strict-docker-template-schema.md
@@ -1,0 +1,5 @@
+---
+'@shipfox/provisioner-docker-provider': major
+---
+
+Make Docker template configuration strict and allow an explicit selection cost, falling back to CPU when omitted. Unknown keys in existing Docker operator configuration now fail validation.

--- a/apps/docs/content/docs/operations/runner-provisioners.mdx
+++ b/apps/docs/content/docs/operations/runner-provisioners.mdx
@@ -83,8 +83,9 @@ templates:
 ```
 
 When several templates satisfy a job's labels, the provisioner chooses the one
-with the fewest virtual CPUs. A specificity rule breaks a tie. The full template
-schema and every environment variable are in the
+with the lowest `cost`. If `cost` is omitted, the template's CPU count is used.
+A specificity rule breaks a tie. The full template schema and every environment
+variable are in the
 [Runner Provisioner reference](/reference/runner-provisioner).
 
 ## Related pages

--- a/apps/docs/content/docs/reference/runner-provisioner.mdx
+++ b/apps/docs/content/docs/reference/runner-provisioner.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Runner Provisioner Configuration Reference"
 sidebarTitle: "Runner Provisioner"
-description: "Every Shipfox runner provisioner environment variable with its default, plus the runner template file schema: labels, image, cpu, memory, and max_concurrency."
+description: "Every Shipfox runner provisioner environment variable with its default, plus the runner template file schema: labels, image, cpu, memory, cost, and max_concurrency."
 ---
 
 This page is the canonical reference for configuring the Docker runner provisioner (`@shipfox/provisioner-docker`). For how a provisioner works, see [Runner Provisioners](/operations/runner-provisioners); for starting one, see [Run a provisioner](/installation/runner-provisioner).
@@ -49,12 +49,13 @@ templates:
 | --- | --- | --- |
 | `labels` | `string[]` | Labels the started runner registers with. A template can serve any job whose required labels are all in this list. |
 | `image` | `string` | Container image to start. |
-| `cpu` | `number` | vCPUs allocated to the container. Also the template's selection cost. |
+| `cpu` | `number` | vCPUs allocated to the container. The default selection cost when `cost` is omitted. |
 | `memory` | `string` | Memory allocation, such as `4GiB`. |
 | `max_concurrency` | `number` | Cap on live containers started from this template. |
 | `target_concurrency` | `number` | Enrolled, unassigned runners to keep ready without demand. Defaults to `0`. Keep it at or below `max_concurrency`: the provisioner does not currently reject a template where it is higher. |
+| `cost` | `number` | Optional positive selection cost. Lower costs are preferred when several templates satisfy the same labels. Defaults to `cpu`. |
 
-**Template selection:** when several templates satisfy a job's labels, the provisioner picks the cheapest (fewest vCPUs), then the most specific.
+**Template selection:** when several templates satisfy a job's labels, the provisioner picks the lowest `cost` (or `cpu` when `cost` is omitted), then the most specific. The file and each template use strict schemas, so unknown keys fail with a file-scoped validation error.
 
 ## Related pages
 

--- a/libs/provisioner/core/src/types.ts
+++ b/libs/provisioner/core/src/types.ts
@@ -19,7 +19,7 @@ export interface ProvisionerTemplate<Spec = unknown> {
   /**
    * Selection cost; lower is preferred when several templates satisfy the same
    * reservation. Providers map this to whatever they optimize for (Docker uses
-   * vCPU count, so generic demand lands on the cheapest box that can run it).
+   * an explicit cost when set and falls back to vCPU count when it is omitted).
    */
   readonly cost: number;
   /** Provider-specific launch details, opaque to the control loop. */

--- a/libs/provisioner/docker/README.md
+++ b/libs/provisioner/docker/README.md
@@ -28,9 +28,10 @@ templates:
 ```
 
 Loading fails fast with a clear, file-scoped error on a missing file, malformed YAML,
-an invalid field, an unusable label, or an empty template set. Labels are canonicalized
-(trim, lowercase, dedupe, sort) with the shared runner-label rules. The vCPU count
-becomes the template's selection cost, so generic demand lands on the cheapest box.
+an invalid or unknown field, an unusable label, or an empty template set. Labels are
+canonicalized (trim, lowercase, dedupe, sort) with the shared runner-label rules.
+The optional `cost` field controls template selection; when it is omitted, the vCPU
+count is used. Lower costs win when several templates satisfy the same generic label.
 
 ## Current behavior
 

--- a/libs/provisioner/docker/src/templates.test.ts
+++ b/libs/provisioner/docker/src/templates.test.ts
@@ -38,6 +38,7 @@ templates:
     cpu: 4
     memory: 8GiB
     max_concurrency: 50
+    cost: 6
 `;
 
 describe('loadDockerTemplates', () => {
@@ -60,7 +61,7 @@ describe('loadDockerTemplates', () => {
         labels: ['ubuntu22', 'ubuntu22-4vcpu'],
         maxConcurrency: 50,
         targetConcurrency: 0,
-        cost: 4,
+        cost: 6,
         spec: {image: 'shipfox-runner:ubuntu22', cpu: 4, memory: '8GiB'},
       },
     ]);
@@ -129,6 +130,29 @@ templates:
 `);
 
     expect(() => loadDockerTemplates(path)).toThrow('cpu');
+  });
+
+  it('throws on an unknown template key with the file and template in the error', () => {
+    const path = writeTemplates(`
+templates:
+  t:
+    labels: [ubuntu22]
+    image: img
+    cpu: 1
+    memory: 2g
+    max_concurrency: 1
+    unknown_field: true
+`);
+
+    expect(() => loadDockerTemplates(path)).toThrow(
+      new RegExp(`Invalid Docker template config at ${path}: .*templates\\.t.*unknown_field`),
+    );
+  });
+
+  it('throws on an unknown file key', () => {
+    const path = writeTemplates(`${VALID}\nunknown: true`);
+
+    expect(() => loadDockerTemplates(path)).toThrow('unknown');
   });
 
   it('throws on a memory value that is not a size', () => {

--- a/libs/provisioner/docker/src/templates.ts
+++ b/libs/provisioner/docker/src/templates.ts
@@ -113,7 +113,7 @@ function toTemplate(
     labels,
     maxConcurrency: spec.max_concurrency,
     targetConcurrency: spec.target_concurrency,
-    // Cheaper (fewer vCPU) templates win when several satisfy the same generic label.
+    // Explicit costs control selection; omitted costs fall back to the vCPU count.
     cost: spec.cost ?? spec.cpu,
     spec: {image: spec.image, cpu: spec.cpu, memory: spec.memory},
   };

--- a/libs/provisioner/docker/src/templates.ts
+++ b/libs/provisioner/docker/src/templates.ts
@@ -24,18 +24,23 @@ export class DockerTemplateConfigError extends Error {
 
 const MAX_TEMPLATE_CONCURRENCY = 100_000;
 
-const dockerTemplateSchema = z.object({
-  labels: z.array(z.string()).min(1),
-  image: z.string().trim().min(1).default(DEFAULT_RUNNER_IMAGE),
-  cpu: z.number().positive(),
-  memory: z.string().regex(MEMORY_PATTERN, 'must be a size like "4GiB", "512m", "2g", or "512"'),
-  max_concurrency: z.number().int().positive().max(MAX_TEMPLATE_CONCURRENCY),
-  target_concurrency: z.number().int().min(0).max(MAX_TEMPLATE_CONCURRENCY).default(0),
-});
+const dockerTemplateSchema = z
+  .object({
+    labels: z.array(z.string()).min(1),
+    image: z.string().trim().min(1).default(DEFAULT_RUNNER_IMAGE),
+    cpu: z.number().positive(),
+    memory: z.string().regex(MEMORY_PATTERN, 'must be a size like "4GiB", "512m", "2g", or "512"'),
+    max_concurrency: z.number().int().positive().max(MAX_TEMPLATE_CONCURRENCY),
+    target_concurrency: z.number().int().min(0).max(MAX_TEMPLATE_CONCURRENCY).default(0),
+    cost: z.number().positive().optional(),
+  })
+  .strict();
 
-const dockerTemplatesFileSchema = z.object({
-  templates: z.record(z.string().min(1), dockerTemplateSchema),
-});
+const dockerTemplatesFileSchema = z
+  .object({
+    templates: z.record(z.string().min(1), dockerTemplateSchema),
+  })
+  .strict();
 
 /**
  * Read, parse, and validate the local Docker template config, returning the
@@ -109,7 +114,7 @@ function toTemplate(
     maxConcurrency: spec.max_concurrency,
     targetConcurrency: spec.target_concurrency,
     // Cheaper (fewer vCPU) templates win when several satisfy the same generic label.
-    cost: spec.cpu,
+    cost: spec.cost ?? spec.cpu,
     spec: {image: spec.image, cpu: spec.cpu, memory: spec.memory},
   };
 }


### PR DESCRIPTION
Harden Docker template configuration before matrix expansion:

- Reject unknown file and template keys with file-scoped validation errors.
- Accept an optional positive cost override while retaining the CPU fallback.
- Add regression coverage and document the operator-config strictness break in a major changeset.

This keeps Docker validation aligned with EC2 while preserving existing configurations that omit `cost`.

Closes ENG-1320

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened Docker template config in `@shipfox/provisioner-docker-provider` with strict schemas and an optional `cost` override (defaults to CPU). Docs now explain cost-first selection and strict validation, aligned with EC2 (ENG-1320).

- **Migration**
  - Remove any unknown keys from the Docker templates file (both top-level and per-template).
  - Optionally set `cost` per template to control selection; omit to keep CPU-based behavior.

<sup>Written for commit e38fc3ad6ab4005f432d8509ed391b51ee23efea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

