### PR TITLE
[@shipfox/api-logs] Drop pure-progress Claude session events

### DIFF
--- a/.changeset/quiet-claude-progress.md
+++ b/.changeset/quiet-claude-progress.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-logs": minor
+---
+
+Drop pure-progress Claude session events before storing normalized log rows.

--- a/libs/api/logs/src/core/session/claude-parser.test.ts
+++ b/libs/api/logs/src/core/session/claude-parser.test.ts
@@ -1,3 +1,4 @@
+import {PURE_PROGRESS_CLAUDE_SYSTEM_SUBTYPES} from './claude/rows.js';
 import {parseClaudeSessionRecord} from './claude-parser.js';
 
 const record = (data: unknown, ts = 1) => ({
@@ -52,6 +53,14 @@ describe('parseClaudeSessionRecord', () => {
         terminalFailure: false,
       },
     ]);
+  });
+
+  it.each([
+    ...PURE_PROGRESS_CLAUDE_SYSTEM_SUBTYPES,
+  ])('drops pure-progress system subtype %s', (subtype) => {
+    const rows = parseClaudeSessionRecord(record({type: 'system', subtype}));
+
+    expect(rows).toEqual([]);
   });
 
   it('expands assistant text, thinking, and tool-use blocks in order', () => {

--- a/libs/api/logs/src/core/session/claude-parser.ts
+++ b/libs/api/logs/src/core/session/claude-parser.ts
@@ -1,6 +1,12 @@
 import type {SessionViewRow} from '@shipfox/api-logs-dto';
 import {z} from 'zod';
-import {assistantRows, resultRow, systemRow, userRows} from './claude/rows.js';
+import {
+  assistantRows,
+  PURE_PROGRESS_CLAUDE_SYSTEM_SUBTYPES,
+  resultRow,
+  systemRow,
+  userRows,
+} from './claude/rows.js';
 import {rawRecordRow} from './rows.js';
 import type {AgentSessionRecord} from './session-record.js';
 
@@ -22,6 +28,14 @@ export function parseClaudeSessionRecord(record: AgentSessionRecord): readonly S
   if (!parsed.success) return [rawRecordRow(record, 'Unsupported Claude message')];
 
   const message = parsed.data;
+  if (
+    message.type === 'system' &&
+    typeof message.subtype === 'string' &&
+    PURE_PROGRESS_CLAUDE_SYSTEM_SUBTYPES.has(message.subtype)
+  ) {
+    return [];
+  }
+
   switch (message.type) {
     case 'system':
     case 'init':

--- a/libs/api/logs/src/core/session/claude/rows.ts
+++ b/libs/api/logs/src/core/session/claude/rows.ts
@@ -18,6 +18,20 @@ import {
 } from '../object.js';
 import {lifecycleRow, messageRow, thinkingRow} from '../rows.js';
 
+export const PURE_PROGRESS_CLAUDE_SYSTEM_SUBTYPES = new Set<string>([
+  'thinking_tokens',
+  'status',
+  'session_state_changed',
+  'task_progress',
+  'hook_progress',
+  'hook_started',
+  'commands_changed',
+  'files_persisted',
+  'memory_recall',
+  'local_command_output',
+  'plugin_install',
+]);
+
 export function systemRow(
   timestamp: number,
   message: Record<string, unknown>,


### PR DESCRIPTION
Drop pure-progress Claude system events at parse time so token and harness progress noise is not stored as normalized session rows.

The change centralizes the 11 pure-progress subtypes beside the Claude row mappings, filters only matching `type: system` messages, and adds table-driven coverage for every dropped subtype. The `@shipfox/api-logs` minor changeset documents the storage behavior change.

Closes ENG-1336

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drop pure-progress Claude system events at parse time so progress noise isn’t stored as normalized session rows. Centralizes 11 `system` subtypes next to the Claude row mappings, filters only `type: system` messages with those subtypes, adds table-driven tests, and documents the behavior change via a minor release in `@shipfox/api-logs` (addresses ENG-1336).

<sup>Written for commit 263d5272afd81db78127a3c66dd94d5d72076bde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1082?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

