### PR TITLE
[Provisioner EC2] Adopt matrix template expansion

### DIFF
--- a/libs/provisioner/ec2/src/templates.test.ts
+++ b/libs/provisioner/ec2/src/templates.test.ts
@@ -21,6 +21,8 @@ function writeTemplates(contents: string): string {
   return path;
 }
 
+const expression = (source: string) => `\${{ ${source} }}`;
+
 function template(overrides: Record<string, string> = {}, extra = ''): string {
   const defaults = `
 templates:
@@ -233,5 +235,107 @@ describe('loadEc2Templates', () => {
     const path = writeTemplates(`${VALID}\nunknown: true`);
 
     expect(() => loadEc2Templates(path)).toThrow('unknown');
+  });
+
+  it('expands a matrix and resolves EC2 fields through operator-supplied lookup maps', () => {
+    const path = writeTemplates(`
+vars:
+  ami_by_arch_os:
+    arm64:
+      ubuntu2204: ami-0aaa
+      ubuntu2404: ami-0aab
+    x64:
+      ubuntu2204: ami-0baa
+      ubuntu2404: ami-0bab
+  cpu_family_by:
+    arm64:
+      4: m7g
+    x64:
+      4: m7i
+  size_by_cpu:
+    4: xlarge
+templates: {}
+matrix:
+  standard:
+    axes:
+      arch: [arm64, x64]
+      cpu: [4]
+      ratio: [4]
+      os: [ubuntu2204, ubuntu2404]
+    template:
+      labels: ["ec2-${expression('arch')}-${expression('cpu')}-${expression('ratio')}-${expression('os')}"]
+      ami: "${expression('vars.ami_by_arch_os[arch][os]')}"
+      instance_type: "${expression('vars.cpu_family_by[arch][ratio]')}.${expression('vars.size_by_cpu[cpu]')}"
+      market: spot
+      spot_max_price: 0.05
+      subnets: [subnet-aaa]
+      security_groups: [sg-runner]
+      associate_public_ip: false
+      root_volume_gb: 100
+      max_concurrency: 100
+      cost: 5
+`);
+
+    const templates = loadEc2Templates(path);
+
+    expect(templates).toHaveLength(4);
+    expect(templates.map(({key}) => key)).toEqual([
+      'standard-arm64-4-4-ubuntu2204',
+      'standard-arm64-4-4-ubuntu2404',
+      'standard-x64-4-4-ubuntu2204',
+      'standard-x64-4-4-ubuntu2404',
+    ]);
+    expect(templates.map(({spec}) => ({ami: spec.ami, instanceType: spec.instanceType}))).toEqual([
+      {ami: 'ami-0aaa', instanceType: 'm7g.xlarge'},
+      {ami: 'ami-0aab', instanceType: 'm7g.xlarge'},
+      {ami: 'ami-0baa', instanceType: 'm7i.xlarge'},
+      {ami: 'ami-0bab', instanceType: 'm7i.xlarge'},
+    ]);
+  });
+
+  it('aggregates missing lookup keys with matrix bindings and field paths', () => {
+    const path = writeTemplates(`
+vars:
+  ami_by_arch_os:
+    arm64:
+      ubuntu2204: ami-0aaa
+    x64:
+      ubuntu2204: ami-0baa
+templates: {}
+matrix:
+  standard:
+    axes:
+      arch: [arm64, x64]
+      os: [ubuntu2204, ubuntu2404]
+    template:
+      labels: ["ec2-${expression('arch')}-${expression('os')}"]
+      ami: "${expression('vars.ami_by_arch_os[arch][os]')}"
+      instance_type: m7g.xlarge
+      market: spot
+      spot_max_price: 0.05
+      subnets: [subnet-aaa]
+      security_groups: [sg-runner]
+      associate_public_ip: false
+      root_volume_gb: 100
+      max_concurrency: 100
+      cost: 5
+`);
+
+    let error: unknown;
+    try {
+      loadEc2Templates(path);
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(Ec2TemplateConfigError);
+    expect(error).toHaveProperty(
+      'message',
+      expect.stringContaining('2 variants failed in matrix `standard`'),
+    );
+    expect(error).toHaveProperty('message', expect.stringContaining('template.ami'));
+    expect(error).toHaveProperty('message', expect.stringContaining('"arch":"arm64"'));
+    expect(error).toHaveProperty('message', expect.stringContaining('"arch":"x64"'));
+    expect(error).toHaveProperty('message', expect.stringContaining('"os":"ubuntu2404"'));
   });
 });

--- a/libs/provisioner/ec2/src/templates.ts
+++ b/libs/provisioner/ec2/src/templates.ts
@@ -1,5 +1,10 @@
 import {readFileSync} from 'node:fs';
-import type {ProvisionerTemplate} from '@shipfox/provisioner-core';
+import {
+  type ProvisionerTemplate,
+  ProvisionerTemplateFileError,
+  parseTemplateFile,
+  renderTemplateVariants,
+} from '@shipfox/provisioner-core';
 import {canonicalizeLabels, findInvalidLabels, MAX_RUNNER_LABELS} from '@shipfox/runner-labels';
 import yaml from 'js-yaml';
 import {z} from 'zod';
@@ -61,11 +66,7 @@ const ec2TemplateSchema = z
     }
   });
 
-const ec2TemplatesFileSchema = z
-  .object({
-    templates: z.record(z.string().min(1), ec2TemplateSchema),
-  })
-  .strict();
+const ec2TemplatesSchema = z.record(z.string().min(1), ec2TemplateSchema);
 
 /**
  * Read, parse, and validate the local EC2 template config, returning the
@@ -74,14 +75,14 @@ const ec2TemplatesFileSchema = z
  * not validate, an invalid label, or an empty template set.
  */
 export function loadEc2Templates(filePath: string): ProvisionerTemplate<Ec2TemplateSpec>[] {
-  const parsed = ec2TemplatesFileSchema.safeParse(parseYamlFile(filePath));
+  const parsed = ec2TemplatesSchema.safeParse(renderTemplates(filePath, parseYamlFile(filePath)));
   if (!parsed.success) {
     throw new Ec2TemplateConfigError(
       `Invalid EC2 template config at ${filePath}: ${formatIssues(parsed.error)}`,
     );
   }
 
-  const entries = Object.entries(parsed.data.templates);
+  const entries = Object.entries(parsed.data);
   if (entries.length === 0) {
     throw new Ec2TemplateConfigError(
       `EC2 template config at ${filePath} declares no templates; add at least one.`,
@@ -89,6 +90,19 @@ export function loadEc2Templates(filePath: string): ProvisionerTemplate<Ec2Templ
   }
 
   return entries.map(([key, spec]) => toTemplate(filePath, key, spec));
+}
+
+function renderTemplates(filePath: string, raw: unknown): unknown {
+  try {
+    return renderTemplateVariants(parseTemplateFile(raw));
+  } catch (error) {
+    if (error instanceof ProvisionerTemplateFileError) {
+      throw new Ec2TemplateConfigError(
+        `Invalid EC2 template config at ${filePath}: ${error.message}`,
+      );
+    }
+    throw error;
+  }
 }
 
 function toTemplate(


### PR DESCRIPTION
Adopt the shared provider-neutral matrix parser and renderer in the EC2 template loader.

Legacy hand-written templates continue through the existing strict EC2 schema and mapping, while matrix variants can resolve provider-specific AMIs and instance types from operator-supplied lookup maps. Core expansion diagnostics remain file-scoped as Ec2TemplateConfigError.

Closes ENG-1325

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopts provider‑neutral matrix expansion in the EC2 template loader. Legacy templates keep working; matrix variants now resolve `ami` and `instance_type` via operator-supplied lookup maps.

- **New Features**
  - Use `parseTemplateFile` and `renderTemplateVariants` from `@shipfox/provisioner-core`, then validate with the existing strict `ec2TemplateSchema` (including `spot_max_price`).
  - Aggregate matrix failures across variants; surface as `Ec2TemplateConfigError` with field paths and bindings.
  - Tests cover matrix expansion, lookups, and error aggregation.
  - Aligns with ENG-1325 by sharing the same matrix logic used by Docker.

<sup>Written for commit fb25eaedbe0ef9418d5d8005b67b10361f892839. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

