### PR TITLE
Allow runner steps to target workspace directories

### DIFF
--- a/.changeset/runner-step-working-directory.md
+++ b/.changeset/runner-step-working-directory.md
@@ -1,0 +1,8 @@
+---
+"@shipfox/api-definitions": minor
+"@shipfox/api-definitions-dto": minor
+"@shipfox/api-workflows": patch
+"@shipfox/api-workflows-dto": minor
+---
+
+Resolve run and agent step working directories against the runner job workspace.

--- a/.changeset/runner-step-working-directory.md
+++ b/.changeset/runner-step-working-directory.md
@@ -1,7 +1,7 @@
 ---
 "@shipfox/api-definitions": minor
 "@shipfox/api-definitions-dto": minor
-"@shipfox/api-workflows": patch
+"@shipfox/api-workflows": minor
 "@shipfox/api-workflows-dto": minor
 ---
 

--- a/libs/api/definitions-dto/src/workflow-model.ts
+++ b/libs/api/definitions-dto/src/workflow-model.ts
@@ -91,6 +91,7 @@ interface WorkflowModelStepBase {
   readonly key?: string;
   readonly if?: WorkflowExpression;
   readonly name?: string;
+  readonly workingDirectory?: string;
   readonly outputs?: OutputDeclarations;
   readonly gate?: WorkflowModelStepGate;
   readonly sourceLocation?: WorkflowSourceLocation;
@@ -102,6 +103,7 @@ export interface WorkflowModelRunStep extends WorkflowModelStepBase {
   readonly templates?: {
     readonly command?: WorkflowFieldTemplate;
     readonly name?: WorkflowFieldTemplate;
+    readonly workingDirectory?: WorkflowFieldTemplate;
     readonly env?: WorkflowEnvTemplates;
   };
 }
@@ -118,6 +120,7 @@ export interface WorkflowModelAgentStep extends WorkflowModelStepBase {
     readonly prompt?: WorkflowFieldTemplate;
     readonly model?: WorkflowFieldTemplate;
     readonly provider?: WorkflowFieldTemplate;
+    readonly workingDirectory?: WorkflowFieldTemplate;
     readonly name?: WorkflowFieldTemplate;
   };
 }

--- a/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
@@ -595,10 +595,25 @@ function normalizeStep(params: {
           allowedJobReferences: params.allowedJobReferences,
           typeOverlay,
         });
+  const workingDirectory =
+    params.step.working_directory === undefined
+      ? undefined
+      : parseInterpolationField({
+          field: 'step.working_directory',
+          source: params.step.working_directory,
+          path: ['jobs', params.sourceName, 'steps', params.index, 'working_directory'],
+          issues: params.issues,
+          fillSite: params.fillSite,
+          allowedJobReferences: params.allowedJobReferences,
+          typeOverlay,
+        });
   const stepBase = {
     id: stepId,
     ...(stepKey === undefined ? {} : {key: stepKey}),
     ...(params.step.name === undefined ? {} : {name: params.step.name}),
+    ...(params.step.working_directory === undefined
+      ? {}
+      : {workingDirectory: params.step.working_directory}),
     ...(outputs === undefined ? {} : {outputs}),
     ...(sourceLocation === undefined ? {} : {sourceLocation}),
     ...(condition === undefined ? {} : {if: condition}),
@@ -612,6 +627,7 @@ function normalizeStep(params: {
       sourceName: params.sourceName,
       stepIndex: params.index,
       name,
+      workingDirectory,
       issues: params.issues,
       fillSite: params.fillSite,
       allowedJobReferences: params.allowedJobReferences,
@@ -626,6 +642,7 @@ function normalizeStep(params: {
       sourceName: params.sourceName,
       stepIndex: params.index,
       name,
+      workingDirectory,
       issues: params.issues,
       fillSite: params.fillSite,
       allowedJobReferences: params.allowedJobReferences,
@@ -645,6 +662,7 @@ function normalizeRunStep(params: {
   sourceName: string;
   stepIndex: number;
   name: WorkflowFieldTemplate | undefined;
+  workingDirectory: WorkflowFieldTemplate | undefined;
   issues: WorkflowModelValidationIssue[];
   fillSite: AvailabilitySite;
   allowedJobReferences: ReadonlySet<string>;
@@ -674,6 +692,7 @@ function normalizeRunStep(params: {
   const templates = optionalRunStepTemplates({
     command: commandTemplate,
     name: params.name,
+    workingDirectory: params.workingDirectory,
     env: stepEnv.templates?.env,
   });
 
@@ -692,6 +711,7 @@ function normalizeAgentStep(params: {
   sourceName: string;
   stepIndex: number;
   name: WorkflowFieldTemplate | undefined;
+  workingDirectory: WorkflowFieldTemplate | undefined;
   issues: WorkflowModelValidationIssue[];
   fillSite: AvailabilitySite;
   allowedJobReferences: ReadonlySet<string>;
@@ -758,6 +778,7 @@ function normalizeAgentStep(params: {
     model: modelTemplate,
     provider: providerTemplate,
     name: params.name,
+    workingDirectory: params.workingDirectory,
   });
 
   return {
@@ -1020,27 +1041,35 @@ function validateRunnerLabels(params: {
 
 type WorkflowModelStepBaseFields = Pick<
   WorkflowModelStep,
-  'id' | 'key' | 'name' | 'outputs' | 'sourceLocation' | 'gate'
+  'id' | 'key' | 'name' | 'workingDirectory' | 'outputs' | 'sourceLocation' | 'gate'
 >;
 
 function optionalRunStepTemplates(params: {
   command: WorkflowFieldTemplate | undefined;
   name: WorkflowFieldTemplate | undefined;
+  workingDirectory: WorkflowFieldTemplate | undefined;
   env: WorkflowEnvTemplates | undefined;
 }):
   | {
       command?: WorkflowFieldTemplate;
       name?: WorkflowFieldTemplate;
+      workingDirectory?: WorkflowFieldTemplate;
       env?: WorkflowEnvTemplates;
     }
   | undefined {
-  if (params.command === undefined && params.name === undefined && params.env === undefined) {
+  if (
+    params.command === undefined &&
+    params.name === undefined &&
+    params.workingDirectory === undefined &&
+    params.env === undefined
+  ) {
     return undefined;
   }
 
   return {
     ...(params.command === undefined ? {} : {command: params.command}),
     ...(params.name === undefined ? {} : {name: params.name}),
+    ...(params.workingDirectory === undefined ? {} : {workingDirectory: params.workingDirectory}),
     ...(params.env === undefined ? {} : {env: params.env}),
   };
 }
@@ -1050,19 +1079,22 @@ function optionalAgentStepTemplates(params: {
   model: WorkflowFieldTemplate | undefined;
   provider: WorkflowFieldTemplate | undefined;
   name: WorkflowFieldTemplate | undefined;
+  workingDirectory: WorkflowFieldTemplate | undefined;
 }):
   | {
       prompt?: WorkflowFieldTemplate;
       model?: WorkflowFieldTemplate;
       provider?: WorkflowFieldTemplate;
       name?: WorkflowFieldTemplate;
+      workingDirectory?: WorkflowFieldTemplate;
     }
   | undefined {
   if (
     params.prompt === undefined &&
     params.model === undefined &&
     params.provider === undefined &&
-    params.name === undefined
+    params.name === undefined &&
+    params.workingDirectory === undefined
   ) {
     return undefined;
   }
@@ -1072,5 +1104,6 @@ function optionalAgentStepTemplates(params: {
     ...(params.model === undefined ? {} : {model: params.model}),
     ...(params.provider === undefined ? {} : {provider: params.provider}),
     ...(params.name === undefined ? {} : {name: params.name}),
+    ...(params.workingDirectory === undefined ? {} : {workingDirectory: params.workingDirectory}),
   };
 }

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -3759,11 +3759,13 @@ describe('normalizeWorkflowDocument', () => {
             steps: [
               {
                 name: `deploy ${interpolation('event.action')}`,
+                working_directory: 'packages/api',
                 run: `deploy ${interpolation('run.id')}`,
                 env: {PR_TITLE: interpolation('event.pull_request.title'), DEBUG: false},
               },
               {
                 name: `review ${interpolation('inputs.topic')}`,
+                working_directory: `packages/${interpolation('inputs.topic')}`,
                 provider: 'openai',
                 prompt: `Review ${interpolation('event.pull_request.title')}`,
               },
@@ -3810,6 +3812,7 @@ describe('normalizeWorkflowDocument', () => {
       expect(model.jobs[0]?.steps[0]).toMatchObject({
         kind: 'run',
         command: {value: `deploy ${interpolation('run.id')}`},
+        workingDirectory: 'packages/api',
         templates: {
           command: [
             {kind: 'literal', value: 'deploy '},
@@ -3844,7 +3847,16 @@ describe('normalizeWorkflowDocument', () => {
       });
       expect(model.jobs[0]?.steps[1]).toMatchObject({
         kind: 'agent',
+        workingDirectory: `packages/${interpolation('inputs.topic')}`,
         templates: {
+          workingDirectory: [
+            {kind: 'literal', value: 'packages/'},
+            {
+              kind: 'deferred',
+              expression: {source: 'inputs.topic'},
+              roots: ['inputs'],
+            },
+          ],
           prompt: [
             {kind: 'literal', value: 'Review '},
             {

--- a/libs/api/definitions/src/core/workflow-model/parse-interpolation-field.ts
+++ b/libs/api/definitions/src/core/workflow-model/parse-interpolation-field.ts
@@ -43,6 +43,7 @@ export type StoredInterpolationField =
   | 'job.execution_name'
   | 'job.runner'
   | 'step.name'
+  | 'step.working_directory'
   | 'step.feedback';
 
 export function parseInterpolationField(params: {

--- a/libs/api/definitions/src/core/workflow-model/workflow-field-label.ts
+++ b/libs/api/definitions/src/core/workflow-model/workflow-field-label.ts
@@ -28,6 +28,8 @@ export function workflowFieldLabel(
       return 'Job execution name interpolation';
     case 'step.name':
       return 'Step name interpolation';
+    case 'step.working_directory':
+      return 'Step working directory interpolation';
     case 'step.success':
       return 'Step gate success';
     case 'step.feedback':

--- a/libs/api/workflows-dto/src/index.ts
+++ b/libs/api/workflows-dto/src/index.ts
@@ -128,3 +128,4 @@ export {
   workflowsWorkflowRunCancelledSchema,
   workflowsWorkflowRunTerminatedSchema,
 } from './events.js';
+export {assertWorkingDirectory, InvalidWorkingDirectoryError} from './working-directory.js';

--- a/libs/api/workflows-dto/src/inter-module.ts
+++ b/libs/api/workflows-dto/src/inter-module.ts
@@ -37,6 +37,7 @@ const interpolationFieldSchema = z.enum([
   'job.name',
   'job.execution_name',
   'step.name',
+  'step.working_directory',
   'step.feedback',
 ]);
 

--- a/libs/api/workflows-dto/src/working-directory.ts
+++ b/libs/api/workflows-dto/src/working-directory.ts
@@ -1,0 +1,28 @@
+const WINDOWS_ABSOLUTE_PATH = /^[A-Za-z]:[\\/]/;
+const PATH_SEPARATOR = /[\\/]/;
+
+export class InvalidWorkingDirectoryError extends Error {
+  constructor(value: unknown) {
+    super(
+      `Invalid working_directory ${JSON.stringify(value)}: it must be a relative path without '..' segments or absolute path syntax.`,
+    );
+    this.name = 'InvalidWorkingDirectoryError';
+  }
+}
+
+/**
+ * Checks the path shape shared by the server dispatch boundary and the runner.
+ * Filesystem containment is checked by the runner after resolving symlinks.
+ */
+export function assertWorkingDirectory(value: unknown): asserts value is string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new InvalidWorkingDirectoryError(value);
+  }
+
+  const isAbsolute =
+    value.startsWith('/') || value.startsWith('\\') || WINDOWS_ABSOLUTE_PATH.test(value);
+  const hasParentSegment = value.split(PATH_SEPARATOR).some((segment) => segment === '..');
+  if (isAbsolute || hasParentSegment) {
+    throw new InvalidWorkingDirectoryError(value);
+  }
+}

--- a/libs/api/workflows/src/core/entities/step.ts
+++ b/libs/api/workflows/src/core/entities/step.ts
@@ -61,6 +61,7 @@ export interface StepConfigEvaluationTraceEntry extends EvaluationTraceEntry {
 }
 
 export interface StepConfigDispatchPlan {
+  working_directory?: ResolvedField;
   run?: ResolvedField;
   env?: Readonly<Record<string, ResolvedField>>;
   agent?: {

--- a/libs/api/workflows/src/core/errors.ts
+++ b/libs/api/workflows/src/core/errors.ts
@@ -66,6 +66,7 @@ export type InterpolationUnresolvableField =
   | 'job.name'
   | 'job.execution_name'
   | 'step.name'
+  | 'step.working_directory'
   | 'step.feedback';
 
 export class InterpolationUnresolvableError extends Error {

--- a/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
+++ b/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
@@ -251,6 +251,62 @@ describe('completeStepDispatchConfig', () => {
     });
   });
 
+  it('resolves a deferred working directory at step dispatch', async () => {
+    const pending = step({
+      config: {},
+      configPlan: {
+        working_directory: plannedField(template('steps.build.outputs.path')),
+      },
+    });
+
+    const result = await completeStepDispatchConfig({
+      step: pending,
+      context: {
+        ...context,
+        values: {
+          ...context.values,
+          steps: {
+            build: {
+              outputs: {path: 'packages/api'},
+            },
+          },
+        },
+      },
+      resolveAgentDefaults,
+      definitionId: 'def-1',
+    });
+
+    expect(result).toEqual({
+      config: {working_directory: 'packages/api'},
+      trace: [
+        {
+          expression: 'steps.build.outputs.path',
+          roots: ['steps'],
+          fillTarget: 'step-dispatch',
+          evaluatedAt: 'step-dispatch',
+          value: 'packages/api',
+          field: 'step.working_directory',
+        },
+      ],
+    });
+  });
+
+  it('rejects invalid resolved working directories', async () => {
+    const pending = step({
+      config: {working_directory: '../outside'},
+      configPlan: null,
+    });
+
+    await expect(
+      completeStepDispatchConfig({
+        step: pending,
+        context,
+        resolveAgentDefaults,
+        definitionId: 'def-1',
+      }),
+    ).rejects.toThrow('Invalid working_directory');
+  });
+
   it('completes deferred agent config with the resolved harness', async () => {
     const integration = materializedIntegration();
     const mcpServers = integrationMcpServers([integration]);

--- a/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.ts
+++ b/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.ts
@@ -1,7 +1,9 @@
+import {assertWorkingDirectory} from '@shipfox/api-workflows-dto';
 import {capTraceEntries} from '@shipfox/expression';
 import type {AgentDefaultsResolver} from '#core/agent-defaults.js';
 import type {PersistedEvaluationTraceEntry, Step} from '#core/entities/step.js';
 import {completeAgentConfig} from './agent.js';
+import {completeStepFieldWithTrace} from './fields.js';
 import {completeRunDispatchConfig} from './run.js';
 import type {WorkflowEvaluationContext} from './workflow-evaluation-context.js';
 
@@ -15,7 +17,10 @@ export async function completeStepDispatchConfig(params: {
   readonly trace: readonly PersistedEvaluationTraceEntry[];
 }> {
   const plan = params.step.configPlan;
-  if (plan === null) return {config: params.step.config, trace: []};
+  if (plan === null) {
+    assertWorkingDirectoryIfPresent(params.step.config.working_directory);
+    return {config: params.step.config, trace: []};
+  }
 
   const config = {...params.step.config};
   delete config.secret_bindings;
@@ -35,6 +40,41 @@ export async function completeStepDispatchConfig(params: {
     definitionId: params.definitionId,
     trace,
   });
+  completeWorkingDirectoryConfig({
+    config,
+    plan,
+    context: params.context,
+    definitionId: params.definitionId,
+    trace,
+  });
+  assertWorkingDirectoryIfPresent(config.working_directory);
 
   return {config, trace: capTraceEntries(trace)};
+}
+
+function assertWorkingDirectoryIfPresent(value: unknown): void {
+  if (value !== undefined) assertWorkingDirectory(value);
+}
+
+function completeWorkingDirectoryConfig(params: {
+  readonly config: Record<string, unknown>;
+  readonly plan: Step['configPlan'] & object;
+  readonly context: WorkflowEvaluationContext;
+  readonly definitionId: string;
+  readonly trace: PersistedEvaluationTraceEntry[];
+}): void {
+  const field = params.plan.working_directory;
+  if (field === undefined) return;
+
+  const resolved = completeStepFieldWithTrace({
+    field: 'step.working_directory',
+    template: field,
+    context: params.context,
+    definitionId: params.definitionId,
+    errorField: 'step.working_directory',
+  });
+  params.config.working_directory = resolved.value;
+  params.trace.push(
+    ...resolved.trace.map((entry) => ({...entry, field: 'step.working_directory' as const})),
+  );
 }

--- a/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
@@ -595,6 +595,59 @@ describe('materializeWorkflowModel', () => {
     });
   });
 
+  it('resolves working directories for run and agent steps', async () => {
+    const model = workflowModel({
+      jobs: {
+        build: {
+          steps: [
+            {run: 'npm test', workingDirectory: 'packages/api'},
+            {prompt: 'Review the changes', workingDirectory: template('run.id')},
+          ],
+        },
+      },
+    });
+
+    const rows = await materializeWorkflowModel({model, context: creationContext()});
+
+    expect(rows[0]?.steps[1]?.config).toEqual({
+      run: 'npm test',
+      working_directory: 'packages/api',
+    });
+    expect(rows[0]?.steps[2]?.config).toMatchObject({
+      harness: 'pi',
+      prompt: 'Review the changes',
+      working_directory: 'run-1',
+    });
+  });
+
+  it('defers unresolved working directory templates until step dispatch', async () => {
+    const model = workflowModel({
+      jobs: {
+        build: {
+          steps: [{run: 'npm test', workingDirectory: template('steps.previous.outputs.path')}],
+        },
+      },
+    });
+
+    const rows = await materializeWorkflowModel({model, context: creationContext()});
+
+    expect(rows[0]?.steps[1]?.config).toEqual({run: 'npm test'});
+    expect(rows[0]?.steps[1]?.configPlan?.working_directory).toEqual({
+      segments: [
+        {
+          kind: 'deferred',
+          expression: {
+            language: 'cel',
+            source: 'steps.previous.outputs.path',
+            check: 'syntax',
+          },
+          fillTarget: 'step-dispatch',
+          roots: ['steps'],
+        },
+      ],
+    });
+  });
+
   it('merges env before resolving and only resolves the winning values', async () => {
     const model = workflowModel({
       env: {SHARED: template('event.missing'), WORKFLOW_ONLY: template('run.id')},

--- a/libs/api/workflows/src/core/step-config/resolve-step-config.ts
+++ b/libs/api/workflows/src/core/step-config/resolve-step-config.ts
@@ -14,6 +14,7 @@ import type {StepConfigDispatchPlan} from '#core/entities/step.js';
 import {resolveAgentStepConfig} from './agent.js';
 import {
   freezeStepField,
+  resolveStepField,
   type StepConfigField,
   type WorkflowStepEvaluationTraceEntry,
   type WorkflowStepTemplateDiagnostic,
@@ -62,6 +63,14 @@ interface BuiltStepConfig {
   readonly hasTemplates: boolean;
 }
 
+interface WorkingDirectoryConfig {
+  readonly config: Record<string, unknown>;
+  readonly configPlan: Pick<StepConfigDispatchPlan, 'working_directory'> | undefined;
+  readonly diagnostics: readonly WorkflowStepTemplateDiagnostic[];
+  readonly trace: readonly WorkflowStepEvaluationTraceEntry[];
+  readonly hasTemplates: boolean;
+}
+
 export async function resolveStepConfig(
   params: ResolveStepConfigParams,
 ): Promise<ResolvedStepConfig> {
@@ -87,17 +96,18 @@ async function buildStepConfig(
 ): Promise<BuiltStepConfig> {
   const gate = gateConfigForStep(params.step);
   const outputs = outputsConfigForStep(params.step);
+  const workingDirectory = resolveWorkingDirectoryConfig(params);
   const runStep = runStepOrNull(params.step);
   const isRunStep = runStep !== null;
 
   if (isRunStep) {
     const run = resolveRunStepConfig({...params, step: runStep});
     return {
-      config: {...run.config, ...gate, ...outputs},
-      configPlan: run.configPlan,
-      diagnostics: run.diagnostics,
-      trace: run.trace,
-      hasTemplates: run.hasTemplates,
+      config: {...workingDirectory.config, ...run.config, ...gate, ...outputs},
+      configPlan: mergeConfigPlans(run.configPlan, workingDirectory.configPlan),
+      diagnostics: [...workingDirectory.diagnostics, ...run.diagnostics],
+      trace: [...workingDirectory.trace, ...run.trace],
+      hasTemplates: run.hasTemplates || workingDirectory.hasTemplates,
     };
   }
 
@@ -106,12 +116,79 @@ async function buildStepConfig(
 
   const agent = await resolveAgentStepConfig({...params, step: agentStep});
   return {
-    config: {...agent.config, ...gate, ...outputs},
-    configPlan: agent.configPlan,
-    diagnostics: agent.diagnostics,
-    trace: agent.trace,
-    hasTemplates: agent.hasTemplates,
+    config: {...workingDirectory.config, ...agent.config, ...gate, ...outputs},
+    configPlan: mergeConfigPlans(agent.configPlan, workingDirectory.configPlan),
+    diagnostics: [...workingDirectory.diagnostics, ...agent.diagnostics],
+    trace: [...workingDirectory.trace, ...agent.trace],
+    hasTemplates: agent.hasTemplates || workingDirectory.hasTemplates,
   };
+}
+
+function resolveWorkingDirectoryConfig(
+  params: Omit<BuildStepConfigParams, 'context'> & {readonly context: WorkflowEvaluationContext},
+): WorkingDirectoryConfig {
+  const value = params.step.workingDirectory;
+  const template = params.step.templates?.workingDirectory;
+  if (value === undefined) {
+    return {
+      config: {},
+      configPlan: undefined,
+      diagnostics: [],
+      trace: [],
+      hasTemplates: template !== undefined,
+    };
+  }
+
+  if (template === undefined || params.mode === 'authored') {
+    return {
+      config: {working_directory: value},
+      configPlan: undefined,
+      diagnostics: [],
+      trace: [],
+      hasTemplates: template !== undefined,
+    };
+  }
+
+  const resolved = resolveStepField({
+    field: 'step.working_directory',
+    template: {segments: template},
+    context: params.context,
+    definitionId: params.definitionId,
+    errorField: 'step.working_directory',
+  });
+  const trace = resolved.trace.map((entry) => ({
+    ...entry,
+    field: 'step.working_directory' as const,
+  }));
+  const diagnostics = resolved.diagnostics.map((diagnostic) => ({
+    ...diagnostic,
+    field: 'step.working_directory' as const,
+  }));
+  if (resolved.kind === 'residual') {
+    return {
+      config: {},
+      configPlan: {working_directory: resolved.field},
+      diagnostics,
+      trace,
+      hasTemplates: true,
+    };
+  }
+
+  return {
+    config: {working_directory: resolved.value},
+    configPlan: undefined,
+    diagnostics,
+    trace,
+    hasTemplates: true,
+  };
+}
+
+function mergeConfigPlans(
+  primary: StepConfigDispatchPlan | null,
+  secondary: Pick<StepConfigDispatchPlan, 'working_directory'> | undefined,
+): StepConfigDispatchPlan | null {
+  if (secondary === undefined) return primary;
+  return {...(primary ?? {}), ...secondary};
 }
 
 function evaluationContext(params: {

--- a/libs/api/workflows/src/db/workflow-runs/run-create.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-create.test.ts
@@ -564,6 +564,20 @@ describe('workflow run queries', () => {
           }),
         expected: {field: 'step.name', source: 'vars.REQUIRED'},
       },
+      {
+        field: 'step.working_directory',
+        model: () =>
+          workflowModel({
+            name: 'Missing working directory var',
+            runner: 'ubuntu-latest',
+            jobs: {
+              build: {
+                steps: [{workingDirectory: template('vars.REQUIRED'), run: 'echo ok'}],
+              },
+            },
+          }),
+        expected: {field: 'step.working_directory', source: 'vars.REQUIRED'},
+      },
     ] as const)('reports missing variables against $field', async ({model, expected}) => {
       let error: unknown;
       try {
@@ -586,6 +600,42 @@ describe('workflow run queries', () => {
 
       expect(error).toBeInstanceOf(InterpolationUnresolvableError);
       expect(error).toMatchObject(expected);
+    });
+
+    test('resolves a working directory that references a workspace variable', async () => {
+      const secrets = createTestSecretsClient();
+      await secrets.setSecrets({
+        workspaceId,
+        namespace: '',
+        values: {BUILD_DIR: 'packages/api'},
+      });
+      const model = workflowModel({
+        name: 'Working directory from var',
+        runner: 'ubuntu-latest',
+        jobs: {
+          build: {
+            steps: [{workingDirectory: template('vars.BUILD_DIR'), run: 'echo ok'}],
+          },
+        },
+      });
+
+      const run = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model,
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId: crypto.randomUUID(),
+          userId: crypto.randomUUID(),
+        },
+        secrets,
+      });
+
+      const [build] = await getJobsByWorkflowRunId(run.id);
+      const [, step] = await getStepsByJobId(build?.id as string);
+      expect(step?.config).toMatchObject({run: 'echo ok', working_directory: 'packages/api'});
     });
 
     test('writes workflows.workflow_run_attempt.created outbox event in same transaction', async () => {

--- a/libs/api/workflows/src/db/workflow-runs/run-create.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-create.ts
@@ -311,6 +311,9 @@ function referencedVariables(
 
     for (const step of job.steps) {
       collectFieldVariableReferences(step.templates?.name, references, {field: 'step.name'});
+      collectFieldVariableReferences(step.templates?.workingDirectory, references, {
+        field: 'step.working_directory',
+      });
       if (step.kind === 'run') {
         collectFieldVariableReferences(step.templates?.command, references, {field: 'run'});
         collectTemplateVariableReferences(step.templates?.env, references);

--- a/libs/api/workflows/test/factories/workflow-model.ts
+++ b/libs/api/workflows/test/factories/workflow-model.ts
@@ -15,6 +15,7 @@ type WorkflowEnvTemplates = NonNullable<NonNullable<WorkflowModel['templates']>[
 interface TestWorkflowStepBase {
   readonly key?: string | undefined;
   readonly name?: string | undefined;
+  readonly workingDirectory?: string | undefined;
   readonly sourceLocation?: WorkflowModel['jobs'][number]['steps'][number]['sourceLocation'];
   readonly if?: ModelStep['if'] | undefined;
   readonly gate?: WorkflowModel['jobs'][number]['steps'][number]['gate'] | undefined;
@@ -172,6 +173,7 @@ function stepBase(step: TestWorkflowStep, jobId: string, stepIndex: number) {
       step.key === undefined ? `${jobId}-step-${stepIndex + 1}` : `${jobId}-${stableId(step.key)}`,
     ...(step.key === undefined ? {} : {key: step.key}),
     ...(step.name === undefined ? {} : {name: step.name}),
+    ...(step.workingDirectory === undefined ? {} : {workingDirectory: step.workingDirectory}),
     ...(step.sourceLocation === undefined ? {} : {sourceLocation: step.sourceLocation}),
     ...(step.if === undefined ? {} : {if: step.if}),
     ...(step.gate === undefined ? {} : {gate: step.gate}),
@@ -204,12 +206,24 @@ function optionalStepEnv(
 function optionalRunTemplates(step: TestRunStep) {
   const command = fieldTemplate('run', step.run);
   const name = step.name === undefined ? undefined : fieldTemplate('step.name', step.name);
+  const workingDirectory =
+    step.workingDirectory === undefined
+      ? undefined
+      : fieldTemplate('step.working_directory', step.workingDirectory);
   const env = envTemplates(step.env);
-  if (command === undefined && name === undefined && env === undefined) return {};
+  if (
+    command === undefined &&
+    name === undefined &&
+    workingDirectory === undefined &&
+    env === undefined
+  ) {
+    return {};
+  }
   return {
     templates: {
       ...(command === undefined ? {} : {command}),
       ...(name === undefined ? {} : {name}),
+      ...(workingDirectory === undefined ? {} : {workingDirectory}),
       ...(env === undefined ? {} : {env}),
     },
   };
@@ -221,7 +235,17 @@ function optionalAgentTemplates(step: TestAgentStep) {
   const provider =
     step.provider === undefined ? undefined : fieldTemplate('agent.provider', step.provider);
   const name = step.name === undefined ? undefined : fieldTemplate('step.name', step.name);
-  if (prompt === undefined && model === undefined && provider === undefined && name === undefined) {
+  const workingDirectory =
+    step.workingDirectory === undefined
+      ? undefined
+      : fieldTemplate('step.working_directory', step.workingDirectory);
+  if (
+    prompt === undefined &&
+    model === undefined &&
+    provider === undefined &&
+    name === undefined &&
+    workingDirectory === undefined
+  ) {
     return {};
   }
   return {
@@ -230,6 +254,7 @@ function optionalAgentTemplates(step: TestAgentStep) {
       ...(model === undefined ? {} : {model}),
       ...(provider === undefined ? {} : {provider}),
       ...(name === undefined ? {} : {name}),
+      ...(workingDirectory === undefined ? {} : {workingDirectory}),
     },
   };
 }

--- a/libs/runner/execution/src/core/run-step.test.ts
+++ b/libs/runner/execution/src/core/run-step.test.ts
@@ -183,6 +183,25 @@ describe('executeRunStep', () => {
     expect(result.outputs?.path).not.toBe('/tmp/user-output');
   });
 
+  it('exposes SHIPFOX_WORKSPACE and overrides user env', async () => {
+    const step = buildStep({
+      config: {
+        run: nodeEnvDumpCommand(['SHIPFOX_WORKSPACE']),
+        env: {SHIPFOX_WORKSPACE: '/tmp/user-workspace'},
+      },
+    });
+
+    const output = collectOutput();
+    const result = await executeRunStep(step, {
+      cwd: tmpdir(),
+      workspace: '/runner/workspace',
+      onOutput: output.sink,
+    });
+
+    expect(result.success).toBe(true);
+    expect(JSON.parse(output.text())).toEqual({SHIPFOX_WORKSPACE: '/runner/workspace'});
+  });
+
   it('collects SHIPFOX_STEP_SUMMARY as a default annotation', async () => {
     const step = buildStep({
       config: {run: 'echo "### Summary" >> "$SHIPFOX_STEP_SUMMARY"'},

--- a/libs/runner/execution/src/core/run-step.ts
+++ b/libs/runner/execution/src/core/run-step.ts
@@ -43,6 +43,7 @@ export interface CommandShellMetadata {
 interface RunStepOptions {
   signal?: AbortSignal;
   cwd?: string;
+  workspace?: string;
   secretEnv?: Readonly<Record<string, string>>;
   secretValues?: readonly string[];
   onOutput?: OutputSink;
@@ -130,6 +131,9 @@ function spawnAndCapture(
       env: {
         ...process.env,
         ...stepEnv,
+        ...((options.workspace ?? options.cwd)
+          ? {SHIPFOX_WORKSPACE: options.workspace ?? options.cwd}
+          : {}),
         SHIPFOX_OUTPUT: outputPath,
         ...(annotationSpool?.env ?? {}),
       },

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -2,35 +2,39 @@ import type {AgentConfigIssueDto, NextStepResponseDto, StepDto} from '@shipfox/a
 import {logger} from '@shipfox/node-opentelemetry';
 import {HTTPError} from 'ky';
 
-const {AgentRuntimeConfigRequestError, StepSecretsRequestError} = vi.hoisted(() => ({
-  AgentRuntimeConfigRequestError: class AgentRuntimeConfigRequestError extends Error {
-    constructor(
-      public readonly status: number,
-      public readonly code: string | undefined,
-      public readonly agentConfigIssue: AgentConfigIssueDto | undefined = undefined,
-    ) {
-      super(
-        code === undefined
-          ? `Agent runtime config request failed with status ${status}.`
-          : `Agent runtime config request failed with status ${status}: ${code}.`,
-      );
-      this.name = 'AgentRuntimeConfigRequestError';
-    }
-  },
-  StepSecretsRequestError: class StepSecretsRequestError extends Error {
-    constructor(
-      public readonly status: number,
-      public readonly code: string | undefined,
-    ) {
-      super(
-        code === undefined
-          ? `Step secrets request failed with status ${status}.`
-          : `Step secrets request failed with status ${status}: ${code}.`,
-      );
-      this.name = 'StepSecretsRequestError';
-    }
-  },
-}));
+const {AgentRuntimeConfigRequestError, StepSecretsRequestError, resolveWorkingDirectoryMock} =
+  vi.hoisted(() => ({
+    AgentRuntimeConfigRequestError: class AgentRuntimeConfigRequestError extends Error {
+      constructor(
+        public readonly status: number,
+        public readonly code: string | undefined,
+        public readonly agentConfigIssue: AgentConfigIssueDto | undefined = undefined,
+      ) {
+        super(
+          code === undefined
+            ? `Agent runtime config request failed with status ${status}.`
+            : `Agent runtime config request failed with status ${status}: ${code}.`,
+        );
+        this.name = 'AgentRuntimeConfigRequestError';
+      }
+    },
+    StepSecretsRequestError: class StepSecretsRequestError extends Error {
+      constructor(
+        public readonly status: number,
+        public readonly code: string | undefined,
+      ) {
+        super(
+          code === undefined
+            ? `Step secrets request failed with status ${status}.`
+            : `Step secrets request failed with status ${status}: ${code}.`,
+        );
+        this.name = 'StepSecretsRequestError';
+      }
+    },
+    resolveWorkingDirectoryMock: vi.fn(async (cwd: string, workingDirectory: unknown) =>
+      workingDirectory === undefined ? cwd : `${cwd}/${String(workingDirectory)}`,
+    ),
+  }));
 
 const requestNextStepMock = vi.fn();
 const requestAgentRuntimeConfigMock = vi.fn();
@@ -75,6 +79,11 @@ vi.mock('@shipfox/runner-logs', async () => {
 
 vi.mock('@shipfox/runner-agent', () => ({
   executeAgentStep: (...args: unknown[]) => executeAgentStepMock(...args),
+}));
+
+vi.mock('@shipfox/runner-workspace', () => ({
+  resolveWorkingDirectory: (cwd: string, workingDirectory: unknown) =>
+    resolveWorkingDirectoryMock(cwd, workingDirectory),
 }));
 
 const {executeStep, pullNextStep, publishStepAnnotations, reportStepResult, runJobSteps} =
@@ -204,6 +213,7 @@ describe('runJobSteps', () => {
     createStepLogStreamMock.mockReset();
     createSessionLogStreamMock.mockReset();
     executeAgentStepMock.mockReset();
+    resolveWorkingDirectoryMock.mockClear();
     requestAgentRuntimeConfigMock.mockResolvedValue({
       harness: 'pi',
       provider_id: 'anthropic',
@@ -262,6 +272,7 @@ describe('runJobSteps', () => {
     expect(executeRunStepMock).toHaveBeenCalledWith(run, {
       signal: ac.signal,
       cwd: '/work',
+      workspace: '/work',
       onCommandStart: expect.any(Function),
       onOutput: expect.any(Function),
     });
@@ -304,6 +315,50 @@ describe('runJobSteps', () => {
       logOutcome: 'drained',
       signal: ac.signal,
     });
+  });
+
+  it('resolves a run step working directory relative to the job workspace', async () => {
+    const setup = buildSetupStep();
+    const run = buildRunStep({config: {run: 'echo test', working_directory: 'api'}});
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(run, 1))
+      .mockResolvedValueOnce({kind: 'done', status: 'succeeded'});
+    executeRunStepMock.mockResolvedValue({success: true, error: null, exit_code: 0});
+    const ac = new AbortController();
+
+    await runLoop({signal: ac.signal});
+
+    expect(resolveWorkingDirectoryMock).toHaveBeenCalledWith('/work', 'api');
+    expect(executeRunStepMock).toHaveBeenCalledWith(
+      run,
+      expect.objectContaining({cwd: '/work/api', workspace: '/work'}),
+    );
+  });
+
+  it('reports a missing working directory without spawning the step', async () => {
+    const setup = buildSetupStep();
+    const run = buildRunStep({config: {run: 'echo test', working_directory: 'missing'}});
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(run, 1))
+      .mockResolvedValueOnce({kind: 'done', status: 'failed'});
+    resolveWorkingDirectoryMock.mockRejectedValueOnce(
+      new Error('Working directory does not exist: missing'),
+    );
+    const ac = new AbortController();
+
+    await runLoop({signal: ac.signal});
+
+    expect(executeRunStepMock).not.toHaveBeenCalled();
+    expect(reportStepMock).toHaveBeenCalledWith(
+      leaseClient,
+      expect.objectContaining({
+        stepId: run.id,
+        status: 'failed',
+        error: {message: 'Working directory does not exist: missing'},
+      }),
+    );
   });
 
   it('reports empty response strings instead of omitting them', async () => {
@@ -1266,6 +1321,32 @@ describe('runJobSteps', () => {
       logOutcome: 'drained',
       signal: ac.signal,
     });
+  });
+
+  it('dispatches an agent step in its configured working directory', async () => {
+    const setup = buildSetupStep();
+    const agent = buildAgentStep({
+      config: {
+        model: 'claude-opus-4-8',
+        thinking: 'high',
+        prompt: 'Fix it.',
+        working_directory: 'api',
+      },
+    });
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(agent, 1))
+      .mockResolvedValueOnce({kind: 'done', status: 'succeeded'});
+    executeAgentStepMock.mockResolvedValue({success: true, error: null, exit_code: 0});
+    const ac = new AbortController();
+
+    await runLoop({signal: ac.signal});
+
+    expect(resolveWorkingDirectoryMock).toHaveBeenCalledWith('/work', 'api');
+    expect(executeAgentStepMock).toHaveBeenCalledWith(
+      agent,
+      expect.objectContaining({cwd: '/work/api'}),
+    );
   });
 
   it('passes the setup ambient git config path to agent steps', async () => {

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -213,7 +213,11 @@ describe('runJobSteps', () => {
     createStepLogStreamMock.mockReset();
     createSessionLogStreamMock.mockReset();
     executeAgentStepMock.mockReset();
-    resolveWorkingDirectoryMock.mockClear();
+    resolveWorkingDirectoryMock.mockReset();
+    resolveWorkingDirectoryMock.mockImplementation(
+      async (cwd: string, workingDirectory: unknown) =>
+        workingDirectory === undefined ? cwd : `${cwd}/${String(workingDirectory)}`,
+    );
     requestAgentRuntimeConfigMock.mockResolvedValue({
       harness: 'pi',
       provider_id: 'anthropic',

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -38,6 +38,7 @@ import {
   StepSecretsRequestError,
   writeStepAnnotations,
 } from '@shipfox/runner-protocol';
+import {resolveWorkingDirectory} from '@shipfox/runner-workspace';
 import type {KyInstance} from 'ky';
 
 const WHITESPACE_REGEX = /\s+/;
@@ -325,6 +326,21 @@ export async function executeStep(params: {
       };
     }
 
+    let stepCwd: string;
+    try {
+      stepCwd = await resolveWorkingDirectory(cwd, step.config.working_directory);
+    } catch (error) {
+      return {
+        result: {
+          success: false,
+          error: {message: error instanceof Error ? error.message : String(error)},
+          exit_code: null,
+        },
+        logOutcome: 'abandoned',
+        preparedWorkspace: false,
+      };
+    }
+
     // Agent steps run the embedded pi harness and forward every session entry into the log
     // pipeline as opaque `agent_session` records. Capture is best-effort: if the spool cannot
     // be opened, run the agent without it rather than failing the step.
@@ -366,7 +382,7 @@ export async function executeStep(params: {
       registerStreamSecrets(sessionStream);
       const result = await executeAgentStep(step, {
         signal,
-        cwd,
+        cwd: stepCwd,
         logsDir,
         ...(ambientGitConfigPath ? {gitConfigGlobal: ambientGitConfigPath} : {}),
         runtime: {
@@ -430,7 +446,8 @@ export async function executeStep(params: {
 
     let result = await executeRunStep(step, {
       signal,
-      cwd,
+      cwd: stepCwd,
+      workspace: cwd,
       ...(runSecretMaterial?.secretEnv ? {secretEnv: runSecretMaterial.secretEnv} : {}),
       ...(runSecretMaterial?.secretValues ? {secretValues: runSecretMaterial.secretValues} : {}),
       onCommandStart: (metadata) => writeCommandMetadata(stepStream, metadata),

--- a/libs/runner/workspace/src/index.ts
+++ b/libs/runner/workspace/src/index.ts
@@ -11,6 +11,12 @@ export {
   writeAmbientGitCredential,
 } from '#checkout.js';
 export {
+  resolveWorkingDirectory,
+  WorkingDirectoryEscapeError,
+  WorkingDirectoryNotDirectoryError,
+  WorkingDirectoryNotFoundError,
+} from '#working-directory.js';
+export {
   cleanupJobCredentials,
   cleanupJobLogs,
   cleanupWorkspace,

--- a/libs/runner/workspace/src/working-directory.test.ts
+++ b/libs/runner/workspace/src/working-directory.test.ts
@@ -1,0 +1,76 @@
+import {mkdir, mkdtemp, realpath, rm, symlink, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {
+  resolveWorkingDirectory,
+  WorkingDirectoryEscapeError,
+  WorkingDirectoryNotDirectoryError,
+  WorkingDirectoryNotFoundError,
+} from '#working-directory.js';
+
+const INVALID_WORKING_DIRECTORY_MESSAGE =
+  /relative path without '..' segments or absolute path syntax/;
+
+describe('resolveWorkingDirectory', () => {
+  let workspace: string;
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(join(tmpdir(), 'shipfox-working-directory-'));
+  });
+
+  afterEach(async () => {
+    await rm(workspace, {recursive: true, force: true});
+  });
+
+  it('defaults to the job workspace', async () => {
+    await expect(resolveWorkingDirectory(workspace, undefined)).resolves.toBe(workspace);
+  });
+
+  it('resolves an existing nested directory without creating anything', async () => {
+    const nested = join(workspace, 'api');
+    await mkdir(nested);
+
+    await expect(resolveWorkingDirectory(workspace, 'api')).resolves.toBe(await realpath(nested));
+  });
+
+  it.each([
+    '../outside',
+    '/tmp/outside',
+    'C:\\outside',
+    'api/../outside',
+  ])('rejects unsafe path syntax: %s', async (workingDirectory) => {
+    await expect(resolveWorkingDirectory(workspace, workingDirectory)).rejects.toThrow(
+      INVALID_WORKING_DIRECTORY_MESSAGE,
+    );
+  });
+
+  it('fails clearly when the directory is missing', async () => {
+    await expect(resolveWorkingDirectory(workspace, 'missing')).rejects.toThrow(
+      WorkingDirectoryNotFoundError,
+    );
+    await expect(resolveWorkingDirectory(workspace, 'missing')).rejects.toThrow(
+      'Working directory does not exist: missing',
+    );
+  });
+
+  it('fails when the path resolves to a file', async () => {
+    await writeFile(join(workspace, 'file.txt'), 'content');
+
+    await expect(resolveWorkingDirectory(workspace, 'file.txt')).rejects.toThrow(
+      WorkingDirectoryNotDirectoryError,
+    );
+  });
+
+  it('rejects a symlink that resolves outside the job workspace', async () => {
+    const outside = await mkdtemp(join(tmpdir(), 'shipfox-working-directory-outside-'));
+    try {
+      await symlink(outside, join(workspace, 'escape'));
+
+      await expect(resolveWorkingDirectory(workspace, 'escape')).rejects.toThrow(
+        WorkingDirectoryEscapeError,
+      );
+    } finally {
+      await rm(outside, {recursive: true, force: true});
+    }
+  });
+});

--- a/libs/runner/workspace/src/working-directory.ts
+++ b/libs/runner/workspace/src/working-directory.ts
@@ -1,0 +1,72 @@
+import {realpath, stat} from 'node:fs/promises';
+import {isAbsolute, relative, resolve, sep} from 'node:path';
+import {assertWorkingDirectory} from '@shipfox/api-workflows-dto';
+
+export class WorkingDirectoryNotFoundError extends Error {
+  constructor(readonly workingDirectory: string) {
+    super(`Working directory does not exist: ${workingDirectory}`);
+    this.name = 'WorkingDirectoryNotFoundError';
+  }
+}
+
+export class WorkingDirectoryNotDirectoryError extends Error {
+  constructor(readonly workingDirectory: string) {
+    super(`Working directory is not a directory: ${workingDirectory}`);
+    this.name = 'WorkingDirectoryNotDirectoryError';
+  }
+}
+
+export class WorkingDirectoryEscapeError extends Error {
+  constructor(readonly workingDirectory: string) {
+    super(`Working directory escapes the job workspace: ${workingDirectory}`);
+    this.name = 'WorkingDirectoryEscapeError';
+  }
+}
+
+/**
+ * Resolves a step's working directory without creating it. The lexical shape is
+ * checked before joining paths, and realpath containment prevents symlink escapes.
+ */
+export async function resolveWorkingDirectory(
+  jobWorkspace: string,
+  workingDirectory: unknown,
+): Promise<string> {
+  if (workingDirectory === undefined) return jobWorkspace;
+  assertWorkingDirectory(workingDirectory);
+
+  const resolvedWorkspace = await realpath(jobWorkspace);
+  const resolvedCandidate = resolve(jobWorkspace, workingDirectory);
+  let realCandidate: string;
+  try {
+    realCandidate = await realpath(resolvedCandidate);
+  } catch (error) {
+    if (isFileSystemError(error, 'ENOENT')) {
+      throw new WorkingDirectoryNotFoundError(workingDirectory);
+    }
+    throw error;
+  }
+
+  if (!isWithin(resolvedWorkspace, realCandidate)) {
+    throw new WorkingDirectoryEscapeError(workingDirectory);
+  }
+
+  const candidateStats = await stat(realCandidate);
+  if (!candidateStats.isDirectory()) {
+    throw new WorkingDirectoryNotDirectoryError(workingDirectory);
+  }
+  return realCandidate;
+}
+
+function isWithin(parent: string, candidate: string): boolean {
+  const distance = relative(parent, candidate);
+  return (
+    distance === '' ||
+    (!distance.startsWith(`..${sep}`) && distance !== '..' && !isAbsolute(distance))
+  );
+}
+
+function isFileSystemError(error: unknown, code: string): error is NodeJS.ErrnoException {
+  return (
+    error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === code
+  );
+}

--- a/libs/shared/expression/src/workflow-context/workflow-context.test.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.test.ts
@@ -575,6 +575,7 @@ describe('workflow context registry', () => {
       expect(getWorkflowInterpolationFieldFailurePolicy('workflow.run_name')).toBe('degrade');
       expect(getWorkflowInterpolationFieldFailurePolicy('job.execution_name')).toBe('degrade');
       expect(getWorkflowInterpolationFieldFailurePolicy('step.name')).toBe('degrade');
+      expect(getWorkflowInterpolationFieldFailurePolicy('step.working_directory')).toBe('fail');
       expect(getWorkflowInterpolationFieldFailurePolicy('step.feedback')).toBe('fail');
       expect(
         workflowInterpolationFields.map(
@@ -714,6 +715,7 @@ describe('workflow interpolation field policies', () => {
       'workflow.run_name',
       'job.execution_name',
       'step.name',
+      'step.working_directory',
       'step.feedback',
     ]);
     expect(Object.keys(workflowInterpolationFieldPolicies)).toEqual(workflowInterpolationFields);
@@ -744,6 +746,7 @@ describe('workflow interpolation field policies', () => {
     ['workflow.run_name', ['server']],
     ['job.execution_name', ['server']],
     ['step.name', ['server']],
+    ['step.working_directory', ['server']],
     ['step.feedback', ['server']],
   ] satisfies readonly [
     WorkflowInterpolationField,
@@ -763,6 +766,7 @@ describe('workflow interpolation field policies', () => {
     expect(workflowInterpolationFieldAcceptsHost('job.runner', 'runner')).toBe(false);
     expect(workflowInterpolationFieldAcceptsHost('job.name', 'runner')).toBe(false);
     expect(workflowInterpolationFieldAcceptsHost('step.name', 'runner')).toBe(false);
+    expect(workflowInterpolationFieldAcceptsHost('step.working_directory', 'runner')).toBe(false);
     expect(workflowInterpolationFieldAcceptsHost('step.feedback', 'runner')).toBe(false);
   });
 

--- a/libs/shared/expression/src/workflow-context/workflow-context.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.ts
@@ -363,6 +363,7 @@ export type WorkflowInterpolationField =
   | 'workflow.run_name'
   | 'job.execution_name'
   | 'step.name'
+  | 'step.working_directory'
   | 'step.feedback';
 
 export const workflowFieldFailurePolicies = ['fail', 'degrade', 'fail-closed'] as const;
@@ -437,6 +438,10 @@ export const workflowInterpolationFieldPolicies: Readonly<
   'step.name': {
     acceptedHosts: serverOnlyHosts,
     failurePolicy: 'degrade',
+  },
+  'step.working_directory': {
+    acceptedHosts: serverOnlyHosts,
+    failurePolicy: 'fail',
   },
   'step.feedback': {
     acceptedHosts: serverOnlyHosts,


### PR DESCRIPTION
## Summary

Run and agent steps now honor a configured working directory relative to the runner job workspace, while preserving the job root as the default. The server resolves templated paths and pre-fetches referenced variables; dispatch and runner validation reject invalid, missing, or escaping directories before execution. Run steps also receive the canonical job root through SHIPFOX_WORKSPACE.

## Validation

- Affected-package type and Biome checks passed.
- Targeted definition, workflow, run-creation, workspace, execution, and orchestration suites passed.
- The combined API workflow run had one existing list-runs fixture-count failure; the isolated test passed 6/6.

Closes ENG-1429

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run and agent steps can now set a working directory relative to the job workspace. Paths are validated on the server and enforced by the runner; run steps also receive SHIPFOX_WORKSPACE. Addresses ENG-1429.

- **New Features**
  - Added step field and templates: `workingDirectory` / `step.working_directory` for run and agent steps in `@shipfox/api-definitions`, `@shipfox/api-definitions-dto`, and `@shipfox/api-workflows`.
  - Server resolves templates, pre-fetches vars, and rejects invalid paths with `assertWorkingDirectory` from `@shipfox/api-workflows-dto` (no absolute paths or "..").
  - Dispatch records unresolved templates; missing vars are reported against `step.working_directory` with a fail policy.
  - Runner resolves the directory against the job workspace with `resolveWorkingDirectory` from `@shipfox/runner-workspace`, prevents symlink escapes, and fails on missing/not-a-directory.
  - Run and agent steps execute in the resolved cwd; run steps get SHIPFOX_WORKSPACE set to the job workspace (overrides user env).

- **Bug Fixes**
  - Aligned linked-package changeset levels and reset the working-directory resolver mock between orchestration tests to avoid cross-test leakage.

<sup>Written for commit c94a8e562d65291c6fca9c4841792d2f8fe288fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

