### PR TITLE
[client-workflows] Use one activity-derived status across workflow UI surfaces

### DIFF
--- a/.changeset/activity-derived-workflow-status.md
+++ b/.changeset/activity-derived-workflow-status.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-workflows": patch
+---
+
+Derives one activity-aware workflow status across graph, execution, and job detail surfaces.

--- a/libs/client/workflows/src/components/job-graph/job-duration-format.ts
+++ b/libs/client/workflows/src/components/job-graph/job-duration-format.ts
@@ -1,5 +1,9 @@
 import {humanDuration} from '@shipfox/react-ui/utils';
-import type {JobDisplayDuration, JobExecutionTime} from '#core/workflow-run.js';
+import type {
+  JobDisplayDuration,
+  JobExecutionDisplayStatus,
+  JobExecutionTime,
+} from '#core/workflow-run.js';
 
 export function formatJobExecutionTimeLabel(time: JobExecutionTime): string {
   switch (time.state) {
@@ -16,6 +20,7 @@ export function formatJobExecutionTimeLabel(time: JobExecutionTime): string {
 
 export function formatJobDurationAccessibleLabel(
   duration: JobDisplayDuration | null,
+  displayStatus?: JobExecutionDisplayStatus,
 ): string | undefined {
   if (duration === null) return undefined;
 
@@ -24,7 +29,11 @@ export function formatJobDurationAccessibleLabel(
     case 'queue':
       return duration.state === 'live' ? `queueing ${label}` : `queued ${label}`;
     case 'run':
-      return duration.state === 'live' ? `running ${label}` : `ran ${label}`;
+      if (duration.state !== 'live') return `ran ${label}`;
+      if (displayStatus === 'running') return `running ${label}`;
+      return displayStatus === 'pending'
+        ? `runner assigned ${label}`
+        : `execution elapsed ${label}`;
     default: {
       const exhaustive: never = duration;
       return exhaustive;

--- a/libs/client/workflows/src/components/job-graph/job-graph-view.test.tsx
+++ b/libs/client/workflows/src/components/job-graph/job-graph-view.test.tsx
@@ -6,6 +6,7 @@ import {
   workflowJob,
   workflowJobExecutionDto,
   workflowRunDetail,
+  workflowStepDto,
 } from '#test/fixtures/workflow-run.js';
 import {JobGraph} from './job-graph.js';
 
@@ -46,10 +47,7 @@ describe('JobGraph', () => {
     render(
       <JobGraph
         run={makeRun({
-          jobs: [
-            makeJob({name: 'linux', status: 'running'}),
-            makeJob({name: 'macos', status: 'running', position: 1}),
-          ],
+          jobs: [makeRunningJob({name: 'linux'}), makeRunningJob({name: 'macos', position: 1})],
         })}
       />,
     );
@@ -99,7 +97,7 @@ describe('JobGraph', () => {
         run={makeRun({
           jobs: [
             makeJob({name: 'build'}),
-            makeJob({name: 'deploy', position: 1, dependencies: ['build'], status: 'running'}),
+            makeRunningJob({name: 'deploy', position: 1, dependencies: ['build']}),
           ],
         })}
       />,
@@ -161,7 +159,7 @@ describe('JobGraph', () => {
       />,
     );
 
-    const build = screen.getByRole('button', {name: 'build, Pending, 2 executions'});
+    const build = screen.getByRole('button', {name: 'build, Succeeded, 2 executions'});
     const deploy = screen.getByRole('button', {name: 'deploy, Pending'});
     expect(within(build).getByText('2')).toBeInTheDocument();
     expect(within(build).queryByText('2 exec')).not.toBeInTheDocument();
@@ -224,7 +222,7 @@ describe('JobGraph', () => {
       dependencies: ['build'],
       status: 'succeeded',
     });
-    const testJob = makeJob({
+    const testJob = makeRunningJob({
       name: 'test',
       position: 2,
       dependencies: ['build'],
@@ -257,7 +255,7 @@ describe('JobGraph', () => {
   test('routes skipped-column join edges away from intermediate nodes', () => {
     const packageJob = makeJob({name: 'package', position: 0, status: 'succeeded'});
     const securityScan = makeJob({name: 'security-scan', position: 1, status: 'succeeded'});
-    const smokeTests = makeJob({
+    const smokeTests = makeRunningJob({
       name: 'smoke-tests',
       position: 2,
       dependencies: ['package'],
@@ -295,4 +293,17 @@ function makeRun(overrides: Partial<WorkflowRunDetail> = {}): WorkflowRunDetail 
 
 function makeJob(overrides: Partial<WorkflowRunJobDetailDto> & {name: string}): Job {
   return workflowJob(overrides);
+}
+
+function makeRunningJob(overrides: Partial<WorkflowRunJobDetailDto> & {name: string}): Job {
+  return makeJob({
+    ...overrides,
+    status: 'running',
+    job_executions: [
+      workflowJobExecutionDto({
+        status: 'running',
+        steps: [workflowStepDto({status: 'running'})],
+      }),
+    ],
+  });
 }

--- a/libs/client/workflows/src/components/job-graph/job-graph.stories.tsx
+++ b/libs/client/workflows/src/components/job-graph/job-graph.stories.tsx
@@ -2,7 +2,7 @@ import type {WorkflowRunJobDetailDto} from '@shipfox/api-workflows-dto';
 import type {Meta, StoryObj} from '@storybook/react';
 import {within} from 'storybook/test';
 import type {Job, WorkflowRunDetail} from '#core/workflow-run.js';
-import {workflowJob, workflowRunDetail} from '#test/fixtures/workflow-run.js';
+import {workflowJob, workflowRunDetail, workflowStepDto} from '#test/fixtures/workflow-run.js';
 import {JobGraph} from './job-graph.js';
 
 const meta = {
@@ -178,5 +178,9 @@ function makeRun(overrides: Partial<WorkflowRunDetail> = {}): WorkflowRunDetail 
 }
 
 function makeJob(overrides: Partial<WorkflowRunJobDetailDto> & {name: string}): Job {
-  return workflowJob(overrides);
+  const job = workflowJob(overrides);
+  if (overrides.status === 'running' && job.jobExecutions.length === 0) {
+    return workflowJob({...overrides, steps: [workflowStepDto({status: 'running'})]});
+  }
+  return job;
 }

--- a/libs/client/workflows/src/components/job-graph/job-graph.stories.tsx
+++ b/libs/client/workflows/src/components/job-graph/job-graph.stories.tsx
@@ -93,6 +93,23 @@ export const Empty: Story = {
   args: {run: makeRun({jobs: []})},
 };
 
+export const LargeWideAndTall: Story = {
+  args: {
+    run: makeRun({
+      jobs: [
+        ...linearJobs(10),
+        ...Array.from({length: 10}, (_, index) =>
+          makeJob({
+            name: `parallel-${String(index + 1).padStart(2, '0')}`,
+            position: 20 + index,
+            status: index < 2 ? 'running' : 'pending',
+          }),
+        ),
+      ],
+    }),
+  },
+};
+
 export const Selected: Story = {
   args: {
     run: makeRun({
@@ -108,23 +125,6 @@ export const Selected: Story = {
         name: 'deploy, Running',
       })
       .click();
-  },
-};
-
-export const LargeWideAndTall: Story = {
-  args: {
-    run: makeRun({
-      jobs: [
-        ...linearJobs(10),
-        ...Array.from({length: 10}, (_, index) =>
-          makeJob({
-            name: `parallel-${String(index + 1).padStart(2, '0')}`,
-            position: 20 + index,
-            status: index < 2 ? 'running' : 'pending',
-          }),
-        ),
-      ],
-    }),
   },
 };
 

--- a/libs/client/workflows/src/components/job-graph/job-node.stories.tsx
+++ b/libs/client/workflows/src/components/job-graph/job-node.stories.tsx
@@ -2,7 +2,11 @@ import type {WorkflowRunJobDetailDto} from '@shipfox/api-workflows-dto';
 import type {Meta, StoryObj} from '@storybook/react';
 import type {KeyboardEventHandler} from 'react';
 import type {JobExecutionStatus, JobStatus} from '#core/workflow-run.js';
-import {workflowJob, workflowJobExecutionDto} from '#test/fixtures/workflow-run.js';
+import {
+  workflowJob,
+  workflowJobExecutionDto,
+  workflowStepDto,
+} from '#test/fixtures/workflow-run.js';
 import type {JobGraphNode} from './graph-model.js';
 import {JobNode} from './job-node.js';
 
@@ -330,6 +334,7 @@ function makeNode({
             queued_at: queuedAt,
             started_at: startedAt,
             finished_at: finishedAt,
+            ...(status === 'running' ? {steps: [workflowStepDto({status: 'running'})]} : {}),
           }),
         ]
       : jobExecutions,
@@ -359,6 +364,6 @@ function makeExecutionsByStatus(
     timed_out_at: null,
     created_at: '2026-06-26T11:54:00.000Z',
     updated_at: '2026-06-26T12:00:00.000Z',
-    steps: [],
+    steps: status === 'running' ? [workflowStepDto({status: 'running'})] : [],
   }));
 }

--- a/libs/client/workflows/src/components/job-graph/job-node.stories.tsx
+++ b/libs/client/workflows/src/components/job-graph/job-node.stories.tsx
@@ -187,7 +187,7 @@ export const ListeningProgression: Story = {
       <JobNode
         node={makeNode({
           id: 'job-listening-running',
-          label: 'running, 0 executions',
+          label: 'listening, 0 executions',
           mode: 'listening',
           status: 'running',
           listenerStatus: 'listening',
@@ -204,7 +204,7 @@ export const ListeningProgression: Story = {
       <JobNode
         node={makeNode({
           id: 'job-one-running-execution',
-          label: 'running, 1 running execution',
+          label: 'listening, 1 running execution',
           mode: 'listening',
           status: 'running',
           listenerStatus: 'listening',
@@ -221,7 +221,7 @@ export const ListeningProgression: Story = {
       <JobNode
         node={makeNode({
           id: 'job-mixed-executions',
-          label: 'running, mixed executions',
+          label: 'listening, mixed executions',
           mode: 'listening',
           status: 'running',
           listenerStatus: 'listening',

--- a/libs/client/workflows/src/components/job-graph/job-node.test.tsx
+++ b/libs/client/workflows/src/components/job-graph/job-node.test.tsx
@@ -2,7 +2,11 @@ import type {WorkflowRunJobDetailDto} from '@shipfox/api-workflows-dto';
 import {TimeTickerProvider} from '@shipfox/react-ui/time-ticker';
 import {act, render, screen, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {workflowJob, workflowJobExecutionDto} from '#test/fixtures/workflow-run.js';
+import {
+  workflowJob,
+  workflowJobExecutionDto,
+  workflowStepDto,
+} from '#test/fixtures/workflow-run.js';
 import type {JobGraphNode} from './graph-model.js';
 import {JobNode} from './job-node.js';
 
@@ -32,6 +36,9 @@ function makeNode(overrides: NodeOverrides): JobGraphNode {
         queued_at: queued_at ?? null,
         started_at: started_at ?? null,
         finished_at: finished_at ?? null,
+        ...(jobOverrides.status === 'running'
+          ? {steps: [workflowStepDto({status: 'running'})]}
+          : {}),
       }),
     ];
   } else if (job_executions !== undefined) {
@@ -200,7 +207,7 @@ describe('JobNode duration', () => {
     renderNode(node);
 
     expect(screen.queryByText('2m 14s')).not.toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'deploy-window, Running'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'deploy-window, Listening'})).toBeInTheDocument();
   });
 });
 
@@ -227,12 +234,12 @@ describe('JobNode listening indicator', () => {
 
     renderNode(node);
 
-    expect(screen.getByRole('button', {name: 'deploy-window, Running'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'deploy-window, Listening'})).toBeInTheDocument();
     expect(screen.queryByLabelText('Waiting for events to start job')).not.toBeInTheDocument();
 
-    await user.hover(screen.getByRole('img', {name: 'Running'}));
+    await user.hover(screen.getByRole('img', {name: 'Listening'}));
 
-    expect(await screen.findByRole('tooltip')).toHaveTextContent('Running');
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('Listening');
   });
 
   test('does not show the listener icon before the listener is armed or after it resolves', () => {
@@ -277,6 +284,12 @@ describe('JobNode status indicator', () => {
     const node = makeNode({
       name: 'deploy',
       status: 'running',
+      job_executions: [
+        workflowJobExecutionDto({
+          status: 'running',
+          steps: [workflowStepDto({status: 'running'})],
+        }),
+      ],
     });
 
     renderNode(node);
@@ -286,11 +299,28 @@ describe('JobNode status indicator', () => {
     expect(await screen.findByRole('tooltip')).toHaveTextContent('Running');
   });
 
-  test('shows a running execution as running while the job is still pending', () => {
+  test('shows a running lifecycle without a running step as pending', () => {
     const node = makeNode({
       name: 'deploy',
       status: 'pending',
       job_executions: [workflowJobExecutionDto({status: 'running'})],
+    });
+
+    renderNode(node);
+
+    expect(screen.getByRole('button', {name: 'deploy, Pending'})).toBeInTheDocument();
+  });
+
+  test('shows a pending lifecycle as running while a step is active', () => {
+    const node = makeNode({
+      name: 'deploy',
+      status: 'pending',
+      job_executions: [
+        workflowJobExecutionDto({
+          status: 'pending',
+          steps: [workflowStepDto({status: 'running'})],
+        }),
+      ],
     });
 
     renderNode(node);
@@ -317,10 +347,17 @@ describe('JobNode execution count indicator', () => {
       name: 'release-gates',
       mode: 'listening',
       status: 'running',
+      listener_status: 'listening',
       job_executions: [
         workflowJobExecutionDto({status: 'pending'}),
-        workflowJobExecutionDto({status: 'running'}),
-        workflowJobExecutionDto({status: 'running'}),
+        workflowJobExecutionDto({
+          status: 'running',
+          steps: [workflowStepDto({status: 'running'})],
+        }),
+        workflowJobExecutionDto({
+          status: 'running',
+          steps: [workflowStepDto({status: 'running'})],
+        }),
         workflowJobExecutionDto({status: 'succeeded'}),
         workflowJobExecutionDto({status: 'succeeded'}),
         workflowJobExecutionDto({status: 'succeeded'}),
@@ -331,7 +368,7 @@ describe('JobNode execution count indicator', () => {
 
     renderNode(node);
 
-    const button = screen.getByRole('button', {name: 'release-gates, Running, 8 executions'});
+    const button = screen.getByRole('button', {name: 'release-gates, Listening, 8 executions'});
     expect(within(button).getByText('8')).toBeInTheDocument();
     expect(within(button).queryByText('8 exec')).not.toBeInTheDocument();
     expect(button.querySelector('[data-execution-status-segment]')).not.toBeInTheDocument();

--- a/libs/client/workflows/src/components/job-graph/job-node.tsx
+++ b/libs/client/workflows/src/components/job-graph/job-node.tsx
@@ -9,7 +9,14 @@ import {cn} from '@shipfox/react-ui/utils';
 import type {KeyboardEventHandler, Ref} from 'react';
 import {getWorkflowStatusVisual} from '#components/workflow-status/status-visuals.js';
 import {WorkflowStatusIcon} from '#components/workflow-status/workflow-status-icon.js';
-import type {JobExecution, JobExecutionStatus, WorkflowRunDetail} from '#core/workflow-run.js';
+import {
+  defaultJobExecution,
+  deriveJobDisplayStatus,
+  deriveJobExecutionDisplayStatus,
+  type JobExecution,
+  type JobExecutionStatus,
+  type WorkflowRunDetail,
+} from '#core/workflow-run.js';
 import type {JobGraphNode} from './graph-model.js';
 import {formatJobDurationAccessibleLabel} from './job-duration-format.js';
 import {JobDurationLabel} from './job-duration-label.js';
@@ -69,16 +76,16 @@ export function JobNode({
   ref?: Ref<HTMLButtonElement>;
 }) {
   useTimeTick();
-  const status =
-    node.status === 'pending' &&
-    node.jobExecutions.some((jobExecution) => jobExecution.status === 'running')
-      ? 'running'
-      : node.status;
+  const status = deriveJobDisplayStatus(node);
+  const execution = defaultJobExecution(node);
   const visual = getWorkflowStatusVisual(status);
   const accessibleLabel = [
     node.displayName,
     visual.label,
-    formatJobDurationAccessibleLabel(node.displayDuration),
+    formatJobDurationAccessibleLabel(
+      node.displayDuration,
+      execution ? deriveJobExecutionDisplayStatus(execution) : undefined,
+    ),
     node.executionCountVisible
       ? executionCountAccessibleLabel(node.jobExecutions.length)
       : undefined,
@@ -199,7 +206,7 @@ const EXECUTION_STATUSES = [
 function executionStatusCounts(executions: JobExecution[]) {
   return executions.reduce(
     (counts, execution) => {
-      counts[execution.status] += 1;
+      counts[deriveJobExecutionDisplayStatus(execution)] += 1;
       return counts;
     },
     {pending: 0, running: 0, succeeded: 0, failed: 0, cancelled: 0},

--- a/libs/client/workflows/src/components/job-graph/job-node.tsx
+++ b/libs/client/workflows/src/components/job-graph/job-node.tsx
@@ -118,7 +118,7 @@ export function JobNode({
         />
       ) : null}
       <div className="flex min-w-0 flex-1 items-center gap-8">
-        <WorkflowStatusIcon status={status} jobMode={node.mode} size={14} />
+        <WorkflowStatusIcon status={status} size={14} />
         <JobLabel label={node.displayName} />
       </div>
       <JobDurationLabel duration={node.displayDuration} />

--- a/libs/client/workflows/src/components/step-list/step-list.tsx
+++ b/libs/client/workflows/src/components/step-list/step-list.tsx
@@ -18,6 +18,7 @@ import {WorkflowStatusIcon} from '#components/workflow-status/workflow-status-ic
 import {
   isWorkflowStatus,
   type Job,
+  type JobDisplayStatus,
   type JobExecution,
   type Step,
   type StepSourceLocation,
@@ -47,7 +48,7 @@ export interface StepExpandedContext {
 export interface StepListEmptyState {
   title: string;
   description: string;
-  status?: Job['status'] | undefined;
+  status?: JobDisplayStatus | undefined;
 }
 
 export interface StepListProps {
@@ -267,7 +268,7 @@ function StepListEmptyStateView({
   );
 }
 
-function StepListEmptyStateIcon({status}: {status: Job['status']}) {
+function StepListEmptyStateIcon({status}: {status: JobDisplayStatus}) {
   if (status !== 'running') {
     return (
       <div className="flex size-32 items-center justify-center rounded-6 border border-border-neutral-strong bg-background-neutral-base p-8">

--- a/libs/client/workflows/src/components/workflow-run-view/job-card.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/job-card.stories.tsx
@@ -126,13 +126,13 @@ export const ListeningProgression: Story = {
       <StorySection label="pending, no executions">
         <JobCardStory job={listeningJobPending()} />
       </StorySection>
-      <StorySection label="running, 0 executions">
+      <StorySection label="listening, 0 executions">
         <JobCardStory job={listeningJobNoExecutions()} />
       </StorySection>
-      <StorySection label="running, 1 running execution">
+      <StorySection label="listening, 1 running execution">
         <JobCardStory job={listeningJobOneExecution()} initialJobExecutionId="exec-listen-one-1" />
       </StorySection>
-      <StorySection label="running, mixed executions">
+      <StorySection label="listening, mixed executions">
         <JobCardStory job={listeningJobMixedExecutions()} initialJobExecutionId="exec-listen-6" />
       </StorySection>
       <StorySection label="failed, resolved">
@@ -145,19 +145,19 @@ export const ListeningProgression: Story = {
 export const ManyExecutions: Story = {
   render: () => (
     <div className="flex flex-col gap-16">
-      <StorySection label="running, 64 executions, short name">
+      <StorySection label="listening, 64 executions, short name">
         <JobCardStory
           job={manyExecutionsListeningJob('gate', 'job-many-short')}
           initialJobExecutionId="exec-many-job-many-short-64"
         />
       </StorySection>
-      <StorySection label="running, 64 executions, medium name">
+      <StorySection label="listening, 64 executions, medium name">
         <JobCardStory
           job={manyExecutionsListeningJob('release-gates', 'job-many-medium')}
           initialJobExecutionId="exec-many-job-many-medium-64"
         />
       </StorySection>
-      <StorySection label="running, 64 executions, long name">
+      <StorySection label="listening, 64 executions, long name">
         <JobCardStory
           job={manyExecutionsListeningJob(
             'release-production-multi-region-with-canary-validation',

--- a/libs/client/workflows/src/components/workflow-run-view/job-card.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/job-card.tsx
@@ -12,7 +12,11 @@ import {Fragment, useId, useRef, useState} from 'react';
 import {getWorkflowStatusVisual} from '#components/workflow-status/status-visuals.js';
 import {
   AGENT_CONFIG_ISSUES,
+  defaultJobExecution,
+  deriveJobDisplayStatus,
+  deriveJobExecutionDisplayStatus,
   type Job,
+  type JobDisplayStatus,
   type JobExecution,
   type JobExecutionTime,
   STEP_ERROR_REASONS,
@@ -30,7 +34,9 @@ import {formatJobExecutionTime, JobExecutionTimeText} from './job-execution-time
 import {StepAttemptLogPanel} from './step-attempt-log-panel.js';
 
 const STATUS_BADGE_LABEL_WIDTH_CH = Math.max(
-  ...WORKFLOW_JOB_STATUSES.map((status) => getWorkflowStatusVisual(status).label.length),
+  ...[...WORKFLOW_JOB_STATUSES, 'listening' as const].map(
+    (status) => getWorkflowStatusVisual(status).label.length,
+  ),
 );
 
 interface LocalSelectedAttempt {
@@ -72,7 +78,11 @@ export function JobCard({
     attemptId: null,
   });
   const title = selectedJobExecution?.name ?? job.displayName;
-  const selectedExecutionStatus = selectedJobExecution?.status ?? job.status;
+  const isNonDefaultExecutionSelected =
+    selectedJobExecution !== undefined && selectedJobExecution.id !== defaultJobExecution(job)?.id;
+  const selectedExecutionStatus = isNonDefaultExecutionSelected
+    ? deriveJobExecutionDisplayStatus(selectedJobExecution)
+    : deriveJobDisplayStatus(job);
   const effectiveSelectedAttemptId =
     selectedAttemptId === undefined &&
     localSelectedAttempt.jobExecutionId === selectedJobExecution?.id
@@ -197,7 +207,7 @@ export function JobCard({
   );
 }
 
-function JobStatusBadge({status}: {status: Job['status'] | JobExecution['status']}) {
+function JobStatusBadge({status}: {status: JobDisplayStatus}) {
   const visual = getWorkflowStatusVisual(status);
 
   return (
@@ -253,7 +263,12 @@ function JobExecutionMetadata({execution}: {execution: JobExecution | undefined}
           ) : item.kind === 'trigger' ? (
             <JobExecutionTriggerMetadata execution={execution} />
           ) : (
-            <JobExecutionMetadataItem icon={item.icon} kind={item.kind} time={item.time} />
+            <JobExecutionMetadataItem
+              icon={item.icon}
+              kind={item.kind}
+              time={item.time}
+              displayStatus={deriveJobExecutionDisplayStatus(execution)}
+            />
           )}
         </Fragment>
       ))}
@@ -310,14 +325,16 @@ function JobExecutionMetadataItem({
   icon,
   kind,
   time,
+  displayStatus,
 }: {
   icon: 'hourglassLine' | 'timerLine';
   kind: 'queue' | 'run';
   time: JobExecutionTime;
+  displayStatus: JobExecution['status'];
 }) {
   useTimeTick();
 
-  const tooltip = `${jobExecutionTimeVerb(kind, time)} for ${formatJobExecutionTime(time)}`;
+  const tooltip = `${jobExecutionTimeVerb(kind, time, displayStatus)} for ${formatJobExecutionTime(time)}`;
 
   return (
     <Tooltip>
@@ -342,9 +359,15 @@ function JobExecutionMetadataItem({
   );
 }
 
-function jobExecutionTimeVerb(kind: 'queue' | 'run', time: JobExecutionTime): string {
-  if (kind === 'queue') return time.state === 'live' ? 'Queuing' : 'Queued';
-  return time.state === 'live' ? 'Running' : 'Ran';
+function jobExecutionTimeVerb(
+  kind: 'queue' | 'run',
+  time: JobExecutionTime,
+  displayStatus: JobExecution['status'],
+): string {
+  if (kind === 'queue') return time.state === 'live' ? 'Queueing' : 'Queued';
+  if (time.state !== 'live') return 'Ran';
+  if (displayStatus === 'running') return 'Running';
+  return displayStatus === 'pending' ? 'Runner assigned' : 'Execution elapsed';
 }
 
 function MetadataSeparator() {
@@ -450,35 +473,48 @@ function emptyStateForJob(job: Job, jobExecution: JobExecution): StepListEmptySt
     };
   }
 
-  if (jobExecution.status === 'pending') {
+  const displayStatus =
+    job.mode === 'listening'
+      ? deriveJobExecutionDisplayStatus(jobExecution)
+      : deriveJobDisplayStatus(job);
+
+  if (jobExecution.status === 'running' && displayStatus === 'pending') {
+    return {
+      title: 'Runner preparing job',
+      description: 'A runner is assigned. Steps will appear here when work begins.',
+      status: displayStatus,
+    };
+  }
+
+  if (displayStatus === 'pending') {
     return {
       title: 'Waiting for this job to start',
       description: 'Steps will appear here once the job starts.',
-      status: jobExecution.status,
+      status: displayStatus,
     };
   }
 
-  if (jobExecution.status === 'running') {
+  if (displayStatus === 'running') {
     return {
       title: 'Waiting for the first step',
-      description: 'This job is running, but no steps have started yet.',
-      status: jobExecution.status,
+      description: 'The first running step will appear here shortly.',
+      status: displayStatus,
     };
   }
 
-  if (jobExecution.status === 'cancelled') {
+  if (displayStatus === 'cancelled') {
     return {
       title: 'Cancelled before start',
       description: 'This job was cancelled before any step started.',
-      status: jobExecution.status,
+      status: displayStatus,
     };
   }
 
-  if (jobExecution.status === 'succeeded' || jobExecution.status === 'failed') {
+  if (displayStatus === 'succeeded' || displayStatus === 'failed') {
     return {
       title: 'No steps recorded',
       description: `Execution #${jobExecution.sequence} finished without recorded steps.`,
-      status: jobExecution.status,
+      status: displayStatus,
     };
   }
 
@@ -498,7 +534,7 @@ function emptyStateForMissingExecution(job: Job): StepListEmptyState {
     return {
       title: 'Waiting for trigger events',
       description: 'Matching trigger events will create job executions here.',
-      status: 'running',
+      status: deriveJobDisplayStatus(job),
     };
   }
 

--- a/libs/client/workflows/src/components/workflow-run-view/job-execution-switcher.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/job-execution-switcher.tsx
@@ -10,7 +10,7 @@ import {Text} from '@shipfox/react-ui/typography';
 import {cn} from '@shipfox/react-ui/utils';
 import {useMemo} from 'react';
 import {WorkflowStatusIcon} from '#components/workflow-status/workflow-status-icon.js';
-import type {Job, JobExecution} from '#core/workflow-run.js';
+import {deriveJobExecutionDisplayStatus, type Job, type JobExecution} from '#core/workflow-run.js';
 import {JobExecutionTimeText} from './job-execution-time-text.js';
 
 export interface JobExecutionSwitcherProps {
@@ -89,7 +89,11 @@ export function JobExecutionSwitcher({
                 aria-current={isSelected ? 'true' : undefined}
                 className="w-full text-left"
               >
-                <WorkflowStatusIcon status={jobExecution.status} size={14} tooltip={false} />
+                <WorkflowStatusIcon
+                  status={deriveJobExecutionDisplayStatus(jobExecution)}
+                  size={14}
+                  tooltip={false}
+                />
                 <span className="font-code text-xs leading-20 text-foreground-neutral-base tabular-nums">
                   #{jobExecution.sequence}
                 </span>
@@ -133,9 +137,11 @@ function TitleExecutionSummary({execution}: {execution: JobExecution}) {
 }
 
 function ExecutionSummary({execution}: {execution: JobExecution}) {
+  const displayStatus = deriveJobExecutionDisplayStatus(execution);
+
   return (
     <span className="flex min-w-0 items-center gap-6">
-      <WorkflowStatusIcon status={execution.status} size={14} tooltip={false} />
+      <WorkflowStatusIcon status={displayStatus} size={14} tooltip={false} />
       <span className="shrink-0 font-code text-xs leading-20 text-foreground-neutral-base tabular-nums">
         Execution #{execution.sequence}
       </span>

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -451,7 +451,7 @@ describe('WorkflowRunView', () => {
     expect(screen.queryByText('No steps recorded')).not.toBeInTheDocument();
   });
 
-  test('uses the selected execution status for zero-step execution states', async () => {
+  test('keeps a terminal job status over inconsistent zero-step execution activity', async () => {
     configureApiClient({
       fetchImpl: vi.fn(() =>
         Promise.resolve(
@@ -483,11 +483,9 @@ describe('WorkflowRunView', () => {
 
     renderView();
 
-    expect(await screen.findByText('Waiting for the first step')).toBeInTheDocument();
-    expect(
-      screen.getByText('This job is running, but no steps have started yet.'),
-    ).toBeInTheDocument();
-    expect(screen.queryByText('No steps recorded')).not.toBeInTheDocument();
+    expect(await screen.findByText('No steps recorded')).toBeInTheDocument();
+    expect(screen.getByText('Execution #2 finished without recorded steps.')).toBeInTheDocument();
+    expect(screen.queryByText('Waiting for the first step')).not.toBeInTheDocument();
   });
 
   test('renders pending zero-step jobs as waiting to start', async () => {
@@ -518,7 +516,7 @@ describe('WorkflowRunView', () => {
     expect(screen.queryByText('No steps recorded')).not.toBeInTheDocument();
   });
 
-  test('renders running zero-step jobs as waiting for the first step', async () => {
+  test('renders claimed idle jobs as runner preparation', async () => {
     configureApiClient({
       fetchImpl: vi.fn(() =>
         Promise.resolve(
@@ -547,10 +545,13 @@ describe('WorkflowRunView', () => {
 
     renderView();
 
-    expect(await screen.findByText('Waiting for the first step')).toBeInTheDocument();
+    expect(await screen.findByText('Runner preparing job')).toBeInTheDocument();
     expect(
-      screen.getByText('This job is running, but no steps have started yet.'),
+      screen.getByText('A runner is assigned. Steps will appear here when work begins.'),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByText('This job is running, but no steps have started yet.'),
+    ).not.toBeInTheDocument();
     expect(screen.queryByText('No steps recorded')).not.toBeInTheDocument();
   });
 
@@ -1245,6 +1246,14 @@ function workflowRunViewDetailDto(
         status: 'running',
         position: 1,
         dependencies: ['build'],
+        job_executions: [
+          workflowJobExecutionDto({
+            job_id: DEPLOY_JOB_ID,
+            name: 'deploy',
+            status: 'running',
+            steps: [workflowStepDto({status: 'running'})],
+          }),
+        ],
       }),
     ],
     ...overrides,

--- a/libs/client/workflows/src/components/workflow-status/status-visuals.test.ts
+++ b/libs/client/workflows/src/components/workflow-status/status-visuals.test.ts
@@ -35,4 +35,13 @@ describe('getWorkflowStatusVisual', () => {
 
     expect(visual).toEqual({kind: 'running', label: 'Running', dot: 'info', badge: 'info'});
   });
+
+  test('returns the active listener visual', () => {
+    expect(getWorkflowStatusVisual('listening')).toEqual({
+      kind: 'listening',
+      label: 'Listening',
+      dot: 'info',
+      badge: 'info',
+    });
+  });
 });

--- a/libs/client/workflows/src/components/workflow-status/status-visuals.ts
+++ b/libs/client/workflows/src/components/workflow-status/status-visuals.ts
@@ -1,11 +1,11 @@
 import type {BadgeVariant} from '@shipfox/react-ui/badge';
 import type {DotVariant} from '@shipfox/react-ui/dot';
-import type {WorkflowStatus} from '#core/workflow-run.js';
+import type {WorkflowDisplayStatus} from '#core/workflow-run.js';
 
-export type {WorkflowStatus};
+export type {WorkflowDisplayStatus};
 
 export interface WorkflowStatusVisual {
-  kind: WorkflowStatus;
+  kind: WorkflowDisplayStatus;
   label: string;
   dot: DotVariant;
   badge: BadgeVariant;
@@ -15,12 +15,14 @@ export interface WorkflowStatusVisual {
 // WorkflowStatusIcon (which renders the glyph per kind). The exhaustive switch turns any new
 // status the API grows into (DESIGN.md section 9) into a compile error; reserve the `warning`
 // tone for the queued/awaiting-* states when they land.
-export function getWorkflowStatusVisual(status: WorkflowStatus): WorkflowStatusVisual {
+export function getWorkflowStatusVisual(status: WorkflowDisplayStatus): WorkflowStatusVisual {
   switch (status) {
     case 'pending':
       return {kind: 'pending', label: 'Pending', dot: 'neutral', badge: 'neutral'};
     case 'running':
       return {kind: 'running', label: 'Running', dot: 'info', badge: 'info'};
+    case 'listening':
+      return {kind: 'listening', label: 'Listening', dot: 'info', badge: 'info'};
     case 'succeeded':
       return {kind: 'succeeded', label: 'Succeeded', dot: 'success', badge: 'success'};
     case 'failed':

--- a/libs/client/workflows/src/components/workflow-status/workflow-status-icon.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-status/workflow-status-icon.stories.tsx
@@ -1,10 +1,18 @@
 import {Code, Text} from '@shipfox/react-ui/typography';
 import type {Meta, StoryObj} from '@storybook/react';
-import type {JobStatus} from '#core/workflow-run.js';
+import type {WorkflowDisplayStatus} from '#core/workflow-run.js';
 import {getWorkflowStatusVisual} from './status-visuals.js';
 import {WorkflowStatusIcon} from './workflow-status-icon.js';
 
-const statuses: JobStatus[] = ['pending', 'running', 'succeeded', 'failed', 'cancelled', 'skipped'];
+const statuses: WorkflowDisplayStatus[] = [
+  'pending',
+  'running',
+  'listening',
+  'succeeded',
+  'failed',
+  'cancelled',
+  'skipped',
+];
 
 const meta = {
   title: 'Workflows/StatusIcon',

--- a/libs/client/workflows/src/components/workflow-status/workflow-status-icon.test.tsx
+++ b/libs/client/workflows/src/components/workflow-status/workflow-status-icon.test.tsx
@@ -1,0 +1,18 @@
+import {render, screen} from '@testing-library/react';
+import {WorkflowStatusIcon} from './workflow-status-icon.js';
+
+describe('WorkflowStatusIcon', () => {
+  test('keeps a running status as a dot', () => {
+    const {container} = render(<WorkflowStatusIcon status="running" tooltip={false} />);
+
+    expect(screen.getByRole('img', {name: 'Running'})).toBeInTheDocument();
+    expect(container.querySelector('svg')).toBeNull();
+  });
+
+  test('uses the pulse glyph for the listening status', () => {
+    const {container} = render(<WorkflowStatusIcon status="listening" tooltip={false} />);
+
+    expect(screen.getByRole('img', {name: 'Listening'})).toBeInTheDocument();
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+});

--- a/libs/client/workflows/src/components/workflow-status/workflow-status-icon.tsx
+++ b/libs/client/workflows/src/components/workflow-status/workflow-status-icon.tsx
@@ -3,7 +3,7 @@ import {Icon, type IconName} from '@shipfox/react-ui/icon';
 import {Tooltip, TooltipContent, TooltipTrigger} from '@shipfox/react-ui/tooltip';
 import {cn} from '@shipfox/react-ui/utils';
 import type {ReactNode} from 'react';
-import {getWorkflowStatusVisual, type WorkflowStatus} from './status-visuals.js';
+import {getWorkflowStatusVisual, type WorkflowDisplayStatus} from './status-visuals.js';
 
 // Status glyphs use the same saturated accent tokens as IconBadge/StatusBadge.
 const toneByVariant: Record<DotVariant, string> = {
@@ -17,7 +17,7 @@ const toneByVariant: Record<DotVariant, string> = {
 
 // Terminal states are self-contained solid discs; the shape names the state. Running and
 // pending render their own shapes (the live Dot and a bold ring), so they aren't here.
-const glyphByKind: Partial<Record<WorkflowStatus, IconName>> = {
+const glyphByKind: Partial<Record<WorkflowDisplayStatus, IconName>> = {
   succeeded: 'checkCircleSolid',
   failed: 'xCircleSolid',
   cancelled: 'forbid2Fill',
@@ -45,7 +45,7 @@ const dotSizeClass: Record<number, string> = {
 const PENDING_RING_MASK = 'radial-gradient(circle closest-side, transparent 0 52%, #000 56%)';
 
 export interface WorkflowStatusIconProps {
-  status: WorkflowStatus;
+  status: WorkflowDisplayStatus;
   jobMode?: 'one_shot' | 'listening';
   /** Optical diameter in px: 14 in the DAG node and run row. */
   size?: number;
@@ -76,25 +76,20 @@ export function WorkflowStatusIcon({
   const box = dotSizeClass[size] ?? 'size-14';
 
   let glyph: ReactNode;
-  if (visual.kind === 'running') {
-    glyph =
-      jobMode === 'listening' ? (
-        <span
-          className={cn(
-            'inline-flex shrink-0 items-center justify-center rounded-full bg-current',
-            box,
-            toneByVariant.info,
-          )}
-        >
-          <Icon
-            name="pulseLine"
-            size={Math.max(8, Math.round(size * 0.7))}
-            className="text-white"
-          />
-        </span>
-      ) : (
-        <Dot variant="info" ripple={ripple} className={box} />
-      );
+  if (visual.kind === 'listening' || (visual.kind === 'running' && jobMode === 'listening')) {
+    glyph = (
+      <span
+        className={cn(
+          'inline-flex shrink-0 items-center justify-center rounded-full bg-current',
+          box,
+          toneByVariant.info,
+        )}
+      >
+        <Icon name="pulseLine" size={Math.max(8, Math.round(size * 0.7))} className="text-white" />
+      </span>
+    );
+  } else if (visual.kind === 'running') {
+    glyph = <Dot variant="info" ripple={ripple} className={box} />;
   } else if (visual.kind === 'pending') {
     glyph = (
       <span

--- a/libs/client/workflows/src/components/workflow-status/workflow-status-icon.tsx
+++ b/libs/client/workflows/src/components/workflow-status/workflow-status-icon.tsx
@@ -46,7 +46,6 @@ const PENDING_RING_MASK = 'radial-gradient(circle closest-side, transparent 0 52
 
 export interface WorkflowStatusIconProps {
   status: WorkflowDisplayStatus;
-  jobMode?: 'one_shot' | 'listening';
   /** Optical diameter in px: 14 in the DAG node and run row. */
   size?: number;
   /** Pulsing halo for the running state. */
@@ -66,7 +65,6 @@ export interface WorkflowStatusIconProps {
  */
 export function WorkflowStatusIcon({
   status,
-  jobMode = 'one_shot',
   size = 14,
   ripple = true,
   tooltip = true,
@@ -76,7 +74,7 @@ export function WorkflowStatusIcon({
   const box = dotSizeClass[size] ?? 'size-14';
 
   let glyph: ReactNode;
-  if (visual.kind === 'listening' || (visual.kind === 'running' && jobMode === 'listening')) {
+  if (visual.kind === 'listening') {
     glyph = (
       <span
         className={cn(

--- a/libs/client/workflows/src/core/entities/job-execution.ts
+++ b/libs/client/workflows/src/core/entities/job-execution.ts
@@ -2,6 +2,7 @@ import {type Duration, intervalToDuration} from 'date-fns';
 import type {Step} from './step.js';
 
 export type JobExecutionStatus = 'pending' | 'running' | 'succeeded' | 'failed' | 'cancelled';
+export type JobExecutionDisplayStatus = JobExecutionStatus;
 export interface WorkflowExecutionEvent {
   source: string;
   event: string;
@@ -64,6 +65,19 @@ export class JobExecution {
   get displayDuration(): JobExecutionDisplayDuration | null {
     return jobExecutionDisplayDurationFromTimestamps(this);
   }
+}
+
+export function deriveJobExecutionDisplayStatus({
+  status,
+  steps,
+}: Pick<JobExecution, 'status' | 'steps'>): JobExecutionDisplayStatus {
+  if (isTerminalJobExecutionStatus(status)) return status;
+  if (steps.some((step) => step.status === 'running')) return 'running';
+  return 'pending';
+}
+
+export function isTerminalJobExecutionStatus(status: JobExecutionStatus): boolean {
+  return status === 'succeeded' || status === 'failed' || status === 'cancelled';
 }
 
 export function jobExecutionQueueTimeFromTimestamps({

--- a/libs/client/workflows/src/core/entities/job-status.test.ts
+++ b/libs/client/workflows/src/core/entities/job-status.test.ts
@@ -1,0 +1,104 @@
+import {deriveJobDisplayStatus, type JobDisplayStatus} from './job.js';
+import {deriveJobExecutionDisplayStatus, type JobExecutionStatus} from './job-execution.js';
+
+type DisplayStep = Parameters<typeof deriveJobExecutionDisplayStatus>[0]['steps'][number];
+
+function displayStep(status: string): DisplayStep {
+  return {status} as DisplayStep;
+}
+
+const EXECUTION_STATUSES = ['pending', 'running', 'succeeded', 'failed', 'cancelled'] as const;
+const TERMINAL_EXECUTION_STATUSES = ['succeeded', 'failed', 'cancelled'] as const;
+
+describe('deriveJobExecutionDisplayStatus', () => {
+  test.each(
+    EXECUTION_STATUSES,
+  )('%s without a running step displays Pending unless terminal', (status) => {
+    const displayStatus = deriveJobExecutionDisplayStatus({status, steps: []});
+
+    expect(displayStatus).toBe(
+      TERMINAL_EXECUTION_STATUSES.includes(status as (typeof TERMINAL_EXECUTION_STATUSES)[number])
+        ? status
+        : 'pending',
+    );
+  });
+
+  test.each([
+    'pending',
+    'running',
+  ] as const)('%s with a running step displays Running', (status) => {
+    expect(deriveJobExecutionDisplayStatus({status, steps: [displayStep('running')]})).toBe(
+      'running',
+    );
+  });
+
+  test.each(TERMINAL_EXECUTION_STATUSES)('%s wins over a running child step', (status) => {
+    expect(deriveJobExecutionDisplayStatus({status, steps: [displayStep('running')]})).toBe(status);
+  });
+});
+
+describe('deriveJobDisplayStatus', () => {
+  test('uses the execution activity for a one-shot job', () => {
+    const statuses: Array<[JobExecutionStatus, string[], JobDisplayStatus]> = [
+      ['pending', [], 'pending'],
+      ['pending', ['running'], 'running'],
+      ['running', [], 'pending'],
+      ['running', ['running'], 'running'],
+    ];
+
+    for (const [status, stepStatuses, expected] of statuses) {
+      expect(
+        deriveJobDisplayStatus({
+          mode: 'one_shot',
+          status: 'running',
+          listenerStatus: 'inactive',
+          jobExecutions: [
+            {
+              status,
+              steps: stepStatuses.map(displayStep),
+              sequence: 1,
+            },
+          ] as never,
+        }),
+      ).toBe(expected);
+    }
+  });
+
+  test.each([
+    'succeeded',
+    'failed',
+    'cancelled',
+    'skipped',
+  ] as const)('terminal job status %s wins over child activity', (status) => {
+    expect(
+      deriveJobDisplayStatus({
+        mode: 'one_shot',
+        status,
+        listenerStatus: 'inactive',
+        jobExecutions: [{status: 'running', steps: [{status: 'running'}], sequence: 1}] as never,
+      }),
+    ).toBe(status);
+  });
+
+  test('keeps an active listener as Listening without executions', () => {
+    expect(
+      deriveJobDisplayStatus({
+        mode: 'listening',
+        status: 'running',
+        listenerStatus: 'listening',
+        jobExecutions: [],
+      }),
+    ).toBe('listening');
+  });
+
+  test('uses the terminal job status when an active listener has resolved', () => {
+    expect(
+      deriveJobDisplayStatus({
+        mode: 'listening',
+        status: 'succeeded',
+        listenerStatus: 'listening',
+        jobExecutions: [],
+      }),
+    ).toBe('succeeded');
+  });
+});

--- a/libs/client/workflows/src/core/entities/job.ts
+++ b/libs/client/workflows/src/core/entities/job.ts
@@ -1,6 +1,11 @@
-import type {JobExecution, JobExecutionDisplayDuration} from './job-execution.js';
+import {
+  deriveJobExecutionDisplayStatus,
+  type JobExecution,
+  type JobExecutionDisplayDuration,
+} from './job-execution.js';
 
 export type JobStatus = 'pending' | 'running' | 'succeeded' | 'failed' | 'cancelled' | 'skipped';
+export type JobDisplayStatus = JobStatus | 'listening';
 export type JobMode = 'one_shot' | 'listening';
 export type ListenerStatus = 'inactive' | 'listening' | 'resolved';
 export type ResolutionReason = 'until' | 'timeout' | 'max_executions' | 'cancelled';
@@ -123,6 +128,16 @@ export function isTerminalJobStatus(status: JobStatus): boolean {
   return TERMINAL_JOB_STATUS_SET.has(status);
 }
 
+export function deriveJobDisplayStatus(
+  job: Pick<Job, 'mode' | 'status' | 'listenerStatus' | 'jobExecutions'>,
+): JobDisplayStatus {
+  if (isTerminalJobStatus(job.status)) return job.status;
+  if (job.mode === 'listening' && job.listenerStatus === 'listening') return 'listening';
+
+  const execution = defaultJobExecution(job);
+  return execution ? deriveJobExecutionDisplayStatus(execution) : 'pending';
+}
+
 export function resolveJobExecution(
   job: Job,
   jobExecutionId: string | undefined,
@@ -135,7 +150,7 @@ export function resolveJobExecution(
   return defaultJobExecution(job);
 }
 
-export function defaultJobExecution(job: Job): JobExecution | undefined {
+export function defaultJobExecution(job: Pick<Job, 'jobExecutions'>): JobExecution | undefined {
   const runningExecution = job.jobExecutions.find(
     (jobExecution) => jobExecution.status === 'running',
   );

--- a/libs/client/workflows/src/core/entities/workflow-run.ts
+++ b/libs/client/workflows/src/core/entities/workflow-run.ts
@@ -4,6 +4,7 @@ import type {WorkflowRunAttempt, WorkflowRunAttemptSummary} from './workflow-run
 export type WorkflowRunStatus = 'pending' | 'running' | 'succeeded' | 'failed' | 'cancelled';
 export type WorkflowRunRerunMode = 'all' | 'failed';
 export type WorkflowStatus = WorkflowRunStatus | (typeof WORKFLOW_JOB_STATUSES)[number];
+export type WorkflowDisplayStatus = WorkflowStatus | 'listening';
 
 export const WORKFLOW_RUN_STATUSES = [
   'pending',

--- a/libs/client/workflows/src/core/workflow-run.ts
+++ b/libs/client/workflows/src/core/workflow-run.ts
@@ -1,5 +1,6 @@
 export type {
   JobDisplayDuration,
+  JobDisplayStatus,
   JobListening,
   JobMode,
   JobStatus,
@@ -9,6 +10,7 @@ export type {
 } from './entities/job.js';
 export {
   defaultJobExecution,
+  deriveJobDisplayStatus,
   isTerminalJobStatus,
   Job,
   resolveJobExecution,
@@ -17,11 +19,16 @@ export {
 } from './entities/job.js';
 export type {
   JobExecutionDisplayDuration,
+  JobExecutionDisplayStatus,
   JobExecutionStatus,
   JobExecutionTime,
   WorkflowExecutionEvent,
 } from './entities/job-execution.js';
-export {JobExecution} from './entities/job-execution.js';
+export {
+  deriveJobExecutionDisplayStatus,
+  isTerminalJobExecutionStatus,
+  JobExecution,
+} from './entities/job-execution.js';
 export type {
   AgentConfigIssue,
   AgentStepConfig,
@@ -39,6 +46,7 @@ export type {
 export {StepAttempt} from './entities/step-attempt.js';
 export type {
   ManualWorkflowLaunch,
+  WorkflowDisplayStatus,
   WorkflowRun,
   WorkflowRunDetail,
   WorkflowRunListItem,

--- a/libs/client/workflows/src/index.ts
+++ b/libs/client/workflows/src/index.ts
@@ -1,7 +1,9 @@
 export type {
   AgentConfigIssue,
   JobDisplayDuration,
+  JobDisplayStatus,
   JobExecutionDisplayDuration,
+  JobExecutionDisplayStatus,
   JobExecutionStatus,
   JobExecutionTime,
   JobStatus,
@@ -14,6 +16,7 @@ export type {
   StepErrorReason,
   StepGateResult,
   StepSourceLocation,
+  WorkflowDisplayStatus,
   WorkflowRun,
   WorkflowRunAttempt,
   WorkflowRunDetail,
@@ -23,6 +26,8 @@ export type {
   WorkflowStatus,
 } from '#core/workflow-run.js';
 export {
+  deriveJobDisplayStatus,
+  deriveJobExecutionDisplayStatus,
   isWorkflowRunTerminal,
   isWorkflowStatus,
   Job,


### PR DESCRIPTION
## Summary

Workflow UI surfaces now share activity-derived display statuses instead of reading raw lifecycle statuses independently. Execution status accounts for active steps, job status accounts for active listeners and default execution activity, and historical selected executions retain their own badge status.

Adds a patch changeset for `@shipfox/client-workflows`.

Closes ENG-1399

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies job and execution status across the workflow UI by deriving a single activity-aware display status and adding a new Listening state. Aligns the graph, run view, badges, and icons with this model and addresses ENG-1399.

- **New Features**
  - Added `deriveJobDisplayStatus` and `deriveJobExecutionDisplayStatus` with exported types (`WorkflowDisplayStatus`, `JobDisplayStatus`, `JobExecutionDisplayStatus`).
  - Introduced `listening` status with a pulse icon; icon rendering now uses the display status only, so `listening` shows the pulse glyph and `running` always uses the dot. Status icons, badges, the execution switcher, and execution count segments read derived statuses.
  - Display rules: terminal job status wins; active listener shows Listening; running lifecycle without a running step shows Pending; pending lifecycle with a running step shows Running.
  - Updated duration labels and tooltips (e.g., “Runner assigned” vs “Execution elapsed”) and improved accessible labels in the graph.
  - Refined empty states (e.g., “Runner preparing job” for claimed idle, clearer zero-step messages).
  - Aligned Storybook stories and test fixtures with the display-status rules; added direct `listening` icon coverage. Added a patch changeset for `@shipfox/client-workflows`.

<sup>Written for commit 14be5e88e8a9737075be6a21a6be1a0ae5c41f3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

