### PR TITLE
[expression] Detect workflow data in shell re-evaluation positions

### DIFF
--- a/.changeset/shell-code-position-classifier.md
+++ b/.changeset/shell-code-position-classifier.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/expression": minor
+---
+
+Add a pure shell code-position classifier for detecting workflow data passed to commands that re-evaluate their arguments.

--- a/libs/shared/expression/README.md
+++ b/libs/shared/expression/README.md
@@ -18,6 +18,8 @@ CEL checks and run-time evaluation for Shipfox workflow expressions.
 - **`MAX_RANGE_ELEMENTS`**: The per-evaluation range materialization limit,
   currently 1,000 values.
 - **`evaluateWorkflowPredicate`**: Returns `true` only for the boolean `true`.
+- **`classifyShellCodePosition`**: Finds named workflow bindings passed directly
+  to shell positions that re-evaluate their arguments.
 - **`parseWorkflowTemplate`**: Splits strings with `${{ ... }}` spans into
   ordered literal and expression segments.
 - **`extractCelContextRoots`**: Returns the sorted top-level CEL identifiers mentioned
@@ -113,7 +115,11 @@ const passed = evaluateWorkflowPredicate(expression, {
   interpolated values from being parsed as shell syntax, but it does not make
   commands and shell positions that deliberately re-evaluate their arguments
   safe, such as `eval`, `sh -c "$value"`, `let`, `declare -i`, arithmetic
-  expressions, or array subscripts like `array[$value]`.
+  expressions, or array subscripts like `array[$value]`. Use
+  `classifyShellCodePosition` with the generated binding names and workflow env
+  names to detect these direct code-position references. The analysis is pure,
+  intentionally shallow, and may miss indirect shell data flow; it is designed
+  to avoid false-positive warnings.
 Trigger filters can use `syntax` while integration event payloads are still open.
 Gate expressions can use `typed` because their local fields are known.
 

--- a/libs/shared/expression/src/index.ts
+++ b/libs/shared/expression/src/index.ts
@@ -114,6 +114,12 @@ export {
   unsafeRunInterpolationErrorCode,
 } from './run/hoist-run-command.js';
 export {
+  classifyShellCodePosition,
+  type ShellCodePositionAnalysis,
+  type ShellCodePositionMatch,
+  type ShellReevaluatingConstruct,
+} from './run/shell-code-position.js';
+export {
   InvalidWorkflowTemplateError,
   invalidWorkflowTemplateErrorCode,
 } from './template/errors.js';

--- a/libs/shared/expression/src/run/shell-code-position.test.ts
+++ b/libs/shared/expression/src/run/shell-code-position.test.ts
@@ -5,6 +5,7 @@ const workflowDataNames = ['MSG', '__sf_0'];
 describe('classifyShellCodePosition', () => {
   it.each([
     ['eval "$MSG"', 'eval'],
+    ["eval 'echo $MSG'", 'eval'],
     ['sh -c "$MSG"', 'sh-c'],
     ['bash -c "$MSG"', 'bash-c'],
     ['source "$MSG"', 'source'],
@@ -34,6 +35,10 @@ describe('classifyShellCodePosition', () => {
     'bash -c \'echo "$1"\' _ "$MSG"',
     'source ./scripts/setup.sh',
     'eval "$(cat script.sh)"',
+    `eval "\${#MSG}"`,
+    "sed 's/$MSG/x/'",
+    "sh -c '$MSG'",
+    'for eval in "$MSG"; do :; done',
     'xargs cmd "$MSG"',
     'xargs sh -c \'echo "$1"\' _ "$MSG"',
     'jq --arg v "$MSG" \'$v\'',
@@ -181,6 +186,7 @@ describe('classifyShellCodePosition', () => {
     ['(( echo "$MSG" ))', []],
     ["(( MSG + arr['k'] ))", [{name: 'MSG', construct: 'arithmetic'}]],
     ['if true; then eval "$MSG"; fi', [{name: 'MSG', construct: 'eval'}]],
+    ['for x in "$MSG"; do eval "$MSG"; done', [{name: 'MSG', construct: 'eval'}]],
     ['echo $((1 + (MSG)))', [{name: 'MSG', construct: 'arithmetic'}]],
     [
       String.raw`eval \

--- a/libs/shared/expression/src/run/shell-code-position.test.ts
+++ b/libs/shared/expression/src/run/shell-code-position.test.ts
@@ -1,0 +1,195 @@
+import {classifyShellCodePosition} from './shell-code-position.js';
+
+const workflowDataNames = ['MSG', '__sf_0'];
+
+describe('classifyShellCodePosition', () => {
+  it.each([
+    ['eval "$MSG"', 'eval'],
+    ['sh -c "$MSG"', 'sh-c'],
+    ['bash -c "$MSG"', 'bash-c'],
+    ['source "$MSG"', 'source'],
+    ['. "$MSG"', 'source'],
+    ['let "$MSG"', 'let'],
+    ['declare -i "$MSG"', 'declare-i'],
+    ['$(( MSG + 1 ))', 'arithmetic'],
+    ['(( MSG + 1 ))', 'arithmetic'],
+    ['awk "$MSG"', 'awk'],
+    ['jq "$MSG"', 'jq'],
+    ['sed "$MSG"', 'sed'],
+    ['awk -e "$MSG"', 'awk'],
+    ['sed -e "$MSG"', 'sed'],
+    ['sed -ne "$MSG"', 'sed'],
+    ['jq -s "$MSG"', 'jq'],
+    ['sh -lc "$MSG"', 'sh-c'],
+    ['bash --command "$MSG"', 'bash-c'],
+    ['xargs sh -c "$MSG"', 'xargs-sh-c'],
+  ] as const)('reports workflow data in the %s code position', (command, construct) => {
+    const result = classifyShellCodePosition({command, workflowDataNames});
+
+    expect(result.matches).toContainEqual({name: 'MSG', construct});
+  });
+
+  it.each([
+    'sh -c \'echo "$1"\' _ "$MSG"',
+    'bash -c \'echo "$1"\' _ "$MSG"',
+    'source ./scripts/setup.sh',
+    'eval "$(cat script.sh)"',
+    'xargs cmd "$MSG"',
+    'xargs sh -c \'echo "$1"\' _ "$MSG"',
+    'jq --arg v "$MSG" \'$v\'',
+    'awk -f "$MSG" \'{print}\'',
+    'sed -f "$MSG" \'s/a/b/\'',
+    'sed -i \'s/a/b/\' "$MSG"',
+    'declare -i MSG',
+    'let MSG=1',
+    '(( MSG = 1 ))',
+    '((MSG=1))',
+  ] as const)('does not report workflow data in the %s data position', (command) => {
+    const result = classifyShellCodePosition({command, workflowDataNames});
+
+    expect(result.matches).toEqual([]);
+  });
+
+  it.each([
+    ['eval "$(cat script.sh)"; eval "$__sf_0"', {name: '__sf_0', construct: 'eval'}, undefined],
+    [
+      'sh -c \'echo "$1"\' _ "$MSG"; sh -c "$__sf_0"',
+      {name: '__sf_0', construct: 'sh-c'},
+      {name: 'MSG', construct: 'sh-c'},
+    ],
+    [
+      'source ./scripts/setup.sh "$MSG"; source "$__sf_0"',
+      {name: '__sf_0', construct: 'source'},
+      {name: 'MSG', construct: 'source'},
+    ],
+    [
+      'jq --arg v "$MSG" "$__sf_0"',
+      {name: '__sf_0', construct: 'jq'},
+      {name: 'MSG', construct: 'jq'},
+    ],
+    [
+      'jq --argfile file "$MSG" "$__sf_0"',
+      {name: '__sf_0', construct: 'jq'},
+      {name: 'MSG', construct: 'jq'},
+    ],
+    [
+      'awk -f "$MSG" \'{print}\'; awk "$__sf_0"',
+      {name: '__sf_0', construct: 'awk'},
+      {name: 'MSG', construct: 'awk'},
+    ],
+    [
+      'sed -f "$MSG" \'s/a/b/\'; sed "$__sf_0"',
+      {name: '__sf_0', construct: 'sed'},
+      {name: 'MSG', construct: 'sed'},
+    ],
+    [
+      'sed -i \'s/a/b/\' "$MSG"; sed "$__sf_0"',
+      {name: '__sf_0', construct: 'sed'},
+      {name: 'MSG', construct: 'sed'},
+    ],
+    [
+      'xargs cmd "$MSG"; xargs sh -c "$__sf_0"',
+      {name: '__sf_0', construct: 'xargs-sh-c'},
+      {name: 'MSG', construct: 'xargs-sh-c'},
+    ],
+  ] as const)('distinguishes the data argument from the code argument in %s', (command, allowed, forbidden) => {
+    const result = classifyShellCodePosition({command, workflowDataNames});
+
+    expect(result.matches).toContainEqual(allowed);
+    if (forbidden !== undefined) expect(result.matches).not.toContainEqual(forbidden);
+  });
+
+  it('recognizes generated bindings and direct references in the same command word', () => {
+    const result = classifyShellCodePosition({
+      command: `eval "prefix-\${__sf_0}-suffix"`,
+      workflowDataNames,
+    });
+
+    expect(result.matches).toEqual([{name: '__sf_0', construct: 'eval'}]);
+  });
+
+  it('reports arithmetic references without following command substitutions', () => {
+    const result = classifyShellCodePosition({
+      command: 'echo $(( MSG + $(cat script.sh) ))',
+      workflowDataNames,
+    });
+
+    expect(result.matches).toEqual([{name: 'MSG', construct: 'arithmetic'}]);
+  });
+
+  it.each([
+    ['sudo eval "$MSG"', {name: 'MSG', construct: 'eval'}],
+    ['env eval "$MSG"', {name: 'MSG', construct: 'eval'}],
+    ['command eval "$MSG"', {name: 'MSG', construct: 'eval'}],
+    ['nohup eval "$MSG"', {name: 'MSG', construct: 'eval'}],
+  ] as const)('follows the %s command wrapper', (command, expected) => {
+    const result = classifyShellCodePosition({command, workflowDataNames});
+
+    expect(result.matches).toContainEqual(expected);
+  });
+
+  it.each([
+    ['let "y = MSG == 2"', [{name: 'MSG', construct: 'let'}]],
+    ['let "y = MSG >= 2"', [{name: 'MSG', construct: 'let'}]],
+    ['(( MSG = 1 ))', []],
+    ['((MSG=1))', []],
+    ['(( MSG += 1 ))', [{name: 'MSG', construct: 'arithmetic'}]],
+    ['(( MSG -= 1 ))', [{name: 'MSG', construct: 'arithmetic'}]],
+    ['(( MSG *= 1 ))', [{name: 'MSG', construct: 'arithmetic'}]],
+    ['(( MSG <<= 1 ))', [{name: 'MSG', construct: 'arithmetic'}]],
+    ['(( MSG >>= 1 ))', [{name: 'MSG', construct: 'arithmetic'}]],
+    ['let "MSG += 1"', [{name: 'MSG', construct: 'let'}]],
+    ['declare -i MSG+=1', [{name: 'MSG', construct: 'declare-i'}]],
+    ['declare -i MSG-=1', [{name: 'MSG', construct: 'declare-i'}]],
+    ['declare -i y+=MSG', [{name: 'MSG', construct: 'declare-i'}]],
+  ] as const)('handles arithmetic assignment and comparison operators in %s', (command, expected) => {
+    const result = classifyShellCodePosition({command, workflowDataNames});
+
+    expect(result.matches).toEqual(expected);
+  });
+
+  it('keeps the command word after nested arithmetic', () => {
+    const result = classifyShellCodePosition({
+      command: 'eval $((1+(2))) "$MSG"',
+      workflowDataNames,
+    });
+
+    expect(result.matches).toEqual([{name: 'MSG', construct: 'eval'}]);
+  });
+
+  it('does not treat a redirection target as an eval argument', () => {
+    const result = classifyShellCodePosition({
+      command: 'eval > "$MSG"',
+      workflowDataNames,
+    });
+
+    expect(result.matches).toEqual([]);
+  });
+
+  it('does not infer a dynamic command head', () => {
+    const result = classifyShellCodePosition({
+      command: '$(printf eval) "$MSG"',
+      workflowDataNames,
+    });
+
+    expect(result.matches).toEqual([]);
+  });
+
+  it.each([
+    ['cat <<EOF\neval "$MSG"\nEOF', []],
+    ['cat <<-EOF\neval "$MSG"\nEOF', []],
+    ['(( echo "$MSG" ))', []],
+    ["(( MSG + arr['k'] ))", [{name: 'MSG', construct: 'arithmetic'}]],
+    ['if true; then eval "$MSG"; fi', [{name: 'MSG', construct: 'eval'}]],
+    ['echo $((1 + (MSG)))', [{name: 'MSG', construct: 'arithmetic'}]],
+    [
+      String.raw`eval \
+"$MSG"`,
+      [{name: 'MSG', construct: 'eval'}],
+    ],
+  ] as const)('uses shell lexical state for %s', (command, expected) => {
+    const result = classifyShellCodePosition({command, workflowDataNames});
+
+    expect(result.matches).toEqual(expected);
+  });
+});

--- a/libs/shared/expression/src/run/shell-code-position.ts
+++ b/libs/shared/expression/src/run/shell-code-position.ts
@@ -1,0 +1,828 @@
+import {
+  classifyShellSite,
+  initialShellScanState,
+  type ShellScanState,
+  type ShellSiteContext,
+  scanShellLiteral,
+} from './shell-quoting.js';
+
+const shellIdentifierPattern = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const shellIdentifierStartPattern = /[A-Za-z_]/;
+const shellIdentifierCharacterPattern = /[A-Za-z0-9_]/;
+const shellAssignmentPattern = /^[A-Za-z_][A-Za-z0-9_]*=/;
+const shellDigitPattern = /[0-9]/;
+const shellRedirectionCharacterPattern = /[<>]/;
+const shellSedFlagPattern = /^-[neiErzbsu]+$/;
+const shellWhitespacePattern = /\s/;
+const shellCompoundArithmeticAssignmentPattern =
+  /^[A-Za-z_][A-Za-z0-9_]*\s*(?:\+=|-=|\*=|\/=|%=|<<=|>>=|&=|\|=|\^=)/;
+
+const shellReservedPrefixWords = new Set([
+  'case',
+  'do',
+  'done',
+  'elif',
+  'else',
+  'fi',
+  'for',
+  'if',
+  'in',
+  'then',
+  'time',
+  'until',
+  'while',
+  '!',
+]);
+
+const shellCommandWrapperWords = new Set(['command', 'env', 'nohup', 'sudo']);
+
+export type ShellReevaluatingConstruct =
+  | 'eval'
+  | 'sh-c'
+  | 'bash-c'
+  | 'source'
+  | 'let'
+  | 'declare-i'
+  | 'arithmetic'
+  | 'awk'
+  | 'jq'
+  | 'sed'
+  | 'xargs-sh-c';
+
+export interface ShellCodePositionMatch {
+  readonly construct: ShellReevaluatingConstruct;
+  readonly name: string;
+}
+
+export interface ShellCodePositionAnalysis {
+  readonly matches: readonly ShellCodePositionMatch[];
+}
+
+interface ShellVariableReference {
+  readonly kind: 'direct' | 'arithmetic';
+  readonly name: string;
+}
+
+interface ShellWord {
+  readonly dynamic: boolean;
+  readonly kind: 'word';
+  readonly isRedirectionTarget: boolean;
+  readonly references: readonly ShellVariableReference[];
+  readonly value: string;
+}
+
+interface MutableShellWord {
+  readonly isRedirectionTarget: boolean;
+  readonly references: ShellVariableReference[];
+  readonly value: string[];
+  dynamic: boolean;
+}
+
+interface ShellControl {
+  readonly kind: 'control';
+}
+
+interface ShellRedirection {
+  readonly kind: 'redirection';
+}
+
+type ShellToken = ShellWord | ShellControl | ShellRedirection;
+
+/**
+ * Finds workflow-controlled values that are passed to shell constructs which
+ * deliberately parse or evaluate their arguments again.
+ *
+ * The scanner follows direct references in a single shell word only. It does
+ * not attempt shell data-flow analysis, and intentionally prefers a missed
+ * warning over a false positive.
+ */
+export function classifyShellCodePosition(params: {
+  readonly command: string;
+  readonly workflowDataNames: Iterable<string>;
+}): ShellCodePositionAnalysis {
+  const workflowDataNames = new Set(params.workflowDataNames);
+  const matches = new Map<string, ShellCodePositionMatch>();
+
+  if (workflowDataNames.size === 0) return {matches: []};
+
+  const tokens = tokenizeShell(params.command);
+  let command: ShellWord[] = [];
+
+  const report = (reference: ShellVariableReference, construct: ShellReevaluatingConstruct) => {
+    if (!workflowDataNames.has(reference.name)) return;
+
+    const key = `${construct}:${reference.name}`;
+    if (!matches.has(key)) matches.set(key, {construct, name: reference.name});
+  };
+
+  const reportReferences = (
+    words: readonly ShellWord[],
+    construct: ShellReevaluatingConstruct,
+    kinds: readonly ShellVariableReference['kind'][] = ['direct'],
+  ) => {
+    for (const word of words) {
+      for (const reference of word.references) {
+        if (kinds.includes(reference.kind)) report(reference, construct);
+      }
+    }
+  };
+
+  const analyzeCommand = (words: readonly ShellWord[]) => {
+    const commandWords = words.filter((word) => !word.isRedirectionTarget);
+    const headIndex = commandHeadIndex(commandWords);
+    const head = commandWords[headIndex];
+    if (head === undefined || !shellWordIsStatic(head)) return;
+
+    const commandName = shellCommandName(head.value);
+    if (commandName === undefined) return;
+
+    const argumentWords = commandWords.slice(headIndex + 1);
+
+    if (commandName === 'eval') {
+      reportReferences(argumentWords, 'eval');
+      return;
+    }
+
+    if (commandName === 'sh' || commandName === 'bash') {
+      const program = shellProgramAfterC(argumentWords);
+      if (program !== undefined) {
+        reportReferences([program], commandName === 'sh' ? 'sh-c' : 'bash-c');
+      }
+      return;
+    }
+
+    if (commandName === 'source' || commandName === '.') {
+      reportReferences(argumentWords.slice(0, 1), 'source');
+      return;
+    }
+
+    if (commandName === 'let') {
+      reportReferences(argumentWords, 'let');
+      reportBareArithmeticReferences(argumentWords, 'let', report, workflowDataNames, false);
+      return;
+    }
+
+    if (commandName === 'declare' && argumentWords.some((word) => word.value === '-i')) {
+      reportReferences(argumentWords, 'declare-i');
+      reportBareArithmeticReferences(argumentWords, 'declare-i', report, workflowDataNames, true);
+      return;
+    }
+
+    if (commandName === 'awk' || commandName === 'jq' || commandName === 'sed') {
+      const program = interpreterProgramWord(commandName, argumentWords);
+      if (program !== undefined) reportReferences([program], commandName);
+      return;
+    }
+
+    if (commandName === 'xargs') {
+      const nestedShell = xargsShellProgram(argumentWords);
+      if (nestedShell !== undefined) {
+        reportReferences([nestedShell.program], 'xargs-sh-c');
+      }
+    }
+  };
+
+  for (const token of tokens) {
+    if (token.kind === 'control') {
+      analyzeCommand(command);
+      command = [];
+      continue;
+    }
+
+    if (
+      token.kind === 'word' &&
+      token.references.some((reference) => reference.kind === 'arithmetic')
+    ) {
+      reportReferences([token], 'arithmetic', ['arithmetic']);
+    }
+
+    if (token.kind === 'word') command.push(token);
+  }
+
+  analyzeCommand(command);
+
+  return {matches: [...matches.values()]};
+}
+
+function tokenizeShell(source: string): readonly ShellToken[] {
+  const tokens: ShellToken[] = [];
+  let current: MutableShellWord | undefined;
+  let index = 0;
+  let redirectionTarget = false;
+  let wordCanStartComment = true;
+  let scanState: ShellScanState = initialShellScanState;
+  let arithmeticContext = false;
+  let parameterBracketDepth = 0;
+  let arithmeticBracketDepth = 0;
+  let arithmeticShellSyntax = false;
+
+  function ensureWord(): MutableShellWord {
+    if (current !== undefined) return current;
+    current = {
+      dynamic: false,
+      isRedirectionTarget: redirectionTarget,
+      references: [],
+      value: [],
+    };
+    redirectionTarget = false;
+    wordCanStartComment = false;
+    return current;
+  }
+
+  function flushWord(): void {
+    if (current === undefined) return;
+    tokens.push({
+      dynamic: current.dynamic,
+      kind: 'word',
+      isRedirectionTarget: current.isRedirectionTarget,
+      references: current.references.filter(
+        (reference) => !(arithmeticShellSyntax && reference.kind === 'arithmetic'),
+      ),
+      value: current.value.join(''),
+    });
+    current = undefined;
+    arithmeticShellSyntax = false;
+  }
+
+  function markDynamic(): void {
+    ensureWord().dynamic = true;
+  }
+
+  function addReference(name: string, kind: ShellVariableReference['kind']): void {
+    if (kind === 'arithmetic' && arithmeticShellSyntax) return;
+    ensureWord().references.push({kind, name});
+  }
+
+  function markArithmeticShellSyntax(): void {
+    arithmeticShellSyntax = true;
+  }
+
+  function advance(text: string): void {
+    scanState = scanShellLiteral(text, scanState);
+    index += text.length;
+
+    const site = classifyShellSite(scanState);
+    if (arithmeticContext && !(site.kind === 'unsafe' && site.region === 'arith')) {
+      arithmeticContext = false;
+      arithmeticBracketDepth = 0;
+    }
+  }
+
+  function advanceEscape(): void {
+    const nextCharacter = source[index + 1];
+    if (nextCharacter === undefined) {
+      advance(source[index] ?? '');
+      return;
+    }
+
+    if (nextCharacter !== '\n') ensureWord().value.push(nextCharacter);
+    advance(source.slice(index, index + 2));
+  }
+
+  function advanceExpansion(kind: ShellVariableReference['kind']): boolean {
+    if (source[index] !== '$') return false;
+
+    if (source.startsWith('$((', index)) {
+      markDynamic();
+      arithmeticContext = true;
+      advance('$((');
+      return true;
+    }
+
+    if (source.startsWith('$[', index)) {
+      markDynamic();
+      arithmeticContext = true;
+      advance('$[');
+      return true;
+    }
+
+    if (source.startsWith('$(', index)) {
+      markDynamic();
+      advance('$(');
+      return true;
+    }
+
+    if (source.startsWith('${', index)) {
+      markDynamic();
+      const firstName = readParameterName(source, index + 2);
+      if (firstName !== undefined) addReference(firstName.value, kind);
+      advance('${');
+      return true;
+    }
+
+    if (source.startsWith("$'", index) || source.startsWith('$"', index)) {
+      markDynamic();
+      advance(source.slice(index, index + 2));
+      return true;
+    }
+
+    const name = readShellIdentifier(source, index + 1);
+    if (name === undefined) return false;
+
+    addReference(name.value, kind);
+    advance(source.slice(index, name.index));
+    return true;
+  }
+
+  while (index < source.length) {
+    const character = source[index];
+    if (character === undefined) break;
+
+    const site = classifyShellSite(scanState);
+    if (site.kind === 'unsafe') {
+      if (site.region === 'line-comment') {
+        if (character === '\n') {
+          advance('\n');
+          flushWord();
+          tokens.push({kind: 'control'});
+          wordCanStartComment = true;
+          redirectionTarget = false;
+        } else {
+          advance(character);
+        }
+        continue;
+      }
+
+      if (site.region === 'heredoc') {
+        advance(character);
+        continue;
+      }
+
+      if (site.region === 'arith') {
+        if (character === '[') arithmeticBracketDepth += 1;
+        if (character === ']' && arithmeticBracketDepth > 0) arithmeticBracketDepth -= 1;
+        if (
+          arithmeticBracketDepth === 0 &&
+          (character === "'" || character === '"' || character === '`')
+        ) {
+          markArithmeticShellSyntax();
+        }
+
+        if (advanceExpansion('arithmetic')) continue;
+
+        const name = readShellIdentifier(source, index);
+        if (name !== undefined) {
+          const nextIndex = skipWhitespace(source, name.index);
+          if (!isArithmeticAssignment(source, nextIndex)) addReference(name.value, 'arithmetic');
+          advance(source.slice(index, name.index));
+          continue;
+        }
+      } else if (site.region === 'param-brace') {
+        if (character === '[') parameterBracketDepth += 1;
+        if (character === ']' && parameterBracketDepth > 0) parameterBracketDepth -= 1;
+
+        const referenceKind =
+          arithmeticContext || parameterBracketDepth > 0 ? 'arithmetic' : 'direct';
+        if (advanceExpansion(referenceKind)) continue;
+      } else {
+        markDynamic();
+      }
+
+      const chunk = scannerChunkAt(source, index, site);
+      advance(chunk);
+      continue;
+    }
+
+    if (character === '\\') {
+      advanceEscape();
+      continue;
+    }
+
+    if (character === '#' && wordCanStartComment) {
+      advance('#');
+      continue;
+    }
+
+    if (character === '$' && advanceExpansion('direct')) continue;
+
+    if (character === '`') {
+      markDynamic();
+      advance('`');
+      continue;
+    }
+
+    if (site.kind === 'unquoted' && isShellWhitespace(character)) {
+      flushWord();
+      if (character === '\n') tokens.push({kind: 'control'});
+      wordCanStartComment = true;
+      if (character === '\n') redirectionTarget = false;
+      advance(character);
+      continue;
+    }
+
+    if (character === "'" || character === '"') {
+      ensureWord();
+      advance(character);
+      continue;
+    }
+
+    if (site.kind === 'unquoted' && startsShellRedirection(source, index)) {
+      flushWord();
+      tokens.push({kind: 'redirection'});
+      redirectionTarget = true;
+      wordCanStartComment = true;
+      const length = shellRedirectionLength(source, index);
+      advance(source.slice(index, index + length));
+      continue;
+    }
+
+    if (site.kind === 'unquoted' && startsShellArithmetic(source, index)) {
+      markDynamic();
+      arithmeticContext = true;
+      advance('((');
+      continue;
+    }
+
+    if (site.kind === 'unquoted' && startsShellControl(source, index)) {
+      flushWord();
+      tokens.push({kind: 'control'});
+      wordCanStartComment = true;
+      redirectionTarget = false;
+      advance(source.slice(index, index + shellControlLength(source, index)));
+      continue;
+    }
+
+    ensureWord().value.push(character);
+    advance(character);
+  }
+
+  flushWord();
+  return tokens;
+}
+
+function scannerChunkAt(
+  source: string,
+  index: number,
+  site: Extract<ShellSiteContext, {kind: 'unsafe'}>,
+): string {
+  if (site.region === 'arith' && source[index] === ')') {
+    let closingRunLength = 0;
+    while (source[index + closingRunLength] === ')') closingRunLength += 1;
+    if (closingRunLength > 2) return ')'.repeat(closingRunLength - 2);
+    if (closingRunLength === 2) return '))';
+    return ')';
+  }
+  if (source.startsWith('$((', index)) return '$((';
+  if (source.startsWith('((', index)) return '((';
+  if (source.startsWith('$[', index)) return '$[';
+  if (source.startsWith('$(', index) || source.startsWith('${', index))
+    return source.slice(index, index + 2);
+  if (source.startsWith('<<-', index)) return '<<-';
+  if (source.startsWith('<<', index)) return '<<';
+  if (source[index] === '\\' && index + 1 < source.length) return source.slice(index, index + 2);
+  return source[index] ?? '';
+}
+
+function commandHeadIndex(words: readonly ShellWord[]): number {
+  let index = 0;
+  while (index < words.length) {
+    const word = words[index];
+    if (isShellAssignment(word)) {
+      index += 1;
+      continue;
+    }
+    if (word !== undefined && shellWordIsStatic(word) && shellReservedPrefixWords.has(word.value)) {
+      index += 1;
+      continue;
+    }
+    if (word !== undefined && shellWordIsStatic(word) && shellCommandWrapperWords.has(word.value)) {
+      index += 1;
+      continue;
+    }
+    break;
+  }
+  return index;
+}
+
+function shellWordIsStatic(word: ShellWord): boolean {
+  return !word.dynamic && word.references.length === 0;
+}
+
+function shellCommandName(value: string): string | undefined {
+  if (value.length === 0) return undefined;
+  const name = value.split('/').at(-1);
+  return name === undefined || (!shellIdentifierPattern.test(name) && name !== '.')
+    ? undefined
+    : name;
+}
+
+function shellProgramAfterC(words: readonly ShellWord[]): ShellWord | undefined {
+  for (let index = 0; index < words.length; index += 1) {
+    const word = words[index];
+    if (word?.value === '-c' || word?.value === '--command') return words[index + 1];
+    if (word?.value.startsWith('-') && !word.value.startsWith('--') && word.value.includes('c')) {
+      return words[index + 1];
+    }
+    if (word?.value === '--') return undefined;
+  }
+  return undefined;
+}
+
+function reportBareArithmeticReferences(
+  words: readonly ShellWord[],
+  construct: 'let' | 'declare-i',
+  report: (reference: ShellVariableReference, construct: ShellReevaluatingConstruct) => void,
+  workflowDataNames: ReadonlySet<string>,
+  skipDeclarationNames: boolean,
+): void {
+  for (const word of words) {
+    if (word.references.length > 0 || word.value.startsWith('-')) continue;
+    const expression = skipDeclarationNames ? declarationExpression(word.value) : word.value;
+    if (expression === undefined) continue;
+
+    for (const identifier of arithmeticIdentifiers(expression)) {
+      if (workflowDataNames.has(identifier)) {
+        report({kind: 'arithmetic', name: identifier}, construct);
+      }
+    }
+  }
+}
+
+function declarationExpression(value: string): string | undefined {
+  if (shellIdentifierPattern.test(value)) return undefined;
+  if (shellCompoundArithmeticAssignmentPattern.test(value)) {
+    return value;
+  }
+  const assignmentIndex = value.indexOf('=');
+  if (assignmentIndex < 0) return undefined;
+  return value.slice(assignmentIndex + 1);
+}
+
+function arithmeticIdentifiers(source: string): readonly string[] {
+  const identifiers: string[] = [];
+  let index = 0;
+  while (index < source.length) {
+    const name = readShellIdentifier(source, index);
+    if (name === undefined) {
+      index += 1;
+      continue;
+    }
+
+    const nextIndex = skipWhitespace(source, name.index);
+    if (!isArithmeticAssignment(source, nextIndex)) identifiers.push(name.value);
+    index = name.index;
+  }
+  return identifiers;
+}
+
+function isArithmeticAssignment(source: string, index: number): boolean {
+  return source[index] === '=' && source[index + 1] !== '=';
+}
+
+function interpreterProgramWord(
+  command: 'awk' | 'jq' | 'sed',
+  words: readonly ShellWord[],
+): ShellWord | undefined {
+  let index = 0;
+  while (index < words.length) {
+    const word = words[index];
+    if (word === undefined) return undefined;
+    const value = word.value;
+
+    if (value === '--') return words[index + 1];
+    if (!value.startsWith('-') || value === '-') return word;
+
+    if (command === 'jq' && jqOptionConsumesArguments(value)) {
+      index += 3;
+      continue;
+    }
+
+    if (command === 'awk' && awkOptionConsumesArgument(value)) {
+      index += 2;
+      continue;
+    }
+
+    if (command === 'awk' && (value === '-e' || value === '--source')) {
+      return words[index + 1];
+    }
+
+    if (command === 'sed' && (value === '-e' || value === '--expression')) {
+      return words[index + 1];
+    }
+
+    if (command === 'sed' && sedOptionConsumesArgument(value)) {
+      index += 2;
+      continue;
+    }
+
+    if (command === 'sed' && value.startsWith('--expression=')) return word;
+    if (command === 'sed' && value.startsWith('--file=')) {
+      index += 1;
+      continue;
+    }
+
+    if (command === 'jq' && jqFlag(value)) {
+      index += 1;
+      continue;
+    }
+
+    if (command === 'awk' && awkFlag(value)) {
+      index += 1;
+      continue;
+    }
+
+    if (command === 'sed' && sedFlag(value)) {
+      index += 1;
+      continue;
+    }
+
+    return undefined;
+  }
+  return undefined;
+}
+
+function jqOptionConsumesArguments(value: string): boolean {
+  return (
+    value === '--arg' ||
+    value === '--argjson' ||
+    value === '--argfile' ||
+    value === '--slurpfile' ||
+    value === '--rawfile'
+  );
+}
+
+function awkOptionConsumesArgument(value: string): boolean {
+  return (
+    value === '-f' ||
+    value === '-v' ||
+    value === '-F' ||
+    value === '--assign' ||
+    value === '--field-separator'
+  );
+}
+
+function sedOptionConsumesArgument(value: string): boolean {
+  return value === '-f' || value === '--file';
+}
+
+function jqFlag(value: string): boolean {
+  return new Set([
+    '-c',
+    '-e',
+    '-j',
+    '-M',
+    '-n',
+    '-r',
+    '-s',
+    '-S',
+    '-C',
+    '--ascii-output',
+    '--compact-output',
+    '--exit-status',
+    '--join-output',
+    '--monochrome-output',
+    '--null-input',
+    '--raw-output',
+    '--sort-keys',
+    '--slurp',
+    '--tab',
+    '--version',
+  ]).has(value);
+}
+
+function awkFlag(value: string): boolean {
+  return (
+    value === '--posix' || value === '--traditional' || value === '--lint' || value === '--sandbox'
+  );
+}
+
+function sedFlag(value: string): boolean {
+  return (
+    shellSedFlagPattern.test(value) ||
+    value === '--posix' ||
+    value === '--regexp-extended' ||
+    value === '--in-place'
+  );
+}
+
+function xargsShellProgram(words: readonly ShellWord[]): {readonly program: ShellWord} | undefined {
+  let index = 0;
+  while (index < words.length) {
+    const word = words[index];
+    if (word === undefined) return undefined;
+    const value = word.value;
+    if (value === '--') {
+      index += 1;
+      break;
+    }
+    if (!value.startsWith('-') || value === '-') break;
+    if (xargsOptionConsumesArgument(value)) index += 2;
+    else index += 1;
+  }
+
+  const shell = words[index];
+  if (shell === undefined || !shellWordIsStatic(shell)) return undefined;
+  const shellName = shellCommandName(shell.value);
+  if (shellName !== 'sh' && shellName !== 'bash') return undefined;
+
+  const program = shellProgramAfterC(words.slice(index + 1));
+  return program === undefined ? undefined : {program};
+}
+
+function xargsOptionConsumesArgument(value: string): boolean {
+  return (
+    value === '-d' ||
+    value === '-E' ||
+    value === '-I' ||
+    value === '-J' ||
+    value === '-L' ||
+    value === '-n' ||
+    value === '-P' ||
+    value === '-s' ||
+    value === '--delimiter' ||
+    value === '--eof' ||
+    value === '--max-args' ||
+    value === '--max-lines' ||
+    value === '--max-procs' ||
+    value === '--max-chars' ||
+    value === '--replace'
+  );
+}
+
+function isShellAssignment(word: ShellWord | undefined): boolean {
+  return word !== undefined && shellAssignmentPattern.test(word.value);
+}
+
+function readParameterName(
+  source: string,
+  start: number,
+): {readonly index: number; readonly value: string} | undefined {
+  const prefix = source[start];
+  return readShellIdentifier(source, prefix === '!' || prefix === '#' ? start + 1 : start);
+}
+
+function readShellIdentifier(
+  source: string,
+  start: number,
+): {readonly index: number; readonly value: string} | undefined {
+  if (!shellIdentifierStartPattern.test(source[start] ?? '')) return undefined;
+  let index = start + 1;
+  while (shellIdentifierCharacterPattern.test(source[index] ?? '')) index += 1;
+  return {index, value: source.slice(start, index)};
+}
+
+function skipWhitespace(source: string, start: number): number {
+  let index = start;
+  while (shellWhitespacePattern.test(source[index] ?? '')) index += 1;
+  return index;
+}
+
+function isShellWhitespace(character: string): boolean {
+  return character === ' ' || character === '\t' || character === '\r' || character === '\n';
+}
+
+function startsShellRedirection(source: string, index: number): boolean {
+  if (source[index] === '>' || source[index] === '<') return true;
+  return (
+    shellDigitPattern.test(source[index] ?? '') &&
+    shellRedirectionCharacterPattern.test(source[index + 1] ?? '')
+  );
+}
+
+function shellRedirectionLength(source: string, index: number): number {
+  let nextIndex = index;
+  while (shellDigitPattern.test(source[nextIndex] ?? '')) nextIndex += 1;
+  if (source.startsWith('<<<', nextIndex)) return nextIndex - index + 3;
+  if (source.startsWith('<<-', nextIndex)) return nextIndex - index + 3;
+  if (source.startsWith('<<', nextIndex)) return nextIndex - index + 2;
+  if (
+    source.startsWith('>>', nextIndex) ||
+    source.startsWith('<>', nextIndex) ||
+    source.startsWith('>&', nextIndex) ||
+    source.startsWith('<&', nextIndex) ||
+    source.startsWith('>|', nextIndex)
+  ) {
+    return nextIndex - index + 2;
+  }
+  return nextIndex - index + 1;
+}
+
+function startsShellArithmetic(source: string, index: number): boolean {
+  return source.startsWith('((', index);
+}
+
+function startsShellControl(source: string, index: number): boolean {
+  return (
+    source[index] === ';' ||
+    source[index] === '&' ||
+    source[index] === '|' ||
+    source[index] === '(' ||
+    source[index] === ')' ||
+    source[index] === '{' ||
+    source[index] === '}'
+  );
+}
+
+function shellControlLength(source: string, index: number): number {
+  if (
+    source.startsWith('&&', index) ||
+    source.startsWith('||', index) ||
+    source.startsWith(';;', index) ||
+    source.startsWith(';&', index) ||
+    source.startsWith(';;&', index) ||
+    source.startsWith('|&', index)
+  ) {
+    return source.startsWith(';;&', index) ? 3 : 2;
+  }
+  return 1;
+}

--- a/libs/shared/expression/src/run/shell-code-position.ts
+++ b/libs/shared/expression/src/run/shell-code-position.ts
@@ -60,6 +60,7 @@ export interface ShellCodePositionAnalysis {
 
 interface ShellVariableReference {
   readonly kind: 'direct' | 'arithmetic';
+  readonly isSingleQuotedLiteral: boolean;
   readonly name: string;
 }
 
@@ -119,16 +120,26 @@ export function classifyShellCodePosition(params: {
     words: readonly ShellWord[],
     construct: ShellReevaluatingConstruct,
     kinds: readonly ShellVariableReference['kind'][] = ['direct'],
+    includeSingleQuotedLiterals = false,
   ) => {
     for (const word of words) {
       for (const reference of word.references) {
-        if (kinds.includes(reference.kind)) report(reference, construct);
+        if (
+          kinds.includes(reference.kind) &&
+          (includeSingleQuotedLiterals || !reference.isSingleQuotedLiteral)
+        ) {
+          report(reference, construct);
+        }
       }
     }
   };
 
   const analyzeCommand = (words: readonly ShellWord[]) => {
     const commandWords = words.filter((word) => !word.isRedirectionTarget);
+    const firstWord = commandWords[0];
+    if (firstWord !== undefined && shellWordIsStatic(firstWord) && firstWord.value === 'for') {
+      return;
+    }
     const headIndex = commandHeadIndex(commandWords);
     const head = commandWords[headIndex];
     if (head === undefined || !shellWordIsStatic(head)) return;
@@ -139,7 +150,7 @@ export function classifyShellCodePosition(params: {
     const argumentWords = commandWords.slice(headIndex + 1);
 
     if (commandName === 'eval') {
-      reportReferences(argumentWords, 'eval');
+      reportReferences(argumentWords, 'eval', ['direct'], true);
       return;
     }
 
@@ -248,9 +259,13 @@ function tokenizeShell(source: string): readonly ShellToken[] {
     ensureWord().dynamic = true;
   }
 
-  function addReference(name: string, kind: ShellVariableReference['kind']): void {
+  function addReference(
+    name: string,
+    kind: ShellVariableReference['kind'],
+    isSingleQuotedLiteral = false,
+  ): void {
     if (kind === 'arithmetic' && arithmeticShellSyntax) return;
-    ensureWord().references.push({kind, name});
+    ensureWord().references.push({kind, isSingleQuotedLiteral, name});
   }
 
   function markArithmeticShellSyntax(): void {
@@ -279,7 +294,10 @@ function tokenizeShell(source: string): readonly ShellToken[] {
     advance(source.slice(index, index + 2));
   }
 
-  function advanceExpansion(kind: ShellVariableReference['kind']): boolean {
+  function advanceExpansion(
+    kind: ShellVariableReference['kind'],
+    isSingleQuotedLiteral = false,
+  ): boolean {
     if (source[index] !== '$') return false;
 
     if (source.startsWith('$((', index)) {
@@ -305,7 +323,9 @@ function tokenizeShell(source: string): readonly ShellToken[] {
     if (source.startsWith('${', index)) {
       markDynamic();
       const firstName = readParameterName(source, index + 2);
-      if (firstName !== undefined) addReference(firstName.value, kind);
+      if (source[index + 2] !== '#' && firstName !== undefined) {
+        addReference(firstName.value, kind, isSingleQuotedLiteral);
+      }
       advance('${');
       return true;
     }
@@ -319,7 +339,7 @@ function tokenizeShell(source: string): readonly ShellToken[] {
     const name = readShellIdentifier(source, index + 1);
     if (name === undefined) return false;
 
-    addReference(name.value, kind);
+    addReference(name.value, kind, isSingleQuotedLiteral);
     advance(source.slice(index, name.index));
     return true;
   }
@@ -393,7 +413,7 @@ function tokenizeShell(source: string): readonly ShellToken[] {
       continue;
     }
 
-    if (character === '$' && advanceExpansion('direct')) continue;
+    if (character === '$' && advanceExpansion('direct', site.kind === 'single')) continue;
 
     if (character === '`') {
       markDynamic();
@@ -532,7 +552,7 @@ function reportBareArithmeticReferences(
 
     for (const identifier of arithmeticIdentifiers(expression)) {
       if (workflowDataNames.has(identifier)) {
-        report({kind: 'arithmetic', name: identifier}, construct);
+        report({kind: 'arithmetic', name: identifier, isSingleQuotedLiteral: false}, construct);
       }
     }
   }

--- a/libs/shared/expression/src/run/shell-quoting.ts
+++ b/libs/shared/expression/src/run/shell-quoting.ts
@@ -327,18 +327,7 @@ function scanShellPlainStart(
     return dollarDoubleStart;
   }
 
-  const frame = topFrame(frames);
   const arithStart = matchShellLogicalPrefix(text, index, '((');
-  if (isArithFrame(frame) && arithStart !== undefined) {
-    replaceTopArithFrame(frames, frame.parenthesisDepth + 2);
-    return arithStart;
-  }
-
-  if (isArithFrame(frame) && text[index] === '(') {
-    replaceTopArithFrame(frames, frame.parenthesisDepth + 1);
-    return index + 1;
-  }
-
   if (arithStart !== undefined) {
     frames.push({kind: 'arith', parenthesisDepth: 0});
     return arithStart;

--- a/libs/shared/expression/src/run/shell-quoting.ts
+++ b/libs/shared/expression/src/run/shell-quoting.ts
@@ -15,7 +15,11 @@ interface ArithSquareFrame {
   readonly kind: 'arith-square';
   readonly bracketDepth: number;
 }
-type ShellScanFrame = ShellFrame | ArithSquareFrame;
+interface ArithFrame {
+  readonly kind: 'arith';
+  readonly parenthesisDepth: number;
+}
+type ShellScanFrame = Exclude<ShellFrame, 'arith'> | ArithFrame | ArithSquareFrame;
 
 export type ShellSiteContext =
   | {readonly kind: 'unquoted' | 'single' | 'double'}
@@ -163,11 +167,23 @@ export function scanShellLiteral(text: string, state: ShellScanState): ShellScan
       continue;
     }
 
-    if (frame === 'arith') {
+    if (isArithFrame(frame)) {
       const arithEnd = matchShellLogicalPrefix(text, index, '))');
-      if (arithEnd !== undefined) {
+      if (frame.parenthesisDepth === 0 && arithEnd !== undefined) {
         frames.pop();
         advance(arithEnd, false);
+        continue;
+      }
+
+      if (text[index] === ')') {
+        replaceTopArithFrame(frames, Math.max(0, frame.parenthesisDepth - 1));
+        advance(index + 1, false);
+        continue;
+      }
+
+      if (text[index] === '(') {
+        replaceTopArithFrame(frames, frame.parenthesisDepth + 1);
+        advance(index + 1, false);
         continue;
       }
 
@@ -277,7 +293,7 @@ function scanShellPlainStart(
 
   const dollarArithStart = matchShellLogicalPrefix(text, index, '$((');
   if (dollarArithStart !== undefined) {
-    frames.push('arith');
+    frames.push({kind: 'arith', parenthesisDepth: 0});
     return dollarArithStart;
   }
 
@@ -311,9 +327,20 @@ function scanShellPlainStart(
     return dollarDoubleStart;
   }
 
+  const frame = topFrame(frames);
   const arithStart = matchShellLogicalPrefix(text, index, '((');
+  if (isArithFrame(frame) && arithStart !== undefined) {
+    replaceTopArithFrame(frames, frame.parenthesisDepth + 2);
+    return arithStart;
+  }
+
+  if (isArithFrame(frame) && text[index] === '(') {
+    replaceTopArithFrame(frames, frame.parenthesisDepth + 1);
+    return index + 1;
+  }
+
   if (arithStart !== undefined) {
-    frames.push('arith');
+    frames.push({kind: 'arith', parenthesisDepth: 0});
     return arithStart;
   }
 
@@ -338,7 +365,7 @@ function scanShellPlainStart(
 function scanShellControlStart(text: string, index: number, frames: ShellScanFrame[]): number {
   const dollarArithStart = matchShellLogicalPrefix(text, index, '$((');
   if (dollarArithStart !== undefined) {
-    frames.push('arith');
+    frames.push({kind: 'arith', parenthesisDepth: 0});
     return dollarArithStart;
   }
 
@@ -428,7 +455,7 @@ function topFrame(frames: readonly ShellScanFrame[]): ShellScanFrame | undefined
 }
 
 function cloneShellScanFrame(frame: ShellScanFrame): ShellScanFrame {
-  if (isArithSquareFrame(frame)) return {...frame};
+  if (isArithSquareFrame(frame) || isArithFrame(frame)) return {...frame};
   return frame;
 }
 
@@ -437,6 +464,7 @@ function findUnsafeRegion(frames: readonly ShellScanFrame[]): ShellFrame {
     const frame = frames[index];
     if (frame === undefined) continue;
     if (isArithSquareFrame(frame)) return 'arith';
+    if (isArithFrame(frame)) return 'arith';
     if (frame !== 'single' && frame !== 'double') return frame;
   }
 
@@ -445,6 +473,16 @@ function findUnsafeRegion(frames: readonly ShellScanFrame[]): ShellFrame {
 
 function isArithSquareFrame(frame: ShellScanFrame | undefined): frame is ArithSquareFrame {
   return typeof frame === 'object' && frame.kind === 'arith-square';
+}
+
+function isArithFrame(frame: ShellScanFrame | undefined): frame is ArithFrame {
+  return typeof frame === 'object' && frame.kind === 'arith';
+}
+
+function replaceTopArithFrame(frames: ShellScanFrame[], parenthesisDepth: number): void {
+  const topIndex = frames.length - 1;
+  const frame = frames[topIndex];
+  if (isArithFrame(frame)) frames[topIndex] = {...frame, parenthesisDepth};
 }
 
 function replaceTopArithSquareFrame(frames: ShellScanFrame[], bracketDepth: number): void {


### PR DESCRIPTION
Add pure analysis in `@shipfox/expression` to detect direct generated and workflow-environment bindings used in shell positions that re-evaluate their arguments. The classifier reuses the shared lexical scanner for quoting, heredocs, continuations, substitutions, arithmetic, and nested parentheses without wiring consumers or changing runtime behavior.

It covers the issue’s command matrix, common wrapper and option forms, safe data positions, and false-positive-sensitive shell syntax. The shared scanner change also keeps hoisting and classification consistent for nested arithmetic.

Closes ENG-1404

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a pure shell code-position classifier to `@shipfox/expression` that flags workflow-controlled values passed to commands that re-evaluate their arguments. Addresses ENG-1404 with a shallow analysis tuned to avoid false positives; scanner refined to preserve shell literal semantics and skip loop headers, with no runtime wiring.

- **New Features**
  - Adds `classifyShellCodePosition` and exports it from the package.
  - Detects direct references in eval; sh/bash -c; source/.; let/declare -i/$(( )); awk/jq/sed; and xargs … sh -c.
  - Includes a table-driven test suite covering report/silent cases and common safe forms.

- **Refactors**
  - Extends the shell scanner to track nested arithmetic parentheses, preserve literal semantics, and remove unreachable nested-arithmetic scan paths.
  - Skips loop headers (e.g., `for`) when computing the command head for more precise classification.

<sup>Written for commit b5ebc15b4ce506f2c9c2dbeb4306fde117989ebc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

