### PR TITLE
Tell users when runner harness setup fails

### DIFF
--- a/libs/client/workflows/src/components/workflow-run-view/agent-config-failure-callout.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/agent-config-failure-callout.stories.tsx
@@ -66,7 +66,7 @@ type AgentConfigIssueValue = NonNullable<StepError['agentConfigIssue']>;
 
 const errorCases: Array<{
   label: string;
-  error: WorkflowStepError;
+  error: StepError;
 }> = [
   {label: 'Provider not configured', error: makeError('provider_not_configured')},
   {label: 'Credentials invalid', error: makeError('credentials_invalid')},

--- a/libs/client/workflows/src/components/workflow-run-view/agent-harness-unavailable-callout.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/agent-harness-unavailable-callout.stories.tsx
@@ -1,0 +1,52 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {expect, within} from 'storybook/test';
+import type {StepError} from '#core/workflow-run.js';
+import {AgentHarnessUnavailableCallout} from './agent-harness-unavailable-callout.js';
+
+const meta = {
+  title: 'Workflows/RunView/AgentHarnessUnavailableCallout',
+  component: AgentHarnessUnavailableCallout,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-560 bg-background-neutral-base p-16">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    error: makeError(),
+  },
+} satisfies Meta<typeof AgentHarnessUnavailableCallout>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const TestRunnerGuidance: Story = {
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    await canvas.findByRole('alert');
+    expect(
+      canvas.getByText('The runner could not start the agent for this step'),
+    ).toBeInTheDocument();
+    expect(
+      canvas.getByText('Runner reported: Pi extension setup failed: Unknown option: --mcp-config'),
+    ).toBeInTheDocument();
+  },
+};
+
+function makeError(): StepError {
+  return {
+    message: 'Pi extension setup failed: Unknown option: --mcp-config',
+    exitCode: null,
+    signal: undefined,
+    reason: 'agent_harness_unavailable',
+    agentConfigIssue: undefined,
+    category: 'user',
+  };
+}

--- a/libs/client/workflows/src/components/workflow-run-view/agent-harness-unavailable-callout.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/agent-harness-unavailable-callout.stories.tsx
@@ -37,6 +37,7 @@ export const TestRunnerGuidance: Story = {
     expect(
       canvas.getByText('Runner reported: Pi extension setup failed: Unknown option: --mcp-config'),
     ).toBeInTheDocument();
+    expect(canvas.queryByRole('link', {name: 'Configure Agents'})).not.toBeInTheDocument();
   },
 };
 

--- a/libs/client/workflows/src/components/workflow-run-view/agent-harness-unavailable-callout.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/agent-harness-unavailable-callout.tsx
@@ -1,0 +1,18 @@
+import {Alert, AlertContent, AlertDescription, AlertTitle} from '@shipfox/react-ui/alert';
+import type {StepError} from '#core/workflow-run.js';
+
+export function AgentHarnessUnavailableCallout({error}: {error: StepError}) {
+  return (
+    <Alert variant="error" animated={false} className="px-10 py-8">
+      <AlertContent>
+        <AlertTitle>The runner could not start the agent for this step</AlertTitle>
+        <AlertDescription>
+          This step&apos;s prompt, provider, model, and thinking settings are valid. The runner
+          could not start its agent before the model was called, so nothing ran. Re-running will not
+          help. Ask an administrator to update the runner, then re-run the workflow.
+        </AlertDescription>
+        <AlertDescription className="mt-4">Runner reported: {error.message}</AlertDescription>
+      </AlertContent>
+    </Alert>
+  );
+}

--- a/libs/client/workflows/src/components/workflow-run-view/job-card.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/job-card.tsx
@@ -25,6 +25,7 @@ import {
 } from '#core/workflow-run.js';
 import {type StepExpandedContext, StepList, type StepListEmptyState} from '../step-list/index.js';
 import {AgentConfigFailureCallout} from './agent-config-failure-callout.js';
+import {AgentHarnessUnavailableCallout} from './agent-harness-unavailable-callout.js';
 import {JobExecutionSwitcher} from './job-execution-switcher.js';
 import {formatJobExecutionTime, JobExecutionTimeText} from './job-execution-time-text.js';
 import {StepAttemptLogPanel} from './step-attempt-log-panel.js';
@@ -393,6 +394,8 @@ function StepAttemptDetailPanel({
           config={step.agentConfig}
           error={selectedAttemptError}
         />
+      ) : isAgentHarnessFailure(step, selectedAttemptError) ? (
+        <AgentHarnessUnavailableCallout error={selectedAttemptError} />
       ) : null}
       <StepAttemptLogPanel stepId={stepId} attempt={attempt} attemptStatus={attemptStatus} />
     </div>
@@ -438,6 +441,10 @@ function toSelectedAttemptError(
 
 function isAgentConfigFailure(step: Step, error: StepError | null): boolean {
   return step.type === 'agent' && error?.reason === 'agent_config_invalid';
+}
+
+function isAgentHarnessFailure(step: Step, error: StepError | null): error is StepError {
+  return step.type === 'agent' && error?.reason === 'agent_harness_unavailable';
 }
 
 function emptyStateForJob(job: Job, jobExecution: JobExecution): StepListEmptyState | undefined {

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -305,6 +305,88 @@ describe('WorkflowRunView', () => {
     );
   });
 
+  test('shows runner guidance for agent harness failures without step settings or admin actions', async () => {
+    const user = userEvent.setup();
+    const stepId = '99999999-9999-4999-8999-000000000006';
+    const attemptId = 'aaaaaaaa-aaaa-4aaa-8aaa-000000000006';
+    configureApiClient({
+      fetchImpl: vi.fn((input: RequestInfo | URL) => {
+        const url = requestUrl(input);
+        if (url.pathname === `/steps/${stepId}/attempts/1/logs`) {
+          return Promise.resolve(jsonResponse(inlineLogBody(outputLine('runner failed\n'), 1)));
+        }
+        return Promise.resolve(
+          jsonResponse(
+            workflowRunViewDetailDto({
+              jobs: [
+                workflowJobDto({
+                  id: BUILD_JOB_ID,
+                  run_attempt_id: RUN_ID,
+                  name: 'build',
+                  status: 'failed',
+                  steps: [
+                    workflowStepDto({
+                      id: stepId,
+                      key: 'implement',
+                      name: 'Fix the failing tests.',
+                      type: 'agent',
+                      status: 'failed',
+                      config: {
+                        provider: 'anthropic',
+                        model: 'claude-opus-4-8',
+                        thinking: 'high',
+                        prompt: 'Fix the failing tests.',
+                      },
+                      error: {
+                        message: 'Pi extension setup failed: Unknown option: --mcp-config',
+                        reason: 'agent_harness_unavailable',
+                        category: 'user',
+                      },
+                      attempts: [
+                        workflowStepAttemptDto({
+                          id: attemptId,
+                          step_id: stepId,
+                          status: 'failed',
+                          exit_code: 1,
+                          error: {
+                            message: 'Pi extension setup failed: Unknown option: --mcp-config',
+                            reason: 'agent_harness_unavailable',
+                          },
+                          finished_at: '2026-05-07T01:01:20.000Z',
+                        }),
+                      ],
+                    }),
+                  ],
+                }),
+              ],
+            }),
+          ),
+        );
+      }),
+    });
+
+    renderView();
+    await user.click(
+      await screen.findByRole('button', {
+        name: 'Fix the failing tests., Failed, attempt 1, User',
+      }),
+    );
+
+    expect(
+      screen.getByText('The runner could not start the agent for this step'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This step's prompt, provider, model, and thinking settings are valid. The runner could not start its agent before the model was called, so nothing ran. Re-running will not help. Ask an administrator to update the runner, then re-run the workflow.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Runner reported: Pi extension setup failed: Unknown option: --mcp-config'),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('link', {name: 'Configure Agents'})).not.toBeInTheDocument();
+    expect(screen.queryByText('claude-opus-4-8')).not.toBeInTheDocument();
+  });
+
   test('falls back to the step error when an agent attempt has no typed error', async () => {
     const user = userEvent.setup();
     const stepId = '99999999-9999-4999-8999-000000000005';

--- a/libs/runner/agent/src/core/errors.ts
+++ b/libs/runner/agent/src/core/errors.ts
@@ -1,8 +1,17 @@
+import {basename} from 'node:path';
 import type {
   AgentSessionRuntimeDiagnostic,
   LoadExtensionsResult,
 } from '@earendil-works/pi-coding-agent';
-import type {AgentConfigIssueDto} from '@shipfox/api-workflows-dto';
+import {type AgentConfigIssueDto, STEP_ERROR_MESSAGE_MAX_LENGTH} from '@shipfox/api-workflows-dto';
+
+const HARNESS_ERROR_PREFIX = 'Pi extension setup failed: ';
+const HARNESS_DIAGNOSTIC_MAX_LENGTH = STEP_ERROR_MESSAGE_MAX_LENGTH - HARNESS_ERROR_PREFIX.length;
+const PATH_PATTERN =
+  /(?<![A-Za-z0-9._~+@%])((?:file:\/\/)?\/(?:[A-Za-z0-9._~+@%=-]+\/)*[A-Za-z0-9._~+@%=-]+)/g;
+const URL_PATTERN = /(?:https?|ssh):\/\//;
+const TRUNCATION_TOKEN_PATTERN = /\s[^\s]*$/;
+const WHITESPACE_PATTERN = /(\s+)/;
 
 /**
  * A user-fixable agent-step configuration failure: an unknown provider, a
@@ -30,29 +39,101 @@ export interface AgentHarnessEnvironment {
   readonly resolvedExtensionPaths?: readonly string[];
 }
 
+export type AgentHarnessResourceLoaderError = LoadExtensionsResult['errors'][number];
+
+export interface AgentHarnessResourceLoaderFailure {
+  readonly error: AgentHarnessResourceLoaderError;
+  readonly directory: string;
+}
+
+/** Removes filesystem prefixes from user-visible harness diagnostics without rewriting syntax. */
+function sanitizeHarnessDiagnosticMessage(messages: readonly string[]): string {
+  const sanitizedMessages = messages
+    .filter((diagnostic) => diagnostic.trim().length > 0)
+    .map(sanitizeDiagnosticMessage)
+    .filter((message, index, allMessages) => allMessages.indexOf(message) === index);
+  const message = sanitizedMessages.join('; ');
+
+  if (message.length <= HARNESS_DIAGNOSTIC_MAX_LENGTH) return message;
+
+  const marker = '…';
+  const candidate = sliceWithoutLoneSurrogate(
+    message,
+    HARNESS_DIAGNOSTIC_MAX_LENGTH - marker.length,
+  );
+  const boundary = candidate.search(TRUNCATION_TOKEN_PATTERN);
+  const discardedTailLength = boundary > 0 ? candidate.length - boundary : 0;
+  const truncated =
+    boundary > 0 && discardedTailLength <= Math.floor(candidate.length / 2)
+      ? candidate.slice(0, boundary)
+      : candidate;
+  return `${truncated.trimEnd()}${marker}`;
+}
+
+function sanitizeDiagnosticMessage(message: string): string {
+  return message
+    .split(WHITESPACE_PATTERN)
+    .map((token) => (URL_PATTERN.test(token) ? token : sanitizeDiagnosticToken(token)))
+    .join('');
+}
+
+function sliceWithoutLoneSurrogate(value: string, length: number): string {
+  const candidate = value.slice(0, length);
+  const lastCodeUnit = candidate.charCodeAt(candidate.length - 1);
+  return lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff ? candidate.slice(0, -1) : candidate;
+}
+
+function sanitizeDiagnosticToken(token: string): string {
+  return token.replace(PATH_PATTERN, (_match, path: string) =>
+    path.startsWith('file://')
+      ? `file://${path.slice(path.lastIndexOf('/') + 1)}`
+      : path.slice(path.lastIndexOf('/') + 1),
+  );
+}
+
 export class AgentHarnessUnavailableError extends Error {
   public readonly diagnostics: readonly AgentSessionRuntimeDiagnostic[];
   public readonly environment: AgentHarnessEnvironment;
-  public readonly resourceLoaderErrors: readonly LoadExtensionsResult['errors'][number][];
+  public readonly missingExtensionDirectories: readonly string[];
+  public readonly resourceLoaderErrors: readonly AgentHarnessResourceLoaderFailure[];
 
   constructor({
     diagnostics,
     environment,
+    missingExtensionDirectories = [],
     resourceLoaderErrors = [],
   }: {
     diagnostics: readonly AgentSessionRuntimeDiagnostic[];
     environment: AgentHarnessEnvironment;
-    resourceLoaderErrors?: readonly LoadExtensionsResult['errors'][number][];
+    missingExtensionDirectories?: readonly string[];
+    resourceLoaderErrors?: readonly AgentHarnessResourceLoaderFailure[];
   }) {
-    const errors = diagnostics.filter((diagnostic) => diagnostic.type === 'error');
-    const messages = [
-      ...errors.map((diagnostic) => diagnostic.message),
-      ...resourceLoaderErrors.map((resourceError) => resourceError.error),
+    const missingDirectories = missingExtensionDirectories.filter(
+      (directory) => !resourceLoaderErrors.some((failure) => failure.directory === directory),
+    );
+    const loaderMessages = resourceLoaderErrors.map(({error, directory}) => {
+      const message = error.error;
+      const sanitizedMessage = sanitizeDiagnosticMessage(message);
+      const extensionName = basename(directory);
+      return extensionName !== '' && !sanitizedMessage.includes(extensionName)
+        ? `${extensionName}: ${message}`
+        : message;
+    });
+    const extensionMessages = [
+      ...(missingDirectories.length === 0
+        ? []
+        : [`Pi extensions failed to load from: ${missingDirectories.join(', ')}`]),
+      ...loaderMessages,
     ];
-    super(`Pi extension setup failed: ${messages.join('; ')}`);
+    const diagnosticMessages = diagnostics
+      .filter((diagnostic) => diagnostic.type === 'error')
+      .map((diagnostic) => diagnostic.message);
+    const detail = sanitizeHarnessDiagnosticMessage([...extensionMessages, ...diagnosticMessages]);
+    super(`${HARNESS_ERROR_PREFIX}${detail || 'The runner harness could not start.'}`);
     this.name = 'AgentHarnessUnavailableError';
     this.diagnostics = diagnostics;
     this.environment = environment;
+    this.missingExtensionDirectories = missingExtensionDirectories;
     this.resourceLoaderErrors = resourceLoaderErrors;
   }
 }

--- a/libs/runner/agent/src/core/errors.ts
+++ b/libs/runner/agent/src/core/errors.ts
@@ -10,9 +10,11 @@ const HARNESS_DIAGNOSTIC_MAX_LENGTH = 200;
 const PATH_PATTERN = /(?:file:\/\/)?\//g;
 const PATH_PREFIX_CHARACTER_PATTERN = /[A-Za-z0-9._~+@%]/;
 const NETWORK_URL_PATTERN = /(?:https?|ssh):\/{0,2}$/;
-const ABSOLUTE_PATH_FIRST_CHARACTER_PATTERN = /[\\/^*?()[\]{}]/;
+const REGEX_DIAGNOSTIC_PATTERN = /[\\^$*+?]/;
+const ENVIRONMENT_PATH_PREFIX_PATTERN = /(?:^|\s)[A-Za-z_][A-Za-z0-9_]*=$/;
 const WHITESPACE_PATTERN = /\s/;
 const PATH_EXTENSION_PATTERN = /\.[A-Za-z0-9]+$/;
+const PATH_BOUNDARY_PREFIX_PATTERN = /^[)\]}]/;
 const TRAILING_PATH_PUNCTUATION_PATTERN = /[.,;:]+$/;
 const TRUNCATION_TOKEN_PATTERN = /\s[^\s]*$/;
 
@@ -75,11 +77,12 @@ function sanitizeHarnessDiagnosticMessage(messages: readonly string[]): string {
 
 function sanitizeDiagnosticMessage(message: string): string {
   let cursor = 0;
+  let skippedUntil = 0;
   let sanitized = '';
 
   for (const match of message.matchAll(PATH_PATTERN)) {
     const matchStart = match.index;
-    if (matchStart < cursor) continue;
+    if (matchStart < cursor || matchStart < skippedUntil) continue;
 
     const prefix = match[0].startsWith('file://') ? 'file://' : '';
     const pathStart = matchStart + prefix.length;
@@ -88,8 +91,7 @@ function sanitizeDiagnosticMessage(message: string): string {
     if (
       (previousCharacter !== undefined && PATH_PREFIX_CHARACTER_PATTERN.test(previousCharacter)) ||
       isFileUrlSlash(message, pathStart) ||
-      isNetworkUrlSlash(message, pathStart) ||
-      !isLikelyAbsolutePath(message, pathStart)
+      isNetworkUrlSlash(message, pathStart)
     ) {
       continue;
     }
@@ -98,8 +100,13 @@ function sanitizeDiagnosticMessage(message: string): string {
     if (pathEnd <= pathStart + 1) continue;
 
     const path = message.slice(pathStart, pathEnd);
+    if (isSlashDelimitedDiagnostic(path)) {
+      skippedUntil = pathEnd;
+      continue;
+    }
+
     sanitized += message.slice(cursor, matchStart);
-    sanitized += `${prefix}${path.slice(path.lastIndexOf('/') + 1)}`;
+    sanitized += `${prefix}${basename(path)}`;
     cursor = pathEnd;
   }
 
@@ -116,12 +123,9 @@ function isNetworkUrlSlash(message: string, pathStart: number): boolean {
   return NETWORK_URL_PATTERN.test(protocolPrefix);
 }
 
-function isLikelyAbsolutePath(message: string, pathStart: number): boolean {
-  const firstPathCharacter = message[pathStart + 1];
-  return (
-    firstPathCharacter !== undefined &&
-    !ABSOLUTE_PATH_FIRST_CHARACTER_PATTERN.test(firstPathCharacter)
-  );
+function isSlashDelimitedDiagnostic(path: string): boolean {
+  if (!path.endsWith('/')) return false;
+  return path.includes('\\/') || REGEX_DIAGNOSTIC_PATTERN.test(path.slice(1, -1));
 }
 
 function findAbsolutePathEnd(message: string, pathStart: number): number {
@@ -130,21 +134,39 @@ function findAbsolutePathEnd(message: string, pathStart: number): number {
 
     if (isPathTerminator(character)) return index;
 
-    if ((character === ',' || character === ':') && message[index + 1] === '/') return index;
+    if (
+      (character === ',' || (character === ':' && isEnvironmentPath(message, pathStart))) &&
+      message[index + 1] === '/' &&
+      isAdjacentPathStart(message, index + 1)
+    ) {
+      return index;
+    }
 
     if (character !== undefined && WHITESPACE_PATTERN.test(character)) {
       const nextCharacter = skipWhitespace(message, index);
       const nextSegmentEnd = findNextPathTerminator(message, nextCharacter);
       const nextSegment = message.slice(nextCharacter, nextSegmentEnd);
       const continuesPath =
-        nextSegment.includes('/') ||
-        PATH_EXTENSION_PATTERN.test(nextSegment.replace(TRAILING_PATH_PUNCTUATION_PATTERN, ''));
+        !PATH_BOUNDARY_PREFIX_PATTERN.test(nextSegment) &&
+        (nextSegment.includes('/') ||
+          PATH_EXTENSION_PATTERN.test(nextSegment.replace(TRAILING_PATH_PUNCTUATION_PATTERN, '')));
 
       if (!continuesPath) return index;
     }
   }
 
   return message.length;
+}
+
+function isEnvironmentPath(message: string, pathStart: number): boolean {
+  return ENVIRONMENT_PATH_PREFIX_PATTERN.test(message.slice(0, pathStart));
+}
+
+function isAdjacentPathStart(message: string, pathStart: number): boolean {
+  const pathEnd = findAbsolutePathEnd(message, pathStart);
+  const path = message.slice(pathStart, pathEnd);
+  const lastComponent = basename(path).replace(TRAILING_PATH_PUNCTUATION_PATTERN, '');
+  return path.slice(1).includes('/') || PATH_EXTENSION_PATTERN.test(lastComponent);
 }
 
 function skipWhitespace(message: string, start: number): number {
@@ -170,12 +192,6 @@ function isPathTerminator(character: string | undefined): boolean {
     character === '<' ||
     character === '>' ||
     character === '|' ||
-    character === '(' ||
-    character === ')' ||
-    character === '[' ||
-    character === ']' ||
-    character === '{' ||
-    character === '}' ||
     character === ';'
   );
 }

--- a/libs/runner/agent/src/core/errors.ts
+++ b/libs/runner/agent/src/core/errors.ts
@@ -173,10 +173,7 @@ function isAdjacentPathStart(message: string, pathStart: number): boolean {
   let index = pathStart + 1;
   let slashCount = 0;
 
-  while (
-    index < message.length &&
-    index - pathStart <= ADJACENT_PATH_LOOKAHEAD_MAX_LENGTH
-  ) {
+  while (index < message.length && index - pathStart <= ADJACENT_PATH_LOOKAHEAD_MAX_LENGTH) {
     const character = message[index];
     if (
       isPathTerminator(character) ||
@@ -212,8 +209,7 @@ function findNextPathTerminator(message: string, start: number): number {
 function isPathClosingBoundary(message: string, index: number): boolean {
   const character = message[index];
   return (
-    (character === ')' || character === ']' || character === '}') &&
-    message[index + 1] !== '/'
+    (character === ')' || character === ']' || character === '}') && message[index + 1] !== '/'
   );
 }
 

--- a/libs/runner/agent/src/core/errors.ts
+++ b/libs/runner/agent/src/core/errors.ts
@@ -3,15 +3,18 @@ import type {
   AgentSessionRuntimeDiagnostic,
   LoadExtensionsResult,
 } from '@earendil-works/pi-coding-agent';
-import {type AgentConfigIssueDto, STEP_ERROR_MESSAGE_MAX_LENGTH} from '@shipfox/api-workflows-dto';
+import type {AgentConfigIssueDto} from '@shipfox/api-workflows-dto';
 
 const HARNESS_ERROR_PREFIX = 'Pi extension setup failed: ';
-const HARNESS_DIAGNOSTIC_MAX_LENGTH = STEP_ERROR_MESSAGE_MAX_LENGTH - HARNESS_ERROR_PREFIX.length;
-const PATH_PATTERN =
-  /(?<![A-Za-z0-9._~+@%])((?:file:\/\/)?\/(?:[A-Za-z0-9._~+@%=-]+\/)*[A-Za-z0-9._~+@%=-]+)/g;
-const URL_PATTERN = /(?:https?|ssh):\/\//;
+const HARNESS_DIAGNOSTIC_MAX_LENGTH = 200;
+const PATH_PATTERN = /(?:file:\/\/)?\//g;
+const PATH_PREFIX_CHARACTER_PATTERN = /[A-Za-z0-9._~+@%]/;
+const NETWORK_URL_PATTERN = /(?:https?|ssh):\/{0,2}$/;
+const ABSOLUTE_PATH_FIRST_CHARACTER_PATTERN = /[\\/^*?()[\]{}]/;
+const WHITESPACE_PATTERN = /\s/;
+const PATH_EXTENSION_PATTERN = /\.[A-Za-z0-9]+$/;
+const TRAILING_PATH_PUNCTUATION_PATTERN = /[.,;:]+$/;
 const TRUNCATION_TOKEN_PATTERN = /\s[^\s]*$/;
-const WHITESPACE_PATTERN = /(\s+)/;
 
 /**
  * A user-fixable agent-step configuration failure: an unknown provider, a
@@ -71,24 +74,116 @@ function sanitizeHarnessDiagnosticMessage(messages: readonly string[]): string {
 }
 
 function sanitizeDiagnosticMessage(message: string): string {
-  return message
-    .split(WHITESPACE_PATTERN)
-    .map((token) => (URL_PATTERN.test(token) ? token : sanitizeDiagnosticToken(token)))
-    .join('');
+  let cursor = 0;
+  let sanitized = '';
+
+  for (const match of message.matchAll(PATH_PATTERN)) {
+    const matchStart = match.index;
+    if (matchStart < cursor) continue;
+
+    const prefix = match[0].startsWith('file://') ? 'file://' : '';
+    const pathStart = matchStart + prefix.length;
+    const previousCharacter = message[pathStart - 1];
+
+    if (
+      (previousCharacter !== undefined && PATH_PREFIX_CHARACTER_PATTERN.test(previousCharacter)) ||
+      isFileUrlSlash(message, pathStart) ||
+      isNetworkUrlSlash(message, pathStart) ||
+      !isLikelyAbsolutePath(message, pathStart)
+    ) {
+      continue;
+    }
+
+    const pathEnd = findAbsolutePathEnd(message, pathStart);
+    if (pathEnd <= pathStart + 1) continue;
+
+    const path = message.slice(pathStart, pathEnd);
+    sanitized += message.slice(cursor, matchStart);
+    sanitized += `${prefix}${path.slice(path.lastIndexOf('/') + 1)}`;
+    cursor = pathEnd;
+  }
+
+  return sanitized + message.slice(cursor);
+}
+
+function isFileUrlSlash(message: string, pathStart: number): boolean {
+  const precedingText = message.slice(Math.max(0, pathStart - 6), pathStart);
+  return precedingText.endsWith('file:') || precedingText.endsWith('file:/');
+}
+
+function isNetworkUrlSlash(message: string, pathStart: number): boolean {
+  const protocolPrefix = message.slice(Math.max(0, pathStart - 8), pathStart + 1);
+  return NETWORK_URL_PATTERN.test(protocolPrefix);
+}
+
+function isLikelyAbsolutePath(message: string, pathStart: number): boolean {
+  const firstPathCharacter = message[pathStart + 1];
+  return (
+    firstPathCharacter !== undefined &&
+    !ABSOLUTE_PATH_FIRST_CHARACTER_PATTERN.test(firstPathCharacter)
+  );
+}
+
+function findAbsolutePathEnd(message: string, pathStart: number): number {
+  for (let index = pathStart + 1; index < message.length; index += 1) {
+    const character = message[index];
+
+    if (isPathTerminator(character)) return index;
+
+    if ((character === ',' || character === ':') && message[index + 1] === '/') return index;
+
+    if (character !== undefined && WHITESPACE_PATTERN.test(character)) {
+      const nextCharacter = skipWhitespace(message, index);
+      const nextSegmentEnd = findNextPathTerminator(message, nextCharacter);
+      const nextSegment = message.slice(nextCharacter, nextSegmentEnd);
+      const continuesPath =
+        nextSegment.includes('/') ||
+        PATH_EXTENSION_PATTERN.test(nextSegment.replace(TRAILING_PATH_PUNCTUATION_PATTERN, ''));
+
+      if (!continuesPath) return index;
+    }
+  }
+
+  return message.length;
+}
+
+function skipWhitespace(message: string, start: number): number {
+  let index = start;
+  while (index < message.length && WHITESPACE_PATTERN.test(message[index] ?? '')) index += 1;
+  return index;
+}
+
+function findNextPathTerminator(message: string, start: number): number {
+  for (let index = start; index < message.length; index += 1) {
+    if (isPathTerminator(message[index])) return index;
+  }
+  return message.length;
+}
+
+function isPathTerminator(character: string | undefined): boolean {
+  return (
+    character === '\n' ||
+    character === '\r' ||
+    character === '`' ||
+    character === '"' ||
+    character === "'" ||
+    character === '<' ||
+    character === '>' ||
+    character === '|' ||
+    character === '(' ||
+    character === ')' ||
+    character === '[' ||
+    character === ']' ||
+    character === '{' ||
+    character === '}' ||
+    character === ';'
+  );
 }
 
 function sliceWithoutLoneSurrogate(value: string, length: number): string {
   const candidate = value.slice(0, length);
   const lastCodeUnit = candidate.charCodeAt(candidate.length - 1);
   return lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff ? candidate.slice(0, -1) : candidate;
-}
-
-function sanitizeDiagnosticToken(token: string): string {
-  return token.replace(PATH_PATTERN, (_match, path: string) =>
-    path.startsWith('file://')
-      ? `file://${path.slice(path.lastIndexOf('/') + 1)}`
-      : path.slice(path.lastIndexOf('/') + 1),
-  );
 }
 
 export class AgentHarnessUnavailableError extends Error {

--- a/libs/runner/agent/src/core/errors.ts
+++ b/libs/runner/agent/src/core/errors.ts
@@ -10,13 +10,15 @@ const HARNESS_DIAGNOSTIC_MAX_LENGTH = 200;
 const PATH_PATTERN = /(?:file:\/\/)?\//g;
 const PATH_PREFIX_CHARACTER_PATTERN = /[A-Za-z0-9._~+@%]/;
 const NETWORK_URL_PATTERN = /(?:https?|ssh):\/{0,2}$/;
-const REGEX_DIAGNOSTIC_PATTERN = /[\\^$*+?]/;
+const REGEX_DIAGNOSTIC_PATTERN = /[\\^*+?()[\]{}]|\$$/;
 const ENVIRONMENT_PATH_PREFIX_PATTERN = /(?:^|\s)[A-Za-z_][A-Za-z0-9_]*=$/;
+const RUNNER_PATH_PATTERN = /^(?:\/runner|\/private\/runner|.*\/node_modules)\//;
 const WHITESPACE_PATTERN = /\s/;
 const PATH_EXTENSION_PATTERN = /\.[A-Za-z0-9]+$/;
-const PATH_BOUNDARY_PREFIX_PATTERN = /^[)\]}]/;
+const PATH_BOUNDARY_PREFIX_PATTERN = /^[()[\]{}]/;
 const TRAILING_PATH_PUNCTUATION_PATTERN = /[.,;:]+$/;
 const TRUNCATION_TOKEN_PATTERN = /\s[^\s]*$/;
+const ADJACENT_PATH_LOOKAHEAD_MAX_LENGTH = 1024;
 
 /**
  * A user-fixable agent-step configuration failure: an unknown provider, a
@@ -124,7 +126,7 @@ function isNetworkUrlSlash(message: string, pathStart: number): boolean {
 }
 
 function isSlashDelimitedDiagnostic(path: string): boolean {
-  if (!path.endsWith('/')) return false;
+  if (!path.endsWith('/') || RUNNER_PATH_PATTERN.test(path)) return false;
   return path.includes('\\/') || REGEX_DIAGNOSTIC_PATTERN.test(path.slice(1, -1));
 }
 
@@ -133,6 +135,7 @@ function findAbsolutePathEnd(message: string, pathStart: number): number {
     const character = message[index];
 
     if (isPathTerminator(character)) return index;
+    if (isPathClosingBoundary(message, index)) return index;
 
     if (
       (character === ',' || (character === ':' && isEnvironmentPath(message, pathStart))) &&
@@ -143,12 +146,16 @@ function findAbsolutePathEnd(message: string, pathStart: number): number {
     }
 
     if (character !== undefined && WHITESPACE_PATTERN.test(character)) {
+      if (isSlashDelimitedDiagnostic(message.slice(pathStart, index))) return index;
+
       const nextCharacter = skipWhitespace(message, index);
       const nextSegmentEnd = findNextPathTerminator(message, nextCharacter);
       const nextSegment = message.slice(nextCharacter, nextSegmentEnd);
+      const nextSlash = nextSegment.indexOf('/');
+      const nextWhitespace = nextSegment.search(WHITESPACE_PATTERN);
       const continuesPath =
         !PATH_BOUNDARY_PREFIX_PATTERN.test(nextSegment) &&
-        (nextSegment.includes('/') ||
+        ((nextSlash >= 0 && (nextWhitespace < 0 || nextSlash < nextWhitespace)) ||
           PATH_EXTENSION_PATTERN.test(nextSegment.replace(TRAILING_PATH_PUNCTUATION_PATTERN, '')));
 
       if (!continuesPath) return index;
@@ -163,10 +170,30 @@ function isEnvironmentPath(message: string, pathStart: number): boolean {
 }
 
 function isAdjacentPathStart(message: string, pathStart: number): boolean {
-  const pathEnd = findAbsolutePathEnd(message, pathStart);
-  const path = message.slice(pathStart, pathEnd);
+  let index = pathStart + 1;
+  let slashCount = 0;
+
+  while (
+    index < message.length &&
+    index - pathStart <= ADJACENT_PATH_LOOKAHEAD_MAX_LENGTH
+  ) {
+    const character = message[index];
+    if (
+      isPathTerminator(character) ||
+      isPathClosingBoundary(message, index) ||
+      WHITESPACE_PATTERN.test(character ?? '') ||
+      character === ',' ||
+      character === ':'
+    ) {
+      break;
+    }
+    if (character === '/') slashCount += 1;
+    index += 1;
+  }
+
+  const path = message.slice(pathStart, index);
   const lastComponent = basename(path).replace(TRAILING_PATH_PUNCTUATION_PATTERN, '');
-  return path.slice(1).includes('/') || PATH_EXTENSION_PATTERN.test(lastComponent);
+  return slashCount > 0 || PATH_EXTENSION_PATTERN.test(lastComponent);
 }
 
 function skipWhitespace(message: string, start: number): number {
@@ -177,9 +204,17 @@ function skipWhitespace(message: string, start: number): number {
 
 function findNextPathTerminator(message: string, start: number): number {
   for (let index = start; index < message.length; index += 1) {
-    if (isPathTerminator(message[index])) return index;
+    if (isPathTerminator(message[index]) || isPathClosingBoundary(message, index)) return index;
   }
   return message.length;
+}
+
+function isPathClosingBoundary(message: string, index: number): boolean {
+  const character = message[index];
+  return (
+    (character === ')' || character === ']' || character === '}') &&
+    message[index + 1] !== '/'
+  );
 }
 
 function isPathTerminator(character: string | undefined): boolean {

--- a/libs/runner/agent/src/core/pi-adapter.test.ts
+++ b/libs/runner/agent/src/core/pi-adapter.test.ts
@@ -436,7 +436,7 @@ describe('piHarnessAdapter', () => {
       type: 'error' as const,
       message:
         'Pattern /foo\\/bar/; directory /runner/extensions/; ' +
-        'path /runner/a:/secret; bracketed /[tenant]/secret',
+        'cache /runner/$cache/; path /runner/a:/secret; bracketed /[tenant]/secret',
     };
     createAgentSessionServicesMock.mockResolvedValue({
       ...piServices('/work', [diagnostic]),
@@ -446,8 +446,44 @@ describe('piHarnessAdapter', () => {
 
     expect(error.message).toBe(
       'Pi extension setup failed: Pattern /foo\\/bar/; directory extensions; ' +
-        'path secret; bracketed secret',
+        'cache $cache; path secret; bracketed secret',
     );
+  });
+
+  it('preserves regex delimiters and diagnostic text between paths', async () => {
+    const diagnostic = {
+      type: 'error' as const,
+      message:
+        'Pattern /(foo)/ and path /private/work/secret.txt; ' +
+        'context /a (see /private/work/secret.txt)',
+    };
+    createAgentSessionServicesMock.mockResolvedValue({
+      ...piServices('/work', [diagnostic]),
+    });
+
+    const error = await piHarnessAdapter.run(invocation()).catch((caught) => caught);
+
+    expect(error.message).toBe(
+      'Pi extension setup failed: Pattern /(foo)/ and path secret.txt; ' +
+        'context a (see secret.txt)',
+    );
+  });
+
+  it('handles a large comma-separated path diagnostic without recursion', async () => {
+    const diagnostic = {
+      type: 'error' as const,
+      message: Array.from(
+        {length: 2000},
+        (_, index) => `/runner/extensions/extension-${index}/index.ts`,
+      ).join(','),
+    };
+    createAgentSessionServicesMock.mockResolvedValue({
+      ...piServices('/work', [diagnostic]),
+    });
+
+    const error = await piHarnessAdapter.run(invocation()).catch((caught) => caught);
+
+    expect(error.message).toContain('…');
   });
 
   it('uses a generic message when all harness diagnostics are empty', async () => {

--- a/libs/runner/agent/src/core/pi-adapter.test.ts
+++ b/libs/runner/agent/src/core/pi-adapter.test.ts
@@ -431,6 +431,25 @@ describe('piHarnessAdapter', () => {
     );
   });
 
+  it('preserves slash syntax and sanitizes unusual absolute path shapes', async () => {
+    const diagnostic = {
+      type: 'error' as const,
+      message:
+        'Pattern /foo\\/bar/; directory /runner/extensions/; ' +
+        'path /runner/a:/secret; bracketed /[tenant]/secret',
+    };
+    createAgentSessionServicesMock.mockResolvedValue({
+      ...piServices('/work', [diagnostic]),
+    });
+
+    const error = await piHarnessAdapter.run(invocation()).catch((caught) => caught);
+
+    expect(error.message).toBe(
+      'Pi extension setup failed: Pattern /foo\\/bar/; directory extensions; ' +
+        'path secret; bracketed secret',
+    );
+  });
+
   it('uses a generic message when all harness diagnostics are empty', async () => {
     createAgentSessionServicesMock.mockResolvedValue({
       ...piServices('/work', [

--- a/libs/runner/agent/src/core/pi-adapter.test.ts
+++ b/libs/runner/agent/src/core/pi-adapter.test.ts
@@ -1,7 +1,3 @@
-const piExtensionTestState = vi.hoisted(() => ({
-  resolver: undefined as ((specifier: string) => string) | undefined,
-}));
-
 const {
   createAgentSessionMock,
   createAgentSessionServicesMock,
@@ -17,6 +13,8 @@ const {
   getLastAssistantTextMock,
   disposeMock,
   extensionShutdownMock,
+  piExtensionDirectoriesMock,
+  isPiExtensionAvailableMock,
 } = vi.hoisted(() => ({
   createAgentSessionMock: vi.fn(),
   createAgentSessionServicesMock: vi.fn(),
@@ -32,6 +30,10 @@ const {
   disposeMock: vi.fn(),
   extensionShutdownMock: vi.fn(),
   modelRuntimeCreateMock: vi.fn(),
+  piExtensionDirectoriesMock: vi.fn(({packageNames}: {packageNames: readonly string[]}) =>
+    packageNames.map((packageName) => `/runner/node_modules/${packageName}`),
+  ),
+  isPiExtensionAvailableMock: vi.fn(),
 }));
 const {assertEgressAllowedMock, EgressDeniedErrorMock} = vi.hoisted(() => {
   class EgressDeniedError extends Error {
@@ -46,10 +48,6 @@ const {assertEgressAllowedMock, EgressDeniedErrorMock} = vi.hoisted(() => {
 
   return {assertEgressAllowedMock: vi.fn(), EgressDeniedErrorMock: EgressDeniedError};
 });
-
-const {isPiExtensionAvailableMock} = vi.hoisted(() => ({
-  isPiExtensionAvailableMock: vi.fn(),
-}));
 
 vi.mock('@earendil-works/pi-coding-agent', () => ({
   createAgentSessionFromServices: createAgentSessionMock,
@@ -71,29 +69,15 @@ vi.mock('@shipfox/node-egress-guard', () => ({
       .filter(Boolean),
 }));
 
-vi.mock('#core/pi-extensions.js', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('#core/pi-extensions.js')>();
-  return {
-    ...actual,
-    isPiExtensionAvailable: isPiExtensionAvailableMock,
-    piExtensionDirectories: (params: Parameters<typeof actual.piExtensionDirectories>[0]) =>
-      piExtensionTestState.resolver === undefined
-        ? actual.piExtensionDirectories(params)
-        : actual.piExtensionDirectories({...params, resolve: piExtensionTestState.resolver}),
-  };
-});
+vi.mock('#core/pi-extensions.js', async () => ({
+  ...(await vi.importActual<typeof import('#core/pi-extensions.js')>('#core/pi-extensions.js')),
+  piExtensionDirectories: piExtensionDirectoriesMock,
+  isPiExtensionAvailable: isPiExtensionAvailableMock,
+}));
 
-import {
-  appendFileSync,
-  existsSync,
-  mkdtempSync,
-  readdirSync,
-  readFileSync,
-  rmSync,
-  statSync,
-} from 'node:fs';
+import {appendFileSync, existsSync, mkdtempSync, readdirSync, readFileSync, rmSync} from 'node:fs';
 import {tmpdir} from 'node:os';
-import {basename, isAbsolute, join} from 'node:path';
+import {join} from 'node:path';
 import {
   type CustomModelProviderRuntimeConfigDto,
   DEFAULT_CUSTOM_MODEL_CONTEXT_WINDOW,
@@ -101,53 +85,31 @@ import {
   DEFAULT_CUSTOM_MODEL_MAX_OUTPUT_TOKENS,
   DEFAULT_CUSTOM_MODEL_REASONING,
 } from '@shipfox/api-agent-dto';
+import {STEP_ERROR_MESSAGE_MAX_LENGTH} from '@shipfox/api-workflows-dto';
 import {AgentConfigError, AgentHarnessUnavailableError} from '#core/errors.js';
 import type {HarnessInvocation} from '#core/harness.js';
 import type {IntegrationToolsBridge} from '#core/integration-tools-bridge.js';
 import {piHarnessAdapter} from '#core/pi-adapter.js';
 import {piExtensionDirectories} from '#core/pi-extensions.js';
 
-function extensionDirectory(packageName: string): string {
-  const [directory] = piExtensionDirectories({packageNames: [packageName]});
-  if (directory === undefined) throw new Error(`Missing resolved directory for ${packageName}`);
-  return directory;
-}
+const piWebAccessDirectory = piExtensionDirectories({packageNames: ['pi-web-access']})[0];
+const piMcpAdapterDirectory = piExtensionDirectories({packageNames: ['pi-mcp-adapter']})[0];
+const TRUNCATED_ATTEMPT_PATTERN = /attempt-\d{3}…$/;
+const LONE_HIGH_SURROGATE_PATTERN = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/;
 
-const piWebAccessDirectory = extensionDirectory('pi-web-access');
-const piMcpAdapterDirectory = extensionDirectory('pi-mcp-adapter');
-
-function piServices(
-  cwd = '/work',
-  diagnostics: Array<{type: string; message: string}> = [],
-  loadedDirectories: readonly string[] = [piWebAccessDirectory, piMcpAdapterDirectory],
-  extensionErrors: Array<{path: string; error: string}> = [],
-) {
+function piServices(cwd = '/work', diagnostics: Array<{type: string; message: string}> = []) {
   return {
     cwd,
     diagnostics,
     resourceLoader: {
       getExtensions: () => ({
-        extensions: loadedDirectories.map((directory) => ({resolvedPath: `${directory}/index.ts`})),
-        errors: extensionErrors,
+        extensions: [piWebAccessDirectory, piMcpAdapterDirectory].map((directory) => ({
+          resolvedPath: `${directory}/index.ts`,
+        })),
+        errors: [],
       }),
     },
   };
-}
-
-function expectResolvedExtensionPaths(
-  paths: readonly string[] | undefined,
-  expectedNames: readonly string[],
-  workspace: string,
-): void {
-  expect(paths).toBeDefined();
-  if (paths === undefined) return;
-
-  expect(paths.map((path) => basename(path))).toEqual(expectedNames);
-  for (const path of paths) {
-    expect(isAbsolute(path)).toBe(true);
-    expect(statSync(path).isDirectory()).toBe(true);
-    expect(path.startsWith(workspace)).toBe(false);
-  }
 }
 
 function invocation(overrides: Partial<HarnessInvocation> = {}): HarnessInvocation {
@@ -215,11 +177,15 @@ describe('piHarnessAdapter', () => {
     getLastAssistantTextMock.mockReset();
     disposeMock.mockReset();
     extensionShutdownMock.mockReset();
+    piExtensionDirectoriesMock.mockReset();
+    piExtensionDirectoriesMock.mockImplementation(
+      ({packageNames}: {packageNames: readonly string[]}) =>
+        packageNames.map((packageName) => `/runner/node_modules/${packageName}`),
+    );
+    isPiExtensionAvailableMock.mockReturnValue(true);
     modelRuntimeCreateMock.mockReset();
-    piExtensionTestState.resolver = undefined;
     assertEgressAllowedMock.mockReset();
     assertEgressAllowedMock.mockResolvedValue(undefined);
-    isPiExtensionAvailableMock.mockReturnValue(true);
     findMock.mockReturnValue({provider: 'anthropic', id: 'claude-opus-4-8'});
     getAllMock.mockReturnValue([{provider: 'anthropic', id: 'claude-opus-4-8'}]);
     hasConfiguredAuthMock.mockReturnValue(true);
@@ -259,11 +225,11 @@ describe('piHarnessAdapter', () => {
     const result = await piHarnessAdapter.run(invocation({provider: 'openai', model: 'gpt-5.1'}));
 
     expect(findMock).toHaveBeenCalledWith('openai', 'gpt-5.1');
-    expectResolvedExtensionPaths(
-      createAgentSessionServicesMock.mock.calls[0]?.[0].resourceLoaderOptions
-        .additionalExtensionPaths,
-      ['pi-web-access'],
-      '/work',
+    expect(createAgentSessionServicesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cwd: '/work',
+        resourceLoaderOptions: {additionalExtensionPaths: [piWebAccessDirectory]},
+      }),
     );
     expect(createAgentSessionMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -279,19 +245,16 @@ describe('piHarnessAdapter', () => {
   it('loads pi-web-access through the Pi resource loader without output tools by default', async () => {
     await piHarnessAdapter.run(invocation());
 
-    expectResolvedExtensionPaths(
-      createAgentSessionServicesMock.mock.calls[0]?.[0].resourceLoaderOptions
-        .additionalExtensionPaths,
-      ['pi-web-access'],
-      '/work',
+    expect(createAgentSessionServicesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceLoaderOptions: {additionalExtensionPaths: [piWebAccessDirectory]},
+      }),
     );
     expect(createAgentSessionMock.mock.calls[0]?.[0]).not.toHaveProperty('customTools');
   });
 
   it('keeps Pi built-ins available when pi-web-access is unavailable', async () => {
-    isPiExtensionAvailableMock.mockImplementation(
-      ({packageName}: {packageName: string}) => packageName !== 'pi-web-access',
-    );
+    isPiExtensionAvailableMock.mockReturnValue(false);
 
     await piHarnessAdapter.run(invocation());
 
@@ -328,11 +291,12 @@ describe('piHarnessAdapter', () => {
         },
       },
     });
-    expectResolvedExtensionPaths(
-      createAgentSessionServicesMock.mock.calls[0]?.[0].resourceLoaderOptions
-        .additionalExtensionPaths,
-      ['pi-web-access', 'pi-mcp-adapter'],
-      sessionDir,
+    expect(createAgentSessionServicesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceLoaderOptions: {
+          additionalExtensionPaths: [piWebAccessDirectory, piMcpAdapterDirectory],
+        },
+      }),
     );
     expect(extensionShutdownMock).toHaveBeenCalledWith({type: 'session_shutdown', reason: 'quit'});
     expect(disposeMock).toHaveBeenCalledAfter(extensionShutdownMock);
@@ -369,12 +333,6 @@ describe('piHarnessAdapter', () => {
   it('fails before creating a Pi session when extension setup reports an error', async () => {
     createAgentSessionServicesMock.mockResolvedValue({
       ...piServices('/work', [{type: 'error', message: 'Unknown option: --mcp-config'}]),
-      resourceLoader: {
-        getExtensions: () => ({
-          extensions: [{resolvedPath: `${piWebAccessDirectory}/index.ts`}],
-          errors: [],
-        }),
-      },
     });
 
     const error = await piHarnessAdapter.run(invocation()).catch((caught) => caught);
@@ -388,10 +346,132 @@ describe('piHarnessAdapter', () => {
         model: 'claude-opus-4-8',
         thinking: 'high',
         extensionPaths: ['pi-web-access'],
-        resolvedExtensionPaths: [`${piWebAccessDirectory}/index.ts`],
       },
     });
     expect(createAgentSessionMock).not.toHaveBeenCalled();
+  });
+
+  it('sanitizes diagnostic paths while preserving raw diagnostics', async () => {
+    const diagnostic = {
+      type: 'error' as const,
+      message:
+        'Extension setup failed at file:///private/runner/workspaces/job-123/pi-mcp-adapter/dist/index.js; ' +
+        'while loading `/private/runner/workspaces/job-123/pi-mcp-adapter`; ' +
+        'paths: /a/b/c,/d/e/f; ' +
+        'specifiers: pi-mcp-adapter/dist/index.js ./lib/helper.js node_modules/pi-web-access/dist/index.ts; ' +
+        'delimiters: </private/runner/a.ts> -/private/runner/b.ts >' +
+        '/private/runner/c.ts |/private/runner/d.ts )/private/runner/e.ts ' +
+        ']/private/runner/f.ts }/private/runner/g.ts; ' +
+        'Expected /^v\\d+$/ ...',
+    };
+    createAgentSessionServicesMock.mockResolvedValue({
+      ...piServices('/work', [diagnostic]),
+    });
+
+    const error = await piHarnessAdapter.run(invocation()).catch((caught) => caught);
+
+    expect(error).toMatchObject({
+      message:
+        'Pi extension setup failed: Extension setup failed at file://index.js; while loading `pi-mcp-adapter`; ' +
+        'paths: c,f; specifiers: pi-mcp-adapter/dist/index.js ./lib/helper.js ' +
+        'node_modules/pi-web-access/dist/index.ts; delimiters: <a.ts> -b.ts >c.ts |d.ts ' +
+        ')e.ts ]f.ts }g.ts; Expected /^v\\d+$/ ...',
+      diagnostics: [diagnostic],
+    });
+  });
+
+  it('uses a generic message when all harness diagnostics are empty', async () => {
+    createAgentSessionServicesMock.mockResolvedValue({
+      ...piServices('/work', [
+        {type: 'error', message: ''},
+        {type: 'error', message: ''},
+      ]),
+    });
+
+    const error = await piHarnessAdapter.run(invocation()).catch((caught) => caught);
+
+    expect(error).toBeInstanceOf(AgentHarnessUnavailableError);
+    expect(error.message).toBe('Pi extension setup failed: The runner harness could not start.');
+    expect(createAgentSessionMock).not.toHaveBeenCalled();
+  });
+
+  it('truncates harness diagnostics at a token boundary with an explicit marker', async () => {
+    const diagnostic = {
+      type: 'error' as const,
+      message: Array.from(
+        {length: 240},
+        (_, index) => `attempt-${String(index).padStart(3, '0')}`,
+      ).join(' '),
+    };
+    createAgentSessionServicesMock.mockResolvedValue({
+      ...piServices('/work', [diagnostic]),
+    });
+
+    const error = await piHarnessAdapter.run(invocation()).catch((caught) => caught);
+    const detail = error.message.replace('Pi extension setup failed: ', '');
+
+    expect(error.message.length).toBeLessThanOrEqual(STEP_ERROR_MESSAGE_MAX_LENGTH);
+    expect(detail).toMatch(TRUNCATED_ATTEMPT_PATTERN);
+  });
+
+  it('keeps a large final token and avoids lone surrogates when truncating', async () => {
+    const longDiagnostic = {
+      type: 'error' as const,
+      message: `prefix ${'x'.repeat(2500)}`,
+    };
+    createAgentSessionServicesMock.mockResolvedValue({
+      ...piServices('/work', [longDiagnostic]),
+    });
+
+    const longError = await piHarnessAdapter.run(invocation()).catch((caught) => caught);
+    const longDetail = longError.message.replace('Pi extension setup failed: ', '');
+
+    expect(longDetail.length).toBeGreaterThan(2000);
+    expect(longError.message.length).toBeLessThanOrEqual(STEP_ERROR_MESSAGE_MAX_LENGTH);
+
+    const surrogateDiagnostic = {
+      type: 'error' as const,
+      message: `prefix ${'A'.repeat(2012)}😀x`,
+    };
+    createAgentSessionServicesMock.mockResolvedValue({
+      ...piServices('/work', [surrogateDiagnostic]),
+    });
+
+    const surrogateError = await piHarnessAdapter.run(invocation()).catch((caught) => caught);
+
+    expect(surrogateError.message).toContain('…');
+    expect(surrogateError.message).not.toMatch(LONE_HIGH_SURROGATE_PATTERN);
+  });
+
+  it('classifies Pi extension package-resolution failures as harness unavailable', async () => {
+    piExtensionDirectoriesMock.mockImplementationOnce(() => {
+      throw new Error(
+        'Unable to resolve Pi extension package "pi-web-access": Cannot find module ' +
+          '/runner/node_modules/pi-web-access/package.json',
+      );
+    });
+
+    const error = await piHarnessAdapter.run(invocation()).catch((caught) => caught);
+
+    expect(error).toBeInstanceOf(AgentHarnessUnavailableError);
+    expect(error.message).toBe(
+      'Pi extension setup failed: Unable to resolve Pi extension package "pi-web-access": ' +
+        'Cannot find module package.json',
+    );
+    expect(createAgentSessionServicesMock).not.toHaveBeenCalled();
+  });
+
+  it('cleans the MCP temp directory when extension resolution fails', async () => {
+    sessionDir = mkdtempSync(join(tmpdir(), 'shipfox-pi-mcp-'));
+    piExtensionDirectoriesMock.mockImplementationOnce(() => {
+      throw new Error('Cannot find package entry');
+    });
+
+    await expect(
+      piHarnessAdapter.run(invocation({cwd: sessionDir, mcpServers: [mcpBridge()]})),
+    ).rejects.toBeInstanceOf(AgentHarnessUnavailableError);
+
+    expect(readdirSync(join(sessionDir, 'logs'))).toEqual([]);
   });
 
   it('reports the Pi extension path error before the diagnostic symptom', async () => {
@@ -407,65 +487,166 @@ describe('piHarnessAdapter', () => {
     });
 
     const error = await piHarnessAdapter.run(invocation()).catch((caught) => caught);
+
     expect(error).toBeInstanceOf(AgentHarnessUnavailableError);
     expect(error).toMatchObject({
-      message: `Pi extension setup failed: Unknown option: --mcp-config; ${piPathError.error}`,
-      resourceLoaderErrors: [piPathError],
+      diagnostics: [{type: 'error', message: 'Unknown option: --mcp-config'}],
+      missingExtensionDirectories: [piWebAccessDirectory],
+      resourceLoaderErrors: [{error: piPathError, directory: piWebAccessDirectory}],
     });
-    expect(createAgentSessionMock).not.toHaveBeenCalled();
-  });
-
-  it('fails when Pi silently loads no requested extension', async () => {
-    createAgentSessionServicesMock.mockResolvedValue(piServices('/work', [], []));
-
-    await expect(piHarnessAdapter.run(invocation())).rejects.toThrow(piWebAccessDirectory);
-    expect(createAgentSessionMock).not.toHaveBeenCalled();
-  });
-
-  it('includes Pi extension errors in the setup failure', async () => {
-    const piPathError = {
-      path: piWebAccessDirectory,
-      error: `Extension path does not exist: ${piWebAccessDirectory}`,
-    };
-    createAgentSessionServicesMock.mockResolvedValue(piServices('/work', [], [], [piPathError]));
-
-    await expect(piHarnessAdapter.run(invocation())).rejects.toThrow(piPathError.error);
-    expect(createAgentSessionMock).not.toHaveBeenCalled();
-  });
-
-  it('names only the Pi extension directory that was not loaded', async () => {
-    sessionDir = mkdtempSync(join(tmpdir(), 'shipfox-pi-mcp-'));
-    createAgentSessionServicesMock.mockResolvedValue(
-      piServices('/work', [], [piWebAccessDirectory]),
+    expect(error.message).toBe(
+      'Pi extension setup failed: Extension path does not exist: pi-web-access; ' +
+        'Unknown option: --mcp-config',
     );
-
-    const error = await piHarnessAdapter
-      .run(invocation({cwd: sessionDir, mcpServers: [mcpBridge()]}))
-      .catch((caught) => caught);
-
-    expect(error.message).toContain(piMcpAdapterDirectory);
+    expect(error.message).not.toContain('pi-web-access: Extension path');
     expect(error.message).not.toContain(piWebAccessDirectory);
     expect(createAgentSessionMock).not.toHaveBeenCalled();
   });
 
-  it('wraps resolver failures as harness-unavailable and cleans the MCP temp directory', async () => {
-    sessionDir = mkdtempSync(join(tmpdir(), 'shipfox-pi-mcp-'));
-    const resolverError = new Error('Cannot find package entry');
-    piExtensionTestState.resolver = () => {
-      throw resolverError;
+  it('reports missing runner extension directories when Pi has no loader error', async () => {
+    createAgentSessionServicesMock.mockResolvedValue({
+      ...piServices(),
+      resourceLoader: {
+        getExtensions: () => ({
+          extensions: [{resolvedPath: `${piMcpAdapterDirectory}/index.ts`}],
+          errors: [],
+        }),
+      },
+    });
+
+    const error = await piHarnessAdapter.run(invocation()).catch((caught) => caught);
+
+    expect(error.message).toBe(
+      'Pi extension setup failed: Pi extensions failed to load from: pi-web-access',
+    );
+  });
+
+  it('keeps missing directories alongside load errors for another runner extension', async () => {
+    sessionDir = mkdtempSync(join(tmpdir(), 'shipfox-pi-mixed-'));
+    const piMcpLoadError = {
+      path: `${piMcpAdapterDirectory}/index.ts`,
+      error: "Unexpected token '}'",
     };
+    createAgentSessionServicesMock.mockResolvedValue({
+      ...piServices(),
+      resourceLoader: {
+        getExtensions: () => ({
+          extensions: [{resolvedPath: `${piMcpAdapterDirectory}/index.ts`}],
+          errors: [piMcpLoadError],
+        }),
+      },
+    });
 
     const error = await piHarnessAdapter
       .run(invocation({cwd: sessionDir, mcpServers: [mcpBridge()]}))
       .catch((caught) => caught);
 
-    expect(error).toBeInstanceOf(AgentHarnessUnavailableError);
-    expect(error).toMatchObject({
-      message: expect.stringContaining('pi-web-access'),
-      environment: {extensionPaths: ['pi-web-access', 'pi-mcp-adapter']},
+    expect(error.message).toBe(
+      'Pi extension setup failed: Pi extensions failed to load from: pi-web-access; ' +
+        "pi-mcp-adapter: Unexpected token '}'",
+    );
+  });
+
+  it('deduplicates loader messages after sanitizing their paths', async () => {
+    const errorMessage = 'Extension does not export a valid factory function';
+    createAgentSessionServicesMock.mockResolvedValue({
+      ...piServices(),
+      resourceLoader: {
+        getExtensions: () => ({
+          extensions: [],
+          errors: [
+            {
+              path: `${piWebAccessDirectory}/index.ts`,
+              error: `${errorMessage}: /runner/one/pi-web-access`,
+            },
+            {
+              path: `${piWebAccessDirectory}/index.ts`,
+              error: `${errorMessage}: /runner/two/pi-web-access`,
+            },
+          ],
+        }),
+      },
     });
-    expect(createAgentSessionServicesMock).not.toHaveBeenCalled();
-    expect(readdirSync(join(sessionDir, 'logs'))).toEqual([]);
+
+    const error = await piHarnessAdapter.run(invocation()).catch((caught) => caught);
+
+    expect(error.message).toBe(`Pi extension setup failed: ${errorMessage}: pi-web-access`);
+  });
+
+  it('sanitizes loader file URLs exactly once', async () => {
+    createAgentSessionServicesMock.mockResolvedValue({
+      ...piServices(),
+      resourceLoader: {
+        getExtensions: () => ({
+          extensions: [],
+          errors: [
+            {
+              path: `${piWebAccessDirectory}/index.ts`,
+              error:
+                'Cannot find package imported from file:///runner/node_modules/pi-web-access/dist/index.js',
+            },
+          ],
+        }),
+      },
+    });
+
+    const error = await piHarnessAdapter.run(invocation()).catch((caught) => caught);
+
+    expect(error.message).toBe(
+      'Pi extension setup failed: pi-web-access: ' +
+        'Cannot find package imported from file://index.js',
+    );
+  });
+
+  it('bounds direct Pi extension package-resolution errors before they reach the step layer', async () => {
+    const {piExtensionDirectories: resolveDirectories} =
+      await vi.importActual<typeof import('#core/pi-extensions.js')>('#core/pi-extensions.js');
+
+    expect(() =>
+      resolveDirectories({
+        packageNames: ['missing-runner-extension'],
+        resolve: () => {
+          throw new Error(
+            'Cannot find module /runner/node_modules/missing-runner-extension/package.json\n' +
+              '    at resolve (internal/modules/cjs/loader.js:1:1)',
+          );
+        },
+      }),
+    ).toThrow(
+      'Unable to resolve Pi extension package "missing-runner-extension": Cannot find module /runner/node_modules/missing-runner-extension/package.json',
+    );
+  });
+
+  it('ignores extension load errors outside the runner harness directories', async () => {
+    const workspaceExtensionError = {
+      path: '/work/.pi/extensions/repo-extension.ts',
+      error: 'Failed to load workspace extension',
+    };
+    createAgentSessionServicesMock.mockResolvedValue({
+      ...piServices(),
+      resourceLoader: {
+        getExtensions: () => ({
+          extensions: [{resolvedPath: `${piWebAccessDirectory}/index.ts`}],
+          errors: [workspaceExtensionError],
+        }),
+      },
+    });
+
+    await expect(piHarnessAdapter.run(invocation())).resolves.toEqual({response: ''});
+    expect(createAgentSessionMock).toHaveBeenCalled();
+  });
+
+  it('ignores diagnostics from extensions outside the runner harness directories', async () => {
+    const workspaceDiagnostic = {
+      type: 'error' as const,
+      message: 'Extension "/work/.pi/extensions/repo-extension.ts" error: provider is invalid',
+    };
+    createAgentSessionServicesMock.mockResolvedValue({
+      ...piServices('/work', [workspaceDiagnostic]),
+    });
+
+    await expect(piHarnessAdapter.run(invocation())).resolves.toEqual({response: ''});
+    expect(createAgentSessionMock).toHaveBeenCalled();
   });
 
   it('registers the output tool for steps with declared outputs', async () => {

--- a/libs/runner/agent/src/core/pi-adapter.test.ts
+++ b/libs/runner/agent/src/core/pi-adapter.test.ts
@@ -94,6 +94,7 @@ import {piExtensionDirectories} from '#core/pi-extensions.js';
 
 const piWebAccessDirectory = piExtensionDirectories({packageNames: ['pi-web-access']})[0];
 const piMcpAdapterDirectory = piExtensionDirectories({packageNames: ['pi-mcp-adapter']})[0];
+const HARNESS_DIAGNOSTIC_MAX_LENGTH = 200;
 const TRUNCATED_ATTEMPT_PATTERN = /attempt-\d{3}…$/;
 const LONE_HIGH_SURROGATE_PATTERN = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/;
 
@@ -351,6 +352,26 @@ describe('piHarnessAdapter', () => {
     expect(createAgentSessionMock).not.toHaveBeenCalled();
   });
 
+  it('classifies Pi service creation failures as harness unavailable', async () => {
+    createAgentSessionServicesMock.mockRejectedValue(new Error('Unable to create Pi services'));
+
+    const error = await piHarnessAdapter.run(invocation()).catch((caught) => caught);
+
+    expect(error).toBeInstanceOf(AgentHarnessUnavailableError);
+    expect(error).toMatchObject({
+      message: 'Pi extension setup failed: Unable to create Pi services',
+      diagnostics: [{type: 'error', message: 'Unable to create Pi services'}],
+      environment: {
+        cwd: '/work',
+        provider: 'anthropic',
+        model: 'claude-opus-4-8',
+        thinking: 'high',
+        extensionPaths: ['pi-web-access'],
+      },
+    });
+    expect(createAgentSessionMock).not.toHaveBeenCalled();
+  });
+
   it('sanitizes diagnostic paths while preserving raw diagnostics', async () => {
     const diagnostic = {
       type: 'error' as const,
@@ -374,10 +395,40 @@ describe('piHarnessAdapter', () => {
       message:
         'Pi extension setup failed: Extension setup failed at file://index.js; while loading `pi-mcp-adapter`; ' +
         'paths: c,f; specifiers: pi-mcp-adapter/dist/index.js ./lib/helper.js ' +
-        'node_modules/pi-web-access/dist/index.ts; delimiters: <a.ts> -b.ts >c.ts |d.ts ' +
-        ')e.ts ]f.ts }g.ts; Expected /^v\\d+$/ ...',
+        'node_modules/pi-web-access/dist/index.ts; delimiters:…',
       diagnostics: [diagnostic],
     });
+  });
+
+  it('sanitizes complete diagnostic paths with spaces and POSIX punctuation', async () => {
+    const diagnostic = {
+      type: 'error' as const,
+      message:
+        'paths: /runner/cache,dir/$package name/index file.js; ' +
+        'url: https://example.com/a/b; regex: /^v\\d+$/; adjacent: /a/b/c,/d/e/f',
+    };
+    createAgentSessionServicesMock.mockResolvedValue({
+      ...piServices('/work', [diagnostic]),
+    });
+
+    const error = await piHarnessAdapter.run(invocation()).catch((caught) => caught);
+
+    expect(error.message).toBe(
+      'Pi extension setup failed: paths: index file.js; url: https://example.com/a/b; ' +
+        'regex: /^v\\d+$/; adjacent: c,f',
+    );
+
+    createAgentSessionServicesMock.mockResolvedValue({
+      ...piServices('/work', [{type: 'error', message: 'already sanitized file://index.js'}]),
+    });
+
+    const alreadySanitizedError = await piHarnessAdapter
+      .run(invocation())
+      .catch((caught) => caught);
+
+    expect(alreadySanitizedError.message).toBe(
+      'Pi extension setup failed: already sanitized file://index.js',
+    );
   });
 
   it('uses a generic message when all harness diagnostics are empty', async () => {
@@ -410,6 +461,7 @@ describe('piHarnessAdapter', () => {
     const error = await piHarnessAdapter.run(invocation()).catch((caught) => caught);
     const detail = error.message.replace('Pi extension setup failed: ', '');
 
+    expect(detail.length).toBeLessThanOrEqual(HARNESS_DIAGNOSTIC_MAX_LENGTH);
     expect(error.message.length).toBeLessThanOrEqual(STEP_ERROR_MESSAGE_MAX_LENGTH);
     expect(detail).toMatch(TRUNCATED_ATTEMPT_PATTERN);
   });
@@ -426,12 +478,13 @@ describe('piHarnessAdapter', () => {
     const longError = await piHarnessAdapter.run(invocation()).catch((caught) => caught);
     const longDetail = longError.message.replace('Pi extension setup failed: ', '');
 
-    expect(longDetail.length).toBeGreaterThan(2000);
+    expect(longDetail.length).toBeGreaterThan(190);
+    expect(longDetail.length).toBeLessThanOrEqual(HARNESS_DIAGNOSTIC_MAX_LENGTH);
     expect(longError.message.length).toBeLessThanOrEqual(STEP_ERROR_MESSAGE_MAX_LENGTH);
 
     const surrogateDiagnostic = {
       type: 'error' as const,
-      message: `prefix ${'A'.repeat(2012)}😀x`,
+      message: `prefix ${'A'.repeat(191)}😀x`,
     };
     createAgentSessionServicesMock.mockResolvedValue({
       ...piServices('/work', [surrogateDiagnostic]),

--- a/libs/runner/agent/src/core/pi-adapter.ts
+++ b/libs/runner/agent/src/core/pi-adapter.ts
@@ -133,16 +133,29 @@ async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult>
         environment: {cwd, provider, model: modelId, thinking, extensionPaths},
       });
     }
-    const services = await createAgentSessionServices({
-      cwd,
-      modelRuntime,
-      ...(mcpConfig === undefined
-        ? {}
-        : {extensionFlagValues: new Map([['mcp-config', mcpConfig.path]])}),
-      resourceLoaderOptions: {
-        additionalExtensionPaths: extensionDirectories,
-      },
-    });
+    let services: Awaited<ReturnType<typeof createAgentSessionServices>>;
+    try {
+      services = await createAgentSessionServices({
+        cwd,
+        modelRuntime,
+        ...(mcpConfig === undefined
+          ? {}
+          : {extensionFlagValues: new Map([['mcp-config', mcpConfig.path]])}),
+        resourceLoaderOptions: {
+          additionalExtensionPaths: extensionDirectories,
+        },
+      });
+    } catch (error) {
+      throw new AgentHarnessUnavailableError({
+        diagnostics: [
+          {
+            type: 'error',
+            message: error instanceof Error ? error.message : String(error),
+          },
+        ],
+        environment: {cwd, provider, model: modelId, thinking, extensionPaths},
+      });
+    }
     const extensionResult = services.resourceLoader?.getExtensions?.();
     const extensionFailure = piExtensionFailure({
       resourceLoader: services.resourceLoader,

--- a/libs/runner/agent/src/core/pi-adapter.ts
+++ b/libs/runner/agent/src/core/pi-adapter.ts
@@ -38,9 +38,10 @@ import {
   withOutputGuidance,
 } from '#core/output-collector.js';
 import {
-  assertPiExtensionsLoaded,
   isPiExtensionAvailable,
+  type PiExtensionFailure,
   piExtensionDirectories,
+  piExtensionFailure,
 } from '#core/pi-extensions.js';
 import {type SessionForwarder, startSessionForwarder} from '#core/session-forwarder.js';
 
@@ -114,24 +115,22 @@ async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult>
 
   try {
     mcpConfig = await createPiMcpConfig(cwd, mcpServers);
-    const extensionPackageNames = [
+    const extensionPaths = [
       ...(isPiExtensionAvailable({packageName: 'pi-web-access'}) ? ['pi-web-access'] : []),
       ...(mcpConfig === undefined ? [] : ['pi-mcp-adapter']),
     ];
     let extensionDirectories: string[];
     try {
-      extensionDirectories = piExtensionDirectories({packageNames: extensionPackageNames});
+      extensionDirectories = piExtensionDirectories({packageNames: extensionPaths});
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
       throw new AgentHarnessUnavailableError({
-        diagnostics: [{type: 'error', message}],
-        environment: {
-          cwd,
-          provider,
-          model: modelId,
-          thinking,
-          extensionPaths: extensionPackageNames,
-        },
+        diagnostics: [
+          {
+            type: 'error',
+            message: error instanceof Error ? error.message : String(error),
+          },
+        ],
+        environment: {cwd, provider, model: modelId, thinking, extensionPaths},
       });
     }
     const services = await createAgentSessionServices({
@@ -145,27 +144,36 @@ async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult>
       },
     });
     const extensionResult = services.resourceLoader?.getExtensions?.();
-    assertPiServiceDiagnostics(
-      services.diagnostics,
-      {
-        cwd,
-        provider,
-        model: modelId,
-        thinking,
-        extensionPaths: extensionPackageNames,
-        ...(extensionResult === undefined
-          ? {}
-          : {
-              resolvedExtensionPaths: extensionResult.extensions.map(
-                (extension) => extension.resolvedPath,
-              ),
-            }),
-      },
-      extensionResult?.errors,
-    );
-    assertPiExtensionsLoaded({
+    const extensionFailure = piExtensionFailure({
       resourceLoader: services.resourceLoader,
+      diagnostics: services.diagnostics,
       directories: extensionDirectories,
+    });
+    if (
+      extensionFailure.unrelatedErrors.length > 0 ||
+      extensionFailure.unrelatedDiagnostics.length > 0
+    ) {
+      logger().warn(
+        {
+          errors: extensionFailure.unrelatedErrors,
+          diagnostics: extensionFailure.unrelatedDiagnostics,
+        },
+        'Pi reported extension failures outside the runner harness',
+      );
+    }
+    assertPiHarnessFailure(extensionFailure, {
+      cwd,
+      provider,
+      model: modelId,
+      thinking,
+      extensionPaths,
+      ...(extensionResult === undefined
+        ? {}
+        : {
+            resolvedExtensionPaths: extensionResult.extensions.map(
+              (extension) => extension.resolvedPath,
+            ),
+          }),
     });
 
     const createdSession = await createAgentSessionFromServices({
@@ -281,14 +289,22 @@ interface PiMcpConfig {
   readonly path: string;
 }
 
-function assertPiServiceDiagnostics(
-  diagnostics: Awaited<ReturnType<typeof createAgentSessionServices>>['diagnostics'],
+function assertPiHarnessFailure(
+  extensionFailure: PiExtensionFailure,
   environment: AgentHarnessUnavailableError['environment'],
-  resourceLoaderErrors: AgentHarnessUnavailableError['resourceLoaderErrors'] = [],
 ): void {
-  const errors = diagnostics.filter((diagnostic) => diagnostic.type === 'error');
-  if (errors.length === 0 && resourceLoaderErrors.length === 0) return;
-  throw new AgentHarnessUnavailableError({diagnostics, environment, resourceLoaderErrors});
+  const hasDiagnosticError = extensionFailure.diagnostics.some(
+    (diagnostic) => diagnostic.type === 'error',
+  );
+  const hasExtensionFailure =
+    extensionFailure.missingDirectories.length > 0 || extensionFailure.errors.length > 0;
+  if (!hasDiagnosticError && !hasExtensionFailure) return;
+  throw new AgentHarnessUnavailableError({
+    diagnostics: extensionFailure.diagnostics,
+    environment,
+    missingExtensionDirectories: extensionFailure.missingDirectories,
+    resourceLoaderErrors: extensionFailure.errors,
+  });
 }
 
 function createInMemoryCredentialStore(credentials: Record<string, Credential>): CredentialStore {

--- a/libs/runner/agent/src/core/pi-extensions.ts
+++ b/libs/runner/agent/src/core/pi-extensions.ts
@@ -1,9 +1,14 @@
 import {realpathSync} from 'node:fs';
 import {createRequire} from 'node:module';
 import {dirname, sep} from 'node:path';
-import type {ResourceLoader} from '@earendil-works/pi-coding-agent';
+import type {AgentSessionRuntimeDiagnostic, ResourceLoader} from '@earendil-works/pi-coding-agent';
+import type {
+  AgentHarnessResourceLoaderError,
+  AgentHarnessResourceLoaderFailure,
+} from '#core/errors.js';
 
 export const PI_HARNESS_EXTENSION_PACKAGE_NAMES = ['pi-web-access', 'pi-mcp-adapter'] as const;
+const PI_EXTENSION_DIAGNOSTIC_PATTERN = /^Extension "([^"]+)" error:/;
 const require = createRequire(import.meta.url);
 const resolvedDirectories = new Map<string, string>();
 const availabilityByPackageName = new Map<string, boolean>();
@@ -36,11 +41,7 @@ export function piExtensionDirectories(params: {
   });
 }
 
-/**
- * Returns whether a Pi extension package can be resolved from the runner installation. Callers
- * like the heartbeat loop invoke this on every tick, so both outcomes are cached: package
- * resolvability is fixed for the process lifetime (a package install doesn't change at runtime).
- */
+/** Returns whether a Pi extension package can be resolved from the runner installation. */
 export function isPiExtensionAvailable(params: {packageName: string}): boolean {
   const cached = availabilityByPackageName.get(params.packageName);
   if (cached !== undefined) return cached;
@@ -61,11 +62,7 @@ export function assertPiHarnessExtensionsAvailable(): void {
   piExtensionDirectories({packageNames: PI_HARNESS_EXTENSION_PACKAGE_NAMES});
 }
 
-/**
- * Verifies that Pi loaded an entry from every requested extension directory. Pi reports entry
- * files rather than package directories, and package-manager symlinks make canonical paths the
- * reliable comparison while the raw fallback keeps diagnostics useful for missing paths.
- */
+/** Verifies that Pi loaded an entry from every requested extension directory. */
 export function assertPiExtensionsLoaded(params: {
   resourceLoader: Pick<ResourceLoader, 'getExtensions'>;
   directories: readonly string[];
@@ -85,19 +82,98 @@ export function assertPiExtensionsLoaded(params: {
   );
 }
 
+/**
+ * Collects runner-owned extension failures while failing closed on harness-level diagnostics.
+ * Pi also loads workspace and user extensions, so only path-attributed failures inside the
+ * requested runner directories are classified as harness failures. Diagnostics without an
+ * extension path remain runner-owned because startup/configuration errors must still abort the
+ * step.
+ */
+export function piExtensionFailure(params: {
+  resourceLoader: Pick<ResourceLoader, 'getExtensions'>;
+  diagnostics: readonly AgentSessionRuntimeDiagnostic[];
+  directories: readonly string[];
+}): PiExtensionFailure {
+  const {extensions, errors} = params.resourceLoader.getExtensions();
+  const missingDirectories = params.directories.filter(
+    (directory) =>
+      !extensions.some((extension) =>
+        extensionPathIsInDirectory(directory, extension.resolvedPath),
+      ),
+  );
+  const loadFailure = partitionByExtensionPath(errors, params.directories, (error) => error.path);
+
+  const diagnosticFailure = partitionByExtensionPath(
+    params.diagnostics,
+    params.directories,
+    (diagnostic) =>
+      diagnostic.type === 'error' ? extensionDiagnosticPath(diagnostic.message) : undefined,
+  );
+
+  return {
+    missingDirectories,
+    errors: loadFailure.runner.flatMap(({item, directory}) =>
+      directory === undefined ? [] : [{error: item, directory}],
+    ),
+    unrelatedErrors: loadFailure.unrelated,
+    diagnostics: diagnosticFailure.runner.map(({item}) => item),
+    unrelatedDiagnostics: diagnosticFailure.unrelated,
+  };
+}
+
+export interface PiExtensionFailure {
+  readonly missingDirectories: readonly string[];
+  readonly errors: readonly AgentHarnessResourceLoaderFailure[];
+  readonly unrelatedErrors: readonly AgentHarnessResourceLoaderError[];
+  readonly diagnostics: readonly AgentSessionRuntimeDiagnostic[];
+  readonly unrelatedDiagnostics: readonly AgentSessionRuntimeDiagnostic[];
+}
+
+function partitionByExtensionPath<T>(
+  items: readonly T[],
+  directories: readonly string[],
+  pathForItem: (item: T) => string | undefined,
+): {
+  runner: readonly {item: T; directory: string | undefined}[];
+  unrelated: readonly T[];
+} {
+  const runner = items.flatMap((item) => {
+    const path = pathForItem(item);
+    const directory =
+      path === undefined
+        ? undefined
+        : directories.find((candidate) => extensionPathIsInDirectory(candidate, path));
+    return path === undefined || directory !== undefined ? [{item, directory}] : [];
+  });
+  const runnerItems = new Set(runner.map(({item}) => item));
+  return {
+    runner,
+    unrelated: items.filter((item) => !runnerItems.has(item)),
+  };
+}
+
 function resolvePiExtensionDirectory(packageName: string, resolve: PackageResolver): string {
   try {
     return dirname(resolve(`${packageName}/package.json`));
   } catch (error) {
-    const reason = error instanceof Error ? error.message : String(error);
+    const reason =
+      error instanceof Error ? (error.message.split('\n', 1)[0] ?? error.message) : String(error);
     throw new Error(`Unable to resolve Pi extension package "${packageName}": ${reason}`);
   }
 }
 
+function extensionDiagnosticPath(message: string): string | undefined {
+  return PI_EXTENSION_DIAGNOSTIC_PATTERN.exec(message)?.[1];
+}
+
 function extensionPathIsInDirectory(directory: string, resolvedPath: string): boolean {
+  if (directory === resolvedPath || isPathSegmentPrefix(directory, resolvedPath)) return true;
+
+  const canonicalDirectory = canonicalizePath(directory);
+  const canonicalResolvedPath = canonicalizePath(resolvedPath);
   return (
-    isPathSegmentPrefix(directory, resolvedPath) ||
-    isPathSegmentPrefix(canonicalizePath(directory), canonicalizePath(resolvedPath))
+    canonicalDirectory === canonicalResolvedPath ||
+    isPathSegmentPrefix(canonicalDirectory, canonicalResolvedPath)
   );
 }
 

--- a/libs/runner/agent/src/core/step.test.ts
+++ b/libs/runner/agent/src/core/step.test.ts
@@ -24,6 +24,10 @@ const {
     runClaudeMock: vi.fn(),
   };
 });
+const {loggerErrorMock, loggerWarnMock} = vi.hoisted(() => ({
+  loggerErrorMock: vi.fn(),
+  loggerWarnMock: vi.fn(),
+}));
 
 vi.mock('#core/pi-adapter.js', () => ({piHarnessAdapter: {run: runAgentMock}}));
 vi.mock('#core/claude-adapter.js', () => ({claudeHarnessAdapter: {run: runClaudeMock}}));
@@ -32,6 +36,9 @@ vi.mock('#core/integration-tools-bridge.js', () => ({
 }));
 vi.mock('@shipfox/runner-protocol', () => ({
   createIntegrationToolsGatewayFetch: createIntegrationToolsGatewayFetchMock,
+}));
+vi.mock('@shipfox/node-opentelemetry', () => ({
+  logger: () => ({error: loggerErrorMock, warn: loggerWarnMock}),
 }));
 
 import {
@@ -88,6 +95,8 @@ describe('executeAgentStep', () => {
     gatewayFetch.mockReset();
     runAgentMock.mockReset();
     runClaudeMock.mockReset();
+    loggerErrorMock.mockReset();
+    loggerWarnMock.mockReset();
   });
 
   afterEach(() => {
@@ -413,27 +422,46 @@ describe('executeAgentStep', () => {
   });
 
   it('fails with agent_harness_unavailable without an agent config issue', async () => {
-    runAgentMock.mockRejectedValue(
-      new AgentHarnessUnavailableError({
-        diagnostics: [{type: 'error', message: 'Unknown option: --mcp-config'}],
-        environment: {
-          cwd: '/work',
-          provider: 'anthropic',
-          model: 'claude-opus-4-8',
-          thinking: 'high',
-          extensionPaths: ['pi-web-access', 'pi-mcp-adapter'],
+    const harnessError = new AgentHarnessUnavailableError({
+      diagnostics: [{type: 'error', message: 'Unknown option: --mcp-config'}],
+      environment: {
+        cwd: '/work',
+        provider: 'anthropic',
+        model: 'claude-opus-4-8',
+        thinking: 'high',
+        extensionPaths: ['pi-web-access', 'pi-mcp-adapter'],
+      },
+      missingExtensionDirectories: ['/runner/node_modules/pi-web-access'],
+      resourceLoaderErrors: [
+        {
+          error: {
+            path: '/runner/node_modules/pi-web-access',
+            error: 'Extension path does not exist: /runner/node_modules/pi-web-access',
+          },
+          directory: '/runner/node_modules/pi-web-access',
         },
-      }),
-    );
+      ],
+    });
+    runAgentMock.mockRejectedValue(harnessError);
     const result = await executeAgentStep(buildAgentStep(), {runtime: RUNTIME});
     expect(result).toEqual({
       success: false,
       error: {
-        message: 'Pi extension setup failed: Unknown option: --mcp-config',
+        message:
+          'Pi extension setup failed: Extension path does not exist: pi-web-access; ' +
+          'Unknown option: --mcp-config',
         reason: 'agent_harness_unavailable',
       },
       exit_code: null,
     });
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'runner.agent_harness_unavailable',
+        harness: 'pi',
+        requestedExtensionPaths: ['pi-web-access', 'pi-mcp-adapter'],
+      }),
+      'Agent harness unavailable',
+    );
   });
 
   it('logs bounded harness diagnostics with step and build identity', async () => {
@@ -457,7 +485,13 @@ describe('executeAgentStep', () => {
           resolvedExtensionPaths: ['/app/node_modules/pi-web-access/index.js'],
         },
         resourceLoaderErrors: [
-          {path: '/app/node_modules/pi-web-access', error: 'Extension path does not exist'},
+          {
+            error: {
+              path: '/app/node_modules/pi-web-access',
+              error: 'Extension path does not exist',
+            },
+            directory: '/app/node_modules/pi-web-access',
+          },
         ],
       }),
     );

--- a/libs/runner/agent/src/core/step.ts
+++ b/libs/runner/agent/src/core/step.ts
@@ -257,7 +257,7 @@ function logHarnessUnavailable(params: {
       })),
       resourceLoaderErrors: error.resourceLoaderErrors
         .slice(0, MAX_HARNESS_DIAGNOSTICS)
-        .map((resourceError) => ({
+        .map(({error: resourceError}) => ({
           path: resourceError.path,
           error: resourceError.error.slice(0, MAX_HARNESS_DIAGNOSTIC_MESSAGE_LENGTH),
         })),


### PR DESCRIPTION
Runner-owned Pi extension and service startup failures now classify as `agent_harness_unavailable` instead of `agent_invocation_failed`. The workflow run view provides administrator guidance so users do not chase step settings. Diagnostics remain actionable while runner paths are sanitized and bounded, structured failure details are retained, and workspace extension failures stay separate from runner failures.

Validation: `mise exec -- turbo check test type --filter=@shipfox/runner-agent --force` and `mise exec -- turbo test type --filter=@shipfox/runner-agent --filter=@shipfox/client-workflows --force`

Closes ENG-1303

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows a clear, admin-guided error when the runner-owned Pi harness can’t start and classifies these as `agent_harness_unavailable`, not step misconfigurations. Improves diagnostic formatting, redaction, and attribution so messages are safe, concise, and actionable. Aligns with Linear ENG-1303.

- **New Features**
  - UI: Added `AgentHarnessUnavailableCallout` using `@shipfox/react-ui/alert`; rendered from `job-card` when an agent step fails with `agent_harness_unavailable`; includes story and run-view test; no “Configure Agents” link.
  - Detection: Classifies Pi service-creation failures, extension package-resolution errors, and missing runner extension directories as harness unavailable; partitions loader errors and diagnostics to runner directories and ignores workspace/user extension issues; warns when unrelated failures are reported; covers `pi-web-access` and `pi-mcp-adapter`.
  - Diagnostics: Formats messages as “Pi extension setup failed: …”; sanitizes runner paths while preserving slash-delimited patterns and regex; collapses absolute paths and `file://` URLs to basenames (once); prefixes loader messages with the extension name; deduplicates after sanitization; truncates at a token boundary with an ellipsis (~200 chars), avoids lone surrogates, and falls back to a generic message when empty; bounded within `STEP_ERROR_MESSAGE_MAX_LENGTH`.
  - Logging: Emits structured logs with environment, missing directories, and loader errors.

<sup>Written for commit 55211d6ad1631ac32fb143a8de7c1cc922a6cda0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

