### PR TITLE
Expose normalized trigger references in workflow context

### DIFF
--- a/.changeset/trigger-reference-context.md
+++ b/.changeset/trigger-reference-context.md
@@ -1,0 +1,12 @@
+---
+"@shipfox/api-integration-core-dto": minor
+"@shipfox/api-integration-core": patch
+"@shipfox/api-projects-dto": minor
+"@shipfox/api-projects": minor
+"@shipfox/api-workflows-dto": minor
+"@shipfox/api-workflows": minor
+"@shipfox/api-triggers": patch
+"@shipfox/expression": minor
+---
+
+Expose the normalized trigger project, repository, ref, and commit in workflow context.

--- a/libs/api/integration/core-dto/src/inter-module.test.ts
+++ b/libs/api/integration/core-dto/src/inter-module.test.ts
@@ -1,6 +1,19 @@
 import {integrationsInterModuleContract} from './inter-module.js';
 
 describe('integrationsInterModuleContract', () => {
+  test('accepts a nullable normalized trigger reference', () => {
+    const result = integrationsInterModuleContract.methods.resolveTriggerReference.output.parse({
+      externalRepositoryId: 'github:42',
+      ref: 'refs/heads/main',
+      commit: 'a'.repeat(40),
+    });
+
+    expect(result?.externalRepositoryId).toBe('github:42');
+    expect(
+      integrationsInterModuleContract.methods.resolveTriggerReference.output.parse(null),
+    ).toBeNull();
+  });
+
   test('accepts a source repository lookup through the producer contract', () => {
     const result = integrationsInterModuleContract.methods.resolveSourceRepository.output.parse({
       connection: {

--- a/libs/api/integration/core-dto/src/inter-module.ts
+++ b/libs/api/integration/core-dto/src/inter-module.ts
@@ -14,6 +14,11 @@ const repository = z.object({
   cloneUrl: z.string(),
   htmlUrl: z.string(),
 });
+const triggerReference = z.object({
+  externalRepositoryId: z.string(),
+  ref: z.string(),
+  commit: z.string(),
+});
 const sourceInput = z.object({workspaceId: id, connectionId: id, externalRepositoryId: z.string()});
 const providerError = z.object({
   reason: z.string(),
@@ -36,6 +41,11 @@ export const integrationsInterModuleContract = defineInterModuleContract({
     resolveSourceRepository: {
       input: sourceInput,
       output: z.object({connection: z.object({id, provider, slug: z.string()}), repository}),
+      errors: sourceErrors,
+    },
+    resolveTriggerReference: {
+      input: z.object({workspaceId: id, connectionId: id, payload: z.unknown()}),
+      output: triggerReference.nullable(),
       errors: sourceErrors,
     },
     listSourceFiles: {

--- a/libs/api/integration/core/src/core/source-control-service.test.ts
+++ b/libs/api/integration/core/src/core/source-control-service.test.ts
@@ -92,6 +92,28 @@ describe('integration source-control service', () => {
     expect(result.repository.externalRepositoryId).toBe('gitea:gitea-owner/platform');
   });
 
+  it('resolves a normalized trigger reference through an active source-control connection', async () => {
+    const resolveTriggerReference = vi.fn(() => ({
+      externalRepositoryId: repository.externalRepositoryId,
+      ref: 'refs/heads/main',
+      commit: 'a'.repeat(40),
+    }));
+    const service = createService({resolveTriggerReference});
+
+    await expect(
+      service.resolveTriggerReference({
+        workspaceId,
+        connectionId: connection.id,
+        payload: {ref: 'refs/heads/main'},
+      }),
+    ).resolves.toEqual({
+      externalRepositoryId: repository.externalRepositoryId,
+      ref: 'refs/heads/main',
+      commit: 'a'.repeat(40),
+    });
+    expect(resolveTriggerReference).toHaveBeenCalledWith({ref: 'refs/heads/main'});
+  });
+
   it('rejects a missing connection', async () => {
     const service = createService();
 

--- a/libs/api/integration/core/src/core/source-control-service.ts
+++ b/libs/api/integration/core/src/core/source-control-service.ts
@@ -13,12 +13,14 @@ import type {
   FileSnapshot,
   RepositoryPage,
   RepositorySnapshot,
+  TriggerReference,
 } from './providers/source-control.js';
 
 export interface IntegrationSourceControlService {
   getConnection(connectionId: string): Promise<IntegrationConnection>;
   listRepositories(input: ListSourceRepositoriesInput): Promise<RepositoryPage>;
   resolveRepository(input: ResolveSourceRepositoryInput): Promise<ResolvedSourceRepository>;
+  resolveTriggerReference(input: ResolveTriggerReferenceInput): Promise<TriggerReference | null>;
   listFiles(input: ListSourceFilesInput): Promise<FilePage>;
   fetchFile(input: FetchSourceFileInput): Promise<FileSnapshot>;
   createCheckoutSpec(input: CreateSourceCheckoutSpecInput): Promise<CheckoutSpec>;
@@ -35,6 +37,12 @@ export interface ResolveSourceRepositoryInput {
   workspaceId: string;
   connectionId: string;
   externalRepositoryId: string;
+}
+
+export interface ResolveTriggerReferenceInput {
+  workspaceId: string;
+  connectionId: string;
+  payload: unknown;
 }
 
 export interface ListSourceFilesInput extends ResolveSourceRepositoryInput {
@@ -106,6 +114,19 @@ export function createSourceControlIntegrationService({
       });
 
       return {connection, repository};
+    },
+
+    async resolveTriggerReference({workspaceId, connectionId, payload}) {
+      const connection = await getConnection(connectionId);
+      if (connection.workspaceId !== workspaceId) {
+        throw new IntegrationConnectionWorkspaceMismatchError(connectionId);
+      }
+
+      // Not every integration source names a repository (for example Linear),
+      // so a missing source-control adapter is a valid null reference rather
+      // than a failed run creation.
+      const sourceControl = registry.get(connection.provider).adapters.source_control;
+      return sourceControl?.resolveTriggerReference(payload) ?? null;
     },
 
     async listFiles({workspaceId, connectionId, externalRepositoryId, ref, prefix, limit, cursor}) {

--- a/libs/api/integration/core/src/presentation/inter-module.ts
+++ b/libs/api/integration/core/src/presentation/inter-module.ts
@@ -41,6 +41,12 @@ export function createIntegrationsInterModulePresentation(params: {
           repository: resolved.repository,
         };
       }),
+    resolveTriggerReference: async (input) =>
+      await known(
+        contract.methods.resolveTriggerReference,
+        input,
+        async () => await params.sourceControl.resolveTriggerReference(input),
+      ),
     listSourceFiles: async (input) =>
       await known(
         contract.methods.listSourceFiles,

--- a/libs/api/projects-dto/src/inter-module.ts
+++ b/libs/api/projects-dto/src/inter-module.ts
@@ -34,6 +34,14 @@ export const projectsInterModuleContract = defineInterModuleContract({
       input: z.object({projectId: idSchema}),
       output: z.object({project: projectSchema.nullable()}),
     },
+    getProjectBySource: {
+      input: z.object({
+        workspaceId: idSchema,
+        sourceConnectionId: idSchema,
+        sourceExternalRepositoryId: z.string(),
+      }),
+      output: z.object({project: projectSchema.nullable()}),
+    },
     requireProjectForWorkspace: {
       input: z.object({projectId: idSchema, workspaceId: idSchema}),
       output: z.object({project: projectSchema}),

--- a/libs/api/projects/src/presentation/inter-module.test.ts
+++ b/libs/api/projects/src/presentation/inter-module.test.ts
@@ -74,6 +74,35 @@ async function expectUnauthorized(
 }
 
 describe('Projects checkout target inter-module presentation', () => {
+  test('resolves a project by its workspace-scoped source repository', async () => {
+    const client = createClient();
+    const workspaceId = crypto.randomUUID();
+    const connectionId = crypto.randomUUID();
+    const project = await insertProject({
+      workspaceId,
+      connectionId,
+      owner: 'acme',
+      name: 'api',
+      externalRepositoryId: 'github:42',
+    });
+
+    await expect(
+      client.getProjectBySource({
+        workspaceId,
+        sourceConnectionId: connectionId,
+        sourceExternalRepositoryId: project.externalRepositoryId,
+      }),
+    ).resolves.toMatchObject({project: {id: project.projectId}});
+
+    await expect(
+      client.getProjectBySource({
+        workspaceId: crypto.randomUUID(),
+        sourceConnectionId: connectionId,
+        sourceExternalRepositoryId: project.externalRepositoryId,
+      }),
+    ).resolves.toEqual({project: null});
+  });
+
   test('resolves a project target in its workspace', async () => {
     const client = createClient();
     const workspaceId = crypto.randomUUID();

--- a/libs/api/projects/src/presentation/inter-module.ts
+++ b/libs/api/projects/src/presentation/inter-module.ts
@@ -7,6 +7,7 @@ import {
 } from '@shipfox/inter-module';
 import {
   getProjectById,
+  getProjectBySource,
   getWorkspaceProjectCounts,
   resolveCheckoutTarget,
   updateProjectSourceMetadata,
@@ -17,6 +18,9 @@ export function createProjectsInterModulePresentation(params: {
 }): InterModulePresentation<typeof projectsInterModuleContract> {
   return defineInterModulePresentation(projectsInterModuleContract, {
     getProjectById: async ({projectId}) => ({project: (await getProjectById(projectId)) ?? null}),
+    getProjectBySource: async (input) => ({
+      project: (await getProjectBySource(input)) ?? null,
+    }),
     requireProjectForWorkspace: async ({projectId, workspaceId}) => {
       const project = await getProjectById(projectId);
       if (project === undefined) {

--- a/libs/api/secrets/src/presentation/routes/management.test.ts
+++ b/libs/api/secrets/src/presentation/routes/management.test.ts
@@ -25,6 +25,7 @@ const requireProjectForWorkspace = vi.fn();
 const projects = createFakeInterModuleClients({
   projects: defineInterModulePresentation(projectsInterModuleContract, {
     getProjectById: () => ({project: null}),
+    getProjectBySource: () => ({project: null}),
     getWorkspaceProjectCounts: () => ({counts: []}),
     requireProjectForWorkspace: async (input) => await requireProjectForWorkspace(input),
     resolveCheckoutTarget: () => ({

--- a/libs/api/server/src/modules.test.ts
+++ b/libs/api/server/src/modules.test.ts
@@ -123,6 +123,7 @@ describe('defaultModules', () => {
             getAgentToolsContext: vi.fn(),
             listSourceFiles: vi.fn(),
             resolveSourceRepository: vi.fn(),
+            resolveTriggerReference: vi.fn(),
           }),
         ],
       },
@@ -157,6 +158,7 @@ describe('defaultModules', () => {
       interModulePresentations: [
         defineInterModulePresentation(projectsInterModuleContract, {
           getProjectById: () => ({project: null}),
+          getProjectBySource: () => ({project: null}),
           getWorkspaceProjectCounts: () => ({counts: []}),
           requireProjectForWorkspace: () => ({
             project: {

--- a/libs/api/triggers/src/core/dispatch-integration-event.test.ts
+++ b/libs/api/triggers/src/core/dispatch-integration-event.test.ts
@@ -114,6 +114,7 @@ describe('dispatchIntegrationEvent', () => {
 
   test('passes the source, event, deliveryId and raw payload through as the trigger payload', async () => {
     const workspaceId = crypto.randomUUID();
+    const connectionId = crypto.randomUUID();
     const deliveryId = crypto.randomUUID();
     const payload = {ref: 'refs/heads/feature', headCommitSha: 'deadbeef'};
     await triggerSubscriptionFactory.create({
@@ -123,10 +124,11 @@ describe('dispatchIntegrationEvent', () => {
       config: {},
     });
 
-    await dispatch({workspaceId, deliveryId, payload});
+    await dispatch({workspaceId, connectionId, deliveryId, payload});
 
     expect(runWorkflow).toHaveBeenCalledWith(
       expect.objectContaining({
+        triggerConnectionId: connectionId,
         triggerPayload: {
           provider: 'github',
           source: 'github',

--- a/libs/api/triggers/src/core/dispatch-integration-event.ts
+++ b/libs/api/triggers/src/core/dispatch-integration-event.ts
@@ -87,6 +87,7 @@ export async function dispatchIntegrationEvent(
         workspaceId: subscription.workspaceId,
         projectId: subscription.projectId,
         definitionId: subscription.workflowDefinitionId,
+        triggerConnectionId: params.connectionId,
         triggerPayload: {
           provider: params.provider,
           source: params.source,

--- a/libs/api/workflows-dto/src/inter-module.test.ts
+++ b/libs/api/workflows-dto/src/inter-module.test.ts
@@ -13,6 +13,7 @@ describe('workflowsInterModuleContract', () => {
         deliveryId: 'delivery-1',
         data: {ref: 'refs/heads/main'},
       },
+      triggerConnectionId: '00000000-0000-4000-8000-000000000005',
       idempotencyKey: 'subscription-1:event-1',
     });
     const delivery = workflowsInterModuleContract.methods.deliverEventToJobListener.input.parse({
@@ -28,6 +29,7 @@ describe('workflowsInterModuleContract', () => {
     });
 
     expect(start.idempotencyKey).toBe('subscription-1:event-1');
+    expect(start.triggerConnectionId).toBe('00000000-0000-4000-8000-000000000005');
     expect(delivery.disposition).toBe('fire');
   });
 

--- a/libs/api/workflows-dto/src/inter-module.ts
+++ b/libs/api/workflows-dto/src/inter-module.ts
@@ -54,6 +54,7 @@ export const workflowsInterModuleContract = defineInterModuleContract({
         workspaceId: idSchema,
         projectId: idSchema,
         definitionId: idSchema,
+        triggerConnectionId: idSchema.optional(),
         triggerPayload: triggerPayloadSchema,
         inputs: z.record(z.string(), z.unknown()).optional(),
         idempotencyKey: z.string().min(1),

--- a/libs/api/workflows/drizzle/0002_tough_raza.sql
+++ b/libs/api/workflows/drizzle/0002_tough_raza.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "workflows_workflow_runs" ADD COLUMN "trigger_reference" jsonb;--> statement-breakpoint

--- a/libs/api/workflows/drizzle/meta/0002_snapshot.json
+++ b/libs/api/workflows/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,1705 @@
+{
+  "id": "2b8a55d0-8d5e-4485-bbce-d5f349032731",
+  "prevId": "23321d79-bb1f-47ef-98a3-dcd11436b3f2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.workflows_job_executions": {
+      "name": "workflows_job_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner": {
+          "name": "runner",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_job_execution_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "workflows_job_status_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_events": {
+          "name": "trigger_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "outputs": {
+          "name": "outputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluation_trace": {
+          "name": "evaluation_trace",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timed_out_at": {
+          "name": "timed_out_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflows_job_executions_job_id_idx": {
+          "name": "workflows_job_executions_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_job_executions_running_idx": {
+          "name": "workflows_job_executions_running_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflows_job_executions\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_job_executions_job_sequence_uq": {
+          "name": "workflows_job_executions_job_sequence_uq",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_job_executions_job_id_workflows_jobs_id_fk": {
+          "name": "workflows_job_executions_job_id_workflows_jobs_id_fk",
+          "tableFrom": "workflows_job_executions",
+          "tableTo": "workflows_jobs",
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows_job_listener_events": {
+      "name": "workflows_job_listener_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "workflows_job_listener_event_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_ref": {
+          "name": "event_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_by_execution_id": {
+          "name": "consumed_by_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflows_job_listener_events_job_event_ref_unique": {
+          "name": "workflows_job_listener_events_job_event_ref_unique",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_job_listener_events_job_received_idx": {
+          "name": "workflows_job_listener_events_job_received_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_job_listener_events_job_id_workflows_jobs_id_fk": {
+          "name": "workflows_job_listener_events_job_id_workflows_jobs_id_fk",
+          "tableFrom": "workflows_job_listener_events",
+          "tableTo": "workflows_jobs",
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_job_listener_events_consumed_by_execution_id_workflows_job_executions_id_fk": {
+          "name": "workflows_job_listener_events_consumed_by_execution_id_workflows_job_executions_id_fk",
+          "tableFrom": "workflows_job_listener_events",
+          "tableTo": "workflows_job_executions",
+          "columnsFrom": ["consumed_by_execution_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows_jobs": {
+      "name": "workflows_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workflow_run_attempt_id": {
+          "name": "workflow_run_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "workflows_job_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'one_shot'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "workflows_job_status_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carried_over": {
+          "name": "carried_over",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "checkout_persist_credentials": {
+          "name": "checkout_persist_credentials",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checkout_permissions_contents": {
+          "name": "checkout_permissions_contents",
+          "type": "workflows_checkout_contents",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluation_trace": {
+          "name": "evaluation_trace",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_timeout_ms": {
+          "name": "execution_timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listening_timeout_ms": {
+          "name": "listening_timeout_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_executions": {
+          "name": "max_executions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_resolve": {
+          "name": "on_resolve",
+          "type": "workflows_job_on_resolve",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_debounce_ms": {
+          "name": "batch_debounce_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_max_size": {
+          "name": "batch_max_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_max_wait_ms": {
+          "name": "batch_max_wait_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listener_status": {
+          "name": "listener_status",
+          "type": "workflows_listener_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'inactive'"
+        },
+        "resolution_reason": {
+          "name": "resolution_reason",
+          "type": "workflows_resolution_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listening_on": {
+          "name": "listening_on",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listening_until": {
+          "name": "listening_until",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outputs": {
+          "name": "outputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dependencies": {
+          "name": "dependencies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runner": {
+          "name": "runner",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflows_jobs_workflow_run_attempt_id_idx": {
+          "name": "workflows_jobs_workflow_run_attempt_id_idx",
+          "columns": [
+            {
+              "expression": "workflow_run_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_jobs_active_listeners_idx": {
+          "name": "workflows_jobs_active_listeners_idx",
+          "columns": [
+            {
+              "expression": "listener_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflows_jobs\".\"listener_status\" = 'listening'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_jobs_workflow_run_attempt_id_workflows_workflow_run_attempts_id_fk": {
+          "name": "workflows_jobs_workflow_run_attempt_id_workflows_workflow_run_attempts_id_fk",
+          "tableFrom": "workflows_jobs",
+          "tableTo": "workflows_workflow_run_attempts",
+          "columnsFrom": ["workflow_run_attempt_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows_outbox": {
+      "name": "workflows_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordering_key": {
+          "name": "ordering_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_attempts": {
+          "name": "dispatch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_dispatch_at": {
+          "name": "next_dispatch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_dispatch_error": {
+          "name": "last_dispatch_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_dispatch_failed_at": {
+          "name": "last_dispatch_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dead_lettered_at": {
+          "name": "dead_lettered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflows_outbox_pending_idx": {
+          "name": "workflows_outbox_pending_idx",
+          "columns": [
+            {
+              "expression": "next_dispatch_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NULL AND \"dead_lettered_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_outbox_dispatched_retention_idx": {
+          "name": "workflows_outbox_dispatched_retention_idx",
+          "columns": [
+            {
+              "expression": "dispatched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows_step_attempts": {
+      "name": "workflows_step_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_execution_id": {
+          "name": "job_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_order": {
+          "name": "execution_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluation_trace": {
+          "name": "evaluation_trace",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_outcome": {
+          "name": "log_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gate_result": {
+          "name": "gate_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restart_feedback": {
+          "name": "restart_feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflows_step_attempts_step_id_workflows_steps_id_fk": {
+          "name": "workflows_step_attempts_step_id_workflows_steps_id_fk",
+          "tableFrom": "workflows_step_attempts",
+          "tableTo": "workflows_steps",
+          "columnsFrom": ["step_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_step_attempts_step_id_job_execution_id_workflows_steps_fk": {
+          "name": "workflows_step_attempts_step_id_job_execution_id_workflows_steps_fk",
+          "tableFrom": "workflows_step_attempts",
+          "tableTo": "workflows_steps",
+          "columnsFrom": ["step_id", "job_execution_id"],
+          "columnsTo": ["id", "job_execution_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflows_step_attempts_step_id_attempt_uq": {
+          "name": "workflows_step_attempts_step_id_attempt_uq",
+          "nullsNotDistinct": false,
+          "columns": ["step_id", "attempt"]
+        },
+        "workflows_step_attempts_job_execution_id_execution_order_uq": {
+          "name": "workflows_step_attempts_job_execution_id_execution_order_uq",
+          "nullsNotDistinct": false,
+          "columns": ["job_execution_id", "execution_order"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workflows_step_attempts_attempt_positive_ck": {
+          "name": "workflows_step_attempts_attempt_positive_ck",
+          "value": "\"workflows_step_attempts\".\"attempt\" > 0"
+        },
+        "workflows_step_attempts_execution_order_positive_ck": {
+          "name": "workflows_step_attempts_execution_order_positive_ck",
+          "value": "\"workflows_step_attempts\".\"execution_order\" > 0"
+        },
+        "workflows_step_attempts_status_dispatched_ck": {
+          "name": "workflows_step_attempts_status_dispatched_ck",
+          "value": "\"workflows_step_attempts\".\"status\" NOT IN ('pending', 'skipped')"
+        },
+        "workflows_step_attempts_log_outcome_ck": {
+          "name": "workflows_step_attempts_log_outcome_ck",
+          "value": "\"workflows_step_attempts\".\"log_outcome\" IS NULL OR \"workflows_step_attempts\".\"log_outcome\" IN ('drained', 'abandoned')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflows_steps": {
+      "name": "workflows_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "job_execution_id": {
+          "name": "job_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_location": {
+          "name": "source_location",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "workflows_step_status_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluation_trace": {
+          "name": "evaluation_trace",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition": {
+          "name": "condition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_plan": {
+          "name": "config_plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authored_config": {
+          "name": "authored_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "current_attempt": {
+          "name": "current_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflows_steps_job_execution_id_idx": {
+          "name": "workflows_steps_job_execution_id_idx",
+          "columns": [
+            {
+              "expression": "job_execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_steps_id_job_execution_id_uq": {
+          "name": "workflows_steps_id_job_execution_id_uq",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "job_execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_steps_job_execution_id_workflows_job_executions_id_fk": {
+          "name": "workflows_steps_job_execution_id_workflows_job_executions_id_fk",
+          "tableFrom": "workflows_steps",
+          "tableTo": "workflows_job_executions",
+          "columnsFrom": ["job_execution_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflows_steps_current_attempt_positive_ck": {
+          "name": "workflows_steps_current_attempt_positive_ck",
+          "value": "\"workflows_steps\".\"current_attempt\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflows_workflow_run_attempts": {
+      "name": "workflows_workflow_run_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "rerun_mode": {
+          "name": "rerun_mode",
+          "type": "workflows_rerun_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rerun_by_user_id": {
+          "name": "rerun_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_tool_materialization": {
+          "name": "agent_tool_materialization",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflows_wra_workflow_run_attempt_unique": {
+          "name": "workflows_wra_workflow_run_attempt_unique",
+          "columns": [
+            {
+              "expression": "workflow_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wra_one_active_attempt_unique": {
+          "name": "workflows_wra_one_active_attempt_unique",
+          "columns": [
+            {
+              "expression": "workflow_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflows_workflow_run_attempts\".\"status\" in ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_workflow_run_attempts_workflow_run_id_workflows_workflow_runs_id_fk": {
+          "name": "workflows_workflow_run_attempts_workflow_run_id_workflows_workflow_runs_id_fk",
+          "tableFrom": "workflows_workflow_run_attempts",
+          "tableTo": "workflows_workflow_runs",
+          "columnsFrom": ["workflow_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflows_wra_attempt_positive_ck": {
+          "name": "workflows_wra_attempt_positive_ck",
+          "value": "\"workflows_workflow_run_attempts\".\"attempt\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflows_workflow_run_counters": {
+      "name": "workflows_workflow_run_counters",
+      "schema": "",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_number": {
+          "name": "next_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflows_wrrc_definition_id_unique": {
+          "name": "workflows_wrrc_definition_id_unique",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows_workflow_runs": {
+      "name": "workflows_workflow_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "current_attempt": {
+          "name": "current_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "trigger_provider": {
+          "name": "trigger_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_event": {
+          "name": "trigger_event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_payload": {
+          "name": "trigger_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_reference": {
+          "name": "trigger_reference",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inputs": {
+          "name": "inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_snapshot": {
+          "name": "source_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_idempotency_key": {
+          "name": "trigger_idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2592000000
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflows_wr_trigger_idempotency_key_unique": {
+          "name": "workflows_wr_trigger_idempotency_key_unique",
+          "columns": [
+            {
+              "expression": "trigger_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_definition_number_unique": {
+          "name": "workflows_wr_definition_number_unique",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_created_id_idx": {
+          "name": "workflows_wr_project_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_status_created_id_idx": {
+          "name": "workflows_wr_project_status_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_definition_created_id_idx": {
+          "name": "workflows_wr_project_definition_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_trigger_created_id_idx": {
+          "name": "workflows_wr_project_trigger_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_running_idx": {
+          "name": "workflows_wr_running_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflows_workflow_runs\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflows_wr_current_attempt_positive_ck": {
+          "name": "workflows_wr_current_attempt_positive_ck",
+          "value": "\"workflows_workflow_runs\".\"current_attempt\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.workflows_job_execution_status": {
+      "name": "workflows_job_execution_status",
+      "schema": "public",
+      "values": ["pending", "running", "succeeded", "failed", "cancelled"]
+    },
+    "public.workflows_job_listener_event_disposition": {
+      "name": "workflows_job_listener_event_disposition",
+      "schema": "public",
+      "values": ["fire", "resolve"]
+    },
+    "public.workflows_checkout_contents": {
+      "name": "workflows_checkout_contents",
+      "schema": "public",
+      "values": ["read", "write"]
+    },
+    "public.workflows_job_mode": {
+      "name": "workflows_job_mode",
+      "schema": "public",
+      "values": ["one_shot", "listening"]
+    },
+    "public.workflows_job_on_resolve": {
+      "name": "workflows_job_on_resolve",
+      "schema": "public",
+      "values": ["finish", "cancel"]
+    },
+    "public.workflows_job_status": {
+      "name": "workflows_job_status",
+      "schema": "public",
+      "values": ["pending", "running", "succeeded", "failed", "cancelled", "skipped"]
+    },
+    "public.workflows_job_status_reason": {
+      "name": "workflows_job_status_reason",
+      "schema": "public",
+      "values": [
+        "dependency_not_completed",
+        "condition_false",
+        "default_gate_rejected",
+        "condition_rejected",
+        "condition_errored",
+        "user_cancelled",
+        "run_cancelled",
+        "timed_out",
+        "runner_lost",
+        "step_failed",
+        "unknown"
+      ]
+    },
+    "public.workflows_listener_status": {
+      "name": "workflows_listener_status",
+      "schema": "public",
+      "values": ["inactive", "listening", "resolved"]
+    },
+    "public.workflows_resolution_reason": {
+      "name": "workflows_resolution_reason",
+      "schema": "public",
+      "values": ["until", "timeout", "max_executions", "cancelled"]
+    },
+    "public.workflows_step_status": {
+      "name": "workflows_step_status",
+      "schema": "public",
+      "values": ["pending", "running", "succeeded", "failed", "cancelled", "skipped"]
+    },
+    "public.workflows_step_status_reason": {
+      "name": "workflows_step_status_reason",
+      "schema": "public",
+      "values": ["default_gate_rejected", "condition_rejected", "condition_errored"]
+    },
+    "public.workflows_rerun_mode": {
+      "name": "workflows_rerun_mode",
+      "schema": "public",
+      "values": ["all", "failed"]
+    },
+    "public.workflows_run_status": {
+      "name": "workflows_run_status",
+      "schema": "public",
+      "values": ["pending", "running", "succeeded", "failed", "cancelled"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/api/workflows/drizzle/meta/_journal.json
+++ b/libs/api/workflows/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1783439600000,
       "tag": "0001_agent_tool_materialization",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1785487448508,
+      "tag": "0002_tough_raza",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/api/workflows/src/core/entities/workflow-run.ts
+++ b/libs/api/workflows/src/core/entities/workflow-run.ts
@@ -22,6 +22,13 @@ export function isWorkflowRunTerminal(
   return TERMINAL_WORKFLOW_RUN_STATUSES.has(status);
 }
 
+export interface WorkflowRunTriggerReference {
+  project: {id: string} | null;
+  repository: string | null;
+  ref: string | null;
+  commit: string | null;
+}
+
 export interface WorkflowSourceSnapshot {
   content: string;
   format: 'yaml';
@@ -70,6 +77,8 @@ export interface WorkflowRun {
   triggerSource: string;
   triggerEvent: string;
   triggerPayload: TriggerPayload;
+  /** Provider-neutral trigger facts captured at run creation, when available. */
+  triggerReference?: WorkflowRunTriggerReference | null | undefined;
   inputs: Record<string, unknown> | null;
   sourceSnapshot: WorkflowSourceSnapshot | null;
   triggerIdempotencyKey: string | null;

--- a/libs/api/workflows/src/core/resolve-trigger-reference.test.ts
+++ b/libs/api/workflows/src/core/resolve-trigger-reference.test.ts
@@ -1,0 +1,158 @@
+import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
+import type {TriggerPayload} from './entities/workflow-run.js';
+import {resolveWorkflowRunTriggerReference} from './resolve-trigger-reference.js';
+
+describe('resolveWorkflowRunTriggerReference', () => {
+  const workspaceId = crypto.randomUUID();
+  const connectionId = crypto.randomUUID();
+
+  it.each([
+    {
+      event: 'push',
+      externalRepositoryId: 'github:42',
+      ref: 'refs/heads/main',
+    },
+    {
+      event: 'pull_request',
+      externalRepositoryId: 'github:43',
+      ref: 'refs/pull/12/head',
+    },
+  ])('resolves the normalized %s trigger facts with its project', async (reference) => {
+    const integrations = {
+      resolveTriggerReference: vi.fn().mockResolvedValue({
+        externalRepositoryId: reference.externalRepositoryId,
+        ref: reference.ref,
+        commit: 'a'.repeat(40),
+      }),
+      resolveSourceRepository: vi.fn().mockResolvedValue({
+        connection: {id: connectionId, provider: 'github', slug: 'github-main'},
+        repository: {
+          externalRepositoryId: reference.externalRepositoryId,
+          owner: 'acme',
+          name: 'api',
+          fullName: 'acme/api',
+          defaultBranch: 'main',
+          visibility: 'private' as const,
+          cloneUrl: 'https://github.com/acme/api.git',
+          htmlUrl: 'https://github.com/acme/api',
+        },
+      }),
+    } as unknown as IntegrationsModuleClient;
+    const projects = {
+      getProjectBySource: vi.fn().mockResolvedValue({project: {id: 'project-1'}}),
+    } as unknown as ProjectsModuleClient;
+    const triggerPayload: TriggerPayload = {
+      provider: 'github',
+      source: 'github-main',
+      event: reference.event,
+      deliveryId: 'delivery-1',
+      data: {event: reference.event},
+    };
+
+    await expect(
+      resolveWorkflowRunTriggerReference({
+        workspaceId,
+        triggerConnectionId: connectionId,
+        triggerPayload,
+        integrations,
+        projects,
+      }),
+    ).resolves.toEqual({
+      project: {id: 'project-1'},
+      repository: 'acme/api',
+      ref: reference.ref,
+      commit: 'a'.repeat(40),
+    });
+    expect(projects.getProjectBySource).toHaveBeenCalledWith({
+      workspaceId,
+      sourceConnectionId: connectionId,
+      sourceExternalRepositoryId: reference.externalRepositoryId,
+    });
+  });
+
+  it('returns null for a provider event without a source-control reference', async () => {
+    const resolveTriggerReference = vi.fn().mockResolvedValue(null);
+    const resolveSourceRepository = vi.fn();
+    const integrations = {
+      resolveTriggerReference,
+      resolveSourceRepository,
+    } as unknown as IntegrationsModuleClient;
+    const projects = {
+      getProjectBySource: vi.fn(),
+    } as unknown as ProjectsModuleClient;
+
+    await expect(
+      resolveWorkflowRunTriggerReference({
+        workspaceId,
+        triggerConnectionId: connectionId,
+        triggerPayload: {
+          provider: 'linear',
+          source: 'linear-main',
+          event: 'Issue.create',
+          deliveryId: 'delivery-1',
+          data: {type: 'Issue'},
+        },
+        integrations,
+        projects,
+      }),
+    ).resolves.toBeNull();
+    expect(resolveSourceRepository).not.toHaveBeenCalled();
+    expect(projects.getProjectBySource).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'trigger reference',
+    'project lookup',
+    'source repository lookup',
+  ] as const)('returns null when %s fails during enrichment', async (failure) => {
+    const integrations = {
+      resolveTriggerReference:
+        failure === 'trigger reference'
+          ? vi.fn().mockRejectedValue(new Error('trigger reference unavailable'))
+          : vi.fn().mockResolvedValue({
+              externalRepositoryId: 'github:42',
+              ref: 'refs/heads/main',
+              commit: 'a'.repeat(40),
+            }),
+      resolveSourceRepository:
+        failure === 'source repository lookup'
+          ? vi.fn().mockRejectedValue(new Error('source repository unavailable'))
+          : vi.fn().mockResolvedValue({
+              connection: {id: connectionId, provider: 'github', slug: 'github-main'},
+              repository: {
+                externalRepositoryId: 'github:42',
+                owner: 'acme',
+                name: 'api',
+                fullName: 'acme/api',
+                defaultBranch: 'main',
+                visibility: 'private' as const,
+                cloneUrl: 'https://github.com/acme/api.git',
+                htmlUrl: 'https://github.com/acme/api',
+              },
+            }),
+    } as unknown as IntegrationsModuleClient;
+    const projects = {
+      getProjectBySource:
+        failure === 'project lookup'
+          ? vi.fn().mockRejectedValue(new Error('project lookup unavailable'))
+          : vi.fn().mockResolvedValue({project: {id: 'project-1'}}),
+    } as unknown as ProjectsModuleClient;
+
+    await expect(
+      resolveWorkflowRunTriggerReference({
+        workspaceId,
+        triggerConnectionId: connectionId,
+        triggerPayload: {
+          provider: 'github',
+          source: 'github-main',
+          event: 'push',
+          deliveryId: 'delivery-1',
+          data: {event: 'push'},
+        },
+        integrations,
+        projects,
+      }),
+    ).resolves.toBeNull();
+  });
+});

--- a/libs/api/workflows/src/core/resolve-trigger-reference.ts
+++ b/libs/api/workflows/src/core/resolve-trigger-reference.ts
@@ -1,0 +1,52 @@
+import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
+import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
+import type {TriggerPayload, WorkflowRunTriggerReference} from './entities/workflow-run.js';
+
+export async function resolveWorkflowRunTriggerReference(params: {
+  workspaceId: string;
+  triggerConnectionId?: string | undefined;
+  triggerPayload: TriggerPayload;
+  integrations?: IntegrationsModuleClient | undefined;
+  projects?: ProjectsModuleClient | undefined;
+}): Promise<WorkflowRunTriggerReference | null> {
+  if (
+    params.triggerConnectionId === undefined ||
+    !('data' in params.triggerPayload) ||
+    params.integrations === undefined ||
+    params.projects === undefined
+  ) {
+    return null;
+  }
+
+  try {
+    const reference = await params.integrations.resolveTriggerReference({
+      workspaceId: params.workspaceId,
+      connectionId: params.triggerConnectionId,
+      payload: params.triggerPayload.data,
+    });
+    if (reference === null) return null;
+
+    const [projectResult, sourceResult] = await Promise.all([
+      params.projects.getProjectBySource({
+        workspaceId: params.workspaceId,
+        sourceConnectionId: params.triggerConnectionId,
+        sourceExternalRepositoryId: reference.externalRepositoryId,
+      }),
+      params.integrations.resolveSourceRepository({
+        workspaceId: params.workspaceId,
+        connectionId: params.triggerConnectionId,
+        externalRepositoryId: reference.externalRepositoryId,
+      }),
+    ]);
+
+    return {
+      project: projectResult.project === null ? null : {id: projectResult.project.id},
+      repository: `${sourceResult.repository.owner}/${sourceResult.repository.name}`,
+      ref: reference.ref,
+      commit: reference.commit,
+    };
+  } catch {
+    // Trigger metadata is best-effort and must not block run creation.
+    return null;
+  }
+}

--- a/libs/api/workflows/src/core/run-workflow.ts
+++ b/libs/api/workflows/src/core/run-workflow.ts
@@ -15,6 +15,7 @@ export interface RunWorkflowParams {
   projectId: string;
   definitionId: string;
   triggerPayload: TriggerPayload;
+  triggerConnectionId?: string | undefined;
   inputs?: Record<string, unknown> | undefined;
   triggerIdempotencyKey?: string | undefined;
   integrations?: IntegrationsModuleClient | undefined;
@@ -47,6 +48,7 @@ export async function runWorkflow(
     name: definition.name,
     model,
     triggerPayload: params.triggerPayload,
+    triggerConnectionId: params.triggerConnectionId,
     inputs: params.inputs,
     sourceSnapshot: definition.sourceSnapshot,
     triggerIdempotencyKey: params.triggerIdempotencyKey,

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
@@ -51,7 +51,14 @@ describe('assembleWorkflowRunContext', () => {
         workspace_id: 'workspace-1',
         created_at: run.createdAt,
       },
-      trigger: {source: 'github', event: 'push'},
+      trigger: {
+        source: 'github',
+        event: 'push',
+        project: null,
+        repository: null,
+        ref: null,
+        commit: null,
+      },
       event: {ref: 'refs/heads/main'},
       inputs: {deploy: true},
     });
@@ -113,6 +120,35 @@ describe('assembleCreationContext', () => {
         },
         inputs: {deploy: true},
       }),
+    });
+  });
+
+  it('exposes the normalized trigger reference on the trigger root', () => {
+    const context = assembleWorkflowRunContext({
+      run: {
+        ...run,
+        triggerReference: {
+          project: {id: 'project-1'},
+          repository: 'acme/api',
+          ref: 'refs/pull/42/head',
+          commit: 'a'.repeat(40),
+        },
+      },
+      triggerPayload: {
+        source: 'github',
+        event: 'pull_request',
+        deliveryId: 'delivery-1',
+        data: {},
+      },
+    });
+
+    expect(context.trigger).toEqual({
+      source: 'github',
+      event: 'pull_request',
+      project: {id: 'project-1'},
+      repository: 'acme/api',
+      ref: 'refs/pull/42/head',
+      commit: 'a'.repeat(40),
     });
   });
 });
@@ -389,7 +425,14 @@ describe('listener filter snapshots', () => {
 
     expect(matcher?.filter_snapshot).toEqual({
       run: expect.objectContaining({id: 'run-1', name: 'Build'}),
-      trigger: {source: 'github', event: 'pull_request'},
+      trigger: {
+        source: 'github',
+        event: 'pull_request',
+        project: null,
+        repository: null,
+        ref: null,
+        commit: null,
+      },
       inputs: {environment: 'prod'},
       job: {key: 'await'},
       jobs: {

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.ts
@@ -8,7 +8,11 @@ import {
 import type {Job, JobListeningTrigger} from '#core/entities/job.js';
 import type {JobExecution} from '#core/entities/job-execution.js';
 import type {Step, StepAttempt, StepStatus} from '#core/entities/step.js';
-import type {TriggerPayload, WorkflowRun} from '#core/entities/workflow-run.js';
+import type {
+  TriggerPayload,
+  WorkflowRun,
+  WorkflowRunTriggerReference,
+} from '#core/entities/workflow-run.js';
 import type {WorkflowEvaluationContext} from './workflow-evaluation-context.js';
 
 export interface JobContextInput {
@@ -27,7 +31,7 @@ export interface AssembleWorkflowRunContextParams {
     | 'projectId'
     | 'workspaceId'
     | 'createdAt'
-  >;
+  > & {readonly triggerReference?: WorkflowRunTriggerReference | null | undefined};
   readonly triggerPayload: TriggerPayload;
   readonly inputs?: Record<string, unknown> | null | undefined;
   readonly vars?: Record<string, string> | undefined;
@@ -36,6 +40,7 @@ export interface AssembleWorkflowRunContextParams {
 export function assembleWorkflowRunContext(
   params: AssembleWorkflowRunContextParams,
 ): WorkflowExpressionEvaluationContext {
+  const triggerReference = params.run.triggerReference;
   return {
     run: {
       id: params.run.id,
@@ -50,6 +55,10 @@ export function assembleWorkflowRunContext(
     trigger: {
       source: params.triggerPayload.source,
       event: params.triggerPayload.event,
+      project: triggerReference?.project ?? null,
+      repository: triggerReference?.repository ?? null,
+      ref: triggerReference?.ref ?? null,
+      commit: triggerReference?.commit ?? null,
     },
     event: 'data' in params.triggerPayload ? params.triggerPayload.data : null,
     inputs: params.inputs ?? null,

--- a/libs/api/workflows/src/db/job-listeners.test.ts
+++ b/libs/api/workflows/src/db/job-listeners.test.ts
@@ -324,7 +324,14 @@ describe('activateJobListener', () => {
     const snapshot = payload.on[0]?.filter_snapshot;
     expect(snapshot).toEqual({
       run: expect.objectContaining({id: expect.any(String), name: 'Test Workflow'}),
-      trigger: {source: 'github', event: 'pull_request'},
+      trigger: {
+        source: 'github',
+        event: 'pull_request',
+        project: null,
+        repository: null,
+        ref: null,
+        commit: null,
+      },
       inputs: {environment: 'prod'},
       job: {key: 'await', name: 'await'},
       jobs: {

--- a/libs/api/workflows/src/db/schema/workflow-runs.ts
+++ b/libs/api/workflows/src/db/schema/workflow-runs.ts
@@ -16,6 +16,7 @@ import {
 import type {
   TriggerPayload,
   WorkflowRun,
+  WorkflowRunTriggerReference,
   WorkflowSourceSnapshot,
 } from '#core/entities/workflow-run.js';
 import {pgTable} from './common.js';
@@ -46,6 +47,7 @@ export const workflowRuns = pgTable(
     triggerSource: text('trigger_source').notNull(),
     triggerEvent: text('trigger_event').notNull(),
     triggerPayload: jsonb('trigger_payload').notNull().$type<TriggerPayload>(),
+    triggerReference: jsonb('trigger_reference').$type<WorkflowRunTriggerReference>(),
     inputs: jsonb('inputs').$type<Record<string, unknown>>(),
     sourceSnapshot: jsonb('source_snapshot').$type<WorkflowSourceSnapshot>(),
     triggerIdempotencyKey: text('trigger_idempotency_key'),
@@ -105,6 +107,7 @@ export function toWorkflowRun(row: WorkflowRunDb): WorkflowRun {
     triggerSource: row.triggerSource,
     triggerEvent: row.triggerEvent,
     triggerPayload: row.triggerPayload as TriggerPayload,
+    triggerReference: row.triggerReference ?? null,
     inputs: row.inputs ?? null,
     sourceSnapshot: row.sourceSnapshot ?? null,
     triggerIdempotencyKey: row.triggerIdempotencyKey,

--- a/libs/api/workflows/src/db/workflow-runs/run-create.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-create.test.ts
@@ -37,6 +37,104 @@ describe('workflow run queries', () => {
   });
 
   describe('createWorkflowRun', () => {
+    test('persists normalized integration trigger facts alongside the payload', async () => {
+      const triggerConnectionId = crypto.randomUUID();
+      const integrations = {
+        resolveTriggerReference: vi.fn().mockResolvedValue({
+          externalRepositoryId: 'github:42',
+          ref: 'refs/heads/main',
+          commit: 'a'.repeat(40),
+        }),
+        resolveSourceRepository: vi.fn().mockResolvedValue({
+          connection: {id: triggerConnectionId, provider: 'github', slug: 'github-main'},
+          repository: {
+            externalRepositoryId: 'github:42',
+            owner: 'acme',
+            name: 'api',
+            fullName: 'acme/api',
+            defaultBranch: 'main',
+            visibility: 'private' as const,
+            cloneUrl: 'https://github.com/acme/api.git',
+            htmlUrl: 'https://github.com/acme/api',
+          },
+        }),
+      } as never;
+      const projects = {
+        getProjectBySource: vi.fn().mockResolvedValue({project: {id: 'project-1'}}),
+      } as never;
+
+      const run = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model: buildModel(),
+        triggerConnectionId,
+        triggerPayload: {
+          provider: 'github',
+          source: 'github-main',
+          event: 'push',
+          deliveryId: 'delivery-1',
+          data: {ref: 'refs/heads/main', headCommitSha: 'a'.repeat(40)},
+        },
+        integrations,
+        projects,
+      });
+
+      const triggerReference = {
+        project: {id: 'project-1'},
+        repository: 'acme/api',
+        ref: 'refs/heads/main',
+        commit: 'a'.repeat(40),
+      };
+      expect(run.triggerReference).toEqual(triggerReference);
+      await expect(
+        db()
+          .select({triggerReference: workflowRuns.triggerReference})
+          .from(workflowRuns)
+          .where(eq(workflowRuns.id, run.id)),
+      ).resolves.toEqual([{triggerReference}]);
+    });
+
+    test('creates a run when trigger enrichment fails', async () => {
+      const triggerConnectionId = crypto.randomUUID();
+      const integrations = {
+        resolveTriggerReference: vi.fn().mockResolvedValue({
+          externalRepositoryId: 'github:42',
+          ref: 'refs/heads/main',
+          commit: 'a'.repeat(40),
+        }),
+        resolveSourceRepository: vi.fn().mockRejectedValue(new Error('source unavailable')),
+      } as never;
+      const projects = {
+        getProjectBySource: vi.fn().mockResolvedValue({project: {id: 'project-1'}}),
+      } as never;
+
+      const run = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model: buildModel(),
+        triggerConnectionId,
+        triggerPayload: {
+          provider: 'github',
+          source: 'github-main',
+          event: 'push',
+          deliveryId: 'delivery-1',
+          data: {ref: 'refs/heads/main', headCommitSha: 'a'.repeat(40)},
+        },
+        integrations,
+        projects,
+      });
+
+      expect(run.triggerReference).toBeNull();
+      await expect(
+        db()
+          .select({triggerReference: workflowRuns.triggerReference})
+          .from(workflowRuns)
+          .where(eq(workflowRuns.id, run.id)),
+      ).resolves.toEqual([{triggerReference: null}]);
+    });
+
     test('resolves and persists a dynamic run name while preserving the static snapshot', async () => {
       const run = await createWorkflowRun({
         workspaceId,

--- a/libs/api/workflows/src/db/workflow-runs/run-create.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-create.ts
@@ -20,6 +20,7 @@ import type {
   WorkflowSourceSnapshot,
 } from '#core/entities/workflow-run.js';
 import {InterpolationUnresolvableError} from '#core/errors.js';
+import {resolveWorkflowRunTriggerReference} from '#core/resolve-trigger-reference.js';
 import {assembleCreationContext} from '#core/step-config/assemble-run-context.js';
 import type {MaterializedWorkflowJob} from '#core/step-config/materialize-workflow-model.js';
 import type {WorkflowStepTemplateDiagnostic} from '#core/step-config/resolve-step-config.js';
@@ -54,6 +55,7 @@ export interface CreateWorkflowRunParams {
   name?: string | undefined;
   model: WorkflowModel;
   triggerPayload: TriggerPayload;
+  triggerConnectionId?: string | undefined;
   inputs?: Record<string, unknown> | undefined;
   sourceSnapshot?: WorkflowSourceSnapshot | null | undefined;
   triggerIdempotencyKey?: string | undefined;
@@ -64,6 +66,13 @@ export interface CreateWorkflowRunParams {
 }
 
 export async function createWorkflowRun(params: CreateWorkflowRunParams): Promise<WorkflowRun> {
+  const triggerReference = await resolveWorkflowRunTriggerReference({
+    workspaceId: params.workspaceId,
+    triggerConnectionId: params.triggerConnectionId,
+    triggerPayload: params.triggerPayload,
+    integrations: params.integrations,
+    projects: params.projects,
+  });
   const staticName = params.name ?? params.model.name;
   const agentToolContext =
     params.integrations === undefined
@@ -115,6 +124,7 @@ export async function createWorkflowRun(params: CreateWorkflowRunParams): Promis
         triggerSource: params.triggerPayload.source,
         triggerEvent: params.triggerPayload.event,
         triggerPayload: params.triggerPayload,
+        triggerReference,
         inputs: params.inputs ?? null,
         sourceSnapshot: params.sourceSnapshot ?? null,
         triggerIdempotencyKey: params.triggerIdempotencyKey ?? null,

--- a/libs/api/workflows/src/presentation/inter-module.ts
+++ b/libs/api/workflows/src/presentation/inter-module.ts
@@ -57,6 +57,7 @@ export function createWorkflowsInterModulePresentation(params: {
             projectId: input.projectId,
             definitionId: input.definitionId,
             triggerPayload: input.triggerPayload,
+            triggerConnectionId: input.triggerConnectionId,
             inputs: input.inputs,
             triggerIdempotencyKey: input.idempotencyKey,
             integrations: params.integrations,

--- a/libs/shared/expression/src/expression/create-workflow-expression.ts
+++ b/libs/shared/expression/src/expression/create-workflow-expression.ts
@@ -89,6 +89,12 @@ function createTypeCheckingEnvironment(): Environment {
     return Number.isInteger(left) && BigInt(left) === right;
   });
 
+  // Typed context fields may be absent at runtime while still exposing their
+  // known shape when present. CEL's built-in equality overloads do not allow a
+  // declared object type to compare with null, so keep null checks aligned with
+  // the runtime context contract.
+  environment.registerOperator('dyn != null', (left: unknown, right: null) => left !== right);
+
   return environment;
 }
 

--- a/libs/shared/expression/src/workflow-context/workflow-context.test.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.test.ts
@@ -1,3 +1,4 @@
+import {evaluateWorkflowPredicate} from '../evaluator/evaluate-workflow-expression.js';
 import {createWorkflowExpression} from '../expression/create-workflow-expression.js';
 import {InvalidWorkflowExpressionError} from '../expression/errors.js';
 import {
@@ -180,9 +181,34 @@ describe('workflow context registry', () => {
         fields: {
           source: 'string',
           event: 'string',
+          project: {
+            kind: 'object',
+            fields: {id: 'string'},
+          },
+          repository: 'string',
+          ref: 'string',
+          commit: 'string',
         },
       },
     });
+    expect(() =>
+      createWorkflowExpression({
+        source: 'trigger.project != null && trigger.commit != null',
+        check: {mode: 'typed', typeEnvironment: workflowContextDefinitions.trigger.typeEnvironment},
+      }),
+    ).not.toThrow();
+    const expression = createWorkflowExpression({
+      source: 'trigger.project != null && trigger.commit != null',
+      check: {mode: 'syntax'},
+    });
+    expect(
+      evaluateWorkflowPredicate(expression, {
+        trigger: {project: {id: 'project-1'}, commit: 'a'.repeat(40)},
+      }),
+    ).toBe(true);
+    expect(evaluateWorkflowPredicate(expression, {trigger: {project: null, commit: null}})).toBe(
+      false,
+    );
     expect(getWorkflowContextTypeEnvironment('job')).toEqual({
       job: {
         kind: 'object',

--- a/libs/shared/expression/src/workflow-context/workflow-context.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.ts
@@ -116,6 +116,13 @@ const triggerTypeEnvironment = {
     fields: {
       source: 'string',
       event: 'string',
+      project: {
+        kind: 'object',
+        fields: {id: 'string'},
+      },
+      repository: 'string',
+      ref: 'string',
+      commit: 'string',
     },
   },
 } as const satisfies ExpressionTypeEnvironment;


### PR DESCRIPTION
Workflow runs created from integration events now retain normalized trigger project, repository, ref, and commit facts for workflow context.

Trigger-reference enrichment is best-effort: resolver, project, or repository lookup failures persist a null reference so webhook run creation succeeds instead of retrying metadata failures indefinitely.

Closes ENG-1430

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose normalized trigger project, repository, ref, and commit in the workflow context and persist them on runs for provider‑neutral logic. Best‑effort enrichment ensures webhook runs are created even when lookups fail, satisfying ENG-1430.

- **New Features**
  - Persist normalized trigger facts on `workflows_workflow_runs.trigger_reference` and surface them as `trigger.project`, `trigger.repository`, `trigger.ref`, `trigger.commit`.
  - Add `resolveTriggerReference` to `@shipfox/api-integration-core` and `getProjectBySource` to `@shipfox/api-projects` to normalize provider payloads.
  - Pass `triggerConnectionId` from triggers to `@shipfox/api-workflows-dto` start calls; lookups are optional and fall back to null.
  - Update expression engine to support null-safe checks on trigger fields.

- **Migration**
  - Apply migration `0002_tough_raza` to add `trigger_reference jsonb` to `workflows_workflow_runs`.
  - No breaking changes; existing runs keep null trigger references.

<sup>Written for commit db3b0c95e99d89f9332f2250bdca64508da8cfa1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

