### PR TITLE
[runner-image] Fix Spot watchdog boot activation

### DIFF
--- a/infra/images/runner/assets/shipfox-spot-watchdog.service
+++ b/infra/images/runner/assets/shipfox-spot-watchdog.service
@@ -10,4 +10,4 @@ Restart=always
 RestartSec=5s
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=cloud-init.target

--- a/infra/images/runner/test/runner-image.test.ts
+++ b/infra/images/runner/test/runner-image.test.ts
@@ -1,4 +1,5 @@
 import {execFileSync} from 'node:child_process';
+import {readdir, readFile} from 'node:fs/promises';
 import {findProducedAmiId, parsePackerAmiArtifact} from '#aws.js';
 import {parseBuildRunnerImageArgs} from '#build-runner-image.js';
 import {buildRunnerImageCandidate, parseRunnerImageCandidateArgs} from '#candidate.js';
@@ -838,5 +839,19 @@ describe('spot watchdog runtime script', () => {
     );
 
     expect(result.trim()).toBe('reboot');
+  });
+});
+
+describe('systemd boot activation', () => {
+  it('activates every installable Shipfox service after cloud-init', async () => {
+    const assets = new URL('../assets/', import.meta.url);
+    const unitNames = (await readdir(assets)).filter((name) => name.endsWith('.service'));
+
+    for (const unitName of unitNames) {
+      const unit = await readFile(new URL(unitName, assets), 'utf8');
+      if (!unit.includes('[Install]')) continue;
+
+      expect(unit, unitName).toContain('WantedBy=cloud-init.target');
+    }
   });
 });


### PR DESCRIPTION
## Summary

Staging validation of the replacement runner image exposed one remaining Ubuntu boot ordering cycle: the Spot watchdog was enabled by `multi-user.target` while ordering itself after the post-cloud-init runner.

Activate the watchdog through `cloud-init.target` so it still starts after the runner without joining the earlier boot transaction. Add a focused unit-level invariant that every installable baked Shipfox service uses the post-cloud-init target, without coupling the test to Packer HCL.

## Validation

- `pnpm --filter=@shipfox/runner-image check`
- `pnpm --filter=@shipfox/runner-image type`
- `pnpm --filter=@shipfox/runner-image test` (51 tests)
- `pnpm --filter=@shipfox/runner-image verify`
- `turbo check type test build depcruise --filter=@shipfox/runner-image...`
- Ubuntu 24.04 `systemd-analyze verify` against the enabled cloud-init transaction

## Remaining ENG-1390 work

After merge, main CI must build a new immutable amd64 candidate. Staging must then verify automatic activation, runner job execution and shutdown, maximum-lifetime termination, Spot handling, diagnostics, and absence of the Packer SSH key before ENG-1390 can close.

Refs ENG-1390