### PR TITLE
[runner] Fail image builds when Pi extensions are incomplete

### DIFF
--- a/.changeset/verify-runner-installation.md
+++ b/.changeset/verify-runner-installation.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/runner-agent": minor
+---
+
+Adds a `pi-extensions` subpath export so image builds can verify the deployed Pi extension closure without loading the runtime environment.

--- a/apps/runner/Dockerfile
+++ b/apps/runner/Dockerfile
@@ -114,7 +114,7 @@ COPY --from=build /prod ./
 
 # Verify the production dependency closure contains every Pi extension entry before the image
 # can be published. This runs against the deployed flat layout, not the pnpm development tree.
-RUN node --input-type=module -e "const {createRequire} = await import('node:module'); const {realpathSync} = await import('node:fs'); const {pathToFileURL} = await import('node:url'); const require = createRequire(realpathSync('/app/node_modules/@shipfox/runner-orchestration/dist/index.js')); const {assertPiHarnessExtensionsAvailable} = await import(new URL('./core/pi-extensions.js', pathToFileURL(require.resolve('@shipfox/runner-agent')))); assertPiHarnessExtensionsAvailable();"
+RUN node ./dist/verify-installation.js
 
 USER shipfox
 

--- a/apps/runner/Dockerfile
+++ b/apps/runner/Dockerfile
@@ -112,6 +112,10 @@ ENV HOME=/home/shipfox
 
 COPY --from=build /prod ./
 
+# Verify the production dependency closure contains every Pi extension entry before the image
+# can be published. This runs against the deployed flat layout, not the pnpm development tree.
+RUN node --input-type=module -e "const {createRequire} = await import('node:module'); const {realpathSync} = await import('node:fs'); const {pathToFileURL} = await import('node:url'); const require = createRequire(realpathSync('/app/node_modules/@shipfox/runner-orchestration/dist/index.js')); const {assertPiHarnessExtensionsAvailable} = await import(new URL('./core/pi-extensions.js', pathToFileURL(require.resolve('@shipfox/runner-agent')))); assertPiHarnessExtensionsAvailable();"
+
 USER shipfox
 
 # The build/promotion workflows pass revision/created as build args.

--- a/apps/runner/package.json
+++ b/apps/runner/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@shipfox/node-opentelemetry": "workspace:*",
+    "@shipfox/runner-agent": "workspace:*",
     "@shipfox/runner-orchestration": "workspace:*"
   },
   "devDependencies": {

--- a/apps/runner/src/verify-installation.ts
+++ b/apps/runner/src/verify-installation.ts
@@ -1,0 +1,7 @@
+import {assertPiHarnessExtensionsAvailable} from '@shipfox/runner-agent/pi-extensions';
+
+// Runs during the container and AMI image builds, against the deployed production closure rather
+// than the pnpm development tree. Imports the leaf module, not a package barrel: the runner barrels
+// validate the runtime environment at module load, which no image build can satisfy. A throw prints
+// the offending package and exits nonzero, which is the whole contract here.
+assertPiHarnessExtensionsAvailable();

--- a/infra/images/runner/scripts/build/install-runner.sh
+++ b/infra/images/runner/scripts/build/install-runner.sh
@@ -11,4 +11,6 @@ cd "$(dirname "$lockfile")"
 corepack prepare pnpm@11.7.0 --activate
 pnpm install --frozen-lockfile
 pnpm --filter=@shipfox/runner deploy --prod --legacy --config.strict-peer-dependencies=false /opt/runner
+cd /opt/runner
+node --input-type=module -e 'const {createRequire} = await import("node:module"); const {realpathSync} = await import("node:fs"); const {pathToFileURL} = await import("node:url"); const require = createRequire(realpathSync("/opt/runner/node_modules/@shipfox/runner-orchestration/dist/index.js")); const {assertPiHarnessExtensionsAvailable} = await import(new URL("./core/pi-extensions.js", pathToFileURL(require.resolve("@shipfox/runner-agent")))); assertPiHarnessExtensionsAvailable();'
 chown -R shipfox:shipfox /opt/runner

--- a/infra/images/runner/scripts/build/install-runner.sh
+++ b/infra/images/runner/scripts/build/install-runner.sh
@@ -11,6 +11,7 @@ cd "$(dirname "$lockfile")"
 corepack prepare pnpm@11.7.0 --activate
 pnpm install --frozen-lockfile
 pnpm --filter=@shipfox/runner deploy --prod --legacy --config.strict-peer-dependencies=false /opt/runner
-cd /opt/runner
-node --input-type=module -e 'const {createRequire} = await import("node:module"); const {realpathSync} = await import("node:fs"); const {pathToFileURL} = await import("node:url"); const require = createRequire(realpathSync("/opt/runner/node_modules/@shipfox/runner-orchestration/dist/index.js")); const {assertPiHarnessExtensionsAvailable} = await import(new URL("./core/pi-extensions.js", pathToFileURL(require.resolve("@shipfox/runner-agent")))); assertPiHarnessExtensionsAvailable();'
+# Verify the deployed production closure contains every Pi extension entry before the image is
+# published. This runs against the deployed flat layout, not the pnpm development tree.
+node /opt/runner/dist/verify-installation.js
 chown -R shipfox:shipfox /opt/runner

--- a/libs/runner/agent/package.json
+++ b/libs/runner/agent/package.json
@@ -25,6 +25,16 @@
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
       }
+    },
+    "./pi-extensions": {
+      "workspace-source": {
+        "types": "./src/core/pi-extensions.ts",
+        "default": "./src/core/pi-extensions.ts"
+      },
+      "default": {
+        "types": "./dist/core/pi-extensions.d.ts",
+        "default": "./dist/core/pi-extensions.js"
+      }
     }
   },
   "scripts": {

--- a/libs/runner/agent/src/core/pi-extensions.test.ts
+++ b/libs/runner/agent/src/core/pi-extensions.test.ts
@@ -1,4 +1,4 @@
-import {mkdtempSync, readFileSync, rmSync, symlinkSync} from 'node:fs';
+import {mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync} from 'node:fs';
 import {createRequire} from 'node:module';
 import {tmpdir} from 'node:os';
 import {basename, dirname, isAbsolute, join} from 'node:path';
@@ -6,7 +6,9 @@ import type {ResourceLoader} from '@earendil-works/pi-coding-agent';
 import {
   assertPiExtensionsLoaded,
   assertPiHarnessExtensionsAvailable,
+  PI_HARNESS_EXTENSION_PACKAGE_NAMES,
   piExtensionDirectories,
+  piExtensionDirectory,
 } from '#core/pi-extensions.js';
 
 const extensionPackageNames = ['pi-web-access', 'pi-mcp-adapter'] as const;
@@ -14,10 +16,50 @@ const require = createRequire(import.meta.url);
 
 type PiExtensionsResult = ReturnType<ResourceLoader['getExtensions']>;
 
+type PiExtensionFixture = {
+  packageJson?: string;
+  presentEntries?: readonly string[];
+};
+
 function extensionDirectory(packageName: string): string {
-  const [directory] = piExtensionDirectories({packageNames: [packageName]});
-  if (directory === undefined) throw new Error(`Missing resolved directory for ${packageName}`);
-  return directory;
+  return piExtensionDirectory({packageName});
+}
+
+/**
+ * Builds a throwaway package tree standing in for a deployed production closure, so the entry
+ * verification can be driven through layouts the pnpm development tree never produces.
+ */
+function piExtensionClosure(fixtures: Record<string, PiExtensionFixture>): {
+  resolve: (specifier: string) => string;
+  cleanup: () => void;
+} {
+  const root = mkdtempSync(join(tmpdir(), 'shipfox-pi-extension-'));
+
+  for (const [packageName, fixture] of Object.entries(fixtures)) {
+    const directory = join(root, packageName);
+    mkdirSync(directory, {recursive: true});
+
+    if (fixture.packageJson !== undefined)
+      writeFileSync(join(directory, 'package.json'), fixture.packageJson);
+    for (const entry of fixture.presentEntries ?? []) writeFileSync(join(directory, entry), '');
+  }
+
+  return {
+    resolve: (specifier) => join(root, specifier),
+    cleanup: () => rmSync(root, {recursive: true, force: true}),
+  };
+}
+
+function completePiExtensionFixtures(): Record<string, PiExtensionFixture> {
+  return Object.fromEntries(
+    PI_HARNESS_EXTENSION_PACKAGE_NAMES.map((packageName) => [
+      packageName,
+      {
+        packageJson: JSON.stringify({name: packageName, pi: {extensions: ['index.js']}}),
+        presentEntries: ['index.js'],
+      },
+    ]),
+  );
 }
 
 function resourceLoader(
@@ -140,7 +182,85 @@ describe('assertPiExtensionsLoaded', () => {
 });
 
 describe('assertPiHarnessExtensionsAvailable', () => {
-  it('verifies every declared Pi extension entry exists', () => {
+  it('verifies every declared Pi extension entry exists in the installed packages', () => {
     expect(() => assertPiHarnessExtensionsAvailable()).not.toThrow();
+  });
+
+  it('accepts a closure where every declared entry is present', () => {
+    const closure = piExtensionClosure(completePiExtensionFixtures());
+
+    try {
+      expect(() => assertPiHarnessExtensionsAvailable({resolve: closure.resolve})).not.toThrow();
+    } finally {
+      closure.cleanup();
+    }
+  });
+
+  it('names the package and entry when a declared entry file is missing', () => {
+    const closure = piExtensionClosure({
+      ...completePiExtensionFixtures(),
+      'pi-mcp-adapter': {
+        packageJson: JSON.stringify({name: 'pi-mcp-adapter', pi: {extensions: ['index.js']}}),
+      },
+    });
+
+    try {
+      expect(() => assertPiHarnessExtensionsAvailable({resolve: closure.resolve})).toThrow(
+        'Pi extension package "pi-mcp-adapter" is missing entry "index.js"',
+      );
+    } finally {
+      closure.cleanup();
+    }
+  });
+
+  it('checks every declared entry in a package manifest', () => {
+    const closure = piExtensionClosure({
+      ...completePiExtensionFixtures(),
+      'pi-web-access': {
+        packageJson: JSON.stringify({
+          name: 'pi-web-access',
+          pi: {extensions: ['present.js', 'missing.js']},
+        }),
+        presentEntries: ['present.js'],
+      },
+    });
+
+    try {
+      expect(() => assertPiHarnessExtensionsAvailable({resolve: closure.resolve})).toThrow(
+        'Pi extension package "pi-web-access" is missing entry "missing.js"',
+      );
+    } finally {
+      closure.cleanup();
+    }
+  });
+
+  it('rejects a package that declares no Pi extension entries', () => {
+    const closure = piExtensionClosure({
+      ...completePiExtensionFixtures(),
+      'pi-web-access': {packageJson: JSON.stringify({name: 'pi-web-access', pi: {extensions: []}})},
+    });
+
+    try {
+      expect(() => assertPiHarnessExtensionsAvailable({resolve: closure.resolve})).toThrow(
+        'Pi extension package "pi-web-access" has no pi.extensions entries.',
+      );
+    } finally {
+      closure.cleanup();
+    }
+  });
+
+  it('reports the package when its manifest cannot be read', () => {
+    const closure = piExtensionClosure({
+      ...completePiExtensionFixtures(),
+      'pi-web-access': {packageJson: '{'},
+    });
+
+    try {
+      expect(() => assertPiHarnessExtensionsAvailable({resolve: closure.resolve})).toThrow(
+        'Unable to inspect Pi extension package "pi-web-access"',
+      );
+    } finally {
+      closure.cleanup();
+    }
   });
 });

--- a/libs/runner/agent/src/core/pi-extensions.test.ts
+++ b/libs/runner/agent/src/core/pi-extensions.test.ts
@@ -3,7 +3,11 @@ import {createRequire} from 'node:module';
 import {tmpdir} from 'node:os';
 import {basename, dirname, isAbsolute, join} from 'node:path';
 import type {ResourceLoader} from '@earendil-works/pi-coding-agent';
-import {assertPiExtensionsLoaded, piExtensionDirectories} from '#core/pi-extensions.js';
+import {
+  assertPiExtensionsLoaded,
+  assertPiHarnessExtensionsAvailable,
+  piExtensionDirectories,
+} from '#core/pi-extensions.js';
 
 const extensionPackageNames = ['pi-web-access', 'pi-mcp-adapter'] as const;
 const require = createRequire(import.meta.url);
@@ -132,5 +136,11 @@ describe('assertPiExtensionsLoaded', () => {
         directories: [resolvedDirectory],
       }),
     ).toThrow(basename(resolvedDirectory));
+  });
+});
+
+describe('assertPiHarnessExtensionsAvailable', () => {
+  it('verifies every declared Pi extension entry exists', () => {
+    expect(() => assertPiHarnessExtensionsAvailable()).not.toThrow();
   });
 });

--- a/libs/runner/agent/src/core/pi-extensions.ts
+++ b/libs/runner/agent/src/core/pi-extensions.ts
@@ -11,29 +11,33 @@ const availabilityByPackageName = new Map<string, boolean>();
 type PackageResolver = (specifier: string) => string;
 
 /**
- * Resolves Pi extension package directories without asking Pi to resolve package names from a
+ * Resolves a Pi extension package directory without asking Pi to resolve package names from a
  * job workspace. The resolver override is intentionally uncached so tests cannot affect the
  * process-wide package resolution cache.
  */
+export function piExtensionDirectory(params: {
+  packageName: string;
+  resolve?: PackageResolver | undefined;
+}): string {
+  const {packageName, resolve} = params;
+  if (resolve !== undefined) return resolvePiExtensionDirectory({packageName, resolve});
+
+  const cached = resolvedDirectories.get(packageName);
+  if (cached !== undefined) return cached;
+
+  const directory = resolvePiExtensionDirectory({packageName, resolve: require.resolve});
+  resolvedDirectories.set(packageName, directory);
+  return directory;
+}
+
+/** Resolves each requested Pi extension package directory, preserving the requested order. */
 export function piExtensionDirectories(params: {
   packageNames: readonly string[];
   resolve?: PackageResolver;
 }): string[] {
-  const injectedResolver = params.resolve;
-  if (injectedResolver !== undefined) {
-    return params.packageNames.map((packageName) =>
-      resolvePiExtensionDirectory(packageName, injectedResolver),
-    );
-  }
-
-  return params.packageNames.map((packageName) => {
-    const cached = resolvedDirectories.get(packageName);
-    if (cached !== undefined) return cached;
-
-    const directory = resolvePiExtensionDirectory(packageName, require.resolve);
-    resolvedDirectories.set(packageName, directory);
-    return directory;
-  });
+  return params.packageNames.map((packageName) =>
+    piExtensionDirectory({packageName, resolve: params.resolve}),
+  );
 }
 
 /**
@@ -47,7 +51,7 @@ export function isPiExtensionAvailable(params: {packageName: string}): boolean {
 
   let available: boolean;
   try {
-    piExtensionDirectories({packageNames: [params.packageName]});
+    piExtensionDirectory({packageName: params.packageName});
     available = true;
   } catch {
     available = false;
@@ -56,16 +60,16 @@ export function isPiExtensionAvailable(params: {packageName: string}): boolean {
   return available;
 }
 
-/** Resolves every Pi extension required by the runner image or throws with the package cause. */
-export function assertPiHarnessExtensionsAvailable(): void {
-  const directories = piExtensionDirectories({packageNames: PI_HARNESS_EXTENSION_PACKAGE_NAMES});
+/**
+ * Resolves every Pi extension required by the runner image and verifies each declared entry file
+ * exists, or throws with the package cause. The runner image build runs this against the deployed
+ * production closure, where a packaging regression is observable and the development tree is not.
+ */
+export function assertPiHarnessExtensionsAvailable(params: {resolve?: PackageResolver} = {}): void {
+  for (const packageName of PI_HARNESS_EXTENSION_PACKAGE_NAMES) {
+    const directory = piExtensionDirectory({packageName, resolve: params.resolve});
 
-  for (const [index, directory] of directories.entries()) {
-    const packageName = PI_HARNESS_EXTENSION_PACKAGE_NAMES[index];
-    if (packageName === undefined)
-      throw new Error(`Missing Pi extension package at index ${index}`);
-
-    assertPiExtensionEntriesAvailable(packageName, directory);
+    assertPiExtensionEntriesAvailable({packageName, directory});
   }
 }
 
@@ -93,7 +97,11 @@ export function assertPiExtensionsLoaded(params: {
   );
 }
 
-function resolvePiExtensionDirectory(packageName: string, resolve: PackageResolver): string {
+function resolvePiExtensionDirectory(params: {
+  packageName: string;
+  resolve: PackageResolver;
+}): string {
+  const {packageName, resolve} = params;
   try {
     return dirname(resolve(`${packageName}/package.json`));
   } catch (error) {
@@ -102,7 +110,8 @@ function resolvePiExtensionDirectory(packageName: string, resolve: PackageResolv
   }
 }
 
-function assertPiExtensionEntriesAvailable(packageName: string, directory: string): void {
+function assertPiExtensionEntriesAvailable(params: {packageName: string; directory: string}): void {
+  const {packageName, directory} = params;
   const packageJsonPath = resolvePath(directory, 'package.json');
   let packageJson: {pi?: {extensions?: string[]}};
 

--- a/libs/runner/agent/src/core/pi-extensions.ts
+++ b/libs/runner/agent/src/core/pi-extensions.ts
@@ -1,6 +1,6 @@
-import {realpathSync} from 'node:fs';
+import {readFileSync, realpathSync, statSync} from 'node:fs';
 import {createRequire} from 'node:module';
-import {dirname, sep} from 'node:path';
+import {dirname, resolve as resolvePath, sep} from 'node:path';
 import type {ResourceLoader} from '@earendil-works/pi-coding-agent';
 
 export const PI_HARNESS_EXTENSION_PACKAGE_NAMES = ['pi-web-access', 'pi-mcp-adapter'] as const;
@@ -58,7 +58,15 @@ export function isPiExtensionAvailable(params: {packageName: string}): boolean {
 
 /** Resolves every Pi extension required by the runner image or throws with the package cause. */
 export function assertPiHarnessExtensionsAvailable(): void {
-  piExtensionDirectories({packageNames: PI_HARNESS_EXTENSION_PACKAGE_NAMES});
+  const directories = piExtensionDirectories({packageNames: PI_HARNESS_EXTENSION_PACKAGE_NAMES});
+
+  for (const [index, directory] of directories.entries()) {
+    const packageName = PI_HARNESS_EXTENSION_PACKAGE_NAMES[index];
+    if (packageName === undefined)
+      throw new Error(`Missing Pi extension package at index ${index}`);
+
+    assertPiExtensionEntriesAvailable(packageName, directory);
+  }
 }
 
 /**
@@ -91,6 +99,36 @@ function resolvePiExtensionDirectory(packageName: string, resolve: PackageResolv
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
     throw new Error(`Unable to resolve Pi extension package "${packageName}": ${reason}`);
+  }
+}
+
+function assertPiExtensionEntriesAvailable(packageName: string, directory: string): void {
+  const packageJsonPath = resolvePath(directory, 'package.json');
+  let packageJson: {pi?: {extensions?: string[]}};
+
+  try {
+    packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
+      pi?: {extensions?: string[]};
+    };
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(`Unable to inspect Pi extension package "${packageName}": ${reason}`);
+  }
+
+  const entries = packageJson.pi?.extensions;
+  if (!Array.isArray(entries) || entries.length === 0) {
+    throw new Error(`Pi extension package "${packageName}" has no pi.extensions entries.`);
+  }
+
+  for (const entry of entries) {
+    try {
+      statSync(resolvePath(directory, entry));
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `Pi extension package "${packageName}" is missing entry "${entry}": ${reason}`,
+      );
+    }
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -820,6 +820,9 @@ importers:
       '@shipfox/node-opentelemetry':
         specifier: workspace:*
         version: link:../../libs/shared/node/opentelemetry
+      '@shipfox/runner-agent':
+        specifier: workspace:*
+        version: link:../../libs/runner/agent
       '@shipfox/runner-orchestration':
         specifier: workspace:*
         version: link:../../libs/runner/orchestration


### PR DESCRIPTION
Runner image builds now fail during packaging when a required Pi extension package or any declared `pi.extensions` entry is missing.

The guard validates the deployed production dependency layout, and both the Docker runner image and EC2 AMI installer execute it immediately after deployment. The probes resolve the runner-agent package through the deployed orchestration dependency tree and load its built assertion entrypoint, matching the legacy pnpm deployment layout without adding a production dependency.

Validation:
- `mise exec -- rtk turbo type test check --filter=@shipfox/runner-agent...`
- `CI=true BUILD_NUMBER=eng-1309 mise exec -- rtk turbo image --filter=@shipfox/runner`
- `mise exec -- rtk sh -n infra/images/runner/scripts/build/install-runner.sh`
- `mise exec -- rtk git diff --check`

Closes ENG-1309

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail runner image and AMI packaging if Pi extensions are incomplete. We validate required packages and that every `pi.extensions` entry file exists using a compiled verifier run during both Docker and AMI builds against the production closure. Addresses ENG-1309.

- New Features
  - Added `assertPiHarnessExtensionsAvailable()` to verify required extensions (`pi-web-access`, `pi-mcp-adapter`) and enforce a non-empty `pi.extensions` array with all files present.
  - Execute a compiled leaf-module verifier (`dist/verify-installation.js`) during Docker and AMI builds via `@shipfox/runner-agent/pi-extensions` (new subpath export), avoiding runtime barrels and failing packaging early.

- Migration
  - Each Pi extension package must define a non-empty `pi.extensions` array in `package.json` and include those files.

<sup>Written for commit 29b9e897f99600a02b94e98ebde835362c5c36a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

