### PR TITLE
Document provisioner template families

### DIFF
--- a/apps/docs/content/docs/operations/runner-provisioners.mdx
+++ b/apps/docs/content/docs/operations/runner-provisioners.mdx
@@ -69,24 +69,62 @@ keeps a small prewarmed pool.
 ## Templates
 
 A **template** maps a label set to the container that provides it. Templates live in
-a YAML file the provisioner loads at startup:
+a YAML file the provisioner loads at startup. A file can share lookup data through
+`vars`, apply a fragment through `defaults`, keep genuine one-offs under `templates:`,
+and generate variants through independent `matrix` families.
 
 ```yaml
+defaults:
+  target_concurrency: 0
+
 templates:
-  docker-ubuntu22-2vcpu:
-    labels: [ubuntu22, ubuntu22-2vcpu]   # labels the started runner registers with
-    image: shipfox-runner:ubuntu22       # container image to start
-    cpu: 2
-    memory: 4GiB
-    max_concurrency: 100
-    target_concurrency: 0
+  docker-local-debug:
+    labels: [docker, local-debug]
+    cpu: 1
+    memory: 2GiB
+    max_concurrency: 2
+    cost: 1
+
+matrix:
+  general:
+    axes:
+      os: [ubuntu22, ubuntu24]
+      cpu: [2, 4]
+    template:
+      labels: [docker, "${{ os }}", "${{ cpu }}vcpu"]
+      image: "ghcr.io/shipfoxhq/runner:${{ os }}"
+      cpu: "${{ cpu }}"
+      memory: "${{ cpu * 2.0 }}GiB"
+      max_concurrency: 50
+      cost: "${{ cpu }}"
+
+  gpu:
+    axes:
+      cuda: [cuda12, cuda13]
+      memory: [16g, 32g]
+    template:
+      labels: [docker, gpu, "${{ cuda }}", "${{ memory }}"]
+      image: "ghcr.io/shipfoxhq/runner:${{ cuda }}"
+      cpu: 8
+      memory: "${{ memory }}"
+      max_concurrency: 10
+      cost: 20
 ```
 
-When several templates satisfy a job's labels, the provisioner chooses the one
-with the lowest `cost`. If `cost` is omitted, the template's CPU count is used.
-A specificity rule breaks a tie. The full template schema and every environment
-variable are in the
+The two matrix blocks are independent families. Add another hardware class by adding
+another block with its own axes; do not add unrelated axes to the general fleet.
+Labels may overlap across families. Matching is subset-based, and the lowest `cost`
+wins when several templates can serve a job. A hand-written entry whose key matches a
+generated key shadows that generated variant and is the per-variant override idiom.
+
+`defaults` is a deep merge for maps, but lists and scalars replace wholesale. If a
+family needs a different subnet list or security-group list, set the full list in that
+family. The full template schema and every environment variable are in the
 [Runner Provisioner reference](/reference/runner-provisioner).
+
+Docker template files use strict schemas. Unknown top-level or template keys that may
+have been silently ignored before now fail with a file-scoped error, so remove them
+when upgrading an existing file.
 
 ## Related pages
 

--- a/apps/docs/content/docs/reference/runner-provisioner.mdx
+++ b/apps/docs/content/docs/reference/runner-provisioner.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Runner Provisioner Configuration Reference"
 sidebarTitle: "Runner Provisioner"
-description: "Every Shipfox runner provisioner environment variable with its default, plus the runner template file schema: labels, image, cpu, memory, cost, and max_concurrency."
+description: "Every Shipfox runner provisioner environment variable with its default, plus the runner template file schema: vars, defaults, matrix families, labels, image, cpu, memory, cost, and max_concurrency."
 ---
 
 This page is the canonical reference for configuring the Docker runner provisioner (`@shipfox/provisioner-docker`). For how a provisioner works, see [Runner Provisioners](/operations/runner-provisioners); for starting one, see [Run a provisioner](/installation/runner-provisioner).
@@ -94,29 +94,106 @@ container output.
 
 ## Template file schema
 
-The templates file maps label sets to the containers that provide them:
+The templates file can contain shared lookup data, a default fragment, hand-written
+one-offs, and any number of independent matrix families. This is a complete Docker
+example with a general fleet, a separate GPU family, and one hand-written template:
 
 ```yaml
+vars:
+  image_by_os:
+    ubuntu22: ghcr.io/shipfoxhq/runner:ubuntu22
+    ubuntu24: ghcr.io/shipfoxhq/runner:ubuntu24
+
+defaults:
+  labels: [docker]
+  target_concurrency: 0
+
 templates:
-  docker-ubuntu22-2vcpu:
-    labels: [ubuntu22, ubuntu22-2vcpu]
-    image: shipfox-runner:ubuntu22
-    cpu: 2
-    memory: 4GiB
-    max_concurrency: 100
+  docker-local-debug:
+    labels: [docker, local-debug]
+    image: ghcr.io/shipfoxhq/runner:debug
+    cpu: 1
+    memory: 2GiB
+    max_concurrency: 2
+    cost: 1
+
+matrix:
+  general:
+    axes:
+      os: [ubuntu22, ubuntu24]
+      cpu: [2, 4]
+    template:
+      labels: [docker, "${{ os }}", "${{ cpu }}vcpu"]
+      image: "${{ vars.image_by_os[os] }}"
+      cpu: "${{ cpu }}"
+      memory: "${{ cpu * 2.0 }}GiB"
+      max_concurrency: 50
+      cost: "${{ cpu }}"
+
+  gpu:
+    axes:
+      cuda: [cuda12, cuda13]
+      memory: [16g, 32g]
+    template:
+      labels: [docker, gpu, "${{ cuda }}", "${{ memory }}"]
+      image: "ghcr.io/shipfoxhq/runner:${{ cuda }}"
+      cpu: 8
+      memory: "${{ memory }}"
+      max_concurrency: 10
+      cost: 20
 ```
+
+The checked-in Docker and EC2 files at `apps/provisioner-docker/templates.example.yaml`
+and `apps/provisioner-ec2/templates.example.yaml` use the same shape. Copy one, replace
+the placeholder images, AMI IDs, subnets, and security groups, then point
+`SHIPFOX_PROVISIONER_TEMPLATES_FILE` at the copy.
+
+| Top-level key | Type | Description |
+| --- | --- | --- |
+| `vars` | map | Shared lookup data available to every family. EC2 operators use it for their own AMI and instance-type maps. |
+| `defaults` | map | A fragment merged under every hand-written and generated template. Maps merge recursively; lists and scalars replace wholesale. |
+| `templates` | map | Hand-written entries for genuine one-offs or per-variant overrides. A hand-written key shadows a generated key and emits a warning. |
+| `matrix` | map | Independent named families. Each family has its own axes and produces its own generated keys. |
+
+### Matrix families
+
+| Key | Type | Description |
+| --- | --- | --- |
+| `axes` | map | Named axes whose values are crossed. An axis can be a list or an expression that returns a list. The default key includes every axis in declaration order. |
+| `exclude` | map list | Partial bindings to remove from the cartesian product. |
+| `include` | map list | Complete bindings to append as extra variants. Every declared axis must be present. |
+| `let` | map | Per-variant expressions evaluated in declaration order. Each binding can use axes, `vars`, and earlier bindings. |
+| `key` | expression | Optional explicit key. Use it only when opting out of the default key guarantee. |
+| `template` | map | Provider-specific template fields rendered for each variant. |
+
+Families are independent. Adding a GPU pool means adding a `gpu` block with GPU
+axes; it does not mean adding GPU axes to the general fleet. Labels may overlap across
+families. Matching is subset-based, and the lowest `cost` wins when several templates
+can serve the same job, followed by specificity.
+
+Defaults do not append lists. If `defaults.subnets` contains two general subnets and
+a GPU family sets `subnets: [subnet-gpu]`, the GPU template has only `subnet-gpu`.
+Use a block override whenever a family needs a different list or scalar.
+
+The provider validates every rendered template with a strict schema. For Docker,
+unknown top-level or template keys now fail with a file-scoped error. This is a
+breaking upgrade for existing Docker files that relied on mistyped keys being ignored;
+remove those keys before upgrading. The optional Docker `cost` field defaults to `cpu`.
 
 | Field | Type | Description |
 | --- | --- | --- |
 | `labels` | `string[]` | Labels the started runner registers with. A template can serve any job whose required labels are all in this list. |
-| `image` | `string` | Container image to start. |
-| `cpu` | `number` | vCPUs allocated to the container. The default selection cost when `cost` is omitted. |
+| `image` | `string` | Optional container image to start. Defaults to `ghcr.io/shipfoxhq/runner:latest`. |
+| `cpu` | `number` | vCPUs allocated to the container. The default Docker selection cost when `cost` is omitted. |
 | `memory` | `string` | Memory allocation, such as `4GiB`. |
 | `max_concurrency` | `number` | Cap on live containers started from this template. |
 | `target_concurrency` | `number` | Enrolled, unassigned runners to keep ready without demand. Defaults to `0`. Keep it at or below `max_concurrency`: the provisioner does not currently reject a template where it is higher. |
-| `cost` | `number` | Optional positive selection cost. Lower costs are preferred when several templates satisfy the same labels. Defaults to `cpu`. |
+| `cost` | `number` | Positive selection cost. Lower costs are preferred when several templates satisfy the same labels. Docker defaults it to `cpu`. |
 
-**Template selection:** when several templates satisfy a job's labels, the provisioner picks the lowest `cost` (or `cpu` when `cost` is omitted), then the most specific. The file and each template use strict schemas, so unknown keys fail with a file-scoped validation error.
+**Template selection:** when several templates satisfy a job's labels, the provisioner
+picks the lowest `cost` (or `cpu` for Docker when `cost` is omitted), then the most
+specific. Use a hand-written entry under `templates:` to override one generated key;
+the hand-written value wins and the loader logs the shadowed variant.
 
 ## Related pages
 

--- a/apps/docs/content/docs/reference/runner-provisioner.mdx
+++ b/apps/docs/content/docs/reference/runner-provisioner.mdx
@@ -163,7 +163,7 @@ the placeholder images, AMI IDs, subnets, and security groups, then point
 | `exclude` | map list | Partial bindings to remove from the cartesian product. |
 | `include` | map list | Complete bindings to append as extra variants. Every declared axis must be present. |
 | `let` | map | Per-variant expressions evaluated in declaration order. Each binding can use axes, `vars`, and earlier bindings. |
-| `key` | expression | Optional explicit key. Use it only when opting out of the default key guarantee. |
+| `key` | expression | Optional explicit key. Without one, the loader builds a key from the family name and each axis value (or object axis `name`) in declaration order, joining parts with hyphens and escaping separators inside values; generated keys must be unique within the file. Use an explicit key only when you need a different naming scheme. |
 | `template` | map | Provider-specific template fields rendered for each variant. |
 
 Families are independent. Adding a GPU pool means adding a `gpu` block with GPU

--- a/apps/provisioner-docker/README.md
+++ b/apps/provisioner-docker/README.md
@@ -60,6 +60,20 @@ until observation succeeds.
 | `SHIPFOX_PROVISIONER_RUNNER_INSTANCE_BATCH_SIZE` | no | `250` | Runner instances created per request (1–1000). |
 | `SHIPFOX_RUNNER_POLL_MAX_DURATION_MS` | no | `300000` | Injected into each runner as `SHIPFOX_POLL_MAX_DURATION_MS`. |
 
+## Template file
+
+Copy [`templates.example.yaml`](templates.example.yaml) and point
+`SHIPFOX_PROVISIONER_TEMPLATES_FILE` at the copy. The example has independent
+`general` and `gpu` matrix families plus one hand-written local-debug template.
+Use a new matrix block for another hardware class instead of adding unrelated axes
+to an existing family.
+
+`defaults` maps merge recursively, while lists and scalars replace wholesale. Labels
+may overlap across families; when multiple templates match, lower `cost` wins before
+specificity. A hand-written entry under `templates:` shadows a generated key and is
+the per-variant override idiom. The provider rejects unknown file and template keys,
+so remove mistyped keys before upgrading an older Docker template file.
+
 ## Runner image
 
 When a template omits `image`, the provisioner uses the published

--- a/apps/provisioner-docker/templates.example.yaml
+++ b/apps/provisioner-docker/templates.example.yaml
@@ -1,18 +1,42 @@
 # Example Docker runner templates for local development.
 # Point SHIPFOX_PROVISIONER_TEMPLATES_FILE at a copy of this file and edit to taste.
-# Each template advertises runner labels and the maximum concurrent containers this
-# provisioner may manage for that template.
-templates:
-  docker-ubuntu22-2vcpu:
-    labels: [ubuntu22, ubuntu22-2vcpu]
-    cpu: 2
-    memory: 4GiB
-    max_concurrency: 100
-    target_concurrency: 0
+# A matrix block is one independent family. Add hardware by adding a family, not by
+# growing one cross-product with unrelated axes.
+defaults:
+  labels: [docker]
+  target_concurrency: 0
 
-  docker-ubuntu22-4vcpu:
-    labels: [ubuntu22, ubuntu22-4vcpu]
-    cpu: 4
-    memory: 8GiB
-    max_concurrency: 50
-    target_concurrency: 0
+# Keep templates: for a genuine one-off. It is not part of either family below.
+templates:
+  docker-local-debug:
+    labels: [docker, local-debug]
+    image: ghcr.io/shipfoxhq/runner:debug
+    cpu: 1
+    memory: 2GiB
+    max_concurrency: 2
+    cost: 1
+
+matrix:
+  general:
+    axes:
+      os: [ubuntu22, ubuntu24]
+      cpu: [2, 4]
+    template:
+      labels: [docker, "${{ os }}", "${{ cpu }}vcpu"]
+      image: "ghcr.io/shipfoxhq/runner:${{ os }}"
+      cpu: "${{ cpu }}"
+      memory: "${{ cpu * 2.0 }}GiB"
+      max_concurrency: 50
+      cost: "${{ cpu }}"
+
+  gpu:
+    axes:
+      cuda: [cuda12, cuda13]
+      memory: [16g, 32g]
+    template:
+      labels: [docker, gpu, "${{ cuda }}", "${{ memory }}"]
+      image: "ghcr.io/shipfoxhq/runner:${{ cuda }}"
+      cpu: 8
+      memory: "${{ memory }}"
+      max_concurrency: 10
+      cost: 20

--- a/apps/provisioner-ec2/README.md
+++ b/apps/provisioner-ec2/README.md
@@ -19,6 +19,18 @@ The AMI must include the Shipfox runner and its shutdown watchdog. Cloud-init wr
 `/etc/shipfox/runner.env` with the API URL, one-use token, labels, poll time, and
 maximum lifetime. The AMI reads that file and shuts down when its watchdog exits.
 
+## Template families
+
+The checked-in [`templates.example.yaml`](templates.example.yaml) contains a general
+on-demand fleet and an independent GPU Spot pool. They use different axes, markets,
+and subnet lists, so adding GPU capacity does not widen the general fleet's
+cross-product. The file also keeps one genuine one-off under `templates:`.
+
+EC2 operators provide their own AMI and instance-type lookup maps under `vars`.
+`defaults` applies common launch settings to every family, but a list override such
+as the GPU `subnets` replaces the default list rather than appending to it. Labels may
+overlap across families; lower `cost` wins when more than one template matches.
+
 ## Configuration
 
 | Variable | Required | Default | Purpose |

--- a/apps/provisioner-ec2/templates.example.yaml
+++ b/apps/provisioner-ec2/templates.example.yaml
@@ -1,18 +1,87 @@
 # Point SHIPFOX_PROVISIONER_TEMPLATES_FILE at a copy of this file.
 # The AMI must be a prebaked Shipfox runner image that reads /etc/shipfox/runner.env.
+# A matrix block is one independent family. The general fleet and GPU pool below
+# deliberately use different axes, markets, and subnets.
+vars:
+  ami_by_arch_os:
+    x64:
+      ubuntu2204: ami-0123456789abcdef0
+      ubuntu2404: ami-0123456789abcdef1
+    arm64:
+      ubuntu2204: ami-0123456789abcdef2
+      ubuntu2404: ami-0123456789abcdef3
+  instance_family_by_arch_cpu:
+    x64:
+      4: m7i
+      8: m7i
+    arm64:
+      4: m7g
+      8: m7g
+  size_by_cpu:
+    4: xlarge
+    8: 2xlarge
+  gpu_ami_by_model_driver:
+    a10:
+      cuda12: ami-0123456789abcde10
+    l4:
+      cuda12: ami-0123456789abcde11
+  gpu_instance_type_by_model:
+    a10: g5.2xlarge
+    l4: g6.2xlarge
+
+defaults:
+  labels: [ec2]
+  subnets: [subnet-general-a, subnet-general-b]
+  security_groups: [sg-runner]
+  iam_instance_profile: shipfox-runner
+  associate_public_ip: false
+  root_volume_gb: 100
+  root_device_name: /dev/sda1
+  max_concurrency: 50
+  target_concurrency: 0
+
+# Keep templates: for a genuine one-off. It is not part of either family below.
 templates:
-  ec2-ubuntu22-2vcpu-spot:
-    labels: [ubuntu22, ubuntu22-2vcpu]
-    ami: ami-0123456789abcdef0
-    instance_type: m6i.large
-    market: spot
-    spot_max_price: null
-    subnets: [subnet-0123456789abcdef0]
-    security_groups: [sg-0123456789abcdef0]
-    iam_instance_profile: shipfox-runner
-    associate_public_ip: false
-    root_volume_gb: 100
-    root_device_name: /dev/sda1
-    max_concurrency: 100
-    target_concurrency: 0
-    cost: 5
+  ec2-one-off-debug:
+    labels: [ec2, debug]
+    ami: ami-0123456789abcdef9
+    instance_type: t3.small
+    market: on-demand
+    subnets: [subnet-general-a]
+    root_volume_gb: 40
+    max_concurrency: 2
+    cost: 1
+
+matrix:
+  general:
+    axes:
+      arch: [x64, arm64]
+      cpu: [4, 8]
+      os: [ubuntu2204, ubuntu2404]
+    let:
+      ami: "${{ vars.ami_by_arch_os[arch][os] }}"
+      family: "${{ vars.instance_family_by_arch_cpu[arch][cpu] }}"
+      size: "${{ vars.size_by_cpu[cpu] }}"
+    template:
+      labels: [ec2, "${{ arch }}", "${{ os }}", "${{ cpu }}vcpu"]
+      ami: "${{ ami }}"
+      instance_type: "${{ family }}.${{ size }}"
+      market: on-demand
+      max_concurrency: 50
+      cost: "${{ cpu }}"
+
+  gpu:
+    axes:
+      model: [a10, l4]
+      driver: [cuda12]
+    template:
+      labels: [ec2, gpu, "${{ model }}", "${{ driver }}"]
+      ami: "${{ vars.gpu_ami_by_model_driver[model][driver] }}"
+      instance_type: "${{ vars.gpu_instance_type_by_model[model] }}"
+      market: spot
+      spot_max_price: 1.25
+      subnets: [subnet-gpu]
+      security_groups: [sg-gpu]
+      root_volume_gb: 200
+      max_concurrency: 10
+      cost: 25

--- a/libs/provisioner/docker/README.md
+++ b/libs/provisioner/docker/README.md
@@ -16,15 +16,48 @@ app.
 
 ## Template config
 
-The template file is YAML keyed by template name:
+The template file can contain shared `vars`, a `defaults` fragment, hand-written
+`templates`, and independent `matrix` families. Keep `templates:` for a genuine
+one-off or a per-variant override:
 
 ```yaml
+defaults:
+  labels: [docker]
+  target_concurrency: 0
+
 templates:
-  docker-ubuntu22-2vcpu:
-    labels: [ubuntu22, ubuntu22-2vcpu]
-    cpu: 2
-    memory: 4GiB
-    max_concurrency: 100
+  docker-local-debug:
+    labels: [docker, local-debug]
+    image: ghcr.io/shipfoxhq/runner:debug
+    cpu: 1
+    memory: 2GiB
+    max_concurrency: 2
+    cost: 1
+
+matrix:
+  general:
+    axes:
+      os: [ubuntu22, ubuntu24]
+      cpu: [2, 4]
+    template:
+      labels: [docker, "${{ os }}", "${{ cpu }}vcpu"]
+      image: "ghcr.io/shipfoxhq/runner:${{ os }}"
+      cpu: "${{ cpu }}"
+      memory: "${{ cpu * 2.0 }}GiB"
+      max_concurrency: 50
+      cost: "${{ cpu }}"
+
+  gpu:
+    axes:
+      cuda: [cuda12, cuda13]
+      memory: [16g, 32g]
+    template:
+      labels: [docker, gpu, "${{ cuda }}", "${{ memory }}"]
+      image: "ghcr.io/shipfoxhq/runner:${{ cuda }}"
+      cpu: 8
+      memory: "${{ memory }}"
+      max_concurrency: 10
+      cost: 20
 ```
 
 Loading fails fast with a clear, file-scoped error on a missing file, malformed YAML,
@@ -32,6 +65,19 @@ an invalid or unknown field, an unusable label, or an empty template set. Labels
 canonicalized (trim, lowercase, dedupe, sort) with the shared runner-label rules.
 The optional `cost` field controls template selection; when it is omitted, the vCPU
 count is used. Lower costs win when several templates satisfy the same generic label.
+Labels may overlap across families; matching is subset-based, so `cost` breaks the tie
+before specificity does. Families are independent, so adding hardware means adding a
+block rather than adding unrelated axes to an existing cross-product.
+
+`defaults` deep-merges maps, but lists and scalars replace wholesale. A family that
+sets `labels` or another list must provide the complete list. A hand-written entry
+whose key matches a generated key shadows the generated template and logs a warning;
+this is the per-variant override idiom.
+
+Docker file and template schemas are strict. Unknown keys that may have been silently
+ignored in older files now fail with a file-scoped validation error. Remove those keys
+before upgrading an existing operator file. The runnable two-family example lives at
+[`apps/provisioner-docker/templates.example.yaml`](../../../apps/provisioner-docker/templates.example.yaml).
 
 ## Current behavior
 

--- a/libs/provisioner/docker/src/templates.test.ts
+++ b/libs/provisioner/docker/src/templates.test.ts
@@ -1,7 +1,8 @@
 import {randomUUID} from 'node:crypto';
 import {mkdtempSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
-import {join} from 'node:path';
+import {dirname, join} from 'node:path';
+import {fileURLToPath} from 'node:url';
 import {DEFAULT_RUNNER_IMAGE, DockerTemplateConfigError, loadDockerTemplates} from '#templates.js';
 
 const mocks = vi.hoisted(() => ({debug: vi.fn(), info: vi.fn(), warn: vi.fn()}));
@@ -10,6 +11,10 @@ vi.mock('@shipfox/node-opentelemetry', () => ({logger: () => mocks}));
 const SHADOWED_TEMPLATE_CPU_PATTERN = /templates\.docker-2-ubuntu22\.cpu/;
 const COMBINED_TEMPLATE_CAP_PATTERN =
   /matrix expands to 1000 templates.*plus 1 hand-written; the maximum is 1000/;
+const EXAMPLE_PATH = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../../apps/provisioner-docker/templates.example.yaml',
+);
 
 let dir: string;
 
@@ -48,6 +53,28 @@ templates:
 `;
 
 describe('loadDockerTemplates', () => {
+  it('loads the checked-in two-family example file', () => {
+    const templates = loadDockerTemplates(EXAMPLE_PATH);
+
+    expect(templates).toHaveLength(9);
+    expect(templates.map(({key}) => key)).toEqual([
+      'docker-local-debug',
+      'general-ubuntu22-2',
+      'general-ubuntu22-4',
+      'general-ubuntu24-2',
+      'general-ubuntu24-4',
+      'gpu-cuda12-16g',
+      'gpu-cuda12-32g',
+      'gpu-cuda13-16g',
+      'gpu-cuda13-32g',
+    ]);
+    expect(templates.find(({key}) => key === 'gpu-cuda12-16g')).toMatchObject({
+      labels: ['16g', 'cuda12', 'docker', 'gpu'],
+      cost: 20,
+      spec: {cpu: 8, memory: '16g'},
+    });
+  });
+
   it('maps each config entry to a provider-agnostic template', () => {
     const path = writeTemplates(VALID);
 

--- a/libs/provisioner/ec2/README.md
+++ b/libs/provisioner/ec2/README.md
@@ -19,23 +19,71 @@ workspace ID, workspace registration token, or activation token.
 
 ## Template config
 
-The template file is YAML keyed by template name:
+The template file can contain shared `vars`, a `defaults` fragment, hand-written
+`templates`, and independent `matrix` families. Operators own the lookup maps under
+`vars`; the provider does not ship AWS instance-family or ratio tables.
 
 ```yaml
+vars:
+  ami_by_arch_os:
+    x64:
+      ubuntu2404: ami-0123456789abcdef0
+  instance_family_by_arch_cpu:
+    x64:
+      4: m7i
+  size_by_cpu:
+    4: xlarge
+  gpu_ami_by_model_driver:
+    a10:
+      cuda12: ami-0123456789abcde10
+  gpu_instance_type_by_model:
+    a10: g5.2xlarge
+
+defaults:
+  labels: [ec2]
+  subnets: [subnet-general-a, subnet-general-b]
+  security_groups: [sg-runner]
+  iam_instance_profile: shipfox-runner
+  associate_public_ip: false
+  root_volume_gb: 100
+  max_concurrency: 50
+  target_concurrency: 0
+
 templates:
-  ec2-ubuntu22-2vcpu-spot:
-    labels: [ubuntu22, ubuntu22-2vcpu]
-    ami: ami-0123456789abcdef0
-    instance_type: m6i.large
-    market: spot
-    spot_max_price: null
-    subnets: [subnet-aaa, subnet-bbb]
-    security_groups: [sg-runner]
-    iam_instance_profile: shipfox-runner
-    associate_public_ip: false
-    root_volume_gb: 100
-    max_concurrency: 200
-    cost: 5
+  ec2-one-off-debug:
+    labels: [ec2, debug]
+    ami: ami-0123456789abcdef9
+    instance_type: t3.small
+    market: on-demand
+    subnets: [subnet-general-a]
+    max_concurrency: 2
+    cost: 1
+
+matrix:
+  general:
+    axes:
+      arch: [x64]
+      cpu: [4]
+      os: [ubuntu2404]
+    template:
+      labels: [ec2, "${{ arch }}", "${{ os }}", "${{ cpu }}vcpu"]
+      ami: "${{ vars.ami_by_arch_os[arch][os] }}"
+      instance_type: "${{ vars.instance_family_by_arch_cpu[arch][cpu] }}.${{ vars.size_by_cpu[cpu] }}"
+      market: on-demand
+      cost: "${{ cpu }}"
+
+  gpu:
+    axes:
+      model: [a10]
+      driver: [cuda12]
+    template:
+      labels: [ec2, gpu, "${{ model }}", "${{ driver }}"]
+      ami: "${{ vars.gpu_ami_by_model_driver[model][driver] }}"
+      instance_type: "${{ vars.gpu_instance_type_by_model[model] }}"
+      market: spot
+      spot_max_price: 1.25
+      subnets: [subnet-gpu]
+      cost: 25
 ```
 
 Loading fails fast with a clear, file-scoped error on a missing file, malformed YAML, an
@@ -47,6 +95,15 @@ canonicalized with the shared runner-label rules.
 default. Set `cost` to an explicit unitless ranking where lower values win template
 selection. Give a Spot template a lower cost than its on-demand equivalent so the planner
 prefers Spot before spilling to on-demand capacity.
+
+Families are independent. The general and GPU families above use different axes and
+markets; the GPU block's `subnets` replaces the general default list rather than
+appending to it. Labels may overlap across families because matching is subset-based;
+the lowest `cost` wins before specificity does. A hand-written entry under `templates:`
+shadows a generated key and is the per-variant override idiom.
+
+The runnable two-family example, including the complete AMI lookup maps, lives at
+[`apps/provisioner-ec2/templates.example.yaml`](../../../apps/provisioner-ec2/templates.example.yaml).
 
 ## Runtime configuration
 

--- a/libs/provisioner/ec2/src/templates.test.ts
+++ b/libs/provisioner/ec2/src/templates.test.ts
@@ -1,7 +1,8 @@
 import {randomUUID} from 'node:crypto';
 import {mkdtempSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
-import {join} from 'node:path';
+import {dirname, join} from 'node:path';
+import {fileURLToPath} from 'node:url';
 import {MAX_RUNNER_LABELS} from '@shipfox/runner-labels';
 import {Ec2TemplateConfigError, loadEc2Templates} from '#templates.js';
 
@@ -22,6 +23,10 @@ function writeTemplates(contents: string): string {
 }
 
 const expression = (source: string) => `\${{ ${source} }}`;
+const EXAMPLE_PATH = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../../apps/provisioner-ec2/templates.example.yaml',
+);
 
 function template(overrides: Record<string, string> = {}, extra = ''): string {
   const defaults = `
@@ -79,6 +84,33 @@ templates:
 `;
 
 describe('loadEc2Templates', () => {
+  it('loads the checked-in two-family example file', () => {
+    const templates = loadEc2Templates(EXAMPLE_PATH);
+
+    expect(templates).toHaveLength(11);
+    expect(templates.filter(({key}) => key.startsWith('general-'))).toHaveLength(8);
+    expect(templates.filter(({key}) => key.startsWith('gpu-'))).toHaveLength(2);
+    expect(templates[0]).toMatchObject({
+      key: 'ec2-one-off-debug',
+      cost: 1,
+      spec: {market: 'on-demand', subnets: ['subnet-general-a']},
+    });
+    expect(templates.find(({key}) => key === 'general-x64-4-ubuntu2204')).toMatchObject({
+      spec: {
+        market: 'on-demand',
+        subnets: ['subnet-general-a', 'subnet-general-b'],
+      },
+    });
+    expect(templates.find(({key}) => key === 'gpu-a10-cuda12')).toMatchObject({
+      cost: 25,
+      spec: {
+        market: 'spot',
+        subnets: ['subnet-gpu'],
+        securityGroups: ['sg-gpu'],
+      },
+    });
+  });
+
   it('maps each config entry to a provider-agnostic template', () => {
     const path = writeTemplates(VALID);
 


### PR DESCRIPTION
This completes ENG-1326 by teaching operators to use independent template families rather than one cross-product.

- Rewrites Docker and EC2 example files with two loader-valid matrix families and a genuine one-off.
- Documents defaults/list replacement, overlapping labels and cost selection, shadowing overrides, independent family growth, and Docker strict-schema upgrades.
- Adds loader regression coverage that reads both checked-in examples.

Closes ENG-1326

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents independent template families for runner provisioners and rewrites the Docker and EC2 example templates around two matrix families, making it easier for operators to build clear, scalable configs. Aligns with ENG-1326 and now clarifies matrix template key derivation alongside `vars`, `defaults`, cost selection, shadowing, and family independence; adds tests that load the examples with real loaders.

- New Features
  - Rewrote `apps/provisioner-docker/templates.example.yaml` and `apps/provisioner-ec2/templates.example.yaml` to use two families (`general`, `gpu`) plus a genuine one-off.
  - Updated operator and reference docs to cover `vars`, `defaults` (maps merge; lists/scalars replace), overlapping labels with `cost` tie-break, per-variant shadowing, family independence, and matrix key derivation (default key from all axes in order, hyphen-joined; optional explicit `key`).
  - Added regression tests that load both example files through `loadDockerTemplates` and `loadEc2Templates` to ensure the examples work end-to-end.

- Migration
  - Docker templates use strict schemas now; unknown top-level or template keys fail. Remove stray or mistyped keys before upgrading.
  - Copy the new examples, replace images/AMIs/subnets/security groups, and point `SHIPFOX_PROVISIONER_TEMPLATES_FILE` at your copy.

<sup>Written for commit 4bedc81a85591f6e019d7c15e48dab7b3e563d97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

