### PR TITLE
[client-shell] Support feature-owned layouts and local navigation

### DIFF
--- a/.changeset/feature-owned-layouts.md
+++ b/.changeset/feature-owned-layouts.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-shell": minor
+---
+
+Adds feature-owned layout parents, layout-local navigation, and checked child-route composition to the public client shell contract.

--- a/docs/adr/0001-client-composition-contract.md
+++ b/docs/adr/0001-client-composition-contract.md
@@ -76,9 +76,18 @@ export type AnchorId =
   | 'projectLayout'
   | 'workspaceSettings';
 
+export type RouteParentId = AnchorId | (string & {});
+
+export interface LayoutContribution {
+  id: string;
+  path: string;
+  parent: RouteParentId;
+  impl: string;
+}
+
 export interface RouteContribution {
   path: string;
-  parent: AnchorId;
+  parent: RouteParentId;
   override?: boolean;
   impl: string;
 }
@@ -88,14 +97,21 @@ export interface FeatureProvider {
   Component: ComponentType<PropsWithChildren>;
 }
 
-export interface NavTabEntry {
+interface NavTabEntryBase {
   id: string;
-  scope: 'workspace' | 'project';
   label: string;
   to: string;
   exact?: boolean;
   order?: number;
 }
+
+export type NavTabEntry =
+  | (NavTabEntryBase & {scope: 'workspace' | 'project'; layout?: never})
+  | (NavTabEntryBase & {
+      scope: 'layout';
+      layout: string;
+      minimumRole?: string;
+    });
 
 export interface SettingsSectionEntry {
   id: string;
@@ -107,6 +123,7 @@ export interface SettingsSectionEntry {
 
 export interface ClientFeature<S extends z.ZodRawShape = z.ZodRawShape> {
   id: string;
+  layouts?: readonly LayoutContribution[];
   routes?: readonly RouteContribution[];
   providers?: readonly FeatureProvider[];
   navigation?: readonly NavTabEntry[];
@@ -162,12 +179,17 @@ The shell owns four anchors:
 | `projectLayout` | Routes scoped to a project |
 | `workspaceSettings` | Routes rendered inside workspace settings |
 
-The generator injects the matching parent route. A route must be below the path represented by its
-anchor. An override must keep the base route's normalized path and anchor.
+Features may also declare layout contributions. A layout has a stable id, a full path, a parent, and
+a public route implementation. A route from any composed feature can name that layout id as its
+parent. Layout ids are unique across the composition and cannot replace shell anchors.
 
-A route may also own the exact anchor path. The generator represents that contribution as an index
-route below the anchor. This keeps workspace home and settings-index redirects with their feature
-owners while allowing them to remain navigation targets.
+The generator injects the matching parent route. A route must be below the path represented by its
+anchor or feature-owned layout. An override must keep the base route's normalized path and parent.
+
+A route may also own the exact anchor path when it names that anchor directly. Root-parented routes
+and layouts cannot use a path equal to or below a protected shell anchor; this prevents a sibling
+route from bypassing the anchor's guards. The generator represents an exact-anchor contribution as
+an index route below the anchor.
 
 An accepted override replaces the whole route options object. It replaces the component, loader,
 `beforeLoad`, search check, static data, pending component, and error component together. Children
@@ -179,6 +201,12 @@ An overriding search check must also accept all upstream-reachable navigation. N
 be optional or have defaults.
 
 Navigation targets remain full paths after an override. They never point to implementation ids.
+
+Feature-owned layouts may expose local navigation. A layout-scoped entry sets `scope: 'layout'`,
+names its layout with `layout`, and may carry opaque `minimumRole` metadata. `minimumRole` is not
+part of workspace- or project-scoped entries. The shell keeps these entries as data and exposes them through `useLayoutNavigation(layoutId)` from
+`@shipfox/client-shell/runtime`. The layout owns rendering and role policy. Child features can add
+entries without importing the layout feature or its route implementation.
 
 ## Generated route tree
 
@@ -269,8 +297,14 @@ second copy of a shell-owned context. Documentation and review remain part of re
 Navigation and settings entries are data. They do not carry JSX. The default `order` is 500. Entries
 sort by numeric order, feature-array position, then declaration position.
 
-Navigation ids must be unique. Each normalized `to` target must exist in the route tree. `to` stays a
-string because a feature package cannot see the consumer's generated route union.
+Navigation ids must be unique. Each normalized `to` target must exist in the route tree. A
+layout-scoped target must be the layout root or a descendant of that layout, including routes below
+nested feature-owned layouts. `to` stays a string because a feature package cannot see the
+consumer's generated route union.
+
+`minimumRole` is available only on layout-scoped entries. It is data for the owning layout. The
+composition check accepts non-empty strings and rejects malformed role metadata. It does not import
+or define a role policy.
 
 A settings section adds navigation data only. The feature contributes its page as a normal route. A
 section with `pathSegment: 'sso'` requires `/workspaces/$wid/settings/sso`. Section ids must be
@@ -293,6 +327,13 @@ id, key, or feature id.
 | Failure | Exact message template |
 | --- | --- |
 | Route collision | `Route "<path>" is contributed by both features "<first>" and "<second>". Set override: true to replace it explicitly.` |
+| Duplicate layout id | `Layout id "<id>" is contributed by both features "<first>" and "<second>".` |
+| Reserved layout id | `Layout id "<id>" in feature "<feature>" is reserved by the shell.` |
+| Reserved layout path | `Layout "<id>" in feature "<feature>" targets path "<path>" which is reserved by a shell anchor.` |
+| Missing layout parent | `Layout "<id>" in feature "<feature>" targets missing layout parent "<parent>".` |
+| Cyclic layout parent | `Layout "<id>" in feature "<feature>" has a cyclic parent reference.` |
+| Missing route parent | `Route "<path>" in feature "<feature>" targets missing layout parent "<parent>".` |
+| Layout replaces route | `Route override for "<path>" from feature "<feature>" cannot replace layout "<id>" contributed by feature "<layout-feature>".` |
 | Missing override base | `Route override for "<path>" from feature "<feature>" has no route to replace.` |
 | Competing overrides | `Route "<path>" has competing overrides from features "<first>" and "<second>".` |
 | Override changes anchor | `Route override for "<path>" from feature "<override>" cannot change anchor from "<base-anchor>" in feature "<base>" to "<override-anchor>".` |
@@ -300,10 +341,16 @@ id, key, or feature id.
 | Duplicate provider | `Provider id "<id>" is contributed by both features "<first>" and "<second>".` |
 | Duplicate navigation | `Navigation entry "<id>" is contributed by both features "<first>" and "<second>".` |
 | Missing navigation target | `Navigation entry "<id>" in feature "<feature>" targets missing route "<path>".` |
+| Invalid navigation layout | `Navigation entry "<id>" in feature "<feature>" has invalid layout metadata. Expected a non-empty layout id.` |
+| Missing navigation layout | `Navigation entry "<id>" in feature "<feature>" targets missing layout "<layout>".` |
+| Navigation outside layout | `Navigation entry "<id>" in feature "<feature>" targets route "<path>" outside layout "<layout>".` |
+| Invalid role metadata | `Navigation entry "<id>" in feature "<feature>" has invalid minimum role metadata. Expected a non-empty string.` |
 | Duplicate settings section | `Settings section "<id>" is contributed by both features "<first>" and "<second>".` |
 | Missing settings route | `Settings section "<id>" in feature "<feature>" requires route "<path>".` |
 | Duplicate config key | `Config key "<key>" is contributed by both features "<first>" and "<second>". Reuse the same schema instance to intentionally share it.` |
 | Invalid anchor nesting | `Route "<path>" must be nested under anchor "<anchor>" (<anchor-path>).` |
+| Invalid layout nesting | `Route "<path>" must be nested under layout "<layout>" (<layout-path>).` |
+| Root parent inside protected anchor | `Route "<path>" in feature "<feature>" cannot use root parent inside reserved anchor "<anchor>" (<anchor-path>). Use parent "<anchor>".` |
 | Route module not found | `Could not resolve route implementation "<specifier>" for "<path>".` |
 | Invalid route export | `Route implementation "<specifier>" for "<path>" must export default defineRoute(...).` |
 | Feature evaluation | `Failed to evaluate features module "<file>". Features modules must be Node-safe: <cause>` |
@@ -322,7 +369,8 @@ Route "/auth/login" is contributed by both features "shipfox.auth" and "fixture.
 The package uses explicit exports:
 
 - `@shipfox/client-shell`: Node-safe authoring types and `defineClientFeature()`;
-- `@shipfox/client-shell/runtime`: browser composition, route helpers, anchors, and checks;
+- `@shipfox/client-shell/runtime`: browser composition, route helpers, anchors, layout navigation,
+  and checks;
 - `@shipfox/client-shell/vite`: the codegen Vite plugin; and
 - `@shipfox/client-shell/testing`: test and Storybook construction helpers.
 
@@ -472,6 +520,46 @@ export const ssoFeature = defineClientFeature({
 ```
 
 This feature uses the settings registry. It does not replace authentication.
+
+### Feature-owned layout
+
+The layout feature declares the parent. Child features contribute routes and local navigation by
+using the stable layout id.
+
+```ts
+export const adminLayoutFeature = defineClientFeature({
+  id: 'acme.admin-layout',
+  layouts: [
+    {
+      id: 'acme.admin-layout',
+      path: '/admin',
+      parent: 'root',
+      impl: '@acme/admin/routes/layout',
+    },
+  ],
+});
+
+export const adminUsersFeature = defineClientFeature({
+  id: 'acme.admin-users',
+  routes: [
+    {
+      path: '/admin/users',
+      parent: 'acme.admin-layout',
+      impl: '@acme/admin-users/routes/users',
+    },
+  ],
+  navigation: [
+    {
+      id: 'admin.users',
+      scope: 'layout',
+      layout: 'acme.admin-layout',
+      label: 'Users',
+      to: '/admin/users',
+      minimumRole: 'observer',
+    },
+  ],
+});
+```
 
 ## Tests and Storybook
 

--- a/docs/adr/0001-client-composition-contract.md
+++ b/docs/adr/0001-client-composition-contract.md
@@ -345,6 +345,7 @@ id, key, or feature id.
 | Missing navigation layout | `Navigation entry "<id>" in feature "<feature>" targets missing layout "<layout>".` |
 | Navigation outside layout | `Navigation entry "<id>" in feature "<feature>" targets route "<path>" outside layout "<layout>".` |
 | Invalid role metadata | `Navigation entry "<id>" in feature "<feature>" has invalid minimum role metadata. Expected a non-empty string.` |
+| Role metadata outside layout | `Navigation entry "<id>" in feature "<feature>" has minimum role metadata but is not layout-scoped.` |
 | Duplicate settings section | `Settings section "<id>" is contributed by both features "<first>" and "<second>".` |
 | Missing settings route | `Settings section "<id>" in feature "<feature>" requires route "<path>".` |
 | Duplicate config key | `Config key "<key>" is contributed by both features "<first>" and "<second>". Reuse the same schema instance to intentionally share it.` |

--- a/libs/client/shell/src/compose/compose-client-features.ts
+++ b/libs/client/shell/src/compose/compose-client-features.ts
@@ -1,25 +1,33 @@
 import type {ClientFeature, NavTabEntry, SettingsSectionEntry} from '#contract.js';
 import {navigationEntries, settingsEntries} from '#runtime/registries.js';
-import {type ComposedRoute, composeRoutes} from './compose-routes.js';
+import {
+  type ComposedLayout,
+  type ComposedRoute,
+  composeLayouts,
+  composeRoutes,
+} from './compose-routes.js';
 import {mergeConfigShapes} from './merge-config.js';
 import {validateProviderIds} from './validate-providers.js';
 import {validateNavigation, validateSettingsSections} from './validate-registries.js';
 
 export interface ComposedClientFeatures {
   configShape: ReturnType<typeof mergeConfigShapes>;
+  layouts: ComposedLayout[];
   navigation: NavTabEntry[];
   routes: ComposedRoute[];
   settingsSections: SettingsSectionEntry[];
 }
 
 export function composeClientFeatures(features: readonly ClientFeature[]): ComposedClientFeatures {
-  const routes = composeRoutes(features);
+  const layouts = composeLayouts(features);
+  const routes = composeRoutes(features, layouts);
   validateProviderIds(features);
-  validateNavigation(features, routes);
+  validateNavigation(features, routes, layouts);
   validateSettingsSections(features, routes);
 
   return {
     configShape: mergeConfigShapes(features),
+    layouts,
     navigation: navigationEntries(features),
     routes,
     settingsSections: settingsEntries(features),

--- a/libs/client/shell/src/compose/compose-routes.test.ts
+++ b/libs/client/shell/src/compose/compose-routes.test.ts
@@ -1,5 +1,5 @@
 import type {ClientFeature} from '#contract.js';
-import {composeRoutes} from './compose-routes.js';
+import {composeLayouts, composeRoutes} from './compose-routes.js';
 
 const base: ClientFeature = {
   id: 'shipfox.base',
@@ -10,6 +10,141 @@ const danglingOverrideMessage = /\/missing.*acme\.insights/u;
 const competingOverridesMessage = /\/projects.*acme\.one.*acme\.two/u;
 
 describe('composeRoutes', () => {
+  test('declares a layout that another feature can use as a route parent', () => {
+    const features: ClientFeature[] = [
+      {
+        id: 'acme.shell',
+        layouts: [{id: 'acme.admin', path: '/admin', parent: 'root', impl: 'layout'}],
+      },
+      {
+        id: 'acme.users',
+        routes: [{path: '/admin/users', parent: 'acme.admin', impl: 'users'}],
+      },
+    ];
+
+    expect(composeLayouts(features)).toEqual([
+      {
+        id: 'acme.admin',
+        path: '/admin',
+        parent: 'root',
+        impl: 'layout',
+        featureId: 'acme.shell',
+      },
+    ]);
+    expect(composeRoutes(features)).toEqual([
+      {
+        path: '/admin/users',
+        parent: 'acme.admin',
+        impl: 'users',
+        featureId: 'acme.users',
+        ownerFeatureId: 'acme.users',
+      },
+    ]);
+  });
+
+  test('names duplicate layout ids and missing layout parents', () => {
+    expect(() =>
+      composeLayouts([
+        {id: 'acme.one', layouts: [{id: 'acme.admin', path: '/one', parent: 'root', impl: 'one'}]},
+        {id: 'acme.two', layouts: [{id: 'acme.admin', path: '/two', parent: 'root', impl: 'two'}]},
+      ]),
+    ).toThrow('Layout id "acme.admin" is contributed by both features "acme.one" and "acme.two".');
+    expect(() =>
+      composeLayouts([
+        {
+          id: 'acme.admin',
+          layouts: [{id: 'acme.admin', path: '/admin', parent: 'acme.missing', impl: 'admin'}],
+        },
+      ]),
+    ).toThrow(
+      'Layout "acme.admin" in feature "acme.admin" targets missing layout parent "acme.missing".',
+    );
+  });
+
+  test('rejects a layout path reserved by a shell anchor', () => {
+    expect(() =>
+      composeLayouts([
+        {
+          id: 'acme.shell',
+          layouts: [
+            {id: 'acme.fake-workspace', path: '/workspaces/$wid', parent: 'root', impl: 'fake'},
+          ],
+        },
+      ]),
+    ).toThrow(
+      'Layout "acme.fake-workspace" in feature "acme.shell" targets path "/workspaces/$wid" which is reserved by a shell anchor.',
+    );
+  });
+
+  test('rejects root-parented routes and layouts inside protected anchors', () => {
+    expect(() =>
+      composeRoutes([
+        {
+          id: 'acme.reports',
+          routes: [{path: '/workspaces/$wid/reports', parent: 'root', impl: 'reports'}],
+        },
+      ]),
+    ).toThrow(
+      'Route "/workspaces/$wid/reports" in feature "acme.reports" cannot use root parent inside reserved anchor "workspaceLayout" (/workspaces/$wid). Use parent "workspaceLayout".',
+    );
+    expect(() =>
+      composeLayouts([
+        {
+          id: 'acme.reports',
+          layouts: [
+            {
+              id: 'acme.reports.layout',
+              path: '/workspaces/$wid/reports',
+              parent: 'root',
+              impl: 'reports',
+            },
+          ],
+        },
+      ]),
+    ).toThrow(
+      'Route "/workspaces/$wid/reports" in feature "acme.reports" cannot use root parent inside reserved anchor "workspaceLayout" (/workspaces/$wid). Use parent "workspaceLayout".',
+    );
+  });
+
+  test('rejects a protected path smuggled through an intermediate root-parented layout', () => {
+    expect(() =>
+      composeLayouts([
+        {
+          id: 'acme.decoy',
+          layouts: [{id: 'acme.decoy-layout', path: '/workspaces', parent: 'root', impl: 'decoy'}],
+        },
+        {
+          id: 'acme.smuggled',
+          layouts: [
+            {
+              id: 'acme.smuggled-layout',
+              path: '/workspaces/$wid/reports',
+              parent: 'acme.decoy-layout',
+              impl: 'reports',
+            },
+          ],
+        },
+      ]),
+    ).toThrow(
+      'Route "/workspaces/$wid/reports" in feature "acme.smuggled" cannot use root parent inside reserved anchor "workspaceLayout" (/workspaces/$wid). Use parent "workspaceLayout".',
+    );
+  });
+
+  test('rejects a child route outside its declared layout path', () => {
+    expect(() =>
+      composeRoutes([
+        {
+          id: 'acme.admin',
+          layouts: [{id: 'acme.admin', path: '/admin', parent: 'root', impl: 'admin'}],
+        },
+        {
+          id: 'acme.users',
+          routes: [{path: '/users', parent: 'acme.admin', impl: 'users'}],
+        },
+      ]),
+    ).toThrow('Route "/users" must be nested under layout "acme.admin" (/admin).');
+  });
+
   test('appends a unique route and explicitly replaces an existing route', () => {
     const routes = composeRoutes([
       base,

--- a/libs/client/shell/src/compose/compose-routes.test.ts
+++ b/libs/client/shell/src/compose/compose-routes.test.ts
@@ -145,6 +145,23 @@ describe('composeRoutes', () => {
     ).toThrow('Route "/users" must be nested under layout "acme.admin" (/admin).');
   });
 
+  test('reports a route and layout path conflict as non-overridable', () => {
+    expect(() =>
+      composeRoutes([
+        {
+          id: 'acme.admin',
+          layouts: [{id: 'acme.admin.layout', path: '/admin', parent: 'root', impl: 'admin'}],
+        },
+        {
+          id: 'acme.route',
+          routes: [{path: '/admin', parent: 'root', impl: 'route'}],
+        },
+      ]),
+    ).toThrow(
+      'Route "/admin" from feature "acme.route" conflicts with layout "acme.admin.layout" contributed by feature "acme.admin". Routes cannot replace layouts.',
+    );
+  });
+
   test('appends a unique route and explicitly replaces an existing route', () => {
     const routes = composeRoutes([
       base,

--- a/libs/client/shell/src/compose/compose-routes.ts
+++ b/libs/client/shell/src/compose/compose-routes.ts
@@ -162,14 +162,9 @@ export function composeLayouts(features: readonly ClientFeature[]): ComposedLayo
       featureId: feature.id,
     })),
   );
-  validateLayoutParents(layouts);
+  const layoutById = validateLayoutParents(layouts);
   for (const layout of layouts) {
-    validateNestedRoute(
-      layout.path,
-      layout.parent,
-      new Map(layouts.map((item) => [item.id, item])),
-      layout.featureId,
-    );
+    validateNestedRoute(layout.path, layout.parent, layoutById, layout.featureId);
   }
   return layouts;
 }
@@ -204,7 +199,7 @@ export function composeRoutes(
       if (layoutAtPath) {
         const message = normalizedContribution.override
           ? `Route override for "${normalizedContribution.path}" from feature "${feature.id}" cannot replace layout "${layoutAtPath.id}" contributed by feature "${layoutAtPath.featureId}".`
-          : `Route "${normalizedContribution.path}" is contributed by both features "${layoutAtPath.featureId}" and "${feature.id}". Set override: true to replace it explicitly.`;
+          : `Route "${normalizedContribution.path}" from feature "${feature.id}" conflicts with layout "${layoutAtPath.id}" contributed by feature "${layoutAtPath.featureId}". Routes cannot replace layouts.`;
         throw new RouteCompositionError(normalizedContribution.path, message, [
           layoutAtPath.featureId,
           feature.id,

--- a/libs/client/shell/src/compose/compose-routes.ts
+++ b/libs/client/shell/src/compose/compose-routes.ts
@@ -1,13 +1,198 @@
-import type {ClientFeature, RouteContribution} from '#contract.js';
-import {RouteCompositionError} from './errors.js';
+import type {
+  AnchorId,
+  ClientFeature,
+  LayoutContribution,
+  RouteContribution,
+  RouteParentId,
+} from '#contract.js';
+import {anchorPaths} from '#runtime/anchor-paths.js';
+import {LayoutCompositionError, RouteCompositionError} from './errors.js';
 import {normalizeRoutePath} from './normalize-route-path.js';
+
+export interface ComposedLayout extends LayoutContribution {
+  featureId: string;
+}
 
 export interface ComposedRoute extends RouteContribution {
   featureId: string;
   ownerFeatureId: string;
 }
 
-export function composeRoutes(features: readonly ClientFeature[]): ComposedRoute[] {
+function isShellAnchor(parent: RouteParentId): parent is AnchorId {
+  return Object.hasOwn(anchorPaths, parent);
+}
+
+function layoutParentPath(
+  parent: RouteParentId,
+  layouts: ReadonlyMap<string, ComposedLayout>,
+): string | undefined {
+  if (isShellAnchor(parent)) return anchorPaths[parent];
+  return layouts.get(parent)?.path;
+}
+
+function resolvedShellAnchor(
+  parent: RouteParentId,
+  layouts: ReadonlyMap<string, ComposedLayout>,
+): AnchorId | undefined {
+  let current = parent;
+  const visited = new Set<string>();
+  while (!isShellAnchor(current)) {
+    if (visited.has(current)) return undefined;
+    visited.add(current);
+    const next = layouts.get(current)?.parent;
+    if (next === undefined) return undefined;
+    current = next;
+  }
+  return current;
+}
+
+function validateNestedRoute(
+  path: string,
+  parent: RouteParentId,
+  layouts: ReadonlyMap<string, ComposedLayout>,
+  featureId: string,
+): void {
+  if (resolvedShellAnchor(parent, layouts) === 'root') {
+    const protectedAnchor = protectedAnchorForRootPath(path);
+    if (protectedAnchor) {
+      const [anchor, anchorPath] = protectedAnchor;
+      throw new RouteCompositionError(
+        path,
+        `Route "${path}" in feature "${featureId}" cannot use root parent inside reserved anchor "${anchor}" (${anchorPath}). Use parent "${anchor}".`,
+        [featureId],
+      );
+    }
+  }
+  const parentPath = layoutParentPath(parent, layouts);
+  if (!parentPath) {
+    if (isShellAnchor(parent)) return;
+    throw new RouteCompositionError(
+      path,
+      `Route "${path}" in feature "${featureId}" targets missing layout parent "${parent}".`,
+      [featureId],
+    );
+  }
+  if (parentPath !== '/' && path !== parentPath && !path.startsWith(`${parentPath}/`)) {
+    const parentKind = isShellAnchor(parent) ? 'anchor' : 'layout';
+    throw new RouteCompositionError(
+      path,
+      `Route "${path}" must be nested under ${parentKind} "${parent}" (${parentPath}).`,
+      [featureId],
+    );
+  }
+}
+
+const anchorPathValues: ReadonlySet<string> = new Set(Object.values(anchorPaths));
+const protectedAnchorPaths = Object.entries(anchorPaths)
+  .filter(([anchor]) => anchor !== 'root')
+  .sort(([, leftPath], [, rightPath]) => rightPath.length - leftPath.length) as Array<
+  [Exclude<AnchorId, 'root'>, string]
+>;
+
+function protectedAnchorForRootPath(
+  path: string,
+): readonly [Exclude<AnchorId, 'root'>, string] | undefined {
+  return protectedAnchorPaths.find(
+    ([, anchorPath]) => path === anchorPath || path.startsWith(`${anchorPath}/`),
+  );
+}
+
+function validateLayoutParents(layouts: readonly ComposedLayout[]): Map<string, ComposedLayout> {
+  const byId = new Map<string, ComposedLayout>();
+  for (const layout of layouts) {
+    if (isShellAnchor(layout.id)) {
+      throw new LayoutCompositionError(
+        layout.id,
+        `Layout id "${layout.id}" in feature "${layout.featureId}" is reserved by the shell.`,
+        [layout.featureId],
+      );
+    }
+    if (anchorPathValues.has(layout.path)) {
+      throw new LayoutCompositionError(
+        layout.id,
+        `Layout "${layout.id}" in feature "${layout.featureId}" targets path "${layout.path}" which is reserved by a shell anchor.`,
+        [layout.featureId],
+      );
+    }
+    const existing = byId.get(layout.id);
+    if (existing) {
+      throw new LayoutCompositionError(
+        layout.id,
+        `Layout id "${layout.id}" is contributed by both features "${existing.featureId}" and "${layout.featureId}".`,
+        [existing.featureId, layout.featureId],
+      );
+    }
+    byId.set(layout.id, layout);
+  }
+
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+  function visit(layout: ComposedLayout): void {
+    if (visited.has(layout.id) || isShellAnchor(layout.parent)) return;
+    if (visiting.has(layout.id)) {
+      throw new LayoutCompositionError(
+        layout.id,
+        `Layout "${layout.id}" in feature "${layout.featureId}" has a cyclic parent reference.`,
+        [layout.featureId],
+      );
+    }
+    const parent = byId.get(layout.parent);
+    if (!parent) {
+      throw new LayoutCompositionError(
+        layout.id,
+        `Layout "${layout.id}" in feature "${layout.featureId}" targets missing layout parent "${layout.parent}".`,
+        [layout.featureId],
+      );
+    }
+    visiting.add(layout.id);
+    visit(parent);
+    visiting.delete(layout.id);
+    visited.add(layout.id);
+  }
+
+  for (const layout of layouts) visit(layout);
+  return byId;
+}
+
+export function composeLayouts(features: readonly ClientFeature[]): ComposedLayout[] {
+  const layouts = features.flatMap((feature) =>
+    (feature.layouts ?? []).map((layout) => ({
+      ...layout,
+      path: normalizeRoutePath(layout.path),
+      featureId: feature.id,
+    })),
+  );
+  validateLayoutParents(layouts);
+  for (const layout of layouts) {
+    validateNestedRoute(
+      layout.path,
+      layout.parent,
+      new Map(layouts.map((item) => [item.id, item])),
+      layout.featureId,
+    );
+  }
+  return layouts;
+}
+
+export function composeRoutes(
+  features: readonly ClientFeature[],
+  providedLayouts?: readonly ComposedLayout[],
+): ComposedRoute[] {
+  const layouts = providedLayouts ? [...providedLayouts] : composeLayouts(features);
+  const layoutById = validateLayoutParents(layouts);
+  const layoutPaths = new Map<string, ComposedLayout>();
+  for (const layout of layouts) {
+    const existing = layoutPaths.get(layout.path);
+    if (existing) {
+      throw new RouteCompositionError(
+        layout.path,
+        `Route "${layout.path}" is contributed by both features "${existing.featureId}" and "${layout.featureId}".`,
+        [existing.featureId, layout.featureId],
+      );
+    }
+    layoutPaths.set(layout.path, layout);
+  }
+
   const routes = new Map<string, ComposedRoute>();
   for (const feature of features) {
     for (const contribution of feature.routes ?? []) {
@@ -15,6 +200,16 @@ export function composeRoutes(features: readonly ClientFeature[]): ComposedRoute
         ...contribution,
         path: normalizeRoutePath(contribution.path),
       };
+      const layoutAtPath = layoutPaths.get(normalizedContribution.path);
+      if (layoutAtPath) {
+        const message = normalizedContribution.override
+          ? `Route override for "${normalizedContribution.path}" from feature "${feature.id}" cannot replace layout "${layoutAtPath.id}" contributed by feature "${layoutAtPath.featureId}".`
+          : `Route "${normalizedContribution.path}" is contributed by both features "${layoutAtPath.featureId}" and "${feature.id}". Set override: true to replace it explicitly.`;
+        throw new RouteCompositionError(normalizedContribution.path, message, [
+          layoutAtPath.featureId,
+          feature.id,
+        ]);
+      }
       const existing = routes.get(normalizedContribution.path);
       if (!existing) {
         if (normalizedContribution.override) {
@@ -58,6 +253,13 @@ export function composeRoutes(features: readonly ClientFeature[]): ComposedRoute
         ownerFeatureId: existing.ownerFeatureId,
       });
     }
+  }
+
+  for (const layout of layouts) {
+    validateNestedRoute(layout.path, layout.parent, layoutById, layout.featureId);
+  }
+  for (const route of routes.values()) {
+    validateNestedRoute(route.path, route.parent, layoutById, route.featureId);
   }
   return [...routes.values()];
 }

--- a/libs/client/shell/src/compose/errors.ts
+++ b/libs/client/shell/src/compose/errors.ts
@@ -17,6 +17,15 @@ export class RouteCompositionError extends CompositionError {
   }
 }
 
+export class LayoutCompositionError extends CompositionError {
+  public readonly id: string;
+
+  constructor(id: string, message: string, featureIds: readonly string[]) {
+    super('LayoutCompositionError', message, featureIds);
+    this.id = id;
+  }
+}
+
 export class ProviderCompositionError extends CompositionError {
   public readonly id: string;
 

--- a/libs/client/shell/src/compose/validate-registries.test.ts
+++ b/libs/client/shell/src/compose/validate-registries.test.ts
@@ -1,3 +1,4 @@
+import type {ClientFeature} from '#contract.js';
 import {composeLayouts, composeRoutes} from './compose-routes.js';
 import {validateNavigation, validateSettingsSections} from './validate-registries.js';
 
@@ -79,6 +80,25 @@ describe('registry validation', () => {
     ];
     expect(() => validateNavigation(invalidRole, ['/admin'])).toThrow(
       'Navigation entry "admin.users" in feature "acme.users" has invalid minimum role metadata.',
+    );
+  });
+
+  test('rejects role metadata on untyped non-layout navigation', () => {
+    const feature = {
+      id: 'acme.users',
+      navigation: [
+        {
+          id: 'users',
+          scope: 'workspace',
+          label: 'Users',
+          to: '/users',
+          minimumRole: 'observer',
+        },
+      ],
+    } as unknown as ClientFeature;
+
+    expect(() => validateNavigation([feature], ['/users'])).toThrow(
+      'Navigation entry "users" in feature "acme.users" has minimum role metadata but is not layout-scoped.',
     );
   });
 

--- a/libs/client/shell/src/compose/validate-registries.test.ts
+++ b/libs/client/shell/src/compose/validate-registries.test.ts
@@ -1,4 +1,4 @@
-import {composeRoutes} from './compose-routes.js';
+import {composeLayouts, composeRoutes} from './compose-routes.js';
 import {validateNavigation, validateSettingsSections} from './validate-registries.js';
 
 const duplicateNavigationMessage = /projects.*shipfox\.one.*acme\.two/u;
@@ -7,6 +7,111 @@ const duplicateSettingsMessage = /members.*shipfox\.one.*acme\.two/u;
 const missingSettingsMessage = /sso.*acme\.two.*\/workspaces\/\$wid\/settings\/sso/u;
 
 describe('registry validation', () => {
+  test('accepts child navigation scoped to a feature-owned layout', () => {
+    const features = [
+      {
+        id: 'acme.admin',
+        layouts: [
+          {id: 'acme.admin.layout', path: '/admin', parent: 'root' as const, impl: 'admin'},
+          {
+            id: 'acme.admin.settings',
+            path: '/admin/settings',
+            parent: 'acme.admin.layout',
+            impl: 'settings',
+          },
+        ],
+      },
+      {
+        id: 'acme.users',
+        routes: [{path: '/admin/settings/users', parent: 'acme.admin.settings', impl: 'users'}],
+        navigation: [
+          {
+            id: 'admin.users',
+            scope: 'layout' as const,
+            layout: 'acme.admin.layout',
+            label: 'Users',
+            to: '/admin/settings/users',
+            minimumRole: 'observer',
+          },
+        ],
+      },
+    ];
+    const layouts = composeLayouts(features);
+    const routes = composeRoutes(features, layouts);
+
+    expect(() => validateNavigation(features, routes, layouts)).not.toThrow();
+  });
+
+  test('names missing layout and invalid role metadata', () => {
+    const missingLayout = [
+      {
+        id: 'acme.users',
+        navigation: [
+          {
+            id: 'admin.users',
+            scope: 'layout' as const,
+            layout: 'acme.missing',
+            label: 'Users',
+            to: '/admin/users',
+          },
+        ],
+      },
+    ];
+    expect(() => validateNavigation(missingLayout, ['/admin/users'])).toThrow(
+      'Navigation entry "admin.users" in feature "acme.users" targets missing layout "acme.missing".',
+    );
+
+    const invalidRole = [
+      {
+        id: 'acme.users',
+        layouts: [{id: 'acme.admin.layout', path: '/admin', parent: 'root', impl: 'admin'}],
+        navigation: [
+          {
+            id: 'admin.users',
+            scope: 'layout' as const,
+            layout: 'acme.admin.layout',
+            label: 'Users',
+            to: '/admin',
+            minimumRole: '   ',
+          },
+        ],
+      },
+    ];
+    expect(() => validateNavigation(invalidRole, ['/admin'])).toThrow(
+      'Navigation entry "admin.users" in feature "acme.users" has invalid minimum role metadata.',
+    );
+  });
+
+  test('rejects layout navigation outside the declared layout subtree', () => {
+    const features = [
+      {
+        id: 'acme.admin',
+        layouts: [
+          {id: 'acme.admin.layout', path: '/admin', parent: 'root' as const, impl: 'admin'},
+        ],
+      },
+      {
+        id: 'acme.users',
+        routes: [{path: '/users', parent: 'root' as const, impl: 'users'}],
+        navigation: [
+          {
+            id: 'admin.users',
+            scope: 'layout' as const,
+            layout: 'acme.admin.layout',
+            label: 'Users',
+            to: '/users',
+          },
+        ],
+      },
+    ];
+
+    expect(() =>
+      validateNavigation(features, composeRoutes(features), composeLayouts(features)),
+    ).toThrow(
+      'Navigation entry "admin.users" in feature "acme.users" targets route "/users" outside layout "acme.admin.layout".',
+    );
+  });
+
   test('names the id and both features for a duplicate navigation entry', () => {
     expect(() =>
       validateNavigation(

--- a/libs/client/shell/src/compose/validate-registries.ts
+++ b/libs/client/shell/src/compose/validate-registries.ts
@@ -1,4 +1,4 @@
-import type {ClientFeature} from '#contract.js';
+import type {ClientFeature, NavTabEntry, RouteParentId} from '#contract.js';
 import {NavCompositionError, SettingsCompositionError} from './errors.js';
 import {normalizeRoutePath} from './normalize-route-path.js';
 
@@ -6,9 +6,17 @@ interface RouteReference {
   path: string;
   featureId?: string;
   ownerFeatureId?: string;
+  parent?: RouteParentId;
 }
 
 type RouteReferences = Iterable<string | RouteReference>;
+
+interface LayoutReference {
+  id: string;
+  path: string;
+  featureId?: string;
+  parent?: RouteParentId;
+}
 
 function routeOwners(routeReferences: RouteReferences): Map<string, string | undefined> {
   const owners = new Map<string, string | undefined>();
@@ -26,14 +34,38 @@ function hasExplicitCoordinator(feature: ClientFeature): boolean {
   return feature.coordinator === feature.id;
 }
 
+function validateRoleMetadata(entry: NavTabEntry, feature: ClientFeature): void {
+  if (entry.scope !== 'layout') return;
+  if ('minimumRole' in entry && entry.minimumRole !== undefined) {
+    if (typeof entry.minimumRole !== 'string' || entry.minimumRole.trim() === '') {
+      throw new NavCompositionError(
+        entry.id,
+        `Navigation entry "${entry.id}" in feature "${feature.id}" has invalid minimum role metadata. Expected a non-empty string.`,
+        [feature.id],
+      );
+    }
+  }
+}
+
 export function validateNavigation(
   features: readonly ClientFeature[],
   routeReferences: RouteReferences,
+  layoutReferences: readonly LayoutReference[] = [],
 ): void {
-  const routes = routeOwners(routeReferences);
+  const routeReferencesWithLayouts: Array<string | RouteReference> = [...routeReferences];
+  for (const layout of layoutReferences) {
+    routeReferencesWithLayouts.push({
+      path: layout.path,
+      ...(layout.featureId ? {featureId: layout.featureId, ownerFeatureId: layout.featureId} : {}),
+      ...(layout.parent ? {parent: layout.parent} : {}),
+    });
+  }
+  const routes = routeOwners(routeReferencesWithLayouts);
+  const layouts = new Map(layoutReferences.map((layout) => [layout.id, layout]));
   const entries = new Map<string, string>();
   for (const feature of features) {
     for (const entry of feature.navigation ?? []) {
+      validateRoleMetadata(entry, feature);
       const existingFeatureId = entries.get(entry.id);
       if (existingFeatureId) {
         throw new NavCompositionError(
@@ -51,6 +83,35 @@ export function validateNavigation(
           [feature.id],
         );
       }
+      if (entry.scope === 'layout') {
+        if (typeof entry.layout !== 'string' || entry.layout.trim() === '') {
+          throw new NavCompositionError(
+            entry.id,
+            `Navigation entry "${entry.id}" in feature "${feature.id}" has invalid layout metadata. Expected a non-empty layout id.`,
+            [feature.id],
+          );
+        }
+        const layout = layouts.get(entry.layout);
+        if (!layout) {
+          throw new NavCompositionError(
+            entry.id,
+            `Navigation entry "${entry.id}" in feature "${feature.id}" targets missing layout "${entry.layout}".`,
+            [feature.id],
+          );
+        }
+        const route = routeReferencesForPath(routeReferencesWithLayouts, target);
+        const isLayoutRoot = route?.path === layout.path;
+        const isLayoutDescendant = routeDescendsFromLayout(route, entry.layout, layouts);
+        if (!isLayoutRoot && !isLayoutDescendant) {
+          throw new NavCompositionError(
+            entry.id,
+            `Navigation entry "${entry.id}" in feature "${feature.id}" targets route "${target}" outside layout "${entry.layout}".`,
+            [feature.id],
+          );
+        }
+        entries.set(entry.id, feature.id);
+        continue;
+      }
       if (routeOwner && routeOwner !== feature.id && !hasExplicitCoordinator(feature)) {
         throw new NavCompositionError(
           entry.id,
@@ -61,6 +122,32 @@ export function validateNavigation(
       entries.set(entry.id, feature.id);
     }
   }
+}
+
+function routeReferencesForPath(
+  routeReferences: RouteReferences,
+  path: string,
+): RouteReference | undefined {
+  for (const route of routeReferences) {
+    const reference = typeof route === 'string' ? {path: route} : route;
+    if (normalizeRoutePath(reference.path) === path) return reference;
+  }
+  return undefined;
+}
+
+function routeDescendsFromLayout(
+  route: RouteReference | undefined,
+  layoutId: string,
+  layouts: ReadonlyMap<string, LayoutReference>,
+): boolean {
+  const visited = new Set<string>();
+  let parent = route?.parent;
+  while (parent && !visited.has(parent)) {
+    if (parent === layoutId) return true;
+    visited.add(parent);
+    parent = layouts.get(parent)?.parent;
+  }
+  return false;
 }
 
 export function validateSettingsSections(

--- a/libs/client/shell/src/compose/validate-registries.ts
+++ b/libs/client/shell/src/compose/validate-registries.ts
@@ -35,9 +35,20 @@ function hasExplicitCoordinator(feature: ClientFeature): boolean {
 }
 
 function validateRoleMetadata(entry: NavTabEntry, feature: ClientFeature): void {
-  if (entry.scope !== 'layout') return;
-  if ('minimumRole' in entry && entry.minimumRole !== undefined) {
-    if (typeof entry.minimumRole !== 'string' || entry.minimumRole.trim() === '') {
+  const rawEntry = entry as NavTabEntry & {minimumRole?: unknown};
+  const hasMinimumRole = Object.hasOwn(rawEntry, 'minimumRole');
+  if (entry.scope !== 'layout') {
+    if (hasMinimumRole) {
+      throw new NavCompositionError(
+        entry.id,
+        `Navigation entry "${entry.id}" in feature "${feature.id}" has minimum role metadata but is not layout-scoped.`,
+        [feature.id],
+      );
+    }
+    return;
+  }
+  if (hasMinimumRole) {
+    if (typeof rawEntry.minimumRole !== 'string' || rawEntry.minimumRole.trim() === '') {
       throw new NavCompositionError(
         entry.id,
         `Navigation entry "${entry.id}" in feature "${feature.id}" has invalid minimum role metadata. Expected a non-empty string.`,

--- a/libs/client/shell/src/contract.ts
+++ b/libs/client/shell/src/contract.ts
@@ -4,10 +4,20 @@ import type {z} from 'zod';
 
 export type AnchorId = 'root' | 'workspaceLayout' | 'projectLayout' | 'workspaceSettings';
 
+/** A fixed shell anchor or the stable id of a feature-owned layout. */
+export type RouteParentId = AnchorId | (string & {});
+
 export interface RouteContribution {
   path: string;
-  parent: AnchorId;
+  parent: RouteParentId;
   override?: boolean;
+  impl: string;
+}
+
+export interface LayoutContribution {
+  id: string;
+  path: string;
+  parent: RouteParentId;
   impl: string;
 }
 
@@ -16,14 +26,19 @@ export interface FeatureProvider {
   Component: ComponentType<PropsWithChildren>;
 }
 
-export interface NavTabEntry {
+interface NavTabEntryBase {
   id: string;
-  scope: 'workspace' | 'project';
   label: string;
   to: string;
   exact?: boolean;
   order?: number;
 }
+
+export type NavTabEntry =
+  | (NavTabEntryBase & {scope: 'workspace' | 'project'; layout?: never})
+  | (NavTabEntryBase & {scope: 'layout'; layout: string; minimumRole?: string});
+
+export type LayoutNavigationEntry = Extract<NavTabEntry, {scope: 'layout'}>;
 
 export interface SettingsSectionEntry {
   id: string;
@@ -41,6 +56,7 @@ export interface ClientFeature<S extends z.ZodRawShape = z.ZodRawShape> {
    * feature.
    */
   coordinator?: string;
+  layouts?: readonly LayoutContribution[];
   routes?: readonly RouteContribution[];
   providers?: readonly FeatureProvider[];
   navigation?: readonly NavTabEntry[];

--- a/libs/client/shell/src/runtime/anchor-paths.ts
+++ b/libs/client/shell/src/runtime/anchor-paths.ts
@@ -1,3 +1,6 @@
+import {normalizeRoutePath} from '#compose/normalize-route-path.js';
+import type {RouteParentId} from '#contract.js';
+
 const anchorPaths = {
   root: '/',
   workspaceLayout: '/workspaces/$wid',
@@ -15,4 +18,27 @@ export function routePathForAnchor(anchor: keyof typeof anchorPaths, fullPath: s
     throw new Error(`Route "${fullPath}" must be nested under anchor "${anchor}" (${anchorPath}).`);
   }
   return fullPath.slice(anchorPath.length);
+}
+
+export function routePathForParent(
+  parent: RouteParentId,
+  fullPath: string,
+  layoutPaths: ReadonlyMap<string, string> = new Map(),
+): string {
+  const normalizedPath = normalizeRoutePath(fullPath);
+  const parentPath = Object.hasOwn(anchorPaths, parent)
+    ? anchorPaths[parent as keyof typeof anchorPaths]
+    : layoutPaths.get(parent);
+  if (!parentPath) {
+    throw new Error(`Route "${normalizedPath}" targets missing layout parent "${parent}".`);
+  }
+  if (parentPath === '/') return normalizedPath;
+  if (normalizedPath === parentPath) return '/';
+  if (parentPath !== '/' && !normalizedPath.startsWith(`${parentPath}/`)) {
+    const parentKind = Object.hasOwn(anchorPaths, parent) ? 'anchor' : 'layout';
+    throw new Error(
+      `Route "${normalizedPath}" must be nested under ${parentKind} "${parent}" (${parentPath}).`,
+    );
+  }
+  return normalizedPath.slice(parentPath.length);
 }

--- a/libs/client/shell/src/runtime/assemble-route-tree.ts
+++ b/libs/client/shell/src/runtime/assemble-route-tree.ts
@@ -1,42 +1,127 @@
-import {createRoute} from '@tanstack/react-router';
-import type {ComposedRoute} from '#compose/compose-routes.js';
-import {buildAnchorSkeleton, routePathForAnchor} from '#runtime/anchors.js';
+import {type AnyRoute, createRoute} from '@tanstack/react-router';
+import type {ComposedLayout, ComposedRoute} from '#compose/compose-routes.js';
+import type {RouteParentId} from '#contract.js';
+import {routePathForParent} from '#runtime/anchor-paths.js';
+import {buildAnchorSkeleton} from '#runtime/anchors.js';
 import type {RouteImpl} from '#runtime/define-route.js';
 
 export type ResolveRouteImpl = (specifier: string) => RouteImpl | Promise<RouteImpl>;
 
+const shellAnchors = ['root', 'workspaceLayout', 'projectLayout', 'workspaceSettings'] as const;
+
+function isShellAnchor(parent: RouteParentId): parent is (typeof shellAnchors)[number] {
+  return shellAnchors.includes(parent as (typeof shellAnchors)[number]);
+}
+
+function orderLayouts(layouts: readonly ComposedLayout[]): ComposedLayout[] {
+  const byId = new Map(layouts.map((layout) => [layout.id, layout]));
+  const ordered: ComposedLayout[] = [];
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+
+  function visit(layout: ComposedLayout): void {
+    if (visited.has(layout.id)) return;
+    if (!isShellAnchor(layout.parent)) {
+      if (visiting.has(layout.id))
+        throw new Error(`Layout "${layout.id}" has a cyclic parent reference.`);
+      const parent = byId.get(layout.parent);
+      if (!parent)
+        throw new Error(`Layout "${layout.id}" targets missing parent "${layout.parent}".`);
+      visiting.add(layout.id);
+      visit(parent);
+      visiting.delete(layout.id);
+    }
+    visited.add(layout.id);
+    ordered.push(layout);
+  }
+
+  for (const layout of layouts) visit(layout);
+  return ordered;
+}
+
 export async function assembleRouteTree(
   routes: readonly ComposedRoute[],
   options: {
+    layouts?: readonly ComposedLayout[];
     resolveImpl: ResolveRouteImpl;
     navigation: Parameters<typeof buildAnchorSkeleton>[0]['navigation'];
     settingsSections: Parameters<typeof buildAnchorSkeleton>[0]['settingsSections'];
   },
 ) {
+  const layouts = orderLayouts(options.layouts ?? []);
+  const layoutPaths = new Map(layouts.map((layout) => [layout.id, layout.path]));
   const skeleton = buildAnchorSkeleton(options);
-  const children = await Promise.all(
+  const layoutRoutes = new Map<string, AnyRoute>();
+
+  for (const layout of layouts) {
+    const impl = await options.resolveImpl(layout.impl);
+    const parentRoute = isShellAnchor(layout.parent)
+      ? skeleton.anchors[layout.parent]
+      : layoutRoutes.get(layout.parent);
+    if (!parentRoute) throw new Error(`Missing layout parent "${layout.parent}".`);
+    layoutRoutes.set(
+      layout.id,
+      createRoute({
+        getParentRoute: () => parentRoute as never,
+        path: routePathForParent(layout.parent, layout.path, layoutPaths),
+        ...impl.options,
+      } as never) as unknown as AnyRoute,
+    );
+  }
+
+  const routeEntries: Array<{parent: RouteParentId; route: AnyRoute}> = await Promise.all(
     routes.map(async (route) => {
       const impl = await options.resolveImpl(route.impl);
+      const parentRoute = isShellAnchor(route.parent)
+        ? skeleton.anchors[route.parent]
+        : layoutRoutes.get(route.parent);
+      if (!parentRoute) throw new Error(`Missing route parent "${route.parent}".`);
       return {
         parent: route.parent,
         route: createRoute({
-          getParentRoute: () => skeleton.anchors[route.parent] as never,
-          path: routePathForAnchor(route.parent, route.path),
+          getParentRoute: () => parentRoute as never,
+          path: routePathForParent(route.parent, route.path, layoutPaths),
           ...impl.options,
-        } as never),
+        } as never) as unknown as AnyRoute,
       };
     }),
   );
-  const childrenFor = (anchor: keyof typeof skeleton.anchors) =>
-    children.filter((child) => child.parent === anchor).map((child) => child.route);
-  const projectLayout = skeleton.projectLayout.addChildren(childrenFor('projectLayout'));
+
+  const routeChildrenFor = (parent: RouteParentId) =>
+    routeEntries.filter((entry) => entry.parent === parent).map((entry) => entry.route);
+  const layoutTrees = new Map<string, AnyRoute>();
+  function layoutTree(layoutId: string): AnyRoute {
+    const existing = layoutTrees.get(layoutId);
+    if (existing) return existing;
+    const layout = layouts.find((candidate) => candidate.id === layoutId);
+    const route = layoutRoutes.get(layoutId);
+    if (!layout || !route) throw new Error(`Missing layout "${layoutId}".`);
+    const children = [
+      ...routeChildrenFor(layoutId),
+      ...layouts
+        .filter((candidate) => candidate.parent === layoutId)
+        .map((candidate) => layoutTree(candidate.id)),
+    ];
+    const tree = route.addChildren(children as never) as unknown as AnyRoute;
+    layoutTrees.set(layoutId, tree);
+    return tree;
+  }
+
+  const childrenFor = (parent: RouteParentId) => [
+    ...routeChildrenFor(parent),
+    ...layouts.filter((layout) => layout.parent === parent).map((layout) => layoutTree(layout.id)),
+  ];
+  const projectLayout = skeleton.projectLayout.addChildren(childrenFor('projectLayout') as never);
   const workspaceSettings = skeleton.workspaceSettings.addChildren(
-    childrenFor('workspaceSettings'),
+    childrenFor('workspaceSettings') as never,
   );
   const workspaceLayout = skeleton.workspaceLayout.addChildren([
     ...childrenFor('workspaceLayout'),
     projectLayout,
     workspaceSettings,
-  ]);
-  return skeleton.rootRoute.addChildren([...childrenFor('root'), workspaceLayout]);
+  ] as never);
+  return skeleton.rootRoute.addChildren([
+    ...childrenFor('root'),
+    workspaceLayout,
+  ] as never) as unknown as typeof skeleton.rootRoute;
 }

--- a/libs/client/shell/src/runtime/index.ts
+++ b/libs/client/shell/src/runtime/index.ts
@@ -23,6 +23,7 @@ export * from './chrome-context.js';
 export * from './compose-client-app.js';
 export * from './define-route.js';
 export * from './last-workspace.js';
+export * from './layout-navigation.js';
 export * from './nav-order.js';
 export * from './route-inputs.js';
 export * from './router-context.js';

--- a/libs/client/shell/src/runtime/layout-navigation.tsx
+++ b/libs/client/shell/src/runtime/layout-navigation.tsx
@@ -1,0 +1,22 @@
+import type {PropsWithChildren} from 'react';
+import {createContext, useContext, useMemo} from 'react';
+import type {ClientFeature, LayoutNavigationEntry} from '#contract.js';
+import {layoutNavigationRegistry} from './registries.js';
+
+type LayoutNavigationRegistry = ReadonlyMap<string, readonly LayoutNavigationEntry[]>;
+
+const LayoutNavigationContext = createContext<LayoutNavigationRegistry>(new Map());
+
+export function LayoutNavigationProvider({
+  features,
+  children,
+}: PropsWithChildren<{features: readonly ClientFeature[]}>) {
+  const registry = useMemo(() => layoutNavigationRegistry(features), [features]);
+  return (
+    <LayoutNavigationContext.Provider value={registry}>{children}</LayoutNavigationContext.Provider>
+  );
+}
+
+export function useLayoutNavigation(layoutId: string): readonly LayoutNavigationEntry[] {
+  return useContext(LayoutNavigationContext).get(layoutId) ?? [];
+}

--- a/libs/client/shell/src/runtime/provider-stack.tsx
+++ b/libs/client/shell/src/runtime/provider-stack.tsx
@@ -5,6 +5,7 @@ import {type createStore, Provider as JotaiProvider} from 'jotai';
 import type {PropsWithChildren, ReactNode} from 'react';
 import type {ClientFeature} from '#contract.js';
 import {AuthRuntime, type AuthRuntimeProps} from './auth.js';
+import {LayoutNavigationProvider} from './layout-navigation.js';
 
 type Store = ReturnType<typeof createStore>;
 
@@ -30,7 +31,9 @@ export function ShellProviderStack({
       <TooltipProvider>
         <QueryClientProvider client={queryClient}>
           <JotaiProvider store={store}>
-            <AuthRuntime {...auth}>{nestedProviders}</AuthRuntime>
+            <LayoutNavigationProvider features={features}>
+              <AuthRuntime {...auth}>{nestedProviders}</AuthRuntime>
+            </LayoutNavigationProvider>
           </JotaiProvider>
         </QueryClientProvider>
       </TooltipProvider>

--- a/libs/client/shell/src/runtime/registries.ts
+++ b/libs/client/shell/src/runtime/registries.ts
@@ -1,5 +1,10 @@
 import {normalizeRoutePath} from '#compose/normalize-route-path.js';
-import type {ClientFeature, NavTabEntry, SettingsSectionEntry} from '#contract.js';
+import type {
+  ClientFeature,
+  LayoutNavigationEntry,
+  NavTabEntry,
+  SettingsSectionEntry,
+} from '#contract.js';
 
 interface Ordered<T> {
   entry: T;
@@ -26,6 +31,19 @@ export function navigationEntries(features: readonly ClientFeature[]): NavTabEnt
     )
     .sort(byOrder)
     .map(({entry}) => ({...entry, to: normalizeRoutePath(entry.to)}));
+}
+
+export function layoutNavigationRegistry(
+  features: readonly ClientFeature[],
+): ReadonlyMap<string, readonly LayoutNavigationEntry[]> {
+  const registry = new Map<string, LayoutNavigationEntry[]>();
+  for (const entry of navigationEntries(features)) {
+    if (entry.scope !== 'layout') continue;
+    const entries = registry.get(entry.layout) ?? [];
+    entries.push(entry);
+    registry.set(entry.layout, entries);
+  }
+  return registry;
 }
 
 export function settingsEntries(features: readonly ClientFeature[]): SettingsSectionEntry[] {

--- a/libs/client/shell/src/runtime/routes.test.tsx
+++ b/libs/client/shell/src/runtime/routes.test.tsx
@@ -1,7 +1,9 @@
+import {Link, Outlet} from '@tanstack/react-router';
 import {screen} from '@testing-library/react';
 import {defineClientFeature} from '#contract.js';
 import {renderComposedShell} from '#test/render.js';
 import {defineRoute} from './define-route.js';
+import {useLayoutNavigation} from './layout-navigation.js';
 
 describe('composed routes', () => {
   test('renders a feature-added route through memory history', async () => {
@@ -44,5 +46,72 @@ describe('composed routes', () => {
 
     expect(await screen.findByRole('heading', {name: 'Commercial projects'})).toBeVisible();
     expect(screen.queryByText('Upstream projects')).not.toBeInTheDocument();
+  });
+
+  test('renders deterministic navigation supplied by child features to a layout', async () => {
+    const features = [
+      defineClientFeature({
+        id: 'acme.admin',
+        layouts: [{id: 'acme.admin.layout', path: '/admin', parent: 'root', impl: 'layout'}],
+      }),
+      defineClientFeature({
+        id: 'acme.users',
+        routes: [{path: '/admin/users', parent: 'acme.admin.layout', impl: 'users'}],
+        navigation: [
+          {
+            id: 'admin.users',
+            scope: 'layout',
+            layout: 'acme.admin.layout',
+            label: 'Users',
+            to: '/admin/users',
+            order: 200,
+          },
+        ],
+      }),
+      defineClientFeature({
+        id: 'acme.overview',
+        routes: [{path: '/admin/overview', parent: 'acme.admin.layout', impl: 'overview'}],
+        navigation: [
+          {
+            id: 'admin.overview',
+            scope: 'layout',
+            layout: 'acme.admin.layout',
+            label: 'Overview',
+            to: '/admin/overview',
+            order: 100,
+          },
+        ],
+      }),
+    ];
+
+    await renderComposedShell({
+      features,
+      initialPath: '/admin/users',
+      resolveImpl: (specifier) => {
+        if (specifier === 'layout') {
+          return defineRoute({
+            component: () => (
+              <>
+                <nav aria-label="Administration sections">
+                  {useLayoutNavigation('acme.admin.layout').map((entry) => (
+                    <Link key={entry.id} to={entry.to as never}>
+                      {entry.label}
+                    </Link>
+                  ))}
+                </nav>
+                <Outlet />
+              </>
+            ),
+          });
+        }
+        return defineRoute({component: () => <h1>{specifier}</h1>});
+      },
+    });
+
+    expect((await screen.findAllByRole('link')).map((link) => link.textContent)).toEqual([
+      'Overview',
+      'Users',
+    ]);
+    expect(await screen.findByRole('heading', {name: 'users'})).toBeVisible();
   });
 });

--- a/libs/client/shell/src/vite/generate.test.ts
+++ b/libs/client/shell/src/vite/generate.test.ts
@@ -1,6 +1,6 @@
 import {readFile} from 'node:fs/promises';
 import {fileURLToPath} from 'node:url';
-import {composeRoutes} from '#compose/compose-routes.js';
+import {composeLayouts, composeRoutes} from '#compose/compose-routes.js';
 import {navigationEntries, settingsEntries} from '#runtime/registries.js';
 import {features} from '#test/fixtures/features.js';
 import {generateAppModule} from './generate.js';
@@ -18,5 +18,39 @@ describe('generateAppModule', () => {
     });
 
     await expect(readFile(goldenFile, 'utf8')).resolves.toBe(generated);
+  });
+
+  test('declares nested layout trees from child to parent', () => {
+    const nestedFeatures = [
+      {
+        id: 'nested-layouts',
+        layouts: [
+          {id: 'nested.outer', path: '/admin', parent: 'root' as const, impl: 'outer'},
+          {
+            id: 'nested.inner',
+            path: '/admin/settings',
+            parent: 'nested.outer',
+            impl: 'inner',
+          },
+        ],
+        routes: [
+          {
+            path: '/admin/settings/users',
+            parent: 'nested.inner',
+            impl: 'users',
+          },
+        ],
+      },
+    ];
+    const generated = generateAppModule({
+      layouts: composeLayouts(nestedFeatures),
+      routes: composeRoutes(nestedFeatures),
+      navigation: [],
+      settingsSections: [],
+    });
+
+    expect(generated.indexOf('const layout1Tree')).toBeLessThan(
+      generated.indexOf('const layout0Tree'),
+    );
   });
 });

--- a/libs/client/shell/src/vite/generate.ts
+++ b/libs/client/shell/src/vite/generate.ts
@@ -1,8 +1,9 @@
-import type {ComposedRoute} from '#compose/compose-routes.js';
-import type {NavTabEntry, SettingsSectionEntry} from '#contract.js';
-import {routePathForAnchor} from '#runtime/anchor-paths.js';
+import type {ComposedLayout, ComposedRoute} from '#compose/compose-routes.js';
+import type {NavTabEntry, RouteParentId, SettingsSectionEntry} from '#contract.js';
+import {routePathForParent} from '#runtime/anchor-paths.js';
 
 export interface GenerateAppModuleOptions {
+  layouts?: readonly ComposedLayout[];
   routes: readonly ComposedRoute[];
   navigation: readonly NavTabEntry[];
   settingsSections: readonly SettingsSectionEntry[];
@@ -16,7 +17,39 @@ function indentedLiteral(value: unknown, indentation: number): string {
   return literal(value).replaceAll('\n', `\n${' '.repeat(indentation)}`);
 }
 
-function routeNames(routes: readonly ComposedRoute[], parent: ComposedRoute['parent']): string {
+function isShellAnchor(parent: RouteParentId): boolean {
+  return ['root', 'workspaceLayout', 'projectLayout', 'workspaceSettings'].includes(parent);
+}
+
+function orderedLayouts(layouts: readonly ComposedLayout[]): ComposedLayout[] {
+  const byId = new Map(layouts.map((layout) => [layout.id, layout]));
+  const ordered: ComposedLayout[] = [];
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+
+  function visit(layout: ComposedLayout): void {
+    if (visited.has(layout.id)) return;
+    if (!isShellAnchor(layout.parent)) {
+      if (visiting.has(layout.id)) {
+        throw new Error(`Layout "${layout.id}" has a cyclic parent reference.`);
+      }
+      const parent = byId.get(layout.parent);
+      if (!parent) {
+        throw new Error(`Layout "${layout.id}" targets missing layout parent "${layout.parent}".`);
+      }
+      visiting.add(layout.id);
+      visit(parent);
+      visiting.delete(layout.id);
+    }
+    visited.add(layout.id);
+    ordered.push(layout);
+  }
+
+  for (const layout of layouts) visit(layout);
+  return ordered;
+}
+
+function routeNames(routes: readonly ComposedRoute[], parent: RouteParentId): string {
   return routes
     .map((route, index) => ({route, index}))
     .filter(({route}) => route.parent === parent)
@@ -24,32 +57,95 @@ function routeNames(routes: readonly ComposedRoute[], parent: ComposedRoute['par
     .join(', ');
 }
 
+function layoutTreeNames(layouts: readonly ComposedLayout[], parent: RouteParentId): string[] {
+  return layouts
+    .map((layout, index) => ({layout, index}))
+    .filter(({layout}) => layout.parent === parent)
+    .map(({index}) => `layout${index}Tree`);
+}
+
+function parentExpression(
+  parent: RouteParentId,
+  layoutIndexes: ReadonlyMap<string, number>,
+): string {
+  if (parent === 'root') return 'skeleton.rootRoute';
+  if (isShellAnchor(parent)) return `skeleton.${parent}`;
+  const index = layoutIndexes.get(parent);
+  if (index === undefined) throw new Error(`Missing generated layout parent "${parent}".`);
+  return `layout${index}`;
+}
+
 export function generateAppModule({
+  layouts = [],
   routes,
   navigation,
   settingsSections,
 }: GenerateAppModuleOptions): string {
-  const generatedRoutes = routes.map((route) => ({
-    ...route,
-    routePath: routePathForAnchor(route.parent, route.path),
-  }));
-  const imports = routes
-    .map((route, index) => `import * as route${index}Module from ${literal(route.impl)};`)
-    .join('\n');
-  const routeDeclarations = generatedRoutes
+  const generatedLayouts = orderedLayouts(layouts);
+  const layoutIndexes = new Map(generatedLayouts.map((layout, index) => [layout.id, index]));
+  const layoutPaths = new Map(generatedLayouts.map((layout) => [layout.id, layout.path]));
+  const imports = [
+    ...generatedLayouts.map(
+      (layout, index) => `import * as layout${index}Module from ${literal(layout.impl)};`,
+    ),
+    ...routes.map((route, index) => `import * as route${index}Module from ${literal(route.impl)};`),
+  ].join('\n');
+  const layoutDeclarations = generatedLayouts
+    .map(
+      (layout, index) => `const layout${index} = createRoute({
+  getParentRoute: () => ${parentExpression(layout.parent, layoutIndexes)},
+  path: ${literal(routePathForParent(layout.parent, layout.path, layoutPaths))},
+  ...routeOptions(layout${index}Module.default, ${literal(layout.impl)}, ${literal(layout.path)}),
+});`,
+    )
+    .join('\n\n');
+  const routeDeclarations = routes
     .map(
       (route, index) => `const route${index} = createRoute({
-  getParentRoute: () => ${route.parent === 'root' ? 'skeleton.rootRoute' : `skeleton.${route.parent}`},
-  path: ${literal(route.routePath)},
+  getParentRoute: () => ${parentExpression(route.parent, layoutIndexes)},
+  path: ${literal(routePathForParent(route.parent, route.path, layoutPaths))},
   ...routeOptions(route${index}Module.default, ${literal(route.impl)}, ${literal(route.path)}),
 });`,
     )
     .join('\n\n');
-  const rootRoutes = routeNames(generatedRoutes, 'root');
-  const workspaceLayoutRoutes = routeNames(generatedRoutes, 'workspaceLayout');
-  const projectLayoutRoutes = routeNames(generatedRoutes, 'projectLayout');
-  const workspaceSettingsRoutes = routeNames(generatedRoutes, 'workspaceSettings');
-  const rootChildren = [rootRoutes, 'workspaceLayout'].filter(Boolean).join(',\n  ');
+  const layoutTreeDeclarations = generatedLayouts
+    .map((layout, index) => ({layout, index}))
+    .reverse()
+    .map(({layout, index}) => {
+      const routeChildren = routeNames(routes, layout.id);
+      const children = [routeChildren, ...layoutTreeNames(generatedLayouts, layout.id)]
+        .filter(Boolean)
+        .join(',\n  ');
+      return `const layout${index}Tree = layout${index}.addChildren([${children}]);`;
+    })
+    .join('\n');
+  const declarations = [layoutDeclarations, routeDeclarations, layoutTreeDeclarations]
+    .filter(Boolean)
+    .join('\n\n');
+  const rootRoutes = routeNames(routes, 'root');
+  const rootChildren = [rootRoutes, ...layoutTreeNames(generatedLayouts, 'root'), 'workspaceLayout']
+    .filter(Boolean)
+    .join(',\n  ');
+  const projectChildren = [
+    routeNames(routes, 'projectLayout'),
+    ...layoutTreeNames(generatedLayouts, 'projectLayout'),
+  ]
+    .filter(Boolean)
+    .join(',\n  ');
+  const workspaceSettingsChildren = [
+    routeNames(routes, 'workspaceSettings'),
+    ...layoutTreeNames(generatedLayouts, 'workspaceSettings'),
+  ]
+    .filter(Boolean)
+    .join(',\n  ');
+  const workspaceChildren = [
+    routeNames(routes, 'workspaceLayout'),
+    ...layoutTreeNames(generatedLayouts, 'workspaceLayout'),
+    'projectLayout',
+    'workspaceSettings',
+  ]
+    .filter(Boolean)
+    .join(',\n  ');
 
   return `// GENERATED by @shipfox/client-shell/vite. Do not edit.
 // biome-ignore-all format: generated code has stable, reviewable output.
@@ -70,14 +166,12 @@ const skeleton = buildAnchorSkeleton({
   settingsSections: ${indentedLiteral(settingsSections, 2)},
 });
 
-${routeDeclarations}
+${declarations}
 
-const projectLayout = skeleton.projectLayout.addChildren([${projectLayoutRoutes}]);
-const workspaceSettings = skeleton.workspaceSettings.addChildren([${workspaceSettingsRoutes}]);
+const projectLayout = skeleton.projectLayout.addChildren([${projectChildren}]);
+const workspaceSettings = skeleton.workspaceSettings.addChildren([${workspaceSettingsChildren}]);
 const workspaceLayout = skeleton.workspaceLayout.addChildren([
-  ${workspaceLayoutRoutes}${workspaceLayoutRoutes ? ',' : ''}
-  projectLayout,
-  workspaceSettings,
+  ${workspaceChildren},
 ]);
 
 export const routeTree = skeleton.rootRoute.addChildren([

--- a/libs/client/shell/src/vite/plugin.ts
+++ b/libs/client/shell/src/vite/plugin.ts
@@ -27,8 +27,9 @@ export function shipfoxClientComposition({
   async function assertRoutesResolve(
     resolveRoute: RouteResolver,
     routes: ReturnType<typeof composeClientFeatures>['routes'],
+    layouts: ReturnType<typeof composeClientFeatures>['layouts'],
   ): Promise<void> {
-    for (const route of routes) {
+    for (const route of [...layouts, ...routes]) {
       const resolvedRoute = await resolveRoute(route.impl, outputPath());
       if (!resolvedRoute) {
         throw new Error(
@@ -47,12 +48,13 @@ export function shipfoxClientComposition({
   }): Promise<void> {
     const evaluated = await evaluateFeatures(featuresPath());
     const composition = composeClientFeatures(evaluated.features);
-    await assertRoutesResolve(resolveRoute, composition.routes);
+    await assertRoutesResolve(resolveRoute, composition.routes, composition.layouts);
 
     watchedFiles = new Set(evaluated.loadedFiles);
     for (const file of watchedFiles) addWatchFile(file);
 
     const output = generateAppModule({
+      layouts: composition.layouts,
       routes: composition.routes,
       navigation: composition.navigation,
       settingsSections: composition.settingsSections,

--- a/libs/client/shell/test/external/FINDINGS.md
+++ b/libs/client/shell/test/external/FINDINGS.md
@@ -14,6 +14,7 @@ The fixture proves that:
 - two application-local providers receive the shell query client and Jotai store, then nest in
   declaration order;
 - application navigation and settings data render through the shell-owned registries;
+- a feature-owned layout receives deterministic navigation from child feature contributions;
 - the external config fragment is required, merged, and readable by both providers and the route;
 - the generated router types an application-local `Link` and `useParams` call; and
 - the unapproved login collision fails with the exact normative diagnostic.

--- a/libs/client/shell/test/external/README.md
+++ b/libs/client/shell/test/external/README.md
@@ -1,9 +1,9 @@
 # External client runtime fixture
 
 This fixture packs the published client runtime closure into a Vite application outside the pnpm
-workspace. The application starts from `defaultFeatures()` and adds one external feature that
-replaces the login route, adds a settings route, appends providers, contributes navigation and
-settings entries, and merges a config fragment.
+workspace. The application starts from `defaultFeatures()` and adds external features that replace
+the login route, add a settings route, append providers, contribute navigation and settings entries,
+merge a config fragment, and compose a layout with child routes from a separate feature.
 
 ## Run the required packed gate
 
@@ -21,6 +21,7 @@ that generated package imports are declared direct dependencies, checks default 
 condition resolution through `dist`, type-checks every packed declaration graph, generates the
 composed TanStack router, builds and type-checks the consumer, runs the behavioral fixture, and
 asserts the exact rejected-collision diagnostic. CI runs this command during static verification.
+The fixture also renders deterministic layout-local links from packed public runtime exports.
 
 ## Run the linked iteration mode
 

--- a/libs/client/shell/test/external/fixture/src/app.fixture.tsx
+++ b/libs/client/shell/test/external/fixture/src/app.fixture.tsx
@@ -110,3 +110,21 @@ test('renders the external route, provider order, navigation, settings, and conf
     'Hello from the external fixture',
   );
 });
+
+test('renders layout-local navigation from a separate child feature', async () => {
+  window.__SHIPFOX_CONFIG__ = {EXTERNAL_GREETING: 'Hello from the external fixture'};
+  router.update({
+    history: createMemoryHistory({initialEntries: ['/external-admin/users']}),
+    context: {auth, queryClient: new QueryClient(), workspaceSetup},
+  });
+  await router.load();
+
+  mountClient();
+
+  await vi.waitFor(() => expect(heading('External administration users')).toBeDefined());
+  expect(
+    [...container.querySelectorAll('[aria-label="External administration sections"] a')].map(
+      (link) => link.textContent?.trim(),
+    ),
+  ).toEqual(['Overview', 'Users']);
+});

--- a/libs/client/shell/test/external/fixture/src/features.ts
+++ b/libs/client/shell/test/external/fixture/src/features.ts
@@ -47,4 +47,57 @@ export const externalFeature = defineClientFeature({
   configShape: externalConfigShape,
 });
 
-export const features = [...defaultFeatures(), externalFeature];
+export const externalLayoutFeature = defineClientFeature({
+  id: 'fixture.admin-layout',
+  layouts: [
+    {
+      id: 'fixture.admin-layout',
+      path: '/external-admin',
+      parent: 'root',
+      impl: './features/external-admin-layout',
+    },
+  ],
+});
+
+export const externalLayoutSectionsFeature = defineClientFeature({
+  id: 'fixture.admin-sections',
+  routes: [
+    {
+      path: '/external-admin/overview',
+      parent: 'fixture.admin-layout',
+      impl: './features/external-admin-overview',
+    },
+    {
+      path: '/external-admin/users',
+      parent: 'fixture.admin-layout',
+      impl: './features/external-admin-users',
+    },
+  ],
+  navigation: [
+    {
+      id: 'admin.users',
+      scope: 'layout',
+      layout: 'fixture.admin-layout',
+      label: 'Users',
+      to: '/external-admin/users',
+      minimumRole: 'fixture-reader',
+      order: 200,
+    },
+    {
+      id: 'admin.overview',
+      scope: 'layout',
+      layout: 'fixture.admin-layout',
+      label: 'Overview',
+      to: '/external-admin/overview',
+      minimumRole: 'fixture-reader',
+      order: 100,
+    },
+  ],
+});
+
+export const features = [
+  ...defaultFeatures(),
+  externalFeature,
+  externalLayoutFeature,
+  externalLayoutSectionsFeature,
+];

--- a/libs/client/shell/test/external/fixture/src/features/external-admin-layout.tsx
+++ b/libs/client/shell/test/external/fixture/src/features/external-admin-layout.tsx
@@ -1,0 +1,21 @@
+import {Link, Outlet} from '@tanstack/react-router';
+import {useLayoutNavigation} from '@shipfox/client-shell/runtime';
+import {defineRoute} from '@shipfox/client-shell/runtime';
+
+function ExternalAdminLayout() {
+  const entries = useLayoutNavigation('fixture.admin-layout');
+  return (
+    <>
+      <nav aria-label="External administration sections">
+        {entries.map((entry) => (
+          <Link key={entry.id} to={entry.to as never}>
+            {entry.label}
+          </Link>
+        ))}
+      </nav>
+      <Outlet />
+    </>
+  );
+}
+
+export default defineRoute({component: ExternalAdminLayout});

--- a/libs/client/shell/test/external/fixture/src/features/external-admin-overview.tsx
+++ b/libs/client/shell/test/external/fixture/src/features/external-admin-overview.tsx
@@ -1,0 +1,3 @@
+import {defineRoute} from '@shipfox/client-shell/runtime';
+
+export default defineRoute({component: () => <h1>External administration overview</h1>});

--- a/libs/client/shell/test/external/fixture/src/features/external-admin-users.tsx
+++ b/libs/client/shell/test/external/fixture/src/features/external-admin-users.tsx
@@ -1,0 +1,3 @@
+import {defineRoute} from '@shipfox/client-shell/runtime';
+
+export default defineRoute({component: () => <h1>External administration users</h1>});

--- a/libs/client/shell/test/render.tsx
+++ b/libs/client/shell/test/render.tsx
@@ -2,7 +2,7 @@ import {QueryClient} from '@tanstack/react-query';
 import {createMemoryHistory, createRouter, Outlet, RouterProvider} from '@tanstack/react-router';
 import {render} from '@testing-library/react';
 import {createStore} from 'jotai';
-import {composeRoutes} from '#compose/compose-routes.js';
+import {composeClientFeatures} from '#compose/compose-client-features.js';
 import type {ClientFeature} from '#contract.js';
 import {assembleRouteTree, type ResolveRouteImpl} from '#runtime/assemble-route-tree.js';
 import {type AuthStateValue, authStateAtom} from '#runtime/auth.js';
@@ -25,7 +25,9 @@ export async function renderComposedShell({
   queryClient: QueryClient;
   store: ReturnType<typeof createStore>;
 }> {
-  const routeTree = await assembleRouteTree(composeRoutes(features), {
+  const composition = composeClientFeatures(features);
+  const routeTree = await assembleRouteTree(composition.routes, {
+    layouts: composition.layouts,
     resolveImpl,
     navigation: navigationEntries(features),
     settingsSections: settingsEntries(features),


### PR DESCRIPTION
Adds a generic feature-owned layout composition seam for the client shell so feature packages can own nested route shells and layout-local navigation without coupling to the host application.

The contract now validates layout IDs, parent chains, route nesting, collisions, and protected shell-anchor boundaries. Layout navigation is exposed as data through the runtime, with role metadata restricted to layout-scoped entries and descendant-target validation. The Vite generator, runtime route tree, ADR, and packed external-consumer fixture are updated together.

Validation: client-shell check, typecheck, 80 tests, build, affected Turbo checks, client architecture audit, Changeset status, and packed external-consumer verification.

Closes ENG-1343

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds feature-owned layouts and layout-scoped navigation so features can own nested route shells and expose deterministic local nav. Updates the contract, generator, runtime, and validations; closes ENG-1343.

- **New Features**
  - `ClientFeature.layouts`: declare layouts with `id`, `path`, `parent` (`RouteParentId`), and `impl`.
  - Routes may set `parent` to a layout id via `RouteParentId`; ids, collisions, cycles, path nesting, protected anchors, and replacing layouts are validated.
  - Reserved layout ids/paths are rejected; missing/cyclic parents are named; root-parented paths inside protected anchors are blocked; routes cannot replace layouts.
  - Layout-local navigation: `navigation` entries with `scope: 'layout'`, `layout`, and optional `minimumRole` (only on layout-scoped entries); targets must be the layout root or descendants; exposed via `useLayoutNavigation(layoutId)` from `@shipfox/client-shell/runtime`.
  - `LayoutNavigationProvider` added to the provider stack; data-only, layout owns rendering and role policy.
  - Codegen/runtime build nested layout trees and resolve both layout and route modules; `@shipfox/client-shell/vite` generates layout trees; ADR and external fixture updated.

- **Migration**
  - Declare a layout in your feature, parent child routes to its layout id, add `scope: 'layout'` navigation entries, and render links with `useLayoutNavigation(layoutId)` in the layout. Use the matching shell anchor as `parent` if paths live under protected anchors.

<sup>Written for commit 0ca79e9a6a213f7e020a148eb0320a3539a87151. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1099?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

