### PR TITLE
[workflow-document] Support working directories on run and agent steps

### DIFF
--- a/.changeset/working-directory-step-schema.md
+++ b/.changeset/working-directory-step-schema.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/workflow-document": minor
+---
+
+Add `working_directory` to the workflow-document schema for run and agent steps.

--- a/libs/shared/workflow/document/src/document/workflow-document.test.ts
+++ b/libs/shared/workflow/document/src/document/workflow-document.test.ts
@@ -46,6 +46,18 @@ describe('workflowDocumentSchema', () => {
     expect(result.success).toBe(true);
   });
 
+  it('accepts working_directory on run and agent steps', () => {
+    const result = workflowDocumentSchema.safeParse({
+      name: 'multi-directory build',
+      jobs: {
+        build: {steps: [{run: 'make test', working_directory: 'api'}]},
+        review: {steps: [{prompt: 'Review the API changes.', working_directory: 'api'}]},
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
   it('accepts job and step if predicates as document fields', () => {
     const workflowDocument = {
       name: 'conditional build',
@@ -868,8 +880,28 @@ describe('workflowDocumentSchema', () => {
     expect(result.success).toBe(false);
   });
 
+  it('rejects checkout as an unsupported step key', () => {
+    const result = workflowDocumentSchema.safeParse({
+      name: 'simple build',
+      jobs: {build: {steps: [{checkout: {path: 'api'}, working_directory: 'api'}]}},
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    expect(result.error.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({code: 'unrecognized_keys', keys: ['checkout']}),
+      ]),
+    );
+  });
+
   it.each([
     ['prompt-only agent step', {prompt: 'Fix the failing tests.'}],
+    [
+      'agent step with working directory',
+      {prompt: 'Fix the failing tests.', working_directory: 'api'},
+    ],
     ['inline agent step', {model: 'claude-opus-4-8', prompt: 'Fix the failing tests.'}],
     ['agent step with harness', {harness: 'claude', model: 'claude-opus-4-8', prompt: 'Fix it.'}],
     ['agent step with thinking', {model: 'claude-opus-4-8', prompt: 'Fix it.', thinking: 'low'}],

--- a/libs/shared/workflow/document/src/document/workflow-document.ts
+++ b/libs/shared/workflow/document/src/document/workflow-document.ts
@@ -349,6 +349,9 @@ export const workflowDocumentStepSchema = z
           '{{ }} interpolation. See [conditionals](/reference/expressions#conditionals-if).',
       }),
     name: z.string().min(1).optional().meta({description: 'Human-readable step name.'}),
+    working_directory: z.string().min(1).optional().meta({
+      description: 'Working directory for the step, relative to the job workspace.',
+    }),
     run: z.string().min(1).optional().meta({
       description: 'Shell command for a run step. Do not combine it with agent-only fields.',
     }),


### PR DESCRIPTION
## Summary

Add `working_directory` to the workflow-document schema for run and agent steps.

The schema remains strict for checkout-shaped steps, which use `path` instead. Runtime normalization and runner behavior are intentionally deferred to ENG-1429.

Closes ENG-1420

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `working_directory` to the workflow document schema for run and agent steps so commands can run in subdirectories. Implements ENG-1420; not allowed on checkout-shaped steps (use `path`).

- **New Features**
  - Optional `working_directory` string on step schema, relative to the job workspace.
  - Validation rejects its use on checkout-shaped steps; tests cover acceptance on run/agent and rejection on checkout.
  - Adds a minor changeset for `@shipfox/workflow-document`.

<sup>Written for commit bd90f65eac3a3f3560923391f3a03510efa8938f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

