### PR TITLE
[provisioner-docker-provider] Adopt matrix expansion in Docker template loading

### DIFF
--- a/libs/provisioner/docker/src/templates.test.ts
+++ b/libs/provisioner/docker/src/templates.test.ts
@@ -8,6 +8,8 @@ const mocks = vi.hoisted(() => ({debug: vi.fn(), info: vi.fn(), warn: vi.fn()}))
 vi.mock('@shipfox/node-opentelemetry', () => ({logger: () => mocks}));
 
 const SHADOWED_TEMPLATE_CPU_PATTERN = /templates\.docker-2-ubuntu22\.cpu/;
+const COMBINED_TEMPLATE_CAP_PATTERN =
+  /matrix expands to 1000 templates.*plus 1 hand-written; the maximum is 1000/;
 
 let dir: string;
 
@@ -207,6 +209,59 @@ matrix:
 
     expect(() => loadDockerTemplates(path)).toThrow(SHADOWED_TEMPLATE_CPU_PATTERN);
     expect(mocks.warn).not.toHaveBeenCalled();
+  });
+
+  it('enforces the combined template cap before splitting generated and hand-written entries', () => {
+    const cpuValues = Array.from({length: 1_000}, (_, index) => index + 1).join(', ');
+    const path = writeTemplates(`
+templates:
+  hand-written:
+    labels: [hand-written]
+    image: hand-written
+    cpu: 1
+    memory: 1g
+    max_concurrency: 1
+matrix:
+  generated:
+    axes:
+      cpu: [${cpuValues}]
+    template:
+      labels: [generated]
+      image: generated
+      cpu: "\${{ cpu }}"
+      memory: 1g
+      max_concurrency: 1
+`);
+
+    expect(() => loadDockerTemplates(path)).toThrow(COMBINED_TEMPLATE_CAP_PATTERN);
+  });
+
+  it('preserves a generated template with an explicit __proto__ key', () => {
+    const path = writeTemplates(`
+templates: {}
+matrix:
+  generated:
+    axes:
+      cpu: [1]
+    key: "'__proto__'"
+    template:
+      labels: [generated]
+      image: generated
+      cpu: 1
+      memory: 1g
+      max_concurrency: 1
+`);
+
+    expect(loadDockerTemplates(path)).toEqual([
+      {
+        key: '__proto__',
+        labels: ['generated'],
+        maxConcurrency: 1,
+        targetConcurrency: 0,
+        cost: 1,
+        spec: {image: 'generated', cpu: 1, memory: '1g'},
+      },
+    ]);
   });
 
   it('wraps core matrix errors in DockerTemplateConfigError', () => {

--- a/libs/provisioner/docker/src/templates.test.ts
+++ b/libs/provisioner/docker/src/templates.test.ts
@@ -4,7 +4,7 @@ import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {DEFAULT_RUNNER_IMAGE, DockerTemplateConfigError, loadDockerTemplates} from '#templates.js';
 
-const mocks = vi.hoisted(() => ({debug: vi.fn()}));
+const mocks = vi.hoisted(() => ({debug: vi.fn(), info: vi.fn(), warn: vi.fn()}));
 vi.mock('@shipfox/node-opentelemetry', () => ({logger: () => mocks}));
 
 let dir: string;
@@ -12,6 +12,8 @@ let dir: string;
 beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), 'provisioner-docker-'));
   mocks.debug.mockReset();
+  mocks.info.mockReset();
+  mocks.warn.mockReset();
 });
 
 afterEach(() => {
@@ -65,6 +67,135 @@ describe('loadDockerTemplates', () => {
         spec: {image: 'shipfox-runner:ubuntu22', cpu: 4, memory: '8GiB'},
       },
     ]);
+    expect(mocks.info).toHaveBeenCalledWith(
+      {
+        event: 'provisioner.templates_loaded',
+        filePath: path,
+        templateCount: 2,
+        familyCount: 0,
+      },
+      'Loaded 2 Docker templates from 0 matrix families',
+    );
+  });
+
+  it('expands matrix families before validating Docker templates', () => {
+    const path = writeTemplates(`
+templates: {}
+matrix:
+  docker:
+    axes:
+      cpu: [2, 4]
+      os: [ubuntu22, ubuntu24]
+    template:
+      labels: [docker, "\${{ os }}"]
+      image: "shipfox-runner:\${{ os }}"
+      cpu: "\${{ cpu }}"
+      memory: "\${{ cpu * 2.0 }}GiB"
+      max_concurrency: "\${{ cpu * 10.0 }}"
+      cost: "\${{ cpu }}"
+`);
+
+    expect(loadDockerTemplates(path)).toEqual([
+      {
+        key: 'docker-2-ubuntu22',
+        labels: ['docker', 'ubuntu22'],
+        maxConcurrency: 20,
+        targetConcurrency: 0,
+        cost: 2,
+        spec: {image: 'shipfox-runner:ubuntu22', cpu: 2, memory: '4GiB'},
+      },
+      {
+        key: 'docker-2-ubuntu24',
+        labels: ['docker', 'ubuntu24'],
+        maxConcurrency: 20,
+        targetConcurrency: 0,
+        cost: 2,
+        spec: {image: 'shipfox-runner:ubuntu24', cpu: 2, memory: '4GiB'},
+      },
+      {
+        key: 'docker-4-ubuntu22',
+        labels: ['docker', 'ubuntu22'],
+        maxConcurrency: 40,
+        targetConcurrency: 0,
+        cost: 4,
+        spec: {image: 'shipfox-runner:ubuntu22', cpu: 4, memory: '8GiB'},
+      },
+      {
+        key: 'docker-4-ubuntu24',
+        labels: ['docker', 'ubuntu24'],
+        maxConcurrency: 40,
+        targetConcurrency: 0,
+        cost: 4,
+        spec: {image: 'shipfox-runner:ubuntu24', cpu: 4, memory: '8GiB'},
+      },
+    ]);
+    expect(mocks.info).toHaveBeenCalledWith(
+      {
+        event: 'provisioner.templates_loaded',
+        filePath: path,
+        templateCount: 4,
+        familyCount: 1,
+      },
+      'Loaded 4 Docker templates from 1 matrix families',
+    );
+  });
+
+  it('keeps a hand-written template when it shadows a generated key', () => {
+    const path = writeTemplates(`
+templates:
+  docker-2-ubuntu22:
+    labels: [hand-written]
+    image: hand-written
+    cpu: 99
+    memory: 2g
+    max_concurrency: 1
+matrix:
+  docker:
+    axes:
+      cpu: [2]
+      os: [ubuntu22]
+    template:
+      labels: [generated]
+      image: generated
+      cpu: 2
+      memory: 4g
+      max_concurrency: 2
+`);
+
+    expect(loadDockerTemplates(path)).toEqual([
+      {
+        key: 'docker-2-ubuntu22',
+        labels: ['hand-written'],
+        maxConcurrency: 1,
+        targetConcurrency: 0,
+        cost: 99,
+        spec: {image: 'hand-written', cpu: 99, memory: '2g'},
+      },
+    ]);
+    expect(mocks.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'provisioner.template_generated_shadowed',
+        templateKey: 'docker-2-ubuntu22',
+        block: 'docker',
+      }),
+      expect.stringContaining('shadowed'),
+    );
+  });
+
+  it('wraps core matrix errors in DockerTemplateConfigError', () => {
+    const path = writeTemplates(`
+templates: {}
+matrix:
+  docker:
+    axes:
+      cpu: []
+    template: {}
+`);
+
+    expect(() => loadDockerTemplates(path)).toThrow(DockerTemplateConfigError);
+    expect(() => loadDockerTemplates(path)).toThrow(
+      new RegExp(`Invalid Docker template config at ${path}: Invalid template file`),
+    );
   });
 
   it('defaults the image to the published Shipfox runner', () => {

--- a/libs/provisioner/docker/src/templates.test.ts
+++ b/libs/provisioner/docker/src/templates.test.ts
@@ -7,6 +7,8 @@ import {DEFAULT_RUNNER_IMAGE, DockerTemplateConfigError, loadDockerTemplates} fr
 const mocks = vi.hoisted(() => ({debug: vi.fn(), info: vi.fn(), warn: vi.fn()}));
 vi.mock('@shipfox/node-opentelemetry', () => ({logger: () => mocks}));
 
+const SHADOWED_TEMPLATE_CPU_PATTERN = /templates\.docker-2-ubuntu22\.cpu/;
+
 let dir: string;
 
 beforeEach(() => {
@@ -176,10 +178,35 @@ matrix:
       expect.objectContaining({
         event: 'provisioner.template_generated_shadowed',
         templateKey: 'docker-2-ubuntu22',
-        block: 'docker',
       }),
       expect.stringContaining('shadowed'),
     );
+  });
+
+  it('validates generated templates before a hand-written shadow can hide them', () => {
+    const path = writeTemplates(`
+templates:
+  docker-2-ubuntu22:
+    labels: [hand-written]
+    image: hand-written
+    cpu: 99
+    memory: 2g
+    max_concurrency: 1
+matrix:
+  docker:
+    axes:
+      cpu: [2]
+      os: [ubuntu22]
+    template:
+      labels: [generated]
+      image: generated
+      cpu: 0
+      memory: 4g
+      max_concurrency: 2
+`);
+
+    expect(() => loadDockerTemplates(path)).toThrow(SHADOWED_TEMPLATE_CPU_PATTERN);
+    expect(mocks.warn).not.toHaveBeenCalled();
   });
 
   it('wraps core matrix errors in DockerTemplateConfigError', () => {

--- a/libs/provisioner/docker/src/templates.test.ts
+++ b/libs/provisioner/docker/src/templates.test.ts
@@ -367,6 +367,20 @@ templates:
     );
   });
 
+  it('throws on an empty template key', () => {
+    const path = writeTemplates(`
+templates:
+  '':
+    labels: [ubuntu22]
+    image: img
+    cpu: 1
+    memory: 2g
+    max_concurrency: 1
+`);
+
+    expect(() => loadDockerTemplates(path)).toThrow('Invalid key in record');
+  });
+
   it('throws on an unknown file key', () => {
     const path = writeTemplates(`${VALID}\nunknown: true`);
 

--- a/libs/provisioner/docker/src/templates.ts
+++ b/libs/provisioner/docker/src/templates.ts
@@ -58,23 +58,38 @@ export function loadDockerTemplates(filePath: string): ProvisionerTemplate<Docke
   const raw = parseYamlFile(filePath);
   let templateFile: ProvisionerTemplateFile;
   let renderedTemplates: RenderedTemplateMap;
+  let validatedTemplates: Readonly<Record<string, z.infer<typeof dockerTemplateSchema>>>;
   try {
     templateFile = parseTemplateFile(raw);
-    renderedTemplates = renderTemplateVariants(templateFile);
+    const generatedTemplates = renderTemplateVariants({...templateFile, templates: {}});
+    const handWrittenTemplates = renderTemplateVariants({...templateFile, matrix: {}});
+    const validatedGeneratedTemplates = validateRenderedTemplates(filePath, generatedTemplates);
+    const validatedHandWrittenTemplates = validateRenderedTemplates(filePath, handWrittenTemplates);
+
+    for (const key of Object.keys(generatedTemplates)) {
+      if (!Object.hasOwn(handWrittenTemplates, key)) continue;
+      logger().warn(
+        {
+          event: 'provisioner.template_generated_shadowed',
+          templateKey: key,
+        },
+        `Generated template "${key}" is shadowed by a hand-written template`,
+      );
+    }
+
+    renderedTemplates = mergeTemplateMaps(handWrittenTemplates, generatedTemplates);
+    validatedTemplates = mergeTemplateMaps(
+      validatedHandWrittenTemplates,
+      validatedGeneratedTemplates,
+    );
   } catch (error) {
+    if (error instanceof DockerTemplateConfigError) throw error;
     throw new DockerTemplateConfigError(
       `Invalid Docker template config at ${filePath}: ${errorMessage(error)}`,
     );
   }
 
-  const parsed = dockerTemplatesFileSchema.safeParse({templates: renderedTemplates});
-  if (!parsed.success) {
-    throw new DockerTemplateConfigError(
-      `Invalid Docker template config at ${filePath}: ${formatIssues(parsed.error)}`,
-    );
-  }
-
-  const entries = Object.entries(parsed.data.templates);
+  const entries = Object.entries(validatedTemplates);
   if (entries.length === 0) {
     throw new DockerTemplateConfigError(
       `Docker template config at ${filePath} declares no templates; add at least one.`,
@@ -108,6 +123,30 @@ export function loadDockerTemplates(filePath: string): ProvisionerTemplate<Docke
   );
 
   return templates;
+}
+
+function validateRenderedTemplates(
+  filePath: string,
+  renderedTemplates: RenderedTemplateMap,
+): Readonly<Record<string, z.infer<typeof dockerTemplateSchema>>> {
+  const parsed = dockerTemplatesFileSchema.safeParse({templates: renderedTemplates});
+  if (!parsed.success) {
+    throw new DockerTemplateConfigError(
+      `Invalid Docker template config at ${filePath}: ${formatIssues(parsed.error)}`,
+    );
+  }
+  return parsed.data.templates;
+}
+
+function mergeTemplateMaps<T>(
+  handWrittenTemplates: Readonly<Record<string, T>>,
+  generatedTemplates: Readonly<Record<string, T>>,
+): Record<string, T> {
+  const merged = {...handWrittenTemplates};
+  for (const [key, template] of Object.entries(generatedTemplates)) {
+    if (!Object.hasOwn(merged, key)) merged[key] = template;
+  }
+  return merged;
 }
 
 function hasImageField(templates: Readonly<Record<string, unknown>>, key: string): boolean {

--- a/libs/provisioner/docker/src/templates.ts
+++ b/libs/provisioner/docker/src/templates.ts
@@ -1,6 +1,7 @@
 import {readFileSync} from 'node:fs';
 import {logger} from '@shipfox/node-opentelemetry';
 import {
+  enumerateVariants,
   type ProvisionerTemplate,
   type ProvisionerTemplateFile,
   parseTemplateFile,
@@ -42,12 +43,6 @@ const dockerTemplateSchema = z
   })
   .strict();
 
-const dockerTemplatesFileSchema = z
-  .object({
-    templates: z.record(z.string().min(1), dockerTemplateSchema),
-  })
-  .strict();
-
 /**
  * Read, parse, and validate the local Docker template config, returning the
  * provider-agnostic templates the control loop drives. Fails fast with a clear,
@@ -61,6 +56,8 @@ export function loadDockerTemplates(filePath: string): ProvisionerTemplate<Docke
   let validatedTemplates: Readonly<Record<string, z.infer<typeof dockerTemplateSchema>>>;
   try {
     templateFile = parseTemplateFile(raw);
+    // Keep the core cap check over the complete file before either category is split.
+    enumerateVariants(templateFile);
     const generatedTemplates = renderTemplateVariants({...templateFile, templates: {}});
     const handWrittenTemplates = renderTemplateVariants({...templateFile, matrix: {}});
     const validatedGeneratedTemplates = validateRenderedTemplates(filePath, generatedTemplates);
@@ -129,13 +126,28 @@ function validateRenderedTemplates(
   filePath: string,
   renderedTemplates: RenderedTemplateMap,
 ): Readonly<Record<string, z.infer<typeof dockerTemplateSchema>>> {
-  const parsed = dockerTemplatesFileSchema.safeParse({templates: renderedTemplates});
-  if (!parsed.success) {
-    throw new DockerTemplateConfigError(
-      `Invalid Docker template config at ${filePath}: ${formatIssues(parsed.error)}`,
-    );
+  const validated = Object.create(null) as Record<string, z.infer<typeof dockerTemplateSchema>>;
+  for (const [key, template] of Object.entries(renderedTemplates)) {
+    const parsed = dockerTemplateSchema.safeParse(template);
+    if (!parsed.success) {
+      const issues = parsed.error.issues
+        .map((issue) => {
+          const path = issue.path.join('.');
+          return `templates.${key}${path ? `.${path}` : ''}: ${issue.message}`;
+        })
+        .join('; ');
+      throw new DockerTemplateConfigError(
+        `Invalid Docker template config at ${filePath}: ${issues}`,
+      );
+    }
+    Object.defineProperty(validated, key, {
+      configurable: true,
+      enumerable: true,
+      value: parsed.data,
+      writable: true,
+    });
   }
-  return parsed.data.templates;
+  return validated;
 }
 
 function mergeTemplateMaps<T>(
@@ -144,7 +156,14 @@ function mergeTemplateMaps<T>(
 ): Record<string, T> {
   const merged = {...handWrittenTemplates};
   for (const [key, template] of Object.entries(generatedTemplates)) {
-    if (!Object.hasOwn(merged, key)) merged[key] = template;
+    if (!Object.hasOwn(merged, key)) {
+      Object.defineProperty(merged, key, {
+        configurable: true,
+        enumerable: true,
+        value: template,
+        writable: true,
+      });
+    }
   }
   return merged;
 }
@@ -209,15 +228,6 @@ function parseYamlFile(filePath: string): unknown {
       `Cannot parse Docker template config at ${filePath}: ${errorMessage(error)}`,
     );
   }
-}
-
-function formatIssues(error: z.ZodError): string {
-  return error.issues
-    .map((issue) => {
-      const path = issue.path.join('.');
-      return path ? `${path}: ${issue.message}` : issue.message;
-    })
-    .join('; ');
 }
 
 function errorMessage(error: unknown): string {

--- a/libs/provisioner/docker/src/templates.ts
+++ b/libs/provisioner/docker/src/templates.ts
@@ -128,6 +128,11 @@ function validateRenderedTemplates(
 ): Readonly<Record<string, z.infer<typeof dockerTemplateSchema>>> {
   const validated = Object.create(null) as Record<string, z.infer<typeof dockerTemplateSchema>>;
   for (const [key, template] of Object.entries(renderedTemplates)) {
+    if (key.length === 0) {
+      throw new DockerTemplateConfigError(
+        `Invalid Docker template config at ${filePath}: templates.: Invalid key in record`,
+      );
+    }
     const parsed = dockerTemplateSchema.safeParse(template);
     if (!parsed.success) {
       const issues = parsed.error.issues

--- a/libs/provisioner/docker/src/templates.ts
+++ b/libs/provisioner/docker/src/templates.ts
@@ -1,6 +1,12 @@
 import {readFileSync} from 'node:fs';
 import {logger} from '@shipfox/node-opentelemetry';
-import type {ProvisionerTemplate} from '@shipfox/provisioner-core';
+import {
+  type ProvisionerTemplate,
+  type ProvisionerTemplateFile,
+  parseTemplateFile,
+  type RenderedTemplateMap,
+  renderTemplateVariants,
+} from '@shipfox/provisioner-core';
 import {canonicalizeLabels, findInvalidLabels, MAX_RUNNER_LABELS} from '@shipfox/runner-labels';
 import yaml from 'js-yaml';
 import {z} from 'zod';
@@ -50,7 +56,18 @@ const dockerTemplatesFileSchema = z
  */
 export function loadDockerTemplates(filePath: string): ProvisionerTemplate<DockerTemplateSpec>[] {
   const raw = parseYamlFile(filePath);
-  const parsed = dockerTemplatesFileSchema.safeParse(raw);
+  let templateFile: ProvisionerTemplateFile;
+  let renderedTemplates: RenderedTemplateMap;
+  try {
+    templateFile = parseTemplateFile(raw);
+    renderedTemplates = renderTemplateVariants(templateFile);
+  } catch (error) {
+    throw new DockerTemplateConfigError(
+      `Invalid Docker template config at ${filePath}: ${errorMessage(error)}`,
+    );
+  }
+
+  const parsed = dockerTemplatesFileSchema.safeParse({templates: renderedTemplates});
   if (!parsed.success) {
     throw new DockerTemplateConfigError(
       `Invalid Docker template config at ${filePath}: ${formatIssues(parsed.error)}`,
@@ -64,8 +81,8 @@ export function loadDockerTemplates(filePath: string): ProvisionerTemplate<Docke
     );
   }
 
-  return entries.map(([key, spec]) => {
-    if (!hasImageField(raw, key)) {
+  const templates = entries.map(([key, spec]) => {
+    if (!hasImageField(renderedTemplates, key)) {
       logger().debug?.(
         {
           event: 'runner.default_image_selected',
@@ -78,11 +95,23 @@ export function loadDockerTemplates(filePath: string): ProvisionerTemplate<Docke
     }
     return toTemplate(filePath, key, spec);
   });
+
+  const familyCount = Object.keys(templateFile.matrix ?? {}).length;
+  logger().info(
+    {
+      event: 'provisioner.templates_loaded',
+      filePath,
+      templateCount: templates.length,
+      familyCount,
+    },
+    `Loaded ${templates.length} Docker templates from ${familyCount} matrix families`,
+  );
+
+  return templates;
 }
 
-function hasImageField(raw: unknown, key: string): boolean {
-  if (!isRecord(raw) || !isRecord(raw.templates)) return false;
-  const template = raw.templates[key];
+function hasImageField(templates: Readonly<Record<string, unknown>>, key: string): boolean {
+  const template = templates[key];
   return isRecord(template) && Object.hasOwn(template, 'image');
 }
 


### PR DESCRIPTION
Wire Docker template loading to the provisioner-core matrix expansion engine.

The loader now expands matrix families before applying the existing Docker provider schema, preserves DockerTemplateConfigError for core and provider failures, and logs the rendered template count with the declared matrix-family count. Coverage includes legacy files, CPU/OS matrices, startup logging, core errors, and hand-written shadowing.

Closes ENG-1324

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates the Docker template loader with the core matrix expander so operators can declare families instead of individual templates. Fulfills ENG-1324 and keeps behavior stable while enforcing combined limits, validating keys, and preserving special keys.

- New Features
  - Uses `parseTemplateFile`, `enumerateVariants`, and `renderTemplateVariants` from `@shipfox/provisioner-core`; wraps core errors in DockerTemplateConfigError.
  - Validates generated variants before hand-written shadows; emits `provisioner.template_generated_shadowed` when a generated key is shadowed.
  - Enforces the combined template cap (generated + hand-written) before splitting categories.
  - Preserves generated keys (e.g., `'__proto__'`) and merges maps safely to avoid prototype pollution.
  - Rejects empty template keys with clear, path-qualified errors.
  - Logs a single `provisioner.templates_loaded` info line with template and family counts; applies the default runner image when none is set.

<sup>Written for commit d15b88c3acc59ca916eceb1663090ad36942e9bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

