### PR TITLE
Carry checkout steps through workflow materialization

### DIFF
--- a/.changeset/checkout-step-materialization.md
+++ b/.changeset/checkout-step-materialization.md
@@ -1,0 +1,8 @@
+---
+"@shipfox/api-definitions-dto": minor
+"@shipfox/api-definitions": minor
+"@shipfox/api-workflows": minor
+"@shipfox/client-workflows": patch
+---
+
+Carry checkout steps from workflow normalization through step materialization and surface their setup error category.

--- a/apps/docs/content/docs/reference/workflow-schema.mdx
+++ b/apps/docs/content/docs/reference/workflow-schema.mdx
@@ -55,9 +55,6 @@ workflow.
 Each step is either a run step, an agent step, or a checkout step. The schema
 rejects unknown fields and invalid field combinations.
 
-Checkout steps are defined in the schema. Model normalization and runtime
-execution support are tracked separately.
-
 ### Run step fields
 
 <RunStepFields />

--- a/libs/api/definitions-dto/src/workflow-model.ts
+++ b/libs/api/definitions-dto/src/workflow-model.ts
@@ -15,6 +15,18 @@ export interface WorkflowModelJobCheckout {
   readonly persistCredentials: boolean;
 }
 
+export interface WorkflowModelStepCheckout {
+  readonly project?: string;
+  readonly connection?: string;
+  readonly repository?: string;
+  readonly ref?: string;
+  readonly fetchDepth: number;
+  readonly path?: string;
+  readonly permissions: {readonly contents: 'read' | 'write'};
+  readonly persistCredentials: boolean;
+  readonly force?: boolean;
+}
+
 export const DEFAULT_JOB_CHECKOUT: WorkflowModelJobCheckout = {
   permissions: {contents: 'read'},
   persistCredentials: true,
@@ -85,7 +97,10 @@ export interface WorkflowModelListeningBatch {
   readonly maxSize?: number;
   readonly maxWaitMs?: number;
 }
-export type WorkflowModelStep = WorkflowModelRunStep | WorkflowModelAgentStep;
+export type WorkflowModelStep =
+  | WorkflowModelRunStep
+  | WorkflowModelAgentStep
+  | WorkflowModelCheckoutStep;
 interface WorkflowModelStepBase {
   readonly id: string;
   readonly key?: string;
@@ -118,6 +133,13 @@ export interface WorkflowModelAgentStep extends WorkflowModelStepBase {
     readonly prompt?: WorkflowFieldTemplate;
     readonly model?: WorkflowFieldTemplate;
     readonly provider?: WorkflowFieldTemplate;
+    readonly name?: WorkflowFieldTemplate;
+  };
+}
+export interface WorkflowModelCheckoutStep extends WorkflowModelStepBase {
+  readonly kind: 'checkout';
+  readonly checkout: WorkflowModelStepCheckout;
+  readonly templates?: {
     readonly name?: WorkflowFieldTemplate;
   };
 }

--- a/libs/api/definitions-dto/src/workflow-model.ts
+++ b/libs/api/definitions-dto/src/workflow-model.ts
@@ -140,6 +140,7 @@ export interface WorkflowModelCheckoutStep extends WorkflowModelStepBase {
   readonly kind: 'checkout';
   readonly checkout: WorkflowModelStepCheckout;
   readonly templates?: {
+    readonly workingDirectory?: WorkflowFieldTemplate;
     readonly name?: WorkflowFieldTemplate;
   };
 }

--- a/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
@@ -1,4 +1,5 @@
 import type {AgentValidationCatalog} from '@shipfox/api-agent-dto/inter-module';
+import {DEFAULT_JOB_CHECKOUT} from '@shipfox/api-definitions-dto';
 import {
   type AvailabilitySite,
   buildTypedRootsEnvironment,
@@ -24,9 +25,11 @@ import type {
   WorkflowEnvTemplates,
   WorkflowFieldTemplate,
   WorkflowModelAgentStep,
+  WorkflowModelCheckoutStep,
   WorkflowModelJob,
   WorkflowModelRunStep,
   WorkflowModelStep,
+  WorkflowModelStepCheckout,
   WorkflowOutputTemplates,
   WorkflowStepSourceLocationMap,
 } from '../entities/workflow-model.js';
@@ -640,18 +643,43 @@ function normalizeStep(params: {
   }
 
   if (params.step.checkout !== undefined) {
-    params.issues.push(
-      issue({
-        code: 'unsupported-checkout',
-        message: 'Checkout steps are not supported by the workflow model yet.',
-        path: ['jobs', params.sourceName, 'steps', params.index, 'checkout'],
-      }),
-    );
-    return undefined;
+    return normalizeCheckoutStep({step: params.step, stepBase, name});
   }
 
   // Keep the model-step union honest if callers bypass the document parser.
-  throw new Error(`Workflow step "${stepId}" is neither a run nor an agent step`);
+  throw new Error(`Workflow step "${stepId}" is neither a run, agent, nor checkout step`);
+}
+
+function normalizeCheckoutStep(params: {
+  step: WorkflowDocumentStep;
+  stepBase: WorkflowModelStepBaseFields;
+  name: WorkflowFieldTemplate | undefined;
+}): WorkflowModelCheckoutStep {
+  const checkout = params.step.checkout;
+  if (checkout === undefined) {
+    throw new Error('Checkout step normalization requires checkout settings');
+  }
+
+  const normalizedCheckout: WorkflowModelStepCheckout = {
+    ...(checkout.project === undefined ? {} : {project: checkout.project}),
+    ...(checkout.connection === undefined ? {} : {connection: checkout.connection}),
+    ...(checkout.repository === undefined ? {} : {repository: checkout.repository}),
+    ...(checkout.ref === undefined ? {} : {ref: checkout.ref}),
+    fetchDepth: checkout['fetch-depth'] ?? 1,
+    ...(checkout.path === undefined ? {} : {path: checkout.path}),
+    permissions: {
+      contents: checkout.permissions?.contents ?? DEFAULT_JOB_CHECKOUT.permissions.contents,
+    },
+    persistCredentials: checkout['persist-credentials'] ?? DEFAULT_JOB_CHECKOUT.persistCredentials,
+    ...(checkout.force === undefined ? {} : {force: checkout.force}),
+  };
+
+  return {
+    ...params.stepBase,
+    kind: 'checkout',
+    checkout: normalizedCheckout,
+    ...(params.name === undefined ? {} : {templates: {name: params.name}}),
+  };
 }
 
 function normalizeRunStep(params: {

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -1056,22 +1056,43 @@ describe('normalizeWorkflowDocument', () => {
     );
   });
 
-  it('reports the staged checkout step until model support lands', () => {
-    const error = expectInvalid({
+  it('normalizes checkout steps and their static defaults', () => {
+    const model = normalizeWorkflowDocument({
       name: 'checkout step',
       jobs: {
         build: {
-          steps: [{checkout: {repository: 'acme/api'}}],
+          steps: [
+            {
+              key: 'fetch-target',
+              checkout: {
+                repository: 'acme/api',
+                ref: 'refs/heads/main',
+                'fetch-depth': 0,
+                path: 'target',
+                permissions: {contents: 'write'},
+                'persist-credentials': false,
+                force: true,
+              },
+            },
+          ],
         },
       },
     });
 
-    expect(error.issues).toContainEqual(
-      expect.objectContaining({
-        code: 'unsupported-checkout',
-        path: ['jobs', 'build', 'steps', 0, 'checkout'],
-      }),
-    );
+    expect(model.jobs[0]?.steps[0]).toMatchObject({
+      id: expect.stringContaining('fetch-target'),
+      key: 'fetch-target',
+      kind: 'checkout',
+      checkout: {
+        repository: 'acme/api',
+        ref: 'refs/heads/main',
+        fetchDepth: 0,
+        path: 'target',
+        permissions: {contents: 'write'},
+        persistCredentials: false,
+        force: true,
+      },
+    });
   });
 
   it('normalizes checkout contents write and defaults persisted credentials', () => {

--- a/libs/api/workflows/src/core/entities/step.ts
+++ b/libs/api/workflows/src/core/entities/step.ts
@@ -13,6 +13,10 @@ import type {InterpolationUnresolvableField} from '../errors.js';
 
 export type StepStatus = 'pending' | 'running' | 'succeeded' | 'failed' | 'cancelled' | 'skipped';
 
+export const STEP_TYPES = ['setup', 'run', 'agent', 'checkout'] as const;
+
+export type StepType = (typeof STEP_TYPES)[number];
+
 export const STEP_STATUS_REASONS = [
   'default_gate_rejected',
   'condition_rejected',
@@ -85,7 +89,7 @@ export interface Step {
   status: StepStatus;
   statusReason: StepStatusReason | null;
   evaluationTrace: readonly PersistedEvaluationTraceEntry[] | null;
-  type: string;
+  type: StepType;
   config: Record<string, unknown>;
   condition: WorkflowExpression | null;
   configPlan: StepConfigDispatchPlan | null;

--- a/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.test.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.test.ts
@@ -177,6 +177,53 @@ describe('materializeJobExecutionSteps', () => {
     });
   });
 
+  it('materializes checkout steps with their resolved config and default name', async () => {
+    const model = workflowModel({
+      jobs: {
+        build: {
+          steps: [
+            {
+              checkout: {
+                repository: 'acme/api',
+                ref: 'refs/heads/main',
+                fetchDepth: 0,
+                path: 'target',
+                permissions: {contents: 'write'},
+                persistCredentials: false,
+                force: true,
+              },
+            },
+          ],
+        },
+      },
+    });
+    const job = model.jobs[0];
+    if (!job) throw new Error('Expected workflow job');
+
+    const steps = await materializeJobExecutionSteps({model, job, context: jobExecutionContext()});
+
+    expect(steps[1]).toEqual({
+      key: null,
+      name: 'Checkout',
+      sourceLocation: null,
+      status: 'pending',
+      type: 'checkout',
+      config: {
+        checkout: {
+          repository: 'acme/api',
+          ref: 'refs/heads/main',
+          fetch_depth: 0,
+          path: 'target',
+          permissions: {contents: 'write'},
+          persist_credentials: false,
+          force: true,
+        },
+      },
+      authoredConfig: null,
+      position: 1,
+    });
+  });
+
   it('prepends setup and resolves job-execution context fields', async () => {
     const model = workflowModel({
       jobs: {

--- a/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-job-execution-steps.ts
@@ -117,13 +117,16 @@ function materializedConfigPlan(
 }
 
 function stepDisplayName(step: WorkflowModelStep): string {
-  switch (step.kind) {
+  const {kind} = step;
+  switch (kind) {
     case 'run':
       return firstLine(step.command.value);
     case 'agent':
       return step.model === undefined
         ? firstLine(step.prompt)
         : `${step.model} · ${firstLine(step.prompt)}`;
+    case 'checkout':
+      return 'Checkout';
     default:
       return assertNever(step);
   }

--- a/libs/api/workflows/src/core/step-config/resolve-step-config.ts
+++ b/libs/api/workflows/src/core/step-config/resolve-step-config.ts
@@ -25,6 +25,7 @@ type WorkflowModelJob = WorkflowModel['jobs'][number];
 type WorkflowModelStep = WorkflowModelJob['steps'][number];
 type WorkflowModelRunStep = Extract<WorkflowModelStep, {kind: 'run'}>;
 type WorkflowModelAgentStep = Extract<WorkflowModelStep, {kind: 'agent'}>;
+type WorkflowModelCheckoutStep = Extract<WorkflowModelStep, {kind: 'checkout'}>;
 
 export type {StepConfigField, WorkflowStepTemplateDiagnostic};
 
@@ -101,6 +102,21 @@ async function buildStepConfig(
     };
   }
 
+  const checkoutStep = checkoutStepOrNull(params.step);
+  if (checkoutStep !== null) {
+    return {
+      config: {
+        ...checkoutStepConfig(checkoutStep),
+        ...gate,
+        ...outputs,
+      },
+      configPlan: null,
+      diagnostics: [],
+      trace: [],
+      hasTemplates: false,
+    };
+  }
+
   const agentStep = agentStepOrNull(params.step);
   if (agentStep === null) throw new Error(`Unsupported workflow step kind: ${params.step.kind}`);
 
@@ -129,6 +145,28 @@ function runStepOrNull(step: WorkflowModelStep): WorkflowModelRunStep | null {
 function agentStepOrNull(step: WorkflowModelStep): WorkflowModelAgentStep | null {
   const isAgentStep = step.kind === 'agent';
   return isAgentStep ? step : null;
+}
+
+function checkoutStepOrNull(step: WorkflowModelStep): WorkflowModelCheckoutStep | null {
+  const isCheckoutStep = step.kind === 'checkout';
+  return isCheckoutStep ? step : null;
+}
+
+function checkoutStepConfig(step: WorkflowModelCheckoutStep): Record<string, unknown> {
+  const checkout = step.checkout;
+  return {
+    checkout: {
+      ...(checkout.project === undefined ? {} : {project: checkout.project}),
+      ...(checkout.connection === undefined ? {} : {connection: checkout.connection}),
+      ...(checkout.repository === undefined ? {} : {repository: checkout.repository}),
+      ...(checkout.ref === undefined ? {} : {ref: checkout.ref}),
+      fetch_depth: checkout.fetchDepth,
+      ...(checkout.path === undefined ? {} : {path: checkout.path}),
+      permissions: checkout.permissions,
+      persist_credentials: checkout.persistCredentials,
+      ...(checkout.force === undefined ? {} : {force: checkout.force}),
+    },
+  };
 }
 
 function gateConfigForStep(step: WorkflowModelStep): Record<string, unknown> {

--- a/libs/api/workflows/src/db/schema/steps.ts
+++ b/libs/api/workflows/src/db/schema/steps.ts
@@ -18,6 +18,7 @@ import {
   STEP_STATUS_REASONS,
   type Step,
   type StepConfigDispatchPlan,
+  type StepType,
   toStepStatusReason,
 } from '#core/entities/step.js';
 import {pgTable} from './common.js';
@@ -45,7 +46,7 @@ export const steps = pgTable(
     status: stepStatusEnum('status').notNull().default('pending'),
     statusReason: stepStatusReasonEnum('status_reason'),
     evaluationTrace: jsonb('evaluation_trace').$type<readonly PersistedEvaluationTraceEntry[]>(),
-    type: text('type').notNull(),
+    type: text('type').notNull().$type<StepType>(),
     config: jsonb('config').notNull().$type<Record<string, unknown>>(),
     condition: jsonb('condition').$type<WorkflowExpression>(),
     configPlan: jsonb('config_plan').$type<StepConfigDispatchPlan>(),

--- a/libs/api/workflows/src/db/workflow-runs/run-create.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-create.ts
@@ -339,7 +339,7 @@ function referencedVariables(
       if (step.kind === 'run') {
         collectFieldVariableReferences(step.templates?.command, references, {field: 'run'});
         collectTemplateVariableReferences(step.templates?.env, references);
-      } else {
+      } else if (step.kind === 'agent') {
         collectFieldVariableReferences(step.templates?.prompt, references, {field: 'agent.prompt'});
         collectFieldVariableReferences(step.templates?.model, references, {field: 'agent.model'});
         collectFieldVariableReferences(step.templates?.provider, references, {

--- a/libs/api/workflows/src/presentation/dto/step.test.ts
+++ b/libs/api/workflows/src/presentation/dto/step.test.ts
@@ -114,6 +114,18 @@ describe('toStepDto error category', () => {
     });
   });
 
+  it("derives category 'setup' for a checkout step error and surfaces the reason", () => {
+    const dto = toStepDto(
+      step({type: 'checkout', error: {message: 'Checkout failed', reason: 'checkout_failed'}}),
+    );
+
+    expect(dto.error).toEqual({
+      message: 'Checkout failed',
+      reason: 'checkout_failed',
+      category: 'setup',
+    });
+  });
+
   it("derives category 'user' for a run step error", () => {
     const dto = toStepDto(
       step({type: 'run', error: {message: 'Command exited with code 1', exitCode: 1}}),

--- a/libs/api/workflows/src/presentation/dto/step.ts
+++ b/libs/api/workflows/src/presentation/dto/step.ts
@@ -107,7 +107,10 @@ export function toStepDto(step: Step): StepDto {
     status: step.status,
     type: step.type,
     config: step.config,
-    error: toStepErrorDto(step.error, step.type === 'setup' ? 'setup' : 'user'),
+    error: toStepErrorDto(
+      step.error,
+      step.type === 'setup' || step.type === 'checkout' ? 'setup' : 'user',
+    ),
     position: step.position,
     current_attempt: step.currentAttempt,
     created_at: step.createdAt.toISOString(),

--- a/libs/api/workflows/test/factories/workflow-model.ts
+++ b/libs/api/workflows/test/factories/workflow-model.ts
@@ -10,6 +10,7 @@ import {
 type ModelStep = WorkflowModel['jobs'][number]['steps'][number];
 type AgentThinking = Extract<ModelStep, {kind: 'agent'}>['thinking'];
 type Harness = Extract<ModelStep, {kind: 'agent'}>['harness'];
+type Checkout = Extract<ModelStep, {kind: 'checkout'}>['checkout'];
 type WorkflowEnvTemplates = NonNullable<NonNullable<WorkflowModel['templates']>['env']>;
 
 interface TestWorkflowStepBase {
@@ -35,7 +36,11 @@ interface TestAgentStep extends TestWorkflowStepBase {
   readonly integrations?: Extract<ModelStep, {kind: 'agent'}>['integrations'] | undefined;
 }
 
-type TestWorkflowStep = TestRunStep | TestAgentStep;
+interface TestCheckoutStep extends TestWorkflowStepBase {
+  readonly checkout: Checkout;
+}
+
+type TestWorkflowStep = TestRunStep | TestAgentStep | TestCheckoutStep;
 
 const DEFAULT_RUNNER_LABELS = ['ubuntu-latest'] as const;
 
@@ -144,26 +149,36 @@ function outputTemplates(outputs: Readonly<Record<string, string>>) {
 
 function normalizeStep(step: TestWorkflowStep, jobId: string, stepIndex: number): ModelStep {
   const base = stepBase(step, jobId, stepIndex);
-  return 'run' in step
-    ? {
-        ...base,
-        kind: 'run',
-        command: {kind: 'shell', value: step.run},
-        ...optionalRunTemplates(step),
-        ...optionalStepEnv(step.env),
-      }
-    : {
-        ...base,
-        kind: 'agent',
-        ...(step.harness === undefined ? {} : {harness: step.harness}),
-        ...(step.model === undefined ? {} : {model: step.model}),
-        ...(step.provider === undefined ? {} : {provider: step.provider}),
-        ...(step.thinking === undefined ? {} : {thinking: step.thinking}),
-        ...(step.tools === undefined ? {} : {tools: step.tools}),
-        ...(step.integrations === undefined ? {} : {integrations: step.integrations}),
-        prompt: step.prompt,
-        ...optionalAgentTemplates(step),
-      };
+  if ('run' in step) {
+    return {
+      ...base,
+      kind: 'run',
+      command: {kind: 'shell', value: step.run},
+      ...optionalRunTemplates(step),
+      ...optionalStepEnv(step.env),
+    };
+  }
+
+  if ('prompt' in step) {
+    return {
+      ...base,
+      kind: 'agent',
+      ...(step.harness === undefined ? {} : {harness: step.harness}),
+      ...(step.model === undefined ? {} : {model: step.model}),
+      ...(step.provider === undefined ? {} : {provider: step.provider}),
+      ...(step.thinking === undefined ? {} : {thinking: step.thinking}),
+      ...(step.tools === undefined ? {} : {tools: step.tools}),
+      ...(step.integrations === undefined ? {} : {integrations: step.integrations}),
+      prompt: step.prompt,
+      ...optionalAgentTemplates(step),
+    };
+  }
+
+  return {
+    ...base,
+    kind: 'checkout',
+    checkout: step.checkout,
+  };
 }
 
 function stepBase(step: TestWorkflowStep, jobId: string, stepIndex: number) {

--- a/libs/client/workflows/src/components/workflow-run-view/job-card.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/job-card.tsx
@@ -433,7 +433,7 @@ function toSelectedAttemptError(
     signal: typeof error.signal === 'string' ? error.signal : undefined,
     reason: resolvedReason,
     agentConfigIssue,
-    category: step.type === 'setup' ? 'setup' : 'user',
+    category: step.type === 'setup' || step.type === 'checkout' ? 'setup' : 'user',
   };
 }
 


### PR DESCRIPTION
Carry authored checkout steps from the workflow schema through normalization, model step config resolution, and execution-step materialization. Checkout errors are surfaced as setup failures in both the API and workflow UI.

This completes the checkout model/materialization portion of ENG-1428. Runner-side checkout execution remains a separate follow-up and is intentionally not included here.

Validation:
- Definitions and workflows typecheck and package checks pass.
- API workflows: 664 tests pass.
- Client workflows: 295 tests pass.
- Docs package check passes.

Closes ENG-1428

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add first-class checkout steps to the workflow model and materialization. Checkout failures are now shown as setup errors in the API and workflow UI. Completes ENG-1428 model/materialization; runner-side execution will follow.

- **New Features**
  - Add a `checkout` step kind; normalize and resolve config, and materialize execution steps named "Checkout".
  - Support repository, ref, fetchDepth, path, permissions, persistCredentials, and force with sensible defaults.
  - Keep checkout templates compatible with run/agent steps (supports name and workingDirectory; only name is used today).
  - Extend step type union and DB typing to include `checkout` and expose a typed `STEP_TYPES`; update docs to remove the prior caveat.

- **Bug Fixes**
  - Limit variable reference collection to agent steps during run creation (avoid treating checkout as agent).

<sup>Written for commit a5d3bbc20211fe1a03138b9d65d267a3aaa1d087. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

