### PR TITLE
Raise provisioner template capacity to 1,000

### DIFF
--- a/.changeset/wise-cats-template.md
+++ b/.changeset/wise-cats-template.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-runners-dto": patch
+---
+
+Allow provisioner demand polls to advertise up to 1000 templates.

--- a/libs/api/runners-dto/src/schemas/poll-demand.test.ts
+++ b/libs/api/runners-dto/src/schemas/poll-demand.test.ts
@@ -1,4 +1,32 @@
-import {pollDemandResponseSchema} from './poll-demand.js';
+import {pollDemandBodySchema, pollDemandResponseSchema} from './poll-demand.js';
+
+const pollDemandTemplate = {
+  template_key: 'linux',
+  labels: ['linux'],
+  available_slots: 1,
+  starting: 0,
+  running: 0,
+};
+
+describe('pollDemandBodySchema', () => {
+  it('accepts up to 1000 advertised templates', () => {
+    const result = pollDemandBodySchema.safeParse({
+      max_reservations: 0,
+      templates: Array.from({length: 1000}, () => pollDemandTemplate),
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects more than 1000 advertised templates', () => {
+    const result = pollDemandBodySchema.safeParse({
+      max_reservations: 0,
+      templates: Array.from({length: 1001}, () => pollDemandTemplate),
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
 
 describe('pollDemandResponseSchema', () => {
   it('requires datetime response fields to be ISO datetimes', () => {

--- a/libs/api/runners-dto/src/schemas/poll-demand.ts
+++ b/libs/api/runners-dto/src/schemas/poll-demand.ts
@@ -13,7 +13,7 @@ export const pollDemandTemplateSchema = z.object({
 export const pollDemandBodySchema = z.object({
   wait_seconds: z.number().int().min(0).optional(),
   max_reservations: z.number().int().min(0).max(1000),
-  templates: z.array(pollDemandTemplateSchema).max(100),
+  templates: z.array(pollDemandTemplateSchema).max(1000),
 });
 
 export const demandStatSchema = z.object({

--- a/libs/api/runners-dto/src/schemas/report-runner-instances.test.ts
+++ b/libs/api/runners-dto/src/schemas/report-runner-instances.test.ts
@@ -41,6 +41,24 @@ describe('providerRunnerReportEventSchema', () => {
 });
 
 describe('reportRunnerInstancesBodySchema', () => {
+  it('accepts a batch at the limit', () => {
+    const event = {
+      provider_runner_id: 'container-1',
+      labels: ['linux'],
+      state: 'running',
+      reported_at: new Date().toISOString(),
+    };
+
+    const result = reportRunnerInstancesBodySchema.safeParse({
+      events: Array.from({length: MAX_PROVIDER_RUNNER_REPORT_EVENTS}, (_, index) => ({
+        ...event,
+        provider_runner_id: `container-${index}`,
+      })),
+    });
+
+    expect(result.success).toBe(true);
+  });
+
   it('enforces the batch size limit', () => {
     const event = {
       provider_runner_id: 'container-1',

--- a/libs/api/runners/src/presentation/routes/poll-demand.test.ts
+++ b/libs/api/runners/src/presentation/routes/poll-demand.test.ts
@@ -290,8 +290,8 @@ describe('POST /provisioners/demand/poll', () => {
     expect(res.statusCode).toBe(400);
   });
 
-  it('returns 400 for too many templates', async () => {
-    const templates = Array.from({length: 101}, (_, index) => ({
+  it('returns 400 for more than 1000 templates', async () => {
+    const templates = Array.from({length: 1001}, (_, index) => ({
       template_key: `linux-${index}`,
       labels: ['linux'],
       available_slots: 1,

--- a/libs/provisioner/core/src/provisioner.test.ts
+++ b/libs/provisioner/core/src/provisioner.test.ts
@@ -4,7 +4,7 @@ import type {
   PollDemandResponseDto,
 } from '@shipfox/api-runners-dto';
 import type {ProvisionerClient} from '#api-client.js';
-import {runProvisionerIteration} from '#provisioner.js';
+import {runProvisionerIteration, startProvisioner} from '#provisioner.js';
 import {createInMemoryTracker} from '#tracker.js';
 import type {ProvisionerAdapter, ProvisionerTemplate} from '#types.js';
 
@@ -146,6 +146,24 @@ describe('runProvisionerIteration', () => {
     });
 
     expect(result).toEqual({nextInterval: 1000, degraded: false});
+  });
+});
+
+describe('startProvisioner', () => {
+  it('rejects more than 1000 templates with a clear error', async () => {
+    const templates = Array.from({length: 1001}, (_, index) => ({
+      ...template,
+      key: `template-${index}`,
+    }));
+
+    await expect(
+      startProvisioner({
+        adapter: {
+          loadTemplates: () => Promise.resolve(templates),
+          launch: () => Promise.resolve(),
+        },
+      }),
+    ).rejects.toThrow('accepts at most 1000');
   });
 });
 

--- a/libs/provisioner/core/src/provisioner.ts
+++ b/libs/provisioner/core/src/provisioner.ts
@@ -15,8 +15,8 @@ import {type RunnerEnvFactory, runProvisionerTick} from '#tick.js';
 import {createInMemoryTracker, type ProviderRunnerTracker} from '#tracker.js';
 import type {ProvisionerAdapter, ProvisionerTemplate} from '#types.js';
 
-/** The demand poll accepts at most 100 advertised templates per request. */
-const MAX_TEMPLATES_PER_POLL = 100;
+/** The demand poll accepts at most 1000 advertised templates per request. */
+const MAX_TEMPLATES_PER_POLL = 1000;
 
 let running = true;
 // Module-level so the long-lived signal handler can cancel the in-flight long-poll;


### PR DESCRIPTION
Raise the provisioner template advertisement cap from 100 to 1,000 so expanded fleets can poll and report without schema rejection.

The startup guard and poll-demand DTO now accept up to 1,000 templates while preserving clear rejection above the limit. The report DTO was already capped at 1,000; its boundary coverage now verifies that contract explicitly.

Validation passed: package checks, focused tests, builds, production-source type emit, and diff checks. The isolated DTO and provisioner suites each pass 43 tests. The dependency-closure Turbo run still encounters an unrelated missing Biome regression fixture, and the test-config type command still encounters the repository's pre-existing missing `@shipfox/vitest` declaration; direct package tests and production-source type emit pass.

Closes ENG-1321

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the provisioner template advertisement cap from 100 to 1,000 so larger fleets can poll without schema rejection (ENG-1321). Adds clear rejection above 1,000 and aligns DTO, route contract, and tests.

- **New Features**
  - Updated `pollDemandBodySchema` and the HTTP route test to accept up to 1,000 templates and reject 1,001; added boundary tests and published a patch changeset for `@shipfox/api-runners-dto`.
  - Added startup validation in `startProvisioner` to enforce the same limit.

<sup>Written for commit 0bb2637264d5c34ff8f13167535854543902d35f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

