### PR TITLE
[api-projects] Add resolveCheckoutTarget inter-module RPC

### DIFF
--- a/.changeset/resolve-checkout-target.md
+++ b/.changeset/resolve-checkout-target.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-projects-dto": minor
+"@shipfox/api-projects": minor
+---
+
+Add a `resolveCheckoutTarget` inter-module method to resolve a project by ID or by owner/repository within a workspace, for callers that need to authorize a checkout target.

--- a/libs/api/projects-dto/src/inter-module.test.ts
+++ b/libs/api/projects-dto/src/inter-module.test.ts
@@ -16,6 +16,36 @@ describe('projectsInterModuleContract', () => {
     expect(result.project?.id).toBe(projectId);
   });
 
+  test('accepts checkout targets addressed by project or repository', () => {
+    const workspaceId = '00000000-0000-4000-8000-000000000001';
+    const connectionId = '00000000-0000-4000-8000-000000000002';
+
+    expect(
+      projectsInterModuleContract.methods.resolveCheckoutTarget.input.parse({
+        workspaceId,
+        defaults: {connectionId, owner: 'acme'},
+        target: {project: '00000000-0000-4000-8000-000000000003'},
+      }).target,
+    ).toEqual({project: '00000000-0000-4000-8000-000000000003'});
+    expect(
+      projectsInterModuleContract.methods.resolveCheckoutTarget.input.parse({
+        workspaceId,
+        defaults: {connectionId, owner: 'acme'},
+        target: {connection: connectionId, repository: 'acme/api'},
+      }).target,
+    ).toEqual({connection: connectionId, repository: 'acme/api'});
+  });
+
+  test('defines the checkout authorization failure', () => {
+    const details = {};
+
+    expect(
+      projectsInterModuleContract.methods.resolveCheckoutTarget.errors[
+        'checkout-repository-not-authorized'
+      ].parse(details),
+    ).toEqual(details);
+  });
+
   test.each([
     ['project-not-found', {projectId: '00000000-0000-4000-8000-000000000001'}],
     [

--- a/libs/api/projects-dto/src/inter-module.ts
+++ b/libs/api/projects-dto/src/inter-module.ts
@@ -13,6 +13,18 @@ const workspaceProjectCountSchema = z.object({
   workspaceId: idSchema,
   count: z.number().int().nonnegative(),
 });
+const checkoutTargetSchema = z.union([
+  z.strictObject({project: idSchema}),
+  z.strictObject({
+    connection: idSchema.optional(),
+    repository: z.string().min(1),
+  }),
+]);
+const resolvedCheckoutTargetSchema = z.object({
+  projectId: idSchema,
+  connectionId: idSchema,
+  externalRepositoryId: z.string(),
+});
 
 /** Producer-owned project lookup and workspace ownership operations. */
 export const projectsInterModuleContract = defineInterModuleContract({
@@ -33,6 +45,17 @@ export const projectsInterModuleContract = defineInterModuleContract({
     getWorkspaceProjectCounts: {
       input: z.object({workspaceIds: z.array(idSchema).min(1).max(100)}),
       output: z.object({counts: z.array(workspaceProjectCountSchema)}),
+    },
+    resolveCheckoutTarget: {
+      input: z.object({
+        workspaceId: idSchema,
+        defaults: z.object({connectionId: idSchema, owner: z.string().min(1)}),
+        target: checkoutTargetSchema,
+      }),
+      output: resolvedCheckoutTargetSchema,
+      errors: {
+        'checkout-repository-not-authorized': z.object({}),
+      },
     },
   },
 });

--- a/libs/api/projects/src/db/index.ts
+++ b/libs/api/projects/src/db/index.ts
@@ -14,6 +14,8 @@ export type {
   ListAdminProjectsResult,
   ListProjectsParams,
   ListProjectsResult,
+  ResolveCheckoutTargetParams,
+  ResolvedCheckoutTarget,
 } from './projects.js';
 export {
   createProject,
@@ -24,6 +26,7 @@ export {
   listAdminProjects,
   listProjects,
   requireProjectForWorkspace,
+  resolveCheckoutTarget,
 } from './projects.js';
 export {projectsIntegrationEventDedup} from './schema/integration-event-dedup.js';
 export {projectsOutbox} from './schema/outbox.js';

--- a/libs/api/projects/src/db/projects.ts
+++ b/libs/api/projects/src/db/projects.ts
@@ -1,4 +1,4 @@
-import {and, count, desc, eq, ilike, inArray, lt, or, type SQL} from 'drizzle-orm';
+import {and, count, desc, eq, ilike, inArray, lt, or, type SQL, sql} from 'drizzle-orm';
 import type {Project} from '#core/entities/project.js';
 import {ProjectAlreadyExistsError, ProjectNotFoundError} from '#core/errors.js';
 import {recordProjectCreated} from '#metrics/instance.js';
@@ -175,6 +175,78 @@ export async function requireProjectForWorkspace(params: {
   if (!project) throw new ProjectNotFoundError(params.projectId);
   if (project.workspaceId !== params.workspaceId) throw new ProjectNotFoundError(params.projectId);
   return project;
+}
+
+export interface ResolveCheckoutTargetParams {
+  workspaceId: string;
+  defaults: {
+    connectionId: string;
+    owner: string;
+  };
+  target: {project: string} | {connection?: string | undefined; repository: string};
+}
+
+export interface ResolvedCheckoutTarget {
+  projectId: string;
+  connectionId: string;
+  externalRepositoryId: string;
+}
+
+export async function resolveCheckoutTarget(
+  params: ResolveCheckoutTargetParams,
+): Promise<ResolvedCheckoutTarget | undefined> {
+  const selection = {
+    projectId: projects.id,
+    connectionId: projects.sourceConnectionId,
+    externalRepositoryId: projects.sourceExternalRepositoryId,
+  };
+
+  if ('project' in params.target) {
+    const [project] = await db()
+      .select(selection)
+      .from(projects)
+      .where(
+        and(eq(projects.workspaceId, params.workspaceId), eq(projects.id, params.target.project)),
+      )
+      .limit(1);
+    return project;
+  }
+
+  const separator = params.target.repository.indexOf('/');
+  if (separator === 0 || separator === params.target.repository.length - 1) return undefined;
+
+  const repository =
+    separator === -1
+      ? {
+          connectionId: params.target.connection ?? params.defaults.connectionId,
+          owner: params.defaults.owner,
+          name: params.target.repository,
+        }
+      : params.target.repository.indexOf('/', separator + 1) === -1
+        ? {
+            connectionId: params.target.connection ?? params.defaults.connectionId,
+            owner: params.target.repository.slice(0, separator),
+            name: params.target.repository.slice(separator + 1),
+          }
+        : undefined;
+  if (repository === undefined) return undefined;
+
+  const matches = await db()
+    .select(selection)
+    .from(projects)
+    .where(
+      and(
+        eq(projects.workspaceId, params.workspaceId),
+        eq(projects.sourceConnectionId, repository.connectionId),
+        sql`lower(${projects.sourceRepositoryOwner}) = lower(${repository.owner})`,
+        sql`lower(${projects.sourceRepositoryName}) = lower(${repository.name})`,
+      ),
+    )
+    .limit(2);
+
+  // Owner/name isn't a unique key: renamed or reconnected repositories can leave
+  // more than one project row matching. Fail closed instead of picking arbitrarily.
+  return matches.length === 1 ? matches[0] : undefined;
 }
 
 export async function listProjects(params: ListProjectsParams): Promise<ListProjectsResult> {

--- a/libs/api/projects/src/db/projects.ts
+++ b/libs/api/projects/src/db/projects.ts
@@ -192,6 +192,32 @@ export interface ResolvedCheckoutTarget {
   externalRepositoryId: string;
 }
 
+export interface UpdateProjectSourceMetadataParams {
+  workspaceId: string;
+  projectId: string;
+  sourceConnectionId: string;
+  sourceExternalRepositoryId: string;
+  sourceRepositoryOwner: string;
+  sourceRepositoryName: string;
+  sourceDefaultBranch: string;
+}
+
+export async function updateProjectSourceMetadata(
+  params: UpdateProjectSourceMetadataParams,
+): Promise<void> {
+  await db()
+    .update(projects)
+    .set({
+      sourceConnectionId: params.sourceConnectionId,
+      sourceExternalRepositoryId: params.sourceExternalRepositoryId,
+      sourceRepositoryOwner: params.sourceRepositoryOwner,
+      sourceRepositoryName: params.sourceRepositoryName,
+      sourceDefaultBranch: params.sourceDefaultBranch,
+      updatedAt: new Date(),
+    })
+    .where(and(eq(projects.workspaceId, params.workspaceId), eq(projects.id, params.projectId)));
+}
+
 export async function resolveCheckoutTarget(
   params: ResolveCheckoutTargetParams,
 ): Promise<ResolvedCheckoutTarget | undefined> {

--- a/libs/api/projects/src/index.ts
+++ b/libs/api/projects/src/index.ts
@@ -60,7 +60,7 @@ export function createProjectsModule({
     e2eRoutes: [projectsE2eRoutes],
     metrics: registerProjectsServiceMetrics,
     publishers: [{name: 'projects', table: projectsOutbox, db, eventSchemas: projectsEventSchemas}],
-    interModulePresentations: [createProjectsInterModulePresentation()],
+    interModulePresentations: [createProjectsInterModulePresentation({integrations})],
     subscribers: [
       subscriber(INTEGRATION_SOURCE_COMMIT_PUSHED, onSourceCommitPushed),
       subscriber(INTEGRATION_SOURCE_REPOSITORY_UPDATED, onSourceRepositoryUpdated),

--- a/libs/api/projects/src/presentation/inter-module.test.ts
+++ b/libs/api/projects/src/presentation/inter-module.test.ts
@@ -1,0 +1,215 @@
+import {projectsInterModuleContract} from '@shipfox/api-projects-dto/inter-module';
+import {isInterModuleKnownError} from '@shipfox/inter-module';
+import {createInMemoryInterModuleTransport} from '@shipfox/node-module/inter-module';
+import {db} from '#db/index.js';
+import {projects} from '#db/schema/projects.js';
+import {createProjectsInterModulePresentation} from './inter-module.js';
+
+function createClient() {
+  const transport = createInMemoryInterModuleTransport();
+  const client = transport.createClient(projectsInterModuleContract);
+  transport.register(createProjectsInterModulePresentation());
+  transport.seal();
+  return client;
+}
+
+async function insertProject(params: {
+  workspaceId: string;
+  connectionId: string;
+  owner: string | null;
+  name: string | null;
+}) {
+  const [project] = await db()
+    .insert(projects)
+    .values({
+      workspaceId: params.workspaceId,
+      sourceConnectionId: params.connectionId,
+      sourceExternalRepositoryId: `repository-${crypto.randomUUID()}`,
+      sourceRepositoryOwner: params.owner,
+      sourceRepositoryName: params.name,
+      name: params.name ?? 'Project',
+    })
+    .returning({
+      projectId: projects.id,
+      connectionId: projects.sourceConnectionId,
+      externalRepositoryId: projects.sourceExternalRepositoryId,
+    });
+
+  if (project === undefined) throw new Error('Project insert returned no row');
+  return project;
+}
+
+async function expectUnauthorized(
+  client: ReturnType<typeof createClient>,
+  input: Parameters<typeof client.resolveCheckoutTarget>[0],
+) {
+  const error = await client.resolveCheckoutTarget(input).catch((caught) => caught);
+
+  expect(
+    isInterModuleKnownError(projectsInterModuleContract.methods.resolveCheckoutTarget, error),
+  ).toBe(true);
+  if (isInterModuleKnownError(projectsInterModuleContract.methods.resolveCheckoutTarget, error)) {
+    expect(error.code).toBe('checkout-repository-not-authorized');
+    expect(error.details).toEqual({});
+  }
+}
+
+describe('Projects checkout target inter-module presentation', () => {
+  test('resolves a project target in its workspace', async () => {
+    const client = createClient();
+    const workspaceId = crypto.randomUUID();
+    const project = await insertProject({
+      workspaceId,
+      connectionId: crypto.randomUUID(),
+      owner: 'acme',
+      name: 'api',
+    });
+
+    await expect(
+      client.resolveCheckoutTarget({
+        workspaceId,
+        defaults: {connectionId: crypto.randomUUID(), owner: 'other'},
+        target: {project: project.projectId},
+      }),
+    ).resolves.toEqual(project);
+  });
+
+  test('resolves a bare repository name against the default owner', async () => {
+    const client = createClient();
+    const workspaceId = crypto.randomUUID();
+    const connectionId = crypto.randomUUID();
+    const project = await insertProject({
+      workspaceId,
+      connectionId,
+      owner: 'AcMe',
+      name: 'Api',
+    });
+
+    await expect(
+      client.resolveCheckoutTarget({
+        workspaceId,
+        defaults: {connectionId, owner: 'acme'},
+        target: {repository: 'api'},
+      }),
+    ).resolves.toEqual(project);
+  });
+
+  test('resolves an owner/name repository case-insensitively', async () => {
+    const client = createClient();
+    const workspaceId = crypto.randomUUID();
+    const connectionId = crypto.randomUUID();
+    const project = await insertProject({
+      workspaceId,
+      connectionId,
+      owner: 'AcMe',
+      name: 'Api',
+    });
+
+    await expect(
+      client.resolveCheckoutTarget({
+        workspaceId,
+        defaults: {connectionId, owner: 'other'},
+        target: {repository: 'aCmE/aPI'},
+      }),
+    ).resolves.toEqual(project);
+  });
+
+  test('uses an explicit connection to select between identical repositories', async () => {
+    const client = createClient();
+    const workspaceId = crypto.randomUUID();
+    const defaultConnectionId = crypto.randomUUID();
+    const explicitConnectionId = crypto.randomUUID();
+    await insertProject({
+      workspaceId,
+      connectionId: defaultConnectionId,
+      owner: 'acme',
+      name: 'api',
+    });
+    const explicitProject = await insertProject({
+      workspaceId,
+      connectionId: explicitConnectionId,
+      owner: 'acme',
+      name: 'api',
+    });
+
+    await expect(
+      client.resolveCheckoutTarget({
+        workspaceId,
+        defaults: {connectionId: defaultConnectionId, owner: 'acme'},
+        target: {connection: explicitConnectionId, repository: 'acme/api'},
+      }),
+    ).resolves.toEqual(explicitProject);
+  });
+
+  test('rejects an ambiguous owner/name match instead of picking arbitrarily', async () => {
+    const client = createClient();
+    const workspaceId = crypto.randomUUID();
+    const connectionId = crypto.randomUUID();
+    await insertProject({workspaceId, connectionId, owner: 'acme', name: 'api'});
+    await insertProject({workspaceId, connectionId, owner: 'acme', name: 'api'});
+
+    await expectUnauthorized(client, {
+      workspaceId,
+      defaults: {connectionId, owner: 'acme'},
+      target: {repository: 'acme/api'},
+    });
+  });
+
+  test('does not let a bare name escape the default owner', async () => {
+    const client = createClient();
+    const workspaceId = crypto.randomUUID();
+    const connectionId = crypto.randomUUID();
+    await insertProject({
+      workspaceId,
+      connectionId,
+      owner: 'other',
+      name: 'api',
+    });
+
+    await expectUnauthorized(client, {
+      workspaceId,
+      defaults: {connectionId, owner: 'acme'},
+      target: {repository: 'api'},
+    });
+  });
+
+  test('rejects a project from another workspace', async () => {
+    const client = createClient();
+    const project = await insertProject({
+      workspaceId: crypto.randomUUID(),
+      connectionId: crypto.randomUUID(),
+      owner: 'acme',
+      name: 'api',
+    });
+
+    await expectUnauthorized(client, {
+      workspaceId: crypto.randomUUID(),
+      defaults: {connectionId: project.connectionId, owner: 'acme'},
+      target: {project: project.projectId},
+    });
+  });
+
+  test.each([
+    ['an unknown target', {repository: 'acme/missing'}],
+    ['a stale name after a rename', {repository: 'acme/old-name'}],
+    ['a leading slash', {repository: '/api'}],
+    ['a trailing slash', {repository: 'acme/'}],
+    ['more than one slash', {repository: 'acme/api/extra'}],
+  ])('rejects %s', async (_label, target) => {
+    const client = createClient();
+    const workspaceId = crypto.randomUUID();
+    const connectionId = crypto.randomUUID();
+    await insertProject({
+      workspaceId,
+      connectionId,
+      owner: 'acme',
+      name: 'new-name',
+    });
+
+    await expectUnauthorized(client, {
+      workspaceId,
+      defaults: {connectionId, owner: 'acme'},
+      target,
+    });
+  });
+});

--- a/libs/api/projects/src/presentation/inter-module.test.ts
+++ b/libs/api/projects/src/presentation/inter-module.test.ts
@@ -1,3 +1,4 @@
+import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
 import {projectsInterModuleContract} from '@shipfox/api-projects-dto/inter-module';
 import {isInterModuleKnownError} from '@shipfox/inter-module';
 import {createInMemoryInterModuleTransport} from '@shipfox/node-module/inter-module';
@@ -5,10 +6,26 @@ import {db} from '#db/index.js';
 import {projects} from '#db/schema/projects.js';
 import {createProjectsInterModulePresentation} from './inter-module.js';
 
-function createClient() {
+function createClient(
+  integrations: Pick<IntegrationsModuleClient, 'resolveSourceRepository'> = {
+    resolveSourceRepository: vi.fn(async ({connectionId, externalRepositoryId}) => ({
+      connection: {id: connectionId, provider: 'github', slug: 'github'},
+      repository: {
+        externalRepositoryId,
+        owner: 'acme',
+        name: 'api',
+        fullName: 'acme/api',
+        defaultBranch: 'main',
+        visibility: 'private' as const,
+        cloneUrl: 'https://github.com/acme/api.git',
+        htmlUrl: 'https://github.com/acme/api',
+      },
+    })),
+  },
+) {
   const transport = createInMemoryInterModuleTransport();
   const client = transport.createClient(projectsInterModuleContract);
-  transport.register(createProjectsInterModulePresentation());
+  transport.register(createProjectsInterModulePresentation({integrations}));
   transport.seal();
   return client;
 }
@@ -18,13 +35,15 @@ async function insertProject(params: {
   connectionId: string;
   owner: string | null;
   name: string | null;
+  externalRepositoryId?: string;
 }) {
   const [project] = await db()
     .insert(projects)
     .values({
       workspaceId: params.workspaceId,
       sourceConnectionId: params.connectionId,
-      sourceExternalRepositoryId: `repository-${crypto.randomUUID()}`,
+      sourceExternalRepositoryId:
+        params.externalRepositoryId ?? `repository-${crypto.randomUUID()}`,
       sourceRepositoryOwner: params.owner,
       sourceRepositoryName: params.name,
       name: params.name ?? 'Project',
@@ -155,6 +174,52 @@ describe('Projects checkout target inter-module presentation', () => {
     });
   });
 
+  test('refreshes provider metadata before resolving a repository name', async () => {
+    const workspaceId = crypto.randomUUID();
+    const connectionId = crypto.randomUUID();
+    const externalRepositoryId = `github:${crypto.randomUUID()}`;
+    const resolveSourceRepository = vi.fn(async () => ({
+      connection: {id: connectionId, provider: 'github', slug: 'github'},
+      repository: {
+        externalRepositoryId,
+        owner: 'acme',
+        name: 'new-name',
+        fullName: 'acme/new-name',
+        defaultBranch: 'main',
+        visibility: 'private' as const,
+        cloneUrl: 'https://github.com/acme/new-name.git',
+        htmlUrl: 'https://github.com/acme/new-name',
+      },
+    }));
+    const client = createClient({resolveSourceRepository});
+    const project = await insertProject({
+      workspaceId,
+      connectionId,
+      owner: 'acme',
+      name: 'old-name',
+      externalRepositoryId,
+    });
+
+    await expectUnauthorized(client, {
+      workspaceId,
+      defaults: {connectionId, owner: 'acme'},
+      target: {repository: 'acme/old-name'},
+    });
+
+    await expect(
+      client.resolveCheckoutTarget({
+        workspaceId,
+        defaults: {connectionId, owner: 'acme'},
+        target: {repository: 'acme/new-name'},
+      }),
+    ).resolves.toEqual(project);
+    expect(resolveSourceRepository).toHaveBeenCalledWith({
+      workspaceId,
+      connectionId,
+      externalRepositoryId: project.externalRepositoryId,
+    });
+  });
+
   test('does not let a bare name escape the default owner', async () => {
     const client = createClient();
     const workspaceId = crypto.randomUUID();
@@ -191,7 +256,6 @@ describe('Projects checkout target inter-module presentation', () => {
 
   test.each([
     ['an unknown target', {repository: 'acme/missing'}],
-    ['a stale name after a rename', {repository: 'acme/old-name'}],
     ['a leading slash', {repository: '/api'}],
     ['a trailing slash', {repository: 'acme/'}],
     ['more than one slash', {repository: 'acme/api/extra'}],

--- a/libs/api/projects/src/presentation/inter-module.ts
+++ b/libs/api/projects/src/presentation/inter-module.ts
@@ -4,7 +4,7 @@ import {
   defineInterModulePresentation,
   type InterModulePresentation,
 } from '@shipfox/inter-module';
-import {getProjectById, getWorkspaceProjectCounts} from '#db/projects.js';
+import {getProjectById, getWorkspaceProjectCounts, resolveCheckoutTarget} from '#db/projects.js';
 
 export function createProjectsInterModulePresentation(): InterModulePresentation<
   typeof projectsInterModuleContract
@@ -32,5 +32,16 @@ export function createProjectsInterModulePresentation(): InterModulePresentation
     getWorkspaceProjectCounts: async ({workspaceIds}) => ({
       counts: await getWorkspaceProjectCounts({workspaceIds}),
     }),
+    resolveCheckoutTarget: async (input) => {
+      const target = await resolveCheckoutTarget(input);
+      if (target === undefined) {
+        throw createInterModuleKnownError(
+          projectsInterModuleContract.methods.resolveCheckoutTarget,
+          'checkout-repository-not-authorized',
+          {},
+        );
+      }
+      return target;
+    },
   });
 }

--- a/libs/api/projects/src/presentation/inter-module.ts
+++ b/libs/api/projects/src/presentation/inter-module.ts
@@ -1,14 +1,20 @@
+import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
 import {projectsInterModuleContract} from '@shipfox/api-projects-dto/inter-module';
 import {
   createInterModuleKnownError,
   defineInterModulePresentation,
   type InterModulePresentation,
 } from '@shipfox/inter-module';
-import {getProjectById, getWorkspaceProjectCounts, resolveCheckoutTarget} from '#db/projects.js';
+import {
+  getProjectById,
+  getWorkspaceProjectCounts,
+  resolveCheckoutTarget,
+  updateProjectSourceMetadata,
+} from '#db/projects.js';
 
-export function createProjectsInterModulePresentation(): InterModulePresentation<
-  typeof projectsInterModuleContract
-> {
+export function createProjectsInterModulePresentation(params: {
+  integrations: Pick<IntegrationsModuleClient, 'resolveSourceRepository'>;
+}): InterModulePresentation<typeof projectsInterModuleContract> {
   return defineInterModulePresentation(projectsInterModuleContract, {
     getProjectById: async ({projectId}) => ({project: (await getProjectById(projectId)) ?? null}),
     requireProjectForWorkspace: async ({projectId, workspaceId}) => {
@@ -41,6 +47,57 @@ export function createProjectsInterModulePresentation(): InterModulePresentation
           {},
         );
       }
+
+      if ('repository' in input.target) {
+        const source = await params.integrations
+          .resolveSourceRepository({
+            workspaceId: input.workspaceId,
+            connectionId: target.connectionId,
+            externalRepositoryId: target.externalRepositoryId,
+          })
+          .catch(() => undefined);
+        if (source === undefined) {
+          throw createInterModuleKnownError(
+            projectsInterModuleContract.methods.resolveCheckoutTarget,
+            'checkout-repository-not-authorized',
+            {},
+          );
+        }
+
+        const separator = input.target.repository.indexOf('/');
+        const requestedOwner =
+          separator === -1 ? input.defaults.owner : input.target.repository.slice(0, separator);
+        const requestedName =
+          separator === -1 ? input.target.repository : input.target.repository.slice(separator + 1);
+        const repositoryMatches =
+          source.repository.owner.toLowerCase() === requestedOwner.toLowerCase() &&
+          source.repository.name.toLowerCase() === requestedName.toLowerCase();
+
+        await updateProjectSourceMetadata({
+          workspaceId: input.workspaceId,
+          projectId: target.projectId,
+          sourceConnectionId: source.connection.id,
+          sourceExternalRepositoryId: source.repository.externalRepositoryId,
+          sourceRepositoryOwner: source.repository.owner,
+          sourceRepositoryName: source.repository.name,
+          sourceDefaultBranch: source.repository.defaultBranch,
+        });
+
+        if (!repositoryMatches) {
+          throw createInterModuleKnownError(
+            projectsInterModuleContract.methods.resolveCheckoutTarget,
+            'checkout-repository-not-authorized',
+            {},
+          );
+        }
+
+        return {
+          ...target,
+          connectionId: source.connection.id,
+          externalRepositoryId: source.repository.externalRepositoryId,
+        };
+      }
+
       return target;
     },
   });

--- a/libs/api/secrets/src/presentation/routes/management.test.ts
+++ b/libs/api/secrets/src/presentation/routes/management.test.ts
@@ -27,6 +27,11 @@ const projects = createFakeInterModuleClients({
     getProjectById: () => ({project: null}),
     getWorkspaceProjectCounts: () => ({counts: []}),
     requireProjectForWorkspace: async (input) => await requireProjectForWorkspace(input),
+    resolveCheckoutTarget: () => ({
+      projectId: crypto.randomUUID(),
+      connectionId: crypto.randomUUID(),
+      externalRepositoryId: 'repo',
+    }),
   }),
 }).projects;
 

--- a/libs/api/server/src/modules.test.ts
+++ b/libs/api/server/src/modules.test.ts
@@ -167,6 +167,11 @@ describe('defaultModules', () => {
               name: 'Project',
             },
           }),
+          resolveCheckoutTarget: () => ({
+            projectId: crypto.randomUUID(),
+            connectionId: crypto.randomUUID(),
+            externalRepositoryId: 'repo',
+          }),
         }),
       ],
     });


### PR DESCRIPTION
Add the producer-side checkout target resolution capability to the projects module.

`resolveCheckoutTarget` resolves a workspace project by ID or by a case-insensitive owner/repository reference, applies the connection and default-owner boundaries, returns the matched connection and external repository ID, and fails closed for unauthorized, malformed, or ambiguous matches. The DTO contract, producer implementation, consumer fakes, regression coverage, and published-package changeset are included.

No runtime caller is wired in this PR; checkout-target integration is downstream work.

Closes ENG-1427

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `resolveCheckoutTarget` inter-module RPC to authorize and resolve a checkout target to a single project in a workspace. Validates repository targets against the provider’s current snapshot and refreshes stored source metadata so renamed or stale repos fail closed (implements ENG-1427).

- **New Features**
  - Adds `projectsInterModule.resolveCheckoutTarget` with input `{workspaceId, defaults: {connectionId, owner}, target}` and output `{projectId, connectionId, externalRepositoryId}`; unauthorized/invalid -> `checkout-repository-not-authorized`.
  - DB resolver: workspace-scoped; case-insensitive; bare names stay in the default owner; optional explicit `connection`; rejects malformed paths and ambiguous owner/name; no DB-only fallback.
  - For repository targets, calls `integrations.resolveSourceRepository`, verifies owner/name match, persists refreshed source identity (connection/IDs/owner/name/defaultBranch), and returns updated `connectionId`/`externalRepositoryId`. Presentation now requires `integrations`; tests/fakes updated.

- **Dependencies**
  - Bumps `@shipfox/api-projects-dto` and `@shipfox/api-projects` (minor).

<sup>Written for commit 4df3200d2cbe71b7f6cfced04ae565b48f5b07a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

