### PR TITLE
Fix production deployment workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,7 @@ jobs:
     timeout-minutes: 40
     env:
       SHIPFOX_TURBO_CONCURRENCY: "4"
+      CLOUDFLARE_PAGES_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
     steps:
       - name: Check out repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -959,6 +959,7 @@ jobs:
       actions: read
       contents: read
       deployments: write
+      pull-requests: read
     uses: ./.github/workflows/deploy.yml
     with:
       environment: production


### PR DESCRIPTION
The production deployment job overrides the workflow permissions, so it must grant the pull-request read scope required by the reusable deployment workflow.

Static verification now identifies preview artifacts by the pull-request head SHA rather than GitHub's temporary merge commit, matching the preview workflow's provenance contract.

This restores CI workflow validation for main deployments.