### PR TITLE
Improve Docker provisioner lifecycle observability and retention

### DIFF
--- a/.changeset/quiet-vitest-flags.md
+++ b/.changeset/quiet-vitest-flags.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/vitest": patch
+---
+
+Forward command-line arguments through the Vitest runner wrapper.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -427,6 +427,10 @@ jobs:
           ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
         run: turbo test $SHIPFOX_TURBO_AFFECTED --concurrency="$SHIPFOX_TURBO_CONCURRENCY"
 
+      - name: Run Docker logging-driver integration test
+        timeout-minutes: 2
+        run: pnpm exec turbo test:integration --filter=@shipfox/provisioner-docker-provider
+
   e2e:
     name: E2E tests
     needs: [release-mode]

--- a/apps/docs/content/docs/reference/runner-provisioner.mdx
+++ b/apps/docs/content/docs/reference/runner-provisioner.mdx
@@ -23,13 +23,73 @@ This page is the canonical reference for configuring the Docker runner provision
 | `SHIPFOX_PROVISIONER_DOCKER_HOST` | local socket | Docker daemon host. Set a Docker host URL when the daemon is remote. |
 | `SHIPFOX_PROVISIONER_DOCKER_NETWORK` | unset | Docker network attached to runner containers, for reaching the API through a Compose or bridge network. |
 | `SHIPFOX_PROVISIONER_DOCKER_EXTRA_HOSTS` | unset | Comma-separated host mappings added to runner containers, such as `host.docker.internal:host-gateway`. |
+| `SHIPFOX_PROVISIONER_DOCKER_LOG_DRIVER` | Docker daemon default | Logging driver for runner containers. Set this to override the daemon default for this provisioner. |
+| `SHIPFOX_PROVISIONER_DOCKER_LOG_OPTIONS` | unset | JSON object of string-valued logging-driver options. Requires `SHIPFOX_PROVISIONER_DOCKER_LOG_DRIVER`; option values are never written to provisioner logs. |
 | `SHIPFOX_PROVISIONER_POLL_WAIT_SECONDS` | `30` | How long each demand poll waits for work before returning. `0` makes the poll non-blocking. |
 | `SHIPFOX_PROVISIONER_POLL_INTERVAL_MS` | `1000` | Wait between demand polls. Backs off toward the max after errors. |
 | `SHIPFOX_PROVISIONER_POLL_MAX_INTERVAL_MS` | `5000` | Largest poll backoff interval after repeated errors. |
 | `SHIPFOX_PROVISIONER_MAX_RESERVATIONS` | `250` | Most reservations requested in one poll. Also bounded by free template capacity and the API's cap of 1000. |
 | `SHIPFOX_PROVISIONER_RUNNER_INSTANCE_BATCH_SIZE` | `250` | Runner instances created per request (1–1000). Must not exceed the API's own batch limit. |
 | `SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS` | `120000` | How long a created container may stay unstarted before the provisioner reaps it as stale. |
+| `SHIPFOX_PROVISIONER_DOCKER_FAILED_CONTAINER_RETENTION_MS` | `3600000` | How long failed runner containers remain stopped for forensic inspection. Set to `0` to disable retention. |
+| `SHIPFOX_PROVISIONER_DOCKER_MAX_RETAINED_FAILED_CONTAINERS` | `20` | Maximum number of failed runner containers retained per provisioner. Set to `0` to disable retention. |
 | `SHIPFOX_RUNNER_MAX_LIFETIME_SECONDS` | `3600` | Hard maximum lifetime injected into each runner. Set it above the longest permitted job so a runner terminates if its provisioner is unavailable. |
+
+## Docker logging and failed-container forensics
+
+Provisioner logs and runner-container output are separate streams. The
+provisioner never copies runner stdout or stderr into its own logs. Use
+`LOG_LEVEL`, `LOG_PRETTY`, `LOG_STDOUT`, `LOG_STDOUT_LEVEL`, `LOG_FILE`, and
+`LOG_FILE_LEVEL` for provisioner-process logs. `LOG_FILE` writes a plain file
+without built-in rotation, so configure external rotation such as `logrotate`.
+The logger keeps the file open: use `copytruncate` in the rotation rule or
+restart the provisioner after rename/create rotation, otherwise it continues
+writing to the old inode. For production, prefer stdout with journald or
+runtime-managed rotation.
+
+Runner containers inherit the Docker daemon logging driver unless
+`SHIPFOX_PROVISIONER_DOCKER_LOG_DRIVER` is set. A local driver with on-host
+rotation can be configured as follows:
+
+```sh
+export SHIPFOX_PROVISIONER_DOCKER_LOG_DRIVER=local
+export SHIPFOX_PROVISIONER_DOCKER_LOG_OPTIONS='{"max-size":"10m","max-file":"5"}'
+```
+
+For journald, configure the driver and a tag, then retrieve output with
+`journalctl`:
+
+```sh
+export SHIPFOX_PROVISIONER_DOCKER_LOG_DRIVER=journald
+export SHIPFOX_PROVISIONER_DOCKER_LOG_OPTIONS='{"tag":"shipfox-runner/{{.Name}}"}'
+journalctl CONTAINER_NAME=<runner-name> --since today
+```
+
+Enable persistent journald storage (`Storage=persistent` in
+`/etc/systemd/journald.conf`) and configure its disk and rotation limits.
+Remote drivers use the retention and access policy of their durable backend.
+For `local` and `json-file`, `docker logs --timestamps --tail 200
+<runner-name>` works only until cleanup removes the container. Use journald or
+the remote backend after cleanup.
+
+Failed containers remain for forensic inspection only when both retention
+settings are greater than zero. The default TTL is one hour and the default
+count bound is 20. Docker `FinishedAt` drives TTL cleanup. Missing `FinishedAt`
+uses the first observed failure time instead of creation time, so a long-running
+container is not removed immediately. Terminal inspection failures defer TTL
+cleanup but remain subject to the count bound, and unknown failure times rank as
+newly observed for count eviction. Successful exits, dead containers,
+stale-created containers, and backend termination keep their immediate cleanup
+behavior.
+
+Forensic output is driver-specific: use `docker inspect <runner-name>` and
+`docker logs --timestamps --tail 200 <runner-name>` for `local` or `json-file`,
+`journalctl CONTAINER_NAME=<runner-name>` for `journald`, and the configured
+durable backend for remote drivers. For a remote Docker daemon, set
+`DOCKER_HOST` to the configured `SHIPFOX_PROVISIONER_DOCKER_HOST` value before
+running Docker commands; omit it for the local default. Run `journalctl` on the
+Docker daemon host, not on the operator workstation. The `none` driver has no
+container output.
 
 ## Template file schema
 

--- a/apps/provisioner-docker/README.md
+++ b/apps/provisioner-docker/README.md
@@ -25,10 +25,11 @@ never reserves more than it can start.
 
 Containers are named by `provisioned_runner_id` and labeled with `shipfox.*` metadata
 so a restarted provisioner can rebuild local capacity from Docker state. Running
-containers are re-reported every tick to keep the backend active-runner view fresh.
-Exited containers are reported as `stopped` or `failed`, then removed after the report
-is accepted. Containers stuck in Docker's `created` state past the registration deadline
-are reaped as stale pre-run resources; running containers are never locally killed.
+containers are re-reported every observation cycle to keep the backend active-runner view fresh.
+Exited containers are reported as `stopped` or `failed`. Successful exits are removed
+immediately; failed exits are retained for the configured forensic TTL/count bound and
+then cleaned up. Containers stuck in Docker's `created` state past the registration
+deadline are reaped as stale pre-run resources; running containers are never locally killed.
 
 If Docker cannot be observed, the provisioner advertises no free capacity and backs off
 until observation succeeds.
@@ -44,6 +45,10 @@ until observation succeeds.
 | `SHIPFOX_PROVISIONER_DOCKER_HOST` | no | local Docker socket | Docker daemon host used by dockerode. |
 | `SHIPFOX_PROVISIONER_DOCKER_NETWORK` | no | — | Docker network attached to runner containers, for example a Compose network that can reach the API. |
 | `SHIPFOX_PROVISIONER_DOCKER_EXTRA_HOSTS` | no | — | Comma-separated host mappings added to runner containers, such as `host.docker.internal:host-gateway`. |
+| `SHIPFOX_PROVISIONER_DOCKER_LOG_DRIVER` | no | Docker daemon default | Logging driver for runner containers. |
+| `SHIPFOX_PROVISIONER_DOCKER_LOG_OPTIONS` | no | — | JSON object of string-valued driver options; requires the driver setting. |
+| `SHIPFOX_PROVISIONER_DOCKER_FAILED_CONTAINER_RETENTION_MS` | no | `3600000` | Failed-container retention TTL in milliseconds; `0` disables retention. |
+| `SHIPFOX_PROVISIONER_DOCKER_MAX_RETAINED_FAILED_CONTAINERS` | no | `20` | Maximum retained failed containers; `0` disables retention. |
 | `SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS` | no | `120000` | How long a `created` runner container may linger before being reaped as stale. |
 | `SHIPFOX_PROVISIONER_POLL_WAIT_SECONDS` | no | `30` | Long-poll wait per demand request. |
 | `SHIPFOX_PROVISIONER_POLL_INTERVAL_MS` | no | `1000` | Base delay between polls; backs off on error. |

--- a/apps/provisioner-docker/src/index.ts
+++ b/apps/provisioner-docker/src/index.ts
@@ -4,6 +4,13 @@ import {startDockerProvisioner} from '@shipfox/provisioner-docker-provider';
 try {
   await startDockerProvisioner();
 } catch (error) {
-  logger().error({error}, 'Fatal provisioner error');
+  logger().error(
+    {
+      event: 'provisioner.fatal',
+      reason: error instanceof Error ? error.message.slice(0, 500) : String(error).slice(0, 500),
+      error,
+    },
+    'Fatal provisioner error',
+  );
   process.exit(1);
 }

--- a/libs/provisioner/core/src/api-client.ts
+++ b/libs/provisioner/core/src/api-client.ts
@@ -21,8 +21,11 @@ const LONG_POLL_TIMEOUT_BUFFER_MS = 15_000;
 
 /** Raised when the provisioner token is missing, revoked, expired, or rejected. */
 export class ProvisionerAuthenticationError extends Error {
-  constructor(public readonly status: number) {
-    super(`Provisioner token was rejected by the API (status ${status}).`);
+  constructor(
+    public readonly status: number,
+    public readonly action = 'API request',
+  ) {
+    super(`Provisioner token was rejected during ${action} (status ${status}).`);
     this.name = 'ProvisionerAuthenticationError';
   }
 }
@@ -69,14 +72,14 @@ export function createProvisionerClient(params: {
 
   return {
     getIdentity() {
-      return withAuthMapping(async () => {
+      return withAuthMapping('get provisioner identity', async () => {
         const response = await api.get('provisioners/me');
         return provisionerIdentityResponseSchema.parse(await response.json());
       });
     },
 
     pollDemand(body, options = {}) {
-      return withAuthMapping(async () => {
+      return withAuthMapping('poll runner demand', async () => {
         const response = await api.post('provisioners/demand/poll', {
           json: body,
           timeout: (body.wait_seconds ?? 0) * 1000 + LONG_POLL_TIMEOUT_BUFFER_MS,
@@ -87,7 +90,7 @@ export function createProvisionerClient(params: {
     },
 
     createRunnerInstances(body, options = {}) {
-      return withAuthMapping(async () => {
+      return withAuthMapping('create runner instances', async () => {
         const response = await api.post('provisioners/runner-instances/batch', {
           json: body,
           ...(options.signal ? {signal: options.signal} : {}),
@@ -97,7 +100,7 @@ export function createProvisionerClient(params: {
     },
 
     attachRunnerInstanceProviderId(runnerInstanceId, providerRunnerId, options = {}) {
-      return withAuthMapping(async () => {
+      return withAuthMapping('attach runner instance provider identity', async () => {
         const response = await api.post(
           `provisioners/runner-instances/${runnerInstanceId}/provider-runner`,
           {
@@ -110,7 +113,7 @@ export function createProvisionerClient(params: {
     },
 
     assignRunnerInstances(reservationId, runnerInstanceIds, options = {}) {
-      return withAuthMapping(async () => {
+      return withAuthMapping('assign runner instances', async () => {
         const response = await api.post('provisioners/runner-instances/assignments', {
           json: {reservation_id: reservationId, runner_instance_ids: runnerInstanceIds},
           ...(options.signal ? {signal: options.signal} : {}),
@@ -120,7 +123,7 @@ export function createProvisionerClient(params: {
     },
 
     reportRunnerInstances(body, options = {}) {
-      return withAuthMapping(async () => {
+      return withAuthMapping('report runner instances', async () => {
         const response = await api.post('provisioners/runner-instances/report', {
           json: body,
           ...(options.signal ? {signal: options.signal} : {}),
@@ -130,7 +133,7 @@ export function createProvisionerClient(params: {
     },
 
     reconcileRunnerInstances(body, options = {}) {
-      return withAuthMapping(async () => {
+      return withAuthMapping('reconcile runner instances', async () => {
         const response = await api.post('provisioners/runner-instances/reconcile', {
           json: body,
           ...(options.signal ? {signal: options.signal} : {}),
@@ -144,12 +147,12 @@ export function createProvisionerClient(params: {
 // A rejected provisioner token surfaces the same way on every call (poll, mint, or the
 // startup identity check), so the loop can recognize "token revoked" rather than treat
 // it as a generic transient error.
-async function withAuthMapping<T>(call: () => Promise<T>): Promise<T> {
+async function withAuthMapping<T>(action: string, call: () => Promise<T>): Promise<T> {
   try {
     return await call();
   } catch (error) {
     if (error instanceof HTTPError && isAuthStatus(error.response.status)) {
-      throw new ProvisionerAuthenticationError(error.response.status);
+      throw new ProvisionerAuthenticationError(error.response.status, action);
     }
     throw error;
   }

--- a/libs/provisioner/core/src/health.test.ts
+++ b/libs/provisioner/core/src/health.test.ts
@@ -1,0 +1,196 @@
+import {createHealthState, type HealthEvent, type HealthFacet, reduceHealth} from '#health.js';
+
+const time = (seconds: number) => new Date(seconds * 1000);
+
+describe('reduceHealth', () => {
+  it.each([
+    {
+      name: 'observation repeats',
+      events: repeatedFailureEvents('provider_observation', 'daemon unavailable', 'capacity'),
+      expectedLogEvents: ['provisioner.degraded', 'provisioner.degraded_reminder'],
+      expectedDerived: {capacityDegraded: true, shouldBackOff: true, ready: false},
+    },
+    {
+      name: 'termination cleanup repeats without affecting capacity',
+      events: repeatedFailureEvents('provider_termination', 'container cleanup failed', 'cleanup'),
+      expectedLogEvents: ['provisioner.degraded', 'provisioner.degraded_reminder'],
+      expectedDerived: {capacityDegraded: false, shouldBackOff: false, ready: false},
+    },
+  ])('keeps one stable episode for $name', ({events, expectedLogEvents, expectedDerived}) => {
+    const result = reduceEvents(events);
+
+    expect(result.logs.map((log) => log.event)).toEqual(expectedLogEvents);
+    expect(result.derived).toEqual(expectedDerived);
+    expect(result.state.incident).toMatchObject({attempts: 6, suppressed: 5});
+  });
+
+  it('keeps concurrent facets stable regardless of evaluation order', () => {
+    const forward = reduceEvents([
+      failure('provider_observation', 'daemon unavailable', 'capacity', 1),
+      failure('provider_termination', 'cleanup unavailable', 'cleanup', 2),
+    ]);
+    const reverse = reduceEvents([
+      failure('provider_termination', 'cleanup unavailable', 'cleanup', 1),
+      failure('provider_observation', 'daemon unavailable', 'capacity', 2),
+    ]);
+
+    expect(Object.fromEntries(forward.state.active)).toEqual(
+      Object.fromEntries(reverse.state.active),
+    );
+    expect(forward.state.incident?.fingerprint).toBe(reverse.state.incident?.fingerprint);
+    expect(forward.derived).toEqual({capacityDegraded: true, shouldBackOff: true, ready: false});
+    expect(reverse.derived).toEqual(forward.derived);
+  });
+  it('treats same-cause facets as distinct health transitions', () => {
+    const result = reduceEvents([
+      failure('provider_observation', 'daemon unavailable', 'capacity', 1),
+      failure('provider_termination', 'daemon unavailable', 'cleanup', 2),
+    ]);
+    expect(result.logs.map((log) => log.event)).toEqual([
+      'provisioner.degraded',
+      'provisioner.degraded',
+    ]);
+    expect(result.logs.at(-1)).toMatchObject({
+      facet: 'provider_termination',
+      changed: true,
+      impact: 'cleanup',
+    });
+  });
+  it('reports a partial recovery as a changed active snapshot', () => {
+    const result = reduceEvents([
+      failure('provider_observation', 'daemon unavailable', 'capacity', 1),
+      failure('provider_termination', 'cleanup unavailable', 'cleanup', 2),
+      recovered('provider_observation', 3),
+    ]);
+    expect(result.logs.map((log) => log.event)).toEqual([
+      'provisioner.degraded',
+      'provisioner.degraded',
+      'provisioner.partially_recovered',
+    ]);
+    expect(result.logs.at(-1)).toMatchObject({
+      level: 'info',
+      recoveredFacet: 'provider_observation',
+      remainingFacetCount: 1,
+      impact: 'cleanup',
+    });
+  });
+
+  it('recovers once after the final facet clears and preserves incident counters', () => {
+    const result = reduceEvents([
+      failure('provider_observation', 'daemon unavailable', 'capacity', 1),
+      failure('provider_termination', 'cleanup unavailable', 'cleanup', 2),
+      recovered('provider_observation', 3),
+      recovered('provider_termination', 4),
+    ]);
+
+    expect(result.logs.map((log) => log.event)).toEqual([
+      'provisioner.degraded',
+      'provisioner.degraded',
+      'provisioner.partially_recovered',
+      'provisioner.recovered',
+    ]);
+    expect(result.logs[2]).toMatchObject({
+      level: 'info',
+      recoveredFacet: 'provider_observation',
+      remainingFacetCount: 1,
+      impact: 'cleanup',
+    });
+    expect(result.logs.at(-1)).toMatchObject({attempts: 2, suppressed: 0});
+    expect(result.state.active).toHaveLength(0);
+    expect(result.state.incident).toBeUndefined();
+    expect(result.derived).toEqual({capacityDegraded: false, shouldBackOff: false, ready: false});
+  });
+
+  it('does not let empty termination success recover observation failure', () => {
+    const result = reduceEvents([
+      failure('provider_observation', 'daemon unavailable', 'capacity', 1),
+      recovered('provider_termination', 2),
+    ]);
+
+    expect(result.state.active.has('provider_observation')).toBe(true);
+    expect(result.logs.map((log) => log.event)).toEqual(['provisioner.degraded']);
+    expect(result.derived.shouldBackOff).toBe(true);
+  });
+
+  it('changes the active fingerprint when cleanup moves to another target', () => {
+    const result = reduceEvents([
+      failure('provider_termination', 'container-A', 'cleanup', 1),
+      failure('provider_termination', 'container-B', 'cleanup', 2),
+    ]);
+
+    expect(result.state.active.get('provider_termination')?.cause).toBe('container-B');
+    expect(result.logs.map((log) => log.event)).toEqual([
+      'provisioner.degraded',
+      'provisioner.degraded',
+    ]);
+    expect(result.logs.at(-1)).toMatchObject({changed: true, cause: 'container-B'});
+    expect(result.state.incident?.attempts).toBe(2);
+  });
+
+  it('confirms readiness separately from recovery', () => {
+    const result = reduceHealth(createHealthState(), {type: 'ready_confirmed', at: time(1)});
+
+    expect(result.logs).toEqual([{level: 'info', event: 'provisioner.ready'}]);
+    expect(result.derived.ready).toBe(true);
+  });
+  it('waits for healthy capacity before confirming the one-time readiness milestone', () => {
+    const failed = reduceHealth(createHealthState(), {
+      type: 'facet_failed',
+      facet: 'runner_capacity',
+      cause: 'launch failed',
+      impact: 'capacity',
+      at: time(1),
+    });
+    const blocked = reduceHealth(failed.state, {type: 'ready_confirmed', at: time(2)});
+    const recovered = reduceHealth(blocked.state, {
+      type: 'facet_recovered',
+      facet: 'runner_capacity',
+      at: time(3),
+    });
+    const confirmed = reduceHealth(recovered.state, {type: 'ready_confirmed', at: time(4)});
+    const repeated = reduceHealth(confirmed.state, {type: 'ready_confirmed', at: time(5)});
+    expect(blocked.logs).toEqual([]);
+    expect(confirmed.logs).toEqual([{level: 'info', event: 'provisioner.ready'}]);
+    expect(repeated.logs).toEqual([]);
+    expect(repeated.state.hasEverBeenReady).toBe(true);
+    expect(repeated.derived.ready).toBe(true);
+  });
+});
+
+function reduceEvents(events: readonly HealthEvent[]) {
+  let result = {
+    state: createHealthState(),
+    derived: {capacityDegraded: false, shouldBackOff: false, ready: false},
+    logs: [] as readonly ReturnType<typeof reduceHealth>['logs'][number][],
+  };
+  for (const event of events) {
+    const next = reduceHealth(result.state, event);
+    result = {
+      state: next.state,
+      derived: next.derived,
+      logs: [...result.logs, ...next.logs],
+    };
+  }
+  return result;
+}
+
+function repeatedFailureEvents(
+  facet: HealthFacet,
+  cause: string,
+  impact: 'capacity' | 'cleanup',
+): HealthEvent[] {
+  return Array.from({length: 6}, (_, index) => failure(facet, cause, impact, index + 1));
+}
+
+function failure(
+  facet: HealthFacet,
+  cause: string,
+  impact: 'capacity' | 'cleanup',
+  seconds: number,
+): HealthEvent {
+  return {type: 'facet_failed', facet, cause, impact, at: time(seconds)};
+}
+
+function recovered(facet: HealthFacet, seconds: number): HealthEvent {
+  return {type: 'facet_recovered', facet, at: time(seconds)};
+}

--- a/libs/provisioner/core/src/health.ts
+++ b/libs/provisioner/core/src/health.ts
@@ -1,0 +1,225 @@
+/** A provider or control-plane failure whose recovery can be proved independently. */
+export type HealthFacet =
+  | 'startup_reconciliation'
+  | 'provider_observation'
+  | 'provider_termination'
+  | 'poll_demand'
+  | 'authentication'
+  | 'runner_capacity';
+export type HealthImpact = 'capacity' | 'cleanup' | 'control_plane';
+
+export interface HealthState {
+  active: ReadonlyMap<HealthFacet, HealthFailure>;
+  incident?: HealthIncident | undefined;
+  hasEverBeenReady: boolean;
+}
+
+export interface HealthFailure {
+  readonly cause: string;
+  readonly impact: HealthImpact;
+  readonly failureCount?: number | undefined;
+}
+
+export interface HealthIncident {
+  /** Stable, sorted representation of every active facet, cause, and impact. */
+  readonly fingerprint: string;
+  readonly startedAt: Date;
+  readonly attempts: number;
+  readonly suppressed: number;
+}
+
+export type HealthEvent =
+  | {
+      readonly type: 'facet_failed';
+      readonly facet: HealthFacet;
+      readonly cause: string;
+      readonly impact: HealthImpact;
+      readonly failureCount?: number | undefined;
+      readonly at: Date;
+    }
+  | {
+      readonly type: 'facet_recovered';
+      readonly facet: HealthFacet;
+      readonly at: Date;
+    }
+  | {readonly type: 'ready_confirmed'; readonly at: Date};
+
+export interface HealthLog {
+  readonly level: 'error' | 'warn' | 'info';
+  readonly event:
+    | 'provisioner.degraded'
+    | 'provisioner.degraded_reminder'
+    | 'provisioner.partially_recovered'
+    | 'provisioner.recovered'
+    | 'provisioner.ready';
+  readonly facet?: HealthFacet | undefined;
+  readonly cause?: string | undefined;
+  readonly changed?: boolean | undefined;
+  readonly recoveredFacet?: HealthFacet | undefined;
+  readonly remainingFacetCount?: number | undefined;
+  readonly impact?: HealthImpact | undefined;
+  readonly attempts?: number | undefined;
+  readonly suppressed?: number | undefined;
+  readonly outageDurationMs?: number | undefined;
+}
+
+export interface HealthDerivedState {
+  readonly capacityDegraded: boolean;
+  readonly shouldBackOff: boolean;
+  readonly ready: boolean;
+}
+
+export interface HealthReduction {
+  readonly state: HealthState;
+  readonly derived: HealthDerivedState;
+  readonly logs: readonly HealthLog[];
+}
+
+const REMINDER_EVERY_SUPPRESSED = 5;
+
+export function createHealthState(): HealthState {
+  return {active: new Map(), hasEverBeenReady: false};
+}
+
+/**
+ * Apply one lifecycle fact to health. The reducer has no logging or timer side effects;
+ * callers decide how to emit the returned log records. Derived control-loop decisions
+ * are calculated from the active facets on every reduction instead of being cached.
+ */
+export function reduceHealth(state: HealthState, event: HealthEvent): HealthReduction {
+  const active = new Map(state.active);
+  let incident = state.incident;
+  let hasEverBeenReady = state.hasEverBeenReady;
+  const logs: HealthLog[] = [];
+
+  if (event.type === 'facet_failed') {
+    active.set(event.facet, {
+      cause: event.cause,
+      impact: event.impact,
+      ...(event.failureCount !== undefined ? {failureCount: event.failureCount} : {}),
+    });
+    const fingerprint = activeFingerprint(active);
+    if (!incident) {
+      incident = {
+        fingerprint,
+        startedAt: event.at,
+        attempts: 1,
+        suppressed: 0,
+      };
+      logs.push({
+        level: 'error',
+        event: 'provisioner.degraded',
+        facet: event.facet,
+        cause: event.cause,
+        impact: event.impact,
+        attempts: incident.attempts,
+        suppressed: incident.suppressed,
+      });
+    } else {
+      const changed = incident.fingerprint !== fingerprint;
+      incident = {
+        ...incident,
+        fingerprint,
+        attempts: incident.attempts + 1,
+        suppressed: incident.suppressed + (changed ? 0 : 1),
+      };
+      if (changed) {
+        logs.push({
+          level: 'error',
+          event: 'provisioner.degraded',
+          facet: event.facet,
+          cause: event.cause,
+          changed: true,
+          impact: event.impact,
+          attempts: incident.attempts,
+          suppressed: incident.suppressed,
+        });
+      } else if (incident.suppressed > 0 && incident.suppressed % REMINDER_EVERY_SUPPRESSED === 0) {
+        logs.push({
+          level: 'warn',
+          event: 'provisioner.degraded_reminder',
+          facet: event.facet,
+          cause: event.cause,
+          impact: event.impact,
+          attempts: incident.attempts,
+          suppressed: incident.suppressed,
+        });
+      }
+    }
+  } else if (event.type === 'facet_recovered') {
+    if (active.has(event.facet)) {
+      active.delete(event.facet);
+      if (active.size === 0 && incident) {
+        logs.push({
+          level: 'info',
+          event: 'provisioner.recovered',
+          attempts: incident.attempts,
+          suppressed: incident.suppressed,
+          outageDurationMs: Math.max(0, event.at.getTime() - incident.startedAt.getTime()),
+        });
+        incident = undefined;
+      } else if (incident) {
+        const fingerprint = activeFingerprint(active);
+        const changed = incident.fingerprint !== fingerprint;
+        incident = {...incident, fingerprint};
+        if (changed) {
+          logs.push({
+            level: 'info',
+            event: 'provisioner.partially_recovered',
+            recoveredFacet: event.facet,
+            remainingFacetCount: active.size,
+            impact: currentImpact(active),
+            attempts: incident.attempts,
+            suppressed: incident.suppressed,
+          });
+        }
+      }
+    }
+  } else if (event.type === 'ready_confirmed' && !hasEverBeenReady && readinessAvailable(active)) {
+    hasEverBeenReady = true;
+    logs.push({level: 'info', event: 'provisioner.ready'});
+  }
+
+  const nextState: HealthState = {
+    active,
+    ...(incident ? {incident} : {}),
+    hasEverBeenReady,
+  };
+  return {state: nextState, derived: deriveHealth(nextState), logs};
+}
+
+export function deriveHealth(state: HealthState): HealthDerivedState {
+  return derivedFor(state.active, state.hasEverBeenReady);
+}
+
+function activeFingerprint(active: ReadonlyMap<HealthFacet, HealthFailure>): string {
+  return JSON.stringify(
+    [...active.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([facet, failure]) => [facet, failure.cause, failure.impact]),
+  );
+}
+
+function derivedFor(
+  active: ReadonlyMap<HealthFacet, HealthFailure>,
+  hasEverBeenReady: boolean,
+): HealthDerivedState {
+  const failures = [...active.values()];
+  return {
+    capacityDegraded: failures.some((failure) => failure.impact === 'capacity'),
+    shouldBackOff: failures.some((failure) => failure.impact !== 'cleanup'),
+    ready: hasEverBeenReady && failures.every((failure) => failure.impact === 'cleanup'),
+  };
+}
+
+function readinessAvailable(active: ReadonlyMap<HealthFacet, HealthFailure>): boolean {
+  return [...active.values()].every((failure) => failure.impact === 'cleanup');
+}
+
+function currentImpact(active: ReadonlyMap<HealthFacet, HealthFailure>): HealthImpact | undefined {
+  if ([...active.values()].some((failure) => failure.impact === 'capacity')) return 'capacity';
+  if ([...active.values()].some((failure) => failure.impact === 'control_plane')) {
+    return 'control_plane';
+  }
+  return [...active.values()][0]?.impact;
+}

--- a/libs/provisioner/core/src/index.ts
+++ b/libs/provisioner/core/src/index.ts
@@ -1,9 +1,28 @@
 export type {ProvisionerClient} from '#api-client.js';
 export {ProvisionerAuthenticationError} from '#api-client.js';
+export {
+  createHealthState,
+  deriveHealth,
+  type HealthDerivedState,
+  type HealthEvent,
+  type HealthFacet,
+  type HealthFailure,
+  type HealthImpact,
+  type HealthIncident,
+  type HealthLog,
+  type HealthReduction,
+  type HealthState,
+  reduceHealth,
+} from '#health.js';
 export {loggingLaunch} from '#launcher.js';
-export {type StartProvisionerOptions, startProvisioner} from '#provisioner.js';
+export {
+  type ProvisionerHealthState,
+  type StartProvisionerOptions,
+  startProvisioner,
+} from '#provisioner.js';
 export type {ProviderRunnerTracker} from '#tracker.js';
 export type {
+  LaunchOutcome,
   LaunchRunner,
   ProviderRunnerLaunch,
   ProvisionerAdapter,

--- a/libs/provisioner/core/src/launcher.ts
+++ b/libs/provisioner/core/src/launcher.ts
@@ -8,6 +8,7 @@ import type {LaunchRunner} from '#types.js';
 export const loggingLaunch: LaunchRunner = (launch) => {
   logger().info(
     {
+      event: 'runner.launch_planned',
       providerRunnerId: launch.providerRunnerId,
       reservationId: launch.reservationId,
       templateKey: launch.template.key,
@@ -15,5 +16,5 @@ export const loggingLaunch: LaunchRunner = (launch) => {
     },
     'Planned provisioned runner (logging launcher)',
   );
-  return Promise.resolve();
+  return Promise.resolve({containerStarted: true, identityAttached: true, reported: true});
 };

--- a/libs/provisioner/core/src/provisioner.test.ts
+++ b/libs/provisioner/core/src/provisioner.test.ts
@@ -4,9 +4,15 @@ import type {
   PollDemandResponseDto,
 } from '@shipfox/api-runners-dto';
 import type {ProvisionerClient} from '#api-client.js';
+import {createHealthState} from '#health.js';
 import {runProvisionerIteration, startProvisioner} from '#provisioner.js';
 import {createInMemoryTracker} from '#tracker.js';
 import type {ProvisionerAdapter, ProvisionerTemplate} from '#types.js';
+
+const observability = vi.hoisted(() => ({
+  logger: {debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn()},
+}));
+vi.mock('@shipfox/node-opentelemetry', () => ({logger: () => observability.logger}));
 
 const EXPIRES_AT = '2026-01-01T00:00:00.000Z';
 
@@ -19,6 +25,10 @@ const template: ProvisionerTemplate<null> = {
 };
 
 describe('runProvisionerIteration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('runs onTick before polling demand', async () => {
     const events: string[] = [];
     const {client} = harness({
@@ -40,13 +50,35 @@ describe('runProvisionerIteration', () => {
       templates: [template],
       tracker: createInMemoryTracker(),
       currentInterval: 1000,
-      degraded: false,
     });
 
     expect(events).toEqual(['observe', 'poll']);
   });
 
-  it('advertises no free capacity and backs off when onTick fails', async () => {
+  it('includes the incomplete lifecycle stage in the launch batch log', async () => {
+    const {client} = harness({response: {stats: [], reservations: [reservation(1)]}});
+    const adapter: ProvisionerAdapter<null> = {
+      loadTemplates: () => Promise.resolve([template]),
+      launch: () =>
+        Promise.resolve({containerStarted: true, identityAttached: false, reported: false}),
+      onTick: () => Promise.resolve(),
+    };
+    await runProvisionerIteration({
+      adapter,
+      client,
+      templates: [template],
+      tracker: createInMemoryTracker(),
+      currentInterval: 1000,
+    });
+    const launchBatchLog = observability.logger.info.mock.calls.find(
+      ([fields]) => fields?.event === 'runner.launch_batch_completed',
+    );
+    expect(launchBatchLog?.[0]).toMatchObject({
+      lifecycleIncomplete: 1,
+      launchLifecycleIncompleteReason: 'Runner launch lifecycle incomplete: identity, report.',
+    });
+  });
+  it('keeps reservations closed and backs off when provider observation fails', async () => {
     const {client, pollBodies} = harness({response: {stats: [], reservations: []}});
     const adapter: ProvisionerAdapter<null> = {
       loadTemplates: () => Promise.resolve([template]),
@@ -60,14 +92,13 @@ describe('runProvisionerIteration', () => {
       templates: [template],
       tracker: createInMemoryTracker(),
       currentInterval: 1000,
-      degraded: false,
     });
 
     expect(pollBodies[0]?.max_reservations).toBe(0);
     expect(result).toEqual({nextInterval: 1500, degraded: true});
   });
 
-  it('keeps advertising no capacity while startup is degraded and observe still fails', async () => {
+  it('keeps reservations closed while a provider observation still fails', async () => {
     const {client, pollBodies} = harness({response: {stats: [], reservations: []}});
     const adapter: ProvisionerAdapter<null> = {
       loadTemplates: () => Promise.resolve([template]),
@@ -81,7 +112,6 @@ describe('runProvisionerIteration', () => {
       templates: [template],
       tracker: createInMemoryTracker(),
       currentInterval: 1000,
-      degraded: true,
     });
 
     expect(pollBodies[0]?.max_reservations).toBe(0);
@@ -94,6 +124,10 @@ describe('runProvisionerIteration', () => {
       loadTemplates: () => Promise.resolve([template]),
       launch: () => Promise.resolve(),
     };
+    const health = createHealthState();
+    health.active = new Map([
+      ['provider_observation', {cause: 'startup reconciliation failed', impact: 'capacity'}],
+    ]);
 
     const result = await runProvisionerIteration({
       adapter,
@@ -101,7 +135,7 @@ describe('runProvisionerIteration', () => {
       templates: [template],
       tracker: createInMemoryTracker(),
       currentInterval: 1000,
-      degraded: true,
+      health,
     });
 
     expect(pollBodies[0]?.max_reservations).toBe(0);
@@ -122,12 +156,42 @@ describe('runProvisionerIteration', () => {
       templates: [template],
       tracker: createInMemoryTracker(),
       currentInterval: 1000,
-      degraded: false,
     });
 
-    expect(result).toEqual({nextInterval: 1500, degraded: false});
+    expect(result).toEqual({nextInterval: 1500, degraded: true});
   });
 
+  it('uses the next degraded poll as a launch probe and recovers after it succeeds', async () => {
+    const {client, pollBodies} = harness({response: {stats: [], reservations: [reservation(1)]}});
+    const health = createHealthState();
+    let launchAttempts = 0;
+    const adapter: ProvisionerAdapter<null> = {
+      loadTemplates: () => Promise.resolve([template]),
+      launch: () => {
+        launchAttempts += 1;
+        return launchAttempts === 1 ? Promise.reject(new Error('start failed')) : Promise.resolve();
+      },
+      onTick: () => Promise.resolve(),
+    };
+    const first = await runProvisionerIteration({
+      adapter,
+      client,
+      templates: [template],
+      tracker: createInMemoryTracker(),
+      currentInterval: 1000,
+      health,
+    });
+    const second = await runProvisionerIteration({
+      adapter,
+      client,
+      templates: [template],
+      tracker: createInMemoryTracker(),
+      currentInterval: first.nextInterval,
+      health,
+    });
+    expect(pollBodies.map((body) => body.max_reservations)).toEqual([5, 1]);
+    expect(second.degraded).toBe(false);
+  });
   it('resets to the base interval after a healthy observe and successful launch', async () => {
     const {client} = harness({response: {stats: [], reservations: [reservation(1)]}});
     const adapter: ProvisionerAdapter<null> = {
@@ -142,7 +206,6 @@ describe('runProvisionerIteration', () => {
       templates: [template],
       tracker: createInMemoryTracker(),
       currentInterval: 3000,
-      degraded: true,
     });
 
     expect(result).toEqual({nextInterval: 1000, degraded: false});

--- a/libs/provisioner/core/src/provisioner.ts
+++ b/libs/provisioner/core/src/provisioner.ts
@@ -87,10 +87,10 @@ export async function startProvisioner<Spec>(
   const providerConfiguration = (await options.adapter.onConfigure?.({templates})) ?? {};
   logger().info(
     {
+      ...providerConfiguration,
       event: 'provisioner.configured',
       templateCount: templates.length,
       templateKeySample: templates.slice(0, CONFIG_SAMPLE_LIMIT).map((template) => template.key),
-      ...providerConfiguration,
     },
     'Provisioner configured',
   );

--- a/libs/provisioner/core/src/provisioner.ts
+++ b/libs/provisioner/core/src/provisioner.ts
@@ -11,28 +11,38 @@ import {
   type ProvisionerClient,
 } from '#api-client.js';
 import {config} from '#config.js';
+import {
+  createHealthState,
+  deriveHealth,
+  type HealthEvent,
+  type HealthFacet,
+  type HealthLog,
+  type HealthState,
+  reduceHealth,
+} from '#health.js';
 import {type RunnerEnvFactory, runProvisionerTick} from '#tick.js';
 import {createInMemoryTracker, type ProviderRunnerTracker} from '#tracker.js';
 import type {ProvisionerAdapter, ProvisionerTemplate} from '#types.js';
 
 /** The demand poll accepts at most 1000 advertised templates per request. */
 const MAX_TEMPLATES_PER_POLL = 1000;
+const CONFIG_SAMPLE_LIMIT = 20;
 
 let running = true;
-// Module-level so the long-lived signal handler can cancel the in-flight long-poll;
-// a locally-scoped capture isn't reachable from a process-global handler.
 let pollAbortController: AbortController | undefined;
 const shutdownController = createGracefulShutdownController({
   onFirstSignal: (signal) => {
     running = false;
-    logger().info({signal}, 'Shutting down gracefully');
+    logger().info({event: 'provisioner.stopping', signal}, 'Provisioner shutting down gracefully');
     pollAbortController?.abort('shutdown');
   },
   onSecondSignal: (signal) => {
-    logger().info({signal}, 'Second signal received, exiting now');
+    logger().info({event: 'provisioner.stopping', signal, forced: true}, 'Provisioner exiting now');
     process.exit(1);
   },
 });
+
+export type ProvisionerHealthState = HealthState;
 
 export interface StartProvisionerOptions<Spec> {
   readonly adapter: ProvisionerAdapter<Spec>;
@@ -44,7 +54,7 @@ export interface RunProvisionerIterationDeps<Spec> {
   readonly templates: readonly ProvisionerTemplate<Spec>[];
   readonly tracker: ProviderRunnerTracker;
   readonly currentInterval: number;
-  readonly degraded: boolean;
+  readonly health?: ProvisionerHealthState;
   readonly signal?: AbortSignal;
 }
 
@@ -54,10 +64,8 @@ export interface RunProvisionerIterationResult {
 }
 
 /**
- * Run the provisioner control loop until a shutdown signal: authenticate, load the
- * provider's templates once, then repeatedly poll demand, plan launches, bootstrap instances,
- * and start runners through the provider's launcher. Backs off on error and aborts the
- * in-flight long-poll on SIGINT/SIGTERM so shutdown is prompt.
+ * Run the provisioner control loop until shutdown. Health transitions are reduced from
+ * typed operation outcomes; adapters do not own readiness, backoff, or suppression state.
  */
 export async function startProvisioner<Spec>(
   options: StartProvisionerOptions<Spec>,
@@ -71,23 +79,47 @@ export async function startProvisioner<Spec>(
     throw new Error('Provisioner started with no templates; configure at least one template.');
   }
   if (templates.length > MAX_TEMPLATES_PER_POLL) {
-    // The demand poll advertises every template at once and the API caps that list, so a
-    // larger set would fail schema validation on every poll. Fail fast instead.
     throw new Error(
       `Provisioner has ${templates.length} templates; the demand poll accepts at most ${MAX_TEMPLATES_PER_POLL}. Reduce the configured templates.`,
     );
   }
+
+  const providerConfiguration = (await options.adapter.onConfigure?.({templates})) ?? {};
+  logger().info(
+    {
+      event: 'provisioner.configured',
+      templateCount: templates.length,
+      templateKeySample: templates.slice(0, CONFIG_SAMPLE_LIMIT).map((template) => template.key),
+      ...providerConfiguration,
+    },
+    'Provisioner configured',
+  );
 
   const client = createProvisionerClient({
     baseUrl: config.SHIPFOX_API_URL,
     token: config.SHIPFOX_PROVISIONER_TOKEN,
   });
 
-  // Fail fast at startup if the token is rejected, rather than discovering it on the
-  // first poll.
-  const identity = await client.getIdentity();
+  let identity: Awaited<ReturnType<ProvisionerClient['getIdentity']>>;
+  try {
+    identity = await client.getIdentity();
+  } catch (error) {
+    if (error instanceof ProvisionerAuthenticationError) {
+      logger().error(
+        {
+          event: 'provisioner.authentication_failed',
+          operation: error.action,
+          status: error.status,
+          reason: 'token_rejected',
+        },
+        `Provisioner token rejected during ${error.action}`,
+      );
+    }
+    throw error;
+  }
   logger().info(
     {
+      event: 'provisioner.authenticated',
       provisionerId: identity.id,
       workspaceId: identity.scope === 'workspace' ? identity.workspace_id : undefined,
       scope: identity.scope,
@@ -97,7 +129,7 @@ export async function startProvisioner<Spec>(
   );
 
   const tracker = createInMemoryTracker();
-  let degraded = false;
+  const health = createHealthState();
   try {
     await options.adapter.onStart?.({
       client,
@@ -108,114 +140,175 @@ export async function startProvisioner<Spec>(
       },
       tracker,
     });
+    applyHealthEvent(health, {type: 'ready_confirmed', at: new Date()});
   } catch (error) {
-    degraded = true;
-    logger().error(
-      {err: error},
-      'Provisioner startup reconciliation failed; advertising no free capacity until observe succeeds',
-    );
+    applyHealthEvent(health, {
+      type: 'facet_failed',
+      facet: 'provider_observation',
+      cause: errorReason(error),
+      impact: 'capacity',
+      at: new Date(),
+    });
   }
 
   let currentInterval = config.SHIPFOX_PROVISIONER_POLL_INTERVAL_MS;
-
   while (running) {
     pollAbortController = new AbortController();
     try {
-      const iteration: RunProvisionerIterationResult = await runProvisionerIteration({
+      const iteration = await runProvisionerIteration({
         adapter: options.adapter,
         client,
         templates,
         tracker,
         currentInterval,
-        degraded,
+        health,
         signal: pollAbortController.signal,
       });
       currentInterval = iteration.nextInterval;
-      degraded = iteration.degraded;
       await interruptableSleep(withJitter(currentInterval));
-    } catch (error) {
+    } catch {
       if (!running) break;
-      if (error instanceof ProvisionerAuthenticationError) {
-        // Distinct from a transient blip: the token was rejected. Keep retrying (it may be
-        // rotated back) but make the cause obvious to an operator reading the logs.
-        logger().error(
-          {err: error},
-          'Provisioner token rejected; retrying after backoff (verify the token is valid and not revoked)',
-        );
-      } else {
-        logger().error({err: error}, 'Provisioner tick failed');
-      }
       currentInterval = nextBackoffInterval(currentInterval);
       await interruptableSleep(withJitter(currentInterval));
     }
   }
 
   await options.adapter.onStop?.();
-  logger().info('Provisioner stopped');
+  logger().info({event: 'provisioner.stopped'}, 'Provisioner stopped');
 }
 
 export async function runProvisionerIteration<Spec>(
   deps: RunProvisionerIterationDeps<Spec>,
 ): Promise<RunProvisionerIterationResult> {
-  let degraded = deps.degraded;
-  let maxReservations = config.SHIPFOX_PROVISIONER_MAX_RESERVATIONS;
-
-  try {
-    if (deps.adapter.onTick) {
+  const health = deps.health ?? createHealthState();
+  let derived = healthDerived(health);
+  let observed = false;
+  if (deps.adapter.onTick) {
+    try {
       await deps.adapter.onTick();
-      degraded = false;
+      applyHealthEvent(health, {
+        type: 'facet_recovered',
+        facet: 'provider_observation',
+        at: new Date(),
+      });
+      observed = true;
+      derived = healthDerived(health);
+    } catch (error) {
+      if (deps.signal?.aborted) throw error;
+      applyHealthEvent(health, {
+        type: 'facet_failed',
+        facet: 'provider_observation',
+        cause: errorReason(error),
+        impact: 'capacity',
+        at: new Date(),
+      });
+      derived = healthDerived(health);
     }
+  }
+  const reservationLimit = config.SHIPFOX_PROVISIONER_MAX_RESERVATIONS;
+  const launchBudget = deriveLaunchBudget(health);
+
+  let result: Awaited<ReturnType<typeof runProvisionerTick>>;
+  try {
+    result = await runProvisionerTick({
+      client: deps.client,
+      templates: deps.templates,
+      tracker: deps.tracker,
+      launch: deps.adapter.launch,
+      ...(deps.adapter.terminate ? {terminate: deps.adapter.terminate} : {}),
+      buildRunnerEnv,
+      reservationLimit,
+      launchBudget,
+      waitSeconds: config.SHIPFOX_PROVISIONER_POLL_WAIT_SECONDS,
+      runnerInstanceBatchSize: config.SHIPFOX_PROVISIONER_RUNNER_INSTANCE_BATCH_SIZE,
+      retryIntervalMs: deps.currentInterval,
+      ...(deps.signal ? {signal: deps.signal} : {}),
+    });
+    applyHealthEvent(health, {type: 'facet_recovered', facet: 'poll_demand', at: new Date()});
+    applyHealthEvent(health, {type: 'facet_recovered', facet: 'authentication', at: new Date()});
   } catch (error) {
-    degraded = true;
-    maxReservations = 0;
-    logger().error(
-      {err: error},
-      'Provisioner observe failed; advertising no free capacity until observe succeeds',
-    );
+    if (deps.signal?.aborted) throw error;
+    const facet: HealthFacet =
+      error instanceof ProvisionerAuthenticationError ? 'authentication' : 'poll_demand';
+    applyHealthEvent(health, {
+      type: 'facet_failed',
+      facet,
+      cause: errorReason(error),
+      impact: 'control_plane',
+      at: new Date(),
+    });
+    throw error;
   }
 
-  if (degraded) maxReservations = 0;
+  if (result.providerTermination.status === 'failed') {
+    applyHealthEvent(health, {
+      type: 'facet_failed',
+      facet: 'provider_termination',
+      cause: result.providerTermination.cause,
+      impact: 'cleanup',
+      at: new Date(),
+    });
+  } else if (
+    result.providerTermination.status === 'succeeded' ||
+    result.providerTermination.status === 'not_needed'
+  ) {
+    applyHealthEvent(health, {
+      type: 'facet_recovered',
+      facet: 'provider_termination',
+      at: new Date(),
+    });
+  }
 
-  const result = await runProvisionerTick({
-    client: deps.client,
-    templates: deps.templates,
-    tracker: deps.tracker,
-    launch: deps.adapter.launch,
-    ...(deps.adapter.terminate ? {terminate: deps.adapter.terminate} : {}),
-    buildRunnerEnv,
-    maxReservations,
-    waitSeconds: config.SHIPFOX_PROVISIONER_POLL_WAIT_SECONDS,
-    runnerInstanceBatchSize: config.SHIPFOX_PROVISIONER_RUNNER_INSTANCE_BATCH_SIZE,
-    ...(deps.signal ? {signal: deps.signal} : {}),
-  });
+  const hasCapacityFailure =
+    result.runnerInstanceCreationFailureCount > 0 ||
+    result.providerLaunchFailureCount > 0 ||
+    (result.launchAttemptedCount > 0 && result.launchedCount === 0);
+  if (hasCapacityFailure) {
+    applyHealthEvent(health, {
+      type: 'facet_failed',
+      facet: 'runner_capacity',
+      cause:
+        result.runnerInstanceCreationFailureReason ??
+        result.providerLaunchFailureReason ??
+        'All attempted runner launches failed.',
+      impact: 'capacity',
+      failureCount: result.runnerInstanceCreationFailureCount + result.providerLaunchFailureCount,
+      at: new Date(),
+    });
+  } else if (result.launchedCount > 0) {
+    applyHealthEvent(health, {type: 'facet_recovered', facet: 'runner_capacity', at: new Date()});
+  }
 
-  if (result.reservationCount > 0 || result.launchedCount > 0) {
+  derived = healthDerived(health);
+  if (observed || result.launchedCount > 0) {
+    applyHealthEvent(health, {type: 'ready_confirmed', at: new Date()});
+    derived = healthDerived(health);
+  }
+
+  if (result.reservationCount > 0 || result.launchedCount > 0 || result.launchAttemptedCount > 0) {
     logger().info(
       {
-        reservations: result.reservationCount,
+        event: 'runner.launch_batch_completed',
+        reserved: result.reservedRunnerCount,
         planned: result.plannedCount,
-        launchAttempts: result.launchAttemptedCount,
-        launched: result.launchedCount,
+        attempted: result.launchAttemptedCount,
+        started: result.launchedCount,
+        failed: result.launchAttemptedCount - result.launchedCount,
+        lifecycleIncomplete: result.launchLifecycleIncompleteCount,
+        ...(result.launchLifecycleIncompleteReason
+          ? {launchLifecycleIncompleteReason: result.launchLifecycleIncompleteReason}
+          : {}),
+        reservations: result.reservationCount,
       },
-      'Provisioner tick complete',
-    );
-  }
-
-  const allAttemptedLaunchesFailed = result.launchAttemptedCount > 0 && result.launchedCount === 0;
-  const shouldBackOff = degraded || allAttemptedLaunchesFailed;
-
-  if (allAttemptedLaunchesFailed) {
-    logger().warn(
-      {attempted: result.launchAttemptedCount},
-      'All attempted provisioned runner launches failed; backing off',
+      'Runner launch batch completed',
     );
   }
 
   return {
-    nextInterval: shouldBackOff
+    nextInterval: derived.shouldBackOff
       ? nextBackoffInterval(deps.currentInterval)
       : config.SHIPFOX_PROVISIONER_POLL_INTERVAL_MS,
-    degraded,
+    degraded: derived.capacityDegraded,
   };
 }
 
@@ -234,12 +327,82 @@ export function nextBackoffInterval(ms: number): number {
 }
 
 export function withJitter(ms: number): number {
-  // Floor the jitter at half the interval so a fast-returning poll (for example with
-  // wait_seconds=0) cannot collapse the delay toward zero and busy-loop the API.
   return applyJitter(ms, {minFactor: 0.5});
 }
 
 async function interruptableSleep(ms: number): Promise<void> {
   if (!running) return;
   await interruptibleSleep(ms, shutdownController.signal);
+}
+
+function applyHealthEvent(state: HealthState, event: HealthEvent): void {
+  const reduction = reduceHealth(state, event);
+  state.active = reduction.state.active;
+  state.incident = reduction.state.incident;
+  state.hasEverBeenReady = reduction.state.hasEverBeenReady;
+  for (const log of reduction.logs) emitHealthLog(log);
+}
+
+function healthDerived(state: HealthState) {
+  return deriveHealth(state);
+}
+
+function deriveLaunchBudget(state: HealthState): number {
+  if (state.active.has('provider_observation')) return 0;
+  if (state.active.has('runner_capacity')) return 1;
+  return Number.POSITIVE_INFINITY;
+}
+function emitHealthLog(log: HealthLog): void {
+  const fields = {
+    event: log.event,
+    ...(log.facet ? {operation: log.facet} : {}),
+    ...(log.cause ? {cause: log.cause} : {}),
+    ...(log.changed ? {changed: true} : {}),
+    ...(log.recoveredFacet ? {recoveredFacet: log.recoveredFacet} : {}),
+    ...(log.remainingFacetCount !== undefined
+      ? {remainingFacetCount: log.remainingFacetCount}
+      : {}),
+    ...(log.impact ? {impact: log.impact} : {}),
+    ...(log.attempts !== undefined ? {attempts: log.attempts} : {}),
+    ...(log.suppressed !== undefined ? {suppressed: log.suppressed} : {}),
+    ...(log.outageDurationMs !== undefined ? {outageDurationMs: log.outageDurationMs} : {}),
+    ...(isApiFacet(log.facet) ? {endpoint: safeEndpoint(config.SHIPFOX_API_URL)} : {}),
+  };
+  if (log.level === 'error') {
+    logger().error(fields, healthMessage(log));
+  } else if (log.level === 'warn') {
+    logger().warn(fields, healthMessage(log));
+  } else {
+    logger().info(fields, healthMessage(log));
+  }
+}
+
+function healthMessage(log: HealthLog): string {
+  if (log.event === 'provisioner.recovered') return 'Provisioner recovered';
+  if (log.event === 'provisioner.partially_recovered') {
+    return `Provisioner partially recovered; ${log.remainingFacetCount ?? 0} failure facet(s) remain active`;
+  }
+  if (log.event === 'provisioner.ready') return 'Provisioner ready';
+  if (log.impact === 'cleanup') return 'Provisioner degraded; cleanup is temporarily unavailable';
+  if (log.impact === 'control_plane') {
+    return 'Provisioner degraded; control-plane operations are temporarily unavailable';
+  }
+  return 'Provisioner degraded; capacity is temporarily unavailable';
+}
+
+function isApiFacet(facet: HealthFacet | undefined): boolean {
+  return facet === 'poll_demand' || facet === 'authentication';
+}
+
+function errorReason(error: unknown): string {
+  return error instanceof Error ? error.message.slice(0, 500) : String(error).slice(0, 500);
+}
+
+function safeEndpoint(value: string): string {
+  try {
+    const url = new URL(value);
+    return `${url.protocol}//${url.host}${url.pathname}`;
+  } catch {
+    return '<invalid-endpoint>';
+  }
 }

--- a/libs/provisioner/core/src/tick.test.ts
+++ b/libs/provisioner/core/src/tick.test.ts
@@ -42,24 +42,242 @@ describe('runProvisionerTick', () => {
     };
     const launches: string[] = [];
 
-    await runProvisionerTick({
+    const result = await runProvisionerTick({
       client,
       templates: [{key: 'linux', labels: ['linux'], maxConcurrency: 1, cost: 1, spec: null}],
       tracker: createInMemoryTracker(),
       launch: (launch) => {
         calls.push('launch');
         launches.push(launch.bootstrapToken ?? '');
-        return Promise.resolve();
+        return Promise.resolve({containerStarted: true, identityAttached: false, reported: false});
       },
       buildRunnerEnv: ({bootstrapToken}) => ({
         SHIPFOX_RUNNER_BOOTSTRAP_TOKEN: bootstrapToken ?? '',
       }),
-      maxReservations: 1,
+      reservationLimit: 1,
+      launchBudget: 1,
       waitSeconds: 0,
       runnerInstanceBatchSize: 1,
     });
 
     expect(calls).toEqual(['create', 'launch']);
     expect(launches).toEqual(['sf_rbt_test']);
+    expect(result).toMatchObject({launchedCount: 1, providerLaunchFailureCount: 0});
+    expect(result.launchLifecycleIncompleteCount).toBe(1);
+  });
+
+  it('counts partial runner-instance creation as failed capacity work', async () => {
+    const client: ProvisionerClient = {
+      getIdentity: async () => ({id: 'provisioner', scope: 'workspace', workspace_id: 'workspace'}),
+      pollDemand: async () => ({
+        stats: [],
+        reservations: [
+          {
+            reservation_id: '018f0d4c-5f42-7b7e-9d9b-4a7d8e6f0001',
+            labels: ['linux'],
+            count: 1,
+            expires_at: '2026-07-21T12:00:00.000Z',
+          },
+        ],
+        terminate_provider_runner_ids: [],
+      }),
+      createRunnerInstances: async () => ({runner_instances: []}),
+      attachRunnerInstanceProviderId: async () => ({attached: true}),
+      assignRunnerInstances: async (_reservationId, runnerInstanceIds) => ({
+        runner_instance_ids: runnerInstanceIds,
+      }),
+      reportRunnerInstances: async () => ({accepted: 0, reservations_released: 0}),
+      reconcileRunnerInstances: async () => ({
+        runners: [],
+        terminated_absent_provider_runner_ids: [],
+      }),
+    };
+
+    const result = await runProvisionerTick({
+      client,
+      templates: [{key: 'linux', labels: ['linux'], maxConcurrency: 1, cost: 1, spec: null}],
+      tracker: createInMemoryTracker(),
+      launch: () => Promise.resolve(),
+      buildRunnerEnv: ({bootstrapToken}) => ({
+        SHIPFOX_RUNNER_BOOTSTRAP_TOKEN: bootstrapToken,
+      }),
+      reservationLimit: 1,
+      launchBudget: 1,
+      waitSeconds: 0,
+      runnerInstanceBatchSize: 1,
+    });
+
+    expect(result).toMatchObject({
+      plannedCount: 1,
+      launchAttemptedCount: 1,
+      launchedCount: 0,
+      runnerInstanceCreationFailureCount: 1,
+    });
+  });
+
+  it('propagates an aborted runner-instance creation without counting capacity failure', async () => {
+    const controller = new AbortController();
+    const client: ProvisionerClient = {
+      getIdentity: async () => ({id: 'provisioner', scope: 'workspace', workspace_id: 'workspace'}),
+      pollDemand: async () => ({
+        stats: [],
+        reservations: [
+          {
+            reservation_id: '018f0d4c-5f42-7b7e-9d9b-4a7d8e6f0001',
+            labels: ['linux'],
+            count: 1,
+            expires_at: '2026-07-21T12:00:00.000Z',
+          },
+        ],
+        terminate_provider_runner_ids: [],
+      }),
+      createRunnerInstances: () => {
+        controller.abort('shutdown');
+        return Promise.reject(new Error('create aborted'));
+      },
+      attachRunnerInstanceProviderId: async () => ({attached: true}),
+      assignRunnerInstances: async (_reservationId, runnerInstanceIds) => ({
+        runner_instance_ids: runnerInstanceIds,
+      }),
+      reportRunnerInstances: async () => ({accepted: 0, reservations_released: 0}),
+      reconcileRunnerInstances: async () => ({
+        runners: [],
+        terminated_absent_provider_runner_ids: [],
+      }),
+    };
+
+    await expect(
+      runProvisionerTick({
+        client,
+        templates: [{key: 'linux', labels: ['linux'], maxConcurrency: 1, cost: 1, spec: null}],
+        tracker: createInMemoryTracker(),
+        launch: () => Promise.resolve(),
+        buildRunnerEnv: ({bootstrapToken}) => ({
+          SHIPFOX_RUNNER_BOOTSTRAP_TOKEN: bootstrapToken,
+        }),
+        reservationLimit: 1,
+        launchBudget: 1,
+        waitSeconds: 0,
+        runnerInstanceBatchSize: 1,
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow('create aborted');
+  });
+
+  it('includes target-concurrency launches in the planned count', async () => {
+    const client: ProvisionerClient = {
+      getIdentity: async () => ({id: 'provisioner', scope: 'workspace', workspace_id: 'workspace'}),
+      pollDemand: async ({max_reservations}) => ({
+        stats: [],
+        reservations:
+          max_reservations > 0
+            ? [
+                {
+                  reservation_id: '018f0d4c-5f42-7b7e-9d9b-4a7d8e6f0001',
+                  labels: ['linux'],
+                  count: 1,
+                  expires_at: '2026-07-21T12:00:00.000Z',
+                },
+              ]
+            : [],
+        terminate_provider_runner_ids: [],
+      }),
+      createRunnerInstances: async () => ({
+        runner_instances: [
+          {
+            runner_instance_id: '018f0d4c-5f42-7b7e-9d9b-4a7d8e6f0002',
+            bootstrap_token: 'sf_rbt_test',
+          },
+        ],
+      }),
+      attachRunnerInstanceProviderId: async () => ({attached: true}),
+      assignRunnerInstances: async (_reservationId, runnerInstanceIds) => ({
+        runner_instance_ids: runnerInstanceIds,
+      }),
+      reportRunnerInstances: async () => ({accepted: 0, reservations_released: 0}),
+      reconcileRunnerInstances: async () => ({
+        runners: [],
+        terminated_absent_provider_runner_ids: [],
+      }),
+    };
+
+    const tickOptions = {
+      client,
+      templates: [
+        {
+          key: 'linux',
+          labels: ['linux'],
+          maxConcurrency: 2,
+          targetConcurrency: 2,
+          cost: 1,
+          spec: null,
+        },
+      ],
+      tracker: createInMemoryTracker(),
+      launch: () => Promise.resolve(),
+      buildRunnerEnv: ({bootstrapToken}: {bootstrapToken: string}) => ({
+        SHIPFOX_RUNNER_BOOTSTRAP_TOKEN: bootstrapToken,
+      }),
+      reservationLimit: 1,
+      launchBudget: 1,
+      waitSeconds: 0,
+      runnerInstanceBatchSize: 1,
+    };
+    const closed = await runProvisionerTick({...tickOptions, launchBudget: 0});
+    const result = await runProvisionerTick({...tickOptions, launchBudget: 1});
+    expect(closed).toMatchObject({plannedCount: 2, launchAttemptedCount: 0, launchedCount: 0});
+
+    expect(result).toMatchObject({plannedCount: 3, launchAttemptedCount: 1, launchedCount: 1});
+  });
+  it('keeps the reservation poll limit independent from warm-pool admission', async () => {
+    let requestedReservations = -1;
+    const client: ProvisionerClient = {
+      getIdentity: async () => ({id: 'provisioner', scope: 'workspace', workspace_id: 'workspace'}),
+      pollDemand: (body) => {
+        requestedReservations = body.max_reservations;
+        return Promise.resolve({stats: [], reservations: [], terminate_provider_runner_ids: []});
+      },
+      createRunnerInstances: async () => ({
+        runner_instances: [
+          {
+            runner_instance_id: '018f0d4c-5f42-7b7e-9d9b-4a7d8e6f0002',
+            bootstrap_token: 'sf_rbt_test',
+          },
+        ],
+      }),
+      attachRunnerInstanceProviderId: async () => ({attached: true}),
+      assignRunnerInstances: async (_reservationId, runnerInstanceIds) => ({
+        runner_instance_ids: runnerInstanceIds,
+      }),
+      reportRunnerInstances: async () => ({accepted: 0, reservations_released: 0}),
+      reconcileRunnerInstances: async () => ({
+        runners: [],
+        terminated_absent_provider_runner_ids: [],
+      }),
+    };
+    const result = await runProvisionerTick({
+      client,
+      templates: [
+        {
+          key: 'linux',
+          labels: ['linux'],
+          maxConcurrency: 2,
+          targetConcurrency: 2,
+          cost: 1,
+          spec: null,
+        },
+      ],
+      tracker: createInMemoryTracker(),
+      launch: () => Promise.resolve(),
+      buildRunnerEnv: ({bootstrapToken}) => ({
+        SHIPFOX_RUNNER_BOOTSTRAP_TOKEN: bootstrapToken,
+      }),
+      reservationLimit: 0,
+      launchBudget: Number.POSITIVE_INFINITY,
+      waitSeconds: 0,
+      runnerInstanceBatchSize: 1,
+    });
+    expect(requestedReservations).toBe(0);
+    expect(result).toMatchObject({plannedCount: 2, launchAttemptedCount: 2, launchedCount: 2});
   });
 });

--- a/libs/provisioner/core/src/tick.test.ts
+++ b/libs/provisioner/core/src/tick.test.ts
@@ -227,7 +227,7 @@ describe('runProvisionerTick', () => {
     const result = await runProvisionerTick({...tickOptions, launchBudget: 1});
     expect(closed).toMatchObject({plannedCount: 2, launchAttemptedCount: 0, launchedCount: 0});
 
-    expect(result).toMatchObject({plannedCount: 3, launchAttemptedCount: 1, launchedCount: 1});
+    expect(result).toMatchObject({plannedCount: 2, launchAttemptedCount: 1, launchedCount: 1});
   });
   it('keeps the reservation poll limit independent from warm-pool admission', async () => {
     let requestedReservations = -1;

--- a/libs/provisioner/core/src/tick.ts
+++ b/libs/provisioner/core/src/tick.ts
@@ -4,8 +4,7 @@ import type {
   DemandStatDto,
   PollDemandTemplateDto,
 } from '@shipfox/api-runners-dto';
-import {logger} from '@shipfox/node-opentelemetry';
-import type {ProvisionerClient} from '#api-client.js';
+import {ProvisionerAuthenticationError, type ProvisionerClient} from '#api-client.js';
 import {type PlannedLaunchGroup, planLaunches, templateAvailableSlots} from '#capacity.js';
 import type {ProviderRunnerTracker} from '#tracker.js';
 import type {LaunchRunner, ProvisionerTemplate, TerminateRunners} from '#types.js';
@@ -16,6 +15,12 @@ const MAX_RESERVATIONS_PER_POLL = 1000;
 const cryptoWithUuidV7 = nodeCrypto as typeof nodeCrypto & {
   randomUUIDv7(): string;
 };
+type WarmLaunchGroup<Spec> = {
+  readonly reservationId: undefined;
+  readonly template: ProvisionerTemplate<Spec>;
+  readonly count: number;
+};
+type LaunchGroup<Spec> = PlannedLaunchGroup<Spec> | WarmLaunchGroup<Spec>;
 
 export type RunnerEnvFactory<Spec> = (args: {
   template: ProvisionerTemplate<Spec>;
@@ -29,18 +34,35 @@ export interface ProvisionerTickDeps<Spec> {
   readonly launch: LaunchRunner<Spec>;
   readonly terminate?: TerminateRunners;
   readonly buildRunnerEnv: RunnerEnvFactory<Spec>;
-  readonly maxReservations: number;
+  readonly reservationLimit: number;
+  readonly launchBudget: number;
   readonly waitSeconds: number;
   readonly runnerInstanceBatchSize: number;
+  readonly retryIntervalMs?: number;
   readonly signal?: AbortSignal;
 }
+
+export type ProvisionerTerminationOutcome =
+  | {status: 'succeeded'}
+  | {status: 'not_needed'}
+  | {status: 'not_attempted'}
+  | {status: 'failed'; cause: string}
+  | {status: 'cancelled'};
 
 export interface ProvisionerTickResult {
   readonly stats: readonly DemandStatDto[];
   readonly reservationCount: number;
+  readonly reservedRunnerCount: number;
+  readonly providerTermination: ProvisionerTerminationOutcome;
   readonly plannedCount: number;
   readonly launchAttemptedCount: number;
   readonly launchedCount: number;
+  readonly runnerInstanceCreationFailureCount: number;
+  readonly runnerInstanceCreationFailureReason?: string;
+  readonly providerLaunchFailureCount: number;
+  readonly providerLaunchFailureReason?: string;
+  readonly launchLifecycleIncompleteCount: number;
+  readonly launchLifecycleIncompleteReason?: string;
 }
 
 /**
@@ -76,19 +98,45 @@ export async function runProvisionerTick<Spec>(
   );
   // Respect local max concurrency before asking: never reserve more than there are
   // free slots to fill (and never more than the API will grant in one poll).
-  const maxReservations = Math.min(deps.maxReservations, totalAvailable, MAX_RESERVATIONS_PER_POLL);
+  const pollReservationLimit = Math.min(
+    deps.reservationLimit,
+    deps.launchBudget,
+    totalAvailable,
+    MAX_RESERVATIONS_PER_POLL,
+  );
 
   const response = await deps.client.pollDemand(
-    {wait_seconds: deps.waitSeconds, max_reservations: maxReservations, templates: advertisements},
+    {
+      wait_seconds: deps.waitSeconds,
+      max_reservations: pollReservationLimit,
+      templates: advertisements,
+    },
     deps.signal ? {signal: deps.signal} : {},
   );
 
-  if (
-    response.terminate_provider_runner_ids.length > 0 &&
-    !deps.signal?.aborted &&
-    deps.terminate
-  ) {
-    await deps.terminate(response.terminate_provider_runner_ids);
+  let providerTermination: ProvisionerTerminationOutcome;
+  if (deps.signal?.aborted) {
+    providerTermination = {status: 'cancelled'};
+  } else if (deps.terminate) {
+    try {
+      await deps.terminate(response.terminate_provider_runner_ids);
+      providerTermination = {status: 'succeeded'};
+    } catch (error) {
+      if (deps.signal?.aborted) {
+        providerTermination = {status: 'cancelled'};
+      } else if (error instanceof ProvisionerAuthenticationError) {
+        throw error;
+      } else {
+        providerTermination = {
+          status: 'failed',
+          cause: errorReason(error),
+        };
+      }
+    }
+  } else if (response.terminate_provider_runner_ids.length > 0) {
+    providerTermination = {status: 'not_attempted'};
+  } else {
+    providerTermination = {status: 'not_needed'};
   }
 
   const planned = planLaunches({
@@ -101,34 +149,73 @@ export async function runProvisionerTick<Spec>(
     availableByKey,
   });
 
-  const plannedCount = planned.reduce((sum, group) => sum + group.count, 0);
+  let plannedCount = planned.reduce((sum, group) => sum + group.count, 0);
+  const reservedRunnerCount = response.reservations.reduce(
+    (sum, reservation) => sum + reservation.count,
+    0,
+  );
 
   let launchAttemptedCount = 0;
   let launchedCount = 0;
-  for (const [reservationId, groups] of groupByReservation(planned)) {
-    if (deps.signal?.aborted) break;
-    const result = await launchReservation(reservationId, groups, deps);
-    launchAttemptedCount += result.attempted;
-    launchedCount += result.launched;
-  }
-
+  let runnerInstanceCreationFailureCount = 0;
+  let runnerInstanceCreationFailureReason: string | undefined;
+  let providerLaunchFailureCount = 0;
+  let providerLaunchFailureReason: string | undefined;
+  let launchLifecycleIncompleteCount = 0;
+  let launchLifecycleIncompleteReason: string | undefined;
   const hotGroups = deps.templates.flatMap((template) => {
     const counts = deps.tracker.countsByTemplate().get(template.key) ?? {starting: 0, running: 0};
     const count = Math.max(0, (template.targetConcurrency ?? 0) - counts.starting - counts.running);
     return count > 0 ? [{reservationId: undefined, template, count}] : [];
   });
-  if (!deps.signal?.aborted && hotGroups.length > 0) {
-    const result = await launchReservation(undefined, hotGroups, deps);
+  const allGroups: LaunchGroup<Spec>[] = [...planned, ...hotGroups];
+  plannedCount = allGroups.reduce((sum, group) => sum + group.count, 0);
+  const budgetedGroups = limitLaunchGroups(allGroups, deps.launchBudget);
+  const reservationGroups = budgetedGroups.filter(
+    (group): group is PlannedLaunchGroup<Spec> => group.reservationId !== undefined,
+  );
+  const warmGroups = budgetedGroups.filter(
+    (group): group is WarmLaunchGroup<Spec> => group.reservationId === undefined,
+  );
+  for (const [reservationId, groups] of groupByReservation(reservationGroups)) {
+    if (deps.signal?.aborted) break;
+    const result = await launchReservation(reservationId, groups, deps);
     launchAttemptedCount += result.attempted;
     launchedCount += result.launched;
+    runnerInstanceCreationFailureCount += result.runnerInstanceCreationFailureCount;
+    runnerInstanceCreationFailureReason ??= result.runnerInstanceCreationFailureReason;
+    providerLaunchFailureCount += result.providerLaunchFailureCount;
+    providerLaunchFailureReason ??= result.providerLaunchFailureReason;
+    launchLifecycleIncompleteCount += result.launchLifecycleIncompleteCount;
+    launchLifecycleIncompleteReason ??= result.launchLifecycleIncompleteReason;
+  }
+
+  if (!deps.signal?.aborted && warmGroups.length > 0) {
+    const result = await launchReservation(undefined, warmGroups, deps);
+    launchAttemptedCount += result.attempted;
+    launchedCount += result.launched;
+    runnerInstanceCreationFailureCount += result.runnerInstanceCreationFailureCount;
+    runnerInstanceCreationFailureReason ??= result.runnerInstanceCreationFailureReason;
+    providerLaunchFailureCount += result.providerLaunchFailureCount;
+    providerLaunchFailureReason ??= result.providerLaunchFailureReason;
+    launchLifecycleIncompleteCount += result.launchLifecycleIncompleteCount;
+    launchLifecycleIncompleteReason ??= result.launchLifecycleIncompleteReason;
   }
 
   return {
     stats: response.stats,
     reservationCount: response.reservations.length,
+    reservedRunnerCount,
+    providerTermination,
     plannedCount,
     launchAttemptedCount,
     launchedCount,
+    runnerInstanceCreationFailureCount,
+    ...(runnerInstanceCreationFailureReason ? {runnerInstanceCreationFailureReason} : {}),
+    providerLaunchFailureCount,
+    ...(providerLaunchFailureReason ? {providerLaunchFailureReason} : {}),
+    launchLifecycleIncompleteCount,
+    ...(launchLifecycleIncompleteReason ? {launchLifecycleIncompleteReason} : {}),
   };
 }
 
@@ -139,7 +226,16 @@ async function launchReservation<Spec>(
     | {reservationId: undefined; template: ProvisionerTemplate<Spec>; count: number}
   )[],
   deps: ProvisionerTickDeps<Spec>,
-): Promise<{attempted: number; launched: number}> {
+): Promise<{
+  attempted: number;
+  launched: number;
+  runnerInstanceCreationFailureCount: number;
+  runnerInstanceCreationFailureReason?: string;
+  providerLaunchFailureCount: number;
+  providerLaunchFailureReason?: string;
+  launchLifecycleIncompleteCount: number;
+  launchLifecycleIncompleteReason?: string;
+}> {
   // A fresh, never-reused provider identity per runner names the compute resource;
   // names the resource, and keys idempotent reporting and reconciliation. UUIDv7 keeps
   // generated ids time-ordered without adding a dependency.
@@ -155,6 +251,12 @@ async function launchReservation<Spec>(
 
   let attempted = 0;
   let launched = 0;
+  let runnerInstanceCreationFailureCount = 0;
+  let runnerInstanceCreationFailureReason: string | undefined;
+  let providerLaunchFailureCount = 0;
+  let providerLaunchFailureReason: string | undefined;
+  let launchLifecycleIncompleteCount = 0;
+  let launchLifecycleIncompleteReason: string | undefined;
   for (const batch of chunk(plannedRunners, deps.runnerInstanceBatchSize)) {
     if (deps.signal?.aborted) break;
     let created: CreateRunnerInstancesResponseDto;
@@ -164,17 +266,21 @@ async function launchReservation<Spec>(
         deps.signal ? {signal: deps.signal} : {},
       );
     } catch (error) {
+      if (error instanceof ProvisionerAuthenticationError) throw error;
+      if (deps.signal?.aborted) throw error;
       // Leave these slots free: the reservation TTL releases the demand and another
       // tick (or another provisioner) can pick it up.
-      logger().error({err: error, reservationId}, 'Failed to create runner instances');
+      attempted += batch.length;
+      runnerInstanceCreationFailureCount += batch.length;
+      runnerInstanceCreationFailureReason ??= instanceCreationFailureReason(error);
       continue;
     }
 
-    if (created.runner_instances.length < batch.length) {
-      logger().warn(
-        {reservationId, requested: batch.length, created: created.runner_instances.length},
-        'Runner instance creation returned fewer results than requested',
-      );
+    const missingCount = Math.max(0, batch.length - created.runner_instances.length);
+    if (missingCount > 0) {
+      attempted += missingCount;
+      runnerInstanceCreationFailureCount += missingCount;
+      runnerInstanceCreationFailureReason ??= `Runner instance creation returned ${created.runner_instances.length} of ${batch.length} requested instances.`;
     }
 
     for (const [index, createdRunner] of created.runner_instances.entries()) {
@@ -190,7 +296,7 @@ async function launchReservation<Spec>(
       });
       attempted += 1;
       try {
-        await deps.launch({
+        const outcome = (await deps.launch({
           runnerInstanceId: createdRunner.runner_instance_id,
           providerRunnerId: plannedRunner.providerRunnerId,
           ...(reservationId ? {reservationId} : {}),
@@ -200,24 +306,76 @@ async function launchReservation<Spec>(
             template,
             bootstrapToken: createdRunner.bootstrap_token,
           }),
-        });
+        })) ?? {containerStarted: true, identityAttached: true, reported: true};
+        if (!outcome.containerStarted) {
+          providerLaunchFailureCount += 1;
+          deps.tracker.remove(plannedRunner.providerRunnerId);
+          providerLaunchFailureReason ??= launchLifecycleFailureReason(outcome);
+          continue;
+        }
         launched += 1;
+        if (!outcome.identityAttached || !outcome.reported) {
+          launchLifecycleIncompleteCount += 1;
+          launchLifecycleIncompleteReason ??= launchLifecycleFailureReason(outcome);
+        }
       } catch (error) {
+        providerLaunchFailureCount += 1;
         // The launch call rejected, so no resource was created: free the slot now instead
         // of leaving a phantom `starting` runner. A persistent failure (bad image, daemon
         // down) would otherwise drain capacity to zero and wedge the loop until restart.
         deps.tracker.remove(plannedRunner.providerRunnerId);
-        logger().error(
-          {err: error, providerRunnerId: plannedRunner.providerRunnerId},
-          'Failed to launch provisioned runner',
-        );
+        if (error instanceof ProvisionerAuthenticationError) throw error;
+        providerLaunchFailureReason ??= launchFailureReason(error);
       }
     }
   }
 
-  return {attempted, launched};
+  return {
+    attempted,
+    launched,
+    runnerInstanceCreationFailureCount,
+    ...(runnerInstanceCreationFailureReason ? {runnerInstanceCreationFailureReason} : {}),
+    providerLaunchFailureCount,
+    ...(providerLaunchFailureReason ? {providerLaunchFailureReason} : {}),
+    launchLifecycleIncompleteCount,
+    ...(launchLifecycleIncompleteReason ? {launchLifecycleIncompleteReason} : {}),
+  };
 }
 
+function instanceCreationFailureReason(error: unknown): string {
+  return error instanceof Error ? error.message.slice(0, 500) : String(error).slice(0, 500);
+}
+
+function launchFailureReason(error: unknown): string {
+  return error instanceof Error ? error.message.slice(0, 500) : String(error).slice(0, 500);
+}
+
+function launchLifecycleFailureReason(outcome: {
+  containerStarted: boolean;
+  identityAttached: boolean;
+  reported: boolean;
+}): string {
+  const missing = [
+    !outcome.containerStarted ? 'container' : undefined,
+    !outcome.identityAttached ? 'identity' : undefined,
+    !outcome.reported ? 'report' : undefined,
+  ].filter((item): item is string => item !== undefined);
+  return `Runner launch lifecycle incomplete: ${missing.join(', ') || 'unknown step'}.`;
+}
+function limitLaunchGroups<Spec>(
+  groups: readonly LaunchGroup<Spec>[],
+  budget: number,
+): LaunchGroup<Spec>[] {
+  let remaining = Math.max(0, budget);
+  const limited: LaunchGroup<Spec>[] = [];
+  for (const group of groups) {
+    if (remaining <= 0) break;
+    const count = Math.min(group.count, remaining);
+    if (count > 0) limited.push({...group, count});
+    remaining -= count;
+  }
+  return limited;
+}
 function groupByReservation<Spec>(
   planned: readonly PlannedLaunchGroup<Spec>[],
 ): Map<string, PlannedLaunchGroup<Spec>[]> {
@@ -236,4 +394,8 @@ function chunk<T>(items: readonly T[], size: number): T[][] {
     batches.push(items.slice(index, index + size));
   }
   return batches;
+}
+
+function errorReason(error: unknown): string {
+  return error instanceof Error ? error.message.slice(0, 500) : String(error).slice(0, 500);
 }

--- a/libs/provisioner/core/src/tick.ts
+++ b/libs/provisioner/core/src/tick.ts
@@ -163,9 +163,22 @@ export async function runProvisionerTick<Spec>(
   let providerLaunchFailureReason: string | undefined;
   let launchLifecycleIncompleteCount = 0;
   let launchLifecycleIncompleteReason: string | undefined;
+  const plannedByTemplate = new Map<string, number>();
+  for (const group of planned) {
+    plannedByTemplate.set(
+      group.template.key,
+      (plannedByTemplate.get(group.template.key) ?? 0) + group.count,
+    );
+  }
   const hotGroups = deps.templates.flatMap((template) => {
     const counts = deps.tracker.countsByTemplate().get(template.key) ?? {starting: 0, running: 0};
-    const count = Math.max(0, (template.targetConcurrency ?? 0) - counts.starting - counts.running);
+    const count = Math.max(
+      0,
+      (template.targetConcurrency ?? 0) -
+        counts.starting -
+        counts.running -
+        (plannedByTemplate.get(template.key) ?? 0),
+    );
     return count > 0 ? [{reservationId: undefined, template, count}] : [];
   });
   const allGroups: LaunchGroup<Spec>[] = [...planned, ...hotGroups];

--- a/libs/provisioner/core/src/types.ts
+++ b/libs/provisioner/core/src/types.ts
@@ -46,10 +46,19 @@ export interface ProviderRunnerLaunch<Spec = unknown> {
   readonly runnerEnv: Readonly<Record<string, string>>;
 }
 
-/** Starts one provisioned runner. The provider implementation owns the side effect. */
-export type LaunchRunner<Spec = unknown> = (launch: ProviderRunnerLaunch<Spec>) => Promise<void>;
+/** Facts about the provider launch lifecycle after the provider attempted the side effect. */
+export interface LaunchOutcome {
+  readonly containerStarted: boolean;
+  readonly identityAttached: boolean;
+  readonly reported: boolean;
+}
+/** Starts one provisioned runner. Legacy adapters may still resolve without an outcome. */
+export type LaunchRunner<Spec = unknown> = (
+  launch: ProviderRunnerLaunch<Spec>,
+  // biome-ignore lint/suspicious/noConfusingVoidType: preserve compatibility with existing adapters that only signal completion
+) => Promise<LaunchOutcome | void>;
 
-/** Tears down provider resources by provisioned runner id when the backend requests it. */
+/** Applies the current provider-termination snapshot; an empty list withdraws the intent. */
 export type TerminateRunners = (providerRunnerIds: readonly string[]) => Promise<void>;
 
 export interface ProvisionerIdentity {
@@ -71,6 +80,10 @@ export interface ProvisionerRuntime {
  */
 export interface ProvisionerAdapter<Spec = unknown> {
   loadTemplates(): Promise<readonly ProvisionerTemplate<Spec>[]>;
+  /** Optional provider details added to the startup configuration record. */
+  onConfigure?(args: {
+    templates: readonly ProvisionerTemplate<Spec>[];
+  }): Promise<Readonly<Record<string, unknown>>>;
   readonly launch: LaunchRunner<Spec>;
   readonly terminate?: TerminateRunners;
   onStart?(runtime: ProvisionerRuntime): Promise<void>;

--- a/libs/provisioner/docker/README.md
+++ b/libs/provisioner/docker/README.md
@@ -7,12 +7,12 @@ app.
 
 ## Public API
 
-- `startDockerProvisioner()` — load the local Docker templates and run the control
+- `startDockerProvisioner()`: load the local Docker templates and run the control
   loop against them.
-- `loadDockerTemplates(filePath)` — read, parse, and validate the template YAML,
+- `loadDockerTemplates(filePath)`: read, parse, and validate the template YAML,
   returning provider-agnostic `ProvisionerTemplate`s with a `DockerTemplateSpec`.
-- `DockerTemplateSpec` — the Docker launch details (`image`, `cpu`, `memory`).
-- `DockerTemplateConfigError` — thrown on any config problem.
+- `DockerTemplateSpec`: the Docker launch details (`image`, `cpu`, `memory`).
+- `DockerTemplateConfigError`: thrown on any config problem.
 
 ## Template config
 
@@ -43,8 +43,9 @@ restarted provisioner can rebuild local capacity from Docker state.
 The provider reports lifecycle through the API:
 
 - `starting` before container creation.
-- `running` on every observe tick for running containers.
-- `stopped` or `failed` after exited containers, then removes them.
+- `running` on every observation cycle for running containers.
+- `stopped` after successful exits, which are removed immediately; failed exits
+  are retained for forensic inspection when retention is enabled.
 - `terminated` for dead/removing containers and stale pre-run `created` containers.
 
 At startup and at the top of every control-loop iteration, the provider lists local
@@ -63,11 +64,94 @@ variables:
 | `SHIPFOX_PROVISIONER_DOCKER_HOST` | no | local Docker socket | Docker daemon host used by dockerode. |
 | `SHIPFOX_PROVISIONER_DOCKER_NETWORK` | no | - | Docker network attached to runner containers, useful for Compose-local API access. |
 | `SHIPFOX_PROVISIONER_DOCKER_EXTRA_HOSTS` | no | - | Comma-separated host mappings added to runner containers, such as `host.docker.internal:host-gateway`. |
+| `SHIPFOX_PROVISIONER_DOCKER_LOG_DRIVER` | no | Docker daemon default | Logging driver for runner containers. Built-in and installed plugin driver names are accepted. |
+| `SHIPFOX_PROVISIONER_DOCKER_LOG_OPTIONS` | no | - | JSON object of string-valued driver options. Requires `SHIPFOX_PROVISIONER_DOCKER_LOG_DRIVER`; option values are never logged. |
+| `SHIPFOX_PROVISIONER_DOCKER_FAILED_CONTAINER_RETENTION_MS` | no | `3600000` | Retention time for failed runner containers, in milliseconds. Set `0` to disable retention. |
+| `SHIPFOX_PROVISIONER_DOCKER_MAX_RETAINED_FAILED_CONTAINERS` | no | `20` | Maximum retained failed runner containers. Set `0` to disable retention. |
 | `SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS` | no | `120000` | Maximum time a `created` container may linger before being reaped as stale. |
 
 The core `SHIPFOX_RUNNER_API_URL` variable is injected into runner containers as
 `SHIPFOX_API_URL` and defaults to `SHIPFOX_API_URL`. Set it when containers reach the
 API through a different hostname or network address than the provisioner process uses.
+
+## Operational logging and failed-container forensics
+
+Provisioner-process logs and runner-container output are separate streams. The
+provisioner uses the shared structured logger. Set `LOG_LEVEL` to the lowest
+level to create, `LOG_PRETTY=true` for human-readable local output,
+`LOG_STDOUT=false` to disable stdout, `LOG_STDOUT_LEVEL` to set the stdout
+threshold, `LOG_FILE` to write a second destination, and `LOG_FILE_LEVEL` to
+set the file threshold. File parent directories are created automatically.
+`LOG_FILE` writes a plain file and does not rotate it. Configure an external
+rotation policy, such as `logrotate`, and keep the rotated files within the
+disk budget for the host. The logger keeps the file open, so use `copytruncate`
+in the rotation rule or restart the provisioner after a rename/create rotation;
+otherwise it continues writing to the old inode. For production, prefer stdout
+and let journald or the container runtime handle rotation.
+
+The provisioner never copies runner stdout or stderr into its own logs. Runner
+containers inherit the Docker daemon logging driver unless
+`SHIPFOX_PROVISIONER_DOCKER_LOG_DRIVER` is set. A provisioner override is
+applied only to containers it creates; existing containers keep their original
+Docker logging configuration. Docker validates driver-specific options when a
+container is created, and option names are reported without option values.
+
+For a local driver with bounded on-host rotation:
+
+```sh
+export SHIPFOX_PROVISIONER_DOCKER_LOG_DRIVER=local
+export SHIPFOX_PROVISIONER_DOCKER_LOG_OPTIONS='{"max-size":"10m","max-file":"5"}'
+```
+
+For journald:
+
+```sh
+export SHIPFOX_PROVISIONER_DOCKER_LOG_DRIVER=journald
+export SHIPFOX_PROVISIONER_DOCKER_LOG_OPTIONS='{"tag":"shipfox-runner/{{.Name}}"}'
+journalctl CONTAINER_NAME=<runner-name> --since today
+```
+
+Ensure journald persistence is enabled (`Storage=persistent` in
+`/etc/systemd/journald.conf`) and that its rotation and disk limits are
+configured before relying on it for incident evidence. Remote drivers should
+be configured with their durable backend's retention, access, and rotation
+policy. For `local` and `json-file`, `docker logs --timestamps --tail 200
+<runner-name>` works only while the container remains; cleanup removes the
+container and its writable layer. For `journald` and remote drivers, use the
+persistent logging backend after cleanup.
+
+Failed containers are retained only when both retention settings are greater
+than zero. The default TTL is one hour and the default bound is 20 containers.
+The TTL uses Docker's `FinishedAt` timestamp. If `FinishedAt` is missing, the
+first observation of the failure is used instead of creation time, so a
+long-running container is not removed immediately. When terminal inspection is
+unavailable, TTL cleanup is deferred while the container remains count-bounded.
+Unknown failure times are ranked as newly observed for count eviction. Expired
+containers and the oldest containers over the count bound are removed on
+observation. Successful, dead, stale-created, and backend-terminated containers
+keep their immediate cleanup behavior. A retained failed container releases
+capacity immediately, and its failure record is emitted once per provisioner
+process. Inspect a failure using the command for its logging driver: use
+`docker logs --timestamps --tail 200 <runner-name>` for `local` or `json-file`,
+`journalctl CONTAINER_NAME=<runner-name>` for `journald`, and the configured
+durable backend for remote drivers. The `none` driver has no container output.
+When Docker runs on a remote host, target the same daemon before using a Docker
+command, for example `DOCKER_HOST="$SHIPFOX_PROVISIONER_DOCKER_HOST" docker
+logs ...`; omit `DOCKER_HOST` when the provisioner uses the local default.
+Run `journalctl` on the Docker daemon host, not on the operator workstation.
+
+## Development
+
+The package's default test command is unit-only and excludes the Docker-dependent
+integration fixture. From the repository root, run
+`pnpm --filter @shipfox/provisioner-docker-provider test:integration` explicitly
+when a Docker daemon and the `alpine:3.20` image are available.
+
+```sh
+turbo check --filter=@shipfox/provisioner-docker-provider
+turbo type --filter=@shipfox/provisioner-docker-provider
+turbo test --filter=@shipfox/provisioner-docker-provider
+```
 
 ## Runner image
 
@@ -86,3 +170,7 @@ the image on the host to pick up a newer release.
 
 The image must not bake in a static manual registration token. It exchanges the single-use
 bootstrap token (`sf_rbt_...`) minted for its runner instance before waiting for assignment.
+
+## License
+
+MIT

--- a/libs/provisioner/docker/package.json
+++ b/libs/provisioner/docker/package.json
@@ -31,7 +31,8 @@
     "build": "shipfox-swc",
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
-    "test": "shipfox-vitest-run",
+    "test": "shipfox-vitest-run --exclude src/docker-engine.integration.test.ts",
+    "test:integration": "shipfox-vitest-run src/docker-engine.integration.test.ts",
     "test:watch": "shipfox-vitest-watch",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"

--- a/libs/provisioner/docker/src/config.test.ts
+++ b/libs/provisioner/docker/src/config.test.ts
@@ -1,0 +1,84 @@
+describe('Docker provisioner configuration', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('uses bounded failed-container retention defaults and inherits the daemon driver', async () => {
+    const {config, dockerLogDriver, dockerLogOptions} = await import('#config.js');
+
+    expect(config.SHIPFOX_PROVISIONER_DOCKER_FAILED_CONTAINER_RETENTION_MS).toBe(3_600_000);
+    expect(config.SHIPFOX_PROVISIONER_DOCKER_MAX_RETAINED_FAILED_CONTAINERS).toBe(20);
+    expect(dockerLogDriver).toBeUndefined();
+    expect(dockerLogOptions).toBeUndefined();
+  });
+
+  it.each(['-1', '1.5'])('rejects invalid retention values: %s', async (value) => {
+    vi.stubEnv('SHIPFOX_PROVISIONER_DOCKER_FAILED_CONTAINER_RETENTION_MS', value);
+    vi.resetModules();
+
+    await expect(import('#config.js')).rejects.toThrow(
+      'SHIPFOX_PROVISIONER_DOCKER_FAILED_CONTAINER_RETENTION_MS',
+    );
+  });
+
+  it('accepts zero to disable retention', async () => {
+    vi.stubEnv('SHIPFOX_PROVISIONER_DOCKER_FAILED_CONTAINER_RETENTION_MS', '0');
+    vi.stubEnv('SHIPFOX_PROVISIONER_DOCKER_MAX_RETAINED_FAILED_CONTAINERS', '0');
+    vi.resetModules();
+
+    const {config} = await import('#config.js');
+
+    expect(config.SHIPFOX_PROVISIONER_DOCKER_FAILED_CONTAINER_RETENTION_MS).toBe(0);
+    expect(config.SHIPFOX_PROVISIONER_DOCKER_MAX_RETAINED_FAILED_CONTAINERS).toBe(0);
+  });
+
+  it('parses string-valued driver options and exposes no option values to callers that log config', async () => {
+    vi.stubEnv('SHIPFOX_PROVISIONER_DOCKER_LOG_DRIVER', 'local');
+    vi.stubEnv(
+      'SHIPFOX_PROVISIONER_DOCKER_LOG_OPTIONS',
+      JSON.stringify({'max-size': '10m', 'max-file': '5'}),
+    );
+    vi.resetModules();
+
+    const {dockerLogDriver, dockerLogOptions} = await import('#config.js');
+
+    expect(dockerLogDriver).toBe('local');
+    expect(dockerLogOptions).toEqual({'max-size': '10m', 'max-file': '5'});
+  });
+
+  it.each([
+    'not-json',
+    '[]',
+    '{"nested":{"value":"secret"}}',
+    '{"max-file":5}',
+  ])('rejects unsafe Docker logging options: %s', async (value) => {
+    vi.stubEnv('SHIPFOX_PROVISIONER_DOCKER_LOG_DRIVER', 'local');
+    vi.stubEnv('SHIPFOX_PROVISIONER_DOCKER_LOG_OPTIONS', value);
+    vi.resetModules();
+
+    await expect(import('#config.js')).rejects.toThrow('SHIPFOX_PROVISIONER_DOCKER_LOG_OPTIONS');
+  });
+
+  it('redacts malformed logging-option values from configuration errors', async () => {
+    const secret = 'splunk-secret-sentinel';
+    vi.stubEnv('SHIPFOX_PROVISIONER_DOCKER_LOG_DRIVER', 'splunk');
+    vi.stubEnv('SHIPFOX_PROVISIONER_DOCKER_LOG_OPTIONS', `{"token":"${secret}`);
+    vi.resetModules();
+
+    const result = import('#config.js');
+    await expect(result).rejects.toThrow(
+      'SHIPFOX_PROVISIONER_DOCKER_LOG_OPTIONS must be valid JSON; the value was not logged because it may contain credentials.',
+    );
+    await expect(result).rejects.not.toThrow(secret);
+  });
+
+  it('rejects logging options without a logging driver', async () => {
+    vi.stubEnv('SHIPFOX_PROVISIONER_DOCKER_LOG_OPTIONS', '{}');
+    vi.resetModules();
+
+    await expect(import('#config.js')).rejects.toThrow(
+      'SHIPFOX_PROVISIONER_DOCKER_LOG_OPTIONS requires SHIPFOX_PROVISIONER_DOCKER_LOG_DRIVER',
+    );
+  });
+});

--- a/libs/provisioner/docker/src/config.ts
+++ b/libs/provisioner/docker/src/config.ts
@@ -16,6 +16,22 @@ export const config = createConfig({
     desc: 'Comma-separated host mappings added to runner containers, such as host.docker.internal:host-gateway. Set it when containers need Docker host names that are not available by default.',
     default: undefined,
   }),
+  SHIPFOX_PROVISIONER_DOCKER_LOG_DRIVER: str({
+    desc: 'Docker logging driver for runner containers. Leave unset to inherit the Docker daemon default. Built-in and installed plugin driver names are accepted.',
+    default: undefined,
+  }),
+  SHIPFOX_PROVISIONER_DOCKER_LOG_OPTIONS: str({
+    desc: 'JSON object of Docker logging-driver options. Every value must be a string, and this setting requires SHIPFOX_PROVISIONER_DOCKER_LOG_DRIVER. Option values are never written to logs because they may contain credentials.',
+    default: undefined,
+  }),
+  SHIPFOX_PROVISIONER_DOCKER_FAILED_CONTAINER_RETENTION_MS: num({
+    desc: 'How long failed runner containers remain available for forensic inspection, in milliseconds. Defaults to one hour. Set 0 to disable failed-container retention.',
+    default: 3_600_000,
+  }),
+  SHIPFOX_PROVISIONER_DOCKER_MAX_RETAINED_FAILED_CONTAINERS: num({
+    desc: 'Maximum number of failed runner containers retained for forensic inspection. Defaults to 20. Set 0 to disable failed-container retention.',
+    default: 20,
+  }),
   SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS: num({
     desc: 'How long a created runner container may remain unstarted before the provisioner reaps it as a stale pre-run resource, in milliseconds.',
     default: 120_000,
@@ -25,6 +41,26 @@ export const config = createConfig({
 export const dockerExtraHosts = parseDockerExtraHosts(
   config.SHIPFOX_PROVISIONER_DOCKER_EXTRA_HOSTS,
 );
+export const dockerLogDriver = config.SHIPFOX_PROVISIONER_DOCKER_LOG_DRIVER?.trim() || undefined;
+export const dockerLogOptions = parseDockerLogOptions(
+  config.SHIPFOX_PROVISIONER_DOCKER_LOG_OPTIONS,
+  dockerLogDriver,
+);
+
+for (const [name, value] of [
+  [
+    'SHIPFOX_PROVISIONER_DOCKER_FAILED_CONTAINER_RETENTION_MS',
+    config.SHIPFOX_PROVISIONER_DOCKER_FAILED_CONTAINER_RETENTION_MS,
+  ],
+  [
+    'SHIPFOX_PROVISIONER_DOCKER_MAX_RETAINED_FAILED_CONTAINERS',
+    config.SHIPFOX_PROVISIONER_DOCKER_MAX_RETAINED_FAILED_CONTAINERS,
+  ],
+] as const) {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative integer; got ${value}.`);
+  }
+}
 
 if (
   !Number.isInteger(config.SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS) ||
@@ -41,4 +77,41 @@ function parseDockerExtraHosts(value: string | undefined): string[] | undefined 
     .map((entry) => entry.trim())
     .filter(Boolean);
   return hosts && hosts.length > 0 ? hosts : undefined;
+}
+
+function parseDockerLogOptions(
+  value: string | undefined,
+  driver: string | undefined,
+): Readonly<Record<string, string>> | undefined {
+  if (value === undefined) return undefined;
+  if (driver === undefined) {
+    throw new Error(
+      'SHIPFOX_PROVISIONER_DOCKER_LOG_OPTIONS requires SHIPFOX_PROVISIONER_DOCKER_LOG_DRIVER.',
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new Error(
+      'SHIPFOX_PROVISIONER_DOCKER_LOG_OPTIONS must be valid JSON; the value was not logged because it may contain credentials.',
+    );
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error(
+      'SHIPFOX_PROVISIONER_DOCKER_LOG_OPTIONS must be a JSON object with string values; arrays and null are not allowed.',
+    );
+  }
+
+  for (const [key, optionValue] of Object.entries(parsed)) {
+    if (typeof optionValue !== 'string') {
+      throw new Error(
+        `SHIPFOX_PROVISIONER_DOCKER_LOG_OPTIONS must contain only string values; option "${key}" is ${typeof optionValue}.`,
+      );
+    }
+  }
+
+  return parsed as Readonly<Record<string, string>>;
 }

--- a/libs/provisioner/docker/src/docker-engine.integration.test.ts
+++ b/libs/provisioner/docker/src/docker-engine.integration.test.ts
@@ -1,10 +1,11 @@
 import {execFileSync} from 'node:child_process';
 import {randomUUID} from 'node:crypto';
+import Docker from 'dockerode';
 import {createDockerEngine} from '#docker-engine.js';
 
 describe.skipIf(!hasDockerDaemon())('DockerEngine integration', () => {
-  it('creates, lists, inspects, and removes a managed container', async () => {
-    const engine = createDockerEngine();
+  it('creates, lists, inspects, and removes a managed container', {timeout: 60_000}, async () => {
+    const engine = createDockerEngine({loggingDriver: 'local'});
     const name = `shipfox-test-${randomUUID()}`;
 
     try {
@@ -20,6 +21,8 @@ describe.skipIf(!hasDockerDaemon())('DockerEngine integration', () => {
         memoryBytes: 32 * 1024 * 1024,
       });
 
+      const inspected = await new Docker().getContainer(name).inspect();
+      expect(inspected.HostConfig?.LogConfig?.Type).toBe('local');
       const containers = await engine.listManaged('00000000-0000-4000-8000-000000000001');
 
       expect(containers.some((container) => container.name === name)).toBe(true);

--- a/libs/provisioner/docker/src/docker-engine.test.ts
+++ b/libs/provisioner/docker/src/docker-engine.test.ts
@@ -44,6 +44,55 @@ describe('createDockerEngine', () => {
     expect(docker.started).toEqual(['runner-1']);
   });
 
+  it('omits LogConfig when the provisioner inherits the daemon driver', async () => {
+    const docker = fakeDocker();
+    const engine = createDockerEngine({docker: docker as never});
+
+    await engine.createAndStart({
+      name: 'runner-1',
+      image: 'runner:latest',
+      env: {},
+      labels: {'shipfox.provisioner_id': 'p1'},
+      nanoCpus: 1,
+      memoryBytes: 1,
+    });
+
+    expect(
+      (docker.created[0] as {HostConfig: {LogConfig?: unknown}}).HostConfig.LogConfig,
+    ).toBeUndefined();
+  });
+
+  it('passes a configured logging driver and options exactly to Docker', async () => {
+    const docker = fakeDocker();
+    const engine = createDockerEngine({
+      docker: docker as never,
+      loggingDriver: 'local',
+      loggingOptions: {'max-size': '10m', 'max-file': '5'},
+    });
+
+    await engine.createAndStart({
+      name: 'runner-1',
+      image: 'runner:latest',
+      env: {},
+      labels: {'shipfox.provisioner_id': 'p1'},
+      nanoCpus: 1,
+      memoryBytes: 1,
+    });
+
+    expect(docker.created[0]).toMatchObject({
+      HostConfig: {
+        LogConfig: {Type: 'local', Config: {'max-size': '10m', 'max-file': '5'}},
+      },
+    });
+  });
+
+  it('exposes the effective daemon logging driver', async () => {
+    const docker = fakeDocker({loggingDriver: 'journald'});
+    const engine = createDockerEngine({docker: docker as never});
+
+    await expect(engine.getInfo()).resolves.toEqual({loggingDriver: 'journald'});
+  });
+
   it('removes a created container when start fails', async () => {
     const docker = fakeDocker({startError: new Error('start failed')});
     const engine = createDockerEngine({docker: docker as never});
@@ -107,7 +156,21 @@ describe('createDockerEngine', () => {
           Created: 1,
         },
       ],
-      inspectById: new Map([['id1', {State: {ExitCode: 137, OOMKilled: true}}]]),
+      inspectById: new Map([
+        [
+          'id1',
+          {
+            Config: {Image: 'runner:latest'},
+            HostConfig: {LogConfig: {Type: 'local'}},
+            State: {
+              ExitCode: 137,
+              OOMKilled: true,
+              StartedAt: '2026-01-01T00:00:01.000Z',
+              FinishedAt: '2026-01-01T00:00:03.000Z',
+            },
+          },
+        ],
+      ]),
     });
     const engine = createDockerEngine({docker: docker as never});
 
@@ -119,9 +182,49 @@ describe('createDockerEngine', () => {
       state: 'exited',
       exitCode: 137,
       oomKilled: true,
+      image: 'runner:latest',
+      loggingDriver: 'local',
+      startedAt: new Date('2026-01-01T00:00:01.000Z'),
+      finishedAt: new Date('2026-01-01T00:00:03.000Z'),
     });
   });
 
+  it('does not inspect running containers during observation', async () => {
+    const docker = fakeDocker({
+      containers: [
+        {
+          Id: 'id1',
+          Names: ['/runner-1'],
+          Labels: {'shipfox.provisioner_id': 'p1'},
+          State: 'running',
+          Created: 1,
+        },
+      ],
+    });
+    const engine = createDockerEngine({docker: docker as never, loggingDriver: 'local'});
+    const result = await engine.listManaged('p1');
+    expect(docker.inspected).toEqual([]);
+    expect(result[0]?.loggingDriver).toBe('local');
+  });
+  it('keeps the observation pass alive when a terminal inspect fails', async () => {
+    const docker = fakeDocker({
+      containers: [
+        {
+          Id: 'id1',
+          Names: ['/runner-1'],
+          Labels: {'shipfox.provisioner_id': 'p1'},
+          State: 'exited',
+          Status: 'Exited (1) 2 seconds ago',
+          Created: 1,
+        },
+      ],
+      inspectErrorById: new Map([['id1', new Error('temporary inspect failure')]]),
+    });
+    const engine = createDockerEngine({docker: docker as never});
+    await expect(engine.listManaged('p1')).resolves.toMatchObject([
+      {id: 'id1', state: 'exited', exitCode: 1},
+    ]);
+  });
   it('keeps listed exited containers when inspect races with removal', async () => {
     const docker = fakeDocker({
       containers: [
@@ -146,6 +249,7 @@ describe('createDockerEngine', () => {
         labels: {'shipfox.provisioner_id': 'p1'},
         state: 'exited',
         createdAt: new Date(1000),
+        terminalInspectFailed: true,
       },
     ]);
   });
@@ -186,12 +290,14 @@ function fakeDocker(
     inspectById?: Map<string, unknown>;
     inspectErrorById?: Map<string, Error>;
     killErrorById?: Map<string, Error>;
+    loggingDriver?: string;
   } = {},
 ) {
   const pulled: string[] = [];
   const created: unknown[] = [];
   const started: string[] = [];
   const removed: string[] = [];
+  const inspected: string[] = [];
   const missingImages = options.missingImages ?? new Set<string>();
 
   return {
@@ -199,10 +305,12 @@ function fakeDocker(
     created,
     started,
     removed,
+    inspected,
     modem: {
       followProgress: (_stream: NodeJS.ReadableStream, callback: (error: Error | null) => void) =>
         callback(null),
     },
+    info: () => Promise.resolve({LoggingDriver: options.loggingDriver ?? 'json-file'}),
     getImage: (image: string) => ({
       inspect: () => {
         if (missingImages.has(image)) {
@@ -239,6 +347,7 @@ function fakeDocker(
     },
     getContainer: (id: string) => ({
       inspect: () => {
+        inspected.push(id);
         const inspectError = options.inspectErrorById?.get(id);
         if (inspectError) return Promise.reject(inspectError);
         return Promise.resolve(options.inspectById?.get(id) ?? {});

--- a/libs/provisioner/docker/src/docker-engine.ts
+++ b/libs/provisioner/docker/src/docker-engine.ts
@@ -2,6 +2,7 @@ import Docker from 'dockerode';
 import {SHIPFOX_LABELS} from '#container-identity.js';
 
 const LEADING_SLASH = /^\//;
+const DOCKER_EXIT_STATUS = /^Exited \((-?\d+)\)/;
 
 export type DockerEngineErrorReason =
   | 'daemon-unreachable'
@@ -40,10 +41,20 @@ export interface DockerContainerView {
   readonly state: DockerContainerState;
   readonly exitCode?: number;
   readonly oomKilled?: boolean;
+  readonly image?: string;
+  readonly loggingDriver?: string;
   readonly createdAt: Date;
+  readonly startedAt?: Date;
+  readonly finishedAt?: Date;
+  readonly terminalInspectFailed?: boolean;
+}
+
+export interface DockerEngineInfo {
+  readonly loggingDriver: string;
 }
 
 export interface DockerEngine {
+  getInfo(): Promise<DockerEngineInfo>;
   ensureImage(image: string): Promise<void>;
   createAndStart(args: {
     name: string;
@@ -62,13 +73,33 @@ export interface CreateDockerEngineOptions {
   readonly host?: string;
   readonly network?: string;
   readonly extraHosts?: readonly string[];
+  readonly loggingDriver?: string;
+  readonly loggingOptions?: Readonly<Record<string, string>>;
   readonly docker?: Docker;
 }
 
 export function createDockerEngine(options: CreateDockerEngineOptions = {}): DockerEngine {
   const docker = options.docker ?? new Docker(dockerOptionsForHost(options.host));
+  let effectiveLoggingDriver: string | undefined;
 
   return {
+    async getInfo() {
+      try {
+        const info = await docker.info();
+        const loggingDriver =
+          typeof info?.LoggingDriver === 'string' && info.LoggingDriver.length > 0
+            ? info.LoggingDriver
+            : undefined;
+        if (!loggingDriver) {
+          throw new Error('Docker system information did not include LoggingDriver.');
+        }
+        effectiveLoggingDriver = loggingDriver;
+        return {loggingDriver};
+      } catch (error) {
+        throw mapError(error, 'unknown', 'Cannot inspect Docker system information.');
+      }
+    },
+
     async ensureImage(image) {
       try {
         await docker.getImage(image).inspect();
@@ -102,7 +133,11 @@ export function createDockerEngine(options: CreateDockerEngineOptions = {}): Doc
     },
 
     async createAndStart(args) {
-      await this.ensureImage(args.image);
+      try {
+        await this.ensureImage(args.image);
+      } catch (error) {
+        throw addLoggingDriverContext(error, selectedLoggingDriver());
+      }
       let container: Docker.Container | undefined;
 
       try {
@@ -117,13 +152,27 @@ export function createDockerEngine(options: CreateDockerEngineOptions = {}): Doc
             RestartPolicy: {Name: 'no'},
             ...(options.network ? {NetworkMode: options.network} : {}),
             ...(options.extraHosts ? {ExtraHosts: [...options.extraHosts]} : {}),
+            ...(options.loggingDriver
+              ? {
+                  LogConfig: {
+                    Type: options.loggingDriver,
+                    Config: {...(options.loggingOptions ?? {})},
+                  },
+                }
+              : {}),
           },
         });
       } catch (error) {
-        throw mapError(
-          error,
-          isConflict(error) ? 'name-conflict' : 'create-failed',
-          'Cannot create runner container.',
+        const selectedDriver = options.loggingDriver ?? effectiveLoggingDriver;
+        throw addLoggingDriverContext(
+          mapError(
+            error,
+            isConflict(error) ? 'name-conflict' : 'create-failed',
+            selectedDriver
+              ? `Cannot create runner container with logging driver ${selectedDriver}.`
+              : 'Cannot create runner container with the Docker daemon logging driver.',
+          ),
+          selectedDriver,
         );
       }
 
@@ -131,7 +180,17 @@ export function createDockerEngine(options: CreateDockerEngineOptions = {}): Doc
         await container.start();
       } catch (error) {
         await removeContainer(container).catch(() => undefined);
-        throw mapError(error, 'start-failed', 'Cannot start runner container.');
+        const selectedDriver = selectedLoggingDriver();
+        throw addLoggingDriverContext(
+          mapError(
+            error,
+            'start-failed',
+            selectedDriver
+              ? `Cannot start runner container with logging driver ${selectedDriver}.`
+              : 'Cannot start runner container with the Docker daemon logging driver.',
+          ),
+          selectedDriver,
+        );
       }
     },
 
@@ -145,19 +204,46 @@ export function createDockerEngine(options: CreateDockerEngineOptions = {}): Doc
         return Promise.all(
           containers.map(async (container) => {
             const state = normalizeState(container.State);
-            const inspected = state === 'exited' ? await inspectContainer(container.Id) : undefined;
+            const inspectTerminalState = state === 'exited' || state === 'dead';
+            let inspected: Docker.ContainerInspectInfo | undefined;
+            let terminalInspectFailed = false;
+            if (inspectTerminalState) {
+              try {
+                inspected = await inspectContainer(container.Id);
+                terminalInspectFailed = !inspected;
+              } catch {
+                // Keep one transient or racing inspect from failing the entire observation pass.
+                inspected = undefined;
+                terminalInspectFailed = true;
+              }
+            }
+            const startedAt = parseDockerDate(inspected?.State?.StartedAt);
+            const finishedAt = parseDockerDate(inspected?.State?.FinishedAt);
+            const loggingDriver =
+              inspected?.HostConfig?.LogConfig?.Type ??
+              options.loggingDriver ??
+              effectiveLoggingDriver;
+            const createdAt = new Date(container.Created * 1000);
+            const exitCode =
+              inspected?.State?.ExitCode ??
+              parseDockerExitCode((container as {Status?: string}).Status);
             return {
               id: container.Id,
               name: container.Names?.[0]?.replace(LEADING_SLASH, '') ?? container.Id,
               labels: container.Labels ?? {},
               state,
-              ...(inspected?.State?.ExitCode !== undefined
-                ? {exitCode: inspected.State.ExitCode}
-                : {}),
+              ...(exitCode !== undefined ? {exitCode} : {}),
               ...(inspected?.State?.OOMKilled !== undefined
                 ? {oomKilled: inspected.State.OOMKilled}
                 : {}),
-              createdAt: new Date(container.Created * 1000),
+              ...(container.Image || inspected?.Config?.Image
+                ? {image: inspected?.Config?.Image ?? container.Image}
+                : {}),
+              ...(loggingDriver ? {loggingDriver} : {}),
+              createdAt: Number.isNaN(createdAt.getTime()) ? new Date() : createdAt,
+              ...(startedAt ? {startedAt} : {}),
+              ...(finishedAt ? {finishedAt} : {}),
+              ...(terminalInspectFailed ? {terminalInspectFailed: true} : {}),
             };
           }),
         );
@@ -193,6 +279,10 @@ export function createDockerEngine(options: CreateDockerEngineOptions = {}): Doc
       }
     },
   };
+
+  function selectedLoggingDriver(): string | undefined {
+    return options.loggingDriver ?? effectiveLoggingDriver;
+  }
 
   async function inspectContainer(id: string): Promise<Docker.ContainerInspectInfo | undefined> {
     try {
@@ -232,6 +322,18 @@ function normalizeState(state: string | undefined): DockerContainerState {
   }
 }
 
+function parseDockerExitCode(status: string | undefined): number | undefined {
+  const match = status?.match(DOCKER_EXIT_STATUS);
+  if (!match) return undefined;
+  const exitCode = Number(match[1]);
+  return Number.isInteger(exitCode) ? exitCode : undefined;
+}
+function parseDockerDate(value: string | undefined): Date | undefined {
+  if (!value || value.startsWith('0001-01-01T00:00:00Z')) return undefined;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
 function mapError(
   error: unknown,
   fallback: DockerEngineErrorReason,
@@ -246,6 +348,22 @@ function mapError(
     });
   if (isConflict(error)) return new DockerEngineError('name-conflict', message, {cause: error});
   return new DockerEngineError(fallback, message, {cause: error});
+}
+
+function addLoggingDriverContext(error: unknown, driver: string | undefined): DockerEngineError {
+  if (!driver) {
+    if (error instanceof DockerEngineError) return error;
+    return mapError(error, 'unknown', 'Docker runner launch failed.');
+  }
+  if (error instanceof DockerEngineError) {
+    if (error.message.includes('logging driver')) return error;
+    return new DockerEngineError(
+      error.reason,
+      `${error.message} Logging driver selected: ${driver}.`,
+      {cause: error},
+    );
+  }
+  return mapError(error, 'unknown', `Docker runner launch failed with logging driver ${driver}.`);
 }
 
 export function dockerOptionsForHost(host: string | undefined): Docker.DockerOptions {

--- a/libs/provisioner/docker/src/episodes.test.ts
+++ b/libs/provisioner/docker/src/episodes.test.ts
@@ -1,0 +1,66 @@
+import {closeEpisode, type EpisodeState, recordEpisode} from '#episodes.js';
+
+describe('keyed diagnostic episodes', () => {
+  it.each([
+    ['opens once and suppresses repeats', 'target-a', 'failure-a'],
+    ['reopens after close', 'target-a', 'failure-a'],
+    ['changes when the fingerprint changes', 'target-a', 'failure-a'],
+  ])('%s', (_name, target, fingerprint) => {
+    const episodes = new Map<string, EpisodeState>();
+    const first = recordEpisode(episodes, target, fingerprint, new Date(1));
+    const repeat = recordEpisode(episodes, target, fingerprint, new Date(2));
+
+    expect(first.transition).toBe('opened');
+    expect(repeat.transition).toBe('suppressed');
+    expect(repeat.state).toMatchObject({attempts: 2, suppressed: 1});
+  });
+
+  it('closes and reopens the same target as a new episode', () => {
+    const episodes = new Map<string, EpisodeState>();
+    recordEpisode(episodes, 'target-a', 'failure-a', new Date(1));
+    closeEpisode(episodes, 'target-a');
+
+    const reopened = recordEpisode(episodes, 'target-a', 'failure-a', new Date(3));
+
+    expect(reopened.transition).toBe('opened');
+    expect(reopened.state).toMatchObject({attempts: 1, suppressed: 0});
+  });
+
+  it('keeps cleanup failures for A and B independent', () => {
+    const episodes = new Map<string, EpisodeState>();
+    const a = recordEpisode(episodes, 'cleanup:A', 'remove-failed', new Date(1));
+    const b = recordEpisode(episodes, 'cleanup:B', 'remove-failed', new Date(2));
+    const aRepeat = recordEpisode(episodes, 'cleanup:A', 'remove-failed', new Date(3));
+
+    expect(a.transition).toBe('opened');
+    expect(b.transition).toBe('opened');
+    expect(aRepeat.transition).toBe('suppressed');
+    expect(episodes.size).toBe(2);
+  });
+  it('reminds by elapsed time instead of observation count', () => {
+    const episodes = new Map<string, EpisodeState>();
+    recordEpisode(episodes, 'target-a', 'failure-a', new Date(0), {
+      reminderIntervalMs: 100,
+    });
+    const beforeInterval = recordEpisode(episodes, 'target-a', 'failure-a', new Date(99), {
+      reminderIntervalMs: 100,
+    });
+    const atInterval = recordEpisode(episodes, 'target-a', 'failure-a', new Date(100), {
+      reminderIntervalMs: 100,
+    });
+    expect(beforeInterval.reminder).toBe(false);
+    expect(atInterval.reminder).toBe(true);
+  });
+  it('returns a bounded recovery summary when an episode closes', () => {
+    const episodes = new Map<string, EpisodeState>();
+    recordEpisode(episodes, 'target-a', 'failure-a', new Date(100));
+    recordEpisode(episodes, 'target-a', 'failure-a', new Date(200));
+    expect(closeEpisode(episodes, 'target-a', new Date(350))).toMatchObject({
+      key: 'target-a',
+      fingerprint: 'failure-a',
+      durationMs: 250,
+      attempts: 2,
+      suppressed: 1,
+    });
+  });
+});

--- a/libs/provisioner/docker/src/episodes.test.ts
+++ b/libs/provisioner/docker/src/episodes.test.ts
@@ -3,8 +3,6 @@ import {closeEpisode, type EpisodeState, recordEpisode} from '#episodes.js';
 describe('keyed diagnostic episodes', () => {
   it.each([
     ['opens once and suppresses repeats', 'target-a', 'failure-a'],
-    ['reopens after close', 'target-a', 'failure-a'],
-    ['changes when the fingerprint changes', 'target-a', 'failure-a'],
   ])('%s', (_name, target, fingerprint) => {
     const episodes = new Map<string, EpisodeState>();
     const first = recordEpisode(episodes, target, fingerprint, new Date(1));
@@ -13,6 +11,13 @@ describe('keyed diagnostic episodes', () => {
     expect(first.transition).toBe('opened');
     expect(repeat.transition).toBe('suppressed');
     expect(repeat.state).toMatchObject({attempts: 2, suppressed: 1});
+  });
+  it('opens a changed fingerprint as a new transition', () => {
+    const episodes = new Map<string, EpisodeState>();
+    recordEpisode(episodes, 'target-a', 'failure-a', new Date(1));
+    const changed = recordEpisode(episodes, 'target-a', 'failure-b', new Date(2));
+    expect(changed.transition).toBe('changed');
+    expect(changed.state).toMatchObject({fingerprint: 'failure-b', attempts: 2});
   });
 
   it('closes and reopens the same target as a new episode', () => {

--- a/libs/provisioner/docker/src/episodes.ts
+++ b/libs/provisioner/docker/src/episodes.ts
@@ -1,0 +1,87 @@
+export interface EpisodeState {
+  readonly fingerprint: string;
+  readonly startedAt: Date;
+  readonly attempts: number;
+  readonly suppressed: number;
+  readonly lastReminderAt?: Date | undefined;
+}
+
+export type EpisodeTransition = 'opened' | 'changed' | 'suppressed';
+
+export interface EpisodeUpdate {
+  readonly transition: EpisodeTransition;
+  readonly state: EpisodeState;
+  readonly reminder: boolean;
+}
+
+export interface EpisodeRecovery {
+  readonly key: string;
+  readonly fingerprint: string;
+  readonly startedAt: Date;
+  readonly endedAt: Date;
+  readonly durationMs: number;
+  readonly attempts: number;
+  readonly suppressed: number;
+}
+
+const REMINDER_INTERVAL_MS = 60_000;
+
+/**
+ * Record one observation of a keyed diagnostic episode. The map is the only mutable
+ * ownership point; callers decide whether an opened/changed/reminder update is logged.
+ */
+export function recordEpisode(
+  episodes: Map<string, EpisodeState>,
+  key: string,
+  fingerprint: string,
+  at: Date,
+  options?: {readonly reminderIntervalMs?: number},
+): EpisodeUpdate {
+  const reminderIntervalMs = options?.reminderIntervalMs ?? REMINDER_INTERVAL_MS;
+  const previous = episodes.get(key);
+  if (!previous) {
+    const state = {fingerprint, startedAt: at, attempts: 1, suppressed: 0};
+    episodes.set(key, state);
+    return {transition: 'opened', state, reminder: false};
+  }
+  if (previous.fingerprint !== fingerprint) {
+    const state = {
+      ...previous,
+      fingerprint,
+      attempts: previous.attempts + 1,
+      lastReminderAt: at,
+    };
+    episodes.set(key, state);
+    return {transition: 'changed', state, reminder: false};
+  }
+  const reminder =
+    at.getTime() - (previous.lastReminderAt?.getTime() ?? previous.startedAt.getTime()) >=
+    reminderIntervalMs;
+  const state = {
+    ...previous,
+    attempts: previous.attempts + 1,
+    suppressed: previous.suppressed + 1,
+    ...(reminder ? {lastReminderAt: at} : {}),
+  };
+  episodes.set(key, state);
+  return {transition: 'suppressed', state, reminder};
+}
+
+export function closeEpisode(
+  episodes: Map<string, EpisodeState>,
+  key: string,
+  endedAt = new Date(),
+): EpisodeRecovery | undefined {
+  const state = episodes.get(key);
+  if (!state) return undefined;
+  episodes.delete(key);
+  return {
+    key,
+    fingerprint: state.fingerprint,
+    startedAt: state.startedAt,
+    endedAt,
+    durationMs: Math.max(0, endedAt.getTime() - state.startedAt.getTime()),
+    attempts: state.attempts,
+    suppressed: state.suppressed,
+  };
+}

--- a/libs/provisioner/docker/src/lifecycle.test.ts
+++ b/libs/provisioner/docker/src/lifecycle.test.ts
@@ -95,6 +95,15 @@ describe('createDockerLifecycle', () => {
     );
   });
 
+  it('marks a buffered starting report as incomplete', async () => {
+    const engine = fakeEngine();
+    const client = fakeClient({reportErrors: [new Error('api unavailable')]});
+    const lifecycle = makeLifecycle({engine, client});
+    const outcome = await lifecycle.launch(launch());
+    expect(outcome).toEqual({containerStarted: true, identityAttached: true, reported: false});
+    expect(engine.created).toHaveLength(1);
+    expect(client.reportBodies[0]?.events[0]).toMatchObject({state: 'starting'});
+  });
   it('does not report a started container as failed when identity attachment fails', async () => {
     const error = new Error('identity API unavailable');
     const engine = fakeEngine();

--- a/libs/provisioner/docker/src/lifecycle.test.ts
+++ b/libs/provisioner/docker/src/lifecycle.test.ts
@@ -16,7 +16,7 @@ import {createDockerLifecycle} from '#lifecycle.js';
 import type {DockerTemplateSpec} from '#templates.js';
 
 const observability = vi.hoisted(() => ({
-  logger: {error: vi.fn(), info: vi.fn(), warn: vi.fn()},
+  logger: {debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn()},
 }));
 
 vi.mock('@shipfox/node-opentelemetry', () => ({logger: () => observability.logger}));
@@ -77,6 +77,45 @@ describe('createDockerLifecycle', () => {
     expect(client.reportBodies[0]?.events[0]?.reason).toBe('start-failed');
   });
 
+  it('does not report a started container as failed when starting-report delivery fails', async () => {
+    const error = new ProvisionerAuthenticationError(401, 'report runner instances');
+    const engine = fakeEngine();
+    const client = fakeClient({reportErrors: [error]});
+    const lifecycle = makeLifecycle({engine, client});
+
+    await expect(lifecycle.launch(launch())).rejects.toThrow(error);
+
+    expect(engine.created).toHaveLength(1);
+    expect(client.reportBodies.flatMap((body) => body.events.map((event) => event.state))).toEqual([
+      'starting',
+    ]);
+    expect(observability.logger.error).not.toHaveBeenCalledWith(
+      expect.objectContaining({event: 'runner.container_launch_failed'}),
+      expect.any(String),
+    );
+  });
+
+  it('does not report a started container as failed when identity attachment fails', async () => {
+    const error = new Error('identity API unavailable');
+    const engine = fakeEngine();
+    const client = fakeClient({attachErrors: [error]});
+    const lifecycle = makeLifecycle({engine, client});
+
+    const outcome = await lifecycle.launch(launch());
+
+    expect(engine.created).toHaveLength(1);
+    expect(client.reportBodies).toEqual([]);
+    expect(outcome).toEqual({containerStarted: true, identityAttached: false, reported: false});
+    expect(observability.logger.debug).toHaveBeenCalledWith(
+      expect.objectContaining({event: 'runner.container_identity_attachment_failed'}),
+      'Failed to attach provider identity after runner container started',
+    );
+    expect(observability.logger.error).not.toHaveBeenCalledWith(
+      expect.objectContaining({event: 'runner.container_launch_failed'}),
+      expect.any(String),
+    );
+  });
+
   it('assigns an enrolled observed runner through its container identity', async () => {
     const engine = fakeEngine({
       containers: [
@@ -119,6 +158,54 @@ describe('createDockerLifecycle', () => {
     ]);
   });
 
+  it('reports a failure again after the retained container disappears and is recreated', async () => {
+    const containers = [container({state: 'exited', exitCode: 1})];
+    const engine = fakeEngine({containers});
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({
+      engine,
+      client,
+      failedContainerRetentionMs: 3_600_000,
+      maxRetainedFailedContainers: 20,
+    });
+
+    await lifecycle.observe();
+    containers.splice(0, 1);
+    await lifecycle.observe();
+    containers.push(container({state: 'exited', exitCode: 1}));
+    await lifecycle.observe();
+
+    expect(
+      observability.logger.error.mock.calls.filter(
+        ([fields]) => fields?.event === 'runner.container_failed',
+      ),
+    ).toHaveLength(2);
+  });
+
+  it('resets retained failure state when a container becomes live again', async () => {
+    const containers = [container({state: 'exited', exitCode: 1})];
+    const engine = fakeEngine({containers});
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({
+      engine,
+      client,
+      failedContainerRetentionMs: 3_600_000,
+      maxRetainedFailedContainers: 20,
+    });
+
+    await lifecycle.observe();
+    containers[0] = container({state: 'running'});
+    await lifecycle.observe();
+    containers[0] = container({state: 'exited', exitCode: 1});
+    await lifecycle.observe();
+
+    expect(
+      observability.logger.error.mock.calls.filter(
+        ([fields]) => fields?.event === 'runner.container_failed',
+      ),
+    ).toHaveLength(2);
+  });
+
   it('reports terminal exited containers and removes them only after report succeeds', async () => {
     const engine = fakeEngine({
       containers: [container({state: 'exited', exitCode: 0})],
@@ -143,6 +230,7 @@ describe('createDockerLifecycle', () => {
 
     expect(observability.logger.error).toHaveBeenCalledWith(
       expect.objectContaining({
+        event: 'runner.container_failed',
         providerRunnerId: 'runner-1',
         containerId: 'runner-1',
         containerName: 'runner-1',
@@ -150,9 +238,30 @@ describe('createDockerLifecycle', () => {
         oomKilled: false,
         reason: 'exit-code-1',
       }),
-      'Provisioned runner container exited unsuccessfully',
+      'Runner container failed',
     );
     expect(engine.removed).toEqual(['runner-1']);
+  });
+
+  it('uses first-observed time instead of creation time for unknown runtime', async () => {
+    const engine = fakeEngine({
+      containers: [
+        container({
+          state: 'exited',
+          exitCode: 1,
+          createdAt: new Date('2025-01-01T00:00:00.000Z'),
+          startedAt: new Date('2026-01-01T00:09:00.000Z'),
+        }),
+      ],
+    });
+    const lifecycle = makeLifecycle({engine});
+
+    await lifecycle.observe();
+
+    expect(observability.logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({event: 'runner.container_failed', runtimeMs: 60_000}),
+      'Runner container failed',
+    );
   });
 
   it('buffers terminal reports and still removes containers when reporting transiently fails', async () => {
@@ -225,6 +334,45 @@ describe('createDockerLifecycle', () => {
     expect(engine.killedAndRemoved).toEqual(['runner-1']);
   });
 
+  it('logs stale cleanup as requested when kill-and-remove fails', async () => {
+    const error = new DockerEngineError('unknown', 'daemon unavailable');
+    const containers = [
+      container({
+        state: 'created',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      }),
+    ];
+    const engine = fakeEngine({
+      containers,
+      killAndRemoveError: error,
+    });
+    const lifecycle = makeLifecycle({engine, registrationDeadlineMs: 60_000});
+
+    await expect(lifecycle.observe()).rejects.toThrow(error);
+    await expect(lifecycle.observe()).rejects.toThrow(error);
+    containers[0] = container({state: 'running'});
+    await lifecycle.observe();
+    containers[0] = container({
+      state: 'created',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+    await expect(lifecycle.observe()).rejects.toThrow(error);
+
+    expect(observability.logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({event: 'runner.container_stale_reap_requested'}),
+      'Stale runner container reap requested before registration',
+    );
+    expect(
+      observability.logger.info.mock.calls.filter(
+        ([fields]) => fields?.event === 'runner.container_stale_reap_requested',
+      ),
+    ).toHaveLength(2);
+    expect(observability.logger.info).not.toHaveBeenCalledWith(
+      expect.objectContaining({event: 'runner.container_stale_reaped'}),
+      expect.any(String),
+    );
+  });
+
   it('marks OOM exits as failed with an oom reason', async () => {
     const engine = fakeEngine({
       containers: [container({state: 'exited', exitCode: 137, oomKilled: true})],
@@ -235,6 +383,343 @@ describe('createDockerLifecycle', () => {
     await lifecycle.observe();
 
     expect(client.reportBodies[0]?.events[0]).toMatchObject({state: 'failed', reason: 'oom'});
+  });
+
+  it('retains failed containers, releases capacity, and suppresses duplicate failure reports', async () => {
+    const engine = fakeEngine({containers: [container({state: 'exited', exitCode: 1})]});
+    const tracker = testTracker();
+    tracker.recordStarting({providerRunnerId: 'runner-1', templateKey: 'small'});
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({
+      engine,
+      client,
+      tracker,
+      failedContainerRetentionMs: 3_600_000,
+      maxRetainedFailedContainers: 20,
+    });
+
+    await lifecycle.observe();
+    await lifecycle.observe();
+
+    expect(engine.removed).toEqual([]);
+    expect(tracker.countsByTemplate()).toEqual(new Map());
+    expect(client.reportBodies.flatMap((body) => body.events)).toHaveLength(1);
+    expect(observability.logger.error).toHaveBeenCalledTimes(1);
+    expect(observability.logger.info).not.toHaveBeenCalledWith(
+      expect.objectContaining({event: 'runner.cleanup_pass_completed'}),
+      expect.any(String),
+    );
+  });
+
+  it('removes expired retained failures using FinishedAt', async () => {
+    const engine = fakeEngine({
+      containers: [
+        container({
+          state: 'exited',
+          exitCode: 1,
+          finishedAt: new Date('2026-01-01T00:00:00.000Z'),
+        }),
+      ],
+    });
+    const lifecycle = makeLifecycle({
+      engine,
+      failedContainerRetentionMs: 60_000,
+      maxRetainedFailedContainers: 20,
+    });
+
+    await lifecycle.observe();
+
+    expect(engine.removed).toEqual(['runner-1']);
+    expect(observability.logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'runner.cleanup_pass_completed',
+        expired: 1,
+      }),
+      'Failed runner container cleanup pass completed',
+    );
+  });
+
+  it('reports an expired failure before removing its container', async () => {
+    const operations: string[] = [];
+    const engine = fakeEngine({
+      containers: [
+        container({
+          state: 'exited',
+          exitCode: 1,
+          finishedAt: new Date('2026-01-01T00:00:00.000Z'),
+        }),
+      ],
+      onRemove: () => operations.push('remove'),
+    });
+    const client = fakeClient({onReport: () => operations.push('report')});
+    const lifecycle = makeLifecycle({
+      engine,
+      client,
+      failedContainerRetentionMs: 60_000,
+      maxRetainedFailedContainers: 20,
+    });
+    await lifecycle.observe();
+    expect(operations).toEqual(['report', 'remove']);
+  });
+  it('evicts the oldest retained failures when the count limit is exceeded', async () => {
+    const engine = fakeEngine({
+      containers: [
+        container({
+          name: 'oldest',
+          state: 'exited',
+          exitCode: 1,
+          finishedAt: new Date('2026-01-01T00:00:01.000Z'),
+        }),
+        container({
+          name: 'newer',
+          state: 'exited',
+          exitCode: 1,
+          finishedAt: new Date('2026-01-01T00:00:02.000Z'),
+        }),
+      ],
+    });
+    const lifecycle = makeLifecycle({
+      engine,
+      failedContainerRetentionMs: 3_600_000,
+      maxRetainedFailedContainers: 1,
+    });
+
+    await lifecycle.observe();
+
+    expect(engine.removed).toEqual(['oldest']);
+  });
+
+  it('uses first-observed failure time when FinishedAt is missing', async () => {
+    const engine = fakeEngine({
+      containers: [
+        container({
+          state: 'exited',
+          exitCode: 1,
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        }),
+      ],
+    });
+    const lifecycle = makeLifecycle({
+      engine,
+      failedContainerRetentionMs: 60_000,
+      maxRetainedFailedContainers: 20,
+    });
+
+    await lifecycle.observe();
+
+    expect(engine.removed).toEqual([]);
+  });
+  it('defers retention cleanup when terminal inspection is unavailable', async () => {
+    const engine = fakeEngine({
+      containers: [
+        container({
+          state: 'exited',
+          exitCode: 1,
+          createdAt: new Date('2025-01-01T00:00:00.000Z'),
+          terminalInspectFailed: true,
+        }),
+      ],
+    });
+    const lifecycle = makeLifecycle({
+      engine,
+      failedContainerRetentionMs: 60_000,
+      maxRetainedFailedContainers: 20,
+    });
+    await lifecycle.observe();
+    expect(engine.removed).toEqual([]);
+    expect(observability.logger.debug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'runner.container_failure_timestamp_fallback',
+        fallback: 'firstObservedAt',
+      }),
+      'Failure timestamp unavailable; TTL cleanup is deferred but count-bounded cleanup still applies',
+    );
+  });
+
+  it('uses a driver-aware forensic log hint', async () => {
+    for (const driver of ['local', 'journald', 'none']) {
+      vi.clearAllMocks();
+      const lifecycle = makeLifecycle({
+        engine: fakeEngine({
+          containers: [container({state: 'exited', exitCode: 1, loggingDriver: driver})],
+        }),
+      });
+
+      await lifecycle.observe();
+
+      const failureLog = observability.logger.error.mock.calls.find(
+        ([fields]) => fields?.event === 'runner.container_failed',
+      )?.[0];
+      expect(failureLog).toBeDefined();
+      if (driver === 'local') {
+        expect(failureLog).toEqual(
+          expect.objectContaining({
+            dockerLogsCommand:
+              'docker --host "$SHIPFOX_PROVISIONER_DOCKER_HOST" logs --timestamps --tail 200 runner-1',
+            dockerLogsHostHint:
+              'Target the daemon configured by SHIPFOX_PROVISIONER_DOCKER_HOST; omit --host when using the local default',
+          }),
+        );
+      } else if (driver === 'journald') {
+        expect(failureLog).toEqual(
+          expect.objectContaining({
+            journaldCommand: 'journalctl CONTAINER_NAME=runner-1',
+            journaldHostHint:
+              'Run journalctl on the Docker daemon host configured by SHIPFOX_PROVISIONER_DOCKER_HOST',
+          }),
+        );
+        expect(failureLog).not.toHaveProperty('dockerLogsCommand');
+      } else {
+        expect(failureLog).toEqual(
+          expect.objectContaining({
+            loggingBackendHint: 'Container logging is disabled for this driver',
+          }),
+        );
+        expect(failureLog).not.toHaveProperty('dockerLogsCommand');
+      }
+    }
+  });
+
+  it('enforces the retained-failure count bound for inspect failures', async () => {
+    const engine = fakeEngine({
+      containers: [
+        container({
+          name: 'inspect-failed',
+          state: 'exited',
+          exitCode: 1,
+          createdAt: new Date('2025-01-01T00:00:00.000Z'),
+          terminalInspectFailed: true,
+        }),
+        container({
+          name: 'recent-failure',
+          state: 'exited',
+          exitCode: 1,
+          finishedAt: new Date('2026-01-01T00:09:00.000Z'),
+        }),
+      ],
+    });
+    const lifecycle = makeLifecycle({
+      engine,
+      failedContainerRetentionMs: 3_600_000,
+      maxRetainedFailedContainers: 1,
+    });
+    await lifecycle.observe();
+    expect(engine.removed).toEqual(['recent-failure']);
+  });
+
+  it('ranks failures without FinishedAt as newly observed for count eviction', async () => {
+    const engine = fakeEngine({
+      containers: [
+        container({
+          name: 'unknown-failure-time',
+          state: 'exited',
+          exitCode: 1,
+        }),
+        container({
+          name: 'known-failure-time',
+          state: 'exited',
+          exitCode: 1,
+          finishedAt: new Date('2026-01-01T00:09:00.000Z'),
+        }),
+      ],
+    });
+    const lifecycle = makeLifecycle({
+      engine,
+      failedContainerRetentionMs: 3_600_000,
+      maxRetainedFailedContainers: 1,
+    });
+
+    await lifecycle.observe();
+
+    expect(engine.removed).toEqual(['known-failure-time']);
+  });
+
+  it('emits one aggregate cleanup error for multiple failures in one pass', async () => {
+    const cleanupError = new DockerEngineError('unknown', 'cleanup failed');
+    const engine = fakeEngine({
+      containers: [
+        container({
+          name: 'first',
+          state: 'exited',
+          exitCode: 1,
+          finishedAt: new Date('2026-01-01T00:00:00.000Z'),
+        }),
+        container({
+          name: 'second',
+          state: 'exited',
+          exitCode: 1,
+          finishedAt: new Date('2026-01-01T00:00:00.000Z'),
+        }),
+        container({
+          name: 'third',
+          state: 'exited',
+          exitCode: 1,
+          finishedAt: new Date('2026-01-01T00:00:00.000Z'),
+        }),
+      ],
+      removeErrors: [cleanupError, undefined, cleanupError],
+    });
+    const lifecycle = makeLifecycle({
+      engine,
+      failedContainerRetentionMs: 60_000,
+      maxRetainedFailedContainers: 20,
+    });
+
+    await lifecycle.observe();
+
+    const cleanupErrors = observability.logger.error.mock.calls.filter(
+      ([fields]) => fields?.event === 'runner.failed_container_cleanup_failed',
+    );
+    expect(cleanupErrors).toHaveLength(1);
+    expect(cleanupErrors[0]?.[0]).toMatchObject({failedRemoval: 2, attempts: 1});
+  });
+  it('keeps a failed container when cleanup fails so the next observation can retry', async () => {
+    const engine = fakeEngine({
+      containers: [
+        container({state: 'exited', exitCode: 1, finishedAt: new Date('2026-01-01T00:00:00.000Z')}),
+      ],
+      removeError: new DockerEngineError('unknown', 'cleanup failed'),
+    });
+    const lifecycle = makeLifecycle({
+      engine,
+      failedContainerRetentionMs: 60_000,
+      maxRetainedFailedContainers: 20,
+    });
+
+    await lifecycle.observe();
+    await lifecycle.observe();
+
+    expect(engine.removed).toEqual(['runner-1', 'runner-1']);
+    expect(observability.logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({event: 'runner.failed_container_cleanup_failed'}),
+      'Failed to remove retained failed runner container; will retry',
+    );
+    expect(observability.logger.info).not.toHaveBeenCalledWith(
+      expect.objectContaining({event: 'runner.cleanup_pass_completed'}),
+      expect.any(String),
+    );
+  });
+  it('resets cleanup-failure suppression after a successful cleanup', async () => {
+    const cleanupError = new DockerEngineError('unknown', 'cleanup failed');
+    const engine = fakeEngine({
+      containers: [
+        container({state: 'exited', exitCode: 1, finishedAt: new Date('2026-01-01T00:00:00.000Z')}),
+      ],
+      removeErrors: [cleanupError, undefined, cleanupError],
+    });
+    const lifecycle = makeLifecycle({
+      engine,
+      failedContainerRetentionMs: 60_000,
+      maxRetainedFailedContainers: 20,
+    });
+    await lifecycle.observe();
+    await lifecycle.observe();
+    await lifecycle.observe();
+    expect(
+      observability.logger.error.mock.calls.filter(
+        ([fields]) => fields?.event === 'runner.failed_container_cleanup_failed',
+      ),
+    ).toHaveLength(2);
   });
 
   it('reaps only created containers past the registration deadline', async () => {
@@ -337,6 +822,37 @@ describe('createDockerLifecycle', () => {
       reason: 'backend-terminate',
     });
     expect(engine.killedAndRemoved).toEqual(['runner-1']);
+    expect(observability.logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({event: 'runner.container_termination_requested', count: 1}),
+      'Runner container termination batch requested',
+    );
+  });
+
+  it('does not retry cleanup for a container terminated during reconcile', async () => {
+    const engine = fakeEngine({
+      containers: [container({state: 'exited', exitCode: 1})],
+    });
+    const client = fakeClient({
+      reconcileResponse: {
+        runners: [reconciledRunner('runner-1', 'terminate')],
+        terminated_absent_provider_runner_ids: [],
+      },
+    });
+    const lifecycle = makeLifecycle({
+      engine,
+      client,
+      failedContainerRetentionMs: 3_600_000,
+      maxRetainedFailedContainers: 20,
+    });
+
+    await lifecycle.reconcile();
+
+    expect(engine.killedAndRemoved).toEqual(['runner-1']);
+    expect(engine.removed).toEqual([]);
+    expect(observability.logger.info).not.toHaveBeenCalledWith(
+      expect.objectContaining({event: 'runner.cleanup_pass_completed'}),
+      expect.any(String),
+    );
   });
 
   it('does not report backend terminate state when Docker kill fails', async () => {
@@ -354,9 +870,112 @@ describe('createDockerLifecycle', () => {
     const lifecycle = makeLifecycle({engine, client});
 
     await expect(lifecycle.reconcile()).rejects.toThrow(error);
+    await expect(lifecycle.reconcile()).rejects.toThrow(error);
 
-    expect(engine.killedAndRemoved).toEqual(['runner-1']);
-    expect(client.reportBodies).toEqual([]);
+    client.reconcileRunnerInstances = (body) => {
+      client.reconcileBodies.push(body);
+      return Promise.resolve({
+        runners: [reconciledRunner('runner-1', 'keep')],
+        terminated_absent_provider_runner_ids: [],
+      });
+    };
+    await lifecycle.reconcile();
+    client.reconcileRunnerInstances = (body) => {
+      client.reconcileBodies.push(body);
+      return Promise.resolve({
+        runners: [reconciledRunner('runner-1', 'terminate')],
+        terminated_absent_provider_runner_ids: [],
+      });
+    };
+    await expect(lifecycle.reconcile()).rejects.toThrow(error);
+
+    expect(engine.killedAndRemoved).toEqual(['runner-1', 'runner-1', 'runner-1']);
+    expect(client.reportBodies.flatMap((body) => body.events.map((event) => event.state))).toEqual([
+      'running',
+    ]);
+    expect(
+      observability.logger.info.mock.calls.filter(
+        ([fields]) => fields?.event === 'runner.container_termination_requested',
+      ),
+    ).toHaveLength(2);
+  });
+
+  it('flushes the initial missing-label diagnostic before terminal side effects', async () => {
+    const error = new DockerEngineError('unknown', 'kill failed');
+    const engine = fakeEngine({
+      containers: [
+        container({state: 'running', labels: {'shipfox.provider_runner_id': 'runner-1'}}),
+      ],
+      killAndRemoveError: error,
+    });
+    const client = fakeClient({
+      reconcileResponse: {
+        runners: [reconciledRunner('runner-1', 'terminate')],
+        terminated_absent_provider_runner_ids: [],
+      },
+    });
+    const lifecycle = makeLifecycle({engine, client});
+    await expect(lifecycle.reconcile()).rejects.toThrow(error);
+    expect(observability.logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({event: 'runner.report_skipped', count: 1}),
+      'Skipping provisioned runner reports because labels are unavailable',
+    );
+  });
+  it('deduplicates poll-driven termination requests across observations', async () => {
+    const error = new DockerEngineError('unknown', 'kill failed');
+    const engine = fakeEngine({
+      containers: [container({state: 'running'})],
+      killAndRemoveError: error,
+    });
+    const lifecycle = makeLifecycle({engine});
+
+    await lifecycle.observe();
+    await expect(lifecycle.terminate(['runner-1'])).rejects.toThrow(error);
+    await lifecycle.observe();
+    await expect(lifecycle.terminate(['runner-1'])).rejects.toThrow(error);
+    await lifecycle.terminate([]);
+    await expect(lifecycle.terminate(['runner-1'])).rejects.toThrow(error);
+
+    expect(
+      observability.logger.info.mock.calls.filter(
+        ([fields]) => fields?.event === 'runner.container_termination_requested',
+      ),
+    ).toHaveLength(2);
+  });
+
+  it('deduplicates the same termination episode across reconcile and poll sources', async () => {
+    const error = new DockerEngineError('unknown', 'kill failed');
+    const engine = fakeEngine({
+      containers: [container({state: 'running'})],
+      killAndRemoveError: error,
+    });
+    const client = fakeClient({
+      reconcileResponse: {
+        runners: [reconciledRunner('runner-1', 'terminate')],
+        terminated_absent_provider_runner_ids: [],
+      },
+    });
+    const lifecycle = makeLifecycle({engine, client});
+
+    await expect(lifecycle.reconcile()).rejects.toThrow(error);
+    await expect(lifecycle.terminate(['runner-1'])).rejects.toThrow(error);
+
+    client.reconcileRunnerInstances = (body) => {
+      client.reconcileBodies.push(body);
+      return Promise.resolve({
+        runners: [reconciledRunner('runner-1', 'keep')],
+        terminated_absent_provider_runner_ids: [],
+      });
+    };
+    await lifecycle.reconcile();
+    await lifecycle.terminate([]);
+    await expect(lifecycle.terminate(['runner-1'])).rejects.toThrow(error);
+
+    expect(
+      observability.logger.info.mock.calls.filter(
+        ([fields]) => fields?.event === 'runner.container_termination_requested',
+      ),
+    ).toHaveLength(2);
   });
 
   it('reconcile adopts backend keep-intent live containers', async () => {
@@ -399,7 +1018,7 @@ describe('createDockerLifecycle', () => {
     expect(engine.removed).toEqual(['runner-1']);
   });
 
-  it('reconcile falls back to local observe when the observed id count exceeds the API limit', async () => {
+  it('reports oversized reconciliation as an incomplete provider operation', async () => {
     const engine = fakeEngine({
       containers: Array.from({length: 5001}, (_, index) =>
         container({name: `runner-${index}`, state: 'running'}),
@@ -408,7 +1027,7 @@ describe('createDockerLifecycle', () => {
     const client = fakeClient();
     const lifecycle = makeLifecycle({engine, client});
 
-    await lifecycle.reconcile();
+    await expect(lifecycle.reconcile()).rejects.toThrow('exceeding the API limit of 5000');
 
     expect(client.reconcileBodies).toEqual([]);
     expect(client.reportBodies.map((body) => body.events.length)).toEqual([
@@ -429,7 +1048,7 @@ describe('createDockerLifecycle', () => {
     });
     const lifecycle = makeLifecycle({engine, client});
 
-    await lifecycle.tick();
+    await expect(lifecycle.tick()).rejects.toThrow('exceeding the API limit of 5000');
     containers.splice(1);
     await lifecycle.tick();
     await lifecycle.tick();
@@ -481,6 +1100,22 @@ describe('createDockerLifecycle', () => {
     expect(engine.killedAndRemoved).toEqual(['runner-1']);
   });
 
+  it('reports a missing-label episode when labels return', async () => {
+    const labels: Record<string, string> = {
+      'shipfox.provider_runner_id': 'runner-1',
+    };
+    const containers = [container({state: 'running', labels})];
+    const engine = fakeEngine({containers});
+    const lifecycle = makeLifecycle({engine});
+    await lifecycle.observe();
+    labels['shipfox.template_key'] = 'small';
+    labels['shipfox.labels'] = 'ubuntu22';
+    await lifecycle.observe();
+    expect(observability.logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({event: 'runner.report_resumed', providerRunnerId: 'runner-1'}),
+      'Runner report resumed after labels became available',
+    );
+  });
   it('terminate does not list Docker for an empty id set', async () => {
     const engine = fakeEngine();
     const lifecycle = makeLifecycle({engine});
@@ -542,15 +1177,18 @@ describe('createDockerLifecycle', () => {
   it('preserves terminal reports over live reports when the retry queue overflows', async () => {
     const engine = fakeEngine({
       containers: [
-        ...Array.from({length: 5001}, (_, index) =>
+        ...Array.from({length: 10001}, (_, index) =>
           container({name: `runner-${index}`, state: 'running'}),
         ),
         container({name: 'terminal-runner', state: 'exited', exitCode: 0}),
       ],
     });
-    const client = fakeClient({reportErrors: [new Error('api down'), new Error('api down')]});
+    const client = fakeClient({
+      reportErrors: [new Error('api down'), new Error('api down'), new Error('api down')],
+    });
     const lifecycle = makeLifecycle({engine, client});
 
+    await lifecycle.observe();
     await lifecycle.observe();
     await lifecycle.flush();
 
@@ -562,6 +1200,17 @@ describe('createDockerLifecycle', () => {
           (event) => event.provider_runner_id === 'terminal-runner' && event.state === 'stopped',
         ),
     ).toBe(true);
+    expect(observability.logger.warn).not.toHaveBeenCalledWith(
+      expect.objectContaining({event: 'runner_report.queue_overflow'}),
+      expect.any(String),
+    );
+    expect(observability.logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'runner_report.delivery_degraded',
+        queueDropped: expect.any(Number),
+      }),
+      'Runner report delivery degraded',
+    );
   });
 
   it('flush drains buffered reports', async () => {
@@ -580,6 +1229,19 @@ describe('createDockerLifecycle', () => {
     });
   });
 
+  it('counts only outage reports in delivery recovery', async () => {
+    const engine = fakeEngine({containers: [container({state: 'running'})]});
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({engine, client});
+    await lifecycle.observe();
+    client.reportErrors.push(new Error('api down'));
+    await lifecycle.observe();
+    await lifecycle.flush();
+    expect(observability.logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({event: 'runner_report.delivery_recovered', delivered: 1}),
+      'Runner report delivery recovered',
+    );
+  });
   it('does not block container creation when the launch starting report is buffered', async () => {
     const engine = fakeEngine();
     const client = fakeClient({reportErrors: [new Error('api down')]});
@@ -621,6 +1283,8 @@ function makeLifecycle(
     client?: ReturnType<typeof fakeClient>;
     tracker?: ProviderRunnerTracker;
     registrationDeadlineMs?: number;
+    failedContainerRetentionMs?: number;
+    maxRetainedFailedContainers?: number;
   } = {},
 ) {
   return createDockerLifecycle({
@@ -635,6 +1299,13 @@ function makeLifecycle(
     now: () => NOW,
     registrationDeadlineMs: args.registrationDeadlineMs ?? 120_000,
     providerKind: 'docker',
+    ...(args.failedContainerRetentionMs !== undefined
+      ? {failedContainerRetentionMs: args.failedContainerRetentionMs}
+      : {}),
+    ...(args.maxRetainedFailedContainers !== undefined
+      ? {maxRetainedFailedContainers: args.maxRetainedFailedContainers}
+      : {}),
+    loggingDriverSource: 'daemon',
   });
 }
 
@@ -652,11 +1323,14 @@ function launch(): ProviderRunnerLaunch<DockerTemplateSpec> {
 function fakeClient(
   options: {
     reportErrors?: Error[];
+    attachErrors?: Error[];
     reconcileErrors?: Error[];
     reconcileResponse?: ReconcileRunnerInstancesResponseDto;
+    onReport?: () => void;
   } = {},
 ): ProvisionerClient & {
   reportBodies: ReportRunnerInstancesBodyDto[];
+  reportErrors: Error[];
   reconcileBodies: ReconcileRunnerInstancesBodyDto[];
   assignmentBodies: Array<{reservationId: string; runnerInstanceIds: string[]}>;
 } {
@@ -664,9 +1338,11 @@ function fakeClient(
   const reconcileBodies: ReconcileRunnerInstancesBodyDto[] = [];
   const assignmentBodies: Array<{reservationId: string; runnerInstanceIds: string[]}> = [];
   const reportErrors = [...(options.reportErrors ?? [])];
+  const attachErrors = [...(options.attachErrors ?? [])];
   const reconcileErrors = [...(options.reconcileErrors ?? [])];
   return {
     reportBodies,
+    reportErrors,
     reconcileBodies,
     assignmentBodies,
     getIdentity: () =>
@@ -678,13 +1354,18 @@ function fakeClient(
     pollDemand: () =>
       Promise.resolve({stats: [], reservations: [], terminate_provider_runner_ids: []}),
     createRunnerInstances: () => Promise.resolve({runner_instances: []}),
-    attachRunnerInstanceProviderId: () => Promise.resolve({attached: true}),
+    attachRunnerInstanceProviderId: () => {
+      const error = attachErrors.shift();
+      if (error) return Promise.reject(error);
+      return Promise.resolve({attached: true});
+    },
     assignRunnerInstances: (reservationId, runnerInstanceIds) => {
       assignmentBodies.push({reservationId, runnerInstanceIds});
       return Promise.resolve({runner_instance_ids: runnerInstanceIds});
     },
     reportRunnerInstances: (body): Promise<ReportRunnerInstancesResponseDto> => {
       reportBodies.push(body);
+      options.onReport?.();
       const error = reportErrors.shift();
       if (error) return Promise.reject(error);
       return Promise.resolve({accepted: body.events.length, reservations_released: 0});
@@ -709,7 +1390,9 @@ function fakeEngine(
     createError?: Error;
     listError?: Error;
     removeError?: Error;
+    removeErrors?: Array<Error | undefined>;
     killAndRemoveError?: Error;
+    onRemove?: () => void;
   } = {},
 ): DockerEngine & {
   created: Parameters<DockerEngine['createAndStart']>[0][];
@@ -720,6 +1403,7 @@ function fakeEngine(
   const created: Parameters<DockerEngine['createAndStart']>[0][] = [];
   const removed: string[] = [];
   const killedAndRemoved: string[] = [];
+  const removeErrors = [...(options.removeErrors ?? [])];
   let listManagedCalls = 0;
 
   return {
@@ -730,6 +1414,7 @@ function fakeEngine(
       return listManagedCalls;
     },
     ensureImage: () => Promise.resolve(),
+    getInfo: () => Promise.resolve({loggingDriver: 'json-file'}),
     createAndStart: (args) => {
       if (options.createError) return Promise.reject(options.createError);
       created.push(args);
@@ -741,8 +1426,10 @@ function fakeEngine(
       return Promise.resolve(options.containers ?? []);
     },
     remove: (name) => {
+      options.onRemove?.();
       removed.push(name);
-      if (options.removeError) return Promise.reject(options.removeError);
+      const error = removeErrors.shift() ?? options.removeError;
+      if (error) return Promise.reject(error);
       return Promise.resolve();
     },
     killAndRemove: (name) => {
@@ -793,6 +1480,11 @@ function container(args: {
   exitCode?: number;
   oomKilled?: boolean;
   createdAt?: Date;
+  startedAt?: Date;
+  finishedAt?: Date;
+  terminalInspectFailed?: boolean;
+  image?: string;
+  loggingDriver?: string;
   labels?: Readonly<Record<string, string>>;
 }): DockerContainerView {
   const name = args.name ?? 'runner-1';
@@ -810,7 +1502,12 @@ function container(args: {
     state: args.state,
     ...(args.exitCode !== undefined ? {exitCode: args.exitCode} : {}),
     ...(args.oomKilled !== undefined ? {oomKilled: args.oomKilled} : {}),
+    ...(args.image !== undefined ? {image: args.image} : {}),
+    ...(args.loggingDriver !== undefined ? {loggingDriver: args.loggingDriver} : {}),
     createdAt: args.createdAt ?? NOW,
+    ...(args.startedAt !== undefined ? {startedAt: args.startedAt} : {}),
+    ...(args.finishedAt !== undefined ? {finishedAt: args.finishedAt} : {}),
+    ...(args.terminalInspectFailed ? {terminalInspectFailed: true} : {}),
   };
 }
 

--- a/libs/provisioner/docker/src/lifecycle.ts
+++ b/libs/provisioner/docker/src/lifecycle.ts
@@ -216,7 +216,7 @@ async function launch(
     return {containerStarted: true, identityAttached: false, reported: false};
   }
 
-  await reportEvents(context, [
+  const reported = await reportEvents(context, [
     {
       provider_runner_id: runner.providerRunnerId,
       template_key: runner.template.key,
@@ -228,7 +228,7 @@ async function launch(
   ]);
   context.knownLiveIds.add(runner.providerRunnerId);
   context.knownTemplateKeys.set(runner.providerRunnerId, runner.template.key);
-  return {containerStarted: true, identityAttached: true, reported: true};
+  return {containerStarted: true, identityAttached: true, reported};
 }
 
 async function reportContainerCreationFailure(
@@ -785,17 +785,26 @@ async function applyTerminalActions(
 async function reportEvents(
   context: DockerLifecycleContext,
   events: readonly RunnerInstanceReportEventDto[],
-): Promise<void> {
+): Promise<boolean> {
   const queued = context.pendingReports.splice(0);
   const reports = [...queued, ...events];
-  if (reports.length === 0) return;
+  if (reports.length === 0) return true;
 
+  const eventStart = queued.length;
+  const eventEnd = eventStart + events.length;
+  let deliveredEvents = 0;
+  let batchStart = 0;
   const batches = chunk(reports, MAX_REPORT_BATCH);
   for (let index = 0; index < batches.length; index += 1) {
     const batch = batches[index] ?? [];
+    const batchEnd = batchStart + batch.length;
+    const batchEventStart = Math.max(batchStart, eventStart);
+    const batchEventEnd = Math.min(batchEnd, eventEnd);
+    const batchEventCount = Math.max(0, batchEventEnd - batchEventStart);
     try {
       await context.client.reportRunnerInstances({events: batch});
       context.reportDeliveryDelivered += batch.length;
+      deliveredEvents += batchEventCount;
     } catch (error) {
       if (error instanceof ProvisionerAuthenticationError) {
         bufferReports(context, [...batch, ...batches.slice(index + 1).flat()]);
@@ -811,15 +820,18 @@ async function reportEvents(
           },
           'Dropped invalid runner report batch',
         );
+        batchStart = batchEnd;
         continue;
       }
       const unsent = [...batch, ...batches.slice(index + 1).flat()];
       bufferReports(context, unsent);
       recordReportDeliveryFailure(context, error);
-      return;
+      return deliveredEvents === events.length;
     }
+    batchStart = batchEnd;
   }
   recordReportDeliveryRecovery(context);
+  return deliveredEvents === events.length;
 }
 
 async function flush(context: DockerLifecycleContext): Promise<void> {

--- a/libs/provisioner/docker/src/lifecycle.ts
+++ b/libs/provisioner/docker/src/lifecycle.ts
@@ -4,6 +4,7 @@ import {
 } from '@shipfox/api-runners-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import type {
+  LaunchOutcome,
   ProviderRunnerLaunch,
   ProviderRunnerTracker,
   ProvisionerClient,
@@ -13,14 +14,25 @@ import type {
 import {ProvisionerAuthenticationError} from '@shipfox/provisioner-core';
 import {buildContainerLabels, parseContainerIdentity} from '#container-identity.js';
 import {type DockerContainerView, type DockerEngine, DockerEngineError} from '#docker-engine.js';
+import {closeEpisode, type EpisodeState, type EpisodeUpdate, recordEpisode} from '#episodes.js';
 import {parseMemoryToBytes} from '#memory.js';
 import type {DockerTemplateSpec} from '#templates.js';
 
 const MAX_REPORT_BATCH = 1000;
 const MAX_PENDING_REPORTS = 5000;
 const MAX_REASON_LENGTH = 500;
-const REPORT_BACKLOG_LOG_EVERY_PASSES = 5;
 const EMPTY_TERMINATE_INTENT_IDS = new Set<string>();
+
+class DockerReconciliationLimitError extends Error {
+  constructor(observedCount: number) {
+    super(
+      `Docker reconciliation observed ${observedCount} managed runners, exceeding the API limit of ${MAX_RECONCILE_OBSERVED_RUNNERS}.`,
+    );
+    this.name = 'DockerReconciliationLimitError';
+  }
+}
+
+type TerminationRequestSource = 'backend' | 'poll';
 
 type TrackerSeed = {
   providerRunnerId: string;
@@ -29,12 +41,13 @@ type TrackerSeed = {
 };
 
 export interface DockerLifecycle {
-  launch(launch: ProviderRunnerLaunch<DockerTemplateSpec>): Promise<void>;
+  launch(launch: ProviderRunnerLaunch<DockerTemplateSpec>): Promise<LaunchOutcome>;
   observe(): Promise<void>;
   reconcile(): Promise<void>;
   tick(): Promise<void>;
   terminate(providerRunnerIds: readonly string[]): Promise<void>;
   flush(): Promise<void>;
+  setLoggingDriver(loggingDriver: string): void;
 }
 
 interface DockerLifecycleOptions {
@@ -46,6 +59,10 @@ interface DockerLifecycleOptions {
   now?: () => Date;
   registrationDeadlineMs: number;
   providerKind: string;
+  failedContainerRetentionMs?: number;
+  maxRetainedFailedContainers?: number;
+  loggingDriver?: string;
+  loggingDriverSource?: 'daemon' | 'provisioner';
 }
 
 interface DockerLifecycleContext {
@@ -59,9 +76,25 @@ interface DockerLifecycleContext {
   readonly providerKind: string;
   readonly knownLiveIds: Set<string>;
   readonly knownTemplateKeys: Map<string, string>;
+  readonly backendTerminationRequestedIds: Set<string>;
+  readonly pollTerminationRequestedIds: Set<string>;
+  readonly episodes: Map<string, EpisodeState>;
+  readonly reportedFailedIds: Set<string>;
+  readonly reportedFailedContainerIds: Map<string, string>;
+  readonly firstObservedFailedAt: Map<string, Date>;
   readonly pendingReports: RunnerInstanceReportEventDto[];
+  readonly pendingMissingLabelEpisodes: Array<{
+    providerRunnerId: string;
+    templateKey?: string;
+    update: EpisodeUpdate;
+  }>;
+  readonly failedContainerRetentionMs: number;
+  readonly maxRetainedFailedContainers: number;
+  loggingDriver?: string;
+  readonly loggingDriverSource: 'daemon' | 'provisioner';
   backendReconcileSucceeded: boolean;
-  reportBacklogPasses: number;
+  reportDeliveryDelivered: number;
+  reportQueueDropped: number;
 }
 
 interface ObservationPlan {
@@ -76,6 +109,9 @@ interface TerminalAction {
   readonly event?: RunnerInstanceReportEventDto;
   readonly remove?: string;
   readonly killAndRemove?: string;
+  readonly retained?: boolean;
+  readonly reason?: string;
+  readonly requestSource?: TerminationRequestSource;
 }
 
 type LiveContainerState = {
@@ -97,9 +133,21 @@ export function createDockerLifecycle(args: DockerLifecycleOptions): DockerLifec
     providerKind: args.providerKind,
     knownLiveIds: new Set<string>(),
     knownTemplateKeys: new Map<string, string>(),
+    backendTerminationRequestedIds: new Set<string>(),
+    pollTerminationRequestedIds: new Set<string>(),
+    episodes: new Map<string, EpisodeState>(),
+    reportedFailedIds: new Set<string>(),
+    reportedFailedContainerIds: new Map<string, string>(),
+    firstObservedFailedAt: new Map<string, Date>(),
     pendingReports: [],
+    pendingMissingLabelEpisodes: [],
+    failedContainerRetentionMs: args.failedContainerRetentionMs ?? 0,
+    maxRetainedFailedContainers: args.maxRetainedFailedContainers ?? 0,
+    ...(args.loggingDriver ? {loggingDriver: args.loggingDriver} : {}),
+    loggingDriverSource: args.loggingDriverSource ?? 'daemon',
     backendReconcileSucceeded: false,
-    reportBacklogPasses: 0,
+    reportDeliveryDelivered: 0,
+    reportQueueDropped: 0,
   };
 
   return {
@@ -109,13 +157,16 @@ export function createDockerLifecycle(args: DockerLifecycleOptions): DockerLifec
     tick: () => tick(context),
     terminate: (ids) => terminate(context, ids),
     flush: () => flush(context),
+    setLoggingDriver: (loggingDriver) => {
+      context.loggingDriver = loggingDriver;
+    },
   };
 }
 
 async function launch(
   context: DockerLifecycleContext,
   runner: ProviderRunnerLaunch<DockerTemplateSpec>,
-): Promise<void> {
+): Promise<LaunchOutcome> {
   const labels = buildContainerLabels({launch: runner, identity: context.identity});
 
   try {
@@ -130,6 +181,12 @@ async function launch(
       nanoCpus: Math.round(runner.template.spec.cpu * 1_000_000_000),
       memoryBytes: parseMemoryToBytes(runner.template.spec.memory),
     });
+  } catch (error) {
+    await reportContainerCreationFailure(context, runner, error);
+    throw error;
+  }
+
+  try {
     const attachRunnerInstanceProviderId = context.client.attachRunnerInstanceProviderId;
     if (!attachRunnerInstanceProviderId)
       throw new Error(
@@ -144,32 +201,71 @@ async function launch(
         `Provider identity was not attached for runner instance ${runner.runnerInstanceId}`,
       );
     }
-    await reportEvents(context, [
-      {
-        provider_runner_id: runner.providerRunnerId,
-        template_key: runner.template.key,
-        labels: [...runner.template.labels],
-        state: 'starting',
-        reported_at: context.now().toISOString(),
-        provider_kind: context.providerKind,
-      },
-    ]);
-    context.knownLiveIds.add(runner.providerRunnerId);
-    context.knownTemplateKeys.set(runner.providerRunnerId, runner.template.key);
   } catch (error) {
-    // Preserve the pre-created instance as the lifecycle record even when launch fails.
-    // The provider ID is still the stable idempotency key for the failed launch attempt.
-    try {
-      await context.client.attachRunnerInstanceProviderId(
-        runner.runnerInstanceId,
-        runner.providerRunnerId,
-      );
-    } catch (attachError) {
-      logger().warn(
-        {err: attachError, runnerInstanceId: runner.runnerInstanceId},
-        'Failed to attach provider identity after runner launch failure',
-      );
-    }
+    logger().debug?.(
+      {
+        event: 'runner.container_identity_attachment_failed',
+        operation: 'attach_runner_instance_provider_id',
+        providerRunnerId: runner.providerRunnerId,
+        runnerInstanceId: runner.runnerInstanceId,
+        reason: truncateReason(errorReason(error)),
+      },
+      'Failed to attach provider identity after runner container started',
+    );
+    if (error instanceof ProvisionerAuthenticationError) throw error;
+    return {containerStarted: true, identityAttached: false, reported: false};
+  }
+
+  await reportEvents(context, [
+    {
+      provider_runner_id: runner.providerRunnerId,
+      template_key: runner.template.key,
+      labels: [...runner.template.labels],
+      state: 'starting',
+      reported_at: context.now().toISOString(),
+      provider_kind: context.providerKind,
+    },
+  ]);
+  context.knownLiveIds.add(runner.providerRunnerId);
+  context.knownTemplateKeys.set(runner.providerRunnerId, runner.template.key);
+  return {containerStarted: true, identityAttached: true, reported: true};
+}
+
+async function reportContainerCreationFailure(
+  context: DockerLifecycleContext,
+  runner: ProviderRunnerLaunch<DockerTemplateSpec>,
+  error: unknown,
+): Promise<void> {
+  try {
+    await context.client.attachRunnerInstanceProviderId(
+      runner.runnerInstanceId,
+      runner.providerRunnerId,
+    );
+  } catch (attachError) {
+    logger().debug?.(
+      {
+        event: 'runner.container_launch_failed',
+        operation: 'attach_runner_instance_provider_id',
+        runnerInstanceId: runner.runnerInstanceId,
+        reason: truncateReason(errorReason(attachError)),
+      },
+      'Failed to attach provider identity after runner container creation failed',
+    );
+  }
+  logger().debug?.(
+    {
+      event: 'runner.container_launch_failed',
+      operation: 'create_and_start',
+      providerRunnerId: runner.providerRunnerId,
+      runnerInstanceId: runner.runnerInstanceId,
+      templateKey: runner.template.key,
+      image: runner.template.spec.image,
+      loggingDriver: context.loggingDriver ?? 'daemon-default',
+      reason: truncateReason(errorReason(error)),
+    },
+    'Runner container launch failed',
+  );
+  try {
     await reportEvents(context, [
       {
         provider_runner_id: runner.providerRunnerId,
@@ -181,30 +277,27 @@ async function launch(
         provider_kind: context.providerKind,
       },
     ]);
-    throw error;
+  } catch {
+    // Report delivery owns retry and degradation logging. Preserve the Docker error
+    // as the launch result instead of reclassifying delivery failure as a launch failure.
   }
 }
 
 async function observe(context: DockerLifecycleContext): Promise<void> {
   await reportEvents(context, []);
-  const containers = await context.engine.listManaged(context.identity.id);
-  await applyObservedContainers(context, containers, EMPTY_TERMINATE_INTENT_IDS);
+  const listedContainers = await context.engine.listManaged(context.identity.id);
+  await applyObservedContainers(context, listedContainers, EMPTY_TERMINATE_INTENT_IDS);
+  await cleanupRetainedFailedContainers(context, listedContainers);
 }
 
 async function reconcile(context: DockerLifecycleContext): Promise<void> {
   await reportEvents(context, []);
-  const containers = await context.engine.listManaged(context.identity.id);
-  const observedProviderRunnerIds = observedRunnerIds(containers);
+  const listedContainers = await context.engine.listManaged(context.identity.id);
+  const observedProviderRunnerIds = observedRunnerIds(listedContainers);
   if (observedProviderRunnerIds.length > MAX_RECONCILE_OBSERVED_RUNNERS) {
-    logger().error(
-      {
-        observedCount: observedProviderRunnerIds.length,
-        maxObserved: MAX_RECONCILE_OBSERVED_RUNNERS,
-      },
-      'Skipping backend reconcile because observed provisioned runner count exceeds the API limit',
-    );
-    await applyObservedContainers(context, containers, EMPTY_TERMINATE_INTENT_IDS);
-    return;
+    await applyObservedContainers(context, listedContainers, EMPTY_TERMINATE_INTENT_IDS);
+    await cleanupRetainedFailedContainers(context, listedContainers);
+    throw new DockerReconciliationLimitError(observedProviderRunnerIds.length);
   }
 
   const response = await context.client.reconcileRunnerInstances({
@@ -215,15 +308,30 @@ async function reconcile(context: DockerLifecycleContext): Promise<void> {
       .filter((runner) => runner.desired_intent === 'terminate')
       .map((runner) => runner.provider_runner_id),
   );
+  context.backendTerminationRequestedIds.clear();
+  for (const providerRunnerId of terminateIntentIds) {
+    context.backendTerminationRequestedIds.add(providerRunnerId);
+  }
+  syncTerminationEpisodes(context);
 
   if (response.terminated_absent_provider_runner_ids.length > 0) {
     logger().info(
-      {providerRunnerIds: response.terminated_absent_provider_runner_ids},
+      {
+        event: 'runner.container_vanished',
+        count: response.terminated_absent_provider_runner_ids.length,
+        providerRunnerIdSample: boundedSample(response.terminated_absent_provider_runner_ids),
+      },
       'Backend terminated provisioned runners absent from Docker',
     );
   }
 
-  await applyObservedContainers(context, containers, terminateIntentIds);
+  await applyObservedContainers(context, listedContainers, terminateIntentIds);
+  await cleanupRetainedFailedContainers(
+    context,
+    listedContainers.filter(
+      (container) => !terminateIntentIds.has(parseContainerIdentity(container).providerRunnerId),
+    ),
+  );
   context.backendReconcileSucceeded = true;
 }
 
@@ -240,6 +348,12 @@ async function terminate(
   context: DockerLifecycleContext,
   providerRunnerIds: readonly string[],
 ): Promise<void> {
+  context.pendingMissingLabelEpisodes.length = 0;
+  context.pollTerminationRequestedIds.clear();
+  for (const providerRunnerId of providerRunnerIds) {
+    context.pollTerminationRequestedIds.add(providerRunnerId);
+  }
+  syncTerminationEpisodes(context);
   if (providerRunnerIds.length === 0) return;
 
   const ids = new Set(providerRunnerIds);
@@ -247,10 +361,11 @@ async function terminate(
   const actions = containers.flatMap((container) => {
     const parsed = parseContainerIdentity(container);
     return ids.has(parsed.providerRunnerId)
-      ? [terminalActionFor(context, container, 'backend-terminate')]
+      ? [terminalActionFor(context, container, 'backend-terminate', 'poll')]
       : [];
   });
 
+  flushMissingLabelEpisodes(context);
   await applyTerminalActions(context, actions);
 }
 
@@ -270,6 +385,8 @@ function buildObservationPlan(
   for (const container of containers) {
     recordContainerObservation(context, plan, listedIds, container, terminateIntentIds);
   }
+  pruneFailedObservationState(context, containers, listedIds);
+  pruneRequestState(context, listedIds);
   synthesizeVanishedContainers(context, plan, listedIds);
 
   return plan;
@@ -284,24 +401,66 @@ function recordContainerObservation(
 ): void {
   const parsed = parseContainerIdentity(container);
   listedIds.add(parsed.providerRunnerId);
+  const staleRegistration =
+    container.state === 'created' &&
+    isPastDeadline(container.createdAt, context.now(), context.registrationDeadlineMs);
+  const staleEpisodeKey = episodeKey('stale-reap', parsed.providerRunnerId);
+  if (!staleRegistration) closeEpisode(context.episodes, staleEpisodeKey);
   if (terminateIntentIds.has(parsed.providerRunnerId)) {
-    plan.terminalActions.push(terminalActionFor(context, container, 'backend-terminate'));
+    closeEpisode(context.episodes, staleEpisodeKey);
+    plan.terminalActions.push(
+      terminalActionFor(context, container, 'backend-terminate', 'backend'),
+    );
     return;
   }
 
   const labels = labelsFor(context, parsed.templateKey, parsed.labels);
   if (labels.length === 0) {
-    logger().warn(
-      {providerRunnerId: parsed.providerRunnerId},
-      'Skipping provisioned runner report because labels are unavailable',
-    );
+    logMissingLabels(context, parsed.providerRunnerId, parsed.templateKey);
     return;
   }
+  const missingLabelsRecovery = closeEpisode(
+    context.episodes,
+    episodeKey('missing-labels', parsed.providerRunnerId),
+    context.now(),
+  );
+  if (missingLabelsRecovery) {
+    logger().info(
+      {
+        event: 'runner.report_resumed',
+        providerRunnerId: parsed.providerRunnerId,
+        durationMs: missingLabelsRecovery.durationMs,
+        attempts: missingLabelsRecovery.attempts,
+        suppressed: missingLabelsRecovery.suppressed,
+      },
+      'Runner report resumed after labels became available',
+    );
+  }
 
-  if (
-    container.state === 'created' &&
-    isPastDeadline(container.createdAt, context.now(), context.registrationDeadlineMs)
-  ) {
+  if (staleRegistration) {
+    const update = recordEpisode(
+      context.episodes,
+      staleEpisodeKey,
+      `${container.id}:${parsed.templateKey ?? 'unknown'}`,
+      context.now(),
+    );
+    if (shouldLogEpisode(update)) {
+      logger().info(
+        {
+          event: 'runner.container_stale_reap_requested',
+          operation: 'kill_and_remove',
+          providerRunnerId: parsed.providerRunnerId,
+          containerId: container.id,
+          containerName: container.name,
+          templateKey: parsed.templateKey,
+          ageMs: Math.max(0, context.now().getTime() - container.createdAt.getTime()),
+          attempts: update.state.attempts,
+          suppressed: update.state.suppressed,
+          ...(update.transition === 'changed' ? {changed: true} : {}),
+        },
+        'Stale runner container reap requested before registration',
+      );
+    }
     plan.terminalActions.push(terminalActionFor(context, container, 'registration-deadline'));
     return;
   }
@@ -317,18 +476,37 @@ function recordContainerObservation(
   }
 
   if (mapped.state === 'failed') {
-    logger().error(
-      {
-        providerRunnerId: parsed.providerRunnerId,
-        ...(parsed.runnerInstanceId ? {runnerInstanceId: parsed.runnerInstanceId} : {}),
-        containerId: container.id,
-        containerName: container.name,
-        exitCode: container.exitCode ?? null,
-        oomKilled: container.oomKilled ?? false,
-        reason: mapped.reason,
-      },
-      'Provisioned runner container exited unsuccessfully',
-    );
+    const previousContainerId = context.reportedFailedContainerIds.get(parsed.providerRunnerId);
+    if (previousContainerId && previousContainerId !== container.id) {
+      context.reportedFailedIds.delete(parsed.providerRunnerId);
+      context.reportedFailedContainerIds.delete(parsed.providerRunnerId);
+    }
+    rememberFirstObservedFailure(context, container);
+    const retained = shouldRetainFailedContainer(context);
+    const shouldReport = !context.reportedFailedIds.has(parsed.providerRunnerId);
+    if (shouldReport) {
+      context.reportedFailedIds.add(parsed.providerRunnerId);
+      context.reportedFailedContainerIds.set(parsed.providerRunnerId, container.id);
+      logFailedContainer(context, container, parsed, mapped.reason);
+    }
+
+    plan.terminalActions.push({
+      providerRunnerId: parsed.providerRunnerId,
+      ...(shouldReport
+        ? {
+            event: eventFor(
+              container,
+              mapped.state,
+              labels,
+              context.providerKind,
+              context.now(),
+              mapped.reason,
+            ),
+          }
+        : {}),
+      ...(retained ? {retained: true} : {remove: container.name}),
+    });
+    return;
   }
 
   plan.terminalActions.push({
@@ -345,6 +523,69 @@ function recordContainerObservation(
   });
 }
 
+function pruneFailedObservationState(
+  context: DockerLifecycleContext,
+  containers: readonly DockerContainerView[],
+  listedProviderIds: ReadonlySet<string>,
+): void {
+  const listedContainerIds = new Set(containers.map((container) => container.id));
+  for (const containerId of context.firstObservedFailedAt.keys()) {
+    if (!listedContainerIds.has(containerId)) context.firstObservedFailedAt.delete(containerId);
+  }
+  for (const providerRunnerId of context.reportedFailedIds) {
+    const containerId = context.reportedFailedContainerIds.get(providerRunnerId);
+    if (
+      !listedProviderIds.has(providerRunnerId) ||
+      !containerId ||
+      !listedContainerIds.has(containerId)
+    ) {
+      context.reportedFailedIds.delete(providerRunnerId);
+      context.reportedFailedContainerIds.delete(providerRunnerId);
+    }
+  }
+  for (const key of context.episodes.keys()) {
+    const containerId = episodeTarget(key, 'failed-cleanup');
+    if (containerId && !listedContainerIds.has(containerId)) closeEpisode(context.episodes, key);
+  }
+}
+
+function pruneRequestState(
+  context: DockerLifecycleContext,
+  listedProviderIds: ReadonlySet<string>,
+): void {
+  for (const providerRunnerId of context.backendTerminationRequestedIds) {
+    if (!listedProviderIds.has(providerRunnerId)) {
+      context.backendTerminationRequestedIds.delete(providerRunnerId);
+    }
+  }
+  for (const providerRunnerId of context.pollTerminationRequestedIds) {
+    if (!listedProviderIds.has(providerRunnerId)) {
+      context.pollTerminationRequestedIds.delete(providerRunnerId);
+    }
+  }
+  for (const key of context.episodes.keys()) {
+    const providerRunnerId =
+      episodeTarget(key, 'stale-reap') ?? episodeTarget(key, 'missing-labels');
+    if (providerRunnerId && !listedProviderIds.has(providerRunnerId)) {
+      closeEpisode(context.episodes, key);
+    }
+  }
+  syncTerminationEpisodes(context);
+}
+
+function syncTerminationEpisodes(context: DockerLifecycleContext): void {
+  const activeIds = new Set([
+    ...context.backendTerminationRequestedIds,
+    ...context.pollTerminationRequestedIds,
+  ]);
+  for (const key of context.episodes.keys()) {
+    const providerRunnerId = episodeTarget(key, 'termination');
+    if (providerRunnerId && !activeIds.has(providerRunnerId)) {
+      closeEpisode(context.episodes, key);
+    }
+  }
+}
+
 function recordLiveContainer(
   context: DockerLifecycleContext,
   plan: ObservationPlan,
@@ -354,11 +595,25 @@ function recordLiveContainer(
   mapped: LiveContainerState,
 ): void {
   context.knownLiveIds.add(parsed.providerRunnerId);
+  context.reportedFailedIds.delete(parsed.providerRunnerId);
+  context.reportedFailedContainerIds.delete(parsed.providerRunnerId);
+  context.firstObservedFailedAt.delete(container.id);
   if (parsed.templateKey) {
     context.knownTemplateKeys.set(parsed.providerRunnerId, parsed.templateKey);
   }
   plan.liveEvents.push(
     eventFor(container, mapped.state, labels, context.providerKind, context.now(), mapped.reason),
+  );
+  logger().debug?.(
+    {
+      event: mapped.state === 'starting' ? 'runner.container_created' : 'runner.container_running',
+      providerRunnerId: parsed.providerRunnerId,
+      containerId: container.id,
+      containerName: container.name,
+      templateKey: parsed.templateKey,
+      loggingDriver: container.loggingDriver ?? context.loggingDriver ?? 'daemon-default',
+    },
+    mapped.state === 'starting' ? 'Runner container created' : 'Runner container running',
   );
   if (parsed.runnerInstanceId && parsed.reservationId) {
     plan.assignmentCandidates.push({
@@ -387,6 +642,14 @@ function synthesizeVanishedContainers(
     context.knownTemplateKeys.delete(providerRunnerId);
     const template = templateKey ? context.templatesByKey.get(templateKey) : undefined;
     if (!template) continue;
+    logger().info(
+      {
+        event: 'runner.container_vanished',
+        providerRunnerId,
+        templateKey: template.key,
+      },
+      'Runner container vanished from Docker',
+    );
     plan.terminalActions.push({
       providerRunnerId,
       event: {
@@ -435,24 +698,87 @@ async function applyObservedContainers(
   containers: readonly DockerContainerView[],
   terminateIntentIds: ReadonlySet<string>,
 ): Promise<void> {
-  await applyObservationPlan(
-    context,
-    buildObservationPlan(context, containers, terminateIntentIds),
-  );
-  reportBacklogIfNeeded(context);
+  context.pendingMissingLabelEpisodes.length = 0;
+  const plan = buildObservationPlan(context, containers, terminateIntentIds);
+  flushMissingLabelEpisodes(context);
+  await applyObservationPlan(context, plan);
 }
 
 async function applyTerminalActions(
   context: DockerLifecycleContext,
   actions: readonly TerminalAction[],
 ): Promise<void> {
+  const requestedIds = actions
+    .filter((action) => action.reason === 'backend-terminate')
+    .filter((action) => {
+      const update = recordEpisode(
+        context.episodes,
+        episodeKey('termination', action.providerRunnerId),
+        'requested',
+        context.now(),
+      );
+      return shouldLogEpisode(update);
+    })
+    .map((action) => action.providerRunnerId);
+  if (requestedIds.length > 0) {
+    logger().info(
+      {
+        event: 'runner.container_termination_requested',
+        operation: 'kill_and_remove',
+        count: requestedIds.length,
+        providerRunnerIdSample: boundedSample(requestedIds),
+      },
+      'Runner container termination batch requested',
+    );
+  }
   for (const action of actions) {
+    const reportBeforeRemove = action.event?.state === 'failed' && action.remove;
+    let reportError: unknown;
+    if (reportBeforeRemove && action.event) {
+      try {
+        await reportEvents(context, [action.event]);
+      } catch (error) {
+        reportError = error;
+      }
+    }
     if (action.killAndRemove) await context.engine.killAndRemove(action.killAndRemove);
     if (action.remove) await context.engine.remove(action.remove);
-    if (action.event) await reportEvents(context, [action.event]);
+    if (reportError) throw reportError;
+    if (!reportBeforeRemove && action.event) await reportEvents(context, [action.event]);
+    if (action.event?.state === 'stopped') {
+      logger().debug?.(
+        {event: 'runner.container_stopped', providerRunnerId: action.providerRunnerId},
+        'Runner container stopped successfully',
+      );
+    }
+    if (action.remove || action.killAndRemove) {
+      logger().debug?.(
+        {
+          event: 'runner.container_removed',
+          providerRunnerId: action.providerRunnerId,
+          operation: action.killAndRemove ? 'kill_and_remove' : 'remove',
+        },
+        'Runner container removed',
+      );
+    }
+    if (action.reason === 'registration-deadline') {
+      closeEpisode(context.episodes, episodeKey('stale-reap', action.providerRunnerId));
+    }
+    if (action.reason === 'backend-terminate') {
+      const requestedIds =
+        action.requestSource === 'poll'
+          ? context.pollTerminationRequestedIds
+          : context.backendTerminationRequestedIds;
+      requestedIds.delete(action.providerRunnerId);
+      syncTerminationEpisodes(context);
+    }
     context.knownLiveIds.delete(action.providerRunnerId);
     context.knownTemplateKeys.delete(action.providerRunnerId);
     context.tracker.remove(action.providerRunnerId);
+    if (!action.retained) {
+      context.reportedFailedIds.delete(action.providerRunnerId);
+      context.reportedFailedContainerIds.delete(action.providerRunnerId);
+    }
   }
 }
 
@@ -469,30 +795,41 @@ async function reportEvents(
     const batch = batches[index] ?? [];
     try {
       await context.client.reportRunnerInstances({events: batch});
+      context.reportDeliveryDelivered += batch.length;
     } catch (error) {
       if (error instanceof ProvisionerAuthenticationError) {
         bufferReports(context, [...batch, ...batches.slice(index + 1).flat()]);
+        recordReportDeliveryFailure(context, error);
         throw error;
       }
       if (isPermanentReportError(error)) {
         logger().error(
-          {err: error, count: batch.length},
-          'Dropping invalid provisioned runner report batch',
+          {
+            event: 'runner_report.invalid_batch_dropped',
+            operation: 'report_runner_instances',
+            count: batch.length,
+          },
+          'Dropped invalid runner report batch',
         );
         continue;
       }
       const unsent = [...batch, ...batches.slice(index + 1).flat()];
       bufferReports(context, unsent);
+      recordReportDeliveryFailure(context, error);
       return;
     }
   }
+  recordReportDeliveryRecovery(context);
 }
 
 async function flush(context: DockerLifecycleContext): Promise<void> {
   try {
     await reportEvents(context, []);
   } catch (error) {
-    logger().error({err: error}, 'Failed to flush provisioned runner reports on shutdown');
+    logger().error(
+      {event: 'runner_report.flush_failed', operation: 'flush_reports', reason: errorReason(error)},
+      'Failed to flush provisioned runner reports on shutdown',
+    );
   }
 }
 
@@ -500,17 +837,17 @@ function terminalActionFor(
   context: DockerLifecycleContext,
   container: DockerContainerView,
   reason: string,
+  requestSource?: TerminationRequestSource,
 ): TerminalAction {
   const parsed = parseContainerIdentity(container);
   const labels = labelsFor(context, parsed.templateKey, parsed.labels);
   if (labels.length === 0) {
-    logger().warn(
-      {providerRunnerId: parsed.providerRunnerId},
-      'Skipping provisioned runner report because labels are unavailable',
-    );
+    logMissingLabels(context, parsed.providerRunnerId, parsed.templateKey);
     return {
       providerRunnerId: parsed.providerRunnerId,
       killAndRemove: container.name,
+      reason,
+      ...(requestSource ? {requestSource} : {}),
     };
   }
 
@@ -519,6 +856,8 @@ function terminalActionFor(
     providerRunnerId: parsed.providerRunnerId,
     event: eventFor(container, 'terminated', labels, context.providerKind, context.now(), reason),
     killAndRemove: container.name,
+    reason,
+    ...(requestSource ? {requestSource} : {}),
   };
 }
 
@@ -553,28 +892,7 @@ function bufferReports(
   }
 
   if (dropped > 0) {
-    logger().warn(
-      {dropped, pending: context.pendingReports.length},
-      'Dropped buffered provisioned runner reports after retry queue overflow',
-    );
-  }
-}
-
-function reportBacklogIfNeeded(context: DockerLifecycleContext): void {
-  if (context.pendingReports.length === 0) {
-    context.reportBacklogPasses = 0;
-    return;
-  }
-
-  context.reportBacklogPasses += 1;
-  if (
-    context.reportBacklogPasses === 2 ||
-    context.reportBacklogPasses % REPORT_BACKLOG_LOG_EVERY_PASSES === 0
-  ) {
-    logger().error(
-      {pending: context.pendingReports.length},
-      'Provisioned-runner reports backing up',
-    );
+    context.reportQueueDropped += dropped;
   }
 }
 
@@ -655,6 +973,53 @@ function errorReason(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function episodeKey(kind: string, target: string): string {
+  return `${kind}:${target}`;
+}
+
+function episodeTarget(key: string, kind: string): string | undefined {
+  const prefix = `${kind}:`;
+  return key.startsWith(prefix) ? key.slice(prefix.length) : undefined;
+}
+
+function shouldLogEpisode(update: {transition: string; reminder: boolean}): boolean {
+  return update.transition !== 'suppressed' || update.reminder;
+}
+
+function logMissingLabels(
+  context: DockerLifecycleContext,
+  providerRunnerId: string,
+  templateKey: string | undefined,
+): void {
+  const update = recordEpisode(
+    context.episodes,
+    episodeKey('missing-labels', providerRunnerId),
+    templateKey ?? 'unknown-template',
+    context.now(),
+  );
+  if (!shouldLogEpisode(update)) return;
+  context.pendingMissingLabelEpisodes.push({
+    providerRunnerId,
+    ...(templateKey ? {templateKey} : {}),
+    update,
+  });
+}
+function flushMissingLabelEpisodes(context: DockerLifecycleContext): void {
+  if (context.pendingMissingLabelEpisodes.length === 0) return;
+  const episodes = context.pendingMissingLabelEpisodes.splice(0);
+  logger().warn(
+    {
+      event: 'runner.report_skipped',
+      count: episodes.length,
+      providerRunnerIdSample: boundedSample(episodes.map(({providerRunnerId}) => providerRunnerId)),
+      attempts: Math.max(...episodes.map(({update: item}) => item.state.attempts)),
+      suppressed: episodes.reduce((sum, {update: item}) => sum + item.state.suppressed, 0),
+      ...(episodes.some(({update: item}) => item.transition === 'changed') ? {changed: true} : {}),
+    },
+    'Skipping provisioned runner reports because labels are unavailable',
+  );
+}
+
 function truncateReason(reason: string): string {
   return reason.slice(0, MAX_REASON_LENGTH);
 }
@@ -665,4 +1030,321 @@ function chunk<T>(items: readonly T[], size: number): T[][] {
     batches.push(items.slice(index, index + size));
   }
   return batches;
+}
+
+async function cleanupRetainedFailedContainers(
+  context: DockerLifecycleContext,
+  containers: readonly DockerContainerView[],
+): Promise<DockerContainerView[]> {
+  if (!shouldRetainFailedContainer(context)) return [...containers];
+
+  const failed = containers.filter(isFailedContainer);
+  const cleanupEligibleFailed = failed.filter((container) => !container.terminalInspectFailed);
+  const now = context.now();
+  for (const container of failed) rememberFirstObservedFailure(context, container, now);
+  const expired = cleanupEligibleFailed.filter(
+    (container) => failureAge(context, container, now) >= context.failedContainerRetentionMs,
+  );
+  const notExpired = failed.filter((container) => !expired.includes(container));
+  const limitEvicted = [...notExpired]
+    .sort(
+      (left, right) => countEvictionAge(context, left, now) - countEvictionAge(context, right, now),
+    )
+    .slice(context.maxRetainedFailedContainers);
+  const removals = dedupeContainers([...expired, ...limitEvicted]);
+  const removedIds = new Set<string>();
+  let failedRemoval = 0;
+  const cleanupEpisodes: Array<{
+    container: DockerContainerView;
+    error: unknown;
+    update: ReturnType<typeof recordEpisode>;
+  }> = [];
+
+  for (const container of removals) {
+    try {
+      await context.engine.remove(container.name);
+      removedIds.add(container.id);
+      context.firstObservedFailedAt.delete(container.id);
+      context.reportedFailedIds.delete(parseContainerIdentity(container).providerRunnerId);
+      context.reportedFailedContainerIds.delete(parseContainerIdentity(container).providerRunnerId);
+      closeEpisode(context.episodes, episodeKey('failed-cleanup', container.id));
+      logger().debug?.(
+        {
+          event: 'runner.container_removed',
+          operation: 'failed_container_cleanup',
+          containerId: container.id,
+          containerName: container.name,
+        },
+        'Retained failed runner container removed',
+      );
+    } catch (error) {
+      failedRemoval += 1;
+      const update = recordEpisode(
+        context.episodes,
+        episodeKey('failed-cleanup', container.id),
+        errorReason(error),
+        now,
+      );
+      cleanupEpisodes.push({container, error, update});
+    }
+  }
+
+  const loggableCleanupEpisodes = cleanupEpisodes.filter(({update}) => shouldLogEpisode(update));
+  if (loggableCleanupEpisodes.length > 0) {
+    const firstFailure = loggableCleanupEpisodes[0];
+    if (firstFailure) {
+      logger().error(
+        {
+          event: 'runner.failed_container_cleanup_failed',
+          operation: 'remove',
+          containerId: firstFailure.container.id,
+          containerName: firstFailure.container.name,
+          containerIdSample: boundedSample(
+            loggableCleanupEpisodes.map(({container}) => container.id),
+          ),
+          reason: errorReason(firstFailure.error),
+          failedRemoval,
+          episodeCount: loggableCleanupEpisodes.length,
+          attempts: Math.max(...loggableCleanupEpisodes.map(({update}) => update.state.attempts)),
+          suppressed: loggableCleanupEpisodes.reduce(
+            (sum, {update}) => sum + update.state.suppressed,
+            0,
+          ),
+          ...(loggableCleanupEpisodes.some(({update}) => update.transition === 'changed')
+            ? {changed: true}
+            : {}),
+        },
+        'Failed to remove retained failed runner container; will retry',
+      );
+    }
+  }
+
+  const remaining = failed.filter((container) => !removedIds.has(container.id)).length;
+  if (removedIds.size > 0) {
+    logger().info(
+      {
+        event: 'runner.cleanup_pass_completed',
+        attempted: removals.length,
+        removed: removedIds.size,
+        failed: failedRemoval,
+        expired: expired.length,
+        limitEvicted: limitEvicted.length,
+        remaining,
+      },
+      'Failed runner container cleanup pass completed',
+    );
+  }
+
+  return containers.filter((container) => !removedIds.has(container.id));
+}
+
+function shouldRetainFailedContainer(context: DockerLifecycleContext): boolean {
+  return context.failedContainerRetentionMs > 0 && context.maxRetainedFailedContainers > 0;
+}
+
+function isFailedContainer(container: DockerContainerView): boolean {
+  return container.state === 'exited' && (container.oomKilled === true || container.exitCode !== 0);
+}
+
+function failureAge(
+  context: DockerLifecycleContext,
+  container: DockerContainerView,
+  now: Date,
+): number {
+  const terminalAt = failureAtForRetention(context, container, now);
+  return Math.max(0, now.getTime() - terminalAt.getTime());
+}
+
+function countEvictionAge(
+  context: DockerLifecycleContext,
+  container: DockerContainerView,
+  now: Date,
+): number {
+  if (!container.finishedAt || Number.isNaN(container.finishedAt.getTime())) {
+    return failureAge(context, container, now);
+  }
+  return failureAge(context, container, now);
+}
+
+function rememberFirstObservedFailure(
+  context: DockerLifecycleContext,
+  container: DockerContainerView,
+  observedAt = context.now(),
+): void {
+  if (container.finishedAt && !Number.isNaN(container.finishedAt.getTime())) return;
+  if (context.firstObservedFailedAt.has(container.id)) return;
+  context.firstObservedFailedAt.set(container.id, observedAt);
+}
+
+function dedupeContainers(containers: readonly DockerContainerView[]): DockerContainerView[] {
+  const seen = new Set<string>();
+  return containers.filter((container) => {
+    if (seen.has(container.id)) return false;
+    seen.add(container.id);
+    return true;
+  });
+}
+
+function logFailedContainer(
+  context: DockerLifecycleContext,
+  container: DockerContainerView,
+  parsed: ParsedContainerIdentity,
+  reason: string | undefined,
+): void {
+  const finishedAtUnavailable =
+    !container.finishedAt || Number.isNaN(container.finishedAt.getTime());
+  if (finishedAtUnavailable) {
+    logger().debug?.(
+      {
+        event: 'runner.container_failure_timestamp_fallback',
+        operation: 'failed_container_retention',
+        containerId: container.id,
+        containerName: container.name,
+        fallback: 'firstObservedAt',
+        reason: container.terminalInspectFailed
+          ? 'terminal-inspect-unavailable'
+          : 'finished-at-unavailable',
+      },
+      container.terminalInspectFailed
+        ? 'Failure timestamp unavailable; TTL cleanup is deferred but count-bounded cleanup still applies'
+        : 'Failure timestamp unavailable; first-observed failure time will drive TTL cleanup',
+    );
+  }
+  const runtimeEndAt = failureAtForRetention(context, container, context.now());
+  const runtimeMs =
+    container.startedAt && !Number.isNaN(container.startedAt.getTime())
+      ? Math.max(0, runtimeEndAt.getTime() - container.startedAt.getTime())
+      : undefined;
+  const retentionDeadline =
+    shouldRetainFailedContainer(context) && !container.terminalInspectFailed
+      ? new Date(
+          failureAtForRetention(context, container, context.now()).getTime() +
+            context.failedContainerRetentionMs,
+        )
+      : undefined;
+  const forensicFields = forensicLogFields(container, context);
+  logger().error(
+    {
+      event: 'runner.container_failed',
+      providerRunnerId: parsed.providerRunnerId,
+      ...(parsed.runnerInstanceId ? {runnerInstanceId: parsed.runnerInstanceId} : {}),
+      containerId: container.id,
+      containerName: container.name,
+      templateKey: parsed.templateKey,
+      image: container.image,
+      exitCode: container.exitCode ?? null,
+      oomKilled: container.oomKilled ?? false,
+      reason,
+      runtimeMs,
+      loggingDriver: container.loggingDriver ?? context.loggingDriver ?? 'daemon-default',
+      loggingDriverSource: context.loggingDriverSource,
+      ...(retentionDeadline ? {retentionDeadline: retentionDeadline.toISOString()} : {}),
+      ...forensicFields,
+    },
+    shouldRetainFailedContainer(context)
+      ? 'Runner container failed and was retained for forensic inspection'
+      : 'Runner container failed',
+  );
+}
+
+function forensicLogFields(
+  container: DockerContainerView,
+  context: DockerLifecycleContext,
+): Record<string, string> {
+  const driver = container.loggingDriver ?? context.loggingDriver;
+  if (driver === 'local' || driver === 'json-file') {
+    return {
+      dockerLogsCommand: `docker --host "$SHIPFOX_PROVISIONER_DOCKER_HOST" logs --timestamps --tail 200 ${container.name}`,
+      dockerLogsHostHint:
+        'Target the daemon configured by SHIPFOX_PROVISIONER_DOCKER_HOST; omit --host when using the local default',
+    };
+  }
+  if (driver === 'journald') {
+    return {
+      journaldCommand: `journalctl CONTAINER_NAME=${container.name}`,
+      journaldHostHint:
+        'Run journalctl on the Docker daemon host configured by SHIPFOX_PROVISIONER_DOCKER_HOST',
+    };
+  }
+  if (driver === 'none') {
+    return {loggingBackendHint: 'Container logging is disabled for this driver'};
+  }
+  return {
+    loggingBackendHint: driver
+      ? `Use the ${driver} Docker logging backend to retrieve container output`
+      : 'Use the configured Docker logging backend to retrieve container output',
+  };
+}
+
+function failureAtForRetention(
+  context: DockerLifecycleContext,
+  container: DockerContainerView,
+  fallback: Date,
+): Date {
+  if (container.finishedAt && !Number.isNaN(container.finishedAt.getTime())) {
+    return container.finishedAt;
+  }
+  return context.firstObservedFailedAt.get(container.id) ?? fallback;
+}
+
+function recordReportDeliveryFailure(context: DockerLifecycleContext, error: unknown): void {
+  const hadEpisode = context.episodes.has('report-delivery');
+  const update = recordEpisode(
+    context.episodes,
+    'report-delivery',
+    errorReason(error),
+    context.now(),
+  );
+  if (!hadEpisode) {
+    context.reportDeliveryDelivered = 0;
+  }
+  if (update.transition !== 'suppressed') {
+    logger().error(
+      {
+        event: 'runner_report.delivery_degraded',
+        operation: 'report_runner_instances',
+        cause: errorReason(error),
+        pending: context.pendingReports.length,
+        attempts: update.state.attempts,
+        suppressed: update.state.suppressed,
+        ...(context.reportQueueDropped > 0 ? {queueDropped: context.reportQueueDropped} : {}),
+      },
+      'Runner report delivery degraded',
+    );
+  }
+  if (update.reminder) {
+    logger().warn(
+      {
+        event: 'runner_report.delivery_degraded_reminder',
+        pending: context.pendingReports.length,
+        suppressed: update.state.suppressed,
+        attempts: update.state.attempts,
+        ...(context.reportQueueDropped > 0 ? {queueDropped: context.reportQueueDropped} : {}),
+      },
+      'Runner report delivery remains degraded',
+    );
+  }
+}
+
+function recordReportDeliveryRecovery(context: DockerLifecycleContext): void {
+  const episode = context.episodes.get('report-delivery');
+  if (!episode) return;
+  logger().info(
+    {
+      event: 'runner_report.delivery_recovered',
+      outageDurationMs: Math.max(0, context.now().getTime() - episode.startedAt.getTime()),
+      attempts: episode.attempts,
+      delivered: context.reportDeliveryDelivered,
+      suppressed: episode.suppressed,
+      ...(context.reportQueueDropped > 0 ? {queueDropped: context.reportQueueDropped} : {}),
+    },
+    'Runner report delivery recovered',
+  );
+  closeEpisode(context.episodes, 'report-delivery');
+  context.reportDeliveryDelivered = 0;
+  context.reportQueueDropped = 0;
+}
+
+function boundedSample(values: readonly string[], limit = 20): string[] {
+  return values.slice(0, limit);
 }

--- a/libs/provisioner/docker/src/provisioner.ts
+++ b/libs/provisioner/docker/src/provisioner.ts
@@ -1,6 +1,7 @@
+import {logger} from '@shipfox/node-opentelemetry';
 import {startProvisioner} from '@shipfox/provisioner-core';
-import {config, dockerExtraHosts} from '#config.js';
-import {createDockerEngine} from '#docker-engine.js';
+import {config, dockerExtraHosts, dockerLogDriver, dockerLogOptions} from '#config.js';
+import {createDockerEngine, DockerEngineError} from '#docker-engine.js';
 import {createDockerLifecycle, type DockerLifecycle} from '#lifecycle.js';
 import {type DockerTemplateSpec, loadDockerTemplates} from '#templates.js';
 
@@ -18,12 +19,42 @@ export function startDockerProvisioner(): Promise<void> {
       ? {network: config.SHIPFOX_PROVISIONER_DOCKER_NETWORK}
       : {}),
     ...(dockerExtraHosts ? {extraHosts: dockerExtraHosts} : {}),
+    ...(dockerLogDriver ? {loggingDriver: dockerLogDriver} : {}),
+    ...(dockerLogOptions ? {loggingOptions: dockerLogOptions} : {}),
   });
   let lifecycle: DockerLifecycle | undefined;
+  let effectiveLoggingDriver = dockerLogDriver;
+  const loggingDriverSource: 'daemon' | 'provisioner' = dockerLogDriver ? 'provisioner' : 'daemon';
 
   return startProvisioner<DockerTemplateSpec>({
     adapter: {
       loadTemplates: () => Promise.resolve(templates),
+      async onConfigure() {
+        if (!dockerLogDriver) {
+          try {
+            effectiveLoggingDriver = (await engine.getInfo()).loggingDriver;
+          } catch (error) {
+            logger().warn(
+              {
+                event: 'docker.logging_driver_discovery_deferred',
+                operation: 'docker_info',
+                reason: error instanceof DockerEngineError ? error.reason : 'unknown',
+              },
+              'Docker logging-driver discovery deferred until the daemon is available',
+            );
+          }
+        }
+        return {
+          loggingDriver: effectiveLoggingDriver ?? 'daemon-default',
+          loggingDriverSource,
+          loggingDriverDiscovery: effectiveLoggingDriver ? 'detected' : 'deferred',
+          loggingOptionNames: dockerLogOptions ? Object.keys(dockerLogOptions).sort() : [],
+          failedContainerRetentionMs:
+            config.SHIPFOX_PROVISIONER_DOCKER_FAILED_CONTAINER_RETENTION_MS,
+          maxRetainedFailedContainers:
+            config.SHIPFOX_PROVISIONER_DOCKER_MAX_RETAINED_FAILED_CONTAINERS,
+        };
+      },
       launch: (launch) => {
         if (!lifecycle) throw new Error('Docker lifecycle has not been initialized.');
         return lifecycle.launch(launch);
@@ -41,11 +72,33 @@ export function startDockerProvisioner(): Promise<void> {
           templates,
           registrationDeadlineMs: config.SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS,
           providerKind: 'docker',
+          failedContainerRetentionMs:
+            config.SHIPFOX_PROVISIONER_DOCKER_FAILED_CONTAINER_RETENTION_MS,
+          maxRetainedFailedContainers:
+            config.SHIPFOX_PROVISIONER_DOCKER_MAX_RETAINED_FAILED_CONTAINERS,
+          ...(effectiveLoggingDriver ? {loggingDriver: effectiveLoggingDriver} : {}),
+          loggingDriverSource,
         });
         await lifecycle.reconcile();
       },
-      onTick() {
+      async onTick() {
         if (!lifecycle) throw new Error('Docker lifecycle has not been initialized.');
+        if (!dockerLogDriver && !effectiveLoggingDriver) {
+          try {
+            effectiveLoggingDriver = (await engine.getInfo()).loggingDriver;
+            lifecycle.setLoggingDriver(effectiveLoggingDriver);
+            logger().info(
+              {
+                event: 'docker.logging_driver_discovered',
+                loggingDriver: effectiveLoggingDriver,
+                loggingDriverSource: 'daemon',
+              },
+              'Docker logging driver discovered after startup',
+            );
+          } catch {
+            // Observation below remains the recoverable source of truth for daemon health.
+          }
+        }
         return lifecycle.tick();
       },
       onStop() {

--- a/libs/provisioner/docker/src/templates.test.ts
+++ b/libs/provisioner/docker/src/templates.test.ts
@@ -4,14 +4,14 @@ import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {DEFAULT_RUNNER_IMAGE, DockerTemplateConfigError, loadDockerTemplates} from '#templates.js';
 
-const mocks = vi.hoisted(() => ({warn: vi.fn()}));
+const mocks = vi.hoisted(() => ({debug: vi.fn()}));
 vi.mock('@shipfox/node-opentelemetry', () => ({logger: () => mocks}));
 
 let dir: string;
 
 beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), 'provisioner-docker-'));
-  mocks.warn.mockReset();
+  mocks.debug.mockReset();
 });
 
 afterEach(() => {
@@ -80,9 +80,14 @@ templates:
     const [template] = loadDockerTemplates(path);
 
     expect(template?.spec.image).toBe(DEFAULT_RUNNER_IMAGE);
-    expect(mocks.warn).toHaveBeenCalledWith(
-      {filePath: path, templateKey: 'docker-ubuntu22', image: DEFAULT_RUNNER_IMAGE},
-      'Docker template image omitted; using default runner image',
+    expect(mocks.debug).toHaveBeenCalledWith(
+      {
+        event: 'runner.default_image_selected',
+        filePath: path,
+        templateKey: 'docker-ubuntu22',
+        image: DEFAULT_RUNNER_IMAGE,
+      },
+      'Docker template omitted image; selected ghcr.io/shipfoxhq/runner:latest as the default runner image',
     );
   });
 

--- a/libs/provisioner/docker/src/templates.ts
+++ b/libs/provisioner/docker/src/templates.ts
@@ -66,9 +66,14 @@ export function loadDockerTemplates(filePath: string): ProvisionerTemplate<Docke
 
   return entries.map(([key, spec]) => {
     if (!hasImageField(raw, key)) {
-      logger().warn(
-        {filePath, templateKey: key, image: spec.image},
-        'Docker template image omitted; using default runner image',
+      logger().debug?.(
+        {
+          event: 'runner.default_image_selected',
+          filePath,
+          templateKey: key,
+          image: spec.image,
+        },
+        'Docker template omitted image; selected ghcr.io/shipfoxhq/runner:latest as the default runner image',
       );
     }
     return toTemplate(filePath, key, spec);

--- a/tools/vitest/src/run.ts
+++ b/tools/vitest/src/run.ts
@@ -2,4 +2,4 @@
 
 import {runVitest} from './run-vitest.js';
 
-runVitest(['run']);
+runVitest(['run', ...process.argv.slice(2)]);

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -83,6 +83,20 @@
       ],
       "dependsOn": ["^build", "build"]
     },
+    "test:integration": {
+      "cache": false,
+      "passThroughEnv": [
+        "CLIENT_BASE_URL",
+        "GITEA_BASE_URL",
+        "LOG_STORAGE_S3_ENDPOINT",
+        "OTEL_*",
+        "POSTGRES_*",
+        "SHIPFOX_*",
+        "TEMPORAL_*",
+        "VITE_API_URL"
+      ],
+      "dependsOn": ["^build", "build"]
+    },
     "test:external": {
       "cache": false,
       "dependsOn": ["^build", "build", "^type:emit", "type:emit"]


### PR DESCRIPTION
## Summary

The Docker provisioner now reports lifecycle transitions and retained failures with bounded, actionable diagnostics while keeping capacity admission health-aware. The shared control loop separates reservation polling from total launch admission, and Docker launch outcomes distinguish container creation from later identity/reporting stages.

The change also documents the logging and retention controls, adds real-Docker logging-driver coverage to CI, and forwards arguments through the Vitest wrapper used by that integration path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the Docker provisioner’s lifecycle observability and health-aware admission, adds bounded failed-container retention, and makes Docker logging configurable. Start-report delivery failures now mark launches as incomplete instead of reporting container failures.

- New Features
  - Health-aware control loop: tracks failures by facet, backs off capacity on provider observation issues, and emits degraded/ready events.
  - Bounded failed-container retention: keep failures for up to 1h or 20 containers (configurable), then clean up; successful exits are removed immediately; stale created containers are reaped.
  - Configurable Docker logging: `SHIPFOX_PROVISIONER_DOCKER_LOG_DRIVER` and `SHIPFOX_PROVISIONER_DOCKER_LOG_OPTIONS` (values never logged); inherits daemon default if unset.
  - Launch outcomes: providers return `containerStarted`, `identityAttached`, and `reported`; failed report delivery yields an incomplete launch instead of a failure.

- Refactors
  - Separated reservation polling from launch admission; admission respects health, a launch budget, and reservation capacity when filling warm pools.
  - Clearer auth errors with action context; structured logs with `event` fields and better fatal error details.
  - Docker engine exposes daemon logging driver and applies configured `LogConfig`; container views include timing, image, and logging metadata.
  - Docs updated; CI runs a Docker logging-driver integration test; `@shipfox/vitest` forwards CLI args.

<sup>Written for commit e650c82dba51bec21c52f3f713c8592b9358c2ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

