### PR TITLE
[api-runners] Activate prewarmed runners for queued jobs

### DIFF
--- a/.changeset/bind-idle-runners.md
+++ b/.changeset/bind-idle-runners.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-runners": patch
+---
+
+Binds idle enrolled runners to newly granted reservations so prewarmed capacity can activate queued jobs.

--- a/libs/api/runners/src/db/reservations.test.ts
+++ b/libs/api/runners/src/db/reservations.test.ts
@@ -7,6 +7,8 @@ import {
   releaseReservationUnits,
 } from '#db/reservations.js';
 import {reservations} from '#db/schema/reservations.js';
+import {runnerControlSessions} from '#db/schema/runner-control-sessions.js';
+import {providerRunners} from '#db/schema/runner-instances.js';
 import {pendingJobFactory, reservationFactory} from '#test/index.js';
 
 describe('pollDemandAndReserve', () => {
@@ -32,6 +34,108 @@ describe('pollDemandAndReserve', () => {
     expect(result.reservations).toHaveLength(1);
     expect(result.reservations[0]?.count).toBe(20);
     expect(result.stats[0]).toMatchObject({labels: ['linux'], queued: 50, reserved: 20});
+  });
+
+  it('binds the oldest matching enrolled runners to a new reservation', async () => {
+    const olderRunner = await createIdleRunner({
+      labels: ['linux'],
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+    const newerRunner = await createIdleRunner({
+      labels: ['linux'],
+      createdAt: new Date('2026-01-02T00:00:00.000Z'),
+    });
+    const unmatchedRunner = await createIdleRunner({
+      labels: ['macos'],
+      createdAt: new Date('2026-01-03T00:00:00.000Z'),
+    });
+    await createPendingJobs(2, ['linux']);
+
+    const result = await pollDemandAndReserve({
+      workspaceId,
+      provisionerId,
+      maxReservations: 2,
+      ttlSeconds: 60,
+      templates: [template('linux', ['linux'], 2)],
+    });
+
+    const rows = await db()
+      .select()
+      .from(providerRunners)
+      .where(inArray(providerRunners.id, [olderRunner.id, newerRunner.id, unmatchedRunner.id]));
+    const rowsById = new Map(rows.map((row) => [row.id, row]));
+    const reservationId = result.reservations[0]?.reservationId;
+
+    expect(reservationId).toEqual(expect.any(String));
+    expect(rowsById.get(olderRunner.id)).toMatchObject({
+      workspaceId,
+      reservationId,
+      assignedAt: expect.any(Date),
+    });
+    expect(rowsById.get(newerRunner.id)).toMatchObject({
+      workspaceId,
+      reservationId,
+      assignedAt: expect.any(Date),
+    });
+    expect(rowsById.get(unmatchedRunner.id)).toMatchObject({
+      workspaceId: null,
+      reservationId: null,
+      assignedAt: null,
+    });
+  });
+
+  it('does not bind a running runner without an active control session', async () => {
+    const [runner] = await db()
+      .insert(providerRunners)
+      .values({
+        provisionerId,
+        providerRunnerId: 'un-enrolled-runner',
+        labels: ['linux'],
+        state: 'running',
+        reportedAt: new Date(),
+      })
+      .returning();
+    if (!runner) throw new Error('Expected runner instance');
+    await createPendingJobs(1, ['linux']);
+
+    const result = await pollDemandAndReserve({
+      workspaceId,
+      provisionerId,
+      maxReservations: 1,
+      ttlSeconds: 60,
+      templates: [template('linux', ['linux'], 1)],
+    });
+
+    const [storedRunner] = await db()
+      .select()
+      .from(providerRunners)
+      .where(eq(providerRunners.id, runner.id));
+    expect(result.reservations[0]?.count).toBe(1);
+    expect(storedRunner).toMatchObject({workspaceId: null, reservationId: null});
+  });
+
+  it('does not grant another reservation after idle runners are covered', async () => {
+    await createIdleRunner({labels: ['linux']});
+    await createPendingJobs(1, ['linux']);
+
+    const firstResult = await pollDemandAndReserve({
+      workspaceId,
+      provisionerId,
+      maxReservations: 1,
+      ttlSeconds: 60,
+      templates: [template('linux', ['linux'], 1)],
+    });
+    const secondResult = await pollDemandAndReserve({
+      workspaceId,
+      provisionerId,
+      maxReservations: 1,
+      ttlSeconds: 60,
+      templates: [template('linux', ['linux'], 1)],
+    });
+
+    expect(firstResult.reservations).toHaveLength(1);
+    expect(secondResult.reservations).toEqual([]);
+    expect(secondResult.stats[0]).toMatchObject({queued: 1, reserved: 1});
   });
 
   it('allocates overlapping label sets most-specific-first', async () => {
@@ -418,6 +522,34 @@ describe('pollDemandAndReserve', () => {
     for (let index = 0; index < count; index++) {
       await pendingJobFactory.create({workspaceId, requiredLabels});
     }
+  }
+
+  async function createIdleRunner(params: {labels: string[]; createdAt?: Date}) {
+    const createdAt = params.createdAt ?? new Date();
+    const [runner] = await db()
+      .insert(providerRunners)
+      .values({
+        provisionerId,
+        providerRunnerId: crypto.randomUUID(),
+        labels: params.labels,
+        state: 'running',
+        reportedAt: createdAt,
+        createdAt,
+        updatedAt: createdAt,
+      })
+      .returning();
+    if (!runner) throw new Error('Expected runner instance');
+
+    await db()
+      .insert(runnerControlSessions)
+      .values({
+        runnerInstanceId: runner.id,
+        provisionerId,
+        hashedToken: crypto.randomUUID(),
+        prefix: 'test',
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+    return runner;
   }
 
   async function activeReservedCount(): Promise<number> {

--- a/libs/api/runners/src/db/reservations.test.ts
+++ b/libs/api/runners/src/db/reservations.test.ts
@@ -7,6 +7,7 @@ import {
   releaseReservationUnits,
 } from '#db/reservations.js';
 import {reservations} from '#db/schema/reservations.js';
+import {runnerActivationTokens} from '#db/schema/runner-activation-tokens.js';
 import {runnerControlSessions} from '#db/schema/runner-control-sessions.js';
 import {providerRunners} from '#db/schema/runner-instances.js';
 import {pendingJobFactory, reservationFactory} from '#test/index.js';
@@ -96,6 +97,29 @@ describe('pollDemandAndReserve', () => {
       })
       .returning();
     if (!runner) throw new Error('Expected runner instance');
+    await createPendingJobs(1, ['linux']);
+
+    const result = await pollDemandAndReserve({
+      workspaceId,
+      provisionerId,
+      maxReservations: 1,
+      ttlSeconds: 60,
+      templates: [template('linux', ['linux'], 1)],
+    });
+
+    const [storedRunner] = await db()
+      .select()
+      .from(providerRunners)
+      .where(eq(providerRunners.id, runner.id));
+    expect(result.reservations[0]?.count).toBe(1);
+    expect(storedRunner).toMatchObject({workspaceId: null, reservationId: null});
+  });
+
+  it('does not bind a runner with an expired control session', async () => {
+    const runner = await createIdleRunner({
+      labels: ['linux'],
+      controlSessionExpiresAt: new Date(Date.now() - 60_000),
+    });
     await createPendingJobs(1, ['linux']);
 
     const result = await pollDemandAndReserve({
@@ -392,6 +416,50 @@ describe('pollDemandAndReserve', () => {
     expect(remaining[0]?.requiredLabels).toEqual(['macos']);
   });
 
+  it('unbinds prewarmed runners and revokes activation tokens when deleting a reservation', async () => {
+    const runner = await createIdleRunner({labels: ['linux']});
+    await createPendingJobs(1, ['linux']);
+
+    const result = await pollDemandAndReserve({
+      workspaceId,
+      provisionerId,
+      maxReservations: 1,
+      ttlSeconds: 60,
+      templates: [template('linux', ['linux'], 1)],
+    });
+    const reservationId = result.reservations[0]?.reservationId;
+    if (!reservationId) throw new Error('Expected reservation');
+
+    const [activationToken] = await db()
+      .insert(runnerActivationTokens)
+      .values({
+        runnerInstanceId: runner.id,
+        hashedToken: crypto.randomUUID(),
+        prefix: 'test',
+        expiresAt: new Date(Date.now() + 60_000),
+      })
+      .returning();
+    if (!activationToken) throw new Error('Expected activation token');
+
+    const deleted = await deleteReservationsByIds([reservationId]);
+
+    const [storedRunner] = await db()
+      .select()
+      .from(providerRunners)
+      .where(eq(providerRunners.id, runner.id));
+    const [storedToken] = await db()
+      .select()
+      .from(runnerActivationTokens)
+      .where(eq(runnerActivationTokens.id, activationToken.id));
+    expect(deleted).toBe(1);
+    expect(storedRunner).toMatchObject({
+      workspaceId: null,
+      reservationId: null,
+      assignedAt: null,
+    });
+    expect(storedToken?.revokedAt).toBeInstanceOf(Date);
+  });
+
   it('decrements reservation units inside a caller transaction', async () => {
     await reservationFactory.create({
       workspaceId,
@@ -524,7 +592,11 @@ describe('pollDemandAndReserve', () => {
     }
   }
 
-  async function createIdleRunner(params: {labels: string[]; createdAt?: Date}) {
+  async function createIdleRunner(params: {
+    labels: string[];
+    createdAt?: Date;
+    controlSessionExpiresAt?: Date;
+  }) {
     const createdAt = params.createdAt ?? new Date();
     const [runner] = await db()
       .insert(providerRunners)
@@ -547,7 +619,7 @@ describe('pollDemandAndReserve', () => {
         provisionerId,
         hashedToken: crypto.randomUUID(),
         prefix: 'test',
-        expiresAt: new Date(Date.now() + 60_000),
+        expiresAt: params.controlSessionExpiresAt ?? new Date(Date.now() + 60_000),
       });
     return runner;
   }

--- a/libs/api/runners/src/db/reservations.test.ts
+++ b/libs/api/runners/src/db/reservations.test.ts
@@ -1,6 +1,7 @@
 import {and, eq, inArray, or, sql, sum} from 'drizzle-orm';
 import {db} from '#db/db.js';
 import {
+  deleteExpiredReservations,
   deleteReservationsByIds,
   pollDemandAndReserve,
   pollInstallationDemandAndReserve,
@@ -452,6 +453,54 @@ describe('pollDemandAndReserve', () => {
       .from(runnerActivationTokens)
       .where(eq(runnerActivationTokens.id, activationToken.id));
     expect(deleted).toBe(1);
+    expect(storedRunner).toMatchObject({
+      workspaceId: null,
+      reservationId: null,
+      assignedAt: null,
+    });
+    expect(storedToken?.revokedAt).toBeInstanceOf(Date);
+  });
+
+  it('unbinds prewarmed runners and revokes activation tokens when deleting expired reservations', async () => {
+    const runner = await createIdleRunner({labels: ['linux']});
+    await createPendingJobs(1, ['linux']);
+
+    const result = await pollDemandAndReserve({
+      workspaceId,
+      provisionerId,
+      maxReservations: 1,
+      ttlSeconds: 60,
+      templates: [template('linux', ['linux'], 1)],
+    });
+    const reservationId = result.reservations[0]?.reservationId;
+    if (!reservationId) throw new Error('Expected reservation');
+
+    await db()
+      .update(reservations)
+      .set({expiresAt: new Date(Date.now() - 60_000)})
+      .where(eq(reservations.id, reservationId));
+    const [activationToken] = await db()
+      .insert(runnerActivationTokens)
+      .values({
+        runnerInstanceId: runner.id,
+        hashedToken: crypto.randomUUID(),
+        prefix: 'test',
+        expiresAt: new Date(Date.now() + 60_000),
+      })
+      .returning();
+    if (!activationToken) throw new Error('Expected activation token');
+
+    const deleted = await deleteExpiredReservations();
+
+    const [storedRunner] = await db()
+      .select()
+      .from(providerRunners)
+      .where(eq(providerRunners.id, runner.id));
+    const [storedToken] = await db()
+      .select()
+      .from(runnerActivationTokens)
+      .where(eq(runnerActivationTokens.id, activationToken.id));
+    expect(deleted).toBeGreaterThanOrEqual(1);
     expect(storedRunner).toMatchObject({
       workspaceId: null,
       reservationId: null,

--- a/libs/api/runners/src/db/reservations.ts
+++ b/libs/api/runners/src/db/reservations.ts
@@ -18,6 +18,7 @@ import {pendingJobExecutions} from './schema/pending-job-executions.js';
 import {provisionerCapabilitySnapshots} from './schema/provisioner-capability-snapshots.js';
 import {provisionerTokens} from './schema/provisioner-tokens.js';
 import {reservations} from './schema/reservations.js';
+import {runnerActivationTokens} from './schema/runner-activation-tokens.js';
 import {runnerControlSessions} from './schema/runner-control-sessions.js';
 import {providerRunners} from './schema/runner-instances.js';
 
@@ -318,6 +319,7 @@ async function bindIdleRunnerInstancesTx(
                 eq(runnerControlSessions.runnerInstanceId, providerRunners.id),
                 eq(runnerControlSessions.provisionerId, params.provisionerId),
                 isNull(runnerControlSessions.closedAt),
+                gt(runnerControlSessions.expiresAt, sql`now()`),
               ),
             ),
         ),
@@ -418,12 +420,65 @@ export async function deleteExpiredReservations(params?: {limit?: number}): Prom
 export async function deleteReservationsByIds(ids: string[]): Promise<number> {
   if (ids.length === 0) return 0;
 
-  const deleted = await db()
-    .delete(reservations)
-    .where(inArray(reservations.id, ids))
-    .returning({id: reservations.id});
+  return await db().transaction(async (tx) => {
+    const assignedRunners = await tx
+      .select({id: providerRunners.id, reservationId: providerRunners.reservationId})
+      .from(providerRunners)
+      .where(
+        and(
+          inArray(providerRunners.reservationId, ids),
+          isNull(providerRunners.runnerSessionId),
+          isNull(providerRunners.reservationReleasedAt),
+        ),
+      )
+      .for('update');
+    const reservationRows = await tx
+      .select({id: reservations.id})
+      .from(reservations)
+      .where(inArray(reservations.id, ids))
+      .for('update');
+    const reservationIds = reservationRows.map((reservation) => reservation.id);
 
-  return deleted.length;
+    if (reservationIds.length === 0) return 0;
+
+    const assignedRunnerIds = assignedRunners
+      .filter((runner) => runner.reservationId && reservationIds.includes(runner.reservationId))
+      .map((runner) => runner.id);
+    if (assignedRunnerIds.length > 0) {
+      await tx
+        .update(runnerActivationTokens)
+        .set({revokedAt: sql`now()`})
+        .where(
+          and(
+            inArray(runnerActivationTokens.runnerInstanceId, assignedRunnerIds),
+            isNull(runnerActivationTokens.consumedAt),
+            isNull(runnerActivationTokens.revokedAt),
+          ),
+        );
+      await tx
+        .update(providerRunners)
+        .set({
+          workspaceId: null,
+          reservationId: null,
+          assignedAt: null,
+          updatedAt: sql`now()`,
+        })
+        .where(
+          and(
+            inArray(providerRunners.id, assignedRunnerIds),
+            isNull(providerRunners.runnerSessionId),
+            isNull(providerRunners.reservationReleasedAt),
+          ),
+        );
+    }
+
+    const deleted = await tx
+      .delete(reservations)
+      .where(inArray(reservations.id, reservationIds))
+      .returning({id: reservations.id});
+
+    return deleted.length;
+  });
 }
 
 export async function releaseReservationUnits(

--- a/libs/api/runners/src/db/reservations.ts
+++ b/libs/api/runners/src/db/reservations.ts
@@ -402,83 +402,98 @@ async function listActiveWorkspaceCapabilityLabelsTx(
 }
 
 export async function deleteExpiredReservations(params?: {limit?: number}): Promise<number> {
-  const expiredIds = db()
-    .select({id: reservations.id})
-    .from(reservations)
-    .where(lt(reservations.expiresAt, sql`now()`))
-    .orderBy(asc(reservations.expiresAt))
-    .limit(params?.limit ?? 1000);
-
-  const deleted = await db()
-    .delete(reservations)
-    .where(inArray(reservations.id, expiredIds))
-    .returning({id: reservations.id});
-
-  return deleted.length;
+  return await db().transaction(async (tx) => {
+    const expiredRows = await tx
+      .select({id: reservations.id})
+      .from(reservations)
+      .where(lt(reservations.expiresAt, sql`now()`))
+      .orderBy(asc(reservations.expiresAt))
+      .limit(params?.limit ?? 1000);
+    return await deleteReservationsWithCleanupTx(
+      tx,
+      expiredRows.map((reservation) => reservation.id),
+      {expiredOnly: true},
+    );
+  });
 }
 
 export async function deleteReservationsByIds(ids: string[]): Promise<number> {
   if (ids.length === 0) return 0;
 
   return await db().transaction(async (tx) => {
-    const assignedRunners = await tx
-      .select({id: providerRunners.id, reservationId: providerRunners.reservationId})
-      .from(providerRunners)
+    return await deleteReservationsWithCleanupTx(tx, ids);
+  });
+}
+
+async function deleteReservationsWithCleanupTx(
+  tx: Tx,
+  ids: string[],
+  params: {expiredOnly?: boolean} = {},
+): Promise<number> {
+  if (ids.length === 0) return 0;
+
+  const assignedRunners = await tx
+    .select({id: providerRunners.id, reservationId: providerRunners.reservationId})
+    .from(providerRunners)
+    .where(
+      and(
+        inArray(providerRunners.reservationId, ids),
+        isNull(providerRunners.runnerSessionId),
+        isNull(providerRunners.reservationReleasedAt),
+      ),
+    )
+    .for('update');
+  const reservationRows = await tx
+    .select({id: reservations.id})
+    .from(reservations)
+    .where(
+      and(
+        inArray(reservations.id, ids),
+        params.expiredOnly ? lt(reservations.expiresAt, sql`now()`) : undefined,
+      ),
+    )
+    .for('update');
+  const reservationIds = reservationRows.map((reservation) => reservation.id);
+
+  if (reservationIds.length === 0) return 0;
+
+  const assignedRunnerIds = assignedRunners
+    .filter((runner) => runner.reservationId && reservationIds.includes(runner.reservationId))
+    .map((runner) => runner.id);
+  if (assignedRunnerIds.length > 0) {
+    await tx
+      .update(runnerActivationTokens)
+      .set({revokedAt: sql`now()`})
       .where(
         and(
-          inArray(providerRunners.reservationId, ids),
+          inArray(runnerActivationTokens.runnerInstanceId, assignedRunnerIds),
+          isNull(runnerActivationTokens.consumedAt),
+          isNull(runnerActivationTokens.revokedAt),
+        ),
+      );
+    await tx
+      .update(providerRunners)
+      .set({
+        workspaceId: null,
+        reservationId: null,
+        assignedAt: null,
+        updatedAt: sql`now()`,
+      })
+      .where(
+        and(
+          inArray(providerRunners.id, assignedRunnerIds),
           isNull(providerRunners.runnerSessionId),
           isNull(providerRunners.reservationReleasedAt),
         ),
-      )
-      .for('update');
-    const reservationRows = await tx
-      .select({id: reservations.id})
-      .from(reservations)
-      .where(inArray(reservations.id, ids))
-      .for('update');
-    const reservationIds = reservationRows.map((reservation) => reservation.id);
+      );
+  }
 
-    if (reservationIds.length === 0) return 0;
+  const deleted = await tx
+    .delete(reservations)
+    .where(inArray(reservations.id, reservationIds))
+    .returning({id: reservations.id});
 
-    const assignedRunnerIds = assignedRunners
-      .filter((runner) => runner.reservationId && reservationIds.includes(runner.reservationId))
-      .map((runner) => runner.id);
-    if (assignedRunnerIds.length > 0) {
-      await tx
-        .update(runnerActivationTokens)
-        .set({revokedAt: sql`now()`})
-        .where(
-          and(
-            inArray(runnerActivationTokens.runnerInstanceId, assignedRunnerIds),
-            isNull(runnerActivationTokens.consumedAt),
-            isNull(runnerActivationTokens.revokedAt),
-          ),
-        );
-      await tx
-        .update(providerRunners)
-        .set({
-          workspaceId: null,
-          reservationId: null,
-          assignedAt: null,
-          updatedAt: sql`now()`,
-        })
-        .where(
-          and(
-            inArray(providerRunners.id, assignedRunnerIds),
-            isNull(providerRunners.runnerSessionId),
-            isNull(providerRunners.reservationReleasedAt),
-          ),
-        );
-    }
-
-    const deleted = await tx
-      .delete(reservations)
-      .where(inArray(reservations.id, reservationIds))
-      .returning({id: reservations.id});
-
-    return deleted.length;
-  });
+  return deleted.length;
 }
 
 export async function releaseReservationUnits(

--- a/libs/api/runners/src/db/reservations.ts
+++ b/libs/api/runners/src/db/reservations.ts
@@ -1,11 +1,25 @@
 import {canonicalizeLabels} from '@shipfox/runner-labels';
-import {and, asc, eq, gt, inArray, lt, sql} from 'drizzle-orm';
+import {
+  and,
+  arrayContains,
+  asc,
+  eq,
+  exists,
+  gt,
+  inArray,
+  isNotNull,
+  isNull,
+  lt,
+  sql,
+} from 'drizzle-orm';
 import type {Tx} from './db.js';
 import {db} from './db.js';
 import {pendingJobExecutions} from './schema/pending-job-executions.js';
 import {provisionerCapabilitySnapshots} from './schema/provisioner-capability-snapshots.js';
 import {provisionerTokens} from './schema/provisioner-tokens.js';
 import {reservations} from './schema/reservations.js';
+import {runnerControlSessions} from './schema/runner-control-sessions.js';
+import {providerRunners} from './schema/runner-instances.js';
 
 export interface ReservationTemplate {
   templateKey: string;
@@ -243,6 +257,13 @@ async function pollDemandAndReserveLockedTx(
 
       remainingMaxReservations -= grant;
       drawSlots(satisfyingTemplates, grant);
+      await bindIdleRunnerInstancesTx(tx, {
+        provisionerId: params.provisionerId,
+        reservationId: inserted.id,
+        requiredLabels: demand.requiredLabels,
+        count: grant,
+        workspaceId: params.workspaceId,
+      });
       reservedAfterGrant += grant;
       grants.push({
         reservationId: inserted.id,
@@ -263,6 +284,70 @@ async function pollDemandAndReserveLockedTx(
   }
 
   return {stats, reservations: grants};
+}
+
+async function bindIdleRunnerInstancesTx(
+  tx: Tx,
+  params: {
+    provisionerId: string;
+    reservationId: string;
+    workspaceId: string;
+    requiredLabels: string[];
+    count: number;
+  },
+): Promise<void> {
+  const idleRunners = await tx
+    .select({id: providerRunners.id})
+    .from(providerRunners)
+    .where(
+      and(
+        eq(providerRunners.provisionerId, params.provisionerId),
+        isNull(providerRunners.workspaceId),
+        isNull(providerRunners.reservationId),
+        isNull(providerRunners.intendedReservationId),
+        isNull(providerRunners.runnerSessionId),
+        isNotNull(providerRunners.providerRunnerId),
+        eq(providerRunners.state, 'running'),
+        arrayContains(providerRunners.labels, params.requiredLabels),
+        exists(
+          tx
+            .select({id: runnerControlSessions.id})
+            .from(runnerControlSessions)
+            .where(
+              and(
+                eq(runnerControlSessions.runnerInstanceId, providerRunners.id),
+                eq(runnerControlSessions.provisionerId, params.provisionerId),
+                isNull(runnerControlSessions.closedAt),
+              ),
+            ),
+        ),
+      ),
+    )
+    .orderBy(asc(providerRunners.createdAt), asc(providerRunners.id))
+    .limit(params.count)
+    .for('update');
+
+  if (idleRunners.length === 0) return;
+
+  await tx
+    .update(providerRunners)
+    .set({
+      workspaceId: params.workspaceId,
+      reservationId: params.reservationId,
+      assignedAt: sql`now()`,
+      updatedAt: sql`now()`,
+    })
+    .where(
+      and(
+        inArray(
+          providerRunners.id,
+          idleRunners.map((runner) => runner.id),
+        ),
+        isNull(providerRunners.workspaceId),
+        isNull(providerRunners.reservationId),
+        isNull(providerRunners.runnerSessionId),
+      ),
+    );
 }
 
 async function listInstallationDemandWorkspaceIds(eligibleWorkspaceIds: ReadonlySet<string>) {


### PR DESCRIPTION
Prewarmed enrolled runners were never bound when demand created a reservation, so targetConcurrency capacity could not serve queued jobs. This binds the oldest matching idle runner instances inside the existing locked reservation transaction, preserving reservation accounting under concurrent polls and allowing installation-scoped provisioners to reuse their provisioner-owned capacity across eligible workspaces.

The change keeps cold-launch reservations and enrollment assignment behavior intact, adds integration coverage for FIFO matching and repeat polling, and includes the required @shipfox/api-runners patch Changeset.

Closes ENG-1331

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Activate prewarmed runners for queued jobs by binding idle enrolled runners to newly granted reservations, and clean up reservation deletions/expirations by unbinding runners and revoking activation tokens. This reduces activation latency and keeps reservation/token state correct under concurrent polls, fulfilling ENG-1331.

- **Bug Fixes**
  - Bind the oldest matching idle runners (running, enrolled, active control session) to the reservation inside the locked transaction, up to the reservation count.
  - Stop granting new reservations when idle runners already cover the queued demand.
  - On deletion or expiry, unbind bound prewarmed runners and revoke any unconsumed activation tokens.

- **Dependencies**
  - Publish patch for `@shipfox/api-runners`.

<sup>Written for commit 3b91d772df92f91e514b996ec914e5eac12507e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

