### PR TITLE
[runner-image] Publish candidate manifests after successful builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -829,7 +829,10 @@ jobs:
   publish-runner-image-candidate-manifest:
     name: Publish runner image candidate manifest
     needs: [publish-runner-image-candidate]
-    if: github.ref == 'refs/heads/main' && needs.publish-runner-image-candidate.result == 'success'
+    if: >-
+      always() &&
+      github.ref == 'refs/heads/main' &&
+      needs['publish-runner-image-candidate'].result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:


### PR DESCRIPTION
The main CI workflow can complete both architecture candidate builds while skipping the immutable candidate-manifest publication job. This updates the job condition to use an explicit matrix dependency and always(), so successful main builds publish their revision-addressed OCI manifest.

Validation: CI workflow YAML parsing, git diff --check, and turbo check type build test --filter=@shipfox/runner-image... passed.

Closes ENG-1378

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Publish the runner image candidate OCI manifest after successful builds on main, so successful candidates aren’t left without an immutable manifest. Aligns with Linear ENG-1378.

- **Bug Fixes**
  - Updated the GitHub Actions condition to use always() and explicitly check that the candidate publish job succeeded, ensuring manifest publication runs when the candidate build passes on main.

<sup>Written for commit c935f3b6f1d8893e0f0e0f619f59df24470e13b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

