### PR TITLE
[client-workflows] Show execution names in job card titles

### DIFF
--- a/.changeset/bright-job-titles.md
+++ b/.changeset/bright-job-titles.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-workflows": patch
+---
+
+Displays resolved job execution names in workflow run job card titles.

--- a/libs/client/workflows/src/components/workflow-run-view/job-card.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/job-card.tsx
@@ -71,6 +71,7 @@ export function JobCard({
     jobExecutionId: undefined,
     attemptId: null,
   });
+  const title = selectedJobExecution?.name ?? job.displayName;
   const selectedExecutionStatus = selectedJobExecution?.status ?? job.status;
   const effectiveSelectedAttemptId =
     selectedAttemptId === undefined &&
@@ -125,7 +126,7 @@ export function JobCard({
           onSelectedJobExecutionChange ? (
             <>
               <Text as="h2" id={titleId} size="sm" bold className="sr-only">
-                {job.displayName}
+                {title}
               </Text>
               <div className="flex min-w-0 items-center gap-8">
                 <JobStatusBadge status={selectedExecutionStatus} />
@@ -147,7 +148,7 @@ export function JobCard({
                 bold
                 className="min-w-0 truncate text-foreground-neutral-base"
               >
-                {job.displayName}
+                {title}
               </Text>
             </div>
           )}

--- a/libs/client/workflows/src/components/workflow-run-view/job-execution-switcher.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/job-execution-switcher.tsx
@@ -65,7 +65,7 @@ export function JobExecutionSwitcher({
         aria-label={`Switch job execution, currently execution ${selected.sequence}`}
       >
         {variant === 'title' ? (
-          <TitleExecutionSummary job={job} execution={selected} />
+          <TitleExecutionSummary execution={selected} />
         ) : (
           <ExecutionSummary execution={selected} />
         )}
@@ -119,14 +119,14 @@ export function JobExecutionSwitcher({
   );
 }
 
-function TitleExecutionSummary({job, execution}: {job: Job; execution: JobExecution}) {
+function TitleExecutionSummary({execution}: {execution: JobExecution}) {
   return (
     <span className="flex min-w-0 items-center gap-8">
       <Text as="span" size="sm" bold className="shrink-0 text-foreground-neutral-base">
         #{execution.sequence}
       </Text>
       <Text as="span" size="sm" bold className="min-w-0 truncate text-foreground-neutral-base">
-        {job.displayName}
+        {execution.name}
       </Text>
     </span>
   );

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -29,6 +29,7 @@ const RERUN_BUTTON_NAME = /^Re-run/;
 const ATTEMPT_2_PATTERN = /Attempt 2/;
 const COPY_RUN_BUTTON_NAME = /Copy run/;
 const EXECUTION_ONE_MENU_ITEM_PATTERN = /#1/;
+const JOB_TEMPLATE_NAME = ['Implement $', '{{ event.issue.identifier }}'].join('');
 
 describe('WorkflowRunView', () => {
   test('renders the run summary, jobs graph, and selected job step attempts when a run loads', async () => {
@@ -53,6 +54,37 @@ describe('WorkflowRunView', () => {
     expect(
       screen.getByRole('button', {name: 'checkout, Succeeded, attempt 1'}),
     ).toBeInTheDocument();
+  });
+
+  test('uses the selected job execution name as the job card title', async () => {
+    configureApiClient({
+      fetchImpl: vi.fn(() =>
+        Promise.resolve(
+          jsonResponse(
+            workflowRunViewDetailDto({
+              jobs: [
+                workflowJobDto({
+                  id: BUILD_JOB_ID,
+                  run_attempt_id: RUN_ID,
+                  name: JOB_TEMPLATE_NAME,
+                  job_executions: [
+                    workflowJobExecutionDto({
+                      job_id: BUILD_JOB_ID,
+                      name: 'Implement ENG-123',
+                    }),
+                  ],
+                }),
+              ],
+            }),
+          ),
+        ),
+      ),
+    });
+
+    renderView();
+
+    expect(await screen.findByRole('region', {name: 'Implement ENG-123'})).toBeInTheDocument();
+    expect(screen.queryByRole('region', {name: JOB_TEMPLATE_NAME})).not.toBeInTheDocument();
   });
 
   test('renders active step attempt logs inline when the selected job is running', async () => {
@@ -125,6 +157,7 @@ describe('WorkflowRunView', () => {
                       id: '77777777-7777-4777-8777-000000000001',
                       job_id: BUILD_JOB_ID,
                       sequence: 1,
+                      name: 'Pull request event',
                       status: 'succeeded',
                       trigger_events: [
                         {
@@ -155,6 +188,7 @@ describe('WorkflowRunView', () => {
                       id: '77777777-7777-4777-8777-000000000002',
                       job_id: BUILD_JOB_ID,
                       sequence: 2,
+                      name: 'Deployment status event',
                       status: 'failed',
                       status_reason: 'step_failed',
                       trigger_events: [
@@ -200,6 +234,9 @@ describe('WorkflowRunView', () => {
     });
 
     renderView();
+    expect(
+      await screen.findByRole('region', {name: 'Deployment status event'}),
+    ).toBeInTheDocument();
     expect(await screen.findByText('second-event')).toBeInTheDocument();
     expect(
       await screen.findByRole('button', {name: 'github · deployment_status (2 events)'}),
@@ -212,6 +249,7 @@ describe('WorkflowRunView', () => {
     await user.click(screen.getByRole('menuitem', {name: EXECUTION_ONE_MENU_ITEM_PATTERN}));
 
     expect(await screen.findByText('first-event')).toBeInTheDocument();
+    expect(screen.getByRole('region', {name: 'Pull request event'})).toBeInTheDocument();
     expect(screen.queryByText('second-event')).not.toBeInTheDocument();
     expect(await screen.findByRole('button', {name: 'github · pull_request'})).toBeInTheDocument();
     expect(screen.getByText('pull_request')).toBeInTheDocument();


### PR DESCRIPTION
Job card titles previously used the static job definition name, so resolved execution names such as issue-specific labels were not shown.

Use the selected job execution name for both regular and listening job card headers, including after switching executions. Add focused regression coverage and a patch Changeset for `@shipfox/client-workflows`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Job card titles now use the selected job execution name. This shows resolved labels (e.g., issue numbers) instead of the static job definition name.

- **Bug Fixes**
  - Applies to both regular and listening job cards and persists after switching executions.
  - Updates title summary to read from `execution.name` instead of `job.displayName`.
  - Adds focused tests and a patch changeset for `@shipfox/client-workflows`.

<sup>Written for commit 55cecd3bd56f0f547a04cf301054aa34bf2652df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

