### PR TITLE
Persist and surface workflow definition warnings

### DIFF
--- a/.changeset/persist-definition-warnings.md
+++ b/.changeset/persist-definition-warnings.md
@@ -1,0 +1,8 @@
+---
+"@shipfox/api-definitions-dto": minor
+"@shipfox/api-definitions": minor
+"@shipfox/client-projects": patch
+"@shipfox/client-workflows": patch
+---
+
+Persist definition validation warnings from repository syncs and surface them on the workflow page without changing sync success or run creation behavior.

--- a/e2e/observe/definitions/src/index.test.ts
+++ b/e2e/observe/definitions/src/index.test.ts
@@ -40,6 +40,7 @@ function listResponse(params: Partial<DefinitionListResponseDto> = {}): Definiti
             finished_at: '2026-07-02T08:00:01.000Z',
             last_error_code: null,
             last_error_message: null,
+            warnings: [],
           }
         : params.sync,
     next_cursor: params.next_cursor ?? null,
@@ -105,6 +106,7 @@ describe('waitForDefinition', () => {
               finished_at: '2026-07-02T08:00:01.000Z',
               last_error_code: 'no-workflow-files',
               last_error_message: 'No workflow files found',
+              warnings: [],
             },
           }),
         ),
@@ -130,6 +132,7 @@ describe('waitForDefinition', () => {
               finished_at: '2026-07-02T08:00:01.000Z',
               last_error_code: 'no-workflow-files',
               last_error_message: 'No workflow files found',
+              warnings: [],
             },
           }),
         ),

--- a/e2e/suites/flow/workflows/src/reject.test.ts
+++ b/e2e/suites/flow/workflows/src/reject.test.ts
@@ -13,6 +13,7 @@ function sync(overrides: Partial<DefinitionSyncSummaryDto> = {}): DefinitionSync
     finished_at: timestamp,
     last_error_code: 'invalid-definition',
     last_error_message: 'Invalid workflow definition: unknown-interpolation-context',
+    warnings: [],
     ...overrides,
   };
 }

--- a/libs/api/definitions-dto/src/index.ts
+++ b/libs/api/definitions-dto/src/index.ts
@@ -1,6 +1,10 @@
 export {
   type CreateDefinitionBodyDto,
   createDefinitionBodySchema,
+  DEFINITION_SYNC_WARNING_CODE_MAX_LENGTH,
+  DEFINITION_SYNC_WARNING_MESSAGE_MAX_LENGTH,
+  DEFINITION_SYNC_WARNING_PATH_MAX_LENGTH,
+  DEFINITION_SYNC_WARNINGS_MAX_COUNT,
   type DefinitionDto,
   type DefinitionListQueryDto,
   type DefinitionListResponseDto,

--- a/libs/api/definitions-dto/src/schemas/dto.ts
+++ b/libs/api/definitions-dto/src/schemas/dto.ts
@@ -1,5 +1,10 @@
 import {z} from 'zod';
 
+export const DEFINITION_SYNC_WARNINGS_MAX_COUNT = 100;
+export const DEFINITION_SYNC_WARNING_CODE_MAX_LENGTH = 128;
+export const DEFINITION_SYNC_WARNING_MESSAGE_MAX_LENGTH = 2048;
+export const DEFINITION_SYNC_WARNING_PATH_MAX_LENGTH = 512;
+
 export const createDefinitionBodySchema = z
   .object({
     project_id: z.string().uuid(),
@@ -71,9 +76,9 @@ export const definitionValidationErrorSchema = z.object({
 export type DefinitionValidationErrorDto = z.infer<typeof definitionValidationErrorSchema>;
 
 export const definitionValidationWarningSchema = z.object({
-  code: z.string(),
-  message: z.string(),
-  path: z.string().optional(),
+  code: z.string().max(DEFINITION_SYNC_WARNING_CODE_MAX_LENGTH),
+  message: z.string().max(DEFINITION_SYNC_WARNING_MESSAGE_MAX_LENGTH),
+  path: z.string().max(DEFINITION_SYNC_WARNING_PATH_MAX_LENGTH).optional(),
 });
 
 export type DefinitionValidationWarningDto = z.infer<typeof definitionValidationWarningSchema>;
@@ -110,6 +115,7 @@ export const definitionSyncSummarySchema = z.object({
     ])
     .nullable(),
   last_error_message: z.string().nullable(),
+  warnings: z.array(definitionValidationWarningSchema).max(DEFINITION_SYNC_WARNINGS_MAX_COUNT),
 });
 
 export type DefinitionSyncSummaryDto = z.infer<typeof definitionSyncSummarySchema>;

--- a/libs/api/definitions-dto/src/schemas/index.ts
+++ b/libs/api/definitions-dto/src/schemas/index.ts
@@ -1,6 +1,10 @@
 export {
   type CreateDefinitionBodyDto,
   createDefinitionBodySchema,
+  DEFINITION_SYNC_WARNING_CODE_MAX_LENGTH,
+  DEFINITION_SYNC_WARNING_MESSAGE_MAX_LENGTH,
+  DEFINITION_SYNC_WARNING_PATH_MAX_LENGTH,
+  DEFINITION_SYNC_WARNINGS_MAX_COUNT,
   type DefinitionDto,
   type DefinitionListQueryDto,
   type DefinitionListResponseDto,

--- a/libs/api/definitions/drizzle/0002_lumpy_ben_parker.sql
+++ b/libs/api/definitions/drizzle/0002_lumpy_ben_parker.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "definitions_sync_states" ADD COLUMN "warnings" jsonb DEFAULT '[]'::jsonb NOT NULL;

--- a/libs/api/definitions/drizzle/meta/0002_snapshot.json
+++ b/libs/api/definitions/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,534 @@
+{
+  "id": "e5dff42f-09f1-4a29-973f-b0d63a150673",
+  "prevId": "a20924e2-d7b1-4f98-b8c4-bab54ea48de5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.definitions_workflow_definitions": {
+      "name": "definitions_workflow_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_path": {
+          "name": "config_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "definitions_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "sha": {
+          "name": "sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "definitions_wd_manual_unique": {
+          "name": "definitions_wd_manual_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "config_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"config_path\" IS NOT NULL AND \"ref\" IS NULL AND \"sha\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "definitions_wd_sha_lookup": {
+          "name": "definitions_wd_sha_lookup",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "config_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sha\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "definitions_wd_ref_lookup": {
+          "name": "definitions_wd_ref_lookup",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "config_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"ref\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "definitions_wd_project_name_id_idx": {
+          "name": "definitions_wd_project_name_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "definitions_wd_source_ref_sha_consistent": {
+          "name": "definitions_wd_source_ref_sha_consistent",
+          "value": "(\"source\" = 'vcs') = (\"ref\" IS NOT NULL OR \"sha\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.definitions_outbox": {
+      "name": "definitions_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordering_key": {
+          "name": "ordering_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_attempts": {
+          "name": "dispatch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_dispatch_at": {
+          "name": "next_dispatch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_dispatch_error": {
+          "name": "last_dispatch_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_dispatch_failed_at": {
+          "name": "last_dispatch_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dead_lettered_at": {
+          "name": "dead_lettered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "definitions_outbox_pending_idx": {
+          "name": "definitions_outbox_pending_idx",
+          "columns": [
+            {
+              "expression": "next_dispatch_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NULL AND \"dead_lettered_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "definitions_outbox_dispatched_retention_idx": {
+          "name": "definitions_outbox_dispatched_retention_idx",
+          "columns": [
+            {
+              "expression": "dispatched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.definitions_sync_states": {
+      "name": "definitions_sync_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_connection_id": {
+          "name": "source_connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_external_repository_id": {
+          "name": "source_external_repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "definitions_sync_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "definitions_sync_error_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warnings": {
+          "name": "warnings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "definitions_sync_states_source_unique": {
+          "name": "definitions_sync_states_source_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_external_repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "definitions_sync_states_failed_idx": {
+          "name": "definitions_sync_states_failed_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"status\" = 'failed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.definitions_source": {
+      "name": "definitions_source",
+      "schema": "public",
+      "values": ["manual", "vcs"]
+    },
+    "public.definitions_sync_error_code": {
+      "name": "definitions_sync_error_code",
+      "schema": "public",
+      "values": [
+        "no-workflow-files",
+        "invalid-definition",
+        "provider-repository-not-found",
+        "provider-file-not-found",
+        "provider-access-denied",
+        "provider-rate-limited",
+        "provider-timeout",
+        "provider-unavailable",
+        "provider-malformed-response",
+        "content-too-large",
+        "too-many-files",
+        "connection-unavailable",
+        "unknown"
+      ]
+    },
+    "public.definitions_sync_status": {
+      "name": "definitions_sync_status",
+      "schema": "public",
+      "values": ["pending", "syncing", "succeeded", "failed"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/api/definitions/drizzle/meta/_journal.json
+++ b/libs/api/definitions/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1778494690000,
       "tag": "0001_definition_list_pagination",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1785415305913,
+      "tag": "0002_lumpy_ben_parker",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/api/definitions/src/core/entities/index.ts
+++ b/libs/api/definitions/src/core/entities/index.ts
@@ -1,4 +1,5 @@
 export * from './integration-context.js';
 export * from './sync-state.js';
+export * from './validation-warning.js';
 export * from './workflow-definition.js';
 export * from './workflow-model.js';

--- a/libs/api/definitions/src/core/entities/sync-state.ts
+++ b/libs/api/definitions/src/core/entities/sync-state.ts
@@ -1,4 +1,26 @@
+import {
+  DEFINITION_SYNC_WARNING_CODE_MAX_LENGTH,
+  DEFINITION_SYNC_WARNING_MESSAGE_MAX_LENGTH,
+  DEFINITION_SYNC_WARNING_PATH_MAX_LENGTH,
+  DEFINITION_SYNC_WARNINGS_MAX_COUNT,
+} from '@shipfox/api-definitions-dto';
+import type {ValidationWarning} from './validation-warning.js';
+
 export type DefinitionSyncStatus = 'pending' | 'syncing' | 'succeeded' | 'failed';
+
+export type DefinitionSyncWarning = ValidationWarning;
+
+export function limitDefinitionSyncWarnings(
+  warnings: readonly DefinitionSyncWarning[],
+): DefinitionSyncWarning[] {
+  return warnings.slice(0, DEFINITION_SYNC_WARNINGS_MAX_COUNT).map((warning) => ({
+    code: warning.code.slice(0, DEFINITION_SYNC_WARNING_CODE_MAX_LENGTH),
+    message: warning.message.slice(0, DEFINITION_SYNC_WARNING_MESSAGE_MAX_LENGTH),
+    ...(warning.path === undefined
+      ? {}
+      : {path: warning.path.slice(0, DEFINITION_SYNC_WARNING_PATH_MAX_LENGTH)}),
+  }));
+}
 
 export const DEFINITION_SYNC_ERROR_CODES = [
   'no-workflow-files',
@@ -33,6 +55,7 @@ export interface DefinitionSyncState {
   status: DefinitionSyncStatus;
   lastErrorCode: DefinitionSyncErrorCode | null;
   lastErrorMessage: string | null;
+  warnings: DefinitionSyncWarning[];
   startedAt: Date | null;
   finishedAt: Date | null;
   createdAt: Date;

--- a/libs/api/definitions/src/core/entities/validation-warning.ts
+++ b/libs/api/definitions/src/core/entities/validation-warning.ts
@@ -1,0 +1,5 @@
+export interface ValidationWarning {
+  code: string;
+  message: string;
+  path?: string | undefined;
+}

--- a/libs/api/definitions/src/core/parse-definition-warnings.test.ts
+++ b/libs/api/definitions/src/core/parse-definition-warnings.test.ts
@@ -1,0 +1,33 @@
+import {agentValidationCatalog} from '#test/agent-validation-catalog.js';
+import {parseDefinitionWithWarnings} from './parse-definition.js';
+import {validateDefinition} from './validate-definition.js';
+
+vi.mock('./validate-definition.js', () => ({
+  validateDefinition: vi.fn(),
+}));
+
+describe('parseDefinitionWithWarnings', () => {
+  it('returns warnings from successful validation', () => {
+    vi.mocked(validateDefinition).mockReturnValue({
+      valid: true,
+      definition: {document: {}, model: {}} as never,
+      warnings: [
+        {
+          code: 'synthetic-warning',
+          message: 'A non-fatal validation warning',
+          path: 'jobs.build.steps.0.run',
+        },
+      ],
+    });
+
+    const parsed = parseDefinitionWithWarnings('name: Workflow', {agentValidationCatalog});
+
+    expect(parsed.warnings).toEqual([
+      {
+        code: 'synthetic-warning',
+        message: 'A non-fatal validation warning',
+        path: 'jobs.build.steps.0.run',
+      },
+    ]);
+  });
+});

--- a/libs/api/definitions/src/core/parse-definition.ts
+++ b/libs/api/definitions/src/core/parse-definition.ts
@@ -1,17 +1,18 @@
-import type {AgentValidationCatalog} from '@shipfox/api-agent-dto/inter-module';
-import type {IntegrationValidationContext} from './entities/integration-context.js';
+import type {ValidationWarning} from './entities/validation-warning.js';
 import type {WorkflowDefinitionPayload} from './entities/workflow-definition.js';
 import {DefinitionParseError} from './errors.js';
-import {validateDefinition} from './validate-definition.js';
+import {type DefinitionValidationOptions, validateDefinition} from './validate-definition.js';
 
-export function parseDefinition(
+export interface ParsedDefinition extends WorkflowDefinitionPayload {
+  warnings: ValidationWarning[];
+}
+
+export type ParseDefinitionOptions = DefinitionValidationOptions;
+
+export function parseDefinitionWithWarnings(
   yamlString: string,
-  options: {
-    defaultRunnerLabels?: readonly string[];
-    agentValidationCatalog: AgentValidationCatalog;
-    integrationValidationContext?: IntegrationValidationContext;
-  },
-): WorkflowDefinitionPayload {
+  options: ParseDefinitionOptions,
+): ParsedDefinition {
   const result = validateDefinition(yamlString, options);
 
   if (!result.valid) {
@@ -24,5 +25,22 @@ export function parseDefinition(
   return {
     ...result.definition,
     sourceSnapshot: {content: yamlString, format: 'yaml'},
+    warnings: result.warnings,
+  };
+}
+
+export function parseDefinition(
+  yamlString: string,
+  options: ParseDefinitionOptions,
+): WorkflowDefinitionPayload {
+  const parsed = parseDefinitionWithWarnings(yamlString, options);
+  return stripDefinitionWarnings(parsed);
+}
+
+export function stripDefinitionWarnings(parsed: ParsedDefinition): WorkflowDefinitionPayload {
+  return {
+    document: parsed.document,
+    model: parsed.model,
+    sourceSnapshot: parsed.sourceSnapshot ?? null,
   };
 }

--- a/libs/api/definitions/src/core/sync-definitions.test.ts
+++ b/libs/api/definitions/src/core/sync-definitions.test.ts
@@ -230,6 +230,7 @@ describe('fetchAndParseWorkflows', () => {
     expect(result[0]?.name).toBe('CI');
     expect(result[0]?.path).toBe('.shipfox/workflows/ci.yml');
     expect(result[0]?.contentHash).toMatch(LOWERCASE_SHA256_HEX_RE);
+    expect(result[0]?.warnings).toEqual([]);
   });
 
   it('produces stable content hashes for identical content', async () => {

--- a/libs/api/definitions/src/core/sync-definitions.ts
+++ b/libs/api/definitions/src/core/sync-definitions.ts
@@ -5,11 +5,12 @@ import {isInterModuleKnownError} from '@shipfox/inter-module';
 import {boundedMap} from '@shipfox/node-module';
 import type {IntegrationValidationContext} from './entities/integration-context.js';
 import type {DefinitionSyncErrorCode} from './entities/sync-state.js';
+import type {ValidationWarning} from './entities/validation-warning.js';
 import type {WorkflowDefinitionPayload} from './entities/workflow-definition.js';
 import {DefinitionParseError, DefinitionSyncPermanentError} from './errors.js';
 import {hasAgentStepIntegrations} from './has-agent-step-integrations.js';
 import type {DefinitionsSourceControl} from './integrations.js';
-import {parseDefinition} from './parse-definition.js';
+import {parseDefinitionWithWarnings, stripDefinitionWarnings} from './parse-definition.js';
 
 export const DEFAULT_WORKFLOW_PATH = '.shipfox/workflows/';
 export const MAX_WORKFLOW_FILES = 100;
@@ -79,6 +80,7 @@ export interface ParsedWorkflow {
   name: string;
   definition: WorkflowDefinitionPayload;
   contentHash: string;
+  warnings: ValidationWarning[];
 }
 
 export interface FetchAndParseWorkflowsParams extends SyncSourceContext {
@@ -152,13 +154,21 @@ function parseWorkflowSnapshot(params: {
   try {
     const definition =
       params.integrationValidationContext === undefined
-        ? parseDefinition(params.content, {agentValidationCatalog: params.agentValidationCatalog})
-        : parseDefinition(params.content, {
+        ? parseDefinitionWithWarnings(params.content, {
+            agentValidationCatalog: params.agentValidationCatalog,
+          })
+        : parseDefinitionWithWarnings(params.content, {
             agentValidationCatalog: params.agentValidationCatalog,
             integrationValidationContext: params.integrationValidationContext,
           });
     const contentHash = sha256Hex(params.content);
-    return {path: params.path, name: definition.document.name, definition, contentHash};
+    return {
+      path: params.path,
+      name: definition.document.name,
+      definition: stripDefinitionWarnings(definition),
+      contentHash,
+      warnings: definition.warnings,
+    };
   } catch (error) {
     if (error instanceof DefinitionParseError) {
       throw new DefinitionSyncPermanentError(

--- a/libs/api/definitions/src/core/validate-definition.ts
+++ b/libs/api/definitions/src/core/validate-definition.ts
@@ -2,6 +2,7 @@ import type {AgentValidationCatalog} from '@shipfox/api-agent-dto/inter-module';
 import {InvalidWorkflowDocumentError} from '@shipfox/workflow-document';
 import {definitionDefaultRunnerLabels} from '../config.js';
 import type {IntegrationValidationContext} from './entities/integration-context.js';
+import type {ValidationWarning} from './entities/validation-warning.js';
 import type {WorkflowDefinitionPayload} from './entities/workflow-definition.js';
 import {
   InvalidWorkflowModelError,
@@ -11,7 +12,13 @@ import {
 import {InvalidWorkflowYamlError, parseWorkflowYamlWithLocations} from './workflow-yaml/index.js';
 
 export type ValidationError = {message: string; path?: string | undefined};
-export type ValidationWarning = {code: string; message: string; path?: string | undefined};
+export type {ValidationWarning} from './entities/validation-warning.js';
+
+export interface DefinitionValidationOptions {
+  defaultRunnerLabels?: readonly string[];
+  agentValidationCatalog: AgentValidationCatalog;
+  integrationValidationContext?: IntegrationValidationContext;
+}
 
 export type ValidationResult =
   | {valid: true; definition: WorkflowDefinitionPayload; warnings: ValidationWarning[]}
@@ -19,11 +26,7 @@ export type ValidationResult =
 
 export function validateDefinition(
   yamlContent: string,
-  options: {
-    defaultRunnerLabels?: readonly string[];
-    agentValidationCatalog: AgentValidationCatalog;
-    integrationValidationContext?: IntegrationValidationContext;
-  },
+  options: DefinitionValidationOptions,
 ): ValidationResult {
   try {
     const {document, stepSourceLocations} = parseWorkflowYamlWithLocations(yamlContent);

--- a/libs/api/definitions/src/db/schema/sync-states.ts
+++ b/libs/api/definitions/src/db/schema/sync-states.ts
@@ -1,10 +1,11 @@
 import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
 import {sql} from 'drizzle-orm';
-import {index, pgEnum, text, timestamp, uniqueIndex, uuid} from 'drizzle-orm/pg-core';
+import {index, jsonb, pgEnum, text, timestamp, uniqueIndex, uuid} from 'drizzle-orm/pg-core';
 import type {
   DefinitionSyncErrorCode,
   DefinitionSyncState,
   DefinitionSyncStatus,
+  DefinitionSyncWarning,
 } from '#core/entities/sync-state.js';
 import {pgTable} from './common.js';
 
@@ -42,6 +43,7 @@ export const definitionSyncStates = pgTable(
     status: definitionSyncStatusEnum('status').notNull().default('pending'),
     lastErrorCode: definitionSyncErrorCodeEnum('last_error_code'),
     lastErrorMessage: text('last_error_message'),
+    warnings: jsonb('warnings').notNull().default([]).$type<DefinitionSyncWarning[]>(),
     startedAt: timestamp('started_at', {withTimezone: true}),
     finishedAt: timestamp('finished_at', {withTimezone: true}),
     createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
@@ -71,6 +73,7 @@ export function toDefinitionSyncState(row: DefinitionSyncStateDb): DefinitionSyn
     status: row.status as DefinitionSyncStatus,
     lastErrorCode: row.lastErrorCode as DefinitionSyncErrorCode | null,
     lastErrorMessage: row.lastErrorMessage,
+    warnings: row.warnings ?? [],
     startedAt: row.startedAt,
     finishedAt: row.finishedAt,
     createdAt: row.createdAt,

--- a/libs/api/definitions/src/db/sync-states.test.ts
+++ b/libs/api/definitions/src/db/sync-states.test.ts
@@ -1,3 +1,9 @@
+import {
+  DEFINITION_SYNC_WARNING_CODE_MAX_LENGTH,
+  DEFINITION_SYNC_WARNING_MESSAGE_MAX_LENGTH,
+  DEFINITION_SYNC_WARNING_PATH_MAX_LENGTH,
+  DEFINITION_SYNC_WARNINGS_MAX_COUNT,
+} from '@shipfox/api-definitions-dto';
 import {eq} from 'drizzle-orm';
 import {db} from './db.js';
 import {definitionSyncStates} from './schema/sync-states.js';
@@ -57,6 +63,57 @@ describe('definition sync state queries', () => {
     expect(second.status).toBe('failed');
     expect(second.lastErrorCode).toBe('invalid-definition');
     expect(second.startedAt?.getTime()).toBe(first.startedAt?.getTime());
+  });
+
+  it('persists warnings and clears them on a subsequent sync', async () => {
+    const warnings = [
+      {
+        code: 're-evaluating-command',
+        message: 'Workflow data is re-executed as shell code.',
+        path: 'jobs.build.steps.0.run',
+      },
+    ];
+
+    const succeeded = await markDefinitionSyncState({
+      projectId,
+      sourceConnectionId,
+      sourceExternalRepositoryId: 'gitea-owner/platform',
+      ref: 'main',
+      status: 'succeeded',
+      warnings,
+    });
+
+    expect(succeeded.warnings).toEqual(warnings);
+
+    const syncing = await markDefinitionSyncState({
+      projectId,
+      sourceConnectionId,
+      sourceExternalRepositoryId: 'gitea-owner/platform',
+      ref: 'main',
+      status: 'syncing',
+    });
+
+    expect(syncing.warnings).toEqual([]);
+  });
+
+  it('bounds warning payloads before persisting them', async () => {
+    const state = await markDefinitionSyncState({
+      projectId,
+      sourceConnectionId,
+      sourceExternalRepositoryId: 'gitea-owner/platform',
+      ref: 'main',
+      status: 'succeeded',
+      warnings: Array.from({length: DEFINITION_SYNC_WARNINGS_MAX_COUNT + 1}, (_, index) => ({
+        code: `${index}-${'c'.repeat(DEFINITION_SYNC_WARNING_CODE_MAX_LENGTH)}`,
+        message: `${index}-${'m'.repeat(DEFINITION_SYNC_WARNING_MESSAGE_MAX_LENGTH)}`,
+        path: `${index}-${'p'.repeat(DEFINITION_SYNC_WARNING_PATH_MAX_LENGTH)}`,
+      })),
+    });
+
+    expect(state.warnings).toHaveLength(DEFINITION_SYNC_WARNINGS_MAX_COUNT);
+    expect(state.warnings[0]?.code).toHaveLength(DEFINITION_SYNC_WARNING_CODE_MAX_LENGTH);
+    expect(state.warnings[0]?.message).toHaveLength(DEFINITION_SYNC_WARNING_MESSAGE_MAX_LENGTH);
+    expect(state.warnings[0]?.path).toHaveLength(DEFINITION_SYNC_WARNING_PATH_MAX_LENGTH);
   });
 
   it('clears stale finish data when a sync starts again', async () => {

--- a/libs/api/definitions/src/db/sync-states.ts
+++ b/libs/api/definitions/src/db/sync-states.ts
@@ -3,7 +3,9 @@ import type {
   DefinitionSyncErrorCode,
   DefinitionSyncState,
   DefinitionSyncStatus,
+  DefinitionSyncWarning,
 } from '#core/entities/sync-state.js';
+import {limitDefinitionSyncWarnings} from '#core/entities/sync-state.js';
 import {db} from './db.js';
 import {definitionSyncStates, toDefinitionSyncState} from './schema/sync-states.js';
 
@@ -18,6 +20,7 @@ export interface MarkDefinitionSyncParams extends DefinitionSyncStateKey {
   status: DefinitionSyncStatus;
   lastErrorCode?: DefinitionSyncErrorCode | null | undefined;
   lastErrorMessage?: string | null | undefined;
+  warnings?: readonly DefinitionSyncWarning[] | null | undefined;
   startedAt?: Date | null | undefined;
   finishedAt?: Date | null | undefined;
 }
@@ -26,6 +29,7 @@ export async function markDefinitionSyncState(
   params: MarkDefinitionSyncParams,
 ): Promise<DefinitionSyncState> {
   const now = new Date();
+  const warnings = limitDefinitionSyncWarnings(params.warnings ?? []);
   const [row] = await db()
     .insert(definitionSyncStates)
     .values({
@@ -36,6 +40,7 @@ export async function markDefinitionSyncState(
       status: params.status,
       lastErrorCode: params.lastErrorCode ?? null,
       lastErrorMessage: params.lastErrorMessage ?? null,
+      warnings,
       startedAt: params.startedAt ?? null,
       finishedAt: params.finishedAt ?? null,
       updatedAt: now,
@@ -51,6 +56,7 @@ export async function markDefinitionSyncState(
         status: params.status,
         lastErrorCode: params.lastErrorCode ?? null,
         lastErrorMessage: params.lastErrorMessage ?? null,
+        warnings,
         ...(params.startedAt !== undefined ? {startedAt: params.startedAt} : {}),
         ...(params.finishedAt !== undefined ? {finishedAt: params.finishedAt} : {}),
         updatedAt: now,

--- a/libs/api/definitions/src/presentation/dto/definition.ts
+++ b/libs/api/definitions/src/presentation/dto/definition.ts
@@ -37,5 +37,6 @@ export function toDefinitionSyncSummaryDto(
     finished_at: syncState.finishedAt?.toISOString() ?? null,
     last_error_code: syncState.lastErrorCode,
     last_error_message: syncState.lastErrorMessage,
+    warnings: syncState.warnings,
   };
 }

--- a/libs/api/definitions/src/presentation/routes/list-definitions.test.ts
+++ b/libs/api/definitions/src/presentation/routes/list-definitions.test.ts
@@ -99,6 +99,7 @@ describe('GET /api/definitions', () => {
       finished_at: finishedAt.toISOString(),
       last_error_code: null,
       last_error_message: null,
+      warnings: [],
     });
   });
 

--- a/libs/api/definitions/src/temporal/activities/sync-activities.test.ts
+++ b/libs/api/definitions/src/temporal/activities/sync-activities.test.ts
@@ -224,6 +224,7 @@ describe('definition sync activities', () => {
 
       expect(result.appliedCount).toBe(1);
       expect(result.deletedCount).toBe(0);
+      expect(result.warnings).toEqual([]);
     });
 
     it('translates DefinitionSyncPermanentError into a non-retryable ApplicationFailure', async () => {
@@ -308,6 +309,7 @@ describe('definition sync activities', () => {
       expect(rows[0]?.status).toBe('failed');
       expect(rows[0]?.lastErrorCode).toBe('invalid-definition');
       expect(rows[0]?.lastErrorMessage).toBe('Invalid workflow at .shipfox/workflows/bad.yml');
+      expect(rows[0]?.warnings).toEqual([]);
       expect(rows[0]?.finishedAt).not.toBeNull();
     });
 
@@ -362,6 +364,13 @@ describe('definition sync activities', () => {
         sourceConnectionId,
         sourceExternalRepositoryId: 'gitea:gitea-owner/platform',
         sourceRef: 'main',
+        warnings: [
+          {
+            code: 're-evaluating-command',
+            message: 'Workflow data is re-executed as shell code.',
+            path: 'jobs.build.steps.0.run',
+          },
+        ],
       });
       await result;
 
@@ -372,6 +381,13 @@ describe('definition sync activities', () => {
       expect(rows[0]?.status).toBe('succeeded');
       expect(rows[0]?.lastErrorCode).toBeNull();
       expect(rows[0]?.lastErrorMessage).toBeNull();
+      expect(rows[0]?.warnings).toEqual([
+        {
+          code: 're-evaluating-command',
+          message: 'Workflow data is re-executed as shell code.',
+          path: 'jobs.build.steps.0.run',
+        },
+      ]);
     });
   });
 });

--- a/libs/api/definitions/src/temporal/activities/sync-activities.ts
+++ b/libs/api/definitions/src/temporal/activities/sync-activities.ts
@@ -3,7 +3,7 @@ import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/i
 import {markErrorReported} from '@shipfox/node-error-monitoring';
 import {Context} from '@temporalio/activity';
 import {ApplicationFailure} from '@temporalio/common';
-import type {DefinitionSyncErrorCode} from '#core/entities/sync-state.js';
+import type {DefinitionSyncErrorCode, DefinitionSyncWarning} from '#core/entities/sync-state.js';
 import {
   classifySyncFailure,
   discoverWorkflowFiles,
@@ -50,6 +50,11 @@ export interface DiscoverWorkflowsActivityResult {
 export interface FetchAndApplyActivityResult {
   appliedCount: number;
   deletedCount: number;
+  warnings: DefinitionSyncWarning[];
+}
+
+export interface MarkSyncSucceededActivityInput extends SyncRefScopedInput {
+  warnings?: readonly DefinitionSyncWarning[] | undefined;
 }
 
 export interface DefinitionSyncActivityOptions {
@@ -93,6 +98,7 @@ function createPrepareDefinitionSyncActivity(sourceControl: DefinitionsSourceCon
         status: 'syncing',
         lastErrorCode: null,
         lastErrorMessage: null,
+        warnings: [],
         startedAt: new Date(),
         finishedAt: null,
       });
@@ -147,7 +153,7 @@ function createFetchAndApplyActivity(
               },
       });
 
-      return await applyVcsDefinitionsBatch({
+      const result = await applyVcsDefinitionsBatch({
         projectId: input.projectId,
         workspaceId: input.workspaceId,
         ref: input.sourceRef,
@@ -160,12 +166,19 @@ function createFetchAndApplyActivity(
           contentHash: entry.contentHash,
         })),
       });
+
+      return {
+        ...result,
+        warnings: definitions.flatMap((entry) => entry.warnings),
+      };
     });
   };
 }
 
 function createMarkSyncSucceededActivity() {
-  return async function markDefinitionSyncSucceeded(input: SyncRefScopedInput): Promise<void> {
+  return async function markDefinitionSyncSucceeded(
+    input: MarkSyncSucceededActivityInput,
+  ): Promise<void> {
     await markDefinitionSyncState({
       projectId: input.projectId,
       sourceConnectionId: input.sourceConnectionId,
@@ -174,6 +187,7 @@ function createMarkSyncSucceededActivity() {
       status: 'succeeded',
       lastErrorCode: null,
       lastErrorMessage: null,
+      warnings: input.warnings ?? [],
       finishedAt: new Date(),
     });
   };
@@ -191,6 +205,7 @@ function createMarkSyncFailedActivity() {
       status: 'failed',
       lastErrorCode: input.code,
       lastErrorMessage: input.message,
+      warnings: [],
       finishedAt: new Date(),
     });
   };

--- a/libs/api/definitions/src/temporal/workflows/definition-sync.ts
+++ b/libs/api/definitions/src/temporal/workflows/definition-sync.ts
@@ -65,7 +65,7 @@ export async function definitionSyncWorkflow(
     const {paths} = await discoverDefinitionWorkflows(source);
     const applied = await fetchAndApplyDefinitionWorkflows({...source, paths});
 
-    await markDefinitionSyncSucceeded(source);
+    await markDefinitionSyncSucceeded({...source, warnings: applied.warnings});
 
     return {
       sourceRef,

--- a/libs/client/projects/src/core/definition.ts
+++ b/libs/client/projects/src/core/definition.ts
@@ -22,6 +22,13 @@ export interface DefinitionSyncSummary {
   finishedAt: string | null;
   lastErrorCode: string | null;
   lastErrorMessage: string | null;
+  warnings: DefinitionSyncWarning[];
+}
+
+export interface DefinitionSyncWarning {
+  code: string;
+  message: string;
+  path?: string | undefined;
 }
 
 export interface DefinitionList {

--- a/libs/client/projects/src/hooks/api/mappers.test.ts
+++ b/libs/client/projects/src/hooks/api/mappers.test.ts
@@ -1,0 +1,19 @@
+import {toDefinitionSyncSummary} from './mappers.js';
+
+describe('toDefinitionSyncSummary', () => {
+  it('preserves warnings without manufacturing a missing path', () => {
+    const summary = toDefinitionSyncSummary({
+      ref: 'main',
+      status: 'succeeded',
+      last_sync_at: '2026-05-07T01:00:00.000Z',
+      started_at: '2026-05-07T00:59:55.000Z',
+      finished_at: '2026-05-07T01:00:00.000Z',
+      last_error_code: null,
+      last_error_message: null,
+      warnings: [{code: 'warning-code', message: 'Warning without a path'}],
+    });
+
+    expect(summary.warnings).toEqual([{code: 'warning-code', message: 'Warning without a path'}]);
+    expect(summary.warnings[0]).not.toHaveProperty('path');
+  });
+});

--- a/libs/client/projects/src/hooks/api/mappers.ts
+++ b/libs/client/projects/src/hooks/api/mappers.ts
@@ -51,6 +51,11 @@ export function toDefinitionSyncSummary(dto: DefinitionSyncSummaryDto): Definiti
     finishedAt: dto.finished_at,
     lastErrorCode: dto.last_error_code,
     lastErrorMessage: dto.last_error_message,
+    warnings: dto.warnings.map((warning) => ({
+      code: warning.code,
+      message: warning.message,
+      ...(warning.path === undefined ? {} : {path: warning.path}),
+    })),
   };
 }
 

--- a/libs/client/workflows/src/pages/project-workflows-page.test.tsx
+++ b/libs/client/workflows/src/pages/project-workflows-page.test.tsx
@@ -54,6 +54,13 @@ describe('ProjectWorkflowsPage', () => {
               finished_at: null,
               last_error_code: 'no-workflow-files',
               last_error_message: 'No workflow files found',
+              warnings: [
+                {
+                  code: 're-evaluating-command',
+                  message: 'Workflow data is re-executed as shell code.',
+                  path: 'jobs.build.steps.0.run',
+                },
+              ],
             },
           }),
         ),
@@ -66,6 +73,47 @@ describe('ProjectWorkflowsPage', () => {
       await screen.findByText('No workflow files found under .shipfox/workflows/.'),
     ).toBeInTheDocument();
     expect(screen.getByText('Workflow sync failed')).toBeInTheDocument();
+    expect(screen.queryByText('Workflow definition warnings')).not.toBeInTheDocument();
+  });
+
+  test('shows definition warnings without rendering a sync failure', async () => {
+    configureApiClient({
+      fetchImpl: createProjectDetailFetch({
+        definitions: jsonResponse(
+          definitionsDto({
+            sync: {
+              ref: 'main',
+              status: 'succeeded',
+              last_sync_at: '2026-05-07T01:00:00.000Z',
+              started_at: '2026-05-07T00:59:55.000Z',
+              finished_at: '2026-05-07T01:00:00.000Z',
+              last_error_code: null,
+              last_error_message: null,
+              warnings: [
+                {
+                  code: 're-evaluating-command',
+                  message: 'Workflow data is re-executed as shell code.',
+                  path: 'jobs.build.steps.0.run',
+                },
+                {
+                  code: 're-evaluating-command',
+                  message: 'Workflow data is re-executed as shell code.',
+                  path: 'jobs.build.steps.0.run',
+                },
+              ],
+            },
+          }),
+        ),
+      }),
+    });
+
+    renderWorkflowsPage();
+
+    expect(await screen.findByText('Workflow definition warnings')).toBeInTheDocument();
+    expect(screen.getAllByText('Workflow data is re-executed as shell code.')).toHaveLength(2);
+    expect(screen.getAllByRole('listitem')).toHaveLength(2);
+    expect(screen.getAllByText('jobs.build.steps.0.run')).toHaveLength(2);
+    expect(screen.queryByText('Workflow sync failed')).not.toBeInTheDocument();
   });
 
   test('opens and closes the definition drawer by clicking the row', async () => {
@@ -238,6 +286,7 @@ function baseDefinitionsDto() {
       finished_at: '2026-05-07T01:00:00.000Z',
       last_error_code: null,
       last_error_message: null,
+      warnings: [],
     },
   };
 }

--- a/libs/client/workflows/src/pages/project-workflows-page.tsx
+++ b/libs/client/workflows/src/pages/project-workflows-page.tsx
@@ -103,6 +103,7 @@ function ProjectWorkflowsPageInner({projectId}: {projectId: string}) {
           />
 
           <WorkflowSyncAlert sync={sync} />
+          <WorkflowSyncWarnings sync={sync} />
 
           <WorkflowDefinitionsList
             definitions={definitions}
@@ -369,6 +370,38 @@ function WorkflowSyncAlert({sync}: {sync: DefinitionSyncSummary | null | undefin
         <Text size="sm">
           {sync.lastErrorMessage ?? 'The latest workflow sync failed before definitions updated.'}
         </Text>
+      </div>
+    </Callout>
+  );
+}
+
+function WorkflowSyncWarnings({sync}: {sync: DefinitionSyncSummary | null | undefined}) {
+  if (sync?.status !== 'succeeded' || sync.warnings.length === 0) return null;
+
+  const seenKeys = new Map<string, number>();
+  const warningItems = sync.warnings.map((warning) => {
+    const baseKey = `${warning.code}-${warning.path ?? 'workflow'}-${warning.message}`;
+    const occurrence = seenKeys.get(baseKey) ?? 0;
+    seenKeys.set(baseKey, occurrence + 1);
+    return {key: `${baseKey}-${occurrence}`, warning};
+  });
+
+  return (
+    <Callout role="status" type="warning">
+      <div className="flex flex-col gap-6">
+        <Text size="sm" bold>
+          Workflow definition warnings
+        </Text>
+        <ul className="flex flex-col gap-4">
+          {warningItems.map(({key, warning}) => (
+            <li key={key}>
+              <Text size="sm">{warning.message}</Text>
+              {warning.path ? (
+                <Code className="text-foreground-neutral-muted">{warning.path}</Code>
+              ) : null}
+            </li>
+          ))}
+        </ul>
       </div>
     </Callout>
   );


### PR DESCRIPTION
Persist validation warnings from repository-backed workflow definitions through sync state and surface them on the workflow page.

This adds the sync-state JSONB storage and migration, carries warnings through Temporal sync activities, exposes them in the definitions DTO and client mapper, and renders them separately from sync failures. Warning payloads are bounded at persistence and DTO boundaries, and the parser, mapper, UI, and persistence regression coverage is included.

The actual warning producer remains a separate follow-up in ENG-1411; this PR handles the persistence and presentation contract without changing sync success, failure, or run-creation behavior.

Closes ENG-1409

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist validation warnings from repository-synced workflow definitions and show them on the workflow page, separate from sync failures. Implements ENG-1409 without changing sync success, failure, or run creation behavior.

- **New Features**
  - Store `warnings` on `definitions_sync_states` and expose via the Definition Sync Summary DTO, bounded by exported limits in `@shipfox/api-definitions-dto`.
  - Parse/validate now returns warnings; propagate through Temporal activities/workflow, persist on successful sync, and clear on new syncs and on failures.
  - Client maps DTO warnings and renders a "Workflow definition warnings" callout only when sync succeeds.
  - Updated test fixtures: e2e observer and flow suites include `warnings`; added tests for bounds, clearing, and UI mapping.

- **Migration**
  - Run DB migrations: adds `warnings` JSONB column to `definitions_sync_states` with default `[]`.

<sup>Written for commit 2fb50ca7ecbf7b00157cb3a37a794721ca264f15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

