### PR TITLE
Allow workflow variables in job and gate predicates

### DIFF
--- a/.changeset/allow-vars-in-predicates.md
+++ b/.changeset/allow-vars-in-predicates.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-definitions": patch
+---
+
+Allow workflow variables in job, step, gate, and listener predicates while preserving the standard availability error for trigger filters.

--- a/e2e/suites/flow/workflows/scenarios/vars-job-condition-disabled/expect.yaml
+++ b/e2e/suites/flow/workflows/scenarios/vars-job-condition-disabled/expect.yaml
@@ -1,0 +1,6 @@
+trigger: push
+run:
+  status: succeeded
+jobs:
+  publish:
+    status: skipped

--- a/e2e/suites/flow/workflows/scenarios/vars-job-condition-disabled/variables.yaml
+++ b/e2e/suites/flow/workflows/scenarios/vars-job-condition-disabled/variables.yaml
@@ -1,0 +1,3 @@
+variables:
+  - key: PUBLISHING_ENABLED
+    value: "false"

--- a/e2e/suites/flow/workflows/scenarios/vars-job-condition-disabled/workflow.yml
+++ b/e2e/suites/flow/workflows/scenarios/vars-job-condition-disabled/workflow.yml
@@ -1,0 +1,13 @@
+name: Vars job condition disabled
+runner: __RUNNER_LABEL__
+triggers:
+  on_push:
+    source: __GITEA_SOURCE__
+    event: push
+    filter: 'event.ref == "refs/heads/main" && event.repository.full_name == "__GITEA_REPOSITORY__"'
+jobs:
+  publish:
+    if: '${{ vars.PUBLISHING_ENABLED == "true" }}'
+    steps:
+      - key: publish
+        run: echo "published"

--- a/e2e/suites/flow/workflows/scenarios/vars-job-condition-enabled/expect.yaml
+++ b/e2e/suites/flow/workflows/scenarios/vars-job-condition-enabled/expect.yaml
@@ -1,0 +1,12 @@
+trigger: push
+run:
+  status: succeeded
+jobs:
+  publish:
+    status: succeeded
+    steps:
+      publish:
+        status: succeeded
+        exit_code: 0
+        logs:
+          include: ["published"]

--- a/e2e/suites/flow/workflows/scenarios/vars-job-condition-enabled/variables.yaml
+++ b/e2e/suites/flow/workflows/scenarios/vars-job-condition-enabled/variables.yaml
@@ -1,0 +1,3 @@
+variables:
+  - key: PUBLISHING_ENABLED
+    value: "true"

--- a/e2e/suites/flow/workflows/scenarios/vars-job-condition-enabled/workflow.yml
+++ b/e2e/suites/flow/workflows/scenarios/vars-job-condition-enabled/workflow.yml
@@ -1,0 +1,13 @@
+name: Vars job condition enabled
+runner: __RUNNER_LABEL__
+triggers:
+  on_push:
+    source: __GITEA_SOURCE__
+    event: push
+    filter: 'event.ref == "refs/heads/main" && event.repository.full_name == "__GITEA_REPOSITORY__"'
+jobs:
+  publish:
+    if: '${{ vars.PUBLISHING_ENABLED == "true" }}'
+    steps:
+      - key: publish
+        run: echo "published"

--- a/e2e/suites/flow/workflows/src/run-scenario.ts
+++ b/e2e/suites/flow/workflows/src/run-scenario.ts
@@ -3,7 +3,7 @@ import {createApiClient} from '@shipfox/e2e-core';
 import {readFakeOpenAiModelProviderState} from '@shipfox/e2e-driver-model-provider';
 import {type LocalRunnerHandle, stopLocalRunner} from '@shipfox/e2e-driver-runner-process';
 import {fetchStepLogs} from '@shipfox/e2e-observe-logs';
-import {createSecret} from '@shipfox/e2e-setup-secrets';
+import {createSecret, createVariable} from '@shipfox/e2e-setup-secrets';
 import type {Attachment} from './attachments.js';
 import {
   attachLocalRunnerLog,
@@ -106,6 +106,16 @@ export async function runScenario(params: RunScenarioParams): Promise<Mismatch[]
         key: secret.key,
         value: secret.value,
         ...(secret.scope === 'project' ? {projectId: project.id} : {}),
+      });
+    }
+
+    for (const variable of scenario.seededVariables) {
+      await createVariable({
+        workspaceId: suite.workspaceId,
+        actorId: E2E_SECRET_ACTOR_ID,
+        key: variable.key,
+        value: variable.value,
+        ...(variable.scope === 'project' ? {projectId: project.id} : {}),
       });
     }
 

--- a/e2e/suites/flow/workflows/src/scenarios.test.ts
+++ b/e2e/suites/flow/workflows/src/scenarios.test.ts
@@ -56,6 +56,28 @@ describe('discoverScenarios', () => {
     }
   });
 
+  test('loads optional scenario variables', () => {
+    const root = createTempScenariosRoot();
+    try {
+      writeScenarioFile(root, 'with-variables', 'expect.yaml', 'run:\n  status: succeeded\n');
+      writeScenarioFile(root, 'with-variables', 'workflow.yml', 'jobs:\n  build:\n    steps: []\n');
+      writeScenarioFile(
+        root,
+        'with-variables',
+        'variables.yaml',
+        'variables:\n  - key: PUBLISHING_ENABLED\n    value: "true"\n',
+      );
+
+      const scenarios = discoverScenarios(root);
+
+      expect(scenarios[0]).toMatchObject({
+        seededVariables: [{key: 'PUBLISHING_ENABLED', value: 'true', scope: 'project'}],
+      });
+    } finally {
+      rmSync(root, {recursive: true, force: true});
+    }
+  });
+
   test('loads optional fake model provider script metadata', () => {
     const root = createTempScenariosRoot();
     try {

--- a/e2e/suites/flow/workflows/src/scenarios.ts
+++ b/e2e/suites/flow/workflows/src/scenarios.ts
@@ -6,7 +6,7 @@ import {z} from 'zod';
 import {type Expectation, parseExpectation} from './expect.js';
 import {parseRejection, type Rejection} from './reject.js';
 
-const seededSecretSchema = z
+const seededKeyValueSchema = z
   .object({
     key: z.string().min(1),
     value: z.string(),
@@ -16,21 +16,13 @@ const seededSecretSchema = z
 
 const seededSecretsSchema = z
   .object({
-    secrets: z.array(seededSecretSchema).default([]),
-  })
-  .strict();
-
-const seededVariableSchema = z
-  .object({
-    key: z.string().min(1),
-    value: z.string(),
-    scope: z.enum(['workspace', 'project']).default('project'),
+    secrets: z.array(seededKeyValueSchema).default([]),
   })
   .strict();
 
 const seededVariablesSchema = z
   .object({
-    variables: z.array(seededVariableSchema).default([]),
+    variables: z.array(seededKeyValueSchema).default([]),
   })
   .strict();
 
@@ -40,8 +32,8 @@ const modelProviderSchema = z
   })
   .strict();
 
-export type SeededSecret = z.infer<typeof seededSecretSchema>;
-export type SeededVariable = z.infer<typeof seededVariableSchema>;
+export type SeededSecret = z.infer<typeof seededKeyValueSchema>;
+export type SeededVariable = z.infer<typeof seededKeyValueSchema>;
 
 export interface ScenarioFile {
   path: string;

--- a/e2e/suites/flow/workflows/src/scenarios.ts
+++ b/e2e/suites/flow/workflows/src/scenarios.ts
@@ -20,6 +20,20 @@ const seededSecretsSchema = z
   })
   .strict();
 
+const seededVariableSchema = z
+  .object({
+    key: z.string().min(1),
+    value: z.string(),
+    scope: z.enum(['workspace', 'project']).default('project'),
+  })
+  .strict();
+
+const seededVariablesSchema = z
+  .object({
+    variables: z.array(seededVariableSchema).default([]),
+  })
+  .strict();
+
 const modelProviderSchema = z
   .object({
     script_key: z.string().min(1),
@@ -27,6 +41,7 @@ const modelProviderSchema = z
   .strict();
 
 export type SeededSecret = z.infer<typeof seededSecretSchema>;
+export type SeededVariable = z.infer<typeof seededVariableSchema>;
 
 export interface ScenarioFile {
   path: string;
@@ -40,6 +55,7 @@ interface BaseScenario {
   workflowYaml: string;
   extraFiles: ScenarioFile[];
   seededSecrets: SeededSecret[];
+  seededVariables: SeededVariable[];
   fakeModelProviderScriptKey?: string | undefined;
 }
 
@@ -89,6 +105,12 @@ function loadSeededSecrets(dir: string): SeededSecret[] {
   return seededSecretsSchema.parse(yaml.load(readFileSync(path, 'utf8'))).secrets;
 }
 
+function loadSeededVariables(dir: string): SeededVariable[] {
+  const path = join(dir, 'variables.yaml');
+  if (!existsSync(path)) return [];
+  return seededVariablesSchema.parse(yaml.load(readFileSync(path, 'utf8'))).variables;
+}
+
 function loadModelProviderScriptKey(dir: string): string | undefined {
   const path = join(dir, 'model-provider.yaml');
   if (!existsSync(path)) return undefined;
@@ -114,6 +136,7 @@ function loadScenario(root: string, name: string): Scenario {
     workflowYaml: readFileSync(workflowPath, 'utf8'),
     extraFiles: readScenarioFiles(join(dir, 'files')),
     seededSecrets: loadSeededSecrets(dir),
+    seededVariables: loadSeededVariables(dir),
     fakeModelProviderScriptKey: loadModelProviderScriptKey(dir),
   };
 

--- a/libs/api/definitions/src/core/workflow-model/invalid-workflow-model-error.ts
+++ b/libs/api/definitions/src/core/workflow-model/invalid-workflow-model-error.ts
@@ -52,8 +52,7 @@ export type WorkflowModelValidationIssueCode =
   | 'unknown-integration-tool'
   | 'unknown-job-dependency'
   | 'unsupported-checkout'
-  | 'untrusted-agent-selection-context'
-  | 'vars-context-in-server-predicate';
+  | 'untrusted-agent-selection-context';
 
 export type WorkflowModelValidationIssuePathSegment = string | number;
 

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -1890,7 +1890,7 @@ describe('normalizeWorkflowDocument', () => {
     ]);
   });
 
-  it('rejects vars in gate success with a server-predicate issue', () => {
+  it('accepts vars in gate success', () => {
     const document: WorkflowDocument = {
       name: 'vars-context gate',
       jobs: {
@@ -1900,21 +1900,12 @@ describe('normalizeWorkflowDocument', () => {
       },
     };
 
-    const error = expectInvalid(document);
+    const model = normalizeWorkflowDocument(document);
 
-    expect(error.issues).toEqual([
-      expect.objectContaining({
-        code: 'vars-context-in-server-predicate',
-        message: expect.stringContaining('cannot reference vars'),
-        path: ['jobs', 'build', 'steps', 0, 'gate', 'success'],
-        details: expect.objectContaining({
-          field: 'step.success',
-          source: 'vars.REQUIRED == "true"',
-          rejectedRoots: ['vars'],
-          site: 'step-report',
-        }),
-      }),
-    ]);
+    expect(model.jobs[0]?.steps[0]?.gate?.success).toMatchObject({
+      source: 'vars.REQUIRED == "true"',
+      check: 'syntax',
+    });
   });
 
   it('accepts jobs root references at the gate predicate site', () => {
@@ -2563,29 +2554,29 @@ describe('normalizeWorkflowDocument', () => {
     );
   });
 
-  it('rejects vars roots in if predicates', () => {
+  it('accepts vars in job and step if predicates', () => {
     const document: WorkflowDocument = {
       name: 'vars condition',
       jobs: {
         build: {
           if: interpolation('vars.REQUIRED == "true"'),
-          steps: [{run: 'npm run build'}],
+          steps: [{if: interpolation('vars.REQUIRED == "true"'), run: 'npm run build'}],
         },
       },
     };
 
-    const error = expectInvalid(document);
+    const model = normalizeWorkflowDocument(document);
 
-    expect(error.issues).toEqual([
-      expect.objectContaining({
-        code: 'vars-context-in-server-predicate',
-        path: ['jobs', 'build', 'if'],
-        details: expect.objectContaining({
-          field: 'job.if',
-          rejectedRoots: ['vars'],
-        }),
-      }),
-    ]);
+    expect(model.jobs[0]?.if).toMatchObject({
+      source: 'vars.REQUIRED == "true"',
+      check: 'typed',
+      resultType: 'bool',
+    });
+    expect(model.jobs[0]?.steps[0]?.if).toMatchObject({
+      source: 'vars.REQUIRED == "true"',
+      check: 'typed',
+      resultType: 'bool',
+    });
   });
 
   it('rejects if job references without a direct needs edge', () => {
@@ -2818,7 +2809,7 @@ describe('normalizeWorkflowDocument', () => {
     ]);
   });
 
-  it('rejects vars in job success with a server-predicate issue', () => {
+  it('accepts vars in job success', () => {
     const document: WorkflowDocument = {
       name: 'vars-context job success',
       jobs: {
@@ -2829,21 +2820,9 @@ describe('normalizeWorkflowDocument', () => {
       },
     };
 
-    const error = expectInvalid(document);
+    const model = normalizeWorkflowDocument(document);
 
-    expect(error.issues).toEqual([
-      expect.objectContaining({
-        code: 'vars-context-in-server-predicate',
-        message: expect.stringContaining('cannot reference vars'),
-        path: ['jobs', 'build', 'success'],
-        details: expect.objectContaining({
-          field: 'job.success',
-          source: 'vars.ENVIRONMENT == "prod"',
-          rejectedRoots: ['vars'],
-          site: 'job-resolution',
-        }),
-      }),
-    ]);
+    expect(model.jobs[0]?.success).toBe('vars.ENVIRONMENT == "prod"');
   });
 
   it('reports malformed job execution timeouts', () => {
@@ -3356,12 +3335,12 @@ describe('normalizeWorkflowDocument', () => {
     [
       'vars root',
       'vars.environment == "prod"',
-      'vars-context-in-server-predicate',
+      'context-unavailable-at-predicate-site',
       {
         field: 'trigger.filter',
         source: 'vars.environment == "prod"',
         contextRoots: ['vars'],
-        rejectedRoots: ['vars'],
+        unavailableRoots: ['vars'],
         site: 'ingest',
       },
     ],

--- a/libs/api/definitions/src/core/workflow-model/validate-predicate-expression.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/validate-predicate-expression.test.ts
@@ -64,6 +64,7 @@ describe('validatePredicateExpression', () => {
     'run.id == "run-1"',
     'inputs.env == "prod"',
     'jobs.build.status == "succeeded"',
+    'vars.ENV == "prod"',
   ])('rejects trigger filter roots that are unavailable at ingest: %s', (source) => {
     const result = validate({field: 'trigger.filter', source, site: 'ingest'});
 
@@ -78,7 +79,6 @@ describe('validatePredicateExpression', () => {
 
   it.each([
     ['runner.os == "linux"', 'runner-context-in-server-predicate'],
-    ['vars.ENV == "prod"', 'vars-context-in-server-predicate'],
   ])('rejects forbidden server predicate roots: %s', (source, code) => {
     const result = validate({field: 'trigger.filter', source, site: 'ingest'});
 
@@ -89,6 +89,24 @@ describe('validatePredicateExpression', () => {
         details: expect.objectContaining({field: 'trigger.filter', source}),
       }),
     ]);
+  });
+
+  it.each([
+    ['job.if', 'job-activation'],
+    ['step.if', 'step-dispatch'],
+    ['step.success', 'step-report'],
+    ['job.success', 'job-resolution'],
+    ['listener.on', 'job-activation'],
+    ['listener.until', 'job-activation'],
+  ] as const)('accepts vars in %s at its evaluation site', (field, site) => {
+    const result = validate({
+      field,
+      source: 'vars.ENABLED == "true"',
+      site,
+    });
+
+    expect(result.issues).toEqual([]);
+    expect(result.expression).toMatchObject({source: 'vars.ENABLED == "true"'});
   });
 
   it.each([

--- a/libs/api/definitions/src/core/workflow-model/validate-predicate-expression.ts
+++ b/libs/api/definitions/src/core/workflow-model/validate-predicate-expression.ts
@@ -64,12 +64,6 @@ export function validatePredicateExpression(params: {
     return undefined;
   }
 
-  const varsRoots = knownRoots.filter((root) => root === 'vars');
-  if (varsRoots.length > 0) {
-    params.issues.push(varsContextInServerPredicateIssue({...params, contextRoots}));
-    return undefined;
-  }
-
   const unavailableRoots = knownRoots.filter((root) => !isRootAvailableAt(root, params.site));
   if (unavailableRoots.length > 0) {
     params.issues.push(
@@ -236,27 +230,6 @@ function runnerContextInServerPredicateIssue(params: {
       source: params.source,
       contextRoots: params.contextRoots,
       runnerRoots: params.runnerRoots,
-      site: params.site,
-    },
-  });
-}
-
-function varsContextInServerPredicateIssue(params: {
-  field: WorkflowPredicateField;
-  source: string;
-  site: AvailabilitySite;
-  path: readonly WorkflowModelValidationIssuePathSegment[];
-  contextRoots: readonly string[];
-}): WorkflowModelValidationIssue {
-  return issue({
-    code: 'vars-context-in-server-predicate',
-    message: `${fieldLabel(params.field)} cannot reference vars because predicate evaluation does not include workflow variables.`,
-    path: params.path,
-    details: {
-      field: params.field,
-      source: params.source,
-      contextRoots: params.contextRoots,
-      rejectedRoots: ['vars'],
       site: params.site,
     },
   });


### PR DESCRIPTION
Allow workflow variables in server-evaluated predicates now that run-creation variable snapshots are available.

The validator now relies on the existing predicate-site availability rules instead of the obsolete vars-specific rejection. This enables job and step conditions, job success, gate success, and listener filters at their evaluation sites. Trigger filters remain rejected at ingest, and secrets remain blocked by server-evaluability checks.

The PR also adds scenario variable seeding and enabled/disabled declarative E2E coverage for the feature-flag pattern.

Closes ENG-1408

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow workflow variables in server‑evaluated predicates for jobs, steps, gates, and listeners using run‑creation variable snapshots. Satisfies ENG‑1408; trigger filters still block vars at ingest and secret roots remain forbidden.

- **New Features**
  - Enable vars in job.if, step.if, job.success, gate.success, and listener.on/until at their evaluation sites.
  - Remove the vars‑specific validator issue; rely on standard predicate‑site availability checks.
  - Add E2E scenarios and runner support to seed variables from variables.yaml (project/workspace scope) to test a vars.PUBLISHING_ENABLED flag.

- **Refactors**
  - Deduplicate the E2E seeded value schema and reuse it for both secrets and variables.

<sup>Written for commit 2e91be3f6338aba9083207bb1f02386a5dbb0bb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

