### PR TITLE
[expression] Add bounded range evaluation for config templating

### DIFF
--- a/.changeset/modern-ranges-config.md
+++ b/.changeset/modern-ranges-config.md
@@ -1,0 +1,5 @@
+---
+'@shipfox/expression': minor
+---
+
+Add scoped CEL environments, a per-evaluation inclusive `range` primitive capped at 1,000 values, and typed exact-expression field resolution for config templating.

--- a/libs/shared/expression/README.md
+++ b/libs/shared/expression/README.md
@@ -9,6 +9,14 @@ CEL checks and run-time evaluation for Shipfox workflow expressions.
 - **`WorkflowExpression`**: Stores the CEL tag, source, and check level.
 - **`ExpressionTypeEnvironment`**: Lists names and field types for typed checks.
 - **`evaluateWorkflowExpression`**: Runs a checked value against caller data.
+- **`evaluateWorkflowExpressionWithEnvironment`**: Runs a checked value against
+  a caller-owned CEL environment for explicitly scoped custom functions.
+- **`WorkflowExpressionEnvironment`**: The evaluate-only environment shape
+  accepted by the scoped evaluator.
+- **`createRangeEnvironment`**: Creates an opt-in evaluator with the bounded,
+  inclusive `range(start, stop, step)` config-templating function.
+- **`MAX_RANGE_ELEMENTS`**: The per-evaluation range materialization limit,
+  currently 1,000 values.
 - **`evaluateWorkflowPredicate`**: Returns `true` only for the boolean `true`.
 - **`parseWorkflowTemplate`**: Splits strings with `${{ ... }}` spans into
   ordered literal and expression segments.
@@ -69,6 +77,18 @@ const passed = evaluateWorkflowPredicate(expression, {
 - Treat the `event`, `inputs`, and open `jobs` contexts as untrusted.
   Interpolation field policies decide what untrusted data may reach each field.
 - Evaluation is deterministic and has no side effects.
+- Workflow evaluation does not include config-templating functions. Use a
+  caller-owned environment when a custom function is intentionally needed.
+- The config-templating range evaluator accepts CEL integers and safe integer
+  values from JavaScript contexts. It creates a fresh CEL environment and one
+  materialization budget for each evaluation, shared by nested range calls;
+  each evaluation can materialize at most 1,000 values.
+- Field resolution remains string-based by default. Callers rendering config
+  objects may opt into raw values for an exact single expression with
+  `preserveSingleExpressionType: true`; mixed literal and expression fields
+  remain strings. Under the `fail` policy, missing exact typed fields fail
+  rather than silently becoming an empty string; `runner-fill` segments remain
+  deferred for the runner instead of being hard-failed server-side.
 - The caller must pass values that match the checked data shape.
 - The evaluator does not read secrets, database rows, events, files, or external
   services.

--- a/libs/shared/expression/src/evaluator/evaluate-workflow-expression.test.ts
+++ b/libs/shared/expression/src/evaluator/evaluate-workflow-expression.test.ts
@@ -2,9 +2,11 @@ import {createWorkflowExpression} from '../expression/create-workflow-expression
 import {WorkflowExpressionEvaluationError} from './errors.js';
 import {
   evaluateWorkflowExpression,
+  evaluateWorkflowExpressionWithEnvironment,
   evaluateWorkflowPredicate,
   evaluateWorkflowPredicateFailClosed,
 } from './evaluate-workflow-expression.js';
+import {createRangeEnvironment} from './range.js';
 
 describe('evaluateWorkflowExpression', () => {
   it('evaluates a validated CEL expression against caller-provided values', () => {
@@ -23,6 +25,48 @@ describe('evaluateWorkflowExpression', () => {
     });
 
     expect(result).toBe(true);
+  });
+
+  it('does not add caller-supplied functions to the global evaluator', () => {
+    const expression = createWorkflowExpression({
+      source: 'range(2, 32, 2)',
+      check: {mode: 'syntax'},
+    });
+    // Creating the opt-in evaluator must not register range in the global evaluator.
+    createRangeEnvironment();
+
+    const evaluateGlobally = () => evaluateWorkflowExpression(expression, {});
+
+    expect(evaluateGlobally).toThrow(WorkflowExpressionEvaluationError);
+  });
+
+  it('evaluates against a caller-supplied environment', () => {
+    const expression = createWorkflowExpression({
+      source: 'range(2, 32, 2)',
+      check: {mode: 'syntax'},
+    });
+    const environment = createRangeEnvironment();
+
+    const result = evaluateWorkflowExpressionWithEnvironment(expression, {}, environment);
+
+    expect(result).toEqual([
+      2n,
+      4n,
+      6n,
+      8n,
+      10n,
+      12n,
+      14n,
+      16n,
+      18n,
+      20n,
+      22n,
+      24n,
+      26n,
+      28n,
+      30n,
+      32n,
+    ]);
   });
 
   it('treats only the boolean true value as a passing predicate', () => {

--- a/libs/shared/expression/src/evaluator/evaluate-workflow-expression.ts
+++ b/libs/shared/expression/src/evaluator/evaluate-workflow-expression.ts
@@ -1,9 +1,10 @@
-import {evaluate} from '@marcbachmann/cel-js';
+import {type Environment, evaluate} from '@marcbachmann/cel-js';
 import type {WorkflowExpression} from '../expression/workflow-expression.js';
 import {WorkflowExpressionEvaluationError} from './errors.js';
 
 export type WorkflowExpressionEvaluationContext = Readonly<Record<string, unknown>>;
 export type WorkflowExpressionEvaluationValue = unknown;
+export type WorkflowExpressionEnvironment = Pick<Environment, 'evaluate'>;
 
 export function evaluateWorkflowExpression(
   expression: WorkflowExpression,
@@ -11,6 +12,25 @@ export function evaluateWorkflowExpression(
 ): WorkflowExpressionEvaluationValue {
   try {
     return evaluate(expression.source, context);
+  } catch (error) {
+    throw new WorkflowExpressionEvaluationError(error);
+  }
+}
+
+/**
+ * Evaluate an expression against a caller-owned CEL environment.
+ *
+ * Workflow expressions deliberately continue to use the global CEL evaluator.
+ * Callers that need custom functions, such as config templating, must opt in
+ * by creating and passing their own environment.
+ */
+export function evaluateWorkflowExpressionWithEnvironment(
+  expression: WorkflowExpression,
+  context: WorkflowExpressionEvaluationContext,
+  environment: WorkflowExpressionEnvironment,
+): WorkflowExpressionEvaluationValue {
+  try {
+    return environment.evaluate(expression.source, context);
   } catch (error) {
     throw new WorkflowExpressionEvaluationError(error);
   }

--- a/libs/shared/expression/src/evaluator/index.ts
+++ b/libs/shared/expression/src/evaluator/index.ts
@@ -5,9 +5,12 @@ export {
 } from './errors.js';
 export {
   evaluateWorkflowExpression,
+  evaluateWorkflowExpressionWithEnvironment,
   evaluateWorkflowPredicate,
   evaluateWorkflowPredicateFailClosed,
   type FailClosedPredicateOutcome,
+  type WorkflowExpressionEnvironment,
   type WorkflowExpressionEvaluationContext,
   type WorkflowExpressionEvaluationValue,
 } from './evaluate-workflow-expression.js';
+export {createRangeEnvironment, MAX_RANGE_ELEMENTS} from './range.js';

--- a/libs/shared/expression/src/evaluator/range.test.ts
+++ b/libs/shared/expression/src/evaluator/range.test.ts
@@ -1,0 +1,110 @@
+import {createRangeEnvironment, MAX_RANGE_ELEMENTS} from './range.js';
+
+describe('range', () => {
+  it('returns an inclusive integer range', () => {
+    const evaluator = createRangeEnvironment();
+
+    const result = evaluator.evaluate('range(2, 8, 2)');
+
+    expect(result).toEqual([2n, 4n, 6n, 8n]);
+  });
+
+  it('returns an empty range when start is after stop', () => {
+    const evaluator = createRangeEnvironment();
+
+    const result = evaluator.evaluate('range(8, 2, 2)');
+
+    expect(result).toEqual([]);
+  });
+
+  it('rejects a non-positive step', () => {
+    const evaluator = createRangeEnvironment();
+    const zeroStep = () => evaluator.evaluate('range(1, 3, 0)');
+    const negativeStep = () => evaluator.evaluate('range(1, 3, -1)');
+
+    expect(zeroStep).toThrow('range step must be positive');
+    expect(negativeStep).toThrow('range step must be positive');
+  });
+
+  it('rejects ranges larger than the per-evaluation budget before allocation', () => {
+    const evaluator = createRangeEnvironment();
+    const evaluateTooLarge = () => evaluator.evaluate('range(1, 1001, 1)');
+
+    expect(evaluateTooLarge).toThrow(
+      `range evaluation budget exceeded; 1001 elements requested with ${MAX_RANGE_ELEMENTS} remaining`,
+    );
+  });
+
+  it('registers range in an opt-in dynamic evaluator', () => {
+    const evaluator = createRangeEnvironment();
+
+    const result = evaluator.evaluate('range(1, 3, 1)');
+
+    expect(result).toEqual([1n, 2n, 3n]);
+  });
+
+  it('exposes only the evaluation method needed by expression callers', () => {
+    const evaluator = createRangeEnvironment();
+    const publicHandle = evaluator as unknown as Record<string, unknown>;
+
+    const ownProperties = Object.keys(publicHandle);
+
+    expect(ownProperties).toEqual(['evaluate']);
+    expect(publicHandle.registerFunction).toBeUndefined();
+    expect(publicHandle.clone).toBeUndefined();
+    expect(publicHandle.parse).toBeUndefined();
+  });
+
+  it('accepts plain JavaScript numbers from the evaluation context', () => {
+    const evaluator = createRangeEnvironment();
+
+    const result = evaluator.evaluate('range(1, stop, 1)', {stop: 3});
+
+    expect(result).toEqual([1n, 2n, 3n]);
+  });
+
+  it('rejects non-integer values from the evaluation context', () => {
+    const evaluator = createRangeEnvironment();
+
+    for (const stop of [2.5, '3', null, 1e21]) {
+      const evaluateInvalid = () => evaluator.evaluate('range(1, stop, 1)', {stop});
+
+      expect(evaluateInvalid).toThrow('range stop must be a safe integer');
+    }
+  });
+
+  it('shares a budget across nested range calls in one evaluation', () => {
+    const evaluator = createRangeEnvironment();
+    const evaluateNested = () => evaluator.evaluate('range(1, 1000, 1).map(value, range(1, 2, 1))');
+
+    expect(evaluateNested).toThrow('range evaluation budget exceeded');
+  });
+
+  it('resets the budget for each evaluation', () => {
+    const evaluator = createRangeEnvironment();
+
+    const first = evaluator.evaluate('range(1, 1000, 1)');
+    const second = evaluator.evaluate('range(1, 1000, 1)');
+
+    expect(first).toHaveLength(1000);
+    expect(second).toHaveLength(1000);
+  });
+
+  it('uses an independent budget for re-entrant evaluation', () => {
+    const evaluator = createRangeEnvironment();
+    let nestedResult: unknown;
+    const context = {
+      get trigger() {
+        nestedResult = evaluator.evaluate('size(range(1, 1000, 1))');
+        return 1n;
+      },
+    };
+    const evaluateOuter = () =>
+      evaluator.evaluate('size(range(1, 900, 1)) + trigger + size(range(1, 101, 1))', context);
+
+    expect(evaluateOuter).toThrow(
+      'range evaluation budget exceeded; 101 elements requested with 100 remaining',
+    );
+    expect(nestedResult).toBe(1000n);
+  });
+});

--- a/libs/shared/expression/src/evaluator/range.ts
+++ b/libs/shared/expression/src/evaluator/range.ts
@@ -1,0 +1,64 @@
+import {type Context, Environment} from '@marcbachmann/cel-js';
+import type {WorkflowExpressionEnvironment} from './evaluate-workflow-expression.js';
+
+/** Maximum number of values a config-template range may materialize. */
+export const MAX_RANGE_ELEMENTS = 1_000;
+const RANGE_FUNCTION_SIGNATURE = 'range(dyn, dyn, dyn): list<int>';
+
+interface RangeBudget {
+  remaining: number;
+}
+
+function materializeRange(start: bigint, stop: bigint, step: bigint): bigint[] {
+  const values: bigint[] = [];
+  for (let value = start; value <= stop; value += step) values.push(value);
+  return values;
+}
+
+function rangeElementCount(start: bigint, stop: bigint, step: bigint): bigint {
+  if (step <= 0n) throw new RangeError('range step must be positive');
+  if (start > stop) return 0n;
+
+  return (stop - start) / step + 1n;
+}
+
+function toCelInteger(value: unknown, name: string): bigint {
+  if (typeof value === 'bigint') return value;
+  if (typeof value === 'number' && Number.isSafeInteger(value)) return BigInt(value);
+  throw new RangeError(`${name} must be a safe integer`);
+}
+
+function evaluateRange(
+  budget: RangeBudget,
+  start: unknown,
+  stop: unknown,
+  step: unknown,
+): bigint[] {
+  const startValue = toCelInteger(start, 'range start');
+  const stopValue = toCelInteger(stop, 'range stop');
+  const stepValue = toCelInteger(step, 'range step');
+  const count = rangeElementCount(startValue, stopValue, stepValue);
+  if (count > BigInt(budget.remaining)) {
+    throw new RangeError(
+      `range evaluation budget exceeded; ${count} elements requested with ${budget.remaining} remaining`,
+    );
+  }
+
+  const values = materializeRange(startValue, stopValue, stepValue);
+  budget.remaining -= values.length;
+  return values;
+}
+
+/** Create the opt-in range evaluator for config templating. */
+export function createRangeEnvironment(): WorkflowExpressionEnvironment {
+  return {
+    evaluate(expression: string, context?: Context) {
+      const budget = {remaining: MAX_RANGE_ELEMENTS};
+      const environment = new Environment({unlistedVariablesAreDyn: true});
+      environment.registerFunction(RANGE_FUNCTION_SIGNATURE, (start, stop, step) =>
+        evaluateRange(budget, start, stop, step),
+      );
+      return environment.evaluate(expression, context);
+    },
+  };
+}

--- a/libs/shared/expression/src/index.ts
+++ b/libs/shared/expression/src/index.ts
@@ -5,12 +5,15 @@ export {
 } from './evaluator/errors.js';
 export {
   evaluateWorkflowExpression,
+  evaluateWorkflowExpressionWithEnvironment,
   evaluateWorkflowPredicate,
   evaluateWorkflowPredicateFailClosed,
   type FailClosedPredicateOutcome,
+  type WorkflowExpressionEnvironment,
   type WorkflowExpressionEvaluationContext,
   type WorkflowExpressionEvaluationValue,
 } from './evaluator/evaluate-workflow-expression.js';
+export {createRangeEnvironment, MAX_RANGE_ELEMENTS} from './evaluator/range.js';
 export {
   createWorkflowExpression,
   unsafeWorkflowExpressionFromSource,

--- a/libs/shared/expression/src/plan/freeze.test.ts
+++ b/libs/shared/expression/src/plan/freeze.test.ts
@@ -1,10 +1,24 @@
 import {createWorkflowExpression} from '../expression/create-workflow-expression.js';
 import {WorkflowTemplateResolutionError} from '../resolver/errors.js';
-import {freezeResolvedFieldAtSite} from './freeze.js';
+import {parseWorkflowTemplate} from '../template/parse-workflow-template.js';
+import {freezeResolvedFieldAtSite, resolveFieldAtSite} from './freeze.js';
+import {planInterpolationField} from './plan-field.js';
 import type {ResolvedField} from './resolved-field.js';
+
+const templateOpen = '$' + '{{';
+const templateClose = '}' + '}';
 
 function expression(source: string) {
   return createWorkflowExpression({source, check: {mode: 'syntax'}});
+}
+
+function plannedField(source: string): ResolvedField {
+  const result = planInterpolationField({
+    field: 'env.value',
+    segments: parseWorkflowTemplate(source),
+  });
+  if (!result.ok) throw new Error('Expected the test field to be plannable.');
+  return result.plan.field;
 }
 
 describe('freezeResolvedFieldAtSite', () => {
@@ -50,6 +64,148 @@ describe('freezeResolvedFieldAtSite', () => {
         },
       ],
     });
+  });
+
+  it('preserves the raw value for an opted-in exact single expression', () => {
+    const field: ResolvedField = {
+      segments: [
+        {
+          kind: 'deferred',
+          expression: expression('cpu'),
+          roots: ['cpu'],
+          fillTarget: 'run-creation',
+        },
+      ],
+    };
+
+    const result = freezeResolvedFieldAtSite({
+      field,
+      failurePolicy: 'fail',
+      site: 'run-creation',
+      context: {cpu: 4},
+      preserveSingleExpressionType: true,
+    });
+
+    expect(result.value).toBe(4);
+  });
+
+  it('keeps mixed literal and expression fields as strings in typed mode', () => {
+    const field: ResolvedField = {
+      segments: [
+        {
+          kind: 'deferred',
+          expression: expression('cpu'),
+          roots: ['cpu'],
+          fillTarget: 'run-creation',
+        },
+        {kind: 'literal', value: 'vcpu'},
+      ],
+    };
+
+    const result = freezeResolvedFieldAtSite({
+      field,
+      failurePolicy: 'fail',
+      site: 'run-creation',
+      context: {cpu: 4},
+      preserveSingleExpressionType: true,
+    });
+
+    expect(result.value).toBe('4vcpu');
+  });
+
+  it('keeps mixed fields on their configured missing-path policy in typed mode', () => {
+    const result = freezeResolvedFieldAtSite({
+      field: plannedField(`${templateOpen} typo_root.value ${templateClose}-suffix`),
+      failurePolicy: 'fail',
+      site: 'run-creation',
+      context: {},
+      preserveSingleExpressionType: true,
+    });
+
+    expect(result.value).toBe('-suffix');
+    expect(result.diagnostics).toEqual([
+      {reason: 'missing-path', expression: 'typo_root.value', contextRoots: ['typo_root']},
+    ]);
+  });
+
+  it('degrades exact typed fields under the explicit degrade policy', () => {
+    const result = freezeResolvedFieldAtSite({
+      field: plannedField(`${templateOpen} typo_root.value ${templateClose}`),
+      failurePolicy: 'degrade',
+      site: 'run-creation',
+      context: {},
+      preserveSingleExpressionType: true,
+    });
+
+    expect(result.value).toBe('');
+    expect(result.diagnostics).toEqual([
+      {reason: 'missing-path', expression: 'typo_root.value', contextRoots: ['typo_root']},
+    ]);
+  });
+
+  it('fails exact typed fields that are not fillable at the requested site', () => {
+    const act = () =>
+      freezeResolvedFieldAtSite({
+        field: {
+          segments: [
+            {
+              kind: 'deferred',
+              expression: expression('execution.index'),
+              roots: ['execution'],
+              fillTarget: 'execution-creation',
+            },
+          ],
+        },
+        failurePolicy: 'fail',
+        site: 'run-creation',
+        context: {},
+        preserveSingleExpressionType: true,
+      });
+
+    expect(act).toThrow(WorkflowTemplateResolutionError);
+  });
+
+  it('records exact typed runner-fill fields as server-side diagnostics', () => {
+    const field: ResolvedField = {
+      segments: [
+        {
+          kind: 'deferred',
+          expression: expression('runner.os'),
+          roots: ['runner'],
+          fillTarget: 'runner-fill',
+        },
+      ],
+    };
+
+    const frozen = freezeResolvedFieldAtSite({
+      field,
+      failurePolicy: 'fail',
+      site: 'job-resolution',
+      context: {runner: {os: 'linux'}},
+      preserveSingleExpressionType: true,
+    });
+
+    expect(frozen).toEqual({
+      value: '',
+      diagnostics: [{reason: 'missing-path', expression: 'runner.os', contextRoots: ['runner']}],
+      trace: [],
+    });
+  });
+
+  it('widens the result when the typed-field option is not a literal boolean', () => {
+    const preserveTypes: boolean = true;
+
+    const result = freezeResolvedFieldAtSite({
+      field: plannedField(`${templateOpen} cpu ${templateClose}`),
+      failurePolicy: 'fail',
+      site: 'run-creation',
+      context: {cpu: 4},
+      preserveSingleExpressionType: preserveTypes,
+    });
+
+    // @ts-expect-error A runtime boolean flag may produce a non-string raw value.
+    const stringValue: string = result.value;
+    expect(stringValue).toBe(4);
   });
 
   it('throws for fail-policy missing paths on known roots available at the site', () => {
@@ -268,5 +424,90 @@ describe('freezeResolvedFieldAtSite', () => {
       diagnostics: [{reason: 'missing-path', expression: 'runner.os', contextRoots: ['runner']}],
       trace: [],
     });
+  });
+});
+
+describe('resolveFieldAtSite', () => {
+  it('preserves boolean values when resolving an exact single expression', () => {
+    const field: ResolvedField = {
+      segments: [
+        {
+          kind: 'deferred',
+          expression: expression('public'),
+          roots: ['public'],
+          fillTarget: 'run-creation',
+        },
+      ],
+    };
+
+    const result = resolveFieldAtSite({
+      field,
+      failurePolicy: 'fail',
+      site: 'run-creation',
+      context: {public: false},
+      preserveSingleExpressionType: true,
+    });
+
+    expect(result).toMatchObject({kind: 'frozen', value: false});
+  });
+
+  it('applies typed rendering to parsed template fields', () => {
+    const exactField = plannedField(`${templateOpen} cpu ${templateClose}`);
+    const mixedField = plannedField(`${templateOpen} cpu ${templateClose}vcpu`);
+
+    const exact = resolveFieldAtSite({
+      field: exactField,
+      failurePolicy: 'fail',
+      site: 'run-creation',
+      context: {cpu: 4},
+      preserveSingleExpressionType: true,
+    });
+    const mixed = resolveFieldAtSite({
+      field: mixedField,
+      failurePolicy: 'fail',
+      site: 'run-creation',
+      context: {cpu: 4},
+      preserveSingleExpressionType: true,
+    });
+
+    expect(exact).toMatchObject({kind: 'frozen', value: 4});
+    expect(mixed).toMatchObject({kind: 'frozen', value: '4vcpu'});
+  });
+
+  it('fails typed fields instead of degrading an unknown missing path to an empty string', () => {
+    const field = plannedField(`${templateOpen} cpu ${templateClose}`);
+    const resolve = () =>
+      resolveFieldAtSite({
+        field,
+        failurePolicy: 'fail',
+        site: 'run-creation',
+        context: {},
+        preserveSingleExpressionType: true,
+      });
+
+    expect(resolve).toThrow(WorkflowTemplateResolutionError);
+  });
+
+  it('leaves exact typed runner-fill fields for the runner', () => {
+    const field: ResolvedField = {
+      segments: [
+        {
+          kind: 'deferred',
+          expression: expression('runner.os'),
+          roots: ['runner'],
+          fillTarget: 'runner-fill',
+        },
+      ],
+    };
+
+    const result = resolveFieldAtSite({
+      field,
+      failurePolicy: 'fail',
+      site: 'job-resolution',
+      context: {runner: {os: 'linux'}},
+      preserveSingleExpressionType: true,
+    });
+
+    expect(result).toEqual({kind: 'residual', field, diagnostics: [], trace: []});
   });
 });

--- a/libs/shared/expression/src/plan/freeze.ts
+++ b/libs/shared/expression/src/plan/freeze.ts
@@ -26,16 +26,16 @@ export interface WorkflowTemplateDiagnostic {
   readonly contextRoots: readonly string[];
 }
 
-export interface FrozenResolvedField {
-  readonly value: string;
+export interface FrozenResolvedField<Value = string> {
+  readonly value: Value;
   readonly diagnostics: readonly WorkflowTemplateDiagnostic[];
   readonly trace: readonly EvaluationTraceEntry[];
 }
 
-export type SiteResolvedField =
+export type SiteResolvedField<Value = string> =
   | {
       readonly kind: 'frozen';
-      readonly value: string;
+      readonly value: Value;
       readonly diagnostics: readonly WorkflowTemplateDiagnostic[];
       readonly trace: readonly EvaluationTraceEntry[];
     }
@@ -46,6 +46,15 @@ export type SiteResolvedField =
       readonly trace: readonly EvaluationTraceEntry[];
     };
 
+interface ResolveFieldAtSiteParams {
+  readonly field: ResolvedField;
+  readonly failurePolicy: WorkflowInterpolationFailurePolicy;
+  readonly site: AvailabilitySite;
+  readonly context: WorkflowExpressionEvaluationContext;
+  /** Preserve the value of an exact single expression instead of stringifying it. */
+  readonly preserveSingleExpressionType?: boolean;
+}
+
 /**
  * Segment lifecycle:
  *
@@ -55,15 +64,24 @@ export type SiteResolvedField =
  * Value fields follow their declared policy at their fill target. Predicates use
  * the planned predicate entry point and fail closed when evaluation is deferred.
  */
-export function freezeResolvedFieldAtSite(params: {
-  readonly field: ResolvedField;
-  readonly failurePolicy: WorkflowInterpolationFailurePolicy;
-  readonly site: AvailabilitySite;
-  readonly context: WorkflowExpressionEvaluationContext;
-}): FrozenResolvedField {
+export function freezeResolvedFieldAtSite(
+  params: ResolveFieldAtSiteParams & {readonly preserveSingleExpressionType: true},
+): FrozenResolvedField<unknown>;
+export function freezeResolvedFieldAtSite(
+  params: ResolveFieldAtSiteParams & {readonly preserveSingleExpressionType?: false},
+): FrozenResolvedField;
+export function freezeResolvedFieldAtSite(
+  params: ResolveFieldAtSiteParams,
+): FrozenResolvedField<unknown>;
+export function freezeResolvedFieldAtSite(
+  params: ResolveFieldAtSiteParams,
+): FrozenResolvedField<unknown> {
   let value = '';
+  let typedValue: unknown;
+  let hasTypedValue = false;
   const diagnostics: WorkflowTemplateDiagnostic[] = [];
   const trace: EvaluationTraceEntry[] = [];
+  const preserveSingleExpressionType = isExactSingleExpressionField(params);
 
   for (const segment of params.field.segments) {
     if (segment.kind === 'literal') {
@@ -72,51 +90,51 @@ export function freezeResolvedFieldAtSite(params: {
     }
 
     if (!shouldFillAtSite(segment.fillTarget, params.site)) {
+      if (exactTypedFieldRequiresFailure(params, segment)) {
+        throw typedFieldNotFillableAtSite(segment);
+      }
       diagnostics.push(missingPathDiagnostic(segment));
       continue;
     }
 
-    try {
-      const literal = coerceWorkflowValueToString(
-        evaluateWorkflowExpression(segment.expression, params.context),
-      );
-      value += literal;
-      trace.push(fillTraceEntry(segment, params.site, literal));
-    } catch (error) {
-      if (error instanceof WorkflowExpressionEvaluationError && error.reason === 'missing-path') {
-        if (missingPathRequiresFailure(segment, params.failurePolicy, params.site)) {
-          throw new WorkflowTemplateResolutionError({
-            source: segment.expression.source,
-            cause: error,
-          });
-        }
+    const evaluated = evaluateFillableSegment(params, segment);
+    trace.push(evaluated.trace);
+    if (evaluated.kind === 'degraded') {
+      diagnostics.push(evaluated.diagnostic);
+      continue;
+    }
 
-        diagnostics.push(missingPathDiagnostic(segment));
-        trace.push(fillTraceEntry(segment, params.site, '', true));
-        continue;
-      }
-
-      throw new WorkflowTemplateResolutionError({
-        source: segment.expression.source,
-        cause: error,
-      });
+    if (preserveSingleExpressionType) {
+      typedValue = evaluated.value;
+      hasTypedValue = true;
+    } else {
+      value += evaluated.literal;
     }
   }
 
-  return {value, diagnostics, trace};
+  return {
+    value: preserveSingleExpressionType && hasTypedValue ? typedValue : value,
+    diagnostics,
+    trace,
+  };
 }
 
-export function resolveFieldAtSite(params: {
-  readonly field: ResolvedField;
-  readonly failurePolicy: WorkflowInterpolationFailurePolicy;
-  readonly site: AvailabilitySite;
-  readonly context: WorkflowExpressionEvaluationContext;
-}): SiteResolvedField {
+export function resolveFieldAtSite(
+  params: ResolveFieldAtSiteParams & {readonly preserveSingleExpressionType: true},
+): SiteResolvedField<unknown>;
+export function resolveFieldAtSite(
+  params: ResolveFieldAtSiteParams & {readonly preserveSingleExpressionType?: false},
+): SiteResolvedField;
+export function resolveFieldAtSite(params: ResolveFieldAtSiteParams): SiteResolvedField<unknown>;
+export function resolveFieldAtSite(params: ResolveFieldAtSiteParams): SiteResolvedField<unknown> {
   let value = '';
+  let typedValue: unknown;
+  let hasTypedValue = false;
   const diagnostics: WorkflowTemplateDiagnostic[] = [];
   const trace: EvaluationTraceEntry[] = [];
   const segments: ResolvedFieldSegment[] = [];
   let hasResidual = false;
+  const preserveSingleExpressionType = isExactSingleExpressionField(params);
 
   for (const segment of params.field.segments) {
     if (segment.kind === 'literal') {
@@ -131,37 +149,87 @@ export function resolveFieldAtSite(params: {
       continue;
     }
 
-    try {
-      const literal = coerceWorkflowValueToString(
-        evaluateWorkflowExpression(segment.expression, params.context),
-      );
-      value += literal;
-      segments.push({kind: 'literal', value: literal});
-      trace.push(fillTraceEntry(segment, params.site, literal));
-    } catch (error) {
-      if (error instanceof WorkflowExpressionEvaluationError && error.reason === 'missing-path') {
-        if (missingPathRequiresFailure(segment, params.failurePolicy, params.site)) {
-          throw new WorkflowTemplateResolutionError({
-            source: segment.expression.source,
-            cause: error,
-          });
-        }
-
-        diagnostics.push(missingPathDiagnostic(segment));
-        segments.push({kind: 'literal', value: ''});
-        trace.push(fillTraceEntry(segment, params.site, '', true));
-        continue;
-      }
-
-      throw new WorkflowTemplateResolutionError({
-        source: segment.expression.source,
-        cause: error,
-      });
+    const evaluated = evaluateFillableSegment(params, segment);
+    trace.push(evaluated.trace);
+    if (evaluated.kind === 'degraded') {
+      diagnostics.push(evaluated.diagnostic);
+      segments.push({kind: 'literal', value: ''});
+      continue;
     }
+
+    if (preserveSingleExpressionType) {
+      typedValue = evaluated.value;
+      hasTypedValue = true;
+    } else {
+      value += evaluated.literal;
+    }
+    segments.push({kind: 'literal', value: evaluated.literal});
   }
 
   if (hasResidual) return {kind: 'residual', field: {segments}, diagnostics, trace};
-  return {kind: 'frozen', value, diagnostics, trace};
+  return {
+    kind: 'frozen',
+    value: preserveSingleExpressionType && hasTypedValue ? typedValue : value,
+    diagnostics,
+    trace,
+  };
+}
+
+function isExactSingleExpressionField(params: ResolveFieldAtSiteParams): boolean {
+  return (
+    params.preserveSingleExpressionType === true &&
+    params.field.segments.length === 1 &&
+    params.field.segments[0]?.kind === 'deferred'
+  );
+}
+
+type FilledFieldSegment =
+  | {
+      readonly kind: 'evaluated';
+      readonly value: unknown;
+      readonly literal: string;
+      readonly trace: EvaluationTraceEntry;
+    }
+  | {
+      readonly kind: 'degraded';
+      readonly diagnostic: WorkflowTemplateDiagnostic;
+      readonly trace: EvaluationTraceEntry;
+    };
+
+function evaluateFillableSegment(
+  params: ResolveFieldAtSiteParams,
+  segment: ResolvedFieldDeferredSegment,
+): FilledFieldSegment {
+  try {
+    const value = evaluateWorkflowExpression(segment.expression, params.context);
+    const literal = coerceWorkflowValueToString(value);
+    return {
+      kind: 'evaluated',
+      value,
+      literal,
+      trace: fillTraceEntry(segment, params.site, literal),
+    };
+  } catch (error) {
+    if (error instanceof WorkflowExpressionEvaluationError && error.reason === 'missing-path') {
+      if (fieldMissingPathRequiresFailure(params, segment)) {
+        throw new WorkflowTemplateResolutionError({
+          source: segment.expression.source,
+          cause: error,
+        });
+      }
+
+      return {
+        kind: 'degraded',
+        diagnostic: missingPathDiagnostic(segment),
+        trace: fillTraceEntry(segment, params.site, '', true),
+      };
+    }
+
+    throw new WorkflowTemplateResolutionError({
+      source: segment.expression.source,
+      cause: error,
+    });
+  }
 }
 
 function fillTraceEntry(
@@ -177,6 +245,36 @@ function fillTraceEntry(
     evaluatedAt: site,
     value,
     ...(degraded ? {degraded: true} : {}),
+  });
+}
+
+function fieldMissingPathRequiresFailure(
+  params: ResolveFieldAtSiteParams,
+  segment: ResolvedFieldDeferredSegment,
+): boolean {
+  return (
+    (isExactSingleExpressionField(params) && params.failurePolicy === 'fail') ||
+    missingPathRequiresFailure(segment, params.failurePolicy, params.site)
+  );
+}
+
+function exactTypedFieldRequiresFailure(
+  params: ResolveFieldAtSiteParams,
+  segment: ResolvedFieldDeferredSegment,
+): boolean {
+  return (
+    isExactSingleExpressionField(params) &&
+    params.failurePolicy === 'fail' &&
+    segment.fillTarget !== 'runner-fill'
+  );
+}
+
+function typedFieldNotFillableAtSite(
+  segment: ResolvedFieldDeferredSegment,
+): WorkflowTemplateResolutionError {
+  return new WorkflowTemplateResolutionError({
+    source: segment.expression.source,
+    cause: new Error('Typed field is not fillable at this site.'),
   });
 }
 


### PR DESCRIPTION
Adds scoped CEL evaluation primitives for config templating in `@shipfox/expression`.

The range evaluator keeps config-only functions out of the global workflow evaluator and creates a fresh CEL environment plus materialization budget for each evaluation. Exact single-expression fields can preserve their runtime type while mixed fields remain strings, and runner-fill segments remain deferred server-side.

Validation: `turbo type test check build --filter=@shipfox/expression...` (32/32 tasks, 499 tests)

Closes ENG-1319

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds bounded config-templating primitives in `@shipfox/expression`: a caller-scoped CEL evaluator, an inclusive `range(start, stop, step)` capped at 1,000 values, and typed results for exact single-expression fields. Addresses ENG-1319 by enabling provisioner-local functions without affecting workflow evaluation.

- **New Features**
  - Scoped evaluation: `evaluateWorkflowExpressionWithEnvironment`, `WorkflowExpressionEnvironment`, and `createRangeEnvironment` let callers add functions without touching the global evaluator.
  - Bounded `range`: inclusive integers; validates positive step and safe integers; per-evaluation budget of 1,000 elements shared across nested calls.
  - Typed fields: with `preserveSingleExpressionType`, an exact single expression returns its raw value (e.g., number, boolean); mixed literal+expression fields stay strings; fail policy errors on missing paths or non-fillable sites; `runner-fill` stays deferred.

- **Migration**
  - Use `createRangeEnvironment()` with `evaluateWorkflowExpressionWithEnvironment(...)` to access `range`.
  - Pass `preserveSingleExpressionType: true` to resolve/freeze for typed exact-expression fields.
  - No changes needed for existing workflow expressions; `range` is not available in the global evaluator.

<sup>Written for commit 8874a0cdcee77ecd36e0978b045a2bd377b5575e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

