### PR TITLE
[runner-protocol] Tolerate unknown step error fields in reports

### DIFF
--- a/libs/runner/protocol/src/api-client.test.ts
+++ b/libs/runner/protocol/src/api-client.test.ts
@@ -565,6 +565,45 @@ describe('api-client auth contexts', () => {
     const body = JSON.parse(calls[0]?.body ?? '{}');
     expect(body.error.message).toHaveLength(STEP_ERROR_MESSAGE_MAX_LENGTH);
   });
+
+  it('retries a 400 report without error classification fields', async () => {
+    const responses = [
+      jsonResponse({code: 'invalid-step-error'}, 400),
+      jsonResponse({ok: true, cancel: false}),
+    ];
+    stubFetch(() => responses.shift() ?? new Response(null, {status: 500}));
+    const leaseClient = createLeaseClient('lease-error');
+
+    await reportStep(leaseClient, {
+      stepId: STEP_ID,
+      attempt: 1,
+      status: 'failed',
+      error: {
+        message: 'The runner could not start the agent',
+        exit_code: null,
+        signal: 'SIGTERM',
+        reason: 'agent_config_invalid',
+        agent_config_issue: 'provider_not_configured',
+        field: 'agent_config',
+        source: 'runner',
+      },
+      exitCode: 1,
+      logOutcome: 'drained',
+    });
+
+    expect(calls).toHaveLength(2);
+    expect(JSON.parse(calls[1]?.body ?? '{}')).toEqual({
+      status: 'failed',
+      attempt: 1,
+      exit_code: 1,
+      error: {
+        message: 'The runner could not start the agent',
+        exit_code: null,
+        signal: 'SIGTERM',
+      },
+      log_outcome: 'drained',
+    });
+  });
 });
 
 describe('appendStepLogs', () => {

--- a/libs/runner/protocol/src/api-client.ts
+++ b/libs/runner/protocol/src/api-client.ts
@@ -340,11 +340,39 @@ export async function reportStep(
     log_outcome: params.logOutcome,
   });
 
-  const response = await leaseClient.post(`runs/jobs/current/steps/${params.stepId}/report`, {
+  const endpoint = `runs/jobs/current/steps/${params.stepId}/report`;
+  const requestOptions = {
     json: body,
     ...(params.signal ? {signal: params.signal} : {}),
-  });
+  };
+
+  let response: Response;
+  try {
+    response = await leaseClient.post(endpoint, requestOptions);
+  } catch (error) {
+    if (!(error instanceof HTTPError) || error.response.status !== 400) throw error;
+
+    logger().warn(
+      {stepId: params.stepId},
+      'Step report rejected with status 400; retrying without error classification fields',
+    );
+    response = await leaseClient.post(endpoint, {
+      ...requestOptions,
+      json: {
+        ...body,
+        ...(body.error == null ? {} : {error: stripStepErrorClassification(body.error)}),
+      },
+    });
+  }
+
   return reportStepResponseSchema.parse(await response.json());
+}
+
+function stripStepErrorClassification(
+  error: Exclude<StepErrorDto, null>,
+): Pick<Exclude<StepErrorDto, null>, 'message' | 'exit_code' | 'signal'> {
+  const {message, exit_code, signal} = error;
+  return {message, exit_code, signal};
 }
 
 // Exchanges the job lease for short-lived, read-only checkout credentials. The job is


### PR DESCRIPTION
Older self-hosted APIs can reject a newer runner's step error classification fields with HTTP 400, which previously abandoned the report. This change makes reportStep retry once for that endpoint after a 400, stripping classification fields while preserving the message, exit code, and signal. The shared retry status list is unchanged, so 400s elsewhere retain their existing behavior.

Validated with `mise exec -- rtk turbo type test check --filter=@shipfox/runner-protocol...`.

Closes ENG-1305

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retry step reports once on HTTP 400 and strip unknown error classification fields to stay compatible with older self-hosted APIs. Preserves message, exit code, and signal; addresses ENG-1305.

- **Bug Fixes**
  - Added retry in `reportStep` for 400 responses from `runs/jobs/current/steps/:id/report`.
  - On retry, remove classification fields; keep `message`, `exit_code`, and `signal`.
  - Keep existing 400 behavior unchanged for other endpoints.
  - Added test verifying the retry and payload stripping.

<sup>Written for commit 9228dfdcbba0083a159d80837d4253497e8b895d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

