### PR TITLE
[api-workflows] Add sequential numbers to workflow runs

### DIFF
--- a/.changeset/sequential-run-numbers.md
+++ b/.changeset/sequential-run-numbers.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/api-workflows": minor
+"@shipfox/api-workflows-dto": minor
+"@shipfox/expression": minor
+---
+
+Add per-definition sequential numbers to workflow runs and expose them in the API and expression context.

--- a/e2e/observe/workflows/src/index.test.ts
+++ b/e2e/observe/workflows/src/index.test.ts
@@ -25,6 +25,7 @@ function run(params: Partial<WorkflowRunDto> = {}): WorkflowRunDto {
     id: params.id ?? runId,
     project_id: params.project_id ?? projectId,
     definition_id: params.definition_id ?? definitionId,
+    number: params.number ?? 1,
     name: params.name ?? 'Build',
     workflow_name: params.workflow_name ?? 'Build',
     status: params.status ?? 'pending',

--- a/e2e/suites/flow/workflows/src/expect.test.ts
+++ b/e2e/suites/flow/workflows/src/expect.test.ts
@@ -107,6 +107,7 @@ function makeDetail(
     id: '33333333-3333-4333-8333-333333333333',
     project_id: '11111111-1111-4111-8111-111111111111',
     definition_id: '22222222-2222-4222-8222-222222222222',
+    number: 1,
     name: 'Hello world',
     workflow_name: 'Hello world',
     status: 'succeeded',

--- a/e2e/suites/flow/workflows/src/listener-helpers.test.ts
+++ b/e2e/suites/flow/workflows/src/listener-helpers.test.ts
@@ -88,6 +88,7 @@ function runDetail(
     id: '33333333-3333-4333-8333-333333333333',
     project_id: '11111111-1111-4111-8111-111111111111',
     definition_id: '22222222-2222-4222-8222-222222222222',
+    number: 1,
     name: 'Listener workflow',
     workflow_name: 'Listener workflow',
     status: 'succeeded',

--- a/libs/api/workflows-dto/src/schemas/workflow-run.test.ts
+++ b/libs/api/workflows-dto/src/schemas/workflow-run.test.ts
@@ -4,6 +4,7 @@ const baseRun = {
   id: '11111111-1111-4111-8111-111111111111',
   project_id: '22222222-2222-4222-8222-222222222222',
   definition_id: '33333333-3333-4333-8333-333333333333',
+  number: 1,
   name: 'Build',
   workflow_name: 'Build',
   status: 'pending',

--- a/libs/api/workflows-dto/src/schemas/workflow-run.ts
+++ b/libs/api/workflows-dto/src/schemas/workflow-run.ts
@@ -79,6 +79,7 @@ export const workflowRunDtoSchema = z.object({
   id: z.string().uuid(),
   project_id: z.string().uuid(),
   definition_id: z.string().uuid(),
+  number: z.number().int().positive(),
   name: z.string(),
   workflow_name: z.string(),
   status: workflowRunStatusSchema,

--- a/libs/api/workflows/drizzle/0000_initial.sql
+++ b/libs/api/workflows/drizzle/0000_initial.sql
@@ -158,11 +158,17 @@ CREATE TABLE "workflows_workflow_run_attempts" (
 	CONSTRAINT "workflows_wra_attempt_positive_ck" CHECK ("workflows_workflow_run_attempts"."attempt" > 0)
 );
 --> statement-breakpoint
+CREATE TABLE "workflows_workflow_run_counters" (
+	"definition_id" uuid NOT NULL,
+	"next_number" integer NOT NULL
+);
+--> statement-breakpoint
 CREATE TABLE "workflows_workflow_runs" (
 	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
 	"workspace_id" uuid NOT NULL,
 	"project_id" uuid NOT NULL,
 	"definition_id" uuid NOT NULL,
+	"number" integer NOT NULL,
 	"name" text NOT NULL,
 	"status" "workflows_run_status" DEFAULT 'pending' NOT NULL,
 	"current_attempt" integer DEFAULT 1 NOT NULL,
@@ -203,7 +209,9 @@ CREATE INDEX "workflows_outbox_dispatched_retention_idx" ON "workflows_outbox" U
 CREATE INDEX "workflows_steps_job_execution_id_idx" ON "workflows_steps" USING btree ("job_execution_id");--> statement-breakpoint
 CREATE UNIQUE INDEX "workflows_wra_workflow_run_attempt_unique" ON "workflows_workflow_run_attempts" USING btree ("workflow_run_id","attempt");--> statement-breakpoint
 CREATE UNIQUE INDEX "workflows_wra_one_active_attempt_unique" ON "workflows_workflow_run_attempts" USING btree ("workflow_run_id") WHERE "workflows_workflow_run_attempts"."status" in ('pending', 'running');--> statement-breakpoint
+CREATE UNIQUE INDEX "workflows_wrrc_definition_id_unique" ON "workflows_workflow_run_counters" USING btree ("definition_id");--> statement-breakpoint
 CREATE UNIQUE INDEX "workflows_wr_trigger_idempotency_key_unique" ON "workflows_workflow_runs" USING btree ("trigger_idempotency_key");--> statement-breakpoint
+CREATE UNIQUE INDEX "workflows_wr_definition_number_unique" ON "workflows_workflow_runs" USING btree ("definition_id","number");--> statement-breakpoint
 CREATE INDEX "workflows_wr_project_created_id_idx" ON "workflows_workflow_runs" USING btree ("project_id","created_at","id");--> statement-breakpoint
 CREATE INDEX "workflows_wr_project_status_created_id_idx" ON "workflows_workflow_runs" USING btree ("project_id","status","created_at","id");--> statement-breakpoint
 CREATE INDEX "workflows_wr_project_definition_created_id_idx" ON "workflows_workflow_runs" USING btree ("project_id","definition_id","created_at","id");--> statement-breakpoint

--- a/libs/api/workflows/drizzle/meta/0000_snapshot.json
+++ b/libs/api/workflows/drizzle/meta/0000_snapshot.json
@@ -1216,6 +1216,47 @@
       },
       "isRLSEnabled": false
     },
+    "public.workflows_workflow_run_counters": {
+      "name": "workflows_workflow_run_counters",
+      "schema": "",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_number": {
+          "name": "next_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflows_wrrc_definition_id_unique": {
+          "name": "workflows_wrrc_definition_id_unique",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
     "public.workflows_workflow_runs": {
       "name": "workflows_workflow_runs",
       "schema": "",
@@ -1242,6 +1283,12 @@
         "definition_id": {
           "name": "definition_id",
           "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
           "primaryKey": false,
           "notNull": true
         },
@@ -1355,6 +1402,27 @@
           "columns": [
             {
               "expression": "trigger_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_definition_number_unique": {
+          "name": "workflows_wr_definition_number_unique",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
               "isExpression": false,
               "asc": true,
               "nulls": "last"

--- a/libs/api/workflows/src/core/entities/workflow-run.ts
+++ b/libs/api/workflows/src/core/entities/workflow-run.ts
@@ -57,6 +57,7 @@ export interface WorkflowRun {
   workspaceId: string;
   projectId: string;
   definitionId: string;
+  number: number;
   /** Effective runtime name: the resolved override, or workflowName when absent. */
   name: string;
   /** Static workflow-name snapshot preserved from the definition at creation. */

--- a/libs/api/workflows/src/core/job-transition/decide-job-activation.test.ts
+++ b/libs/api/workflows/src/core/job-transition/decide-job-activation.test.ts
@@ -113,6 +113,7 @@ function expression(source: string) {
 function workflowRun(): WorkflowRun {
   return {
     id: crypto.randomUUID(),
+    number: 1,
     workspaceId: crypto.randomUUID(),
     projectId: crypto.randomUUID(),
     definitionId: crypto.randomUUID(),

--- a/libs/api/workflows/src/core/listener-execution-materialization.test.ts
+++ b/libs/api/workflows/src/core/listener-execution-materialization.test.ts
@@ -21,6 +21,7 @@ describe('materializeListenerExecution', () => {
       model,
       run: {
         id: crypto.randomUUID(),
+        number: 1,
         name: 'Review run',
         workflowName: 'Review run',
         definitionId: crypto.randomUUID(),

--- a/libs/api/workflows/src/core/listener-execution-materialization.ts
+++ b/libs/api/workflows/src/core/listener-execution-materialization.ts
@@ -33,6 +33,7 @@ export interface MaterializeListenerExecutionParams {
   readonly run: Pick<
     WorkflowRun,
     | 'id'
+    | 'number'
     | 'name'
     | 'workflowName'
     | 'definitionId'

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
@@ -19,6 +19,7 @@ const date = new Date('2026-06-30T12:00:00.000Z');
 describe('assembleWorkflowRunContext', () => {
   const run = {
     id: 'run-1',
+    number: 1,
     name: 'Build',
     workflowName: 'Build',
     definitionId: 'def-1',
@@ -42,6 +43,7 @@ describe('assembleWorkflowRunContext', () => {
     expect(context).toEqual({
       run: {
         id: 'run-1',
+        number: 1,
         name: 'Build',
         workflow_name: 'Build',
         definition_id: 'def-1',
@@ -78,6 +80,7 @@ describe('assembleWorkflowRunContext', () => {
 describe('assembleCreationContext', () => {
   const run = {
     id: 'run-1',
+    number: 1,
     name: 'Build',
     workflowName: 'Build',
     definitionId: 'def-1',
@@ -117,6 +120,7 @@ describe('assembleCreationContext', () => {
 describe('assembleExecutionCreationContext', () => {
   const run = {
     id: 'run-1',
+    number: 1,
     name: 'Build',
     workflowName: 'Build',
     definitionId: 'def-1',
@@ -228,6 +232,7 @@ describe('assembleExecutionCreationContext', () => {
 describe('assembleJobActivationContext', () => {
   const run = {
     id: 'run-1',
+    number: 1,
     name: 'Build',
     workflowName: 'Build',
     definitionId: 'def-1',
@@ -335,6 +340,7 @@ describe('assembleJobActivationContext', () => {
 describe('listener filter snapshots', () => {
   const run = {
     id: 'run-1',
+    number: 1,
     name: 'Build',
     workflowName: 'Build',
     definitionId: 'def-1',
@@ -927,6 +933,7 @@ describe('assembleJobResolutionContext', () => {
 describe('assembleExecutionResolutionContext', () => {
   const run = {
     id: 'run-1',
+    number: 1,
     name: 'Build',
     workflowName: 'Build',
     definitionId: 'def-1',

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.ts
@@ -17,7 +17,14 @@ export interface JobContextInput {
 export interface AssembleWorkflowRunContextParams {
   readonly run: Pick<
     WorkflowRun,
-    'id' | 'name' | 'workflowName' | 'definitionId' | 'projectId' | 'workspaceId' | 'createdAt'
+    | 'id'
+    | 'number'
+    | 'name'
+    | 'workflowName'
+    | 'definitionId'
+    | 'projectId'
+    | 'workspaceId'
+    | 'createdAt'
   >;
   readonly triggerPayload: TriggerPayload;
   readonly inputs?: Record<string, unknown> | null | undefined;
@@ -30,6 +37,7 @@ export function assembleWorkflowRunContext(
   return {
     run: {
       id: params.run.id,
+      number: params.run.number,
       name: params.run.name,
       workflow_name: params.run.workflowName,
       definition_id: params.run.definitionId,

--- a/libs/api/workflows/src/core/workflow-run-creation.test.ts
+++ b/libs/api/workflows/src/core/workflow-run-creation.test.ts
@@ -136,6 +136,7 @@ function workflowRun(params: {inputs?: Record<string, unknown> | null} = {}): Wo
   const now = new Date('2026-01-01T00:00:00.000Z');
   return {
     id: 'run-1',
+    number: 1,
     workspaceId: 'workspace-1',
     projectId: 'project-1',
     definitionId: 'definition-1',

--- a/libs/api/workflows/src/db/db.ts
+++ b/libs/api/workflows/src/db/db.ts
@@ -7,11 +7,13 @@ import {workflowsOutbox} from './schema/outbox.js';
 import {stepAttempts} from './schema/step-attempts.js';
 import {steps} from './schema/steps.js';
 import {workflowRunAttempts} from './schema/workflow-run-attempts.js';
+import {workflowRunCounters} from './schema/workflow-run-counters.js';
 import {workflowRuns} from './schema/workflow-runs.js';
 
 export const schema = {
   workflowRuns,
   workflowRunAttempts,
+  workflowRunCounters,
   jobs,
   jobExecutions,
   jobListenerEvents,

--- a/libs/api/workflows/src/db/index.ts
+++ b/libs/api/workflows/src/db/index.ts
@@ -23,6 +23,7 @@ export {
   settleListenerJobExecution,
 } from './job-listeners.js';
 export {workflowsOutbox} from './schema/outbox.js';
+export {workflowRunCounters} from './schema/workflow-run-counters.js';
 export type {
   BulkUpdateStepStatusesParams,
   CancelWorkflowRunParams,

--- a/libs/api/workflows/src/db/schema/workflow-run-counters.ts
+++ b/libs/api/workflows/src/db/schema/workflow-run-counters.ts
@@ -1,0 +1,13 @@
+import {integer, uniqueIndex, uuid} from 'drizzle-orm/pg-core';
+import {pgTable} from './common.js';
+
+export const workflowRunCounters = pgTable(
+  'workflow_run_counters',
+  {
+    definitionId: uuid('definition_id').notNull(),
+    nextNumber: integer('next_number').notNull(),
+  },
+  (table) => [uniqueIndex('workflows_wrrc_definition_id_unique').on(table.definitionId)],
+);
+
+export type WorkflowRunCounterDb = typeof workflowRunCounters.$inferSelect;

--- a/libs/api/workflows/src/db/schema/workflow-runs.ts
+++ b/libs/api/workflows/src/db/schema/workflow-runs.ts
@@ -37,6 +37,7 @@ export const workflowRuns = pgTable(
     workspaceId: uuid('workspace_id').notNull(),
     projectId: uuid('project_id').notNull(),
     definitionId: uuid('definition_id').notNull(),
+    number: integer('number').notNull(),
     name: text('name'),
     workflowName: text('workflow_name').notNull(),
     status: workflowRunStatusEnum('status').notNull().default('pending'),
@@ -57,6 +58,7 @@ export const workflowRuns = pgTable(
   },
   (table) => [
     uniqueIndex('workflows_wr_trigger_idempotency_key_unique').on(table.triggerIdempotencyKey),
+    uniqueIndex('workflows_wr_definition_number_unique').on(table.definitionId, table.number),
     index('workflows_wr_project_created_id_idx').on(table.projectId, table.createdAt, table.id),
     index('workflows_wr_project_status_created_id_idx').on(
       table.projectId,
@@ -93,6 +95,7 @@ export function toWorkflowRun(row: WorkflowRunDb): WorkflowRun {
     workspaceId: row.workspaceId,
     projectId: row.projectId,
     definitionId: row.definitionId,
+    number: row.number,
     name: row.name ?? row.workflowName,
     workflowName: row.workflowName,
     nameOverride: row.name,

--- a/libs/api/workflows/src/db/workflow-runs/run-create.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-create.test.ts
@@ -9,6 +9,7 @@ import {buildModel, expression, shellRef, template} from '#test/helpers/workflow
 import {workflowModel} from '#test/index.js';
 import {db} from '../db.js';
 import {workflowsOutbox} from '../schema/outbox.js';
+import {workflowRunCounters} from '../schema/workflow-run-counters.js';
 import {workflowRuns} from '../schema/workflow-runs.js';
 import {
   createWorkflowRun,
@@ -169,6 +170,7 @@ describe('workflow run queries', () => {
       expect(run.id).toBeDefined();
       expect(run.projectId).toBe(projectId);
       expect(run.definitionId).toBe(definitionId);
+      expect(run.number).toBe(1);
       expect(run.status).toBe('pending');
       expect(run.triggerProvider).toBeNull();
       expect(run.triggerPayload).toMatchObject({source: 'manual', event: 'fire'});
@@ -208,6 +210,137 @@ describe('workflow run queries', () => {
         config: {},
       });
       expect(jobSteps[1]).toMatchObject({position: 1, config: {run: 'echo hello'}});
+    });
+
+    test('allocates distinct consecutive numbers for concurrent creations of one definition', async () => {
+      const [first, second] = await Promise.all([
+        createWorkflowRun({
+          workspaceId,
+          projectId,
+          definitionId,
+          model: buildModel({name: 'First'}),
+          triggerPayload: {
+            source: 'manual',
+            event: 'fire',
+            subscriptionId: crypto.randomUUID(),
+            userId: crypto.randomUUID(),
+          },
+        }),
+        createWorkflowRun({
+          workspaceId,
+          projectId,
+          definitionId,
+          model: buildModel({name: 'Second'}),
+          triggerPayload: {
+            source: 'manual',
+            event: 'fire',
+            subscriptionId: crypto.randomUUID(),
+            userId: crypto.randomUUID(),
+          },
+        }),
+      ]);
+
+      expect([first.number, second.number].sort((a, b) => a - b)).toEqual([1, 2]);
+      const [counter] = await db()
+        .select()
+        .from(workflowRunCounters)
+        .where(eq(workflowRunCounters.definitionId, definitionId));
+      expect(counter?.nextNumber).toBe(3);
+    });
+
+    test('makes the allocated number available to run-creation expressions', async () => {
+      const run = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model: buildModel({
+          jobs: {
+            build: {
+              executionName: `Build #${template('run.number')}`,
+              steps: [{run: 'echo build'}],
+            },
+          },
+        }),
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId: crypto.randomUUID(),
+          userId: crypto.randomUUID(),
+        },
+      });
+      const [job] = await getJobsByWorkflowRunId(run.id);
+      if (!job) throw new Error('Expected workflow job');
+      const [execution] = await getJobExecutionsByJobId(job.id);
+
+      expect(execution?.name).toBe('Build #1');
+    });
+
+    test('rolls back number allocation when creation rolls back', async () => {
+      await expect(
+        createWorkflowRun({
+          workspaceId,
+          projectId,
+          definitionId,
+          model: buildModel({env: {TOKEN: template('vars.TOKEN')}}),
+          triggerPayload: {
+            source: 'manual',
+            event: 'fire',
+            subscriptionId: crypto.randomUUID(),
+            userId: crypto.randomUUID(),
+          },
+        }),
+      ).rejects.toThrow('Secrets client is not configured.');
+
+      const run = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model: buildModel(),
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId: crypto.randomUUID(),
+          userId: crypto.randomUUID(),
+        },
+      });
+
+      expect(run.number).toBe(1);
+      const [counter] = await db()
+        .select()
+        .from(workflowRunCounters)
+        .where(eq(workflowRunCounters.definitionId, definitionId));
+      expect(counter?.nextNumber).toBe(2);
+    });
+
+    test('numbers definitions independently within one project', async () => {
+      const otherDefinitionId = crypto.randomUUID();
+      const first = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model: buildModel(),
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId: crypto.randomUUID(),
+          userId: crypto.randomUUID(),
+        },
+      });
+      const second = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId: otherDefinitionId,
+        model: buildModel(),
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId: crypto.randomUUID(),
+          userId: crypto.randomUUID(),
+        },
+      });
+
+      expect(first.number).toBe(1);
+      expect(second.number).toBe(1);
     });
 
     async function createJobOutputRun() {
@@ -1412,6 +1545,7 @@ describe('workflow run queries', () => {
       });
 
       expect(second.id).toBe(first.id);
+      expect(second.number).toBe(first.number);
       expect(second.triggerIdempotencyKey).toBe(idempotencyKey);
       expect(second.sourceSnapshot).toEqual({
         content: 'name: Original\njobs: {}\n',
@@ -1428,6 +1562,11 @@ describe('workflow run queries', () => {
         .from(workflowsOutbox)
         .where(sql`${workflowsOutbox.payload}->>'workflowRunId' = ${first.id}`);
       expect(outboxRows).toHaveLength(1);
+      const [counter] = await db()
+        .select()
+        .from(workflowRunCounters)
+        .where(eq(workflowRunCounters.definitionId, definitionId));
+      expect(counter?.nextNumber).toBe(2);
     });
 
     test('duplicate triggerIdempotencyKey returns the persisted run name without reevaluating it', async () => {

--- a/libs/api/workflows/src/db/workflow-runs/run-create.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-create.ts
@@ -8,7 +8,7 @@ import {
   type WorkflowExpression,
 } from '@shipfox/expression';
 import {logger} from '@shipfox/node-opentelemetry';
-import {eq} from 'drizzle-orm';
+import {eq, sql} from 'drizzle-orm';
 import type {AgentDefaultsResolver} from '#core/agent-defaults.js';
 import {
   createAgentToolMaterializationSnapshot,
@@ -32,8 +32,9 @@ import {
   recordWorkflowDisplayNameResolutionDegraded,
   recordWorkflowRunCreated,
 } from '#metrics/instance.js';
-import {db} from '../db.js';
+import {db, type Tx} from '../db.js';
 import {workflowRunAttempts} from '../schema/workflow-run-attempts.js';
+import {workflowRunCounters} from '../schema/workflow-run-counters.js';
 import {toWorkflowRun, workflowRuns} from '../schema/workflow-runs.js';
 import {type MaterializedRunGraphJob, persistMaterializedRunGraph} from './run-graph.js';
 
@@ -79,12 +80,33 @@ export async function createWorkflowRun(params: CreateWorkflowRunParams): Promis
     context: agentToolContext,
   });
   const result = await db().transaction(async (tx) => {
+    // Serialize idempotent trigger resolution separately from per-definition number
+    // allocation so a replay never consumes a number, including when two deliveries
+    // race before either run is visible.
+    if (params.triggerIdempotencyKey) {
+      await tx.execute(
+        sql`select pg_advisory_xact_lock(hashtext(${params.triggerIdempotencyKey}))`,
+      );
+      const existing = await tx
+        .select()
+        .from(workflowRuns)
+        .where(eq(workflowRuns.triggerIdempotencyKey, params.triggerIdempotencyKey))
+        .limit(1);
+      const existingRow = existing[0];
+      if (existingRow) return {run: toWorkflowRun(existingRow), created: false};
+    }
+
+    // Keep allocation on the existing transaction so a trigger burst cannot pin
+    // every pool connection and then wait for a second connection per run.
+    const number = await allocateWorkflowRunNumber(tx, params.definitionId);
+
     const insertResult = await tx
       .insert(workflowRuns)
       .values({
         workspaceId: params.workspaceId,
         projectId: params.projectId,
         definitionId: params.definitionId,
+        number,
         name: null,
         workflowName: staticName,
         status: 'pending',
@@ -230,6 +252,19 @@ export async function createWorkflowRun(params: CreateWorkflowRunParams): Promis
   }
 
   return result.run;
+}
+
+async function allocateWorkflowRunNumber(tx: Tx, definitionId: string): Promise<number> {
+  const [counterRow] = await tx
+    .insert(workflowRunCounters)
+    .values({definitionId, nextNumber: 2})
+    .onConflictDoUpdate({
+      target: workflowRunCounters.definitionId,
+      set: {nextNumber: sql`${workflowRunCounters.nextNumber} + 1`},
+    })
+    .returning({number: sql<number>`${workflowRunCounters.nextNumber} - 1`});
+  if (!counterRow) throw new Error('Run counter allocation returned no rows');
+  return counterRow.number;
 }
 
 export async function loadReferencedVariables(params: {

--- a/libs/api/workflows/src/db/workflow-runs/run-rerun.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-rerun.test.ts
@@ -113,6 +113,7 @@ describe('workflow run queries', () => {
 
       expect(rerun).toMatchObject({
         id: source.id,
+        number: source.number,
         name: 'Run staging',
         workflowName: 'Test Workflow',
         nameOverride: 'Run staging',

--- a/libs/api/workflows/src/presentation/dto/workflow-run.ts
+++ b/libs/api/workflows/src/presentation/dto/workflow-run.ts
@@ -7,6 +7,7 @@ export function toRunDto(run: WorkflowRun, latestAttempt = run.currentAttempt): 
     id: run.id,
     project_id: run.projectId,
     definition_id: run.definitionId,
+    number: run.number,
     name: run.name,
     workflow_name: run.workflowName,
     status: run.status,

--- a/libs/api/workflows/src/presentation/routes/get-run.test.ts
+++ b/libs/api/workflows/src/presentation/routes/get-run.test.ts
@@ -118,6 +118,7 @@ describe('GET /api/workflows/runs/:id', () => {
     const body = res.json();
     expect(body.id).toBe(run.id);
     expect(body).toMatchObject({name: 'Test', workflow_name: 'Test'});
+    expect(body.number).toBe(run.number);
     expect(body.source_snapshot).toBeNull();
     expect(body.jobs).toHaveLength(1);
     expect(body.jobs[0].key).toBe('build');

--- a/libs/api/workflows/test/factories/workflow-run.ts
+++ b/libs/api/workflows/test/factories/workflow-run.ts
@@ -32,6 +32,7 @@ export const workflowRunFactory = Factory.define<WorkflowRun, WorkflowRunTransie
       workspaceId,
       projectId,
       definitionId,
+      number: 1,
       name: 'Test Workflow',
       workflowName: 'Test Workflow',
       nameOverride: null,

--- a/libs/client/workflows/test/fixtures/workflow-run.ts
+++ b/libs/client/workflows/test/fixtures/workflow-run.ts
@@ -56,6 +56,7 @@ export function workflowRunDto(
     id: RUN_ID,
     project_id: PROJECT_ID,
     definition_id: DEFINITION_ID,
+    number: 1,
     name: 'deploy-web',
     workflow_name: 'deploy-web',
     status: 'running',

--- a/libs/shared/expression/src/workflow-context/workflow-context.test.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.test.ts
@@ -148,11 +148,13 @@ describe('workflow context registry', () => {
   });
 
   it('exports type environments for the known v1 context fields', () => {
-    expect(getWorkflowContextTypeEnvironment('run')).toEqual({
+    const runTypeEnvironment = getWorkflowContextTypeEnvironment('run');
+    expect(runTypeEnvironment).toEqual({
       run: {
         kind: 'object',
         fields: {
           id: 'string',
+          number: 'int',
           name: 'string',
           run_name: 'string',
           definition_id: 'string',
@@ -162,6 +164,13 @@ describe('workflow context registry', () => {
         },
       },
     });
+    if (!runTypeEnvironment) throw new Error('Run type environment is not defined');
+    expect(() =>
+      createWorkflowExpression({
+        source: 'run.number > 0',
+        check: {mode: 'typed', typeEnvironment: runTypeEnvironment},
+      }),
+    ).not.toThrow();
     expect(getWorkflowContextTypeEnvironment('trigger')).toEqual({
       trigger: {
         kind: 'object',

--- a/libs/shared/expression/src/workflow-context/workflow-context.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.ts
@@ -98,6 +98,7 @@ const runTypeEnvironment = {
     kind: 'object',
     fields: {
       id: 'string',
+      number: 'int',
       name: 'string',
       run_name: 'string',
       definition_id: 'string',


### PR DESCRIPTION
Workflow runs now receive a sequential number scoped to their workflow definition and expose it through the API and expression context.

Allocation is transaction-local so concurrent trigger bursts do not require a second pool connection. Idempotent deliveries return the existing run number, reruns preserve it, and a rolled-back creation rolls back the counter increment as well.

Validation completed with the API workflows test suite (61 files, 655 tests), package type/check/build/dependency-cruiser checks, expression type/context tests, and database-boundary verification.

Closes ENG-1446

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-workflow-definition sequential run numbers and exposes them via the API and expression context. Delivers a readable, display-only identifier per ENG-1446; UUIDs remain the canonical run ID.

- **New Features**
  - Adds `number` to `workflows_workflow_runs`, unique per `definition_id`, allocated via `workflows_workflow_run_counters`.
  - Transactional allocation with idempotency protection: deduplicated triggers reuse the existing run/number; reruns keep the number; rollbacks don’t consume; concurrent creations get consecutive numbers.
  - Exposes `number` in DTOs and `GET` responses, and in expressions as `run.number` at creation time (e.g., "Build #${run.number}"); expression type env includes `number: int`.

- **Migration**
  - Adds `workflows_workflow_run_counters`, `workflows_workflow_runs.number`, and unique indexes on `workflows_workflow_run_counters.definition_id` and `(workflows_workflow_runs.definition_id, number)`.
  - Dev/test: drop `workflows_%` and `__drizzle_migrations_workflows`, then re-migrate to align `0000_initial.sql` and the snapshot.

<sup>Written for commit 232fe3ca496a1197f53a54b723c586349831b095. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

