### PR TITLE
[api-definitions] Expose non-fatal definition validation warnings

### DIFF
--- a/.changeset/definition-validation-warnings.md
+++ b/.changeset/definition-validation-warnings.md
@@ -1,0 +1,8 @@
+---
+"@shipfox/api-definitions-dto": minor
+"@shipfox/api-definitions": minor
+---
+
+Expose non-fatal definition validation warnings from the `/validate` response without
+preventing workflow synchronization. Persistence and surfacing for repo-synced definitions
+remain a follow-up.

--- a/libs/api/definitions-dto/src/index.ts
+++ b/libs/api/definitions-dto/src/index.ts
@@ -7,12 +7,14 @@ export {
   type DefinitionResponseDto,
   type DefinitionSyncSummaryDto,
   type DefinitionValidationErrorDto,
+  type DefinitionValidationWarningDto,
   definitionDtoSchema,
   definitionListQuerySchema,
   definitionListResponseSchema,
   definitionResponseSchema,
   definitionSyncSummarySchema,
   definitionValidationErrorSchema,
+  definitionValidationWarningSchema,
   type TriggerDto,
 } from '#schemas/index.js';
 export {

--- a/libs/api/definitions-dto/src/schemas/dto.ts
+++ b/libs/api/definitions-dto/src/schemas/dto.ts
@@ -70,6 +70,14 @@ export const definitionValidationErrorSchema = z.object({
 
 export type DefinitionValidationErrorDto = z.infer<typeof definitionValidationErrorSchema>;
 
+export const definitionValidationWarningSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+  path: z.string().optional(),
+});
+
+export type DefinitionValidationWarningDto = z.infer<typeof definitionValidationWarningSchema>;
+
 export const definitionListQuerySchema = z.object({
   project_id: z.string().uuid(),
   limit: z.coerce.number().int().min(1).max(100).default(50),

--- a/libs/api/definitions-dto/src/schemas/index.ts
+++ b/libs/api/definitions-dto/src/schemas/index.ts
@@ -7,11 +7,13 @@ export {
   type DefinitionResponseDto,
   type DefinitionSyncSummaryDto,
   type DefinitionValidationErrorDto,
+  type DefinitionValidationWarningDto,
   definitionDtoSchema,
   definitionListQuerySchema,
   definitionListResponseSchema,
   definitionResponseSchema,
   definitionSyncSummarySchema,
   definitionValidationErrorSchema,
+  definitionValidationWarningSchema,
 } from './dto.js';
 export type {TriggerDto} from './trigger.js';

--- a/libs/api/definitions/src/core/validate-definition.test.ts
+++ b/libs/api/definitions/src/core/validate-definition.test.ts
@@ -20,6 +20,7 @@ jobs:
 
     expect(result.valid).toBe(true);
     if (result.valid) {
+      expect(result.warnings).toEqual([]);
       expect(result.definition.document.name).toBe('Test');
       expect(result.definition.document.jobs.build?.steps).toHaveLength(1);
       expect(result.definition.model.jobs[0]?.id).toBe('build');
@@ -31,6 +32,7 @@ jobs:
 
     expect(result.valid).toBe(false);
     if (!result.valid) {
+      expect(result).not.toHaveProperty('warnings');
       expect(result.errors).toHaveLength(1);
       expect(result.errors[0]?.message).toContain('Invalid workflow YAML syntax');
     }

--- a/libs/api/definitions/src/core/validate-definition.ts
+++ b/libs/api/definitions/src/core/validate-definition.ts
@@ -3,13 +3,18 @@ import {InvalidWorkflowDocumentError} from '@shipfox/workflow-document';
 import {definitionDefaultRunnerLabels} from '../config.js';
 import type {IntegrationValidationContext} from './entities/integration-context.js';
 import type {WorkflowDefinitionPayload} from './entities/workflow-definition.js';
-import {InvalidWorkflowModelError, normalizeWorkflowDocument} from './workflow-model/index.js';
+import {
+  InvalidWorkflowModelError,
+  normalizeWorkflowDocument,
+  type WorkflowModelValidationIssue,
+} from './workflow-model/index.js';
 import {InvalidWorkflowYamlError, parseWorkflowYamlWithLocations} from './workflow-yaml/index.js';
 
 export type ValidationError = {message: string; path?: string | undefined};
+export type ValidationWarning = {code: string; message: string; path?: string | undefined};
 
 export type ValidationResult =
-  | {valid: true; definition: WorkflowDefinitionPayload}
+  | {valid: true; definition: WorkflowDefinitionPayload; warnings: ValidationWarning[]}
   | {valid: false; errors: ValidationError[]};
 
 export function validateDefinition(
@@ -22,16 +27,30 @@ export function validateDefinition(
 ): ValidationResult {
   try {
     const {document, stepSourceLocations} = parseWorkflowYamlWithLocations(yamlContent);
+    const warnings: WorkflowModelValidationIssue[] = [];
     const model = normalizeWorkflowDocument(document, {
       defaultRunnerLabels: options.defaultRunnerLabels ?? definitionDefaultRunnerLabels,
       agentValidationCatalog: options.agentValidationCatalog,
       integrationValidationContext: options.integrationValidationContext,
       stepSourceLocations,
+      warnings,
     });
-    return {valid: true, definition: {document, model}};
+    return {valid: true, definition: {document, model}, warnings: validationWarningsFor(warnings)};
   } catch (error) {
     return {valid: false, errors: validationErrorsFor(error)};
   }
+}
+
+function validationWarningsFor(
+  issues: readonly WorkflowModelValidationIssue[],
+): ValidationWarning[] {
+  return issues.map((issue) =>
+    validationWarning({
+      code: issue.code,
+      message: issue.message,
+      path: issue.path.join('.') || undefined,
+    }),
+  );
 }
 
 function validationErrorsFor(error: unknown): ValidationError[] {
@@ -68,4 +87,13 @@ function validationErrorsFor(error: unknown): ValidationError[] {
 function validationError(params: {message: string; path?: string | undefined}): ValidationError {
   if (params.path === undefined) return {message: params.message};
   return {message: params.message, path: params.path};
+}
+
+function validationWarning(params: {
+  code: string;
+  message: string;
+  path?: string | undefined;
+}): ValidationWarning {
+  if (params.path === undefined) return {code: params.code, message: params.message};
+  return {code: params.code, message: params.message, path: params.path};
 }

--- a/libs/api/definitions/src/core/workflow-model/index.ts
+++ b/libs/api/definitions/src/core/workflow-model/index.ts
@@ -5,5 +5,6 @@ export {
   type WorkflowModelValidationIssue,
   type WorkflowModelValidationIssueCode,
   type WorkflowModelValidationIssuePathSegment,
+  type WorkflowModelValidationIssueSeverity,
 } from './invalid-workflow-model-error.js';
 export {normalizeWorkflowDocument} from './normalize-workflow-document.js';

--- a/libs/api/definitions/src/core/workflow-model/invalid-workflow-model-error.ts
+++ b/libs/api/definitions/src/core/workflow-model/invalid-workflow-model-error.ts
@@ -55,11 +55,14 @@ export type WorkflowModelValidationIssueCode =
 
 export type WorkflowModelValidationIssuePathSegment = string | number;
 
+export type WorkflowModelValidationIssueSeverity = 'error' | 'warning';
+
 export interface WorkflowModelValidationIssue {
   readonly code: WorkflowModelValidationIssueCode;
   readonly message: string;
   readonly path: readonly WorkflowModelValidationIssuePathSegment[];
   readonly details?: Readonly<Record<string, unknown>>;
+  readonly severity?: WorkflowModelValidationIssueSeverity;
 }
 
 export class InvalidWorkflowModelError extends Error {

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.ts
@@ -21,6 +21,8 @@ export function normalizeWorkflowDocument(
     agentValidationCatalog: AgentValidationCatalog;
     integrationValidationContext?: IntegrationValidationContext | undefined;
     stepSourceLocations?: WorkflowStepSourceLocationMap | undefined;
+    /** Provide a fresh array for each call to collect non-fatal validation issues. */
+    warnings?: WorkflowModelValidationIssue[] | undefined;
   },
 ): WorkflowModel {
   const issues: WorkflowModelValidationIssue[] = [];
@@ -54,9 +56,11 @@ export function normalizeWorkflowDocument(
 
   validateCycles(document.jobs, jobIdBySourceName, issues);
 
-  if (issues.length > 0) {
-    throw new InvalidWorkflowModelError(issues);
-  }
+  const warnings = issues.filter((issue) => issue.severity === 'warning');
+  options.warnings?.push(...warnings);
+
+  const errors = issues.filter((issue) => issue.severity !== 'warning');
+  if (errors.length > 0) throw new InvalidWorkflowModelError(errors);
 
   return {
     kind: 'workflow',

--- a/libs/api/definitions/src/core/workflow-model/validation-issue.ts
+++ b/libs/api/definitions/src/core/workflow-model/validation-issue.ts
@@ -2,6 +2,7 @@ import type {
   WorkflowModelValidationIssue,
   WorkflowModelValidationIssueCode,
   WorkflowModelValidationIssuePathSegment,
+  WorkflowModelValidationIssueSeverity,
 } from './invalid-workflow-model-error.js';
 
 export function issue(params: {
@@ -9,12 +10,14 @@ export function issue(params: {
   message: string;
   path: readonly WorkflowModelValidationIssuePathSegment[];
   details?: Readonly<Record<string, unknown>>;
+  severity?: WorkflowModelValidationIssueSeverity;
 }): WorkflowModelValidationIssue {
   if (params.details === undefined) {
     return {
       code: params.code,
       message: params.message,
       path: params.path,
+      ...(params.severity === undefined ? {} : {severity: params.severity}),
     };
   }
 
@@ -23,5 +26,6 @@ export function issue(params: {
     message: params.message,
     path: params.path,
     details: params.details,
+    ...(params.severity === undefined ? {} : {severity: params.severity}),
   };
 }

--- a/libs/api/definitions/src/presentation/routes/validate-definition.test.ts
+++ b/libs/api/definitions/src/presentation/routes/validate-definition.test.ts
@@ -39,6 +39,7 @@ jobs:
     expect(res.statusCode).toBe(200);
     const body = res.json();
     expect(body.valid).toBe(true);
+    expect(body.warnings).toEqual([]);
     expect(body.workflow_document.name).toBe('Test');
     expect(body.workflow_model.kind).toBe('workflow');
   });

--- a/libs/api/definitions/src/presentation/routes/validate-definition.ts
+++ b/libs/api/definitions/src/presentation/routes/validate-definition.ts
@@ -1,5 +1,9 @@
 import type {AgentInterModuleClient} from '@shipfox/api-agent-dto/inter-module';
-import {definitionDtoSchema, definitionValidationErrorSchema} from '@shipfox/api-definitions-dto';
+import {
+  definitionDtoSchema,
+  definitionValidationErrorSchema,
+  definitionValidationWarningSchema,
+} from '@shipfox/api-definitions-dto';
 import {defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
 import {validateDefinition} from '#core/validate-definition.js';
@@ -13,6 +17,7 @@ const validationResultSchema = z.union([
     valid: z.literal(true),
     workflow_document: definitionDtoSchema.shape.workflow_document,
     workflow_model: definitionDtoSchema.shape.workflow_model,
+    warnings: z.array(definitionValidationWarningSchema),
   }),
   z.object({
     valid: z.literal(false),
@@ -42,6 +47,7 @@ export function buildValidateDefinitionRoute(agent: AgentInterModuleClient) {
           valid: true as const,
           workflow_document: result.definition.document,
           workflow_model: result.definition.model,
+          warnings: result.warnings,
         };
       }
 


### PR DESCRIPTION
Definition validation currently treats every finding as fatal, taking an entire workflow offline for a diagnostic that should only inform the author. This adds the non-fatal warning channel and exposes warnings from the interactive `/validate` response with code, message, and path while preserving existing fatal validation behavior.

Sync-state persistence and warning surfacing for repo-synced definitions remain the follow-up tracked by ENG-1409. The normalizer also documents the fresh-array contract for its warning collector.

Validated with the affected dependency graph: 120/120 Turbo type and test tasks passed, plus package checks and `git diff --check`.

Closes ENG-1403

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose non-fatal validation warnings for workflow definitions and return them from the `/validate` endpoint. Valid workflows can now include warnings without blocking sync; fatal errors are unchanged. Addresses ENG-1403; persistence for repo-synced warnings is tracked in ENG-1409.

- **New Features**
  - `validateDefinition` returns `warnings` for valid results.
  - `/validate` now responds with a `warnings` array of `{code, message, path?}` using `definitionValidationWarningSchema`.
  - `normalizeWorkflowDocument` accepts a `warnings` collector; gathers `severity: 'warning'` issues, throws on others.
  - DTO updates in `@shipfox/api-definitions-dto`: add `definitionValidationWarningSchema` and `DefinitionValidationWarningDto` exports.

<sup>Written for commit 8d22059f282244314e6609d285d6724eaadebfd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

