### PR TITLE
[expression] Accept integer literals in numeric equality

### DIFF
--- a/.changeset/flexible-number-equality.md
+++ b/.changeset/flexible-number-equality.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/expression": patch
+---
+
+Accepts integer literals in CEL equality checks against numeric workflow values.

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -1954,6 +1954,33 @@ describe('normalizeWorkflowDocument', () => {
     });
   });
 
+  it('allows integer equality literals for number step outputs in gate success expressions', () => {
+    const document: WorkflowDocument = {
+      name: 'number output equality',
+      jobs: {
+        build: {
+          steps: [
+            {
+              key: 'collect',
+              run: 'npm run collect',
+              outputs: {issue_number: {type: 'number'}},
+              gate: {success: 'step.outputs.issue_number == 1'},
+            },
+          ],
+        },
+      },
+    };
+
+    const model = normalizeWorkflowDocument(document);
+
+    expect(model.jobs[0]?.steps[0]?.gate?.success).toEqual({
+      language: 'cel',
+      source: 'step.outputs.issue_number == 1',
+      check: 'typed',
+      resultType: 'bool',
+    });
+  });
+
   it('rejects untrusted step outputs in trusted-only run fields', () => {
     const document: WorkflowDocument = {
       name: 'untrusted step output',

--- a/libs/shared/expression/src/evaluator/evaluate-workflow-expression.test.ts
+++ b/libs/shared/expression/src/evaluator/evaluate-workflow-expression.test.ts
@@ -27,6 +27,28 @@ describe('evaluateWorkflowExpression', () => {
     expect(result).toBe(true);
   });
 
+  it.each([
+    [1, true],
+    [1.5, false],
+  ])('evaluates number equality with an integer literal for %s', (value, expected) => {
+    const expression = createWorkflowExpression({
+      source: 'event.value == 1',
+      check: {
+        mode: 'typed',
+        typeEnvironment: {
+          event: {kind: 'object', fields: {value: 'double'}},
+        },
+        expectedResultType: 'bool',
+      },
+    });
+
+    const result = evaluateWorkflowPredicate(expression, {
+      event: {value},
+    });
+
+    expect(result).toBe(expected);
+  });
+
   it('does not add caller-supplied functions to the global evaluator', () => {
     const expression = createWorkflowExpression({
       source: 'range(2, 32, 2)',

--- a/libs/shared/expression/src/expression/create-workflow-expression.test.ts
+++ b/libs/shared/expression/src/expression/create-workflow-expression.test.ts
@@ -168,6 +168,53 @@ describe('createWorkflowExpression', () => {
     });
   });
 
+  it.each([
+    ['event.value == 1', 'double'],
+    ['1 == event.value', 'double'],
+    ['event.value != 1', 'double'],
+    ['event.value == 1.0', 'int'],
+  ] satisfies readonly [
+    string,
+    ExpressionScalarType,
+  ][])('type-checks cross-type numeric equality in %s', (source, scalarType) => {
+    const expression = createWorkflowExpression({
+      source,
+      check: {
+        mode: 'typed',
+        typeEnvironment: {
+          event: {kind: 'object', fields: {value: scalarType}},
+        },
+        expectedResultType: 'bool',
+      },
+    });
+
+    expect(expression).toEqual({
+      language: 'cel',
+      source,
+      check: 'typed',
+      resultType: 'bool',
+    });
+  });
+
+  it.each([
+    'event.value == "1"',
+    'event.value + 1 == 2',
+  ])('keeps non-numeric and arithmetic double operations strict in %s', (source) => {
+    const act = () =>
+      createWorkflowExpression({
+        source,
+        check: {
+          mode: 'typed',
+          typeEnvironment: {
+            event: {kind: 'object', fields: {value: 'double'}},
+          },
+          expectedResultType: 'bool',
+        },
+      });
+
+    expect(act).toThrow(InvalidWorkflowExpressionError);
+  });
+
   it('rejects timestamp fields compared with non-timestamp values', () => {
     const act = () =>
       createWorkflowExpression({

--- a/libs/shared/expression/src/expression/create-workflow-expression.ts
+++ b/libs/shared/expression/src/expression/create-workflow-expression.ts
@@ -43,7 +43,7 @@ export function createWorkflowExpression(
   }
 
   if (params.check.mode === 'typed') {
-    const environment = new Environment({unlistedVariablesAreDyn: false});
+    const environment = createTypeCheckingEnvironment();
     for (const [name, type] of Object.entries(params.check.typeEnvironment ?? {})) {
       const celType = toCelType(type, environment, name);
       if (typeof celType === 'string') {
@@ -78,6 +78,18 @@ export function createWorkflowExpression(
     check: params.check.mode,
     ...(resultType === undefined ? {} : {resultType}),
   };
+}
+
+function createTypeCheckingEnvironment(): Environment {
+  const environment = new Environment({unlistedVariablesAreDyn: false});
+
+  // CEL evaluates numeric equality across types, but its static checker normally
+  // rejects the same expression. Match validation to the runtime contract.
+  environment.registerOperator('double == int', (left: number, right: bigint) => {
+    return Number.isInteger(left) && BigInt(left) === right;
+  });
+
+  return environment;
 }
 
 export function unsafeWorkflowExpressionFromSource(params: {


### PR DESCRIPTION
Workflow outputs declared as `number` are represented as CEL doubles. Typed definition validation therefore rejected natural integer equality literals such as `step.outputs.issue_number == 1`, even though runtime CEL equality supports the comparison.

Align typed validation with runtime numeric equality for integer and double operands, including reversed and not-equal forms. String mismatches and mixed numeric arithmetic remain strict. The change includes checker, evaluator, and workflow-model regression coverage plus a patch Changeset for `@shipfox/expression`.

Validation: `turbo check type test --filter=@shipfox/expression...`; 507 expression tests; 386 API definitions tests; `git diff --check`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept integer literals in CEL numeric equality so typed validation no longer rejects expressions like step.outputs.issue_number == 1. Aligns the checker with runtime behavior for int/double equality and != without changing arithmetic or string rules.

- **Bug Fixes**
  - Typed checker permits int == double and double == int (including !=).
  - String mismatches and mixed numeric arithmetic remain strict.
  - Added coverage in checker, evaluator, and workflow-model tests; published a patch changeset for `@shipfox/expression`.

<sup>Written for commit 7d9c6098d118ac5a88c7c055102811e794568a3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

