### PR TITLE
Generate the workflow contexts reference from the expression registry

### DIFF
--- a/.changeset/agent-thinking-interpolation.md
+++ b/.changeset/agent-thinking-interpolation.md
@@ -1,0 +1,14 @@
+---
+"@shipfox/workflow-document": minor
+"@shipfox/api-definitions": minor
+"@shipfox/api-definitions-dto": minor
+"@shipfox/api-workflows": minor
+"@shipfox/api-workflows-dto": minor
+"@shipfox/api-agent": minor
+"@shipfox/api-agent-dto": minor
+---
+
+Accept a `${{ }}` interpolation in an agent step's `thinking` field. The schema
+still offers the per-harness enum for editor completion, and the resolved value
+is checked against the harness levels when the step dispatches. An unsupported
+resolved level fails the step.

--- a/.changeset/workflow-context-root.md
+++ b/.changeset/workflow-context-root.md
@@ -1,0 +1,11 @@
+---
+"@shipfox/expression": major
+"@shipfox/api-workflows": minor
+---
+
+Split workflow definition facts out of the `run` context into a `workflow` root.
+`run.workflow_name` becomes `workflow.name` and `run.definition_id` becomes
+`workflow.id`, so `workflow` and `run` mirror the `job` and `execution` pair.
+Adds `contextRootsForField`, which returns the readable roots for a predicate or
+an interpolation field without the caller choosing a mechanism, and
+`workflowContextDocs`, the reader-facing description of every root and property.

--- a/apps/docs/content/docs/how-to/author-workflows/define-listener-success.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/define-listener-success.mdx
@@ -69,7 +69,7 @@ jobs:
 
 The expression runs after the listener resolves. It requires a non-empty
 `executions` list and rejects any failed execution. The exact execution fields
-remain in the [Expressions reference](/reference/expressions#job-success-success).
+remain in the [Workflow schema](/reference/workflow-schema#job-fields).
 
 Commit and push the file to the project's default branch. Wait for **Require a
 task check** to sync.
@@ -97,5 +97,6 @@ curl -X POST '<ingest-url>' \
   -d '<body-from-the-case>'
 ```
 
-The default result, custom predicate scope, and expression failure behavior live
-in [Expressions](/reference/expressions#job-success-success).
+The [Contexts reference](/reference/contexts#context-availability) lists the
+predicate scope. The [Expressions reference](/reference/expressions#functions-and-macros)
+lists the syntax and functions.

--- a/apps/docs/content/docs/how-to/author-workflows/pass-trigger-inputs.mdx
+++ b/apps/docs/content/docs/how-to/author-workflows/pass-trigger-inputs.mdx
@@ -74,6 +74,6 @@ Restore `0 2 * * *` after both start paths work.
 3. Open each run's trigger data. Confirm that the matching `with` value appears
    under `inputs`.
 
-The [Expressions reference](/reference/expressions#context-available) defines
+The [Contexts reference](/reference/contexts#context-availability) defines
 where `inputs` is available. The [Cron reference](/reference/trigger-sources#cron)
 defines schedule fields.

--- a/apps/docs/content/docs/how-to/run-and-troubleshoot/event-routing.mdx
+++ b/apps/docs/content/docs/how-to/run-and-troubleshoot/event-routing.mdx
@@ -45,8 +45,9 @@ A false filter creates no run. A filter error does the same. Fix the trigger and
 wait for a successful sync. Then send a new event. Shipfox does not replay the
 old event after an edit.
 
-Use [Trigger sources](/reference/trigger-sources) for exact event contracts and
-[Expressions](/reference/expressions#trigger-filters) for filter behavior.
+Use [Trigger sources](/reference/trigger-sources) for exact event contracts.
+Use [Expressions](/reference/expressions) for filter syntax and the [Contexts
+reference](/reference/contexts#context-availability) for available data.
 
 ## If evaluation or run creation failed
 

--- a/apps/docs/content/docs/how-to/run-and-troubleshoot/workflow-sync.mdx
+++ b/apps/docs/content/docs/how-to/run-and-troubleshoot/workflow-sync.mdx
@@ -24,6 +24,26 @@ message before changing the workflow.
 | Repository or file not found | The project still points to a repository visible through its source integration connection |
 | Access denied or integration connection unavailable | The source integration is installed and authorized for the repository |
 | Too large or too many files | The workflow files fit the documented [limits](/reference/limits) |
+| Context not available | A field reads a context that does not exist where Shipfox fills that field. See below |
+
+## Correct a context that is not available
+
+A field can read only the contexts listed in [Context
+availability](/reference/contexts#context-availability). If it reads another
+context, sync fails. The error names the field, the unavailable context, and the
+stage where that context first exists:
+
+```text
+Job runner interpolation references context "steps" that is not available at
+job activation. "steps" becomes available at step dispatch.
+```
+
+Correct it in one of two ways:
+
+- Move the reference to a field that Shipfox fills later. A step `run` or `env`
+  value can read step results that `jobs.<job_id>.runner` cannot.
+- Carry the value forward as data. Declare a step output or a job output, then
+  read it through `steps`, `needs`, or `jobs` in the later field.
 
 ## Correct and verify
 

--- a/apps/docs/content/docs/reference/contexts.mdx
+++ b/apps/docs/content/docs/reference/contexts.mdx
@@ -1,0 +1,56 @@
+---
+title: "Workflow contexts"
+sidebarTitle: "Contexts"
+description: "Look up every context a workflow can read, the properties it holds, and the fields that can read it."
+---
+
+import ContextAvailability from '../../generated/reference/context-availability.mdx';
+import ContextProperties from '../../generated/reference/context-properties.mdx';
+import ContextRoots from '../../generated/reference/context-roots.mdx';
+
+A **context** is a group of run data that an expression can read, such as
+`event`, `steps`, or `vars`. Read a property with `context.property`, or with
+`context["property"]` when the name is not an identifier.
+
+For the syntax around a context, see [Expressions](/reference/expressions).
+
+## Available contexts
+
+<ContextRoots />
+
+## Context availability
+
+Each workflow field reads a fixed set of contexts.
+
+<ContextAvailability />
+
+A predicate field reads one context that the server builds for it. A template
+field can reference any context the field is allowed to resolve. Shipfox fills
+each reference when its data exists. Only `run` and `env` reach `secrets`. The
+runner holds secret values.
+
+Two fields cannot read their own result:
+
+- `run_name` cannot read `run.name`.
+- `jobs.<job_id>.execution_name` cannot read `execution.name`.
+
+Workflow `name` and job `name` are literal text and accept no context. Use
+`run_name` and `execution_name` for a name that depends on the run.
+
+## Context properties
+
+<ContextProperties />
+
+## Related pages
+
+<Cards>
+  <Card title="Expressions" href="/reference/expressions">
+    The syntax, operators, and functions available inside `${'{{ }}'}`.
+  </Card>
+  <Card title="Workflow schema" href="/reference/workflow-schema">
+    The fields that carry these expressions.
+  </Card>
+  <Card title="Secrets and variables" href="/reference/secrets-variables">
+    How `vars` and `secrets` are stored, scoped, and bound.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/reference/contexts.mdx
+++ b/apps/docs/content/docs/reference/contexts.mdx
@@ -24,18 +24,13 @@ reads `step` and `vars`.
 
 <ContextAvailability />
 
-A predicate is evaluated once, so it reads only what exists at that moment. A
-template can combine contexts that become available at different times.
+A field cannot read the value it sets. For example, `run_name` cannot read
+`run.name`.
 
-Only a run step's `run` command and `env` values can reference `secrets`. See
-[Secrets and variables](/reference/secrets-variables#using-secrets).
-
-Reading a context that the table does not list for a field fails the sync, with
-an error that names the context. The workflow never runs with an empty value in
-its place. See [Correct a context that is not
+Reading a context the table does not list for the field fails the sync, with an
+error that names the context. The workflow never runs with an empty value in its
+place. See [Correct a context that is not
 available](/how-to/run-and-troubleshoot/workflow-sync#correct-a-context-that-is-not-available).
-
-A field cannot read the value it sets: `run_name` cannot read `run.name`.
 
 ## Context properties
 

--- a/apps/docs/content/docs/reference/contexts.mdx
+++ b/apps/docs/content/docs/reference/contexts.mdx
@@ -8,11 +8,8 @@ import ContextAvailability from '../../generated/reference/context-availability.
 import ContextProperties from '../../generated/reference/context-properties.mdx';
 import ContextRoots from '../../generated/reference/context-roots.mdx';
 
-A **context** is a group of run data that an expression can read, such as
-`event`, `steps`, or `vars`. Read a property with `context.property`, or with
-`context["property"]` when the name is not an identifier.
-
-For the syntax around a context, see [Expressions](/reference/expressions).
+A **context** is a group of run data that an expression can read. See
+[Expressions](/reference/expressions) for the syntax.
 
 ## Available contexts
 
@@ -20,22 +17,25 @@ For the syntax around a context, see [Expressions](/reference/expressions).
 
 ## Context availability
 
-Each workflow field reads a fixed set of contexts.
+Different contexts exist at different points in a run, so each field can read
+only some of them. A trigger `filter` runs before Shipfox creates a run, so it
+reads only `event` and `trigger`. A gate runs after its step reports, so it
+reads `step` and `vars`.
 
 <ContextAvailability />
 
-A predicate field reads one context that the server builds for it. A template
-field can reference any context the field is allowed to resolve. Shipfox fills
-each reference when its data exists. Only `run` and `env` reach `secrets`. The
-runner holds secret values.
+A predicate is evaluated once, so it reads only what exists at that moment. A
+template can combine contexts that become available at different times.
 
-Two fields cannot read their own result:
+Only a run step's `run` command and `env` values can reference `secrets`. See
+[Secrets and variables](/reference/secrets-variables#using-secrets).
 
-- `run_name` cannot read `run.name`.
-- `jobs.<job_id>.execution_name` cannot read `execution.name`.
+Reading a context that the table does not list for a field fails the sync, with
+an error that names the context. The workflow never runs with an empty value in
+its place. See [Correct a context that is not
+available](/how-to/run-and-troubleshoot/workflow-sync#correct-a-context-that-is-not-available).
 
-Workflow `name` and job `name` are literal text and accept no context. Use
-`run_name` and `execution_name` for a name that depends on the run.
+A field cannot read the value it sets: `run_name` cannot read `run.name`.
 
 ## Context properties
 
@@ -45,7 +45,7 @@ Workflow `name` and job `name` are literal text and accept no context. Use
 
 <Cards>
   <Card title="Expressions" href="/reference/expressions">
-    The syntax, operators, and functions available inside `${'{{ }}'}`.
+    The syntax, operators, and functions available inside an expression.
   </Card>
   <Card title="Workflow schema" href="/reference/workflow-schema">
     The fields that carry these expressions.

--- a/apps/docs/content/docs/reference/expressions.mdx
+++ b/apps/docs/content/docs/reference/expressions.mdx
@@ -63,8 +63,9 @@ computed key such as `vars[inputs.name]` is not.
 | `? :` | `run.number == 1 ? "first" : "rerun"` | The middle value when true, the last when false |
 | `( )` | `(a \|\| b) && c` | Groups an expression against precedence |
 
-Comparing values of different types is an error rather than a false result. A
-predicate that errors never passes.
+Comparing values of different types is an error rather than a false result, and
+`int` and `double` count as different types. A predicate that errors never
+passes.
 
 ## Functions and macros
 

--- a/apps/docs/content/docs/reference/expressions.mdx
+++ b/apps/docs/content/docs/reference/expressions.mdx
@@ -39,49 +39,55 @@ computed key such as `vars[inputs.name]` is not.
 
 ## Types
 
-| Type | Example |
+| Type | Written as |
 | --- | --- |
 | `string` | `"refs/heads/main"` |
 | `int` | `42` |
 | `double` | `1.5` |
 | `bool` | `true` |
-| `timestamp` | `run.created_at` |
-| `list` | `execution.events` |
-| `map` | `steps.build.outputs` |
+| `list` | `["main", "release"]` |
+| `map` | `{"env": "prod"}` |
+| `timestamp` | `timestamp("2026-01-01T00:00:00Z")` |
 
 ## Operators
 
-| Operator | Meaning |
-| --- | --- |
-| `==`, `!=` | Equal, not equal |
-| `<`, `<=`, `>`, `>=` | Ordered comparison |
-| `&&`, `||`, `!` | And, or, not |
-| `in` | Membership in a list or map |
-| `+`, `-`, `*`, `/`, `%` | Arithmetic. `+` also joins strings and lists |
-| `? :` | Conditional value |
+| Operator | Example | Result |
+| --- | --- | --- |
+| `==`, `!=` | `trigger.event == "push"` | Compares two values of the same type |
+| `<`, `<=`, `>`, `>=` | `run.created_at > timestamp("2026-01-01T00:00:00Z")` | Orders numbers, strings, and timestamps |
+| `&&`, `\|\|`, `!` | `job.key == "deploy" && !step.is_retry` | Combines boolean values |
+| `in` | `"prod" in inputs.environments` | True when a list contains the value |
+| `in` | `"API_URL" in vars` | True when a map contains the key |
+| `+` | `"v" + inputs.version` | Adds numbers, joins strings, joins lists |
+| `-`, `*`, `/`, `%` | `executions.size() % 2 == 0` | Arithmetic on numbers |
+| `? :` | `run.number == 1 ? "first" : "rerun"` | The middle value when true, the last when false |
+| `( )` | `(a \|\| b) && c` | Groups an expression against precedence |
+
+Comparing values of different types is an error rather than a false result. A
+predicate that errors never passes.
 
 ## Functions and macros
 
-| Call | Result |
-| --- | --- |
-| `list.size()`, `string.size()` | Number of elements or characters |
-| `list.all(item, predicate)` | True when every element matches |
-| `list.exists(item, predicate)` | True when at least one element matches |
-| `list.exists_one(item, predicate)` | True when exactly one element matches |
-| `list.filter(item, predicate)` | The elements that match |
-| `list.map(item, expression)` | The expression applied to each element |
-| `string.contains(part)` | True when the string contains `part` |
-| `string.startsWith(part)`, `string.endsWith(part)` | Prefix and suffix tests |
-| `string.matches(pattern)` | True when the string matches a regular expression |
+| Call | Example | Result |
+| --- | --- | --- |
+| `list.size()`, `string.size()` | `executions.size() > 1` | Number of elements or characters |
+| `list.all(item, predicate)` | `executions.all(e, e.status == "succeeded")` | True when every element matches |
+| `list.exists(item, predicate)` | `execution.events.exists(e, e.event == "push")` | True when at least one element matches |
+| `list.exists_one(item, predicate)` | `needs.exists_one(j, j.status == "failed")` | True when exactly one element matches |
+| `list.filter(item, predicate)` | `executions.filter(e, e.status == "failed")` | The elements that match |
+| `list.map(item, expression)` | `needs.map(j, j.key)` | The expression applied to each element |
+| `string.contains(part)` | `event.ref.contains("release")` | True when the string contains `part` |
+| `string.startsWith(part)`, `string.endsWith(part)` | `event.ref.startsWith("refs/heads/")` | Prefix and suffix tests |
+| `string.matches(pattern)` | `event.ref.matches("^refs/tags/v[0-9]+$")` | True when the string matches a regular expression |
+| `string.split(separator)` | `event.ref.split("/")[2]` | The parts between each separator |
+| `string.lowerAscii()`, `string.upperAscii()` | `event.ref.lowerAscii()` | The string in one case |
+| `has(field)` | `has(event.pull_request)` | True when the field is present |
+| `string(value)`, `int(value)`, `double(value)` | `"run-" + string(run.number)` | The value converted to that type |
+| `timestamp(string)` | `timestamp("2026-01-01T00:00:00Z")` | A timestamp from an RFC 3339 string |
 
-This job `success` predicate uses a macro over the executions of the job:
-
-```yaml
-success: 'executions.all(e, e.status == "succeeded")'
-```
-
-Shipfox adds no custom functions. Expressions can use CEL's standard functions
-when the required context is available.
+The [CEL language
+definition](https://github.com/google/cel-spec/blob/master/doc/langdef.md#standard-definitions)
+documents the full standard library.
 
 ## Related pages
 

--- a/apps/docs/content/docs/reference/expressions.mdx
+++ b/apps/docs/content/docs/reference/expressions.mdx
@@ -1,39 +1,40 @@
 ---
 title: "Expressions and Interpolation (CEL)"
 sidebarTitle: "Expressions (CEL)"
-description: "Shipfox evaluates CEL in trigger filters, if conditionals, gates, and job success, and resolves ${{ }} templates in commands, env, prompts, and outputs from staged run context."
+description: "Shipfox uses CEL predicates to make workflow decisions. It uses ${{ }} templates to put context in commands, environment values, prompts, and outputs."
 ---
 
-Shipfox uses [CEL (Common Expression Language)](https://cel.dev) in two roles.
-**Predicates** decide an outcome: does this event fire the trigger, does this
-job or step run, did a gated step succeed. **Templates** produce strings: the
-`${{ }}` syntax fills run context into prompts, commands, env values, names,
-and outputs. Both roles use the same read-only engine: expressions compute
-over the data in scope, and they cannot reach the database, the network, or
-the filesystem.
+Shipfox uses [CEL (Common Expression Language)](https://cel.dev) in two ways.
+A **predicate** gives a true or false result. This result controls a trigger,
+job, step, or gate.
 
-One rule separates the two roles. **Templates read context at their fill site,
-while predicates receive a field-specific server-side context.** Job and step
-conditionals, gates, listening-job filters, and job success predicates can read
-`vars` after run creation. A trigger filter runs before run creation, so it
-cannot read `vars`. No predicate can read `secrets`, because secret values exist
-only on the runner.
+A **template** puts a string value in text. The text can be a prompt, command,
+environment value, name, or output. Templates use the `${{ }}` syntax.
+
+Each workflow field can use context that exists when Shipfox reads the field.
+A trigger `filter` cannot use `vars` or step outputs because no run exists yet.
+Job and step `if` fields can use `vars`.
+
+Only `run` commands and `env` values can use `secrets`. The
+[context table](#context-available) shows when each context root becomes
+available.
 
 ## The CEL engine
 
-Expressions support CEL's standard value types (integers, strings, booleans,
-lists, maps), its standard operators (`==`, `!=`, `<`, `>`, `&&`, `||`, `!`,
-`in`, arithmetic) and macros (`.map()`, `.filter()`, `.all()`, `.exists()`),
-plus string helpers like `.contains()`, `.startsWith()`, and `.endsWith()`.
-There are no custom functions and no side effects.
+Expressions use the standard features of CEL:
+
+- Value types: integers, strings, booleans, lists, and maps
+- Operators: `==`, `!=`, `<`, `>`, `&&`, `||`, `!`, `in`, and arithmetic
+- Macros: `.map()`, `.filter()`, `.all()`, and `.exists()`
+- String functions: `.contains()`, `.startsWith()`, and `.endsWith()`
+
+The engine has no custom functions. Expressions cannot cause side effects.
 
 ## Predicates
 
 ### Predicate context
 
-Predicates run on the server, and each predicate type receives a specific
-context. A root can exist at a lifecycle site but still be absent from a
-predicate's field context.
+Each predicate field can read only the context in this table:
 
 | Predicate | Context |
 |---|---|
@@ -44,20 +45,24 @@ predicate's field context.
 | `gate.success` | `step` and `vars` |
 | Job `success` | `executions`, `jobs`, and `vars` |
 
-For a listening-job filter, `event` is the event that may create a new
-execution. In a trigger filter, `event` is the payload that may create the
-run. `secrets` is unavailable to every predicate.
+In a listening-job filter, `event` can start a new execution. In a trigger
+filter, `event` can start a new run. No predicate can read `secrets`.
 
 ### Trigger filters
 
-A trigger's `filter` runs when the event arrives, before any run is created.
-In scope: `event` (the payload) and `trigger` (`source` and `event`). A false
-result skips the event. An expression error **fails closed**: the trigger does
-not fire. The same filter shape applies to a listening job's `on` and `until`
-entries, but those filters evaluate the incoming listener event against the
-activation snapshot described above.
+Shipfox evaluates a trigger `filter` when the event arrives. At this time, a
+run does not exist.
 
-This trigger fragment belongs under an existing workflow's `triggers` map:
+The filter can read `event`. This context contains the payload. The filter can
+also read the `source` and `event` fields of `trigger`.
+
+A false result stops the event. If the expression has an error, Shipfox does
+not start the trigger. This is fail-closed behavior.
+
+Listening jobs have `on` and `until` fields. These fields use the incoming
+listener event and the context in the predicate table.
+
+This example is a trigger fragment in the `triggers` map of a workflow:
 
 ```yaml
 triggers:
@@ -69,11 +74,13 @@ triggers:
 
 ### Conditionals: `if`
 
-Jobs and steps accept an `if:` field holding exactly one `${{ }}`-wrapped CEL
-boolean. When it is false, the job or step is marked **skipped**, not failed.
-An evaluation error also skips, recorded with a distinct reason.
+Jobs and steps can have an `if` field. This field contains exactly one CEL
+boolean in `${{ }}`.
 
-This job fragment belongs under an existing workflow's `jobs` map:
+A false result gives the **skipped** status to the job or step. An evaluation
+error gives the same status. The recorded reason gives the cause.
+
+This example is a job fragment in the `jobs` map of a workflow:
 
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
@@ -91,12 +98,17 @@ jobs:
 
 ### Gate success: `gate.success`
 
-Evaluated the moment a gated step finishes. In scope: `step.exit_code` (an
-integer), `step.status` (a string), `step.outputs` (the step's declared
-outputs), and `vars`. See [Feedback loops](/understand/feedback-loops) for the
-full gate model.
+Shipfox evaluates `gate.success` when the gated step finishes. The expression
+can read these fields:
 
-This gate fragment belongs on a run or agent step:
+- `step.exit_code` is an integer
+- `step.status` is a string
+- `step.outputs` contains the declared outputs of the step
+- `vars` contains the workflow variables
+
+[Feedback loops](/understand/feedback-loops) gives the full gate model.
+
+This example is a gate fragment on a run step or an agent step:
 
 ```yaml
 gate:
@@ -105,13 +117,17 @@ gate:
 
 ### Job success: `success`
 
-A job's optional `success` expression decides whether the job succeeded once
-all its executions settle. In scope is `executions`, a list where each element
-carries `index`, `name`, `status`, `events`, `outputs`, and timing fields, plus
-`jobs` and `vars`. The default succeeds when no execution failed. It also
-succeeds when a listening job resolves with no executions:
+A job can have a `success` expression. Shipfox gets its result after all
+executions finish. This expression can read the `executions` list, `jobs`, and
+`vars`.
 
-This job fragment belongs under an existing workflow's `jobs` map:
+Each list item contains `index`, `name`, and `status`. It also contains
+`events`, `outputs`, and time fields.
+
+By default, a job succeeds if no execution fails. A listening job also succeeds
+if it has no executions when it resolves.
+
+This example is a job fragment in the `jobs` map of a workflow:
 
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
@@ -122,7 +138,7 @@ jobs:
       - run: ./maybe-flaky.sh
 ```
 
-Add this `success` field to a job to require at least one execution:
+The next `success` field is true only if the job has one or more executions:
 
 ```yaml
 success: 'executions.size() > 0 && executions.all(e, e.status == "succeeded")'
@@ -130,33 +146,40 @@ success: 'executions.size() > 0 && executions.all(e, e.status == "succeeded")'
 
 ## Templates: `${{ }}`
 
-Interpolation fills run context into string values. It works in:
+Interpolation puts run-context values in strings. These fields can contain
+templates:
 
-- `run` commands and `env` values (run steps)
-- agent `prompt`, `model`, and `provider`
-- job `runner`, `name`, and `outputs`
-- step `name` and gate `on_failure.feedback`
+- The `run` commands and `env` values of run steps
+- The `prompt`, `model`, and `provider` fields of agent steps
+- The `runner`, `name`, and `outputs` fields of jobs
+- The `name` and `on_failure.feedback` fields of steps
 
-To write a literal `${{`, escape it as `$${{`.
+The sequence `$${{` writes a literal `${{`.
 
 ### Infrastructure selectors
 
-`job.runner`, agent `model`, and agent `provider` select execution
-infrastructure. Use workflow-authored values for these fields. Incoming event,
-trigger input, listening-event, and output data can currently reach these
-selectors through interpolation because definition validation does not enforce
-that boundary. `agent.thinking` is an enum, not a template site. Do not treat
-these fields as a safety boundary until the selector checks are enforced.
+The `job.runner`, agent `model`, and agent `provider` fields select execution
+infrastructure. Use values that you write in the workflow for these fields.
 
-**Resolution is staged.** Each reference resolves at the moment its data
-exists: `event` and `trigger` at ingest, `inputs`, `job`, and `vars` at run
-creation, `executions` and `execution` at execution creation, `needs` and
-`jobs` at job activation, and `steps.*` and `step.*` at step dispatch. Secrets
-resolve during runner fill. You write the reference once, and Shipfox fills it
-as late as needed. A reference used before its context exists fails with the
-`context-unavailable-at-fill-site` error instead of passing empty text through.
+Event, trigger-input, listening-event, and output data can currently reach
+these fields. Definition validation does not block this data.
 
-This job fragment belongs under an existing workflow's `jobs` map:
+The `agent.thinking` field is an enum, not a template site. These fields are
+not a safety boundary.
+
+**Shipfox resolves each reference when its data becomes available:**
+
+- `trigger` and `event` at ingest
+- `run`, `inputs`, `job`, and `vars` at run creation
+- `executions` and `execution` at execution creation
+- `needs` and `jobs` at job activation
+- `steps.*` and `step.*` at step dispatch
+- `secrets` at runner fill
+
+A typed error occurs if Shipfox cannot resolve a reference. The error code is
+`context-unavailable-at-fill-site`. Shipfox does not use empty text.
+
+This example is a job fragment in the `jobs` map of a workflow:
 
 ```yaml
 # yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
@@ -172,46 +195,65 @@ jobs:
 ### Context available
 
 | Root | Holds | Available from |
-|---|---|---|---|
+|---|---|---|
 | `run` | `id`, `name`, `workflow_name`, `definition_id`, `project_id`, `workspace_id`, `created_at` | Run creation |
 | `trigger` | `source`, `event` | Ingest |
-| `event` | The trigger's raw event payload (open shape, such as `event.ref`, `event.title`) | Ingest |
-| `inputs` | Values from the trigger's `with` block (open shape) | Run creation |
-| `job` | The current job's `key` and `name` | Run creation |
-| `executions` | The current job's executions, including `index`, `name`, `status`, `events`, `outputs`, and timing fields | Execution creation |
+| `event` | The raw event payload of the trigger (open shape, such as `event.ref`, `event.title`) | Ingest |
+| `inputs` | Values from the `with` block of the trigger (open shape) | Run creation |
+| `job` | The `key` and `name` of the current job | Run creation |
+| `executions` | The executions of the current job, including `index`, `name`, `status`, `events`, `outputs`, and time fields | Execution creation |
 | `execution` | Current execution metadata and its listening-job events | Execution creation |
 | `needs` | Direct dependency jobs with their status and outputs | Job activation |
 | `jobs` | Named upstream jobs with their status and outputs | Job activation |
-| `steps.<key>` | Earlier steps' `status`, `exit_code`, `outputs`, and `attempts` | Step dispatch |
+| `steps.<key>` | The `status`, `exit_code`, `outputs`, and `attempts` of earlier steps | Step dispatch |
 | `step` | `attempt`, `is_retry`, `restart.from`, and `restart.feedback` | Step dispatch |
-| `vars` | Workspace/project [variables](/reference/secrets-variables), literal keys only | Run creation |
-| `secrets` | Workspace/project [secrets](/reference/secrets-variables), literal keys only. Runner-only. | Runner fill |
+| `vars` | Workspace and project [variables](/reference/secrets-variables), literal keys only | Run creation |
+| `secrets` | Workspace and project [secrets](/reference/secrets-variables), literal keys only. Only the runner holds these values. | Runner fill |
 
 ### Secrets and variables
 
-`${{ vars.KEY }}` resolves server-side when the run is created and works in
-every template site and in server predicates after run creation. The `secrets`
-root never resolves on the server. `${{ secrets.KEY }}` is allowed only in a
-run step's `run` command or `env` values, and the runner pulls the value just
-before the step executes. Secrets never work in predicates.
-The full model lives in [Secrets and variables](/reference/secrets-variables).
+Shipfox resolves `${{ vars.KEY }}` on the server when it creates the run.
+Every template site can read this context.
+
+Predicates can read `vars` after run creation if the predicate table lists this
+context. A trigger `filter` cannot read `vars` because no run exists at ingest.
+
+The server never resolves `${{ secrets.KEY }}`. Only the `run` and `env` fields
+of a run step can use this context.
+
+The runner gets the secret value immediately before the step starts. Predicates
+cannot read this value.
+
+[Secrets and variables](/reference/secrets-variables) gives the full model.
 
 ### Run-command safety
 
-Shipfox hoists each template in a `run` command into a generated environment
-binding and uses quoted shell expansion. This keeps interpolated text from
-being parsed as shell syntax. It does not protect commands that deliberately
-re-evaluate their arguments as code, such as `eval`, `sh -c "$value"`, `let`,
-`declare -i`, arithmetic expressions, or array subscripts. Keep workflow data
-out of those code positions. See [Commands receive template values as data](/understand/data-and-templating#commands-receive-template-values-as-data)
-for the shell data-position model.
+Shipfox puts each template in a `run` command into a generated environment
+binding. It uses quoted shell expansion. Thus, the shell does not parse the
+interpolated text.
+
+Some commands parse their arguments again as code:
+
+- `eval`
+- `sh -c "$value"`
+- `let`
+- `declare -i`
+- Arithmetic expressions
+- Array subscripts
+
+Do not put workflow data in these code positions. [Commands receive template
+values as
+data](/understand/data-and-templating#commands-receive-template-values-as-data)
+explains the shell data-position model.
 
 ### Outputs
 
-Steps declare typed outputs and later steps or jobs read them through
-`steps.<key>.outputs` and `needs`/`jobs`. The authored shape and the runtime
-mechanics live in [Step outputs](/reference/workflow-schema#step-outputs). The
-mental model lives in [Context and templating](/understand/data-and-templating).
+Steps declare typed outputs. Later steps can read these outputs through
+`steps.<key>.outputs`. Jobs can read them through `needs` or `jobs`.
+
+[Step outputs](/reference/workflow-schema#step-outputs) gives the authored shape
+and runtime operation. [Context and
+templating](/understand/data-and-templating) explains the context model.
 
 ## Shipped vs. roadmap
 
@@ -229,9 +271,9 @@ mental model lives in [Context and templating](/understand/data-and-templating).
 
 <Cards>
   <Card title="Workflow schema" href="/reference/workflow-schema">
-    The full YAML schema these expressions live in.
+    The full YAML schema that contains these expressions.
   </Card>
   <Card title="Context and templating" href="/understand/data-and-templating">
-    The mental model: what data flows through a run, and why the rules exist.
+    The model of context data in a run and the reasons for the rules.
   </Card>
 </Cards>

--- a/apps/docs/content/docs/reference/expressions.mdx
+++ b/apps/docs/content/docs/reference/expressions.mdx
@@ -1,268 +1,98 @@
 ---
-title: "Expressions and Interpolation (CEL)"
-sidebarTitle: "Expressions (CEL)"
-description: "Shipfox uses CEL predicates to make workflow decisions. It uses ${{ }} templates to put context in commands, environment values, prompts, and outputs."
+title: "Expressions (CEL)"
+sidebarTitle: "Expressions"
+description: "Look up the syntax, operators, and functions available inside a Shipfox expression."
 ---
 
-Shipfox uses [CEL (Common Expression Language)](https://cel.dev) in two ways.
-A **predicate** gives a true or false result. This result controls a trigger,
-job, step, or gate.
+Shipfox expressions use [CEL](https://cel.dev). A workflow writes them in two
+forms.
 
-A **template** puts a string value in text. The text can be a prompt, command,
-environment value, name, or output. Templates use the `${{ }}` syntax.
+A **template** puts a value into text with `${{ }}`. A **predicate** gives a true
+or false result that controls a trigger, job, step, or gate.
 
-Each workflow field can use context that exists when Shipfox reads the field.
-A trigger `filter` cannot use `vars` or step outputs because no run exists yet.
-Job and step `if` fields can use `vars`.
+For the data an expression can read, see [Contexts](/reference/contexts).
 
-Only `run` commands and `env` values can use `secrets`. The
-[context table](#context-available) shows when each context root becomes
-available.
+## Syntax
 
-## The CEL engine
-
-Expressions use the standard features of CEL:
-
-- Value types: integers, strings, booleans, lists, and maps
-- Operators: `==`, `!=`, `<`, `>`, `&&`, `||`, `!`, `in`, and arithmetic
-- Macros: `.map()`, `.filter()`, `.all()`, and `.exists()`
-- String functions: `.contains()`, `.startsWith()`, and `.endsWith()`
-
-The engine has no custom functions. Expressions cannot cause side effects.
-
-## Predicates
-
-### Predicate context
-
-Each predicate field can read only the context in this table:
-
-| Predicate | Context |
-|---|---|
-| `trigger.filter` | `event` and `trigger` |
-| Listening-job `on` and `until` filters | The incoming listener event as `event`, plus snapshotted `run`, `trigger`, `inputs`, `vars`, `job`, and referenced `jobs` values |
-| `job.if` | `run`, `trigger`, `event`, `inputs`, `vars`, `jobs`, and `needs` |
-| `step.if` | `vars`, `jobs`, `execution`, `step`, and `steps` |
-| `gate.success` | `step` and `vars` |
-| Job `success` | `executions`, `jobs`, and `vars` |
-
-In a listening-job filter, `event` can start a new execution. In a trigger
-filter, `event` can start a new run. No predicate can read `secrets`.
-
-### Trigger filters
-
-Shipfox evaluates a trigger `filter` when the event arrives. At this time, a
-run does not exist.
-
-The filter can read `event`. This context contains the payload. The filter can
-also read the `source` and `event` fields of `trigger`.
-
-A false result stops the event. If the expression has an error, Shipfox does
-not start the trigger. This is fail-closed behavior.
-
-Listening jobs have `on` and `until` fields. These fields use the incoming
-listener event and the context in the predicate table.
-
-This example is a trigger fragment in the `triggers` map of a workflow:
+Write an expression between `${{` and `}}`:
 
 ```yaml
-triggers:
-  on_main_push:
-    source: github_acme
-    event: push
-    filter: event.ref == "refs/heads/main"
+run: echo "Building ${{ trigger.event }}"
 ```
 
-### Conditionals: `if`
+| Form | Example | Result |
+| --- | --- | --- |
+| Property access | `event.ref` | The `ref` property of `event` |
+| Index access | `vars["API_URL"]` | A property whose name is not an identifier |
+| List index | `execution.events[0].data` | The first element of a list |
+| Escape | `$${{` | The literal text `${{` |
 
-Jobs and steps can have an `if` field. This field contains exactly one CEL
-boolean in `${{ }}`.
-
-A false result gives the **skipped** status to the job or step. An evaluation
-error gives the same status. The recorded reason gives the cause.
-
-This example is a job fragment in the `jobs` map of a workflow:
+A predicate field takes the expression on its own. An `if` field takes exactly
+one `${{ }}` and nothing else:
 
 ```yaml
-# yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
-jobs:
-  deploy:
-    if: ${{ event.ref == "refs/heads/main" }}
-    steps:
-      - key: build
-        run: ./build.sh
-        outputs:
-          artifact_count: number
-      - run: ./deploy.sh
-        if: ${{ steps.build.outputs.artifact_count > 0 }}
+if: ${{ trigger.event == "push" }}
 ```
 
-### Gate success: `gate.success`
+`vars` and `secrets` accept a literal key only. `vars["API_URL"]` is valid and a
+computed key such as `vars[inputs.name]` is not.
 
-Shipfox evaluates `gate.success` when the gated step finishes. The expression
-can read these fields:
+## Types
 
-- `step.exit_code` is an integer
-- `step.status` is a string
-- `step.outputs` contains the declared outputs of the step
-- `vars` contains the workflow variables
+| Type | Example |
+| --- | --- |
+| `string` | `"refs/heads/main"` |
+| `int` | `42` |
+| `double` | `1.5` |
+| `bool` | `true` |
+| `timestamp` | `run.created_at` |
+| `list` | `execution.events` |
+| `map` | `steps.build.outputs` |
 
-[Feedback loops](/understand/feedback-loops) gives the full gate model.
+## Operators
 
-This example is a gate fragment on a run step or an agent step:
+| Operator | Meaning |
+| --- | --- |
+| `==`, `!=` | Equal, not equal |
+| `<`, `<=`, `>`, `>=` | Ordered comparison |
+| `&&`, `||`, `!` | And, or, not |
+| `in` | Membership in a list or map |
+| `+`, `-`, `*`, `/`, `%` | Arithmetic. `+` also joins strings and lists |
+| `? :` | Conditional value |
+
+## Functions and macros
+
+| Call | Result |
+| --- | --- |
+| `list.size()`, `string.size()` | Number of elements or characters |
+| `list.all(item, predicate)` | True when every element matches |
+| `list.exists(item, predicate)` | True when at least one element matches |
+| `list.exists_one(item, predicate)` | True when exactly one element matches |
+| `list.filter(item, predicate)` | The elements that match |
+| `list.map(item, expression)` | The expression applied to each element |
+| `string.contains(part)` | True when the string contains `part` |
+| `string.startsWith(part)`, `string.endsWith(part)` | Prefix and suffix tests |
+| `string.matches(pattern)` | True when the string matches a regular expression |
+
+This job `success` predicate uses a macro over the executions of the job:
 
 ```yaml
-gate:
-  success: step.exit_code == 0
+success: 'executions.all(e, e.status == "succeeded")'
 ```
 
-### Job success: `success`
-
-A job can have a `success` expression. Shipfox gets its result after all
-executions finish. This expression can read the `executions` list, `jobs`, and
-`vars`.
-
-Each list item contains `index`, `name`, and `status`. It also contains
-`events`, `outputs`, and time fields.
-
-By default, a job succeeds if no execution fails. A listening job also succeeds
-if it has no executions when it resolves.
-
-This example is a job fragment in the `jobs` map of a workflow:
-
-```yaml
-# yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
-jobs:
-  build:
-    success: '!executions.exists(e, e.status == "failed")'
-    steps:
-      - run: ./maybe-flaky.sh
-```
-
-The next `success` field is true only if the job has one or more executions:
-
-```yaml
-success: 'executions.size() > 0 && executions.all(e, e.status == "succeeded")'
-```
-
-## Templates: `${{ }}`
-
-Interpolation puts run-context values in strings. These fields can contain
-templates:
-
-- The `run` commands and `env` values of run steps
-- The `prompt`, `model`, and `provider` fields of agent steps
-- The `runner`, `name`, and `outputs` fields of jobs
-- The `name` and `on_failure.feedback` fields of steps
-
-The sequence `$${{` writes a literal `${{`.
-
-**Shipfox resolves each reference when its data becomes available:**
-
-- `trigger` and `event` at ingest
-- `run`, `inputs`, `job`, and `vars` at run creation
-- `executions` and `execution` at execution creation
-- `needs` and `jobs` at job activation
-- `steps.*` and `step.*` at step dispatch
-- `secrets` at runner fill
-
-A typed error occurs if Shipfox cannot resolve a reference. The error code is
-`context-unavailable-at-fill-site`. Shipfox does not use empty text.
-
-This example is a job fragment in the `jobs` map of a workflow:
-
-```yaml
-# yaml-language-server: $schema=https://www.shipfox.io/docs/workflow.schema.json
-jobs:
-  build:
-    env:
-      SOURCE: "${{ trigger.source }}"
-    steps:
-      - run: echo "Building for ${{ trigger.event }}"
-      - prompt: "Investigate the event that triggered this run: ${{ event.title }}"
-```
-
-### Context available
-
-| Root | Holds | Available from |
-|---|---|---|
-| `run` | `id`, `name`, `workflow_name`, `definition_id`, `project_id`, `workspace_id`, `created_at` | Run creation |
-| `trigger` | `source`, `event` | Ingest |
-| `event` | The raw event payload of the trigger (open shape, such as `event.ref`, `event.title`) | Ingest |
-| `inputs` | Values from the `with` block of the trigger (open shape) | Run creation |
-| `job` | The `key` and `name` of the current job | Run creation |
-| `executions` | The executions of the current job, including `index`, `name`, `status`, `events`, `outputs`, and time fields | Execution creation |
-| `execution` | Current execution metadata and its listening-job events | Execution creation |
-| `needs` | Direct dependency jobs with their status and outputs | Job activation |
-| `jobs` | Named upstream jobs with their status and outputs | Job activation |
-| `steps.<key>` | The `status`, `exit_code`, `outputs`, and `attempts` of earlier steps | Step dispatch |
-| `step` | `attempt`, `is_retry`, `restart.from`, and `restart.feedback` | Step dispatch |
-| `vars` | Workspace and project [variables](/reference/secrets-variables), literal keys only | Run creation |
-| `secrets` | Workspace and project [secrets](/reference/secrets-variables), literal keys only. Only the runner holds these values. | Runner fill |
-
-### Secrets and variables
-
-Shipfox resolves `${{ vars.KEY }}` on the server when it creates the run.
-Every template site can read this context.
-
-Predicates can read `vars` after run creation if the predicate table lists this
-context. A trigger `filter` cannot read `vars` because no run exists at ingest.
-
-The server never resolves `${{ secrets.KEY }}`. Only the `run` and `env` fields
-of a run step can use this context.
-
-The runner gets the secret value immediately before the step starts. Predicates
-cannot read this value.
-
-[Secrets and variables](/reference/secrets-variables) gives the full model.
-
-### Run-command safety
-
-Shipfox puts each template in a `run` command into a generated environment
-binding. It uses quoted shell expansion. Thus, the shell does not parse the
-interpolated text.
-
-Some commands parse their arguments again as code:
-
-- `eval`
-- `sh -c "$value"`
-- `let`
-- `declare -i`
-- Arithmetic expressions
-- Array subscripts
-
-Do not put workflow data in these code positions. [Commands receive template
-values as
-data](/understand/data-and-templating#commands-receive-template-values-as-data)
-explains the shell data-position model.
-
-### Outputs
-
-Steps declare typed outputs. Later steps can read these outputs through
-`steps.<key>.outputs`. Jobs can read them through `needs` or `jobs`.
-
-[Step outputs](/reference/workflow-schema#step-outputs) gives the authored shape
-and runtime operation. [Context and
-templating](/understand/data-and-templating) explains the context model.
-
-## Shipped vs. roadmap
-
-| Feature | Status |
-|---|---|
-| Trigger `filter` evaluation | ✅ Shipped |
-| `if` conditionals on jobs and steps | ✅ Shipped |
-| `gate.success` (exit code, status, outputs) and job `success` | ✅ Shipped |
-| `${{ }}` templates in commands, env, prompts, names, outputs, feedback | ✅ Shipped |
-| Step and job `outputs` | ✅ Shipped |
-| `${{ vars.* }}` and `${{ secrets.* }}` | ✅ Shipped |
-| `loop`, `matrix`, `branch` | 🔜 Roadmap |
+Shipfox adds no custom functions. Expressions can use CEL's standard functions
+when the required context is available.
 
 ## Related pages
 
 <Cards>
+  <Card title="Contexts" href="/reference/contexts">
+    Every context, its properties, and the fields that can read it.
+  </Card>
   <Card title="Workflow schema" href="/reference/workflow-schema">
-    The full YAML schema that contains these expressions.
+    The fields that carry these expressions.
   </Card>
   <Card title="Context and templating" href="/understand/data-and-templating">
-    The model of context data in a run and the reasons for the rules.
+    Why templates and predicates are separate, and how commands receive values.
   </Card>
 </Cards>

--- a/apps/docs/content/docs/reference/expressions.mdx
+++ b/apps/docs/content/docs/reference/expressions.mdx
@@ -156,17 +156,6 @@ templates:
 
 The sequence `$${{` writes a literal `${{`.
 
-### Infrastructure selectors
-
-The `job.runner`, agent `model`, and agent `provider` fields select execution
-infrastructure. Use values that you write in the workflow for these fields.
-
-Event, trigger-input, listening-event, and output data can currently reach
-these fields. Definition validation does not block this data.
-
-The `agent.thinking` field is an enum, not a template site. These fields are
-not a safety boundary.
-
 **Shipfox resolves each reference when its data becomes available:**
 
 - `trigger` and `event` at ingest

--- a/apps/docs/content/docs/reference/glossary.mdx
+++ b/apps/docs/content/docs/reference/glossary.mdx
@@ -20,7 +20,7 @@ This glossary defines the core terms used in Shipfox documentation and in the pr
   </Accordion>
 
   <Accordion title="CEL">
-    Common Expression Language, a lightweight expression language used in Shipfox for trigger filters (`filter`), `if` conditionals, gate success conditions (`gate.success`), and job success conditions. CEL expressions are type-safe, side-effect-free, and sandboxed. In `gate.success`, `step.exit_code` (integer), `step.status` (string), and `step.outputs` are available. In `filter`, the variable `event` carries the event payload. See [Expressions](/reference/expressions).
+    Common Expression Language, the expression language Shipfox uses for `${{ }}` templates and for predicate fields such as `filter`, `if`, `gate.success`, and job `success`. See [Expressions](/reference/expressions) for the syntax and [Contexts](/reference/contexts) for the data each field can read.
   </Accordion>
 
   <Accordion title="Execution">

--- a/apps/docs/content/docs/reference/index.mdx
+++ b/apps/docs/content/docs/reference/index.mdx
@@ -14,8 +14,11 @@ guide](/how-to).
   <Card title="Workflow schema" href="/reference/workflow-schema">
     Look up trigger, job, step, agent, gate, and listening fields.
   </Card>
+  <Card title="Contexts" href="/reference/contexts">
+    Look up every context, its properties, and the fields that can read it.
+  </Card>
   <Card title="Expressions" href="/reference/expressions">
-    Look up contexts, templates, CEL rules, and safe data binding.
+    Look up the syntax, operators, and functions inside an expression.
   </Card>
   <Card title="Trigger sources" href="/reference/trigger-sources">
     Look up manual, schedule, and integration trigger contracts.

--- a/apps/docs/content/docs/reference/meta.json
+++ b/apps/docs/content/docs/reference/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "index",
     "workflow-schema",
+    "contexts",
     "expressions",
     "trigger-sources",
     "secrets-variables",

--- a/apps/docs/content/docs/reference/trigger-sources.mdx
+++ b/apps/docs/content/docs/reference/trigger-sources.mdx
@@ -101,5 +101,5 @@ triggers:
     filter: event.ref == "refs/heads/main"
 ```
 
-See [Expressions](/reference/expressions#trigger-filters) for the engine and
-the exact scope.
+See [Expressions](/reference/expressions) for the engine and the [Contexts
+reference](/reference/contexts#context-availability) for the exact scope.

--- a/apps/docs/content/docs/reference/workflow-schema.mdx
+++ b/apps/docs/content/docs/reference/workflow-schema.mdx
@@ -154,12 +154,14 @@ A `${{ }}` value in `run` reaches the command as a quoted shell variable, so the
 shell reads it as text and not as part of the command.
 
 <Callout title="Keep run data out of code positions" type="warn">
-  A few commands read their argument as shell code again: `eval`,
-  `sh -c "$value"`, `let`, `declare -i`, arithmetic expressions, and array
-  subscripts. A value that reaches one of them runs as a command on the runner,
-  with the job's credentials and workspace. Event payloads, trigger inputs, and
-  step outputs come from outside the workflow, so prefer passing them as
-  arguments: `deploy "$TARGET"` rather than `eval "deploy $TARGET"`.
+  Some programs read their argument as code again, which puts an interpolated
+  value back in a code position: `eval`, `sh -c`, `bash -c`, `source`, `let`,
+  `declare -i`, shell arithmetic, `awk`, `jq`, `sed`, and `xargs sh -c`. A value
+  that reaches one of them runs on the runner with the job's credentials and
+  workspace. Event payloads, trigger inputs, and step outputs come from outside
+  the workflow, so pass them as arguments to a fixed program instead:
+  `deploy "$TARGET"` rather than `eval "deploy $TARGET"`. A workflow sync warns
+  when it finds one of these positions.
 </Callout>
 
 ### Checkout step fields

--- a/apps/docs/content/docs/reference/workflow-schema.mdx
+++ b/apps/docs/content/docs/reference/workflow-schema.mdx
@@ -196,8 +196,11 @@ A batch must set at least one of `debounce`, `max_size`, or `max_wait`.
 ## Related pages
 
 <Cards>
-  <Card title="Expressions (CEL)" href="/reference/expressions">
-    Gate and job success predicates, and `${{ }}` interpolation.
+  <Card title="Contexts" href="/reference/contexts">
+    Every context, its properties, and the fields that can read it.
+  </Card>
+  <Card title="Expressions" href="/reference/expressions">
+    The syntax, operators, and functions available inside an expression.
   </Card>
   <Card title="Model Providers" href="/reference/model-providers">
     Every provider ID, default model, and how agent config resolves.

--- a/apps/docs/content/docs/reference/workflow-schema.mdx
+++ b/apps/docs/content/docs/reference/workflow-schema.mdx
@@ -150,6 +150,18 @@ rejects unknown fields and invalid field combinations.
 
 <RunStepFields />
 
+A `${{ }}` value in `run` reaches the command as a quoted shell variable, so the
+shell reads it as text and not as part of the command.
+
+<Callout title="Keep run data out of code positions" type="warn">
+  A few commands read their argument as shell code again: `eval`,
+  `sh -c "$value"`, `let`, `declare -i`, arithmetic expressions, and array
+  subscripts. A value that reaches one of them runs as a command on the runner,
+  with the job's credentials and workspace. Event payloads, trigger inputs, and
+  step outputs come from outside the workflow, so prefer passing them as
+  arguments: `deploy "$TARGET"` rather than `eval "deploy $TARGET"`.
+</Callout>
+
 ### Checkout step fields
 
 <CheckoutStepFields />

--- a/apps/docs/content/docs/understand/data-and-templating.mdx
+++ b/apps/docs/content/docs/understand/data-and-templating.mdx
@@ -86,31 +86,16 @@ Outputs suit small facts. Files and build products belong in external artifact
 storage, with an output carrying their location. Exact output types and limits
 live in [Step outputs](/reference/workflow-schema#step-outputs).
 
-## Commands receive template values as data
+## Templates carry untrusted data
 
-Shipfox does not splice template values into shell text. It binds each
-interpolated value to the command environment and replaces the template with a
-quoted shell reference. This happens automatically, including for events,
-inputs, listening events, and outputs.
+Events, inputs, and step outputs carry data the workflow did not write. A shell
+step reads that data as text, so it cannot run as a command. [A few shell
+constructs](/reference/workflow-schema#run-step-fields) re-read their own
+arguments and break that.
 
-This binding keeps an interpolated value in a data position. A command that
-re-executes its arguments can parse the value as shell code again. Keep workflow
-data out of those code positions: `eval`, `sh -c "$value"`, `let`, `declare -i`,
-arithmetic expressions, and array subscripts.
-
-Infrastructure selectors are not a trust boundary either. The `runner` field of
-a job and the `model`, `provider`, and `thinking` fields of an agent step accept
-templates like any other field. Event data can choose where a job runs and how
-much reasoning it uses. Use a literal or a variable when that choice must not
-depend on the event.
-
-Prompts do not have shell injection, but they still have instruction injection.
-Tell the agent which fields are data. Limit the tools and write access on that
-step.
-
-Secrets are different again. Keep raw secrets out of prompts and persisted
-outputs. Use a run step when a command needs a secret. For external work, give
-the agent a narrow tool that keeps the credential behind its integration connection.
+Nothing guards a prompt or a job setting this way. An event can plant orders
+for an agent. It can also pick the runner a job uses. Keep an event out of any
+choice you would not let a stranger make.
 
 [Secrets and variables](/reference/secrets-variables) describes storage,
 masking, and binding. [Integrations, integration connections, and

--- a/apps/docs/content/docs/understand/data-and-templating.mdx
+++ b/apps/docs/content/docs/understand/data-and-templating.mdx
@@ -26,7 +26,7 @@ Workspace variables and project settings provide long-lived configuration.
 Events and outputs describe this run. Secrets grant authority and follow a
 stricter path.
 
-The [Expressions reference](/reference/expressions#context-available) is the
+The [Contexts reference](/reference/contexts#context-availability) is the
 canonical map of which context roots each field can read.
 
 ## Templates carry data; predicates make decisions
@@ -94,8 +94,15 @@ quoted shell reference. This happens automatically, including for events,
 inputs, listening events, and outputs.
 
 This binding keeps an interpolated value in a data position. A command that
-re-executes its arguments, such as `eval` or `sh -c`, can parse the value as
-shell code again. Keep workflow data out of those code positions.
+re-executes its arguments can parse the value as shell code again. Keep workflow
+data out of those code positions: `eval`, `sh -c "$value"`, `let`, `declare -i`,
+arithmetic expressions, and array subscripts.
+
+Infrastructure selectors are not a trust boundary either. The `runner` field of
+a job and the `model`, `provider`, and `thinking` fields of an agent step accept
+templates like any other field. Event data can choose where a job runs and how
+much reasoning it uses. Use a literal or a variable when that choice must not
+depend on the event.
 
 Prompts do not have shell injection, but they still have instruction injection.
 Tell the agent which fields are data. Limit the tools and write access on that

--- a/apps/docs/content/docs/understand/events-and-triggers.mdx
+++ b/apps/docs/content/docs/understand/events-and-triggers.mdx
@@ -68,7 +68,9 @@ than a failed job.
 Use the event journal and [event-routing
 guide](/how-to/run-and-troubleshoot/event-routing) to separate delivery from
 filter evaluation. The [Expressions
-reference](/reference/expressions#trigger-filters) defines filter behavior.
+reference](/reference/expressions) defines the expression syntax. The
+[Contexts reference](/reference/contexts#context-availability) defines the
+available data.
 
 ## Choose the mechanism by intent
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -16,7 +16,7 @@
     "start": "next start --port ${SHIPFOX_DOCS_PORT:-3500}",
     "type": "shipfox-tsc-check",
     "generate": "tsx --conditions=workspace-source scripts/generate.mjs",
-    "test": "pnpm generate && pnpm test:unit && tsx scripts/check-writing.mjs && tsx scripts/check-links.mjs && tsx scripts/check-workflow-schema.mjs && tsx scripts/check-catalog.mjs && tsx scripts/check-integration-docs.mjs",
+    "test": "pnpm generate && pnpm test:unit && tsx scripts/check-writing.mjs && tsx scripts/check-links.mjs && tsx scripts/check-workflow-schema.mjs && tsx --conditions=workspace-source scripts/check-contexts.mjs && tsx scripts/check-catalog.mjs && tsx scripts/check-integration-docs.mjs",
     "test:unit": "tsx --test",
     "postinstall": "fumadocs-mdx"
   },
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@shipfox/api-agent-dto": "workspace:*",
     "@shipfox/api-integration-core-dto": "workspace:*",
+    "@shipfox/expression": "workspace:*",
     "@shipfox/api-integration-github": "workspace:*",
     "@shipfox/api-integration-github-dto": "workspace:*",
     "@shipfox/api-integration-sentry-dto": "workspace:*",

--- a/apps/docs/scripts/check-contexts.mjs
+++ b/apps/docs/scripts/check-contexts.mjs
@@ -1,0 +1,61 @@
+import {
+  buildTypedRootsEnvironment,
+  getWorkflowContextTypeEnvironment,
+  workflowContextDocs,
+  workflowInterpolationFields,
+  workflowPredicateFields,
+} from '@shipfox/expression';
+import {
+  contextFieldRows,
+  contextRootShape,
+  WORKFLOW_FIELD_YAML_KEYS,
+} from './lib/context-reference.mjs';
+
+const failures = [];
+const engineFields = [...workflowPredicateFields, ...workflowInterpolationFields];
+const mappedFields = Object.keys(WORKFLOW_FIELD_YAML_KEYS);
+
+for (const field of engineFields) {
+  if (!mappedFields.includes(field)) {
+    failures.push(
+      `Expression field "${field}" has no YAML key in scripts/lib/context-reference.mjs. Add it so the availability matrix documents the field.`,
+    );
+  }
+}
+
+for (const field of mappedFields) {
+  if (!engineFields.includes(field)) {
+    failures.push(
+      `YAML key mapping names "${field}", which the expression engine no longer defines. Remove it from scripts/lib/context-reference.mjs.`,
+    );
+  }
+}
+
+const deps = {
+  getTypeEnvironment: getWorkflowContextTypeEnvironment,
+  buildTypedRoots: buildTypedRootsEnvironment,
+};
+
+for (const doc of workflowContextDocs) {
+  const shape = contextRootShape(doc.root, deps);
+  const rendered = new Set(
+    shape === undefined
+      ? []
+      : contextFieldRows(shape, '', doc.collapse ?? []).map((row) => row.path),
+  );
+  for (const path of Object.keys(doc.fields ?? {})) {
+    if (rendered.has(path)) continue;
+    failures.push(
+      `Context "${doc.root}" describes "${path}", which its type no longer has. Remove the description in libs/shared/expression/src/workflow-context/workflow-context-docs.ts.`,
+    );
+  }
+}
+
+if (failures.length > 0) {
+  // biome-ignore lint/suspicious/noConsole: CLI diagnostics
+  console.error(`✖ context reference drift\n${failures.map((line) => `  - ${line}`).join('\n')}`);
+  process.exit(1);
+}
+
+// biome-ignore lint/suspicious/noConsole: CLI diagnostics
+console.log(`✓ context reference covers ${engineFields.length} expression fields`);

--- a/apps/docs/scripts/generate.mjs
+++ b/apps/docs/scripts/generate.mjs
@@ -13,7 +13,6 @@ import {webhookEventCatalog} from '@shipfox/api-integration-webhook-dto';
 import {
   buildTypedRootsEnvironment,
   contextRootsForField,
-  getWorkflowContextDefinition,
   getWorkflowContextTypeEnvironment,
   workflowContextDocs,
 } from '@shipfox/expression';
@@ -89,25 +88,12 @@ function renderContextAvailability() {
     '| Workflow key | Available contexts |',
     '|---|---|',
     ...Object.entries(WORKFLOW_FIELD_YAML_KEYS).map(
-      ([field, key]) => `| \`${key}\` | ${availableContexts(contextRootsForField(field))} |`,
+      ([field, key]) =>
+        `| \`${key}\` | ${contextRootsForField(field)
+          .map((root) => `\`${root}\``)
+          .join(', ')} |`,
     ),
   ].join('\n');
-}
-
-/**
- * A template field can read every context its host can resolve, so listing all
- * of them per row buries the one distinction that matters: whether `secrets`
- * is reachable.
- */
-function availableContexts(roots) {
-  const serverRoots = workflowContextDocs
-    .map((doc) => doc.root)
-    .filter((root) => getWorkflowContextDefinition(root).host === 'server');
-  if (roots.length === workflowContextDocs.length) return 'Every context, including `secrets`';
-  if (roots.length === serverRoots.length && serverRoots.every((root) => roots.includes(root))) {
-    return 'Every context except `secrets`';
-  }
-  return roots.map((root) => `\`${root}\``).join(', ');
 }
 
 function renderContextProperties() {

--- a/apps/docs/scripts/generate.mjs
+++ b/apps/docs/scripts/generate.mjs
@@ -10,8 +10,20 @@ import {
 import {githubEventCatalog} from '@shipfox/api-integration-github-dto';
 import {sentryEventCatalog} from '@shipfox/api-integration-sentry-dto';
 import {webhookEventCatalog} from '@shipfox/api-integration-webhook-dto';
+import {
+  buildTypedRootsEnvironment,
+  contextRootsForField,
+  getWorkflowContextDefinition,
+  getWorkflowContextTypeEnvironment,
+  workflowContextDocs,
+} from '@shipfox/expression';
 import {buildWorkflowJsonSchema, thinkingLevelsForHarness} from '@shipfox/workflow-document';
 import {registeredIntegrationProviders} from '@/lib/registered-integration-providers';
+import {
+  contextFieldRows,
+  contextRootShape,
+  WORKFLOW_FIELD_YAML_KEYS,
+} from './lib/context-reference.mjs';
 import {slugForHeading} from './lib/slug.mjs';
 
 const docsRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
@@ -54,7 +66,74 @@ const regions = [
   ]),
   ['content/generated/integrations/catalog.json', renderIntegrationCatalogData],
   ['content/generated/reference/workflow-schema.mdx', renderWorkflowSchemaReference],
+  ['content/generated/reference/context-roots.mdx', renderContextRoots],
+  ['content/generated/reference/context-availability.mdx', renderContextAvailability],
+  ['content/generated/reference/context-properties.mdx', renderContextProperties],
 ];
+
+const contextShapeDeps = {
+  getTypeEnvironment: getWorkflowContextTypeEnvironment,
+  buildTypedRoots: buildTypedRootsEnvironment,
+};
+
+function renderContextRoots() {
+  return [
+    '| Context | Holds |',
+    '|---|---|',
+    ...workflowContextDocs.map((doc) => `| \`${doc.root}\` | ${doc.summary} |`),
+  ].join('\n');
+}
+
+function renderContextAvailability() {
+  return [
+    '| Workflow key | Available contexts |',
+    '|---|---|',
+    ...Object.entries(WORKFLOW_FIELD_YAML_KEYS).map(
+      ([field, key]) => `| \`${key}\` | ${availableContexts(contextRootsForField(field))} |`,
+    ),
+  ].join('\n');
+}
+
+/**
+ * A template field can read every context its host can resolve, so listing all
+ * of them per row buries the one distinction that matters: whether `secrets`
+ * is reachable.
+ */
+function availableContexts(roots) {
+  const serverRoots = workflowContextDocs
+    .map((doc) => doc.root)
+    .filter((root) => getWorkflowContextDefinition(root).host === 'server');
+  if (roots.length === workflowContextDocs.length) return 'Every context, including `secrets`';
+  if (roots.length === serverRoots.length && serverRoots.every((root) => roots.includes(root))) {
+    return 'Every context except `secrets`';
+  }
+  return roots.map((root) => `\`${root}\``).join(', ');
+}
+
+function renderContextProperties() {
+  return workflowContextDocs.flatMap((doc) => renderContextRoot(doc)).join('\n');
+}
+
+function renderContextRoot(doc) {
+  const lines = [`### \`${doc.root}\``, '', doc.summary, ''];
+  if (doc.shapeNote !== undefined) lines.push(doc.shapeNote, '');
+
+  const shape = contextRootShape(doc.root, contextShapeDeps);
+  const rows = shape === undefined ? [] : contextFieldRows(shape, '', doc.collapse ?? []);
+  if (rows.length === 0) return lines;
+
+  const prefix = doc.propertyPrefix ?? `${doc.root}.`;
+  lines.push('| Property | Type | Description |', '|---|---|---|');
+  for (const row of rows) {
+    const description = doc.fields?.[row.path];
+    if (description === undefined) {
+      throw new Error(`Context ${doc.root} property ${row.path} has no description.`);
+    }
+    lines.push(`| \`${prefix}${row.path}\` | \`${row.type}\` | ${description} |`);
+  }
+  lines.push('');
+  return lines;
+}
 
 function renderIntegrationCatalogData() {
   return JSON.stringify(

--- a/apps/docs/scripts/lib/context-reference.mjs
+++ b/apps/docs/scripts/lib/context-reference.mjs
@@ -24,6 +24,11 @@ export const WORKFLOW_FIELD_YAML_KEYS = {
   'job.execution_name': 'jobs.<job_id>.execution_name',
   'step.name': 'jobs.<job_id>.steps[*].name',
   'step.working_directory': 'jobs.<job_id>.steps[*].working_directory',
+  'checkout.project': 'jobs.<job_id>.steps[*].checkout.project',
+  'checkout.connection': 'jobs.<job_id>.steps[*].checkout.connection',
+  'checkout.repository': 'jobs.<job_id>.steps[*].checkout.repository',
+  'checkout.ref': 'jobs.<job_id>.steps[*].checkout.ref',
+  'checkout.path': 'jobs.<job_id>.steps[*].checkout.path',
   'step.feedback': 'jobs.<job_id>.steps[*].gate.on_failure.feedback',
 };
 

--- a/apps/docs/scripts/lib/context-reference.mjs
+++ b/apps/docs/scripts/lib/context-reference.mjs
@@ -1,0 +1,80 @@
+/**
+ * Keep the YAML names beside the generator and its drift check.
+ *
+ * The engine names expression sites as the runtime does. Readers need the YAML
+ * key they type, so the check fails when the engine gains an unmapped field.
+ */
+export const WORKFLOW_FIELD_YAML_KEYS = {
+  'trigger.filter': 'triggers.<trigger_id>.filter',
+  'listener.on': 'jobs.<job_id>.listening.on[*].filter',
+  'listener.until': 'jobs.<job_id>.listening.until[*].filter',
+  'job.if': 'jobs.<job_id>.if',
+  'step.if': 'jobs.<job_id>.steps[*].if',
+  'step.success': 'jobs.<job_id>.steps[*].gate.success',
+  'job.success': 'jobs.<job_id>.success',
+  run: 'jobs.<job_id>.steps[*].run',
+  'env.value': 'env.<name>',
+  'agent.prompt': 'jobs.<job_id>.steps[*].prompt',
+  'agent.model': 'jobs.<job_id>.steps[*].model',
+  'agent.provider': 'jobs.<job_id>.steps[*].provider',
+  'agent.thinking': 'jobs.<job_id>.steps[*].thinking',
+  'job.runner': 'jobs.<job_id>.runner',
+  'job.outputs': 'jobs.<job_id>.outputs.<name>',
+  'workflow.run_name': 'run_name',
+  'job.execution_name': 'jobs.<job_id>.execution_name',
+  'step.name': 'jobs.<job_id>.steps[*].name',
+  'step.working_directory': 'jobs.<job_id>.steps[*].working_directory',
+  'step.feedback': 'jobs.<job_id>.steps[*].gate.on_failure.feedback',
+};
+
+// Keep the shape lookup here so generation and drift checking traverse the same
+// typed registry.
+export function contextRootShape(root, deps) {
+  const {getTypeEnvironment, buildTypedRoots} = deps;
+  if (root === 'jobs') {
+    return objectFields(buildTypedRoots({jobs: [{key: '<job_key>'}]}).jobs)['<job_key>'];
+  }
+  if (root === 'steps') {
+    return objectFields(buildTypedRoots({steps: [{key: '<step_key>'}]}).steps)['<step_key>'];
+  }
+
+  const environment = getTypeEnvironment(root);
+  const type = environment?.[root];
+  if (type === undefined) return undefined;
+  return type.kind === 'list' ? type.element : type;
+}
+
+export function contextFieldRows(type, prefix = '', collapse = []) {
+  if (typeof type !== 'object' || type.kind !== 'object') return [];
+
+  return Object.entries(type.fields).flatMap(([name, fieldType]) => {
+    const path = `${prefix}${name}`;
+    const row = {path, type: typeLabel(fieldType)};
+    // Keep collapsed paths as leaves because another context root documents
+    // their element shape.
+    if (collapse.includes(path)) return [row];
+    if (typeof fieldType === 'object' && fieldType.kind === 'object') {
+      return [row, ...contextFieldRows(fieldType, `${path}.`, collapse)];
+    }
+    if (
+      typeof fieldType === 'object' &&
+      fieldType.kind === 'list' &&
+      typeof fieldType.element === 'object' &&
+      fieldType.element.kind === 'object'
+    ) {
+      return [row, ...contextFieldRows(fieldType.element, `${path}[*].`, collapse)];
+    }
+    return [row];
+  });
+}
+
+export function typeLabel(type) {
+  if (typeof type === 'string') return type;
+  if (type.kind === 'map') return 'map';
+  if (type.kind === 'list') return `list<${typeLabel(type.element)}>`;
+  return 'object';
+}
+
+function objectFields(type) {
+  return typeof type === 'object' && type.kind === 'object' ? type.fields : {};
+}

--- a/libs/api/agent-dto/src/inter-module.ts
+++ b/libs/api/agent-dto/src/inter-module.ts
@@ -32,7 +32,9 @@ const agentConfigInputSchema = z.object({
   harness: harnessSchema.optional(),
   provider: modelProviderRefSchema.optional(),
   model: z.string().optional(),
-  thinking: agentThinkingSchema.optional(),
+  // A resolved template may contain any string; the agent module validates it
+  // against the resolved harness and returns the domain error if it is invalid.
+  thinking: z.string().optional(),
 });
 
 const resolvedAgentConfigSchema = z.object({

--- a/libs/api/agent/src/core/errors.ts
+++ b/libs/api/agent/src/core/errors.ts
@@ -48,7 +48,7 @@ export class UnsupportedHarnessProviderError extends Error {
 export class UnsupportedHarnessThinkingError extends Error {
   constructor(
     public readonly harness: Harness,
-    public readonly thinking: AgentThinking,
+    public readonly thinking: string,
     public readonly supportedLevels: readonly AgentThinking[],
   ) {
     super(

--- a/libs/api/agent/src/core/resolve-agent-config.ts
+++ b/libs/api/agent/src/core/resolve-agent-config.ts
@@ -21,7 +21,8 @@ export interface ContextualAgentConfig {
   readonly harness?: Harness | undefined;
   readonly provider?: string | undefined;
   readonly model?: string | undefined;
-  readonly thinking?: AgentThinking | undefined;
+  /** A resolved template can carry any string. `resolveThinking` validates it. */
+  readonly thinking?: string | undefined;
 }
 
 export interface ResolvedAgentConfig {
@@ -249,14 +250,15 @@ function resolveThinking(params: {
   const descriptor = getHarnessDescriptor(params.harness);
 
   if (params.step.thinking !== undefined) {
-    if (!thinkingSchema.safeParse(params.step.thinking).success) {
+    const parsed = thinkingSchema.safeParse(params.step.thinking);
+    if (!parsed.success) {
       throw new UnsupportedHarnessThinkingError(
         params.harness,
         params.step.thinking,
         descriptor.thinkingLevels,
       );
     }
-    return params.step.thinking;
+    return parsed.data;
   }
 
   const candidates = [

--- a/libs/api/definitions-dto/src/workflow-model.ts
+++ b/libs/api/definitions-dto/src/workflow-model.ts
@@ -4,7 +4,7 @@ import type {
   ResolvedFieldSegment,
   WorkflowExpression,
 } from '@shipfox/expression';
-import type {AgentThinking, Harness} from '@shipfox/workflow-document';
+import type {Harness} from '@shipfox/workflow-document';
 import {z} from 'zod';
 
 export const DEFAULT_RUN_TIMEOUT_MS = 30 * 24 * 60 * 60 * 1000;
@@ -151,7 +151,8 @@ export interface WorkflowModelAgentStep extends WorkflowModelStepBase {
   readonly harness?: Harness;
   readonly model?: string;
   readonly provider?: string;
-  readonly thinking?: AgentThinking;
+  /** An authored level, or a template source resolved when the step dispatches. */
+  readonly thinking?: string;
   readonly tools?: readonly string[];
   readonly integrations?: readonly WorkflowModelStepIntegration[];
   readonly prompt: string;
@@ -159,6 +160,7 @@ export interface WorkflowModelAgentStep extends WorkflowModelStepBase {
     readonly prompt?: WorkflowFieldTemplate;
     readonly model?: WorkflowFieldTemplate;
     readonly provider?: WorkflowFieldTemplate;
+    readonly thinking?: WorkflowFieldTemplate;
     readonly workingDirectory?: WorkflowFieldTemplate;
     readonly name?: WorkflowFieldTemplate;
   };

--- a/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
@@ -918,6 +918,18 @@ function normalizeAgentStep(params: {
           allowedJobReferences: params.allowedJobReferences,
           typeOverlay: params.typeOverlay,
         });
+  const thinkingTemplate =
+    params.step.thinking === undefined
+      ? undefined
+      : parseInterpolationField({
+          field: 'agent.thinking',
+          source: params.step.thinking,
+          path: ['jobs', params.sourceName, 'steps', params.stepIndex, 'thinking'],
+          issues: params.issues,
+          fillSite: params.fillSite,
+          allowedJobReferences: params.allowedJobReferences,
+          typeOverlay: params.typeOverlay,
+        });
   validateAgentStep({
     step: params.step,
     sourceName: params.sourceName,
@@ -940,6 +952,7 @@ function normalizeAgentStep(params: {
     prompt: promptTemplate,
     model: modelTemplate,
     provider: providerTemplate,
+    thinking: thinkingTemplate,
     name: params.name,
     workingDirectory: params.workingDirectory,
   });
@@ -1095,11 +1108,14 @@ function validateHarnessThinking(params: {
 }): void {
   const {harness, thinking} = params.step;
   if (harness === undefined || thinking === undefined) return;
+  // An interpolated level is only known when the step dispatches, so the agent
+  // module checks it against the resolved harness there.
+  if (hasInterpolationSyntax(thinking)) return;
 
   const supportedLevels =
     params.agentValidationCatalog.harnesses.find((entry) => entry.id === harness)
       ?.thinking_levels ?? [];
-  if (supportedLevels.includes(thinking)) return;
+  if ((supportedLevels as readonly string[]).includes(thinking)) return;
   params.issues.push(
     issue({
       code: 'harness-thinking-incompatible',
@@ -1241,6 +1257,7 @@ function optionalAgentStepTemplates(params: {
   prompt: WorkflowFieldTemplate | undefined;
   model: WorkflowFieldTemplate | undefined;
   provider: WorkflowFieldTemplate | undefined;
+  thinking: WorkflowFieldTemplate | undefined;
   name: WorkflowFieldTemplate | undefined;
   workingDirectory: WorkflowFieldTemplate | undefined;
 }):
@@ -1248,6 +1265,7 @@ function optionalAgentStepTemplates(params: {
       prompt?: WorkflowFieldTemplate;
       model?: WorkflowFieldTemplate;
       provider?: WorkflowFieldTemplate;
+      thinking?: WorkflowFieldTemplate;
       name?: WorkflowFieldTemplate;
       workingDirectory?: WorkflowFieldTemplate;
     }
@@ -1256,6 +1274,7 @@ function optionalAgentStepTemplates(params: {
     params.prompt === undefined &&
     params.model === undefined &&
     params.provider === undefined &&
+    params.thinking === undefined &&
     params.name === undefined &&
     params.workingDirectory === undefined
   ) {
@@ -1266,6 +1285,7 @@ function optionalAgentStepTemplates(params: {
     ...(params.prompt === undefined ? {} : {prompt: params.prompt}),
     ...(params.model === undefined ? {} : {model: params.model}),
     ...(params.provider === undefined ? {} : {provider: params.provider}),
+    ...(params.thinking === undefined ? {} : {thinking: params.thinking}),
     ...(params.name === undefined ? {} : {name: params.name}),
     ...(params.workingDirectory === undefined ? {} : {workingDirectory: params.workingDirectory}),
   };

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -213,7 +213,7 @@ describe('normalizeWorkflowDocument', () => {
   it('allows computed access to unrelated dynamic-name context fields', () => {
     const model = normalizeWorkflowDocument({
       name: 'Workflow',
-      run_name: interpolation('run["workflow_name"]'),
+      run_name: interpolation('run["id"]'),
       jobs: {
         build: {
           execution_name: interpolation('execution["status"]'),
@@ -1009,6 +1009,29 @@ describe('normalizeWorkflowDocument', () => {
         supportedLevels: ['low', 'medium', 'high', 'xhigh', 'max'],
       },
     });
+  });
+
+  it('defers an interpolated thinking level to dispatch', () => {
+    const document: WorkflowDocument = {
+      name: 'agent build',
+      jobs: {
+        fix: {
+          steps: [
+            {
+              harness: 'claude',
+              prompt: 'Fix it.',
+              thinking: workflowInterpolation('vars.THINKING'),
+            },
+          ],
+        },
+      },
+    };
+
+    const model = normalizeWorkflowDocument(document);
+    const step = model.jobs[0]?.steps[0];
+
+    if (step?.kind !== 'agent') throw new Error('Expected an agent step');
+    expect(step.templates?.thinking).toMatchObject([{kind: 'deferred', roots: ['vars']}]);
   });
 
   it('normalizes job success expressions and execution timeouts', () => {

--- a/libs/api/definitions/src/core/workflow-model/parse-interpolation-field.ts
+++ b/libs/api/definitions/src/core/workflow-model/parse-interpolation-field.ts
@@ -37,6 +37,7 @@ export type StoredInterpolationField =
   | 'agent.prompt'
   | 'agent.model'
   | 'agent.provider'
+  | 'agent.thinking'
   | 'job.outputs'
   | 'workflow.run_name'
   | 'job.execution_name'

--- a/libs/api/workflows-dto/src/inter-module.ts
+++ b/libs/api/workflows-dto/src/inter-module.ts
@@ -32,6 +32,7 @@ const interpolationFieldSchema = z.enum([
   'agent.prompt',
   'agent.model',
   'agent.provider',
+  'agent.thinking',
   'job.runner',
   'job.outputs',
   'job.execution_name',

--- a/libs/api/workflows/src/core/agent-defaults.ts
+++ b/libs/api/workflows/src/core/agent-defaults.ts
@@ -6,7 +6,8 @@ export interface AgentDefaultsInput {
   readonly harness?: Harness | undefined;
   readonly provider?: ModelProviderRef | undefined;
   readonly model?: string | undefined;
-  readonly thinking?: AgentThinking | undefined;
+  /** A resolved template can carry any string. The agent module validates it. */
+  readonly thinking?: string | undefined;
 }
 
 export interface ResolvedAgentDefaults {

--- a/libs/api/workflows/src/core/entities/step.ts
+++ b/libs/api/workflows/src/core/entities/step.ts
@@ -8,7 +8,7 @@ import type {
   ResolvedField,
   WorkflowExpression,
 } from '@shipfox/expression';
-import type {AgentThinking, Harness} from '@shipfox/workflow-document';
+import type {Harness} from '@shipfox/workflow-document';
 import type {InterpolationUnresolvableField} from '../errors.js';
 
 export type StepStatus = 'pending' | 'running' | 'succeeded' | 'failed' | 'cancelled' | 'skipped';
@@ -80,7 +80,7 @@ export interface StepConfigDispatchPlan {
     model?: ResolvedField;
     provider?: ResolvedField;
     harness?: Harness;
-    thinking?: AgentThinking;
+    thinking?: ResolvedField;
     tools?: readonly string[];
     integrations?: readonly MaterializedAgentIntegrationConfigDto[];
     mcpServers?: readonly AgentIntegrationMcpServerConfigDto[];

--- a/libs/api/workflows/src/core/errors.ts
+++ b/libs/api/workflows/src/core/errors.ts
@@ -61,6 +61,7 @@ export type InterpolationUnresolvableField =
   | 'agent.prompt'
   | 'agent.model'
   | 'agent.provider'
+  | 'agent.thinking'
   | 'job.runner'
   | 'job.outputs'
   | 'job.execution_name'

--- a/libs/api/workflows/src/core/step-config/agent.ts
+++ b/libs/api/workflows/src/core/step-config/agent.ts
@@ -42,6 +42,7 @@ interface AgentFieldResolutions {
   readonly prompt: FieldResolution;
   readonly model: FieldResolution | undefined;
   readonly provider: FieldResolution | undefined;
+  readonly thinking: FieldResolution | undefined;
   readonly hasTemplates: boolean;
 }
 
@@ -72,9 +73,11 @@ export async function resolveAgentStepConfig(
 
   if (usesAuthoredMode) return authoredAgentStepConfig(params.step, fields);
 
-  const hasDeferredModelOrProvider =
-    fields.model?.kind === 'residual' || fields.provider?.kind === 'residual';
-  if (hasDeferredModelOrProvider) return deferredAgentStepConfig(params, fields);
+  const hasDeferredAgentField =
+    fields.model?.kind === 'residual' ||
+    fields.provider?.kind === 'residual' ||
+    fields.thinking?.kind === 'residual';
+  if (hasDeferredAgentField) return deferredAgentStepConfig(params, fields);
 
   return await agentStepConfigWithDefaults(params.step, params, fields);
 }
@@ -119,7 +122,10 @@ export async function completeAgentConfig(params: {
     harness: agent.harness ?? readConfigHarness(params.config),
     provider,
     model,
-    thinking: agent.thinking ?? readConfigThinking(params.config),
+    thinking:
+      agent.thinking === undefined
+        ? readConfigThinking(params.config)
+        : completeAgentField({field: 'agent.thinking', template: agent.thinking, params}),
     resolveAgentDefaults: params.resolveAgentDefaults,
     definitionId: params.definitionId,
   });
@@ -138,7 +144,7 @@ export async function completeAgentConfig(params: {
 }
 
 function completeAgentField(args: {
-  readonly field: 'agent.prompt' | 'agent.model' | 'agent.provider';
+  readonly field: 'agent.prompt' | 'agent.model' | 'agent.provider' | 'agent.thinking';
   readonly template: ResolvedField;
   readonly params: {
     readonly context: WorkflowEvaluationContext;
@@ -161,7 +167,7 @@ export async function completeAgentDefaults(params: {
   readonly harness: WorkflowModelAgentStep['harness'] | undefined;
   readonly provider: string | undefined;
   readonly model: string | undefined;
-  readonly thinking: AgentThinking | undefined;
+  readonly thinking: string | undefined;
   readonly resolveAgentDefaults?: AgentDefaultsResolver | undefined;
   readonly definitionId: string;
 }): Promise<ResolvedAgentDefaults> {
@@ -218,12 +224,23 @@ function resolveAgentFields(params: ResolveAgentStepConfigParams): AgentFieldRes
     trace,
     definitionId: params.definitionId,
   });
+  const thinking = resolveOptionalAgentField({
+    field: 'agent.thinking',
+    value: params.step.thinking,
+    template: params.step.templates?.thinking,
+    context: params.context,
+    mode: params.mode,
+    diagnostics,
+    trace,
+    definitionId: params.definitionId,
+  });
   const hasTemplates =
     params.step.templates?.prompt !== undefined ||
     params.step.templates?.model !== undefined ||
-    params.step.templates?.provider !== undefined;
+    params.step.templates?.provider !== undefined ||
+    params.step.templates?.thinking !== undefined;
 
-  return {diagnostics, trace, prompt, model, provider, hasTemplates};
+  return {diagnostics, trace, prompt, model, provider, thinking, hasTemplates};
 }
 
 function authoredAgentStepConfig(
@@ -260,7 +277,7 @@ function deferredAgentStepConfig(
         ...(fields.model === undefined ? {} : {model: dispatchPlanField(fields.model)}),
         ...(fields.provider === undefined ? {} : {provider: dispatchPlanField(fields.provider)}),
         ...(step.harness === undefined ? {} : {harness: step.harness}),
-        ...(step.thinking === undefined ? {} : {thinking: step.thinking}),
+        ...(fields.thinking === undefined ? {} : {thinking: dispatchPlanField(fields.thinking)}),
         ...agentToolsConfig(step),
         ...materializedAgentIntegrationsConfig(params),
       },
@@ -284,7 +301,7 @@ async function agentStepConfigWithDefaults(
     harness: step.harness,
     provider: providerValue,
     model: modelValue,
-    thinking: step.thinking,
+    thinking: frozenFieldValue(fields.thinking),
     resolveAgentDefaults: params.resolveAgentDefaults,
     definitionId: params.definitionId,
   });
@@ -384,7 +401,7 @@ function frozenFieldValue(field: FieldResolution | undefined): string | undefine
 }
 
 function resolveAgentField(params: {
-  readonly field: 'agent.prompt' | 'agent.model' | 'agent.provider';
+  readonly field: 'agent.prompt' | 'agent.model' | 'agent.provider' | 'agent.thinking';
   readonly value: string;
   readonly template: ResolvedField['segments'] | undefined;
   readonly context: WorkflowEvaluationContext;
@@ -414,7 +431,7 @@ function resolveAgentField(params: {
 }
 
 function resolveOptionalAgentField(params: {
-  readonly field: 'agent.prompt' | 'agent.model' | 'agent.provider';
+  readonly field: 'agent.prompt' | 'agent.model' | 'agent.provider' | 'agent.thinking';
   readonly value: string | undefined;
   readonly template: ResolvedField['segments'] | undefined;
   readonly context: WorkflowEvaluationContext;

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
@@ -42,12 +42,14 @@ describe('assembleWorkflowRunContext', () => {
     });
 
     expect(context).toEqual({
+      workflow: {
+        id: 'def-1',
+        name: 'Build',
+      },
       run: {
         id: 'run-1',
         number: 1,
         name: 'Build',
-        workflow_name: 'Build',
-        definition_id: 'def-1',
         project_id: 'proj-1',
         workspace_id: 'workspace-1',
         created_at: run.createdAt,
@@ -403,7 +405,7 @@ describe('listener filter snapshots', () => {
           source: 'github',
           event: 'pull_request',
           filter:
-            'jobs.build.outputs.pr_number == event.pull_request.number && inputs.environment == "prod" && trigger.event == "pull_request" && run.id != "" && job.key == "await" && vars.ENABLED == "true"',
+            'jobs.build.outputs.pr_number == event.pull_request.number && inputs.environment == "prod" && trigger.event == "pull_request" && workflow.name != "" && run.id != "" && job.key == "await" && vars.ENABLED == "true"',
         },
       ],
       until: null,
@@ -430,6 +432,7 @@ describe('listener filter snapshots', () => {
     const [matcher] = applyListenerFilterSnapshots(plan.on, context);
 
     expect(matcher?.filter_snapshot).toEqual({
+      workflow: {id: 'def-1', name: 'Build'},
       run: expect.objectContaining({id: 'run-1', name: 'Build'}),
       trigger: {
         source: 'github',

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.ts
@@ -42,12 +42,14 @@ export function assembleWorkflowRunContext(
 ): WorkflowExpressionEvaluationContext {
   const triggerReference = params.run.triggerReference;
   return {
+    workflow: {
+      id: params.run.definitionId,
+      name: params.run.workflowName,
+    },
     run: {
       id: params.run.id,
       number: params.run.number,
       name: params.run.name,
-      workflow_name: params.run.workflowName,
-      definition_id: params.run.definitionId,
       project_id: params.run.projectId,
       workspace_id: params.run.workspaceId,
       created_at: params.run.createdAt,
@@ -255,13 +257,18 @@ export function assembleListenerSnapshotContext(params: {
   readonly dependencyJobs: readonly JobContextInput[];
 }): WorkflowExpressionEvaluationContext {
   const context: Record<string, unknown> = {};
-  if (params.plan.roots.has('run') || params.plan.roots.has('trigger')) {
+  if (
+    params.plan.roots.has('workflow') ||
+    params.plan.roots.has('run') ||
+    params.plan.roots.has('trigger')
+  ) {
     const runContext = assembleWorkflowRunContext({
       run: params.run,
       triggerPayload: params.triggerPayload,
       inputs: params.inputs,
       vars: params.vars,
     });
+    if (params.plan.roots.has('workflow')) context.workflow = runContext.workflow;
     if (params.plan.roots.has('run')) context.run = runContext.run;
     if (params.plan.roots.has('trigger')) context.trigger = runContext.trigger;
   }

--- a/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
+++ b/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
@@ -9,6 +9,7 @@ import {
 import {agentInterModuleContract} from '@shipfox/api-agent-dto/inter-module';
 import {parseWorkflowTemplate, planInterpolationField} from '@shipfox/expression';
 import {createInterModuleKnownError} from '@shipfox/inter-module';
+import {agentThinkingSchema} from '@shipfox/workflow-document';
 import type {AgentDefaultsResolver} from '#core/agent-defaults.js';
 import type {Step} from '#core/entities/step.js';
 import {AgentConfigUnresolvableError, InterpolationUnresolvableError} from '#core/errors.js';
@@ -68,7 +69,7 @@ const resolveAgentDefaults: AgentDefaultsResolver = (params) => ({
   harness: params.harness ?? 'pi',
   provider: params.provider ?? 'openai',
   model: params.model ?? 'gpt-5.5',
-  thinking: params.thinking ?? 'off',
+  thinking: agentThinkingSchema.safeParse(params.thinking).data ?? 'off',
 });
 
 function materializedIntegration(): MaterializedAgentIntegrationConfigDto {
@@ -428,7 +429,7 @@ describe('completeStepDispatchConfig', () => {
       configPlan: {
         agent: {
           harness: 'claude',
-          thinking: 'off',
+          thinking: plannedField('off'),
           prompt: plannedField(`Review ${template('steps.build.outputs.sha')}`),
         },
       },

--- a/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
@@ -727,6 +727,44 @@ describe('materializeWorkflowModel', () => {
     });
   });
 
+  it('defers unresolved thinking templates until step dispatch', async () => {
+    const model = workflowModel({
+      jobs: {
+        build: {
+          steps: [
+            {
+              harness: 'pi',
+              prompt: 'Review the change.',
+              thinking: template('steps.previous.outputs.thinking'),
+            },
+          ],
+        },
+      },
+    });
+
+    const rows = await materializeWorkflowModel({model, context: creationContext()});
+
+    expect(rows[0]?.steps[1]?.config).toEqual({});
+    expect(rows[0]?.steps[1]?.configPlan?.agent).toMatchObject({
+      harness: 'pi',
+      prompt: {segments: [{kind: 'literal', value: 'Review the change.'}]},
+      thinking: {
+        segments: [
+          {
+            kind: 'deferred',
+            expression: {
+              language: 'cel',
+              source: 'steps.previous.outputs.thinking',
+              check: 'syntax',
+            },
+            fillTarget: 'step-dispatch',
+            roots: ['steps'],
+          },
+        ],
+      },
+    });
+  });
+
   it('merges env before resolving and only resolves the winning values', async () => {
     const model = workflowModel({
       env: {SHARED: template('event.missing'), WORKFLOW_ONLY: template('run.id')},

--- a/libs/api/workflows/src/presentation/routes/get-step-secrets.test.ts
+++ b/libs/api/workflows/src/presentation/routes/get-step-secrets.test.ts
@@ -1,5 +1,6 @@
 import {closeApp, createApp, type FastifyInstance} from '@shipfox/node-fastify';
 import {createCapturingLogger} from '@shipfox/node-log/test';
+import {agentThinkingSchema} from '@shipfox/workflow-document';
 import {eq} from 'drizzle-orm';
 import type {StepStatus} from '#core/entities/step.js';
 import {db} from '#db/db.js';
@@ -256,7 +257,7 @@ async function createStep(params: {
       harness: defaults.harness ?? 'pi',
       provider: defaults.provider ?? 'anthropic',
       model: defaults.model ?? 'claude-opus-4-8',
-      thinking: defaults.thinking ?? 'high',
+      thinking: agentThinkingSchema.safeParse(defaults.thinking).data ?? 'high',
     }),
     triggerPayload: {
       source: 'manual',

--- a/libs/api/workflows/test/factories/workflow-model.ts
+++ b/libs/api/workflows/test/factories/workflow-model.ts
@@ -243,6 +243,8 @@ function optionalAgentTemplates(step: TestAgentStep) {
   const model = step.model === undefined ? undefined : fieldTemplate('agent.model', step.model);
   const provider =
     step.provider === undefined ? undefined : fieldTemplate('agent.provider', step.provider);
+  const thinking =
+    step.thinking === undefined ? undefined : fieldTemplate('agent.thinking', step.thinking);
   const name = step.name === undefined ? undefined : fieldTemplate('step.name', step.name);
   const workingDirectory =
     step.workingDirectory === undefined
@@ -252,6 +254,7 @@ function optionalAgentTemplates(step: TestAgentStep) {
     prompt === undefined &&
     model === undefined &&
     provider === undefined &&
+    thinking === undefined &&
     name === undefined &&
     workingDirectory === undefined
   ) {
@@ -262,6 +265,7 @@ function optionalAgentTemplates(step: TestAgentStep) {
       ...(prompt === undefined ? {} : {prompt}),
       ...(model === undefined ? {} : {model}),
       ...(provider === undefined ? {} : {provider}),
+      ...(thinking === undefined ? {} : {thinking}),
       ...(name === undefined ? {} : {name}),
       ...(workingDirectory === undefined ? {} : {workingDirectory}),
     },

--- a/libs/api/workflows/test/fixtures/agent-inter-module.ts
+++ b/libs/api/workflows/test/fixtures/agent-inter-module.ts
@@ -9,6 +9,7 @@ import type {
   AgentInterModuleClient,
   AgentValidationCatalog,
 } from '@shipfox/api-agent-dto/inter-module';
+import {agentThinkingSchema} from '@shipfox/workflow-document';
 import type {AgentDefaultsResolver} from '#core/agent-defaults.js';
 
 export const agentValidationCatalog: AgentValidationCatalog = {
@@ -53,6 +54,6 @@ export const resolveTestAgentDefaults: AgentDefaultsResolver = (config) => {
     harness: config.harness ?? 'pi',
     provider,
     model: config.model ?? (provider === 'openai' ? 'gpt-5.5-pro' : 'claude-opus-4-8'),
-    thinking: config.thinking ?? 'xhigh',
+    thinking: agentThinkingSchema.safeParse(config.thinking).data ?? 'xhigh',
   };
 };

--- a/libs/shared/expression/src/index.ts
+++ b/libs/shared/expression/src/index.ts
@@ -135,6 +135,7 @@ export {
   type AvailabilitySite,
   availabilitySites,
   buildTypedRootsEnvironment,
+  contextRootsForField,
   type FillTarget,
   getWorkflowContextAvailability,
   getWorkflowContextDefinition,
@@ -146,6 +147,7 @@ export {
   getWorkflowPredicateContextRoots,
   getWorkflowPredicateFieldMinimumFillTarget,
   getWorkflowPredicateFieldTypeEnvironment,
+  isWorkflowPredicateField,
   type OpenWorkflowContextDefinition,
   projectWorkflowPredicateContext,
   type ReservedRootDefinition,
@@ -186,3 +188,7 @@ export {
   workflowPredicateFieldFailurePolicy,
   workflowPredicateFields,
 } from './workflow-context/workflow-context.js';
+export {
+  type WorkflowContextDoc,
+  workflowContextDocs,
+} from './workflow-context/workflow-context-docs.js';

--- a/libs/shared/expression/src/workflow-context/workflow-context-docs.test.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context-docs.test.ts
@@ -1,0 +1,25 @@
+import {getWorkflowContextDefinition, workflowContextNames} from './workflow-context.js';
+import {type WorkflowContextDoc, workflowContextDocs} from './workflow-context-docs.js';
+
+describe('workflowContextDocs', () => {
+  it('documents every context root exactly once', () => {
+    expect(workflowContextDocs.map((doc) => doc.root)).toEqual([...workflowContextNames]);
+  });
+
+  it('gives every root a summary', () => {
+    const missing = workflowContextDocs.filter((doc) => doc.summary.trim() === '');
+
+    expect(missing).toEqual([]);
+  });
+
+  it('explains the shape of every open root and lists fields for every typed root', () => {
+    for (const doc of workflowContextDocs as readonly WorkflowContextDoc[]) {
+      const definition = getWorkflowContextDefinition(doc.root);
+      if (definition.shape === 'open') {
+        expect(doc.shapeNote, `${doc.root} needs a shape note`).toBeDefined();
+        continue;
+      }
+      expect(doc.fields, `${doc.root} needs field descriptions`).toBeDefined();
+    }
+  });
+});

--- a/libs/shared/expression/src/workflow-context/workflow-context-docs.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context-docs.ts
@@ -1,0 +1,187 @@
+import type {WorkflowContextName} from './workflow-context.js';
+
+/**
+ * Reader-facing descriptions for every context root and property.
+ *
+ * They live beside the type registry so a new field cannot ship undescribed:
+ * the documentation generator renders types from the registry and looks up each
+ * property here, and its check fails on a property with no description or a
+ * description for a property that no longer exists.
+ */
+export interface WorkflowContextDoc {
+  readonly root: WorkflowContextName;
+  readonly summary: string;
+  /** Why an open-shape root has no property table. */
+  readonly shapeNote?: string;
+  /** Prefix shown in the property column, such as `needs[*].`. */
+  readonly propertyPrefix?: string;
+  /** Description per property path, relative to the root. */
+  readonly fields?: Readonly<Record<string, string>>;
+  /** Paths whose element shape another root already documents. */
+  readonly collapse?: readonly string[];
+}
+
+const executionFields = {
+  index: 'Position of the execution in its job, starting at zero.',
+  name: 'Resolved execution name, or the job name when `execution_name` is not set.',
+  status: 'Terminal status of the execution.',
+  started_at: 'Time the execution started.',
+  finished_at: 'Time the execution finished.',
+  events: 'Listener events in the batch that started this execution. Empty for a standard job.',
+  'events[*].source': 'Integration connection slug that delivered the event.',
+  'events[*].event': 'Shipfox event name.',
+  'events[*].delivery_id': 'Identifier of the provider delivery.',
+  'events[*].received_at': 'Time Shipfox received the event.',
+  'events[*].data': 'Raw event payload. The provider owns its shape.',
+  outputs: 'Outputs the execution produced, keyed by output name.',
+} as const;
+
+const jobEntityFields = {
+  key: 'Key of the job in the `jobs` map.',
+  status: 'Terminal status of the job.',
+  outputs: 'Declared job outputs, keyed by output name.',
+  executions:
+    'Executions of the job, each with the properties of the `execution` context. A standard job has one.',
+} as const;
+
+const stepEntityFields = {
+  status: 'Terminal status of the step.',
+  exit_code: 'Exit code of the latest terminal attempt.',
+  outputs: 'Declared step outputs of the latest terminal attempt.',
+  response: 'Final agent response. Absent on a run step.',
+  gate: 'Gate result of the latest terminal attempt. Absent when the step has no gate.',
+  'gate.passed': 'Whether the gate expression passed.',
+  'gate.source': 'Gate expression that produced the result.',
+  'gate.reason': 'Why the gate could not be checked, when it was uncheckable.',
+  'gate.exit_code': 'Exit code the gate read.',
+  attempts: 'Every terminal attempt of the step, oldest first.',
+  'attempts[*].status': 'Terminal status of the attempt.',
+  'attempts[*].exit_code': 'Exit code the attempt reported.',
+  'attempts[*].outputs': 'Declared outputs the attempt reported.',
+  'attempts[*].response': 'Final agent response of the attempt. Absent on a run step.',
+  'attempts[*].gate': 'Gate result of the attempt. Absent when the step has no gate.',
+  'attempts[*].gate.passed': 'Whether the gate expression passed.',
+  'attempts[*].gate.source': 'Gate expression that produced the result.',
+  'attempts[*].gate.reason': 'Why the gate could not be checked, when it was uncheckable.',
+  'attempts[*].gate.exit_code': 'Exit code the gate read.',
+} as const;
+
+export const workflowContextDocs = [
+  {
+    root: 'workflow',
+    summary: 'The workflow definition this run came from.',
+    fields: {
+      id: 'Identifier of the workflow definition.',
+      name: 'Workflow `name` from the definition.',
+    },
+  },
+  {
+    root: 'run',
+    summary: 'The current run.',
+    fields: {
+      id: 'Identifier of the run.',
+      number: 'Sequential run number within the workflow definition.',
+      name: 'Resolved run name, or the workflow name when `run_name` is not set.',
+      project_id: 'Identifier of the project that owns the run.',
+      workspace_id: 'Identifier of the workspace that owns the run.',
+      created_at: 'Time the run was created.',
+    },
+  },
+  {
+    root: 'trigger',
+    summary: 'The trigger that started the run.',
+    fields: {
+      source: 'Integration connection slug, or `manual` or `cron`.',
+      event: 'Shipfox event name that matched the trigger.',
+      project: 'Shipfox project resolved from the event repository. Null when there is none.',
+      'project.id': 'Identifier of the resolved project.',
+      repository: 'Repository the event came from, as `owner/name`. Null when there is none.',
+      ref: 'Git ref the event carried. Null when there is none.',
+      commit: 'Commit SHA the event carried. Null when there is none.',
+    },
+  },
+  {
+    root: 'event',
+    summary: 'The raw payload of the event that started the run.',
+    shapeNote:
+      'The provider owns this payload, so it has no fixed shape. Read the fields it documents, such as `event.ref` or `event.pull_request.number`.',
+  },
+  {
+    root: 'inputs',
+    summary: 'Values the trigger `with` block passed into the run.',
+    shapeNote: 'The keys are the ones the workflow declares in its trigger `with` block.',
+  },
+  {
+    root: 'job',
+    summary: 'The job being evaluated.',
+    fields: {
+      key: 'Key of the job in the `jobs` map.',
+      name: 'Job `name`, or the job key when no name is set.',
+    },
+  },
+  {
+    root: 'executions',
+    summary: 'Every execution of the current job.',
+    propertyPrefix: 'executions[*].',
+    fields: executionFields,
+  },
+  {
+    root: 'execution',
+    summary: 'The current execution of the job.',
+    fields: {
+      ...executionFields,
+      failed: 'Whether an earlier step in this execution failed.',
+    },
+  },
+  {
+    root: 'jobs',
+    summary: 'Upstream jobs, keyed by job key.',
+    shapeNote: 'The keys are the job keys the workflow declares.',
+    propertyPrefix: 'jobs.<job_key>.',
+    fields: jobEntityFields,
+    collapse: ['executions'],
+  },
+  {
+    root: 'needs',
+    summary: 'The jobs this job declares in `needs`.',
+    propertyPrefix: 'needs[*].',
+    fields: jobEntityFields,
+    collapse: ['executions'],
+  },
+  {
+    root: 'steps',
+    summary: 'Earlier steps of the current job, keyed by step key.',
+    shapeNote: 'The keys are the step keys the workflow declares.',
+    propertyPrefix: 'steps.<step_key>.',
+    fields: stepEntityFields,
+  },
+  {
+    root: 'step',
+    summary: 'The step being evaluated. Its properties depend on the field reading it.',
+    fields: {
+      attempt: 'Attempt number of the step, starting at one. Not readable in `gate.success`.',
+      is_retry: 'Whether this is a repeat attempt. Not readable in `gate.success`.',
+      restart:
+        'Provenance of a restart, when a gate restarted this step. Not readable in `gate.success`.',
+      'restart.from':
+        'The step whose gate restarted this attempt, with the properties of a `steps` entry. Not readable in `gate.success`.',
+      'restart.feedback': 'Feedback the restarting gate produced. Not readable in `gate.success`.',
+      exit_code: 'Exit code the step reported. Readable in `gate.success` only.',
+      status: 'Status the step reported. Readable in `gate.success` only.',
+      outputs: 'Outputs the step reported. Readable in `gate.success` only.',
+    },
+    collapse: ['restart.from'],
+  },
+  {
+    root: 'vars',
+    summary: 'Workspace and project variables.',
+    shapeNote:
+      'The keys are the variable names the workspace defines. Only a literal key is allowed, so `vars["KEY"]` works and a computed key does not.',
+  },
+  {
+    root: 'secrets',
+    summary: 'Workspace and project secrets.',
+    shapeNote:
+      'The keys are the secret names the workspace defines. Only a literal key is allowed. The runner resolves the value, so no predicate can read it.',
+  },
+] as const satisfies readonly WorkflowContextDoc[];

--- a/libs/shared/expression/src/workflow-context/workflow-context-docs.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context-docs.ts
@@ -24,7 +24,7 @@ export interface WorkflowContextDoc {
 const executionFields = {
   index: 'Position of the execution in its job, starting at zero.',
   name: 'Resolved execution name, or the job name when `execution_name` is not set.',
-  status: 'Terminal status of the execution.',
+  status: 'Final status of the execution.',
   started_at: 'Time the execution started.',
   finished_at: 'Time the execution finished.',
   events: 'Listener events in the batch that started this execution. Empty for a standard job.',
@@ -38,31 +38,31 @@ const executionFields = {
 
 const jobEntityFields = {
   key: 'Key of the job in the `jobs` map.',
-  status: 'Terminal status of the job.',
+  status: 'Final status of the job.',
   outputs: 'Declared job outputs, keyed by output name.',
   executions:
     'Executions of the job, each with the properties of the `execution` context. A standard job has one.',
 } as const;
 
 const stepEntityFields = {
-  status: 'Terminal status of the step.',
-  exit_code: 'Exit code of the latest terminal attempt.',
-  outputs: 'Declared step outputs of the latest terminal attempt.',
+  status: 'Final status of the step.',
+  exit_code: 'Exit code of the most recent finished attempt.',
+  outputs: 'Declared step outputs of the most recent finished attempt.',
   response: 'Final agent response. Absent on a run step.',
-  gate: 'Gate result of the latest terminal attempt. Absent when the step has no gate.',
+  gate: 'Gate result of the most recent finished attempt. Absent when the step has no gate.',
   'gate.passed': 'Whether the gate expression passed.',
   'gate.source': 'Gate expression that produced the result.',
-  'gate.reason': 'Why the gate could not be checked, when it was uncheckable.',
+  'gate.reason': 'Why Shipfox could not check the gate.',
   'gate.exit_code': 'Exit code the gate read.',
-  attempts: 'Every terminal attempt of the step, oldest first.',
-  'attempts[*].status': 'Terminal status of the attempt.',
+  attempts: 'Every finished attempt of the step, oldest first.',
+  'attempts[*].status': 'Final status of the attempt.',
   'attempts[*].exit_code': 'Exit code the attempt reported.',
   'attempts[*].outputs': 'Declared outputs the attempt reported.',
   'attempts[*].response': 'Final agent response of the attempt. Absent on a run step.',
   'attempts[*].gate': 'Gate result of the attempt. Absent when the step has no gate.',
   'attempts[*].gate.passed': 'Whether the gate expression passed.',
   'attempts[*].gate.source': 'Gate expression that produced the result.',
-  'attempts[*].gate.reason': 'Why the gate could not be checked, when it was uncheckable.',
+  'attempts[*].gate.reason': 'Why Shipfox could not check the gate.',
   'attempts[*].gate.exit_code': 'Exit code the gate read.',
 } as const;
 
@@ -113,7 +113,7 @@ export const workflowContextDocs = [
   },
   {
     root: 'job',
-    summary: 'The job being evaluated.',
+    summary: 'The current job.',
     fields: {
       key: 'Key of the job in the `jobs` map.',
       name: 'Job `name`, or the job key when no name is set.',
@@ -157,12 +157,11 @@ export const workflowContextDocs = [
   },
   {
     root: 'step',
-    summary: 'The step being evaluated. Its properties depend on the field reading it.',
+    summary: 'The current step. Its properties depend on the field that reads it.',
     fields: {
       attempt: 'Attempt number of the step, starting at one. Not readable in `gate.success`.',
       is_retry: 'Whether this is a repeat attempt. Not readable in `gate.success`.',
-      restart:
-        'Provenance of a restart, when a gate restarted this step. Not readable in `gate.success`.',
+      restart: 'Set when a gate restarted this step. Not readable in `gate.success`.',
       'restart.from':
         'The step whose gate restarted this attempt, with the properties of a `steps` entry. Not readable in `gate.success`.',
       'restart.feedback': 'Feedback the restarting gate produced. Not readable in `gate.success`.',
@@ -182,6 +181,6 @@ export const workflowContextDocs = [
     root: 'secrets',
     summary: 'Workspace and project secrets.',
     shapeNote:
-      'The keys are the secret names the workspace defines. Only a literal key is allowed. The runner resolves the value, so no predicate can read it.',
+      'The keys are the secret names the workspace defines. Only a literal key is allowed. The runner reads the value, so no predicate can read it.',
   },
 ] as const satisfies readonly WorkflowContextDoc[];

--- a/libs/shared/expression/src/workflow-context/workflow-context-docs.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context-docs.ts
@@ -104,12 +104,13 @@ export const workflowContextDocs = [
     root: 'event',
     summary: 'The raw payload of the event that started the run.',
     shapeNote:
-      'The provider owns this payload, so it has no fixed shape. Read the fields it documents, such as `event.ref` or `event.pull_request.number`.',
+      'The provider owns this payload, so it has no fixed shape. Each provider page under [Integrations](/integrations) lists the events Shipfox delivers and links the payload each one carries.',
   },
   {
     root: 'inputs',
     summary: 'Values the trigger `with` block passed into the run.',
-    shapeNote: 'The keys are the ones the workflow declares in its trigger `with` block.',
+    shapeNote:
+      'The keys are the ones the trigger declares. See [trigger fields](/reference/workflow-schema#trigger-fields).',
   },
   {
     root: 'job',
@@ -175,12 +176,12 @@ export const workflowContextDocs = [
     root: 'vars',
     summary: 'Workspace and project variables.',
     shapeNote:
-      'The keys are the variable names the workspace defines. Only a literal key is allowed, so `vars["KEY"]` works and a computed key does not.',
+      'The keys are the variable names the workspace defines. See [Secrets and variables](/reference/secrets-variables).',
   },
   {
     root: 'secrets',
     summary: 'Workspace and project secrets.',
     shapeNote:
-      'The keys are the secret names the workspace defines. Only a literal key is allowed. The runner reads the value, so no predicate can read it.',
+      'The keys are the secret names the workspace defines. See [Secrets and variables](/reference/secrets-variables).',
   },
 ] as const satisfies readonly WorkflowContextDoc[];

--- a/libs/shared/expression/src/workflow-context/workflow-context.test.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.test.ts
@@ -5,6 +5,7 @@ import {
   type AvailabilitySite,
   availabilitySites,
   buildTypedRootsEnvironment,
+  contextRootsForField,
   type FillTarget,
   getWorkflowContextTypeEnvironment,
   getWorkflowInterpolationFieldFailurePolicy,
@@ -36,6 +37,7 @@ import {
 describe('workflow context registry', () => {
   it('defines exactly the v1 contexts', () => {
     expect(workflowContextNames).toEqual([
+      'workflow',
       'run',
       'trigger',
       'event',
@@ -153,6 +155,15 @@ describe('workflow context registry', () => {
   });
 
   it('exports type environments for the known v1 context fields', () => {
+    expect(getWorkflowContextTypeEnvironment('workflow')).toEqual({
+      workflow: {
+        kind: 'object',
+        fields: {
+          id: 'string',
+          name: 'string',
+        },
+      },
+    });
     const runTypeEnvironment = getWorkflowContextTypeEnvironment('run');
     expect(runTypeEnvironment).toEqual({
       run: {
@@ -161,8 +172,6 @@ describe('workflow context registry', () => {
           id: 'string',
           number: 'int',
           name: 'string',
-          workflow_name: 'string',
-          definition_id: 'string',
           project_id: 'string',
           workspace_id: 'string',
           created_at: 'timestamp',
@@ -374,6 +383,7 @@ describe('workflow context registry', () => {
   it('returns the roots available at each availability site', () => {
     expect(rootsAvailableAt('ingest')).toEqual(['trigger', 'event']);
     expect(rootsAvailableAt('run-creation')).toEqual([
+      'workflow',
       'run',
       'trigger',
       'event',
@@ -382,6 +392,7 @@ describe('workflow context registry', () => {
       'vars',
     ]);
     expect(rootsAvailableAt('execution-creation')).toEqual([
+      'workflow',
       'run',
       'trigger',
       'event',
@@ -392,6 +403,7 @@ describe('workflow context registry', () => {
       'vars',
     ]);
     expect(rootsAvailableAt('job-activation')).toEqual([
+      'workflow',
       'run',
       'trigger',
       'event',
@@ -404,6 +416,7 @@ describe('workflow context registry', () => {
       'vars',
     ]);
     expect(rootsAvailableAt('step-dispatch')).toEqual([
+      'workflow',
       'run',
       'trigger',
       'event',
@@ -418,6 +431,7 @@ describe('workflow context registry', () => {
       'vars',
     ]);
     expect(rootsAvailableAt('step-report')).toEqual([
+      'workflow',
       'run',
       'trigger',
       'event',
@@ -432,6 +446,7 @@ describe('workflow context registry', () => {
       'vars',
     ]);
     expect(rootsAvailableAt('execution-resolution')).toEqual([
+      'workflow',
       'run',
       'trigger',
       'event',
@@ -446,6 +461,7 @@ describe('workflow context registry', () => {
       'vars',
     ]);
     expect(rootsAvailableAt('job-resolution')).toEqual([
+      'workflow',
       'run',
       'trigger',
       'event',
@@ -648,18 +664,32 @@ describe('workflow context registry', () => {
       expect(getWorkflowPredicateFieldMinimumFillTarget('step.if')).toBe('step-dispatch');
     });
 
+    it('resolves roots for a predicate field from its declared contract', () => {
+      expect(contextRootsForField('step.success')).toEqual(['step', 'vars']);
+      expect(contextRootsForField('trigger.filter')).toEqual(['event', 'trigger']);
+    });
+
+    it('resolves roots for an interpolation field from its accepted hosts', () => {
+      expect(contextRootsForField('agent.prompt')).toEqual(
+        workflowContextNames.filter((name) => name !== 'secrets'),
+      );
+      expect(contextRootsForField('run')).toEqual(workflowContextNames);
+      expect(contextRootsForField('env.value')).toContain('secrets');
+    });
+
     it('declares the runtime roots for every predicate field', () => {
       expect(workflowPredicateContextRoots).toEqual({
         'step.success': ['step', 'vars'],
         'job.success': ['executions', 'jobs', 'vars'],
         'trigger.filter': ['event', 'trigger'],
-        'listener.on': ['event', 'run', 'trigger', 'inputs', 'vars', 'job', 'jobs'],
-        'listener.until': ['event', 'run', 'trigger', 'inputs', 'vars', 'job', 'jobs'],
-        'job.if': ['run', 'trigger', 'event', 'inputs', 'vars', 'jobs', 'needs'],
+        'listener.on': ['event', 'workflow', 'run', 'trigger', 'inputs', 'vars', 'job', 'jobs'],
+        'listener.until': ['event', 'workflow', 'run', 'trigger', 'inputs', 'vars', 'job', 'jobs'],
+        'job.if': ['workflow', 'run', 'trigger', 'event', 'inputs', 'vars', 'jobs', 'needs'],
         'step.if': ['vars', 'jobs', 'execution', 'step', 'steps'],
       });
       expect(getWorkflowPredicateContextRoots('listener.on')).toEqual([
         'event',
+        'workflow',
         'run',
         'trigger',
         'inputs',
@@ -673,12 +703,13 @@ describe('workflow context registry', () => {
       ['step.success', ['step', 'vars']],
       ['job.success', ['executions', 'jobs', 'vars']],
       ['trigger.filter', ['event', 'trigger']],
-      ['listener.on', ['event', 'run', 'trigger', 'inputs', 'vars', 'job', 'jobs']],
-      ['listener.until', ['event', 'run', 'trigger', 'inputs', 'vars', 'job', 'jobs']],
-      ['job.if', ['run', 'trigger', 'event', 'inputs', 'vars', 'jobs', 'needs']],
+      ['listener.on', ['event', 'workflow', 'run', 'trigger', 'inputs', 'vars', 'job', 'jobs']],
+      ['listener.until', ['event', 'workflow', 'run', 'trigger', 'inputs', 'vars', 'job', 'jobs']],
+      ['job.if', ['workflow', 'run', 'trigger', 'event', 'inputs', 'vars', 'jobs', 'needs']],
       ['step.if', ['vars', 'jobs', 'execution', 'step', 'steps']],
     ] as const)('projects runtime contexts for %s', (field, expectedRoots) => {
       const context = {
+        workflow: {id: 'definition-1', name: 'Build'},
         run: {id: 'run-1'},
         trigger: {event: 'push'},
         event: {action: 'opened'},

--- a/libs/shared/expression/src/workflow-context/workflow-context.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.ts
@@ -6,6 +6,7 @@ import {
 } from '../outputs/output-declarations.js';
 
 export const workflowContextNames = [
+  'workflow',
   'run',
   'trigger',
   'event',
@@ -94,6 +95,18 @@ export type WorkflowContextDefinition =
   | OpenWorkflowContextDefinition
   | RunnerWorkflowContextDefinition;
 
+// `workflow` holds definition facts and `run` holds instance facts, mirroring
+// the `job` and `execution` pair one level down.
+const workflowTypeEnvironment = {
+  workflow: {
+    kind: 'object',
+    fields: {
+      id: 'string',
+      name: 'string',
+    },
+  },
+} as const satisfies ExpressionTypeEnvironment;
+
 const runTypeEnvironment = {
   run: {
     kind: 'object',
@@ -101,8 +114,6 @@ const runTypeEnvironment = {
       id: 'string',
       number: 'int',
       name: 'string',
-      workflow_name: 'string',
-      definition_id: 'string',
       project_id: 'string',
       workspace_id: 'string',
       created_at: 'timestamp',
@@ -281,6 +292,14 @@ export function buildTypedRootsEnvironment(params: {
 }
 
 export const workflowContextDefinitions = {
+  workflow: {
+    availability: 'run-creation',
+    sensitivity: 'persistable',
+    host: 'server',
+    shape: 'known',
+    checkMode: 'typed',
+    typeEnvironment: workflowTypeEnvironment,
+  },
   run: {
     availability: 'run-creation',
     sensitivity: 'persistable',
@@ -518,6 +537,7 @@ export type WorkflowPredicateField = (typeof workflowPredicateFields)[number];
 
 const listenerPredicateContextRoots = [
   'event',
+  'workflow',
   'run',
   'trigger',
   'inputs',
@@ -539,7 +559,7 @@ export const workflowPredicateContextRoots = {
   'trigger.filter': ['event', 'trigger'],
   'listener.on': listenerPredicateContextRoots,
   'listener.until': listenerPredicateContextRoots,
-  'job.if': ['run', 'trigger', 'event', 'inputs', 'vars', 'jobs', 'needs'],
+  'job.if': ['workflow', 'run', 'trigger', 'event', 'inputs', 'vars', 'jobs', 'needs'],
   'step.if': ['vars', 'jobs', 'execution', 'step', 'steps'],
 } as const satisfies Record<WorkflowPredicateField, readonly WorkflowContextName[]>;
 
@@ -684,6 +704,30 @@ export function getWorkflowPredicateContextRoots<Field extends WorkflowPredicate
   field: Field,
 ): readonly WorkflowPredicateContextRoot<Field>[] {
   return workflowPredicateContextRoots[field];
+}
+
+/**
+ * The roots a field can read, whichever kind of field it is.
+ *
+ * A predicate has an enumerated contract because the runtime assembles one
+ * context for it. A template has no single context: each reference is filled
+ * where its data arrives, so its only field-level constraint is which host can
+ * resolve it. Callers that document or check fields should use this instead of
+ * choosing a mechanism themselves.
+ */
+export function contextRootsForField(
+  field: WorkflowPredicateField | WorkflowInterpolationField,
+): readonly WorkflowContextName[] {
+  if (isWorkflowPredicateField(field)) return workflowPredicateContextRoots[field];
+
+  const {acceptedHosts} = workflowInterpolationFieldPolicies[field];
+  return workflowContextNames.filter((name) =>
+    acceptedHosts.includes(workflowContextDefinitions[name].host),
+  );
+}
+
+export function isWorkflowPredicateField(field: string): field is WorkflowPredicateField {
+  return (workflowPredicateFields as readonly string[]).includes(field);
 }
 
 export function projectWorkflowPredicateContext(

--- a/libs/shared/workflow/document/src/document/workflow-document.ts
+++ b/libs/shared/workflow/document/src/document/workflow-document.ts
@@ -8,6 +8,27 @@ const nonEmptyRecordSchema = <ValueSchema extends z.ZodType>(valueSchema: ValueS
     .refine((value) => Object.keys(value).length > 0, {message: 'Expected at least one entry'});
 
 export const WORKFLOW_LITERAL_NAME_PATTERN = /^(?:[^$]|\$\$\{\{|\$(?!\{\{))*$/;
+// The inverse of a literal name: a literal prefix followed by an unescaped
+// `${{`. An enum field that also accepts a template matches one or the other.
+export const WORKFLOW_INTERPOLATED_VALUE_PATTERN = /^(?:[^$]|\$\$\{\{|\$(?!\{\{))*\$\{\{/;
+
+// Reasoning effort is an enum so editors can complete it, and a template so a
+// workflow can choose the effort from run context. The resolved value is
+// checked against the harness levels when the step is dispatched.
+export const agentThinkingFieldSchema = z
+  .union([
+    agentThinkingSchema,
+    z.string().regex(WORKFLOW_INTERPOLATED_VALUE_PATTERN, {
+      message:
+        'Agent thinking must be a supported level or a $' +
+        '{{ }} interpolation that resolves to one.',
+    }),
+  ])
+  .meta({
+    description:
+      'Reasoning effort for an agent step. Supported values depend on the resolved harness. Accepts a $' +
+      '{{ }} interpolation. When omitted, Shipfox uses the provider default, or `xhigh` when none is configured.',
+  });
 
 const workflowNameSchema = literalNameSchema(
   'Workflow name must be literal. Move runtime interpolation to run_name.',
@@ -155,11 +176,11 @@ const workflowDocumentTriggerBaseSchema = {
   }),
   with: z.record(z.string(), z.unknown()).optional().meta({
     description:
-      'Provider-specific values used to match or configure the trigger. See [expressions](/reference/expressions#context-available).',
+      'Provider-specific values used to match or configure the trigger. See [Trigger sources](/reference/trigger-sources).',
   }),
   filter: z.string().min(1).optional().meta({
     description:
-      'CEL condition that filters matching events. It is not supported for `manual` or `cron` triggers. See [trigger filters](/reference/expressions#trigger-filters).',
+      'CEL condition that filters matching events. It is not supported for `manual` or `cron` triggers. See [Expressions](/reference/expressions) and [Contexts](/reference/contexts#context-availability).',
   }),
   config: z.record(z.string(), z.unknown()).optional().meta({
     description:
@@ -415,7 +436,7 @@ export const workflowDocumentStepSchema = z
       .meta({
         description:
           'CEL condition wrapped in exactly one $' +
-          '{{ }} interpolation. See [conditionals](/reference/expressions#conditionals-if).',
+          '{{ }} interpolation. See [conditionals](/reference/expressions#syntax).',
       }),
     name: z.string().min(1).optional().meta({description: 'Human-readable step name.'}),
     working_directory: z.string().min(1).optional().meta({
@@ -438,10 +459,7 @@ export const workflowDocumentStepSchema = z
       description:
         'Agent harness. When omitted, Shipfox uses the workspace default harness, or `pi` when none is configured.',
     }),
-    thinking: agentThinkingSchema.optional().meta({
-      description:
-        'Reasoning effort for an agent step. Supported values depend on the resolved harness. When omitted, Shipfox uses the provider default, or `xhigh` when none is configured.',
-    }),
+    thinking: agentThinkingFieldSchema.optional(),
     provider: z.string().min(1).optional().meta({
       description:
         'Model provider ID for an agent step. It requires `prompt` and is not valid on a run step.',
@@ -554,7 +572,7 @@ export const workflowDocumentJobSchema = z.strictObject({
     .meta({
       description:
         'CEL condition wrapped in exactly one $' +
-        '{{ }} interpolation. See [conditionals](/reference/expressions#conditionals-if).',
+        '{{ }} interpolation. See [conditionals](/reference/expressions#syntax).',
     }),
   runner: stringOrStringArraySchema.optional().meta({
     description:
@@ -562,7 +580,7 @@ export const workflowDocumentJobSchema = z.strictObject({
   }),
   success: z.string().min(1).optional().meta({
     description:
-      'CEL expression that determines whether the job succeeds. See [job success](/reference/expressions#job-success-success).',
+      'CEL expression that determines whether the job succeeds. See [Expressions](/reference/expressions#functions-and-macros) and [Contexts](/reference/contexts#context-availability).',
   }),
   outputs: nonEmptyRecordSchema(z.string().min(1)).optional().meta({
     description: 'Named job outputs mapped from step values.',

--- a/libs/shared/workflow/document/src/document/workflow-json-schema.test.ts
+++ b/libs/shared/workflow/document/src/document/workflow-json-schema.test.ts
@@ -162,7 +162,9 @@ function thinkingValuesFor(conditionals: JsonSchema[], harness: string): unknown
   const conditional = conditionals.find(
     (candidate) => object(object(object(candidate.if).properties).harness).const === harness,
   );
-  return object(object(object(conditional?.then).properties).thinking).enum;
+  const thinking = object(object(object(conditional?.then).properties).thinking);
+  const branches = Array.isArray(thinking.anyOf) ? thinking.anyOf : [];
+  return branches.map(object).find((branch) => Array.isArray(branch.enum))?.enum;
 }
 
 function descriptionsMissingFrom(schema: JsonSchema, path = '#'): string[] {

--- a/libs/shared/workflow/document/src/document/workflow-json-schema.ts
+++ b/libs/shared/workflow/document/src/document/workflow-json-schema.ts
@@ -22,6 +22,11 @@ export function buildWorkflowJsonSchema({
   const stepSchema = stepSchemaFor(schema);
   const stepProperties = propertiesOf(stepSchema);
   const thinkingSchema = object(stepProperties.thinking);
+  // `thinking` accepts an enum value or a template, so the per-harness branch
+  // narrows the enum alternative and keeps the template alternative intact.
+  const thinkingBranches = objects(thinkingSchema.anyOf);
+  const thinkingEnumBranch = thinkingBranches.find((branch) => Array.isArray(branch.enum)) ?? {};
+  const thinkingTemplateBranches = thinkingBranches.filter((branch) => !Array.isArray(branch.enum));
 
   delete stepProperties.agent;
   projectWorkflowValidation(schema, stepSchema);
@@ -41,8 +46,13 @@ export function buildWorkflowJsonSchema({
     conditional.then = {
       properties: {
         thinking: {
-          ...thinkingSchema,
-          enum: [...thinkingLevelsForHarness(harness)],
+          ...(typeof thinkingSchema.description === 'string'
+            ? {description: thinkingSchema.description}
+            : {}),
+          anyOf: [
+            {...thinkingEnumBranch, enum: [...thinkingLevelsForHarness(harness)]},
+            ...thinkingTemplateBranches,
+          ],
         },
       },
     };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -722,6 +722,9 @@ importers:
       '@shipfox/biome':
         specifier: workspace:*
         version: link:../../tools/biome
+      '@shipfox/expression':
+        specifier: workspace:*
+        version: link:../../libs/shared/expression
       '@shipfox/ts-config':
         specifier: workspace:*
         version: link:../../tools/ts-config


### PR DESCRIPTION
Splits the expressions reference in two and generates the new page from the engine, so the reference cannot drift from what a workflow can actually read.

`reference/expressions` now covers only syntax, types, operators, and functions, with a working example on every row. `reference/contexts` is new and holds every context, its properties, and the availability matrix keyed by the YAML field an author types. Both tables and every property description are generated from `@shipfox/expression`, and `apps/docs/scripts/check-contexts.mjs` fails the build when the engine gains an expression site the docs do not name, when a property has no description, or when a description outlives its property. That check already caught the checkout target fields added by #1185.

Two product changes come with it, each with its own changeset.

`workflow` becomes a context root holding `workflow.name` and `workflow.id`, replacing `run.workflow_name` and `run.definition_id`. `run` now holds instance facts only, so `workflow` and `run` mirror the `job` and `execution` pair one level down and the generated tables teach one rule instead of a rule plus an exception. This removes fields from an exported type environment, so `@shipfox/expression` takes a major bump.

`agent.thinking` accepts a `${{ }}` interpolation. The published JSON Schema keeps the per-harness enum for editor completion through an `anyOf` branch, and the resolved value is checked against the harness levels when the step dispatches. An unsupported level fails the step rather than falling back, so a workflow never silently runs at a different reasoning effort than it asked for.

The rest is placement. The shell re-evaluation warning moved from the concept page to the `run` field it constrains and now lists all eleven constructs the sync warns about. Recovery from a context that is not available moved to the workflow sync guide, since it is a definition error rather than a runtime one. The glossary entry for CEL stopped restating gate fields.

Review notes. ENG-1454 is resolved upstream by #1178 and #1181, which is what unblocked generating the matrix from the registry rather than hand-authoring it. The security callout is the first `type="warn"` callout in the docs; fumadocs-ui 16.7.10 supports it, and it is one word to change if the repo prefers `info` everywhere.

Closes ENG-1414