### PR TITLE
[runner] Report truthful Pi tool capabilities

### DIFF
--- a/libs/runner/agent/src/core/pi-adapter.test.ts
+++ b/libs/runner/agent/src/core/pi-adapter.test.ts
@@ -47,6 +47,10 @@ const {assertEgressAllowedMock, EgressDeniedErrorMock} = vi.hoisted(() => {
   return {assertEgressAllowedMock: vi.fn(), EgressDeniedErrorMock: EgressDeniedError};
 });
 
+const {isPiExtensionAvailableMock} = vi.hoisted(() => ({
+  isPiExtensionAvailableMock: vi.fn(),
+}));
+
 vi.mock('@earendil-works/pi-coding-agent', () => ({
   createAgentSessionFromServices: createAgentSessionMock,
   createAgentSessionServices: createAgentSessionServicesMock,
@@ -71,6 +75,7 @@ vi.mock('#core/pi-extensions.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('#core/pi-extensions.js')>();
   return {
     ...actual,
+    isPiExtensionAvailable: isPiExtensionAvailableMock,
     piExtensionDirectories: (params: Parameters<typeof actual.piExtensionDirectories>[0]) =>
       piExtensionTestState.resolver === undefined
         ? actual.piExtensionDirectories(params)
@@ -214,6 +219,7 @@ describe('piHarnessAdapter', () => {
     piExtensionTestState.resolver = undefined;
     assertEgressAllowedMock.mockReset();
     assertEgressAllowedMock.mockResolvedValue(undefined);
+    isPiExtensionAvailableMock.mockReturnValue(true);
     findMock.mockReturnValue({provider: 'anthropic', id: 'claude-opus-4-8'});
     getAllMock.mockReturnValue([{provider: 'anthropic', id: 'claude-opus-4-8'}]);
     hasConfiguredAuthMock.mockReturnValue(true);
@@ -280,6 +286,19 @@ describe('piHarnessAdapter', () => {
       '/work',
     );
     expect(createAgentSessionMock.mock.calls[0]?.[0]).not.toHaveProperty('customTools');
+  });
+
+  it('keeps Pi built-ins available when pi-web-access is unavailable', async () => {
+    isPiExtensionAvailableMock.mockImplementation(
+      ({packageName}: {packageName: string}) => packageName !== 'pi-web-access',
+    );
+
+    await piHarnessAdapter.run(invocation());
+
+    expect(createAgentSessionServicesMock).toHaveBeenCalledWith(
+      expect.objectContaining({resourceLoaderOptions: {additionalExtensionPaths: []}}),
+    );
+    expect(createAgentSessionMock).toHaveBeenCalled();
   });
 
   it('configures eager loopback MCP proxy access in the job workspace', async () => {

--- a/libs/runner/agent/src/core/pi-adapter.ts
+++ b/libs/runner/agent/src/core/pi-adapter.ts
@@ -37,7 +37,11 @@ import {
   runOutputTurnLoop,
   withOutputGuidance,
 } from '#core/output-collector.js';
-import {assertPiExtensionsLoaded, piExtensionDirectories} from '#core/pi-extensions.js';
+import {
+  assertPiExtensionsLoaded,
+  isPiExtensionAvailable,
+  piExtensionDirectories,
+} from '#core/pi-extensions.js';
 import {type SessionForwarder, startSessionForwarder} from '#core/session-forwarder.js';
 
 const KEYLESS_CUSTOM_PROVIDER_API_KEY = 'shipfox-keyless-custom-provider-placeholder';
@@ -110,16 +114,24 @@ async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult>
 
   try {
     mcpConfig = await createPiMcpConfig(cwd, mcpServers);
-    const extensionPaths =
-      mcpConfig === undefined ? ['pi-web-access'] : ['pi-web-access', 'pi-mcp-adapter'];
+    const extensionPackageNames = [
+      ...(isPiExtensionAvailable({packageName: 'pi-web-access'}) ? ['pi-web-access'] : []),
+      ...(mcpConfig === undefined ? [] : ['pi-mcp-adapter']),
+    ];
     let extensionDirectories: string[];
     try {
-      extensionDirectories = piExtensionDirectories({packageNames: extensionPaths});
+      extensionDirectories = piExtensionDirectories({packageNames: extensionPackageNames});
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new AgentHarnessUnavailableError({
         diagnostics: [{type: 'error', message}],
-        environment: {cwd, provider, model: modelId, thinking, extensionPaths},
+        environment: {
+          cwd,
+          provider,
+          model: modelId,
+          thinking,
+          extensionPaths: extensionPackageNames,
+        },
       });
     }
     const services = await createAgentSessionServices({
@@ -140,8 +152,7 @@ async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult>
         provider,
         model: modelId,
         thinking,
-        extensionPaths:
-          mcpConfig === undefined ? ['pi-web-access'] : ['pi-web-access', 'pi-mcp-adapter'],
+        extensionPaths: extensionPackageNames,
         ...(extensionResult === undefined
           ? {}
           : {

--- a/libs/runner/agent/src/core/pi-extensions.ts
+++ b/libs/runner/agent/src/core/pi-extensions.ts
@@ -3,9 +3,10 @@ import {createRequire} from 'node:module';
 import {dirname, sep} from 'node:path';
 import type {ResourceLoader} from '@earendil-works/pi-coding-agent';
 
-const PI_HARNESS_EXTENSION_PACKAGE_NAMES = ['pi-web-access', 'pi-mcp-adapter'] as const;
+export const PI_HARNESS_EXTENSION_PACKAGE_NAMES = ['pi-web-access', 'pi-mcp-adapter'] as const;
 const require = createRequire(import.meta.url);
 const resolvedDirectories = new Map<string, string>();
+const availabilityByPackageName = new Map<string, boolean>();
 
 type PackageResolver = (specifier: string) => string;
 
@@ -35,14 +36,24 @@ export function piExtensionDirectories(params: {
   });
 }
 
-/** Returns whether a Pi extension package can be resolved from the runner installation. */
+/**
+ * Returns whether a Pi extension package can be resolved from the runner installation. Callers
+ * like the heartbeat loop invoke this on every tick, so both outcomes are cached: package
+ * resolvability is fixed for the process lifetime (a package install doesn't change at runtime).
+ */
 export function isPiExtensionAvailable(params: {packageName: string}): boolean {
+  const cached = availabilityByPackageName.get(params.packageName);
+  if (cached !== undefined) return cached;
+
+  let available: boolean;
   try {
     piExtensionDirectories({packageNames: [params.packageName]});
-    return true;
+    available = true;
   } catch {
-    return false;
+    available = false;
   }
+  availabilityByPackageName.set(params.packageName, available);
+  return available;
 }
 
 /** Resolves every Pi extension required by the runner image or throws with the package cause. */

--- a/libs/runner/agent/src/core/tool-capabilities.test.ts
+++ b/libs/runner/agent/src/core/tool-capabilities.test.ts
@@ -1,0 +1,45 @@
+const {isPiExtensionAvailableMock} = vi.hoisted(() => ({
+  isPiExtensionAvailableMock: vi.fn(),
+}));
+
+vi.mock('#core/pi-extensions.js', () => ({
+  isPiExtensionAvailable: isPiExtensionAvailableMock,
+}));
+
+import {runnerToolCapabilities} from '#core/tool-capabilities.js';
+
+beforeEach(() => {
+  isPiExtensionAvailableMock.mockReturnValue(true);
+});
+
+describe('runnerToolCapabilities', () => {
+  it('reports web access tools when pi-web-access is available', () => {
+    expect(runnerToolCapabilities().harnesses.pi?.tools).toEqual([
+      'read',
+      'bash',
+      'edit',
+      'write',
+      'grep',
+      'find',
+      'ls',
+      'web_search',
+      'fetch_content',
+      'get_search_content',
+    ]);
+    expect(isPiExtensionAvailableMock).toHaveBeenCalledWith({packageName: 'pi-web-access'});
+  });
+
+  it('reports only built-in tools when pi-web-access is unavailable', () => {
+    isPiExtensionAvailableMock.mockReturnValue(false);
+
+    expect(runnerToolCapabilities().harnesses.pi?.tools).toEqual([
+      'read',
+      'bash',
+      'edit',
+      'write',
+      'grep',
+      'find',
+      'ls',
+    ]);
+  });
+});

--- a/libs/runner/agent/src/core/tool-capabilities.ts
+++ b/libs/runner/agent/src/core/tool-capabilities.ts
@@ -1,17 +1,9 @@
 import type {RunnerToolCapabilitiesDto} from '@shipfox/api-runners-dto';
+import {isPiExtensionAvailable} from '#core/pi-extensions.js';
 
-const PI_TOOLS = [
-  'read',
-  'bash',
-  'edit',
-  'write',
-  'grep',
-  'find',
-  'ls',
-  'web_search',
-  'fetch_content',
-  'get_search_content',
-] as const;
+const PI_BUILTIN_TOOLS = ['read', 'bash', 'edit', 'write', 'grep', 'find', 'ls'] as const;
+
+const PI_WEB_ACCESS_TOOLS = ['web_search', 'fetch_content', 'get_search_content'] as const;
 
 const CLAUDE_TOOLS = [
   'Read',
@@ -25,9 +17,13 @@ const CLAUDE_TOOLS = [
 ] as const;
 
 export function runnerToolCapabilities(): RunnerToolCapabilitiesDto {
+  const piTools = isPiExtensionAvailable({packageName: 'pi-web-access'})
+    ? [...PI_BUILTIN_TOOLS, ...PI_WEB_ACCESS_TOOLS]
+    : [...PI_BUILTIN_TOOLS];
+
   return {
     harnesses: {
-      pi: {tools: [...PI_TOOLS]},
+      pi: {tools: piTools},
       claude: {tools: [...CLAUDE_TOOLS]},
     },
   };

--- a/libs/runner/agent/src/index.ts
+++ b/libs/runner/agent/src/index.ts
@@ -1,3 +1,7 @@
-export {assertPiHarnessExtensionsAvailable} from '#core/pi-extensions.js';
+export {
+  assertPiHarnessExtensionsAvailable,
+  isPiExtensionAvailable,
+  PI_HARNESS_EXTENSION_PACKAGE_NAMES,
+} from '#core/pi-extensions.js';
 export {executeAgentStep} from '#core/step.js';
 export {runnerToolCapabilities} from '#core/tool-capabilities.js';

--- a/libs/runner/orchestration/src/core/runner.test.ts
+++ b/libs/runner/orchestration/src/core/runner.test.ts
@@ -315,7 +315,7 @@ describe('startRunner', () => {
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalledWith(
       {packageNames: ['pi-mcp-adapter']},
-      'Required Pi extensions are unavailable; corresponding Pi tools will not be advertised',
+      'Required Pi extensions are unavailable; functionality may be degraded',
     );
   });
 

--- a/libs/runner/orchestration/src/core/runner.test.ts
+++ b/libs/runner/orchestration/src/core/runner.test.ts
@@ -29,12 +29,18 @@ vi.mock('#core/step-loop.js', () => ({
   runJobSteps: vi.fn(),
 }));
 
+const {isPiExtensionAvailableMock} = vi.hoisted(() => ({
+  isPiExtensionAvailableMock: vi.fn((_params: {packageName: string}) => true),
+}));
+
 vi.mock('@shipfox/runner-agent', () => ({
   runnerToolCapabilities: vi.fn(() => ({
     harnesses: {
       pi: {tools: ['read']},
     },
   })),
+  isPiExtensionAvailable: isPiExtensionAvailableMock,
+  PI_HARNESS_EXTENSION_PACKAGE_NAMES: ['pi-web-access', 'pi-mcp-adapter'],
 }));
 
 vi.mock('@shipfox/runner-protocol', () => ({
@@ -62,6 +68,7 @@ vi.mock('@shipfox/runner-protocol', () => ({
   },
 }));
 
+import {logger} from '@shipfox/node-opentelemetry';
 import {runnerToolCapabilities} from '@shipfox/runner-agent';
 import {
   consumeManagedRunnerBootstrapToken,
@@ -136,6 +143,7 @@ beforeEach(() => {
   vi.spyOn(Math, 'random').mockReturnValue(0);
   setPollConfig({interval: 1, maxInterval: 5, maxDuration: 1});
   mockResolveWorkspaceRoot.mockReturnValue(WORKSPACE_ROOT);
+  isPiExtensionAvailableMock.mockReturnValue(true);
   mockRequireRunnerLabels.mockReturnValue(['local']);
   mockRunnerStartupMode.mockReturnValue('direct');
   mockConsumeManagedRunnerBootstrapToken.mockReturnValue('sf_rbt_bootstrap-token');
@@ -294,6 +302,23 @@ describe('runJob', () => {
 });
 
 describe('startRunner', () => {
+  it('warns once when required Pi extensions are unavailable', async () => {
+    const warn = vi.spyOn(logger(), 'warn').mockImplementation(() => undefined);
+    isPiExtensionAvailableMock.mockImplementation(
+      ({packageName}: {packageName: string}) => packageName === 'pi-web-access',
+    );
+    mockRequestJob.mockRejectedValue(new RunnerSessionExhaustedError());
+
+    await startRunner();
+    await startRunner();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      {packageNames: ['pi-mcp-adapter']},
+      'Required Pi extensions are unavailable; corresponding Pi tools will not be advertised',
+    );
+  });
+
   it('exits before polling when the workspace root is unsafe', async () => {
     mockResolveWorkspaceRoot.mockImplementation(() => {
       throw new UnsafeWorkspaceRootError('/');

--- a/libs/runner/orchestration/src/core/runner.ts
+++ b/libs/runner/orchestration/src/core/runner.ts
@@ -6,7 +6,11 @@ import {
   createGracefulShutdownController,
   interruptibleSleep,
 } from '@shipfox/node-resilient-loop';
-import {runnerToolCapabilities} from '@shipfox/runner-agent';
+import {
+  isPiExtensionAvailable,
+  PI_HARNESS_EXTENSION_PACKAGE_NAMES,
+  runnerToolCapabilities,
+} from '@shipfox/runner-agent';
 import {
   consumeManagedRunnerBootstrapToken,
   createLeaseClient,
@@ -37,6 +41,7 @@ import {startHeartbeatLoop} from '#core/heartbeat-loop.js';
 import {runJobSteps} from '#core/step-loop.js';
 
 let running = true;
+let warnedAboutUnavailablePiExtensions = false;
 // Module-level so the long-lived SIGINT handler can reach the in-flight job's
 // controller; locally-scoped capture isn't possible from a process-global handler.
 let currentJobAbortController: AbortController | undefined;
@@ -62,6 +67,7 @@ export async function startRunner(): Promise<void> {
   // not silently fail every job.
   const workspaceRoot = resolveWorkspaceRootFromEnv();
   requireRunnerLabels();
+  warnAboutUnavailablePiExtensions();
   const startupMode = runnerStartupMode();
 
   logger().info(
@@ -146,6 +152,21 @@ export async function startRunner(): Promise<void> {
   }
 
   logger().info('Runner stopped');
+}
+
+function warnAboutUnavailablePiExtensions(): void {
+  if (warnedAboutUnavailablePiExtensions) return;
+
+  const unavailablePackages = PI_HARNESS_EXTENSION_PACKAGE_NAMES.filter(
+    (packageName) => !isPiExtensionAvailable({packageName}),
+  );
+  if (unavailablePackages.length === 0) return;
+
+  warnedAboutUnavailablePiExtensions = true;
+  logger().warn(
+    {packageNames: unavailablePackages},
+    'Required Pi extensions are unavailable; corresponding Pi tools will not be advertised',
+  );
 }
 
 export function nextBackoffInterval(ms: number): number {

--- a/libs/runner/orchestration/src/core/runner.ts
+++ b/libs/runner/orchestration/src/core/runner.ts
@@ -165,7 +165,7 @@ function warnAboutUnavailablePiExtensions(): void {
   warnedAboutUnavailablePiExtensions = true;
   logger().warn(
     {packageNames: unavailablePackages},
-    'Required Pi extensions are unavailable; corresponding Pi tools will not be advertised',
+    'Required Pi extensions are unavailable; functionality may be degraded',
   );
 }
 


### PR DESCRIPTION
Runner capability reports now reflect the installed Pi extensions instead of claiming web tools unconditionally. Successful and failed extension resolutions are cached for the process lifetime, and runner startup emits one warning listing any missing required Pi extensions while continuing to serve other harnesses.

The MCP adapter remains log-only in the capability report because its tool names are dynamic per connection rather than a fixed set that can be negotiated truthfully.

Validation completed with:
`mise exec -- turbo type test check --filter=@shipfox/runner-agent... --filter=@shipfox/runner-orchestration...`

Closes ENG-1308

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runner now reports Pi tool capabilities based on installed extensions and keeps built-ins usable when web access is missing. Web tools are advertised only when `pi-web-access` is available; startup warns once about missing required extensions (ENG-1308).

- New Features
  - Advertise only built-in Pi tools by default; add `web_search`, `fetch_content`, `get_search_content` when `pi-web-access` is installed.
  - Skip loading `pi-web-access` when missing so sessions still start and built-ins remain available.
  - Cache extension availability (success and failure) for the process lifetime.
  - Export `isPiExtensionAvailable` and `PI_HARNESS_EXTENSION_PACKAGE_NAMES` from `@shipfox/runner-agent`; MCP adapter tools are not reported since names are dynamic per connection.

<sup>Written for commit 9c8ad5dc57b81d1f7f221b4467bcb417dfb6e5cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

