### PR TITLE
[runner-image] Encrypt candidate AMIs at volume launch

### DIFF
--- a/infra/images/runner/source.aws.pkr.hcl
+++ b/infra/images/runner/source.aws.pkr.hcl
@@ -2,8 +2,6 @@ source "amazon-ebs" "build_image" {
   ami_name                    = var.image_lifecycle == "candidate" ? "shipfox-runner-candidate-${var.candidate_id}-${var.architecture}" : "shipfox-runner-${var.image_os}-${var.architecture}-${var.build_number}-${var.build_attempt}"
   ami_virtualization_type     = "hvm"
   associate_public_ip_address = true
-  encrypt_boot                = true
-  kms_key_id                  = var.image_lifecycle == "candidate" ? var.candidate_kms_key_id : ""
   ami_users                   = var.image_lifecycle == "candidate" ? var.candidate_ami_users : []
   imds_support                = "v2.0"
   instance_type               = var.architecture == "amd64" ? "t3.large" : "t4g.large"
@@ -20,6 +18,15 @@ source "amazon-ebs" "build_image" {
     }
     most_recent = true
     owners      = ["099720109477"]
+  }
+
+  launch_block_device_mappings {
+    delete_on_termination = true
+    device_name           = "/dev/sda1"
+    encrypted             = true
+    kms_key_id            = var.image_lifecycle == "candidate" ? var.candidate_kms_key_id : ""
+    volume_size           = var.os_disk_size_gb
+    volume_type           = "gp3"
   }
 
   tags = merge({


### PR DESCRIPTION
Packer's `encrypt_boot` path creates an intermediary AMI and calls `ec2:CopyImage` when applying the candidate KMS key. The runner-image build role reserves that action for candidate-to-release promotion, so both candidate architectures failed with `UnauthorizedOperation` in [CI run 30396584664](https://github.com/ShipfoxHQ/shipfox/actions/runs/30396584664).

Encrypt the root EBS volume directly when launching the build instance. The resulting AMI remains encrypted with the configured candidate key, while the build avoids the unnecessary same-region copy and does not require broader IAM permissions.

Validated with the runner-image Packer verifier, an explicit candidate `packer validate`, and scoped `check`, `type`, and `build` tasks for `@shipfox/runner-image` and its dependency graph.

Related to ENG-1378

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Encrypt candidate runner AMIs at volume launch to avoid Packer’s same-region CopyImage and the resulting UnauthorizedOperation, per ENG-1378. The root EBS volume is now encrypted on instance launch with the candidate KMS key; the AMI stays encrypted without broader IAM.

- **Bug Fixes**
  - Use launch_block_device_mappings to encrypt /dev/sda1 with the candidate KMS key.
  - Remove encrypt_boot and top-level kms_key_id; no CopyImage during build.
  - Validated via Packer verifier, packer validate, and scoped check/type/build tasks for `@shipfox/runner-image`.

<sup>Written for commit 811f6d8e65f7898c593428edcd1c1c69f1610356. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

