### PR TITLE
[Provisioner Core] Add template matrix variant enumeration

### DIFF
--- a/libs/provisioner/core/package.json
+++ b/libs/provisioner/core/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@shipfox/api-runners-dto": "workspace:*",
     "@shipfox/config": "workspace:*",
+    "@shipfox/expression": "workspace:*",
     "@shipfox/node-opentelemetry": "workspace:*",
     "@shipfox/node-resilient-loop": "workspace:*",
     "ky": "catalog:"

--- a/libs/provisioner/core/src/index.ts
+++ b/libs/provisioner/core/src/index.ts
@@ -20,6 +20,22 @@ export {
   type StartProvisionerOptions,
   startProvisioner,
 } from '#provisioner.js';
+export {
+  enumerateTemplateVariants,
+  enumerateVariants,
+  MAX_TEMPLATES,
+  type MatrixAxis,
+  type MatrixBlock,
+  type ParsedTemplateList,
+  type ParsedTemplateObject,
+  type ParsedTemplateValue,
+  type ProvisionerTemplateFile,
+  ProvisionerTemplateFileError,
+  parseProvisionerTemplateFile,
+  parseTemplateFile,
+  type Variant,
+  type VariantBindings,
+} from '#template-file.js';
 export type {ProviderRunnerTracker} from '#tracker.js';
 export type {
   LaunchOutcome,

--- a/libs/provisioner/core/src/template-file.test.ts
+++ b/libs/provisioner/core/src/template-file.test.ts
@@ -121,6 +121,27 @@ describe('enumerateVariants', () => {
     ]);
   });
 
+  it('preserves prototype-named matrix and axis keys', () => {
+    const matrix = Object.fromEntries([
+      [
+        '__proto__',
+        {
+          axes: Object.fromEntries([['__proto__', ['x64']]]),
+          template: {},
+        },
+      ],
+    ]);
+    const file = parseTemplateFile({templates: {}, matrix});
+
+    expect(Object.keys(file.matrix ?? {})).toEqual(['__proto__']);
+    expect(enumerateVariants(file)).toEqual([
+      {
+        block: '__proto__',
+        bindings: Object.fromEntries([['__proto__', 'x64']]),
+      },
+    ]);
+  });
+
   it('evaluates expression axes against file vars and requires a non-empty list', () => {
     const file = parseTemplateFile({
       vars: {cpus: [2, 4]},

--- a/libs/provisioner/core/src/template-file.test.ts
+++ b/libs/provisioner/core/src/template-file.test.ts
@@ -1,0 +1,179 @@
+import {enumerateVariants, MAX_TEMPLATES, parseTemplateFile} from '#template-file.js';
+
+const expression = (source: string) => `\${{ ${source} }}`;
+const MULTI_BLOCK_ERROR_PATTERN =
+  /matrix\.standard\.axes\.cpu.*matrix\.standard\.include\.0.*matrix\.gpu\.include\.0/s;
+const INCOMPLETE_INCLUDE_PATTERN =
+  /must bind every declared axis.*missing arch.*unknown axes: extra/s;
+
+describe('parseTemplateFile', () => {
+  it('preserves the existing hand-written file shape when matrix is absent', () => {
+    const templates = {linux: {labels: ['linux']}};
+
+    const parsed = parseTemplateFile({templates});
+
+    expect(parsed).toEqual({templates});
+  });
+
+  it('parses shared vars, defaults, and expressions without evaluating them', () => {
+    const parsed = parseTemplateFile({
+      vars: {sizes: [2, 4]},
+      defaults: {market: 'spot'},
+      templates: {},
+      matrix: {
+        standard: {
+          axes: {cpu: expression('vars.sizes')},
+          template: {cpu: expression('cpu')},
+          let: {double_cpu: expression('cpu * 2')},
+          key: expression('string(cpu)'),
+        },
+      },
+    });
+
+    expect(parsed.vars).toEqual({sizes: [2, 4]});
+    expect(parsed.defaults).toEqual({market: 'spot'});
+    expect(parsed.matrix?.standard?.axes.cpu).toMatchObject({source: 'vars.sizes'});
+    expect(parsed.matrix?.standard?.let.double_cpu).toMatchObject({source: 'cpu * 2'});
+    expect(parsed.matrix?.standard?.key).toMatchObject({source: 'string(cpu)'});
+    expect(parsed.matrix?.standard?.template.cpu).toEqual([
+      expect.objectContaining({kind: 'expr', expression: expect.objectContaining({source: 'cpu'})}),
+    ]);
+  });
+
+  it('reports structural errors from multiple blocks together', () => {
+    expect(() =>
+      parseTemplateFile({
+        templates: {},
+        matrix: {
+          standard: {axes: {cpu: []}, template: {}, include: [{cpu: 1, extra: true}]},
+          gpu: {axes: {arch: [1]}, template: {}, include: [{wrong: 'x'}]},
+        },
+      }),
+    ).toThrow(MULTI_BLOCK_ERROR_PATTERN);
+  });
+
+  it('requires complete include bindings and rejects unknown axes', () => {
+    expect(() =>
+      parseTemplateFile({
+        templates: {},
+        matrix: {
+          standard: {
+            axes: {cpu: [2], arch: ['x64']},
+            include: [{cpu: 4, extra: true}],
+            template: {},
+          },
+        },
+      }),
+    ).toThrow(INCOMPLETE_INCLUDE_PATTERN);
+  });
+});
+
+describe('enumerateVariants', () => {
+  it('enumerates independent families in stable cartesian-product order', () => {
+    const file = parseTemplateFile({
+      templates: {one_off: {}},
+      matrix: {
+        standard: {
+          axes: {arch: ['x64', 'arm64'], cpu: [2, 4]},
+          exclude: [{arch: 'x64', cpu: 4}],
+          include: [{arch: 'x64', cpu: 8}],
+          template: {},
+        },
+        gpu: {
+          axes: {model: ['a10', 'a100'], size: ['small', 'large']},
+          template: {},
+        },
+      },
+    });
+
+    const variants = enumerateVariants(file);
+
+    expect(variants).toEqual([
+      {block: 'standard', bindings: {arch: 'x64', cpu: 2}},
+      {block: 'standard', bindings: {arch: 'arm64', cpu: 2}},
+      {block: 'standard', bindings: {arch: 'arm64', cpu: 4}},
+      {block: 'standard', bindings: {arch: 'x64', cpu: 8}},
+      {block: 'gpu', bindings: {model: 'a10', size: 'small'}},
+      {block: 'gpu', bindings: {model: 'a10', size: 'large'}},
+      {block: 'gpu', bindings: {model: 'a100', size: 'small'}},
+      {block: 'gpu', bindings: {model: 'a100', size: 'large'}},
+    ]);
+  });
+
+  it('applies partial excludes across all matching variants', () => {
+    const file = parseTemplateFile({
+      templates: {},
+      matrix: {
+        standard: {
+          axes: {
+            arch: ['x64', 'arm64'],
+            cpu: [2, 4],
+          },
+          exclude: [{arch: 'x64'}],
+          template: {},
+        },
+      },
+    });
+
+    expect(enumerateVariants(file)).toEqual([
+      {block: 'standard', bindings: {arch: 'arm64', cpu: 2}},
+      {block: 'standard', bindings: {arch: 'arm64', cpu: 4}},
+    ]);
+  });
+
+  it('evaluates expression axes against file vars and requires a non-empty list', () => {
+    const file = parseTemplateFile({
+      vars: {cpus: [2, 4]},
+      templates: {},
+      matrix: {
+        standard: {
+          axes: {cpu: expression('vars.cpus')},
+          template: {},
+        },
+      },
+    });
+
+    expect(enumerateVariants(file)).toEqual([
+      {block: 'standard', bindings: {cpu: 2}},
+      {block: 'standard', bindings: {cpu: 4}},
+    ]);
+
+    const empty = parseTemplateFile({
+      templates: {},
+      matrix: {standard: {axes: {cpu: expression('[]')}, template: {}}},
+    });
+    expect(() => enumerateVariants(empty)).toThrow('axis "cpu" must not be empty');
+  });
+
+  it('uses the scoped range evaluator for generated axes', () => {
+    const file = parseTemplateFile({
+      templates: {},
+      matrix: {
+        standard: {
+          axes: {cpu: expression('range(2, 6, 2)')},
+          template: {},
+        },
+      },
+    });
+
+    expect(enumerateVariants(file).map(({bindings}) => bindings)).toEqual([
+      {cpu: 2n},
+      {cpu: 4n},
+      {cpu: 6n},
+    ]);
+  });
+
+  it('counts all blocks and hand-written templates before materializing variants', () => {
+    const file = parseTemplateFile({
+      templates: {one_off: {}},
+      matrix: {
+        standard: {axes: {cpu: Array.from({length: MAX_TEMPLATES}, (_, i) => i)}, template: {}},
+        gpu: {axes: {model: ['a']}, template: {}},
+      },
+    });
+
+    expect(() => enumerateVariants(file)).toThrow(
+      `matrix expands to ${MAX_TEMPLATES + 1} templates (standard: ${MAX_TEMPLATES}, gpu: 1) plus 1 hand-written; the maximum is ${MAX_TEMPLATES}`,
+    );
+  });
+});

--- a/libs/provisioner/core/src/template-file.ts
+++ b/libs/provisioner/core/src/template-file.ts
@@ -163,7 +163,7 @@ function evaluateBlockAxes(
   errors: string[],
 ): PreparedBlock | undefined {
   const axisNames = Object.keys(block.axes);
-  const axisValues: Record<string, readonly unknown[]> = {};
+  const axisValues = createMap<readonly unknown[]>();
   let cartesianCount = 1n;
   let hasError = false;
   const environment = createRangeEnvironment();
@@ -240,7 +240,7 @@ function materializeCartesianProduct(
     delete bindings[axisName];
   }
 
-  visit(0, {});
+  visit(0, createMap());
   return variants;
 }
 
@@ -252,7 +252,7 @@ function parseMatrix(
   const blocks = parseRecord(value, 'matrix', errors);
   if (blocks === undefined) return undefined;
 
-  const parsed: Record<string, MatrixBlock> = {};
+  const parsed = createMap<MatrixBlock>();
   for (const [name, rawBlock] of Object.entries(blocks)) {
     const block = parseBlock(name, rawBlock, errors);
     if (block !== undefined) parsed[name] = block;
@@ -298,7 +298,7 @@ function parseAxes(
   const rawAxes = parseRecord(value, path, errors);
   if (rawAxes === undefined) return {};
 
-  const axes: Record<string, MatrixAxis> = {};
+  const axes = createMap<MatrixAxis>();
   for (const [name, axis] of Object.entries(rawAxes)) {
     if (name.length === 0) {
       errors.push(`${path} contains an empty axis name`);
@@ -367,7 +367,7 @@ function parseExpressionMap(
   const rawBindings = parseRecord(value, path, errors);
   if (rawBindings === undefined) return {};
 
-  const bindings: Record<string, WorkflowExpression> = {};
+  const bindings = createMap<WorkflowExpression>();
   for (const [name, expression] of Object.entries(rawBindings)) {
     const parsed = parseExpression(expression, `${path}.${name}`, errors);
     if (parsed !== undefined) bindings[name] = parsed;
@@ -493,6 +493,10 @@ function valuesEqual(left: unknown, right: unknown): boolean {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function createMap<T>(): Record<string, T> {
+  return Object.create(null) as Record<string, T>;
 }
 
 function expressionErrorMessage(error: unknown): string {

--- a/libs/provisioner/core/src/template-file.ts
+++ b/libs/provisioner/core/src/template-file.ts
@@ -1,0 +1,510 @@
+import {
+  createRangeEnvironment,
+  createWorkflowExpression,
+  evaluateWorkflowExpressionWithEnvironment,
+  InvalidWorkflowExpressionError,
+  InvalidWorkflowTemplateError,
+  parseWorkflowTemplate,
+  type WorkflowExpression,
+  type WorkflowTemplateSegment,
+} from '@shipfox/expression';
+
+/** The maximum number of hand-written and expanded templates in one file. */
+export const MAX_TEMPLATES = 1_000;
+
+export type VariantBindings = Readonly<Record<string, unknown>>;
+
+export interface ParsedTemplateList extends ReadonlyArray<ParsedTemplateValue> {}
+
+export interface ParsedTemplateObject {
+  readonly [key: string]: ParsedTemplateValue;
+}
+
+export type ParsedTemplateValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | readonly WorkflowTemplateSegment[]
+  | ParsedTemplateList
+  | ParsedTemplateObject;
+
+export type MatrixAxis = readonly unknown[] | WorkflowExpression;
+
+export interface MatrixBlock {
+  readonly axes: Readonly<Record<string, MatrixAxis>>;
+  readonly exclude: readonly VariantBindings[];
+  readonly include: readonly VariantBindings[];
+  readonly let: Readonly<Record<string, WorkflowExpression>>;
+  readonly key?: WorkflowExpression;
+  readonly template: Readonly<Record<string, ParsedTemplateValue>>;
+}
+
+export interface ProvisionerTemplateFile {
+  readonly templates: Readonly<Record<string, unknown>>;
+  readonly vars?: Readonly<Record<string, unknown>>;
+  readonly defaults?: Readonly<Record<string, ParsedTemplateValue>>;
+  readonly matrix?: Readonly<Record<string, MatrixBlock>>;
+}
+
+export interface Variant {
+  readonly block: string;
+  readonly bindings: VariantBindings;
+}
+
+export class ProvisionerTemplateFileError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ProvisionerTemplateFileError';
+  }
+}
+
+/**
+ * Parse the provider-neutral template-file envelope and matrix declarations.
+ * Expressions are syntax-checked but not evaluated until enumeration.
+ */
+export function parseTemplateFile(raw: unknown): ProvisionerTemplateFile {
+  const errors: string[] = [];
+  if (!isRecord(raw)) {
+    throw new ProvisionerTemplateFileError('Template file must be a map.');
+  }
+
+  const allowedKeys = new Set(['templates', 'vars', 'defaults', 'matrix']);
+  for (const key of Object.keys(raw)) {
+    if (!allowedKeys.has(key)) errors.push(`unknown file key "${key}"`);
+  }
+
+  const templates = parseRecord(raw.templates, 'templates', errors) ?? {};
+  const vars = parseOptionalRecord(raw.vars, 'vars', errors);
+  const defaults = parseOptionalTemplateFragment(raw.defaults, 'defaults', errors);
+  const matrix = parseMatrix(raw.matrix, errors);
+
+  if (errors.length > 0) {
+    throw new ProvisionerTemplateFileError(`Invalid template file: ${errors.join('; ')}`);
+  }
+
+  return {
+    templates,
+    ...(vars === undefined ? {} : {vars}),
+    ...(defaults === undefined ? {} : {defaults}),
+    ...(matrix === undefined ? {} : {matrix}),
+  };
+}
+
+/**
+ * Enumerate matrix variants in declaration order.
+ *
+ * Axis values are crossed with the first declared axis as the most significant
+ * axis and the last declared axis as the least significant axis. All blocks are
+ * evaluated and validated before the first cartesian product is materialized.
+ */
+export function enumerateVariants(file: ProvisionerTemplateFile): Variant[] {
+  const preparedBlocks: PreparedBlock[] = [];
+  const errors: string[] = [];
+
+  for (const [blockName, block] of Object.entries(file.matrix ?? {})) {
+    const prepared = evaluateBlockAxes(blockName, block, file.vars ?? {}, errors);
+    if (prepared !== undefined) preparedBlocks.push(prepared);
+  }
+
+  if (errors.length > 0) {
+    throw new ProvisionerTemplateFileError(`Invalid template matrix: ${errors.join('; ')}`);
+  }
+
+  const contributions = preparedBlocks.map(({name, cartesianCount, include}) => ({
+    name,
+    count: cartesianCount + BigInt(include.length),
+  }));
+  const matrixCount = contributions.reduce((total, contribution) => total + contribution.count, 0n);
+  const handWrittenCount = BigInt(Object.keys(file.templates).length);
+  const totalCount = matrixCount + handWrittenCount;
+
+  if (totalCount > BigInt(MAX_TEMPLATES)) {
+    const contributionText = contributions.map(({name, count}) => `${name}: ${count}`).join(', ');
+    const matrixText = contributionText.length > 0 ? ` (${contributionText})` : '';
+    throw new ProvisionerTemplateFileError(
+      `matrix expands to ${matrixCount} templates${matrixText} plus ${handWrittenCount} hand-written; the maximum is ${MAX_TEMPLATES}`,
+    );
+  }
+
+  const variants: Variant[] = [];
+  for (const block of preparedBlocks) {
+    const cartesian = materializeCartesianProduct(block.axisNames, block.axisValues);
+    for (const bindings of cartesian) {
+      if (!block.exclude.some((entry) => matchesPartial(bindings, entry))) {
+        variants.push({block: block.name, bindings});
+      }
+    }
+    for (const bindings of block.include) {
+      variants.push({block: block.name, bindings});
+    }
+  }
+
+  return variants;
+}
+
+export const parseProvisionerTemplateFile = parseTemplateFile;
+export const enumerateTemplateVariants = enumerateVariants;
+
+interface PreparedBlock {
+  readonly name: string;
+  readonly axisNames: readonly string[];
+  readonly axisValues: Readonly<Record<string, readonly unknown[]>>;
+  readonly exclude: readonly VariantBindings[];
+  readonly include: readonly VariantBindings[];
+  readonly cartesianCount: bigint;
+}
+
+function evaluateBlockAxes(
+  blockName: string,
+  block: MatrixBlock,
+  vars: Readonly<Record<string, unknown>>,
+  errors: string[],
+): PreparedBlock | undefined {
+  const axisNames = Object.keys(block.axes);
+  const axisValues: Record<string, readonly unknown[]> = {};
+  let cartesianCount = 1n;
+  let hasError = false;
+  const environment = createRangeEnvironment();
+
+  for (const axisName of axisNames) {
+    const axis = block.axes[axisName];
+    if (axis === undefined) {
+      errors.push(`matrix "${blockName}" axis "${axisName}" is missing`);
+      hasError = true;
+      continue;
+    }
+    let values: unknown[];
+    if (Array.isArray(axis)) {
+      values = [...axis];
+    } else {
+      try {
+        const expression = axis as WorkflowExpression;
+        const result = evaluateWorkflowExpressionWithEnvironment(expression, {vars}, environment);
+        if (!Array.isArray(result)) {
+          errors.push(`matrix "${blockName}" axis "${axisName}" must evaluate to a list`);
+          hasError = true;
+          continue;
+        }
+        values = result;
+      } catch (error) {
+        errors.push(
+          `matrix "${blockName}" axis "${axisName}" could not be evaluated: ${errorMessage(error)}`,
+        );
+        hasError = true;
+        continue;
+      }
+    }
+
+    if (values.length === 0) {
+      errors.push(`matrix "${blockName}" axis "${axisName}" must not be empty`);
+      hasError = true;
+      continue;
+    }
+
+    axisValues[axisName] = values;
+    cartesianCount *= BigInt(values.length);
+  }
+
+  return hasError
+    ? undefined
+    : {
+        name: blockName,
+        axisNames,
+        axisValues,
+        exclude: block.exclude,
+        include: block.include,
+        cartesianCount,
+      };
+}
+
+function materializeCartesianProduct(
+  axisNames: readonly string[],
+  axisValues: Readonly<Record<string, readonly unknown[]>>,
+): VariantBindings[] {
+  const variants: VariantBindings[] = [];
+
+  function visit(axisIndex: number, bindings: Record<string, unknown>): void {
+    if (axisIndex === axisNames.length) {
+      variants.push({...bindings});
+      return;
+    }
+
+    const axisName = axisNames[axisIndex];
+    if (axisName === undefined) return;
+    for (const value of axisValues[axisName] ?? []) {
+      bindings[axisName] = value;
+      visit(axisIndex + 1, bindings);
+    }
+    delete bindings[axisName];
+  }
+
+  visit(0, {});
+  return variants;
+}
+
+function parseMatrix(
+  value: unknown,
+  errors: string[],
+): Readonly<Record<string, MatrixBlock>> | undefined {
+  if (value === undefined) return undefined;
+  const blocks = parseRecord(value, 'matrix', errors);
+  if (blocks === undefined) return undefined;
+
+  const parsed: Record<string, MatrixBlock> = {};
+  for (const [name, rawBlock] of Object.entries(blocks)) {
+    const block = parseBlock(name, rawBlock, errors);
+    if (block !== undefined) parsed[name] = block;
+  }
+  return parsed;
+}
+
+function parseBlock(name: string, value: unknown, errors: string[]): MatrixBlock | undefined {
+  const path = `matrix.${name}`;
+  if (!isRecord(value)) {
+    errors.push(`${path} must be a map`);
+    return undefined;
+  }
+
+  const allowedKeys = new Set(['axes', 'exclude', 'include', 'let', 'key', 'template']);
+  for (const key of Object.keys(value)) {
+    if (!allowedKeys.has(key)) errors.push(`${path} has unknown key "${key}"`);
+  }
+
+  const axes = parseAxes(value.axes, `${path}.axes`, errors);
+  const exclude = parseVariantList(value.exclude, `${path}.exclude`, errors, axes);
+  const include = parseVariantList(value.include, `${path}.include`, errors, axes, true);
+  const bindings = parseExpressionMap(value.let, `${path}.let`, errors);
+  const key =
+    value.key === undefined ? undefined : parseExpression(value.key, `${path}.key`, errors);
+  const template = parseTemplateObject(value.template, `${path}.template`, errors);
+
+  return {
+    axes,
+    exclude,
+    include,
+    let: bindings,
+    ...(key === undefined ? {} : {key}),
+    template,
+  };
+}
+
+function parseAxes(
+  value: unknown,
+  path: string,
+  errors: string[],
+): Readonly<Record<string, MatrixAxis>> {
+  const rawAxes = parseRecord(value, path, errors);
+  if (rawAxes === undefined) return {};
+
+  const axes: Record<string, MatrixAxis> = {};
+  for (const [name, axis] of Object.entries(rawAxes)) {
+    if (name.length === 0) {
+      errors.push(`${path} contains an empty axis name`);
+      continue;
+    }
+    if (Array.isArray(axis)) {
+      if (axis.length === 0) errors.push(`${path}.${name} must not be empty`);
+      axes[name] = axis;
+      continue;
+    }
+    const expression = parseExpression(axis, `${path}.${name}`, errors);
+    if (expression !== undefined) axes[name] = expression;
+  }
+  return axes;
+}
+
+function parseVariantList(
+  value: unknown,
+  path: string,
+  errors: string[],
+  axes: Readonly<Record<string, MatrixAxis>>,
+  requireComplete = false,
+): VariantBindings[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) {
+    errors.push(`${path} must be a list`);
+    return [];
+  }
+
+  return value.flatMap((entry, index) => {
+    const entryPath = `${path}.${index}`;
+    if (!isRecord(entry)) {
+      errors.push(`${entryPath} must be a map`);
+      return [];
+    }
+
+    const axisNames = Object.keys(axes);
+    const missing = axisNames.filter((axisName) => !Object.hasOwn(entry, axisName));
+    const extra = Object.keys(entry).filter((axisName) => !Object.hasOwn(axes, axisName));
+    if (requireComplete && missing.length > 0) {
+      errors.push(`${entryPath} must bind every declared axis; missing ${missing.join(', ')}`);
+    }
+    if (extra.length > 0) {
+      errors.push(`${entryPath} has unknown axes: ${extra.join(', ')}`);
+    }
+    if (requireComplete && (missing.length > 0 || extra.length > 0)) return [];
+    if (!requireComplete && extra.length > 0) return [];
+
+    return [
+      Object.fromEntries(
+        (requireComplete ? axisNames : Object.keys(entry)).map((axisName) => [
+          axisName,
+          entry[axisName],
+        ]),
+      ),
+    ];
+  });
+}
+
+function parseExpressionMap(
+  value: unknown,
+  path: string,
+  errors: string[],
+): Readonly<Record<string, WorkflowExpression>> {
+  if (value === undefined) return {};
+  const rawBindings = parseRecord(value, path, errors);
+  if (rawBindings === undefined) return {};
+
+  const bindings: Record<string, WorkflowExpression> = {};
+  for (const [name, expression] of Object.entries(rawBindings)) {
+    const parsed = parseExpression(expression, `${path}.${name}`, errors);
+    if (parsed !== undefined) bindings[name] = parsed;
+  }
+  return bindings;
+}
+
+function parseExpression(
+  value: unknown,
+  path: string,
+  errors: string[],
+): WorkflowExpression | undefined {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    errors.push(`${path} must be a non-empty expression`);
+    return undefined;
+  }
+
+  try {
+    if (value.includes('${{')) {
+      const segments = parseWorkflowTemplate(value);
+      if (segments.length !== 1 || segments[0]?.kind !== 'expr') {
+        errors.push(`${path} must contain exactly one expression`);
+        return undefined;
+      }
+      return segments[0].expression;
+    }
+    return createWorkflowExpression({source: value, check: {mode: 'syntax'}});
+  } catch (error) {
+    errors.push(`${path} is invalid: ${expressionErrorMessage(error)}`);
+    return undefined;
+  }
+}
+
+function parseRecord(
+  value: unknown,
+  path: string,
+  errors: string[],
+): Record<string, unknown> | undefined {
+  if (!isRecord(value)) {
+    errors.push(`${path} must be a map`);
+    return undefined;
+  }
+  return value;
+}
+
+function parseOptionalRecord(
+  value: unknown,
+  path: string,
+  errors: string[],
+): Readonly<Record<string, unknown>> | undefined {
+  if (value === undefined) return undefined;
+  return parseRecord(value, path, errors);
+}
+
+function parseOptionalTemplateFragment(
+  value: unknown,
+  path: string,
+  errors: string[],
+): Readonly<Record<string, ParsedTemplateValue>> | undefined {
+  if (value === undefined) return undefined;
+  return parseTemplateObject(value, path, errors);
+}
+
+function parseTemplateObject(
+  value: unknown,
+  path: string,
+  errors: string[],
+): Readonly<Record<string, ParsedTemplateValue>> {
+  const record = parseRecord(value, path, errors);
+  if (record === undefined) return {};
+
+  return Object.fromEntries(
+    Object.entries(record).map(([key, child]) => [
+      key,
+      parseTemplateValue(child, `${path}.${key}`, errors),
+    ]),
+  );
+}
+
+function parseTemplateValue(value: unknown, path: string, errors: string[]): ParsedTemplateValue {
+  if (typeof value === 'string' && value.includes('${{')) {
+    try {
+      return parseWorkflowTemplate(value);
+    } catch (error) {
+      errors.push(`${path} is invalid: ${expressionErrorMessage(error)}`);
+      return value;
+    }
+  }
+  if (Array.isArray(value)) {
+    return value.map((child, index) => parseTemplateValue(child, `${path}.${index}`, errors));
+  }
+  if (isRecord(value)) {
+    return parseTemplateObject(value, path, errors);
+  }
+  return value as ParsedTemplateValue;
+}
+
+function matchesPartial(bindings: VariantBindings, partial: VariantBindings): boolean {
+  return Object.entries(partial).every(([key, value]) => valuesEqual(bindings[key], value));
+}
+
+function valuesEqual(left: unknown, right: unknown): boolean {
+  if (typeof left === 'number' && typeof right === 'bigint') {
+    return Number.isInteger(left) && Number.isSafeInteger(left) && BigInt(left) === right;
+  }
+  if (typeof left === 'bigint' && typeof right === 'number') return valuesEqual(right, left);
+  if (Object.is(left, right)) return true;
+  if (Array.isArray(left) && Array.isArray(right)) {
+    return (
+      left.length === right.length && left.every((value, index) => valuesEqual(value, right[index]))
+    );
+  }
+  if (isRecord(left) && isRecord(right)) {
+    const leftKeys = Object.keys(left);
+    const rightKeys = Object.keys(right);
+    return (
+      leftKeys.length === rightKeys.length &&
+      leftKeys.every((key) => Object.hasOwn(right, key) && valuesEqual(left[key], right[key]))
+    );
+  }
+  return false;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function expressionErrorMessage(error: unknown): string {
+  if (error instanceof InvalidWorkflowExpressionError) return error.reason;
+  if (error instanceof InvalidWorkflowTemplateError) return error.reason;
+  return errorMessage(error);
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    if (error.cause instanceof Error) return error.cause.message;
+    return error.message;
+  }
+  return String(error);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6259,6 +6259,9 @@ importers:
       '@shipfox/config':
         specifier: workspace:*
         version: link:../../shared/common/config
+      '@shipfox/expression':
+        specifier: workspace:*
+        version: link:../../shared/expression
       '@shipfox/node-opentelemetry':
         specifier: workspace:*
         version: link:../../shared/node/opentelemetry


### PR DESCRIPTION
Add the provisioner-core template-file model and deterministic matrix variant enumeration needed by the templated provisioner configuration flow. The parser validates the matrix shape and expression syntax, while enumeration evaluates scoped axes, applies partial exclusions and complete inclusions, preserves deterministic ordering, and enforces the expansion cap.

Closes ENG-1322

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements ENG-1322 by adding a template-file model and deterministic matrix variant enumeration for the templated provisioner configuration flow. Validates matrix shape and expressions, evaluates scoped axes with includes/excludes in stable order, preserves prototype-named keys, and enforces a 1,000-template cap.

- New Features
  - Parse template files (vars, defaults, templates, matrix blocks); expressions are syntax-checked at parse and evaluated during enumeration.
  - Enumerate variants across blocks in stable cartesian order (first axis most significant); supports partial excludes and complete includes.
  - Preserve `__proto__` matrix, axis, and binding names using null-prototype maps.
  - Export parseTemplateFile, parseProvisionerTemplateFile, enumerateVariants, enumerateTemplateVariants, MAX_TEMPLATES, and related types from core index.

- Dependencies
  - Add `@shipfox/expression` for expression parsing/evaluation and range environment.

<sup>Written for commit 4d87c85ff4241b7555518755188853a167a17766. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

