### PR TITLE
Refresh project repository identity on GitHub events

### DIFF
--- a/.changeset/refresh-project-repository-identity.md
+++ b/.changeset/refresh-project-repository-identity.md
@@ -1,0 +1,10 @@
+---
+"@shipfox/api-integration-core-dto": minor
+"@shipfox/api-integration-core": patch
+"@shipfox/api-integration-github-dto": patch
+"@shipfox/api-integration-github": patch
+"@shipfox/api-integration-spi": minor
+"@shipfox/api-projects": patch
+---
+
+Refresh source-backed project repository identity from GitHub repository and installation-repository events.

--- a/libs/api/integration/core-dto/src/events.test.ts
+++ b/libs/api/integration/core-dto/src/events.test.ts
@@ -1,8 +1,10 @@
 import {
   INTEGRATION_EVENT_RECEIVED,
   INTEGRATION_SOURCE_COMMIT_PUSHED,
+  INTEGRATION_SOURCE_REPOSITORY_UPDATED,
   integrationEventReceivedSchema,
   integrationSourceCommitPushedSchema,
+  integrationSourceRepositoryUpdatedSchema,
   integrationsEventSchemas,
 } from './events.js';
 
@@ -30,6 +32,20 @@ const validCommitPushed = {
     headCommitSha: 'abc123',
     defaultBranch: 'main',
     isDefaultBranch: true,
+  },
+};
+
+const validRepositoryUpdated = {
+  provider: 'github',
+  workspaceId: 'ws-1',
+  connectionId: 'conn-1',
+  deliveryId: 'delivery-1',
+  receivedAt: '2026-06-21T00:00:00.000Z',
+  repository: {
+    externalRepositoryId: 'github:42',
+    owner: 'acme',
+    name: 'platform-renamed',
+    defaultBranch: 'main',
   },
 };
 
@@ -98,12 +114,32 @@ describe('integrationEventReceivedSchema', () => {
   });
 });
 
+describe('integrationSourceRepositoryUpdatedSchema', () => {
+  it('parses a valid repository identity update unchanged', () => {
+    const result = integrationSourceRepositoryUpdatedSchema.parse(validRepositoryUpdated);
+
+    expect(result).toEqual(validRepositoryUpdated);
+  });
+
+  it('rejects a payload missing repository identity', () => {
+    const {repository: _repository, ...withoutRepository} = validRepositoryUpdated;
+
+    const parse = () => integrationSourceRepositoryUpdatedSchema.parse(withoutRepository);
+
+    expect(parse).toThrow();
+  });
+});
+
 describe('integrationsEventSchemas', () => {
   it('registers every integration publisher event type', () => {
     const registeredTypes = Object.keys(integrationsEventSchemas).sort();
 
     expect(registeredTypes).toEqual(
-      [INTEGRATION_EVENT_RECEIVED, INTEGRATION_SOURCE_COMMIT_PUSHED].sort(),
+      [
+        INTEGRATION_EVENT_RECEIVED,
+        INTEGRATION_SOURCE_COMMIT_PUSHED,
+        INTEGRATION_SOURCE_REPOSITORY_UPDATED,
+      ].sort(),
     );
   });
 });

--- a/libs/api/integration/core-dto/src/events.ts
+++ b/libs/api/integration/core-dto/src/events.ts
@@ -51,6 +51,32 @@ export type IntegrationSourceCommitPushedEvent = z.infer<
   typeof integrationSourceCommitPushedSchema
 >;
 
+export const sourceRepositoryIdentitySchema = z.object({
+  externalRepositoryId: nonEmptyStringSchema,
+  owner: nonEmptyStringSchema,
+  name: nonEmptyStringSchema,
+  defaultBranch: nonEmptyStringSchema,
+});
+export type SourceRepositoryIdentity = z.infer<typeof sourceRepositoryIdentitySchema>;
+
+export const INTEGRATION_SOURCE_REPOSITORY_UPDATED =
+  'integrations.source_control.repository_updated' as const;
+
+// Typed, provider-agnostic source-control event. The producing provider owns the
+// translation from its raw webhook into this shape, so domain consumers never decode
+// provider payloads.
+export const integrationSourceRepositoryUpdatedSchema = z.object({
+  provider: nonEmptyStringSchema,
+  workspaceId: nonEmptyStringSchema,
+  connectionId: nonEmptyStringSchema,
+  deliveryId: nonEmptyStringSchema,
+  receivedAt: isoDateTimeSchema,
+  repository: sourceRepositoryIdentitySchema,
+});
+export type IntegrationSourceRepositoryUpdatedEvent = z.infer<
+  typeof integrationSourceRepositoryUpdatedSchema
+>;
+
 export interface SentryIssuePayload {
   action: SentryIssueAction;
   issueId: string;
@@ -83,9 +109,11 @@ export type SentryIssueAction = (typeof SENTRY_ISSUE_ACTIONS)[number];
 export interface IntegrationsEventMap {
   [INTEGRATION_EVENT_RECEIVED]: IntegrationEventReceivedEvent;
   [INTEGRATION_SOURCE_COMMIT_PUSHED]: IntegrationSourceCommitPushedEvent;
+  [INTEGRATION_SOURCE_REPOSITORY_UPDATED]: IntegrationSourceRepositoryUpdatedEvent;
 }
 
 export const integrationsEventSchemas = {
   [INTEGRATION_EVENT_RECEIVED]: integrationEventReceivedSchema,
   [INTEGRATION_SOURCE_COMMIT_PUSHED]: integrationSourceCommitPushedSchema,
+  [INTEGRATION_SOURCE_REPOSITORY_UPDATED]: integrationSourceRepositoryUpdatedSchema,
 } satisfies Record<keyof IntegrationsEventMap, z.ZodType>;

--- a/libs/api/integration/core/src/db/webhook-deliveries.test.ts
+++ b/libs/api/integration/core/src/db/webhook-deliveries.test.ts
@@ -1,8 +1,10 @@
 import {
   INTEGRATION_EVENT_RECEIVED,
   INTEGRATION_SOURCE_COMMIT_PUSHED,
+  INTEGRATION_SOURCE_REPOSITORY_UPDATED,
   type IntegrationEventReceivedEvent,
   type SourcePushPayload,
+  type SourceRepositoryIdentity,
 } from '@shipfox/api-integration-spi';
 import {and, eq, sql} from 'drizzle-orm';
 import {db} from './db.js';
@@ -13,6 +15,7 @@ import {
   publishIntegrationEventReceived,
   publishSourceCommitPushed,
   publishSourcePush,
+  publishSourceRepositoryUpdated,
   recordDeliveryOnly,
 } from './webhook-deliveries.js';
 
@@ -274,5 +277,77 @@ describe('publishSourceCommitPushed', () => {
     await publishSourceCommitPushed(params);
 
     expect(await deliveriesFor(params.provider, params.deliveryId)).toHaveLength(0);
+  });
+});
+
+describe('publishSourceRepositoryUpdated', () => {
+  function buildParams() {
+    const deliveryId = crypto.randomUUID();
+    const repositories: SourceRepositoryIdentity[] = [
+      {
+        externalRepositoryId: 'github:42',
+        owner: 'acme',
+        name: 'platform-renamed',
+        defaultBranch: 'main',
+      },
+      {
+        externalRepositoryId: 'github:43',
+        owner: 'acme',
+        name: 'runner',
+        defaultBranch: 'trunk',
+      },
+    ];
+    return {
+      provider: 'github',
+      source: 'github_acme_production',
+      workspaceId: crypto.randomUUID(),
+      connectionId: crypto.randomUUID(),
+      connectionName: 'Acme Production',
+      deliveryId,
+      receivedAt: new Date().toISOString(),
+      rawPayload: {action: 'added', repositories_added: repositories},
+      event: 'installation_repositories.added',
+      repositories,
+    };
+  }
+
+  it('writes the generic envelope and one typed event per repository', async () => {
+    const params = buildParams();
+
+    const result = await db().transaction((tx) => publishSourceRepositoryUpdated({tx, ...params}));
+
+    expect(result.published).toBe(true);
+    const outbox = await outboxFor(params.deliveryId);
+    expect(outbox).toHaveLength(3);
+    expect(outbox.filter((row) => row.eventType === INTEGRATION_EVENT_RECEIVED)).toHaveLength(1);
+    expect(
+      outbox.filter((row) => row.eventType === INTEGRATION_SOURCE_REPOSITORY_UPDATED),
+    ).toHaveLength(2);
+    expect(outbox[0]?.payload).toMatchObject({
+      event: 'installation_repositories.added',
+      payload: params.rawPayload,
+    });
+    expect(
+      outbox
+        .filter((row) => row.eventType === INTEGRATION_SOURCE_REPOSITORY_UPDATED)
+        .map((row) => row.payload),
+    ).toEqual(
+      expect.arrayContaining(
+        params.repositories.map((repository) =>
+          expect.objectContaining({repository, deliveryId: params.deliveryId}),
+        ),
+      ),
+    );
+  });
+
+  it('does not publish a duplicate delivery twice', async () => {
+    const params = buildParams();
+
+    const first = await db().transaction((tx) => publishSourceRepositoryUpdated({tx, ...params}));
+    const second = await db().transaction((tx) => publishSourceRepositoryUpdated({tx, ...params}));
+
+    expect(first.published).toBe(true);
+    expect(second.published).toBe(false);
+    expect(await outboxFor(params.deliveryId)).toHaveLength(3);
   });
 });

--- a/libs/api/integration/core/src/db/webhook-deliveries.test.ts
+++ b/libs/api/integration/core/src/db/webhook-deliveries.test.ts
@@ -323,7 +323,9 @@ describe('publishSourceRepositoryUpdated', () => {
     expect(
       outbox.filter((row) => row.eventType === INTEGRATION_SOURCE_REPOSITORY_UPDATED),
     ).toHaveLength(2);
-    expect(outbox[0]?.payload).toMatchObject({
+    expect(
+      outbox.find((row) => row.eventType === INTEGRATION_EVENT_RECEIVED)?.payload,
+    ).toMatchObject({
       event: 'installation_repositories.added',
       payload: params.rawPayload,
     });

--- a/libs/api/integration/core/src/db/webhook-deliveries.ts
+++ b/libs/api/integration/core/src/db/webhook-deliveries.ts
@@ -1,9 +1,11 @@
 import {
   INTEGRATION_EVENT_RECEIVED,
   INTEGRATION_SOURCE_COMMIT_PUSHED,
+  INTEGRATION_SOURCE_REPOSITORY_UPDATED,
   type IntegrationEventReceivedEvent,
   type IntegrationsEventMap,
   type SourcePushPayload,
+  type SourceRepositoryIdentity,
 } from '@shipfox/api-integration-spi';
 import {writeOutboxEvent, writeOutboxEvents} from '@shipfox/node-outbox';
 import {lt} from 'drizzle-orm';
@@ -136,6 +138,83 @@ export async function publishSourcePush(
   return {published: true};
 }
 
+export interface PublishSourceRepositoryUpdatedParams {
+  tx: IntegrationTx;
+  provider: string;
+  source: string;
+  workspaceId: string;
+  connectionId: string;
+  connectionName: string;
+  deliveryId: string;
+  receivedAt: string;
+  rawPayload: unknown;
+  event: string;
+  repositories: SourceRepositoryIdentity[];
+}
+
+// Emits the generic provider envelope for triggers and one typed repository event per
+// normalized repository for domain modules. One delivery-dedup gates all rows, so a
+// redelivered webhook writes nothing. Requires a transaction: the dedup insert and all
+// outbox rows must commit or roll back together.
+export async function publishSourceRepositoryUpdated(
+  params: PublishSourceRepositoryUpdatedParams,
+): Promise<{published: boolean}> {
+  const inserted = await params.tx
+    .insert(integrationsWebhookDeliveries)
+    .values({
+      provider: params.provider,
+      dedupScope: providerDedupScope(params.provider),
+      deliveryId: params.deliveryId,
+    })
+    .onConflictDoNothing({
+      target: [
+        integrationsWebhookDeliveries.provider,
+        integrationsWebhookDeliveries.dedupScope,
+        integrationsWebhookDeliveries.deliveryId,
+      ],
+    })
+    .returning({deliveryId: integrationsWebhookDeliveries.deliveryId});
+
+  if (inserted.length === 0) return {published: false};
+
+  await writeOutboxEvents<IntegrationsEventMap>(params.tx, integrationsOutbox, [
+    {
+      type: INTEGRATION_EVENT_RECEIVED,
+      payload: {
+        provider: params.provider,
+        source: params.source,
+        event: params.event,
+        workspaceId: params.workspaceId,
+        connectionId: params.connectionId,
+        connectionName: params.connectionName,
+        deliveryId: params.deliveryId,
+        receivedAt: params.receivedAt,
+        payload: params.rawPayload,
+      },
+    },
+    ...params.repositories.map(
+      (
+        repository,
+      ): {
+        type: typeof INTEGRATION_SOURCE_REPOSITORY_UPDATED;
+        payload: IntegrationsEventMap[typeof INTEGRATION_SOURCE_REPOSITORY_UPDATED];
+      } => ({
+        type: INTEGRATION_SOURCE_REPOSITORY_UPDATED,
+        payload: {
+          provider: params.provider,
+          workspaceId: params.workspaceId,
+          connectionId: params.connectionId,
+          deliveryId: params.deliveryId,
+          receivedAt: params.receivedAt,
+          repository,
+        },
+      }),
+    ),
+  ]);
+
+  return {published: true};
+}
+
 export interface PublishSourceCommitPushedParams {
   provider: string;
   workspaceId: string;
@@ -211,6 +290,7 @@ export async function pruneWebhookDeliveries(
 
 export type PublishIntegrationEventReceivedFn = typeof publishIntegrationEventReceived;
 export type PublishSourcePushFn = typeof publishSourcePush;
+export type PublishSourceRepositoryUpdatedFn = typeof publishSourceRepositoryUpdated;
 export type PublishSourceCommitPushedFn = typeof publishSourceCommitPushed;
 export type ClaimWebhookDeliveryFn = typeof claimWebhookDelivery;
 export type RecordDeliveryOnlyFn = typeof recordDeliveryOnly;

--- a/libs/api/integration/core/src/db/webhook-deliveries.ts
+++ b/libs/api/integration/core/src/db/webhook-deliveries.ts
@@ -16,6 +16,12 @@ import {integrationsWebhookDeliveries} from './schema/webhook-deliveries.js';
 type IntegrationDb = ReturnType<typeof db>;
 type IntegrationTx = Parameters<Parameters<IntegrationDb['transaction']>[0]>[0];
 type Executor = IntegrationDb | IntegrationTx;
+type IntegrationOutboxEvent = {
+  [K in keyof IntegrationsEventMap & string]: {
+    type: K;
+    payload: IntegrationsEventMap[K];
+  };
+}[keyof IntegrationsEventMap & string];
 
 function connectionDedupScope(connectionId: string): string {
   return `connection:${connectionId}`;
@@ -68,77 +74,7 @@ export async function publishIntegrationEventReceived(
   return {published: true};
 }
 
-export interface PublishSourcePushParams {
-  tx: IntegrationTx;
-  provider: string;
-  source: string;
-  workspaceId: string;
-  connectionId: string;
-  connectionName: string;
-  deliveryId: string;
-  receivedAt: string;
-  rawPayload: unknown;
-  push: SourcePushPayload;
-}
-
-// Emits a single source-control push as two outbox rows: the generic
-// `INTEGRATION_EVENT_RECEIVED` envelope with the raw provider payload for triggers, and the
-// typed `INTEGRATION_SOURCE_COMMIT_PUSHED` event for domain modules. One delivery-dedup gates
-// both, so a redelivered webhook writes nothing. Requires a transaction: the dedup insert and
-// both outbox rows must commit or roll back together.
-export async function publishSourcePush(
-  params: PublishSourcePushParams,
-): Promise<{published: boolean}> {
-  const inserted = await params.tx
-    .insert(integrationsWebhookDeliveries)
-    .values({
-      provider: params.provider,
-      dedupScope: providerDedupScope(params.provider),
-      deliveryId: params.deliveryId,
-    })
-    .onConflictDoNothing({
-      target: [
-        integrationsWebhookDeliveries.provider,
-        integrationsWebhookDeliveries.dedupScope,
-        integrationsWebhookDeliveries.deliveryId,
-      ],
-    })
-    .returning({deliveryId: integrationsWebhookDeliveries.deliveryId});
-
-  if (inserted.length === 0) return {published: false};
-
-  await writeOutboxEvents<IntegrationsEventMap>(params.tx, integrationsOutbox, [
-    {
-      type: INTEGRATION_EVENT_RECEIVED,
-      payload: {
-        provider: params.provider,
-        source: params.source,
-        event: 'push',
-        workspaceId: params.workspaceId,
-        connectionId: params.connectionId,
-        connectionName: params.connectionName,
-        deliveryId: params.deliveryId,
-        receivedAt: params.receivedAt,
-        payload: params.rawPayload,
-      },
-    },
-    {
-      type: INTEGRATION_SOURCE_COMMIT_PUSHED,
-      payload: {
-        provider: params.provider,
-        workspaceId: params.workspaceId,
-        connectionId: params.connectionId,
-        deliveryId: params.deliveryId,
-        receivedAt: params.receivedAt,
-        push: params.push,
-      },
-    },
-  ]);
-
-  return {published: true};
-}
-
-export interface PublishSourceRepositoryUpdatedParams {
+interface PublishSourceEventsParams {
   tx: IntegrationTx;
   provider: string;
   source: string;
@@ -149,15 +85,11 @@ export interface PublishSourceRepositoryUpdatedParams {
   receivedAt: string;
   rawPayload: unknown;
   event: string;
-  repositories: SourceRepositoryIdentity[];
+  typedEvents: IntegrationOutboxEvent[];
 }
 
-// Emits the generic provider envelope for triggers and one typed repository event per
-// normalized repository for domain modules. One delivery-dedup gates all rows, so a
-// redelivered webhook writes nothing. Requires a transaction: the dedup insert and all
-// outbox rows must commit or roll back together.
-export async function publishSourceRepositoryUpdated(
-  params: PublishSourceRepositoryUpdatedParams,
+async function publishSourceEvents(
+  params: PublishSourceEventsParams,
 ): Promise<{published: boolean}> {
   const inserted = await params.tx
     .insert(integrationsWebhookDeliveries)
@@ -192,13 +124,92 @@ export async function publishSourceRepositoryUpdated(
         payload: params.rawPayload,
       },
     },
-    ...params.repositories.map(
-      (
-        repository,
-      ): {
-        type: typeof INTEGRATION_SOURCE_REPOSITORY_UPDATED;
-        payload: IntegrationsEventMap[typeof INTEGRATION_SOURCE_REPOSITORY_UPDATED];
-      } => ({
+    ...params.typedEvents,
+  ]);
+
+  return {published: true};
+}
+
+export interface PublishSourcePushParams {
+  tx: IntegrationTx;
+  provider: string;
+  source: string;
+  workspaceId: string;
+  connectionId: string;
+  connectionName: string;
+  deliveryId: string;
+  receivedAt: string;
+  rawPayload: unknown;
+  push: SourcePushPayload;
+}
+
+// Emits a single source-control push as two outbox rows: the generic
+// `INTEGRATION_EVENT_RECEIVED` envelope with the raw provider payload for triggers, and the
+// typed `INTEGRATION_SOURCE_COMMIT_PUSHED` event for domain modules. One delivery-dedup gates
+// both, so a redelivered webhook writes nothing. Requires a transaction: the dedup insert and
+// both outbox rows must commit or roll back together.
+export function publishSourcePush(params: PublishSourcePushParams): Promise<{published: boolean}> {
+  return publishSourceEvents({
+    tx: params.tx,
+    provider: params.provider,
+    source: params.source,
+    workspaceId: params.workspaceId,
+    connectionId: params.connectionId,
+    connectionName: params.connectionName,
+    deliveryId: params.deliveryId,
+    receivedAt: params.receivedAt,
+    rawPayload: params.rawPayload,
+    event: 'push',
+    typedEvents: [
+      {
+        type: INTEGRATION_SOURCE_COMMIT_PUSHED,
+        payload: {
+          provider: params.provider,
+          workspaceId: params.workspaceId,
+          connectionId: params.connectionId,
+          deliveryId: params.deliveryId,
+          receivedAt: params.receivedAt,
+          push: params.push,
+        },
+      },
+    ],
+  });
+}
+
+export interface PublishSourceRepositoryUpdatedParams {
+  tx: IntegrationTx;
+  provider: string;
+  source: string;
+  workspaceId: string;
+  connectionId: string;
+  connectionName: string;
+  deliveryId: string;
+  receivedAt: string;
+  rawPayload: unknown;
+  event: string;
+  repositories: SourceRepositoryIdentity[];
+}
+
+// Emits the generic provider envelope for triggers and one typed repository event per
+// normalized repository for domain modules. One delivery-dedup gates all rows, so a
+// redelivered webhook writes nothing. Requires a transaction: the dedup insert and all
+// outbox rows must commit or roll back together.
+export function publishSourceRepositoryUpdated(
+  params: PublishSourceRepositoryUpdatedParams,
+): Promise<{published: boolean}> {
+  return publishSourceEvents({
+    tx: params.tx,
+    provider: params.provider,
+    source: params.source,
+    workspaceId: params.workspaceId,
+    connectionId: params.connectionId,
+    connectionName: params.connectionName,
+    deliveryId: params.deliveryId,
+    receivedAt: params.receivedAt,
+    rawPayload: params.rawPayload,
+    event: params.event,
+    typedEvents: params.repositories.map(
+      (repository): IntegrationOutboxEvent => ({
         type: INTEGRATION_SOURCE_REPOSITORY_UPDATED,
         payload: {
           provider: params.provider,
@@ -210,9 +221,7 @@ export async function publishSourceRepositoryUpdated(
         },
       }),
     ),
-  ]);
-
-  return {published: true};
+  });
 }
 
 export interface PublishSourceCommitPushedParams {

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -126,10 +126,16 @@ export type {
   PublishIntegrationEventReceivedResult,
   PublishSourcePushFn,
   PublishSourcePushParams,
+  PublishSourceRepositoryUpdatedFn,
+  PublishSourceRepositoryUpdatedParams,
   RecordDeliveryOnlyFn,
   RecordDeliveryOnlyParams,
 } from '#db/webhook-deliveries.js';
-export {claimWebhookDelivery, pruneWebhookDeliveries} from '#db/webhook-deliveries.js';
+export {
+  claimWebhookDelivery,
+  pruneWebhookDeliveries,
+  publishSourceRepositoryUpdated,
+} from '#db/webhook-deliveries.js';
 export {integrationRouteErrorHandler} from '#presentation/routes/errors.js';
 
 export interface CreateIntegrationsModuleOptions {

--- a/libs/api/integration/core/src/providers/github.ts
+++ b/libs/api/integration/core/src/providers/github.ts
@@ -10,6 +10,7 @@ import {db} from '#db/db.js';
 import {
   publishIntegrationEventReceived,
   publishSourcePush,
+  publishSourceRepositoryUpdated,
   recordDeliveryOnly,
 } from '#db/webhook-deliveries.js';
 import {retryConnectionSlugCollision, slugifyConnectionSlug} from '#providers/connection-slug.js';
@@ -111,6 +112,7 @@ async function loadGithubModuleParts(
     getExistingGithubConnection,
     connectGithubInstallation,
     publishIntegrationEventReceived,
+    publishSourceRepositoryUpdated,
     publishSourcePush,
     recordDeliveryOnly,
     getIntegrationConnectionById,

--- a/libs/api/integration/github-dto/src/schemas/webhooks.ts
+++ b/libs/api/integration/github-dto/src/schemas/webhooks.ts
@@ -21,6 +21,28 @@ export const githubWebhookInstallationSchema = z.object({
 });
 export type GithubWebhookInstallationDto = z.infer<typeof githubWebhookInstallationSchema>;
 
+const githubWebhookRepositorySchema = z.object({
+  id: z.number().int().positive(),
+  name: z.string().min(1),
+  owner: z.object({login: z.string().min(1)}),
+  default_branch: z.string().min(1),
+});
+
+export const githubRepositoryRenamedPayloadSchema = z.object({
+  repository: githubWebhookRepositorySchema,
+});
+export type GithubRepositoryRenamedPayloadDto = z.infer<
+  typeof githubRepositoryRenamedPayloadSchema
+>;
+
+export const githubInstallationRepositoriesPayloadSchema = z.object({
+  repositories_added: z.array(githubWebhookRepositorySchema),
+  repositories_removed: z.array(githubWebhookRepositorySchema),
+});
+export type GithubInstallationRepositoriesPayloadDto = z.infer<
+  typeof githubInstallationRepositoriesPayloadSchema
+>;
+
 export const githubWebhookEnvelopeSchema = githubWebhookActionSchema.merge(
   githubWebhookInstallationSchema,
 );

--- a/libs/api/integration/github/src/connection-external-url.test.ts
+++ b/libs/api/integration/github/src/connection-external-url.test.ts
@@ -40,6 +40,7 @@ function createProvider(lookup: (connectionId: string) => Promise<GithubInstalla
     connectGithubInstallation: vi.fn() as never,
     coreDb: vi.fn() as never,
     publishIntegrationEventReceived: vi.fn(() => Promise.resolve({published: false})),
+    publishSourceRepositoryUpdated: vi.fn(() => Promise.resolve({published: false})),
     publishSourcePush: vi.fn(() => Promise.resolve({published: false})),
     recordDeliveryOnly: vi.fn(() => Promise.resolve()),
     getIntegrationConnectionById: vi.fn(() => Promise.resolve(undefined)),

--- a/libs/api/integration/github/src/core/agent-tools.test.ts
+++ b/libs/api/integration/github/src/core/agent-tools.test.ts
@@ -547,6 +547,7 @@ function createProvider() {
     connectGithubInstallation: vi.fn() as never,
     coreDb: vi.fn() as never,
     publishIntegrationEventReceived: vi.fn(() => Promise.resolve({published: false})),
+    publishSourceRepositoryUpdated: vi.fn(() => Promise.resolve({published: false})),
     publishSourcePush: vi.fn(() => Promise.resolve({published: false})),
     recordDeliveryOnly: vi.fn(() => Promise.resolve()),
     getIntegrationConnectionById: vi.fn(() => Promise.resolve(undefined)),

--- a/libs/api/integration/github/src/core/webhook-processor.test.ts
+++ b/libs/api/integration/github/src/core/webhook-processor.test.ts
@@ -51,6 +51,7 @@ describe('GitHub webhook processor', () => {
     const processor = createGithubWebhookProcessor({
       coreDb,
       publishIntegrationEventReceived: vi.fn(),
+      publishSourceRepositoryUpdated: vi.fn(),
       publishSourcePush: vi.fn(),
       recordDeliveryOnly: vi.fn(),
       getIntegrationConnectionById: vi.fn(),
@@ -78,6 +79,7 @@ describe('GitHub webhook processor', () => {
     const processor = createGithubWebhookProcessor({
       coreDb: vi.fn(),
       publishIntegrationEventReceived: vi.fn(),
+      publishSourceRepositoryUpdated: vi.fn(),
       publishSourcePush: vi.fn(),
       recordDeliveryOnly: vi.fn(),
       getIntegrationConnectionById: vi.fn(),
@@ -114,6 +116,7 @@ describe('GitHub webhook processor', () => {
       coreDb: () =>
         ({transaction: (callback: (tx: unknown) => Promise<unknown>) => callback({})}) as never,
       publishIntegrationEventReceived: vi.fn(),
+      publishSourceRepositoryUpdated: vi.fn(),
       publishSourcePush: vi.fn(),
       recordDeliveryOnly: vi.fn(),
       getIntegrationConnectionById: vi.fn(),
@@ -145,6 +148,7 @@ describe('GitHub webhook processor', () => {
     const processor = createGithubWebhookProcessor({
       coreDb: db,
       publishIntegrationEventReceived,
+      publishSourceRepositoryUpdated: vi.fn(),
       publishSourcePush: vi.fn(),
       recordDeliveryOnly: vi.fn(),
       getIntegrationConnectionById: vi.fn(() => Promise.resolve(connection)),

--- a/libs/api/integration/github/src/core/webhook-processor.ts
+++ b/libs/api/integration/github/src/core/webhook-processor.ts
@@ -5,6 +5,7 @@ import {
   type GetIntegrationConnectionByIdFn,
   type PublishIntegrationEventReceivedFn,
   type PublishSourcePushFn,
+  type PublishSourceRepositoryUpdatedFn,
   type RecordDeliveryOnlyFn,
   type StoredWebhookRequest,
   type WebhookProcessingResult,
@@ -21,6 +22,7 @@ const SIGNATURE_HEADER = 'x-hub-signature-256';
 export interface CreateGithubWebhookProcessorOptions {
   coreDb: () => NodePgDatabase<Record<string, unknown>>;
   publishIntegrationEventReceived: PublishIntegrationEventReceivedFn;
+  publishSourceRepositoryUpdated: PublishSourceRepositoryUpdatedFn;
   publishSourcePush: PublishSourcePushFn;
   recordDeliveryOnly: RecordDeliveryOnlyFn;
   getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
@@ -81,6 +83,7 @@ async function processGithubWebhookRequest(
       event,
       payload,
       publishIntegrationEventReceived: options.publishIntegrationEventReceived,
+      publishSourceRepositoryUpdated: options.publishSourceRepositoryUpdated,
       publishSourcePush: options.publishSourcePush,
       recordDeliveryOnly: options.recordDeliveryOnly,
       getIntegrationConnectionById: options.getIntegrationConnectionById,

--- a/libs/api/integration/github/src/core/webhook.test.ts
+++ b/libs/api/integration/github/src/core/webhook.test.ts
@@ -4,6 +4,7 @@ import type {
   IntegrationConnection,
   PublishIntegrationEventReceivedFn,
   PublishSourcePushFn,
+  PublishSourceRepositoryUpdatedFn,
   RecordDeliveryOnlyFn,
 } from '@shipfox/api-integration-spi';
 import {db} from '#db/db.js';
@@ -30,12 +31,16 @@ function deps(
   options: {
     connection?: IntegrationConnection | undefined;
     publishIntegrationEventReceivedResult?: {published: boolean};
+    publishSourceRepositoryUpdatedResult?: {published: boolean};
     publishSourcePushResult?: {published: boolean};
   } = {},
 ) {
   return {
     publishIntegrationEventReceived: vi.fn<PublishIntegrationEventReceivedFn>(() =>
       Promise.resolve(options.publishIntegrationEventReceivedResult ?? {published: true}),
+    ),
+    publishSourceRepositoryUpdated: vi.fn<PublishSourceRepositoryUpdatedFn>(() =>
+      Promise.resolve(options.publishSourceRepositoryUpdatedResult ?? {published: true}),
     ),
     publishSourcePush: vi.fn<PublishSourcePushFn>(() =>
       Promise.resolve(options.publishSourcePushResult ?? {published: true}),
@@ -392,6 +397,96 @@ describe('handleGithubEvent', () => {
     expect(result.outcome).toBe('published-envelope');
     expect(handlers.recordDeliveryOnly).not.toHaveBeenCalled();
     expect(handlers.publishIntegrationEventReceived).toHaveBeenCalledTimes(1);
+  });
+
+  it('publishes a typed repository update for a repository rename', async () => {
+    const installationId = 7784;
+    const connection = fakeConnection();
+    await seedInstallation(installationId, connection.id);
+    const handlers = deps({connection});
+    const deliveryId = randomUUID();
+    const payload = {
+      action: 'renamed',
+      installation: {id: installationId},
+      repository: {
+        id: 42,
+        name: 'platform-renamed',
+        owner: {login: 'acme'},
+        default_branch: 'trunk',
+      },
+    };
+
+    const result = await handleGithubEvent({
+      tx: db(),
+      deliveryId,
+      event: 'repository',
+      payload,
+      ...handlers,
+    });
+
+    expect(result.outcome).toBe('published');
+    expect(handlers.publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(handlers.publishSourceRepositoryUpdated).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'repository.renamed',
+        rawPayload: payload,
+        repositories: [
+          {
+            externalRepositoryId: 'github:42',
+            owner: 'acme',
+            name: 'platform-renamed',
+            defaultBranch: 'trunk',
+          },
+        ],
+      }),
+    );
+  });
+
+  it('publishes one typed repository update per installation repository', async () => {
+    const installationId = 7785;
+    const connection = fakeConnection();
+    await seedInstallation(installationId, connection.id);
+    const handlers = deps({connection});
+    const deliveryId = randomUUID();
+    const payload = {
+      action: 'added',
+      installation: {id: installationId},
+      repositories_added: [
+        {id: 42, name: 'platform', owner: {login: 'acme'}, default_branch: 'main'},
+      ],
+      repositories_removed: [
+        {id: 43, name: 'runner', owner: {login: 'acme'}, default_branch: 'trunk'},
+      ],
+    };
+
+    const result = await handleGithubEvent({
+      tx: db(),
+      deliveryId,
+      event: 'installation_repositories',
+      payload,
+      ...handlers,
+    });
+
+    expect(result.outcome).toBe('published');
+    expect(handlers.publishSourceRepositoryUpdated).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'installation_repositories.added',
+        repositories: [
+          {
+            externalRepositoryId: 'github:42',
+            owner: 'acme',
+            name: 'platform',
+            defaultBranch: 'main',
+          },
+          {
+            externalRepositoryId: 'github:43',
+            owner: 'acme',
+            name: 'runner',
+            defaultBranch: 'trunk',
+          },
+        ],
+      }),
+    );
   });
 
   it('returns the cached installation token cleanup handle when the installation is deleted', async () => {

--- a/libs/api/integration/github/src/core/webhook.ts
+++ b/libs/api/integration/github/src/core/webhook.ts
@@ -1,6 +1,8 @@
 import {
   type GithubPushPayloadDto,
+  githubInstallationRepositoriesPayloadSchema,
   githubPushPayloadSchema,
+  githubRepositoryRenamedPayloadSchema,
   githubWebhookActionSchema,
   githubWebhookInstallationSchema,
 } from '@shipfox/api-integration-github-dto';
@@ -10,8 +12,10 @@ import {
   type IntegrationTx,
   type PublishIntegrationEventReceivedFn,
   type PublishSourcePushFn,
+  type PublishSourceRepositoryUpdatedFn,
   type RecordDeliveryOnlyFn,
   type SourcePushPayload,
+  type SourceRepositoryIdentity,
 } from '@shipfox/api-integration-spi';
 import {logger} from '@shipfox/node-opentelemetry';
 import {getGithubInstallationByInstallationId} from '#db/installations.js';
@@ -27,6 +31,7 @@ export interface HandleGithubEventParams {
   event: string;
   payload: unknown;
   publishIntegrationEventReceived: PublishIntegrationEventReceivedFn;
+  publishSourceRepositoryUpdated: PublishSourceRepositoryUpdatedFn;
   publishSourcePush: PublishSourcePushFn;
   recordDeliveryOnly: RecordDeliveryOnlyFn;
   getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
@@ -235,6 +240,30 @@ export async function handleGithubEvent(
   }
 
   const eventName = action ? `${params.event}.${action}` : params.event;
+  const repositories = normalizeRepositoryUpdates(params.event, action, params.payload);
+  if (repositories) {
+    const result = await params.publishSourceRepositoryUpdated({
+      tx: params.tx,
+      provider: GITHUB_SOURCE,
+      source: connection.slug,
+      workspaceId: connection.workspaceId,
+      connectionId: connection.id,
+      connectionName: connection.displayName,
+      deliveryId: params.deliveryId,
+      receivedAt: new Date().toISOString(),
+      rawPayload: params.payload,
+      event: eventName,
+      repositories,
+    });
+    return withInstallationTokenCleanup(
+      {outcome: result.published ? 'published' : 'duplicate'},
+      params.event,
+      action,
+      connection.workspaceId,
+      installationId,
+    );
+  }
+
   const result = await publishGithubEnvelopeOnly({
     tx: params.tx,
     deliveryId: params.deliveryId,
@@ -250,6 +279,49 @@ export async function handleGithubEvent(
     connection.workspaceId,
     installationId,
   );
+}
+
+function normalizeRepositoryUpdates(
+  event: string,
+  action: string | undefined,
+  payload: unknown,
+): SourceRepositoryIdentity[] | undefined {
+  if (event === 'repository' && action === 'renamed') {
+    const parsed = githubRepositoryRenamedPayloadSchema.safeParse(payload);
+    if (!parsed.success) return undefined;
+    return [toSourceRepositoryIdentity(parsed.data.repository)];
+  }
+
+  if (event !== 'installation_repositories' || (action !== 'added' && action !== 'removed')) {
+    return undefined;
+  }
+
+  const parsed = githubInstallationRepositoriesPayloadSchema.safeParse(payload);
+  if (!parsed.success) return undefined;
+
+  const repositories = new Map<number, SourceRepositoryIdentity>();
+  for (const repository of [
+    ...parsed.data.repositories_added,
+    ...parsed.data.repositories_removed,
+  ]) {
+    const normalized = toSourceRepositoryIdentity(repository);
+    repositories.set(repository.id, normalized);
+  }
+  return repositories.size > 0 ? [...repositories.values()] : undefined;
+}
+
+function toSourceRepositoryIdentity(repository: {
+  id: number;
+  name: string;
+  owner: {login: string};
+  default_branch: string;
+}): SourceRepositoryIdentity {
+  return {
+    externalRepositoryId: buildProviderRepositoryId(GITHUB_SOURCE, String(repository.id)),
+    owner: repository.owner.login,
+    name: repository.name,
+    defaultBranch: repository.default_branch,
+  };
 }
 
 function shouldDeleteInstallationTokenSecret(event: string, action: string | undefined): boolean {

--- a/libs/api/integration/github/src/index.test.ts
+++ b/libs/api/integration/github/src/index.test.ts
@@ -25,6 +25,7 @@ describe('createGithubIntegrationProvider', () => {
       connectGithubInstallation: vi.fn() as never,
       coreDb: vi.fn() as never,
       publishIntegrationEventReceived: vi.fn(() => Promise.resolve({published: false})),
+      publishSourceRepositoryUpdated: vi.fn(() => Promise.resolve({published: false})),
       publishSourcePush: vi.fn(() => Promise.resolve({published: false})),
       recordDeliveryOnly: vi.fn(() => Promise.resolve()),
       getIntegrationConnectionById: vi.fn(() => Promise.resolve(undefined)),

--- a/libs/api/integration/github/src/index.ts
+++ b/libs/api/integration/github/src/index.ts
@@ -2,6 +2,7 @@ import type {
   GetIntegrationConnectionByIdFn,
   PublishIntegrationEventReceivedFn,
   PublishSourcePushFn,
+  PublishSourceRepositoryUpdatedFn,
   RecordDeliveryOnlyFn,
 } from '@shipfox/api-integration-spi';
 import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
@@ -69,6 +70,7 @@ export interface CreateGithubIntegrationProviderOptions
   github?: GithubApiClient | undefined;
   coreDb: () => NodePgDatabase<Record<string, unknown>>;
   publishIntegrationEventReceived: PublishIntegrationEventReceivedFn;
+  publishSourceRepositoryUpdated: PublishSourceRepositoryUpdatedFn;
   publishSourcePush: PublishSourcePushFn;
   recordDeliveryOnly: RecordDeliveryOnlyFn;
   getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
@@ -129,6 +131,7 @@ export function createGithubIntegrationProvider(options: CreateGithubIntegration
       createGithubWebhookRoutes({
         coreDb: options.coreDb,
         publishIntegrationEventReceived: options.publishIntegrationEventReceived,
+        publishSourceRepositoryUpdated: options.publishSourceRepositoryUpdated,
         publishSourcePush: options.publishSourcePush,
         recordDeliveryOnly: options.recordDeliveryOnly,
         getIntegrationConnectionById: options.getIntegrationConnectionById,

--- a/libs/api/integration/github/src/presentation/routes/install.test.ts
+++ b/libs/api/integration/github/src/presentation/routes/install.test.ts
@@ -103,6 +103,7 @@ async function createTestApp(options: CreateTestAppOptions = {}): Promise<Fastif
     // Webhook receiver dependencies — install/OAuth tests don't exercise them.
     coreDb: vi.fn() as never,
     publishIntegrationEventReceived: vi.fn(() => Promise.resolve({published: false})),
+    publishSourceRepositoryUpdated: vi.fn(() => Promise.resolve({published: false})),
     publishSourcePush: vi.fn(() => Promise.resolve({published: false})),
     recordDeliveryOnly: vi.fn(() => Promise.resolve()),
     getIntegrationConnectionById: vi.fn(() => Promise.resolve(undefined)),

--- a/libs/api/integration/github/src/presentation/routes/webhooks.test.ts
+++ b/libs/api/integration/github/src/presentation/routes/webhooks.test.ts
@@ -11,6 +11,7 @@ import {createGithubWebhookRoutes} from './webhooks.js';
 const WEBHOOK_SECRET = 'test-webhook-secret';
 
 // The route persists through injected core functions (publishSourcePush,
+// publishSourceRepositoryUpdated,
 // recordDeliveryOnly, getIntegrationConnectionById) that @shipfox/api-integration-core
 // owns and wires in production. github only orchestrates them, so here we fake that
 // interface with spies and assert the route's own behavior: signature/payload
@@ -34,6 +35,7 @@ function fakeConnection(overrides: Partial<IntegrationConnection> = {}): Integra
 interface TestApp {
   app: FastifyInstance;
   publishIntegrationEventReceived: ReturnType<typeof vi.fn>;
+  publishSourceRepositoryUpdated: ReturnType<typeof vi.fn>;
   publishSourcePush: ReturnType<typeof vi.fn>;
   recordDeliveryOnly: ReturnType<typeof vi.fn>;
   getIntegrationConnectionById: ReturnType<typeof vi.fn>;
@@ -41,6 +43,7 @@ interface TestApp {
 
 async function createTestApp(options: {connection?: IntegrationConnection} = {}): Promise<TestApp> {
   const publishIntegrationEventReceived = vi.fn(() => Promise.resolve({published: true}));
+  const publishSourceRepositoryUpdated = vi.fn(() => Promise.resolve({published: true}));
   const publishSourcePush = vi.fn(() => Promise.resolve({published: true}));
   const recordDeliveryOnly = vi.fn(() => Promise.resolve());
   const getIntegrationConnectionById = vi.fn(() =>
@@ -49,6 +52,7 @@ async function createTestApp(options: {connection?: IntegrationConnection} = {})
   const routes = createGithubWebhookRoutes({
     coreDb: db,
     publishIntegrationEventReceived,
+    publishSourceRepositoryUpdated,
     publishSourcePush,
     recordDeliveryOnly,
     getIntegrationConnectionById,
@@ -58,6 +62,7 @@ async function createTestApp(options: {connection?: IntegrationConnection} = {})
   return {
     app,
     publishIntegrationEventReceived,
+    publishSourceRepositoryUpdated,
     publishSourcePush,
     recordDeliveryOnly,
     getIntegrationConnectionById,

--- a/libs/api/integration/github/src/presentation/routes/webhooks.ts
+++ b/libs/api/integration/github/src/presentation/routes/webhooks.ts
@@ -3,6 +3,7 @@ import type {
   GetIntegrationConnectionByIdFn,
   PublishIntegrationEventReceivedFn,
   PublishSourcePushFn,
+  PublishSourceRepositoryUpdatedFn,
   RecordDeliveryOnlyFn,
   StoredWebhookRequest,
   WebhookProcessingResult,
@@ -28,6 +29,7 @@ const DELIVERY_HEADER = 'x-github-delivery';
 export interface CreateGithubWebhookRoutesOptions {
   coreDb: () => NodePgDatabase<Record<string, unknown>>;
   publishIntegrationEventReceived: PublishIntegrationEventReceivedFn;
+  publishSourceRepositoryUpdated: PublishSourceRepositoryUpdatedFn;
   publishSourcePush: PublishSourcePushFn;
   recordDeliveryOnly: RecordDeliveryOnlyFn;
   getIntegrationConnectionById: GetIntegrationConnectionByIdFn;

--- a/libs/api/integration/spi/src/ports.ts
+++ b/libs/api/integration/spi/src/ports.ts
@@ -1,6 +1,7 @@
 import type {
   IntegrationEventReceivedEvent,
   SourcePushPayload,
+  SourceRepositoryIdentity,
 } from '@shipfox/api-integration-core-dto';
 import type {IntegrationConnection, IntegrationConnectionLifecycleStatus} from '#contracts.js';
 
@@ -35,6 +36,20 @@ export type PublishSourcePushFn = (params: {
   receivedAt: string;
   rawPayload: unknown;
   push: SourcePushPayload;
+}) => Promise<{published: boolean}>;
+
+export type PublishSourceRepositoryUpdatedFn = (params: {
+  tx: IntegrationTx;
+  provider: string;
+  source: string;
+  workspaceId: string;
+  connectionId: string;
+  connectionName: string;
+  deliveryId: string;
+  receivedAt: string;
+  rawPayload: unknown;
+  event: string;
+  repositories: SourceRepositoryIdentity[];
 }) => Promise<{published: boolean}>;
 
 export type RecordDeliveryOnlyFn = (params: {

--- a/libs/api/projects/src/db/db.ts
+++ b/libs/api/projects/src/db/db.ts
@@ -17,6 +17,9 @@ export function db() {
   return _db;
 }
 
+export type Tx = Parameters<Parameters<ReturnType<typeof db>['transaction']>[0]>[0];
+export type Executor = ReturnType<typeof db> | Tx;
+
 export function closeDb(): void {
   _db = undefined;
 }

--- a/libs/api/projects/src/db/projects.ts
+++ b/libs/api/projects/src/db/projects.ts
@@ -2,7 +2,7 @@ import {and, count, desc, eq, ilike, inArray, lt, or, type SQL} from 'drizzle-or
 import type {Project} from '#core/entities/project.js';
 import {ProjectAlreadyExistsError, ProjectNotFoundError} from '#core/errors.js';
 import {recordProjectCreated} from '#metrics/instance.js';
-import {db} from './db.js';
+import {db, type Executor} from './db.js';
 import {projects, toProject} from './schema/projects.js';
 
 export interface CreateProjectParams {
@@ -135,6 +135,7 @@ export async function getProjectBySource(
 }
 
 export interface UpdateProjectSourceRepositoryParams extends GetProjectBySourceParams {
+  tx?: Executor;
   sourceRepositoryOwner: string;
   sourceRepositoryName: string;
   sourceDefaultBranch: string;
@@ -143,7 +144,8 @@ export interface UpdateProjectSourceRepositoryParams extends GetProjectBySourceP
 export async function updateProjectSourceRepository(
   params: UpdateProjectSourceRepositoryParams,
 ): Promise<Project | undefined> {
-  const rows = await db()
+  const executor = params.tx ?? db();
+  const rows = await executor
     .update(projects)
     .set({
       sourceRepositoryOwner: params.sourceRepositoryOwner,

--- a/libs/api/projects/src/db/projects.ts
+++ b/libs/api/projects/src/db/projects.ts
@@ -134,6 +134,37 @@ export async function getProjectBySource(
   return toProject(row);
 }
 
+export interface UpdateProjectSourceRepositoryParams extends GetProjectBySourceParams {
+  sourceRepositoryOwner: string;
+  sourceRepositoryName: string;
+  sourceDefaultBranch: string;
+}
+
+export async function updateProjectSourceRepository(
+  params: UpdateProjectSourceRepositoryParams,
+): Promise<Project | undefined> {
+  const rows = await db()
+    .update(projects)
+    .set({
+      sourceRepositoryOwner: params.sourceRepositoryOwner,
+      sourceRepositoryName: params.sourceRepositoryName,
+      sourceDefaultBranch: params.sourceDefaultBranch,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(projects.workspaceId, params.workspaceId),
+        eq(projects.sourceConnectionId, params.sourceConnectionId),
+        eq(projects.sourceExternalRepositoryId, params.sourceExternalRepositoryId),
+      ),
+    )
+    .returning();
+
+  const row = rows[0];
+  if (!row) return undefined;
+  return toProject(row);
+}
+
 export async function requireProjectForWorkspace(params: {
   projectId: string;
   workspaceId: string;

--- a/libs/api/projects/src/index.ts
+++ b/libs/api/projects/src/index.ts
@@ -3,6 +3,7 @@ import {fileURLToPath} from 'node:url';
 import type {AuthInterModuleClient} from '@shipfox/api-auth-dto/inter-module';
 import {
   INTEGRATION_SOURCE_COMMIT_PUSHED,
+  INTEGRATION_SOURCE_REPOSITORY_UPDATED,
   type IntegrationsEventMap,
 } from '@shipfox/api-integration-core-dto';
 import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
@@ -13,7 +14,7 @@ import {registerProjectsServiceMetrics} from '#metrics/index.js';
 import {projectsE2eRoutes} from '#presentation/e2eRoutes/index.js';
 import {createProjectRoutes} from '#presentation/index.js';
 import {createProjectsInterModulePresentation} from '#presentation/inter-module.js';
-import {onSourceCommitPushed} from '#presentation/subscribers/index.js';
+import {onSourceCommitPushed, onSourceRepositoryUpdated} from '#presentation/subscribers/index.js';
 import {createProjectsMaintenanceActivities} from '#temporal/activities/index.js';
 import {PROJECTS_MAINTENANCE_TASK_QUEUE} from '#temporal/constants.js';
 
@@ -60,7 +61,10 @@ export function createProjectsModule({
     metrics: registerProjectsServiceMetrics,
     publishers: [{name: 'projects', table: projectsOutbox, db, eventSchemas: projectsEventSchemas}],
     interModulePresentations: [createProjectsInterModulePresentation()],
-    subscribers: [subscriber(INTEGRATION_SOURCE_COMMIT_PUSHED, onSourceCommitPushed)],
+    subscribers: [
+      subscriber(INTEGRATION_SOURCE_COMMIT_PUSHED, onSourceCommitPushed),
+      subscriber(INTEGRATION_SOURCE_REPOSITORY_UPDATED, onSourceRepositoryUpdated),
+    ],
     workers: [
       {
         taskQueue: PROJECTS_MAINTENANCE_TASK_QUEUE,

--- a/libs/api/projects/src/presentation/subscribers/index.ts
+++ b/libs/api/projects/src/presentation/subscribers/index.ts
@@ -1,1 +1,2 @@
 export {onSourceCommitPushed} from './on-source-commit-pushed.js';
+export {onSourceRepositoryUpdated} from './on-source-repository-updated.js';

--- a/libs/api/projects/src/presentation/subscribers/on-source-commit-pushed.test.ts
+++ b/libs/api/projects/src/presentation/subscribers/on-source-commit-pushed.test.ts
@@ -1,6 +1,7 @@
 import type {AuthInterModuleClient} from '@shipfox/api-auth-dto/inter-module';
 import {
   INTEGRATION_SOURCE_COMMIT_PUSHED,
+  INTEGRATION_SOURCE_REPOSITORY_UPDATED,
   type IntegrationSourceCommitPushedEvent,
   type SourcePushPayload,
 } from '@shipfox/api-integration-core-dto';
@@ -150,5 +151,6 @@ describe('onSourceCommitPushed', () => {
     const events = module.subscribers?.map((subscriber) => subscriber.event);
 
     expect(events).toContain(INTEGRATION_SOURCE_COMMIT_PUSHED);
+    expect(events).toContain(INTEGRATION_SOURCE_REPOSITORY_UPDATED);
   });
 });

--- a/libs/api/projects/src/presentation/subscribers/on-source-repository-updated.test.ts
+++ b/libs/api/projects/src/presentation/subscribers/on-source-repository-updated.test.ts
@@ -1,0 +1,74 @@
+import {
+  INTEGRATION_SOURCE_REPOSITORY_UPDATED,
+  type IntegrationSourceRepositoryUpdatedEvent,
+} from '@shipfox/api-integration-core-dto';
+import type {DomainEvent} from '@shipfox/node-outbox';
+import {getProjectBySource} from '#db/index.js';
+import {projectFactory} from '#test/index.js';
+import {onSourceRepositoryUpdated} from './on-source-repository-updated.js';
+
+function buildEvent(params: {
+  workspaceId: string;
+  connectionId: string;
+  externalRepositoryId: string;
+}): DomainEvent<IntegrationSourceRepositoryUpdatedEvent> {
+  return {
+    id: crypto.randomUUID(),
+    type: INTEGRATION_SOURCE_REPOSITORY_UPDATED,
+    createdAt: new Date(),
+    payload: {
+      provider: 'github',
+      workspaceId: params.workspaceId,
+      connectionId: params.connectionId,
+      deliveryId: crypto.randomUUID(),
+      receivedAt: new Date().toISOString(),
+      repository: {
+        externalRepositoryId: params.externalRepositoryId,
+        owner: 'acme',
+        name: 'platform-renamed',
+        defaultBranch: 'trunk',
+      },
+    },
+  };
+}
+
+describe('onSourceRepositoryUpdated', () => {
+  it('refreshes the denormalized repository identity by stable external id', async () => {
+    const workspaceId = crypto.randomUUID();
+    const connectionId = crypto.randomUUID();
+    const externalRepositoryId = `github:${crypto.randomUUID()}`;
+    const project = await projectFactory.create({
+      workspaceId,
+      sourceConnectionId: connectionId,
+      sourceExternalRepositoryId: externalRepositoryId,
+      sourceRepositoryOwner: 'old-owner',
+      sourceRepositoryName: 'old-name',
+      sourceDefaultBranch: 'main',
+    });
+    const event = buildEvent({workspaceId, connectionId, externalRepositoryId});
+
+    await onSourceRepositoryUpdated(event.payload, event);
+
+    const refreshed = await getProjectBySource({
+      workspaceId,
+      sourceConnectionId: connectionId,
+      sourceExternalRepositoryId: externalRepositoryId,
+    });
+    expect(refreshed).toMatchObject({
+      id: project.id,
+      sourceRepositoryOwner: 'acme',
+      sourceRepositoryName: 'platform-renamed',
+      sourceDefaultBranch: 'trunk',
+    });
+  });
+
+  it('ignores updates for repositories without a bound project', async () => {
+    const event = buildEvent({
+      workspaceId: crypto.randomUUID(),
+      connectionId: crypto.randomUUID(),
+      externalRepositoryId: `github:${crypto.randomUUID()}`,
+    });
+
+    await expect(onSourceRepositoryUpdated(event.payload, event)).resolves.toBeUndefined();
+  });
+});

--- a/libs/api/projects/src/presentation/subscribers/on-source-repository-updated.test.ts
+++ b/libs/api/projects/src/presentation/subscribers/on-source-repository-updated.test.ts
@@ -71,4 +71,38 @@ describe('onSourceRepositoryUpdated', () => {
 
     await expect(onSourceRepositoryUpdated(event.payload, event)).resolves.toBeUndefined();
   });
+
+  it('deduplicates the same repository update event for a project', async () => {
+    const workspaceId = crypto.randomUUID();
+    const connectionId = crypto.randomUUID();
+    const externalRepositoryId = `github:${crypto.randomUUID()}`;
+    await projectFactory.create({
+      workspaceId,
+      sourceConnectionId: connectionId,
+      sourceExternalRepositoryId: externalRepositoryId,
+      sourceRepositoryOwner: 'old-owner',
+      sourceRepositoryName: 'old-name',
+      sourceDefaultBranch: 'main',
+    });
+    const event = buildEvent({workspaceId, connectionId, externalRepositoryId});
+
+    await onSourceRepositoryUpdated(event.payload, event);
+    const duplicate = {
+      ...event,
+      payload: {
+        ...event.payload,
+        repository: {...event.payload.repository, name: 'stale-name'},
+      },
+    };
+    await onSourceRepositoryUpdated(duplicate.payload, duplicate);
+
+    const refreshed = await getProjectBySource({
+      workspaceId,
+      sourceConnectionId: connectionId,
+      sourceExternalRepositoryId: externalRepositoryId,
+    });
+    expect(refreshed).toMatchObject({
+      sourceRepositoryName: 'platform-renamed',
+    });
+  });
 });

--- a/libs/api/projects/src/presentation/subscribers/on-source-repository-updated.ts
+++ b/libs/api/projects/src/presentation/subscribers/on-source-repository-updated.ts
@@ -1,22 +1,43 @@
 import type {IntegrationSourceRepositoryUpdatedEvent} from '@shipfox/api-integration-core-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import type {DomainEvent} from '@shipfox/node-outbox';
-import {updateProjectSourceRepository} from '#db/projects.js';
+import {db} from '#db/db.js';
+import {recordIntegrationEventForProject} from '#db/integration-event-dedup.js';
+import {getProjectBySource, updateProjectSourceRepository} from '#db/projects.js';
 
 export async function onSourceRepositoryUpdated(
   payload: IntegrationSourceRepositoryUpdatedEvent,
   event: DomainEvent<IntegrationSourceRepositoryUpdatedEvent>,
 ): Promise<void> {
-  const project = await updateProjectSourceRepository({
+  const project = await getProjectBySource({
     workspaceId: payload.workspaceId,
     sourceConnectionId: payload.connectionId,
     sourceExternalRepositoryId: payload.repository.externalRepositoryId,
-    sourceRepositoryOwner: payload.repository.owner,
-    sourceRepositoryName: payload.repository.name,
-    sourceDefaultBranch: payload.repository.defaultBranch,
   });
 
-  if (project) return;
+  if (project) {
+    const outcome = await db().transaction(async (tx) => {
+      const {firstSeen} = await recordIntegrationEventForProject({
+        tx,
+        integrationEventId: event.id,
+        projectId: project.id,
+      });
+      if (!firstSeen) return 'duplicate';
+
+      const updated = await updateProjectSourceRepository({
+        tx,
+        workspaceId: payload.workspaceId,
+        sourceConnectionId: payload.connectionId,
+        sourceExternalRepositoryId: payload.repository.externalRepositoryId,
+        sourceRepositoryOwner: payload.repository.owner,
+        sourceRepositoryName: payload.repository.name,
+        sourceDefaultBranch: payload.repository.defaultBranch,
+      });
+      return updated ? 'updated' : 'missing';
+    });
+
+    if (outcome !== 'missing') return;
+  }
 
   logger().info(
     {

--- a/libs/api/projects/src/presentation/subscribers/on-source-repository-updated.ts
+++ b/libs/api/projects/src/presentation/subscribers/on-source-repository-updated.ts
@@ -1,0 +1,29 @@
+import type {IntegrationSourceRepositoryUpdatedEvent} from '@shipfox/api-integration-core-dto';
+import {logger} from '@shipfox/node-opentelemetry';
+import type {DomainEvent} from '@shipfox/node-outbox';
+import {updateProjectSourceRepository} from '#db/projects.js';
+
+export async function onSourceRepositoryUpdated(
+  payload: IntegrationSourceRepositoryUpdatedEvent,
+  event: DomainEvent<IntegrationSourceRepositoryUpdatedEvent>,
+): Promise<void> {
+  const project = await updateProjectSourceRepository({
+    workspaceId: payload.workspaceId,
+    sourceConnectionId: payload.connectionId,
+    sourceExternalRepositoryId: payload.repository.externalRepositoryId,
+    sourceRepositoryOwner: payload.repository.owner,
+    sourceRepositoryName: payload.repository.name,
+    sourceDefaultBranch: payload.repository.defaultBranch,
+  });
+
+  if (project) return;
+
+  logger().info(
+    {
+      eventId: event.id,
+      connectionId: payload.connectionId,
+      externalRepositoryId: payload.repository.externalRepositoryId,
+    },
+    'source repository updated: no project bound to source, dropping',
+  );
+}


### PR DESCRIPTION
GitHub repository rename and installation-repositories webhooks now publish a typed, provider-agnostic repository identity event. Projects consume it and refresh the denormalized owner, name, and default branch using the stable external repository ID, while preserving delivery deduplication and the generic integration envelope.

The update remains intentionally last-write-wins for this issue. A receipt-time comparison against the project’s general `updatedAt` would be unsafe because that field also changes for unrelated project edits; stronger source-event ordering would require a dedicated source version or timestamp in a follow-up.

Validation completed: affected-package type checks, dependency checks, database-boundary verification, and 91 focused tests across the changed packages and dependents.

Closes ENG-1426

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish provider-agnostic repository identity updates from GitHub rename and installation-repositories webhooks, and refresh projects by stable external repository ID with atomic deduplication. Fulfills ENG-1426 by keeping project owner, name, and default branch in sync.

- **New Features**
  - Added `integrations.source_control.repository_updated` event and schema in `@shipfox/api-integration-core-dto`; exposed via `@shipfox/api-integration-spi`.
  - GitHub translates `repository.renamed` and `installation_repositories.added/removed` into typed repository-identity events and also writes the generic envelope; one typed event per repository with delivery dedup.
  - Introduced `publishSourceRepositoryUpdated` in `@shipfox/api-integration-core` to atomically emit the envelope and per-repo events from a single delivery; GitHub normalizes `externalRepositoryId` as `github:<id>`.
  - `@shipfox/api-projects` subscribes to the new event and updates denormalized owner/name/defaultBranch using the stable `externalRepositoryId` (last-write-wins).

- **Refactors**
  - Shared webhook publication logic via a new internal `publishSourceEvents`, used by both push and repository-update flows.
  - Added per-project integration-event dedup in `@shipfox/api-projects` to avoid reapplying the same repository update.

<sup>Written for commit be1f9d187f2b775b7358cec0f5506d27dd00e35c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

