### PR TITLE
[runner-orchestration] Remove managed runner pre-bootstrap sleep

### DIFF
--- a/libs/runner/orchestration/src/core/runner.test.ts
+++ b/libs/runner/orchestration/src/core/runner.test.ts
@@ -10,6 +10,11 @@ vi.mock('#config.js', () => ({
   },
 }));
 
+vi.mock('@shipfox/node-resilient-loop', async (importActual) => ({
+  ...(await importActual<typeof import('@shipfox/node-resilient-loop')>()),
+  interruptibleSleep: vi.fn(async () => undefined),
+}));
+
 vi.mock('#core/heartbeat-loop.js', () => ({
   startHeartbeatLoop: vi.fn(() => ({stop: vi.fn(), bumpGeneration: vi.fn()})),
 }));
@@ -69,6 +74,7 @@ vi.mock('@shipfox/runner-protocol', () => ({
 }));
 
 import {logger} from '@shipfox/node-opentelemetry';
+import {interruptibleSleep} from '@shipfox/node-resilient-loop';
 import {runnerToolCapabilities} from '@shipfox/runner-agent';
 import {
   consumeManagedRunnerBootstrapToken,
@@ -121,6 +127,7 @@ const mockRunnerStartupMode = vi.mocked(runnerStartupMode);
 const mockRequestJob = vi.mocked(requestJob);
 const mockStartHeartbeatLoop = vi.mocked(startHeartbeatLoop);
 const mockRunnerToolCapabilities = vi.mocked(runnerToolCapabilities);
+const mockInterruptibleSleep = vi.mocked(interruptibleSleep);
 
 const JOB = {
   workflow_run_id: '00000000-0000-0000-0000-000000000004',
@@ -385,7 +392,10 @@ describe('startRunner', () => {
     vi.stubEnv('SHIPFOX_RUNNER_PROTOCOL_VERSION', '1');
     mockRunnerStartupMode.mockReturnValue('managed');
     mockConsumeManagedRunnerBootstrapToken.mockReturnValue('sf_rbt_bootstrap-token');
-    mockExchangeRunnerBootstrapToken.mockResolvedValue({controlSessionToken: 'control-token'});
+    mockExchangeRunnerBootstrapToken.mockImplementation(() => {
+      expect(mockInterruptibleSleep).not.toHaveBeenCalled();
+      return Promise.resolve({controlSessionToken: 'control-token'});
+    });
     mockEnrollRunnerControlSession.mockResolvedValue();
     mockHeartbeatRunnerControlSession.mockResolvedValue();
     mockPollRunnerAssignment.mockResolvedValue('activation-token');
@@ -411,6 +421,7 @@ describe('startRunner', () => {
       registrationToken: 'activation-token',
     });
     expect(mockRequestJob).toHaveBeenCalledWith('session-token');
+    expect(mockInterruptibleSleep).toHaveBeenCalledTimes(1);
   });
 
   it('retries a failed first direct registration', async () => {

--- a/libs/runner/orchestration/src/core/runner.ts
+++ b/libs/runner/orchestration/src/core/runner.ts
@@ -80,12 +80,12 @@ export async function startRunner(): Promise<void> {
   );
 
   let currentInterval = config.SHIPFOX_POLL_INTERVAL_MS;
-  await interruptableSleep(withJitter(config.SHIPFOX_POLL_INTERVAL_MS));
   let runnerSession: RunnerSession | undefined;
   if (startupMode === 'managed') {
     runnerSession = await initializeManagedRunnerSession();
     if (!runnerSession) return;
   }
+  await interruptableSleep(withJitter(config.SHIPFOX_POLL_INTERVAL_MS));
   let pollDeadline = nextPollDeadline();
 
   while (running) {


### PR DESCRIPTION
Managed runners currently wait through the job-polling jitter before exchanging their bootstrap token, adding unnecessary latency to every cold start. Defer that jitter until after managed enrollment so activation can reach the control plane immediately while job polling keeps its existing jitter.

Closes ENG-1329

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Managed runners no longer sleep before exchanging the bootstrap token. We defer polling jitter until after managed enrollment to reduce cold-start latency while keeping job polling jitter. Addresses ENG-1329.

- **Refactors**
  - Moved `interruptableSleep(withJitter(...))` to run after `initializeManagedRunnerSession()` in `startRunner`.
  - Updated tests to mock `interruptibleSleep` from `@shipfox/node-resilient-loop` and assert no pre-bootstrap sleep, with one sleep after activation.

<sup>Written for commit c1235ad008439402484865e93501f5ebda6beb14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

