### PR TITLE
[api-logs] Make Claude session events readable

### DIFF
--- a/.changeset/name-claude-session-events.md
+++ b/.changeset/name-claude-session-events.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-logs": minor
+---
+
+Name and tone Claude session events that carry useful signal.

--- a/libs/api/logs/src/core/session/claude-parser.test.ts
+++ b/libs/api/logs/src/core/session/claude-parser.test.ts
@@ -5,6 +5,148 @@ const record = (data: unknown, ts = 1) => ({
   ts,
   data: typeof data === 'string' ? data : JSON.stringify(data),
 });
+const meta = (label: string, value: string, inline?: boolean) =>
+  inline == null ? {label, value} : {label, value, inline};
+
+const namedSystemEvents = [
+  {
+    subtype: 'permission_denied',
+    data: {tool_name: 'mcp__shipfox_outputs__set_output', decision_reason: 'Permission mode'},
+    expected: {
+      label: 'Permission denied',
+      detail: 'mcp__shipfox_outputs__set_output',
+      meta: [meta('reason', 'Permission mode')],
+      tone: 'error',
+    },
+  },
+  {
+    subtype: 'api_retry',
+    data: {attempt: 2, max_retries: 3, error_status: 429, retry_delay_ms: 1_500},
+    expected: {
+      label: 'API retry',
+      detail: 'attempt 2/3',
+      meta: [meta('status', '429'), meta('retry delay', '1,500 ms')],
+      tone: 'warning',
+    },
+  },
+  {
+    subtype: 'informational',
+    data: {level: 'warning', content: 'The hook blocked continuation.'},
+    expected: {
+      label: 'Warning',
+      detail: 'The hook blocked continuation.',
+      meta: [],
+      tone: 'warning',
+    },
+  },
+  {
+    subtype: 'compact_boundary',
+    data: {
+      compact_metadata: {trigger: 'auto', pre_tokens: 12_000, post_tokens: 4_000, duration_ms: 250},
+    },
+    expected: {
+      label: 'Context compacted',
+      detail: null,
+      meta: [
+        meta('trigger', 'auto'),
+        meta('tokens before', '12K tokens'),
+        meta('tokens after', '4,000 tokens'),
+        meta('duration', '250 ms'),
+      ],
+      tone: 'default',
+    },
+  },
+  {
+    subtype: 'model_refusal_fallback',
+    data: {},
+    expected: {
+      label: 'Model refused, fell back',
+      detail: null,
+      meta: [],
+      tone: 'warning',
+    },
+  },
+  {
+    subtype: 'model_refusal_no_fallback',
+    data: {},
+    expected: {
+      label: 'Model refused',
+      detail: null,
+      meta: [],
+      tone: 'error',
+    },
+  },
+  {
+    subtype: 'mirror_error',
+    data: {error: 'Session store unavailable'},
+    expected: {
+      label: 'Session mirror failed',
+      detail: 'Session store unavailable',
+      meta: [],
+      tone: 'error',
+    },
+  },
+  {
+    subtype: 'worker_shutting_down',
+    data: {},
+    expected: {
+      label: 'Worker shutting down',
+      detail: null,
+      meta: [],
+      tone: 'warning',
+    },
+  },
+  {
+    subtype: 'elicitation_complete',
+    data: {},
+    expected: {
+      label: 'Elicitation complete',
+      detail: null,
+      meta: [],
+      tone: 'default',
+    },
+  },
+  {
+    subtype: 'notification',
+    data: {},
+    expected: {
+      label: 'Notification',
+      detail: null,
+      meta: [],
+      tone: 'default',
+    },
+  },
+  {
+    subtype: 'task_started',
+    data: {},
+    expected: {
+      label: 'Task started',
+      detail: null,
+      meta: [],
+      tone: 'default',
+    },
+  },
+  {
+    subtype: 'task_updated',
+    data: {},
+    expected: {
+      label: 'Task updated',
+      detail: null,
+      meta: [],
+      tone: 'default',
+    },
+  },
+  {
+    subtype: 'task_notification',
+    data: {},
+    expected: {
+      label: 'Task notification',
+      detail: null,
+      meta: [],
+      tone: 'default',
+    },
+  },
+] as const;
 
 describe('parseClaudeSessionRecord', () => {
   it('returns a raw row for malformed JSON', () => {
@@ -44,8 +186,9 @@ describe('parseClaudeSessionRecord', () => {
         kind: 'lifecycle',
         timestamp: 1,
         label: 'Session started',
-        detail: 'session-1',
+        detail: null,
         meta: [
+          {label: 'session', value: 'session-1'},
           {label: 'cwd', value: '/workspace', inline: false},
           {label: 'model', value: 'claude-opus-4-8'},
         ],
@@ -61,6 +204,23 @@ describe('parseClaudeSessionRecord', () => {
     const rows = parseClaudeSessionRecord(record({type: 'system', subtype}));
 
     expect(rows).toEqual([]);
+  });
+
+  it.each(namedSystemEvents)('names and tones $subtype system events', ({
+    subtype,
+    data,
+    expected,
+  }) => {
+    const rows = parseClaudeSessionRecord(record({type: 'system', subtype, ...data}));
+
+    expect(rows).toEqual([
+      {
+        kind: 'lifecycle',
+        timestamp: 1,
+        ...expected,
+        terminalFailure: false,
+      },
+    ]);
   });
 
   it('reports repeated init and result records as turns within one session', () => {
@@ -90,8 +250,8 @@ describe('parseClaudeSessionRecord', () => {
         kind: 'lifecycle',
         timestamp: 1,
         label: 'Session started',
-        detail: 'session-1',
-        meta: [],
+        detail: null,
+        meta: [meta('session', 'session-1')],
         tone: 'default',
         terminalFailure: false,
       },
@@ -108,7 +268,7 @@ describe('parseClaudeSessionRecord', () => {
         kind: 'lifecycle',
         timestamp: 1,
         label: 'Turn 2 started',
-        detail: 'session-1',
+        detail: null,
         meta: [{label: 'turn', value: '2'}],
         tone: 'default',
         terminalFailure: false,
@@ -125,7 +285,7 @@ describe('parseClaudeSessionRecord', () => {
     ]);
   });
 
-  it('keeps non-init system messages as session events', () => {
+  it('qualifies unmapped system events instead of using a bare generic label', () => {
     const rows = parseClaudeSessionRecord(
       record({type: 'system', subtype: 'custom_event', session_id: 'session-1'}),
     );
@@ -134,8 +294,8 @@ describe('parseClaudeSessionRecord', () => {
       {
         kind: 'lifecycle',
         timestamp: 1,
-        label: 'Session event',
-        detail: 'session-1',
+        label: 'Session event (custom_event)',
+        detail: null,
         meta: [],
         tone: 'default',
         terminalFailure: false,

--- a/libs/api/logs/src/core/session/claude/rows.ts
+++ b/libs/api/logs/src/core/session/claude/rows.ts
@@ -13,6 +13,7 @@ import {
   formatNumber,
   isMeta,
   metaItem,
+  numberField,
   stringField,
   stringifyValue,
   toJson,
@@ -34,6 +35,101 @@ export const PURE_PROGRESS_CLAUDE_SYSTEM_SUBTYPES = new Set<string>([
 ]);
 const OUTPUT_REPROMPT_PREFIX = 'The previous turn ended without setting required workflow outputs:';
 
+type SystemEventMapping = {
+  label: string | ((message: Record<string, unknown>) => string);
+  tone:
+    | SessionViewLifecycleRow['tone']
+    | ((message: Record<string, unknown>) => SessionViewLifecycleRow['tone']);
+  detail?: (message: Record<string, unknown>) => string | null;
+  meta?: (message: Record<string, unknown>) => readonly SessionViewRowMeta[];
+};
+
+const SYSTEM_EVENT_MAPPINGS: Record<string, SystemEventMapping> = {
+  permission_denied: {
+    label: 'Permission denied',
+    tone: 'error',
+    detail: (message) => stringField(message, 'tool_name') ?? null,
+    meta: (message) =>
+      [
+        metaItem(
+          'reason',
+          stringField(message, 'decision_reason') ?? stringField(message, 'message'),
+        ),
+      ].filter(isMeta),
+  },
+  api_retry: {
+    label: 'API retry',
+    tone: 'warning',
+    detail: (message) => {
+      const attempt = numberField(message, 'attempt');
+      const maxRetries = numberField(message, 'max_retries');
+      return attempt == null || maxRetries == null
+        ? null
+        : `attempt ${formatNumber(attempt)}/${formatNumber(maxRetries)}`;
+    },
+    meta: (message) =>
+      [
+        numberMeta(message, 'error_status', 'status'),
+        numberMeta(message, 'retry_delay_ms', 'retry delay', 'ms'),
+      ].filter(isMeta),
+  },
+  informational: {
+    label: (message) => titleCase(stringField(message, 'level') ?? 'informational'),
+    tone: (message) => (stringField(message, 'level') === 'warning' ? 'warning' : 'default'),
+    detail: (message) => stringField(message, 'content') ?? null,
+  },
+  compact_boundary: {
+    label: 'Context compacted',
+    tone: 'default',
+    meta: (message) => {
+      const compactMetadata = asLooseObject(field(message, 'compact_metadata')) ?? {};
+      return [
+        metaItem('trigger', stringField(compactMetadata, 'trigger')),
+        numberMeta(compactMetadata, 'pre_tokens', 'tokens before', 'tokens'),
+        numberMeta(compactMetadata, 'post_tokens', 'tokens after', 'tokens'),
+        numberMeta(compactMetadata, 'duration_ms', 'duration', 'ms'),
+      ].filter(isMeta);
+    },
+  },
+  model_refusal_fallback: {
+    label: 'Model refused, fell back',
+    tone: 'warning',
+  },
+  model_refusal_no_fallback: {
+    label: 'Model refused',
+    tone: 'error',
+  },
+  mirror_error: {
+    label: 'Session mirror failed',
+    tone: 'error',
+    detail: (message) => stringField(message, 'error') ?? null,
+  },
+  worker_shutting_down: {
+    label: 'Worker shutting down',
+    tone: 'warning',
+  },
+  elicitation_complete: {
+    label: 'Elicitation complete',
+    tone: 'default',
+  },
+  notification: {
+    label: 'Notification',
+    tone: 'default',
+  },
+  task_started: {
+    label: 'Task started',
+    tone: 'default',
+  },
+  task_updated: {
+    label: 'Task updated',
+    tone: 'default',
+  },
+  task_notification: {
+    label: 'Task notification',
+    tone: 'default',
+  },
+};
+
 export function systemRow(
   timestamp: number,
   message: Record<string, unknown>,
@@ -51,8 +147,25 @@ export function systemRow(
     ),
   ].filter(isMeta);
 
-  if (!isInit)
-    return lifecycleRow(timestamp, 'Session event', sessionId ?? null, 'default', false, baseMeta);
+  if (!isInit) {
+    const mapping = subtype === undefined ? undefined : SYSTEM_EVENT_MAPPINGS[subtype];
+    const label =
+      mapping === undefined
+        ? `Session event (${subtype ?? 'unknown'})`
+        : typeof mapping.label === 'function'
+          ? mapping.label(message)
+          : mapping.label;
+    const tone =
+      mapping === undefined
+        ? 'default'
+        : typeof mapping.tone === 'function'
+          ? mapping.tone(message)
+          : mapping.tone;
+    const detail = mapping?.detail?.(message) ?? null;
+    const meta = [...baseMeta, ...(mapping?.meta?.(message) ?? [])];
+
+    return lifecycleRow(timestamp, label, detail, tone, false, meta);
+  }
 
   const isNewSession =
     !context.hasInit || sessionId === undefined || sessionId !== context.sessionId;
@@ -61,11 +174,17 @@ export function systemRow(
   context.turn = isNewSession ? 1 : context.turn + 1;
 
   const label = isNewSession ? 'Session started' : `Turn ${context.turn} started`;
-  const meta = [metaItem('turn', isNewSession ? null : String(context.turn)), ...baseMeta].filter(
-    isMeta,
-  );
+  const meta = [
+    metaItem('session', isNewSession ? sessionId : null),
+    metaItem('turn', isNewSession ? null : String(context.turn)),
+    ...baseMeta,
+  ].filter(isMeta);
 
-  return lifecycleRow(timestamp, label, sessionId ?? null, 'default', false, meta);
+  return lifecycleRow(timestamp, label, null, 'default', false, meta);
+}
+
+function titleCase(value: string): string {
+  return value.length === 0 ? value : `${value[0]?.toUpperCase()}${value.slice(1)}`;
 }
 
 export function assistantRows(


### PR DESCRIPTION
Make Claude session log lifecycle rows self-describing instead of collapsing all non-init system events into the generic `Session event` label.

The parser now maps signal-bearing Claude SDK subtypes to explicit labels, tones, per-event details, and metadata; keeps the session id on the session-start row metadata; and qualifies genuinely unmapped subtypes. Table-driven coverage exercises every mapping, with the required `@shipfox/api-logs` minor Changeset.

Validation: `mise exec -- turbo type check test --filter=@shipfox/api-logs...`

Closes ENG-1337

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Claude session lifecycle logs self-describing by naming system events, setting tones, and adding useful per-event details. Closes ENG-1337.

- **New Features**
  - Map Claude system subtypes to clear labels, tones, detail, and metadata, incl. permission_denied, api_retry, informational (level-aware), compact_boundary, model_refusal_*, mirror_error, worker_shutting_down, elicitation_complete, notification, task_*.
  - Init events now show "Session started" or "Turn N started"; store `session_id` as `meta.session` and add `meta.turn`; no detail field.
  - Unmapped system events are labeled "Session event (subtype)" instead of a generic label.
  - Table-driven tests cover all mappings; minor bump to `@shipfox/api-logs`.

<sup>Written for commit 0c5172b74b34472f3c3d4eff4a78b5946cc8e5dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

