### PR TITLE
Enforce suspended workspace access for JWT-backed routes

### DIFF
--- a/.changeset/suspended-workspace-jwt-access.md
+++ b/.changeset/suspended-workspace-jwt-access.md
@@ -1,0 +1,10 @@
+---
+"@shipfox/api-auth": major
+"@shipfox/api-auth-context": patch
+"@shipfox/api-workspaces-dto": patch
+"@shipfox/api-workspaces": patch
+---
+
+Carry workspace lifecycle status in JWT membership claims and enforce suspended or inactive access at the stateless workspace gate while keeping access-token verification stateless.
+
+`getAuthenticatedSessionContext()` now reads refresh-session metadata from verified access-token claims without checking active refresh-session state; revoking a refresh session does not invalidate an already-issued access token.

--- a/.changeset/suspended-workspace-jwt-access.md
+++ b/.changeset/suspended-workspace-jwt-access.md
@@ -1,8 +1,12 @@
 ---
 "@shipfox/api-auth": major
 "@shipfox/api-auth-context": patch
+"@shipfox/annotations": patch
+"@shipfox/api-logs": patch
+"@shipfox/api-triggers": patch
 "@shipfox/api-workspaces-dto": patch
 "@shipfox/api-workspaces": patch
+"@shipfox/api-workflows": patch
 ---
 
 Carry workspace lifecycle status in JWT membership claims and enforce suspended or inactive access at the stateless workspace gate while keeping access-token verification stateless.

--- a/.changeset/suspended-workspace-jwt-access.md
+++ b/.changeset/suspended-workspace-jwt-access.md
@@ -1,12 +1,12 @@
 ---
 "@shipfox/api-auth": major
-"@shipfox/api-auth-context": patch
-"@shipfox/annotations": patch
-"@shipfox/api-logs": patch
-"@shipfox/api-triggers": patch
-"@shipfox/api-workspaces-dto": patch
-"@shipfox/api-workspaces": patch
-"@shipfox/api-workflows": patch
+"@shipfox/api-auth-context": major
+"@shipfox/annotations": major
+"@shipfox/api-logs": major
+"@shipfox/api-triggers": major
+"@shipfox/api-workspaces-dto": major
+"@shipfox/api-workspaces": major
+"@shipfox/api-workflows": major
 ---
 
 Carry workspace lifecycle status in JWT membership claims and enforce suspended or inactive access at the stateless workspace gate while keeping access-token verification stateless.

--- a/docs/adr/0008-administration-controls.md
+++ b/docs/adr/0008-administration-controls.md
@@ -222,8 +222,9 @@ is accepted alongside the claim-based access-token lifetime.
 
 Jobs queued or running before suspension continue to their normal terminal
 state. Suspension does not cancel jobs, revoke runner leases, or stop active
-workflow execution. Reactivation restores normal access and admission rules.
-It does not replay work rejected during suspension.
+workflow execution. Reactivation makes newly issued or refreshed claims active;
+existing access tokens retain their claim snapshot until expiration. It does not
+replay work rejected during suspension.
 
 Member-facing routes expose only a safe suspension state. The client replaces
 ordinary workspace content with a neutral suspension page. It does not show

--- a/docs/adr/0008-administration-controls.md
+++ b/docs/adr/0008-administration-controls.md
@@ -188,16 +188,37 @@ tokens, bootstrap values, or database errors.
 
 ### Define suspension semantics
 
-**User suspension blocks authentication and revokes active sessions.** New
-sign-ins become ineligible. Authenticated requests check the current user
-suspension state as well as the session. Reactivation restores eligibility to
-sign in but does not restore revoked sessions or modify the user's data.
+**User suspension blocks new authentication and revokes refresh sessions.**
+New sign-ins become ineligible. Current-state reads such as `/auth/me` expose
+the persisted suspended status, while ordinary JWT verification remains
+claim-only. An access token already issued remains usable until its configured
+`exp` time. Reactivation restores eligibility to sign in but does not restore
+revoked refresh sessions or modify the user's data.
 
 **Workspace suspension blocks every new-job admission path.** The workspace
 and its data remain in place. Member actions, triggers, schedules, and
 webhook-driven admission reject new work with the stable
 `workspace-suspended` result. The result is not transient and must not create
 a retry loop.
+
+Newly issued or refreshed user JWTs carry the lifecycle status of each workspace
+membership. The stateless member-access gate maps a `suspended` claim to the
+stable `workspace-suspended` result (409) and a deleted claim to
+`workspace-inactive` (403); an absent membership remains an ordinary forbidden
+result. Workspace-scoped member, invitation, trigger, log, and workflow routes
+use that gate. Resource routes retain a non-leaking 404 for missing resources or
+memberships, while annotation reads filter to active claimed workspaces and
+return no rows for suspended or deleted claims. Existing access tokens remain
+usable until their configured `exp` time because workspace authorization is
+claim-based. Refresh-session state is the renewal boundary; it does not
+retroactively invalidate an issued access token. The recommended access-token
+lifetime is 15 minutes.
+
+The refresh membership snapshot is read before refresh-token rotation and
+access-token signing. If workspace suspension races with that read, the
+in-flight refresh may still issue a token containing the pre-suspension status;
+the next refresh observes the new workspace state. This bounded snapshot race
+is accepted alongside the claim-based access-token lifetime.
 
 Jobs queued or running before suspension continue to their normal terminal
 state. Suspension does not cancel jobs, revoke runner leases, or stop active

--- a/libs/api/agent/src/presentation/routes/model-provider-config.test.ts
+++ b/libs/api/agent/src/presentation/routes/model-provider-config.test.ts
@@ -75,7 +75,7 @@ describe('model provider config routes', () => {
       stopReason: 'stop',
       timestamp: Date.now(),
     });
-    authenticatedMemberships = [{workspaceId, role: 'admin'}];
+    authenticatedMemberships = [{workspaceId, role: 'admin', workspaceStatus: 'active'}];
     app = await createApp({
       auth: [fakeUserAuth],
       routes: agentRoutes,

--- a/libs/api/annotations/src/presentation/routes/read-annotations.test.ts
+++ b/libs/api/annotations/src/presentation/routes/read-annotations.test.ts
@@ -16,7 +16,13 @@ const fakeUserAuth: AuthMethod = {
     const memberships = rawWorkspaceIds
       .split(',')
       .filter((workspaceId) => workspaceId.length > 0)
-      .map((workspaceId) => ({workspaceId, role: 'admin' as const}));
+      .map((value) => {
+        const [workspaceId, status] = value.split('|');
+        if (!workspaceId) throw new Error('missing test workspace id');
+        const workspaceStatus: 'active' | 'suspended' | 'deleted' =
+          status === 'suspended' ? 'suspended' : status === 'deleted' ? 'deleted' : 'active';
+        return {workspaceId, role: 'admin' as const, workspaceStatus};
+      });
 
     setUserContext(
       request,
@@ -138,6 +144,24 @@ describe('GET /annotations', () => {
       method: 'GET',
       url: readUrl({workflowRunId, attempt: 1}),
       headers: {authorization: 'Bearer user', 'x-test-workspaces': crypto.randomUUID()},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({annotations: [], has_more: false, next_cursor: null});
+  });
+
+  it('does not return annotations for suspended membership claims', async () => {
+    const workspaceId = crypto.randomUUID();
+    const workflowRunId = crypto.randomUUID();
+    await annotationFactory.create({workspaceId, workflowRunId});
+
+    const res = await app.inject({
+      method: 'GET',
+      url: readUrl({workflowRunId, attempt: 1}),
+      headers: {
+        authorization: 'Bearer user',
+        'x-test-workspaces': `${workspaceId}|suspended`,
+      },
     });
 
     expect(res.statusCode).toBe(200);

--- a/libs/api/annotations/src/presentation/routes/read-annotations.ts
+++ b/libs/api/annotations/src/presentation/routes/read-annotations.ts
@@ -29,7 +29,9 @@ export const readAnnotationsRoute = defineRoute({
       throw new ClientError('Invalid cursor', 'invalid-cursor', {status: 400});
     }
 
-    const workspaceIds = user.memberships.map((membership) => membership.workspaceId);
+    const workspaceIds = user.memberships
+      .filter((membership) => membership.workspaceStatus === 'active')
+      .map((membership) => membership.workspaceId);
     const result = await listAnnotationsForRunAttempt({
       workflowRunId,
       workflowRunAttempt: attempt,

--- a/libs/api/auth-context/src/index.ts
+++ b/libs/api/auth-context/src/index.ts
@@ -14,6 +14,7 @@ export type WorkspaceStatus = 'active' | 'suspended' | 'deleted';
 export interface UserContextMembership {
   workspaceId: string;
   role: WorkspaceRole;
+  workspaceStatus: WorkspaceStatus;
 }
 
 export interface UserContext {
@@ -39,9 +40,12 @@ export function buildUserContext(params: BuildUserContextParams): UserContext {
     email: params.email,
     name: params.name ?? null,
     memberships,
-    canAccess: (workspaceId) => memberships.some((m) => m.workspaceId === workspaceId),
+    canAccess: (workspaceId) =>
+      memberships.some((m) => m.workspaceId === workspaceId && m.workspaceStatus === 'active'),
     hasRole: (workspaceId, role) =>
-      memberships.some((m) => m.workspaceId === workspaceId && m.role === role),
+      memberships.some(
+        (m) => m.workspaceId === workspaceId && m.workspaceStatus === 'active' && m.role === role,
+      ),
   };
 }
 
@@ -114,7 +118,34 @@ export function requireWorkspaceAccess(
     throw new ClientError('Not a member of this workspace', 'forbidden', {status: 403});
   }
 
+  if (membership.workspaceStatus === 'suspended') {
+    throw new ClientError('Workspace is suspended', 'workspace-suspended', {status: 409});
+  }
+  if (membership.workspaceStatus === 'deleted') {
+    throw new ClientError('Workspace is not active', 'workspace-inactive', {status: 403});
+  }
+
   return {workspaceId: params.workspaceId, userId: context.userId, role: membership.role};
+}
+
+/**
+ * Applies the workspace lifecycle gate to a resource that has already been loaded. Missing
+ * membership remains resource-shaped 404 to avoid leaking the resource's existence, while
+ * suspended and deleted claims retain their stable lifecycle errors.
+ */
+export function requireWorkspaceResourceAccess(params: {
+  request: RequestWithContext;
+  workspaceId: string;
+  notFoundError: ClientError;
+}): RequireWorkspaceAccessResult {
+  try {
+    return requireWorkspaceAccess(params);
+  } catch (error) {
+    if (error instanceof ClientError && error.code === 'forbidden') {
+      throw params.notFoundError;
+    }
+    throw error;
+  }
 }
 
 export function setProvisionerContext(

--- a/libs/api/auth-context/src/require-workspace-access.test.ts
+++ b/libs/api/auth-context/src/require-workspace-access.test.ts
@@ -26,7 +26,10 @@ describe('requireWorkspaceAccess', () => {
   test('returns workspaceId, userId, and role when the token grants access', () => {
     const userId = crypto.randomUUID();
     const workspaceId = crypto.randomUUID();
-    const request = requestWith({userId, memberships: [{workspaceId, role: 'admin'}]});
+    const request = requestWith({
+      userId,
+      memberships: [{workspaceId, role: 'admin', workspaceStatus: 'active'}],
+    });
 
     const result = requireWorkspaceAccess({request, workspaceId});
 
@@ -38,7 +41,7 @@ describe('requireWorkspaceAccess', () => {
   test('throws 403 when the token does not include the workspace', () => {
     const request = requestWith({
       userId: crypto.randomUUID(),
-      memberships: [{workspaceId: crypto.randomUUID(), role: 'admin'}],
+      memberships: [{workspaceId: crypto.randomUUID(), role: 'admin', workspaceStatus: 'active'}],
     });
 
     const act = () => requireWorkspaceAccess({request, workspaceId: crypto.randomUUID()});
@@ -53,4 +56,35 @@ describe('requireWorkspaceAccess', () => {
     expect(act).toThrow(ClientError);
     expect(act).toThrow(expect.objectContaining({status: 401}));
   });
+
+  test.each([
+    ['suspended', 'workspace-suspended', 409],
+    ['deleted', 'workspace-inactive', 403],
+  ] as const)('maps a %s workspace claim to the stable access error', (workspaceStatus, code, status) => {
+    const workspaceId = crypto.randomUUID();
+    const request = requestWith({
+      userId: crypto.randomUUID(),
+      memberships: [{workspaceId, role: 'admin', workspaceStatus}],
+    });
+
+    const act = () => requireWorkspaceAccess({request, workspaceId});
+
+    expect(act).toThrow(ClientError);
+    expect(act).toThrow(expect.objectContaining({code, status}));
+  });
+});
+
+test('context access helpers only authorize active memberships', () => {
+  const workspaceId = crypto.randomUUID();
+  const context = buildUserContext({
+    userId: crypto.randomUUID(),
+    email: 'user@example.com',
+    memberships: [
+      {workspaceId, role: 'admin', workspaceStatus: 'suspended'},
+      {workspaceId: crypto.randomUUID(), role: 'admin', workspaceStatus: 'deleted'},
+    ],
+  });
+
+  expect(context.canAccess(workspaceId)).toBe(false);
+  expect(context.hasRole(workspaceId, 'admin')).toBe(false);
 });

--- a/libs/api/auth/README.md
+++ b/libs/api/auth/README.md
@@ -70,6 +70,17 @@ Required environment:
 | `CLIENT_BASE_URL` | `http://localhost:5173` | Base URL used in email verification and password reset links. |
 | `ADMIN_BOOTSTRAP_TOKEN` | none | Deployment secret accepted once to create the first administrator owner. Set it before bootstrap and remove or rotate it after successful bootstrap. |
 
+The recommended access-token lifetime is 15 minutes. Because user JWTs are
+verified from their claims, a token issued before logout, password changes,
+session revocation, or workspace suspension remains usable until its configured
+`exp` time. Logout and session revocation block refresh-session renewal, while
+password changes revoke other refresh sessions and retain the current session
+when its refresh cookie is valid. Workspace suspension is carried into the next
+status-aware snapshot, where the stateless workspace gate rejects member access;
+none of these actions retroactively invalidate an issued access token. Newly
+issued and refreshed tokens carry workspace lifecycle status so the gate can
+return the stable suspended or inactive access result.
+
 Email delivery uses the shared `@shipfox/node-mailer` configuration.
 
 The signup gate is off by default. When it is on, provide at least one non-empty
@@ -99,8 +110,9 @@ itself.
 ### User session token
 
 - **Design:** a stateless session token. It carries the user's identity and
-  current membership list in its claims so protected routes can authorize without
-  a per-request user or membership lookup.
+  workspace membership list, including each workspace's lifecycle status, in
+  its claims so protected routes can authorize without a per-request user or
+  membership lookup.
 - **Audience:** signed-in users on first-party clients (web app, CLI).
 - **Grants:** the user's own account routes and, downstream, any route that
   authorizes against the membership claims. Its scope is "this user, with these
@@ -111,12 +123,12 @@ itself.
     fresh token when it expires.
   - *Store* — held in client memory only, never persisted to disk or local
     storage. Refresh sessions are stored server-side as hashes, never in raw form.
-  - *Discard* — expires on its own (minutes, not hours); the refresh session is
-    revoked on logout and on password change.
+  - *Discard* — expires at the configured `exp` time. Revoking the refresh
+    session blocks renewal but does not invalidate the issued access token.
 - **Tradeoff — stale memberships:** because memberships ride in the claims, a
-  membership change only takes effect on the next refresh. Accepted because the
-  token is short-lived, so the staleness window is bounded and a per-request
-  membership read is avoided.
+  membership or workspace-status change only takes effect on the next token
+  issuance or refresh. Accepted because the recommended lifetime is 15 minutes,
+  so the staleness window is bounded and a per-request membership read is avoided.
 
 ### Runner session token
 
@@ -279,9 +291,9 @@ All routes are mounted under `/admin/auth/users` and require an authenticated be
 
 | Method | Path | Required role | Result |
 | --- | --- | --- | --- |
-| `POST` | `/:userId/suspend` | `admin-operator` | Suspends the user, revokes all active sessions, and returns the final safe user summary with a correlation ID. |
+| `POST` | `/:userId/suspend` | `admin-operator` | Suspends the user, revokes all refresh sessions, and returns the final safe user summary with a correlation ID. Issued access tokens remain valid until `exp`. |
 | `POST` | `/:userId/reactivate` | `admin-operator` | Restores sign-in eligibility without restoring revoked sessions. |
-| `POST` | `/:userId/revoke-sessions` | `admin-operator` | Revokes all active sessions without changing account status and returns the number of affected sessions. |
+| `POST` | `/:userId/revoke-sessions` | `admin-operator` | Revokes all refresh sessions without changing account status and returns the number of affected sessions. Issued access tokens remain valid until `exp`. |
 
 Each command requires an `Idempotency-Key`. Suspension requires a bounded reason; reactivation and session revocation accept an optional bounded reason. Repeating a successful command returns its committed result. Reusing a key for a different command or request returns `409 idempotency-key-reused`.
 
@@ -311,7 +323,7 @@ It also exports lower-level pieces for tests and advanced integration:
 - `issueJobLeaseToken(claims)` / `verifyJobLeaseToken(token)`: mint and verify job lease tokens.
 - `createEnvironmentSignupPolicy()`: creates the environment-backed signup policy used by default. Pass `signupPolicy` to `createAuthModule` to replace it.
 - `getClientContext(request)`: reads the authenticated user context from a Fastify request.
-- `getAuthenticatedSessionContext(request)`: resolves an authenticated request to its user ID and active refresh-session ID.
+- `getAuthenticatedSessionContext(request)`: reads the user ID and required refresh-session ID from verified access-token claims. It does not check whether the refresh session is still active.
 - `findUserByEmail({email})`: read-only lookup of the current owner of a normalized email; see below.
 - Entity types: `User`, `UserStatus`, `RefreshToken`, `PasswordReset`, and `EmailOwner`.
 
@@ -416,9 +428,9 @@ const session = await getAuthenticatedSessionContext(request);
 ```
 
 The refresh-session ID remains the same when its refresh token rotates. The
-helper verifies that the session is active and belongs to the authenticated user,
-and returns the standard `401 unauthorized` error for a missing, malformed,
-expired, or revoked session. It exposes neither refresh-token material nor
+helper does not query the refresh-session table. It returns the standard `401
+unauthorized` error when the verified request context is missing, inconsistent,
+or has no refresh-session ID. It exposes neither refresh-token material nor
 storage details.
 
 ## Data Model
@@ -441,7 +453,11 @@ Passwords use Argon2id. Password reset tokens and refresh tokens are opaque toke
 - A denied password signup returns `403` with error code `signup-not-allowed`. The policy message is capped at 500 characters.
 - Invitation signup validates the invitation and bypasses the signup policy. Invitations remain a separate authorization path.
 - Login only succeeds for active users with verified email addresses and a password hash.
-- Authenticated requests reject suspended or deleted users. Session-bound access tokens also reject a revoked refresh session.
+- Login and refresh reject suspended or deleted users. Current-state reads such
+  as `/auth/me` still return the persisted suspended-user status. Ordinary JWT
+  verification does not query user or refresh-session rows.
+- Revoking a refresh session blocks renewal. An already-issued access token
+  remains valid until its configured `exp` time.
 - Refresh tokens rotate on each refresh.
 - Password reset tokens and email challenge proofs are consumed once.
 - Password change revokes other refresh sessions. It keeps the current session when the current refresh cookie is valid.

--- a/libs/api/auth/src/core/auth.test.ts
+++ b/libs/api/auth/src/core/auth.test.ts
@@ -73,7 +73,13 @@ vi.mock('#config.js', () => ({
 vi.mock('@shipfox/node-mailer', () => ({mailer: testConfig.mailer}));
 
 const listMembershipsByUserMock = vi.fn(() =>
-  Promise.resolve({memberships: [] as Array<{workspaceId: string; role: 'admin'}>}),
+  Promise.resolve({
+    memberships: [] as Array<{
+      workspaceId: string;
+      role: 'admin';
+      workspaceStatus: 'active' | 'suspended' | 'deleted';
+    }>,
+  }),
 );
 const workspaces = {
   listMembershipsForTokenClaims: listMembershipsByUserMock,
@@ -492,7 +498,6 @@ describe('auth core', () => {
   test('refreshAccessToken rejects a lost rotation claim when the token was revoked', async () => {
     const user = await userFactory.create({emailVerifiedAt: new Date()});
     const loginResult = await login({email: user.email, password: user.plainPassword});
-    listMembershipsByUserMock.mockClear();
     vi.spyOn(refreshTokenDb, 'rotateRefreshToken').mockImplementationOnce(async () => {
       await logout({refreshToken: loginResult.refreshToken});
       return undefined;
@@ -501,7 +506,9 @@ describe('auth core', () => {
     const raced = refreshAccessToken({refreshToken: loginResult.refreshToken});
 
     await expect(raced).rejects.toBeInstanceOf(TokenInvalidError);
-    expect(listMembershipsByUserMock).not.toHaveBeenCalled();
+    await expect(
+      verifyUserToken({token: loginResult.token, secret: userAccessTokenKey()}),
+    ).resolves.toMatchObject({sub: user.id});
   });
 
   test('refreshAccessToken rejects reuse past the grace window and revokes the session', async () => {
@@ -524,6 +531,9 @@ describe('auth core', () => {
         })
       : undefined;
     expect(successor).toBeUndefined();
+    await expect(
+      verifyUserToken({token: refreshed.token, secret: userAccessTokenKey()}),
+    ).resolves.toMatchObject({sub: user.id});
   });
 
   test('refreshAccessToken rejects refresh tokens for inactive users', async () => {
@@ -597,6 +607,9 @@ describe('auth core', () => {
 
     expect(currentRefresh.user.id).toBe(user.id);
     await expect(otherRefresh).rejects.toBeInstanceOf(TokenInvalidError);
+    await expect(
+      verifyUserToken({token: loginResult.token, secret: userAccessTokenKey()}),
+    ).resolves.toMatchObject({sub: user.id});
   });
 
   test('changePassword rejects unknown users and invalid current passwords', async () => {
@@ -696,8 +709,8 @@ describe('auth core', () => {
     const workspaceB = crypto.randomUUID();
     listMembershipsByUserMock.mockResolvedValueOnce({
       memberships: [
-        {workspaceId: workspaceA, role: 'admin'},
-        {workspaceId: workspaceB, role: 'admin'},
+        {workspaceId: workspaceA, role: 'admin', workspaceStatus: 'active'},
+        {workspaceId: workspaceB, role: 'admin', workspaceStatus: 'suspended'},
       ],
     });
 
@@ -706,8 +719,8 @@ describe('auth core', () => {
     const claims = await verifyUserToken({token: result.token, secret: userAccessTokenKey()});
     expect(claims.name).toBe(user.name);
     expect(claims.memberships).toEqual([
-      {workspaceId: workspaceA, role: 'admin'},
-      {workspaceId: workspaceB, role: 'admin'},
+      {workspaceId: workspaceA, role: 'admin', workspaceStatus: 'active'},
+      {workspaceId: workspaceB, role: 'admin', workspaceStatus: 'suspended'},
     ]);
   });
 
@@ -718,7 +731,7 @@ describe('auth core', () => {
 
     const newWorkspaceId = crypto.randomUUID();
     listMembershipsByUserMock.mockResolvedValueOnce({
-      memberships: [{workspaceId: newWorkspaceId, role: 'admin'}],
+      memberships: [{workspaceId: newWorkspaceId, role: 'admin', workspaceStatus: 'active'}],
     });
     const refreshed = await refreshAccessToken({refreshToken: loginResult.refreshToken});
 
@@ -726,7 +739,9 @@ describe('auth core', () => {
       token: refreshed.token,
       secret: userAccessTokenKey(),
     });
-    expect(refreshedClaims.memberships).toEqual([{workspaceId: newWorkspaceId, role: 'admin'}]);
+    expect(refreshedClaims.memberships).toEqual([
+      {workspaceId: newWorkspaceId, role: 'admin', workspaceStatus: 'active'},
+    ]);
   });
 
   test('login fails closed when listMembershipsByUser throws', async () => {
@@ -738,7 +753,7 @@ describe('auth core', () => {
     await expect(promise).rejects.toBeInstanceOf(AuthDependencyUnavailableError);
   });
 
-  test('refresh fails closed when listMembershipsByUser throws', async () => {
+  test('does not rotate a refresh token when listMembershipsByUser throws', async () => {
     const user = await userFactory.create({emailVerifiedAt: new Date()});
     listMembershipsByUserMock.mockResolvedValueOnce({memberships: []});
     const loginResult = await login({email: user.email, password: user.plainPassword});
@@ -747,5 +762,9 @@ describe('auth core', () => {
     const promise = refreshAccessToken({refreshToken: loginResult.refreshToken});
 
     await expect(promise).rejects.toBeInstanceOf(AuthDependencyUnavailableError);
+
+    const retry = await refreshAccessToken({refreshToken: loginResult.refreshToken});
+    expect(retry.token).toEqual(expect.any(String));
+    expect(retry.refreshToken).toEqual(expect.any(String));
   });
 });

--- a/libs/api/auth/src/core/auth.ts
+++ b/libs/api/auth/src/core/auth.ts
@@ -46,7 +46,7 @@ import {
   TokenInvalidError,
   UserNotFoundError,
 } from './errors.js';
-import {signUserToken} from './jwt.js';
+import {signUserToken, type TokenMembership} from './jwt.js';
 import {hashPassword, verifyPassword} from './password.js';
 import type {SignupPolicy} from './ports.js';
 import {createEnvironmentSignupPolicy} from './signup-policy.js';
@@ -95,21 +95,30 @@ function recordRefreshOutcome(outcome: AuthTokenRefreshOutcome): void {
   recordTokenRefreshed(outcome);
 }
 
-async function signAccessToken(
-  user: User,
+type TokenMemberships = TokenMembership[];
+
+async function loadTokenMemberships(
+  userId: string,
   workspaces: WorkspacesInterModuleClient,
-  refreshSessionId: string,
-): Promise<string> {
+): Promise<TokenMemberships> {
   const memberships = await workspaces
-    .listMembershipsForTokenClaims({userId: user.id})
+    .listMembershipsForTokenClaims({userId})
     .catch((error: unknown) => {
       throw new AuthDependencyUnavailableError('workspaces', error);
     });
+  return memberships.memberships;
+}
+
+async function signAccessToken(
+  user: User,
+  memberships: TokenMemberships,
+  refreshSessionId: string,
+): Promise<string> {
   return await signUserToken({
     userId: user.id,
     email: user.email,
     name: user.name,
-    memberships: memberships.memberships,
+    memberships,
     refreshSessionId,
     secret: userAccessTokenKey(),
     expiresIn: config.AUTH_JWT_EXPIRES_IN,
@@ -142,7 +151,8 @@ async function createSessionTokens(
   workspaces: WorkspacesInterModuleClient,
 ): Promise<{token: string; refreshToken: string; adminRole: AdminRole | null}> {
   const refreshSessionId = crypto.randomUUID();
-  const token = await signAccessToken(user, workspaces, refreshSessionId);
+  const memberships = await loadTokenMemberships(user.id, workspaces);
+  const token = await signAccessToken(user, memberships, refreshSessionId);
   const adminRole = await getCurrentAdminRole({userId: user.id});
   const {refreshToken} = await createRefreshSession(user, refreshSessionId);
   return {token, refreshToken, adminRole};
@@ -335,7 +345,7 @@ export async function signupWithInvitation(
     }
   }
 
-  // Step 4: Issue session. signAccessToken reads memberships through the
+  // Step 4: Issue session. createSessionTokens reads memberships through the
   // workspaces module API, so a successful accept is reflected in the JWT.
   const {token, refreshToken, adminRole} = await createSessionTokens(user, params.workspaces);
 
@@ -479,7 +489,8 @@ export async function refreshAccessToken(params: {
   // second tab); past it, reuse of a retired token means a compromised session.
   if (current.rotatedAt) {
     if (isWithinRotationGrace(current)) {
-      const token = await signAccessToken(user, params.workspaces, current.sessionId);
+      const memberships = await loadTokenMemberships(user.id, params.workspaces);
+      const token = await signAccessToken(user, memberships, current.sessionId);
       recordRefreshOutcome('grace');
       return {token, refreshToken: undefined, user, adminRole};
     }
@@ -487,6 +498,10 @@ export async function refreshAccessToken(params: {
     recordRefreshOutcome('rejected');
     throw new TokenInvalidError('Refresh token reused after rotation');
   }
+
+  // Keep the external membership snapshot ahead of rotation so an outage
+  // cannot retire a refresh token that the caller can still retry.
+  const memberships = await loadTokenMemberships(user.id, params.workspaces);
 
   // Losing the CAS requires a state check: another request may have rotated,
   // revoked, or expired the token before this refresh could claim it.
@@ -509,12 +524,12 @@ export async function refreshAccessToken(params: {
       recordRefreshOutcome('rejected');
       throw new TokenInvalidError('Refresh token is invalid or expired');
     }
-    const token = await signAccessToken(user, params.workspaces, latest.sessionId);
+    const token = await signAccessToken(user, memberships, latest.sessionId);
     recordRefreshOutcome('grace');
     return {token, refreshToken: undefined, user, adminRole};
   }
 
-  const token = await signAccessToken(user, params.workspaces, current.sessionId);
+  const token = await signAccessToken(user, memberships, current.sessionId);
   recordRefreshOutcome('rotated');
   return {token, refreshToken: nextRefreshToken, user, adminRole};
 }

--- a/libs/api/auth/src/core/jwt.test.ts
+++ b/libs/api/auth/src/core/jwt.test.ts
@@ -12,8 +12,8 @@ describe('jwt', () => {
     const userId = crypto.randomUUID();
     const email = `jwt-${crypto.randomUUID()}@example.com`;
     const memberships: TokenMembership[] = [
-      {workspaceId: crypto.randomUUID(), role: 'admin'},
-      {workspaceId: crypto.randomUUID(), role: 'admin'},
+      {workspaceId: crypto.randomUUID(), role: 'admin', workspaceStatus: 'active'},
+      {workspaceId: crypto.randomUUID(), role: 'admin', workspaceStatus: 'suspended'},
     ];
 
     const token = await signUserToken({
@@ -140,7 +140,7 @@ describe('jwt', () => {
   test('rejects a token with non-UUID workspaceId in memberships', async () => {
     const token = await new SignJWT({
       email: `jwt-${crypto.randomUUID()}@example.com`,
-      memberships: [{workspaceId: 'not-a-uuid', role: 'admin'}],
+      memberships: [{workspaceId: 'not-a-uuid', role: 'admin', workspaceStatus: 'active'}],
     })
       .setProtectedHeader({alg: 'HS256'})
       .setSubject(crypto.randomUUID())
@@ -151,10 +151,26 @@ describe('jwt', () => {
     await expect(verifyUserToken({token, secret: SECRET})).rejects.toThrow();
   });
 
+  test('accepts legacy tokens with missing workspace status as active', async () => {
+    const token = await new SignJWT({
+      email: `jwt-${crypto.randomUUID()}@example.com`,
+      memberships: [{workspaceId: crypto.randomUUID(), role: 'admin'}],
+    })
+      .setProtectedHeader({alg: 'HS256'})
+      .setSubject(crypto.randomUUID())
+      .setIssuedAt()
+      .setExpirationTime('7d')
+      .sign(encodeSecret(SECRET));
+
+    await expect(verifyUserToken({token, secret: SECRET})).resolves.toMatchObject({
+      memberships: [{workspaceId: expect.any(String), role: 'admin', workspaceStatus: 'active'}],
+    });
+  });
+
   test('rejects a token with unknown role value', async () => {
     const token = await new SignJWT({
       email: `jwt-${crypto.randomUUID()}@example.com`,
-      memberships: [{workspaceId: crypto.randomUUID(), role: 'owner'}],
+      memberships: [{workspaceId: crypto.randomUUID(), role: 'owner', workspaceStatus: 'active'}],
     })
       .setProtectedHeader({alg: 'HS256'})
       .setSubject(crypto.randomUUID())

--- a/libs/api/auth/src/core/jwt.ts
+++ b/libs/api/auth/src/core/jwt.ts
@@ -1,4 +1,4 @@
-import {workspaceRoleSchema} from '@shipfox/api-workspaces-dto';
+import {workspaceRoleSchema, workspaceStatusSchema} from '@shipfox/api-workspaces-dto';
 import {signHs256, verifyHs256} from '@shipfox/node-jwt';
 import {z} from 'zod';
 import {recordTokenIssued, recordTokenVerified} from '#metrics/index.js';
@@ -6,6 +6,7 @@ import {recordTokenIssued, recordTokenVerified} from '#metrics/index.js';
 export const tokenMembershipSchema = z.object({
   workspaceId: z.string().uuid(),
   role: workspaceRoleSchema,
+  workspaceStatus: workspaceStatusSchema.default('active'),
 });
 
 export type TokenMembership = z.infer<typeof tokenMembershipSchema>;

--- a/libs/api/auth/src/db/refresh-tokens.test.ts
+++ b/libs/api/auth/src/db/refresh-tokens.test.ts
@@ -1,7 +1,6 @@
 import {hashOpaqueToken} from '@shipfox/node-tokens';
 import {
   createRefreshToken,
-  findActiveRefreshSession,
   findActiveRefreshTokenByHash,
   findRefreshTokenByHash,
   revokeRefreshSession,
@@ -43,24 +42,6 @@ describe('refresh-tokens db', () => {
     const found = await findActiveRefreshTokenByHash({hashedToken});
 
     expect(found).toBeUndefined();
-  });
-
-  test('finds only the active session owned by the requested user', async () => {
-    const user = await createUser({email: emailFor('rt-session'), hashedPassword: 'h'});
-    const otherUser = await createUser({email: emailFor('rt-session-other'), hashedPassword: 'h'});
-    const sessionId = crypto.randomUUID();
-    await createRefreshToken({
-      userId: user.id,
-      sessionId,
-      hashedToken: hashOpaqueToken(`active-${crypto.randomUUID()}`),
-      expiresAt: new Date(Date.now() + 60_000),
-    });
-
-    const found = await findActiveRefreshSession({sessionId, userId: user.id});
-    const otherUserFound = await findActiveRefreshSession({sessionId, userId: otherUser.id});
-
-    expect(found?.sessionId).toBe(sessionId);
-    expect(otherUserFound).toBeUndefined();
   });
 
   test('rotates a token once, creates the successor, and only the first caller wins', async () => {

--- a/libs/api/auth/src/db/refresh-tokens.ts
+++ b/libs/api/auth/src/db/refresh-tokens.ts
@@ -87,29 +87,6 @@ export async function findActiveRefreshTokenByHash(params: {
   return toRefreshToken(row);
 }
 
-export async function findActiveRefreshSession(params: {
-  sessionId: string;
-  userId: string;
-}): Promise<RefreshToken | undefined> {
-  const rows = await db()
-    .select()
-    .from(refreshTokens)
-    .where(
-      and(
-        eq(refreshTokens.sessionId, params.sessionId),
-        eq(refreshTokens.userId, params.userId),
-        isNull(refreshTokens.revokedAt),
-        isNull(refreshTokens.rotatedAt),
-        gt(refreshTokens.expiresAt, sql`now()`),
-      ),
-    )
-    .limit(1);
-
-  const row = rows[0];
-  if (!row) return undefined;
-  return toRefreshToken(row);
-}
-
 /**
  * Looks up a non-revoked, non-expired token by hash, including ones already
  * rotated. Rotation reads {@link RefreshToken.rotatedAt} to decide whether to

--- a/libs/api/auth/src/presentation/auth/jwt-auth.test.ts
+++ b/libs/api/auth/src/presentation/auth/jwt-auth.test.ts
@@ -9,7 +9,7 @@ import {
   revokeRefreshTokenByHash,
   rotateRefreshToken,
 } from '#db/refresh-tokens.js';
-import {createUser, findUserById} from '#db/users.js';
+import {createUser} from '#db/users.js';
 import {createJwtAuthMethod, getAuthenticatedSessionContext, getClientContext} from './jwt-auth.js';
 
 const SECRET = userAccessTokenKey();
@@ -138,7 +138,35 @@ describe('jwt-auth', () => {
     expect(res.json().client.email).toBe(email);
   });
 
-  test('resolves the active refresh-session identity from an authenticated request', async () => {
+  test('verifies a token from claims when its user and refresh session are missing', async () => {
+    const userId = crypto.randomUUID();
+    const refreshSessionId = crypto.randomUUID();
+    const token = await signUserToken({
+      userId,
+      email: emailFor('jwt-missing-user'),
+      memberships: [],
+      refreshSessionId,
+      secret: SECRET,
+      expiresIn: '7d',
+    });
+
+    const protectedResponse = await app.inject({
+      method: 'GET',
+      url: '/protected',
+      headers: {authorization: `Bearer ${token}`},
+    });
+    const sessionResponse = await app.inject({
+      method: 'GET',
+      url: '/session',
+      headers: {authorization: `Bearer ${token}`},
+    });
+
+    expect(protectedResponse.statusCode).toBe(200);
+    expect(sessionResponse.statusCode).toBe(200);
+    expect(sessionResponse.json()).toEqual({userId, refreshSessionId});
+  });
+
+  test('returns the refresh-session identity from an authenticated request', async () => {
     const user = await createUser({email: emailFor('jwt-session'), hashedPassword: 'h'});
     const rawRefreshToken = `refresh-${crypto.randomUUID()}`;
     const refreshToken = await createRefreshToken({
@@ -186,7 +214,7 @@ describe('jwt-auth', () => {
     expect(refreshed.json()).toEqual(initial.json());
   });
 
-  test('rejects an authenticated token after its refresh session is revoked', async () => {
+  test('keeps an authenticated token valid after its refresh session is revoked', async () => {
     const user = await createUser({email: emailFor('jwt-session-revoked'), hashedPassword: 'h'});
     const rawRefreshToken = `refresh-${crypto.randomUUID()}`;
     const refreshToken = await createRefreshToken({
@@ -210,7 +238,8 @@ describe('jwt-auth', () => {
       headers: {authorization: `Bearer ${token}`},
     });
 
-    expect(res.statusCode).toBe(401);
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({userId: user.id, refreshSessionId: refreshToken.sessionId});
   });
 
   test('rejects an authenticated token without a refresh-session claim', async () => {
@@ -230,9 +259,5 @@ describe('jwt-auth', () => {
     });
 
     expect(res.statusCode).toBe(401);
-  });
-
-  test('helpers remain available', () => {
-    expect(typeof findUserById).toBe('function');
   });
 });

--- a/libs/api/auth/src/presentation/auth/jwt-auth.ts
+++ b/libs/api/auth/src/presentation/auth/jwt-auth.ts
@@ -12,8 +12,6 @@ import type {RefreshToken} from '#core/entities/refresh-token.js';
 import type {User} from '#core/entities/user.js';
 import type {UserTokenClaims} from '#core/jwt.js';
 import {verifyUserToken} from '#core/jwt.js';
-import {findActiveRefreshSession} from '#db/refresh-tokens.js';
-import {findUserById} from '#db/users.js';
 import {createBearerTokenAuthMethod} from './bearer-token-auth.js';
 
 const AUTHENTICATED_SESSION_CONTEXT_KEY = Symbol.for('@shipfox/api-auth/session');
@@ -61,10 +59,7 @@ function getAuthenticatedSessionTokenContext(request: FastifyRequest): {
   );
 }
 
-/**
- * Resolves the active refresh session backing an authenticated user request.
- * The session check intentionally happens only for consumers that need browser-session binding.
- */
+/** Returns the refresh-session metadata carried by a verified access token. */
 export async function getAuthenticatedSessionContext(
   request: FastifyRequest,
 ): Promise<AuthenticatedSessionContext> {
@@ -73,13 +68,7 @@ export async function getAuthenticatedSessionContext(
   if (!client || !token || token.userId !== client.userId || !token.refreshSessionId)
     throw new ClientError('Invalid or expired token', 'unauthorized', {status: 401});
 
-  const session = await findActiveRefreshSession({
-    sessionId: token.refreshSessionId,
-    userId: client.userId,
-  });
-  if (!session) throw new ClientError('Invalid or expired token', 'unauthorized', {status: 401});
-
-  return {userId: client.userId, refreshSessionId: session.sessionId};
+  return await Promise.resolve({userId: client.userId, refreshSessionId: token.refreshSessionId});
 }
 
 export function createJwtAuthMethod(): AuthMethod {
@@ -92,19 +81,7 @@ export function createJwtAuthMethod(): AuthMethod {
       } catch {
         throw new InvalidJwtTokenError();
       }
-      const user = await findUserById({id: claims.sub});
-
-      // Legacy access tokens without a session claim remain verifiable for the
-      // migration window; known suspended or deleted users are still rejected.
-      if (user && user.status !== 'active') return null;
-      if (!claims.refreshSessionId) return claims;
-      if (!user) return null;
-
-      const session = await findActiveRefreshSession({
-        sessionId: claims.refreshSessionId,
-        userId: claims.sub,
-      });
-      return session ? claims : null;
+      return claims;
     },
     isInvalidTokenError: (error) => error instanceof InvalidJwtTokenError,
     invalidTokenError: {message: 'Invalid or expired token', code: 'unauthorized'},

--- a/libs/api/auth/src/presentation/routes/administration.test.ts
+++ b/libs/api/auth/src/presentation/routes/administration.test.ts
@@ -723,7 +723,8 @@ describe('Auth administration routes', () => {
       headers: {authorization: `Bearer ${target.token}`},
     });
     const suspendedLogin = await login(app, {email: target.email, password: target.password});
-    expect(suspendedMe.statusCode).toBe(401);
+    expect(suspendedMe.statusCode).toBe(200);
+    expect(suspendedMe.json().user).toMatchObject({id: target.userId, status: 'suspended'});
     expect(suspendedLogin.statusCode).toBe(401);
 
     const suspendedDbUser = (
@@ -840,6 +841,13 @@ describe('Auth administration routes', () => {
       payload: {},
     });
     expect(secondRefresh.statusCode).toBe(401);
+
+    const revokedAccess = await app.inject({
+      method: 'GET',
+      url: '/auth/me',
+      headers: {authorization: `Bearer ${newLogin.json().token}`},
+    });
+    expect(revokedAccess.statusCode).toBe(200);
 
     const repeatedRevoke = await app.inject({
       method: 'POST',

--- a/libs/api/auth/src/presentation/routes/password/change-password.test.ts
+++ b/libs/api/auth/src/presentation/routes/password/change-password.test.ts
@@ -48,6 +48,11 @@ describe('POST /auth/change-password', () => {
       headers: {cookie: cookieHeader(account.refreshCookie)},
       payload: {},
     });
+    const access = await app.inject({
+      method: 'GET',
+      url: '/auth/me',
+      headers: {authorization: `Bearer ${account.token}`},
+    });
     const oldPasswordValid = await verifyPassword({
       password: account.password,
       hash: updatedUser?.hashedPassword ?? '',
@@ -62,6 +67,7 @@ describe('POST /auth/change-password', () => {
     expect(oldPasswordValid).toBe(false);
     expect(newPasswordValid).toBe(true);
     expect(refresh.statusCode).toBe(200);
+    expect(access.statusCode).toBe(200);
   });
 
   test('transforms invalid current password into 401', async () => {

--- a/libs/api/auth/src/presentation/routes/password/password-reset-confirm.test.ts
+++ b/libs/api/auth/src/presentation/routes/password/password-reset-confirm.test.ts
@@ -1,6 +1,7 @@
 import {AUTH_PASSWORD_RESET_SEND_REQUESTED} from '@shipfox/api-auth-dto';
 import type {FastifyInstance} from 'fastify';
 import {
+  cookieHeader,
   createAuthTestApp,
   extractToken,
   getSetCookie,
@@ -42,12 +43,25 @@ describe('POST /auth/password-reset/confirm', () => {
       payload: {token: resetToken, new_password: 'reset password is long'},
     });
     const loginRes = await login(app, {email: account.email, password: 'reset password is long'});
+    const oldRefresh = await app.inject({
+      method: 'POST',
+      url: '/auth/refresh',
+      headers: {cookie: cookieHeader(account.refreshCookie)},
+      payload: {},
+    });
+    const oldAccess = await app.inject({
+      method: 'GET',
+      url: '/auth/me',
+      headers: {authorization: `Bearer ${account.token}`},
+    });
 
     expect(confirm.statusCode).toBe(200);
     expect(confirm.json().token).toBeDefined();
     expect(confirm.json().user.email).toBe(account.email);
     expect(getSetCookie(confirm)).toContain('shipfox_refresh_token=');
     expect(loginRes.statusCode).toBe(200);
+    expect(oldRefresh.statusCode).toBe(401);
+    expect(oldAccess.statusCode).toBe(200);
   });
 
   test('transforms invalid token into 410', async () => {

--- a/libs/api/auth/src/presentation/routes/registration/signup.test.ts
+++ b/libs/api/auth/src/presentation/routes/registration/signup.test.ts
@@ -165,7 +165,7 @@ describe('POST /auth/signup', () => {
       alreadyMember: false,
     }));
     listMembershipsByUserMock.mockResolvedValueOnce({
-      memberships: [{workspaceId, role: 'admin' as const}],
+      memberships: [{workspaceId, role: 'admin' as const, workspaceStatus: 'active'}],
     });
     const res = await app.inject({
       method: 'POST',
@@ -190,7 +190,7 @@ describe('POST /auth/signup', () => {
       workspace_id: workspaceId,
     });
     expect(body.accept_error).toBeUndefined();
-    expect(claims.memberships).toEqual([{workspaceId, role: 'admin'}]);
+    expect(claims.memberships).toEqual([{workspaceId, role: 'admin', workspaceStatus: 'active'}]);
     expect(capturedMail()).toHaveLength(0);
   });
 

--- a/libs/api/auth/src/presentation/routes/session/logout.test.ts
+++ b/libs/api/auth/src/presentation/routes/session/logout.test.ts
@@ -36,10 +36,16 @@ describe('POST /auth/logout', () => {
       headers: {cookie: cookieHeader(account.refreshCookie)},
       payload: {},
     });
+    const access = await app.inject({
+      method: 'GET',
+      url: '/auth/me',
+      headers: {authorization: `Bearer ${account.token}`},
+    });
 
     expect(res.statusCode).toBe(204);
     expect(res.headers['set-cookie']).toContain('shipfox_refresh_token=;');
     expect(refresh.statusCode).toBe(401);
+    expect(access.statusCode).toBe(200);
   });
 
   test('returns 204 when the refresh cookie is missing', async () => {

--- a/libs/api/auth/src/presentation/routes/session/refresh.test.ts
+++ b/libs/api/auth/src/presentation/routes/session/refresh.test.ts
@@ -85,5 +85,16 @@ describe('POST /auth/refresh', () => {
 
     expect(res.statusCode).toBe(503);
     expect(res.json().code).toBe('auth-dependency-unavailable');
+    expect(res.headers['set-cookie']).toBeUndefined();
+
+    const retry = await app.inject({
+      method: 'POST',
+      url: '/auth/refresh',
+      headers: {cookie: cookieHeader(account.refreshCookie)},
+    });
+
+    expect(retry.statusCode).toBe(200);
+    expect(retry.json().token).toBeDefined();
+    expect(retry.headers['set-cookie']).toContain('shipfox_refresh_token=');
   });
 });

--- a/libs/api/definitions/src/presentation/routes/create-definition.test.ts
+++ b/libs/api/definitions/src/presentation/routes/create-definition.test.ts
@@ -27,7 +27,7 @@ describe('POST /api/definitions', () => {
         buildUserContext({
           userId: crypto.randomUUID(),
           email: 'user@example.com',
-          memberships: [{workspaceId, role: 'admin'}],
+          memberships: [{workspaceId, role: 'admin', workspaceStatus: 'active'}],
         }),
       );
       done();
@@ -92,7 +92,7 @@ jobs:
         buildUserContext({
           userId: crypto.randomUUID(),
           email: 'user@example.com',
-          memberships: [{workspaceId, role: 'admin'}],
+          memberships: [{workspaceId, role: 'admin', workspaceStatus: 'active'}],
         }),
       );
       done();
@@ -165,7 +165,7 @@ jobs:
         buildUserContext({
           userId: crypto.randomUUID(),
           email: 'user@example.com',
-          memberships: [{workspaceId, role: 'admin'}],
+          memberships: [{workspaceId, role: 'admin', workspaceStatus: 'active'}],
         }),
       );
       done();

--- a/libs/api/definitions/src/presentation/routes/get-definition.test.ts
+++ b/libs/api/definitions/src/presentation/routes/get-definition.test.ts
@@ -37,7 +37,7 @@ describe('GET /api/definitions/:id', () => {
         buildUserContext({
           userId: crypto.randomUUID(),
           email: 'user@example.com',
-          memberships: [{workspaceId, role: 'admin'}],
+          memberships: [{workspaceId, role: 'admin', workspaceStatus: 'active'}],
         }),
       );
       done();

--- a/libs/api/definitions/src/presentation/routes/list-definitions.test.ts
+++ b/libs/api/definitions/src/presentation/routes/list-definitions.test.ts
@@ -46,7 +46,7 @@ describe('GET /api/definitions', () => {
         buildUserContext({
           userId: crypto.randomUUID(),
           email: 'user@example.com',
-          memberships: [{workspaceId, role: 'admin'}],
+          memberships: [{workspaceId, role: 'admin', workspaceStatus: 'active'}],
         }),
       );
       done();

--- a/libs/api/integration/core/test/route-utils.ts
+++ b/libs/api/integration/core/test/route-utils.ts
@@ -89,7 +89,7 @@ export function useIntegrationRouteTest() {
   beforeEach(async () => {
     await closeApp();
     workspaceId = crypto.randomUUID();
-    authenticatedMemberships = [{workspaceId, role: 'admin'}];
+    authenticatedMemberships = [{workspaceId, role: 'admin', workspaceStatus: 'active'}];
   });
 
   afterEach(async () => {

--- a/libs/api/integration/gitea/src/presentation/routes/connections.test.ts
+++ b/libs/api/integration/gitea/src/presentation/routes/connections.test.ts
@@ -116,7 +116,7 @@ describe('Gitea connection routes', () => {
   it('connects an org and returns the connection DTO', async () => {
     const app = await createTestApp();
     const workspaceId = crypto.randomUUID();
-    authenticatedMemberships = [{workspaceId, role: 'admin'}];
+    authenticatedMemberships = [{workspaceId, role: 'admin', workspaceStatus: 'active'}];
 
     const res = await app.inject({
       method: 'POST',
@@ -137,7 +137,7 @@ describe('Gitea connection routes', () => {
       gitea: giteaClient({organizationExists: vi.fn(() => Promise.resolve(false))}),
     });
     const workspaceId = crypto.randomUUID();
-    authenticatedMemberships = [{workspaceId, role: 'admin'}];
+    authenticatedMemberships = [{workspaceId, role: 'admin', workspaceStatus: 'active'}];
 
     const res = await app.inject({
       method: 'POST',
@@ -152,7 +152,7 @@ describe('Gitea connection routes', () => {
 
   it('returns 409 when the org is already linked to another workspace', async () => {
     const workspaceId = crypto.randomUUID();
-    authenticatedMemberships = [{workspaceId, role: 'admin'}];
+    authenticatedMemberships = [{workspaceId, role: 'admin', workspaceStatus: 'active'}];
     const app = await createTestApp({
       existingConnection: {
         id: crypto.randomUUID(),
@@ -180,7 +180,7 @@ describe('Gitea connection routes', () => {
 
   it('returns 409 when connection slug allocation conflicts repeatedly', async () => {
     const workspaceId = crypto.randomUUID();
-    authenticatedMemberships = [{workspaceId, role: 'admin'}];
+    authenticatedMemberships = [{workspaceId, role: 'admin', workspaceStatus: 'active'}];
     const app = await createTestApp({
       connectGiteaConnection: vi.fn(() =>
         Promise.reject(new ConnectionSlugConflictError(new Error('duplicate slug'))),

--- a/libs/api/integration/github/src/presentation/routes/install.test.ts
+++ b/libs/api/integration/github/src/presentation/routes/install.test.ts
@@ -142,7 +142,7 @@ describe('GitHub integration routes', () => {
   it('returns an install URL with signed workspace state', async () => {
     const app = await createTestApp();
     const workspaceId = crypto.randomUUID();
-    authenticatedMemberships = [{workspaceId, role: 'admin'}];
+    authenticatedMemberships = [{workspaceId, role: 'admin', workspaceStatus: 'active'}];
 
     const res = await app.inject({
       method: 'POST',
@@ -191,7 +191,7 @@ describe('GitHub integration routes', () => {
     expect(requireWorkspaceMembershipMock).toHaveBeenCalledWith({
       workspaceId,
       userId: 'user-1',
-      memberships: [{workspaceId, role: 'admin'}],
+      memberships: [{workspaceId, role: 'admin', workspaceStatus: 'active'}],
     });
   });
 
@@ -261,7 +261,7 @@ describe('GitHub integration routes', () => {
 });
 
 async function createInstallState(app: FastifyInstance, workspaceId: string): Promise<string> {
-  authenticatedMemberships = [{workspaceId, role: 'admin'}];
+  authenticatedMemberships = [{workspaceId, role: 'admin', workspaceStatus: 'active'}];
   const res = await app.inject({
     method: 'POST',
     url: '/integrations/github/install',

--- a/libs/api/integration/linear/src/presentation/routes/install.test.ts
+++ b/libs/api/integration/linear/src/presentation/routes/install.test.ts
@@ -141,7 +141,7 @@ describe('Linear integration routes', () => {
   it('returns an actor=app OAuth URL with signed workspace state', async () => {
     const app = await createTestApp();
     const workspaceId = crypto.randomUUID();
-    authenticatedMemberships = [{workspaceId, role: 'admin'}];
+    authenticatedMemberships = [{workspaceId, role: 'admin', workspaceStatus: 'active'}];
 
     const res = await app.inject({
       method: 'POST',
@@ -216,7 +216,7 @@ describe('Linear integration routes', () => {
     expect(requireWorkspaceMembershipMock).toHaveBeenCalledWith({
       workspaceId,
       userId: 'user-1',
-      memberships: [{workspaceId, role: 'admin'}],
+      memberships: [{workspaceId, role: 'admin', workspaceStatus: 'active'}],
     });
   });
 
@@ -272,7 +272,7 @@ describe('Linear integration routes', () => {
     expect(requireWorkspaceMembershipMock).toHaveBeenCalledWith({
       workspaceId,
       userId: 'user-1',
-      memberships: [{workspaceId, role: 'admin'}],
+      memberships: [{workspaceId, role: 'admin', workspaceStatus: 'active'}],
     });
   });
 
@@ -442,7 +442,7 @@ describe('Linear integration routes', () => {
 });
 
 async function createInstallState(app: FastifyInstance, workspaceId: string): Promise<string> {
-  authenticatedMemberships = [{workspaceId, role: 'admin'}];
+  authenticatedMemberships = [{workspaceId, role: 'admin', workspaceStatus: 'active'}];
   const res = await app.inject({
     method: 'POST',
     url: '/integrations/linear/install',

--- a/libs/api/integration/sentry/src/presentation/routes/install.test.ts
+++ b/libs/api/integration/sentry/src/presentation/routes/install.test.ts
@@ -109,7 +109,7 @@ async function createTestApp(options: CreateTestAppOptions = {}): Promise<Fastif
 function connectPayload(options: {authorize?: boolean} = {}) {
   const workspaceId = crypto.randomUUID();
   if (options.authorize !== false) {
-    authenticatedMemberships = [{workspaceId, role: 'admin'}];
+    authenticatedMemberships = [{workspaceId, role: 'admin', workspaceStatus: 'active'}];
   }
   return {
     workspace_id: workspaceId,
@@ -143,7 +143,7 @@ describe('Sentry integration routes', () => {
   it('returns the external-install URL for a member', async () => {
     const app = await createTestApp();
     const workspaceId = crypto.randomUUID();
-    authenticatedMemberships = [{workspaceId, role: 'admin'}];
+    authenticatedMemberships = [{workspaceId, role: 'admin', workspaceStatus: 'active'}];
 
     const res = await app.inject({
       method: 'POST',

--- a/libs/api/integration/slack/src/core/install.test.ts
+++ b/libs/api/integration/slack/src/core/install.test.ts
@@ -62,7 +62,11 @@ function callbackParams(
     }),
     sessionUserId: 'user-1',
     sessionMemberships: [
-      {workspaceId: '00000000-0000-4000-8000-000000000002', role: 'admin'},
+      {
+        workspaceId: '00000000-0000-4000-8000-000000000002',
+        role: 'admin',
+        workspaceStatus: 'active',
+      },
     ] satisfies UserContextMembership[],
     requireWorkspaceMembership: vi.fn(() => Promise.resolve()),
     getExistingSlackConnection: vi.fn(() => Promise.resolve(undefined)),

--- a/libs/api/integration/slack/src/presentation/routes/install.test.ts
+++ b/libs/api/integration/slack/src/presentation/routes/install.test.ts
@@ -123,7 +123,7 @@ describe('Slack integration routes', () => {
   it('returns Slack’s bot-only OAuth URL with signed workspace state', async () => {
     const app = await createTestApp();
     const workspaceId = '00000000-0000-4000-8000-000000000002';
-    authenticatedMemberships = [{workspaceId, role: 'admin'}];
+    authenticatedMemberships = [{workspaceId, role: 'admin', workspaceStatus: 'active'}];
 
     const res = await app.inject({
       method: 'POST',
@@ -172,7 +172,7 @@ describe('Slack integration routes', () => {
     const tokenStore = {storeTokens: vi.fn(() => Promise.resolve())};
     const app = await createTestApp({tokenStore, agentTools});
     const workspaceId = '00000000-0000-4000-8000-000000000002';
-    authenticatedMemberships = [{workspaceId, role: 'admin'}];
+    authenticatedMemberships = [{workspaceId, role: 'admin', workspaceStatus: 'active'}];
     const install = await app.inject({
       method: 'POST',
       url: '/integrations/slack/install',
@@ -205,7 +205,7 @@ describe('Slack integration routes', () => {
     });
     const app = await createTestApp({slack, tokenStore});
     const workspaceId = '00000000-0000-4000-8000-000000000002';
-    authenticatedMemberships = [{workspaceId, role: 'admin'}];
+    authenticatedMemberships = [{workspaceId, role: 'admin', workspaceStatus: 'active'}];
     const install = await app.inject({
       method: 'POST',
       url: '/integrations/slack/install',

--- a/libs/api/integration/webhook/src/presentation/routes/connections.test.ts
+++ b/libs/api/integration/webhook/src/presentation/routes/connections.test.ts
@@ -26,7 +26,7 @@ const INBOUND_URL_RE = /^https:\/\/api\.example\.com\/webhook\//;
 let authenticatedMemberships: UserContextMembership[] = [];
 
 function authorizeWorkspace(workspaceId: string): void {
-  authenticatedMemberships = [{workspaceId, role: 'admin'}];
+  authenticatedMemberships = [{workspaceId, role: 'admin', workspaceStatus: 'active'}];
 }
 
 const fakeUserAuth: AuthMethod = {

--- a/libs/api/logs/src/presentation/routes/read-logs.test.ts
+++ b/libs/api/logs/src/presentation/routes/read-logs.test.ts
@@ -50,13 +50,15 @@ const fakeUserAuth: AuthMethod = {
       throw new ClientError('Invalid user token', 'unauthorized', {status: 401});
     }
     const header = request.headers['x-test-workspace'];
-    const workspaceId = Array.isArray(header) ? header[0] : header;
+    const value = Array.isArray(header) ? header[0] : header;
+    const [workspaceId, status] = value?.split('|') ?? [];
+    const workspaceStatus = status === 'suspended' || status === 'deleted' ? status : 'active';
     setUserContext(
       request,
       buildUserContext({
         userId: 'user-1',
         email: 'user@example.com',
-        memberships: workspaceId ? [{workspaceId, role: 'admin'}] : [],
+        memberships: workspaceId ? [{workspaceId, role: 'admin', workspaceStatus}] : [],
       }),
     );
     return Promise.resolve();
@@ -174,11 +176,11 @@ describe('GET /steps/:stepId/attempts/:attempt/logs', () => {
     return `/steps/${stepId}/attempts/${attempt}/logs?cursor=${cursor}`;
   }
 
-  function authedGet(stream: AttemptStream, cursor: number, workspaceId = stream.workspaceId) {
+  function authedGet(stream: AttemptStream, cursor: number, workspaceClaim = stream.workspaceId) {
     return app.inject({
       method: 'GET',
       url: readUrl(stream.stepId, stream.attempt, cursor),
-      headers: {authorization: 'Bearer user', 'x-test-workspace': workspaceId},
+      headers: {authorization: 'Bearer user', 'x-test-workspace': workspaceClaim},
     });
   }
 
@@ -286,6 +288,18 @@ describe('GET /steps/:stepId/attempts/:attempt/logs', () => {
 
     expect(res.statusCode).toBe(404);
     expect(res.json().code).toBe('not-found');
+  });
+
+  it('returns workspace-suspended for a suspended membership claim', async () => {
+    const stream = await arrangeStream({
+      workspaceId: crypto.randomUUID(),
+      chunks: [ndjsonBody(outputLine('secret\n'))],
+    });
+
+    const res = await authedGet(stream, 0, `${stream.workspaceId}|suspended`);
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('workspace-suspended');
   });
 
   it('serves an open stream inline with the next cursor and stream state', async () => {

--- a/libs/api/logs/src/presentation/routes/read-logs.ts
+++ b/libs/api/logs/src/presentation/routes/read-logs.ts
@@ -1,4 +1,4 @@
-import {requireUserContext} from '@shipfox/api-auth-context';
+import {requireWorkspaceResourceAccess} from '@shipfox/api-auth-context';
 import {readLogsQuerySchema, readLogsResponseSchema} from '@shipfox/api-logs-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
@@ -22,16 +22,20 @@ export const readLogsRoute = defineRoute({
     },
   },
   handler: async (request) => {
-    const user = requireUserContext(request);
     const {stepId, attempt} = request.params;
     const {cursor} = request.query;
 
     const stream = await getStreamByStepAttempt({stepId, attempt});
-    // 404 covers both "no such stream" and "not your workspace" so the endpoint never
-    // leaks the existence of another workspace's step.
-    if (!stream || !user.canAccess(stream.workspaceId)) {
+    // Missing streams and memberships remain 404 so the endpoint never leaks another
+    // workspace's step; lifecycle claims propagate their stable access errors.
+    if (!stream) {
       throw new ClientError('Logs not found', 'not-found', {status: 404});
     }
+    requireWorkspaceResourceAccess({
+      request,
+      workspaceId: stream.workspaceId,
+      notFoundError: new ClientError('Logs not found', 'not-found', {status: 404}),
+    });
 
     return toReadLogsDto(await buildLogReadResult(stream, cursor));
   },

--- a/libs/api/projects/src/presentation/routes/projects.test.ts
+++ b/libs/api/projects/src/presentation/routes/projects.test.ts
@@ -49,7 +49,7 @@ describe('project routes', () => {
     await closeApp();
     workspaceId = crypto.randomUUID();
     sourceConnectionId = crypto.randomUUID();
-    authenticatedMemberships = [{workspaceId, role: 'admin'}];
+    authenticatedMemberships = [{workspaceId, role: 'admin', workspaceStatus: 'active'}];
     integrations = {
       resolveSourceRepository: vi.fn(async () => {
         await Promise.resolve();

--- a/libs/api/runners/src/presentation/routes/list-active-runners.test.ts
+++ b/libs/api/runners/src/presentation/routes/list-active-runners.test.ts
@@ -50,7 +50,7 @@ describe('GET /workspaces/:workspaceId/runners/active', () => {
   beforeEach(async () => {
     await closeApp();
     workspaceId = crypto.randomUUID();
-    authenticatedMemberships = [{workspaceId, role: 'admin'}];
+    authenticatedMemberships = [{workspaceId, role: 'admin', workspaceStatus: 'active'}];
     app = await createApp({
       auth: [
         fakeUserAuth,
@@ -353,7 +353,13 @@ describe('GET /workspaces/:workspaceId/runners/active', () => {
   });
 
   it('returns 403 when the user is not a workspace member', async () => {
-    authenticatedMemberships = [{workspaceId: crypto.randomUUID(), role: 'admin'}];
+    authenticatedMemberships = [
+      {
+        workspaceId: crypto.randomUUID(),
+        role: 'admin',
+        workspaceStatus: 'active',
+      },
+    ];
 
     const res = await app.inject({
       method: 'GET',

--- a/libs/api/runners/src/presentation/routes/manual-registration-tokens.test.ts
+++ b/libs/api/runners/src/presentation/routes/manual-registration-tokens.test.ts
@@ -58,7 +58,7 @@ describe('manual registration token routes', () => {
   beforeEach(async () => {
     await closeApp();
     workspaceId = crypto.randomUUID();
-    authenticatedMemberships = [{workspaceId, role: 'admin'}];
+    authenticatedMemberships = [{workspaceId, role: 'admin', workspaceStatus: 'active'}];
     app = await createApp({
       auth: [
         fakeUserAuth,
@@ -109,7 +109,13 @@ describe('manual registration token routes', () => {
     });
 
     it('returns 403 when the user is not a workspace member', async () => {
-      authenticatedMemberships = [{workspaceId: crypto.randomUUID(), role: 'admin'}];
+      authenticatedMemberships = [
+        {
+          workspaceId: crypto.randomUUID(),
+          role: 'admin',
+          workspaceStatus: 'active',
+        },
+      ];
 
       const res = await app.inject({
         method: 'GET',

--- a/libs/api/runners/src/presentation/routes/provisioner-tokens.test.ts
+++ b/libs/api/runners/src/presentation/routes/provisioner-tokens.test.ts
@@ -45,7 +45,7 @@ describe('provisioner token routes', () => {
   beforeEach(async () => {
     await closeApp();
     workspaceId = crypto.randomUUID();
-    authenticatedMemberships = [{workspaceId, role: 'admin'}];
+    authenticatedMemberships = [{workspaceId, role: 'admin', workspaceStatus: 'active'}];
     app = await createApp({
       auth: [fakeUserAuth, createProvisionerTokenAuthMethod()],
       routes: provisionerRoutes,
@@ -74,7 +74,13 @@ describe('provisioner token routes', () => {
     });
 
     it('returns 403 when the user is not a workspace member', async () => {
-      authenticatedMemberships = [{workspaceId: crypto.randomUUID(), role: 'admin'}];
+      authenticatedMemberships = [
+        {
+          workspaceId: crypto.randomUUID(),
+          role: 'admin',
+          workspaceStatus: 'active',
+        },
+      ];
 
       const res = await app.inject({
         method: 'GET',

--- a/libs/api/secrets/src/presentation/routes/management.test.ts
+++ b/libs/api/secrets/src/presentation/routes/management.test.ts
@@ -61,7 +61,7 @@ describe('secrets management routes', () => {
     await closeApp();
     workspaceId = crypto.randomUUID();
     projectId = crypto.randomUUID();
-    authenticatedMemberships = [{workspaceId, role: 'admin'}];
+    authenticatedMemberships = [{workspaceId, role: 'admin', workspaceStatus: 'active'}];
     requireProjectForWorkspace.mockResolvedValue({
       project: {
         id: projectId,
@@ -108,7 +108,13 @@ describe('secrets management routes', () => {
   });
 
   it('requires admin membership for writes', async () => {
-    authenticatedMemberships = [{workspaceId, role: 'viewer' as UserContextMembership['role']}];
+    authenticatedMemberships = [
+      {
+        workspaceId,
+        role: 'viewer' as UserContextMembership['role'],
+        workspaceStatus: 'active',
+      },
+    ];
 
     const res = await app.inject({
       method: 'PUT',

--- a/libs/api/triggers/src/presentation/routes/fire-manual.test.ts
+++ b/libs/api/triggers/src/presentation/routes/fire-manual.test.ts
@@ -22,7 +22,11 @@ const workflows = {} as WorkflowsModuleClient;
 describe('POST /:definitionId/fire-manual', () => {
   let app: FastifyInstance;
   let workspaceId: string;
-  let memberships: Array<{workspaceId: string; role: 'admin'}>;
+  let memberships: Array<{
+    workspaceId: string;
+    role: 'admin';
+    workspaceStatus: 'active' | 'suspended' | 'deleted';
+  }>;
 
   beforeAll(async () => {
     app = Fastify();
@@ -41,7 +45,7 @@ describe('POST /:definitionId/fire-manual', () => {
 
   beforeEach(() => {
     workspaceId = crypto.randomUUID();
-    memberships = [{workspaceId, role: 'admin'}];
+    memberships = [{workspaceId, role: 'admin', workspaceStatus: 'active'}];
     fireManualSubscriptionMock.mockReset();
   });
 
@@ -87,6 +91,22 @@ describe('POST /:definitionId/fire-manual', () => {
         env_key: 'REF',
       },
     });
+  });
+
+  test('returns workspace-suspended for a suspended membership claim', async () => {
+    const definitionId = crypto.randomUUID();
+    await triggerSubscriptionFactory.create({workspaceId, workflowDefinitionId: definitionId});
+    memberships = [{workspaceId, role: 'admin', workspaceStatus: 'suspended'}];
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/${definitionId}/fire-manual`,
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('workspace-suspended');
+    expect(fireManualSubscriptionMock).not.toHaveBeenCalled();
   });
 
   test('maps suspended workspace to 409', async () => {

--- a/libs/api/triggers/src/presentation/routes/fire-manual.ts
+++ b/libs/api/triggers/src/presentation/routes/fire-manual.ts
@@ -1,4 +1,4 @@
-import {requireUserContext} from '@shipfox/api-auth-context';
+import {requireUserContext, requireWorkspaceResourceAccess} from '@shipfox/api-auth-context';
 import {
   fireManualTriggerBodySchema,
   fireManualTriggerResponseSchema,
@@ -81,10 +81,18 @@ export function createFireManualTriggerRoute(workflows: WorkflowsModuleClient) {
       const userContext = requireUserContext(request);
 
       const subscription = await getManualSubscriptionByDefinitionId(definitionId);
-      // 404 covers both "no such manual trigger" and "not your workspace" to avoid leaking existence.
-      if (!subscription || !userContext.canAccess(subscription.workspaceId)) {
+      // Missing triggers and memberships remain 404 to avoid leaking existence; lifecycle claims
+      // propagate their stable access errors.
+      if (!subscription) {
         throw new ManualTriggerNotFoundError(definitionId);
       }
+      requireWorkspaceResourceAccess({
+        request,
+        workspaceId: subscription.workspaceId,
+        notFoundError: new ClientError('Manual trigger not found', 'manual-trigger-not-found', {
+          status: 404,
+        }),
+      });
 
       const run = await fireManualSubscription({
         workflows,

--- a/libs/api/triggers/src/presentation/routes/get-trigger-event.test.ts
+++ b/libs/api/triggers/src/presentation/routes/get-trigger-event.test.ts
@@ -10,7 +10,11 @@ import {getTriggerEventRoute} from './get-trigger-event.js';
 describe('GET /trigger-events/:id', () => {
   let app: FastifyInstance;
   let workspaceId: string;
-  let memberships: Array<{workspaceId: string; role: 'admin'}>;
+  let memberships: Array<{
+    workspaceId: string;
+    role: 'admin';
+    workspaceStatus: 'active' | 'suspended' | 'deleted';
+  }>;
 
   beforeAll(async () => {
     app = Fastify();
@@ -29,7 +33,7 @@ describe('GET /trigger-events/:id', () => {
 
   beforeEach(() => {
     workspaceId = crypto.randomUUID();
-    memberships = [{workspaceId, role: 'admin'}];
+    memberships = [{workspaceId, role: 'admin', workspaceStatus: 'active'}];
   });
 
   test('returns the event with its decisions and full payload', async () => {
@@ -158,6 +162,16 @@ describe('GET /trigger-events/:id', () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.json().decisions).toEqual([]);
+  });
+
+  test('returns workspace-suspended for a suspended membership claim', async () => {
+    const event = await receivedEventFactory.create({workspaceId});
+    memberships = [{workspaceId, role: 'admin', workspaceStatus: 'suspended'}];
+
+    const res = await app.inject({method: 'GET', url: `/trigger-events/${event.id}`});
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('workspace-suspended');
   });
 
   test('returns 404 for an unknown event id', async () => {

--- a/libs/api/triggers/src/presentation/routes/get-trigger-event.ts
+++ b/libs/api/triggers/src/presentation/routes/get-trigger-event.ts
@@ -1,4 +1,4 @@
-import {requireUserContext} from '@shipfox/api-auth-context';
+import {requireWorkspaceResourceAccess} from '@shipfox/api-auth-context';
 import {triggerEventDetailResponseSchema} from '@shipfox/api-triggers-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
@@ -19,13 +19,18 @@ export const getTriggerEventRoute = defineRoute({
   },
   handler: async (request) => {
     const {id} = request.params;
-    const userContext = requireUserContext(request);
 
     const event = await getTriggerEventById(id);
-    // 404 covers both "no such event" and "not your workspace" to avoid leaking existence.
-    if (!event || !userContext.canAccess(event.workspaceId)) {
+    // Missing events and memberships remain 404 to avoid leaking existence; lifecycle claims
+    // propagate their stable access errors.
+    if (!event) {
       throw new ClientError('Trigger event not found', 'not-found', {status: 404});
     }
+    requireWorkspaceResourceAccess({
+      request,
+      workspaceId: event.workspaceId,
+      notFoundError: new ClientError('Trigger event not found', 'not-found', {status: 404}),
+    });
 
     const decisions = await listDecisionsByReceivedEventId(event.id);
 

--- a/libs/api/triggers/src/presentation/routes/list-trigger-event-facets.test.ts
+++ b/libs/api/triggers/src/presentation/routes/list-trigger-event-facets.test.ts
@@ -13,7 +13,11 @@ const facets = (res: {
 describe('GET /trigger-events/facets', () => {
   let app: FastifyInstance;
   let workspaceId: string;
-  let memberships: Array<{workspaceId: string; role: 'admin'}>;
+  let memberships: Array<{
+    workspaceId: string;
+    role: 'admin';
+    workspaceStatus: 'active' | 'suspended' | 'deleted';
+  }>;
 
   beforeAll(async () => {
     app = Fastify();
@@ -32,7 +36,7 @@ describe('GET /trigger-events/facets', () => {
 
   beforeEach(() => {
     workspaceId = crypto.randomUUID();
-    memberships = [{workspaceId, role: 'admin'}];
+    memberships = [{workspaceId, role: 'admin', workspaceStatus: 'active'}];
   });
 
   test('returns distinct sources and events with counts, ordered by count desc', async () => {
@@ -91,6 +95,18 @@ describe('GET /trigger-events/facets', () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual({sources: [], events: []});
+  });
+
+  test('returns workspace-suspended for a suspended membership claim', async () => {
+    memberships = [{workspaceId, role: 'admin', workspaceStatus: 'suspended'}];
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/trigger-events/facets?workspace_id=${workspaceId}`,
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('workspace-suspended');
   });
 
   test('denies a workspace the caller does not belong to', async () => {

--- a/libs/api/triggers/src/presentation/routes/list-trigger-event-facets.ts
+++ b/libs/api/triggers/src/presentation/routes/list-trigger-event-facets.ts
@@ -1,9 +1,9 @@
-import {requireUserContext} from '@shipfox/api-auth-context';
+import {requireWorkspaceAccess} from '@shipfox/api-auth-context';
 import {
   triggerEventFacetsQuerySchema,
   triggerEventFacetsResponseSchema,
 } from '@shipfox/api-triggers-dto';
-import {ClientError, defineRoute} from '@shipfox/node-fastify';
+import {defineRoute} from '@shipfox/node-fastify';
 import {listTriggerEventFacets} from '#db/index.js';
 
 export const listTriggerEventFacetsRoute = defineRoute({
@@ -19,10 +19,7 @@ export const listTriggerEventFacetsRoute = defineRoute({
   handler: async (request) => {
     const {workspace_id: workspaceId} = request.query;
 
-    const userContext = requireUserContext(request);
-    if (!userContext.canAccess(workspaceId)) {
-      throw new ClientError('Not a member of this workspace', 'forbidden', {status: 403});
-    }
+    requireWorkspaceAccess({request, workspaceId});
 
     return await listTriggerEventFacets({workspaceId});
   },

--- a/libs/api/triggers/src/presentation/routes/list-trigger-events.test.ts
+++ b/libs/api/triggers/src/presentation/routes/list-trigger-events.test.ts
@@ -12,7 +12,11 @@ const eventIds = (res: {json: () => {trigger_events: Array<{id: string}>}}) =>
 describe('GET /trigger-events', () => {
   let app: FastifyInstance;
   let workspaceId: string;
-  let memberships: Array<{workspaceId: string; role: 'admin'}>;
+  let memberships: Array<{
+    workspaceId: string;
+    role: 'admin';
+    workspaceStatus: 'active' | 'suspended' | 'deleted';
+  }>;
 
   beforeAll(async () => {
     app = Fastify();
@@ -31,7 +35,7 @@ describe('GET /trigger-events', () => {
 
   beforeEach(() => {
     workspaceId = crypto.randomUUID();
-    memberships = [{workspaceId, role: 'admin'}];
+    memberships = [{workspaceId, role: 'admin', workspaceStatus: 'active'}];
   });
 
   test('returns a workspace events newest first, isolated and payload-free', async () => {
@@ -316,6 +320,18 @@ describe('GET /trigger-events', () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual({trigger_events: [], next_cursor: null});
+  });
+
+  test('returns workspace-suspended for a suspended membership claim', async () => {
+    memberships = [{workspaceId, role: 'admin', workspaceStatus: 'suspended'}];
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/trigger-events?workspace_id=${workspaceId}`,
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('workspace-suspended');
   });
 
   test('denies a workspace the caller does not belong to', async () => {

--- a/libs/api/triggers/src/presentation/routes/list-trigger-events.ts
+++ b/libs/api/triggers/src/presentation/routes/list-trigger-events.ts
@@ -1,4 +1,4 @@
-import {requireUserContext} from '@shipfox/api-auth-context';
+import {requireWorkspaceAccess} from '@shipfox/api-auth-context';
 import {
   triggerEventListQuerySchema,
   triggerEventListResponseSchema,
@@ -30,10 +30,7 @@ export const listTriggerEventsRoute = defineRoute({
       cursor,
     } = request.query;
 
-    const userContext = requireUserContext(request);
-    if (!userContext.canAccess(workspaceId)) {
-      throw new ClientError('Not a member of this workspace', 'forbidden', {status: 403});
-    }
+    requireWorkspaceAccess({request, workspaceId});
 
     const decodedCursor = decodeTimestampIdCursor(cursor);
     if (cursor && !decodedCursor) {

--- a/libs/api/workflows/src/presentation/routes/cancel-run.test.ts
+++ b/libs/api/workflows/src/presentation/routes/cancel-run.test.ts
@@ -34,7 +34,7 @@ describe('POST /api/workflows/runs/:id/cancel', () => {
         buildUserContext({
           userId: crypto.randomUUID(),
           email: 'user@example.com',
-          memberships: [{workspaceId, role: 'admin'}],
+          memberships: [{workspaceId, role: 'admin', workspaceStatus: 'active'}],
         }),
       );
       done();

--- a/libs/api/workflows/src/presentation/routes/get-run-aggregates.test.ts
+++ b/libs/api/workflows/src/presentation/routes/get-run-aggregates.test.ts
@@ -39,7 +39,7 @@ describe('GET /api/workflows/runs/aggregates', () => {
         buildUserContext({
           userId: crypto.randomUUID(),
           email: 'user@example.com',
-          memberships: [{workspaceId, role: 'admin'}],
+          memberships: [{workspaceId, role: 'admin', workspaceStatus: 'active'}],
         }),
       );
       done();

--- a/libs/api/workflows/src/presentation/routes/get-run.test.ts
+++ b/libs/api/workflows/src/presentation/routes/get-run.test.ts
@@ -49,6 +49,7 @@ const projects = {
 describe('GET /api/workflows/runs/:id', () => {
   let app: FastifyInstance;
   let workspaceId: string;
+  let workspaceStatus: 'active' | 'deleted';
 
   beforeAll(async () => {
     app = Fastify();
@@ -60,7 +61,7 @@ describe('GET /api/workflows/runs/:id', () => {
         buildUserContext({
           userId: crypto.randomUUID(),
           email: 'user@example.com',
-          memberships: [{workspaceId, role: 'admin'}],
+          memberships: [{workspaceId, role: 'admin', workspaceStatus}],
         }),
       );
       done();
@@ -71,6 +72,7 @@ describe('GET /api/workflows/runs/:id', () => {
 
   beforeEach(() => {
     workspaceId = crypto.randomUUID();
+    workspaceStatus = 'active';
     projectAccessState.workspaceId = workspaceId;
     getProjectById.mockImplementation(({projectId}) =>
       Promise.resolve({
@@ -366,6 +368,30 @@ jobs:
     expect(res.statusCode).toBe(404);
     expect(res.json().code).toBe('not-found');
     expect(detailSpy).not.toHaveBeenCalled();
+  });
+
+  test('preserves workspace-inactive for a deleted membership claim', async () => {
+    workspaceStatus = 'deleted';
+    const run = await createWorkflowRun({
+      workspaceId,
+      projectId: crypto.randomUUID(),
+      definitionId: crypto.randomUUID(),
+      model: workflowModel({name: 'Test'}),
+      triggerPayload: {
+        source: 'manual',
+        event: 'fire',
+        subscriptionId: crypto.randomUUID(),
+        userId: crypto.randomUUID(),
+      },
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/workflows/runs/${run.id}`,
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.json().code).toBe('workspace-inactive');
   });
 
   test('propagates unexpected errors from project access check', async () => {

--- a/libs/api/workflows/src/presentation/routes/list-run-attempts.test.ts
+++ b/libs/api/workflows/src/presentation/routes/list-run-attempts.test.ts
@@ -36,7 +36,7 @@ describe('GET /api/workflows/runs/:id/attempts', () => {
         buildUserContext({
           userId: crypto.randomUUID(),
           email: 'user@example.com',
-          memberships: [{workspaceId, role: 'admin'}],
+          memberships: [{workspaceId, role: 'admin', workspaceStatus: 'active'}],
         }),
       );
       done();

--- a/libs/api/workflows/src/presentation/routes/list-runs.test.ts
+++ b/libs/api/workflows/src/presentation/routes/list-runs.test.ts
@@ -43,7 +43,7 @@ describe('GET /api/workflows/runs', () => {
         buildUserContext({
           userId: crypto.randomUUID(),
           email: 'user@example.com',
-          memberships: [{workspaceId, role: 'admin'}],
+          memberships: [{workspaceId, role: 'admin', workspaceStatus: 'active'}],
         }),
       );
       done();

--- a/libs/api/workflows/src/presentation/routes/require-accessible-run.ts
+++ b/libs/api/workflows/src/presentation/routes/require-accessible-run.ts
@@ -20,7 +20,10 @@ export async function requireAccessibleRun({
   }
 
   await requireProjectAccess(request, run.projectId, projects).catch((err: unknown) => {
-    if (err instanceof ClientError && (err.status === 403 || err.status === 404)) {
+    if (
+      err instanceof ClientError &&
+      (err.status === 404 || (err.status === 403 && err.code === 'forbidden'))
+    ) {
       throw new ClientError('Run not found', 'not-found', {status: 404});
     }
     throw err;

--- a/libs/api/workflows/src/presentation/routes/rerun-run.test.ts
+++ b/libs/api/workflows/src/presentation/routes/rerun-run.test.ts
@@ -43,7 +43,7 @@ describe('POST /api/workflows/runs/:id/rerun', () => {
         buildUserContext({
           userId: crypto.randomUUID(),
           email: 'user@example.com',
-          memberships: [{workspaceId, role: 'admin'}],
+          memberships: [{workspaceId, role: 'admin', workspaceStatus: 'active'}],
         }),
       );
       done();

--- a/libs/api/workspaces-dto/src/inter-module.ts
+++ b/libs/api/workspaces-dto/src/inter-module.ts
@@ -11,7 +11,13 @@ export const workspacesInterModuleContract = defineInterModuleContract({
     listMembershipsForTokenClaims: {
       input: z.object({userId: idSchema}),
       output: z.object({
-        memberships: z.array(z.object({workspaceId: idSchema, role: workspaceRoleSchema})),
+        memberships: z.array(
+          z.object({
+            workspaceId: idSchema,
+            role: workspaceRoleSchema,
+            workspaceStatus: workspaceStatusSchema.default('active'),
+          }),
+        ),
       }),
     },
     /** Resolves the user id that created the workspace, or null when no creator was recorded. */
@@ -61,7 +67,13 @@ export const workspacesInterModuleContract = defineInterModuleContract({
       input: z.object({
         workspaceId: idSchema,
         userId: idSchema,
-        memberships: z.array(z.object({workspaceId: idSchema, role: workspaceRoleSchema})),
+        memberships: z.array(
+          z.object({
+            workspaceId: idSchema,
+            role: workspaceRoleSchema,
+            workspaceStatus: workspaceStatusSchema.default('active'),
+          }),
+        ),
       }),
       output: z.object({}),
       errors: {

--- a/libs/api/workspaces/src/core/invitations.test.ts
+++ b/libs/api/workspaces/src/core/invitations.test.ts
@@ -105,7 +105,7 @@ describe('invitations core', () => {
       workspaceId: workspace.id,
       email,
       invitedByUserId: inviter.userId,
-      invitedByMemberships: [{workspaceId: workspace.id, role: 'admin'}],
+      invitedByMemberships: [{workspaceId: workspace.id, role: 'admin', workspaceStatus: 'active'}],
     });
 
     expect(invitation.email).toBe(email);
@@ -129,7 +129,7 @@ describe('invitations core', () => {
       email,
       invitedByUserId: inviter.userId,
       invitedByDisplay: 'Dana Scully',
-      invitedByMemberships: [{workspaceId: workspace.id, role: 'admin'}],
+      invitedByMemberships: [{workspaceId: workspace.id, role: 'admin', workspaceStatus: 'active'}],
     });
 
     const payload = await latestInvitationPayload(email);
@@ -157,7 +157,7 @@ describe('invitations core', () => {
       workspaceId: workspace.id,
       email,
       invitedByUserId: inviter.userId,
-      invitedByMemberships: [{workspaceId: workspace.id, role: 'admin'}],
+      invitedByMemberships: [{workspaceId: workspace.id, role: 'admin', workspaceStatus: 'active'}],
     });
 
     const payload = await latestInvitationPayload(email);
@@ -181,7 +181,7 @@ describe('invitations core', () => {
       email,
       invitedByUserId: inviter.userId,
       invitedByDisplay: '   ',
-      invitedByMemberships: [{workspaceId: workspace.id, role: 'admin'}],
+      invitedByMemberships: [{workspaceId: workspace.id, role: 'admin', workspaceStatus: 'active'}],
     });
 
     const payload = await latestInvitationPayload(email);
@@ -204,14 +204,14 @@ describe('invitations core', () => {
       workspaceId: workspace.id,
       email,
       invitedByUserId: inviter.userId,
-      invitedByMemberships: [{workspaceId: workspace.id, role: 'admin'}],
+      invitedByMemberships: [{workspaceId: workspace.id, role: 'admin', workspaceStatus: 'active'}],
     });
 
     const promise = createWorkspaceInvitation({
       workspaceId: workspace.id,
       email,
       invitedByUserId: inviter.userId,
-      invitedByMemberships: [{workspaceId: workspace.id, role: 'admin'}],
+      invitedByMemberships: [{workspaceId: workspace.id, role: 'admin', workspaceStatus: 'active'}],
     });
 
     await expect(promise).rejects.toBeInstanceOf(OpenInvitationExistsError);
@@ -233,7 +233,7 @@ describe('invitations core', () => {
       workspaceId: workspace.id,
       email: invitee.email,
       invitedByUserId: inviter.userId,
-      invitedByMemberships: [{workspaceId: workspace.id, role: 'admin'}],
+      invitedByMemberships: [{workspaceId: workspace.id, role: 'admin', workspaceStatus: 'active'}],
     });
     const token = extractToken((await latestInvitationPayload(invitee.email)).inviteLink);
 
@@ -269,7 +269,7 @@ describe('invitations core', () => {
       workspaceId: workspace.id,
       email,
       invitedByUserId: inviter.userId,
-      invitedByMemberships: [{workspaceId: workspace.id, role: 'admin'}],
+      invitedByMemberships: [{workspaceId: workspace.id, role: 'admin', workspaceStatus: 'active'}],
     });
     const payload = await latestInvitationPayload(email);
     const token = extractToken(payload.inviteLink);

--- a/libs/api/workspaces/src/core/invitations.ts
+++ b/libs/api/workspaces/src/core/invitations.ts
@@ -46,6 +46,7 @@ export async function createWorkspaceInvitation(params: {
     workspaceId: params.workspaceId,
     userId: params.invitedByUserId,
     memberships: params.invitedByMemberships,
+    enforceWorkspaceStatus: false,
   });
 
   const rawToken = generateOpaqueToken('invitation');
@@ -216,6 +217,7 @@ export async function listWorkspaceInvitations(params: {
     workspaceId: params.workspaceId,
     userId: params.requesterUserId,
     memberships: params.requesterMemberships,
+    enforceWorkspaceStatus: false,
   });
 
   return listOpenInvitationsByWorkspace({workspaceId: params.workspaceId});
@@ -231,6 +233,7 @@ export async function revokeWorkspaceInvitation(params: {
     workspaceId: params.workspaceId,
     userId: params.requesterUserId,
     memberships: params.requesterMemberships,
+    enforceWorkspaceStatus: false,
   });
 
   const invitation = await findInvitationById({id: params.invitationId});

--- a/libs/api/workspaces/src/core/workspaces.test.ts
+++ b/libs/api/workspaces/src/core/workspaces.test.ts
@@ -5,7 +5,7 @@ import {findMembership} from '#db/memberships.js';
 import {workspacesOutbox} from '#db/schema/outbox.js';
 import {updateWorkspace} from '#db/workspaces.js';
 import {userFactory} from '#test/index.js';
-import {MembershipRequiredError, WorkspaceNotFoundError} from './errors.js';
+import {MembershipRequiredError, WorkspaceInactiveError, WorkspaceNotFoundError} from './errors.js';
 import {
   createWorkspaceForUser,
   getWorkspaceOperatingState,
@@ -83,6 +83,25 @@ describe('workspaces core', () => {
     await updateWorkspace({id: workspace.id, status: 'suspended'});
 
     expect(await getWorkspaceOperatingState({workspaceId: workspace.id})).toBe('suspended');
+  });
+
+  test('requireWorkspaceMembership rejects a suspended workspace', async () => {
+    const user = userFactory.build();
+    const workspace = await createWorkspaceForUser({
+      name: 'Suspended Workspace',
+      userId: user.userId,
+      userEmail: user.email,
+      userName: user.name,
+    });
+    await updateWorkspace({id: workspace.id, status: 'suspended'});
+
+    const membership = requireWorkspaceMembership({
+      workspaceId: workspace.id,
+      userId: user.userId,
+      memberships: [{workspaceId: workspace.id, role: 'admin', workspaceStatus: 'active'}],
+    });
+
+    await expect(membership).rejects.toBeInstanceOf(WorkspaceInactiveError);
   });
 
   test('requireWorkspaceMembership rejects when memberships do not include the workspace', async () => {

--- a/libs/api/workspaces/src/core/workspaces.test.ts
+++ b/libs/api/workspaces/src/core/workspaces.test.ts
@@ -64,7 +64,7 @@ describe('workspaces core', () => {
     const result = await requireWorkspaceMembership({
       workspaceId: workspace.id,
       userId: user.userId,
-      memberships: [{workspaceId: workspace.id, role: 'admin'}],
+      memberships: [{workspaceId: workspace.id, role: 'admin', workspaceStatus: 'active'}],
     });
 
     expect(result.workspace.id).toBe(workspace.id);
@@ -110,7 +110,7 @@ describe('workspaces core', () => {
     const missingWorkspace = requireWorkspaceMembership({
       workspaceId: ghostId,
       userId: owner.userId,
-      memberships: [{workspaceId: ghostId, role: 'admin'}],
+      memberships: [{workspaceId: ghostId, role: 'admin', workspaceStatus: 'active'}],
     });
 
     await expect(missingWorkspace).rejects.toBeInstanceOf(WorkspaceNotFoundError);

--- a/libs/api/workspaces/src/core/workspaces.ts
+++ b/libs/api/workspaces/src/core/workspaces.ts
@@ -31,6 +31,7 @@ export interface RequireWorkspaceMembershipParams {
   workspaceId: string;
   userId: string;
   memberships: ReadonlyArray<UserContextMembership>;
+  enforceWorkspaceStatus?: boolean;
 }
 
 export interface RequireWorkspaceMembershipResult {
@@ -52,7 +53,7 @@ export async function requireWorkspaceMembership(
   if (!workspace) {
     throw new WorkspaceNotFoundError(params.workspaceId);
   }
-  if (workspace.status !== 'active') {
+  if (params.enforceWorkspaceStatus !== false && workspace.status !== 'active') {
     throw new WorkspaceInactiveError(params.workspaceId);
   }
 
@@ -128,6 +129,7 @@ export async function listWorkspaceMembers(params: {
     workspaceId: params.workspaceId,
     userId: params.requesterUserId,
     memberships: params.requesterMemberships,
+    enforceWorkspaceStatus: false,
   });
 
   return listMembershipsByWorkspace({workspaceId: params.workspaceId});
@@ -143,6 +145,7 @@ export async function removeWorkspaceMember(params: {
     workspaceId: params.workspaceId,
     userId: params.requesterUserId,
     memberships: params.requesterMemberships,
+    enforceWorkspaceStatus: false,
   });
 
   if (params.userId === params.requesterUserId) {

--- a/libs/api/workspaces/src/presentation/inter-module.test.ts
+++ b/libs/api/workspaces/src/presentation/inter-module.test.ts
@@ -1,3 +1,4 @@
+import {buildUserContext, requireWorkspaceAccess, setUserContext} from '@shipfox/api-auth-context';
 import {workspacesInterModuleContract} from '@shipfox/api-workspaces-dto/inter-module';
 import {isInterModuleKnownError} from '@shipfox/inter-module';
 import {createInMemoryInterModuleTransport} from '@shipfox/node-module/inter-module';
@@ -52,6 +53,56 @@ describe('Workspaces inter-module presentation', () => {
     const result = await client.getWorkspaceCreator({workspaceId: workspace.id});
 
     expect(result).toEqual({creatorUserId: null});
+  });
+
+  test('carries workspace status into token claims', async () => {
+    const client = createClient();
+    const userId = crypto.randomUUID();
+    const active = await createWorkspaceForUser({name: 'Active Workspace', userId});
+    const suspended = await createWorkspaceForUser({name: 'Suspended Workspace', userId});
+    const deleted = await createWorkspaceForUser({name: 'Deleted Workspace', userId});
+    await updateWorkspace({id: suspended.id, status: 'suspended'});
+    await updateWorkspace({id: deleted.id, status: 'deleted'});
+
+    expect(await client.listMembershipsForTokenClaims({userId})).toEqual({
+      memberships: [
+        {workspaceId: active.id, role: 'admin', workspaceStatus: 'active'},
+        {workspaceId: deleted.id, role: 'admin', workspaceStatus: 'deleted'},
+        {workspaceId: suspended.id, role: 'admin', workspaceStatus: 'suspended'},
+      ],
+    });
+
+    await updateWorkspace({id: suspended.id, status: 'active'});
+
+    expect(await client.listMembershipsForTokenClaims({userId})).toEqual({
+      memberships: [
+        {workspaceId: active.id, role: 'admin', workspaceStatus: 'active'},
+        {workspaceId: deleted.id, role: 'admin', workspaceStatus: 'deleted'},
+        {workspaceId: suspended.id, role: 'admin', workspaceStatus: 'active'},
+      ],
+    });
+  });
+
+  test('preserves suspended-workspace access errors through the claim boundary', async () => {
+    const client = createClient();
+    const userId = crypto.randomUUID();
+    const workspace = await createWorkspaceForUser({name: 'Suspended Access Workspace', userId});
+    await updateWorkspace({id: workspace.id, status: 'suspended'});
+
+    const claims = await client.listMembershipsForTokenClaims({userId});
+    const request = {};
+    setUserContext(
+      request,
+      buildUserContext({
+        userId,
+        email: `user-${userId}@example.com`,
+        memberships: claims.memberships,
+      }),
+    );
+
+    expect(() => requireWorkspaceAccess({request, workspaceId: workspace.id})).toThrow(
+      expect.objectContaining({code: 'workspace-suspended', status: 409}),
+    );
   });
 
   test('returns only the current workspace operating state', async () => {

--- a/libs/api/workspaces/src/presentation/inter-module.ts
+++ b/libs/api/workspaces/src/presentation/inter-module.ts
@@ -26,10 +26,13 @@ export function createWorkspacesInterModulePresentation(): InterModulePresentati
 > {
   return defineInterModulePresentation(workspacesInterModuleContract, {
     listMembershipsForTokenClaims: async ({userId}) => ({
-      memberships: (await listMembershipsByUser({userId})).map(({workspaceId}) => ({
-        workspaceId,
-        role: 'admin' as const,
-      })),
+      memberships: (await listMembershipsByUser({userId})).map(
+        ({workspaceId, workspaceStatus}) => ({
+          workspaceId,
+          role: 'admin' as const,
+          workspaceStatus,
+        }),
+      ),
     }),
     getWorkspaceCreator: async (input) => {
       try {

--- a/libs/api/workspaces/src/presentation/routes/invitations/create.test.ts
+++ b/libs/api/workspaces/src/presentation/routes/invitations/create.test.ts
@@ -66,6 +66,21 @@ describe('POST /workspaces/:workspaceId/invitations', () => {
     expect(await invitationOutboxEventsTo(inviteeEmail)).toHaveLength(1);
   });
 
+  test('returns workspace-suspended for a suspended membership claim', async () => {
+    const workspaceId = crypto.randomUUID();
+    const token = `claim:${crypto.randomUUID()}:suspended-invite-create@example.com:${workspaceId}:suspended`;
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/workspaces/${workspaceId}/invitations`,
+      headers: {authorization: `Bearer ${token}`},
+      payload: {email: uniqueEmail('suspended-invite')},
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('workspace-suspended');
+  });
+
   test('transforms a whitespace/case-equivalent duplicate open invitation into 409', async () => {
     const owner = await signupVerifyLogin(app, 'invite-create-duplicate-equivalent');
     const workspaceId = await createWorkspace(app, owner.token);

--- a/libs/api/workspaces/src/presentation/routes/invitations/create.ts
+++ b/libs/api/workspaces/src/presentation/routes/invitations/create.ts
@@ -1,4 +1,4 @@
-import {AUTH_USER, getUserContext} from '@shipfox/api-auth-context';
+import {AUTH_USER, getUserContext, requireWorkspaceAccess} from '@shipfox/api-auth-context';
 import {createInvitationBodySchema, invitationDtoSchema} from '@shipfox/api-workspaces-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
@@ -45,6 +45,7 @@ export const createInvitationRoute = defineRoute({
     }
 
     const {workspaceId} = request.params;
+    requireWorkspaceAccess({request, workspaceId});
     const {email} = request.body;
     const invitation = await createWorkspaceInvitation({
       workspaceId,

--- a/libs/api/workspaces/src/presentation/routes/invitations/list.test.ts
+++ b/libs/api/workspaces/src/presentation/routes/invitations/list.test.ts
@@ -65,6 +65,20 @@ describe('GET /workspaces/:workspaceId/invitations', () => {
     expect(res.json().invitations).toEqual([]);
   });
 
+  test('returns workspace-suspended for a suspended membership claim', async () => {
+    const workspaceId = crypto.randomUUID();
+    const token = `claim:${crypto.randomUUID()}:suspended-invite-list@example.com:${workspaceId}:suspended`;
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/workspaces/${workspaceId}/invitations`,
+      headers: {authorization: `Bearer ${token}`},
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('workspace-suspended');
+  });
+
   test('transforms missing membership into 403', async () => {
     const outsider = await signupVerifyLogin(app, 'invite-list-outsider');
     const workspaceId = crypto.randomUUID();

--- a/libs/api/workspaces/src/presentation/routes/invitations/list.test.ts
+++ b/libs/api/workspaces/src/presentation/routes/invitations/list.test.ts
@@ -1,4 +1,5 @@
 import type {FastifyInstance} from 'fastify';
+import {updateWorkspace} from '#db/workspaces.js';
 import {
   createExpiredInvite,
   createInvite,
@@ -44,6 +45,21 @@ describe('GET /workspaces/:workspaceId/invitations', () => {
         email: inviteeEmail,
       }),
     ]);
+  });
+
+  test('keeps an active claim usable when the workspace row is suspended', async () => {
+    const owner = await signupVerifyLogin(app, 'invite-list-snapshot');
+    const workspaceId = await createWorkspace(app, owner.token);
+    await updateWorkspace({id: workspaceId, status: 'suspended'});
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/workspaces/${workspaceId}/invitations`,
+      headers: {authorization: `Bearer ${owner.token}`},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().invitations).toEqual([]);
   });
 
   test('excludes expired unaccepted invitations', async () => {

--- a/libs/api/workspaces/src/presentation/routes/invitations/list.ts
+++ b/libs/api/workspaces/src/presentation/routes/invitations/list.ts
@@ -1,4 +1,4 @@
-import {AUTH_USER, getUserContext} from '@shipfox/api-auth-context';
+import {AUTH_USER, getUserContext, requireWorkspaceAccess} from '@shipfox/api-auth-context';
 import {listInvitationsResponseSchema} from '@shipfox/api-workspaces-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
@@ -40,6 +40,7 @@ export const listInvitationsRoute = defineRoute({
     }
 
     const {workspaceId} = request.params;
+    requireWorkspaceAccess({request, workspaceId});
     const invitations = await listWorkspaceInvitations({
       workspaceId,
       requesterUserId: client.userId,

--- a/libs/api/workspaces/src/presentation/routes/invitations/revoke.test.ts
+++ b/libs/api/workspaces/src/presentation/routes/invitations/revoke.test.ts
@@ -82,6 +82,20 @@ describe('DELETE /workspaces/:workspaceId/invitations/:invitationId', () => {
     expect(res.json().code).toBe('forbidden');
   });
 
+  test('returns workspace-suspended for a suspended membership claim', async () => {
+    const workspaceId = crypto.randomUUID();
+    const token = `claim:${crypto.randomUUID()}:suspended-invite-revoke@example.com:${workspaceId}:suspended`;
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/workspaces/${workspaceId}/invitations/${crypto.randomUUID()}`,
+      headers: {authorization: `Bearer ${token}`},
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('workspace-suspended');
+  });
+
   test('transforms missing membership into 403', async () => {
     const outsider = await signupVerifyLogin(app, 'invite-revoke-outsider');
     const workspaceId = crypto.randomUUID();

--- a/libs/api/workspaces/src/presentation/routes/invitations/revoke.ts
+++ b/libs/api/workspaces/src/presentation/routes/invitations/revoke.ts
@@ -1,4 +1,4 @@
-import {AUTH_USER, getUserContext} from '@shipfox/api-auth-context';
+import {AUTH_USER, getUserContext, requireWorkspaceAccess} from '@shipfox/api-auth-context';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
 import {
@@ -51,6 +51,7 @@ export const revokeInvitationRoute = defineRoute({
     }
 
     const {workspaceId, invitationId} = request.params;
+    requireWorkspaceAccess({request, workspaceId});
 
     await revokeWorkspaceInvitation({
       workspaceId,

--- a/libs/api/workspaces/src/presentation/routes/members/list.test.ts
+++ b/libs/api/workspaces/src/presentation/routes/members/list.test.ts
@@ -1,5 +1,5 @@
 import type {FastifyInstance} from 'fastify';
-import {createWorkspace as createWorkspaceRow} from '#db/workspaces.js';
+import {createWorkspace as createWorkspaceRow, updateWorkspace} from '#db/workspaces.js';
 import {
   createInvite,
   createWorkspace,
@@ -48,6 +48,20 @@ describe('GET /workspaces/:workspaceId/members', () => {
         .members.map((member: {user_email: string}) => member.user_email)
         .sort(),
     ).toEqual([guest.email, owner.email].sort());
+  });
+
+  test('keeps an active claim usable when the workspace row is suspended', async () => {
+    const owner = await signupVerifyLogin(app, 'members-list-snapshot');
+    const workspaceId = await createWorkspace(app, owner.token);
+    await updateWorkspace({id: workspaceId, status: 'suspended'});
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/workspaces/${workspaceId}/members`,
+      headers: {authorization: `Bearer ${owner.token}`},
+    });
+
+    expect(res.statusCode).toBe(200);
   });
 
   test('authorizes from a static membership claim without a membership row', async () => {

--- a/libs/api/workspaces/src/presentation/routes/members/list.test.ts
+++ b/libs/api/workspaces/src/presentation/routes/members/list.test.ts
@@ -66,6 +66,20 @@ describe('GET /workspaces/:workspaceId/members', () => {
     expect(res.json().members).toEqual([]);
   });
 
+  test('returns workspace-suspended for a suspended membership claim', async () => {
+    const workspaceId = crypto.randomUUID();
+    const token = `claim:${crypto.randomUUID()}:suspended-list@example.com:${workspaceId}:suspended`;
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/workspaces/${workspaceId}/members`,
+      headers: {authorization: `Bearer ${token}`},
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('workspace-suspended');
+  });
+
   test('transforms missing membership into 403', async () => {
     const outsider = await signupVerifyLogin(app, 'members-list-outsider');
     const workspaceId = crypto.randomUUID();

--- a/libs/api/workspaces/src/presentation/routes/members/list.ts
+++ b/libs/api/workspaces/src/presentation/routes/members/list.ts
@@ -1,4 +1,4 @@
-import {AUTH_USER, getUserContext} from '@shipfox/api-auth-context';
+import {AUTH_USER, getUserContext, requireWorkspaceAccess} from '@shipfox/api-auth-context';
 import {listMembersResponseSchema} from '@shipfox/api-workspaces-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
@@ -40,6 +40,7 @@ export const listMembersRoute = defineRoute({
     }
 
     const {workspaceId} = request.params;
+    requireWorkspaceAccess({request, workspaceId});
     const members = await listWorkspaceMembers({
       workspaceId,
       requesterUserId: client.userId,

--- a/libs/api/workspaces/src/presentation/routes/members/remove.test.ts
+++ b/libs/api/workspaces/src/presentation/routes/members/remove.test.ts
@@ -79,6 +79,20 @@ describe('DELETE /workspaces/:workspaceId/members/:userId', () => {
     expect(res.json().code).toBe('self-removal-not-allowed');
   });
 
+  test('returns workspace-suspended for a suspended membership claim', async () => {
+    const workspaceId = crypto.randomUUID();
+    const token = `claim:${crypto.randomUUID()}:suspended-member-remove@example.com:${workspaceId}:suspended`;
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/workspaces/${workspaceId}/members/${crypto.randomUUID()}`,
+      headers: {authorization: `Bearer ${token}`},
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('workspace-suspended');
+  });
+
   test('transforms missing membership into 403', async () => {
     const outsider = await signupVerifyLogin(app, 'members-remove-outsider');
     const workspaceId = crypto.randomUUID();

--- a/libs/api/workspaces/src/presentation/routes/members/remove.ts
+++ b/libs/api/workspaces/src/presentation/routes/members/remove.ts
@@ -1,4 +1,4 @@
-import {AUTH_USER, getUserContext} from '@shipfox/api-auth-context';
+import {AUTH_USER, getUserContext, requireWorkspaceAccess} from '@shipfox/api-auth-context';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
 import {
@@ -53,6 +53,7 @@ export const removeMemberRoute = defineRoute({
     }
 
     const {workspaceId, userId} = request.params;
+    requireWorkspaceAccess({request, workspaceId});
 
     await removeWorkspaceMember({
       workspaceId,

--- a/libs/api/workspaces/test/routes.ts
+++ b/libs/api/workspaces/test/routes.ts
@@ -52,14 +52,15 @@ const fakeUserAuth: AuthMethod = {
   authenticate: async (request) => {
     const raw = request.headers.authorization?.replace(BEARER_RE, '');
     if (raw?.startsWith('claim:')) {
-      const [, userId, email, workspaceId] = raw.split(':');
+      const [, userId, email, workspaceId, status] = raw.split(':');
       if (!userId || !email || !workspaceId) throw new Error('Invalid test user claim token');
+      const workspaceStatus = status === 'suspended' || status === 'deleted' ? status : 'active';
       setUserContext(
         request,
         buildUserContext({
           userId,
           email,
-          memberships: [{workspaceId, role: 'admin'}],
+          memberships: [{workspaceId, role: 'admin', workspaceStatus}],
         }),
       );
       return;
@@ -74,7 +75,11 @@ const fakeUserAuth: AuthMethod = {
         userId,
         email,
         name: encodedName ? decodeURIComponent(encodedName) : null,
-        memberships: memberships.map((m) => ({workspaceId: m.workspaceId, role: 'admin' as const})),
+        memberships: memberships.map((m) => ({
+          workspaceId: m.workspaceId,
+          role: 'admin' as const,
+          workspaceStatus: 'active' as const,
+        })),
       }),
     );
   },


### PR DESCRIPTION
JWT-backed workspace access now carries workspace lifecycle status through membership claims and applies the stateless access gate consistently across workspace, trigger, log, annotation, and workflow routes.

The implementation preserves non-leaking resource errors, keeps deleted-workspace access distinct from suspended access, and defaults missing status to active so tokens issued before rollout remain valid until expiry. Authentication and access checks remain claim-only; database reads remain limited to token issuance/renewal and endpoint data operations.

The Changeset, ADR, README, compatibility tests, route coverage, package checks, type checks, focused tests, and published-artifact verification are included.

Closes ENG-1367

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces suspended workspace access using workspace-status in JWT membership claims and a stateless gate across workspace, trigger, log, annotation, and workflow routes. Member and invitation routes honor the token’s claim snapshot, while DB-backed membership checks still reject inactive workspaces when enforced (ENG-1367).

- **New Features**
  - JWT membership claims include `workspaceStatus`; legacy tokens default to `active`.
  - `requireWorkspaceAccess` maps `suspended` → 409 `workspace-suspended`, `deleted` → 403 `workspace-inactive`; `requireWorkspaceResourceAccess` preserves non-leaking 404s for missing resources/memberships.
  - Member/invitation routes authorize from verified claim snapshots; `requireWorkspaceMembership` enforces DB status by default and is explicitly called with `enforceWorkspaceStatus: false` for these routes.
  - Annotation reads include only active claimed workspaces.
  - Access-token verification is claim-only. `getAuthenticatedSessionContext` reads `refreshSessionId` from claims; revoking a refresh session does not invalidate an issued access token. Memberships are loaded at issuance/refresh.

- **Migration**
  - No client changes. Use a short access-token TTL (15m recommended).
  - After suspension, pre-suspension tokens may continue to access member/invitation routes until `exp`; newly issued or refreshed tokens carry `suspended` and are blocked.

<sup>Written for commit 67da5a6151d711afe80b71f5a69a1d6d038fd682. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

