### PR TITLE
Validate literal agent model and provider during workflow authoring

### DIFF
--- a/.changeset/quiet-agent-model-validation.md
+++ b/.changeset/quiet-agent-model-validation.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/api-agent-dto": minor
+"@shipfox/api-agent": patch
+"@shipfox/api-definitions": patch
+---
+
+Validate literal agent model and provider values during workflow authoring.

--- a/libs/api/agent-dto/src/inter-module.ts
+++ b/libs/api/agent-dto/src/inter-module.ts
@@ -19,6 +19,7 @@ const agentValidationCatalogSchema = z.object({
     z.object({
       id: harnessSchema,
       supported_provider_ids: z.array(z.string().min(1)),
+      model_ids_by_provider: z.record(z.string().min(1), z.array(z.string().min(1))).optional(),
       thinking_levels: z.array(agentThinkingSchema),
       effective_tools: z.array(z.string().min(1)),
     }),

--- a/libs/api/agent/src/core/validation-catalog.test.ts
+++ b/libs/api/agent/src/core/validation-catalog.test.ts
@@ -1,0 +1,13 @@
+import {getAgentValidationCatalog} from './validation-catalog.js';
+
+describe('getAgentValidationCatalog', () => {
+  it('includes the model allowlist for each harness/provider pair', () => {
+    const catalog = getAgentValidationCatalog();
+    const pi = catalog.harnesses.find((harness) => harness.id === 'pi');
+    const claude = catalog.harnesses.find((harness) => harness.id === 'claude');
+
+    expect(pi?.model_ids_by_provider?.anthropic).toContain('claude-opus-4-8');
+    expect(pi?.model_ids_by_provider?.openai).toContain('gpt-5.5-pro');
+    expect(claude?.model_ids_by_provider?.anthropic).toContain('claude-opus-4-8');
+  });
+});

--- a/libs/api/agent/src/core/validation-catalog.test.ts
+++ b/libs/api/agent/src/core/validation-catalog.test.ts
@@ -6,6 +6,9 @@ describe('getAgentValidationCatalog', () => {
     const pi = catalog.harnesses.find((harness) => harness.id === 'pi');
     const claude = catalog.harnesses.find((harness) => harness.id === 'claude');
 
+    expect(Object.keys(pi?.model_ids_by_provider ?? {})).toEqual(
+      expect.arrayContaining(pi?.supported_provider_ids ?? []),
+    );
     expect(pi?.model_ids_by_provider?.anthropic).toContain('claude-opus-4-8');
     expect(pi?.model_ids_by_provider?.openai).toContain('gpt-5.5-pro');
     expect(claude?.model_ids_by_provider?.anthropic).toContain('claude-opus-4-8');

--- a/libs/api/agent/src/core/validation-catalog.ts
+++ b/libs/api/agent/src/core/validation-catalog.ts
@@ -5,6 +5,7 @@ import {
 } from '@shipfox/api-agent-dto';
 import type {AgentValidationCatalog} from '@shipfox/api-agent-dto/inter-module';
 import {harnessToolDeploymentConfig} from '#config.js';
+import {listHarnessProviderModels} from './harness/index.js';
 import {getModelProviderEntry} from './model-provider-policy.js';
 
 /** Produces the versioned, JSON-safe policy snapshot consumed by Definitions. */
@@ -18,6 +19,12 @@ export function getAgentValidationCatalog(): AgentValidationCatalog {
     harnesses: listHarnessDescriptors().map((harness) => ({
       id: harness.id,
       supported_provider_ids: [...harness.supportedProviderIds],
+      model_ids_by_provider: Object.fromEntries(
+        harness.supportedProviderIds.map((providerId) => [
+          providerId,
+          listHarnessProviderModels(harness.id, providerId).map((model) => model.id),
+        ]),
+      ),
       thinking_levels: [...harness.thinkingLevels],
       effective_tools: listEnabledHarnessTools(harness.id, harnessToolDeploymentConfig).map(
         (tool) => tool.name,

--- a/libs/api/definitions/src/core/workflow-model/invalid-workflow-model-error.ts
+++ b/libs/api/definitions/src/core/workflow-model/invalid-workflow-model-error.ts
@@ -23,6 +23,7 @@ export type WorkflowModelValidationIssueCode =
   | 'invalid-interpolation-template'
   | 'invalid-duration'
   | 'invalid-listener-filter'
+  | 'invalid-model'
   | 'invalid-job-if'
   | 'invalid-job-output'
   | 'invalid-job-success'

--- a/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
@@ -1,4 +1,3 @@
-import {DEFAULT_HARNESS} from '@shipfox/api-agent-dto';
 import type {AgentValidationCatalog} from '@shipfox/api-agent-dto/inter-module';
 import {
   type AvailabilitySite,
@@ -726,8 +725,10 @@ function normalizeAgentStep(params: {
     sourceName: params.sourceName,
     stepIndex: params.stepIndex,
     issues: params.issues,
-    validateLiteralModel: modelTemplate === undefined,
-    validateLiteralProvider: providerTemplate === undefined,
+    validateLiteralModel:
+      params.step.model !== undefined && !hasInterpolationSyntax(params.step.model),
+    validateLiteralProvider:
+      params.step.provider !== undefined && !hasInterpolationSyntax(params.step.provider),
     agentValidationCatalog: params.context.agentValidationCatalog,
   });
   const integrations = normalizeAgentIntegrations({
@@ -770,16 +771,15 @@ function validateAgentStep(params: {
   validateHarnessThinking(params);
   validateHarnessTools(params);
   const providerId = params.step.provider;
-  const harness = params.step.harness ?? DEFAULT_HARNESS;
+  const harness = params.step.harness;
   const provider =
     providerId === undefined
       ? undefined
       : params.agentValidationCatalog.providers.find((entry) => entry.id === providerId);
 
   if (params.validateLiteralProvider && providerId !== undefined) {
-    if (provider === undefined && harness === DEFAULT_HARNESS) return;
-
-    if (provider === undefined || provider.support_status !== 'supported') {
+    if (provider === undefined) {
+      if (harness === undefined || harness === 'pi') return;
       params.issues.push(
         issue({
           code: 'invalid-provider',
@@ -790,6 +790,20 @@ function validateAgentStep(params: {
       );
       return;
     }
+
+    if (provider.support_status !== 'supported') {
+      params.issues.push(
+        issue({
+          code: 'invalid-provider',
+          message: `Provider "${providerId}" is not supported.`,
+          path: ['jobs', params.sourceName, 'steps', params.stepIndex, 'provider'],
+          details: {provider: providerId},
+        }),
+      );
+      return;
+    }
+
+    if (harness === undefined) return;
 
     const descriptor = params.agentValidationCatalog.harnesses.find(
       (entry) => entry.id === harness,
@@ -811,7 +825,7 @@ function validateAgentStep(params: {
     }
   }
 
-  if (!params.validateLiteralModel || providerId === undefined) return;
+  if (!params.validateLiteralModel || providerId === undefined || harness === undefined) return;
   if (provider === undefined || provider.support_status !== 'supported') return;
 
   const model = params.step.model;

--- a/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
@@ -1,3 +1,4 @@
+import {DEFAULT_HARNESS} from '@shipfox/api-agent-dto';
 import type {AgentValidationCatalog} from '@shipfox/api-agent-dto/inter-module';
 import {
   type AvailabilitySite,
@@ -725,6 +726,7 @@ function normalizeAgentStep(params: {
     sourceName: params.sourceName,
     stepIndex: params.stepIndex,
     issues: params.issues,
+    validateLiteralModel: modelTemplate === undefined,
     validateLiteralProvider: providerTemplate === undefined,
     agentValidationCatalog: params.context.agentValidationCatalog,
   });
@@ -761,47 +763,70 @@ function validateAgentStep(params: {
   sourceName: string;
   stepIndex: number;
   issues: WorkflowModelValidationIssue[];
+  validateLiteralModel: boolean;
   validateLiteralProvider: boolean;
   agentValidationCatalog: AgentValidationCatalog;
 }): void {
   validateHarnessThinking(params);
   validateHarnessTools(params);
-  if (!params.validateLiteralProvider) return;
-
   const providerId = params.step.provider;
-  if (providerId === undefined) return;
+  const harness = params.step.harness ?? DEFAULT_HARNESS;
+  const provider =
+    providerId === undefined
+      ? undefined
+      : params.agentValidationCatalog.providers.find((entry) => entry.id === providerId);
 
-  const provider = params.agentValidationCatalog.providers.find((entry) => entry.id === providerId);
-  const harness = params.step.harness;
-  if (provider === undefined && harness === 'pi') return;
+  if (params.validateLiteralProvider && providerId !== undefined) {
+    if (provider === undefined && harness === DEFAULT_HARNESS) return;
 
-  if (provider === undefined || provider.support_status !== 'supported') {
-    params.issues.push(
-      issue({
-        code: 'invalid-provider',
-        message: `Provider "${providerId}" is not supported.`,
-        path: ['jobs', params.sourceName, 'steps', params.stepIndex, 'provider'],
-        details: {provider: providerId},
-      }),
+    if (provider === undefined || provider.support_status !== 'supported') {
+      params.issues.push(
+        issue({
+          code: 'invalid-provider',
+          message: `Provider "${providerId}" is not supported.`,
+          path: ['jobs', params.sourceName, 'steps', params.stepIndex, 'provider'],
+          details: {provider: providerId},
+        }),
+      );
+      return;
+    }
+
+    const descriptor = params.agentValidationCatalog.harnesses.find(
+      (entry) => entry.id === harness,
     );
-    return;
+    if (!descriptor?.supported_provider_ids.includes(providerId)) {
+      params.issues.push(
+        issue({
+          code: 'harness-provider-incompatible',
+          message: `Harness "${harness}" does not support provider: ${providerId}. Supported providers: ${descriptor?.supported_provider_ids.join(', ') ?? ''}.`,
+          path: ['jobs', params.sourceName, 'steps', params.stepIndex, 'provider'],
+          details: {
+            harness,
+            provider: providerId,
+            supportedProviders: descriptor?.supported_provider_ids ?? [],
+          },
+        }),
+      );
+      return;
+    }
   }
 
-  if (harness === undefined) return;
+  if (!params.validateLiteralModel || providerId === undefined) return;
+  if (provider === undefined || provider.support_status !== 'supported') return;
+
+  const model = params.step.model;
+  if (model === undefined) return;
 
   const descriptor = params.agentValidationCatalog.harnesses.find((entry) => entry.id === harness);
-  if (descriptor?.supported_provider_ids.includes(providerId)) return;
+  const modelIds = descriptor?.model_ids_by_provider?.[providerId];
+  if (modelIds === undefined || modelIds.includes(model)) return;
 
   params.issues.push(
     issue({
-      code: 'harness-provider-incompatible',
-      message: `Harness "${harness}" does not support provider: ${providerId}. Supported providers: ${descriptor?.supported_provider_ids.join(', ') ?? ''}.`,
-      path: ['jobs', params.sourceName, 'steps', params.stepIndex, 'provider'],
-      details: {
-        harness,
-        provider: providerId,
-        supportedProviders: descriptor?.supported_provider_ids ?? [],
-      },
+      code: 'invalid-model',
+      message: `Agent model "${model}" is not available for harness "${harness}" and provider "${providerId}".`,
+      path: ['jobs', params.sourceName, 'steps', params.stepIndex, 'model'],
+      details: {harness, provider: providerId, model},
     }),
   );
 }

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -285,7 +285,7 @@ describe('normalizeWorkflowDocument', () => {
             {
               key: 'review',
               harness: 'claude',
-              model: 'gpt-5.5-pro',
+              model: 'claude-opus-4-8',
               provider: 'anthropic',
               prompt: 'Review the fix.',
               thinking: 'low',
@@ -669,6 +669,7 @@ describe('normalizeWorkflowDocument', () => {
             {
               harness: 'pi',
               provider: 'workspace-openai-compatible',
+              model: 'workspace-model',
               prompt: 'Fix it.',
             },
           ],
@@ -682,6 +683,55 @@ describe('normalizeWorkflowDocument', () => {
       kind: 'agent',
       harness: 'pi',
       provider: 'workspace-openai-compatible',
+      model: 'workspace-model',
+    });
+  });
+
+  it('reports unsupported literal models', () => {
+    const document: WorkflowDocument = {
+      name: 'agent build',
+      jobs: {
+        fix: {
+          steps: [{provider: 'anthropic', model: 'not-a-model', prompt: 'Fix it.'}],
+        },
+      },
+    };
+
+    const error = expectInvalid(document);
+
+    expect(error.issues).toEqual([
+      {
+        code: 'invalid-model',
+        message:
+          'Agent model "not-a-model" is not available for harness "pi" and provider "anthropic".',
+        path: ['jobs', 'fix', 'steps', 0, 'model'],
+        details: {harness: 'pi', provider: 'anthropic', model: 'not-a-model'},
+      },
+    ]);
+  });
+
+  it('allows custom providers without an explicit harness', () => {
+    const document: WorkflowDocument = {
+      name: 'agent build',
+      jobs: {
+        fix: {
+          steps: [
+            {
+              provider: 'workspace-openai-compatible',
+              model: 'workspace-model',
+              prompt: 'Fix it.',
+            },
+          ],
+        },
+      },
+    };
+
+    const model = normalizeWorkflowDocument(document);
+
+    expect(model.jobs[0]?.steps[0]).toMatchObject({
+      kind: 'agent',
+      provider: 'workspace-openai-compatible',
+      model: 'workspace-model',
     });
   });
 
@@ -1245,7 +1295,7 @@ describe('normalizeWorkflowDocument', () => {
     ]);
   });
 
-  it('preserves explicit model ids even when the seed catalog only knows provider defaults', () => {
+  it('accepts explicit model ids present in the harness catalog', () => {
     const document: WorkflowDocument = {
       name: 'agent build',
       jobs: {
@@ -4426,6 +4476,30 @@ describe('normalizeWorkflowDocument', () => {
       expect(model.jobs[0]?.steps[0]).toMatchObject({
         kind: 'agent',
         templates: {provider: [{kind: 'deferred', roots: ['run']}]},
+      });
+    });
+
+    it('skips static model catalog validation when model is interpolated', () => {
+      const document: WorkflowDocument = {
+        name: 'templated model',
+        jobs: {
+          fix: {
+            steps: [
+              {
+                provider: 'anthropic',
+                model: interpolation('run.name'),
+                prompt: 'Fix it.',
+              },
+            ],
+          },
+        },
+      };
+
+      const model = normalizeWorkflowDocument(document);
+
+      expect(model.jobs[0]?.steps[0]).toMatchObject({
+        kind: 'agent',
+        templates: {model: [{kind: 'deferred', roots: ['run']}]},
       });
     });
 

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -692,7 +692,7 @@ describe('normalizeWorkflowDocument', () => {
       name: 'agent build',
       jobs: {
         fix: {
-          steps: [{provider: 'anthropic', model: 'not-a-model', prompt: 'Fix it.'}],
+          steps: [{harness: 'pi', provider: 'anthropic', model: 'not-a-model', prompt: 'Fix it.'}],
         },
       },
     };
@@ -732,6 +732,31 @@ describe('normalizeWorkflowDocument', () => {
       kind: 'agent',
       provider: 'workspace-openai-compatible',
       model: 'workspace-model',
+    });
+  });
+
+  it('defers harness-specific validation when harness is omitted', () => {
+    const document: WorkflowDocument = {
+      name: 'workspace-default harness',
+      jobs: {
+        fix: {
+          steps: [
+            {
+              provider: 'anthropic',
+              model: 'claude-sonnet-4-6',
+              prompt: 'Fix it.',
+            },
+          ],
+        },
+      },
+    };
+
+    const model = normalizeWorkflowDocument(document);
+
+    expect(model.jobs[0]?.steps[0]).toMatchObject({
+      kind: 'agent',
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-6',
     });
   });
 
@@ -1300,7 +1325,7 @@ describe('normalizeWorkflowDocument', () => {
       name: 'agent build',
       jobs: {
         fix: {
-          steps: [{provider: 'openai', model: 'gpt-4.1', prompt: 'Fix it.'}],
+          steps: [{harness: 'pi', provider: 'openai', model: 'gpt-4.1', prompt: 'Fix it.'}],
         },
       },
     };
@@ -4479,6 +4504,26 @@ describe('normalizeWorkflowDocument', () => {
       });
     });
 
+    it('does not add provider catalog issues for invalid provider interpolation', () => {
+      const document: WorkflowDocument = {
+        name: 'invalid provider interpolation',
+        jobs: {
+          fix: {
+            steps: [{harness: 'claude', provider: interpolation('foo.bar'), prompt: 'Fix it.'}],
+          },
+        },
+      };
+
+      const error = expectInvalid(document);
+
+      expect(error.issues).toEqual([
+        expect.objectContaining({
+          code: 'unknown-interpolation-context',
+          path: ['jobs', 'fix', 'steps', 0, 'provider'],
+        }),
+      ]);
+    });
+
     it('skips static model catalog validation when model is interpolated', () => {
       const document: WorkflowDocument = {
         name: 'templated model',
@@ -4501,6 +4546,33 @@ describe('normalizeWorkflowDocument', () => {
         kind: 'agent',
         templates: {model: [{kind: 'deferred', roots: ['run']}]},
       });
+    });
+
+    it('does not add model catalog issues for invalid model interpolation', () => {
+      const document: WorkflowDocument = {
+        name: 'invalid model interpolation',
+        jobs: {
+          fix: {
+            steps: [
+              {
+                harness: 'pi',
+                provider: 'anthropic',
+                model: interpolation('foo.bar'),
+                prompt: 'Fix it.',
+              },
+            ],
+          },
+        },
+      };
+
+      const error = expectInvalid(document);
+
+      expect(error.issues).toEqual([
+        expect.objectContaining({
+          code: 'unknown-interpolation-context',
+          path: ['jobs', 'fix', 'steps', 0, 'model'],
+        }),
+      ]);
     });
 
     it('still validates literal providers through the catalog', () => {

--- a/libs/api/definitions/test/agent-validation-catalog.ts
+++ b/libs/api/definitions/test/agent-validation-catalog.ts
@@ -7,6 +7,21 @@ import {
 } from '@shipfox/api-agent-dto';
 import type {AgentValidationCatalog} from '@shipfox/api-agent-dto/inter-module';
 
+const piModelIdsByProvider = Object.fromEntries(
+  MODEL_PROVIDER_CATALOG_SEED.filter((entry) => entry.support_status === 'supported').map(
+    (entry) => [
+      entry.id,
+      entry.id === 'anthropic'
+        ? ['claude-opus-4-8']
+        : entry.id === 'openai'
+          ? ['gpt-4.1', 'gpt-5.5-pro']
+          : entry.default_model === null
+            ? []
+            : [entry.default_model],
+    ],
+  ),
+);
+
 export const agentValidationCatalog: AgentValidationCatalog = {
   version: 1,
   providers: MODEL_PROVIDER_IDS.map((id) => ({
@@ -18,12 +33,7 @@ export const agentValidationCatalog: AgentValidationCatalog = {
     id: harness.id,
     supported_provider_ids: [...harness.supportedProviderIds],
     model_ids_by_provider:
-      harness.id === 'pi'
-        ? {
-            anthropic: ['claude-opus-4-8'],
-            openai: ['gpt-4.1', 'gpt-5.5-pro'],
-          }
-        : {anthropic: ['claude-opus-4-8']},
+      harness.id === 'pi' ? piModelIdsByProvider : {anthropic: ['claude-opus-4-8']},
     thinking_levels: [...harness.thinkingLevels],
     effective_tools: listEnabledHarnessTools(
       harness.id,

--- a/libs/api/definitions/test/agent-validation-catalog.ts
+++ b/libs/api/definitions/test/agent-validation-catalog.ts
@@ -17,6 +17,13 @@ export const agentValidationCatalog: AgentValidationCatalog = {
   harnesses: listHarnessDescriptors().map((harness) => ({
     id: harness.id,
     supported_provider_ids: [...harness.supportedProviderIds],
+    model_ids_by_provider:
+      harness.id === 'pi'
+        ? {
+            anthropic: ['claude-opus-4-8'],
+            openai: ['gpt-4.1', 'gpt-5.5-pro'],
+          }
+        : {anthropic: ['claude-opus-4-8']},
     thinking_levels: [...harness.thinkingLevels],
     effective_tools: listEnabledHarnessTools(
       harness.id,


### PR DESCRIPTION
Validate literal agent model and provider values during workflow authoring.

The Agent validation catalog now carries per-harness model allowlists into Definitions normalization. Literal built-in values fail with field-specific validation issues before dispatch, while interpolated values and workspace custom providers remain deferred until runtime.

Closes ENG-1405

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates literal agent provider and model during workflow authoring with per-harness, per-provider model allowlists. Defers harness-specific checks when the harness is omitted or values are interpolated/invalid, and returns clear errors only for unsupported literal values (ENG-1405).

- **New Features**
  - Catalog exposes `model_ids_by_provider` in `@shipfox/api-agent-dto`, populated by `getAgentValidationCatalog` in `@shipfox/api-agent`.
  - `@shipfox/api-definitions` normalization validates provider support and harness compatibility, enforces model allowlists, and adds `invalid-model` error code.
  - Skips static checks when `model` or `provider` is interpolated, allows workspace custom providers/models without an explicit harness, and defers harness-specific validation when the harness is omitted.

<sup>Written for commit 32c82e68a0bee45dd3b66650c285790f28c0d76d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

