### PR TITLE
[api-logs] Stop flagging benign Claude SDK messages

### DIFF
--- a/.changeset/fold-tool-summaries.md
+++ b/.changeset/fold-tool-summaries.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-logs-dto": minor
+"@shipfox/client-logs": patch
+---
+
+Preserve and display Claude tool-use summaries on their matching tool-call rows.

--- a/.changeset/quiet-sdk-events.md
+++ b/.changeset/quiet-sdk-events.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-logs": minor
+---
+
+Stop treating benign Claude SDK message types as unknown session-parser failures.

--- a/libs/api/logs-dto/src/schemas/session-view.test.ts
+++ b/libs/api/logs-dto/src/schemas/session-view.test.ts
@@ -25,6 +25,7 @@ const rowsByKind: SessionViewRow[] = [
     id: 'call-1',
     name: 'read_file',
     input: '{"path":"src/index.ts"}',
+    summary: 'Read the source file.',
   },
   {
     kind: 'tool-result',

--- a/libs/api/logs-dto/src/schemas/session-view.ts
+++ b/libs/api/logs-dto/src/schemas/session-view.ts
@@ -36,6 +36,7 @@ export const sessionViewToolCallRowSchema = z.object({
   id: z.string().nullable(),
   name: z.string().min(1),
   input: z.string(),
+  summary: z.string().optional(),
 });
 
 export const sessionViewToolResultRowSchema = z.object({

--- a/libs/api/logs/drizzle/0002_wise_dorian_gray.sql
+++ b/libs/api/logs/drizzle/0002_wise_dorian_gray.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "logs_attempt_streams" ADD COLUMN "claude_pending_tool_rows" jsonb;

--- a/libs/api/logs/drizzle/meta/0002_snapshot.json
+++ b/libs/api/logs/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,561 @@
+{
+  "id": "c7c62bb2-21a0-48c3-95bd-38dda56a083b",
+  "prevId": "2d8b03a3-df94-4be5-a2cc-cd5b431bcd59",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.logs_attempt_streams": {
+      "name": "logs_attempt_streams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_run_attempt_id": {
+          "name": "workflow_run_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "committed_length": {
+          "name": "committed_length",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "close_reason": {
+          "name": "close_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "declared_total_bytes": {
+          "name": "declared_total_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claude_has_init": {
+          "name": "claude_has_init",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "claude_session_id": {
+          "name": "claude_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claude_turn": {
+          "name": "claude_turn",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "claude_pending_result": {
+          "name": "claude_pending_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claude_pending_tool_rows": {
+          "name": "claude_pending_tool_rows",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "truncated": {
+          "name": "truncated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "logs_attempt_streams_identity_unique": {
+          "name": "logs_attempt_streams_identity_unique",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "logs_attempt_streams_step_attempt_idx": {
+          "name": "logs_attempt_streams_step_attempt_idx",
+          "columns": [
+            {
+              "expression": "step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "logs_attempt_streams_open_by_job_idx": {
+          "name": "logs_attempt_streams_open_by_job_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"state\" = 'open'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "logs_attempt_streams_open_age_idx": {
+          "name": "logs_attempt_streams_open_age_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"state\" = 'open'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "logs_attempt_streams_retention_idx": {
+          "name": "logs_attempt_streams_retention_idx",
+          "columns": [
+            {
+              "expression": "closed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"state\" = 'closed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "logs_attempt_streams_uncompacted_idx": {
+          "name": "logs_attempt_streams_uncompacted_idx",
+          "columns": [
+            {
+              "expression": "closed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"state\" = 'closed' and \"object_key\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.logs_chunks": {
+      "name": "logs_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "stream_id": {
+          "name": "stream_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stream_offset": {
+          "name": "stream_offset",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_len": {
+          "name": "byte_len",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "logs_chunks_stream_seq_idx": {
+          "name": "logs_chunks_stream_seq_idx",
+          "columns": [
+            {
+              "expression": "stream_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "logs_chunks_stream_id_logs_attempt_streams_id_fk": {
+          "name": "logs_chunks_stream_id_logs_attempt_streams_id_fk",
+          "tableFrom": "logs_chunks",
+          "tableTo": "logs_attempt_streams",
+          "columnsFrom": ["stream_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.logs_job_accounting": {
+      "name": "logs_job_accounting",
+      "schema": "",
+      "columns": {
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stored_bytes_used": {
+          "name": "stored_bytes_used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "capped_at": {
+          "name": "capped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.logs_outbox": {
+      "name": "logs_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordering_key": {
+          "name": "ordering_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_attempts": {
+          "name": "dispatch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_dispatch_at": {
+          "name": "next_dispatch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_dispatch_error": {
+          "name": "last_dispatch_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_dispatch_failed_at": {
+          "name": "last_dispatch_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dead_lettered_at": {
+          "name": "dead_lettered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "logs_outbox_pending_idx": {
+          "name": "logs_outbox_pending_idx",
+          "columns": [
+            {
+              "expression": "next_dispatch_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NULL AND \"dead_lettered_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "logs_outbox_dispatched_retention_idx": {
+          "name": "logs_outbox_dispatched_retention_idx",
+          "columns": [
+            {
+              "expression": "dispatched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/api/logs/drizzle/meta/_journal.json
+++ b/libs/api/logs/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1785166831100,
       "tag": "0001_strong_major_mapleleaf",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1785232769856,
+      "tag": "0002_wise_dorian_gray",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/api/logs/src/core/append-logs.test.ts
+++ b/libs/api/logs/src/core/append-logs.test.ts
@@ -208,6 +208,7 @@ describe('appendLogs', () => {
             },
           }),
         ),
+        endLine(0),
       );
 
       await appendLogs({...ctx, attempt: 1, offset: 0, body}, workflows);
@@ -366,6 +367,62 @@ describe('appendLogs', () => {
         claudeTurn: 2,
         claudePendingResult: null,
       });
+    });
+
+    it('folds a tool-use summary across append requests before storing the row', async () => {
+      const ctx = newCtx();
+      await allowLargeLogBudget(ctx);
+      const workflows = createFakeInterModuleClients({
+        workflows: defineInterModulePresentation(workflowsInterModuleContract, {
+          startRunFromTrigger: vi.fn(),
+          deliverEventToJobListener: vi.fn(),
+          getStepLogContext: () => ({harness: 'claude' as const}),
+          getLeasedAgentToolContext: vi.fn(),
+        }),
+      }).workflows;
+      const first = ndjsonBody(
+        sessionLine(
+          JSON.stringify({
+            type: 'assistant',
+            message: {
+              role: 'assistant',
+              content: [
+                {type: 'tool_use', id: 'tool-1', name: 'Read', input: {file_path: 'src/a.ts'}},
+              ],
+            },
+          }),
+        ),
+      );
+      const second = ndjsonBody(
+        sessionLine(
+          JSON.stringify({
+            type: 'tool_use_summary',
+            summary: 'Read the source file.',
+            preceding_tool_use_ids: ['tool-1'],
+          }),
+        ),
+        endLine(0),
+      );
+
+      await appendLogs({...ctx, attempt: 1, offset: 0, body: first}, workflows);
+      await appendLogs({...ctx, attempt: 1, offset: first.length, body: second}, workflows);
+
+      const stream = await findStream({...ctx, attempt: 1});
+      const rows = recordsFromChunks(await listChunks(stream?.id as string)).flatMap((record) =>
+        record.type === 'agent_session' ? [record.row] : [],
+      );
+
+      expect(rows).toEqual([
+        {
+          kind: 'tool-call',
+          timestamp: expect.any(Number),
+          id: 'tool-1',
+          name: 'Read',
+          input: '{\n  "file_path": "src/a.ts"\n}',
+          summary: 'Read the source file.',
+        },
+      ]);
+      expect(stream?.claudePendingToolRows).toEqual([]);
     });
 
     it('does not duplicate parsed rows on a retried append', async () => {

--- a/libs/api/logs/src/core/append-logs.ts
+++ b/libs/api/logs/src/core/append-logs.ts
@@ -30,6 +30,7 @@ import {
 import {allowedBudget} from './budget.js';
 import {closeStream, controlTombstone} from './close-stream.js';
 import {MalformedLogChunkError, OffsetGapError} from './errors.js';
+import {flushPendingToolRows} from './session/claude/rows.js';
 import {
   type ClaudeParseContext,
   claudeInitSessionId,
@@ -180,6 +181,7 @@ interface StoredBody {
   recordCounts: Partial<Record<LogRecord['type'], number>>;
   claudeParseContext: ClaudeParseContext | undefined;
   claudePendingResult: SessionViewLifecycleRow | null | undefined;
+  claudePendingToolRows: readonly SessionViewRow[] | undefined;
 }
 
 /**
@@ -303,6 +305,12 @@ function buildStoredBody(
     }
   }
 
+  if (isStreamFinal && parseContext?.claude !== undefined) {
+    for (const row of flushPendingToolRows(parseContext.claude)) {
+      storedRecords.push(storedAgentSessionRow(row));
+    }
+  }
+
   const body = Buffer.from(storedRecords.map((record) => `${JSON.stringify(record)}\n`).join(''));
   const recordCounts: Partial<Record<LogRecord['type'], number>> = {};
   for (const record of storedRecords) {
@@ -314,6 +322,7 @@ function buildStoredBody(
     recordCounts,
     claudeParseContext: parseContext?.claude,
     claudePendingResult: parseContext?.claude === undefined ? undefined : pendingResult,
+    claudePendingToolRows: parseContext?.claude?.pendingToolRows,
   };
 }
 
@@ -451,19 +460,20 @@ export async function appendLogs(
     }
 
     const parseHarness =
-      sessionHarness === 'claude' || stream.claudePendingResult !== null
+      sessionHarness === 'claude' ||
+      stream.claudePendingResult !== null ||
+      stream.claudePendingToolRows.length > 0
         ? 'claude'
         : sessionHarness;
     const stored = buildStoredBody(
       parsed.records,
       parseHarness,
       parseHarness === 'claude'
-        ? {
+        ? createClaudeParseContext(stream.claudePendingToolRows, {
             hasInit: stream.claudeHasInit,
             sessionId: stream.claudeSessionId,
             turn: stream.claudeTurn,
-            toolCallRows: new Map(),
-          }
+          })
         : undefined,
       parseHarness === 'claude' ? stream.claudePendingResult : undefined,
       declaredTotalBytes !== undefined,
@@ -489,6 +499,7 @@ export async function appendLogs(
           sessionId: stored.claudeParseContext.sessionId,
           turn: stored.claudeParseContext.turn,
           pendingResult: stored.claudePendingResult ?? null,
+          pendingToolRows: stored.claudePendingToolRows ?? [],
         });
       }
     }

--- a/libs/api/logs/src/core/append-logs.ts
+++ b/libs/api/logs/src/core/append-logs.ts
@@ -462,6 +462,7 @@ export async function appendLogs(
             hasInit: stream.claudeHasInit,
             sessionId: stream.claudeSessionId,
             turn: stream.claudeTurn,
+            toolCallRows: new Map(),
           }
         : undefined,
       parseHarness === 'claude' ? stream.claudePendingResult : undefined,

--- a/libs/api/logs/src/core/close-stream.ts
+++ b/libs/api/logs/src/core/close-stream.ts
@@ -47,7 +47,23 @@ export async function closeStream(
   });
   if (!closedResult) return null;
 
-  const {stream: closed, pendingClaudeResult} = closedResult;
+  const {stream: closed, pendingClaudeResult, pendingClaudeToolRows} = closedResult;
+  if (pendingClaudeToolRows.length > 0) {
+    const data = Buffer.from(
+      `${pendingClaudeToolRows
+        .map((row) =>
+          JSON.stringify({v: 1, ts: row.timestamp, type: 'agent_session', row} satisfies LogRecord),
+        )
+        .join('\n')}\n`,
+    );
+    await insertChunk(tx, {
+      streamId: closed.id,
+      streamOffset: closed.committedLength,
+      byteLen: data.length,
+      data,
+      origin: 'control',
+    });
+  }
   if (pendingClaudeResult !== null) {
     const record: LogRecord = {
       v: 1,

--- a/libs/api/logs/src/core/entities/attempt-stream.ts
+++ b/libs/api/logs/src/core/entities/attempt-stream.ts
@@ -1,4 +1,4 @@
-import type {SessionViewLifecycleRow} from '@shipfox/api-logs-dto';
+import type {SessionViewLifecycleRow, SessionViewRow} from '@shipfox/api-logs-dto';
 
 /** Lifecycle state of an attempt's log stream. */
 export type StreamState = 'open' | 'closed';
@@ -35,6 +35,7 @@ export interface AttemptStream {
   claudeSessionId: string | null;
   claudeTurn: number;
   claudePendingResult: SessionViewLifecycleRow | null;
+  claudePendingToolRows: SessionViewRow[];
   truncated: boolean;
   objectKey: string | null;
   createdAt: Date;

--- a/libs/api/logs/src/core/session/claude-parser.test.ts
+++ b/libs/api/logs/src/core/session/claude-parser.test.ts
@@ -206,6 +206,91 @@ describe('parseClaudeSessionRecord', () => {
     expect(rows).toEqual([]);
   });
 
+  it.each([
+    ['tool_progress', {type: 'tool_progress'}],
+    ['prompt_suggestion', {type: 'prompt_suggestion'}],
+    [
+      'tool_use_summary',
+      {
+        type: 'tool_use_summary',
+        tool_use_id: 'tool-1',
+        summary: 'The tool completed successfully.',
+      },
+    ],
+  ] as const)('does not store companion message type %s as a row', (_type, message) => {
+    const rows = parseClaudeSessionRecord(record(message));
+
+    expect(rows).toEqual([]);
+  });
+
+  it.each([
+    [
+      'signed in',
+      {type: 'auth_status', isAuthenticating: false, output: ['Signed in']},
+      {label: 'Authentication complete', detail: 'Signed in', tone: 'default'},
+    ],
+    [
+      'authenticating',
+      {type: 'auth_status', isAuthenticating: true, output: []},
+      {label: 'Authenticating', detail: null, tone: 'default'},
+    ],
+    [
+      'failed',
+      {type: 'auth_status', isAuthenticating: false, output: [], error: 'Invalid credentials'},
+      {label: 'Authentication failed', detail: 'Invalid credentials', tone: 'error'},
+    ],
+  ] as const)('maps auth status messages to lifecycle rows (%s)', (_name, message, expected) => {
+    const rows = parseClaudeSessionRecord(record(message));
+
+    expect(rows).toEqual([
+      {kind: 'lifecycle', timestamp: 1, meta: [], terminalFailure: false, ...expected},
+    ]);
+  });
+
+  it.each([
+    [
+      'warning',
+      {status: 'allowed_warning', rateLimitType: 'five_hour', utilization: 0.42},
+      {
+        label: 'Rate limit warning',
+        detail: 'Five hour',
+        meta: [{label: 'utilization', value: '42%'}],
+        tone: 'warning',
+      },
+    ],
+    [
+      'rejected',
+      {status: 'rejected', rateLimitType: 'five_hour', utilization: 1},
+      {
+        label: 'Rate limit exceeded',
+        detail: 'Five hour',
+        meta: [{label: 'utilization', value: '100%'}],
+        tone: 'error',
+      },
+    ],
+    [
+      'allowed',
+      {status: 'allowed'},
+      {label: 'Rate limit available', detail: null, meta: [], tone: 'default'},
+    ],
+    [
+      'unrecognized',
+      {status: 'some_future_status'},
+      {
+        label: 'Rate limit updated',
+        detail: null,
+        meta: [{label: 'status', value: 'some_future_status'}],
+        tone: 'warning',
+      },
+    ],
+  ] as const)('maps rate-limit events to lifecycle rows (%s)', (_name, rateLimitInfo, expected) => {
+    const rows = parseClaudeSessionRecord(
+      record({type: 'rate_limit_event', rate_limit_info: rateLimitInfo}),
+    );
+
+    expect(rows).toEqual([{kind: 'lifecycle', timestamp: 1, terminalFailure: false, ...expected}]);
+  });
+
   it.each(namedSystemEvents)('names and tones $subtype system events', ({
     subtype,
     data,

--- a/libs/api/logs/src/core/session/claude-parser.test.ts
+++ b/libs/api/logs/src/core/session/claude-parser.test.ts
@@ -223,6 +223,72 @@ describe('parseClaudeSessionRecord', () => {
     expect(rows).toEqual([]);
   });
 
+  it('folds a tool-use summary into the last matching tool-call row', () => {
+    const context = createClaudeParseContext();
+    const rows = parseClaudeSessionRecord(
+      record({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [
+            {type: 'tool_use', id: 'tool-1', name: 'Read', input: {file_path: 'src/a.ts'}},
+            {type: 'tool_use', id: 'tool-2', name: 'Read', input: {file_path: 'src/b.ts'}},
+          ],
+        },
+      }),
+      context,
+    );
+
+    expect(
+      parseClaudeSessionRecord(
+        record({
+          type: 'tool_use_summary',
+          summary: 'Read both source files.',
+          preceding_tool_use_ids: ['tool-1', 'tool-2'],
+        }),
+        context,
+      ),
+    ).toEqual([]);
+    expect(rows).toEqual([
+      {
+        kind: 'tool-call',
+        timestamp: 1,
+        id: 'tool-1',
+        name: 'Read',
+        input: '{\n  "file_path": "src/a.ts"\n}',
+      },
+      {
+        kind: 'tool-call',
+        timestamp: 1,
+        id: 'tool-2',
+        name: 'Read',
+        input: '{\n  "file_path": "src/b.ts"\n}',
+        summary: 'Read both source files.',
+      },
+    ]);
+  });
+
+  it('supports the legacy single tool-use id summary shape', () => {
+    const context = createClaudeParseContext();
+    const rows = parseClaudeSessionRecord(
+      record({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [{type: 'tool_use', id: 'tool-1', name: 'Read', input: {file_path: 'src/a.ts'}}],
+        },
+      }),
+      context,
+    );
+
+    parseClaudeSessionRecord(
+      record({type: 'tool_use_summary', tool_use_id: 'tool-1', summary: 'Read the source file.'}),
+      context,
+    );
+
+    expect(rows[0]).toMatchObject({summary: 'Read the source file.'});
+  });
+
   it.each([
     [
       'signed in',

--- a/libs/api/logs/src/core/session/claude-parser.test.ts
+++ b/libs/api/logs/src/core/session/claude-parser.test.ts
@@ -1,4 +1,4 @@
-import {PURE_PROGRESS_CLAUDE_SYSTEM_SUBTYPES} from './claude/rows.js';
+import {flushPendingToolRows, PURE_PROGRESS_CLAUDE_SYSTEM_SUBTYPES} from './claude/rows.js';
 import {createClaudeParseContext, parseClaudeSessionRecord} from './claude-parser.js';
 
 const record = (data: unknown, ts = 1) => ({
@@ -225,19 +225,21 @@ describe('parseClaudeSessionRecord', () => {
 
   it('folds a tool-use summary into the last matching tool-call row', () => {
     const context = createClaudeParseContext();
-    const rows = parseClaudeSessionRecord(
-      record({
-        type: 'assistant',
-        message: {
-          role: 'assistant',
-          content: [
-            {type: 'tool_use', id: 'tool-1', name: 'Read', input: {file_path: 'src/a.ts'}},
-            {type: 'tool_use', id: 'tool-2', name: 'Read', input: {file_path: 'src/b.ts'}},
-          ],
-        },
-      }),
-      context,
-    );
+    expect(
+      parseClaudeSessionRecord(
+        record({
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: [
+              {type: 'tool_use', id: 'tool-1', name: 'Read', input: {file_path: 'src/a.ts'}},
+              {type: 'tool_use', id: 'tool-2', name: 'Read', input: {file_path: 'src/b.ts'}},
+            ],
+          },
+        }),
+        context,
+      ),
+    ).toEqual([]);
 
     expect(
       parseClaudeSessionRecord(
@@ -248,8 +250,7 @@ describe('parseClaudeSessionRecord', () => {
         }),
         context,
       ),
-    ).toEqual([]);
-    expect(rows).toEqual([
+    ).toEqual([
       {
         kind: 'tool-call',
         timestamp: 1,
@@ -270,23 +271,31 @@ describe('parseClaudeSessionRecord', () => {
 
   it('supports the legacy single tool-use id summary shape', () => {
     const context = createClaudeParseContext();
-    const rows = parseClaudeSessionRecord(
-      record({
-        type: 'assistant',
-        message: {
-          role: 'assistant',
-          content: [{type: 'tool_use', id: 'tool-1', name: 'Read', input: {file_path: 'src/a.ts'}}],
-        },
-      }),
-      context,
-    );
+    expect(
+      parseClaudeSessionRecord(
+        record({
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: [
+              {type: 'tool_use', id: 'tool-1', name: 'Read', input: {file_path: 'src/a.ts'}},
+            ],
+          },
+        }),
+        context,
+      ),
+    ).toEqual([]);
 
-    parseClaudeSessionRecord(
-      record({type: 'tool_use_summary', tool_use_id: 'tool-1', summary: 'Read the source file.'}),
-      context,
-    );
-
-    expect(rows[0]).toMatchObject({summary: 'Read the source file.'});
+    expect(
+      parseClaudeSessionRecord(
+        record({
+          type: 'tool_use_summary',
+          tool_use_id: 'tool-1',
+          summary: 'Read the source file.',
+        }),
+        context,
+      ),
+    ).toEqual([expect.objectContaining({summary: 'Read the source file.'})]);
   });
 
   it.each([
@@ -483,6 +492,7 @@ describe('parseClaudeSessionRecord', () => {
   });
 
   it('expands assistant text, thinking, and tool-use blocks in order', () => {
+    const context = createClaudeParseContext();
     const rows = parseClaudeSessionRecord(
       record({
         type: 'assistant',
@@ -495,9 +505,10 @@ describe('parseClaudeSessionRecord', () => {
           ],
         },
       }),
+      context,
     );
 
-    expect(rows).toEqual([
+    expect([...rows, ...flushPendingToolRows(context)]).toEqual([
       {
         kind: 'message',
         timestamp: 1,

--- a/libs/api/logs/src/core/session/claude-parser.test.ts
+++ b/libs/api/logs/src/core/session/claude-parser.test.ts
@@ -529,6 +529,168 @@ describe('parseClaudeSessionRecord', () => {
     ]);
   });
 
+  it('keeps assistant content after an identified tool call in order', () => {
+    const context = createClaudeParseContext();
+    const rows = parseClaudeSessionRecord(
+      record({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [
+            {type: 'text', text: 'Before the tool.'},
+            {type: 'tool_use', id: 'tool-1', name: 'Read', input: {file_path: 'src/a.ts'}},
+            {type: 'text', text: 'After the tool.'},
+          ],
+        },
+      }),
+      context,
+    );
+
+    expect(rows).toEqual([
+      {
+        kind: 'message',
+        timestamp: 1,
+        role: 'assistant',
+        label: 'assistant',
+        meta: [],
+        text: 'Before the tool.',
+        terminalFailure: false,
+      },
+    ]);
+    expect(flushPendingToolRows(context)).toEqual([
+      {
+        kind: 'tool-call',
+        timestamp: 1,
+        id: 'tool-1',
+        name: 'Read',
+        input: '{\n  "file_path": "src/a.ts"\n}',
+      },
+      {
+        kind: 'message',
+        timestamp: 1,
+        role: 'assistant',
+        label: 'assistant',
+        meta: [],
+        text: 'After the tool.',
+        terminalFailure: false,
+      },
+    ]);
+  });
+
+  it('keeps mixed user tool-result and text rows in order', () => {
+    const context = createClaudeParseContext();
+    expect(
+      parseClaudeSessionRecord(
+        record({
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: [
+              {type: 'tool_use', id: 'tool-1', name: 'Read', input: {file_path: 'src/a.ts'}},
+            ],
+          },
+        }),
+        context,
+      ),
+    ).toEqual([]);
+
+    expect(
+      parseClaudeSessionRecord(
+        record({
+          type: 'user',
+          message: {
+            role: 'user',
+            content: [
+              {type: 'tool_result', tool_use_id: 'tool-1', content: 'file contents'},
+              {type: 'text', text: 'The file was read.'},
+            ],
+          },
+        }),
+        context,
+      ),
+    ).toEqual([]);
+    expect(flushPendingToolRows(context)).toEqual([
+      {
+        kind: 'tool-call',
+        timestamp: 1,
+        id: 'tool-1',
+        name: 'Read',
+        input: '{\n  "file_path": "src/a.ts"\n}',
+      },
+      {
+        kind: 'tool-result',
+        timestamp: 1,
+        toolCallId: 'tool-1',
+        toolName: 'tool',
+        output: 'file contents',
+        isError: false,
+      },
+      {
+        kind: 'message',
+        timestamp: 1,
+        role: 'user',
+        label: 'user',
+        meta: [],
+        text: 'The file was read.',
+        terminalFailure: false,
+      },
+    ]);
+  });
+
+  it('keeps lifecycle rows behind a pending tool call until its summary arrives', () => {
+    const context = createClaudeParseContext();
+    expect(
+      parseClaudeSessionRecord(
+        record({
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: [
+              {type: 'tool_use', id: 'tool-1', name: 'Read', input: {file_path: 'src/a.ts'}},
+            ],
+          },
+        }),
+        context,
+      ),
+    ).toEqual([]);
+
+    expect(
+      parseClaudeSessionRecord(
+        record({type: 'auth_status', isAuthenticating: true, output: []}),
+        context,
+      ),
+    ).toEqual([]);
+
+    expect(
+      parseClaudeSessionRecord(
+        record({
+          type: 'tool_use_summary',
+          preceding_tool_use_ids: ['tool-1'],
+          summary: 'Read the source file.',
+        }),
+        context,
+      ),
+    ).toEqual([
+      {
+        kind: 'tool-call',
+        timestamp: 1,
+        id: 'tool-1',
+        name: 'Read',
+        input: '{\n  "file_path": "src/a.ts"\n}',
+        summary: 'Read the source file.',
+      },
+      {
+        kind: 'lifecycle',
+        timestamp: 1,
+        label: 'Authenticating',
+        detail: null,
+        meta: [],
+        tone: 'default',
+        terminalFailure: false,
+      },
+    ]);
+  });
+
   it('maps user tool results to tool-result rows', () => {
     const rows = parseClaudeSessionRecord(
       record({

--- a/libs/api/logs/src/core/session/claude-parser.ts
+++ b/libs/api/logs/src/core/session/claude-parser.ts
@@ -1,4 +1,4 @@
-import type {SessionViewRow} from '@shipfox/api-logs-dto';
+import type {SessionViewRow, SessionViewToolCallRow} from '@shipfox/api-logs-dto';
 import {z} from 'zod';
 import {
   assistantRows,
@@ -7,6 +7,7 @@ import {
   rateLimitRow,
   resultRow,
   systemRow,
+  toolUseSummary,
   userRows,
 } from './claude/rows.js';
 import {stringField} from './object.js';
@@ -23,10 +24,11 @@ export interface ClaudeParseContext {
   hasInit: boolean;
   sessionId: string | null;
   turn: number;
+  toolCallRows: Map<string, SessionViewToolCallRow>;
 }
 
 export function createClaudeParseContext(): ClaudeParseContext {
-  return {hasInit: false, sessionId: null, turn: 0};
+  return {hasInit: false, sessionId: null, turn: 0, toolCallRows: new Map()};
 }
 
 export function claudeInitSessionId(record: AgentSessionRecord): string | undefined {
@@ -81,16 +83,18 @@ export function parseClaudeSessionRecord(
       return [systemRow(record.ts, message, context)];
     case 'tool_progress':
     case 'prompt_suggestion':
-    case 'tool_use_summary':
       // These messages describe an already-emitted tool call or an interactive client state.
       // They have no standalone row representation and must not look like parser failures.
+      return [];
+    case 'tool_use_summary':
+      toolUseSummary(message, context);
       return [];
     case 'auth_status':
       return [authStatusRow(record.ts, message)];
     case 'rate_limit_event':
       return [rateLimitRow(record.ts, message)];
     case 'assistant':
-      return assistantRows(record.ts, message);
+      return assistantRows(record.ts, message, context);
     case 'user':
       return userRows(record.ts, message);
     case 'result':

--- a/libs/api/logs/src/core/session/claude-parser.ts
+++ b/libs/api/logs/src/core/session/claude-parser.ts
@@ -2,7 +2,9 @@ import type {SessionViewRow} from '@shipfox/api-logs-dto';
 import {z} from 'zod';
 import {
   assistantRows,
+  authStatusRow,
   PURE_PROGRESS_CLAUDE_SYSTEM_SUBTYPES,
+  rateLimitRow,
   resultRow,
   systemRow,
   userRows,
@@ -77,6 +79,16 @@ export function parseClaudeSessionRecord(
     case 'system':
     case 'init':
       return [systemRow(record.ts, message, context)];
+    case 'tool_progress':
+    case 'prompt_suggestion':
+    case 'tool_use_summary':
+      // These messages describe an already-emitted tool call or an interactive client state.
+      // They have no standalone row representation and must not look like parser failures.
+      return [];
+    case 'auth_status':
+      return [authStatusRow(record.ts, message)];
+    case 'rate_limit_event':
+      return [rateLimitRow(record.ts, message)];
     case 'assistant':
       return assistantRows(record.ts, message);
     case 'user':

--- a/libs/api/logs/src/core/session/claude-parser.ts
+++ b/libs/api/logs/src/core/session/claude-parser.ts
@@ -96,9 +96,10 @@ export function parseClaudeSessionRecord(
 
   switch (message.type) {
     case 'system':
-      return stringField(message, 'subtype') === 'init'
-        ? [...flushPendingToolRows(context), systemRow(record.ts, message, context)]
-        : [systemRow(record.ts, message, context)];
+      if (stringField(message, 'subtype') === 'init') {
+        return [...flushPendingToolRows(context), systemRow(record.ts, message, context)];
+      }
+      return deferRow(context, systemRow(record.ts, message, context));
     case 'init':
       return [...flushPendingToolRows(context), systemRow(record.ts, message, context)];
     case 'tool_progress':
@@ -109,9 +110,9 @@ export function parseClaudeSessionRecord(
     case 'tool_use_summary':
       return toolUseSummary(message, context) ? flushPendingToolRows(context) : [];
     case 'auth_status':
-      return [authStatusRow(record.ts, message)];
+      return deferRow(context, authStatusRow(record.ts, message));
     case 'rate_limit_event':
-      return [rateLimitRow(record.ts, message)];
+      return deferRow(context, rateLimitRow(record.ts, message));
     case 'assistant':
       return [...flushPendingToolRows(context), ...assistantRows(record.ts, message, context)];
     case 'user':
@@ -127,4 +128,11 @@ export function parseClaudeSessionRecord(
         rawRecordRow(record, `Unknown Claude message: ${message.type}`),
       ];
   }
+}
+
+function deferRow(context: ClaudeParseContext, row: SessionViewRow): readonly SessionViewRow[] {
+  if (context.toolCallRows.size === 0) return [row];
+
+  context.pendingToolRows.push(row);
+  return [];
 }

--- a/libs/api/logs/src/core/session/claude-parser.ts
+++ b/libs/api/logs/src/core/session/claude-parser.ts
@@ -3,6 +3,7 @@ import {z} from 'zod';
 import {
   assistantRows,
   authStatusRow,
+  flushPendingToolRows,
   PURE_PROGRESS_CLAUDE_SYSTEM_SUBTYPES,
   rateLimitRow,
   resultRow,
@@ -24,11 +25,25 @@ export interface ClaudeParseContext {
   hasInit: boolean;
   sessionId: string | null;
   turn: number;
+  pendingToolRows: SessionViewRow[];
   toolCallRows: Map<string, SessionViewToolCallRow>;
 }
 
-export function createClaudeParseContext(): ClaudeParseContext {
-  return {hasInit: false, sessionId: null, turn: 0, toolCallRows: new Map()};
+export function createClaudeParseContext(
+  pendingToolRows: readonly SessionViewRow[] = [],
+  state: Pick<ClaudeParseContext, 'hasInit' | 'sessionId' | 'turn'> = {
+    hasInit: false,
+    sessionId: null,
+    turn: 0,
+  },
+): ClaudeParseContext {
+  const rows = [...pendingToolRows];
+  const toolCallRows = new Map<string, SessionViewToolCallRow>();
+  for (const row of rows) {
+    if (row.kind === 'tool-call' && row.id !== null) toolCallRows.set(row.id, row);
+  }
+
+  return {...state, pendingToolRows: rows, toolCallRows};
 }
 
 export function claudeInitSessionId(record: AgentSessionRecord): string | undefined {
@@ -62,11 +77,13 @@ export function parseClaudeSessionRecord(
   try {
     json = JSON.parse(record.data);
   } catch {
-    return [rawRecordRow(record, 'Malformed session entry')];
+    return [...flushPendingToolRows(context), rawRecordRow(record, 'Malformed session entry')];
   }
 
   const parsed = claudeMessageSchema.safeParse(json);
-  if (!parsed.success) return [rawRecordRow(record, 'Unsupported Claude message')];
+  if (!parsed.success) {
+    return [...flushPendingToolRows(context), rawRecordRow(record, 'Unsupported Claude message')];
+  }
 
   const message = parsed.data;
   if (
@@ -79,27 +96,35 @@ export function parseClaudeSessionRecord(
 
   switch (message.type) {
     case 'system':
+      return stringField(message, 'subtype') === 'init'
+        ? [...flushPendingToolRows(context), systemRow(record.ts, message, context)]
+        : [systemRow(record.ts, message, context)];
     case 'init':
-      return [systemRow(record.ts, message, context)];
+      return [...flushPendingToolRows(context), systemRow(record.ts, message, context)];
     case 'tool_progress':
     case 'prompt_suggestion':
       // These messages describe an already-emitted tool call or an interactive client state.
       // They have no standalone row representation and must not look like parser failures.
       return [];
     case 'tool_use_summary':
-      toolUseSummary(message, context);
-      return [];
+      return toolUseSummary(message, context) ? flushPendingToolRows(context) : [];
     case 'auth_status':
       return [authStatusRow(record.ts, message)];
     case 'rate_limit_event':
       return [rateLimitRow(record.ts, message)];
     case 'assistant':
-      return assistantRows(record.ts, message, context);
+      return [...flushPendingToolRows(context), ...assistantRows(record.ts, message, context)];
     case 'user':
-      return userRows(record.ts, message);
+      return userRows(record.ts, message, context);
     case 'result':
-      return [resultRow(record.ts, message, context.turn, isFinalResult)];
+      return [
+        ...flushPendingToolRows(context),
+        resultRow(record.ts, message, context.turn, isFinalResult),
+      ];
     default:
-      return [rawRecordRow(record, `Unknown Claude message: ${message.type}`)];
+      return [
+        ...flushPendingToolRows(context),
+        rawRecordRow(record, `Unknown Claude message: ${message.type}`),
+      ];
   }
 }

--- a/libs/api/logs/src/core/session/claude/rows.ts
+++ b/libs/api/logs/src/core/session/claude/rows.ts
@@ -183,8 +183,72 @@ export function systemRow(
   return lifecycleRow(timestamp, label, null, 'default', false, meta);
 }
 
+export function authStatusRow(
+  timestamp: number,
+  message: Record<string, unknown>,
+): SessionViewLifecycleRow {
+  const error = stringField(message, 'error');
+  const output = stringList(field(message, 'output')).join('\n');
+  const isAuthenticating = booleanField(message, 'isAuthenticating');
+
+  return lifecycleRow(
+    timestamp,
+    error
+      ? 'Authentication failed'
+      : isAuthenticating
+        ? 'Authenticating'
+        : 'Authentication complete',
+    (error ?? output) || null,
+    error ? 'error' : 'default',
+    false,
+  );
+}
+
+const RATE_LIMIT_STATUS_MAPPINGS: Record<
+  string,
+  {label: string; tone: SessionViewLifecycleRow['tone']}
+> = {
+  rejected: {label: 'Rate limit exceeded', tone: 'error'},
+  allowed_warning: {label: 'Rate limit warning', tone: 'warning'},
+  allowed: {label: 'Rate limit available', tone: 'default'},
+};
+
+export function rateLimitRow(
+  timestamp: number,
+  message: Record<string, unknown>,
+): SessionViewLifecycleRow {
+  const rateLimitInfo = asLooseObject(field(message, 'rate_limit_info')) ?? {};
+  const status = stringField(rateLimitInfo, 'status');
+  const rateLimitType = stringField(rateLimitInfo, 'rateLimitType');
+  const utilization = numberField(rateLimitInfo, 'utilization');
+  const mapping = status === undefined ? undefined : RATE_LIMIT_STATUS_MAPPINGS[status];
+  const meta = [
+    metaItem('utilization', utilization == null ? null : `${formatNumber(utilization * 100)}%`),
+    mapping === undefined ? metaItem('status', status ?? null) : null,
+  ].filter(isMeta);
+
+  return lifecycleRow(
+    timestamp,
+    mapping?.label ?? 'Rate limit updated',
+    rateLimitType == null ? null : humanizeEnumValue(rateLimitType),
+    mapping?.tone ?? 'warning',
+    false,
+    meta,
+  );
+}
+
 function titleCase(value: string): string {
   return value.length === 0 ? value : `${value[0]?.toUpperCase()}${value.slice(1)}`;
+}
+
+function humanizeEnumValue(value: string): string {
+  return titleCase(value.replaceAll('_', ' '));
+}
+
+function stringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+
+  return value.filter((item): item is string => typeof item === 'string' && item.length > 0);
 }
 
 export function assistantRows(

--- a/libs/api/logs/src/core/session/claude/rows.ts
+++ b/libs/api/logs/src/core/session/claude/rows.ts
@@ -169,7 +169,10 @@ export function systemRow(
 
   const isNewSession =
     !context.hasInit || sessionId === undefined || sessionId !== context.sessionId;
-  if (isNewSession) context.toolCallRows.clear();
+  if (isNewSession) {
+    context.pendingToolRows.length = 0;
+    context.toolCallRows.clear();
+  }
   context.hasInit = true;
   context.sessionId = sessionId ?? null;
   context.turn = isNewSession ? 1 : context.turn + 1;
@@ -241,9 +244,9 @@ export function rateLimitRow(
 export function toolUseSummary(
   message: Record<string, unknown>,
   context: ClaudeParseContext,
-): void {
+): boolean {
   const summary = stringField(message, 'summary');
-  if (summary === undefined) return;
+  if (summary === undefined) return false;
 
   const precedingToolUseIds = stringList(field(message, 'preceding_tool_use_ids'));
   const toolUseId = stringField(message, 'tool_use_id');
@@ -259,8 +262,19 @@ export function toolUseSummary(
     if (row === undefined) continue;
 
     row.summary = row.summary === undefined ? summary : `${row.summary}\n\n${summary}`;
-    return;
+    return true;
   }
+
+  return false;
+}
+
+export function flushPendingToolRows(context: ClaudeParseContext): readonly SessionViewRow[] {
+  if (context.pendingToolRows.length === 0) return [];
+
+  const rows = context.pendingToolRows;
+  context.pendingToolRows = [];
+  context.toolCallRows.clear();
+  return rows;
 }
 
 function titleCase(value: string): string {
@@ -286,6 +300,7 @@ export function assistantRows(
   const rows: SessionViewRow[] = [];
   const textParts: string[] = [];
   const thinkingParts: string[] = [];
+  let queuedToolCall = false;
 
   const pushText = () => {
     if (textParts.length === 0) return;
@@ -304,8 +319,13 @@ export function assistantRows(
       pushText();
       pushThinking();
       const row = toolCallRow(timestamp, block);
-      rows.push(row);
-      if (row.id !== null) context.toolCallRows.set(row.id, row);
+      if (row.id === null) {
+        rows.push(row);
+      } else {
+        queuedToolCall = true;
+        context.pendingToolRows.push(row);
+        context.toolCallRows.set(row.id, row);
+      }
       continue;
     }
 
@@ -324,7 +344,7 @@ export function assistantRows(
   pushText();
   pushThinking();
 
-  if (rows.length > 0) return rows;
+  if (rows.length > 0 || queuedToolCall) return rows;
 
   const text = stringField(sdkMessage, 'content') ?? stringField(message, 'result');
   return [messageRow(timestamp, 'assistant', 'assistant', text ?? toJson(message), false)];
@@ -333,11 +353,13 @@ export function assistantRows(
 export function userRows(
   timestamp: number,
   message: Record<string, unknown>,
+  context: ClaudeParseContext,
 ): readonly SessionViewRow[] {
   const sdkMessage = asLooseObject(message.message) ?? message;
   const role = isPlatformMessage(sdkMessage) ? 'platform' : 'user';
   const rows: SessionViewRow[] = [];
   const textParts: string[] = [];
+  let queuedToolResult = false;
   const pushText = () => {
     if (textParts.length === 0) return;
     rows.push(messageRow(timestamp, role, role, textParts.join('\n\n'), false));
@@ -348,7 +370,13 @@ export function userRows(
     const type = stringField(block, 'type');
     if (type === 'tool_result' || type === 'tool-result') {
       pushText();
-      rows.push(toolResultRow(timestamp, block));
+      const row = toolResultRow(timestamp, block);
+      if (row.toolCallId !== null && context.toolCallRows.has(row.toolCallId)) {
+        context.pendingToolRows.push(row);
+        queuedToolResult = true;
+      } else {
+        rows.push(row);
+      }
       continue;
     }
 
@@ -358,10 +386,14 @@ export function userRows(
 
   pushText();
 
-  if (rows.length > 0) return rows;
+  if (queuedToolResult) return rows;
+  if (rows.length > 0) return [...flushPendingToolRows(context), ...rows];
 
   const content = stringField(sdkMessage, 'content');
-  return [messageRow(timestamp, role, role, content ?? toJson(message), false)];
+  return [
+    ...flushPendingToolRows(context),
+    messageRow(timestamp, role, role, content ?? toJson(message), false),
+  ];
 }
 
 export function resultRow(

--- a/libs/api/logs/src/core/session/claude/rows.ts
+++ b/libs/api/logs/src/core/session/claude/rows.ts
@@ -169,6 +169,7 @@ export function systemRow(
 
   const isNewSession =
     !context.hasInit || sessionId === undefined || sessionId !== context.sessionId;
+  if (isNewSession) context.toolCallRows.clear();
   context.hasInit = true;
   context.sessionId = sessionId ?? null;
   context.turn = isNewSession ? 1 : context.turn + 1;
@@ -237,6 +238,31 @@ export function rateLimitRow(
   );
 }
 
+export function toolUseSummary(
+  message: Record<string, unknown>,
+  context: ClaudeParseContext,
+): void {
+  const summary = stringField(message, 'summary');
+  if (summary === undefined) return;
+
+  const precedingToolUseIds = stringList(field(message, 'preceding_tool_use_ids'));
+  const toolUseId = stringField(message, 'tool_use_id');
+  const candidateIds =
+    precedingToolUseIds.length > 0
+      ? precedingToolUseIds
+      : toolUseId === undefined
+        ? []
+        : [toolUseId];
+
+  for (const id of [...candidateIds].reverse()) {
+    const row = context.toolCallRows.get(id);
+    if (row === undefined) continue;
+
+    row.summary = row.summary === undefined ? summary : `${row.summary}\n\n${summary}`;
+    return;
+  }
+}
+
 function titleCase(value: string): string {
   return value.length === 0 ? value : `${value[0]?.toUpperCase()}${value.slice(1)}`;
 }
@@ -254,6 +280,7 @@ function stringList(value: unknown): string[] {
 export function assistantRows(
   timestamp: number,
   message: Record<string, unknown>,
+  context: ClaudeParseContext,
 ): readonly SessionViewRow[] {
   const sdkMessage = asLooseObject(message.message) ?? message;
   const rows: SessionViewRow[] = [];
@@ -276,7 +303,9 @@ export function assistantRows(
     if (type === 'tool_use' || type === 'tool-use' || type === 'toolCall') {
       pushText();
       pushThinking();
-      rows.push(toolCallRow(timestamp, block));
+      const row = toolCallRow(timestamp, block);
+      rows.push(row);
+      if (row.id !== null) context.toolCallRows.set(row.id, row);
       continue;
     }
 

--- a/libs/api/logs/src/core/session/claude/rows.ts
+++ b/libs/api/logs/src/core/session/claude/rows.ts
@@ -300,16 +300,24 @@ export function assistantRows(
   const rows: SessionViewRow[] = [];
   const textParts: string[] = [];
   const thinkingParts: string[] = [];
-  let queuedToolCall = false;
+  let queueRows = context.toolCallRows.size > 0;
+
+  const pushRow = (row: SessionViewRow) => {
+    if (queueRows) {
+      context.pendingToolRows.push(row);
+    } else {
+      rows.push(row);
+    }
+  };
 
   const pushText = () => {
     if (textParts.length === 0) return;
-    rows.push(messageRow(timestamp, 'assistant', 'assistant', textParts.join('\n\n'), false));
+    pushRow(messageRow(timestamp, 'assistant', 'assistant', textParts.join('\n\n'), false));
     textParts.length = 0;
   };
   const pushThinking = () => {
     if (thinkingParts.length === 0) return;
-    rows.push(thinkingRow(timestamp, thinkingParts.join('\n\n')));
+    pushRow(thinkingRow(timestamp, thinkingParts.join('\n\n')));
     thinkingParts.length = 0;
   };
 
@@ -320,9 +328,9 @@ export function assistantRows(
       pushThinking();
       const row = toolCallRow(timestamp, block);
       if (row.id === null) {
-        rows.push(row);
+        pushRow(row);
       } else {
-        queuedToolCall = true;
+        queueRows = true;
         context.pendingToolRows.push(row);
         context.toolCallRows.set(row.id, row);
       }
@@ -344,7 +352,7 @@ export function assistantRows(
   pushText();
   pushThinking();
 
-  if (rows.length > 0 || queuedToolCall) return rows;
+  if (rows.length > 0 || queueRows) return rows;
 
   const text = stringField(sdkMessage, 'content') ?? stringField(message, 'result');
   return [messageRow(timestamp, 'assistant', 'assistant', text ?? toJson(message), false)];
@@ -359,7 +367,8 @@ export function userRows(
   const role = isPlatformMessage(sdkMessage) ? 'platform' : 'user';
   const rows: SessionViewRow[] = [];
   const textParts: string[] = [];
-  let queuedToolResult = false;
+  const hadPendingToolCall = context.toolCallRows.size > 0;
+  let matchedToolResult = false;
   const pushText = () => {
     if (textParts.length === 0) return;
     rows.push(messageRow(timestamp, role, role, textParts.join('\n\n'), false));
@@ -372,11 +381,9 @@ export function userRows(
       pushText();
       const row = toolResultRow(timestamp, block);
       if (row.toolCallId !== null && context.toolCallRows.has(row.toolCallId)) {
-        context.pendingToolRows.push(row);
-        queuedToolResult = true;
-      } else {
-        rows.push(row);
+        matchedToolResult = true;
       }
+      rows.push(row);
       continue;
     }
 
@@ -386,14 +393,19 @@ export function userRows(
 
   pushText();
 
-  if (queuedToolResult) return rows;
-  if (rows.length > 0) return [...flushPendingToolRows(context), ...rows];
+  if (rows.length === 0) {
+    const content = stringField(sdkMessage, 'content');
+    rows.push(messageRow(timestamp, role, role, content ?? toJson(message), false));
+  }
 
-  const content = stringField(sdkMessage, 'content');
-  return [
-    ...flushPendingToolRows(context),
-    messageRow(timestamp, role, role, content ?? toJson(message), false),
-  ];
+  if (hadPendingToolCall) {
+    if (matchedToolResult) {
+      context.pendingToolRows.push(...rows);
+      return [];
+    }
+    return [...flushPendingToolRows(context), ...rows];
+  }
+  return rows;
 }
 
 export function resultRow(

--- a/libs/api/logs/src/db/schema/attempt-streams.ts
+++ b/libs/api/logs/src/db/schema/attempt-streams.ts
@@ -1,4 +1,4 @@
-import type {SessionViewLifecycleRow} from '@shipfox/api-logs-dto';
+import type {SessionViewLifecycleRow, SessionViewRow} from '@shipfox/api-logs-dto';
 import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
 import {sql} from 'drizzle-orm';
 import {
@@ -55,6 +55,7 @@ export const attemptStreams = pgTable(
     claudeSessionId: text('claude_session_id'),
     claudeTurn: integer('claude_turn').notNull().default(0),
     claudePendingResult: jsonb('claude_pending_result').$type<SessionViewLifecycleRow>(),
+    claudePendingToolRows: jsonb('claude_pending_tool_rows').$type<SessionViewRow[]>(),
     truncated: boolean('truncated').notNull().default(false),
     objectKey: text('object_key'),
     createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
@@ -107,6 +108,7 @@ export function toAttemptStream(row: AttemptStreamDb): AttemptStream {
     claudeSessionId: row.claudeSessionId,
     claudeTurn: row.claudeTurn,
     claudePendingResult: row.claudePendingResult ?? null,
+    claudePendingToolRows: row.claudePendingToolRows ?? [],
     truncated: row.truncated,
     objectKey: row.objectKey,
     createdAt: row.createdAt,

--- a/libs/api/logs/src/db/streams.ts
+++ b/libs/api/logs/src/db/streams.ts
@@ -1,4 +1,4 @@
-import type {SessionViewLifecycleRow} from '@shipfox/api-logs-dto';
+import type {SessionViewLifecycleRow, SessionViewRow} from '@shipfox/api-logs-dto';
 import {and, asc, eq, getTableColumns, isNull, lt, notInArray, sql} from 'drizzle-orm';
 import type {AttemptStream, StreamCloseReason} from '#core/entities/attempt-stream.js';
 import {LeaseStreamMismatchError} from '#core/errors.js';
@@ -169,6 +169,7 @@ export async function setClaudeParseContext(
     sessionId: string | null;
     turn: number;
     pendingResult: SessionViewLifecycleRow | null;
+    pendingToolRows: readonly SessionViewRow[];
   },
 ): Promise<void> {
   await tx
@@ -178,6 +179,7 @@ export async function setClaudeParseContext(
       claudeSessionId: params.sessionId,
       claudeTurn: params.turn,
       claudePendingResult: params.pendingResult,
+      claudePendingToolRows: [...params.pendingToolRows],
       updatedAt: sql`now()`,
     })
     .where(eq(attemptStreams.id, params.streamId));
@@ -193,7 +195,11 @@ export async function setClaudeParseContext(
 export async function markStreamClosed(
   tx: Transaction,
   params: {streamId: string; reason: StreamCloseReason; markTruncated: boolean},
-): Promise<{stream: AttemptStream; pendingClaudeResult: SessionViewLifecycleRow | null} | null> {
+): Promise<{
+  stream: AttemptStream;
+  pendingClaudeResult: SessionViewLifecycleRow | null;
+  pendingClaudeToolRows: SessionViewRow[];
+} | null> {
   const [open] = await tx
     .select()
     .from(attemptStreams)
@@ -209,6 +215,7 @@ export async function markStreamClosed(
       closedAt: sql`now()`,
       updatedAt: sql`now()`,
       claudePendingResult: null,
+      claudePendingToolRows: null,
       ...(params.markTruncated ? {truncated: true} : {}),
     })
     .where(and(eq(attemptStreams.id, params.streamId), eq(attemptStreams.state, 'open')))
@@ -218,6 +225,7 @@ export async function markStreamClosed(
     ? {
         stream: toAttemptStream(row),
         pendingClaudeResult: open.claudePendingResult ?? null,
+        pendingClaudeToolRows: open.claudePendingToolRows ?? [],
       }
     : null;
 }

--- a/libs/client/logs/src/components/agent-session-rows.tsx
+++ b/libs/client/logs/src/components/agent-session-rows.tsx
@@ -103,7 +103,7 @@ function AgentSessionRowView({
         <LogDisclosure indent={indent}>
           <LogDisclosureTrigger
             timestamp={new Date(row.timestamp)}
-            summary={compactPreview(row.input)}
+            summary={compactPreview(row.summary ?? row.input)}
             trailing={
               awaitingResult ? (
                 <span className="inline-flex items-center gap-4">
@@ -123,9 +123,20 @@ function AgentSessionRowView({
             </span>
           </LogDisclosureTrigger>
           <LogDisclosureContent>
-            <LogContent variant="code">
-              <PreviewText text={row.input} />
-            </LogContent>
+            {row.summary != null ? (
+              <>
+                <LogContent>
+                  <PreviewText text={row.summary} />
+                </LogContent>
+                <LogContent variant="code">
+                  <PreviewText text={row.input} />
+                </LogContent>
+              </>
+            ) : (
+              <LogContent variant="code">
+                <PreviewText text={row.input} />
+              </LogContent>
+            )}
           </LogDisclosureContent>
         </LogDisclosure>
       );

--- a/libs/client/logs/src/core/log-model.ts
+++ b/libs/client/logs/src/core/log-model.ts
@@ -15,7 +15,14 @@ export type SessionViewRow =
       terminalFailure: boolean;
     }
   | {kind: 'thinking'; timestamp: number; text: string}
-  | {kind: 'tool-call'; timestamp: number; id: string | null; name: string; input: string}
+  | {
+      kind: 'tool-call';
+      timestamp: number;
+      id: string | null;
+      name: string;
+      input: string;
+      summary?: string | undefined;
+    }
   | {
       kind: 'tool-result';
       timestamp: number;


### PR DESCRIPTION
## Summary

Handle benign Claude Agent SDK message types in session parsing:

- Ignore `tool_progress`, `prompt_suggestion`, and `tool_use_summary` instead of emitting parser-failure rows.
- Render `auth_status` and `rate_limit_event` as lifecycle rows with meaningful status, tone, and metadata.
- Preserve the raw fallback for malformed or genuinely unknown message types, including forward-compatible warnings for unknown rate-limit statuses.
- Add focused coverage and a minor `@shipfox/api-logs` changeset.

Validation passed with `mise exec -- turbo test --filter=@shipfox/api-logs...`, `mise exec -- turbo type --filter=@shipfox/api-logs...`, and `mise exec -- turbo check --filter=@shipfox/api-logs...`. The dependency-graph check reported one pre-existing warning in `@shipfox/node-outbox`; `@shipfox/api-logs` was clean.

Closes ENG-1339

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop flagging benign Claude SDK messages as unknown in `@shipfox/api-logs`, fold tool-use summaries into matching tool-call rows, preserve row order around tool summaries, and persist tool state across appends for accurate grouping. Implements ENG-1339.

- **Bug Fixes**
  - Ignore `tool_progress` and `prompt_suggestion` (no rows).
  - Fold `tool_use_summary` into the matching tool-call row; buffer tool-call/result and adjacent assistant/user/lifecycle rows until summaries arrive; flush on lifecycle boundaries and stream close; expose `summary` via `@shipfox/api-logs-dto` and render it in `@shipfox/client-logs`.
  - Map `auth_status` to lifecycle rows with clear labels and tones (authenticating, complete, failed).
  - Map `rate_limit_event` to lifecycle rows with labels, tones, humanized type, and utilization; unknown statuses surface as warnings.
  - Reserve `raw` for malformed or truly unknown message types only.

- **Migration**
  - Run DB migrations; adds `logs_attempt_streams.claude_pending_tool_rows` to persist tool state.

<sup>Written for commit 3b1d12431c3cd4ae5d0a87899c34b04fd259c164. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

