### PR TITLE
Add workflow run and job execution naming contracts

### DIFF
--- a/.changeset/naming-contract-foundation.md
+++ b/.changeset/naming-contract-foundation.md
@@ -1,0 +1,8 @@
+---
+"@shipfox/workflow-document": minor
+"@shipfox/expression": minor
+"@shipfox/api-definitions-dto": minor
+"@shipfox/api-definitions": minor
+---
+
+Add workflow run and job execution naming fields to the authoring, expression, and normalized definition contracts.

--- a/libs/api/definitions-dto/src/workflow-model.ts
+++ b/libs/api/definitions-dto/src/workflow-model.ts
@@ -27,6 +27,7 @@ export type WorkflowOutputTemplates = Readonly<Record<string, WorkflowFieldTempl
 export interface WorkflowModel {
   readonly kind: 'workflow';
   readonly name: string;
+  readonly runName?: WorkflowFieldTemplate;
   readonly env?: Readonly<Record<string, string>>;
   readonly templates?: {readonly env?: WorkflowEnvTemplates};
   readonly triggers: readonly WorkflowModelTrigger[];
@@ -58,6 +59,7 @@ export interface WorkflowModelJob {
   readonly executionTimeoutMs?: number;
   readonly listening?: WorkflowModelJobListening;
   readonly name?: WorkflowFieldTemplate;
+  readonly executionName?: WorkflowFieldTemplate;
   readonly env?: Readonly<Record<string, string>>;
   readonly templates?: {readonly env?: WorkflowEnvTemplates};
   readonly dependencies: readonly string[];

--- a/libs/api/definitions/src/core/workflow-model/invalid-workflow-model-error.ts
+++ b/libs/api/definitions/src/core/workflow-model/invalid-workflow-model-error.ts
@@ -2,6 +2,7 @@ export const invalidWorkflowModelErrorCode = 'invalid-workflow-model';
 
 export type WorkflowModelValidationIssueCode =
   | 'context-unavailable-at-fill-site'
+  | 'dynamic-name-self-reference'
   | 'context-unavailable-at-predicate-site'
   | 'computed-context-key'
   | 'duplicate-job-id'

--- a/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
@@ -253,6 +253,18 @@ function normalizeJob(params: {
           allowedJobReferences,
           typeOverlay: upstreamJobsTypeOverlay,
         }) ?? [{kind: 'literal' as const, value: params.job.name}]);
+  const executionName =
+    params.job.execution_name === undefined
+      ? undefined
+      : (parseInterpolationField({
+          field: 'job.execution_name',
+          source: params.job.execution_name,
+          path: ['jobs', params.sourceName, 'execution_name'],
+          issues: params.issues,
+          fillSite: 'execution-creation',
+          allowedJobReferences,
+          typeOverlay: upstreamJobsTypeOverlay,
+        }) ?? [{kind: 'literal' as const, value: params.job.execution_name}]);
 
   return {
     id,
@@ -268,6 +280,7 @@ function normalizeJob(params: {
     ...(executionTimeoutMs === undefined ? {} : {executionTimeoutMs}),
     ...(listening === undefined ? {} : {listening}),
     ...(name === undefined ? {} : {name}),
+    ...(executionName === undefined ? {} : {executionName}),
     ...jobEnv,
     dependencies,
     steps,

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -79,6 +79,137 @@ const integrationValidationContext = {
 } satisfies IntegrationValidationContext;
 
 describe('normalizeWorkflowDocument', () => {
+  it('normalizes workflow run and job execution name templates', () => {
+    const model = normalizeWorkflowDocument({
+      name: 'Deploy application',
+      run_name: `Deploy ${interpolation('inputs.environment')}`,
+      jobs: {
+        deploy: {
+          name: 'Deploy',
+          execution_name: `Deploy ${interpolation('event.environment')}`,
+          steps: [{run: 'deploy'}],
+        },
+      },
+    });
+
+    expect(model.runName).toMatchObject([
+      {kind: 'literal', value: 'Deploy '},
+      {kind: 'deferred', roots: ['inputs'], fillTarget: 'run-creation'},
+    ]);
+    expect(model.jobs[0]?.executionName).toMatchObject([
+      {kind: 'literal', value: 'Deploy '},
+      {kind: 'deferred', roots: ['event'], fillTarget: 'execution-creation'},
+    ]);
+  });
+
+  it('preserves literal workflow run and job execution names', () => {
+    const model = normalizeWorkflowDocument({
+      name: 'Workflow',
+      run_name: 'Static run name',
+      jobs: {
+        build: {
+          execution_name: 'Static execution name',
+          steps: [{run: 'build'}],
+        },
+      },
+    });
+
+    expect(model.runName).toEqual([{kind: 'literal', value: 'Static run name'}]);
+    expect(model.jobs[0]?.executionName).toEqual([
+      {kind: 'literal', value: 'Static execution name'},
+    ]);
+  });
+
+  it.each([
+    [
+      'run_name',
+      {
+        name: 'Workflow',
+        run_name: interpolation('steps.build.outputs.name'),
+        jobs: {build: {steps: [{run: 'build'}]}},
+      },
+    ],
+    [
+      'execution_name',
+      {
+        name: 'Workflow',
+        jobs: {
+          build: {
+            execution_name: interpolation('steps.build.outputs.name'),
+            steps: [{run: 'build'}],
+          },
+        },
+      },
+    ],
+  ] as const)('rejects unavailable context in %s', (_field, document) => {
+    const error = expectInvalid(document as unknown as WorkflowDocument);
+    expect(error.issues).toEqual([
+      expect.objectContaining({code: 'context-unavailable-at-fill-site'}),
+    ]);
+  });
+
+  it('allows computed access to unrelated dynamic-name context fields', () => {
+    const model = normalizeWorkflowDocument({
+      name: 'Workflow',
+      run_name: interpolation('run["name"]'),
+      jobs: {
+        build: {
+          execution_name: interpolation('execution["status"]'),
+          steps: [{run: 'build'}],
+        },
+      },
+    });
+
+    expect(model.runName).toMatchObject([{kind: 'deferred', roots: ['run']}]);
+    expect(model.jobs[0]?.executionName).toMatchObject([{kind: 'deferred', roots: ['execution']}]);
+  });
+
+  it.each([
+    [
+      'run_name',
+      {
+        name: 'Workflow',
+        run_name: interpolation('run.run_name'),
+        jobs: {build: {steps: [{run: 'build'}]}},
+      },
+    ],
+    [
+      'run_name bracket access',
+      {
+        name: 'Workflow',
+        run_name: interpolation('run["run_name"]'),
+        jobs: {build: {steps: [{run: 'build'}]}},
+      },
+    ],
+    [
+      'execution_name',
+      {
+        name: 'Workflow',
+        jobs: {
+          build: {
+            execution_name: interpolation('execution.name'),
+            steps: [{run: 'build'}],
+          },
+        },
+      },
+    ],
+    [
+      'execution_name bracket access',
+      {
+        name: 'Workflow',
+        jobs: {
+          build: {
+            execution_name: interpolation('execution["name"]'),
+            steps: [{run: 'build'}],
+          },
+        },
+      },
+    ],
+  ] as const)('rejects dynamic-name self-reference in %s', (_field, document) => {
+    const error = expectInvalid(document as unknown as WorkflowDocument);
+    expect(error.issues).toEqual([expect.objectContaining({code: 'dynamic-name-self-reference'})]);
+  });
+
   it('normalizes a workflow document into a WorkflowModel', () => {
     const document: WorkflowDocument = {
       name: 'simple build',

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.ts
@@ -12,6 +12,7 @@ import {normalizeDependencies, validateCycles} from './normalize-dependencies.js
 import {normalizeEnv} from './normalize-env.js';
 import {normalizeJobs} from './normalize-jobs.js';
 import {normalizeTriggers} from './normalize-triggers.js';
+import {parseInterpolationField} from './parse-interpolation-field.js';
 
 export function normalizeWorkflowDocument(
   document: WorkflowDocument,
@@ -40,6 +41,16 @@ export function normalizeWorkflowDocument(
   );
   const dependencies = normalizeDependencies(document.jobs, jobIdBySourceName, issues);
   const workflowEnv = normalizeEnv({env: document.env, path: ['env'], issues});
+  const runName =
+    document.run_name === undefined
+      ? undefined
+      : (parseInterpolationField({
+          field: 'workflow.run_name',
+          source: document.run_name,
+          path: ['run_name'],
+          issues,
+          fillSite: 'run-creation',
+        }) ?? [{kind: 'literal' as const, value: document.run_name}]);
 
   validateCycles(document.jobs, jobIdBySourceName, issues);
 
@@ -50,6 +61,7 @@ export function normalizeWorkflowDocument(
   return {
     kind: 'workflow',
     name: document.name,
+    ...(runName === undefined ? {} : {runName}),
     ...workflowEnv,
     triggers,
     jobs,

--- a/libs/api/definitions/src/core/workflow-model/parse-interpolation-field.ts
+++ b/libs/api/definitions/src/core/workflow-model/parse-interpolation-field.ts
@@ -2,6 +2,7 @@ import {secretKeySchema, secretStoreSchema} from '@shipfox/api-secrets-dto';
 import {
   type AvailabilitySite,
   analyzeContextKeyAccess,
+  analyzeContextRootKeyAccess,
   createWorkflowExpression,
   type ExpressionTypeEnvironment,
   extractCelUntrustedPathAccesses,
@@ -10,6 +11,7 @@ import {
   getWorkflowContextHost,
   getWorkflowContextTypeEnvironment,
   getWorkflowContextUntrustedPaths,
+  getWorkflowInterpolationFieldSelfReference,
   InvalidWorkflowExpressionError,
   InvalidWorkflowTemplateError,
   type PlanViolation,
@@ -41,6 +43,8 @@ export type StoredInterpolationField =
   | 'agent.provider'
   | 'job.outputs'
   | 'job.name'
+  | 'workflow.run_name'
+  | 'job.execution_name'
   | 'job.runner'
   | 'step.name'
   | 'step.feedback';
@@ -76,6 +80,38 @@ export function parseInterpolationField(params: {
   }
 
   return plan.plan.field.segments;
+}
+
+function dynamicNameSelfReference(params: {
+  field: StoredInterpolationField;
+  source: string;
+  path: readonly WorkflowModelValidationIssuePathSegment[];
+  segment: WorkflowTemplateExprSegment;
+}): WorkflowModelValidationIssue | undefined {
+  const target = getWorkflowInterpolationFieldSelfReference(params.field);
+  if (target === undefined) return undefined;
+
+  const access = analyzeContextRootKeyAccess(params.segment.expression, [target.root]);
+  const reference = access.references.find((entry) => entry.key === target.key);
+  const computedReference = access.violations.find(
+    (violation) =>
+      violation.root === target.root &&
+      (violation.key === undefined || violation.key === target.key),
+  );
+  if (reference === undefined && computedReference === undefined) return undefined;
+
+  return issue({
+    code: 'dynamic-name-self-reference',
+    message: `${fieldLabel(params.field)} interpolation cannot reference its own dynamic name.`,
+    path: params.path,
+    details: {
+      field: params.field,
+      source: params.source,
+      expression: params.segment.expression.source,
+      reference:
+        reference === undefined ? `${target.root}[computed]` : `${reference.root}.${reference.key}`,
+    },
+  });
 }
 
 function parseTemplate(params: {
@@ -148,6 +184,12 @@ function validateExpressionSegment(params: {
         }),
       ),
     );
+    return undefined;
+  }
+
+  const selfReference = dynamicNameSelfReference(params);
+  if (selfReference !== undefined) {
+    params.issues.push(selfReference);
     return undefined;
   }
 

--- a/libs/api/definitions/src/core/workflow-model/workflow-field-label.ts
+++ b/libs/api/definitions/src/core/workflow-model/workflow-field-label.ts
@@ -22,6 +22,10 @@ export function workflowFieldLabel(
       return 'Job outputs mapping';
     case 'job.name':
       return 'Job name interpolation';
+    case 'workflow.run_name':
+      return 'Workflow run name interpolation';
+    case 'job.execution_name':
+      return 'Job execution name interpolation';
     case 'step.name':
       return 'Step name interpolation';
     case 'step.success':

--- a/libs/api/workflows/test/factories/workflow-model.ts
+++ b/libs/api/workflows/test/factories/workflow-model.ts
@@ -42,6 +42,7 @@ const DEFAULT_RUNNER_LABELS = ['ubuntu-latest'] as const;
 interface TestWorkflowJob {
   readonly needs?: string | readonly string[] | undefined;
   readonly name?: string | undefined;
+  readonly executionName?: string | undefined;
   readonly runner?: string | readonly string[] | undefined;
   readonly runnerTemplates?: readonly string[] | undefined;
   readonly checkout?: WorkflowModel['jobs'][number]['checkout'] | undefined;
@@ -55,6 +56,7 @@ interface TestWorkflowJob {
 
 interface TestWorkflowModelInput {
   readonly name?: string | undefined;
+  readonly runName?: string | undefined;
   readonly runner?: string | readonly string[] | undefined;
   readonly env?: WorkflowModel['env'] | undefined;
   readonly jobs?: Readonly<Record<string, TestWorkflowJob>> | undefined;
@@ -91,6 +93,13 @@ export function workflowModel(input: TestWorkflowModelInput = {}): WorkflowModel
               {kind: 'literal' as const, value: job.name},
             ],
           }),
+      ...(job.executionName === undefined
+        ? {}
+        : {
+            executionName: fieldTemplate('job.execution_name', job.executionName) ?? [
+              {kind: 'literal' as const, value: job.executionName},
+            ],
+          }),
       ...(job.listening === undefined ? {} : {listening: job.listening}),
       ...optionalScopedEnv(job.env),
       dependencies: normalizeStringArray(job.needs).map(stableId),
@@ -101,6 +110,13 @@ export function workflowModel(input: TestWorkflowModelInput = {}): WorkflowModel
   return {
     kind: 'workflow',
     name: input.name ?? 'Test Workflow',
+    ...(input.runName === undefined
+      ? {}
+      : {
+          runName: fieldTemplate('workflow.run_name', input.runName) ?? [
+            {kind: 'literal' as const, value: input.runName},
+          ],
+        }),
     ...optionalScopedEnv(input.env),
     triggers: [],
     jobs: modelJobs,

--- a/libs/shared/expression/src/index.ts
+++ b/libs/shared/expression/src/index.ts
@@ -137,6 +137,7 @@ export {
   getWorkflowContextTypeEnvironment,
   getWorkflowContextUntrustedPaths,
   getWorkflowInterpolationFieldFailurePolicy,
+  getWorkflowInterpolationFieldSelfReference,
   getWorkflowPredicateFieldMinimumFillTarget,
   type OpenWorkflowContextDefinition,
   type ReservedRootDefinition,

--- a/libs/shared/expression/src/plan/context-key-access.test.ts
+++ b/libs/shared/expression/src/plan/context-key-access.test.ts
@@ -77,7 +77,9 @@ describe('analyzeContextRootKeyAccess', () => {
 
     expect(result).toEqual({
       references: [],
-      violations: [{root: 'jobs', source}],
+      violations: [
+        source === 'jobs["build"]' ? {root: 'jobs', key: 'build', source} : {root: 'jobs', source},
+      ],
     });
   });
 

--- a/libs/shared/expression/src/plan/context-key-access.ts
+++ b/libs/shared/expression/src/plan/context-key-access.ts
@@ -27,6 +27,8 @@ export interface ContextKeyAccessReference {
 
 export interface ContextKeyAccessViolation {
   readonly root: string;
+  /** First key when a computed access still uses a literal string key. */
+  readonly key?: string;
   readonly source: string;
 }
 
@@ -221,7 +223,7 @@ function recordContextRootKeyAccess(
 ): void {
   const [key] = chain.segments;
   if (chain.computed || key === undefined) {
-    violations.push({root: chain.root, source});
+    violations.push({root: chain.root, ...(key === undefined ? {} : {key}), source});
     return;
   }
 

--- a/libs/shared/expression/src/workflow-context/workflow-context.test.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.test.ts
@@ -196,6 +196,7 @@ describe('workflow context registry', () => {
         fields: {
           id: 'string',
           name: 'string',
+          run_name: 'string',
           definition_id: 'string',
           project_id: 'string',
           workspace_id: 'string',
@@ -612,6 +613,8 @@ describe('workflow context registry', () => {
       expect(getWorkflowInterpolationFieldFailurePolicy('agent.thinking')).toBe('fail');
       expect(getWorkflowInterpolationFieldFailurePolicy('job.runner')).toBe('fail');
       expect(getWorkflowInterpolationFieldFailurePolicy('job.name')).toBe('degrade');
+      expect(getWorkflowInterpolationFieldFailurePolicy('workflow.run_name')).toBe('degrade');
+      expect(getWorkflowInterpolationFieldFailurePolicy('job.execution_name')).toBe('degrade');
       expect(getWorkflowInterpolationFieldFailurePolicy('step.name')).toBe('degrade');
       expect(getWorkflowInterpolationFieldFailurePolicy('step.feedback')).toBe('fail');
       expect(
@@ -749,6 +752,8 @@ describe('workflow interpolation field policies', () => {
       'job.runner',
       'job.outputs',
       'job.name',
+      'workflow.run_name',
+      'job.execution_name',
       'step.name',
       'step.feedback',
     ]);
@@ -765,6 +770,8 @@ describe('workflow interpolation field policies', () => {
     ['job.runner', ['trusted', 'untrusted']],
     ['job.outputs', ['trusted', 'untrusted']],
     ['job.name', ['trusted', 'untrusted']],
+    ['workflow.run_name', ['trusted', 'untrusted']],
+    ['job.execution_name', ['trusted', 'untrusted']],
     ['step.name', ['trusted', 'untrusted']],
     ['step.feedback', ['trusted', 'untrusted']],
   ] satisfies readonly [
@@ -772,6 +779,18 @@ describe('workflow interpolation field policies', () => {
     readonly WorkflowContextTrustTier[],
   ][])('allows %s interpolation from the expected trust tiers', (field, trustTiers) => {
     expect(workflowInterpolationFieldPolicies[field].acceptedTrustTiers).toEqual(trustTiers);
+  });
+
+  it('declares dynamic-name self-reference targets in field policies', () => {
+    expect(workflowInterpolationFieldPolicies['workflow.run_name'].selfReference).toEqual({
+      root: 'run',
+      key: 'run_name',
+    });
+    expect(workflowInterpolationFieldPolicies['job.execution_name'].selfReference).toEqual({
+      root: 'execution',
+      key: 'name',
+    });
+    expect(workflowInterpolationFieldPolicies['step.name'].selfReference).toBeUndefined();
   });
 
   it.each([
@@ -784,6 +803,8 @@ describe('workflow interpolation field policies', () => {
     ['job.runner', ['server']],
     ['job.outputs', ['server']],
     ['job.name', ['server']],
+    ['workflow.run_name', ['server']],
+    ['job.execution_name', ['server']],
     ['step.name', ['server']],
     ['step.feedback', ['server']],
   ] satisfies readonly [
@@ -836,10 +857,16 @@ describe('workflow interpolation field policies', () => {
 
   it('marks display names for render sanitization', () => {
     expect(workflowInterpolationFieldPolicies['job.name'].renderSanitize).toBe(true);
+    expect(workflowInterpolationFieldPolicies['workflow.run_name'].renderSanitize).toBe(true);
+    expect(workflowInterpolationFieldPolicies['job.execution_name'].renderSanitize).toBe(true);
     expect(workflowInterpolationFieldPolicies['step.name'].renderSanitize).toBe(true);
 
     const nonDisplayFields = workflowInterpolationFields.filter(
-      (field) => field !== 'job.name' && field !== 'step.name',
+      (field) =>
+        field !== 'job.name' &&
+        field !== 'workflow.run_name' &&
+        field !== 'job.execution_name' &&
+        field !== 'step.name',
     );
     for (const field of nonDisplayFields) {
       expect(workflowInterpolationFieldPolicies[field].renderSanitize).toBe(false);

--- a/libs/shared/expression/src/workflow-context/workflow-context.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.ts
@@ -106,6 +106,7 @@ const runTypeEnvironment = {
     fields: {
       id: 'string',
       name: 'string',
+      run_name: 'string',
       definition_id: 'string',
       project_id: 'string',
       workspace_id: 'string',
@@ -381,6 +382,8 @@ export type WorkflowInterpolationField =
   | 'job.runner'
   | 'job.outputs'
   | 'job.name'
+  | 'workflow.run_name'
+  | 'job.execution_name'
   | 'step.name'
   | 'step.feedback';
 
@@ -394,6 +397,10 @@ export interface WorkflowInterpolationFieldPolicy {
   readonly failurePolicy: WorkflowInterpolationFailurePolicy;
   readonly renderSanitize: boolean;
   readonly minimumFillTarget?: AvailabilitySite;
+  readonly selfReference?: {
+    readonly root: WorkflowContextName;
+    readonly key: string;
+  };
 }
 
 const trustedOnlyTrustTiers: readonly WorkflowContextTrustTier[] = ['trusted'];
@@ -401,7 +408,9 @@ const anyTrustTier: readonly WorkflowContextTrustTier[] = ['trusted', 'untrusted
 const serverOnlyHosts: readonly WorkflowContextHost[] = ['server'];
 const anyHost: readonly WorkflowContextHost[] = ['server', 'runner'];
 
-export const workflowInterpolationFieldPolicies = {
+export const workflowInterpolationFieldPolicies: Readonly<
+  Record<WorkflowInterpolationField, WorkflowInterpolationFieldPolicy>
+> = {
   run: {
     acceptedTrustTiers: trustedOnlyTrustTiers,
     acceptedHosts: anyHost,
@@ -457,6 +466,22 @@ export const workflowInterpolationFieldPolicies = {
     failurePolicy: 'degrade',
     renderSanitize: true,
   },
+  'workflow.run_name': {
+    acceptedTrustTiers: anyTrustTier,
+    acceptedHosts: serverOnlyHosts,
+    failurePolicy: 'degrade',
+    renderSanitize: true,
+    minimumFillTarget: 'run-creation',
+    selfReference: {root: 'run', key: 'run_name'},
+  },
+  'job.execution_name': {
+    acceptedTrustTiers: anyTrustTier,
+    acceptedHosts: serverOnlyHosts,
+    failurePolicy: 'degrade',
+    renderSanitize: true,
+    minimumFillTarget: 'execution-creation',
+    selfReference: {root: 'execution', key: 'name'},
+  },
   'step.name': {
     acceptedTrustTiers: anyTrustTier,
     acceptedHosts: serverOnlyHosts,
@@ -469,7 +494,7 @@ export const workflowInterpolationFieldPolicies = {
     failurePolicy: 'fail',
     renderSanitize: false,
   },
-} as const satisfies Record<WorkflowInterpolationField, WorkflowInterpolationFieldPolicy>;
+};
 
 export const workflowInterpolationFields = Object.keys(
   workflowInterpolationFieldPolicies,
@@ -604,6 +629,12 @@ export function getWorkflowInterpolationFieldFailurePolicy(
   field: WorkflowInterpolationField,
 ): WorkflowInterpolationFailurePolicy {
   return workflowInterpolationFieldPolicies[field].failurePolicy;
+}
+
+export function getWorkflowInterpolationFieldSelfReference(
+  field: WorkflowInterpolationField,
+): WorkflowInterpolationFieldPolicy['selfReference'] {
+  return workflowInterpolationFieldPolicies[field].selfReference;
 }
 
 export function getWorkflowInterpolationFieldMinimumFillTarget(

--- a/libs/shared/workflow/document/src/document/workflow-document.test.ts
+++ b/libs/shared/workflow/document/src/document/workflow-document.test.ts
@@ -15,6 +15,22 @@ function interpolation(source: string): string {
 }
 
 describe('workflowDocumentSchema', () => {
+  it('accepts dynamic workflow and job execution names', () => {
+    const result = workflowDocumentSchema.safeParse({
+      name: 'Deploy application',
+      run_name: interpolation('inputs.environment'),
+      jobs: {
+        deploy: {
+          name: 'Deploy',
+          execution_name: interpolation('inputs.environment'),
+          steps: [{run: 'deploy'}],
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
   it('accepts a valid minimal workflow document', () => {
     const workflowDocument = {
       name: 'simple build',

--- a/libs/shared/workflow/document/src/document/workflow-document.ts
+++ b/libs/shared/workflow/document/src/document/workflow-document.ts
@@ -475,7 +475,10 @@ export const workflowDocumentJobSchema = z.strictObject({
     description:
       'Event-listening configuration for this job. See [listening jobs](/understand/listening-jobs).',
   }),
-  name: z.string().min(1).optional().meta({description: 'Human-readable job name.'}),
+  name: z.string().min(1).optional().meta({description: 'Static human-readable job name.'}),
+  execution_name: z.string().min(1).optional().meta({
+    description: 'Dynamic name for each job execution. Supports workflow expressions.',
+  }),
   env: workflowDocumentEnvSchema.optional().meta({
     description:
       'Environment variables for run steps in this job. They do not apply to agent steps. See [secrets and variables](/reference/secrets-variables).',
@@ -486,7 +489,10 @@ export const workflowDocumentJobSchema = z.strictObject({
 });
 
 export const workflowDocumentSchema = z.strictObject({
-  name: z.string().min(1).meta({description: 'Human-readable workflow name.'}),
+  name: z.string().min(1).meta({description: 'Static human-readable workflow name.'}),
+  run_name: z.string().min(1).optional().meta({
+    description: 'Dynamic name for each workflow run. Supports workflow expressions.',
+  }),
   runner: stringOrStringArraySchema.optional().meta({
     description:
       'Default runner label or ordered fallback labels for run jobs. See [runners and execution environments](/understand/runners-and-execution-environments).',


### PR DESCRIPTION
## Summary

Add the additive authoring and normalized-model contract for dynamic workflow run and job execution names.

- Add optional `run_name` and `execution_name` workflow fields with static/dynamic schema descriptions.
- Normalize them into `WorkflowModel.runName` and `WorkflowModelJob.executionName`.
- Register creation-boundary expression policies and centralized self-reference metadata.
- Reject unavailable context and dynamic-name self-reference, including bracket notation.
- Update fixtures, generated schema coverage, tests, and published-package Changesets.

No persistence or UI behavior changes are included.

Validation passed for the affected package type checks, Biome checks, expression tests, definitions tests, and workflow schema checks.

Closes ENG-1391

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds dynamic naming for workflow runs and job executions. Authors can set `run_name` and `execution_name` templates; the system normalizes and validates them to meet ENG-1391.

- New Features
  - Add `run_name` (workflow) and `execution_name` (job) to `@shipfox/workflow-document`, with clear static vs dynamic field descriptions.
  - Normalize to `WorkflowModel.runName` and `WorkflowModelJob.executionName` in `@shipfox/api-definitions` and expose in `@shipfox/api-definitions-dto`.
  - Define expression policies in `@shipfox/expression` with creation-time availability; reject unavailable context and dynamic-name self-reference (dot and bracket access).
  - Update tests, fixtures, schema coverage, and Changesets for `@shipfox/workflow-document`, `@shipfox/expression`, `@shipfox/api-definitions-dto`, and `@shipfox/api-definitions`.
  - No persistence or UI changes.

<sup>Written for commit 9a0bffc029e4d0df8d31aed37e933811c7029c9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

