### PR TITLE
[api-workflows] Transition job executions to running on runner claim

### DIFF
--- a/.changeset/claimed-job-executions.md
+++ b/.changeset/claimed-job-executions.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-workflows": patch
+---
+
+Transition job executions from pending to running when the runner claims them.

--- a/libs/api/workflows/src/presentation/subscribers/on-runner-job-claimed.test.ts
+++ b/libs/api/workflows/src/presentation/subscribers/on-runner-job-claimed.test.ts
@@ -2,7 +2,20 @@ import {getJobExecutionsByJobId, getJobsByWorkflowRunId} from '#db/index.js';
 import {workflowRunFactory} from '#test/index.js';
 import {onRunnerJobClaimed} from './on-runner-job-claimed.js';
 
+const signalMock = vi.fn();
+const getHandleMock = vi.fn(() => ({signal: signalMock}));
+
+vi.mock('@shipfox/node-temporal', () => ({
+  temporalClient: () => ({workflow: {getHandle: getHandleMock}}),
+}));
+
 describe('onRunnerJobClaimed', () => {
+  beforeEach(() => {
+    getHandleMock.mockClear();
+    signalMock.mockReset();
+    signalMock.mockResolvedValue(undefined);
+  });
+
   it('stamps started_at on the job execution from the claim event payload', async () => {
     const run = await workflowRunFactory.create();
     const job = (await getJobsByWorkflowRunId(run.id))[0];
@@ -23,6 +36,11 @@ describe('onRunnerJobClaimed', () => {
 
     const after = (await getJobExecutionsByJobId(job.id))[0];
     expect(after?.startedAt?.getTime()).toBe(claimedAt.getTime());
+    expect(getHandleMock).toHaveBeenCalledWith(`job:${job.id}`);
+    expect(signalMock).toHaveBeenCalledWith('job-claimed', {
+      jobExecutionId: jobExecution.id,
+      claimedAt: claimedAt.toISOString(),
+    });
   });
 
   it('is idempotent: a redelivered event keeps the first started_at (coalesce)', async () => {
@@ -53,5 +71,36 @@ describe('onRunnerJobClaimed', () => {
 
     const after = (await getJobExecutionsByJobId(job.id))[0];
     expect(after?.startedAt?.getTime()).toBe(first.getTime());
+  });
+
+  it('discards a claim signal when the job workflow already terminated', async () => {
+    const notFound = new Error('gone');
+    notFound.name = 'WorkflowNotFoundError';
+    signalMock.mockRejectedValueOnce(notFound);
+
+    await expect(
+      onRunnerJobClaimed({
+        workflowRunId: crypto.randomUUID(),
+        workflowRunAttemptId: crypto.randomUUID(),
+        jobId: crypto.randomUUID(),
+        jobExecutionId: crypto.randomUUID(),
+        claimedAt: '2026-06-22T10:05:00.000Z',
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('rethrows a transient Temporal signal failure for subscriber retry', async () => {
+    const failure = new Error('temporal unavailable');
+    signalMock.mockRejectedValueOnce(failure);
+
+    await expect(
+      onRunnerJobClaimed({
+        workflowRunId: crypto.randomUUID(),
+        workflowRunAttemptId: crypto.randomUUID(),
+        jobId: crypto.randomUUID(),
+        jobExecutionId: crypto.randomUUID(),
+        claimedAt: '2026-06-22T10:05:00.000Z',
+      }),
+    ).rejects.toBe(failure);
   });
 });

--- a/libs/api/workflows/src/presentation/subscribers/on-runner-job-claimed.ts
+++ b/libs/api/workflows/src/presentation/subscribers/on-runner-job-claimed.ts
@@ -1,6 +1,9 @@
 import type {RunnerJobClaimedEvent} from '@shipfox/api-runners-dto';
 import {logger} from '@shipfox/node-opentelemetry';
+import {temporalClient} from '@shipfox/node-temporal';
 import {recordJobExecutionStartedAt} from '#db/index.js';
+import {JOB_CLAIMED_SIGNAL} from '#temporal/constants.js';
+import {isWorkflowNotFound} from '#temporal/workflow-not-found.js';
 
 // Anticorruption layer: the runner reports a `claimed` fact in its own lease-broker
 // language; the run lifecycle treats the claim as the job's start, so we project it onto
@@ -20,4 +23,23 @@ export async function onRunnerJobClaimed(payload: RunnerJobClaimedEvent): Promis
     jobExecutionId: payload.jobExecutionId,
     startedAt: new Date(payload.claimedAt),
   });
+
+  const handle = temporalClient().workflow.getHandle(`job:${payload.jobId}`);
+  try {
+    await handle.signal(JOB_CLAIMED_SIGNAL, {
+      jobExecutionId: payload.jobExecutionId,
+      claimedAt: payload.claimedAt,
+    });
+  } catch (err) {
+    // A terminal execution can race the claim outbox delivery. Its persisted status is
+    // authoritative, so discard the signal if Temporal has already closed the workflow.
+    if (isWorkflowNotFound(err)) {
+      logger().debug(
+        {jobId: payload.jobId, jobExecutionId: payload.jobExecutionId},
+        'Job workflow already terminated; claim event discarded',
+      );
+      return;
+    }
+    throw err;
+  }
 }

--- a/libs/api/workflows/src/temporal/constants.ts
+++ b/libs/api/workflows/src/temporal/constants.ts
@@ -2,5 +2,6 @@ export const WORKFLOWS_TASK_QUEUE = 'workflows-orchestrator';
 export const RUN_CANCEL_SIGNAL = 'run-cancel';
 export const JOB_FINISHED_SIGNAL = 'job-finished';
 export const JOB_LEASE_EXPIRED_SIGNAL = 'job-lease-expired';
+export const JOB_CLAIMED_SIGNAL = 'job-claimed';
 export const LISTENER_EVENTS_AVAILABLE_SIGNAL = 'events-available';
 export const LISTENER_RESOLVE_SIGNAL = 'resolve';

--- a/libs/api/workflows/src/temporal/index.ts
+++ b/libs/api/workflows/src/temporal/index.ts
@@ -1,5 +1,6 @@
 export {createOrchestrationActivities} from './activities/index.js';
 export {
+  JOB_CLAIMED_SIGNAL,
   JOB_FINISHED_SIGNAL,
   JOB_LEASE_EXPIRED_SIGNAL,
   WORKFLOWS_TASK_QUEUE,

--- a/libs/api/workflows/src/temporal/workflows/index.ts
+++ b/libs/api/workflows/src/temporal/workflows/index.ts
@@ -1,4 +1,5 @@
 export {
+  jobClaimedSignal,
   jobExecutionOrchestration,
   jobFinishedSignal,
   jobLeaseExpiredSignal,

--- a/libs/api/workflows/src/temporal/workflows/job-execution-orchestration.test.ts
+++ b/libs/api/workflows/src/temporal/workflows/job-execution-orchestration.test.ts
@@ -92,7 +92,7 @@ async function expectEmptyRequiredLabelsFailure(input: typeof defaultJobInput): 
 }
 
 describe('jobExecutionOrchestration', () => {
-  test('finished signal (succeeded) flips status and releases the lease', async () => {
+  test('runner claim flips status to running, then finished releases the lease', async () => {
     setCfg({
       dag: makeDag([dagJob('job-1', 'build')]),
       jobResults: new Map([['job-1', 'succeeded']]),
@@ -105,6 +105,108 @@ describe('jobExecutionOrchestration', () => {
     expect(callsNamed('releaseLeaseActivity')).toHaveLength(1);
     expect(callsNamed('resolveLeaseExpiredJobExecutionActivity')).toHaveLength(0);
     expect(callsNamed('bulkSetStepStatuses')).toHaveLength(0);
+  });
+
+  test('keeps an execution pending until the current runner claim', async () => {
+    setCfg({dag: makeDag([]), jobResults: new Map(), skipSignal: true});
+
+    const handle = await testEnv.client.workflow.start('jobExecutionOrchestration', {
+      taskQueue: TASK_QUEUE,
+      workflowId: 'job:job-pending-before-claim',
+      args: [
+        {
+          ...defaultJobInput,
+          jobId: 'job-pending-before-claim',
+          jobExecutionId: 'job-pending-before-claim',
+        },
+      ],
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(setExecutionStatusCalls()).toHaveLength(0);
+
+    await handle.signal('job-claimed', {
+      jobExecutionId: 'job-pending-before-claim',
+      claimedAt: '2026-06-22T10:05:00.000Z',
+    });
+    await handle.signal('job-finished', {
+      jobExecutionId: 'job-pending-before-claim',
+      status: 'succeeded',
+    });
+
+    const result = await handle.result();
+    expect(result.status).toBe('succeeded');
+    expect(finalStatusesFor('job-pending-before-claim')).toEqual(['running', 'succeeded']);
+  });
+
+  test('ignores stale and duplicate claims and transitions exactly once', async () => {
+    setCfg({dag: makeDag([]), jobResults: new Map(), skipSignal: true});
+
+    const handle = await testEnv.client.workflow.start('jobExecutionOrchestration', {
+      taskQueue: TASK_QUEUE,
+      workflowId: 'job:job-claim-idempotent',
+      args: [
+        {
+          ...defaultJobInput,
+          jobId: 'job-claim-idempotent',
+          jobExecutionId: 'execution-current',
+        },
+      ],
+    });
+
+    await handle.signal('job-claimed', {
+      jobExecutionId: 'execution-stale',
+      claimedAt: '2026-06-22T10:04:00.000Z',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(setExecutionStatusCalls()).toHaveLength(0);
+
+    const claim = {
+      jobExecutionId: 'execution-current',
+      claimedAt: '2026-06-22T10:05:00.000Z',
+    };
+    await handle.signal('job-claimed', claim);
+    await handle.signal('job-claimed', {...claim, claimedAt: '2026-06-22T10:06:00.000Z'});
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    await handle.signal('job-finished', {
+      jobExecutionId: 'execution-current',
+      status: 'succeeded',
+    });
+
+    const result = await handle.result();
+    expect(result.status).toBe('succeeded');
+    expect(finalStatusesFor('execution-current')).toEqual(['running', 'succeeded']);
+  });
+
+  test('a finish before a delayed claim remains terminal', async () => {
+    setCfg({dag: makeDag([]), jobResults: new Map(), skipSignal: true});
+
+    const handle = await testEnv.client.workflow.start('jobExecutionOrchestration', {
+      taskQueue: TASK_QUEUE,
+      workflowId: 'job:job-finish-before-claim',
+      args: [
+        {
+          ...defaultJobInput,
+          jobId: 'job-finish-before-claim',
+          jobExecutionId: 'job-finish-before-claim',
+        },
+      ],
+    });
+
+    await handle.signal('job-finished', {
+      jobExecutionId: 'job-finish-before-claim',
+      status: 'succeeded',
+    });
+    const result = await handle.result();
+
+    expect(result.status).toBe('succeeded');
+    expect(finalStatusesFor('job-finish-before-claim')).toEqual(['succeeded']);
+    await expect(
+      handle.signal('job-claimed', {
+        jobExecutionId: 'job-finish-before-claim',
+        claimedAt: '2026-06-22T10:05:00.000Z',
+      }),
+    ).rejects.toThrow();
   });
 
   test('empty required labels fail before the job is marked running', async () => {
@@ -272,7 +374,7 @@ describe('jobExecutionOrchestration', () => {
     ]);
   }, 15_000);
 
-  test('already-terminal job is not enqueued', async () => {
+  test('already-terminal job is not reopened after a claim', async () => {
     setCfg({
       dag: makeDag([]),
       jobResults: new Map(),
@@ -282,7 +384,7 @@ describe('jobExecutionOrchestration', () => {
     const result = await executeJob({...defaultJobInput, jobId: 'job-cancelled'});
 
     expect(result).toMatchObject({status: 'cancelled'});
-    expect(callsNamed('enqueueJobExecutionForRunner')).toHaveLength(0);
+    expect(callsNamed('enqueueJobExecutionForRunner')).toHaveLength(1);
     expect(callsNamed('releaseLeaseActivity')).toHaveLength(0);
   });
 
@@ -314,13 +416,31 @@ describe('jobExecutionOrchestration', () => {
 
     expect(result.status).toBe('failed');
     expect(callsNamed('failJobExecutionAsTimedOutActivity')).toHaveLength(1);
-    expect(finalStatusesFor('job-timeout')).toEqual(['running']);
+    expect(finalStatusesFor('job-timeout')).toEqual([]);
     expect(callsNamed('bulkSetStepStatuses')).toContainEqual({
       name: 'bulkSetStepStatuses',
       params: {jobExecutionId: 'job-timeout', status: 'failed'},
     });
     expect(callsNamed('releaseLeaseActivity')).toHaveLength(0);
     expect(callsNamed('resolveLeaseExpiredJobExecutionActivity')).toHaveLength(0);
+  });
+
+  test('does not reset the execution deadline after claim', async () => {
+    setCfg({
+      dag: makeDag([dagJob('job-claim-timeout', 'build')]),
+      jobResults: new Map(),
+      skipOutcomeSignal: true,
+    });
+
+    const result = await executeJob({
+      ...defaultJobInput,
+      jobId: 'job-claim-timeout',
+      executionTimeoutMs: 250,
+    });
+
+    expect(result.status).toBe('failed');
+    expect(finalStatusesFor('job-claim-timeout')).toEqual(['running']);
+    expect(callsNamed('failJobExecutionAsTimedOutActivity')).toHaveLength(1);
   });
 
   test('surfaces a timeout activity failure', async () => {
@@ -339,7 +459,7 @@ describe('jobExecutionOrchestration', () => {
       }),
     ).rejects.toThrow();
 
-    expect(finalStatusesFor('job-timeout-error')).toEqual(['running']);
+    expect(finalStatusesFor('job-timeout-error')).toEqual([]);
   });
 
   test('no signal — workflow stays blocked indefinitely', async () => {

--- a/libs/api/workflows/src/temporal/workflows/job-execution-orchestration.ts
+++ b/libs/api/workflows/src/temporal/workflows/job-execution-orchestration.ts
@@ -9,25 +9,25 @@ import {
 import type {RuntimeCompletionStatus} from '#core/workflow-scheduling/runtime-dag.js';
 
 import type {createOrchestrationActivities} from '../activities/index.js';
-import {JOB_FINISHED_SIGNAL, JOB_LEASE_EXPIRED_SIGNAL} from '../constants.js';
+import {JOB_CLAIMED_SIGNAL, JOB_FINISHED_SIGNAL, JOB_LEASE_EXPIRED_SIGNAL} from '../constants.js';
+import {remainingMs} from './deadline.js';
 
 /**
- * Two signals, one precedence ladder, then best-effort lease release:
+ * Enqueue, wait for the runner claim, then wait for one of the terminal facts:
  *
- *   job-finished (recordStepResult exhausted the steps) ─┐
- *   job-lease-expired (runner heartbeat went stale) ─────┤
- *                                                        ▼
- *   condition(finished ∥ leaseExpired, executionTimeout)
- *     ├─ finished      → setJobExecutionStatus(status) + resolve job status     ─┐
- *     ├─ leaseExpired  → resolveLeaseExpiredJobExecutionActivity                 ─┤→ releaseLease
- *     └─ neither (6h)  → failJobExecutionAsTimedOutActivity + sweep steps (NO release; the
- *                        TIMED_OUT event drives cooperative cancel, the detector reaps)
+ *   enqueue ──> PENDING ── job-claimed ──> RUNNING
+ *                 │                          │
+ *                 │ timeout                  ├─ job-finished
+ *                 │                          ├─ job-lease-expired
+ *                 ▼                          └─ timeout
+ *              TERMINAL
  *
- * Both signals can be delivered before condition() resumes (independent outboxes,
- * no ordering), so finished is evaluated FIRST: a genuinely-finished job is never
- * flipped to failed by a late lease-expiry. releaseLease is best-effort — a runners
- * DB outage must never block the child workflow from returning the job outcome to
- * run-orchestration; a leftover lease row is reaped by the stuck detector.
+ * The claim signal is the runner-owned lifecycle boundary. The workflow keeps the
+ * execution pending while it is queued, then performs the versioned pending → running
+ * transition after the current claim. One deadline spans both waits; claim never resets
+ * it. Signals can arrive in any order, so the precedence is finished > lease expired >
+ * claimed > timeout. Lease cleanup remains best-effort — a runners DB outage must never
+ * block the child workflow from returning the job outcome to run-orchestration.
  */
 
 const {
@@ -64,6 +64,11 @@ export const jobFinishedSignal =
   );
 export const jobLeaseExpiredSignal =
   defineSignal<[{jobExecutionId?: string | undefined}]>(JOB_LEASE_EXPIRED_SIGNAL);
+export interface JobClaimedSignalPayload {
+  jobExecutionId: string;
+  claimedAt: string;
+}
+export const jobClaimedSignal = defineSignal<[JobClaimedSignalPayload]>(JOB_CLAIMED_SIGNAL);
 
 export interface JobExecutionOrchestrationInput {
   workspaceId: string;
@@ -116,27 +121,13 @@ async function resolveJobStatusOrFailClosed(
   }
 }
 
-async function markJobExecutionRunningAndEnqueue(
-  input: JobExecutionOrchestrationInput,
-): Promise<
-  | {kind: 'running'; runningVersion: number}
-  | {kind: 'terminal'; result: JobExecutionOrchestrationResult}
-> {
+async function enqueueJobExecution(input: JobExecutionOrchestrationInput): Promise<void> {
   if (hasNoRequiredRunnerLabels(input.requiredLabels)) {
     throw ApplicationFailure.nonRetryable(
       `Job ${input.jobId} has no required runner labels`,
       'EmptyRequiredLabelsError',
     );
   }
-
-  const {newVersion: runningVersion, status} = await setJobExecutionStatus({
-    jobExecutionId: input.jobExecutionId,
-    status: 'running',
-    version: input.executionVersion,
-  });
-
-  const start = jobExecutionStartOutcome({newVersion: runningVersion, status});
-  if (start.kind === 'terminal') return start;
 
   await enqueueJobExecutionForRunner({
     workspaceId: input.workspaceId,
@@ -147,30 +138,59 @@ async function markJobExecutionRunningAndEnqueue(
     projectId: input.projectId,
     requiredLabels: input.requiredLabels,
   });
+}
 
+async function markJobExecutionRunning(
+  input: JobExecutionOrchestrationInput,
+): Promise<
+  | {kind: 'running'; runningVersion: number}
+  | {kind: 'terminal'; result: JobExecutionOrchestrationResult}
+> {
+  const {newVersion: runningVersion, status} = await setJobExecutionStatus({
+    jobExecutionId: input.jobExecutionId,
+    status: 'running',
+    version: input.executionVersion,
+  });
+
+  const start = jobExecutionStartOutcome({newVersion: runningVersion, status});
+  if (start.kind === 'terminal') return start;
   return {kind: 'running', runningVersion};
 }
 
-// Both signals can arrive before condition() resumes (independent outboxes, no
-// ordering), so callers must evaluate `finished` before `leaseExpired`.
-async function awaitJobOutcome(
+interface JobExecutionSignals extends JobExecutionOutcomeSignals {
+  claimed: JobClaimedSignalPayload | undefined;
+}
+
+function registerJobExecutionSignalHandlers(
   jobExecutionId: string,
-  timeoutMs: number,
-): Promise<JobExecutionOutcomeSignals> {
-  let finished: {status: RuntimeCompletionStatus; jobExecutionId?: string | undefined} | undefined;
-  let leaseExpired = false;
+  signals: JobExecutionSignals,
+): void {
   setHandler(jobFinishedSignal, (payload) => {
     if (payload.jobExecutionId !== undefined && payload.jobExecutionId !== jobExecutionId) return;
-    finished ??= payload;
+    signals.finished ??= payload;
   });
   setHandler(jobLeaseExpiredSignal, (payload = {}) => {
     if (payload.jobExecutionId !== undefined && payload.jobExecutionId !== jobExecutionId) return;
-    leaseExpired = true;
+    signals.leaseExpired = true;
   });
+  setHandler(jobClaimedSignal, (payload) => {
+    if (payload.jobExecutionId !== jobExecutionId) return;
+    signals.claimed ??= payload;
+  });
+}
 
-  await condition(() => finished !== undefined || leaseExpired, timeoutMs);
-
-  return {finished, leaseExpired};
+async function waitForJobExecutionSignal(
+  signals: JobExecutionSignals,
+  deadline: number,
+  includeClaim: boolean,
+): Promise<void> {
+  await condition(
+    () =>
+      signals.finished !== undefined ||
+      signals.leaseExpired ||
+      (includeClaim && signals.claimed !== undefined),
+    remainingMs(deadline) ?? 0,
+  );
 }
 
 interface JobExecutionResolution {
@@ -286,7 +306,41 @@ async function resolveTimedOutJobExecution({
 export async function jobExecutionOrchestration(
   input: JobExecutionOrchestrationInput,
 ): Promise<JobExecutionOrchestrationResult> {
-  const running = await markJobExecutionRunningAndEnqueue(input);
+  const signals: JobExecutionSignals = {
+    finished: undefined,
+    leaseExpired: false,
+    claimed: undefined,
+  };
+  // Register every signal before enqueue can block or publish a claim/outcome event. The
+  // handlers retain signals that arrive while the enqueue activity is in flight.
+  registerJobExecutionSignalHandlers(input.jobExecutionId, signals);
+  await enqueueJobExecution(input);
+
+  const timeoutMs = input.executionTimeoutMs ?? DEFAULT_EXECUTION_MAX_DURATION_MS;
+  const deadline = Date.now() + timeoutMs;
+  await waitForJobExecutionSignal(signals, deadline, true);
+
+  // A terminal fact wins over claim even when both signals arrive before the condition
+  // resumes. This prevents a late claim from reopening an execution that already finished.
+  let resolution = resolveJobExecutionOutcomeSignal(signals);
+  if (resolution === 'finished') {
+    const {finished} = signals;
+    if (finished === undefined) throw new Error('Missing finished signal for finished resolution');
+
+    return resolveFinishedJobExecution({
+      input,
+      runningVersion: input.executionVersion,
+      status: finished.status,
+    });
+  }
+  if (resolution === 'lease-expired') {
+    return resolveLeaseExpiredJobExecution({input, runningVersion: input.executionVersion});
+  }
+  if (!signals.claimed) {
+    return resolveTimedOutJobExecution({input, runningVersion: input.executionVersion});
+  }
+
+  const running = await markJobExecutionRunning(input);
   if (running.kind === 'terminal') {
     if (input.resolveJobStatus === false) {
       return {status: running.result.status, jobVersion: input.jobVersion};
@@ -295,16 +349,11 @@ export async function jobExecutionOrchestration(
   }
   const {runningVersion} = running;
 
-  const timeoutMs = input.executionTimeoutMs ?? DEFAULT_EXECUTION_MAX_DURATION_MS;
-  const signals = await awaitJobOutcome(input.jobExecutionId, timeoutMs);
-
-  // Precedence ladder: a genuinely-finished job is never flipped to failed by a
-  // late lease-expiry, so `finished` wins over `leaseExpired`.
-  const resolution = resolveJobExecutionOutcomeSignal(signals);
+  await waitForJobExecutionSignal(signals, deadline, false);
+  resolution = resolveJobExecutionOutcomeSignal(signals);
   if (resolution === 'finished') {
     const {finished} = signals;
     if (finished === undefined) throw new Error('Missing finished signal for finished resolution');
-
     return resolveFinishedJobExecution({input, runningVersion, status: finished.status});
   }
   if (resolution === 'lease-expired') {

--- a/libs/api/workflows/src/temporal/workflows/test-env.ts
+++ b/libs/api/workflows/src/temporal/workflows/test-env.ts
@@ -9,7 +9,7 @@ import type {
   ListenerBufferPeek,
 } from '#db/job-listeners.js';
 import type {RunDag} from '../activities/orchestration-activities.js';
-import {JOB_FINISHED_SIGNAL, JOB_LEASE_EXPIRED_SIGNAL} from '../constants.js';
+import {JOB_CLAIMED_SIGNAL, JOB_FINISHED_SIGNAL, JOB_LEASE_EXPIRED_SIGNAL} from '../constants.js';
 
 const TASK_QUEUE = 'test-orchestration';
 const WORKFLOWS_PATH = resolve(import.meta.dirname, '../../../dist/temporal/workflows/index.js');
@@ -31,6 +31,10 @@ export interface TestConfig {
   duplicateSignal?: boolean;
   /** If true, enqueueJobExecutionForRunner does nothing (no signal — for timeout testing) */
   skipSignal?: boolean;
+  /** If true, emit the claim but hold back the terminal outcome (for deadline testing) */
+  skipOutcomeSignal?: boolean;
+  /** Runner-owned claim timestamp used by the mock claim event */
+  claimedAt?: string;
   /** If true, signal job-lease-expired instead of job-finished */
   signalLeaseExpired?: boolean;
   /** If true, signal BOTH job-finished and job-lease-expired (precedence testing) */
@@ -285,6 +289,12 @@ function createMockActivities() {
 
       const status = cfg.jobResults.get(params.jobId) ?? 'succeeded';
       const handle = testEnv.client.workflow.getHandle(`job:${params.jobId}`);
+      await handle.signal(JOB_CLAIMED_SIGNAL, {
+        jobExecutionId: params.jobExecutionId,
+        claimedAt: cfg.claimedAt ?? '2026-06-22T10:05:00.000Z',
+      });
+
+      if (cfg.skipOutcomeSignal) return;
 
       if (cfg.signalLeaseExpired) {
         await handle.signal(JOB_LEASE_EXPIRED_SIGNAL, {jobExecutionId: params.jobExecutionId});
@@ -297,14 +307,25 @@ function createMockActivities() {
         return;
       }
 
-      await handle.signal(JOB_FINISHED_SIGNAL, {status, jobExecutionId: params.jobExecutionId});
-
-      if (cfg.duplicateSignal) {
-        await handle.signal(JOB_FINISHED_SIGNAL, {
-          status: 'failed',
-          jobExecutionId: params.jobExecutionId,
-        });
-      }
+      // Let the workflow process the claim before the independent finished outbox arrives.
+      // The precedence tests above intentionally deliver all facts in one activation.
+      const duplicateSignal = cfg.duplicateSignal;
+      setTimeout(() => {
+        void handle
+          .signal(JOB_FINISHED_SIGNAL, {status, jobExecutionId: params.jobExecutionId})
+          .then(async () => {
+            if (duplicateSignal) {
+              await handle.signal(JOB_FINISHED_SIGNAL, {
+                status: 'failed',
+                jobExecutionId: params.jobExecutionId,
+              });
+            }
+          })
+          .catch(() => {
+            // The claim can observe an already-terminal execution and close the workflow before
+            // this independently delivered outcome signal arrives.
+          });
+      }, 100);
     },
 
     resolveLeaseExpiredJobExecutionActivity: (params: {

--- a/libs/api/workflows/src/temporal/workflows/test-env.ts
+++ b/libs/api/workflows/src/temporal/workflows/test-env.ts
@@ -112,6 +112,16 @@ export function setExecutionStatusCalls() {
   }>;
 }
 
+async function waitForJobExecutionStatusWrite(jobExecutionId: string): Promise<void> {
+  while (
+    !setExecutionStatusCalls().some(
+      (call) => call.params.jobExecutionId === jobExecutionId && call.params.status === 'running',
+    )
+  ) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  }
+}
+
 export function listenerFiringOutcomeCalls() {
   return callsNamed('recordListenerFiringOutcomeActivity') as Array<{
     name: string;
@@ -307,25 +317,25 @@ function createMockActivities() {
         return;
       }
 
-      // Let the workflow process the claim before the independent finished outbox arrives.
-      // The precedence tests above intentionally deliver all facts in one activation.
+      // The runner's terminal outbox is independent from its claim. Wait for the mocked
+      // pending → running write so normal-completion tests exercise that ordering without
+      // relying on a wall-clock delay. The precedence tests above intentionally deliver all
+      // facts in one activation.
       const duplicateSignal = cfg.duplicateSignal;
-      setTimeout(() => {
-        void handle
-          .signal(JOB_FINISHED_SIGNAL, {status, jobExecutionId: params.jobExecutionId})
-          .then(async () => {
-            if (duplicateSignal) {
-              await handle.signal(JOB_FINISHED_SIGNAL, {
-                status: 'failed',
-                jobExecutionId: params.jobExecutionId,
-              });
-            }
-          })
-          .catch(() => {
-            // The claim can observe an already-terminal execution and close the workflow before
-            // this independently delivered outcome signal arrives.
-          });
-      }, 100);
+      void waitForJobExecutionStatusWrite(params.jobExecutionId)
+        .then(async () => {
+          await handle.signal(JOB_FINISHED_SIGNAL, {status, jobExecutionId: params.jobExecutionId});
+          if (duplicateSignal) {
+            await handle.signal(JOB_FINISHED_SIGNAL, {
+              status: 'failed',
+              jobExecutionId: params.jobExecutionId,
+            });
+          }
+        })
+        .catch(() => {
+          // The claim can observe an already-terminal execution and close the workflow before
+          // this independently delivered outcome signal arrives.
+        });
     },
 
     resolveLeaseExpiredJobExecutionActivity: (params: {


### PR DESCRIPTION
Runner job executions now remain pending after enqueue and transition to running only when Temporal receives the runner's claim event. The claim path projects the runner-owned timestamp into `started_at` first-write-wins and forwards a typed Temporal signal. Orchestration registers claim and outcome handlers before enqueue, ignores stale or duplicate claims, keeps one deadline across queued and running states, and preserves terminal precedence.

A patch changeset is included for `@shipfox/api-workflows`.

Validation: `mise exec -- turbo check type test --filter=@shipfox/api-workflows` passed with 61 test files and 651 tests.

Closes ENG-1400

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Job executions now stay pending after enqueue and switch to running only when a runner claims them. Adds a `job-claimed` Temporal signal and updates orchestration to wait for claim, keep one deadline, and preserve terminal precedence. Closes ENG-1400.

- **New Features**
  - Stamps started_at from the runner’s claim and forwards a typed `job-claimed` signal; discards signals to closed workflows and retries transient failures.
  - Ignores stale or duplicate claims; a late claim cannot reopen a terminal execution; finished > lease-expired > claim > timeout.
  - One execution deadline spans pending and running; claim does not reset it; lease release remains best-effort; tests synchronize mocked runner outcome signals to match claim→finish ordering.
  - Patch release for `@shipfox/api-workflows`.

<sup>Written for commit 68b43c5874fb9b8a21a0a2f4f899eba7210ce478. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

