### PR TITLE
Migrate Shipfox workflows to split static and dynamic names

### DIFF
--- a/apps/docs/content/docs/reference/workflow-schema.mdx
+++ b/apps/docs/content/docs/reference/workflow-schema.mdx
@@ -33,6 +33,84 @@ workflow.
 
 <TopLevelFields />
 
+## Workflow and job names
+
+Workflow and job names use separate static and dynamic fields.
+
+| Field | Names | Expressions | Required |
+| --- | --- | --- | --- |
+| `name` | Workflow definition | Not allowed | Yes |
+| `run_name` | Workflow run | Allowed | No |
+| `jobs.<job_key>.name` | Job | Not allowed | No |
+| `jobs.<job_key>.execution_name` | Job execution | Allowed | No |
+
+### Static names
+
+Workflow `name` and job `name` values are literal labels. A job `name` is
+optional. Add one when the job key is not a useful label. The job key is the
+fallback when no job name is set.
+
+Interpolation in a static name is invalid. Use the matching dynamic field:
+
+```text
+Workflow name must be literal. Move runtime interpolation to run_name.
+Job name must be literal. Move runtime interpolation to execution_name.
+```
+
+### Dynamic run names
+
+`run_name` resolves when Shipfox creates a workflow run. It can use trigger
+metadata, trigger event data, workflow inputs, referenced workflow variables,
+and stable run facts that already exist at creation time.
+
+It cannot use job, execution, step, or job-output values that do not exist when
+the run is created. A rerun keeps the original resolved run name.
+
+### Dynamic execution names
+
+`execution_name` resolves when Shipfox creates a job execution. It can use run
+context, trigger data, inputs, referenced variables, stable job facts, the
+execution sequence, listener events, and prior executions.
+
+It cannot use the current execution name, future executions, step results, or
+job outputs that do not exist at execution creation.
+
+Listening jobs resolve `execution_name` separately for each execution. The
+template can therefore include the event batch or execution sequence.
+
+### Fallbacks and reruns
+
+Dynamic names are optional and affect display labels only. If a dynamic field
+is omitted or resolves to an empty value, Shipfox uses the matching static
+fallback. A runtime resolution failure also uses that fallback and records a
+diagnostic without changing execution status.
+
+| Dynamic field | Static fallback |
+| --- | --- |
+| `run_name` | Workflow `name` |
+| `execution_name` | Job `name`, or the job key |
+
+Dynamic-name expressions that use unavailable context or invalid syntax are
+definition validation errors. Rerunning a workflow keeps its resolved run
+name. Rerunning a job execution keeps its resolved execution name.
+
+```yaml
+# yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
+name: Pull request review
+run_name: 'Review PR #${{ event.pull_request.number }}'
+
+jobs:
+  reviews:
+    name: Process review
+    execution_name: Review batch ${{ execution.index }}
+    listening:
+      on:
+        - source: github
+          event: pull_request_review
+    steps:
+      - prompt: Summarize ${{ execution.events[0].data.body }}
+```
+
 ## Trigger fields
 
 <TriggerFields />

--- a/libs/api/definitions/src/core/parse-definition.test.ts
+++ b/libs/api/definitions/src/core/parse-definition.test.ts
@@ -65,7 +65,13 @@ describe('parseDefinition', () => {
         onResolve: 'cancel',
       },
     });
-    expect(definition.model.jobs[0]?.executionName).toBeDefined();
+    expect(definition.model.jobs[0]).toMatchObject({
+      name: [{kind: 'literal', value: 'Review batch'}],
+      executionName: [
+        {kind: 'literal', value: 'Review batch '},
+        {kind: 'deferred', roots: ['execution'], fillTarget: 'execution-creation'},
+      ],
+    });
   });
 
   test('attaches source line locations to workflow model steps', () => {

--- a/libs/api/definitions/test/fixtures/valid-listening-job.yml
+++ b/libs/api/definitions/test/fixtures/valid-listening-job.yml
@@ -2,6 +2,7 @@ name: Listening workflow
 runner: ubuntu-latest
 jobs:
   review:
+    name: Review batch
     execution_name: Review batch ${{ execution.index }}
     listening:
       on:

--- a/libs/shared/workflow/document/src/document/workflow-document.ts
+++ b/libs/shared/workflow/document/src/document/workflow-document.ts
@@ -478,7 +478,7 @@ export const workflowDocumentJobSchema = z.strictObject({
     description:
       'Event-listening configuration for this job. See [listening jobs](/understand/listening-jobs).',
   }),
-  name: z.string().min(1).optional().meta({description: 'Static human-readable job name.'}),
+  name: z.string().min(1).optional().meta({description: 'Static literal human-readable job name.'}),
   execution_name: z.string().min(1).optional().meta({
     description: 'Dynamic name for each job execution. Supports workflow expressions.',
   }),
@@ -492,7 +492,7 @@ export const workflowDocumentJobSchema = z.strictObject({
 });
 
 export const workflowDocumentSchema = z.strictObject({
-  name: z.string().min(1).meta({description: 'Static human-readable workflow name.'}),
+  name: z.string().min(1).meta({description: 'Static literal human-readable workflow name.'}),
   run_name: z.string().min(1).optional().meta({
     description: 'Dynamic name for each workflow run. Supports workflow expressions.',
   }),

--- a/libs/shared/workflow/document/src/document/workflow-json-schema.test.ts
+++ b/libs/shared/workflow/document/src/document/workflow-json-schema.test.ts
@@ -21,6 +21,26 @@ describe('buildWorkflowJsonSchema', () => {
     );
   });
 
+  it('describes static and dynamic workflow and job name fields', () => {
+    const schema = buildWorkflowJsonSchema();
+    const rootProperties = object(schema.properties);
+    const jobs = object(rootProperties.jobs);
+    const jobProperties = object(object(jobs.additionalProperties).properties);
+
+    expect(rootProperties.name).toMatchObject({
+      description: 'Static literal human-readable workflow name.',
+    });
+    expect(rootProperties.run_name).toMatchObject({
+      description: 'Dynamic name for each workflow run. Supports workflow expressions.',
+    });
+    expect(jobProperties.name).toMatchObject({
+      description: 'Static literal human-readable job name.',
+    });
+    expect(jobProperties.execution_name).toMatchObject({
+      description: 'Dynamic name for each job execution. Supports workflow expressions.',
+    });
+  });
+
   it('restricts thinking values for each harness', () => {
     const schema = buildWorkflowJsonSchema();
     const conditionals = objects(stepSchemaFor(schema).allOf);


### PR DESCRIPTION
## Summary

- migrate the listening-job fixture to literal `name` plus dynamic `execution_name`
- document the final split between static workflow/job names and dynamic run/execution names
- align generated schema descriptions and parser/schema tests with the naming contract

No Cloud workflow sources are changed.

Closes ENG-1395