### PR TITLE
[runner-image] Tag candidate AMIs before sharing them with worker accounts

### DIFF
--- a/infra/images/runner/locals.aws.pkr.hcl
+++ b/infra/images/runner/locals.aws.pkr.hcl
@@ -1,4 +1,24 @@
 locals {
   aws_architecture    = var.architecture == "amd64" ? "x86_64" : "arm64"
   ubuntu_architecture = var.architecture
+
+  image_name = var.image_lifecycle == "candidate" ? "shipfox-runner-candidate-${var.candidate_id}-${var.architecture}" : "shipfox-runner-${var.image_os}-${var.architecture}-${var.build_number}-${var.build_attempt}"
+
+  image_tags = merge({
+    Name                    = local.image_name
+    "shipfox.build_attempt" = var.build_attempt
+    "shipfox.build_number"  = var.build_number
+    "shipfox.image_os"      = var.image_os
+    "shipfox.architecture"  = var.architecture
+    "shipfox.runner"        = "@shipfox/runner"
+    "shipfox.revision"      = var.revision
+    "shipfox.lifecycle"     = var.image_lifecycle
+    "shipfox.managed"       = "true"
+    },
+    var.image_lifecycle == "candidate" ? {
+      "shipfox.candidate_id" = var.candidate_id
+      "shipfox.expires_at"   = var.candidate_expires_at
+    } : {},
+    var.runner_version != "" ? { "shipfox.runner_version" = var.runner_version } : {},
+  )
 }

--- a/infra/images/runner/source.aws.pkr.hcl
+++ b/infra/images/runner/source.aws.pkr.hcl
@@ -1,5 +1,5 @@
 source "amazon-ebs" "build_image" {
-  ami_name                    = var.image_lifecycle == "candidate" ? "shipfox-runner-candidate-${var.candidate_id}-${var.architecture}" : "shipfox-runner-${var.image_os}-${var.architecture}-${var.build_number}-${var.build_attempt}"
+  ami_name                    = local.image_name
   ami_virtualization_type     = "hvm"
   associate_public_ip_address = true
   ami_users                   = var.image_lifecycle == "candidate" ? var.candidate_ami_users : []
@@ -29,21 +29,10 @@ source "amazon-ebs" "build_image" {
     volume_type           = "gp3"
   }
 
-  tags = merge({
-    Name                    = var.image_lifecycle == "candidate" ? "shipfox-runner-candidate-${var.candidate_id}-${var.architecture}" : "shipfox-runner-${var.image_os}-${var.architecture}-${var.build_number}-${var.build_attempt}"
-    "shipfox.build_attempt" = var.build_attempt
-    "shipfox.build_number"  = var.build_number
-    "shipfox.image_os"      = var.image_os
-    "shipfox.architecture"  = var.architecture
-    "shipfox.runner"        = "@shipfox/runner"
-    "shipfox.revision"      = var.revision
-    "shipfox.lifecycle"     = var.image_lifecycle
-    "shipfox.managed"       = "true"
-    },
-    var.image_lifecycle == "candidate" ? {
-      "shipfox.candidate_id" = var.candidate_id
-      "shipfox.expires_at"   = var.candidate_expires_at
-    } : {},
-    var.runner_version != "" ? { "shipfox.runner_version" = var.runner_version } : {},
-  )
+  tags = local.image_tags
+
+  # Packer shares the AMI (ModifyImageAttribute) before it applies `tags`, so a
+  # tag-scoped sharing policy only matches when the tags exist at registration.
+  # `run_tags` are attached through CreateImage's tag specifications.
+  run_tags = local.image_tags
 }


### PR DESCRIPTION
Every `main` build has failed since candidate publishing landed. Packer registers the AMI, then fails with `UnauthorizedOperation` on `ec2:ModifyImageAttribute`, the call that shares the candidate with the staging and production worker accounts.

The build role does grant that action, but it scopes it to images tagged `shipfox.managed=true` and `shipfox.lifecycle=candidate`. Packer runs its modify-attributes step before its create-tags step, so the AMI was still untagged at the moment it was shared and the conditions could not match.

This passes the existing tag map as `run_tags` in addition to `tags`. Packer attaches run tags through the `CreateImage` tag specifications, so the image is tagged at registration. The tag-scoped policy now matches, and a managed image is never registered untagged, which also closes a window where the discovery contract did not hold. The AMI name and tag map moved into locals because both settings need them.

This is one of two required changes. The same policy statement also gates the action on `ec2:Attribute = launchPermission`, which AWS cannot populate for the multi-property `LaunchPermission` object, so the share is denied even once the tags are correct. Removing that condition and applying the unit is a follow-up in `ShipfoxHQ/cloud`. Candidate publishing stays red until both land.

Refs ENG-1378

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tag runner AMIs at registration so the tag-scoped sharing policy matches when Packer modifies launch permissions. Fixes `main` image build failures after candidate publishing and aligns with ENG-1378.

- **Bug Fixes**
  - Pass the existing tag map as `run_tags` so tags exist at AMI creation and sharing to worker accounts is authorized.
  - Move AMI name and tag map to `locals` and reuse for `ami_name`, `tags`, and `run_tags`.
  - Note: Candidate publishing stays red until the companion policy change in `ShipfoxHQ/cloud` removes the `ec2:Attribute=launchPermission` condition (ENG-1378).

<sup>Written for commit 44e4fd6371339907d965ccd40200360a3df56f9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

