### PR TITLE
[CI] Skip empty Cloudflare Pages preview deploys

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -33,6 +33,8 @@ jobs:
     if: github.event.pull_request.head.ref != 'changeset-release/main'
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    outputs:
+      should_deploy: ${{ steps.plan.outputs.should_deploy }}
     steps:
       - name: Check out exact preview commit
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -152,6 +154,10 @@ jobs:
           include-hidden-files: true
           if-no-files-found: error
 
+      - name: Report skipped preview
+        if: steps.plan.outputs.should_deploy != 'true'
+        run: echo 'no Pages target affected; preview skipped' >> "$GITHUB_STEP_SUMMARY"
+
       - name: Report preview build metrics
         if: always()
         env:
@@ -184,6 +190,7 @@ jobs:
     needs: build
     if: >-
       needs.build.result == 'success' &&
+      needs.build.outputs.should_deploy == 'true' &&
       github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       actions: read


### PR DESCRIPTION
Non-Pages pull requests intentionally produce no Pages preview artifact. The preview workflow still invoked the reusable deploy workflow after a successful build job, causing artifact verification to fail for an artifact that should not exist.

This carries the affected-plan decision out of the build job and requires it before invoking deployment. When no Pages target is affected, the build completes successfully and reports `no Pages target affected; preview skipped`.

Validation:
- `mise exec -- turbo check type test --filter=@shipfox/cloudflare-pages...`
- Parsed `.github/workflows/preview.yml` through the repository YAML dependency and verified the build output and deploy condition

This fixes the CI orchestration failure observed on #1102 without modifying or rerunning that pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skips empty Cloudflare Pages preview deploys for PRs that don’t touch Pages targets, preventing artifact verification failures and false CI failures.

- **Bug Fixes**
  - Propagates the plan result as a job output (`should_deploy`) from build to deploy.
  - Gates the deploy job on `needs.build.outputs.should_deploy == 'true'`.
  - Adds a summary message when skipped: “no Pages target affected; preview skipped.”

<sup>Written for commit 4473247d484dac0803ffbf2916bdc05727a12922. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

