### PR TITLE
[api-workspaces] Add authenticated workspace slug availability checks

### DIFF
--- a/.changeset/quiet-workspaces-check.md
+++ b/.changeset/quiet-workspaces-check.md
@@ -1,6 +1,9 @@
 ---
 "@shipfox/api-workspaces": minor
 "@shipfox/api-workspaces-dto": minor
+"@shipfox/api-auth": patch
+"@shipfox/api-runners": patch
+"@shipfox/node-rate-limit": minor
 ---
 
 Add an authenticated, rate-limited workspace slug availability endpoint.

--- a/.changeset/quiet-workspaces-check.md
+++ b/.changeset/quiet-workspaces-check.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-workspaces": minor
+"@shipfox/api-workspaces-dto": minor
+---
+
+Add an authenticated, rate-limited workspace slug availability endpoint.

--- a/libs/api/auth/src/db/rate-limits.ts
+++ b/libs/api/auth/src/db/rate-limits.ts
@@ -1,28 +1,23 @@
+import {
+  type ConsumeRateLimitParams,
+  type ConsumeRateLimitResult,
+  createRateLimitPersistence,
+} from '@shipfox/node-rate-limit';
 import {lt, sql} from 'drizzle-orm';
 import {db} from './db.js';
 import {authRateLimits} from './schema/rate-limits.js';
 
-export interface ConsumeAuthRateLimitParams {
-  action: string;
-  scope: string;
-  identifierHmac: string;
-  windowStart: Date;
-  expiresAt: Date;
-  timeoutMs: number;
-}
+type AuthRateLimitTransaction = Parameters<Parameters<ReturnType<typeof db>['transaction']>[0]>[0];
 
-export interface ConsumeAuthRateLimitResult {
-  count: number;
-  expiresAt: Date;
-}
-
-export async function consumeAuthRateLimit(
-  params: ConsumeAuthRateLimitParams,
-): Promise<ConsumeAuthRateLimitResult> {
-  return await db().transaction(async (tx) => {
-    await tx.execute(sql`select set_config('statement_timeout', ${`${params.timeoutMs}ms`}, true)`);
-
-    const rows = await tx
+const persistence = createRateLimitPersistence<AuthRateLimitTransaction>({
+  transaction: (callback) => db().transaction(callback),
+  setStatementTimeout: async (transaction, timeoutMs) => {
+    await transaction.execute(
+      sql`select set_config('statement_timeout', ${`${timeoutMs}ms`}, true)`,
+    );
+  },
+  consume: async (transaction, params) => {
+    const rows = await transaction
       .insert(authRateLimits)
       .values({
         action: params.action,
@@ -46,24 +41,15 @@ export async function consumeAuthRateLimit(
       })
       .returning({count: authRateLimits.count, expiresAt: authRateLimits.expiresAt});
 
-    const row = rows[0];
-    if (!row) throw new Error('Rate limit upsert returned no rows');
-    return row;
-  });
-}
+    return rows[0];
+  },
+  prune: async (now) => {
+    const result = await db().delete(authRateLimits).where(lt(authRateLimits.expiresAt, now));
+    return result.rowCount ?? 0;
+  },
+});
 
-let nextPruneAt = 0;
-
-export async function pruneExpiredAuthRateLimits(
-  params: {now?: Date | undefined; minIntervalMs?: number | undefined} = {},
-): Promise<number | undefined> {
-  const now = params.now ?? new Date();
-  const minIntervalMs = params.minIntervalMs ?? 60_000;
-  if (minIntervalMs > 0 && now.getTime() < nextPruneAt) return undefined;
-
-  nextPruneAt = now.getTime() + minIntervalMs;
-
-  const result = await db().delete(authRateLimits).where(lt(authRateLimits.expiresAt, now));
-
-  return result.rowCount ?? 0;
-}
+export type ConsumeAuthRateLimitParams = ConsumeRateLimitParams<string, string>;
+export type ConsumeAuthRateLimitResult = ConsumeRateLimitResult;
+export const consumeAuthRateLimit = persistence.consume;
+export const pruneExpiredAuthRateLimits = persistence.prune;

--- a/libs/api/auth/src/presentation/routes/rate-limit.ts
+++ b/libs/api/auth/src/presentation/routes/rate-limit.ts
@@ -1,10 +1,9 @@
 import {ClientError, type FastifyReply, type FastifyRequest} from '@shipfox/node-fastify';
+import {describeRateLimitError} from '@shipfox/node-rate-limit';
 import {
   type AuthRateLimitAction,
-  AuthRateLimitExceededError,
   type AuthRateLimitPolicy,
   type AuthRateLimitScope,
-  AuthRateLimitUnavailableError,
   checkAuthRateLimit,
 } from '#core/rate-limit.js';
 
@@ -57,59 +56,30 @@ async function enforceRateLimit(params: {
       ...policy,
     });
   } catch (error) {
-    if (error instanceof AuthRateLimitExceededError) {
+    const presentation = describeRateLimitError({
+      error,
+      route: routeName(params.request),
+      unavailableCode: 'auth-rate-limit-unavailable',
+      unavailableMessage: 'Authentication rate limiter unavailable',
+    });
+    if (!presentation) throw error;
+
+    if (presentation.status === 429) {
       params.request.log.warn(
-        {
-          action: error.action,
-          scope: error.scope,
-          route: routeName(params.request),
-          retryAfterSeconds: error.retryAfterSeconds,
-          identifierHmacPrefix: error.identifierHmacPrefix,
-        },
+        {...presentation.data, retryAfterSeconds: presentation.retryAfterSeconds},
         'Auth rate limit blocked request',
       );
-      params.reply.header('Retry-After', String(error.retryAfterSeconds));
-      throw new ClientError('Rate limit exceeded', 'rate-limited', {
-        status: 429,
-        details: {retry_after_seconds: error.retryAfterSeconds},
-        data: {
-          action: error.action,
-          scope: error.scope,
-          route: routeName(params.request),
-          identifierHmacPrefix: error.identifierHmacPrefix,
-        },
-        cause: error,
-      });
+      params.reply.header('Retry-After', String(presentation.retryAfterSeconds));
+    } else {
+      params.request.log.error({...presentation.data, err: error}, 'Auth rate limiter unavailable');
     }
 
-    if (error instanceof AuthRateLimitUnavailableError) {
-      params.request.log.error(
-        {
-          action: error.action,
-          scope: error.scope,
-          route: routeName(params.request),
-          identifierHmacPrefix: error.identifierHmacPrefix,
-          err: error,
-        },
-        'Auth rate limiter unavailable',
-      );
-      throw new ClientError(
-        'Authentication rate limiter unavailable',
-        'auth-rate-limit-unavailable',
-        {
-          status: 503,
-          data: {
-            action: error.action,
-            scope: error.scope,
-            route: routeName(params.request),
-            identifierHmacPrefix: error.identifierHmacPrefix,
-          },
-          cause: error,
-        },
-      );
-    }
-
-    throw error;
+    throw new ClientError(presentation.message, presentation.code, {
+      status: presentation.status,
+      ...(presentation.details ? {details: presentation.details} : {}),
+      data: presentation.data,
+      cause: error,
+    });
   }
 }
 

--- a/libs/api/auth/src/presentation/routes/rate-limit.ts
+++ b/libs/api/auth/src/presentation/routes/rate-limit.ts
@@ -1,5 +1,5 @@
 import {ClientError, type FastifyReply, type FastifyRequest} from '@shipfox/node-fastify';
-import {describeRateLimitError} from '@shipfox/node-rate-limit';
+import {enforceRateLimit as enforceSharedRateLimit} from '@shipfox/node-rate-limit';
 import {
   type AuthRateLimitAction,
   type AuthRateLimitPolicy,
@@ -48,39 +48,36 @@ async function enforceRateLimit(params: {
   const policy = policies[params.action][params.scope];
   if (!policy) return;
 
-  try {
-    await checkAuthRateLimit({
-      action: params.action,
-      scope: params.scope,
-      identifier: params.identifier,
-      ...policy,
-    });
-  } catch (error) {
-    const presentation = describeRateLimitError({
-      error,
-      route: routeName(params.request),
-      unavailableCode: 'auth-rate-limit-unavailable',
-      unavailableMessage: 'Authentication rate limiter unavailable',
-    });
-    if (!presentation) throw error;
-
-    if (presentation.status === 429) {
-      params.request.log.warn(
-        {...presentation.data, retryAfterSeconds: presentation.retryAfterSeconds},
-        'Auth rate limit blocked request',
-      );
-      params.reply.header('Retry-After', String(presentation.retryAfterSeconds));
-    } else {
-      params.request.log.error({...presentation.data, err: error}, 'Auth rate limiter unavailable');
-    }
-
-    throw new ClientError(presentation.message, presentation.code, {
-      status: presentation.status,
-      ...(presentation.details ? {details: presentation.details} : {}),
-      data: presentation.data,
-      cause: error,
-    });
-  }
+  await enforceSharedRateLimit({
+    request: params.request,
+    reply: params.reply,
+    check: () =>
+      checkAuthRateLimit({
+        action: params.action,
+        scope: params.scope,
+        identifier: params.identifier,
+        ...policy,
+      }),
+    route: routeName(params.request),
+    unavailableCode: 'auth-rate-limit-unavailable',
+    unavailableMessage: 'Authentication rate limiter unavailable',
+    setRetryAfter: (reply, retryAfterSeconds) => {
+      reply.header('Retry-After', String(retryAfterSeconds));
+    },
+    logWarn: (request, context) => {
+      request.log.warn(context, 'Auth rate limit blocked request');
+    },
+    logError: (request, context) => {
+      request.log.error(context, 'Auth rate limiter unavailable');
+    },
+    createClientError: (presentation, cause) =>
+      new ClientError(presentation.message, presentation.code, {
+        status: presentation.status,
+        ...(presentation.details ? {details: presentation.details} : {}),
+        data: presentation.data,
+        cause,
+      }),
+  });
 }
 
 export function createAuthRateLimitPreHandler(action: AuthRateLimitAction) {

--- a/libs/api/runners/src/db/rate-limits.ts
+++ b/libs/api/runners/src/db/rate-limits.ts
@@ -1,28 +1,25 @@
+import {
+  type ConsumeRateLimitParams,
+  type ConsumeRateLimitResult,
+  createRateLimitPersistence,
+} from '@shipfox/node-rate-limit';
 import {lt, sql} from 'drizzle-orm';
 import {db} from './db.js';
 import {runnersRateLimits} from './schema/rate-limits.js';
 
-export interface ConsumeRunnersRateLimitParams {
-  action: string;
-  scope: string;
-  identifierHmac: string;
-  windowStart: Date;
-  expiresAt: Date;
-  timeoutMs: number;
-}
+type RunnersRateLimitTransaction = Parameters<
+  Parameters<ReturnType<typeof db>['transaction']>[0]
+>[0];
 
-export interface ConsumeRunnersRateLimitResult {
-  count: number;
-  expiresAt: Date;
-}
-
-export async function consumeRunnersRateLimit(
-  params: ConsumeRunnersRateLimitParams,
-): Promise<ConsumeRunnersRateLimitResult> {
-  return await db().transaction(async (tx) => {
-    await tx.execute(sql`select set_config('statement_timeout', ${`${params.timeoutMs}ms`}, true)`);
-
-    const rows = await tx
+const persistence = createRateLimitPersistence<RunnersRateLimitTransaction>({
+  transaction: (callback) => db().transaction(callback),
+  setStatementTimeout: async (transaction, timeoutMs) => {
+    await transaction.execute(
+      sql`select set_config('statement_timeout', ${`${timeoutMs}ms`}, true)`,
+    );
+  },
+  consume: async (transaction, params) => {
+    const rows = await transaction
       .insert(runnersRateLimits)
       .values({
         action: params.action,
@@ -46,24 +43,15 @@ export async function consumeRunnersRateLimit(
       })
       .returning({count: runnersRateLimits.count, expiresAt: runnersRateLimits.expiresAt});
 
-    const row = rows[0];
-    if (!row) throw new Error('Rate limit upsert returned no rows');
-    return row;
-  });
-}
+    return rows[0];
+  },
+  prune: async (now) => {
+    const result = await db().delete(runnersRateLimits).where(lt(runnersRateLimits.expiresAt, now));
+    return result.rowCount ?? 0;
+  },
+});
 
-let nextPruneAt = 0;
-
-export async function pruneExpiredRunnersRateLimits(
-  params: {now?: Date | undefined; minIntervalMs?: number | undefined} = {},
-): Promise<number | undefined> {
-  const now = params.now ?? new Date();
-  const minIntervalMs = params.minIntervalMs ?? 60_000;
-  if (minIntervalMs > 0 && now.getTime() < nextPruneAt) return undefined;
-
-  nextPruneAt = now.getTime() + minIntervalMs;
-
-  const result = await db().delete(runnersRateLimits).where(lt(runnersRateLimits.expiresAt, now));
-
-  return result.rowCount ?? 0;
-}
+export type ConsumeRunnersRateLimitParams = ConsumeRateLimitParams<string, string>;
+export type ConsumeRunnersRateLimitResult = ConsumeRateLimitResult;
+export const consumeRunnersRateLimit = persistence.consume;
+export const pruneExpiredRunnersRateLimits = persistence.prune;

--- a/libs/api/runners/src/presentation/routes/rate-limit.ts
+++ b/libs/api/runners/src/presentation/routes/rate-limit.ts
@@ -1,11 +1,8 @@
 import {requireProvisionerContext} from '@shipfox/api-auth-context';
 import {ClientError, type FastifyReply, type FastifyRequest} from '@shipfox/node-fastify';
+import {describeRateLimitError} from '@shipfox/node-rate-limit';
 import {config} from '#config.js';
-import {
-  checkRunnersRateLimit,
-  RunnersRateLimitExceededError,
-  RunnersRateLimitUnavailableError,
-} from '#core/rate-limit.js';
+import {checkRunnersRateLimit} from '#core/rate-limit.js';
 import {getRunnerContext} from '#presentation/auth/index.js';
 
 function routeName(request: FastifyRequest): string {
@@ -30,55 +27,33 @@ async function enforceRateLimit(params: {
       windowSeconds: params.windowSeconds,
     });
   } catch (error) {
-    if (error instanceof RunnersRateLimitExceededError) {
+    const presentation = describeRateLimitError({
+      error,
+      route: routeName(params.request),
+      unavailableCode: 'runners-rate-limit-unavailable',
+      unavailableMessage: 'Runners rate limiter unavailable',
+    });
+    if (!presentation) throw error;
+
+    if (presentation.status === 429) {
       params.request.log.warn(
-        {
-          action: error.action,
-          scope: error.scope,
-          route: routeName(params.request),
-          retryAfterSeconds: error.retryAfterSeconds,
-          identifierHmacPrefix: error.identifierHmacPrefix,
-        },
+        {...presentation.data, retryAfterSeconds: presentation.retryAfterSeconds},
         'Runners rate limit blocked request',
       );
-      params.reply.header('Retry-After', String(error.retryAfterSeconds));
-      throw new ClientError('Rate limit exceeded', 'rate-limited', {
-        status: 429,
-        details: {retry_after_seconds: error.retryAfterSeconds},
-        data: {
-          action: error.action,
-          scope: error.scope,
-          route: routeName(params.request),
-          identifierHmacPrefix: error.identifierHmacPrefix,
-        },
-        cause: error,
-      });
-    }
-
-    if (error instanceof RunnersRateLimitUnavailableError) {
+      params.reply.header('Retry-After', String(presentation.retryAfterSeconds));
+    } else {
       params.request.log.error(
-        {
-          action: error.action,
-          scope: error.scope,
-          route: routeName(params.request),
-          identifierHmacPrefix: error.identifierHmacPrefix,
-          err: error,
-        },
+        {...presentation.data, err: error},
         'Runners rate limiter unavailable',
       );
-      throw new ClientError('Runners rate limiter unavailable', 'runners-rate-limit-unavailable', {
-        status: 503,
-        data: {
-          action: error.action,
-          scope: error.scope,
-          route: routeName(params.request),
-          identifierHmacPrefix: error.identifierHmacPrefix,
-        },
-        cause: error,
-      });
     }
 
-    throw error;
+    throw new ClientError(presentation.message, presentation.code, {
+      status: presentation.status,
+      ...(presentation.details ? {details: presentation.details} : {}),
+      data: presentation.data,
+      cause: error,
+    });
   }
 }
 

--- a/libs/api/runners/src/presentation/routes/rate-limit.ts
+++ b/libs/api/runners/src/presentation/routes/rate-limit.ts
@@ -1,6 +1,6 @@
 import {requireProvisionerContext} from '@shipfox/api-auth-context';
 import {ClientError, type FastifyReply, type FastifyRequest} from '@shipfox/node-fastify';
-import {describeRateLimitError} from '@shipfox/node-rate-limit';
+import {enforceRateLimit as enforceSharedRateLimit} from '@shipfox/node-rate-limit';
 import {config} from '#config.js';
 import {checkRunnersRateLimit} from '#core/rate-limit.js';
 import {getRunnerContext} from '#presentation/auth/index.js';
@@ -18,43 +18,37 @@ async function enforceRateLimit(params: {
   limit: number;
   windowSeconds: number;
 }): Promise<void> {
-  try {
-    await checkRunnersRateLimit({
-      action: params.action,
-      scope: params.scope,
-      identifier: params.identifier,
-      limit: params.limit,
-      windowSeconds: params.windowSeconds,
-    });
-  } catch (error) {
-    const presentation = describeRateLimitError({
-      error,
-      route: routeName(params.request),
-      unavailableCode: 'runners-rate-limit-unavailable',
-      unavailableMessage: 'Runners rate limiter unavailable',
-    });
-    if (!presentation) throw error;
-
-    if (presentation.status === 429) {
-      params.request.log.warn(
-        {...presentation.data, retryAfterSeconds: presentation.retryAfterSeconds},
-        'Runners rate limit blocked request',
-      );
-      params.reply.header('Retry-After', String(presentation.retryAfterSeconds));
-    } else {
-      params.request.log.error(
-        {...presentation.data, err: error},
-        'Runners rate limiter unavailable',
-      );
-    }
-
-    throw new ClientError(presentation.message, presentation.code, {
-      status: presentation.status,
-      ...(presentation.details ? {details: presentation.details} : {}),
-      data: presentation.data,
-      cause: error,
-    });
-  }
+  await enforceSharedRateLimit({
+    request: params.request,
+    reply: params.reply,
+    check: () =>
+      checkRunnersRateLimit({
+        action: params.action,
+        scope: params.scope,
+        identifier: params.identifier,
+        limit: params.limit,
+        windowSeconds: params.windowSeconds,
+      }),
+    route: routeName(params.request),
+    unavailableCode: 'runners-rate-limit-unavailable',
+    unavailableMessage: 'Runners rate limiter unavailable',
+    setRetryAfter: (reply, retryAfterSeconds) => {
+      reply.header('Retry-After', String(retryAfterSeconds));
+    },
+    logWarn: (request, context) => {
+      request.log.warn(context, 'Runners rate limit blocked request');
+    },
+    logError: (request, context) => {
+      request.log.error(context, 'Runners rate limiter unavailable');
+    },
+    createClientError: (presentation, cause) =>
+      new ClientError(presentation.message, presentation.code, {
+        status: presentation.status,
+        ...(presentation.details ? {details: presentation.details} : {}),
+        data: presentation.data,
+        cause,
+      }),
+  });
 }
 
 export function createProvisionerMintRateLimitPreHandler() {

--- a/libs/api/workspaces-dto/src/schemas/index.ts
+++ b/libs/api/workspaces-dto/src/schemas/index.ts
@@ -71,6 +71,8 @@ export {
   type WorkspaceAdminSummaryDto,
   type WorkspaceDto,
   type WorkspaceResponseDto,
+  type WorkspaceSlugAvailabilityQueryDto,
+  type WorkspaceSlugAvailabilityResponseDto,
   workspaceAdministrationMutationBodySchema,
   workspaceAdministrationMutationResponseSchema,
   workspaceAdminJobCountsSchema,
@@ -80,5 +82,7 @@ export {
   workspaceAdminSummarySchema,
   workspaceDtoSchema,
   workspaceResponseSchema,
+  workspaceSlugAvailabilityQuerySchema,
+  workspaceSlugAvailabilityResponseSchema,
   workspaceStatusSchema,
 } from './workspace.js';

--- a/libs/api/workspaces-dto/src/schemas/workspace.ts
+++ b/libs/api/workspaces-dto/src/schemas/workspace.ts
@@ -21,6 +21,22 @@ export const updateWorkspaceBodySchema = z
 
 export type UpdateWorkspaceBodyDto = z.infer<typeof updateWorkspaceBodySchema>;
 
+export const workspaceSlugAvailabilityQuerySchema = z.object({
+  slug: slugSchema,
+});
+
+export type WorkspaceSlugAvailabilityQueryDto = z.infer<
+  typeof workspaceSlugAvailabilityQuerySchema
+>;
+
+export const workspaceSlugAvailabilityResponseSchema = z.object({
+  available: z.boolean(),
+});
+
+export type WorkspaceSlugAvailabilityResponseDto = z.infer<
+  typeof workspaceSlugAvailabilityResponseSchema
+>;
+
 export const workspaceDtoSchema = z.object({
   id: z.string().uuid(),
   name: z.string(),

--- a/libs/api/workspaces/README.md
+++ b/libs/api/workspaces/README.md
@@ -38,16 +38,18 @@ const membership = await ensureMembership({
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `CLIENT_BASE_URL` | `http://localhost:5173` | Base URL used in workspace invitation links. |
+| `AUTH_ROOT_KEY` | none | Root key used to HMAC source IPs for the workspace slug availability rate limit. |
 
 Invitation email uses the shared `@shipfox/node-mailer` configuration.
 
 ## Routes / API / Data Model
 
-Routes mount under `/workspaces`. They make, list, and update workspaces, manage
-members, and make, list, view, accept, or revoke invites. Every workspace has a
-unique `slug` used in client URLs; creating a workspace requires one, and
-`PATCH /workspaces/:workspaceId` can rename it. A taken slug returns
-`slug-conflict`. Updates write a `workspaces.workspace.updated` outbox event.
+Routes mount under `/workspaces`. They make, list, and update workspaces, check
+workspace slug availability, manage members, and make, list, view, accept, or
+revoke invites. Every workspace has a unique `slug` used in client URLs;
+creating a workspace requires one, and `PATCH /workspaces/:workspaceId` can
+rename it. A taken slug returns `slug-conflict`. Updates write a
+`workspaces.workspace.updated` outbox event.
 The composed module also mounts
 `GET /admin/workspaces`, which requires the Auth `admin-observer` role and returns
 bounded workspace identity, lifecycle, member, project, and best-effort job-count
@@ -65,6 +67,7 @@ The module creates these tables:
 - `workspaces_invitations`
 - `workspaces_outbox`
 - `workspaces_admin_command_results`
+- `workspaces_rate_limits`
 
 ## Behavior Notes
 
@@ -75,6 +78,10 @@ counts only new rows.
 
 Invite acceptance keeps its current transaction. It does not change a row that
 is already there.
+
+`GET /workspaces/slug-availability?slug=acme` requires an authenticated user and
+returns only `{available: boolean}`. A malformed slug returns 400. Requests are
+limited to 60 per source IP in a five-minute window.
 
 `ensureMembership` fails when its workspace does not exist. Workspace checks
 throw `WorkspaceNotFoundError` or `MembershipRequiredError`. Invite helpers

--- a/libs/api/workspaces/drizzle/0003_dapper_talos.sql
+++ b/libs/api/workspaces/drizzle/0003_dapper_talos.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "workspaces_rate_limits" (
+	"action" text NOT NULL,
+	"scope" text NOT NULL,
+	"identifier_hmac" text NOT NULL,
+	"window_start" timestamp with time zone NOT NULL,
+	"count" integer DEFAULT 1 NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "workspaces_rate_limits_window_unique" ON "workspaces_rate_limits" USING btree ("action","scope","identifier_hmac","window_start");--> statement-breakpoint
+CREATE INDEX "workspaces_rate_limits_expires_at_idx" ON "workspaces_rate_limits" USING btree ("expires_at");--> statement-breakpoint

--- a/libs/api/workspaces/drizzle/meta/0003_snapshot.json
+++ b/libs/api/workspaces/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,689 @@
+{
+  "id": "e5b3f962-5a45-4af5-abc8-e8983ab5b26e",
+  "prevId": "496634ce-3e5f-4c06-a9ff-857afa65422c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.workspaces_admin_command_results": {
+      "name": "workspaces_admin_command_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key_fingerprint": {
+          "name": "idempotency_key_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_fingerprint": {
+          "name": "request_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspaces_admin_command_results_actor_key_unique": {
+          "name": "workspaces_admin_command_results_actor_key_unique",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces_invitations": {
+      "name": "workspaces_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by_display": {
+          "name": "invited_by_display",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspaces_invitations_hashed_token_unique": {
+          "name": "workspaces_invitations_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspaces_invitations_workspace_email_idx": {
+          "name": "workspaces_invitations_workspace_email_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspaces_invitations_workspace_id_workspaces_workspaces_id_fk": {
+          "name": "workspaces_invitations_workspace_id_workspaces_workspaces_id_fk",
+          "tableFrom": "workspaces_invitations",
+          "tableTo": "workspaces_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces_memberships": {
+      "name": "workspaces_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspaces_memberships_user_workspace_unique": {
+          "name": "workspaces_memberships_user_workspace_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspaces_memberships_workspace_id_idx": {
+          "name": "workspaces_memberships_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspaces_memberships_workspace_id_workspaces_workspaces_id_fk": {
+          "name": "workspaces_memberships_workspace_id_workspaces_workspaces_id_fk",
+          "tableFrom": "workspaces_memberships",
+          "tableTo": "workspaces_workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces_outbox": {
+      "name": "workspaces_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordering_key": {
+          "name": "ordering_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_attempts": {
+          "name": "dispatch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_dispatch_at": {
+          "name": "next_dispatch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_dispatch_error": {
+          "name": "last_dispatch_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_dispatch_failed_at": {
+          "name": "last_dispatch_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dead_lettered_at": {
+          "name": "dead_lettered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workspaces_outbox_pending_idx": {
+          "name": "workspaces_outbox_pending_idx",
+          "columns": [
+            {
+              "expression": "next_dispatch_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NULL AND \"dead_lettered_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspaces_outbox_dispatched_retention_idx": {
+          "name": "workspaces_outbox_dispatched_retention_idx",
+          "columns": [
+            {
+              "expression": "dispatched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces_rate_limits": {
+      "name": "workspaces_rate_limits",
+      "schema": "",
+      "columns": {
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier_hmac": {
+          "name": "identifier_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspaces_rate_limits_window_unique": {
+          "name": "workspaces_rate_limits_window_unique",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identifier_hmac",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "window_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspaces_rate_limits_expires_at_idx": {
+          "name": "workspaces_rate_limits_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces_workspaces": {
+      "name": "workspaces_workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workspaces_workspace_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspaces_name_id_idx": {
+          "name": "workspaces_name_id_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspaces_slug_unique": {
+          "name": "workspaces_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.workspaces_workspace_status": {
+      "name": "workspaces_workspace_status",
+      "schema": "public",
+      "values": ["active", "suspended", "deleted"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/api/workspaces/drizzle/meta/_journal.json
+++ b/libs/api/workspaces/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1785225824871,
       "tag": "0002_wide_enchantress",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1785483624863,
+      "tag": "0003_dapper_talos",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/api/workspaces/package.json
+++ b/libs/api/workspaces/package.json
@@ -59,6 +59,7 @@
     "@shipfox/api-workspaces-dto": "workspace:*",
     "@shipfox/config": "workspace:*",
     "@shipfox/inter-module": "workspace:*",
+    "@shipfox/node-auth-root-key": "workspace:*",
     "@shipfox/node-drizzle": "workspace:*",
     "@shipfox/node-fastify": "workspace:*",
     "@shipfox/node-email": "workspace:*",
@@ -67,6 +68,7 @@
     "@shipfox/node-opentelemetry": "workspace:*",
     "@shipfox/node-outbox": "workspace:*",
     "@shipfox/node-postgres": "workspace:*",
+    "@shipfox/node-rate-limit": "workspace:*",
     "@shipfox/node-tokens": "workspace:*",
     "drizzle-orm": "catalog:",
     "zod": "catalog:"

--- a/libs/api/workspaces/src/core/index.ts
+++ b/libs/api/workspaces/src/core/index.ts
@@ -39,6 +39,7 @@ export {
 } from './invitations.js';
 export {type EnsureMembershipParams, ensureMembership} from './memberships.js';
 export {
+  checkWorkspaceSlugAvailability,
   createWorkspaceForUser,
   getWorkspace,
   listUserWorkspaceMemberships,

--- a/libs/api/workspaces/src/core/rate-limit.test.ts
+++ b/libs/api/workspaces/src/core/rate-limit.test.ts
@@ -1,0 +1,113 @@
+import {eq, sql} from 'drizzle-orm';
+import {db} from '#db/db.js';
+import {workspacesRateLimits} from '#db/schema/rate-limits.js';
+import {
+  checkWorkspacesRateLimit,
+  hashWorkspacesRateLimitIdentifier,
+  WorkspacesRateLimitUnavailableError,
+} from './rate-limit.js';
+
+const HMAC_HEX_PATTERN = /^[a-f0-9]{64}$/;
+
+describe('checkWorkspacesRateLimit', () => {
+  it('hashes identifiers without storing the raw identifier', async () => {
+    const identifier = `ip-${crypto.randomUUID()}`;
+    const identifierHmac = hashWorkspacesRateLimitIdentifier({
+      action: 'slug-availability',
+      scope: 'ip',
+      identifier,
+    });
+
+    await checkWorkspacesRateLimit({
+      action: 'slug-availability',
+      scope: 'ip',
+      identifier,
+      limit: 1,
+      windowSeconds: 60,
+      now: new Date('2026-06-23T00:00:10Z'),
+    });
+
+    const rows = await db()
+      .select({identifierHmac: workspacesRateLimits.identifierHmac})
+      .from(workspacesRateLimits)
+      .where(eq(workspacesRateLimits.identifierHmac, identifierHmac));
+
+    expect(identifierHmac).toMatch(HMAC_HEX_PATTERN);
+    expect(identifierHmac).not.toContain(identifier);
+    expect(rows).toEqual([{identifierHmac}]);
+  });
+
+  it('rejects the first over-limit attempt with retry-after seconds', async () => {
+    const identifier = `ip-${crypto.randomUUID()}`;
+    const now = new Date('2026-06-23T00:00:10Z');
+
+    await checkWorkspacesRateLimit({
+      action: 'slug-availability',
+      scope: 'ip',
+      identifier,
+      limit: 2,
+      windowSeconds: 60,
+      now,
+    });
+    await checkWorkspacesRateLimit({
+      action: 'slug-availability',
+      scope: 'ip',
+      identifier,
+      limit: 2,
+      windowSeconds: 60,
+      now,
+    });
+    const result = checkWorkspacesRateLimit({
+      action: 'slug-availability',
+      scope: 'ip',
+      identifier,
+      limit: 2,
+      windowSeconds: 60,
+      now,
+    });
+
+    await expect(result).rejects.toMatchObject({
+      name: 'WorkspacesRateLimitExceededError',
+      retryAfterSeconds: 50,
+    });
+  });
+
+  it('fails closed when the limiter query times out', async () => {
+    const identifier = `ip-${crypto.randomUUID()}`;
+    const identifierHmac = hashWorkspacesRateLimitIdentifier({
+      action: 'slug-availability',
+      scope: 'ip',
+      identifier,
+    });
+    await db()
+      .insert(workspacesRateLimits)
+      .values({
+        action: 'slug-availability',
+        scope: 'ip',
+        identifierHmac,
+        windowStart: new Date('2026-06-23T00:03:00Z'),
+        count: 1,
+        expiresAt: new Date('2026-06-23T00:04:00Z'),
+      });
+
+    await db().transaction(async (tx) => {
+      await tx.execute(sql`
+        SELECT 1
+        FROM workspaces_rate_limits
+        WHERE identifier_hmac = ${identifierHmac}
+        FOR UPDATE
+      `);
+      const result = checkWorkspacesRateLimit({
+        action: 'slug-availability',
+        scope: 'ip',
+        identifier,
+        limit: 1,
+        windowSeconds: 60,
+        now: new Date('2026-06-23T00:03:30Z'),
+        timeoutMs: 10,
+      });
+
+      await expect(result).rejects.toBeInstanceOf(WorkspacesRateLimitUnavailableError);
+    });
+  });
+});

--- a/libs/api/workspaces/src/core/rate-limit.ts
+++ b/libs/api/workspaces/src/core/rate-limit.ts
@@ -1,0 +1,119 @@
+import {rateLimitIdentifierKey} from '@shipfox/node-auth-root-key';
+import {
+  checkRateLimit,
+  hashRateLimitIdentifier,
+  RateLimitExceededError,
+  type RateLimitOutcome,
+  type RateLimitPolicy,
+  RateLimitUnavailableError,
+} from '@shipfox/node-rate-limit';
+import {consumeWorkspacesRateLimit, pruneExpiredWorkspacesRateLimits} from '#db/rate-limits.js';
+import {
+  recordWorkspaceRateLimitCheck,
+  recordWorkspaceRateLimitPruneFailure,
+} from '#metrics/instance.js';
+
+export type WorkspacesRateLimitAction = 'slug-availability';
+export type WorkspacesRateLimitScope = 'ip';
+export type WorkspacesRateLimitOutcome = RateLimitOutcome;
+export type WorkspacesRateLimitPolicy = RateLimitPolicy;
+
+export interface CheckWorkspacesRateLimitParams extends WorkspacesRateLimitPolicy {
+  action: WorkspacesRateLimitAction;
+  scope: WorkspacesRateLimitScope;
+  identifier: string;
+  now?: Date | undefined;
+  timeoutMs?: number | undefined;
+}
+
+export class WorkspacesRateLimitExceededError extends RateLimitExceededError<
+  WorkspacesRateLimitAction,
+  WorkspacesRateLimitScope
+> {
+  constructor(params: {
+    action: WorkspacesRateLimitAction;
+    scope: WorkspacesRateLimitScope;
+    retryAfterSeconds: number;
+    identifierHmacPrefix: string;
+  }) {
+    super(params);
+    this.name = 'WorkspacesRateLimitExceededError';
+  }
+}
+
+export class WorkspacesRateLimitUnavailableError extends RateLimitUnavailableError<
+  WorkspacesRateLimitAction,
+  WorkspacesRateLimitScope
+> {
+  constructor(params: {
+    action: WorkspacesRateLimitAction;
+    scope: WorkspacesRateLimitScope;
+    identifierHmacPrefix: string;
+    cause: unknown;
+  }) {
+    super(params);
+    this.name = 'WorkspacesRateLimitUnavailableError';
+  }
+}
+
+export const WORKSPACE_SLUG_AVAILABILITY_RATE_LIMIT = {
+  limit: 60,
+  windowSeconds: 5 * 60,
+} as const;
+
+const RATE_LIMIT_TIMEOUT_MS = 250;
+const IDENTIFIER_HASH_DOMAIN = 'shipfox.workspaces.rate-limit.identifier.v1';
+
+export function hashWorkspacesRateLimitIdentifier(params: {
+  action: WorkspacesRateLimitAction;
+  scope: WorkspacesRateLimitScope;
+  identifier: string;
+}): string {
+  return hashRateLimitIdentifier({
+    action: params.action,
+    scope: params.scope,
+    identifier: params.identifier,
+    secret: rateLimitIdentifierKey(),
+    domain: IDENTIFIER_HASH_DOMAIN,
+  });
+}
+
+export async function checkWorkspacesRateLimit(
+  params: CheckWorkspacesRateLimitParams,
+): Promise<void> {
+  try {
+    await checkRateLimit({
+      action: params.action,
+      scope: params.scope,
+      identifier: params.identifier,
+      limit: params.limit,
+      windowSeconds: params.windowSeconds,
+      identifierSecret: rateLimitIdentifierKey(),
+      identifierHashDomain: IDENTIFIER_HASH_DOMAIN,
+      consume: consumeWorkspacesRateLimit,
+      prune: pruneExpiredWorkspacesRateLimits,
+      onCheck: recordWorkspaceRateLimitCheck,
+      onPruneFailure: recordWorkspaceRateLimitPruneFailure,
+      now: params.now,
+      timeoutMs: params.timeoutMs ?? RATE_LIMIT_TIMEOUT_MS,
+    });
+  } catch (error) {
+    if (error instanceof RateLimitExceededError) {
+      throw new WorkspacesRateLimitExceededError({
+        action: error.action,
+        scope: error.scope,
+        retryAfterSeconds: error.retryAfterSeconds,
+        identifierHmacPrefix: error.identifierHmacPrefix,
+      });
+    }
+    if (error instanceof RateLimitUnavailableError) {
+      throw new WorkspacesRateLimitUnavailableError({
+        action: error.action,
+        scope: error.scope,
+        identifierHmacPrefix: error.identifierHmacPrefix,
+        cause: error.cause,
+      });
+    }
+    throw error;
+  }
+}

--- a/libs/api/workspaces/src/core/workspaces.ts
+++ b/libs/api/workspaces/src/core/workspaces.ts
@@ -19,7 +19,7 @@ import {
 import {memberships} from '#db/schema/memberships.js';
 import {workspacesOutbox} from '#db/schema/outbox.js';
 import {toWorkspace, workspaces} from '#db/schema/workspaces.js';
-import {getWorkspaceById, updateWorkspace} from '#db/workspaces.js';
+import {getWorkspaceById, isWorkspaceSlugAvailable, updateWorkspace} from '#db/workspaces.js';
 import type {Workspace} from './entities/workspace.js';
 import {
   MembershipNotFoundError,
@@ -99,6 +99,10 @@ export async function createWorkspaceForUser(params: {
 
     return workspace;
   });
+}
+
+export async function checkWorkspaceSlugAvailability(slug: string): Promise<boolean> {
+  return await isWorkspaceSlugAvailable(slug);
 }
 
 export async function updateWorkspaceDetails(params: {

--- a/libs/api/workspaces/src/db/db.ts
+++ b/libs/api/workspaces/src/db/db.ts
@@ -4,6 +4,7 @@ import {workspacesAdminCommandResults} from './schema/admin-command-results.js';
 import {invitations} from './schema/invitations.js';
 import {memberships} from './schema/memberships.js';
 import {workspacesOutbox} from './schema/outbox.js';
+import {workspacesRateLimits} from './schema/rate-limits.js';
 import {workspaces} from './schema/workspaces.js';
 
 export const schema = {
@@ -12,6 +13,7 @@ export const schema = {
   memberships,
   invitations,
   workspacesOutbox,
+  workspacesRateLimits,
 };
 
 let _db: NodePgDatabase<typeof schema> | undefined;

--- a/libs/api/workspaces/src/db/index.ts
+++ b/libs/api/workspaces/src/db/index.ts
@@ -22,8 +22,17 @@ export {
   listMembershipsByWorkspace,
   removeMembership,
 } from './memberships.js';
+export type {
+  ConsumeWorkspacesRateLimitParams,
+  ConsumeWorkspacesRateLimitResult,
+} from './rate-limits.js';
+export {
+  consumeWorkspacesRateLimit,
+  pruneExpiredWorkspacesRateLimits,
+} from './rate-limits.js';
 export {workspacesAdminCommandResults} from './schema/admin-command-results.js';
 export {workspacesOutbox} from './schema/outbox.js';
+export {workspacesRateLimits} from './schema/rate-limits.js';
 export type {
   AdminWorkspaceRow,
   CreateWorkspaceParams,
@@ -36,6 +45,7 @@ export {
   createWorkspace,
   getWorkspaceById,
   getWorkspaceServiceMetrics,
+  isWorkspaceSlugAvailable,
   listAdminWorkspaces,
   updateWorkspace,
 } from './workspaces.js';

--- a/libs/api/workspaces/src/db/rate-limits.test.ts
+++ b/libs/api/workspaces/src/db/rate-limits.test.ts
@@ -1,0 +1,74 @@
+import {and, eq, sql} from 'drizzle-orm';
+import {consumeWorkspacesRateLimit, pruneExpiredWorkspacesRateLimits} from '#db/rate-limits.js';
+import {db} from './db.js';
+import {workspacesRateLimits} from './schema/rate-limits.js';
+
+describe('workspaces rate limits db', () => {
+  it('atomically increments one bucket for concurrent attempts', async () => {
+    const identifierHmac = `hmac-${crypto.randomUUID()}`;
+    const params = {
+      action: 'slug-availability',
+      scope: 'ip',
+      identifierHmac,
+      windowStart: new Date('2026-06-23T00:00:00Z'),
+      expiresAt: new Date('2026-06-23T00:01:00Z'),
+      timeoutMs: 5_000,
+    };
+
+    await Promise.all(Array.from({length: 20}, () => consumeWorkspacesRateLimit(params)));
+
+    const [row] = await db()
+      .select({count: workspacesRateLimits.count})
+      .from(workspacesRateLimits)
+      .where(eq(workspacesRateLimits.identifierHmac, identifierHmac));
+    expect(row?.count).toBe(20);
+  });
+
+  it('prunes expired counters and keeps active counters', async () => {
+    const expiredIdentifierHmac = `expired-${crypto.randomUUID()}`;
+    const activeIdentifierHmac = `active-${crypto.randomUUID()}`;
+    await db()
+      .insert(workspacesRateLimits)
+      .values([
+        {
+          action: 'slug-availability',
+          scope: 'ip',
+          identifierHmac: expiredIdentifierHmac,
+          windowStart: new Date('2026-06-23T00:00:00Z'),
+          count: 1,
+          expiresAt: new Date('2026-06-23T00:01:00Z'),
+        },
+        {
+          action: 'slug-availability',
+          scope: 'ip',
+          identifierHmac: activeIdentifierHmac,
+          windowStart: new Date('2026-06-23T00:04:00Z'),
+          count: 1,
+          expiresAt: new Date('2026-06-23T00:06:00Z'),
+        },
+      ]);
+
+    const result = await pruneExpiredWorkspacesRateLimits({
+      now: new Date('2026-06-23T00:05:00Z'),
+      minIntervalMs: 0,
+    });
+
+    expect(result).toBeGreaterThanOrEqual(1);
+    expect(await countBucket(expiredIdentifierHmac)).toBe(0);
+    expect(await countBucket(activeIdentifierHmac)).toBe(1);
+  });
+
+  async function countBucket(identifierHmac: string): Promise<number> {
+    const [row] = await db()
+      .select({count: sql<number>`count(*)::int`})
+      .from(workspacesRateLimits)
+      .where(
+        and(
+          eq(workspacesRateLimits.action, 'slug-availability'),
+          eq(workspacesRateLimits.scope, 'ip'),
+          eq(workspacesRateLimits.identifierHmac, identifierHmac),
+        ),
+      );
+    return row?.count ?? 0;
+  }
+});

--- a/libs/api/workspaces/src/db/rate-limits.ts
+++ b/libs/api/workspaces/src/db/rate-limits.ts
@@ -1,28 +1,25 @@
+import {
+  type ConsumeRateLimitParams,
+  type ConsumeRateLimitResult,
+  createRateLimitPersistence,
+} from '@shipfox/node-rate-limit';
 import {lt, sql} from 'drizzle-orm';
 import {db} from './db.js';
 import {workspacesRateLimits} from './schema/rate-limits.js';
 
-export interface ConsumeWorkspacesRateLimitParams {
-  action: string;
-  scope: string;
-  identifierHmac: string;
-  windowStart: Date;
-  expiresAt: Date;
-  timeoutMs: number;
-}
+type WorkspacesRateLimitTransaction = Parameters<
+  Parameters<ReturnType<typeof db>['transaction']>[0]
+>[0];
 
-export interface ConsumeWorkspacesRateLimitResult {
-  count: number;
-  expiresAt: Date;
-}
-
-export async function consumeWorkspacesRateLimit(
-  params: ConsumeWorkspacesRateLimitParams,
-): Promise<ConsumeWorkspacesRateLimitResult> {
-  return await db().transaction(async (tx) => {
-    await tx.execute(sql`select set_config('statement_timeout', ${`${params.timeoutMs}ms`}, true)`);
-
-    const rows = await tx
+const persistence = createRateLimitPersistence<WorkspacesRateLimitTransaction>({
+  transaction: (callback) => db().transaction(callback),
+  setStatementTimeout: async (transaction, timeoutMs) => {
+    await transaction.execute(
+      sql`select set_config('statement_timeout', ${`${timeoutMs}ms`}, true)`,
+    );
+  },
+  consume: async (transaction, params) => {
+    const rows = await transaction
       .insert(workspacesRateLimits)
       .values({
         action: params.action,
@@ -46,26 +43,17 @@ export async function consumeWorkspacesRateLimit(
       })
       .returning({count: workspacesRateLimits.count, expiresAt: workspacesRateLimits.expiresAt});
 
-    const row = rows[0];
-    if (!row) throw new Error('Rate limit upsert returned no rows');
-    return row;
-  });
-}
+    return rows[0];
+  },
+  prune: async (now) => {
+    const result = await db()
+      .delete(workspacesRateLimits)
+      .where(lt(workspacesRateLimits.expiresAt, now));
+    return result.rowCount ?? 0;
+  },
+});
 
-let nextPruneAt = 0;
-
-export async function pruneExpiredWorkspacesRateLimits(
-  params: {now?: Date | undefined; minIntervalMs?: number | undefined} = {},
-): Promise<number | undefined> {
-  const now = params.now ?? new Date();
-  const minIntervalMs = params.minIntervalMs ?? 60_000;
-  if (minIntervalMs > 0 && now.getTime() < nextPruneAt) return undefined;
-
-  nextPruneAt = now.getTime() + minIntervalMs;
-
-  const result = await db()
-    .delete(workspacesRateLimits)
-    .where(lt(workspacesRateLimits.expiresAt, now));
-
-  return result.rowCount ?? 0;
-}
+export type ConsumeWorkspacesRateLimitParams = ConsumeRateLimitParams<string, string>;
+export type ConsumeWorkspacesRateLimitResult = ConsumeRateLimitResult;
+export const consumeWorkspacesRateLimit = persistence.consume;
+export const pruneExpiredWorkspacesRateLimits = persistence.prune;

--- a/libs/api/workspaces/src/db/rate-limits.ts
+++ b/libs/api/workspaces/src/db/rate-limits.ts
@@ -1,0 +1,71 @@
+import {lt, sql} from 'drizzle-orm';
+import {db} from './db.js';
+import {workspacesRateLimits} from './schema/rate-limits.js';
+
+export interface ConsumeWorkspacesRateLimitParams {
+  action: string;
+  scope: string;
+  identifierHmac: string;
+  windowStart: Date;
+  expiresAt: Date;
+  timeoutMs: number;
+}
+
+export interface ConsumeWorkspacesRateLimitResult {
+  count: number;
+  expiresAt: Date;
+}
+
+export async function consumeWorkspacesRateLimit(
+  params: ConsumeWorkspacesRateLimitParams,
+): Promise<ConsumeWorkspacesRateLimitResult> {
+  return await db().transaction(async (tx) => {
+    await tx.execute(sql`select set_config('statement_timeout', ${`${params.timeoutMs}ms`}, true)`);
+
+    const rows = await tx
+      .insert(workspacesRateLimits)
+      .values({
+        action: params.action,
+        scope: params.scope,
+        identifierHmac: params.identifierHmac,
+        windowStart: params.windowStart,
+        count: 1,
+        expiresAt: params.expiresAt,
+      })
+      .onConflictDoUpdate({
+        target: [
+          workspacesRateLimits.action,
+          workspacesRateLimits.scope,
+          workspacesRateLimits.identifierHmac,
+          workspacesRateLimits.windowStart,
+        ],
+        set: {
+          count: sql`${workspacesRateLimits.count} + 1`,
+          updatedAt: sql`now()`,
+        },
+      })
+      .returning({count: workspacesRateLimits.count, expiresAt: workspacesRateLimits.expiresAt});
+
+    const row = rows[0];
+    if (!row) throw new Error('Rate limit upsert returned no rows');
+    return row;
+  });
+}
+
+let nextPruneAt = 0;
+
+export async function pruneExpiredWorkspacesRateLimits(
+  params: {now?: Date | undefined; minIntervalMs?: number | undefined} = {},
+): Promise<number | undefined> {
+  const now = params.now ?? new Date();
+  const minIntervalMs = params.minIntervalMs ?? 60_000;
+  if (minIntervalMs > 0 && now.getTime() < nextPruneAt) return undefined;
+
+  nextPruneAt = now.getTime() + minIntervalMs;
+
+  const result = await db()
+    .delete(workspacesRateLimits)
+    .where(lt(workspacesRateLimits.expiresAt, now));
+
+  return result.rowCount ?? 0;
+}

--- a/libs/api/workspaces/src/db/schema/rate-limits.ts
+++ b/libs/api/workspaces/src/db/schema/rate-limits.ts
@@ -1,0 +1,27 @@
+import {index, integer, text, timestamp, uniqueIndex} from 'drizzle-orm/pg-core';
+import {pgTable} from './common.js';
+
+export const workspacesRateLimits = pgTable(
+  'rate_limits',
+  {
+    action: text('action').notNull(),
+    scope: text('scope').notNull(),
+    identifierHmac: text('identifier_hmac').notNull(),
+    windowStart: timestamp('window_start', {withTimezone: true}).notNull(),
+    count: integer('count').notNull().default(1),
+    expiresAt: timestamp('expires_at', {withTimezone: true}).notNull(),
+    createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', {withTimezone: true}).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex('workspaces_rate_limits_window_unique').on(
+      table.action,
+      table.scope,
+      table.identifierHmac,
+      table.windowStart,
+    ),
+    index('workspaces_rate_limits_expires_at_idx').on(table.expiresAt),
+  ],
+);
+
+export type WorkspaceRateLimitDb = typeof workspacesRateLimits.$inferSelect;

--- a/libs/api/workspaces/src/db/workspaces.ts
+++ b/libs/api/workspaces/src/db/workspaces.ts
@@ -68,6 +68,16 @@ export async function getWorkspaceById(id: string): Promise<Workspace | undefine
   return toWorkspace(row);
 }
 
+export async function isWorkspaceSlugAvailable(slug: string): Promise<boolean> {
+  const rows = await db()
+    .select({id: workspaces.id})
+    .from(workspaces)
+    .where(eq(workspaces.slug, slug))
+    .limit(1);
+
+  return rows.length === 0;
+}
+
 export interface AdminWorkspaceRow extends Workspace {
   memberCount: number;
 }

--- a/libs/api/workspaces/src/metrics/instance.ts
+++ b/libs/api/workspaces/src/metrics/instance.ts
@@ -3,6 +3,7 @@ import {instanceMetrics} from '@shipfox/node-opentelemetry';
 export type WorkspacesInvitationEmailRequested = 'requested' | 'skipped';
 export type WorkspacesMembershipChangeAction = 'added' | 'removed';
 export type WorkspacesInvitationAcceptOutcome = 'added' | 'already_member';
+export type WorkspacesRateLimitOutcome = 'allowed' | 'blocked' | 'unavailable';
 
 const meter = instanceMetrics.getMeter('workspaces');
 
@@ -27,6 +28,20 @@ const invitationAcceptedCount = meter.createCounter<{
 }>('workspaces_invitation_accepted', {
   description: 'Workspace invitations accepted by membership outcome',
 });
+
+const workspaceRateLimitCheckCount = meter.createCounter<{
+  action: 'slug-availability';
+  outcome: WorkspacesRateLimitOutcome;
+}>('workspaces_rate_limit_checks', {
+  description: 'Workspace rate-limit checks by action and outcome',
+});
+
+const workspaceRateLimitPruneFailureCount = meter.createCounter(
+  'workspaces_rate_limit_prune_failures',
+  {
+    description: 'Workspace rate-limit prune failures',
+  },
+);
 
 function recordMetric(record: () => void): void {
   try {
@@ -54,4 +69,15 @@ export function recordWorkspaceInvitationAccepted(
   outcome: WorkspacesInvitationAcceptOutcome,
 ): void {
   recordMetric(() => invitationAcceptedCount.add(1, {outcome}));
+}
+
+export function recordWorkspaceRateLimitCheck(params: {
+  action: 'slug-availability';
+  outcome: WorkspacesRateLimitOutcome;
+}): void {
+  recordMetric(() => workspaceRateLimitCheckCount.add(1, params));
+}
+
+export function recordWorkspaceRateLimitPruneFailure(): void {
+  recordMetric(() => workspaceRateLimitPruneFailureCount.add(1));
 }

--- a/libs/api/workspaces/src/presentation/routes/index.ts
+++ b/libs/api/workspaces/src/presentation/routes/index.ts
@@ -9,6 +9,7 @@ import {
   createWorkspaceRoute,
   listUserWorkspacesRoute,
   updateWorkspaceRoute,
+  workspaceSlugAvailabilityRoute,
 } from './workspaces/index.js';
 
 export const workspacesRoutes: RouteGroup[] = [
@@ -18,6 +19,7 @@ export const workspacesRoutes: RouteGroup[] = [
     routes: [
       listUserWorkspacesRoute,
       createWorkspaceRoute,
+      workspaceSlugAvailabilityRoute,
       updateWorkspaceRoute,
       {
         prefix: '/:workspaceId/members',

--- a/libs/api/workspaces/src/presentation/routes/rate-limit.ts
+++ b/libs/api/workspaces/src/presentation/routes/rate-limit.ts
@@ -1,0 +1,78 @@
+import {ClientError, type FastifyReply, type FastifyRequest} from '@shipfox/node-fastify';
+import {
+  checkWorkspacesRateLimit,
+  WORKSPACE_SLUG_AVAILABILITY_RATE_LIMIT,
+  WorkspacesRateLimitExceededError,
+  WorkspacesRateLimitUnavailableError,
+} from '#core/rate-limit.js';
+
+function routeName(request: FastifyRequest): string {
+  return request.routeOptions.url ?? request.url.split('?')[0] ?? 'unknown';
+}
+
+export function createWorkspaceSlugAvailabilityRateLimitPreHandler() {
+  return async (request: FastifyRequest, reply: FastifyReply): Promise<void> => {
+    try {
+      await checkWorkspacesRateLimit({
+        action: 'slug-availability',
+        scope: 'ip',
+        identifier: request.ip,
+        ...WORKSPACE_SLUG_AVAILABILITY_RATE_LIMIT,
+      });
+    } catch (error) {
+      if (error instanceof WorkspacesRateLimitExceededError) {
+        request.log.warn(
+          {
+            action: error.action,
+            scope: error.scope,
+            route: routeName(request),
+            retryAfterSeconds: error.retryAfterSeconds,
+            identifierHmacPrefix: error.identifierHmacPrefix,
+          },
+          'Workspace rate limit blocked request',
+        );
+        reply.header('Retry-After', String(error.retryAfterSeconds));
+        throw new ClientError('Rate limit exceeded', 'rate-limited', {
+          status: 429,
+          details: {retry_after_seconds: error.retryAfterSeconds},
+          data: {
+            action: error.action,
+            scope: error.scope,
+            route: routeName(request),
+            identifierHmacPrefix: error.identifierHmacPrefix,
+          },
+          cause: error,
+        });
+      }
+
+      if (error instanceof WorkspacesRateLimitUnavailableError) {
+        request.log.error(
+          {
+            action: error.action,
+            scope: error.scope,
+            route: routeName(request),
+            identifierHmacPrefix: error.identifierHmacPrefix,
+            err: error,
+          },
+          'Workspace rate limiter unavailable',
+        );
+        throw new ClientError(
+          'Workspace rate limiter unavailable',
+          'workspace-rate-limit-unavailable',
+          {
+            status: 503,
+            data: {
+              action: error.action,
+              scope: error.scope,
+              route: routeName(request),
+              identifierHmacPrefix: error.identifierHmacPrefix,
+            },
+            cause: error,
+          },
+        );
+      }
+
+      throw error;
+    }
+  };
+}

--- a/libs/api/workspaces/src/presentation/routes/rate-limit.ts
+++ b/libs/api/workspaces/src/presentation/routes/rate-limit.ts
@@ -1,5 +1,5 @@
 import {ClientError, type FastifyReply, type FastifyRequest} from '@shipfox/node-fastify';
-import {describeRateLimitError} from '@shipfox/node-rate-limit';
+import {enforceRateLimit as enforceSharedRateLimit} from '@shipfox/node-rate-limit';
 import {
   checkWorkspacesRateLimit,
   WORKSPACE_SLUG_AVAILABILITY_RATE_LIMIT,
@@ -11,38 +11,35 @@ function routeName(request: FastifyRequest): string {
 
 export function createWorkspaceSlugAvailabilityRateLimitPreHandler() {
   return async (request: FastifyRequest, reply: FastifyReply): Promise<void> => {
-    try {
-      await checkWorkspacesRateLimit({
-        action: 'slug-availability',
-        scope: 'ip',
-        identifier: request.ip,
-        ...WORKSPACE_SLUG_AVAILABILITY_RATE_LIMIT,
-      });
-    } catch (error) {
-      const presentation = describeRateLimitError({
-        error,
-        route: routeName(request),
-        unavailableCode: 'workspace-rate-limit-unavailable',
-        unavailableMessage: 'Workspace rate limiter unavailable',
-      });
-      if (!presentation) throw error;
-
-      if (presentation.status === 429) {
-        request.log.warn(
-          {...presentation.data, retryAfterSeconds: presentation.retryAfterSeconds},
-          'Workspace rate limit blocked request',
-        );
-        reply.header('Retry-After', String(presentation.retryAfterSeconds));
-      } else {
-        request.log.error({...presentation.data, err: error}, 'Workspace rate limiter unavailable');
-      }
-
-      throw new ClientError(presentation.message, presentation.code, {
-        status: presentation.status,
-        ...(presentation.details ? {details: presentation.details} : {}),
-        data: presentation.data,
-        cause: error,
-      });
-    }
+    await enforceSharedRateLimit({
+      request,
+      reply,
+      check: () =>
+        checkWorkspacesRateLimit({
+          action: 'slug-availability',
+          scope: 'ip',
+          identifier: request.ip,
+          ...WORKSPACE_SLUG_AVAILABILITY_RATE_LIMIT,
+        }),
+      route: routeName(request),
+      unavailableCode: 'workspace-rate-limit-unavailable',
+      unavailableMessage: 'Workspace rate limiter unavailable',
+      setRetryAfter: (reply, retryAfterSeconds) => {
+        reply.header('Retry-After', String(retryAfterSeconds));
+      },
+      logWarn: (request, context) => {
+        request.log.warn(context, 'Workspace rate limit blocked request');
+      },
+      logError: (request, context) => {
+        request.log.error(context, 'Workspace rate limiter unavailable');
+      },
+      createClientError: (presentation, cause) =>
+        new ClientError(presentation.message, presentation.code, {
+          status: presentation.status,
+          ...(presentation.details ? {details: presentation.details} : {}),
+          data: presentation.data,
+          cause,
+        }),
+    });
   };
 }

--- a/libs/api/workspaces/src/presentation/routes/rate-limit.ts
+++ b/libs/api/workspaces/src/presentation/routes/rate-limit.ts
@@ -1,9 +1,8 @@
 import {ClientError, type FastifyReply, type FastifyRequest} from '@shipfox/node-fastify';
+import {describeRateLimitError} from '@shipfox/node-rate-limit';
 import {
   checkWorkspacesRateLimit,
   WORKSPACE_SLUG_AVAILABILITY_RATE_LIMIT,
-  WorkspacesRateLimitExceededError,
-  WorkspacesRateLimitUnavailableError,
 } from '#core/rate-limit.js';
 
 function routeName(request: FastifyRequest): string {
@@ -20,59 +19,30 @@ export function createWorkspaceSlugAvailabilityRateLimitPreHandler() {
         ...WORKSPACE_SLUG_AVAILABILITY_RATE_LIMIT,
       });
     } catch (error) {
-      if (error instanceof WorkspacesRateLimitExceededError) {
+      const presentation = describeRateLimitError({
+        error,
+        route: routeName(request),
+        unavailableCode: 'workspace-rate-limit-unavailable',
+        unavailableMessage: 'Workspace rate limiter unavailable',
+      });
+      if (!presentation) throw error;
+
+      if (presentation.status === 429) {
         request.log.warn(
-          {
-            action: error.action,
-            scope: error.scope,
-            route: routeName(request),
-            retryAfterSeconds: error.retryAfterSeconds,
-            identifierHmacPrefix: error.identifierHmacPrefix,
-          },
+          {...presentation.data, retryAfterSeconds: presentation.retryAfterSeconds},
           'Workspace rate limit blocked request',
         );
-        reply.header('Retry-After', String(error.retryAfterSeconds));
-        throw new ClientError('Rate limit exceeded', 'rate-limited', {
-          status: 429,
-          details: {retry_after_seconds: error.retryAfterSeconds},
-          data: {
-            action: error.action,
-            scope: error.scope,
-            route: routeName(request),
-            identifierHmacPrefix: error.identifierHmacPrefix,
-          },
-          cause: error,
-        });
+        reply.header('Retry-After', String(presentation.retryAfterSeconds));
+      } else {
+        request.log.error({...presentation.data, err: error}, 'Workspace rate limiter unavailable');
       }
 
-      if (error instanceof WorkspacesRateLimitUnavailableError) {
-        request.log.error(
-          {
-            action: error.action,
-            scope: error.scope,
-            route: routeName(request),
-            identifierHmacPrefix: error.identifierHmacPrefix,
-            err: error,
-          },
-          'Workspace rate limiter unavailable',
-        );
-        throw new ClientError(
-          'Workspace rate limiter unavailable',
-          'workspace-rate-limit-unavailable',
-          {
-            status: 503,
-            data: {
-              action: error.action,
-              scope: error.scope,
-              route: routeName(request),
-              identifierHmacPrefix: error.identifierHmacPrefix,
-            },
-            cause: error,
-          },
-        );
-      }
-
-      throw error;
+      throw new ClientError(presentation.message, presentation.code, {
+        status: presentation.status,
+        ...(presentation.details ? {details: presentation.details} : {}),
+        data: presentation.data,
+        cause: error,
+      });
     }
   };
 }

--- a/libs/api/workspaces/src/presentation/routes/workspaces/index.ts
+++ b/libs/api/workspaces/src/presentation/routes/workspaces/index.ts
@@ -1,3 +1,4 @@
 export {createWorkspaceRoute} from './create.js';
 export {listUserWorkspacesRoute} from './list.js';
+export {workspaceSlugAvailabilityRoute} from './slug-availability.js';
 export {updateWorkspaceRoute} from './update.js';

--- a/libs/api/workspaces/src/presentation/routes/workspaces/slug-availability.test.ts
+++ b/libs/api/workspaces/src/presentation/routes/workspaces/slug-availability.test.ts
@@ -1,0 +1,159 @@
+import {sql} from 'drizzle-orm';
+import {
+  hashWorkspacesRateLimitIdentifier,
+  WORKSPACE_SLUG_AVAILABILITY_RATE_LIMIT,
+} from '#core/rate-limit.js';
+import {createWorkspaceForUser} from '#core/workspaces.js';
+import {db} from '#db/db.js';
+import {workspacesRateLimits} from '#db/schema/rate-limits.js';
+import {createWorkspacesTestApp, signupVerifyLogin} from '#test/routes.js';
+
+let ipSequence = 1;
+
+function uniqueIp(): string {
+  ipSequence += 1;
+  return `203.0.113.${ipSequence}`;
+}
+
+function windowStartFor(now: Date, windowSeconds: number): Date {
+  const windowMs = windowSeconds * 1000;
+  return new Date(Math.floor(now.getTime() / windowMs) * windowMs);
+}
+
+describe('GET /workspaces/slug-availability', () => {
+  test('returns true for an available slug and false for a taken slug', async () => {
+    const app = await createWorkspacesTestApp({fastifyOptions: {trustProxy: true}});
+    const user = await signupVerifyLogin(app, 'workspace-slug-availability');
+    const takenSlug = `taken-${crypto.randomUUID().slice(0, 8)}`;
+    await createWorkspaceForUser({
+      name: 'Taken Workspace',
+      slug: takenSlug,
+      userId: crypto.randomUUID(),
+    });
+
+    const headers = {
+      authorization: `Bearer ${user.token}`,
+      'x-forwarded-for': uniqueIp(),
+    };
+    const available = await app.inject({
+      method: 'GET',
+      url: `/workspaces/slug-availability?slug=available-${crypto.randomUUID().slice(0, 8)}`,
+      headers,
+    });
+    const taken = await app.inject({
+      method: 'GET',
+      url: `/workspaces/slug-availability?slug=${takenSlug}`,
+      headers: {...headers, 'x-forwarded-for': uniqueIp()},
+    });
+
+    expect(available.statusCode).toBe(200);
+    expect(available.json()).toEqual({available: true});
+    expect(taken.statusCode).toBe(200);
+    expect(taken.json()).toEqual({available: false});
+
+    await app.close();
+  });
+
+  test('rejects malformed slugs instead of reporting them as taken', async () => {
+    const app = await createWorkspacesTestApp({fastifyOptions: {trustProxy: true}});
+    const user = await signupVerifyLogin(app, 'workspace-slug-invalid');
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/workspaces/slug-availability?slug=Not%20A%20Slug',
+      headers: {
+        authorization: `Bearer ${user.token}`,
+        'x-forwarded-for': uniqueIp(),
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+
+    await app.close();
+  });
+
+  test('rejects unauthenticated callers', async () => {
+    const app = await createWorkspacesTestApp({fastifyOptions: {trustProxy: true}});
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/workspaces/slug-availability?slug=available',
+    });
+
+    expect(res.statusCode).toBe(401);
+
+    await app.close();
+  });
+
+  test('rate-limits repeated availability checks by source IP', async () => {
+    const app = await createWorkspacesTestApp({fastifyOptions: {trustProxy: true}});
+    const user = await signupVerifyLogin(app, 'workspace-slug-rate-limit');
+    const headers = {
+      authorization: `Bearer ${user.token}`,
+      'x-forwarded-for': uniqueIp(),
+    };
+    const url = `/workspaces/slug-availability?slug=rate-limit-${crypto.randomUUID().slice(0, 8)}`;
+    let lastResponse = await app.inject({method: 'GET', url, headers});
+
+    for (let attempt = 1; attempt <= WORKSPACE_SLUG_AVAILABILITY_RATE_LIMIT.limit; attempt += 1) {
+      lastResponse = await app.inject({method: 'GET', url, headers});
+    }
+
+    expect(lastResponse.statusCode).toBe(429);
+    expect(lastResponse.json()).toMatchObject({
+      code: 'rate-limited',
+      details: {retry_after_seconds: expect.any(Number)},
+    });
+    expect(lastResponse.headers['retry-after']).toEqual(expect.any(String));
+
+    await app.close();
+  });
+
+  test('fails closed when limiter storage is unavailable', async () => {
+    const app = await createWorkspacesTestApp({fastifyOptions: {trustProxy: true}});
+    const user = await signupVerifyLogin(app, 'workspace-slug-rate-limit-unavailable');
+    const ip = uniqueIp();
+    const now = new Date();
+    const windowStart = windowStartFor(now, WORKSPACE_SLUG_AVAILABILITY_RATE_LIMIT.windowSeconds);
+    const identifierHmac = hashWorkspacesRateLimitIdentifier({
+      action: 'slug-availability',
+      scope: 'ip',
+      identifier: ip,
+    });
+
+    await db()
+      .insert(workspacesRateLimits)
+      .values({
+        action: 'slug-availability',
+        scope: 'ip',
+        identifierHmac,
+        windowStart,
+        count: 1,
+        expiresAt: new Date(
+          windowStart.getTime() + WORKSPACE_SLUG_AVAILABILITY_RATE_LIMIT.windowSeconds * 1000,
+        ),
+      });
+
+    await db().transaction(async (tx) => {
+      await tx.execute(sql`
+        SELECT 1
+        FROM workspaces_rate_limits
+        WHERE identifier_hmac = ${identifierHmac}
+        FOR UPDATE
+      `);
+      const res = await app.inject({
+        method: 'GET',
+        url: `/workspaces/slug-availability?slug=unavailable-${crypto.randomUUID().slice(0, 8)}`,
+        headers: {
+          authorization: `Bearer ${user.token}`,
+          'x-forwarded-for': ip,
+        },
+      });
+
+      expect(res.statusCode).toBe(503);
+      expect(res.json()).toEqual({code: 'workspace-rate-limit-unavailable'});
+    });
+
+    await app.close();
+  });
+});

--- a/libs/api/workspaces/src/presentation/routes/workspaces/slug-availability.ts
+++ b/libs/api/workspaces/src/presentation/routes/workspaces/slug-availability.ts
@@ -1,0 +1,30 @@
+import {AUTH_USER, getUserContext} from '@shipfox/api-auth-context';
+import {
+  workspaceSlugAvailabilityQuerySchema,
+  workspaceSlugAvailabilityResponseSchema,
+} from '@shipfox/api-workspaces-dto';
+import {ClientError, defineRoute} from '@shipfox/node-fastify';
+import {checkWorkspaceSlugAvailability} from '#core/index.js';
+import {createWorkspaceSlugAvailabilityRateLimitPreHandler} from '../rate-limit.js';
+
+export const workspaceSlugAvailabilityRoute = defineRoute({
+  method: 'GET',
+  path: '/slug-availability',
+  description: 'Check whether a workspace slug is available.',
+  auth: AUTH_USER,
+  schema: {
+    querystring: workspaceSlugAvailabilityQuerySchema,
+    response: {
+      200: workspaceSlugAvailabilityResponseSchema,
+    },
+  },
+  preHandler: createWorkspaceSlugAvailabilityRateLimitPreHandler(),
+  handler: async (request) => {
+    const client = getUserContext(request);
+    if (!client) {
+      throw new ClientError('Authentication required', 'unauthorized', {status: 401});
+    }
+
+    return {available: await checkWorkspaceSlugAvailability(request.query.slug)};
+  },
+});

--- a/libs/api/workspaces/test/env.ts
+++ b/libs/api/workspaces/test/env.ts
@@ -5,4 +5,5 @@ process.env.POSTGRES_PASSWORD ??= 'password';
 process.env.POSTGRES_DATABASE = 'api_test';
 process.env.POSTGRES_MAX_CONNECTIONS ??= '5';
 process.env.WORKSPACE_JWT_SECRET = 'test-secret';
+process.env.AUTH_ROOT_KEY = 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=';
 process.env.TZ = 'UTC';

--- a/libs/api/workspaces/test/globalSetup.ts
+++ b/libs/api/workspaces/test/globalSetup.ts
@@ -9,7 +9,7 @@ export async function setup() {
 
   await runMigrations(db(), migrationsPath, '__drizzle_migrations_workspaces');
   await db().execute(
-    sql`TRUNCATE workspaces_admin_command_results, workspaces_outbox, workspaces_workspaces CASCADE`,
+    sql`TRUNCATE workspaces_admin_command_results, workspaces_outbox, workspaces_rate_limits, workspaces_workspaces CASCADE`,
   );
 
   closeDb();

--- a/libs/api/workspaces/test/routes.ts
+++ b/libs/api/workspaces/test/routes.ts
@@ -2,8 +2,8 @@ import type {OutgoingHttpHeaders} from 'node:http';
 import {AUTH_USER, buildUserContext, setUserContext} from '@shipfox/api-auth-context';
 import {withSlugSuffix} from '@shipfox/api-common-dto';
 import {WORKSPACES_INVITATION_SEND_REQUESTED} from '@shipfox/api-workspaces-dto';
-import type {AuthMethod} from '@shipfox/node-fastify';
-import {createApp, type FastifyInstance} from '@shipfox/node-fastify';
+import type {AppConfig, AuthMethod} from '@shipfox/node-fastify';
+import {ClientError, createApp, type FastifyInstance} from '@shipfox/node-fastify';
 import type {Mailer, MailMessage} from '@shipfox/node-mailer';
 import {hashOpaqueToken} from '@shipfox/node-tokens';
 import {and, desc, eq, sql} from 'drizzle-orm';
@@ -53,6 +53,9 @@ const fakeUserAuth: AuthMethod = {
   name: AUTH_USER,
   authenticate: async (request) => {
     const raw = request.headers.authorization?.replace(BEARER_RE, '');
+    if (!raw) {
+      throw new ClientError('Authentication required', 'unauthorized', {status: 401});
+    }
     if (raw?.startsWith('claim:')) {
       const [, userId, email, workspaceId, status] = raw.split(':');
       if (!userId || !email || !workspaceId) throw new Error('Invalid test user claim token');
@@ -145,8 +148,11 @@ export async function latestInvitationLinkTo(email: string): Promise<string> {
   return payload?.inviteLink ?? '';
 }
 
-export async function createWorkspacesTestApp(): Promise<FastifyInstance> {
+export async function createWorkspacesTestApp(
+  options: Pick<AppConfig, 'fastifyOptions'> = {},
+): Promise<FastifyInstance> {
   return await createApp({
+    ...options,
     auth: [fakeUserAuth],
     routes: workspacesRoutes,
     swagger: false,

--- a/libs/shared/node/rate-limit/src/index.test.ts
+++ b/libs/shared/node/rate-limit/src/index.test.ts
@@ -1,6 +1,7 @@
 import {
   type ConsumeRateLimitParams,
   checkRateLimit,
+  createRateLimitPersistence,
   hashRateLimitIdentifier,
   RateLimitExceededError,
   RateLimitPolicyError,
@@ -205,6 +206,54 @@ describe('checkRateLimit', () => {
     await expect(result).resolves.toBeUndefined();
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(onPruneFailure).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('createRateLimitPersistence', () => {
+  it('shares transaction timeout and missing-row handling', async () => {
+    const events: string[] = [];
+    const persistence = createRateLimitPersistence<{id: string}>({
+      transaction: async (callback) => await callback({id: 'transaction'}),
+      setStatementTimeout: (transaction, timeoutMs) => {
+        events.push(`${transaction.id}:${timeoutMs}`);
+        return Promise.resolve();
+      },
+      consume: (transaction, params) => {
+        events.push(`${transaction.id}:${params.action}`);
+        return Promise.resolve({count: 1, expiresAt: params.expiresAt});
+      },
+      prune: () => Promise.resolve(0),
+    });
+
+    await expect(
+      persistence.consume({
+        action: 'login',
+        scope: 'email',
+        identifierHmac: 'hmac',
+        windowStart: new Date('2026-06-23T00:00:00Z'),
+        expiresAt: new Date('2026-06-23T00:01:00Z'),
+        timeoutMs: 750,
+      }),
+    ).resolves.toMatchObject({count: 1});
+    expect(events).toEqual(['transaction:750', 'transaction:login']);
+  });
+
+  it('throttles opportunistic pruning through the shared persistence', async () => {
+    const prune = vi.fn(async () => 1);
+    const persistence = createRateLimitPersistence<object>({
+      transaction: async (callback) => await callback({}),
+      setStatementTimeout: () => Promise.resolve(),
+      consume: (_transaction, params) => Promise.resolve({count: 1, expiresAt: params.expiresAt}),
+      prune,
+    });
+    const firstNow = new Date('2026-06-23T00:00:00Z');
+    const secondNow = new Date('2026-06-23T00:00:30Z');
+
+    await expect(persistence.prune({now: firstNow, minIntervalMs: 60_000})).resolves.toBe(1);
+    await expect(
+      persistence.prune({now: secondNow, minIntervalMs: 60_000}),
+    ).resolves.toBeUndefined();
+    expect(prune).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/libs/shared/node/rate-limit/src/index.ts
+++ b/libs/shared/node/rate-limit/src/index.ts
@@ -42,6 +42,59 @@ export interface ConsumeRateLimitResult {
 }
 
 /**
+ * Table-specific operations used by the shared fixed-window persistence
+ * mechanics. Each API package keeps its own table and database boundary.
+ */
+export interface RateLimitPersistenceAdapter<
+  Transaction,
+  Action extends string = string,
+  Scope extends string = string,
+> {
+  transaction: <Result>(callback: (transaction: Transaction) => Promise<Result>) => Promise<Result>;
+  setStatementTimeout: (transaction: Transaction, timeoutMs: number) => Promise<void>;
+  consume: (
+    transaction: Transaction,
+    params: ConsumeRateLimitParams<Action, Scope>,
+  ) => Promise<ConsumeRateLimitResult | undefined>;
+  prune: (now: Date) => Promise<number>;
+}
+
+/**
+ * Builds table-owned rate-limit persistence functions with shared transaction,
+ * timeout, missing-row, and opportunistic-pruning behavior.
+ */
+export function createRateLimitPersistence<
+  Transaction,
+  Action extends string = string,
+  Scope extends string = string,
+>(adapter: RateLimitPersistenceAdapter<Transaction, Action, Scope>) {
+  let nextPruneAt = 0;
+
+  return {
+    consume: async (
+      params: ConsumeRateLimitParams<Action, Scope>,
+    ): Promise<ConsumeRateLimitResult> => {
+      return await adapter.transaction(async (transaction) => {
+        await adapter.setStatementTimeout(transaction, params.timeoutMs);
+        const result = await adapter.consume(transaction, params);
+        if (!result) throw new Error('Rate limit upsert returned no rows');
+        return result;
+      });
+    },
+    prune: async (
+      params: {now?: Date | undefined; minIntervalMs?: number | undefined} = {},
+    ): Promise<number | undefined> => {
+      const now = params.now ?? new Date();
+      const minIntervalMs = params.minIntervalMs ?? 60_000;
+      if (minIntervalMs > 0 && now.getTime() < nextPruneAt) return undefined;
+
+      nextPruneAt = now.getTime() + minIntervalMs;
+      return await adapter.prune(now);
+    },
+  };
+}
+
+/**
  * Parameters for one rate-limit check.
  *
  * Callers provide product policy, HMAC separation, persistence, and metrics.
@@ -140,6 +193,64 @@ export class RateLimitPolicyError extends Error {
     super(message);
     this.name = 'RateLimitPolicyError';
   }
+}
+
+export interface RateLimitErrorPresentation {
+  status: 429 | 503;
+  code: string;
+  message: string;
+  retryAfterSeconds?: number;
+  details?: {retry_after_seconds: number};
+  data: {
+    action: string;
+    scope: string;
+    route: string;
+    identifierHmacPrefix: string;
+  };
+}
+
+/**
+ * Normalizes rate-limit failures for HTTP adapters without coupling this
+ * shared package to a specific web framework or domain error type.
+ */
+export function describeRateLimitError(params: {
+  error: unknown;
+  route: string;
+  unavailableCode: string;
+  unavailableMessage: string;
+}): RateLimitErrorPresentation | undefined {
+  const {error} = params;
+  if (error instanceof RateLimitExceededError) {
+    return {
+      status: 429,
+      code: 'rate-limited',
+      message: 'Rate limit exceeded',
+      retryAfterSeconds: error.retryAfterSeconds,
+      details: {retry_after_seconds: error.retryAfterSeconds},
+      data: {
+        action: error.action,
+        scope: error.scope,
+        route: params.route,
+        identifierHmacPrefix: error.identifierHmacPrefix,
+      },
+    };
+  }
+
+  if (error instanceof RateLimitUnavailableError) {
+    return {
+      status: 503,
+      code: params.unavailableCode,
+      message: params.unavailableMessage,
+      data: {
+        action: error.action,
+        scope: error.scope,
+        route: params.route,
+        identifierHmacPrefix: error.identifierHmacPrefix,
+      },
+    };
+  }
+
+  return undefined;
 }
 
 const DEFAULT_TIMEOUT_MS = 250;

--- a/libs/shared/node/rate-limit/src/index.ts
+++ b/libs/shared/node/rate-limit/src/index.ts
@@ -195,12 +195,7 @@ export class RateLimitPolicyError extends Error {
   }
 }
 
-export interface RateLimitErrorPresentation {
-  status: 429 | 503;
-  code: string;
-  message: string;
-  retryAfterSeconds?: number;
-  details?: {retry_after_seconds: number};
+interface RateLimitErrorPresentationBase {
   data: {
     action: string;
     scope: string;
@@ -208,6 +203,27 @@ export interface RateLimitErrorPresentation {
     identifierHmacPrefix: string;
   };
 }
+
+export type RateLimitErrorPresentation =
+  | (RateLimitErrorPresentationBase & {
+      status: 429;
+      code: 'rate-limited';
+      message: 'Rate limit exceeded';
+      retryAfterSeconds: number;
+      details: {retry_after_seconds: number};
+    })
+  | (RateLimitErrorPresentationBase & {
+      status: 503;
+      code: string;
+      message: string;
+      details?: never;
+      retryAfterSeconds?: never;
+    });
+
+export type RateLimitLogContext = RateLimitErrorPresentation['data'] & {
+  retryAfterSeconds?: number;
+  err?: unknown;
+};
 
 /**
  * Normalizes rate-limit failures for HTTP adapters without coupling this
@@ -251,6 +267,48 @@ export function describeRateLimitError(params: {
   }
 
   return undefined;
+}
+
+/**
+ * Runs one rate-limit check and centralizes HTTP adapter error handling.
+ * Callers provide only their domain checker, messages, logging, and framework
+ * error constructor.
+ */
+export async function enforceRateLimit<Request, Reply>(params: {
+  request: Request;
+  reply: Reply;
+  check: () => Promise<void>;
+  route: string;
+  unavailableCode: string;
+  unavailableMessage: string;
+  setRetryAfter: (reply: Reply, retryAfterSeconds: number) => void;
+  logWarn: (request: Request, context: RateLimitLogContext) => void;
+  logError: (request: Request, context: RateLimitLogContext) => void;
+  createClientError: (presentation: RateLimitErrorPresentation, cause: unknown) => Error;
+}): Promise<void> {
+  try {
+    await params.check();
+  } catch (error) {
+    const presentation = describeRateLimitError({
+      error,
+      route: params.route,
+      unavailableCode: params.unavailableCode,
+      unavailableMessage: params.unavailableMessage,
+    });
+    if (!presentation) throw error;
+
+    if (presentation.status === 429) {
+      params.logWarn(params.request, {
+        ...presentation.data,
+        retryAfterSeconds: presentation.retryAfterSeconds,
+      });
+      params.setRetryAfter(params.reply, presentation.retryAfterSeconds);
+    } else {
+      params.logError(params.request, {...presentation.data, err: error});
+    }
+
+    throw params.createClientError(presentation, error);
+  }
 }
 
 const DEFAULT_TIMEOUT_MS = 250;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4499,6 +4499,9 @@ importers:
       '@shipfox/inter-module':
         specifier: workspace:*
         version: link:../../shared/common/inter-module
+      '@shipfox/node-auth-root-key':
+        specifier: workspace:*
+        version: link:../../shared/node/auth-root-key
       '@shipfox/node-drizzle':
         specifier: workspace:*
         version: link:../../shared/node/drizzle
@@ -4523,6 +4526,9 @@ importers:
       '@shipfox/node-postgres':
         specifier: workspace:*
         version: link:../../shared/node/postgres
+      '@shipfox/node-rate-limit':
+        specifier: workspace:*
+        version: link:../../shared/node/rate-limit
       '@shipfox/node-tokens':
         specifier: workspace:*
         version: link:../../shared/node/tokens


### PR DESCRIPTION
Adds an authenticated `GET /workspaces/slug-availability?slug=...` endpoint that returns whether a workspace slug is available.

The endpoint validates slugs, applies a source-IP rate limit backed by HMAC identifiers, fails closed when limiter storage is unavailable, and adds the required DTOs, migration, documentation, and focused coverage for concurrency, pruning, hashing, and HTTP behavior.

Closes ENG-1453

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an authenticated `GET /workspaces/slug-availability?slug=...` endpoint and centralizes rate-limit persistence, error translation, and HTTP pre-handler orchestration via `@shipfox/node-rate-limit` for consistent 429/503 behavior across services. Closes ENG-1453.

- New Features
  - Endpoint returns `{available: boolean}`; requires auth; validates slugs (400 on malformed).
  - Per-IP rate limit: 60 requests per 5 minutes using HMAC-hashed identifiers; over limit returns 429 with `Retry-After`; fails closed with 503 (`workspace-rate-limit-unavailable`); emits metrics.
  - Uses shared rate-limit persistence, error presentation, and pre-handler orchestration from `@shipfox/node-rate-limit`; refactors `@shipfox/api-auth` and `@shipfox/api-runners` to the same flow.
  - Adds DTOs in `@shipfox/api-workspaces-dto`, focused tests, and docs; new deps: `@shipfox/node-rate-limit`, `@shipfox/node-auth-root-key`.

- Migration
  - Run migrations to create `workspaces_rate_limits`.
  - Set `AUTH_ROOT_KEY` for HMAC hashing of source IPs.

<sup>Written for commit 96600f17a91ac2b0129d08bad31425c60150baf0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

