### PR TITLE
[api-auth-dto] Expose Auth admin role predicate

### DIFF
--- a/.changeset/quiet-admin-roles.md
+++ b/.changeset/quiet-admin-roles.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-auth-dto": minor
+---
+
+Expose the Auth-owned `isAdminRole` predicate for downstream consumers.

--- a/libs/api/auth-dto/package.json
+++ b/libs/api/auth-dto/package.json
@@ -45,6 +45,8 @@
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
     "depcruise": "shipfox-depcruise",
+    "test": "shipfox-vitest-run",
+    "test:watch": "shipfox-vitest-watch",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"
   },
@@ -58,6 +60,7 @@
     "@shipfox/depcruise": "workspace:*",
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
-    "@shipfox/typescript": "workspace:*"
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*"
   }
 }

--- a/libs/api/auth-dto/src/schemas/admin.test.ts
+++ b/libs/api/auth-dto/src/schemas/admin.test.ts
@@ -1,0 +1,12 @@
+import {describe, expect, it} from '@shipfox/vitest/vi';
+import {isAdminRole} from '../index.js';
+
+describe('isAdminRole', () => {
+  it.each(['admin-observer', 'admin-operator', 'admin-owner'])('accepts %s', (value) => {
+    expect(isAdminRole(value)).toBe(true);
+  });
+
+  it.each([undefined, null, '', 'admin-custom'])('rejects %s', (value) => {
+    expect(isAdminRole(value)).toBe(false);
+  });
+});

--- a/libs/api/auth-dto/src/schemas/admin.ts
+++ b/libs/api/auth-dto/src/schemas/admin.ts
@@ -6,6 +6,10 @@ export const adminRoleSchema = z.enum(['admin-observer', 'admin-operator', 'admi
 
 export type AdminRole = z.infer<typeof adminRoleSchema>;
 
+export function isAdminRole(value: unknown): value is AdminRole {
+  return adminRoleSchema.safeParse(value).success;
+}
+
 const timestampSchema = z.string().datetime();
 const identifierEmailSchema = z.string().email();
 const CONTROL_OR_FORMAT_CHARACTER_RE = /[\p{Cc}\p{Cf}]/u;

--- a/libs/api/auth-dto/src/schemas/index.ts
+++ b/libs/api/auth-dto/src/schemas/index.ts
@@ -33,6 +33,7 @@ export {
   type GrantAdminRoleResponseDto,
   grantAdminRoleBodySchema,
   grantAdminRoleResponseSchema,
+  isAdminRole,
   type ListAdminGrantsQueryDto,
   type ListAdminGrantsResponseDto,
   listAdminGrantsQuerySchema,

--- a/libs/api/auth-dto/vitest.config.ts
+++ b/libs/api/auth-dto/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({}, import.meta.url) as UserConfigExport;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2334,6 +2334,9 @@ importers:
       '@shipfox/typescript':
         specifier: workspace:*
         version: link:../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../tools/vitest
 
   libs/api/common-dto:
     dependencies:


### PR DESCRIPTION
Expose the Auth-owned fixed administrator-role contract as a runtime-safe public predicate for downstream consumers.

This keeps the three-role policy in @shipfox/api-auth-dto so Cloud can replace its interim client role package after the upstream release. A minor Changeset is included; no dedicated Linear issue exists for this public helper, and the Cloud package migration remains the follow-up after publication.

Validation: auth-dto check, test, type, build, and declaration emit; frozen lockfile install; packed public-artifact verification.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose `isAdminRole` from `@shipfox/api-auth-dto` for runtime-safe admin role checks. Keeps the fixed three-role policy unchanged (`admin-observer`, `admin-operator`, `admin-owner`).

- **New Features**
  - Public `isAdminRole(value): value is AdminRole` predicate, re-exported from the package index.
  - Unit tests cover accepted and rejected values.

- **Dependencies**
  - Add `@shipfox/vitest` and a Vitest config; add `test` and `test:watch` scripts.

<sup>Written for commit 59e1ea97332a80965bf0a1db1289cd1b5696b0fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

