### PR TITLE
[client-workflows] Display workflow run numbers in run history

### DIFF
--- a/.changeset/readable-run-numbers.md
+++ b/.changeset/readable-run-numbers.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-workflows": major
+---
+
+Displays workflow run numbers beside their workflow names and removes the ambiguous UUID short-id label.

--- a/.changeset/readable-run-numbers.md
+++ b/.changeset/readable-run-numbers.md
@@ -2,4 +2,4 @@
 "@shipfox/client-workflows": major
 ---
 
-Displays workflow run numbers beside their workflow names and removes the ambiguous UUID short-id label.
+Replaces the exported workflow-run UUID short-id with API-provided workflow names and run numbers in client workflow metadata.

--- a/libs/client/workflows/src/components/workflow-run-list/run-display.test.ts
+++ b/libs/client/workflows/src/components/workflow-run-list/run-display.test.ts
@@ -8,9 +8,10 @@ describe('runMatchesSearch', () => {
     expect(matches).toBe(true);
   });
 
-  test('matches case-insensitively across id, name, status, and trigger', () => {
+  test('matches case-insensitively across id, name, status, trigger, and number', () => {
     const run = workflowRunListItem({
       id: 'ABCD1234-X',
+      number: 5184,
       name: 'Deploy Production',
       status: 'running',
       trigger_provider: 'github',
@@ -22,6 +23,16 @@ describe('runMatchesSearch', () => {
     expect(runMatchesSearch(run, 'deploy production')).toBe(true);
     expect(runMatchesSearch(run, 'RUNNING')).toBe(true);
     expect(runMatchesSearch(run, 'github_acme · push')).toBe(true);
+    expect(runMatchesSearch(run, '5184')).toBe(true);
+  });
+
+  test('matches the workflow name even when the run has a different display name', () => {
+    const run = workflowRunListItem({
+      name: 'Deploy to production',
+      workflow_name: 'CI',
+    });
+
+    expect(runMatchesSearch(run, 'CI')).toBe(true);
   });
 
   test('returns false when nothing in the run contains the query', () => {

--- a/libs/client/workflows/src/components/workflow-run-list/run-display.ts
+++ b/libs/client/workflows/src/components/workflow-run-list/run-display.ts
@@ -4,7 +4,17 @@ import type {WorkflowRunListStatusFilter} from './types.js';
 export function runMatchesSearch(run: WorkflowRunListItem, query: string): boolean {
   const needle = query.trim().toLowerCase();
   if (needle === '') return true;
-  const haystack = `${run.id} ${run.name} ${run.status} ${run.triggerLabel}`.toLowerCase();
+  const haystack = [
+    run.id,
+    run.name,
+    run.workflowName,
+    run.status,
+    run.triggerLabel,
+    run.number?.toString(),
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
   return haystack.includes(needle);
 }
 

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-header.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-header.tsx
@@ -27,7 +27,7 @@ export function WorkflowRunListHeader({
       <Input
         value={query}
         onChange={(event) => onQueryChange(event.target.value)}
-        placeholder="Run id or trigger..."
+        placeholder="Run id, number, or trigger..."
         aria-label="Search runs"
         size="small"
         iconLeft={<Icon name="searchLine" className="size-14 text-foreground-neutral-muted" />}

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-view.test.tsx
@@ -58,7 +58,11 @@ describe('WorkflowRunListView', () => {
   });
 
   test('renders optimistic temp runs without a navigable link', async () => {
-    renderListView([run('pending', 'queued-build', 'temp-1234'), run('running', 'deploy-web')]);
+    const optimisticRun = {
+      ...run('pending', 'queued-build', 'temp-1234', {workflow_name: 'CI'}),
+      number: null,
+    };
+    renderListView([optimisticRun, run('running', 'deploy-web')]);
 
     // The canonical run is a link to its detail page; the optimistic temp run is shown but
     // not yet navigable (its detail page does not exist until the canonical row replaces it).
@@ -66,6 +70,7 @@ describe('WorkflowRunListView', () => {
     expect(links.some((link) => link.textContent?.includes('deploy-web'))).toBe(true);
     expect(links.some((link) => link.textContent?.includes('queued-build'))).toBe(false);
     expect(screen.getByText('queued-build')).toBeInTheDocument();
+    expect(screen.queryByText('CI #1')).not.toBeInTheDocument();
   });
 
   test('shows a finished run duration in the row metadata', async () => {
@@ -84,6 +89,31 @@ describe('WorkflowRunListView', () => {
         name: (name) => name.includes('build-image') && name.includes('ran 2m 14s'),
       }),
     ).toBeInTheDocument();
+  });
+
+  test('renders the workflow name beside the run number', async () => {
+    renderListView([
+      run('succeeded', 'Deploy production', 'run-deploy-production', {
+        number: 5184,
+        workflow_name: 'CI',
+      }),
+    ]);
+
+    expect(await screen.findByText('CI #5184')).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', {name: (name) => name.includes('CI #5184')}),
+    ).toBeInTheDocument();
+  });
+
+  test('omits the run number while an optimistic run is waiting for the server', async () => {
+    const optimisticRun = {
+      ...run('pending', 'queued-build', 'temp-1234', {workflow_name: 'CI'}),
+      number: null,
+    };
+    renderListView([optimisticRun]);
+
+    expect(await screen.findByText('queued-build')).toBeInTheDocument();
+    expect(screen.queryByText('CI #1')).not.toBeInTheDocument();
   });
 
   test('shows a live running run duration in the row metadata', async () => {

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-row.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-row.tsx
@@ -8,6 +8,10 @@ import {
   useWorkflowRunDurationAccessibleLabel,
   WorkflowRunDurationLabel,
 } from '#components/workflow-run-duration-label.js';
+import {
+  formatWorkflowRunNumberLabel,
+  WorkflowRunNumberLabel,
+} from '#components/workflow-run-number-label.js';
 import {getWorkflowStatusVisual} from '#components/workflow-status/status-visuals.js';
 import {WorkflowStatusIcon} from '#components/workflow-status/workflow-status-icon.js';
 import type {WorkflowRunListItem} from '#core/workflow-run.js';
@@ -55,6 +59,7 @@ export function WorkflowRunRow({
 }) {
   const durationLabel = useWorkflowRunDurationAccessibleLabel(run.runAttempt.displayDuration);
   const statusLabel = getWorkflowStatusVisual(run.status).label;
+  const runNumberLabel = formatWorkflowRunNumberLabel(run);
   const body = (
     <>
       {selected ? (
@@ -72,6 +77,12 @@ export function WorkflowRunRow({
       </div>
 
       <div className="flex min-w-0 items-center gap-8">
+        {run.number !== null ? (
+          <>
+            <WorkflowRunNumberLabel run={run} />
+            {run.triggerDisplayLabel ? <RunMetadataSeparator /> : null}
+          </>
+        ) : null}
         {run.triggerDisplayLabel ? (
           <TriggerLabel run={run} />
         ) : (
@@ -114,7 +125,7 @@ export function WorkflowRunRow({
           withoutWorkflowRunSelectionSearch(previous)) as never
       }
       aria-current={selected ? 'page' : undefined}
-      aria-label={[run.name, statusLabel, durationLabel, run.triggerLabel]
+      aria-label={[run.name, runNumberLabel, statusLabel, durationLabel, run.triggerLabel]
         .filter((part): part is string => Boolean(part))
         .join(', ')}
       className={cn(

--- a/libs/client/workflows/src/components/workflow-run-number-label.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-number-label.test.tsx
@@ -1,0 +1,28 @@
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {formatWorkflowRunNumberLabel, WorkflowRunNumberLabel} from './workflow-run-number-label.js';
+
+describe('WorkflowRunNumberLabel', () => {
+  test('formats the workflow name and run number together', () => {
+    expect(formatWorkflowRunNumberLabel({workflowName: 'CI', number: 5184})).toBe('CI #5184');
+  });
+
+  test('does not render before a server run number is available', () => {
+    const {container} = render(<WorkflowRunNumberLabel run={{workflowName: 'CI', number: null}} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  test('provides a tooltip for long workflow labels', async () => {
+    const user = userEvent.setup();
+    const label = 'release-production-multi-region-with-canary-and-smoke-tests #5184';
+    render(<WorkflowRunNumberLabel run={{workflowName: label.slice(0, -6), number: 5184}} />);
+
+    const visibleLabel = screen.getByText(label);
+    expect(visibleLabel).toHaveClass('max-w-[240px]', 'truncate');
+
+    await user.hover(visibleLabel);
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(label);
+  });
+});

--- a/libs/client/workflows/src/components/workflow-run-number-label.tsx
+++ b/libs/client/workflows/src/components/workflow-run-number-label.tsx
@@ -1,0 +1,36 @@
+import {Tooltip, TooltipContent, TooltipTrigger} from '@shipfox/react-ui/tooltip';
+import {Code} from '@shipfox/react-ui/typography';
+import type {WorkflowRun} from '#core/workflow-run.js';
+
+type WorkflowRunNumberLabelRun = Pick<WorkflowRun, 'number' | 'workflowName'>;
+
+export function formatWorkflowRunNumberLabel({
+  number,
+  workflowName,
+}: WorkflowRunNumberLabelRun): string | undefined {
+  return number === null ? undefined : `${workflowName} #${number}`;
+}
+
+export function WorkflowRunNumberLabel({run}: {run: WorkflowRunNumberLabelRun}) {
+  const label = formatWorkflowRunNumberLabel(run);
+  if (label === undefined) return null;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Code
+          as="span"
+          variant="label"
+          className="min-w-0 max-w-[240px] truncate text-foreground-neutral-muted"
+        >
+          {label}
+        </Code>
+      </TooltipTrigger>
+      <TooltipContent>
+        <Code as="span" variant="label" className="block max-w-[360px] break-words">
+          {label}
+        </Code>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
@@ -56,6 +56,21 @@ describe('WorkflowRunSummary', () => {
     expect(within(summary).queryByText('CI #1')).not.toBeInTheDocument();
   });
 
+  test('separates a standalone run number from the run timestamp', async () => {
+    const run = workflowRunDetail({
+      workflow_name: 'CI',
+      trigger_source: '',
+      trigger_event: '',
+    });
+    render(<WorkflowRunSummary run={run} />);
+
+    const summary = await screen.findByRole('region', {name: 'deploy-web'});
+
+    expect(within(summary).getByText('CI #1')).toBeInTheDocument();
+    const timestamp = within(summary).getByText(RELATIVE_TIME_TEXT_PATTERN);
+    expect(timestamp.previousElementSibling).toHaveAttribute('aria-hidden', 'true');
+  });
+
   test('uses the selected run attempt for summary status and trigger time', async () => {
     const rootCreatedAt = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
     const attemptCreatedAt = new Date(Date.now() - 5 * 60 * 1000).toISOString();

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
@@ -29,13 +29,14 @@ describe('WorkflowRunSummary', () => {
     restoreElementWidthDescriptors();
   });
 
-  test('renders status, trigger metadata, and trigger time', async () => {
-    renderSummary();
+  test('renders status, run number, trigger metadata, and trigger time', async () => {
+    renderSummary({workflow_name: 'CI', number: 5184});
 
     const summary = await screen.findByRole('region', {name: 'deploy-web'});
 
     expect(within(summary).getByRole('heading', {name: 'deploy-web'})).toBeInTheDocument();
     expect(within(summary).getAllByText('Running')).not.toHaveLength(0);
+    expect(within(summary).getByText('CI #5184')).toBeInTheDocument();
     expect(within(summary).getByText('fire')).toBeInTheDocument();
     expect(within(summary).queryByText('manual')).not.toBeInTheDocument();
     expect(within(summary).getByText(RELATIVE_TIME_TEXT_PATTERN)).toBeInTheDocument();
@@ -44,6 +45,15 @@ describe('WorkflowRunSummary', () => {
     expect(
       within(summary).queryByRole('button', {name: COPY_RUN_BUTTON_NAME}),
     ).not.toBeInTheDocument();
+  });
+
+  test('omits the run number before the server assigns one', async () => {
+    const run = {...workflowRunDetail({workflow_name: 'CI'}), number: null};
+    render(<WorkflowRunSummary run={run} />);
+
+    const summary = await screen.findByRole('region', {name: 'deploy-web'});
+
+    expect(within(summary).queryByText('CI #1')).not.toBeInTheDocument();
   });
 
   test('uses the selected run attempt for summary status and trigger time', async () => {

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
@@ -182,7 +182,9 @@ export function WorkflowRunSummary({
               </>
             ) : null}
 
-            {attemptSwitcher || run.triggerDisplayLabel ? <MetadataSeparator /> : null}
+            {run.number !== null || attemptSwitcher || run.triggerDisplayLabel ? (
+              <MetadataSeparator />
+            ) : null}
             <RelativeTime
               value={run.runAttempt.createdAt}
               className="shrink-0 whitespace-nowrap text-xs leading-20 text-foreground-neutral-muted"

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
@@ -14,6 +14,7 @@ import {Tooltip, TooltipContent, TooltipTrigger} from '@shipfox/react-ui/tooltip
 import {Header, Text} from '@shipfox/react-ui/typography';
 import type {Ref} from 'react';
 import {useId} from 'react';
+import {WorkflowRunNumberLabel} from '#components/workflow-run-number-label.js';
 import {
   isWorkflowRunTerminal,
   type Job,
@@ -133,6 +134,13 @@ export function WorkflowRunSummary({
           </div>
 
           <div className="col-span-2 row-start-2 flex min-w-0 items-center gap-12 overflow-hidden text-foreground-neutral-muted">
+            {run.number !== null ? (
+              <>
+                <WorkflowRunNumberLabel run={run} />
+                {attemptSwitcher || run.triggerDisplayLabel ? <MetadataSeparator /> : null}
+              </>
+            ) : null}
+
             {attemptSwitcher ? (
               <WorkflowRunAttemptSwitcher
                 workspaceId={attemptSwitcher.workspaceId}

--- a/libs/client/workflows/src/core/entities/workflow-run.ts
+++ b/libs/client/workflows/src/core/entities/workflow-run.ts
@@ -35,7 +35,9 @@ export interface WorkflowRun {
   id: string;
   projectId: string;
   definitionId: string;
+  number: number | null;
   name: string;
+  workflowName: string;
   currentAttempt: number;
   triggerProvider: string | null;
   triggerSource: string;
@@ -47,7 +49,6 @@ export interface WorkflowRun {
   sourceSnapshot: WorkflowSourceSnapshot | null;
   createdAt: string;
   updatedAt: string;
-  shortId: string;
   isTemporary: boolean;
 }
 
@@ -71,10 +72,6 @@ export interface WorkflowRunListPage {
 
 export interface ManualWorkflowLaunch {
   workflowRunId: string;
-}
-
-export function workflowRunShortId(id: string): string {
-  return id.length <= 8 ? id : id.slice(0, 8);
 }
 
 export function workflowRunTriggerLabel({

--- a/libs/client/workflows/src/core/workflow-run.test.ts
+++ b/libs/client/workflows/src/core/workflow-run.test.ts
@@ -18,7 +18,6 @@ import {
 import {
   isWorkflowRunTerminal,
   isWorkflowStatus,
-  workflowRunShortId,
   workflowRunTriggerDisplayLabel,
   workflowRunTriggerLabel,
 } from './workflow-run.js';
@@ -51,7 +50,9 @@ describe('workflow run model mapping', () => {
       id: '66666666-6666-4666-8666-666666666666',
       projectId: '44444444-4444-4444-8444-444444444444',
       definitionId: '55555555-5555-4555-8555-555555555555',
+      number: 1,
       name: 'deploy-web',
+      workflowName: 'deploy-web',
       currentAttempt: 3,
       triggerProvider: 'github',
       triggerSource: 'github_acme',
@@ -63,7 +64,6 @@ describe('workflow run model mapping', () => {
       sourceSnapshot: {format: 'yaml', content: 'jobs: {}'},
       createdAt: '2026-05-07T01:01:00.000Z',
       updatedAt: '2026-05-07T01:02:00.000Z',
-      shortId: '66666666',
       isTemporary: false,
     });
     expect(run).not.toHaveProperty('status');
@@ -91,7 +91,6 @@ describe('workflow run model mapping', () => {
       triggerLabel: '',
       inputs: null,
       sourceSnapshot: null,
-      shortId: 'temp-123',
       isTemporary: true,
     });
   });
@@ -628,12 +627,7 @@ describe('workflow run helpers', () => {
     expect(neither).toBe('');
   });
 
-  test('formats short ids and classifies workflow statuses', () => {
-    const short = workflowRunShortId('abc123');
-    const long = workflowRunShortId('66666666-6666-4666-8666-666666666666');
-
-    expect(short).toBe('abc123');
-    expect(long).toBe('66666666');
+  test('classifies workflow statuses', () => {
     expect(isWorkflowRunTerminal('succeeded')).toBe(true);
     expect(isWorkflowRunTerminal('running')).toBe(false);
     expect(isWorkflowStatus('pending')).toBe(true);

--- a/libs/client/workflows/src/core/workflow-run.ts
+++ b/libs/client/workflows/src/core/workflow-run.ts
@@ -61,7 +61,6 @@ export {
   isWorkflowStatus,
   TERMINAL_WORKFLOW_RUN_STATUSES,
   WORKFLOW_RUN_STATUSES,
-  workflowRunShortId,
   workflowRunTriggerDisplayLabel,
   workflowRunTriggerLabel,
 } from './entities/workflow-run.js';

--- a/libs/client/workflows/src/hooks/api/workflow-run-mapper.ts
+++ b/libs/client/workflows/src/hooks/api/workflow-run-mapper.ts
@@ -25,7 +25,6 @@ import {
   type WorkflowRunDetail,
   type WorkflowRunListItem,
   type WorkflowRunListPage,
-  workflowRunShortId,
   workflowRunTriggerDisplayLabel,
   workflowRunTriggerLabel,
 } from '#core/workflow-run.js';
@@ -35,7 +34,9 @@ export function toWorkflowRun(dto: WorkflowRunResponseDto): WorkflowRun {
     id: dto.id,
     projectId: dto.project_id,
     definitionId: dto.definition_id,
+    number: dto.number,
     name: dto.name,
+    workflowName: dto.workflow_name,
     currentAttempt: dto.current_attempt,
     triggerProvider: dto.trigger_provider,
     triggerSource: dto.trigger_source,
@@ -55,7 +56,6 @@ export function toWorkflowRun(dto: WorkflowRunResponseDto): WorkflowRun {
       : null,
     createdAt: dto.created_at,
     updatedAt: dto.updated_at,
-    shortId: workflowRunShortId(dto.id),
     isTemporary: dto.id.startsWith('temp-'),
   };
 }

--- a/libs/client/workflows/src/hooks/api/workflow-runs.test.tsx
+++ b/libs/client/workflows/src/hooks/api/workflow-runs.test.tsx
@@ -240,6 +240,8 @@ describe('workflow run API hooks', () => {
       expect(cached?.pages[0]?.runs[0]).toMatchObject({
         projectId: PROJECT_ID,
         definitionId: DEFINITION_ID,
+        number: null,
+        workflowName: 'New run',
         status: 'pending',
         triggerSource: 'manual',
         triggerProvider: null,

--- a/libs/client/workflows/src/hooks/api/workflow-runs.ts
+++ b/libs/client/workflows/src/hooks/api/workflow-runs.ts
@@ -338,7 +338,9 @@ function buildTempRun({
     id,
     projectId,
     definitionId,
+    number: null,
     name,
+    workflowName: name,
     status: 'pending',
     currentAttempt: 1,
     latestAttempt: 1,
@@ -352,7 +354,6 @@ function buildTempRun({
     sourceSnapshot: null,
     createdAt,
     updatedAt: createdAt,
-    shortId: id.slice(0, 8),
     isTemporary: true,
     runAttempt: new WorkflowRunAttemptSummary({
       workflowRunId: id,

--- a/libs/client/workflows/src/index.ts
+++ b/libs/client/workflows/src/index.ts
@@ -34,7 +34,6 @@ export {
   JobExecution,
   TERMINAL_WORKFLOW_RUN_STATUSES,
   WORKFLOW_RUN_STATUSES,
-  workflowRunShortId,
   workflowRunTriggerLabel,
 } from '#core/workflow-run.js';
 export {


### PR DESCRIPTION
Replaces ambiguous UUID short IDs in client workflow run history with the API-provided workflow name and run number.

The number is display-only and remains scoped per workflow definition; URL identity continues to use the workflow run ID. Optimistic manual runs remain numberless until the canonical server response arrives.

Validation: 324 client-workflows tests; affected check, type, and build tasks passed.

Closes ENG-1451

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Display workflow run numbers beside workflow names in the client run list and summary, replacing ambiguous UUID short IDs. Addresses ENG-1451; URLs still use the run ID, and optimistic runs omit numbers until the server responds.

- New Features
  - Show labels like “CI #5184” via a new `WorkflowRunNumberLabel` with tooltip for long names.
  - Search now matches workflow name and run number.
  - ARIA row labels include the run number for better accessibility.
  - List search placeholder updated to “Run id, number, or trigger...”.
  - Keep a separator between a standalone run number and the timestamp in the run summary.

- Migration
  - Breaking: In `@shipfox/client-workflows`, remove usage of `WorkflowRun.shortId` and `workflowRunShortId`; use `workflowName` and `number` instead.
  - `WorkflowRun` now has `number: number | null` and `workflowName: string`; `number` is `null` for optimistic runs.

<sup>Written for commit 5e03be957ecab21ce9eacb31c8315593fb809d79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

