### PR TITLE
[provisioner-core] Split demand polling from convergence

### DIFF
--- a/.changeset/steady-converge-loops.md
+++ b/.changeset/steady-converge-loops.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/provisioner-core": patch
+---
+
+Splits provisioner demand polling from provider convergence and makes shutdown cleanup resilient.

--- a/apps/docs/content/docs/reference/runner-provisioner.mdx
+++ b/apps/docs/content/docs/reference/runner-provisioner.mdx
@@ -28,6 +28,7 @@ This page is the canonical reference for configuring the Docker runner provision
 | `SHIPFOX_PROVISIONER_POLL_WAIT_SECONDS` | `30` | How long each demand poll waits for work before returning. `0` makes the poll non-blocking. |
 | `SHIPFOX_PROVISIONER_POLL_INTERVAL_MS` | `1000` | Wait between demand polls. Backs off toward the max after errors. |
 | `SHIPFOX_PROVISIONER_POLL_MAX_INTERVAL_MS` | `5000` | Largest poll backoff interval after repeated errors. |
+| `SHIPFOX_PROVISIONER_CONVERGE_INTERVAL_MS` | `1000` | Provider observation and reconciliation cadence. Backs off on errors up to the larger of 5000ms and the configured cadence. |
 | `SHIPFOX_PROVISIONER_MAX_RESERVATIONS` | `250` | Most reservations requested in one poll. Also bounded by free template capacity and the API's cap of 1000. |
 | `SHIPFOX_PROVISIONER_RUNNER_INSTANCE_BATCH_SIZE` | `250` | Runner instances created per request (1–1000). Must not exceed the API's own batch limit. |
 | `SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS` | `120000` | How long a created container may stay unstarted before the provisioner reaps it as stale. |

--- a/apps/provisioner-docker/README.md
+++ b/apps/provisioner-docker/README.md
@@ -10,22 +10,24 @@ configuration and launcher live in
 
 ## What it does
 
-On each cycle the provisioner:
+The provisioner runs two independent loops:
 
-1. Observes local Docker containers owned by this provisioner and reports lifecycle.
-2. Advertises its current per-template capacity (free slots, starting, running).
-3. Long-polls the API for demand and receives count-based reservations.
-4. Chooses a local template for each reservation's label set, deterministically,
-   filling the cheapest matching template first.
-5. Batch-mints one single-use registration token per planned runner.
-6. Creates and starts one Docker container per runner.
+- The convergence loop observes local Docker containers and reports lifecycle.
+- The demand loop:
+
+  1. Builds current per-template capacity advertisements, long-polls the API for
+     demand, and receives count-based reservations.
+  2. Chooses a local template for each reservation's label set, deterministically,
+     filling the cheapest matching template first.
+  3. Batch-mints one single-use registration token per planned runner.
+  4. Creates and starts one Docker container per runner.
 
 It respects each template's `max_concurrency` before requesting reservations, so it
 never reserves more than it can start.
 
 Containers are named by `provisioned_runner_id` and labeled with `shipfox.*` metadata
 so a restarted provisioner can rebuild local capacity from Docker state. Running
-containers are re-reported every observation cycle to keep the backend active-runner view fresh.
+containers are re-reported every convergence cycle to keep the backend active-runner view fresh.
 Exited containers are reported as `stopped` or `failed`. Successful exits are removed
 immediately; failed exits are retained for the configured forensic TTL/count bound and
 then cleaned up. Containers stuck in Docker's `created` state past the registration
@@ -53,6 +55,7 @@ until observation succeeds.
 | `SHIPFOX_PROVISIONER_POLL_WAIT_SECONDS` | no | `30` | Long-poll wait per demand request. |
 | `SHIPFOX_PROVISIONER_POLL_INTERVAL_MS` | no | `1000` | Base delay between polls; backs off on error. |
 | `SHIPFOX_PROVISIONER_POLL_MAX_INTERVAL_MS` | no | `5000` | Backoff ceiling. |
+| `SHIPFOX_PROVISIONER_CONVERGE_INTERVAL_MS` | no | `1000` | Provider observation and reconciliation cadence; backs off on errors up to the larger of 5000ms and this cadence. |
 | `SHIPFOX_PROVISIONER_MAX_RESERVATIONS` | no | `250` | Most reservations requested per poll (also capped by free capacity and the API's limit of 1000). |
 | `SHIPFOX_PROVISIONER_RUNNER_INSTANCE_BATCH_SIZE` | no | `250` | Runner instances created per request (1–1000). |
 | `SHIPFOX_RUNNER_POLL_MAX_DURATION_MS` | no | `300000` | Injected into each runner as `SHIPFOX_POLL_MAX_DURATION_MS`. |

--- a/apps/provisioner-ec2/README.md
+++ b/apps/provisioner-ec2/README.md
@@ -33,6 +33,7 @@ maximum lifetime. The AMI reads that file and shuts down when its watchdog exits
 | `SHIPFOX_PROVISIONER_POLL_WAIT_SECONDS` | no | `30` | Demand long-poll duration. |
 | `SHIPFOX_PROVISIONER_POLL_INTERVAL_MS` | no | `1000` | Delay between healthy demand polls. |
 | `SHIPFOX_PROVISIONER_POLL_MAX_INTERVAL_MS` | no | `5000` | Maximum error-backoff interval. |
+| `SHIPFOX_PROVISIONER_CONVERGE_INTERVAL_MS` | no | `1000` | Shared provider observation cadence. EC2 keeps full backend reconciliation on its separate EC2 interval. |
 | `SHIPFOX_PROVISIONER_MAX_RESERVATIONS` | no | `250` | Largest demand reservation request. |
 | `SHIPFOX_PROVISIONER_RUNNER_INSTANCE_BATCH_SIZE` | no | `250` | Runner instances created per control-plane request. |
 | `SHIPFOX_RUNNER_POLL_MAX_DURATION_MS` | no | `300000` | Idle polling lifetime injected into each runner. |

--- a/libs/provisioner/core/README.md
+++ b/libs/provisioner/core/README.md
@@ -6,15 +6,19 @@ plug in a provider adapter; everything else here is shared.
 
 ## What a provisioner does
 
-A provisioner authenticates with a long-lived provisioner token, then repeatedly:
+A provisioner authenticates with a long-lived provisioner token, then runs two
+independent loops:
 
-1. Advertises its current per-template capacity.
-2. Long-polls the API for demand and receives count-based reservations.
-3. Picks a local template for each reservation's labels.
-4. Batch-mints one single-use registration token per planned runner.
-5. Hands each planned runner to the provider's launcher.
+- The convergence loop observes provider state, reports lifecycle, and handles
+  termination intents.
+- The demand loop builds capacity advertisements from the tracker, long-polls the
+  API for count-based reservations, picks a local template for each reservation's
+  labels, mints one single-use registration token per planned runner, and hands each
+  planned runner to the provider's launcher.
 
-It never reserves more than its templates have free capacity.
+It never reserves more than its templates have free capacity. Demand polling and
+provider convergence run independently: a blocking demand poll does not delay
+observation, reporting, assignment, or termination handling.
 
 ## Public API
 

--- a/libs/provisioner/core/src/config.test.ts
+++ b/libs/provisioner/core/src/config.test.ts
@@ -35,6 +35,13 @@ describe('provisioner core config validation', () => {
     await expect(import('#config.js')).rejects.toThrow('SHIPFOX_PROVISIONER_POLL_MAX_INTERVAL_MS');
   });
 
+  it('rejects a zero converge interval', async () => {
+    vi.stubEnv('SHIPFOX_PROVISIONER_CONVERGE_INTERVAL_MS', '0');
+    vi.resetModules();
+
+    await expect(import('#config.js')).rejects.toThrow('SHIPFOX_PROVISIONER_CONVERGE_INTERVAL_MS');
+  });
+
   it('rejects max reservations above the API cap', async () => {
     vi.stubEnv('SHIPFOX_PROVISIONER_MAX_RESERVATIONS', '1001');
     vi.resetModules();
@@ -89,6 +96,7 @@ describe('provisioner core config validation', () => {
 
     expect(config.SHIPFOX_API_URL).toBe('https://api.shipfox.io');
     expect(config.SHIPFOX_PROVISIONER_POLL_WAIT_SECONDS).toBe(30);
+    expect(config.SHIPFOX_PROVISIONER_CONVERGE_INTERVAL_MS).toBe(1000);
     expect(config.SHIPFOX_PROVISIONER_MAX_RESERVATIONS).toBe(250);
     expect(config.SHIPFOX_PROVISIONER_RUNNER_INSTANCE_BATCH_SIZE).toBe(250);
     expect(config.SHIPFOX_RUNNER_POLL_MAX_DURATION_MS).toBe(300_000);

--- a/libs/provisioner/core/src/config.ts
+++ b/libs/provisioner/core/src/config.ts
@@ -29,6 +29,10 @@ export const config = createConfig({
     desc: 'Largest interval the poll backoff can reach after repeated errors, in milliseconds.',
     default: 5000,
   }),
+  SHIPFOX_PROVISIONER_CONVERGE_INTERVAL_MS: num({
+    desc: 'How often the provisioner observes and reconciles provider state, in milliseconds.',
+    default: 1000,
+  }),
   SHIPFOX_PROVISIONER_MAX_RESERVATIONS: num({
     desc: 'Most reservations the provisioner requests in one poll. The provisioner also never asks for more than its templates have free capacity, and the API caps a single poll at 1000.',
     default: 250,
@@ -68,6 +72,12 @@ if (config.SHIPFOX_PROVISIONER_POLL_INTERVAL_MS <= 0) {
 if (config.SHIPFOX_PROVISIONER_POLL_MAX_INTERVAL_MS < config.SHIPFOX_PROVISIONER_POLL_INTERVAL_MS) {
   throw new Error(
     `SHIPFOX_PROVISIONER_POLL_MAX_INTERVAL_MS must be greater than or equal to SHIPFOX_PROVISIONER_POLL_INTERVAL_MS; got ${config.SHIPFOX_PROVISIONER_POLL_MAX_INTERVAL_MS} and ${config.SHIPFOX_PROVISIONER_POLL_INTERVAL_MS}.`,
+  );
+}
+
+if (config.SHIPFOX_PROVISIONER_CONVERGE_INTERVAL_MS <= 0) {
+  throw new Error(
+    `SHIPFOX_PROVISIONER_CONVERGE_INTERVAL_MS must be greater than 0; got ${config.SHIPFOX_PROVISIONER_CONVERGE_INTERVAL_MS}.`,
   );
 }
 

--- a/libs/provisioner/core/src/provisioner.test.ts
+++ b/libs/provisioner/core/src/provisioner.test.ts
@@ -5,7 +5,13 @@ import type {
 } from '@shipfox/api-runners-dto';
 import type {ProvisionerClient} from '#api-client.js';
 import {createHealthState} from '#health.js';
-import {runProvisionerIteration, startProvisioner} from '#provisioner.js';
+import {
+  drainTerminationQueue,
+  runConvergeIteration,
+  runDemandIteration,
+  runProvisionerIteration,
+  startProvisioner,
+} from '#provisioner.js';
 import {createInMemoryTracker} from '#tracker.js';
 import type {ProvisionerAdapter, ProvisionerTemplate} from '#types.js';
 
@@ -212,6 +218,238 @@ describe('runProvisionerIteration', () => {
   });
 });
 
+describe('split demand and converge loops', () => {
+  it('runs convergence while demand polling is blocked', async () => {
+    const {client} = harness({response: {stats: [], reservations: []}});
+    let signalPollStarted!: () => void;
+    const pollStarted = new Promise<void>((resolve) => {
+      signalPollStarted = resolve;
+    });
+    let releasePoll!: (response: PollDemandResponseDto) => void;
+    const blockedPoll = new Promise<PollDemandResponseDto>((resolve) => {
+      releasePoll = resolve;
+    });
+    client.pollDemand = () => {
+      signalPollStarted();
+      return blockedPoll;
+    };
+    let observed = false;
+    const health = createHealthState();
+    const adapter: ProvisionerAdapter<null> = {
+      loadTemplates: () => Promise.resolve([template]),
+      launch: () => Promise.resolve(),
+      onTick: () => {
+        observed = true;
+        return Promise.resolve();
+      },
+    };
+
+    const demand = runDemandIteration({
+      adapter,
+      client,
+      templates: [template],
+      tracker: createInMemoryTracker(),
+      currentInterval: 1000,
+      health,
+    });
+    await pollStarted;
+
+    await runConvergeIteration({
+      adapter,
+      currentInterval: 1000,
+      baseInterval: 1000,
+      health,
+    });
+    expect(observed).toBe(true);
+
+    releasePoll({stats: [], reservations: [], terminate_provider_runner_ids: []});
+    await demand;
+  });
+
+  it('does not run observation concurrently with launch', async () => {
+    const {client} = harness({response: {stats: [], reservations: [reservation(1)]}});
+    let signalLaunchStarted!: () => void;
+    const launchStarted = new Promise<void>((resolve) => {
+      signalLaunchStarted = resolve;
+    });
+    let releaseLaunch!: () => void;
+    const blockedLaunch = new Promise<void>((resolve) => {
+      releaseLaunch = resolve;
+    });
+    const events: string[] = [];
+    const adapter: ProvisionerAdapter<null> = {
+      loadTemplates: () => Promise.resolve([template]),
+      launch: async () => {
+        events.push('launch-start');
+        signalLaunchStarted();
+        await blockedLaunch;
+        events.push('launch-end');
+      },
+      onTick: () => {
+        events.push('observe');
+        return Promise.resolve();
+      },
+    };
+    const health = createHealthState();
+    const withProviderLock = createTestMutex();
+
+    const demand = runDemandIteration({
+      adapter,
+      client,
+      templates: [template],
+      tracker: createInMemoryTracker(),
+      currentInterval: 1000,
+      health,
+      withProviderLock,
+    });
+    await launchStarted;
+
+    const converge = runConvergeIteration({
+      adapter,
+      currentInterval: 1000,
+      baseInterval: 1000,
+      health,
+      withProviderLock,
+    });
+    await Promise.resolve();
+    expect(events).toEqual(['launch-start']);
+
+    releaseLaunch();
+    await Promise.all([demand, converge]);
+    expect(events).toEqual(['launch-start', 'launch-end', 'observe']);
+  });
+
+  it('keeps advertised capacity at zero after a failed convergence pass', async () => {
+    const {client, pollBodies} = harness({response: {stats: [], reservations: []}});
+    const health = createHealthState();
+    const adapter: ProvisionerAdapter<null> = {
+      loadTemplates: () => Promise.resolve([template]),
+      launch: () => Promise.resolve(),
+      onTick: () => Promise.reject(new Error('provider unavailable')),
+    };
+
+    await runConvergeIteration({
+      adapter,
+      currentInterval: 1000,
+      baseInterval: 1000,
+      health,
+    });
+    await runDemandIteration({
+      adapter,
+      client,
+      templates: [template],
+      tracker: createInMemoryTracker(),
+      currentInterval: 1000,
+      health,
+    });
+
+    expect(pollBodies[0]?.max_reservations).toBe(0);
+  });
+
+  it('handles queued termination intents during convergence', async () => {
+    const {client} = harness({
+      response: {stats: [], reservations: [], terminate_provider_runner_ids: ['runner-1']},
+    });
+    const pending = new Set<string>();
+    const terminated: string[][] = [];
+    const adapter: ProvisionerAdapter<null> = {
+      loadTemplates: () => Promise.resolve([template]),
+      launch: () => Promise.resolve(),
+      terminate: (providerRunnerIds) => {
+        terminated.push([...providerRunnerIds]);
+        return Promise.resolve();
+      },
+    };
+
+    await runDemandIteration({
+      adapter,
+      client,
+      templates: [template],
+      tracker: createInMemoryTracker(),
+      currentInterval: 1000,
+      deferTermination: (providerRunnerIds) => {
+        for (const providerRunnerId of providerRunnerIds) pending.add(providerRunnerId);
+        return Promise.resolve();
+      },
+    });
+    await runConvergeIteration({
+      adapter,
+      currentInterval: 1000,
+      baseInterval: 1000,
+      takeTerminationIntents: () => {
+        const providerRunnerIds = [...pending];
+        pending.clear();
+        return providerRunnerIds;
+      },
+    });
+
+    expect(terminated).toEqual([['runner-1']]);
+    expect(pending).toEqual(new Set());
+  });
+
+  it('requeues termination intents when convergence termination fails', async () => {
+    const health = createHealthState();
+    const requeued: string[][] = [];
+    const adapter: ProvisionerAdapter<null> = {
+      loadTemplates: () => Promise.resolve([template]),
+      launch: () => Promise.resolve(),
+      terminate: () => Promise.reject(new Error('provider unavailable')),
+    };
+
+    await runConvergeIteration({
+      adapter,
+      currentInterval: 1000,
+      baseInterval: 1000,
+      health,
+      takeTerminationIntents: () => ['runner-1'],
+      requeueTerminationIntents: (providerRunnerIds) => requeued.push([...providerRunnerIds]),
+    });
+
+    expect(requeued).toEqual([['runner-1']]);
+  });
+
+  it('best-effort drains deferred terminations before shutdown', async () => {
+    const terminated: string[][] = [];
+    const adapter: ProvisionerAdapter<null> = {
+      loadTemplates: () => Promise.resolve([template]),
+      launch: () => Promise.resolve(),
+      terminate: (providerRunnerIds) => {
+        terminated.push([...providerRunnerIds]);
+        return Promise.resolve();
+      },
+    };
+
+    await drainTerminationQueue(adapter, () => ['runner-1', 'runner-2']);
+
+    expect(terminated).toEqual([['runner-1', 'runner-2']]);
+  });
+
+  it('logs and returns when deferred termination draining times out', async () => {
+    vi.useFakeTimers();
+    try {
+      const adapter: ProvisionerAdapter<null> = {
+        loadTemplates: () => Promise.resolve([template]),
+        launch: () => Promise.resolve(),
+        terminate: () =>
+          new Promise<void>(() => {
+            // Intentionally unresolved to exercise the shutdown deadline.
+          }),
+      };
+
+      const drain = drainTerminationQueue(adapter, () => ['runner-1']);
+      await vi.advanceTimersByTimeAsync(1000);
+      await drain;
+
+      expect(observability.logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({event: 'provisioner.termination_drain_timed_out'}),
+        expect.any(String),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
 describe('startProvisioner', () => {
   it('rejects more than 1000 templates with a clear error', async () => {
     const templates = Array.from({length: 1001}, (_, index) => ({
@@ -280,5 +518,22 @@ function reservation(count: number) {
     labels: ['ubuntu22'],
     count,
     expires_at: EXPIRES_AT,
+  };
+}
+
+function createTestMutex() {
+  let previous = Promise.resolve();
+  return async <Result>(operation: () => Promise<Result>): Promise<Result> => {
+    const predecessor = previous;
+    let release!: () => void;
+    previous = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await predecessor;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
   };
 }

--- a/libs/provisioner/core/src/provisioner.test.ts
+++ b/libs/provisioner/core/src/provisioner.test.ts
@@ -6,6 +6,7 @@ import type {
 import type {ProvisionerClient} from '#api-client.js';
 import {createHealthState} from '#health.js';
 import {
+  createTerminationQueue,
   drainTerminationQueue,
   runConvergeIteration,
   runDemandIteration,
@@ -219,6 +220,16 @@ describe('runProvisionerIteration', () => {
 });
 
 describe('split demand and converge loops', () => {
+  it('replaces deferred termination snapshots when demand withdraws an intent', async () => {
+    const queue = createTerminationQueue();
+
+    await queue.replace(['runner-1']);
+    expect(queue.take()).toEqual(['runner-1']);
+
+    await queue.replace([]);
+    expect(queue.take()).toEqual([]);
+  });
+
   it('runs convergence while demand polling is blocked', async () => {
     const {client} = harness({response: {stats: [], reservations: []}});
     let signalPollStarted!: () => void;

--- a/libs/provisioner/core/src/provisioner.ts
+++ b/libs/provisioner/core/src/provisioner.ts
@@ -175,7 +175,7 @@ export async function startProvisioner<Spec>(
   const terminationQueue = createTerminationQueue();
   const deferTermination = options.adapter.terminate
     ? (providerRunnerIds: readonly string[]) => {
-        terminationQueue.enqueue(providerRunnerIds);
+        terminationQueue.replace(providerRunnerIds);
         return Promise.resolve();
       }
     : undefined;
@@ -195,7 +195,7 @@ export async function startProvisioner<Spec>(
       baseInterval: config.SHIPFOX_PROVISIONER_CONVERGE_INTERVAL_MS,
       withProviderLock,
       takeTerminationIntents: () => terminationQueue.take(),
-      requeueTerminationIntents: (providerRunnerIds) => terminationQueue.enqueue(providerRunnerIds),
+      requeueTerminationIntents: (providerRunnerIds) => terminationQueue.requeue(providerRunnerIds),
     }),
   ];
 
@@ -574,15 +574,19 @@ function createProviderMutex(): ProviderPass {
 
 const inlineProviderPass: ProviderPass = <Result>(operation: () => Promise<Result>) => operation();
 
-function createTerminationQueue(): {
-  enqueue: TerminateRunners;
+export function createTerminationQueue(): {
+  replace: TerminateRunners;
+  requeue: (providerRunnerIds: readonly string[]) => void;
   take: () => readonly string[];
 } {
-  const pending = new Set<string>();
+  let pending = new Set<string>();
   return {
-    enqueue(providerRunnerIds) {
-      for (const providerRunnerId of providerRunnerIds) pending.add(providerRunnerId);
+    replace(providerRunnerIds) {
+      pending = new Set(providerRunnerIds);
       return Promise.resolve();
+    },
+    requeue(providerRunnerIds) {
+      for (const providerRunnerId of providerRunnerIds) pending.add(providerRunnerId);
     },
     take() {
       const providerRunnerIds = [...pending];

--- a/libs/provisioner/core/src/provisioner.ts
+++ b/libs/provisioner/core/src/provisioner.ts
@@ -20,13 +20,15 @@ import {
   type HealthState,
   reduceHealth,
 } from '#health.js';
-import {type RunnerEnvFactory, runProvisionerTick} from '#tick.js';
+import {type ProviderPass, type RunnerEnvFactory, runProvisionerTick} from '#tick.js';
 import {createInMemoryTracker, type ProviderRunnerTracker} from '#tracker.js';
-import type {ProvisionerAdapter, ProvisionerTemplate} from '#types.js';
+import type {ProvisionerAdapter, ProvisionerTemplate, TerminateRunners} from '#types.js';
 
 /** The demand poll accepts at most 1000 advertised templates per request. */
 const MAX_TEMPLATES_PER_POLL = 1000;
 const CONFIG_SAMPLE_LIMIT = 20;
+const CONVERGE_BACKOFF_FLOOR_MS = 5000;
+const TERMINATION_DRAIN_TIMEOUT_MS = 1000;
 
 let running = true;
 let pollAbortController: AbortController | undefined;
@@ -56,9 +58,27 @@ export interface RunProvisionerIterationDeps<Spec> {
   readonly currentInterval: number;
   readonly health?: ProvisionerHealthState;
   readonly signal?: AbortSignal;
+  readonly withProviderLock?: ProviderPass;
+  readonly deferTermination?: TerminateRunners;
 }
 
 export interface RunProvisionerIterationResult {
+  readonly nextInterval: number;
+  readonly degraded: boolean;
+}
+
+export interface RunConvergeIterationDeps<Spec> {
+  readonly adapter: ProvisionerAdapter<Spec>;
+  readonly currentInterval: number;
+  readonly baseInterval: number;
+  readonly health?: ProvisionerHealthState;
+  readonly signal?: AbortSignal;
+  readonly withProviderLock?: ProviderPass;
+  readonly takeTerminationIntents?: () => readonly string[];
+  readonly requeueTerminationIntents?: (providerRunnerIds: readonly string[]) => void;
+}
+
+export interface RunConvergeIterationResult {
   readonly nextInterval: number;
   readonly degraded: boolean;
 }
@@ -151,29 +171,47 @@ export async function startProvisioner<Spec>(
     });
   }
 
-  let currentInterval = config.SHIPFOX_PROVISIONER_POLL_INTERVAL_MS;
-  while (running) {
-    pollAbortController = new AbortController();
+  const withProviderLock = createProviderMutex();
+  const terminationQueue = createTerminationQueue();
+  const deferTermination = options.adapter.terminate
+    ? (providerRunnerIds: readonly string[]) => {
+        terminationQueue.enqueue(providerRunnerIds);
+        return Promise.resolve();
+      }
+    : undefined;
+  const loops = [
+    runDemandLoop({
+      adapter: options.adapter,
+      client,
+      templates,
+      tracker,
+      health,
+      withProviderLock,
+      ...(deferTermination ? {deferTermination} : {}),
+    }),
+    runConvergeLoop({
+      adapter: options.adapter,
+      health,
+      baseInterval: config.SHIPFOX_PROVISIONER_CONVERGE_INTERVAL_MS,
+      withProviderLock,
+      takeTerminationIntents: () => terminationQueue.take(),
+      requeueTerminationIntents: (providerRunnerIds) => terminationQueue.enqueue(providerRunnerIds),
+    }),
+  ];
+
+  try {
+    await Promise.all(loops);
+  } finally {
+    running = false;
+    pollAbortController?.abort('shutdown');
+    await Promise.allSettled(loops);
     try {
-      const iteration = await runProvisionerIteration({
-        adapter: options.adapter,
-        client,
-        templates,
-        tracker,
-        currentInterval,
-        health,
-        signal: pollAbortController.signal,
-      });
-      currentInterval = iteration.nextInterval;
-      await interruptableSleep(withJitter(currentInterval));
-    } catch {
-      if (!running) break;
-      currentInterval = nextBackoffInterval(currentInterval);
-      await interruptableSleep(withJitter(currentInterval));
+      await drainTerminationQueue(options.adapter, () => terminationQueue.take());
+      await options.adapter.onStop?.();
+    } finally {
+      shutdownController.stop();
     }
   }
-
-  await options.adapter.onStop?.();
   logger().info({event: 'provisioner.stopped'}, 'Provisioner stopped');
 }
 
@@ -181,32 +219,92 @@ export async function runProvisionerIteration<Spec>(
   deps: RunProvisionerIterationDeps<Spec>,
 ): Promise<RunProvisionerIterationResult> {
   const health = deps.health ?? createHealthState();
-  let derived = healthDerived(health);
-  let observed = false;
-  if (deps.adapter.onTick) {
+  const withProviderLock = deps.withProviderLock ?? createProviderMutex();
+  await runConvergeIteration({
+    adapter: deps.adapter,
+    currentInterval: config.SHIPFOX_PROVISIONER_CONVERGE_INTERVAL_MS,
+    baseInterval: config.SHIPFOX_PROVISIONER_CONVERGE_INTERVAL_MS,
+    health,
+    ...(deps.signal ? {signal: deps.signal} : {}),
+    withProviderLock,
+  });
+  return runDemandIteration({...deps, health, withProviderLock});
+}
+
+export async function runConvergeIteration<Spec>(
+  deps: RunConvergeIterationDeps<Spec>,
+): Promise<RunConvergeIterationResult> {
+  const health = deps.health ?? createHealthState();
+
+  let failed = false;
+  const withProviderLock = deps.withProviderLock ?? inlineProviderPass;
+  await withProviderLock(async () => {
+    if (deps.adapter.onTick) {
+      try {
+        await deps.adapter.onTick();
+        applyHealthEvent(health, {
+          type: 'facet_recovered',
+          facet: 'provider_observation',
+          at: new Date(),
+        });
+        applyHealthEvent(health, {type: 'ready_confirmed', at: new Date()});
+      } catch (error) {
+        if (deps.signal?.aborted) throw error;
+        failed = true;
+        applyHealthEvent(health, {
+          type: 'facet_failed',
+          facet: 'provider_observation',
+          cause: errorReason(error),
+          impact: 'capacity',
+          at: new Date(),
+        });
+      }
+    }
+
+    // Only take intents a pass can actually act on; taking them without a terminate
+    // port would drop them, since take() clears the queue.
+    if (!deps.adapter.terminate) return;
+    const terminationIntents = [...(deps.takeTerminationIntents?.() ?? [])];
+    if (terminationIntents.length === 0) return;
     try {
-      await deps.adapter.onTick();
+      await deps.adapter.terminate(terminationIntents);
       applyHealthEvent(health, {
         type: 'facet_recovered',
-        facet: 'provider_observation',
+        facet: 'provider_termination',
         at: new Date(),
       });
-      observed = true;
-      derived = healthDerived(health);
     } catch (error) {
+      // Requeue before the abort rethrow: a terminate that fails during shutdown is
+      // exactly the case where the intents must survive into the next pass.
+      deps.requeueTerminationIntents?.(terminationIntents);
       if (deps.signal?.aborted) throw error;
+      failed = true;
       applyHealthEvent(health, {
         type: 'facet_failed',
-        facet: 'provider_observation',
+        facet: 'provider_termination',
         cause: errorReason(error),
-        impact: 'capacity',
+        impact: 'cleanup',
         at: new Date(),
       });
-      derived = healthDerived(health);
     }
-  }
+  });
+
+  const derived = healthDerived(health);
+  return {
+    nextInterval: failed
+      ? nextConvergeInterval(deps.currentInterval, deps.baseInterval)
+      : deps.baseInterval,
+    degraded: derived.capacityDegraded,
+  };
+}
+
+export async function runDemandIteration<Spec>(
+  deps: RunProvisionerIterationDeps<Spec>,
+): Promise<RunProvisionerIterationResult> {
+  const health = deps.health ?? createHealthState();
+  const launchBudget = () => deriveLaunchBudget(health);
+
   const reservationLimit = config.SHIPFOX_PROVISIONER_MAX_RESERVATIONS;
-  const launchBudget = deriveLaunchBudget(health);
 
   let result: Awaited<ReturnType<typeof runProvisionerTick>>;
   try {
@@ -215,7 +313,11 @@ export async function runProvisionerIteration<Spec>(
       templates: deps.templates,
       tracker: deps.tracker,
       launch: deps.adapter.launch,
-      ...(deps.adapter.terminate ? {terminate: deps.adapter.terminate} : {}),
+      ...(deps.deferTermination
+        ? {terminate: deps.deferTermination}
+        : deps.adapter.terminate
+          ? {terminate: deps.adapter.terminate}
+          : {}),
       buildRunnerEnv,
       reservationLimit,
       launchBudget,
@@ -223,6 +325,7 @@ export async function runProvisionerIteration<Spec>(
       runnerInstanceBatchSize: config.SHIPFOX_PROVISIONER_RUNNER_INSTANCE_BATCH_SIZE,
       retryIntervalMs: deps.currentInterval,
       ...(deps.signal ? {signal: deps.signal} : {}),
+      ...(deps.withProviderLock ? {withProviderLock: deps.withProviderLock} : {}),
     });
     applyHealthEvent(health, {type: 'facet_recovered', facet: 'poll_demand', at: new Date()});
     applyHealthEvent(health, {type: 'facet_recovered', facet: 'authentication', at: new Date()});
@@ -240,23 +343,25 @@ export async function runProvisionerIteration<Spec>(
     throw error;
   }
 
-  if (result.providerTermination.status === 'failed') {
-    applyHealthEvent(health, {
-      type: 'facet_failed',
-      facet: 'provider_termination',
-      cause: result.providerTermination.cause,
-      impact: 'cleanup',
-      at: new Date(),
-    });
-  } else if (
-    result.providerTermination.status === 'succeeded' ||
-    result.providerTermination.status === 'not_needed'
-  ) {
-    applyHealthEvent(health, {
-      type: 'facet_recovered',
-      facet: 'provider_termination',
-      at: new Date(),
-    });
+  if (!deps.deferTermination) {
+    if (result.providerTermination.status === 'failed') {
+      applyHealthEvent(health, {
+        type: 'facet_failed',
+        facet: 'provider_termination',
+        cause: result.providerTermination.cause,
+        impact: 'cleanup',
+        at: new Date(),
+      });
+    } else if (
+      result.providerTermination.status === 'succeeded' ||
+      result.providerTermination.status === 'not_needed'
+    ) {
+      applyHealthEvent(health, {
+        type: 'facet_recovered',
+        facet: 'provider_termination',
+        at: new Date(),
+      });
+    }
   }
 
   const hasCapacityFailure =
@@ -279,11 +384,11 @@ export async function runProvisionerIteration<Spec>(
     applyHealthEvent(health, {type: 'facet_recovered', facet: 'runner_capacity', at: new Date()});
   }
 
-  derived = healthDerived(health);
-  if (observed || result.launchedCount > 0) {
+  if (result.launchedCount > 0) {
     applyHealthEvent(health, {type: 'ready_confirmed', at: new Date()});
-    derived = healthDerived(health);
   }
+
+  const derived = healthDerived(health);
 
   if (result.reservationCount > 0 || result.launchedCount > 0 || result.launchAttemptedCount > 0) {
     logger().info(
@@ -312,6 +417,49 @@ export async function runProvisionerIteration<Spec>(
   };
 }
 
+/** Best-effort delivery for deferred terminations before the provider stops. */
+export async function drainTerminationQueue<Spec>(
+  adapter: ProvisionerAdapter<Spec>,
+  takeTerminationIntents: () => readonly string[],
+): Promise<void> {
+  if (!adapter.terminate) return;
+  const providerRunnerIds = [...takeTerminationIntents()];
+  if (providerRunnerIds.length === 0) return;
+
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const outcome = await Promise.race([
+    adapter.terminate(providerRunnerIds).then(
+      () => 'completed' as const,
+      (error: unknown) => {
+        logger().warn(
+          {
+            event: 'provisioner.termination_drain_failed',
+            providerRunnerCount: providerRunnerIds.length,
+            reason: errorReason(error),
+          },
+          'Deferred provider terminations failed during shutdown',
+        );
+        return 'failed' as const;
+      },
+    ),
+    new Promise<'timed_out'>((resolve) => {
+      timeout = setTimeout(() => resolve('timed_out'), TERMINATION_DRAIN_TIMEOUT_MS);
+    }),
+  ]);
+  if (timeout) clearTimeout(timeout);
+
+  if (outcome === 'timed_out') {
+    logger().warn(
+      {
+        event: 'provisioner.termination_drain_timed_out',
+        providerRunnerCount: providerRunnerIds.length,
+        timeoutMs: TERMINATION_DRAIN_TIMEOUT_MS,
+      },
+      'Deferred provider terminations did not complete before shutdown',
+    );
+  }
+}
+
 export const buildRunnerEnv: RunnerEnvFactory<unknown> = ({template, bootstrapToken}) => ({
   SHIPFOX_API_URL: config.SHIPFOX_RUNNER_API_URL ?? config.SHIPFOX_API_URL,
   SHIPFOX_RUNNER_BOOTSTRAP_TOKEN: bootstrapToken,
@@ -333,6 +481,115 @@ export function withJitter(ms: number): number {
 async function interruptableSleep(ms: number): Promise<void> {
   if (!running) return;
   await interruptibleSleep(ms, shutdownController.signal);
+}
+
+async function runDemandLoop<Spec>(deps: {
+  readonly adapter: ProvisionerAdapter<Spec>;
+  readonly client: ProvisionerClient;
+  readonly templates: readonly ProvisionerTemplate<Spec>[];
+  readonly tracker: ProviderRunnerTracker;
+  readonly health: ProvisionerHealthState;
+  readonly withProviderLock: ProviderPass;
+  readonly deferTermination?: TerminateRunners;
+}): Promise<void> {
+  let currentInterval = config.SHIPFOX_PROVISIONER_POLL_INTERVAL_MS;
+  while (running) {
+    const abortController = new AbortController();
+    pollAbortController = abortController;
+    try {
+      const iteration = await runDemandIteration({
+        adapter: deps.adapter,
+        client: deps.client,
+        templates: deps.templates,
+        tracker: deps.tracker,
+        currentInterval,
+        health: deps.health,
+        signal: abortController.signal,
+        withProviderLock: deps.withProviderLock,
+        ...(deps.deferTermination ? {deferTermination: deps.deferTermination} : {}),
+      });
+      currentInterval = iteration.nextInterval;
+    } catch {
+      if (!running) break;
+      currentInterval = nextBackoffInterval(currentInterval);
+    } finally {
+      pollAbortController = undefined;
+    }
+    await interruptableSleep(withJitter(currentInterval));
+  }
+}
+
+async function runConvergeLoop<Spec>(deps: {
+  readonly adapter: ProvisionerAdapter<Spec>;
+  readonly health: ProvisionerHealthState;
+  readonly baseInterval: number;
+  readonly withProviderLock: ProviderPass;
+  readonly takeTerminationIntents: () => readonly string[];
+  readonly requeueTerminationIntents: (providerRunnerIds: readonly string[]) => void;
+}): Promise<void> {
+  let currentInterval = deps.baseInterval;
+  while (running) {
+    try {
+      const iteration = await runConvergeIteration({
+        adapter: deps.adapter,
+        currentInterval,
+        baseInterval: deps.baseInterval,
+        health: deps.health,
+        signal: shutdownController.signal,
+        withProviderLock: deps.withProviderLock,
+        takeTerminationIntents: deps.takeTerminationIntents,
+        requeueTerminationIntents: deps.requeueTerminationIntents,
+      });
+      currentInterval = iteration.nextInterval;
+    } catch {
+      if (!running) break;
+      currentInterval = nextConvergeInterval(currentInterval, deps.baseInterval);
+    }
+    await interruptableSleep(withJitter(currentInterval));
+  }
+}
+
+function nextConvergeInterval(currentInterval: number, baseInterval: number): number {
+  return calculateNextBackoffInterval(currentInterval, {
+    maxMs: Math.max(baseInterval, CONVERGE_BACKOFF_FLOOR_MS),
+  });
+}
+
+function createProviderMutex(): ProviderPass {
+  let previous = Promise.resolve();
+  return async <Result>(operation: () => Promise<Result>): Promise<Result> => {
+    const predecessor = previous;
+    let release!: () => void;
+    previous = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await predecessor;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  };
+}
+
+const inlineProviderPass: ProviderPass = <Result>(operation: () => Promise<Result>) => operation();
+
+function createTerminationQueue(): {
+  enqueue: TerminateRunners;
+  take: () => readonly string[];
+} {
+  const pending = new Set<string>();
+  return {
+    enqueue(providerRunnerIds) {
+      for (const providerRunnerId of providerRunnerIds) pending.add(providerRunnerId);
+      return Promise.resolve();
+    },
+    take() {
+      const providerRunnerIds = [...pending];
+      pending.clear();
+      return providerRunnerIds;
+    },
+  };
 }
 
 function applyHealthEvent(state: HealthState, event: HealthEvent): void {

--- a/libs/provisioner/core/src/tick.test.ts
+++ b/libs/provisioner/core/src/tick.test.ts
@@ -290,4 +290,154 @@ describe('runProvisionerTick', () => {
     expect(requestedReservations).toBe(0);
     expect(result).toMatchObject({plannedCount: 2, launchAttemptedCount: 2, launchedCount: 2});
   });
+
+  it('plans from tracker capacity observed after the demand poll', async () => {
+    const tracker = createInMemoryTracker();
+    let requestedReservations = -1;
+    const client = createTestClient({
+      pollDemand: (body) => {
+        requestedReservations = body.max_reservations;
+        tracker.recordStarting({providerRunnerId: 'existing', templateKey: 'linux'});
+        return Promise.resolve(demandResponse());
+      },
+    });
+
+    const result = await runProvisionerTick({
+      client,
+      templates: [{key: 'linux', labels: ['linux'], maxConcurrency: 1, cost: 1, spec: null}],
+      tracker,
+      launch: () => Promise.resolve(),
+      buildRunnerEnv: ({bootstrapToken}) => ({SHIPFOX_RUNNER_BOOTSTRAP_TOKEN: bootstrapToken}),
+      reservationLimit: 1,
+      launchBudget: 1,
+      waitSeconds: 0,
+      runnerInstanceBatchSize: 1,
+    });
+
+    expect(requestedReservations).toBe(1);
+    expect(result).toMatchObject({reservationCount: 1, plannedCount: 0, launchAttemptedCount: 0});
+  });
+
+  it('re-evaluates a lazy launch budget after polling demand', async () => {
+    let requestedReservations = -1;
+    const budgets = [1, 0];
+    const client = createTestClient({
+      pollDemand: (body) => {
+        requestedReservations = body.max_reservations;
+        return Promise.resolve(demandResponse());
+      },
+      createRunnerInstances: async () => ({
+        runner_instances: [{runner_instance_id: 'runner-instance', bootstrap_token: 'sf_rbt_test'}],
+      }),
+    });
+
+    const result = await runProvisionerTick({
+      client,
+      templates: [{key: 'linux', labels: ['linux'], maxConcurrency: 1, cost: 1, spec: null}],
+      tracker: createInMemoryTracker(),
+      launch: () => Promise.resolve(),
+      buildRunnerEnv: ({bootstrapToken}) => ({SHIPFOX_RUNNER_BOOTSTRAP_TOKEN: bootstrapToken}),
+      reservationLimit: 1,
+      launchBudget: () => budgets.shift() ?? 0,
+      waitSeconds: 0,
+      runnerInstanceBatchSize: 1,
+    });
+
+    expect(requestedReservations).toBe(1);
+    expect(result).toMatchObject({plannedCount: 1, launchAttemptedCount: 0, launchedCount: 0});
+  });
+
+  it('holds completion mutations behind the provider lock', async () => {
+    let signalPollStarted!: () => void;
+    const pollStarted = new Promise<void>((resolve) => {
+      signalPollStarted = resolve;
+    });
+    let releasePoll!: (response: ReturnType<typeof demandResponse>) => void;
+    const pollResponse = new Promise<ReturnType<typeof demandResponse>>((resolve) => {
+      releasePoll = resolve;
+    });
+    const client = createTestClient({
+      pollDemand: () => {
+        signalPollStarted();
+        return pollResponse;
+      },
+      createRunnerInstances: async () => ({
+        runner_instances: [{runner_instance_id: 'runner-instance', bootstrap_token: 'sf_rbt_test'}],
+      }),
+    });
+    const launches: string[] = [];
+    let releaseLock!: () => void;
+    const lock = new Promise<void>((resolve) => {
+      releaseLock = resolve;
+    });
+    let signalLockEntered!: () => void;
+    const lockEntered = new Promise<void>((resolve) => {
+      signalLockEntered = resolve;
+    });
+    const withProviderLock = async <Result>(operation: () => Promise<Result>) => {
+      signalLockEntered();
+      await lock;
+      return operation();
+    };
+
+    const tick = runProvisionerTick({
+      client,
+      templates: [{key: 'linux', labels: ['linux'], maxConcurrency: 1, cost: 1, spec: null}],
+      tracker: createInMemoryTracker(),
+      launch: () => {
+        launches.push('launch');
+        return Promise.resolve();
+      },
+      buildRunnerEnv: ({bootstrapToken}) => ({SHIPFOX_RUNNER_BOOTSTRAP_TOKEN: bootstrapToken}),
+      reservationLimit: 1,
+      launchBudget: 1,
+      waitSeconds: 0,
+      runnerInstanceBatchSize: 1,
+      withProviderLock,
+    });
+
+    await pollStarted;
+    releasePoll(demandResponse());
+    await lockEntered;
+    expect(launches).toEqual([]);
+
+    releaseLock();
+    await tick;
+    expect(launches).toEqual(['launch']);
+  });
 });
+
+function createTestClient(options: {
+  readonly pollDemand: ProvisionerClient['pollDemand'];
+  readonly createRunnerInstances?: ProvisionerClient['createRunnerInstances'];
+}): ProvisionerClient {
+  return {
+    getIdentity: async () => ({id: 'provisioner', scope: 'workspace', workspace_id: 'workspace'}),
+    pollDemand: options.pollDemand,
+    createRunnerInstances: options.createRunnerInstances ?? (async () => ({runner_instances: []})),
+    attachRunnerInstanceProviderId: async () => ({attached: true}),
+    assignRunnerInstances: async (_reservationId, runnerInstanceIds) => ({
+      runner_instance_ids: runnerInstanceIds,
+    }),
+    reportRunnerInstances: async () => ({accepted: 0, reservations_released: 0}),
+    reconcileRunnerInstances: async () => ({
+      runners: [],
+      terminated_absent_provider_runner_ids: [],
+    }),
+  };
+}
+
+function demandResponse() {
+  return {
+    stats: [],
+    reservations: [
+      {
+        reservation_id: '018f0d4c-5f42-7b7e-9d9b-4a7d8e6f0001',
+        labels: ['linux'],
+        count: 1,
+        expires_at: '2026-07-21T12:00:00.000Z',
+      },
+    ],
+    terminate_provider_runner_ids: [],
+  };
+}

--- a/libs/provisioner/core/src/tick.ts
+++ b/libs/provisioner/core/src/tick.ts
@@ -27,6 +27,8 @@ export type RunnerEnvFactory<Spec> = (args: {
   bootstrapToken: string;
 }) => Record<string, string>;
 
+export type ProviderPass = <Result>(operation: () => Promise<Result>) => Promise<Result>;
+
 export interface ProvisionerTickDeps<Spec> {
   readonly client: ProvisionerClient;
   readonly templates: readonly ProvisionerTemplate<Spec>[];
@@ -35,11 +37,12 @@ export interface ProvisionerTickDeps<Spec> {
   readonly terminate?: TerminateRunners;
   readonly buildRunnerEnv: RunnerEnvFactory<Spec>;
   readonly reservationLimit: number;
-  readonly launchBudget: number;
+  readonly launchBudget: number | (() => number);
   readonly waitSeconds: number;
   readonly runnerInstanceBatchSize: number;
   readonly retryIntervalMs?: number;
   readonly signal?: AbortSignal;
+  readonly withProviderLock?: ProviderPass;
 }
 
 export type ProvisionerTerminationOutcome =
@@ -86,21 +89,16 @@ export async function runProvisionerTick<Spec>(
     };
   });
 
-  const availableByKey = new Map(
-    advertisements.map((advertisement) => [
-      advertisement.template_key,
-      advertisement.available_slots,
-    ]),
-  );
   const totalAvailable = advertisements.reduce(
     (sum, advertisement) => sum + advertisement.available_slots,
     0,
   );
+  const launchBudget = resolveLaunchBudget(deps.launchBudget);
   // Respect local max concurrency before asking: never reserve more than there are
   // free slots to fill (and never more than the API will grant in one poll).
   const pollReservationLimit = Math.min(
     deps.reservationLimit,
-    deps.launchBudget,
+    launchBudget,
     totalAvailable,
     MAX_RESERVATIONS_PER_POLL,
   );
@@ -114,6 +112,14 @@ export async function runProvisionerTick<Spec>(
     deps.signal ? {signal: deps.signal} : {},
   );
 
+  const complete = () => completeProvisionerTick(deps, response);
+  return deps.withProviderLock ? deps.withProviderLock(complete) : complete();
+}
+
+async function completeProvisionerTick<Spec>(
+  deps: ProvisionerTickDeps<Spec>,
+  response: Awaited<ReturnType<ProvisionerClient['pollDemand']>>,
+): Promise<ProvisionerTickResult> {
   let providerTermination: ProvisionerTerminationOutcome;
   if (deps.signal?.aborted) {
     providerTermination = {status: 'cancelled'};
@@ -139,6 +145,15 @@ export async function runProvisionerTick<Spec>(
     providerTermination = {status: 'not_needed'};
   }
 
+  const availableByKey = new Map(
+    deps.templates.map((template) => {
+      const counts = deps.tracker.countsByTemplate().get(template.key) ?? {
+        starting: 0,
+        running: 0,
+      };
+      return [template.key, templateAvailableSlots(template, counts)];
+    }),
+  );
   const planned = planLaunches({
     reservations: response.reservations.map((reservation) => ({
       reservationId: reservation.reservation_id,
@@ -183,7 +198,7 @@ export async function runProvisionerTick<Spec>(
   });
   const allGroups: LaunchGroup<Spec>[] = [...planned, ...hotGroups];
   plannedCount = allGroups.reduce((sum, group) => sum + group.count, 0);
-  const budgetedGroups = limitLaunchGroups(allGroups, deps.launchBudget);
+  const budgetedGroups = limitLaunchGroups(allGroups, resolveLaunchBudget(deps.launchBudget));
   const reservationGroups = budgetedGroups.filter(
     (group): group is PlannedLaunchGroup<Spec> => group.reservationId !== undefined,
   );
@@ -362,6 +377,10 @@ async function launchReservation<Spec>(
 
 function instanceCreationFailureReason(error: unknown): string {
   return error instanceof Error ? error.message.slice(0, 500) : String(error).slice(0, 500);
+}
+
+function resolveLaunchBudget(budget: number | (() => number)): number {
+  return typeof budget === 'function' ? budget() : budget;
 }
 
 function launchFailureReason(error: unknown): string {


### PR DESCRIPTION
Separates provisioner demand polling from provider convergence so provider observation and termination handling remain responsive while the control plane is long-polling. The change also adds health-aware launch budgeting, resilient shutdown cleanup, focused regression coverage, and the release changeset.

The provider mutex intentionally remains around each complete launch batch so tracker state and capacity planning stay atomic.

Closes ENG-1332

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split demand polling from provider convergence in `@shipfox/provisioner-core` so provider observation and termination stay responsive during long-polls. Adds snapshot-based termination handling, health-aware launch budgeting, and resilient shutdown cleanup. Fulfills ENG-1332.

- **New Features**
  - Separate demand and convergence loops with independent cadence/backoff; observation runs while the control plane long-polls.
  - New `SHIPFOX_PROVISIONER_CONVERGE_INTERVAL_MS` (>0). Convergence backoff caps at max(5000ms, cadence).
  - Termination uses snapshot semantics: each demand poll replaces the queue; convergence applies intents and requeues on failure; best-effort 1s drain on shutdown with warnings.
  - Provider mutex around each launch batch and tick completion so observation never overlaps with launch.
  - Health-aware, lazy launch budget; after a failed convergence pass, advertised capacity is zero. Planning uses tracker capacity observed after the poll.
  - Updated docs and added tests for loop splitting, config validation, budgeting, locking, termination, and shutdown behavior.

<sup>Written for commit ac816fda05601fbe40f7b734dca725f20e374eb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

