### PR TITLE
[api-common-dto] Add shared resource slug primitive

### DIFF
--- a/.changeset/shared-resource-slug.md
+++ b/.changeset/shared-resource-slug.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-common-dto": minor
+---
+
+Add the shared resource slug schema and name-derived slug helpers.

--- a/libs/api/common-dto/src/index.ts
+++ b/libs/api/common-dto/src/index.ts
@@ -15,3 +15,9 @@ export {
 } from './administration-action.js';
 export {displayNameSchema} from './schemas/display-name.js';
 export {emailSchema} from './schemas/email.js';
+export {
+  RESOURCE_SLUG_PATTERN,
+  slugifyName,
+  slugSchema,
+  withSlugSuffix,
+} from './schemas/slug.js';

--- a/libs/api/common-dto/src/schemas/slug.test.ts
+++ b/libs/api/common-dto/src/schemas/slug.test.ts
@@ -1,0 +1,53 @@
+import {RESOURCE_SLUG_PATTERN, slugifyName, slugSchema, withSlugSuffix} from './slug.js';
+
+const expectedResourceSlugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+describe('slugSchema', () => {
+  it.each(['acme', 'checkout-api', 'settings', 'new', 'a1'])('accepts %s', (value) => {
+    expect(slugSchema.parse(value)).toBe(value);
+  });
+
+  it.each([
+    '',
+    'a',
+    'AcmE',
+    'checkout_api',
+    '-checkout',
+    'checkout-',
+    'checkout--api',
+    'a'.repeat(41),
+  ])('rejects %s', (value) => {
+    expect(() => slugSchema.parse(value)).toThrow();
+  });
+
+  it('uses the shared lowercase hyphenated pattern', () => {
+    expect(RESOURCE_SLUG_PATTERN).toEqual(expectedResourceSlugPattern);
+  });
+});
+
+describe('slugifyName', () => {
+  it('lowercases, folds diacritics, and collapses non-alphanumeric runs', () => {
+    expect(slugifyName('Équipe Renard — API', {fallback: 'workspace'})).toBe('equipe-renard-api');
+  });
+
+  it('trims hyphens and truncates to 40 characters', () => {
+    expect(slugifyName(`  ${'a'.repeat(39)} name  `, {fallback: 'workspace'})).toBe('a'.repeat(39));
+  });
+
+  it.each(['A', '🚀', '漢字'])('uses the fallback when %s produces an invalid slug', (name) => {
+    expect(slugifyName(name, {fallback: 'workspace'})).toBe('workspace');
+  });
+});
+
+describe('withSlugSuffix', () => {
+  it.each([
+    ['workspace', 2, 'workspace-2'],
+    ['project', 3, 'project-3'],
+    ['a'.repeat(40), 2, `${'a'.repeat(38)}-2`],
+  ])('adds the attempt suffix', (slug, attempt, expected) => {
+    const suffixedSlug = withSlugSuffix(slug, attempt);
+
+    expect(suffixedSlug).toBe(expected);
+    expect(slugSchema.parse(suffixedSlug)).toBe(suffixedSlug);
+  });
+});

--- a/libs/api/common-dto/src/schemas/slug.ts
+++ b/libs/api/common-dto/src/schemas/slug.ts
@@ -1,0 +1,33 @@
+import {z} from 'zod';
+
+const RESOURCE_SLUG_MAX_LENGTH = 40;
+
+export const RESOURCE_SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export const slugSchema = z
+  .string()
+  .min(2)
+  .max(RESOURCE_SLUG_MAX_LENGTH)
+  .regex(RESOURCE_SLUG_PATTERN);
+
+export function slugifyName(name: string, options: {fallback: string}): string {
+  const slug = name
+    .normalize('NFD')
+    .replaceAll(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/g, '-')
+    .replaceAll(/^-+|-+$/g, '')
+    .slice(0, RESOURCE_SLUG_MAX_LENGTH)
+    .replaceAll(/-+$/g, '');
+
+  return slug.length >= 2 ? slug : options.fallback;
+}
+
+export function withSlugSuffix(slug: string, attempt: number): string {
+  const suffix = `-${attempt}`;
+  const base = slug
+    .slice(0, Math.max(0, RESOURCE_SLUG_MAX_LENGTH - suffix.length))
+    .replaceAll(/-+$/g, '');
+
+  return `${base}${suffix}`;
+}


### PR DESCRIPTION
Add the shared resource-slug primitive for the upcoming workspace and project URL work.

The common DTO now owns the URL-safe format, browser-safe name derivation with valid fallbacks, and bounded numeric suffixes for fixture defaults. The package export and minor changeset make the contract available to API and client consumers.

Closes ENG-1445

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared resource slug schema and helpers to `@shipfox/api-common-dto` to standardize workspace and project URLs. Provides a consistent 2–40 char, lowercase, hyphenated slug with safe name conversion and suffixing (supports ENG-1445).

- **New Features**
  - Exported `RESOURCE_SLUG_PATTERN`, `slugSchema`, `slugifyName`, and `withSlugSuffix` for API and client use.
  - `slugifyName` lowercases, removes diacritics, collapses non-alphanumerics to `-`, trims, enforces length, and falls back when invalid.
  - `withSlugSuffix` adds a numeric suffix while keeping within length limits.
  - Added tests for schema validation, name conversion, and suffix behavior.

<sup>Written for commit 456123c47198d7240a4cb77e6ebd0294935097c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

