### PR TITLE
[Provisioner Core] Render matrix variants into templates

### DIFF
--- a/libs/provisioner/core/src/index.ts
+++ b/libs/provisioner/core/src/index.ts
@@ -33,6 +33,9 @@ export {
   ProvisionerTemplateFileError,
   parseProvisionerTemplateFile,
   parseTemplateFile,
+  type RenderedTemplateMap,
+  renderTemplateVariants,
+  renderVariants,
   type Variant,
   type VariantBindings,
 } from '#template-file.js';

--- a/libs/provisioner/core/src/template-file.test.ts
+++ b/libs/provisioner/core/src/template-file.test.ts
@@ -1,10 +1,29 @@
-import {enumerateVariants, MAX_TEMPLATES, parseTemplateFile} from '#template-file.js';
+import {
+  enumerateVariants,
+  MAX_TEMPLATES,
+  parseTemplateFile,
+  renderTemplateVariants,
+} from '#template-file.js';
+
+const observability = vi.hoisted(() => {
+  const warningCalls: unknown[][] = [];
+  return {
+    logger: {warn: (...args: unknown[]) => warningCalls.push(args)},
+    warningCalls,
+  };
+});
+
+vi.mock('@shipfox/node-opentelemetry', () => ({logger: () => observability.logger}));
 
 const expression = (source: string) => `\${{ ${source} }}`;
 const MULTI_BLOCK_ERROR_PATTERN =
   /matrix\.standard\.axes\.cpu.*matrix\.standard\.include\.0.*matrix\.gpu\.include\.0/s;
 const INCOMPLETE_INCLUDE_PATTERN =
   /must bind every declared axis.*missing arch.*unknown axes: extra/s;
+const KEY_COLLISION_PATTERN = /key "4".*x64.*arm64.*differing axes: arch/s;
+const OBJECT_AXIS_NAME_PATTERN = /machine.*name field/;
+const RENDER_FAILURE_PATTERN =
+  /2 variants failed in matrix `standard`.*template\.ami.*ubuntu2404.*ubuntu2604/s;
 
 describe('parseTemplateFile', () => {
   it('preserves the existing hand-written file shape when matrix is absent', () => {
@@ -196,5 +215,151 @@ describe('enumerateVariants', () => {
     expect(() => enumerateVariants(file)).toThrow(
       `matrix expands to ${MAX_TEMPLATES + 1} templates (standard: ${MAX_TEMPLATES}, gpu: 1) plus 1 hand-written; the maximum is ${MAX_TEMPLATES}`,
     );
+  });
+});
+
+describe('renderTemplateVariants', () => {
+  beforeEach(() => {
+    observability.warningCalls.length = 0;
+  });
+
+  it('renders independent families with defaults, overrides, and declaration-order lets', () => {
+    const file = parseTemplateFile({
+      vars: {image: 'runner:latest'},
+      defaults: {
+        image: expression('vars.image'),
+        labels: ['default'],
+        nested: {from_defaults: true, shared: 'default'},
+      },
+      templates: {
+        one_off: {labels: ['one-off'], nested: {from_defaults: false}},
+      },
+      matrix: {
+        standard: {
+          axes: {arch: ['arm64'], cpu: [6], os: ['ubuntu2404']},
+          let: {memory: expression('cpu * 4.0')},
+          template: {
+            cpu: expression('cpu'),
+            memory: expression('memory'),
+            labels: ['standard'],
+            nested: {shared: 'standard'},
+          },
+        },
+        gpu: {
+          axes: {model: [{name: 'a10'}], size: ['small']},
+          template: {model: expression('model.name')},
+        },
+      },
+    });
+
+    const templates = renderTemplateVariants(file);
+
+    expect(templates).toEqual({
+      one_off: {
+        image: 'runner:latest',
+        labels: ['one-off'],
+        nested: {from_defaults: false, shared: 'default'},
+      },
+      'standard-arm64-6-ubuntu2404': {
+        image: 'runner:latest',
+        labels: ['standard'],
+        nested: {from_defaults: true, shared: 'standard'},
+        cpu: 6,
+        memory: 24,
+      },
+      'gpu-a10-small': {
+        image: 'runner:latest',
+        labels: ['default'],
+        nested: {from_defaults: true, shared: 'default'},
+        model: 'a10',
+      },
+    });
+  });
+
+  it('widens generated keys when an axis is added', () => {
+    const withoutOs = parseTemplateFile({
+      templates: {},
+      matrix: {standard: {axes: {arch: ['x64'], cpu: [4]}, template: {}}},
+    });
+    const withOs = parseTemplateFile({
+      templates: {},
+      matrix: {
+        standard: {axes: {arch: ['x64'], cpu: [4], os: ['ubuntu2404']}, template: {}},
+      },
+    });
+
+    expect(Object.keys(renderTemplateVariants(withoutOs))).toEqual(['standard-x64-4']);
+    expect(Object.keys(renderTemplateVariants(withOs))).toEqual(['standard-x64-4-ubuntu2404']);
+  });
+
+  it('rejects collisions from an explicit key override and names differing axes', () => {
+    const file = parseTemplateFile({
+      templates: {},
+      matrix: {
+        standard: {
+          axes: {arch: ['x64', 'arm64'], cpu: [4]},
+          key: expression('string(cpu)'),
+          template: {},
+        },
+      },
+    });
+
+    expect(() => renderTemplateVariants(file)).toThrow(KEY_COLLISION_PATTERN);
+  });
+
+  it('requires names for object-valued axes only when deriving the default key', () => {
+    const withoutName = parseTemplateFile({
+      templates: {},
+      matrix: {standard: {axes: {machine: [{id: 'a'}]}, template: {}}},
+    });
+    expect(() => renderTemplateVariants(withoutName)).toThrow(OBJECT_AXIS_NAME_PATTERN);
+
+    const explicitKey = parseTemplateFile({
+      templates: {},
+      matrix: {
+        standard: {
+          axes: {machine: [{id: 'a'}]},
+          key: expression("'custom-machine'"),
+          template: {machine: expression('machine.id')},
+        },
+      },
+    });
+    expect(renderTemplateVariants(explicitKey)).toEqual({
+      'custom-machine': {machine: 'a'},
+    });
+  });
+
+  it('lets hand-written templates shadow generated twins and warns', () => {
+    const file = parseTemplateFile({
+      templates: {'standard-x64-4': {cpu: 99}},
+      matrix: {
+        standard: {axes: {arch: ['x64'], cpu: [4]}, template: {cpu: expression('cpu')}},
+      },
+    });
+
+    expect(renderTemplateVariants(file)).toEqual({'standard-x64-4': {cpu: 99}});
+    expect(observability.warningCalls).toHaveLength(1);
+    expect(observability.warningCalls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        event: 'provisioner.template_generated_shadowed',
+        templateKey: 'standard-x64-4',
+      }),
+    );
+    expect(observability.warningCalls[0]?.[1]).toEqual(expect.stringContaining('shadowed'));
+  });
+
+  it('aggregates rendering failures across variants in one block', () => {
+    const file = parseTemplateFile({
+      vars: {ami_by_os: {ubuntu2204: 'ami-2204'}},
+      templates: {},
+      matrix: {
+        standard: {
+          axes: {os: ['ubuntu2204', 'ubuntu2404', 'ubuntu2604']},
+          template: {ami: expression('vars.ami_by_os[os]')},
+        },
+      },
+    });
+
+    expect(() => renderTemplateVariants(file)).toThrow(RENDER_FAILURE_PATTERN);
   });
 });

--- a/libs/provisioner/core/src/template-file.test.ts
+++ b/libs/provisioner/core/src/template-file.test.ts
@@ -292,6 +292,25 @@ describe('renderTemplateVariants', () => {
     expect(Object.keys(renderTemplateVariants(withOs))).toEqual(['standard-x64-4-ubuntu2404']);
   });
 
+  it('keeps default keys distinct when axis values contain the separator', () => {
+    const file = parseTemplateFile({
+      templates: {},
+      matrix: {
+        standard: {
+          axes: {left: ['a-b', 'a'], right: ['c', 'b-c']},
+          template: {},
+        },
+      },
+    });
+
+    expect(Object.keys(renderTemplateVariants(file))).toEqual([
+      'standard-a%2Db-c',
+      'standard-a%2Db-b%2Dc',
+      'standard-a-c',
+      'standard-a-b%2Dc',
+    ]);
+  });
+
   it('rejects collisions from an explicit key override and names differing axes', () => {
     const file = parseTemplateFile({
       templates: {},
@@ -326,6 +345,26 @@ describe('renderTemplateVariants', () => {
     });
     expect(renderTemplateVariants(explicitKey)).toEqual({
       'custom-machine': {machine: 'a'},
+    });
+  });
+
+  it('preserves opaque arrays that resemble workflow template segments', () => {
+    const opaqueSegments = [
+      {kind: 'literal', text: 'keep me'},
+      {kind: 'expr', expression: {source: 'cpu'}},
+    ];
+    const file = parseTemplateFile({
+      templates: {},
+      matrix: {
+        standard: {
+          axes: {cpu: [4]},
+          template: {provider_spec: opaqueSegments},
+        },
+      },
+    });
+
+    expect(renderTemplateVariants(file)).toEqual({
+      'standard-4': {provider_spec: opaqueSegments},
     });
   });
 

--- a/libs/provisioner/core/src/template-file.ts
+++ b/libs/provisioner/core/src/template-file.ts
@@ -13,6 +13,10 @@ import {logger} from '@shipfox/node-opentelemetry';
 /** The maximum number of hand-written and expanded templates in one file. */
 export const MAX_TEMPLATES = 1_000;
 
+// Provider data can have the same shape as parsed expression segments, so the
+// parser marks its arrays.
+const WORKFLOW_TEMPLATE_SEGMENTS = Symbol('workflowTemplateSegments');
+
 export type VariantBindings = Readonly<Record<string, unknown>>;
 
 export interface ParsedTemplateList extends ReadonlyArray<ParsedTemplateValue> {}
@@ -21,6 +25,10 @@ export interface ParsedTemplateObject {
   readonly [key: string]: ParsedTemplateValue;
 }
 
+type ParsedWorkflowTemplateSegments = readonly WorkflowTemplateSegment[] & {
+  readonly [WORKFLOW_TEMPLATE_SEGMENTS]: true;
+};
+
 export type ParsedTemplateValue =
   | string
   | number
@@ -28,6 +36,7 @@ export type ParsedTemplateValue =
   | null
   | undefined
   | readonly WorkflowTemplateSegment[]
+  | ParsedWorkflowTemplateSegments
   | ParsedTemplateList
   | ParsedTemplateObject;
 
@@ -515,13 +524,17 @@ function deriveTemplateKey(
       parts.push(coerceKeyPart(value));
     }
   }
-  return parts.join('-');
+  return parts.map(encodeTemplateKeyPart).join('-');
 }
 
 function coerceKeyPart(value: unknown): string {
   if (value === null) return 'null';
   if (value === undefined) return 'undefined';
   return coerceTemplateValue(value);
+}
+
+function encodeTemplateKeyPart(value: string): string {
+  return value.replaceAll('%', '%25').replaceAll('-', '%2D');
 }
 
 function mergeTemplateObjects(
@@ -566,18 +579,11 @@ function createEvaluationContext(
 
 function isWorkflowTemplateSegments(
   value: ParsedTemplateValue,
-): value is readonly WorkflowTemplateSegment[] {
+): value is ParsedWorkflowTemplateSegments {
   return (
     Array.isArray(value) &&
-    value.length > 0 &&
-    value.every(
-      (segment) =>
-        isRecord(segment) &&
-        (segment.kind === 'literal' || segment.kind === 'expr') &&
-        (segment.kind === 'literal'
-          ? typeof segment.text === 'string'
-          : isRecord(segment.expression)),
-    )
+    Object.hasOwn(value, WORKFLOW_TEMPLATE_SEGMENTS) &&
+    (value as unknown as ParsedWorkflowTemplateSegments)[WORKFLOW_TEMPLATE_SEGMENTS]
   );
 }
 
@@ -911,7 +917,7 @@ function parseTemplateObject(
 function parseTemplateValue(value: unknown, path: string, errors: string[]): ParsedTemplateValue {
   if (typeof value === 'string' && value.includes('${{')) {
     try {
-      return parseWorkflowTemplate(value);
+      return markWorkflowTemplateSegments(parseWorkflowTemplate(value));
     } catch (error) {
       errors.push(`${path} is invalid: ${expressionErrorMessage(error)}`);
       return value;
@@ -924,6 +930,14 @@ function parseTemplateValue(value: unknown, path: string, errors: string[]): Par
     return parseTemplateObject(value, path, errors);
   }
   return value as ParsedTemplateValue;
+}
+
+function markWorkflowTemplateSegments(
+  segments: readonly WorkflowTemplateSegment[],
+): ParsedWorkflowTemplateSegments {
+  const marked = [...segments] as unknown as ParsedWorkflowTemplateSegments;
+  Object.defineProperty(marked, WORKFLOW_TEMPLATE_SEGMENTS, {value: true});
+  return marked;
 }
 
 function matchesPartial(bindings: VariantBindings, partial: VariantBindings): boolean {

--- a/libs/provisioner/core/src/template-file.ts
+++ b/libs/provisioner/core/src/template-file.ts
@@ -8,6 +8,7 @@ import {
   type WorkflowExpression,
   type WorkflowTemplateSegment,
 } from '@shipfox/expression';
+import {logger} from '@shipfox/node-opentelemetry';
 
 /** The maximum number of hand-written and expanded templates in one file. */
 export const MAX_TEMPLATES = 1_000;
@@ -146,6 +147,466 @@ export function enumerateVariants(file: ProvisionerTemplateFile): Variant[] {
 
 export const parseProvisionerTemplateFile = parseTemplateFile;
 export const enumerateTemplateVariants = enumerateVariants;
+
+export type RenderedTemplateMap = Readonly<Record<string, unknown>>;
+
+/**
+ * Render all matrix variants and hand-written templates into one provider-neutral map.
+ *
+ * Defaults are merged before any expression is evaluated. Exact single-expression
+ * leaves retain their CEL value type; mixed leaves are rendered as strings.
+ */
+export function renderTemplateVariants(file: ProvisionerTemplateFile): RenderedTemplateMap {
+  const variants = enumerateVariants(file);
+  const failures = new RenderFailureCollector();
+  const renderedHandWritten = renderHandWrittenTemplates(file, failures);
+  const renderedGenerated: RenderedVariant[] = [];
+
+  for (const variant of variants) {
+    const block = file.matrix?.[variant.block];
+    if (block === undefined) {
+      failures.record(variant.block, variant.bindings, 'block', 'Matrix block is missing.');
+      continue;
+    }
+
+    const evaluation = evaluateVariant(variant, block, file.vars ?? {}, failures);
+    if (evaluation === undefined) continue;
+
+    const mergedTemplate = mergeTemplateObjects(file.defaults, block.template);
+    const rendered = renderTemplateObject(
+      mergedTemplate,
+      evaluation.context,
+      evaluation.environment,
+      variant.block,
+      evaluation.displayBindings,
+      failures,
+    );
+    if (rendered.failed) continue;
+
+    renderedGenerated.push({
+      block: variant.block,
+      bindings: variant.bindings,
+      displayBindings: evaluation.displayBindings,
+      key: evaluation.key,
+      template: rendered.value,
+    });
+  }
+
+  if (failures.hasFailures()) throw failures.toError();
+
+  const generatedByKey = new Map<string, RenderedVariant>();
+  const collisions: string[] = [];
+  for (const generated of renderedGenerated) {
+    const previous = generatedByKey.get(generated.key);
+    if (previous !== undefined) {
+      collisions.push(formatCollision(generated.key, previous, generated));
+      continue;
+    }
+    generatedByKey.set(generated.key, generated);
+  }
+
+  if (collisions.length > 0) {
+    throw new ProvisionerTemplateFileError(`Template key collisions: ${collisions.join('; ')}`);
+  }
+
+  const templates: Record<string, unknown> = Object.fromEntries(renderedHandWritten.templates);
+  for (const generated of renderedGenerated) {
+    if (Object.hasOwn(file.templates, generated.key)) {
+      logger().warn(
+        {
+          event: 'provisioner.template_generated_shadowed',
+          templateKey: generated.key,
+          block: generated.block,
+          bindings: generated.displayBindings,
+        },
+        `Generated template "${generated.key}" from matrix "${generated.block}" is shadowed by a hand-written template`,
+      );
+      continue;
+    }
+    Object.defineProperty(templates, generated.key, {
+      configurable: true,
+      enumerable: true,
+      value: generated.template,
+      writable: true,
+    });
+  }
+
+  return templates;
+}
+
+export const renderVariants = renderTemplateVariants;
+
+interface RenderedVariant {
+  readonly block: string;
+  readonly bindings: VariantBindings;
+  readonly displayBindings: VariantBindings;
+  readonly key: string;
+  readonly template: unknown;
+}
+
+interface VariantEvaluation {
+  readonly context: Readonly<Record<string, unknown>>;
+  readonly displayBindings: VariantBindings;
+  readonly environment: ReturnType<typeof createRangeEnvironment>;
+  readonly key: string;
+}
+
+interface RenderedHandWrittenTemplates {
+  readonly templates: readonly (readonly [string, unknown])[];
+}
+
+interface RenderedValue {
+  readonly failed: boolean;
+  readonly value: unknown;
+}
+
+interface RenderFailure {
+  readonly bindings: VariantBindings;
+  readonly message: string;
+  readonly path: string;
+}
+
+const MAX_FAILURE_SAMPLES = 5;
+
+class RenderFailureCollector {
+  private readonly failures = new Map<
+    string,
+    {count: number; samples: RenderFailure[]; variantKeys: Set<string>}
+  >();
+
+  record(block: string, bindings: VariantBindings, path: string, message: string): void {
+    const entry = this.failures.get(block) ?? {count: 0, samples: [], variantKeys: new Set()};
+    const variantKey = formatBindings(bindings);
+    if (!entry.variantKeys.has(variantKey)) {
+      entry.variantKeys.add(variantKey);
+      entry.count += 1;
+    }
+    if (entry.samples.length < MAX_FAILURE_SAMPLES) {
+      entry.samples.push({bindings, path, message});
+    }
+    this.failures.set(block, entry);
+  }
+
+  hasFailures(): boolean {
+    return this.failures.size > 0;
+  }
+
+  toError(): ProvisionerTemplateFileError {
+    const messages = [...this.failures.entries()].map(([block, entry]) => {
+      const samples = entry.samples
+        .map(
+          (failure) =>
+            `${failure.path} for bindings ${formatBindings(failure.bindings)}: ${failure.message}`,
+        )
+        .join('; ');
+      const omitted =
+        entry.count > entry.samples.length ? `; ${entry.count - entry.samples.length} more` : '';
+      return `${entry.count} variants failed in matrix \`${block}\`: ${samples}${omitted}`;
+    });
+    return new ProvisionerTemplateFileError(`Template rendering failed: ${messages.join('; ')}`);
+  }
+}
+
+function renderHandWrittenTemplates(
+  file: ProvisionerTemplateFile,
+  failures: RenderFailureCollector,
+): RenderedHandWrittenTemplates {
+  const templates: (readonly [string, unknown])[] = [];
+  for (const [key, rawTemplate] of Object.entries(file.templates)) {
+    const parseErrors: string[] = [];
+    const parsedTemplate = parseTemplateValue(rawTemplate, `templates.${key}`, parseErrors);
+    if (parseErrors.length > 0) {
+      failures.record('templates', {template: key}, `templates.${key}`, parseErrors.join('; '));
+      continue;
+    }
+
+    const mergedTemplate = mergeTemplateObjects(file.defaults, parsedTemplate);
+    const environment = createRangeEnvironment();
+    const context = createEvaluationContext(file.vars ?? {}, {}, {});
+    const rendered = renderTemplateObject(
+      mergedTemplate,
+      context,
+      environment,
+      'templates',
+      {template: key},
+      failures,
+    );
+    if (!rendered.failed) templates.push([key, rendered.value]);
+  }
+  return {templates};
+}
+
+function evaluateVariant(
+  variant: Variant,
+  block: MatrixBlock,
+  vars: Readonly<Record<string, unknown>>,
+  failures: RenderFailureCollector,
+): VariantEvaluation | undefined {
+  const environment = createRangeEnvironment();
+  const letBindings = createMap<unknown>();
+  let hasFailure = false;
+
+  for (const [name, expression] of Object.entries(block.let)) {
+    const context = createEvaluationContext(vars, variant.bindings, letBindings);
+    try {
+      letBindings[name] = evaluateWorkflowExpressionWithEnvironment(
+        expression,
+        context,
+        environment,
+      );
+    } catch (error) {
+      hasFailure = true;
+      failures.record(
+        variant.block,
+        {...variant.bindings, ...letBindings},
+        `let.${name}`,
+        errorMessage(error),
+      );
+    }
+  }
+
+  const displayBindings = {...variant.bindings, ...letBindings};
+  const context = createEvaluationContext(vars, variant.bindings, letBindings);
+  let key: string;
+  if (block.key !== undefined) {
+    try {
+      key = coerceTemplateValue(
+        evaluateWorkflowExpressionWithEnvironment(block.key, context, environment),
+      );
+    } catch (error) {
+      hasFailure = true;
+      failures.record(variant.block, displayBindings, 'key', errorMessage(error));
+      key = '';
+    }
+  } else {
+    try {
+      key = deriveTemplateKey(variant.block, block.axes, variant.bindings);
+    } catch (error) {
+      hasFailure = true;
+      failures.record(variant.block, displayBindings, 'key', errorMessage(error));
+      key = '';
+    }
+  }
+
+  return hasFailure ? undefined : {context, displayBindings, environment, key};
+}
+
+function renderTemplateObject(
+  template: ParsedTemplateValue,
+  context: Readonly<Record<string, unknown>>,
+  environment: ReturnType<typeof createRangeEnvironment>,
+  block: string,
+  bindings: VariantBindings,
+  failures: RenderFailureCollector,
+): RenderedValue {
+  return renderTemplateValue(template, context, environment, 'template', block, bindings, failures);
+}
+
+function renderTemplateValue(
+  value: ParsedTemplateValue,
+  context: Readonly<Record<string, unknown>>,
+  environment: ReturnType<typeof createRangeEnvironment>,
+  path: string,
+  block: string,
+  bindings: VariantBindings,
+  failures: RenderFailureCollector,
+): RenderedValue {
+  if (isWorkflowTemplateSegments(value)) {
+    return renderTemplateSegments(value, context, environment, path, block, bindings, failures);
+  }
+  if (Array.isArray(value)) {
+    let failed = false;
+    const rendered = value.map((child, index) => {
+      const result = renderTemplateValue(
+        child,
+        context,
+        environment,
+        `${path}.${index}`,
+        block,
+        bindings,
+        failures,
+      );
+      failed ||= result.failed;
+      return result.value;
+    });
+    return {failed, value: rendered};
+  }
+  if (isRecord(value)) {
+    let failed = false;
+    const rendered = Object.fromEntries(
+      Object.entries(value).map(([key, child]) => {
+        const result = renderTemplateValue(
+          child as ParsedTemplateValue,
+          context,
+          environment,
+          `${path}.${key}`,
+          block,
+          bindings,
+          failures,
+        );
+        failed ||= result.failed;
+        return [key, result.value];
+      }),
+    );
+    return {failed, value: rendered};
+  }
+  return {failed: false, value};
+}
+
+function renderTemplateSegments(
+  segments: readonly WorkflowTemplateSegment[],
+  context: Readonly<Record<string, unknown>>,
+  environment: ReturnType<typeof createRangeEnvironment>,
+  path: string,
+  block: string,
+  bindings: VariantBindings,
+  failures: RenderFailureCollector,
+): RenderedValue {
+  const exactExpression = segments.length === 1 && segments[0]?.kind === 'expr';
+  if (exactExpression) {
+    const segment = segments[0];
+    if (segment?.kind !== 'expr') return {failed: false, value: ''};
+    try {
+      return {
+        failed: false,
+        value: evaluateWorkflowExpressionWithEnvironment(segment.expression, context, environment),
+      };
+    } catch (error) {
+      failures.record(block, bindings, path, errorMessage(error));
+      return {failed: true, value: undefined};
+    }
+  }
+
+  let failed = false;
+  let rendered = '';
+  for (const segment of segments) {
+    if (segment.kind === 'literal') {
+      rendered += segment.text;
+      continue;
+    }
+    try {
+      rendered += coerceTemplateValue(
+        evaluateWorkflowExpressionWithEnvironment(segment.expression, context, environment),
+      );
+    } catch (error) {
+      failed = true;
+      failures.record(block, bindings, path, errorMessage(error));
+    }
+  }
+  return {failed, value: rendered};
+}
+
+function deriveTemplateKey(
+  blockName: string,
+  axes: Readonly<Record<string, MatrixAxis>>,
+  bindings: VariantBindings,
+): string {
+  const parts = [blockName];
+  for (const axisName of Object.keys(axes)) {
+    const value = bindings[axisName];
+    if (isRecord(value) || Array.isArray(value)) {
+      if (!isRecord(value) || !Object.hasOwn(value, 'name')) {
+        throw new Error(
+          `axis "${axisName}" object must have a name field for default key derivation`,
+        );
+      }
+      parts.push(coerceKeyPart(value.name));
+    } else {
+      parts.push(coerceKeyPart(value));
+    }
+  }
+  return parts.join('-');
+}
+
+function coerceKeyPart(value: unknown): string {
+  if (value === null) return 'null';
+  if (value === undefined) return 'undefined';
+  return coerceTemplateValue(value);
+}
+
+function mergeTemplateObjects(
+  defaults: Readonly<Record<string, ParsedTemplateValue>> | undefined,
+  template: ParsedTemplateValue,
+): ParsedTemplateValue {
+  if (defaults === undefined) return template;
+  return deepMergeTemplateValues(defaults as ParsedTemplateValue, template);
+}
+
+function deepMergeTemplateValues(
+  left: ParsedTemplateValue,
+  right: ParsedTemplateValue,
+): ParsedTemplateValue {
+  if (!isRecord(left) || !isRecord(right)) return right;
+  return Object.fromEntries(
+    [...new Set([...Object.keys(left), ...Object.keys(right)])].map((key) => {
+      if (!Object.hasOwn(right, key)) return [key, left[key]];
+      if (!Object.hasOwn(left, key)) return [key, right[key]];
+      return [
+        key,
+        deepMergeTemplateValues(
+          left[key] as ParsedTemplateValue,
+          right[key] as ParsedTemplateValue,
+        ),
+      ];
+    }),
+  );
+}
+
+function createEvaluationContext(
+  vars: Readonly<Record<string, unknown>>,
+  bindings: VariantBindings,
+  letBindings: Readonly<Record<string, unknown>>,
+): Readonly<Record<string, unknown>> {
+  const context = createMap<unknown>();
+  context.vars = vars;
+  for (const [name, value] of Object.entries(bindings)) context[name] = value;
+  for (const [name, value] of Object.entries(letBindings)) context[name] = value;
+  return context;
+}
+
+function isWorkflowTemplateSegments(
+  value: ParsedTemplateValue,
+): value is readonly WorkflowTemplateSegment[] {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every(
+      (segment) =>
+        isRecord(segment) &&
+        (segment.kind === 'literal' || segment.kind === 'expr') &&
+        (segment.kind === 'literal'
+          ? typeof segment.text === 'string'
+          : isRecord(segment.expression)),
+    )
+  );
+}
+
+function coerceTemplateValue(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'bigint') {
+    return String(value);
+  }
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (value instanceof Date) return value.toISOString();
+  const serialized = JSON.stringify(value, (_key, nestedValue) => {
+    if (typeof nestedValue !== 'bigint') return nestedValue;
+    const numberValue = Number(nestedValue);
+    return Number.isSafeInteger(numberValue) ? numberValue : nestedValue.toString();
+  });
+  return serialized ?? '';
+}
+
+function formatCollision(key: string, previous: RenderedVariant, current: RenderedVariant): string {
+  const axisNames = new Set([...Object.keys(previous.bindings), ...Object.keys(current.bindings)]);
+  const differingAxes = [...axisNames].filter(
+    (axisName) => !valuesEqual(previous.bindings[axisName], current.bindings[axisName]),
+  );
+  return `key "${key}" is used by matrix "${previous.block}" with bindings ${formatBindings(previous.displayBindings)} and matrix "${current.block}" with bindings ${formatBindings(current.displayBindings)}; differing axes: ${differingAxes.join(', ') || 'none'}`;
+}
+
+function formatBindings(bindings: VariantBindings): string {
+  return coerceTemplateValue(bindings);
+}
 
 interface PreparedBlock {
   readonly name: string;


### PR DESCRIPTION
Render enumerated provisioner matrix variants into provider-neutral template objects so the existing provider Zod schemas can validate one complete rendered object.

The renderer evaluates scoped `let` bindings and typed expressions, deep-merges file defaults before rendering, derives collision-resistant keys from every declared axis, and handles generated-key collisions, hand-written shadowing, and aggregated diagnostics at load time.

Closes ENG-1323

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render all matrix variants into a single provider‑neutral template map ready for provider Zod schema validation. Implements ENG‑1323 with defaults merge, scoped lets, typed rendering, hardened key derivation, shadow warnings, and aggregated errors.

- **New Features**
  - Added `renderTemplateVariants`/`renderVariants` returning a `RenderedTemplateMap` that combines generated and hand‑written templates.
  - Deep‑merge `defaults` into each template before evaluation (maps merge; lists/scalars replace).
  - Evaluate block‑scoped `let` in declaration order; expressions see axes and `vars`.
  - Preserve types for single‑expression leaves; mixed segments stringified; tagged workflow segment arrays are preserved as arrays.
  - Keys: derive from block + all axes by default (object axes require `name`); key parts escape `-`/`%` to keep defaults unique; explicit `key` supported.
  - Detect collisions across blocks/variants and report differing axes; hand‑written templates shadow generated ones with a warning via `@shipfox/node-opentelemetry`.
  - Aggregate rendering failures per block with capped samples and a single error message.

<sup>Written for commit c81cf95cacd27cbc427252b9be8eb80abaaef02f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

