### PR TITLE
[runner] Prevent null activation polling loops

### DIFF
--- a/.changeset/steady-runners-poll.md
+++ b/.changeset/steady-runners-poll.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-runners": patch
+---
+
+Keep runner assignment polls open through transient activation-token races.

--- a/libs/api/runners/src/config.test.ts
+++ b/libs/api/runners/src/config.test.ts
@@ -27,6 +27,17 @@ describe('EPHEMERAL_REGISTRATION_TOKEN_TTL_SECONDS validation', () => {
     expect(config.EPHEMERAL_REGISTRATION_TOKEN_TTL_SECONDS).toBe(3600);
   });
 });
+describe('runner assignment polling defaults', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+  it('uses a 250 millisecond interval between assignment reads', async () => {
+    vi.resetModules();
+    const {config} = await import('#config.js');
+    expect(config.RUNNER_ASSIGNMENT_POLL_INTERVAL_MS).toBe(250);
+  });
+});
 describe('REGISTRATION_TOKEN_BATCH_MAX validation', () => {
   afterEach(() => {
     vi.unstubAllEnvs();

--- a/libs/api/runners/src/config.ts
+++ b/libs/api/runners/src/config.ts
@@ -24,7 +24,7 @@ export const config = createConfig({
   }),
   RUNNER_ASSIGNMENT_POLL_INTERVAL_MS: num({
     desc: 'Delay between durable assignment reads while a runner-control session waits for an assignment, in milliseconds.',
-    default: 1000,
+    default: 250,
   }),
   EPHEMERAL_REGISTRATION_TOKEN_TTL_SECONDS: num({
     desc: `Lifetime of a provisioner-minted runner registration token, in seconds. The token can be exchanged once by a runner before this time passes. Set this between 1 and ${EPHEMERAL_REGISTRATION_TOKEN_TTL_HARD_MAX_SECONDS}.`,

--- a/libs/api/runners/src/presentation/routes/runner-enrollment.test.ts
+++ b/libs/api/runners/src/presentation/routes/runner-enrollment.test.ts
@@ -23,6 +23,7 @@ import {
   runnersTestAuthClient,
 } from '#test/index.js';
 import {createRunnerRoutes} from './index.js';
+import {pollForRunnerActivationToken} from './runner-enrollment.js';
 
 const token = 'provisioner-test-token';
 const fakeUserAuth: AuthMethod = {name: AUTH_USER, authenticate: () => Promise.resolve()};
@@ -276,6 +277,31 @@ describe('runner enrollment control plane', () => {
     expect(closed.statusCode).toBe(401);
   });
 
+  it('keeps polling when an assignment cannot yet mint an activation token', async () => {
+    vi.useFakeTimers();
+    const abortController = new AbortController();
+    const getAssignment = vi.fn().mockResolvedValue({workspaceId: 'workspace-id'});
+    const issueActivationToken = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce('activation-token');
+    try {
+      const activationToken = pollForRunnerActivationToken({
+        deadline: Date.now() + 1_000,
+        intervalMs: 5,
+        signal: abortController.signal,
+        getAssignment,
+        issueActivationToken,
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(issueActivationToken).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(5);
+      await expect(activationToken).resolves.toBe('activation-token');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
   it('rejects registration with an expired activation token', async () => {
     const created = await app.inject({
       method: 'POST',

--- a/libs/api/runners/src/presentation/routes/runner-enrollment.ts
+++ b/libs/api/runners/src/presentation/routes/runner-enrollment.ts
@@ -166,6 +166,27 @@ export const runnerControlHeartbeatRoute = defineRoute({
   },
 });
 
+type RunnerAssignmentPollParams = {
+  deadline: number;
+  intervalMs: number;
+  signal: AbortSignal;
+  getAssignment: () => Promise<unknown | null>;
+  issueActivationToken: () => Promise<string | null>;
+};
+export async function pollForRunnerActivationToken(
+  params: RunnerAssignmentPollParams,
+): Promise<string | null> {
+  while (Date.now() <= params.deadline) {
+    if (params.signal.aborted) return null;
+    const assignment = await params.getAssignment();
+    if (assignment) {
+      const activationToken = await params.issueActivationToken();
+      if (activationToken) return activationToken;
+    }
+    await new Promise((resolve) => setTimeout(resolve, params.intervalMs));
+  }
+  return null;
+}
 export const runnerAssignmentPollRoute = defineRoute({
   method: 'GET',
   path: '/assignment',
@@ -177,20 +198,17 @@ export const runnerAssignmentPollRoute = defineRoute({
     const deadline = Date.now() + config.RUNNER_ASSIGNMENT_POLL_MAX_WAIT_SECONDS * 1000;
     const abortController = new AbortController();
     reply.raw.on('close', () => abortController.abort());
-    while (Date.now() <= deadline) {
-      if (abortController.signal.aborted) return {activation_token: null};
-      const assignment = await getRunnerAssignment(session);
-      if (assignment) {
-        const activationToken = await issueRunnerActivationToken({
+    const activationToken = await pollForRunnerActivationToken({
+      deadline,
+      intervalMs: config.RUNNER_ASSIGNMENT_POLL_INTERVAL_MS,
+      signal: abortController.signal,
+      getAssignment: () => getRunnerAssignment(session),
+      issueActivationToken: () =>
+        issueRunnerActivationToken({
           ...session,
           ttlSeconds: config.RUNNER_ACTIVATION_TOKEN_TTL_SECONDS,
-        });
-        return {activation_token: activationToken};
-      }
-      await new Promise((resolve) =>
-        setTimeout(resolve, config.RUNNER_ASSIGNMENT_POLL_INTERVAL_MS),
-      );
-    }
-    return {activation_token: null};
+        }),
+    });
+    return {activation_token: activationToken};
   },
 });

--- a/libs/runner/orchestration/src/core/runner.test.ts
+++ b/libs/runner/orchestration/src/core/runner.test.ts
@@ -10,9 +10,12 @@ vi.mock('#config.js', () => ({
   },
 }));
 
+const {interruptibleSleepMock} = vi.hoisted(() => ({
+  interruptibleSleepMock: vi.fn(async (_ms: number, _signal: AbortSignal) => undefined),
+}));
 vi.mock('@shipfox/node-resilient-loop', async (importActual) => ({
   ...(await importActual<typeof import('@shipfox/node-resilient-loop')>()),
-  interruptibleSleep: vi.fn(async () => undefined),
+  interruptibleSleep: interruptibleSleepMock,
 }));
 
 vi.mock('#core/heartbeat-loop.js', () => ({
@@ -422,6 +425,52 @@ describe('startRunner', () => {
     });
     expect(mockRequestJob).toHaveBeenCalledWith('session-token');
     expect(mockInterruptibleSleep).toHaveBeenCalledTimes(1);
+  });
+
+  it('backs off before retrying a managed assignment poll that returns no token', async () => {
+    vi.stubEnv('SHIPFOX_RUNNER_BOOTSTRAP_TOKEN', 'sf_rbt_bootstrap-token');
+    vi.stubEnv('SHIPFOX_RUNNER_PROVIDER_KIND', 'ec2');
+    vi.stubEnv('SHIPFOX_RUNNER_PROTOCOL_VERSION', '1');
+    mockRunnerStartupMode.mockReturnValue('managed');
+    mockExchangeRunnerBootstrapToken.mockResolvedValue({controlSessionToken: 'control-token'});
+    mockEnrollRunnerControlSession.mockResolvedValue();
+    mockHeartbeatRunnerControlSession.mockResolvedValue();
+    mockPollRunnerAssignment.mockResolvedValueOnce(null).mockResolvedValueOnce('activation-token');
+    mockRequestJob.mockRejectedValue(new RunnerSessionExhaustedError());
+
+    await startRunner();
+
+    expect(mockPollRunnerAssignment).toHaveBeenCalledTimes(2);
+    expect(mockInterruptibleSleep.mock.calls.map(([ms]) => ms)).toEqual([1, 0]);
+  });
+
+  it('surfaces heartbeat failures during a managed assignment retry backoff', async () => {
+    vi.useFakeTimers();
+    const heartbeatError = new Error('heartbeat failed');
+    vi.stubEnv('SHIPFOX_RUNNER_BOOTSTRAP_TOKEN', 'sf_rbt_bootstrap-token');
+    vi.stubEnv('SHIPFOX_RUNNER_PROVIDER_KIND', 'ec2');
+    vi.stubEnv('SHIPFOX_RUNNER_PROTOCOL_VERSION', '1');
+    mockRunnerStartupMode.mockReturnValue('managed');
+    mockExchangeRunnerBootstrapToken.mockResolvedValue({controlSessionToken: 'control-token'});
+    mockEnrollRunnerControlSession.mockResolvedValue();
+    mockHeartbeatRunnerControlSession.mockResolvedValueOnce().mockRejectedValueOnce(heartbeatError);
+    mockPollRunnerAssignment.mockResolvedValue(null);
+    mockInterruptibleSleep.mockImplementationOnce(
+      async (_ms, signal) =>
+        await new Promise<void>((resolve) =>
+          signal.addEventListener('abort', () => resolve(), {once: true}),
+        ),
+    );
+
+    try {
+      const runner = startRunner();
+      const expectation = expect(runner).rejects.toBe(heartbeatError);
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      await expectation;
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('retries a failed first direct registration', async () => {

--- a/libs/runner/orchestration/src/core/runner.ts
+++ b/libs/runner/orchestration/src/core/runner.ts
@@ -328,6 +328,8 @@ async function waitForRunnerActivation(controlSessionToken: string): Promise<str
       try {
         const activationToken = await pollRunnerAssignment(controlSessionToken, controller.signal);
         if (activationToken) return activationToken;
+        await interruptibleSleep(config.SHIPFOX_POLL_INTERVAL_MS, controller.signal);
+        if (heartbeatError) return handleControlSessionError(heartbeatError);
       } catch (error) {
         if (!running) return undefined;
         if (controller.signal.aborted && heartbeatError)


### PR DESCRIPTION
The assignment API could return immediately when a runner had an assignment but activation-token minting temporarily returned null. Managed runners then re-polled without delay, producing a hot loop and repeated advisory-lock transactions.

Keep server long polls open through transient nulls, retry durable assignment reads every 250 milliseconds, and add a client-side fallback delay. The client backoff also listens for control-session heartbeat failures so outages still surface instead of looking like clean exits.

Validation: `mise exec -- turbo check type test build type:emit --filter=@shipfox/api-runners... --filter=@shipfox/runner-orchestration...`

Closes ENG-1328

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents hot-looping in runner activation polling by holding server long-polls through transient null tokens and adding a small client backoff. This reduces API churn while keeping activation fast (ENG-1328).

- **Bug Fixes**
  - Server: keep `/assignment` long-polling until a token can be minted; only return null at the deadline.
  - Server: extract `pollForRunnerActivationToken` and lower `RUNNER_ASSIGNMENT_POLL_INTERVAL_MS` to 250ms in `@shipfox/api-runners`.
  - Client: after a null response, `waitForRunnerActivation` backs off using `SHIPFOX_POLL_INTERVAL_MS` and surfaces heartbeat failures in `@shipfox/runner-orchestration`.
  - Tests cover server polling through transient nulls and the client backoff behavior.

<sup>Written for commit 0fa7ca1e0a92c93f6bab93c545cc765cb52f13a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

