### PR TITLE
[provisioner-core] Cover warm-pool reservation payloads

### DIFF
--- a/libs/provisioner/core/src/tick.test.ts
+++ b/libs/provisioner/core/src/tick.test.ts
@@ -241,20 +241,24 @@ describe('runProvisionerTick', () => {
   });
   it('keeps the reservation poll limit independent from warm-pool admission', async () => {
     let requestedReservations = -1;
+    const createBodies: CreateRunnerInstancesBodyDto[] = [];
     const client: ProvisionerClient = {
       getIdentity: async () => ({id: 'provisioner', scope: 'workspace', workspace_id: 'workspace'}),
       pollDemand: (body) => {
         requestedReservations = body.max_reservations;
         return Promise.resolve({stats: [], reservations: [], terminate_provider_runner_ids: []});
       },
-      createRunnerInstances: async () => ({
-        runner_instances: [
-          {
-            runner_instance_id: '018f0d4c-5f42-7b7e-9d9b-4a7d8e6f0002',
-            bootstrap_token: 'sf_rbt_test',
-          },
-        ],
-      }),
+      createRunnerInstances: (body) => {
+        createBodies.push(body);
+        return Promise.resolve({
+          runner_instances: [
+            {
+              runner_instance_id: '018f0d4c-5f42-7b7e-9d9b-4a7d8e6f0002',
+              bootstrap_token: 'sf_rbt_test',
+            },
+          ],
+        });
+      },
       attachRunnerInstanceProviderId: async () => ({attached: true}),
       assignRunnerInstances: async (_reservationId, runnerInstanceIds) => ({
         runner_instance_ids: runnerInstanceIds,
@@ -289,5 +293,9 @@ describe('runProvisionerTick', () => {
     });
     expect(requestedReservations).toBe(0);
     expect(result).toMatchObject({plannedCount: 2, launchAttemptedCount: 2, launchedCount: 2});
+    expect(createBodies).toEqual([
+      {runner_instances: [{template_key: 'linux'}]},
+      {runner_instances: [{template_key: 'linux'}]},
+    ]);
   });
 });


### PR DESCRIPTION
The reservation-id launch behavior shipped in main with #1092. This PR adds the missing regression coverage for the warm-pool branch by capturing `createRunnerInstances` request bodies and asserting prewarmed launches send only their template key, with no reservation intent when no reservation is held.

Validated with `turbo test type --filter=@shipfox/provisioner-core...` (59 core tests passing).

Closes ENG-1330

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add regression tests to ensure warm‑pool launches omit reservation intent: when no reservation is held, `createRunnerInstances` is called twice with only a template key. This matches reservation‑id behavior on `main` and satisfies ENG‑1330.

<sup>Written for commit 4c9ff0fc77894753ae6a83e6db9b620674b70d99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

