### PR TITLE
[provisioner-ec2] Fix EC2 runner reservation assignment

### DIFF
--- a/libs/provisioner/ec2/src/lifecycle.test.ts
+++ b/libs/provisioner/ec2/src/lifecycle.test.ts
@@ -11,7 +11,7 @@ import {createEc2Lifecycle} from '#lifecycle.js';
 import type {Ec2TemplateSpec} from '#templates.js';
 
 const observability = vi.hoisted(() => ({
-  logger: {error: vi.fn(), info: vi.fn()},
+  logger: {error: vi.fn(), info: vi.fn(), warn: vi.fn()},
   recordEc2Launch: vi.fn(),
   recordEc2Termination: vi.fn(),
 }));
@@ -150,6 +150,62 @@ describe('createEc2Lifecycle', () => {
       new Map([['spot-small', {starting: 0, running: 1}]]),
     );
     expect(client.reportBodies[0]?.events[0]).toMatchObject({state: 'running'});
+  });
+
+  it('assigns an enrolled observed runner through its EC2 identity', async () => {
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({
+      engine: fakeEngine({instances: [instance({state: 'running'})]}),
+      client,
+    });
+
+    await lifecycle.observe();
+
+    expect(client.assignmentBodies).toEqual([
+      {
+        reservationId: '00000000-0000-4000-8000-000000000003',
+        runnerInstanceIds: [RUNNER_INSTANCE_ID],
+      },
+    ]);
+  });
+
+  it('continues reporting and terminating runners when assignment is rejected', async () => {
+    const engine = fakeEngine({
+      instances: [
+        instance({state: 'running'}),
+        instance({
+          state: 'running',
+          instanceId: 'i-terminate',
+          providerRunnerId: 'runner-terminate',
+        }),
+      ],
+    });
+    const client = fakeClient({
+      assignmentErrors: [httpError(404)],
+      reconcileResponse: {
+        runners: [reconciledRunner('runner-terminate', 'terminate')],
+        terminated_absent_provider_runner_ids: [],
+      },
+    });
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.reconcile();
+
+    expect(client.reportBodies.flatMap((body) => body.events)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({provider_runner_id: 'runner-1', state: 'running'}),
+        expect.objectContaining({
+          provider_runner_id: 'runner-terminate',
+          state: 'terminated',
+          reason: 'backend-terminate',
+        }),
+      ]),
+    );
+    expect(engine.terminated).toEqual(['i-terminate']);
+    expect(observability.logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({reservationId: '00000000-0000-4000-8000-000000000003'}),
+      'Reservation assignment rejected',
+    );
   });
 
   it('reports a Spot-reclaimed terminated instance as failed', async () => {
@@ -550,21 +606,26 @@ function fakeEngine(
 function fakeClient(
   options: {
     reportErrors?: Error[];
+    assignmentErrors?: Error[];
     attachResult?: {attached: boolean};
     reconcileResponse?: Awaited<ReturnType<ProvisionerClient['reconcileRunnerInstances']>>;
   } = {},
 ): ProvisionerClient & {
   reportBodies: ReportRunnerInstancesBodyDto[];
   reconcileBodies: Array<{observed_provider_runner_ids: string[]}>;
+  assignmentBodies: Array<{reservationId: string; runnerInstanceIds: string[]}>;
   attachments: Array<{runnerInstanceId: string; providerRunnerId: string}>;
 } {
   const reportBodies: ReportRunnerInstancesBodyDto[] = [];
   const reconcileBodies: Array<{observed_provider_runner_ids: string[]}> = [];
+  const assignmentBodies: Array<{reservationId: string; runnerInstanceIds: string[]}> = [];
   const attachments: Array<{runnerInstanceId: string; providerRunnerId: string}> = [];
   const reportErrors = [...(options.reportErrors ?? [])];
+  const assignmentErrors = [...(options.assignmentErrors ?? [])];
   return {
     reportBodies,
     reconcileBodies,
+    assignmentBodies,
     attachments,
     getIdentity: () =>
       Promise.resolve({id: 'provisioner', scope: 'installation', workspace_id: null}),
@@ -584,8 +645,12 @@ function fakeClient(
       attachments.push({runnerInstanceId, providerRunnerId});
       return Promise.resolve(options.attachResult ?? {attached: true});
     },
-    assignRunnerInstances: (_reservationId, runnerInstanceIds) =>
-      Promise.resolve({runner_instance_ids: runnerInstanceIds}),
+    assignRunnerInstances: (reservationId, runnerInstanceIds) => {
+      assignmentBodies.push({reservationId, runnerInstanceIds});
+      const error = assignmentErrors.shift();
+      if (error) return Promise.reject(error);
+      return Promise.resolve({runner_instance_ids: runnerInstanceIds});
+    },
     reportRunnerInstances: (body) => {
       reportBodies.push(body);
       const error = reportErrors.shift();

--- a/libs/provisioner/ec2/src/lifecycle.ts
+++ b/libs/provisioner/ec2/src/lifecycle.ts
@@ -33,6 +33,11 @@ type LocallyLaunchedRunner = {
   launchedAt: Date;
 };
 
+type AssignmentCandidate = {
+  reservationId: string;
+  runnerInstanceId: string;
+};
+
 export interface Ec2Lifecycle {
   launch(launch: ProviderRunnerLaunch<Ec2TemplateSpec>): Promise<void>;
   observe(): Promise<void>;
@@ -225,6 +230,7 @@ async function applyObservedInstances(
 ): Promise<void> {
   const trackerRunners: TrackerSeed[] = [];
   const events: RunnerInstanceReportEventDto[] = [];
+  const assignmentCandidates: AssignmentCandidate[] = [];
   const observedIds = new Set<string>();
   const reapInstances: Ec2InstanceView[] = [];
   const terminateIntentInstances: Ec2InstanceView[] = [];
@@ -251,6 +257,16 @@ async function applyObservedInstances(
     if (labels.length === 0) continue;
 
     const mapped = mapInstanceState(instance);
+    if (
+      (mapped.state === 'starting' || mapped.state === 'running') &&
+      identity.runnerInstanceId &&
+      identity.reservationId
+    ) {
+      assignmentCandidates.push({
+        runnerInstanceId: identity.runnerInstanceId,
+        reservationId: identity.reservationId,
+      });
+    }
     if (mapped.state === 'failed' || mapped.state === 'terminated') {
       const terminationReason =
         mapped.reason === 'spot-interruption' ? 'spot-interruption' : 'observed-terminated';
@@ -277,9 +293,32 @@ async function applyObservedInstances(
 
   synthesizeAbsentLaunchedRunners(context, observedIds, trackerRunners, events);
   context.tracker.replaceAll(trackerRunners);
+  await assignEnrolledReservations(context, assignmentCandidates);
   if (events.length > 0) await reportEvents(context, events);
   await terminateInstances(context, terminateIntentInstances, 'backend-terminate');
   await terminateInstances(context, reapInstances, 'registration-deadline');
+}
+
+async function assignEnrolledReservations(
+  context: Ec2LifecycleContext,
+  candidates: readonly AssignmentCandidate[],
+): Promise<void> {
+  const assignments = new Map<string, string[]>();
+  for (const {reservationId, runnerInstanceId} of candidates) {
+    const runnerInstanceIds = assignments.get(reservationId) ?? [];
+    runnerInstanceIds.push(runnerInstanceId);
+    assignments.set(reservationId, runnerInstanceIds);
+  }
+  for (const [reservationId, runnerInstanceIds] of assignments) {
+    try {
+      await context.client.assignRunnerInstances(reservationId, runnerInstanceIds);
+    } catch (error) {
+      logger().warn(
+        {reservationId, runnerInstanceIds, err: error},
+        'Reservation assignment rejected',
+      );
+    }
+  }
 }
 
 function synthesizeAbsentLaunchedRunners(


### PR DESCRIPTION
## Summary

Wire EC2 convergence to assign observed runner instances to their demand reservation, mirroring the Docker provisioner fallback while retaining enrollment as the fast path.

Assignment failures are logged and isolated per reservation so stale or deleted reservations cannot block fleet reporting, reaping, or termination.

Closes ENG-1333

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Assigns observed EC2 runners to their demand reservations during convergence and isolates assignment errors so stale or deleted reservations don’t block reporting, reaping, or termination. Addresses ENG-1333.

- **Bug Fixes**
  - Assign enrolled runners (starting/running) to their reservation using EC2 identity; batched per reservation.
  - On assignment failure, log a warning and continue normal reporting and termination.
  - Tests added for successful assignment and rejection paths; added `logger.warn` and test helpers to record assignment calls.

<sup>Written for commit 5eeb5bb1835fc9b484f56509c80541f0afdd91e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

