### PR TITLE
[runner-image] Fix runner AMI boot activation

### DIFF
--- a/infra/images/runner/assets/shipfox-max-lifetime.service
+++ b/infra/images/runner/assets/shipfox-max-lifetime.service
@@ -9,4 +9,4 @@ Type=oneshot
 ExecStart=/opt/shipfox-runner/scripts/runtime/start-max-lifetime.sh
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=cloud-init.target

--- a/infra/images/runner/assets/shipfox-runner.service
+++ b/infra/images/runner/assets/shipfox-runner.service
@@ -22,4 +22,4 @@ StandardError=journal
 SyslogIdentifier=shipfox-runner
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=cloud-init.target

--- a/infra/images/runner/build.pkr.hcl
+++ b/infra/images/runner/build.pkr.hcl
@@ -40,10 +40,6 @@ build {
     ]
   }
 
-  provisioner "shell" {
-    inline = ["sudo passwd --lock ubuntu"]
-  }
-
   provisioner "file" {
     destination = "/tmp/shipfox-spot-watchdog.service"
     source      = abspath("${path.root}/assets/shipfox-spot-watchdog.service")
@@ -64,6 +60,14 @@ build {
       "sudo systemctl enable shipfox-spot-watchdog.service"
     ]
     only = ["amazon-ebs.build_image"]
+  }
+
+  provisioner "shell" {
+    inline = [
+      "sudo passwd --lock ubuntu",
+      "sudo rm -f /home/ubuntu/.ssh/authorized_keys",
+      "sudo test ! -e /home/ubuntu/.ssh/authorized_keys"
+    ]
   }
 
   post-processor "manifest" {

--- a/infra/images/runner/build.pkr.hcl
+++ b/infra/images/runner/build.pkr.hcl
@@ -62,6 +62,7 @@ build {
     only = ["amazon-ebs.build_image"]
   }
 
+  # Harden the build user only after every provisioner that needs Packer's SSH access has run.
   provisioner "shell" {
     inline = [
       "sudo passwd --lock ubuntu",


### PR DESCRIPTION
## Summary

The validated runner-image candidate did not start the runner or maximum-lifetime watchdog automatically because their `multi-user.target` activation formed an ordering cycle with `cloud-final.service`.

Activate both services through the cloud-init completion target so they can start after cloud-final, and remove the Packer build key from the baked `ubuntu` account during final image hardening.

## Validation

- `pnpm --filter=@shipfox/runner-image check`
- `pnpm --filter=@shipfox/runner-image type`
- `pnpm --filter=@shipfox/runner-image test` (50 tests)
- `pnpm --filter=@shipfox/runner-image verify`
- `turbo build depcruise --filter=@shipfox/runner-image...`
- Ubuntu 24.04 systemd transaction verification against the enabled cloud-init graph

After merge, the main workflow must produce a replacement immutable candidate and ENG-1390 must complete the staging registration, job, shutdown, watchdog, diagnostics, and baked-key smoke checks before ENG-1380 pins it.

Refs ENG-1390

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix runner AMI boot activation in `@shipfox/runner-image` by enabling the runner and max‑lifetime services under `cloud-init.target` so they start after `cloud-final` without an ordering cycle. Harden the image by locking `ubuntu`, removing the baked Packer SSH key, and documenting that this runs as the final provisioner; satisfies ENG-1390 boot/watchdog checks and unblocks ENG-1380 pin.

<sup>Written for commit f9ff468f589b96c1c7b99522a2f14f52c82aaad4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

