### PR TITLE
[client-shell] Add optional account menu extension slot

### DIFF
--- a/.changeset/bright-menu-slots.md
+++ b/.changeset/bright-menu-slots.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-shell": minor
+---
+
+Add an optional browser account-menu entry slot for composing applications.

--- a/docs/adr/0001-client-composition-contract.md
+++ b/docs/adr/0001-client-composition-contract.md
@@ -218,9 +218,12 @@ The gate remains outside the shell because it queries project, integration, and 
 features. A composition that contains workspace routes but omits the gate fails loudly.
 
 The shell receives browser-only `ChromeSlots` through `composeClientApp()`. They provide the
-project breadcrumb and project/workspace consistency guard. They are not feature providers or
-manifest data, so Node-safe manifest evaluation never imports browser chrome or creates a
-shell-to-feature dependency.
+project breadcrumb and project/workspace consistency guard. An application may also provide one
+`AccountMenuEntry` component. The shell renders that optional component inside `UserMenu` before
+the shell-owned logout action; the component may return nothing based on the current session. The
+slot cannot replace the user identity, theme controls, logout action, or authentication runtime.
+These slots are not feature providers or manifest data, so Node-safe manifest evaluation never
+imports browser chrome or creates a shell-to-feature dependency.
 
 ## Composition rules
 

--- a/libs/client/shell/src/components/user-menu.test.tsx
+++ b/libs/client/shell/src/components/user-menu.test.tsx
@@ -1,0 +1,74 @@
+import {DropdownMenuItem} from '@shipfox/react-ui/dropdown-menu';
+import {fireEvent, screen} from '@testing-library/react';
+import {defineClientFeature} from '#contract.js';
+import {useAuthState} from '#runtime/auth.js';
+import type {ChromeSlots} from '#runtime/chrome-context.js';
+import {defineRoute} from '#runtime/define-route.js';
+import {renderComposedShell} from '#test/render.js';
+
+function accountMenuFeature() {
+  return defineClientFeature({
+    id: 'acme.account-menu',
+    routes: [
+      {path: '/workspaces/$wid/account-menu', parent: 'workspaceLayout', impl: 'account-menu'},
+    ],
+  });
+}
+
+function PrivateAccountMenuEntry() {
+  const {isAuthenticated} = useAuthState();
+  if (!isAuthenticated) return null;
+  return <DropdownMenuItem>Private entry</DropdownMenuItem>;
+}
+
+async function openAccountMenu(chrome: Partial<ChromeSlots> = {}) {
+  await renderComposedShell({
+    features: [accountMenuFeature()],
+    initialPath: '/workspaces/workspace/account-menu',
+    resolveImpl: () => defineRoute({component: () => <h1>Account menu</h1>}),
+    chrome,
+  });
+  fireEvent.pointerDown(await screen.findByRole('button', {name: 'User menu'}));
+}
+
+describe('UserMenu', () => {
+  test('keeps shell-owned controls when no account-menu entry is provided', async () => {
+    await openAccountMenu();
+
+    expect(await screen.findByText('Theme')).toBeVisible();
+    expect(screen.getByRole('menuitem', {name: 'Logout'})).toBeVisible();
+    expect(screen.queryByRole('menuitem', {name: 'Private entry'})).not.toBeInTheDocument();
+  });
+
+  test('renders a composing account-menu entry without replacing shell controls', async () => {
+    await openAccountMenu({AccountMenuEntry: PrivateAccountMenuEntry});
+
+    expect(await screen.findByRole('menuitem', {name: 'Private entry'})).toBeVisible();
+    expect(screen.getByText('Theme')).toBeVisible();
+    expect(screen.getByRole('menuitem', {name: 'Logout'})).toBeVisible();
+  });
+
+  test('contains a failing account-menu entry without unmounting the shell', async () => {
+    const failure = new Error('Account menu failed');
+    const reportErrorSpy = vi.fn();
+    vi.stubGlobal('reportError', reportErrorSpy);
+    const FailingAccountMenuEntry = () => {
+      throw failure;
+    };
+
+    try {
+      await openAccountMenu({AccountMenuEntry: FailingAccountMenuEntry});
+
+      expect(await screen.findByText('Theme')).toBeVisible();
+      expect(screen.getByRole('menuitem', {name: 'Logout'})).toBeVisible();
+      expect(reportErrorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cause: failure,
+          message: 'Failed to render account menu entry.',
+        }),
+      );
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/libs/client/shell/src/components/user-menu.tsx
+++ b/libs/client/shell/src/components/user-menu.tsx
@@ -12,15 +12,37 @@ import {
 import {useTheme} from '@shipfox/react-ui/hooks';
 import type {Theme} from '@shipfox/react-ui/theme';
 import {Link} from '@tanstack/react-router';
+import {Component, type PropsWithChildren} from 'react';
 import {useAuthState} from '#runtime/auth.js';
+import {useChrome} from '#runtime/chrome-context.js';
 
 const themeOptions: Array<{value: Theme; label: string}> = [
   {value: 'light', label: 'Light'},
   {value: 'dark', label: 'Dark'},
   {value: 'system', label: 'System'},
 ];
+
+type AccountMenuEntryBoundaryState = {hasError: boolean};
+
+class AccountMenuEntryBoundary extends Component<PropsWithChildren, AccountMenuEntryBoundaryState> {
+  override state: AccountMenuEntryBoundaryState = {hasError: false};
+
+  static getDerivedStateFromError(): AccountMenuEntryBoundaryState {
+    return {hasError: true};
+  }
+
+  override componentDidCatch(error: unknown): void {
+    globalThis.reportError?.(new Error('Failed to render account menu entry.', {cause: error}));
+  }
+
+  override render() {
+    return this.state.hasError ? null : this.props.children;
+  }
+}
+
 export function UserMenu() {
   const {user} = useAuthState();
+  const {AccountMenuEntry} = useChrome();
   const {theme, setTheme} = useTheme();
   const email = user?.email ?? '';
   return (
@@ -49,6 +71,11 @@ export function UserMenu() {
             </DropdownMenuRadioItem>
           ))}
         </DropdownMenuRadioGroup>
+        {AccountMenuEntry ? (
+          <AccountMenuEntryBoundary>
+            <AccountMenuEntry />
+          </AccountMenuEntryBoundary>
+        ) : undefined}
         <DropdownMenuSeparator />
         <DropdownMenuItem asChild>
           <Link to={'/auth/logout' as never}>Logout</Link>

--- a/libs/client/shell/src/runtime/chrome-context.tsx
+++ b/libs/client/shell/src/runtime/chrome-context.tsx
@@ -4,6 +4,12 @@ import {createContext, useContext} from 'react';
 export interface ChromeSlots {
   ProjectBreadcrumb: ComponentType;
   ProjectLayoutGuard: ComponentType;
+  /**
+   * Optional content rendered in the account menu before the shell-owned logout
+   * action. The composing component must render one DropdownMenuItem or return
+   * null, and owns whether this content renders from the current session.
+   */
+  AccountMenuEntry?: ComponentType;
 }
 
 const ChromeContext = createContext<ChromeSlots | undefined>(undefined);

--- a/libs/client/shell/test/external/fixture/src/app.fixture.tsx
+++ b/libs/client/shell/test/external/fixture/src/app.fixture.tsx
@@ -94,10 +94,10 @@ test('renders the external route, provider order, navigation, settings, and conf
   if (!(userMenu instanceof HTMLButtonElement)) throw new Error('Expected the user menu button.');
   userMenu.dispatchEvent(new MouseEvent('pointerdown', {bubbles: true, button: 0}));
   await vi.waitFor(() =>
-    expect(container.querySelector('[data-testid="external-account-menu-entry"]')).toBeTruthy(),
+    expect(document.body.querySelector('[data-testid="external-account-menu-entry"]')).toBeTruthy(),
   );
-  expect(container.textContent).toContain('Theme');
-  expect(container.textContent).toContain('Logout');
+  expect(document.body.textContent).toContain('Theme');
+  expect(document.body.textContent).toContain('Logout');
   await vi.waitFor(() => expect(readProviderEvidence().map(({id}) => id)).toEqual(['outer', 'inner']));
   const providers = readProviderEvidence();
   expect(providers[1]?.queryClient).toBe(providers[0]?.queryClient);

--- a/libs/client/shell/test/external/fixture/src/app.fixture.tsx
+++ b/libs/client/shell/test/external/fixture/src/app.fixture.tsx
@@ -90,6 +90,14 @@ test('renders the external route, provider order, navigation, settings, and conf
     'outer > inner',
   );
   expect(container.textContent).toContain('Hello from the external fixture');
+  const userMenu = container.querySelector('[aria-label="User menu"]');
+  if (!(userMenu instanceof HTMLButtonElement)) throw new Error('Expected the user menu button.');
+  userMenu.dispatchEvent(new MouseEvent('pointerdown', {bubbles: true, button: 0}));
+  await vi.waitFor(() =>
+    expect(container.querySelector('[data-testid="external-account-menu-entry"]')).toBeTruthy(),
+  );
+  expect(container.textContent).toContain('Theme');
+  expect(container.textContent).toContain('Logout');
   await vi.waitFor(() => expect(readProviderEvidence().map(({id}) => id)).toEqual(['outer', 'inner']));
   const providers = readProviderEvidence();
   expect(providers[1]?.queryClient).toBe(providers[0]?.queryClient);

--- a/libs/client/shell/test/external/fixture/src/main.tsx
+++ b/libs/client/shell/test/external/fixture/src/main.tsx
@@ -11,8 +11,10 @@ import {
   type AuthStateValue,
   mergeConfigShapes,
   type RouterContext,
+  useAuthState,
 } from '@shipfox/client-shell/runtime';
 import {ShellProviders} from '@shipfox/client-shell/testing';
+import {DropdownMenuItem} from '@shipfox/react-ui/dropdown-menu';
 import {QueryClient} from '@tanstack/react-query';
 import {Outlet, RouterProvider} from '@tanstack/react-router';
 import {createStore} from 'jotai';
@@ -46,6 +48,16 @@ function FixtureProjectLayoutGuard() {
   return <Outlet />;
 }
 
+function FixtureAccountMenuEntry() {
+  const {isAuthenticated} = useAuthState();
+  if (!isAuthenticated) return null;
+  return (
+    <DropdownMenuItem data-testid="external-account-menu-entry">
+      External account action
+    </DropdownMenuItem>
+  );
+}
+
 export function ClientApp() {
   const [queryClient] = useState(
     () => new QueryClient({defaultOptions: {queries: {retry: false}}}),
@@ -68,6 +80,7 @@ export function ClientApp() {
       chrome={{
         ProjectBreadcrumb: FixtureProjectBreadcrumb,
         ProjectLayoutGuard: FixtureProjectLayoutGuard,
+        AccountMenuEntry: FixtureAccountMenuEntry,
       }}
     >
       <ShellProviders

--- a/libs/client/shell/test/external/verify.mjs
+++ b/libs/client/shell/test/external/verify.mjs
@@ -43,7 +43,7 @@ const config = readPublicationClosureConfig(join(repositoryRoot, 'publication-cl
 const workspacePackages = readWorkspacePackages(repositoryRoot);
 validatePublicationState(workspacePackages, config, repositoryRoot);
 const clientRoots = config.roots.filter((root) => root.startsWith('@shipfox/client-'));
-const fixtureSupportPackages = ['@shipfox/client-config'];
+const fixtureSupportPackages = ['@shipfox/client-config', '@shipfox/react-ui'];
 const consumerPackages = [...clientRoots, ...fixtureSupportPackages];
 const closure = computePublicationClosure(workspacePackages, clientRoots);
 const entryPoints = closure.flatMap((name) =>

--- a/libs/client/shell/test/render.tsx
+++ b/libs/client/shell/test/render.tsx
@@ -14,10 +14,12 @@ export async function renderComposedShell({
   features,
   initialPath,
   resolveImpl,
+  chrome: chromeOverrides,
 }: {
   features: readonly ClientFeature[];
   initialPath: string;
   resolveImpl: ResolveRouteImpl;
+  chrome?: Partial<ChromeSlots>;
 }): Promise<{
   router: unknown;
   queryClient: QueryClient;
@@ -40,6 +42,7 @@ export async function renderComposedShell({
   const chrome: ChromeSlots = {
     ProjectBreadcrumb: () => null,
     ProjectLayoutGuard: Outlet,
+    ...chromeOverrides,
   };
   store.set(authStateAtom, auth);
   const router = createRouter({


### PR DESCRIPTION
## Summary

Add an optional `AccountMenuEntry` browser slot to the client shell so composing applications can contribute one session-aware dropdown item before the shell-owned logout action.

The slot remains additive and cannot replace shell identity, theme, logout, or auth controls. Its render is isolated behind a local error boundary, and the external fixture documents and verifies the required `DropdownMenuItem` contract.

Closes ENG-1345

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional account menu slot to `@shipfox/client-shell` so apps can inject one session-aware `DropdownMenuItem` before Logout. Satisfies ENG-1345 while keeping shell-owned identity, theme, and auth controls intact behind an error boundary.

- **New Features**
  - Added `AccountMenuEntry` slot on `ChromeSlots`, rendered in `UserMenu` before Logout.
  - Component must return one `DropdownMenuItem` or `null`; isolated by an error boundary that reports via `globalThis.reportError` without unmounting shell UI.

- **Bug Fixes**
  - Fixed external fixture account menu portal assertion to target menu content rendered via the portal.

<sup>Written for commit 55041080bcf829de03f334d00cccf7826a7a6b44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

