### PR TITLE
[api-auth] Reopen bootstrap recovery after owner suspension

### DIFF
--- a/.changeset/calm-owners-recover.md
+++ b/.changeset/calm-owners-recover.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-auth": patch
+---
+
+Treats suspended users as inactive admin owners during bootstrap recovery.

--- a/docs/adr/0008-administration-controls.md
+++ b/docs/adr/0008-administration-controls.md
@@ -87,6 +87,12 @@ token safely, publishes its administration-action event in the same
 transaction, and rejects later bootstrap attempts while an active owner exists.
 The token never enters browser storage, API responses, logs, or audit metadata.
 
+**A suspended owner does not count as an active owner.** The grant remains
+stored, but a user account with `suspended` status is excluded from the active
+owner check. If that leaves no active owner, authenticated bootstrap recovery
+is intentionally available again with the deployment token. Reactivating the
+owner closes bootstrap while the grant remains valid.
+
 ### Domain modules own administration behavior
 
 **Each domain module owns administration behavior for its resources.** The

--- a/libs/api/auth/README.md
+++ b/libs/api/auth/README.md
@@ -247,6 +247,8 @@ Bootstrap and grant-management routes are mounted under `/admin/auth/admin-grant
 
 `POST` and `DELETE` routes require an `Idempotency-Key` header; a repeated key replays the same result, and reusing a key with a different command returns `409 idempotency-key-reused`. Every mutation writes a redacted `administration.action.performed` outbox event.
 
+Bootstrap remains closed only while an active `admin-owner` exists. An owner is active when its grant is not revoked and its user account has `active` status. A suspended owner does not count as active, so suspending the sole owner intentionally reopens deployment-token bootstrap for recovery. The suspended grant remains stored; reactivating that user closes bootstrap again.
+
 ### Rate limiting
 
 The public auth endpoints include an application-layer abuse baseline for open source installs:

--- a/libs/api/auth/src/db/admin-grants.test.ts
+++ b/libs/api/auth/src/db/admin-grants.test.ts
@@ -31,7 +31,7 @@ describe('admin grants db', () => {
     expect(await findCurrentAdminRole({userId: user.id})).toBeNull();
   });
 
-  test('does not report a suspended owner as active', async () => {
+  test('reopens bootstrap when the sole owner user is suspended', async () => {
     const user = await userFactory.create({emailVerifiedAt: new Date()});
     await createAdminGrant({userId: user.id, role: 'admin-owner'});
 

--- a/libs/api/auth/src/db/admin-grants.ts
+++ b/libs/api/auth/src/db/admin-grants.ts
@@ -32,6 +32,24 @@ import {authOutbox} from './schema/outbox.js';
 import {users} from './schema/users.js';
 
 type Tx = Parameters<Parameters<ReturnType<typeof db>['transaction']>[0]>[0];
+type AdminOwnerQueryExecutor = ReturnType<typeof db> | Tx;
+
+function activeAdminOwnerWhere() {
+  return and(
+    eq(adminGrants.role, 'admin-owner'),
+    isNull(adminGrants.revokedAt),
+    eq(users.status, 'active'),
+  );
+}
+
+async function listActiveAdminOwners(executor: AdminOwnerQueryExecutor) {
+  return await executor
+    .select({id: adminGrants.id})
+    .from(adminGrants)
+    .innerJoin(users, eq(adminGrants.userId, users.id))
+    .where(activeAdminOwnerWhere())
+    .limit(2);
+}
 
 export interface CreateAdminGrantParams {
   userId: string;
@@ -95,23 +113,6 @@ export async function listAdminGrantSummaries(params: {
   };
 }
 
-export async function hasActiveAdminOwner(): Promise<boolean> {
-  const rows = await db()
-    .select({id: adminGrants.id})
-    .from(adminGrants)
-    .innerJoin(users, eq(adminGrants.userId, users.id))
-    .where(
-      and(
-        eq(adminGrants.role, 'admin-owner'),
-        isNull(adminGrants.revokedAt),
-        eq(users.status, 'active'),
-      ),
-    )
-    .limit(1);
-
-  return rows.length > 0;
-}
-
 export async function findCurrentAdminRole(params: {userId: string}): Promise<AdminRole | null> {
   const rows = await db()
     .select({role: adminGrants.role})
@@ -126,6 +127,18 @@ export async function findCurrentAdminRole(params: {userId: string}): Promise<Ad
     );
 
   return highestAdminRole(rows.map(({role}) => role));
+}
+
+/**
+ * An owner is active only while both the grant and its user account remain
+ * active. A suspended owner's grant is retained, but it intentionally does
+ * not prevent deployment-bound bootstrap recovery.
+ */
+export async function hasActiveAdminOwner(
+  executor: AdminOwnerQueryExecutor = db(),
+): Promise<boolean> {
+  const rows = await listActiveAdminOwners(executor);
+  return rows.length > 0;
 }
 
 export async function revokeAdminGrant(params: {grantId: string}): Promise<AdminGrant | undefined> {
@@ -143,17 +156,7 @@ export async function revokeAdminGrant(params: {grantId: string}): Promise<Admin
     if (!grant) return undefined;
 
     if (grant.role === 'admin-owner') {
-      const activeOwners = await tx
-        .select({id: adminGrants.id})
-        .from(adminGrants)
-        .innerJoin(users, eq(adminGrants.userId, users.id))
-        .where(
-          and(
-            eq(adminGrants.role, 'admin-owner'),
-            isNull(adminGrants.revokedAt),
-            eq(users.status, 'active'),
-          ),
-        );
+      const activeOwners = await listActiveAdminOwners(tx);
       if (activeOwners.length <= 1) throw new LastAdminOwnerError();
     }
 
@@ -269,19 +272,7 @@ export async function bootstrapFirstAdminOwner(
     });
     if (existing) return existing;
 
-    const activeOwners = await tx
-      .select({id: adminGrants.id})
-      .from(adminGrants)
-      .innerJoin(users, eq(adminGrants.userId, users.id))
-      .where(
-        and(
-          eq(adminGrants.role, 'admin-owner'),
-          isNull(adminGrants.revokedAt),
-          eq(users.status, 'active'),
-        ),
-      )
-      .limit(1);
-    if (activeOwners.length > 0) throw new AdminBootstrapClosedError();
+    if (await hasActiveAdminOwner(tx)) throw new AdminBootstrapClosedError();
 
     const userRows = await tx
       .select({id: users.id, status: users.status})
@@ -375,17 +366,7 @@ export async function revokeAdminGrantWithAudit(
     if (!grant) throw new AdminGrantNotFoundError();
 
     if (grant.role === 'admin-owner') {
-      const activeOwners = await tx
-        .select({id: adminGrants.id})
-        .from(adminGrants)
-        .innerJoin(users, eq(adminGrants.userId, users.id))
-        .where(
-          and(
-            eq(adminGrants.role, 'admin-owner'),
-            isNull(adminGrants.revokedAt),
-            eq(users.status, 'active'),
-          ),
-        );
+      const activeOwners = await listActiveAdminOwners(tx);
       if (activeOwners.length <= 1) throw new LastAdminOwnerError();
     }
 


### PR DESCRIPTION
## Summary

When the sole admin owner is suspended, the retained grant no longer counts as an active owner, so authenticated deployment-token bootstrap recovery is available again. Reactivating the user closes bootstrap again.

The active-owner predicate is shared by bootstrap and final-owner revocation checks, with the behavior covered by a database test and documented in the Auth README and administration ADR. The bootstrap-state route is provided by the rebased main baseline; this change aligns its active-owner behavior with the same predicate.

Validated with the api-auth check, type, test, and build tasks, repository documentation verification, Changeset status, and diff whitespace checks.

Closes ENG-1366