### PR TITLE
Keep agent harness state out of checked-out repositories

### DIFF
--- a/libs/runner/agent/src/core/claude-adapter.test.ts
+++ b/libs/runner/agent/src/core/claude-adapter.test.ts
@@ -60,6 +60,7 @@ import type {IntegrationToolsBridge} from '#core/integration-tools-bridge.js';
 function invocation(overrides: Partial<HarnessInvocation> = {}): HarnessInvocation {
   return {
     cwd: testCwd,
+    logsDir: join(testCwd, 'runner-logs'),
     model: 'claude-opus-4-8',
     provider: 'anthropic',
     thinking: 'xhigh',
@@ -416,7 +417,7 @@ describe('claudeHarnessAdapter', () => {
       }),
     });
     const env = lastQueryOptions().env;
-    expect(env.CLAUDE_CONFIG_DIR).toMatch(`${testCwd}/logs/claude-config-`);
+    expect(env.CLAUDE_CONFIG_DIR).toMatch(`${testCwd}/runner-logs/claude-config-`);
     expect(lastQueryOptions()).not.toHaveProperty('tools');
     expect(lastQueryOptions().mcpServers).toBeUndefined();
   });

--- a/libs/runner/agent/src/core/claude-adapter.ts
+++ b/libs/runner/agent/src/core/claude-adapter.ts
@@ -159,7 +159,7 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
     messages?.close();
     signal.removeEventListener('abort', abortQuery);
     claudeQuery?.close();
-    if (configDir !== undefined) await rm(configDir, {recursive: true, force: true});
+    if (configDir !== undefined) await cleanupClaudeConfigDir(configDir);
   }
 }
 
@@ -390,6 +390,19 @@ function isFileNotFoundError(error: unknown): boolean {
 async function createClaudeConfigDir(logsDir: string): Promise<string> {
   await mkdir(logsDir, {recursive: true});
   return mkdtemp(join(logsDir, 'claude-config-'));
+}
+
+async function cleanupClaudeConfigDir(configDir: string): Promise<void> {
+  try {
+    await rm(configDir, {
+      recursive: true,
+      force: true,
+      maxRetries: 3,
+      retryDelay: 100,
+    });
+  } catch (error) {
+    logger().warn({err: error, configDir}, 'Failed to remove Claude configuration');
+  }
 }
 
 function forwardSessionEntry(

--- a/libs/runner/agent/src/core/claude-adapter.ts
+++ b/libs/runner/agent/src/core/claude-adapter.ts
@@ -47,6 +47,7 @@ interface ClaudeAuth {
 async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessResult> {
   const {
     cwd,
+    logsDir,
     model,
     provider,
     thinking,
@@ -61,6 +62,7 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
   const collector = new OutputCollector(invocation.outputs);
 
   if (signal.aborted) throw new Error('Agent step aborted before the Claude session started');
+  if (logsDir === undefined) throw new Error('Agent logs directory is required');
   if (provider !== 'anthropic') {
     throw new AgentConfigError(
       `Harness "claude" only supports provider "anthropic"; received "${provider}".`,
@@ -96,7 +98,7 @@ async function runClaudeAgent(invocation: HarnessInvocation): Promise<HarnessRes
   };
 
   try {
-    configDir = await createClaudeConfigDir(cwd);
+    configDir = await createClaudeConfigDir(logsDir);
     if (signal.aborted) throw new Error('Agent step aborted before the Claude session started');
 
     messages = new ClaudeInputStream();
@@ -385,8 +387,7 @@ function isFileNotFoundError(error: unknown): boolean {
   return typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT';
 }
 
-async function createClaudeConfigDir(cwd: string): Promise<string> {
-  const logsDir = join(cwd, 'logs');
+async function createClaudeConfigDir(logsDir: string): Promise<string> {
   await mkdir(logsDir, {recursive: true});
   return mkdtemp(join(logsDir, 'claude-config-'));
 }

--- a/libs/runner/agent/src/core/harness.ts
+++ b/libs/runner/agent/src/core/harness.ts
@@ -6,6 +6,8 @@ import type {IntegrationToolsBridge} from '#core/integration-tools-bridge.js';
 // Revisit this shared contract if a third harness needs materially different inputs.
 export interface HarnessInvocation {
   readonly cwd: string;
+  /** Runner-owned per-job directory for harness state, outside the checked-out workspace. */
+  readonly logsDir?: string | undefined;
   readonly model: string;
   readonly provider: string;
   readonly thinking: string;

--- a/libs/runner/agent/src/core/pi-adapter.test.ts
+++ b/libs/runner/agent/src/core/pi-adapter.test.ts
@@ -5,6 +5,7 @@ const piExtensionTestState = vi.hoisted(() => ({
 const {
   createAgentSessionMock,
   createAgentSessionServicesMock,
+  sessionManagerCreateMock,
   findMock,
   getAllMock,
   hasConfiguredAuthMock,
@@ -20,6 +21,7 @@ const {
 } = vi.hoisted(() => ({
   createAgentSessionMock: vi.fn(),
   createAgentSessionServicesMock: vi.fn(),
+  sessionManagerCreateMock: vi.fn(() => ({})),
   findMock: vi.fn(),
   getAllMock: vi.fn(),
   hasConfiguredAuthMock: vi.fn(),
@@ -58,7 +60,7 @@ vi.mock('@earendil-works/pi-coding-agent', () => ({
   ModelRuntime: {
     create: modelRuntimeCreateMock,
   },
-  SessionManager: {create: () => ({})},
+  SessionManager: {create: sessionManagerCreateMock},
 }));
 
 vi.mock('@shipfox/node-egress-guard', () => ({
@@ -153,6 +155,7 @@ function expectResolvedExtensionPaths(
 function invocation(overrides: Partial<HarnessInvocation> = {}): HarnessInvocation {
   return {
     cwd: '/work',
+    logsDir: '/runner-logs/job-1',
     model: 'claude-opus-4-8',
     provider: 'anthropic',
     thinking: 'high',
@@ -204,6 +207,8 @@ describe('piHarnessAdapter', () => {
     delete process.env.GIT_CONFIG_GLOBAL;
     createAgentSessionMock.mockReset();
     createAgentSessionServicesMock.mockReset();
+    sessionManagerCreateMock.mockReset();
+    sessionManagerCreateMock.mockReturnValue({});
     findMock.mockReset();
     getAllMock.mockReset();
     hasConfiguredAuthMock.mockReset();
@@ -301,8 +306,9 @@ describe('piHarnessAdapter', () => {
     expect(createAgentSessionMock).toHaveBeenCalled();
   });
 
-  it('configures eager loopback MCP proxy access in the job workspace', async () => {
+  it('configures eager loopback MCP proxy access in the runner job logs directory', async () => {
     sessionDir = mkdtempSync(join(tmpdir(), 'shipfox-pi-mcp-'));
+    const logsDir = join(sessionDir, 'runner-logs');
     const bridge = mcpBridge();
     let configPath = '';
     let config: unknown;
@@ -312,11 +318,15 @@ describe('piHarnessAdapter', () => {
       return piServices(sessionDir);
     });
 
-    await piHarnessAdapter.run(invocation({cwd: sessionDir, mcpServers: [bridge]}));
+    await piHarnessAdapter.run(invocation({cwd: sessionDir, logsDir, mcpServers: [bridge]}));
 
     expect(bridge.activateHttp).toHaveBeenCalledTimes(1);
     expect(bindExtensionsMock).toHaveBeenCalledWith(expect.objectContaining({mode: 'print'}));
-    expect(configPath).toMatch(`${sessionDir}/logs/pi-mcp-`);
+    expect(configPath).toMatch(`${logsDir}/pi-mcp-`);
+    expect(sessionManagerCreateMock).toHaveBeenCalledWith(
+      sessionDir,
+      join(logsDir, 'agent-sessions'),
+    );
     expect(config).toEqual({
       settings: {toolPrefix: 'none'},
       mcpServers: {
@@ -353,6 +363,7 @@ describe('piHarnessAdapter', () => {
     const result = piHarnessAdapter.run(
       invocation({
         cwd: sessionDir,
+        logsDir: join(sessionDir, 'runner-logs'),
         signal: abortController.signal,
         mcpServers: [mcpBridge()],
       }),
@@ -440,7 +451,13 @@ describe('piHarnessAdapter', () => {
     );
 
     const error = await piHarnessAdapter
-      .run(invocation({cwd: sessionDir, mcpServers: [mcpBridge()]}))
+      .run(
+        invocation({
+          cwd: sessionDir,
+          logsDir: join(sessionDir, 'runner-logs'),
+          mcpServers: [mcpBridge()],
+        }),
+      )
       .catch((caught) => caught);
 
     expect(error.message).toContain(piMcpAdapterDirectory);
@@ -456,7 +473,13 @@ describe('piHarnessAdapter', () => {
     };
 
     const error = await piHarnessAdapter
-      .run(invocation({cwd: sessionDir, mcpServers: [mcpBridge()]}))
+      .run(
+        invocation({
+          cwd: sessionDir,
+          logsDir: join(sessionDir, 'runner-logs'),
+          mcpServers: [mcpBridge()],
+        }),
+      )
       .catch((caught) => caught);
 
     expect(error).toBeInstanceOf(AgentHarnessUnavailableError);
@@ -465,7 +488,7 @@ describe('piHarnessAdapter', () => {
       environment: {extensionPaths: ['pi-web-access', 'pi-mcp-adapter']},
     });
     expect(createAgentSessionServicesMock).not.toHaveBeenCalled();
-    expect(readdirSync(join(sessionDir, 'logs'))).toEqual([]);
+    expect(readdirSync(join(sessionDir, 'runner-logs'))).toEqual([]);
   });
 
   it('registers the output tool for steps with declared outputs', async () => {
@@ -493,6 +516,7 @@ describe('piHarnessAdapter', () => {
     await piHarnessAdapter.run(
       invocation({
         cwd: sessionDir,
+        logsDir: join(sessionDir, 'runner-logs'),
         mcpServers: [mcpBridge()],
         tools: ['read', 'mcp', 'web_search'],
       }),
@@ -508,6 +532,7 @@ describe('piHarnessAdapter', () => {
     await piHarnessAdapter.run(
       invocation({
         cwd: sessionDir,
+        logsDir: join(sessionDir, 'runner-logs'),
         mcpServers: [mcpBridge()],
         tools: ['read', 'web_search'],
       }),
@@ -550,6 +575,7 @@ describe('piHarnessAdapter', () => {
     await piHarnessAdapter.run(
       invocation({
         cwd: sessionDir,
+        logsDir: join(sessionDir, 'runner-logs'),
         provider: 'local-ollama',
         model: 'llama',
         mcpServers: [mcpBridge()],

--- a/libs/runner/agent/src/core/pi-adapter.ts
+++ b/libs/runner/agent/src/core/pi-adapter.ts
@@ -65,6 +65,7 @@ export const piHarnessAdapter: HarnessAdapter = {run: runPiAgent};
 async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult> {
   const {
     cwd,
+    logsDir,
     model: modelId,
     provider,
     thinking,
@@ -86,6 +87,7 @@ async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult>
   // tokens after the step loop has moved on. Guard on entry, then again once the
   // session exists so a mid-creation abort still stops pi.
   if (signal.aborted) throw new Error('Agent step aborted before the pi session started');
+  if (logsDir === undefined) throw new Error('Agent logs directory is required');
 
   const modelRuntime = await ModelRuntime.create({
     credentials: createInMemoryCredentialStore(
@@ -113,7 +115,7 @@ async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult>
   let mcpConfig: PiMcpConfig | undefined;
 
   try {
-    mcpConfig = await createPiMcpConfig(cwd, mcpServers);
+    mcpConfig = await createPiMcpConfig(logsDir, mcpServers);
     const extensionPackageNames = [
       ...(isPiExtensionAvailable({packageName: 'pi-web-access'}) ? ['pi-web-access'] : []),
       ...(mcpConfig === undefined ? [] : ['pi-mcp-adapter']),
@@ -174,9 +176,9 @@ async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult>
       thinkingLevel: thinking as PiThinkingLevel,
       ...piToolsOption(tools, customProvider, mcpConfig !== undefined),
       ...(hasDeclaredOutputs ? {customTools: [setOutputTool(collector)]} : {}),
-      // Keep the session JSONL inside the job workspace so it forwards from a deterministic path
-      // and is cleaned up with the workspace; pi's default lives under ~/.pi, outside it.
-      sessionManager: SessionManager.create(cwd, join(cwd, 'logs', 'agent-sessions')),
+      // Keep the session JSONL in the runner-owned job logs directory so it forwards from a
+      // deterministic path and is cleaned up with the job; pi's default lives under ~/.pi.
+      sessionManager: SessionManager.create(cwd, join(logsDir, 'agent-sessions')),
     });
     const piSession = createdSession.session;
     session = piSession;
@@ -318,14 +320,13 @@ function createInMemoryCredentialStore(credentials: Record<string, Credential>):
 }
 
 async function createPiMcpConfig(
-  cwd: string,
+  logsDir: string,
   mcpServers: HarnessInvocation['mcpServers'],
 ): Promise<PiMcpConfig | undefined> {
   if (mcpServers === undefined || mcpServers.length === 0) return undefined;
 
-  const logsDirectory = join(cwd, 'logs');
-  await mkdir(logsDirectory, {recursive: true});
-  const directory = await mkdtemp(join(logsDirectory, 'pi-mcp-'));
+  await mkdir(logsDir, {recursive: true});
+  const directory = await mkdtemp(join(logsDir, 'pi-mcp-'));
   const path = join(directory, 'mcp.json');
   try {
     const serverEntries = await Promise.all(

--- a/libs/runner/agent/src/core/step.ts
+++ b/libs/runner/agent/src/core/step.ts
@@ -37,6 +37,7 @@ export async function executeAgentStep(
   options: {
     signal?: AbortSignal;
     cwd?: string;
+    logsDir?: string | undefined;
     runtime: {
       harness: Harness;
       provider: string;
@@ -98,6 +99,7 @@ export async function executeAgentStep(
       stepId: step.id,
       attempt: step.current_attempt,
       cwd: options.cwd ?? process.cwd(),
+      logsDir: options.logsDir,
       harness: options.runtime.harness,
       model: options.runtime.model,
       outputs: outputDeclarationsFromConfig(step.config.outputs),
@@ -122,6 +124,7 @@ async function runSelectedHarness(params: {
   stepId: string;
   attempt: number;
   cwd: string;
+  logsDir: string | undefined;
   harness: Harness;
   model: string;
   outputs: OutputDeclarations | undefined;
@@ -141,6 +144,7 @@ async function runSelectedHarness(params: {
     stepId,
     attempt,
     cwd,
+    logsDir,
     harness,
     model,
     outputs,
@@ -161,6 +165,7 @@ async function runSelectedHarness(params: {
     const {response, outputs: collectedOutputs} = await raceAbort(
       adapter.run({
         cwd,
+        ...(logsDir === undefined ? {} : {logsDir}),
         model,
         provider,
         thinking,

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -1239,6 +1239,7 @@ describe('runJobSteps', () => {
     expect(executeAgentStepMock).toHaveBeenCalledWith(agent, {
       signal: ac.signal,
       cwd: '/work',
+      logsDir: LOGS_DIR,
       runtime: {
         harness: 'pi',
         provider: 'anthropic',
@@ -1435,6 +1436,7 @@ describe('runJobSteps', () => {
     expect(executeAgentStepMock).toHaveBeenCalledWith(agent, {
       signal: ac.signal,
       cwd: '/work',
+      logsDir: LOGS_DIR,
       runtime: {
         harness: 'pi',
         provider: 'anthropic',

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -367,6 +367,7 @@ export async function executeStep(params: {
       const result = await executeAgentStep(step, {
         signal,
         cwd,
+        logsDir,
         ...(ambientGitConfigPath ? {gitConfigGlobal: ambientGitConfigPath} : {}),
         runtime: {
           harness: runtimeConfig.harness,


### PR DESCRIPTION
Agent harnesses previously wrote Claude config, Pi MCP state, and Pi session JSONL under the checked-out workspace's `logs/` directory. That could dirty the customer's repository or cause agent transcripts to be committed accidentally.

This change passes the runner-owned per-job `logsDir` through step execution into both harness adapters. All three producers now live under that directory and continue to be cleaned up with the job. The focused adapter and orchestration tests assert the new locations.

Validation: agent tests (159/159), orchestration tests (86/86), affected type checks, and Biome checks.

Closes ENG-1415

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move all agent harness state into the per-job runner logs directory and make Claude config cleanup best-effort to avoid masking successful runs. Prevents dirty repos and accidental transcript commits, satisfying ENG-1415.

- **Refactors**
  - Pass per-job `logsDir` from orchestration to `executeAgentStep`, then into both harness adapters.
  - Claude: write `claude-config-*` under `logsDir`; require `logsDir`; cleanup is best-effort with retries and a warning on failure.
  - Pi: write MCP config under `logsDir/pi-mcp-*`; store session JSONL under `logsDir/agent-sessions`; require `logsDir`.
  - Updated tests to assert new locations and session manager paths.

<sup>Written for commit 782587c7e0260595791a6a30b588b038c07af870. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

