### PR TITLE
[client-workflows] Show running jobs in the workflow graph

### DIFF
--- a/.changeset/running-job-graph.md
+++ b/.changeset/running-job-graph.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-workflows": patch
+---
+
+Show running job executions as running in the workflow graph.

--- a/libs/client/workflows/src/components/job-graph/job-node.test.tsx
+++ b/libs/client/workflows/src/components/job-graph/job-node.test.tsx
@@ -285,6 +285,18 @@ describe('JobNode status indicator', () => {
 
     expect(await screen.findByRole('tooltip')).toHaveTextContent('Running');
   });
+
+  test('shows a running execution as running while the job is still pending', () => {
+    const node = makeNode({
+      name: 'deploy',
+      status: 'pending',
+      job_executions: [workflowJobExecutionDto({status: 'running'})],
+    });
+
+    renderNode(node);
+
+    expect(screen.getByRole('button', {name: 'deploy, Running'})).toBeInTheDocument();
+  });
 });
 
 describe('JobNode execution count indicator', () => {

--- a/libs/client/workflows/src/components/job-graph/job-node.tsx
+++ b/libs/client/workflows/src/components/job-graph/job-node.tsx
@@ -69,7 +69,12 @@ export function JobNode({
   ref?: Ref<HTMLButtonElement>;
 }) {
   useTimeTick();
-  const visual = getWorkflowStatusVisual(node.status);
+  const status =
+    node.status === 'pending' &&
+    node.jobExecutions.some((jobExecution) => jobExecution.status === 'running')
+      ? 'running'
+      : node.status;
+  const visual = getWorkflowStatusVisual(status);
   const accessibleLabel = [
     node.displayName,
     visual.label,
@@ -106,7 +111,7 @@ export function JobNode({
         />
       ) : null}
       <div className="flex min-w-0 flex-1 items-center gap-8">
-        <WorkflowStatusIcon status={node.status} jobMode={node.mode} size={14} />
+        <WorkflowStatusIcon status={status} jobMode={node.mode} size={14} />
         <JobLabel label={node.displayName} />
       </div>
       <JobDurationLabel duration={node.displayDuration} />


### PR DESCRIPTION
Running one-shot jobs could appear pending in the graph even while the detail panel showed an active execution and running step. The graph now treats a pending job with a running execution as running, while preserving terminal aggregate states.

Includes regression coverage and a patch Changeset for `@shipfox/client-workflows`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the workflow graph to show Running when a pending job has an active execution. Aligns the graph with the detail panel while keeping terminal aggregate states unchanged.

- **Bug Fixes**
  - Treat pending jobs with a running execution as Running in visuals and accessibility labels.
  - Added regression test and a patch changeset for `@shipfox/client-workflows`.

<sup>Written for commit 70714a2a8f3bc7becb56e56a0f6748aaf4a44e28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

