### PR TITLE
[runner-image] Publish shareable runner-image candidates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -903,7 +903,7 @@ jobs:
 
       - name: Build runner image catalog tooling
         if: steps.runner-image-candidate.outputs.digest == ''
-        run: turbo build --filter=@shipfox/runner-image
+        run: mise exec -- turbo build --filter=@shipfox/runner-image
 
       - name: Create immutable runner image candidate manifest
         if: steps.runner-image-candidate.outputs.digest == ''
@@ -946,14 +946,22 @@ jobs:
           # transient read-access gap (see its comment); re-checking here
           # catches a false negative that has since cleared, so a rerun
           # reuses the real digest instead of moving the immutable tag.
-          recheck_digest="$(oras resolve "$RUNNER_IMAGE_CANDIDATE_REPOSITORY:$GITHUB_SHA" 2>/dev/null || true)"
-          if [[ -n "$recheck_digest" ]]; then
+          recheck_error="$(mktemp)"
+          trap 'rm -f "$recheck_error"' EXIT
+          set +e
+          recheck_digest="$(oras resolve "$RUNNER_IMAGE_CANDIDATE_REPOSITORY:$GITHUB_SHA" 2>"$recheck_error")"
+          recheck_status=$?
+          set -e
+          if (( recheck_status == 0 )); then
             if [[ ! "$recheck_digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
               echo "Existing runner image candidate returned an invalid digest: $recheck_digest" >&2
               exit 1
             fi
             echo "Reused $RUNNER_IMAGE_CANDIDATE_REPOSITORY@$recheck_digest (found on re-check)" >> "$GITHUB_STEP_SUMMARY"
             exit 0
+          elif ! grep -Eiq 'failed to resolve digest:.*not found' "$recheck_error"; then
+            cat "$recheck_error" >&2
+            exit "$recheck_status"
           fi
 
           created_at="$(jq -r '.build.createdAt' runner-image-candidate.json)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -793,6 +793,8 @@ jobs:
         env:
           BUILD_ARCH: ${{ matrix.architecture }}
           BUILD_ATTEMPT: ${{ github.run_attempt }}
+          BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS: ${{ vars.AWS_RUNNER_IMAGE_CANDIDATE_CONSUMER_ACCOUNT_IDS }}
+          BUILD_CANDIDATE_KMS_KEY_ID: ${{ vars.AWS_RUNNER_IMAGE_CANDIDATE_KMS_KEY_ID }}
           BUILD_NUMBER: ${{ github.run_number }}
           BUILD_REVISION: ${{ github.sha }}
           PACKER_LOG: "1"
@@ -805,7 +807,14 @@ jobs:
           RUNNER_IMAGE_CANDIDATE_RESULT_PATH: ${{ runner.temp }}/runner-image-candidate-${{ matrix.architecture }}.json
         run: |
           set -euo pipefail
-          jq -r '"- Candidate \(.architecture): \(.region):\(.amiId) for \(.revision) (\(.status))"' "$RUNNER_IMAGE_CANDIDATE_RESULT_PATH" >> "$GITHUB_STEP_SUMMARY"
+          jq -r '"- Candidate \(.architecture): \(.region):\(.amiId) owner \(.owner), expires \(.expiresAt) for \(.revision) (\(.status))"' "$RUNNER_IMAGE_CANDIDATE_RESULT_PATH" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload runner image candidate result
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: runner-image-candidate-${{ matrix.architecture }}
+          path: ${{ runner.temp }}/runner-image-candidate-${{ matrix.architecture }}.json
+          if-no-files-found: error
 
       - name: Upload Packer diagnostics
         if: failure()
@@ -816,6 +825,161 @@ jobs:
             ${{ runner.temp }}/packer-${{ matrix.architecture }}.log
             infra/images/runner/packer-manifest.json
           if-no-files-found: warn
+
+  publish-runner-image-candidate-manifest:
+    name: Publish runner image candidate manifest
+    needs: [publish-runner-image-candidate]
+    if: github.ref == 'refs/heads/main' && needs.publish-runner-image-candidate.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: read
+      contents: read
+      packages: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Set up mise
+        uses: ./.github/actions/setup-mise
+        with:
+          tools: gh node npm:pnpm npm:turbo
+
+      - name: Set up pnpm
+        uses: ./.github/actions/setup-pnpm
+
+      - name: Set up ORAS
+        uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2
+        with:
+          version: 1.3.3
+
+      - name: Log in to GHCR
+        run: |
+          set -euo pipefail
+          printf '%s' "${{ secrets.GITHUB_TOKEN }}" \
+            | oras login ghcr.io --username "${{ github.actor }}" --password-stdin
+
+      - name: Resolve existing runner image candidate
+        id: runner-image-candidate
+        env:
+          RUNNER_IMAGE_CANDIDATE_REPOSITORY: ghcr.io/shipfoxhq/runner-image-candidates
+        run: |
+          set -euo pipefail
+          resolve_error="$(mktemp)"
+          trap 'rm -f "$resolve_error"' EXIT
+
+          set +e
+          existing_digest="$(oras resolve "$RUNNER_IMAGE_CANDIDATE_REPOSITORY:$GITHUB_SHA" 2>"$resolve_error")"
+          resolve_status=$?
+          set -e
+
+          if (( resolve_status == 0 )); then
+            if [[ ! "$existing_digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+              echo "Existing runner image candidate returned an invalid digest: $existing_digest" >&2
+              exit 1
+            fi
+            echo "digest=$existing_digest" >> "$GITHUB_OUTPUT"
+          # GHCR returns this same "not found" shape both when the tag truly
+          # doesn't exist yet and when the caller lacks read access to a
+          # private package, to avoid leaking private-package existence. A
+          # transient permission gap can therefore read as "not published
+          # yet" here; the publish step re-resolves immediately before
+          # pushing as a safety net against moving the immutable tag.
+          elif grep -Eiq 'failed to resolve digest:.*not found' "$resolve_error"; then
+            echo 'digest=' >> "$GITHUB_OUTPUT"
+          else
+            cat "$resolve_error" >&2
+            exit "$resolve_status"
+          fi
+
+      - name: Download runner image candidate results
+        if: steps.runner-image-candidate.outputs.digest == ''
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: runner-image-candidate-*
+          path: runner-image-candidate-results
+          merge-multiple: true
+
+      - name: Build runner image catalog tooling
+        if: steps.runner-image-candidate.outputs.digest == ''
+        run: turbo build --filter=@shipfox/runner-image
+
+      - name: Create immutable runner image candidate manifest
+        if: steps.runner-image-candidate.outputs.digest == ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          build_created_at="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" --jq '.run_started_at')"
+          candidate_args=()
+          while IFS= read -r candidate_path; do
+            candidate_args+=(--candidate "$candidate_path")
+          done < <(find runner-image-candidate-results -type f -name '*.json' -print | sort)
+          node infra/images/runner/bin/runner-image-catalog.js merge-candidates \
+            "${candidate_args[@]}" \
+            --source-repository "https://github.com/$GITHUB_REPOSITORY" \
+            --revision "$GITHUB_SHA" \
+            --build-system github-actions \
+            --build-id "$GITHUB_RUN_ID" \
+            --build-number "$GITHUB_RUN_NUMBER" \
+            --build-attempt "$GITHUB_RUN_ATTEMPT" \
+            --build-created-at "$build_created_at" \
+            --build-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            --output runner-image-candidate.json
+
+      # The first successful main build owns the full-revision tag. Reruns
+      # reuse its digest and never move the revision-addressed reference.
+      - name: Publish immutable runner image candidate manifest
+        env:
+          RUNNER_IMAGE_CANDIDATE_EXISTING_DIGEST: ${{ steps.runner-image-candidate.outputs.digest }}
+          RUNNER_IMAGE_CANDIDATE_REPOSITORY: ghcr.io/shipfoxhq/runner-image-candidates
+        run: |
+          set -euo pipefail
+          if [[ -n "$RUNNER_IMAGE_CANDIDATE_EXISTING_DIGEST" ]]; then
+            echo "Reused $RUNNER_IMAGE_CANDIDATE_REPOSITORY@$RUNNER_IMAGE_CANDIDATE_EXISTING_DIGEST" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # Re-resolve immediately before pushing. The earlier resolve step
+          # cannot always tell "no candidate published yet" apart from a
+          # transient read-access gap (see its comment); re-checking here
+          # catches a false negative that has since cleared, so a rerun
+          # reuses the real digest instead of moving the immutable tag.
+          recheck_digest="$(oras resolve "$RUNNER_IMAGE_CANDIDATE_REPOSITORY:$GITHUB_SHA" 2>/dev/null || true)"
+          if [[ -n "$recheck_digest" ]]; then
+            if [[ ! "$recheck_digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+              echo "Existing runner image candidate returned an invalid digest: $recheck_digest" >&2
+              exit 1
+            fi
+            echo "Reused $RUNNER_IMAGE_CANDIDATE_REPOSITORY@$recheck_digest (found on re-check)" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          created_at="$(jq -r '.build.createdAt' runner-image-candidate.json)"
+          oras push \
+            --artifact-type application/vnd.shipfox.runner-image-candidate.v1+json \
+            --annotation "org.opencontainers.image.created=$created_at" \
+            --annotation "org.opencontainers.image.revision=$GITHUB_SHA" \
+            --annotation "org.opencontainers.image.source=https://github.com/$GITHUB_REPOSITORY" \
+            --format json \
+            "$RUNNER_IMAGE_CANDIDATE_REPOSITORY:$GITHUB_SHA" \
+            runner-image-candidate.json:application/vnd.shipfox.runner-image-candidate.v1+json \
+            | tee runner-image-candidate-publication.json
+
+          published_digest="$(jq -r '.digest // (.reference | split("@")[1])' runner-image-candidate-publication.json)"
+          if [[ ! "$published_digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+            echo "Published runner image candidate returned an invalid digest: $published_digest" >&2
+            exit 1
+          fi
+          echo "Published $RUNNER_IMAGE_CANDIDATE_REPOSITORY@$published_digest" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Report runner image candidate manifest
+        if: steps.runner-image-candidate.outputs.digest == ''
+        run: |
+          set -euo pipefail
+          echo '## Runner image candidate' >> "$GITHUB_STEP_SUMMARY"
+          jq -r '.images[] | "- `\(.architecture)`: `\(.region):\(.amiId)` owner `\(.owner)`, expires `\(.expiresAt)`"' runner-image-candidate.json >> "$GITHUB_STEP_SUMMARY"
 
   publish-application-release:
     name: Publish application release

--- a/infra/images/runner/README.md
+++ b/infra/images/runner/README.md
@@ -7,7 +7,7 @@
 Builds run the production deploy inside the target VM. This is required because the runner contains architecture-specific native payloads. The wrapper obtains the Node version from `mise`, prunes `@shipfox/runner`, and then invokes Packer.
 
 ```sh
-BUILD_ARCH=amd64 BUILD_ATTEMPT=1 BUILD_NUMBER=42 BUILD_REVISION=0123456789abcdef0123456789abcdef01234567 pnpm --filter=@shipfox/runner-image exec node ./bin/build-runner-image-candidate.js --output /tmp/runner-image-candidate.json
+BUILD_ARCH=amd64 BUILD_ATTEMPT=1 BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS=123456789012,210987654321 BUILD_CANDIDATE_KMS_KEY_ID=alias/shipfox-runner-image-candidate BUILD_NUMBER=42 BUILD_REVISION=0123456789abcdef0123456789abcdef01234567 pnpm --filter=@shipfox/runner-image exec node ./bin/build-runner-image-candidate.js --output /tmp/runner-image-candidate.json
 BUILD_ARCH=amd64 BUILD_ATTEMPT=1 BUILD_NUMBER=42 BUILD_RUNNER_VERSION=0.1.0 pnpm --filter=@shipfox/runner-image exec node ./bin/build-runner-image.js ubuntu24 qemu
 ```
 
@@ -42,11 +42,11 @@ On EC2, launch a runner with a short max lifetime, stop the provisioner, and ver
 
 ## Candidate builds
 
-After every successful merge to `main`, CI builds one candidate AMI per architecture in the candidate AWS account. Candidates are not releases: CI does not publish a catalog, set a latest pointer, or record a release version.
+After every successful merge to `main`, CI builds one candidate AMI per architecture in the candidate AWS account. Candidates are not releases: CI shares them only with the configured worker-plane accounts and publishes one immutable OCI manifest at the full source revision. There is no moving `latest` or `main` pointer.
 
-The candidate command writes its AMI ID, architecture, region, source SHA, and whether it built or reused the image to its required `--output` JSON file. The AMI tags are the discovery contract. Internal users resolve an available image by its exact source SHA and architecture with `shipfox.managed=true`, `shipfox.lifecycle=candidate`, `shipfox.revision`, and `shipfox.architecture`. Candidates also record their GitHub build metadata and an expiry timestamp for account-level cleanup.
+The candidate command writes its AMI ID, architecture, region, owner, creation time, expiration time, source SHA, and whether it built or reused the image to its required `--output` JSON file. The AMI tags are the discovery contract. Internal users resolve an available image by its exact source SHA and architecture with `shipfox.managed=true`, `shipfox.lifecycle=candidate`, `shipfox.candidate_id`, `shipfox.revision`, and `shipfox.architecture`. Candidates are encrypted with `BUILD_CANDIDATE_KMS_KEY_ID`, shared with the comma-separated or JSON-array account IDs in `BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS`, and retain the 14-day expiry.
 
-CI assumes `AWS_RUNNER_IMAGE_ROLE_ARN` through GitHub OIDC. The role must belong to the candidate account and trust only `ShipfoxHQ/shipfox` builds from `main`. Candidate AMIs must not be used by production provisioning.
+CI assumes `AWS_RUNNER_IMAGE_ROLE_ARN` through GitHub OIDC. Repository variables `AWS_RUNNER_IMAGE_CANDIDATE_KMS_KEY_ID` and `AWS_RUNNER_IMAGE_CANDIDATE_CONSUMER_ACCOUNT_IDS` supply the candidate distribution inputs; account IDs are intentionally not Packer source defaults. The role must belong to the candidate account and trust only `ShipfoxHQ/shipfox` builds from `main`. Candidate AMIs must not be used by production provisioning.
 
 QEMU output is test-only and is not published as a distributed artifact. The supported consumer path is a local or CI build followed by a boot test:
 

--- a/infra/images/runner/schema/runner-image-candidate.v1.schema.json
+++ b/infra/images/runner/schema/runner-image-candidate.v1.schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:shipfox:schema:runner-image-candidate:v1",
+  "title": "Shipfox runner image candidate v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["kind", "apiVersion", "source", "build", "images"],
+  "properties": {
+    "kind": { "const": "shipfox.runner-image-candidate" },
+    "apiVersion": { "const": "v1" },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "revision"],
+      "properties": {
+        "repository": { "const": "https://github.com/ShipfoxHQ/shipfox" },
+        "revision": { "type": "string", "pattern": "^[a-f0-9]{40}$" }
+      }
+    },
+    "build": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["system", "id", "number", "attempt", "url", "createdAt"],
+      "properties": {
+        "system": { "type": "string", "minLength": 1 },
+        "id": { "type": "string", "minLength": 1 },
+        "number": { "type": "integer", "minimum": 1 },
+        "attempt": { "type": "integer", "minimum": 1 },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "pattern": "^https://[^\\s/?#]+(?:[/?#][^\\s]*)?$"
+        },
+        "createdAt": { "$ref": "#/$defs/timestamp" }
+      }
+    },
+    "images": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": { "$ref": "#/$defs/image" },
+      "allOf": [
+        {
+          "contains": {
+            "type": "object",
+            "required": ["architecture"],
+            "properties": { "architecture": { "const": "amd64" } }
+          }
+        },
+        {
+          "contains": {
+            "type": "object",
+            "required": ["architecture"],
+            "properties": { "architecture": { "const": "arm64" } }
+          }
+        }
+      ]
+    }
+  },
+  "$defs": {
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^(?:(?:\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|02-(?:0[1-9]|1\\d|2[0-8])))|(?:(?:\\d{2}(?:0[48]|[2468][048]|[13579][26])|(?:[02468][048]|[13579][26])00)-02-29))T(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d(?:\\.[0-9]{3})?Z$"
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "amiId",
+        "architecture",
+        "candidateId",
+        "createdAt",
+        "encrypted",
+        "expiresAt",
+        "imageOs",
+        "owner",
+        "region"
+      ],
+      "properties": {
+        "amiId": { "type": "string", "pattern": "^ami-[0-9a-f]{17}$" },
+        "architecture": { "enum": ["amd64", "arm64"] },
+        "candidateId": { "type": "string", "pattern": "^main-[a-f0-9]{40}$" },
+        "createdAt": { "$ref": "#/$defs/timestamp" },
+        "encrypted": { "const": true },
+        "expiresAt": { "$ref": "#/$defs/timestamp" },
+        "imageOs": { "type": "string", "pattern": "^[a-z0-9][a-z0-9._-]*$" },
+        "owner": { "type": "string", "pattern": "^[0-9]{12}$" },
+        "region": { "type": "string", "pattern": "^[a-z]{2}(?:-gov)?-[a-z]+-\\d$" }
+      }
+    }
+  }
+}

--- a/infra/images/runner/source.aws.pkr.hcl
+++ b/infra/images/runner/source.aws.pkr.hcl
@@ -3,6 +3,8 @@ source "amazon-ebs" "build_image" {
   ami_virtualization_type     = "hvm"
   associate_public_ip_address = true
   encrypt_boot                = true
+  kms_key_id                  = var.image_lifecycle == "candidate" ? var.candidate_kms_key_id : ""
+  ami_users                   = var.image_lifecycle == "candidate" ? var.candidate_ami_users : []
   imds_support                = "v2.0"
   instance_type               = var.architecture == "amd64" ? "t3.large" : "t4g.large"
   region                      = "eu-central-1"

--- a/infra/images/runner/src/build-runner-image.ts
+++ b/infra/images/runner/src/build-runner-image.ts
@@ -7,6 +7,8 @@ import {
   readMiseNodeVersion,
 } from './runner-image.js';
 
+export const AWS_ACCOUNT_ID_PATTERN = /^\d{12}$/u;
+
 export function parseBuildRunnerImageArgs(args: string[], env = process.env, nodeVersion?: string) {
   const [os, platform, ...extraPackerArgs] = args;
   if (!os || !platform)
@@ -33,8 +35,22 @@ export function parseBuildRunnerImageArgs(args: string[], env = process.env, nod
     extraPackerArgs,
   };
   if (lifecycle === 'candidate') {
+    const candidateMetadata =
+      platform === 'aws'
+        ? {
+            candidateKmsKeyId: required(
+              env.BUILD_CANDIDATE_KMS_KEY_ID ?? env.AWS_RUNNER_IMAGE_CANDIDATE_KMS_KEY_ID,
+              'BUILD_CANDIDATE_KMS_KEY_ID',
+            ),
+            candidateConsumerAccountIds: parseCandidateConsumerAccountIds(
+              env.BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS ??
+                env.AWS_RUNNER_IMAGE_CANDIDATE_CONSUMER_ACCOUNT_IDS,
+            ),
+          }
+        : {};
     return {
       ...sharedBuild,
+      ...candidateMetadata,
       candidateExpiresAt: required(env.BUILD_CANDIDATE_EXPIRES_AT, 'BUILD_CANDIDATE_EXPIRES_AT'),
       candidateId: required(env.BUILD_CANDIDATE_ID, 'BUILD_CANDIDATE_ID'),
     };
@@ -49,6 +65,28 @@ export function parseBuildRunnerImageArgs(args: string[], env = process.env, nod
 function required(value: string | undefined, name: string): string {
   if (!value) throw new Error(`${name} is not set.`);
   return value;
+}
+
+function parseCandidateConsumerAccountIds(value: string | undefined): string[] {
+  const rawValues = required(value, 'BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS');
+  let accountIds: unknown;
+  try {
+    accountIds = rawValues.trimStart().startsWith('[')
+      ? JSON.parse(rawValues)
+      : rawValues.split(',').map((accountId) => accountId.trim());
+  } catch {
+    throw new Error('BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS must be a CSV or JSON array.');
+  }
+  if (
+    !Array.isArray(accountIds) ||
+    accountIds.length === 0 ||
+    accountIds.some(
+      (accountId) => typeof accountId !== 'string' || !AWS_ACCOUNT_ID_PATTERN.test(accountId),
+    )
+  ) {
+    throw new Error('BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS must contain 12-digit AWS account IDs.');
+  }
+  return [...new Set(accountIds)];
 }
 
 export function runBuildRunnerImageCli(args = process.argv.slice(2)): void {

--- a/infra/images/runner/src/candidate.ts
+++ b/infra/images/runner/src/candidate.ts
@@ -1,11 +1,18 @@
 import {writeFile} from 'node:fs/promises';
 import {parseArgs} from 'node:util';
-import {DescribeImagesCommand, EC2Client, type Image} from '@aws-sdk/client-ec2';
+import {
+  DescribeImagesCommand,
+  EC2Client,
+  type Image,
+  ModifyImageAttributeCommand,
+} from '@aws-sdk/client-ec2';
 import {log} from '@shipfox/tool-utils';
-import {parseBuildRunnerImageArgs} from './build-runner-image.js';
+import {AWS_ACCOUNT_ID_PATTERN, parseBuildRunnerImageArgs} from './build-runner-image.js';
 import {buildRunnerImage, type RunnerImageBuild} from './runner-image.js';
 
 const DEFAULT_CANDIDATE_TTL_DAYS = 14;
+const DEFAULT_DESCRIBE_AVAILABILITY_RETRIES = 5;
+const DEFAULT_DESCRIBE_AVAILABILITY_DELAY_MS = 2000;
 const GIT_REVISION_PATTERN = /^[a-f0-9]{40}$/u;
 const POSITIVE_INTEGER_PATTERN = /^[1-9]\d*$/u;
 
@@ -13,19 +20,33 @@ export interface RunnerImageCandidate {
   amiId: string;
   architecture: 'amd64' | 'arm64';
   candidateId: string;
+  createdAt: string;
+  expiresAt: string;
+  imageOs: string;
+  owner: string;
   region: string;
   revision: string;
   status: 'built' | 'reused';
 }
 
+interface CandidateImageMetadata {
+  amiId: string;
+  createdAt: string;
+  expiresAt: string;
+  owner: string;
+}
+
 interface Ec2ClientLike {
   send(command: DescribeImagesCommand): Promise<{Images?: Image[]}>;
+  send(command: ModifyImageAttributeCommand): Promise<unknown>;
 }
 
 interface BuildRunnerImageCandidateOptions {
   build?: (build: RunnerImageBuild) => Promise<{amiId: string | null}>;
   client?: Ec2ClientLike;
   region?: string;
+  describeAvailabilityRetries?: number;
+  describeAvailabilityDelayMs?: number;
 }
 
 export async function buildRunnerImageCandidate(
@@ -38,15 +59,29 @@ export async function buildRunnerImageCandidate(
   const candidateId = build.candidateId;
   const region = options.region ?? 'eu-central-1';
   const client = options.client ?? new EC2Client({region});
-  const existingAmiId = await findRunnerImageCandidate(client, build.revision, build.architecture);
-  if (existingAmiId) {
-    return candidateResult('reused', existingAmiId, build, candidateId, region);
+  const existingImage = await findRunnerImageCandidate(
+    client,
+    build.revision,
+    build.architecture,
+    candidateId,
+  );
+  if (existingImage) {
+    await reshareRunnerImageCandidate(client, existingImage.amiId, build);
+    return candidateResult('reused', existingImage, build, candidateId, region);
   }
 
   const result = await (options.build ?? buildRunnerImage)(build);
   if (!result.amiId) throw new Error('Packer did not report a runner candidate AMI.');
 
-  return candidateResult('built', result.amiId, build, candidateId, region);
+  const builtImage = await describeBuiltCandidate(
+    client,
+    result.amiId,
+    build,
+    candidateId,
+    options.describeAvailabilityRetries ?? DEFAULT_DESCRIBE_AVAILABILITY_RETRIES,
+    options.describeAvailabilityDelayMs ?? DEFAULT_DESCRIBE_AVAILABILITY_DELAY_MS,
+  );
+  return candidateResult('built', builtImage, build, candidateId, region);
 }
 
 export function parseRunnerImageCandidateArgs(
@@ -64,6 +99,9 @@ export function parseRunnerImageCandidateArgs(
   });
   if (positionals.length)
     throw new Error('build-runner-image-candidate does not accept arguments.');
+  if (env.GITHUB_ACTIONS === 'true' && env.GITHUB_REF !== 'refs/heads/main') {
+    throw new Error('Runner image candidates can only be built and shared from main.');
+  }
   const revision = required(env.BUILD_REVISION ?? env.GITHUB_SHA, 'BUILD_REVISION');
   if (!GIT_REVISION_PATTERN.test(revision)) {
     throw new Error('BUILD_REVISION must be a full lowercase Git revision.');
@@ -103,43 +141,139 @@ async function findRunnerImageCandidate(
   client: Ec2ClientLike,
   revision: string,
   architecture: 'amd64' | 'arm64',
-): Promise<string | null> {
+  candidateId: string,
+): Promise<CandidateImageMetadata | null> {
   const output = await client.send(
     new DescribeImagesCommand({
       Owners: ['self'],
       Filters: [
         {Name: 'tag:shipfox.managed', Values: ['true']},
         {Name: 'tag:shipfox.lifecycle', Values: ['candidate']},
+        {Name: 'tag:shipfox.candidate_id', Values: [candidateId]},
         {Name: 'tag:shipfox.revision', Values: [revision]},
         {Name: 'tag:shipfox.architecture', Values: [architecture]},
       ],
     }),
   );
-  const imageIds = (output.Images ?? [])
-    .filter((image) => image.State === 'available' && image.ImageId)
-    .map((image) => image.ImageId as string);
-  if (imageIds.length > 1) {
+  const images = (output.Images ?? []).filter((image) => image.State === 'available');
+  if (images.length > 1) {
     throw new Error(
-      `Expected at most one ${architecture} candidate AMI for ${revision}, found: ${imageIds.join(', ')}.`,
+      `Expected at most one ${architecture} candidate AMI for ${revision}, found: ${images
+        .map((image) => image.ImageId ?? 'unknown')
+        .join(', ')}.`,
     );
   }
-  return imageIds[0] ?? null;
+  const image = images[0];
+  return image ? candidateImageMetadata(image) : null;
+}
+
+async function describeBuiltCandidate(
+  client: Ec2ClientLike,
+  amiId: string,
+  build: RunnerImageBuild,
+  candidateId: string,
+  availabilityRetries: number,
+  availabilityDelayMs: number,
+): Promise<CandidateImageMetadata> {
+  const image = await describeAvailableImage(
+    client,
+    amiId,
+    availabilityRetries,
+    availabilityDelayMs,
+  );
+  const metadata = candidateImageMetadata(image);
+  if (!image.Tags) {
+    throw new Error(`Candidate AMI ${amiId} does not carry the expected build identity tags.`);
+  }
+  const tags = new Map(image.Tags.map((tag) => [tag.Key, tag.Value]));
+  if (
+    tags.get('shipfox.candidate_id') !== candidateId ||
+    tags.get('shipfox.revision') !== build.revision ||
+    tags.get('shipfox.architecture') !== build.architecture
+  ) {
+    throw new Error(`Candidate AMI ${amiId} does not carry the expected build identity tags.`);
+  }
+  return metadata;
+}
+
+// DescribeImages can briefly lag behind a Packer build that just registered the
+// AMI. Retry with a bounded backoff instead of failing an otherwise-successful
+// build on a single eventually-consistent read.
+async function describeAvailableImage(
+  client: Ec2ClientLike,
+  amiId: string,
+  retries: number,
+  delayMs: number,
+): Promise<Image> {
+  for (let attempt = 0; ; attempt++) {
+    const output = await client.send(
+      new DescribeImagesCommand({Owners: ['self'], ImageIds: [amiId]}),
+    );
+    const image = output.Images?.find((candidate) => candidate.ImageId === amiId);
+    if (image?.State === 'available') return image;
+    if (attempt >= retries) {
+      throw new Error(`Candidate AMI ${amiId} is not available after the Packer build.`);
+    }
+    await sleep(delayMs);
+  }
+}
+
+async function reshareRunnerImageCandidate(
+  client: Ec2ClientLike,
+  amiId: string,
+  build: RunnerImageBuild,
+): Promise<void> {
+  if (!build.candidateConsumerAccountIds?.length) return;
+  await client.send(
+    new ModifyImageAttributeCommand({
+      ImageId: amiId,
+      LaunchPermission: {
+        Add: build.candidateConsumerAccountIds.map((accountId) => ({UserId: accountId})),
+      },
+    }),
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
 }
 
 function candidateResult(
   status: RunnerImageCandidate['status'],
-  amiId: string,
+  image: CandidateImageMetadata,
   build: RunnerImageBuild,
   candidateId: string,
   region: string,
 ): RunnerImageCandidate {
   return {
     status,
-    amiId,
+    amiId: image.amiId,
     architecture: build.architecture,
     candidateId,
+    createdAt: image.createdAt,
+    expiresAt: image.expiresAt,
+    imageOs: build.os,
+    owner: image.owner,
     region,
     revision: build.revision,
+  };
+}
+
+function candidateImageMetadata(image: Image): CandidateImageMetadata {
+  const amiId = required(image.ImageId, 'Candidate AMI ID');
+  const owner = image.OwnerId;
+  const createdAt = image.CreationDate;
+  const expiresAt = image.Tags?.find((tag) => tag.Key === 'shipfox.expires_at')?.Value;
+  if (!owner || !AWS_ACCOUNT_ID_PATTERN.test(owner)) {
+    throw new Error(`Candidate AMI ${amiId} has no valid owner account.`);
+  }
+  return {
+    amiId,
+    createdAt: timestamp(createdAt, `Candidate AMI ${amiId} creation time`),
+    expiresAt: timestamp(expiresAt, `Candidate AMI ${amiId} expiration time`),
+    owner,
   };
 }
 
@@ -154,4 +288,11 @@ function candidateTtlDays(value: string | undefined): number {
 function required(value: string | undefined, name: string): string {
   if (!value) throw new Error(`${name} is required.`);
   return value;
+}
+
+function timestamp(value: string | undefined, label: string): string {
+  if (!value) throw new Error(`${label} is missing.`);
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) throw new Error(`${label} is not a valid timestamp.`);
+  return parsed.toISOString();
 }

--- a/infra/images/runner/src/candidate.ts
+++ b/infra/images/runner/src/candidate.ts
@@ -238,22 +238,15 @@ async function reshareRunnerImageCandidate(
   const permissions = await client.send(
     new DescribeImageAttributeCommand({ImageId: amiId, Attribute: 'launchPermission'}),
   );
-  const existingAccountIds = new Set(
-    (permissions.LaunchPermissions ?? [])
-      .map((permission) => permission.UserId)
-      .filter((accountId): accountId is string => Boolean(accountId)),
-  );
-  const staleAccountIds = [...existingAccountIds].filter(
-    (accountId) => !consumerAccountIds.includes(accountId),
+  const stalePermissions = (permissions.LaunchPermissions ?? []).filter(
+    (permission) => !permission.UserId || !consumerAccountIds.includes(permission.UserId),
   );
   await client.send(
     new ModifyImageAttributeCommand({
       ImageId: amiId,
       LaunchPermission: {
         Add: consumerAccountIds.map((accountId) => ({UserId: accountId})),
-        ...(staleAccountIds.length
-          ? {Remove: staleAccountIds.map((accountId) => ({UserId: accountId}))}
-          : {}),
+        ...(stalePermissions.length ? {Remove: stalePermissions} : {}),
       },
     }),
   );

--- a/infra/images/runner/src/candidate.ts
+++ b/infra/images/runner/src/candidate.ts
@@ -1,6 +1,8 @@
 import {writeFile} from 'node:fs/promises';
 import {parseArgs} from 'node:util';
 import {
+  DescribeImageAttributeCommand,
+  type DescribeImageAttributeCommandOutput,
   DescribeImagesCommand,
   EC2Client,
   type Image,
@@ -13,6 +15,8 @@ import {buildRunnerImage, type RunnerImageBuild} from './runner-image.js';
 const DEFAULT_CANDIDATE_TTL_DAYS = 14;
 const DEFAULT_DESCRIBE_AVAILABILITY_RETRIES = 5;
 const DEFAULT_DESCRIBE_AVAILABILITY_DELAY_MS = 2000;
+const CANDIDATE_REGION = 'eu-central-1';
+const INVALID_AMI_NOT_FOUND = 'InvalidAMIID.NotFound';
 const GIT_REVISION_PATTERN = /^[a-f0-9]{40}$/u;
 const POSITIVE_INTEGER_PATTERN = /^[1-9]\d*$/u;
 
@@ -38,6 +42,7 @@ interface CandidateImageMetadata {
 
 interface Ec2ClientLike {
   send(command: DescribeImagesCommand): Promise<{Images?: Image[]}>;
+  send(command: DescribeImageAttributeCommand): Promise<DescribeImageAttributeCommandOutput>;
   send(command: ModifyImageAttributeCommand): Promise<unknown>;
 }
 
@@ -57,7 +62,7 @@ export async function buildRunnerImageCandidate(
     throw new Error('Runner image candidate builds require candidate lifecycle metadata.');
   }
   const candidateId = build.candidateId;
-  const region = options.region ?? 'eu-central-1';
+  const region = candidateRegion(options.region);
   const client = options.client ?? new EC2Client({region});
   const existingImage = await findRunnerImageCandidate(
     client,
@@ -119,7 +124,7 @@ export function parseRunnerImageCandidateArgs(
   return {
     build,
     outputPath: required(values.output, '--output'),
-    region: env.AWS_REGION ?? 'eu-central-1',
+    region: candidateRegion(env.AWS_REGION),
   };
 }
 
@@ -206,9 +211,14 @@ async function describeAvailableImage(
   delayMs: number,
 ): Promise<Image> {
   for (let attempt = 0; ; attempt++) {
-    const output = await client.send(
-      new DescribeImagesCommand({Owners: ['self'], ImageIds: [amiId]}),
-    );
+    let output: {Images?: Image[]};
+    try {
+      output = await client.send(new DescribeImagesCommand({Owners: ['self'], ImageIds: [amiId]}));
+    } catch (error) {
+      if (!isImageNotFoundError(error) || attempt >= retries) throw error;
+      await sleep(delayMs);
+      continue;
+    }
     const image = output.Images?.find((candidate) => candidate.ImageId === amiId);
     if (image?.State === 'available') return image;
     if (attempt >= retries) {
@@ -223,15 +233,36 @@ async function reshareRunnerImageCandidate(
   amiId: string,
   build: RunnerImageBuild,
 ): Promise<void> {
-  if (!build.candidateConsumerAccountIds?.length) return;
+  const consumerAccountIds = build.candidateConsumerAccountIds;
+  if (!consumerAccountIds?.length) return;
+  const permissions = await client.send(
+    new DescribeImageAttributeCommand({ImageId: amiId, Attribute: 'launchPermission'}),
+  );
+  const existingAccountIds = new Set(
+    (permissions.LaunchPermissions ?? [])
+      .map((permission) => permission.UserId)
+      .filter((accountId): accountId is string => Boolean(accountId)),
+  );
+  const staleAccountIds = [...existingAccountIds].filter(
+    (accountId) => !consumerAccountIds.includes(accountId),
+  );
   await client.send(
     new ModifyImageAttributeCommand({
       ImageId: amiId,
       LaunchPermission: {
-        Add: build.candidateConsumerAccountIds.map((accountId) => ({UserId: accountId})),
+        Add: consumerAccountIds.map((accountId) => ({UserId: accountId})),
+        ...(staleAccountIds.length
+          ? {Remove: staleAccountIds.map((accountId) => ({UserId: accountId}))}
+          : {}),
       },
     }),
   );
+}
+
+function isImageNotFoundError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  const awsError = error as {code?: unknown; name?: unknown};
+  return awsError.code === INVALID_AMI_NOT_FOUND || awsError.name === INVALID_AMI_NOT_FOUND;
 }
 
 function sleep(ms: number): Promise<void> {
@@ -288,6 +319,14 @@ function candidateTtlDays(value: string | undefined): number {
 function required(value: string | undefined, name: string): string {
   if (!value) throw new Error(`${name} is required.`);
   return value;
+}
+
+function candidateRegion(value: string | undefined): string {
+  const region = value ?? CANDIDATE_REGION;
+  if (region !== CANDIDATE_REGION) {
+    throw new Error(`Runner image candidates must use ${CANDIDATE_REGION}.`);
+  }
+  return region;
 }
 
 function timestamp(value: string | undefined, label: string): string {

--- a/infra/images/runner/src/catalog.ts
+++ b/infra/images/runner/src/catalog.ts
@@ -3,9 +3,12 @@ import {parseArgs} from 'node:util';
 import {Ajv2020, type ValidateFunction} from 'ajv/dist/2020.js';
 import * as addFormatsModule from 'ajv-formats';
 import {readPackerAmiArtifact} from './aws.js';
+import type {RunnerImageCandidate} from './candidate.js';
 
 export const RUNNER_IMAGE_RELEASE_KIND = 'shipfox.runner-image-release';
 export const RUNNER_IMAGE_RELEASE_API_VERSION = 'v1';
+export const RUNNER_IMAGE_CANDIDATE_KIND = 'shipfox.runner-image-candidate';
+export const RUNNER_IMAGE_CANDIDATE_API_VERSION = 'v1';
 const UTC_TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:\.\d{3})?Z$/;
 const POSITIVE_INTEGER_PATTERN = /^[1-9]\d*$/u;
 const addFormats = addFormatsModule.default as unknown as (validator: Ajv2020) => void;
@@ -47,7 +50,36 @@ export interface RunnerImageReleaseManifest {
   images: RunnerImageReleaseImage[];
 }
 
+export interface RunnerImageCandidateManifestInput {
+  sourceRepository: string;
+  revision: string;
+  build: RunnerImageReleaseInput['build'];
+  images: RunnerImageCandidate[];
+}
+
+export interface RunnerImageCandidateManifest {
+  kind: typeof RUNNER_IMAGE_CANDIDATE_KIND;
+  apiVersion: typeof RUNNER_IMAGE_CANDIDATE_API_VERSION;
+  source: {
+    repository: string;
+    revision: string;
+  };
+  build: RunnerImageCandidateManifestInput['build'];
+  images: Array<{
+    amiId: string;
+    architecture: 'amd64' | 'arm64';
+    candidateId: string;
+    createdAt: string;
+    encrypted: true;
+    expiresAt: string;
+    imageOs: string;
+    owner: string;
+    region: string;
+  }>;
+}
+
 const validateManifest = createManifestValidator();
+const validateCandidateManifest = createCandidateManifestValidator();
 
 export function createRunnerImageReleaseManifest(
   input: RunnerImageReleaseInput,
@@ -106,6 +138,63 @@ export function mergeRunnerImageReleaseManifests(
   });
 }
 
+export function createRunnerImageCandidateManifest(
+  input: RunnerImageCandidateManifestInput,
+): RunnerImageCandidateManifest {
+  if (
+    input.images.some(
+      (image) =>
+        image.revision !== input.revision || image.candidateId !== `main-${input.revision}`,
+    )
+  ) {
+    throw new Error('Runner image candidates must describe the same source revision.');
+  }
+  const manifest: RunnerImageCandidateManifest = {
+    kind: RUNNER_IMAGE_CANDIDATE_KIND,
+    apiVersion: RUNNER_IMAGE_CANDIDATE_API_VERSION,
+    source: {
+      repository: input.sourceRepository,
+      revision: input.revision,
+    },
+    build: {
+      ...input.build,
+      createdAt: timestamp(input.build.createdAt, 'Build creation time'),
+    },
+    images: input.images
+      .map((image) => ({
+        amiId: image.amiId,
+        architecture: image.architecture,
+        candidateId: image.candidateId,
+        createdAt: timestamp(image.createdAt, `Image ${image.amiId} creation time`),
+        encrypted: true as const,
+        expiresAt: timestamp(image.expiresAt, `Image ${image.amiId} expiration time`),
+        imageOs: image.imageOs,
+        owner: image.owner,
+        region: image.region,
+      }))
+      .sort((left, right) => left.architecture.localeCompare(right.architecture)),
+  };
+
+  if (!validateCandidateManifest(manifest)) {
+    throw new Error(
+      `Invalid runner image candidate manifest: ${formatErrors(validateCandidateManifest)}`,
+    );
+  }
+  assertUniqueArchitectures(manifest.images);
+  return manifest;
+}
+
+export function mergeRunnerImageCandidateManifests(
+  candidates: readonly RunnerImageCandidate[],
+  input: Omit<RunnerImageCandidateManifestInput, 'images'>,
+): RunnerImageCandidateManifest {
+  if (!candidates.length) throw new Error('At least one runner image candidate is required.');
+  if (candidates.some((candidate) => candidate.revision !== input.revision)) {
+    throw new Error('Runner image candidates must describe the same source revision.');
+  }
+  return createRunnerImageCandidateManifest({...input, images: [...candidates]});
+}
+
 export function runRunnerImageCatalogCli(args = process.argv.slice(2)): void {
   const [command] = args;
   if (command === 'create') {
@@ -116,7 +205,11 @@ export function runRunnerImageCatalogCli(args = process.argv.slice(2)): void {
     mergeRunnerImageCatalog(args.slice(1));
     return;
   }
-  throw new Error('Usage: runner-image-catalog <create|merge> [options]');
+  if (command === 'merge-candidates') {
+    mergeRunnerImageCandidateCatalog(args.slice(1));
+    return;
+  }
+  throw new Error('Usage: runner-image-catalog <create|merge|merge-candidates> [options]');
 }
 
 function createRunnerImageCatalog(args: string[]): void {
@@ -204,6 +297,48 @@ function mergeRunnerImageCatalog(args: string[]): void {
   writeManifest(required(values.output, '--output'), mergeRunnerImageReleaseManifests(manifests));
 }
 
+function mergeRunnerImageCandidateCatalog(args: string[]): void {
+  const {values, positionals} = parseArgs({
+    args,
+    strict: true,
+    allowPositionals: true,
+    options: {
+      candidate: {type: 'string', multiple: true},
+      'build-attempt': {type: 'string'},
+      'build-created-at': {type: 'string'},
+      'build-id': {type: 'string'},
+      'build-number': {type: 'string'},
+      'build-system': {type: 'string'},
+      'build-url': {type: 'string'},
+      output: {type: 'string'},
+      revision: {type: 'string'},
+      'source-repository': {type: 'string'},
+    },
+  });
+  if (positionals.length)
+    throw new Error('runner-image-catalog merge-candidates does not accept positional arguments.');
+  const candidatePaths = stringValues(values.candidate, '--candidate');
+  if (candidatePaths.length < 2) {
+    throw new Error('runner-image-catalog merge-candidates requires both architecture results.');
+  }
+  const candidates = candidatePaths.map(readRunnerImageCandidate);
+  const buildNumber = required(values['build-number'], '--build-number');
+  const buildAttempt = required(values['build-attempt'], '--build-attempt');
+  const manifest = mergeRunnerImageCandidateManifests(candidates, {
+    sourceRepository: required(values['source-repository'], '--source-repository'),
+    revision: required(values.revision, '--revision'),
+    build: {
+      system: required(values['build-system'], '--build-system'),
+      id: required(values['build-id'], '--build-id'),
+      number: positiveInteger(buildNumber),
+      attempt: positiveInteger(buildAttempt),
+      url: required(values['build-url'], '--build-url'),
+      createdAt: required(values['build-created-at'], '--build-created-at'),
+    },
+  });
+  writeManifest(required(values.output, '--output'), manifest);
+}
+
 function readRunnerImageReleaseManifest(path: string): RunnerImageReleaseManifest {
   const value = JSON.parse(readFileSync(path, 'utf8'));
   if (!validateManifest(value)) {
@@ -212,7 +347,33 @@ function readRunnerImageReleaseManifest(path: string): RunnerImageReleaseManifes
   return value as RunnerImageReleaseManifest;
 }
 
-function writeManifest(path: string, manifest: RunnerImageReleaseManifest): void {
+function readRunnerImageCandidate(path: string): RunnerImageCandidate {
+  const value: unknown = JSON.parse(readFileSync(path, 'utf8'));
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`Runner image candidate ${path} must be an object.`);
+  }
+  const candidate = value as Partial<RunnerImageCandidate>;
+  if (
+    typeof candidate.amiId !== 'string' ||
+    (candidate.architecture !== 'amd64' && candidate.architecture !== 'arm64') ||
+    typeof candidate.candidateId !== 'string' ||
+    typeof candidate.createdAt !== 'string' ||
+    typeof candidate.expiresAt !== 'string' ||
+    typeof candidate.imageOs !== 'string' ||
+    typeof candidate.owner !== 'string' ||
+    typeof candidate.region !== 'string' ||
+    typeof candidate.revision !== 'string' ||
+    (candidate.status !== 'built' && candidate.status !== 'reused')
+  ) {
+    throw new Error(`Runner image candidate ${path} is missing required metadata.`);
+  }
+  return candidate as RunnerImageCandidate;
+}
+
+function writeManifest(
+  path: string,
+  manifest: RunnerImageReleaseManifest | RunnerImageCandidateManifest,
+): void {
   writeFileSync(path, `${JSON.stringify(manifest, null, 2)}\n`);
 }
 
@@ -222,6 +383,14 @@ function createManifestValidator(): ValidateFunction<RunnerImageReleaseManifest>
   const validator = new Ajv2020({allErrors: true, strict: true});
   addFormats(validator);
   return validator.compile<RunnerImageReleaseManifest>(schema);
+}
+
+function createCandidateManifestValidator(): ValidateFunction<RunnerImageCandidateManifest> {
+  const schemaPath = new URL('../schema/runner-image-candidate.v1.schema.json', import.meta.url);
+  const schema = JSON.parse(readFileSync(schemaPath, 'utf8'));
+  const validator = new Ajv2020({allErrors: true, strict: true});
+  addFormats(validator);
+  return validator.compile<RunnerImageCandidateManifest>(schema);
 }
 
 function architecture(value: string | undefined): 'amd64' | 'arm64' {
@@ -244,7 +413,7 @@ function positiveInteger(value: string): number {
   return parsed;
 }
 
-function assertUniqueArchitectures(images: readonly RunnerImageReleaseImage[]): void {
+function assertUniqueArchitectures(images: ReadonlyArray<{architecture: 'amd64' | 'arm64'}>): void {
   const architectures = new Set<string>();
   for (const image of images) {
     if (architectures.has(image.architecture)) {
@@ -252,6 +421,13 @@ function assertUniqueArchitectures(images: readonly RunnerImageReleaseImage[]): 
     }
     architectures.add(image.architecture);
   }
+}
+
+function stringValues(value: unknown, label: string): string[] {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    throw new Error(`${label} must be provided at least twice.`);
+  }
+  return value as string[];
 }
 
 function timestamp(value: string, label: string): string {

--- a/infra/images/runner/src/runner-image.ts
+++ b/infra/images/runner/src/runner-image.ts
@@ -19,6 +19,8 @@ export interface RunnerImageBuild {
   buildNumber: string;
   candidateExpiresAt?: string;
   candidateId?: string;
+  candidateKmsKeyId?: string;
+  candidateConsumerAccountIds?: string[];
   lifecycle: RunnerImageLifecycle;
   nodeVersion: string;
   revision: string;
@@ -67,6 +69,16 @@ export function packerBuildArgs(
   }
   if (build.candidateExpiresAt) {
     args.push('-var', `candidate_expires_at=${build.candidateExpiresAt}`);
+  }
+  if (build.lifecycle === 'candidate' && build.platform === 'aws') {
+    if (!build.candidateKmsKeyId) {
+      throw new Error('Candidate AWS builds require candidateKmsKeyId.');
+    }
+    if (!build.candidateConsumerAccountIds?.length) {
+      throw new Error('Candidate AWS builds require candidate consumer accounts.');
+    }
+    args.push('-var', `candidate_kms_key_id=${build.candidateKmsKeyId}`);
+    args.push('-var', `candidate_ami_users=${JSON.stringify(build.candidateConsumerAccountIds)}`);
   }
   if (build.runnerVersion) args.push('-var', `runner_version=${build.runnerVersion}`);
   if (build.platform === 'qemu') args.push(...qemuSourceImageArgs(rootDir));

--- a/infra/images/runner/test/catalog.test.ts
+++ b/infra/images/runner/test/catalog.test.ts
@@ -2,7 +2,9 @@ import {mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {
+  createRunnerImageCandidateManifest,
   createRunnerImageReleaseManifest,
+  mergeRunnerImageCandidateManifests,
   mergeRunnerImageReleaseManifests,
   runRunnerImageCatalogCli,
 } from '#catalog.js';
@@ -36,6 +38,85 @@ function input(architecture: 'amd64' | 'arm64' = 'amd64') {
     ],
   };
 }
+
+function candidate(architecture: 'amd64' | 'arm64') {
+  return {
+    amiId: architecture === 'amd64' ? 'ami-0123abc456def7890' : 'ami-0fedcba9876543210',
+    architecture,
+    candidateId: `main-${revision}`,
+    createdAt: '2026-07-19T10:15:00.000Z',
+    expiresAt: '2026-08-02T10:15:00.000Z',
+    imageOs: 'ubuntu24',
+    owner: '123456789012',
+    region: 'eu-central-1',
+    revision,
+    status: 'built' as const,
+  };
+}
+
+function candidateManifestInput() {
+  return {
+    sourceRepository: 'https://github.com/ShipfoxHQ/shipfox',
+    revision,
+    build: {
+      system: 'github-actions',
+      id: '123456789',
+      number: 42,
+      attempt: 1,
+      url: 'https://github.com/ShipfoxHQ/shipfox/actions/runs/123456789',
+      createdAt: '2026-07-19T10:00:00Z',
+    },
+  };
+}
+
+describe('runner image candidate manifests', () => {
+  it('merges both architecture results into a strict immutable candidate manifest', () => {
+    const manifest = mergeRunnerImageCandidateManifests(
+      [candidate('arm64'), candidate('amd64')],
+      candidateManifestInput(),
+    );
+
+    expect(manifest).toMatchObject({
+      kind: 'shipfox.runner-image-candidate',
+      apiVersion: 'v1',
+      source: {revision},
+      build: {createdAt: '2026-07-19T10:00:00.000Z'},
+      images: [
+        expect.objectContaining({architecture: 'amd64', encrypted: true}),
+        expect.objectContaining({architecture: 'arm64', encrypted: true}),
+      ],
+    });
+  });
+
+  it('rejects a candidate result from a different source revision', () => {
+    const mismatched = {
+      ...candidate('arm64'),
+      revision: 'fedcba9876543210fedcba9876543210fedcba98',
+    };
+
+    expect(() =>
+      mergeRunnerImageCandidateManifests(
+        [candidate('amd64'), mismatched],
+        candidateManifestInput(),
+      ),
+    ).toThrow('same source revision');
+  });
+
+  it('requires both architectures', () => {
+    expect(() =>
+      createRunnerImageCandidateManifest({
+        ...candidateManifestInput(),
+        images: [candidate('amd64')],
+      }),
+    ).toThrow('Invalid runner image candidate manifest');
+  });
+
+  it('rejects an empty candidate list', () => {
+    expect(() => mergeRunnerImageCandidateManifests([], candidateManifestInput())).toThrow(
+      'At least one runner image candidate is required.',
+    );
+  });
+});
 
 describe('createRunnerImageReleaseManifest', () => {
   it('creates a strict AMI release catalog entry', () => {
@@ -216,6 +297,130 @@ describe('runner-image-catalog CLI', () => {
         'amd64',
         'arm64',
       ]);
+    } finally {
+      await rm(tempDir, {force: true, recursive: true});
+    }
+  });
+
+  it('merges candidate results through the CLI', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'shipfox-runner-image-candidate-'));
+    const amd64Path = join(tempDir, 'amd64.json');
+    const arm64Path = join(tempDir, 'arm64.json');
+    const mergedPath = join(tempDir, 'candidate.json');
+    await writeFile(amd64Path, JSON.stringify(candidate('amd64')));
+    await writeFile(arm64Path, JSON.stringify(candidate('arm64')));
+
+    try {
+      runRunnerImageCatalogCli([
+        'merge-candidates',
+        '--candidate',
+        amd64Path,
+        '--candidate',
+        arm64Path,
+        '--source-repository',
+        'https://github.com/ShipfoxHQ/shipfox',
+        '--revision',
+        revision,
+        '--build-system',
+        'github-actions',
+        '--build-id',
+        '123456789',
+        '--build-number',
+        '42',
+        '--build-attempt',
+        '1',
+        '--build-created-at',
+        '2026-07-19T10:00:00Z',
+        '--build-url',
+        'https://github.com/ShipfoxHQ/shipfox/actions/runs/123456789',
+        '--output',
+        mergedPath,
+      ]);
+
+      const manifest = JSON.parse(await readFile(mergedPath, 'utf8'));
+
+      expect(manifest.kind).toBe('shipfox.runner-image-candidate');
+      expect(manifest.images.map((image: {architecture: string}) => image.architecture)).toEqual([
+        'amd64',
+        'arm64',
+      ]);
+    } finally {
+      await rm(tempDir, {force: true, recursive: true});
+    }
+  });
+
+  it('requires both architecture results to merge candidates', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'shipfox-runner-image-candidate-'));
+    const amd64Path = join(tempDir, 'amd64.json');
+    await writeFile(amd64Path, JSON.stringify(candidate('amd64')));
+
+    try {
+      expect(() =>
+        runRunnerImageCatalogCli([
+          'merge-candidates',
+          '--candidate',
+          amd64Path,
+          '--source-repository',
+          'https://github.com/ShipfoxHQ/shipfox',
+          '--revision',
+          revision,
+          '--build-system',
+          'github-actions',
+          '--build-id',
+          '123456789',
+          '--build-number',
+          '42',
+          '--build-attempt',
+          '1',
+          '--build-created-at',
+          '2026-07-19T10:00:00Z',
+          '--build-url',
+          'https://github.com/ShipfoxHQ/shipfox/actions/runs/123456789',
+          '--output',
+          join(tempDir, 'candidate.json'),
+        ]),
+      ).toThrow('runner-image-catalog merge-candidates requires both architecture results.');
+    } finally {
+      await rm(tempDir, {force: true, recursive: true});
+    }
+  });
+
+  it('rejects a candidate result file missing required metadata', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'shipfox-runner-image-candidate-'));
+    const amd64Path = join(tempDir, 'amd64.json');
+    const arm64Path = join(tempDir, 'arm64.json');
+    const {owner: _owner, ...incompleteCandidate} = candidate('amd64');
+    await writeFile(amd64Path, JSON.stringify(incompleteCandidate));
+    await writeFile(arm64Path, JSON.stringify(candidate('arm64')));
+
+    try {
+      expect(() =>
+        runRunnerImageCatalogCli([
+          'merge-candidates',
+          '--candidate',
+          amd64Path,
+          '--candidate',
+          arm64Path,
+          '--source-repository',
+          'https://github.com/ShipfoxHQ/shipfox',
+          '--revision',
+          revision,
+          '--build-system',
+          'github-actions',
+          '--build-id',
+          '123456789',
+          '--build-number',
+          '42',
+          '--build-attempt',
+          '1',
+          '--build-created-at',
+          '2026-07-19T10:00:00Z',
+          '--build-url',
+          'https://github.com/ShipfoxHQ/shipfox/actions/runs/123456789',
+          '--output',
+          join(tempDir, 'candidate.json'),
+        ]),
+      ).toThrow(`Runner image candidate ${amd64Path} is missing required metadata.`);
     } finally {
       await rm(tempDir, {force: true, recursive: true});
     }

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -489,7 +489,13 @@ describe('runner image candidates', () => {
       .fn()
       .mockResolvedValueOnce({Images: [availableImage('ami-0fedcba9876543210', 'arm64')]})
       .mockResolvedValueOnce({
-        LaunchPermissions: [{UserId: '123456789012'}, {UserId: '999999999999'}],
+        LaunchPermissions: [
+          {UserId: '123456789012'},
+          {UserId: '999999999999'},
+          {Group: 'all'},
+          {OrganizationArn: 'arn:aws:organizations::123456789012:organization/o-example'},
+          {OrganizationalUnitArn: 'arn:aws:organizations::123456789012:ou/o-example/ou-example'},
+        ],
       });
     const buildImage = vi.fn();
 
@@ -518,7 +524,15 @@ describe('runner image candidates', () => {
           ImageId: 'ami-0fedcba9876543210',
           LaunchPermission: {
             Add: [{UserId: '123456789012'}, {UserId: '210987654321'}],
-            Remove: [{UserId: '999999999999'}],
+            Remove: [
+              {UserId: '999999999999'},
+              {Group: 'all'},
+              {OrganizationArn: 'arn:aws:organizations::123456789012:organization/o-example'},
+              {
+                OrganizationalUnitArn:
+                  'arn:aws:organizations::123456789012:ou/o-example/ou-example',
+              },
+            ],
           },
         },
       }),

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -97,6 +97,8 @@ describe('packerBuildArgs', () => {
         buildNumber: '42',
         candidateExpiresAt: '2026-08-03T10:00:00Z',
         candidateId: 'main-0123456789abcdef0123456789abcdef01234567',
+        candidateConsumerAccountIds: ['123456789012', '210987654321'],
+        candidateKmsKeyId: 'alias/shipfox-runner-image-candidate',
         lifecycle: 'candidate',
         nodeVersion: '24.17.0',
         revision: '0123456789abcdef0123456789abcdef01234567',
@@ -108,7 +110,53 @@ describe('packerBuildArgs', () => {
     expect(args).toContain('image_lifecycle=candidate');
     expect(args).toContain('candidate_id=main-0123456789abcdef0123456789abcdef01234567');
     expect(args).toContain('candidate_expires_at=2026-08-03T10:00:00Z');
+    expect(args).toContain('candidate_kms_key_id=alias/shipfox-runner-image-candidate');
+    expect(args).toContain('candidate_ami_users=["123456789012","210987654321"]');
     expect(args.some((arg) => arg.startsWith('runner_version='))).toBe(false);
+  });
+
+  it('requires a KMS key for candidate AWS builds', () => {
+    expect(() =>
+      packerBuildArgs(
+        {
+          os: 'ubuntu24',
+          platform: 'aws',
+          architecture: 'amd64',
+          buildAttempt: '1',
+          buildNumber: '42',
+          candidateExpiresAt: '2026-08-03T10:00:00Z',
+          candidateId: 'main-0123456789abcdef0123456789abcdef01234567',
+          candidateConsumerAccountIds: ['123456789012'],
+          lifecycle: 'candidate',
+          nodeVersion: '24.17.0',
+          revision: '0123456789abcdef0123456789abcdef01234567',
+          extraPackerArgs: [],
+        },
+        '/tmp/workspace',
+      ),
+    ).toThrow('Candidate AWS builds require candidateKmsKeyId.');
+  });
+
+  it('requires consumer accounts for candidate AWS builds', () => {
+    expect(() =>
+      packerBuildArgs(
+        {
+          os: 'ubuntu24',
+          platform: 'aws',
+          architecture: 'amd64',
+          buildAttempt: '1',
+          buildNumber: '42',
+          candidateExpiresAt: '2026-08-03T10:00:00Z',
+          candidateId: 'main-0123456789abcdef0123456789abcdef01234567',
+          candidateKmsKeyId: 'alias/shipfox-runner-image-candidate',
+          lifecycle: 'candidate',
+          nodeVersion: '24.17.0',
+          revision: '0123456789abcdef0123456789abcdef01234567',
+          extraPackerArgs: [],
+        },
+        '/tmp/workspace',
+      ),
+    ).toThrow('Candidate AWS builds require candidate consumer accounts.');
   });
 
   it('rejects an unchecked custom QEMU source', () => {
@@ -242,6 +290,8 @@ describe('parseBuildRunnerImageArgs', () => {
         BUILD_ATTEMPT: '1',
         BUILD_CANDIDATE_EXPIRES_AT: '2026-08-03T10:00:00Z',
         BUILD_CANDIDATE_ID: 'main-0123456789abcdef0123456789abcdef01234567',
+        BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS: '123456789012,210987654321',
+        BUILD_CANDIDATE_KMS_KEY_ID: 'alias/shipfox-runner-image-candidate',
         BUILD_IMAGE_LIFECYCLE: 'candidate',
         BUILD_NUMBER: '42',
         BUILD_REVISION: '0123456789abcdef0123456789abcdef01234567',
@@ -256,10 +306,124 @@ describe('parseBuildRunnerImageArgs', () => {
     });
     expect(build).not.toHaveProperty('runnerVersion');
   });
+
+  it('accepts a JSON array of consumer account ids', () => {
+    const build = parseBuildRunnerImageArgs(
+      ['ubuntu24', 'aws'],
+      {
+        BUILD_ARCH: 'amd64',
+        BUILD_ATTEMPT: '1',
+        BUILD_CANDIDATE_EXPIRES_AT: '2026-08-03T10:00:00Z',
+        BUILD_CANDIDATE_ID: 'main-0123456789abcdef0123456789abcdef01234567',
+        BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS: '["123456789012","123456789012","210987654321"]',
+        BUILD_CANDIDATE_KMS_KEY_ID: 'alias/shipfox-runner-image-candidate',
+        BUILD_IMAGE_LIFECYCLE: 'candidate',
+        BUILD_NUMBER: '42',
+        BUILD_REVISION: '0123456789abcdef0123456789abcdef01234567',
+      },
+      '24.17.0',
+    );
+
+    expect(build).toMatchObject({
+      candidateConsumerAccountIds: ['123456789012', '210987654321'],
+    });
+  });
+
+  it('rejects malformed JSON consumer account ids', () => {
+    expect(() =>
+      parseBuildRunnerImageArgs(
+        ['ubuntu24', 'aws'],
+        {
+          BUILD_ARCH: 'amd64',
+          BUILD_ATTEMPT: '1',
+          BUILD_CANDIDATE_EXPIRES_AT: '2026-08-03T10:00:00Z',
+          BUILD_CANDIDATE_ID: 'main-0123456789abcdef0123456789abcdef01234567',
+          BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS: '[123456789012',
+          BUILD_CANDIDATE_KMS_KEY_ID: 'alias/shipfox-runner-image-candidate',
+          BUILD_IMAGE_LIFECYCLE: 'candidate',
+          BUILD_NUMBER: '42',
+          BUILD_REVISION: '0123456789abcdef0123456789abcdef01234567',
+        },
+        '24.17.0',
+      ),
+    ).toThrow('BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS must be a CSV or JSON array.');
+  });
+
+  it('rejects a non-array JSON value for consumer account ids', () => {
+    expect(() =>
+      parseBuildRunnerImageArgs(
+        ['ubuntu24', 'aws'],
+        {
+          BUILD_ARCH: 'amd64',
+          BUILD_ATTEMPT: '1',
+          BUILD_CANDIDATE_EXPIRES_AT: '2026-08-03T10:00:00Z',
+          BUILD_CANDIDATE_ID: 'main-0123456789abcdef0123456789abcdef01234567',
+          BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS: '{"account":"123456789012"}',
+          BUILD_CANDIDATE_KMS_KEY_ID: 'alias/shipfox-runner-image-candidate',
+          BUILD_IMAGE_LIFECYCLE: 'candidate',
+          BUILD_NUMBER: '42',
+          BUILD_REVISION: '0123456789abcdef0123456789abcdef01234567',
+        },
+        '24.17.0',
+      ),
+    ).toThrow('BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS must contain 12-digit AWS account IDs.');
+  });
+
+  it('rejects an empty consumer account id list', () => {
+    expect(() =>
+      parseBuildRunnerImageArgs(
+        ['ubuntu24', 'aws'],
+        {
+          BUILD_ARCH: 'amd64',
+          BUILD_ATTEMPT: '1',
+          BUILD_CANDIDATE_EXPIRES_AT: '2026-08-03T10:00:00Z',
+          BUILD_CANDIDATE_ID: 'main-0123456789abcdef0123456789abcdef01234567',
+          BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS: '[]',
+          BUILD_CANDIDATE_KMS_KEY_ID: 'alias/shipfox-runner-image-candidate',
+          BUILD_IMAGE_LIFECYCLE: 'candidate',
+          BUILD_NUMBER: '42',
+          BUILD_REVISION: '0123456789abcdef0123456789abcdef01234567',
+        },
+        '24.17.0',
+      ),
+    ).toThrow('BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS must contain 12-digit AWS account IDs.');
+  });
+
+  it('rejects a consumer account id that is not 12 digits', () => {
+    expect(() =>
+      parseBuildRunnerImageArgs(
+        ['ubuntu24', 'aws'],
+        {
+          BUILD_ARCH: 'amd64',
+          BUILD_ATTEMPT: '1',
+          BUILD_CANDIDATE_EXPIRES_AT: '2026-08-03T10:00:00Z',
+          BUILD_CANDIDATE_ID: 'main-0123456789abcdef0123456789abcdef01234567',
+          BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS: '123456789012,not-an-account-id',
+          BUILD_CANDIDATE_KMS_KEY_ID: 'alias/shipfox-runner-image-candidate',
+          BUILD_IMAGE_LIFECYCLE: 'candidate',
+          BUILD_NUMBER: '42',
+          BUILD_REVISION: '0123456789abcdef0123456789abcdef01234567',
+        },
+        '24.17.0',
+      ),
+    ).toThrow('BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS must contain 12-digit AWS account IDs.');
+  });
 });
 
 describe('runner image candidates', () => {
   const revision = '0123456789abcdef0123456789abcdef01234567';
+  const availableImage = (amiId: string, architecture: 'amd64' | 'arm64') => ({
+    ImageId: amiId,
+    State: 'available' as const,
+    OwnerId: '123456789012',
+    CreationDate: '2026-07-19T10:15:00Z',
+    Tags: [
+      {Key: 'shipfox.candidate_id', Value: `main-${revision}`},
+      {Key: 'shipfox.revision', Value: revision},
+      {Key: 'shipfox.architecture', Value: architecture},
+      {Key: 'shipfox.expires_at', Value: '2026-08-03T10:00:00Z'},
+    ],
+  });
 
   it('builds a candidate when no matching AMI exists', async () => {
     const build = parseBuildRunnerImageArgs(
@@ -269,13 +433,20 @@ describe('runner image candidates', () => {
         BUILD_ATTEMPT: '1',
         BUILD_CANDIDATE_EXPIRES_AT: '2026-08-03T10:00:00Z',
         BUILD_CANDIDATE_ID: `main-${revision}`,
+        BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS: '123456789012,210987654321',
+        BUILD_CANDIDATE_KMS_KEY_ID: 'alias/shipfox-runner-image-candidate',
         BUILD_IMAGE_LIFECYCLE: 'candidate',
         BUILD_NUMBER: '42',
         BUILD_REVISION: revision,
       },
       '24.17.0',
     );
-    const send = vi.fn().mockResolvedValue({Images: []});
+    const send = vi
+      .fn()
+      .mockResolvedValueOnce({Images: []})
+      .mockResolvedValueOnce({
+        Images: [availableImage('ami-0123abc456def7890', 'amd64')],
+      });
     const buildImage = vi.fn().mockResolvedValue({amiId: 'ami-0123abc456def7890'});
 
     const candidate = await buildRunnerImageCandidate(build, {
@@ -288,6 +459,10 @@ describe('runner image candidates', () => {
       amiId: 'ami-0123abc456def7890',
       architecture: 'amd64',
       candidateId: `main-${revision}`,
+      createdAt: '2026-07-19T10:15:00.000Z',
+      expiresAt: '2026-08-03T10:00:00.000Z',
+      imageOs: 'ubuntu24',
+      owner: '123456789012',
       region: 'eu-central-1',
       revision,
       status: 'built',
@@ -302,6 +477,8 @@ describe('runner image candidates', () => {
         BUILD_ATTEMPT: '1',
         BUILD_CANDIDATE_EXPIRES_AT: '2026-08-03T10:00:00Z',
         BUILD_CANDIDATE_ID: `main-${revision}`,
+        BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS: '123456789012,210987654321',
+        BUILD_CANDIDATE_KMS_KEY_ID: 'alias/shipfox-runner-image-candidate',
         BUILD_IMAGE_LIFECYCLE: 'candidate',
         BUILD_NUMBER: '42',
         BUILD_REVISION: revision,
@@ -309,7 +486,7 @@ describe('runner image candidates', () => {
       '24.17.0',
     );
     const send = vi.fn().mockResolvedValue({
-      Images: [{ImageId: 'ami-0fedcba9876543210', State: 'available'}],
+      Images: [availableImage('ami-0fedcba9876543210', 'arm64')],
     });
     const buildImage = vi.fn();
 
@@ -321,6 +498,19 @@ describe('runner image candidates', () => {
     expect(buildImage).not.toHaveBeenCalled();
     expect(candidate.status).toBe('reused');
     expect(candidate.amiId).toBe('ami-0fedcba9876543210');
+    expect(candidate.createdAt).toBe('2026-07-19T10:15:00.000Z');
+    expect(candidate.expiresAt).toBe('2026-08-03T10:00:00.000Z');
+    expect(candidate.owner).toBe('123456789012');
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: {
+          ImageId: 'ami-0fedcba9876543210',
+          LaunchPermission: {
+            Add: [{UserId: '123456789012'}, {UserId: '210987654321'}],
+          },
+        },
+      }),
+    );
   });
 
   it('rejects duplicate available candidate AMIs', async () => {
@@ -331,6 +521,8 @@ describe('runner image candidates', () => {
         BUILD_ATTEMPT: '1',
         BUILD_CANDIDATE_EXPIRES_AT: '2026-08-03T10:00:00Z',
         BUILD_CANDIDATE_ID: `main-${revision}`,
+        BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS: '123456789012,210987654321',
+        BUILD_CANDIDATE_KMS_KEY_ID: 'alias/shipfox-runner-image-candidate',
         BUILD_IMAGE_LIFECYCLE: 'candidate',
         BUILD_NUMBER: '42',
         BUILD_REVISION: revision,
@@ -349,10 +541,163 @@ describe('runner image candidates', () => {
     await expect(candidate).rejects.toThrow('Expected at most one amd64 candidate AMI');
   });
 
+  it('rejects a built AMI that is not available yet', async () => {
+    const build = parseBuildRunnerImageArgs(
+      ['ubuntu24', 'aws'],
+      {
+        BUILD_ARCH: 'amd64',
+        BUILD_ATTEMPT: '1',
+        BUILD_CANDIDATE_EXPIRES_AT: '2026-08-03T10:00:00Z',
+        BUILD_CANDIDATE_ID: `main-${revision}`,
+        BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS: '123456789012,210987654321',
+        BUILD_CANDIDATE_KMS_KEY_ID: 'alias/shipfox-runner-image-candidate',
+        BUILD_IMAGE_LIFECYCLE: 'candidate',
+        BUILD_NUMBER: '42',
+        BUILD_REVISION: revision,
+      },
+      '24.17.0',
+    );
+    const send = vi
+      .fn()
+      .mockResolvedValueOnce({Images: []})
+      .mockResolvedValueOnce({
+        Images: [{...availableImage('ami-0123abc456def7890', 'amd64'), State: 'pending'}],
+      });
+    const buildImage = vi.fn().mockResolvedValue({amiId: 'ami-0123abc456def7890'});
+
+    const candidate = buildRunnerImageCandidate(build, {
+      build: buildImage,
+      client: {send},
+      describeAvailabilityRetries: 0,
+    });
+
+    await expect(candidate).rejects.toThrow('is not available after the Packer build');
+  });
+
+  it('retries the availability check until the built AMI becomes available', async () => {
+    const build = parseBuildRunnerImageArgs(
+      ['ubuntu24', 'aws'],
+      {
+        BUILD_ARCH: 'amd64',
+        BUILD_ATTEMPT: '1',
+        BUILD_CANDIDATE_EXPIRES_AT: '2026-08-03T10:00:00Z',
+        BUILD_CANDIDATE_ID: `main-${revision}`,
+        BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS: '123456789012,210987654321',
+        BUILD_CANDIDATE_KMS_KEY_ID: 'alias/shipfox-runner-image-candidate',
+        BUILD_IMAGE_LIFECYCLE: 'candidate',
+        BUILD_NUMBER: '42',
+        BUILD_REVISION: revision,
+      },
+      '24.17.0',
+    );
+    const send = vi
+      .fn()
+      .mockResolvedValueOnce({Images: []})
+      .mockResolvedValueOnce({
+        Images: [{...availableImage('ami-0123abc456def7890', 'amd64'), State: 'pending'}],
+      })
+      .mockResolvedValueOnce({
+        Images: [availableImage('ami-0123abc456def7890', 'amd64')],
+      });
+    const buildImage = vi.fn().mockResolvedValue({amiId: 'ami-0123abc456def7890'});
+
+    const candidate = await buildRunnerImageCandidate(build, {
+      build: buildImage,
+      client: {send},
+      describeAvailabilityRetries: 1,
+      describeAvailabilityDelayMs: 1,
+    });
+
+    expect(candidate.status).toBe('built');
+    expect(candidate.amiId).toBe('ami-0123abc456def7890');
+  });
+
+  it('rejects a built AMI whose tags do not match the requested build', async () => {
+    const build = parseBuildRunnerImageArgs(
+      ['ubuntu24', 'aws'],
+      {
+        BUILD_ARCH: 'amd64',
+        BUILD_ATTEMPT: '1',
+        BUILD_CANDIDATE_EXPIRES_AT: '2026-08-03T10:00:00Z',
+        BUILD_CANDIDATE_ID: `main-${revision}`,
+        BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS: '123456789012,210987654321',
+        BUILD_CANDIDATE_KMS_KEY_ID: 'alias/shipfox-runner-image-candidate',
+        BUILD_IMAGE_LIFECYCLE: 'candidate',
+        BUILD_NUMBER: '42',
+        BUILD_REVISION: revision,
+      },
+      '24.17.0',
+    );
+    const send = vi
+      .fn()
+      .mockResolvedValueOnce({Images: []})
+      .mockResolvedValueOnce({
+        Images: [availableImage('ami-0123abc456def7890', 'arm64')],
+      });
+    const buildImage = vi.fn().mockResolvedValue({amiId: 'ami-0123abc456def7890'});
+
+    const candidate = buildRunnerImageCandidate(build, {build: buildImage, client: {send}});
+
+    await expect(candidate).rejects.toThrow('does not carry the expected build identity tags');
+  });
+
+  it('rejects a candidate AMI with no valid owner account', async () => {
+    const build = parseBuildRunnerImageArgs(
+      ['ubuntu24', 'aws'],
+      {
+        BUILD_ARCH: 'arm64',
+        BUILD_ATTEMPT: '1',
+        BUILD_CANDIDATE_EXPIRES_AT: '2026-08-03T10:00:00Z',
+        BUILD_CANDIDATE_ID: `main-${revision}`,
+        BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS: '123456789012,210987654321',
+        BUILD_CANDIDATE_KMS_KEY_ID: 'alias/shipfox-runner-image-candidate',
+        BUILD_IMAGE_LIFECYCLE: 'candidate',
+        BUILD_NUMBER: '42',
+        BUILD_REVISION: revision,
+      },
+      '24.17.0',
+    );
+    const send = vi.fn().mockResolvedValue({
+      Images: [{...availableImage('ami-0fedcba9876543210', 'arm64'), OwnerId: undefined}],
+    });
+
+    const candidate = buildRunnerImageCandidate(build, {client: {send}});
+
+    await expect(candidate).rejects.toThrow('has no valid owner account');
+  });
+
+  it('rejects a candidate AMI missing its expiry tag', async () => {
+    const build = parseBuildRunnerImageArgs(
+      ['ubuntu24', 'aws'],
+      {
+        BUILD_ARCH: 'arm64',
+        BUILD_ATTEMPT: '1',
+        BUILD_CANDIDATE_EXPIRES_AT: '2026-08-03T10:00:00Z',
+        BUILD_CANDIDATE_ID: `main-${revision}`,
+        BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS: '123456789012,210987654321',
+        BUILD_CANDIDATE_KMS_KEY_ID: 'alias/shipfox-runner-image-candidate',
+        BUILD_IMAGE_LIFECYCLE: 'candidate',
+        BUILD_NUMBER: '42',
+        BUILD_REVISION: revision,
+      },
+      '24.17.0',
+    );
+    const image = availableImage('ami-0fedcba9876543210', 'arm64');
+    const send = vi.fn().mockResolvedValue({
+      Images: [{...image, Tags: image.Tags.filter((tag) => tag.Key !== 'shipfox.expires_at')}],
+    });
+
+    const candidate = buildRunnerImageCandidate(build, {client: {send}});
+
+    await expect(candidate).rejects.toThrow('expiration time is missing');
+  });
+
   it('derives candidate metadata from the source revision and requires a result path', () => {
     const result = parseRunnerImageCandidateArgs(['--output', '/tmp/candidate.json'], {
       BUILD_ARCH: 'amd64',
       BUILD_ATTEMPT: '1',
+      BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS: '123456789012,210987654321',
+      BUILD_CANDIDATE_KMS_KEY_ID: 'alias/shipfox-runner-image-candidate',
       BUILD_NUMBER: '42',
       BUILD_REVISION: revision,
     });
@@ -363,6 +708,21 @@ describe('runner image candidates', () => {
       revision,
     });
     expect(result.outputPath).toBe('/tmp/candidate.json');
+  });
+
+  it('rejects candidate builds from non-main GitHub refs', () => {
+    expect(() =>
+      parseRunnerImageCandidateArgs(['--output', '/tmp/candidate.json'], {
+        BUILD_ARCH: 'amd64',
+        BUILD_ATTEMPT: '1',
+        BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS: '123456789012,210987654321',
+        BUILD_CANDIDATE_KMS_KEY_ID: 'alias/shipfox-runner-image-candidate',
+        BUILD_NUMBER: '42',
+        BUILD_REVISION: revision,
+        GITHUB_ACTIONS: 'true',
+        GITHUB_REF: 'refs/pull/1378/merge',
+      }),
+    ).toThrow('only be built and shared from main');
   });
 });
 

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -485,9 +485,12 @@ describe('runner image candidates', () => {
       },
       '24.17.0',
     );
-    const send = vi.fn().mockResolvedValue({
-      Images: [availableImage('ami-0fedcba9876543210', 'arm64')],
-    });
+    const send = vi
+      .fn()
+      .mockResolvedValueOnce({Images: [availableImage('ami-0fedcba9876543210', 'arm64')]})
+      .mockResolvedValueOnce({
+        LaunchPermissions: [{UserId: '123456789012'}, {UserId: '999999999999'}],
+      });
     const buildImage = vi.fn();
 
     const candidate = await buildRunnerImageCandidate(build, {
@@ -505,8 +508,17 @@ describe('runner image candidates', () => {
       expect.objectContaining({
         input: {
           ImageId: 'ami-0fedcba9876543210',
+          Attribute: 'launchPermission',
+        },
+      }),
+    );
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: {
+          ImageId: 'ami-0fedcba9876543210',
           LaunchPermission: {
             Add: [{UserId: '123456789012'}, {UserId: '210987654321'}],
+            Remove: [{UserId: '999999999999'}],
           },
         },
       }),
@@ -610,6 +622,45 @@ describe('runner image candidates', () => {
 
     expect(candidate.status).toBe('built');
     expect(candidate.amiId).toBe('ami-0123abc456def7890');
+  });
+
+  it('retries a transient AMI-not-found response during availability checks', async () => {
+    const build = parseBuildRunnerImageArgs(
+      ['ubuntu24', 'aws'],
+      {
+        BUILD_ARCH: 'amd64',
+        BUILD_ATTEMPT: '1',
+        BUILD_CANDIDATE_EXPIRES_AT: '2026-08-03T10:00:00Z',
+        BUILD_CANDIDATE_ID: `main-${revision}`,
+        BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS: '123456789012,210987654321',
+        BUILD_CANDIDATE_KMS_KEY_ID: 'alias/shipfox-runner-image-candidate',
+        BUILD_IMAGE_LIFECYCLE: 'candidate',
+        BUILD_NUMBER: '42',
+        BUILD_REVISION: revision,
+      },
+      '24.17.0',
+    );
+    const notFound = Object.assign(new Error('The image does not exist.'), {
+      name: 'InvalidAMIID.NotFound',
+    });
+    const send = vi
+      .fn()
+      .mockResolvedValueOnce({Images: []})
+      .mockRejectedValueOnce(notFound)
+      .mockResolvedValueOnce({
+        Images: [availableImage('ami-0123abc456def7890', 'amd64')],
+      });
+    const buildImage = vi.fn().mockResolvedValue({amiId: 'ami-0123abc456def7890'});
+
+    const candidate = await buildRunnerImageCandidate(build, {
+      build: buildImage,
+      client: {send},
+      describeAvailabilityRetries: 1,
+      describeAvailabilityDelayMs: 1,
+    });
+
+    expect(candidate.status).toBe('built');
+    expect(send).toHaveBeenCalledTimes(3);
   });
 
   it('rejects a built AMI whose tags do not match the requested build', async () => {
@@ -723,6 +774,20 @@ describe('runner image candidates', () => {
         GITHUB_REF: 'refs/pull/1378/merge',
       }),
     ).toThrow('only be built and shared from main');
+  });
+
+  it('rejects candidate builds for unsupported AWS regions', () => {
+    expect(() =>
+      parseRunnerImageCandidateArgs(['--output', '/tmp/candidate.json'], {
+        AWS_REGION: 'us-east-1',
+        BUILD_ARCH: 'amd64',
+        BUILD_ATTEMPT: '1',
+        BUILD_CANDIDATE_CONSUMER_ACCOUNT_IDS: '123456789012,210987654321',
+        BUILD_CANDIDATE_KMS_KEY_ID: 'alias/shipfox-runner-image-candidate',
+        BUILD_NUMBER: '42',
+        BUILD_REVISION: revision,
+      }),
+    ).toThrow('Runner image candidates must use eu-central-1.');
   });
 });
 

--- a/infra/images/runner/variable.pkr.hcl
+++ b/infra/images/runner/variable.pkr.hcl
@@ -17,6 +17,16 @@ variable "candidate_id" {
   default = ""
 }
 
+variable "candidate_kms_key_id" {
+  type    = string
+  default = ""
+}
+
+variable "candidate_ami_users" {
+  type    = list(string)
+  default = []
+}
+
 variable "architecture" {
   type    = string
   default = "amd64"


### PR DESCRIPTION
Adds the main-only runner-image candidate publication path for EC2 runner rollouts.

- Passes the candidate KMS key and consumer account IDs from CI into Packer so candidate AMIs are encrypted and shared.
- Reuses candidates by immutable revision and architecture identity, re-shares current launch permissions, and retries post-build availability checks.
- Publishes schema-validated amd64/arm64 OCI candidate manifests under the full source SHA without moving tags.
- Adds catalog/schema validation and negative-path coverage.

Candidate registry inputs remain repository variables, so account IDs and key IDs are not embedded in source defaults.

Closes ENG-1378

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes encrypted, shareable EC2 runner-image candidates on main and pushes one immutable OCI manifest per commit to `ghcr.io/shipfoxhq/runner-image-candidates`. Implements ENG-1378 with strict provenance, reuse, consumer-only permissions, and validation.

- **New Features**
  - CI builds amd64/arm64 candidate AMIs with KMS encryption and shares to configured consumer account IDs.
  - Reuses existing candidates by revision/arch, converges launch permissions to the configured consumer accounts (removes public/org shares), retries AMI availability with NotFound handling, and enforces `eu-central-1`.
  - Creates a v1 schema-validated candidate manifest (owner, candidateId, created/expires, OS, region, encrypted) and publishes under the full commit SHA without moving tags, re-checking the digest before push.
  - Adds `merge-candidates` to the catalog CLI and uploads per-arch candidate JSON results as build artifacts.

- **Migration**
  - Set repository variables `AWS_RUNNER_IMAGE_CANDIDATE_KMS_KEY_ID` and `AWS_RUNNER_IMAGE_CANDIDATE_CONSUMER_ACCOUNT_IDS` (CSV or JSON array of 12-digit IDs).
  - Ensure the GitHub OIDC role in the candidate account allows main-only builds.
  - Consumers resolve AMIs by tags: `shipfox.managed=true`, `shipfox.lifecycle=candidate`, `shipfox.candidate_id`, `shipfox.revision`, `shipfox.architecture`.

<sup>Written for commit d8242035f0b8a933075d904c0687b71094857fb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

