### PR TITLE
[api-runners] Keep assignment retries idempotent after cleanup

### DIFF
--- a/.changeset/calm-runners-retry.md
+++ b/.changeset/calm-runners-retry.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-runners": patch
+---
+
+Allows provisioner assignment retries after reservation cleanup.

--- a/libs/api/runners/src/db/runner-assignments.test.ts
+++ b/libs/api/runners/src/db/runner-assignments.test.ts
@@ -61,6 +61,25 @@ describe('assignRunnerInstances', () => {
     expect(results).toEqual([[runner.id], [runner.id]]);
   });
 
+  it('is idempotent after an assigned reservation is deleted', async () => {
+    const reservation = await createReservation();
+    const runner = await createEnrolledRunner();
+    await assignRunnerInstances({
+      provisionerId,
+      reservationId: reservation.id,
+      runnerInstanceIds: [runner.id],
+    });
+    await db().delete(reservations).where(eq(reservations.id, reservation.id));
+
+    const assigned = await assignRunnerInstances({
+      provisionerId,
+      reservationId: reservation.id,
+      runnerInstanceIds: [runner.id],
+    });
+
+    expect(assigned).toEqual([runner.id]);
+  });
+
   it('rejects expired reservations', async () => {
     const reservation = await createReservation({expiresAt: new Date(Date.now() - 1_000)});
     const runner = await createEnrolledRunner();

--- a/libs/api/runners/src/db/runner-assignments.ts
+++ b/libs/api/runners/src/db/runner-assignments.ts
@@ -21,21 +21,6 @@ export async function assignRunnerInstances(params: {
     await tx.execute(
       sql`select pg_advisory_xact_lock(hashtext(${`runners_assignment:${params.provisionerId}:${params.reservationId}`}))`,
     );
-    const [reservation] = await tx
-      .select()
-      .from(reservations)
-      .where(
-        and(
-          eq(reservations.id, params.reservationId),
-          eq(reservations.provisionerId, params.provisionerId),
-        ),
-      )
-      .limit(1)
-      .for('update');
-    if (!reservation) throw new ReservationNotFoundError(params.reservationId);
-    if (reservation.expiresAt <= new Date())
-      throw new ReservationExpiredError(params.reservationId);
-
     const runnerRows = await tx
       .select({
         id: providerRunners.id,
@@ -53,6 +38,33 @@ export async function assignRunnerInstances(params: {
         ),
       )
       .for('update');
+
+    // The assignment outlives its short reservation row. A retry after maintenance
+    // cleanup is complete when every owned runner already carries the requested assignment.
+    if (
+      runnerInstanceIds.length > 0 &&
+      runnerRows.length === runnerInstanceIds.length &&
+      runnerRows.every((runner) => runner.reservationId === params.reservationId)
+    )
+      return params.runnerInstanceIds;
+
+    const [reservation] = await tx
+      .select()
+      .from(reservations)
+      .where(
+        and(
+          eq(reservations.id, params.reservationId),
+          eq(reservations.provisionerId, params.provisionerId),
+        ),
+      )
+      .limit(1)
+      .for('update');
+    if (!reservation) throw new ReservationNotFoundError(params.reservationId);
+    if (reservation.expiresAt <= new Date())
+      throw new ReservationExpiredError(params.reservationId);
+    if (runnerRows.length !== runnerInstanceIds.length)
+      throw new RunnerInstanceNotAssignableError(runnerInstanceIds[0] ?? '');
+
     const activeControlSessions = await tx
       .select({runnerInstanceId: runnerControlSessions.runnerInstanceId})
       .from(runnerControlSessions)
@@ -72,8 +84,6 @@ export async function assignRunnerInstances(params: {
       ...runner,
       controlSessionId: runnerInstanceIdsWithControlSession.has(runner.id) ? runner.id : null,
     }));
-    if (runners.length !== runnerInstanceIds.length)
-      throw new RunnerInstanceNotAssignableError(runnerInstanceIds[0] ?? '');
 
     const alreadyAssigned = runners.filter((runner) => runner.reservationId !== null);
     if (alreadyAssigned.some((runner) => runner.reservationId !== reservation.id))


### PR DESCRIPTION
## Summary

Keep provisioner runner-assignment retries successful after the temporary reservation row has been cleaned up.

The assignment endpoint now recognizes the durable runner assignment before requiring the short-lived reservation. First-time assignments still require a live, unexpired reservation.

Adds regression coverage for the production sequence: assign a runner, delete the reservation, then retry the assignment.

## Validation

- `turbo test --filter=@shipfox/api-runners... --force`
- `turbo check type depcruise --filter=@shipfox/api-runners...`
- `pnpm check:api-database-boundaries`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make runner assignment retries idempotent after reservation cleanup in `@shipfox/api-runners`. Retries now succeed if runners already hold the assignment, while first-time assignments still require a live reservation.

- **Bug Fixes**
  - Return success when all requested runners already reference the given reservation, even if the reservation row was cleaned up.
  - Keep validation for first-time assignments (reservation must exist and not be expired).
  - Add regression test for assign → delete reservation → retry flow.

<sup>Written for commit d07c93425d8e5ffd9663406b180ef064c1c646ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

