### PR TITLE
[expression] Align predicate property types with runtime

### DIFF
--- a/.changeset/align-predicate-contexts.md
+++ b/.changeset/align-predicate-contexts.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/api-definitions": major
+"@shipfox/api-workflows": patch
+"@shipfox/expression": major
+---
+
+Align predicate property types with their runtime shapes, replace `run.run_name` with `run.workflow_name`, and remove `failed` from `executions` entries.

--- a/apps/docs/content/docs/reference/expressions.mdx
+++ b/apps/docs/content/docs/reference/expressions.mdx
@@ -108,8 +108,8 @@ gate:
 A job's optional `success` expression decides whether the job succeeded once
 all its executions settle. In scope is `executions`, a list where each element
 carries `index`, `name`, `status`, `events`, `outputs`, and timing fields, plus
-`vars`. The default succeeds when no execution failed. It also succeeds when a
-listening job resolves with no executions:
+`jobs` and `vars`. The default succeeds when no execution failed. It also
+succeeds when a listening job resolves with no executions:
 
 This job fragment belongs under an existing workflow's `jobs` map:
 

--- a/libs/api/definitions/src/core/workflow-model/normalize-if-condition.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-if-condition.ts
@@ -21,7 +21,6 @@ const ifExpressionSyntax = `\${{ }}`;
 export function normalizeIfCondition(params: {
   readonly field: Extract<WorkflowPredicateField, 'job.if' | 'step.if'>;
   readonly source: string | undefined;
-  readonly site: 'job-activation' | 'step-dispatch';
   readonly path: readonly WorkflowModelValidationIssuePathSegment[];
   readonly invalidCode: Extract<
     WorkflowModelValidationIssueCode,
@@ -59,7 +58,6 @@ export function normalizeIfCondition(params: {
   return validatePredicateExpression({
     field: params.field,
     source: expressionSegment.expression.source,
-    site: params.site,
     path: params.path,
     invalidCode: params.invalidCode,
     invalidMessage: params.invalidMessage,

--- a/libs/api/definitions/src/core/workflow-model/normalize-job-listening.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-job-listening.ts
@@ -108,7 +108,6 @@ function normalizeListeningTrigger(params: {
     validatePredicateExpression({
       field: params.field,
       source: params.trigger.filter,
-      site: 'job-activation',
       path: params.path,
       invalidCode: 'invalid-listener-filter',
       invalidMessage: `${params.field === 'listener.on' ? 'Listener on' : 'Listener until'} filter must be a valid CEL boolean expression.`,

--- a/libs/api/definitions/src/core/workflow-model/normalize-job-success.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-job-success.ts
@@ -17,7 +17,6 @@ export function normalizeJobSuccess(params: {
   const expression = validatePredicateExpression({
     field: 'job.success',
     source: params.source,
-    site: 'job-resolution',
     path: ['jobs', params.sourceName, 'success'],
     invalidCode: 'invalid-job-success',
     invalidMessage: 'Job success must be a valid CEL boolean expression.',

--- a/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
@@ -229,7 +229,6 @@ function normalizeJob(params: {
   const condition = normalizeIfCondition({
     field: 'job.if',
     source: params.job.if,
-    site: 'job-activation',
     path: ['jobs', params.sourceName, 'if'],
     invalidCode: 'invalid-job-if',
     invalidMessage: 'Job if must be a valid wrapped CEL boolean expression.',
@@ -584,7 +583,6 @@ function normalizeStep(params: {
   const condition = normalizeIfCondition({
     field: 'step.if',
     source: params.step.if,
-    site: 'step-dispatch',
     path: ['jobs', params.sourceName, 'steps', params.index, 'if'],
     invalidCode: 'invalid-step-if',
     invalidMessage: 'Step if must be a valid wrapped CEL boolean expression.',

--- a/libs/api/definitions/src/core/workflow-model/normalize-step-gate.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-step-gate.ts
@@ -79,7 +79,6 @@ function normalizeGateSuccess(params: {
   return validatePredicateExpression({
     field: 'step.success',
     source: params.source,
-    site: 'step-report',
     path: ['jobs', params.sourceName, 'steps', params.stepIndex, 'gate', 'success'],
     invalidCode: 'invalid-step-gate-success',
     invalidMessage: 'Step gate success must be a valid CEL boolean expression.',

--- a/libs/api/definitions/src/core/workflow-model/normalize-triggers.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-triggers.ts
@@ -107,7 +107,6 @@ function validateTriggerFilter(params: {
   validatePredicateExpression({
     field: 'trigger.filter',
     source: trigger.filter,
-    site: 'ingest',
     path,
     invalidCode: 'invalid-trigger-filter',
     invalidMessage: 'Trigger filter must be a valid boolean predicate.',

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -151,7 +151,7 @@ describe('normalizeWorkflowDocument', () => {
   it('allows computed access to unrelated dynamic-name context fields', () => {
     const model = normalizeWorkflowDocument({
       name: 'Workflow',
-      run_name: interpolation('run["name"]'),
+      run_name: interpolation('run["workflow_name"]'),
       jobs: {
         build: {
           execution_name: interpolation('execution["status"]'),
@@ -169,7 +169,7 @@ describe('normalizeWorkflowDocument', () => {
       'run_name',
       {
         name: 'Workflow',
-        run_name: interpolation('run.run_name'),
+        run_name: interpolation('run.name'),
         jobs: {build: {steps: [{run: 'build'}]}},
       },
     ],
@@ -177,7 +177,7 @@ describe('normalizeWorkflowDocument', () => {
       'run_name bracket access',
       {
         name: 'Workflow',
-        run_name: interpolation('run["run_name"]'),
+        run_name: interpolation('run["name"]'),
         jobs: {build: {steps: [{run: 'build'}]}},
       },
     ],
@@ -1232,7 +1232,7 @@ describe('normalizeWorkflowDocument', () => {
     ]);
   });
 
-  it('validates listener filters against job-activation roots', () => {
+  it('validates listener filters against their persisted snapshot roots', () => {
     const document: WorkflowDocument = {
       name: 'listener filter roots',
       jobs: {
@@ -1274,6 +1274,8 @@ describe('normalizeWorkflowDocument', () => {
   it.each([
     ['step root', 'step.status == "succeeded"', 'context-unavailable-at-predicate-site'],
     ['steps root', 'steps.build.outputs.sha == "abc"', 'context-unavailable-at-predicate-site'],
+    ['executions root', 'executions.size() > 0', 'context-unavailable-at-predicate-site'],
+    ['matrix root', 'matrix.os == "linux"', 'context-unavailable-at-predicate-site'],
     ['runner root', 'runner.os == "linux"', 'runner-context-in-server-predicate'],
     ['non-boolean source', 'event.action', 'invalid-listener-filter'],
   ] as const)('reports invalid listener on filters for %s', (_label, filter, code) => {

--- a/libs/api/definitions/src/core/workflow-model/validate-predicate-expression.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/validate-predicate-expression.test.ts
@@ -1,11 +1,13 @@
-import type {ExpressionTypeEnvironment} from '@shipfox/expression';
+import {
+  type ExpressionTypeEnvironment,
+  getWorkflowPredicateFieldMinimumFillTarget,
+} from '@shipfox/expression';
 import type {WorkflowModelValidationIssue} from './invalid-workflow-model-error.js';
 import {validatePredicateExpression} from './validate-predicate-expression.js';
 
 function validate(params: {
   source: string;
   field: Parameters<typeof validatePredicateExpression>[0]['field'];
-  site: Parameters<typeof validatePredicateExpression>[0]['site'];
   allowedJobReferences?: ReadonlySet<string>;
   typeOverlay?: ExpressionTypeEnvironment;
 }): {
@@ -16,7 +18,6 @@ function validate(params: {
   const expression = validatePredicateExpression({
     field: params.field,
     source: params.source,
-    site: params.site,
     path: ['predicate'],
     invalidCode: 'invalid-job-success',
     invalidMessage: 'Predicate must be a valid CEL boolean expression.',
@@ -36,7 +37,7 @@ describe('validatePredicateExpression', () => {
     ['trigger.event == "push"', 'typed'],
     ['has(event.ref)', 'syntax'],
   ] as const)('accepts trigger filters at ingest: %s', (source, check) => {
-    const result = validate({field: 'trigger.filter', source, site: 'ingest'});
+    const result = validate({field: 'trigger.filter', source});
 
     expect(result.issues).toEqual([]);
     expect(result.expression).toMatchObject({source, check});
@@ -46,7 +47,7 @@ describe('validatePredicateExpression', () => {
     ['event.ref', 'Predicate source must be boolean-shaped.'],
     ['trigger.event', 'must return bool'],
   ])('rejects non-boolean trigger filters: %s', (source, reason) => {
-    const result = validate({field: 'trigger.filter', source, site: 'ingest'});
+    const result = validate({field: 'trigger.filter', source});
 
     expect(result.expression).toBeUndefined();
     expect(result.issues).toEqual([
@@ -66,7 +67,7 @@ describe('validatePredicateExpression', () => {
     'jobs.build.status == "succeeded"',
     'vars.ENV == "prod"',
   ])('rejects trigger filter roots that are unavailable at ingest: %s', (source) => {
-    const result = validate({field: 'trigger.filter', source, site: 'ingest'});
+    const result = validate({field: 'trigger.filter', source});
 
     expect(result.expression).toBeUndefined();
     expect(result.issues).toEqual([
@@ -80,7 +81,7 @@ describe('validatePredicateExpression', () => {
   it.each([
     ['runner.os == "linux"', 'runner-context-in-server-predicate'],
   ])('rejects forbidden server predicate roots: %s', (source, code) => {
-    const result = validate({field: 'trigger.filter', source, site: 'ingest'});
+    const result = validate({field: 'trigger.filter', source});
 
     expect(result.expression).toBeUndefined();
     expect(result.issues).toEqual([
@@ -99,10 +100,10 @@ describe('validatePredicateExpression', () => {
     ['listener.on', 'job-activation'],
     ['listener.until', 'job-activation'],
   ] as const)('accepts vars in %s at its evaluation site', (field, site) => {
+    expect(getWorkflowPredicateFieldMinimumFillTarget(field)).toBe(site);
     const result = validate({
       field,
       source: 'vars.ENABLED == "true"',
-      site,
     });
 
     expect(result.issues).toEqual([]);
@@ -110,15 +111,15 @@ describe('validatePredicateExpression', () => {
   });
 
   it.each([
-    ['step.success', 'step-report', 'step.status == "succeeded"'],
-    ['job.success', 'job-resolution', 'executions.all(e, e.status == "succeeded")'],
-    ['trigger.filter', 'ingest', 'event.action == "created"'],
-    ['listener.on', 'job-activation', 'trigger.event == "pull_request"'],
-    ['listener.until', 'job-activation', 'job.key == "await-review"'],
-    ['job.if', 'job-activation', 'needs.exists(n, n.status == "succeeded")'],
-    ['step.if', 'step-dispatch', 'execution.status == "running"'],
-  ] as const)('accepts the runtime context contract for %s', (field, site, source) => {
-    const result = validate({field, source, site});
+    ['step.success', 'step.status == "succeeded"'],
+    ['job.success', 'executions.all(e, e.status == "succeeded")'],
+    ['trigger.filter', 'event.action == "created"'],
+    ['listener.on', 'trigger.event == "pull_request"'],
+    ['listener.until', 'job.key == "await-review"'],
+    ['job.if', 'needs.exists(n, n.status == "succeeded")'],
+    ['step.if', 'execution.status == "running"'],
+  ] as const)('accepts the runtime context contract for %s', (field, source) => {
+    const result = validate({field, source});
 
     expect(result.issues).toEqual([]);
     expect(result.expression).toMatchObject({source});
@@ -151,13 +152,15 @@ describe('validatePredicateExpression', () => {
     ['job.if', 'job-activation', 'execution.status == "running"', 'execution', 'Job if'],
     ['step.if', 'step-dispatch', 'run.id == "run-1"', 'run', 'Step if'],
   ] as const)('rejects roots omitted from the %s runtime context', (field, site, source, root, label) => {
-    const result = validate({field, source, site});
+    const result = validate({field, source});
 
     expect(result.expression).toBeUndefined();
     expect(result.issues).toEqual([
       expect.objectContaining({
         code: 'context-unavailable-at-predicate-site',
-        message: expect.stringContaining(`"${root}" is not supplied to ${label}.`),
+        message: expect.stringContaining(
+          `"${root}" that is not supplied when ${label} is evaluated at`,
+        ),
         details: expect.objectContaining({
           field,
           source,
@@ -181,7 +184,6 @@ describe('validatePredicateExpression', () => {
     const result = validate({
       field,
       source,
-      site: 'job-activation',
       ...(allowedJobs === undefined ? {} : {allowedJobReferences: allowedJobs}),
     });
 
@@ -193,7 +195,7 @@ describe('validatePredicateExpression', () => {
     'step.status == "succeeded"',
     'steps.build.outputs.sha == "abc"',
   ])('rejects listener roots that are unavailable at job activation: %s', (source) => {
-    const result = validate({field: 'listener.on', source, site: 'job-activation'});
+    const result = validate({field: 'listener.on', source});
 
     expect(result.expression).toBeUndefined();
     expect(result.issues).toEqual([
@@ -204,11 +206,72 @@ describe('validatePredicateExpression', () => {
     ]);
   });
 
+  it.each([
+    ['listener.on', 'executions.size() > 0', 'executions'],
+    ['listener.until', 'execution.status == "waiting"', 'execution'],
+    ['listener.on', 'needs.size() > 0', 'needs'],
+    ['listener.until', 'matrix.os == "linux"', 'matrix'],
+    ['job.if', 'job.key == "build"', 'job'],
+    ['job.if', 'executions.size() > 0', 'executions'],
+    ['step.if', 'run.id == "run-1"', 'run'],
+    ['step.success', 'execution.status == "failed"', 'execution'],
+    ['job.success', 'run.id == "run-1"', 'run'],
+  ] as const)('rejects %s context that its runtime evaluator does not supply: %s', (field, source, unavailableRoot) => {
+    const result = validate({field, source});
+
+    expect(result.expression).toBeUndefined();
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: 'context-unavailable-at-predicate-site',
+        details: expect.objectContaining({
+          field,
+          source,
+          unavailableRoots: [unavailableRoot],
+        }),
+      }),
+    ]);
+  });
+
+  it.each([
+    ['step.if', 'step.exit_code == 0'],
+    ['step.success', 'step.attempt > 1'],
+    ['job.success', 'executions.exists(e, e.failed)'],
+  ] as const)('rejects %s properties absent from its runtime shape: %s', (field, source) => {
+    const result = validate({field, source, typeOverlay: {}});
+
+    expect(result.expression).toBeUndefined();
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: 'invalid-job-success',
+        details: expect.objectContaining({
+          field,
+          source,
+          reason: expect.stringContaining('No such key'),
+        }),
+      }),
+    ]);
+  });
+
+  it('still checks typed properties when a predicate also uses open context', () => {
+    const result = validate({
+      field: 'step.success',
+      source: 'step.attempt > 1 && vars.RETRY == "true"',
+    });
+
+    expect(result.expression).toBeUndefined();
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        details: expect.objectContaining({
+          reason: expect.stringContaining('No such key: attempt'),
+        }),
+      }),
+    ]);
+  });
+
   it('rejects listener job references without a direct needs edge', () => {
     const result = validate({
       field: 'listener.on',
       source: 'jobs.build.outputs.pr_number == event.issue.number',
-      site: 'job-activation',
       allowedJobReferences: new Set(['test']),
     });
 
@@ -225,7 +288,6 @@ describe('validatePredicateExpression', () => {
     const result = validate({
       field: 'job.success',
       source: 'jobs.build.outputs.ready',
-      site: 'job-resolution',
     });
 
     expect(result.issues).toEqual([]);

--- a/libs/api/definitions/src/core/workflow-model/validate-predicate-expression.ts
+++ b/libs/api/definitions/src/core/workflow-model/validate-predicate-expression.ts
@@ -1,15 +1,15 @@
 import {
   type AvailabilitySite,
-  availabilitySites,
   createWorkflowExpression,
+  type ExpressionType,
   type ExpressionTypeEnvironment,
   extractExactContextRoots,
   getWorkflowContextDefinition,
-  getWorkflowContextTypeEnvironment,
   getWorkflowPredicateContextRoots,
+  getWorkflowPredicateFieldMinimumFillTarget,
+  getWorkflowPredicateFieldTypeEnvironment,
   InvalidWorkflowExpressionError,
   predicateSourceIsBooleanShaped,
-  resolveContextRootAvailability,
   resolveContextRootHost,
   validateServerEvaluable,
   type WorkflowContextName,
@@ -29,7 +29,6 @@ import {workflowFieldLabel} from './workflow-field-label.js';
 export function validatePredicateExpression(params: {
   field: WorkflowPredicateField;
   source: string;
-  site: AvailabilitySite;
   path: readonly WorkflowModelValidationIssuePathSegment[];
   invalidCode: WorkflowModelValidationIssueCode;
   invalidMessage: string;
@@ -37,6 +36,7 @@ export function validatePredicateExpression(params: {
   allowedJobReferences?: ReadonlySet<string>;
   typeOverlay?: ExpressionTypeEnvironment | undefined;
 }): WorkflowExpression | undefined {
+  const site = getWorkflowPredicateFieldMinimumFillTarget(params.field);
   const syntaxExpression = createSyntaxExpression(params);
   if (syntaxExpression === undefined) return undefined;
 
@@ -55,6 +55,7 @@ export function validatePredicateExpression(params: {
       ...serverEvaluability.violations.map((violation) =>
         runnerContextInServerPredicateIssue({
           ...params,
+          site,
           contextRoots,
           runnerRoots: violation.runnerRoots,
         }),
@@ -65,17 +66,15 @@ export function validatePredicateExpression(params: {
 
   const predicateContextRoots = getWorkflowPredicateContextRoots(params.field);
   const unavailableRoots = knownRoots.filter(
-    (root) =>
-      !predicateContextRoots.includes(root as (typeof predicateContextRoots)[number]) ||
-      !isRootAvailableAt(root, params.site),
+    (root) => !predicateContextRoots.includes(root as (typeof predicateContextRoots)[number]),
   );
   if (unavailableRoots.length > 0) {
     params.issues.push(
       unavailablePredicateContextIssue({
         ...params,
+        site,
         contextRoots,
         unavailableRoots,
-        predicateContextRoots,
       }),
     );
     return undefined;
@@ -96,7 +95,11 @@ export function validatePredicateExpression(params: {
     return undefined;
   }
 
-  if (params.typeOverlay === undefined && knownRoots.some((root) => hasSyntaxOnlyCheckMode(root))) {
+  if (
+    params.typeOverlay === undefined &&
+    knownRoots.length > 0 &&
+    knownRoots.every((root) => hasSyntaxOnlyCheckMode(root))
+  ) {
     if (
       isWorkflowFilterPredicateField(params.field) &&
       !predicateSourceIsBooleanShaped(syntaxExpression.source)
@@ -121,7 +124,7 @@ export function validatePredicateExpression(params: {
         mode: 'typed',
         // `undefined` preserves the legacy syntax-only path above. `{}` means
         // callers intentionally requested typed checking with the standard roots.
-        typeEnvironment: mergeTypeEnvironments(knownRoots, params.typeOverlay),
+        typeEnvironment: mergeTypeEnvironments(params.field, knownRoots, params.typeOverlay),
         expectedResultType: 'bool',
       },
     });
@@ -232,7 +235,6 @@ function unavailablePredicateContextIssue(params: {
   path: readonly WorkflowModelValidationIssuePathSegment[];
   contextRoots: readonly string[];
   unavailableRoots: readonly string[];
-  predicateContextRoots: readonly string[];
 }): WorkflowModelValidationIssue {
   return issue({
     code: 'context-unavailable-at-predicate-site',
@@ -240,11 +242,9 @@ function unavailablePredicateContextIssue(params: {
       params.unavailableRoots,
     )} ${formatList(params.unavailableRoots)} that ${availabilityVerb(
       params.unavailableRoots,
-    )} not available in its evaluation context at ${describeAvailabilitySite(params.site)}. ${params.unavailableRoots
-      .map((root) =>
-        unavailableRootAvailabilityMessage(root, params.field, params.predicateContextRoots),
-      )
-      .join(' ')}`,
+    )} not supplied when ${fieldLabel(params.field)} is evaluated at ${describeAvailabilitySite(
+      params.site,
+    )}.`,
     path: params.path,
     details: {
       field: params.field,
@@ -256,33 +256,13 @@ function unavailablePredicateContextIssue(params: {
   });
 }
 
-function isRootAvailableAt(root: string, site: AvailabilitySite): boolean {
-  const availability = resolveContextRootAvailability(root);
-  if (availability === undefined) return false;
-
-  return availabilitySites.indexOf(availability) <= availabilitySites.indexOf(site);
-}
-
-function unavailableRootAvailabilityMessage(
-  root: string,
-  field: WorkflowPredicateField,
-  predicateContextRoots: readonly string[],
-): string {
-  if (!predicateContextRoots.includes(root)) {
-    return `"${root}" is not supplied to ${fieldLabel(field)}.`;
-  }
-
-  const availability = resolveContextRootAvailability(root);
-  if (availability === undefined) return `"${root}" is not available at any server site.`;
-  return `"${root}" becomes available at ${describeAvailabilitySite(availability)}.`;
-}
-
 function hasSyntaxOnlyCheckMode(root: string): boolean {
   if (!isWorkflowContextName(root)) return resolveContextRootHost(root) === 'server';
   return isWorkflowContextName(root) && getWorkflowContextDefinition(root).checkMode === 'syntax';
 }
 
 function mergeTypeEnvironments(
+  field: WorkflowPredicateField,
   roots: readonly string[],
   typeOverlay?: ExpressionTypeEnvironment,
 ): ExpressionTypeEnvironment {
@@ -290,26 +270,43 @@ function mergeTypeEnvironments(
 
   for (const root of roots) {
     const overlayType = typeOverlay?.[root];
-    if (overlayType !== undefined) {
-      typeEnvironment[root] = overlayType;
-      continue;
-    }
-
     if (!isWorkflowContextName(root)) {
-      if (typeOverlay !== undefined) typeEnvironment[root] = {kind: 'map'};
+      if (overlayType !== undefined) typeEnvironment[root] = overlayType;
+      else typeEnvironment[root] = {kind: 'map'};
       continue;
     }
 
-    const contextTypeEnvironment = getWorkflowContextTypeEnvironment(root);
+    const contextTypeEnvironment = getWorkflowPredicateFieldTypeEnvironment(field, root);
     if (contextTypeEnvironment === undefined) {
-      if (typeOverlay !== undefined) typeEnvironment[root] = {kind: 'map'};
+      if (overlayType !== undefined) typeEnvironment[root] = overlayType;
+      else typeEnvironment[root] = {kind: 'map'};
       continue;
     }
 
-    Object.assign(typeEnvironment, contextTypeEnvironment);
+    const contextType = contextTypeEnvironment[root];
+    if (contextType === undefined) continue;
+    typeEnvironment[root] =
+      overlayType === undefined ? contextType : overlayKnownFields(contextType, overlayType);
   }
 
   return typeEnvironment;
+}
+
+function overlayKnownFields(base: ExpressionType, overlay: ExpressionType): ExpressionType {
+  if (typeof base === 'string' || typeof overlay === 'string') return overlay;
+  if (base.kind !== 'object' || overlay.kind !== 'object') return overlay;
+
+  // Preserve output specialization without reintroducing properties absent from this field's
+  // runtime shape.
+  return {
+    kind: 'object',
+    fields: Object.fromEntries(
+      Object.entries(base.fields).map(([key, fieldType]) => [
+        key,
+        overlay.fields[key] ?? fieldType,
+      ]),
+    ),
+  };
 }
 
 function isWorkflowContextName(root: string): root is WorkflowContextName {

--- a/libs/api/workflows/src/core/job-transition/derive-job-success.ts
+++ b/libs/api/workflows/src/core/job-transition/derive-job-success.ts
@@ -9,8 +9,7 @@ import type {JobStatusReason} from '../entities/job.js';
 import type {JobExecution} from '../entities/job-execution.js';
 import type {PersistedEvaluationTraceEntry} from '../entities/step.js';
 import {
-  assembleExecutionsContext,
-  assembleJobsContext,
+  assembleJobResolutionContext,
   type JobContextInput,
 } from '../step-config/assemble-run-context.js';
 import type {RuntimeCompletionStatus} from '../workflow-scheduling/runtime-dag.js';
@@ -31,23 +30,19 @@ export function deriveJobSuccess(params: {
     source: params.success ?? DEFAULT_JOB_SUCCESS,
     check: {mode: 'syntax'},
   });
-  const context = {
-    ...(params.vars === undefined ? {} : {vars: params.vars}),
-    ...assembleExecutionsContext(params.executions),
-    ...assembleJobsContext(params.jobs),
-  };
+  const context = assembleJobResolutionContext(params);
   const outcome = evaluatePlannedPredicateAtSite({
     expression,
     field: 'job.success',
-    site: 'job-resolution',
-    context,
+    site: context.site,
+    context: context.values,
   });
   const trace = capTraceEntries([
     {
       ...predicateTraceEntry({
         expression: expression.source,
         route: outcome.route,
-        site: 'job-resolution',
+        site: context.site,
         value: outcome.value,
         degraded: outcome.evaluationFailed,
       }),

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
@@ -1,3 +1,4 @@
+import {getWorkflowPredicateContextRoots} from '@shipfox/expression';
 import type {JobExecution} from '#core/entities/job-execution.js';
 import type {Step, StepAttempt} from '#core/entities/step.js';
 import {
@@ -271,6 +272,9 @@ describe('assembleJobActivationContext', () => {
       ],
     });
 
+    expect(Object.keys(context.values).sort()).toEqual(
+      [...getWorkflowPredicateContextRoots('job.if')].sort(),
+    );
     expect(context).toEqual({
       site: 'job-activation',
       values: {
@@ -332,6 +336,7 @@ describe('assembleJobActivationContext', () => {
             executions: [],
           },
         ],
+        vars: {},
       },
     });
   });
@@ -362,7 +367,7 @@ describe('listener filter snapshots', () => {
           source: 'github',
           event: 'pull_request',
           filter:
-            'jobs.build.outputs.pr_number == event.pull_request.number && inputs.environment == "prod" && trigger.event == "pull_request" && run.id != "" && job.key == "await"',
+            'jobs.build.outputs.pr_number == event.pull_request.number && inputs.environment == "prod" && trigger.event == "pull_request" && run.id != "" && job.key == "await" && vars.ENABLED == "true"',
         },
       ],
       until: null,
@@ -372,6 +377,7 @@ describe('listener filter snapshots', () => {
       run,
       triggerPayload,
       inputs: {environment: 'prod'},
+      vars: {ENABLED: 'true'},
       plan,
       dependencyJobs: [
         {
@@ -392,6 +398,7 @@ describe('listener filter snapshots', () => {
       trigger: {source: 'github', event: 'pull_request'},
       inputs: {environment: 'prod'},
       job: {key: 'await'},
+      vars: {ENABLED: 'true'},
       jobs: {
         build: expect.objectContaining({
           key: 'build',
@@ -401,6 +408,11 @@ describe('listener filter snapshots', () => {
         }),
       },
     });
+    expect(Object.keys(matcher?.filter_snapshot ?? {}).sort()).toEqual(
+      getWorkflowPredicateContextRoots('listener.on')
+        .filter((root) => root !== 'event')
+        .sort(),
+    );
     expect(matcher?.filter_snapshot).not.toHaveProperty('event');
     expect(matcher?.filter_snapshot?.jobs).not.toHaveProperty('review');
   });
@@ -564,6 +576,9 @@ describe('assembleStepDispatchContext', () => {
       jobExecution: execution,
     });
 
+    expect(Object.keys(context.values).sort()).toEqual(
+      [...getWorkflowPredicateContextRoots('step.if')].sort(),
+    );
     expect(context).toEqual({
       site: 'step-dispatch',
       values: {
@@ -585,6 +600,7 @@ describe('assembleStepDispatchContext', () => {
           ],
           outputs: {},
         },
+        jobs: {},
         step: {
           attempt: 2n,
           is_retry: true,
@@ -607,6 +623,7 @@ describe('assembleStepDispatchContext', () => {
           test: {status: 'pending', attempts: []},
           running: {status: 'running', attempts: []},
         },
+        vars: {},
       },
     });
   });
@@ -850,9 +867,13 @@ describe('assembleGateContext', () => {
   it('wraps the reported step result with the step-report site', () => {
     const context = assembleGateContext({status: 'failed', exitCode: 1});
 
+    expect(Object.keys(context.values).sort()).toEqual(
+      [...getWorkflowPredicateContextRoots('step.success')].sort(),
+    );
     expect(context).toEqual({
       site: 'step-report',
       values: {
+        vars: {},
         step: {
           exit_code: 1n,
           status: 'failed',
@@ -884,11 +905,16 @@ describe('assembleJobResolutionContext', () => {
       jobExecution({sequence: 1, name: 'Second', status: 'succeeded', finishedAt: date}),
     ];
 
-    const context = assembleJobResolutionContext(executions);
+    const context = assembleJobResolutionContext({executions, jobs: []});
 
+    expect(Object.keys(context.values).sort()).toEqual(
+      [...getWorkflowPredicateContextRoots('job.success')].sort(),
+    );
     expect(context).toEqual({
       site: 'job-resolution',
       values: {
+        jobs: {},
+        vars: {},
         executions: [
           {
             index: 0,

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.ts
@@ -156,6 +156,7 @@ export function assembleJobActivationContext(
       ...assembleWorkflowRunContext(params),
       ...assembleJobsContext(params.jobs),
       needs: params.jobs.map(assembleJobContext),
+      vars: params.vars ?? {},
     },
   };
 }
@@ -425,8 +426,8 @@ export function assembleStepDispatchContext(params: {
   return {
     site: 'step-dispatch',
     values: {
-      ...(params.vars === undefined ? {} : {vars: params.vars}),
-      ...(params.jobs === undefined ? {} : assembleJobsContext(params.jobs)),
+      vars: params.vars ?? {},
+      ...assembleJobsContext(params.jobs ?? []),
       ...(params.jobExecution === undefined
         ? {}
         : {
@@ -518,7 +519,7 @@ export function assembleGateContext(params: {
   return {
     site: 'step-report',
     values: {
-      ...(params.vars === undefined ? {} : {vars: params.vars}),
+      vars: params.vars ?? {},
       step: {
         ...(params.exitCode === null ? {} : {exit_code: BigInt(params.exitCode)}),
         status: params.status,
@@ -528,12 +529,18 @@ export function assembleGateContext(params: {
   };
 }
 
-export function assembleJobResolutionContext(
-  executions: readonly JobExecution[],
-): WorkflowEvaluationContext {
+export function assembleJobResolutionContext(params: {
+  readonly executions: readonly JobExecution[];
+  readonly jobs: readonly JobContextInput[];
+  readonly vars?: Record<string, string> | undefined;
+}): WorkflowEvaluationContext {
   return {
     site: 'job-resolution',
-    values: assembleExecutionsContext(executions),
+    values: {
+      ...assembleExecutionsContext(params.executions),
+      ...assembleJobsContext(params.jobs),
+      vars: params.vars ?? {},
+    },
   };
 }
 

--- a/libs/shared/expression/README.md
+++ b/libs/shared/expression/README.md
@@ -32,6 +32,11 @@ CEL checks and run-time evaluation for Shipfox workflow expressions.
 - **`workflowInterpolationFieldPolicies`**: Defines the host, fill-site, and
   failure constraints for each interpolatable field. Use
   `workflowInterpolationFieldAcceptsHost` for host checks.
+- **`workflowPredicateContextRoots`**: Defines the exact context roots each
+  predicate field receives. Read it with `getWorkflowPredicateContextRoots`,
+  narrow runtime context with `projectWorkflowPredicateContext`, and read
+  predicate-specific property shapes with
+  `getWorkflowPredicateFieldTypeEnvironment`.
 
 Use this package where workflow code accepts or runs expression text. It keeps
 the CEL parser behind a Shipfox API. Other packages do not need to depend on the
@@ -75,6 +80,9 @@ const passed = evaluateWorkflowPredicate(expression, {
 
 - Use `syntax` when fields are not known yet.
 - Use `typed` when the caller knows the names and field types in scope.
+- Predicate evaluation narrows the supplied context to the roots
+  `workflowPredicateContextRoots` declares for that field, so a reference
+  outside the policy fails closed rather than reading an incidental value.
 - Context values can include external data. Interpolatable fields rely on their
   structural sink guarantees, while host and availability checks remain enforced.
 - Evaluation is deterministic and has no side effects.

--- a/libs/shared/expression/src/index.ts
+++ b/libs/shared/expression/src/index.ts
@@ -145,6 +145,7 @@ export {
   getWorkflowInterpolationFieldSelfReference,
   getWorkflowPredicateContextRoots,
   getWorkflowPredicateFieldMinimumFillTarget,
+  getWorkflowPredicateFieldTypeEnvironment,
   type OpenWorkflowContextDefinition,
   projectWorkflowPredicateContext,
   type ReservedRootDefinition,

--- a/libs/shared/expression/src/plan/evaluate-planned-predicate.test.ts
+++ b/libs/shared/expression/src/plan/evaluate-planned-predicate.test.ts
@@ -62,6 +62,21 @@ describe('evaluatePlannedPredicateAtSite', () => {
     });
   });
 
+  it('treats absent restart provenance as optional when guarded with has', () => {
+    const result = evaluatePlannedPredicateAtSite({
+      expression: expression('has(step.restart) && step.restart.feedback != ""'),
+      field: 'step.if',
+      site: 'step-dispatch',
+      context: {step: {attempt: 1, is_retry: false}},
+    });
+
+    expect(result).toEqual({
+      value: false,
+      evaluationFailed: false,
+      route: {roots: ['step'], runnerRoots: [], fillTarget: 'step-dispatch'},
+    });
+  });
+
   it('fails closed when the predicate needs a later server fill site', () => {
     const result = evaluatePlannedPredicateAtSite({
       expression: expression('executions.all(e, e.status == "succeeded")'),

--- a/libs/shared/expression/src/workflow-context/workflow-context.test.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.test.ts
@@ -9,6 +9,7 @@ import {
   getWorkflowInterpolationFieldFailurePolicy,
   getWorkflowPredicateContextRoots,
   getWorkflowPredicateFieldMinimumFillTarget,
+  getWorkflowPredicateFieldTypeEnvironment,
   projectWorkflowPredicateContext,
   resolveContextRootAvailability,
   resolveContextRootHost,
@@ -159,7 +160,7 @@ describe('workflow context registry', () => {
           id: 'string',
           number: 'int',
           name: 'string',
-          run_name: 'string',
+          workflow_name: 'string',
           definition_id: 'string',
           project_id: 'string',
           workspace_id: 'string',
@@ -209,6 +210,9 @@ describe('workflow context registry', () => {
         },
       },
     });
+    expect(getWorkflowContextTypeEnvironment('executions')).not.toHaveProperty(
+      'executions.element.fields.failed',
+    );
     expect(getWorkflowContextTypeEnvironment('needs')).toMatchObject({
       needs: {
         kind: 'list',
@@ -673,6 +677,28 @@ describe('workflow context registry', () => {
         }),
       ).toEqual({});
     });
+
+    it('uses predicate-specific types for runtime-specific properties', () => {
+      expect(getWorkflowPredicateFieldTypeEnvironment('step.if', 'execution')).toMatchObject({
+        execution: {fields: {failed: 'bool'}},
+      });
+      expect(getWorkflowPredicateFieldTypeEnvironment('step.if', 'step')).toMatchObject({
+        step: {fields: {attempt: 'int', is_retry: 'bool'}},
+      });
+      expect(getWorkflowPredicateFieldTypeEnvironment('step.success', 'step')).toEqual({
+        step: {
+          kind: 'object',
+          fields: {
+            exit_code: 'int',
+            status: 'string',
+            outputs: {kind: 'map'},
+          },
+        },
+      });
+      expect(
+        getWorkflowPredicateFieldTypeEnvironment('job.success', 'executions'),
+      ).not.toHaveProperty('executions.element.fields.failed');
+    });
   });
 
   it('supports CEL type-checking against the known context fields', () => {
@@ -796,7 +822,7 @@ describe('workflow interpolation field policies', () => {
   it('declares dynamic-name self-reference targets in field policies', () => {
     expect(workflowInterpolationFieldPolicies['workflow.run_name'].selfReference).toEqual({
       root: 'run',
-      key: 'run_name',
+      key: 'name',
     });
     expect(workflowInterpolationFieldPolicies['job.execution_name'].selfReference).toEqual({
       root: 'execution',

--- a/libs/shared/expression/src/workflow-context/workflow-context.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.ts
@@ -101,7 +101,7 @@ const runTypeEnvironment = {
       id: 'string',
       number: 'int',
       name: 'string',
-      run_name: 'string',
+      workflow_name: 'string',
       definition_id: 'string',
       project_id: 'string',
       workspace_id: 'string',
@@ -150,7 +150,6 @@ const executionType = {
     index: 'int',
     name: 'string',
     status: 'string',
-    failed: 'bool',
     started_at: 'timestamp',
     finished_at: 'timestamp',
     events: {
@@ -169,7 +168,13 @@ const executionsTypeEnvironment = {
 } as const satisfies ExpressionTypeEnvironment;
 
 const executionTypeEnvironment = {
-  execution: executionType,
+  execution: {
+    kind: 'object',
+    fields: {
+      ...executionType.fields,
+      failed: 'bool',
+    },
+  },
 } as const satisfies ExpressionTypeEnvironment;
 
 const stepGateType = {
@@ -204,7 +209,7 @@ const stepEntityType = {
   },
 } as const;
 
-const stepTypeEnvironment = {
+const stepDispatchTypeEnvironment = {
   step: {
     kind: 'object',
     fields: {
@@ -217,9 +222,27 @@ const stepTypeEnvironment = {
           feedback: 'string',
         },
       },
+    },
+  },
+} as const satisfies ExpressionTypeEnvironment;
+
+const stepReportTypeEnvironment = {
+  step: {
+    kind: 'object',
+    fields: {
       exit_code: 'int',
       status: 'string',
       outputs: {kind: 'map'},
+    },
+  },
+} as const satisfies ExpressionTypeEnvironment;
+
+const stepTypeEnvironment = {
+  step: {
+    kind: 'object',
+    fields: {
+      ...stepDispatchTypeEnvironment.step.fields,
+      ...stepReportTypeEnvironment.step.fields,
     },
   },
 } as const satisfies ExpressionTypeEnvironment;
@@ -429,7 +452,7 @@ export const workflowInterpolationFieldPolicies: Readonly<
     acceptedHosts: serverOnlyHosts,
     failurePolicy: 'degrade',
     minimumFillTarget: 'run-creation',
-    selfReference: {root: 'run', key: 'run_name'},
+    selfReference: {root: 'run', key: 'name'},
   },
   'job.execution_name': {
     acceptedHosts: serverOnlyHosts,
@@ -509,6 +532,13 @@ const workflowPredicateFieldMinimumFillTargets = {
   'job.if': 'job-activation',
   'step.if': 'step-dispatch',
 } as const satisfies Record<WorkflowPredicateField, AvailabilitySite>;
+
+const workflowPredicateFieldTypeEnvironments: Partial<
+  Record<WorkflowPredicateField, ExpressionTypeEnvironment>
+> = {
+  'step.success': stepReportTypeEnvironment,
+  'step.if': stepDispatchTypeEnvironment,
+};
 
 export function getWorkflowContextDefinition(name: WorkflowContextName): WorkflowContextDefinition {
   return workflowContextDefinitions[name];
@@ -610,6 +640,17 @@ export function getWorkflowPredicateFieldMinimumFillTarget(
   field: WorkflowPredicateField,
 ): AvailabilitySite {
   return workflowPredicateFieldMinimumFillTargets[field];
+}
+
+export function getWorkflowPredicateFieldTypeEnvironment(
+  field: WorkflowPredicateField,
+  root: WorkflowContextName,
+): ExpressionTypeEnvironment | undefined {
+  const typeEnvironment: ExpressionTypeEnvironment | undefined =
+    workflowPredicateFieldTypeEnvironments[field];
+  if (typeEnvironment === undefined) return getWorkflowContextTypeEnvironment(root);
+  const rootType = typeEnvironment[root];
+  return rootType === undefined ? getWorkflowContextTypeEnvironment(root) : {[root]: rootType};
 }
 
 export function getWorkflowPredicateContextRoots<Field extends WorkflowPredicateField>(


### PR DESCRIPTION
Aligns typed predicate properties with the values each runtime evaluation surface supplies.

The field-specific root contracts landed in #1178. This follow-up splits step predicate types between dispatch and report shapes, declares `run.workflow_name` instead of unavailable `run.run_name`, guards workflow naming against `run.name` self-reference, and removes unavailable `executions[*].failed` while preserving `execution.failed` at step dispatch.

Predicate validation now derives its evaluation site from the shared field policy, and runtime assemblers plus documentation match the narrowed contract.

Validated with focused check, type, test, build, and dependency-boundary checks for expression, API definitions, API workflows, and docs.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns predicate property types with their runtime shapes and enforces site-specific context roots. Replaces `run.run_name` with `run.workflow_name` and removes `executions[*].failed`; validation, runtime assemblers, and docs now match the narrowed contract.

- **Migration**
  - Replace `run.run_name` with `run.workflow_name` (interpolation self-reference is `run.name`).
  - Remove `executions[*].failed`; use `e.status == "failed"` or `execution.failed` (only in `step.if`).
  - Update predicates to only use roots supplied at their site (e.g., no `run` in `step.if`, no `execution` in `job.success`, listener filters validated against persisted snapshot roots).
  - Typed checks now enforce the per-field runtime shape; drop properties absent at that site (e.g., `step.attempt`/`is_retry` in `step.success`).
  - Upgrade to the new major versions of `@shipfox/api-definitions` and `@shipfox/expression`.

<sup>Written for commit 7c848e16d26a77a8d53bffea6e049b0ce0b8e7f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

