### PR TITLE
Add E2E coverage for environment-backed signup gating

### DIFF
--- a/.changeset/e2e-signup-gate.md
+++ b/.changeset/e2e-signup-gate.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-auth": patch
+---
+
+Render configured signup-gate denial messages in the Auth client.

--- a/e2e/harness/src/e2e.mjs
+++ b/e2e/harness/src/e2e.mjs
@@ -9,6 +9,9 @@ import {fileURLToPath} from 'node:url';
 const defaultE2eAdminApiKey = 'e2e-admin-api-key';
 const defaultApiUrl = 'http://localhost:16101';
 const defaultClientUrl = 'http://localhost:5173';
+const defaultAuthSignupGateEnabled = 'true';
+const defaultAuthSignupAllowedEmailDomains = 'allowed.example.test';
+const defaultAuthSignupNotAllowedMessage = 'This E2E deployment does not accept new accounts.';
 const defaultReadinessTimeoutMs = 60_000;
 const defaultShutdownTimeoutMs = 15_000;
 const defaultTurboTask = 'test:e2e';
@@ -183,6 +186,12 @@ export function e2eEnv(sourceEnv) {
     E2E_ENABLED: sourceEnv.E2E_ENABLED ?? 'true',
     AUTH_ROOT_KEY:
       sourceEnv.AUTH_ROOT_KEY ?? 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=',
+    AUTH_SIGNUP_GATE_ENABLED:
+      sourceEnv.AUTH_SIGNUP_GATE_ENABLED ?? defaultAuthSignupGateEnabled,
+    AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS:
+      sourceEnv.AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS ?? defaultAuthSignupAllowedEmailDomains,
+    AUTH_SIGNUP_NOT_ALLOWED_MESSAGE:
+      sourceEnv.AUTH_SIGNUP_NOT_ALLOWED_MESSAGE ?? defaultAuthSignupNotAllowedMessage,
     E2E_GITEA_URL: giteaUrl,
     GITEA_CLONE_BASE_URL: sourceEnv.GITEA_CLONE_BASE_URL ?? giteaUrl,
     HOST: sourceEnv.HOST ?? '0.0.0.0',

--- a/e2e/harness/test/e2e.test.mjs
+++ b/e2e/harness/test/e2e.test.mjs
@@ -68,6 +68,12 @@ describe('e2eEnv', () => {
     assert.equal(env.INTEGRATIONS_ENABLE_GITHUB_PROVIDER, 'true');
     assert.equal(env.INTEGRATIONS_ENABLE_SLACK_PROVIDER, 'true');
     assert.equal(env.AUTH_ROOT_KEY, 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=');
+    assert.equal(env.AUTH_SIGNUP_GATE_ENABLED, 'true');
+    assert.equal(env.AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS, 'allowed.example.test');
+    assert.equal(
+      env.AUTH_SIGNUP_NOT_ALLOWED_MESSAGE,
+      'This E2E deployment does not accept new accounts.',
+    );
     assert.equal(env.GITHUB_API_BASE_URL, 'http://127.0.0.1:55361/');
     assert.equal(env.SLACK_API_BASE_URL, 'http://127.0.0.1:55362/');
     assert.match(env.GITHUB_APP_PRIVATE_KEY, /BEGIN PRIVATE KEY/u);
@@ -90,6 +96,9 @@ describe('e2eEnv', () => {
       SHIPFOX_API_URL: 'http://localhost:55351',
       GITEA_BASE_URL: 'http://localhost:55356',
       WEBHOOK_PUBLIC_URL: 'https://webhooks.example.test',
+      AUTH_SIGNUP_GATE_ENABLED: 'false',
+      AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS: 'override.example.test',
+      AUTH_SIGNUP_NOT_ALLOWED_MESSAGE: 'Signups are temporarily closed.',
     });
 
     assert.equal(env.API_URL, 'http://localhost:16101');
@@ -100,6 +109,9 @@ describe('e2eEnv', () => {
     assert.equal(env.GITHUB_API_BASE_URL, 'http://127.0.0.1:16121');
     assert.equal(env.SLACK_API_BASE_URL, 'http://127.0.0.1:16122');
     assert.equal(env.WEBHOOK_PUBLIC_URL, 'https://webhooks.example.test');
+    assert.equal(env.AUTH_SIGNUP_GATE_ENABLED, 'false');
+    assert.equal(env.AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS, 'override.example.test');
+    assert.equal(env.AUTH_SIGNUP_NOT_ALLOWED_MESSAGE, 'Signups are temporarily closed.');
   });
 
   test('keeps explicit turbo concurrency', () => {

--- a/e2e/screens/auth/src/index.ts
+++ b/e2e/screens/auth/src/index.ts
@@ -38,6 +38,39 @@ export class LoginScreen {
   }
 }
 
+export class SignupScreen {
+  constructor(private readonly page: Page) {}
+  async goto(): Promise<void> {
+    await this.page.goto('/auth/signup');
+  }
+  heading(): Locator {
+    return this.page.getByRole('heading', {name: 'Create your Shipfox account'});
+  }
+  nameField(): Locator {
+    return this.page.getByLabel('Name');
+  }
+  emailField(): Locator {
+    return this.page.getByLabel('Email');
+  }
+  passwordField(): Locator {
+    return this.page.getByLabel('Password');
+  }
+  submitButton(): Locator {
+    return this.page.getByRole('button', {name: 'Create account'});
+  }
+  alert(): Locator {
+    return this.page.getByRole('alert');
+  }
+  verificationHeading(): Locator {
+    return this.page.getByRole('heading', {name: 'Check your email'});
+  }
+  async submit(params: {email: string; name: string; password: string}): Promise<void> {
+    await this.nameField().fill(params.name);
+    await this.emailField().fill(params.email);
+    await this.passwordField().fill(params.password);
+    await this.submitButton().click();
+  }
+}
 export class GuestRedirectScreen {
   constructor(private readonly page: Page) {}
 
@@ -57,6 +90,7 @@ export class GuestRedirectScreen {
 export interface AuthScreenFixtures {
   guestRedirects: GuestRedirectScreen;
   login: LoginScreen;
+  signup: SignupScreen;
 }
 
 export const authScreens = {
@@ -65,5 +99,8 @@ export const authScreens = {
   },
   login: async ({page}: {page: Page}, use: FixtureUse<LoginScreen>) => {
     await use(new LoginScreen(page));
+  },
+  signup: async ({page}: {page: Page}, use: FixtureUse<SignupScreen>) => {
+    await use(new SignupScreen(page));
   },
 };

--- a/e2e/suites/api/auth/tests/auth-api.e2e.ts
+++ b/e2e/suites/api/auth/tests/auth-api.e2e.ts
@@ -1,6 +1,11 @@
+import {randomUUID} from 'node:crypto';
 import {meResponseSchema} from '@shipfox/api-auth-dto';
 import {config} from '@shipfox/e2e-core';
 import {expect, test} from './test.js';
+
+const SIGNUP_NOT_ALLOWED_MESSAGE =
+  process.env.AUTH_SIGNUP_NOT_ALLOWED_MESSAGE ??
+  'This E2E deployment does not accept new accounts.';
 
 test('creates an E2E user, session, and reads the authenticated user', async ({request, auth}) => {
   const user = await auth.createUser();
@@ -15,4 +20,21 @@ test('creates an E2E user, session, and reads the authenticated user', async ({r
   expect(body.user.id).toBe(user.user.id);
   expect(body.user.email).toBe(user.email);
   expect(session.setCookie).toContain('shipfox_refresh_token=');
+});
+
+test('rejects a password signup outside the configured allowlist', async ({request}) => {
+  const response = await request.post(`${config.API_URL}/auth/signup`, {
+    data: {
+      email: `blocked-${randomUUID()}@example.test`,
+      password: 'correct horse battery staple',
+      name: 'Blocked Signup',
+    },
+  });
+  const body = await response.json();
+
+  expect(response.status()).toBe(403);
+  expect(body).toMatchObject({
+    code: 'signup-not-allowed',
+    details: {message: SIGNUP_NOT_ALLOWED_MESSAGE},
+  });
 });

--- a/e2e/suites/client/auth/tests/auth-client.e2e.ts
+++ b/e2e/suites/client/auth/tests/auth-client.e2e.ts
@@ -50,7 +50,6 @@ test('keeps an unlisted password signup on the signup form', async ({page, signu
   await expect(page).toHaveURL(SIGNUP_URL_RE);
   await expect(signup.alert()).toContainText(SIGNUP_NOT_ALLOWED_MESSAGE);
   await expect(signup.verificationHeading()).toBeHidden();
-  await stableScreenshot(page, 'auth/signup-not-allowed');
 });
 test('starts email verification for an address in the signup allowlist', async ({signup}) => {
   await signup.goto();

--- a/e2e/suites/client/auth/tests/auth-client.e2e.ts
+++ b/e2e/suites/client/auth/tests/auth-client.e2e.ts
@@ -4,8 +4,14 @@ import {expect, test} from './test.js';
 
 const LOGIN_URL_RE = /\/auth\/login$/u;
 const LOGIN_WITH_REDIRECT_URL_RE = /\/auth\/login\?redirect=/u;
+const SIGNUP_URL_RE = /\/auth\/signup$/u;
 const ONBOARDING_URL_RE = /\/setup\/workspaces\/new\/?$/u;
 const ANY_WORKSPACE_URL_RE = /\/workspaces\//u;
+const SIGNUP_NOT_ALLOWED_MESSAGE =
+  process.env.AUTH_SIGNUP_NOT_ALLOWED_MESSAGE ??
+  'This E2E deployment does not accept new accounts.';
+const ALLOWED_SIGNUP_EMAIL_DOMAIN =
+  process.env.AUTH_SIGNUP_ALLOWED_EMAIL_DOMAINS?.split(',')[0]?.trim() ?? 'allowed.example.test';
 
 function workspaceUrlRe(wid: string): RegExp {
   return new RegExp(`/workspaces/${wid}(/|$)`, 'u');
@@ -25,7 +31,7 @@ test('logs in through the UI with an E2E-created verified user', async ({
   guestRedirects,
   login,
 }) => {
-  const user = await auth.createUser();
+  const user = await auth.createUser({email: `existing-${randomUUID()}@example.test`});
 
   await login.goto();
   await login.submit(user.email, user.password);
@@ -34,6 +40,27 @@ test('logs in through the UI with an E2E-created verified user', async ({
   await stableScreenshot(page, 'auth/post-login-workspace');
 });
 
+test('keeps an unlisted password signup on the signup form', async ({page, signup}) => {
+  await signup.goto();
+  await signup.submit({
+    email: `blocked-${randomUUID()}@example.test`,
+    name: 'Blocked Signup',
+    password: 'correct horse battery staple',
+  });
+  await expect(page).toHaveURL(SIGNUP_URL_RE);
+  await expect(signup.alert()).toContainText(SIGNUP_NOT_ALLOWED_MESSAGE);
+  await expect(signup.verificationHeading()).toBeHidden();
+  await stableScreenshot(page, 'auth/signup-not-allowed');
+});
+test('starts email verification for an address in the signup allowlist', async ({signup}) => {
+  await signup.goto();
+  await signup.submit({
+    email: `allowed-${randomUUID()}@${ALLOWED_SIGNUP_EMAIL_DOMAIN}`,
+    name: 'Allowed Signup',
+    password: 'correct horse battery staple',
+  });
+  await expect(signup.verificationHeading()).toBeVisible();
+});
 test('form login routes a user with workspaces straight to /workspaces/$wid', async ({
   page,
   auth,

--- a/e2e/suites/client/workspaces/tests/invitations-members.e2e.ts
+++ b/e2e/suites/client/workspaces/tests/invitations-members.e2e.ts
@@ -17,7 +17,7 @@ function textRe(text: string): RegExp {
   return new RegExp(text.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&'), 'u');
 }
 
-test('accepts an invitation from the public landing page via login', async ({
+test('accepts an invitation for an existing user outside the signup allowlist via login', async ({
   page,
   auth,
   invitationAccept,
@@ -95,7 +95,7 @@ test('accepts an invitation from the public landing page via login', async ({
   });
 });
 
-test('creates an account from an invitation with the email locked', async ({
+test('creates an account from an invitation outside the signup allowlist with the email locked', async ({
   page,
   auth,
   invitationAccept,

--- a/libs/client/auth/src/pages/form-utils.test.ts
+++ b/libs/client/auth/src/pages/form-utils.test.ts
@@ -26,6 +26,16 @@ describe('authErrorMessage', () => {
     expect(result).toBe('Try later');
   });
 
+  test('renders the configured signup denial message from safe error details', () => {
+    const error = new ApiError({
+      code: 'signup-not-allowed',
+      message: 'Forbidden',
+      status: 403,
+      details: {code: 'signup-not-allowed', details: {message: 'Ask your administrator to join.'}},
+    });
+    const result = authErrorMessage(error);
+    expect(result).toBe('Ask your administrator to join.');
+  });
   test('uses generic copy for unknown errors', () => {
     const result = authErrorMessage(new Error('boom'));
 

--- a/libs/client/auth/src/pages/form-utils.ts
+++ b/libs/client/auth/src/pages/form-utils.ts
@@ -1,5 +1,17 @@
 import {ApiError} from '@shipfox/client-api';
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function signupNotAllowedMessage(error: ApiError): string | undefined {
+  if (error.code !== 'signup-not-allowed') return undefined;
+  if (!isRecord(error.details)) return undefined;
+  const details = error.details.details;
+  if (!isRecord(details)) return undefined;
+  return typeof details.message === 'string' ? details.message : undefined;
+}
+
 export function authErrorMessage(error: unknown): string {
   if (!(error instanceof ApiError)) return 'Something went wrong. Try again.';
 
@@ -25,5 +37,7 @@ export function authErrorMessage(error: unknown): string {
     return 'We could not reach the API. Check your connection and try again.';
   }
 
+  const signupMessage = signupNotAllowedMessage(error);
+  if (signupMessage) return signupMessage;
   return error.message || 'Something went wrong. Try again.';
 }


### PR DESCRIPTION
## Summary

Exercise the environment-backed signup gate through the real E2E API and client composition.

The E2E harness now starts with a deterministic enabled allowlist and message while preserving overrides. Coverage includes the 403 HTTP contract, denied and allowed password signup UI, existing-user login bypass, and invitation-created account bypass. The Auth client maps the configured safe response detail to the user-visible denial message.

The full repository E2E suite and affected package checks pass.

Closes ENG-1386

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds E2E coverage for environment-backed signup gating and shows the server-configured denial message in the Auth client. Addresses ENG-1386 by validating the 403 contract and UI behavior for blocked and allowed signups.

- **New Features**
  - E2E harness sets deterministic signup-gate env defaults and supports overrides; tests cover both.
  - API E2E asserts 403 for non-allowlisted password signups with code `signup-not-allowed` and the configured `details.message`.
  - Client E2E adds a Signup screen and tests: blocked signups stay on the form with the denial alert; allowlisted emails start verification; existing-user and invitation flows bypass the gate; functional assertions only (removed visual snapshot).
  - `@shipfox/client-auth`: `authErrorMessage` now renders the safe denial message from API error details; unit test added.

<sup>Written for commit 54eac98cd7449c4c7a21dc7c6178d3f0954d24c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

