### PR TITLE
[api-integration-github] Drop fork-originated pull request deliveries at GitHub ingestion

### DIFF
--- a/.changeset/fork-pull-request-deliveries.md
+++ b/.changeset/fork-pull-request-deliveries.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-integration-github": patch
+---
+
+Drop pull request webhook deliveries opened from a fork before they can trigger a run.

--- a/libs/api/integration/github/src/core/webhook.test.ts
+++ b/libs/api/integration/github/src/core/webhook.test.ts
@@ -272,7 +272,12 @@ describe('handleGithubEvent', () => {
     const payload = {
       action: 'opened',
       installation: {id: installationId},
-      pull_request: {number: 17},
+      repository: {id: 42, full_name: 'shipfox/platform'},
+      pull_request: {
+        number: 17,
+        head: {repo: {id: 42, full_name: 'shipfox/platform'}},
+        base: {repo: {id: 42, full_name: 'shipfox/platform'}},
+      },
     };
 
     const result = await handleGithubEvent({
@@ -297,6 +302,96 @@ describe('handleGithubEvent', () => {
         payload,
       },
     });
+  });
+
+  it('records and drops pull request deliveries whose head repository is a fork', async () => {
+    const handlers = deps();
+    const deliveryId = randomUUID();
+    const payload = {
+      action: 'opened',
+      installation: {id: 7787},
+      repository: {id: 42, full_name: 'shipfox/platform'},
+      pull_request: {
+        head: {repo: {id: 84, full_name: 'contributor/platform'}},
+        base: {repo: {id: 42, full_name: 'shipfox/platform'}},
+      },
+    };
+
+    const result = await handleGithubEvent({
+      tx: db(),
+      deliveryId,
+      event: 'pull_request',
+      payload,
+      ...handlers,
+    });
+
+    expect(result.outcome).toBe('fork-pull-request');
+    expect(handlers.publishSourcePush).not.toHaveBeenCalled();
+    expect(handlers.publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(handlers.getIntegrationConnectionById).not.toHaveBeenCalled();
+    expect(firstRecordDeliveryOnlyCall(handlers.recordDeliveryOnly)).toMatchObject({
+      provider: 'github',
+      deliveryId,
+    });
+  });
+
+  it('records and drops pull request deliveries whose head repository is unresolved', async () => {
+    const handlers = deps();
+    const deliveryId = randomUUID();
+    const payload = {
+      action: 'synchronize',
+      installation: {id: 7789},
+      repository: {id: 42, full_name: 'shipfox/platform'},
+      pull_request: {
+        head: {repo: null},
+        base: {repo: {id: 42, full_name: 'shipfox/platform'}},
+      },
+    };
+
+    const result = await handleGithubEvent({
+      tx: db(),
+      deliveryId,
+      event: 'pull_request',
+      payload,
+      ...handlers,
+    });
+
+    expect(result.outcome).toBe('fork-pull-request');
+    expect(handlers.publishSourcePush).not.toHaveBeenCalled();
+    expect(handlers.publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(handlers.getIntegrationConnectionById).not.toHaveBeenCalled();
+    expect(firstRecordDeliveryOnlyCall(handlers.recordDeliveryOnly)).toMatchObject({
+      provider: 'github',
+      deliveryId,
+    });
+  });
+
+  it('publishes pull request deliveries whose head and base repositories match', async () => {
+    const installationId = 7788;
+    const connection = fakeConnection();
+    await seedInstallation(installationId, connection.id);
+    const handlers = deps({connection});
+    const payload = {
+      action: 'opened',
+      installation: {id: installationId},
+      repository: {id: 42, full_name: 'shipfox/platform'},
+      pull_request: {
+        head: {repo: {id: 42, full_name: 'shipfox/platform'}},
+        base: {repo: {id: 42, full_name: 'shipfox/platform'}},
+      },
+    };
+
+    const result = await handleGithubEvent({
+      tx: db(),
+      deliveryId: randomUUID(),
+      event: 'pull_request',
+      payload,
+      ...handlers,
+    });
+
+    expect(result.outcome).toBe('published-envelope');
+    expect(handlers.recordDeliveryOnly).not.toHaveBeenCalled();
+    expect(handlers.publishIntegrationEventReceived).toHaveBeenCalledTimes(1);
   });
 
   it('returns the cached installation token cleanup handle when the installation is deleted', async () => {
@@ -374,7 +469,12 @@ describe('handleGithubEvent', () => {
     const payload = {
       action: null,
       installation: {id: installationId},
-      pull_request: {number: 17},
+      repository: {id: 42, full_name: 'shipfox/platform'},
+      pull_request: {
+        number: 17,
+        head: {repo: {id: 42, full_name: 'shipfox/platform'}},
+        base: {repo: {id: 42, full_name: 'shipfox/platform'}},
+      },
     };
 
     const result = await handleGithubEvent({

--- a/libs/api/integration/github/src/core/webhook.ts
+++ b/libs/api/integration/github/src/core/webhook.ts
@@ -39,6 +39,7 @@ export type HandleGithubEventOutcome =
   | 'duplicate-envelope'
   | 'published-push-envelope-only'
   | 'duplicate-push-envelope-only'
+  | 'fork-pull-request'
   | 'unknown-installation'
   | 'missing-connection'
   | 'inactive-connection'
@@ -53,11 +54,88 @@ function isBranchDeletion(after: string): boolean {
   return after === DELETED_BRANCH_SHA;
 }
 
+interface GithubRepositoryIdentity {
+  id?: string;
+  fullName?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function repositoryIdentity(value: unknown): GithubRepositoryIdentity | undefined {
+  if (!isRecord(value)) return undefined;
+
+  const id =
+    (typeof value.id === 'number' && Number.isInteger(value.id) ? String(value.id) : undefined) ??
+    (typeof value.id === 'string' && value.id.trim() ? value.id.trim() : undefined);
+  const fullName =
+    typeof value.full_name === 'string' && value.full_name.trim()
+      ? value.full_name.trim().toLowerCase()
+      : undefined;
+  if (!id && !fullName) return undefined;
+
+  return {...(id ? {id} : {}), ...(fullName ? {fullName} : {})};
+}
+
+function areSameRepositories(
+  head: GithubRepositoryIdentity,
+  base: GithubRepositoryIdentity,
+): boolean {
+  if (head.id && base.id) return head.id === base.id;
+  if (head.fullName && base.fullName) return head.fullName === base.fullName;
+  return false;
+}
+
+function pullRequestRepositories(
+  payload: unknown,
+):
+  | {head: GithubRepositoryIdentity | undefined; base: GithubRepositoryIdentity | undefined}
+  | undefined {
+  if (!isRecord(payload) || !isRecord(payload.pull_request)) return undefined;
+
+  const pullRequest = payload.pull_request;
+  const head = isRecord(pullRequest.head) ? repositoryIdentity(pullRequest.head.repo) : undefined;
+  const base =
+    (isRecord(pullRequest.base) ? repositoryIdentity(pullRequest.base.repo) : undefined) ??
+    repositoryIdentity(payload.repository);
+  return {head, base};
+}
+
 export async function handleGithubEvent(
   params: HandleGithubEventParams,
 ): Promise<HandleGithubEventResult> {
   const actionEnvelope = githubWebhookActionSchema.safeParse(params.payload);
   const action = actionEnvelope.success ? actionEnvelope.data.action : undefined;
+
+  const pullRequestRepos = pullRequestRepositories(params.payload);
+  if (
+    pullRequestRepos &&
+    (!pullRequestRepos.head ||
+      !pullRequestRepos.base ||
+      !areSameRepositories(pullRequestRepos.head, pullRequestRepos.base))
+  ) {
+    logger().info(
+      {
+        deliveryId: params.deliveryId,
+        event: params.event,
+        reason:
+          !pullRequestRepos.head || !pullRequestRepos.base
+            ? 'repository_unresolved'
+            : 'repositories_differ',
+        headRepository: pullRequestRepos.head,
+        baseRepository: pullRequestRepos.base,
+      },
+      'github webhook: fork or indeterminate pull request, dropping',
+    );
+    await params.recordDeliveryOnly({
+      tx: params.tx,
+      provider: GITHUB_SOURCE,
+      deliveryId: params.deliveryId,
+    });
+    return {outcome: 'fork-pull-request'};
+  }
+
   const installationEnvelope = githubWebhookInstallationSchema.safeParse(params.payload);
   const installationId = installationEnvelope.success
     ? installationEnvelope.data.installation?.id

--- a/libs/api/integration/github/src/presentation/routes/webhooks.test.ts
+++ b/libs/api/integration/github/src/presentation/routes/webhooks.test.ts
@@ -284,12 +284,20 @@ describe('GitHub webhook route', () => {
   });
 
   it('records and drops a pull request opened from a fork', async () => {
-    const {app, publishIntegrationEventReceived, publishSourcePush, recordDeliveryOnly} =
-      await createTestApp();
+    const installationId = 7787;
+    const connection = fakeConnection();
+    await seedInstallation(installationId, connection.id);
+    const {
+      app,
+      publishIntegrationEventReceived,
+      publishSourcePush,
+      recordDeliveryOnly,
+      getIntegrationConnectionById,
+    } = await createTestApp({connection});
     const deliveryId = randomUUID();
     const rawPayload = {
       action: 'opened',
-      installation: {id: 7787},
+      installation: {id: installationId},
       repository: {id: 42, full_name: 'shipfox/platform'},
       pull_request: {
         head: {repo: {id: 84, full_name: 'contributor/platform'}},
@@ -310,6 +318,7 @@ describe('GitHub webhook route', () => {
     expect(publishSourcePush).not.toHaveBeenCalled();
     expect(recordDeliveryOnly).toHaveBeenCalledTimes(1);
     expect(recordDeliveryOnly.mock.calls[0]?.[0]).toMatchObject({provider: 'github', deliveryId});
+    expect(getIntegrationConnectionById).not.toHaveBeenCalled();
   });
 
   it('publishes a generic envelope for a non-push event without an action', async () => {

--- a/libs/api/integration/github/src/presentation/routes/webhooks.test.ts
+++ b/libs/api/integration/github/src/presentation/routes/webhooks.test.ts
@@ -250,7 +250,12 @@ describe('GitHub webhook route', () => {
     const rawPayload = {
       action: 'opened',
       installation: {id: installationId},
-      pull_request: {number: 17},
+      repository: {id: 42, full_name: 'shipfox/platform'},
+      pull_request: {
+        number: 17,
+        head: {repo: {id: 42, full_name: 'shipfox/platform'}},
+        base: {repo: {id: 42, full_name: 'shipfox/platform'}},
+      },
     };
     const body = JSON.stringify(rawPayload);
 
@@ -276,6 +281,35 @@ describe('GitHub webhook route', () => {
         payload: rawPayload,
       },
     });
+  });
+
+  it('records and drops a pull request opened from a fork', async () => {
+    const {app, publishIntegrationEventReceived, publishSourcePush, recordDeliveryOnly} =
+      await createTestApp();
+    const deliveryId = randomUUID();
+    const rawPayload = {
+      action: 'opened',
+      installation: {id: 7787},
+      repository: {id: 42, full_name: 'shipfox/platform'},
+      pull_request: {
+        head: {repo: {id: 84, full_name: 'contributor/platform'}},
+        base: {repo: {id: 42, full_name: 'shipfox/platform'}},
+      },
+    };
+    const body = JSON.stringify(rawPayload);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/integrations/github',
+      headers: signedHeaders(body, 'pull_request', deliveryId),
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(publishSourcePush).not.toHaveBeenCalled();
+    expect(recordDeliveryOnly).toHaveBeenCalledTimes(1);
+    expect(recordDeliveryOnly.mock.calls[0]?.[0]).toMatchObject({provider: 'github', deliveryId});
   });
 
   it('publishes a generic envelope for a non-push event without an action', async () => {


### PR DESCRIPTION
GitHub webhook ingestion now records and drops pull request deliveries when the head repository differs from the base repository or cannot be resolved, preventing fork-originated or indeterminate pull requests from triggering runs. Same-repository pull requests retain the existing delivery path, while issue-comment deliveries remain unchanged because they do not include head-repository data.

Closes ENG-1422

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops fork-originated and indeterminate pull request deliveries at GitHub ingestion in `@shipfox/api-integration-github` to prevent runs from forks (Closes ENG-1422). Same-repo PRs and issue-comment deliveries are unchanged.

- **Bug Fixes**
  - Compare PR head/base repositories by id or full_name; if missing or different, return outcome `fork-pull-request`.
  - Record delivery-only (provider `github`) and skip envelope publishing and connection lookup.
  - Tests: added fork/unresolved cases and same-repo success; hardened the route test by seeding an active installation; added patch changeset.

<sup>Written for commit e2f4ba579d0de1ae52fe9b3ebf7727c9458e9ab3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

