### PR TITLE
[api-auth] Expose authenticated administrator bootstrap state

### DIFF
--- a/.changeset/fair-bootstrap-state.md
+++ b/.changeset/fair-bootstrap-state.md
@@ -1,0 +1,6 @@
+---
+'@shipfox/api-auth': minor
+'@shipfox/api-auth-dto': minor
+---
+
+Expose authenticated administrator bootstrap availability through the Auth API.

--- a/libs/api/auth-dto/src/schemas/admin.ts
+++ b/libs/api/auth-dto/src/schemas/admin.ts
@@ -38,6 +38,12 @@ export const bootstrapAdminOwnerResponseSchema = adminGrantDtoSchema;
 
 export type BootstrapAdminOwnerResponseDto = z.infer<typeof bootstrapAdminOwnerResponseSchema>;
 
+export const adminBootstrapStateSchema = z.object({
+  state: z.enum(['available', 'closed']),
+});
+
+export type AdminBootstrapStateDto = z.infer<typeof adminBootstrapStateSchema>;
+
 export const grantAdminRoleBodySchema = z.object({
   user_id: z.string().uuid(),
   role: adminRoleSchema,

--- a/libs/api/auth-dto/src/schemas/index.ts
+++ b/libs/api/auth-dto/src/schemas/index.ts
@@ -9,12 +9,14 @@ export {
   authUserSignedUpSchema,
 } from '../events.js';
 export {
+  type AdminBootstrapStateDto,
   type AdminGrantDto,
   type AdministratorGrantSummaryDto,
   type AdministratorUserIdentityDto,
   type AdministratorUserLookupQueryDto,
   type AdministratorUserSummaryDto,
   type AdminRole,
+  adminBootstrapStateSchema,
   adminGrantDtoSchema,
   administratorGrantSummarySchema,
   administratorUserIdentitySchema,

--- a/libs/api/auth/README.md
+++ b/libs/api/auth/README.md
@@ -234,7 +234,9 @@ When password login is disabled, the password and email-verification rows in thi
 
 ### Administrator grants
 
-All routes are mounted under `/admin/auth/admin-grants` and require an authenticated bearer token. Administrator role checks are enforced in the core layer, not by route-level middleware.
+`GET /admin/auth/bootstrap-state` requires an authenticated bearer token and returns exactly `{state: 'available' | 'closed'}`. It reports `available` only while no active `admin-owner` exists and never reports deployment-token configuration.
+
+Bootstrap and grant-management routes are mounted under `/admin/auth/admin-grants` and require an authenticated bearer token. Administrator role checks are enforced in the core layer, not by route-level middleware.
 
 | Method | Path | Required role | Result |
 | --- | --- | --- | --- |

--- a/libs/api/auth/src/core/administration.ts
+++ b/libs/api/auth/src/core/administration.ts
@@ -6,6 +6,7 @@ import {config} from '#config.js';
 import {
   bootstrapFirstAdminOwner as bootstrapFirstAdminOwnerInDb,
   grantAdminRoleWithAudit,
+  hasActiveAdminOwner,
   listAdminGrantSummaries,
   revokeAdminGrantWithAudit,
 } from '#db/admin-grants.js';
@@ -103,6 +104,10 @@ export async function bootstrapFirstAdminOwner(
       idempotencyKeyFingerprint: hashAdministrationValue(params.idempotencyKey),
     }),
   });
+}
+
+export async function getAdminBootstrapState(): Promise<'available' | 'closed'> {
+  return (await hasActiveAdminOwner()) ? 'closed' : 'available';
 }
 
 export async function findAdministratorUserSummary(

--- a/libs/api/auth/src/db/admin-grants.test.ts
+++ b/libs/api/auth/src/db/admin-grants.test.ts
@@ -1,7 +1,12 @@
 import {eq} from 'drizzle-orm';
 import {LastAdminOwnerError} from '#core/errors.js';
 import {userFactory} from '#test/index.js';
-import {createAdminGrant, findCurrentAdminRole, revokeAdminGrant} from './admin-grants.js';
+import {
+  createAdminGrant,
+  findCurrentAdminRole,
+  hasActiveAdminOwner,
+  revokeAdminGrant,
+} from './admin-grants.js';
 import {db} from './db.js';
 import {users} from './schema/users.js';
 
@@ -24,6 +29,17 @@ describe('admin grants db', () => {
 
     await db().update(users).set({status: 'suspended'}).where(eq(users.id, user.id));
     expect(await findCurrentAdminRole({userId: user.id})).toBeNull();
+  });
+
+  test('does not report a suspended owner as active', async () => {
+    const user = await userFactory.create({emailVerifiedAt: new Date()});
+    await createAdminGrant({userId: user.id, role: 'admin-owner'});
+
+    await expect(hasActiveAdminOwner()).resolves.toBe(true);
+
+    await db().update(users).set({status: 'suspended'}).where(eq(users.id, user.id));
+
+    await expect(hasActiveAdminOwner()).resolves.toBe(false);
   });
 
   test('prevents revoking the final active owner but permits replacement first', async () => {

--- a/libs/api/auth/src/db/admin-grants.ts
+++ b/libs/api/auth/src/db/admin-grants.ts
@@ -95,6 +95,23 @@ export async function listAdminGrantSummaries(params: {
   };
 }
 
+export async function hasActiveAdminOwner(): Promise<boolean> {
+  const rows = await db()
+    .select({id: adminGrants.id})
+    .from(adminGrants)
+    .innerJoin(users, eq(adminGrants.userId, users.id))
+    .where(
+      and(
+        eq(adminGrants.role, 'admin-owner'),
+        isNull(adminGrants.revokedAt),
+        eq(users.status, 'active'),
+      ),
+    )
+    .limit(1);
+
+  return rows.length > 0;
+}
+
 export async function findCurrentAdminRole(params: {userId: string}): Promise<AdminRole | null> {
   const rows = await db()
     .select({role: adminGrants.role})

--- a/libs/api/auth/src/index.test.ts
+++ b/libs/api/auth/src/index.test.ts
@@ -78,7 +78,10 @@ describe('authModule', () => {
         getWorkspaceOperatingState: vi.fn(),
       },
     });
-    expect(module.routes).toHaveLength(3);
+    expect(module.routes).toHaveLength(4);
+    expect(module.routes).toEqual(
+      expect.arrayContaining([expect.objectContaining({prefix: '/admin/auth'})]),
+    );
     const signupPolicy = buildAuthRoutes.mock.calls[0]?.[2];
 
     expect(signupPolicy).toEqual(expect.objectContaining({isSignupAllowed: expect.any(Function)}));

--- a/libs/api/auth/src/index.ts
+++ b/libs/api/auth/src/index.ts
@@ -18,6 +18,7 @@ import {createRunnerSessionAuthMethod} from '#presentation/auth/runner-session-a
 import {createAuthE2eRoutes} from '#presentation/e2eRoutes/index.js';
 import {createAuthInterModulePresentation} from '#presentation/inter-module.js';
 import {
+  administrationBootstrapRoutes,
   administrationRoutes,
   administrationUserRoutes,
 } from '#presentation/routes/administration.js';
@@ -114,6 +115,7 @@ export function createAuthModule({
     loginMethods: passwordLoginMethods(config.AUTH_PASSWORD_ENABLED),
     routes: [
       buildAuthRoutes(config.AUTH_PASSWORD_ENABLED, workspaces, signupPolicy),
+      administrationBootstrapRoutes,
       administrationRoutes,
       administrationUserRoutes,
     ],

--- a/libs/api/auth/src/metrics/instance.ts
+++ b/libs/api/auth/src/metrics/instance.ts
@@ -3,7 +3,12 @@ import {instanceMetrics} from '@shipfox/node-opentelemetry';
 export type AuthTokenType = 'session' | 'job_lease' | 'runner_session';
 export type AuthTokenVerificationOutcome = 'ok' | 'rejected';
 export type AuthTokenRefreshOutcome = 'rotated' | 'grace' | 'rejected';
-export type AuthRateLimitAction = 'login' | 'email-send' | 'bootstrap' | 'lookup';
+export type AuthRateLimitAction =
+  | 'login'
+  | 'email-send'
+  | 'bootstrap'
+  | 'bootstrap-state'
+  | 'lookup';
 export type AuthRateLimitScope = 'ip' | 'email';
 export type AuthRateLimitOutcome = 'allowed' | 'blocked' | 'unavailable';
 

--- a/libs/api/auth/src/presentation/routes/administration.test.ts
+++ b/libs/api/auth/src/presentation/routes/administration.test.ts
@@ -48,6 +48,46 @@ describe('Auth administration routes', () => {
     expect(response.statusCode).toBe(401);
   });
 
+  test('requires an authenticated session for bootstrap state', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/admin/auth/bootstrap-state',
+    });
+
+    expect(response.statusCode).toBe(401);
+  });
+
+  test('reports only available or closed bootstrap state', async () => {
+    const account = await createVerifiedSession('admin-bootstrap-state');
+
+    const available = await app.inject({
+      method: 'GET',
+      url: '/admin/auth/bootstrap-state',
+      headers: {authorization: `Bearer ${account.token}`},
+    });
+
+    expect(available.statusCode).toBe(200);
+    expect(available.json()).toEqual({state: 'available'});
+
+    const bootstrap = await app.inject({
+      method: 'POST',
+      url: '/admin/auth/admin-grants/bootstrap',
+      headers: authHeaders(account.token, 'bootstrap-state-bootstrap'),
+      payload: {bootstrap_token: BOOTSTRAP_TOKEN},
+    });
+    expect(bootstrap.statusCode).toBe(201);
+
+    const closed = await app.inject({
+      method: 'GET',
+      url: '/admin/auth/bootstrap-state',
+      headers: {authorization: `Bearer ${account.token}`},
+    });
+
+    expect(closed.statusCode).toBe(200);
+    expect(closed.json()).toEqual({state: 'closed'});
+    expect(JSON.stringify(closed.json())).not.toContain(BOOTSTRAP_TOKEN);
+  });
+
   test('does not register the removed versioned administration namespace', async () => {
     const response = await app.inject({
       method: 'GET',
@@ -138,6 +178,36 @@ describe('Auth administration routes', () => {
       result: 'succeeded',
     });
     expect(JSON.stringify(events[0]?.payload)).not.toContain(BOOTSTRAP_TOKEN);
+  });
+
+  test('serializes concurrent bootstrap attempts to one active first owner', async () => {
+    const first = await createVerifiedSession('admin-bootstrap-race-first');
+    const second = await createVerifiedSession('admin-bootstrap-race-second');
+
+    const responses = await Promise.all(
+      [first, second].map((account, index) =>
+        app.inject({
+          method: 'POST',
+          url: '/admin/auth/admin-grants/bootstrap',
+          headers: authHeaders(account.token, `bootstrap-race-${index}`),
+          payload: {bootstrap_token: BOOTSTRAP_TOKEN},
+        }),
+      ),
+    );
+
+    expect(responses.map((response) => response.statusCode).sort()).toEqual([201, 409]);
+    const activeOwnerRoles = await Promise.all(
+      [first, second].map(async (account) => {
+        const response = await app.inject({
+          method: 'GET',
+          url: `/admin/auth/users?user_id=${account.userId}`,
+          headers: {authorization: `Bearer ${account.token}`},
+        });
+        return response.statusCode === 200 && response.json().admin_role === 'admin-owner';
+      }),
+    );
+
+    expect(activeOwnerRoles.filter(Boolean)).toHaveLength(1);
   });
 
   test('lets an owner list, grant, and revoke roles with idempotent audited mutations', async () => {

--- a/libs/api/auth/src/presentation/routes/administration.test.ts
+++ b/libs/api/auth/src/presentation/routes/administration.test.ts
@@ -1,8 +1,10 @@
 import {ADMINISTRATION_ACTION_PERFORMED} from '@shipfox/api-common-dto';
 import {sql} from 'drizzle-orm';
 import type {FastifyInstance} from 'fastify';
+import {type AuthRateLimitAction, hashAuthRateLimitIdentifier} from '#core/rate-limit.js';
 import {db} from '#db/db.js';
 import {authOutbox} from '#db/schema/outbox.js';
+import {authRateLimits} from '#db/schema/rate-limits.js';
 import {createAuthTestApp, createVerifiedSession, resetCapturedMail} from '#test/routes.js';
 
 const BOOTSTRAP_TOKEN = 'test-bootstrap-token';
@@ -18,6 +20,30 @@ function authHeaders(token: string, idempotencyKey: string) {
     authorization: `Bearer ${token}`,
     'idempotency-key': idempotencyKey,
   };
+}
+
+async function seedExhaustedIpBucket(params: {
+  action: AuthRateLimitAction;
+  identifier: string;
+  limit: number;
+  windowSeconds: number;
+}): Promise<void> {
+  const windowMs = params.windowSeconds * 1000;
+  const windowStart = new Date(Math.floor(Date.now() / windowMs) * windowMs);
+  await db()
+    .insert(authRateLimits)
+    .values({
+      action: params.action,
+      scope: 'ip',
+      identifierHmac: hashAuthRateLimitIdentifier({
+        action: params.action,
+        scope: 'ip',
+        identifier: params.identifier,
+      }),
+      windowStart,
+      count: params.limit,
+      expiresAt: new Date(windowStart.getTime() + windowMs),
+    });
 }
 
 describe('Auth administration routes', () => {
@@ -86,6 +112,38 @@ describe('Auth administration routes', () => {
     expect(closed.statusCode).toBe(200);
     expect(closed.json()).toEqual({state: 'closed'});
     expect(JSON.stringify(closed.json())).not.toContain(BOOTSTRAP_TOKEN);
+  });
+
+  test('keeps bootstrap-state reads separate from the bootstrap write limit', async () => {
+    const account = await createVerifiedSession('admin-bootstrap-state-rate-limit');
+    const ip = '127.0.0.1';
+
+    await seedExhaustedIpBucket({
+      action: 'bootstrap',
+      identifier: ip,
+      limit: 5,
+      windowSeconds: 15 * 60,
+    });
+    const state = await app.inject({
+      method: 'GET',
+      url: '/admin/auth/bootstrap-state',
+      headers: {authorization: `Bearer ${account.token}`},
+    });
+    expect(state.statusCode).toBe(200);
+
+    await resetAdministrationState();
+    await seedExhaustedIpBucket({
+      action: 'bootstrap-state',
+      identifier: ip,
+      limit: 60,
+      windowSeconds: 5 * 60,
+    });
+    const blocked = await app.inject({
+      method: 'GET',
+      url: '/admin/auth/bootstrap-state',
+      headers: {authorization: `Bearer ${account.token}`},
+    });
+    expect(blocked.statusCode).toBe(429);
   });
 
   test('does not register the removed versioned administration namespace', async () => {

--- a/libs/api/auth/src/presentation/routes/administration.ts
+++ b/libs/api/auth/src/presentation/routes/administration.ts
@@ -1,5 +1,6 @@
 import {AUTH_USER} from '@shipfox/api-auth-context';
 import {
+  adminBootstrapStateSchema,
   administratorUserLookupQuerySchema,
   administratorUserSummarySchema,
   bootstrapAdminOwnerBodySchema,
@@ -19,6 +20,7 @@ import {requireAdminRole} from '#core/admin-role.js';
 import {
   bootstrapFirstAdminOwner,
   findAdministratorUserSummary,
+  getAdminBootstrapState,
   grantAdministratorRole,
   listAdministratorGrantSummaries,
   revokeAdministratorGrant,
@@ -165,6 +167,16 @@ const bootstrapRoute = defineRoute({
   },
 });
 
+const bootstrapStateRoute = defineRoute({
+  method: 'GET',
+  path: '/bootstrap-state',
+  description: 'Read whether first administrator owner bootstrap is available.',
+  schema: {response: {200: adminBootstrapStateSchema}},
+  preHandler: createAuthIpRateLimitPreHandler('bootstrap'),
+  errorHandler: translateAdministrationError,
+  handler: async () => ({state: await getAdminBootstrapState()}),
+});
+
 const listRoute = defineRoute({
   method: 'GET',
   path: '/',
@@ -267,6 +279,12 @@ export const administrationRoutes: RouteGroup = {
   prefix: '/admin/auth/admin-grants',
   auth: AUTH_USER,
   routes: [bootstrapRoute, listRoute, grantRoute, revokeRoute],
+};
+
+export const administrationBootstrapRoutes: RouteGroup = {
+  prefix: '/admin/auth',
+  auth: AUTH_USER,
+  routes: [bootstrapStateRoute],
 };
 
 export const administrationUserRoutes: RouteGroup = {

--- a/libs/api/auth/src/presentation/routes/administration.ts
+++ b/libs/api/auth/src/presentation/routes/administration.ts
@@ -172,7 +172,7 @@ const bootstrapStateRoute = defineRoute({
   path: '/bootstrap-state',
   description: 'Read whether first administrator owner bootstrap is available.',
   schema: {response: {200: adminBootstrapStateSchema}},
-  preHandler: createAuthIpRateLimitPreHandler('bootstrap'),
+  preHandler: createAuthIpRateLimitPreHandler('bootstrap-state'),
   errorHandler: translateAdministrationError,
   handler: async () => ({state: await getAdminBootstrapState()}),
 });

--- a/libs/api/auth/src/presentation/routes/rate-limit.ts
+++ b/libs/api/auth/src/presentation/routes/rate-limit.ts
@@ -23,6 +23,9 @@ const policies: Record<
   bootstrap: {
     ip: {limit: 5, windowSeconds: 15 * 60},
   },
+  'bootstrap-state': {
+    ip: {limit: 60, windowSeconds: 5 * 60},
+  },
   lookup: {
     ip: {limit: 60, windowSeconds: 5 * 60},
   },

--- a/libs/api/auth/test/routes.ts
+++ b/libs/api/auth/test/routes.ts
@@ -9,6 +9,7 @@ import {db} from '#db/db.js';
 import {authOutbox} from '#db/schema/outbox.js';
 import {createJwtAuthMethod} from '#presentation/auth/jwt-auth.js';
 import {
+  administrationBootstrapRoutes,
   administrationRoutes,
   administrationUserRoutes,
 } from '#presentation/routes/administration.js';
@@ -156,7 +157,12 @@ export async function createAuthTestApp(params?: {
 }): Promise<FastifyInstance> {
   const appConfig: AppConfig = {
     auth: [createJwtAuthMethod()],
-    routes: [buildAuthRoutes(true, workspaces), administrationRoutes, administrationUserRoutes],
+    routes: [
+      buildAuthRoutes(true, workspaces),
+      administrationBootstrapRoutes,
+      administrationRoutes,
+      administrationUserRoutes,
+    ],
     swagger: false,
   };
   if (params?.fastifyOptions) appConfig.fastifyOptions = params.fastifyOptions;


### PR DESCRIPTION
Add the authenticated Auth read that lets private administration clients decide whether first-owner bootstrap may render. The endpoint returns only `available` or `closed`, uses the existing active-owner semantics, and is rate-limited through a dedicated bootstrap-state read bucket. Coverage includes anonymous access, closure after successful bootstrap, concurrent first-owner races, and suspended-owner state.

Closes ENG-1344

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an authenticated GET `/admin/auth/bootstrap-state` so private admin clients can decide if the first-owner bootstrap should render. Returns `{state: 'available' | 'closed'}` based on active-owner state and fulfills ENG-1344.

- **New Features**
  - New `GET /admin/auth/bootstrap-state` with bearer auth; separate `bootstrap-state` IP rate limit (60 per 5m), distinct from the bootstrap write limit.
  - Reports `available` only when no active `admin-owner` exists; suspended owners don’t count.
  - Never reveals `ADMIN_BOOTSTRAP_TOKEN` in responses or logs.
  - Adds `adminBootstrapStateSchema` and `AdminBootstrapStateDto` in `@shipfox/api-auth-dto`; exposes via `administrationBootstrapRoutes` in `@shipfox/api-auth`. Tests cover anonymous access, post-bootstrap closure, concurrent first-owner race (single owner), and bootstrap-state rate-limit separation.

<sup>Written for commit b5ce12f09901687daf84b3ae0211fabbd55686e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

