### PR TITLE
Add checkout targeting to workflow schemas

### DIFF
--- a/.changeset/checkout-model-compatibility.md
+++ b/.changeset/checkout-model-compatibility.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-definitions": patch
+---
+
+Report an explicit model validation issue for checkout opt-out and checkout steps until their normalization and runtime support lands.

--- a/.changeset/checkout-targeting-schema.md
+++ b/.changeset/checkout-targeting-schema.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/workflow-document": minor
+---
+
+Add checkout target fields, checkout opt-out, and checkout steps to the workflow document schema.

--- a/apps/docs/content/docs/reference/workflow-schema.mdx
+++ b/apps/docs/content/docs/reference/workflow-schema.mdx
@@ -9,6 +9,7 @@ import {
   AgentStepFields,
   CheckoutFields,
   CheckoutPermissionsFields,
+  CheckoutStepFields,
   EnvironmentVariables,
   GateFailureFields,
   GateFields,
@@ -51,12 +52,19 @@ workflow.
 
 ## Step fields
 
-Each step is either a run step or an agent step. The schema rejects unknown
-fields and invalid field combinations.
+Each step is either a run step, an agent step, or a checkout step. The schema
+rejects unknown fields and invalid field combinations.
+
+Checkout steps are defined in the schema. Model normalization and runtime
+execution support are tracked separately.
 
 ### Run step fields
 
 <RunStepFields />
+
+### Checkout step fields
+
+<CheckoutStepFields />
 
 ### Agent step fields
 

--- a/apps/docs/scripts/generate.mjs
+++ b/apps/docs/scripts/generate.mjs
@@ -231,6 +231,14 @@ function object(value) {
   return typeof value === 'object' && value !== null && !Array.isArray(value) ? value : {};
 }
 
+function objectSchemaFor(value) {
+  const schema = object(value);
+  if (schema.type === 'object' || schema.properties) return schema;
+  return (
+    objects(schema.anyOf).find((option) => option.type === 'object' || option.properties) ?? {}
+  );
+}
+
 function strings(value) {
   return Array.isArray(value) ? value.filter((item) => typeof item === 'string') : [];
 }
@@ -248,7 +256,7 @@ function renderWorkflowSchemaReference() {
   const integrations = object(steps.properties).integrations;
   const integration = object(integrations.items);
   const gate = object(steps.properties).gate;
-  const checkout = object(jobs.properties).checkout;
+  const checkout = objectSchemaFor(object(jobs.properties).checkout);
   const checkoutPermissions = object(checkout.properties).permissions;
   const gateFailure = object(gate.properties).on_failure;
   const triggers = object(root.triggers);
@@ -302,6 +310,20 @@ function renderWorkflowSchemaReference() {
       types: {
         gate: namedType('Gate'),
         env: namedType('Environment'),
+        outputs: recordType('Output'),
+      },
+    }),
+    component('CheckoutStepFields', object(steps.properties), {
+      fields: ['key', 'if', 'name', 'checkout', 'gate', 'outputs'],
+      required: ['checkout'],
+      nested: {
+        checkout: '#checkout-fields',
+        gate: '#gate-fields',
+        outputs: '#step-outputs',
+      },
+      types: {
+        checkout: namedType('Checkout'),
+        gate: namedType('Gate'),
         outputs: recordType('Output'),
       },
     }),

--- a/libs/api/definitions/src/core/workflow-model/invalid-workflow-model-error.ts
+++ b/libs/api/definitions/src/core/workflow-model/invalid-workflow-model-error.ts
@@ -51,6 +51,8 @@ export type WorkflowModelValidationIssueCode =
   | 'unknown-integration-method'
   | 'unknown-integration-tool'
   | 'unknown-job-dependency'
+  | 'unsupported-checkout'
+  | 'untrusted-agent-selection-context'
   | 'vars-context-in-server-predicate';
 
 export type WorkflowModelValidationIssuePathSegment = string | number;

--- a/libs/api/definitions/src/core/workflow-model/normalize-job-checkout.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-job-checkout.ts
@@ -1,11 +1,26 @@
 import {DEFAULT_JOB_CHECKOUT, type WorkflowModelJobCheckout} from '@shipfox/api-definitions-dto';
-import type {WorkflowDocumentJobCheckout} from '@shipfox/workflow-document';
+import type {WorkflowDocumentJob} from '@shipfox/workflow-document';
+import type {WorkflowModelValidationIssue} from './invalid-workflow-model-error.js';
+import {issue} from './validation-issue.js';
 
 export {DEFAULT_JOB_CHECKOUT};
 
-export function normalizeJobCheckout(
-  checkout: WorkflowDocumentJobCheckout | undefined,
-): WorkflowModelJobCheckout {
+export function normalizeJobCheckout(params: {
+  checkout: WorkflowDocumentJob['checkout'];
+  issues: WorkflowModelValidationIssue[];
+  path: readonly (string | number)[];
+}): WorkflowModelJobCheckout {
+  if (params.checkout === false) {
+    params.issues.push(
+      issue({
+        code: 'unsupported-checkout',
+        message: 'checkout: false is not supported by the workflow model yet.',
+        path: params.path,
+      }),
+    );
+  }
+
+  const checkout = params.checkout === false ? undefined : params.checkout;
   return {
     permissions: {
       contents: checkout?.permissions?.contents ?? DEFAULT_JOB_CHECKOUT.permissions.contents,

--- a/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
@@ -194,7 +194,11 @@ function normalizeJob(params: {
     issues: params.issues,
     defaultRunnerLabels: params.context.defaultRunnerLabels,
   });
-  const checkout = normalizeJobCheckout(params.job.checkout);
+  const checkout = normalizeJobCheckout({
+    checkout: params.job.checkout,
+    issues: params.issues,
+    path: ['jobs', params.sourceName, 'checkout'],
+  });
   const jobEnv = normalizeEnv({
     env: params.job.env,
     path: ['jobs', params.sourceName, 'env'],
@@ -458,8 +462,8 @@ function normalizeJobSteps(params: {
 }): readonly WorkflowModelStep[] {
   const usedStepIds = new Map<string, number>();
 
-  return params.job.steps.map((step, index) =>
-    normalizeStep({
+  return params.job.steps.flatMap((step, index) => {
+    const normalized = normalizeStep({
       step,
       index,
       sourceName: params.sourceName,
@@ -474,8 +478,9 @@ function normalizeJobSteps(params: {
       upstreamJobs: params.upstreamJobs,
       directNeedJobs: params.directNeedJobs,
       context: params.context,
-    }),
-  );
+    });
+    return normalized === undefined ? [] : [normalized];
+  });
 }
 
 function normalizeStep(params: {
@@ -493,7 +498,7 @@ function normalizeStep(params: {
   upstreamJobs: readonly WorkflowJobTypeOverlay[];
   directNeedJobs: readonly WorkflowJobTypeOverlay[];
   context: NormalizeContext;
-}): WorkflowModelStep {
+}): WorkflowModelStep | undefined {
   const stepKey = params.step.key;
   const stepId =
     stepKey === undefined
@@ -619,8 +624,18 @@ function normalizeStep(params: {
     });
   }
 
-  // workflowDocumentStepSchema requires either `run` or an agent `prompt`; this
-  // keeps the model-step union honest if callers bypass the document parser.
+  if (params.step.checkout !== undefined) {
+    params.issues.push(
+      issue({
+        code: 'unsupported-checkout',
+        message: 'Checkout steps are not supported by the workflow model yet.',
+        path: ['jobs', params.sourceName, 'steps', params.index, 'checkout'],
+      }),
+    );
+    return undefined;
+  }
+
+  // Keep the model-step union honest if callers bypass the document parser.
   throw new Error(`Workflow step "${stepId}" is neither a run nor an agent step`);
 }
 

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -1037,6 +1037,43 @@ describe('normalizeWorkflowDocument', () => {
     expect(model.jobs[0]?.checkout).toEqual(DEFAULT_JOB_CHECKOUT);
   });
 
+  it('reports the staged job checkout opt-out until model support lands', () => {
+    const error = expectInvalid({
+      name: 'checkout disabled',
+      jobs: {
+        build: {
+          checkout: false,
+          steps: [{run: 'npm test'}],
+        },
+      },
+    });
+
+    expect(error.issues).toContainEqual(
+      expect.objectContaining({
+        code: 'unsupported-checkout',
+        path: ['jobs', 'build', 'checkout'],
+      }),
+    );
+  });
+
+  it('reports the staged checkout step until model support lands', () => {
+    const error = expectInvalid({
+      name: 'checkout step',
+      jobs: {
+        build: {
+          steps: [{checkout: {repository: 'acme/api'}}],
+        },
+      },
+    });
+
+    expect(error.issues).toContainEqual(
+      expect.objectContaining({
+        code: 'unsupported-checkout',
+        path: ['jobs', 'build', 'steps', 0, 'checkout'],
+      }),
+    );
+  });
+
   it('normalizes checkout contents write and defaults persisted credentials', () => {
     const document: WorkflowDocument = {
       name: 'write checkout',

--- a/libs/shared/workflow/document/src/document/workflow-document.test.ts
+++ b/libs/shared/workflow/document/src/document/workflow-document.test.ts
@@ -1,3 +1,4 @@
+import type {WorkflowDocumentJobCheckout} from './workflow-document.js';
 import {
   WORKFLOW_DOCUMENT_ENV_MAX_ENTRIES,
   WORKFLOW_DOCUMENT_ENV_MAX_SERIALIZED_BYTES,
@@ -44,6 +45,12 @@ describe('workflowDocumentSchema', () => {
     const result = workflowDocumentSchema.safeParse(workflowDocument);
 
     expect(result.success).toBe(true);
+  });
+
+  it('types job checkout opt-out', () => {
+    const checkout = false satisfies WorkflowDocumentJobCheckout;
+
+    expect(checkout).toBe(false);
   });
 
   it('accepts working_directory on run and agent steps', () => {
@@ -369,6 +376,21 @@ describe('workflowDocumentSchema', () => {
         },
       },
     ],
+    [
+      'checkout target fields',
+      {
+        checkout: {
+          project: '0192f3a1-0000-0000-0000-000000000000',
+          ref: 'refs/heads/main',
+          'fetch-depth': 0,
+          path: 'target',
+          force: true,
+          permissions: {contents: 'read'},
+          'persist-credentials': false,
+        },
+      },
+    ],
+    ['checkout disabled', {checkout: false}],
     ['checkout persist credentials false', {checkout: {'persist-credentials': false}}],
     ['empty checkout', {checkout: {}}],
     ['omitted checkout', {}],
@@ -384,6 +406,53 @@ describe('workflowDocumentSchema', () => {
     });
 
     expect(result.success).toBe(true);
+  });
+
+  it('accepts the shared checkout object on a checkout step', () => {
+    const result = workflowDocumentSchema.safeParse({
+      name: 'targeted checkout',
+      jobs: {
+        build: {
+          checkout: false,
+          steps: [
+            {
+              key: 'fetch-target',
+              checkout: {
+                connection: 'github',
+                repository: 'acme/api',
+                ref: 'refs/heads/main',
+                'fetch-depth': 0,
+                path: 'target',
+                permissions: {contents: 'write'},
+                'persist-credentials': true,
+                force: false,
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects project with connection or repository in a checkout object', () => {
+    for (const checkout of [
+      {project: 'project-id', connection: 'github'},
+      {project: 'project-id', repository: 'acme/api'},
+    ]) {
+      const result = workflowDocumentSchema.safeParse({
+        name: 'invalid checkout target',
+        jobs: {
+          build: {
+            checkout,
+            steps: [{run: 'npm test'}],
+          },
+        },
+      });
+
+      expect(result.success).toBe(false);
+    }
   });
 
   it('keeps trigger filters as strings', () => {
@@ -874,16 +943,58 @@ describe('workflowDocumentSchema', () => {
         },
       },
     ],
+    [
+      'checkout disabled with a non-boolean value',
+      {
+        name: 'simple build',
+        jobs: {build: {checkout: true, steps: [{run: 'npm test'}]}},
+      },
+    ],
+    [
+      'negative checkout fetch depth',
+      {
+        name: 'simple build',
+        jobs: {build: {checkout: {'fetch-depth': -1}, steps: [{run: 'npm test'}]}},
+      },
+    ],
+    [
+      'fractional checkout fetch depth',
+      {
+        name: 'simple build',
+        jobs: {build: {checkout: {'fetch-depth': 1.5}, steps: [{run: 'npm test'}]}},
+      },
+    ],
+    [
+      'checkout step with a run command',
+      {
+        name: 'simple build',
+        jobs: {build: {steps: [{checkout: {}, run: 'npm test'}]}},
+      },
+    ],
+    [
+      'checkout step with an agent prompt',
+      {
+        name: 'simple build',
+        jobs: {build: {steps: [{checkout: {}, prompt: 'Review the change.'}]}},
+      },
+    ],
+    [
+      'checkout step with environment variables',
+      {
+        name: 'simple build',
+        jobs: {build: {steps: [{checkout: {}, env: {CI: true}}]}},
+      },
+    ],
   ])('rejects %s', (_label, workflowDocument) => {
     const result = workflowDocumentSchema.safeParse(workflowDocument);
 
     expect(result.success).toBe(false);
   });
 
-  it('rejects checkout as an unsupported step key', () => {
+  it('rejects an unknown step key', () => {
     const result = workflowDocumentSchema.safeParse({
       name: 'simple build',
-      jobs: {build: {steps: [{checkout: {path: 'api'}, working_directory: 'api'}]}},
+      jobs: {build: {steps: [{checkout: {path: 'api'}, unknown_step_key: true}]}},
     });
 
     expect(result.success).toBe(false);
@@ -891,7 +1002,7 @@ describe('workflowDocumentSchema', () => {
 
     expect(result.error.issues).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({code: 'unrecognized_keys', keys: ['checkout']}),
+        expect.objectContaining({code: 'unrecognized_keys', keys: ['unknown_step_key']}),
       ]),
     );
   });
@@ -1035,5 +1146,17 @@ describe('workflowDocumentSchema', () => {
       ? undefined
       : result.error.issues.find((issue) => issue.path.includes('integrations'));
     expect(integrationsIssue?.message).toBe('"integrations" is not valid on a run step.');
+  });
+
+  it('reports a checkout-step conflict on the conflicting field', () => {
+    const result = workflowDocumentSchema.safeParse({
+      name: 'checkout build',
+      jobs: {build: {steps: [{checkout: {}, run: 'npm test'}]}},
+    });
+
+    const runIssue = result.success
+      ? undefined
+      : result.error.issues.find((issue) => issue.path.includes('run'));
+    expect(runIssue?.message).toBe('"run" is not valid on a checkout step.');
   });
 });

--- a/libs/shared/workflow/document/src/document/workflow-document.ts
+++ b/libs/shared/workflow/document/src/document/workflow-document.ts
@@ -283,21 +283,66 @@ const workflowDocumentStepGateSchema = z
     message: 'Expected success or on_failure',
   });
 
-export const workflowDocumentCheckoutSchema = z.strictObject({
-  permissions: z
-    .strictObject({
-      contents: z.enum(['read', 'write']).optional().meta({
-        description: 'Repository contents permission granted to checkout.',
-      }),
-    })
-    .optional()
-    .meta({
-      description: 'Repository permissions used during checkout.',
+export const workflowDocumentCheckoutSchema = z
+  .strictObject({
+    project: z.string().min(1).optional().meta({
+      description: 'Shipfox project id to check out. Exclusive with connection and repository.',
     }),
-  'persist-credentials': z.boolean().optional().meta({
-    description: 'Whether checkout credentials remain available to later run steps.',
-  }),
-});
+    connection: z.string().min(1).optional().meta({
+      description: 'Integration connection slug to use for checkout.',
+    }),
+    repository: z.string().min(1).optional().meta({
+      description: 'Repository to check out, as owner/name or a bare name.',
+    }),
+    ref: z.string().min(1).optional().meta({
+      description: 'Repository ref to check out.',
+    }),
+    'fetch-depth': z.number().int().min(0).optional().meta({
+      description: 'Number of commits to fetch. Use 0 for full history.',
+    }),
+    path: z.string().min(1).optional().meta({
+      description: 'Relative path under the job workspace where this repository is checked out.',
+    }),
+    permissions: z
+      .strictObject({
+        contents: z.enum(['read', 'write']).optional().meta({
+          description: 'Repository contents permission granted to checkout.',
+        }),
+      })
+      .optional()
+      .meta({
+        description: 'Repository permissions used during checkout.',
+      }),
+    'persist-credentials': z.boolean().optional().meta({
+      description: 'Whether checkout credentials remain available to later run steps.',
+    }),
+    force: z.boolean().optional().meta({
+      description: 'Whether checkout may replace an occupied destination.',
+    }),
+  })
+  .superRefine((checkout, ctx) => {
+    if (checkout.project !== undefined && checkout.connection !== undefined) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['connection'],
+        message: '"connection" cannot be combined with "project".',
+      });
+    }
+    if (checkout.project !== undefined && checkout.repository !== undefined) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['repository'],
+        message: '"repository" cannot be combined with "project".',
+      });
+    }
+  });
+
+const workflowDocumentJobCheckoutSchema = z
+  .union([workflowDocumentCheckoutSchema, z.literal(false)])
+  .meta({
+    description:
+      'Checkout settings for repository content and credentials, or false to skip checkout.',
+  });
 
 export const workflowDocumentStepIntegrationSelectionSchema = z.array(z.string().min(1)).min(1);
 
@@ -326,12 +371,13 @@ export const workflowDocumentAgentStepFields = [
   'integrations',
 ] as const;
 
-// A step is a run step (`run`) or an inline agent step (`prompt`), never
-// both. They share one strict object so an unknown key is still rejected; the
-// `superRefine` discriminates by which payload keys are present and emits one
-// targeted issue per failure mode (a plain union would surface every branch's
-// errors at once). The `agent` keyword is declared only so the reserved-keyword
-// case produces a clear message instead of a generic "unrecognized key".
+// A step is a run step (`run`), an inline agent step (`prompt`), or a checkout
+// step (`checkout`), never two kinds at once. They share one strict object so
+// an unknown key is still rejected; the `superRefine` discriminates by which
+// payload keys are present and emits one targeted issue per failure mode (a
+// plain union would surface every branch's errors at once). The `agent`
+// keyword is declared only so the reserved-keyword case produces a clear
+// message instead of a generic "unrecognized key".
 export const workflowDocumentStepSchema = z
   .strictObject({
     key: z
@@ -354,6 +400,9 @@ export const workflowDocumentStepSchema = z
     }),
     run: z.string().min(1).optional().meta({
       description: 'Shell command for a run step. Do not combine it with agent-only fields.',
+    }),
+    checkout: workflowDocumentCheckoutSchema.optional().meta({
+      description: 'Repository checkout settings for this step.',
     }),
     model: z.string().min(1).optional().meta({
       description:
@@ -405,6 +454,33 @@ export const workflowDocumentStepSchema = z
       return;
     }
 
+    if (step.checkout !== undefined) {
+      if (step.run !== undefined) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['run'],
+          message: '"run" is not valid on a checkout step.',
+        });
+      }
+      for (const key of workflowDocumentAgentStepFields) {
+        if (step[key] !== undefined) {
+          ctx.addIssue({
+            code: 'custom',
+            path: [key],
+            message: `"${key}" is not valid on a checkout step.`,
+          });
+        }
+      }
+      if (step.env !== undefined) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['env'],
+          message: '"env" is not valid on a checkout step.',
+        });
+      }
+      return;
+    }
+
     if (step.run !== undefined) {
       for (const key of workflowDocumentAgentStepFields) {
         if (step[key] !== undefined) {
@@ -423,7 +499,7 @@ export const workflowDocumentStepSchema = z
     if (!isAgent) {
       ctx.addIssue({
         code: 'custom',
-        message: 'A step must define either "run" or an agent "prompt".',
+        message: 'A step must define either "run", an agent "prompt", or "checkout".',
       });
       return;
     }
@@ -471,9 +547,7 @@ export const workflowDocumentJobSchema = z.strictObject({
   execution_timeout: z.string().min(1).optional().meta({
     description: 'Maximum duration for one job execution.',
   }),
-  checkout: workflowDocumentCheckoutSchema.optional().meta({
-    description: 'Checkout settings for repository content and credentials.',
-  }),
+  checkout: workflowDocumentJobCheckoutSchema.optional(),
   listening: workflowDocumentListeningSchema.optional().meta({
     description:
       'Event-listening configuration for this job. See [listening jobs](/understand/listening-jobs).',
@@ -514,7 +588,7 @@ export const workflowDocumentSchema = z.strictObject({
 });
 
 export type WorkflowDocument = z.infer<typeof workflowDocumentSchema>;
-export type WorkflowDocumentJobCheckout = z.infer<typeof workflowDocumentCheckoutSchema>;
+export type WorkflowDocumentJobCheckout = z.infer<typeof workflowDocumentJobCheckoutSchema>;
 export type WorkflowDocumentEnv = z.infer<typeof workflowDocumentEnvSchema>;
 export type WorkflowDocumentJob = z.infer<typeof workflowDocumentJobSchema>;
 export type WorkflowDocumentJobListening = z.infer<typeof workflowDocumentListeningSchema>;

--- a/libs/shared/workflow/document/src/document/workflow-json-schema.test.ts
+++ b/libs/shared/workflow/document/src/document/workflow-json-schema.test.ts
@@ -59,10 +59,50 @@ describe('buildWorkflowJsonSchema', () => {
     expect(triggers.minProperties).toBe(1);
     expect(jobOutputs.minProperties).toBe(1);
     expect(discriminator).toMatchObject({
-      oneOf: [{required: ['run']}, {required: ['prompt']}],
+      oneOf: [{required: ['run']}, {required: ['prompt']}, {required: ['checkout']}],
     });
     expect(requiredAlternatives(gate)).toEqual(['success', 'on_failure']);
     expect(requiredAlternatives(batch)).toEqual(['debounce', 'max_size', 'max_wait']);
+  });
+
+  it('publishes checkout fields for both job and checkout-step syntax', () => {
+    const schema = buildWorkflowJsonSchema();
+    const root = object(schema.properties);
+    const jobs = object(root.jobs);
+    const job = object(jobs.additionalProperties);
+    const jobCheckout = object(object(job.properties).checkout);
+    const step = stepSchemaFor(schema);
+    const stepCheckout = object(object(step.properties).checkout);
+
+    expect(jobCheckout.anyOf).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({type: 'object'}),
+        expect.objectContaining({const: false}),
+      ]),
+    );
+    expect(objectSchemaFor(jobCheckout).properties).toEqual(
+      expect.objectContaining({
+        project: expect.any(Object),
+        connection: expect.any(Object),
+        repository: expect.any(Object),
+        ref: expect.any(Object),
+        'fetch-depth': expect.any(Object),
+        path: expect.any(Object),
+        permissions: expect.any(Object),
+        'persist-credentials': expect.any(Object),
+        force: expect.any(Object),
+      }),
+    );
+    expect(stepCheckout).toEqual(
+      expect.objectContaining({
+        type: 'object',
+        properties: expect.objectContaining({
+          project: expect.any(Object),
+          'fetch-depth': expect.any(Object),
+          force: expect.any(Object),
+        }),
+      }),
+    );
   });
 
   it('describes every JSON Schema property', () => {
@@ -90,6 +130,13 @@ function jobOutputsSchemaFor(schema: JsonSchema): JsonSchema {
   const jobs = object(object(schema.properties).jobs);
   const job = object(jobs.additionalProperties);
   return object(object(job.properties).outputs);
+}
+
+function objectSchemaFor(schema: JsonSchema): JsonSchema {
+  if (schema.type === 'object' || schema.properties) return schema;
+  return (
+    objects(schema.anyOf).find((option) => option.type === 'object' || option.properties) ?? {}
+  );
 }
 
 function requiredAlternatives(schema: JsonSchema): unknown {

--- a/libs/shared/workflow/document/src/document/workflow-json-schema.ts
+++ b/libs/shared/workflow/document/src/document/workflow-json-schema.ts
@@ -65,17 +65,34 @@ function projectWorkflowValidation(schema: JsonSchema, stepSchema: JsonSchema) {
       oneOf: [
         {
           required: ['run'],
-          not: {anyOf: workflowDocumentAgentStepFields.map((field) => ({required: [field]}))},
+          not: {
+            anyOf: [
+              ...workflowDocumentAgentStepFields.map((field) => ({required: [field]})),
+              {required: ['checkout']},
+            ],
+          },
         },
         {
           required: ['prompt'],
-          not: {anyOf: [{required: ['run']}, {required: ['env']}]},
+          not: {anyOf: [{required: ['run']}, {required: ['checkout']}, {required: ['env']}]},
+        },
+        {
+          required: ['checkout'],
+          not: {
+            anyOf: [
+              {required: ['run']},
+              ...workflowDocumentAgentStepFields.map((field) => ({required: [field]})),
+              {required: ['env']},
+            ],
+          },
         },
       ],
     },
   ];
 
   const job = object(jobs.additionalProperties);
+  projectCheckoutTargetValidation(propertiesOf(job).checkout);
+  projectCheckoutTargetValidation(propertiesOf(stepSchema).checkout);
   const jobOutputs = object(propertiesOf(job).outputs);
   jobOutputs.minProperties = 1;
   const listening = object(propertiesOf(job).listening);
@@ -84,6 +101,23 @@ function projectWorkflowValidation(schema: JsonSchema, stepSchema: JsonSchema) {
 
   const gate = object(propertiesOf(stepSchema).gate);
   addAtLeastOneConstraint(gate, ['success', 'on_failure']);
+}
+
+function projectCheckoutTargetValidation(schema: JsonSchema | undefined) {
+  const checkout = objectSchemaFor(schema);
+  if (Object.keys(checkout).length === 0) return;
+
+  checkout.allOf = [
+    ...objects(checkout.allOf),
+    {
+      not: {
+        allOf: [
+          {required: ['project']},
+          {anyOf: [{required: ['connection']}, {required: ['repository']}]},
+        ],
+      },
+    },
+  ];
 }
 
 function addAtLeastOneConstraint(schema: JsonSchema, fields: string[]) {
@@ -107,6 +141,14 @@ function object(value: unknown): JsonSchema {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
     ? (value as JsonSchema)
     : {};
+}
+
+function objectSchemaFor(value: unknown): JsonSchema {
+  const schema = object(value);
+  if (schema.type === 'object' || schema.properties) return schema;
+  return (
+    objects(schema.anyOf).find((option) => option.type === 'object' || option.properties) ?? {}
+  );
 }
 
 function objects(value: unknown): JsonSchema[] {


### PR DESCRIPTION
Add checkout targeting to the workflow document schema and expose the same contract in the generated JSON Schema and workflow reference docs.

The schema now supports shared checkout targets, job-level `checkout: false`, and checkout step fields. The current model layer reports a structured `unsupported-checkout` validation issue for the opt-out and checkout-step forms until the normalization and runtime follow-up work lands, avoiding an internal parse-time failure while keeping the model union accurate.

The reference page documents checkout-step fields and clearly notes that runtime execution support is tracked separately.

Closes ENG-1419

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds checkout targeting to `@shipfox/workflow-document`: a shared checkout object for jobs and checkout steps, plus job-level `checkout: false`. Exposes these in the JSON Schema and docs; for ENG-1419, `@shipfox/api-definitions` reports `unsupported-checkout` for opt-out and checkout steps until normalization and runtime support land.

- **New Features**
  - Shared checkout target on jobs and checkout steps: `project` or `connection`/`repository`, `ref`, `fetch-depth`, `path`, `permissions`, `persist-credentials`, `force` (with `project` exclusive of `connection`/`repository`).
  - New checkout step kind; schema and JSON Schema reject mixing with run/agent/env fields, and the discriminator now covers run, prompt, and checkout. Docs include checkout step fields.
  - Job-level `checkout: false` accepted and published as an object | false union in JSON Schema.

- **Migration**
  - No runtime change yet. Using `checkout: false` or checkout steps will parse but trigger `unsupported-checkout` model issues, and checkout steps are dropped by the model for now.

<sup>Written for commit c56fe5f1428c9ce34e64b9a450516b4e00432c6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

