### PR TITLE
Restore restrictions for dynamic infrastructure selectors

### DIFF
--- a/.changeset/restore-selector-restrictions.md
+++ b/.changeset/restore-selector-restrictions.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-definitions": minor
+"@shipfox/expression": patch
+---
+
+Existing workflows that use external event, input, listening-event, or output data to dynamically select runner labels, agent models, or agent providers now fail validation. Bind dynamic selectors through workflow-authored `vars` or `secrets` instead.

--- a/libs/api/definitions/src/core/workflow-model/invalid-workflow-model-error.ts
+++ b/libs/api/definitions/src/core/workflow-model/invalid-workflow-model-error.ts
@@ -52,7 +52,7 @@ export type WorkflowModelValidationIssueCode =
   | 'unknown-integration-tool'
   | 'unknown-job-dependency'
   | 'unsupported-checkout'
-  | 'untrusted-agent-selection-context';
+  | 'untrusted-infrastructure-selection-context';
 
 export type WorkflowModelValidationIssuePathSegment = string | number;
 

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -4499,6 +4499,22 @@ describe('normalizeWorkflowDocument', () => {
         {provider: interpolation('executions[0].events[0].data.body'), prompt: 'Fix it.'},
         'executions',
       ],
+      ['model', {model: interpolation('execution.outputs.value'), prompt: 'Fix it.'}, 'execution'],
+      [
+        'provider',
+        {provider: interpolation('execution.outputs.value'), prompt: 'Fix it.'},
+        'execution',
+      ],
+      [
+        'model',
+        {model: interpolation('executions[0].outputs.value'), prompt: 'Fix it.'},
+        'executions',
+      ],
+      [
+        'provider',
+        {provider: interpolation('executions[0].outputs.value'), prompt: 'Fix it.'},
+        'executions',
+      ],
     ] as const)('rejects path-specific external context in agent %s interpolation', (_field, step, root) => {
       const document: WorkflowDocument = {
         name: 'path-specific external agent field',
@@ -4526,6 +4542,8 @@ describe('normalizeWorkflowDocument', () => {
       ['execution', interpolation('execution.events[0].data.runner')],
       ['execution', interpolation('execution["events"][0].data.runner')],
       ['executions', interpolation('executions[0].events[0].data.runner')],
+      ['execution', interpolation('execution.outputs.runner')],
+      ['executions', interpolation('executions[0].outputs.runner')],
       ['steps', interpolation('steps.filter(s, true).map(s, s.outputs.runner)[0]')],
       ['step', interpolation('step.outputs.runner')],
       ['needs', interpolation('needs[0].outputs.runner')],

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -3770,7 +3770,7 @@ describe('normalizeWorkflowDocument', () => {
         env: {RUN_ID: interpolation('run.id'), PORT: 3000},
         jobs: {
           build: {
-            runner: ['linux', interpolation('execution.events[0].data.runner')],
+            runner: ['linux', interpolation('job.key')],
             env: {JOB_NAME: interpolation('job.key')},
             steps: [
               {
@@ -3808,12 +3808,12 @@ describe('normalizeWorkflowDocument', () => {
             kind: 'deferred',
             expression: {
               language: 'cel',
-              source: 'execution.events[0].data.runner',
+              source: 'job.key',
               check: 'typed',
               resultType: 'string',
             },
-            roots: ['execution'],
-            fillTarget: 'execution-creation',
+            roots: ['job'],
+            fillTarget: 'run-creation',
           },
         ],
       ]);
@@ -4417,9 +4417,15 @@ describe('normalizeWorkflowDocument', () => {
     it.each([
       ['model', {model: interpolation('event.model'), prompt: 'Fix it.'}, 'event'],
       ['provider', {provider: interpolation('inputs.provider'), prompt: 'Fix it.'}, 'inputs'],
-    ] as const)('allows external context in agent %s interpolation', (field, step, root) => {
+      ['model', {model: interpolation('needs[0].outputs.value'), prompt: 'Fix it.'}, 'needs'],
+      [
+        'provider',
+        {provider: interpolation('jobs.build.outputs.value'), prompt: 'Fix it.'},
+        'jobs',
+      ],
+    ] as const)('rejects external context in agent %s interpolation', (field, step, root) => {
       const document: WorkflowDocument = {
-        name: 'external agent field',
+        name: 'unsafe agent field',
         jobs: {
           fix: {
             steps: [step],
@@ -4427,14 +4433,17 @@ describe('normalizeWorkflowDocument', () => {
         },
       };
 
-      const model = normalizeWorkflowDocument(document);
+      const error = expectInvalid(document);
 
-      expect(model.jobs[0]?.steps[0]).toMatchObject({
-        kind: 'agent',
-        templates: {
-          [field]: [{kind: 'deferred', roots: [root]}],
-        },
-      });
+      expect(error.issues).toEqual([
+        expect.objectContaining({
+          code: 'untrusted-infrastructure-selection-context',
+          details: expect.objectContaining({
+            field: `agent.${field}`,
+            rejectedRoots: [root],
+          }),
+        }),
+      ]);
     });
 
     it.each([
@@ -4480,7 +4489,17 @@ describe('normalizeWorkflowDocument', () => {
         {provider: interpolation('execution["events"][0].data.body'), prompt: 'Fix it.'},
         'execution',
       ],
-    ] as const)('allows path-specific external context in agent %s interpolation', (field, step, root) => {
+      [
+        'model',
+        {model: interpolation('executions[0].events[0].data.body'), prompt: 'Fix it.'},
+        'executions',
+      ],
+      [
+        'provider',
+        {provider: interpolation('executions[0].events[0].data.body'), prompt: 'Fix it.'},
+        'executions',
+      ],
+    ] as const)('rejects path-specific external context in agent %s interpolation', (_field, step, root) => {
       const document: WorkflowDocument = {
         name: 'path-specific external agent field',
         jobs: {
@@ -4490,14 +4509,97 @@ describe('normalizeWorkflowDocument', () => {
         },
       };
 
-      const model = normalizeWorkflowDocument(document);
+      const error = expectInvalid(document);
 
-      expect(model.jobs[0]?.steps[1]).toMatchObject({
-        kind: 'agent',
-        templates: {
-          [field]: [{kind: 'deferred', roots: [root]}],
+      expect(error.issues).toEqual([
+        expect.objectContaining({
+          code: 'untrusted-infrastructure-selection-context',
+          path: ['jobs', 'fix', 'steps', 1, expect.any(String)],
+          details: expect.objectContaining({rejectedRoots: [root]}),
+        }),
+      ]);
+    });
+
+    it.each([
+      ['event', interpolation('event.runner')],
+      ['inputs', interpolation('inputs.runner')],
+      ['execution', interpolation('execution.events[0].data.runner')],
+      ['execution', interpolation('execution["events"][0].data.runner')],
+      ['executions', interpolation('executions[0].events[0].data.runner')],
+      ['steps', interpolation('steps.filter(s, true).map(s, s.outputs.runner)[0]')],
+      ['step', interpolation('step.outputs.runner')],
+      ['needs', interpolation('needs[0].outputs.runner')],
+      ['jobs', interpolation('jobs.build.outputs.runner')],
+      ['execution', interpolation('dyn(execution).events[0].data.runner')],
+      ['execution', interpolation('(true ? execution : execution).events[0].data.runner')],
+      ['execution', interpolation('[execution][0].events[0].data.runner')],
+      ['execution', interpolation('{x: execution}.x.events[0].data.runner')],
+      [
+        'executions',
+        interpolation(
+          'executions.exists(e, e[job.key] == "gpu-flag") ? "gpu-runner" : "cpu-runner"',
+        ),
+      ],
+    ] as const)('rejects %s context from a dynamic runner selector', (root, runner) => {
+      const document: WorkflowDocument = {
+        name: 'unsafe runner selector',
+        jobs: {
+          build: {
+            runner,
+            steps: [{run: 'echo ok'}],
+          },
+        },
+      };
+
+      const error = expectInvalid(document);
+
+      expect(error.issues).toEqual([
+        expect.objectContaining({
+          code: 'untrusted-infrastructure-selection-context',
+          path: ['jobs', 'build', 'runner', 0],
+          details: expect.objectContaining({field: 'job.runner', rejectedRoots: [root]}),
+        }),
+      ]);
+    });
+
+    it('reports all rejected contexts used by a dynamic runner selector', () => {
+      const error = expectInvalid({
+        name: 'multiple unsafe runner contexts',
+        jobs: {
+          build: {
+            runner: interpolation('event.runner + inputs.runner'),
+            steps: [{run: 'echo ok'}],
+          },
         },
       });
+
+      expect(error.issues).toEqual([
+        expect.objectContaining({
+          code: 'untrusted-infrastructure-selection-context',
+          details: expect.objectContaining({rejectedRoots: ['event', 'inputs']}),
+        }),
+      ]);
+    });
+
+    it.each([
+      'run.name',
+      'trigger.source',
+      'job.key',
+      'executions[0].name',
+      'execution.name',
+      'vars.RUNNER',
+    ])('keeps approved %s context available to dynamic runner selectors', (source) => {
+      const model = normalizeWorkflowDocument({
+        name: 'approved runner selector',
+        jobs: {
+          build: {
+            runner: interpolation(source),
+            steps: [{run: 'echo ok'}],
+          },
+        },
+      });
+
+      expect(model.jobs[0]?.runnerTemplates).toHaveLength(1);
     });
 
     it.each([

--- a/libs/api/definitions/src/core/workflow-model/parse-interpolation-field.ts
+++ b/libs/api/definitions/src/core/workflow-model/parse-interpolation-field.ts
@@ -5,6 +5,7 @@ import {
   analyzeContextRootKeyAccess,
   createWorkflowExpression,
   type ExpressionTypeEnvironment,
+  extractCelContextPathRoots,
   getWorkflowContextAvailability,
   getWorkflowContextDefinition,
   getWorkflowContextHost,
@@ -45,6 +46,31 @@ export type StoredInterpolationField =
   | 'step.name'
   | 'step.working_directory'
   | 'step.feedback';
+
+const infrastructureSelectorFields = new Set<StoredInterpolationField>([
+  'job.runner',
+  'agent.model',
+  'agent.provider',
+]);
+
+const infrastructureSelectorAllowedRoots = new Set<WorkflowContextName>([
+  'run',
+  'trigger',
+  'job',
+  'executions',
+  'execution',
+  'steps',
+  'step',
+  'vars',
+  'secrets',
+]);
+
+const infrastructureSelectorExternalPaths = new Map<string, readonly string[]>([
+  ['executions', ['events']],
+  ['execution', ['events']],
+  ['steps', ['outputs']],
+  ['step', ['outputs']],
+]);
 
 export function parseInterpolationField(params: {
   field: StoredInterpolationField;
@@ -152,6 +178,22 @@ function validateExpressionSegment(params: {
   const contextRoots = uniqueStrings(params.segment.contextRoots);
   const knownRoots = contextRoots.filter(isWorkflowContextName);
   const unknownRoots = contextRoots.filter((root) => !isWorkflowContextName(root));
+
+  const rejectedInfrastructureSelectorRoots = findInfrastructureSelectorRoots({
+    field: params.field,
+    expression: params.segment.expression,
+    knownRoots,
+  });
+  if (rejectedInfrastructureSelectorRoots.length > 0) {
+    params.issues.push(
+      infrastructureSelectorContextIssue({
+        ...params,
+        contextRoots,
+        rejectedRoots: rejectedInfrastructureSelectorRoots,
+      }),
+    );
+    return undefined;
+  }
 
   const rejectedHostRoots = knownRoots.filter(
     (root) => !workflowInterpolationFieldAcceptsHost(params.field, getWorkflowContextHost(root)),
@@ -279,6 +321,49 @@ function validateExpressionSegment(params: {
     );
     return undefined;
   }
+}
+
+function findInfrastructureSelectorRoots(params: {
+  field: StoredInterpolationField;
+  expression: WorkflowTemplateExprSegment['expression'];
+  knownRoots: readonly WorkflowContextName[];
+}): readonly WorkflowContextName[] {
+  if (!infrastructureSelectorFields.has(params.field)) return [];
+
+  const pathRoots = extractCelContextPathRoots({
+    source: params.expression.source,
+    pathsByRoot: infrastructureSelectorExternalPaths,
+  });
+  const rejectedRoots = new Set<WorkflowContextName>(
+    params.knownRoots.filter((root) => !infrastructureSelectorAllowedRoots.has(root)),
+  );
+  for (const root of pathRoots) {
+    if (isWorkflowContextName(root)) rejectedRoots.add(root);
+  }
+
+  return [...rejectedRoots].sort();
+}
+
+function infrastructureSelectorContextIssue(params: {
+  field: WorkflowInterpolationField;
+  source: string;
+  path: readonly WorkflowModelValidationIssuePathSegment[];
+  contextRoots: readonly string[];
+  rejectedRoots: readonly WorkflowContextName[];
+}): WorkflowModelValidationIssue {
+  return issue({
+    code: 'untrusted-infrastructure-selection-context',
+    message: `${fieldLabel(params.field)} interpolation cannot use external context ${formatList(
+      params.rejectedRoots,
+    )}. Infrastructure selectors must come from approved workflow or configuration context.`,
+    path: params.path,
+    details: {
+      field: params.field,
+      source: params.source,
+      contextRoots: params.contextRoots,
+      rejectedRoots: params.rejectedRoots,
+    },
+  });
 }
 
 function runnerContextInFieldIssue(params: {

--- a/libs/api/definitions/src/core/workflow-model/parse-interpolation-field.ts
+++ b/libs/api/definitions/src/core/workflow-model/parse-interpolation-field.ts
@@ -66,8 +66,8 @@ const infrastructureSelectorAllowedRoots = new Set<WorkflowContextName>([
 ]);
 
 const infrastructureSelectorExternalPaths = new Map<string, readonly string[]>([
-  ['executions', ['events']],
-  ['execution', ['events']],
+  ['executions', ['events', 'outputs']],
+  ['execution', ['events', 'outputs']],
   ['steps', ['outputs']],
   ['step', ['outputs']],
 ]);

--- a/libs/shared/expression/README.md
+++ b/libs/shared/expression/README.md
@@ -24,6 +24,8 @@ CEL checks and run-time evaluation for Shipfox workflow expressions.
   ordered literal and expression segments.
 - **`extractCelContextRoots`**: Returns the sorted top-level CEL identifiers mentioned
   by an expression for downstream context and agent-selection checks.
+- **`extractCelContextPathRoots`**: Finds configured child paths, including paths
+  reached through CEL indexes and comprehensions.
 - **Typed errors**: Reports bad text and run failures with stable error classes.
 - **`workflowContextDefinitions`**: Names the workflow contexts (`run`,
   `trigger`, `event`, `inputs`, `job`, `executions`, `execution`, `jobs`, `step`) and

--- a/libs/shared/expression/src/index.ts
+++ b/libs/shared/expression/src/index.ts
@@ -123,6 +123,7 @@ export {
   InvalidWorkflowTemplateError,
   invalidWorkflowTemplateErrorCode,
 } from './template/errors.js';
+export {extractCelContextPathRoots} from './template/extract-cel-context-path-roots.js';
 export {extractCelContextRoots} from './template/extract-cel-context-roots.js';
 export {parseWorkflowTemplate} from './template/parse-workflow-template.js';
 export type {

--- a/libs/shared/expression/src/template/extract-cel-context-path-roots.test.ts
+++ b/libs/shared/expression/src/template/extract-cel-context-path-roots.test.ts
@@ -1,8 +1,8 @@
 import {extractCelContextPathRoots} from './extract-cel-context-path-roots.js';
 
 const pathsByRoot = new Map<string, readonly string[]>([
-  ['execution', ['events']],
-  ['executions', ['events']],
+  ['execution', ['events', 'outputs']],
+  ['executions', ['events', 'outputs']],
   ['steps', ['outputs']],
   ['step', ['outputs']],
 ]);
@@ -15,8 +15,10 @@ describe('extractCelContextPathRoots', () => {
   it.each([
     ['execution.events[0].data', ['execution']],
     ['execution["events"][0].data', ['execution']],
+    ['execution.outputs.value', ['execution']],
     ['executions[0].events', ['executions']],
     ['executions[0]["events"]', ['executions']],
+    ['executions[0].outputs.value', ['executions']],
     ['execution.events.exists(e, e.data.ok)', ['execution']],
     ['executions.map(e, e.events[0].data.body)', ['executions']],
     ['executions.exists(e, e.events.size() > 0)', ['executions']],

--- a/libs/shared/expression/src/template/extract-cel-context-path-roots.test.ts
+++ b/libs/shared/expression/src/template/extract-cel-context-path-roots.test.ts
@@ -1,0 +1,58 @@
+import {extractCelContextPathRoots} from './extract-cel-context-path-roots.js';
+
+const pathsByRoot = new Map<string, readonly string[]>([
+  ['execution', ['events']],
+  ['executions', ['events']],
+  ['steps', ['outputs']],
+  ['step', ['outputs']],
+]);
+
+function extract(source: string): string[] {
+  return extractCelContextPathRoots({source, pathsByRoot});
+}
+
+describe('extractCelContextPathRoots', () => {
+  it.each([
+    ['execution.events[0].data', ['execution']],
+    ['execution["events"][0].data', ['execution']],
+    ['executions[0].events', ['executions']],
+    ['executions[0]["events"]', ['executions']],
+    ['execution.events.exists(e, e.data.ok)', ['execution']],
+    ['executions.map(e, e.events[0].data.body)', ['executions']],
+    ['executions.exists(e, e.events.size() > 0)', ['executions']],
+    ['executions.exists(e, e[job.key] == "gpu-flag")', ['executions']],
+    ['cel.bind(e, executions, e.events[0].data.body)', ['executions']],
+    ['cel.bind(e, executions, e[job.key])', ['executions']],
+    ['steps.filter(s, true).map(s, s.outputs.value)[0]', ['steps']],
+    ['step.outputs.value', ['step']],
+  ] as const)('finds configured path access in %s', (source, roots) => {
+    expect(extract(source)).toEqual(roots);
+  });
+
+  it.each([
+    'execution.name',
+    'executions[0].name',
+    'run.id',
+    'execution.events_count',
+  ])('ignores other paths in %s', (source) => {
+    expect(extract(source)).toEqual([]);
+  });
+
+  it('conservatively treats computed object fields as configured path access', () => {
+    expect(extract('execution[x]')).toEqual(['execution']);
+    expect(extract('executions[i][x]')).toEqual(['executions']);
+  });
+
+  it.each([
+    'dyn(execution).events[0].data',
+    '(true ? execution : execution).events[0].data',
+    '[execution][0].events[0].data',
+    '{x: execution}.x.events[0].data',
+  ])('fails closed for wrapped configured paths in %s', (source) => {
+    expect(extract(source)).toEqual(['execution']);
+  });
+
+  it('allows computed list indexes on executions', () => {
+    expect(extract('executions[i].name')).toEqual([]);
+  });
+});

--- a/libs/shared/expression/src/template/extract-cel-context-path-roots.ts
+++ b/libs/shared/expression/src/template/extract-cel-context-path-roots.ts
@@ -1,0 +1,278 @@
+import {type ASTNode, type BinaryOperator, parse as parseCel} from '@marcbachmann/cel-js';
+
+const binaryOperators = new Set<BinaryOperator>([
+  '!=',
+  '==',
+  'in',
+  '+',
+  '-',
+  '*',
+  '/',
+  '%',
+  '<',
+  '<=',
+  '>',
+  '>=',
+]);
+
+const comprehensionMethods = new Set(['all', 'exists', 'exists_one', 'filter', 'map']);
+
+/** Finds roots that read one of the configured direct child paths in a CEL expression. */
+export function extractCelContextPathRoots(params: {
+  source: string;
+  pathsByRoot: ReadonlyMap<string, readonly string[]>;
+}): string[] {
+  const roots = new Set<string>();
+  collectContextPathRoots(parseCel(params.source).ast, params.pathsByRoot, roots, new Map());
+  return [...roots].sort();
+}
+
+function collectContextPathRoots(
+  node: ASTNode,
+  pathsByRoot: ReadonlyMap<string, readonly string[]>,
+  roots: Set<string>,
+  aliases: ReadonlyMap<string, string>,
+): void {
+  if (binaryOperators.has(node.op as BinaryOperator) || node.op === '||' || node.op === '&&') {
+    collectBinaryContextPathRoots(node.args as [ASTNode, ASTNode], pathsByRoot, roots, aliases);
+    return;
+  }
+
+  switch (node.op) {
+    case 'id':
+    case 'value':
+      return;
+    case '.':
+    case '.?': {
+      const [target, field] = node.args as [ASTNode, string];
+      collectContextPathRoots(target, pathsByRoot, roots, aliases);
+      const root = rootName(target, aliases);
+      if (root !== undefined) {
+        if (pathsByRoot.get(root)?.includes(field)) roots.add(root);
+      } else {
+        // A call, collection, or conditional can hide a configured root. Treat
+        // that unresolved target as reachable so wrappers cannot bypass checks.
+        addUnresolvedTargetRoots(target, pathsByRoot, roots, aliases);
+      }
+      return;
+    }
+    case '[]':
+    case '[?]': {
+      const [target, key] = node.args as [ASTNode, ASTNode];
+      collectContextPathRoots(target, pathsByRoot, roots, aliases);
+      collectContextPathRoots(key, pathsByRoot, roots, aliases);
+      const root = rootName(target, aliases);
+      if (root === undefined) {
+        // The same conservative fallback applies to bracket access.
+        addUnresolvedTargetRoots(target, pathsByRoot, roots, aliases);
+        return;
+      }
+      if (!pathsByRoot.has(root)) return;
+
+      const field = literalFieldName(key);
+      if (field !== undefined) {
+        if (pathsByRoot.get(root)?.includes(field)) roots.add(root);
+        return;
+      }
+
+      if (!isAllowedListIndex(target, root, aliases)) roots.add(root);
+      return;
+    }
+    case 'call':
+      for (const argument of node.args[1]) {
+        collectContextPathRoots(argument, pathsByRoot, roots, aliases);
+      }
+      return;
+    case 'rcall': {
+      const [method, receiver, args] = node.args as [string, ASTNode, ASTNode[]];
+      collectContextPathRoots(receiver, pathsByRoot, roots, aliases);
+      const nextAliases = comprehensionAliases(method, receiver, args, aliases, pathsByRoot);
+      for (const argument of args) {
+        collectContextPathRoots(argument, pathsByRoot, roots, nextAliases);
+      }
+      return;
+    }
+    case 'list':
+      for (const element of node.args) {
+        collectContextPathRoots(element, pathsByRoot, roots, aliases);
+      }
+      return;
+    case 'map':
+      for (const [key, value] of node.args) {
+        collectContextPathRoots(key, pathsByRoot, roots, aliases);
+        collectContextPathRoots(value, pathsByRoot, roots, aliases);
+      }
+      return;
+    case '?:':
+      collectContextPathRoots(node.args[0], pathsByRoot, roots, aliases);
+      collectContextPathRoots(node.args[1], pathsByRoot, roots, aliases);
+      collectContextPathRoots(node.args[2], pathsByRoot, roots, aliases);
+      return;
+    case '!_':
+    case '-_':
+      collectContextPathRoots(node.args, pathsByRoot, roots, aliases);
+      return;
+  }
+
+  throw new Error(`Unsupported CEL AST operator: ${(node as {op: string}).op}`);
+}
+
+function collectBinaryContextPathRoots(
+  [left, right]: [ASTNode, ASTNode],
+  pathsByRoot: ReadonlyMap<string, readonly string[]>,
+  roots: Set<string>,
+  aliases: ReadonlyMap<string, string>,
+): void {
+  collectContextPathRoots(left, pathsByRoot, roots, aliases);
+  collectContextPathRoots(right, pathsByRoot, roots, aliases);
+}
+
+function rootName(node: ASTNode, aliases: ReadonlyMap<string, string>): string | undefined {
+  switch (node.op) {
+    case 'id':
+      return aliases.get(node.args) ?? node.args;
+    case '.':
+    case '.?':
+      return rootName(node.args[0], aliases);
+    case '[]':
+    case '[?]':
+      return rootName(node.args[0], aliases);
+    case 'rcall':
+      return rootName(node.args[1], aliases);
+    default:
+      return undefined;
+  }
+}
+
+function addUnresolvedTargetRoots(
+  target: ASTNode,
+  pathsByRoot: ReadonlyMap<string, readonly string[]>,
+  roots: Set<string>,
+  aliases: ReadonlyMap<string, string>,
+): void {
+  for (const root of configuredRoots(target, pathsByRoot, aliases)) roots.add(root);
+}
+
+function configuredRoots(
+  node: ASTNode,
+  pathsByRoot: ReadonlyMap<string, readonly string[]>,
+  aliases: ReadonlyMap<string, string>,
+): ReadonlySet<string> {
+  const roots = new Set<string>();
+  collectConfiguredRoots(node, pathsByRoot, roots, aliases);
+  return roots;
+}
+
+function collectConfiguredRoots(
+  node: ASTNode,
+  pathsByRoot: ReadonlyMap<string, readonly string[]>,
+  roots: Set<string>,
+  aliases: ReadonlyMap<string, string>,
+): void {
+  if (binaryOperators.has(node.op as BinaryOperator) || node.op === '||' || node.op === '&&') {
+    const [left, right] = node.args as [ASTNode, ASTNode];
+    collectConfiguredRoots(left, pathsByRoot, roots, aliases);
+    collectConfiguredRoots(right, pathsByRoot, roots, aliases);
+    return;
+  }
+
+  switch (node.op) {
+    case 'id': {
+      const root = aliases.get(node.args) ?? node.args;
+      if (pathsByRoot.has(root)) roots.add(root);
+      return;
+    }
+    case 'value':
+      return;
+    case '.':
+    case '.?':
+      collectConfiguredRoots(node.args[0], pathsByRoot, roots, aliases);
+      return;
+    case '[]':
+    case '[?]':
+      collectConfiguredRoots(node.args[0], pathsByRoot, roots, aliases);
+      collectConfiguredRoots(node.args[1], pathsByRoot, roots, aliases);
+      return;
+    case 'call':
+      for (const argument of node.args[1]) {
+        collectConfiguredRoots(argument, pathsByRoot, roots, aliases);
+      }
+      return;
+    case 'rcall': {
+      const [method, receiver, args] = node.args as [string, ASTNode, ASTNode[]];
+      collectConfiguredRoots(receiver, pathsByRoot, roots, aliases);
+      const nextAliases = comprehensionAliases(method, receiver, args, aliases, pathsByRoot);
+      for (const argument of args) {
+        collectConfiguredRoots(argument, pathsByRoot, roots, nextAliases);
+      }
+      return;
+    }
+    case 'list':
+      for (const element of node.args) {
+        collectConfiguredRoots(element, pathsByRoot, roots, aliases);
+      }
+      return;
+    case 'map':
+      for (const [key, value] of node.args) {
+        if (key.op !== 'id') collectConfiguredRoots(key, pathsByRoot, roots, aliases);
+        collectConfiguredRoots(value, pathsByRoot, roots, aliases);
+      }
+      return;
+    case '?:':
+      collectConfiguredRoots(node.args[0], pathsByRoot, roots, aliases);
+      collectConfiguredRoots(node.args[1], pathsByRoot, roots, aliases);
+      collectConfiguredRoots(node.args[2], pathsByRoot, roots, aliases);
+      return;
+    case '!_':
+    case '-_':
+      collectConfiguredRoots(node.args, pathsByRoot, roots, aliases);
+      return;
+  }
+
+  throw new Error(`Unsupported CEL AST operator: ${(node as {op: string}).op}`);
+}
+
+function literalFieldName(node: ASTNode): string | undefined {
+  return node.op === 'value' && typeof node.args === 'string' ? node.args : undefined;
+}
+
+function isAllowedListIndex(
+  target: ASTNode,
+  root: string,
+  aliases: ReadonlyMap<string, string>,
+): boolean {
+  return root === 'executions' && target.op === 'id' && aliases.get(target.args) === undefined;
+}
+
+function comprehensionAliases(
+  method: string,
+  receiver: ASTNode,
+  args: readonly ASTNode[],
+  aliases: ReadonlyMap<string, string>,
+  pathsByRoot: ReadonlyMap<string, readonly string[]>,
+): ReadonlyMap<string, string> {
+  const [alias] = args;
+  if (alias?.op !== 'id') return aliases;
+
+  const source = method === 'bind' ? args[1] : receiver;
+  if (source === undefined) return aliases;
+
+  if (method !== 'bind' && !comprehensionMethods.has(method)) return aliases;
+
+  const root = configuredRoot(source, pathsByRoot, aliases);
+  if (root === undefined) return aliases;
+
+  return new Map([...aliases, [alias.args, root]]);
+}
+
+function configuredRoot(
+  node: ASTNode,
+  pathsByRoot: ReadonlyMap<string, readonly string[]>,
+  aliases: ReadonlyMap<string, string>,
+): string | undefined {
+  const root = rootName(node, aliases);
+  if (root !== undefined && pathsByRoot.has(root)) return root;
+
+  const roots = configuredRoots(node, pathsByRoot, aliases);
+  return roots.size === 1 ? [...roots][0] : undefined;
+}


### PR DESCRIPTION
Dynamic runner labels and agent model/provider selectors are now limited to approved workflow and configuration contexts. Event, input, listening-event, and output data are rejected, including through wrapped CEL expressions and comprehension aliases.

The validation error identifies the affected selector and rejected contexts. The changeset documents the breaking validation behavior and the `vars`/`secrets` remediation path.

Validation: `turbo check`, `turbo type`, `turbo test`, and `turbo depcruise` for `@shipfox/api-definitions` and `@shipfox/expression`, plus `git diff --check`.

Closes ENG-1455

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores restrictions on dynamic infrastructure selectors so `job.runner`, `agent.model`, and `agent.provider` only use approved workflow/config context. Also treats `execution.outputs` and `executions[*].outputs` as external and blocks them. Addresses ENG-1455.

- **New Features**
  - Enforces trusted context for `job.runner`, `agent.model`, and `agent.provider`; blocks `event`, `inputs`, `execution.events`, `executions.events`, `execution.outputs`, `executions.outputs`, `steps.outputs`, and `step.outputs` in interpolations (including wrapped CEL paths and comprehension aliases).
  - Adds `extractCelContextPathRoots` to `@shipfox/expression` to detect configured child path access in CEL.
  - Introduces `untrusted-infrastructure-selection-context` validation with field, path, and rejected roots details.

- **Migration**
  - Workflows sourcing runner labels, model, or provider from event/input/output data (including execution outputs) now fail validation. Bind dynamic selectors through `vars` or `secrets`.

<sup>Written for commit 6ccdf7295ca1f28d9cd4b052899d6169a811cbd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

