### PR TITLE
[api-definitions] Warn on re-evaluating shell commands

### DIFF
--- a/.changeset/reevaluating-command-warning.md
+++ b/.changeset/reevaluating-command-warning.md
@@ -1,5 +1,6 @@
 ---
 "@shipfox/api-definitions": patch
+"@shipfox/expression": patch
 ---
 
 Warn when workflow-controlled values are passed to shell positions that re-execute them as code.

--- a/.changeset/reevaluating-command-warning.md
+++ b/.changeset/reevaluating-command-warning.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-definitions": patch
+---
+
+Warn when workflow-controlled values are passed to shell positions that re-execute them as code.

--- a/libs/api/definitions/src/core/sync-definitions.test.ts
+++ b/libs/api/definitions/src/core/sync-definitions.test.ts
@@ -27,6 +27,19 @@ jobs:
       - run: pnpm test
 `;
 
+const eventInterpolation = '$'.concat('{{ event.x }}');
+
+const warningYaml = `
+name: Warning only
+runner: ubuntu-latest
+jobs:
+  build:
+    steps:
+      - env:
+          MSG: '${eventInterpolation}'
+        run: eval "$MSG"
+`;
+
 const validIntegrationYaml = `
 name: Agent CI
 runner: ubuntu-latest
@@ -231,6 +244,31 @@ describe('fetchAndParseWorkflows', () => {
     expect(result[0]?.path).toBe('.shipfox/workflows/ci.yml');
     expect(result[0]?.contentHash).toMatch(LOWERCASE_SHA256_HEX_RE);
     expect(result[0]?.warnings).toEqual([]);
+  });
+
+  it('keeps warning-only definitions available to the sync path', async () => {
+    const result = await fetchAndParseWorkflows({
+      ...baseContext,
+      ref: 'main',
+      paths: ['.shipfox/workflows/warning.yml'],
+      sourceControl: sourceControl({
+        fetchFile: vi.fn(() =>
+          Promise.resolve({
+            path: '.shipfox/workflows/warning.yml',
+            ref: 'main',
+            content: warningYaml,
+          }),
+        ),
+      }),
+    });
+
+    expect(result[0]?.warnings).toMatchObject([
+      {
+        code: 're-evaluating-command',
+        path: 'jobs.build.steps.0.run',
+      },
+    ]);
+    expect(result[0]?.definition.model.jobs[0]?.steps).toHaveLength(1);
   });
 
   it('produces stable content hashes for identical content', async () => {

--- a/libs/api/definitions/src/core/validate-definition.test.ts
+++ b/libs/api/definitions/src/core/validate-definition.test.ts
@@ -219,6 +219,36 @@ jobs:
     }
   });
 
+  test('warns for every repeated and unsafe flagged position', () => {
+    const result = validateDefinition(`
+name: Multiple re-evaluating commands
+runner: ubuntu-latest
+jobs:
+  build:
+    steps:
+      - env:
+          MSG: fixed
+        run: |
+          eval "$MSG" "$MSG"; echo $(${interpolation('event.first')}); eval "$MSG"; echo $((1 + ${interpolation('event.second')}))
+`);
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.warnings).toHaveLength(5);
+      expect(result.warnings.every((warning) => warning.code === 're-evaluating-command')).toBe(
+        true,
+      );
+      expect(result.warnings.every((warning) => warning.path === 'jobs.build.steps.0.run')).toBe(
+        true,
+      );
+      expect(result.warnings.filter((warning) => warning.message.includes('eval'))).toHaveLength(3);
+      expect(result.warnings.some((warning) => warning.message.includes('event.first'))).toBe(true);
+      expect(result.warnings.some((warning) => warning.message.includes('event.second'))).toBe(
+        true,
+      );
+    }
+  });
+
   test('disabled Pi search tools return precise definition validation paths', () => {
     const yaml = `
 name: Pi tools

--- a/libs/api/definitions/src/core/validate-definition.test.ts
+++ b/libs/api/definitions/src/core/validate-definition.test.ts
@@ -5,6 +5,10 @@ function validateDefinition(yaml: string, options = {}) {
   return validateDefinitionBase(yaml, {agentValidationCatalog, ...options});
 }
 
+function interpolation(source: string): string {
+  return '$'.concat('{{ ', source, ' }}');
+}
+
 describe('validateDefinition', () => {
   test('valid YAML returns { valid: true, definition }', () => {
     const yaml = `
@@ -120,6 +124,98 @@ jobs:
     expect(result.valid).toBe(true);
     if (result.valid) {
       expect(result.definition.model.jobs[0]?.runner).toEqual(['ubuntu-latest']);
+    }
+  });
+
+  test.each([
+    [
+      'an env binding',
+      'MSG',
+      `
+name: Re-evaluating command
+runner: ubuntu-latest
+jobs:
+  build:
+    steps:
+      - env:
+          MSG: '${interpolation('event.x')}'
+        run: eval "$MSG"
+`,
+    ],
+    [
+      'a hoisted interpolation',
+      '__sf_0',
+      `
+name: Re-evaluating command
+runner: ubuntu-latest
+jobs:
+  build:
+    steps:
+      - run: 'eval "${interpolation('event.x')}"'
+`,
+    ],
+  ] as const)('returns one non-fatal warning for %s', (_description, valueName, yaml) => {
+    const result = validateDefinition(yaml);
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0]).toMatchObject({
+        code: 're-evaluating-command',
+        path: 'jobs.build.steps.0.run',
+      });
+      expect(result.warnings[0]?.message).toContain(`$${valueName}`);
+      expect(result.warnings[0]?.message).toContain('eval');
+      expect(result.warnings[0]?.message).toContain('re-executed as code');
+      expect(result.definition.model.jobs[0]?.steps).toHaveLength(1);
+    }
+  });
+
+  test.each([
+    'eval "$(cat script.sh)"',
+    "sh -c 'echo fixed'",
+    'source ./scripts/setup.sh',
+    'xargs cmd "$MSG"',
+  ])('does not warn for the common data-safe form %s', (run) => {
+    const result = validateDefinition(`
+name: Safe command
+runner: ubuntu-latest
+jobs:
+  build:
+    steps:
+      - env:
+          MSG: fixed
+        run: |
+          ${run}
+`);
+
+    expect(result).toMatchObject({valid: true, warnings: []});
+  });
+
+  test.each([
+    ['command substitution', `echo $(${interpolation('event.ref')})`, 'command substitution'],
+    ['backtick substitution', `echo \`${interpolation('event.ref')}\``, 'backtick substitution'],
+    ['arithmetic expansion', `echo $(( ${interpolation('event.ref')} + 1 ))`, 'shell arithmetic'],
+  ])('warns for interpolation inside %s', (_description, run, construct) => {
+    const result = validateDefinition(`
+name: Unsafe interpolation
+runner: ubuntu-latest
+jobs:
+  build:
+    steps:
+      - run: |
+          ${run}
+`);
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0]).toMatchObject({
+        code: 're-evaluating-command',
+        path: 'jobs.build.steps.0.run',
+      });
+      expect(result.warnings[0]?.message).toContain('event.ref');
+      expect(result.warnings[0]?.message).toContain(construct);
     }
   });
 

--- a/libs/api/definitions/src/core/workflow-model/invalid-workflow-model-error.ts
+++ b/libs/api/definitions/src/core/workflow-model/invalid-workflow-model-error.ts
@@ -44,6 +44,7 @@ export type WorkflowModelValidationIssueCode =
   | 'runner-context-not-bare'
   | 'runner-context-in-field'
   | 'runner-context-in-server-predicate'
+  | 're-evaluating-command'
   | 'self-job-dependency'
   | 'too-many-runner-labels'
   | 'unknown-secret-store'

--- a/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
@@ -7,6 +7,7 @@ import {
   type ExpressionTypeEnvironment,
   hoistPlannedRunCommand,
   type ShellReevaluatingConstruct,
+  type UnsafeRunInterpolation,
   UnsafeRunInterpolationError,
   type WorkflowJobTypeOverlay,
   type WorkflowStepTypeOverlay,
@@ -768,17 +769,21 @@ function addReevaluatingCommandWarnings(params: {
       reservedNames: envKeys,
     });
   } catch (error) {
-    if (error instanceof UnsafeRunInterpolationError) {
+    if (!(error instanceof UnsafeRunInterpolationError)) return;
+
+    for (const occurrence of error.occurrences) {
       params.issues.push(
         issue({
           code: 're-evaluating-command',
-          message: unsafeInterpolationWarningMessage(error),
+          message: unsafeInterpolationWarningMessage(occurrence),
           path: params.path,
           severity: 'warning',
         }),
       );
     }
-    return;
+
+    if (error.partial === undefined) return;
+    hoisted = error.partial;
   }
 
   try {
@@ -802,7 +807,7 @@ function addReevaluatingCommandWarnings(params: {
   }
 }
 
-function unsafeInterpolationWarningMessage(error: UnsafeRunInterpolationError): string {
+function unsafeInterpolationWarningMessage(error: UnsafeRunInterpolation): string {
   const regionLabel = {
     single: 'single-quoted shell text',
     double: 'double-quoted shell text',

--- a/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
@@ -2,8 +2,12 @@ import type {AgentValidationCatalog} from '@shipfox/api-agent-dto/inter-module';
 import {
   type AvailabilitySite,
   buildTypedRootsEnvironment,
+  classifyShellCodePosition,
   type ExpressionType,
   type ExpressionTypeEnvironment,
+  hoistPlannedRunCommand,
+  type ShellReevaluatingConstruct,
+  UnsafeRunInterpolationError,
   type WorkflowJobTypeOverlay,
   type WorkflowStepTypeOverlay,
 } from '@shipfox/expression';
@@ -30,7 +34,10 @@ import type {
   WorkflowOutputTemplates,
   WorkflowStepSourceLocationMap,
 } from '../entities/workflow-model.js';
-import type {WorkflowModelValidationIssue} from './invalid-workflow-model-error.js';
+import type {
+  WorkflowModelValidationIssue,
+  WorkflowModelValidationIssuePathSegment,
+} from './invalid-workflow-model-error.js';
 import {normalizeAgentIntegrations} from './normalize-agent-integrations.js';
 import {normalizeEnv} from './normalize-env.js';
 import {normalizeIfCondition} from './normalize-if-condition.js';
@@ -178,6 +185,8 @@ function normalizeJob(params: {
     sourceName: params.sourceName,
     jobId: id,
     job: params.job,
+    workflowEnvKeys: Object.keys(params.document.env ?? {}),
+    jobEnvKeys: Object.keys(params.job.env ?? {}),
     issues: params.issues,
     stepSourceLocations: params.stepSourceLocations,
     fillSite: stepFillSite,
@@ -466,6 +475,8 @@ function normalizeJobSteps(params: {
   sourceName: string;
   jobId: string;
   job: WorkflowDocumentJob;
+  workflowEnvKeys: readonly string[];
+  jobEnvKeys: readonly string[];
   issues: WorkflowModelValidationIssue[];
   stepSourceLocations: WorkflowStepSourceLocationMap | undefined;
   fillSite: AvailabilitySite;
@@ -484,6 +495,8 @@ function normalizeJobSteps(params: {
       sourceName: params.sourceName,
       jobId: params.jobId,
       allSteps: params.job.steps,
+      workflowEnvKeys: params.workflowEnvKeys,
+      jobEnvKeys: params.jobEnvKeys,
       usedStepIds,
       issues: params.issues,
       stepSourceLocations: params.stepSourceLocations,
@@ -504,6 +517,8 @@ function normalizeStep(params: {
   sourceName: string;
   jobId: string;
   allSteps: readonly WorkflowDocumentStep[];
+  workflowEnvKeys: readonly string[];
+  jobEnvKeys: readonly string[];
   usedStepIds: Map<string, number>;
   issues: WorkflowModelValidationIssue[];
   stepSourceLocations: WorkflowStepSourceLocationMap | undefined;
@@ -631,6 +646,8 @@ function normalizeStep(params: {
       stepBase,
       sourceName: params.sourceName,
       stepIndex: params.index,
+      workflowEnvKeys: params.workflowEnvKeys,
+      jobEnvKeys: params.jobEnvKeys,
       name,
       workingDirectory,
       issues: params.issues,
@@ -676,6 +693,8 @@ function normalizeRunStep(params: {
   stepBase: WorkflowModelStepBaseFields;
   sourceName: string;
   stepIndex: number;
+  workflowEnvKeys: readonly string[];
+  jobEnvKeys: readonly string[];
   name: WorkflowFieldTemplate | undefined;
   workingDirectory: WorkflowFieldTemplate | undefined;
   issues: WorkflowModelValidationIssue[];
@@ -704,6 +723,15 @@ function normalizeRunStep(params: {
     allowedJobReferences: params.allowedJobReferences,
     typeOverlay: params.typeOverlay,
   });
+  addReevaluatingCommandWarnings({
+    command: commandTemplate,
+    source: params.step.run,
+    workflowEnvKeys: params.workflowEnvKeys,
+    jobEnvKeys: params.jobEnvKeys,
+    stepEnvKeys: Object.keys(params.step.env ?? {}),
+    path: ['jobs', params.sourceName, 'steps', params.stepIndex, 'run'],
+    issues: params.issues,
+  });
   const templates = optionalRunStepTemplates({
     command: commandTemplate,
     name: params.name,
@@ -718,6 +746,99 @@ function normalizeRunStep(params: {
     ...(stepEnv.env === undefined ? {} : {env: stepEnv.env}),
     ...(templates === undefined ? {} : {templates}),
   };
+}
+
+function addReevaluatingCommandWarnings(params: {
+  command: WorkflowFieldTemplate | undefined;
+  source: string;
+  workflowEnvKeys: readonly string[];
+  jobEnvKeys: readonly string[];
+  stepEnvKeys: readonly string[];
+  path: readonly WorkflowModelValidationIssuePathSegment[];
+  issues: WorkflowModelValidationIssue[];
+}): void {
+  const envKeys = new Set([...params.workflowEnvKeys, ...params.jobEnvKeys, ...params.stepEnvKeys]);
+  let hoisted: ReturnType<typeof hoistPlannedRunCommand>;
+
+  try {
+    hoisted = hoistPlannedRunCommand({
+      field: {
+        segments: params.command ?? [{kind: 'literal', value: params.source}],
+      },
+      reservedNames: envKeys,
+    });
+  } catch (error) {
+    if (error instanceof UnsafeRunInterpolationError) {
+      params.issues.push(
+        issue({
+          code: 're-evaluating-command',
+          message: unsafeInterpolationWarningMessage(error),
+          path: params.path,
+          severity: 'warning',
+        }),
+      );
+    }
+    return;
+  }
+
+  try {
+    const matches = classifyShellCodePosition({
+      command: hoisted.command,
+      workflowDataNames: [...envKeys, ...hoisted.bindings.map((binding) => binding.name)],
+    }).matches;
+
+    for (const match of matches) {
+      params.issues.push(
+        issue({
+          code: 're-evaluating-command',
+          message: reevaluatingCommandWarningMessage(match.construct, match.name),
+          path: params.path,
+          severity: 'warning',
+        }),
+      );
+    }
+  } catch {
+    return;
+  }
+}
+
+function unsafeInterpolationWarningMessage(error: UnsafeRunInterpolationError): string {
+  const regionLabel = {
+    single: 'single-quoted shell text',
+    double: 'double-quoted shell text',
+    'dollar-single': 'ANSI-C shell text',
+    'dollar-double': 'dollar-double-quoted shell text',
+    'paren-sub': 'command substitution',
+    arith: 'shell arithmetic',
+    backtick: 'backtick substitution',
+    'param-brace': 'shell parameter expansion',
+    heredoc: 'a heredoc',
+    'line-comment': 'a shell comment',
+    escape: 'a shell escape',
+  }[error.region];
+
+  return `Value "${error.source}" is inside ${regionLabel} and will be re-executed as code. Hoisting cannot protect it; move the interpolation to a normal quoted argument instead.`;
+}
+
+function reevaluatingCommandWarningMessage(
+  construct: ShellReevaluatingConstruct,
+  name: string,
+): string {
+  const constructLabel = {
+    eval: 'eval',
+    'sh-c': 'sh -c',
+    'bash-c': 'bash -c',
+    source: 'source',
+    let: 'let',
+    'declare-i': 'declare -i',
+    arithmetic: 'shell arithmetic',
+    awk: 'awk',
+    jq: 'jq',
+    sed: 'sed',
+    'xargs-sh-c': 'xargs sh -c',
+  }[construct];
+
+  return `Value "$${name}" is passed to ${constructLabel} and re-executed as code. Hoisting cannot protect it; pass the value to a fixed program instead.`;
 }
 
 function normalizeAgentStep(params: {

--- a/libs/shared/expression/src/index.ts
+++ b/libs/shared/expression/src/index.ts
@@ -110,6 +110,7 @@ export {
   hoistPlannedRunCommand,
   type PlannedRunCommandBinding,
   type RunCommandHoistOptions,
+  type UnsafeRunInterpolation,
   UnsafeRunInterpolationError,
   unsafeRunInterpolationErrorCode,
 } from './run/hoist-run-command.js';

--- a/libs/shared/expression/src/run/hoist-run-command.test.ts
+++ b/libs/shared/expression/src/run/hoist-run-command.test.ts
@@ -146,6 +146,30 @@ describe('hoistPlannedRunCommand', () => {
     expect((error as Error).message).toContain('Bind the value to env and reference $VAR');
   });
 
+  it('retains every unsafe interpolation and safe binding in the error analysis', () => {
+    const field = plannedField(
+      `echo $(${templateExpression(' run.first ')}) ; eval "${templateExpression(' run.second ')}"; echo $((1 + ${templateExpression(' run.third ')}))`,
+    );
+
+    let error: unknown;
+    try {
+      hoistPlannedRunCommand({field});
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(UnsafeRunInterpolationError);
+    expect(error).toMatchObject({
+      occurrences: [
+        {region: 'paren-sub', source: 'run.first'},
+        {region: 'arith', source: 'run.third'},
+      ],
+      partial: {
+        bindings: [{name: '__sf_0'}],
+      },
+    });
+  });
+
   it('does not let quotes inside comments affect later interpolation sites', () => {
     const field = plannedField(
       `# "comment only"\nprintf '%s\\n' ${templateExpression(' run.id ')}`,

--- a/libs/shared/expression/src/run/hoist-run-command.ts
+++ b/libs/shared/expression/src/run/hoist-run-command.ts
@@ -27,16 +27,30 @@ export interface HoistedPlannedRunCommand {
   readonly bindings: readonly PlannedRunCommandBinding[];
 }
 
+export interface UnsafeRunInterpolation {
+  readonly region: ShellUnsafeRegion;
+  readonly source: string;
+}
+
 export class UnsafeRunInterpolationError extends Error {
   readonly code = unsafeRunInterpolationErrorCode;
+  readonly occurrences: readonly UnsafeRunInterpolation[];
+  readonly partial: HoistedPlannedRunCommand | undefined;
   readonly region: ShellUnsafeRegion;
   readonly source: string;
 
-  constructor(params: {readonly region: ShellUnsafeRegion; readonly source: string}) {
+  constructor(params: {
+    readonly region: ShellUnsafeRegion;
+    readonly source: string;
+    readonly occurrences?: readonly UnsafeRunInterpolation[];
+    readonly partial?: HoistedPlannedRunCommand;
+  }) {
     super(
       `Unsafe run interpolation inside ${params.region}. Bind the value to env and reference $VAR instead.`,
     );
     this.name = 'UnsafeRunInterpolationError';
+    this.occurrences = params.occurrences ?? [{region: params.region, source: params.source}];
+    this.partial = params.partial;
     this.region = params.region;
     this.source = params.source;
   }
@@ -51,13 +65,24 @@ export function hoistPlannedRunCommand(params: {
   readonly field: ResolvedField;
   readonly reservedNames?: Iterable<string>;
 }): HoistedPlannedRunCommand {
-  return hoistCommandSegments({
+  const result = hoistCommandSegments({
     segments: params.field.segments,
     options: params.reservedNames === undefined ? {} : {reservedNames: params.reservedNames},
     literalText: (segment) => segment.value,
     isBindingSegment: (segment): segment is ResolvedFieldDeferredSegment =>
       segment.kind === 'deferred',
   });
+
+  const firstUnsafeInterpolation = result.unsafeInterpolations[0];
+  if (firstUnsafeInterpolation !== undefined) {
+    throw new UnsafeRunInterpolationError({
+      ...firstUnsafeInterpolation,
+      occurrences: result.unsafeInterpolations,
+      partial: {command: result.command, bindings: result.bindings},
+    });
+  }
+
+  return {command: result.command, bindings: result.bindings};
 }
 
 function hoistCommandSegments<
@@ -71,10 +96,12 @@ function hoistCommandSegments<
 }): {
   readonly command: string;
   readonly bindings: readonly {readonly name: string; readonly segment: BindingSegment}[];
+  readonly unsafeInterpolations: readonly UnsafeRunInterpolation[];
 } {
   let command = '';
   let state: ShellScanState = initialShellScanState;
   const bindings: {name: string; segment: BindingSegment}[] = [];
+  const unsafeInterpolations: UnsafeRunInterpolation[] = [];
   const reservedNames = new Set(params.options.reservedNames ?? []);
   let nextIndex = 0;
 
@@ -90,10 +117,11 @@ function hoistCommandSegments<
 
     const site = classifyShellSite(state);
     if (site.kind === 'unsafe') {
-      throw new UnsafeRunInterpolationError({
+      unsafeInterpolations.push({
         region: site.region,
         source: segment.expression.source,
       });
+      continue;
     }
 
     const name = nextGeneratedName(reservedNames, nextIndex);
@@ -103,7 +131,7 @@ function hoistCommandSegments<
     command += shellReference(name, site);
   }
 
-  return {command, bindings};
+  return {command, bindings, unsafeInterpolations};
 }
 
 function nextGeneratedName(reservedNames: ReadonlySet<string>, startIndex: number): string {

--- a/libs/shared/expression/src/run/shell-code-position.test.ts
+++ b/libs/shared/expression/src/run/shell-code-position.test.ts
@@ -113,6 +113,19 @@ describe('classifyShellCodePosition', () => {
     expect(result.matches).toEqual([{name: '__sf_0', construct: 'eval'}]);
   });
 
+  it('preserves every repeated workflow reference in a code position', () => {
+    const result = classifyShellCodePosition({
+      command: 'eval "$MSG" "$MSG"; eval "$MSG"',
+      workflowDataNames,
+    });
+
+    expect(result.matches).toEqual([
+      {name: 'MSG', construct: 'eval'},
+      {name: 'MSG', construct: 'eval'},
+      {name: 'MSG', construct: 'eval'},
+    ]);
+  });
+
   it('reports arithmetic references without following command substitutions', () => {
     const result = classifyShellCodePosition({
       command: 'echo $(( MSG + $(cat script.sh) ))',

--- a/libs/shared/expression/src/run/shell-code-position.ts
+++ b/libs/shared/expression/src/run/shell-code-position.ts
@@ -102,7 +102,7 @@ export function classifyShellCodePosition(params: {
   readonly workflowDataNames: Iterable<string>;
 }): ShellCodePositionAnalysis {
   const workflowDataNames = new Set(params.workflowDataNames);
-  const matches = new Map<string, ShellCodePositionMatch>();
+  const matches: ShellCodePositionMatch[] = [];
 
   if (workflowDataNames.size === 0) return {matches: []};
 
@@ -112,8 +112,7 @@ export function classifyShellCodePosition(params: {
   const report = (reference: ShellVariableReference, construct: ShellReevaluatingConstruct) => {
     if (!workflowDataNames.has(reference.name)) return;
 
-    const key = `${construct}:${reference.name}`;
-    if (!matches.has(key)) matches.set(key, {construct, name: reference.name});
+    matches.push({construct, name: reference.name});
   };
 
   const reportReferences = (
@@ -212,7 +211,7 @@ export function classifyShellCodePosition(params: {
 
   analyzeCommand(command);
 
-  return {matches: [...matches.values()]};
+  return {matches};
 }
 
 function tokenizeShell(source: string): readonly ShellToken[] {


### PR DESCRIPTION
Workflow-controlled values passed to shell positions that re-execute them as code now produce validation warnings. This also handles `UnsafeRunInterpolationError`, so interpolations inside command substitutions, backticks, and arithmetic expansions no longer pass silently without an early diagnostic.

The PR includes definition-validation and sync-path regression coverage plus the required changeset. Validation passed with the API definitions package checks, type checks, and 62 dependency-aware test tasks.

Closes ENG-1411

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit non-fatal validation warnings when workflow-controlled values are passed to shell constructs that re-execute them as code, without blocking syncs or runs. Fulfills Linear ENG-1411 by wiring the code-position classifier into `@shipfox/api-definitions` validation and preserving all occurrences for clearer diagnostics.

- **New Features**
  - Emits `re-evaluating-command` warnings during run-step validation with a path to the specific step’s `run`.
  - Covers `eval`, `sh -c`, `bash -c`, `source`, arithmetic, `awk`, `jq`, `sed`, `xargs sh -c`, and more.
  - Handles `UnsafeRunInterpolationError`; warns for interpolations inside command/backtick substitutions and arithmetic expansions, and continues with a partial hoist.
  - Preserves repeats: one warning per occurrence and unsafe interpolation, with messages naming the construct and value.
  - Never fatal: definitions still sync and runs are created.
  - No warnings for common safe forms: `eval "$(cat script.sh)"`, `sh -c 'echo fixed'`, `source ./scripts/setup.sh`, `xargs cmd "$MSG"`.
  - Adds tests for repeated matches, unsafe interpolation coverage, validation paths, sync-path behavior, plus a changeset in `@shipfox/api-definitions` and `@shipfox/expression`.

<sup>Written for commit 1bc9599cf1893dbe16008d09e572515a9571e7dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

