### PR TITLE
Normalize source-control trigger references

### DIFF
--- a/.changeset/normalized-trigger-reference.md
+++ b/.changeset/normalized-trigger-reference.md
@@ -1,0 +1,8 @@
+---
+"@shipfox/api-integration-spi": minor
+"@shipfox/api-integration-core": patch
+"@shipfox/api-integration-github": patch
+"@shipfox/api-integration-gitea": patch
+---
+
+Adds provider-normalized repository, ref, and commit extraction for source-control trigger payloads.

--- a/libs/api/integration/core/src/core/agent-tool-selection.test.ts
+++ b/libs/api/integration/core/src/core/agent-tool-selection.test.ts
@@ -109,6 +109,7 @@ function sourceProvider(provider: string) {
           await Promise.resolve();
           throw new Error('not used');
         },
+        resolveTriggerReference: () => null,
       },
     },
   };

--- a/libs/api/integration/core/src/core/providers/registry.test.ts
+++ b/libs/api/integration/core/src/core/providers/registry.test.ts
@@ -22,6 +22,7 @@ function sourceControlAdapter() {
       await Promise.resolve();
       throw new Error('not used');
     },
+    resolveTriggerReference: () => null,
   };
 }
 

--- a/libs/api/integration/core/src/core/providers/source-control.ts
+++ b/libs/api/integration/core/src/core/providers/source-control.ts
@@ -14,4 +14,5 @@ export type {
   RepositoryVisibility,
   ResolveRepositoryInput,
   SourceControlProvider,
+  TriggerReference,
 } from '@shipfox/api-integration-spi';

--- a/libs/api/integration/core/src/core/source-control-service.test.ts
+++ b/libs/api/integration/core/src/core/source-control-service.test.ts
@@ -52,6 +52,7 @@ describe('integration source-control service', () => {
         await Promise.resolve();
         return {path: '.shipfox/workflows/ci.yml', ref: 'main', content: 'name: CI'};
       },
+      resolveTriggerReference: () => null,
       createCheckoutSpec: async (input) => {
         await Promise.resolve();
         return {repositoryUrl: repository.cloneUrl, ref: input.ref ?? repository.defaultBranch};

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -114,6 +114,7 @@ export type {
   RepositoryVisibility,
   ResolveRepositoryInput,
   SourceControlProvider,
+  TriggerReference,
 } from '#core/providers/source-control.js';
 export type {IntegrationSourceControlService} from '#core/source-control-service.js';
 export {createSourceControlIntegrationService} from '#core/source-control-service.js';

--- a/libs/api/integration/core/src/presentation/routes/list-repositories.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/list-repositories.test.ts
@@ -126,6 +126,7 @@ describe('GET /integration-connections/:connectionId/repositories', () => {
               await Promise.resolve();
               throw new Error('not used');
             },
+            resolveTriggerReference: () => null,
           },
         },
       }),

--- a/libs/api/integration/core/test/route-utils.ts
+++ b/libs/api/integration/core/test/route-utils.ts
@@ -66,6 +66,7 @@ export function sourceProvider(overrides: Partial<IntegrationProvider> = {}): In
           await Promise.resolve();
           throw new Error('not used');
         },
+        resolveTriggerReference: () => null,
       },
     },
     ...overrides,

--- a/libs/api/integration/gitea/src/core/source-control.test.ts
+++ b/libs/api/integration/gitea/src/core/source-control.test.ts
@@ -103,16 +103,6 @@ describe('GiteaSourceControlProvider', () => {
       repository: {full_name: 'shipfox/platform'},
     },
     {
-      ref: 'refs/heads/-feature',
-      after: VALID_COMMIT,
-      repository: {full_name: 'shipfox/platform'},
-    },
-    {
-      ref: 'refs/tags/-evil',
-      after: VALID_COMMIT,
-      repository: {full_name: 'shipfox/platform'},
-    },
-    {
       ref: 'refs/heads/feature..branch',
       after: VALID_COMMIT,
       repository: {full_name: 'shipfox/platform'},

--- a/libs/api/integration/gitea/src/core/source-control.test.ts
+++ b/libs/api/integration/gitea/src/core/source-control.test.ts
@@ -3,6 +3,8 @@ import type {GiteaApiClient, GiteaRepository} from '#api/client.js';
 import {GiteaIntegrationProviderError} from './errors.js';
 import {GiteaSourceControlProvider} from './source-control.js';
 
+const VALID_COMMIT = 'a'.repeat(40);
+
 const REPOSITORY: GiteaRepository = {
   ownerLogin: 'shipfox',
   name: 'platform',
@@ -53,6 +55,100 @@ function connection(): IntegrationConnection<'gitea'> {
 }
 
 describe('GiteaSourceControlProvider', () => {
+  it('normalizes push trigger references', () => {
+    const provider = new GiteaSourceControlProvider(giteaClient());
+
+    const result = provider.resolveTriggerReference({
+      ref: 'refs/heads/feature/review',
+      after: VALID_COMMIT,
+      repository: {full_name: 'shipfox/platform'},
+    });
+
+    expect(result).toEqual({
+      externalRepositoryId: 'gitea:shipfox/platform',
+      ref: 'refs/heads/feature/review',
+      commit: VALID_COMMIT,
+    });
+  });
+
+  it('normalizes pull-request trigger references from the head repository', () => {
+    const provider = new GiteaSourceControlProvider(giteaClient());
+
+    const result = provider.resolveTriggerReference({
+      repository: {full_name: 'shipfox/platform'},
+      pull_request: {
+        number: 17,
+        head: {
+          sha: VALID_COMMIT,
+          repo: {full_name: 'shipfox/platform'},
+        },
+        base: {repo: {full_name: 'shipfox/platform'}},
+      },
+    });
+
+    expect(result).toEqual({
+      externalRepositoryId: 'gitea:shipfox/platform',
+      ref: 'refs/pull/17/head',
+      commit: VALID_COMMIT,
+    });
+  });
+
+  it.each([
+    undefined,
+    {},
+    {ref: 'refs/heads/main', after: VALID_COMMIT},
+    {
+      ref: 'refs/heads/feature branch',
+      after: VALID_COMMIT,
+      repository: {full_name: 'shipfox/platform'},
+    },
+    {
+      ref: 'refs/heads/-feature',
+      after: VALID_COMMIT,
+      repository: {full_name: 'shipfox/platform'},
+    },
+    {
+      ref: 'refs/tags/-evil',
+      after: VALID_COMMIT,
+      repository: {full_name: 'shipfox/platform'},
+    },
+    {
+      ref: 'refs/heads/feature..branch',
+      after: VALID_COMMIT,
+      repository: {full_name: 'shipfox/platform'},
+    },
+    {
+      ref: 'refs/heads/main',
+      after: '0'.repeat(40),
+      repository: {full_name: 'shipfox/platform'},
+    },
+    {
+      ref: 'refs/heads/main',
+      after: 'not-a-commit',
+      repository: {full_name: 'shipfox/platform'},
+    },
+    {ref: 'refs/heads/main', after: VALID_COMMIT, repository: {full_name: 'shipfox'}},
+    {
+      ref: 'refs/heads/main',
+      after: VALID_COMMIT,
+      repository: {full_name: 'shipfox/platform/extra'},
+    },
+    {
+      repository: {full_name: 'shipfox/platform'},
+      pull_request: {
+        number: 17,
+        head: {sha: VALID_COMMIT, repo: {full_name: 'fork/platform'}},
+        base: {repo: {full_name: 'shipfox/platform'}},
+      },
+    },
+  ])('returns null for an unresolvable or unsafe trigger payload', (payload) => {
+    const provider = new GiteaSourceControlProvider(giteaClient());
+
+    const result = provider.resolveTriggerReference(payload);
+
+    expect(result).toBeNull();
+  });
+
   it('lists org repositories scoped to the connection account', async () => {
     const gitea = giteaClient();
     const provider = new GiteaSourceControlProvider(gitea);

--- a/libs/api/integration/gitea/src/core/source-control.ts
+++ b/libs/api/integration/gitea/src/core/source-control.ts
@@ -1,6 +1,7 @@
 import {Buffer} from 'node:buffer';
 import {giteaProviderKind} from '@shipfox/api-integration-gitea-dto';
 import {
+  asRecord,
   buildProviderRepositoryId,
   type CheckoutSpec,
   type CreateCheckoutSpecInput,
@@ -8,15 +9,21 @@ import {
   type FilePage,
   type FileSnapshot,
   type IntegrationConnection,
+  isRecord,
+  isValidGitObjectId,
+  isValidTriggerRef,
   type ListFilesInput,
   type ListRepositoriesInput,
   MAX_REPOSITORY_FILE_BYTES,
+  nonEmptyString,
   parseProviderRepositoryId,
+  positiveInteger,
   type RepositoryPage,
   type RepositorySnapshot,
   type RepositoryVisibility,
   type ResolveRepositoryInput,
   type SourceControlProvider,
+  type TriggerReference,
 } from '@shipfox/api-integration-spi';
 import type {GiteaApiClient, GiteaRepository} from '#api/client.js';
 import {config, giteaCloneBaseOrigin} from '#config.js';
@@ -134,6 +141,45 @@ export class GiteaSourceControlProvider
     };
   }
 
+  resolveTriggerReference(payload: unknown): TriggerReference | null {
+    if (!isRecord(payload)) return null;
+
+    const pullRequest = asRecord(payload.pull_request);
+    if (pullRequest) {
+      const head = asRecord(pullRequest.head);
+      const repository = asRecord(head?.repo);
+      const base = asRecord(pullRequest.base);
+      const baseRepository = asRecord(base?.repo) ?? asRecord(payload.repository);
+      if (!repository || !baseRepository || !sameGiteaRepository(repository, baseRepository)) {
+        return null;
+      }
+      const repositoryId = giteaRepositoryId(repository);
+      const number = positiveInteger(pullRequest.number);
+      const commit = nonEmptyString(head?.sha);
+      const ref = number === null ? null : `refs/pull/${number}/head`;
+      if (!repositoryId || !ref || !commit) return null;
+      const hasValidReference = isValidGitObjectId(commit) && isValidTriggerRef(ref);
+      if (!hasValidReference) return null;
+      return {
+        externalRepositoryId: buildProviderRepositoryId(giteaProviderKind, repositoryId),
+        ref,
+        commit,
+      };
+    }
+
+    const repositoryId = giteaRepositoryId(asRecord(payload.repository));
+    const ref = nonEmptyString(payload.ref);
+    const commit = nonEmptyString(payload.after);
+    if (!repositoryId || !ref || !commit) return null;
+    const hasValidReference = isValidGitObjectId(commit) && isValidTriggerRef(ref);
+    if (!hasValidReference) return null;
+    return {
+      externalRepositoryId: buildProviderRepositoryId(giteaProviderKind, repositoryId),
+      ref,
+      commit,
+    };
+  }
+
   async createCheckoutSpec(
     input: CreateCheckoutSpecInput<GiteaIntegrationConnection>,
   ): Promise<CheckoutSpec> {
@@ -158,6 +204,24 @@ export class GiteaSourceControlProvider
       },
     };
   }
+}
+
+function giteaRepositoryId(repository: Record<string, unknown> | null): string | null {
+  const fullName = nonEmptyString(repository?.full_name);
+  if (!fullName) return null;
+  const separatorIndex = fullName.indexOf('/');
+  const owner = separatorIndex > 0 ? fullName.slice(0, separatorIndex) : '';
+  const repo = separatorIndex > 0 ? fullName.slice(separatorIndex + 1) : '';
+  return owner && repo && !repo.includes('/') ? `${owner}/${repo}` : null;
+}
+
+function sameGiteaRepository(
+  first: Record<string, unknown>,
+  second: Record<string, unknown>,
+): boolean {
+  const firstId = giteaRepositoryId(first);
+  const secondId = giteaRepositoryId(second);
+  return Boolean(firstId && secondId && firstId.toLowerCase() === secondId.toLowerCase());
 }
 
 function createCheckoutRepositoryUrl(cloneUrl: string): string {

--- a/libs/api/integration/github/src/core/source-control.test.ts
+++ b/libs/api/integration/github/src/core/source-control.test.ts
@@ -140,8 +140,6 @@ describe('GithubSourceControlProvider', () => {
     {},
     {ref: 'refs/heads/main', after: VALID_COMMIT},
     {ref: 'refs/heads/feature branch', after: VALID_COMMIT, repository: {id: 42}},
-    {ref: 'refs/heads/-feature', after: VALID_COMMIT, repository: {id: 42}},
-    {ref: 'refs/tags/-evil', after: VALID_COMMIT, repository: {id: 42}},
     {ref: 'refs/heads/feature..branch', after: VALID_COMMIT, repository: {id: 42}},
     {ref: 'refs/heads/main', after: '0'.repeat(40), repository: {id: 42}},
     {ref: 'refs/heads/main', after: 'not-a-commit', repository: {id: 42}},

--- a/libs/api/integration/github/src/core/source-control.test.ts
+++ b/libs/api/integration/github/src/core/source-control.test.ts
@@ -3,6 +3,8 @@ import {githubInstallationFactory} from '#test/index.js';
 import {GithubIntegrationProviderError} from './errors.js';
 import {GithubSourceControlProvider} from './source-control.js';
 
+const VALID_COMMIT = 'a'.repeat(40);
+
 function githubClient(overrides: Partial<GithubApiClient> = {}): GithubApiClient {
   return {
     exchangeOAuthCode: vi.fn(() => Promise.resolve('token')),
@@ -94,6 +96,70 @@ describe('GithubSourceControlProvider', () => {
       updatedAt: new Date(),
     };
   }
+
+  it('normalizes push trigger references', () => {
+    const provider = new GithubSourceControlProvider(githubClient());
+
+    const result = provider.resolveTriggerReference({
+      ref: 'refs/heads/feature/review',
+      after: VALID_COMMIT,
+      repository: {id: 42},
+    });
+
+    expect(result).toEqual({
+      externalRepositoryId: 'github:42',
+      ref: 'refs/heads/feature/review',
+      commit: VALID_COMMIT,
+    });
+  });
+
+  it('normalizes pull-request trigger references from the head repository', () => {
+    const provider = new GithubSourceControlProvider(githubClient());
+
+    const result = provider.resolveTriggerReference({
+      repository: {id: 42},
+      pull_request: {
+        number: 17,
+        head: {
+          sha: VALID_COMMIT,
+          repo: {id: 42},
+        },
+        base: {repo: {id: 42}},
+      },
+    });
+
+    expect(result).toEqual({
+      externalRepositoryId: 'github:42',
+      ref: 'refs/pull/17/head',
+      commit: VALID_COMMIT,
+    });
+  });
+
+  it.each([
+    undefined,
+    {},
+    {ref: 'refs/heads/main', after: VALID_COMMIT},
+    {ref: 'refs/heads/feature branch', after: VALID_COMMIT, repository: {id: 42}},
+    {ref: 'refs/heads/-feature', after: VALID_COMMIT, repository: {id: 42}},
+    {ref: 'refs/tags/-evil', after: VALID_COMMIT, repository: {id: 42}},
+    {ref: 'refs/heads/feature..branch', after: VALID_COMMIT, repository: {id: 42}},
+    {ref: 'refs/heads/main', after: '0'.repeat(40), repository: {id: 42}},
+    {ref: 'refs/heads/main', after: 'not-a-commit', repository: {id: 42}},
+    {
+      repository: {id: 42},
+      pull_request: {
+        number: 17,
+        head: {sha: VALID_COMMIT, repo: {id: 84}},
+        base: {repo: {id: 42}},
+      },
+    },
+  ])('returns null for an unresolvable or unsafe trigger payload', (payload) => {
+    const provider = new GithubSourceControlProvider(githubClient());
+
+    const result = provider.resolveTriggerReference(payload);
+
+    expect(result).toBeNull();
+  });
 
   it('lists repositories using installation auth metadata', async () => {
     await createInstallation();

--- a/libs/api/integration/github/src/core/source-control.ts
+++ b/libs/api/integration/github/src/core/source-control.ts
@@ -1,5 +1,6 @@
 import {Buffer} from 'node:buffer';
 import {
+  asRecord,
   buildProviderRepositoryId,
   type CheckoutSpec,
   type CreateCheckoutSpecInput,
@@ -7,15 +8,21 @@ import {
   type FilePage,
   type FileSnapshot,
   type IntegrationConnection,
+  isRecord,
+  isValidGitObjectId,
+  isValidTriggerRef,
   type ListFilesInput,
   type ListRepositoriesInput,
   MAX_REPOSITORY_FILE_BYTES,
+  nonEmptyString,
   parseProviderRepositoryId,
+  positiveInteger,
   type RepositoryPage,
   type RepositorySnapshot,
   type RepositoryVisibility,
   type ResolveRepositoryInput,
   type SourceControlProvider,
+  type TriggerReference,
 } from '@shipfox/api-integration-spi';
 import type {GithubApiClient, GithubRepository} from '#api/client.js';
 import {config} from '#config.js';
@@ -143,6 +150,45 @@ export class GithubSourceControlProvider
     };
   }
 
+  resolveTriggerReference(payload: unknown): TriggerReference | null {
+    if (!isRecord(payload)) return null;
+
+    const pullRequest = asRecord(payload.pull_request);
+    if (pullRequest) {
+      const head = asRecord(pullRequest.head);
+      const repository = asRecord(head?.repo);
+      const base = asRecord(pullRequest.base);
+      const baseRepository = asRecord(base?.repo) ?? asRecord(payload.repository);
+      if (!repository || !baseRepository || !sameGithubRepository(repository, baseRepository)) {
+        return null;
+      }
+      const repositoryId = githubRepositoryId(repository);
+      const number = positiveInteger(pullRequest.number);
+      const commit = nonEmptyString(head?.sha);
+      const ref = number === null ? null : `refs/pull/${number}/head`;
+      if (!repositoryId || !ref || !commit) return null;
+      const hasValidReference = isValidGitObjectId(commit) && isValidTriggerRef(ref);
+      if (!hasValidReference) return null;
+      return {
+        externalRepositoryId: buildProviderRepositoryId(GITHUB_PROVIDER, repositoryId),
+        ref,
+        commit,
+      };
+    }
+
+    const repositoryId = githubRepositoryId(asRecord(payload.repository));
+    const ref = nonEmptyString(payload.ref);
+    const commit = nonEmptyString(payload.after);
+    if (!repositoryId || !ref || !commit) return null;
+    const hasValidReference = isValidGitObjectId(commit) && isValidTriggerRef(ref);
+    if (!hasValidReference) return null;
+    return {
+      externalRepositoryId: buildProviderRepositoryId(GITHUB_PROVIDER, repositoryId),
+      ref,
+      commit,
+    };
+  }
+
   async createCheckoutSpec(
     input: CreateCheckoutSpecInput<GithubIntegrationConnection>,
   ): Promise<CheckoutSpec> {
@@ -176,6 +222,23 @@ export class GithubSourceControlProvider
 
     return Number.parseInt(installation.installationId, 10);
   }
+}
+
+function githubRepositoryId(repository: Record<string, unknown> | null): string | null {
+  return positiveInteger(repository?.id) === null ? null : String(repository?.id);
+}
+
+function sameGithubRepository(
+  first: Record<string, unknown>,
+  second: Record<string, unknown>,
+): boolean {
+  const firstId = githubRepositoryId(first);
+  const secondId = githubRepositoryId(second);
+  if (firstId && secondId) return firstId === secondId;
+
+  const firstName = nonEmptyString(first.full_name);
+  const secondName = nonEmptyString(second.full_name);
+  return Boolean(firstName && secondName && firstName.toLowerCase() === secondName.toLowerCase());
 }
 
 function githubAppGitAuthor(): CheckoutSpec['gitAuthor'] {

--- a/libs/api/integration/spi/src/contracts.test.ts
+++ b/libs/api/integration/spi/src/contracts.test.ts
@@ -11,6 +11,8 @@ describe('git ref names', () => {
   it.each([
     'refs/heads/main',
     'refs/heads/feature/review',
+    'refs/heads/foo./bar',
+    'refs/heads/foo/-bar',
     'refs/pull/17/head',
   ])('accepts %s', (ref) => {
     expect(isValidGitRefName(ref)).toBe(true);
@@ -18,6 +20,8 @@ describe('git ref names', () => {
 
   it.each([
     '',
+    'HEAD',
+    'main',
     '-main',
     'refs/heads/foo bar',
     'refs/heads/foo..bar',
@@ -29,11 +33,8 @@ describe('git ref names', () => {
     expect(isValidGitRefName(ref)).toBe(false);
   });
 
-  it.each([
-    'refs/tags/-evil',
-    'refs/heads/feature/-evil',
-  ])('rejects unsafe trigger ref %s', (ref) => {
-    expect(isValidTriggerRef(ref)).toBe(false);
+  it.each(['refs/tags/-evil', 'refs/heads/feature/-evil'])('accepts safe trigger ref %s', (ref) => {
+    expect(isValidTriggerRef(ref)).toBe(true);
   });
 });
 

--- a/libs/api/integration/spi/src/contracts.test.ts
+++ b/libs/api/integration/spi/src/contracts.test.ts
@@ -1,8 +1,56 @@
 import {
   buildProviderRepositoryId,
   IntegrationProviderError,
+  isValidGitObjectId,
+  isValidGitRefName,
+  isValidTriggerRef,
   parseProviderRepositoryId,
 } from './contracts.js';
+
+describe('git ref names', () => {
+  it.each([
+    'refs/heads/main',
+    'refs/heads/feature/review',
+    'refs/pull/17/head',
+  ])('accepts %s', (ref) => {
+    expect(isValidGitRefName(ref)).toBe(true);
+  });
+
+  it.each([
+    '',
+    '-main',
+    'refs/heads/foo bar',
+    'refs/heads/foo..bar',
+    'refs/heads/foo.lock',
+    'refs/heads/.foo',
+    'refs/heads/foo.',
+    'refs/heads/foo@{bar',
+  ])('rejects %s', (ref) => {
+    expect(isValidGitRefName(ref)).toBe(false);
+  });
+
+  it.each([
+    'refs/tags/-evil',
+    'refs/heads/feature/-evil',
+  ])('rejects unsafe trigger ref %s', (ref) => {
+    expect(isValidTriggerRef(ref)).toBe(false);
+  });
+});
+
+describe('git object ids', () => {
+  it.each(['a'.repeat(40), 'b'.repeat(64)])('accepts a full object id', (value) => {
+    expect(isValidGitObjectId(value)).toBe(true);
+  });
+
+  it.each([
+    'a',
+    'abcdef1234567890',
+    '0'.repeat(40),
+    'g'.repeat(40),
+  ])('rejects an invalid object id', (value) => {
+    expect(isValidGitObjectId(value)).toBe(false);
+  });
+});
 
 describe('provider repository identifiers', () => {
   it('prefixes provider-owned identifiers', () => {

--- a/libs/api/integration/spi/src/contracts.ts
+++ b/libs/api/integration/spi/src/contracts.ts
@@ -2,6 +2,9 @@ export type IntegrationProviderKind = string;
 export type IntegrationCapability = 'source_control' | 'agent_tools';
 export type IntegrationConnectionLifecycleStatus = 'active' | 'disabled' | 'error';
 
+const GIT_OBJECT_ID_PATTERN = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i;
+const ZERO_GIT_OBJECT_ID_PATTERN = /^0+$/;
+
 export interface IntegrationConnection<
   ProviderKind extends IntegrationProviderKind = IntegrationProviderKind,
 > {
@@ -110,6 +113,12 @@ export interface CreateCheckoutSpecInput<
   permissions?: CheckoutPermissions | undefined;
 }
 
+export interface TriggerReference {
+  externalRepositoryId: string;
+  ref: string;
+  commit: string;
+}
+
 export interface SourceControlProvider<
   Connection extends IntegrationConnection = IntegrationConnection,
 > {
@@ -117,6 +126,7 @@ export interface SourceControlProvider<
   resolveRepository(input: ResolveRepositoryInput<Connection>): Promise<RepositorySnapshot>;
   listFiles(input: ListFilesInput<Connection>): Promise<FilePage>;
   fetchFile(input: FetchFileInput<Connection>): Promise<FileSnapshot>;
+  resolveTriggerReference(payload: unknown): TriggerReference | null;
   createCheckoutSpec?(input: CreateCheckoutSpecInput<Connection>): Promise<CheckoutSpec>;
 }
 
@@ -292,4 +302,61 @@ export function parseProviderRepositoryId(
     );
   }
   return value;
+}
+
+/** Checks the constraints enforced by `git check-ref-format`. */
+export function isValidGitRefName(ref: string): boolean {
+  if (!ref || ref === '@' || ref.startsWith('-')) return false;
+  if (
+    ref.startsWith('/') ||
+    ref.endsWith('/') ||
+    ref.includes('//') ||
+    ref.includes('..') ||
+    ref.includes('@{') ||
+    ref.endsWith('.')
+  ) {
+    return false;
+  }
+  if (
+    [...ref].some((character) => {
+      const code = character.codePointAt(0) ?? 0;
+      return code <= 0x20 || code === 0x7f || '~^:?*[]\\'.includes(character);
+    })
+  ) {
+    return false;
+  }
+
+  const components = ref.split('/');
+  return components.every(
+    (component) =>
+      component.length > 0 &&
+      !component.startsWith('.') &&
+      !component.endsWith('.') &&
+      !component.endsWith('.lock'),
+  );
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function asRecord(value: unknown): Record<string, unknown> | null {
+  return isRecord(value) ? value : null;
+}
+
+export function nonEmptyString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+export function positiveInteger(value: unknown): number | null {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0 ? value : null;
+}
+
+/** Validates a provider ref before it is passed to a git operation. */
+export function isValidTriggerRef(ref: string): boolean {
+  return isValidGitRefName(ref) && ref.split('/').every((component) => !component.startsWith('-'));
+}
+
+export function isValidGitObjectId(value: string): boolean {
+  return GIT_OBJECT_ID_PATTERN.test(value) && !ZERO_GIT_OBJECT_ID_PATTERN.test(value);
 }

--- a/libs/api/integration/spi/src/contracts.ts
+++ b/libs/api/integration/spi/src/contracts.ts
@@ -308,6 +308,7 @@ export function parseProviderRepositoryId(
 export function isValidGitRefName(ref: string): boolean {
   if (!ref || ref === '@' || ref.startsWith('-')) return false;
   if (
+    !ref.includes('/') ||
     ref.startsWith('/') ||
     ref.endsWith('/') ||
     ref.includes('//') ||
@@ -329,10 +330,7 @@ export function isValidGitRefName(ref: string): boolean {
   const components = ref.split('/');
   return components.every(
     (component) =>
-      component.length > 0 &&
-      !component.startsWith('.') &&
-      !component.endsWith('.') &&
-      !component.endsWith('.lock'),
+      component.length > 0 && !component.startsWith('.') && !component.endsWith('.lock'),
   );
 }
 
@@ -354,7 +352,7 @@ export function positiveInteger(value: unknown): number | null {
 
 /** Validates a provider ref before it is passed to a git operation. */
 export function isValidTriggerRef(ref: string): boolean {
-  return isValidGitRefName(ref) && ref.split('/').every((component) => !component.startsWith('-'));
+  return isValidGitRefName(ref);
 }
 
 export function isValidGitObjectId(value: string): boolean {


### PR DESCRIPTION
## Summary

Adds the provider-neutral source-control trigger reference contract and GitHub/Gitea implementations so webhook payloads resolve consistently to a repository, ref, and commit. The implementations validate Git refs and object IDs and reject deletion and fork pull-request payloads before downstream resolution.

Closes ENG-1418

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes source-control webhook payloads into a provider‑neutral repository, ref, and commit with validation and safety checks. Aligns trigger ref validation with Git semantics and addresses ENG-1418 by standardizing reference extraction across GitHub and Gitea.

- **New Features**
  - Added `TriggerReference` and validation helpers (`isValidGitRefName`, `isValidTriggerRef`, `isValidGitObjectId`) in `@shipfox/api-integration-spi`.
  - Extended `SourceControlProvider` with `resolveTriggerReference(payload)`.
  - Implemented normalization for `@shipfox/api-integration-github` and `@shipfox/api-integration-gitea` (push and same-repo PRs), rejecting fork PRs and invalid refs/commits.
  - Aligned ref validation to Git semantics (`git check-ref-format`) to accept hierarchical refs and enforce component rules.

- **Migration**
  - Update custom source-control providers to implement `resolveTriggerReference(payload): TriggerReference | null`.
  - Use the new helpers to validate refs and commits, and only accept PRs where head and base repositories match.

<sup>Written for commit 9595e6f07e1166aa10514a72be28a09dc9d96cce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

