### PR TITLE
Add workspace-scoped project slugs end to end

### DIFF
--- a/.changeset/project-slug.md
+++ b/.changeset/project-slug.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/api-projects": major
+"@shipfox/api-projects-dto": major
+"@shipfox/client-projects": major
+---
+
+Add required, workspace-scoped project slugs across the API and project creation form.

--- a/e2e/setup/projects/package.json
+++ b/e2e/setup/projects/package.json
@@ -37,6 +37,7 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
+    "@shipfox/api-common-dto": "workspace:*",
     "@shipfox/api-projects-dto": "workspace:*",
     "@shipfox/e2e-core": "workspace:*"
   },

--- a/e2e/setup/projects/src/index.test.ts
+++ b/e2e/setup/projects/src/index.test.ts
@@ -30,6 +30,7 @@ describe('createProject', () => {
       json: {
         workspace_id: workspaceId,
         name: 'E2E Project',
+        slug: 'e2e-project-2',
         source_connection_id: undefined,
         source_external_repository_id: undefined,
       },
@@ -53,6 +54,7 @@ describe('createProject', () => {
       json: {
         workspace_id: workspaceId,
         name: 'Platform',
+        slug: 'platform-2',
         source_connection_id: sourceConnectionId,
         source_external_repository_id: 'e2e:platform',
       },

--- a/e2e/setup/projects/src/index.ts
+++ b/e2e/setup/projects/src/index.ts
@@ -1,3 +1,4 @@
+import {slugifyName, withSlugSuffix} from '@shipfox/api-common-dto';
 import type {E2eCreateProjectBodyDto, E2eCreateProjectResponseDto} from '@shipfox/api-projects-dto';
 import {requestJson} from '@shipfox/e2e-core';
 
@@ -6,18 +7,23 @@ export type {E2eCreateProjectBodyDto, E2eCreateProjectResponseDto} from '@shipfo
 export interface CreateProjectParams {
   workspaceId: string;
   name?: string;
+  slug?: string | undefined;
   sourceConnectionId?: string | undefined;
   sourceExternalRepositoryId?: string | undefined;
 }
 
 const DEFAULT_PROJECT_NAME = 'E2E Project';
+let projectSequence = 1;
 
 export async function createProject(
   params: CreateProjectParams,
 ): Promise<E2eCreateProjectResponseDto> {
+  const name = params.name ?? DEFAULT_PROJECT_NAME;
   const body: E2eCreateProjectBodyDto = {
     workspace_id: params.workspaceId,
-    name: params.name ?? DEFAULT_PROJECT_NAME,
+    name,
+    slug:
+      params.slug ?? withSlugSuffix(slugifyName(name, {fallback: 'project'}), ++projectSequence),
     source_connection_id: params.sourceConnectionId,
     source_external_repository_id: params.sourceExternalRepositoryId,
   };

--- a/e2e/suites/flow/workflows/package.json
+++ b/e2e/suites/flow/workflows/package.json
@@ -39,6 +39,7 @@
     "type": "shipfox-tsc-check"
   },
   "devDependencies": {
+    "@shipfox/api-common-dto": "workspace:*",
     "@shipfox/api-definitions-dto": "workspace:*",
     "@shipfox/api-integration-webhook-dto": "workspace:*",
     "@shipfox/api-integration-github-dto": "workspace:*",

--- a/e2e/suites/flow/workflows/src/create-project.ts
+++ b/e2e/suites/flow/workflows/src/create-project.ts
@@ -1,3 +1,4 @@
+import {slugifyName} from '@shipfox/api-common-dto';
 import type {CreateProjectBodyDto, ProjectResponseDto} from '@shipfox/api-projects-dto';
 import {createApiClient} from '@shipfox/e2e-core';
 
@@ -15,6 +16,7 @@ export async function createProject(params: CreateProjectParams): Promise<Projec
   const body: CreateProjectBodyDto = {
     workspace_id: params.workspaceId,
     name: params.name,
+    slug: slugifyName(params.name, {fallback: 'project'}),
     source: {
       connection_id: params.connectionId,
       external_repository_id: params.externalRepositoryId,

--- a/libs/api/projects-dto/src/e2e/project.ts
+++ b/libs/api/projects-dto/src/e2e/project.ts
@@ -1,10 +1,11 @@
-import {displayNameSchema} from '@shipfox/api-common-dto';
+import {displayNameSchema, slugSchema} from '@shipfox/api-common-dto';
 import {z} from 'zod';
 import {projectResponseSchema} from '../schemas/project.js';
 
 export const e2eCreateProjectBodySchema = z.object({
   workspace_id: z.string().uuid(),
   name: displayNameSchema,
+  slug: slugSchema.optional(),
   source_connection_id: z.string().uuid().optional(),
   source_external_repository_id: z.string().min(1).max(255).optional(),
 });

--- a/libs/api/projects-dto/src/events.test.ts
+++ b/libs/api/projects-dto/src/events.test.ts
@@ -1,0 +1,23 @@
+import {projectCreatedEventSchema} from './events.js';
+
+const legacyProjectCreatedEvent = {
+  actorId: 'actor-1',
+  workspaceId: 'workspace-1',
+  projectId: 'project-1',
+  sourceConnectionId: 'connection-1',
+  sourceExternalRepositoryId: 'repository-1',
+};
+
+describe('project created event schema', () => {
+  test('accepts legacy in-flight payloads without a slug', () => {
+    expect(projectCreatedEventSchema.parse(legacyProjectCreatedEvent)).toEqual(
+      legacyProjectCreatedEvent,
+    );
+  });
+
+  test('preserves slugs on new payloads', () => {
+    expect(
+      projectCreatedEventSchema.parse({...legacyProjectCreatedEvent, slug: 'project'}),
+    ).toMatchObject({slug: 'project'});
+  });
+});

--- a/libs/api/projects-dto/src/events.ts
+++ b/libs/api/projects-dto/src/events.ts
@@ -3,6 +3,7 @@ import {z} from 'zod';
 const nonEmptyStringSchema = z.string().nonempty();
 
 export const PROJECT_CREATED = 'projects.project.created' as const;
+export const PROJECT_UPDATED = 'projects.project.updated' as const;
 export const PROJECT_SOURCE_BOUND = 'projects.project.source_bound' as const;
 export const PROJECT_SOURCE_COMMIT_OBSERVED = 'projects.project.source_commit_observed' as const;
 
@@ -10,10 +11,20 @@ export const projectCreatedEventSchema = z.object({
   actorId: nonEmptyStringSchema,
   workspaceId: nonEmptyStringSchema,
   projectId: nonEmptyStringSchema,
+  slug: nonEmptyStringSchema,
   sourceConnectionId: nonEmptyStringSchema,
   sourceExternalRepositoryId: nonEmptyStringSchema,
 });
 export type ProjectCreatedEvent = z.infer<typeof projectCreatedEventSchema>;
+
+export const projectUpdatedEventSchema = z.object({
+  actorId: nonEmptyStringSchema,
+  workspaceId: nonEmptyStringSchema,
+  projectId: nonEmptyStringSchema,
+  name: nonEmptyStringSchema,
+  slug: nonEmptyStringSchema,
+});
+export type ProjectUpdatedEvent = z.infer<typeof projectUpdatedEventSchema>;
 
 export const projectSourceBoundEventSchema = z.object({
   actorId: nonEmptyStringSchema,
@@ -40,12 +51,14 @@ export type ProjectSourceCommitObservedEvent = z.infer<
 
 export interface ProjectsEventMap {
   [PROJECT_CREATED]: ProjectCreatedEvent;
+  [PROJECT_UPDATED]: ProjectUpdatedEvent;
   [PROJECT_SOURCE_BOUND]: ProjectSourceBoundEvent;
   [PROJECT_SOURCE_COMMIT_OBSERVED]: ProjectSourceCommitObservedEvent;
 }
 
 export const projectsEventSchemas = {
   [PROJECT_CREATED]: projectCreatedEventSchema,
+  [PROJECT_UPDATED]: projectUpdatedEventSchema,
   [PROJECT_SOURCE_BOUND]: projectSourceBoundEventSchema,
   [PROJECT_SOURCE_COMMIT_OBSERVED]: projectSourceCommitObservedEventSchema,
 } satisfies Record<keyof ProjectsEventMap, z.ZodType>;

--- a/libs/api/projects-dto/src/events.ts
+++ b/libs/api/projects-dto/src/events.ts
@@ -7,15 +7,23 @@ export const PROJECT_UPDATED = 'projects.project.updated' as const;
 export const PROJECT_SOURCE_BOUND = 'projects.project.source_bound' as const;
 export const PROJECT_SOURCE_COMMIT_OBSERVED = 'projects.project.source_commit_observed' as const;
 
-export const projectCreatedEventSchema = z.object({
+const projectCreatedEventWithoutSlugSchema = z.object({
   actorId: nonEmptyStringSchema,
   workspaceId: nonEmptyStringSchema,
   projectId: nonEmptyStringSchema,
-  slug: nonEmptyStringSchema,
   sourceConnectionId: nonEmptyStringSchema,
   sourceExternalRepositoryId: nonEmptyStringSchema,
 });
-export type ProjectCreatedEvent = z.infer<typeof projectCreatedEventSchema>;
+
+const projectCreatedEventWithSlugSchema = projectCreatedEventWithoutSlugSchema.extend({
+  slug: nonEmptyStringSchema,
+});
+
+export const projectCreatedEventSchema = z.union([
+  projectCreatedEventWithSlugSchema,
+  projectCreatedEventWithoutSlugSchema,
+]);
+export type ProjectCreatedEvent = z.infer<typeof projectCreatedEventWithSlugSchema>;
 
 export const projectUpdatedEventSchema = z.object({
   actorId: nonEmptyStringSchema,

--- a/libs/api/projects-dto/src/schemas/index.ts
+++ b/libs/api/projects-dto/src/schemas/index.ts
@@ -17,4 +17,6 @@ export {
   projectDtoSchema,
   projectResponseSchema,
   projectSourceDtoSchema,
+  type UpdateProjectBodyDto,
+  updateProjectBodySchema,
 } from './project.js';

--- a/libs/api/projects-dto/src/schemas/project.ts
+++ b/libs/api/projects-dto/src/schemas/project.ts
@@ -1,4 +1,4 @@
-import {displayNameSchema} from '@shipfox/api-common-dto';
+import {displayNameSchema, slugSchema} from '@shipfox/api-common-dto';
 import {z} from 'zod';
 
 export const projectSourceDtoSchema = z.object({
@@ -10,6 +10,7 @@ export type ProjectSourceDto = z.infer<typeof projectSourceDtoSchema>;
 export const createProjectBodySchema = z.object({
   workspace_id: z.string().uuid(),
   name: displayNameSchema,
+  slug: slugSchema,
   source: z.object({
     connection_id: z.string().uuid(),
     external_repository_id: z.string().min(1).max(255),
@@ -18,10 +19,20 @@ export const createProjectBodySchema = z.object({
 
 export type CreateProjectBodyDto = z.infer<typeof createProjectBodySchema>;
 
+export const updateProjectBodySchema = z
+  .object({
+    name: displayNameSchema.optional(),
+    slug: slugSchema.optional(),
+  })
+  .partial();
+
+export type UpdateProjectBodyDto = z.infer<typeof updateProjectBodySchema>;
+
 export const projectDtoSchema = z.object({
   id: z.string().uuid(),
   workspace_id: z.string().uuid(),
   name: z.string(),
+  slug: slugSchema,
   source: projectSourceDtoSchema,
   created_at: z.string(),
   updated_at: z.string(),

--- a/libs/api/projects/drizzle/0000_initial.sql
+++ b/libs/api/projects/drizzle/0000_initial.sql
@@ -7,6 +7,7 @@ CREATE TABLE "projects_projects" (
 	"source_repository_name" text,
 	"source_default_branch" text,
 	"name" text NOT NULL,
+	"slug" text NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
 );
@@ -33,6 +34,7 @@ CREATE TABLE "projects_integration_event_dedup" (
 );
 --> statement-breakpoint
 CREATE UNIQUE INDEX "projects_source_unique" ON "projects_projects" USING btree ("source_connection_id","source_external_repository_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "projects_workspace_slug_unique" ON "projects_projects" USING btree ("workspace_id","slug");--> statement-breakpoint
 CREATE INDEX "projects_workspace_created_id_idx" ON "projects_projects" USING btree ("workspace_id","created_at","id");--> statement-breakpoint
 CREATE INDEX "projects_source_repository_lookup_idx" ON "projects_projects" USING btree ("workspace_id","source_connection_id",lower("source_repository_owner"),lower("source_repository_name"));--> statement-breakpoint
 CREATE INDEX "projects_outbox_pending_idx" ON "projects_outbox" USING btree ("next_dispatch_at","created_at") WHERE "dispatched_at" IS NULL AND "dead_lettered_at" IS NULL;

--- a/libs/api/projects/drizzle/meta/0000_snapshot.json
+++ b/libs/api/projects/drizzle/meta/0000_snapshot.json
@@ -238,6 +238,12 @@
           "primaryKey": false,
           "notNull": true
         },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
         "created_at": {
           "name": "created_at",
           "type": "timestamp with time zone",
@@ -265,6 +271,27 @@
             },
             {
               "expression": "source_external_repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_workspace_slug_unique": {
+          "name": "projects_workspace_slug_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
               "isExpression": false,
               "asc": true,
               "nulls": "last"

--- a/libs/api/projects/package.json
+++ b/libs/api/projects/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "@shipfox/api-auth-dto": "workspace:*",
     "@shipfox/api-auth-context": "workspace:*",
+    "@shipfox/api-common-dto": "workspace:*",
     "@shipfox/api-integration-core-dto": "workspace:*",
     "@shipfox/api-projects-dto": "workspace:*",
     "@shipfox/inter-module": "workspace:*",

--- a/libs/api/projects/src/core/entities/project.ts
+++ b/libs/api/projects/src/core/entities/project.ts
@@ -7,6 +7,7 @@ export interface Project {
   sourceRepositoryName: string | null;
   sourceDefaultBranch: string | null;
   name: string;
+  slug: string;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/libs/api/projects/src/core/errors.ts
+++ b/libs/api/projects/src/core/errors.ts
@@ -24,3 +24,10 @@ export class ProjectAlreadyExistsError extends Error {
     this.name = 'ProjectAlreadyExistsError';
   }
 }
+
+export class ProjectSlugConflictError extends Error {
+  constructor(public readonly slug: string) {
+    super(`Project slug already exists: ${slug}`);
+    this.name = 'ProjectSlugConflictError';
+  }
+}

--- a/libs/api/projects/src/core/index.ts
+++ b/libs/api/projects/src/core/index.ts
@@ -3,6 +3,7 @@ export {
   ProjectAccessDeniedError,
   ProjectAlreadyExistsError,
   ProjectNotFoundError,
+  ProjectSlugConflictError,
 } from './errors.js';
-export type {CreateProjectFromSourceParams} from './projects.js';
-export {createProjectFromSource} from './projects.js';
+export type {CreateProjectFromSourceParams, UpdateProjectDetailsParams} from './projects.js';
+export {createProjectFromSource, updateProjectDetails} from './projects.js';

--- a/libs/api/projects/src/core/projects.test.ts
+++ b/libs/api/projects/src/core/projects.test.ts
@@ -45,6 +45,7 @@ describe('createProjectFromSource', () => {
       actorId,
       workspaceId,
       name: 'Platform',
+      slug: 'platform',
       sourceConnectionId,
       sourceExternalRepositoryId: 'gitea:gitea-owner/platform',
       integrations: integrations as IntegrationsModuleClient,
@@ -52,6 +53,7 @@ describe('createProjectFromSource', () => {
 
     expect(project.workspaceId).toBe(workspaceId);
     expect(project.name).toBe('Platform');
+    expect(project.slug).toBe('platform');
     expect(project.sourceConnectionId).toBe(sourceConnectionId);
     expect(project.sourceExternalRepositoryId).toBe('gitea:gitea-owner/platform');
     expect(project.sourceRepositoryOwner).toBe('gitea-owner');
@@ -64,6 +66,7 @@ describe('createProjectFromSource', () => {
       actorId,
       workspaceId,
       name: 'Platform',
+      slug: 'platform',
       sourceConnectionId,
       sourceExternalRepositoryId: 'gitea:gitea-owner/platform',
       integrations: integrations as IntegrationsModuleClient,
@@ -81,6 +84,7 @@ describe('createProjectFromSource', () => {
     expect(events.map((event) => event.payload)).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
+          slug: 'platform',
           sourceConnectionId,
           sourceExternalRepositoryId: 'gitea:gitea-owner/platform',
         }),
@@ -98,6 +102,7 @@ describe('createProjectFromSource', () => {
       actorId,
       workspaceId,
       name: 'Platform',
+      slug: 'platform',
       sourceConnectionId,
       sourceExternalRepositoryId: 'gitea:gitea-owner/platform',
       integrations: integrations as IntegrationsModuleClient,
@@ -107,6 +112,7 @@ describe('createProjectFromSource', () => {
       actorId,
       workspaceId,
       name: 'Platform Again',
+      slug: 'platform-again',
       sourceConnectionId,
       sourceExternalRepositoryId: 'gitea:gitea-owner/platform',
       integrations: integrations as IntegrationsModuleClient,
@@ -128,6 +134,7 @@ describe('createProjectFromSource', () => {
       actorId,
       workspaceId,
       name: 'Missing',
+      slug: 'missing',
       sourceConnectionId,
       sourceExternalRepositoryId: 'not-found',
       integrations: integrations as IntegrationsModuleClient,

--- a/libs/api/projects/src/core/projects.ts
+++ b/libs/api/projects/src/core/projects.ts
@@ -2,16 +2,25 @@ import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/i
 import {
   PROJECT_CREATED,
   PROJECT_SOURCE_BOUND,
+  PROJECT_UPDATED,
   type ProjectsEventMap,
 } from '@shipfox/api-projects-dto';
+import {isUniqueViolation} from '@shipfox/node-drizzle';
 import {writeOutboxEvent} from '@shipfox/node-outbox';
 import {and, eq} from 'drizzle-orm';
 import {db} from '#db/db.js';
+import {updateProject} from '#db/projects.js';
 import {projectsOutbox} from '#db/schema/outbox.js';
 import {projects, toProject} from '#db/schema/projects.js';
 import {recordProjectCreated} from '#metrics/instance.js';
 import type {Project} from './entities/project.js';
-import {ProjectAlreadyExistsError} from './errors.js';
+import {
+  ProjectAlreadyExistsError,
+  ProjectNotFoundError,
+  ProjectSlugConflictError,
+} from './errors.js';
+
+const PROJECTS_WORKSPACE_SLUG_UNIQUE_CONSTRAINT = 'projects_workspace_slug_unique';
 
 export interface CreateProjectFromSourceParams {
   actorId: string;
@@ -19,6 +28,7 @@ export interface CreateProjectFromSourceParams {
   name: string;
   sourceConnectionId: string;
   sourceExternalRepositoryId: string;
+  slug: string;
   integrations: IntegrationsModuleClient;
 }
 
@@ -32,40 +42,54 @@ export async function createProjectFromSource(
   });
 
   const project = await db().transaction(async (tx) => {
-    const [projectRow] = await tx
-      .insert(projects)
-      .values({
-        workspaceId: params.workspaceId,
-        sourceConnectionId: source.connection.id,
-        sourceExternalRepositoryId: source.repository.externalRepositoryId,
-        sourceRepositoryOwner: source.repository.owner,
-        sourceRepositoryName: source.repository.name,
-        sourceDefaultBranch: source.repository.defaultBranch,
-        name: params.name,
-      })
-      .onConflictDoNothing({
-        target: [projects.sourceConnectionId, projects.sourceExternalRepositoryId],
-      })
-      .returning();
+    let projectRow: typeof projects.$inferSelect | undefined;
+    for (let attempt = 0; attempt < 2 && !projectRow; attempt += 1) {
+      try {
+        [projectRow] = await tx
+          .insert(projects)
+          .values({
+            workspaceId: params.workspaceId,
+            sourceConnectionId: source.connection.id,
+            sourceExternalRepositoryId: source.repository.externalRepositoryId,
+            sourceRepositoryOwner: source.repository.owner,
+            sourceRepositoryName: source.repository.name,
+            sourceDefaultBranch: source.repository.defaultBranch,
+            name: params.name,
+            slug: params.slug,
+          })
+          .onConflictDoNothing({
+            target: [projects.sourceConnectionId, projects.sourceExternalRepositoryId],
+          })
+          .returning();
+      } catch (error) {
+        if (isUniqueViolation(error, PROJECTS_WORKSPACE_SLUG_UNIQUE_CONSTRAINT)) {
+          throw new ProjectSlugConflictError(params.slug);
+        }
+        throw error;
+      }
+
+      if (!projectRow) {
+        const [existing] = await tx
+          .select()
+          .from(projects)
+          .where(
+            and(
+              eq(projects.sourceConnectionId, source.connection.id),
+              eq(projects.sourceExternalRepositoryId, source.repository.externalRepositoryId),
+            ),
+          )
+          .limit(1);
+        if (existing) {
+          throw new ProjectAlreadyExistsError(
+            existing.id,
+            source.connection.id,
+            source.repository.externalRepositoryId,
+          );
+        }
+      }
+    }
 
     if (!projectRow) {
-      const [existing] = await tx
-        .select()
-        .from(projects)
-        .where(
-          and(
-            eq(projects.sourceConnectionId, source.connection.id),
-            eq(projects.sourceExternalRepositoryId, source.repository.externalRepositoryId),
-          ),
-        )
-        .limit(1);
-      if (existing) {
-        throw new ProjectAlreadyExistsError(
-          existing.id,
-          source.connection.id,
-          source.repository.externalRepositoryId,
-        );
-      }
       throw new Error('Project insert returned no rows');
     }
 
@@ -77,6 +101,7 @@ export async function createProjectFromSource(
         actorId: params.actorId,
         workspaceId: project.workspaceId,
         projectId: project.id,
+        slug: project.slug,
         sourceConnectionId: project.sourceConnectionId,
         sourceExternalRepositoryId: project.sourceExternalRepositoryId,
       },
@@ -97,4 +122,35 @@ export async function createProjectFromSource(
   });
   recordProjectCreated();
   return project;
+}
+
+export interface UpdateProjectDetailsParams {
+  actorId: string;
+  projectId: string;
+  name?: string | undefined;
+  slug?: string | undefined;
+}
+
+export function updateProjectDetails(params: UpdateProjectDetailsParams): Promise<Project> {
+  return db().transaction(async (tx) => {
+    const update = await updateProject(
+      {projectId: params.projectId, name: params.name, slug: params.slug},
+      {tx},
+    );
+    if (!update) throw new ProjectNotFoundError(params.projectId);
+    if (!update.changed) return update.project;
+
+    await writeOutboxEvent<ProjectsEventMap>(tx, projectsOutbox, {
+      type: PROJECT_UPDATED,
+      payload: {
+        actorId: params.actorId,
+        workspaceId: update.project.workspaceId,
+        projectId: update.project.id,
+        name: update.project.name,
+        slug: update.project.slug,
+      },
+    });
+
+    return update.project;
+  });
 }

--- a/libs/api/projects/src/db/index.ts
+++ b/libs/api/projects/src/db/index.ts
@@ -16,6 +16,8 @@ export type {
   ListProjectsResult,
   ResolveCheckoutTargetParams,
   ResolvedCheckoutTarget,
+  UpdateProjectParams,
+  UpdateProjectResult,
 } from './projects.js';
 export {
   createProject,
@@ -27,6 +29,7 @@ export {
   listProjects,
   requireProjectForWorkspace,
   resolveCheckoutTarget,
+  updateProject,
 } from './projects.js';
 export {projectsIntegrationEventDedup} from './schema/integration-event-dedup.js';
 export {projectsOutbox} from './schema/outbox.js';

--- a/libs/api/projects/src/db/projects.test.ts
+++ b/libs/api/projects/src/db/projects.test.ts
@@ -1,5 +1,13 @@
+import {eq} from 'drizzle-orm';
 import {projectFactory} from '#test/index.js';
-import {getProjectCount, getWorkspaceProjectCounts} from './projects.js';
+import {db} from './db.js';
+import {
+  getProjectById,
+  getProjectCount,
+  getWorkspaceProjectCounts,
+  updateProject,
+} from './projects.js';
+import {projects} from './schema/projects.js';
 
 describe('getProjectCount', () => {
   it('reports the current project count', async () => {
@@ -26,5 +34,40 @@ describe('getProjectCount', () => {
     const counts = await getWorkspaceProjectCounts({workspaceIds: [workspaceId]});
 
     expect(counts).toEqual([{workspaceId, count: 0}]);
+  });
+});
+
+describe('updateProject', () => {
+  it('preserves a concurrent update to fields omitted from a partial update', async () => {
+    const project = await projectFactory.create();
+    let allowStaleTransactionUpdate!: () => void;
+    let staleTransactionRead!: () => void;
+    const staleTransactionCanUpdate = new Promise<void>((resolve) => {
+      allowStaleTransactionUpdate = resolve;
+    });
+    const staleTransactionHasRead = new Promise<void>((resolve) => {
+      staleTransactionRead = resolve;
+    });
+
+    const staleTransaction = db().transaction(async (tx) => {
+      await tx.select({id: projects.id}).from(projects).where(eq(projects.id, project.id)).limit(1);
+      staleTransactionRead();
+      await staleTransactionCanUpdate;
+      return updateProject({projectId: project.id, slug: 'stale-slug-update'}, {tx});
+    });
+
+    await staleTransactionHasRead;
+    try {
+      await updateProject({projectId: project.id, name: 'Concurrent name'});
+    } finally {
+      allowStaleTransactionUpdate();
+    }
+    await staleTransaction;
+
+    const finalProject = await getProjectById(project.id);
+    expect(finalProject).toMatchObject({
+      name: 'Concurrent name',
+      slug: 'stale-slug-update',
+    });
   });
 });

--- a/libs/api/projects/src/db/projects.ts
+++ b/libs/api/projects/src/db/projects.ts
@@ -1,15 +1,35 @@
+import {isUniqueViolation} from '@shipfox/node-drizzle';
 import {and, count, desc, eq, ilike, inArray, lt, or, type SQL, sql} from 'drizzle-orm';
 import type {Project} from '#core/entities/project.js';
-import {ProjectAlreadyExistsError, ProjectNotFoundError} from '#core/errors.js';
+import {
+  ProjectAlreadyExistsError,
+  ProjectNotFoundError,
+  ProjectSlugConflictError,
+} from '#core/errors.js';
 import {recordProjectCreated} from '#metrics/instance.js';
 import {db, type Executor} from './db.js';
 import {projects, toProject} from './schema/projects.js';
+
+type ProjectDatabase = ReturnType<typeof db>;
+type ProjectTransaction = Parameters<Parameters<ProjectDatabase['transaction']>[0]>[0];
 
 export interface CreateProjectParams {
   workspaceId: string;
   sourceConnectionId: string;
   sourceExternalRepositoryId: string;
   name: string;
+  slug: string;
+}
+
+export interface UpdateProjectParams {
+  projectId: string;
+  name?: string | undefined;
+  slug?: string | undefined;
+}
+
+export interface UpdateProjectResult {
+  project: Project;
+  changed: boolean;
 }
 
 export interface ProjectCursor {
@@ -50,6 +70,8 @@ export interface ListAdminProjectsResult {
   nextCursor: ProjectCursor | null;
 }
 
+const PROJECTS_WORKSPACE_SLUG_UNIQUE_CONSTRAINT = 'projects_workspace_slug_unique';
+
 function cursorWhere(cursor: ProjectCursor | undefined): SQL | undefined {
   if (!cursor) return undefined;
   return or(
@@ -60,37 +82,51 @@ function cursorWhere(cursor: ProjectCursor | undefined): SQL | undefined {
 
 export async function createProject(params: CreateProjectParams): Promise<Project> {
   const project = await db().transaction(async (tx) => {
-    const [projectRow] = await tx
-      .insert(projects)
-      .values({
-        workspaceId: params.workspaceId,
-        sourceConnectionId: params.sourceConnectionId,
-        sourceExternalRepositoryId: params.sourceExternalRepositoryId,
-        name: params.name,
-      })
-      .onConflictDoNothing({
-        target: [projects.sourceConnectionId, projects.sourceExternalRepositoryId],
-      })
-      .returning();
+    let projectRow: typeof projects.$inferSelect | undefined;
+    for (let attempt = 0; attempt < 2 && !projectRow; attempt += 1) {
+      try {
+        [projectRow] = await tx
+          .insert(projects)
+          .values({
+            workspaceId: params.workspaceId,
+            sourceConnectionId: params.sourceConnectionId,
+            sourceExternalRepositoryId: params.sourceExternalRepositoryId,
+            name: params.name,
+            slug: params.slug,
+          })
+          .onConflictDoNothing({
+            target: [projects.sourceConnectionId, projects.sourceExternalRepositoryId],
+          })
+          .returning();
+      } catch (error) {
+        if (isUniqueViolation(error, PROJECTS_WORKSPACE_SLUG_UNIQUE_CONSTRAINT)) {
+          throw new ProjectSlugConflictError(params.slug);
+        }
+        throw error;
+      }
+
+      if (!projectRow) {
+        const [conflict] = await tx
+          .select()
+          .from(projects)
+          .where(
+            and(
+              eq(projects.sourceConnectionId, params.sourceConnectionId),
+              eq(projects.sourceExternalRepositoryId, params.sourceExternalRepositoryId),
+            ),
+          )
+          .limit(1);
+        if (conflict) {
+          throw new ProjectAlreadyExistsError(
+            conflict.id,
+            params.sourceConnectionId,
+            params.sourceExternalRepositoryId,
+          );
+        }
+      }
+    }
 
     if (!projectRow) {
-      const [conflict] = await tx
-        .select()
-        .from(projects)
-        .where(
-          and(
-            eq(projects.sourceConnectionId, params.sourceConnectionId),
-            eq(projects.sourceExternalRepositoryId, params.sourceExternalRepositoryId),
-          ),
-        )
-        .limit(1);
-      if (conflict) {
-        throw new ProjectAlreadyExistsError(
-          conflict.id,
-          params.sourceConnectionId,
-          params.sourceExternalRepositoryId,
-        );
-      }
       throw new Error('Insert returned no rows');
     }
 
@@ -98,6 +134,45 @@ export async function createProject(params: CreateProjectParams): Promise<Projec
   });
   recordProjectCreated();
   return project;
+}
+
+export async function updateProject(
+  params: UpdateProjectParams,
+  options: {tx?: ProjectDatabase | ProjectTransaction | undefined} = {},
+): Promise<UpdateProjectResult | undefined> {
+  const executor = options.tx ?? db();
+
+  const [existingRow] = await executor
+    .select()
+    .from(projects)
+    .where(eq(projects.id, params.projectId))
+    .limit(1);
+  if (!existingRow) return undefined;
+
+  const nextName = params.name ?? existingRow.name;
+  const nextSlug = params.slug ?? existingRow.slug;
+  if (nextName === existingRow.name && nextSlug === existingRow.slug) {
+    return {project: toProject(existingRow), changed: false};
+  }
+
+  try {
+    const [row] = await executor
+      .update(projects)
+      .set({
+        name: nextName,
+        slug: nextSlug,
+        updatedAt: new Date(),
+      })
+      .where(eq(projects.id, params.projectId))
+      .returning();
+
+    return row ? {project: toProject(row), changed: true} : undefined;
+  } catch (error) {
+    if (isUniqueViolation(error, PROJECTS_WORKSPACE_SLUG_UNIQUE_CONSTRAINT)) {
+      throw new ProjectSlugConflictError(nextSlug);
+    }
+    throw error;
+  }
 }
 
 export async function getProjectById(id: string): Promise<Project | undefined> {

--- a/libs/api/projects/src/db/projects.ts
+++ b/libs/api/projects/src/db/projects.ts
@@ -159,8 +159,8 @@ export async function updateProject(
     const [row] = await executor
       .update(projects)
       .set({
-        name: nextName,
-        slug: nextSlug,
+        ...(params.name !== undefined ? {name: params.name} : {}),
+        ...(params.slug !== undefined ? {slug: params.slug} : {}),
         updatedAt: new Date(),
       })
       .where(eq(projects.id, params.projectId))

--- a/libs/api/projects/src/db/schema/projects.ts
+++ b/libs/api/projects/src/db/schema/projects.ts
@@ -15,6 +15,7 @@ export const projects = pgTable(
     sourceRepositoryName: text('source_repository_name'),
     sourceDefaultBranch: text('source_default_branch'),
     name: text('name').notNull(),
+    slug: text('slug').notNull(),
     createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', {withTimezone: true}).notNull().defaultNow(),
   },
@@ -23,6 +24,7 @@ export const projects = pgTable(
       table.sourceConnectionId,
       table.sourceExternalRepositoryId,
     ),
+    uniqueIndex('projects_workspace_slug_unique').on(table.workspaceId, table.slug),
     index('projects_workspace_created_id_idx').on(table.workspaceId, table.createdAt, table.id),
     index('projects_source_repository_lookup_idx').on(
       table.workspaceId,
@@ -46,6 +48,7 @@ export function toProject(row: ProjectDb): Project {
     sourceRepositoryName: row.sourceRepositoryName,
     sourceDefaultBranch: row.sourceDefaultBranch,
     name: row.name,
+    slug: row.slug,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };

--- a/libs/api/projects/src/index.ts
+++ b/libs/api/projects/src/index.ts
@@ -29,6 +29,8 @@ export {
   ProjectAccessDeniedError,
   ProjectAlreadyExistsError,
   ProjectNotFoundError,
+  ProjectSlugConflictError,
+  updateProjectDetails,
 } from '#core/index.js';
 export type {GetProjectBySourceParams} from '#db/index.js';
 export {

--- a/libs/api/projects/src/presentation/dto/project.ts
+++ b/libs/api/projects/src/presentation/dto/project.ts
@@ -6,6 +6,7 @@ export function toProjectDto(project: Project) {
     id: project.id,
     workspace_id: project.workspaceId,
     name: project.name,
+    slug: project.slug,
     source: {
       connection_id: project.sourceConnectionId,
       external_repository_id: project.sourceExternalRepositoryId,

--- a/libs/api/projects/src/presentation/e2eRoutes/create-project.test.ts
+++ b/libs/api/projects/src/presentation/e2eRoutes/create-project.test.ts
@@ -6,6 +6,7 @@ import {projectsE2eRoutes} from './index.js';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/u;
 const E2E_SOURCE_RE = /^e2e:/u;
+const GENERATED_PROJECT_SLUG_RE = /^e2e-project-/u;
 
 describe('projects E2E routes', () => {
   afterEach(async () => {
@@ -32,6 +33,28 @@ describe('projects E2E routes', () => {
     });
     expect(res.json().source.connection_id).toMatch(UUID_RE);
     expect(res.json().source.external_repository_id).toMatch(E2E_SOURCE_RE);
+  });
+
+  test('generates distinct slugs for repeated names in one workspace', async () => {
+    const workspaceId = crypto.randomUUID();
+    const app = await createApp({routes: [projectsE2eRoutes], swagger: false});
+
+    const first = await app.inject({
+      method: 'POST',
+      url: '/projects',
+      payload: {workspace_id: workspaceId, name: 'E2E Project'},
+    });
+    const second = await app.inject({
+      method: 'POST',
+      url: '/projects',
+      payload: {workspace_id: workspaceId, name: 'E2E Project'},
+    });
+
+    expect(first.statusCode).toBe(201);
+    expect(second.statusCode).toBe(201);
+    expect(first.json().slug).toMatch(GENERATED_PROJECT_SLUG_RE);
+    expect(second.json().slug).toMatch(GENERATED_PROJECT_SLUG_RE);
+    expect(second.json().slug).not.toBe(first.json().slug);
   });
 
   test('preserves explicit synthetic source values', async () => {

--- a/libs/api/projects/src/presentation/e2eRoutes/create-project.ts
+++ b/libs/api/projects/src/presentation/e2eRoutes/create-project.ts
@@ -1,16 +1,19 @@
 import {randomUUID} from 'node:crypto';
+import {slugifyName, withSlugSuffix} from '@shipfox/api-common-dto';
 import {
   e2eCreateProjectBodySchema,
   e2eCreateProjectResponseSchema,
 } from '@shipfox/api-projects-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
-import {ProjectAlreadyExistsError} from '#core/index.js';
+import {ProjectAlreadyExistsError, ProjectSlugConflictError} from '#core/index.js';
 import {createProject} from '#db/index.js';
 import {toProjectDto} from '#presentation/dto/index.js';
 
 function syntheticExternalRepositoryId(): string {
   return `e2e:${randomUUID()}`;
 }
+
+let e2eProjectSequence = 1;
 
 export const createE2eProjectRoute = defineRoute({
   method: 'POST',
@@ -33,12 +36,18 @@ export const createE2eProjectRoute = defineRoute({
         status: 409,
       });
     }
+    if (error instanceof ProjectSlugConflictError) {
+      throw new ClientError('Project slug already exists', 'slug-conflict', {status: 409});
+    }
     throw error;
   },
   handler: async (request, reply) => {
     const project = await createProject({
       workspaceId: request.body.workspace_id,
       name: request.body.name,
+      slug:
+        request.body.slug ??
+        withSlugSuffix(slugifyName(request.body.name, {fallback: 'project'}), ++e2eProjectSequence),
       sourceConnectionId: request.body.source_connection_id ?? randomUUID(),
       sourceExternalRepositoryId:
         request.body.source_external_repository_id ?? syntheticExternalRepositoryId(),

--- a/libs/api/projects/src/presentation/e2eRoutes/create-project.ts
+++ b/libs/api/projects/src/presentation/e2eRoutes/create-project.ts
@@ -13,7 +13,12 @@ function syntheticExternalRepositoryId(): string {
   return `e2e:${randomUUID()}`;
 }
 
-let e2eProjectSequence = 1;
+const MAX_GENERATED_SLUG_ATTEMPTS = 5;
+
+function generatedProjectSlug(slugBase: string): string {
+  const suffix = Number.parseInt(randomUUID().replaceAll('-', '').slice(0, 8), 16);
+  return withSlugSuffix(slugBase, suffix);
+}
 
 export const createE2eProjectRoute = defineRoute({
   method: 'POST',
@@ -42,18 +47,33 @@ export const createE2eProjectRoute = defineRoute({
     throw error;
   },
   handler: async (request, reply) => {
-    const project = await createProject({
-      workspaceId: request.body.workspace_id,
-      name: request.body.name,
-      slug:
-        request.body.slug ??
-        withSlugSuffix(slugifyName(request.body.name, {fallback: 'project'}), ++e2eProjectSequence),
-      sourceConnectionId: request.body.source_connection_id ?? randomUUID(),
-      sourceExternalRepositoryId:
-        request.body.source_external_repository_id ?? syntheticExternalRepositoryId(),
-    });
+    const requestedSlug = request.body.slug;
+    const slugBase = slugifyName(request.body.name, {fallback: 'project'});
+    let slug = requestedSlug ?? generatedProjectSlug(slugBase);
 
-    reply.code(201);
-    return toProjectDto(project);
+    for (let attempt = 0; attempt < MAX_GENERATED_SLUG_ATTEMPTS; attempt += 1) {
+      try {
+        const project = await createProject({
+          workspaceId: request.body.workspace_id,
+          name: request.body.name,
+          slug,
+          sourceConnectionId: request.body.source_connection_id ?? randomUUID(),
+          sourceExternalRepositoryId:
+            request.body.source_external_repository_id ?? syntheticExternalRepositoryId(),
+        });
+
+        reply.code(201);
+        return toProjectDto(project);
+      } catch (error) {
+        const shouldRetrySlug =
+          requestedSlug === undefined &&
+          error instanceof ProjectSlugConflictError &&
+          attempt < MAX_GENERATED_SLUG_ATTEMPTS - 1;
+        if (!shouldRetrySlug) throw error;
+        slug = generatedProjectSlug(slugBase);
+      }
+    }
+
+    throw new Error('Unable to generate a unique project slug');
   },
 });

--- a/libs/api/projects/src/presentation/inter-module.test.ts
+++ b/libs/api/projects/src/presentation/inter-module.test.ts
@@ -47,6 +47,7 @@ async function insertProject(params: {
       sourceRepositoryOwner: params.owner,
       sourceRepositoryName: params.name,
       name: params.name ?? 'Project',
+      slug: `p-${crypto.randomUUID().slice(0, 8)}`,
     })
     .returning({
       projectId: projects.id,

--- a/libs/api/projects/src/presentation/routes/create-project.ts
+++ b/libs/api/projects/src/presentation/routes/create-project.ts
@@ -6,7 +6,11 @@ import {
 import {createProjectBodySchema, projectResponseSchema} from '@shipfox/api-projects-dto';
 import {isInterModuleKnownError} from '@shipfox/inter-module';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
-import {createProjectFromSource, ProjectAlreadyExistsError} from '#core/index.js';
+import {
+  createProjectFromSource,
+  ProjectAlreadyExistsError,
+  ProjectSlugConflictError,
+} from '#core/index.js';
 import {toProjectDto} from '#presentation/dto/index.js';
 
 function providerStatus(reason: string): number {
@@ -73,6 +77,9 @@ export function createProjectRoute(integrations: IntegrationsModuleClient) {
           status: 409,
         });
       }
+      if (error instanceof ProjectSlugConflictError) {
+        throw new ClientError('Project slug already exists', 'slug-conflict', {status: 409});
+      }
       if (known?.code === 'provider-failure') {
         throw new ClientError('Integration provider request failed', known.details.reason, {
           details: {retry_after_seconds: known.details.retryAfterSeconds},
@@ -82,7 +89,7 @@ export function createProjectRoute(integrations: IntegrationsModuleClient) {
       throw error;
     },
     handler: async (request, reply) => {
-      const {workspace_id: workspaceId, name, source} = request.body;
+      const {workspace_id: workspaceId, name, slug, source} = request.body;
       const actor = requireUserContext(request);
 
       requireWorkspaceAccess({request, workspaceId});
@@ -90,6 +97,7 @@ export function createProjectRoute(integrations: IntegrationsModuleClient) {
         actorId: actor.userId,
         workspaceId,
         name,
+        slug,
         sourceConnectionId: source.connection_id,
         sourceExternalRepositoryId: source.external_repository_id,
         integrations,

--- a/libs/api/projects/src/presentation/routes/index.ts
+++ b/libs/api/projects/src/presentation/routes/index.ts
@@ -5,6 +5,7 @@ import {createAdminProjectsRoute} from './admin-projects.js';
 import {createProjectRoute} from './create-project.js';
 import {getProjectRoute} from './get-project.js';
 import {listProjectsRoute} from './list-projects.js';
+import {updateProjectRoute} from './update-project.js';
 
 export function createProjectRoutes(
   integrations: IntegrationsModuleClient,
@@ -13,7 +14,12 @@ export function createProjectRoutes(
   return [
     {
       prefix: '/projects',
-      routes: [createProjectRoute(integrations), listProjectsRoute, getProjectRoute],
+      routes: [
+        createProjectRoute(integrations),
+        listProjectsRoute,
+        getProjectRoute,
+        updateProjectRoute,
+      ],
     },
     {
       prefix: '/admin/projects',

--- a/libs/api/projects/src/presentation/routes/projects.test.ts
+++ b/libs/api/projects/src/presentation/routes/projects.test.ts
@@ -15,9 +15,12 @@ import {
 import {createInterModuleKnownError} from '@shipfox/inter-module';
 import type {AuthMethod} from '@shipfox/node-fastify';
 import {closeApp, createApp} from '@shipfox/node-fastify';
+import {sql} from 'drizzle-orm';
 import type {FastifyInstance, FastifyRequest} from 'fastify';
 import type {Project} from '#core/entities/project.js';
+import {db} from '#db/db.js';
 import {createProject} from '#db/projects.js';
+import {projectsOutbox} from '#db/schema/outbox.js';
 import {createProjectRoutes} from './index.js';
 
 let authenticatedMemberships: UserContextMembership[] = [];
@@ -95,6 +98,7 @@ describe('project routes', () => {
       payload: {
         workspace_id: workspaceId,
         name: '  Platform  ',
+        slug: 'platform',
         source: {
           connection_id: sourceConnectionId,
           external_repository_id: 'gitea:gitea-owner/platform',
@@ -104,10 +108,288 @@ describe('project routes', () => {
 
     expect(res.statusCode).toBe(201);
     expect(res.json().name).toBe('Platform');
+    expect(res.json().slug).toBe('platform');
     expect(res.json().source).toEqual({
       connection_id: sourceConnectionId,
       external_repository_id: 'gitea:gitea-owner/platform',
     });
+  });
+
+  test('returns a distinct conflict when a slug is taken in the workspace', async () => {
+    await app.inject({
+      method: 'POST',
+      url: '/projects',
+      headers: {authorization: 'Bearer user'},
+      payload: {
+        workspace_id: workspaceId,
+        name: 'Platform',
+        slug: 'platform',
+        source: {
+          connection_id: sourceConnectionId,
+          external_repository_id: 'gitea:gitea-owner/platform',
+        },
+      },
+    });
+    vi.mocked(integrations.resolveSourceRepository).mockResolvedValueOnce({
+      connection: {
+        id: crypto.randomUUID(),
+        provider: 'gitea',
+        slug: 'gitea_owner',
+      },
+      repository: {
+        externalRepositoryId: 'gitea:gitea-owner/other',
+        owner: 'gitea-owner',
+        name: 'other',
+        fullName: 'gitea-owner/other',
+        defaultBranch: 'main',
+        visibility: 'private',
+        cloneUrl: 'https://gitea.local/gitea-owner/other.git',
+        htmlUrl: 'https://gitea.local/gitea-owner/other',
+      },
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/projects',
+      headers: {authorization: 'Bearer user'},
+      payload: {
+        workspace_id: workspaceId,
+        name: 'Other',
+        slug: 'platform',
+        source: {
+          connection_id: crypto.randomUUID(),
+          external_repository_id: 'gitea:gitea-owner/other',
+        },
+      },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('slug-conflict');
+    expect(res.json().code).not.toBe('project-already-exists');
+  });
+
+  test('allows the same slug in different workspaces', async () => {
+    const secondWorkspaceId = crypto.randomUUID();
+    authenticatedMemberships = [
+      {workspaceId, role: 'admin', workspaceStatus: 'active'},
+      {workspaceId: secondWorkspaceId, role: 'admin', workspaceStatus: 'active'},
+    ];
+    await app.inject({
+      method: 'POST',
+      url: '/projects',
+      headers: {authorization: 'Bearer user'},
+      payload: {
+        workspace_id: workspaceId,
+        name: 'Platform',
+        slug: 'platform',
+        source: {
+          connection_id: sourceConnectionId,
+          external_repository_id: 'gitea:gitea-owner/platform',
+        },
+      },
+    });
+    vi.mocked(integrations.resolveSourceRepository).mockResolvedValueOnce({
+      connection: {
+        id: crypto.randomUUID(),
+        provider: 'gitea',
+        slug: 'gitea_owner',
+      },
+      repository: {
+        externalRepositoryId: 'gitea:gitea-owner/other-workspace',
+        owner: 'gitea-owner',
+        name: 'other-workspace',
+        fullName: 'gitea-owner/other-workspace',
+        defaultBranch: 'main',
+        visibility: 'private',
+        cloneUrl: 'https://gitea.local/gitea-owner/other-workspace.git',
+        htmlUrl: 'https://gitea.local/gitea-owner/other-workspace',
+      },
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/projects',
+      headers: {authorization: 'Bearer user'},
+      payload: {
+        workspace_id: secondWorkspaceId,
+        name: 'Platform',
+        slug: 'platform',
+        source: {
+          connection_id: crypto.randomUUID(),
+          external_repository_id: 'gitea:gitea-owner/other-workspace',
+        },
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.json().slug).toBe('platform');
+  });
+
+  test('accepts a project slug named new', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/projects',
+      headers: {authorization: 'Bearer user'},
+      payload: {
+        workspace_id: workspaceId,
+        name: 'New Project',
+        slug: 'new',
+        source: {
+          connection_id: sourceConnectionId,
+          external_repository_id: 'gitea:gitea-owner/platform',
+        },
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.json().slug).toBe('new');
+  });
+
+  test('renames a project, frees the old slug, and writes an update event', async () => {
+    const createRes = await app.inject({
+      method: 'POST',
+      url: '/projects',
+      headers: {authorization: 'Bearer user'},
+      payload: {
+        workspace_id: workspaceId,
+        name: 'Platform',
+        slug: 'platform',
+        source: {
+          connection_id: sourceConnectionId,
+          external_repository_id: 'gitea:gitea-owner/platform',
+        },
+      },
+    });
+
+    const patchRes = await app.inject({
+      method: 'PATCH',
+      url: `/projects/${createRes.json().id}`,
+      headers: {authorization: 'Bearer user'},
+      payload: {name: 'Renamed Platform', slug: 'renamed-platform'},
+    });
+
+    expect(patchRes.statusCode).toBe(200);
+    expect(patchRes.json()).toMatchObject({
+      name: 'Renamed Platform',
+      slug: 'renamed-platform',
+    });
+
+    const events = await db()
+      .select()
+      .from(projectsOutbox)
+      .where(sql`${projectsOutbox.payload}->>'projectId' = ${createRes.json().id}`);
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          eventType: 'projects.project.updated',
+          payload: expect.objectContaining({
+            name: 'Renamed Platform',
+            slug: 'renamed-platform',
+          }),
+        }),
+      ]),
+    );
+
+    vi.mocked(integrations.resolveSourceRepository).mockResolvedValueOnce({
+      connection: {
+        id: crypto.randomUUID(),
+        provider: 'gitea',
+        slug: 'gitea_owner',
+      },
+      repository: {
+        externalRepositoryId: 'gitea:gitea-owner/other',
+        owner: 'gitea-owner',
+        name: 'other',
+        fullName: 'gitea-owner/other',
+        defaultBranch: 'main',
+        visibility: 'private',
+        cloneUrl: 'https://gitea.local/gitea-owner/other.git',
+        htmlUrl: 'https://gitea.local/gitea-owner/other',
+      },
+    });
+    const reuseRes = await app.inject({
+      method: 'POST',
+      url: '/projects',
+      headers: {authorization: 'Bearer user'},
+      payload: {
+        workspace_id: workspaceId,
+        name: 'Other',
+        slug: 'platform',
+        source: {
+          connection_id: crypto.randomUUID(),
+          external_repository_id: 'gitea:gitea-owner/other',
+        },
+      },
+    });
+    expect(reuseRes.statusCode).toBe(201);
+  });
+
+  test('treats an empty project update as a no-op', async () => {
+    const createRes = await app.inject({
+      method: 'POST',
+      url: '/projects',
+      headers: {authorization: 'Bearer user'},
+      payload: {
+        workspace_id: workspaceId,
+        name: 'Platform',
+        slug: 'platform',
+        source: {
+          connection_id: sourceConnectionId,
+          external_repository_id: 'gitea:gitea-owner/platform',
+        },
+      },
+    });
+    const created = createRes.json();
+    const beforeEvents = await db()
+      .select()
+      .from(projectsOutbox)
+      .where(sql`${projectsOutbox.payload}->>'projectId' = ${created.id}`);
+
+    const patchRes = await app.inject({
+      method: 'PATCH',
+      url: `/projects/${created.id}`,
+      headers: {authorization: 'Bearer user'},
+      payload: {},
+    });
+
+    expect(patchRes.statusCode).toBe(200);
+    expect(patchRes.json()).toMatchObject({
+      name: 'Platform',
+      slug: 'platform',
+      updated_at: created.updated_at,
+    });
+    const afterEvents = await db()
+      .select()
+      .from(projectsOutbox)
+      .where(sql`${projectsOutbox.payload}->>'projectId' = ${created.id}`);
+    expect(afterEvents).toHaveLength(beforeEvents.length);
+  });
+
+  test('returns a slug conflict when updating to another project slug', async () => {
+    const first = await createProject({
+      workspaceId,
+      name: 'Platform',
+      slug: 'platform',
+      sourceConnectionId: crypto.randomUUID(),
+      sourceExternalRepositoryId: 'gitea:platform',
+    });
+    const second = await createProject({
+      workspaceId,
+      name: 'Other',
+      slug: 'other',
+      sourceConnectionId: crypto.randomUUID(),
+      sourceExternalRepositoryId: 'gitea:other',
+    });
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: `/projects/${second.id}`,
+      headers: {authorization: 'Bearer user'},
+      payload: {slug: first.slug},
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('slug-conflict');
   });
 
   test.each([
@@ -122,6 +404,7 @@ describe('project routes', () => {
       payload: {
         workspace_id: workspaceId,
         name,
+        slug: 'invalid-name',
         source: {
           connection_id: sourceConnectionId,
           external_repository_id: 'gitea:gitea-owner/platform',
@@ -141,6 +424,7 @@ describe('project routes', () => {
       payload: {
         workspace_id: workspaceId,
         name: 'Platform',
+        slug: 'platform',
         source: {
           connection_id: sourceConnectionId,
           external_repository_id: 'gitea:gitea-owner/platform',
@@ -189,6 +473,7 @@ describe('project routes', () => {
         payload: {
           workspace_id: workspaceId,
           name,
+          slug: name.toLowerCase(),
           source: {
             connection_id: sourceConnectionId,
             external_repository_id: `gitea:gitea-owner/${name.toLowerCase()}-${index}`,
@@ -212,6 +497,7 @@ describe('project routes', () => {
     const payload = {
       workspace_id: workspaceId,
       name: 'Platform',
+      slug: 'platform',
       source: {
         connection_id: sourceConnectionId,
         external_repository_id: 'gitea:gitea-owner/platform',
@@ -252,6 +538,7 @@ describe('project routes', () => {
       payload: {
         workspace_id: workspaceId,
         name: 'Platform',
+        slug: 'platform',
         source: {
           connection_id: sourceConnectionId,
           external_repository_id: 'gitea:gitea-owner/platform',
@@ -320,6 +607,7 @@ describe('project routes', () => {
         await createProject({
           workspaceId,
           name,
+          slug: name.toLowerCase(),
           sourceConnectionId: crypto.randomUUID(),
           sourceExternalRepositoryId: `gitea:${name.toLowerCase()}`,
         }),
@@ -375,12 +663,14 @@ describe('project routes', () => {
     const firstProject = await createProject({
       workspaceId: firstWorkspaceId,
       name: 'GlobalAdminLookupAlpha',
+      slug: 'global-admin-lookup-alpha',
       sourceConnectionId: crypto.randomUUID(),
       sourceExternalRepositoryId: 'gitea:global-admin-lookup-alpha',
     });
     const secondProject = await createProject({
       workspaceId: secondWorkspaceId,
       name: 'GlobalAdminLookupBeta',
+      slug: 'global-admin-lookup-beta',
       sourceConnectionId: crypto.randomUUID(),
       sourceExternalRepositoryId: 'gitea:global-admin-lookup-beta',
     });
@@ -404,6 +694,7 @@ describe('project routes', () => {
     const project = await createProject({
       workspaceId,
       name: 'Platform',
+      slug: 'platform',
       sourceConnectionId: crypto.randomUUID(),
       sourceExternalRepositoryId: 'gitea:platform',
     });

--- a/libs/api/projects/src/presentation/routes/update-project.ts
+++ b/libs/api/projects/src/presentation/routes/update-project.ts
@@ -1,0 +1,46 @@
+import {AUTH_USER, requireUserContext} from '@shipfox/api-auth-context';
+import {projectResponseSchema, updateProjectBodySchema} from '@shipfox/api-projects-dto';
+import {ClientError, defineRoute} from '@shipfox/node-fastify';
+import {z} from 'zod';
+import {ProjectNotFoundError, ProjectSlugConflictError, updateProjectDetails} from '#core/index.js';
+import {requireProjectAccess} from '#presentation/auth/require-project-access.js';
+import {toProjectDto} from '#presentation/dto/index.js';
+
+const projectParamsSchema = z.object({
+  projectId: z.string().uuid(),
+});
+
+export const updateProjectRoute = defineRoute({
+  method: 'PATCH',
+  path: '/:projectId',
+  auth: AUTH_USER,
+  description: 'Update a project.',
+  schema: {
+    params: projectParamsSchema,
+    body: updateProjectBodySchema,
+    response: {
+      200: projectResponseSchema,
+    },
+  },
+  errorHandler: (error) => {
+    if (error instanceof ProjectSlugConflictError) {
+      throw new ClientError('Project slug already exists', 'slug-conflict', {status: 409});
+    }
+    if (error instanceof ProjectNotFoundError) {
+      throw new ClientError('Project not found', 'project-not-found', {status: 404});
+    }
+    throw error;
+  },
+  handler: async (request) => {
+    const {projectId} = request.params;
+    await requireProjectAccess({request, projectId});
+    const actor = requireUserContext(request);
+    const project = await updateProjectDetails({
+      actorId: actor.userId,
+      projectId,
+      name: request.body.name,
+      slug: request.body.slug,
+    });
+    return toProjectDto(project);
+  },
+});

--- a/libs/api/projects/test/factories/project.ts
+++ b/libs/api/projects/test/factories/project.ts
@@ -1,3 +1,4 @@
+import {withSlugSuffix} from '@shipfox/api-common-dto';
 import {Factory} from 'fishery';
 import type {Project} from '#core/entities/index.js';
 import {createProject} from '#db/index.js';
@@ -9,6 +10,7 @@ export const projectFactory = Factory.define<Project>(({sequence, onCreate}) => 
       sourceConnectionId: project.sourceConnectionId,
       sourceExternalRepositoryId: project.sourceExternalRepositoryId,
       name: project.name,
+      slug: project.slug,
     }),
   );
 
@@ -21,6 +23,7 @@ export const projectFactory = Factory.define<Project>(({sequence, onCreate}) => 
     sourceRepositoryName: null,
     sourceDefaultBranch: null,
     name: `Project ${sequence}`,
+    slug: withSlugSuffix('project', sequence + 1),
     createdAt: new Date(),
     updatedAt: new Date(),
   };

--- a/libs/client/onboarding/src/workspace-setup-route.test.tsx
+++ b/libs/client/onboarding/src/workspace-setup-route.test.tsx
@@ -211,6 +211,7 @@ function projectStub() {
     id: '22222222-2222-4222-8222-222222222222',
     workspace_id: WORKSPACE_ID,
     name: 'Platform',
+    slug: 'platform',
     source: {
       connection_id: '33333333-3333-4333-8333-333333333333',
       external_repository_id: 'platform',

--- a/libs/client/projects/package.json
+++ b/libs/client/projects/package.json
@@ -62,6 +62,7 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
+    "@shipfox/api-common-dto": "workspace:*",
     "@shipfox/api-definitions-dto": "workspace:*",
     "@shipfox/api-integration-core-dto": "workspace:*",
     "@shipfox/api-projects-dto": "workspace:*",

--- a/libs/client/projects/src/components/project-switcher.test.tsx
+++ b/libs/client/projects/src/components/project-switcher.test.tsx
@@ -82,6 +82,7 @@ function projectDto({id, name}: {id: string; name: string}) {
     id,
     workspace_id: PROJECT_TEST_WID,
     name,
+    slug: name.toLowerCase(),
     source: {
       connection_id: '33333333-3333-4333-8333-333333333333',
       external_repository_id: name.toLowerCase(),

--- a/libs/client/projects/src/core/project.ts
+++ b/libs/client/projects/src/core/project.ts
@@ -7,6 +7,7 @@ export interface Project {
   id: string;
   workspaceId: string;
   name: string;
+  slug: string;
   source: ProjectSource;
   createdAt: string;
   updatedAt: string;
@@ -20,6 +21,7 @@ export interface ProjectList {
 export interface CreateProjectCommand {
   workspaceId: string;
   name: string;
+  slug: string;
   source: ProjectSource;
 }
 

--- a/libs/client/projects/src/hooks/api/mappers.ts
+++ b/libs/client/projects/src/hooks/api/mappers.ts
@@ -8,6 +8,7 @@ export function toProject(dto: ProjectResponseDto): Project {
     id: dto.id,
     workspaceId: dto.workspace_id,
     name: dto.name,
+    slug: dto.slug,
     source: {
       connectionId: dto.source.connection_id,
       externalRepositoryId: dto.source.external_repository_id,

--- a/libs/client/projects/src/hooks/api/projects.test.ts
+++ b/libs/client/projects/src/hooks/api/projects.test.ts
@@ -73,6 +73,7 @@ describe('createProject', () => {
 
     const request = fetchImpl.mock.calls[0]?.[0] as Request;
     expect(result.name).toBe('Platform');
+    expect(result.slug).toBe('platform');
     expect(request.url).toBe('https://api.example.test/projects');
     expect(request.method).toBe('POST');
     expect(requestBody).toEqual({

--- a/libs/client/projects/src/hooks/api/projects.test.ts
+++ b/libs/client/projects/src/hooks/api/projects.test.ts
@@ -49,6 +49,7 @@ describe('createProject', () => {
         id: '44444444-4444-4444-8444-444444444444',
         workspace_id: '11111111-1111-4111-8111-111111111111',
         name: 'Platform',
+        slug: 'platform',
         source: {
           connection_id: '33333333-3333-4333-8333-333333333333',
           external_repository_id: 'platform',
@@ -61,6 +62,7 @@ describe('createProject', () => {
     const body = {
       workspaceId: '11111111-1111-4111-8111-111111111111',
       name: 'Platform',
+      slug: 'platform',
       source: {
         connectionId: '33333333-3333-4333-8333-333333333333',
         externalRepositoryId: 'platform',
@@ -76,6 +78,7 @@ describe('createProject', () => {
     expect(requestBody).toEqual({
       workspace_id: body.workspaceId,
       name: body.name,
+      slug: body.slug,
       source: {
         connection_id: body.source.connectionId,
         external_repository_id: body.source.externalRepositoryId,

--- a/libs/client/projects/src/hooks/api/projects.ts
+++ b/libs/client/projects/src/hooks/api/projects.ts
@@ -80,6 +80,7 @@ export async function createProject(command: CreateProjectCommand): Promise<Proj
   const body = createProjectBodySchema.parse({
     workspace_id: command.workspaceId,
     name: command.name,
+    slug: command.slug,
     source: {
       connection_id: command.source.connectionId,
       external_repository_id: command.source.externalRepositoryId,

--- a/libs/client/projects/src/pages/create-project-page.stories.tsx
+++ b/libs/client/projects/src/pages/create-project-page.stories.tsx
@@ -176,6 +176,7 @@ function fetchForScenario(scenario: Scenario): typeof fetch {
           id: '99999999-9999-4999-8999-999999999999',
           workspace_id: WORKSPACE_ID,
           name: 'Platform',
+          slug: 'platform',
           source: {
             connection_id: GITHUB_CONNECTION_ID,
             external_repository_id: 'platform',

--- a/libs/client/projects/src/pages/create-project-page.test.tsx
+++ b/libs/client/projects/src/pages/create-project-page.test.tsx
@@ -37,6 +37,7 @@ describe('CreateProjectPage', () => {
     const slugInput = await screen.findByLabelText('Project slug');
     await waitFor(() => expect(nameInput).toHaveValue('Platform'));
     expect(slugInput).toHaveValue('platform');
+    expect(slugInput).toHaveAttribute('aria-describedby', 'project-slug-description');
     expect(screen.getByRole('radio', {name: GITEA_RADIO_LABEL_RE})).toBeChecked();
     expect(screen.getAllByText('gitea-owner/platform').length).toBeGreaterThan(0);
     fireEvent.change(nameInput, {
@@ -286,6 +287,10 @@ describe('CreateProjectPage', () => {
     fireEvent.click(screen.getByRole('button', {name: 'Create project'}));
 
     expect(await screen.findByText('This project slug is already in use.')).toBeInTheDocument();
+    expect(screen.getByLabelText('Project slug')).toHaveAttribute(
+      'aria-describedby',
+      'project-slug-error',
+    );
     await waitFor(() => expect(screen.getByLabelText('Project slug')).toHaveFocus());
     expect(screen.queryByText(PROJECT_REQUEST_FAILED_RE)).not.toBeInTheDocument();
   });

--- a/libs/client/projects/src/pages/create-project-page.test.tsx
+++ b/libs/client/projects/src/pages/create-project-page.test.tsx
@@ -290,6 +290,37 @@ describe('CreateProjectPage', () => {
     expect(screen.queryByText(PROJECT_REQUEST_FAILED_RE)).not.toBeInTheDocument();
   });
 
+  test('clears a slug conflict when the slug is regenerated from the project name', async () => {
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (request.url.includes('/integration-connections?')) {
+        return Promise.resolve(jsonResponse({connections: [connectionDto()]}));
+      }
+      if (request.url.includes(`/integration-connections/${CONNECTION_ID}/repositories`)) {
+        return Promise.resolve(jsonResponse({repositories: [repositoryDto()], next_cursor: null}));
+      }
+      if (request.url.endsWith('/projects') && request.method === 'POST') {
+        return Promise.resolve(jsonResponse({code: 'slug-conflict'}, {status: 409}));
+      }
+      return Promise.resolve(jsonResponse({}));
+    });
+    configureApiClient({fetchImpl});
+
+    renderProjectPage(`/workspaces/${PROJECT_TEST_WID}/projects/new`, <CreateProjectPage />);
+    expect((await screen.findAllByText('gitea-owner/platform')).length).toBeGreaterThan(0);
+    fireEvent.click(screen.getByRole('button', {name: 'Create project'}));
+
+    expect(await screen.findByText('This project slug is already in use.')).toBeInTheDocument();
+    fireEvent.change(await screen.findByLabelText('Project name'), {
+      target: {value: 'Launch Pad'},
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('This project slug is already in use.')).not.toBeInTheDocument();
+      expect(screen.getByLabelText('Project slug')).toHaveValue('launch-pad');
+    });
+  });
+
   test('shows provider-specific submit errors', async () => {
     const fetchImpl = vi.fn((input: RequestInfo | URL) => {
       const request = input as Request;

--- a/libs/client/projects/src/pages/create-project-page.test.tsx
+++ b/libs/client/projects/src/pages/create-project-page.test.tsx
@@ -38,6 +38,7 @@ describe('CreateProjectPage', () => {
     await waitFor(() => expect(nameInput).toHaveValue('Platform'));
     expect(slugInput).toHaveValue('platform');
     expect(slugInput).toHaveAttribute('aria-describedby', 'project-slug-description');
+    expect(screen.getByText('/w/acme/p/platform')).toBeInTheDocument();
     expect(screen.getByRole('radio', {name: GITEA_RADIO_LABEL_RE})).toBeChecked();
     expect(screen.getAllByText('gitea-owner/platform').length).toBeGreaterThan(0);
     fireEvent.change(nameInput, {
@@ -46,6 +47,7 @@ describe('CreateProjectPage', () => {
     fireEvent.change(slugInput, {
       target: {value: 'launchpad'},
     });
+    expect(screen.getByText('/w/acme/p/launchpad')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', {name: 'Create project'}));
 
     expect(await screen.findByRole('heading', {name: 'Runs'})).toBeInTheDocument();
@@ -83,6 +85,7 @@ describe('CreateProjectPage', () => {
     fireEvent.change(nameInput, {target: {value: 'Launch Pad'}});
 
     expect(slugInput).toHaveValue('launch-pad');
+    expect(screen.getByText('/w/acme/p/launch-pad')).toBeInTheDocument();
   });
 
   test('uses the current repository-derived name when submitted before touching the field', async () => {

--- a/libs/client/projects/src/pages/create-project-page.test.tsx
+++ b/libs/client/projects/src/pages/create-project-page.test.tsx
@@ -6,6 +6,7 @@ import {CreateProjectPage} from './create-project-page.js';
 const CONNECTION_ID = '33333333-3333-4333-8333-333333333333';
 const SECOND_CONNECTION_ID = '66666666-6666-4666-8666-666666666666';
 const REPOSITORY_NOT_FOUND_RE = /Repository not found/;
+const PROJECT_REQUEST_FAILED_RE = /Project request failed/;
 const GITEA_RADIO_LABEL_RE = /^Gitea Source$/;
 
 describe('CreateProjectPage', () => {
@@ -33,11 +34,16 @@ describe('CreateProjectPage', () => {
 
     renderProjectPage(`/workspaces/${PROJECT_TEST_WID}/projects/new`, <CreateProjectPage />);
     const nameInput = await screen.findByLabelText('Project name');
+    const slugInput = await screen.findByLabelText('Project slug');
     await waitFor(() => expect(nameInput).toHaveValue('Platform'));
+    expect(slugInput).toHaveValue('platform');
     expect(screen.getByRole('radio', {name: GITEA_RADIO_LABEL_RE})).toBeChecked();
     expect(screen.getAllByText('gitea-owner/platform').length).toBeGreaterThan(0);
     fireEvent.change(nameInput, {
       target: {value: '  Launch Pad  '},
+    });
+    fireEvent.change(slugInput, {
+      target: {value: 'launchpad'},
     });
     fireEvent.click(screen.getByRole('button', {name: 'Create project'}));
 
@@ -45,12 +51,38 @@ describe('CreateProjectPage', () => {
     expect(createProjectBody).toEqual({
       workspace_id: PROJECT_TEST_WID,
       name: 'Launch Pad',
+      slug: 'launchpad',
       source: {
         connection_id: CONNECTION_ID,
         external_repository_id: 'platform',
       },
     });
   }, 10_000);
+
+  test('auto-derives the slug from each keystroke in the name field until the slug is touched', async () => {
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (request.url.includes('/integration-connections?')) {
+        return Promise.resolve(jsonResponse({connections: [connectionDto()]}));
+      }
+      if (request.url.includes(`/integration-connections/${CONNECTION_ID}/repositories`)) {
+        return Promise.resolve(jsonResponse({repositories: [repositoryDto()], next_cursor: null}));
+      }
+      return Promise.resolve(jsonResponse({}));
+    });
+    configureApiClient({fetchImpl});
+
+    renderProjectPage(`/workspaces/${PROJECT_TEST_WID}/projects/new`, <CreateProjectPage />);
+    const nameInput = await screen.findByLabelText('Project name');
+    const slugInput = await screen.findByLabelText('Project slug');
+    await waitFor(() => expect(nameInput).toHaveValue('Platform'));
+
+    fireEvent.change(nameInput, {target: {value: 'L'}});
+    fireEvent.change(nameInput, {target: {value: 'La'}});
+    fireEvent.change(nameInput, {target: {value: 'Launch Pad'}});
+
+    expect(slugInput).toHaveValue('launch-pad');
+  });
 
   test('uses the current repository-derived name when submitted before touching the field', async () => {
     let createProjectBody: unknown;
@@ -78,6 +110,7 @@ describe('CreateProjectPage', () => {
     expect(createProjectBody).toEqual({
       workspace_id: PROJECT_TEST_WID,
       name: 'Platform',
+      slug: 'platform',
       source: {
         connection_id: CONNECTION_ID,
         external_repository_id: 'platform',
@@ -232,6 +265,31 @@ describe('CreateProjectPage', () => {
     expect(await screen.findByRole('heading', {name: 'Runs'})).toBeInTheDocument();
   });
 
+  test('surfaces a slug conflict on the slug field without a generic form error', async () => {
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (request.url.includes('/integration-connections?')) {
+        return Promise.resolve(jsonResponse({connections: [connectionDto()]}));
+      }
+      if (request.url.includes(`/integration-connections/${CONNECTION_ID}/repositories`)) {
+        return Promise.resolve(jsonResponse({repositories: [repositoryDto()], next_cursor: null}));
+      }
+      if (request.url.endsWith('/projects') && request.method === 'POST') {
+        return Promise.resolve(jsonResponse({code: 'slug-conflict'}, {status: 409}));
+      }
+      return Promise.resolve(jsonResponse({}));
+    });
+    configureApiClient({fetchImpl});
+
+    renderProjectPage(`/workspaces/${PROJECT_TEST_WID}/projects/new`, <CreateProjectPage />);
+    expect((await screen.findAllByText('gitea-owner/platform')).length).toBeGreaterThan(0);
+    fireEvent.click(screen.getByRole('button', {name: 'Create project'}));
+
+    expect(await screen.findByText('This project slug is already in use.')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByLabelText('Project slug')).toHaveFocus());
+    expect(screen.queryByText(PROJECT_REQUEST_FAILED_RE)).not.toBeInTheDocument();
+  });
+
   test('shows provider-specific submit errors', async () => {
     const fetchImpl = vi.fn((input: RequestInfo | URL) => {
       const request = input as Request;
@@ -302,6 +360,7 @@ function projectDto({id}: {id: string}) {
     id,
     workspace_id: '11111111-1111-4111-8111-111111111111',
     name: 'Project Detail',
+    slug: 'project-detail',
     source: {
       connection_id: CONNECTION_ID,
       external_repository_id: 'platform',

--- a/libs/client/projects/src/pages/create-project-page.tsx
+++ b/libs/client/projects/src/pages/create-project-page.tsx
@@ -88,6 +88,7 @@ export function CreateProjectPage() {
     if (!nameTouched && form.state.values.name !== defaultProjectName) {
       form.setFieldValue('name', defaultProjectName);
       if (!slugTouched) {
+        setSlugConflict(false);
         form.setFieldValue('slug', slugifyName(defaultProjectName, {fallback: 'project'}));
       }
     }
@@ -307,6 +308,7 @@ export function CreateProjectPage() {
                       setNameTouched(true);
                       field.handleChange(nextName);
                       if (!slugTouched) {
+                        setSlugConflict(false);
                         form.setFieldValue('slug', slugifyName(nextName, {fallback: 'project'}));
                       }
                     }}

--- a/libs/client/projects/src/pages/create-project-page.tsx
+++ b/libs/client/projects/src/pages/create-project-page.tsx
@@ -331,7 +331,11 @@ export function CreateProjectPage() {
                   label="Project slug"
                   id="project-slug"
                   error={slugConflict ? 'This project slug is already in use.' : fieldError(field)}
-                  description="Used in project URLs."
+                  description={
+                    <span className="font-code" aria-live="polite">
+                      {`/w/${workspace.slug}/p/${field.state.value}`}
+                    </span>
+                  }
                 >
                   <FormFieldInput
                     name="slug"

--- a/libs/client/projects/src/pages/create-project-page.tsx
+++ b/libs/client/projects/src/pages/create-project-page.tsx
@@ -1,3 +1,4 @@
+import {slugifyName} from '@shipfox/api-common-dto';
 import {createProjectBodySchema} from '@shipfox/api-projects-dto';
 import {useMaybeActiveWorkspace} from '@shipfox/client-auth';
 import {
@@ -69,21 +70,28 @@ export function CreateProjectPage() {
   const defaultProjectName = projectNameFromRepository(
     selectedRepository?.name ?? selectedRepositoryId ?? '',
   );
+  const defaultProjectSlug = slugifyName(defaultProjectName, {fallback: 'project'});
 
   const [formError, setFormError] = useState<string | undefined>();
+  const [slugTouched, setSlugTouched] = useState(false);
+  const [slugConflict, setSlugConflict] = useState(false);
 
   const form = useForm({
-    defaultValues: {name: defaultProjectName},
+    defaultValues: {name: defaultProjectName, slug: defaultProjectSlug},
     onSubmit: async ({value}) => {
-      await createProjectFromForm(nameTouched ? value.name : defaultProjectName);
+      const projectSlug = slugTouched ? value.slug : slugifyName(value.name, {fallback: 'project'});
+      await createProjectFromForm(nameTouched ? value.name : defaultProjectName, projectSlug);
     },
   });
 
   useEffect(() => {
     if (!nameTouched && form.state.values.name !== defaultProjectName) {
       form.setFieldValue('name', defaultProjectName);
+      if (!slugTouched) {
+        form.setFieldValue('slug', slugifyName(defaultProjectName, {fallback: 'project'}));
+      }
     }
-  }, [defaultProjectName, form, nameTouched]);
+  }, [defaultProjectName, form, nameTouched, slugTouched]);
 
   function selectConnection(connectionId: string) {
     setSelectedConnectionId(connectionId);
@@ -102,8 +110,9 @@ export function CreateProjectPage() {
     return <Navigate to="/workspaces/$wid/integrations" params={{wid: workspace.id}} replace />;
   }
 
-  async function createProjectFromForm(projectName: string) {
+  async function createProjectFromForm(projectName: string, projectSlug: string) {
     setFormError(undefined);
+    setSlugConflict(false);
     if (!workspace) {
       setFormError('Workspace is still loading. Try again in a moment.');
       errorRef.current?.focus();
@@ -124,6 +133,7 @@ export function CreateProjectPage() {
       const command: CreateProjectCommand = {
         workspaceId: workspace.id,
         name: projectName,
+        slug: projectSlug,
         source: {
           connectionId: selectedConnection.id,
           externalRepositoryId: selectedRepository.externalRepositoryId,
@@ -143,6 +153,11 @@ export function CreateProjectPage() {
           to: '/workspaces/$wid/projects/$pid',
           params: {wid: workspace.id, pid: copy.existingProjectId},
         });
+        return;
+      }
+      if (copy.slugConflict) {
+        setSlugConflict(true);
+        requestAnimationFrame(() => document.getElementById('project-slug')?.focus());
         return;
       }
       setFormError(`${copy.title}: ${copy.message}`);
@@ -288,12 +303,49 @@ export function CreateProjectPage() {
                     type="text"
                     value={field.state.value}
                     onChange={(event) => {
+                      const nextName = event.target.value;
                       setNameTouched(true);
-                      field.handleChange(event.target.value);
+                      field.handleChange(nextName);
+                      if (!slugTouched) {
+                        form.setFieldValue('slug', slugifyName(nextName, {fallback: 'project'}));
+                      }
                     }}
                     onBlur={field.handleBlur}
                     placeholder="Platform"
                   />
+                </FormField>
+              )}
+            </form.Field>
+
+            <form.Field
+              name="slug"
+              validators={{
+                onBlur: createProjectBodySchema.shape.slug,
+                onSubmit: createProjectBodySchema.shape.slug,
+              }}
+            >
+              {(field) => (
+                <FormField
+                  label="Project slug"
+                  id="project-slug"
+                  error={slugConflict ? 'This project slug is already in use.' : fieldError(field)}
+                >
+                  <FormFieldInput
+                    name="slug"
+                    type="text"
+                    value={field.state.value}
+                    onChange={(event) => {
+                      setSlugTouched(true);
+                      setSlugConflict(false);
+                      field.handleChange(event.target.value);
+                    }}
+                    onBlur={field.handleBlur}
+                    placeholder="platform"
+                    className="font-code"
+                  />
+                  <Text size="sm" className="text-foreground-neutral-muted">
+                    Used in project URLs.
+                  </Text>
                 </FormField>
               )}
             </form.Field>

--- a/libs/client/projects/src/pages/create-project-page.tsx
+++ b/libs/client/projects/src/pages/create-project-page.tsx
@@ -331,6 +331,7 @@ export function CreateProjectPage() {
                   label="Project slug"
                   id="project-slug"
                   error={slugConflict ? 'This project slug is already in use.' : fieldError(field)}
+                  description="Used in project URLs."
                 >
                   <FormFieldInput
                     name="slug"
@@ -345,9 +346,6 @@ export function CreateProjectPage() {
                     placeholder="platform"
                     className="font-code"
                   />
-                  <Text size="sm" className="text-foreground-neutral-muted">
-                    Used in project URLs.
-                  </Text>
                 </FormField>
               )}
             </form.Field>

--- a/libs/client/projects/src/pages/projects-hub-page.test.tsx
+++ b/libs/client/projects/src/pages/projects-hub-page.test.tsx
@@ -267,6 +267,7 @@ function projectDto({
     id,
     workspace_id: PROJECT_TEST_WID,
     name,
+    slug: name.toLowerCase(),
     source: {
       connection_id: connectionId,
       external_repository_id: externalRepositoryId,

--- a/libs/client/projects/src/project-error.test.ts
+++ b/libs/client/projects/src/project-error.test.ts
@@ -19,6 +19,7 @@ describe('projectErrorCopy', () => {
     ['malformed-provider-response', 'Provider response changed'],
     ['source-connection-not-found', 'Source connection not found'],
     ['source-connection-inactive', 'Source connection inactive'],
+    ['slug-conflict', 'Project slug already exists'],
   ])('maps %s', (code, title) => {
     const result = projectErrorCopy(apiError(code));
 

--- a/libs/client/projects/src/project-error.ts
+++ b/libs/client/projects/src/project-error.ts
@@ -4,6 +4,7 @@ export interface ProjectErrorCopy {
   title: string;
   message: string;
   existingProjectId?: string | undefined;
+  slugConflict?: boolean | undefined;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -96,6 +97,13 @@ export function projectErrorCopy(error: unknown): ProjectErrorCopy {
       title: 'Project already exists',
       message: 'This repository is already connected to a Shipfox project.',
       existingProjectId: stringDetail(error, 'existing_project_id'),
+    };
+  }
+  if (error.code === 'slug-conflict') {
+    return {
+      title: 'Project slug already exists',
+      message: 'Choose another slug and try again.',
+      slugConflict: true,
     };
   }
 

--- a/libs/client/workflows/src/pages/project-workflows-page.test.tsx
+++ b/libs/client/workflows/src/pages/project-workflows-page.test.tsx
@@ -222,6 +222,7 @@ function projectDto() {
     id: PROJECT_ID,
     workspace_id: PROJECT_TEST_WID,
     name: 'Platform',
+    slug: 'platform',
     source: {
       connection_id: CONNECTION_ID,
       external_repository_id: 'platform',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1402,6 +1402,9 @@ importers:
 
   e2e/setup/projects:
     dependencies:
+      '@shipfox/api-common-dto':
+        specifier: workspace:*
+        version: link:../../../libs/api/common-dto
       '@shipfox/api-projects-dto':
         specifier: workspace:*
         version: link:../../../libs/api/projects-dto
@@ -1828,6 +1831,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
         version: 1.29.0(zod@4.4.3)
+      '@shipfox/api-common-dto':
+        specifier: workspace:*
+        version: link:../../../../libs/api/common-dto
       '@shipfox/api-definitions-dto':
         specifier: workspace:*
         version: link:../../../../libs/api/definitions-dto
@@ -3675,6 +3681,9 @@ importers:
       '@shipfox/api-auth-dto':
         specifier: workspace:*
         version: link:../auth-dto
+      '@shipfox/api-common-dto':
+        specifier: workspace:*
+        version: link:../common-dto
       '@shipfox/api-integration-core-dto':
         specifier: workspace:*
         version: link:../integration/core-dto
@@ -5383,6 +5392,9 @@ importers:
 
   libs/client/projects:
     dependencies:
+      '@shipfox/api-common-dto':
+        specifier: workspace:*
+        version: link:../../api/common-dto
       '@shipfox/api-definitions-dto':
         specifier: workspace:*
         version: link:../../api/definitions-dto


### PR DESCRIPTION
Projects now carry a required, mutable slug across the API, database, events, client creation flow, and test helpers.

The API enforces workspace-scoped uniqueness, returns a distinct `slug-conflict` response, and exposes project updates through `PATCH /projects/:projectId`. No-op updates leave timestamps and outbox state unchanged. The client derives slugs from project names until the user edits the slug field.

The changeset uses major bumps for the three public project packages because the required create-request field is breaking for consumers.

Validation completed: focused API, client, and E2E tests; dependent type and type-emit checks; package checks; database-boundary, dependency, lockfile, and published-artifact validation.

Closes ENG-1448

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds required, workspace-scoped project slugs across API, database, and client, plus a new update endpoint and distinct 409 slug-conflict errors. Fulfills ENG-1448 by adding the slug field to the create form, enforcing workspace-level uniqueness, generating collision‑resistant slugs when omitted, showing a live project URL preview, and keeping events backward-compatible.

- New Features
  - Database: added NOT NULL `slug` with unique `(workspace_id, slug)`; `updateProject` preserves concurrent partial updates and only bumps `updated_at` on real changes.
  - API: `createProjectBodySchema.slug` is required; `PATCH /projects/:projectId` accepts `{name?, slug?}` and returns `409 slug-conflict`; `PROJECT_CREATED` accepts legacy payloads without `slug` and includes it going forward; new `PROJECT_UPDATED` event on changes; E2E `POST /projects` auto-generates collision-resistant slugs and retries uniqueness when omitted.
  - Client: create-project page adds a “Project slug” field, derives from name on each keystroke until edited, shows a live `/w/:workspace/p/:slug` preview, focuses the field on conflicts, clears stale slug errors when the name changes, and adds accessible descriptions; DTOs/mappers/tests now include `slug`.

- Migration
  - Breaking: require `slug` on create; bump `@shipfox/api-projects`, `@shipfox/api-projects-dto`, and `@shipfox/client-projects` to new majors.
  - DB: baseline updated; for dev/test, drop `projects_%` and `__drizzle_migrations_projects`, then migrate from scratch.
  - Consumers: send a workspace-unique `slug` when creating projects and handle `409 slug-conflict`; in-flight `PROJECT_CREATED` events without `slug` remain valid.

<sup>Written for commit d641eeaa5137920e6225ecfb417f3c4c2b5336fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

