### PR TITLE
[runner-agent] Add Pi extension resolution regression coverage

### DIFF
--- a/libs/runner/agent/src/core/pi-adapter.test.ts
+++ b/libs/runner/agent/src/core/pi-adapter.test.ts
@@ -1,3 +1,7 @@
+const piExtensionTestState = vi.hoisted(() => ({
+  resolver: undefined as ((specifier: string) => string) | undefined,
+}));
+
 const {
   createAgentSessionMock,
   createAgentSessionServicesMock,
@@ -63,9 +67,28 @@ vi.mock('@shipfox/node-egress-guard', () => ({
       .filter(Boolean),
 }));
 
-import {appendFileSync, existsSync, mkdtempSync, readFileSync, rmSync} from 'node:fs';
+vi.mock('#core/pi-extensions.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('#core/pi-extensions.js')>();
+  return {
+    ...actual,
+    piExtensionDirectories: (params: Parameters<typeof actual.piExtensionDirectories>[0]) =>
+      piExtensionTestState.resolver === undefined
+        ? actual.piExtensionDirectories(params)
+        : actual.piExtensionDirectories({...params, resolve: piExtensionTestState.resolver}),
+  };
+});
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
 import {tmpdir} from 'node:os';
-import {join} from 'node:path';
+import {basename, isAbsolute, join} from 'node:path';
 import {
   type CustomModelProviderRuntimeConfigDto,
   DEFAULT_CUSTOM_MODEL_CONTEXT_WINDOW,
@@ -79,22 +102,47 @@ import type {IntegrationToolsBridge} from '#core/integration-tools-bridge.js';
 import {piHarnessAdapter} from '#core/pi-adapter.js';
 import {piExtensionDirectories} from '#core/pi-extensions.js';
 
-const piWebAccessDirectory = piExtensionDirectories({packageNames: ['pi-web-access']})[0];
-const piMcpAdapterDirectory = piExtensionDirectories({packageNames: ['pi-mcp-adapter']})[0];
+function extensionDirectory(packageName: string): string {
+  const [directory] = piExtensionDirectories({packageNames: [packageName]});
+  if (directory === undefined) throw new Error(`Missing resolved directory for ${packageName}`);
+  return directory;
+}
 
-function piServices(cwd = '/work', diagnostics: Array<{type: string; message: string}> = []) {
+const piWebAccessDirectory = extensionDirectory('pi-web-access');
+const piMcpAdapterDirectory = extensionDirectory('pi-mcp-adapter');
+
+function piServices(
+  cwd = '/work',
+  diagnostics: Array<{type: string; message: string}> = [],
+  loadedDirectories: readonly string[] = [piWebAccessDirectory, piMcpAdapterDirectory],
+  extensionErrors: Array<{path: string; error: string}> = [],
+) {
   return {
     cwd,
     diagnostics,
     resourceLoader: {
       getExtensions: () => ({
-        extensions: [piWebAccessDirectory, piMcpAdapterDirectory].map((directory) => ({
-          resolvedPath: `${directory}/index.ts`,
-        })),
-        errors: [],
+        extensions: loadedDirectories.map((directory) => ({resolvedPath: `${directory}/index.ts`})),
+        errors: extensionErrors,
       }),
     },
   };
+}
+
+function expectResolvedExtensionPaths(
+  paths: readonly string[] | undefined,
+  expectedNames: readonly string[],
+  workspace: string,
+): void {
+  expect(paths).toBeDefined();
+  if (paths === undefined) return;
+
+  expect(paths.map((path) => basename(path))).toEqual(expectedNames);
+  for (const path of paths) {
+    expect(isAbsolute(path)).toBe(true);
+    expect(statSync(path).isDirectory()).toBe(true);
+    expect(path.startsWith(workspace)).toBe(false);
+  }
 }
 
 function invocation(overrides: Partial<HarnessInvocation> = {}): HarnessInvocation {
@@ -163,6 +211,7 @@ describe('piHarnessAdapter', () => {
     disposeMock.mockReset();
     extensionShutdownMock.mockReset();
     modelRuntimeCreateMock.mockReset();
+    piExtensionTestState.resolver = undefined;
     assertEgressAllowedMock.mockReset();
     assertEgressAllowedMock.mockResolvedValue(undefined);
     findMock.mockReturnValue({provider: 'anthropic', id: 'claude-opus-4-8'});
@@ -204,11 +253,11 @@ describe('piHarnessAdapter', () => {
     const result = await piHarnessAdapter.run(invocation({provider: 'openai', model: 'gpt-5.1'}));
 
     expect(findMock).toHaveBeenCalledWith('openai', 'gpt-5.1');
-    expect(createAgentSessionServicesMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        cwd: '/work',
-        resourceLoaderOptions: {additionalExtensionPaths: [piWebAccessDirectory]},
-      }),
+    expectResolvedExtensionPaths(
+      createAgentSessionServicesMock.mock.calls[0]?.[0].resourceLoaderOptions
+        .additionalExtensionPaths,
+      ['pi-web-access'],
+      '/work',
     );
     expect(createAgentSessionMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -224,10 +273,11 @@ describe('piHarnessAdapter', () => {
   it('loads pi-web-access through the Pi resource loader without output tools by default', async () => {
     await piHarnessAdapter.run(invocation());
 
-    expect(createAgentSessionServicesMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        resourceLoaderOptions: {additionalExtensionPaths: [piWebAccessDirectory]},
-      }),
+    expectResolvedExtensionPaths(
+      createAgentSessionServicesMock.mock.calls[0]?.[0].resourceLoaderOptions
+        .additionalExtensionPaths,
+      ['pi-web-access'],
+      '/work',
     );
     expect(createAgentSessionMock.mock.calls[0]?.[0]).not.toHaveProperty('customTools');
   });
@@ -259,12 +309,11 @@ describe('piHarnessAdapter', () => {
         },
       },
     });
-    expect(createAgentSessionServicesMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        resourceLoaderOptions: {
-          additionalExtensionPaths: [piWebAccessDirectory, piMcpAdapterDirectory],
-        },
-      }),
+    expectResolvedExtensionPaths(
+      createAgentSessionServicesMock.mock.calls[0]?.[0].resourceLoaderOptions
+        .additionalExtensionPaths,
+      ['pi-web-access', 'pi-mcp-adapter'],
+      sessionDir,
     );
     expect(extensionShutdownMock).toHaveBeenCalledWith({type: 'session_shutdown', reason: 'quit'});
     expect(disposeMock).toHaveBeenCalledAfter(extensionShutdownMock);
@@ -345,6 +394,59 @@ describe('piHarnessAdapter', () => {
       resourceLoaderErrors: [piPathError],
     });
     expect(createAgentSessionMock).not.toHaveBeenCalled();
+  });
+
+  it('fails when Pi silently loads no requested extension', async () => {
+    createAgentSessionServicesMock.mockResolvedValue(piServices('/work', [], []));
+
+    await expect(piHarnessAdapter.run(invocation())).rejects.toThrow(piWebAccessDirectory);
+    expect(createAgentSessionMock).not.toHaveBeenCalled();
+  });
+
+  it('includes Pi extension errors in the setup failure', async () => {
+    const piPathError = {
+      path: piWebAccessDirectory,
+      error: `Extension path does not exist: ${piWebAccessDirectory}`,
+    };
+    createAgentSessionServicesMock.mockResolvedValue(piServices('/work', [], [], [piPathError]));
+
+    await expect(piHarnessAdapter.run(invocation())).rejects.toThrow(piPathError.error);
+    expect(createAgentSessionMock).not.toHaveBeenCalled();
+  });
+
+  it('names only the Pi extension directory that was not loaded', async () => {
+    sessionDir = mkdtempSync(join(tmpdir(), 'shipfox-pi-mcp-'));
+    createAgentSessionServicesMock.mockResolvedValue(
+      piServices('/work', [], [piWebAccessDirectory]),
+    );
+
+    const error = await piHarnessAdapter
+      .run(invocation({cwd: sessionDir, mcpServers: [mcpBridge()]}))
+      .catch((caught) => caught);
+
+    expect(error.message).toContain(piMcpAdapterDirectory);
+    expect(error.message).not.toContain(piWebAccessDirectory);
+    expect(createAgentSessionMock).not.toHaveBeenCalled();
+  });
+
+  it('wraps resolver failures as harness-unavailable and cleans the MCP temp directory', async () => {
+    sessionDir = mkdtempSync(join(tmpdir(), 'shipfox-pi-mcp-'));
+    const resolverError = new Error('Cannot find package entry');
+    piExtensionTestState.resolver = () => {
+      throw resolverError;
+    };
+
+    const error = await piHarnessAdapter
+      .run(invocation({cwd: sessionDir, mcpServers: [mcpBridge()]}))
+      .catch((caught) => caught);
+
+    expect(error).toBeInstanceOf(AgentHarnessUnavailableError);
+    expect(error).toMatchObject({
+      message: expect.stringContaining('pi-web-access'),
+      environment: {extensionPaths: ['pi-web-access', 'pi-mcp-adapter']},
+    });
+    expect(createAgentSessionServicesMock).not.toHaveBeenCalled();
+    expect(readdirSync(join(sessionDir, 'logs'))).toEqual([]);
   });
 
   it('registers the output tool for steps with declared outputs', async () => {

--- a/libs/runner/agent/src/core/pi-adapter.ts
+++ b/libs/runner/agent/src/core/pi-adapter.ts
@@ -110,10 +110,18 @@ async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult>
 
   try {
     mcpConfig = await createPiMcpConfig(cwd, mcpServers);
-    const extensionDirectories = piExtensionDirectories({
-      packageNames:
-        mcpConfig === undefined ? ['pi-web-access'] : ['pi-web-access', 'pi-mcp-adapter'],
-    });
+    const extensionPaths =
+      mcpConfig === undefined ? ['pi-web-access'] : ['pi-web-access', 'pi-mcp-adapter'];
+    let extensionDirectories: string[];
+    try {
+      extensionDirectories = piExtensionDirectories({packageNames: extensionPaths});
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new AgentHarnessUnavailableError({
+        diagnostics: [{type: 'error', message}],
+        environment: {cwd, provider, model: modelId, thinking, extensionPaths},
+      });
+    }
     const services = await createAgentSessionServices({
       cwd,
       modelRuntime,

--- a/libs/runner/agent/src/core/pi-extensions.test.ts
+++ b/libs/runner/agent/src/core/pi-extensions.test.ts
@@ -1,0 +1,136 @@
+import {mkdtempSync, readFileSync, rmSync, symlinkSync} from 'node:fs';
+import {createRequire} from 'node:module';
+import {tmpdir} from 'node:os';
+import {basename, dirname, isAbsolute, join} from 'node:path';
+import type {ResourceLoader} from '@earendil-works/pi-coding-agent';
+import {assertPiExtensionsLoaded, piExtensionDirectories} from '#core/pi-extensions.js';
+
+const extensionPackageNames = ['pi-web-access', 'pi-mcp-adapter'] as const;
+const require = createRequire(import.meta.url);
+
+type PiExtensionsResult = ReturnType<ResourceLoader['getExtensions']>;
+
+function extensionDirectory(packageName: string): string {
+  const [directory] = piExtensionDirectories({packageNames: [packageName]});
+  if (directory === undefined) throw new Error(`Missing resolved directory for ${packageName}`);
+  return directory;
+}
+
+function resourceLoader(
+  directories: readonly string[],
+  errors: PiExtensionsResult['errors'] = [],
+): Pick<ResourceLoader, 'getExtensions'> {
+  return {
+    getExtensions: (): PiExtensionsResult => ({
+      extensions: directories.map((directory) => ({
+        resolvedPath: join(directory, 'index.ts'),
+      })) as PiExtensionsResult['extensions'],
+      errors,
+      runtime: undefined as never,
+    }),
+  };
+}
+
+describe('piExtensionDirectories', () => {
+  it('resolves the real package directories with a non-empty Pi extension manifest', () => {
+    const directories = piExtensionDirectories({packageNames: extensionPackageNames});
+
+    expect(directories).toHaveLength(extensionPackageNames.length);
+    for (const [index, directory] of directories.entries()) {
+      const packageName = extensionPackageNames[index];
+      if (packageName === undefined) throw new Error(`Missing package name at index ${index}`);
+      const packageJson = JSON.parse(readFileSync(join(directory, 'package.json'), 'utf8'));
+
+      expect(isAbsolute(directory)).toBe(true);
+      expect(packageJson.name).toBe(packageName);
+      expect(packageJson.pi?.extensions).toEqual(expect.arrayContaining([expect.any(String)]));
+      expect(packageJson.pi.extensions.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('resolves pi-web-access through package.json because its bare package entry is absent', () => {
+    expect(() => require.resolve('pi-web-access')).toThrow();
+
+    const packageJsonPath = require.resolve('pi-web-access/package.json');
+    const [directory] = piExtensionDirectories({packageNames: ['pi-web-access']});
+
+    expect(dirname(packageJsonPath)).toBe(directory);
+  });
+
+  it('names the unavailable package when an injected resolver fails', () => {
+    const packageName = 'pi-web-access';
+
+    expect(() =>
+      piExtensionDirectories({
+        packageNames: [packageName],
+        resolve: () => {
+          throw new Error('resolver unavailable');
+        },
+      }),
+    ).toThrow(`Unable to resolve Pi extension package "${packageName}": resolver unavailable`);
+  });
+
+  it('memoizes repeated real package resolution and returns the same directory string', () => {
+    const [firstDirectory] = piExtensionDirectories({packageNames: ['pi-web-access']});
+    const [secondDirectory] = piExtensionDirectories({packageNames: ['pi-web-access']});
+
+    expect(secondDirectory).toBe(firstDirectory);
+  });
+});
+
+describe('assertPiExtensionsLoaded', () => {
+  it('accepts every requested directory when Pi reports an entry from each', () => {
+    const directories = piExtensionDirectories({packageNames: extensionPackageNames});
+
+    expect(() =>
+      assertPiExtensionsLoaded({
+        resourceLoader: resourceLoader(directories),
+        directories,
+      }),
+    ).not.toThrow();
+  });
+
+  it('includes the missing directory and Pi error text when no extension loaded', () => {
+    const resolvedDirectory = extensionDirectory('pi-web-access');
+    const error = {
+      path: resolvedDirectory,
+      error: `Extension path does not exist: ${resolvedDirectory}`,
+    };
+
+    expect(() =>
+      assertPiExtensionsLoaded({
+        resourceLoader: resourceLoader([], [error]),
+        directories: [resolvedDirectory],
+      }),
+    ).toThrow(`${resolvedDirectory}. Pi errors: ${JSON.stringify([error])}`);
+  });
+
+  it('accepts a symlinked extension directory like the pnpm development layout', () => {
+    const resolvedDirectory = extensionDirectory('pi-web-access');
+    const temporaryDirectory = mkdtempSync(join(tmpdir(), 'shipfox-pi-extension-'));
+    const linkedDirectory = join(temporaryDirectory, 'pi-web-access');
+    symlinkSync(resolvedDirectory, linkedDirectory, 'dir');
+
+    try {
+      expect(() =>
+        assertPiExtensionsLoaded({
+          resourceLoader: resourceLoader([linkedDirectory]),
+          directories: [resolvedDirectory],
+        }),
+      ).not.toThrow();
+    } finally {
+      rmSync(temporaryDirectory, {recursive: true, force: true});
+    }
+  });
+
+  it('does not treat a sibling directory with a similar name as a loaded extension', () => {
+    const resolvedDirectory = extensionDirectory('pi-web-access');
+
+    expect(() =>
+      assertPiExtensionsLoaded({
+        resourceLoader: resourceLoader([`${resolvedDirectory}-other`]),
+        directories: [resolvedDirectory],
+      }),
+    ).toThrow(basename(resolvedDirectory));
+  });
+});


### PR DESCRIPTION
Pi extension package names were previously passed through as workspace-relative paths, and the adapter tests asserted those literal names instead of proving that real extension directories loaded.

This adds real package-manifest resolution coverage, loader error and symlink handling tests, and adapter assertions that protect absolute paths, workspace boundaries, failure attribution, and MCP cleanup. Resolver failures are classified as harness-unavailable so users see the package cause instead of a downstream Pi flag symptom.

Validated with the affected-package Turbo type, test, and check workflow.

Closes ENG-1307

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add regression coverage and stricter checks for Pi extension directory resolution so real packages load and failures surface clearly. Closes ENG-1307.

- **Bug Fixes**
  - Resolve real package dirs for `pi-web-access`/`pi-mcp-adapter`; assert absolute, outside workspace; verify Pi reports them loaded and fail if none.
  - Wrap resolver failures as harness-unavailable with diagnostics (cwd, provider, model, thinking, extensionPaths); include loader error text; name only the missing extension on partial loads; clean MCP temp logs.
  - Add `pi-extensions.test.ts`: `package.json` fallback for `pi-web-access`, non-empty manifest, memoized resolution, accept symlinked dirs (pnpm), reject lookalike sibling paths.

<sup>Written for commit f72913ecf2582648a24384ea933713286d88e3f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

