### PR TITLE
Persist resolved job execution names in workflow runs

### DIFF
--- a/.changeset/persist-execution-names.md
+++ b/.changeset/persist-execution-names.md
@@ -1,0 +1,8 @@
+---
+"@shipfox/api-definitions": patch
+"@shipfox/api-workflows": minor
+"@shipfox/api-workflows-dto": minor
+"@shipfox/expression": minor
+---
+
+Persist resolved workflow job execution names and handle dynamic naming failures consistently.

--- a/libs/api/definitions/src/core/parse-definition.test.ts
+++ b/libs/api/definitions/src/core/parse-definition.test.ts
@@ -65,7 +65,7 @@ describe('parseDefinition', () => {
         onResolve: 'cancel',
       },
     });
-    expect(definition.model.jobs[0]?.name).toBeDefined();
+    expect(definition.model.jobs[0]?.executionName).toBeDefined();
   });
 
   test('attaches source line locations to workflow model steps', () => {

--- a/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
@@ -253,6 +253,21 @@ function normalizeJob(params: {
           allowedJobReferences,
           typeOverlay: upstreamJobsTypeOverlay,
         }) ?? [{kind: 'literal' as const, value: params.job.name}]);
+  if (name?.some((segment) => segment.kind !== 'literal')) {
+    params.issues.push(
+      issue({
+        code: 'invalid-interpolation-template',
+        message:
+          'Job name must be static text. Use execution_name for a per-execution dynamic name.',
+        path: ['jobs', params.sourceName, 'name'],
+        details: {
+          field: 'job.name',
+          source: params.job.name,
+          reason: 'Job names cannot contain interpolation expressions.',
+        },
+      }),
+    );
+  }
   const executionName =
     params.job.execution_name === undefined
       ? undefined

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -1011,7 +1011,7 @@ describe('normalizeWorkflowDocument', () => {
       name: 'listen for reviews',
       jobs: {
         review: {
-          name: displayName,
+          execution_name: displayName,
           listening: {
             on: [
               {
@@ -1046,7 +1046,7 @@ describe('normalizeWorkflowDocument', () => {
         onResolve: 'cancel',
       },
     });
-    expect(model.jobs[0]?.name?.[1]).toMatchObject({
+    expect(model.jobs[0]?.executionName?.[1]).toMatchObject({
       kind: 'deferred',
       expression: {source: 'execution.index', check: 'typed'},
     });
@@ -4125,7 +4125,7 @@ describe('normalizeWorkflowDocument', () => {
       });
     });
 
-    it('does not apply availability checks to job names', () => {
+    it('rejects dynamic job names in favor of execution_name', () => {
       const document: WorkflowDocument = {
         name: 'job display context',
         jobs: {
@@ -4141,16 +4141,17 @@ describe('normalizeWorkflowDocument', () => {
         },
       };
 
-      const model = normalizeWorkflowDocument(document);
-
-      expect(model.jobs[0]?.name?.[0]).toMatchObject({
-        kind: 'deferred',
-        roots: ['execution'],
-      });
-      expect(model.jobs[1]?.name?.[0]).toMatchObject({
-        kind: 'deferred',
-        roots: ['execution'],
-      });
+      const error = expectInvalid(document);
+      expect(error.issues).toEqual([
+        expect.objectContaining({
+          code: 'invalid-interpolation-template',
+          path: ['jobs', 'build', 'name'],
+        }),
+        expect.objectContaining({
+          code: 'invalid-interpolation-template',
+          path: ['jobs', 'review', 'name'],
+        }),
+      ]);
     });
 
     it('does not apply availability checks to workflow-level or job-level env', () => {
@@ -4280,7 +4281,7 @@ describe('normalizeWorkflowDocument', () => {
       });
     });
 
-    it('allows execution events in untrusted-capable fields', () => {
+    it('rejects execution events in static job names', () => {
       const document: WorkflowDocument = {
         name: 'execution events allowed',
         jobs: {
@@ -4292,25 +4293,13 @@ describe('normalizeWorkflowDocument', () => {
         },
       };
 
-      const model = normalizeWorkflowDocument(document);
-
-      expect(model.jobs[0]?.name?.[1]).toMatchObject({
-        kind: 'deferred',
-        expression: {check: 'typed'},
-        roots: ['execution'],
-      });
-      expect(model.jobs[0]?.steps[0]).toMatchObject({
-        kind: 'agent',
-        templates: {
-          prompt: [
-            {
-              kind: 'deferred',
-              expression: {check: 'typed'},
-              roots: ['execution'],
-            },
-          ],
-        },
-      });
+      const error = expectInvalid(document);
+      expect(error.issues).toEqual([
+        expect.objectContaining({
+          code: 'invalid-interpolation-template',
+          path: ['jobs', 'build', 'name'],
+        }),
+      ]);
     });
 
     it('allows untrusted context in env, prompt, and step names', () => {

--- a/libs/api/definitions/test/fixtures/valid-listening-job.yml
+++ b/libs/api/definitions/test/fixtures/valid-listening-job.yml
@@ -2,7 +2,7 @@ name: Listening workflow
 runner: ubuntu-latest
 jobs:
   review:
-    name: Review batch ${{ execution.index }}
+    execution_name: Review batch ${{ execution.index }}
     listening:
       on:
         - source: github

--- a/libs/api/workflows-dto/src/inter-module.ts
+++ b/libs/api/workflows-dto/src/inter-module.ts
@@ -35,6 +35,7 @@ const interpolationFieldSchema = z.enum([
   'job.runner',
   'job.outputs',
   'job.name',
+  'job.execution_name',
   'step.name',
   'step.feedback',
 ]);

--- a/libs/api/workflows/drizzle/0000_initial.sql
+++ b/libs/api/workflows/drizzle/0000_initial.sql
@@ -15,7 +15,7 @@ CREATE TABLE "workflows_job_executions" (
 	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
 	"job_id" uuid NOT NULL,
 	"sequence" integer NOT NULL,
-	"name" text NOT NULL,
+	"name" text,
 	"runner" jsonb,
 	"status" "workflows_job_execution_status" DEFAULT 'pending' NOT NULL,
 	"status_reason" "workflows_job_status_reason",

--- a/libs/api/workflows/drizzle/meta/0000_snapshot.json
+++ b/libs/api/workflows/drizzle/meta/0000_snapshot.json
@@ -31,7 +31,7 @@
           "name": "name",
           "type": "text",
           "primaryKey": false,
-          "notNull": true
+          "notNull": false
         },
         "runner": {
           "name": "runner",

--- a/libs/api/workflows/src/core/entities/job-execution.ts
+++ b/libs/api/workflows/src/core/entities/job-execution.ts
@@ -15,6 +15,8 @@ export interface JobExecution {
   id: string;
   jobId: string;
   sequence: number;
+  /** A dynamically resolved name; null means use the parent job's fallback. */
+  nameOverride: string | null;
   name: string;
   runner: string[] | null;
   status: JobExecutionStatus;

--- a/libs/api/workflows/src/core/errors.ts
+++ b/libs/api/workflows/src/core/errors.ts
@@ -64,6 +64,7 @@ export type InterpolationUnresolvableField =
   | 'job.runner'
   | 'job.outputs'
   | 'job.name'
+  | 'job.execution_name'
   | 'step.name'
   | 'step.feedback';
 

--- a/libs/api/workflows/src/core/job-transition/decide-job-activation.test.ts
+++ b/libs/api/workflows/src/core/job-transition/decide-job-activation.test.ts
@@ -179,6 +179,7 @@ export function jobExecution(params: Partial<JobExecution> = {}): JobExecution {
     id: crypto.randomUUID(),
     jobId: params.jobId ?? crypto.randomUUID(),
     sequence: params.sequence ?? 1,
+    nameOverride: params.nameOverride ?? params.name ?? 'build',
     name: params.name ?? 'build',
     runner: null,
     status: params.status ?? 'succeeded',

--- a/libs/api/workflows/src/core/job-transition/derive-job-success.test.ts
+++ b/libs/api/workflows/src/core/job-transition/derive-job-success.test.ts
@@ -116,6 +116,7 @@ function jobExecution(params: Partial<JobExecution> = {}): JobExecution {
     id: crypto.randomUUID(),
     jobId: params.jobId ?? crypto.randomUUID(),
     sequence: params.sequence ?? 1,
+    nameOverride: params.nameOverride ?? params.name ?? 'build',
     name: params.name ?? 'build',
     runner: null,
     status: params.status ?? 'succeeded',

--- a/libs/api/workflows/src/core/listener-execution-materialization.ts
+++ b/libs/api/workflows/src/core/listener-execution-materialization.ts
@@ -1,4 +1,5 @@
 import type {WorkflowModel} from '@shipfox/api-definitions-dto';
+import {evaluationTraceEntry} from '@shipfox/expression';
 import type {AgentDefaultsResolver} from './agent-defaults.js';
 import type {
   AgentToolMaterializationContext,
@@ -25,6 +26,7 @@ import {
   materializeJobRunner,
   resolveJobExecutionName,
 } from './step-config/index.js';
+import {staticJobName} from './step-config/static-job-name.js';
 
 export interface MaterializeListenerExecutionParams {
   readonly model: WorkflowModel | null;
@@ -39,7 +41,9 @@ export interface MaterializeListenerExecutionParams {
     | 'triggerPayload'
     | 'inputs'
   >;
-  readonly job: Pick<Job, 'id' | 'key'>;
+  readonly job: Pick<Job, 'id' | 'key'> & Partial<Pick<Job, 'name'>>;
+  readonly vars?: Record<string, string> | undefined;
+  readonly variableResolutionError?: InterpolationUnresolvableError | undefined;
   readonly sequence: number;
   readonly triggerEvents: readonly WorkflowExecutionEvent[];
   readonly priorExecutions: readonly JobExecution[];
@@ -49,7 +53,7 @@ export interface MaterializeListenerExecutionParams {
 }
 
 export interface MaterializedListenerExecution {
-  readonly name: string;
+  readonly nameOverride: string | null;
   readonly runner: readonly string[];
   readonly status: JobExecutionStatus;
   readonly statusReason: 'unknown' | null;
@@ -61,14 +65,18 @@ export interface MaterializedListenerExecution {
 export async function materializeListenerExecution(
   params: MaterializeListenerExecutionParams,
 ): Promise<MaterializedListenerExecution> {
-  const fallbackName = `${params.job.key} #${params.sequence}`;
-  let executionName = fallbackName;
+  let executionName = params.job.name ?? params.job.key;
+  let nameOverride: string | null = null;
   let evaluationTrace: readonly PersistedEvaluationTraceEntry[] = [];
   let runner: readonly string[] = [];
   let steps: readonly MaterializedWorkflowStep[] = [];
   let status: JobExecutionStatus = 'pending';
+  if (params.variableResolutionError) {
+    evaluationTrace = [variableResolutionTrace(params.variableResolutionError)];
+  }
 
   try {
+    if (params.variableResolutionError) throw params.variableResolutionError;
     if (!params.model) throw new PermanentListenerMaterializationError('Run attempt has no model');
     const modelJob = params.model.jobs.find((job) => job.key === params.job.key);
     if (!modelJob) {
@@ -77,16 +85,34 @@ export async function materializeListenerExecution(
       );
     }
 
+    const materializationJob = {
+      ...params.job,
+      name: params.job.name ?? staticJobName(modelJob) ?? null,
+    };
+    executionName = materializationJob.name ?? params.job.key;
+
     const resolvedName = resolveJobExecutionName({
       definitionId: params.run.definitionId,
       job: modelJob,
-      fallbackName,
-      context: listenerExecutionContext({...params, executionName, status}).values,
+      context: listenerExecutionContext({
+        ...params,
+        job: materializationJob,
+        nameOverride: null,
+        executionName,
+        status,
+      }).values,
     });
-    executionName = resolvedName.value;
+    nameOverride = resolvedName.nameOverride;
+    executionName = nameOverride ?? executionName;
     evaluationTrace = resolvedName.trace;
 
-    const context = listenerExecutionContext({...params, executionName, status});
+    const context = listenerExecutionContext({
+      ...params,
+      job: materializationJob,
+      nameOverride,
+      executionName,
+      status,
+    });
     runner = materializeJobRunner({
       job: modelJob,
       context,
@@ -109,7 +135,7 @@ export async function materializeListenerExecution(
   }
 
   return {
-    name: executionName,
+    nameOverride,
     runner,
     status,
     statusReason: status === 'failed' ? 'unknown' : null,
@@ -119,12 +145,29 @@ export async function materializeListenerExecution(
   };
 }
 
+function variableResolutionTrace(
+  error: InterpolationUnresolvableError,
+): PersistedEvaluationTraceEntry {
+  return {
+    ...evaluationTraceEntry({
+      expression: error.source,
+      roots: ['vars'],
+      fillTarget: 'execution-creation',
+      evaluatedAt: 'execution-creation',
+      degraded: true,
+    }),
+    field: error.field,
+    ...(error.envKey === undefined ? {} : {envKey: error.envKey}),
+  };
+}
+
 function listenerExecutionContext(
   params: Pick<
     MaterializeListenerExecutionParams,
-    'run' | 'job' | 'sequence' | 'triggerEvents' | 'priorExecutions'
+    'run' | 'job' | 'vars' | 'sequence' | 'triggerEvents' | 'priorExecutions'
   > & {
     readonly executionName: string;
+    readonly nameOverride: string | null;
     readonly status: JobExecutionStatus;
   },
 ) {
@@ -132,8 +175,10 @@ function listenerExecutionContext(
     run: params.run,
     triggerPayload: params.run.triggerPayload,
     inputs: params.run.inputs,
-    jobId: params.job.id,
+    vars: params.vars,
+    job: {...params.job, name: params.job.name ?? null},
     sequence: params.sequence,
+    nameOverride: params.nameOverride,
     executionName: params.executionName,
     status: params.status,
     triggerEvents: params.triggerEvents,

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
@@ -140,8 +140,9 @@ describe('assembleExecutionCreationContext', () => {
         data: {ref: 'refs/heads/main'},
       },
       inputs: {deploy: true},
-      jobId: 'job-1',
+      job: {id: 'job-1', key: 'build', name: 'Build'},
       sequence: 2,
+      nameOverride: null,
       executionName: 'Build #2',
       status: 'pending',
       triggerEvents: [
@@ -197,6 +198,7 @@ describe('assembleExecutionCreationContext', () => {
             outputs: {},
           },
         ],
+        job: {key: 'build', name: 'Build'},
         execution: {
           index: 1,
           name: 'Build #2',
@@ -995,6 +997,7 @@ function jobExecution(overrides: Partial<JobExecution> = {}): JobExecution {
     id: 'exec-1',
     jobId: 'job-1',
     sequence: 2,
+    nameOverride: 'Deploy',
     name: 'Deploy',
     runner: null,
     status: 'running',

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.ts
@@ -56,8 +56,9 @@ export function assembleCreationContext(
 }
 
 export interface AssembleExecutionCreationContextParams extends AssembleWorkflowRunContextParams {
-  readonly jobId: string;
+  readonly job: Pick<Job, 'id' | 'key' | 'name'>;
   readonly sequence: number;
+  readonly nameOverride: string | null;
   readonly executionName: string;
   readonly status: JobExecution['status'];
   readonly triggerEvents: readonly JobExecution['triggerEvents'][number][];
@@ -68,9 +69,10 @@ export function assembleExecutionCreationContext(
   params: AssembleExecutionCreationContextParams,
 ): WorkflowEvaluationContext {
   const execution: JobExecution = {
-    id: `${params.jobId}:${params.sequence}`,
-    jobId: params.jobId,
+    id: `${params.job.id}:${params.sequence}`,
+    jobId: params.job.id,
     sequence: params.sequence,
+    nameOverride: params.nameOverride,
     name: params.executionName,
     runner: null,
     status: params.status,
@@ -92,6 +94,7 @@ export function assembleExecutionCreationContext(
     values: {
       ...assembleWorkflowRunContext(params),
       ...executions,
+      job: {key: params.job.key, name: params.job.name ?? params.job.key},
       execution: executionValues.at(-1),
     },
   };
@@ -212,7 +215,7 @@ function isListenerSnapshotRoot(root: string): root is ListenerSnapshotRoot {
 }
 
 export function assembleListenerSnapshotContext(params: {
-  readonly job: Pick<Job, 'key'>;
+  readonly job: Pick<Job, 'key'> & Partial<Pick<Job, 'name'>>;
   readonly run: AssembleWorkflowRunContextParams['run'];
   readonly triggerPayload: TriggerPayload;
   readonly inputs?: Record<string, unknown> | null | undefined;
@@ -234,7 +237,10 @@ export function assembleListenerSnapshotContext(params: {
     context.inputs = params.inputs ?? null;
   }
   if (params.plan.roots.has('job')) {
-    context.job = {key: params.job.key};
+    context.job = {
+      key: params.job.key,
+      ...(params.job.name === undefined ? {} : {name: params.job.name ?? params.job.key}),
+    };
   }
   if (params.plan.roots.has('jobs')) {
     context.jobs = requestedJobsContext(params.dependencyJobs, params.plan.jobKeys);
@@ -506,7 +512,7 @@ export function assembleExecutionResolutionContext(params: {
   readonly triggerPayload: TriggerPayload;
   readonly inputs?: Record<string, unknown> | null | undefined;
   readonly vars?: Record<string, string> | undefined;
-  readonly job: Pick<Job, 'key'>;
+  readonly job: Pick<Job, 'key'> & Partial<Pick<Job, 'name'>>;
   readonly jobExecution: JobExecution;
   readonly executions: readonly JobExecution[];
   readonly steps: readonly Step[];
@@ -528,7 +534,10 @@ export function assembleExecutionResolutionContext(params: {
         params.jobExecution,
         executionIndex < 0 ? params.jobExecution.sequence - 1 : executionIndex,
       ),
-      job: {key: params.job.key},
+      job: {
+        key: params.job.key,
+        ...(params.job.name === undefined ? {} : {name: params.job.name ?? params.job.key}),
+      },
       steps: assembleStepsContext({steps: params.steps, attempts: params.attempts}),
     },
   };

--- a/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.test.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.test.ts
@@ -157,6 +157,26 @@ function githubAgentToolCatalog(): readonly AgentToolCatalogEntry[] {
 }
 
 describe('materializeJobExecutionSteps', () => {
+  it('resolves static job names through the job execution context', async () => {
+    const model = workflowModel({
+      jobs: {
+        review: {
+          name: 'Review',
+          steps: [{name: template('job.name'), run: 'echo review'}],
+        },
+      },
+    });
+    const job = model.jobs[0];
+    if (!job) throw new Error('Expected workflow job');
+
+    const steps = await materializeJobExecutionSteps({model, job, context: jobExecutionContext()});
+
+    expect(steps[1]).toMatchObject({
+      name: 'Review',
+      config: {run: 'echo review'},
+    });
+  });
+
   it('prepends setup and resolves job-execution context fields', async () => {
     const model = workflowModel({
       jobs: {

--- a/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.ts
@@ -7,6 +7,7 @@ import type {
 } from '#core/agent-tools.js';
 import type {StepConfigDispatchPlan} from '#core/entities/step.js';
 import {resolveStepConfig, type WorkflowStepTemplateDiagnostic} from './resolve-step-config.js';
+import {staticJobName} from './static-job-name.js';
 import type {WorkflowEvaluationContext} from './workflow-evaluation-context.js';
 
 type WorkflowModelJob = WorkflowModel['jobs'][number];
@@ -71,8 +72,10 @@ export async function materializeJobExecutionSteps(
     SETUP_STEP,
     ...(await Promise.all(
       job.steps.map(async (step, stepPosition) => {
-        // The trusted context exposes the stable job key; the authored display field remains `job.name`.
-        const stepContext = {...context.values, job: {key: job.key}};
+        const stepContext = {
+          ...context.values,
+          job: {key: job.key, name: staticJobName(job) ?? job.key},
+        };
         const resolved = await resolveStepConfig({
           jobKey: job.key,
           step,

--- a/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
@@ -58,6 +58,28 @@ function creationContext(
 }
 
 describe('materializeWorkflowModel', () => {
+  it('keeps literal job names while omitting dynamic name sources from runtime jobs', async () => {
+    const model = workflowModel({
+      jobs: {
+        deploy: {
+          name: 'Deploy',
+          steps: [{run: 'echo deploy'}],
+        },
+        review: {
+          name: `Review ${template('inputs.environment')}`,
+          steps: [{run: 'echo review'}],
+        },
+      },
+    });
+
+    const rows = await materializeWorkflowModel({model});
+    const deploy = rows.find((job) => job.key === 'deploy');
+    const review = rows.find((job) => job.key === 'review');
+
+    expect(deploy).toMatchObject({key: 'deploy', name: 'Deploy'});
+    expect(review).not.toHaveProperty('name');
+  });
+
   it('converts workflow model jobs and steps to runtime rows', async () => {
     const model = workflowModel({
       runner: 'ubuntu-latest',

--- a/libs/api/workflows/src/core/step-config/materialize-workflow-model.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-workflow-model.ts
@@ -11,6 +11,7 @@ import {
   type MaterializedWorkflowStep,
   materializeJobExecutionSteps,
 } from './materialize-job-execution-steps.js';
+import {staticJobName} from './static-job-name.js';
 import type {WorkflowEvaluationContext} from './workflow-evaluation-context.js';
 
 type WorkflowModelJob = WorkflowModel['jobs'][number];
@@ -21,7 +22,7 @@ export interface MaterializedWorkflowJob {
   readonly executionTimeoutMs?: number;
   readonly checkout: WorkflowModelJob['checkout'];
   readonly listening?: WorkflowModelJob['listening'];
-  readonly name?: WorkflowModelJob['name'];
+  readonly name?: string;
   readonly outputs?: WorkflowModelJob['outputs'];
   readonly dependencies: readonly string[];
   readonly runner: readonly string[];
@@ -52,31 +53,36 @@ export async function materializeWorkflowModel(
   const jobsById = new Map(model.jobs.map((job) => [job.id, job]));
 
   return await Promise.all(
-    model.jobs.map(async (job, position) => ({
-      key: job.key,
-      mode: job.mode,
-      ...(job.success === undefined ? {} : {success: job.success}),
-      ...(job.executionTimeoutMs === undefined ? {} : {executionTimeoutMs: job.executionTimeoutMs}),
-      checkout: job.checkout,
-      ...(job.listening === undefined ? {} : {listening: job.listening}),
-      ...(job.name === undefined ? {} : {name: job.name}),
-      ...(job.outputs === undefined ? {} : {outputs: job.outputs}),
-      dependencies: dependencySourceNames(job, jobsById),
-      runner: job.runner,
-      position,
-      steps:
-        job.mode === 'listening'
-          ? []
-          : await materializeJobExecutionSteps({
-              model,
-              job,
-              context,
-              resolveAgentDefaults,
-              definitionId,
-              agentToolContext,
-              agentToolSnapshot,
-            }),
-    })),
+    model.jobs.map(async (job, position) => {
+      const name = staticJobName(job);
+      return {
+        key: job.key,
+        mode: job.mode,
+        ...(job.success === undefined ? {} : {success: job.success}),
+        ...(job.executionTimeoutMs === undefined
+          ? {}
+          : {executionTimeoutMs: job.executionTimeoutMs}),
+        checkout: job.checkout,
+        ...(job.listening === undefined ? {} : {listening: job.listening}),
+        ...(name === undefined ? {} : {name}),
+        ...(job.outputs === undefined ? {} : {outputs: job.outputs}),
+        dependencies: dependencySourceNames(job, jobsById),
+        runner: job.runner,
+        position,
+        steps:
+          job.mode === 'listening'
+            ? []
+            : await materializeJobExecutionSteps({
+                model,
+                job,
+                context,
+                resolveAgentDefaults,
+                definitionId,
+                agentToolContext,
+                agentToolSnapshot,
+              }),
+      };
+    }),
   );
 }
 

--- a/libs/api/workflows/src/core/step-config/resolve-job-execution-name.test.ts
+++ b/libs/api/workflows/src/core/step-config/resolve-job-execution-name.test.ts
@@ -6,11 +6,11 @@ function template(source: string): string {
 }
 
 describe('resolveJobExecutionName', () => {
-  it('resolves an interpolated job name at execution creation', () => {
+  it('resolves an interpolated execution name at execution creation', () => {
     const [job] = workflowModel({
       jobs: {
         deploy: {
-          name: `Deploy ${template('inputs.environment')}`,
+          executionName: `Deploy ${template('inputs.environment')}`,
           steps: [{run: 'echo deploy'}],
         },
       },
@@ -20,18 +20,17 @@ describe('resolveJobExecutionName', () => {
     const result = resolveJobExecutionName({
       definitionId: 'definition-1',
       job,
-      fallbackName: 'deploy #1',
       context: {inputs: {environment: 'prod'}},
     });
 
     expect(result).toMatchObject({
-      value: 'Deploy prod',
+      nameOverride: 'Deploy prod',
       trace: [
         {
-          field: 'job.name',
+          field: 'job.execution_name',
           expression: 'inputs.environment',
           roots: ['inputs'],
-          fillTarget: 'run-creation',
+          fillTarget: 'execution-creation',
           evaluatedAt: 'execution-creation',
           value: 'prod',
         },
@@ -43,7 +42,7 @@ describe('resolveJobExecutionName', () => {
     const [job] = workflowModel({
       jobs: {
         deploy: {
-          name: template('inputs.environment'),
+          executionName: template('inputs.environment'),
           steps: [{run: 'echo deploy'}],
         },
       },
@@ -53,18 +52,17 @@ describe('resolveJobExecutionName', () => {
     const result = resolveJobExecutionName({
       definitionId: 'definition-1',
       job,
-      fallbackName: 'deploy #1',
       context: {inputs: {environment: ''}},
     });
 
     expect(result).toMatchObject({
-      value: 'deploy #1',
+      nameOverride: null,
       trace: [
         {
-          field: 'job.name',
+          field: 'job.execution_name',
           expression: 'inputs.environment',
           roots: ['inputs'],
-          fillTarget: 'run-creation',
+          fillTarget: 'execution-creation',
           evaluatedAt: 'execution-creation',
           value: '',
         },
@@ -72,10 +70,26 @@ describe('resolveJobExecutionName', () => {
     });
   });
 
-  it('falls back when the job has no name template', () => {
+  it('falls back to the static job name when no execution name template exists', () => {
+    const [job] = workflowModel({
+      jobs: {deploy: {steps: [{run: 'echo deploy'}]}},
+    }).jobs;
+    if (!job) throw new Error('Missing deploy job');
+
+    const result = resolveJobExecutionName({
+      definitionId: 'definition-1',
+      job,
+      context: {},
+    });
+
+    expect(result).toEqual({nameOverride: null, trace: []});
+  });
+
+  it('falls back when execution-name evaluation fails', () => {
     const [job] = workflowModel({
       jobs: {
         deploy: {
+          executionName: template('inputs.environment.missing'),
           steps: [{run: 'echo deploy'}],
         },
       },
@@ -85,10 +99,18 @@ describe('resolveJobExecutionName', () => {
     const result = resolveJobExecutionName({
       definitionId: 'definition-1',
       job,
-      fallbackName: 'deploy #1',
-      context: {},
+      context: {inputs: null},
     });
 
-    expect(result).toEqual({value: 'deploy #1', trace: []});
+    expect(result).toMatchObject({
+      nameOverride: null,
+      trace: [
+        expect.objectContaining({
+          field: 'job.execution_name',
+          expression: 'inputs.environment.missing',
+          degraded: true,
+        }),
+      ],
+    });
   });
 });

--- a/libs/api/workflows/src/core/step-config/resolve-job-execution-name.ts
+++ b/libs/api/workflows/src/core/step-config/resolve-job-execution-name.ts
@@ -1,50 +1,65 @@
 import type {WorkflowModel} from '@shipfox/api-definitions-dto';
 import {
   capTraceEntries,
+  evaluationTraceEntry,
   getWorkflowInterpolationFieldFailurePolicy,
   resolveFieldAtSite,
   type WorkflowExpressionEvaluationContext,
   WorkflowTemplateResolutionError,
 } from '@shipfox/expression';
 import type {PersistedEvaluationTraceEntry} from '#core/entities/step.js';
-import {InterpolationUnresolvableError} from '#core/errors.js';
 
 interface WorkflowModelJobName {
-  readonly name?: WorkflowModel['jobs'][number]['name'] | undefined;
+  readonly executionName?: WorkflowModel['jobs'][number]['executionName'] | undefined;
 }
 
 export interface ResolveJobExecutionNameParams {
   readonly definitionId: string;
   readonly job: WorkflowModelJobName;
-  readonly fallbackName: string;
   readonly context: WorkflowExpressionEvaluationContext;
 }
 
 export function resolveJobExecutionName(params: ResolveJobExecutionNameParams): {
-  readonly value: string;
+  /** The resolved override to persist. The static fallback is deliberately not persisted. */
+  readonly nameOverride: string | null;
   readonly trace: readonly PersistedEvaluationTraceEntry[];
 } {
-  if (params.job.name === undefined) return {value: params.fallbackName, trace: []};
+  if (params.job.executionName === undefined) return {nameOverride: null, trace: []};
 
   try {
     const resolved = resolveFieldAtSite({
-      field: {segments: params.job.name},
+      field: {segments: params.job.executionName},
       site: 'execution-creation',
       context: params.context,
-      failurePolicy: getWorkflowInterpolationFieldFailurePolicy('job.name'),
+      failurePolicy: getWorkflowInterpolationFieldFailurePolicy('job.execution_name'),
     });
     return {
-      value:
-        resolved.kind === 'frozen' && resolved.value !== '' ? resolved.value : params.fallbackName,
-      trace: capTraceEntries(resolved.trace.map((entry) => ({...entry, field: 'job.name'}))),
+      nameOverride: resolved.kind === 'frozen' && resolved.value !== '' ? resolved.value : null,
+      trace: capTraceEntries(
+        resolved.trace.map((entry) => ({...entry, field: 'job.execution_name'})),
+      ),
     };
   } catch (error) {
     if (error instanceof WorkflowTemplateResolutionError) {
-      throw new InterpolationUnresolvableError(params.definitionId, {
-        field: 'job.name',
-        source: error.source,
-        cause: error,
-      });
+      const failedSegment = params.job.executionName.find(
+        (segment) => segment.kind === 'deferred' && segment.expression.source === error.source,
+      );
+      const trace =
+        failedSegment?.kind === 'deferred'
+          ? [
+              {
+                ...evaluationTraceEntry({
+                  expression: failedSegment.expression.source,
+                  roots: failedSegment.roots,
+                  fillTarget: failedSegment.fillTarget,
+                  evaluatedAt: 'execution-creation',
+                  degraded: true,
+                }),
+                field: 'job.execution_name',
+              },
+            ]
+          : [];
+      return {nameOverride: null, trace: capTraceEntries(trace)};
     }
     throw error;
   }

--- a/libs/api/workflows/src/core/step-config/static-job-name.ts
+++ b/libs/api/workflows/src/core/step-config/static-job-name.ts
@@ -1,0 +1,11 @@
+import type {WorkflowModel} from '@shipfox/api-definitions-dto';
+
+type WorkflowModelJob = WorkflowModel['jobs'][number];
+
+export function staticJobName(job: WorkflowModelJob): string | undefined {
+  const literalValues = job.name?.flatMap((segment) =>
+    segment.kind === 'literal' ? [segment.value] : [],
+  );
+  if (literalValues === undefined || literalValues.length !== job.name?.length) return undefined;
+  return literalValues.join('');
+}

--- a/libs/api/workflows/src/core/workflow-run-creation.test.ts
+++ b/libs/api/workflows/src/core/workflow-run-creation.test.ts
@@ -19,7 +19,7 @@ describe('deriveInitialJobExecutionPlan', () => {
     const model = buildModel({
       jobs: {
         deploy: {
-          name: `Deploy ${template('inputs.environment')}`,
+          executionName: `Deploy ${template('inputs.environment')}`,
           runner: ['linux'],
           runnerTemplates: [template('inputs.runner')],
           steps: [{run: 'echo deploy'}],
@@ -47,10 +47,10 @@ describe('deriveInitialJobExecutionPlan', () => {
         {
           expression: 'inputs.environment',
           roots: ['inputs'],
-          fillTarget: 'run-creation',
+          fillTarget: 'execution-creation',
           evaluatedAt: 'execution-creation',
           value: 'prod',
-          field: 'job.name',
+          field: 'job.execution_name',
         },
       ],
     });
@@ -86,7 +86,7 @@ describe('deriveInitialJobExecutionPlan', () => {
     const model = buildModel({
       jobs: {
         deploy: {
-          name: `Current ${template('execution.name')}`,
+          executionName: `Current ${template('execution.name')}`,
           steps: [{run: 'echo deploy'}],
         },
       },

--- a/libs/api/workflows/src/core/workflow-run-creation.ts
+++ b/libs/api/workflows/src/core/workflow-run-creation.ts
@@ -55,6 +55,7 @@ export function deriveInitialJobExecutionPlan(params: {
   inputs?: Record<string, unknown> | null | undefined;
   vars?: Record<string, string> | undefined;
 }): {
+  nameOverride: string | null;
   name: string;
   runner: readonly string[];
   evaluationTrace: JobExecution['evaluationTrace'];
@@ -64,8 +65,9 @@ export function deriveInitialJobExecutionPlan(params: {
     triggerPayload: params.triggerPayload,
     inputs: params.inputs ?? null,
     vars: params.vars,
-    jobId: params.jobId,
+    job: {id: params.jobId, key: params.job.key, name: params.job.name ?? null},
     sequence: params.sequence,
+    nameOverride: null,
     executionName: params.fallbackName,
     status: 'pending',
     triggerEvents: [],
@@ -73,8 +75,7 @@ export function deriveInitialJobExecutionPlan(params: {
   });
   const resolvedName = resolveJobExecutionName({
     definitionId: params.run.definitionId,
-    job: params.job,
-    fallbackName: params.fallbackName,
+    job: params.modelJob,
     context: nameContext.values,
   });
   const runnerContext = assembleExecutionCreationContext({
@@ -82,15 +83,17 @@ export function deriveInitialJobExecutionPlan(params: {
     triggerPayload: params.triggerPayload,
     inputs: params.inputs ?? null,
     vars: params.vars,
-    jobId: params.jobId,
+    job: {id: params.jobId, key: params.job.key, name: params.job.name ?? null},
     sequence: params.sequence,
-    executionName: resolvedName.value,
+    nameOverride: resolvedName.nameOverride,
+    executionName: resolvedName.nameOverride ?? params.fallbackName,
     status: 'pending',
     triggerEvents: [],
     priorExecutions: [],
   });
   return {
-    name: resolvedName.value,
+    nameOverride: resolvedName.nameOverride,
+    name: resolvedName.nameOverride ?? params.fallbackName,
     runner: materializeJobRunner({
       job: params.modelJob,
       context: runnerContext,
@@ -105,7 +108,9 @@ export function deriveJobExecutionRunner(params: {
   modelJob: WorkflowModel['jobs'][number];
   jobId: string;
   sequence: number;
+  nameOverride: string | null;
   executionName: string;
+  jobName?: string | null | undefined;
   status: JobExecution['status'];
   triggerEvents?: readonly JobExecution['triggerEvents'][number][] | undefined;
   priorExecutions?: readonly JobExecution[] | undefined;
@@ -116,8 +121,9 @@ export function deriveJobExecutionRunner(params: {
       run: params.run,
       triggerPayload: params.run.triggerPayload,
       inputs: params.run.inputs,
-      jobId: params.jobId,
+      job: {id: params.jobId, key: params.modelJob.key, name: params.jobName ?? null},
       sequence: params.sequence,
+      nameOverride: params.nameOverride,
       executionName: params.executionName,
       status: params.status,
       triggerEvents: params.triggerEvents ?? [],

--- a/libs/api/workflows/src/db/job-listeners.test.ts
+++ b/libs/api/workflows/src/db/job-listeners.test.ts
@@ -929,9 +929,9 @@ describe('drainListenerEventsIntoExecution', () => {
       jobId: job.id,
       expectedSequence: 1,
       secrets: {
-        getVariablesByNamespace: async () => {
+        getVariablesByNamespace: () => {
           variableLoads += 1;
-          return {values: {REGION: 'eu-west'}};
+          return Promise.resolve({values: {REGION: 'eu-west'}});
         },
       },
     });

--- a/libs/api/workflows/src/db/job-listeners.test.ts
+++ b/libs/api/workflows/src/db/job-listeners.test.ts
@@ -929,7 +929,7 @@ describe('drainListenerEventsIntoExecution', () => {
       jobId: job.id,
       expectedSequence: 1,
       secrets: {
-        getVariablesByNamespace: () => {
+        getVariablesByNamespace: async () => {
           variableLoads += 1;
           return {values: {REGION: 'eu-west'}};
         },

--- a/libs/api/workflows/src/db/job-listeners.test.ts
+++ b/libs/api/workflows/src/db/job-listeners.test.ts
@@ -326,7 +326,7 @@ describe('activateJobListener', () => {
       run: expect.objectContaining({id: expect.any(String), name: 'Test Workflow'}),
       trigger: {source: 'github', event: 'pull_request'},
       inputs: {environment: 'prod'},
-      job: {key: 'await'},
+      job: {key: 'await', name: 'await'},
       jobs: {
         build: expect.objectContaining({
           status: 'succeeded',
@@ -491,6 +491,97 @@ describe('drainListenerEventsIntoExecution', () => {
     expect(result).toMatchObject({kind: 'execution', sequence: 1, status: 'pending'});
     expect(executions).toHaveLength(1);
     expect(events.every((event) => event.consumedByExecutionId === executions[0]?.id)).toBe(true);
+  });
+
+  it('persists a failed execution when listener variables are missing', async () => {
+    const job = await createListeningJobFromModel({
+      jobs: {
+        review: {
+          executionName: `Review ${template('vars.REGION')}`,
+          steps: [{run: `echo ${template('vars.MISSING')}`}],
+        },
+      },
+    });
+    await bufferEvent(job.id);
+
+    const result = await drainListenerEventsIntoExecution({
+      jobId: job.id,
+      expectedSequence: 1,
+      secrets: {
+        getVariablesByNamespace: async () => ({values: {}}),
+      },
+    });
+
+    const [execution] = await db()
+      .select()
+      .from(jobExecutions)
+      .where(eq(jobExecutions.jobId, job.id));
+    expect(result).toMatchObject({kind: 'execution', sequence: 1, status: 'failed'});
+    expect(execution).toMatchObject({
+      status: 'failed',
+      name: null,
+      evaluationTrace: [
+        expect.objectContaining({
+          expression: 'vars.MISSING',
+          roots: ['vars'],
+          fillTarget: 'execution-creation',
+          evaluatedAt: 'execution-creation',
+          field: 'run',
+          degraded: true,
+        }),
+      ],
+    });
+  });
+
+  it('resolves a distinct name for each listener firing with boundary variables', async () => {
+    const job = await createListeningJobFromModel({
+      jobs: {
+        review: {
+          name: 'Process review',
+          executionName: `Review ${template('vars.REGION')} ${template('execution.index')}`,
+          steps: [{run: 'echo review'}],
+        },
+      },
+    });
+    await db().update(jobs).set({name: 'Process review'}).where(eq(jobs.id, job.id));
+    const secrets = {
+      getVariablesByNamespace: async () => ({values: {REGION: 'eu-west'}}),
+    };
+    await bufferEvent(job.id);
+    await drainListenerEventsIntoExecution({
+      jobId: job.id,
+      expectedSequence: 1,
+      secrets,
+    });
+    await bufferEvent(job.id);
+    await drainListenerEventsIntoExecution({
+      jobId: job.id,
+      expectedSequence: 2,
+      secrets,
+    });
+
+    const executions = await db()
+      .select()
+      .from(jobExecutions)
+      .where(eq(jobExecutions.jobId, job.id))
+      .orderBy(asc(jobExecutions.sequence));
+    const stored = await readJob(job.id);
+
+    expect(stored?.name).toBe('Process review');
+    expect(executions.map((execution) => execution.name)).toEqual([
+      'Review eu-west 0',
+      'Review eu-west 1',
+    ]);
+    expect(executions.map((execution) => execution.evaluationTrace)).toEqual([
+      expect.arrayContaining([
+        expect.objectContaining({field: 'job.execution_name', expression: 'vars.REGION'}),
+        expect.objectContaining({field: 'job.execution_name', expression: 'execution.index'}),
+      ]),
+      expect.arrayContaining([
+        expect.objectContaining({field: 'job.execution_name', expression: 'vars.REGION'}),
+        expect.objectContaining({field: 'job.execution_name', expression: 'execution.index'}),
+      ]),
+    ]);
   });
 
   it('uses the frozen agent tool materialization snapshot for listener executions', async () => {
@@ -823,12 +914,30 @@ describe('drainListenerEventsIntoExecution', () => {
     expect(stored?.outputs).toEqual({message: 'hello'});
   });
 
-  it('reports empty when nothing is buffered', async () => {
-    const job = await createListeningJob({status: 'running', listenerStatus: 'listening'});
+  it('reports empty without loading external state when nothing is buffered', async () => {
+    const job = await createListeningJobFromModel({
+      jobs: {
+        review: {
+          executionName: template('vars.REGION'),
+          steps: [{run: 'echo review'}],
+        },
+      },
+    });
+    let variableLoads = 0;
 
-    const result = await drainListenerEventsIntoExecution({jobId: job.id, expectedSequence: 1});
+    const result = await drainListenerEventsIntoExecution({
+      jobId: job.id,
+      expectedSequence: 1,
+      secrets: {
+        getVariablesByNamespace: () => {
+          variableLoads += 1;
+          return {values: {REGION: 'eu-west'}};
+        },
+      },
+    });
 
     expect(result).toEqual({kind: 'empty'});
+    expect(variableLoads).toBe(0);
   });
 
   it('returns the existing execution when the sequence was already materialized', async () => {

--- a/libs/api/workflows/src/db/job-listeners.ts
+++ b/libs/api/workflows/src/db/job-listeners.ts
@@ -2,6 +2,7 @@ import type {AgentInterModuleClient} from '@shipfox/api-agent-dto/inter-module';
 import {readPersistedWorkflowModel} from '@shipfox/api-definitions-dto';
 import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
 import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
+import type {SecretsInterModuleClient} from '@shipfox/api-secrets-dto/inter-module';
 import {
   WORKFLOWS_JOB_ACTIVATED,
   type WorkflowsJobActivatedEventDto,
@@ -10,7 +11,12 @@ import {and, asc, count, eq, inArray, isNull, notInArray, sql} from 'drizzle-orm
 import {type AgentDefaultsResolver, createAgentDefaultsResolver} from '#core/agent-defaults.js';
 import {loadAgentToolMaterializationContext} from '#core/agent-tools.js';
 import {isJobTerminal, type JobStatus, type ResolutionReason} from '#core/entities/job.js';
-import type {JobExecutionStatus, WorkflowExecutionEvent} from '#core/entities/job-execution.js';
+import type {
+  JobExecution,
+  JobExecutionStatus,
+  WorkflowExecutionEvent,
+} from '#core/entities/job-execution.js';
+import {InterpolationUnresolvableError} from '#core/errors.js';
 import {type DeriveJobSuccessResult, deriveJobSuccess} from '#core/job-transition/index.js';
 import {
   type MaterializedListenerExecution,
@@ -38,6 +44,7 @@ import {toWorkflowRun, workflowRuns} from './schema/workflow-runs.js';
 import {
   bulkUpdateStepStatuses,
   getDirectDependencyJobContexts,
+  loadReferencedVariables,
   updateJobStatusAtVersion,
 } from './workflow-runs.js';
 
@@ -182,11 +189,61 @@ export interface DrainListenerEventsParams {
   projects?: ProjectsModuleClient | undefined;
   resolveAgentDefaults?: AgentDefaultsResolver | undefined;
   agent?: AgentInterModuleClient | undefined;
+  secrets?: Pick<SecretsInterModuleClient, 'getVariablesByNamespace'> | undefined;
 }
 
 export async function drainListenerEventsIntoExecution(
   params: DrainListenerEventsParams,
 ): Promise<DrainListenerEventsResult> {
+  const probeResult = await db().transaction(async (tx) => {
+    const existing = await findExistingExecution(params, tx);
+    if (existing) return existing;
+
+    const resolveRequested = await hasPendingResolveEvent(params.jobId, tx);
+    if (resolveRequested) return {kind: 'resolve-requested' as const};
+
+    const hasBufferedFire = await hasBufferedFireEvent(params.jobId, tx);
+    return hasBufferedFire ? null : {kind: 'empty' as const};
+  });
+  if (probeResult !== null) return probeResult;
+
+  // Resolve external state before opening the persistence transaction. The
+  // secrets module uses the shared pool and cannot reuse this transaction's
+  // connection across the inter-module boundary.
+  const materializationTarget = await loadListenerMaterializationTarget(params.jobId);
+  const model =
+    materializationTarget.attempt.model === null
+      ? null
+      : readPersistedWorkflowModel(materializationTarget.attempt.model);
+  const modelJob = model?.jobs.find((job) => job.key === materializationTarget.job.key);
+  let vars: Record<string, string> | undefined;
+  let variableResolutionError: InterpolationUnresolvableError | undefined;
+  if (model !== null && modelJob !== undefined) {
+    try {
+      vars = await loadReferencedVariables({
+        model,
+        jobs: [modelJob],
+        workspaceId: materializationTarget.run.workspaceId,
+        projectId: materializationTarget.run.projectId,
+        definitionId: materializationTarget.run.definitionId,
+        secrets: params.secrets,
+      });
+    } catch (error) {
+      if (!(error instanceof InterpolationUnresolvableError)) throw error;
+      variableResolutionError = error;
+    }
+  }
+  const agentToolContext =
+    materializationTarget.attempt.agentToolMaterialization === null
+      ? await loadAgentToolMaterializationContext({
+          model,
+          workspaceId: materializationTarget.run.workspaceId,
+          projectId: materializationTarget.run.projectId,
+          integrations: params.integrations,
+          projects: params.projects,
+        })
+      : undefined;
+
   const drained = await db().transaction(async (tx) => {
     const existing = await findExistingExecution(params, tx);
     if (existing) return {result: existing};
@@ -198,25 +255,20 @@ export async function drainListenerEventsIntoExecution(
     if (bufferedEvents.length === 0) return {result: {kind: 'empty' as const}};
 
     const target = await loadListenerMaterializationTarget(params.jobId, tx);
-    const model =
-      target.attempt.model === null ? null : readPersistedWorkflowModel(target.attempt.model);
-    const agentToolContext =
-      target.attempt.agentToolMaterialization === null
-        ? await loadAgentToolMaterializationContext({
-            model,
-            workspaceId: target.run.workspaceId,
-            projectId: target.run.projectId,
-            integrations: params.integrations,
-            projects: params.projects,
-          })
-        : undefined;
+    const priorExecutions = await loadListenerPriorExecutions(
+      params.jobId,
+      target.job.name ?? target.job.key,
+      tx,
+    );
     const materialized = await materializeListenerExecution({
       model,
       run: toWorkflowRun(target.run),
       job: toJob(target.job),
+      vars,
+      variableResolutionError,
       sequence: params.expectedSequence,
       triggerEvents: listenerTriggerEvents(bufferedEvents),
-      priorExecutions: target.priorExecutions,
+      priorExecutions,
       resolveAgentDefaults:
         params.resolveAgentDefaults ??
         (params.agent
@@ -330,7 +382,9 @@ async function deriveJobListenerResolutionDecision(
     expectedVersion: jobRow.version,
     ...deriveJobSuccess({
       success: jobRow.success,
-      executions: executionRows.map(toJobExecution),
+      executions: executionRows.map((execution) =>
+        toJobExecution(execution, jobRow.name ?? jobRow.key),
+      ),
       jobs: dependencyJobs,
     }),
   };
@@ -462,6 +516,21 @@ async function hasPendingResolveEvent(jobId: string, tx: Tx): Promise<boolean> {
   return resolveEvent !== undefined;
 }
 
+async function hasBufferedFireEvent(jobId: string, tx: Tx): Promise<boolean> {
+  const [fireEvent] = await tx
+    .select({id: jobListenerEvents.id})
+    .from(jobListenerEvents)
+    .where(
+      and(
+        eq(jobListenerEvents.jobId, jobId),
+        eq(jobListenerEvents.disposition, 'fire'),
+        isNull(jobListenerEvents.consumedByExecutionId),
+      ),
+    )
+    .limit(1);
+  return fireEvent !== undefined;
+}
+
 async function lockBufferedFireEvents(
   params: DrainListenerEventsParams,
   tx: Tx,
@@ -509,7 +578,7 @@ async function persistMaterializedListenerExecution(
     .values({
       jobId: params.jobId,
       sequence: params.sequence,
-      name: params.materialized.name,
+      name: params.materialized.nameOverride,
       runner: params.materialized.runner.length === 0 ? null : [...params.materialized.runner],
       status: params.materialized.status,
       statusReason: params.materialized.statusReason,
@@ -559,21 +628,29 @@ function drainExecutionResult(
   };
 }
 
-async function loadListenerMaterializationTarget(jobId: string, tx: Tx) {
-  const [target] = await tx
+async function loadListenerMaterializationTarget(jobId: string, tx?: Tx) {
+  const query = (tx ?? db())
     .select({job: jobs, attempt: workflowRunAttempts, run: workflowRuns})
     .from(jobs)
     .innerJoin(workflowRunAttempts, eq(jobs.workflowRunAttemptId, workflowRunAttempts.id))
     .innerJoin(workflowRuns, eq(workflowRunAttempts.workflowRunId, workflowRuns.id))
     .where(eq(jobs.id, jobId))
-    .limit(1)
-    .for('update');
+    .limit(1);
+  const [target] = tx === undefined ? await query : await query.for('update');
   if (!target) throw new Error(`Job not found: ${jobId}`);
 
+  return target;
+}
+
+async function loadListenerPriorExecutions(
+  jobId: string,
+  fallbackName: string,
+  tx: Tx,
+): Promise<JobExecution[]> {
   const priorExecutions = await tx
     .select()
     .from(jobExecutions)
     .where(eq(jobExecutions.jobId, jobId))
     .orderBy(asc(jobExecutions.sequence), asc(jobExecutions.id));
-  return {...target, priorExecutions: priorExecutions.map(toJobExecution)};
+  return priorExecutions.map((execution) => toJobExecution(execution, fallbackName));
 }

--- a/libs/api/workflows/src/db/schema/job-executions.ts
+++ b/libs/api/workflows/src/db/schema/job-executions.ts
@@ -32,7 +32,9 @@ export const jobExecutions = pgTable(
       .notNull()
       .references(() => jobs.id, {onDelete: 'cascade'}),
     sequence: integer('sequence').notNull(),
-    name: text('name').notNull(),
+    // A null value means no dynamic override was resolved. The core entity
+    // exposes the parent job's static name/key as the effective name.
+    name: text('name'),
     runner: jsonb('runner').$type<string[]>(),
     status: jobExecutionStatusEnum('status').notNull().default('pending'),
     statusReason: jobStatusReasonEnum('status_reason'),
@@ -62,12 +64,13 @@ export const jobExecutions = pgTable(
 export type JobExecutionDb = typeof jobExecutions.$inferSelect;
 export type JobExecutionCreateDb = typeof jobExecutions.$inferInsert;
 
-export function toJobExecution(row: JobExecutionDb): JobExecution {
+export function toJobExecution(row: JobExecutionDb, fallbackName: string): JobExecution {
   return {
     id: row.id,
     jobId: row.jobId,
     sequence: row.sequence,
-    name: row.name,
+    nameOverride: row.name,
+    name: row.name ?? fallbackName,
     runner: row.runner as string[] | null,
     status: row.status,
     statusReason: toJobStatusReason(row.statusReason),

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -74,6 +74,7 @@ export {
   createRerunWorkflowRun,
   createWorkflowRun,
   failWorkflowRunAsTimedOut,
+  loadReferencedVariables,
   updateWorkflowRunStatus,
 } from './workflow-runs/runs.js';
 export type {

--- a/libs/api/workflows/src/db/workflow-runs/job-executions.ts
+++ b/libs/api/workflows/src/db/workflow-runs/job-executions.ts
@@ -32,35 +32,48 @@ import {
 } from './shared.js';
 import {bulkUpdateStepStatuses, getStepsByJobExecutionIdForUpdate} from './steps.js';
 
+async function getJobExecutionFallbackName(tx: Tx, jobExecutionId: string): Promise<string> {
+  const [row] = await tx
+    .select({job: jobs})
+    .from(jobExecutions)
+    .innerJoin(jobs, eq(jobExecutions.jobId, jobs.id))
+    .where(eq(jobExecutions.id, jobExecutionId))
+    .limit(1);
+  if (!row) throw new JobNotFoundError(jobExecutionId);
+  return row.job.name ?? row.job.key;
+}
+
 export async function getJobExecutionById(id: string, tx?: Tx): Promise<JobExecution | undefined> {
   const rows = await (tx ?? db())
-    .select()
+    .select({jobExecution: jobExecutions, job: jobs})
     .from(jobExecutions)
+    .innerJoin(jobs, eq(jobExecutions.jobId, jobs.id))
     .where(eq(jobExecutions.id, id))
     .limit(1);
   const row = rows[0];
-  return row ? toJobExecution(row) : undefined;
+  return row ? toJobExecution(row.jobExecution, row.job.name ?? row.job.key) : undefined;
 }
 
 export async function getJobExecutionsByWorkflowRunAttemptId(
   workflowRunAttemptId: string,
 ): Promise<JobExecution[]> {
   const rows = await db()
-    .select({jobExecution: jobExecutions})
+    .select({jobExecution: jobExecutions, job: jobs})
     .from(jobExecutions)
     .innerJoin(jobs, eq(jobExecutions.jobId, jobs.id))
     .where(eq(jobs.workflowRunAttemptId, workflowRunAttemptId))
     .orderBy(asc(jobExecutions.sequence), asc(jobExecutions.id));
-  return rows.map((row) => toJobExecution(row.jobExecution));
+  return rows.map((row) => toJobExecution(row.jobExecution, row.job.name ?? row.job.key));
 }
 
 export async function getJobExecutionsByJobId(jobId: string): Promise<JobExecution[]> {
   const rows = await db()
-    .select()
+    .select({jobExecution: jobExecutions, job: jobs})
     .from(jobExecutions)
+    .innerJoin(jobs, eq(jobExecutions.jobId, jobs.id))
     .where(eq(jobExecutions.jobId, jobId))
     .orderBy(asc(jobExecutions.sequence), asc(jobExecutions.id));
-  return rows.map(toJobExecution);
+  return rows.map((row) => toJobExecution(row.jobExecution, row.job.name ?? row.job.key));
 }
 
 export async function getFirstJobExecutionByJobId(
@@ -68,13 +81,14 @@ export async function getFirstJobExecutionByJobId(
   tx?: Tx,
 ): Promise<JobExecution | undefined> {
   const rows = await (tx ?? db())
-    .select()
+    .select({jobExecution: jobExecutions, job: jobs})
     .from(jobExecutions)
+    .innerJoin(jobs, eq(jobExecutions.jobId, jobs.id))
     .where(eq(jobExecutions.jobId, jobId))
     .orderBy(asc(jobExecutions.sequence), asc(jobExecutions.id))
     .limit(1);
   const row = rows[0];
-  return row ? toJobExecution(row) : undefined;
+  return row ? toJobExecution(row.jobExecution, row.job.name ?? row.job.key) : undefined;
 }
 
 export async function getLatestJobExecutionByJobId(
@@ -82,13 +96,14 @@ export async function getLatestJobExecutionByJobId(
   tx?: Tx,
 ): Promise<JobExecution | undefined> {
   const rows = await (tx ?? db())
-    .select()
+    .select({jobExecution: jobExecutions, job: jobs})
     .from(jobExecutions)
+    .innerJoin(jobs, eq(jobExecutions.jobId, jobs.id))
     .where(eq(jobExecutions.jobId, jobId))
     .orderBy(desc(jobExecutions.sequence), desc(jobExecutions.id))
     .limit(1);
   const row = rows[0];
-  return row ? toJobExecution(row) : undefined;
+  return row ? toJobExecution(row.jobExecution, row.job.name ?? row.job.key) : undefined;
 }
 
 export interface UpdateJobExecutionStatusAtVersionParams {
@@ -129,10 +144,14 @@ async function resolveJobExecutionOutputs(
     .from(jobExecutions)
     .where(eq(jobExecutions.jobId, target.job.id))
     .orderBy(asc(jobExecutions.sequence), asc(jobExecutions.id));
+  const fallbackName = target.job.name ?? target.job.key;
   const executions = executionRows.map((row) =>
     row.id === target.execution.id
-      ? toJobExecution({...row, status: params.status, statusReason: params.statusReason})
-      : toJobExecution(row),
+      ? toJobExecution(
+          {...row, status: params.status, statusReason: params.statusReason},
+          fallbackName,
+        )
+      : toJobExecution(row, fallbackName),
   );
   const jobExecution = executions.find((execution) => execution.id === target.execution.id);
   if (!jobExecution) throw new JobNotFoundError(params.jobExecutionId);
@@ -217,7 +236,10 @@ async function updateJobExecutionStatusAtVersion(
 
   const row = rows[0];
   if (!row) return null;
-  return {execution: toJobExecution(row), changed: true};
+  return {
+    execution: toJobExecution(row, await getJobExecutionFallbackName(tx, row.id)),
+    changed: true,
+  };
 }
 
 export interface UpdateJobExecutionStatusParams {
@@ -250,7 +272,7 @@ export async function updateJobExecutionStatus(
             .where(eq(jobExecutions.id, params.jobExecutionId))
             .limit(1)
         )[0];
-        return row ? toJobExecution(row) : undefined;
+        return row ? toJobExecution(row, await getJobExecutionFallbackName(tx, row.id)) : undefined;
       },
       matchFn: (execution) =>
         (execution.status === params.status && execution.statusReason === statusReason) ||
@@ -317,7 +339,7 @@ export async function failJobExecutionAsTimedOut(params: {
             .where(eq(jobExecutions.id, params.jobExecutionId))
             .limit(1)
         )[0];
-        return row ? toJobExecution(row) : undefined;
+        return row ? toJobExecution(row, await getJobExecutionFallbackName(tx, row.id)) : undefined;
       },
       matchFn: (execution) => (execution.timedOutAt !== null ? {execution, changed: false} : null),
       failureMessage: `Optimistic lock failure: job execution ${params.jobExecutionId} version ${params.expectedVersion}`,

--- a/libs/api/workflows/src/db/workflow-runs/jobs.ts
+++ b/libs/api/workflows/src/db/workflow-runs/jobs.ts
@@ -98,7 +98,8 @@ export async function getDirectDependencyJobContexts(
       context = {job: toJob(row.job), executions: []};
       contextsByJobId.set(row.job.id, context);
     }
-    if (row.execution) context.executions.push(toJobExecution(row.execution));
+    if (row.execution)
+      context.executions.push(toJobExecution(row.execution, row.job.name ?? row.job.key));
   }
 
   return [...contextsByJobId.values()];
@@ -249,7 +250,8 @@ async function directDependencyContextsByJobKey(
       context = {job: toJob(row.job), executions: []};
       contextsByJobKey.set(row.job.key, context);
     }
-    if (row.execution) context.executions.push(toJobExecution(row.execution));
+    if (row.execution)
+      context.executions.push(toJobExecution(row.execution, row.job.name ?? row.job.key));
   }
 
   return contextsByJobKey;
@@ -390,7 +392,9 @@ export async function resolveJobStatusFromJobExecutions(params: {
 
     const {status, statusReason, trace} = evaluateJobSuccess({
       success: jobRow.success,
-      executions: jobExecutionRows.map(toJobExecution),
+      executions: jobExecutionRows.map((execution) =>
+        toJobExecution(execution, jobRow.name ?? jobRow.key),
+      ),
       jobs: await getDirectDependencyJobContexts(params.jobId, tx),
     });
 

--- a/libs/api/workflows/src/db/workflow-runs/queries.ts
+++ b/libs/api/workflows/src/db/workflow-runs/queries.ts
@@ -336,6 +336,7 @@ export async function getJobExecutionDetail(
 ): Promise<JobExecutionDetail | undefined> {
   const rows = await db()
     .select({
+      job: jobs,
       jobExecution: jobExecutions,
       step: steps,
       stepAttempt: stepAttempts,
@@ -357,7 +358,10 @@ export async function getJobExecutionDetail(
   const first = rows[0];
   if (!first) return undefined;
 
-  const detail: JobExecutionDetail = {...toJobExecution(first.jobExecution), steps: []};
+  const detail: JobExecutionDetail = {
+    ...toJobExecution(first.jobExecution, first.job.name ?? first.job.key),
+    steps: [],
+  };
   const stepById = new Map<string, StepDetail>();
   for (const row of rows) {
     if (row.step) {
@@ -407,7 +411,10 @@ function hydrateWorkflowRunDetail(
     if (!row.jobExecution) continue;
     let jobExecution = jobExecutionById.get(row.jobExecution.id);
     if (!jobExecution) {
-      jobExecution = {...toJobExecution(row.jobExecution), steps: []};
+      jobExecution = {
+        ...toJobExecution(row.jobExecution, row.job.name ?? row.job.key),
+        steps: [],
+      };
       jobExecutionById.set(row.jobExecution.id, jobExecution);
       job.jobExecutions.push(jobExecution);
     }

--- a/libs/api/workflows/src/db/workflow-runs/run-create.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-create.test.ts
@@ -75,7 +75,8 @@ describe('workflow run queries', () => {
       expect(jobExecutions[0]).toMatchObject({
         jobId: runJobs[0]?.id,
         sequence: 1,
-        name: 'build #1',
+        nameOverride: null,
+        name: 'build',
         runner: ['ubuntu-latest'],
         evaluationTrace: null,
       });
@@ -219,7 +220,7 @@ describe('workflow run queries', () => {
         env: {RUN_ID: template('run.id')},
         jobs: {
           build: {
-            name: `Build ${template('event.ref')}`,
+            executionName: `Build ${template('event.ref')}`,
             steps: [
               {
                 run: 'npm test',
@@ -257,10 +258,10 @@ describe('workflow run queries', () => {
           {
             expression: 'event.ref',
             roots: ['event'],
-            fillTarget: 'ingest',
+            fillTarget: 'execution-creation',
             evaluatedAt: 'execution-creation',
             value: 'refs/heads/main',
-            field: 'job.name',
+            field: 'job.execution_name',
           },
         ],
       });
@@ -335,7 +336,8 @@ describe('workflow run queries', () => {
         runner: 'ubuntu-latest',
         jobs: {
           listen: {
-            name: displayNameSource,
+            name: 'Process review',
+            executionName: displayNameSource,
             listening: {
               on: [{source: 'github', event: 'pull_request_review'}],
               until: [{source: 'github', event: 'pull_request'}],
@@ -370,7 +372,7 @@ describe('workflow run queries', () => {
       const build = runJobs.find((job) => job.key === 'build');
       expect(listen).toMatchObject({
         mode: 'listening',
-        name: displayNameSource,
+        name: 'Process review',
         listeningTimeoutMs: 30 * 24 * 60 * 60 * 1000,
         maxExecutions: 3,
         onResolve: 'cancel',
@@ -405,7 +407,8 @@ describe('workflow run queries', () => {
         runner: 'ubuntu-latest',
         jobs: {
           listen: {
-            name: displayNameSource,
+            name: 'Process review',
+            executionName: displayNameSource,
             listening: {
               on: [{source: 'github', event: 'pull_request_review'}],
               until: [{source: 'github', event: 'pull_request'}],

--- a/libs/api/workflows/src/db/workflow-runs/run-create.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-create.ts
@@ -192,15 +192,22 @@ export async function loadReferencedVariables(params: {
   const keys = [...new Set(references.map((reference) => reference.key))].sort();
   if (keys.length === 0) return undefined;
 
-  if (!params.secrets) throw new Error('Secrets client is not configured.');
+  const requiredReferences = references.filter(
+    (reference) => reference.field !== 'job.execution_name',
+  );
+  const requiredKeys = new Set(requiredReferences.map((reference) => reference.key));
+  if (!params.secrets) {
+    if (requiredKeys.size === 0) return undefined;
+    throw new Error('Secrets client is not configured.');
+  }
   const {values: vars} = await params.secrets.getVariablesByNamespace({
     workspaceId: params.workspaceId,
     projectId: params.projectId,
     namespace: '',
   });
-  const missingKey = keys.find((key) => !(key in vars));
+  const missingKey = [...requiredKeys].find((key) => !(key in vars));
   if (missingKey !== undefined) {
-    const reference = references.find((candidate) => candidate.key === missingKey);
+    const reference = requiredReferences.find((candidate) => candidate.key === missingKey);
     throw new InterpolationUnresolvableError(params.definitionId, {
       field: reference?.field ?? 'env',
       source: reference?.source ?? `vars.${missingKey}`,
@@ -221,7 +228,7 @@ function materializeRunGraphJobs(params: {
     job: {
       key: job.key,
       mode: job.mode,
-      name: workflowTemplateSource(job.name),
+      name: job.name ?? null,
       status: 'pending' as const,
       checkoutPersistCredentials: job.checkout.persistCredentials,
       checkoutPermissionsContents: job.checkout.permissions.contents,
@@ -242,7 +249,7 @@ function materializeRunGraphJobs(params: {
     createExecution: (jobRow) => {
       if (jobRow.mode === 'listening') return undefined;
 
-      const fallbackName = `${jobRow.key} #1`;
+      const fallbackName = jobRow.name ?? jobRow.key;
       const modelJob = params.params.model.jobs[jobIndex];
       if (!modelJob) return undefined;
       const executionPlan = deriveInitialJobExecutionPlan({
@@ -259,7 +266,9 @@ function materializeRunGraphJobs(params: {
 
       return {
         sequence: 1,
-        name: executionPlan.name,
+        // Persist only the resolved override. The core entity supplies the
+        // static job name/key when this is null.
+        name: executionPlan.nameOverride,
         runner: [...executionPlan.runner],
         status: 'pending' as const,
         evaluationTrace:
@@ -293,7 +302,7 @@ function referencedVariables(
   }
 
   for (const job of jobs) {
-    collectFieldVariableReferences(job.name, references, {field: 'job.name'});
+    collectFieldVariableReferences(job.executionName, references, {field: 'job.execution_name'});
     for (const template of job.runnerTemplates ?? []) {
       collectFieldVariableReferences(template, references, {field: 'job.runner'});
     }
@@ -355,16 +364,6 @@ function collectFieldVariableReferences(
       });
     }
   }
-}
-
-function workflowTemplateSource(template: MaterializedWorkflowJob['name']): string | null {
-  if (template === undefined) return null;
-
-  return template
-    .map((segment) =>
-      segment.kind === 'literal' ? segment.value : `$${'{{'} ${segment.expression.source} ${'}}'}`,
-    )
-    .join('');
 }
 
 function logTemplateDiagnostics(params: {

--- a/libs/api/workflows/src/db/workflow-runs/run-rerun.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-rerun.test.ts
@@ -411,7 +411,7 @@ describe('workflow run queries', () => {
         model: buildModel({
           jobs: {
             deploy: {
-              name: `Deploy ${template('inputs.environment')}`,
+              executionName: `Deploy ${template('inputs.environment')}`,
               steps: [{run: 'echo deploy'}],
             },
           },
@@ -449,6 +449,54 @@ describe('workflow run queries', () => {
       if (!rerunJob) throw new Error('Missing rerun deploy job');
       const [rerunExecution] = await getJobExecutionsByJobId(rerunJob.id);
       expect(rerunExecution?.name).toBe('Deploy prod (attempt 1)');
+    });
+
+    test('reruns preserve a null name override instead of copying the fallback', async () => {
+      const source = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model: buildModel({
+          jobs: {
+            deploy: {name: 'Deploy', steps: [{run: 'echo deploy'}]},
+          },
+        }),
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId: crypto.randomUUID(),
+          userId: crypto.randomUUID(),
+        },
+      });
+      const [sourceJob] = await getJobsByWorkflowRunId(source.id);
+      if (!sourceJob) throw new Error('Missing deploy job');
+      await markJob([sourceJob], 'deploy', 'failed');
+      const [sourceExecution] = await getJobExecutionsByJobId(sourceJob.id);
+      if (!sourceExecution) throw new Error('Missing deploy execution');
+      expect(sourceExecution.nameOverride).toBeNull();
+      expect(sourceExecution.name).toBe('Deploy');
+      await updateWorkflowRunStatus({
+        workflowRunId: source.id,
+        status: 'failed',
+        expectedVersion: 1,
+      });
+
+      const rerun = await createRerunWorkflowRun({
+        workflowRunId: source.id,
+        mode: 'all',
+        actorUserId: crypto.randomUUID(),
+      });
+
+      const [rerunJob] = await getJobsByWorkflowRunId(rerun.id);
+      if (!rerunJob) throw new Error('Missing rerun deploy job');
+      const [rerunExecution] = await getJobExecutionsByJobId(rerunJob.id);
+      expect(rerunExecution?.nameOverride).toBeNull();
+      expect(rerunExecution?.name).toBe('Deploy');
+      const [storedRerunExecution] = await db()
+        .select({name: jobExecutions.name})
+        .from(jobExecutions)
+        .where(eq(jobExecutions.jobId, rerunJob.id));
+      expect(storedRerunExecution?.name).toBeNull();
     });
 
     test('writes one run-attempt-created outbox event for the rerun', async () => {

--- a/libs/api/workflows/src/db/workflow-runs/run-rerun.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-rerun.ts
@@ -225,7 +225,8 @@ function materializeRerunGraphJobs(params: {
 
         const sourceExecution = params.sourceJobExecutionByJobId.get(sourceJob.id);
         const modelJob = sourceModelJobByKey.get(job.key);
-        const executionName = sourceExecution?.name ?? `${job.key} #1`;
+        const nameOverride = sourceExecution?.name ?? null;
+        const executionName = nameOverride ?? job.name ?? job.key;
         const runner =
           carriedOver || modelJob === undefined
             ? (sourceExecution?.runner ?? job.runner ?? null)
@@ -234,13 +235,17 @@ function materializeRerunGraphJobs(params: {
                 modelJob,
                 jobId: job.id,
                 sequence: 1,
+                nameOverride,
                 executionName,
+                jobName: job.name,
                 status: 'pending',
               });
 
         return {
           sequence: 1,
-          name: executionName,
+          // Reruns preserve the authored/resolved override, never the
+          // effective fallback exposed by the core entity.
+          name: nameOverride,
           runner: runner ? [...runner] : null,
           status: carriedOver ? ('succeeded' as const) : ('pending' as const),
           statusReason: null,

--- a/libs/api/workflows/src/presentation/dto/job.test.ts
+++ b/libs/api/workflows/src/presentation/dto/job.test.ts
@@ -90,6 +90,7 @@ function jobExecutionEntity(overrides: Partial<JobExecution> = {}): JobExecution
     id: '33333333-3333-4333-8333-333333333333',
     jobId: '11111111-1111-4111-8111-111111111111',
     sequence: 1,
+    nameOverride: 'deploy',
     name: 'deploy',
     runner: null,
     status: 'pending',

--- a/libs/api/workflows/src/temporal/activities/index.ts
+++ b/libs/api/workflows/src/temporal/activities/index.ts
@@ -51,6 +51,7 @@ export function createOrchestrationActivities(params: {
       agent: params.agent,
       integrations: params.integrations,
       projects: params.projects,
+      secrets: params.secrets,
     }),
     peekListenerBufferActivity,
     resolveJobListenerActivity,

--- a/libs/api/workflows/src/temporal/activities/orchestration-activities.ts
+++ b/libs/api/workflows/src/temporal/activities/orchestration-activities.ts
@@ -287,6 +287,7 @@ export function createDrainListenerEventsActivity(clients: {
   agent: AgentInterModuleClient;
   integrations?: IntegrationsModuleClient | undefined;
   projects?: ProjectsModuleClient | undefined;
+  secrets: Pick<SecretsInterModuleClient, 'getVariablesByNamespace'>;
 }) {
   return async function drainListenerEventsActivity(params: {
     jobId: string;

--- a/libs/shared/expression/src/workflow-context/workflow-context.test.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.test.ts
@@ -218,6 +218,7 @@ describe('workflow context registry', () => {
         kind: 'object',
         fields: {
           key: 'string',
+          name: 'string',
         },
       },
     });

--- a/libs/shared/expression/src/workflow-context/workflow-context.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.ts
@@ -130,6 +130,7 @@ const jobTypeEnvironment = {
     kind: 'object',
     fields: {
       key: 'string',
+      name: 'string',
     },
   },
 } as const satisfies ExpressionTypeEnvironment;


### PR DESCRIPTION
Persist resolved workflow job execution names through run creation and listener materialization.

Dynamic names are stored as nullable execution-level overrides, preserving stable job names and fallback behavior across reruns. The workflow and definition contracts now keep static `job.name` separate from dynamic `execution_name`, while permanent variable-resolution failures are persisted as failed executions with degraded evaluation traces.

The listener preflight of model, variables, and agent context intentionally occurs before the database transaction because the secrets module uses the shared connection pool. The transaction still re-reads and locks the materialization target before persisting the result.

The nullable execution-name schema change is folded into the existing `0000_initial` migration and snapshot; no standalone migration is added.

Validation passed: 651 workflow tests, 395 definitions tests, package checks, TypeScript builds, database-boundary checks, Turbo build, Changeset validation, and `git diff --check`.

Closes ENG-1393