### PR TITLE
Normalize checkout targets for step-dispatch templating

### DIFF
--- a/.changeset/templated-checkout-targets.md
+++ b/.changeset/templated-checkout-targets.md
@@ -1,0 +1,8 @@
+---
+"@shipfox/workflow-document": minor
+"@shipfox/api-definitions": minor
+"@shipfox/api-definitions-dto": minor
+"@shipfox/expression": minor
+---
+
+Normalize checkout target fields for step-dispatch resolution and reject unsupported job-level checkout fields.

--- a/.changeset/templated-checkout-targets.md
+++ b/.changeset/templated-checkout-targets.md
@@ -3,6 +3,8 @@
 "@shipfox/api-definitions": minor
 "@shipfox/api-definitions-dto": minor
 "@shipfox/expression": minor
+"@shipfox/api-workflows": minor
+"@shipfox/api-workflows-dto": minor
 ---
 
-Normalize checkout target fields for step-dispatch resolution and reject unsupported job-level checkout fields.
+Normalize checkout target fields for step-dispatch resolution, reject unsupported job-level checkout fields, and keep the workflow model and runtime checkout contracts aligned.

--- a/apps/docs/content/docs/reference/workflow-schema.mdx
+++ b/apps/docs/content/docs/reference/workflow-schema.mdx
@@ -137,6 +137,8 @@ These fields apply to an explicit checkout step.
 
 ### Checkout permissions fields
 
+These permissions apply to both job-level checkout and explicit checkout steps.
+
 <CheckoutPermissionsFields />
 
 ## Step fields

--- a/apps/docs/content/docs/reference/workflow-schema.mdx
+++ b/apps/docs/content/docs/reference/workflow-schema.mdx
@@ -124,7 +124,8 @@ jobs:
 ### Job checkout fields
 
 The job-level `checkout` block supports repository permissions and credential
-persistence, or `false` to skip the implicit checkout.
+persistence. `checkout: false` is accepted by the document schema but is not
+supported by the workflow model yet.
 
 <JobCheckoutFields />
 

--- a/apps/docs/content/docs/reference/workflow-schema.mdx
+++ b/apps/docs/content/docs/reference/workflow-schema.mdx
@@ -13,6 +13,7 @@ import {
   EnvironmentVariables,
   GateFailureFields,
   GateFields,
+  JobCheckoutFields,
   JobFields,
   ListeningBatchFields,
   ListeningFields,
@@ -120,7 +121,16 @@ jobs:
 
 <JobFields />
 
+### Job checkout fields
+
+The job-level `checkout` block supports repository permissions and credential
+persistence, or `false` to skip the implicit checkout.
+
+<JobCheckoutFields />
+
 ## Checkout fields
+
+These fields apply to an explicit checkout step.
 
 <CheckoutFields />
 

--- a/apps/docs/scripts/generate.mjs
+++ b/apps/docs/scripts/generate.mjs
@@ -256,7 +256,8 @@ function renderWorkflowSchemaReference() {
   const integrations = object(steps.properties).integrations;
   const integration = object(integrations.items);
   const gate = object(steps.properties).gate;
-  const checkout = objectSchemaFor(object(jobs.properties).checkout);
+  const jobCheckout = objectSchemaFor(object(jobs.properties).checkout);
+  const checkout = objectSchemaFor(object(steps.properties).checkout);
   const checkoutPermissions = object(checkout.properties).permissions;
   const gateFailure = object(gate.properties).on_failure;
   const triggers = object(root.triggers);
@@ -283,16 +284,20 @@ function renderWorkflowSchemaReference() {
     component('JobFields', object(jobs.properties), {
       required: ['steps'],
       nested: {
-        checkout: '#checkout-fields',
+        checkout: '#job-checkout-fields',
         listening: '#listening-fields',
       },
       types: {
         outputs: recordType('string'),
-        checkout: namedType('Checkout'),
+        checkout: namedType('JobCheckout'),
         listening: namedType('Listening'),
         env: namedType('Environment'),
         steps: codeType('Step[]'),
       },
+    }),
+    component('JobCheckoutFields', object(jobCheckout.properties), {
+      nested: {permissions: '#checkout-permissions-fields'},
+      types: {permissions: namedType('CheckoutPermissions')},
     }),
     component('CheckoutFields', object(checkout.properties), {
       nested: {permissions: '#checkout-permissions-fields'},

--- a/libs/api/definitions-dto/src/index.ts
+++ b/libs/api/definitions-dto/src/index.ts
@@ -41,6 +41,7 @@ export {
   DEFAULT_JOB_SUCCESS,
   DEFAULT_RUN_TIMEOUT_MS,
   readPersistedWorkflowModel,
+  WORKFLOW_MODEL_CHECKOUT_TARGET_FIELDS,
   workflowModelFromSnapshot,
   workflowModelSnapshotSchema,
 } from './workflow-model.js';

--- a/libs/api/definitions-dto/src/workflow-model.ts
+++ b/libs/api/definitions-dto/src/workflow-model.ts
@@ -18,6 +18,19 @@ export interface WorkflowModelCheckoutTemplates {
   readonly path?: WorkflowFieldTemplate;
 }
 
+export type WorkflowModelCheckoutTargetKey = keyof WorkflowModelCheckoutTemplates;
+
+export const WORKFLOW_MODEL_CHECKOUT_TARGET_FIELDS = [
+  ['project', 'checkout.project'],
+  ['connection', 'checkout.connection'],
+  ['repository', 'checkout.repository'],
+  ['ref', 'checkout.ref'],
+  ['path', 'checkout.path'],
+] as const satisfies readonly (readonly [
+  WorkflowModelCheckoutTargetKey,
+  `checkout.${WorkflowModelCheckoutTargetKey}`,
+])[];
+
 export interface WorkflowModelCheckout {
   readonly project?: string;
   readonly connection?: string;

--- a/libs/api/definitions-dto/src/workflow-model.ts
+++ b/libs/api/definitions-dto/src/workflow-model.ts
@@ -46,13 +46,12 @@ export interface WorkflowModelCheckout {
 
 export type WorkflowModelJobCheckout = Pick<
   WorkflowModelCheckout,
-  'fetchDepth' | 'permissions' | 'persistCredentials'
+  'permissions' | 'persistCredentials'
 >;
 
 export interface WorkflowModelStepCheckout extends WorkflowModelCheckout {}
 
 export const DEFAULT_JOB_CHECKOUT: WorkflowModelJobCheckout = {
-  fetchDepth: 1,
   permissions: {contents: 'read'},
   persistCredentials: true,
 };

--- a/libs/api/definitions-dto/src/workflow-model.ts
+++ b/libs/api/definitions-dto/src/workflow-model.ts
@@ -10,12 +10,15 @@ import {z} from 'zod';
 export const DEFAULT_RUN_TIMEOUT_MS = 30 * 24 * 60 * 60 * 1000;
 export const DEFAULT_JOB_SUCCESS = "!executions.exists(e, e.status == 'failed')";
 
-export interface WorkflowModelJobCheckout {
-  readonly permissions: {readonly contents: 'read' | 'write'};
-  readonly persistCredentials: boolean;
+export interface WorkflowModelCheckoutTemplates {
+  readonly project?: WorkflowFieldTemplate;
+  readonly connection?: WorkflowFieldTemplate;
+  readonly repository?: WorkflowFieldTemplate;
+  readonly ref?: WorkflowFieldTemplate;
+  readonly path?: WorkflowFieldTemplate;
 }
 
-export interface WorkflowModelStepCheckout {
+export interface WorkflowModelCheckout {
   readonly project?: string;
   readonly connection?: string;
   readonly repository?: string;
@@ -25,9 +28,15 @@ export interface WorkflowModelStepCheckout {
   readonly permissions: {readonly contents: 'read' | 'write'};
   readonly persistCredentials: boolean;
   readonly force?: boolean;
+  readonly templates?: WorkflowModelCheckoutTemplates;
 }
 
+export interface WorkflowModelJobCheckout extends WorkflowModelCheckout {}
+
+export interface WorkflowModelStepCheckout extends WorkflowModelCheckout {}
+
 export const DEFAULT_JOB_CHECKOUT: WorkflowModelJobCheckout = {
+  fetchDepth: 1,
   permissions: {contents: 'read'},
   persistCredentials: true,
 };

--- a/libs/api/definitions-dto/src/workflow-model.ts
+++ b/libs/api/definitions-dto/src/workflow-model.ts
@@ -31,7 +31,10 @@ export interface WorkflowModelCheckout {
   readonly templates?: WorkflowModelCheckoutTemplates;
 }
 
-export interface WorkflowModelJobCheckout extends WorkflowModelCheckout {}
+export type WorkflowModelJobCheckout = Pick<
+  WorkflowModelCheckout,
+  'fetchDepth' | 'permissions' | 'persistCredentials'
+>;
 
 export interface WorkflowModelStepCheckout extends WorkflowModelCheckout {}
 

--- a/libs/api/definitions/src/core/workflow-model/invalid-workflow-model-error.ts
+++ b/libs/api/definitions/src/core/workflow-model/invalid-workflow-model-error.ts
@@ -5,6 +5,7 @@ export type WorkflowModelValidationIssueCode =
   | 'dynamic-name-self-reference'
   | 'context-unavailable-at-predicate-site'
   | 'computed-context-key'
+  | 'checkout-target-invalid'
   | 'duplicate-job-id'
   | 'duplicate-step-id'
   | 'duplicate-trigger-id'

--- a/libs/api/definitions/src/core/workflow-model/normalize-job-checkout.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-job-checkout.ts
@@ -1,8 +1,9 @@
 import {
   DEFAULT_JOB_CHECKOUT,
+  WORKFLOW_MODEL_CHECKOUT_TARGET_FIELDS,
   type WorkflowFieldTemplate,
   type WorkflowModelCheckout,
-  type WorkflowModelCheckoutTemplates,
+  type WorkflowModelCheckoutTargetKey,
   type WorkflowModelJobCheckout,
 } from '@shipfox/api-definitions-dto';
 import type {AvailabilitySite, ExpressionTypeEnvironment} from '@shipfox/expression';
@@ -15,16 +16,6 @@ import {parseInterpolationField} from './parse-interpolation-field.js';
 import {issue} from './validation-issue.js';
 
 export {DEFAULT_JOB_CHECKOUT};
-
-type CheckoutTargetKey = keyof WorkflowModelCheckoutTemplates;
-
-const checkoutTargetFields = [
-  ['project', 'checkout.project'],
-  ['connection', 'checkout.connection'],
-  ['repository', 'checkout.repository'],
-  ['ref', 'checkout.ref'],
-  ['path', 'checkout.path'],
-] as const satisfies readonly (readonly [CheckoutTargetKey, `${string}.${CheckoutTargetKey}`])[];
 
 export function normalizeJobCheckout(params: {
   checkout: WorkflowDocumentJob['checkout'];
@@ -63,8 +54,8 @@ export function normalizeCheckout(params: {
 }): WorkflowModelCheckout {
   validateCheckoutTargetShape(params);
 
-  const templates: Partial<Record<CheckoutTargetKey, WorkflowFieldTemplate>> = {};
-  for (const [key, field] of checkoutTargetFields) {
+  const templates: Partial<Record<WorkflowModelCheckoutTargetKey, WorkflowFieldTemplate>> = {};
+  for (const [key, field] of WORKFLOW_MODEL_CHECKOUT_TARGET_FIELDS) {
     const source = params.checkout[key];
     if (source === undefined) continue;
 

--- a/libs/api/definitions/src/core/workflow-model/normalize-job-checkout.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-job-checkout.ts
@@ -1,14 +1,35 @@
-import {DEFAULT_JOB_CHECKOUT, type WorkflowModelJobCheckout} from '@shipfox/api-definitions-dto';
-import type {WorkflowDocumentJob} from '@shipfox/workflow-document';
-import type {WorkflowModelValidationIssue} from './invalid-workflow-model-error.js';
+import {
+  DEFAULT_JOB_CHECKOUT,
+  type WorkflowFieldTemplate,
+  type WorkflowModelCheckout,
+  type WorkflowModelCheckoutTemplates,
+  type WorkflowModelJobCheckout,
+} from '@shipfox/api-definitions-dto';
+import type {AvailabilitySite, ExpressionTypeEnvironment} from '@shipfox/expression';
+import type {WorkflowDocumentCheckout, WorkflowDocumentJob} from '@shipfox/workflow-document';
+import type {
+  WorkflowModelValidationIssue,
+  WorkflowModelValidationIssuePathSegment,
+} from './invalid-workflow-model-error.js';
+import {parseInterpolationField} from './parse-interpolation-field.js';
 import {issue} from './validation-issue.js';
 
 export {DEFAULT_JOB_CHECKOUT};
 
+type CheckoutTargetKey = keyof WorkflowModelCheckoutTemplates;
+
+const checkoutTargetFields = [
+  ['project', 'checkout.project'],
+  ['connection', 'checkout.connection'],
+  ['repository', 'checkout.repository'],
+  ['ref', 'checkout.ref'],
+  ['path', 'checkout.path'],
+] as const satisfies readonly (readonly [CheckoutTargetKey, `${string}.${CheckoutTargetKey}`])[];
+
 export function normalizeJobCheckout(params: {
   checkout: WorkflowDocumentJob['checkout'];
   issues: WorkflowModelValidationIssue[];
-  path: readonly (string | number)[];
+  path: readonly WorkflowModelValidationIssuePathSegment[];
 }): WorkflowModelJobCheckout {
   if (params.checkout === false) {
     params.issues.push(
@@ -18,14 +39,94 @@ export function normalizeJobCheckout(params: {
         path: params.path,
       }),
     );
+
+    return DEFAULT_JOB_CHECKOUT;
   }
 
-  const checkout = params.checkout === false ? undefined : params.checkout;
+  const checkout = params.checkout ?? {};
   return {
+    fetchDepth: DEFAULT_JOB_CHECKOUT.fetchDepth,
     permissions: {
-      contents: checkout?.permissions?.contents ?? DEFAULT_JOB_CHECKOUT.permissions.contents,
+      contents: checkout.permissions?.contents ?? DEFAULT_JOB_CHECKOUT.permissions.contents,
+    },
+    persistCredentials: checkout['persist-credentials'] ?? DEFAULT_JOB_CHECKOUT.persistCredentials,
+  };
+}
+
+export function normalizeCheckout(params: {
+  checkout: WorkflowDocumentCheckout;
+  issues: WorkflowModelValidationIssue[];
+  path: readonly WorkflowModelValidationIssuePathSegment[];
+  fillSite: AvailabilitySite;
+  allowedJobReferences?: ReadonlySet<string>;
+  typeOverlay?: ExpressionTypeEnvironment | undefined;
+}): WorkflowModelCheckout {
+  validateCheckoutTargetShape(params);
+
+  const templates: Partial<Record<CheckoutTargetKey, WorkflowFieldTemplate>> = {};
+  for (const [key, field] of checkoutTargetFields) {
+    const source = params.checkout[key];
+    if (source === undefined) continue;
+
+    const template = parseInterpolationField({
+      field,
+      source,
+      path: [...params.path, key],
+      issues: params.issues,
+      fillSite: params.fillSite,
+      ...(params.allowedJobReferences === undefined
+        ? {}
+        : {allowedJobReferences: params.allowedJobReferences}),
+      ...(params.typeOverlay === undefined ? {} : {typeOverlay: params.typeOverlay}),
+    });
+    if (template === undefined) continue;
+
+    templates[key] = template;
+  }
+
+  const normalized = {
+    ...(params.checkout.project === undefined ? {} : {project: params.checkout.project}),
+    ...(params.checkout.connection === undefined ? {} : {connection: params.checkout.connection}),
+    ...(params.checkout.repository === undefined ? {} : {repository: params.checkout.repository}),
+    ...(params.checkout.ref === undefined ? {} : {ref: params.checkout.ref}),
+    fetchDepth: params.checkout['fetch-depth'] ?? DEFAULT_JOB_CHECKOUT.fetchDepth,
+    ...(params.checkout.path === undefined ? {} : {path: params.checkout.path}),
+    permissions: {
+      contents: params.checkout.permissions?.contents ?? DEFAULT_JOB_CHECKOUT.permissions.contents,
     },
     persistCredentials:
-      checkout?.['persist-credentials'] ?? DEFAULT_JOB_CHECKOUT.persistCredentials,
-  };
+      params.checkout['persist-credentials'] ?? DEFAULT_JOB_CHECKOUT.persistCredentials,
+    ...(params.checkout.force === undefined ? {} : {force: params.checkout.force}),
+    ...(Object.keys(templates).length === 0 ? {} : {templates}),
+  } satisfies WorkflowModelCheckout;
+
+  return normalized;
+}
+
+function validateCheckoutTargetShape(params: {
+  checkout: WorkflowDocumentCheckout;
+  issues: WorkflowModelValidationIssue[];
+  path: readonly WorkflowModelValidationIssuePathSegment[];
+}): void {
+  if (params.checkout.project !== undefined && params.checkout.connection !== undefined) {
+    params.issues.push(
+      issue({
+        code: 'checkout-target-invalid',
+        message: 'Checkout target "connection" cannot be combined with "project".',
+        path: [...params.path, 'connection'],
+        details: {fields: ['project', 'connection']},
+      }),
+    );
+  }
+
+  if (params.checkout.project !== undefined && params.checkout.repository !== undefined) {
+    params.issues.push(
+      issue({
+        code: 'checkout-target-invalid',
+        message: 'Checkout target "repository" cannot be combined with "project".',
+        path: [...params.path, 'repository'],
+        details: {fields: ['project', 'repository']},
+      }),
+    );
+  }
 }

--- a/libs/api/definitions/src/core/workflow-model/normalize-job-checkout.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-job-checkout.ts
@@ -17,6 +17,8 @@ import {issue} from './validation-issue.js';
 
 export {DEFAULT_JOB_CHECKOUT};
 
+const DEFAULT_CHECKOUT_FETCH_DEPTH = 1;
+
 export function normalizeJobCheckout(params: {
   checkout: WorkflowDocumentJob['checkout'];
   issues: WorkflowModelValidationIssue[];
@@ -36,7 +38,6 @@ export function normalizeJobCheckout(params: {
 
   const checkout = params.checkout ?? {};
   return {
-    fetchDepth: DEFAULT_JOB_CHECKOUT.fetchDepth,
     permissions: {
       contents: checkout.permissions?.contents ?? DEFAULT_JOB_CHECKOUT.permissions.contents,
     },
@@ -80,7 +81,7 @@ export function normalizeCheckout(params: {
     ...(params.checkout.connection === undefined ? {} : {connection: params.checkout.connection}),
     ...(params.checkout.repository === undefined ? {} : {repository: params.checkout.repository}),
     ...(params.checkout.ref === undefined ? {} : {ref: params.checkout.ref}),
-    fetchDepth: params.checkout['fetch-depth'] ?? DEFAULT_JOB_CHECKOUT.fetchDepth,
+    fetchDepth: params.checkout['fetch-depth'] ?? DEFAULT_CHECKOUT_FETCH_DEPTH,
     ...(params.checkout.path === undefined ? {} : {path: params.checkout.path}),
     permissions: {
       contents: params.checkout.permissions?.contents ?? DEFAULT_JOB_CHECKOUT.permissions.contents,

--- a/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
@@ -1,5 +1,4 @@
 import type {AgentValidationCatalog} from '@shipfox/api-agent-dto/inter-module';
-import {DEFAULT_JOB_CHECKOUT} from '@shipfox/api-definitions-dto';
 import {
   type AvailabilitySite,
   buildTypedRootsEnvironment,
@@ -45,7 +44,7 @@ import type {
 import {normalizeAgentIntegrations} from './normalize-agent-integrations.js';
 import {normalizeEnv} from './normalize-env.js';
 import {normalizeIfCondition} from './normalize-if-condition.js';
-import {normalizeJobCheckout} from './normalize-job-checkout.js';
+import {normalizeCheckout, normalizeJobCheckout} from './normalize-job-checkout.js';
 import {normalizeJobListening} from './normalize-job-listening.js';
 import {normalizeJobSuccess} from './normalize-job-success.js';
 import {normalizeNeeds} from './normalize-needs.js';
@@ -662,7 +661,17 @@ function normalizeStep(params: {
   }
 
   if (params.step.checkout !== undefined) {
-    return normalizeCheckoutStep({step: params.step, stepBase, name});
+    return normalizeCheckoutStep({
+      step: params.step,
+      stepBase,
+      name,
+      sourceName: params.sourceName,
+      stepIndex: params.index,
+      issues: params.issues,
+      fillSite: params.fillSite,
+      allowedJobReferences: params.allowedJobReferences,
+      typeOverlay,
+    });
   }
 
   // Keep the model-step union honest if callers bypass the document parser.
@@ -673,25 +682,26 @@ function normalizeCheckoutStep(params: {
   step: WorkflowDocumentStep;
   stepBase: WorkflowModelStepBaseFields;
   name: WorkflowFieldTemplate | undefined;
+  sourceName: string;
+  stepIndex: number;
+  issues: WorkflowModelValidationIssue[];
+  fillSite: AvailabilitySite;
+  allowedJobReferences: ReadonlySet<string>;
+  typeOverlay?: ExpressionTypeEnvironment | undefined;
 }): WorkflowModelCheckoutStep {
   const checkout = params.step.checkout;
   if (checkout === undefined) {
     throw new Error('Checkout step normalization requires checkout settings');
   }
 
-  const normalizedCheckout: WorkflowModelStepCheckout = {
-    ...(checkout.project === undefined ? {} : {project: checkout.project}),
-    ...(checkout.connection === undefined ? {} : {connection: checkout.connection}),
-    ...(checkout.repository === undefined ? {} : {repository: checkout.repository}),
-    ...(checkout.ref === undefined ? {} : {ref: checkout.ref}),
-    fetchDepth: checkout['fetch-depth'] ?? 1,
-    ...(checkout.path === undefined ? {} : {path: checkout.path}),
-    permissions: {
-      contents: checkout.permissions?.contents ?? DEFAULT_JOB_CHECKOUT.permissions.contents,
-    },
-    persistCredentials: checkout['persist-credentials'] ?? DEFAULT_JOB_CHECKOUT.persistCredentials,
-    ...(checkout.force === undefined ? {} : {force: checkout.force}),
-  };
+  const normalizedCheckout: WorkflowModelStepCheckout = normalizeCheckout({
+    checkout,
+    issues: params.issues,
+    path: ['jobs', params.sourceName, 'steps', params.stepIndex, 'checkout'],
+    fillSite: params.fillSite,
+    allowedJobReferences: params.allowedJobReferences,
+    typeOverlay: params.typeOverlay,
+  });
 
   return {
     ...params.stepBase,

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -1118,6 +1118,74 @@ describe('normalizeWorkflowDocument', () => {
     );
   });
 
+  it('normalizes checkout-step targets from earlier step outputs', () => {
+    const model = normalizeWorkflowDocument({
+      name: 'templated checkout step',
+      jobs: {
+        build: {
+          steps: [
+            {
+              key: 'route',
+              run: 'echo route',
+              outputs: {
+                connection: {type: 'string'},
+                repository: {type: 'string'},
+                ref: {type: 'string'},
+                path: {type: 'string'},
+              },
+            },
+            {
+              key: 'checkout',
+              checkout: {
+                connection: interpolation('inputs.connection'),
+                repository: interpolation('steps.route.outputs.repository'),
+                ref: interpolation('steps.route.outputs.ref'),
+                path: interpolation('steps.route.outputs.path'),
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(model.jobs[0]?.steps[1]).toMatchObject({
+      kind: 'checkout',
+      checkout: {
+        connection: interpolation('inputs.connection'),
+        repository: interpolation('steps.route.outputs.repository'),
+        ref: interpolation('steps.route.outputs.ref'),
+        path: interpolation('steps.route.outputs.path'),
+        fetchDepth: 1,
+        permissions: {contents: 'read'},
+        persistCredentials: true,
+        templates: {
+          connection: [{kind: 'deferred', roots: ['inputs'], fillTarget: 'run-creation'}],
+          repository: [{kind: 'deferred', roots: ['steps'], fillTarget: 'step-dispatch'}],
+          ref: [{kind: 'deferred', roots: ['steps'], fillTarget: 'step-dispatch'}],
+          path: [{kind: 'deferred', roots: ['steps'], fillTarget: 'step-dispatch'}],
+        },
+      },
+    });
+  });
+
+  it('reports invalid checkout target combinations from model normalization', () => {
+    const error = expectInvalid({
+      name: 'invalid checkout target',
+      jobs: {
+        build: {
+          steps: [{checkout: {project: 'project-id', repository: 'acme/api'}}],
+        },
+      },
+    });
+
+    expect(error.issues).toContainEqual(
+      expect.objectContaining({
+        code: 'checkout-target-invalid',
+        path: ['jobs', 'build', 'steps', 0, 'checkout', 'repository'],
+      }),
+    );
+  });
+
   it('normalizes checkout steps and their static defaults', () => {
     const model = normalizeWorkflowDocument({
       name: 'checkout step',
@@ -1175,6 +1243,7 @@ describe('normalizeWorkflowDocument', () => {
     const model = normalizeWorkflowDocument(document);
 
     expect(model.jobs[0]?.checkout).toEqual({
+      fetchDepth: 1,
       permissions: {contents: 'write'},
       persistCredentials: true,
     });
@@ -1194,6 +1263,7 @@ describe('normalizeWorkflowDocument', () => {
     const model = normalizeWorkflowDocument(document);
 
     expect(model.jobs[0]?.checkout).toEqual({
+      fetchDepth: 1,
       permissions: {contents: 'read'},
       persistCredentials: false,
     });

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -1243,7 +1243,6 @@ describe('normalizeWorkflowDocument', () => {
     const model = normalizeWorkflowDocument(document);
 
     expect(model.jobs[0]?.checkout).toEqual({
-      fetchDepth: 1,
       permissions: {contents: 'write'},
       persistCredentials: true,
     });
@@ -1263,7 +1262,6 @@ describe('normalizeWorkflowDocument', () => {
     const model = normalizeWorkflowDocument(document);
 
     expect(model.jobs[0]?.checkout).toEqual({
-      fetchDepth: 1,
       permissions: {contents: 'read'},
       persistCredentials: false,
     });

--- a/libs/api/definitions/src/core/workflow-model/parse-interpolation-field.ts
+++ b/libs/api/definitions/src/core/workflow-model/parse-interpolation-field.ts
@@ -43,7 +43,12 @@ export type StoredInterpolationField =
   | 'job.runner'
   | 'step.name'
   | 'step.working_directory'
-  | 'step.feedback';
+  | 'step.feedback'
+  | 'checkout.project'
+  | 'checkout.connection'
+  | 'checkout.repository'
+  | 'checkout.ref'
+  | 'checkout.path';
 
 export function parseInterpolationField(params: {
   field: StoredInterpolationField;

--- a/libs/api/definitions/src/core/workflow-model/workflow-field-label.ts
+++ b/libs/api/definitions/src/core/workflow-model/workflow-field-label.ts
@@ -28,6 +28,16 @@ export function workflowFieldLabel(
       return 'Step name interpolation';
     case 'step.working_directory':
       return 'Step working directory interpolation';
+    case 'checkout.project':
+      return 'Checkout project interpolation';
+    case 'checkout.connection':
+      return 'Checkout connection interpolation';
+    case 'checkout.repository':
+      return 'Checkout repository interpolation';
+    case 'checkout.ref':
+      return 'Checkout ref interpolation';
+    case 'checkout.path':
+      return 'Checkout path interpolation';
     case 'step.success':
       return 'Step gate success';
     case 'step.feedback':

--- a/libs/api/workflows-dto/src/inter-module.ts
+++ b/libs/api/workflows-dto/src/inter-module.ts
@@ -39,6 +39,11 @@ const interpolationFieldSchema = z.enum([
   'step.name',
   'step.working_directory',
   'step.feedback',
+  'checkout.project',
+  'checkout.connection',
+  'checkout.repository',
+  'checkout.ref',
+  'checkout.path',
 ]);
 
 /**

--- a/libs/api/workflows/src/core/entities/step.ts
+++ b/libs/api/workflows/src/core/entities/step.ts
@@ -68,6 +68,13 @@ export interface StepConfigDispatchPlan {
   working_directory?: ResolvedField;
   run?: ResolvedField;
   env?: Readonly<Record<string, ResolvedField>>;
+  checkout?: {
+    project?: ResolvedField;
+    connection?: ResolvedField;
+    repository?: ResolvedField;
+    ref?: ResolvedField;
+    path?: ResolvedField;
+  };
   agent?: {
     prompt?: ResolvedField;
     model?: ResolvedField;

--- a/libs/api/workflows/src/core/errors.ts
+++ b/libs/api/workflows/src/core/errors.ts
@@ -67,7 +67,12 @@ export type InterpolationUnresolvableField =
   | 'workflow.run_name'
   | 'step.name'
   | 'step.working_directory'
-  | 'step.feedback';
+  | 'step.feedback'
+  | 'checkout.project'
+  | 'checkout.connection'
+  | 'checkout.repository'
+  | 'checkout.ref'
+  | 'checkout.path';
 
 export class InterpolationUnresolvableError extends Error {
   readonly field: InterpolationUnresolvableField;

--- a/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
+++ b/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
@@ -291,6 +291,72 @@ describe('completeStepDispatchConfig', () => {
     });
   });
 
+  it('resolves deferred checkout targets at step dispatch', async () => {
+    const pending = step({
+      type: 'checkout',
+      config: {
+        checkout: {
+          fetch_depth: 1,
+          permissions: {contents: 'read'},
+          persist_credentials: true,
+        },
+      },
+      configPlan: {
+        checkout: {
+          repository: plannedField(template('steps.build.outputs.repository')),
+          ref: plannedField(template('steps.build.outputs.ref')),
+        },
+      },
+    });
+
+    const result = await completeStepDispatchConfig({
+      step: pending,
+      context: {
+        ...context,
+        values: {
+          ...context.values,
+          steps: {
+            build: {
+              outputs: {repository: 'acme/api', ref: 'refs/heads/main'},
+            },
+          },
+        },
+      },
+      resolveAgentDefaults,
+      definitionId: 'def-1',
+    });
+
+    expect(result).toEqual({
+      config: {
+        checkout: {
+          fetch_depth: 1,
+          permissions: {contents: 'read'},
+          persist_credentials: true,
+          repository: 'acme/api',
+          ref: 'refs/heads/main',
+        },
+      },
+      trace: [
+        {
+          expression: 'steps.build.outputs.repository',
+          roots: ['steps'],
+          fillTarget: 'step-dispatch',
+          evaluatedAt: 'step-dispatch',
+          value: 'acme/api',
+          field: 'checkout.repository',
+        },
+        {
+          expression: 'steps.build.outputs.ref',
+          roots: ['steps'],
+          fillTarget: 'step-dispatch',
+          evaluatedAt: 'step-dispatch',
+          value: 'refs/heads/main',
+          field: 'checkout.ref',
+        },
+      ],
+    });
+  });
+
   it('rejects invalid resolved working directories', async () => {
     const pending = step({
       config: {working_directory: '../outside'},

--- a/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.ts
+++ b/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.ts
@@ -47,9 +47,51 @@ export async function completeStepDispatchConfig(params: {
     definitionId: params.definitionId,
     trace,
   });
+  completeCheckoutConfig({
+    config,
+    plan,
+    context: params.context,
+    definitionId: params.definitionId,
+    trace,
+  });
   assertWorkingDirectoryIfPresent(config.working_directory);
 
   return {config, trace: capTraceEntries(trace)};
+}
+
+function completeCheckoutConfig(params: {
+  readonly config: Record<string, unknown>;
+  readonly plan: Step['configPlan'] & object;
+  readonly context: WorkflowEvaluationContext;
+  readonly definitionId: string;
+  readonly trace: PersistedEvaluationTraceEntry[];
+}): void {
+  const checkoutPlan = params.plan.checkout;
+  if (checkoutPlan === undefined) return;
+
+  const checkout = params.config.checkout;
+  if (checkout === null || typeof checkout !== 'object' || Array.isArray(checkout)) {
+    throw new Error('Checkout dispatch config is missing an object');
+  }
+
+  const resolvedCheckout = {...checkout} as Record<string, unknown>;
+  params.config.checkout = resolvedCheckout;
+
+  for (const key of ['project', 'connection', 'repository', 'ref', 'path'] as const) {
+    const field = checkoutPlan[key];
+    if (field === undefined) continue;
+
+    const fieldName = `checkout.${key}` as const;
+    const resolved = completeStepFieldWithTrace({
+      field: fieldName,
+      template: field,
+      context: params.context,
+      definitionId: params.definitionId,
+      errorField: fieldName,
+    });
+    resolvedCheckout[key] = resolved.value;
+    params.trace.push(...resolved.trace.map((entry) => ({...entry, field: fieldName})));
+  }
 }
 
 function assertWorkingDirectoryIfPresent(value: unknown): void {

--- a/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.ts
+++ b/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.ts
@@ -1,3 +1,4 @@
+import {WORKFLOW_MODEL_CHECKOUT_TARGET_FIELDS} from '@shipfox/api-definitions-dto';
 import {assertWorkingDirectory} from '@shipfox/api-workflows-dto';
 import {capTraceEntries} from '@shipfox/expression';
 import type {AgentDefaultsResolver} from '#core/agent-defaults.js';
@@ -77,11 +78,10 @@ function completeCheckoutConfig(params: {
   const resolvedCheckout = {...checkout} as Record<string, unknown>;
   params.config.checkout = resolvedCheckout;
 
-  for (const key of ['project', 'connection', 'repository', 'ref', 'path'] as const) {
+  for (const [key, fieldName] of WORKFLOW_MODEL_CHECKOUT_TARGET_FIELDS) {
     const field = checkoutPlan[key];
     if (field === undefined) continue;
 
-    const fieldName = `checkout.${key}` as const;
     const resolved = completeStepFieldWithTrace({
       field: fieldName,
       template: field,

--- a/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
@@ -352,7 +352,6 @@ describe('materializeWorkflowModel', () => {
       jobs: {
         build: {
           checkout: {
-            fetchDepth: 1,
             permissions: {contents: 'write'},
             persistCredentials: false,
           },
@@ -364,7 +363,6 @@ describe('materializeWorkflowModel', () => {
     const rows = await materializeWorkflowModel({model});
 
     expect(rows[0]?.checkout).toEqual({
-      fetchDepth: 1,
       permissions: {contents: 'write'},
       persistCredentials: false,
     });

--- a/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
@@ -338,6 +338,7 @@ describe('materializeWorkflowModel', () => {
       jobs: {
         build: {
           checkout: {
+            fetchDepth: 1,
             permissions: {contents: 'write'},
             persistCredentials: false,
           },
@@ -349,6 +350,7 @@ describe('materializeWorkflowModel', () => {
     const rows = await materializeWorkflowModel({model});
 
     expect(rows[0]?.checkout).toEqual({
+      fetchDepth: 1,
       permissions: {contents: 'write'},
       persistCredentials: false,
     });

--- a/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
@@ -1,5 +1,10 @@
 import {agentInterModuleContract} from '@shipfox/api-agent-dto/inter-module';
-import {DEFAULT_JOB_CHECKOUT, type WorkflowModel} from '@shipfox/api-definitions-dto';
+import {
+  DEFAULT_JOB_CHECKOUT,
+  type WorkflowFieldTemplate,
+  type WorkflowModel,
+} from '@shipfox/api-definitions-dto';
+import {parseWorkflowTemplate, planInterpolationField} from '@shipfox/expression';
 import {createInterModuleKnownError} from '@shipfox/inter-module';
 import type {AgentDefaultsResolver} from '#core/agent-defaults.js';
 import {AgentConfigUnresolvableError, InterpolationUnresolvableError} from '#core/errors.js';
@@ -28,6 +33,15 @@ function expression(source: string): TestWorkflowExpression {
 
 function template(source: string): string {
   return `\${{ ${source} }}`;
+}
+
+function checkoutTemplate(
+  field: 'checkout.repository' | 'checkout.ref',
+  source: string,
+): WorkflowFieldTemplate {
+  const result = planInterpolationField({field, segments: parseWorkflowTemplate(source)});
+  if (!result.ok) throw new Error(`Expected valid checkout template for ${field}`);
+  return result.plan.field.segments;
 }
 
 function shellRef(name: string): string {
@@ -647,6 +661,71 @@ describe('materializeWorkflowModel', () => {
           roots: ['steps'],
         },
       ],
+    });
+  });
+
+  it('defers checkout target templates until step dispatch', async () => {
+    const repository = template('steps.previous.outputs.repository');
+    const ref = template('steps.previous.outputs.ref');
+    const model = workflowModel({
+      jobs: {
+        build: {
+          steps: [
+            {
+              checkout: {
+                repository,
+                ref,
+                fetchDepth: 1,
+                permissions: {contents: 'read'},
+                persistCredentials: true,
+                templates: {
+                  repository: checkoutTemplate('checkout.repository', repository),
+                  ref: checkoutTemplate('checkout.ref', ref),
+                },
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    const rows = await materializeWorkflowModel({model, context: creationContext()});
+
+    expect(rows[0]?.steps[1]?.config).toEqual({
+      checkout: {
+        fetch_depth: 1,
+        permissions: {contents: 'read'},
+        persist_credentials: true,
+      },
+    });
+    expect(rows[0]?.steps[1]?.authoredConfig).toEqual({
+      checkout: {
+        repository,
+        ref,
+        fetch_depth: 1,
+        permissions: {contents: 'read'},
+        persist_credentials: true,
+      },
+    });
+    expect(rows[0]?.steps[1]?.configPlan?.checkout).toEqual({
+      repository: {
+        segments: [
+          expect.objectContaining({
+            kind: 'deferred',
+            roots: ['steps'],
+            fillTarget: 'step-dispatch',
+          }),
+        ],
+      },
+      ref: {
+        segments: [
+          expect.objectContaining({
+            kind: 'deferred',
+            roots: ['steps'],
+            fillTarget: 'step-dispatch',
+          }),
+        ],
+      },
     });
   });
 

--- a/libs/api/workflows/src/core/step-config/resolve-step-config.ts
+++ b/libs/api/workflows/src/core/step-config/resolve-step-config.ts
@@ -1,8 +1,5 @@
-import type {
-  WorkflowEnvTemplates,
-  WorkflowModel,
-  WorkflowModelCheckoutTemplates,
-} from '@shipfox/api-definitions-dto';
+import type {WorkflowEnvTemplates, WorkflowModel} from '@shipfox/api-definitions-dto';
+import {WORKFLOW_MODEL_CHECKOUT_TARGET_FIELDS} from '@shipfox/api-definitions-dto';
 import {
   type AvailabilitySite,
   capTraceEntries,
@@ -83,16 +80,6 @@ interface CheckoutConfig {
   readonly trace: readonly WorkflowStepEvaluationTraceEntry[];
   readonly hasTemplates: boolean;
 }
-
-type CheckoutTargetKey = keyof WorkflowModelCheckoutTemplates;
-
-const checkoutTargetFields = [
-  ['project', 'checkout.project'],
-  ['connection', 'checkout.connection'],
-  ['repository', 'checkout.repository'],
-  ['ref', 'checkout.ref'],
-  ['path', 'checkout.path'],
-] as const satisfies readonly (readonly [CheckoutTargetKey, `checkout.${CheckoutTargetKey}`])[];
 
 export async function resolveStepConfig(
   params: ResolveStepConfigParams,
@@ -271,7 +258,7 @@ function resolveCheckoutStepConfig(
   const trace: WorkflowStepEvaluationTraceEntry[] = [];
   let hasTemplates = false;
 
-  for (const [key, field] of checkoutTargetFields) {
+  for (const [key, field] of WORKFLOW_MODEL_CHECKOUT_TARGET_FIELDS) {
     const template = checkout.templates?.[key];
     if (template !== undefined) hasTemplates = true;
 

--- a/libs/api/workflows/src/core/step-config/resolve-step-config.ts
+++ b/libs/api/workflows/src/core/step-config/resolve-step-config.ts
@@ -1,4 +1,8 @@
-import type {WorkflowEnvTemplates, WorkflowModel} from '@shipfox/api-definitions-dto';
+import type {
+  WorkflowEnvTemplates,
+  WorkflowModel,
+  WorkflowModelCheckoutTemplates,
+} from '@shipfox/api-definitions-dto';
 import {
   type AvailabilitySite,
   capTraceEntries,
@@ -72,6 +76,24 @@ interface WorkingDirectoryConfig {
   readonly hasTemplates: boolean;
 }
 
+interface CheckoutConfig {
+  readonly config: Record<string, unknown>;
+  readonly configPlan: Pick<StepConfigDispatchPlan, 'checkout'> | undefined;
+  readonly diagnostics: readonly WorkflowStepTemplateDiagnostic[];
+  readonly trace: readonly WorkflowStepEvaluationTraceEntry[];
+  readonly hasTemplates: boolean;
+}
+
+type CheckoutTargetKey = keyof WorkflowModelCheckoutTemplates;
+
+const checkoutTargetFields = [
+  ['project', 'checkout.project'],
+  ['connection', 'checkout.connection'],
+  ['repository', 'checkout.repository'],
+  ['ref', 'checkout.ref'],
+  ['path', 'checkout.path'],
+] as const satisfies readonly (readonly [CheckoutTargetKey, `checkout.${CheckoutTargetKey}`])[];
+
 export async function resolveStepConfig(
   params: ResolveStepConfigParams,
 ): Promise<ResolvedStepConfig> {
@@ -114,16 +136,17 @@ async function buildStepConfig(
 
   const checkoutStep = checkoutStepOrNull(params.step);
   if (checkoutStep !== null) {
+    const checkout = resolveCheckoutStepConfig({...params, step: checkoutStep});
     return {
       config: {
-        ...checkoutStepConfig(checkoutStep),
+        ...checkout.config,
         ...gate,
         ...outputs,
       },
-      configPlan: null,
-      diagnostics: [],
-      trace: [],
-      hasTemplates: false,
+      configPlan: checkout.configPlan === undefined ? null : checkout.configPlan,
+      diagnostics: checkout.diagnostics,
+      trace: checkout.trace,
+      hasTemplates: checkout.hasTemplates,
     };
   }
 
@@ -229,20 +252,60 @@ function checkoutStepOrNull(step: WorkflowModelStep): WorkflowModelCheckoutStep 
   return isCheckoutStep ? step : null;
 }
 
-function checkoutStepConfig(step: WorkflowModelCheckoutStep): Record<string, unknown> {
-  const checkout = step.checkout;
+function resolveCheckoutStepConfig(
+  params: Omit<BuildStepConfigParams, 'context' | 'step'> & {
+    readonly context: WorkflowEvaluationContext;
+    readonly step: WorkflowModelCheckoutStep;
+  },
+): CheckoutConfig {
+  const checkout = params.step.checkout;
+  const config: Record<string, unknown> = {
+    fetch_depth: checkout.fetchDepth,
+    permissions: checkout.permissions,
+    persist_credentials: checkout.persistCredentials,
+    ...(checkout.force === undefined ? {} : {force: checkout.force}),
+  };
+  const checkoutConfig: Record<string, unknown> = config;
+  const checkoutPlan: NonNullable<StepConfigDispatchPlan['checkout']> = {};
+  const diagnostics: WorkflowStepTemplateDiagnostic[] = [];
+  const trace: WorkflowStepEvaluationTraceEntry[] = [];
+  let hasTemplates = false;
+
+  for (const [key, field] of checkoutTargetFields) {
+    const template = checkout.templates?.[key];
+    if (template !== undefined) hasTemplates = true;
+
+    const value = checkout[key];
+    if (value === undefined) continue;
+
+    if (template === undefined || params.mode === 'authored') {
+      checkoutConfig[key] = value;
+      continue;
+    }
+
+    const resolved = resolveStepField({
+      field,
+      template: {segments: template},
+      context: params.context,
+      definitionId: params.definitionId,
+      errorField: field,
+    });
+    trace.push(...resolved.trace.map((entry) => ({...entry, field})));
+    diagnostics.push(...resolved.diagnostics.map((diagnostic) => ({...diagnostic, field})));
+
+    if (resolved.kind === 'residual') {
+      checkoutPlan[key] = resolved.field;
+    } else {
+      checkoutConfig[key] = resolved.value;
+    }
+  }
+
   return {
-    checkout: {
-      ...(checkout.project === undefined ? {} : {project: checkout.project}),
-      ...(checkout.connection === undefined ? {} : {connection: checkout.connection}),
-      ...(checkout.repository === undefined ? {} : {repository: checkout.repository}),
-      ...(checkout.ref === undefined ? {} : {ref: checkout.ref}),
-      fetch_depth: checkout.fetchDepth,
-      ...(checkout.path === undefined ? {} : {path: checkout.path}),
-      permissions: checkout.permissions,
-      persist_credentials: checkout.persistCredentials,
-      ...(checkout.force === undefined ? {} : {force: checkout.force}),
-    },
+    config: {checkout: config},
+    configPlan: Object.keys(checkoutPlan).length === 0 ? undefined : {checkout: checkoutPlan},
+    diagnostics,
+    trace,
+    hasTemplates,
   };
 }
 

--- a/libs/api/workflows/src/db/workflow-runs/run-create.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-create.test.ts
@@ -759,6 +759,7 @@ describe('workflow run queries', () => {
           jobs: {
             build: {
               checkout: {
+                fetchDepth: 1,
                 permissions: {contents: 'write'},
                 persistCredentials: false,
               },

--- a/libs/api/workflows/src/db/workflow-runs/run-create.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-create.test.ts
@@ -1,4 +1,6 @@
+import type {WorkflowFieldTemplate} from '@shipfox/api-definitions-dto';
 import {WORKFLOWS_WORKFLOW_RUN_ATTEMPT_CREATED} from '@shipfox/api-workflows-dto';
+import {parseWorkflowTemplate, planInterpolationField} from '@shipfox/expression';
 import {and, eq, sql} from 'drizzle-orm';
 import type {AgentDefaultsResolver} from '#core/agent-defaults.js';
 import {InterpolationUnresolvableError} from '#core/errors.js';
@@ -24,6 +26,15 @@ import {
   resolveJobStatusFromJobExecutions,
   updateJobExecutionStatus,
 } from '../workflow-runs.js';
+
+function checkoutTemplate(source: string): WorkflowFieldTemplate {
+  const result = planInterpolationField({
+    field: 'checkout.repository',
+    segments: parseWorkflowTemplate(source),
+  });
+  if (!result.ok) throw new Error('Expected valid checkout template');
+  return result.plan.field.segments;
+}
 
 describe('workflow run queries', () => {
   let workspaceId: string;
@@ -759,7 +770,6 @@ describe('workflow run queries', () => {
           jobs: {
             build: {
               checkout: {
-                fetchDepth: 1,
                 permissions: {contents: 'write'},
                 persistCredentials: false,
               },
@@ -1032,6 +1042,32 @@ describe('workflow run queries', () => {
             },
           }),
         expected: {field: 'step.working_directory', source: 'vars.REQUIRED'},
+      },
+      {
+        field: 'checkout.repository',
+        model: () =>
+          workflowModel({
+            name: 'Missing checkout repository var',
+            runner: 'ubuntu-latest',
+            jobs: {
+              build: {
+                steps: [
+                  {
+                    checkout: {
+                      repository: template('vars.REQUIRED'),
+                      fetchDepth: 1,
+                      permissions: {contents: 'read'},
+                      persistCredentials: true,
+                      templates: {
+                        repository: checkoutTemplate(template('vars.REQUIRED')),
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          }),
+        expected: {field: 'checkout.repository', source: 'vars.REQUIRED'},
       },
     ] as const)('reports missing variables against $field', async ({model, expected}) => {
       let error: unknown;

--- a/libs/api/workflows/src/db/workflow-runs/run-create.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-create.ts
@@ -1,4 +1,8 @@
-import {createWorkflowModelSnapshot, type WorkflowModel} from '@shipfox/api-definitions-dto';
+import {
+  createWorkflowModelSnapshot,
+  WORKFLOW_MODEL_CHECKOUT_TARGET_FIELDS,
+  type WorkflowModel,
+} from '@shipfox/api-definitions-dto';
 import type {IntegrationsModuleClient} from '@shipfox/api-integration-core-dto/inter-module';
 import type {ProjectsModuleClient} from '@shipfox/api-projects-dto/inter-module';
 import type {SecretsInterModuleClient} from '@shipfox/api-secrets-dto/inter-module';
@@ -441,6 +445,10 @@ function referencedVariables(
         collectFieldVariableReferences(step.templates?.provider, references, {
           field: 'agent.provider',
         });
+      } else if (step.kind === 'checkout') {
+        for (const [key, field] of WORKFLOW_MODEL_CHECKOUT_TARGET_FIELDS) {
+          collectFieldVariableReferences(step.checkout.templates?.[key], references, {field});
+        }
       }
     }
   }

--- a/libs/api/workflows/src/db/workflow-runs/run-rerun.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-rerun.test.ts
@@ -212,7 +212,6 @@ describe('workflow run queries', () => {
           jobs: {
             build: {
               checkout: {
-                fetchDepth: 1,
                 permissions: {contents: 'write'},
                 persistCredentials: false,
               },

--- a/libs/api/workflows/src/db/workflow-runs/run-rerun.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs/run-rerun.test.ts
@@ -212,6 +212,7 @@ describe('workflow run queries', () => {
           jobs: {
             build: {
               checkout: {
+                fetchDepth: 1,
                 permissions: {contents: 'write'},
                 persistCredentials: false,
               },

--- a/libs/api/workflows/src/temporal/workflows/job-execution-orchestration.test.ts
+++ b/libs/api/workflows/src/temporal/workflows/job-execution-orchestration.test.ts
@@ -67,6 +67,21 @@ function finalStatusesFor(jobId: string): string[] {
     .map((c) => c.params.status);
 }
 
+async function waitForExecutionStatus(jobExecutionId: string, status: string): Promise<void> {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    if (
+      setExecutionStatusCalls().some(
+        (call) => call.params.jobExecutionId === jobExecutionId && call.params.status === status,
+      )
+    ) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+
+  throw new Error(`Timed out waiting for ${jobExecutionId} to reach ${status}`);
+}
+
 function terminalSetJobCall(jobId: string) {
   return setExecutionStatusCalls().find(
     (call) => call.params.jobExecutionId === jobId && call.params.status !== 'running',
@@ -129,6 +144,7 @@ describe('jobExecutionOrchestration', () => {
       jobExecutionId: 'job-pending-before-claim',
       claimedAt: '2026-06-22T10:05:00.000Z',
     });
+    await waitForExecutionStatus('job-pending-before-claim', 'running');
     await handle.signal('job-finished', {
       jobExecutionId: 'job-pending-before-claim',
       status: 'succeeded',

--- a/libs/api/workflows/test/factories/job.ts
+++ b/libs/api/workflows/test/factories/job.ts
@@ -31,7 +31,6 @@ export const jobFactory = Factory.define<Job, JobTransientParams>(({transientPar
                 jobs: {
                   build: {
                     checkout: {
-                      fetchDepth: 1,
                       permissions: checkout.permissions ?? {contents: 'read'},
                       persistCredentials: checkout.persistCredentials ?? true,
                     },

--- a/libs/api/workflows/test/factories/job.ts
+++ b/libs/api/workflows/test/factories/job.ts
@@ -31,6 +31,7 @@ export const jobFactory = Factory.define<Job, JobTransientParams>(({transientPar
                 jobs: {
                   build: {
                     checkout: {
+                      fetchDepth: 1,
                       permissions: checkout.permissions ?? {contents: 'read'},
                       persistCredentials: checkout.persistCredentials ?? true,
                     },

--- a/libs/shared/expression/src/workflow-context/workflow-context.test.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.test.ts
@@ -618,6 +618,11 @@ describe('workflow context registry', () => {
       expect(getWorkflowInterpolationFieldFailurePolicy('step.name')).toBe('degrade');
       expect(getWorkflowInterpolationFieldFailurePolicy('step.working_directory')).toBe('fail');
       expect(getWorkflowInterpolationFieldFailurePolicy('step.feedback')).toBe('fail');
+      expect(getWorkflowInterpolationFieldFailurePolicy('checkout.project')).toBe('fail');
+      expect(getWorkflowInterpolationFieldFailurePolicy('checkout.connection')).toBe('fail');
+      expect(getWorkflowInterpolationFieldFailurePolicy('checkout.repository')).toBe('fail');
+      expect(getWorkflowInterpolationFieldFailurePolicy('checkout.ref')).toBe('fail');
+      expect(getWorkflowInterpolationFieldFailurePolicy('checkout.path')).toBe('fail');
       expect(
         workflowInterpolationFields.map(
           (field) => workflowInterpolationFieldPolicies[field].failurePolicy,
@@ -839,6 +844,11 @@ describe('workflow interpolation field policies', () => {
       'step.name',
       'step.working_directory',
       'step.feedback',
+      'checkout.project',
+      'checkout.connection',
+      'checkout.repository',
+      'checkout.ref',
+      'checkout.path',
     ]);
     expect(Object.keys(workflowInterpolationFieldPolicies)).toEqual(workflowInterpolationFields);
   });
@@ -869,6 +879,11 @@ describe('workflow interpolation field policies', () => {
     ['step.name', ['server']],
     ['step.working_directory', ['server']],
     ['step.feedback', ['server']],
+    ['checkout.project', ['server']],
+    ['checkout.connection', ['server']],
+    ['checkout.repository', ['server']],
+    ['checkout.ref', ['server']],
+    ['checkout.path', ['server']],
   ] satisfies readonly [
     WorkflowInterpolationField,
     readonly string[],

--- a/libs/shared/expression/src/workflow-context/workflow-context.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.ts
@@ -395,7 +395,12 @@ export type WorkflowInterpolationField =
   | 'job.execution_name'
   | 'step.name'
   | 'step.working_directory'
-  | 'step.feedback';
+  | 'step.feedback'
+  | 'checkout.project'
+  | 'checkout.connection'
+  | 'checkout.repository'
+  | 'checkout.ref'
+  | 'checkout.path';
 
 export const workflowFieldFailurePolicies = ['fail', 'degrade', 'fail-closed'] as const;
 export type WorkflowFieldFailurePolicy = (typeof workflowFieldFailurePolicies)[number];
@@ -471,6 +476,26 @@ export const workflowInterpolationFieldPolicies: Readonly<
     failurePolicy: 'fail',
   },
   'step.feedback': {
+    acceptedHosts: serverOnlyHosts,
+    failurePolicy: 'fail',
+  },
+  'checkout.project': {
+    acceptedHosts: serverOnlyHosts,
+    failurePolicy: 'fail',
+  },
+  'checkout.connection': {
+    acceptedHosts: serverOnlyHosts,
+    failurePolicy: 'fail',
+  },
+  'checkout.repository': {
+    acceptedHosts: serverOnlyHosts,
+    failurePolicy: 'fail',
+  },
+  'checkout.ref': {
+    acceptedHosts: serverOnlyHosts,
+    failurePolicy: 'fail',
+  },
+  'checkout.path': {
     acceptedHosts: serverOnlyHosts,
     failurePolicy: 'fail',
   },

--- a/libs/shared/workflow/document/src/document/index.ts
+++ b/libs/shared/workflow/document/src/document/index.ts
@@ -19,6 +19,7 @@ export {
   WORKFLOW_DOCUMENT_STEP_OUTPUT_SCHEMA_MAX_SERIALIZED_BYTES,
   WORKFLOW_DOCUMENT_STEP_OUTPUTS_MAX_ENTRIES,
   type WorkflowDocument,
+  type WorkflowDocumentCheckout,
   type WorkflowDocumentEnv,
   type WorkflowDocumentJob,
   type WorkflowDocumentJobCheckout,

--- a/libs/shared/workflow/document/src/document/workflow-document.test.ts
+++ b/libs/shared/workflow/document/src/document/workflow-document.test.ts
@@ -414,20 +414,6 @@ describe('workflowDocumentSchema', () => {
         },
       },
     ],
-    [
-      'checkout target fields',
-      {
-        checkout: {
-          project: '0192f3a1-0000-0000-0000-000000000000',
-          ref: 'refs/heads/main',
-          'fetch-depth': 0,
-          path: 'target',
-          force: true,
-          permissions: {contents: 'read'},
-          'persist-credentials': false,
-        },
-      },
-    ],
     ['checkout disabled', {checkout: false}],
     ['checkout persist credentials false', {checkout: {'persist-credentials': false}}],
     ['empty checkout', {checkout: {}}],
@@ -444,6 +430,28 @@ describe('workflowDocumentSchema', () => {
     });
 
     expect(result.success).toBe(true);
+  });
+
+  it('rejects checkout target fields on a job checkout', () => {
+    const result = workflowDocumentSchema.safeParse({
+      name: 'targeted checkout',
+      jobs: {
+        build: {
+          checkout: {
+            project: '0192f3a1-0000-0000-0000-000000000000',
+            ref: 'refs/heads/main',
+            'fetch-depth': 0,
+            path: 'target',
+            force: true,
+            permissions: {contents: 'read'},
+            'persist-credentials': false,
+          },
+          steps: [{run: 'npm test'}],
+        },
+      },
+    });
+
+    expect(result.success).toBe(false);
   });
 
   it('accepts the shared checkout object on a checkout step', () => {
@@ -474,7 +482,7 @@ describe('workflowDocumentSchema', () => {
     expect(result.success).toBe(true);
   });
 
-  it('rejects project with connection or repository in a checkout object', () => {
+  it('rejects project with connection or repository in a checkout step', () => {
     for (const checkout of [
       {project: 'project-id', connection: 'github'},
       {project: 'project-id', repository: 'acme/api'},
@@ -483,8 +491,7 @@ describe('workflowDocumentSchema', () => {
         name: 'invalid checkout target',
         jobs: {
           build: {
-            checkout,
-            steps: [{run: 'npm test'}],
+            steps: [{checkout}],
           },
         },
       });

--- a/libs/shared/workflow/document/src/document/workflow-document.ts
+++ b/libs/shared/workflow/document/src/document/workflow-document.ts
@@ -296,6 +296,21 @@ const workflowDocumentStepGateSchema = z
     message: 'Expected success or on_failure',
   });
 
+const workflowDocumentCheckoutPermissionsSchema = z
+  .strictObject({
+    contents: z.enum(['read', 'write']).optional().meta({
+      description: 'Repository contents permission granted to checkout.',
+    }),
+  })
+  .optional()
+  .meta({
+    description: 'Repository permissions used during checkout.',
+  });
+
+const workflowDocumentPersistCredentialsSchema = z.boolean().optional().meta({
+  description: 'Whether checkout credentials remain available to later run steps.',
+});
+
 export const workflowDocumentCheckoutSchema = z
   .strictObject({
     project: z.string().min(1).optional().meta({
@@ -316,19 +331,8 @@ export const workflowDocumentCheckoutSchema = z
     path: z.string().min(1).optional().meta({
       description: 'Relative path under the job workspace where this repository is checked out.',
     }),
-    permissions: z
-      .strictObject({
-        contents: z.enum(['read', 'write']).optional().meta({
-          description: 'Repository contents permission granted to checkout.',
-        }),
-      })
-      .optional()
-      .meta({
-        description: 'Repository permissions used during checkout.',
-      }),
-    'persist-credentials': z.boolean().optional().meta({
-      description: 'Whether checkout credentials remain available to later run steps.',
-    }),
+    permissions: workflowDocumentCheckoutPermissionsSchema,
+    'persist-credentials': workflowDocumentPersistCredentialsSchema,
     force: z.boolean().optional().meta({
       description: 'Whether checkout may replace an occupied destination.',
     }),
@@ -351,7 +355,13 @@ export const workflowDocumentCheckoutSchema = z
   });
 
 const workflowDocumentJobCheckoutSchema = z
-  .union([workflowDocumentCheckoutSchema, z.literal(false)])
+  .union([
+    z.strictObject({
+      permissions: workflowDocumentCheckoutPermissionsSchema,
+      'persist-credentials': workflowDocumentPersistCredentialsSchema,
+    }),
+    z.literal(false),
+  ])
   .meta({
     description:
       'Checkout settings for repository content and credentials, or false to skip checkout.',
@@ -601,6 +611,7 @@ export const workflowDocumentSchema = z.strictObject({
 });
 
 export type WorkflowDocument = z.infer<typeof workflowDocumentSchema>;
+export type WorkflowDocumentCheckout = z.infer<typeof workflowDocumentCheckoutSchema>;
 export type WorkflowDocumentJobCheckout = z.infer<typeof workflowDocumentJobCheckoutSchema>;
 export type WorkflowDocumentEnv = z.infer<typeof workflowDocumentEnvSchema>;
 export type WorkflowDocumentJob = z.infer<typeof workflowDocumentJobSchema>;

--- a/libs/shared/workflow/document/src/document/workflow-json-schema.test.ts
+++ b/libs/shared/workflow/document/src/document/workflow-json-schema.test.ts
@@ -88,7 +88,7 @@ describe('buildWorkflowJsonSchema', () => {
     expect(requiredAlternatives(batch)).toEqual(['debounce', 'max_size', 'max_wait']);
   });
 
-  it('publishes checkout fields for both job and checkout-step syntax', () => {
+  it('publishes the supported job checkout subset and full checkout-step fields', () => {
     const schema = buildWorkflowJsonSchema();
     const root = object(schema.properties);
     const jobs = object(root.jobs);
@@ -103,19 +103,10 @@ describe('buildWorkflowJsonSchema', () => {
         expect.objectContaining({const: false}),
       ]),
     );
-    expect(objectSchemaFor(jobCheckout).properties).toEqual(
-      expect.objectContaining({
-        project: expect.any(Object),
-        connection: expect.any(Object),
-        repository: expect.any(Object),
-        ref: expect.any(Object),
-        'fetch-depth': expect.any(Object),
-        path: expect.any(Object),
-        permissions: expect.any(Object),
-        'persist-credentials': expect.any(Object),
-        force: expect.any(Object),
-      }),
-    );
+    expect(objectSchemaFor(jobCheckout).properties).toEqual({
+      permissions: expect.any(Object),
+      'persist-credentials': expect.any(Object),
+    });
     expect(stepCheckout).toEqual(
       expect.objectContaining({
         type: 'object',

--- a/libs/shared/workflow/document/src/document/workflow-json-schema.ts
+++ b/libs/shared/workflow/document/src/document/workflow-json-schema.ts
@@ -97,7 +97,6 @@ function projectWorkflowValidation(schema: JsonSchema, stepSchema: JsonSchema) {
 
   const job = object(jobs.additionalProperties);
   addLiteralNamePattern(propertiesOf(job).name);
-  projectCheckoutTargetValidation(propertiesOf(job).checkout);
   projectCheckoutTargetValidation(propertiesOf(stepSchema).checkout);
   const jobOutputs = object(propertiesOf(job).outputs);
   jobOutputs.minProperties = 1;

--- a/libs/shared/workflow/document/src/index.ts
+++ b/libs/shared/workflow/document/src/index.ts
@@ -22,6 +22,7 @@ export {
   WORKFLOW_DOCUMENT_STEP_OUTPUT_SCHEMA_MAX_SERIALIZED_BYTES,
   WORKFLOW_DOCUMENT_STEP_OUTPUTS_MAX_ENTRIES,
   type WorkflowDocument,
+  type WorkflowDocumentCheckout,
   type WorkflowDocumentEnv,
   type WorkflowDocumentJob,
   type WorkflowDocumentJobCheckout,


### PR DESCRIPTION
Normalize explicit checkout target fields as templates at the step-dispatch fill site while keeping static checkout controls unchanged.

Job-level checkout now exposes only supported permissions and credential settings. The published JSON schema and workflow reference docs match that boundary, so unsupported job target fields fail during authoring.

Checkout-step target templates are now consumed at runtime: values available during execution creation are resolved immediately, while deferred values are completed at step dispatch with persisted plans and evaluation traces.

Validation: affected package checks, types, and tests pass; full workflow-document, API definitions, API workflows, expression, and docs suites pass.

Part of ENG-1433

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize checkout targets as server-evaluated templates and limit job-level checkout to permissions and credential persistence. Templates resolve at run creation or step dispatch; checkout variable references are collected before run creation, and the runner-claim orchestration test is stabilized (ENG-1433).

- **New Features**
  - Use a shared mapping of checkout target fields across normalization, materialization, and dispatch for consistent resolution and trace.
  - Parse templates for `project`, `connection`, `repository`, `ref`, and `path`; resolve deferred values at step dispatch.
  - Reject invalid target combos (e.g., `project` with `connection` or `repository`) with clear validation errors.
  - Job-level `checkout` supports only `permissions` and `persist-credentials`; default `fetchDepth: 1` applies in the model.
  - Collect checkout target variable references before run creation to surface missing vars early.

- **Migration**
  - Move target fields (`project`, `connection`, `repository`, `ref`, `path`) from job `checkout` to a checkout step.
  - Use interpolation in checkout steps to reference inputs or prior step outputs; these resolve at dispatch.
  - Remove unsupported fields from job `checkout` to avoid authoring errors.

<sup>Written for commit 1f5182926a9830bdf97020354f90288438760ea7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/1185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

