### PR TITLE
[api-runners] Atomically reconcile terminal runner state

### DIFF
--- a/.changeset/terminal-runner-reconciliation.md
+++ b/.changeset/terminal-runner-reconciliation.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-runners": patch
+---
+
+Atomically reconcile pending and running runner state when a job execution reaches a terminal state.

--- a/libs/api/runners/src/db/job-executions.test.ts
+++ b/libs/api/runners/src/db/job-executions.test.ts
@@ -3,6 +3,7 @@ import {
   RUNNER_JOB_LEASE_EXPIRED,
   RUNNER_JOB_QUEUED,
 } from '@shipfox/api-runners-dto';
+import {pgClient} from '@shipfox/node-postgres';
 import {eq, sql} from 'drizzle-orm';
 import {EmptyRequiredLabelsError, RunnerSessionExhaustedError} from '#core/errors.js';
 import {claimJobExecution} from '#core/job-executions.js';
@@ -21,9 +22,9 @@ import {
   expireStuckJobExecutions,
   getJobExecutionQueueDepth,
   isJobLeaseActive,
+  reconcileTerminalJobExecution,
   recordHeartbeat,
   releaseJobExecution,
-  requestJobExecutionCancellation,
 } from './job-executions.js';
 import {runnersOutbox} from './schema/outbox.js';
 import {pendingJobExecutions} from './schema/pending-job-executions.js';
@@ -975,11 +976,11 @@ describe('recordHeartbeat', () => {
     );
   });
 
-  it('returns cancel:true after requestJobExecutionCancellation', async () => {
+  it('returns cancel:true after reconcileTerminalJobExecution', async () => {
     await pendingJobFactory.create({workspaceId});
     const claimed = await claimPendingJobExecution({workspaceId, runnerSessionId, maxClaims: null});
 
-    await requestJobExecutionCancellation({jobExecutionId: claimed?.jobExecutionId as string});
+    await reconcileTerminalJobExecution({jobExecutionId: claimed?.jobExecutionId as string});
 
     const result = await recordHeartbeat({
       jobExecutionId: claimed?.jobExecutionId as string,
@@ -1016,7 +1017,7 @@ describe('recordHeartbeat', () => {
   });
 });
 
-describe('requestJobExecutionCancellation', () => {
+describe('reconcileTerminalJobExecution', () => {
   let workspaceId: string;
   let runnerSessionId: string;
 
@@ -1026,46 +1027,192 @@ describe('requestJobExecutionCancellation', () => {
     runnerSessionId = runnerSession.id;
   });
 
-  it('sets cancellation_requested_at on a fresh row', async () => {
-    await pendingJobFactory.create({workspaceId});
-    const claimed = await claimPendingJobExecution({workspaceId, runnerSessionId, maxClaims: null});
+  it('deletes a pending execution', async () => {
+    const pending = await pendingJobFactory.create({workspaceId});
 
-    await requestJobExecutionCancellation({jobExecutionId: claimed?.jobExecutionId as string});
+    await reconcileTerminalJobExecution({jobExecutionId: pending.jobExecutionId});
+
+    expect(
+      await db()
+        .select()
+        .from(pendingJobExecutions)
+        .where(eq(pendingJobExecutions.jobExecutionId, pending.jobExecutionId)),
+    ).toHaveLength(0);
+  });
+
+  it('sets cancellation_requested_at on a running execution', async () => {
+    const pending = await pendingJobFactory.create({workspaceId});
+    const claimed = await claimPendingJobExecution({workspaceId, runnerSessionId, maxClaims: null});
+    expect(claimed?.jobExecutionId).toBe(pending.jobExecutionId);
+
+    await reconcileTerminalJobExecution({jobExecutionId: pending.jobExecutionId});
 
     const rows = await db()
       .select()
       .from(runningJobExecutions)
-      .where(eq(runningJobExecutions.jobId, claimed?.jobId as string));
+      .where(eq(runningJobExecutions.jobExecutionId, pending.jobExecutionId));
     expect(rows[0]?.cancellationRequestedAt).not.toBeNull();
   });
 
   it('is idempotent: second call preserves the first timestamp', async () => {
-    await pendingJobFactory.create({workspaceId});
+    const pending = await pendingJobFactory.create({workspaceId});
     const claimed = await claimPendingJobExecution({workspaceId, runnerSessionId, maxClaims: null});
+    expect(claimed?.jobExecutionId).toBe(pending.jobExecutionId);
 
-    await requestJobExecutionCancellation({jobExecutionId: claimed?.jobExecutionId as string});
+    await reconcileTerminalJobExecution({jobExecutionId: pending.jobExecutionId});
     const after1 = await db()
       .select()
       .from(runningJobExecutions)
-      .where(eq(runningJobExecutions.jobId, claimed?.jobId as string));
+      .where(eq(runningJobExecutions.jobExecutionId, pending.jobExecutionId));
     const firstTs = after1[0]?.cancellationRequestedAt;
 
     await new Promise((r) => setTimeout(r, 10));
-    await requestJobExecutionCancellation({jobExecutionId: claimed?.jobExecutionId as string});
+    await reconcileTerminalJobExecution({jobExecutionId: pending.jobExecutionId});
 
     const after2 = await db()
       .select()
       .from(runningJobExecutions)
-      .where(eq(runningJobExecutions.jobId, claimed?.jobId as string));
+      .where(eq(runningJobExecutions.jobExecutionId, pending.jobExecutionId));
     expect(after2[0]?.cancellationRequestedAt?.getTime()).toBe(firstTs?.getTime());
   });
 
-  it('is a no-op when the job execution is missing (does not throw)', async () => {
+  it('is a no-op when the job execution is missing', async () => {
     await expect(
-      requestJobExecutionCancellation({jobExecutionId: crypto.randomUUID()}),
+      reconcileTerminalJobExecution({jobExecutionId: crypto.randomUUID()}),
     ).resolves.toBeUndefined();
   });
+
+  it('leaves a pending sibling for the same job untouched', async () => {
+    const target = await pendingJobFactory.create({workspaceId});
+    const sibling = await pendingJobFactory.create({workspaceId, jobId: target.jobId});
+
+    await reconcileTerminalJobExecution({jobExecutionId: target.jobExecutionId});
+
+    expect(
+      await db()
+        .select()
+        .from(pendingJobExecutions)
+        .where(eq(pendingJobExecutions.jobExecutionId, target.jobExecutionId)),
+    ).toHaveLength(0);
+    expect(
+      await db()
+        .select()
+        .from(pendingJobExecutions)
+        .where(eq(pendingJobExecutions.jobExecutionId, sibling.jobExecutionId)),
+    ).toHaveLength(1);
+  });
+
+  it('leaves a running sibling for the same job uncancelled', async () => {
+    const target = await pendingJobFactory.create({workspaceId});
+    const sibling = await pendingJobFactory.create({workspaceId, jobId: target.jobId});
+    const targetClaim = await claimPendingJobExecution({
+      workspaceId,
+      runnerSessionId,
+      maxClaims: null,
+    });
+    const siblingClaim = await claimPendingJobExecution({
+      workspaceId,
+      runnerSessionId,
+      maxClaims: null,
+    });
+    expect(targetClaim?.jobExecutionId).toBe(target.jobExecutionId);
+    expect(siblingClaim?.jobExecutionId).toBe(sibling.jobExecutionId);
+
+    await reconcileTerminalJobExecution({jobExecutionId: target.jobExecutionId});
+
+    const rows = await db()
+      .select({
+        jobExecutionId: runningJobExecutions.jobExecutionId,
+        cancellationRequestedAt: runningJobExecutions.cancellationRequestedAt,
+      })
+      .from(runningJobExecutions)
+      .where(eq(runningJobExecutions.jobId, target.jobId));
+    const byJobExecutionId = new Map(
+      rows.map((row) => [row.jobExecutionId, row.cancellationRequestedAt]),
+    );
+    expect(byJobExecutionId.get(target.jobExecutionId)).not.toBeNull();
+    expect(byJobExecutionId.get(sibling.jobExecutionId)).toBeNull();
+  });
+
+  it('cancels the lease when reconciliation races a claim that has already acquired the row', async () => {
+    const pending = await pendingJobFactory.create({workspaceId});
+    const releaseClaim = deferred<void>();
+    const claimTransactionReady = deferred<void>();
+    const lockHolder = db().transaction(async (tx) => {
+      await tx.execute(sql`LOCK TABLE runners_outbox IN ACCESS EXCLUSIVE MODE`);
+      claimTransactionReady.resolve();
+      await releaseClaim.promise;
+    });
+
+    let claim: ReturnType<typeof claimPendingJobExecution> | undefined;
+    let reconciliation: Promise<void> | undefined;
+    try {
+      await claimTransactionReady.promise;
+      claim = claimPendingJobExecution({workspaceId, runnerSessionId, maxClaims: null});
+      await waitForLockWait({queryLike: '%runners_outbox%'});
+
+      reconciliation = reconcileTerminalJobExecution({jobExecutionId: pending.jobExecutionId});
+      // Claim has already deleted the pending row and inserted the lease, but cannot commit its
+      // outbox event while the table lock is held. Reconciliation must wait on that same claim.
+      await waitForLockWait({queryLike: '%runners_pending_jobs%'});
+    } finally {
+      releaseClaim.resolve();
+      await Promise.allSettled([
+        lockHolder,
+        claim ?? Promise.resolve(null),
+        reconciliation ?? Promise.resolve(),
+      ]);
+    }
+
+    if (!claim || !reconciliation) throw new Error('Claim and reconciliation must both start');
+    const [claimed] = await Promise.all([claim, reconciliation, lockHolder]);
+    expect(claimed?.jobExecutionId).toBe(pending.jobExecutionId);
+
+    expect(
+      await db()
+        .select()
+        .from(pendingJobExecutions)
+        .where(eq(pendingJobExecutions.jobExecutionId, pending.jobExecutionId)),
+    ).toHaveLength(0);
+    const runningRows = await db()
+      .select({cancellationRequestedAt: runningJobExecutions.cancellationRequestedAt})
+      .from(runningJobExecutions)
+      .where(eq(runningJobExecutions.jobExecutionId, pending.jobExecutionId));
+    expect(runningRows).toHaveLength(1);
+    expect(runningRows[0]?.cancellationRequestedAt).not.toBeNull();
+  });
 });
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((innerResolve, innerReject) => {
+    resolve = innerResolve;
+    reject = innerReject;
+  });
+  return {promise, resolve, reject};
+}
+
+async function waitForLockWait(params: {queryLike: string}) {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    const result = await pgClient().query<{count: number}>(
+      `
+        SELECT count(*)::int AS count
+        FROM pg_stat_activity
+        WHERE datname = current_database()
+          AND pid <> pg_backend_pid()
+          AND state = 'active'
+          AND wait_event_type = 'Lock'
+          AND query ILIKE $1
+      `,
+      [params.queryLike],
+    );
+    if ((result.rows[0]?.count ?? 0) > 0) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`Timed out waiting for lock waiter matching ${params.queryLike}`);
+}
 
 describe('cancelRunnerJobs', () => {
   let workspaceId: string;

--- a/libs/api/runners/src/db/job-executions.test.ts
+++ b/libs/api/runners/src/db/job-executions.test.ts
@@ -1153,8 +1153,9 @@ describe('reconcileTerminalJobExecution', () => {
 
       reconciliation = reconcileTerminalJobExecution({jobExecutionId: pending.jobExecutionId});
       // Claim has already deleted the pending row and inserted the lease, but cannot commit its
-      // outbox event while the table lock is held. Reconciliation must wait on that same claim.
-      await waitForLockWait({queryLike: '%runners_pending_jobs%'});
+      // outbox event while the table lock is held. Reconciliation must wait on that same claim's
+      // execution advisory lock.
+      await waitForLockWait({queryLike: '%pg_advisory_xact_lock%'});
     } finally {
       releaseClaim.resolve();
       await Promise.allSettled([
@@ -1371,6 +1372,32 @@ describe('detectAndExpireStuckJobs', () => {
     // The lease-expired event carries only the assignment identifiers.
     expect(payload.status).toBeUndefined();
     expect(payload.steps).toBeUndefined();
+  });
+
+  it('does not requeue an execution after its lease has expired', async () => {
+    const stale = await makeStaleJob(600);
+
+    await expireStuckJobExecutions({
+      noFirstHeartbeatGraceSeconds: 60,
+      thresholdSeconds: 180,
+    });
+
+    await enqueueJobExecution({
+      workspaceId,
+      workflowRunId: stale.workflowRunId,
+      workflowRunAttemptId: stale.workflowRunAttemptId,
+      jobId: stale.jobId,
+      jobExecutionId: stale.jobExecutionId,
+      projectId: stale.projectId,
+      requiredLabels: ['linux'],
+    });
+
+    expect(
+      await db()
+        .select()
+        .from(pendingJobExecutions)
+        .where(eq(pendingJobExecutions.jobExecutionId, stale.jobExecutionId)),
+    ).toHaveLength(0);
   });
 
   it('expires a job that never sent a first heartbeat after the startup grace', async () => {
@@ -1598,6 +1625,42 @@ describe('detectAndExpireStuckJobs', () => {
 
     expect(await runningJobsForTest()).toHaveLength(0);
     expect(await outboxForJobs([stuck1.jobId, stuck2.jobId])).toHaveLength(2);
+  });
+
+  it('skips an execution whose advisory lock is held and reaps the next stale page', async () => {
+    const first = await makeStaleJob(600);
+    const second = await makeStaleJob(600);
+    const releaseLock = deferred<void>();
+    const lockReady = deferred<void>();
+    const lockHolder = db().transaction(async (tx) => {
+      await tx.execute(
+        sql`select pg_advisory_xact_lock(hashtext(${`runners_job_execution:${first.jobExecutionId}`}))`,
+      );
+      lockReady.resolve();
+      await releaseLock.promise;
+    });
+
+    try {
+      await lockReady.promise;
+      const reaped = await expireStuckJobExecutions({
+        noFirstHeartbeatGraceSeconds: 60,
+        thresholdSeconds: 180,
+        limit: 1,
+      });
+
+      expect(reaped).toHaveLength(1);
+      expect(reaped[0]?.jobExecutionId).toBe(second.jobExecutionId);
+    } finally {
+      releaseLock.resolve();
+      await lockHolder;
+    }
+
+    const remaining = await expireStuckJobExecutions({
+      noFirstHeartbeatGraceSeconds: 60,
+      thresholdSeconds: 180,
+      limit: 1,
+    });
+    expect(remaining.map((row) => row.jobExecutionId)).toContain(first.jobExecutionId);
   });
 
   it('a reaper tick and a concurrent claim of the same orphan-pending job do not deadlock', async () => {

--- a/libs/api/runners/src/db/job-executions.test.ts
+++ b/libs/api/runners/src/db/job-executions.test.ts
@@ -1600,7 +1600,7 @@ describe('detectAndExpireStuckJobs', () => {
     expect(await outboxForJobs([stuck1.jobId, stuck2.jobId])).toHaveLength(2);
   });
 
-  it('a reaper tick and a concurrent claim of the same orphan-pending job leave consistent state', async () => {
+  it('a reaper tick and a concurrent claim of the same orphan-pending job do not deadlock', async () => {
     const {jobId, jobExecutionId, workflowRunId, workflowRunAttemptId, projectId} =
       await makeStaleJob(600);
     // Orphan pending row from a post-claim enqueue retry for an already-running job.
@@ -1616,15 +1616,14 @@ describe('detectAndExpireStuckJobs', () => {
         requiredLabels: ['linux'],
       });
 
-    // The reaper locks running-then-pending while the claim locks pending-then-running;
-    // a deadlock loser rolls back, so either side may settle as rejected.
-    await Promise.allSettled([
+    // Both operations acquire the pending-row lock before the running-row lock.
+    const [reaped, claimed] = await Promise.all([
       detectAndExpireStuckJobs({thresholdSeconds: 180}),
       claimPendingJobExecution({workspaceId, runnerSessionId, maxClaims: null}),
     ]);
 
-    // A follow-up tick finishes any reap that lost a deadlock race.
-    await detectAndExpireStuckJobs({thresholdSeconds: 180});
+    expect(reaped.expired).toBeGreaterThanOrEqual(1);
+    expect(claimed).toBeNull();
 
     // The expired job is gone and not re-claimable; its orphan pending row is swept.
     expect(await runningJobsForTest()).toHaveLength(0);

--- a/libs/api/runners/src/db/job-executions.test.ts
+++ b/libs/api/runners/src/db/job-executions.test.ts
@@ -487,6 +487,40 @@ describe('claimPendingJobExecution', () => {
     expect(claimed).toHaveLength(1);
   });
 
+  it('locks only the FIFO candidate before acquiring its execution advisory lock', async () => {
+    const first = await pendingJobFactory.create({workspaceId});
+    const second = await pendingJobFactory.create({workspaceId});
+    const releaseLock = deferred<void>();
+    const lockReady = deferred<void>();
+    const lockHolder = db().transaction(async (tx) => {
+      await tx.execute(
+        sql`select pg_advisory_xact_lock(hashtext(${`runners_job_execution:${first.jobExecutionId}`}))`,
+      );
+      lockReady.resolve();
+      await releaseLock.promise;
+    });
+
+    try {
+      await lockReady.promise;
+      expect(
+        await claimPendingJobExecution({workspaceId, runnerSessionId, maxClaims: null}),
+      ).toBeNull();
+      expect(
+        await db()
+          .select()
+          .from(pendingJobExecutions)
+          .where(eq(pendingJobExecutions.workspaceId, workspaceId)),
+      ).toHaveLength(2);
+    } finally {
+      releaseLock.resolve();
+      await lockHolder;
+    }
+
+    const claimed = await claimPendingJobExecution({workspaceId, runnerSessionId, maxClaims: null});
+    expect(claimed?.jobExecutionId).toBe(first.jobExecutionId);
+    expect(second.jobExecutionId).not.toBe(claimed?.jobExecutionId);
+  });
+
   it('claims the oldest job first', async () => {
     const older = await pendingJobFactory.create({workspaceId});
     await pendingJobFactory.create({workspaceId});

--- a/libs/api/runners/src/db/job-executions.ts
+++ b/libs/api/runners/src/db/job-executions.ts
@@ -229,25 +229,33 @@ export async function claimPendingJobExecution(params: {
     }
 
     // `id` is a uuidv7 (time-ordered), so it is a deterministic FIFO tiebreaker
-    // for rows sharing a created_at within a batch.
-    const jobExecutionLockAvailable = sql`
-      pg_try_advisory_xact_lock(
-        hashtext(${runnerJobExecutionLockPrefix} || ${pendingJobExecutions.jobExecutionId}::text)
-      )
-    `;
-    const [row] = await tx
+    // for rows sharing a created_at within a batch. Lock only the FIFO candidate before
+    // attempting its execution advisory lock; putting pg_try_advisory_xact_lock in this
+    // predicate would evaluate it while scanning and temporarily lock many queue entries.
+    const candidate = tx
       .select()
       .from(pendingJobExecutions)
       .where(
         and(
           eq(pendingJobExecutions.workspaceId, params.workspaceId),
           arrayContained(pendingJobExecutions.requiredLabels, params.sessionLabels),
-          jobExecutionLockAvailable,
         ),
       )
       .orderBy(asc(pendingJobExecutions.createdAt), asc(pendingJobExecutions.id))
       .limit(1)
-      .for('update', {skipLocked: true});
+      .for('update', {skipLocked: true})
+      .as('pending_candidate');
+
+    const [row] = await tx
+      .select()
+      .from(candidate)
+      .where(
+        sql`
+          pg_try_advisory_xact_lock(
+            hashtext(${runnerJobExecutionLockPrefix} || ${candidate.jobExecutionId}::text)
+          )
+        `,
+      );
 
     if (!row) return null;
 

--- a/libs/api/runners/src/db/job-executions.ts
+++ b/libs/api/runners/src/db/job-executions.ts
@@ -38,6 +38,14 @@ import {providerRunners} from './schema/runner-instances.js';
 import {runnerSessions} from './schema/runner-sessions.js';
 import {runningJobExecutions} from './schema/running-job-executions.js';
 
+const runnerJobExecutionLockPrefix = 'runners_job_execution:';
+
+async function lockJobExecution(tx: Tx, jobExecutionId: string): Promise<void> {
+  await tx.execute(
+    sql`select pg_advisory_xact_lock(hashtext(${`${runnerJobExecutionLockPrefix}${jobExecutionId}`}))`,
+  );
+}
+
 export interface EnqueueJobExecutionParams {
   workspaceId: string;
   workflowRunId: string;
@@ -77,17 +85,29 @@ export async function getWorkspaceJobCounts(params: {
 }
 
 // Idempotent while the job execution is still pending: a duplicate jobExecutionId already in
-// `runners_pending_jobs` is a no-op. Temporal retries the enqueue activity
-// at-least-once, so a unique-violation throw on a retry-after-lost-result
-// would permanently fail a healthy job execution's workflow. The guard does not extend
-// past the claim: once the job execution has moved to `runners_running_jobs`, a retry
-// can reinsert an orphan pending row, which a later `claimPendingJobExecution` drops
-// via the running-execution unique constraint (onConflictDoNothing) instead of failing.
+// `runners_pending_jobs` is a no-op. Temporal retries the enqueue activity at-least-once, so a
+// unique-violation throw on a retry-after-lost-result would permanently fail a healthy execution.
+// The per-execution advisory lock serializes retries with lease expiry/reconciliation, and the
+// durable lease-expired event prevents a retry from re-queueing an execution already reaped.
 export async function enqueueJobExecution(params: EnqueueJobExecutionParams): Promise<void> {
   const requiredLabels = [...canonicalizeLabels(params.requiredLabels)];
   if (requiredLabels.length === 0) throw new EmptyRequiredLabelsError();
 
   const enqueued = await db().transaction(async (tx) => {
+    await lockJobExecution(tx, params.jobExecutionId);
+
+    const [leaseExpired] = await tx
+      .select({id: runnersOutbox.id})
+      .from(runnersOutbox)
+      .where(
+        and(
+          eq(runnersOutbox.eventType, RUNNER_JOB_LEASE_EXPIRED),
+          sql`${runnersOutbox.payload}->>'jobExecutionId' = ${params.jobExecutionId}`,
+        ),
+      )
+      .limit(1);
+    if (leaseExpired) return false;
+
     const [inserted] = await tx
       .insert(pendingJobExecutions)
       .values({
@@ -210,6 +230,11 @@ export async function claimPendingJobExecution(params: {
 
     // `id` is a uuidv7 (time-ordered), so it is a deterministic FIFO tiebreaker
     // for rows sharing a created_at within a batch.
+    const jobExecutionLockAvailable = sql`
+      pg_try_advisory_xact_lock(
+        hashtext(${runnerJobExecutionLockPrefix} || ${pendingJobExecutions.jobExecutionId}::text)
+      )
+    `;
     const [row] = await tx
       .select()
       .from(pendingJobExecutions)
@@ -217,6 +242,7 @@ export async function claimPendingJobExecution(params: {
         and(
           eq(pendingJobExecutions.workspaceId, params.workspaceId),
           arrayContained(pendingJobExecutions.requiredLabels, params.sessionLabels),
+          jobExecutionLockAvailable,
         ),
       )
       .orderBy(asc(pendingJobExecutions.createdAt), asc(pendingJobExecutions.id))
@@ -330,6 +356,8 @@ async function touchRunnerSessionLiveness(params: {
  */
 export async function releaseJobExecution(params: {jobExecutionId: string}): Promise<void> {
   await db().transaction(async (tx) => {
+    await lockJobExecution(tx, params.jobExecutionId);
+
     // Delete pending before running to match `claimPendingJobExecution`'s lock-acquisition
     // order (it locks the pending row first, then the running row). A concurrent
     // claim picking up an orphan pending row for this same job execution would otherwise
@@ -392,7 +420,16 @@ export async function expireStuckJobExecutions(params: {
         jobExecutionId: runningJobExecutions.jobExecutionId,
       })
       .from(runningJobExecutions)
-      .where(stalePredicate)
+      .where(
+        and(
+          stalePredicate,
+          sql`
+            pg_try_advisory_xact_lock(
+              hashtext(${runnerJobExecutionLockPrefix} || ${runningJobExecutions.jobExecutionId}::text)
+            )
+          `,
+        ),
+      )
       .orderBy(
         asc(
           sql`CASE WHEN ${runningJobExecutions.firstHeartbeatAt} IS NULL AND ${runningJobExecutions.lastHeartbeatAt} <= ${runningJobExecutions.startedAt} THEN ${runningJobExecutions.startedAt} ELSE ${runningJobExecutions.lastHeartbeatAt} END`,
@@ -407,7 +444,9 @@ export async function expireStuckJobExecutions(params: {
     const staleJobExecutionIds = staleRows.map((row) => row.jobExecutionId);
 
     // Sweep pending rows first so this transaction cannot hold a running-row lock while waiting
-    // for a pending-row lock held by reconciliation or a claim of an orphan pending row.
+    // for a pending-row lock held by reconciliation or a claim of an orphan pending row. The
+    // advisory lock acquired in the candidate scan also makes enqueue retries wait until this
+    // transaction has either reaped the execution or released its lock without selecting it.
     await tx
       .delete(pendingJobExecutions)
       .where(inArray(pendingJobExecutions.jobExecutionId, staleJobExecutionIds));
@@ -693,6 +732,8 @@ export async function reconcileTerminalJobExecution(params: {
   jobExecutionId: string;
 }): Promise<void> {
   await db().transaction(async (tx) => {
+    await lockJobExecution(tx, params.jobExecutionId);
+
     // Delete pending before updating running to match claim/release lock order. Claim locks
     // pending rows with SKIP LOCKED before inserting the running lease, so this ordering makes
     // a concurrent terminal reconciliation either win before claim or cancel the new lease.

--- a/libs/api/runners/src/db/job-executions.ts
+++ b/libs/api/runners/src/db/job-executions.ts
@@ -352,9 +352,9 @@ export async function releaseJobExecution(params: {jobExecutionId: string}): Pro
  * pending row: a failed best-effort `releaseJobExecution` would otherwise leave an orphan
  * that a later claim re-runs as an already-finished job execution.
  *
- * Locks running-then-pending, the inverse of `claimPendingJobExecution` / `releaseJobExecution`.
- * That pre-existing asymmetry opens a narrow deadlock window against a concurrent
- * claim of the same orphan-pending job execution; Postgres breaks it and the cron retries.
+ * Locks pending-then-running to match `claimPendingJobExecution`, `releaseJobExecution`, and
+ * `reconcileTerminalJobExecution`. The stale candidate scan intentionally does not lock running
+ * rows first; the running-row DELETE re-checks the stale predicate after the pending-row sweep.
  */
 export async function expireStuckJobExecutions(params: {
   thresholdSeconds: number;
@@ -386,17 +386,31 @@ export async function expireStuckJobExecutions(params: {
       ),
     );
 
-    const staleIds = tx
-      .select({id: runningJobExecutions.id})
+    const staleRows = await tx
+      .select({
+        id: runningJobExecutions.id,
+        jobExecutionId: runningJobExecutions.jobExecutionId,
+      })
       .from(runningJobExecutions)
       .where(stalePredicate)
       .orderBy(
         asc(
           sql`CASE WHEN ${runningJobExecutions.firstHeartbeatAt} IS NULL AND ${runningJobExecutions.lastHeartbeatAt} <= ${runningJobExecutions.startedAt} THEN ${runningJobExecutions.startedAt} ELSE ${runningJobExecutions.lastHeartbeatAt} END`,
         ),
+        asc(runningJobExecutions.id),
       )
-      .limit(params.limit ?? 100)
-      .for('update', {skipLocked: true});
+      .limit(params.limit ?? 100);
+
+    if (staleRows.length === 0) return [];
+
+    const staleIds = staleRows.map((row) => row.id);
+    const staleJobExecutionIds = staleRows.map((row) => row.jobExecutionId);
+
+    // Sweep pending rows first so this transaction cannot hold a running-row lock while waiting
+    // for a pending-row lock held by reconciliation or a claim of an orphan pending row.
+    await tx
+      .delete(pendingJobExecutions)
+      .where(inArray(pendingJobExecutions.jobExecutionId, staleJobExecutionIds));
 
     const deleted = await tx
       .delete(runningJobExecutions)
@@ -409,13 +423,6 @@ export async function expireStuckJobExecutions(params: {
       });
 
     if (deleted.length === 0) return [];
-
-    await tx.delete(pendingJobExecutions).where(
-      inArray(
-        pendingJobExecutions.jobExecutionId,
-        deleted.map((row) => row.jobExecutionId),
-      ),
-    );
 
     await writeOutboxEvents<RunnersEventMap>(
       tx,

--- a/libs/api/runners/src/db/job-executions.ts
+++ b/libs/api/runners/src/db/job-executions.ts
@@ -677,15 +677,28 @@ export async function recordHeartbeat(params: {
   };
 }
 
-export async function requestJobExecutionCancellation(params: {
+/**
+ * Reconciles a terminal job execution with runner state in one transaction: removes its pending
+ * queue row and requests cancellation on its running lease, if either exists. The operation is
+ * idempotent and preserves the first cancellation-request timestamp.
+ */
+export async function reconcileTerminalJobExecution(params: {
   jobExecutionId: string;
 }): Promise<void> {
-  await db()
-    .update(runningJobExecutions)
-    .set({
-      cancellationRequestedAt: sql`COALESCE(${runningJobExecutions.cancellationRequestedAt}, now())`,
-    })
-    .where(eq(runningJobExecutions.jobExecutionId, params.jobExecutionId));
+  await db().transaction(async (tx) => {
+    // Delete pending before updating running to match claim/release lock order. Claim locks
+    // pending rows with SKIP LOCKED before inserting the running lease, so this ordering makes
+    // a concurrent terminal reconciliation either win before claim or cancel the new lease.
+    await tx
+      .delete(pendingJobExecutions)
+      .where(eq(pendingJobExecutions.jobExecutionId, params.jobExecutionId));
+    await tx
+      .update(runningJobExecutions)
+      .set({
+        cancellationRequestedAt: sql`COALESCE(${runningJobExecutions.cancellationRequestedAt}, now())`,
+      })
+      .where(eq(runningJobExecutions.jobExecutionId, params.jobExecutionId));
+  });
 }
 
 export async function cancelRunnerJobs(params: {jobIds: string[]}): Promise<void> {

--- a/libs/api/runners/src/presentation/routes/heartbeat.test.ts
+++ b/libs/api/runners/src/presentation/routes/heartbeat.test.ts
@@ -6,7 +6,7 @@ import {eq} from 'drizzle-orm';
 import type {FastifyInstance} from 'fastify';
 import {claimJobExecution} from '#core/job-executions.js';
 import {db} from '#db/db.js';
-import {requestJobExecutionCancellation} from '#db/job-executions.js';
+import {reconcileTerminalJobExecution} from '#db/job-executions.js';
 import {runnerSessions} from '#db/schema/runner-sessions.js';
 import {runningJobExecutions} from '#db/schema/running-job-executions.js';
 import {createRunnerRegistrationTokenAuthMethod} from '#presentation/auth/index.js';
@@ -223,10 +223,10 @@ describe('POST /runners/jobs/:jobId/heartbeat', () => {
     expect(session?.toolCapabilitiesReportedAt).toEqual(new Date('2026-01-01T00:00:00.000Z'));
   });
 
-  it('returns 200 + cancel:true after requestJobExecutionCancellation', async () => {
+  it('returns 200 + cancel:true after reconcileTerminalJobExecution', async () => {
     const {jobId, jobExecutionId, workflowRunId, workflowRunAttemptId, leaseToken} =
       await claimAvailableJob();
-    await requestJobExecutionCancellation({jobExecutionId});
+    await reconcileTerminalJobExecution({jobExecutionId});
 
     const res = await app.inject({
       method: 'POST',

--- a/libs/api/runners/src/presentation/subscribers/on-workflows-job-execution-timed-out.test.ts
+++ b/libs/api/runners/src/presentation/subscribers/on-workflows-job-execution-timed-out.test.ts
@@ -2,6 +2,7 @@ import type {WorkflowsJobExecutionTimedOutEventDto} from '@shipfox/api-workflows
 import {eq} from 'drizzle-orm';
 import {db} from '#db/db.js';
 import {claimPendingJobExecution} from '#db/job-executions.js';
+import {pendingJobExecutions} from '#db/schema/pending-job-executions.js';
 import {runningJobExecutions} from '#db/schema/running-job-executions.js';
 import {pendingJobFactory, runnerSessionFactory} from '#test/index.js';
 import {onWorkflowsJobExecutionTimedOut} from './on-workflows-job-execution-timed-out.js';
@@ -22,6 +23,21 @@ describe('onWorkflowsJobExecutionTimedOut', () => {
     workspaceId = crypto.randomUUID();
     const runnerSession = await runnerSessionFactory.create({workspaceId});
     runnerSessionId = runnerSession.id;
+  });
+
+  it('deletes an unclaimed pending execution', async () => {
+    const pending = await pendingJobFactory.create({workspaceId});
+
+    await onWorkflowsJobExecutionTimedOut(
+      buildPayload(pending.jobId, pending.jobExecutionId, pending.workflowRunAttemptId),
+    );
+
+    expect(
+      await db()
+        .select()
+        .from(pendingJobExecutions)
+        .where(eq(pendingJobExecutions.jobExecutionId, pending.jobExecutionId)),
+    ).toHaveLength(0);
   });
 
   it('sets cancellation_requested_at on the matching running_jobs row', async () => {

--- a/libs/api/runners/src/presentation/subscribers/on-workflows-job-execution-timed-out.ts
+++ b/libs/api/runners/src/presentation/subscribers/on-workflows-job-execution-timed-out.ts
@@ -1,6 +1,6 @@
 import type {WorkflowsJobExecutionTimedOutEventDto} from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
-import {requestJobExecutionCancellation} from '#db/job-executions.js';
+import {reconcileTerminalJobExecution} from '#db/job-executions.js';
 
 export async function onWorkflowsJobExecutionTimedOut(
   payload: WorkflowsJobExecutionTimedOutEventDto,
@@ -11,7 +11,7 @@ export async function onWorkflowsJobExecutionTimedOut(
       jobExecutionId: payload.jobExecutionId,
       workflowRunAttemptId: payload.workflowRunAttemptId,
     },
-    'Requesting runner cancellation for timed-out job execution',
+    'Reconciling runner state for timed-out job execution',
   );
-  await requestJobExecutionCancellation({jobExecutionId: payload.jobExecutionId});
+  await reconcileTerminalJobExecution({jobExecutionId: payload.jobExecutionId});
 }


### PR DESCRIPTION
A terminal job execution could remain queued or be claimed after timeout because timeout handling only marked running leases. This change adds an execution-scoped transaction that deletes the exact pending row first, then requests cancellation on the exact running lease while preserving the first cancellation timestamp. The timeout subscriber uses this operation without changing job-level cancellation behavior.

Coverage includes pending, running, missing, duplicate, sibling-isolation, subscriber, and coordinated PostgreSQL claim-wins race scenarios. A patch changeset is included for `@shipfox/api-runners`.

Validation:
- `mise exec -- turbo test type check --filter=@shipfox/api-runners...` — 481 tests passed
- `mise exec -- pnpm check:api-database-boundaries`
- `mise exec -- pnpm exec changeset status`
- `mise exec -- git diff --check`

Closes ENG-1398

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Atomically reconcile terminal runner state and serialize per-execution operations with advisory locks to prevent races, deadlocks, and re-queues after lease expiry. Addresses ENG-1398.

- **Bug Fixes**
  - Added `reconcileTerminalJobExecution(jobExecutionId)` to delete the exact pending row and set `cancellationRequestedAt` on the running lease in one transaction, idempotently preserving the first timestamp.
  - Updated the timeout subscriber to use reconciliation; heartbeat now returns cancel:true after reconciliation without changing job-level cancellation semantics.
  - Serialized enqueue, claim, release, expiry, and reconciliation with per-execution advisory locks. Claim now row-locks only the FIFO candidate before taking its advisory lock; expiry sweeps pending before deleting stale leases and skips lock-held executions to avoid deadlocks.
  - Enqueue ignores retries after a durable `RUNNER_JOB_LEASE_EXPIRED` outbox event to prevent re-queuing an expired execution.
  - Expanded coverage for blocked FIFO candidates, lock-held skips, deterministic claim-vs-reconcile/expiry races, and orphan-pending reaper interactions.
  - Patch release for `@shipfox/api-runners`.

<sup>Written for commit ab4d892110cfe8f8d15af8fc24349a463cddd402. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

