### PR TITLE
[runner] Clean up runner job logs after crashes

### DIFF
--- a/libs/runner/orchestration/src/core/runner.test.ts
+++ b/libs/runner/orchestration/src/core/runner.test.ts
@@ -26,6 +26,7 @@ vi.mock('@shipfox/runner-workspace', async (importActual) => ({
   ...(await importActual<typeof import('@shipfox/runner-workspace')>()),
   cleanupJobCredentials: vi.fn(),
   cleanupJobLogs: vi.fn(),
+  cleanupOrphanedJobLogs: vi.fn(),
   jobCredentialsPath: vi.fn(),
   jobWorkspacePath: vi.fn(),
   jobLogsPath: vi.fn(),
@@ -97,6 +98,7 @@ import {
 import {
   cleanupJobCredentials,
   cleanupJobLogs,
+  cleanupOrphanedJobLogs,
   cleanupWorkspace,
   InvalidJobIdError,
   jobCredentialsPath,
@@ -116,6 +118,7 @@ const mockJobLogsPath = vi.mocked(jobLogsPath);
 const mockJobCredentialsPath = vi.mocked(jobCredentialsPath);
 const mockCleanupWorkspace = vi.mocked(cleanupWorkspace);
 const mockCleanupJobLogs = vi.mocked(cleanupJobLogs);
+const mockCleanupOrphanedJobLogs = vi.mocked(cleanupOrphanedJobLogs);
 const mockCleanupJobCredentials = vi.mocked(cleanupJobCredentials);
 const mockResolveWorkspaceRoot = vi.mocked(resolveWorkspaceRootFromEnv);
 const mockRunJobSteps = vi.mocked(runJobSteps);
@@ -313,6 +316,17 @@ describe('runJob', () => {
 });
 
 describe('startRunner', () => {
+  it('sweeps orphaned job logs before polling', async () => {
+    mockRequestJob.mockRejectedValue(new RunnerSessionExhaustedError());
+
+    await startRunner();
+
+    expect(mockCleanupOrphanedJobLogs).toHaveBeenCalledWith(WORKSPACE_ROOT);
+    expect(mockCleanupOrphanedJobLogs.mock.invocationCallOrder[0]).toBeLessThan(
+      mockRegisterRunnerSession.mock.invocationCallOrder[0] ?? Infinity,
+    );
+  });
+
   it('warns once when required Pi extensions are unavailable', async () => {
     const warn = vi.spyOn(logger(), 'warn').mockImplementation(() => undefined);
     isPiExtensionAvailableMock.mockImplementation(

--- a/libs/runner/orchestration/src/core/runner.ts
+++ b/libs/runner/orchestration/src/core/runner.ts
@@ -30,6 +30,7 @@ import {
 import {
   cleanupJobCredentials,
   cleanupJobLogs,
+  cleanupOrphanedJobLogs,
   cleanupWorkspace,
   jobCredentialsPath,
   jobLogsPath,
@@ -67,6 +68,7 @@ export async function startRunner(): Promise<void> {
   // Fail fast at startup: a dangerous root should crash the process at deploy,
   // not silently fail every job.
   const workspaceRoot = resolveWorkspaceRootFromEnv();
+  await cleanupOrphanedJobLogs(workspaceRoot);
   requireRunnerLabels();
   warnAboutUnavailablePiExtensions();
   const startupMode = runnerStartupMode();

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -48,6 +48,7 @@ const executeSetupStepMock = vi.fn();
 const createStepLogStreamMock = vi.fn();
 const createSessionLogStreamMock = vi.fn();
 const executeAgentStepMock = vi.fn();
+const createJobLogsDirMock = vi.fn();
 
 vi.mock('@shipfox/runner-protocol', () => ({
   requestNextStep: (...args: unknown[]) => requestNextStepMock(...args),
@@ -82,6 +83,7 @@ vi.mock('@shipfox/runner-agent', () => ({
 }));
 
 vi.mock('@shipfox/runner-workspace', () => ({
+  createJobLogsDir: (...args: unknown[]) => createJobLogsDirMock(...args),
   resolveWorkingDirectory: (cwd: string, workingDirectory: unknown) =>
     resolveWorkingDirectoryMock(cwd, workingDirectory),
 }));
@@ -218,6 +220,7 @@ describe('runJobSteps', () => {
       async (cwd: string, workingDirectory: unknown) =>
         workingDirectory === undefined ? cwd : `${cwd}/${String(workingDirectory)}`,
     );
+    createJobLogsDirMock.mockReset();
     requestAgentRuntimeConfigMock.mockResolvedValue({
       harness: 'pi',
       provider_id: 'anthropic',
@@ -239,6 +242,7 @@ describe('runJobSteps', () => {
     executeSetupStepMock.mockResolvedValue({
       result: {success: true, error: null, exit_code: 0},
     });
+    createJobLogsDirMock.mockResolvedValue(undefined);
     createStepLogStreamMock.mockImplementation((opts: {stepId: string}) => {
       events.push(`create:${opts.stepId}`);
       return makeFakeStream(opts.stepId);
@@ -988,6 +992,45 @@ describe('runJobSteps', () => {
     expect(events).toContain(`drain:${setup.id}`);
     expect(events).toContain(`dispose:${setup.id}`);
     expect(requestNextStepMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports log directory preparation failures through the setup step', async () => {
+    const setup = buildSetupStep();
+    const error = {message: 'disk full', reason: 'workspace_prep_failed' as const};
+    requestNextStepMock.mockResolvedValueOnce(stepResponse(setup, 1));
+    createJobLogsDirMock.mockRejectedValueOnce(new Error(error.message));
+    reportStepMock.mockResolvedValueOnce({ok: true, cancel: true});
+    const ac = new AbortController();
+
+    await runLoop({signal: ac.signal});
+
+    expect(createJobLogsDirMock).toHaveBeenCalledWith(LOGS_DIR);
+    expect(createStepLogStreamMock).not.toHaveBeenCalled();
+    expect(reportStepMock).toHaveBeenCalledWith(leaseClient, {
+      stepId: setup.id,
+      attempt: 1,
+      status: 'failed',
+      error,
+      exitCode: null,
+      logOutcome: 'abandoned',
+      signal: ac.signal,
+    });
+    expect(executeSetupStepMock).not.toHaveBeenCalled();
+  });
+
+  it('prepares the log directory once across setup retries', async () => {
+    const setup = buildSetupStep();
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(setup, 2))
+      .mockResolvedValueOnce({kind: 'done', status: 'succeeded'});
+    const ac = new AbortController();
+
+    await runLoop({signal: ac.signal});
+
+    expect(createJobLogsDirMock).toHaveBeenCalledOnce();
+    expect(createJobLogsDirMock).toHaveBeenCalledWith(LOGS_DIR);
+    expect(executeSetupStepMock).toHaveBeenCalledTimes(2);
   });
 
   it('fails a run step dispatched before setup without spawning it', async () => {

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -38,7 +38,7 @@ import {
   StepSecretsRequestError,
   writeStepAnnotations,
 } from '@shipfox/runner-protocol';
-import {resolveWorkingDirectory} from '@shipfox/runner-workspace';
+import {createJobLogsDir, resolveWorkingDirectory} from '@shipfox/runner-workspace';
 import type {KyInstance} from 'ky';
 
 const WHITESPACE_REGEX = /\s+/;
@@ -71,6 +71,7 @@ export async function runJobSteps(params: {
   // step pulled before a successful setup is failed cleanly rather than spawned
   // against an unprepared cwd.
   let workspacePrepared = false;
+  let logsPrepared = false;
   let ambientGitConfigPath: string | undefined;
 
   // The most recent step's stream, kept until the next
@@ -97,6 +98,13 @@ export async function runJobSteps(params: {
         `Running ${stepLabel}`,
       );
 
+      const prepareLogs =
+        step.type === 'setup' && !logsPrepared
+          ? async () => {
+              await createJobLogsDir(logsDir);
+              logsPrepared = true;
+            }
+          : undefined;
       const execution = await executeStep({
         step,
         attempt,
@@ -113,6 +121,7 @@ export async function runJobSteps(params: {
         logsDir,
         jobContext,
         gitConfigPath,
+        ...(prepareLogs ? {prepareLogs} : {}),
       });
       activeStream = execution.stream;
       if (execution.preparedWorkspace) workspacePrepared = true;
@@ -223,6 +232,7 @@ export async function executeStep(params: {
   gitConfigPath: string;
   jobId: string;
   stepLabel: string;
+  prepareLogs?: (() => Promise<void>) | undefined;
 }): Promise<StepExecution> {
   const {
     step,
@@ -240,6 +250,7 @@ export async function executeStep(params: {
     gitConfigPath,
     jobId,
     stepLabel,
+    prepareLogs,
   } = params;
 
   let stream: LogStreamLifecycle | undefined;
@@ -276,6 +287,19 @@ export async function executeStep(params: {
       });
 
     if (step.type === 'setup') {
+      if (prepareLogs) {
+        try {
+          await prepareLogs();
+        } catch (error) {
+          const result = setupLogDirectoryFailure(error);
+          logger().warn(
+            {err: error, jobId, stepId: step.id, attempt, reason: result.error?.reason},
+            'Setup step failed',
+          );
+          return {result, logOutcome: 'abandoned', preparedWorkspace: false};
+        }
+      }
+
       let setupStream: StepLogStream | undefined;
       try {
         setupStream = createStepLogStream({
@@ -564,6 +588,17 @@ function stepSecretsFailure(error: unknown): StepResult {
     error: {
       message: error instanceof Error ? error.message : 'Run step secrets could not be resolved.',
       reason: 'config_unresolvable',
+    },
+    exit_code: null,
+  };
+}
+
+function setupLogDirectoryFailure(error: unknown): StepResult {
+  return {
+    success: false,
+    error: {
+      message: error instanceof Error ? error.message : String(error),
+      reason: 'workspace_prep_failed',
     },
     exit_code: null,
   };

--- a/libs/runner/workspace/src/index.ts
+++ b/libs/runner/workspace/src/index.ts
@@ -19,8 +19,10 @@ export {
 export {
   cleanupJobCredentials,
   cleanupJobLogs,
+  cleanupOrphanedJobLogs,
   cleanupWorkspace,
   createJobDir,
+  createJobLogsDir,
   InvalidJobIdError,
   jobCredentialsPath,
   jobLogsPath,

--- a/libs/runner/workspace/src/workspace.test.ts
+++ b/libs/runner/workspace/src/workspace.test.ts
@@ -4,8 +4,10 @@ import {join} from 'node:path';
 import {
   cleanupJobCredentials,
   cleanupJobLogs,
+  cleanupOrphanedJobLogs,
   cleanupWorkspace,
   createJobDir,
+  createJobLogsDir,
   InvalidJobIdError,
   jobCredentialsPath,
   jobLogsPath,
@@ -128,6 +130,74 @@ describe('createJobDir', () => {
 
     const readStale = () => stat(join(cwd, 'stale.txt'));
     await expect(readStale()).rejects.toThrow();
+  });
+});
+
+describe('createJobLogsDir', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'shipfox-job-logs-create-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(root, {recursive: true, force: true});
+  });
+
+  it('creates the per-job log directory', async () => {
+    const logsDir = join(root, 'job-11111111-1111-4111-8111-111111111111');
+
+    await createJobLogsDir(logsDir);
+
+    expect((await stat(logsDir)).isDirectory()).toBe(true);
+  });
+
+  it('pre-cleans a dirty directory left from a previous run', async () => {
+    const logsDir = join(root, 'job-22222222-2222-4222-8222-222222222222');
+    await createJobLogsDir(logsDir);
+    await writeFile(join(logsDir, 'stale.ndjson'), '{}\n');
+
+    await createJobLogsDir(logsDir);
+
+    const readStale = () => stat(join(logsDir, 'stale.ndjson'));
+    await expect(readStale()).rejects.toThrow();
+  });
+});
+
+describe('cleanupOrphanedJobLogs', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'shipfox-job-logs-sweep-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(root, {recursive: true, force: true});
+  });
+
+  it('removes UUID-named job directories and preserves unrelated entries', async () => {
+    const logsRoot = join(root, '.shipfox-runner-logs');
+    const orphan = join(logsRoot, 'job-33333333-3333-4333-8333-333333333333');
+    const otherJob = join(logsRoot, 'job-not-a-uuid');
+    const unrelatedUuidDir = join(logsRoot, 'other-33333333-3333-4333-8333-333333333333');
+    const file = join(logsRoot, 'README');
+    await mkdir(orphan, {recursive: true});
+    await writeFile(join(orphan, 'setup.ndjson'), '{}\n');
+    await mkdir(otherJob, {recursive: true});
+    await mkdir(unrelatedUuidDir, {recursive: true});
+    await writeFile(file, 'keep');
+
+    await cleanupOrphanedJobLogs(root);
+
+    await expect(stat(orphan)).rejects.toThrow();
+    expect((await stat(otherJob)).isDirectory()).toBe(true);
+    expect((await stat(unrelatedUuidDir)).isDirectory()).toBe(true);
+    expect((await stat(file)).isFile()).toBe(true);
+    expect((await stat(logsRoot)).isDirectory()).toBe(true);
+  });
+
+  it('does not throw when the runner log root is missing', async () => {
+    await expect(cleanupOrphanedJobLogs(root)).resolves.toBeUndefined();
   });
 });
 

--- a/libs/runner/workspace/src/workspace.ts
+++ b/libs/runner/workspace/src/workspace.ts
@@ -1,4 +1,5 @@
-import {mkdir, rm} from 'node:fs/promises';
+import type {Dirent} from 'node:fs';
+import {mkdir, readdir, rm} from 'node:fs/promises';
 import {homedir, tmpdir} from 'node:os';
 import {join, parse, resolve} from 'node:path';
 import {logger} from '@shipfox/node-opentelemetry';
@@ -90,14 +91,54 @@ export function jobCredentialsPath(jobId: string, root: string): string {
 }
 
 /**
- * Pre-cleans the per-job directory before creating it, so a directory left by a
- * previous crash is never reused. Run inside the setup step so a prep failure is
- * reported through the step protocol rather than bailing the job.
+ * Pre-cleans a per-job directory before recreating it, so a directory left by a
+ * previous crash is never reused.
+ */
+async function resetDir(dir: string): Promise<void> {
+  await rm(dir, {recursive: true, force: true});
+  await mkdir(dir, {recursive: true});
+}
+
+/**
+ * Run inside the setup step so a prep failure is reported through the step
+ * protocol rather than bailing the job.
  */
 export async function createJobDir(cwd: string): Promise<void> {
-  // Pre-clean the per-job directory only — never the configured root.
-  await rm(cwd, {recursive: true, force: true});
-  await mkdir(cwd, {recursive: true});
+  await resetDir(cwd);
+}
+
+/**
+ * Resets the runner-owned log directory before a job can reuse it after a crash.
+ */
+export async function createJobLogsDir(logsDir: string): Promise<void> {
+  await resetDir(logsDir);
+}
+
+/**
+ * Removes only UUID-named per-job log directories left under the runner log root.
+ * The log root itself and unrelated entries are preserved.
+ */
+export async function cleanupOrphanedJobLogs(root: string): Promise<void> {
+  const logsRoot = join(root, RUNNER_LOGS_DIR);
+  let entries: Dirent[];
+  try {
+    entries = await readdir(logsRoot, {withFileTypes: true});
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return;
+    logger().warn({err, logsRoot}, 'Failed to sweep orphaned job logs');
+    return;
+  }
+
+  await Promise.all(
+    entries
+      .filter(
+        (entry) =>
+          entry.isDirectory() &&
+          entry.name.startsWith('job-') &&
+          isUuid(entry.name.slice('job-'.length)),
+      )
+      .map((entry) => cleanupJobLogs(join(logsRoot, entry.name))),
+  );
 }
 
 /**


### PR DESCRIPTION
Runner job logs could survive a SIGKILL or hard runner crash because cleanup only ran from `runJob`'s `finally` block.

This change:

- pre-cleans the per-job log directory once before setup capture starts;
- sweeps orphaned UUID-named job directories at runner startup while preserving unrelated entries; and
- reports log-directory preparation failures through the setup StepResult instead of letting the lease expire silently.

Closes ENG-1416

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans up runner job logs after crashes by resetting each job’s log directory once at setup and sweeping orphaned job log directories on startup before session registration. Reports log-prep failures via the setup result so jobs fail fast instead of letting leases expire. Closes ENG-1416.

- **Bug Fixes**
  - Reset the per-job log directory once per job before the first setup log capture.
  - Sweep UUID-named orphaned job log directories at startup before registering the runner session, preserving unrelated entries.
  - Report log-directory preparation failures as a setup `StepResult` with reason `workspace_prep_failed`.

<sup>Written for commit 152a0cca95a56b5995b32c99b0082eb2dedd3e23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

