### PR TITLE
[api-auth] Remove version segment from administration routes

### DIFF
--- a/.changeset/unversioned-admin-routes.md
+++ b/.changeset/unversioned-admin-routes.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-auth": minor
+---
+
+Moves Auth administration routes to the unversioned `/admin/...` namespace.

--- a/docs/adr/0008-administration-controls.md
+++ b/docs/adr/0008-administration-controls.md
@@ -92,7 +92,7 @@ The token never enters browser storage, API responses, logs, or audit metadata.
 **Each domain module owns administration behavior for its resources.** The
 owner defines:
 
-- Its `/admin/v1/...` HTTP routes and each route's minimum role.
+- Its `/admin/...` HTTP routes and each route's minimum role.
 - Its use cases and call to the Auth role check.
 - Its database reads and mutations.
 - Its safe dashboard read model and client feature.
@@ -102,11 +102,11 @@ The initial path families are:
 
 | Owner | Path family | Minimum role and scope |
 | --- | --- | --- |
-| Auth | `/admin/v1/auth/users` | `admin-observer` for bounded lookup and safe account status; `admin-operator` for suspension, reactivation, and session revocation. |
-| Auth | `/admin/v1/auth/admin-grants` | `admin-owner` for local administrator role listing and changes. |
-| Workspaces | `/admin/v1/workspaces` | `admin-observer` for bounded lookup and safe status; `admin-operator` for suspension and reactivation. |
-| Projects | `/admin/v1/projects` | `admin-observer` for bounded lookup and safe status. |
-| Each configuration owner | `/admin/v1/<module>/configuration` | `admin-observer` for safe effective-configuration inspection. |
+| Auth | `/admin/auth/users` | `admin-observer` for bounded lookup and safe account status; `admin-operator` for suspension, reactivation, and session revocation. |
+| Auth | `/admin/auth/admin-grants` | `admin-owner` for local administrator role listing and changes. |
+| Workspaces | `/admin/workspaces` | `admin-observer` for bounded lookup and safe status; `admin-operator` for suspension and reactivation. |
+| Projects | `/admin/projects` | `admin-observer` for bounded lookup and safe status. |
+| Each configuration owner | `/admin/<module>/configuration` | `admin-observer` for safe effective-configuration inspection. |
 
 **Authorization and behavior stay at the owning route or use case.** A module
 obtains current facts from another module through the producer's declared
@@ -119,7 +119,7 @@ through a central Administration gateway.
 
 ### Keep the API dashboard-only
 
-**`/admin/v1` is an internal contract for the Shipfox administration
+**`/admin` is an internal contract for the Shipfox administration
 dashboard.** Requests use the ordinary authenticated browser session and the
 normal same-origin protections. Mutations use the same Cross-Site Request
 Forgery (CSRF), origin, secure-cookie, and session-rotation protections as

--- a/libs/api/auth/README.md
+++ b/libs/api/auth/README.md
@@ -234,7 +234,7 @@ When password login is disabled, the password and email-verification rows in thi
 
 ### Administrator grants
 
-All routes are mounted under `/admin/v1/auth/admin-grants` and require an authenticated bearer token. Ownership is enforced in the core layer, not by route-level middleware.
+All routes are mounted under `/admin/auth/admin-grants` and require an authenticated bearer token. Ownership is enforced in the core layer, not by route-level middleware.
 
 | Method | Path | Required role | Result |
 | --- | --- | --- | --- |
@@ -254,7 +254,7 @@ The public auth endpoints include an application-layer abuse baseline for open s
 | `POST /auth/login` | 60 attempts per 5 minutes | 10 attempts per 15 minutes |
 | `POST /auth/password-reset` | 30 email-send attempts per hour | 3 email-send attempts per hour |
 | `POST /auth/verify-email/resend` | Shared with password reset | Shared with password reset |
-| `POST /admin/v1/auth/admin-grants/bootstrap` | 5 attempts per 15 minutes | n/a |
+| `POST /admin/auth/admin-grants/bootstrap` | 5 attempts per 15 minutes | n/a |
 
 Counters are stored in PostgreSQL as fixed windows in `auth_rate_limits`. IP addresses and email addresses are HMAC-SHA256 values before storage; raw identifiers are not persisted. The identifier key is derived from `AUTH_ROOT_KEY` separately from every token key.
 

--- a/libs/api/auth/src/presentation/routes/administration.test.ts
+++ b/libs/api/auth/src/presentation/routes/administration.test.ts
@@ -37,10 +37,21 @@ describe('Auth administration routes', () => {
     await app.close();
   });
 
-  test('requires an authenticated session for bootstrap', async () => {
+  test('does not register the removed versioned administration namespace', async () => {
     const response = await app.inject({
       method: 'POST',
       url: '/admin/v1/auth/admin-grants/bootstrap',
+      headers: {'idempotency-key': 'removed-versioned-bootstrap'},
+      payload: {bootstrap_token: BOOTSTRAP_TOKEN},
+    });
+
+    expect(response.statusCode).toBe(404);
+  });
+
+  test('requires an authenticated session for bootstrap', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/admin/auth/admin-grants/bootstrap',
       headers: {'idempotency-key': 'anonymous-bootstrap'},
       payload: {bootstrap_token: BOOTSTRAP_TOKEN},
     });
@@ -53,7 +64,7 @@ describe('Auth administration routes', () => {
 
     const response = await app.inject({
       method: 'POST',
-      url: '/admin/v1/auth/admin-grants/bootstrap',
+      url: '/admin/auth/admin-grants/bootstrap',
       headers: authHeaders(account.token, 'invalid-bootstrap'),
       payload: {bootstrap_token: 'wrong-token'},
     });
@@ -69,7 +80,7 @@ describe('Auth administration routes', () => {
     for (let attempt = 0; attempt < 5; attempt += 1) {
       const response = await app.inject({
         method: 'POST',
-        url: '/admin/v1/auth/admin-grants/bootstrap',
+        url: '/admin/auth/admin-grants/bootstrap',
         headers: authHeaders(account.token, `bootstrap-rate-limit-${attempt}`),
         payload: {bootstrap_token: 'wrong-token'},
       });
@@ -78,7 +89,7 @@ describe('Auth administration routes', () => {
 
     const blocked = await app.inject({
       method: 'POST',
-      url: '/admin/v1/auth/admin-grants/bootstrap',
+      url: '/admin/auth/admin-grants/bootstrap',
       headers: authHeaders(account.token, 'bootstrap-rate-limit-blocked'),
       payload: {bootstrap_token: 'wrong-token'},
     });
@@ -92,7 +103,7 @@ describe('Auth administration routes', () => {
 
     const response = await app.inject({
       method: 'POST',
-      url: '/admin/v1/auth/admin-grants/bootstrap',
+      url: '/admin/auth/admin-grants/bootstrap',
       headers: authHeaders(first.token, 'bootstrap-first'),
       payload: {bootstrap_token: BOOTSTRAP_TOKEN},
     });
@@ -102,7 +113,7 @@ describe('Auth administration routes', () => {
 
     const repeated = await app.inject({
       method: 'POST',
-      url: '/admin/v1/auth/admin-grants/bootstrap',
+      url: '/admin/auth/admin-grants/bootstrap',
       headers: authHeaders(first.token, 'bootstrap-first'),
       payload: {bootstrap_token: BOOTSTRAP_TOKEN},
     });
@@ -111,7 +122,7 @@ describe('Auth administration routes', () => {
 
     const secondAttempt = await app.inject({
       method: 'POST',
-      url: '/admin/v1/auth/admin-grants/bootstrap',
+      url: '/admin/auth/admin-grants/bootstrap',
       headers: authHeaders(second.token, 'bootstrap-second'),
       payload: {bootstrap_token: BOOTSTRAP_TOKEN},
     });
@@ -137,7 +148,7 @@ describe('Auth administration routes', () => {
 
     const bootstrap = await app.inject({
       method: 'POST',
-      url: '/admin/v1/auth/admin-grants/bootstrap',
+      url: '/admin/auth/admin-grants/bootstrap',
       headers: authHeaders(owner.token, 'grant-bootstrap'),
       payload: {bootstrap_token: BOOTSTRAP_TOKEN},
     });
@@ -145,7 +156,7 @@ describe('Auth administration routes', () => {
 
     const grant = await app.inject({
       method: 'POST',
-      url: '/admin/v1/auth/admin-grants',
+      url: '/admin/auth/admin-grants',
       headers: authHeaders(owner.token, 'grant-observer'),
       payload: {
         user_id: target.userId,
@@ -157,7 +168,7 @@ describe('Auth administration routes', () => {
 
     const repeatedGrant = await app.inject({
       method: 'POST',
-      url: '/admin/v1/auth/admin-grants',
+      url: '/admin/auth/admin-grants',
       headers: authHeaders(owner.token, 'grant-observer'),
       payload: {
         user_id: target.userId,
@@ -170,7 +181,7 @@ describe('Auth administration routes', () => {
 
     const grants = await app.inject({
       method: 'GET',
-      url: '/admin/v1/auth/admin-grants',
+      url: '/admin/auth/admin-grants',
       headers: {authorization: `Bearer ${owner.token}`},
     });
     expect(grants.statusCode).toBe(200);
@@ -180,7 +191,7 @@ describe('Auth administration routes', () => {
 
     const revoked = await app.inject({
       method: 'DELETE',
-      url: `/admin/v1/auth/admin-grants/${grant.json().id}`,
+      url: `/admin/auth/admin-grants/${grant.json().id}`,
       headers: authHeaders(owner.token, 'revoke-observer'),
       payload: {reason: 'Support investigation complete'},
     });
@@ -189,7 +200,7 @@ describe('Auth administration routes', () => {
 
     const repeatedRevoke = await app.inject({
       method: 'DELETE',
-      url: `/admin/v1/auth/admin-grants/${grant.json().id}`,
+      url: `/admin/auth/admin-grants/${grant.json().id}`,
       headers: authHeaders(owner.token, 'revoke-observer'),
       payload: {reason: 'Support investigation complete'},
     });
@@ -209,14 +220,14 @@ describe('Auth administration routes', () => {
 
     await app.inject({
       method: 'POST',
-      url: '/admin/v1/auth/admin-grants/bootstrap',
+      url: '/admin/auth/admin-grants/bootstrap',
       headers: authHeaders(owner.token, 'final-bootstrap'),
       payload: {bootstrap_token: BOOTSTRAP_TOKEN},
     });
 
     const firstGrant = await app.inject({
       method: 'POST',
-      url: '/admin/v1/auth/admin-grants',
+      url: '/admin/auth/admin-grants',
       headers: authHeaders(owner.token, 'role-key'),
       payload: {user_id: target.userId, role: 'admin-observer', reason: 'Initial review'},
     });
@@ -224,7 +235,7 @@ describe('Auth administration routes', () => {
 
     const reusedKey = await app.inject({
       method: 'POST',
-      url: '/admin/v1/auth/admin-grants',
+      url: '/admin/auth/admin-grants',
       headers: authHeaders(owner.token, 'role-key'),
       payload: {user_id: target.userId, role: 'admin-operator', reason: 'Different command'},
     });
@@ -233,11 +244,11 @@ describe('Auth administration routes', () => {
 
     const finalOwnerRevoke = await app.inject({
       method: 'DELETE',
-      url: `/admin/v1/auth/admin-grants/${
+      url: `/admin/auth/admin-grants/${
         (
           await app.inject({
             method: 'GET',
-            url: '/admin/v1/auth/admin-grants',
+            url: '/admin/auth/admin-grants',
             headers: {authorization: `Bearer ${owner.token}`},
           })
         )

--- a/libs/api/auth/src/presentation/routes/administration.ts
+++ b/libs/api/auth/src/presentation/routes/administration.ts
@@ -189,7 +189,7 @@ const revokeRoute = defineRoute({
 });
 
 export const administrationRoutes: RouteGroup = {
-  prefix: '/admin/v1/auth/admin-grants',
+  prefix: '/admin/auth/admin-grants',
   auth: AUTH_USER,
   routes: [bootstrapRoute, listRoute, grantRoute, revokeRoute],
 };


### PR DESCRIPTION
Move Auth administrator bootstrap and grant endpoints to the stable unversioned `/admin` namespace before the private dashboard adopts them.

The obsolete `/admin/v1` paths are intentionally not registered. Existing authorization, idempotency, rate limiting, and final-owner protection behavior remains unchanged. Package documentation and the accepted repository ADR now describe the unversioned contract.

Closes ENG-1358

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved Auth administration bootstrap and grant routes in `@shipfox/api-auth` to the stable unversioned `/admin/auth/admin-grants` namespace and stopped registering the old `/admin/v1` paths. Existing authorization, idempotency, rate limiting, and final-owner protections are unchanged; closes ENG-1358.

<sup>Written for commit ddbd184f0dec0c33e864d262962c617a2aaca6a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

