### PR TITLE
Reduce runner activation latency with intended reservations

### DIFF
--- a/.changeset/swift-runners-enroll.md
+++ b/.changeset/swift-runners-enroll.md
@@ -1,5 +1,5 @@
 ---
-"@shipfox/api-runners": patch
+"@shipfox/api-runners": minor
 "@shipfox/api-runners-dto": minor
 ---
 

--- a/.changeset/swift-runners-enroll.md
+++ b/.changeset/swift-runners-enroll.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-runners": patch
+"@shipfox/api-runners-dto": minor
+---
+
+Stores runner reservation intent and promotes it during enrollment for lower activation latency.

--- a/libs/api/runners-dto/src/index.ts
+++ b/libs/api/runners-dto/src/index.ts
@@ -76,6 +76,7 @@ export {
   type RunnerBootstrapExchangeBodyDto,
   type RunnerBootstrapExchangeResponseDto,
   type RunnerEnrollmentBodyDto,
+  type RunnerEnrollmentResponseDto,
   type RunnerHarnessToolCapabilitiesDto,
   type RunnerInstanceReportEventDto,
   type RunnerInstanceStateDto,
@@ -97,6 +98,7 @@ export {
   runnerBootstrapExchangeResponseSchema,
   runnerControlHeartbeatResponseSchema,
   runnerEnrollmentBodySchema,
+  runnerEnrollmentResponseSchema,
   runnerHarnessToolCapabilitiesSchema,
   runnerToolCapabilitiesSchema,
 } from '#schemas/index.js';

--- a/libs/api/runners-dto/src/schemas/index.ts
+++ b/libs/api/runners-dto/src/schemas/index.ts
@@ -111,11 +111,13 @@ export {
   type RunnerBootstrapExchangeBodyDto,
   type RunnerBootstrapExchangeResponseDto,
   type RunnerEnrollmentBodyDto,
+  type RunnerEnrollmentResponseDto,
   runnerAssignmentPollResponseSchema,
   runnerBootstrapExchangeBodySchema,
   runnerBootstrapExchangeResponseSchema,
   runnerControlHeartbeatResponseSchema,
   runnerEnrollmentBodySchema,
+  runnerEnrollmentResponseSchema,
 } from './runner-enrollment.js';
 export {
   type RunnerHarnessToolCapabilitiesDto,

--- a/libs/api/runners-dto/src/schemas/runner-enrollment.ts
+++ b/libs/api/runners-dto/src/schemas/runner-enrollment.ts
@@ -9,7 +9,14 @@ export const createRunnerInstancesBodySchema = z
   .object({
     provider_kind: z.string().min(1).max(64).optional(),
     runner_instances: z
-      .array(z.object({template_key: z.string().min(1).max(255).optional()}).strict())
+      .array(
+        z
+          .object({
+            template_key: z.string().min(1).max(255).optional(),
+            reservation_id: z.string().uuid().optional(),
+          })
+          .strict(),
+      )
       .min(1)
       .max(500),
   })
@@ -32,6 +39,9 @@ export const runnerEnrollmentBodySchema = z
     protocol_version: z.string().min(1).max(64),
   })
   .strict();
+export const runnerEnrollmentResponseSchema = z.object({
+  activation_token: z.string().min(1).nullable(),
+});
 export const attachRunnerControlProviderIdBodySchema = z
   .object({provider_runner_id: z.string().min(1).max(255)})
   .strict();
@@ -47,3 +57,4 @@ export type RunnerBootstrapExchangeResponseDto = z.infer<
   typeof runnerBootstrapExchangeResponseSchema
 >;
 export type RunnerEnrollmentBodyDto = z.infer<typeof runnerEnrollmentBodySchema>;
+export type RunnerEnrollmentResponseDto = z.infer<typeof runnerEnrollmentResponseSchema>;

--- a/libs/api/runners/drizzle/0001_intended_reservation.sql
+++ b/libs/api/runners/drizzle/0001_intended_reservation.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "runners_runner_instances" ADD COLUMN "intended_reservation_id" uuid;--> statement-breakpoint
+CREATE INDEX "runners_runner_instances_provisioner_intended_reservation_idx" ON "runners_runner_instances" USING btree ("provisioner_id","intended_reservation_id") WHERE "runners_runner_instances"."intended_reservation_id" is not null and "runners_runner_instances"."reservation_released_at" is null;--> statement-breakpoint
+CREATE INDEX "runners_runner_instances_provisioner_reservation_idx" ON "runners_runner_instances" USING btree ("provisioner_id","reservation_id") WHERE "runners_runner_instances"."reservation_id" is not null;

--- a/libs/api/runners/drizzle/meta/0001_snapshot.json
+++ b/libs/api/runners/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,2093 @@
+{
+  "id": "3cb0e19d-8b01-4f57-ae98-9b53549f5509",
+  "prevId": "8d720b64-18a7-4afe-a026-b12f509aa356",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.runners_ephemeral_registration_tokens": {
+      "name": "runners_ephemeral_registration_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_id": {
+          "name": "reservation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_runner_id": {
+          "name": "provider_runner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_session_id": {
+          "name": "consumed_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_ephemeral_registration_tokens_hashed_token_unique": {
+          "name": "runners_ephemeral_registration_tokens_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_ephemeral_registration_tokens_reservation_id_idx": {
+          "name": "runners_ephemeral_registration_tokens_reservation_id_idx",
+          "columns": [
+            {
+              "expression": "reservation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_ephemeral_registration_tokens_active_provider_runner_idx": {
+          "name": "runners_ephemeral_registration_tokens_active_provider_runner_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_runner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "consumed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_ephemeral_registration_tokens_terminal_idx": {
+          "name": "runners_ephemeral_registration_tokens_terminal_idx",
+          "columns": [
+            {
+              "expression": "coalesce(\"consumed_at\", \"expires_at\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_manual_registration_tokens": {
+      "name": "runners_manual_registration_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_manual_registration_tokens_hashed_token_unique": {
+          "name": "runners_manual_registration_tokens_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_manual_registration_tokens_workspace_id_idx": {
+          "name": "runners_manual_registration_tokens_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_outbox": {
+      "name": "runners_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordering_key": {
+          "name": "ordering_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_attempts": {
+          "name": "dispatch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_dispatch_at": {
+          "name": "next_dispatch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_dispatch_error": {
+          "name": "last_dispatch_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_dispatch_failed_at": {
+          "name": "last_dispatch_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dead_lettered_at": {
+          "name": "dead_lettered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runners_outbox_pending_idx": {
+          "name": "runners_outbox_pending_idx",
+          "columns": [
+            {
+              "expression": "next_dispatch_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NULL AND \"dead_lettered_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_outbox_dispatched_retention_idx": {
+          "name": "runners_outbox_dispatched_retention_idx",
+          "columns": [
+            {
+              "expression": "dispatched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_pending_jobs": {
+      "name": "runners_pending_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_run_attempt_id": {
+          "name": "workflow_run_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_execution_id": {
+          "name": "job_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required_labels": {
+          "name": "required_labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_pending_jobs_workspace_created_idx": {
+          "name": "runners_pending_jobs_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_pending_jobs_job_id_idx": {
+          "name": "runners_pending_jobs_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "runners_pending_jobs_job_execution_id_unique": {
+          "name": "runners_pending_jobs_job_execution_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["job_execution_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_provisioner_capability_snapshots": {
+      "name": "runners_provisioner_capability_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available_slots": {
+          "name": "available_slots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starting": {
+          "name": "starting",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "running": {
+          "name": "running",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "advertised_at": {
+          "name": "advertised_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_provisioner_capability_snapshots_workspace_active_idx": {
+          "name": "runners_provisioner_capability_snapshots_workspace_active_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "advertised_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_provisioner_capability_snapshots_provisioner_idx": {
+          "name": "runners_provisioner_capability_snapshots_provisioner_idx",
+          "columns": [
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_provisioner_tokens": {
+      "name": "runners_provisioner_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "runners_provisioner_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_provisioner_tokens_hashed_token_unique": {
+          "name": "runners_provisioner_tokens_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_provisioner_tokens_workspace_last_seen_idx": {
+          "name": "runners_provisioner_tokens_workspace_last_seen_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runners_provisioner_tokens_scope_workspace_ck": {
+          "name": "runners_provisioner_tokens_scope_workspace_ck",
+          "value": "(scope = 'workspace' AND workspace_id IS NOT NULL) OR (scope = 'installation' AND workspace_id IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.runners_rate_limits": {
+      "name": "runners_rate_limits",
+      "schema": "",
+      "columns": {
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier_hmac": {
+          "name": "identifier_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_rate_limits_window_unique": {
+          "name": "runners_rate_limits_window_unique",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identifier_hmac",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "window_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_rate_limits_expires_at_idx": {
+          "name": "runners_rate_limits_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_reservations": {
+      "name": "runners_reservations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required_labels": {
+          "name": "required_labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "runners_reservations_workspace_expires_idx": {
+          "name": "runners_reservations_workspace_expires_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_reservations_expires_idx": {
+          "name": "runners_reservations_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runners_reservations_count_positive_ck": {
+          "name": "runners_reservations_count_positive_ck",
+          "value": "\"runners_reservations\".\"count\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.runners_runner_activation_tokens": {
+      "name": "runners_runner_activation_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "runner_instance_id": {
+          "name": "runner_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_session_id": {
+          "name": "consumed_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_runner_activation_tokens_hashed_token_unique": {
+          "name": "runners_runner_activation_tokens_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_activation_tokens_runner_instance_idx": {
+          "name": "runners_runner_activation_tokens_runner_instance_idx",
+          "columns": [
+            {
+              "expression": "runner_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_runner_bootstrap_tokens": {
+      "name": "runners_runner_bootstrap_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "runner_instance_id": {
+          "name": "runner_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_runner_bootstrap_tokens_hashed_token_unique": {
+          "name": "runners_runner_bootstrap_tokens_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_bootstrap_tokens_runner_instance_idx": {
+          "name": "runners_runner_bootstrap_tokens_runner_instance_idx",
+          "columns": [
+            {
+              "expression": "runner_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_runner_control_sessions": {
+      "name": "runners_runner_control_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "runner_instance_id": {
+          "name": "runner_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "close_reason": {
+          "name": "close_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_runner_control_sessions_hashed_token_unique": {
+          "name": "runners_runner_control_sessions_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_control_sessions_active_runner_instance_unique": {
+          "name": "runners_runner_control_sessions_active_runner_instance_unique",
+          "columns": [
+            {
+              "expression": "runner_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"closed_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_control_sessions_runner_instance_idx": {
+          "name": "runners_runner_control_sessions_runner_instance_idx",
+          "columns": [
+            {
+              "expression": "runner_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_runner_instances": {
+      "name": "runners_runner_instances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_runner_id": {
+          "name": "provider_runner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intended_reservation_id": {
+          "name": "intended_reservation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reservation_id": {
+          "name": "reservation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "state": {
+          "name": "state",
+          "type": "runners_provider_runner_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_session_id": {
+          "name": "runner_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_kind": {
+          "name": "provider_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "protocol_version": {
+          "name": "protocol_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stopping_at": {
+          "name": "stopping_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stopped_at": {
+          "name": "stopped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminated_at": {
+          "name": "terminated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reservation_released_at": {
+          "name": "reservation_released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_runner_instances_provisioner_runner_unique": {
+          "name": "runners_runner_instances_provisioner_runner_unique",
+          "columns": [
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_runner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"runners_runner_instances\".\"provider_runner_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_instances_workspace_state_updated_idx": {
+          "name": "runners_runner_instances_workspace_state_updated_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_instances_stale_reaper_idx": {
+          "name": "runners_runner_instances_stale_reaper_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reported_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_instances_provisioner_intended_reservation_idx": {
+          "name": "runners_runner_instances_provisioner_intended_reservation_idx",
+          "columns": [
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "intended_reservation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runners_runner_instances\".\"intended_reservation_id\" is not null and \"runners_runner_instances\".\"reservation_released_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_instances_provisioner_reservation_idx": {
+          "name": "runners_runner_instances_provisioner_reservation_idx",
+          "columns": [
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reservation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runners_runner_instances\".\"reservation_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_instances_active_template_counts_idx": {
+          "name": "runners_runner_instances_active_template_counts_idx",
+          "columns": [
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "template_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"state\" in ('starting', 'running') and \"template_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_runner_sessions": {
+      "name": "runners_runner_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "runners_runner_session_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'workspace'"
+        },
+        "registration_token_id": {
+          "name": "registration_token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_token_kind": {
+          "name": "registration_token_kind",
+          "type": "runners_runner_session_registration_token_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runner_instance_id": {
+          "name": "runner_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_runner_id": {
+          "name": "provider_runner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_capabilities": {
+          "name": "tool_capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_capabilities_reported_at": {
+          "name": "tool_capabilities_reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_claims": {
+          "name": "max_claims",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claims_used": {
+          "name": "claims_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_runner_sessions_kind_created_id_idx": {
+          "name": "runners_runner_sessions_kind_created_id_idx",
+          "columns": [
+            {
+              "expression": "registration_token_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_sessions_provider_runner_updated_idx": {
+          "name": "runners_runner_sessions_provider_runner_updated_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_runner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"provisioner_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runners_runner_sessions_claims_ck": {
+          "name": "runners_runner_sessions_claims_ck",
+          "value": "\"runners_runner_sessions\".\"claims_used\" >= 0 AND ((\"runners_runner_sessions\".\"registration_token_kind\" = 'manual' AND \"runners_runner_sessions\".\"max_claims\" IS NULL) OR (\"runners_runner_sessions\".\"registration_token_kind\" in ('ephemeral', 'activation') AND \"runners_runner_sessions\".\"max_claims\" IS NOT NULL AND \"runners_runner_sessions\".\"max_claims\" > 0 AND \"runners_runner_sessions\".\"claims_used\" <= \"runners_runner_sessions\".\"max_claims\"))"
+        },
+        "runners_runner_sessions_link_ck": {
+          "name": "runners_runner_sessions_link_ck",
+          "value": "((\"runners_runner_sessions\".\"registration_token_kind\" = 'manual' AND \"runners_runner_sessions\".\"runner_instance_id\" IS NULL AND \"runners_runner_sessions\".\"provisioner_id\" IS NULL AND \"runners_runner_sessions\".\"provider_runner_id\" IS NULL) OR (\"runners_runner_sessions\".\"registration_token_kind\" = 'ephemeral' AND \"runners_runner_sessions\".\"runner_instance_id\" IS NULL AND \"runners_runner_sessions\".\"provisioner_id\" IS NOT NULL AND \"runners_runner_sessions\".\"provider_runner_id\" IS NOT NULL) OR (\"runners_runner_sessions\".\"registration_token_kind\" = 'activation' AND \"runners_runner_sessions\".\"runner_instance_id\" IS NOT NULL AND \"runners_runner_sessions\".\"provisioner_id\" IS NOT NULL AND \"runners_runner_sessions\".\"provider_runner_id\" IS NOT NULL))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.runners_running_jobs": {
+      "name": "runners_running_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_run_attempt_id": {
+          "name": "workflow_run_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_execution_id": {
+          "name": "job_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runner_session_id": {
+          "name": "runner_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_runner_id": {
+          "name": "provider_runner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_labels": {
+          "name": "required_labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runner_labels": {
+          "name": "runner_labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "first_heartbeat_at": {
+          "name": "first_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "cancellation_requested_at": {
+          "name": "cancellation_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runners_running_jobs_no_first_heartbeat_started_idx": {
+          "name": "runners_running_jobs_no_first_heartbeat_started_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"first_heartbeat_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_running_jobs_last_heartbeat_at_idx": {
+          "name": "runners_running_jobs_last_heartbeat_at_idx",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_running_jobs_provider_runner_started_idx": {
+          "name": "runners_running_jobs_provider_runner_started_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_runner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"provisioner_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_running_jobs_cancellation_requested_idx": {
+          "name": "runners_running_jobs_cancellation_requested_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_runner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"cancellation_requested_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_running_jobs_job_id_idx": {
+          "name": "runners_running_jobs_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_running_jobs_runner_session_id_idx": {
+          "name": "runners_running_jobs_runner_session_id_idx",
+          "columns": [
+            {
+              "expression": "runner_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runners_running_jobs_runner_session_id_runners_runner_sessions_id_fk": {
+          "name": "runners_running_jobs_runner_session_id_runners_runner_sessions_id_fk",
+          "tableFrom": "runners_running_jobs",
+          "tableTo": "runners_runner_sessions",
+          "columnsFrom": ["runner_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "runners_running_jobs_job_execution_id_unique": {
+          "name": "runners_running_jobs_job_execution_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["job_execution_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "runners_running_jobs_link_ck": {
+          "name": "runners_running_jobs_link_ck",
+          "value": "(\"runners_running_jobs\".\"provisioner_id\" IS NULL) = (\"runners_running_jobs\".\"provider_runner_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.runners_provisioner_scope": {
+      "name": "runners_provisioner_scope",
+      "schema": "public",
+      "values": ["workspace", "installation"]
+    },
+    "public.runners_provider_runner_state": {
+      "name": "runners_provider_runner_state",
+      "schema": "public",
+      "values": ["starting", "running", "stopping", "stopped", "failed", "terminated"]
+    },
+    "public.runners_runner_session_registration_token_kind": {
+      "name": "runners_runner_session_registration_token_kind",
+      "schema": "public",
+      "values": ["manual", "ephemeral", "activation"]
+    },
+    "public.runners_runner_session_scope": {
+      "name": "runners_runner_session_scope",
+      "schema": "public",
+      "values": ["workspace"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/api/runners/drizzle/meta/_journal.json
+++ b/libs/api/runners/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1777238442655,
       "tag": "0000_initial",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1785161220762,
+      "tag": "0001_intended_reservation",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/api/runners/src/core/runner-activation.ts
+++ b/libs/api/runners/src/core/runner-activation.ts
@@ -1,5 +1,6 @@
 import {extractDisplayPrefix, generateOpaqueToken, hashOpaqueToken} from '@shipfox/node-tokens';
 import {and, eq, isNull, sql} from 'drizzle-orm';
+import type {Tx} from '#db/db.js';
 import {db} from '#db/db.js';
 import {runnerActivationTokens} from '#db/schema/runner-activation-tokens.js';
 import {providerRunners} from '#db/schema/runner-instances.js';
@@ -9,46 +10,55 @@ export async function issueRunnerActivationToken(params: {
   provisionerId: string;
   ttlSeconds: number;
 }): Promise<string | null> {
-  return await db().transaction(async (tx) => {
-    await tx.execute(
-      sql`select pg_advisory_xact_lock(hashtext(${`runners_activation:${params.runnerInstanceId}`}))`,
-    );
-    const [runner] = await tx
-      .select({
-        workspaceId: providerRunners.workspaceId,
-        runnerSessionId: providerRunners.runnerSessionId,
-        state: providerRunners.state,
-      })
-      .from(providerRunners)
-      .where(
-        and(
-          eq(providerRunners.id, params.runnerInstanceId),
-          eq(providerRunners.provisionerId, params.provisionerId),
-        ),
-      )
-      .limit(1)
-      .for('update');
-    if (!runner?.workspaceId || runner.runnerSessionId || runner.state !== 'running') return null;
+  return await db().transaction(async (tx) => issueRunnerActivationTokenTx(tx, params));
+}
 
-    await tx
-      .update(runnerActivationTokens)
-      .set({revokedAt: sql`now()`})
-      .where(
-        and(
-          eq(runnerActivationTokens.runnerInstanceId, params.runnerInstanceId),
-          isNull(runnerActivationTokens.consumedAt),
-          isNull(runnerActivationTokens.revokedAt),
-        ),
-      );
-    const rawToken = generateOpaqueToken('runnerActivationToken');
-    await tx.insert(runnerActivationTokens).values({
-      runnerInstanceId: params.runnerInstanceId,
-      hashedToken: hashOpaqueToken(rawToken),
-      prefix: extractDisplayPrefix(rawToken),
-      expiresAt: new Date(Date.now() + params.ttlSeconds * 1000),
-    });
-    return rawToken;
+export async function issueRunnerActivationTokenTx(
+  tx: Tx,
+  params: {
+    runnerInstanceId: string;
+    provisionerId: string;
+    ttlSeconds: number;
+  },
+): Promise<string | null> {
+  await tx.execute(
+    sql`select pg_advisory_xact_lock(hashtext(${`runners_activation:${params.runnerInstanceId}`}))`,
+  );
+  const [runner] = await tx
+    .select({
+      workspaceId: providerRunners.workspaceId,
+      runnerSessionId: providerRunners.runnerSessionId,
+      state: providerRunners.state,
+    })
+    .from(providerRunners)
+    .where(
+      and(
+        eq(providerRunners.id, params.runnerInstanceId),
+        eq(providerRunners.provisionerId, params.provisionerId),
+      ),
+    )
+    .limit(1)
+    .for('update');
+  if (!runner?.workspaceId || runner.runnerSessionId || runner.state !== 'running') return null;
+
+  await tx
+    .update(runnerActivationTokens)
+    .set({revokedAt: sql`now()`})
+    .where(
+      and(
+        eq(runnerActivationTokens.runnerInstanceId, params.runnerInstanceId),
+        isNull(runnerActivationTokens.consumedAt),
+        isNull(runnerActivationTokens.revokedAt),
+      ),
+    );
+  const rawToken = generateOpaqueToken('runnerActivationToken');
+  await tx.insert(runnerActivationTokens).values({
+    runnerInstanceId: params.runnerInstanceId,
+    hashedToken: hashOpaqueToken(rawToken),
+    prefix: extractDisplayPrefix(rawToken),
+    expiresAt: new Date(Date.now() + params.ttlSeconds * 1000),
   });
+  return rawToken;
 }
 
 export async function getRunnerAssignment(params: {

--- a/libs/api/runners/src/core/runner-control-sessions.ts
+++ b/libs/api/runners/src/core/runner-control-sessions.ts
@@ -1,12 +1,23 @@
 import type {RunnerToolCapabilitiesDto} from '@shipfox/api-runners-dto';
+import type {NodePgDatabase} from '@shipfox/node-drizzle';
+import {logger} from '@shipfox/node-opentelemetry';
 import {extractDisplayPrefix, generateOpaqueToken, hashOpaqueToken} from '@shipfox/node-tokens';
 import {canonicalizeLabels} from '@shipfox/runner-labels';
 import {and, eq, gt, isNull, notInArray, or, sql} from 'drizzle-orm';
-import {db} from '#db/db.js';
+import {config} from '#config.js';
+import {
+  ReservationExpiredError,
+  ReservationNotFoundError,
+  RunnerInstanceAlreadyAssignedError,
+  RunnerInstanceNotAssignableError,
+} from '#core/errors.js';
+import {db, type schema, type Tx} from '#db/db.js';
+import {assignRunnerInstancesTx} from '#db/runner-assignments.js';
 import {terminalStates} from '#db/runner-instances.js';
 import {provisionerTokens} from '#db/schema/provisioner-tokens.js';
 import {runnerBootstrapTokens, runnerControlSessions} from '#db/schema/runner-control-sessions.js';
 import {providerRunners} from '#db/schema/runner-instances.js';
+import {issueRunnerActivationTokenTx} from './runner-activation.js';
 
 export class RunnerBootstrapTokenInvalidError extends Error {
   constructor() {
@@ -25,7 +36,10 @@ export class RunnerControlSessionInvalidError extends Error {
 export async function createRunnerInstancesWithBootstrapTokens(params: {
   provisionerId: string;
   providerKind?: string | null;
-  runnerInstances: Array<{templateKey?: string | null}>;
+  runnerInstances: Array<{
+    templateKey?: string | null;
+    reservationId?: string | null;
+  }>;
   ttlSeconds: number;
 }): Promise<Array<{runnerInstanceId: string; bootstrapToken: string}>> {
   const expiresAt = new Date(Date.now() + params.ttlSeconds * 1000);
@@ -37,6 +51,7 @@ export async function createRunnerInstancesWithBootstrapTokens(params: {
           provisionerId: params.provisionerId,
           providerKind: params.providerKind ?? null,
           templateKey: runner.templateKey ?? null,
+          intendedReservationId: runner.reservationId ?? null,
           state: 'starting' as const,
           labels: [],
           reportedAt: new Date(),
@@ -123,28 +138,87 @@ export async function enrollRunnerControlSession(params: {
   capabilities?: RunnerToolCapabilitiesDto | null;
   providerKind: string;
   protocolVersion: string;
-}): Promise<void> {
-  const updated = await db()
-    .update(providerRunners)
-    .set({
-      labels: [...canonicalizeLabels(params.labels)],
-      providerKind: params.providerKind,
-      protocolVersion: params.protocolVersion,
-      capabilities: params.capabilities ?? null,
-      state: 'running',
-      reportedAt: sql`now()`,
-      updatedAt: sql`now()`,
-    })
-    .where(
-      and(
-        eq(providerRunners.id, params.runnerInstanceId),
-        eq(providerRunners.provisionerId, params.provisionerId),
-        notInArray(providerRunners.state, [...terminalStates]),
-      ),
-    )
-    .returning({id: providerRunners.id});
-  if (!updated[0]) throw new RunnerControlSessionInvalidError();
-  await touchRunnerControlSession(params.runnerInstanceId, params.provisionerId);
+}): Promise<string | null> {
+  return await db().transaction(async (tx) => {
+    const [current] = await tx
+      .select({intendedReservationId: providerRunners.intendedReservationId})
+      .from(providerRunners)
+      .where(
+        and(
+          eq(providerRunners.id, params.runnerInstanceId),
+          eq(providerRunners.provisionerId, params.provisionerId),
+        ),
+      );
+    if (!current) throw new RunnerControlSessionInvalidError();
+    if (current.intendedReservationId)
+      await tx.execute(
+        sql`select pg_advisory_xact_lock(hashtext(${`runners_assignment:${params.provisionerId}:${current.intendedReservationId}`}))`,
+      );
+
+    const [updated] = await tx
+      .update(providerRunners)
+      .set({
+        labels: [...canonicalizeLabels(params.labels)],
+        providerKind: params.providerKind,
+        protocolVersion: params.protocolVersion,
+        capabilities: params.capabilities ?? null,
+        state: 'running',
+        reportedAt: sql`now()`,
+        updatedAt: sql`now()`,
+      })
+      .where(
+        and(
+          eq(providerRunners.id, params.runnerInstanceId),
+          eq(providerRunners.provisionerId, params.provisionerId),
+          notInArray(providerRunners.state, [...terminalStates]),
+        ),
+      )
+      .returning({
+        id: providerRunners.id,
+        intendedReservationId: providerRunners.intendedReservationId,
+      });
+    if (!updated) throw new RunnerControlSessionInvalidError();
+
+    await updateRunnerControlSessionLastSeen(tx, params.runnerInstanceId, params.provisionerId);
+
+    const intendedReservationId = updated.intendedReservationId;
+    if (!intendedReservationId) return null;
+
+    try {
+      return await tx.transaction(async (promotionTx) => {
+        await assignRunnerInstancesTx(promotionTx, {
+          provisionerId: params.provisionerId,
+          reservationId: intendedReservationId,
+          runnerInstanceIds: [params.runnerInstanceId],
+        });
+        return await issueRunnerActivationTokenTx(promotionTx, {
+          runnerInstanceId: params.runnerInstanceId,
+          provisionerId: params.provisionerId,
+          ttlSeconds: config.RUNNER_ACTIVATION_TOKEN_TTL_SECONDS,
+        });
+      });
+    } catch (error) {
+      const expectedFailure =
+        error instanceof ReservationExpiredError ||
+        error instanceof ReservationNotFoundError ||
+        error instanceof RunnerInstanceAlreadyAssignedError ||
+        error instanceof RunnerInstanceNotAssignableError;
+      const details = {
+        err: error,
+        runnerInstanceId: params.runnerInstanceId,
+        provisionerId: params.provisionerId,
+        reservationId: intendedReservationId,
+      };
+      if (expectedFailure)
+        logger().debug(details, 'Runner reservation could not be promoted during enrollment');
+      else
+        logger().error(
+          details,
+          'Unexpected failure promoting runner reservation during enrollment',
+        );
+      return null;
+    }
+  });
 }
 
 export async function attachRunnerControlProviderId(params: {
@@ -168,16 +242,7 @@ export async function attachRunnerControlProviderId(params: {
 }
 
 export async function touchRunnerControlSession(runnerInstanceId: string, provisionerId: string) {
-  await db()
-    .update(runnerControlSessions)
-    .set({lastSeenAt: sql`now()`})
-    .where(
-      and(
-        eq(runnerControlSessions.runnerInstanceId, runnerInstanceId),
-        eq(runnerControlSessions.provisionerId, provisionerId),
-        isNull(runnerControlSessions.closedAt),
-      ),
-    );
+  await updateRunnerControlSessionLastSeen(db(), runnerInstanceId, provisionerId);
   await db()
     .update(providerRunners)
     .set({reportedAt: sql`now()`, updatedAt: sql`now()`})
@@ -185,6 +250,23 @@ export async function touchRunnerControlSession(runnerInstanceId: string, provis
       and(
         eq(providerRunners.id, runnerInstanceId),
         eq(providerRunners.provisionerId, provisionerId),
+      ),
+    );
+}
+
+async function updateRunnerControlSessionLastSeen(
+  tx: Tx | NodePgDatabase<typeof schema>,
+  runnerInstanceId: string,
+  provisionerId: string,
+) {
+  await tx
+    .update(runnerControlSessions)
+    .set({lastSeenAt: sql`now()`})
+    .where(
+      and(
+        eq(runnerControlSessions.runnerInstanceId, runnerInstanceId),
+        eq(runnerControlSessions.provisionerId, provisionerId),
+        isNull(runnerControlSessions.closedAt),
       ),
     );
 }

--- a/libs/api/runners/src/db/runner-assignments.test.ts
+++ b/libs/api/runners/src/db/runner-assignments.test.ts
@@ -160,6 +160,27 @@ describe('assignRunnerInstances', () => {
     ).resolves.toEqual([runner.id]);
   });
 
+  it('does not charge capacity for an already released reservation assignment', async () => {
+    const reservation = await createReservation();
+    await db().insert(providerRunners).values({
+      provisionerId,
+      reservationId: reservation.id,
+      reservationReleasedAt: new Date(),
+      providerRunnerId: crypto.randomUUID(),
+      state: 'failed',
+      reportedAt: new Date(),
+    });
+    const runner = await createEnrolledRunner();
+
+    await expect(
+      assignRunnerInstances({
+        provisionerId,
+        reservationId: reservation.id,
+        runnerInstanceIds: [runner.id],
+      }),
+    ).resolves.toEqual([runner.id]);
+  });
+
   it('does not charge capacity for a terminal reservation intent before release bookkeeping', async () => {
     const reservation = await createReservation();
     await db().insert(providerRunners).values({

--- a/libs/api/runners/src/db/runner-assignments.test.ts
+++ b/libs/api/runners/src/db/runner-assignments.test.ts
@@ -139,6 +139,47 @@ describe('assignRunnerInstances', () => {
     await expect(assignment).rejects.toThrow(RunnerInstanceNotAssignableError);
   });
 
+  it('does not charge capacity for an already released reservation intent', async () => {
+    const reservation = await createReservation();
+    await db().insert(providerRunners).values({
+      provisionerId,
+      intendedReservationId: reservation.id,
+      reservationReleasedAt: new Date(),
+      providerRunnerId: crypto.randomUUID(),
+      state: 'failed',
+      reportedAt: new Date(),
+    });
+    const runner = await createEnrolledRunner();
+
+    await expect(
+      assignRunnerInstances({
+        provisionerId,
+        reservationId: reservation.id,
+        runnerInstanceIds: [runner.id],
+      }),
+    ).resolves.toEqual([runner.id]);
+  });
+
+  it('does not charge capacity for a terminal reservation intent before release bookkeeping', async () => {
+    const reservation = await createReservation();
+    await db().insert(providerRunners).values({
+      provisionerId,
+      intendedReservationId: reservation.id,
+      providerRunnerId: crypto.randomUUID(),
+      state: 'failed',
+      reportedAt: new Date(),
+    });
+    const runner = await createEnrolledRunner();
+
+    await expect(
+      assignRunnerInstances({
+        provisionerId,
+        reservationId: reservation.id,
+        runnerInstanceIds: [runner.id],
+      }),
+    ).resolves.toEqual([runner.id]);
+  });
+
   async function createReservation(
     overrides: Partial<{expiresAt: Date; requiredLabels: string[]}> = {},
   ) {

--- a/libs/api/runners/src/db/runner-assignments.ts
+++ b/libs/api/runners/src/db/runner-assignments.ts
@@ -118,7 +118,10 @@ export async function assignRunnerInstancesTx(
       and(
         eq(providerRunners.provisionerId, params.provisionerId),
         or(
-          eq(providerRunners.reservationId, reservation.id),
+          and(
+            eq(providerRunners.reservationId, reservation.id),
+            isNull(providerRunners.reservationReleasedAt),
+          ),
           and(
             eq(providerRunners.intendedReservationId, reservation.id),
             notInArray(providerRunners.id, runnerInstanceIds),

--- a/libs/api/runners/src/db/runner-assignments.ts
+++ b/libs/api/runners/src/db/runner-assignments.ts
@@ -1,11 +1,13 @@
-import {and, eq, inArray, isNull, sql} from 'drizzle-orm';
+import {and, eq, inArray, isNull, notInArray, or, sql} from 'drizzle-orm';
 import {
   ReservationExpiredError,
   ReservationNotFoundError,
   RunnerInstanceAlreadyAssignedError,
   RunnerInstanceNotAssignableError,
 } from '#core/errors.js';
+import type {Tx} from './db.js';
 import {db} from './db.js';
+import {terminalStates} from './runner-instances.js';
 import {reservations} from './schema/reservations.js';
 import {runnerControlSessions} from './schema/runner-control-sessions.js';
 import {providerRunners} from './schema/runner-instances.js';
@@ -16,110 +18,143 @@ export async function assignRunnerInstances(params: {
   reservationId: string;
   runnerInstanceIds: string[];
 }): Promise<string[]> {
+  return await db().transaction(async (tx) => assignRunnerInstancesTx(tx, params));
+}
+
+export async function assignRunnerInstancesTx(
+  tx: Tx,
+  params: {
+    provisionerId: string;
+    reservationId: string;
+    runnerInstanceIds: string[];
+  },
+): Promise<string[]> {
   const runnerInstanceIds = [...params.runnerInstanceIds].sort();
-  return await db().transaction(async (tx) => {
-    await tx.execute(
-      sql`select pg_advisory_xact_lock(hashtext(${`runners_assignment:${params.provisionerId}:${params.reservationId}`}))`,
-    );
-    const runnerRows = await tx
-      .select({
-        id: providerRunners.id,
-        reservationId: providerRunners.reservationId,
-        workspaceId: providerRunners.workspaceId,
-        providerRunnerId: providerRunners.providerRunnerId,
-        labels: providerRunners.labels,
-        state: providerRunners.state,
-      })
-      .from(providerRunners)
+  await tx.execute(
+    sql`select pg_advisory_xact_lock(hashtext(${`runners_assignment:${params.provisionerId}:${params.reservationId}`}))`,
+  );
+  const runnerRows = await tx
+    .select({
+      id: providerRunners.id,
+      reservationId: providerRunners.reservationId,
+      intendedReservationId: providerRunners.intendedReservationId,
+      workspaceId: providerRunners.workspaceId,
+      providerRunnerId: providerRunners.providerRunnerId,
+      labels: providerRunners.labels,
+      state: providerRunners.state,
+    })
+    .from(providerRunners)
+    .where(
+      and(
+        eq(providerRunners.provisionerId, params.provisionerId),
+        inArray(providerRunners.id, runnerInstanceIds),
+      ),
+    )
+    .for('update');
+
+  // The assignment outlives its short reservation row. A retry after maintenance
+  // cleanup is complete when every owned runner already carries the requested assignment.
+  if (
+    runnerInstanceIds.length > 0 &&
+    runnerRows.length === runnerInstanceIds.length &&
+    runnerRows.every((runner) => runner.reservationId === params.reservationId)
+  ) {
+    await tx
+      .update(providerRunners)
+      .set({intendedReservationId: null, updatedAt: sql`now()`})
       .where(
         and(
           eq(providerRunners.provisionerId, params.provisionerId),
           inArray(providerRunners.id, runnerInstanceIds),
         ),
-      )
-      .for('update');
+      );
+    return params.runnerInstanceIds;
+  }
 
-    // The assignment outlives its short reservation row. A retry after maintenance
-    // cleanup is complete when every owned runner already carries the requested assignment.
-    if (
-      runnerInstanceIds.length > 0 &&
-      runnerRows.length === runnerInstanceIds.length &&
-      runnerRows.every((runner) => runner.reservationId === params.reservationId)
+  const [reservation] = await tx
+    .select()
+    .from(reservations)
+    .where(
+      and(
+        eq(reservations.id, params.reservationId),
+        eq(reservations.provisionerId, params.provisionerId),
+      ),
     )
-      return params.runnerInstanceIds;
+    .limit(1)
+    .for('update');
+  if (!reservation) throw new ReservationNotFoundError(params.reservationId);
+  if (reservation.expiresAt <= new Date()) throw new ReservationExpiredError(params.reservationId);
+  if (runnerRows.length !== runnerInstanceIds.length)
+    throw new RunnerInstanceNotAssignableError(runnerInstanceIds[0] ?? '');
 
-    const [reservation] = await tx
-      .select()
-      .from(reservations)
-      .where(
-        and(
-          eq(reservations.id, params.reservationId),
-          eq(reservations.provisionerId, params.provisionerId),
+  const activeControlSessions = await tx
+    .select({runnerInstanceId: runnerControlSessions.runnerInstanceId})
+    .from(runnerControlSessions)
+    .where(
+      and(
+        inArray(
+          runnerControlSessions.runnerInstanceId,
+          runnerRows.map((runner) => runner.id),
         ),
-      )
-      .limit(1)
-      .for('update');
-    if (!reservation) throw new ReservationNotFoundError(params.reservationId);
-    if (reservation.expiresAt <= new Date())
-      throw new ReservationExpiredError(params.reservationId);
-    if (runnerRows.length !== runnerInstanceIds.length)
-      throw new RunnerInstanceNotAssignableError(runnerInstanceIds[0] ?? '');
+        isNull(runnerControlSessions.closedAt),
+      ),
+    );
+  const runnerInstanceIdsWithControlSession = new Set(
+    activeControlSessions.map((session) => session.runnerInstanceId),
+  );
+  const runners = runnerRows.map((runner) => ({
+    ...runner,
+    controlSessionId: runnerInstanceIdsWithControlSession.has(runner.id) ? runner.id : null,
+  }));
 
-    const activeControlSessions = await tx
-      .select({runnerInstanceId: runnerControlSessions.runnerInstanceId})
-      .from(runnerControlSessions)
-      .where(
-        and(
-          inArray(
-            runnerControlSessions.runnerInstanceId,
-            runnerRows.map((runner) => runner.id),
+  const alreadyAssigned = runners.filter((runner) => runner.reservationId !== null);
+  if (alreadyAssigned.some((runner) => runner.reservationId !== reservation.id))
+    throw new RunnerInstanceAlreadyAssignedError(alreadyAssigned[0]?.id ?? '');
+  const newRunners = runners.filter((runner) => runner.reservationId === null);
+  const assignedCount = await tx
+    .select({count: sql<number>`count(*)::int`})
+    .from(providerRunners)
+    .where(
+      and(
+        eq(providerRunners.provisionerId, params.provisionerId),
+        or(
+          eq(providerRunners.reservationId, reservation.id),
+          and(
+            eq(providerRunners.intendedReservationId, reservation.id),
+            notInArray(providerRunners.id, runnerInstanceIds),
+            isNull(providerRunners.reservationReleasedAt),
+            notInArray(providerRunners.state, [...terminalStates]),
           ),
-          isNull(runnerControlSessions.closedAt),
+        ),
+      ),
+    );
+  if ((assignedCount[0]?.count ?? 0) + newRunners.length > reservation.count)
+    throw new RunnerInstanceNotAssignableError(newRunners[0]?.id ?? '');
+  for (const runner of newRunners) {
+    if (
+      runner.state !== 'running' ||
+      !runner.providerRunnerId ||
+      !runner.controlSessionId ||
+      !reservation.requiredLabels.every((label) => runner.labels.includes(label))
+    )
+      throw new RunnerInstanceNotAssignableError(runner.id);
+  }
+  if (newRunners.length > 0) {
+    await tx
+      .update(providerRunners)
+      .set({
+        workspaceId: reservation.workspaceId,
+        reservationId: reservation.id,
+        intendedReservationId: null,
+        assignedAt: sql`now()`,
+        updatedAt: sql`now()`,
+      })
+      .where(
+        inArray(
+          providerRunners.id,
+          newRunners.map((runner) => runner.id),
         ),
       );
-    const runnerInstanceIdsWithControlSession = new Set(
-      activeControlSessions.map((session) => session.runnerInstanceId),
-    );
-    const runners = runnerRows.map((runner) => ({
-      ...runner,
-      controlSessionId: runnerInstanceIdsWithControlSession.has(runner.id) ? runner.id : null,
-    }));
-
-    const alreadyAssigned = runners.filter((runner) => runner.reservationId !== null);
-    if (alreadyAssigned.some((runner) => runner.reservationId !== reservation.id))
-      throw new RunnerInstanceAlreadyAssignedError(alreadyAssigned[0]?.id ?? '');
-    const newRunners = runners.filter((runner) => runner.reservationId === null);
-    const assignedCount = await tx
-      .select({count: sql<number>`count(*)::int`})
-      .from(providerRunners)
-      .where(eq(providerRunners.reservationId, reservation.id));
-    if ((assignedCount[0]?.count ?? 0) + newRunners.length > reservation.count)
-      throw new RunnerInstanceNotAssignableError(newRunners[0]?.id ?? '');
-    for (const runner of newRunners) {
-      if (
-        runner.state !== 'running' ||
-        !runner.providerRunnerId ||
-        !runner.controlSessionId ||
-        !reservation.requiredLabels.every((label) => runner.labels.includes(label))
-      )
-        throw new RunnerInstanceNotAssignableError(runner.id);
-    }
-    if (newRunners.length > 0) {
-      await tx
-        .update(providerRunners)
-        .set({
-          workspaceId: reservation.workspaceId,
-          reservationId: reservation.id,
-          assignedAt: sql`now()`,
-          updatedAt: sql`now()`,
-        })
-        .where(
-          inArray(
-            providerRunners.id,
-            newRunners.map((runner) => runner.id),
-          ),
-        );
-    }
-    return params.runnerInstanceIds;
-  });
+  }
+  return params.runnerInstanceIds;
 }

--- a/libs/api/runners/src/db/runner-instances.test.ts
+++ b/libs/api/runners/src/db/runner-instances.test.ts
@@ -413,6 +413,38 @@ describe('reportRunnerInstances', () => {
     expect(providerRunnerRows[0]?.reservationReleasedAt).toBeInstanceOf(Date);
   });
 
+  it('releases an intended reservation for a runner that dies before enrollment', async () => {
+    const reservationId = await createReservation(2);
+    const [runner] = await db()
+      .insert(providerRunners)
+      .values({
+        provisionerId,
+        intendedReservationId: reservationId,
+        providerRunnerId: 'pre-enrollment-runner',
+        state: 'starting',
+        reportedAt: new Date(),
+      })
+      .returning();
+    if (!runner) throw new Error('Runner instance insert returned no row');
+    if (!runner.providerRunnerId) throw new Error('Runner instance provider id missing');
+
+    const result = await reportRunnerInstances({
+      workspaceId,
+      provisionerId,
+      events: [event({providerRunnerId: runner.providerRunnerId, state: 'failed'})],
+    });
+
+    const [storedRunner] = await db()
+      .select()
+      .from(providerRunners)
+      .where(eq(providerRunners.id, runner.id));
+    const reservationRows = await reservationRowsFor({workspaceId, provisionerId});
+    expect(result).toEqual({accepted: 1, reservationsReleased: 1, terminateIntentsHonored: []});
+    expect(reservationRows[0]?.count).toBe(1);
+    expect(storedRunner?.intendedReservationId).toBeNull();
+    expect(storedRunner?.reservationReleasedAt).toBeInstanceOf(Date);
+  });
+
   it('does not release a reservation owned by another workspace or provisioner', async () => {
     const otherWorkspaceReservationId = await createReservation(1, {
       workspaceId: crypto.randomUUID(),

--- a/libs/api/runners/src/db/runner-instances.test.ts
+++ b/libs/api/runners/src/db/runner-instances.test.ts
@@ -445,6 +445,59 @@ describe('reportRunnerInstances', () => {
     expect(storedRunner?.reservationReleasedAt).toBeInstanceOf(Date);
   });
 
+  it('releases an intended reservation from an installation-scoped terminal report', async () => {
+    const installationProvisioner = await provisionerTokenFactory.create({
+      scope: 'installation',
+      workspaceId: null,
+    });
+    const reservationWorkspaceId = crypto.randomUUID();
+    await reservationFactory.create({
+      workspaceId: reservationWorkspaceId,
+      provisionerId: installationProvisioner.id,
+      requiredLabels: ['linux'],
+      count: 2,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const [reservation] = await db()
+      .select()
+      .from(reservations)
+      .where(
+        and(
+          eq(reservations.workspaceId, reservationWorkspaceId),
+          eq(reservations.provisionerId, installationProvisioner.id),
+        ),
+      )
+      .orderBy(desc(reservations.id))
+      .limit(1);
+    if (!reservation) throw new Error('Expected reservation');
+    await db().insert(providerRunners).values({
+      provisionerId: installationProvisioner.id,
+      intendedReservationId: reservation.id,
+      providerRunnerId: 'installation-pre-enrollment-runner',
+      state: 'starting',
+      reportedAt: new Date(),
+    });
+
+    const result = await reportRunnerInstances({
+      workspaceId: null,
+      provisionerId: installationProvisioner.id,
+      events: [event({providerRunnerId: 'installation-pre-enrollment-runner', state: 'failed'})],
+    });
+
+    const [storedReservation] = await db()
+      .select()
+      .from(reservations)
+      .where(eq(reservations.id, reservation.id));
+    const [storedRunner] = await db()
+      .select()
+      .from(providerRunners)
+      .where(eq(providerRunners.providerRunnerId, 'installation-pre-enrollment-runner'));
+    expect(result).toEqual({accepted: 1, reservationsReleased: 1, terminateIntentsHonored: []});
+    expect(storedReservation?.count).toBe(1);
+    expect(storedRunner?.intendedReservationId).toBeNull();
+    expect(storedRunner?.reservationReleasedAt).toBeInstanceOf(Date);
+  });
+
   it('does not release a reservation owned by another workspace or provisioner', async () => {
     const otherWorkspaceReservationId = await createReservation(1, {
       workspaceId: crypto.randomUUID(),
@@ -1075,6 +1128,60 @@ describe('reapStaleRunnerInstances', () => {
 
     expect(result.reaped).toBe(1);
     expect(row).toMatchObject({workspaceId: null, providerRunnerId: null, state: 'failed'});
+  });
+
+  it('releases an intended reservation while reaping a stale installation runner', async () => {
+    const installationProvisioner = await provisionerTokenFactory.create({
+      scope: 'installation',
+      workspaceId: null,
+    });
+    const reservationWorkspaceId = crypto.randomUUID();
+    await reservationFactory.create({
+      workspaceId: reservationWorkspaceId,
+      provisionerId: installationProvisioner.id,
+      requiredLabels: ['linux'],
+      count: 1,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const [reservation] = await db()
+      .select()
+      .from(reservations)
+      .where(
+        and(
+          eq(reservations.workspaceId, reservationWorkspaceId),
+          eq(reservations.provisionerId, installationProvisioner.id),
+        ),
+      )
+      .orderBy(desc(reservations.id))
+      .limit(1);
+    if (!reservation) throw new Error('Expected reservation');
+    const [instance] = await db()
+      .insert(providerRunners)
+      .values({
+        provisionerId: installationProvisioner.id,
+        intendedReservationId: reservation.id,
+        providerRunnerId: 'stale-installation-runner-with-reservation',
+        state: 'starting',
+        reportedAt: staleAt(),
+        updatedAt: staleAt(),
+      })
+      .returning({id: providerRunners.id});
+    if (!instance) throw new Error('Runner instance insert returned no row');
+
+    const result = await reapStaleRunnerInstances({thresholdSeconds: 60, limit: 100});
+    const [row] = await db()
+      .select()
+      .from(providerRunners)
+      .where(eq(providerRunners.id, instance.id));
+    const remainingReservations = await db()
+      .select()
+      .from(reservations)
+      .where(eq(reservations.id, reservation.id));
+
+    expect(result).toEqual({reaped: 1, reservationsReleased: 1});
+    expect(row?.intendedReservationId).toBeNull();
+    expect(row?.reservationReleasedAt).toBeInstanceOf(Date);
+    expect(remainingReservations).toHaveLength(0);
   });
 
   it('skips fresh rows, live provisioners, terminal rows, running jobs, and fresh sessions', async () => {

--- a/libs/api/runners/src/db/runner-instances.test.ts
+++ b/libs/api/runners/src/db/runner-instances.test.ts
@@ -498,6 +498,49 @@ describe('reportRunnerInstances', () => {
     expect(storedRunner?.reservationReleasedAt).toBeInstanceOf(Date);
   });
 
+  it('prefers the validated intended reservation when both reservation ids are set', async () => {
+    const installationProvisioner = await provisionerTokenFactory.create({
+      scope: 'installation',
+      workspaceId: null,
+    });
+    const staleReservationId = await createReservation(1, {
+      workspaceId: crypto.randomUUID(),
+      provisionerId: installationProvisioner.id,
+    });
+    const intendedReservationId = await createReservation(1, {
+      workspaceId: crypto.randomUUID(),
+      provisionerId: installationProvisioner.id,
+    });
+    await db().insert(providerRunners).values({
+      provisionerId: installationProvisioner.id,
+      reservationId: staleReservationId,
+      intendedReservationId,
+      providerRunnerId: 'installation-runner-with-stale-reservation',
+      state: 'starting',
+      reportedAt: new Date(),
+    });
+
+    const result = await reportRunnerInstances({
+      workspaceId: null,
+      provisionerId: installationProvisioner.id,
+      events: [
+        event({providerRunnerId: 'installation-runner-with-stale-reservation', state: 'failed'}),
+      ],
+    });
+
+    const [staleReservation] = await db()
+      .select()
+      .from(reservations)
+      .where(eq(reservations.id, staleReservationId));
+    const [intendedReservation] = await db()
+      .select()
+      .from(reservations)
+      .where(eq(reservations.id, intendedReservationId));
+    expect(result).toEqual({accepted: 1, reservationsReleased: 1, terminateIntentsHonored: []});
+    expect(staleReservation?.count).toBe(1);
+    expect(intendedReservation).toBeUndefined();
+  });
+
   it('does not release a reservation owned by another workspace or provisioner', async () => {
     const otherWorkspaceReservationId = await createReservation(1, {
       workspaceId: crypto.randomUUID(),

--- a/libs/api/runners/src/db/runner-instances.ts
+++ b/libs/api/runners/src/db/runner-instances.ts
@@ -584,20 +584,37 @@ async function releaseTerminalRunnerInstanceReservationsByIds(
 ): Promise<number> {
   if (params.providerRunnerIds.length === 0) return 0;
 
+  const reservationWorkspacePredicate =
+    params.workspaceId === null
+      ? sql``
+      : sql`and ${eq(reservations.workspaceId, params.workspaceId)}`;
+
   const rows = await tx
     .select({
       id: providerRunners.id,
-      reservationId: providerRunners.reservationId,
-      intendedReservationId: providerRunners.intendedReservationId,
-      reservationWorkspaceId: sql<string | null>`coalesce(
-        (select ${reservations.workspaceId}
+      releaseReservationId: sql<string | null>`coalesce(
+        (select ${reservations.id}
+         from ${reservations}
+         where ${reservations.id} = ${providerRunners.intendedReservationId}
+           and ${reservations.provisionerId} = ${params.provisionerId}
+           ${reservationWorkspacePredicate}),
+        (select ${reservations.id}
          from ${reservations}
          where ${reservations.id} = ${providerRunners.reservationId}
-           and ${reservations.provisionerId} = ${params.provisionerId}),
+           and ${reservations.provisionerId} = ${params.provisionerId}
+           ${reservationWorkspacePredicate})
+      )`,
+      releaseReservationWorkspaceId: sql<string | null>`coalesce(
         (select ${reservations.workspaceId}
          from ${reservations}
          where ${reservations.id} = ${providerRunners.intendedReservationId}
-           and ${reservations.provisionerId} = ${params.provisionerId})
+           and ${reservations.provisionerId} = ${params.provisionerId}
+           ${reservationWorkspacePredicate}),
+        (select ${reservations.workspaceId}
+         from ${reservations}
+         where ${reservations.id} = ${providerRunners.reservationId}
+           and ${reservations.provisionerId} = ${params.provisionerId}
+           ${reservationWorkspacePredicate})
       )`,
     })
     .from(providerRunners)
@@ -697,12 +714,11 @@ async function releaseTerminalRunnerInstanceReservationsByIds(
   const updatedIds = new Set(updated.map((row) => row.id));
   for (const row of rows) {
     if (!updatedIds.has(row.id)) continue;
-    const reservationId = row.reservationId ?? row.intendedReservationId;
-    if (!reservationId || !row.reservationWorkspaceId) continue;
-    const key = `${row.reservationWorkspaceId}:${reservationId}`;
+    if (!row.releaseReservationId || !row.releaseReservationWorkspaceId) continue;
+    const key = `${row.releaseReservationWorkspaceId}:${row.releaseReservationId}`;
     const release = releasesByReservationId.get(key) ?? {
-      workspaceId: row.reservationWorkspaceId,
-      reservationId,
+      workspaceId: row.releaseReservationWorkspaceId,
+      reservationId: row.releaseReservationId,
       count: 0,
     };
     release.count += 1;

--- a/libs/api/runners/src/db/runner-instances.ts
+++ b/libs/api/runners/src/db/runner-instances.ts
@@ -564,7 +564,7 @@ async function releaseTerminalRunnerInstanceReservations(
   events: RunnerInstanceReportEvent[],
 ): Promise<number> {
   const terminalEvents = events.filter((event) => isTerminalState(event.state));
-  if (terminalEvents.length === 0 || !params.workspaceId) return 0;
+  if (terminalEvents.length === 0) return 0;
 
   return await releaseTerminalRunnerInstanceReservationsByIds(tx, {
     workspaceId: params.workspaceId,
@@ -576,7 +576,7 @@ async function releaseTerminalRunnerInstanceReservations(
 async function releaseTerminalRunnerInstanceReservationsByIds(
   tx: Tx,
   params: {
-    workspaceId: string;
+    workspaceId: string | null;
     provisionerId: string;
     providerRunnerIds: string[];
     requireUnlinkedSession?: boolean;
@@ -589,6 +589,16 @@ async function releaseTerminalRunnerInstanceReservationsByIds(
       id: providerRunners.id,
       reservationId: providerRunners.reservationId,
       intendedReservationId: providerRunners.intendedReservationId,
+      reservationWorkspaceId: sql<string | null>`coalesce(
+        (select ${reservations.workspaceId}
+         from ${reservations}
+         where ${reservations.id} = ${providerRunners.reservationId}
+           and ${reservations.provisionerId} = ${params.provisionerId}),
+        (select ${reservations.workspaceId}
+         from ${reservations}
+         where ${reservations.id} = ${providerRunners.intendedReservationId}
+           and ${reservations.provisionerId} = ${params.provisionerId})
+      )`,
     })
     .from(providerRunners)
     .where(
@@ -600,25 +610,55 @@ async function releaseTerminalRunnerInstanceReservationsByIds(
           isNotNull(providerRunners.reservationId),
           isNotNull(providerRunners.intendedReservationId),
         ),
-        or(
-          eq(providerRunners.workspaceId, params.workspaceId),
-          and(
-            isNull(providerRunners.workspaceId),
-            isNotNull(providerRunners.intendedReservationId),
-            exists(
-              tx
-                .select({id: reservations.id})
-                .from(reservations)
-                .where(
-                  and(
-                    eq(reservations.workspaceId, params.workspaceId),
-                    eq(reservations.provisionerId, params.provisionerId),
-                    eq(reservations.id, providerRunners.intendedReservationId),
+        params.workspaceId === null
+          ? undefined
+          : or(
+              and(
+                eq(providerRunners.workspaceId, params.workspaceId),
+                or(
+                  exists(
+                    tx
+                      .select({id: reservations.id})
+                      .from(reservations)
+                      .where(
+                        and(
+                          eq(reservations.workspaceId, params.workspaceId),
+                          eq(reservations.provisionerId, params.provisionerId),
+                          eq(reservations.id, providerRunners.reservationId),
+                        ),
+                      ),
+                  ),
+                  exists(
+                    tx
+                      .select({id: reservations.id})
+                      .from(reservations)
+                      .where(
+                        and(
+                          eq(reservations.workspaceId, params.workspaceId),
+                          eq(reservations.provisionerId, params.provisionerId),
+                          eq(reservations.id, providerRunners.intendedReservationId),
+                        ),
+                      ),
                   ),
                 ),
+              ),
+              and(
+                isNull(providerRunners.workspaceId),
+                isNotNull(providerRunners.intendedReservationId),
+                exists(
+                  tx
+                    .select({id: reservations.id})
+                    .from(reservations)
+                    .where(
+                      and(
+                        eq(reservations.workspaceId, params.workspaceId),
+                        eq(reservations.provisionerId, params.provisionerId),
+                        eq(reservations.id, providerRunners.intendedReservationId),
+                      ),
+                    ),
+                ),
+              ),
             ),
-          ),
-        ),
         params.requireUnlinkedSession === false
           ? undefined
           : isNull(providerRunners.runnerSessionId),
@@ -650,28 +690,36 @@ async function releaseTerminalRunnerInstanceReservationsByIds(
     )
     .returning({id: providerRunners.id});
 
-  const releasesByReservationId = new Map<string, number>();
+  const releasesByReservationId = new Map<
+    string,
+    {workspaceId: string; reservationId: string; count: number}
+  >();
   const updatedIds = new Set(updated.map((row) => row.id));
   for (const row of rows) {
     if (!updatedIds.has(row.id)) continue;
     const reservationId = row.reservationId ?? row.intendedReservationId;
-    if (!reservationId) continue;
-    releasesByReservationId.set(
+    if (!reservationId || !row.reservationWorkspaceId) continue;
+    const key = `${row.reservationWorkspaceId}:${reservationId}`;
+    const release = releasesByReservationId.get(key) ?? {
+      workspaceId: row.reservationWorkspaceId,
       reservationId,
-      (releasesByReservationId.get(reservationId) ?? 0) + 1,
-    );
+      count: 0,
+    };
+    release.count += 1;
+    releasesByReservationId.set(key, release);
   }
 
   if (releasesByReservationId.size === 0) return 0;
 
-  return await releaseReservationUnits(tx, {
-    workspaceId: params.workspaceId,
-    provisionerId: params.provisionerId,
-    releases: [...releasesByReservationId].map(([reservationId, count]) => ({
-      reservationId,
-      count,
-    })),
-  });
+  let released = 0;
+  for (const release of releasesByReservationId.values()) {
+    released += await releaseReservationUnits(tx, {
+      workspaceId: release.workspaceId,
+      provisionerId: params.provisionerId,
+      releases: [{reservationId: release.reservationId, count: release.count}],
+    });
+  }
+  return released;
 }
 
 function staleRunnerInstanceCutoff(thresholdSeconds: number): SQL {
@@ -728,14 +776,14 @@ function groupRunnerInstanceIds(
     provisionerId: string;
     providerRunnerId: string | null;
   }>,
-): Array<{workspaceId: string; provisionerId: string; providerRunnerIds: string[]}> {
+): Array<{workspaceId: string | null; provisionerId: string; providerRunnerIds: string[]}> {
   const groups = new Map<
     string,
-    {workspaceId: string; provisionerId: string; providerRunnerIds: string[]}
+    {workspaceId: string | null; provisionerId: string; providerRunnerIds: string[]}
   >();
   for (const row of rows) {
-    if (!row.workspaceId || !row.providerRunnerId) continue;
-    const key = `${row.workspaceId}:${row.provisionerId}`;
+    if (!row.providerRunnerId) continue;
+    const key = `${row.workspaceId ?? ''}:${row.provisionerId}`;
     const group = groups.get(key) ?? {
       workspaceId: row.workspaceId,
       provisionerId: row.provisionerId,

--- a/libs/api/runners/src/db/runner-instances.ts
+++ b/libs/api/runners/src/db/runner-instances.ts
@@ -28,6 +28,7 @@ import {
 import {releaseReservationUnits} from './reservations.js';
 import {ephemeralRegistrationTokens} from './schema/ephemeral-registration-tokens.js';
 import {provisionerTokens} from './schema/provisioner-tokens.js';
+import {reservations} from './schema/reservations.js';
 import {providerRunners, toRunnerInstance} from './schema/runner-instances.js';
 import {runnerSessions} from './schema/runner-sessions.js';
 import {runningJobExecutions} from './schema/running-job-executions.js';
@@ -587,27 +588,54 @@ async function releaseTerminalRunnerInstanceReservationsByIds(
     .select({
       id: providerRunners.id,
       reservationId: providerRunners.reservationId,
+      intendedReservationId: providerRunners.intendedReservationId,
     })
     .from(providerRunners)
     .where(
       and(
-        eq(providerRunners.workspaceId, params.workspaceId),
         eq(providerRunners.provisionerId, params.provisionerId),
         inArray(providerRunners.providerRunnerId, params.providerRunnerIds),
         inArray(providerRunners.state, terminalStates),
-        isNotNull(providerRunners.reservationId),
+        or(
+          isNotNull(providerRunners.reservationId),
+          isNotNull(providerRunners.intendedReservationId),
+        ),
+        or(
+          eq(providerRunners.workspaceId, params.workspaceId),
+          and(
+            isNull(providerRunners.workspaceId),
+            isNotNull(providerRunners.intendedReservationId),
+            exists(
+              tx
+                .select({id: reservations.id})
+                .from(reservations)
+                .where(
+                  and(
+                    eq(reservations.workspaceId, params.workspaceId),
+                    eq(reservations.provisionerId, params.provisionerId),
+                    eq(reservations.id, providerRunners.intendedReservationId),
+                  ),
+                ),
+            ),
+          ),
+        ),
         params.requireUnlinkedSession === false
           ? undefined
           : isNull(providerRunners.runnerSessionId),
         isNull(providerRunners.reservationReleasedAt),
       ),
-    );
+    )
+    .for('update');
 
   if (rows.length === 0) return 0;
 
   const updated = await tx
     .update(providerRunners)
-    .set({reservationReleasedAt: sql`now()`, updatedAt: sql`now()`})
+    .set({
+      intendedReservationId: null,
+      reservationReleasedAt: sql`now()`,
+      updatedAt: sql`now()`,
+    })
     .where(
       and(
         inArray(
@@ -620,14 +648,17 @@ async function releaseTerminalRunnerInstanceReservationsByIds(
         isNull(providerRunners.reservationReleasedAt),
       ),
     )
-    .returning({reservationId: providerRunners.reservationId});
+    .returning({id: providerRunners.id});
 
   const releasesByReservationId = new Map<string, number>();
-  for (const row of updated) {
-    if (!row.reservationId) continue;
+  const updatedIds = new Set(updated.map((row) => row.id));
+  for (const row of rows) {
+    if (!updatedIds.has(row.id)) continue;
+    const reservationId = row.reservationId ?? row.intendedReservationId;
+    if (!reservationId) continue;
     releasesByReservationId.set(
-      row.reservationId,
-      (releasesByReservationId.get(row.reservationId) ?? 0) + 1,
+      reservationId,
+      (releasesByReservationId.get(reservationId) ?? 0) + 1,
     );
   }
 

--- a/libs/api/runners/src/db/schema/runner-instances.ts
+++ b/libs/api/runners/src/db/schema/runner-instances.ts
@@ -23,6 +23,7 @@ export const providerRunners = pgTable(
     workspaceId: uuid('workspace_id'),
     provisionerId: uuid('provisioner_id').notNull(),
     providerRunnerId: text('provider_runner_id'),
+    intendedReservationId: uuid('intended_reservation_id'),
     reservationId: uuid('reservation_id'),
     assignedAt: timestamp('assigned_at', {withTimezone: true}),
     templateKey: text('template_key'),
@@ -53,6 +54,14 @@ export const providerRunners = pgTable(
       table.updatedAt,
       table.reportedAt,
     ),
+    index('runners_runner_instances_provisioner_intended_reservation_idx')
+      .on(table.provisionerId, table.intendedReservationId)
+      .where(
+        sql`${table.intendedReservationId} is not null and ${table.reservationReleasedAt} is null`,
+      ),
+    index('runners_runner_instances_provisioner_reservation_idx')
+      .on(table.provisionerId, table.reservationId)
+      .where(sql`${table.reservationId} is not null`),
     index('runners_runner_instances_active_template_counts_idx')
       .on(table.provisionerId, table.state, table.templateKey)
       .where(sql`"state" in ('starting', 'running') and "template_key" is not null`),

--- a/libs/api/runners/src/presentation/routes/runner-enrollment.test.ts
+++ b/libs/api/runners/src/presentation/routes/runner-enrollment.test.ts
@@ -103,7 +103,8 @@ describe('runner enrollment control plane', () => {
       headers: {authorization: `Bearer ${controlToken}`},
       payload: {labels: ['Linux', 'linux'], provider_kind: 'docker', protocol_version: '1'},
     });
-    expect(enrolled.statusCode).toBe(204);
+    expect(enrolled.statusCode).toBe(200);
+    expect(enrolled.json()).toEqual({activation_token: null});
 
     const attached = await app.inject({
       method: 'POST',
@@ -136,6 +137,122 @@ describe('runner enrollment control plane', () => {
       headers: {authorization: `Bearer ${controlToken}`},
     });
     expect(jobs.statusCode).toBe(401);
+  });
+
+  it('promotes an intended reservation during enrollment and returns its activation token', async () => {
+    const workspaceId = crypto.randomUUID();
+    const [reservation] = await db()
+      .insert(reservations)
+      .values({
+        workspaceId,
+        provisionerId,
+        requiredLabels: ['linux'],
+        count: 1,
+        expiresAt: new Date(Date.now() + 60_000),
+      })
+      .returning();
+    if (!reservation) throw new Error('Reservation insert returned no row');
+
+    const created = await app.inject({
+      method: 'POST',
+      url: '/provisioners/runner-instances/batch',
+      headers: {authorization: `Bearer ${token}`},
+      payload: {
+        runner_instances: [{template_key: 'linux', reservation_id: reservation.id}],
+      },
+    });
+    const runner = created.json().runner_instances[0];
+    const exchanged = await app.inject({
+      method: 'POST',
+      url: '/runner-enrollment/exchange',
+      payload: {bootstrap_token: runner.bootstrap_token},
+    });
+    const controlToken = exchanged.json().control_session_token;
+
+    const attached = await app.inject({
+      method: 'POST',
+      url: `/provisioners/runner-instances/${runner.runner_instance_id}/provider-runner`,
+      headers: {authorization: `Bearer ${token}`},
+      payload: {provider_runner_id: 'container-intended-assignment'},
+    });
+    expect(attached.json()).toEqual({attached: true});
+
+    const enrolled = await app.inject({
+      method: 'POST',
+      url: '/runner-control/enrollment',
+      headers: {authorization: `Bearer ${controlToken}`},
+      payload: {labels: ['linux'], provider_kind: 'docker', protocol_version: '1'},
+    });
+
+    expect(enrolled.statusCode).toBe(200);
+    expect(enrolled.json()).toEqual({activation_token: expect.any(String)});
+    const [instance] = await db()
+      .select()
+      .from(providerRunners)
+      .where(eq(providerRunners.id, runner.runner_instance_id));
+    expect(instance).toMatchObject({
+      workspaceId,
+      reservationId: reservation.id,
+      intendedReservationId: null,
+      state: 'running',
+      providerRunnerId: 'container-intended-assignment',
+      assignedAt: expect.any(Date),
+    });
+  });
+
+  it('keeps enrollment successful when an intended reservation cannot be promoted', async () => {
+    const workspaceId = crypto.randomUUID();
+    const [reservation] = await db()
+      .insert(reservations)
+      .values({
+        workspaceId,
+        provisionerId,
+        requiredLabels: ['gpu'],
+        count: 1,
+        expiresAt: new Date(Date.now() + 60_000),
+      })
+      .returning();
+    if (!reservation) throw new Error('Reservation insert returned no row');
+
+    const created = await app.inject({
+      method: 'POST',
+      url: '/provisioners/runner-instances/batch',
+      headers: {authorization: `Bearer ${token}`},
+      payload: {runner_instances: [{reservation_id: reservation.id}]},
+    });
+    const runner = created.json().runner_instances[0];
+    const exchanged = await app.inject({
+      method: 'POST',
+      url: '/runner-enrollment/exchange',
+      payload: {bootstrap_token: runner.bootstrap_token},
+    });
+    const controlToken = exchanged.json().control_session_token;
+    await app.inject({
+      method: 'POST',
+      url: `/provisioners/runner-instances/${runner.runner_instance_id}/provider-runner`,
+      headers: {authorization: `Bearer ${token}`},
+      payload: {provider_runner_id: 'container-intended-mismatch'},
+    });
+
+    const enrolled = await app.inject({
+      method: 'POST',
+      url: '/runner-control/enrollment',
+      headers: {authorization: `Bearer ${controlToken}`},
+      payload: {labels: ['linux'], provider_kind: 'docker', protocol_version: '1'},
+    });
+
+    expect(enrolled.statusCode).toBe(200);
+    expect(enrolled.json()).toEqual({activation_token: null});
+    const [instance] = await db()
+      .select()
+      .from(providerRunners)
+      .where(eq(providerRunners.id, runner.runner_instance_id));
+    expect(instance).toMatchObject({
+      workspaceId: null,
+      reservationId: null,
+      intendedReservationId: reservation.id,
+      state: 'running',
+    });
   });
 
   it('rejects enrollment when the authenticated runner instance is terminal', async () => {

--- a/libs/api/runners/src/presentation/routes/runner-enrollment.ts
+++ b/libs/api/runners/src/presentation/routes/runner-enrollment.ts
@@ -11,6 +11,7 @@ import {
   runnerBootstrapExchangeResponseSchema,
   runnerControlHeartbeatResponseSchema,
   runnerEnrollmentBodySchema,
+  runnerEnrollmentResponseSchema,
 } from '@shipfox/api-runners-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
@@ -43,9 +44,10 @@ export const createRunnerInstancesRoute = defineRoute({
     const results = await createRunnerInstancesWithBootstrapTokens({
       provisionerId: provisionerTokenId,
       ...(request.body.provider_kind ? {providerKind: request.body.provider_kind} : {}),
-      runnerInstances: request.body.runner_instances.map((runner) =>
-        runner.template_key ? {templateKey: runner.template_key} : {},
-      ),
+      runnerInstances: request.body.runner_instances.map((runner) => ({
+        ...(runner.template_key ? {templateKey: runner.template_key} : {}),
+        ...(runner.reservation_id ? {reservationId: runner.reservation_id} : {}),
+      })),
       ttlSeconds: config.RUNNER_BOOTSTRAP_TOKEN_TTL_SECONDS,
     });
     return {
@@ -111,16 +113,16 @@ export const enrollRunnerRoute = defineRoute({
   method: 'POST',
   path: '/enrollment',
   description: 'Declare the authenticated runner instance labels and protocol capabilities',
-  schema: {body: runnerEnrollmentBodySchema, response: {204: z.null()}},
+  schema: {body: runnerEnrollmentBodySchema, response: {200: runnerEnrollmentResponseSchema}},
   preHandler: authenticateRunnerControlSession,
   errorHandler: (error) => {
     if (error instanceof RunnerControlSessionInvalidError)
       throw new ClientError(error.message, 'runner-control-session-invalid', {status: 409});
     throw error;
   },
-  handler: async (request, reply) => {
+  handler: async (request) => {
     const session = requireRunnerControlSessionContext(request);
-    await enrollRunnerControlSession({
+    const activationToken = await enrollRunnerControlSession({
       runnerInstanceId: session.runnerInstanceId,
       provisionerId: session.provisionerId,
       labels: request.body.labels,
@@ -128,7 +130,7 @@ export const enrollRunnerRoute = defineRoute({
       providerKind: request.body.provider_kind,
       protocolVersion: request.body.protocol_version,
     });
-    return await reply.code(204).send();
+    return {activation_token: activationToken};
   },
 });
 

--- a/libs/provisioner/core/src/tick.test.ts
+++ b/libs/provisioner/core/src/tick.test.ts
@@ -1,3 +1,4 @@
+import type {CreateRunnerInstancesBodyDto} from '@shipfox/api-runners-dto';
 import type {ProvisionerClient} from './api-client.js';
 import {runProvisionerTick} from './tick.js';
 import {createInMemoryTracker} from './tracker.js';
@@ -5,6 +6,7 @@ import {createInMemoryTracker} from './tracker.js';
 describe('runProvisionerTick', () => {
   it('creates runner instances with bootstrap tokens before launching demand-driven runners', async () => {
     const calls: string[] = [];
+    const createBodies: CreateRunnerInstancesBodyDto[] = [];
     const client: ProvisionerClient = {
       getIdentity: async () => ({id: 'provisioner', scope: 'workspace', workspace_id: 'workspace'}),
       pollDemand: async () => ({
@@ -19,8 +21,9 @@ describe('runProvisionerTick', () => {
         ],
         terminate_provider_runner_ids: [],
       }),
-      createRunnerInstances: () => {
+      createRunnerInstances: (body) => {
         calls.push('create');
+        createBodies.push(body);
         return Promise.resolve({
           runner_instances: [
             {
@@ -64,6 +67,13 @@ describe('runProvisionerTick', () => {
     expect(launches).toEqual(['sf_rbt_test']);
     expect(result).toMatchObject({launchedCount: 1, providerLaunchFailureCount: 0});
     expect(result.launchLifecycleIncompleteCount).toBe(1);
+    expect(createBodies).toEqual([
+      {
+        runner_instances: [
+          {template_key: 'linux', reservation_id: '018f0d4c-5f42-7b7e-9d9b-4a7d8e6f0001'},
+        ],
+      },
+    ]);
   });
 
   it('counts partial runner-instance creation as failed capacity work', async () => {

--- a/libs/provisioner/core/src/tick.ts
+++ b/libs/provisioner/core/src/tick.ts
@@ -275,7 +275,12 @@ async function launchReservation<Spec>(
     let created: CreateRunnerInstancesResponseDto;
     try {
       created = await deps.client.createRunnerInstances(
-        {runner_instances: batch.map((runner) => ({template_key: runner.template.key}))},
+        {
+          runner_instances: batch.map((runner) => ({
+            template_key: runner.template.key,
+            ...(reservationId ? {reservation_id: reservationId} : {}),
+          })),
+        },
         deps.signal ? {signal: deps.signal} : {},
       );
     } catch (error) {

--- a/libs/provisioner/docker/src/docker-engine.test.ts
+++ b/libs/provisioner/docker/src/docker-engine.test.ts
@@ -111,6 +111,48 @@ describe('createDockerEngine', () => {
     expect(docker.removed).toEqual(['runner-1']);
   });
 
+  it('runs the pre-start hook before starting the container', async () => {
+    const docker = fakeDocker();
+    const engine = createDockerEngine({docker: docker as never});
+
+    await engine.createAndStart({
+      name: 'runner-1',
+      image: 'runner:latest',
+      env: {},
+      labels: {'shipfox.provisioner_id': 'p1'},
+      nanoCpus: 1,
+      memoryBytes: 1,
+      beforeStart: () => {
+        docker.events.push('before-start');
+        return Promise.resolve();
+      },
+    });
+
+    expect(docker.events).toEqual(['create', 'before-start', 'start']);
+    expect(docker.started).toEqual(['runner-1']);
+  });
+
+  it('removes a created container when the pre-start hook fails', async () => {
+    const docker = fakeDocker();
+    const engine = createDockerEngine({docker: docker as never});
+    const error = new Error('attach failed');
+
+    await expect(
+      engine.createAndStart({
+        name: 'runner-1',
+        image: 'runner:latest',
+        env: {},
+        labels: {'shipfox.provisioner_id': 'p1'},
+        nanoCpus: 1,
+        memoryBytes: 1,
+        beforeStart: () => Promise.reject(error),
+      }),
+    ).rejects.toBe(error);
+
+    expect(docker.removed).toEqual(['runner-1']);
+    expect(docker.started).toEqual([]);
+  });
+
   it('maps create conflicts to name-conflict', async () => {
     const docker = fakeDocker({createError: statusError(409)});
     const engine = createDockerEngine({docker: docker as never});
@@ -296,6 +338,7 @@ function fakeDocker(
   const pulled: string[] = [];
   const created: unknown[] = [];
   const started: string[] = [];
+  const events: string[] = [];
   const removed: string[] = [];
   const inspected: string[] = [];
   const missingImages = options.missingImages ?? new Set<string>();
@@ -304,6 +347,7 @@ function fakeDocker(
     pulled,
     created,
     started,
+    events,
     removed,
     inspected,
     modem: {
@@ -328,10 +372,12 @@ function fakeDocker(
     createContainer: (params: unknown) => {
       if (options.createError) return Promise.reject(options.createError);
       created.push(params);
+      events.push('create');
       const name = (params as {name: string}).name;
       return Promise.resolve({
         start: () => {
           if (options.startError) return Promise.reject(options.startError);
+          events.push('start');
           started.push(name);
           return Promise.resolve();
         },

--- a/libs/provisioner/docker/src/docker-engine.ts
+++ b/libs/provisioner/docker/src/docker-engine.ts
@@ -63,6 +63,7 @@ export interface DockerEngine {
     labels: Readonly<Record<string, string>>;
     nanoCpus: number;
     memoryBytes: number;
+    beforeStart?: () => Promise<void>;
   }): Promise<void>;
   listManaged(provisionerId: string): Promise<DockerContainerView[]>;
   remove(name: string): Promise<void>;
@@ -174,6 +175,13 @@ export function createDockerEngine(options: CreateDockerEngineOptions = {}): Doc
           ),
           selectedDriver,
         );
+      }
+
+      try {
+        await args.beforeStart?.();
+      } catch (error) {
+        await removeContainer(container).catch(() => undefined);
+        throw error;
       }
 
       try {

--- a/libs/provisioner/docker/src/lifecycle.test.ts
+++ b/libs/provisioner/docker/src/lifecycle.test.ts
@@ -104,25 +104,33 @@ describe('createDockerLifecycle', () => {
     expect(engine.created).toHaveLength(1);
     expect(client.reportBodies[0]?.events[0]).toMatchObject({state: 'starting'});
   });
-  it('does not report a started container as failed when identity attachment fails', async () => {
+  it('reports a failed launch when identity attachment fails before start', async () => {
     const error = new Error('identity API unavailable');
-    const engine = fakeEngine();
+    const events: string[] = [];
+    const engine = fakeEngine({events});
     const client = fakeClient({attachErrors: [error]});
     const lifecycle = makeLifecycle({engine, client});
 
-    const outcome = await lifecycle.launch(launch());
+    await expect(lifecycle.launch(launch())).rejects.toThrow(error);
 
     expect(engine.created).toHaveLength(1);
-    expect(client.reportBodies).toEqual([]);
-    expect(outcome).toEqual({containerStarted: true, identityAttached: false, reported: false});
-    expect(observability.logger.debug).toHaveBeenCalledWith(
-      expect.objectContaining({event: 'runner.container_identity_attachment_failed'}),
-      'Failed to attach provider identity after runner container started',
-    );
+    expect(events).not.toContain('start');
+    expect(client.reportBodies.map((body) => body.events[0]?.state)).toEqual(['failed']);
     expect(observability.logger.error).not.toHaveBeenCalledWith(
       expect.objectContaining({event: 'runner.container_launch_failed'}),
       expect.any(String),
     );
+  });
+
+  it('attaches the provider identity before starting the container', async () => {
+    const events: string[] = [];
+    const engine = fakeEngine({events});
+    const client = fakeClient({events});
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.launch(launch());
+
+    expect(events).toEqual(['create', 'attach', 'start']);
   });
 
   it('assigns an enrolled observed runner through its container identity', async () => {
@@ -1336,6 +1344,7 @@ function fakeClient(
     reconcileErrors?: Error[];
     reconcileResponse?: ReconcileRunnerInstancesResponseDto;
     onReport?: () => void;
+    events?: string[];
   } = {},
 ): ProvisionerClient & {
   reportBodies: ReportRunnerInstancesBodyDto[];
@@ -1366,6 +1375,7 @@ function fakeClient(
     attachRunnerInstanceProviderId: () => {
       const error = attachErrors.shift();
       if (error) return Promise.reject(error);
+      options.events?.push('attach');
       return Promise.resolve({attached: true});
     },
     assignRunnerInstances: (reservationId, runnerInstanceIds) => {
@@ -1402,6 +1412,7 @@ function fakeEngine(
     removeErrors?: Array<Error | undefined>;
     killAndRemoveError?: Error;
     onRemove?: () => void;
+    events?: string[];
   } = {},
 ): DockerEngine & {
   created: Parameters<DockerEngine['createAndStart']>[0][];
@@ -1427,7 +1438,11 @@ function fakeEngine(
     createAndStart: (args) => {
       if (options.createError) return Promise.reject(options.createError);
       created.push(args);
-      return Promise.resolve();
+      options.events?.push('create');
+      return (async () => {
+        await args.beforeStart?.();
+        options.events?.push('start');
+      })();
     },
     listManaged: () => {
       listManagedCalls += 1;

--- a/libs/provisioner/docker/src/lifecycle.ts
+++ b/libs/provisioner/docker/src/lifecycle.ts
@@ -168,7 +168,6 @@ async function launch(
   runner: ProviderRunnerLaunch<DockerTemplateSpec>,
 ): Promise<LaunchOutcome> {
   const labels = buildContainerLabels({launch: runner, identity: context.identity});
-
   try {
     await context.engine.createAndStart({
       name: runner.providerRunnerId,
@@ -180,40 +179,26 @@ async function launch(
       labels,
       nanoCpus: Math.round(runner.template.spec.cpu * 1_000_000_000),
       memoryBytes: parseMemoryToBytes(runner.template.spec.memory),
+      beforeStart: async () => {
+        const attachRunnerInstanceProviderId = context.client.attachRunnerInstanceProviderId;
+        if (!attachRunnerInstanceProviderId)
+          throw new Error(
+            'Provisioner client does not support runner-instance provider identity attachment',
+          );
+        const result = await attachRunnerInstanceProviderId(
+          runner.runnerInstanceId,
+          runner.providerRunnerId,
+        );
+        if (!result.attached) {
+          throw new Error(
+            `Provider identity was not attached for runner instance ${runner.runnerInstanceId}`,
+          );
+        }
+      },
     });
   } catch (error) {
     await reportContainerCreationFailure(context, runner, error);
     throw error;
-  }
-
-  try {
-    const attachRunnerInstanceProviderId = context.client.attachRunnerInstanceProviderId;
-    if (!attachRunnerInstanceProviderId)
-      throw new Error(
-        'Provisioner client does not support runner-instance provider identity attachment',
-      );
-    const result = await attachRunnerInstanceProviderId(
-      runner.runnerInstanceId,
-      runner.providerRunnerId,
-    );
-    if (!result.attached) {
-      throw new Error(
-        `Provider identity was not attached for runner instance ${runner.runnerInstanceId}`,
-      );
-    }
-  } catch (error) {
-    logger().debug?.(
-      {
-        event: 'runner.container_identity_attachment_failed',
-        operation: 'attach_runner_instance_provider_id',
-        providerRunnerId: runner.providerRunnerId,
-        runnerInstanceId: runner.runnerInstanceId,
-        reason: truncateReason(errorReason(error)),
-      },
-      'Failed to attach provider identity after runner container started',
-    );
-    if (error instanceof ProvisionerAuthenticationError) throw error;
-    return {containerStarted: true, identityAttached: false, reported: false};
   }
 
   const reported = await reportEvents(context, [

--- a/libs/runner/orchestration/src/core/runner.test.ts
+++ b/libs/runner/orchestration/src/core/runner.test.ts
@@ -433,7 +433,7 @@ describe('startRunner', () => {
     vi.stubEnv('SHIPFOX_RUNNER_PROTOCOL_VERSION', '1');
     mockRunnerStartupMode.mockReturnValue('managed');
     mockExchangeRunnerBootstrapToken.mockResolvedValue({controlSessionToken: 'control-token'});
-    mockEnrollRunnerControlSession.mockResolvedValue();
+    mockEnrollRunnerControlSession.mockResolvedValue(null);
     mockHeartbeatRunnerControlSession.mockResolvedValue();
     mockPollRunnerAssignment.mockResolvedValueOnce(null).mockResolvedValueOnce('activation-token');
     mockRequestJob.mockRejectedValue(new RunnerSessionExhaustedError());
@@ -452,7 +452,7 @@ describe('startRunner', () => {
     vi.stubEnv('SHIPFOX_RUNNER_PROTOCOL_VERSION', '1');
     mockRunnerStartupMode.mockReturnValue('managed');
     mockExchangeRunnerBootstrapToken.mockResolvedValue({controlSessionToken: 'control-token'});
-    mockEnrollRunnerControlSession.mockResolvedValue();
+    mockEnrollRunnerControlSession.mockResolvedValue(null);
     mockHeartbeatRunnerControlSession.mockResolvedValueOnce().mockRejectedValueOnce(heartbeatError);
     mockPollRunnerAssignment.mockResolvedValue(null);
     mockInterruptibleSleep.mockImplementationOnce(

--- a/libs/runner/orchestration/src/core/runner.test.ts
+++ b/libs/runner/orchestration/src/core/runner.test.ts
@@ -399,7 +399,7 @@ describe('startRunner', () => {
       expect(mockInterruptibleSleep).not.toHaveBeenCalled();
       return Promise.resolve({controlSessionToken: 'control-token'});
     });
-    mockEnrollRunnerControlSession.mockResolvedValue();
+    mockEnrollRunnerControlSession.mockResolvedValue(null);
     mockHeartbeatRunnerControlSession.mockResolvedValue();
     mockPollRunnerAssignment.mockResolvedValue('activation-token');
     mockRequestJob.mockRejectedValue(new RunnerSessionExhaustedError());
@@ -473,6 +473,31 @@ describe('startRunner', () => {
     }
   });
 
+  it('uses an activation token returned by enrollment without polling for assignment', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(0);
+    vi.stubEnv('SHIPFOX_RUNNER_BOOTSTRAP_TOKEN', 'sf_rbt_bootstrap-token');
+    vi.stubEnv('SHIPFOX_RUNNER_PROVIDER_KIND', 'ec2');
+    vi.stubEnv('SHIPFOX_RUNNER_PROTOCOL_VERSION', '1');
+    mockRunnerStartupMode.mockReturnValue('managed');
+    mockExchangeRunnerBootstrapToken.mockResolvedValue({controlSessionToken: 'control-token'});
+    mockEnrollRunnerControlSession.mockResolvedValue('enrollment-activation-token');
+    mockRegisterRunnerSession.mockResolvedValue({
+      session_id: '00000000-0000-0000-0000-000000000003',
+      session_token: 'session-token',
+      mode: 'activation',
+      max_claims: 1,
+    });
+    mockRequestJob.mockRejectedValue(new RunnerSessionExhaustedError());
+
+    await startRunner();
+
+    expect(mockPollRunnerAssignment).not.toHaveBeenCalled();
+    expect(mockRegisterRunnerSession).toHaveBeenCalledWith({
+      capabilities: {harnesses: {pi: {tools: ['read']}}},
+      registrationToken: 'enrollment-activation-token',
+    });
+  });
+
   it('retries a failed first direct registration', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(0);
     mockRegisterRunnerSession
@@ -495,7 +520,7 @@ describe('startRunner', () => {
     vi.spyOn(Date, 'now').mockReturnValue(0);
     mockRunnerStartupMode.mockReturnValue('managed');
     mockExchangeRunnerBootstrapToken.mockResolvedValue({controlSessionToken: 'control-token'});
-    mockEnrollRunnerControlSession.mockResolvedValue();
+    mockEnrollRunnerControlSession.mockResolvedValue(null);
     mockHeartbeatRunnerControlSession.mockResolvedValue();
     mockPollRunnerAssignment.mockImplementation(async (_controlSessionToken, signal) => {
       process.emit('SIGTERM');

--- a/libs/runner/orchestration/src/core/runner.ts
+++ b/libs/runner/orchestration/src/core/runner.ts
@@ -288,13 +288,14 @@ async function initializeManagedRunnerSession(): Promise<RunnerSession | undefin
   const exchanged = await exchangeRunnerBootstrapToken(bootstrapToken);
   const controlSessionToken = exchanged.controlSessionToken;
   const enrollmentConfig = managedRunnerEnrollmentConfig();
-  await enrollRunnerControlSession({
+  const enrollmentActivationToken = await enrollRunnerControlSession({
     controlSessionToken,
     capabilities: runnerToolCapabilities(),
     providerKind: enrollmentConfig.providerKind,
     protocolVersion: enrollmentConfig.protocolVersion,
   });
-  const activationToken = await waitForRunnerActivation(controlSessionToken);
+  const activationToken =
+    enrollmentActivationToken ?? (await waitForRunnerActivation(controlSessionToken));
   if (!activationToken) return undefined;
 
   const runnerSession = await registerRunnerSession({

--- a/libs/runner/protocol/src/api-client.test.ts
+++ b/libs/runner/protocol/src/api-client.test.ts
@@ -103,15 +103,16 @@ describe('api-client auth contexts', () => {
   });
 
   it('enrolls, heartbeats, and polls only with the control-session token', async () => {
-    stubFetch(() => new Response(null, {status: 204}));
+    stubFetch(() => jsonResponse({activation_token: null}));
 
-    await enrollRunnerControlSession({
+    const enrollmentActivationToken = await enrollRunnerControlSession({
       controlSessionToken: 'control-token',
       capabilities: TOOL_CAPABILITIES,
       providerKind: 'ec2',
       protocolVersion: '1',
     });
 
+    expect(enrollmentActivationToken).toBeNull();
     expect(calls[0]?.url).toContain('runner-control/enrollment');
     expect(calls[0]?.authorization).toBe('Bearer control-token');
     expect(JSON.parse(calls[0]?.body ?? '{}')).toEqual({

--- a/libs/runner/protocol/src/api-client.ts
+++ b/libs/runner/protocol/src/api-client.ts
@@ -24,6 +24,7 @@ import {
   runnerBootstrapExchangeResponseSchema,
   runnerControlHeartbeatResponseSchema,
   runnerEnrollmentBodySchema,
+  runnerEnrollmentResponseSchema,
 } from '@shipfox/api-runners-dto';
 import {type StepSecretsResponseDto, stepSecretsResponseSchema} from '@shipfox/api-secrets-dto';
 import {
@@ -192,16 +193,18 @@ export async function enrollRunnerControlSession(params: {
   capabilities: RunnerToolCapabilitiesDto;
   providerKind: string;
   protocolVersion: string;
-}): Promise<void> {
+}): Promise<string | null> {
   const body = runnerEnrollmentBodySchema.parse({
     labels: configuredRunnerLabels(),
     capabilities: params.capabilities,
     provider_kind: params.providerKind,
     protocol_version: params.protocolVersion,
   });
-  await createRunnerControlClient(params.controlSessionToken).post('runner-control/enrollment', {
-    json: body,
-  });
+  const response = await createRunnerControlClient(params.controlSessionToken).post(
+    'runner-control/enrollment',
+    {json: body},
+  );
+  return runnerEnrollmentResponseSchema.parse(await response.json()).activation_token;
 }
 
 export async function heartbeatRunnerControlSession(


### PR DESCRIPTION
## Summary

Runner creation now records its intended reservation, and enrollment promotes that reservation before issuing an activation token. Runner clients consume the returned token immediately and retain polling as a fallback, while provisioners pass reservation IDs through and Docker attaches provider identity before starting the container.

Capacity accounting, terminal cleanup, reservation indexes, and savepoint-scoped promotion keep failed or expired fast paths from blocking replacement runners. The API and DTO release metadata, including the folded single migration, are included with the change.

## Validation

- `mise exec -- rtk turbo type --filter=@shipfox/api-runners --filter=@shipfox/provisioner-core --filter=@shipfox/provisioner-docker-provider`
- `mise exec -- rtk turbo check --filter=@shipfox/api-runners --filter=@shipfox/provisioner-core --filter=@shipfox/provisioner-docker-provider`
- `@shipfox/api-runners`: 38 files, 443 tests passed
- `@shipfox/api-runners-dto`: 9 files, 43 tests passed
- `@shipfox/provisioner-core`: 8 files, 43 tests passed
- Docker unit suite: 6 files, 73 tests passed
- `@shipfox/runner-protocol`: 3 files, 55 tests passed
- `@shipfox/runner-orchestration`: 4 files, 83 tests passed
- API database boundaries and migration catalog: passed with no findings

The real Docker integration test was excluded from the local unit run because it requires the Docker daemon and previously timed out in this environment.

Closes ENG-1327

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces runner activation latency by storing intended reservations and promoting them during enrollment to return an immediate activation token. Also fixes terminal cleanup by preferring the provisioner’s intended reservation and refines capacity accounting to ignore released intents/assignments. Addresses ENG-1327.

- **New Features**
  - Enrollment promotes intended reservations and returns `activation_token` when available; runners still poll as a fallback.
  - `createRunnerInstances` accepts `reservation_id`; `@shipfox/provisioner-core` passes it through for reservation-driven launches.
  - Docker lifecycle attaches provider identity before starting; cleans up the container if attachment fails.
  - DB adds `intended_reservation_id` and reservation indexes for fast lookups.
  - Cleanup prefers the provisioner’s intended reservation when intent and stale assignment coexist.

- **Migration**
  - Apply migration `0001_intended_reservation`.
  - Update clients to expect HTTP 200 with `{activation_token}` (or `null`) from `runner-control/enrollment` (was 204).
  - Use new DTOs in `@shipfox/api-runners-dto`: `RunnerEnrollmentResponseDto` and `runnerEnrollmentResponseSchema`.

<sup>Written for commit 8397093e21028b1a7891a95d37f43c2b591c1ebe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

