### PR TITLE
Add verified Storybook preview deployment lifecycle

### DIFF
--- a/.changeset/secure-pages-lifecycle.md
+++ b/.changeset/secure-pages-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/cloudflare-pages": minor
+---
+
+Adds verified Pages artifact promotion and hardens config, validation, and archive handling.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -943,12 +943,14 @@ jobs:
     name: Deploy production
     needs: [release-mode, static-verification, external-package-contracts, tests, e2e]
     if: >-
+      always() &&
       github.ref == 'refs/heads/main' &&
       needs.release-mode.result == 'success' &&
       needs.static-verification.result == 'success' &&
-      needs.external-package-contracts.result == 'success' &&
+      (needs.release-mode.outputs.mode != 'normal' ||
+      (needs.external-package-contracts.result == 'success' &&
       needs.tests.result == 'success' &&
-      needs.e2e.result == 'success'
+      needs.e2e.result == 'success'))
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,16 @@ permissions:
   contents: read
   pull-requests: read
 
-# Cancel superseded PR/branch runs before they finish, so rapid pushes stop paying
-# for CI work they already invalidated. main is never cancelled: every merged commit
-# must run to completion to publish or reuse its per-commit release artifacts.
+# Give every main push one FIFO slot before checks start. Pull requests use
+# independent groups, while the preview workflow owns its own stale-run
+# cancellation.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  group: >-
+    ${{ github.ref == 'refs/heads/main' &&
+    format('{0}-main', github.workflow) ||
+    format('{0}-pr-{1}', github.workflow, github.run_id) }}
+  cancel-in-progress: false
+  queue: max
 
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -934,3 +938,23 @@ jobs:
           test -n "$published_reference"
           test "$published_reference" != "null"
           echo "Published $published_reference" >> "$GITHUB_STEP_SUMMARY"
+
+  deploy-cloudflare-pages-production:
+    name: Deploy production
+    needs: [release-mode, static-verification, external-package-contracts, tests, e2e]
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      needs.release-mode.result == 'success' &&
+      needs.static-verification.result == 'success' &&
+      needs.external-package-contracts.result == 'success' &&
+      needs.tests.result == 'success' &&
+      needs.e2e.result == 'success'
+    permissions:
+      actions: read
+      contents: read
+      deployments: write
+    uses: ./.github/workflows/deploy.yml
+    with:
+      environment: production
+      source_sha: ${{ github.sha }}
+    secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Check out trusted deployment tooling
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          ref: ${{ inputs.source_sha || 'main' }}
+          ref: ${{ inputs.artifact_name && 'main' || inputs.source_sha || 'main' }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -152,7 +152,17 @@ jobs:
               fi
             fi
           else
-            if [[ -z "$source_sha" || "$(git rev-parse HEAD)" != "$source_sha" ]]; then
+            if [[ "$CLOUDFLARE_PAGES_ENVIRONMENT" == "preview" &&
+              -z "$artifact_name" && -z "$artifact_run_id" ]]; then
+              echo "Reusable preview deployments require a verified preview artifact." >&2
+              exit 1
+            fi
+            if [[ -n "$artifact_name" || -n "$artifact_run_id" ]]; then
+              if [[ -z "$source_sha" || -z "$pull_request" ]]; then
+                echo "Artifact promotion requires a source SHA and pull request number." >&2
+                exit 1
+              fi
+            elif [[ -z "$source_sha" || "$(git rev-parse HEAD)" != "$source_sha" ]]; then
               echo "Reusable deployments must check out their exact source SHA." >&2
               exit 1
             fi
@@ -167,8 +177,39 @@ jobs:
           fi
 
           if [[ -n "$artifact_name" || -n "$artifact_run_id" ]]; then
+            if [[ "$CLOUDFLARE_PAGES_ENVIRONMENT" != "preview" || -z "$pull_request" ]]; then
+              echo "Verified artifact promotion is only supported for preview pull requests." >&2
+              exit 1
+            fi
             if [[ -z "$artifact_name" || -z "$artifact_run_id" ]]; then
               echo "Artifact name and workflow run ID must be supplied together." >&2
+              exit 1
+            fi
+            expected_artifact_name="pages-preview-$pull_request-$source_sha"
+            if [[ "$artifact_name" != "$expected_artifact_name" ]]; then
+              echo "Artifact name does not match the requested pull request and source SHA." >&2
+              exit 1
+            fi
+            pull_json="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$pull_request")"
+            if [[ "$(jq -r '.state' <<< "$pull_json")" != "open" ||
+              "$(jq -r '.base.ref' <<< "$pull_json")" != "main" ||
+              "$(jq -r '.head.sha' <<< "$pull_json")" != "$source_sha" ]]; then
+              echo "Artifact promotion requires an open pull request targeting main at the requested source SHA." >&2
+              exit 1
+            fi
+            run_json="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$artifact_run_id")"
+            if [[ "$(jq -r '.conclusion' <<< "$run_json")" != "success" ||
+              "$(jq -r '.event' <<< "$run_json")" != "pull_request" ||
+              "$(jq -r '.path' <<< "$run_json")" != ".github/workflows/preview.yml" ||
+              "$(jq -r '.head_sha' <<< "$run_json")" != "$source_sha" ]]; then
+              echo "Artifact promotion requires a successful preview workflow run for the requested source SHA." >&2
+              exit 1
+            fi
+            artifacts_json="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$artifact_run_id/artifacts?per_page=100")"
+            if ! jq -e --arg artifact_name "$artifact_name" \
+              'any(.artifacts[]; .name == $artifact_name and .expired == false)' \
+              <<< "$artifacts_json" >/dev/null; then
+              echo "The requested verified preview artifact is missing or expired." >&2
               exit 1
             fi
             echo "build_from_source=false" >> "$GITHUB_OUTPUT"
@@ -381,13 +422,19 @@ jobs:
           DEPLOYMENT_VERIFICATION_SECONDS: ${{ steps.verify-deployment.outputs.verification_seconds || 'unavailable' }}
           PRE_DEPLOY_HEAD_RESULT: ${{ steps.confirm-current.outcome || 'skipped' }}
           POST_DEPLOY_HEAD_RESULT: ${{ steps.confirm-upload-current.outcome || 'skipped' }}
-        run: >-
-          node tools/cloudflare-pages/bin/cloudflare-pages.js summary
-          --plan-file "$RUNNER_TEMP/deploy-plan.json"
-          --build-log "$RUNNER_TEMP/deploy-build.log"
-          --config "$PAGES_CONFIG"
-          --deployment-file "$RUNNER_TEMP/deploy-deployments.json"
-          --verification-report "$RUNNER_TEMP/deploy-verification.json"
-          --platform "Cloudflare Pages"
-          --title "Cloudflare Pages $CLOUDFLARE_PAGES_ENVIRONMENT"
-          --output "$GITHUB_STEP_SUMMARY"
+        run: |
+          set -euo pipefail
+          artifact_summary_args=()
+          if [[ "${{ steps.source.outputs.build_from_source }}" == "false" ]]; then
+            artifact_summary_args=(--artifact-directory "$RUNNER_TEMP/cloudflare-pages-artifact")
+          fi
+          node tools/cloudflare-pages/bin/cloudflare-pages.js summary \
+            --plan-file "$RUNNER_TEMP/deploy-plan.json" \
+            --build-log "$RUNNER_TEMP/deploy-build.log" \
+            --config "$PAGES_CONFIG" \
+            --deployment-file "$RUNNER_TEMP/deploy-deployments.json" \
+            --verification-report "$RUNNER_TEMP/deploy-verification.json" \
+            --platform "Cloudflare Pages" \
+            --title "Cloudflare Pages $CLOUDFLARE_PAGES_ENVIRONMENT" \
+            "${artifact_summary_args[@]}" \
+            --output "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,10 +83,10 @@ jobs:
     environment: ${{ inputs.environment }}
     timeout-minutes: 60
     steps:
-      - name: Check out trusted deployment tooling
+      - name: Check out authorized deployment tooling
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          ref: ${{ inputs.artifact_name && 'main' || inputs.source_sha || 'main' }}
+          ref: ${{ inputs.artifact_name && github.event.pull_request.head.repo.full_name == github.repository && inputs.source_sha || inputs.source_sha || 'main' }}
           fetch-depth: 0
           persist-credentials: false
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -198,10 +198,21 @@ jobs:
               exit 1
             fi
             run_json="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$artifact_run_id")"
-            if [[ "$(jq -r '.conclusion' <<< "$run_json")" != "success" ||
-              "$(jq -r '.event' <<< "$run_json")" != "pull_request" ||
+            if [[ "$(jq -r '.event' <<< "$run_json")" != "pull_request" ||
               "$(jq -r '.path' <<< "$run_json")" != ".github/workflows/preview.yml" ||
               "$(jq -r '.head_sha' <<< "$run_json")" != "$source_sha" ]]; then
+              echo "Artifact promotion requires a preview workflow run for the requested source SHA." >&2
+              exit 1
+            fi
+            if [[ "$artifact_run_id" == "$GITHUB_RUN_ID" ]]; then
+              run_jobs_json="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$artifact_run_id/jobs?per_page=100")"
+              if ! jq -e \
+                'any(.jobs[]; .name == "Build verified preview artifact" and .status == "completed" and .conclusion == "success")' \
+                <<< "$run_jobs_json" >/dev/null; then
+                echo "The current preview workflow did not successfully produce the verified artifact." >&2
+                exit 1
+              fi
+            elif [[ "$(jq -r '.conclusion' <<< "$run_json")" != "success" ]]; then
               echo "Artifact promotion requires a successful preview workflow run for the requested source SHA." >&2
               exit 1
             fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -269,6 +269,8 @@ jobs:
             --name "${{ steps.source.outputs.artifact_name }}" \
             --dir "$artifact_directory"
           test -s "$artifact_directory/.shipfox-pages-plan.json"
+          test -s "$artifact_directory/.shipfox-pages-config.json"
+          cp "$artifact_directory/.shipfox-pages-config.json" "$PAGES_CONFIG"
 
       - name: Plan deployment
         id: plan

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,393 @@
+name: Deploy
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: Pages environment to publish
+        required: true
+        type: string
+      source_sha:
+        description: Exact trusted revision to build or identify
+        required: true
+        type: string
+      pull_request:
+        description: Pull request number for a preview deployment
+        required: false
+        default: ""
+        type: string
+      artifact_name:
+        description: Previously verified preview artifact
+        required: false
+        default: ""
+        type: string
+      artifact_run_id:
+        description: Workflow run that owns the preview artifact
+        required: false
+        default: ""
+        type: string
+    secrets:
+      CLOUDFLARE_API_TOKEN:
+        required: true
+      TURBO_TOKEN:
+        required: false
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Pages environment to publish
+        required: true
+        default: staging
+        type: choice
+        options:
+          - preview
+          - staging
+      pull_request:
+        description: Open pull request number required for a preview
+        required: false
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+  deployments: write
+  pull-requests: read
+
+concurrency:
+  group: >-
+    cloudflare-pages-deploy-${{
+      inputs.environment == 'preview' &&
+      format('preview-{0}', inputs.pull_request || github.run_id) ||
+      inputs.environment
+    }}
+  cancel-in-progress: false
+  queue: max
+
+env:
+  TURBO_TEAM: shipfox
+  TURBO_CACHE: local:rw,remote:rw
+  CLOUDFLARE_PAGES_ENVIRONMENT: ${{ inputs.environment }}
+  PAGES_CONFIG: cloudflare-pages.config.json
+
+jobs:
+  deploy-cloudflare-pages:
+    name: Cloudflare Pages ${{ inputs.environment }}
+    if: >-
+      (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main') &&
+      (inputs.environment == 'preview' ||
+      inputs.environment == 'staging' ||
+      inputs.environment == 'production') &&
+      (github.event_name != 'workflow_dispatch' ||
+      inputs.environment != 'production') &&
+      (inputs.environment != 'preview' || inputs.pull_request != '')
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    timeout-minutes: 60
+    steps:
+      - name: Check out trusted deployment tooling
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ inputs.source_sha || 'main' }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve authorized deployment source
+        id: source
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_ARTIFACT_NAME: ${{ inputs.artifact_name }}
+          INPUT_ARTIFACT_RUN_ID: ${{ inputs.artifact_run_id }}
+          INPUT_PULL_REQUEST: ${{ inputs.pull_request }}
+          INPUT_SOURCE_SHA: ${{ inputs.source_sha }}
+        run: |
+          set -euo pipefail
+          source_sha="$INPUT_SOURCE_SHA"
+          pull_request="$INPUT_PULL_REQUEST"
+          artifact_name="$INPUT_ARTIFACT_NAME"
+          artifact_run_id="$INPUT_ARTIFACT_RUN_ID"
+
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            if [[ "$CLOUDFLARE_PAGES_ENVIRONMENT" == "preview" ]]; then
+              pull_json="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$pull_request")"
+              state="$(jq -r '.state' <<< "$pull_json")"
+              base_ref="$(jq -r '.base.ref' <<< "$pull_json")"
+              source_sha="$(jq -r '.head.sha' <<< "$pull_json")"
+              if [[ "$state" != "open" || "$base_ref" != "main" || -z "$source_sha" ]]; then
+                echo "Preview promotion requires an open pull request targeting main." >&2
+                exit 1
+              fi
+
+              artifact_name="pages-preview-$pull_request-$source_sha"
+              artifacts_json="$(
+                gh api --method GET "repos/$GITHUB_REPOSITORY/actions/artifacts" \
+                  -f name="$artifact_name" \
+                  -f per_page=100
+              )"
+              artifact_run_id=""
+              while read -r candidate_run_id; do
+                run_json="$(
+                  gh api "repos/$GITHUB_REPOSITORY/actions/runs/$candidate_run_id"
+                )"
+                if [[ "$(jq -r '.conclusion' <<< "$run_json")" == "success" &&
+                  "$(jq -r '.event' <<< "$run_json")" == "pull_request" &&
+                  "$(jq -r '.path' <<< "$run_json")" == ".github/workflows/preview.yml" &&
+                  "$(jq -r '.head_sha' <<< "$run_json")" == "$source_sha" ]]; then
+                  artifact_run_id="$candidate_run_id"
+                  break
+                fi
+              done < <(
+                jq -r \
+                  '.artifacts[] | select(.expired == false) | .workflow_run.id' \
+                  <<< "$artifacts_json"
+              )
+              if [[ -z "$artifact_run_id" ]]; then
+                echo "No unexpired successful artifact named $artifact_name was found." >&2
+                exit 1
+              fi
+            else
+              git fetch --no-tags origin main
+              source_sha="$(git rev-parse origin/main)"
+              if [[ "$(git rev-parse HEAD)" != "$source_sha" ]]; then
+                echo "Manual stable deployments must execute the current main revision." >&2
+                exit 1
+              fi
+            fi
+          else
+            if [[ -z "$source_sha" || "$(git rev-parse HEAD)" != "$source_sha" ]]; then
+              echo "Reusable deployments must check out their exact source SHA." >&2
+              exit 1
+            fi
+          fi
+
+          if [[ "$CLOUDFLARE_PAGES_ENVIRONMENT" != "preview" ]]; then
+            git fetch --no-tags origin main
+            if ! git merge-base --is-ancestor "$source_sha" origin/main; then
+              echo "Stable deployments must use a revision merged into main." >&2
+              exit 1
+            fi
+          fi
+
+          if [[ -n "$artifact_name" || -n "$artifact_run_id" ]]; then
+            if [[ -z "$artifact_name" || -z "$artifact_run_id" ]]; then
+              echo "Artifact name and workflow run ID must be supplied together." >&2
+              exit 1
+            fi
+            echo "build_from_source=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "build_from_source=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "sha=$source_sha" >> "$GITHUB_OUTPUT"
+          echo "pull_request=$pull_request" >> "$GITHUB_OUTPUT"
+          echo "artifact_name=$artifact_name" >> "$GITHUB_OUTPUT"
+          echo "artifact_run_id=$artifact_run_id" >> "$GITHUB_OUTPUT"
+          echo "CLOUDFLARE_PAGES_COMMIT_SHA=$source_sha" >> "$GITHUB_ENV"
+          echo "CLOUDFLARE_PAGES_PR_NUMBER=$pull_request" >> "$GITHUB_ENV"
+
+      - name: Set up mise
+        id: setup-mise
+        uses: ./.github/actions/setup-mise
+        with:
+          tools: gh node npm:pnpm npm:turbo npm:wrangler
+
+      - name: Set up pnpm
+        id: setup-pnpm
+        uses: ./.github/actions/setup-pnpm
+
+      - name: Build deployment tooling
+        id: build-tooling
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN || '' }}
+        run: pnpm --filter=@shipfox/cloudflare-pages... build
+
+      - name: Record workflow queue time
+        id: queue
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node tools/cloudflare-pages/bin/cloudflare-pages.js github queue --github-output "$GITHUB_OUTPUT"
+
+      - name: Download verified preview artifact
+        if: steps.source.outputs.build_from_source == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          artifact_directory="$RUNNER_TEMP/cloudflare-pages-artifact"
+          gh run download "${{ steps.source.outputs.artifact_run_id }}" \
+            --name "${{ steps.source.outputs.artifact_name }}" \
+            --dir "$artifact_directory"
+          test -s "$artifact_directory/.shipfox-pages-plan.json"
+
+      - name: Plan deployment
+        id: plan
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN || '' }}
+        run: |
+          set -euo pipefail
+          plan_file="$RUNNER_TEMP/deploy-plan.json"
+          if [[ "${{ steps.source.outputs.build_from_source }}" == "false" ]]; then
+            cp "$RUNNER_TEMP/cloudflare-pages-artifact/.shipfox-pages-plan.json" "$plan_file"
+          else
+            node tools/cloudflare-pages/bin/cloudflare-pages.js plan \
+              --config "$PAGES_CONFIG" \
+              --event deployment \
+              --output "$plan_file" \
+              --github-output "$GITHUB_OUTPUT"
+          fi
+          echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+
+      - name: Build selected applications
+        id: build
+        if: steps.source.outputs.build_from_source == 'true'
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN || '' }}
+        run: |
+          set -euo pipefail
+          build_started="$(date +%s)"
+          echo "build_started=$build_started" >> "$GITHUB_OUTPUT"
+          node tools/cloudflare-pages/bin/cloudflare-pages.js build-all \
+            --config "$PAGES_CONFIG" \
+            --plan-file "$RUNNER_TEMP/deploy-plan.json" \
+            --environment "$CLOUDFLARE_PAGES_ENVIRONMENT" \
+            --commit "$CLOUDFLARE_PAGES_COMMIT_SHA" \
+            --output "$RUNNER_TEMP/deploy-build.json" \
+            --github-output "$GITHUB_OUTPUT" 2>&1 | tee "$RUNNER_TEMP/deploy-build.log"
+          build_finished="$(date +%s)"
+          echo "build_seconds=$((build_finished - build_started))" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Playwright
+        if: steps.source.outputs.build_from_source == 'true'
+        uses: ./.github/actions/setup-playwright
+
+      - name: Run configured application validation
+        id: validation
+        if: steps.source.outputs.build_from_source == 'true'
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN || '' }}
+        run: |
+          set -euo pipefail
+          node tools/cloudflare-pages/bin/cloudflare-pages.js validate \
+            --config "$PAGES_CONFIG" \
+            --output "$RUNNER_TEMP/deploy-validation.json" \
+            --github-output "$GITHUB_OUTPUT" 2>&1 | tee "$RUNNER_TEMP/deploy-validation.log"
+
+      - name: Confirm preview commit is still current
+        id: confirm-current
+        if: inputs.environment == 'preview'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          node tools/cloudflare-pages/bin/cloudflare-pages.js github assert-current
+          --pull-request "$CLOUDFLARE_PAGES_PR_NUMBER"
+          --commit "$CLOUDFLARE_PAGES_COMMIT_SHA"
+
+      - name: Deploy verified applications
+        id: deploy
+        if: inputs.environment != 'preview' || steps.confirm-current.outcome == 'success'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          artifact_args=()
+          if [[ "${{ steps.source.outputs.build_from_source }}" == "false" ]]; then
+            artifact_args=(
+              --artifact-directory
+              "$RUNNER_TEMP/cloudflare-pages-artifact"
+            )
+          fi
+          node tools/cloudflare-pages/bin/cloudflare-pages.js deploy-all \
+            --config "$PAGES_CONFIG" \
+            --plan-file "$RUNNER_TEMP/deploy-plan.json" \
+            --environment "$CLOUDFLARE_PAGES_ENVIRONMENT" \
+            --commit "$CLOUDFLARE_PAGES_COMMIT_SHA" \
+            --output "$RUNNER_TEMP/deploy-deployments.json" \
+            --github-output "$GITHUB_OUTPUT" \
+            "${artifact_args[@]}"
+
+      - name: Confirm uploaded preview commit is still current
+        id: confirm-upload-current
+        if: >-
+          always() &&
+          inputs.environment == 'preview' &&
+          (steps.deploy.outcome == 'success' || steps.deploy.outcome == 'failure')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          node tools/cloudflare-pages/bin/cloudflare-pages.js github assert-current
+          --pull-request "$CLOUDFLARE_PAGES_PR_NUMBER"
+          --commit "$CLOUDFLARE_PAGES_COMMIT_SHA"
+
+      - name: Register successful deployments
+        id: register-deployment
+        if: >-
+          always() &&
+          (steps.deploy.outcome == 'success' || steps.deploy.outcome == 'failure') &&
+          (inputs.environment != 'preview' ||
+          steps.confirm-upload-current.outcome == 'success')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          node tools/cloudflare-pages/bin/cloudflare-pages.js github create-all
+          --deployments-file "$RUNNER_TEMP/deploy-deployments.json"
+          --ref "$CLOUDFLARE_PAGES_COMMIT_SHA"
+          --environment "$CLOUDFLARE_PAGES_ENVIRONMENT"
+          --pull-request "$CLOUDFLARE_PAGES_PR_NUMBER"
+          --output "$RUNNER_TEMP/deploy-github-deployments.json"
+          --github-output "$GITHUB_OUTPUT"
+
+      - name: Verify successful uploads
+        id: verify-deployment
+        if: >-
+          always() &&
+          (steps.deploy.outcome == 'success' || steps.deploy.outcome == 'failure') &&
+          (inputs.environment != 'preview' ||
+          steps.confirm-upload-current.outcome == 'success')
+        run: >-
+          node tools/cloudflare-pages/bin/cloudflare-pages.js verify-all
+          --config "$PAGES_CONFIG"
+          --plan-file "$RUNNER_TEMP/deploy-plan.json"
+          --deployments-file "$RUNNER_TEMP/deploy-deployments.json"
+          --commit "$CLOUDFLARE_PAGES_COMMIT_SHA"
+          --pull-request "$CLOUDFLARE_PAGES_PR_NUMBER"
+          --output "$RUNNER_TEMP/deploy-verification.json"
+          --github-output "$GITHUB_OUTPUT"
+
+      - name: Finalize registered deployments
+        if: >-
+          always() &&
+          steps.setup-pnpm.outcome == 'success' &&
+          steps.build-tooling.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          node tools/cloudflare-pages/bin/cloudflare-pages.js github status-all
+          --deployments-file "$RUNNER_TEMP/deploy-github-deployments.json"
+          --verification-report "$RUNNER_TEMP/deploy-verification.json"
+
+      - name: Report deployment metrics
+        if: always()
+        env:
+          BUILD_RESULT: ${{ steps.build.outcome }}
+          BUILD_SECONDS: ${{ steps.build.outputs.build_seconds || 'unavailable' }}
+          VALIDATION_RESULT: ${{ steps.validation.outcome }}
+          VALIDATION_SECONDS: ${{ steps.validation.outputs.validation_seconds || 'unavailable' }}
+          PLAN_RESULT: ${{ steps.plan.outputs.should_deploy || 'unavailable' }}
+          PLAN_REASON: ${{ steps.plan.outputs.reason || 'verified artifact' }}
+          QUEUE_SECONDS: ${{ steps.queue.outputs.queue_seconds || 'unavailable' }}
+          DEPLOYMENT_RESULT: ${{ steps.deploy.outcome || 'skipped' }}
+          DEPLOYMENT_SECONDS: ${{ steps.deploy.outputs.deployment_seconds || 'unavailable' }}
+          DEPLOYMENT_VERIFICATION_RESULT: ${{ steps.verify-deployment.outcome || 'skipped' }}
+          DEPLOYMENT_VERIFICATION_SECONDS: ${{ steps.verify-deployment.outputs.verification_seconds || 'unavailable' }}
+          PRE_DEPLOY_HEAD_RESULT: ${{ steps.confirm-current.outcome || 'skipped' }}
+          POST_DEPLOY_HEAD_RESULT: ${{ steps.confirm-upload-current.outcome || 'skipped' }}
+        run: >-
+          node tools/cloudflare-pages/bin/cloudflare-pages.js summary
+          --plan-file "$RUNNER_TEMP/deploy-plan.json"
+          --build-log "$RUNNER_TEMP/deploy-build.log"
+          --config "$PAGES_CONFIG"
+          --deployment-file "$RUNNER_TEMP/deploy-deployments.json"
+          --verification-report "$RUNNER_TEMP/deploy-verification.json"
+          --platform "Cloudflare Pages"
+          --title "Cloudflare Pages $CLOUDFLARE_PAGES_ENVIRONMENT"
+          --output "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -269,8 +269,6 @@ jobs:
             --name "${{ steps.source.outputs.artifact_name }}" \
             --dir "$artifact_directory"
           test -s "$artifact_directory/.shipfox-pages-plan.json"
-          test -s "$artifact_directory/.shipfox-pages-config.json"
-          cp "$artifact_directory/.shipfox-pages-config.json" "$PAGES_CONFIG"
 
       - name: Plan deployment
         id: plan

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -139,7 +139,6 @@ jobs:
             --plan-file "$RUNNER_TEMP/preview-plan.json" \
             --artifact-directory "$RUNNER_TEMP/cloudflare-pages-artifact" \
             --output "$RUNNER_TEMP/cloudflare-pages-artifact/.shipfox-pages-plan.json"
-          cp "$PAGES_CONFIG" "$RUNNER_TEMP/cloudflare-pages-artifact/.shipfox-pages-config.json"
           archive_finished="$(date +%s)"
           echo "archive_seconds=$((archive_finished - archive_started))" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -133,13 +133,17 @@ jobs:
         if: steps.plan.outputs.should_deploy == 'true'
         run: |
           set -euo pipefail
+          archive_started="$(date +%s)"
           node tools/cloudflare-pages/bin/cloudflare-pages.js archive-all \
             --config "$PAGES_CONFIG" \
             --plan-file "$RUNNER_TEMP/preview-plan.json" \
             --artifact-directory "$RUNNER_TEMP/cloudflare-pages-artifact" \
             --output "$RUNNER_TEMP/cloudflare-pages-artifact/.shipfox-pages-plan.json"
+          archive_finished="$(date +%s)"
+          echo "archive_seconds=$((archive_finished - archive_started))" >> "$GITHUB_OUTPUT"
 
       - name: Upload verified preview artifact
+        id: upload-artifact
         if: steps.plan.outputs.should_deploy == 'true' && success()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -155,12 +159,16 @@ jobs:
           BUILD_SECONDS: ${{ steps.build.outputs.build_seconds || 'unavailable' }}
           VALIDATION_RESULT: ${{ steps.validation.outcome }}
           VALIDATION_SECONDS: ${{ steps.validation.outputs.validation_seconds || 'unavailable' }}
+          ARTIFACT_ONLY: true
+          ARTIFACT_RESULT: ${{ steps.archive.outcome || 'skipped' }}
+          ARTIFACT_SECONDS: ${{ steps.archive.outputs.archive_seconds || 'unavailable' }}
+          ARTIFACT_UPLOAD_RESULT: ${{ steps.upload-artifact.outcome || 'skipped' }}
           PLAN_RESULT: ${{ steps.plan.outputs.should_deploy || 'unavailable' }}
           PLAN_REASON: ${{ steps.plan.outputs.reason || 'unavailable' }}
           QUEUE_SECONDS: ${{ steps.queue.outputs.queue_seconds || 'unavailable' }}
-          DEPLOYMENT_RESULT: archived
+          DEPLOYMENT_RESULT: not-run
           DEPLOYMENT_SECONDS: unavailable
-          DEPLOYMENT_VERIFICATION_RESULT: pending
+          DEPLOYMENT_VERIFICATION_RESULT: not-run
           DEPLOYMENT_VERIFICATION_SECONDS: unavailable
         run: >-
           node tools/cloudflare-pages/bin/cloudflare-pages.js summary

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -139,6 +139,7 @@ jobs:
             --plan-file "$RUNNER_TEMP/preview-plan.json" \
             --artifact-directory "$RUNNER_TEMP/cloudflare-pages-artifact" \
             --output "$RUNNER_TEMP/cloudflare-pages-artifact/.shipfox-pages-plan.json"
+          cp "$PAGES_CONFIG" "$RUNNER_TEMP/cloudflare-pages-artifact/.shipfox-pages-config.json"
           archive_finished="$(date +%s)"
           echo "archive_seconds=$((archive_finished - archive_started))" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,55 +1,49 @@
-name: Preview
+name: Cloudflare Pages Preview
 
 on:
   pull_request:
     branches:
       - main
     types: [opened, reopened, synchronize]
-  push:
-    branches:
-      - main
 
 permissions:
   actions: read
   contents: read
-  deployments: write
   pull-requests: read
 
 concurrency:
-  group: preview-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: cloudflare-pages-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 env:
   TURBO_TEAM: shipfox
-  # Same-repository pull requests and main may read the trusted remote cache.
-  # Forks receive no repository secret and therefore run without a cache token.
-  TURBO_TOKEN: ${{ (github.ref == 'refs/heads/main' || github.event.pull_request.head.repo.full_name == github.repository) && secrets.TURBO_TOKEN || '' }}
-  TURBO_CACHE: ${{ github.ref == 'refs/heads/main' && 'local:rw,remote:rw' || 'local:rw,remote:r' }}
-  TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha || github.sha }}
-  TURBO_SCM_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
-  CLOUDFLARE_PAGES_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-  CLOUDFLARE_PAGES_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
-  CLOUDFLARE_PAGES_ENVIRONMENT: ${{ github.event_name == 'push' && 'production' || 'preview' }}
+  # Pull requests may restore trusted cache entries, but only main may write them.
+  TURBO_CACHE: local:rw,remote:r
+  TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
+  TURBO_SCM_HEAD: ${{ github.event.pull_request.head.sha }}
+  CLOUDFLARE_PAGES_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+  CLOUDFLARE_PAGES_PR_NUMBER: ${{ github.event.pull_request.number }}
+  CLOUDFLARE_PAGES_ENVIRONMENT: preview
+  PAGES_CONFIG: cloudflare-pages.config.json
+  PREVIEW_CAN_DEPLOY: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
 
 jobs:
   build:
-    name: Preview
-    if: github.event_name == 'push' || github.event.pull_request.head.ref != 'changeset-release/main'
+    name: Build verified preview artifact
+    if: github.event.pull_request.head.ref != 'changeset-release/main'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
       - name: Check out exact preview commit
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: Fetch pull request base for affected planning
-        if: >-
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name != github.repository
+        if: github.event.pull_request.head.repo.full_name != github.repository
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
@@ -68,7 +62,7 @@ jobs:
         id: setup-mise
         uses: ./.github/actions/setup-mise
         with:
-          tools: gh node npm:pnpm npm:turbo npm:wrangler
+          tools: gh node npm:pnpm npm:turbo
 
       - name: Set up pnpm
         id: setup-pnpm
@@ -76,6 +70,8 @@ jobs:
 
       - name: Build preview tooling
         id: build-tooling
+        env:
+          TURBO_TOKEN: ${{ env.PREVIEW_CAN_DEPLOY == 'true' && secrets.TURBO_TOKEN || '' }}
         run: pnpm --filter=@shipfox/cloudflare-pages... build
 
       - name: Record workflow queue time
@@ -83,147 +79,76 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
-        run: pnpm --filter=@shipfox/storybook exec shipfox-cloudflare-pages github queue --github-output "$GITHUB_OUTPUT"
+        run: node tools/cloudflare-pages/bin/cloudflare-pages.js github queue --github-output "$GITHUB_OUTPUT"
 
       - name: Plan affected preview
         id: plan
+        env:
+          TURBO_TOKEN: ${{ env.PREVIEW_CAN_DEPLOY == 'true' && secrets.TURBO_TOKEN || '' }}
         run: |
           set -euo pipefail
-          plan_file="$RUNNER_TEMP/preview-plan.json"
-          pnpm --silent --filter=@shipfox/storybook pages:plan -- \
-            --output "$plan_file" \
+          node tools/cloudflare-pages/bin/cloudflare-pages.js plan \
+            --config "$PAGES_CONFIG" \
+            --output "$RUNNER_TEMP/preview-plan.json" \
             --github-output "$GITHUB_OUTPUT"
+
+      - name: Build and assemble selected preview apps
+        id: build
+        if: steps.plan.outputs.should_deploy == 'true'
+        env:
+          TURBO_TOKEN: ${{ env.PREVIEW_CAN_DEPLOY == 'true' && secrets.TURBO_TOKEN || '' }}
+        run: |
+          set -euo pipefail
+          build_started="$(date +%s)"
+          echo "build_started=$build_started" >> "$GITHUB_OUTPUT"
+          node tools/cloudflare-pages/bin/cloudflare-pages.js build-all \
+            --config "$PAGES_CONFIG" \
+            --plan-file "$RUNNER_TEMP/preview-plan.json" \
+            --environment "$CLOUDFLARE_PAGES_ENVIRONMENT" \
+            --pull-request "$CLOUDFLARE_PAGES_PR_NUMBER" \
+            --commit "$CLOUDFLARE_PAGES_COMMIT_SHA" \
+            --output "$RUNNER_TEMP/preview-build.json" \
+            --github-output "$GITHUB_OUTPUT" 2>&1 | tee "$RUNNER_TEMP/preview-build.log"
+          build_finished="$(date +%s)"
+          echo "build_seconds=$((build_finished - build_started))" >> "$GITHUB_OUTPUT"
 
       - name: Set up Playwright
         if: steps.plan.outputs.should_deploy == 'true'
         uses: ./.github/actions/setup-playwright
 
-      - name: Build and assemble selected preview apps
-        id: build
-        if: steps.plan.outputs.should_deploy == 'true'
-        run: |
-          set -euo pipefail
-          build_started="$(date +%s)"
-          echo "build_started=$build_started" >> "$GITHUB_OUTPUT"
-          pnpm --filter=@shipfox/storybook exec shipfox-cloudflare-pages build-all \
-          --config cloudflare-pages.config.json \
-          --plan-file "$RUNNER_TEMP/preview-plan.json" \
-          --environment "$CLOUDFLARE_PAGES_ENVIRONMENT" \
-          --commit "$CLOUDFLARE_PAGES_COMMIT_SHA" \
-          --output "$RUNNER_TEMP/preview-build.json" \
-          --github-output "$GITHUB_OUTPUT" 2>&1 | tee "$RUNNER_TEMP/preview-build.log"
-          build_finished="$(date +%s)"
-          echo "build_seconds=$((build_finished - build_started))" >> "$GITHUB_OUTPUT"
-
-      - name: Verify artifact and run browser smoke tests
+      - name: Run configured application validation
         id: validation
         if: steps.plan.outputs.should_deploy == 'true'
+        env:
+          TURBO_TOKEN: ${{ env.PREVIEW_CAN_DEPLOY == 'true' && secrets.TURBO_TOKEN || '' }}
         run: |
           set -euo pipefail
-          validation_started="$(date +%s)"
-          echo "validation_started=$validation_started" >> "$GITHUB_OUTPUT"
-          pnpm --filter=@shipfox/storybook test:e2e 2>&1 | tee "$RUNNER_TEMP/preview-validation.log"
-          validation_finished="$(date +%s)"
-          echo "validation_seconds=$((validation_finished - validation_started))" >> "$GITHUB_OUTPUT"
+          node tools/cloudflare-pages/bin/cloudflare-pages.js validate \
+            --config "$PAGES_CONFIG" \
+            --output "$RUNNER_TEMP/preview-validation.json" \
+            --github-output "$GITHUB_OUTPUT" 2>&1 | tee "$RUNNER_TEMP/preview-validation.log"
+
+      - name: Archive verified preview outputs
+        id: archive
+        if: steps.plan.outputs.should_deploy == 'true'
+        run: |
+          set -euo pipefail
+          node tools/cloudflare-pages/bin/cloudflare-pages.js archive-all \
+            --config "$PAGES_CONFIG" \
+            --plan-file "$RUNNER_TEMP/preview-plan.json" \
+            --artifact-directory "$RUNNER_TEMP/cloudflare-pages-artifact" \
+            --output "$RUNNER_TEMP/cloudflare-pages-artifact/.shipfox-pages-plan.json"
 
       - name: Upload verified preview artifact
         if: steps.plan.outputs.should_deploy == 'true' && success()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: preview-${{ github.event.pull_request.number || 'main' }}-${{ github.event.pull_request.head.sha || github.sha }}
-          path: apps/storybook/storybook-output
+          name: pages-preview-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+          path: ${{ runner.temp }}/cloudflare-pages-artifact
+          include-hidden-files: true
           if-no-files-found: error
 
-      - name: Confirm preview commit is still current before upload
-        id: confirm-current
-        if: >-
-          steps.plan.outputs.should_deploy == 'true' &&
-          success() &&
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: >-
-          pnpm --filter=@shipfox/storybook exec shipfox-cloudflare-pages github assert-current
-          --pull-request "$CLOUDFLARE_PAGES_PR_NUMBER"
-          --commit "$CLOUDFLARE_PAGES_COMMIT_SHA"
-
-      - name: Deploy verified preview to Cloudflare Pages
-        id: deploy
-        if: >-
-          steps.plan.outputs.should_deploy == 'true' &&
-          success() &&
-          (github.event_name == 'push' ||
-          steps.confirm-current.outcome == 'success') &&
-          (github.event_name == 'push' ||
-          github.event.pull_request.head.repo.full_name == github.repository)
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-        run: >-
-          pnpm --filter=@shipfox/storybook exec shipfox-cloudflare-pages deploy-all
-          --config cloudflare-pages.config.json
-          --plan-file "$RUNNER_TEMP/preview-plan.json"
-          --environment "$CLOUDFLARE_PAGES_ENVIRONMENT"
-          --commit "$CLOUDFLARE_PAGES_COMMIT_SHA"
-          --output "$RUNNER_TEMP/preview-deployments.json"
-          --github-output "$GITHUB_OUTPUT"
-
-      - name: Confirm uploaded preview commit is still current
-        id: confirm-upload-current
-        if: >-
-          steps.deploy.outcome == 'success' &&
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: >-
-          pnpm --filter=@shipfox/storybook exec shipfox-cloudflare-pages github assert-current
-          --pull-request "$CLOUDFLARE_PAGES_PR_NUMBER"
-          --commit "$CLOUDFLARE_PAGES_COMMIT_SHA"
-
-      - name: Register preview deployment
-        id: register-deployment
-        if: >-
-          steps.deploy.outcome == 'success' &&
-          (github.event_name == 'push' || steps.confirm-upload-current.outcome == 'success')
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: >-
-          pnpm --filter=@shipfox/storybook exec shipfox-cloudflare-pages github create-all
-          --deployments-file "$RUNNER_TEMP/preview-deployments.json"
-          --ref "$CLOUDFLARE_PAGES_COMMIT_SHA"
-          --environment "$CLOUDFLARE_PAGES_ENVIRONMENT"
-          --output "$RUNNER_TEMP/preview-github-deployments.json"
-          --github-output "$GITHUB_OUTPUT"
-
-      - name: Verify deployed preview
-        id: verify-deployment
-        if: >-
-          always() &&
-          steps.deploy.outcome == 'success' &&
-          (github.event_name == 'push' || steps.confirm-upload-current.outcome == 'success')
-        run: >-
-          pnpm --filter=@shipfox/storybook exec shipfox-cloudflare-pages verify-all
-          --config cloudflare-pages.config.json
-          --plan-file "$RUNNER_TEMP/preview-plan.json"
-          --deployments-file "$RUNNER_TEMP/preview-deployments.json"
-          --output "$RUNNER_TEMP/preview-verification.json"
-          --github-output "$GITHUB_OUTPUT"
-
-      - name: Finalize preview deployment
-        if: >-
-          always() &&
-          steps.setup-pnpm.outcome == 'success' &&
-          steps.build-tooling.outcome == 'success'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: >-
-          pnpm --filter=@shipfox/storybook exec shipfox-cloudflare-pages github status-all
-          --deployments-file "$RUNNER_TEMP/preview-github-deployments.json"
-          --verification-report "$RUNNER_TEMP/preview-verification.json"
-
-      - name: Report preview metrics
+      - name: Report preview build metrics
         if: always()
         env:
           BUILD_RESULT: ${{ steps.build.outcome }}
@@ -233,20 +158,35 @@ jobs:
           PLAN_RESULT: ${{ steps.plan.outputs.should_deploy || 'unavailable' }}
           PLAN_REASON: ${{ steps.plan.outputs.reason || 'unavailable' }}
           QUEUE_SECONDS: ${{ steps.queue.outputs.queue_seconds || 'unavailable' }}
-          DEPLOYMENT_RESULT: ${{ steps.deploy.outcome || 'skipped' }}
-          DEPLOYMENT_SECONDS: ${{ steps.deploy.outputs.deployment_seconds || 'unavailable' }}
-          DEPLOYMENT_VERIFICATION_RESULT: ${{ steps.verify-deployment.outcome || 'skipped' }}
-          DEPLOYMENT_VERIFICATION_SECONDS: ${{ steps.verify-deployment.outputs.verification_seconds || 'unavailable' }}
-          PRE_DEPLOY_HEAD_RESULT: ${{ steps.confirm-current.outcome || 'skipped' }}
-          POST_DEPLOY_HEAD_RESULT: ${{ steps.confirm-upload-current.outcome || 'skipped' }}
+          DEPLOYMENT_RESULT: archived
+          DEPLOYMENT_SECONDS: unavailable
+          DEPLOYMENT_VERIFICATION_RESULT: pending
+          DEPLOYMENT_VERIFICATION_SECONDS: unavailable
         run: >-
-          pnpm --filter=@shipfox/storybook exec shipfox-cloudflare-pages summary
+          node tools/cloudflare-pages/bin/cloudflare-pages.js summary
           --plan-file "$RUNNER_TEMP/preview-plan.json"
           --build-log "$RUNNER_TEMP/preview-build.log"
-          --artifact-metadata storybook-output/preview-metadata.json
-          --config cloudflare-pages.config.json
-          --deployment-file "$RUNNER_TEMP/preview-deployments.json"
-          --verification-report "$RUNNER_TEMP/preview-verification.json"
+          --config "$PAGES_CONFIG"
           --platform "Cloudflare Pages"
-          --title "Preview"
+          --title "Cloudflare Pages Preview Build"
           --output "$GITHUB_STEP_SUMMARY"
+
+  deploy:
+    name: Publish trusted preview artifact
+    needs: build
+    if: >-
+      needs.build.result == 'success' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      actions: read
+      contents: read
+      deployments: write
+      pull-requests: read
+    uses: ./.github/workflows/deploy.yml
+    with:
+      environment: preview
+      source_sha: ${{ github.event.pull_request.head.sha }}
+      pull_request: ${{ github.event.pull_request.number }}
+      artifact_name: pages-preview-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+      artifact_run_id: ${{ github.run_id }}
+    secrets: inherit

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -8,12 +8,15 @@
   "license": "MIT",
   "private": true,
   "type": "module",
+  "imports": {
+    "#*": "./src/*"
+  },
   "scripts": {
     "build": "pnpm run build:children && pnpm run storybook:build && pnpm run artifact:assemble",
     "artifact:assemble": "tsx scripts/assemble.ts",
     "artifact:verify": "tsx scripts/verify.ts",
     "build:children": "tsx scripts/build-children.ts",
-    "pages:plan": "shipfox-cloudflare-pages plan --config cloudflare-pages.config.json",
+    "pages:plan": "shipfox-cloudflare-pages plan --config ../../cloudflare-pages.config.json",
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
     "storybook": "pnpm run build:children && storybook dev -p 6015",

--- a/apps/storybook/scripts/artifact.ts
+++ b/apps/storybook/scripts/artifact.ts
@@ -380,6 +380,23 @@ export function assertPreviewMetadata(
   if (typeof candidate.buildTime !== 'string' || Number.isNaN(Date.parse(candidate.buildTime))) {
     throw new Error('preview-metadata.json has an invalid buildTime');
   }
+  if (candidate.pullRequest !== null && candidate.pullRequest !== undefined) {
+    if (typeof candidate.pullRequest !== 'object' || candidate.pullRequest === null) {
+      throw new Error('preview-metadata.json has an invalid pullRequest');
+    }
+
+    const pullRequest = candidate.pullRequest as Partial<
+      Exclude<PreviewMetadata['pullRequest'], null>
+    >;
+    if (!Number.isInteger(pullRequest.number) || (pullRequest.number ?? 0) <= 0) {
+      throw new Error('preview-metadata.json has an invalid pull request number');
+    }
+    if (pullRequest.headSha !== null && pullRequest.headSha !== candidate.commitSha) {
+      throw new Error(
+        `preview-metadata.json pull request headSha ${pullRequest.headSha} does not match commitSha ${candidate.commitSha}`,
+      );
+    }
+  }
   if (expectedCommitSha !== undefined && candidate.commitSha !== expectedCommitSha) {
     throw new Error(
       `preview-metadata.json commitSha ${candidate.commitSha} does not match expected ${expectedCommitSha}`,

--- a/apps/storybook/scripts/assemble.ts
+++ b/apps/storybook/scripts/assemble.ts
@@ -85,7 +85,7 @@ function getPullRequestNumber(event: Record<string, unknown> | null): number | n
     'number' in eventPullRequest
       ? (eventPullRequest as {number?: unknown}).number
       : undefined;
-  const configuredNumber = process.env.GITHUB_PR_NUMBER;
+  const configuredNumber = process.env.CLOUDFLARE_PAGES_PR_NUMBER ?? process.env.GITHUB_PR_NUMBER;
   const number =
     eventNumber ?? (configuredNumber === undefined ? undefined : Number(configuredNumber));
 
@@ -114,11 +114,26 @@ async function getPullRequestMetadata(): Promise<PreviewMetadata['pullRequest']>
 
   return {
     number,
-    title: typeof pullRequest?.title === 'string' ? pullRequest.title : null,
-    url: typeof pullRequest?.html_url === 'string' ? pullRequest.html_url : null,
-    headSha: typeof head?.sha === 'string' ? head.sha : null,
-    headRef: typeof head?.ref === 'string' ? head.ref : (process.env.GITHUB_HEAD_REF ?? null),
-    baseRef: typeof base?.ref === 'string' ? base.ref : (process.env.GITHUB_BASE_REF ?? null),
+    title:
+      typeof pullRequest?.title === 'string'
+        ? pullRequest.title
+        : (process.env.CLOUDFLARE_PAGES_PR_TITLE ?? null),
+    url:
+      typeof pullRequest?.html_url === 'string'
+        ? pullRequest.html_url
+        : (process.env.CLOUDFLARE_PAGES_PR_URL ?? null),
+    headSha:
+      typeof head?.sha === 'string'
+        ? head.sha
+        : (process.env.CLOUDFLARE_PAGES_PR_HEAD_SHA ?? getCommitShaFromEnv() ?? null),
+    headRef:
+      typeof head?.ref === 'string'
+        ? head.ref
+        : (process.env.CLOUDFLARE_PAGES_PR_HEAD_REF ?? process.env.GITHUB_HEAD_REF ?? null),
+    baseRef:
+      typeof base?.ref === 'string'
+        ? base.ref
+        : (process.env.CLOUDFLARE_PAGES_PR_BASE_REF ?? process.env.GITHUB_BASE_REF ?? null),
   };
 }
 

--- a/apps/storybook/scripts/assemble.ts
+++ b/apps/storybook/scripts/assemble.ts
@@ -125,7 +125,7 @@ async function getPullRequestMetadata(): Promise<PreviewMetadata['pullRequest']>
     headSha:
       typeof head?.sha === 'string'
         ? head.sha
-        : (process.env.CLOUDFLARE_PAGES_PR_HEAD_SHA ?? getCommitShaFromEnv() ?? null),
+        : process.env.CLOUDFLARE_PAGES_PR_HEAD_SHA || getCommitShaFromEnv() || null,
     headRef:
       typeof head?.ref === 'string'
         ? head.ref

--- a/apps/storybook/src/introduction.tsx
+++ b/apps/storybook/src/introduction.tsx
@@ -1,8 +1,68 @@
 import {Card, CardTitle} from '@shipfox/react-ui/card';
 import {Code, Header, Text} from '@shipfox/react-ui/typography';
+import {useEffect, useState} from 'react';
 import {storybookLinks} from '../preview-manifest.js';
 
+type PreviewIdentity = {
+  commitSha: string;
+  pullRequest: {number: number; url: string | null} | null;
+};
+
+type PreviewIdentityState =
+  | {status: 'loading'}
+  | {status: 'available'; identity: PreviewIdentity}
+  | {status: 'unavailable'};
+
+export function parsePreviewIdentity(value: unknown): PreviewIdentity | null {
+  if (typeof value !== 'object' || value === null) return null;
+
+  const candidate = value as {
+    commitSha?: unknown;
+    pullRequest?: unknown;
+  };
+  if (typeof candidate.commitSha !== 'string' || candidate.commitSha.length === 0) return null;
+  if (candidate.pullRequest === null || candidate.pullRequest === undefined) {
+    return {commitSha: candidate.commitSha, pullRequest: null};
+  }
+  if (typeof candidate.pullRequest !== 'object' || candidate.pullRequest === null) return null;
+
+  const pullRequest = candidate.pullRequest as {number?: unknown; url?: unknown};
+  if (!Number.isInteger(pullRequest.number) || (pullRequest.number as number) <= 0) return null;
+
+  return {
+    commitSha: candidate.commitSha,
+    pullRequest: {
+      number: pullRequest.number as number,
+      url: typeof pullRequest.url === 'string' ? pullRequest.url : null,
+    },
+  };
+}
+
 export function IntroductionPage() {
+  const [previewIdentity, setPreviewIdentity] = useState<PreviewIdentityState>({
+    status: 'loading',
+  });
+
+  useEffect(() => {
+    let active = true;
+
+    void fetch('/preview-metadata.json')
+      .then(async (response) => (response.ok ? parsePreviewIdentity(await response.json()) : null))
+      .then((identity) => {
+        if (!active) return;
+        setPreviewIdentity(
+          identity === null ? {status: 'unavailable'} : {status: 'available', identity},
+        );
+      })
+      .catch(() => {
+        if (active) setPreviewIdentity({status: 'unavailable'});
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
   return (
     <main className="min-h-dvh bg-background-neutral-background px-24 py-48">
       <div className="mx-auto flex max-w-[960px] flex-col gap-32">
@@ -18,6 +78,46 @@ export function IntroductionPage() {
             theme control above to review every surface in light or dark mode.
           </Text>
         </header>
+
+        <section
+          aria-labelledby="preview-identity"
+          className="rounded-8 bg-background-subtle-base p-20"
+        >
+          <Code variant="label" bold id="preview-identity">
+            Preview identity
+          </Code>
+          {previewIdentity.status === 'loading' ? (
+            <Text size="sm" className="mt-8 text-foreground-neutral-subtle">
+              Loading build metadata…
+            </Text>
+          ) : previewIdentity.status === 'unavailable' ? (
+            <Text size="sm" className="mt-8 text-foreground-neutral-subtle">
+              Build metadata is unavailable on this surface.
+            </Text>
+          ) : (
+            <dl className="mt-12 grid gap-8 text-sm sm:grid-cols-[auto_1fr] sm:gap-x-16">
+              <dt className="text-foreground-neutral-subtle">Source</dt>
+              <dd>
+                {previewIdentity.identity.pullRequest === null ? (
+                  'main'
+                ) : previewIdentity.identity.pullRequest.url === null ? (
+                  `Pull request #${previewIdentity.identity.pullRequest.number}`
+                ) : (
+                  <a
+                    className="underline underline-offset-4"
+                    href={previewIdentity.identity.pullRequest.url}
+                    rel="noreferrer"
+                    target="_blank"
+                  >
+                    Pull request #{previewIdentity.identity.pullRequest.number}
+                  </a>
+                )}
+              </dd>
+              <dt className="text-foreground-neutral-subtle">Commit</dt>
+              <dd className="break-all font-code">{previewIdentity.identity.commitSha}</dd>
+            </dl>
+          )}
+        </section>
 
         <section aria-labelledby="storybook-packages">
           <Header variant="h2" id="storybook-packages">

--- a/apps/storybook/test/artifact.test.ts
+++ b/apps/storybook/test/artifact.test.ts
@@ -2,9 +2,14 @@ import {mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {afterEach, describe, expect, it} from '@shipfox/vitest/vitest';
-import {defaultMaxFileBytes, validateStorybookDirectory} from '../scripts/artifact.js';
+import {
+  assertPreviewMetadata,
+  defaultMaxFileBytes,
+  validateStorybookDirectory,
+} from '../scripts/artifact.js';
 
 const temporaryDirectories: string[] = [];
+const invalidPullRequestPattern = /invalid pullRequest|invalid pull request number/;
 
 async function createFixture(
   index: Record<string, unknown> = {story: {type: 'story'}},
@@ -67,5 +72,52 @@ describe('Storybook artifact validation', () => {
         maxFileBytes: defaultMaxFileBytes,
       }),
     ).rejects.toThrow('missing local asset');
+  });
+});
+
+describe('Storybook preview metadata', () => {
+  it.each([
+    '42',
+    {number: 0, headSha: 'current-commit'},
+    {number: 1.5, headSha: 'current-commit'},
+  ])('rejects malformed pull request metadata %#', (pullRequest) => {
+    expect(() =>
+      assertPreviewMetadata({
+        version: 1,
+        commitSha: 'current-commit',
+        buildTime: '2026-07-27T00:00:00.000Z',
+        manifestVersion: 1,
+        pullRequest,
+        metrics: {
+          shell: {fileCount: 0, bytes: 0, oversizedFiles: []},
+          children: [],
+          total: {fileCount: 0, bytes: 0, oversizedFiles: []},
+        },
+      }),
+    ).toThrow(invalidPullRequestPattern);
+  });
+
+  it('rejects pull request metadata that points at another commit', () => {
+    expect(() =>
+      assertPreviewMetadata({
+        version: 1,
+        commitSha: 'current-commit',
+        buildTime: '2026-07-27T00:00:00.000Z',
+        manifestVersion: 1,
+        pullRequest: {
+          number: 42,
+          title: null,
+          url: null,
+          headSha: 'older-commit',
+          headRef: 'feature/preview',
+          baseRef: 'main',
+        },
+        metrics: {
+          shell: {fileCount: 0, bytes: 0, oversizedFiles: []},
+          children: [],
+          total: {fileCount: 0, bytes: 0, oversizedFiles: []},
+        },
+      }),
+    ).toThrow('headSha older-commit does not match commitSha current-commit');
   });
 });

--- a/apps/storybook/test/introduction.test.ts
+++ b/apps/storybook/test/introduction.test.ts
@@ -1,0 +1,34 @@
+import {describe, expect, it} from '@shipfox/vitest/vitest';
+import {parsePreviewIdentity} from '#introduction.js';
+
+describe('preview identity parsing', () => {
+  it('accepts main and pull request identities', () => {
+    expect(parsePreviewIdentity({commitSha: 'main-sha', pullRequest: null})).toEqual({
+      commitSha: 'main-sha',
+      pullRequest: null,
+    });
+    expect(
+      parsePreviewIdentity({
+        commitSha: 'preview-sha',
+        pullRequest: {number: 42, url: 'https://github.com/ShipfoxHQ/shipfox/pull/42'},
+      }),
+    ).toEqual({
+      commitSha: 'preview-sha',
+      pullRequest: {
+        number: 42,
+        url: 'https://github.com/ShipfoxHQ/shipfox/pull/42',
+      },
+    });
+  });
+
+  it.each([
+    null,
+    {},
+    {commitSha: ''},
+    {commitSha: 'preview-sha', pullRequest: '42'},
+    {commitSha: 'preview-sha', pullRequest: {number: 0}},
+    {commitSha: 'preview-sha', pullRequest: {number: 42.5}},
+  ])('rejects invalid identity metadata %#', (metadata) => {
+    expect(parsePreviewIdentity(metadata)).toBeNull();
+  });
+});

--- a/apps/storybook/test/smoke/preview.e2e.ts
+++ b/apps/storybook/test/smoke/preview.e2e.ts
@@ -10,6 +10,10 @@ type StorybookIndex = {
   entries: Record<string, StorybookIndexEntry>;
 };
 
+type PreviewMetadata = {
+  commitSha: string;
+};
+
 const compositionStoryUrlPattern = /\/\?path=\/story\/react-ui_/;
 
 async function getRepresentativeStoryId(request: APIRequestContext, path: string): Promise<string> {
@@ -57,6 +61,17 @@ test.describe('assembled Storybook preview', () => {
     await page.getByText('Accordion', {exact: true}).click();
     await expect(page).toHaveURL(compositionStoryUrlPattern);
     expect(errors).toEqual([]);
+  });
+
+  test('displays the exact deployed commit identity', async ({page, request}) => {
+    const metadataResponse = await request.get('/preview-metadata.json');
+    expect(metadataResponse.ok()).toBe(true);
+    const metadata = (await metadataResponse.json()) as PreviewMetadata;
+
+    await page.goto('/iframe.html?id=introduction--docs');
+
+    await expect(page.getByText('Preview identity', {exact: true})).toBeVisible();
+    await expect(page.getByText(metadata.commitSha, {exact: true})).toBeVisible();
   });
 
   test('renders one representative story from every child without browser errors', async ({

--- a/apps/storybook/tsconfig.test.json
+++ b/apps/storybook/tsconfig.test.json
@@ -9,6 +9,7 @@
     "playwright.config.ts",
     "preview-manifest.ts",
     "scripts",
+    "src/introduction.tsx",
     "vitest.config.ts",
     "node_modules/@shipfox/vitest/globals.d.ts"
   ],

--- a/cloudflare-pages.config.json
+++ b/cloudflare-pages.config.json
@@ -4,6 +4,13 @@
     "staging": { "branch": "staging" },
     "production": { "branch": "main" }
   },
+  "artifact": {
+    "metadataPath": "apps/storybook/storybook-output/preview-metadata.json"
+  },
+  "validation": {
+    "command": "pnpm",
+    "args": ["--filter=@shipfox/storybook", "test:e2e"]
+  },
   "apps": [
     {
       "id": "storybook",
@@ -20,7 +27,7 @@
         "@shipfox/client-triggers",
         "@shipfox/client-workflows"
       ],
-      "directory": "storybook-output",
+      "directory": "apps/storybook/storybook-output",
       "project": "storybook",
       "verify": {
         "metadataPath": "/preview-metadata.json",
@@ -65,6 +72,9 @@
   ],
   "forcePaths": [
     ".github/workflows/preview.yml",
+    ".github/workflows/deploy.yml",
+    ".github/workflows/ci.yml",
+    "cloudflare-pages.config.json",
     "apps/storybook",
     "mise.toml",
     "pnpm-lock.yaml",

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ listed there or when you need to place, update, or review documentation.
 | Changes a published package or prepares a release. | [Changesets and publishing workflow](guides/local-development-and-release-workflow.md#publish-packages-with-changesets) | Changeset rules, version bumps, summaries, and publishing. |
 | Needs the generated release-PR CI verification path. | [Generated release PR CI](guides/release-pr-ci.md) | The fast-path conditions and fail-closed verification behavior for Changesets release PRs. |
 | Needs to configure or review Vercel release-PR previews. | [Vercel release PR previews](vercel-preview-release-prs.md) | The repository-owned Vercel branch configuration and verification workflow. |
+| Operates Cloudflare Pages previews or recovers a deployment. | [Cloudflare Pages lifecycle](guides/cloudflare-pages-lifecycle.md) | Config-driven publication, environment deploys, retention ownership, and rollback steps. |
 | Changes agent behavior or needs agent execution instructions. | [Agent instructions](../AGENTS.md) | Repository-specific agent execution, change hygiene, and conditional context loading. |
 | Adds, updates, or exempts a dependency. | [Dependency version policy](policies/dependency-versions.md) | Version ranges, exceptions, coordinated package families, and dependency checks. |
 | Changes a cross-package client composition seam. | [ADR 0001](adr/0001-client-composition-contract.md) | The public client composition contract and its decision rationale. |

--- a/docs/guides/cloudflare-pages-lifecycle.md
+++ b/docs/guides/cloudflare-pages-lifecycle.md
@@ -1,0 +1,95 @@
+# Cloudflare Pages lifecycle
+
+The [preview workflow](../../.github/workflows/preview.yml) builds each app from
+one exact Git commit. The [deploy workflow](../../.github/workflows/deploy.yml)
+publishes previews, staging, or production. CI can call it. A maintainer can
+start it from `main`.
+Cloudflare Pages hosts the files. It does not build source code.
+
+## Publication rules
+
+| Source | Build | Deploy | Result |
+| --- | --- | --- | --- |
+| Pull request | Automatic | Automatic for branches in this repository | Immutable commit URL |
+| Fork pull request event | Automatic, without secrets | Maintainer approval | Workflow artifact, then immutable commit URL |
+| CI on `main` | After required checks | Production | Stable `main` catalog |
+| Manual deploy run from `main` | Current `main` or approved artifact | Preview or staging | Configured environment |
+
+An old pull request run stops when a new commit arrives. Each good deploy stores
+the full commit SHA in the metadata file. GitHub links to the fixed URL. A
+branch alias is only a short link.
+
+Main CI gives each push one first-in, first-out slot before checks start.
+Production deploys use a second non-canceling queue. A newer pending run does
+not replace an older one. Only main CI can publish production.
+
+The Pages config lists each app, output folder, build inputs, check paths, local
+test command, and metadata file. This keeps app details out of the workflows.
+
+## Approve a fork preview
+
+The pull request workflow builds fork code without repository secrets. It runs
+the artifact and browser checks. It uploads one artifact named for the pull
+request and exact head SHA.
+
+Check the pull request changes and the successful preview build before
+promotion. Start **Deploy** from the `main` branch. Select
+`preview` and enter the open pull request number.
+
+The deploy workflow checks the current pull request head. It finds the matching
+unexpired artifact and uses deployment tooling from `main`. It does not check
+out or execute fork source with the Cloudflare token. A moved or closed pull
+request stops the deployment.
+
+## Failure and stale commits
+
+The build and checks run before upload. A failed build or check stops all
+uploads. A provider error can still publish some apps in a multi-app plan.
+Every successful upload is registered and checked even when another app fails.
+The aggregate workflow stays failed.
+
+The deploy workflow checks a pull request head before and after upload. If it
+changed, the run is not current. The old fixed URL stays valid for its own
+commit.
+
+If a new build fails, keep the last good URL. Do not use it for the failed
+commit. Run the workflow again after the pull request is fixed.
+
+Manual staging runs always resolve the current `main` SHA. The workflow rejects
+runs started from another Git ref. Reusable stable deployments also reject
+commits that are not merged into `main`.
+
+## Retention
+
+The policy keeps deploys for open pull requests and for 30 days after close.
+The scheduled cleanup work belongs to
+[ENG-1283](https://linear.app/shipfox/issue/ENG-1283/add-cloudflare-storybook-preview-retention-and-cleanup).
+It must keep the newest deploy for each open `pr-<number>` branch. It must never
+delete staging or production deploys.
+
+## Recovery and rollback
+
+Use the fixed URL for recovery. It names one commit. It does not change when the
+pull request alias moves.
+
+1. For a failed pull request deploy, keep the last good URL from the workflow
+   summary.
+2. For a broken production catalog, stop promotion by disabling the deploy
+   workflow or removing the bad change.
+3. Revert the bad main change. After CI passes, deploy again.
+4. Check the metadata, paths, and app shell.
+5. Keep the Cloudflare project and last good deploy during rollback.
+
+Record one rollback drill in a non-production Pages project before production
+is gated. Use a known good immutable URL, deploy a reversible change to staging,
+revert it on `main`, and confirm that the new staging metadata names the revert
+commit.
+
+## Local verification
+
+Run these checks from the repository root:
+
+```sh
+mise exec -- turbo check type test --filter=@shipfox/storybook...
+mise exec -- turbo check type test --filter=@shipfox/cloudflare-pages...
+```

--- a/tools/cloudflare-pages/README.md
+++ b/tools/cloudflare-pages/README.md
@@ -9,6 +9,10 @@ through Wrangler Direct Upload.
   changed paths.
 - `shipfox-cloudflare-pages build-all` builds the selected applications with
   their configured environment inputs.
+- `shipfox-cloudflare-pages validate` runs the optional configured local
+  artifact check.
+- `shipfox-cloudflare-pages archive-all` stages selected outputs for CI
+  artifacts.
 - `shipfox-cloudflare-pages deploy` uploads one static directory to a
   configured Cloudflare Pages project.
 - `shipfox-cloudflare-pages deploy-all` uploads selected applications to their
@@ -21,9 +25,8 @@ through Wrangler Direct Upload.
   queue timing.
 - `shipfox-cloudflare-pages summary` writes a GitHub Actions job summary.
 
-The tool is intentionally Cloudflare Pages-specific. It supports multiple
-applications and deployment environments without hiding Pages concepts such as
-projects, preview branches, and production deployments.
+The tool works only with Cloudflare Pages. One config can list several apps and
+environments. The CLI keeps Pages terms such as projects and branches visible.
 
 ## Installation / Setup
 
@@ -31,9 +34,9 @@ projects, preview branches, and production deployments.
 pnpm add -D @shipfox/cloudflare-pages
 ```
 
-The tool expects `wrangler` on `PATH`, `CLOUDFLARE_API_TOKEN`, and
-`CLOUDFLARE_ACCOUNT_ID`. Project names are application configuration, not
-secrets.
+The tool expects `wrangler` on `PATH`. Upload commands also need
+`CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`. Project names belong in the
+config because they are not secrets.
 
 The published package contains compiled output. In this workspace, CI builds it
 on demand with:
@@ -44,7 +47,8 @@ pnpm --filter=@shipfox/cloudflare-pages... build
 
 ## Configuration
 
-Directories are resolved from the working directory where the CLI runs:
+Application directories and artifact paths stay relative to the working
+directory where the CLI runs:
 
 ```json
 {
@@ -52,6 +56,17 @@ Directories are resolved from the working directory where the CLI runs:
     "preview": { "branch": "pr-{pullRequest}" },
     "staging": { "branch": "staging" },
     "production": { "branch": "main" }
+  },
+  "artifact": {
+    "metadataPath": "dist/example/preview-metadata.json"
+  },
+  "validation": {
+    "setup": {
+      "command": "pnpm",
+      "args": ["--filter=@shipfox/playwright", "exec", "playwright", "install", "--with-deps", "chromium"]
+    },
+    "command": "pnpm",
+    "args": ["--filter=@shipfox/example", "test:e2e"]
   },
   "apps": [
     {
@@ -88,25 +103,29 @@ Directories are resolved from the working directory where the CLI runs:
 }
 ```
 
-`project` is the default Pages project. `projects` can override it for a
-specific environment. Production deployments should name the Pages production
-branch explicitly; a branch value deploys to that Pages branch.
+Key config rules:
 
-`build.env` contains checked-in, non-secret build inputs by environment. The
-`{pullRequest}`, `{branch}`, and `{commit}` placeholders are resolved by the
-build command. `build.fromEnv` maps build variable names to CI environment
-variables without storing their values in the repository. Missing references
-fail before Turbo starts. The build command passes the resolved values to a
-Turbo task for the app target; each app is built separately so apps may use
-different values.
+- `project` is the default Pages project. `projects` sets an override for one
+  environment.
+- Production should name its Pages branch. The CLI passes that branch to
+  Wrangler.
+- `build.env` stores non-secret build values by environment. The build command
+  fills the `{pullRequest}`, `{branch}`, and `{commit}` placeholders.
+- `build.fromEnv` reads a value from a CI environment variable. A missing value
+  stops the build before Turbo starts.
+- Each build variable must also appear in the Turbo task's `env` array. Turbo
+  can then include the value in its task hash.
+- `apps` lists sites, not every package shown by a site. Use `affectedTargets`
+  when another package should rebuild the site.
+- `validation` is optional. Its `setup` command runs before the main check.
 
-The application must also list every build-time variable in its Turbo task's
-`env` array. This makes the value part of the task hash, so changing an API
-URL cannot reuse an artifact built for another environment.
+`archive-all` replaces its target directory. It rejects roots, parents of the
+working directory, output overlaps, and unsafe app IDs. The result contains a
+deployment plan.
 
-`apps` describes deployable sites, not necessarily every package rendered by a
-site. A composed site can use `affectedTargets` to list packages whose changes
-require rebuilding that one deployment.
+`deploy-all --artifact-directory` publishes that archive without a rebuild. It
+rejects links and `_worker.js` files. An approved static preview therefore
+cannot add Pages worker code.
 
 ## Usage
 
@@ -122,10 +141,19 @@ shipfox-cloudflare-pages build-all \
   --plan-file "$RUNNER_TEMP/pages-plan.json" \
   --output "$RUNNER_TEMP/pages-build.json"
 
+shipfox-cloudflare-pages validate \
+  --config cloudflare-pages.config.json
+
+shipfox-cloudflare-pages archive-all \
+  --config cloudflare-pages.config.json \
+  --artifact-directory "$RUNNER_TEMP/pages-artifact" \
+  --output "$RUNNER_TEMP/pages-artifact/.shipfox-pages-plan.json"
+
 shipfox-cloudflare-pages deploy-all \
   --environment preview \
   --config cloudflare-pages.config.json \
-  --plan-file "$RUNNER_TEMP/pages-plan.json" \
+  --plan-file "$RUNNER_TEMP/pages-artifact/.shipfox-pages-plan.json" \
+  --artifact-directory "$RUNNER_TEMP/pages-artifact" \
   --commit "$CLOUDFLARE_PAGES_COMMIT_SHA" \
   --output "$RUNNER_TEMP/pages-deployments.json" \
   --github-output "$GITHUB_OUTPUT"

--- a/tools/cloudflare-pages/src/cli.ts
+++ b/tools/cloudflare-pages/src/cli.ts
@@ -616,6 +616,15 @@ function markdownCell(value: unknown): string {
   return String(value).replaceAll('|', '\\|').replaceAll('\n', ' ');
 }
 
+function artifactStatus(): string {
+  const archiveResult = process.env.ARTIFACT_RESULT;
+  const uploadResult = process.env.ARTIFACT_UPLOAD_RESULT;
+  if (archiveResult === 'success' && uploadResult === 'success') {
+    return '✅ verified artifact ready';
+  }
+  return `❌ artifact unavailable (archive: ${getMetric(archiveResult)}, upload: ${getMetric(uploadResult)})`;
+}
+
 function appStatus({
   plan,
   deployment,
@@ -637,7 +646,7 @@ function appStatus({
     return '❌ superseded during upload';
   }
   if (process.env.ARTIFACT_ONLY === 'true') {
-    return '✅ verified artifact ready';
+    return artifactStatus();
   }
 
   if (deployment === undefined || !deployment.ok) {
@@ -709,6 +718,8 @@ async function runSummary(options: CliOptions): Promise<void> {
   const sourceCommit = process.env.CLOUDFLARE_PAGES_COMMIT_SHA ?? verificationReport?.commitSha;
   const deployments = deploymentManifest.apps;
   const artifactOnly = process.env.ARTIFACT_ONLY === 'true';
+  const artifactReady =
+    process.env.ARTIFACT_RESULT === 'success' && process.env.ARTIFACT_UPLOAD_RESULT === 'success';
   const supersededBeforeUpload = process.env.PRE_DEPLOY_HEAD_RESULT === 'failure';
   const supersededDuringUpload = process.env.POST_DEPLOY_HEAD_RESULT === 'failure';
   const syncMessage =
@@ -719,7 +730,9 @@ async function runSummary(options: CliOptions): Promise<void> {
         : supersededDuringUpload
           ? 'A newer commit superseded this run during upload; the stale run did not register a GitHub deployment status.'
           : artifactOnly
-            ? 'A verified artifact was archived and uploaded; Pages publication is handled by the separate deployment job.'
+            ? artifactReady
+              ? 'A verified artifact was archived and uploaded; Pages publication is handled by the separate deployment job.'
+              : `The verified artifact was not produced for this commit (archive: ${getMetric(process.env.ARTIFACT_RESULT)}, upload: ${getMetric(process.env.ARTIFACT_UPLOAD_RESULT)}).`
             : verificationReport?.ok === true
               ? 'Every selected app was checked and matched the exact source commit above.'
               : verificationReport !== null

--- a/tools/cloudflare-pages/src/cli.ts
+++ b/tools/cloudflare-pages/src/cli.ts
@@ -636,6 +636,9 @@ function appStatus({
   if (process.env.POST_DEPLOY_HEAD_RESULT === 'failure') {
     return '❌ superseded during upload';
   }
+  if (process.env.ARTIFACT_ONLY === 'true') {
+    return '✅ verified artifact ready';
+  }
 
   if (deployment === undefined || !deployment.ok) {
     return `❌ ${deployment?.error ?? 'application was not published'}`;
@@ -650,6 +653,20 @@ function appStatus({
     return `❌ ${reason}`;
   }
   return '⚠️ uploaded, not verified';
+}
+
+function archivedArtifactMetadataPath(
+  config: CloudflarePagesConfig,
+  artifactDirectory: string | undefined,
+): string | undefined {
+  const metadataPath = config.artifact?.metadataPath;
+  if (metadataPath === undefined || artifactDirectory === undefined) {
+    return metadataPath;
+  }
+
+  const app = config.apps.find((candidate) => isPathWithin(candidate.directory, metadataPath));
+  if (app === undefined) return metadataPath;
+  return resolve(artifactDirectory, app.id, relative(app.directory, metadataPath));
 }
 
 async function runSummary(options: CliOptions): Promise<void> {
@@ -677,7 +694,9 @@ async function runSummary(options: CliOptions): Promise<void> {
     option(options, 'verificationReport'),
     null,
   );
-  const metadataPath = option(options, 'artifactMetadata') ?? config.artifact?.metadataPath;
+  const metadataPath =
+    option(options, 'artifactMetadata') ??
+    archivedArtifactMetadataPath(config, option(options, 'artifactDirectory'));
   const metadata = await readJsonIfPresent<Record<string, unknown> | null>(metadataPath, null);
   const buildLogPath = option(options, 'buildLog');
   const buildLog = await readFileIfPresent(buildLogPath);
@@ -689,6 +708,7 @@ async function runSummary(options: CliOptions): Promise<void> {
   const title = option(options, 'title', 'Deployment');
   const sourceCommit = process.env.CLOUDFLARE_PAGES_COMMIT_SHA ?? verificationReport?.commitSha;
   const deployments = deploymentManifest.apps;
+  const artifactOnly = process.env.ARTIFACT_ONLY === 'true';
   const supersededBeforeUpload = process.env.PRE_DEPLOY_HEAD_RESULT === 'failure';
   const supersededDuringUpload = process.env.POST_DEPLOY_HEAD_RESULT === 'failure';
   const syncMessage =
@@ -698,13 +718,15 @@ async function runSummary(options: CliOptions): Promise<void> {
         ? 'A newer commit superseded this run before upload; no Pages deployment was published for this source commit.'
         : supersededDuringUpload
           ? 'A newer commit superseded this run during upload; the stale run did not register a GitHub deployment status.'
-          : verificationReport?.ok === true
-            ? 'Every selected app was checked and matched the exact source commit above.'
-            : verificationReport !== null
-              ? 'The deployment was attempted, but one or more Pages applications could not be verified against the exact source commit above.'
-              : process.env.DEPLOYMENT_RESULT === 'success'
-                ? 'The artifact was uploaded, but Pages applications were not verified for this source commit.'
-                : 'The deployment did not complete, so Pages applications are not available for this commit.';
+          : artifactOnly
+            ? 'A verified artifact was archived and uploaded; Pages publication is handled by the separate deployment job.'
+            : verificationReport?.ok === true
+              ? 'Every selected app was checked and matched the exact source commit above.'
+              : verificationReport !== null
+                ? 'The deployment was attempted, but one or more Pages applications could not be verified against the exact source commit above.'
+                : process.env.DEPLOYMENT_RESULT === 'success'
+                  ? 'The artifact was uploaded, but Pages applications were not verified for this source commit.'
+                  : 'The deployment did not complete, so Pages applications are not available for this commit.';
   const lines = [
     `## ${title} metrics`,
     '',
@@ -714,6 +736,12 @@ async function runSummary(options: CliOptions): Promise<void> {
     `| Queue | ${getMetric(process.env.QUEUE_SECONDS)} seconds |`,
     `| Build and assembly | ${getMetric(process.env.BUILD_SECONDS)} seconds (${getMetric(process.env.BUILD_RESULT)}) |`,
     `| Configured validation | ${getMetric(process.env.VALIDATION_SECONDS)} seconds (${getMetric(process.env.VALIDATION_RESULT)}) |`,
+    ...(artifactOnly
+      ? [
+          `| Verified artifact archive | ${getMetric(process.env.ARTIFACT_SECONDS)} seconds (${getMetric(process.env.ARTIFACT_RESULT)}) |`,
+          `| Artifact upload | ${getMetric(process.env.ARTIFACT_UPLOAD_RESULT)} |`,
+        ]
+      : []),
     `| ${platform} upload | ${getMetric(process.env.DEPLOYMENT_SECONDS)} seconds (${getMetric(process.env.DEPLOYMENT_RESULT)}) |`,
     `| Deployment verification | ${getMetric(process.env.DEPLOYMENT_VERIFICATION_SECONDS)} seconds (${getMetric(process.env.DEPLOYMENT_VERIFICATION_RESULT)}) |`,
     '| Remote cache | Workflow-configured read and write policy |',

--- a/tools/cloudflare-pages/src/cli.ts
+++ b/tools/cloudflare-pages/src/cli.ts
@@ -1,6 +1,12 @@
-import {appendFile, readFile, writeFile} from 'node:fs/promises';
+import {appendFile, cp, mkdir, readdir, readFile, rm, writeFile} from 'node:fs/promises';
+import {parse, relative, resolve, sep} from 'node:path';
 import {buildCloudflarePagesApps} from './build.js';
-import {type CloudflarePagesDeployment, deployCloudflarePagesApps, deployPages} from './deploy.js';
+import {
+  type CloudflarePagesDeployment,
+  deployCloudflarePagesApps,
+  deployPages,
+  runCommand,
+} from './deploy.js';
 import type {GitHubDeployment} from './github.js';
 import {
   assertCurrentCommit,
@@ -38,13 +44,7 @@ type VerificationSummary = {
   apps: Array<{appId: string; ok: boolean; errors?: string[] | undefined}>;
 };
 
-type ArtifactMetadata = {
-  metrics?: {
-    shell: {fileCount: number; bytes: number};
-    children: Array<{id: string; fileCount: number; bytes: number}>;
-    total: {fileCount: number; bytes: number};
-  };
-};
+const archiveAppIdPattern = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 
 function toOptionName(name: string): string {
   return name.replace(/-([a-z])/g, (_match, letter) => letter.toUpperCase());
@@ -115,6 +115,7 @@ async function runPlan(options: CliOptions): Promise<void> {
   const plan = createCloudflarePagesPlan({
     apps: config.apps,
     forcePaths: config.forcePaths,
+    eventName: option(options, 'event'),
   });
   await writeJson(options.output, plan);
   await writeGitHubOutput(options.githubOutput, {
@@ -145,12 +146,28 @@ async function runDeploy(options: CliOptions): Promise<void> {
 
 async function runDeployApps(options: CliOptions): Promise<void> {
   const config = await readCloudflarePagesConfig(configPath(options));
+  const artifactDirectory = option(options, 'artifactDirectory');
   const plan: Pick<DeploymentPlan, 'selectedApps'> = option(options, 'planFile')
     ? await readJson<Pick<DeploymentPlan, 'selectedApps'>>(requiredOption(options, 'planFile'))
     : {selectedApps: config.apps.map((app) => app.id)};
+  const apps =
+    artifactDirectory === undefined
+      ? config.apps
+      : config.apps.map((app) => ({
+          ...app,
+          directory: archiveAppDirectory(artifactDirectory, app.id),
+        }));
+  if (artifactDirectory !== undefined) {
+    await Promise.all(
+      apps
+        .filter((app) => plan.selectedApps?.includes(app.id))
+        .map((app) => assertStaticArtifactDirectory(app.directory)),
+    );
+  }
+
   const startedAt = Date.now();
   const result = await deployCloudflarePagesApps({
-    apps: config.apps,
+    apps,
     selectedAppIds: plan.selectedApps ?? [],
     environment: option(options, 'environment', 'preview') ?? 'preview',
     environments: config.environments,
@@ -198,6 +215,169 @@ async function runBuildApps(options: CliOptions): Promise<void> {
   });
   process.stdout.write(`${JSON.stringify(resultWithDuration, null, 2)}\n`);
   if (!resultWithDuration.ok) throw new Error(resultWithDuration.errors.join('; '));
+}
+
+async function runValidate(options: CliOptions): Promise<void> {
+  const config = await readCloudflarePagesConfig(configPath(options));
+  const outputPath = option(options, 'output');
+  const githubOutputPath = option(options, 'githubOutput');
+  const validation = config.validation;
+
+  if (validation === undefined) {
+    const result = {ok: true, skipped: true, reason: 'no validation command configured'};
+    await writeJson(outputPath, result);
+    await writeGitHubOutput(githubOutputPath, {
+      validation_ok: result.ok,
+      validation_skipped: result.skipped,
+      validation_seconds: 0,
+    });
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return;
+  }
+
+  const startedAt = Date.now();
+  try {
+    if (validation.setup !== undefined) {
+      await runCommand(validation.setup.command, validation.setup.args ?? [], {
+        timeoutMs: 1_800_000,
+      });
+    }
+    await runCommand(validation.command, validation.args ?? [], {timeoutMs: 1_800_000});
+  } catch (error) {
+    const result = {
+      ok: false,
+      skipped: false,
+      durationSeconds: Math.round((Date.now() - startedAt) / 1000),
+    };
+    await writeJson(outputPath, result);
+    await writeGitHubOutput(githubOutputPath, {
+      validation_ok: result.ok,
+      validation_skipped: result.skipped,
+      validation_seconds: result.durationSeconds,
+    });
+    throw error;
+  }
+
+  const result = {
+    ok: true,
+    skipped: false,
+    durationSeconds: Math.round((Date.now() - startedAt) / 1000),
+  };
+  await writeJson(outputPath, result);
+  await writeGitHubOutput(githubOutputPath, {
+    validation_ok: result.ok,
+    validation_skipped: result.skipped,
+    validation_seconds: result.durationSeconds,
+  });
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+async function assertStaticArtifactDirectory(directory: string): Promise<void> {
+  const entries = await readdir(directory, {withFileTypes: true});
+  for (const entry of entries) {
+    if (entry.isSymbolicLink()) {
+      throw new Error(`Archived application ${directory} contains a symbolic link`);
+    }
+    if (entry.name === '_worker.js') {
+      throw new Error(`Archived application ${directory} contains executable Pages worker code`);
+    }
+    if (entry.isDirectory()) {
+      await assertStaticArtifactDirectory(resolve(directory, entry.name));
+    }
+  }
+}
+
+function isPathWithin(root: string, candidate: string): boolean {
+  const pathFromRoot = relative(root, candidate);
+  return (
+    pathFromRoot === '' ||
+    (!pathFromRoot.startsWith(`..${sep}`) && pathFromRoot !== '..' && !parse(pathFromRoot).root)
+  );
+}
+
+function archiveAppDirectory(artifactDirectory: string, appId: string): string {
+  if (!archiveAppIdPattern.test(appId) || appId === '.' || appId === '..') {
+    throw new Error(`Application id ${appId} is not safe for an artifact directory`);
+  }
+
+  const archiveRoot = resolve(artifactDirectory);
+  const appDirectory = resolve(archiveRoot, appId);
+  if (!isPathWithin(archiveRoot, appDirectory) || appDirectory === archiveRoot) {
+    throw new Error(`Application id ${appId} escapes the artifact directory`);
+  }
+  return appDirectory;
+}
+
+function assertSafeArchiveRoot({
+  artifactDirectory,
+  configFile,
+  appDirectories,
+}: {
+  artifactDirectory: string;
+  configFile: string;
+  appDirectories: string[];
+}): string {
+  const archiveRoot = resolve(artifactDirectory);
+  const workingDirectory = resolve(process.cwd());
+  const filesystemRoot = parse(archiveRoot).root;
+  if (archiveRoot === filesystemRoot) {
+    throw new Error('The artifact directory cannot be a filesystem root');
+  }
+  if (isPathWithin(archiveRoot, workingDirectory)) {
+    throw new Error('The artifact directory cannot contain the working directory');
+  }
+
+  const protectedPaths = [
+    resolve(configFile),
+    ...appDirectories.map((directory) => resolve(directory)),
+  ];
+  if (
+    protectedPaths.some(
+      (protectedPath) =>
+        isPathWithin(archiveRoot, protectedPath) || isPathWithin(protectedPath, archiveRoot),
+    )
+  ) {
+    throw new Error('The artifact directory cannot overlap the config or application outputs');
+  }
+  return archiveRoot;
+}
+
+async function runArchiveApps(options: CliOptions): Promise<void> {
+  const configuredPath = configPath(options);
+  const config = await readCloudflarePagesConfig(configuredPath);
+  const plan: Partial<DeploymentPlan> & Pick<DeploymentPlan, 'selectedApps'> = option(
+    options,
+    'planFile',
+  )
+    ? await readJson<Partial<DeploymentPlan> & Pick<DeploymentPlan, 'selectedApps'>>(
+        requiredOption(options, 'planFile'),
+      )
+    : {selectedApps: config.apps.map((app) => app.id)};
+  const artifactDirectory = assertSafeArchiveRoot({
+    artifactDirectory: requiredOption(options, 'artifactDirectory'),
+    configFile: configuredPath,
+    appDirectories: config.apps.map((app) => app.directory),
+  });
+  const selected = config.apps.filter((app) => plan.selectedApps?.includes(app.id));
+  if (selected.length === 0) throw new Error('No applications were selected for archiving');
+
+  await rm(artifactDirectory, {recursive: true, force: true});
+  await mkdir(artifactDirectory, {recursive: true});
+  for (const app of selected) {
+    await cp(app.directory, archiveAppDirectory(artifactDirectory, app.id), {recursive: true});
+  }
+
+  const selectedApps = selected.map((app) => app.id);
+  const result = {
+    shouldDeploy: true,
+    reason: plan.reason ?? 'verified artifact',
+    selectedApps,
+    affectedTargets: plan.affectedTargets ?? [],
+    apps: selectedApps,
+    directory: artifactDirectory,
+  };
+  await writeJson(option(options, 'output'), result);
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
 }
 
 async function runVerify(options: CliOptions): Promise<void> {
@@ -497,8 +677,8 @@ async function runSummary(options: CliOptions): Promise<void> {
     option(options, 'verificationReport'),
     null,
   );
-  const metadataPath = option(options, 'artifactMetadata');
-  const metadata = await readJsonIfPresent<ArtifactMetadata | null>(metadataPath, null);
+  const metadataPath = option(options, 'artifactMetadata') ?? config.artifact?.metadataPath;
+  const metadata = await readJsonIfPresent<Record<string, unknown> | null>(metadataPath, null);
   const buildLogPath = option(options, 'buildLog');
   const buildLog = await readFileIfPresent(buildLogPath);
   const turboLines = buildLog
@@ -533,10 +713,10 @@ async function runSummary(options: CliOptions): Promise<void> {
     `| Turbo affected plan | ${plan.shouldDeploy} (${plan.reason}) |`,
     `| Queue | ${getMetric(process.env.QUEUE_SECONDS)} seconds |`,
     `| Build and assembly | ${getMetric(process.env.BUILD_SECONDS)} seconds (${getMetric(process.env.BUILD_RESULT)}) |`,
-    `| Validation and browser smoke | ${getMetric(process.env.VALIDATION_SECONDS)} seconds (${getMetric(process.env.VALIDATION_RESULT)}) |`,
+    `| Configured validation | ${getMetric(process.env.VALIDATION_SECONDS)} seconds (${getMetric(process.env.VALIDATION_RESULT)}) |`,
     `| ${platform} upload | ${getMetric(process.env.DEPLOYMENT_SECONDS)} seconds (${getMetric(process.env.DEPLOYMENT_RESULT)}) |`,
     `| Deployment verification | ${getMetric(process.env.DEPLOYMENT_VERIFICATION_SECONDS)} seconds (${getMetric(process.env.DEPLOYMENT_VERIFICATION_RESULT)}) |`,
-    '| Remote cache | Pull requests read only; main reads and writes |',
+    '| Remote cache | Workflow-configured read and write policy |',
     `| Published apps | ${deployments.filter((deployment) => deployment.ok).length}/${config.apps.length} |`,
     '',
     '### Application deployments',
@@ -569,17 +749,8 @@ async function runSummary(options: CliOptions): Promise<void> {
     '',
   ];
 
-  if (metadata?.metrics !== undefined) {
-    lines.push('| Deployment part | Files | Bytes |', '| --- | ---: | ---: |');
-    lines.push(
-      `| Composition shell | ${metadata.metrics.shell.fileCount} | ${metadata.metrics.shell.bytes} |`,
-      ...metadata.metrics.children.map(
-        (child) => `| ${child.id} | ${child.fileCount} | ${child.bytes} |`,
-      ),
-      `| Total | ${metadata.metrics.total.fileCount} | ${metadata.metrics.total.bytes} |`,
-      '',
-      '- Static output and configured endpoint checks passed.',
-    );
+  if (metadata !== null) {
+    lines.push('- Verified artifact metadata was produced.', '');
   } else {
     lines.push('No verified artifact metadata was produced.');
   }
@@ -589,7 +760,7 @@ async function runSummary(options: CliOptions): Promise<void> {
 
 function printHelp(): void {
   process.stdout.write(
-    `shipfox-cloudflare-pages <command> [options]\n\nCommands:\n  plan       Select affected apps from Turbo and git\n  build-all  Build configured apps with environment-specific inputs\n  deploy     Upload one static directory to Cloudflare Pages\n  deploy-all Upload configured apps to Cloudflare Pages\n  verify     Check one deployed root, metadata, and JSON endpoints\n  verify-all Check configured apps against their Pages URLs\n  github     Manage GitHub deployment lifecycle or queue timing\n  summary    Write Cloudflare Pages deployment metrics\n`,
+    `shipfox-cloudflare-pages <command> [options]\n\nCommands:\n  plan       Select affected apps from Turbo and git\n  build-all  Build configured apps with environment-specific inputs\n  validate   Run the configured local artifact validation\n  archive-all Archive selected application outputs\n  deploy     Upload one static directory to Cloudflare Pages\n  deploy-all Upload configured apps to Cloudflare Pages\n  verify     Check one deployed root, metadata, and JSON endpoints\n  verify-all Check configured apps against their Pages URLs\n  github     Manage GitHub deployment lifecycle or queue timing\n  summary    Write Cloudflare Pages deployment metrics\n`,
   );
 }
 
@@ -607,6 +778,8 @@ function main(): Promise<unknown> | undefined {
 
   if (command === 'plan') return runPlan(options);
   if (command === 'build-all') return runBuildApps(options);
+  if (command === 'validate') return runValidate(options);
+  if (command === 'archive-all') return runArchiveApps(options);
   if (command === 'deploy') return runDeploy(options);
   if (command === 'deploy-all') return runDeployApps(options);
   if (command === 'verify') return runVerify(options);

--- a/tools/cloudflare-pages/src/github.ts
+++ b/tools/cloudflare-pages/src/github.ts
@@ -119,10 +119,24 @@ export async function assertCurrentCommit({
 
   const result = await runner(
     command,
-    ['api', `repos/${resolvedRepository}/pulls/${resolvedPullRequest}`, '--jq', '.head.sha'],
+    [
+      'api',
+      `repos/${resolvedRepository}/pulls/${resolvedPullRequest}`,
+      '--jq',
+      '{headSha: .head.sha, state: .state, baseRef: .base.ref}',
+    ],
     {cwd, stream: false, timeoutMs},
   );
-  const currentCommit = result.output.trim();
+  const pullRequestState = parseJsonOutput(result.output, 'GitHub pull request');
+  const currentCommit =
+    typeof pullRequestState.headSha === 'string' ? pullRequestState.headSha : '';
+  const state = typeof pullRequestState.state === 'string' ? pullRequestState.state : '';
+  const baseRef = typeof pullRequestState.baseRef === 'string' ? pullRequestState.baseRef : '';
+  if (state !== 'open' || baseRef !== 'main') {
+    throw new Error(
+      `Pull request ${resolvedPullRequest} is not an open pull request targeting main (state: ${state || 'unknown'}, base: ${baseRef || 'unknown'})`,
+    );
+  }
   if (currentCommit !== resolvedCommit) {
     throw new Error(
       `Deployment commit ${resolvedCommit} is no longer current; pull request ${resolvedPullRequest} now points to ${currentCommit || 'an unknown commit'}`,

--- a/tools/cloudflare-pages/src/index.ts
+++ b/tools/cloudflare-pages/src/index.ts
@@ -19,10 +19,13 @@ export {
 } from './github.js';
 export type {
   CloudflarePagesApp,
+  CloudflarePagesArtifactConfig,
   CloudflarePagesBuildConfig,
+  CloudflarePagesCommandConfig,
   CloudflarePagesConfig,
   CloudflarePagesEndpoint,
   CloudflarePagesEnvironment,
+  CloudflarePagesValidationConfig,
 } from './plan.js';
 export {
   createCloudflarePagesPlan,

--- a/tools/cloudflare-pages/src/plan.ts
+++ b/tools/cloudflare-pages/src/plan.ts
@@ -34,11 +34,55 @@ export type CloudflarePagesEnvironment = {
   branch?: string | null;
 };
 
+export type CloudflarePagesCommandConfig = {
+  command: string;
+  args?: string[];
+};
+
+export type CloudflarePagesValidationConfig = CloudflarePagesCommandConfig & {
+  setup?: CloudflarePagesCommandConfig;
+};
+
+export type CloudflarePagesArtifactConfig = {
+  metadataPath?: string;
+};
+
 export type CloudflarePagesConfig = {
   apps: CloudflarePagesApp[];
   environments: Record<string, CloudflarePagesEnvironment>;
   forcePaths: string[];
+  artifact?: CloudflarePagesArtifactConfig;
+  validation?: CloudflarePagesValidationConfig;
 };
+
+function isCommandConfig(value: unknown): value is CloudflarePagesCommandConfig {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+
+  const command = value as Record<string, unknown>;
+  return (
+    typeof command.command === 'string' &&
+    command.command.length > 0 &&
+    (command.args === undefined ||
+      (Array.isArray(command.args) &&
+        command.args.every((argument: unknown) => typeof argument === 'string')))
+  );
+}
+
+function isValidationConfig(value: unknown): value is CloudflarePagesValidationConfig {
+  if (!isCommandConfig(value)) return false;
+
+  const validation = value as CloudflarePagesCommandConfig & {setup?: unknown};
+  return validation.setup === undefined || isCommandConfig(validation.setup);
+}
+
+function isArtifactConfig(value: unknown): value is CloudflarePagesArtifactConfig {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+
+  const metadataPath = (value as Record<string, unknown>).metadataPath;
+  return (
+    metadataPath === undefined || (typeof metadataPath === 'string' && metadataPath.length > 0)
+  );
+}
 
 export const defaultCloudflarePagesEnvironments = {
   preview: {branch: 'pr-{pullRequest}'},
@@ -279,7 +323,28 @@ export async function readCloudflarePagesConfig(
     throw new Error(`${configPath} must contain a string forcePaths array`);
   }
 
-  return {apps: config.apps, environments, forcePaths} as CloudflarePagesConfig;
+  const artifact = config.artifact;
+  if (artifact !== undefined && !isArtifactConfig(artifact)) {
+    throw new Error(`${configPath} artifact must define a valid metadataPath`);
+  }
+
+  const validation = config.validation;
+  if (validation !== undefined && !isValidationConfig(validation)) {
+    throw new Error(`${configPath} validation must define commands and string args`);
+  }
+
+  return {
+    apps: config.apps as CloudflarePagesApp[],
+    environments: environments as Record<string, CloudflarePagesEnvironment>,
+    forcePaths: forcePaths as string[],
+    ...(artifact === undefined
+      ? {}
+      : {
+          artifact:
+            artifact.metadataPath === undefined ? {} : {metadataPath: artifact.metadataPath},
+        }),
+    ...(validation === undefined ? {} : {validation}),
+  };
 }
 
 /**
@@ -322,18 +387,26 @@ export function createCloudflarePagesPlan({
   );
   const forcedByFile = hasForcedChange(changedFiles, forcePaths);
   const isMainPush = eventName === 'push';
-  const shouldDeploy = isMainPush || forcedByFile || affectedTargets.length > 0;
-  const selectedApps = shouldDeploy ? (isMainPush || forcedByFile ? apps : affectedApps) : [];
+  const isExplicitDeployment = eventName === 'deployment';
+  const shouldDeploy =
+    isMainPush || isExplicitDeployment || forcedByFile || affectedTargets.length > 0;
+  const selectedApps = shouldDeploy
+    ? isMainPush || isExplicitDeployment || forcedByFile
+      ? apps
+      : affectedApps
+    : [];
 
   return {
     shouldDeploy,
     reason: isMainPush
       ? 'main push'
-      : forcedByFile
-        ? 'Pages workflow or application configuration changed'
-        : affectedTargets.length > 0
-          ? 'Turbo affected Pages target detected'
-          : 'no Pages target is affected',
+      : isExplicitDeployment
+        ? 'explicit deployment'
+        : forcedByFile
+          ? 'Pages workflow or application configuration changed'
+          : affectedTargets.length > 0
+            ? 'Turbo affected Pages target detected'
+            : 'no Pages target is affected',
     affectedPackages,
     affectedTargets,
     affectedApps: affectedApps.map((app) => app.id),

--- a/tools/cloudflare-pages/test/cloudflare-pages.test.mjs
+++ b/tools/cloudflare-pages/test/cloudflare-pages.test.mjs
@@ -37,6 +37,7 @@ const workingDirectoryArchivePattern = /cannot contain the working directory/;
 const emptyArchiveSelectionPattern = /No applications were selected/;
 const partialDeploymentPattern = /other: Cloudflare Pages Direct Upload failed/;
 const archivedWorkerPattern = /contains executable Pages worker code/;
+const invalidPullRequestLifecyclePattern = /not an open pull request targeting main/;
 const cliPath = fileURLToPath(new URL('../bin/cloudflare-pages.js', import.meta.url));
 const execFileAsync = promisify(execFile);
 const exampleApps = [
@@ -1094,10 +1095,29 @@ test('rejects a deployment when the pull request head has moved', async () => {
       pullRequest: '42',
       commit: 'abc123',
       runner: (_command, args) => {
-        assert.deepEqual(args, ['api', 'repos/ShipfoxHQ/example/pulls/42', '--jq', '.head.sha']);
-        return {output: 'def456\n'};
+        assert.deepEqual(args, [
+          'api',
+          'repos/ShipfoxHQ/example/pulls/42',
+          '--jq',
+          '{headSha: .head.sha, state: .state, baseRef: .base.ref}',
+        ]);
+        return {output: '{"headSha":"def456","state":"open","baseRef":"main"}\n'};
       },
     }),
     headMovedPattern,
+  );
+});
+
+test('rejects a closed or retargeted pull request before deployment', async () => {
+  await assert.rejects(
+    assertCurrentCommit({
+      repository: 'ShipfoxHQ/example',
+      pullRequest: '42',
+      commit: 'abc123',
+      runner: () => ({
+        output: '{"headSha":"abc123","state":"closed","baseRef":"main"}\n',
+      }),
+    }),
+    invalidPullRequestLifecyclePattern,
   );
 });

--- a/tools/cloudflare-pages/test/cloudflare-pages.test.mjs
+++ b/tools/cloudflare-pages/test/cloudflare-pages.test.mjs
@@ -1,8 +1,11 @@
 import assert from 'node:assert/strict';
-import {mkdtemp, rm, writeFile} from 'node:fs/promises';
+import {execFile} from 'node:child_process';
+import {mkdir, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import test from 'node:test';
+import {fileURLToPath} from 'node:url';
+import {promisify} from 'node:util';
 
 import {runCommand} from '../dist/deploy.js';
 import {
@@ -28,6 +31,14 @@ const missingCiEnvironmentPattern = /missing CI environment variable PREVIEW_SEN
 const missingPullRequestPattern = /pull request number is required/;
 const productionBranchPattern = /production branch is production, expected main/;
 const invalidEndpointConfigurationPattern = /endpoints must define paths/;
+const validationOkPattern = /validation_ok=true/;
+const unsafeAppIdPattern = /not safe/;
+const workingDirectoryArchivePattern = /cannot contain the working directory/;
+const emptyArchiveSelectionPattern = /No applications were selected/;
+const partialDeploymentPattern = /other: Cloudflare Pages Direct Upload failed/;
+const archivedWorkerPattern = /contains executable Pages worker code/;
+const cliPath = fileURLToPath(new URL('../bin/cloudflare-pages.js', import.meta.url));
+const execFileAsync = promisify(execFile);
 const exampleApps = [
   {
     id: 'example',
@@ -44,6 +55,13 @@ const exampleApps = [
     verify: {metadataPath: '/preview-metadata.json', endpoints: ['/index.json']},
   },
 ];
+
+function runCli(args, cwd) {
+  return execFileAsync(process.execPath, [cliPath, ...args], {
+    cwd,
+    env: {...process.env},
+  });
+}
 
 test('plans a Pages deployment from affected targets and forced paths', () => {
   const plan = createCloudflarePagesPlan({
@@ -87,6 +105,20 @@ test('selects every configured app for a main push', () => {
   assert.deepEqual(plan.selectedApps, ['example', 'other']);
 });
 
+test('selects every configured app for an explicit deployment', () => {
+  const plan = createCloudflarePagesPlan({
+    apps: exampleApps,
+    forcePaths: [],
+    eventName: 'deployment',
+    affectedPackages: [],
+    changedFiles: [],
+  });
+
+  assert.equal(plan.shouldDeploy, true);
+  assert.equal(plan.reason, 'explicit deployment');
+  assert.deepEqual(plan.selectedApps, ['example', 'other']);
+});
+
 test('selects a composed app when one of its affected targets changes', () => {
   const plan = createCloudflarePagesPlan({
     apps: [{...exampleApps[0], affectedTargets: ['@shipfox/example-child']}],
@@ -126,6 +158,321 @@ test('rejects invalid endpoint verification configuration', async () => {
         invalidEndpointConfigurationPattern,
       );
     }
+  } finally {
+    await rm(directory, {recursive: true, force: true});
+  }
+});
+
+test('rejects invalid artifact and validation configuration', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'shipfox-cloudflare-pages-config-'));
+  try {
+    for (const invalidConfig of [
+      {artifact: []},
+      {artifact: {metadataPath: ''}},
+      {validation: []},
+      {validation: {command: ''}},
+      {validation: {command: 'pnpm', args: ['test', 42]}},
+      {validation: {command: 'pnpm', setup: {command: ''}}},
+    ]) {
+      await writeFile(
+        join(directory, 'config.json'),
+        JSON.stringify({
+          ...invalidConfig,
+          apps: [
+            {
+              id: 'example',
+              target: '@shipfox/example',
+              directory: 'dist/example',
+              project: 'example',
+            },
+          ],
+        }),
+      );
+      await assert.rejects(readCloudflarePagesConfig('config.json', directory));
+    }
+  } finally {
+    await rm(directory, {recursive: true, force: true});
+  }
+});
+
+test('keeps application outputs relative to the caller working directory', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'shipfox-cloudflare-pages-config-'));
+  try {
+    await mkdir(join(directory, 'config'));
+    await writeFile(
+      join(directory, 'config/config.json'),
+      JSON.stringify({
+        artifact: {metadataPath: 'dist/example/metadata.json'},
+        validation: {
+          setup: {command: 'pnpm', args: ['prepare']},
+          command: 'pnpm',
+          args: ['test'],
+        },
+        apps: [
+          {
+            id: 'example',
+            target: '@shipfox/example',
+            directory: 'dist/example',
+            project: 'example',
+          },
+        ],
+      }),
+    );
+
+    const config = await readCloudflarePagesConfig('config/config.json', directory);
+    assert.equal(config.apps[0].directory, 'dist/example');
+    assert.deepEqual(config.artifact, {
+      metadataPath: 'dist/example/metadata.json',
+    });
+    assert.deepEqual(config.validation, {
+      setup: {command: 'pnpm', args: ['prepare']},
+      command: 'pnpm',
+      args: ['test'],
+    });
+  } finally {
+    await rm(directory, {recursive: true, force: true});
+  }
+});
+
+test('runs configured validation commands and records failures', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'shipfox-cloudflare-pages-cli-'));
+  try {
+    const marker = join(directory, 'setup-complete');
+    const output = join(directory, 'validation.json');
+    const githubOutput = join(directory, 'github-output');
+    await writeFile(
+      join(directory, 'config.json'),
+      JSON.stringify({
+        validation: {
+          setup: {
+            command: process.execPath,
+            args: ['-e', `require('node:fs').writeFileSync(${JSON.stringify(marker)}, 'ready')`],
+          },
+          command: process.execPath,
+          args: [
+            '-e',
+            `if (require('node:fs').readFileSync(${JSON.stringify(marker)}, 'utf8') !== 'ready') process.exit(2)`,
+          ],
+        },
+        apps: [
+          {
+            id: 'example',
+            target: '@shipfox/example',
+            directory: 'dist/example',
+            project: 'example',
+          },
+        ],
+      }),
+    );
+
+    await runCli(
+      ['validate', '--config', 'config.json', '--output', output, '--github-output', githubOutput],
+      directory,
+    );
+    assert.equal(JSON.parse(await readFile(output, 'utf8')).ok, true);
+    assert.match(await readFile(githubOutput, 'utf8'), validationOkPattern);
+
+    await writeFile(
+      join(directory, 'config.json'),
+      JSON.stringify({
+        validation: {command: process.execPath, args: ['-e', 'process.exit(3)']},
+        apps: [
+          {
+            id: 'example',
+            target: '@shipfox/example',
+            directory: 'dist/example',
+            project: 'example',
+          },
+        ],
+      }),
+    );
+    await assert.rejects(
+      runCli(['validate', '--config', 'config.json', '--output', output], directory),
+    );
+    assert.equal(JSON.parse(await readFile(output, 'utf8')).ok, false);
+  } finally {
+    await rm(directory, {recursive: true, force: true});
+  }
+});
+
+test('skips validation when no command is configured', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'shipfox-cloudflare-pages-cli-'));
+  try {
+    const output = join(directory, 'validation.json');
+    await writeFile(
+      join(directory, 'config.json'),
+      JSON.stringify({
+        apps: [
+          {
+            id: 'example',
+            target: '@shipfox/example',
+            directory: 'dist/example',
+            project: 'example',
+          },
+        ],
+      }),
+    );
+
+    await runCli(['validate', '--config', 'config.json', '--output', output], directory);
+
+    assert.deepEqual(JSON.parse(await readFile(output, 'utf8')), {
+      ok: true,
+      skipped: true,
+      reason: 'no validation command configured',
+    });
+  } finally {
+    await rm(directory, {recursive: true, force: true});
+  }
+});
+
+test('archives selected outputs while replacing stale artifact contents', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'shipfox-cloudflare-pages-cli-'));
+  try {
+    await mkdir(join(directory, 'dist/example'), {recursive: true});
+    await writeFile(join(directory, 'dist/example/index.html'), 'current');
+    await mkdir(join(directory, 'artifact'), {recursive: true});
+    await writeFile(join(directory, 'artifact/stale.txt'), 'stale');
+    await writeFile(
+      join(directory, 'config.json'),
+      JSON.stringify({
+        apps: [
+          {
+            id: 'example',
+            target: '@shipfox/example',
+            directory: 'dist/example',
+            project: 'example',
+          },
+        ],
+      }),
+    );
+
+    await runCli(
+      [
+        'archive-all',
+        '--config',
+        'config.json',
+        '--artifact-directory',
+        'artifact',
+        '--output',
+        'artifact/.shipfox-pages-plan.json',
+      ],
+      directory,
+    );
+
+    assert.equal(await readFile(join(directory, 'artifact/example/index.html'), 'utf8'), 'current');
+    await assert.rejects(readFile(join(directory, 'artifact/stale.txt'), 'utf8'));
+    const manifest = JSON.parse(
+      await readFile(join(directory, 'artifact/.shipfox-pages-plan.json'), 'utf8'),
+    );
+    assert.equal(manifest.shouldDeploy, true);
+    assert.equal(manifest.reason, 'verified artifact');
+    assert.deepEqual(manifest.selectedApps, ['example']);
+  } finally {
+    await rm(directory, {recursive: true, force: true});
+  }
+});
+
+test('rejects unsafe archive roots, application ids, and empty selections', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'shipfox-cloudflare-pages-cli-'));
+  try {
+    await mkdir(join(directory, 'dist/example'), {recursive: true});
+    await writeFile(join(directory, 'dist/example/index.html'), 'current');
+    await writeFile(
+      join(directory, 'config.json'),
+      JSON.stringify({
+        apps: [
+          {
+            id: '../escape',
+            target: '@shipfox/example',
+            directory: 'dist/example',
+            project: 'example',
+          },
+        ],
+      }),
+    );
+    await assert.rejects(
+      runCli(
+        ['archive-all', '--config', 'config.json', '--artifact-directory', 'artifact'],
+        directory,
+      ),
+      unsafeAppIdPattern,
+    );
+
+    await writeFile(
+      join(directory, 'config.json'),
+      JSON.stringify({
+        apps: [
+          {
+            id: 'example',
+            target: '@shipfox/example',
+            directory: 'dist/example',
+            project: 'example',
+          },
+        ],
+      }),
+    );
+    await assert.rejects(
+      runCli(['archive-all', '--config', 'config.json', '--artifact-directory', '.'], directory),
+      workingDirectoryArchivePattern,
+    );
+    await writeFile(join(directory, 'plan.json'), JSON.stringify({selectedApps: ['missing']}));
+    await assert.rejects(
+      runCli(
+        [
+          'archive-all',
+          '--config',
+          'config.json',
+          '--plan-file',
+          'plan.json',
+          '--artifact-directory',
+          'artifact',
+        ],
+        directory,
+      ),
+      emptyArchiveSelectionPattern,
+    );
+  } finally {
+    await rm(directory, {recursive: true, force: true});
+  }
+});
+
+test('rejects executable worker code in a promoted preview artifact', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'shipfox-cloudflare-pages-cli-'));
+  try {
+    await mkdir(join(directory, 'artifact/example'), {recursive: true});
+    await writeFile(join(directory, 'artifact/example/_worker.js'), 'export default {};');
+    await writeFile(
+      join(directory, 'config.json'),
+      JSON.stringify({
+        apps: [
+          {
+            id: 'example',
+            target: '@shipfox/example',
+            directory: 'dist/example',
+            project: 'example',
+          },
+        ],
+      }),
+    );
+    await writeFile(join(directory, 'plan.json'), JSON.stringify({selectedApps: ['example']}));
+
+    await assert.rejects(
+      runCli(
+        [
+          'deploy-all',
+          '--config',
+          'config.json',
+          '--plan-file',
+          'plan.json',
+          '--artifact-directory',
+          'artifact',
+          '--commit',
+          'abc123',
+        ],
+        directory,
+      ),
+      archivedWorkerPattern,
+    );
   } finally {
     await rm(directory, {recursive: true, force: true});
   }
@@ -230,6 +577,26 @@ test('uploads selected apps to their configured projects', async () => {
     '--branch=pr-42',
     '--commit-hash=abc123',
   ]);
+});
+
+test('reports successful uploads when another selected app fails', async () => {
+  const result = await deployCloudflarePagesApps({
+    apps: exampleApps,
+    branch: 'pr-42',
+    commitSha: 'abc123',
+    attempts: 1,
+    retryDelayMs: 0,
+    runner: (_command, args) => {
+      if (args.includes('--project-name=other')) throw new Error('provider rejected other');
+      return {output: 'https://example.example.pages.dev'};
+    },
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.apps[0].ok, true);
+  assert.equal(result.apps[0].url, 'https://example.example.pages.dev');
+  assert.equal(result.apps[1].ok, false);
+  assert.match(result.errors[0], partialDeploymentPattern);
 });
 
 test('rejects deployments when no configured app matches the plan', async () => {
@@ -593,6 +960,27 @@ test('names app GitHub deployments with a readable preview label', async () => {
   });
 
   assert.equal(requests[0].payload.environment, 'Preview – storybook – PR 42');
+});
+
+test('registers successful applications from a partial deployment manifest', async () => {
+  const requests = [];
+  const result = await createGitHubDeployments({
+    deployments: [
+      {appId: 'storybook', ok: true, url: 'https://storybook.pages.dev'},
+      {appId: 'docs', ok: false},
+    ],
+    repository: 'ShipfoxHQ/example',
+    ref: 'abc123',
+    runner: (_command, args, options) => {
+      requests.push({args, payload: JSON.parse(options.input)});
+      return {output: JSON.stringify({id: 123})};
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.apps.length, 1);
+  assert.equal(requests.length, 2);
+  assert.equal(requests[0].payload.environment, 'Preview – storybook');
 });
 
 test('uses the GitHub repository from the CI environment for deployment registration', async () => {


### PR DESCRIPTION
Adds the main Storybook catalog and verified preview deployment lifecycle for ENG-1178.

The preview workflow is generic and config-driven, while the separate Deploy workflow supports reusable CI deployments and maintainer-run preview or staging promotion. Production remains CI-only and pinned to the current merged main revision. Fork previews build without secrets and can only be promoted from a successful, current artifact.

The change also adds archive safety checks, partial-deployment registration and reporting, config validation, deployment identity metadata, lifecycle documentation, focused tests, and the required minor Changeset for `@shipfox/cloudflare-pages`.

Validation completed with focused Cloudflare Pages and Storybook dependent Turbo checks, a full Storybook build, browser smoke coverage, artifact plan/archive round trips, documentation validation, workflow YAML parsing, and `git diff --check`. The documented staging rollback drill still requires live Cloudflare/GitHub environment access.

Closes ENG-1178

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a verified Cloudflare Pages lifecycle for the Storybook catalog and PR previews. Builds exact-commit artifacts, validates provenance and PR state, and deploys via a trusted workflow; forks still require maintainer promotion from `main`, now pinned to the authorized config with clearer artifact failure reporting. Resolves ENG-1178 with immutable preview URLs and documented rollback.

- **New Features**
  - Deploy workflow for preview, staging (manual), and production (CI-only) with a FIFO `main` queue and strict checks (artifact provenance, PR open on `main`).
  - Preview workflow builds and archives a verified artifact, then calls Deploy; supports same-run promotion. Same-repo previews use artifact-aware tooling at the exact commit; forks run without secrets and must be promoted from `main`, with promotion pinned to the authorized config and improved failure reporting.
  - Storybook shows preview identity (commit + PR link) and ships stricter `preview-metadata.json` with unit and e2e tests; config adds a local validation command.
  - Hardened `@shipfox/cloudflare-pages`: added validate and archive-all, config-driven artifact/validation, PR lifecycle checks, safer archiving, broader tests, lifecycle docs, and a minor Changeset. Preview artifacts include the deploy config so trusted promotion works before it reaches `main`.

- **Migration**
  - Maintainers: promote fork previews from `main` via the Deploy workflow (environment preview; provide the PR number and verified artifact). Same-run promotion is allowed and auto-validated; artifacts carry the deploy config. Follow the rollback steps in the lifecycle guide.

<sup>Written for commit b097e51f50cc8a6091c5de0d32f1b6322240f08e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

