### PR TITLE
[api-runners] Stabilize concurrent lease expiry coverage

### DIFF
--- a/libs/api/runners/src/db/job-executions.test.ts
+++ b/libs/api/runners/src/db/job-executions.test.ts
@@ -1713,20 +1713,25 @@ describe('detectAndExpireStuckJobs', () => {
         requiredLabels: ['linux'],
       });
 
-    // Both operations acquire the pending-row lock before the running-row lock.
-    const [reaped, claimed] = await Promise.all([
+    // The reaper may acquire the execution lock first, or it may skip the row while the claim
+    // transaction holds it. Either interleaving must complete without deadlocking.
+    const [firstReap, claimed] = await Promise.all([
       detectAndExpireStuckJobs({thresholdSeconds: 180}),
       claimPendingJobExecution({workspaceId, runnerSessionId, maxClaims: null}),
     ]);
 
-    expect(reaped.expired).toBeGreaterThanOrEqual(1);
-    expect(claimed).toBeNull();
+    // Once the contending claim settles, the next tick reaps a row that the non-blocking
+    // advisory-lock scan intentionally skipped.
+    const secondReap = await detectAndExpireStuckJobs({thresholdSeconds: 180});
 
+    expect(claimed).toBeNull();
+    expect(firstReap.expired + secondReap.expired).toBeGreaterThanOrEqual(1);
     // The expired job is gone and not re-claimable; its orphan pending row is swept.
     expect(await runningJobsForTest()).toHaveLength(0);
     expect(
       await db().select().from(pendingJobExecutions).where(eq(pendingJobExecutions.jobId, jobId)),
     ).toHaveLength(0);
+    expect(await outboxForJobs([jobId])).toHaveLength(1);
     expect(
       await claimPendingJobExecution({workspaceId, runnerSessionId, maxClaims: null}),
     ).toBeNull();


### PR DESCRIPTION
The concurrent reaper and claim test assumed the reaper always won the per-execution advisory lock. CI can schedule the claim first, causing the non-blocking reaper scan to skip the stale row even though the next maintenance tick cleans it up correctly.

Update the test to accept either lock winner, run a follow-up reaper tick after contention settles, and verify job-specific lease expiration and cleanup. Production behavior is unchanged.

Validated with 30 focused stress runs, the 78-test job-executions file, the full 484-test api-runners suite, package check and type validation, and dependency-scoped Turbo validation across 34 packages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilized the concurrent lease expiry test to handle advisory lock contention between the reaper and claim, eliminating flakes. The test now accepts either lock winner, triggers a second `detectAndExpireStuckJobs` tick after contention settles, and verifies lease expiry, pending-row sweep, and outbox emission; production behavior is unchanged.

<sup>Written for commit 3678666a614b91d7aaa95197ca7a3de029ee7579. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

